### PR TITLE
Add Slave_skipped_errors to global status

### DIFF
--- a/mysql-test/suite/engines/funcs/t/rpl_variables.test
+++ b/mysql-test/suite/engines/funcs/t/rpl_variables.test
@@ -15,6 +15,7 @@ show variables like 'slave_load_tmpdir';
 # We just set some arbitrary values in variables-master.opt so we can test
 # that a list of values works correctly
 show variables like 'slave_skip_errors';
+show global status like 'slave_skipped_errors';
 
 # Cleanup
 set global slave_net_timeout=@my_slave_net_timeout;

--- a/mysql-test/suite/engines/funcs/t/rpl_variables.test
+++ b/mysql-test/suite/engines/funcs/t/rpl_variables.test
@@ -15,7 +15,6 @@ show variables like 'slave_load_tmpdir';
 # We just set some arbitrary values in variables-master.opt so we can test
 # that a list of values works correctly
 show variables like 'slave_skip_errors';
-show global status like 'slave_skipped_errors';
 
 # Cleanup
 set global slave_net_timeout=@my_slave_net_timeout;

--- a/mysql-test/suite/rpl/r/rpl_skip_error.result
+++ b/mysql-test/suite/rpl/r/rpl_skip_error.result
@@ -95,6 +95,9 @@ t2	CREATE TABLE `t2` (
   `data` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
+show global status like 'slave_skipped_errors';
+Variable_name	Value
+Slave_skipped_errors	4
 INSERT INTO t2 VALUES(1, 1);
 INSERT INTO t2 VALUES(2, 1);
 INSERT INTO t2 VALUES(3, 1);

--- a/mysql-test/suite/rpl/r/rpl_skip_error.result
+++ b/mysql-test/suite/rpl/r/rpl_skip_error.result
@@ -104,6 +104,9 @@ DELETE FROM t2 WHERE id = 5;
 SET SQL_LOG_BIN=1;
 UPDATE t2 SET id= id + 3, data = 2;
 
+show global status like 'slave_skipped_errors';
+Variable_name	Value
+Slave_skipped_errors	5
 **** We cannot execute a select as there are differences in the 
 **** behavior between STMT and RBR.
 ==== Clean Up ====

--- a/mysql-test/suite/rpl/t/rpl_skip_error.test
+++ b/mysql-test/suite/rpl/t/rpl_skip_error.test
@@ -157,6 +157,7 @@ sync_slave_with_master;
 
 let $error= query_get_value("SHOW SLAVE STATUS", Last_SQL_Error, 1);
 echo $error;
+show global status like 'slave_skipped_errors';
 
 --echo **** We cannot execute a select as there are differences in the 
 --echo **** behavior between STMT and RBR.

--- a/mysql-test/suite/rpl/t/rpl_skip_error.test
+++ b/mysql-test/suite/rpl/t/rpl_skip_error.test
@@ -140,6 +140,7 @@ connection slave;
 
 CREATE TABLE t2(id INT NOT NULL PRIMARY KEY, data INT) Engine=MyIsam;
 SHOW CREATE TABLE t2;
+show global status like 'slave_skipped_errors';
 
 connection master;
 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -440,8 +440,12 @@ inline int ignored_error_code(int err_code)
     break;
   }
 #endif
-  return ((err_code == ER_SLAVE_IGNORED_TABLE) ||
-          (use_slave_mask && bitmap_is_set(&slave_error_mask, err_code)));
+  if (use_slave_mask && bitmap_is_set(&slave_error_mask, err_code))
+  {
+    statistic_increment(slave_skipped_errors, LOCK_status);
+    return true;
+  }
+  return err_code == ER_SLAVE_IGNORED_TABLE;
 }
 
 /*

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -516,6 +516,7 @@ ulong binlog_stmt_cache_use= 0, binlog_stmt_cache_disk_use= 0;
 ulong max_connections, max_connect_errors;
 ulong extra_max_connections;
 ulong slave_retried_transactions;
+ulonglong slave_skipped_errors;
 ulong feature_files_opened_with_delayed_keys;
 ulonglong denied_connections;
 my_decimal decimal_zero;
@@ -7921,6 +7922,7 @@ SHOW_VAR status_vars[]= {
   {"Slave_received_heartbeats",(char*) &show_slave_received_heartbeats, SHOW_SIMPLE_FUNC},
   {"Slave_retried_transactions",(char*)&slave_retried_transactions, SHOW_LONG},
   {"Slave_running",            (char*) &show_slave_running,     SHOW_SIMPLE_FUNC},
+  {"Slave_skipped_errors",     (char*) &slave_skipped_errors, SHOW_LONGLONG},
 #endif
   {"Slow_launch_threads",      (char*) &slow_launch_threads,    SHOW_LONG},
   {"Slow_queries",             (char*) offsetof(STATUS_VAR, long_query_count), SHOW_LONG_STATUS},

--- a/sql/slave.h
+++ b/sql/slave.h
@@ -130,6 +130,7 @@ extern my_bool opt_log_slave_updates;
 extern char *opt_slave_skip_errors;
 extern my_bool opt_replicate_annotate_row_events;
 extern ulonglong relay_log_space_limit;
+extern ulonglong slave_skipped_errors;
 
 /*
   3 possible values for Master_info::slave_running and


### PR DESCRIPTION
This counts the number of times a replication event is ignored due to slave_skip_errors. from mdev-7198
