### PR TITLE
Spelling errorneous->erroneous

### DIFF
--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -1769,7 +1769,7 @@ void rpl_group_info::cleanup_context(THD *thd, bool error)
     trans_rollback(thd);      // if a "real transaction"
     /*
       Now that we have rolled back the transaction, make sure we do not
-      errorneously update the GTID position.
+      erroneously update the GTID position.
     */
     gtid_pending= false;
   }

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7080,7 +7080,7 @@ ER_INSIDE_TRANSACTION_PREVENTS_SWITCH_GTID_DOMAIN_ID_SEQ_NO
 ER_STORED_FUNCTION_PREVENTS_SWITCH_GTID_DOMAIN_ID_SEQ_NO
         eng "Cannot modify @@session.gtid_domain_id or @@session.gtid_seq_no inside a stored function or trigger"
 ER_GTID_POSITION_NOT_FOUND_IN_BINLOG2
-	eng "Connecting slave requested to start from GTID %u-%u-%llu, which is not in the master's binlog. Since the master's binlog contains GTIDs with higher sequence numbers, it probably means that the slave has diverged due to executing extra errorneous transactions"
+	eng "Connecting slave requested to start from GTID %u-%u-%llu, which is not in the master's binlog. Since the master's binlog contains GTIDs with higher sequence numbers, it probably means that the slave has diverged due to executing extra erroneous transactions"
 ER_BINLOG_MUST_BE_EMPTY
 	eng "This operation is not allowed if any GTID has been logged to the binary log. Run RESET MASTER first to erase the log"
 ER_NO_SUCH_QUERY

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -3345,7 +3345,7 @@ int apply_event_and_update_pos(Log_event* ev, THD* thd,
   else
   {
     /*
-      Make sure we do not errorneously update gtid_slave_pos with a lingering
+      Make sure we do not erroneously update gtid_slave_pos with a lingering
       GTID from this failed event group (MDEV-4906).
     */
     rgi->gtid_pending= false;

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -943,7 +943,7 @@ give_error_start_pos_missing_in_binlog(int *err, const char **errormsg,
       binlog_gtid.seq_no >= error_gtid->seq_no)
   {
     *errormsg= "Requested slave GTID state not found in binlog. The slave has "
-      "probably diverged due to executing errorneous transactions";
+      "probably diverged due to executing erroneous transactions";
     *err= ER_GTID_POSITION_NOT_FOUND_IN_BINLOG2;
   }
   else
@@ -2751,7 +2751,7 @@ err:
                 "%u-%u-%llu, which is not in the master's binlog. Since the "
                 "master's binlog contains GTIDs with higher sequence numbers, "
                 "it probably means that the slave has diverged due to "
-                "executing extra errorneous transactions",
+                "executing extra erroneous transactions",
                 error_gtid.domain_id, error_gtid.server_id, error_gtid.seq_no);
     /* Use this error code so slave will know not to try reconnect. */
     my_errno = ER_MASTER_FATAL_ERROR_READING_BINLOG;


### PR DESCRIPTION
noted by Rhys Campbell