### PR TITLE
MDEV-7781 Allow {un,}install plugins during bootstrap/skip-grant-tables

### DIFF
--- a/mysql-test/t/bootstrap.test
+++ b/mysql-test/t/bootstrap.test
@@ -60,3 +60,22 @@ SELECT 'bug' as '' FROM INFORMATION_SCHEMA.ENGINES WHERE engine='innodb'
  and SUPPORT='YES';
 
 --echo End of 5.5 tests
+
+--source include/not_windows_embedded.inc
+--source include/have_example_plugin.inc
+#
+# Check that --bootstrap can load/unload plugins
+#
+--disable_query_log
+let $PLUGIN_DIR=`select @@plugin_dir`;
+eval SELECT "install plugin example soname '$HA_EXAMPLE_SO';" INTO OUTFILE '$MYSQLTEST_VARDIR/tmp/install_plugin.sql';
+--enable_query_log
+--exec $MYSQLD_BOOTSTRAP_CMD --plugin-dir=$PLUGIN_DIR  < $MYSQLTEST_VARDIR/tmp/install_plugin.sql >> $MYSQLTEST_VARDIR/tmp/bootstrap.log 2>&1
+remove_file $MYSQLTEST_VARDIR/tmp/install_plugin.sql;
+--write_file $MYSQLTEST_VARDIR/tmp/bootstrap_plugins.sql
+use test;
+create table t1(a int) engine=example;
+drop table t1;
+EOF
+--exec $MYSQLD_BOOTSTRAP_CMD --plugin-dir=$PLUGIN_DIR < $MYSQLTEST_VARDIR/tmp/bootstrap_plugins.sql >> $MYSQLTEST_VARDIR/tmp/bootstrap.log 2>&1
+remove_file $MYSQLTEST_VARDIR/tmp/bootstrap_plugins.sql;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -2085,14 +2085,8 @@ bool mysql_install_plugin(THD *thd, const LEX_STRING *name,
   char **argv=orig_argv;
   DBUG_ENTER("mysql_install_plugin");
 
-  if (opt_noacl)
-  {
-    my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "--skip-grant-tables");
-    DBUG_RETURN(TRUE);
-  }
-
   tables.init_one_table("mysql", 5, "plugin", 6, "plugin", TL_WRITE);
-  if (check_table_access(thd, INSERT_ACL, &tables, FALSE, 1, FALSE))
+  if (!opt_noacl && check_table_access(thd, INSERT_ACL, &tables, FALSE, 1, FALSE))
     DBUG_RETURN(TRUE);
 
   /* need to open before acquiring LOCK_plugin or it will deadlock */
@@ -2227,15 +2221,9 @@ bool mysql_uninstall_plugin(THD *thd, const LEX_STRING *name,
   bool error= false;
   DBUG_ENTER("mysql_uninstall_plugin");
 
-  if (opt_noacl)
-  {
-    my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "--skip-grant-tables");
-    DBUG_RETURN(TRUE);
-  }
-
   tables.init_one_table("mysql", 5, "plugin", 6, "plugin", TL_WRITE);
 
-  if (check_table_access(thd, DELETE_ACL, &tables, FALSE, 1, FALSE))
+  if (!opt_noacl && check_table_access(thd, DELETE_ACL, &tables, FALSE, 1, FALSE))
     DBUG_RETURN(TRUE);
 
   /* need to open before acquiring LOCK_plugin or it will deadlock */


### PR DESCRIPTION
This aids packagers to install/uninstall plugins without starting a full
mysql instance.

for MDEV-7781.