### PR TITLE
Execute sync_with_master before SELECT in rpl_gtid_basic.test

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_gtid_basic.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_basic.test
@@ -550,8 +550,8 @@ SELECT * FROM t1 WHERE a >= 30 ORDER BY a;
 --save_master_pos
 
 --connection server_4
-SELECT * FROM t1 WHERE a >= 30 ORDER BY a;
 --sync_with_master
+SELECT * FROM t1 WHERE a >= 30 ORDER BY a;
 
 
 # Clean up.


### PR DESCRIPTION
Before, this test was dependent on timing, see
https://github.com/MariaDB/server/commit/fa5809ce109a8966059ea3cbda982cf2f160c430#diff-c2b3c619c264711c41f76581dc0397fcL436
https://github.com/MariaDB/server/commit/ef4d8db5ece5edfe3574561a8cec70863d390c91#diff-c2b3c619c264711c41f76581dc0397fcR478
where 34 was removed and then again added to .result file

Usually slave synchronized on its own before select, but not always. Those two lines were probably swapped by accident