### PR TITLE
MDEV-7130 MASTER_POS_WAIT does not respect timeout when connection_name is specificed

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_mdev7130.result
+++ b/mysql-test/suite/rpl/r/rpl_mdev7130.result
@@ -1,0 +1,27 @@
+include/master-slave.inc
+[connection master]
+connection slave;
+# Normal anonymous connection -- works (expected -1)
+select master_pos_wait('master-bin.000001',1000000,1);
+master_pos_wait('master-bin.000001',1000000,1)
+-1
+include/stop_slave.inc
+connection slave;
+reset slave all;
+change master 'my_slave' to master_port=MASTER_MYPORT, master_host='127.0.0.1', master_user='root';
+set default_master_connection = 'my_slave';
+include/start_slave.inc
+connection slave;
+# Call without connection name -- works (expected -1)
+select master_pos_wait('master-bin.000001',1000000,1);
+master_pos_wait('master-bin.000001',1000000,1)
+-1
+set default_master_connection = '';
+# Call for non-existing anonymous connection -- works (expected NULL)
+select master_pos_wait('master-bin.000001',1000000,1);
+master_pos_wait('master-bin.000001',1000000,1)
+NULL
+# Call with a valid connection name -- hangs (expected -1)
+select master_pos_wait('master-bin.000001',1000000,1,"my_slave");
+master_pos_wait('master-bin.000001',1000000,1,"my_slave")
+-1

--- a/mysql-test/suite/rpl/t/rpl_mdev7130.test
+++ b/mysql-test/suite/rpl/t/rpl_mdev7130.test
@@ -1,0 +1,26 @@
+--source include/master-slave.inc
+
+--enable_connect_log
+
+--connection slave
+
+--echo # Normal anonymous connection -- works (expected -1)
+select master_pos_wait('master-bin.000001',1000000,1);
+
+--source include/stop_slave.inc
+reset slave all;
+--replace_result $MASTER_MYPORT MASTER_MYPORT
+eval change master 'my_slave' to master_port=$MASTER_MYPORT, master_host='127.0.0.1', master_user='root';
+set default_master_connection = 'my_slave';
+--source include/start_slave.inc
+
+--echo # Call without connection name -- works (expected -1)
+select master_pos_wait('master-bin.000001',1000000,1);
+
+set default_master_connection = '';
+
+--echo # Call for non-existing anonymous connection -- works (expected NULL)
+select master_pos_wait('master-bin.000001',1000000,1);
+
+--echo # Call with a valid connection name -- hangs (expected -1)
+select master_pos_wait('master-bin.000001',1000000,1,"my_slave");

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -3956,11 +3956,11 @@ longlong Item_master_pos_wait::val_int()
   }
 #ifdef HAVE_REPLICATION
   longlong pos = (ulong)args[1]->val_int();
-  longlong timeout = (arg_count==3) ? args[2]->val_int() : 0 ;
+  longlong timeout = (arg_count>=3) ? args[2]->val_int() : 0 ;
   String connection_name_buff;
   LEX_STRING connection_name;
   Master_info *mi;
-  if (arg_count == 4)
+  if (arg_count >= 4)
   {
     String *con;
     if (!(con= args[3]->val_str(&connection_name_buff)))


### PR DESCRIPTION
https://mariadb.atlassian.net/browse/MDEV-7130
MASTER_POS_WAIT(log_name,log_pos,timeout,"connection_name") hangs, does not respect the timeout

Changed also arg_count check for connection_name to prevent same bug if fifth argument is introduced in future

Tests can be reduced to just one master_pos_wait select, it may be better since each this select waits one second timeout (except one for non-existing connection, line 23)