### PR TITLE
Fix BigEndian build

### DIFF
--- a/storage/cassandra/ha_cassandra.cc
+++ b/storage/cassandra/ha_cassandra.cc
@@ -887,7 +887,7 @@ bool cassandra_to_dyncol_intLong(const char *cass_data,
 {
   value->type= DYN_COL_INT;
 #ifdef WORDS_BIGENDIAN
-  value->x.long_value= (longlong *)*cass_data;
+  value->x.long_value= (longlong)*cass_data;
 #else
   flip64(cass_data, (char *)&value->x.long_value);
 #endif


### PR DESCRIPTION
On BigEndian build fails with:
[ 109s]
/home/abuild/rpmbuild/BUILD/mariadb-10.0.17/storage/cassandra/ha_cassandra.cc:890:22:
error: invalid conversion from 'longlong*
{aka long long int*}

' to 'long long int' [-fpermissive]
[ 109s] value->x.long_value= (longlong *)*cass_data;
[ 109s] ^

This commit fixes it

Signed-off-by: Dinar Valeev <dvaleev@suse.com>