### PR TITLE
spelling: parallell -> parallel

### DIFF
--- a/include/mysql/psi/mysql_socket.h
+++ b/include/mysql/psi/mysql_socket.h
@@ -149,7 +149,7 @@ MYSQL_SOCKET socket __attribute__ ((unused))
 /**
   MYSQL_SOCKET helper. Get socket descriptor.
   @param mysql_socket Instrumented socket
-  @sa mysql_socket_setfd
+  @sa mysql_socket_getfd
 */
 static inline my_socket
 mysql_socket_getfd(MYSQL_SOCKET mysql_socket)
@@ -161,7 +161,7 @@ mysql_socket_getfd(MYSQL_SOCKET mysql_socket)
   MYSQL_SOCKET helper. Set socket descriptor.
   @param mysql_socket Instrumented socket
   @param fd Socket descriptor
-  @sa mysql_socket_getfd
+  @sa mysql_socket_setfd
 */
 static inline void
 mysql_socket_setfd(MYSQL_SOCKET *mysql_socket, my_socket fd)

--- a/man/mysqldump.1
+++ b/man/mysqldump.1
@@ -1261,7 +1261,7 @@ to point the slave to the correct master server host\&. Add any such parameters 
 .\" max-allowed-packet option: mysqldump
 \fB\-\-max\-allowed\-packet=\fR\fB\fIlength\fR\fR
 .sp
-Sets the maximum packet length to send to or recieve from server\&.
+Sets the maximum packet length to send to or receive from server\&.
 .RE
 .sp
 .RS 4

--- a/mysql-test/lib/v1/ndb_config_1_node.ini
+++ b/mysql-test/lib/v1/ndb_config_1_node.ini
@@ -16,7 +16,7 @@ DiskPageBufferMemory= CHOOSE_DiskPageBufferMemory
 
 #
 # Increase timeouts to cater for slow test-machines
-#   (possibly running several tests in parallell)
+#   (possibly running several tests in parallel)
 #
 HeartbeatIntervalDbDb= 30000
 HeartbeatIntervalDbApi= 30000

--- a/mysql-test/lib/v1/ndb_config_2_node.ini
+++ b/mysql-test/lib/v1/ndb_config_2_node.ini
@@ -21,7 +21,7 @@ InitialNoOfOpenFiles= 27
 
 #
 # Increase timeouts to cater for slow test-machines
-#   (possibly running several tests in parallell)
+#   (possibly running several tests in parallel)
 #
 HeartbeatIntervalDbDb= 30000
 HeartbeatIntervalDbApi= 30000

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -837,7 +837,7 @@ sub run_test_server ($$$) {
 	    redo;
 	  }
 
-	  # Limit number of parallell NDB tests
+	  # Limit number of parallel NDB tests
 	  if ($t->{ndb_test} and $num_ndb_tests >= $max_ndb){
 	    #mtr_report("Skipping, num ndb is already at max, $num_ndb_tests");
 	    next;
@@ -6423,7 +6423,7 @@ Options to control what engine/variation to run:
   skip-ssl              Dont start server with support for ssl connections
   vs-config             Visual Studio configuration used to create executables
                         (default: MTR_VS_CONFIG environment variable)
-  parallel=#            How many parallell test should be run
+  parallel=#            How many parallel test should be run
   defaults-file=<config template> Use fixed config template for all
                         tests
   defaults-extra-file=<config template> Extra config template to add to

--- a/mysql-test/std_data/ndb_config_config.ini
+++ b/mysql-test/std_data/ndb_config_config.ini
@@ -21,7 +21,7 @@ InitialNoOfOpenFiles= 27
  
 # 
 # Increase timeouts to cater for slow test-machines 
-#   (possibly running several tests in parallell) 
+#   (possibly running several tests in parallel) 
 # 
 HeartbeatIntervalDbDb= 30000 
 HeartbeatIntervalDbApi= 30000 

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -3271,7 +3271,7 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
               it may be good to consider what actually happens when
               open_purge_index_file succeeds but register or sync fails.
 
-              Perhaps we might need the code below in MYSQL_LOG_BIN::cleanup
+              Perhaps we might need the code below in MYSQL_BIN_LOG::cleanup
               for "real life" purposes as well? 
      */
     DBUG_EXECUTE_IF("fault_injection_registering_index", {

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -715,7 +715,7 @@ struct rpl_group_info
   /**
     Save pointer to Annotate_rows event and switch on the
     binlog_annotate_row_events for this sql thread.
-    To be called when sql thread recieves an Annotate_rows event.
+    To be called when sql thread receives an Annotate_rows event.
   */
   inline void set_annotate_event(Annotate_rows_log_event *event)
   {

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2445,7 +2445,7 @@ int select_result_explain_buffer::send_data(List<Item> &items)
   DBUG_ENTER("select_result_explain_buffer::send_data");
 
   /*
-    Switch to the recieveing thread, so that we correctly count memory used
+    Switch to the receiveing thread, so that we correctly count memory used
     by it. This is needed as it's the receiving thread that will free the
     memory.
   */

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -488,7 +488,7 @@ err_len:
 		return("incorrect column length in SYS_FOREIGN");
 	}
 
-	/* This recieves a dict_foreign_t* that points to a stack variable.
+	/* This receives a dict_foreign_t* that points to a stack variable.
 	So mem_heap_free(foreign->heap) is not used as elsewhere.
 	Since the heap used here is freed elsewhere, foreign->heap
 	is not assigned. */

--- a/storage/innobase/trx/trx0undo.cc
+++ b/storage/innobase/trx/trx0undo.cc
@@ -64,7 +64,7 @@ we trigger the start of a purge? When a transaction writes to an undo log,
 it may notice that the space is running out. When a read view is closed,
 it may make some history superfluous. The server can have an utility which
 periodically checks if it can purge some history.
-	In a parallellized purge we have the problem that a query thread
+	In a parallelized purge we have the problem that a query thread
 can remove a delete marked clustered index record before another query
 thread has processed an earlier version of the record, which cannot then
 be done because the row cannot be constructed from the clustered index

--- a/storage/maria/maria_chk.c
+++ b/storage/maria/maria_chk.c
@@ -1054,7 +1054,7 @@ static int maria_chk(HA_CHECK *param, char *filename)
       error= 1;
       goto end2;
     }
-    /* We can't do parallell repair with BLOCK_RECORD yet */
+    /* We can't do parallel repair with BLOCK_RECORD yet */
     if (param->testflag & T_REP_PARALLEL)
     {
       param->testflag&= ~T_REP_PARALLEL;

--- a/storage/ndb/include/ndbapi/NdbEventOperation.hpp
+++ b/storage/ndb/include/ndbapi/NdbEventOperation.hpp
@@ -63,7 +63,7 @@ class NdbEventOperationImpl;
  * - Event code does not check table schema version. Make sure to drop events
  * after table is dropped. Will be fixed in later
  * versions.
- * - If a node failure has occured not all events will be recieved
+ * - If a node failure has occured not all events will be received
  * anymore. Drop NdbEventOperation and Create again after nodes are up
  * again. Will be fixed in later versions.
  *

--- a/storage/ndb/src/cw/cpcc-win32/csharp/telnetclient/telnetClient.cs
+++ b/storage/ndb/src/cw/cpcc-win32/csharp/telnetclient/telnetClient.cs
@@ -99,9 +99,9 @@ namespace NDB_CPC.telnetclient
 				if ( sock1.Connected ) 
 				{	
 					// Define a new Callback to read the data 
-					AsyncCallback recieveData = new AsyncCallback( OnRecievedData );
+					AsyncCallback receiveData = new AsyncCallback( OnRecievedData );
 					// Begin reading data asyncronously
-					sock1.BeginReceive( m_byBuff, 0, m_byBuff.Length, SocketFlags.None, recieveData , sock1 );
+					sock1.BeginReceive( m_byBuff, 0, m_byBuff.Length, SocketFlags.None, receiveData , sock1 );
 				}
 			}
 			catch( Exception ex )
@@ -163,7 +163,7 @@ namespace NDB_CPC.telnetclient
 				}
 				else
 				{
-					// If no data was recieved then the connection is probably dead
+					// If no data was received then the connection is probably dead
 					Console.WriteLine( "Disconnected", sock.RemoteEndPoint );
 					sock.Shutdown( SocketShutdown.Both );
 					sock.Close();

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -10559,7 +10559,7 @@ void Dbtc::releaseAbortResources(Signal* signal)
 
   // MASV let state be CS_ABORTING until all 
   // signals in the "air" have been received. Reset to CS_CONNECTED
-  // will be done when a TCKEYREQ with start flag is recieved
+  // will be done when a TCKEYREQ with start flag is received
   // or releaseApiCon is called
   // apiConnectptr.p->apiConnectstate = CS_CONNECTED;
   apiConnectptr.p->apiConnectstate = CS_ABORTING;

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
@@ -526,7 +526,7 @@ private:
   //  we signal with a condition variable to the waiting
   //  thread (receiveOptimisedResponse) that the signal has arrived.
   // Parameters:
-  //  signal: The recieved signal
+  //  signal: The received signal
   // Returns: -
   //**************************************************************************
 
@@ -566,7 +566,7 @@ private:
   /**
    *   This function is called from "outside" of MgmtSrvr
    *   when a signal is sent to MgmtSrvr.
-   *   @param  mgmtSrvr: The MgmtSrvr object which shall recieve the signal.
+   *   @param  mgmtSrvr: The MgmtSrvr object which shall receive the signal.
    *   @param  signal: The received signal.
    */
   static void signalReceivedNotification(void* mgmtSrvr, 
@@ -600,7 +600,7 @@ private:
   
   Uint32 theWaitNode;
   WaitSignalType theWaitState;
-  // State denoting a set of signals we accept to recieve.
+  // State denoting a set of signals we accept to receive.
 
   NdbCondition* theMgmtWaitForResponseCondPtr; 
   // Condition variable used when we wait for a signal to arrive/a 

--- a/storage/ndb/test/ndbapi/testDict.cpp
+++ b/storage/ndb/test/ndbapi/testDict.cpp
@@ -942,7 +942,7 @@ int runStoreFrm(NDBT_Context* ctx, NDBT_Step* step){
     
     // Verfiy the frm data
     if (memcmp(pData, pData2, resultLen) != 0){
-      g_err << "Wrong data recieved" << endl;
+      g_err << "Wrong data received" << endl;
       for (size_t i = 0; i < dataLen; i++){
 	unsigned char c = ((unsigned char*)pData2)[i];
 	g_err << hex << c << ", ";

--- a/storage/ndb/test/odbc/SQL99_test/SQL99_test.cpp
+++ b/storage/ndb/test/odbc/SQL99_test/SQL99_test.cpp
@@ -1611,7 +1611,7 @@ Function: AggretateFn():
 <char* szTableName> - name of the table
 <int nCol> - number of the column
 <double* pdIn> - pointer to double containing the value to be used in a call to COUNT; used only by this function
-<double* pdOut> - pointer to double that will recieve the result
+<double* pdOut> - pointer to double that will receive the result
 <attr_type attrType> - type of the attribute
 *************************************************/
 SQLRETURN AggregateFn(aggr_fn fn, char* szTableName, int nCol, double* pdIn, double* pdOut, attr_type attrType){

--- a/storage/tokudb/ft-index/ft/ft-flusher.cc
+++ b/storage/tokudb/ft-index/ft/ft-flusher.cc
@@ -601,7 +601,7 @@ handle_split_of_child(
 
     // We never set the rightmost blocknum to be the root.
     // Instead, we wait for the root to split and let promotion initialize the rightmost
-    // blocknum to be the first non-root leaf node on the right extreme to recieve an insert.
+    // blocknum to be the first non-root leaf node on the right extreme to receive an insert.
     BLOCKNUM rightmost_blocknum = toku_drd_unsafe_fetch(&ft->rightmost_blocknum);
     invariant(ft->h->root_blocknum.b != rightmost_blocknum.b);
     if (childa->blocknum.b == rightmost_blocknum.b) {

--- a/storage/xtradb/dict/dict0load.cc
+++ b/storage/xtradb/dict/dict0load.cc
@@ -488,7 +488,7 @@ err_len:
 		return("incorrect column length in SYS_FOREIGN");
 	}
 
-	/* This recieves a dict_foreign_t* that points to a stack variable.
+	/* This receives a dict_foreign_t* that points to a stack variable.
 	So mem_heap_free(foreign->heap) is not used as elsewhere.
 	Since the heap used here is freed elsewhere, foreign->heap
 	is not assigned. */

--- a/storage/xtradb/trx/trx0undo.cc
+++ b/storage/xtradb/trx/trx0undo.cc
@@ -64,7 +64,7 @@ we trigger the start of a purge? When a transaction writes to an undo log,
 it may notice that the space is running out. When a read view is closed,
 it may make some history superfluous. The server can have an utility which
 periodically checks if it can purge some history.
-	In a parallellized purge we have the problem that a query thread
+	In a parallelized purge we have the problem that a query thread
 can remove a delete marked clustered index record before another query
 thread has processed an earlier version of the record, which cannot then
 be done because the row cannot be constructed from the clustered index


### PR DESCRIPTION
The parallelizm of 'l's in the word "parallel" has exceeded the english
language specification.

Comments only are affected. storage/ndb had too much parallell in code
to consider fixing.