### PR TITLE
MDEV-7977 MYSQL_BIN_LOG::write_incident failing to release LOCK_log

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -5784,6 +5784,10 @@ bool MYSQL_BIN_LOG::write_incident(THD *thd)
     if (check_purge)
       purge();
   }
+  else
+  {
+    mysql_mutex_unlock(&LOCK_log);
+  }
 
   DBUG_RETURN(error);
 }


### PR DESCRIPTION
This adds a unlock(LOCK_log) for the unlikely(!is_open()) branch