### PR TITLE
MDEV-7820 Server crashes in in my_strcasecmp_utf8 on subquery in ORDER B...

### DIFF
--- a/mysql-test/r/func_gconcat.result
+++ b/mysql-test/r/func_gconcat.result
@@ -1091,3 +1091,15 @@ insert into t1 values ('a'),('b');
 select 1 from t1 where a in (select group_concat(a) from t1);
 1
 drop table t1;
+CREATE TABLE t1 (f1 VARCHAR(10)) ENGINE=MyISAM;
+INSERT INTO t1 VALUES ('a'),('b');
+CREATE TABLE t2 (f2 VARCHAR(10)) ENGINE=MyISAM;
+INSERT INTO t2 VALUES ('c');
+CREATE TABLE t3 (f3 VARCHAR(10)) ENGINE=MyISAM;
+INSERT INTO t3 VALUES ('d'),('e');
+SELECT GROUP_CONCAT( f2 ORDER BY ( f2 IN ( SELECT f1 FROM t1 WHERE f1 <= f2 ) ) ) AS field
+FROM ( SELECT * FROM t2 ) AS sq2, t3
+ORDER BY field;
+field
+c,c
+drop table t3, t2, t1;

--- a/mysql-test/t/func_gconcat.test
+++ b/mysql-test/t/func_gconcat.test
@@ -803,3 +803,21 @@ create table t1 (a char(1) character set utf8);
 insert into t1 values ('a'),('b');
 select 1 from t1 where a in (select group_concat(a) from t1);
 drop table t1;
+
+#
+# MDEV-7820 Server crashes in in my_strcasecmp_utf8 on subquery in ORDER BY clause of GROUP_CONCAT
+#
+CREATE TABLE t1 (f1 VARCHAR(10)) ENGINE=MyISAM;
+INSERT INTO t1 VALUES ('a'),('b');
+
+CREATE TABLE t2 (f2 VARCHAR(10)) ENGINE=MyISAM;
+INSERT INTO t2 VALUES ('c');
+
+CREATE TABLE t3 (f3 VARCHAR(10)) ENGINE=MyISAM;
+INSERT INTO t3 VALUES ('d'),('e');
+
+SELECT GROUP_CONCAT( f2 ORDER BY ( f2 IN ( SELECT f1 FROM t1 WHERE f1 <= f2 ) ) ) AS field
+FROM ( SELECT * FROM t2 ) AS sq2, t3
+ORDER BY field;
+
+drop table t3, t2, t1;

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -7256,7 +7256,7 @@ find_item_in_list(Item *find, List<Item> &items, uint *counter,
         Item_field for tables.
       */
       Item_ident *item_ref= (Item_ident *) item;
-      if (item_ref->name && item_ref->table_name &&
+      if (field_name && item_ref->name && item_ref->table_name &&
           !my_strcasecmp(system_charset_info, item_ref->name, field_name) &&
           !my_strcasecmp(table_alias_charset, item_ref->table_name,
                          table_name) &&


### PR DESCRIPTION
...Y clause of GROUP_CONCAT

It is possible for Item_field to have a NULL field_name. This is true if
the Item_field is created based on a field in a temporary table that has
no name. It is thus necessary to do a null check before attempting a
strcmp.