### PR TITLE
MDEV-8032: audit plugin - csv output broken

### DIFF
--- a/plugin/server_audit/server_audit.c
+++ b/plugin/server_audit/server_audit.c
@@ -1118,6 +1118,8 @@ static size_t escape_string(const char *str, unsigned int len,
       *(result++)= '\\';
       *(result++)= '\\';
     }
+    else if (is_space(*str))
+      *(result++)= ' ';
     else
       *(result++)= *str;
     str++;


### PR DESCRIPTION
since the audit file output is csv formatted, special characters like newline or tab should be replaced on the query. this replacement is done on querys with passwords (escape_string_hide_passwords) but not on casual escape_string()

see https://mariadb.atlassian.net/browse/MDEV-8032