### PR TITLE
c99 style for assigning structure members

### DIFF
--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -158,7 +158,7 @@ do {									\
 } while (0)
 
 #if !defined __STRICT_ANSI__ && defined __GNUC__ && (__GNUC__) > 2 && !defined __INTEL_COMPILER
-#define STRUCT_FLD(name, value)	name: value
+#define STRUCT_FLD(name, value)	.name = value
 #else
 #define STRUCT_FLD(name, value)	value
 #endif

--- a/storage/xtradb/handler/i_s.cc
+++ b/storage/xtradb/handler/i_s.cc
@@ -180,7 +180,7 @@ do {									\
 
 #if !defined __STRICT_ANSI__ && defined __GNUC__ && (__GNUC__) > 2 && 	\
 	!defined __INTEL_COMPILER && !defined __clang__
-#define STRUCT_FLD(name, value)	name: value
+#define STRUCT_FLD(name, value)	.name = value
 #else
 #define STRUCT_FLD(name, value)	value
 #endif


### PR DESCRIPTION
mainly to reduce clang warnings