### PR TITLE
Convert CR/LF line endings to LF only (Windows to Unix) (MDEV-4447)

### DIFF
--- a/storage/connect/filamap.cpp
+++ b/storage/connect/filamap.cpp
@@ -413,7 +413,7 @@ int MAPFAM::DeleteRecords(PGLOBAL g, int irc)
 
   if (Tpos == Spos) {
     /*******************************************************************/
-    /*  First line to delete. Move of eventual preceeding lines is     */
+    /*  First line to delete. Move of eventual preceding lines is     */
     /*  not required here, just setting of future Spos and Tpos.       */
     /*******************************************************************/
     Tpos = Spos = Fpos;


### PR DESCRIPTION
Omit *.result and std_data/*