### PR TITLE
Remove needless "@" from "@ONLY@"

### DIFF
--- a/libmysql/CMakeLists.txt
+++ b/libmysql/CMakeLists.txt
@@ -381,7 +381,7 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
   CONFIGURE_FILE(
     ${VERSION_SCRIPT_TEMPLATE}
     ${CMAKE_CURRENT_BINARY_DIR}/libmysql_versions.ld
-    @ONLY@
+    @ONLY
   )
   SET(VERSION_SCRIPT_LINK_FLAGS 
     "-Wl,${CMAKE_CURRENT_BINARY_DIR}/libmysql_versions.ld")


### PR DESCRIPTION
configure_file CMake command uses `@ONLY` not `@ONLY@`.
See also: http://www.cmake.org/cmake/help/v3.2/command/configure_file.html

Without this change, the following warning is reported:

    CMake Warning (dev) at libmysql/CMakeLists.txt:381 (CONFIGURE_FILE):
      configure_file called with unknown argument(s):

       @ONLY@

    This warning is for project developers.  Use -Wno-dev to suppress it.

10.0 branch has the same problem.