### PR TITLE
Fixes MDEV-8083: MTR is broken on systems with IPv6 disabled

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2500,10 +2500,17 @@ static MYSQL_SOCKET activate_tcp_port(uint port)
 
     if (mysql_socket_getfd(ip_sock) == INVALID_SOCKET)
     {
-      sql_print_error("Failed to create a socket for %s '%s': errno: %d.",
-                      (a->ai_family == AF_INET) ? "IPv4" : "IPv6",
-                      (const char *) ip_addr,
-                      (int) socket_errno);
+      /*
+        Do not throw an error if a wildcard address is being used, but IPv6 is
+        not available, i.e. an attempt to create an AF_INET6 socket fails.
+      */
+      if (!real_bind_addr_str && ai->ai_family == AF_INET6)
+        sql_print_information("IPv6 is not available.");
+      else
+        sql_print_error("Failed to create a socket for %s '%s': errno: %d.",
+                        (a->ai_family == AF_INET) ? "IPv4" : "IPv6",
+                        (const char *) ip_addr,
+                        (int) socket_errno);
     }
     else 
     {


### PR DESCRIPTION
Mimic the MySQL behavior: if bind-address is ‘*’, but the system fails
to create an IPv6 socket, just print an informational message rather than
an error to the log. This makes MTR usable on systems with IPv6 support
disabled in the kernel.