### PR TITLE
Fixes MDEV-7658: MDEV-7026 fix reintroduces MDEV-6615 on AArch64

### DIFF
--- a/storage/innobase/include/os0sync.h
+++ b/storage/innobase/include/os0sync.h
@@ -324,7 +324,7 @@ amount of increment. */
 /**********************************************************//**
 Returns the old value of *ptr, atomically sets *ptr to new_val */
 
-#ifdef __powerpc__
+#if defined(__powerpc__) || defined(__aarch64__)
 /*
   os_atomic_test_and_set_byte_release() should imply a release barrier before
   setting, and a full barrier after. But __sync_lock_test_and_set() is only

--- a/storage/xtradb/include/os0sync.h
+++ b/storage/xtradb/include/os0sync.h
@@ -331,7 +331,7 @@ amount of increment. */
 /**********************************************************//**
 Returns the old value of *ptr, atomically sets *ptr to new_val */
 
-#ifdef __powerpc__
+#if defined(__powerpc__) || defined(__aarch64__)
 /*
   os_atomic_test_and_set_byte_release() should imply a release barrier before
   setting, and a full barrier after. But __sync_lock_test_and_set() is only


### PR DESCRIPTION
This is an addendum to the fix for MDEV-7026. The ARM memory model is
similar to that of PowerPC and thus needs the same semantics with
respect to memory barriers. That is, os_atomic_test_and_set_*_release()
must be a store with a release barrier followed by a full
barrier. Unlike x86 using __sync_lock_test_and_set() which is
implemented as “exclusive load with acquire barriers + exclusive store”
is insufficient in contexts where os_atomic_test_and_set_*_release()
macros are used.