### PR TITLE
Fix Mariadb compile and install error in Mac OS X yosemite

### DIFF
--- a/storage/tokudb/ft-index/cmake_modules/TokuSetupCompiler.cmake
+++ b/storage/tokudb/ft-index/cmake_modules/TokuSetupCompiler.cmake
@@ -181,8 +181,8 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL Clang)
 endif ()
 
 ## always want these
-set(CMAKE_C_FLAGS "-Wall -Werror ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "-Wall -Werror ${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS "-Wall ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall ${CMAKE_CXX_FLAGS}")
 
 ## need to set -stdlib=libc++ to get real c++11 support on darwin
 if (APPLE)

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -379,7 +379,7 @@ static int free_share(TOKUDB_SHARE * share) {
     }
 
 const char *ha_tokudb::table_type() const {
-    extern const char * const tokudb_hton_name;
+    extern const char *tokudb_hton_name;
     return tokudb_hton_name;
 } 
 


### PR DESCRIPTION
There are two error in compile progress
The first one is below:

[ 80%] Building CXX object storage/tokudb/ft-index/locktree/CMakeFiles/locktree_static.dir/locktree.cc.o
In file included from /Users/tangjiacheng/Development/server/storage/tokudb/ft-index/locktree/locktree.cc:99:
In file included from /Users/tangjiacheng/Development/server/storage/tokudb/ft-index/locktree/locktree.h:94:
/Users/tangjiacheng/Development/server/storage/tokudb/ft-index/buildheader/db.h:323:1: error: 
      empty struct has size 0 in C, size 1 in C++ [-Werror,-Wextern-c-compat]
struct __toku_db_lsn {
^
1 error generated.
make[2]: *** [storage/tokudb/ft-index/locktree/CMakeFiles/locktree_static.dir/locktree.cc.o] Error 1
make[1]: *** [storage/tokudb/ft-index/locktree/CMakeFiles/locktree_static.dir/all] Error 2
make: *** [all] Error 2

I guess it is arised by the different from OS X gcc compiler to GNU gcc

The second is here:

In file included from /Users/tangjiacheng/Development/server/storage/tokudb/ha_tokudb.cc:8293:
/Users/tangjiacheng/Development/server/storage/tokudb/hatoku_hton.cc:262:13: error: 
      redefinition of 'tokudb_hton_name' with a different type: 'const char *'
      vs 'const char *const'
const char *tokudb_hton_name = "TokuDB";
            ^
/Users/tangjiacheng/Development/server/storage/tokudb/ha_tokudb.cc:382:31: note: 
      previous definition is here
    extern const char * const tokudb_hton_name;

It is arised by the difference of two tokudb_hton_name definition