### PR TITLE
Clarify the log message about master_info and relay_info files.

### DIFF
--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -3313,7 +3313,8 @@ bool change_master(THD* thd, Master_info* mi, bool *master_info_added)
     *master_info_added= true;
   }
   if (global_system_variables.log_warnings > 1)
-    sql_print_information("Master: '%.*s'  Master_info_file: '%s'  "
+    sql_print_information("Master connection name: '%.*s'  "
+                          "Master_info_file: '%s'  "
                           "Relay_info_file: '%s'",
                           (int) mi->connection_name.length,
                           mi->connection_name.str,


### PR DESCRIPTION
Just "Master" could be understood as the master IP or hostname and thus can
cause confusion to db admins. "Master connection name" clearly states that
the log line contains connection name in the (possibly) multi-master setup.