### PR TITLE
Add parenthesis in macro definitions to prevent order of operation problems

### DIFF
--- a/sql/log_slow.h
+++ b/sql/log_slow.h
@@ -16,23 +16,23 @@
 /* Defining what to log to slow log */
 
 #define LOG_SLOW_VERBOSITY_INIT           0
-#define LOG_SLOW_VERBOSITY_INNODB         1 << 0
-#define LOG_SLOW_VERBOSITY_QUERY_PLAN     1 << 1
-#define LOG_SLOW_VERBOSITY_EXPLAIN        1 << 2
+#define LOG_SLOW_VERBOSITY_INNODB         (1 << 0)
+#define LOG_SLOW_VERBOSITY_QUERY_PLAN     (1 << 1)
+#define LOG_SLOW_VERBOSITY_EXPLAIN        (1 << 2)
 
 #define QPLAN_INIT            QPLAN_QC_NO
 
-#define QPLAN_ADMIN           1 << 0
-#define QPLAN_FILESORT        1 << 1
-#define QPLAN_FILESORT_DISK   1 << 2
-#define QPLAN_FULL_JOIN       1 << 3
-#define QPLAN_FULL_SCAN       1 << 4
-#define QPLAN_QC              1 << 5
-#define QPLAN_QC_NO           1 << 6
-#define QPLAN_TMP_DISK        1 << 7
-#define QPLAN_TMP_TABLE       1 << 8
-#define QPLAN_FILESORT_PRIORITY_QUEUE       1 << 9
+#define QPLAN_ADMIN           (1 << 0)
+#define QPLAN_FILESORT        (1 << 1)
+#define QPLAN_FILESORT_DISK   (1 << 2)
+#define QPLAN_FULL_JOIN       (1 << 3)
+#define QPLAN_FULL_SCAN       (1 << 4)
+#define QPLAN_QC              (1 << 5)
+#define QPLAN_QC_NO           (1 << 6)
+#define QPLAN_TMP_DISK        (1 << 7)
+#define QPLAN_TMP_TABLE       (1 << 8)
+#define QPLAN_FILESORT_PRIORITY_QUEUE       (1 << 9)
 
 /* ... */
-#define QPLAN_MAX             ((ulong) 1) << 31 /* reserved as placeholder */
+#define QPLAN_MAX             (((ulong) 1) << 31) /* reserved as placeholder */
 


### PR DESCRIPTION
When macro is expanded in an expression like ~QPLAN_QC_NO (e.g. in the
Query_cache::send_result_to_client() function in sql/sql_cache.cc) then without
the parenthesis the expression will be evaluated to a wrong value.