### PR TITLE
MDEV-8565: COLUMN_CHECK fails on valid data

### DIFF
--- a/mysys/ma_dyncol.c
+++ b/mysys/ma_dyncol.c
@@ -3723,7 +3723,7 @@ mariadb_dyncol_check(DYNAMIC_COLUMN *str)
     if (prev_type != DYN_COL_NULL)
     {
       /* It is not first entry */
-      if (prev_data_offset >= data_offset)
+      if (prev_data_offset >= data_offset  &&  type != DYN_COL_INT)
       {
         DBUG_PRINT("info", ("Field order: %u  Previous data offset: %u"
                             " >= Current data offset: %u",


### PR DESCRIPTION
When an INTEGER type dynamic column has a value of ZERO, it is stored as a zero-length amount of data (nothing in the data section at all). This change now ignores the data length in COLUMN_CHECK for INTEGER data types, since zero-length data is a valid result produced by COLUMN_CREATE due to the way variable length INTEGER data is stored.