### PR TITLE
Fix segfault with musl libc due to bad use of strerror_r

### DIFF
--- a/strings/my_vsnprintf.c
+++ b/strings/my_vsnprintf.c
@@ -827,11 +827,7 @@ void my_strerror(char *buf, size_t len, int nr)
     */
 #if defined(__WIN__)
     strerror_s(buf, len, nr);
-#elif ((defined _POSIX_C_SOURCE && (_POSIX_C_SOURCE >= 200112L)) ||    \
-       (defined _XOPEN_SOURCE   && (_XOPEN_SOURCE >= 600)))      &&    \
-      ! defined _GNU_SOURCE
-    strerror_r(nr, buf, len);             /* I can build with or without GNU */
-#elif defined _GNU_SOURCE
+#elif defined(__GLIBC__) && defined(_GNU_SOURCE)
     char *r= strerror_r(nr, buf, len);
     if (r != buf)                         /* Want to help, GNU? */
       strmake(buf, r, len - 1);           /* Then don't. */


### PR DESCRIPTION
The only known implementation that has the GNU variand of strerror_r is
GNU libc. Building with musl libc and _GNU_SOURCE enables some other gnu
extensions, but musl libc does not implement the broken strerror_r.

We fix thsi by check explicitly for GNU libc in addition to _GNU_SOURCE
and if they both are not set, then fall back to standard.

This fixes segfault with musl libc.