### PR TITLE
MDEV-8917 - check for missing shared libraries with "ldd $mysqld" and produce

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -324,6 +324,15 @@ then
   exit 1
 fi
 
+# check whether all shared library dependencies are met
+if ldd $mysqld | grep -q "not found"
+then
+    echo "FATAL ERROR: missing shared libraries"
+    echo "the following libraries required by $mysqld are missing:"
+    ldd $mysqld | grep "not found"
+    exit 1
+fi
+
 if test -n "$langdir"
 then
   if test ! -f "$langdir/errmsg.sys"


### PR DESCRIPTION
less confusing error output if requirements are not met (MDEV-8917)