### PR TITLE
MDEV-9003 - fix debian logrotate slow log filename

### DIFF
--- a/debian/mariadb-server-10.1.mysql-server.logrotate
+++ b/debian/mariadb-server-10.1.mysql-server.logrotate
@@ -2,7 +2,7 @@
 #   flush-logs'd only once.
 #   Else the binary logs would automatically increase by n times every day.
 # - The error log is obsolete, messages go to syslog now.
-/var/log/mysql.log /var/log/mysql/mysql.log /var/log/mysql/mysql-slow.log {
+/var/log/mysql.log /var/log/mysql/mysql.log /var/log/mysql/mariadb-slow.log {
 	daily
 	rotate 7
 	missingok


### PR DESCRIPTION
debian/additions/my.cnf sets slow_query_log_file to
/var/log/mysql/mariadb-slow.log.

Update the filename to rotate the slow log file.