### PR TITLE
MDEV-9001 - Fix DB name quoting in mysqldump --routine

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -2443,7 +2443,7 @@ static uint dump_routines_for_db(char *db)
   DBUG_ENTER("dump_routines_for_db");
   DBUG_PRINT("enter", ("db: '%s'", db));
 
-  mysql_real_escape_string(mysql, db_name_buff, db, strlen(db));
+  escape_quotes_for_mysql(mysql->charset, db_name_buff, 0, db, strlen(db), '`');
 
   /* nice comments */
   print_comment(sql_file, 0,

--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -1027,7 +1027,8 @@ extern CHARSET_INFO *fs_character_set(void);
 #endif
 extern size_t escape_quotes_for_mysql(CHARSET_INFO *charset_info,
                                       char *to, size_t to_length,
-                                      const char *from, size_t length);
+                                      const char *from, size_t length,
+                                      const char quote_char);
 
 extern void thd_increment_bytes_sent(void *thd, ulong length);
 extern void thd_increment_bytes_received(void *thd, ulong length);

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -1194,7 +1194,7 @@ mysql_real_escape_string(MYSQL *mysql, char *to,const char *from,
 			 ulong length)
 {
   if (mysql->server_status & SERVER_STATUS_NO_BACKSLASH_ESCAPES)
-    return (uint) escape_quotes_for_mysql(mysql->charset, to, 0, from, length);
+    return (uint) escape_quotes_for_mysql(mysql->charset, to, 0, from, length, '\'');
   return (uint) escape_string_for_mysql(mysql->charset, to, 0, from, length);
 }
 

--- a/mysys/charset.c
+++ b/mysys/charset.c
@@ -1022,9 +1022,10 @@ CHARSET_INFO *fs_character_set()
     to_length           Length of destination buffer, or 0
     from                The string to escape
     length              The length of the string to escape
+    quote_char          The character to double-up (probably ', ", or `)
 
   DESCRIPTION
-    This escapes the contents of a string by doubling up any apostrophes that
+    This escapes the contents of a string by doubling up any "quote_char"'s that
     it contains. This is used when the NO_BACKSLASH_ESCAPES SQL_MODE is in
     effect on the server.
 
@@ -1039,7 +1040,8 @@ CHARSET_INFO *fs_character_set()
 
 size_t escape_quotes_for_mysql(CHARSET_INFO *charset_info,
                                char *to, size_t to_length,
-                               const char *from, size_t length)
+                               const char *from, size_t length,
+                               const char quote_char)
 {
   const char *to_start= to;
   const char *end, *to_end=to_start + (to_length ? to_length-1 : 2*length);
@@ -1069,15 +1071,15 @@ size_t escape_quotes_for_mysql(CHARSET_INFO *charset_info,
       character, because we are only escaping the ' character with itself.
      */
 #endif
-    if (*from == '\'')
+    if (*from == quote_char)
     {
       if (to + 2 > to_end)
       {
         overflow= TRUE;
         break;
       }
-      *to++= '\'';
-      *to++= '\'';
+      *to++= quote_char;
+      *to++= quote_char;
     }
     else
     {

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -2179,7 +2179,7 @@ after_set_capability:
 
     query.append("SELECT binlog_gtid_pos('");
     escape_quotes_for_mysql(&my_charset_bin, quote_buf, sizeof(quote_buf),
-                            mi->master_log_name, strlen(mi->master_log_name));
+                            mi->master_log_name, strlen(mi->master_log_name), '\'');
     query.append(quote_buf);
     query.append("',");
     query.append_ulonglong(mi->master_log_pos);

--- a/storage/spider/spd_db_mysql.cc
+++ b/storage/spider/spd_db_mysql.cc
@@ -2531,7 +2531,7 @@ size_t spider_db_mysql::escape_string(
   DBUG_PRINT("info",("spider this=%p", this));
   if (db_conn->server_status & SERVER_STATUS_NO_BACKSLASH_ESCAPES)
     DBUG_RETURN(escape_quotes_for_mysql(db_conn->charset, to, 0,
-      from, from_length));
+      from, from_length, '\''));
   DBUG_RETURN(escape_string_for_mysql(db_conn->charset, to, 0,
     from, from_length));
 }

--- a/storage/spider/spd_db_oracle.cc
+++ b/storage/spider/spd_db_oracle.cc
@@ -3782,7 +3782,7 @@ size_t spider_db_oracle_util::escape_string(
   DBUG_ENTER("spider_db_oracle::escape_string");
   DBUG_PRINT("info",("spider this=%p", this));
   DBUG_RETURN(escape_quotes_for_mysql(access_charset, to, 0,
-    from, from_length));
+    from, from_length, '\''));
 }
 
 int spider_db_oracle_util::append_escaped_util(


### PR DESCRIPTION
MariaDB fix for: https://bugs.mysql.com/bug.php?id=78932

(code is original, not copied from MySQL)