### PR TITLE
MDEV-8981: Analyze stmt - cycles can overflow

### DIFF
--- a/sql/sql_analyze_stmt.h
+++ b/sql/sql_analyze_stmt.h
@@ -47,6 +47,14 @@ protected:
   ulonglong count;
   ulonglong cycles;
   ulonglong last_start;
+
+  void cycles_stop_tracking()
+  {
+    ulonglong end= my_timer_cycles();
+    cycles += end - last_start;
+    if (unlikely(end < last_start))
+      cycles += ULONGLONG_MAX;
+  }
 public:
   Exec_time_tracker() : count(0), cycles(0) {}
   
@@ -59,7 +67,7 @@ public:
   void stop_tracking()
   {
     count++;
-    cycles += my_timer_cycles()- last_start;
+    cycles_stop_tracking();
   }
 
   // interface for getting the time
@@ -93,7 +101,7 @@ public:
   */
   void stop_tracking()
   {
-    cycles += my_timer_cycles()- last_start;
+    cycles_stop_tracking();
   }
 };
 


### PR DESCRIPTION
A 64bit counter can overflow within the time of a query
so lets take it that the measurement is the small value
rather than an order 1e12 millisecond query.


$ ./mtr analyze_format_json
Logging: ./mtr  analyze_format_json
vardir: /home/dan/software_projects/mariadb-server/mysql-test/var
Checking leftover processes...
Removing old var directory...
Creating var directory '/home/dan/software_projects/mariadb-server/mysql-test/var'...
Checking supported features...
MariaDB Version 10.1.8-MariaDB
 - SSL connections supported
Collecting tests...
Installing system database...

==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 16000..16019
main.analyze_format_json                 [ pass ]     79
--------------------------------------------------------------------------
The servers were restarted 0 times
Spent 0.079 of 14 seconds executing testcases

Completed: All 1 tests were successful.
