### PR TITLE
MDEV-8975 10.1 Fails To Join Existing Galera Cluster

### DIFF
--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -410,11 +410,12 @@ size_t wsrep_guess_ip (char* buf, size_t buf_len)
       WSREP_ERROR("Networking not configured, cannot receive state "
                   "transfer.");
       ret= 0;
+      goto done;
     } else if (INADDR_ANY != ip_type) {
       strncpy (buf, my_bind_addr_str, buf_len);
       ret= strlen(buf);
+      goto done;
     }
-    goto done;
   }
 
   // Attempt 2: mysqld binds to all interfaces, try IP from wsrep_node_address.


### PR DESCRIPTION
MDEV-8034 broke local machine IP address detection when the bind address is set to "0.0.0.0"
Without being able to detect the local machine's address, MariaDB would fail to join a Galera cluster.
This fixes that issue.

Commit that broke 
https://github.com/MariaDB/server/commit/bb52905432779d1648241baa5945c61617f2d58f#diff-178aabda2843643674e204fc5b37b89a

MDEV-8975 Notes:
https://mariadb.atlassian.net/browse/MDEV-8975