### PR TITLE
MDEV-7655: add collate to virtual columns

### DIFF
--- a/mysql-test/suite/vcol/inc/vcol_column_def_options.inc
+++ b/mysql-test/suite/vcol/inc/vcol_column_def_options.inc
@@ -111,3 +111,12 @@ create table t1 (a int, b int as (a % 2));
 alter table t1 modify b int as (a % 2) persistent references t2(a);
 show create table t1;
 drop table t1;
+
+# MDEV-7655 add collation
+create table t1 (col1 varchar(50) COLLATE latin1_general_ci DEFAULT NULL,  v_col1 varchar(50) as (col1) persistent COLLATE latin1_general_cs);
+show create table t1;
+describe t1;
+insert into t1(col1) values ('A'),('a'),('B'),('b'),('C');
+select * from t1 where v_col1='a';
+select * from t1 where col1='a';
+drop table t1;

--- a/mysql-test/suite/vcol/r/vcol_column_def_options_innodb.result
+++ b/mysql-test/suite/vcol/r/vcol_column_def_options_innodb.result
@@ -144,3 +144,23 @@ t1	CREATE TABLE `t1` (
   `b` int(11) AS (a % 2) VIRTUAL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
 drop table t1;
+create table t1 (col1 varchar(50) COLLATE latin1_general_ci DEFAULT NULL,  v_col1 varchar(50) as (col1) persistent COLLATE latin1_general_cs);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `col1` varchar(50) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
+  `v_col1` varchar(50) CHARACTER SET latin1 AS (col1) PERSISTENT COLLATE latin1_general_cs
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+describe t1;
+Field	Type	Null	Key	Default	Extra
+col1	varchar(50)	YES		NULL	
+v_col1	varchar(50)	YES		NULL	PERSISTENT
+insert into t1(col1) values ('A'),('a'),('B'),('b'),('C');
+select * from t1 where v_col1='a';
+col1	v_col1
+a	a
+select * from t1 where col1='a';
+col1	v_col1
+A	A
+a	a
+drop table t1;

--- a/mysql-test/suite/vcol/r/vcol_column_def_options_myisam.result
+++ b/mysql-test/suite/vcol/r/vcol_column_def_options_myisam.result
@@ -144,3 +144,23 @@ t1	CREATE TABLE `t1` (
   `b` int(11) AS (a % 2) VIRTUAL
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 drop table t1;
+create table t1 (col1 varchar(50) COLLATE latin1_general_ci DEFAULT NULL,  v_col1 varchar(50) as (col1) persistent COLLATE latin1_general_cs);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `col1` varchar(50) CHARACTER SET latin1 COLLATE latin1_general_ci DEFAULT NULL,
+  `v_col1` varchar(50) CHARACTER SET latin1 AS (col1) PERSISTENT COLLATE latin1_general_cs
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+describe t1;
+Field	Type	Null	Key	Default	Extra
+col1	varchar(50)	YES		NULL	
+v_col1	varchar(50)	YES		NULL	PERSISTENT
+insert into t1(col1) values ('A'),('a'),('B'),('b'),('C');
+select * from t1 where v_col1='a';
+col1	v_col1
+a	a
+select * from t1 where col1='a';
+col1	v_col1
+A	A
+a	a
+drop table t1;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1829,8 +1829,9 @@ int show_create_table(THD *thd, TABLE_LIST *table_list, String *packet,
       /*
 	For string types dump collation name only if
 	collation is not primary for the given charset
+	virtual column collation is after the collation defination
       */
-      if (!(field->charset()->state & MY_CS_PRIMARY))
+      if (!(field->charset()->state & MY_CS_PRIMARY) && !field->vcol_info)
       {
 	packet->append(STRING_WITH_LEN(" COLLATE "));
 	packet->append(field->charset()->name);
@@ -1848,6 +1849,11 @@ int show_create_table(THD *thd, TABLE_LIST *table_list, String *packet,
         packet->append(STRING_WITH_LEN(" PERSISTENT"));
       else
         packet->append(STRING_WITH_LEN(" VIRTUAL"));
+      if (!(field->charset()->state & MY_CS_PRIMARY))
+      {
+	packet->append(STRING_WITH_LEN(" COLLATE "));
+	packet->append(field->charset()->name);
+      }
     }
     else
     {

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -6203,6 +6203,19 @@ vcol_attribute:
             lex->alter_info.flags|= Alter_info::ALTER_ADD_INDEX;
           }
         | COMMENT_SYM TEXT_STRING_sys { Lex->last_field->comment= $2; }
+        | COLLATE_SYM collation_name
+          {
+            if (Lex->charset && !my_charset_same(Lex->charset,$2))
+            {
+              my_error(ER_COLLATION_CHARSET_MISMATCH, MYF(0),
+                       $2->name,Lex->charset->csname);
+              MYSQL_YYABORT;
+            }
+            else
+            {
+              Lex->last_field->charset= $2;
+            }
+          }
         ;
 
 parse_vcol_expr:
@@ -6585,32 +6598,7 @@ attribute:
             lex->last_field->flags|= PRI_KEY_FLAG | NOT_NULL_FLAG;
             lex->alter_info.flags|= Alter_info::ALTER_ADD_INDEX;
           }
-        | UNIQUE_SYM
-          {
-            LEX *lex=Lex;
-            lex->last_field->flags|= UNIQUE_FLAG;
-            lex->alter_info.flags|= Alter_info::ALTER_ADD_INDEX;
-          }
-        | UNIQUE_SYM KEY_SYM
-          {
-            LEX *lex=Lex;
-            lex->last_field->flags|= UNIQUE_KEY_FLAG;
-            lex->alter_info.flags|= Alter_info::ALTER_ADD_INDEX; 
-          }
-        | COMMENT_SYM TEXT_STRING_sys { Lex->last_field->comment= $2; }
-        | COLLATE_SYM collation_name
-          {
-            if (Lex->charset && !my_charset_same(Lex->charset,$2))
-            {
-              my_error(ER_COLLATION_CHARSET_MISMATCH, MYF(0),
-                       $2->name,Lex->charset->csname);
-              MYSQL_YYABORT;
-            }
-            else
-            {
-              Lex->last_field->charset= $2;
-            }
-          }
+        | vcol_attribute
         | IDENT_sys equal TEXT_STRING_sys
           {
             new (thd->mem_root)


### PR DESCRIPTION
Collate is allowed at the end of a virtual column syntax just like
comment:

create table t1 (col1 varchar(50) COLLATE latin1_general_ci,
                 v_col1 varchar(255) as (col1) persistent COLLATE latin1_general_cs);

SHOW CREATE TABLE altered to preserve syntax.