### PR TITLE
MDEV-9095: try memlock as nonroot first

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5418,7 +5418,7 @@ static int init_server_components()
         }
         else
           if (global_system_variables.log_warnings)
-            sql_print_warning("Succeed at locking memory as effective uid=0.");
+            sql_print_information("Succeed at locking memory as effective uid=0.");
         if (user_info)
           set_user(mysqld_user, user_info);
       }
@@ -5439,7 +5439,7 @@ static int init_server_components()
     else
     {
       if (global_system_variables.log_warnings)
-        sql_print_warning("Succeed at locking memory as current user.");
+        sql_print_information("Succeed at locking memory as current user.");
       if (user_info)
       {
         if (setreuid((uid_t)-1, 0) != -1)

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5415,8 +5415,6 @@ static int init_server_components()
                               "Errno: %d\n",errno);
           locked_in_memory= 0;
         }
-        if (user_info)
-          set_user(mysqld_user, user_info);
       }
       else
       {
@@ -5427,6 +5425,8 @@ static int init_server_components()
         locked_in_memory= 0;
       }
     }
+    if (user_info)
+      set_user(mysqld_user, user_info);
   }
   else
 #endif

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5407,7 +5407,7 @@ static int init_server_components()
         sql_print_warning("Failed to lock memory as current user "
                             "(Errno: %d)", mlockall_err);
       /* ok, denied. Try to gain effective uid=0 to mlockall */
-      if (mlockall_err == EPERM && setreuid((uid_t)-1, 0) != -1)
+      if (setreuid((uid_t)-1, 0) != -1)
       {
         if (mlockall(MCL_CURRENT)) {
           if (global_system_variables.log_warnings)
@@ -5415,22 +5415,25 @@ static int init_server_components()
                               "Errno: %d\n",errno);
           locked_in_memory= 0;
         }
+        if (global_system_variables.log_warnings)
+          sql_print_warning("Succeed at locking memory as effective uid=0.");
       }
       else
       {
-        if (global_system_variables.log_warnings && mlockall_err == EPERM)
+        if (global_system_variables.log_warnings)
           sql_print_warning("Failed setreuid to effective uid=0 while "
                             "attempting to lock memory, (Errno: %d)\n"
                             , errno);
         locked_in_memory= 0;
       }
     }
+    else
+      if (global_system_variables.log_warnings)
+        sql_print_warning("Succeed at locking memory as current user.");
     if (user_info)
       set_user(mysqld_user, user_info);
   }
-  else
 #endif
-    locked_in_memory=0;
 
   ft_init_stopwords();
 

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -42,6 +42,9 @@ PrivateNetwork=false
 User=mysql
 Group=mysql
 
+# To allow memlock to be used as non-root user if set in configuration
+CapabilityBoundingSet=CAP_IPC_LOCK
+
 # Execute pre and post scripts as root, otherwise it does it as User=
 PermissionsStartOnly=true
 

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -49,6 +49,9 @@ PrivateNetwork=false
 User=mysql
 Group=mysql
 
+# To allow memlock to be used as non-root user if set in configuration
+CapabilityBoundingSet=CAP_IPC_LOCK
+
 # Execute pre and post scripts as root, otherwise it does it as User=
 PermissionsStartOnly=true
 


### PR DESCRIPTION
Adjust systemd files to enable CAP_IPC_LOCK to allow rootless mlockall
(triggered by memlock option).

If the rootless mlockall fails, revert to trying as effective UID=0 as
per previous behavior.