### PR TITLE
MDEV-9186 - Debian packaging: extend libcrack hack to create correct control file

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -39,6 +39,9 @@ then
   # packages by snipped in rules file
   MARIADB_OPTIONAL_DEBS="${MARIADB_OPTIONAL_DEBS} cracklib-password-check-10.2"
   sed -i -e "/\\\${MAYBE_LIBCRACK}/d" debian/control
+  # Remove package entry from control file completely so that
+  # resulting Debian source package will actually be buildable
+  sed -i -e "/Package: mariadb-cracklib-password-check/,+6d" debian/control
 else
   MAYBE_LIBCRACK='libcrack2-dev (>= 2.9.0),'
   sed -i -e "s/\\\${MAYBE_LIBCRACK}/${MAYBE_LIBCRACK}/g" debian/control


### PR DESCRIPTION
When the debian/control gets stripped off the libcrack3 dependency,
it should also strip off the mariadb-cracklib-password-check-10.2
package entry, otherwise the resulting Debian source package will
not be re-buildable independently later.

Successful build visible at https://launchpad.net/~mysql-ubuntu/+archive/ubuntu/mariadb-10.2/+builds?build_text=&build_state=all (ppc64 build for e717ceb, the other builds fail due to inherited other problems in current 10.2 master). Builds at https://buildbot.askmonty.org/buildbot/grid?branch=ok-debpkg-10.2&category=main also fail due to inherited problems from current 10.2 master, so it is not useful for QA in at the moment.