### PR TITLE
switch from myisam_recover to myisam_recover_options

### DIFF
--- a/debian/additions/my.cnf
+++ b/debian/additions/my.cnf
@@ -62,7 +62,7 @@ max_heap_table_size	= 32M
 #
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched. On error, make copy and try a repair.
-myisam_recover          = BACKUP
+myisam_recover_options = BACKUP
 key_buffer_size		= 128M
 #open-files-limit	= 2000
 table_open_cache	= 400


### PR DESCRIPTION
myisam_recover is only an alias for myisam_recover_options.
Use the option name instead of the alias is more correct.
This also avoids an note about the use of an alias instead of the option
name on every server start.