### PR TITLE
MDEV-9257: Increase limit on parallel workers in mysql-test-run

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1801,9 +1801,12 @@ sub set_build_thread_ports($) {
   if ( lc($opt_build_thread) eq 'auto' ) {
     my $found_free = 0;
     $build_thread = 300;	# Start attempts from here
+    my $build_thread_upper = $build_thread + ($opt_parallel > 49
+                                              ? $opt_parallel
+                                              : 49);
     while (! $found_free)
     {
-      $build_thread= mtr_get_unique_id($build_thread, 349);
+      $build_thread= mtr_get_unique_id($build_thread, $build_thread_upper);
       if ( !defined $build_thread ) {
         mtr_error("Could not get a unique build thread id");
       }


### PR DESCRIPTION
Parallel workers of the mysql-test-run has an artificial limit of 50 workers. On some hardware more CPUs are present. Running on such a hardware bot runs out of unique build thread ids.

I submit this under the MCA (that was emailed today).