### PR TITLE
MDEV-9303 - SphinxSE: add support for json filtering

### DIFF
--- a/storage/sphinx/ha_sphinx.cc
+++ b/storage/sphinx/ha_sphinx.cc
@@ -1411,6 +1411,14 @@ static bool myismagic ( char c )
 	return c=='@';
 }
 
+static bool myisjson ( char c )
+{
+	return
+		c=='.' ||
+		c=='[' ||
+		c==']';
+}
+
 
 bool CSphSEQuery::ParseField ( char * sField )
 {
@@ -1622,7 +1630,7 @@ bool CSphSEQuery::ParseField ( char * sField )
 				break;
 
 			tFilter.m_sAttrName = sValue;
-			while ( (*sValue) && ( myisattr(*sValue) || myismagic(*sValue) ) )
+			while ( (*sValue) && ( myisattr(*sValue) || myismagic(*sValue) || myisjson(*sValue) ) )
 				sValue++;
 			if ( !*sValue )
 				break;

--- a/storage/sphinx/mysql-test/sphinx/sphinx.result
+++ b/storage/sphinx/mysql-test/sphinx/sphinx.result
@@ -4,17 +4,20 @@ id	w	q
 1	2	test
 2	2	test
 4	1	test
+5	1	test
 drop table ts;
 create table ts ( id bigint unsigned not null, w int not null, q varchar(255) not null, index(q) ) engine=sphinx connection="sphinx://127.0.0.1:SPHINXSEARCH_PORT/*";
 select * from ts where q='test;filter=gid,1;mode=extended';
 id	w	q
-1	2421	test;filter=gid,1;mode=extended
-2	2421	test;filter=gid,1;mode=extended
+1	2379	test;filter=gid,1;mode=extended
+2	2379	test;filter=gid,1;mode=extended
+5	1412	test;filter=gid,1;mode=extended
 select * from ts where q='test|one;mode=extended';
 id	w	q
-1	3595	test|one;mode=extended
-2	2460	test|one;mode=extended
-4	1471	test|one;mode=extended
+1	3579	test|one;mode=extended
+2	2439	test|one;mode=extended
+4	1456	test|one;mode=extended
+5	1456	test|one;mode=extended
 select * from ts where q='test;offset=1;limit=1';
 id	w	q
 2	2	test;offset=1;limit=1
@@ -32,10 +35,11 @@ id	w	q	gid	_sph_count
 2	1		1	0
 3	1		2	0
 4	1		2	0
+5	1		1	0
 select * from ts where q=';groupby=attr:gid';
 id	w	q	gid	_sph_count
 3	1	;groupby=attr:gid	2	2
-1	1	;groupby=attr:gid	1	2
+1	1	;groupby=attr:gid	1	3
 explain select * from ts where q=';groupby=attr:gid';
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	ts	ref	q	q	257	const	3	Using where with pushed condition
@@ -54,3 +58,20 @@ show status like "sphinx_word%";
 Variable_name	Value
 Sphinx_word_count	0
 Sphinx_words	
+create table ts ( id bigint unsigned not null, w int not null, q varchar(255) not null, index(q) ) engine=sphinx connection="sphinx://127.0.0.1:SPHINXSEARCH_PORT/*";
+select * from ts where q=';filter=meta.foo_count,100';
+id	w	q
+1	1	;filter=meta.foo_count,100
+select * from ts where q='test;filter=meta.sub.int,7';
+id	w	q
+5	1	test;filter=meta.sub.int,7
+select * from ts where q=';filter=meta.sub.list[0],4';
+id	w	q
+select * from ts where q=';filter=meta.sub.list[1],4';
+id	w	q
+5	1	;filter=meta.sub.list[1],4
+select * from ts where q='test;range=meta.foo_count,100,500';
+id	w	q
+1	2	test;range=meta.foo_count,100,500
+5	1	test;range=meta.foo_count,100,500
+drop table ts;

--- a/storage/sphinx/mysql-test/sphinx/sphinx.test
+++ b/storage/sphinx/mysql-test/sphinx/sphinx.test
@@ -32,3 +32,12 @@ drop table ts;
 
 show status like "sphinx_total%";
 show status like "sphinx_word%";
+
+--replace_result $SPHINXSEARCH_PORT SPHINXSEARCH_PORT
+eval create table ts ( id bigint unsigned not null, w int not null, q varchar(255) not null, index(q) ) engine=sphinx connection="sphinx://127.0.0.1:$SPHINXSEARCH_PORT/*";
+select * from ts where q=';filter=meta.foo_count,100';
+select * from ts where q='test;filter=meta.sub.int,7';
+select * from ts where q=';filter=meta.sub.list[0],4';
+select * from ts where q=';filter=meta.sub.list[1],4';
+select * from ts where q='test;range=meta.foo_count,100,500';
+drop table ts;

--- a/storage/sphinx/mysql-test/sphinx/testdata.xml
+++ b/storage/sphinx/mysql-test/sphinx/testdata.xml
@@ -5,12 +5,14 @@
 <sphinx:field name="title"/> 
 <sphinx:field name="content"/>
 <sphinx:attr name="gid" type="int"/>
+<sphinx:attr name="meta" type="json"/>
 </sphinx:schema>
 
 <sphinx:document id="1">
 <title>test one</title>
 <content>this is my test document number one. also checking search within phrases.</content>
 <gid>1</gid>
+<meta>{ "foo_count": 100 }</meta>
 </sphinx:document>
 
 <sphinx:document id="2">
@@ -29,6 +31,13 @@
 <title>doc number four</title>
 <content>this is to test groups</content>
 <gid>2</gid>
+</sphinx:document>
+
+<sphinx:document id="5">
+<title>doc number five</title>
+<content>this is to test json filtering</content>
+<gid>1</gid>
+<meta>{ "foo_count": 200, "sub": { "list": [ 3, 4 ], "int": 7 } }</meta>
 </sphinx:document>
 
 </sphinx:docset>


### PR DESCRIPTION
The filter command did not accept characters . [ ] which are valid
in an attribute name for a sphinx query with json filtering.

+ test case added