### PR TITLE
Do not build optimised power crc32 on bigendian

### DIFF
--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -73,16 +73,20 @@ IF(WITH_INNOBASE_STORAGE_ENGINE OR WITH_XTRADB_STORAGE_ENGINE)
   # We use the InnoDB code directly in case the code changes.
   ADD_DEFINITIONS("-DUNIV_INNOCHECKSUM")
 
-  enable_language(ASM)
-
   SET(INNOBASE_SOURCES
       ../storage/innobase/buf/buf0checksum.cc
       ../storage/innobase/ut/ut0crc32.cc
       ../storage/innobase/ut/ut0ut.cc
-      ../storage/innobase/ut/crc32_power8/crc32.S
-      ../storage/innobase/ut/crc32_power8/crc32_wrapper.c
       ../storage/innobase/page/page0zip.cc
       )
+
+  IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+      enable_language(ASM)
+      LIST(APPEND INNOBASE_SOURCES
+         ../storage/innobase/ut/crc32_power8/crc32.S
+         ../storage/innobase/ut/crc32_power8/crc32_wrapper.c
+         )
+  ENDIF()
 
   MYSQL_ADD_EXECUTABLE(innochecksum innochecksum.cc ${INNOBASE_SOURCES})
   TARGET_LINK_LIBRARIES(innochecksum mysys mysys_ssl)

--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -362,8 +362,6 @@ IF(MSVC)
           PROPERTIES COMPILE_FLAGS "/wd4003")
 ENDIF()
 
-enable_language(ASM)
-
 SET(INNOBASE_SOURCES
 	api/api0api.cc
 	api/api0misc.cc
@@ -478,8 +476,6 @@ SET(INNOBASE_SOURCES
 	ut/ut0bh.cc
 	ut/ut0byte.cc
 	ut/ut0crc32.cc
-	ut/crc32_power8/crc32.S
-	ut/crc32_power8/crc32_wrapper.c
 	ut/ut0dbg.cc
 	ut/ut0list.cc
 	ut/ut0mem.cc
@@ -489,6 +485,14 @@ SET(INNOBASE_SOURCES
 	ut/ut0vec.cc
 	ut/ut0wqueue.cc
 	ut/ut0timer.cc)
+
+IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+    enable_language(ASM)
+    LIST(APPEND INNOBASE_SOURCES
+       ut/crc32_power8/crc32.S
+       ut/crc32_power8/crc32_wrapper.c
+       )
+ENDIF()
 
 IF(WITH_INNODB)
   # Legacy option

--- a/storage/innobase/ut/ut0crc32.cc
+++ b/storage/innobase/ut/ut0crc32.cc
@@ -194,7 +194,7 @@ ut_crc32_power8(
 		 const byte*		 buf,		 /*!< in: data over which to calculate CRC32 */
 		 ulint		 		 len)		 /*!< in: data length */
 {
-#if defined(__powerpc__)
+#if defined(__powerpc__) && !defined(WORDS_BIGENDIAN)
   return crc32_vpmsum(0, buf, len);
 #else
 		 ut_error;
@@ -338,7 +338,8 @@ ut_crc32_init()
 
 #endif /* defined(__GNUC__) && defined(__x86_64__) */
 
-#if defined(__linux__) && defined(__powerpc__) && defined(AT_HWCAP2)
+#if defined(__linux__) && defined(__powerpc__) && defined(AT_HWCAP2) \
+        && !defined(WORDS_BIGENDIAN)
 	if (getauxval(AT_HWCAP2) & PPC_FEATURE2_ARCH_2_07)
 		 ut_crc32_power8_enabled = true;
 #endif /* defined(__linux__) && defined(__powerpc__) */

--- a/storage/xtradb/CMakeLists.txt
+++ b/storage/xtradb/CMakeLists.txt
@@ -345,8 +345,6 @@ IF (MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
 				    PROPERTIES COMPILE_FLAGS -Od)
 ENDIF()
 
-enable_language(ASM)
-
 SET(INNOBASE_SOURCES
 	api/api0api.cc
 	api/api0misc.cc
@@ -464,8 +462,6 @@ SET(INNOBASE_SOURCES
 	ut/ut0bh.cc
 	ut/ut0byte.cc
 	ut/ut0crc32.cc
-		 ut/crc32_power8/crc32.S
-		 ut/crc32_power8/crc32_wrapper.c
 	ut/ut0dbg.cc
 	ut/ut0list.cc
 	ut/ut0mem.cc
@@ -475,6 +471,14 @@ SET(INNOBASE_SOURCES
 	ut/ut0vec.cc
 	ut/ut0wqueue.cc
 	ut/ut0timer.cc)
+
+IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64le")
+    enable_language(ASM)
+    LIST(APPEND INNOBASE_SOURCES
+       ut/crc32_power8/crc32.S
+       ut/crc32_power8/crc32_wrapper.c
+       )
+ENDIF()
 
 MYSQL_ADD_PLUGIN(xtradb ${INNOBASE_SOURCES} STORAGE_ENGINE
   DEFAULT RECOMPILE_FOR_EMBEDDED

--- a/storage/xtradb/ut/ut0crc32.cc
+++ b/storage/xtradb/ut/ut0crc32.cc
@@ -194,7 +194,7 @@ ut_crc32_power8(
 		 const byte*		 buf,		 /*!< in: data over which to calculate CRC32 */
 		 ulint		 		 len)		 /*!< in: data length */
 {
-#if defined(__powerpc__)
+#if defined(__powerpc__) && !defined(WORDS_BIGENDIAN)
   return crc32_vpmsum(0, buf, len);
 #else
 		 ut_error;
@@ -338,7 +338,8 @@ ut_crc32_init()
 
 #endif /* defined(__GNUC__) && defined(__x86_64__) */
 
-#if defined(__linux__) && defined(__powerpc__) && defined(AT_HWCAP2)
+#if defined(__linux__) && defined(__powerpc__) && defined(AT_HWCAP2) \
+        && !defined(WORDS_BIGENDIAN)
 	if (getauxval(AT_HWCAP2) & PPC_FEATURE2_ARCH_2_07)
 		 ut_crc32_power8_enabled = true;
 #endif /* defined(__linux__) && defined(__powerpc__) */


### PR DESCRIPTION
based on @janlindstrom  and @vaintroub feedback/questions in #133 here is a patch that ensures compilation on power platforms only and only includes the optimised code on little endian.