### PR TITLE
MDEV-9259 - Add missing mroonga files to Debian packaging in 10.1

### DIFF
--- a/debian/mariadb-server-10.1.files.in
+++ b/debian/mariadb-server-10.1.files.in
@@ -6,6 +6,7 @@ usr/lib/mysql/plugin/ha_blackhole.so
 usr/lib/mysql/plugin/ha_federated.so
 usr/lib/mysql/plugin/ha_federatedx.so
 usr/lib/mysql/plugin/ha_innodb.so
+usr/lib/mysql/plugin/ha_mroonga.so
 usr/lib/mysql/plugin/ha_sphinx.so
 usr/lib/mysql/plugin/handlersocket.so
 usr/lib/mysql/plugin/locales.so
@@ -85,6 +86,8 @@ usr/share/mysql/echo_stderr
 usr/share/mysql/errmsg-utf8.txt
 usr/share/mysql/fill_help_tables.sql
 usr/share/mysql/maria_add_gis_sp_bootstrap.sql
+usr/share/mysql/mroonga/install.sql
+usr/share/mysql/mroonga/uninstall.sql
 usr/share/mysql/mysql_system_tables_data.sql
 usr/share/mysql/mysql_system_tables.sql
 usr/share/mysql/mysql_performance_tables.sql


### PR DESCRIPTION
Issue: https://mariadb.atlassian.net/browse/MDEV-9259

The change is very unlikely to produce regressions, but you still should check the test results before merging at: https://buildbot.askmonty.org/buildbot/grid?branch=ok-debpkg-10.1&category=main