### PR TITLE
MDEV-9617 - mariadb-10.0: solaris10 build fixes

### DIFF
--- a/sql/gcalc_slicescan.cc
+++ b/sql/gcalc_slicescan.cc
@@ -49,14 +49,14 @@ typedef int (*sc_compare_func)(const void*, const void*);
 static Gcalc_scan_iterator::point *eq_sp(const Gcalc_heap::Info *pi)
 {
   GCALC_DBUG_ASSERT(pi->type == Gcalc_heap::nt_eq_node);
-  return (Gcalc_scan_iterator::point *) pi->eq_data;
+  return (Gcalc_scan_iterator::point *) pi->u.s3.eq_data;
 }
 
 
 static Gcalc_scan_iterator::intersection_info *i_data(const Gcalc_heap::Info *pi)
 {
   GCALC_DBUG_ASSERT(pi->type == Gcalc_heap::nt_intersection);
-  return (Gcalc_scan_iterator::intersection_info *) pi->intersection_data;
+  return (Gcalc_scan_iterator::intersection_info *) pi->u.s2.intersection_data;
 }
 
 
@@ -594,8 +594,8 @@ void Gcalc_scan_iterator::intersection_info::do_calc_t()
   Gcalc_coord1 a2_a1x, a2_a1y;
   Gcalc_coord2 x1y2, x2y1;
 
-  gcalc_sub_coord1(a2_a1x, edge_b->pi->ix, edge_a->pi->ix);
-  gcalc_sub_coord1(a2_a1y, edge_b->pi->iy, edge_a->pi->iy);
+  gcalc_sub_coord1(a2_a1x, edge_b->pi->u.s1.ix, edge_a->pi->u.s1.ix);
+  gcalc_sub_coord1(a2_a1y, edge_b->pi->u.s1.iy, edge_a->pi->u.s1.iy);
 
   GCALC_DBUG_ASSERT(!gcalc_is_zero(edge_a->dy, GCALC_COORD_BASE) ||
                     !gcalc_is_zero(edge_b->dy, GCALC_COORD_BASE));
@@ -619,7 +619,7 @@ void Gcalc_scan_iterator::intersection_info::do_calc_y()
   Gcalc_coord3 a_tb, b_ta;
 
   gcalc_mul_coord(a_tb, GCALC_COORD_BASE3,
-                  t_b, GCALC_COORD_BASE2, edge_a->pi->iy, GCALC_COORD_BASE);
+                  t_b, GCALC_COORD_BASE2, edge_a->pi->u.s1.iy, GCALC_COORD_BASE);
   gcalc_mul_coord(b_ta, GCALC_COORD_BASE3,
                   t_a, GCALC_COORD_BASE2, edge_a->dy, GCALC_COORD_BASE);
 
@@ -635,7 +635,7 @@ void Gcalc_scan_iterator::intersection_info::do_calc_x()
   Gcalc_coord3 a_tb, b_ta;
 
   gcalc_mul_coord(a_tb, GCALC_COORD_BASE3,
-                  t_b, GCALC_COORD_BASE2, edge_a->pi->ix, GCALC_COORD_BASE);
+                  t_b, GCALC_COORD_BASE2, edge_a->pi->u.s1.ix, GCALC_COORD_BASE);
   gcalc_mul_coord(b_ta, GCALC_COORD_BASE3,
                   t_a, GCALC_COORD_BASE2, edge_a->dx, GCALC_COORD_BASE);
 
@@ -656,7 +656,7 @@ static int cmp_node_isc(const Gcalc_heap::Info *node,
   inf->calc_y_exp();
 
   gcalc_mul_coord(exp, GCALC_COORD_BASE3,
-                  inf->t_b, GCALC_COORD_BASE2, node->iy, GCALC_COORD_BASE);
+                  inf->t_b, GCALC_COORD_BASE2, node->u.s1.iy, GCALC_COORD_BASE);
 
   result= gcalc_cmp_coord(exp, inf->y_exp, GCALC_COORD_BASE3);
 #ifdef GCALC_CHECK_WITH_FLOAT
@@ -684,7 +684,7 @@ static int cmp_node_isc(const Gcalc_heap::Info *node,
 
   inf->calc_x_exp();
   gcalc_mul_coord(exp, GCALC_COORD_BASE3,
-                  inf->t_b, GCALC_COORD_BASE2, node->ix, GCALC_COORD_BASE);
+                  inf->t_b, GCALC_COORD_BASE2, node->u.s1.ix, GCALC_COORD_BASE);
 
   result= gcalc_cmp_coord(exp, inf->x_exp, GCALC_COORD_BASE3);
 #ifdef GCALC_CHECK_WITH_FLOAT
@@ -844,13 +844,13 @@ Gcalc_heap::Info *Gcalc_heap::new_point_info(double x, double y,
     return NULL;
   *m_hook= result;
   m_hook= &result->next;
-  result->x= x;
-  result->y= y;
-  result->shape= shape;
-  result->top_node= 1;
+  result->u.s1.x= x;
+  result->u.s1.y= y;
+  result->u.s1.shape= shape;
+  result->u.s1.top_node= 1;
   result->type= nt_shape_node;
-  gcalc_set_double(result->ix, x, coord_extent);
-  gcalc_set_double(result->iy, y, coord_extent);
+  gcalc_set_double(result->u.s1.ix, x, coord_extent);
+  gcalc_set_double(result->u.s1.iy, y, coord_extent);
 
   m_n_points++;
   return result;
@@ -864,11 +864,11 @@ static Gcalc_heap::Info *new_intersection(
   if (!isc)
     return 0;
   isc->type= Gcalc_heap::nt_intersection;
-  isc->p1= ii->edge_a->pi;
-  isc->p2= ii->edge_a->next_pi;
-  isc->p3= ii->edge_b->pi;
-  isc->p4= ii->edge_b->next_pi;
-  isc->intersection_data= ii;
+  isc->u.s2.p1= ii->edge_a->pi;
+  isc->u.s2.p2= ii->edge_a->next_pi;
+  isc->u.s2.p3= ii->edge_b->pi;
+  isc->u.s2.p4= ii->edge_b->next_pi;
+  isc->u.s2.intersection_data= ii;
   return isc;
 }
 
@@ -881,25 +881,25 @@ static Gcalc_heap::Info *new_eq_point(
   if (!eqp)
     return 0;
   eqp->type= Gcalc_heap::nt_eq_node;
-  eqp->node= p;
-  eqp->eq_data= edge;
+  eqp->u.s3.node= p;
+  eqp->u.s3.eq_data= edge;
   return eqp;
 }
 
 
 void Gcalc_heap::Info::calc_xy(double *x, double *y) const
 {
-  double b0_x= p2->x - p1->x;
-  double b0_y= p2->y - p1->y;
-  double b1_x= p4->x - p3->x;
-  double b1_y= p4->y - p3->y;
+  double b0_x= this->u.s2.p2->u.s1.x - this->u.s2.p1->u.s1.x;
+  double b0_y= this->u.s2.p2->u.s1.y - this->u.s2.p1->u.s1.y;
+  double b1_x= this->u.s2.p4->u.s1.x - this->u.s2.p3->u.s1.x;
+  double b1_y= this->u.s2.p4->u.s1.y - this->u.s2.p3->u.s1.y;
   double b0xb1= b0_x * b1_y - b0_y * b1_x;
-  double t= (p3->x - p1->x) * b1_y - (p3->y - p1->y) * b1_x;
+  double t= (this->u.s2.p3->u.s1.x - this->u.s2.p1->u.s1.x) * b1_y - (this->u.s2.p3->u.s1.y - this->u.s2.p1->u.s1.y) * b1_x;
 
   t/= b0xb1;
 
-  *x= p1->x + b0_x * t;
-  *y= p1->y + b0_y * t;
+  *x= this->u.s2.p1->u.s1.x + b0_x * t;
+  *y= this->u.s2.p1->u.s1.y + b0_y * t;
 }
 
 
@@ -933,10 +933,10 @@ void Gcalc_heap::Info::calc_xy_ld(long double *x, long double *y) const
 static int cmp_point_info(const Gcalc_heap::Info *i0,
                           const Gcalc_heap::Info *i1)
 {
-  int cmp_y= gcalc_cmp_coord1(i0->iy, i1->iy);
+  int cmp_y= gcalc_cmp_coord1(i0->u.s1.iy, i1->u.s1.iy);
   if (cmp_y)
     return cmp_y;
-  return gcalc_cmp_coord1(i0->ix, i1->ix);
+  return gcalc_cmp_coord1(i0->u.s1.ix, i1->u.s1.ix);
 }
 
 
@@ -944,11 +944,11 @@ static inline void trim_node(Gcalc_heap::Info *node, Gcalc_heap::Info *prev_node
 {
   if (!node)
     return;
-  node->top_node= 0;
-  GCALC_DBUG_ASSERT((node->left == prev_node) || (node->right == prev_node));
-  if (node->left == prev_node)
-    node->left= node->right;
-  node->right= NULL;
+  node->u.s1.top_node= 0;
+  GCALC_DBUG_ASSERT((node->u.s1.left == prev_node) || (node->u.s1.right == prev_node));
+  if (node->u.s1.left == prev_node)
+    node->u.s1.left= node->u.s1.right;
+  node->u.s1.right= NULL;
   GCALC_DBUG_ASSERT(cmp_point_info(node, prev_node));
 }
 
@@ -972,8 +972,8 @@ void Gcalc_heap::prepare_operation()
   /* TODO - move this to the 'normal_scan' loop */
   for (cur= get_first(); cur; cur= cur->get_next())
   {
-    trim_node(cur->left, cur);
-    trim_node(cur->right, cur);
+    trim_node(cur->u.s1.left, cur);
+    trim_node(cur->u.s1.right, cur);
   }
 }
 
@@ -995,7 +995,7 @@ int Gcalc_shape_transporter::int_single_point(gcalc_shape_info Info,
   Gcalc_heap::Info *point= m_heap->new_point_info(x, y, Info);
   if (!point)
     return 1;
-  point->left= point->right= 0;
+  point->u.s1.left= point->u.s1.right= 0;
   return 0;
 }
 
@@ -1018,9 +1018,9 @@ int Gcalc_shape_transporter::int_add_point(gcalc_shape_info Info,
       m_heap->free_point_info(point, hook);
       return 0;
     }
-    GCALC_DBUG_ASSERT(!m_prev || m_prev->x != x || m_prev->y != y);
-    m_prev->left= point;
-    point->right= m_prev;
+    GCALC_DBUG_ASSERT(!m_prev || m_prev->u.s1.x != x || m_prev->u.s1.y != y);
+    m_prev->u.s1.left= point;
+    point->u.s1.right= m_prev;
   }
   else
     m_first= point;
@@ -1040,16 +1040,16 @@ void Gcalc_shape_transporter::int_complete()
   /* simple point */
   if (m_first == m_prev)
   {
-    m_first->right= m_first->left= NULL;
+    m_first->u.s1.right= m_first->u.s1.left= NULL;
     return;
   }
 
   /* line */
   if (m_shape_started == 1)
   {
-    m_first->right= NULL;
-    m_prev->left= m_prev->right;
-    m_prev->right= NULL;
+    m_first->u.s1.right= NULL;
+    m_prev->u.s1.left= m_prev->u.s1.right;
+    m_prev->u.s1.right= NULL;
     return;
   }
 
@@ -1057,32 +1057,32 @@ void Gcalc_shape_transporter::int_complete()
   if (cmp_point_info(m_first, m_prev) == 0)
   {
     /* Coinciding points, remove the last one from the list */
-    m_prev->right->left= m_first;
-    m_first->right= m_prev->right;
+    m_prev->u.s1.right->u.s1.left= m_first;
+    m_first->u.s1.right= m_prev->u.s1.right;
     m_heap->free_point_info(m_prev, m_prev_hook);
   }
   else
   {
-    GCALC_DBUG_ASSERT(m_prev->x != m_first->x || m_prev->y != m_first->y);
-    m_first->right= m_prev;
-    m_prev->left= m_first;
+    GCALC_DBUG_ASSERT(m_prev->u.s1.x != m_first->u.s1.x || m_prev->u.s1.y != m_first->u.s1.y);
+    m_first->u.s1.right= m_prev;
+    m_prev->u.s1.left= m_first;
   }
 }
 
 
 inline void calc_dx_dy(Gcalc_scan_iterator::point *p)
 {
-  gcalc_sub_coord1(p->dx, p->next_pi->ix, p->pi->ix);
-  gcalc_sub_coord1(p->dy, p->next_pi->iy, p->pi->iy);
+  gcalc_sub_coord1(p->dx, p->next_pi->u.s1.ix, p->pi->u.s1.ix);
+  gcalc_sub_coord1(p->dy, p->next_pi->u.s1.iy, p->pi->u.s1.iy);
   if (GCALC_SIGN(p->dx[0]))
   {
-    p->l_border= &p->next_pi->ix;
-    p->r_border= &p->pi->ix;
+    p->l_border= &p->next_pi->u.s1.ix;
+    p->r_border= &p->pi->u.s1.ix;
   }
   else
   {
-    p->r_border= &p->next_pi->ix;
-    p->l_border= &p->pi->ix;
+    p->r_border= &p->next_pi->u.s1.ix;
+    p->l_border= &p->pi->u.s1.ix;
   }
 }
 
@@ -1143,10 +1143,10 @@ int Gcalc_scan_iterator::point::cmp_dx_dy(const Gcalc_heap::Info *p1,
                                           const Gcalc_heap::Info *p4)
 {
   Gcalc_coord1 dx_a, dy_a, dx_b, dy_b;
-  gcalc_sub_coord1(dx_a, p2->ix, p1->ix);
-  gcalc_sub_coord1(dy_a, p2->iy, p1->iy);
-  gcalc_sub_coord1(dx_b, p4->ix, p3->ix);
-  gcalc_sub_coord1(dy_b, p4->iy, p3->iy);
+  gcalc_sub_coord1(dx_a, p2->u.s1.ix, p1->u.s1.ix);
+  gcalc_sub_coord1(dy_a, p2->u.s1.iy, p1->u.s1.iy);
+  gcalc_sub_coord1(dx_b, p4->u.s1.ix, p3->u.s1.ix);
+  gcalc_sub_coord1(dy_b, p4->u.s1.iy, p3->u.s1.iy);
   return cmp_dx_dy(dx_a, dy_a, dx_b, dy_b);
 }
 
@@ -1280,7 +1280,7 @@ int Gcalc_scan_iterator::arrange_event(int do_sorting, int n_intersections)
 int Gcalc_heap::Info::equal_pi(const Info *pi) const
 {
   if (type == nt_intersection)
-    return equal_intersection;
+    return this->u.s2.equal_intersection;
   if (pi->type == nt_eq_node)
     return 1;
   if (type == nt_eq_node || pi->type == nt_intersection)
@@ -1322,7 +1322,7 @@ int Gcalc_scan_iterator::step()
 #ifndef GCALC_DBUG_OFF
     if (m_cur_pi->type == Gcalc_heap::nt_intersection &&
         m_cur_pi->get_next()->type == Gcalc_heap::nt_intersection &&
-        m_cur_pi->equal_intersection)
+        m_cur_pi->u.s2.equal_intersection)
       GCALC_DBUG_ASSERT(cmp_intersections(m_cur_pi, m_cur_pi->get_next()) == 0);
 #endif /*GCALC_DBUG_OFF*/
     GCALC_DBUG_CHECK_COUNTER();
@@ -1377,10 +1377,10 @@ static int node_on_right(const Gcalc_heap::Info *node,
   Gcalc_coord2 ax_by, ay_bx;
   int result;
 
-  gcalc_sub_coord1(a_x, node->ix, edge_a->ix);
-  gcalc_sub_coord1(a_y, node->iy, edge_a->iy);
-  gcalc_sub_coord1(b_x, edge_b->ix, edge_a->ix);
-  gcalc_sub_coord1(b_y, edge_b->iy, edge_a->iy);
+  gcalc_sub_coord1(a_x, node->u.s1.ix, edge_a->u.s1.ix);
+  gcalc_sub_coord1(a_y, node->u.s1.iy, edge_a->u.s1.iy);
+  gcalc_sub_coord1(b_x, edge_b->u.s1.ix, edge_a->u.s1.ix);
+  gcalc_sub_coord1(b_y, edge_b->u.s1.iy, edge_a->u.s1.iy);
   gcalc_mul_coord1(ax_by, a_x, b_y);
   gcalc_mul_coord1(ay_bx, a_y, b_x);
   result= gcalc_cmp_coord(ax_by, ay_bx, GCALC_COORD_BASE2);
@@ -1412,8 +1412,8 @@ static int cmp_tops(const Gcalc_heap::Info *top_node,
 {
   int cmp_res_a, cmp_res_b;
 
-  cmp_res_a= gcalc_cmp_coord1(edge_a->ix, top_node->ix);
-  cmp_res_b= gcalc_cmp_coord1(edge_b->ix, top_node->ix);
+  cmp_res_a= gcalc_cmp_coord1(edge_a->u.s1.ix, top_node->u.s1.ix);
+  cmp_res_b= gcalc_cmp_coord1(edge_b->u.s1.ix, top_node->u.s1.ix);
 
   if (cmp_res_a <= 0 && cmp_res_b > 0)
     return -1;
@@ -1438,26 +1438,26 @@ int Gcalc_scan_iterator::insert_top_node()
   if (!sp0)
     GCALC_DBUG_RETURN(1);
   sp0->pi= m_cur_pi;
-  sp0->next_pi= m_cur_pi->left;
+  sp0->next_pi= m_cur_pi->u.s1.left;
 #ifndef GCALC_DBUG_OFF
   sp0->thread= m_cur_thread++;
 #endif /*GCALC_DBUG_OFF*/
-  if (m_cur_pi->left)
+  if (m_cur_pi->u.s1.left)
   {
     calc_dx_dy(sp0);
-    if (m_cur_pi->right)
+    if (m_cur_pi->u.s1.right)
     {
       if (!(sp1= new_slice_point()))
         GCALC_DBUG_RETURN(1);
       sp1->event= sp0->event= scev_two_threads;
       sp1->pi= m_cur_pi;
-      sp1->next_pi= m_cur_pi->right;
+      sp1->next_pi= m_cur_pi->u.s1.right;
 #ifndef GCALC_DBUG_OFF
       sp1->thread= m_cur_thread++;
 #endif /*GCALC_DBUG_OFF*/
       calc_dx_dy(sp1);
       /* We have two threads so should decide which one will be first */
-      cmp_res= cmp_tops(m_cur_pi, m_cur_pi->left, m_cur_pi->right);
+      cmp_res= cmp_tops(m_cur_pi, m_cur_pi->u.s1.left, m_cur_pi->u.s1.right);
       if (cmp_res > 0)
       {
         point *tmp= sp0;
@@ -1467,7 +1467,7 @@ int Gcalc_scan_iterator::insert_top_node()
       else if (cmp_res == 0)
       {
         /* Exactly same direction of the edges. */
-        cmp_res= gcalc_cmp_coord1(m_cur_pi->left->iy, m_cur_pi->right->iy);
+        cmp_res= gcalc_cmp_coord1(m_cur_pi->u.s1.left->u.s1.iy, m_cur_pi->u.s1.right->u.s1.iy);
         if (cmp_res != 0)
         {
           if (cmp_res < 0)
@@ -1483,7 +1483,7 @@ int Gcalc_scan_iterator::insert_top_node()
         }
         else
         {
-          cmp_res= gcalc_cmp_coord1(m_cur_pi->left->ix, m_cur_pi->right->ix);
+          cmp_res= gcalc_cmp_coord1(m_cur_pi->u.s1.left->u.s1.ix, m_cur_pi->u.s1.right->u.s1.ix);
           if (cmp_res != 0)
           {
             if (cmp_res < 0)
@@ -1517,7 +1517,7 @@ int Gcalc_scan_iterator::insert_top_node()
     /* We need to find the place to insert. */
     for (; sp; prev_hook= sp->next_ptr(), sp=sp->get_next())
     {
-      if (sp->event || gcalc_cmp_coord1(*sp->r_border, m_cur_pi->ix) < 0)
+      if (sp->event || gcalc_cmp_coord1(*sp->r_border, m_cur_pi->u.s1.ix) < 0)
         continue;
       cmp_res= node_on_right(m_cur_pi, sp->pi, sp->next_pi);
       if (cmp_res == 0)
@@ -1743,7 +1743,7 @@ int Gcalc_scan_iterator::node_scan()
   GCALC_DBUG_PRINT(("node for %d", sp->thread));
   /* Handle the point itself. */
   sp->pi= cur_pi;
-  sp->next_pi= cur_pi->left;
+  sp->next_pi= cur_pi->u.s1.left;
   sp->event= scev_point;
   calc_dx_dy(sp);
 
@@ -1794,7 +1794,7 @@ void Gcalc_scan_iterator::intersection_scan()
   ii->edge_a->event= ii->edge_b->event= scev_intersection;
   ii->edge_a->ev_pi= ii->edge_b->ev_pi= m_cur_pi;
   free_item(ii);
-  m_cur_pi->intersection_data= NULL;
+  m_cur_pi->u.s2.intersection_data= NULL;
 
   GCALC_DBUG_VOID_RETURN;
 }
@@ -1813,7 +1813,7 @@ int Gcalc_scan_iterator::add_intersection(point *sp_a, point *sp_b,
       !(ii= new_intersection(m_heap, i_calc)))
     GCALC_DBUG_RETURN(1);
 
-  ii->equal_intersection= 0;
+  ii->u.s2.equal_intersection= 0;
 
   for (;
        pi_from->get_next() != sp_a->next_pi &&
@@ -1824,7 +1824,7 @@ int Gcalc_scan_iterator::add_intersection(point *sp_a, point *sp_b,
     if (skip_next)
     {
       if (cur->type == Gcalc_heap::nt_intersection)
-        skip_next= cur->equal_intersection;
+        skip_next= cur->u.s2.equal_intersection;
       else
         skip_next= 0;
       continue;
@@ -1832,7 +1832,7 @@ int Gcalc_scan_iterator::add_intersection(point *sp_a, point *sp_b,
     if (cur->type == Gcalc_heap::nt_intersection)
     {
       cmp_res= cmp_intersections(cur, ii);
-      skip_next= cur->equal_intersection;
+      skip_next= cur->u.s2.equal_intersection;
     }
     else if (cur->type == Gcalc_heap::nt_eq_node)
       continue;
@@ -1840,7 +1840,7 @@ int Gcalc_scan_iterator::add_intersection(point *sp_a, point *sp_b,
       cmp_res= cmp_node_isc(cur, ii);
     if (cmp_res == 0)
     {
-      ii->equal_intersection= 1;
+      ii->u.s2.equal_intersection= 1;
       break;
     }
     else if (cmp_res > 0)
@@ -1881,13 +1881,13 @@ void calc_t(Gcalc_coord2 t_a, Gcalc_coord2 t_b,
   Gcalc_coord2 x1y2, x2y1;
   Gcalc_coord1 dya, dyb;
 
-  gcalc_sub_coord1(a2_a1x, p3->ix, p1->ix);
-  gcalc_sub_coord1(a2_a1y, p3->iy, p1->iy);
+  gcalc_sub_coord1(a2_a1x, p3->u.s1.ix, p1->u.s1.ix);
+  gcalc_sub_coord1(a2_a1y, p3->u.s1.iy, p1->u.s1.iy);
 
-  gcalc_sub_coord1(dxa, p2->ix, p1->ix);
-  gcalc_sub_coord1(dya, p2->iy, p1->iy);
-  gcalc_sub_coord1(dxb, p4->ix, p3->ix);
-  gcalc_sub_coord1(dyb, p4->iy, p3->iy);
+  gcalc_sub_coord1(dxa, p2->u.s1.ix, p1->u.s1.ix);
+  gcalc_sub_coord1(dya, p2->u.s1.iy, p1->u.s1.iy);
+  gcalc_sub_coord1(dxb, p4->u.s1.ix, p3->u.s1.ix);
+  gcalc_sub_coord1(dyb, p4->u.s1.iy, p3->u.s1.iy);
 
   gcalc_mul_coord1(x1y2, dxa, dyb);
   gcalc_mul_coord1(x2y1, dya, dxb);
@@ -1908,11 +1908,11 @@ double Gcalc_scan_iterator::get_y() const
     Gcalc_coord2 t_a, t_b;
     Gcalc_coord3 a_tb, b_ta, y_exp;
     calc_t(t_a, t_b, dxa, dya,
-           state.pi->p1, state.pi->p2, state.pi->p3, state.pi->p4);
+           state.pi->u.s2.p1, state.pi->u.s2.p2, state.pi->u.s2.p3, state.pi->u.s2.p4);
 
 
     gcalc_mul_coord(a_tb, GCALC_COORD_BASE3,
-        t_b, GCALC_COORD_BASE2, state.pi->p1->iy, GCALC_COORD_BASE);
+        t_b, GCALC_COORD_BASE2, state.pi->u.s2.p1->u.s1.iy, GCALC_COORD_BASE);
     gcalc_mul_coord(b_ta, GCALC_COORD_BASE3,
         t_a, GCALC_COORD_BASE2, dya, GCALC_COORD_BASE);
 
@@ -1922,7 +1922,7 @@ double Gcalc_scan_iterator::get_y() const
              get_pure_double(t_b, GCALC_COORD_BASE2)) / m_heap->coord_extent;
   }
   else
-    return state.pi->y;
+    return state.pi->u.s1.y;
 }
 
 
@@ -1934,11 +1934,11 @@ double Gcalc_scan_iterator::get_event_x() const
     Gcalc_coord2 t_a, t_b;
     Gcalc_coord3 a_tb, b_ta, x_exp;
     calc_t(t_a, t_b, dxa, dya,
-           state.pi->p1, state.pi->p2, state.pi->p3, state.pi->p4);
+           state.pi->u.s2.p1, state.pi->u.s2.p2, state.pi->u.s2.p3, state.pi->u.s2.p4);
 
 
     gcalc_mul_coord(a_tb, GCALC_COORD_BASE3,
-        t_b, GCALC_COORD_BASE2, state.pi->p1->ix, GCALC_COORD_BASE);
+        t_b, GCALC_COORD_BASE2, state.pi->u.s2.p1->u.s1.ix, GCALC_COORD_BASE);
     gcalc_mul_coord(b_ta, GCALC_COORD_BASE3,
         t_a, GCALC_COORD_BASE2, dxa, GCALC_COORD_BASE);
 
@@ -1948,7 +1948,7 @@ double Gcalc_scan_iterator::get_event_x() const
              get_pure_double(t_b, GCALC_COORD_BASE2)) / m_heap->coord_extent;
   }
   else
-    return state.pi->x;
+    return state.pi->u.s1.x;
 }
 
 double Gcalc_scan_iterator::get_h() const
@@ -1961,7 +1961,7 @@ double Gcalc_scan_iterator::get_h() const
     state.pi->calc_xy(&x, &next_y);
   }
   else
-    next_y= state.pi->y;
+    next_y= state.pi->u.s1.y;
   return next_y - cur_y;
 }
 
@@ -1970,11 +1970,11 @@ double Gcalc_scan_iterator::get_sp_x(const point *sp) const
 {
   double dy;
   if (sp->event & (scev_end | scev_two_ends | scev_point))
-    return sp->pi->x;
-  dy= sp->next_pi->y - sp->pi->y;
+    return sp->pi->u.s1.x;
+  dy= sp->next_pi->u.s1.y - sp->pi->u.s1.y;
   if (fabs(dy) < 1e-12)
-    return sp->pi->x;
-  return (sp->next_pi->x - sp->pi->x) * dy;
+    return sp->pi->u.s1.x;
+  return (sp->next_pi->u.s1.x - sp->pi->u.s1.x) * dy;
 }
 
 

--- a/sql/gcalc_slicescan.h
+++ b/sql/gcalc_slicescan.h
@@ -188,7 +188,7 @@ public:
         double x,y;
         Gcalc_coord1 ix, iy;
         int top_node;
-      };
+      } s1;
       struct
       {
         /* nt_intersection */
@@ -199,19 +199,19 @@ public:
         const Info *p4;
         void *intersection_data;
         int equal_intersection;
-      };
+      } s2;
       struct
       {
         /* nt_eq_node */
         const Info *node;
         void *eq_data;
-      };
-    };
+      } s3;
+    } u;
 
     bool is_bottom() const
-      { GCALC_DBUG_ASSERT(type == nt_shape_node); return !left; }
+      { GCALC_DBUG_ASSERT(type == nt_shape_node); return !u.s1.left; }
     bool is_top() const
-      { GCALC_DBUG_ASSERT(type == nt_shape_node); return top_node; }
+      { GCALC_DBUG_ASSERT(type == nt_shape_node); return u.s1.top_node; }
     bool is_single_node() const
       { return is_bottom() && is_top(); }
 
@@ -383,7 +383,7 @@ public:
     inline const point *c_get_next() const
       { return (const point *)next; }
     inline bool is_bottom() const { return !next_pi; }
-    gcalc_shape_info get_shape() const { return pi->shape; }
+    gcalc_shape_info get_shape() const { return pi->u.s1.shape; }
     inline point *get_next() { return (point *)next; }
     inline const point *get_next() const { return (const point *)next; }
     /* Compare the dx_dy parameters regarding the horiz_dir */

--- a/sql/gcalc_tools.cc
+++ b/sql/gcalc_tools.cc
@@ -1243,7 +1243,7 @@ inline int Gcalc_operation_reducer::get_single_result(res_point *res,
       GCALC_DBUG_RETURN(1);
   }
   else
-    if (storage->single_point(res->pi->x, res->pi->y))
+    if (storage->single_point(res->pi->u.s1.x, res->pi->u.s1.y))
       GCALC_DBUG_RETURN(1);
   free_result(res);
   GCALC_DBUG_RETURN(0);
@@ -1269,8 +1269,8 @@ int Gcalc_operation_reducer::get_result_thread(res_point *cur,
       }
       else
       {
-	x= cur->pi->x;
-        y= cur->pi->y;
+	x= cur->pi->u.s1.x;
+        y= cur->pi->u.s1.y;
       }
       if (storage->add_point(x, y))
         GCALC_DBUG_RETURN(1);

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -637,10 +637,10 @@ static double count_edge_t(const Gcalc_heap::Info *ea,
                            double &ex, double &ey, double &vx, double &vy,
                            double &e_sqrlen)
 {
-  ex= eb->x - ea->x;
-  ey= eb->y - ea->y;
-  vx= v->x - ea->x;
-  vy= v->y - ea->y;
+  ex= eb->u.s1.x - ea->u.s1.x;
+  ey= eb->u.s1.y - ea->u.s1.y;
+  vx= v->u.s1.x - ea->u.s1.x;
+  vy= v->u.s1.y - ea->u.s1.y;
   e_sqrlen= ex * ex + ey * ey;
   return (ex * vx + ey * vy) / e_sqrlen;
 }
@@ -656,8 +656,8 @@ static double distance_to_line(double ex, double ey, double vx, double vy,
 static double distance_points(const Gcalc_heap::Info *a,
                               const Gcalc_heap::Info *b)
 {
-  double x= a->x - b->x;
-  double y= a->y - b->y;
+  double x= a->u.s1.x - b->u.s1.x;
+  double y= a->u.s1.y - b->u.s1.y;
   return sqrt(x * x + y * y);
 }
 
@@ -1698,7 +1698,7 @@ double Item_func_distance::val_real()
       continue;
 
 count_distance:
-    if (cur_point->shape >= obj2_si)
+    if (cur_point->u.s1.shape >= obj2_si)
       continue;
     cur_point_edge= !cur_point->is_bottom();
 
@@ -1706,13 +1706,13 @@ count_distance:
     {
       /* We only check vertices of object 2 */
       if (dist_point->type != Gcalc_heap::nt_shape_node ||
-          dist_point->shape < obj2_si)
+          dist_point->u.s1.shape < obj2_si)
         continue;
 
       /* if we have an edge to check */
-      if (dist_point->left)
+      if (dist_point->u.s1.left)
       {
-        t= count_edge_t(dist_point, dist_point->left, cur_point,
+        t= count_edge_t(dist_point, dist_point->u.s1.left, cur_point,
                         ex, ey, vx, vy, e_sqrlen);
         if ((t>0.0) && (t<1.0))
         {
@@ -1723,7 +1723,7 @@ count_distance:
       }
       if (cur_point_edge)
       {
-        t= count_edge_t(cur_point, cur_point->left, dist_point,
+        t= count_edge_t(cur_point, cur_point->u.s1.left, dist_point,
                         ex, ey, vx, vy, e_sqrlen);
         if ((t>0.0) && (t<1.0))
         {

--- a/storage/connect/CMakeLists.txt
+++ b/storage/connect/CMakeLists.txt
@@ -45,6 +45,7 @@ add_definitions( -DHUGE_SUPPORT -DZIP_SUPPORT -DPIVOT_SUPPORT )
 # OS specific C flags, definitions and source files.
 #
 IF(UNIX)
+ IF(NOT "${CMAKE_C_COMPILER_ID} ${CMAKE_CXX_COMPILER_ID}" MATCHES SunPro)
   # Bar: -Wfatal-errors removed (does not present in gcc on solaris10)
   if(WITH_WARNINGS)
     add_definitions(-Wall -Wextra -Wmissing-declarations)
@@ -71,10 +72,13 @@ IF(UNIX)
 
     #message(STATUS "CONNECT: GCC: Some warnings disabled")
   endif(WITH_WARNINGS)
+ ENDIF()
 
   add_definitions( -DUNIX -DLINUX -DUBUNTU )
 
+ IF(NOT "${CMAKE_C_COMPILER_ID} ${CMAKE_CXX_COMPILER_ID}" MATCHES SunPro)
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -fexceptions -fPIC ")
+ ENDIF()
   get_property(inc_dirs DIRECTORY PROPERTY INCLUDE_DIRECTORIES)
   SET(CONNECT_SOURCES ${CONNECT_SOURCES} inihandl.c)
   SET(IPHLPAPI_LIBRARY "")

--- a/storage/connect/maputil.cpp
+++ b/storage/connect/maputil.cpp
@@ -190,8 +190,8 @@ bool CloseMemMap(void *memory, size_t dwSize)
   {
   if (memory) {
     // All this must be redesigned
-    int rc = msync(memory, dwSize, MS_SYNC);
-    return (munmap(memory, dwSize) < 0) ? true : false;
+    int rc = msync((char *)memory, dwSize, MS_SYNC);
+    return (munmap((char *)memory, dwSize) < 0) ? true : false;
   } else
     return false;
 

--- a/storage/connect/xindex.cpp
+++ b/storage/connect/xindex.cpp
@@ -1279,7 +1279,7 @@ bool XINDEX::MapInit(PGLOBAL g)
     IOFF *noff = (IOFF*)mbase;
 
     // Position the memory base at the offset of this index
-    mbase += noff[id].Low;
+    mbase += noff[id].u.Low;
     } // endif id
 
   //  Now start the mapping process.
@@ -2347,10 +2347,10 @@ bool XFILE::Open(PGLOBAL g, char *filename, int id, MODE mode)
       return true;
       } // endif
 
-    NewOff.Low = (int)ftell(Xfile);
+    NewOff.u.Low = (int)ftell(Xfile);
 
     if (trace)
-      htrc("XFILE Open: NewOff.Low=%d\n", NewOff.Low);
+      htrc("XFILE Open: NewOff.Low=%d\n", NewOff.u.Low);
 
   } else if (mode == MODE_WRITE) {
     if (id >= 0) {
@@ -2358,10 +2358,10 @@ bool XFILE::Open(PGLOBAL g, char *filename, int id, MODE mode)
       memset(noff, 0, sizeof(noff));
       Write(g, noff, sizeof(IOFF), MAX_INDX, rc);
       fseek(Xfile, 0, SEEK_END);
-      NewOff.Low = (int)ftell(Xfile);
+      NewOff.u.Low = (int)ftell(Xfile);
 
       if (trace)
-        htrc("XFILE Open: NewOff.Low=%d\n", NewOff.Low);
+        htrc("XFILE Open: NewOff.Low=%d\n", NewOff.u.Low);
 
       } // endif id
 
@@ -2373,10 +2373,10 @@ bool XFILE::Open(PGLOBAL g, char *filename, int id, MODE mode)
       } // endif MAX_INDX
 
       if (trace)
-        htrc("XFILE Open: noff[%d].Low=%d\n", id, noff[id].Low);
+        htrc("XFILE Open: noff[%d].Low=%d\n", id, noff[id].u.Low);
 
     // Position the cursor at the offset of this index
-    if (fseek(Xfile, noff[id].Low, SEEK_SET)) {
+    if (fseek(Xfile, noff[id].u.Low, SEEK_SET)) {
       sprintf(g->Message, MSG(FUNC_ERRNO), errno, "Xseek");
       return true;
       } // endif
@@ -2649,7 +2649,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
     if (id >= 0) {
       // New not sep index file. Write the header.
       memset(noff, 0, sizeof(noff));
-      NewOff.Low = write(Hfile, &noff, sizeof(noff));
+      NewOff.u.Low = write(Hfile, &noff, sizeof(noff));
       } // endif id
 
     if (trace)

--- a/storage/connect/xindex.h
+++ b/storage/connect/xindex.h
@@ -66,9 +66,9 @@ typedef struct index_def : public BLOCK {
 typedef struct index_off {
   union {
 #if defined(WORDS_BIGENDIAN)
-    struct {int High; int Low;};
+    struct {int High; int Low;} u;
 #else   // !WORDS_BIGENDIAN
-    struct {int Low; int High;};
+    struct {int Low; int High;} u;
 #endif   //!WORDS_BIGENDIAN
     longlong Val;                 // File position
     }; // end of union

--- a/storage/spider/spd_conn.cc
+++ b/storage/spider/spd_conn.cc
@@ -2718,11 +2718,16 @@ void *spider_bg_sts_action(
 #endif
   spider_db_handler **dbton_hdl;
 #else
-  int need_mons[share->link_count];
-  SPIDER_CONN *conns[share->link_count];
-  uint conn_link_idx[share->link_count];
-  uchar conn_can_fo[share->link_bitmap_size];
-  char *conn_keys[share->link_count];
+  int *need_mons;
+  SPIDER_CONN **conns;
+  uint *conn_link_idx;
+  uchar *conn_can_fo;
+  char **conn_keys;
+  need_mons = (int *)alloca(share->link_count * sizeof(int));
+  conns = (SPIDER_CONN **)alloca(share->link_count * sizeof(SPIDER_CONN *));
+  conn_link_idx = (uint *)alloca(share->link_count * sizeof(uint));
+  conn_can_fo = (uchar *)alloca(share->link_bitmap_size * sizeof(uchar));
+  conn_keys = (char **)alloca(share->link_count * sizeof(char *));
 #if defined(HS_HAS_SQLCOM) && defined(HAVE_HANDLERSOCKET)
   char *hs_r_conn_keys[share->link_count];
   char *hs_w_conn_keys[share->link_count];
@@ -3100,11 +3105,16 @@ void *spider_bg_crd_action(
 #endif
   spider_db_handler **dbton_hdl;
 #else
-  int need_mons[share->link_count];
-  SPIDER_CONN *conns[share->link_count];
-  uint conn_link_idx[share->link_count];
-  uchar conn_can_fo[share->link_bitmap_size];
-  char *conn_keys[share->link_count];
+  int *need_mons;
+  SPIDER_CONN **conns;
+  uint *conn_link_idx;
+  uchar *conn_can_fo;
+  char **conn_keys;
+  need_mons = (int *)alloca(share->link_count * sizeof(int));
+  conns = (SPIDER_CONN **)alloca(share->link_count * sizeof(SPIDER_CONN *));
+  conn_link_idx = (uint *)alloca(share->link_count * sizeof(uint));
+  conn_can_fo = (uchar *)alloca(share->link_bitmap_size * sizeof(uchar));
+  conn_keys = (char **)alloca(share->link_count * sizeof(char *));
 #if defined(HS_HAS_SQLCOM) && defined(HAVE_HANDLERSOCKET)
   char *hs_r_conn_keys[share->link_count];
   char *hs_w_conn_keys[share->link_count];
@@ -3422,7 +3432,8 @@ int spider_create_mon_threads(
         SPIDER_SQL_INT_LEN + 1);
       conv_name_str.set_charset(system_charset_info);
 #else
-      char buf[share->table_name_length + SPIDER_SQL_INT_LEN + 1];
+      char *buf;
+      buf = (char *)alloca((share->table_name_length + SPIDER_SQL_INT_LEN + 1) * sizeof(char));
       spider_string conv_name_str(buf, share->table_name_length +
         SPIDER_SQL_INT_LEN + 1, system_charset_info);
 #endif
@@ -3752,8 +3763,10 @@ int spider_conn_first_link_idx(
   int *link_idxs, link_idx;
   long *balances;
 #else
-  int link_idxs[link_count];
-  long balances[link_count];
+  int *link_idxs;
+  long *balances;
+  link_idxs = (int *)alloca((link_count) * sizeof(int));
+  balances = (long *)alloca((link_count) * sizeof(long));
 #endif
   DBUG_ENTER("spider_conn_first_link_idx");
 #ifdef _MSC_VER

--- a/storage/spider/spd_db_conn.cc
+++ b/storage/spider/spd_db_conn.cc
@@ -9300,7 +9300,8 @@ int spider_db_udf_ping_table(
       spider_string where_str(init_sql_alloc_size);
       where_str.set_charset(system_charset_info);
 #else
-      char sql_buf[init_sql_alloc_size], where_buf[init_sql_alloc_size];
+      char *sql_buf, *where_buf;
+      sql_buf = (char *)alloca((init_sql_alloc_size) * sizeof(char)); where_buf = (char *)alloca((init_sql_alloc_size) * sizeof(char));
       spider_string sql_str(sql_buf, sizeof(sql_buf),
         system_charset_info);
       spider_string where_str(where_buf, sizeof(where_buf),
@@ -9521,7 +9522,8 @@ int spider_db_udf_ping_table_mon_next(
   spider_string sql_str(init_sql_alloc_size);
   sql_str.set_charset(thd->variables.character_set_client);
 #else
-  char sql_buf[init_sql_alloc_size];
+  char *sql_buf;
+  sql_buf = (char *)alloca((init_sql_alloc_size) * sizeof(char));
   spider_string sql_str(sql_buf, sizeof(sql_buf),
     thd->variables.character_set_client);
 #endif

--- a/storage/spider/spd_ping_table.cc
+++ b/storage/spider/spd_ping_table.cc
@@ -245,7 +245,8 @@ void spider_release_ping_table_mon_list(
   spider_string conv_name_str(conv_name_length + link_idx_str_length + 1);
   conv_name_str.set_charset(system_charset_info);
 #else
-  char buf[conv_name_length + link_idx_str_length + 1];
+  char *buf;
+  buf  = (char *)alloca((conv_name_length + link_idx_str_length + 1) * sizeof(char));
   spider_string conv_name_str(buf, conv_name_length + link_idx_str_length + 1,
     system_charset_info);
 #endif
@@ -1368,7 +1369,8 @@ int spider_ping_table_mon_from_table(
   *((char *)(conv_name_str.ptr() + conv_name_length + link_idx_str_length)) =
     '\0';
 #else
-  char buf[conv_name_length + link_idx_str_length + 1];
+  char *buf;
+  buf = (char *)alloca((conv_name_length + link_idx_str_length + 1) * sizeof(char));
   buf[conv_name_length + link_idx_str_length] = '\0';
   spider_string conv_name_str(buf, conv_name_length + link_idx_str_length + 1,
     system_charset_info);

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -3710,7 +3710,8 @@ int spider_create_conn_keys(
   uint *hs_w_conn_keys_lengths;
 #endif
 #else
-  uint conn_keys_lengths[share->all_link_count];
+  uint *conn_keys_lengths;
+  conn_keys_lengths = (uint *)alloca((share->all_link_count) * sizeof(uint));
 #if defined(HS_HAS_SQLCOM) && defined(HAVE_HANDLERSOCKET)
   uint hs_r_conn_keys_lengths[share->all_link_count];
   uint hs_w_conn_keys_lengths[share->all_link_count];
@@ -4692,8 +4693,10 @@ SPIDER_SHARE *spider_get_share(
         goto error_but_no_delete;
       }
 #else
-      char db[table_share->db.length + 1],
-        table_name[table_share->table_name.length + 1];
+      char *db,
+        *table_name;
+      db = (char *)alloca((table_share->db.length + 1) * sizeof(char));
+      table_name = (char *)alloca((table_share->table_name.length + 1) * sizeof(char));
 #endif
       memcpy(db, table_share->db.str, table_share->db.length);
       db[table_share->db.length] = '\0';
@@ -5113,8 +5116,10 @@ SPIDER_SHARE *spider_get_share(
         goto error_but_no_delete;
       }
 #else
-      char db[table_share->db.length + 1],
-        table_name[table_share->table_name.length + 1];
+      char *db,
+        *table_name;
+      db = (char *)alloca((table_share->db.length + 1) * sizeof(char));
+      table_name = (char *)alloca((table_share->table_name.length + 1) * sizeof(char));
 #endif
       memcpy(db, table_share->db.str, table_share->db.length);
       db[table_share->db.length] = '\0';

--- a/storage/spider/spd_trx.cc
+++ b/storage/spider/spd_trx.cc
@@ -3722,8 +3722,10 @@ int spider_check_trx_and_get_conn(
             DBUG_RETURN(HA_ERR_OUT_OF_MEM);
           }
 #else
-          char db[table_share->db.length + 1],
-            table_name[table_share->table_name.length + 1];
+          char *db,
+            *table_name;
+          db = (char *)alloca((table_share->db.length + 1) * sizeof(char));
+          table_name = (char *)alloca((table_share->table_name.length + 1) * sizeof(char));
 #endif
           memcpy(db, table_share->db.str, table_share->db.length);
           db[table_share->db.length] = '\0';
@@ -3881,8 +3883,10 @@ int spider_check_trx_and_get_conn(
           DBUG_RETURN(HA_ERR_OUT_OF_MEM);
         }
 #else
-        char db[table_share->db.length + 1],
-          table_name[table_share->table_name.length + 1];
+        char *db,
+          *table_name;
+	db = (char *)alloca((table_share->db.length + 1) * sizeof(char));
+	table_name = (char *)alloca((table_share->table_name.length + 1) * sizeof(char));
 #endif
         memcpy(db, table_share->db.str, table_share->db.length);
         db[table_share->db.length] = '\0';
@@ -4027,8 +4031,10 @@ int spider_check_trx_and_get_conn(
           DBUG_RETURN(HA_ERR_OUT_OF_MEM);
         }
 #else
-        char db[table_share->db.length + 1],
-          table_name[table_share->table_name.length + 1];
+        char *db,
+          *table_name;
+	db = (char *)alloca((table_share->db.length + 1) * sizeof(char));
+	table_name = (char *)alloca((table_share->table_name.length + 1) * sizeof(char));
 #endif
         memcpy(db, table_share->db.str, table_share->db.length);
         db[table_share->db.length] = '\0';

--- a/unittest/mysys/CMakeLists.txt
+++ b/unittest/mysys/CMakeLists.txt
@@ -13,9 +13,11 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
-MY_ADD_TESTS(bitmap base64 my_vsnprintf my_atomic my_rdtsc lf my_malloc
+MY_ADD_TESTS(bitmap base64 my_atomic my_rdtsc lf my_malloc
              my_getopt
              LINK_LIBRARIES mysys)
+MY_ADD_TESTS(my_vsnprintf
+             LINK_LIBRARIES strings mysys)
 
 MY_ADD_TESTS(ma_dyncol
 	     LINK_LIBRARIES mysqlclient)

--- a/unittest/strings/CMakeLists.txt
+++ b/unittest/strings/CMakeLists.txt
@@ -1,3 +1,3 @@
 
-MY_ADD_TESTS(strings LINK_LIBRARIES strings)
+MY_ADD_TESTS(strings LINK_LIBRARIES strings mysys)
 


### PR DESCRIPTION
<pre>
modifications to 10.0.23 to get it compiled on solaris 10 (patched up
to current) using the latest solaris-studio compilers (12.4):

configuration options used:

env \
  CC=cc \
  CFLAGS="-xtarget=ultra2 -xarch=sparcvis -xO4 -xstrconst -mt" \
  LDFLAGS=-s \
  CXX=CC \
  CXXFLAGS="-xtarget=ultra2 -xarch=sparcvis -xO4 -noex -mt" \
    cmake . -L \
      -DCMAKE_INSTALL_PREFIX=/opt/mysql \
      -DINSTALL_SBINDIR=sbin \
      -DDEFAULT_SYSCONFDIR=/opt/mysql/etc \
      -DENABLED_LOCAL_INFILE=1 \
      -DMYSQL_UNIX_ADDR=/tmp/.mysql.sock \
      -DWITH_EXTRA_CHARSETS=complex \
      -DWITH_READLINE=ON \
      -DWITH_MYSQLD_LDFLAGS=-lmtmalloc
gmake


daemon can be installed, initialized and started, and does
(at least :-) simple things, including handling of innodb databases.

test suite passes with a minor handful of failures (some wrt. ipv6,
which is neither configured nor used on the host; some because
of differing error messages; one seems a bug in the test-suite)

here is what i had to patch (see pull request), in order of
appearance during build of the server:

1)
linking  unittest/strings/strings-t  and  unittest/mysys/my_vsnprintf-t
throws undefined-symbol errors such as
"undefined symbol strdup_root, first referenced in
 CMakeFiles/strings-t.dir/strings-t.c.o"

this is solved for me by adding after "../../strings/libstrings.a"
"../../mysys/libmysys.a ../../strings/libstrings.a -lrt"
to the respective cmake-generated CMakeFiles/....dir/link.txt files

i changed
  unittest/mysys/CMakeLists.txt, unittest/strings/CMakeLists.txt
such that linkage works.  the change probably should be #ifdef'ed.


2)
studio-cplusplus seems not to like anonymous structs / unions the way as
gnu-cplusplus does.
this affects Gcalc_heap::Info in
  sql/item_geofunc.h
and it's use in
  sql/item_geofunc.cc, sql/gcalc_slicescan.cc.

i rewrote the code to use trivial struct / union names.


3)
for studio-compiler, when declaring an array, dimensions must be constant.
affected files:
   storage/spider/spd_conn.cc, storage/spider/spd_db_conn.cc,
   storage/spider/spd_ping_table.cc, storage/spider/spd_table.cc,
   storage/spider/spd_trx.cc

i rewrote the code to declare a pointer and use alloca()


4)
studio-compiler uses -W to propagate options to sub-commands of the
compile-process and, in particular, error-terminates on -Wall.
so i had to conditionalize the adding of -W (and -f) options in
  storage/connect/CMakeLists.txt.

the attached patch should probably get generalized w.r.t. other compilers.


5)
another anonymous struct problem in
  storage/connect/xindex.h, storage/connect/xindex.cpp


6)
had to add a trivial cast in
  storage/connect/maputil.cpp


7)
studio-cplusplus has problem with template inside struct in
  storage/sphinx/ha_sphinx.cc

i rearranged the code, so the template is outside the struct, and a
union is used


i still get oodles of warnings  "Identifier expected instead of }." (from
enums or initializers like "{ foo, bar, }"), and  "bar hides foo::bar".
oh, well.

</pre>

