### PR TITLE
MDEV-9354: Debian: unmask the mysql.service on installation

### DIFF
--- a/debian/dist/Debian/mariadb-server-10.0.postinst
+++ b/debian/dist/Debian/mariadb-server-10.0.postinst
@@ -264,6 +264,11 @@ fi
 
 db_stop # in case invoke failes
 
+# If we upgrade from MySQL mysql.service may be masked, which also
+# means init.d script is disabled. Unmask mysql service explicitely.
+# Ignore exit code as command is not available everywhere.
+deb-systemd-helper unmask mysql.service > /dev/null || true
+
 #DEBHELPER#
 
 exit 0

--- a/debian/dist/Ubuntu/mariadb-server-10.0.postinst
+++ b/debian/dist/Ubuntu/mariadb-server-10.0.postinst
@@ -280,6 +280,11 @@ fi
 
 db_stop # in case invoke failes
 
+# If we upgrade from MySQL mysql.service may be masked, which also
+# means init.d script is disabled. Unmask mysql service explicitely.
+# Ignore exit code as command is not available everywhere.
+deb-systemd-helper unmask mysql.service > /dev/null || true
+
 #DEBHELPER#
 
 exit 0


### PR DESCRIPTION
Unmask the systemd mysql.service if left behind by mysql-server-5.6

Without this a simple 'apt-get install mariadb-server' would end
up with a system where mysqld is not running despite it was
running OK with mysql-server-5.6 installed, and users might wrongly
think mariadb-server package is broken when the real cause was
the removal of mysql-server-5.6 that left a /etc/systemd/system/
file behind pointing to /dev/null.