### PR TITLE
MDEV-9433: mysys/my_rnd.c - remove #ifdef __cplusplus

### DIFF
--- a/mysys/my_rnd.c
+++ b/mysys/my_rnd.c
@@ -95,7 +95,3 @@ double my_rnd_ssl(struct my_rnd_struct *rand_st)
 
   return my_rnd(rand_st);
 }
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
header file has the CPP guff

cppchecker reported the error

[mysys/my_rnd.c:100]: (error) Invalid number of character '{' when these macros are defined: '__cplusplus'.

I submit this under the MCA.