### PR TITLE
MDEV-8012: Wrong exit code when asking for help

### DIFF
--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -232,8 +232,6 @@ my_bool
 get_one_option(int optid, const struct my_option *opt __attribute__((unused)),
 	       char *argument)
 {
-  int error = 0;
-
   switch(optid) {
   case 'c':
     opt_count_iterations= 1;
@@ -281,8 +279,8 @@ get_one_option(int optid, const struct my_option *opt __attribute__((unused)),
     break;
   case '?':
   case 'I':					/* Info */
-    error++;
-    break;
+    usage();
+    exit(0);
   case OPT_CHARSETS_DIR:
 #if MYSQL_VERSION_ID > 32300
     charsets_dir = argument;
@@ -292,11 +290,6 @@ get_one_option(int optid, const struct my_option *opt __attribute__((unused)),
     opt_protocol= find_type_or_exit(argument, &sql_protocol_typelib,
                                     opt->name);
     break;
-  }
-  if (error)
-  {
-    usage();
-    exit(1);
   }
   return 0;
 }

--- a/extra/mysql_waitpid.c
+++ b/extra/mysql_waitpid.c
@@ -54,6 +54,7 @@ get_one_option(int optid, const struct my_option *opt __attribute__((unused)),
   case 'I':
   case '?':
     usage();
+    exit(0);
   }
   return 0;
 }
@@ -69,7 +70,10 @@ int main(int argc, char *argv[])
     exit(-1);
   if (!argv[0] || !argv[1] || (pid= atoi(argv[0])) <= 0 ||
       (t= atoi(argv[1])) <= 0)
+  {
     usage();
+    exit(-1);
+  }
   for (; t > 0; t--)
   {
     if (kill((pid_t) pid, sig))
@@ -100,5 +104,4 @@ void usage(void)
   printf("integer arguments.\n\n");
   printf("Options:\n");
   my_print_help(my_long_options);
-  exit(-1);
 }


### PR DESCRIPTION
[MDEV-8012](https://jira.mariadb.org/browse/MDEV-8012): Wrong exit code when asking for help

`--help` is a perfectly valid parameter and both `mysqladmin` and `mysql_waitpid` should exit with success (zero errror code).

I did not send the MCA yet, but this fix is under BSD license and can be used by MariaDB developers.