### PR TITLE
MDEV-505: feature request: add \H option for mysql client prompt

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -5112,17 +5112,29 @@ static const char *construct_prompt()
           processed_prompt.append("unknown");
         break;
       case 'h':
+      case 'H':
       {
-	const char *prompt;
-	prompt= connected ? mysql_get_host_info(&mysql) : "not_connected";
-	if (strstr(prompt, "Localhost"))
-	  processed_prompt.append("localhost");
-	else
-	{
-	  const char *end=strcend(prompt,' ');
-	  processed_prompt.append(prompt, (uint) (end-prompt));
-	}
-	break;
+        const char *prompt;
+        prompt= connected ? mysql_get_host_info(&mysql) : "not_connected";
+        if (strstr(prompt, "Localhost"))
+        {
+          if (*c == 'h')
+            processed_prompt.append("localhost");
+          else
+          {
+            char hostname[HOST_NAME_MAX];
+            if (gethostname(hostname, sizeof(hostname)) == 0)
+              processed_prompt.append(hostname);
+            else
+              processed_prompt.append("gethostname(2) failed");
+          }
+        }
+        else
+        {
+          const char *end=strcend(prompt,' ');
+          processed_prompt.append(prompt, (uint) (end-prompt));
+        }
+        break;
       }
       case 'p':
       {


### PR DESCRIPTION
[MDEV-505](https://jira.mariadb.org/browse/MDEV-505): feature request: add \H option for mysql client prompt

Introduce `\H` option which behaves mostly like `\h`. The only exception is
when the client connects to the server hosted on localhost. In this case, the
hostname will be used instead.

I already sent my MCA so the developers of MariaDB may use this patch however they consider best.

Best regards,
Dan Ungureanu