### PR TITLE
MDEV-9758: CHECKSUM TABLE to calculate in multiple column chunks

### DIFF
--- a/mysql-test/r/myisam.result
+++ b/mysql-test/r/myisam.result
@@ -596,6 +596,10 @@ test.t2	3442722830
 test.t3	NULL
 Warnings:
 Error	1146	Table 'test.t3' doesn't exist
+alter table t1 add d int default 30, add e bigint default 300000, add f decimal(30) default 442;
+checksum table t2;
+Table	Checksum
+test.t2	3442722830
 drop table t1,t2;
 create table t1 (a int, key (a));
 show keys from t1;

--- a/mysql-test/r/myisam.result
+++ b/mysql-test/r/myisam.result
@@ -597,9 +597,9 @@ test.t3	NULL
 Warnings:
 Error	1146	Table 'test.t3' doesn't exist
 alter table t1 add d int default 30, add e bigint default 300000, add f decimal(30) default 442;
-checksum table t2;
+checksum table t1;
 Table	Checksum
-test.t2	3442722830
+test.t1	2924214226
 drop table t1,t2;
 create table t1 (a int, key (a));
 show keys from t1;

--- a/mysql-test/t/myisam.test
+++ b/mysql-test/t/myisam.test
@@ -553,7 +553,7 @@ checksum table t1, t2, t3 quick;
 checksum table t1, t2, t3;
 checksum table t1, t2, t3 extended;
 alter table t1 add d int default 30, add e bigint default 300000, add f decimal(30) default 442;
-checksum table t2;
+checksum table t1;
 #show table status;
 drop table t1,t2;
 

--- a/mysql-test/t/myisam.test
+++ b/mysql-test/t/myisam.test
@@ -552,6 +552,8 @@ insert t2 select * from t1;
 checksum table t1, t2, t3 quick;
 checksum table t1, t2, t3;
 checksum table t1, t2, t3 extended;
+alter table t1 add d int default 30, add e bigint default 300000, add f decimal(30) default 442;
+checksum table t2;
 #show table status;
 drop table t1,t2;
 

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -9745,23 +9745,23 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
       if (!(check_opt->flags & T_EXTEND) &&
           (((t->file->ha_table_flags() & HA_HAS_OLD_CHECKSUM) && thd->variables.old_mode) ||
            ((t->file->ha_table_flags() & HA_HAS_NEW_CHECKSUM) && !thd->variables.old_mode)))
-	protocol->store((ulonglong)t->file->checksum());
+        protocol->store((ulonglong)t->file->checksum());
       else if (check_opt->flags & T_QUICK)
-	protocol->store_null();
+        protocol->store_null();
       else
       {
-	/* calculating table's checksum */
-	ha_checksum crc= 0;
+        /* calculating table's checksum */
+        ha_checksum crc= 0;
         uchar null_mask=256 -  (1 << t->s->last_null_bit_pos);
 
         t->use_all_columns();
 
-	if (t->file->ha_rnd_init(1))
-	  protocol->store_null();
-	else
-	{
-	  for (;;)
-	  {
+        if (t->file->ha_rnd_init(1))
+          protocol->store_null();
+        else
+        {
+          for (;;)
+          {
             if (thd->killed)
             {
               /* 
@@ -9772,7 +9772,7 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
               thd->protocol->remove_last_row();
               goto err;
             }
-	    ha_checksum row_crc= 0;
+            ha_checksum row_crc= 0;
             int error= t->file->ha_rnd_next(t->record[0]);
             if (unlikely(error))
             {
@@ -9780,21 +9780,21 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
                 continue;
               break;
             }
-	    if (t->s->null_bytes)
+            if (t->s->null_bytes)
             {
               /* fix undefined null bits */
               t->record[0][t->s->null_bytes-1] |= null_mask;
               if (!(t->s->db_create_options & HA_OPTION_PACK_RECORD))
                 t->record[0][0] |= 1;
 
-	      row_crc= my_checksum(row_crc, t->record[0], t->s->null_bytes);
+              row_crc= my_checksum(row_crc, t->record[0], t->s->null_bytes);
             }
 
-	    uchar *checksum_start= NULL;
-	    size_t checksum_length= 0;
-	    for (uint i= 0; i < t->s->fields; i++ )
-	    {
-	      Field *f= t->field[i];
+            uchar *checksum_start= NULL;
+            size_t checksum_length= 0;
+            for (uint i= 0; i < t->s->fields; i++ )
+            {
+              Field *f= t->field[i];
 
               if (! thd->variables.old_mode && f->is_real_null(0))
                 continue;
@@ -9841,16 +9841,16 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
                     checksum_length= f->pack_length();
                   }
                   break;
-	      }
-	    }
-	    if (checksum_start)
-	      row_crc= my_checksum(row_crc, checksum_start, checksum_length);
+              }
+            }
+            if (checksum_start)
+              row_crc= my_checksum(row_crc, checksum_start, checksum_length);
 
-	    crc+= row_crc;
-	  }
-	  protocol->store((ulonglong)crc);
+            crc+= row_crc;
+          }
+          protocol->store((ulonglong)crc);
           t->file->ha_rnd_end();
-	}
+        }
       }
       trans_rollback_stmt(thd);
       close_thread_tables(thd);

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -9790,6 +9790,8 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
 	      row_crc= my_checksum(row_crc, t->record[0], t->s->null_bytes);
             }
 
+	    uchar *checksum_start= NULL;
+	    size_t checksum_length= 0;
 	    for (uint i= 0; i < t->s->fields; i++ )
 	    {
 	      Field *f= t->field[i];
@@ -9807,6 +9809,12 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
                 case MYSQL_TYPE_GEOMETRY:
                 case MYSQL_TYPE_BIT:
                 {
+                  if (checksum_start)
+                  {
+                    row_crc= my_checksum(row_crc, checksum_start, checksum_length);
+                    checksum_start= NULL;
+                    checksum_length= 0;
+                  }
                   String tmp;
                   f->val_str(&tmp);
                   row_crc= my_checksum(row_crc, (uchar*) tmp.ptr(),
@@ -9814,10 +9822,29 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
                   break;
                 }
                 default:
-                  row_crc= my_checksum(row_crc, f->ptr, f->pack_length());
+                  if (checksum_start)
+                  {
+                    if (checksum_start + checksum_length == f->ptr)
+                    {
+                      checksum_length+= f->pack_length();
+                    }
+                    else
+                    {
+                      row_crc= my_checksum(row_crc, checksum_start, checksum_length);
+                      checksum_start= NULL;
+                      checksum_length= 0;
+                    }
+                  }
+                  else
+                  {
+                    checksum_start= f->ptr;
+                    checksum_length= f->pack_length();
+                  }
                   break;
 	      }
 	    }
+	    if (checksum_start)
+	      row_crc= my_checksum(row_crc, checksum_start, checksum_length);
 
 	    crc+= row_crc;
 	  }

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -9831,8 +9831,8 @@ bool mysql_checksum_table(THD *thd, TABLE_LIST *tables,
                     else
                     {
                       row_crc= my_checksum(row_crc, checksum_start, checksum_length);
-                      checksum_start= NULL;
-                      checksum_length= 0;
+                      checksum_start= f->ptr;
+                      checksum_length= f->pack_length();
                     }
                   }
                   else


### PR DESCRIPTION
Checksum implementations contain optimizations for calculating
checksums of larger blocks of memory.

This optimization calls my_checksum on a larger block of memory
rather than calling on multiple adjacent memory as its going though
the table columns for each table row.

I submit this under the MCA.