### PR TITLE
MDEV-9857: malloc aligned to CACHE_LINE_SIZE (10.2)

### DIFF
--- a/include/lf.h
+++ b/include/lf.h
@@ -62,7 +62,7 @@ typedef struct {
 } LF_PINBOX;
 
 typedef struct {
-  void * volatile pin[LF_PINBOX_PINS];
+  void * volatile pin[LF_PINBOX_PINS] MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
   LF_PINBOX *pinbox;
   void  **stack_ends_here;
   void  *purgatory;

--- a/include/lf.h
+++ b/include/lf.h
@@ -68,14 +68,6 @@ typedef struct {
   void  *purgatory;
   uint32 purgatory_count;
   uint32 volatile link;
-  /*
-    we want sizeof(LF_PINS) to be CPU_LEVEL1_DCACHE_LINESIZE * 2
-    to avoid false sharing
-  */
-  char pad[CPU_LEVEL1_DCACHE_LINESIZE * 2 - sizeof(uint32) * 2
-                                          - sizeof(LF_PINBOX*)
-                                          - sizeof(void*)
-                                          - sizeof(void*) * (LF_PINBOX_PINS + 1)];
 } LF_PINS;
 
 /* compile-time assert to make sure we have enough pins.  */

--- a/include/my_align_alloc.h
+++ b/include/my_align_alloc.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2000, 2011, Oracle and/or its affiliates. 2016 IBM
+   All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef _my_aligned_alloc_h
+#define _my_aligned_alloc_h
+
+
+#if defined (_MSC_VER)
+#define ALIGNED_ALLOC(S,A) _aligned_malloc((A), (S))
+#elif defined (_ISOC11_SOURCE)
+#define ALIGNED_ALLOC(S,A)  aligned_alloc((A), (S))
+#elif  _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+inline void *XXaligned_alloc(size_t size, size_t align)
+{
+  void *m;
+  errno = posix_memalign(&m, align, size);
+  return errno ? NULL : m;
+}
+#define ALIGNED_ALLOC(S,A)  XXaligned_alloc((S), (A))
+
+#else
+#warn   "No aligned malloc - cache lines may be shared"
+#define ALIGNED_ALLOC(S,A)  malloc(S)
+#endif
+
+#ifdef SAFEMALLOC
+void *sf_malloc(size_t size, myf my_flags);
+void *sf_realloc(void *ptr, size_t size, myf my_flags);
+void sf_free(void *ptr);
+size_t sf_malloc_usable_size(void *ptr, my_bool *is_thread_specific);
+#else
+#define sf_malloc(X,Y)    ALIGNED_ALLOC((X), CPU_LEVEL1_DCACHE_LINESIZE)
+#define sf_realloc(X,Y,Z) realloc((X), (Y))
+#define sf_free(X)      free(X)
+#endif
+
+#endif

--- a/include/my_align_alloc.h
+++ b/include/my_align_alloc.h
@@ -19,6 +19,7 @@
 
 
 #if defined (_MSC_VER)
+#include <malloc.h>
 #define ALIGNED_ALLOC(S,A) _aligned_malloc((A), (S))
 #elif defined (_ISOC11_SOURCE)
 #define ALIGNED_ALLOC(S,A)  aligned_alloc((A), (S))
@@ -32,7 +33,7 @@ inline void *XXaligned_alloc(size_t size, size_t align)
 #define ALIGNED_ALLOC(S,A)  XXaligned_alloc((S), (A))
 
 #else
-#warn   "No aligned malloc - cache lines may be shared"
+#warning   "No aligned malloc - cache lines may be shared"
 #define ALIGNED_ALLOC(S,A)  malloc(S)
 #endif
 

--- a/include/my_global.h
+++ b/include/my_global.h
@@ -1236,11 +1236,10 @@ static inline double rint(double x)
   Provide defaults for the CPU cache line size, if it has not been detected by
   CMake using getconf
 */
-#if !defined(CPU_LEVEL1_DCACHE_LINESIZE) || CPU_LEVEL1_DCACHE_LINESIZE == 0
-  #if CPU_LEVEL1_DCACHE_LINESIZE == 0
-    #undef CPU_LEVEL1_DCACHE_LINESIZE
-  #endif
-
+#if CPU_LEVEL1_DCACHE_LINESIZE == 0
+  #undef CPU_LEVEL1_DCACHE_LINESIZE
+#endif
+#if !defined(CPU_LEVEL1_DCACHE_LINESIZE)
   #if defined(__s390__)
     #define CPU_LEVEL1_DCACHE_LINESIZE 256
   #elif defined(__powerpc__) || defined(__aarch64__)

--- a/mysys/lf_alloc-pin.c
+++ b/mysys/lf_alloc-pin.c
@@ -121,7 +121,6 @@ void lf_pinbox_init(LF_PINBOX *pinbox, uint free_ptr_offset,
                     lf_pinbox_free_func *free_func, void *free_func_arg)
 {
   DBUG_ASSERT(free_ptr_offset % sizeof(void *) == 0);
-  compile_time_assert(sizeof(LF_PINS) == CPU_LEVEL1_DCACHE_LINESIZE * 2);
   lf_dynarray_init(&pinbox->pinarray, sizeof(LF_PINS));
   pinbox->pinstack_top_ver= 0;
   pinbox->pins_in_array= 0;

--- a/mysys/mysys_priv.h
+++ b/mysys/mysys_priv.h
@@ -87,16 +87,7 @@ typedef struct {
 extern int (*_my_b_encr_read)(IO_CACHE *info,uchar *Buffer,size_t Count);
 extern int (*_my_b_encr_write)(IO_CACHE *info,const uchar *Buffer,size_t Count);
 
-#ifdef SAFEMALLOC
-void *sf_malloc(size_t size, myf my_flags);
-void *sf_realloc(void *ptr, size_t size, myf my_flags);
-void sf_free(void *ptr);
-size_t sf_malloc_usable_size(void *ptr, my_bool *is_thread_specific);
-#else
-#define sf_malloc(X,Y)    malloc(X)
-#define sf_realloc(X,Y,Z) realloc(X,Y)
-#define sf_free(X)      free(X)
-#endif
+#include <my_align_alloc.h>
 
 /*
   EDQUOT is used only in 3 C files only in mysys/. If it does not exist on

--- a/mysys/safemalloc.c
+++ b/mysys/safemalloc.c
@@ -115,7 +115,8 @@ void *sf_malloc(size_t size, myf my_flags)
     init_done= 1;
   }
 
-  irem= (struct st_irem *) malloc (sizeof(struct st_irem) + size + 4);
+  irem= (struct st_irem *) ALIGNED_ALLOC (sizeof(struct st_irem) + size + 4,
+                                          CPU_LEVEL1_DCACHE_LINESIZE);
 
   if (!irem)
     return 0;

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -57,11 +57,6 @@ UNIV_INTERN ulint		btr_search_n_succ	= 0;
 UNIV_INTERN ulint		btr_search_n_hash_fail	= 0;
 #endif /* UNIV_SEARCH_PERF_STAT */
 
-/** padding to prevent other memory update
-hotspots from residing on the same memory
-cache line as btr_search_latch */
-UNIV_INTERN byte		btr_sea_pad1[CACHE_LINE_SIZE];
-
 /** The latch protecting the adaptive search system: this latch protects the
 (1) positions of records on those pages where a hash index has been built.
 NOTE: It does not protect values of non-ordering fields within a record from
@@ -70,14 +65,11 @@ indexes. */
 
 /* We will allocate the latch from dynamic memory to get it to the
 same DRAM page as other hotspot semaphores */
-UNIV_INTERN rw_lock_t*		btr_search_latch_temp;
-
-/** padding to prevent other memory update hotspots from residing on
-the same memory cache line */
-UNIV_INTERN byte		btr_sea_pad2[CACHE_LINE_SIZE];
+UNIV_INTERN rw_lock_t*		btr_search_latch_temp
+					 MY_ALIGNED(CACHE_LINE_SIZE);
 
 /** The adaptive hash index */
-UNIV_INTERN btr_search_sys_t*	btr_search_sys;
+UNIV_INTERN btr_search_sys_t*	btr_search_sys MY_ALIGNED(CACHE_LINE_SIZE);
 
 #ifdef UNIV_PFS_RWLOCK
 /* Key to register btr_search_sys with performance schema */

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -784,10 +784,8 @@ struct log_group_t{
 
 /** Redo log buffer */
 struct log_t{
-	byte		pad[CACHE_LINE_SIZE];	/*!< padding to prevent other memory
-					update hotspots from residing on the
-					same memory cache line */
-	lsn_t		lsn;		/*!< log sequence number */
+	lsn_t		lsn MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< log sequence number */
 	ulint		buf_free;	/*!< first free offset within the log
 					buffer */
 #ifndef UNIV_HOTBACKUP

--- a/storage/innobase/include/ut0rbt.h
+++ b/storage/innobase/include/ut0rbt.h
@@ -34,7 +34,7 @@ Created 2007-03-20 Sunny Bains
 #include <string.h>
 #include <assert.h>
 
-#define	ut_malloc	malloc
+#define	ut_malloc(X)	ALIGNED_ALLOC(X, CACHE_LINE_SIZE)
 #define	ut_free		free
 #define	ulint		unsigned long
 #define	ut_a(c)		assert(c)

--- a/storage/innobase/srv/srv0conc.cc
+++ b/storage/innobase/srv/srv0conc.cc
@@ -109,14 +109,12 @@ UNIV_INTERN mysql_pfs_key_t	srv_conc_mutex_key;
 
 /** Variables tracking the active and waiting threads. */
 struct srv_conc_t {
-	char		pad[CACHE_LINE_SIZE  - (sizeof(ulint) + sizeof(lint))];
-
 	/** Number of transactions that have declared_to_be_inside_innodb set.
 	It used to be a non-error for this value to drop below zero temporarily.
 	This is no longer true. We'll, however, keep the lint datatype to add
 	assertions to catch any corner cases that we may have missed. */
 
-	volatile lint	n_active;
+	volatile lint	n_active MY_ALIGNED(CACHE_LINE_SIZE);
 
 	/** Number of OS threads waiting in the FIFO for permission to
 	enter InnoDB */

--- a/storage/innobase/ut/ut0mem.cc
+++ b/storage/innobase/ut/ut0mem.cc
@@ -32,7 +32,7 @@ Created 5/11/1994 Heikki Tuuri
 #ifndef UNIV_HOTBACKUP
 # include "os0thread.h"
 # include "srv0srv.h"
-
+# include <my_align_alloc.h>
 #include <stdlib.h>
 
 /** The total amount of memory currently allocated from the operating
@@ -114,7 +114,7 @@ ut_malloc_low(
 retry:
 	os_fast_mutex_lock(&ut_list_mutex);
 
-	ret = malloc(n + sizeof(ut_mem_block_t));
+	ret = ALIGNED_ALLOC(n + sizeof(ut_mem_block_t), CACHE_LINE_SIZE);
 
 	if (ret == NULL && retry_count < 60) {
 		if (retry_count == 0) {

--- a/storage/perfschema/pfs_digest.cc
+++ b/storage/perfschema/pfs_digest.cc
@@ -47,7 +47,7 @@ bool flag_statements_digest= true;
   Current index in Stat array where new record is to be inserted.
   index 0 is reserved for "all else" case when entire array is full.
 */
-volatile uint32 digest_index;
+PFS_ALIGNED volatile uint32 digest_index;
 bool digest_full= false;
 
 LF_HASH digest_hash;

--- a/storage/perfschema/pfs_events_stages.cc
+++ b/storage/perfschema/pfs_events_stages.cc
@@ -41,7 +41,7 @@ bool flag_events_stages_history_long= false;
 /** True if EVENTS_STAGES_HISTORY_LONG circular buffer is full. */
 bool events_stages_history_long_full= false;
 /** Index in EVENTS_STAGES_HISTORY_LONG circular buffer. */
-volatile uint32 events_stages_history_long_index= 0;
+PFS_ALIGNED volatile uint32 events_stages_history_long_index= 0;
 /** EVENTS_STAGES_HISTORY_LONG circular buffer. */
 PFS_events_stages *events_stages_history_long_array= NULL;
 

--- a/storage/perfschema/pfs_events_statements.cc
+++ b/storage/perfschema/pfs_events_statements.cc
@@ -41,7 +41,7 @@ bool flag_events_statements_history_long= false;
 /** True if EVENTS_STATEMENTS_HISTORY_LONG circular buffer is full. */
 bool events_statements_history_long_full= false;
 /** Index in EVENTS_STATEMENTS_HISTORY_LONG circular buffer. */
-volatile uint32 events_statements_history_long_index= 0;
+PFS_ALIGNED volatile uint32 events_statements_history_long_index= 0;
 /** EVENTS_STATEMENTS_HISTORY_LONG circular buffer. */
 PFS_events_statements *events_statements_history_long_array= NULL;
 static unsigned char *h_long_stmts_digest_token_array= NULL;

--- a/storage/perfschema/pfs_events_waits.cc
+++ b/storage/perfschema/pfs_events_waits.cc
@@ -45,7 +45,7 @@ bool flag_thread_instrumentation= false;
 /** True if EVENTS_WAITS_HISTORY_LONG circular buffer is full. */
 bool events_waits_history_long_full= false;
 /** Index in EVENTS_WAITS_HISTORY_LONG circular buffer. */
-volatile uint32 events_waits_history_long_index= 0;
+PFS_ALIGNED volatile uint32 events_waits_history_long_index= 0;
 /** EVENTS_WAITS_HISTORY_LONG circular buffer. */
 PFS_events_waits *events_waits_history_long_array= NULL;
 

--- a/storage/perfschema/pfs_lock.h
+++ b/storage/perfschema/pfs_lock.h
@@ -21,6 +21,7 @@
   Performance schema internal locks (declarations).
 */
 
+#include "pfs_global.h"
 #include "pfs_atomic.h"
 
 /**
@@ -79,7 +80,7 @@ struct pfs_lock
     The version number is stored in the high 30 bits.
     The state is stored in the low 2 bits.
   */
-  volatile uint32 m_version_state;
+  PFS_ALIGNED volatile uint32 m_version_state;
 
   /** Returns true if the record is free. */
   bool is_free(void)

--- a/storage/xtradb/btr/btr0sea.cc
+++ b/storage/xtradb/btr/btr0sea.cc
@@ -68,11 +68,11 @@ being updated in-place! We can use fact (1) to perform unique searches to
 indexes. */
 
 UNIV_INTERN prio_rw_lock_t*	btr_search_latch_arr
-					MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
+					MY_ALIGNED(CACHE_LINE_SIZE);
 
 /** The adaptive hash index */
 UNIV_INTERN btr_search_sys_t*	btr_search_sys
-					MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
+					MY_ALIGNED(CACHE_LINE_SIZE);
 
 #ifdef UNIV_PFS_RWLOCK
 /* Key to register btr_search_sys with performance schema */

--- a/storage/xtradb/btr/btr0sea.cc
+++ b/storage/xtradb/btr/btr0sea.cc
@@ -60,11 +60,6 @@ UNIV_INTERN ulint		btr_search_n_succ	= 0;
 UNIV_INTERN ulint		btr_search_n_hash_fail	= 0;
 #endif /* UNIV_SEARCH_PERF_STAT */
 
-/** padding to prevent other memory update
-hotspots from residing on the same memory
-cache line as btr_search_latch */
-UNIV_INTERN byte		btr_sea_pad1[CACHE_LINE_SIZE];
-
 /** Array of latches protecting individual AHI partitions. The latches
 protect: (1) positions of records on those pages where a hash index from the
 corresponding AHI partition has been built.
@@ -72,14 +67,12 @@ NOTE: They do not protect values of non-ordering fields within a record from
 being updated in-place! We can use fact (1) to perform unique searches to
 indexes. */
 
-UNIV_INTERN prio_rw_lock_t*	btr_search_latch_arr;
-
-/** padding to prevent other memory update hotspots from residing on
-the same memory cache line */
-UNIV_INTERN byte		btr_sea_pad2[CACHE_LINE_SIZE];
+UNIV_INTERN prio_rw_lock_t*	btr_search_latch_arr
+					MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
 
 /** The adaptive hash index */
-UNIV_INTERN btr_search_sys_t*	btr_search_sys;
+UNIV_INTERN btr_search_sys_t*	btr_search_sys
+					MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
 
 #ifdef UNIV_PFS_RWLOCK
 /* Key to register btr_search_sys with performance schema */

--- a/storage/xtradb/include/log0log.h
+++ b/storage/xtradb/include/log0log.h
@@ -857,10 +857,8 @@ struct log_group_t{
 
 /** Redo log buffer */
 struct log_t{
-	byte		pad[CACHE_LINE_SIZE];	/*!< padding to prevent other memory
-					update hotspots from residing on the
-					same memory cache line */
-	lsn_t		lsn;		/*!< log sequence number */
+	lsn_t		lsn MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< log sequence number */
 	ulint		buf_free;	/*!< first free offset within the log
 					buffer */
 #ifndef UNIV_HOTBACKUP

--- a/storage/xtradb/include/trx0sys.h
+++ b/storage/xtradb/include/trx0sys.h
@@ -674,38 +674,32 @@ struct trx_sys_t{
 	trx_id_t	max_trx_id;	/*!< The smallest number not yet
 					assigned as a transaction id or
 					transaction number */
-	char		pad1[CACHE_LINE_SIZE];	/*!< Ensure max_trx_id does not share
-					cache line with other fields. */
-	trx_id_t*	descriptors;	/*!< Array of trx descriptors */
+	trx_id_t*	descriptors MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< Array of trx descriptors */
 	ulint		descr_n_max;	/*!< The current size of the descriptors
 					array. */
-	char		pad2[CACHE_LINE_SIZE];	/*!< Ensure static descriptor fields
-					do not share cache lines with
-					descr_n_used */
-	ulint		descr_n_used;	/*!< Number of used elements in the
+	ulint		descr_n_used MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< Number of used elements in the
 					descriptors array. */
-	char		pad3[CACHE_LINE_SIZE];	/*!< Ensure descriptors do not share
-					cache line with other fields */
+	trx_list_t	rw_trx_list MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< List of active and committed in
+					memory read-write transactions, sorted
+					on trx id, biggest first. Recovered
+					transactions are always on this list. */
 #ifdef UNIV_DEBUG
 	trx_id_t	rw_max_trx_id;	/*!< Max trx id of read-write transactions
 					which exist or existed */
 #endif
-	trx_list_t	rw_trx_list;	/*!< List of active and committed in
-					memory read-write transactions, sorted
-					on trx id, biggest first. Recovered
-					transactions are always on this list. */
-	char		pad4[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_list_t	ro_trx_list;	/*!< List of active and committed in
+	trx_list_t	ro_trx_list MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< List of active and committed in
 					memory read-only transactions, sorted
 					on trx id, biggest first. NOTE:
 					The order for read-only transactions
 					is not necessary. We should exploit
 					this and increase concurrency during
 					add/remove. */
-	char		pad5[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_list_t	mysql_trx_list;	/*!< List of transactions created
+	trx_list_t	mysql_trx_list MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< List of transactions created
 					for MySQL. All transactions on
 					ro_trx_list are on mysql_trx_list. The
 					rw_trx_list can contain system
@@ -717,16 +711,12 @@ struct trx_sys_t{
 					mysql_trx_list may additionally contain
 					transactions that have not yet been
 					started in InnoDB. */
-	char		pad6[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_list_t	trx_serial_list;
+	trx_list_t	trx_serial_list MY_ALIGNED(CACHE_LINE_SIZE);
 					/*!< trx->no ordered List of
 					transactions in either TRX_PREPARED or
 					TRX_ACTIVE which have already been
 					assigned a serialization number */
-	char		pad7[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_rseg_t*	const rseg_array[TRX_SYS_N_RSEGS];
+	trx_rseg_t*	const rseg_array[TRX_SYS_N_RSEGS] MY_ALIGNED(CACHE_LINE_SIZE);
 					/*!< Pointer array to rollback
 					segments; NULL if slot not in use;
 					created and destroyed in

--- a/storage/xtradb/include/ut0rbt.h
+++ b/storage/xtradb/include/ut0rbt.h
@@ -34,7 +34,7 @@ Created 2007-03-20 Sunny Bains
 #include <string.h>
 #include <assert.h>
 
-#define	ut_malloc	malloc
+#define	ut_malloc(X)	ALIGNED_ALLOC(X, CACHE_LINE_SIZE)
 #define	ut_free		free
 #define	ulint		unsigned long
 #define	ut_a(c)		assert(c)

--- a/storage/xtradb/srv/srv0conc.cc
+++ b/storage/xtradb/srv/srv0conc.cc
@@ -110,14 +110,12 @@ UNIV_INTERN mysql_pfs_key_t	srv_conc_mutex_key;
 
 /** Variables tracking the active and waiting threads. */
 struct srv_conc_t {
-	char		pad[CACHE_LINE_SIZE  - (sizeof(ulint) + sizeof(lint))];
-
 	/** Number of transactions that have declared_to_be_inside_innodb set.
 	It used to be a non-error for this value to drop below zero temporarily.
 	This is no longer true. We'll, however, keep the lint datatype to add
 	assertions to catch any corner cases that we may have missed. */
 
-	volatile lint	n_active;
+	volatile lint	n_active MY_ALIGNED(CACHE_LINE_SIZE);
 
 	/** Number of OS threads waiting in the FIFO for permission to
 	enter InnoDB */

--- a/storage/xtradb/ut/ut0mem.cc
+++ b/storage/xtradb/ut/ut0mem.cc
@@ -32,7 +32,7 @@ Created 5/11/1994 Heikki Tuuri
 #ifndef UNIV_HOTBACKUP
 # include "os0thread.h"
 # include "srv0srv.h"
-
+# include <my_align_alloc.h>
 #include <stdlib.h>
 
 /** The total amount of memory currently allocated from the operating
@@ -114,7 +114,7 @@ ut_malloc_low(
 retry:
 	os_fast_mutex_lock(&ut_list_mutex);
 
-	ret = malloc(n + sizeof(ut_mem_block_t));
+	ret = ALIGNED_ALLOC(n + sizeof(ut_mem_block_t), CACHE_LINE_SIZE);
 
 	if (ret == NULL && retry_count < 60) {
 		if (retry_count == 0) {


### PR DESCRIPTION
By using alignment and and aligned malloc we avoid avoid false sharing.

Though we use the aligned malloc everywhere (in innodb/xtradb via ut_malloc), the code is already pretty light on the times it allocates.

Builds upon previous cache size alignment work.

I submit this under the MCA. 

FYI: @svoj , @akopytov , @janlindstrom 