### PR TITLE
MDEV-9403 - Use hostname instead of IP in donor's socat

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -34,6 +34,7 @@ ssystag=""
 XTRABACKUP_PID=""
 SST_PORT=""
 REMOTEIP=""
+REMOTEHOST=""
 tcert=""
 tpem=""
 tkey=""
@@ -208,7 +209,7 @@ get_transfer()
                 tcmd="socat -u openssl-listen:${TSST_PORT},reuseaddr,cert=${tpem},cafile=${tcert}${sockopt} stdio"
             else
                 wsrep_log_info "Encrypting with cert=${tpem}, cafile=${tcert}"
-                tcmd="socat -u stdio openssl-connect:${REMOTEIP}:${TSST_PORT},cert=${tpem},cafile=${tcert}${sockopt}"
+                tcmd="socat -u stdio openssl-connect:${REMOTEHOST}:${TSST_PORT},cert=${tpem},cafile=${tcert}${sockopt}"
             fi
         elif [[ $encrypt -eq 3 ]];then
             wsrep_log_info "Using openssl based encryption with socat: with key and crt"
@@ -231,7 +232,7 @@ get_transfer()
                     tcmd="socat -u stdio openssl-connect:${REMOTEIP}:${TSST_PORT},cert=${tpem},key=${tkey},verify=0${sockopt}"
                 else
                     wsrep_log_info "Encrypting with cert=${tpem}, key=${tkey}, cafile=${tcert}"
-                    tcmd="socat -u stdio openssl-connect:${REMOTEIP}:${TSST_PORT},cert=${tpem},key=${tkey},cafile=${tcert}${sockopt}"
+                    tcmd="socat -u stdio openssl-connect:${REMOTEHOST}:${TSST_PORT},cert=${tpem},key=${tkey},cafile=${tcert}${sockopt}"
                 fi
             fi
 
@@ -495,6 +496,10 @@ setup_ports()
     if [[ "$WSREP_SST_OPT_ROLE"  == "donor" ]];then
         SST_PORT=$(echo $WSREP_SST_OPT_ADDR | awk -F '[:/]' '{ print $2 }')
         REMOTEIP=$(echo $WSREP_SST_OPT_ADDR | awk -F ':' '{ print $1 }')
+        REMOTEHOST=$(getent hosts $REMOTEIP | awk '{ print $2 }')
+        if [[ -z $REMOTEHOST ]];then
+            REMOTEHOST=$REMOTEIP
+        fi
         lsn=$(echo $WSREP_SST_OPT_ADDR | awk -F '[:/]' '{ print $4 }')
         sst_ver=$(echo $WSREP_SST_OPT_ADDR | awk -F '[:/]' '{ print $5 }')
     else


### PR DESCRIPTION
Using IP address in donor's socat with TLS/SSL and certificate which doesn't contain IP address in CN or SubjectAltName causes transfer to fail with message: 'socat[5799] E certificate is valid but its commonName does not match hostname'. This patch tries to reverse resolve IP address to hostname and use it for transfer. If reverse resolution fails, IP address is still used as fall-back, so proper A/AAAA and PTR records are important, but not mandatory.
Please, review and consider. Certain certificates cannot contain IP addresses, e.g. FreeIPA's Dogtag doesn't allow it, so in my case I would need to use self-signed certificates instead, use verify=0 with socat or don't use TLS/SSL at all. Issue is mentioned in https://jira.mariadb.org/browse/MDEV-9403