### PR TITLE
MDEV-10194: use aligned malloc to CACHE_LINE_SIZE globally (10.2)

### DIFF
--- a/cmake/cpu_info.cmake
+++ b/cmake/cpu_info.cmake
@@ -15,25 +15,51 @@
 
 # Symbols with information about the CPU.
 
-IF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  FIND_PROGRAM(SYSCTL sysctl)
-  MARK_AS_ADVANCED(SYSCTL)
+IF(NOT CPU_LEVEL1_DCACHE_LINESIZE)
+  IF(CMAKE_CROSSCOMPILING)
+   MESSAGE(FATAL_ERROR
+   "CPU_LEVEL1_DCACHE_LINESIZE is not defined.  Please specify -DCPU_LEVEL1_DCACHE_LINESIZE "
+   "to the size of the level 1 data cache for the destination architecture.")
+  ELSE()
+    IF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+      FIND_PROGRAM(SYSCTL sysctl)
+      MARK_AS_ADVANCED(SYSCTL)
 
-  IF(SYSCTL)
-    EXECUTE_PROCESS(
-      COMMAND ${SYSCTL} -n hw.cachelinesize
-      OUTPUT_VARIABLE CPU_LEVEL1_DCACHE_LINESIZE
-      )
+      IF(SYSCTL)
+        EXECUTE_PROCESS(
+          COMMAND ${SYSCTL} -n hw.cachelinesize
+          OUTPUT_VARIABLE CPU_LEVEL1_DCACHE_LINESIZE
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+      ENDIF()
+
+    ELSE()
+      FIND_PROGRAM(GETCONF getconf)
+      MARK_AS_ADVANCED(GETCONF)
+
+      IF(GETCONF)
+        EXECUTE_PROCESS(
+          COMMAND ${GETCONF} LEVEL1_DCACHE_LINESIZE
+          OUTPUT_VARIABLE CPU_LEVEL1_DCACHE_LINESIZE
+          OUTPUT_STRIP_TRAILING_WHITESPACE
+          )
+      ENDIF()
+    ENDIF()
   ENDIF()
 
-ELSE()
-  FIND_PROGRAM(GETCONF getconf)
-  MARK_AS_ADVANCED(GETCONF)
-
-  IF(GETCONF)
-    EXECUTE_PROCESS(
-      COMMAND ${GETCONF} LEVEL1_DCACHE_LINESIZE
-      OUTPUT_VARIABLE CPU_LEVEL1_DCACHE_LINESIZE
-      )
+  IF(CPU_LEVEL1_DCACHE_LINESIZE)
+    SET(CPU_LEVEL1_DCACHE_LINESIZE "${CPU_LEVEL1_DCACHE_LINESIZE}" CACHE INTERNAL "CPU level 1 Data cache line size")
+    MESSAGE(STATUS "Cache line size discovered to be ${CPU_LEVEL1_DCACHE_LINESIZE}")
+  ELSE()
+    IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64(le)?")
+      # the getconf results for powerpc where added quite recently in glibc
+      # 2017-06-09 in commit cdfbe5037f2f67bf5f560b73732b69d0fabe2314 so the
+      # result will be 0 with older glibcs
+      SET(CPU_LEVEL1_DCACHE_LINESIZE "128" CACHE INTERNAL "CPU level 1 Data cache line size")
+    ELSE()
+      SET(CPU_LEVEL1_DCACHE_LINESIZE "64" CACHE INTERNAL "CPU level 1 Data cache line size")
+    ENDIF()
+    MESSAGE(WARNING "Cache line size could not be discovered so assumed to be ${CPU_LEVEL1_DCACHE_LINESIZE}")
   ENDIF()
+
 ENDIF()

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -270,6 +270,9 @@
 /* this means WITH_VALGRIND - we change some code paths for valgrind */
 #cmakedefine HAVE_valgrind 1
 
+/* detected cache size */
+#cmakedefine CPU_LEVEL1_DCACHE_LINESIZE @CPU_LEVEL1_DCACHE_LINESIZE@
+
 /* Types we may use */
 #ifdef __APPLE__
   /*

--- a/include/lf.h
+++ b/include/lf.h
@@ -62,14 +62,12 @@ typedef struct {
 } LF_PINBOX;
 
 typedef struct {
-  void * volatile pin[LF_PINBOX_PINS];
+  void * volatile pin[LF_PINBOX_PINS] MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
   LF_PINBOX *pinbox;
   void  **stack_ends_here;
   void  *purgatory;
   uint32 purgatory_count;
   uint32 volatile link;
-  /* avoid false sharing */
-  char pad[CPU_LEVEL1_DCACHE_LINESIZE];
 } LF_PINS;
 
 /* compile-time assert to make sure we have enough pins.  */

--- a/include/my_align_alloc.h
+++ b/include/my_align_alloc.h
@@ -37,13 +37,6 @@ inline void *posix_memaligned_alloc(size_t size, size_t align)
 #define ALIGNED_ALLOC(S,A)  malloc(S)
 #endif
 
-inline void *aligned_calloc(size_t nmemb, size_t size)
-{
-  void *ptr = ALIGNED_ALLOC(nmemb * size, CPU_LEVEL1_DCACHE_LINESIZE);
-  bzero(ptr, nmemb * size);
-  return ptr;
-}
-
 #ifdef SAFEMALLOC
 void *sf_malloc(size_t size, myf my_flags);
 void *sf_realloc(void *ptr, size_t size, myf my_flags);

--- a/include/my_align_alloc.h
+++ b/include/my_align_alloc.h
@@ -1,0 +1,58 @@
+/* Copyright (c) 2000, 2011, Oracle and/or its affiliates. 2016 IBM
+   All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef MY_ALIGN_ALLOC_INCLUDED
+#define MY_ALIGN_ALLOC_INCLUDED
+
+
+#if defined (_MSC_VER)
+#include <malloc.h>
+#define ALIGNED_ALLOC(S,A) _aligned_malloc((A), (S))
+#elif defined (_ISOC11_SOURCE)
+#define ALIGNED_ALLOC(S,A)  aligned_alloc((A), (S))
+#elif  _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600
+inline void *posix_memaligned_alloc(size_t size, size_t align)
+{
+  void *m;
+  errno = posix_memalign(&m, align, size);
+  return errno ? NULL : m;
+}
+#define ALIGNED_ALLOC(S,A)  posix_memaligned_alloc((S), (A))
+
+#else
+#warning   "No aligned malloc - cache lines may be shared"
+#define ALIGNED_ALLOC(S,A)  malloc(S)
+#endif
+
+inline void *aligned_calloc(size_t nmemb, size_t size)
+{
+  void *ptr = ALIGNED_ALLOC(nmemb * size, CPU_LEVEL1_DCACHE_LINESIZE);
+  bzero(ptr, nmemb * size);
+  return ptr;
+}
+
+#ifdef SAFEMALLOC
+void *sf_malloc(size_t size, myf my_flags);
+void *sf_realloc(void *ptr, size_t size, myf my_flags);
+void sf_free(void *ptr);
+size_t sf_malloc_usable_size(void *ptr, my_bool *is_thread_specific);
+#else
+#define sf_malloc(X,Y)    ALIGNED_ALLOC((X), CPU_LEVEL1_DCACHE_LINESIZE)
+#define sf_realloc(X,Y,Z) realloc((X), (Y))
+#define sf_free(X)      free(X)
+#endif
+
+#endif

--- a/mysys/mysys_priv.h
+++ b/mysys/mysys_priv.h
@@ -87,16 +87,7 @@ typedef struct {
 extern int (*_my_b_encr_read)(IO_CACHE *info,uchar *Buffer,size_t Count);
 extern int (*_my_b_encr_write)(IO_CACHE *info,const uchar *Buffer,size_t Count);
 
-#ifdef SAFEMALLOC
-void *sf_malloc(size_t size, myf my_flags);
-void *sf_realloc(void *ptr, size_t size, myf my_flags);
-void sf_free(void *ptr);
-size_t sf_malloc_usable_size(void *ptr, my_bool *is_thread_specific);
-#else
-#define sf_malloc(X,Y)    malloc(X)
-#define sf_realloc(X,Y,Z) realloc(X,Y)
-#define sf_free(X)      free(X)
-#endif
+#include <my_align_alloc.h>
 
 /*
   EDQUOT is used only in 3 C files only in mysys/. If it does not exist on

--- a/mysys/safemalloc.c
+++ b/mysys/safemalloc.c
@@ -115,7 +115,8 @@ void *sf_malloc(size_t size, myf my_flags)
     init_done= 1;
   }
 
-  irem= (struct st_irem *) malloc (sizeof(struct st_irem) + size + 4);
+  irem= (struct st_irem *) ALIGNED_ALLOC (sizeof(struct st_irem) + size + 4,
+                                          CPU_LEVEL1_DCACHE_LINESIZE);
 
   if (!irem)
     return 0;

--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -123,7 +123,8 @@ struct Table_cache_instance
     records, Share_free_tables::List (TABLE::prev and TABLE::next),
     TABLE::in_use.
   */
-  mysql_mutex_t LOCK_table_cache;
+  /** Avoid false sharing between instances */
+  mysql_mutex_t LOCK_table_cache MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
   I_P_List <TABLE, I_P_List_adapter<TABLE, &TABLE::global_free_next,
                                     &TABLE::global_free_prev>,
             I_P_List_null_counter, I_P_List_fast_push_back<TABLE> >
@@ -131,8 +132,6 @@ struct Table_cache_instance
   ulong records;
   uint mutex_waits;
   uint mutex_nowaits;
-  /** Avoid false sharing between instances */
-  char pad[CPU_LEVEL1_DCACHE_LINESIZE];
 
   Table_cache_instance(): records(0), mutex_waits(0), mutex_nowaits(0)
   {

--- a/sql/table_cache.h
+++ b/sql/table_cache.h
@@ -20,10 +20,10 @@
 
 struct Share_free_tables
 {
-  typedef I_P_List <TABLE, TABLE_share> List;
+  /** MY_ALIGNED - Avoid false sharing between instances */
+  typedef I_P_List <TABLE, TABLE_share> List
+    MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
   List list;
-  /** Avoid false sharing between instances */
-  char pad[CPU_LEVEL1_DCACHE_LINESIZE];
 };
 
 
@@ -51,9 +51,8 @@ struct TDC_element
     Doubly-linked (back-linked) lists of used and unused TABLE objects
     for this share.
   */
-  All_share_tables_list all_tables;
+  All_share_tables_list all_tables MY_ALIGNED(CPU_LEVEL1_DCACHE_LINESIZE);
   /** Avoid false sharing between TDC_element and free_tables */
-  char pad[CPU_LEVEL1_DCACHE_LINESIZE];
   Share_free_tables free_tables[1];
 };
 

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -57,25 +57,16 @@ ulint		btr_search_n_succ	= 0;
 ulint		btr_search_n_hash_fail	= 0;
 #endif /* UNIV_SEARCH_PERF_STAT */
 
-/** padding to prevent other memory update
-hotspots from residing on the same memory
-cache line as btr_search_latches */
-UNIV_INTERN byte		btr_sea_pad1[CACHE_LINE_SIZE];
-
 /** The latches protecting the adaptive search system: this latches protects the
 (1) positions of records on those pages where a hash index has been built.
 NOTE: It does not protect values of non-ordering fields within a record from
 being updated in-place! We can use fact (1) to perform unique searches to
 indexes. We will allocate the latches from dynamic memory to get it to the
 same DRAM page as other hotspot semaphores */
-rw_lock_t**	btr_search_latches;
-
-/** padding to prevent other memory update hotspots from residing on
-the same memory cache line */
-UNIV_INTERN byte		btr_sea_pad2[CACHE_LINE_SIZE];
+rw_lock_t**	btr_search_latches MY_ALIGNED(CACHE_LINE_SIZE);
 
 /** The adaptive hash index */
-btr_search_sys_t*	btr_search_sys;
+btr_search_sys_t*	btr_search_sys MY_ALIGNED(CACHE_LINE_SIZE);
 
 /** If the number of records on the page divided by this parameter
 would have been successfully accessed using a hash index, the index

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -579,21 +579,17 @@ struct log_group_t{
 
 /** Redo log buffer */
 struct log_t{
-	char		pad1[CACHE_LINE_SIZE];
-					/*!< Padding to prevent other memory
-					update hotspots from residing on the
-					same memory cache line */
-	lsn_t		lsn;		/*!< log sequence number */
+	lsn_t		lsn MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< log sequence number */
 	ulint		buf_free;	/*!< first free offset within the log
 					buffer in use */
-
-	char		pad2[CACHE_LINE_SIZE];/*!< Padding */
-	LogSysMutex	mutex;		/*!< mutex protecting the log */
-	char		pad3[CACHE_LINE_SIZE]; /*!< Padding */
-	LogSysMutex	write_mutex;	/*!< mutex protecting writing to log
+	LogSysMutex	mutex MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< mutex protecting the log */
+	LogSysMutex	write_mutex MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< mutex protecting writing to log
 					file and accessing to log_group_t */
-	char		pad4[CACHE_LINE_SIZE];/*!< Padding */
-	FlushOrderMutex	log_flush_order_mutex;/*!< mutex to serialize access to
+	FlushOrderMutex	log_flush_order_mutex MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< mutex to serialize access to
 					the flush list when we are putting
 					dirty blocks in the list. The idea
 					behind this mutex is to be able

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -883,6 +883,13 @@ ut_delete_array(
 
 #define UT_DELETE_ARRAY(ptr)		::delete[] ptr
 
+inline void *aligned_calloc(size_t nmemb, size_t size)
+{
+  void *ptr = ALIGNED_ALLOC(nmemb * size, CPU_LEVEL1_DCACHE_LINESIZE);
+  bzero(ptr, nmemb * size);
+  return ptr;
+}
+
 #define ut_malloc(n_bytes, key)		ALIGNED_ALLOC(n_bytes, CPU_LEVEL1_DCACHE_LINESIZE)
 
 #define ut_zalloc(n_bytes, key)		::aligned_calloc(1, n_bytes)

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -126,6 +126,8 @@ InnoDB:
 
 #include <stddef.h>
 #include <stdlib.h> /* malloc() */
+#include <my_align_alloc.h>
+
 #include <string.h> /* strlen(), strrchr(), strncmp() */
 
 #include "my_global.h" /* needed for headers from mysql/psi/ */
@@ -329,10 +331,9 @@ public:
 
 		for (size_t retries = 1; ; retries++) {
 
-			if (set_to_zero) {
-				ptr = calloc(1, total_bytes);
-			} else {
-				ptr = malloc(total_bytes);
+			ptr = ALIGNED_ALLOC(total_bytes, CPU_LEVEL1_DCACHE_LINESIZE);
+			if (set_to_zero && ptr) {
+				bzero(ptr, total_bytes);
 			}
 
 			if (ptr != NULL || retries >= alloc_max_retries) {
@@ -882,15 +883,15 @@ ut_delete_array(
 
 #define UT_DELETE_ARRAY(ptr)		::delete[] ptr
 
-#define ut_malloc(n_bytes, key)		::malloc(n_bytes)
+#define ut_malloc(n_bytes, key)		ALIGNED_ALLOC(n_bytes, CPU_LEVEL1_DCACHE_LINESIZE)
 
-#define ut_zalloc(n_bytes, key)		::calloc(1, n_bytes)
+#define ut_zalloc(n_bytes, key)		::aligned_calloc(1, n_bytes)
 
-#define ut_malloc_nokey(n_bytes)	::malloc(n_bytes)
+#define ut_malloc_nokey(n_bytes)	ALIGNED_ALLOC(n_bytes, CPU_LEVEL1_DCACHE_LINESIZE)
 
-#define ut_zalloc_nokey(n_bytes)	::calloc(1, n_bytes)
+#define ut_zalloc_nokey(n_bytes)	::aligned_calloc(1, n_bytes)
 
-#define ut_zalloc_nokey_nofatal(n_bytes)	::calloc(1, n_bytes)
+#define ut_zalloc_nokey_nofatal(n_bytes)	::aligned_calloc(1, n_bytes)
 
 #define ut_realloc(ptr, n_bytes)	::realloc(ptr, n_bytes)
 

--- a/storage/innobase/include/ut0rbt.h
+++ b/storage/innobase/include/ut0rbt.h
@@ -34,7 +34,7 @@ Created 2007-03-20 Sunny Bains
 #include <string.h>
 #include <assert.h>
 
-#define	ut_malloc	malloc
+#define	ut_malloc(X)	ALIGNED_ALLOC(X, CACHE_LINE_SIZE)
 #define	ut_free		free
 #define	ulint		unsigned long
 #define	ut_a(c)		assert(c)

--- a/storage/innobase/srv/srv0conc.cc
+++ b/storage/innobase/srv/srv0conc.cc
@@ -71,14 +71,12 @@ ulong	srv_thread_concurrency	= 0;
 
 /** Variables tracking the active and waiting threads. */
 struct srv_conc_t {
-	char		pad[CACHE_LINE_SIZE  - (sizeof(ulint) + sizeof(lint))];
-
 	/** Number of transactions that have declared_to_be_inside_innodb set.
 	It used to be a non-error for this value to drop below zero temporarily.
 	This is no longer true. We'll, however, keep the lint datatype to add
 	assertions to catch any corner cases that we may have missed. */
 
-	volatile lint	n_active;
+	volatile lint	n_active MY_ALIGNED(CACHE_LINE_SIZE);
 
 	/** Number of OS threads waiting in the FIFO for permission to
 	enter InnoDB */

--- a/storage/perfschema/pfs_events_stages.cc
+++ b/storage/perfschema/pfs_events_stages.cc
@@ -41,7 +41,7 @@ bool flag_events_stages_history_long= false;
 /** True if EVENTS_STAGES_HISTORY_LONG circular buffer is full. */
 bool events_stages_history_long_full= false;
 /** Index in EVENTS_STAGES_HISTORY_LONG circular buffer. */
-volatile uint32 events_stages_history_long_index= 0;
+PFS_ALIGNED volatile uint32 events_stages_history_long_index= 0;
 /** EVENTS_STAGES_HISTORY_LONG circular buffer. */
 PFS_events_stages *events_stages_history_long_array= NULL;
 

--- a/storage/perfschema/pfs_events_statements.cc
+++ b/storage/perfschema/pfs_events_statements.cc
@@ -41,7 +41,7 @@ bool flag_events_statements_history_long= false;
 /** True if EVENTS_STATEMENTS_HISTORY_LONG circular buffer is full. */
 bool events_statements_history_long_full= false;
 /** Index in EVENTS_STATEMENTS_HISTORY_LONG circular buffer. */
-volatile uint32 events_statements_history_long_index= 0;
+PFS_ALIGNED volatile uint32 events_statements_history_long_index= 0;
 /** EVENTS_STATEMENTS_HISTORY_LONG circular buffer. */
 PFS_events_statements *events_statements_history_long_array= NULL;
 static unsigned char *h_long_stmts_digest_token_array= NULL;

--- a/storage/perfschema/pfs_events_waits.cc
+++ b/storage/perfschema/pfs_events_waits.cc
@@ -45,7 +45,7 @@ bool flag_thread_instrumentation= false;
 /** True if EVENTS_WAITS_HISTORY_LONG circular buffer is full. */
 bool events_waits_history_long_full= false;
 /** Index in EVENTS_WAITS_HISTORY_LONG circular buffer. */
-volatile uint32 events_waits_history_long_index= 0;
+PFS_ALIGNED volatile uint32 events_waits_history_long_index= 0;
 /** EVENTS_WAITS_HISTORY_LONG circular buffer. */
 PFS_events_waits *events_waits_history_long_array= NULL;
 

--- a/storage/perfschema/pfs_lock.h
+++ b/storage/perfschema/pfs_lock.h
@@ -21,6 +21,7 @@
   Performance schema internal locks (declarations).
 */
 
+#include "pfs_global.h"
 #include "pfs_atomic.h"
 
 /**
@@ -79,7 +80,7 @@ struct pfs_lock
     The version number is stored in the high 30 bits.
     The state is stored in the low 2 bits.
   */
-  volatile uint32 m_version_state;
+  PFS_ALIGNED volatile uint32 m_version_state;
 
   /** Returns true if the record is free. */
   bool is_free(void)

--- a/storage/xtradb/btr/btr0sea.cc
+++ b/storage/xtradb/btr/btr0sea.cc
@@ -53,11 +53,6 @@ UNIV_INTERN ulint		btr_search_index_num;
 /** A dummy variable to fool the compiler */
 UNIV_INTERN ulint		btr_search_this_is_zero = 0;
 
-/** padding to prevent other memory update
-hotspots from residing on the same memory
-cache line as btr_search_latch */
-UNIV_INTERN byte		btr_sea_pad1[CACHE_LINE_SIZE];
-
 /** Array of latches protecting individual AHI partitions. The latches
 protect: (1) positions of records on those pages where a hash index from the
 corresponding AHI partition has been built.
@@ -65,14 +60,12 @@ NOTE: They do not protect values of non-ordering fields within a record from
 being updated in-place! We can use fact (1) to perform unique searches to
 indexes. */
 
-UNIV_INTERN prio_rw_lock_t*	btr_search_latch_arr;
-
-/** padding to prevent other memory update hotspots from residing on
-the same memory cache line */
-UNIV_INTERN byte		btr_sea_pad2[CACHE_LINE_SIZE];
+UNIV_INTERN prio_rw_lock_t*	btr_search_latch_arr
+					MY_ALIGNED(CACHE_LINE_SIZE);
 
 /** The adaptive hash index */
-UNIV_INTERN btr_search_sys_t*	btr_search_sys;
+UNIV_INTERN btr_search_sys_t*	btr_search_sys
+					MY_ALIGNED(CACHE_LINE_SIZE);
 
 #ifdef UNIV_PFS_RWLOCK
 /* Key to register btr_search_sys with performance schema */

--- a/storage/xtradb/include/log0log.h
+++ b/storage/xtradb/include/log0log.h
@@ -836,10 +836,8 @@ struct log_group_t{
 
 /** Redo log buffer */
 struct log_t{
-	byte		pad[CACHE_LINE_SIZE];	/*!< padding to prevent other memory
-					update hotspots from residing on the
-					same memory cache line */
-	lsn_t		lsn;		/*!< log sequence number */
+	lsn_t		lsn MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< log sequence number */
 	ulint		buf_free;	/*!< first free offset within the log
 					buffer */
 #ifndef UNIV_HOTBACKUP

--- a/storage/xtradb/include/trx0sys.h
+++ b/storage/xtradb/include/trx0sys.h
@@ -675,38 +675,32 @@ struct trx_sys_t{
 	trx_id_t	max_trx_id;	/*!< The smallest number not yet
 					assigned as a transaction id or
 					transaction number */
-	char		pad1[CACHE_LINE_SIZE];	/*!< Ensure max_trx_id does not share
-					cache line with other fields. */
-	trx_id_t*	descriptors;	/*!< Array of trx descriptors */
+	trx_id_t*	descriptors MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< Array of trx descriptors */
 	ulint		descr_n_max;	/*!< The current size of the descriptors
 					array. */
-	char		pad2[CACHE_LINE_SIZE];	/*!< Ensure static descriptor fields
-					do not share cache lines with
-					descr_n_used */
-	ulint		descr_n_used;	/*!< Number of used elements in the
+	ulint		descr_n_used MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< Number of used elements in the
 					descriptors array. */
-	char		pad3[CACHE_LINE_SIZE];	/*!< Ensure descriptors do not share
-					cache line with other fields */
+	trx_list_t	rw_trx_list MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< List of active and committed in
+					memory read-write transactions, sorted
+					on trx id, biggest first. Recovered
+					transactions are always on this list. */
 #ifdef UNIV_DEBUG
 	trx_id_t	rw_max_trx_id;	/*!< Max trx id of read-write transactions
 					which exist or existed */
 #endif
-	trx_list_t	rw_trx_list;	/*!< List of active and committed in
-					memory read-write transactions, sorted
-					on trx id, biggest first. Recovered
-					transactions are always on this list. */
-	char		pad4[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_list_t	ro_trx_list;	/*!< List of active and committed in
+	trx_list_t	ro_trx_list MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< List of active and committed in
 					memory read-only transactions, sorted
 					on trx id, biggest first. NOTE:
 					The order for read-only transactions
 					is not necessary. We should exploit
 					this and increase concurrency during
 					add/remove. */
-	char		pad5[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_list_t	mysql_trx_list;	/*!< List of transactions created
+	trx_list_t	mysql_trx_list MY_ALIGNED(CACHE_LINE_SIZE);
+					/*!< List of transactions created
 					for MySQL. All transactions on
 					ro_trx_list are on mysql_trx_list. The
 					rw_trx_list can contain system
@@ -718,16 +712,12 @@ struct trx_sys_t{
 					mysql_trx_list may additionally contain
 					transactions that have not yet been
 					started in InnoDB. */
-	char		pad6[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_list_t	trx_serial_list;
+	trx_list_t	trx_serial_list MY_ALIGNED(CACHE_LINE_SIZE);
 					/*!< trx->no ordered List of
 					transactions in either TRX_PREPARED or
 					TRX_ACTIVE which have already been
 					assigned a serialization number */
-	char		pad7[CACHE_LINE_SIZE];	/*!< Ensure list base nodes do not
-					share cache line with other fields */
-	trx_rseg_t*	const rseg_array[TRX_SYS_N_RSEGS];
+	trx_rseg_t*	const rseg_array[TRX_SYS_N_RSEGS] MY_ALIGNED(CACHE_LINE_SIZE);
 					/*!< Pointer array to rollback
 					segments; NULL if slot not in use;
 					created and destroyed in

--- a/storage/xtradb/include/ut0rbt.h
+++ b/storage/xtradb/include/ut0rbt.h
@@ -34,7 +34,7 @@ Created 2007-03-20 Sunny Bains
 #include <string.h>
 #include <assert.h>
 
-#define	ut_malloc	malloc
+#define	ut_malloc(X)	ALIGNED_ALLOC(X, CACHE_LINE_SIZE)
 #define	ut_free		free
 #define	ulint		unsigned long
 #define	ut_a(c)		assert(c)

--- a/storage/xtradb/srv/srv0conc.cc
+++ b/storage/xtradb/srv/srv0conc.cc
@@ -113,14 +113,12 @@ UNIV_INTERN mysql_pfs_key_t	srv_conc_mutex_key;
 
 /** Variables tracking the active and waiting threads. */
 struct srv_conc_t {
-	char		pad[CACHE_LINE_SIZE  - (sizeof(ulint) + sizeof(lint))];
-
 	/** Number of transactions that have declared_to_be_inside_innodb set.
 	It used to be a non-error for this value to drop below zero temporarily.
 	This is no longer true. We'll, however, keep the lint datatype to add
 	assertions to catch any corner cases that we may have missed. */
 
-	volatile lint	n_active;
+	volatile lint	n_active MY_ALIGNED(CACHE_LINE_SIZE);
 
 	/** Number of OS threads waiting in the FIFO for permission to
 	enter InnoDB */

--- a/storage/xtradb/ut/ut0mem.cc
+++ b/storage/xtradb/ut/ut0mem.cc
@@ -32,7 +32,7 @@ Created 5/11/1994 Heikki Tuuri
 #ifndef UNIV_HOTBACKUP
 # include "os0thread.h"
 # include "srv0srv.h"
-
+# include <my_align_alloc.h>
 #include <stdlib.h>
 
 /** The total amount of memory currently allocated from the operating
@@ -114,7 +114,7 @@ ut_malloc_low(
 retry:
 	os_fast_mutex_lock(&ut_list_mutex);
 
-	ret = malloc(n + sizeof(ut_mem_block_t));
+	ret = ALIGNED_ALLOC(n + sizeof(ut_mem_block_t), CACHE_LINE_SIZE);
 
 	if (ret == NULL && retry_count < 60) {
 		if (retry_count == 0) {


### PR DESCRIPTION
This replaces the padding constructs in innodb/xtradb/performance
schema contructs and the lf allocator.

Windows _aligned_malloc call is used and POSIX aligned_alloc is
otherwise used. posix_memalign is used as a fallback.

I submit this under the MCA. This is the same as #180. Just collapsed to a single commit since most has been merged already.
