### PR TITLE
MDEV-9479: Enable OQGRAPH Engine to compile with Boost-1.60+

### DIFF
--- a/storage/oqgraph/oqgraph_shim.h
+++ b/storage/oqgraph/oqgraph_shim.h
@@ -254,7 +254,7 @@ namespace boost
     typedef no_property type;
   };
 
-#if BOOST_VERSION >= 104601
+#if BOOST_VERSION < 106000 && BOOST_VERSION >= 104601
   template <>
   struct graph_bundle_type<oqgraph3::graph>
   {


### PR DESCRIPTION
This used to be a compile failure. The defined structure isn't required
in the later versions of boost.

Not sure what the delay is in applying this simple downstream patch so putting it here to make it easy to merge.