### PR TITLE
MDEV-10292: Backport tokudb compile fix

### DIFF
--- a/storage/tokudb/PerconaFT/ft/bndata.cc
+++ b/storage/tokudb/PerconaFT/ft/bndata.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <ft/bndata.h>
 #include <ft/ft-internal.h>
 

--- a/storage/tokudb/PerconaFT/ft/cachetable/cachetable.cc
+++ b/storage/tokudb/PerconaFT/ft/cachetable/cachetable.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <string.h>
 #include <time.h>
 #include <stdarg.h>

--- a/storage/tokudb/PerconaFT/ft/cachetable/checkpoint.cc
+++ b/storage/tokudb/PerconaFT/ft/cachetable/checkpoint.cc
@@ -73,6 +73,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
  *
  *****/
 
+#include <my_global.h>
 #include <time.h>
 
 #include "portability/toku_portability.h"

--- a/storage/tokudb/PerconaFT/ft/cursor.cc
+++ b/storage/tokudb/PerconaFT/ft/cursor.cc
@@ -35,6 +35,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/ft-internal.h"
 
 #include "ft/cursor.h"

--- a/storage/tokudb/PerconaFT/ft/ft-cachetable-wrappers.cc
+++ b/storage/tokudb/PerconaFT/ft/ft-cachetable-wrappers.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/serialize/block_table.h"
 #include "ft/ft-cachetable-wrappers.h"
 #include "ft/ft-flusher.h"

--- a/storage/tokudb/PerconaFT/ft/ft-flusher.cc
+++ b/storage/tokudb/PerconaFT/ft/ft-flusher.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/ft.h"
 #include "ft/ft-cachetable-wrappers.h"
 #include "ft/ft-internal.h"

--- a/storage/tokudb/PerconaFT/ft/ft-hot-flusher.cc
+++ b/storage/tokudb/PerconaFT/ft/ft-hot-flusher.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/ft.h"
 #include "ft/ft-cachetable-wrappers.h"
 #include "ft/ft-flusher.h"

--- a/storage/tokudb/PerconaFT/ft/ft-ops.cc
+++ b/storage/tokudb/PerconaFT/ft/ft-ops.cc
@@ -147,6 +147,7 @@ basement nodes, bulk fetch,  and partial fetch:
 
 */
 
+#include <my_global.h>
 #include "ft/cachetable/checkpoint.h"
 #include "ft/cursor.h"
 #include "ft/ft.h"

--- a/storage/tokudb/PerconaFT/ft/ft-status.cc
+++ b/storage/tokudb/PerconaFT/ft/ft-status.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/ft.h"
 #include "ft/ft-status.h"
 

--- a/storage/tokudb/PerconaFT/ft/ft-test-helpers.cc
+++ b/storage/tokudb/PerconaFT/ft/ft-test-helpers.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/ft.h"
 #include "ft/ft-cachetable-wrappers.h"
 #include "ft/ft-internal.h"

--- a/storage/tokudb/PerconaFT/ft/ft-verify.cc
+++ b/storage/tokudb/PerconaFT/ft/ft-verify.cc
@@ -44,6 +44,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
  *   For each nonleaf node:  All the messages have keys that are between the associated pivot keys ( left_pivot_key < message <= right_pivot_key)
  */
 
+#include <my_global.h>
 #include "ft/serialize/block_table.h"
 #include "ft/ft.h"
 #include "ft/ft-cachetable-wrappers.h"

--- a/storage/tokudb/PerconaFT/ft/ft.cc
+++ b/storage/tokudb/PerconaFT/ft/ft.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/serialize/block_table.h"
 #include "ft/ft.h"
 #include "ft/ft-cachetable-wrappers.h"

--- a/storage/tokudb/PerconaFT/ft/le-cursor.cc
+++ b/storage/tokudb/PerconaFT/ft/le-cursor.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/ft.h"
 #include "ft/ft-internal.h"
 #include "ft/le-cursor.h"

--- a/storage/tokudb/PerconaFT/ft/leafentry.cc
+++ b/storage/tokudb/PerconaFT/ft/leafentry.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "serialize/wbuf.h"
 #include "leafentry.h"
 

--- a/storage/tokudb/PerconaFT/ft/loader/dbufio.cc
+++ b/storage/tokudb/PerconaFT/ft/loader/dbufio.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
@@ -135,7 +136,7 @@ static ssize_t dbf_read_some_compressed(struct dbufio_file *dbf, char *buf, size
         ret = 0;
         goto exit;
     }
-    if (readcode < header_size) {
+    if (readcode < (ssize_t) header_size) {
         errno = TOKUDB_NO_DATA;
         ret = -1;
         goto exit;
@@ -163,7 +164,7 @@ static ssize_t dbf_read_some_compressed(struct dbufio_file *dbf, char *buf, size
         ret = -1;
         goto exit;
     }
-    if (readcode < total_size) {
+    if (readcode < (ssize_t) total_size) {
         errno = TOKUDB_NO_DATA;
         ret = -1;
         goto exit;

--- a/storage/tokudb/PerconaFT/ft/loader/loader.cc
+++ b/storage/tokudb/PerconaFT/ft/loader/loader.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <toku_portability.h>
 
 #include <arpa/inet.h>

--- a/storage/tokudb/PerconaFT/ft/loader/pqueue.cc
+++ b/storage/tokudb/PerconaFT/ft/loader/pqueue.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <toku_portability.h>
 #include "toku_os.h"
 #include "ft-internal.h"

--- a/storage/tokudb/PerconaFT/ft/logger/log_upgrade.cc
+++ b/storage/tokudb/PerconaFT/ft/logger/log_upgrade.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <ft/log_header.h>
 
 #include "log-internal.h"

--- a/storage/tokudb/PerconaFT/ft/logger/logcursor.cc
+++ b/storage/tokudb/PerconaFT/ft/logger/logcursor.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "log-internal.h"
 #include "logger/logcursor.h"
 #include <limits.h>

--- a/storage/tokudb/PerconaFT/ft/logger/logfilemgr.cc
+++ b/storage/tokudb/PerconaFT/ft/logger/logfilemgr.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "logger/log-internal.h"
 #include "logger/logcursor.h"
 #include "logger/logfilemgr.h"

--- a/storage/tokudb/PerconaFT/ft/logger/logger.cc
+++ b/storage/tokudb/PerconaFT/ft/logger/logger.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <memory.h>
 #include <ctype.h>
 #include <limits.h>

--- a/storage/tokudb/PerconaFT/ft/logger/recover.cc
+++ b/storage/tokudb/PerconaFT/ft/logger/recover.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/cachetable/cachetable.h"
 #include "ft/cachetable/checkpoint.h"
 #include "ft/ft.h"

--- a/storage/tokudb/PerconaFT/ft/msg.cc
+++ b/storage/tokudb/PerconaFT/ft/msg.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "portability/toku_portability.h"
 
 #include "ft/msg.h"

--- a/storage/tokudb/PerconaFT/ft/node.cc
+++ b/storage/tokudb/PerconaFT/ft/node.cc
@@ -35,6 +35,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "ft/ft.h"
 #include "ft/ft-internal.h"
 #include "ft/serialize/ft_node-serialize.h"

--- a/storage/tokudb/PerconaFT/ft/pivotkeys.cc
+++ b/storage/tokudb/PerconaFT/ft/pivotkeys.cc
@@ -35,6 +35,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <string>
 
 #include "portability/memory.h"

--- a/storage/tokudb/PerconaFT/ft/serialize/block_table.cc
+++ b/storage/tokudb/PerconaFT/ft/serialize/block_table.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include "portability/memory.h"
 #include "portability/toku_assert.h"
 #include "portability/toku_portability.h"

--- a/storage/tokudb/PerconaFT/ft/serialize/compress.cc
+++ b/storage/tokudb/PerconaFT/ft/serialize/compress.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <toku_portability.h>
 #include <util/scoped_malloc.h>
 
@@ -97,7 +98,6 @@ void toku_compress (enum toku_compression_method a,
     static const int zlib_without_checksum_windowbits = -15;
 
     a = normalize_compression_method(a);
-    assert(sourceLen < (1LL << 32));
     switch (a) {
     case TOKU_NO_COMPRESSION:
         dest[0] = TOKU_NO_COMPRESSION;
@@ -171,8 +171,10 @@ void toku_compress (enum toku_compression_method a,
         return;
     }
     case TOKU_SNAPPY_METHOD: {
-        snappy::RawCompress((char*)source, sourceLen, (char*)dest + 1, destLen);
-        *destLen += 1;
+        size_t tmp_dest= *destLen;
+        snappy::RawCompress((char*)source, sourceLen, (char*)dest + 1,
+                            &tmp_dest);
+        *destLen= tmp_dest + 1;
         dest[0] = TOKU_SNAPPY_METHOD;
         return;
     }

--- a/storage/tokudb/PerconaFT/ft/ule.cc
+++ b/storage/tokudb/PerconaFT/ft/ule.cc
@@ -47,6 +47,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 // See design documentation for nested transactions at
 // TokuWiki/Imp/TransactionsOverview.
 
+#include <my_global.h>
 #include "portability/toku_portability.h"
 
 #include "ft/ft-internal.h"

--- a/storage/tokudb/PerconaFT/portability/toku_portability.h
+++ b/storage/tokudb/PerconaFT/portability/toku_portability.h
@@ -178,6 +178,8 @@ extern void *realloc(void*, size_t)            __THROW __attribute__((__deprecat
 #    endif
 #if !defined(__APPLE__)
 // Darwin headers use these types, we should not poison them
+#undef TRUE
+#undef FALSE
 # pragma GCC poison u_int8_t
 # pragma GCC poison u_int16_t
 # pragma GCC poison u_int32_t

--- a/storage/tokudb/PerconaFT/src/ydb.cc
+++ b/storage/tokudb/PerconaFT/src/ydb.cc
@@ -39,6 +39,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 extern const char *toku_patent_string;
 const char *toku_copyright_string = "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.";
 
+#include <my_global.h>
 #include <db.h>
 #include <errno.h>
 #include <string.h>

--- a/storage/tokudb/PerconaFT/src/ydb_db.cc
+++ b/storage/tokudb/PerconaFT/src/ydb_db.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <ctype.h>
 
 #include <db.h>

--- a/storage/tokudb/PerconaFT/src/ydb_env_func.cc
+++ b/storage/tokudb/PerconaFT/src/ydb_env_func.cc
@@ -36,6 +36,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
+#include <my_global.h>
 #include <toku_portability.h>
 
 #include <memory.h>


### PR DESCRIPTION
From monty: e4062d4d203a6be596d3f61dfe4db1b4f91e24aa was applied to 10.2 - this ports the TokuDB component back to 10.0 where the problem began.

Added my_global.h to PerconaFT to avoid "error <my_config.h> MUST be included first"