### PR TITLE
MDEV-10303 - rsync_sst_rsync: ignore lost+found during database directory transfer

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -222,7 +222,7 @@ then
         [ "$OS" == "Linux" ] && count=$(grep -c processor /proc/cpuinfo)
         [ "$OS" == "Darwin" -o "$OS" == "FreeBSD" ] && count=$(sysctl -n hw.ncpu)
 
-        find . -maxdepth 1 -mindepth 1 -type d -print0 | xargs -I{} -0 -P $count \
+        find . -maxdepth 1 -mindepth 1 -type d ! -name 'lost+found' -print0 | xargs -I{} -0 -P $count \
              rsync --owner --group --perms --links --specials \
              --ignore-times --inplace --recursive --delete --quiet \
              $WHOLE_FILE_OPT --exclude '*/ib_logfile*' "$WSREP_SST_OPT_DATA"/{}/ \


### PR DESCRIPTION
`lost+found` is excluded when transferring normal directories. The database directory transfer however does not exclude it. As a result, `wsrep_sst_rsync` in donor mode attempts  to read its content. This fails as it is owned by root with strict 700 permissions.

This change excludes lost+found from the list of database directories in the `wsrep_sst_rsync` script.