### PR TITLE
Cross Compile HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE change to compile check

### DIFF
--- a/configure.cmake
+++ b/configure.cmake
@@ -1107,7 +1107,7 @@ CHECK_STRUCT_HAS_MEMBER("struct timespec" tv_sec "time.h" STRUCT_TIMESPEC_HAS_TV
 CHECK_STRUCT_HAS_MEMBER("struct timespec" tv_nsec "time.h" STRUCT_TIMESPEC_HAS_TV_NSEC)
 
 IF(NOT MSVC)
-  CHECK_C_SOURCE_RUNS(
+  CHECK_C_SOURCE_COMPILES(
   "
   #define _GNU_SOURCE
   #include <fcntl.h>


### PR DESCRIPTION
HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE only needed a compile check
rather than a RUN check so after changing to a compile check there
is one less variable to manually set while cross compiling.

Added in 21adad00

I submit this under the MCA.