### PR TITLE
MDEV-10294: MTR using --valgrind-option to specify a tool / fixing callgrind [10.1]

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -3764,6 +3764,7 @@ sub run_testcase ($$) {
   my $print_freq=20;
 
   mtr_verbose("Running test:", $tinfo->{name});
+  $ENV{'MTR_TEST_NAME'} = $tinfo->{name};
   resfile_report_test($tinfo) if $opt_resfile;
 
   # Allow only alpanumerics pluss _ - + . in combination names,


### PR DESCRIPTION
Based off #194 feedback. Thanks @elenst 

fixed --callgrind by removing --base

closes #194

I submit this under the MCA.