### PR TITLE
MDEV-10374 Run tokudb sys vars tests on mariadb

### DIFF
--- a/storage/tokudb/mysql-test/tokudb_sys_vars/include/have_tokudb.inc
+++ b/storage/tokudb/mysql-test/tokudb_sys_vars/include/have_tokudb.inc
@@ -1,0 +1,1 @@
+let $datadir=`select @@datadir`;

--- a/storage/tokudb/mysql-test/tokudb_sys_vars/r/tokudb_analyze_in_background_basic.result
+++ b/storage/tokudb/mysql-test/tokudb_sys_vars/r/tokudb_analyze_in_background_basic.result
@@ -19,29 +19,30 @@ SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
 0
 SET GLOBAL tokudb_analyze_in_background = -6;
+ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of '-6'
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
-1
+0
 SET GLOBAL tokudb_analyze_in_background = 1.6;
 ERROR 42000: Incorrect argument type to variable 'tokudb_analyze_in_background'
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
-1
+0
 SET GLOBAL tokudb_analyze_in_background = "T";
 ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of 'T'
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
-1
+0
 SET GLOBAL tokudb_analyze_in_background = "Y";
 ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of 'Y'
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
-1
+0
 SET GLOBAL tokudb_analyze_in_background = 'foobar';
 ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of 'foobar'
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
-1
+0
 SET SESSION tokudb_analyze_in_background = 0;
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
@@ -53,31 +54,32 @@ SELECT @@session.tokudb_analyze_in_background;
 SET SESSION tokudb_analyze_in_background = DEFAULT;
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
-1
+0
 SET SESSION tokudb_analyze_in_background = -6;
+ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of '-6'
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
-1
+0
 SET SESSION tokudb_analyze_in_background = 1.6;
 ERROR 42000: Incorrect argument type to variable 'tokudb_analyze_in_background'
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
-1
+0
 SET SESSION tokudb_analyze_in_background = "T";
 ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of 'T'
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
-1
+0
 SET SESSION tokudb_analyze_in_background = "Y";
 ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of 'Y'
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
-1
+0
 SET SESSION tokudb_analyze_in_background = 'foobar';
 ERROR 42000: Variable 'tokudb_analyze_in_background' can't be set to the value of 'foobar'
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
-1
+0
 SET GLOBAL tokudb_analyze_in_background = 0;
 SET SESSION tokudb_analyze_in_background = 1;
 SELECT @@global.tokudb_analyze_in_background;

--- a/storage/tokudb/mysql-test/tokudb_sys_vars/suite.opt
+++ b/storage/tokudb/mysql-test/tokudb_sys_vars/suite.opt
@@ -1,0 +1,1 @@
+--tokudb --plugin-load-add=$HA_TOKUDB_SO --loose-tokudb-check-jemalloc=0 --sql-mode=NO_ENGINE_SUBSTITUTION

--- a/storage/tokudb/mysql-test/tokudb_sys_vars/suite.pm
+++ b/storage/tokudb/mysql-test/tokudb_sys_vars/suite.pm
@@ -1,0 +1,14 @@
+package My::Suite::TokuDB;
+use File::Basename;
+@ISA = qw(My::Suite);
+
+# Ensure we can run the TokuDB tests even if hugepages are enabled
+$ENV{TOKU_HUGE_PAGES_OK}=1;
+
+#return "Not run for embedded server" if $::opt_embedded_server;
+return "No TokuDB engine" unless $ENV{HA_TOKUDB_SO} or $::mysqld_variables{tokudb};
+
+sub is_default { not $::opt_embedded_server }
+
+bless { };
+

--- a/storage/tokudb/mysql-test/tokudb_sys_vars/t/tokudb_analyze_in_background_basic.test
+++ b/storage/tokudb/mysql-test/tokudb_sys_vars/t/tokudb_analyze_in_background_basic.test
@@ -17,6 +17,7 @@ SELECT @@global.tokudb_analyze_in_background;
 SET GLOBAL tokudb_analyze_in_background = DEFAULT;
 SELECT @@global.tokudb_analyze_in_background;
 
+-- error ER_WRONG_VALUE_FOR_VAR
 SET GLOBAL tokudb_analyze_in_background = -6;
 SELECT @@global.tokudb_analyze_in_background;
 
@@ -46,6 +47,7 @@ SELECT @@session.tokudb_analyze_in_background;
 SET SESSION tokudb_analyze_in_background = DEFAULT;
 SELECT @@session.tokudb_analyze_in_background;
 
+-- error ER_WRONG_VALUE_FOR_VAR
 SET SESSION tokudb_analyze_in_background = -6;
 SELECT @@session.tokudb_analyze_in_background;
 


### PR DESCRIPTION
Need to add some control files that allow the tokudb_sys_vars tests to run.  Also need to fix the tokudb_analyze_in_background_basic test since mysql and mariadb handle the values for boolean system variables differently.
