### PR TITLE
MDEV-10491: If log_error is set, direct SST log entries to MariaDB er…

### DIFF
--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -338,7 +338,9 @@ read_cnf()
 
     if [[ $ssyslog -ne -1 ]];then 
         if my_print_defaults -c $WSREP_SST_OPT_CONF mysqld_safe | tr '_' '-' | grep -q -- "--syslog";then 
-            ssyslog=1
+            if ! my_print_defaults -c $WSREP_SST_OPT_CONF --mysqld | tr '_' '-' | grep -q -- "--log-error";then
+                ssyslog=1
+            fi
         fi
     fi
 }


### PR DESCRIPTION
…ror log even if mysqld_safe's syslog option is set, since this matches the behavior of mysqld.