### PR TITLE
MDEV-9872: Generic CRC32 message using ptr

### DIFF
--- a/storage/innobase/include/ut0crc32.h
+++ b/storage/innobase/include/ut0crc32.h
@@ -54,8 +54,6 @@ extern ut_crc32_func_t	ut_crc32_legacy_big_endian;
 but very slow). */
 extern ut_crc32_func_t	ut_crc32_byte_by_byte;
 
-/** Flag that tells whether the CPU supports CRC32 or not */
-extern bool		ut_crc32_sse2_enabled;
-extern bool		ut_crc32_power8_enabled;
+extern const char *ut_crc32_implementation;
 
 #endif /* ut0crc32_h */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1702,13 +1702,8 @@ innobase_start_or_create_for_mysql(void)
 
 	srv_boot();
 
-	if (ut_crc32_sse2_enabled) {
-		ib::info() << "Using SSE crc32 instructions";
-	} else if (ut_crc32_power8_enabled) {
-		ib::info() << "Using POWER8 crc32 instructions";
-	} else {
-		ib::info() << "Using generic crc32 instructions";
-	}
+	ib::info() << ut_crc32_implementation;
+
 
 	if (!srv_read_only_mode) {
 

--- a/storage/innobase/ut/ut0crc32.cc
+++ b/storage/innobase/ut/ut0crc32.cc
@@ -445,7 +445,6 @@ void
 ut_crc32_slice8_table_init()
 /*========================*/
 {
-#ifndef HAVE_CRC32_VPMSUM
 	/* bit-reversed poly 0x1EDC6F41 (from SSE42 crc32 instruction) */
 	static const uint32_t	poly = 0x82f63b78;
 	uint32_t		n;
@@ -469,7 +468,6 @@ ut_crc32_slice8_table_init()
 	}
 
 	ut_crc32_slice8_table_initialized = true;
-#endif
 }
 
 /** Calculate CRC32 over 8-bit data using a software implementation.

--- a/storage/innobase/ut/ut0crc32.cc
+++ b/storage/innobase/ut/ut0crc32.cc
@@ -705,7 +705,7 @@ ut_crc32_init()
 	ut_crc32_byte_by_byte = ut_crc32_byte_by_byte_sw;
 	ut_crc32_implementation = "Using generic crc32 instructions";
 
-#if defined(__GNUC__) && defined(__x86_64__) && !defined(UNIV_DEBUG_VALGRIND)
+#if defined(__GNUC__) && defined(__x86_64__)
 	uint32_t	vend[3];
 	uint32_t	model;
 	uint32_t	family;

--- a/storage/xtradb/include/ut0crc32.h
+++ b/storage/xtradb/include/ut0crc32.h
@@ -46,7 +46,6 @@ typedef ib_uint32_t (*ib_ut_crc32_t)(const byte* ptr, ulint len);
 
 extern ib_ut_crc32_t	ut_crc32;
 
-extern bool	ut_crc32_sse2_enabled;
-extern bool     ut_crc32_power8_enabled;
+extern const char *ut_crc32_implementation;
 
 #endif /* ut0crc32_h */

--- a/storage/xtradb/srv/srv0start.cc
+++ b/storage/xtradb/srv/srv0start.cc
@@ -1938,13 +1938,7 @@ innobase_start_or_create_for_mysql(void)
 
 	srv_boot();
 
-	if (ut_crc32_sse2_enabled) {
-		ib_logf(IB_LOG_LEVEL_INFO, "Using SSE crc32 instructions");
-	} else if (ut_crc32_power8_enabled) {
-		ib_logf(IB_LOG_LEVEL_INFO, "Using POWER8 crc32 instructions");
-	} else {
-		ib_logf(IB_LOG_LEVEL_INFO, "Using generic crc32 instructions");
-	}
+	ib_logf(IB_LOG_LEVEL_INFO, ut_crc32_implementation);
 
 	if (!srv_read_only_mode) {
 

--- a/storage/xtradb/ut/ut0crc32.cc
+++ b/storage/xtradb/ut/ut0crc32.cc
@@ -97,9 +97,8 @@ have support for it */
 static ib_uint32_t	ut_crc32_slice8_table[8][256];
 static ibool		ut_crc32_slice8_table_initialized = FALSE;
 
-/* Flag that tells whether the CPU supports CRC32 or not */
-UNIV_INTERN bool	ut_crc32_sse2_enabled = false;
-UNIV_INTERN bool	ut_crc32_power8_enabled = false;
+/** Text description of CRC32 implementation */
+const char *ut_crc32_implementation = NULL;
 
 /********************************************************************//**
 Initializes the table that is used to generate the CRC32 if the CPU does
@@ -213,8 +212,6 @@ ut_crc32_sse42(
 #if defined(__GNUC__) && defined(__x86_64__)
 	ib_uint64_t	crc = (ib_uint32_t) (-1);
 
-	ut_a(ut_crc32_sse2_enabled);
-
 	while (len && ((ulint) buf & 7)) {
 		ut_crc32_sse42_byte;
 	}
@@ -302,6 +299,7 @@ void
 ut_crc32_init()
 /*===========*/
 {
+	bool            ut_crc32_sse2_enabled = false;
 #if defined(__GNUC__) && defined(__x86_64__)
 	ib_uint32_t	vend[3];
 	ib_uint32_t	model;
@@ -336,14 +334,16 @@ ut_crc32_init()
 #endif /* defined(__GNUC__) && defined(__x86_64__) */
 
 #ifdef HAVE_CRC32_VPMSUM
-	ut_crc32_power8_enabled = true;
 	ut_crc32 = ut_crc32_power8;
+	ut_crc32_implementation = "Using POWER8 crc32 instructions";
 #else
 	if (ut_crc32_sse2_enabled) {
 		ut_crc32 = ut_crc32_sse42;
+		ut_crc32_implementation = "Using SSE2 crc32 instructions";
 	} else {
 		ut_crc32_slice8_table_init();
 		ut_crc32 = ut_crc32_slice8;
+		ut_crc32_implementation = "Using generic crc32 instructions";
 	}
 #endif
 }

--- a/storage/xtradb/ut/ut0crc32.cc
+++ b/storage/xtradb/ut/ut0crc32.cc
@@ -303,7 +303,7 @@ ut_crc32_init()
 	ut_crc32 = ut_crc32_slice8;
 	ut_crc32_implementation = "Using generic crc32 instructions";
 
-#if defined(__GNUC__) && defined(__x86_64__) && !defined(UNIV_DEBUG_VALGRIND)
+#if defined(__GNUC__) && defined(__x86_64__)
 	ib_uint32_t	vend[3];
 	ib_uint32_t	model;
 	ib_uint32_t	family;


### PR DESCRIPTION
To stop the expansion of booleans to represent different crc32 implementations for display purposes lets just use a pointer.

I submit this under the MCA.
