### PR TITLE
MDEV-10750 - travis: gcc-5 and gcc-6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+# below requires https://github.com/travis-ci/apt-source-whitelist/pull/309
 #      - llvm-toolchain-trusty-3.8
 #      - llvm-toolchain-trusty-3.9
+# llvm urls awaiting fix
+# https://github.com/travis-ci/apt-source-whitelist/pull/288
+# https://github.com/travis-ci/apt-source-whitelist/pull/309
     packages: # make sure these match debian/control contents
       - gcc-5
       - g++-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,21 @@ cache:
   - apt
   - ccache
 
+env:
+  matrix:
+    - GCC_VERSION=5
+    - GCC_VERSION=6
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
+#      - llvm-toolchain-trusty-3.8
+#      - llvm-toolchain-trusty-3.9
     packages: # make sure these match debian/control contents
+      - gcc-5
+      - g++-5
+      - gcc-6
+      - g++-6
       - bison
       - chrpath
       - cmake
@@ -48,7 +60,8 @@ addons:
 # libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 
 script:
-  - ${CC} --version ; ${CXX} --version
+  - export MYSQL_BUILD_CC=/usr/bin/gcc-${GCC_VERSION} MYSQL_BUILD_CXX=/usr/bin/g++-${GCC_VERSION}
+  - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
   - cd "${TRAVIS_BUILD_DIR}"
   - env DEB_BUILD_OPTIONS="parallel=4" debian/autobake-deb.sh;
 


### PR DESCRIPTION
depends on no_ipv6 PR to succeed.

I submit this under the MCA.
