### PR TITLE
10.2 travis parallel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ addons:
       - po-debconf
       - psmisc
       - zlib1g-dev
-      - libcrack2-dev # no effect as the package is disallowed on Travis-CI
+      - libcrack2-dev # no effect as the package is disallowed on Travis-CI - https://github.com/travis-ci/apt-package-whitelist/pull/2939
       - libjemalloc-dev
       - devscripts # implicit for any build on Ubuntu
 

--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -16,8 +16,11 @@ set -e
 # On Travis-CI we want to simulate the full build, including tests.
 # Also on Travis-CI it is useful not to override the DEB_BUILD_OPTIONS
 # at this stage at all.
-if [[ ! $TRAVIS ]]
+if [[ $TRAVIS ]]
 then
+  export DEB_MTR_OPTIONS="--skip-test-list=${TRAVIS_BUILD_DIR}/.travis-skip-tests"
+else
+  export DEB_MTR_OPTIONS=
   export DEB_BUILD_OPTIONS="nocheck"
 fi
 

--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -19,6 +19,7 @@ set -e
 if [[ $TRAVIS ]]
 then
   export DEB_MTR_OPTIONS="--skip-test-list=${TRAVIS_BUILD_DIR}/.travis-skip-tests"
+  export DEB_BUILD_OPTIONS="parallel=4"
 else
   export DEB_MTR_OPTIONS=
   export DEB_BUILD_OPTIONS="nocheck"

--- a/debian/rules
+++ b/debian/rules
@@ -83,7 +83,7 @@ build-stamp: configure
 
 ifeq ($(findstring nocheck,$(DEB_BUILD_OPTIONS)),)
 	if [ ! -f testsuite-stamp ] ; then \
-	  cd $(builddir)/mysql-test && ./mtr --force --parallel=$(NUMJOBS) --skip-rpl --suite=main; \
+	  cd $(builddir)/mysql-test && ./mtr --force --parallel=$(NUMJOBS) $(DEB_MTR_OPTIONS) --skip-rpl --suite=main; \
 	fi
 endif
 


### PR DESCRIPTION
depends on IPv6 test being disabled (based on this as it would of have conflicts).

I submit this under the MCA.