### PR TITLE
MDEV-10751 - fix ipv6 detection test in MTR (aka make travis work)

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -277,7 +277,7 @@ my $current_config_name; # The currently running config file template
 our @opt_experimentals;
 our $experimental_test_cases= [];
 
-my $baseport;
+our $baseport;
 # $opt_build_thread may later be set from $opt_port_base
 my $opt_build_thread= $ENV{'MTR_BUILD_THREAD'} || "auto";
 my $opt_port_base= $ENV{'MTR_PORT_BASE'} || "auto";

--- a/mysql-test/suite.pm
+++ b/mysql-test/suite.pm
@@ -56,9 +56,15 @@ sub skip_combinations {
   sub ipv6_ok() {
     use Socket;
     return 0 unless socket my $sock, PF_INET6, SOCK_STREAM, getprotobyname('tcp');
-    # eval{}, if there's no Socket::sockaddr_in6 at all, old Perl installation
-    eval { connect $sock, sockaddr_in6(7, Socket::IN6ADDR_LOOPBACK) };
-    return $@ eq "";
+    my $ipv6_works = false;
+    # eval{}, if there's no Socket::sockaddr_in6 at all, old Perl installation <5.14
+    eval {
+      my $addr = sockaddr_in6($baseport, Socket::IN6ADDR_LOOPBACK) or return 0;
+      die 'bind failed' unless bind $sock, $addr;
+      close $sock;
+      $ipv6_works = true;
+    };
+    return $@ eq "" && $ipv6_works;
   }
   $skip{'include/check_ipv6.inc'} = 'No IPv6' unless ipv6_ok();
 


### PR DESCRIPTION
based on a number of variants in https://travis-ci.org/grooverdan/mariadb-server/builds (10.2-travis_no_ipv6  branch) the current ipv6 detection isn't returning false on travis where there is no IPv6.

Here we do a bind (to the MTR baseport) rather than a connect to test. This seems to work correctly.

I submit this under the MCA.