### PR TITLE
remove die() from BUILD/autorun.sh

### DIFF
--- a/BUILD/autorun.sh
+++ b/BUILD/autorun.sh
@@ -19,8 +19,6 @@
 
 # Create MySQL cmake configure wrapper
 
-die() { echo "$@"; exit 1; }
-
 # Use a configure script that will call CMake.
 path=`dirname $0`
 cp $path/cmake_configure.sh $path/../configure


### PR DESCRIPTION
This patch removes die() function from the BUILD/autorun.sh. It was
introduced in the c682570431 commit (Fix BUILD/autorun.sh to really bail
out on error.). Last users of die() was removed in the 8664de22 commit
(WL#5665: Removal of the autotools-based build system) and since it is
not used anywhere.

No functionality changes. Just cleanup.