### PR TITLE
Call profiling.restart() and profiling.reset() only if profiling is e…

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1661,7 +1661,9 @@ void THD::free_connection()
   /* close all prepared statements, to save memory */
   stmt_map.reset();
   free_connection_done= 1;
+#if defined(ENABLED_PROFILING)
   profiling.restart();                          // Reset profiling
+#endif
 }
 
 /*
@@ -1686,7 +1688,9 @@ void THD::reset_for_reuse()
   abort_on_warning= 0;
   free_connection_done= 0;
   m_command= COM_CONNECT;
+#if defined(ENABLED_PROFILING)
   profiling.reset();
+#endif
 #ifdef SIGNAL_WITH_VIO_CLOSE
   active_vio = 0;
 #endif


### PR DESCRIPTION
…nabled

in other case we will get:

../server/sql/sql_class.cc: In member function ‘void THD::free_connection()’:
../server/sql/sql_class.cc:1664:3: error: ‘profiling’ was not declared in this scope
   profiling.restart();                          // Reset profiling
      ^~~~~~~~~

../server/sql/sql_class.cc: In member function ‘void THD::reset_for_reuse()’:
../server/sql/sql_class.cc:1689:3: error: ‘profiling’ was not declared in this scope
  profiling.reset();
       ^~~~~~~~~

errors.