### PR TITLE
MDEV-10292: Tokudb - PerconaFT - compile error in recent gcc

### DIFF
--- a/storage/tokudb/PerconaFT/cmake_modules/TokuSetupCompiler.cmake
+++ b/storage/tokudb/PerconaFT/cmake_modules/TokuSetupCompiler.cmake
@@ -66,9 +66,7 @@ set_cflags_if_supported(
   -Wno-error=address-of-array-temporary
   -Wno-error=tautological-constant-out-of-range-compare
   -Wno-error=maybe-uninitialized
-  -Wno-ignored-attributes
   -Wno-error=extern-c-compat
-  -Wno-pointer-bool-conversion
   -fno-rtti
   -fno-exceptions
   )


### PR DESCRIPTION
Seems as though these warnings aren't actually generated so there is no need to ignore those errors.

These options cause compiler errors with recent gcc versions when creating a shared object as per JIRA.

I submit this under the MCA.