### PR TITLE
MDEV-10708: tokudb_parts.partition_alter4_tokudb is slow

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -297,7 +297,7 @@ our $opt_report_times= 0;
 
 my $opt_sleep;
 
-my $opt_testcase_timeout= $ENV{MTR_TESTCASE_TIMEOUT} ||  15; # minutes
+our $opt_testcase_timeout= $ENV{MTR_TESTCASE_TIMEOUT} ||  15; # minutes
 my $opt_suite_timeout   = $ENV{MTR_SUITE_TIMEOUT}    || 360; # minutes
 my $opt_shutdown_timeout= $ENV{MTR_SHUTDOWN_TIMEOUT} ||  10; # seconds
 my $opt_start_timeout   = $ENV{MTR_START_TIMEOUT}    || 180; # seconds

--- a/storage/tokudb/mysql-test/tokudb_parts/suite.pm
+++ b/storage/tokudb/mysql-test/tokudb_parts/suite.pm
@@ -10,5 +10,12 @@ return "No TokuDB engine" unless $ENV{HA_TOKUDB_SO} or $::mysqld_variables{tokud
 
 sub is_default { not $::opt_embedded_server }
 
+sub skip_combinations {
+  my %skip = ();
+
+  $skip{'t/partition_alter4_tokudb.test'} = "Requires test case timeout >= 20mins (currently $::opt_testcase_timeout)" if $::opt_testcase_timeout < 20;
+  %skip;
+}
+
 bless { };
 


### PR DESCRIPTION
This test can take over 15 minutes. Disable test unless at least 20mins
is available.

Signed-off-by: Daniel Black <daniel.black@au.ibm.com>