### PR TITLE
MDEV-10292: Tokudb - PerconaFT - compile error in recent gcc (10.0)

### DIFF
--- a/storage/tokudb/PerconaFT/cmake_modules/TokuSetupCompiler.cmake
+++ b/storage/tokudb/PerconaFT/cmake_modules/TokuSetupCompiler.cmake
@@ -98,9 +98,7 @@ set_cflags_if_supported(
   -Wno-error=address-of-array-temporary
   -Wno-error=tautological-constant-out-of-range-compare
   -Wno-error=maybe-uninitialized
-  -Wno-ignored-attributes
   -Wno-error=extern-c-compat
-  -Wno-pointer-bool-conversion
   -fno-rtti
   -fno-exceptions
   )


### PR DESCRIPTION
The following directives to ignore warnings where in the PerconaFT build in tokudb.
These generate errors when g++ ... -o xxx.so is used to compile are shared object.

As these don't actually hit any warnings they have been removed.

* -Wno-ignored-attributes
* -Wno-pointer-bool-conversion

I submit this under the MCA.