### PR TITLE
MDEV-10757: Fix tokudb test rows-32m-rand-insert

### DIFF
--- a/storage/tokudb/mysql-test/tokudb/r/rows-32m-rand-insert.result
+++ b/storage/tokudb/mysql-test/tokudb/r/rows-32m-rand-insert.result
@@ -1009,6 +1009,7 @@ Table	Op	Msg_type	Msg_text
 test.t	check	status	OK
 optimize table t;
 Table	Op	Msg_type	Msg_text
+test.t	optimize	note	Table does not support optimize, doing recreate + analyze instead
 test.t	optimize	status	OK
 check table t;
 Table	Op	Msg_type	Msg_text


### PR DESCRIPTION
Was:

CURRENT_TEST: tokudb.rows-32m-rand-insert
--- /source/storage/tokudb/mysql-test/tokudb/r/rows-32m-rand-insert.result	2016-08-29 10:16:55.216852004 +0000
+++ /source/storage/tokudb/mysql-test/tokudb/r/rows-32m-rand-insert.reject	2016-08-29 10:43:18.661888803 +0000
@@ -1009,6 +1009,7 @@
 test.t	check	status	OK
 optimize table t;
 Table	Op	Msg_type	Msg_text
+test.t	optimize	note	Table does not support optimize, doing recreate + analyze instead
 test.t	optimize	status	OK
 check table t;
 Table	Op	Msg_type	Msg_text


I submit this under the MCA