### PR TITLE
no need to set net->vio to zero in mysql_real_connect

### DIFF
--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -3118,7 +3118,6 @@ CLI_MYSQL_REAL_CONNECT(MYSQL *mysql,const char *host, const char *user,
     DBUG_RETURN(0);
 
   mysql->methods= &client_methods;
-  net->vio = 0;				/* If something goes wrong */
   mysql->client_flag=0;			/* For handshake */
 
   /* use default options */


### PR DESCRIPTION
because it is zero always in this place as we have check for this above
which checks that net->vio isn't 0 and exit.

--
I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.