### PR TITLE
MDEV-10830 - Fix undefined database test error when running mysql_install_db

### DIFF
--- a/scripts/mysql_install_db.pl.in
+++ b/scripts/mysql_install_db.pl.in
@@ -508,7 +508,7 @@ if ( open(PIPE, "| $mysqld_install_cmd_line") )
   # FIXME  > /dev/null ?
   if ( open(PIPE, "| $mysqld_install_cmd_line") )
   {
-    print PIPE "use test;\n";
+    print PIPE "use mysql;\n";
     while ( <SQL> )
     {
       print PIPE $_;

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -473,7 +473,7 @@ else
 fi
 
 s_echo "Creating OpenGIS required SP-s..."
-if { echo "use test;"; cat "$maria_add_gis_sp"; } | mysqld_install_cmd_line > /dev/null
+if { echo "use mysql;"; cat "$maria_add_gis_sp"; } | mysqld_install_cmd_line > /dev/null
 then
   s_echo "OK"
 else


### PR DESCRIPTION
When using mariaDb in docker mode it can fail as it calls mysql_install_db but as we are going through a slightly different install process the test database has not been created, therefore we should fall back to the mysql database as per https://mariadb.com/kb/en/mariadb/mariadb-10112-mysql_install_db-aborts-on-unkown-file-test/