### PR TITLE
MDEV-10829: innodb_numa_interleave=1, use numa numa_get_mems_allowed

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1157,10 +1157,11 @@ buf_chunk_init(
 
 #ifdef HAVE_LIBNUMA
 	if (srv_numa_interleave) {
+		struct bitmask *numa_mems_allowed = numa_get_mems_allowed();
 		int	st = mbind(chunk->mem, chunk->mem_size,
 				   MPOL_INTERLEAVE,
-				   numa_all_nodes_ptr->maskp,
-				   numa_all_nodes_ptr->size,
+				   numa_mems_allowed->maskp,
+				   numa_mems_allowed->size,
 				   MPOL_MF_MOVE);
 		if (st != 0) {
 			ib_logf(IB_LOG_LEVEL_WARN,
@@ -1551,11 +1552,13 @@ buf_pool_init(
 
 #ifdef HAVE_LIBNUMA
 	if (srv_numa_interleave) {
+		struct bitmask *numa_mems_allowed = numa_get_mems_allowed();
+
 		ib_logf(IB_LOG_LEVEL_INFO,
 			"Setting NUMA memory policy to MPOL_INTERLEAVE");
 		if (set_mempolicy(MPOL_INTERLEAVE,
-				  numa_all_nodes_ptr->maskp,
-				  numa_all_nodes_ptr->size) != 0) {
+				  numa_mems_allowed->maskp,
+				  numa_mems_allowed->size) != 0) {
 			ib_logf(IB_LOG_LEVEL_WARN,
 				"Failed to set NUMA memory policy to"
 				" MPOL_INTERLEAVE (error: %s).",

--- a/storage/xtradb/buf/buf0buf.cc
+++ b/storage/xtradb/buf/buf0buf.cc
@@ -1235,10 +1235,11 @@ buf_chunk_init(
 
 #ifdef HAVE_LIBNUMA
 	if (srv_numa_interleave) {
+		struct bitmask *numa_mems_allowed = numa_get_mems_allowed();
 		int	st = mbind(chunk->mem, chunk->mem_size,
 				   MPOL_INTERLEAVE,
-				   numa_all_nodes_ptr->maskp,
-				   numa_all_nodes_ptr->size,
+				   numa_mems_allowed->maskp,
+				   numa_mems_allowed->size,
 				   MPOL_MF_MOVE);
 		if (st != 0) {
 			ib_logf(IB_LOG_LEVEL_WARN,
@@ -1645,11 +1646,13 @@ buf_pool_init(
 
 #ifdef HAVE_LIBNUMA
 	if (srv_numa_interleave) {
+		struct bitmask *numa_mems_allowed = numa_get_mems_allowed();
+
 		ib_logf(IB_LOG_LEVEL_INFO,
 			"Setting NUMA memory policy to MPOL_INTERLEAVE");
 		if (set_mempolicy(MPOL_INTERLEAVE,
-				  numa_all_nodes_ptr->maskp,
-				  numa_all_nodes_ptr->size) != 0) {
+				  numa_mems_allowed->maskp,
+				  numa_mems_allowed->size) != 0) {
 			ib_logf(IB_LOG_LEVEL_WARN,
 				"Failed to set NUMA memory policy to"
 				" MPOL_INTERLEAVE (error: %s).",


### PR DESCRIPTION
Using numa_all_nodes_ptr was excessively optimistic. Due to
constraints in systemd, containers or otherwise mysqld could of been
limited to a smaller set of cpus. Use the numa_get_mems_allowed
library function to see what we can interleave between before doing
so. The alternative is to fail interleaving overall.

I submit this under the MCA.