### PR TITLE
MDEV-10832 - Out of tree build: mysql_install_db to see all .sql files

### DIFF
--- a/scripts/mysql_install_db.pl.in
+++ b/scripts/mysql_install_db.pl.in
@@ -297,17 +297,19 @@ parse_arguments($opt, 'PICK-ARGS-FROM-ARGV', @ARGV);
 # ----------------------------------------------------------------------
 
 # FIXME $extra_bindir is not used
-my ($bindir,$extra_bindir,$mysqld,$pkgdatadir,$mysqld_opt,$scriptdir);
+my ($bindir,$extra_bindir,$mysqld,$srcpkgdatadir,$buildpkgdatadir,$mysqld_opt,
+    $scriptdir);
 
 if ( $opt->{srcdir} )
 {
-  $opt->{basedir} = $opt->{builddir};
-  $bindir         = "$opt->{basedir}/client";
-  $extra_bindir   = "$opt->{basedir}/extra";
-  $mysqld         = "$opt->{basedir}/sql/mysqld";
-  $mysqld_opt     = "--language=$opt->{srcdir}/sql/share/english";
-  $pkgdatadir     = "$opt->{srcdir}/scripts";
-  $scriptdir      = "$opt->{srcdir}/scripts";
+  $opt->{basedir}  = $opt->{builddir};
+  $bindir          = "$opt->{basedir}/client";
+  $extra_bindir    = "$opt->{basedir}/extra";
+  $mysqld          = "$opt->{basedir}/sql/mysqld";
+  $mysqld_opt      = "--language=$opt->{srcdir}/sql/share/english";
+  $srcpkgdatadir   = "$opt->{srcdir}/scripts";
+  $buildpkgdatadir = "$opt->{builddir}/scripts";
+  $scriptdir       = "$opt->{srcdir}/scripts";
 }
 elsif ( $opt->{basedir} )
 {
@@ -317,18 +319,20 @@ elsif ( $opt->{basedir} )
                                     "libexec","sbin","bin") ||  # ,"sql"
                     find_in_basedir($opt,"file","mysqld-nt",
                                   "bin");  # ,"sql"
-  $pkgdatadir     = find_in_basedir($opt,"dir","fill_help_tables.sql",
+  $srcpkgdatadir  = find_in_basedir($opt,"dir","fill_help_tables.sql",
                                     "share","share/mysql");  # ,"scripts"
+  $buildpkgdir    = $srcpkgdatadir;
   $scriptdir      = "$opt->{basedir}/scripts";
 }
 else
 {
-  $opt->{basedir} = '@prefix@';
-  $bindir         = '@bindir@';
-  $extra_bindir   = $bindir;
-  $mysqld         = '@libexecdir@/mysqld';
-  $pkgdatadir     = '@pkgdatadir@';
-  $scriptdir      = '@scriptdir@';
+  $opt->{basedir}  = '@prefix@';
+  $bindir          = '@bindir@';
+  $extra_bindir    = $bindir;
+  $mysqld          = '@libexecdir@/mysqld';
+  $srcpkgdatadir   = '@pkgdatadir@';
+  $buildpkgdatadir = '@pkgdatadir@';
+  $scriptdir       = '@scriptdir@';
 }
 
 unless ( $opt->{ldata} )
@@ -336,19 +340,15 @@ unless ( $opt->{ldata} )
   $opt->{ldata} = '@localstatedir@';
 }
 
-if ( $opt->{srcdir} )
-{
-  $pkgdatadir = "$opt->{srcdir}/scripts";
-}
 
 # ----------------------------------------------------------------------
 # Set up paths to SQL scripts required for bootstrap
 # ----------------------------------------------------------------------
 
-my $fill_help_tables     = "$pkgdatadir/fill_help_tables.sql";
-my $create_system_tables = "$pkgdatadir/mysql_system_tables.sql";
-my $fill_system_tables   = "$pkgdatadir/mysql_system_tables_data.sql";
-my $maria_add_gis_sp     = "$pkgdatadir/maria_add_gis_sp_bootstrap.sql";
+my $fill_help_tables     = "$srcpkgdatadir/fill_help_tables.sql";
+my $create_system_tables = "$srcpkgdatadir/mysql_system_tables.sql";
+my $fill_system_tables   = "$srcpkgdatadir/mysql_system_tables_data.sql";
+my $maria_add_gis_sp     = "$buildpkgdatadir/maria_add_gis_sp_bootstrap.sql";
 
 foreach my $f ( $fill_help_tables,$create_system_tables,$fill_system_tables,$maria_add_gis_sp )
 {

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -270,7 +270,8 @@ then
   extra_bindir="$basedir/extra"
   mysqld="$basedir/sql/mysqld"
   langdir="$basedir/sql/share/english"
-  pkgdatadir="$srcdir/scripts"
+  srcpkgdatadir="$srcdir/scripts"
+  buildpkgdatadir="$builddir/scripts"
   scriptdir="$srcdir/scripts"
 elif test -n "$basedir"
 then
@@ -288,7 +289,8 @@ then
     cannot_find_file errmsg.sys $basedir/share/english $basedir/share/mysql/english
     exit 1
   fi
-  pkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql`
+  srcpkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql`
+  buildpkgdatadir=$srcpkgdatadir
   if test -z "$pkgdatadir"
   then
     cannot_find_file fill_help_tables.sql $basedir/share $basedir/share/mysql
@@ -300,16 +302,17 @@ else
   bindir="@bindir@"
   extra_bindir="$bindir"
   mysqld="@libexecdir@/mysqld"
-  pkgdatadir="@pkgdatadir@"
+  srcpkgdatadir="@pkgdatadir@"
+  buildpkgdatadir="@pkgdatadir@"
   scriptdir="@scriptdir@"
 fi
 
 # Set up paths to SQL scripts required for bootstrap
-fill_help_tables="$pkgdatadir/fill_help_tables.sql"
-create_system_tables="$pkgdatadir/mysql_system_tables.sql"
-create_system_tables2="$pkgdatadir/mysql_performance_tables.sql"
-fill_system_tables="$pkgdatadir/mysql_system_tables_data.sql"
-maria_add_gis_sp="$pkgdatadir/maria_add_gis_sp_bootstrap.sql"
+fill_help_tables="$srcpkgdatadir/fill_help_tables.sql"
+create_system_tables="$srcpkgdatadir/mysql_system_tables.sql"
+create_system_tables2="$srcpkgdatadir/mysql_performance_tables.sql"
+fill_system_tables="$srcpkgdatadir/mysql_system_tables_data.sql"
+maria_add_gis_sp="$buildpkgdatadir/maria_add_gis_sp_bootstrap.sql"
 
 for f in "$fill_help_tables" "$create_system_tables" "$create_system_tables2" "$fill_system_tables" "$maria_add_gis_sp"
 do


### PR DESCRIPTION
Since MDEV-7875 (da0991c6), not all sql source files are in the source directory, maria_add_gis_sp_bootstrap.sql is in the build directory.

When mariadb is build out of the source tree mysql_install_db should be able to see all these when --{src,build}dir are used/


After patch:
<pre>
~/repos/build-mariadb-server-10.1]$  mkdir /tmp/datadir && scripts/mysql_install_db --srcdir=../mariadb-server --builddir=`pwd` --datadir=/tmp/datadir --log-bin=/tmp/datadir/mysqlbin --socket /tmp/s.sock 
Installing MariaDB/MySQL system tables in '/tmp/datadir' ...
2016-09-19 15:33:50 140578819905728 [Note] /home/dan/repos/build-mariadb-server-10.1/sql/mysqld (mysqld 10.1.18-MariaDB) starting as process 24072 ...
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Using mutexes to ref count buffer pool pages
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: The InnoDB memory heap is disabled
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Compressed tables use zlib 1.2.8
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Using Linux native AIO
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Using SSE crc32 instructions
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Initializing buffer pool, size = 128.0M
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Completed initialization of buffer pool
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: The first specified data file ./ibdata1 did not exist: a new database to be created!
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Setting file ./ibdata1 size to 12 MB
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Database physically writes the file full: wait...
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Setting log file ./ib_logfile101 size to 48 MB
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Setting log file ./ib_logfile1 size to 48 MB
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Renaming log file ./ib_logfile101 to ./ib_logfile0
2016-09-19 15:33:51 140578819905728 [Warning] InnoDB: New log files created, LSN=45883
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Doublewrite buffer not found: creating new
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Doublewrite buffer created
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: 128 rollback segment(s) are active.
2016-09-19 15:33:51 140578819905728 [Warning] InnoDB: Creating foreign key constraint system tables.
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Foreign key constraint system tables created
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Creating tablespace and datafile system tables.
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Tablespace and datafile system tables created.
2016-09-19 15:33:51 140578819905728 [Note] InnoDB: Waiting for purge to start
2016-09-19 15:33:51 140578819905728 [Note] InnoDB:  Percona XtraDB (http://www.percona.com) 5.6.31-77.0 started; log sequence number 0
2016-09-19 15:33:51 140578094315264 [Note] InnoDB: Dumping buffer pool(s) not yet started
2016-09-19 15:33:51 140578819894016 [Warning] Failed to load slave replication state from table mysql.gtid_slave_pos: 1146: Table 'mysql.gtid_slave_pos' doesn't exist
OK
Filling help tables...
2016-09-19 15:33:53 140127941306560 [Note] /home/dan/repos/build-mariadb-server-10.1/sql/mysqld (mysqld 10.1.18-MariaDB) starting as process 24103 ...
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Using mutexes to ref count buffer pool pages
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: The InnoDB memory heap is disabled
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Compressed tables use zlib 1.2.8
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Using Linux native AIO
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Using SSE crc32 instructions
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Initializing buffer pool, size = 128.0M
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Completed initialization of buffer pool
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Highest supported file format is Barracuda.
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: 128 rollback segment(s) are active.
2016-09-19 15:33:53 140127941306560 [Note] InnoDB: Waiting for purge to start
2016-09-19 15:33:53 140127941306560 [Note] InnoDB:  Percona XtraDB (http://www.percona.com) 5.6.31-77.0 started; log sequence number 1616799
2016-09-19 15:33:53 140127223396096 [Note] InnoDB: Dumping buffer pool(s) not yet started
OK
Creating OpenGIS required SP-s...
2016-09-19 15:33:56 140390818265280 [Note] /home/dan/repos/build-mariadb-server-10.1/sql/mysqld (mysqld 10.1.18-MariaDB) starting as process 24133 ...
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Using mutexes to ref count buffer pool pages
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: The InnoDB memory heap is disabled
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Compressed tables use zlib 1.2.8
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Using Linux native AIO
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Using SSE crc32 instructions
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Initializing buffer pool, size = 128.0M
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Completed initialization of buffer pool
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Highest supported file format is Barracuda.
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: 128 rollback segment(s) are active.
2016-09-19 15:33:56 140390818265280 [Note] InnoDB: Waiting for purge to start
2016-09-19 15:33:56 140390818265280 [Note] InnoDB:  Percona XtraDB (http://www.percona.com) 5.6.31-77.0 started; log sequence number 1616809
2016-09-19 15:33:56 140390097204992 [Note] InnoDB: Dumping buffer pool(s) not yet started
OK
</pre>

I submit under the MCA.