### PR TITLE
MDEV-10982 - Show real version number in 'ready for connections' message

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6007,11 +6007,25 @@ int mysqld_main(int argc, char **argv)
   }
 
   disable_log_notes= 0; /* Startup done, now we can give notes again */
-  sql_print_information(ER_DEFAULT(ER_STARTUP),my_progname,server_version,
-                        ((mysql_socket_getfd(unix_sock) == INVALID_SOCKET) ?
-                         (char*) "" : mysqld_unix_port),
-                         mysqld_port,
-                         MYSQL_COMPILATION_COMMENT);
+  if (IS_SYSVAR_AUTOSIZE(&server_version_ptr)) {
+    sql_print_information(ER_DEFAULT(ER_STARTUP),my_progname,server_version,
+                          ((mysql_socket_getfd(unix_sock) == INVALID_SOCKET) ?
+                           (char*) "" : mysqld_unix_port),
+                          mysqld_port,
+                          MYSQL_COMPILATION_COMMENT);
+  } else {
+    char version_str[2*SERVER_VERSION_LENGTH + 10];
+    char real_server_version[SERVER_VERSION_LENGTH];
+
+    set_server_version(real_server_version, sizeof(real_server_version));
+    sprintf(version_str, "%s' as '%s", real_server_version, server_version);
+
+    sql_print_information(ER_DEFAULT(ER_STARTUP),my_progname,version_str,
+                          ((mysql_socket_getfd(unix_sock) == INVALID_SOCKET) ?
+                           (char*) "" : mysqld_unix_port),
+                          mysqld_port,
+                          MYSQL_COMPILATION_COMMENT);
+  }
 
   // try to keep fd=0 busy
   if (!freopen(IF_WIN("NUL","/dev/null"), "r", stdin))


### PR DESCRIPTION
See https://jira.mariadb.org/browse/MDEV-10982

When setting a fake version for clients the real and fake version string were printed at the beginning of the startup messages, but only the fake one was printed as part of the "ready for connections" message
