### PR TITLE
MDEV-10541 - Don't use RPL_VERSION_HACK if version string is explicitly set

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11456,7 +11456,11 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio,
     data_len= SCRAMBLE_LENGTH;
   }
 
-  end= strxnmov(end, SERVER_VERSION_LENGTH, RPL_VERSION_HACK, server_version, NullS) + 1;
+  if (IS_SYSVAR_AUTOSIZE(&server_version_ptr)) {
+    end= strxnmov(end, SERVER_VERSION_LENGTH, RPL_VERSION_HACK, server_version, NullS) + 1;
+  } else {
+    end= strnmov(end, server_version, SERVER_VERSION_LENGTH) + 1;
+  }
   int4store((uchar*) end, mpvio->thd->thread_id);
   end+= 4;
 


### PR DESCRIPTION
MariaDB clients know how to filter out the RPL HACK prefix, but other clients don't

Only add the RPL prefix now when using the default "real" version number, but not when a "fake" version number has explicitly been set. When explicitly setting it via --version=... we want clients to see exactly that.
