### PR TITLE
MDEV-9451: Remove innodb_buffer_pool_populate from xtradb (10.2)

### DIFF
--- a/storage/xtradb/handler/ha_innodb.cc
+++ b/storage/xtradb/handler/ha_innodb.cc
@@ -20265,11 +20265,6 @@ static MYSQL_SYSVAR_LONGLONG(buffer_pool_size, innobase_buffer_pool_size,
   "The size of the memory buffer InnoDB uses to cache data and indexes of its tables.",
   NULL, NULL, 128*1024*1024L, 5*1024*1024L, LONGLONG_MAX, 1024*1024L);
 
-static MYSQL_SYSVAR_BOOL(buffer_pool_populate, srv_numa_interleave,
-  PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
-  "Depricated. This option is temporary alias of --innodb-numa-interleave.",
-  NULL, NULL, FALSE);
-
 static MYSQL_SYSVAR_ENUM(foreground_preflush, srv_foreground_preflush,
   PLUGIN_VAR_OPCMDARG,
   "The algorithm InnoDB uses for the query threads at sync preflush.  "


### PR DESCRIPTION
innodb_buffer_pool_populate has not had an effect since 10.0.23
in commit 1e270d504d56cb015efe060b319e3a5b9bc6513f when its
functionality was removed.

As we've only just enabled LIBNUMA in MDEV-10829 it isn't logical
to have innodb_buffer_pool_populate aliasing for innodb_numa_interleave
this late in the game.

So the simplest way is just to remove innodb_buffer_pool_populate.

I submit this under the MCA.