### PR TITLE
MDEV-11451: isinf || isnan -> !isfinite

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -2671,7 +2671,7 @@ String *Item_func_format::val_str_ascii(String *str)
       return 0; /* purecov: inspected */
     nr= my_double_round(nr, (longlong) dec, FALSE, FALSE);
     str->set_real(nr, dec, &my_charset_numeric);
-    if (isnan(nr) || my_isinf(nr))
+    if (!isfinite(nr))
       return str;
     str_length=str->length();
   }

--- a/storage/innobase/gis/gis0geo.cc
+++ b/storage/innobase/gis/gis0geo.cc
@@ -364,8 +364,9 @@ mbr_join_square(
 		b += 2;
 	} while (a != end);
 
-	/* Check for infinity or NaN, so we don't get NaN in calculations */
-	if (my_isinf(square) || my_isnan(square)) {
+	/* Check if finite (not infinity or NaN),
+	so we don't get NaN in calculations */
+	if (!isfinite(square)) {
 		return DBL_MAX;
 	}
 

--- a/storage/innobase/gis/gis0rtree.cc
+++ b/storage/innobase/gis/gis0rtree.cc
@@ -1988,7 +1988,7 @@ rtr_estimate_n_rows_in_range(
 	mtr_commit(&mtr);
 	mem_heap_free(heap);
 
-	if (my_isinf(area) || my_isnan(area)) {
+	if (!isfinite(area)) {
 		return(HA_POS_ERROR);
 	}
 

--- a/storage/myisam/rt_split.c
+++ b/storage/myisam/rt_split.c
@@ -69,8 +69,8 @@ static double mbr_join_square(const double *a, const double *b, int n_dim)
     b += 2;
   }while (a != end);
 
-   /* Check for infinity or NaN */
-  if (my_isinf(square) || isnan(square))
+   /* Check if not finite (i.e. infinity or NaN) */
+  if (!isfinite(square))
     square = DBL_MAX;
 
   return square;


### PR DESCRIPTION
my_isinf(square) || my_isnan(square) -> !isfinite(square)

There are only 3 logical states for a number. The isfinite is a single call rather than multiple leaving scope for compiler/architecture optimization.

Changed the logic as follows in a few files.

my_isinf(square) || my_isnan(square) -> !isfinite(square)

I submit this under the MCA.