### PR TITLE
MDEV-11454: Make innodb_buffer_pool_dump_pct refer to the entire buff…

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_pct_function.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_pct_function.result
@@ -1,0 +1,54 @@
+SET GLOBAL innodb_buffer_pool_dump_pct=25, global innodb_buffer_pool_dump_at_shutdown=1;;
+# populate with data
+CREATE TABLE t1 (
+c01 blob, c02 blob, c03 blob, c04 blob, c05 blob,
+c06 blob, c07 blob, c08 blob, c09 blob, c10 blob,
+c11 blob, c12 blob, c13 blob, c14 blob, c15 blob,
+c16 blob, c17 blob, c18 blob, c19 blob, c20 blob,
+c21 blob, c22 blob, c23 blob, c24 blob, c25 blob,
+c26 blob, c27 blob, c28 blob, c29 blob, c30 blob,
+c31 blob, c32 blob, c33 blob, c34 blob, c35 blob,
+c36 blob, c37 blob, c38 blob, c39 blob, c40 blob,
+c41 blob, c42 blob, c43 blob, c44 blob, c45 blob,
+c46 blob, c47 blob, c48 blob, c49 blob, c50 blob,
+c51 blob, c52 blob, c53 blob, c54 blob, c55 blob,
+c56 blob, c57 blob, c58 blob, c59 blob, c60 blob,
+c61 blob, c62 blob, c63 blob, c64 blob
+) ROW_FORMAT=dynamic;
+SET @a = repeat('a', 16 * 1024);
+INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a
+);
+insert into t1 select * from t1;
+# Restart server
+SET GLOBAL innodb_buffer_pool_load_now=1;
+# Case 1: Limit from innodb_buffer_pool_dump_pct
+SELECT 256 as 'Previous pool pages',
+ROUND(25 / 100 * @@innodb_buffer_pool_size / @@innodb_page_size) as 'Limit',
+128 as 'Pages saved';
+Previous pool pages	Limit	Pages saved
+256	128	128
+# Case 2: blog_pages is the minimum.
+# load buffer pool with entire table.
+select * from t1;
+SET GLOBAL innodb_buffer_pool_dump_pct=75, global innodb_buffer_pool_dump_at_shutdown=1;
+# Restart server
+SET GLOBAL innodb_buffer_pool_load_now=1;
+# now loaded
+SELECT 256 as 'Previous pool pages',
+ROUND(75 / 100 * @@innodb_buffer_pool_size / @@innodb_page_size) as 'Limit',
+256 as 'Pages saved';
+Previous pool pages	Limit	Pages saved
+256	384	256
+DROP TABLE t1;

--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_pct_function.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_pct_function.result
@@ -1,4 +1,3 @@
-SET GLOBAL innodb_buffer_pool_dump_pct=25, global innodb_buffer_pool_dump_at_shutdown=1;;
 # populate with data
 CREATE TABLE t1 (
 c01 blob, c02 blob, c03 blob, c04 blob, c05 blob,
@@ -31,6 +30,7 @@ INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,
 @a,@a,@a,@a
 );
 insert into t1 select * from t1;
+SET GLOBAL innodb_buffer_pool_dump_pct=25,GLOBAL innodb_fast_shutdown=0, GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
 # Restart server
 SET GLOBAL innodb_buffer_pool_load_now=1;
 # Case 1: Limit from innodb_buffer_pool_dump_pct

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.opt
@@ -1,0 +1,5 @@
+--loose-default-storage-engine=innodb
+--loose-innodb_buffer_pool_load_at_startup=0
+--loose-innodb_buffer_pool_dump_at_shutdown=0
+--loose-innodb-buffer-pool-size=8M
+--loose-innodb-page-size=16k

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.opt
@@ -2,4 +2,5 @@
 --loose-innodb_buffer_pool_load_at_startup=0
 --loose-innodb_buffer_pool_dump_at_shutdown=0
 --loose-innodb-buffer-pool-size=8M
+--loose-innodb-buffer-pool-instances=1
 --loose-innodb-page-size=16k

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.test
@@ -1,0 +1,110 @@
+#
+# Functional test for innodb_buffer_pool_dump_pct
+#
+# From MDEV-11454 the amount dumped is the minimum of:
+# * innodb_buffer_pool_dump_pct * Innodb_buffer_pool_pages_total * innodb_page_size
+# * innodb_buffer_pool_pages_data * innodb_page_size
+
+-- source include/have_innodb.inc
+
+--let $PCT=25
+
+--eval SET GLOBAL innodb_buffer_pool_dump_pct=$PCT, global innodb_buffer_pool_dump_at_shutdown=1;
+
+--echo # populate with data
+
+CREATE TABLE t1 (
+c01 blob, c02 blob, c03 blob, c04 blob, c05 blob,
+c06 blob, c07 blob, c08 blob, c09 blob, c10 blob,
+c11 blob, c12 blob, c13 blob, c14 blob, c15 blob,
+c16 blob, c17 blob, c18 blob, c19 blob, c20 blob,
+c21 blob, c22 blob, c23 blob, c24 blob, c25 blob,
+c26 blob, c27 blob, c28 blob, c29 blob, c30 blob,
+c31 blob, c32 blob, c33 blob, c34 blob, c35 blob,
+c36 blob, c37 blob, c38 blob, c39 blob, c40 blob,
+c41 blob, c42 blob, c43 blob, c44 blob, c45 blob,
+c46 blob, c47 blob, c48 blob, c49 blob, c50 blob,
+c51 blob, c52 blob, c53 blob, c54 blob, c55 blob,
+c56 blob, c57 blob, c58 blob, c59 blob, c60 blob,
+c61 blob, c62 blob, c63 blob, c64 blob
+) ROW_FORMAT=dynamic;
+
+SET @a = repeat('a', 16 * 1024);
+INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a
+);
+
+insert into t1 select * from t1;
+
+--let $blob_pages=`select count(*)  from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE`
+
+# Dump on shutdown has been set - shutdown now
+
+--echo # Restart server
+--let $shutdown_timeout= 10
+--let $allow_rpl_inited= 1
+--source include/restart_mysqld.inc
+
+SET GLOBAL innodb_buffer_pool_load_now=1;
+
+# Wait fit for the load to complete
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 33) = 'Buffer pool(s) load completed at '
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_status';
+-- source include/wait_condition.inc
+
+
+--let $loaded_blob_pages=`select count(*)  from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE`
+
+--echo # Case 1: Limit from innodb_buffer_pool_dump_pct
+
+eval SELECT $blob_pages as 'Previous pool pages',
+	ROUND($PCT / 100 * @@innodb_buffer_pool_size / @@innodb_page_size) as 'Limit',
+	$loaded_blob_pages as 'Pages saved';
+
+--echo # Case 2: blog_pages is the minimum.
+
+--echo # load buffer pool with entire table.
+--disable_result_log
+select * from t1;
+--enable_result_log
+
+--let $PCT=75
+eval SET GLOBAL innodb_buffer_pool_dump_pct=$PCT, global innodb_buffer_pool_dump_at_shutdown=1;
+
+--let $blob_pages=`select count(*)  from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE`
+
+--echo # Restart server
+--source include/restart_mysqld.inc
+
+
+SET GLOBAL innodb_buffer_pool_load_now=1;
+
+# Wait for load
+-- source include/wait_condition.inc
+
+--echo # now loaded
+
+--let $loaded_blob_pages=`select count(*)  from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE`
+
+eval SELECT $blob_pages as 'Previous pool pages',
+	ROUND($PCT / 100 * @@innodb_buffer_pool_size / @@innodb_page_size) as 'Limit',
+	$loaded_blob_pages as 'Pages saved';
+
+# Clean up
+#
+#
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/ib_buffer_pool
+DROP TABLE t1;

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_function.test
@@ -7,10 +7,6 @@
 
 -- source include/have_innodb.inc
 
---let $PCT=25
-
---eval SET GLOBAL innodb_buffer_pool_dump_pct=$PCT, global innodb_buffer_pool_dump_at_shutdown=1;
-
 --echo # populate with data
 
 CREATE TABLE t1 (
@@ -49,11 +45,12 @@ insert into t1 select * from t1;
 
 --let $blob_pages=`select count(*)  from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE`
 
+--let $PCT=25
+--eval SET GLOBAL innodb_buffer_pool_dump_pct=$PCT,GLOBAL innodb_fast_shutdown=0, GLOBAL innodb_buffer_pool_dump_at_shutdown=1
+
 # Dump on shutdown has been set - shutdown now
 
 --echo # Restart server
---let $shutdown_timeout= 10
---let $allow_rpl_inited= 1
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_buffer_pool_load_now=1;

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -322,6 +322,10 @@ buf_dump(
 			t_pages = buf_pool->curr_size
 					*  srv_buf_pool_dump_pct / 100;
 			if (n_pages > t_pages) {
+				buf_dump_status(STATUS_INFO,
+					"Instance %d, restricted to %u pages " \
+					"due to innodb_buf_pool_dump_pct (%d)",
+					i, t_pages, srv_buf_pool_dump_pct);
 				n_pages = t_pages;
 			}
 

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -313,9 +313,17 @@ buf_dump(
 		}
 
 		if (srv_buf_pool_dump_pct != 100) {
+			ulint		t_pages;
+
 			ut_ad(srv_buf_pool_dump_pct < 100);
 
-			n_pages = n_pages * srv_buf_pool_dump_pct / 100;
+			/* limit the number of total pages dumped to X% of the
+			 * total number of pages */
+			t_pages = buf_pool->curr_size
+					*  srv_buf_pool_dump_pct / 100;
+			if (n_pages > t_pages) {
+				n_pages = t_pages;
+			}
 
 			if (n_pages == 0) {
 				n_pages = 1;

--- a/storage/xtradb/buf/buf0dump.cc
+++ b/storage/xtradb/buf/buf0dump.cc
@@ -256,6 +256,10 @@ buf_dump(
 			t_pages = buf_pool->curr_size
 					*  srv_buf_pool_dump_pct / 100;
 			if (n_pages > t_pages) {
+				buf_dump_status(STATUS_INFO,
+					"Instance %d, restricted to %u pages " \
+					"due to innodb_buf_pool_dump_pct (%d)",
+					i, t_pages, srv_buf_pool_dump_pct);
 				n_pages = t_pages;
 			}
 

--- a/storage/xtradb/buf/buf0dump.cc
+++ b/storage/xtradb/buf/buf0dump.cc
@@ -155,8 +155,7 @@ buf_load_status(
 		fmt, ap);
 
 	if (severity == STATUS_NOTICE || severity == STATUS_ERR) {
-		ut_print_timestamp(stderr);
-		fprintf(stderr, " InnoDB: %s\n",
+		ib_logf((ib_log_level_t) severity, "%s",
 			export_vars.innodb_buffer_pool_load_status);
 	}
 

--- a/storage/xtradb/buf/buf0dump.cc
+++ b/storage/xtradb/buf/buf0dump.cc
@@ -248,9 +248,17 @@ buf_dump(
 		}
 
 		if (srv_buf_pool_dump_pct != 100) {
+			ulint		t_pages;
+
 			ut_ad(srv_buf_pool_dump_pct < 100);
 
-			n_pages = n_pages * srv_buf_pool_dump_pct / 100;
+			/* limit the number of total pages dumped to X% of the
+			 * total number of pages */
+			t_pages = buf_pool->curr_size
+					*  srv_buf_pool_dump_pct / 100;
+			if (n_pages > t_pages) {
+				n_pages = t_pages;
+			}
 
 			if (n_pages == 0) {
 				n_pages = 1;


### PR DESCRIPTION
…er pool size

Rather than innodb_buffer_pool_dump_pct referring to the percentage of hot data
in the buffer pool, it refers to the entire buffer pool size. This means that a
completed load followed by a shutdown will write the exact same data.

The problem was:

With innodb_buffer_pool_dump_pct say 25% (the default since 10.2.2), a server
started will restore 25% of the buffer pool size with the expectation that over
time the rest of the buffer pool will be populated. Then on shutdown 25% will
be saved.

If a server is started and then is shutdown a) without much activity occurring
b) is started as a hot spare and shutdown before being used, then 6.25% (25%
of 25%) of the buffer pool is saved.

This will generate bigger dump files for users who don't have a full
innodb_buffer_pool however a realistic scenario is a buffer pool should be
completely used.

I submit this under the MCA.