### PR TITLE
MDEV-11455: create status variable innodb_buffer_pool_load_incomplete

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_abort_loads.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_abort_loads.result
@@ -4,7 +4,7 @@ SELECT variable_name, variable_value
 FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
 variable_name	variable_value
-INNODB_BUFFER_POOL_LOAD_INCOMPLETE	0
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	OFF
 
 # populate with data
 CREATE TABLE t1 (
@@ -37,17 +37,17 @@ INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,
 @a,@a,@a,@a,@a,
 @a,@a,@a,@a
 );
-SET GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
+SET GLOBAL innodb_buffer_pool_dump_at_shutdown=1, GLOBAL innodb_fast_shutdown=0;
 
 # Restart server
-SET debug_sync="buf_load SIGNAL stalling",
+SET debug_sync="buf_load WAIT_FOR shutdown",
 GLOBAL innodb_buffer_pool_load_now=1,
 GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
 SELECT variable_name, variable_value
 FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
 variable_name	variable_value
-INNODB_BUFFER_POOL_LOAD_INCOMPLETE	1
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	ON
 
 # Restart server
 
@@ -64,7 +64,7 @@ SELECT variable_name, variable_value
 FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
 variable_name	variable_value
-INNODB_BUFFER_POOL_LOAD_INCOMPLETE	0
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	OFF
 
 # Load it again and abort with innodb_buffer_pool_load_abort=1
 SET debug_sync="buf_load WAIT_FOR abort_release",
@@ -78,7 +78,7 @@ FROM information_schema.global_status
 WHERE LOWER(variable_name) IN ('innodb_buffer_pool_load_incomplete', 'innodb_buffer_pool_load_status');
 variable_name	variable_value
 INNODB_BUFFER_POOL_LOAD_STATUS	Buffer pool(s) load aborted on request
-INNODB_BUFFER_POOL_LOAD_INCOMPLETE	1
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	ON
 
 # innodb_buffer_pool_dump_now=1 should reset the innodb_buffer_pool_load_incomplete status
 SET GLOBAL innodb_buffer_pool_dump_now=1;
@@ -87,7 +87,7 @@ FROM information_schema.global_status
 WHERE LOWER(variable_name) IN ('innodb_buffer_pool_load_incomplete', 'innodb_buffer_pool_dump_status');
 variable_name	VALUE
 INNODB_BUFFER_POOL_DUMP_STATUS	Buffer pool(s) dump completed at 
-INNODB_BUFFER_POOL_LOAD_INCOMPLETE	0
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	OFF
 SET DEBUG_SYNC= 'RESET';
 
 # Clean up

--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_abort_loads.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_abort_loads.result
@@ -1,0 +1,94 @@
+
+# innodb_buffer_pool_load_incomplete defaults 0
+SELECT variable_name, variable_value
+FROM information_schema.global_status
+WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
+variable_name	variable_value
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	0
+
+# populate with data
+CREATE TABLE t1 (
+c01 blob, c02 blob, c03 blob, c04 blob, c05 blob,
+c06 blob, c07 blob, c08 blob, c09 blob, c10 blob,
+c11 blob, c12 blob, c13 blob, c14 blob, c15 blob,
+c16 blob, c17 blob, c18 blob, c19 blob, c20 blob,
+c21 blob, c22 blob, c23 blob, c24 blob, c25 blob,
+c26 blob, c27 blob, c28 blob, c29 blob, c30 blob,
+c31 blob, c32 blob, c33 blob, c34 blob, c35 blob,
+c36 blob, c37 blob, c38 blob, c39 blob, c40 blob,
+c41 blob, c42 blob, c43 blob, c44 blob, c45 blob,
+c46 blob, c47 blob, c48 blob, c49 blob, c50 blob,
+c51 blob, c52 blob, c53 blob, c54 blob, c55 blob,
+c56 blob, c57 blob, c58 blob, c59 blob, c60 blob,
+c61 blob, c62 blob, c63 blob, c64 blob
+) ROW_FORMAT=dynamic;
+SET @a = repeat('a', 16 * 1024);
+INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a
+);
+SET GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
+
+# Restart server
+SET debug_sync="buf_load SIGNAL stalling",
+GLOBAL innodb_buffer_pool_load_now=1,
+GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
+SELECT variable_name, variable_value
+FROM information_schema.global_status
+WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
+variable_name	variable_value
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	1
+
+# Restart server
+
+# Load buffer pool
+SET GLOBAL innodb_buffer_pool_load_now=1;
+
+# Should be more than previous as we didn't overwrite our save file
+select count(*) > Previous_loaded as Loaded_more from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE;;
+Loaded_more
+1
+
+# Successful, so innodb_buffer_pool_load_incomplete should be 0
+SELECT variable_name, variable_value
+FROM information_schema.global_status
+WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
+variable_name	variable_value
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	0
+
+# Load it again and abort with innodb_buffer_pool_load_abort=1
+SET debug_sync="buf_load WAIT_FOR abort_release",
+GLOBAL innodb_buffer_pool_load_now=1;
+SET GLOBAL innodb_buffer_pool_load_abort=1;
+SET DEBUG_SYNC= 'now SIGNAL abort_release';
+
+# was aborted - should be incomplete
+SELECT variable_name, variable_value
+FROM information_schema.global_status
+WHERE LOWER(variable_name) IN ('innodb_buffer_pool_load_incomplete', 'innodb_buffer_pool_load_status');
+variable_name	variable_value
+INNODB_BUFFER_POOL_LOAD_STATUS	Buffer pool(s) load aborted on request
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	1
+
+# innodb_buffer_pool_dump_now=1 should reset the innodb_buffer_pool_load_incomplete status
+SET GLOBAL innodb_buffer_pool_dump_now=1;
+SELECT variable_name, SUBSTR(variable_value, 1, 33) as VALUE
+FROM information_schema.global_status
+WHERE LOWER(variable_name) IN ('innodb_buffer_pool_load_incomplete', 'innodb_buffer_pool_dump_status');
+variable_name	VALUE
+INNODB_BUFFER_POOL_DUMP_STATUS	Buffer pool(s) dump completed at 
+INNODB_BUFFER_POOL_LOAD_INCOMPLETE	0
+SET DEBUG_SYNC= 'RESET';
+
+# Clean up
+DROP TABLE t1;

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.opt
@@ -1,0 +1,5 @@
+--loose-default-storage-engine=innodb
+--loose-innodb_buffer_pool_load_at_startup=0
+--loose-innodb_buffer_pool_dump_at_shutdown=0
+--loose-innodb-buffer-pool-size=8M
+--loose-innodb-page-size=16k

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.opt
@@ -2,4 +2,5 @@
 --loose-innodb_buffer_pool_load_at_startup=0
 --loose-innodb_buffer_pool_dump_at_shutdown=0
 --loose-innodb-buffer-pool-size=8M
+--loose-innodb-buffer-pool-instances=1
 --loose-innodb-page-size=16k

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.test
@@ -45,16 +45,14 @@ INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,
 @a,@a,@a,@a
 );
 
-SET GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
+SET GLOBAL innodb_buffer_pool_dump_at_shutdown=1, GLOBAL innodb_fast_shutdown=0;
 # Dump on shutdown has been set - shutdown now
 
 --echo
 --echo # Restart server
---let $shutdown_timeout= 10
---let $allow_rpl_inited= 1
 --source include/restart_mysqld.inc
 
-SET debug_sync="buf_load SIGNAL stalling",
+SET debug_sync="buf_load WAIT_FOR shutdown",
     GLOBAL innodb_buffer_pool_load_now=1,
     GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
 

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_abort_loads.test
@@ -1,0 +1,132 @@
+#
+# MDEV-11455 - add status variable innodb_buffer_pool_load_abort
+#
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+--echo
+--echo # innodb_buffer_pool_load_incomplete defaults 0
+SELECT variable_name, variable_value
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
+
+--echo
+--echo # populate with data
+
+CREATE TABLE t1 (
+c01 blob, c02 blob, c03 blob, c04 blob, c05 blob,
+c06 blob, c07 blob, c08 blob, c09 blob, c10 blob,
+c11 blob, c12 blob, c13 blob, c14 blob, c15 blob,
+c16 blob, c17 blob, c18 blob, c19 blob, c20 blob,
+c21 blob, c22 blob, c23 blob, c24 blob, c25 blob,
+c26 blob, c27 blob, c28 blob, c29 blob, c30 blob,
+c31 blob, c32 blob, c33 blob, c34 blob, c35 blob,
+c36 blob, c37 blob, c38 blob, c39 blob, c40 blob,
+c41 blob, c42 blob, c43 blob, c44 blob, c45 blob,
+c46 blob, c47 blob, c48 blob, c49 blob, c50 blob,
+c51 blob, c52 blob, c53 blob, c54 blob, c55 blob,
+c56 blob, c57 blob, c58 blob, c59 blob, c60 blob,
+c61 blob, c62 blob, c63 blob, c64 blob
+) ROW_FORMAT=dynamic;
+
+SET @a = repeat('a', 16 * 1024);
+INSERT INTO t1 VALUES (@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a,@a,
+@a,@a,@a,@a
+);
+
+SET GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
+# Dump on shutdown has been set - shutdown now
+
+--echo
+--echo # Restart server
+--let $shutdown_timeout= 10
+--let $allow_rpl_inited= 1
+--source include/restart_mysqld.inc
+
+SET debug_sync="buf_load SIGNAL stalling",
+    GLOBAL innodb_buffer_pool_load_now=1,
+    GLOBAL innodb_buffer_pool_dump_at_shutdown=1;
+
+SELECT variable_name, variable_value
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
+
+--let $incomplete=`select count(*) as BLOB_PAGES from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE`
+
+--echo
+--echo # Restart server
+--source include/restart_mysqld.inc
+
+--echo
+--echo # Load buffer pool
+SET GLOBAL innodb_buffer_pool_load_now=1;
+
+# Wait for for the load to complete
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 33) = 'Buffer pool(s) load completed at '
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_status';
+-- source include/wait_condition.inc
+
+--echo
+--echo # Should be more than previous as we didn't overwrite our save file
+--replace_result $incomplete Previous_loaded
+--eval select count(*) > $incomplete as Loaded_more from information_schema.INNODB_BUFFER_PAGE WHERE PAGE_TYPE='BLOB' group by PAGE_TYPE;
+
+--echo
+--echo # Successful, so innodb_buffer_pool_load_incomplete should be 0
+SELECT variable_name, variable_value
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) = 'innodb_buffer_pool_load_incomplete';
+
+
+--echo
+--echo # Load it again and abort with innodb_buffer_pool_load_abort=1
+SET debug_sync="buf_load WAIT_FOR abort_release",
+    GLOBAL innodb_buffer_pool_load_now=1;
+
+SET GLOBAL innodb_buffer_pool_load_abort=1;
+
+SET DEBUG_SYNC= 'now SIGNAL abort_release';
+
+--echo
+--echo # was aborted - should be incomplete
+SELECT variable_name, variable_value
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) IN ('innodb_buffer_pool_load_incomplete', 'innodb_buffer_pool_load_status');
+
+
+--echo
+--echo # innodb_buffer_pool_dump_now=1 should reset the innodb_buffer_pool_load_incomplete status
+
+SET GLOBAL innodb_buffer_pool_dump_now=1;
+# Wait for for the dump to complete
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 33) = 'Buffer pool(s) dump completed at '
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) = 'innodb_buffer_pool_dump_status';
+-- source include/wait_condition.inc
+
+SELECT variable_name, SUBSTR(variable_value, 1, 33) as VALUE
+    FROM information_schema.global_status
+    WHERE LOWER(variable_name) IN ('innodb_buffer_pool_load_incomplete', 'innodb_buffer_pool_dump_status');
+
+SET DEBUG_SYNC= 'RESET';
+
+--echo
+--echo # Clean up
+#
+#
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/data/ib_buffer_pool
+DROP TABLE t1;

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -598,6 +598,7 @@ buf_load()
 		fscanf_ret = fscanf(f, ULINTPF "," ULINTPF,
 				    &space_id, &page_no);
 
+		DEBUG_SYNC_C("buf_load");
 		if (fscanf_ret != 2) {
 			if (feof(f)) {
 				break;

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -424,6 +424,11 @@ buf_dump(
 
 	buf_dump_status(STATUS_INFO,
 			"Buffer pool(s) dump completed at %s", now);
+
+	/* Though dumping doesn't really related to an incomplete load,
+	 * we reset this to 0 here to indicate that a shutdown can also perform
+	 * a dump */
+	export_vars.innodb_buffer_pool_load_incomplete = 0;
 }
 
 /*****************************************************************//**
@@ -587,6 +592,8 @@ buf_load()
 
 	rewind(f);
 
+	export_vars.innodb_buffer_pool_load_incomplete = 1;
+
 	for (i = 0; i < dump_n && !SHUTTING_DOWN(); i++) {
 		fscanf_ret = fscanf(f, ULINTPF "," ULINTPF,
 				    &space_id, &page_no);
@@ -749,8 +756,23 @@ buf_load()
 
 	ut_sprintf_timestamp(now);
 
-	buf_load_status(STATUS_INFO,
+	if (i == dump_n) {
+		buf_load_status(STATUS_INFO,
 			"Buffer pool(s) load completed at %s", now);
+		export_vars.innodb_buffer_pool_load_incomplete = 0;
+	} else if (!buf_load_abort_flag) {
+		buf_load_status(STATUS_INFO,
+			"Buffer pool(s) load aborted due to user instigated abort at %s",
+			now);
+		/* intentionally don't reset innodb_buffer_pool_load_incomplete
+                   as we don't want a shutdown to saving the buffer pool */
+	} else {
+		buf_load_status(STATUS_INFO,
+			"Buffer pool(s) load aborted due to shutdown at %s",
+			now);
+		/* intentionally don't reset innodb_buffer_pool_load_incomplete
+                   as we want to abort without saving the buffer pool */
+	}
 
 	/* Make sure that estimated = completed when we end. */
 	/* mysql_stage_set_work_completed(pfs_stage_progress, dump_n); */
@@ -816,8 +838,14 @@ DECLARE_THREAD(buf_dump_thread)(
 	}
 
 	if (srv_buffer_pool_dump_at_shutdown && srv_fast_shutdown != 2) {
-		buf_dump(FALSE /* ignore shutdown down flag,
-		keep going even if we are in a shutdown state */);
+		if (export_vars.innodb_buffer_pool_load_incomplete == 1) {
+			buf_dump_status(STATUS_INFO,
+				"Dumping of buffer pool not started"
+				" as load was incomplete");
+		} else {
+			buf_dump(FALSE /* ignore shutdown down flag,
+			keep going even if we are in a shutdown state */);
+		}
 	}
 
 	srv_buf_dump_thread_active = FALSE;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -963,6 +963,8 @@ static SHOW_VAR innodb_status_variables[]= {
   (char*) &export_vars.innodb_buffer_pool_load_status,	  SHOW_CHAR},
   {"buffer_pool_resize_status",
   (char*) &export_vars.innodb_buffer_pool_resize_status,  SHOW_CHAR},
+  {"buffer_pool_load_incomplete",
+  (char*) &export_vars.innodb_buffer_pool_load_incomplete, SHOW_LONG},
   {"buffer_pool_pages_data",
   (char*) &export_vars.innodb_buffer_pool_pages_data,	  SHOW_LONG},
   {"buffer_pool_bytes_data",

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -964,7 +964,7 @@ static SHOW_VAR innodb_status_variables[]= {
   {"buffer_pool_resize_status",
   (char*) &export_vars.innodb_buffer_pool_resize_status,  SHOW_CHAR},
   {"buffer_pool_load_incomplete",
-  (char*) &export_vars.innodb_buffer_pool_load_incomplete, SHOW_LONG},
+  &export_vars.innodb_buffer_pool_load_incomplete,        SHOW_BOOL},
   {"buffer_pool_pages_data",
   (char*) &export_vars.innodb_buffer_pool_pages_data,	  SHOW_LONG},
   {"buffer_pool_bytes_data",

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -995,7 +995,7 @@ struct export_var_t{
 	char  innodb_buffer_pool_dump_status[OS_FILE_MAX_PATH + 128];/*!< Buf pool dump status */
 	char  innodb_buffer_pool_load_status[OS_FILE_MAX_PATH + 128];/*!< Buf pool load status */
 	char  innodb_buffer_pool_resize_status[512];/*!< Buf pool resize status */
-	ulint innodb_buffer_pool_load_incomplete;/*!< Buf pool load incomplete */
+	ibool innodb_buffer_pool_load_incomplete;/*!< Buf pool load incomplete */
 	ulint innodb_buffer_pool_pages_total;	/*!< Buffer pool size */
 	ulint innodb_buffer_pool_pages_data;	/*!< Data pages */
 	ulint innodb_buffer_pool_bytes_data;	/*!< File bytes used */

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -995,6 +995,7 @@ struct export_var_t{
 	char  innodb_buffer_pool_dump_status[OS_FILE_MAX_PATH + 128];/*!< Buf pool dump status */
 	char  innodb_buffer_pool_load_status[OS_FILE_MAX_PATH + 128];/*!< Buf pool load status */
 	char  innodb_buffer_pool_resize_status[512];/*!< Buf pool resize status */
+	ulint innodb_buffer_pool_load_incomplete;/*!< Buf pool load incomplete */
 	ulint innodb_buffer_pool_pages_total;	/*!< Buffer pool size */
 	ulint innodb_buffer_pool_pages_data;	/*!< Data pages */
 	ulint innodb_buffer_pool_bytes_data;	/*!< File bytes used */

--- a/storage/xtradb/buf/buf0dump.cc
+++ b/storage/xtradb/buf/buf0dump.cc
@@ -573,6 +573,7 @@ buf_load()
 		fscanf_ret = fscanf(f, ULINTPF "," ULINTPF,
 				    &space_id, &page_no);
 
+		DEBUG_SYNC_C("buf_load");
 		if (fscanf_ret != 2) {
 			if (feof(f)) {
 				break;

--- a/storage/xtradb/buf/buf0dump.cc
+++ b/storage/xtradb/buf/buf0dump.cc
@@ -359,6 +359,11 @@ buf_dump(
 
 	buf_dump_status(STATUS_NOTICE,
 			"Buffer pool(s) dump completed at %s", now);
+
+	/* Though dumping doesn't really related to an incomplete load,
+	 * we reset this to 0 here to indicate that a shutdown can also perform
+	 * a dump */
+	export_vars.innodb_buffer_pool_load_incomplete = 0;
 }
 
 /*****************************************************************//**
@@ -659,8 +664,23 @@ buf_load()
 
 	ut_sprintf_timestamp(now);
 
-	buf_load_status(STATUS_NOTICE,
+	if (i == dump_n) {
+		buf_load_status(STATUS_NOTICE,
 			"Buffer pool(s) load completed at %s", now);
+		export_vars.innodb_buffer_pool_load_incomplete = 0;
+	} else if (!buf_load_abort_flag) {
+		buf_load_status(STATUS_NOTICE,
+			"Buffer pool(s) load aborted due to user instigated abort at %s",
+			now);
+		/* intentionally don't reset innodb_buffer_pool_load_incomplete
+                   as we don't want a shutdown to saving the buffer pool */
+	} else {
+		buf_load_status(STATUS_NOTICE,
+			"Buffer pool(s) load aborted due to shutdown at %s",
+			now);
+		/* intentionally don't reset innodb_buffer_pool_load_incomplete
+                   as we want to abort without saving the buffer pool */
+	}
 }
 
 /*****************************************************************//**
@@ -716,8 +736,14 @@ DECLARE_THREAD(buf_dump_thread)(
 	}
 
 	if (srv_buffer_pool_dump_at_shutdown && srv_fast_shutdown != 2) {
-		buf_dump(FALSE /* ignore shutdown down flag,
-		keep going even if we are in a shutdown state */);
+		if (export_vars.innodb_buffer_pool_load_incomplete == 1) {
+			buf_dump_status(STATUS_VERBOSE,
+				"Dumping of buffer pool not started"
+				" as load was incomplete");
+		} else {
+			buf_dump(FALSE /* ignore shutdown down flag,
+			keep going even if we are in a shutdown state */);
+		}
 	}
 
 	srv_buf_dump_thread_active = FALSE;

--- a/storage/xtradb/handler/ha_innodb.cc
+++ b/storage/xtradb/handler/ha_innodb.cc
@@ -986,7 +986,7 @@ static SHOW_VAR innodb_status_variables[]= {
   {"buffer_pool_dump_status",
   (char*) &export_vars.innodb_buffer_pool_dump_status,	  SHOW_CHAR},
   {"buffer_pool_load_incomplete",
-  (char*) &export_vars.innodb_buffer_pool_load_incomplete, SHOW_LONG},
+  &export_vars.innodb_buffer_pool_load_incomplete,        SHOW_BOOL},
   {"buffer_pool_load_status",
   (char*) &export_vars.innodb_buffer_pool_load_status,	  SHOW_CHAR},
   {"buffer_pool_pages_data",

--- a/storage/xtradb/handler/ha_innodb.cc
+++ b/storage/xtradb/handler/ha_innodb.cc
@@ -985,6 +985,8 @@ static SHOW_VAR innodb_status_variables[]= {
   (char*) &export_vars.innodb_buffer_pool_bytes_dirty,	  SHOW_LONG},
   {"buffer_pool_dump_status",
   (char*) &export_vars.innodb_buffer_pool_dump_status,	  SHOW_CHAR},
+  {"buffer_pool_load_incomplete",
+  (char*) &export_vars.innodb_buffer_pool_load_incomplete, SHOW_LONG},
   {"buffer_pool_load_status",
   (char*) &export_vars.innodb_buffer_pool_load_status,	  SHOW_CHAR},
   {"buffer_pool_pages_data",

--- a/storage/xtradb/include/srv0srv.h
+++ b/storage/xtradb/include/srv0srv.h
@@ -1097,6 +1097,7 @@ struct export_var_t{
 	ulint innodb_data_reads;		/*!< I/O read requests */
 	char  innodb_buffer_pool_dump_status[512];/*!< Buf pool dump status */
 	char  innodb_buffer_pool_load_status[512];/*!< Buf pool load status */
+	ulint innodb_buffer_pool_load_incomplete;/*!< Buf pool load incomplete */
 	ulint innodb_buffer_pool_pages_total;	/*!< Buffer pool size */
 	ulint innodb_buffer_pool_pages_data;	/*!< Data pages */
 	ulint innodb_buffer_pool_bytes_data;	/*!< File bytes used */

--- a/storage/xtradb/include/srv0srv.h
+++ b/storage/xtradb/include/srv0srv.h
@@ -1097,7 +1097,7 @@ struct export_var_t{
 	ulint innodb_data_reads;		/*!< I/O read requests */
 	char  innodb_buffer_pool_dump_status[512];/*!< Buf pool dump status */
 	char  innodb_buffer_pool_load_status[512];/*!< Buf pool load status */
-	ulint innodb_buffer_pool_load_incomplete;/*!< Buf pool load incomplete */
+	ibool innodb_buffer_pool_load_incomplete;/*!< Buf pool load incomplete */
 	ulint innodb_buffer_pool_pages_total;	/*!< Buffer pool size */
 	ulint innodb_buffer_pool_pages_data;	/*!< Data pages */
 	ulint innodb_buffer_pool_bytes_data;	/*!< File bytes used */


### PR DESCRIPTION
This status variable indicates that an innodb buffer pool load never
completed and dumping at shutdown would result in an incomplete dump file.

This status variable is set to 1 once a buffer pool loads. Upon a successful
load this status variable returns to 0.

With this status variable set, the system variable
innodb_buffer_pool_dump_at_shutdown==1 will have no effect as dumping after
an incomplete load will generate a less complete dump file than the current
one.

If a user aborts a buffer pool load by changing the system variable
innodb_buffer_pool_load_abort=1 will cause the the status variable
innodb_buffer_pool_load_incomplete to remain set to 1.

A shutdown that occurs while innodb is loading the buffer pool will
not save the buffer pool on shutdown.

A user may indirectly set innodb_buffer_pool_load_incomplete
to 0 by:
* Forcing a load, by setting innodb_buffer_pool_load_now=ON, or
* Forcing a dump, by setting innodb_buffer_pool_dump_now=ON

This will enable the next dump on shutdown to complete.

I submit this under the MCA.