### PR TITLE
Fix error in lock_has_higher_priority

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2330,7 +2330,6 @@ lock_queue_validate(
 	ulint				space;
 	ulint				page_no;
 	ulint				rec_fold;
-	hash_table_t*		hash;
 	hash_cell_t*		cell;
 	lock_t*				next;
 	bool				wait_lock = false;

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2242,8 +2242,6 @@ lock_rec_create(
 /*********************************************************************//**
 Check if lock1 has higher priority than lock2.
 NULL has lowest priority.
-Respect the preference of the upper server layer to reduce conflict
-during in-order parallel replication.
 If neither of them is wait lock, the first one has higher priority.
 If only one of them is a wait lock, it has lower priority.
 Otherwise, the one with an older transaction has higher priority.
@@ -2264,15 +2262,6 @@ has_higher_priority(
     } else if (!lock_get_wait(lock2)) {
         return false;
     }
-	// Ask the upper server layer if any of the two trx should be prefered.
-	int preference = thd_deadlock_victim_preference(lock1->trx->mysql_thd, lock2->trx->mysql_thd);
-	if (preference == -1) {
-		// lock1 is preferred as a victim, so lock2 has higher priority
-		return false;
-	} else if (preference == 1) {
-		// lock2 is preferred as a victim, so lock1 has higher priority
-		return true;
-	}
 	return lock1->trx->start_time_micro <= lock2->trx->start_time_micro;
 }
 

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2257,7 +2257,13 @@ has_higher_priority(
 		return false;
 	} else if (lock2 == NULL) {
 		return true;
-	}
+    }
+    // No preference. Compre them by wait mode and trx age.
+    if (!lock_get_wait(lock1)) {
+        return true;
+    } else if (!lock_get_wait(lock2)) {
+        return false;
+    }
 	// Ask the upper server layer if any of the two trx should be prefered.
 	int preference = thd_deadlock_victim_preference(lock1->trx->mysql_thd, lock2->trx->mysql_thd);
 	if (preference == -1) {
@@ -2266,12 +2272,6 @@ has_higher_priority(
 	} else if (preference == 1) {
 		// lock2 is preferred as a victim, so lock1 has higher priority
 		return true;
-	}
-	// No preference. Compre them by wait mode and trx age.
-	if (!lock_get_wait(lock1)) {
-		return true;
-	} else if (!lock_get_wait(lock2)) {
-		return false;
 	}
 	return lock1->trx->start_time_micro <= lock2->trx->start_time_micro;
 }

--- a/storage/xtradb/lock/lock0lock.cc
+++ b/storage/xtradb/lock/lock0lock.cc
@@ -2033,8 +2033,6 @@ wsrep_print_wait_locks(
 /*********************************************************************//**
 Check if lock1 has higher priority than lock2.
 NULL has lowest priority.
-Respect the preference of the upper server layer to reduce conflict
-during in-order parallel replication.
 If neither of them is wait lock, the first one has higher priority.
 If only one of them is a wait lock, it has lower priority.
 Otherwise, the one with an older transaction has higher priority.
@@ -2047,15 +2045,6 @@ has_higher_priority(
 	if (lock1 == NULL) {
 		return false;
 	} else if (lock2 == NULL) {
-		return true;
-	}
-	// Ask the upper server layer if any of the two trx should be prefered.
-	int preference = thd_deadlock_victim_preference(lock1->trx->mysql_thd, lock2->trx->mysql_thd);
-	if (preference == -1) {
-		// lock1 is preferred as a victim, so lock2 has higher priority
-		return false;
-	} else if (preference == 1) {
-		// lock2 is preferred as a victim, so lock1 has higher priority
 		return true;
 	}
 	// No preference. Compre them by wait mode and trx age.

--- a/storage/xtradb/lock/lock0lock.cc
+++ b/storage/xtradb/lock/lock0lock.cc
@@ -2121,7 +2121,6 @@ lock_queue_validate(
 	ulint				space;
 	ulint				page_no;
 	ulint				rec_fold;
-	hash_table_t*		hash;
 	hash_cell_t*		cell;
 	lock_t*				next;
 	bool				wait_lock = false;


### PR DESCRIPTION
Remove victim preference from lock_has_higher_priority since VATS is disabled in replication.
Decide priority based on wait mode first.