### PR TITLE
MDEV-10651: enable test sys_vars.innodb_buffer_pool_dump_pct_basic

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_pct_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_dump_pct_basic.result
@@ -1,3 +1,4 @@
+SET @orig = @@global.innodb_buffer_pool_dump_pct;
 SELECT @@global.innodb_buffer_pool_dump_pct;
 @@global.innodb_buffer_pool_dump_pct
 25
@@ -33,3 +34,4 @@ SET GLOBAL innodb_buffer_pool_dump_pct='foo';
 ERROR 42000: Incorrect argument type to variable 'innodb_buffer_pool_dump_pct'
 SET innodb_buffer_pool_dump_pct=50;
 ERROR HY000: Variable 'innodb_buffer_pool_dump_pct' is a GLOBAL variable and should be set with SET GLOBAL
+SET GLOBAL innodb_buffer_pool_dump_pct=@orig;

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_dump_pct_basic.test
@@ -9,6 +9,9 @@
 
 -- source include/have_innodb.inc
 
+# Save the default value
+SET @orig = @@global.innodb_buffer_pool_dump_pct;
+
 # Check the default value
 SELECT @@global.innodb_buffer_pool_dump_pct;
 
@@ -55,3 +58,6 @@ SET GLOBAL innodb_buffer_pool_dump_pct='foo';
 # Set without using Global
 --error ER_GLOBAL_VARIABLE
 SET innodb_buffer_pool_dump_pct=50;
+
+# Restore original value
+SET GLOBAL innodb_buffer_pool_dump_pct=@orig;

--- a/mysql-test/unstable-tests
+++ b/mysql-test/unstable-tests
@@ -307,7 +307,6 @@ sys_vars.keep_files_on_create_basic        : MDEV-10676 - timeout
 sys_vars.slow_query_log_file_basic         : Modified on 2016-08-09 (MDEV-10465)
 sys_vars.sysvars_innodb                    : MDEV-6958 - error-prone rdiffs
 sys_vars.sysvars_server_embedded           : MDEV-6958 - error-prone rdiffs
-sys_vars.innodb_buffer_pool_dump_pct_basic : MDEV-10651 - sporadic failure on file_exists
 sys_vars.innodb_fatal_semaphore_wait_threshold : MDEV-10513 - crashes
 sys_vars.sysvars_wsrep                         : Modified in 10.1.17
 sys_vars.wsrep_max_ws_size_basic               : Modified in 10.1.17


### PR DESCRIPTION
Since 10.2 (2e814d4702d71a04388386a9f591d14a35980bfe) this test
changed and the race condition of MDEV-10651 no longer forms part
of this test.

As such re-enable this test.

Also include save/restore of the default values of this variable.

I submit this under the MCA.