### PR TITLE
MDEV-8692 prefschema test failures on ARM (on Debian build system)

### DIFF
--- a/mysql-test/suite/perfschema/include/have_timer_cycle.inc
+++ b/mysql-test/suite/perfschema/include/have_timer_cycle.inc
@@ -1,0 +1,4 @@
+if (!`SELECT count(*) FROM performance_schema.performance_timers WHERE timer_name='CYCLE' AND timer_frequency IS NOT NULL`)
+{
+  Skip Need performance timer CYCLE;
+}

--- a/mysql-test/suite/perfschema/r/privilege.result
+++ b/mysql-test/suite/perfschema/r/privilege.result
@@ -554,7 +554,7 @@ ERROR 42000: DROP command denied to user 'pfs_user_4'@'localhost' for table 'eve
 #
 # Grant access to change tables with the root account
 GRANT UPDATE ON performance_schema.setup_consumers TO pfs_user_4;
-GRANT UPDATE ON performance_schema.setup_timers TO pfs_user_4;
+GRANT UPDATE, SELECT ON performance_schema.setup_timers TO pfs_user_4;
 GRANT UPDATE, SELECT ON performance_schema.setup_instruments TO pfs_user_4;
 GRANT DROP ON performance_schema.events_waits_current TO pfs_user_4;
 GRANT DROP ON performance_schema.events_waits_history TO pfs_user_4;
@@ -565,7 +565,7 @@ UPDATE performance_schema.setup_instruments SET enabled = 'YES'
 WHERE name LIKE 'wait/synch/mutex/%'
    OR name LIKE 'wait/synch/rwlock/%';
 UPDATE performance_schema.setup_consumers SET enabled = 'YES';
-UPDATE performance_schema.setup_timers SET timer_name = 'TICK';
+UPDATE performance_schema.setup_timers SET timer_name = 'TICK' WHERE name <> "wait";
 TRUNCATE TABLE performance_schema.events_waits_history_long;
 TRUNCATE TABLE performance_schema.events_waits_history;
 TRUNCATE TABLE performance_schema.events_waits_current;
@@ -575,4 +575,3 @@ DROP USER pfs_user_4;
 flush privileges;
 UPDATE performance_schema.setup_instruments SET enabled = 'YES', timed = 'YES';
 UPDATE performance_schema.setup_consumers SET enabled = 'YES';
-UPDATE performance_schema.setup_timers SET timer_name = 'CYCLE';

--- a/mysql-test/suite/perfschema/t/dml_performance_timers.test
+++ b/mysql-test/suite/perfschema/t/dml_performance_timers.test
@@ -2,6 +2,7 @@
 
 --source include/not_embedded.inc
 --source include/have_perfschema.inc
+--source include/have_timer_cycle.inc
 
 --replace_column 2 <frequency> 3 <resolution> 4 <overhead>
 select * from performance_schema.performance_timers;

--- a/mysql-test/suite/perfschema/t/dml_setup_timers.test
+++ b/mysql-test/suite/perfschema/t/dml_setup_timers.test
@@ -2,6 +2,7 @@
 
 --source include/not_embedded.inc
 --source include/have_perfschema.inc
+--source include/have_timer_cycle.inc
 
 select * from performance_schema.setup_timers;
 

--- a/mysql-test/suite/perfschema/t/privilege.test
+++ b/mysql-test/suite/perfschema/t/privilege.test
@@ -291,7 +291,7 @@ TRUNCATE TABLE performance_schema.events_waits_current;
 --echo # Grant access to change tables with the root account
 
 GRANT UPDATE ON performance_schema.setup_consumers TO pfs_user_4;
-GRANT UPDATE ON performance_schema.setup_timers TO pfs_user_4;
+GRANT UPDATE, SELECT ON performance_schema.setup_timers TO pfs_user_4;
 GRANT UPDATE, SELECT ON performance_schema.setup_instruments TO pfs_user_4;
 GRANT DROP ON performance_schema.events_waits_current TO pfs_user_4;
 GRANT DROP ON performance_schema.events_waits_history TO pfs_user_4;
@@ -308,7 +308,11 @@ WHERE name LIKE 'wait/synch/mutex/%'
 
 UPDATE performance_schema.setup_consumers SET enabled = 'YES';
 
-UPDATE performance_schema.setup_timers SET timer_name = 'TICK';
+# We do not touch "wait", to avoid restoring it at the end of the test,
+# as its default value initialized at server startup is ambiguous:
+# it can be CYCLE or NANOSECOND depending on platform
+
+UPDATE performance_schema.setup_timers SET timer_name = 'TICK' WHERE name <> "wait";
 
 TRUNCATE TABLE performance_schema.events_waits_history_long;
 TRUNCATE TABLE performance_schema.events_waits_history;
@@ -323,5 +327,5 @@ DROP USER pfs_user_4;
 flush privileges;
 UPDATE performance_schema.setup_instruments SET enabled = 'YES', timed = 'YES';
 UPDATE performance_schema.setup_consumers SET enabled = 'YES';
-UPDATE performance_schema.setup_timers SET timer_name = 'CYCLE';
 
+# Note, we did not touch "wait", so no need to restore the default value, see above.

--- a/mysys/my_rdtsc.c
+++ b/mysys/my_rdtsc.c
@@ -129,6 +129,31 @@ ulonglong my_timer_cycles_il_x86_64();
   clock_gettime(CLOCK_SGI_CYCLE) for Irix platforms,
   or on read_real_time for aix platforms. There is
   nothing for Alpha platforms, they would be tricky.
+
+  On the platforms that do not have a CYCLE timer,
+  "wait" events are initialized to use NANOSECOND instead of CYCLE
+  during performance_schema initialization (at the server startup).
+
+  Linux performance monitor (see "man perf_event_open") can
+  provide cycle counter on the platforms that do not have
+  other kinds of cycle counters. But we don't use it so far.
+
+  ARM notes
+  ---------
+  During tests on ARMv7 Debian, perf_even_open() based cycle counter provided
+  too low frequency with too high overhead:
+  MariaDB [performance_schema]> SELECT * FROM performance_timers;
+  +-------------+-----------------+------------------+----------------+
+  | TIMER_NAME  | TIMER_FREQUENCY | TIMER_RESOLUTION | TIMER_OVERHEAD |
+  +-------------+-----------------+------------------+----------------+
+  | CYCLE       | 689368159       | 1                | 970            |
+  | NANOSECOND  | 1000000000      | 1                | 308            |
+  | MICROSECOND | 1000000         | 1                | 417            |
+  | MILLISECOND | 1000            | 1000             | 407            |
+  | TICK        | 127             | 1                | 612            |
+  +-------------+-----------------+------------------+----------------+
+  Therefore, it was decided not to use perf_even_open() on ARM
+  (i.e. go without CYCLE and have "wait" events use NANOSECOND by default).
 */
 
 ulonglong my_timer_cycles(void)


### PR DESCRIPTION
This is a back-port of the fix from 10.0+ for 5.5.
A few tests assumes that the CYCLE timer is always available,
which is not true on some platforms (e.g. ARM).
Fixing the tests not to reply on the CYCLE availability.