### PR TITLE
MDEV-11075: changing to algorithm innodb from crc32

### DIFF
--- a/storage/innobase/page/page0zip.cc
+++ b/storage/innobase/page/page0zip.cc
@@ -5243,13 +5243,15 @@ page_zip_verify_checksum(
 
 		const uint32_t calculated = page_zip_calc_checksum(
 			data, size, SRV_CHECKSUM_ALGORITHM_CRC32);
-		const uint32_t calculated1 = page_zip_calc_checksum(
-			data, size, SRV_CHECKSUM_ALGORITHM_CRC32, true);
+		uint32_t calculated1;
 
 		if (stored == calculated
-		    || stored == calculated1
 #ifdef UNIV_INNOCHECKSUM
 		    || ( encrypted == true && checksum == calculated)
+#endif
+		    || stored == (calculated1 = 
+					page_zip_calc_checksum(data, size, SRV_CHECKSUM_ALGORITHM_CRC32, true))
+#ifdef UNIV_INNOCHECKSUM
 		    || ( encrypted == true && checksum == calculated1)
 #endif
 		) {


### PR DESCRIPTION
With innodb compressed pages formerly as crc32 changing to the
innodb checksum, optimize for speed by only calcuating the big
endian variant of crc32 after checking that the little endian
doesn't validate the page.

I submit this under the MCA.