### PR TITLE
MDEV-11075: Power - runtime detection of optimized instructions

### DIFF
--- a/storage/innobase/ut/ut0crc32.cc
+++ b/storage/innobase/ut/ut0crc32.cc
@@ -83,6 +83,12 @@ mysys/my_perf.c, contributed by Facebook under the following license.
 #include "my_config.h"
 #include <string.h>
 
+#if defined(__linux__) && defined(HAVE_CRC32_VPMSUM)
+/* Used to detect at runtime if we have vpmsum instructions (PowerISA 2.07) */
+#include <sys/auxv.h>
+#include <bits/hwcap.h>
+#endif
+
 #include "univ.i"
 #include "ut0crc32.h"
 
@@ -740,8 +746,14 @@ ut_crc32_init()
 	}
 
 #elif defined(HAVE_CRC32_VPMSUM)
-	ut_crc32 = ut_crc32_power8;
-	ut_crc32_implementation = "Using POWER8 crc32 instructions";
+#if defined(__linux__)
+	if (getauxval(AT_HWCAP2) & PPC_FEATURE2_ARCH_2_07) {
+#endif
+		ut_crc32 = ut_crc32_power8;
+		ut_crc32_implementation = "Using POWER8 crc32 instructions";
+#if defined(__linux__)
+	}
+#endif
 #endif
 
 }

--- a/storage/xtradb/ut/ut0crc32.cc
+++ b/storage/xtradb/ut/ut0crc32.cc
@@ -336,7 +336,13 @@ ut_crc32_init()
 	}
 
 #elif defined(HAVE_CRC32_VPMSUM)
-	ut_crc32 = ut_crc32_power8;
-	ut_crc32_implementation = "Using POWER8 crc32 instructions";
+#if defined(__linux__)
+	if (getauxval(AT_HWCAP2) & PPC_FEATURE2_ARCH_2_07) {
+#endif
+		ut_crc32 = ut_crc32_power8;
+		ut_crc32_implementation = "Using POWER8 crc32 instructions";
+#if defined(__linux__)
+	}
+#endif
 #endif
 }


### PR DESCRIPTION
From https://github.com/MariaDB/server/pull/212#discussion_r91666636 @dr-m asked about runtime checks for Power.

Here it is. They aren't totally needed as Power8 is the first processor supporting MariaDB. It adds one syscall on initialization so it isn't too much to add anyway. It does reduce one less thing to account for if someone wants to back port support to Power7 or earlier (MDEV-10984) however.

I submit this under the MCA.