### PR TITLE
Travis: add lib{stemmer,xml2,pcre3}-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,12 @@ addons:
       - libjudy-dev
       - libncurses5-dev
       - libpam0g-dev
+      - libpcre3-dev
       - libreadline-gplv2-dev
+      - libstemmer-dev
       - libssl-dev
       - libnuma-dev
+      - libxml2-dev
       - lsb-release
       - perl
       - po-debconf
@@ -38,6 +41,11 @@ addons:
       - libcrack2-dev
       - libjemalloc-dev
       - devscripts # implicit for any build on Ubuntu
+
+# libsnappy-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3880
+# liblzma-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3879
+# libzmq-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3881
+# libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 
 script:
   - ${CC} --version ; ${CXX} --version


### PR DESCRIPTION
Without these packages installed, MariaDB builds these packages from the bundled source. As we are limited on compile time anyway lets just use the packages.

There are a couple of packages not yet whitelisted on travis. Added these as comment reference for the time being with the aim that once these are whitelisted they can be included in the packages.

I submit this under the MCA.