### PR TITLE
MDEV-11611 - fix Ninja build

### DIFF
--- a/dbug/CMakeLists.txt
+++ b/dbug/CMakeLists.txt
@@ -58,13 +58,13 @@ IF(NOT WIN32 AND NOT CMAKE_GENERATOR MATCHES Xcode)
     ADD_CUSTOM_COMMAND(OUTPUT user.ps
                        DEPENDS user.r ${OUTPUT_INC} ${SOURCE_INC}
                        COMMAND ${GROFF} -mm ${CMAKE_CURRENT_SOURCE_DIR}/user.r > user.ps || touch user.ps)
-    ADD_CUSTOM_TARGET(user.ps ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/user.ps)
+    ADD_CUSTOM_TARGET(user_ps ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/user.ps)
   ENDIF(GROFF)
   IF(NROFF)
     ADD_CUSTOM_COMMAND(OUTPUT user.t
                        DEPENDS user.r ${OUTPUT_INC} ${SOURCE_INC}
                        COMMAND ${NROFF} -mm ${CMAKE_CURRENT_SOURCE_DIR}/user.r > user.t || touch user.t)
-    ADD_CUSTOM_TARGET(user.t ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/user.t)
+    ADD_CUSTOM_TARGET(user_t ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/user.t)
   ENDIF(NROFF)
 
 ENDIF()


### PR DESCRIPTION
Hi.

Here is the Ninja output:
```
ninja: warning: multiple rules generate dbug/user.ps. builds involving this target will not be correct; continuing anyway [-w dupbuild=warn]
ninja: warning: multiple rules generate dbug/user.t. builds involving this target will not be correct; continuing anyway [-w dupbuild=warn]
ninja: error: dependency cycle: dbug/user.ps -> dbug/CMakeFiles/user.ps -> dbug/user.ps
```

This patch removes 2 target which do nothing. Or I don't know what's their purpose.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.