### PR TITLE
mtr: main.func_date_add cleanup

### DIFF
--- a/mysql-test/r/func_date_add.result
+++ b/mysql-test/r/func_date_add.result
@@ -147,4 +147,5 @@ v1	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VI
 select 30 + (20010101 + interval 2 day), x from v1;
 30 + (20010101 + interval 2 day)	x
 20010133	20010133
+drop view v1;
 End of 10.2 tests

--- a/mysql-test/t/func_date_add.test
+++ b/mysql-test/t/func_date_add.test
@@ -128,4 +128,6 @@ create or replace view v1 as select 30 + (20010101 + interval 2 day) as x;
 show create view v1;
 select 30 + (20010101 + interval 2 day), x from v1;
 
+drop view v1;
+
 --echo End of 10.2 tests


### PR DESCRIPTION
Tests added in 180065eb don't clean up the view.

mtr complained in travis:
<pre>
MTR's internal check of the test case 'main.func_date_add' failed.
This means that the test case does not preserve the state that existed
before the test case was executed.  Most likely the test case did not
do a proper clean-up. It could also be caused by the previous test run
by this thread, if the server wasn't restarted.
This is the diff of the states of the servers before and after the
test case was executed:
mysqltest: Logging to '/home/travis/build/MariaDB/server/builddir/mysql-test/var/3/tmp/check-mysqld_1.log'.
mysqltest: Results saved in '/home/travis/build/MariaDB/server/builddir/mysql-test/var/3/tmp/check-mysqld_1.result'.
mysqltest: Connecting to server localhost:16000 (socket /home/travis/build/MariaDB/server/builddir/mysql-test/var/tmp/3/mysqld.1.sock) as 'root', connection 'default', attempt 0 ...
mysqltest: ... Connected.
mysqltest: Start processing test commands from './include/check-testcase.test' ...
mysqltest: ... Done processing test commands.
--- /home/travis/build/MariaDB/server/builddir/mysql-test/var/3/tmp/check-mysqld_1.result	2016-12-19 10:05:17.974484345 +0000
+++ /home/travis/build/MariaDB/server/builddir/mysql-test/var/3/tmp/check-mysqld_1.reject	2016-12-19 10:05:18.090483670 +0000
@@ -483,6 +483,7 @@
 def	performance_schema	utf8	utf8_general_ci	NULL
 def	test	latin1	latin1_swedish_ci	NULL
 tables_in_test
+v1
 tables_in_mysql
 mysql.columns_priv
 mysql.column_stats

mysqltest: Result length mismatch
</pre>

I submit this under the MCA.