### PR TITLE
MDEV-11829 Add support for RFC3339 datetime parsing

### DIFF
--- a/mysql-test/r/ctype_utf16le.result
+++ b/mysql-test/r/ctype_utf16le.result
@@ -1168,6 +1168,42 @@ a
 2007-09-16
 DROP TABLE t1;
 #
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+a
+2016-12-10 10:10:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+a
+2016-12-10 10:10:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+SELECT * FROM t1;
+a
+2016-12-10 10:10:10
+DROP TABLE t1;
+#
 # Testing cs->cset->ll10tostr
 #
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf16le);

--- a/mysql-test/t/ctype_utf16le.test
+++ b/mysql-test/t/ctype_utf16le.test
@@ -529,6 +529,32 @@ INSERT INTO t1 VALUES ('2007-09-16');
 SELECT * FROM t1;
 DROP TABLE t1;
 
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+SELECT * FROM t1;
+DROP TABLE t1;
 
 --echo #
 --echo # Testing cs->cset->ll10tostr


### PR DESCRIPTION
This add support for parsing RFC3339 by ignoring the specified local offset.

For 10.1, I wanted to keep it simple and just extending the parser to recognize and safely ignore the offset provided by RFC3339. This does not change the current behavior, which was the excess characters would be truncated.

With this patch I've validated there are no warnings when inserting RFC3339 datetime objects, and partition pruning works successfully.

Ideally the rfc3339 offset would be parsed and optionally applied to convert the datetime to local server time. I though that an advanced feature for 10.1 and I'm working on a separate pull request for the 10.2 branch with this support.