### PR TITLE
MDEV-11386: Advance Toochain library cache workaround (temporary)

### DIFF
--- a/support-files/rpm/server-postin.sh
+++ b/support-files/rpm/server-postin.sh
@@ -31,6 +31,14 @@ if [ $1 = 1 ] ; then
   # The user may already exist, make sure it has the proper group nevertheless (BUG#12823)
   usermod --gid %{mysqld_group} %{mysqld_user} 2> /dev/null || true
 
+  # Temporary Workaround for MDEV-11386 - will be corrected in Advance Toolchain 10.0-3 and 8.0-8
+  if compgen -G "/opt/at*/sbin/ldconfig" > /dev/null  ; then
+    for ldconfig in /opt/at*/sbin/ldconfig; do
+      $ldconfig
+    done
+
+  fi
+
   # Change permissions so that the user that will run the MySQL daemon
   # owns all database files.
   chown -R %{mysqld_user}:%{mysqld_group} $datadir


### PR DESCRIPTION
Due to the way Advance Toolchain before 10.0-3 and 8.0-8 is
packaged, shared libraries installed after the library cache
advance-toolchain-atX.Y-runtime package aren't updated in
/opt/atX.Y/etc/ld.so.cache. This results in mysqld,
configured with RUNPATH set to /opt/atX.Y/lib64, resulting
in the Advance Toolchain loader being used and if libraries
such as jemalloc, libssl or any other library that mysqld uses
is installed after Advance Toolchain, these libraries aren't in
the cache and therefore won't be found in the RPM postinstall
when mysqld is executed by mysql_install_db.

See JIRA issue for test.

I submit this under the MCA.