### PR TITLE
dict_tf_init is defined but not used.

### DIFF
--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -1006,25 +1006,6 @@ dict_tf_set(
 	ulint		page_compression_level,
 	ulint		not_used);
 
-/** Initialize a dict_table_t::flags pointer.
-@param[in]	compact,	Table uses Compact or greater
-@param[in]	zip_ssize	Zip Shift Size (log 2 minus 9)
-@param[in]	atomic_blobs	Table uses Compressed or Dynamic
-@param[in]	data_dir	Table uses DATA DIRECTORY
-@param[in]	page_compressed Table uses page compression
-@param[in]	page_compression_level Page compression level
-@param[in]	not_used        For future */
-UNIV_INLINE
-ulint
-dict_tf_init(
-	bool		compact,
-	ulint		zip_ssize,
-	bool		atomic_blobs,
-	bool		data_dir,
-	bool		page_compressed,
-	ulint		page_compression_level,
-	ulint		not_used);
-
 /** Convert a 32 bit integer table flags to the 32 bit FSP Flags.
 Fsp Flags are written into the tablespace header at the offset
 FSP_SPACE_FLAGS and are also stored in the fil_space_t::flags field.


### PR DESCRIPTION
So we remove it. Fixed compile warning:

In file included from /mariadb-server/storage/innobase/include/btr0pcur.h:30:0,
                 from /mariadb-server/storage/innobase/include/row0mysql.h:37,
                 from /mariadb-server/storage/innobase/fts/fts0fts.cc:28:
/mariadb-server/storage/innobase/include/dict0dict.h:1019:1: warning: ‘ulint dict_tf_init(bool, ulint, bool, bool, bool, ulint, ulint)’ declared ‘static’ but never defined [-Wunused-function]
 dict_tf_init(
 ^~~~~~~~~~~~

g++ --version
g++ (GCC) 6.3.1 20161221 (Red Hat 6.3.1-1)

I submit this under the MCA.