### PR TITLE
MDEV-10646: (10.1) systemd depends on After=network-online.target

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -10,11 +10,12 @@
 # Daniel Black
 # Erkan Yanar
 # David Strauss
+# Jason Ross
 # and probably others
 
 [Unit]
 Description=MariaDB database server
-After=network.target
+After=network-online.target
 After=syslog.target
 
 [Install]

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -14,12 +14,13 @@
 # Daniel Black
 # Erkan Yanar
 # David Strauss
+# Jason Ross
 # and probably others
 # Inspired from https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-db/mysql-init-scripts/files/mysqld_at.service
 
 [Unit]
 Description=MariaDB database server
-After=network.target
+After=network-online.target
 After=syslog.target
 
 ConditionPathExists=@INSTALL_SYSCONF2DIR@/my%I.cnf


### PR DESCRIPTION
Previously it was network.target which only guarantees that
the network has attempted to be started according to the
documentation.

https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

Thanks for Jason Ross for the bug report and fix.

I submit this under the MCA.