### PR TITLE
(10.1) Correct cmake message - no systemd socket activation (yet)

### DIFF
--- a/cmake/systemd.cmake
+++ b/cmake/systemd.cmake
@@ -18,7 +18,7 @@ INCLUDE(FindPkgConfig)
 
 MACRO(CHECK_SYSTEMD)
   IF(UNIX)
-    SET(WITH_SYSTEMD "auto" CACHE STRING "Compile with systemd socket activation and notification")
+    SET(WITH_SYSTEMD "auto" CACHE STRING "Compile with systemd Type=notify support")
     IF(WITH_SYSTEMD STREQUAL "yes" OR WITH_SYSTEMD STREQUAL "auto")
       IF(PKG_CONFIG_FOUND)
         IF(WITH_SYSTEMD STREQUAL "yes")


### PR DESCRIPTION
Since MDEV-5536 isn't implemented there is no socket activation
support yet.

Correct the cmake messsage for WITH_SYSTEMD to reflect this.

I submit this under the MCA.