### PR TITLE
MDEV-12055: Correct binlog_stm_ctype_ucs test

### DIFF
--- a/mysql-test/extra/binlog_tests/ctype_ucs_binlog.test
+++ b/mysql-test/extra/binlog_tests/ctype_ucs_binlog.test
@@ -53,7 +53,7 @@ SELECT * FROM t1;
 DROP TABLE t1;
 FLUSH LOGS;
 let $MYSQLD_DATADIR= `select @@datadir`;
---replace_regex /TIMESTAMP=[0-9]*/TIMESTAMP=XXX/ /# at [0-9]*/# at #/ /(exec_time=|end_log_pos |Xid = |thread_id=|server id |table id |mapped to number )[0-9]+/\1#/  /server v [^ ]*/server v #.##.##/  /CRC32 0x[0-9a-f]*/CRC32 XXX/ /GTID [0-9]+-[0-9]+-[0-9]+/GTID #-#-#/ /Gtid list [[][0-9]+-[0-9]+-[0-9]+[\]]/Gtid list [#-#-#]/ /session[.](gtid_domain_id|server_id|gtid_seq_no)=[0-9]+/session.\1=#/
+--replace_regex /TIMESTAMP=[0-9]*/TIMESTAMP=XXX/ /# at [0-9]*/# at #/ /(exec_time=|end_log_pos |Xid = |thread_id=|server id |table id |mapped to number )[0-9]+/\1#/  /server v [^ ]*/server v #.##.##/  /CRC32 0x[0-9a-f]*/CRC32 XXX/ /GTID [0-9]+-[0-9]+-[0-9]+/GTID #-#-#/ /Gtid list [[][0-9]+-[0-9]+-[0-9]+[\]]/Gtid list [#-#-#]/ /session[.](gtid_domain_id|server_id|gtid_seq_no)=[0-9]+/session.\1=#/ /(^#|created )[0-9]{6} [ 1][0-9]:[0-9]{2}:[0-9]{2}/\1YYMMDD HH:MM:SS/
 --exec $MYSQL_BINLOG --base64-output=decode-rows -vv $MYSQLD_DATADIR/master-bin.000003
 
 SET TIMESTAMP=DEFAULT;

--- a/mysql-test/suite/binlog/r/binlog_row_ctype_ucs.result
+++ b/mysql-test/suite/binlog/r/binlog_row_ctype_ucs.result
@@ -72,21 +72,21 @@ FLUSH LOGS;
 /*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
 DELIMITER /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Start: binlog v 4, server v #.##.## created 700101  6:46:40
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Start: binlog v 4, server v #.##.## created YYMMDD HH:MM:SS
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Gtid list [#-#-#]
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Gtid list [#-#-#]
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000002
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000002
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000003
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000003
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
 /*!100101 SET @@session.skip_parallel_replication=0*//*!*/;
 /*!100001 SET @@session.gtid_domain_id=#*//*!*/;
 /*!100001 SET @@session.server_id=#*//*!*/;
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 use `test`/*!*/;
 SET TIMESTAMP=XXX/*!*/;
 SET @@session.pseudo_thread_id=#/*!*/;
@@ -100,135 +100,135 @@ SET @@session.collation_database=DEFAULT/*!*/;
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf8)
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
 #Q> INSERT INTO t1 VALUES ('ä(i1)')
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
 ### INSERT INTO `test`.`t1`
 ### SET
 ###   @1='ä(i1)' /* VARSTRING(30) meta=30 nullable=1 is_null=0 */
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
 #Q> INSERT INTO t1 VALUES ('ä(i2)')
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
 ### INSERT INTO `test`.`t1`
 ### SET
 ###   @1='ä(i2)' /* VARSTRING(30) meta=30 nullable=1 is_null=0 */
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
 #Q> INSERT INTO t1 VALUES ('ä(i3)')
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
 ### INSERT INTO `test`.`t1`
 ### SET
 ###   @1='ä(i3)' /* VARSTRING(30) meta=30 nullable=1 is_null=0 */
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
 #Q> INSERT INTO t1 VALUES ('ä(p1)')
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
 ### INSERT INTO `test`.`t1`
 ### SET
 ###   @1='ä(p1)' /* VARSTRING(30) meta=30 nullable=1 is_null=0 */
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
 #Q> INSERT INTO t1 VALUES ('ä(p2)')
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
 ### INSERT INTO `test`.`t1`
 ### SET
 ###   @1='ä(p2)' /* VARSTRING(30) meta=30 nullable=1 is_null=0 */
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Annotate_rows:
 #Q> INSERT INTO t1 VALUES ('ä(p3)')
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Table_map: `test`.`t1` mapped to number #
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
 ### INSERT INTO `test`.`t1`
 ### SET
 ###   @1='ä(p3)' /* VARSTRING(30) meta=30 nullable=1 is_null=0 */
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 DROP TABLE `t1` /* generated by server */
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Rotate to master-bin.000004  pos: 4
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Rotate to master-bin.000004  pos: 4
 DELIMITER ;
 # End of log file
 ROLLBACK /* added by mysqlbinlog */;

--- a/mysql-test/suite/binlog/r/binlog_stm_ctype_ucs.result
+++ b/mysql-test/suite/binlog/r/binlog_stm_ctype_ucs.result
@@ -76,21 +76,21 @@ FLUSH LOGS;
 /*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
 DELIMITER /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Start: binlog v 4, server v #.##.## created 700101  6:46:40
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Start: binlog v 4, server v #.##.## created YYMMDD HH:MM:SS
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Gtid list [#-#-#]
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Gtid list [#-#-#]
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000002
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000002
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000003
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000003
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
 /*!100101 SET @@session.skip_parallel_replication=0*//*!*/;
 /*!100001 SET @@session.gtid_domain_id=#*//*!*/;
 /*!100001 SET @@session.server_id=#*//*!*/;
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 use `test`/*!*/;
 SET TIMESTAMP=XXX/*!*/;
 SET @@session.pseudo_thread_id=#/*!*/;
@@ -104,105 +104,105 @@ SET @@session.collation_database=DEFAULT/*!*/;
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf8)
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 INSERT INTO t1 VALUES ('ä(i1)')
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 INSERT INTO t1 VALUES ('ä(i2)')
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 INSERT INTO t1 VALUES ('ä(i3)')
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 INSERT INTO t1 VALUES ('ä(p1)')
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 INSERT INTO t1 VALUES ('ä(p2)')
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-#
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 BEGIN
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 INSERT INTO t1 VALUES ('ä(p3)')
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 COMMIT
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	GTID #-#-# ddl
 /*!100001 SET @@session.gtid_seq_no=#*//*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Query	thread_id=#	exec_time=#	error_code=0
 SET TIMESTAMP=XXX/*!*/;
 DROP TABLE `t1` /* generated by server */
 /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX 	Rotate to master-bin.000004  pos: 4
+#YYMMDD HH:MM:SS server id #  end_log_pos # CRC32 XXX 	Rotate to master-bin.000004  pos: 4
 DELIMITER ;
 # End of log file
 ROLLBACK /* added by mysqlbinlog */;


### PR DESCRIPTION
The fix from MDEV-10866 was insufficient.
Attempt 2 at fixing this.

binlog.binlog_row_ctype_ucs 'row'        w18 [ fail ]
        Test ended at 2017-02-13 10:36:57

<pre>
CURRENT_TEST: binlog.binlog_row_ctype_ucs
--- /mariadb/mysql-test/suite/binlog/r/binlog_row_ctype_ucs.result        2017-02-06 09:29:43.116183650 +1100
+++ /mariadb/mysql-test/suite/binlog/r/binlog_row_ctype_ucs.reject        2017-02-13 10:36:56.984056229 +1100
@@ -71,21 +71,21 @@
 /*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
 DELIMITER /*!*/;
 # at #
-#700101  6:46:40 server id #  end_log_pos # CRC32 XXX  Start: binlog v 4, server v #.##.## created 700101  6:46:40
+#170213 10:36:56 server id #  end_log_pos # CRC32 XXX  Start: binlog v 4, server v #.##.## created 170213 10:36:56
 # at #
</pre>
...
I submit this under the MCA.