### PR TITLE
MDEV-10515: Correct stat_tables_par test results

### DIFF
--- a/mysql-test/r/stat_tables_par.result
+++ b/mysql-test/r/stat_tables_par.result
@@ -46,19 +46,19 @@ dbt3_s001	supplier	PRIMARY	1	1.0000
 dbt3_s001	supplier	i_s_nationkey	1	1.1111
 flush table lineitem;
 set use_stat_tables='never';
-select sum(l_extendedprice*l_discount) as revenue
+select round(sum(l_extendedprice*l_discount),4) as revenue
 from lineitem
 where l_shipdate >= date '1994-01-01' 
 and l_shipdate < date '1994-01-01' + interval '1' year
 and l_discount between 0.06 - 0.01 and 0.06 + 0.01
 and l_quantity < 24;
 revenue
-77949.91860000002
+77949.9186
 set debug_sync='statistics_mem_alloc_start1  WAIT_FOR second_thread_started_too';
 set debug_sync='statistics_mem_alloc_start2  SIGNAL first_thread_working';
 use dbt3_s001;
 set use_stat_tables='preferably';
-select sum(l_extendedprice*l_discount) as revenue
+select round(sum(l_extendedprice*l_discount),4) as revenue
 from lineitem
 where l_shipdate >= date '1994-01-01' 
 and l_shipdate < date '1994-01-01' + interval '1' year
@@ -68,16 +68,16 @@ set debug_sync='statistics_mem_alloc_start1  SIGNAL second_thread_started_too';
 set debug_sync='statistics_mem_alloc_start2  WAIT_FOR first_thread_working';
 use dbt3_s001;
 set use_stat_tables='preferably';
-select sum(l_extendedprice*l_discount) as revenue
+select round(sum(l_extendedprice*l_discount),4) as revenue
 from lineitem
 where l_shipdate >= date '1994-01-01' 
 and l_shipdate < date '1994-01-01' + interval '1' year
 and l_discount between 0.06 - 0.01 and 0.06 + 0.01
 and l_quantity < 24;
 revenue
-77949.91860000002
+77949.9186
 revenue
-77949.91860000002
+77949.9186
 set use_stat_tables='preferably';
 set debug_sync='RESET';
 select * from mysql.index_stats where table_name='lineitem' order by index_name;

--- a/mysql-test/r/stat_tables_par_innodb.result
+++ b/mysql-test/r/stat_tables_par_innodb.result
@@ -49,19 +49,19 @@ dbt3_s001	supplier	PRIMARY	1	1.0000
 dbt3_s001	supplier	i_s_nationkey	1	1.1111
 flush table lineitem;
 set use_stat_tables='never';
-select sum(l_extendedprice*l_discount) as revenue
+select round(sum(l_extendedprice*l_discount),4) as revenue
 from lineitem
 where l_shipdate >= date '1994-01-01' 
 and l_shipdate < date '1994-01-01' + interval '1' year
 and l_discount between 0.06 - 0.01 and 0.06 + 0.01
 and l_quantity < 24;
 revenue
-77949.91860000002
+77949.9186
 set debug_sync='statistics_mem_alloc_start1  WAIT_FOR second_thread_started_too';
 set debug_sync='statistics_mem_alloc_start2  SIGNAL first_thread_working';
 use dbt3_s001;
 set use_stat_tables='preferably';
-select sum(l_extendedprice*l_discount) as revenue
+select round(sum(l_extendedprice*l_discount),4) as revenue
 from lineitem
 where l_shipdate >= date '1994-01-01' 
 and l_shipdate < date '1994-01-01' + interval '1' year
@@ -71,16 +71,16 @@ set debug_sync='statistics_mem_alloc_start1  SIGNAL second_thread_started_too';
 set debug_sync='statistics_mem_alloc_start2  WAIT_FOR first_thread_working';
 use dbt3_s001;
 set use_stat_tables='preferably';
-select sum(l_extendedprice*l_discount) as revenue
+select round(sum(l_extendedprice*l_discount),4) as revenue
 from lineitem
 where l_shipdate >= date '1994-01-01' 
 and l_shipdate < date '1994-01-01' + interval '1' year
 and l_discount between 0.06 - 0.01 and 0.06 + 0.01
 and l_quantity < 24;
 revenue
-77949.91860000002
+77949.9186
 revenue
-77949.91860000002
+77949.9186
 set use_stat_tables='preferably';
 set debug_sync='RESET';
 select * from mysql.index_stats where table_name='lineitem' order by index_name;

--- a/mysql-test/t/stat_tables_par.test
+++ b/mysql-test/t/stat_tables_par.test
@@ -44,7 +44,7 @@ select * from mysql.index_stats;
 #
 
 let $Q6=
-select sum(l_extendedprice*l_discount) as revenue
+select round(sum(l_extendedprice*l_discount),4) as revenue
 from lineitem
 where l_shipdate >= date '1994-01-01' 
       and l_shipdate < date '1994-01-01' + interval '1' year


### PR DESCRIPTION
Test results are distorted by a small rounding error
during an intermediate stage of calculating the result.
By using the SQL ROUND function we stablise tests.

I submit this under the MCA