### PR TITLE
MDEV-12194 - Remove connect warnings in storage connect

### DIFF
--- a/storage/connect/ha_connect.cc
+++ b/storage/connect/ha_connect.cc
@@ -5172,7 +5172,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
                                       TABLE_SHARE *table_s,
                                       HA_CREATE_INFO *create_info)
 {
-  char        v=0, spc= ',', qch= 0;
+  char        v=0, spc, qch;
   const char *fncn= "?";
   const char *user, *fn, *db, *host, *pwd, *sep, *tbl, *src;
   const char *col, *ocl, *rnk, *pic, *fcl, *skc, *zfn;


### PR DESCRIPTION
Both of these are unconditionally assigned later.

from gcc-6.2.1 compile:

storage/connect/ha_connect.cc: In function ‘int connect_assisted_discovery(handlerton*, THD*, TABLE_SHARE*, HA_CREATE_INFO*)’:
storage/connect/ha_connect.cc:5175:20: warning: variable ‘spc’ set but not used [-Wunused-but-set-variable]
   char        v=0, spc= ',', qch= 0;
                    ^~~
storage/connect/ha_connect.cc:5175:30: warning: variable ‘qch’ set but not used [-Wunused-but-set-variable]
   char        v=0, spc= ',', qch= 0;
                              ^~~
I submit this under the MCA.