### PR TITLE
Remove warning: unused variable 'volatile_var' [-Wunused-variable] (10.1)

### DIFF
--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -91,7 +91,7 @@ private:
 # elif defined(__powerpc__)
 #include <sys/platform/ppc.h>
 #  define UT_RELAX_CPU() do { \
-     volatile lint      volatile_var = __ppc_get_timebase(); \
+     lint  __attribute__((unused)) volatile_var = __ppc_get_timebase(); \
    } while (0)
 # else
 #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */

--- a/storage/xtradb/include/ut0ut.h
+++ b/storage/xtradb/include/ut0ut.h
@@ -88,7 +88,7 @@ private:
 # elif defined(__powerpc__)
 #include <sys/platform/ppc.h>
 #  define UT_RELAX_CPU() do { \
-     volatile lint      volatile_var = __ppc_get_timebase(); \
+     lint  __attribute__((unused)) volatile_var = __ppc_get_timebase(); \
    } while (0)
 # else
 #  define UT_RELAX_CPU() ((void)0) /* avoid warning for an empty statement */


### PR DESCRIPTION
This occurred in gcc-6.2.1.

The variable wasn't used so was no need to be volatile either.

I submit this under the MCA.