### PR TITLE
MDEV-11619: mtr --mem {no arguement of a directory}

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1194,7 +1194,7 @@ sub command_line_setup {
 	     # Directories
              'tmpdir=s'                 => \$opt_tmpdir,
              'vardir=s'                 => \$opt_vardir,
-             'mem:s'                    => \$opt_mem,
+             'mem'                      => \$opt_mem,
 	     'clean-vardir'             => \$opt_clean_vardir,
              'client-bindir=s'          => \$path_client_bindir,
              'client-libdir=s'          => \$path_client_libdir,
@@ -1456,9 +1456,6 @@ sub command_line_setup {
 
     # Use $ENV{'MTR_MEM'} as first location to look (if defined)
     unshift(@tmpfs_locations, $ENV{'MTR_MEM'}) if defined $ENV{'MTR_MEM'};
-
-    # however if the opt_mem was given a value, use this first
-    unshift(@tmpfs_locations, $opt_mem) if $opt_mem ne '';
 
     foreach my $fs (@tmpfs_locations)
     {


### PR DESCRIPTION
mtr --mem plugin was an issue because plugin was treated
as a directory where mtr treated as a tmp location rather
than a legitimate test name.

This removes functionality of where ./mtr --mem /tmp/dir could be
a directory.

Now MTR_MEM=/tmp/dir ./mtr is needed.

The case where MTR_MEM=/tmp/dir ./mtr --mem has the equalivant
effect.

Thanks Elena for helping and identifing edge cases.

I submit this under the MCA.