### PR TITLE
whitespace - fix indenting after commit 7450cb7f6 (10.2)

### DIFF
--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -4823,9 +4823,9 @@ static bool fix_all_session_vcol_exprs(THD *thd, TABLE_LIST *tables)
             fix_session_vcol_expr(thd, (*df)->default_value))
           goto err;
 
-        for (Virtual_column_info **cc= t->check_constraints; cc && *cc; cc++)
-          if (fix_session_vcol_expr(thd, (*cc)))
-            goto err;
+      for (Virtual_column_info **cc= t->check_constraints; cc && *cc; cc++)
+        if (fix_session_vcol_expr(thd, (*cc)))
+          goto err;
 
       thd->security_ctx= save_security_ctx;
     }


### PR DESCRIPTION
This caused gcc-6.3.1 errors:7450cb7f6

mariadb-server/sql/sql_base.cc: In function ‘bool fix_all_session_vcol_exprs(THD*, TABLE_LIST*)’:
mariadb-server/sql/sql_base.cc:4821:7: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
       for (Field **df= t->default_field; df && *df; df++)
       ^~~
mariadb-server/sql/sql_base.cc:4826:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘for’
         for (Virtual_column_info **cc= t->check_constraints; cc && *cc; cc++)
         ^~~

It was obvious from 7450cb7f6 that the indenting should of been removed

I submit this under the MCA.