### PR TITLE
MDEV-12195 - whitespace warnings + printf attributes in sql/log

### DIFF
--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -3479,7 +3479,7 @@ Item_func_group_concat::fix_fields(THD *thd, Item **ref)
          args[i]->fix_fields(thd, args + i)) ||
         args[i]->check_cols(1))
       return TRUE;
-      with_subselect|= args[i]->with_subselect;
+    with_subselect|= args[i]->with_subselect;
   }
 
   /* skip charset aggregation for order columns */

--- a/sql/log.h
+++ b/sql/log.h
@@ -1066,10 +1066,14 @@ int query_error_code(THD *thd, bool not_killed);
 uint purge_log_get_error_code(int res);
 
 int vprint_msg_to_log(enum loglevel level, const char *format, va_list args);
-void sql_print_error(const char *format, ...);
-void sql_print_warning(const char *format, ...);
-void sql_print_information(const char *format, ...);
-typedef void (*sql_print_message_func)(const char *format, ...);
+void sql_print_error(const char *format, ...)
+                     ATTRIBUTE_FORMAT_FPTR(printf, 1, 2);
+void sql_print_warning(const char *format, ...)
+                       ATTRIBUTE_FORMAT_FPTR(printf, 1, 2);
+void sql_print_information(const char *format, ...)
+                           ATTRIBUTE_FORMAT_FPTR(printf, 1, 2);
+typedef void (*sql_print_message_func)(const char *format, ...)
+                                       ATTRIBUTE_FORMAT_FPTR(printf, 1, 2);
 extern sql_print_message_func sql_print_message_handlers[];
 
 int error_log_print(enum loglevel level, const char *format,
@@ -1079,7 +1083,8 @@ bool slow_log_print(THD *thd, const char *query, uint query_length,
                     ulonglong current_utime);
 
 bool general_log_print(THD *thd, enum enum_server_command command,
-                       const char *format,...);
+                       const char *format,...)
+                       ATTRIBUTE_FORMAT_FPTR(printf, 3, 4);
 
 bool general_log_write(THD *thd, enum enum_server_command command,
                        const char *query, uint query_length);

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2894,8 +2894,8 @@ log_event_print_value(IO_CACHE *file, const uchar *ptr,
     case 2:
       {
         strmake(typestr, "ENUM(2 bytes)", typestr_length);
-      if (!ptr)
-        goto return_null;
+        if (!ptr)
+          goto return_null;
 
         int32 i32= uint2korr(ptr);
         my_b_printf(file, "%d", i32);

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -12122,7 +12122,7 @@ static bool secure_auth(THD *thd)
   else
   {
     my_error(ER_NOT_SUPPORTED_AUTH_MODE, MYF(0));
-    general_log_print(thd, COM_CONNECT,
+    general_log_print(thd, COM_CONNECT, "%s",
                       ER_THD(thd, ER_NOT_SUPPORTED_AUTH_MODE));
   }
   return 1;
@@ -12195,7 +12195,7 @@ static bool send_plugin_request_packet(MPVIO_EXT *mpvio,
   if (switch_from_short_to_long_scramble)
   {
     my_error(ER_NOT_SUPPORTED_AUTH_MODE, MYF(0));
-    general_log_print(mpvio->thd, COM_CONNECT,
+    general_log_print(mpvio->thd, COM_CONNECT, "%s",
                       ER_THD(mpvio->thd, ER_NOT_SUPPORTED_AUTH_MODE));
     DBUG_RETURN (1);
   }
@@ -12273,7 +12273,7 @@ static bool find_mpvio_user(MPVIO_EXT *mpvio)
     DBUG_ASSERT(my_strcasecmp(system_charset_info, mpvio->acl_user->plugin.str,
                               old_password_plugin_name.str));
     my_error(ER_NOT_SUPPORTED_AUTH_MODE, MYF(0));
-    general_log_print(mpvio->thd, COM_CONNECT,
+    general_log_print(mpvio->thd, COM_CONNECT, "%s",
                       ER_THD(mpvio->thd, ER_NOT_SUPPORTED_AUTH_MODE));
     DBUG_RETURN (1);
   }


### PR DESCRIPTION
No answer on https://lists.launchpad.net/maria-developers/msg10431.html

Fix whitespace.

format attributes highlighted misuse of functions.