### PR TITLE
MDEV-12169 - port "Print binary data as hex in the mysql client" by @dveeden

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -3585,7 +3585,7 @@ print_table_data(MYSQL_RES *result)
       length= MY_MAX(length,field->max_length);
     if (length < 4 && !IS_NOT_NULL(field->flags))
       length=4;					// Room for "NULL"
-    if (opt_binhex && is_binary_field(field))
+    if (opt_binhex && is_binary_field(field) && IS_NOT_NULL(field->flags))
       length= 2+length*2;
     field->max_length=length;
     num_flag[mysql_field_tell(result) - 1]= IS_NUM(field->type);
@@ -3656,7 +3656,7 @@ print_table_data(MYSQL_RES *result)
       visible_length= charset_info->cset->numcells(charset_info, buffer, buffer + data_length);
       extra_padding= data_length - visible_length;
 
-      if (opt_binhex && is_binary_field(field))
+      if (opt_binhex && is_binary_field(field) && IS_NOT_NULL(field->flags))
       {
         print_as_hex(PAGER, buffer, data_length, field_max_length);
       }
@@ -3877,7 +3877,7 @@ print_table_data_vertically(MYSQL_RES *result)
       field= mysql_fetch_field(result);
       if (column_names)
         tee_fprintf(PAGER, "%*s: ",(int) max_length,field->name);
-      if (opt_binhex && is_binary_field(field))
+      if (opt_binhex && is_binary_field(field) && IS_NOT_NULL(field->flags))
       {
         print_as_hex(PAGER, cur[off], lengths[off], lengths[off]);
         tee_putc('\n', PAGER);

--- a/mysql-test/r/mysql.result
+++ b/mysql-test/r/mysql.result
@@ -70,6 +70,13 @@ drop table t1;
 | >a   <               | 0123456789 |      4 |
 | >abcd<               |            |      4 |
 +----------------------+------------+--------+
++----------------------+------------+--------+
+| concat('>',col1,'<') | col2       | col3   |
++----------------------+------------+--------+
+| >a   <               | b          | 123421 |
+| >a   <               | 0123456789 |      4 |
+| >abcd<               |            |      4 |
++----------------------+------------+--------+
 +-------------------+
 | __taÃ±gÃ¨ Ã‘Ã£mÃ©      |
 +-------------------+
@@ -95,6 +102,24 @@ Field	Type	Null	Key	Default	Extra
 i	int(11)	YES		NULL	
 j	int(11)	NO		NULL	
 k	int(11)	YES		NULL	
+i	j	k
+NULL	1	NULL
+Field	Type	Null	Key	Default	Extra
+i	int(11)	YES		NULL	
+j	int(11)	NO		NULL	
+k	int(11)	YES		NULL	
++------+---+------+
+| i    | j | k    |
++------+---+------+
+| NULL | 1 | NULL |
++------+---+------+
++-------+---------+------+-----+---------+-------+
+| Field | Type    | Null | Key | Default | Extra |
++-------+---------+------+-----+---------+-------+
+| i     | int(11) | YES  |     | NULL    |       |
+| j     | int(11) | NO   |     | NULL    |       |
+| k     | int(11) | YES  |     | NULL    |       |
++-------+---------+------+-----+---------+-------+
 +------+---+------+
 | i    | j | k    |
 +------+---+------+
@@ -118,6 +143,13 @@ i	s1
 |    2 | NULL |
 |    3 |      |
 +------+------+
+unhex('zz')
+NULL
++-------------+
+| unhex('zz') |
++-------------+
+| NULL        |
++-------------+
 unhex('zz')
 NULL
 +-------------+
@@ -208,6 +240,7 @@ COUNT (*)
 1
 COUNT (*)
 1
+ERROR 2005 (HY000) at line 1: Unknown MySQL server host 'invalid_hostname' (errno)
 ERROR 2005 (HY000) at line 1: Unknown MySQL server host 'invalid_hostname' (errno)
 End of 5.0 tests
 WARNING: --server-arg option not supported in this configuration.
@@ -541,6 +574,44 @@ a
 ERROR 1300 (HY000): Invalid utf8 character string: 'test\xF0\x9F\x98\x81 '
 ERROR 1300 (HY000): Invalid binary character string: 'test\xF0\x9F\x98\x81 '
 ERROR 1300 (HY000) at line 2: Invalid utf8 character string: 'test\xF0\x9F\x98\x81'
+id	name
+õ»#)\0$ç¿1lˆ˜|H	test 1
+õ»#4\0$ç¿1lˆ˜|H	test 2
+õ»#8\0$ç¿1lˆ˜|H	test 3
+NULL	test null
+id	name
+õ»#)\0$ç¿1lˆ˜|H	test 1
+õ»#4\0$ç¿1lˆ˜|H	test 2
+õ»#8\0$ç¿1lˆ˜|H	test 3
+NULL	test null
+*************************** 1. row ***************************
+  id: õ»#) $ç¿1lˆ˜|H
+name: test 1
+*************************** 2. row ***************************
+  id: õ»#4 $ç¿1lˆ˜|H
+name: test 2
+*************************** 3. row ***************************
+  id: õ»#8 $ç¿1lˆ˜|H
+name: test 3
+*************************** 4. row ***************************
+  id: NULL
+name: test null
+*************************** 1. row ***************************
+  id: õ»#) $ç¿1lˆ˜|H
+name: test 1
+*************************** 2. row ***************************
+  id: õ»#4 $ç¿1lˆ˜|H
+name: test 2
+*************************** 3. row ***************************
+  id: õ»#8 $ç¿1lˆ˜|H
+name: test 3
+*************************** 4. row ***************************
+  id: NULL
+name: test null
+id	name
+õ»#4\0$ç¿1lˆ˜|H	test 2
+id	name
+õ»#4\0$ç¿1lˆ˜|H	test 2
 set GLOBAL sql_mode=default;
 
 End of tests

--- a/mysql-test/t/mysql.test
+++ b/mysql-test/t/mysql.test
@@ -49,6 +49,7 @@ drop table t1;
 #
 # Bug#16859 -- NULLs in columns must not truncate data as if a C-language "string".
 #
+--exec $MYSQL -t --binary-as-hex=0 test -e "create table t1 (col1 binary(4), col2 varchar(10), col3 int); insert into t1 values ('a', 'b', 123421),('a ', '0123456789', 4), ('abcd', '', 4); select concat('>',col1,'<'), col2, col3 from t1; drop table t1;" 2>&1
 --exec $MYSQL -t test -e "create table t1 (col1 binary(4), col2 varchar(10), col3 int); insert into t1 values ('a', 'b', 123421),('a ', '0123456789', 4), ('abcd', '', 4); select concat('>',col1,'<'), col2, col3 from t1; drop table t1;" 2>&1
 
 #
@@ -65,7 +66,9 @@ drop table t1;
 #
 # "DESCRIBE" commands may return strange NULLness flags.
 #
+--exec $MYSQL --binary-as-hex=0 --default-character-set utf8 test -e "create table t1 (i int, j int not null, k int); insert into t1 values (null, 1, null); select * from t1; describe t1; drop table t1;"
 --exec $MYSQL --default-character-set utf8 test -e "create table t1 (i int, j int not null, k int); insert into t1 values (null, 1, null); select * from t1; describe t1; drop table t1;"
+--exec $MYSQL --binary-as-hex=0 -t --default-character-set utf8 test -e "create table t1 (i int, j int not null, k int); insert into t1 values (null, 1, null); select * from t1; describe t1; drop table t1;"
 --exec $MYSQL -t --default-character-set utf8 test -e "create table t1 (i int, j int not null, k int); insert into t1 values (null, 1, null); select * from t1; describe t1; drop table t1;"
 
 #
@@ -77,8 +80,11 @@ drop table t1;
 #
 # Bug#21618: NULL shown as empty string in client
 #
---exec $MYSQL test -e "select unhex('zz');" 
---exec $MYSQL -t test -e "select unhex('zz');" 
+--exec $MYSQL test -e "select unhex('zz');"
+--exec $MYSQL -t test -e "select unhex('zz');"
+--exec $MYSQL --binary-as-hex=0 test -e "select unhex('zz');"
+--exec $MYSQL -t --binary-as-hex=0 test -e "select unhex('zz');"
+
 
 # Bug#19265 describe command does not work from mysql prompt
 #
@@ -365,7 +371,11 @@ remove_file $MYSQLTEST_VARDIR/tmp/bug31060.sql;
 --replace_regex /\([0-9|-]*\)/(errno)/
 --error 1
 --exec $MYSQL --default-character-set=binary test -e "CONNECT test invalid_hostname" 2>&1
+--replace_regex /\([0-9|-]*\)/(errno)/
+--error 1
+--exec $MYSQL --binary-as-hex=0 --default-character-set=binary test -e "CONNECT test invalid_hostname" 2>&1
 --exec $MYSQL --default-character-set=binary test -e "DELIMITER //" 2>&1
+--exec $MYSQL --binary-as-hex=0 --default-character-set=binary test -e "DELIMITER //" 2>&1
 
 --echo End of 5.0 tests
 
@@ -641,6 +651,15 @@ EOF
 --error 1
 --exec $MYSQL --default-character-set=utf8 < $MYSQLTEST_VARDIR/tmp/mdev-6572.sql 2>&1
 --remove_file $MYSQLTEST_VARDIR/tmp/mdev-6572.sql
+
+--exec $MYSQL test -e "SET @uuid1='f5bb2329-0024-11e7-bf31-6c8814987c48'; SET @uuid2='f5bb2334-0024-11e7-bf31-6c8814987c48'; SET @uuid3='f5bb2338-0024-11e7-bf31-6c8814987c48'; create table t1(id binary(16), name varchar(100)); insert into t1 values(unhex(replace(@uuid1,'-','')), 'test 1'); insert into t1 values(unhex(replace(@uuid2,'-','')), 'test 2'); insert into t1 values(unhex(replace(@uuid3,'-','')), 'test 3'); insert into t1 values(NULL,'test null');"
+--exec $MYSQL test -e "select * from t1"
+--exec $MYSQL --binary-as-hex=0 test -e "select * from t1"
+--exec $MYSQL test -e "select * from t1\G"
+--exec $MYSQL --binary-as-hex=0 test -e "select * from t1\G"
+--exec $MYSQL test -e "select * from t1 where id = 0xF5BB2334002411E7BF316C8814987C48"
+--exec $MYSQL --binary-as-hex=0 test -e "select * from t1 where id = 0xF5BB2334002411E7BF316C8814987C48"
+--exec $MYSQL test -e "drop table t1"
 
 set GLOBAL sql_mode=default;
 --echo


### PR DESCRIPTION
original code: https://github.com/mysql/mysql-server/pull/118

MariaDB [test]> create table t1(id binary(16) primary key, name varchar(100));
Query OK, 0 rows affected (0.03 sec)

MariaDB [test]> insert into t1 values(unhex(replace(uuid(),'-','')), 'test 1');
Query OK, 1 row affected (0.00 sec)

MariaDB [test]> insert into t1 values(unhex(replace(uuid(),'-','')), 'test 2');
Query OK, 1 row affected (0.00 sec)

MariaDB [test]> insert into t1 values(unhex(replace(uuid(),'-','')), 'test 3');
Query OK, 1 row affected (0.00 sec)

MariaDB [test]> select * from t1;
+------------------+--------+
| id               | name   |
+------------------+--------+
| ^_?m?T?dl?^T?|H | test 1 |
| !?T?dl?^T?|H | test 2 |
| #t1?T??dl?^T??|H | test 3 |
+------------------+--------+
3 rows in set (0.00 sec)

With the addition of this patch, the following is possible:

MariaDB [test]> select * from t1;
+------------------------------------+--------+
| id                                 | name   |
+------------------------------------+--------+
| 0x1FE6166DFF5411E6AB646C8814987C48 | test 1 |
| 0x21EFDCB2FF5411E6AB646C8814987C48 | test 2 |
| 0x237431D4FF5411E6AB646C8814987C48 | test 3 |
+------------------------------------+--------+
3 rows in set (0.00 sec)

MariaDB [test]> select * from t1 where id = 0x21EFDCB2FF5411E6AB646C8814987C48;
+------------------------------------+--------+
| id                                 | name   |
+------------------------------------+--------+
| 0x21EFDCB2FF5411E6AB646C8814987C48 | test 2 |
+------------------------------------+--------+
1 row in set (0.00 sec)

MariaDB [test]> select * from t1\G
*************************** 1. row ***************************
  id: 0x1FE6166DFF5411E6AB646C8814987C48
name: test 1
*************************** 2. row ***************************
  id: 0x21EFDCB2FF5411E6AB646C8814987C48
name: test 2
*************************** 3. row ***************************
  id: 0x237431D4FF5411E6AB646C8814987C48
name: test 3
3 rows in set (0.01 sec)

This patch also introduces the new option --binary-as-hex=0 in
order to disable this new behavior.