### PR TITLE
MDEV-11829 - add rfc3339 support

### DIFF
--- a/include/my_time.h
+++ b/include/my_time.h
@@ -80,6 +80,15 @@ extern uchar days_in_month[];
 
 /* Usefull constants */
 #define SECONDS_IN_24H 86400L
+#define SECS_PER_MIN	60
+#define MINS_PER_HOUR	60
+#define HOURS_PER_DAY	24
+#define DAYS_PER_WEEK	7
+#define DAYS_PER_NYEAR	365
+#define DAYS_PER_LYEAR	366
+#define SECS_PER_HOUR	(SECS_PER_MIN * MINS_PER_HOUR)
+#define SECS_PER_DAY	((long) SECS_PER_HOUR * HOURS_PER_DAY)
+#define MONS_PER_YEAR	12
 
 /* Limits for the TIME data type */
 #define TIME_MAX_HOUR 838
@@ -100,11 +109,13 @@ typedef struct st_mysql_time_status
 {
   int warnings;
   uint precision;
+  long tz_offset;
+  my_bool tz_offset_valid;
 } MYSQL_TIME_STATUS;
 
 static inline void my_time_status_init(MYSQL_TIME_STATUS *status)
 {
-  status->warnings= status->precision= 0;
+  status->warnings= status->precision= status->tz_offset_valid= 0;
 }
 
 my_bool check_date(const MYSQL_TIME *ltime, my_bool not_zero_date,
@@ -113,6 +124,7 @@ my_bool str_to_time(const char *str, uint length, MYSQL_TIME *l_time,
                     ulonglong flag, MYSQL_TIME_STATUS *status);
 my_bool str_to_datetime(const char *str, uint length, MYSQL_TIME *l_time,
                         ulonglong flags, MYSQL_TIME_STATUS *status);
+my_bool str_to_offset(const char *str, uint length, long *offset);
 longlong number_to_datetime(longlong nr, ulong sec_part, MYSQL_TIME *time_res,
                             ulonglong flags, int *was_cut);
 

--- a/mysql-test/r/ctype_utf16le.result
+++ b/mysql-test/r/ctype_utf16le.result
@@ -1209,6 +1209,42 @@ DROP TABLE t1;
 select @@collation_connection;
 @@collation_connection
 utf16le_general_ci
+CREATE TABLE t1 (a timestamp);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+a
+2016-12-10 18:10:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a timestamp);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+a
+2016-12-10 11:40:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a timestamp);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+SELECT * FROM t1;
+a
+2016-12-10 13:10:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
 CREATE TABLE t1 (a datetime);
 INSERT INTO t1 VALUES ('1900-12-10T10:10:10Z');
 Warnings:

--- a/mysql-test/r/ctype_utf16le.result
+++ b/mysql-test/r/ctype_utf16le.result
@@ -1168,6 +1168,70 @@ a
 2007-09-16
 DROP TABLE t1;
 #
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+a
+2016-12-10 18:10:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+a
+2016-12-10 11:40:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+SELECT * FROM t1;
+a
+2016-12-10 13:10:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('1900-12-10T10:10:10Z');
+Warnings:
+Warning	1265	Data truncated for column 'a' at row 1
+SELECT * FROM t1;
+a
+1900-12-10 10:10:10
+DROP TABLE t1;
+#
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('1900-12-10T10:10:10-05:00');
+Warnings:
+Warning	1265	Data truncated for column 'a' at row 1
+SELECT * FROM t1;
+a
+1900-12-10 10:10:10
+DROP TABLE t1;
+#
 # Testing cs->cset->ll10tostr
 #
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf16le);

--- a/mysql-test/r/ctype_utf16le.result
+++ b/mysql-test/r/ctype_utf16le.result
@@ -1232,6 +1232,70 @@ a
 1900-12-10 10:10:10
 DROP TABLE t1;
 #
+# Checking str_to_time() for Conveting TimeZone
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10-05:00');
+SELECT * FROM t1;
+a
+05:10:10
+DROP TABLE t1;
+#
+# Checking str_to_time() for Conveting TimeZone
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10+04:30');
+SELECT * FROM t1;
+a
+14:40:10
+DROP TABLE t1;
+#
+# Checking str_to_time() for Conveting TimeZone
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10Z');
+SELECT * FROM t1;
+a
+10:10:10
+DROP TABLE t1;
+#
+# Checking str_to_time() for Conveting TimeZone
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+Warnings:
+Note	1265	Data truncated for column 'a' at row 1
+SELECT * FROM t1;
+a
+10:10:10
+DROP TABLE t1;
+#
+# Checking str_to_time() for Conveting TimeZone
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+Warnings:
+Note	1265	Data truncated for column 'a' at row 1
+SELECT * FROM t1;
+a
+05:10:10
+DROP TABLE t1;
+#
 # Testing cs->cset->ll10tostr
 #
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf16le);

--- a/mysql-test/r/ctype_utf16le.result
+++ b/mysql-test/r/ctype_utf16le.result
@@ -1332,6 +1332,32 @@ a
 05:10:10
 DROP TABLE t1;
 #
+# Checking str_to_datetime() for RFC3339
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+set @@parse_rfc3339_timezones=0;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+a
+2016-12-10 10:10:10
+DROP TABLE t1;
+#
+# Checking str_to_time() for Conveting TimeZone
+#
+select @@collation_connection;
+@@collation_connection
+utf16le_general_ci
+set @@parse_rfc3339_timezones=0;
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10-05:00');
+SELECT * FROM t1;
+a
+10:10:10
+DROP TABLE t1;
+#
 # Testing cs->cset->ll10tostr
 #
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf16le);

--- a/mysql-test/t/ctype_utf16le.test
+++ b/mysql-test/t/ctype_utf16le.test
@@ -560,6 +560,33 @@ DROP TABLE t1;
 --echo # Checking str_to_datetime() for RFC3339
 --echo #
 select @@collation_connection;
+CREATE TABLE t1 (a timestamp);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a timestamp);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a timestamp);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
 CREATE TABLE t1 (a datetime);
 INSERT INTO t1 VALUES ('1900-12-10T10:10:10Z');
 SELECT * FROM t1;

--- a/mysql-test/t/ctype_utf16le.test
+++ b/mysql-test/t/ctype_utf16le.test
@@ -575,6 +575,51 @@ SELECT * FROM t1;
 DROP TABLE t1;
 
 --echo #
+--echo # Checking str_to_time() for Conveting TimeZone
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10-05:00');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_time() for Conveting TimeZone
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10+04:30');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_time() for Conveting TimeZone
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10Z');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_time() for Conveting TimeZone
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_time() for Conveting TimeZone
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
 --echo # Testing cs->cset->ll10tostr
 --echo #
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf16le);

--- a/mysql-test/t/ctype_utf16le.test
+++ b/mysql-test/t/ctype_utf16le.test
@@ -647,6 +647,26 @@ SELECT * FROM t1;
 DROP TABLE t1;
 
 --echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+set @@parse_rfc3339_timezones=0;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_time() for Conveting TimeZone
+--echo #
+select @@collation_connection;
+set @@parse_rfc3339_timezones=0;
+CREATE TABLE t1 (a time);
+INSERT INTO t1 VALUES ('10:10:10-05:00');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
 --echo # Testing cs->cset->ll10tostr
 --echo #
 CREATE TABLE t1 (a VARCHAR(10) CHARACTER SET utf16le);

--- a/mysql-test/t/ctype_utf16le.test
+++ b/mysql-test/t/ctype_utf16le.test
@@ -529,6 +529,50 @@ INSERT INTO t1 VALUES ('2007-09-16');
 SELECT * FROM t1;
 DROP TABLE t1;
 
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10+01:30');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('2016-12-10T10:10:10Z');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('1900-12-10T10:10:10Z');
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Checking str_to_datetime() for RFC3339
+--echo #
+select @@collation_connection;
+CREATE TABLE t1 (a datetime);
+INSERT INTO t1 VALUES ('1900-12-10T10:10:10-05:00');
+SELECT * FROM t1;
+DROP TABLE t1;
 
 --echo #
 --echo # Testing cs->cset->ll10tostr

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -672,6 +672,8 @@ typedef struct system_variables
 
   Time_zone *time_zone;
 
+  my_bool parse_rfc3339_timezones;
+
   my_bool sysdate_is_now;
 
   /* deadlock detection */

--- a/sql/sql_time.cc
+++ b/sql/sql_time.cc
@@ -289,7 +289,21 @@ str_to_time(CHARSET_INFO *cs, const char *str,uint length,
     length= to_ascii(cs, str, length, cnv, sizeof(cnv));
     str= cnv;
   }
-  return str_to_time(str, length, l_time, fuzzydate, status);
+  bool ret = str_to_time(str, length, l_time, fuzzydate, status);
+  if(ret == 0 && status->tz_offset_valid)
+  {
+    MYSQL_TIME tz_convert_to_time;
+    calc_time_from_sec(&tz_convert_to_time, status->tz_offset, 0);
+    l_time->minute += tz_convert_to_time.minute;
+    l_time->hour += tz_convert_to_time.hour;
+    if(l_time->minute >= 60)
+    {
+      l_time->hour++;
+      l_time->minute -= 60;
+    }
+    check_time_range(l_time, 6, &status->warnings);
+  }
+  return ret;
 }
 
 

--- a/sql/sql_time.cc
+++ b/sql/sql_time.cc
@@ -290,7 +290,7 @@ str_to_time(CHARSET_INFO *cs, const char *str,uint length,
     str= cnv;
   }
   bool ret = str_to_time(str, length, l_time, fuzzydate, status);
-  if(ret == 0 && status->tz_offset_valid)
+  if(ret == 0 && current_thd->variables.parse_rfc3339_timezones && status->tz_offset_valid)
   {
     MYSQL_TIME tz_convert_to_time;
     calc_time_from_sec(&tz_convert_to_time, status->tz_offset, 0);
@@ -319,7 +319,7 @@ bool str_to_datetime(CHARSET_INFO *cs, const char *str, uint length,
     str= cnv;
   }
   bool ret = str_to_datetime(str, length, l_time, flags, status);
-  if(ret == 0 && status->tz_offset_valid)
+  if(ret == 0 && current_thd->variables.parse_rfc3339_timezones && status->tz_offset_valid)
   {
     uint tz_convert_err;
     my_time_t tm= Time_zone_offset(status->tz_offset).TIME_to_gmt_sec(l_time, &tz_convert_err);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4770,6 +4770,13 @@ static Sys_var_tz Sys_time_zone(
        SESSION_VAR(time_zone), NO_CMD_LINE,
        DEFAULT(&default_tz), NO_MUTEX_GUARD, IN_BINLOG);
 
+static Sys_var_mybool Sys_parse_rfc3339_timezones(
+       "parse_rfc3339_timezones",
+       "Parse and apply RFC3339 Timezones when parsing stirngs",
+       SESSION_VAR(parse_rfc3339_timezones), NO_CMD_LINE,
+       DEFAULT(TRUE));
+
+
 #ifdef WITH_WSREP
 #include "wsrep_var.h"
 #include "wsrep_sst.h"

--- a/sql/tzfile.h
+++ b/sql/tzfile.h
@@ -118,16 +118,6 @@ struct tzhead {
 #endif
 #endif
 
-#define SECS_PER_MIN	60
-#define MINS_PER_HOUR	60
-#define HOURS_PER_DAY	24
-#define DAYS_PER_WEEK	7
-#define DAYS_PER_NYEAR	365
-#define DAYS_PER_LYEAR	366
-#define SECS_PER_HOUR	(SECS_PER_MIN * MINS_PER_HOUR)
-#define SECS_PER_DAY	((long) SECS_PER_HOUR * HOURS_PER_DAY)
-#define MONS_PER_YEAR	12
-
 #define TM_YEAR_BASE	1900
 
 #define EPOCH_YEAR	1970

--- a/sql/tztime.h
+++ b/sql/tztime.h
@@ -72,6 +72,29 @@ protected:
   static inline void adjust_leap_second(MYSQL_TIME *t);
 };
 
+/*
+  Instance of this class represents time zone which
+  was specified as offset from UTC.
+*/
+class Time_zone_offset : public Time_zone
+{
+public:
+  Time_zone_offset(long tz_offset_arg);
+  virtual my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t,
+                                    uint *error_code) const;
+  virtual void   gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const;
+  virtual const String * get_name() const;
+  /*
+    This have to be public because we want to be able to access it from
+    my_offset_tzs_get_key() function
+  */
+  long offset;
+private:
+  /* Extra reserve because of snprintf */
+  char name_buff[7+16];
+  String name;
+};
+
 extern Time_zone * my_tz_UTC;
 extern Time_zone * my_tz_SYSTEM;
 extern Time_zone * my_tz_OFFSET0;


### PR DESCRIPTION
This pull request is a continuation of #290 based on the 10.2 branch. Support for parsing RFC3339 format and applying the offset for DATETIME or TIMESTAMP fields. This also adds support for parsing offsets provided on TIME fields.

The offset is parsed via the str_to_offset function, and is returned in the MYSQL_TIME_STATUS. If the datetime is ourside the unix epoch, the timezone offset can not be applied. This is a limitation of using the existing Timezone classes and TIME_to_gmt_sec / gmt_sec_to_TIME for the conversion. If the datetime is outside the epoch range, then the warning of MYSQL_TIME_WARN_TRUNCATED is set.

This parsing will change the behavior of running applications that are currently using RFC3339 time format.  The current mariadb behavior is that the offset is truncated. In order to preserve the existing behavior a session variable was added parse_rfc3339_timezones that can be set to false to preserve the existing behavior of not applying any provided offsets.