### PR TITLE
MDEV-12292 - port "Report timing with more precision" by @dveeden

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -5077,7 +5077,7 @@ static void nice_time(double sec,char *buff,bool part_second)
 
 static void end_timer(ulonglong start_time, char *buff)
 {
-  double sec = (start_timer() - start_time) / (double)(1000 * 1000);
+  double sec= (start_timer() - start_time) / (double) (1000 * 1000);
   nice_time(sec, buff, 1);
 }
 

--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -3209,7 +3209,8 @@ com_go(String *buffer,char *line __attribute__((unused)))
   char		buff[200]; /* about 110 chars used so far */
   char		time_buff[52+3+1]; /* time max + space&parens + NUL */
   MYSQL_RES	*result;
-  ulong		timer, warnings= 0;
+  ulonglong	timer;
+  ulong		warnings= 0;
   uint		error= 0;
   int           err= 0;
 

--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -34,7 +34,6 @@
 #include <m_ctype.h>
 #include <stdarg.h>
 #include <my_dir.h>
-#include <my_rdtsc.h>
 #ifndef __GNU_LIBRARY__
 #define __GNU_LIBRARY__		      // Skip warnings in getopt.h
 #endif
@@ -5035,7 +5034,7 @@ void tee_putc(int c, FILE *file)
 
 static ulonglong start_timer(void)
 {
-  return my_timer_microseconds();
+  return microsecond_interval_timer();
 }
 
 

--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -34,6 +34,7 @@
 #include <m_ctype.h>
 #include <stdarg.h>
 #include <my_dir.h>
+#include <my_rdtsc.h>
 #ifndef __GNU_LIBRARY__
 #define __GNU_LIBRARY__		      // Skip warnings in getopt.h
 #endif
@@ -1074,9 +1075,9 @@ static void print_table_data_xml(MYSQL_RES *result);
 static void print_tab_data(MYSQL_RES *result);
 static void print_table_data_vertically(MYSQL_RES *result);
 static void print_warnings(void);
-static ulong start_timer(void);
-static void end_timer(ulong start_time,char *buff);
-static void mysql_end_timer(ulong start_time,char *buff);
+static ulonglong start_timer(void);
+static void end_timer(ulonglong start_time, char *buff);
+static void mysql_end_timer(ulonglong start_time, char *buff);
 static void nice_time(double sec,char *buff,bool part_second);
 extern "C" sig_handler mysql_end(int sig);
 extern "C" sig_handler handle_sigint(int sig);
@@ -5031,14 +5032,9 @@ void tee_putc(int c, FILE *file)
 #endif
 #endif
 
-static ulong start_timer(void)
+static ulonglong start_timer(void)
 {
-#if defined(__WIN__)
-  return clock();
-#else
-  struct tms tms_tmp;
-  return times(&tms_tmp);
-#endif
+  return my_timer_microseconds();
 }
 
 
@@ -5072,20 +5068,20 @@ static void nice_time(double sec,char *buff,bool part_second)
     buff=strmov(buff," min ");
   }
   if (part_second)
-    sprintf(buff,"%.2f sec",sec);
+    sprintf(buff,"%.3f sec",sec);
   else
     sprintf(buff,"%d sec",(int) sec);
 }
 
 
-static void end_timer(ulong start_time,char *buff)
+static void end_timer(ulonglong start_time, char *buff)
 {
-  nice_time((double) (start_timer() - start_time) /
-	    CLOCKS_PER_SEC,buff,1);
+  double sec = (start_timer() - start_time) / (double)(1000 * 1000);
+  nice_time(sec, buff, 1);
 }
 
 
-static void mysql_end_timer(ulong start_time,char *buff)
+static void mysql_end_timer(ulonglong start_time, char *buff)
 {
   buff[0]=' ';
   buff[1]='(';


### PR DESCRIPTION
based upon: https://github.com/dveeden/mysql-server/commit/d5e46428075d86dbdc333d27951bb06cb4c11a32

MariaDB [test]> select sleep(0.123);
+--------------+
| sleep(0.123) |
+--------------+
|            0 |
+--------------+
1 row in set (0.123 sec)

"More exact timing for mysql client based on my_timer_microseconds"

Based on suggestion from @grooverdan on https://github.com/mysql/mysql-server/pull/112

This patch is slightly bigger because the original did not preserve the
return type of my_timer_microseconds and this patch does.
   (my_timer_microseconds returns ulonglong, not simply ulong)

Also I believe the correct place to do the division of microseconds to
seconds is better in the caller of nice_time because nice_time takes a
"double sec" param, so we should convert before calling; the other caller
of nice_time does not call with microseconds.