### PR TITLE
fix 32bit redefine of char_to_byte_length_safe

### DIFF
--- a/sql/item.h
+++ b/sql/item.h
@@ -96,13 +96,6 @@ enum precedence {
 
 typedef Bounds_checked_array<Item*> Ref_ptr_array;
 
-static inline uint32
-char_to_byte_length_safe(size_t char_length_arg, uint32 mbmaxlen_arg)
-{
-  ulonglong tmp= ((ulonglong) char_length_arg) * mbmaxlen_arg;
-  return tmp > UINT_MAX32 ? UINT_MAX32 : static_cast<uint32>(tmp);
-}
-
 bool mark_unsupported_function(const char *where, void *store, uint result);
 
 /* convenience helper for mark_unsupported_function() above */

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -183,8 +183,8 @@ public:
 static inline uint32
 char_to_byte_length_safe(size_t char_length_arg, uint32 mbmaxlen_arg)
 {
-   ulonglong tmp= ((ulonglong) char_length_arg) * mbmaxlen_arg;
-   return (tmp > UINT_MAX32) ? (uint32) UINT_MAX32 : (uint32) tmp;
+  ulonglong tmp= ((ulonglong) char_length_arg) * mbmaxlen_arg;
+  return tmp > UINT_MAX32 ? UINT_MAX32 : static_cast<uint32>(tmp);
 }
 
 /**

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -181,7 +181,7 @@ public:
 
 
 static inline uint32
-char_to_byte_length_safe(uint32 char_length_arg, uint32 mbmaxlen_arg)
+char_to_byte_length_safe(size_t char_length_arg, uint32 mbmaxlen_arg)
 {
    ulonglong tmp= ((ulonglong) char_length_arg) * mbmaxlen_arg;
    return (tmp > UINT_MAX32) ? (uint32) UINT_MAX32 : (uint32) tmp;


### PR DESCRIPTION
Error can be seen here: https://hastebin.com/azomatocoq.scala

sql/item.h: defined uint32 char_to_byte_length_safe(size_t, uint32)
sql/sql_type.h: defined uint32 char_to_byte_length_safe(uint32, uint32)

As @knielsen observed, C++ overloading allows this on 64bit
 because size_t and uint32 differ.

Since item.h does a #include "sql_type.h", there is no point in
redifining this function in item.h