### PR TITLE
MDEV-12144: Use LOCK_error_log on all stdout/stderr operations

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4144,15 +4144,11 @@ static int init_server_components()
       opt_error_log= 0;                         // Too long file name
     else
     {
-      my_bool res;
 #ifndef EMBEDDED_LIBRARY
-      res= reopen_fstreams(log_error_file, stdout, stderr);
+      reopen_fstreams(log_error_file, stdout, stderr);
 #else
-      res= reopen_fstreams(log_error_file, NULL, stderr);
+      reopen_fstreams(log_error_file, NULL, stderr);
 #endif
-
-      if (!res)
-        setbuf(stderr, NULL);
 
 #ifdef _WIN32
       /* Add error log to windows crash reporting. */


### PR DESCRIPTION
At the same time remove the duplication of code removing
the buffering on stderr.

I don't claim this actually corrects the MDEV-12144 however the LOCK_error_log for log rotations seems like  a resonable thing.