### PR TITLE
fix warning "ignoring return value" of fwrite

### DIFF
--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -331,7 +331,9 @@ void wsrep_dump_rbr_buf(THD *thd, const void* rbr_buf, size_t buf_len)
   FILE *of= fopen(filename, "wb");
   if (of)
   {
-    fwrite (rbr_buf, buf_len, 1, of);
+    if (fwrite(rbr_buf, buf_len, 1, of) == 0)
+      WSREP_ERROR("Failed to write buffer of length %llu to '%s'",
+                  (unsigned long long)buf_len, filename);
     fclose(of);
   }
   else


### PR DESCRIPTION
sql/wsrep_binlog.cc:334:37: warning: ignoring return value of
 'size_t fwrite(const void*, size_t, size_t, FILE*)',
 declared with attribute warn_unused_result [-Wunused-result]
     fwrite (rbr_buf, buf_len, 1, of);

As seen here:
https://hastebin.com/urelisikuy.pas

Submitted under MCA