### PR TITLE
10.2 travis container+clang

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -10,3 +10,6 @@ elif [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'g++' ]]; then
   export MYSQL_BUILD_CXX=g++-${GCC_VERSION};
   export MYSQL_BUILD_CC=gcc-${GCC_VERSION}
 fi
+# main.mysqlhotcopy_myisam consitently failed in travis containers
+# https://travis-ci.org/grooverdan/mariadb-server/builds/217661580
+echo 'main.mysqlhotcopy_myisam : unstable in containers' | tee -a debian/unstable-tests.amd64

--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'clang++' ]]; then
+  case ${GCC_VERSION} in
+    4.8) MYSQL_BUILD_CXX=clang++-3.8;;
+    5) MYSQL_BUILD_CXX=clang++-3.9;;
+    6) MYSQL_BUILD_CXX=clang++-4.0;;
+  esac
+  export MYSQL_BUILD_CXX MYSQL_BUILD_CC=${MYSQL_BUILD_CXX/++/}
+elif [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'g++' ]]; then
+  export MYSQL_BUILD_CXX=g++-${GCC_VERSION};
+  export MYSQL_BUILD_CC=gcc-${GCC_VERSION}
+fi

--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -5,7 +5,7 @@ if [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'clang++' ]]; then
     5) MYSQL_BUILD_CXX=clang++-3.9;;
     6) MYSQL_BUILD_CXX=clang++-4.0;;
   esac
-  export MYSQL_BUILD_CXX MYSQL_BUILD_CC=${MYSQL_BUILD_CXX/++/}
+  export MYSQL_BUILD_CXX MYSQL_BUILD_CC=${MYSQL_BUILD_CXX/++/} MYSQL_COMPILER_LAUNCHER=ccache
 elif [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'g++' ]]; then
   export MYSQL_BUILD_CXX=g++-${GCC_VERSION};
   export MYSQL_BUILD_CC=gcc-${GCC_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 # vim ft=yaml
 # travis-ci.org definition
 
-# non-container builds don't have enough RAM to reliably compile
-sudo: required
+sudo: false
 dist: trusty
 
 language: cpp
+os:
+  - linux
 compiler:
   - gcc
+  - clang
 cache:
   - apt
   - ccache
@@ -17,21 +19,25 @@ env:
     - GCC_VERSION=4.8
     - GCC_VERSION=5
     - GCC_VERSION=6
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-# below requires https://github.com/travis-ci/apt-source-whitelist/pull/309
-#      - llvm-toolchain-trusty-3.8
-#      - llvm-toolchain-trusty-3.9
-# llvm urls awaiting fix
-# https://github.com/travis-ci/apt-source-whitelist/pull/288
-# https://github.com/travis-ci/apt-source-whitelist/pull/309
+      - llvm-toolchain-trusty
+      - llvm-toolchain-trusty-3.9
+      - llvm-toolchain-trusty-4.0
     packages: # make sure these match debian/control contents
       - gcc-5
       - g++-5
       - gcc-6
       - g++-6
+      - clang-3.8
+      - llvm-3.8-dev
+      - clang-3.9
+      - llvm-3.9-dev
+      - clang-4.0
+      - llvm-4.0-dev
       - bison
       - chrpath
       - cmake
@@ -57,18 +63,23 @@ addons:
       - zlib1g-dev
       - libcrack2-dev
       - libjemalloc-dev
+      - libsnappy-dev
+      - liblzma-dev
+      - libzmq-dev
+      - libdistro-info-perl
       - devscripts # implicit for any build on Ubuntu
 
-# libsnappy-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3880
-# liblzma-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3879
-# libzmq-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3881
 # libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 
 script:
-  - export MYSQL_BUILD_CC=/usr/bin/gcc-${GCC_VERSION} MYSQL_BUILD_CXX=/usr/bin/g++-${GCC_VERSION}
+  - source .travis.compiler.sh
   - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
   - cd "${TRAVIS_BUILD_DIR}"
+# https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
+# in trusty containers
+  - export MTR_MEM=/tmp
   - env DEB_BUILD_OPTIONS="parallel=3" debian/autobake-deb.sh;
+  - ccache --show-stats
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,21 @@
 sudo: false
 dist: trusty
 
+git:
+  depth: 2
+
 language: cpp
 os:
   - linux
 compiler:
   - gcc
   - clang
+
 cache:
-  - apt
-  - ccache
+  apt: true
+  ccache: true
+  directories:
+    - /usr/local
 
 env:
   matrix:
@@ -20,8 +26,30 @@ env:
     - GCC_VERSION=5
     - GCC_VERSION=6
 
-#matrix:
-#  include:
+matrix:
+  allowed_failures:
+    - os: osx
+  include:
+    - os: osx
+      before_install:
+        - brew update
+        - brew install homebrew/boneyard/judy gnutls lz4 lzo xz snappy ccache
+        # Below fixed by: https://github.com/MariaDB/server/pull/347
+        - sed -i -e 's:/usr/bin/::g' cmake/libutils.cmake
+      script:
+        - ccache --version
+        - cmake .
+                 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+                 -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/ccache
+                 -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache
+                 -DCMAKE_BUILD_TYPE=Debug
+                 -DWITH_SSL=system -DWITH_ZLIB=system
+                 -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON
+        - make -j 4
+        - cd mysql-test
+        - ./mtr --force --parallel=4 --skip-rpl --suite=main,innodb --skip-test-list=unstable-tests
+        - ccache --show-stats
+
 #    - env:
 #        - GCC_VERSION=6
 #      addon:
@@ -39,12 +67,12 @@ env:
 #        build_command_prepend:
 #          - source .travis.compiler.sh
 #          - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
-#          - cmake . {MYSQL_BUILD_CXX:+-DCMAKE_CXX_COMPILER=$${MYSQL_BUILD_CXX} \
-#                    {MYSQL_BUILD_CC:+-DCMAKE_C_COMPILER=$${MYSQL_BUILD_CC} \
-#                   -DCMAKE_BUILD_TYPE=Debug \
-#                   -DWITH_SSL=system -DWITH_ZLIB=system \
+#          - cmake . {MYSQL_BUILD_CXX:+-DCMAKE_CXX_COMPILER=$${MYSQL_BUILD_CXX}
+#                    {MYSQL_BUILD_CC:+-DCMAKE_C_COMPILER=$${MYSQL_BUILD_CC}
+#                   -DCMAKE_BUILD_TYPE=Debug
+#                   -DWITH_SSL=system -DWITH_ZLIB=system
 #                   -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON
-#       
+#
 #        # The command that will be added as an argument to "cov-build" to compile your project for analysis,
 #        build_command: make -j 4
 #
@@ -52,7 +80,7 @@ env:
 #        # Take care in resource usage, and consider the build frequency allowances per
 #        #   https://scan.coverity.com/faq#frequency - 7 per week is the current limit.
 #        branch_pattern: .*coverity.*
-#        
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,39 @@ env:
     - GCC_VERSION=5
     - GCC_VERSION=6
 
+#matrix:
+#  include:
+#    - env:
+#        - GCC_VERSION=6
+#      addon:
+#      coverity_scan:
+#        # ref: https://scan.coverity.com/travis_ci
+#        # GitHub project metadata
+#        project:
+#          - name: MariaDB/server
+#          - description: MariaDB Server
+#
+#        # Where email notification of build analysis results will be sent
+#        notification_email: security@mariadb.org
+#
+#        # Commands to prepare for build_command
+#        build_command_prepend:
+#          - source .travis.compiler.sh
+#          - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
+#          - cmake . {MYSQL_BUILD_CXX:+-DCMAKE_CXX_COMPILER=$${MYSQL_BUILD_CXX} \
+#                    {MYSQL_BUILD_CC:+-DCMAKE_C_COMPILER=$${MYSQL_BUILD_CC} \
+#                   -DCMAKE_BUILD_TYPE=Debug \
+#                   -DWITH_SSL=system -DWITH_ZLIB=system \
+#                   -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON
+#       
+#        # The command that will be added as an argument to "cov-build" to compile your project for analysis,
+#        build_command: make -j 4
+#
+#        # Pattern to match selecting branches that will run analysis.
+#        # Take care in resource usage, and consider the build frequency allowances per
+#        #   https://scan.coverity.com/faq#frequency - 7 per week is the current limit.
+#        branch_pattern: .*coverity.*
+#        
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,10 @@ addons:
 # libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 
 script:
+# mroonga just generates too many warnings with clang and travis stops the job
+  - if [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'clang++' ]]; then
+      rm -rf "${TRAVIS_BUILD_DIR}"/storage/mroonga;
+    fi   
   - source .travis.compiler.sh
   - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
   - cd "${TRAVIS_BUILD_DIR}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,9 @@ addons:
 
 script:
 # mroonga just generates too many warnings with clang and travis stops the job
+# tokudb has fatal warnings
   - if [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'clang++' ]]; then
-      rm -rf "${TRAVIS_BUILD_DIR}"/storage/mroonga;
+      rm -rf "${TRAVIS_BUILD_DIR}"/storage/{mroonga,tokudb};
     fi   
   - source .travis.compiler.sh
   - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,13 @@ env:
 matrix:
   allowed_failures:
     - os: osx
+      env:
+        - GCC_VERSION=4.8
+        - GCC_VERSION=5
+        - GCC_VERSION=6
+      compiler:
+        - gcc
+        - clang
   include:
     - os: osx
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,10 @@ matrix:
                  -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON
         - make -j 4
         - cd mysql-test
-        - ./mtr --force --parallel=4 --skip-rpl --suite=main,innodb --skip-test-list=unstable-tests
+        - ./mtr --force --parallel=4 --testcase-timeout=2
+               --suite=main,innodb
+               --skip-rpl
+               --skip-test-list=unstable-tests
         - ccache --show-stats
 
 #    - env:


### PR DESCRIPTION
container builds are faster and as most packages are now whitelisted this is possible.

Added clang version to build to be nice to @Sp1l in freebsd maintenance land and because clang just general gives more hints on silly c code that is probably incorrect. Tokudb and mroonga where just too messy to deal with in clang due to excessive warnings/errors.

Disable main.mysqlhotcopy_myisam in container builds consistently failed and I've come across the same thing in a docker based MTR run at work.

Added the skeleton travis coverity config for enabling if anyone agrees with the concept of a "*converity*" branch the same way as bb-* to trigger the build, and where to send the results too. MDEV-6262 has some references.