### PR TITLE
Don't use full path of libtool

### DIFF
--- a/cmake/libutils.cmake
+++ b/cmake/libutils.cmake
@@ -188,7 +188,7 @@ MACRO(MERGE_STATIC_LIBS TARGET OUTPUT_NAME LIBS_TO_MERGE)
       # binaries properly)
       ADD_CUSTOM_COMMAND(TARGET ${TARGET} POST_BUILD
         COMMAND rm ${TARGET_LOCATION}
-        COMMAND /usr/bin/libtool -static -o ${TARGET_LOCATION} 
+        COMMAND libtool -static -o ${TARGET_LOCATION} 
         ${STATIC_LIBS}
       )  
     ELSE()


### PR DESCRIPTION
This is to be friendly to our OSX users where
the libtool path is very different.

Ref:
* https://github.com/Homebrew/homebrew-core/blob/master/Formula/mariadb.rb#L44..L46

I submit this under the MCA.