### PR TITLE
fil_crypt_rotate_page - space_id should be compared to TRX_SYS_SPACE not space

### DIFF
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -1951,7 +1951,7 @@ fil_crypt_rotate_page(
 		return;
 	}
 
-	if (space == TRX_SYS_SPACE && offset == TRX_SYS_PAGE_NO) {
+	if (space_id == TRX_SYS_SPACE && offset == TRX_SYS_PAGE_NO) {
 		/* don't encrypt this as it contains address to dblwr buffer */
 		return;
 	}


### PR DESCRIPTION

Fixes compile error that highlights problem:

/source/storage/innobase/fil/fil0crypt.cc: In function 'void fil_crypt_rotate_page(const key_state_t*, rotate_thread_t*)':
/source/storage/innobase/fil/fil0crypt.cc:1770:15: error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
  if (space == TRX_SYS_SPACE && offset == TRX_SYS_PAGE_NO) {

I submit this under the MCA.

@dr-m, @janlindstrom  should be an obvious one.