### PR TITLE
xtradb: fil_crypt_rotate_page, space_id should be compared to TRX_SYS_SPACE

### DIFF
--- a/storage/xtradb/fil/fil0crypt.cc
+++ b/storage/xtradb/fil/fil0crypt.cc
@@ -1951,7 +1951,7 @@ fil_crypt_rotate_page(
 		return;
 	}
 
-	if (space == TRX_SYS_SPACE && offset == TRX_SYS_PAGE_NO) {
+	if (space_id == TRX_SYS_SPACE && offset == TRX_SYS_PAGE_NO) {
 		/* don't encrypt this as it contains address to dblwr buffer */
 		return;
 	}


### PR DESCRIPTION
like 9a218f4fb871c1169dd6015a3be9d965929dbd1f

sorry for missing it first time @janlindstrom 