### PR TITLE
buffer size inadequite according to gcc-7

### DIFF
--- a/storage/myisam/myisamchk.c
+++ b/storage/myisam/myisamchk.c
@@ -1397,7 +1397,7 @@ static void descript(HA_CHECK *param, register MI_INFO *info, char * name)
 	 key < share->state.header.uniques; key++, uniqueinfo++)
     {
       my_bool new_row=0;
-      char null_bit[8],null_pos[8];
+      char null_bit[8],null_pos[10];
       printf("%-8d%-5d",key+1,uniqueinfo->key+1);
       for (keyseg=uniqueinfo->seg ; keyseg->type != HA_KEYTYPE_END ; keyseg++)
       {


### PR DESCRIPTION
storage/myisam/myisamchk.c:1410:21: warning: '%ld' directive writing between 1 and 10 bytes into a region of size 8 [-Wformat-overflow=]

sprintf(null_pos,"%ld",(long) keyseg->null_pos+1);