### PR TITLE
MDEV-12453: AWS SDK version failed to build on OSX

### DIFF
--- a/plugin/aws_key_management/CMakeLists.txt
+++ b/plugin/aws_key_management/CMakeLists.txt
@@ -112,7 +112,7 @@ ELSE()
   ExternalProject_Add(
     aws_sdk_cpp
     GIT_REPOSITORY "https://github.com/awslabs/aws-sdk-cpp.git"
-    GIT_TAG "1.0.8"
+    GIT_TAG "1.0.100"
     UPDATE_COMMAND ""
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp"
     ${byproducts}


### PR DESCRIPTION
Update AWS SDK version from 1.0.8 to 1.0.100

Commit b64910ce27a4df33e3ad2e3f40764e8b3271a9aa (MDEV-12453)
enabled AWS_SDK to build correctly on buildbot.

Travis still had build faults like below despite many common elements
between the builds;

/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/cstring:79:9: error: no member named 'strcoll' in the global namespace; did you mean 'strtoll'?
[ 24%] Building CXX object storage/rocksdb/CMakeFiles/rocksdblib.dir/rocksdb/db/internal_stats.cc.o
using ::strcoll;
      ~~^
/usr/include/stdlib.h:169:3: note: 'strtoll' declared here
         strtoll(const char *__str, char **__endptr, int __base);
         ^

Failing build: https://travis-ci.org/grooverdan/mariadb-server/jobs/219607054#L1307
Fixed build: https://travis-ci.org/grooverdan/mariadb-server/jobs/219686992#L4217