### PR TITLE
MDEV-12469: static_assert cannot be determined on bigendian

### DIFF
--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -1303,7 +1303,7 @@ static int rdb_unpack_floating_point(
   // On little-endian, swap the bytes around
   swap_func(dst, tmp);
 #else
-  static_assert(swap_func == nullptr, "Assuming that no swapping is needed.");
+  DBUG_ASSERT(swap_func == nullptr);
 #endif
 
   return UNPACK_SUCCESS;


### PR DESCRIPTION
Show up on big endian machines:

http://buildbot.askmonty.org/buildbot/builders/kvm-rpm-centos73-ppc64/builds/140/steps/compile/logs/stdio

debug assert is sufficient.