### PR TITLE
MDEV-12469: correct rocksdb compile warning

### DIFF
--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3036,7 +3036,7 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
 
     // Now, read the DDLs.
     const int real_val_size = val.size() - Rdb_key_def::VERSION_SIZE;
-    if (real_val_size % Rdb_key_def::PACKED_SIZE * 2) {
+    if (real_val_size % Rdb_key_def::PACKED_SIZE * 2 > 0) {
       sql_print_error("RocksDB: Table_store: invalid keylist for table %s",
                       tdef->full_tablename().c_str());
       return true;


### PR DESCRIPTION
mariadb-10.2.5/storage/rocksdb/rdb_datadic.cc:3039:50: warning: '*' in boolean context, suggest '&&' instead [-Wint-in-bool-context]

     if (real_val_size % Rdb_key_def::PACKED_SIZE * 2) {