### PR TITLE
Travis: Test more suites, latest OSX, etc...

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -1,15 +1,46 @@
 #!/bin/sh
-if [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'clang++' ]]; then
-  case ${GCC_VERSION} in
-    4.8) MYSQL_BUILD_CXX=clang++-3.8;;
-    5) MYSQL_BUILD_CXX=clang++-3.9;;
-    6) MYSQL_BUILD_CXX=clang++-4.0;;
-  esac
-  export MYSQL_BUILD_CXX MYSQL_BUILD_CC=${MYSQL_BUILD_CXX/++/} MYSQL_COMPILER_LAUNCHER=ccache
-elif [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'g++' ]]; then
-  export MYSQL_BUILD_CXX=g++-${GCC_VERSION};
-  export MYSQL_BUILD_CC=gcc-${GCC_VERSION}
+set -v -x
+if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
+  if [[ "${CXX}" == 'clang++' ]]; then
+    CMAKE_OPT="-DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON"
+    #CMAKE_OPT="${CMAKE_OPT} -DWITH_ASAN=ON"
+    if which ccache ; then
+      CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+    fi
+    case ${GCC_VERSION} in
+      5) CXX=clang++-3.9 ;;
+      6) CXX=clang++-4.0 ;;
+    esac
+    export CXX CC=${CXX/++/}
+  elif [[ "${CXX}" == 'g++' ]]; then
+    CMAKE_OPT=""
+    export CXX=g++-${GCC_VERSION}
+    export CC=gcc-${GCC_VERSION}
+  fi
+  if [[ ${GCC_VERSION} == 6 ]]; then
+         wget http://mirrors.kernel.org/ubuntu/pool/universe/p/percona-xtradb-cluster-galera-2.x/percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb ;
+         ar vx percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb
+         tar -xJvf data.tar.xz
+         export WSREP_PROVIDER=$PWD/usr/lib/libgalera_smm.so
+         MYSQL_TEST_SUITES="${MYSQL_TEST_SUITES},wsrep"
+  #elif [[ ${GCC_VERSION} != 5 ]]; then
+    #CMAKE_OPT="${CMAKE_OPT} -DWITH_ASAN=ON"
+  fi
+else
+  # osx_image based tests
+  CMAKE_OPT="-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
+  #CMAKE_OPT="${CMAKE_OPT} -DWITH_ASAN=ON"
+  if which ccache ; then
+    CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+  fi
+  CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_MROONGA_STORAGE_ENGINE=ON"
+  if [[ "${TYPE}" == "Debug" ]]; then
+    CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON"
+  fi
 fi
+
 # main.mysqlhotcopy_myisam consitently failed in travis containers
 # https://travis-ci.org/grooverdan/mariadb-server/builds/217661580
-echo 'main.mysqlhotcopy_myisam : unstable in containers' | tee -a debian/unstable-tests.amd64
+echo 'main.mysqlhotcopy_myisam : unstable in containers' >> ${TRAVIS_BUILD_DIR}/mysql-test/unstable-tests
+echo 'archive.mysqlhotcopy_archive : unstable in containers' >> ${TRAVIS_BUILD_DIR}/mysql-test/unstable-tests
+set +v +x

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ git:
 language: cpp
 os:
   - linux
+  - osx
+osx_image: xcode8.3
 compiler:
   - gcc
   - clang
@@ -18,48 +20,37 @@ cache:
   apt: true
   ccache: true
   directories:
-    - /usr/local
+    - /usr/local/Cellar
 
 env:
   matrix:
-    - GCC_VERSION=4.8
-    - GCC_VERSION=5
-    - GCC_VERSION=6
+#    - GCC_VERSION=4.8 TYPE=Debug          MYSQL_TEST_SUITES=rpl
+#    - GCC_VERSION=5   TYPE=Debug          MYSQL_TEST_SUITES=main,archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+#    - GCC_VERSION=6   TYPE=Debug          MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption,rocksdb
+#    - GCC_VERSION=6   TYPE=Debug          MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
+    - GCC_VERSION=4.8 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
+    - GCC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main,archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+    - GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption,rocksdb
+    - GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
 
 matrix:
-  allowed_failures:
+  exclude:
     - os: osx
-      env:
-        - GCC_VERSION=4.8
-        - GCC_VERSION=5
-        - GCC_VERSION=6
-      compiler:
-        - gcc
-        - clang
+      compiler: gcc
   include:
-    - os: osx
-      before_install:
-        - brew update
-        - brew install homebrew/boneyard/judy gnutls lz4 lzo xz snappy ccache
-        # Below fixed by: https://github.com/MariaDB/server/pull/347
-        - sed -i -e 's:/usr/bin/::g' cmake/libutils.cmake
+    - os: linux
+      compiler: gcc
       script:
-        - ccache --version
-        - cmake .
-                 -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
-                 -DCMAKE_C_COMPILER_LAUNCHER=/usr/local/bin/ccache
-                 -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/local/bin/ccache
-                 -DCMAKE_BUILD_TYPE=Debug
-                 -DWITH_SSL=system -DWITH_ZLIB=system
-                 -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON
-        - make -j 4
-        - cd mysql-test
-        - ./mtr --force --parallel=4 --testcase-timeout=2
-               --suite=main,innodb
-               --skip-rpl
-               --skip-test-list=unstable-tests
+        - ${CC} --version ; ${CXX} --version
+      # Just for disabling hotcopy tests for now
+        - source .travis.compiler.sh
+      # https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
+      # in trusty containers
+        - export MTR_MEM=/tmp
+        - env DEB_BUILD_OPTIONS="parallel=6" debian/autobake-deb.sh;
         - ccache --show-stats
 
+# Matrix include for coverity
 #    - env:
 #        - GCC_VERSION=6
 #      addon:
@@ -77,8 +68,7 @@ matrix:
 #        build_command_prepend:
 #          - source .travis.compiler.sh
 #          - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
-#          - cmake . {MYSQL_BUILD_CXX:+-DCMAKE_CXX_COMPILER=$${MYSQL_BUILD_CXX}
-#                    {MYSQL_BUILD_CC:+-DCMAKE_C_COMPILER=$${MYSQL_BUILD_CC}
+#          - cmake . 
 #                   -DCMAKE_BUILD_TYPE=Debug
 #                   -DWITH_SSL=system -DWITH_ZLIB=system
 #                   -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON
@@ -103,12 +93,11 @@ addons:
       - g++-5
       - gcc-6
       - g++-6
-      - clang-3.8
-      - llvm-3.8-dev
       - clang-3.9
       - llvm-3.9-dev
       - clang-4.0
       - llvm-4.0-dev
+      - libasan0
       - bison
       - chrpath
       - cmake
@@ -118,6 +107,7 @@ addons:
       - gdb
       - libaio-dev
       - libboost-dev
+      - libcurl3-dev
       - libjudy-dev
       - libncurses5-dev
       - libpam0g-dev
@@ -142,19 +132,31 @@ addons:
 
 # libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 
+before_install:
+  - if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then
+      brew update;
+      brew install gnutls lz4 lzo xz snappy ccache jemalloc curl ossp-uuid pcre;
+      brew link ccache;
+    fi
+
 script:
-# mroonga just generates too many warnings with clang and travis stops the job
-# tokudb has fatal warnings
-  - if [[ "${TRAVIS_OS_NAME}" == 'linux' && "${CXX}" == 'clang++' ]]; then
-      rm -rf "${TRAVIS_BUILD_DIR}"/storage/{mroonga,tokudb};
-    fi   
+  - ccache --version
+# Clang:
+#   mroonga just generates too many warnings with clang and travis stops the job
+#   tokudb has fatal warnings
   - source .travis.compiler.sh
-  - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
-  - cd "${TRAVIS_BUILD_DIR}"
-# https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
-# in trusty containers
-  - export MTR_MEM=/tmp
-  - env DEB_BUILD_OPTIONS="parallel=3" debian/autobake-deb.sh;
+  - cmake .
+           -DCMAKE_BUILD_TYPE=${TYPE}
+           ${CMAKE_OPT}
+           -DWITH_SSL=system -DWITH_ZLIB=system -DPLUGIN_AWS_KEY_MANAGEMENT=DYNAMIC -DAWS_SDK_EXTERNAL_PROJECT=ON
+  - make -j 6
+  - cd mysql-test
+# With ASAN --thread-stack=400K to account for overhead
+# Test timeout needs to be 10(minutes) or less due to travis out timeout
+  - ./mtr --force --max-test-fail=20 --parallel=6 --testcase-timeout=2
+         --suite=${MYSQL_TEST_SUITES}
+         --skip-test-list=unstable-tests
+         --skip-test=binlog.binlog_unsafe
   - ccache --show-stats
 
 notifications:


### PR DESCRIPTION
Remove clang-3.8 which doesn't have a repository on apt.llvm.org any
more.

For OSX, xcode8.3 is explicitly specified.

/usr/local/Cellar is used as a cache repository to save brew install
time on OSX (and /usr/local was too big).

Debian autobake.sh is moved to a matrix include.

Other branches of the matrix build test other test suites.
An Ubuntu galera is downloaded and used in the test suite.

TYPE=RelWithDebInfo used with the test to provide backtraces with line
numbers when crashes occur.

Build of PLUGIN_AWS_KEY_MANAGEMENT enabled in build.

Code supporting TYPE=Debug and -DWITH_ASAN=ON included by not enabled
due to large numbers of errors.

Running more tests in parallel (6) as container based builds seem to
support them. The test case timeout has been set to 2 minutes as large
stalls will put test cases over 50 minute interval.

ccache enabled where possible. Linux clang builds don't use them as the
minimum CMake version isn't there.

I submit this under the MCA.