### PR TITLE
MDEV-12488: Remove type mismatch in InnoDB printf-like calls

### DIFF
--- a/storage/xtradb/sync/sync0arr.cc
+++ b/storage/xtradb/sync/sync0arr.cc
@@ -527,7 +527,7 @@ sync_array_cell_print(
 				"waiters flag " ULINTPF "\n",
 				(void*) mutex, mutex->cmutex_name,
 				(ulong) mutex->lock_word,
-				mutex->thread_id,
+				os_thread_pf(mutex->thread_id),
 				mutex->file_name, mutex->line,
 				mutex->waiters);
 		}


### PR DESCRIPTION
@dr-m - missed one. It wasn't in 10.0.

To fix OSX error:
https://travis-ci.org/grooverdan/mariadb-server/jobs/225036945#L4667

/Users/travis/build/grooverdan/mariadb-server/storage/xtradb/sync/sync0arr.cc:530:5: warning: format specifies type 'unsigned long' but the argument has type 'os_thread_id_t' (aka '_opaque_pthread_t *') [-Wformat]
                                mutex->thread_id,

                                ^~~~~~~~~~~~~~~~
I submit this under the MCA.