### PR TITLE
MDEV-12469: rocksdb having large numberic storage errors on ppc64 (BE)

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -22,6 +22,13 @@ IF(CMAKE_SYSTEM_PROCESSOR MATCHES "i[36]86")
   SKIP_ROCKSDB_PLUGIN("Intel 32 bit not supported.")
 ENDIF()
 
+# Due to retrieved data being incorrect endian
+include(TestBigEndian)
+test_big_endian(BIG_ENDIAN)
+if(BIG_ENDIAN)
+  SKIP_ROCKSDB_PLUGIN("Big Endian not supported.")
+endif()
+
 #
 # Also, disable building on 32-bit Windows
 #


### PR DESCRIPTION
Just disabling rocksdb on Big Endian for now. Sound reasonable @spetrunia ?

(from: http://buildbot.askmonty.org/buildbot/builders/p8-rhel6-bintar/builds/820/steps/test/logs/stdio)

Errors like the following indicate a potential endian storage issue:

rocksdb.rocksdb_range                    w1 [ fail ]
        Test ended at 2017-04-27 18:56:11

CURRENT_TEST: rocksdb.rocksdb_range
--- /home/buildbot/maria-slave/p8-rhel6-bintar/build/storage/rocksdb/mysql-test/rocksdb/r/rocksdb_range.result	2017-04-27 17:41:27.740050347 -0400
+++ /home/buildbot/maria-slave/p8-rhel6-bintar/build/storage/rocksdb/mysql-test/rocksdb/r/rocksdb_range.reject	2017-04-27 18:56:11.230050346 -0400
@@ -25,15 +25,15 @@
 select * from t2 force index (a) where a=0;
 pk	a	b
 0	0	0
-1	0	1
-2	0	2
-3	0	3
-4	0	4
-5	0	5
-6	0	6
-7	0	7
-8	0	8
-9	0	9
+16777216	0	1
+33554432	0	2
+50331648	0	3
+67108864	0	4
+83886080	0	5
+100663296	0	6
+117440512	0	7
+134217728	0	8
+150994944	0	9
 # The rest are for code coverage:
 explain
 select * from t2 force index (a) where a=2;
@@ -41,23 +41,23 @@
 1	SIMPLE	t2	ref	a	a	4	const	#
 select * from t2 force index (a) where a=2;
 pk	a	b
-20	2	20
-21	2	21
-22	2	22
-23	2	23
-24	2	24
-25	2	25
-26	2	26
-27	2	27
-28	2	28
-29	2	29
+335544320	2	20
+352321536	2	21
+369098752	2	22
+385875968	2	23
+402653184	2	24
+419430400	2	25
+436207616	2	26
+452984832	2	27
+469762048	2	28
+486539264	2	29
 explain
 select * from t2 force index (a) where a=3 and pk=33;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t2	const	a	a	8	const,const	#
 select * from t2 force index (a) where a=3 and pk=33;
 pk	a	b
-33	3	33
+553648128	3	33
 select * from t2 force index (a) where a=99 and pk=99;
 pk	a	b
 select * from t2 force index (a) where a=0 and pk=0;
...

