### PR TITLE
Remove compile warning - "this" canot be null

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2011,7 +2011,7 @@ bool THD::notify_shared_lock(MDL_context_owner *ctx_in_use,
         if (!thd_table->needs_reopen())
         {
           signalled|= mysql_lock_abort_for_thread(this, thd_table);
-          if (this && WSREP(this) && wsrep_thd_is_BF(this, FALSE))
+          if (WSREP(this) && wsrep_thd_is_BF(this, FALSE))
           {
             WSREP_DEBUG("remove_table_from_cache: %llu",
                         (unsigned long long) this->real_id);


### PR DESCRIPTION
/home/travis/build/MariaDB/server/sql/sql_class.cc:1941:15: warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]
          if (this && WSREP(this) && wsrep_thd_is_BF(this, FALSE))
              ^~~~ ~~

I submit this under the MCA.