### PR TITLE
mysql_config: Use configured prefix value

### DIFF
--- a/scripts/mysql_config.sh
+++ b/scripts/mysql_config.sh
@@ -76,8 +76,7 @@ get_full_path ()
 
 me=`get_full_path $0`
 
-# Script might have been renamed but assume mysql_<something>config<something>
-basedir=`echo $me | sed -e 's;/bin/mysql_.*config.*;;'`
+basedir='@prefix'
 
 ldata='@localstatedir@'
 execdir='@libexecdir@'


### PR DESCRIPTION
instead of guessing basedir in mysql_config; Resolves: rhb#916189

Ported from: https://github.com/devexp-db/mariadb/blob/f27/mariadb-basedir.patch