### PR TITLE
MDEV-12646: wsrep.cnf - wsrep_on=1 by default

### DIFF
--- a/support-files/wsrep.cnf.sh
+++ b/support-files/wsrep.cnf.sh
@@ -30,6 +30,9 @@ bind-address=0.0.0.0
 ## WSREP options
 ##
 
+# Enable wsrep
+wsrep_on=1
+
 # Full path to wsrep provider library or 'none'
 wsrep_provider=none
 


### PR DESCRIPTION
From: https://github.com/devexp-db/mariadb/blob/f27/mariadb-galera.cnf.patch

Without a provider this has no effect however this reduces means enabling is only setting the provider.