### PR TITLE
MDEV-12646 - scripts/mysql_install_db: Fix paths in mysql_install_db script

### DIFF
--- a/scripts/mysql_install_db.pl.in
+++ b/scripts/mysql_install_db.pl.in
@@ -320,7 +320,7 @@ elsif ( $opt->{basedir} )
                     find_in_basedir($opt,"file","mysqld-nt",
                                   "bin");  # ,"sql"
   $srcpkgdatadir  = find_in_basedir($opt,"dir","fill_help_tables.sql",
-                                    "share","share/mysql");  # ,"scripts"
+                                    "share","@INSTALL_MYSQLSHAREDIR@");  # ,"scripts"
   $buildpkgdir    = $srcpkgdatadir;
   $scriptdir      = "$opt->{basedir}/scripts";
 }

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -311,17 +311,17 @@ then
     cannot_find_file mysqld $basedir/libexec $basedir/sbin $basedir/bin
     exit 1
   fi
-  langdir=`find_in_basedir --dir errmsg.sys share/english share/mysql/english`
+  langdir=`find_in_basedir --dir errmsg.sys share/english @INSTALL_MYSQLSHAREDIR@/english`
   if test -z "$langdir"
   then
-    cannot_find_file errmsg.sys $basedir/share/english $basedir/share/mysql/english
+    cannot_find_file errmsg.sys $basedir/share/english $basedir/@INSTALL_MYSQLSHAREDIR@/english
     exit 1
   fi
-  srcpkgdatadir=`find_in_basedir --dir fill_help_tables.sql share share/mysql`
+  srcpkgdatadir=`find_in_basedir --dir fill_help_tables.sql share @INSTALL_MYSQLSHAREDIR@`
   buildpkgdatadir=$srcpkgdatadir
   if test -z "$srcpkgdatadir"
   then
-    cannot_find_file fill_help_tables.sql $basedir/share $basedir/share/mysql
+    cannot_find_file fill_help_tables.sql $basedir/share $basedir/@INSTALL_MYSQLSHAREDIR@
     exit 1
   fi
   scriptdir="$basedir/scripts"


### PR DESCRIPTION
Resolves: rhb#1134328

From: https://github.com/devexp-db/mariadb/blob/f27/mariadb-install-db-sharedir.patch