### PR TITLE
MDEV-12436: binlog.binlog_unsafe - assumed len(hostname) <= 50

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_unsafe.result
+++ b/mysql-test/suite/binlog/r/binlog_unsafe.result
@@ -1,14 +1,14 @@
 #### Setup tables ####
-CREATE TABLE t0 (a CHAR(100));
-CREATE TABLE t1 (a CHAR(100));
-CREATE TABLE t2 (a CHAR(100));
-CREATE TABLE t3 (a CHAR(100));
-CREATE TABLE ta0 (a CHAR(100));
-CREATE TABLE ta1 (a CHAR(100));
-CREATE TABLE ta2 (a CHAR(100));
-CREATE TABLE ta3 (a CHAR(100));
+CREATE TABLE t0 (a CHAR(200));
+CREATE TABLE t1 (a CHAR(200));
+CREATE TABLE t2 (a CHAR(200));
+CREATE TABLE t3 (a CHAR(200));
+CREATE TABLE ta0 (a CHAR(200));
+CREATE TABLE ta1 (a CHAR(200));
+CREATE TABLE ta2 (a CHAR(200));
+CREATE TABLE ta3 (a CHAR(200));
 CREATE TABLE autoinc_table (a INT PRIMARY KEY AUTO_INCREMENT);
-CREATE TABLE data_table (a CHAR(100));
+CREATE TABLE data_table (a CHAR(200));
 INSERT INTO data_table VALUES ('foo');
 CREATE TABLE trigger_table_1 (a INT);
 CREATE TABLE trigger_table_2 (a INT);
@@ -2392,7 +2392,7 @@ Note	1592	Unsafe statement written to the binary log using statement format sinc
 DROP PROCEDURE p1;
 DROP TABLE t1;
 DROP TABLE IF EXISTS t1;
-CREATE TABLE t1 (a VARCHAR(100), b VARCHAR(100));
+CREATE TABLE t1 (a VARCHAR(200), b VARCHAR(200));
 INSERT INTO t1 VALUES ('a','b');
 UPDATE t1 SET b = '%s%s%s%s%s%s%s%s%s%s%s%s%s%s' WHERE a = 'a' LIMIT 1;
 Warnings:
@@ -2423,7 +2423,7 @@ CREATE FUNCTION fun_check_log_bin() RETURNS INT
 BEGIN
 SET @@SQL_LOG_BIN = 0;
 INSERT INTO t1 VALUES(@@global.sync_binlog);
-RETURN 100;
+RETURN 200;
 END|
 "One unsafe warning should be issued in the following statement"
 SELECT fun_check_log_bin();

--- a/mysql-test/suite/binlog/t/binlog_unsafe.test
+++ b/mysql-test/suite/binlog/t/binlog_unsafe.test
@@ -110,16 +110,16 @@ call mtr.add_suppression("Unsafe statement written to the binary log using state
 
 --echo #### Setup tables ####
 
-CREATE TABLE t0 (a CHAR(100));
-CREATE TABLE t1 (a CHAR(100));
-CREATE TABLE t2 (a CHAR(100));
-CREATE TABLE t3 (a CHAR(100));
-CREATE TABLE ta0 (a CHAR(100));
-CREATE TABLE ta1 (a CHAR(100));
-CREATE TABLE ta2 (a CHAR(100));
-CREATE TABLE ta3 (a CHAR(100));
+CREATE TABLE t0 (a CHAR(200));
+CREATE TABLE t1 (a CHAR(200));
+CREATE TABLE t2 (a CHAR(200));
+CREATE TABLE t3 (a CHAR(200));
+CREATE TABLE ta0 (a CHAR(200));
+CREATE TABLE ta1 (a CHAR(200));
+CREATE TABLE ta2 (a CHAR(200));
+CREATE TABLE ta3 (a CHAR(200));
 CREATE TABLE autoinc_table (a INT PRIMARY KEY AUTO_INCREMENT);
-CREATE TABLE data_table (a CHAR(100));
+CREATE TABLE data_table (a CHAR(200));
 INSERT INTO data_table VALUES ('foo');
 CREATE TABLE trigger_table_1 (a INT);
 CREATE TABLE trigger_table_2 (a INT);
@@ -433,7 +433,7 @@ DROP TABLE t1;
 DROP TABLE IF EXISTS t1;
 --enable_warnings
 
-CREATE TABLE t1 (a VARCHAR(100), b VARCHAR(100));
+CREATE TABLE t1 (a VARCHAR(200), b VARCHAR(200));
 INSERT INTO t1 VALUES ('a','b');
 UPDATE t1 SET b = '%s%s%s%s%s%s%s%s%s%s%s%s%s%s' WHERE a = 'a' LIMIT 1;
 DROP TABLE t1;
@@ -471,7 +471,7 @@ CREATE FUNCTION fun_check_log_bin() RETURNS INT
 BEGIN
   SET @@SQL_LOG_BIN = 0;
   INSERT INTO t1 VALUES(@@global.sync_binlog);
-  RETURN 100;
+  RETURN 200;
 END|
 DELIMITER ;|
 --echo "One unsafe warning should be issued in the following statement"


### PR DESCRIPTION
Increased size in tests to allow for 100 character hostname.

<pre>
[11:32 dan ~/repos/build-mariadb-server-10.0]$ hostname
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
[11:33 dan ~/repos/build-mariadb-server-10.0]$ hostname | wc -c
64
[11:31 dan ~/repos/build-mariadb-server-10.0]$ (cd mysql-test/; ./mtr  binlog.binlog_unsafe)
Logging: /home/dan/repos/mariadb-server/mysql-test/mysql-test-run.pl  binlog.binlog_unsafe
vardir: /home/dan/repos/build-mariadb-server-10.0/mysql-test/var
Checking leftover processes...
Removing old var directory...
Creating var directory '/home/dan/repos/build-mariadb-server-10.0/mysql-test/var'...
Checking supported features...
MariaDB Version 10.0.31-MariaDB-debug
 - SSL connections supported
 - binaries are debug compiled
Sphinx 'indexer' binary not found, sphinx suite will be skipped
Collecting tests...
Installing system database...

==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 16000..16019
binlog.binlog_unsafe 'stmt'              [ pass ]   5515
--------------------------------------------------------------------------
The servers were restarted 0 times
Spent 5.515 of 12 seconds executing testcases

Completed: All 1 tests were successful.

</pre>

I submit this under the MCA.