### PR TITLE
mtr: fix_vs_config doesn't change bindir

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1290,10 +1290,6 @@ sub command_line_setup {
   
   fix_vs_config_dir();
 
-  # Respect MTR_BINDIR variable, which is typically set in to the 
-  # build directory in out-of-source builds.
-  $bindir=$ENV{MTR_BINDIR}||$basedir;
-  
   # Look for the client binaries directory
   if ($path_client_bindir)
   {


### PR DESCRIPTION
The same code and comment as removed is just before the fix_vs_config_dir function call. This function doesn't change the bindir however it does use it. As such remove the duplicated code.

I submit this under the MCA.