### PR TITLE
MDEV-12646: systemd service file changes from Fedora

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -1,23 +1,28 @@
+# It's not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades.  If you want to customize, the
+# best way is to create a file "/etc/systemd/system/mariadb.service",
+# containing
+#	.include /usr/lib/systemd/system/mariadb.service
+#	...make your changes here...
+# or create a file "/etc/systemd/system/mariadb.service.d/foo.conf",
+# which doesn't need to include ".include" call and which will be parsed
+# after the file mariadb.service itself is parsed.
 #
-# /etc/systemd/system/mariadb.service
+# For more info about custom unit files, see systemd.unit(5) or
+# https://mariadb.com/kb/en/mariadb/systemd/
+#
+# Copyright notice:
 #
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation; either version 2.1 of the License, or
 # (at your option) any later version.
-#
-# Thanks to:
-# Daniel Black
-# Erkan Yanar
-# David Strauss
-# and probably others
 
 [Unit]
 Description=MariaDB @VERSION@ database server
 Documentation=man:mysqld(8)
 Documentation=https://mariadb.com/kb/en/library/systemd/
 After=network.target
-After=syslog.target
 
 [Install]
 WantedBy=multi-user.target
@@ -81,11 +86,14 @@ ExecStartPre=/bin/sh -c "[ ! -e @bindir@/galera_recovery ] && VAR= || \
 # Use the [Service] section and Environment="MYSQLD_OPTS=...".
 # This isn't a replacement for my.cnf.
 # _WSREP_NEW_CLUSTER is for the exclusive use of the script galera_new_cluster
-ExecStart=@sbindir@/mysqld $MYSQLD_OPTS $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION
-@SYSTEMD_EXECSTARTPOST@
+# Note: we set --basedir to prevent probes that might trigger SELinux alarms,
+# per bug https://bugzilla.redhat.com/show_bug.cgi?id=547485
+ExecStart=@sbindir@/mysqld $MYSQLD_OPTS --basedir=@prefix@ $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION
 
 # Unset _WSREP_START_POSITION environment variable.
 ExecStartPost=/bin/sh -c "systemctl unset-environment _WSREP_START_POSITION"
+
+@SYSTEMD_EXECSTARTPOST@
 
 KillSignal=SIGTERM
 

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -1,29 +1,35 @@
 # Multi instance version of mariadb. For if you run multiple versions at once.
-# Also used for mariadb@bootstrap to bootstrap Galera.
 #
-# create config file @sysconf2dir@/my{instancename}.cnf
+# create config file @sysconf2dir@/my{instancename}.cnf to be used as the
+# configuration file for this service.
 #
 # start as systemctl start mariadb@{instancename}.server
-
+#
+# It's not recommended to modify this file in-place, because it will be
+# overwritten during package upgrades.  If you want to customize, the
+# best way is to create a file "/etc/systemd/system/mariadb@.service",
+# containing
+#	.include /usr/lib/systemd/system/mariadb@.service
+#	...make your changes here...
+# or create a file "/etc/systemd/system/mariadb@.service.d/foo.conf",
+# which doesn't need to include ".include" call and which will be parsed
+# after the file mariadb@.service itself is parsed.
+#
+# For more info about custom unit files, see systemd.unit(5) or
+# https://mariadb.com/kb/en/mariadb/systemd/
+#
+# Copyright notice:
+#
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation; either version 2.1 of the License, or
 # (at your option) any later version.
-#
-# Thanks to:
-# Daniel Black
-# Erkan Yanar
-# David Strauss
-# and probably others
-# Inspired from https://gitweb.gentoo.org/repo/gentoo.git/tree/dev-db/mysql-init-scripts/files/mysqld_at.service
 
 [Unit]
 Description=MariaDB @VERSION@ database server (multi-instance)
 Documentation=man:mysqld(8)
 Documentation=https://mariadb.com/kb/en/library/systemd/
 After=network.target
-After=syslog.target
-
 ConditionPathExists=@sysconf2dir@/my%I.cnf
 
 [Install]
@@ -68,6 +74,8 @@ ProtectHome=true
 # Execute pre and post scripts as root, otherwise it does it as User=
 PermissionsStartOnly=true
 
+@SYSTEMD_EXECSTARTPRE@
+
 # Perform automatic wsrep recovery. When server is started without wsrep,
 # galera_recovery simply returns an empty string. In any case, however,
 # the script is not expected to return with a non-zero status.
@@ -95,9 +103,12 @@ ExecStartPre=/bin/sh -c "[ ! -e @bindir@/galera_recovery ] && VAR= || \
 # This isn't a replacement for my.cnf.
 # _WSREP_NEW_CLUSTER is for the exclusive use of the script galera_new_cluster
 
+# Note: we set --basedir to prevent probes that might trigger SELinux alarms,
+# per bug https://bugzilla.redhat.com/show_bug.cgi?id=547485
+#
 # Note: Place $MYSQLD_OPTS at the very end for its options to take precedence.
 
-ExecStart=@sbindir@/mysqld --defaults-file=@sysconf2dir@/my%I.cnf \
+ExecStart=@sbindir@/mysqld --defaults-file=@sysconf2dir@/my%I.cnf --basedir=@prefix@ \
   $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION%I $MYSQLD_OPTS
 # Alternate: (remove ConditionPathExists above)
 # use [mysqld.INSTANCENAME] as sections in my.cnf
@@ -107,6 +118,8 @@ ExecStart=@sbindir@/mysqld --defaults-file=@sysconf2dir@/my%I.cnf \
 
 # Unset _WSREP_START_POSITION environment variable.
 ExecStartPost=/bin/sh -c "systemctl unset-environment _WSREP_START_POSITION%I"
+
+@SYSTEMD_EXECSTARTPOST@
 
 KillSignal=SIGTERM
 

--- a/support-files/use_galera_new_cluster.conf
+++ b/support-files/use_galera_new_cluster.conf
@@ -15,8 +15,11 @@ ConditionPathExists=
 Type=oneshot
 Restart=no
 
+ExecStartPre=
+
 # Override the multi instance service for a bootstrap start instance
 ExecStart=
 ExecStart=/usr/bin/echo "Please use galera_new_cluster to start the mariadb service with --wsrep-new-cluster"
 ExecStart=/usr/bin/false
 
+ExecStartPost=


### PR DESCRIPTION
Include comment header that describes overrides.

Unit description now includes @VERSION@.

After=syslog.target removed - redunant

Add --basedir=@prefix to prevent /root/.my.cnf lookups

Additional changes to multi instance (support-files/mariadb@.service.in):
* added @SYSTEMD_EXECSTARTPRE@ / @SYSTEMD_EXECSTARTPOST@
* removed mariadb@bootstrap reference as galera_new_cluster as
  its a little too proment.
* use_galera_new_cluster.conf updated to override pre/post steps

I submit this under the MCA.