### PR TITLE
fix two use-after-scope bugs found by ASAN

### DIFF
--- a/sql/sql_explain.cc
+++ b/sql/sql_explain.cc
@@ -351,9 +351,9 @@ int print_explain_row(select_result_sink *result,
                       mem_root);
   
   /* 'possible_keys' */
+  StringBuffer<64> possible_keys_buf;
   if (possible_keys && !possible_keys->is_empty())
   {
-    StringBuffer<64> possible_keys_buf;
     push_string_list(thd, &item_list, *possible_keys, &possible_keys_buf);
   }
   else

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -529,6 +529,7 @@ int mysql_update(THD *thd,
   if (!(select && select->quick))
     status_var_increment(thd->status_var.update_scan_count);
 
+  IO_CACHE tempfile;
   if (query_plan.using_filesort || query_plan.using_io_buffer)
   {
     /*
@@ -576,7 +577,6 @@ int mysql_update(THD *thd,
 	update these in a separate loop based on the pointer.
       */
       explain->buf_tracker.on_scan_init();
-      IO_CACHE tempfile;
       if (open_cached_file(&tempfile, mysql_tmpdir,TEMP_PREFIX,
 			   DISK_BUFFER_SIZE, MYF(MY_WME)))
 	goto err;


### PR DESCRIPTION
I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

```
ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f6464b17df0 at pc 0x00000324feed bp 0x7f6464b16e00 sp 0x7f6464b16df8
READ of size 8 at 0x7f6464b17df0 thread T27
    #0 0x324feec in my_b_tell /home/kevg/work/tmp/server/include/my_sys.h:587:31
    #1 0x324eeb9 in reinit_io_cache /home/kevg/work/tmp/server/mysys/mf_iocache.c:485:22
    #2 0x14f5047 in init_read_record(READ_RECORD*, THD*, TABLE*, SQL_SELECT*, SORT_INFO*, int, bool, bool) /home/kevg/work/tmp/server/sql/records.cc:234:5
    #3 0x1c476bb in mysql_update(THD*, TABLE_LIST*, List<Item>&, List<Item>&, Item*, unsigned int, st_order*, unsigned long long, enum_duplicates, bool, unsigned long long*, unsigned long long*) /home/kevg/work/tmp/server/sql/sql_update.cc:697:7
    #4 0x189044c in mysql_execute_command(THD*) /home/kevg/work/tmp/server/sql/sql_parse.cc:4247:21
    #5 0x187df5f in mysql_parse(THD*, char*, unsigned int, Parser_state*, bool, bool) /home/kevg/work/tmp/server/sql/sql_parse.cc:7874:18
    #6 0x1870304 in dispatch_command(enum_server_command, THD*, char*, unsigned int, bool, bool) /home/kevg/work/tmp/server/sql/sql_parse.cc:1811:7
    #7 0x18790bc in do_command(THD*) /home/kevg/work/tmp/server/sql/sql_parse.cc:1361:17
    #8 0x1dda025 in do_handle_one_connection(CONNECT*) /home/kevg/work/tmp/server/sql/sql_connect.cc:1354:11
    #9 0x1dd9731 in handle_one_connection /home/kevg/work/tmp/server/sql/sql_connect.cc:1260:3
    #10 0x311b534 in pfs_spawn_thread /home/kevg/work/tmp/server/storage/perfschema/pfs.cc:1862:3
    #11 0x7f64c7d0f6d9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76d9)
    #12 0x7f64c68ea17e in clone /build/glibc-cxyGtm/glibc-2.24/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:105

Address 0x7f6464b17df0 is located in stack of thread T27 at offset 976 in frame
    #0 0x1c413bf in mysql_update(THD*, TABLE_LIST*, List<Item>&, List<Item>&, Item*, unsigned int, st_order*, unsigned long long, enum_duplicates, bool, unsigned long long*, unsigned long long*) /home/kevg/work/tmp/server/sql/sql_update.cc:255

  This frame has 21 object(s):
    [32, 40) 'table_list.addr'
    [64, 72) 'conds.addr'
    [96, 100) 'error:261'
    [112, 116) 'dup_key_found:262'
    [128, 129) 'need_sort:263'
    [144, 145) 'reverse:264'
    [160, 164) 'table_count:268'
    [176, 184) 'old_covering_keys:270'
    [208, 392) 'info:274'
    [464, 488) 'all_fields:277'
    [528, 608) 'query_plan:279'
    [640, 672) '_db_stack_frame_:283'
    [704, 720) 'agg.tmp'
    [736, 752) 'agg.tmp65'
    [768, 784) 'agg.tmp73'
    [800, 804) 'cond_value:384'
    [816, 824) 'scanned_limit:468'
    [848, 856) 'ref.tmp:503'
    [880, 928) 'fsort:547'
    [960, 1344) 'tempfile:579' <== Memory access at offset 976 is inside this variable
    [1408, 1920) 'buff:1009'
```

```
ERROR: AddressSanitizer: stack-use-after-scope on address 0x7f7b4c277b00 at pc 0x00000352482d bp 0x7f7b4c2766b0 sp 0x7f7b4c2766a8
READ of size 4 at 0x7f7b4c277b00 thread T27
    #0 0x352482c in my_convert /home/kevg/work/tmp/server/strings/ctype.c:1109:10
    #1 0x10c016a in copy_and_convert(char*, unsigned int, charset_info_st const*, char const*, unsigned int, charset_info_st const*, unsigned int*) /home/kevg/work/tmp/server/sql/sql_string.h:43:10
    #2 0x14e009b in Protocol::net_store_data_cs(unsigned char const*, unsigned long, charset_info_st const*, charset_info_st const*) /home/kevg/work/tmp/server/sql/protocol.cc:118:8
    #3 0x14ea16e in Protocol::store_string_aux(char const*, unsigned long, charset_info_st const*, charset_info_st const*) /home/kevg/work/tmp/server/sql/protocol.cc:1089:12
    #4 0x14eab92 in Protocol_text::store(char const*, unsigned long, charset_info_st const*) /home/kevg/work/tmp/server/sql/protocol.cc:1129:10
    #5 0x1121960 in Item::send(Protocol*, String*) /home/kevg/work/tmp/server/sql/item.cc:6886:25
    #6 0x14e9401 in Protocol::send_result_set_row(List<Item>*) /home/kevg/work/tmp/server/sql/protocol.cc:979:15
    #7 0x170c4fb in select_send::send_data(List<Item>&) /home/kevg/work/tmp/server/sql/sql_class.cc:2762:17
    #8 0x1ec3ecd in print_explain_row(select_result_sink*, unsigned char, bool, unsigned int, char const*, char const*, char const*, join_type, String_list*, char const*, char const*, char const*, unsigned long long*, double*, double, char const*) /home/kevg/work/tmp/server/sql/sql_explain.cc:410:15
    #9 0x1ec053a in Explain_update::print_explain(Explain_query*, select_result_sink*, unsigned char, bool) /home/kevg/work/tmp/server/sql/sql_explain.cc:2101:3
    #10 0x1eb0ef0 in Explain_query::print_explain(select_result_sink*, unsigned char, bool) /home/kevg/work/tmp/server/sql/sql_explain.cc:189:19
    #11 0x1eb0181 in Explain_query::send_explain(THD*) /home/kevg/work/tmp/server/sql/sql_explain.cc:169:10
    #12 0x1c4ae09 in mysql_update(THD*, TABLE_LIST*, List<Item>&, List<Item>&, Item*, unsigned int, st_order*, unsigned long long, enum_duplicates, bool, unsigned long long*, unsigned long long*) /home/kevg/work/tmp/server/sql/sql_update.cc:1049:32
    #13 0x189044c in mysql_execute_command(THD*) /home/kevg/work/tmp/server/sql/sql_parse.cc:4247:21
    #14 0x187df5f in mysql_parse(THD*, char*, unsigned int, Parser_state*, bool, bool) /home/kevg/work/tmp/server/sql/sql_parse.cc:7874:18
    #15 0x1870304 in dispatch_command(enum_server_command, THD*, char*, unsigned int, bool, bool) /home/kevg/work/tmp/server/sql/sql_parse.cc:1811:7
    #16 0x18790bc in do_command(THD*) /home/kevg/work/tmp/server/sql/sql_parse.cc:1361:17
    #17 0x1dd9f45 in do_handle_one_connection(CONNECT*) /home/kevg/work/tmp/server/sql/sql_connect.cc:1354:11
    #18 0x1dd9651 in handle_one_connection /home/kevg/work/tmp/server/sql/sql_connect.cc:1260:3
    #19 0x311b454 in pfs_spawn_thread /home/kevg/work/tmp/server/storage/perfschema/pfs.cc:1862:3
    #20 0x7f7b7e1626d9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76d9)
    #21 0x7f7b7cd3d17e in clone /build/glibc-cxyGtm/glibc-2.24/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:105

Address 0x7f7b4c277b00 is located in stack of thread T27 at offset 128 in frame
    #0 0x1ec289f in print_explain_row(select_result_sink*, unsigned char, bool, unsigned int, char const*, char const*, char const*, join_type, String_list*, char const*, char const*, char const*, unsigned long long*, double*, double, char const*) /home/kevg/work/tmp/server/sql/sql_explain.cc:325

  This frame has 2 object(s):
    [32, 56) 'item_list:329'
    [96, 192) 'possible_keys_buf:356' <== Memory access at offset 128 is inside this variable

```