### PR TITLE
Add functionality to set keepalive tcp options

### DIFF
--- a/include/violite.h
+++ b/include/violite.h
@@ -51,11 +51,26 @@ enum enum_vio_io_event
   VIO_IO_EVENT_CONNECT
 };
 
+struct vio_keepalive_opts
+{
+  int interval;
+  int idle;
+  int probes;
+};
+
+
 #define VIO_LOCALHOST 1U                        /* a localhost connection */
 #define VIO_BUFFERED_READ 2U                    /* use buffered read */
 #define VIO_READ_BUFFER_SIZE 16384U             /* size of read buffer */
 #define VIO_DESCRIPTION_SIZE 30                 /* size of description */
 
+#define VIO_DEFAULT_KEEPALIVE_TIME          7200
+#define VIO_DEFAULT_KEEPALIVE_PROBES        9
+#ifdef WIN32
+#define VIO_DEFAULT_KEEPALIVE_INTVL         1
+#else
+#define VIO_DEFAULT_KEEPALIVE_INTVL         75
+#endif
 Vio* vio_new(my_socket sd, enum enum_vio_type type, uint flags);
 Vio*  mysql_socket_vio_new(MYSQL_SOCKET mysql_socket, enum enum_vio_type type, uint flags);
 #ifdef __WIN__
@@ -84,6 +99,8 @@ my_bool	vio_is_blocking(Vio *vio);
 int	vio_fastsend(Vio *vio);
 /* setsockopt SO_KEEPALIVE at SOL_SOCKET level, when possible */
 int	vio_keepalive(Vio *vio, my_bool	onoff);
+void	vio_set_keepalive_options(Vio * vio, const struct vio_keepalive_opts *opts);
+struct vio_keepalive_opts	vio_get_keepalive_options(Vio * vio);
 /* Whenever we should retry the last read/write operation. */
 my_bool	vio_should_retry(Vio *vio);
 /* Check that operation was timed out */
@@ -211,7 +228,6 @@ enum SSL_type
   SSL_TYPE_X509,
   SSL_TYPE_SPECIFIED
 };
-
 
 /* HFTODO - hide this if we don't want client in embedded server */
 /* This structure is for every connection on both sides */

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -701,6 +701,7 @@ typedef struct system_variables
   my_bool session_track_state_change;
 
   ulong threadpool_priority;
+  ulong keepalive_time, keepalive_intvl, keepalive_probes;
 } SV;
 
 /**

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -853,6 +853,7 @@ static int check_connection(THD *thd)
   uint connect_errors= 0;
   int auth_rc;
   NET *net= &thd->net;
+  vio_keepalive_opts opts;
 
   DBUG_PRINT("info",
              ("New connection received on %s", vio_description(net->vio)));
@@ -1000,7 +1001,12 @@ static int check_connection(THD *thd)
     bzero((char*) &net->vio->remote, sizeof(net->vio->remote));
   }
   vio_keepalive(net->vio, TRUE);
-  
+
+  opts.interval = global_system_variables.keepalive_intvl;
+  opts.idle = global_system_variables.keepalive_time;
+  opts.probes = global_system_variables.keepalive_probes;
+  vio_set_keepalive_options(net->vio, &opts);
+
   if (thd->packet.alloc(thd->variables.net_buffer_length))
   {
     /*

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5073,6 +5073,33 @@ static Sys_var_ulong Sys_host_cache_size(
        NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
        ON_UPDATE(fix_host_cache_size));
 
+static Sys_var_ulong Sys_keepalive_time_seconds(
+       "keepalive_time",
+       "The interval between the last data packet sent and the first keepalive probe.",
+       AUTO_SET GLOBAL_VAR(Sys_keepalive_time_seconds),
+       CMD_LINE(REQUIRED_ARG), VALID_RANGE(0, 65536),
+       DEFAULT(VIO_DEFAULT_KEEPALIVE_TIME),
+       BLOCK_SIZE(1),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL));
+
+static Sys_var_ulong Sys_keepalive_intvl_seconds(
+       "keepalive_intvl",
+       "The interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime.",
+       AUTO_SET GLOBAL_VAR(Sys_keepalive_intvl_seconds),
+       CMD_LINE(REQUIRED_ARG), VALID_RANGE(0, 65536),
+       DEFAULT(VIO_DEFAULT_KEEPALIVE_INTVL),
+       BLOCK_SIZE(1),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL));
+
+static Sys_var_ulong Sys_keepalive_probes(
+       "keepalive_probes",
+       "The number of unacknowledged probes to send before considering the connection dead and notifying the application layer.",
+       AUTO_SET GLOBAL_VAR(Sys_keepalive_probes),
+       CMD_LINE(REQUIRED_ARG), VALID_RANGE(0, 65536),
+       DEFAULT(VIO_DEFAULT_KEEPALIVE_PROBES),
+       BLOCK_SIZE(1),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL));
+
 static Sys_var_charptr Sys_ignore_db_dirs(
        "ignore_db_dirs",
        "Specifies a directory to add to the ignore list when collecting "


### PR DESCRIPTION
I tried to implement support of flexible configuration for `keepalive`.
If we take linux or macos, by default  values are too high and can not provide reliable work for production application (it is somewhere around 2,5 hours before keepalive actually starts working)
But lowering values for complete OS is not always an option, so it should be configurable on the application side. And in fact many applications can do it. For instance `postgres`. 
So I suggest we add configuration variables:
* `keepalive_time`
* `keepalive_intvl`
* `keepalive_probes`
and use their values as socket options.

For meaning of params please check manual http://www.tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/