### PR TITLE
travis: add uuid-dev as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,6 +128,7 @@ addons:
       - liblzma-dev
       - libzmq-dev
       - libdistro-info-perl
+      - uuid-dev
       - devscripts # implicit for any build on Ubuntu
 
 # libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882


### PR DESCRIPTION
OSX already has ossp-uuid