### PR TITLE
MDEV-13004 - resolve an issue found by cppcheck

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -5628,16 +5628,16 @@ rm_if_not_found(
 	/* Truncate ".ibd" */
 	name[strlen(name) - 4] = '\0';
 
+        if (!table) {
+                snprintf(name, FN_REFLEN, "%s/%s/%s", data_home_dir,
+                                                      db_name, file_name);
+                return os_file_delete(0, name);
+        }
+
 	HASH_SEARCH(name_hash, inc_dir_tables_hash, ut_fold_string(name),
 		    xb_filter_entry_t*,
 		    table, (void) 0,
 		    !strcmp(table->name, name));
-
-	if (!table) {
-		snprintf(name, FN_REFLEN, "%s/%s/%s", data_home_dir,
-						      db_name, file_name);
-		return os_file_delete(0, name);
-	}
 
 	return(TRUE);
 }


### PR DESCRIPTION
[extra/mariabackup/xtrabackup.cc:5634] -> [extra/mariabackup/xtrabackup.cc:5636]: (warning) Either the condition '!table' is redundant or there is possible null pointer dereference: table.