### PR TITLE
MDEV-13032: fix galera_new_cluster to be POSIX

### DIFF
--- a/scripts/galera_new_cluster.sh
+++ b/scripts/galera_new_cluster.sh
@@ -5,7 +5,7 @@
 # the Free Software Foundation; either version 2.1 of the License, or
 # (at your option) any later version.
 
-if [ "${1}" == "-h" -o "${1}" == "--help" ]; then
+if [ "${1}" = "-h" ] || [ "${1}" = "--help" ]; then
     cat <<EOF
 
 Usage: ${0}


### PR DESCRIPTION
Apologies. Introduced in a9a38fcd7aa4599d78fe9407d5f38c31394cd17c

<pre>

$ ls -la /bin/sh
lrwxrwxrwx 1 root root 4 Feb 18  2016 /bin/sh -> dash
$ ./galera_new_cluster.sh -h

Usage: ./galera_new_cluster.sh

    The script galera_new_cluster is used to bootstrap new Galera Cluster,
    when all the nodes are down. Run galera_new_cluster on the first node only.
    On the remaining nodes simply run 'service @DAEMON_NAME@ start'.

    For more information on Galera Cluster configuration and usage see:
    https://mariadb.com/kb/en/mariadb/getting-started-with-mariadb-galera-cluster/

$ ./galera_new_cluster.sh --help

Usage: ./galera_new_cluster.sh

    The script galera_new_cluster is used to bootstrap new Galera Cluster,
    when all the nodes are down. Run galera_new_cluster on the first node only.
    On the remaining nodes simply run 'service @DAEMON_NAME@ start'.

    For more information on Galera Cluster configuration and usage see:
    https://mariadb.com/kb/en/mariadb/getting-started-with-mariadb-galera-cluster/

</pre>