### PR TITLE
travis: enable (main,archive).mysqlhotcopy_\1 test

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -39,8 +39,4 @@ else
   fi
 fi
 
-# main.mysqlhotcopy_myisam consitently failed in travis containers
-# https://travis-ci.org/grooverdan/mariadb-server/builds/217661580
-echo 'main.mysqlhotcopy_myisam : unstable in containers' >> ${TRAVIS_BUILD_DIR}/mysql-test/unstable-tests
-echo 'archive.mysqlhotcopy_archive : unstable in containers' >> ${TRAVIS_BUILD_DIR}/mysql-test/unstable-tests
 set +v +x

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ matrix:
       compiler: gcc
       script:
         - ${CC} --version ; ${CXX} --version
-      # Just for disabling hotcopy tests for now
         - source .travis.compiler.sh
       # https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
       # in trusty containers
@@ -108,6 +107,7 @@ addons:
       - libaio-dev
       - libboost-dev
       - libcurl3-dev
+      - libdbd-mysql
       - libjudy-dev
       - libncurses5-dev
       - libpam0g-dev


### PR DESCRIPTION
mysqlhotcopy tests has been disabled as per MDEV-10995 however the earlier reason for failure was a missing dependency libdbd-mysql rather than any container issues.

Re-enable these tests in travis.