### PR TITLE
travis fakeroot + remove allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ addons:
       - libdistro-info-perl
       - uuid-dev
       - devscripts # implicit for any build on Ubuntu
+      - fakeroot
 
 # libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,13 +62,6 @@ matrix:
     - os: osx
       compiler: clang
       env: GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
-    # MDEV-13002 plugins.server_audit and plugins.thread_pool_server_audit test fail due to mysqltest error
-    - os: linux
-      compiler: gcc
-      env: GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
-    - os: linux
-      compiler: clang
-      env: GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
 
 # Matrix include for coverity
 #    - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
   include:
     - os: linux
       compiler: gcc
+      # disable cache - was out of disk space
+      cache: false
       script:
         - ${CC} --version ; ${CXX} --version
         - source .travis.compiler.sh


### PR DESCRIPTION
Fakeroot was missing from the dependences so the debian build didn't build. I think travis took it out of their base image.

The MDEV-13002 fix c7141fa75df91ae4c2a1214283111eeb1c2eda11 hasn't quite merged into 10.2 however its not far off. So take out the allowed failures that resulted in plugins for this test.

Even with fakeroot added the debian build ran out of space (https://travis-ci.org/grooverdan/mariadb-server/jobs/248211177). As such I removed the cache for this build.

I submit this under the MCA.