### PR TITLE
travis: force deb build not to use ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ matrix:
       # https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
       # in trusty containers
         - export MTR_MEM=/tmp
-        - env DEB_BUILD_OPTIONS="parallel=6" debian/autobake-deb.sh;
+        - env DEB_BUILD_OPTIONS="parallel=6" MYSQL_BUILD_PATH=/usr/local/bin:/usr/bin:/bin debian/autobake-deb.sh;
         - ccache --show-stats
   # Until OSX becomes a bit more stable: MDEV-12435
   allow_failures:


### PR DESCRIPTION
18a2b0a1681af73181bd98d23ae0973fc1249df5 wasn't sufficient.
The path needed to be set so ccache wasn't picked up.

Success as per https://travis-ci.org/grooverdan/mariadb-server/jobs/248239117

@svoj, Hope you, your neighbour and their dog come to a non-destructive tranquillity soon.