### PR TITLE
Remove obsolete synonyms for access bits

### DIFF
--- a/include/my_dir.h
+++ b/include/my_dir.h
@@ -35,9 +35,9 @@ extern "C" {
 #define MY_S_ISUID	S_ISUID /* set user id on execution */
 #define MY_S_ISGID	S_ISGID /* set group id on execution */
 #define MY_S_ISVTX	S_ISVTX /* save swapped text even after use */
-#define MY_S_IREAD	S_IREAD /* read permission, owner */
-#define MY_S_IWRITE	S_IWRITE	/* write permission, owner */
-#define MY_S_IEXEC	S_IEXEC /* execute/search permission, owner */
+#define MY_S_IREAD	S_IRUSR /* read permission, owner */
+#define MY_S_IWRITE	S_IWUSR /* write permission, owner */
+#define MY_S_IEXEC	S_IXUSR /* execute/search permission, owner */
 
 #define MY_S_ISDIR(m)	(((m) & MY_S_IFMT) == MY_S_IFDIR)
 #define MY_S_ISCHR(m)	(((m) & MY_S_IFMT) == MY_S_IFCHR)


### PR DESCRIPTION
Replace S_IREAD, S_IWRITE and S_IEXEC with more modern equivalents.

Fixes building for Android.

See https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html and http://pubs.opengroup.org/onlinepubs/7908799/xsh/sysstat.h.html.