### PR TITLE
wt_thd_will_wait_for: release locks

### DIFF
--- a/mysys/waiting_threads.c
+++ b/mysys/waiting_threads.c
@@ -1002,6 +1002,7 @@ retry:
     if (thd->killed)
     {
       stop_waiting_locked(thd);
+      rc_unlock(rc);
       DBUG_RETURN(WT_DEADLOCK);
     }
   }
@@ -1017,12 +1018,14 @@ retry:
     if (push_dynamic(&blocker->my_resources, (void*)&rc))
     {
       stop_waiting_locked(thd);
+      rc_unlock(rc);
       DBUG_RETURN(WT_DEADLOCK); /* deadlock and OOM use the same error code */
     }
     if (push_dynamic(&rc->owners, (void*)&blocker))
     {
       pop_dynamic(&blocker->my_resources);
       stop_waiting_locked(thd);
+      rc_unlock(rc);
       DBUG_RETURN(WT_DEADLOCK);
     }
   }


### PR DESCRIPTION
The last branch in this function returns DEADLOCK with
rc unlocked so ensure other branches also unlock it.

Identified by coverity id 972076

I submit this under the MCA.