### PR TITLE
create_new_thread: release LOCK_thread_count

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5496,6 +5496,8 @@ static void create_new_thread(THD *thd)
 
   MYSQL_CALLBACK(thd->scheduler, add_connection, (thd));
 
+  mysql_mutex_unlock(&LOCK_thread_count);
+
   DBUG_VOID_RETURN;
 }
 #endif /* EMBEDDED_LIBRARY */


### PR DESCRIPTION
Like create_embedded_thd we release the LOCK_thread_count
after it is scheduled.

Found by Coverity id 972079

I submit this under the MCA