### PR TITLE
ma_loghandler: release file_header_lock on error

### DIFF
--- a/storage/maria/ma_loghandler.c
+++ b/storage/maria/ma_loghandler.c
@@ -1269,6 +1269,7 @@ static my_bool translog_set_lsn_for_files(uint32 from_file, uint32 to_file,
           mysql_file_close(fd, MYF(MY_WME))))
     {
       translog_stop_writing();
+      mysql_mutex_unlock(&log_descriptor.file_header_lock);
       DBUG_RETURN(1);
     }
   }


### PR DESCRIPTION
translog_stop_writing doesn't release a lock (though
does to a DBUG_ASSERT).

Better to just release the lock.

Found by Coverity id 972092

I submit under the MCA.