### PR TITLE
ma_loghandler: translog_set_only_in_buffers failed to release lock

### DIFF
--- a/storage/maria/ma_loghandler.c
+++ b/storage/maria/ma_loghandler.c
@@ -2291,10 +2291,11 @@ static void translog_set_only_in_buffers(TRANSLOG_ADDRESS in_buffers)
   if (cmp_translog_addr(in_buffers, log_descriptor.in_buffers_only) > 0)
   {
     if (translog_status != TRANSLOG_OK)
-      DBUG_VOID_RETURN;
+      goto end;
     log_descriptor.in_buffers_only= in_buffers;
     DBUG_PRINT("info", ("set new in_buffers_only"));
   }
+end:
   mysql_mutex_unlock(&log_descriptor.sent_to_disk_lock);
   DBUG_VOID_RETURN;
 }


### PR DESCRIPTION
Release the lock for the error path.

Found by Coverity (id 972093).

I submit this under the MCA.