### PR TITLE
ma_pagecache: release lock in pagecache_read

### DIFF
--- a/storage/maria/ma_pagecache.c
+++ b/storage/maria/ma_pagecache.c
@@ -3474,6 +3474,7 @@ restart:
                             lock_to_read[lock].unlock_lock,
                             unlock_pin, FALSE))
       {
+        pagecache_pthread_mutex_unlock(&pagecache->cache_lock);
         DBUG_ASSERT(0);
         return (uchar*) 0;
       }


### PR DESCRIPTION
make_lock_and_pin didn't release the lock so we should.

Found by Coverity (id 972095).

I submit this under the MCA.