### PR TITLE
ha_archive::info remove hidden assignment

### DIFF
--- a/storage/archive/ha_archive.cc
+++ b/storage/archive/ha_archive.cc
@@ -1640,7 +1640,6 @@ int ha_archive::info(uint flag)
       stats.update_time= (ulong) file_stat.st_mtime;
     if (flag & HA_STATUS_CONST)
     {
-      stats.max_data_file_length= share->rows_recorded * stats.mean_rec_length;
       stats.max_data_file_length= MAX_FILE_SIZE;
       stats.create_time= (ulong) file_stat.st_ctime;
     }


### PR DESCRIPTION
max_data_file_size is overwritten in next statement
so this assignment didn't ever get used.

Found by Coverity (ID 1409644)
I submit this under the MCA.