### PR TITLE
item_timefunc: identical operands

### DIFF
--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -3041,7 +3041,7 @@ get_date_time_result_type(const char *format, uint length)
   const char *val= format;
   const char *end= format + length;
 
-  for (; val != end && val != end; val++)
+  for (; val != end; val++)
   {
     if (*val == '%' && val+1 != end)
     {


### PR DESCRIPTION
CID 971836 (#1 of 1): Same on both sides (CONSTANT_EXPRESSION_RESULT)
pointless_expression: The expression val != end && val != end does not
accomplish anything because it evaluates to either of its identical
operands, val != end.

All code in this region was from the original commit in 2002.

I submit this under the MCA.