### PR TITLE
ma_recovery: unintentional order of operations

### DIFF
--- a/storage/maria/ma_recovery.c
+++ b/storage/maria/ma_recovery.c
@@ -888,7 +888,7 @@ prototype_redo_exec_hook(REDO_CREATE_TABLE)
     goto end;
   fn_format(filename, name, "", MARIA_NAME_IEXT,
             (MY_UNPACK_FILENAME |
-             (flags & HA_DONT_TOUCH_DATA) ? MY_RETURN_REAL_PATH : 0) |
+             ((flags & HA_DONT_TOUCH_DATA) ? MY_RETURN_REAL_PATH : 0)) |
             MY_APPEND_EXT);
   linkname_ptr= NULL;
   create_flag= MY_DELETE_OLD;


### PR DESCRIPTION
Coverity report this as:
CID 971840 (#1 of 1): Operands don't affect result (CONSTANT_EXPRESSION_RESULT)
result_independent_of_operands: 4 | (flags & 1) is always true regardless of the values of its operands. This occurs as the logical first operand of "?:".

The C order of precidence has | over ?:. The indenting implies an |
of the 3 terms.

Adjust to indented meaning.

I submit this under MCA.