### PR TITLE
sql_class: incorrect assignment in Security_context::destroy

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -3670,7 +3670,7 @@ void Security_context::destroy()
   if (external_user)
   {
     my_free(external_user);
-    user= NULL;
+    external_user= NULL;
   }
 
   my_free(ip);


### PR DESCRIPTION
Found by Coverity (id 971843).

I submit this under the MCA.