### PR TITLE
travis: Debian build - minimise packages, enable ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,15 +40,50 @@ matrix:
   include:
     - os: linux
       compiler: gcc
-      # disable cache - was out of disk space
-      cache: false
+      addons:
+        apt:
+          packages: # make sure these match debian/control contents
+            - bison
+            - chrpath
+            - cmake
+            - debhelper
+            - dh-apparmor
+            - dpatch
+            - gdb
+            - libaio-dev
+            - libboost-dev
+            - libcurl3-dev
+            - libdbd-mysql
+            - libjudy-dev
+            - libncurses5-dev
+            - libpam0g-dev
+            - libpcre3-dev
+            - libreadline-gplv2-dev
+            - libstemmer-dev
+            - libssl-dev
+            - libnuma-dev
+            - libxml2-dev
+            - lsb-release
+            - perl
+            - po-debconf
+            - psmisc
+            - zlib1g-dev
+            - libcrack2-dev
+            - libjemalloc-dev
+            - libsnappy-dev
+            - liblzma-dev
+            - libzmq-dev
+            - libdistro-info-perl
+            - uuid-dev
+            - devscripts
+            - fakeroot
       script:
         - ${CC} --version ; ${CXX} --version
         - source .travis.compiler.sh
       # https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
       # in trusty containers
         - export MTR_MEM=/tmp
-        - env DEB_BUILD_OPTIONS="parallel=6" MYSQL_BUILD_PATH=/usr/local/bin:/usr/bin:/bin debian/autobake-deb.sh;
+        - env DEB_BUILD_OPTIONS="parallel=6" debian/autobake-deb.sh;
         - ccache --show-stats
   # Until OSX becomes a bit more stable: MDEV-12435
   allow_failures:
@@ -103,7 +138,7 @@ addons:
       - llvm-toolchain-trusty
       - llvm-toolchain-trusty-3.9
       - llvm-toolchain-trusty-4.0
-    packages: # make sure these match debian/control contents
+    packages: # make sure these match the build requirements
       - gcc-5
       - g++-5
       - gcc-6
@@ -116,9 +151,6 @@ addons:
       - bison
       - chrpath
       - cmake
-      - debhelper
-      - dh-apparmor
-      - dpatch
       - gdb
       - libaio-dev
       - libboost-dev
@@ -135,7 +167,6 @@ addons:
       - libxml2-dev
       - lsb-release
       - perl
-      - po-debconf
       - psmisc
       - zlib1g-dev
       - libcrack2-dev
@@ -143,10 +174,7 @@ addons:
       - libsnappy-dev
       - liblzma-dev
       - libzmq-dev
-      - libdistro-info-perl
       - uuid-dev
-      - devscripts # implicit for any build on Ubuntu
-      - fakeroot
 
 # libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 


### PR DESCRIPTION
Even disabling the ccache on the Debian build didn't always prevent
the Travis build running out of space.

As an alternative strategy, the number of alternative compilers has been
reduced to save space. This additional space has been partially reused
by the ccache.

Debian build specific packages have been removed from other builds.

I submit this under the MCA.