### PR TITLE
client: mysql - fix type

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -2852,7 +2852,7 @@ You can turn off this feature to get a quicker startup with -A\n\n");
         mysql_free_result(fields);
         break;
       }
-      field_names[i][num_fields*2]= '\0';
+      field_names[i][num_fields*2]= NULL;
       j=0;
       while ((sql_field=mysql_fetch_field(fields)))
       {


### PR DESCRIPTION
field_names[x][y] is a pointer

client/mysql.cc: In function 'void build_completion_hash(bool, bool)':
client/mysql.cc:2855:37: error: invalid conversion from 'char' to 'char*' [-fpermissive]
       field_names[i][num_fields*2]= '\0';