### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,8 @@ scripts/wsrep_sst_xtrabackup
 scripts/wsrep_sst_xtrabackup-v2
 scripts/maria_add_gis_sp.sql
 scripts/maria_add_gis_sp_bootstrap.sql
+scripts/galera_new_cluster
+scripts/galera_recovery
 sql-bench/bench-count-distinct
 sql-bench/bench-init.pl
 sql-bench/compare-results
@@ -222,6 +224,7 @@ support-files/config.medium.ini
 support-files/config.small.ini
 support-files/mariadb.pc
 support-files/mariadb@.service
+support-files/mariadb.service
 support-files/my-huge.cnf
 support-files/my-innodb-heavy-4G.cnf
 support-files/my-large.cnf
@@ -235,6 +238,7 @@ support-files/mysqld_multi.server
 support-files/wsrep.cnf
 support-files/wsrep_notify
 support-files/policy/selinux/mysqld-safe.pp
+support-files/mariadb.pp
 tags
 tests/async_queries
 tests/bug25714


### PR DESCRIPTION
during build on 10.2 following files are generated:

  * scripts/galera_new_cluster
  * scripts/galera_recovery
  * support-files/mariadb.service
  * support-files/mariadb.pp

and they are untracked for git. Let's add them to .gitignore

--
I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.