### PR TITLE
MDEV-12386: Use AppVeyor for public Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 10.2-{build}
 before_build:
 - md %APPVEYOR_BUILD_FOLDER%\win_build
 - cd %APPVEYOR_BUILD_FOLDER%\win_build
-- cmake ..  -G "Visual Studio 15 2017" -DBOOST_ROOT=C:\Libraries\boost_1_64_0 -DPKG_CONFIG_EXECUTABLE=C:\perl\bin\pkg-config -DBISON_EXECUTABLE=C:\cygwin\bin\bison
+- cmake ..  -G "Visual Studio 15 2017" -DBISON_EXECUTABLE=C:\cygwin\bin\bison
 - dir
 build:
   project: win_build\MySQL.sln
@@ -13,5 +13,5 @@ configuration:
 test:
 test_script:
 - cd %APPVEYOR_BUILD_FOLDER%\win_build\mysql-test
-- perl mysql-test-run.pl --force --max-test-fail=20 --parallel=6 --testcase-timeout=2 --skip-test-list=unstable-tests --suite=main,innodb,plugins,mariabackup
+- perl mysql-test-run.pl --force --max-test-fail=20 --parallel=6 --testcase-timeout=4 --skip-test-list=unstable-tests --suite=main,innodb,plugins,mariabackup
 image: Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: 10.2-{build}
+before_build:
+- md %APPVEYOR_BUILD_FOLDER%\win_build
+- cd %APPVEYOR_BUILD_FOLDER%\win_build
+- cmake ..  -G "Visual Studio 15 2017" -DBOOST_ROOT=C:\Libraries\boost_1_64_0 -DPKG_CONFIG_EXECUTABLE=C:\perl\bin\pkg-config -DBISON_EXECUTABLE=C:\cygwin\bin\bison
+- dir
+build:
+  project: win_build\MySQL.sln
+  parallel: true
+  verbosity: minimal
+configuration:
+  - Debug
+test:
+test_script:
+- cd %APPVEYOR_BUILD_FOLDER%\win_build\mysql-test
+- perl mysql-test-run.pl --force --max-test-fail=20 --parallel=6 --testcase-timeout=2 --skip-test-list=unstable-tests --suite=main,innodb,plugins,mariabackup
+image: Visual Studio 2017


### PR DESCRIPTION
This is so pull requests will be Windows tested.

Current Build: https://ci.appveyor.com/project/grooverdan/mariadb-server

Obviously needs a few clicks to authorise AppVeyor as a github hook.

In the AppVeyor the settings I changed where:

"Skip branches without appveyor.yml" - enable  (not sure how it would work without this).
"Git clone depth" - 2 (though seems to be ignored looking at output)

I submit this under the MCA.