### PR TITLE
travis: add clang-5.0

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -8,8 +8,8 @@ if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
       CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
     fi
     case ${GCC_VERSION} in
-      5) CXX=clang++-3.9 ;;
-      6) CXX=clang++-4.0 ;;
+      5) CXX=clang++-4.0 ;;
+      6) CXX=clang++-5.0 ;;
     esac
     export CXX CC=${CXX/++/}
   elif [[ "${CXX}" == 'g++' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,18 +136,17 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty
-      - llvm-toolchain-trusty-3.9
       - llvm-toolchain-trusty-4.0
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
     packages: # make sure these match the build requirements
       - gcc-5
       - g++-5
       - gcc-6
       - g++-6
-      - clang-3.9
-      - llvm-3.9-dev
       - clang-4.0
       - llvm-4.0-dev
+      - clang-5.0
+      - llvm-5.0-dev
       - libasan0
       - bison
       - chrpath


### PR DESCRIPTION
Also removed clang-3.9

clang-6.0 is now the development version.

clang-3.6 (that is the distro version of trusty) is still being tested as the low end compatibility (for travis GCC_VERSION=4.8).