### PR TITLE
MDEV-13550 - Copy ctor instread of memcpy() in partition_info::get_clone()

### DIFF
--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -42,13 +42,12 @@ partition_info *partition_info::get_clone(THD *thd)
 
   List_iterator<partition_element> part_it(partitions);
   partition_element *part;
-  partition_info *clone= new (mem_root) partition_info();
+  partition_info *clone= new (mem_root) partition_info(*this);
   if (!clone)
   {
     mem_alloc_error(sizeof(partition_info));
     DBUG_RETURN(NULL);
   }
-  memcpy(clone, this, sizeof(partition_info));
   memset(&(clone->read_partitions), 0, sizeof(clone->read_partitions));
   memset(&(clone->lock_partitions), 0, sizeof(clone->lock_partitions));
   clone->bitmaps_are_initialized= FALSE;


### PR DESCRIPTION
List<>::last is wrong after memcpy(). Doing it on constructed objects is bad practice.