### PR TITLE
submodules.cmake: git returns 128 if not in a repository

### DIFF
--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -2,8 +2,9 @@
 IF(GIT_EXECUTABLE AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
   EXECUTE_PROCESS(COMMAND "${GIT_EXECUTABLE}" config --get cmake.update-submodules
                   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-                  OUTPUT_VARIABLE cmake_update_submodules)
-  IF(cmake_update_submodules MATCHES no)
+                  OUTPUT_VARIABLE cmake_update_submodules
+                  RESULT_VARIABLE git_config_get_result)
+  IF(git_config_get_result EQUAL 128 OR cmake_update_submodules MATCHES no)
     SET(update_result 0)
   ELSEIF (cmake_update_submodules MATCHES force)
     MESSAGE("-- Updating submodules (forced)")


### PR DESCRIPTION
It is possible that a .git directory isn't definitive on the
existance of a working git tree. A git worktree over sshfs
for instance will fail to build unless the main repository
also exists in the same directory. Adding this extra test
will make the detection that little more ruggardised for these
odd build environments.