### PR TITLE
simplify READ_RECORD usage NFC

### DIFF
--- a/sql/event_db_repository.cc
+++ b/sql/event_db_repository.cc
@@ -499,7 +499,7 @@ Event_db_repository::table_scan_all_for_i_s(THD *thd, TABLE *schema_table,
   */
   do
   {
-    ret= read_record_info.read_record(&read_record_info);
+    ret= read_record_info.read_record();
     if (ret == 0)
       ret= copy_event_to_schema_table(thd, schema_table, event_table);
   } while (ret == 0);
@@ -1008,7 +1008,7 @@ Event_db_repository::drop_schema_events(THD *thd, const LEX_CSTRING *schema)
   if (init_read_record(&read_record_info, thd, table, NULL, NULL, 1, 0, FALSE))
     goto end;
 
-  while (!ret && !(read_record_info.read_record(&read_record_info)) )
+  while (!ret && !(read_record_info.read_record()))
   {
     char *et_field= get_field(thd->mem_root, table->field[field]);
 

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -1156,7 +1156,7 @@ Events::load_events_from_db(THD *thd)
     DBUG_RETURN(TRUE);
   }
 
-  while (!(read_record_info.read_record(&read_record_info)))
+  while (!(read_record_info.read_record()))
   {
     Event_queue_element *et;
     bool created, dropped;

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -3826,8 +3826,8 @@ int subselect_single_select_engine::exec()
             {
               /* Change the access method to full table scan */
               tab->save_read_first_record= tab->read_first_record;
-              tab->save_read_record= tab->read_record.read_record;
-              tab->read_record.read_record= rr_sequential;
+              tab->save_read_record= tab->read_record.read_record_func;
+              tab->read_record.read_record_func= rr_sequential;
               tab->read_first_record= read_first_record_seq;
               tab->read_record.record= tab->table->record[0];
               tab->read_record.thd= join->thd;
@@ -3849,8 +3849,8 @@ int subselect_single_select_engine::exec()
       JOIN_TAB *tab= *ptab;
       tab->read_record.record= 0;
       tab->read_record.ref_length= 0;
-      tab->read_first_record= tab->save_read_first_record; 
-      tab->read_record.read_record= tab->save_read_record;
+      tab->read_first_record= tab->save_read_first_record;
+      tab->read_record.read_record_func= tab->save_read_record;
     }
     executed= 1;
     if (!(uncacheable() & ~UNCACHEABLE_EXPLAIN) &&

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -11042,7 +11042,7 @@ int QUICK_INDEX_MERGE_SELECT::get_next()
   if (doing_pk_scan)
     DBUG_RETURN(pk_quick_select->get_next());
 
-  if ((result= read_record.read_record(&read_record)) == -1)
+  if ((result= read_record.read_record()) == -1)
   {
     result= HA_ERR_END_OF_FILE;
     end_read_record(&read_record);
@@ -11078,7 +11078,7 @@ int QUICK_INDEX_INTERSECT_SELECT::get_next()
   int result;
   DBUG_ENTER("QUICK_INDEX_INTERSECT_SELECT::get_next");
 
-  if ((result= read_record.read_record(&read_record)) == -1)
+  if ((result= read_record.read_record()) == -1)
   {
     result= HA_ERR_END_OF_FILE;
     end_read_record(&read_record);

--- a/sql/opt_subselect.cc
+++ b/sql/opt_subselect.cc
@@ -3872,7 +3872,7 @@ bool setup_sj_materialization_part2(JOIN_TAB *sjm_tab)
     sjm_tab->read_record.copy_field= sjm->copy_field;
     sjm_tab->read_record.copy_field_end= sjm->copy_field +
                                          sjm->sjm_table_cols.elements;
-    sjm_tab->read_record.read_record= rr_sequential_and_unpack;
+    sjm_tab->read_record.read_record_func= rr_sequential_and_unpack;
   }
 
   sjm_tab->bush_children->end[-1].next_select= end_sj_materialize;

--- a/sql/records.cc
+++ b/sql/records.cc
@@ -88,8 +88,8 @@ bool init_read_record_idx(READ_RECORD *info, THD *thd, TABLE *table,
       table->file->print_error(error, MYF(0));
   }
 
-  /* read_record will be changed to rr_index in rr_index_first */
-  info->read_record= reverse ? rr_index_last : rr_index_first;
+  /* read_record_func will be changed to rr_index in rr_index_first */
+  info->read_record_func= reverse ? rr_index_last : rr_index_first;
   DBUG_RETURN(error != 0);
 }
 
@@ -228,8 +228,8 @@ bool init_read_record(READ_RECORD *info,THD *thd, TABLE *table,
   if (tempfile && !(select && select->quick))
   {
     DBUG_PRINT("info",("using rr_from_tempfile"));
-    info->read_record= (addon_field ?
-                        rr_unpack_from_tempfile : rr_from_tempfile);
+    info->read_record_func=
+        addon_field ? rr_unpack_from_tempfile : rr_from_tempfile;
     info->io_cache= tempfile;
     reinit_io_cache(info->io_cache,READ_CACHE,0L,0,0);
     info->ref_pos=table->file->ref;
@@ -259,14 +259,14 @@ bool init_read_record(READ_RECORD *info,THD *thd, TABLE *table,
       if (! init_rr_cache(thd, info))
       {
 	DBUG_PRINT("info",("using rr_from_cache"));
-	info->read_record=rr_from_cache;
+        info->read_record_func= rr_from_cache;
       }
     }
   }
   else if (select && select->quick)
   {
     DBUG_PRINT("info",("using rr_quick"));
-    info->read_record=rr_quick;
+    info->read_record_func= rr_quick;
   }
   else if (filesort && filesort->record_pointers)
   {
@@ -276,13 +276,13 @@ bool init_read_record(READ_RECORD *info,THD *thd, TABLE *table,
     info->cache_pos= filesort->record_pointers;
     info->cache_end= (info->cache_pos+ 
                       filesort->return_rows * info->ref_length);
-    info->read_record= (addon_field ?
-                        rr_unpack_from_buffer : rr_from_pointers);
+    info->read_record_func=
+        addon_field ? rr_unpack_from_buffer : rr_from_pointers;
   }
   else if (table->file->keyread_enabled())
   {
     int error;
-    info->read_record= rr_index_first;
+    info->read_record_func= rr_index_first;
     if (!table->file->inited &&
         (error= table->file->ha_index_init(table->file->keyread, 1)))
     {
@@ -294,7 +294,7 @@ bool init_read_record(READ_RECORD *info,THD *thd, TABLE *table,
   else
   {
     DBUG_PRINT("info",("using rr_sequential"));
-    info->read_record=rr_sequential;
+    info->read_record_func= rr_sequential;
     if (table->file->ha_rnd_init_with_error(1))
       DBUG_RETURN(1);
     /* We can use record cache if we don't update dynamic length tables */
@@ -330,7 +330,7 @@ void end_read_record(READ_RECORD *info)
   {
     if (info->table->is_created())
       (void) info->table->file->extra(HA_EXTRA_NO_CACHE);
-    if (info->read_record != rr_quick) // otherwise quick_range does it
+    if (info->read_record_func != rr_quick) // otherwise quick_range does it
       (void) info->table->file->ha_index_or_rnd_end();
     info->table=0;
   }
@@ -398,7 +398,7 @@ static int rr_index_first(READ_RECORD *info)
   }
 
   tmp= info->table->file->ha_index_first(info->record);
-  info->read_record= rr_index;
+  info->read_record_func= rr_index;
   if (tmp)
     tmp= rr_handle_error(info, tmp);
   return tmp;
@@ -421,7 +421,7 @@ static int rr_index_first(READ_RECORD *info)
 static int rr_index_last(READ_RECORD *info)
 {
   int tmp= info->table->file->ha_index_last(info->record);
-  info->read_record= rr_index_desc;
+  info->read_record_func= rr_index_desc;
   if (tmp)
     tmp= rr_handle_error(info, tmp);
   return tmp;

--- a/sql/records.h
+++ b/sql/records.h
@@ -55,7 +55,7 @@ struct READ_RECORD
   //handler *file;
   TABLE **forms;                                /* head and ref forms */
   Unlock_row_func unlock_row;
-  Read_func read_record;
+  Read_func read_record_func;
   THD *thd;
   SQL_SELECT *select;
   uint cache_records;
@@ -69,6 +69,8 @@ struct READ_RECORD
   struct st_io_cache *io_cache;
   bool print_error, ignore_not_found_rows;
   void    (*unpack)(struct st_sort_addon_field *, uchar *, uchar *);
+
+  int read_record() { return read_record_func(this); }
 
   /* 
     SJ-Materialization runtime may need to read fields from the materialized

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -1828,7 +1828,7 @@ static bool acl_load(THD *thd, const Grant_tables& tables)
   {
     if (host_table.init_read_record(&read_record_info, thd))
       DBUG_RETURN(true);
-    while (!(read_record_info.read_record(&read_record_info)))
+    while (!(read_record_info.read_record()))
     {
       ACL_HOST host;
       update_hostname(&host.host, get_field(&acl_memroot, host_table.host()));
@@ -1932,7 +1932,7 @@ static bool acl_load(THD *thd, const Grant_tables& tables)
   }
 
   allow_all_hosts=0;
-  while (!(read_record_info.read_record(&read_record_info)))
+  while (!(read_record_info.read_record()))
   {
     ACL_USER user;
     bool is_role= FALSE;
@@ -2144,7 +2144,7 @@ static bool acl_load(THD *thd, const Grant_tables& tables)
   const Db_table& db_table= tables.db_table();
   if (db_table.init_read_record(&read_record_info, thd))
     DBUG_RETURN(TRUE);
-  while (!(read_record_info.read_record(&read_record_info)))
+  while (!(read_record_info.read_record()))
   {
     ACL_DB db;
     char *db_name;
@@ -2211,7 +2211,7 @@ static bool acl_load(THD *thd, const Grant_tables& tables)
   {
     if (proxies_priv_table.init_read_record(&read_record_info, thd))
       DBUG_RETURN(TRUE);
-    while (!(read_record_info.read_record(&read_record_info)))
+    while (!(read_record_info.read_record()))
     {
       ACL_PROXY_USER proxy;
       proxy.init(proxies_priv_table, &acl_memroot);
@@ -2240,7 +2240,7 @@ static bool acl_load(THD *thd, const Grant_tables& tables)
 
     MEM_ROOT temp_root;
     init_alloc_root(&temp_root, ACL_ALLOC_BLOCK_SIZE, 0, MYF(0));
-    while (!(read_record_info.read_record(&read_record_info)))
+    while (!(read_record_info.read_record()))
     {
       char *hostname= safe_str(get_field(&temp_root, roles_mapping_table.host()));
       char *username= safe_str(get_field(&temp_root, roles_mapping_table.user()));

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -588,7 +588,7 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
     deltempfile= new (thd->mem_root) Unique (refpos_order_cmp, table->file,
                                              table->file->ref_length,
                                              MEM_STRIP_BUF_SIZE);
-    while (!(error=info.read_record(&info)) && !thd->killed &&
+    while (!(error=info.read_record()) && !thd->killed &&
           ! thd->is_error())
     {
       if (record_should_be_deleted(thd, table, select, explain))
@@ -613,7 +613,7 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
     delete_record= true;
   }
 
-  while (!(error=info.read_record(&info)) && !thd->killed &&
+  while (!(error=info.read_record()) && !thd->killed &&
         ! thd->is_error())
   {
     if (delete_while_scanning)
@@ -1286,7 +1286,7 @@ int multi_delete::do_table_deletes(TABLE *table, SORT_INFO *sort_info,
   */
   info.ignore_not_found_rows= 1;
   bool will_batch= !table->file->start_bulk_delete();
-  while (!(local_error= info.read_record(&info)) && !thd->killed)
+  while (!(local_error= info.read_record()) && !thd->killed)
   {
     if (table->triggers &&
         table->triggers->process_triggers(thd, TRG_EVENT_DELETE,

--- a/sql/sql_help.cc
+++ b/sql/sql_help.cc
@@ -202,7 +202,7 @@ int search_topics(THD *thd, TABLE *topics, struct st_find_field *find_fields,
                        FALSE))
     DBUG_RETURN(0);
 
-  while (!read_record_info.read_record(&read_record_info))
+  while (!read_record_info.read_record())
   {
     if (!select->cond->val_int())		// Doesn't match like
       continue;
@@ -246,7 +246,7 @@ int search_keyword(THD *thd, TABLE *keywords,
                        FALSE))
     DBUG_RETURN(0);
 
-  while (!read_record_info.read_record(&read_record_info) && count<2)
+  while (!read_record_info.read_record() && count<2)
   {
     if (!select->cond->val_int())		// Dosn't match like
       continue;
@@ -380,7 +380,7 @@ int search_categories(THD *thd, TABLE *categories,
   if (init_read_record(&read_record_info, thd, categories, select, NULL,
                        1, 0, FALSE))
     DBUG_RETURN(0);
-  while (!read_record_info.read_record(&read_record_info))
+  while (!read_record_info.read_record())
   {
     if (select && !select->cond->val_int())
       continue;
@@ -418,7 +418,7 @@ void get_all_items_for_category(THD *thd, TABLE *items, Field *pfname,
                        FALSE))
     DBUG_VOID_RETURN;
 
-  while (!read_record_info.read_record(&read_record_info))
+  while (!read_record_info.read_record())
   {
     if (!select->cond->val_int())
       continue;

--- a/sql/sql_join_cache.cc
+++ b/sql/sql_join_cache.cc
@@ -3373,7 +3373,7 @@ int JOIN_TAB_SCAN::next()
   if (is_first_record)
     is_first_record= FALSE;
   else
-    err= info->read_record(info);
+    err= info->read_record();
 
   if (!err)
   {
@@ -3388,7 +3388,7 @@ int JOIN_TAB_SCAN::next()
       Move to the next record if the last retrieved record does not
       meet the condition pushed to the table join_tab.
     */
-    err= info->read_record(info);
+    err= info->read_record();
     if (!err)
     {
       join_tab->tracker->r_rows++;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1840,7 +1840,7 @@ static void plugin_load(MEM_ROOT *tmp_root)
     goto end;
   }
   table->use_all_columns();
-  while (!(error= read_record_info.read_record(&read_record_info)))
+  while (!(error= read_record_info.read_record()))
   {
     DBUG_PRINT("info", ("init plugin record"));
     String str_name, str_dl;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -10972,32 +10972,32 @@ pick_table_access_method(JOIN_TAB *tab)
   {
   case JT_REF:
     tab->read_first_record= join_read_always_key;
-    tab->read_record.read_record= join_read_next_same;
+    tab->read_record.read_record_func= join_read_next_same;
     break;
 
   case JT_REF_OR_NULL:
     tab->read_first_record= join_read_always_key_or_null;
-    tab->read_record.read_record= join_read_next_same_or_null;
+    tab->read_record.read_record_func= join_read_next_same_or_null;
     break;
 
   case JT_CONST:
     tab->read_first_record= join_read_const;
-    tab->read_record.read_record= join_no_more_records;
+    tab->read_record.read_record_func= join_no_more_records;
     break;
 
   case JT_EQ_REF:
     tab->read_first_record= join_read_key;
-    tab->read_record.read_record= join_no_more_records;
+    tab->read_record.read_record_func= join_no_more_records;
     break;
 
   case JT_FT:
     tab->read_first_record= join_ft_read_first;
-    tab->read_record.read_record= join_ft_read_next;
+    tab->read_record.read_record_func= join_ft_read_next;
     break;
 
   case JT_SYSTEM:
     tab->read_first_record= join_read_system;
-    tab->read_record.read_record= join_no_more_records;
+    tab->read_record.read_record_func= join_no_more_records;
     break;
 
   /* keep gcc happy */  
@@ -18878,7 +18878,7 @@ sub_select(JOIN *join,JOIN_TAB *join_tab,bool end_of_records)
       skip_over= TRUE;
     }
 
-    error= info->read_record(info);
+    error= info->read_record();
 
     if (skip_over && !error) 
     {
@@ -19721,7 +19721,7 @@ int read_first_record_seq(JOIN_TAB *tab)
 {
   if (tab->read_record.table->file->ha_rnd_init_with_error(1))
     return 1;
-  return (*tab->read_record.read_record)(&tab->read_record);
+  return tab->read_record.read_record();
 }
 
 static int
@@ -19776,7 +19776,7 @@ int join_init_read_record(JOIN_TAB *tab)
   if (init_read_record(&tab->read_record, tab->join->thd, tab->table,
                        tab->select, tab->filesort_result, 1,1, FALSE))
     return 1;
-  return (*tab->read_record.read_record)(&tab->read_record);
+  return tab->read_record.read_record();
 }
 
 int
@@ -19796,9 +19796,9 @@ join_read_record_no_init(JOIN_TAB *tab)
 
   tab->read_record.copy_field=     save_copy;
   tab->read_record.copy_field_end= save_copy_end;
-  tab->read_record.read_record= rr_sequential_and_unpack;
+  tab->read_record.read_record_func= rr_sequential_and_unpack;
 
-  return (*tab->read_record.read_record)(&tab->read_record);
+  return tab->read_record.read_record();
 }
 
 
@@ -19831,7 +19831,7 @@ join_read_first(JOIN_TAB *tab)
               !table->covering_keys.is_set(tab->index) ||
               table->file->keyread == tab->index);
   tab->table->status=0;
-  tab->read_record.read_record=join_read_next;
+  tab->read_record.read_record_func= join_read_next;
   tab->read_record.table=table;
   tab->read_record.index=tab->index;
   tab->read_record.record=table->record[0];
@@ -19871,7 +19871,7 @@ join_read_last(JOIN_TAB *tab)
               !table->covering_keys.is_set(tab->index) ||
               table->file->keyread == tab->index);
   tab->table->status=0;
-  tab->read_record.read_record=join_read_prev;
+  tab->read_record.read_record_func= join_read_prev;
   tab->read_record.table=table;
   tab->read_record.index=tab->index;
   tab->read_record.record=table->record[0];
@@ -21837,7 +21837,7 @@ check_reverse_order:
           with key part (A) and then traverse the index backwards.
         */
         tab->read_first_record= join_read_last_key;
-        tab->read_record.read_record= join_read_prev_same;
+        tab->read_record.read_record_func= join_read_prev_same;
         /*
           Cancel Pushed Index Condition, as it doesn't work for reverse scans.
         */
@@ -26762,7 +26762,7 @@ AGGR_OP::end_send()
       error= join_init_read_record(join_tab);
     }
     else
-      error= join_tab->read_record.read_record(&join_tab->read_record);
+      error= join_tab->read_record.read_record();
 
     if (error > 0 || (join->thd->is_error()))   // Fatal error
       rc= NESTED_LOOP_ERROR;

--- a/sql/sql_servers.cc
+++ b/sql/sql_servers.cc
@@ -208,7 +208,7 @@ static bool servers_load(THD *thd, TABLE_LIST *tables)
   if (init_read_record(&read_record_info,thd,table=tables[0].table, NULL, NULL,
                        1,0, FALSE))
     DBUG_RETURN(1);
-  while (!(read_record_info.read_record(&read_record_info)))
+  while (!(read_record_info.read_record()))
   {
     /* return_val is already TRUE, so no need to set */
     if ((get_server_from_table_to_cache(table)))

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -9703,7 +9703,7 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to,
   thd->progress.max_counter= from->file->records();
   time_to_report_progress= MY_HOW_OFTEN_TO_WRITE/10;
 
-  while (!(error=info.read_record(&info)))
+  while (!(error= info.read_record()))
   {
     if (thd->killed)
     {

--- a/sql/sql_udf.cc
+++ b/sql/sql_udf.cc
@@ -189,7 +189,7 @@ void udf_init()
   }
 
   table->use_all_columns();
-  while (!(error= read_record_info.read_record(&read_record_info)))
+  while (!(error= read_record_info.read_record()))
   {
     DBUG_PRINT("info",("init udf record"));
     LEX_CSTRING name;

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -616,7 +616,7 @@ int mysql_update(THD *thd,
       THD_STAGE_INFO(thd, stage_searching_rows_for_update);
       ha_rows tmp_limit= limit;
 
-      while (!(error=info.read_record(&info)) && !thd->killed)
+      while (!(error=info.read_record()) && !thd->killed)
       {
         explain->buf_tracker.on_record_read();
         thd->inc_examined_row_count(1);
@@ -732,7 +732,7 @@ int mysql_update(THD *thd,
   can_compare_record= records_are_comparable(table);
   explain->tracker.on_scan_init();
 
-  while (!(error=info.read_record(&info)) && !thd->killed)
+  while (!(error=info.read_record()) && !thd->killed)
   {
     explain->tracker.on_record_read();
     thd->inc_examined_row_count(1);

--- a/sql/sql_window.cc
+++ b/sql/sql_window.cc
@@ -740,7 +740,7 @@ public:
   void init(READ_RECORD *info)
   {
     ref_length= info->ref_length;
-    if (info->read_record == rr_from_pointers)
+    if (info->read_record_func == rr_from_pointers)
     {
       io_cache= NULL;
       cache_start= info->cache_pos;
@@ -2700,7 +2700,7 @@ bool compute_window_func(THD *thd,
 
   while (true)
   {
-    if ((err= info.read_record(&info)))
+    if ((err= info.read_record()))
       break; // End of file.
 
     /* Remember current row so that we can restore it before computing

--- a/storage/spider/spd_trx.cc
+++ b/storage/spider/spd_trx.cc
@@ -2688,7 +2688,7 @@ int spider_initinal_xa_recover(
                      FALSE);
   }
   SPD_INIT_ALLOC_ROOT(&mem_root, 4096, 0, MYF(MY_WME));
-  while ((!(read_record->read_record(read_record))) && cnt < (int) len)
+  while ((!(read_record->read_record())) && cnt < (int) len)
   {
     spider_get_sys_xid(table_xa, &xid_list[cnt], &mem_root);
     cnt++;


### PR DESCRIPTION
```c++
READ_RECORD read_record;
...
// this
// read_record.read_record(&read_record);
// becomes just
read_record.read_record();
```

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.