### PR TITLE
Hits statistics for queries in query cache (for query cache information plugin)

### DIFF
--- a/mysql-test/suite/plugins/r/qc_info.result
+++ b/mysql-test/suite/plugins/r/qc_info.result
@@ -26,15 +26,29 @@ set time_zone=@new_time_zone,default_week_format=4,character_set_client='binary'
 select * from t1;
 set time_zone= @time_zone, default_week_format= @default_week_format, character_set_client= @character_set_client,character_set_results= @character_set_results, sql_mode= @sql_mode, div_precision_increment= @div_precision_increment, lc_time_names= @lc_time_names, autocommit= @autocommit, group_concat_max_len= @group_concat_max_len, max_sort_length= @max_sort_length;
 select * from information_schema.query_cache_info;
-STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER
-test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	Europe/Moscow	4	7	STRICT_ALL_TABLES	ar_SD	1	1	#	0	0	0	#
-test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	SYSTEM	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	#	0	0	1	#
+STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER	HITS
+test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	Europe/Moscow	4	7	STRICT_ALL_TABLES	ar_SD	1	1	#	0	0	0	#	0
+test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	SYSTEM	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	#	0	0	1	#	0
+reset query cache;
+select * from t1;
+a
+1
+2
+3
+select * from t1;
+a
+1
+2
+3
+select hits, statement_text from information_schema.query_cache_info;
+hits	statement_text
+1	select * from t1
 drop table t1;
 select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info;
 statement_schema	statement_text	result_blocks_count	result_blocks_size
 set global query_cache_size = 0;
 select * from information_schema.query_cache_info;
-STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER
+STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER	HITS
 set global query_cache_size= default;
 set global query_cache_type=default;
 show query_cache_info;

--- a/mysql-test/suite/plugins/r/qc_info_priv.result
+++ b/mysql-test/suite/plugins/r/qc_info_priv.result
@@ -26,9 +26,9 @@ set time_zone=@new_time_zone,default_week_format=4,character_set_client='binary'
 select * from t1;
 set time_zone= @time_zone, default_week_format= @default_week_format, character_set_client= @character_set_client,character_set_results= @character_set_results, sql_mode= @sql_mode, div_precision_increment= @div_precision_increment, lc_time_names= @lc_time_names, autocommit= @autocommit, group_concat_max_len= @group_concat_max_len, max_sort_length= @max_sort_length;
 select * from information_schema.query_cache_info;
-STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER
-test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	Europe/Moscow	4	7	STRICT_ALL_TABLES	ar_SD	1	1	#	0	0	0	#
-test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	SYSTEM	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	#	0	0	1	#
+STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER	HITS
+test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	Europe/Moscow	4	7	STRICT_ALL_TABLES	ar_SD	1	1	#	0	0	0	#	0
+test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	SYSTEM	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	#	0	0	1	#	0
 create user mysqltest;
 connect  conn1,localhost,mysqltest,,;
 connection conn1;

--- a/mysql-test/suite/plugins/t/qc_info.test
+++ b/mysql-test/suite/plugins/t/qc_info.test
@@ -1,5 +1,11 @@
 --source qc_info_init.inc
 
+# test that hits are correctly incremented
+reset query cache;
+select * from t1;
+select * from t1;
+select hits, statement_text from information_schema.query_cache_info;
+
 drop table t1;
 # the query was invalidated
 select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info;

--- a/plugin/qc_info/qc_info.cc
+++ b/plugin/qc_info/qc_info.cc
@@ -77,6 +77,7 @@ bool schema_table_store_record(THD *thd, TABLE *table);
 #define COLUMN_IN_TRANS 20
 #define COLUMN_AUTOCOMMIT 21
 #define COLUMN_PKT_NR 22
+#define COLUMN_HITS 23
 
 /* ST_FIELD_INFO is defined in table.h */
 static ST_FIELD_INFO qc_info_fields[]=
@@ -104,6 +105,7 @@ static ST_FIELD_INFO qc_info_fields[]=
   {"IN_TRANS", MY_INT32_NUM_DECIMAL_DIGITS, MYSQL_TYPE_TINY, 0, 0, 0, 0},
   {"AUTOCOMMIT", MY_INT32_NUM_DECIMAL_DIGITS, MYSQL_TYPE_TINY, 0, 0, 0, 0},
   {"PACKET_NUMBER", MY_INT32_NUM_DECIMAL_DIGITS, MYSQL_TYPE_TINY, 0, 0, 0, 0},
+  {"HITS", MY_INT32_NUM_DECIMAL_DIGITS, MYSQL_TYPE_LONGLONG, 0, MY_I_S_UNSIGNED, 0, 0},
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, 0}
 };
 
@@ -216,6 +218,7 @@ static int qc_info_fill_table(THD *thd, TABLE_LIST *tables,
     table->field[COLUMN_IN_TRANS]->store(flags.in_trans, 0);
     table->field[COLUMN_AUTOCOMMIT]->store(flags.autocommit, 0);
     table->field[COLUMN_PKT_NR]->store(flags.pkt_nr, 0);
+    table->field[COLUMN_HITS]->store(query_cache_query->hits(), 0);
 
     /* The database against which the statement is executed is part of the
        query cache query key

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -961,7 +961,7 @@ inline void Query_cache_query::unlock_reading()
 void Query_cache_query::init_n_lock()
 {
   DBUG_ENTER("Query_cache_query::init_n_lock");
-  res=0; wri = 0; len = 0; ready= 0;
+  res=0; wri = 0; len = 0; ready= 0; hit_count = 0;
   mysql_rwlock_init(key_rwlock_query_cache_query_lock, &lock);
   lock_writing();
   DBUG_PRINT("qcache", ("inited & locked query for block 0x%lx",
@@ -2142,6 +2142,7 @@ lookup:
   }
   move_to_query_list_end(query_block);
   hits++;
+  query->increment_hits();
   unlock();
 
   /*

--- a/sql/sql_cache.h
+++ b/sql/sql_cache.h
@@ -159,6 +159,7 @@ struct Query_cache_query
   unsigned int last_pkt_nr;
   uint8 tbls_type;
   uint8 ready;
+  ulonglong hit_count;
 
   Query_cache_query() {}                      /* Remove gcc warning */
   inline void init_n_lock();
@@ -184,6 +185,8 @@ struct Query_cache_query
   */
   inline void set_results_ready()          { ready= 1; }
   inline bool is_results_ready()           { return ready; }
+  inline void increment_hits() { hit_count++; }
+  inline ulong hits() { return hit_count; }
   void lock_writing();
   void lock_reading();
   bool try_lock_writing();


### PR DESCRIPTION
This pull request adds HITS column to QUERY_CACHE_INFO table of [qc_info](https://mariadb.com/kb/en/the-mariadb-library/query-cache-information-plugin/) plugin.

Our case is that we plan to turn off query cache on our production server, because we believe it becomes a bottleneck in some situations.
Load testing shows that server becomes overloaded if query cache is turned off. It is because there are some queries that begin to kill server when not using query cache. The problem is to figure out what exactly are those queries.
Currently there is no way to figure out whether the query has used query cache or not. The query_cache_info plugin shows the contents of the query cache, but it does not show any usage statistics. Moreover there is no session stat variable that could help understand whether the last query result is taken directly from query cache or not.
One can save snapthots of query_cache_info table and try to make some guess by comparing this snapshots over time but this way is neither accurate nor convenient.

Another case is to use this hits statistics to tune query cache usage. The queries that have low or zero hits can be disabled with SQL_NO_CACHE hint thus increasing query cache efficiency, I think it’s pretty straightforward.

I've found an issue  [MDEV-4682](https://jira.mariadb.org/browse/MDEV-4682) that is somewhat related and addresses this problem.

The issue has a [pull request](https://github.com/MariaDB/server/pull/6/) (which almost completely rewrites qc_info plugin) that has never been merged.
Inspired by that request I’ve made a patch which is a way smaller and adds just few lines to qc_info plugin and to sql_cache (to increment hits when query result are read from cache) and one additional column to query_cache_info table. The tests are updated accordingly.

We are using exactly this patch on MariaDb-10.1.24 at production server with almost 1TB of data, thousands of tables and about 15K tps, it is working without any problems.

I think HITS statistic for query cache should be useful for many real world cases. If you think so, please review this PR and let me know if it needs any updates.

Thanks!
