### PR TITLE
add TSAN option to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,11 @@ IF (WITH_ASAN)
   ENDIF()
 ENDIF()
 
+OPTION(WITH_TSAN "Enable thread sanitizer" OFF)
+IF (WITH_TSAN)
+  MY_CHECK_AND_SET_COMPILER_FLAG("-fsanitize=thread" DEBUG RELWITHDEBINFO)
+ENDIF()
+
 # enable security hardening features, like most distributions do
 # in our benchmarks that costs about ~1% of performance, depending on the load
 IF(CMAKE_C_COMPILER_VERSION VERSION_LESS "4.6")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,23 +206,28 @@ ENDIF()
 
 OPTION(WITH_TSAN "Enable thread sanitizer" OFF)
 IF (WITH_TSAN)
+  IF(SECURITY_HARDENED)
+    MESSAGE(FATAL_ERROR "WITH_TSAN and SECURITY_HARDENED are mutually exclusive")
+  ENDIF()
   MY_CHECK_AND_SET_COMPILER_FLAG("-fsanitize=thread" DEBUG RELWITHDEBINFO)
 ENDIF()
 
-# enable security hardening features, like most distributions do
-# in our benchmarks that costs about ~1% of performance, depending on the load
-IF(CMAKE_C_COMPILER_VERSION VERSION_LESS "4.6")
-  SET(security_default OFF)
-ELSE()
-  SET(security_default ON)
-ENDIF()
-OPTION(SECURITY_HARDENED "Use security-enhancing compiler features (stack protector, relro, etc)" ${security_default})
-IF(SECURITY_HARDENED AND NOT WITH_TSAN)
-  # security-enhancing flags
-  MY_CHECK_AND_SET_COMPILER_FLAG("-pie -fPIC")
-  MY_CHECK_AND_SET_COMPILER_FLAG("-Wl,-z,relro,-z,now")
-  MY_CHECK_AND_SET_COMPILER_FLAG("-fstack-protector --param=ssp-buffer-size=4")
-  MY_CHECK_AND_SET_COMPILER_FLAG("-D_FORTIFY_SOURCE=2" RELEASE RELWITHDEBINFO)
+IF(NOT WITH_TSAN)
+  # enable security hardening features, like most distributions do
+  # in our benchmarks that costs about ~1% of performance, depending on the load
+  IF(CMAKE_C_COMPILER_VERSION VERSION_LESS "4.6")
+    SET(security_default OFF)
+  ELSE()
+    SET(security_default ON)
+  ENDIF()
+  OPTION(SECURITY_HARDENED "Use security-enhancing compiler features (stack protector, relro, etc)" ${security_default})
+  IF(SECURITY_HARDENED)
+    # security-enhancing flags
+    MY_CHECK_AND_SET_COMPILER_FLAG("-pie -fPIC")
+    MY_CHECK_AND_SET_COMPILER_FLAG("-Wl,-z,relro,-z,now")
+    MY_CHECK_AND_SET_COMPILER_FLAG("-fstack-protector --param=ssp-buffer-size=4")
+    MY_CHECK_AND_SET_COMPILER_FLAG("-D_FORTIFY_SOURCE=2" RELEASE RELWITHDEBINFO)
+  ENDIF()
 ENDIF()
 
 # Always enable debug sync for debug builds.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ ELSE()
   SET(security_default ON)
 ENDIF()
 OPTION(SECURITY_HARDENED "Use security-enhancing compiler features (stack protector, relro, etc)" ${security_default})
-IF(SECURITY_HARDENED)
+IF(SECURITY_HARDENED AND NOT WITH_TSAN)
   # security-enhancing flags
   MY_CHECK_AND_SET_COMPILER_FLAG("-pie -fPIC")
   MY_CHECK_AND_SET_COMPILER_FLAG("-Wl,-z,relro,-z,now")


### PR DESCRIPTION
I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

Do not work with `TokuDB` so `-DWITHOUT_TOKUDB_STORAGE_ENGINE=1` is required to use TSAN.