### PR TITLE
Fixes Galera rsync sst on FreeBSD

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -68,7 +68,7 @@ check_pid_and_port()
         local port_info="$(sockstat -46lp ${rsync_port} 2>/dev/null | \
             grep ":${rsync_port}")"
         local is_rsync="$(echo $port_info | \
-            grep -w '[[:space:]]\+rsync[[:space:]]\+'"$rsync_pid" 2>/dev/null)"
+            grep '[[:space:]]\+rsync[[:space:]]\+'"$rsync_pid" 2>/dev/null)"
         ;;
     *)
         if ! which lsof > /dev/null; then


### PR DESCRIPTION
Corrects the following error with rsync sst on FreeBSD:
WSREP_SST: [ERROR] rsync daemon port '4444' has been taken

The FreeBSD version of grep doesn't play nicely with the -w parameter mixed with [[:space:]] and ends up matching nothing. This causes the script to loop and attempt to spawn more than one instance of rsync, which fails with the initial instance already having the port open. Because of this, the entire script fails and no sst occurs resulting in the error message listed above appearing in the log file.