### PR TITLE
apparmor: allow to read /etc/mysql/mariadb.conf.d/*

### DIFF
--- a/support-files/policy/apparmor/usr.sbin.mysqld
+++ b/support-files/policy/apparmor/usr.sbin.mysqld
@@ -34,6 +34,8 @@
   /etc/mysql/*.pem r,
   /etc/mysql/conf.d/ r,
   /etc/mysql/conf.d/* r,
+  /etc/mysql/mariadb.conf.d/ r,
+  /etc/mysql/mariadb.conf.d/* r,
   /etc/nsswitch.conf r,
   /etc/passwd r,
   /etc/services r,


### PR DESCRIPTION
At least the Debian package reads configuration from there.