### PR TITLE
fix a data race

### DIFF
--- a/storage/innobase/sync/sync0debug.cc
+++ b/storage/innobase/sync/sync0debug.cc
@@ -1304,12 +1304,12 @@ rw_lock_debug_mutex_enter()
 void
 rw_lock_debug_mutex_exit()
 {
-	mutex_exit(&rw_lock_debug_mutex);
-
 	if (rw_lock_debug_waiters) {
 		rw_lock_debug_waiters = FALSE;
 		os_event_set(rw_lock_debug_event);
 	}
+
+	mutex_exit(&rw_lock_debug_mutex);
 }
 #endif /* UNIV_DEBUG */
 


### PR DESCRIPTION
rw_lock_debug_waiters was not protected

Found by TSAN.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.