### PR TITLE
MDEV-13919 sql_mode=ORACLE: Derive length of VARCHAR SP parameters 

### DIFF
--- a/mysql-test/suite/compat/oracle/r/sp-param.result
+++ b/mysql-test/suite/compat/oracle/r/sp-param.result
@@ -130,3 +130,89 @@ t1	CREATE TABLE "t1" (
 )
 DROP TABLE t1;
 DROP FUNCTION f1;
+
+MDEV-13919 sql_mode=ORACLE: Derive length of VARCHAR SP parameters with no length from actual parameters
+
+set sql_mode= 'oracle,strict_trans_tables';
+CREATE OR REPLACE PROCEDURE p1(pinout INOUT varchar, pin IN varchar)
+AS
+BEGIN
+pinout:=pin;
+END;
+/
+call p1(@w,'0123456789')
+/
+declare w varchar(10);
+begin
+call p1(w,'0123456789');
+end;
+/
+declare w varchar(5);
+begin
+call p1(w,'0123456789');
+end;
+/
+ERROR 22001: Data too long for column 'pinout' at row 1
+declare w varchar(20);
+begin
+w:='aaa';
+call p1(w,'0123456789');
+end;
+/
+declare w varchar(8);
+begin
+w:='aaa';
+call p1(w,'0123456789');
+end;
+/
+ERROR 22001: Data too long for column 'pinout' at row 1
+declare str varchar(6000);
+pout varchar(6000);
+begin
+str:=lpad('x',6000,'y');
+call p1(pout,str);
+select length(pout);
+end;
+/
+length(pout)
+6000
+declare str varchar(6000);
+pout varchar(4000);
+begin
+str:=lpad('x',6000,'y');
+call p1(pout,str);
+select length(pout);
+end;
+/
+ERROR 22001: Data too long for column 'pinout' at row 1
+declare str varchar(40000);
+pout varchar(60000);
+begin
+str:=lpad('x',40000,'y');
+call p1(pout,str);
+select length(pout);
+end;
+/
+length(pout)
+40000
+declare str text(80000);
+pout text(80000);
+begin
+str:=lpad('x',80000,'y');
+call p1(pout,str);
+select length(pout);
+end;
+/
+ERROR 22001: Data too long for column 'pin' at row 1
+declare str text(80000);
+pout text(80000);
+begin
+str:=lpad('x',60000,'y');
+call p1(pout,str);
+select length(pout);
+end;
+/
+length(pout)
+60000
+drop procedure p1
+/

--- a/mysql-test/suite/compat/oracle/t/sp-param.test
+++ b/mysql-test/suite/compat/oracle/t/sp-param.test
@@ -35,3 +35,85 @@ SET sql_mode=ORACLE;
 --let type = RAW
 --let length = 4000
 --source sp-param.inc
+
+--echo
+--echo MDEV-13919 sql_mode=ORACLE: Derive length of VARCHAR SP parameters with no length from actual parameters
+--echo
+set sql_mode= 'oracle,strict_trans_tables';
+delimiter /;
+CREATE OR REPLACE PROCEDURE p1(pinout INOUT varchar, pin IN varchar)
+AS
+BEGIN
+  pinout:=pin;
+END;
+/
+call p1(@w,'0123456789')
+/
+declare w varchar(10);
+begin
+  call p1(w,'0123456789');
+end;
+/
+--error ER_DATA_TOO_LONG
+declare w varchar(5);
+begin
+  call p1(w,'0123456789');
+end;
+/
+declare w varchar(20);
+begin
+  w:='aaa';
+  call p1(w,'0123456789');
+end;
+/
+--error ER_DATA_TOO_LONG
+declare w varchar(8);
+begin
+  w:='aaa';
+  call p1(w,'0123456789');
+end;
+/
+declare str varchar(6000);
+        pout varchar(6000);
+begin
+  str:=lpad('x',6000,'y');
+  call p1(pout,str);
+  select length(pout);
+end;
+/
+--error ER_DATA_TOO_LONG
+declare str varchar(6000);
+        pout varchar(4000);
+begin
+  str:=lpad('x',6000,'y');
+  call p1(pout,str);
+  select length(pout);
+end;
+/
+declare str varchar(40000);
+        pout varchar(60000);
+begin
+  str:=lpad('x',40000,'y');
+  call p1(pout,str);
+  select length(pout);
+end;
+/
+--error ER_DATA_TOO_LONG
+declare str text(80000);
+        pout text(80000);
+begin
+  str:=lpad('x',80000,'y');
+  call p1(pout,str);
+  select length(pout);
+end;
+/
+declare str text(80000);
+        pout text(80000);
+begin
+  str:=lpad('x',60000,'y');
+  call p1(pout,str);
+  select length(pout);
+end;
+/
+drop procedure p1
+/

--- a/sql/sp_head.h
+++ b/sql/sp_head.h
@@ -215,7 +215,7 @@ public:
     m_sp_cache_version= version_arg;
   }
 
-  sp_rcontext *rcontext_create(THD *thd, Field *retval);
+  sp_rcontext *rcontext_create(THD *thd, Field *retval, List<Item> *args);
 
 private:
   /**

--- a/sql/sp_rcontext.h
+++ b/sql/sp_rcontext.h
@@ -71,7 +71,8 @@ public:
   static sp_rcontext *create(THD *thd,
                              const sp_pcontext *root_parsing_ctx,
                              Field *return_value_fld,
-                             bool resolve_type_refs);
+                             bool resolve_type_refs,
+                             List<Item> *args);
 
   ~sp_rcontext();
 
@@ -344,6 +345,9 @@ private:
                                   Qualified_column_ident *ref);
   bool resolve_table_rowtype_ref(THD *thd, Row_definition_list &defs,
                                            Table_ident *ref);
+  bool adjust_formal_params_to_actual_params(THD *thd,
+                                         List<Spvar_definition> &field_def_lst,
+                                         List<Item> *args);
 
   /// Create and initialize an Item-adapter (Item_field) for each SP-var field.
   ///

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -2384,6 +2384,29 @@ Field *Type_handler_set::make_table_field(const LEX_CSTRING *name,
                    attr.collation);
 }
 
+/*
+   If length is not specified for a varchar parameter, set length to the
+   maximum length of the actual argument. Goals are:
+   - avoid to allocate too much unused memory for m_var_table
+   - allow length check inside the callee rather than during copy of
+     returned values in output variables.
+   - allow varchar parameter size greater than 4000
+   Default length has been stored in "decimal" member during parse.
+*/
+bool Type_handler_varchar::adjust_spparam_type(Spvar_definition *def,
+                                               Item *from) const
+{
+  if (def->decimals)
+  {
+    uint def_max_char_length= MAX_FIELD_VARCHARLENGTH / def->charset->mbmaxlen;
+    uint arg_max_length= from->max_char_length();
+    set_if_smaller(arg_max_length, def_max_char_length);
+    def->length= arg_max_length > 0 ? arg_max_length : def->decimals;
+    def->create_length_to_internal_length_string();
+  }
+  return false;
+}
+
 /*************************************************************************/
 
 uint32 Type_handler_decimal_result::max_display_length(const Item *item) const

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -65,6 +65,7 @@ class in_vector;
 class Type_handler_hybrid_field_type;
 class Sort_param;
 class Arg_comparator;
+class Spvar_definition;
 struct st_value;
 class Protocol;
 class handler;
@@ -688,6 +689,10 @@ public:
   type_handler_adjusted_to_max_octet_length(uint max_octet_length,
                                             CHARSET_INFO *cs) const
   { return this; }
+  virtual bool adjust_spparam_type(Spvar_definition *def, Item *from) const
+  {
+    return false;
+  }
   virtual ~Type_handler() {}
   /**
     Determines MariaDB traditional data types that always present
@@ -2523,6 +2528,7 @@ public:
                           const Record_addr &addr,
                           const Type_all_attributes &attr,
                           TABLE *table) const;
+  bool adjust_spparam_type(Spvar_definition *def, Item *from) const;
 };
 
 

--- a/sql/sql_yacc_ora.yy
+++ b/sql/sql_yacc_ora.yy
@@ -1054,8 +1054,6 @@ bool my_yyoverflow(short **a, YYSTYPE **b, ulong *yystacksize);
 
 %type <const_simple_string>
         field_length opt_field_length opt_field_length_default_1
-        opt_field_length_default_sp_param_varchar
-        opt_field_length_default_sp_param_char
 
 %type <string>
         text_string hex_or_bin_String opt_gconcat_separator
@@ -1219,6 +1217,8 @@ bool my_yyoverflow(short **a, YYSTYPE **b, ulong *yystacksize);
 %type <Lex_cast_type> cast_type cast_type_numeric cast_type_temporal
 
 %type <Lex_length_and_dec> precision opt_precision float_options
+        opt_field_length_default_sp_param_varchar
+        opt_field_length_default_sp_param_char
 
 %type <symbol> keyword keyword_sp
                keyword_directly_assignable
@@ -6549,9 +6549,11 @@ opt_field_length_default_1:
 
 
 /*
-  In sql_mode=ORACLE, a VARCHAR with no length is used
-  in SP parameters and return values and it's translated to VARCHAR(4000),
-  where 4000 is the maximum possible size for VARCHAR.
+  In sql_mode=ORACLE, real size of VARCHAR and CHAR with no length
+  in SP parameters is fixed at runtime with the length of real args.
+  Let's translate VARCHAR to VARCHAR(4000) for return value.
+
+  Since Oracle 9, maximum size for VARCHAR in PL/SQL is 32767.
 
   In MariaDB the limit for VARCHAR is 65535 bytes.
   We could translate VARCHAR with no length to VARCHAR(65535), but
@@ -6562,17 +6564,14 @@ opt_field_length_default_1:
   the maximum possible length in characters in case of mbmaxlen=4
   (e.g. utf32, utf16, utf8mb4). However, we'll have character sets with
   mbmaxlen=5 soon (e.g. gb18030).
-
-  Let's translate VARCHAR to VARCHAR(4000), which covert all possible Oracle
-  values.
 */
 opt_field_length_default_sp_param_varchar:
-          /* empty */  { $$= (char*) "4000"; }
-        | field_length { $$= $1; }
+          /* empty */  { $$.set("4000", "4000"); }
+        | field_length { $$.set($1, NULL); }
 
 opt_field_length_default_sp_param_char:
-          /* empty */  { $$= (char*) "2000"; }
-        | field_length { $$= $1; }
+          /* empty */  { $$.set("2000", "2000"); }
+        | field_length { $$.set($1, NULL); }
 
 opt_precision:
           /* empty */    { $$.set(0, 0); }


### PR DESCRIPTION
I share this patch under term of MCA.