### PR TITLE
fix a data race in debug build

### DIFF
--- a/storage/innobase/include/sync0policy.h
+++ b/storage/innobase/include/sync0policy.h
@@ -52,7 +52,7 @@ public:
 			m_line(),
 			m_thread_id(os_thread_id_t(ULINT_UNDEFINED))
 		{
-			m_thread_id_mutex.init();
+			/* No op */
 		}
 
 		/** Create the context for SyncDebug
@@ -61,15 +61,7 @@ public:
 			:
 			latch_t(id)
 		{
-			m_thread_id_mutex.init();
-
 			ut_ad(id != LATCH_ID_NONE);
-		}
-
-		/** Destructor */
-		~Context()
-		{
-			m_thread_id_mutex.destroy();
 		}
 
 		/** Set to locked state
@@ -139,23 +131,13 @@ public:
 		/** Synchronized m_thread_id getter */
 		os_thread_id_t get_thread_id() const
 		{
-			m_thread_id_mutex.enter();
-
-			os_thread_id_t thread_id = m_thread_id;
-
-			m_thread_id_mutex.exit();
-
-			return thread_id;
+			return my_atomic_loadlong(&m_thread_id);
 		}
 
 		/** Synchronized m_thread_id setter */
 		void set_thread_id(os_thread_id_t thread_id)
 		{
-			m_thread_id_mutex.enter();
-
-			m_thread_id = thread_id;
-
-			m_thread_id_mutex.exit();
+                        my_atomic_storelong(&m_thread_id, thread_id);
 		}
 
 		/** Mutex to check for lock order violation */
@@ -168,12 +150,8 @@ public:
 		unsigned	m_line;
 
 	private:
-		/** Thread ID of the thread that own(ed) the mutex
-		Guarded by m_thread_id_mutex */
-		os_thread_id_t	m_thread_id;
-
-		/** Mutex to m_thread_id */
-		mutable OSMutex m_thread_id_mutex;
+		/** Thread ID of the thread that own(ed) the mutex */
+		ulint		m_thread_id;
 	};
 
 	/** Constructor. */

--- a/storage/innobase/include/sync0policy.h
+++ b/storage/innobase/include/sync0policy.h
@@ -161,7 +161,7 @@ public:
 
 		m_magic_n = 0;
 
-		my_atomic_storelint(&m_context.m_thread_id, 0);
+		m_context.m_thread_id = 0;
 	}
 
 	/** Called when the mutex is "created". Note: Not from the constructor

--- a/storage/innobase/include/sync0policy.ic
+++ b/storage/innobase/include/sync0policy.ic
@@ -80,7 +80,7 @@ void MutexDebug<Mutex>::locked(
 	UNIV_NOTHROW
 {
 	ut_ad(!is_owned());
-	ut_ad(get_thread_id() == os_thread_id_t(ULINT_UNDEFINED));
+	ut_ad(m_context.m_thread_id == ULINT_UNDEFINED);
 
 	m_context.locked(mutex, name, line);
 

--- a/storage/innobase/include/sync0policy.ic
+++ b/storage/innobase/include/sync0policy.ic
@@ -80,7 +80,7 @@ void MutexDebug<Mutex>::locked(
 	UNIV_NOTHROW
 {
 	ut_ad(!is_owned());
-	ut_ad(m_context.m_thread_id == os_thread_id_t(ULINT_UNDEFINED));
+	ut_ad(get_thread_id() == os_thread_id_t(ULINT_UNDEFINED));
 
 	m_context.locked(mutex, name, line);
 

--- a/storage/innobase/include/sync0types.h
+++ b/storage/innobase/include/sync0types.h
@@ -1163,10 +1163,12 @@ enum rw_lock_flag_t {
 #ifdef _WIN64
 #define my_atomic_addlint(A,B) my_atomic_add64((int64*) (A), (B))
 #define my_atomic_loadlint(A) my_atomic_load64((int64*) (A))
+#define my_atomic_storelint(A,B) my_atomic_store64((int64*) (A), (B))
 #define my_atomic_caslint(A,B,C) my_atomic_cas64((int64*) (A), (int64*) (B), (C))
 #else
 #define my_atomic_addlint my_atomic_addlong
 #define my_atomic_loadlint my_atomic_loadlong
+#define my_atomic_storelint my_atomic_storelong
 #define my_atomic_caslint my_atomic_caslong
 #endif
 


### PR DESCRIPTION
This particular one flooded TSAN report.

TSAN warnings reduced from 212 to 135 for `main.create` test.

It's a bit funny that code which supposed to be detecting threading bugs is racy itself.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.