### PR TITLE
MDEV-13909 Fix wsrep_sst_rsync fails on debian

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -244,18 +244,18 @@ parse_cnf()
     # finally get the variable value (if variables has been specified multiple time use the last value only)
 
     # look in group+suffix
-    if [[ -n $WSREP_SST_OPT_CONF_SUFFIX ]]; then
+    if [ -n $WSREP_SST_OPT_CONF_SUFFIX ]; then
         reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF "${group}${WSREP_SST_OPT_CONF_SUFFIX}" | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
     fi
 
     # look in group
-    if [[ -z $reval ]]; then
+    if [ -z $reval ]; then
         reval=$($MY_PRINT_DEFAULTS -c $WSREP_SST_OPT_CONF $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
     fi
 
     # use default if we haven't found a value
-    if [[ -z $reval ]]; then
-        [[ -n $3 ]] && reval=$3
+    if [ -z $reval ]; then
+        [ -n $3 ] && reval=$3
     fi
     echo $reval
 }


### PR DESCRIPTION
Fix for the following error messages during SST:
/usr/local/mysql/bin/wsrep_sst_rsync: 258: /usr/local/mysql/bin/wsrep_sst_rsync: [[: not found
/usr/local/mysql/bin/wsrep_sst_rsync: 263: /usr/local/mysql/bin/wsrep_sst_rsync: [[: not found
/usr/local/mysql/bin/wsrep_sst_rsync: 268: /usr/local/mysql/bin/wsrep_sst_rsync: [[: not found