### PR TITLE
fix some data races

### DIFF
--- a/storage/innobase/include/sync0rw.ic
+++ b/storage/innobase/include/sync0rw.ic
@@ -356,9 +356,13 @@ rw_lock_s_unlock_func(
 #endif /* UNIV_DEBUG */
 	rw_lock_t*	lock)	/*!< in/out: rw-lock */
 {
-	ut_ad(lock->lock_word > -X_LOCK_DECR);
-	ut_ad(lock->lock_word != 0);
-	ut_ad(lock->lock_word < X_LOCK_DECR);
+#ifdef UNIV_DEBUG
+	lint	dbg_lock_word = my_atomic_loadlint_explicit(
+			&lock->lock_word, MY_MEMORY_ORDER_RELAXED);
+#endif
+	ut_ad(dbg_lock_word > -X_LOCK_DECR);
+	ut_ad(dbg_lock_word != 0);
+	ut_ad(dbg_lock_word < X_LOCK_DECR);
 
 	ut_d(rw_lock_remove_debug_info(lock, pass, RW_LOCK_S));
 
@@ -411,7 +415,8 @@ rw_lock_x_unlock_func(
 		We need to signal read/write waiters.
 		We do not need to signal wait_ex waiters, since they cannot
 		exist when there is a writer. */
-		if (lock->waiters) {
+		if (my_atomic_load32_explicit(&lock->waiters,
+					      MY_MEMORY_ORDER_RELAXED)) {
 			my_atomic_store32((int32*) &lock->waiters, 0);
 			os_event_set(lock->event);
 			sync_array_object_signalled();

--- a/storage/innobase/include/sync0rw.ic
+++ b/storage/innobase/include/sync0rw.ic
@@ -359,10 +359,10 @@ rw_lock_s_unlock_func(
 #ifdef UNIV_DEBUG
 	lint	dbg_lock_word = my_atomic_loadlint_explicit(
 			&lock->lock_word, MY_MEMORY_ORDER_RELAXED);
-#endif
 	ut_ad(dbg_lock_word > -X_LOCK_DECR);
 	ut_ad(dbg_lock_word != 0);
 	ut_ad(dbg_lock_word < X_LOCK_DECR);
+#endif
 
 	ut_d(rw_lock_remove_debug_info(lock, pass, RW_LOCK_S));
 

--- a/storage/innobase/sync/sync0rw.cc
+++ b/storage/innobase/sync/sync0rw.cc
@@ -880,10 +880,12 @@ rw_lock_validate(
 
 	ut_ad(lock);
 
-	lock_word = lock->lock_word;
+	lock_word = my_atomic_loadlint_explicit(&lock->lock_word,
+						MY_MEMORY_ORDER_RELAXED);
 
 	ut_ad(lock->magic_n == RW_LOCK_MAGIC_N);
-	ut_ad(lock->waiters < 2);
+	ut_ad(my_atomic_load32_explicit(&lock->waiters,
+					MY_MEMORY_ORDER_RELAXED) < 2);
 	ut_ad(lock_word > -(2 * X_LOCK_DECR));
 	ut_ad(lock_word <= X_LOCK_DECR);
 


### PR DESCRIPTION
```
  Read of size 8 at 0x7b780000cf10 by thread T21:
    #0 rw_lock_validate(rw_lock_t const*) storage/innobase/sync/sync0rw.cc:883 (mysqld+0x0000012b0cea)
    #1 rw_lock_own(rw_lock_t*, unsigned long) storage/innobase/sync/sync0rw.cc:1022 (mysqld+0x0000012b144c)
    #2 buf_page_hash_get_low storage/innobase/include/buf0buf.ic:1091 (mysqld+0x0000013de005)
    #3 buf_page_get_gen(page_id_t const&, page_size_t const&, unsigned long, buf_block_t*, unsigned long, char const*, unsigned int, mtr_t*, dberr_t*) storage/innobase/buf/buf0buf.cc:4230 (mysqld+0x0000013f4ed4)
    #4 btr_cur_search_to_nth_level(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_cur_t*, unsigned long, char const*, unsigned int, mtr_t*, unsigned long) storage/innobase/btr/btr0cur.cc:1314 (mysqld+0x000001390acb)
    #5 btr_pcur_open_low storage/innobase/include/btr0pcur.ic:457 (mysqld+0x0000012167b7)
    #6 row_search_on_row_ref(btr_pcur_t*, unsigned long, dict_table_t const*, dtuple_t const*, mtr_t*) storage/innobase/row/row0row.cc:1030 (mysqld+0x00000121a3ac)
    #7 row_purge_reposition_pcur storage/innobase/row/row0purge.cc:103 (mysqld+0x00000120830b)
    #8 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:678 (mysqld+0x00000120a056)
    #9 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc44)
    #10 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf45)
    #11 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c49a)
    #12 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3ec)
    #13 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f798)
    #14 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa5c)
    #15 srv_task_execute storage/innobase/srv/srv0srv.cc:2580 (mysqld+0x00000129676b)
    #16 srv_worker_thread storage/innobase/srv/srv0srv.cc:2627 (mysqld+0x00000129694c)
    #17 <null> <null> (libtsan.so.0+0x000000025aab)

  Previous atomic write of size 8 at 0x7b780000cf10 by thread T22:
    #0 __tsan_atomic64_compare_exchange_strong <null> (libtsan.so.0+0x000000069d02)
    #1 rw_lock_lock_word_decr storage/innobase/include/sync0rw.ic:219 (mysqld+0x0000013d82f0)
    #2 rw_lock_s_lock_low storage/innobase/include/sync0rw.ic:243 (mysqld+0x0000013d835c)
    #3 rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:288 (mysqld+0x0000013d84f0)
    #4 pfs_rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:639 (mysqld+0x0000013d97bd)
    #5 buf_page_get_gen(page_id_t const&, page_size_t const&, unsigned long, buf_block_t*, unsigned long, char const*, unsigned int, mtr_t*, dberr_t*) storage/innobase/buf/buf0buf.cc:4206 (mysqld+0x0000013f4cb2)
    #6 btr_cur_search_to_nth_level(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_cur_t*, unsigned long, char const*, unsigned int, mtr_t*, unsigned long) storage/innobase/btr/btr0cur.cc:1314 (mysqld+0x000001390acb)
    #7 btr_pcur_open_low storage/innobase/include/btr0pcur.ic:457 (mysqld+0x0000012167b7)
    #8 row_search_on_row_ref(btr_pcur_t*, unsigned long, dict_table_t const*, dtuple_t const*, mtr_t*) storage/innobase/row/row0row.cc:1030 (mysqld+0x00000121a3ac)
    #9 row_purge_reposition_pcur storage/innobase/row/row0purge.cc:103 (mysqld+0x00000120830b)
    #10 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:678 (mysqld+0x00000120a056)
    #11 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc44)
    #12 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf45)
    #13 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c49a)
    #14 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3ec)
    #15 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f798)
    #16 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa5c)
    #17 srv_task_execute storage/innobase/srv/srv0srv.cc:2580 (mysqld+0x00000129676b)
    #18 srv_worker_thread storage/innobase/srv/srv0srv.cc:2627 (mysqld+0x00000129694c)
    #19 <null> <null> (libtsan.so.0+0x000000025aab)


WARNING: ThreadSanitizer: data race (pid=2759)
  Atomic write of size 4 at 0x7f41346a3080 by thread T20:
    #0 __tsan_atomic32_exchange <null> (libtsan.so.0+0x000000063f1f)
    #1 rw_lock_s_lock_spin(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:356 (mysqld+0x0000012af9e2)
    #2 rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:292 (mysqld+0x0000013d8513)
    #3 pfs_rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:639 (mysqld+0x0000013d97bf)
    #4 buf_page_get_gen(page_id_t const&, page_size_t const&, unsigned long, buf_block_t*, unsigned long, char const*, unsigned int, mtr_t*, dberr_t*) storage/innobase/buf/buf0buf.cc:4750 (mysqld+0x0000013f74f6)
    #5 btr_cur_search_to_nth_level(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_cur_t*, unsigned long, char const*, unsigned int, mtr_t*, unsigned long) storage/innobase/btr/btr0cur.cc:1314 (mysqld+0x000001390acd)
    #6 btr_pcur_open_low storage/innobase/include/btr0pcur.ic:457 (mysqld+0x0000012167b7)
    #7 row_search_on_row_ref(btr_pcur_t*, unsigned long, dict_table_t const*, dtuple_t const*, mtr_t*) storage/innobase/row/row0row.cc:1030 (mysqld+0x00000121a3ac)
    #8 row_purge_reposition_pcur storage/innobase/row/row0purge.cc:103 (mysqld+0x00000120830b)
    #9 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:678 (mysqld+0x00000120a056)
    #10 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc44)
    #11 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf45)
    #12 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c49a)
    #13 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3ec)
    #14 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f798)
    #15 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa5c)
    #16 srv_task_execute storage/innobase/srv/srv0srv.cc:2580 (mysqld+0x00000129676b)
    #17 srv_worker_thread storage/innobase/srv/srv0srv.cc:2627 (mysqld+0x00000129694c)
    #18 <null> <null> (libtsan.so.0+0x000000025aab)

  Previous read of size 4 at 0x7f41346a3080 by thread T19:
    #0 rw_lock_validate(rw_lock_t const*) storage/innobase/sync/sync0rw.cc:887 (mysqld+0x0000012b0d8f)
    #1 rw_lock_get_debug_info(rw_lock_t const*, std::vector<rw_lock_debug_t*, std::allocator<rw_lock_debug_t*> >*) storage/innobase/sync/sync0rw.cc:1058 (mysqld+0x0000012b164c)
    #2 rw_lock_own_flagged(rw_lock_t const*, unsigned long) storage/innobase/sync/sync0rw.cc:1088 (mysqld+0x0000012b17dd)
    #3 FindPage::operator()(mtr_memo_slot_t*) storage/innobase/mtr/mtr0mtr.cc:150 (mysqld+0x0000010d7b30)
    #4 Iterate<FindPage>::operator()(dyn_buf_t<512ul>::block_t*) storage/innobase/mtr/mtr0mtr.cc:66 (mysqld+0x0000010d93a0)
    #5 bool dyn_buf_t<512ul>::for_each_block_in_reverse<Iterate<FindPage> >(Iterate<FindPage>&) const storage/innobase/include/dyn0buf.h:367 (mysqld+0x0000010d8aab)
    #6 mtr_t::memo_contains_page_flagged(unsigned char const*, unsigned long) const storage/innobase/mtr/mtr0mtr.cc:1132 (mysqld+0x0000010d7040)
    #7 mtr_t::memo_modify_page(unsigned char const*) storage/innobase/mtr/mtr0mtr.cc:1142 (mysqld+0x0000010d70c8)
    #8 mlog_write_initial_log_record_fast storage/innobase/include/mtr0log.ic:226 (mysqld+0x0000010cc640)
    #9 mlog_log_string(unsigned char*, unsigned long, mtr_t*) storage/innobase/mtr/mtr0log.cc:345 (mysqld+0x0000010ce1ee)
    #10 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:726 (mysqld+0x00000120a75c)
    #11 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc44)
    #12 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf45)
    #13 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c49a)
    #14 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3ec)
    #15 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f798)
    #16 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa5c)
    #17 trx_purge(unsigned long, unsigned long, bool) storage/innobase/trx/trx0purge.cc:1666 (mysqld+0x0000012e1539)
    #18 srv_do_purge storage/innobase/srv/srv0srv.cc:2731 (mysqld+0x000001296ef4)
    #19 srv_purge_coordinator_thread storage/innobase/srv/srv0srv.cc:2876 (mysqld+0x000001297889)
    #20 <null> <null> (libtsan.so.0+0x000000025aab)



WARNING: ThreadSanitizer: data race (pid=2992)
  Atomic write of size 4 at 0x7fec1a0d5d50 by thread T19:
    #0 __tsan_atomic32_store <null> (libtsan.so.0+0x000000063261)
    #1 rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:415 (mysqld+0x0000010d07fa)
    #2 pfs_rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:779 (mysqld+0x0000010d0f32)
    #3 buf_page_release_latch storage/innobase/include/buf0buf.ic:1331 (mysqld+0x0000010d2b63)
    #4 memo_slot_release storage/innobase/mtr/mtr0mtr.cc:196 (mysqld+0x0000010d2dbd)
    #5 ReleaseAll::operator()(mtr_memo_slot_t*) const storage/innobase/mtr/mtr0mtr.cc:313 (mysqld+0x0000010d7dbc)
    #6 Iterate<ReleaseAll>::operator()(dyn_buf_t<512ul>::block_t*) storage/innobase/mtr/mtr0mtr.cc:66 (mysqld+0x0000010d949e)
    #7 bool dyn_buf_t<512ul>::for_each_block_in_reverse<Iterate<ReleaseAll> >(Iterate<ReleaseAll>&) const storage/innobase/include/dyn0buf.h:367 (mysqld+0x0000010d8c31)
    #8 mtr_t::Command::release_all() storage/innobase/mtr/mtr0mtr.cc:917 (mysqld+0x0000010d63e2)
    #9 mtr_t::commit() storage/innobase/mtr/mtr0mtr.cc:574 (mysqld+0x0000010d3c14)
    #10 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:732 (mysqld+0x00000120a76b)
    #11 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc44)
    #12 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf45)
    #13 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c49a)
    #14 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3ec)
    #15 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f798)
    #16 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa5c)
    #17 trx_purge(unsigned long, unsigned long, bool) storage/innobase/trx/trx0purge.cc:1666 (mysqld+0x0000012e153d)
    #18 srv_do_purge storage/innobase/srv/srv0srv.cc:2731 (mysqld+0x000001296ef4)
    #19 srv_purge_coordinator_thread storage/innobase/srv/srv0srv.cc:2876 (mysqld+0x000001297889)
    #20 <null> <null> (libtsan.so.0+0x000000025aab)

  Previous read of size 4 at 0x7fec1a0d5d50 by thread T21:
    #0 rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:414 (mysqld+0x0000010d07cc)
    #1 pfs_rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:779 (mysqld+0x0000010d0f32)
    #2 buf_page_release_latch storage/innobase/include/buf0buf.ic:1331 (mysqld+0x0000010d2b63)
    #3 memo_slot_release storage/innobase/mtr/mtr0mtr.cc:196 (mysqld+0x0000010d2dbd)
    #4 ReleaseAll::operator()(mtr_memo_slot_t*) const storage/innobase/mtr/mtr0mtr.cc:313 (mysqld+0x0000010d7dbc)
    #5 Iterate<ReleaseAll>::operator()(dyn_buf_t<512ul>::block_t*) storage/innobase/mtr/mtr0mtr.cc:66 (mysqld+0x0000010d949e)
    #6 bool dyn_buf_t<512ul>::for_each_block_in_reverse<Iterate<ReleaseAll> >(Iterate<ReleaseAll>&) const storage/innobase/include/dyn0buf.h:367 (mysqld+0x0000010d8c31)
    #7 mtr_t::Command::release_all() storage/innobase/mtr/mtr0mtr.cc:917 (mysqld+0x0000010d63e2)
    #8 mtr_t::commit() storage/innobase/mtr/mtr0mtr.cc:574 (mysqld+0x0000010d3c14)
    #9 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:732 (mysqld+0x00000120a76b)
    #10 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc44)
    #11 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf45)
    #12 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c49a)
    #13 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3ec)
    #14 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f798)
    #15 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa5c)
    #16 srv_task_execute storage/innobase/srv/srv0srv.cc:2580 (mysqld+0x00000129676b)
    #17 srv_worker_thread storage/innobase/srv/srv0srv.cc:2627 (mysqld+0x00000129694c)
    #18 <null> <null> (libtsan.so.0+0x000000025aab)


WARNING: ThreadSanitizer: data race (pid=7240)
  Read of size 8 at 0x7f2978ca2b48 by thread T19:
    #0 rw_lock_s_unlock_func storage/innobase/include/sync0rw.ic:359 (mysqld+0x000001347e0e)
    #1 pfs_rw_lock_s_unlock_func storage/innobase/include/sync0rw.ic:834 (mysqld+0x000001348c5c)
    #2 buf_page_release_latch storage/innobase/include/buf0buf.ic:1322 (mysqld+0x00000134b67b)
    #3 mtr_t::release_block_at_savepoint(unsigned long, buf_block_t*) storage/innobase/include/mtr0mtr.ic:175 (mysqld+0x00000136c1fb)
    #4 btr_cur_search_to_nth_level(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_cur_t*, unsigned long, char const*, unsigned int, mtr_t*, unsigned long) storage/innobase/btr/btr0cur.cc:1494 (mysqld+0x000001391975)
    #5 btr_pcur_open_low storage/innobase/include/btr0pcur.ic:457 (mysqld+0x0000012167a5)
    #6 row_search_on_row_ref(btr_pcur_t*, unsigned long, dict_table_t const*, dtuple_t const*, mtr_t*) storage/innobase/row/row0row.cc:1030 (mysqld+0x00000121a39a)
    #7 row_purge_reposition_pcur storage/innobase/row/row0purge.cc:103 (mysqld+0x0000012082f9)
    #8 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:678 (mysqld+0x00000120a044)
    #9 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc32)
    #10 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf33)
    #11 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c488)
    #12 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3e0)
    #13 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f78c)
    #14 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa50)
    #15 trx_purge(unsigned long, unsigned long, bool) storage/innobase/trx/trx0purge.cc:1666 (mysqld+0x0000012e151f)
    #16 srv_do_purge storage/innobase/srv/srv0srv.cc:2731 (mysqld+0x000001296eda)
    #17 srv_purge_coordinator_thread storage/innobase/srv/srv0srv.cc:2876 (mysqld+0x00000129786f)
    #18 <null> <null> (libtsan.so.0+0x000000025aab)

  Previous atomic write of size 8 at 0x7f2978ca2b48 by thread T21:
    #0 __tsan_atomic64_compare_exchange_strong <null> (libtsan.so.0+0x000000069d02)
    #1 rw_lock_lock_word_decr storage/innobase/include/sync0rw.ic:219 (mysqld+0x0000013d82d0)
    #2 rw_lock_s_lock_low storage/innobase/include/sync0rw.ic:243 (mysqld+0x0000013d833c)
    #3 pfs_rw_lock_s_lock_low storage/innobase/include/sync0rw.ic:713 (mysqld+0x0000013d9a91)
    #4 buf_page_get_gen(page_id_t const&, page_size_t const&, unsigned long, buf_block_t*, unsigned long, char const*, unsigned int, mtr_t*, dberr_t*) storage/innobase/buf/buf0buf.cc:4696 (mysqld+0x0000013f70f4)
    #5 btr_cur_search_to_nth_level(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_cur_t*, unsigned long, char const*, unsigned int, mtr_t*, unsigned long) storage/innobase/btr/btr0cur.cc:1314 (mysqld+0x000001390aaf)
    #6 btr_pcur_open_low storage/innobase/include/btr0pcur.ic:457 (mysqld+0x0000012167a5)
    #7 row_search_on_row_ref(btr_pcur_t*, unsigned long, dict_table_t const*, dtuple_t const*, mtr_t*) storage/innobase/row/row0row.cc:1030 (mysqld+0x00000121a39a)
    #8 row_purge_reposition_pcur storage/innobase/row/row0purge.cc:103 (mysqld+0x0000012082f9)
    #9 row_purge_reset_trx_id storage/innobase/row/row0purge.cc:678 (mysqld+0x00000120a044)
    #10 row_purge_record_func storage/innobase/row/row0purge.cc:1056 (mysqld+0x00000120bc32)
    #11 row_purge storage/innobase/row/row0purge.cc:1105 (mysqld+0x00000120bf33)
    #12 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1184 (mysqld+0x00000120c488)
    #13 que_thr_step storage/innobase/que/que0que.cc:1054 (mysqld+0x00000113f3e0)
    #14 que_run_threads_low storage/innobase/que/que0que.cc:1116 (mysqld+0x00000113f78c)
    #15 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1156 (mysqld+0x00000113fa50)
    #16 srv_task_execute storage/innobase/srv/srv0srv.cc:2580 (mysqld+0x000001296751)
    #17 srv_worker_thread storage/innobase/srv/srv0srv.cc:2627 (mysqld+0x000001296932)
    #18 <null> <null> (libtsan.so.0+0x000000025aab)
```

I hope relaxed operations should be ok in these cases.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.