### PR TITLE
Fix misuse of MY_CHECK_CXX_COMPILER_FLAG in storage/innobase/innodb.c…

### DIFF
--- a/storage/innobase/innodb.cmake
+++ b/storage/innobase/innodb.cmake
@@ -245,8 +245,8 @@ ENDIF()
 # Avoid generating Hardware Capabilities due to crc32 instructions
 IF(CMAKE_SYSTEM_NAME MATCHES "SunOS" AND CMAKE_SYSTEM_PROCESSOR MATCHES "i386")
   INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/compile_flags.cmake)
-  MY_CHECK_CXX_COMPILER_FLAG("-Wa,-nH" HAVE_WA_NH)
-  IF(HAVE_WA_NH)
+  MY_CHECK_CXX_COMPILER_FLAG("-Wa,-nH" hava_CXX__Wa__nH)
+  IF(hava_CXX__Wa__nH)
     ADD_COMPILE_FLAGS(
       ut/ut0crc32.cc
       COMPILE_FLAGS "-Wa,-nH"


### PR DESCRIPTION
MY_CHECK_CXX_COMPILER_FLAG is used incorrectly in in storage/innobase/innodb.cmake#248

```
MY_CHECK_CXX_COMPILER_FLAG("-Wa,-nH" HAVE_WA_NH)
```

definition of MY_CHECK_CXX_COMPILER_FLAG in cmake/check_compiler_flag.cmake says that result variable should in the form of `hava_CXX_*`
```
MACRO (MY_CHECK_CXX_COMPILER_FLAG flag)
  STRING(REGEX REPLACE "[-,= +]" "_" result "have_CXX_${flag}")
  SET(SAVE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
  SET(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${flag}")
  CHECK_CXX_SOURCE_COMPILES("int main(void) { return 0; }" ${result}
    ${fail_patterns})
  SET(CMAKE_REQUIRED_FLAGS "${SAVE_CMAKE_REQUIRED_FLAGS}")
ENDMACRO()
```
