### PR TITLE
fix data races

### DIFF
--- a/storage/innobase/include/sync0rw.ic
+++ b/storage/innobase/include/sync0rw.ic
@@ -393,17 +393,21 @@ rw_lock_x_unlock_func(
 #endif /* UNIV_DEBUG */
 	rw_lock_t*	lock)	/*!< in/out: rw-lock */
 {
-	ut_ad(lock->lock_word == 0 || lock->lock_word == -X_LOCK_HALF_DECR
-	      || lock->lock_word <= -X_LOCK_DECR);
+	lint	lock_word;
+	lock_word = my_atomic_loadlint_explicit(&lock->lock_word,
+						MY_MEMORY_ORDER_RELAXED);
 
-	if (lock->lock_word == 0) {
+	ut_ad(lock_word == 0 || lock_word == -X_LOCK_HALF_DECR
+	      || lock_word <= -X_LOCK_DECR);
+
+	if (lock_word == 0) {
 		/* Last caller in a possible recursive chain. */
 		lock->writer_thread = 0;
 	}
 
 	ut_d(rw_lock_remove_debug_info(lock, pass, RW_LOCK_X));
 
-	if (lock->lock_word == 0 || lock->lock_word == -X_LOCK_HALF_DECR) {
+	if (lock_word == 0 || lock_word == -X_LOCK_HALF_DECR) {
 		/* There is 1 x-lock */
 		/* atomic increment is needed, because it is last */
 		if (my_atomic_addlint(&lock->lock_word, X_LOCK_DECR) <= -X_LOCK_DECR) {
@@ -421,13 +425,13 @@ rw_lock_x_unlock_func(
 			os_event_set(lock->event);
 			sync_array_object_signalled();
 		}
-	} else if (lock->lock_word == -X_LOCK_DECR
-		   || lock->lock_word == -(X_LOCK_DECR + X_LOCK_HALF_DECR)) {
+	} else if (lock_word == -X_LOCK_DECR
+		   || lock_word == -(X_LOCK_DECR + X_LOCK_HALF_DECR)) {
 		/* There are 2 x-locks */
 		lock->lock_word += X_LOCK_DECR;
 	} else {
 		/* There are more than 2 x-locks. */
-		ut_ad(lock->lock_word < -X_LOCK_DECR);
+		ut_ad(lock_word < -X_LOCK_DECR);
 		lock->lock_word += 1;
 	}
 

--- a/storage/innobase/sync/sync0rw.cc
+++ b/storage/innobase/sync/sync0rw.cc
@@ -310,7 +310,9 @@ lock_loop:
 
 	/* Spin waiting for the writer field to become free */
 	HMT_low();
-	while (i < srv_n_spin_wait_rounds && lock->lock_word <= 0) {
+	while (i < srv_n_spin_wait_rounds &&
+	       my_atomic_loadlint_explicit(&lock->lock_word,
+					   MY_MEMORY_ORDER_RELAXED) <= 0) {
 		if (srv_spin_wait_delay) {
 			ut_delay(ut_rnd_interval(0, srv_spin_wait_delay));
 		}


### PR DESCRIPTION
Another set of races.

```
WARNING: ThreadSanitizer: data race (pid=1174)
  Atomic write of size 8 at 0x7b5c00000648 by thread T3:
    #0 __tsan_atomic64_fetch_add <null>
    #1 rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:409
    #2 pfs_rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:784
    #3 log_complete_checkpoint storage/innobase/log/log0log.cc:1450
    #4 log_io_complete_checkpoint storage/innobase/log/log0log.cc:1467
    #5 log_io_complete(log_group_t*) storage/innobase/log/log0log.cc:844
    #6 fil_aio_wait(unsigned long) storage/innobase/fil/fil0fil.cc:5490
    #7 io_handler_thread storage/innobase/srv/srv0start.cc:340
    #8 <null> <null>

  Previous read of size 8 at 0x7b5c00000648 by main thread:
    #0 rw_lock_s_lock_spin(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:313
    #1 rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:292
    #2 pfs_rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:644
    #3 log_write_checkpoint_info(bool, unsigned long) storage/innobase/log/log0log.cc:1584
    #4 log_checkpoint(bool, bool) storage/innobase/log/log0log.cc:1733
    #5 log_make_checkpoint_at(unsigned long, bool) storage/innobase/log/log0log.cc:1755
    #6 recv_reset_logs(unsigned long) storage/innobase/log/log0recv.cc:3544
    #7 create_log_files storage/innobase/srv/srv0start.cc:512
    #8 innobase_start_or_create_for_mysql() storage/innobase/srv/srv0start.cc:1959
    #9 innobase_init storage/innobase/handler/ha_innodb.cc:4151
    #10 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:521
    #11 plugin_initialize sql/sql_plugin.cc:1440
    #12 plugin_init(int*, char**, int) sql/sql_plugin.cc:1722
    #13 init_server_components sql/mysqld.cc:5337
    #14 mysqld_main(int, char**) sql/mysqld.cc:5932
    #15 main sql/main.cc:25

  Location is heap block of size 848 at 0x7b5c00000380 allocated by main thread:
    #0 calloc <null>
    #1 log_sys_init() storage/innobase/log/log0log.cc:709
    #2 innobase_start_or_create_for_mysql() storage/innobase/srv/srv0start.cc:1849
    #3 innobase_init storage/innobase/handler/ha_innodb.cc:4151
    #4 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:521
    #5 plugin_initialize sql/sql_plugin.cc:1440
    #6 plugin_init(int*, char**, int) sql/sql_plugin.cc:1722
    #7 init_server_components sql/mysqld.cc:5337
    #8 mysqld_main(int, char**) sql/mysqld.cc:5932
    #9 main sql/main.cc:25

  Thread T3 (tid=1183, running) created by main thread at:
    #0 pthread_create <null>
    #1 os_thread_create_func(void* (*)(void*), void*, unsigned long*) storage/innobase/os/os0thread.cc:137
    #2 innobase_start_or_create_for_mysql() storage/innobase/srv/srv0start.cc:1860
    #3 innobase_init storage/innobase/handler/ha_innodb.cc:4151
    #4 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:521
    #5 plugin_initialize sql/sql_plugin.cc:1440
    #6 plugin_init(int*, char**, int) sql/sql_plugin.cc:1722
    #7 init_server_components sql/mysqld.cc:5337
    #8 mysqld_main(int, char**) sql/mysqld.cc:5932
    #9 main sql/main.cc:25


WARNING: ThreadSanitizer: data race (pid=3591)
  Atomic write of size 8 at 0x7b5c00000648 by thread T3:
    #0 __tsan_atomic64_fetch_add <null> (libtsan.so.0+0x000000064f10)
    #1 rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:413 (mysqld+0x000000c2f8ce)
    #2 pfs_rw_lock_x_unlock_func storage/innobase/include/sync0rw.ic:788 (mysqld+0x000000c2f8ce)
    #3 log_complete_checkpoint storage/innobase/log/log0log.cc:1450 (mysqld+0x000000c2f8ce)
    #4 log_io_complete_checkpoint storage/innobase/log/log0log.cc:1467 (mysqld+0x000000c2f8ce)
    #5 log_io_complete(log_group_t*) storage/innobase/log/log0log.cc:844 (mysqld+0x000000c2f8ce)
    #6 fil_aio_wait(unsigned long) storage/innobase/fil/fil0fil.cc:5490 (mysqld+0x000000ebe9ed)
    #7 io_handler_thread storage/innobase/srv/srv0start.cc:340 (mysqld+0x000000d547af)
    #8 <null> <null> (libtsan.so.0+0x000000025aab)

  Previous read of size 8 at 0x7b5c00000648 by main thread:
    #0 rw_lock_s_lock_spin(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:313 (mysqld+0x000000d62517)
    #1 rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:292 (mysqld+0x000000c341dd)
    #2 pfs_rw_lock_s_lock_func storage/innobase/include/sync0rw.ic:648 (mysqld+0x000000c341dd)
    #3 log_write_checkpoint_info(bool, unsigned long) storage/innobase/log/log0log.cc:1584 (mysqld+0x000000c341dd)
    #4 log_checkpoint(bool, bool) storage/innobase/log/log0log.cc:1733 (mysqld+0x000000c34d89)
    #5 log_make_checkpoint_at(unsigned long, bool) storage/innobase/log/log0log.cc:1755 (mysqld+0x000000c356ab)
    #6 recv_reset_logs(unsigned long) storage/innobase/log/log0recv.cc:3544 (mysqld+0x000000c3fa96)
    #7 create_log_files storage/innobase/srv/srv0start.cc:512 (mysqld+0x000000d555aa)
    #8 innobase_start_or_create_for_mysql() storage/innobase/srv/srv0start.cc:1959 (mysqld+0x000000d5b3a2)
    #9 innobase_init storage/innobase/handler/ha_innodb.cc:4151 (mysqld+0x000000bbdf3f)
    #10 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:521 (mysqld+0x0000008e7e2c)
    #11 plugin_initialize sql/sql_plugin.cc:1440 (mysqld+0x0000005c00aa)
    #12 plugin_init(int*, char**, int) sql/sql_plugin.cc:1722 (mysqld+0x0000005c1c15)
    #13 init_server_components sql/mysqld.cc:5337 (mysqld+0x00000049e117)
    #14 mysqld_main(int, char**) sql/mysqld.cc:5932 (mysqld+0x0000004a6b5c)
    #15 main sql/main.cc:25 (mysqld+0x00000047198e)

  Location is heap block of size 848 at 0x7b5c00000380 allocated by main thread:
    #0 calloc <null> (libtsan.so.0+0x0000000282a6)
    #1 log_sys_init() storage/innobase/log/log0log.cc:709 (mysqld+0x000000c3d562)
    #2 innobase_start_or_create_for_mysql() storage/innobase/srv/srv0start.cc:1849 (mysqld+0x000000d5a1da)
    #3 innobase_init storage/innobase/handler/ha_innodb.cc:4151 (mysqld+0x000000bbdf3f)
    #4 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:521 (mysqld+0x0000008e7e2c)
    #5 plugin_initialize sql/sql_plugin.cc:1440 (mysqld+0x0000005c00aa)
    #6 plugin_init(int*, char**, int) sql/sql_plugin.cc:1722 (mysqld+0x0000005c1c15)
    #7 init_server_components sql/mysqld.cc:5337 (mysqld+0x00000049e117)
    #8 mysqld_main(int, char**) sql/mysqld.cc:5932 (mysqld+0x0000004a6b5c)
    #9 main sql/main.cc:25 (mysqld+0x00000047198e)

  Thread T3 (tid=3596, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.0+0x0000000290c3)
    #1 os_thread_create_func(void* (*)(void*), void*, unsigned long*) storage/innobase/os/os0thread.cc:137 (mysqld+0x000000c66bc7)
    #2 innobase_start_or_create_for_mysql() storage/innobase/srv/srv0start.cc:1860 (mysqld+0x000000d5a24f)
    #3 innobase_init storage/innobase/handler/ha_innodb.cc:4151 (mysqld+0x000000bbdf3f)
    #4 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:521 (mysqld+0x0000008e7e2c)
    #5 plugin_initialize sql/sql_plugin.cc:1440 (mysqld+0x0000005c00aa)
    #6 plugin_init(int*, char**, int) sql/sql_plugin.cc:1722 (mysqld+0x0000005c1c15)
    #7 init_server_components sql/mysqld.cc:5337 (mysqld+0x00000049e117)
    #8 mysqld_main(int, char**) sql/mysqld.cc:5932 (mysqld+0x0000004a6b5c)
    #9 main sql/main.cc:25 (mysqld+0x00000047198e)
```

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.