### PR TITLE
SQL: thd_start_utime() fix

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4724,7 +4724,7 @@ extern "C" int thd_rpl_is_parallel(const MYSQL_THD thd)
   of the current query. */
 extern "C" unsigned long long thd_start_utime(const MYSQL_THD thd)
 {
-  return thd->start_utime;
+  return thd->start_time * 1000000 + thd->start_time_sec_part;
 }
 
 


### PR DESCRIPTION
Using start_utime is wrong, because it is `my_interval_timer()` which is
time since unspecified (but always the same) point in the past.

See comment for `my_interval_timer()`:

> The value is not anchored to any specific point in time (e.g. epoch) nor
is it subject to resetting or drifting by way of adjtime() or settimeofday(),
and thus it is *NOT* appropriate for getting the current timestamp. It can be
used for calculating time intervals, though.

@vaintroub Vladislav, please review.