### PR TITLE
MDEV-14207: mysql innodb_gis test fixes

### DIFF
--- a/mysql-test/suite/innodb_gis/t/rtree_compress.test
+++ b/mysql-test/suite/innodb_gis/t/rtree_compress.test
@@ -5,7 +5,7 @@
 --source include/not_embedded.inc
 
 --source include/have_innodb.inc
---source include/have_innodb_zip.inc
+--source include/innodb_page_size_small.inc
 --source include/have_debug.inc
 --source include/big_test.inc
 # Valgrind takes too much time on PB2 even in the --big-test runs.

--- a/mysql-test/suite/innodb_gis/t/rtree_compress2.test
+++ b/mysql-test/suite/innodb_gis/t/rtree_compress2.test
@@ -5,7 +5,7 @@
 --source include/not_embedded.inc
 
 --source include/have_innodb.inc
---source include/have_innodb_zip.inc
+--source include/innodb_page_size_small.inc
 --source include/big_test.inc
 # Valgrind takes too much time on PB2 even in the --big-test runs.
 --source include/not_valgrind.inc

--- a/mysql-test/suite/innodb_gis/t/rtree_purge.test
+++ b/mysql-test/suite/innodb_gis/t/rtree_purge.test
@@ -4,7 +4,7 @@
 --source include/not_embedded.inc
 
 --source include/have_innodb.inc
---source include/have_innodb_zip.inc
+--source include/innodb_page_size_small.inc
 --source include/have_debug.inc
 --source include/big_test.inc
 # Valgrind takes too much time on PB2 even in the --big-test runs.

--- a/mysql-test/suite/innodb_gis/t/rtree_purge.test
+++ b/mysql-test/suite/innodb_gis/t/rtree_purge.test
@@ -45,7 +45,7 @@ delimiter ;|
 
 call p(200);
 
---source include/wait_all_purged.inc
+--source ../../innodb/include/wait_all_purged.inc
 
 # Clean up.
 drop procedure p;

--- a/mysql-test/unstable-tests
+++ b/mysql-test/unstable-tests
@@ -258,15 +258,15 @@ innodb_gis.bug17057168               : Added in 10.2.10
 innodb_gis.geometry                  : Added in 10.2.10
 innodb_gis.gis_split_inf             : Added in 10.2.10
 innodb_gis.gis_split_nan             : Added in 10.2.10
-innodb_gis.kill_server               : Added in 10.2.10
+innodb_gis.kill_server               : Added in 10.2.10 - MDEV-14218 - Assertion Failure
 innodb_gis.multi_pk                  : Added in 10.2.10
 innodb_gis.point_basic               : Added in 10.2.10
 innodb_gis.point_big                 : Added in 10.2.10
 innodb_gis.repeatable_spatial        : Added in 10.2.10
 innodb_gis.rollback                  : Added in 10.2.10
 innodb_gis.row_format                : Added in 10.2.10
-innodb_gis.rtree_compress            : MDEV-14207 - Missing include; added in 10.2.10
-innodb_gis.rtree_compress2           : MDEV-14207 - Missing include; added in 10.2.10
+innodb_gis.rtree_compress            : Modified in 10.2.11
+innodb_gis.rtree_compress2           : MDEV-14227 - Assertion failure (same as MDEV-14218?)
 innodb_gis.rtree_concurrent_srch     : Added in 10.2.10
 innodb_gis.rtree_create_inplace      : Added in 10.2.10
 innodb_gis.rtree_debug               : MDEV-14209 - Huge error log; added in 10.2.10
@@ -274,7 +274,7 @@ innodb_gis.rtree_drop_index          : Added in 10.2.10
 innodb_gis.rtree_estimate            : Added in 10.2.10
 innodb_gis.rtree_multi_pk            : Added in 10.2.10
 innodb_gis.rtree_old                 : Added in 10.2.10
-innodb_gis.rtree_purge               : MDEV-14207 - Missing include; added in 10.2.10
+innodb_gis.rtree_purge               : Modified in 10.2.11
 innodb_gis.rtree_recovery            : Added in 10.2.10
 innodb_gis.rtree_rollback1           : Added in 10.2.10
 innodb_gis.rtree_rollback2           : Added in 10.2.10


### PR DESCRIPTION
@janlindstrom - missed a file

Copied straight from MySQL.

used by:
$ git grep -l  have_innodb_zip.inc
mysql-test/suite/innodb_gis/t/rtree_compress.test
mysql-test/suite/innodb_gis/t/rtree_compress2.test
mysql-test/suite/innodb_gis/t/rtree_purge.test
