### PR TITLE
travis: osx - xcode 8.3 -> 9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ language: cpp
 os:
   - linux
   - osx
-osx_image: xcode8.3
+osx_image: xcode9.1
 compiler:
   - gcc
   - clang


### PR DESCRIPTION
Doesn't actually fix any OSX test failures. Shows a few new warnings and doesn't compile fail.

I submit this under the MCA.