### PR TITLE
mysys: Remove freebsd freopen implementation - not relevant to stable releases

### DIFF
--- a/mysys/my_fopen.c
+++ b/mysys/my_fopen.c
@@ -19,10 +19,6 @@
 #include <errno.h>
 #include "mysys_err.h"
 
-#if defined(__FreeBSD__)
-extern int getosreldate(void);
-#endif
-
 static void make_ftype(char * to,int flag);
 
 /*
@@ -130,52 +126,6 @@ static FILE *my_win_freopen(const char *path, const char *mode, FILE *stream)
   return stream;
 }
 
-#elif defined(__FreeBSD__)
-
-/* No close operation hook. */
-
-static int no_close(void *cookie __attribute__((unused)))
-{
-  return 0;
-}
-
-/*
-  A hack around a race condition in the implementation of freopen.
-
-  The race condition stems from the fact that the current fd of
-  the stream is closed before its number is used to duplicate the
-  new file descriptor. This defeats the desired atomicity of the
-  close and duplicate of dup2().
-
-  See PR number 79887 for reference:
-  http://www.freebsd.org/cgi/query-pr.cgi?pr=79887
-*/
-
-static FILE *my_freebsd_freopen(const char *path, const char *mode, FILE *stream)
-{
-  int old_fd;
-  FILE *result;
-
-  flockfile(stream);
-
-  old_fd= fileno(stream);
-
-  /* Use a no operation close hook to avoid having the fd closed. */
-  stream->_close= no_close;
-
-  /* Relies on the implicit dup2 to close old_fd. */
-  result= freopen(path, mode, stream);
-
-  /* If successful, the _close hook was replaced. */
-
-  if (result == NULL)
-    close(old_fd);
-  else
-    funlockfile(result);
-
-  return result;
-}
-
 #endif
 
 
@@ -199,16 +149,6 @@ FILE *my_freopen(const char *path, const char *mode, FILE *stream)
 
 #if defined(_WIN32)
   result= my_win_freopen(path, mode, stream);
-#elif defined(__FreeBSD__)
-  /*
-    XXX: Once the fix is ported to the stable releases, this should
-         be dependent upon the specific FreeBSD versions. Check at:
-         http://www.freebsd.org/cgi/query-pr.cgi?pr=79887
-  */
-  if (getosreldate() > 900027)
-    result= freopen(path, mode, stream);
-  else
-    result= my_freebsd_freopen(path, mode, stream);
 #else
   result= freopen(path, mode, stream);
 #endif


### PR DESCRIPTION
my_freebsd_freopen was added in 998065c3a6f3 on January 2011

It was added because of https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=79887 which
was fixed in 7.4 and 8.2.

Both of these reached end of life in February 2011
https://www.freebsd.org/releases/

FYI @Sp1l

I submit the code removal under the MCA.