### PR TITLE
MDEV-14528 - Track master timestamp in case rolling back to serial replication

### DIFF
--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -3953,6 +3953,14 @@ static int exec_relay_log_event(THD* thd, Relay_log_info* rli,
       */
       if (res == 0)
         rli->event_relay_log_pos= rli->future_event_relay_log_pos;
+      /*
+        If we rolled back to serial execution. Then write master timestamp as usual.
+      */
+      if (res < 0 && !(ev->is_artificial_event() || ev->is_relay_log_event() || (ev->when == 0)))
+      {
+        rli->last_master_timestamp= ev->when + (time_t) ev->exec_time;
+        DBUG_ASSERT(rli->last_master_timestamp >= 0);
+      }
       if (res >= 0)
         DBUG_RETURN(res);
       /*


### PR DESCRIPTION
I tried to switch on parallel replication from Amazon Aurora to MariaDB. 

[my.cnf]
slave-parallel-threads = 4
slave-parallel-mode    = optimistic

+ 'set global <connection>.slave_parallel_mode=optimistic;'

As I understand now it doesn't have sense because it's rolling back to serial replication. But it introduces a silent problem with Seconds_behind_master. This value always = 0.

So, probably, would be good to keep this metric even in this unnatural but working mode.