### PR TITLE
MDEV-14374 - This patch is used to remove the hardware barrier specified in UT_REA…

### DIFF
--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -77,8 +77,8 @@ typedef time_t	ib_time_t;
 # define UT_RELAX_CPU() do { \
      volatile int32	volatile_var; \
      int32 oldval= 0; \
-     my_atomic_cas32(&volatile_var, &oldval, 1); \
-   } while (0)
+     my_atomic_cas32_strong_explicit(&volatile_var, &oldval, 1, MY_MEMORY_ORDER_RELAXED, MY_MEMORY_ORDER_RELAXED);\   
+} while (0)
 #endif
 
 #if defined (__GNUC__)


### PR DESCRIPTION
…LAX_CPU for arm architecture.

The new code now uses the memory order as ATOMIC_RELAX instead of acqire/release.