### PR TITLE
FRM: fail to load extra2 option with size 1 fix

### DIFF
--- a/sql/table.cc
+++ b/sql/table.cc
@@ -1226,7 +1226,7 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
   if (*extra2 != '/')   // old frm had '/' there
   {
     const uchar *e2end= extra2 + len;
-    while (extra2 + 3 < e2end)
+    while (extra2 + 3 <= e2end)
     {
       uchar type= *extra2++;
       size_t length= *extra2++;


### PR DESCRIPTION
From comment in unreg.h:
```
  Types of values in the MariaDB extra2 frm segment.
  Each value is written as
    type:       1 byte
    length:     1 byte  (1..255) or \0 and 2 bytes.
    binary value of the 'length' bytes.
```
length == 1 is valid.

Please, review and merge.