### PR TITLE
Remove use of volatile in stored_field_cmp_to_item

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -8919,15 +8919,10 @@ int stored_field_cmp_to_item(THD *thd, Field *field, Item *item)
     }
     return my_time_compare(&field_time, &item_time);
   }
-  /*
-    The patch for Bug#13463415 started using this function for comparing
-    BIGINTs. That uncovered a bug in Visual Studio 32bit optimized mode.
-    Prefixing the auto variables with volatile fixes the problem....
-  */
-  volatile double result= item->val_real();
+  double result= item->val_real();
   if (item->null_value)
     return 0;
-  volatile double field_result= field->val_real();
+  double field_result= field->val_real();
   if (field_result < result)
     return -1;
   else if (field_result > result)


### PR DESCRIPTION
This was added in c79641594348 but would hurt all other compilers because of Visual Studio. Hopefully this has been fixed now.

As groaned at by @cvicentiu and as covered recently by @svoj, volatile is for memory hardware devices and isn't a toy.

I submit this code and comment removal under the MCA.