### PR TITLE
MDEV-15838 - item_cmp_type: simplier for a faster codepath

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -8712,13 +8712,11 @@ void Item_trigger_field::cleanup()
 
 Item_result item_cmp_type(Item_result a,Item_result b)
 {
-  if (a == STRING_RESULT && b == STRING_RESULT)
-    return STRING_RESULT;
-  if (a == INT_RESULT && b == INT_RESULT)
-    return INT_RESULT;
-  else if (a == ROW_RESULT || b == ROW_RESULT)
+  if (a == b)
+    return a;
+  if (a == ROW_RESULT || b == ROW_RESULT)
     return ROW_RESULT;
-  else if (a == TIME_RESULT || b == TIME_RESULT)
+  if (a == TIME_RESULT || b == TIME_RESULT)
     return TIME_RESULT;
   if ((a == INT_RESULT || a == DECIMAL_RESULT) &&
       (b == INT_RESULT || b == DECIMAL_RESULT))


### PR DESCRIPTION
The common case for this function is that both types are the same.

The Item_result defination from include/mysql.h.pp is the following enum
   enum Item_result
   {
     STRING_RESULT=0, REAL_RESULT, INT_RESULT, ROW_RESULT, DECIMAL_RESULT,
     TIME_RESULT
   };

The compilers aren't quite smart enough to optimize to this shortcut so
this makes it quicker.

Before the change:

0000000000012730 <item_cmp_type(Item_result, Item_result)>:
   12730:       89 f0                   mov    %esi,%eax
   12732:       09 f8                   or     %edi,%eax
   12734:       74 4c                   je     12782 <item_cmp_type(Item_result, Item_result)+0x52>
   12736:       83 ff 02                cmp    $0x2,%edi
   12739:       75 0a                   jne    12745 <item_cmp_type(Item_result, Item_result)+0x15>
   1273b:       b8 02 00 00 00          mov    $0x2,%eax
   12740:       83 fe 02                cmp    $0x2,%esi
   12743:       74 3c                   je     12781 <item_cmp_type(Item_result, Item_result)+0x51>
   12745:       83 ff 03                cmp    $0x3,%edi
   12748:       b8 03 00 00 00          mov    $0x3,%eax
   1274d:       74 32                   je     12781 <item_cmp_type(Item_result, Item_result)+0x51>
   1274f:       83 fe 03                cmp    $0x3,%esi
   12752:       74 2d                   je     12781 <item_cmp_type(Item_result, Item_result)+0x51>
   12754:       83 ff 05                cmp    $0x5,%edi
   12757:       b8 05 00 00 00          mov    $0x5,%eax
   1275c:       74 23                   je     12781 <item_cmp_type(Item_result, Item_result)+0x51>
   1275e:       83 fe 05                cmp    $0x5,%esi
   12761:       74 1e                   je     12781 <item_cmp_type(Item_result, Item_result)+0x51>
   12763:       83 ff 04                cmp    $0x4,%edi
   12766:       74 05                   je     1276d <item_cmp_type(Item_result, Item_result)+0x3d>
   12768:       83 ff 02                cmp    $0x2,%edi
   1276b:       75 0f                   jne    1277c <item_cmp_type(Item_result, Item_result)+0x4c>
   1276d:       b8 04 00 00 00          mov    $0x4,%eax
   12772:       83 fe 02                cmp    $0x2,%esi
   12775:       74 0a                   je     12781 <item_cmp_type(Item_result, Item_result)+0x51>
   12777:       83 fe 04                cmp    $0x4,%esi
   1277a:       74 05                   je     12781 <item_cmp_type(Item_result, Item_result)+0x51>
   1277c:       b8 01 00 00 00          mov    $0x1,%eax
   12781:       c3                      retq
   12782:       31 c0                   xor    %eax,%eax
   12784:       c3                      retq

After, noting the short cut and the beginning of the function:

0000000000012730 <item_cmp_type(Item_result, Item_result)>:
   12730:       39 f7                   cmp    %esi,%edi
   12732:       75 03                   jne    12737 <item_cmp_type(Item_result, Item_result)+0x7>
   12734:       89 f8                   mov    %edi,%eax
   12736:       c3                      retq
   12737:       83 ff 03                cmp    $0x3,%edi
   1273a:       b8 03 00 00 00          mov    $0x3,%eax
   1273f:       74 32                   je     12773 <item_cmp_type(Item_result, Item_result)+0x43>
   12741:       83 fe 03                cmp    $0x3,%esi
   12744:       74 2d                   je     12773 <item_cmp_type(Item_result, Item_result)+0x43>
   12746:       83 ff 05                cmp    $0x5,%edi
   12749:       b8 05 00 00 00          mov    $0x5,%eax
   1274e:       74 23                   je     12773 <item_cmp_type(Item_result, Item_result)+0x43>
   12750:       83 fe 05                cmp    $0x5,%esi
   12753:       74 1e                   je     12773 <item_cmp_type(Item_result, Item_result)+0x43>
   12755:       83 ff 04                cmp    $0x4,%edi
   12758:       74 05                   je     1275f <item_cmp_type(Item_result, Item_result)+0x2f>
   1275a:       83 ff 02                cmp    $0x2,%edi
   1275d:       75 0f                   jne    1276e <item_cmp_type(Item_result, Item_result)+0x3e>
   1275f:       b8 04 00 00 00          mov    $0x4,%eax
   12764:       83 fe 02                cmp    $0x2,%esi
   12767:       74 0a                   je     12773 <item_cmp_type(Item_result, Item_result)+0x43>
   12769:       83 fe 04                cmp    $0x4,%esi
   1276c:       74 05                   je     12773 <item_cmp_type(Item_result, Item_result)+0x43>
   1276e:       b8 01 00 00 00          mov    $0x1,%eax
   12773:       c3                      retq

I submit this under the MCA.