### PR TITLE
travis: backport 10.3 changes

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -1,41 +1,50 @@
 #!/bin/sh
 set -v -x
+
+# Exclude modules from build not directly affecting the current
+# test suites found in $MYSQL_TEST_SUITES, to conserve job time
+# as well as disk usage
+
+function exclude_modules() {
+# excludes for all
+CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_SPHINX=NO"
+# exclude storage engines not being tested in current job
+if [[ ! "${MYSQL_TEST_SUITES}" =~ "archive" ]]; then
+CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_ARCHIVE=NO"
+fi
+if [[ ! "${MYSQL_TEST_SUITES}" =~ "rocksdb" ]]; then
+CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_ROCKSDB=NO"
+fi
+}
+
 if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
+  TEST_CASE_TIMEOUT=2
+  exclude_modules;
+  if which ccache ; then
+    CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+    ccache --max-size=1200M
+  fi
   if [[ "${CXX}" == 'clang++' ]]; then
-    CMAKE_OPT="-DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON"
-    #CMAKE_OPT="${CMAKE_OPT} -DWITH_ASAN=ON"
-    if which ccache ; then
-      CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-    fi
     export CXX CC=${CXX/++/}
   elif [[ "${CXX}" == 'g++' ]]; then
-    CMAKE_OPT=""
-    if [[ "${MYSQL_TEST_SUITES}" == 'rpl' ]]; then
-      CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_TOKUDB_STORAGE_ENGINE=TRUE"
-      CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_MROONGA_STORAGE_ENGINE=TRUE"
-    fi
     export CXX=g++-${CC_VERSION}
     export CC=gcc-${CC_VERSION}
   fi
   if [[ ${CC_VERSION} == 6 ]]; then
-         wget http://mirrors.kernel.org/ubuntu/pool/universe/p/percona-xtradb-cluster-galera-2.x/percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb ;
-         ar vx percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb
-         tar -xJvf data.tar.xz
-         export WSREP_PROVIDER=$PWD/usr/lib/libgalera_smm.so
-         MYSQL_TEST_SUITES="${MYSQL_TEST_SUITES},wsrep"
-  #elif [[ ${CC_VERSION} != 5 ]]; then
-    #CMAKE_OPT="${CMAKE_OPT} -DWITH_ASAN=ON"
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/p/percona-xtradb-cluster-galera-2.x/percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb ;
+    ar vx percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb
+    tar -xJvf data.tar.xz
+    export WSREP_PROVIDER=$PWD/usr/lib/libgalera_smm.so
+    MYSQL_TEST_SUITES="${MYSQL_TEST_SUITES},wsrep"
   fi
-else
-  # osx_image based tests
-  CMAKE_OPT="-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
-  #CMAKE_OPT="${CMAKE_OPT} -DWITH_ASAN=ON"
+fi
+
+if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then
+  TEST_CASE_TIMEOUT=20
+  exclude_modules;
+  CMAKE_OPT="${CMAKE_OPT} -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
   if which ccache ; then
     CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-  fi
-  CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_MROONGA_STORAGE_ENGINE=ON"
-  if [[ "${TYPE}" == "Debug" ]]; then
-    CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON"
   fi
 fi
 

--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -7,23 +7,23 @@ if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
     if which ccache ; then
       CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
     fi
-    case ${GCC_VERSION} in
-      5) CXX=clang++-4.0 ;;
-      6) CXX=clang++-5.0 ;;
-    esac
     export CXX CC=${CXX/++/}
   elif [[ "${CXX}" == 'g++' ]]; then
     CMAKE_OPT=""
-    export CXX=g++-${GCC_VERSION}
-    export CC=gcc-${GCC_VERSION}
+    if [[ "${MYSQL_TEST_SUITES}" == 'rpl' ]]; then
+      CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_TOKUDB_STORAGE_ENGINE=TRUE"
+      CMAKE_OPT="${CMAKE_OPT} -DWITHOUT_MROONGA_STORAGE_ENGINE=TRUE"
+    fi
+    export CXX=g++-${CC_VERSION}
+    export CC=gcc-${CC_VERSION}
   fi
-  if [[ ${GCC_VERSION} == 6 ]]; then
+  if [[ ${CC_VERSION} == 6 ]]; then
          wget http://mirrors.kernel.org/ubuntu/pool/universe/p/percona-xtradb-cluster-galera-2.x/percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb ;
          ar vx percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb
          tar -xJvf data.tar.xz
          export WSREP_PROVIDER=$PWD/usr/lib/libgalera_smm.so
          MYSQL_TEST_SUITES="${MYSQL_TEST_SUITES},wsrep"
-  #elif [[ ${GCC_VERSION} != 5 ]]; then
+  #elif [[ ${CC_VERSION} != 5 ]]; then
     #CMAKE_OPT="${CMAKE_OPT} -DWITH_ASAN=ON"
   fi
 else

--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -19,11 +19,9 @@ fi
 
 if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
   TEST_CASE_TIMEOUT=2
-  exclude_modules;
-  if which ccache ; then
-    CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-    ccache --max-size=1200M
-  fi
+  exclude_modules
+  ccache --max-size=1200M
+
   if [[ "${CXX}" == 'clang++' ]]; then
     export CXX CC=${CXX/++/}
   elif [[ "${CXX}" == 'g++' ]]; then
@@ -43,9 +41,10 @@ if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then
   TEST_CASE_TIMEOUT=20
   exclude_modules;
   CMAKE_OPT="${CMAKE_OPT} -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl"
-  if which ccache ; then
-    CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-  fi
+fi
+
+if which ccache ; then
+  CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
 fi
 
 set +v +x

--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -10,10 +10,10 @@ function exclude_modules() {
 CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=NO -DPLUGIN_SPHINX=NO"
 # exclude storage engines not being tested in current job
 if [[ ! "${MYSQL_TEST_SUITES}" =~ "archive" ]]; then
-CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_ARCHIVE=NO"
+  CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_ARCHIVE=NO"
 fi
 if [[ ! "${MYSQL_TEST_SUITES}" =~ "rocksdb" ]]; then
-CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_ROCKSDB=NO"
+  CMAKE_OPT="${CMAKE_OPT} -DPLUGIN_ROCKSDB=NO"
 fi
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
   include:
     - os: linux
       compiler: gcc
+      env:
+        - DebPackages
       addons:
         apt:
           packages: # make sure these match debian/control contents

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,6 @@ matrix:
             - fakeroot
       script:
         - ${CC} --version ; ${CXX} --version
-        - source .travis.compiler.sh
       # https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
       # in trusty containers
         - export MTR_MEM=/tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,8 +112,8 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
-      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
+      - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-trusty-6.0
     packages: # make sure these include all compilers and all build dependencies (see list above)
       - gcc-5
       - g++-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ addons:
       - llvm-6.0-dev
       - bison
       - chrpath
-      - cmake
+      - cmake3
       - gdb
       - libaio-dev
       - libboost-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,8 +177,6 @@ script:
            -DWITH_SSL=system -DWITH_ZLIB=system
   - make -j 4
   - cd mysql-test
-# With ASAN use --thread-stack=400K to account for overhead
-# Test timeout needs to be 10 (minutes) or less due to travis job timeout
   - travis_wait 30 ./mtr --force --max-test-fail=20 --parallel=4 --testcase-timeout=${TEST_CASE_TIMEOUT}
          --suite=${MYSQL_TEST_SUITES}
          --skip-test-list=unstable-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ compiler:
   - clang
 
 cache:
+  timeout: 300
   apt: true
   ccache: true
   directories:
@@ -24,12 +25,12 @@ cache:
 
 env:
   matrix:
-    - CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
-    - CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
-    - CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
-    - CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
-    - CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
-    - CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
+    - CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
+    - CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+    - CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
+    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
+    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
+    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
 
 matrix:
   exclude:
@@ -85,26 +86,26 @@ matrix:
         - export MTR_MEM=/tmp
         - env DEB_BUILD_OPTIONS="parallel=4" debian/autobake-deb.sh;
         - ccache --show-stats
-  # Until OSX becomes a bit more stable: MDEV-12435
+  # Until OSX becomes a bit more stable: MDEV-12435 MDEV-16213
   allow_failures:
     - os: osx
       compiler: clang
-      env: CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
+      env: CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
     - os: osx
       compiler: clang
-      env: CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
+      env: CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
     - os: osx
       compiler: clang
-      env: CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+      env: CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
     - os: osx
       compiler: clang
-      env: CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
+      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
     - os: osx
       compiler: clang
-      env: CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
+      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
     - os: osx
       compiler: clang
-      env: CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
+      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
 
 addons:
   apt:
@@ -121,7 +122,6 @@ addons:
       - llvm-5.0-dev
       - clang-6.0
       - llvm-6.0-dev
-#      - libasan0
       - bison
       - chrpath
       - cmake
@@ -160,10 +160,12 @@ before_install:
       brew link ccache;
     fi
 
-script:
+before_script:
+  - df -h
   - ccache --version
   - ccache --show-stats
-  - ccache --max-size=1000M
+
+script:
 # following modules are disabled after sourcing .travis.compiler.sh:
 # clang disabled: mroonga just generates too many warnings with clang and travis stops the job
 # cland disabled: tokudb has fatal warnings
@@ -172,16 +174,17 @@ script:
   - cmake .
            -DCMAKE_BUILD_TYPE=${TYPE}
            ${CMAKE_OPT}
-           -DWITH_SSL=system -DWITH_ZLIB=system -DPLUGIN_AWS_KEY_MANAGEMENT=DYNAMIC -DAWS_SDK_EXTERNAL_PROJECT=ON
+           -DWITH_SSL=system -DWITH_ZLIB=system
   - make -j 4
   - cd mysql-test
-# With ASAN --thread-stack=400K to account for overhead
+# With ASAN use --thread-stack=400K to account for overhead
 # Test timeout needs to be 10 (minutes) or less due to travis job timeout
-  - ./mtr --force --max-test-fail=20 --parallel=4 --testcase-timeout=4
+  - travis_wait 30 ./mtr --force --max-test-fail=20 --parallel=4 --testcase-timeout=${TEST_CASE_TIMEOUT}
          --suite=${MYSQL_TEST_SUITES}
          --skip-test-list=unstable-tests
          --skip-test=binlog.binlog_unsafe
   - ccache --show-stats
+  - df -h
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,18 @@ compiler:
 
 cache:
   apt: true
-  ccache: true # Does not currently work for clang builds: https://github.com/travis-ci/travis-ci/issues/6201
+  ccache: true
   directories:
     - /usr/local/Cellar # Fails do to permission error: https://github.com/travis-ci/travis-ci/issues/8092
 
 env:
   matrix:
-    - GCC_VERSION=4.8 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
-    - GCC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main,archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
-    - GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption,rocksdb
-    - GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
+    - CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
+    - CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+    - CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
+    - CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
+    - CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
+    - CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
 
 matrix:
   exclude:
@@ -81,39 +83,45 @@ matrix:
       # https://github.com/travis-ci/travis-ci/issues/7062 - /run/shm isn't writable or executable
       # in trusty containers
         - export MTR_MEM=/tmp
-        - env DEB_BUILD_OPTIONS="parallel=6" debian/autobake-deb.sh;
+        - env DEB_BUILD_OPTIONS="parallel=4" debian/autobake-deb.sh;
         - ccache --show-stats
   # Until OSX becomes a bit more stable: MDEV-12435
   allow_failures:
     - os: osx
       compiler: clang
-      env: GCC_VERSION=4.8 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
+      env: CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
     - os: osx
       compiler: clang
-      env: GCC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main,archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+      env: CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
     - os: osx
       compiler: clang
-      env: GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption,rocksdb
+      env: CC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
     - os: osx
       compiler: clang
-      env: GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
+      env: CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
+    - os: osx
+      compiler: clang
+      env: CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
+    - os: osx
+      compiler: clang
+      env: CC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-4.0
       - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
     packages: # make sure these include all compilers and all build dependencies (see list above)
       - gcc-5
       - g++-5
       - gcc-6
       - g++-6
-      - clang-4.0
-      - llvm-4.0-dev
       - clang-5.0
       - llvm-5.0-dev
-      - libasan0
+      - clang-6.0
+      - llvm-6.0-dev
+#      - libasan0
       - bison
       - chrpath
       - cmake
@@ -154,19 +162,22 @@ before_install:
 
 script:
   - ccache --version
-# Clang:
-#   mroonga just generates too many warnings with clang and travis stops the job
-#   tokudb has fatal warnings
+  - ccache --show-stats
+  - ccache --max-size=1000M
+# following modules are disabled after sourcing .travis.compiler.sh:
+# clang disabled: mroonga just generates too many warnings with clang and travis stops the job
+# cland disabled: tokudb has fatal warnings
+# gcc/rpl: tokudb and mroonga
   - source .travis.compiler.sh
   - cmake .
            -DCMAKE_BUILD_TYPE=${TYPE}
            ${CMAKE_OPT}
            -DWITH_SSL=system -DWITH_ZLIB=system -DPLUGIN_AWS_KEY_MANAGEMENT=DYNAMIC -DAWS_SDK_EXTERNAL_PROJECT=ON
-  - make -j 6
+  - make -j 4
   - cd mysql-test
 # With ASAN --thread-stack=400K to account for overhead
-# Test timeout needs to be 10(minutes) or less due to travis out timeout
-  - ./mtr --force --max-test-fail=20 --parallel=6 --testcase-timeout=2
+# Test timeout needs to be 10 (minutes) or less due to travis job timeout
+  - ./mtr --force --max-test-fail=20 --parallel=4 --testcase-timeout=4
          --suite=${MYSQL_TEST_SUITES}
          --skip-test-list=unstable-tests
          --skip-test=binlog.binlog_unsafe

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,12 @@ compiler:
 
 cache:
   apt: true
-  ccache: true
+  ccache: true # Does not currently work for clang builds: https://github.com/travis-ci/travis-ci/issues/6201
   directories:
-    - /usr/local/Cellar
+    - /usr/local/Cellar # Fails do to permission error: https://github.com/travis-ci/travis-ci/issues/8092
 
 env:
   matrix:
-#    - GCC_VERSION=4.8 TYPE=Debug          MYSQL_TEST_SUITES=rpl
-#    - GCC_VERSION=5   TYPE=Debug          MYSQL_TEST_SUITES=main,archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
-#    - GCC_VERSION=6   TYPE=Debug          MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption,rocksdb
-#    - GCC_VERSION=6   TYPE=Debug          MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
     - GCC_VERSION=4.8 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
     - GCC_VERSION=5   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main,archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
     - GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption,rocksdb
@@ -102,44 +98,13 @@ matrix:
       compiler: clang
       env: GCC_VERSION=6   TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,percona,perfschema,plugins,multi_source,roles
 
-# Matrix include for coverity
-#    - env:
-#        - GCC_VERSION=6
-#      addon:
-#      coverity_scan:
-#        # ref: https://scan.coverity.com/travis_ci
-#        # GitHub project metadata
-#        project:
-#          - name: MariaDB/server
-#          - description: MariaDB Server
-#
-#        # Where email notification of build analysis results will be sent
-#        notification_email: security@mariadb.org
-#
-#        # Commands to prepare for build_command
-#        build_command_prepend:
-#          - source .travis.compiler.sh
-#          - ${MYSQL_BUILD_CC} --version ; ${MYSQL_BUILD_CXX} --version
-#          - cmake . 
-#                   -DCMAKE_BUILD_TYPE=Debug
-#                   -DWITH_SSL=system -DWITH_ZLIB=system
-#                   -DWITHOUT_TOKUDB_STORAGE_ENGINE=ON -DWITHOUT_MROONGA_STORAGE_ENGINE=ON
-#
-#        # The command that will be added as an argument to "cov-build" to compile your project for analysis,
-#        build_command: make -j 4
-#
-#        # Pattern to match selecting branches that will run analysis.
-#        # Take care in resource usage, and consider the build frequency allowances per
-#        #   https://scan.coverity.com/faq#frequency - 7 per week is the current limit.
-#        branch_pattern: .*coverity.*
-
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-trusty-4.0
       - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
-    packages: # make sure these match the build requirements
+    packages: # make sure these include all compilers and all build dependencies (see list above)
       - gcc-5
       - g++-5
       - gcc-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ matrix:
             - libreadline-gplv2-dev
             - libstemmer-dev
             - libssl-dev
+            - libsystemd-daemon-dev
             - libnuma-dev
             - libxml2-dev
             - lsb-release
@@ -137,6 +138,7 @@ addons:
       - libreadline-gplv2-dev
       - libstemmer-dev
       - libssl-dev
+      - libsystemd-daemon-dev
       - libnuma-dev
       - libxml2-dev
       - lsb-release
@@ -151,7 +153,6 @@ addons:
       - libzmq-dev
       - uuid-dev
 
-# libsystemd-daemon-dev # https://github.com/travis-ci/apt-package-whitelist/issues/3882
 
 before_install:
   - if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then

--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -6,16 +6,11 @@
 # Exit immediately on any error
 set -e
 
-# On Buildbot, don't run the mysql-test-run test suite as part of build.
-# It takes a lot of time, and we will do a better test anyway in
-# Buildbot, running the test suite from installed .debs on a clean VM.
-# On Travis-CI we want to simulate the full build, including tests.
-# Also on Travis-CI it is useful not to override the DEB_BUILD_OPTIONS
-# at this stage at all.
-if [[ ! $TRAVIS ]]
-then
-  export DEB_BUILD_OPTIONS="nocheck"
-fi
+# This file is invocated from Buildbot and Travis-CI to build deb packages.
+# As both of those CI systems have many parallel jobs that include different
+# parts of the test suite, we don't need to run the mysql-test-run at all when
+# building the deb packages here.
+export DEB_BUILD_OPTIONS="nocheck $DEB_BUILD_OPTIONS"
 
 # Travis-CI optimizations
 if [[ $TRAVIS ]]
@@ -26,6 +21,12 @@ then
   # Don't include test suite package on Travis-CI to make the build time shorter
   sed '/Package: mariadb-test-data/,+26d' -i debian/control
   sed '/Package: mariadb-test/,+34d' -i debian/control
+
+  # Don't build the test package at all to save time and disk space
+  sed 's|DINSTALL_MYSQLTESTDIR=share/mysql/mysql-test|DINSTALL_MYSQLTESTDIR=false|' -i debian/rules
+
+  # Also skip building RocksDB and TokuDB to save even more time and disk space
+  sed 's|-DDEB|-DWITHOUT_TOKUDB_STORAGE_ENGINE=true -DWITHOUT_MROONGA_STORAGE_ENGINE=true -DWITHOUT_ROCKSDB_STORAGE_ENGINE=true -DDEB|' -i debian/rules
 fi
 
 
@@ -80,11 +81,11 @@ GCCVERSION=$(gcc -dumpfullversion -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g
 						     -e 's/^[0-9]\{3,4\}$/&00/')
 # Don't build rocksdb package if gcc version is less than 4.8 or we are running on
 # x86 32 bit.
-if [[ $GCCVERSION -lt 40800 ]] || [[ $(arch) =~ i[346]86 ]]
+if [[ $GCCVERSION -lt 40800 ]] || [[ $(arch) =~ i[346]86 ]] || [[ $TRAVIS ]]
 then
   sed '/Package: mariadb-plugin-rocksdb/,+10d' -i debian/control
 fi
-if [[ $GCCVERSION -lt 40800 ]]
+if [[ $GCCVERSION -lt 40800 ]] || [[ $TRAVIS ]]
 then
   sed '/Package: mariadb-plugin-aws-key-management-10.2/,+12d' -i debian/control
 fi

--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -18,9 +18,12 @@ then
   # On Travis-CI, the log must stay under 4MB so make the build less verbose
   sed -i -e '/Add support for verbose builds/,+2d' debian/rules
 
-  # Don't include test suite package on Travis-CI to make the build time shorter
-  sed '/Package: mariadb-test-data/,+26d' -i debian/control
-  sed '/Package: mariadb-test/,+34d' -i debian/control
+  # Don't include test suite package or large plugins on Travis-CI to make the build time shorter
+  sed -e '/^Package: mariadb-test/,/^$/d' \
+      -e '/^Package: mariadb-plugin-tokudb/,/^$/d' \
+      -e '/^Package: mariadb-plugin-mroonga/,/^$/d' \
+      -e '/^Package: mariadb-plugin-rocksdb/,/^$/d' \
+      -i debian/control
 
   # Don't build the test package at all to save time and disk space
   sed 's|DINSTALL_MYSQLTESTDIR=share/mysql/mysql-test|DINSTALL_MYSQLTESTDIR=false|' -i debian/rules

--- a/debian/rules
+++ b/debian/rules
@@ -32,7 +32,7 @@ CXX := $(DEB_HOST_GNU_TYPE)-g++
 # at https://www.debian.org/doc/debian-policy/ch-source.html#s-debianrules-options
 ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
     NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-    MAKEFLAGS += -j $(NUMJOBS)
+    MAKEFLAGS += -j$(NUMJOBS)
 else
     # NUMJOBS cannot be empty as it is used as a parameter to mtr, default to 1.
     NUMJOBS = 1


### PR DESCRIPTION
Also recommend enabling Travis auto-cancellation to prevent builds queuing up on the same branch if it isn't already. https://blog.travis-ci.com/2017-09-21-default-auto-cancellation.

Lets wait for this to finish. There's a substantial backlog of osx builds for the last day.