### PR TITLE
MDEV-15043 - Scripts: compilation warnings suppression

### DIFF
--- a/BUILD/capture_warnings.sh
+++ b/BUILD/capture_warnings.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Usage: cmake -DWARN_MODE=early|late|both
+#
+# Warn modes:
+#   early   print warnings while compiling each source file (like usually)
+#   late    print warnings at finish of build process
+#   both    print warnings both 'early' and 'late'
+#
+# Suppressing specific warnings. All messages with 'warning:' and 'note:'
+# are collected in <build_dir>/compile.warnings To make them all suppressed do
+#
+#   cd <build_dir>; cat compile.warnings >> suppress.warnings
+#
+# After that only newly introduced warnings will be shown. This helps to
+# concentrate on current task's warnings effectively avoiding those that are to
+# be fixed by other people.
+#
+# To disable processing warnings by this module do
+#
+#   cmake -UWARN_MODE
+#
+
+warn_path=$1
+warn_mode=$2 # 'late', 'early' or 'both'
+shift 2
+
+warn_file="$warn_path/compile.warnings"
+suppress_file="$warn_path/suppress.warnings"
+
+# suppress_warnings:
+#
+# 1. treat STDIN as sequence of warnings (w) delimited by ^~~~... lines
+#
+# 2. sanitize each w to matchable m:
+#    a. ignore 'In file included from' lines;
+#    b. protect BRE chars;
+#    c. ignore text coords (NNN:NNN);
+#    d. convert multiline to X-delimited single line.
+#
+# 3. match sanitized m against X-delimited suppress.warnings:
+#    if match not found print w to STDOUT.
+
+suppress_warnings()
+{
+    [ -f "$suppress_file" ] || {
+        cat
+        return
+    }
+    [ -z "$suppress_file" ] && {
+        cat > /dev/null
+        return
+    }
+    local m w from
+    IFS=""
+    while read -r l
+    do
+        w="$w$l"$'\n'
+
+        [[ $l =~ ^"In file included from " ]] && {
+            from=1
+            continue
+        }
+
+        [[ $from && $l =~ ^[[:space:]]+"from " ]] &&
+            continue
+
+        unset from
+
+        if [[ $l =~ ^[[:space:]]*~*\^~*$ ]]
+        then
+            cat "$suppress_file" | tr '\n' 'X' | /bin/grep -Gq "$m" ||
+                echo "$w"
+            unset m w
+        else
+            # Protect BRE metacharacters \.[*^$
+            l=${l//\\/\\\\}
+            l=${l//./\\.}
+            l=${l//[/\\[}
+            l=${l//-/\\-}
+            l=${l//\*/\\*}
+            l=${l//^/\\^}
+            l=${l//\$/\\\$}
+            # replace text coords line:char with BRE wildcard
+            [[ $l =~ ^(.*:)[[:digit:]]+:[[:digit:]]+(.*)$ ]] &&
+                l=${BASH_REMATCH[1]}[[:digit:]]\\+:[[:digit:]]\\+${BASH_REMATCH[2]}
+            m="$m$l"$'X'
+        fi
+    done
+}
+
+exec 3>&1
+"$@" 2>&1 1>&3 | suppress_warnings | (
+    cmderr=`cat`
+
+    if [[ -n "$cmderr" ]]; then
+        if [[ "$cmderr" =~ error: ]]; then
+            echo "$cmderr" >&2
+            exit
+        fi
+        [[ "$warn_mode" != "late" ]] &&
+            echo "$cmderr" >&2
+        [[ "$warn_mode" != "early" && "$cmderr" =~ (warning|note): ]] &&
+            echo "$cmderr" >> "$warn_file"
+    fi
+)
+
+exit ${PIPESTATUS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,3 +503,5 @@ IF(NON_DISTRIBUTABLE_WARNING)
   MESSAGE(WARNING "
 You have linked MariaDB with GPLv3 libraries!  You may not distribute the resulting binary. If you do, you will put yourself into a legal problem with Free Software Foundation.")
 ENDIF()
+
+INCLUDE(${CMAKE_SOURCE_DIR}/cmake/print_warnings.cmake)

--- a/cmake/print_warnings.cmake
+++ b/cmake/print_warnings.cmake
@@ -1,0 +1,31 @@
+IF(DEFINED WARN_MODE)
+  IF(NOT WARN_MODE STREQUAL "early" AND
+      NOT WARN_MODE STREQUAL "late" AND
+      NOT WARN_MODE STREQUAL "both")
+    MESSAGE(FATAL_ERROR "Unknown WARN_MODE: expected 'early', 'late' or 'both'")
+  ENDIF()
+
+  SET_DIRECTORY_PROPERTIES(PROPERTIES RULE_LAUNCH_COMPILE
+    "bash ${CMAKE_SOURCE_DIR}/BUILD/capture_warnings.sh ${CMAKE_BINARY_DIR} ${WARN_MODE}")
+  SET_DIRECTORY_PROPERTIES(PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    "${CMAKE_BINARY_DIR}/compile.warnings")
+  ADD_CUSTOM_TARGET(rm_compile.warnings ALL
+    COMMAND rm -f compile.warnings
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+  ADD_CUSTOM_TARGET(print_warnings ALL
+    COMMAND bash -c '[ -f compile.warnings ] && { echo "Warnings found:" \; cat compile.warnings \; echo "" \; } \; true'
+    DEPENDS mysqld rm_compile.warnings
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+  IF(TARGET explain_filename-t)
+    ADD_DEPENDENCIES(print_warnings explain_filename-t)
+  ENDIF()
+
+  IF(TARGET mysql_client_test)
+    ADD_DEPENDENCIES(print_warnings mysql_client_test)
+  ENDIF()
+
+  IF(TARGET udf_example)
+    ADD_DEPENDENCIES(print_warnings udf_example)
+  ENDIF()
+ENDIF()


### PR DESCRIPTION
This module allows to suppress selection of warnings. Much easier to see warnings produced by your own patch instead of whole pile of messages. Module is OFF by default, so it will not affect anyone's build unless properly configured.

```
Usage: cmake -DWARN_MODE=early|late|both

Warn modes:
  early   print warnings while compiling each source file (like usually)
  late    print warnings at finish of build process
  both    print warnings both 'early' and 'late'

Suppressing specific warnings. All messages with 'warning:' and 'note:'
are collected in <build_dir>/compile.warnings To make them all suppressed do

  cd <build_dir>; cat compile.warnings >> suppress.warnings

After that only newly introduced warnings will be shown. This helps to
concentrate on current task's warnings effectively avoiding those that are to
be fixed by other people.

To disable processing warnings by this module do

  cmake -UWARN_MODE

```