### PR TITLE
SQL: renamed field_visibility to invisible

### DIFF
--- a/sql/field.cc
+++ b/sql/field.cc
@@ -1603,7 +1603,7 @@ String *Field::val_int_as_str(String *val_buffer, bool unsigned_val)
 Field::Field(uchar *ptr_arg,uint32 length_arg,uchar *null_ptr_arg,
 	     uchar null_bit_arg,
 	     utype unireg_check_arg, const LEX_CSTRING *field_name_arg)
-  :ptr(ptr_arg), field_visibility(NOT_INVISIBLE),
+  :ptr(ptr_arg), invisible(VISIBLE),
   null_ptr(null_ptr_arg), table(0), orig_table(0),
   table_name(0), field_name(*field_name_arg), option_list(0),
   option_struct(0), key_start(0), part_of_key(0),
@@ -2196,7 +2196,7 @@ Field *Field::make_new_field(MEM_ROOT *root, TABLE *new_table,
   tmp->flags&= (NOT_NULL_FLAG | BLOB_FLAG | UNSIGNED_FLAG |
                 ZEROFILL_FLAG | BINARY_FLAG | ENUM_FLAG | SET_FLAG);
   tmp->reset_fields();
-  tmp->field_visibility= NOT_INVISIBLE;
+  tmp->invisible= VISIBLE;
   return tmp;
 }
 
@@ -10647,7 +10647,7 @@ Column_definition::Column_definition(THD *thd, Field *old_field,
   option_list= old_field->option_list;
   pack_flag= 0;
   compression_method_ptr= 0;
-  field_visibility= old_field->field_visibility;
+  invisible= old_field->invisible;
 
   if (orig_field)
   {
@@ -10785,7 +10785,7 @@ Column_definition::redefine_stage1_common(const Column_definition *dup_field,
   flags=        dup_field->flags;
   interval=     dup_field->interval;
   vcol_info=    dup_field->vcol_info;
-  field_visibility= dup_field->field_visibility;
+  invisible=    dup_field->invisible;
 }
 
 

--- a/sql/field.h
+++ b/sql/field.h
@@ -675,7 +675,7 @@ public:
 
   uchar		*ptr;			// Position to field in record
 
-  field_visible_type field_visibility;
+  field_visibility_t invisible;
   /**
      Byte where the @c NULL bit is stored inside a record. If this Field is a
      @c NOT @c NULL field, this member is @c NULL.
@@ -4048,7 +4048,7 @@ public:
     max number of characters. 
   */
   ulonglong length;
-  field_visible_type field_visibility;
+  field_visibility_t invisible;
   /*
     The value of `length' as set by parser: is the number of characters
     for most of the types, or of bytes for BLOBs or numeric types.
@@ -4079,7 +4079,7 @@ public:
    :Type_handler_hybrid_field_type(&type_handler_null),
     compression_method_ptr(0),
     comment(null_clex_str),
-    on_update(NULL), length(0),field_visibility(NOT_INVISIBLE), decimals(0),
+    on_update(NULL), length(0), invisible(VISIBLE), decimals(0),
     flags(0), pack_length(0), key_length(0), unireg_check(Field::NONE),
     interval(0), charset(&my_charset_bin),
     srid(0), geom_type(Field::GEOM_GEOMETRY),
@@ -4556,6 +4556,6 @@ bool check_expression(Virtual_column_info *vcol, LEX_CSTRING *name,
 #define f_no_default(x)		((x) & FIELDFLAG_NO_DEFAULT)
 #define f_bit_as_char(x)        ((x) & FIELDFLAG_TREAT_BIT_AS_CHAR)
 #define f_is_hex_escape(x)      ((x) & FIELDFLAG_HEX_ESCAPE)
-#define f_visibility(x)         (static_cast<field_visible_type> ((x) & 3))
+#define f_visibility(x)         (static_cast<field_visibility_t> ((x) & INVISIBLE_MAX_BITS))
 
 #endif /* FIELD_INCLUDED */

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -5528,7 +5528,7 @@ find_field_in_table(THD *thd, TABLE *table, const char *name, uint length,
 
   if (field_ptr && *field_ptr)
   {
-    if ((*field_ptr)->field_visibility == COMPLETELY_INVISIBLE &&
+    if ((*field_ptr)->invisible == INVISIBLE_FULL &&
         DBUG_EVALUATE_IF("test_completely_invisible", 0, 1))
       DBUG_RETURN((Field*)0);
 
@@ -7617,7 +7617,7 @@ insert_fields(THD *thd, Name_resolution_context *context, const char *db_name,
         But view fields can never be invisible.
       */
       if ((field= field_iterator.field()) &&
-          field->field_visibility != NOT_INVISIBLE)
+          field->invisible)
         continue;
       Item *item;
 
@@ -8247,7 +8247,7 @@ fill_record(THD *thd, TABLE *table, Field **ptr, List<Item> &values,
     /* Ensure that all fields are from the same table */
     DBUG_ASSERT(field->table == table);
 
-    if (field->field_visibility != NOT_INVISIBLE)
+    if (field->invisible)
       continue;
     else
       value=v++;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2168,7 +2168,7 @@ int show_create_table(THD *thd, TABLE_LIST *table_list, String *packet,
 
     uint flags = field->flags;
 
-    if (field->field_visibility > USER_DEFINED_INVISIBLE)
+    if (field->invisible > INVISIBLE_USER)
        continue;
     if (not_the_first_field)
       packet->append(STRING_WITH_LEN(",\n"));
@@ -2226,7 +2226,7 @@ int show_create_table(THD *thd, TABLE_LIST *table_list, String *packet,
         packet->append(STRING_WITH_LEN(" NULL"));
       }
 
-      if (field->field_visibility == USER_DEFINED_INVISIBLE)
+      if (field->invisible == INVISIBLE_USER)
       {
         packet->append(STRING_WITH_LEN(" INVISIBLE"));
       }
@@ -5722,7 +5722,7 @@ static int get_schema_column_record(THD *thd, TABLE_LIST *tables,
 
   for (; (field= *ptr) ; ptr++)
   {
-    if(field->field_visibility > USER_DEFINED_INVISIBLE)
+    if(field->invisible > INVISIBLE_USER)
       continue;
     uchar *pos;
     char tmp[MAX_FIELD_WIDTH];
@@ -5803,7 +5803,7 @@ static int get_schema_column_record(THD *thd, TABLE_LIST *tables,
     else
       table->field[20]->store(STRING_WITH_LEN("NEVER"), cs);
     /*Invisible can coexist with auto_increment and virtual */
-    if (field->field_visibility == USER_DEFINED_INVISIBLE)
+    if (field->invisible == INVISIBLE_USER)
     {
       if (buf.length())
         buf.append(STRING_WITH_LEN(", "));

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -3275,22 +3275,22 @@ bool Column_definition::prepare_stage1_check_typelib_default()
       field_list               list of all table fields
       field_name               name/prefix of invisible field
                                ( Prefix in the case when it is
-                                *COMPLETELY_INVISIBLE*
+                                *INVISIBLE_FULL*
                                and given name is duplicate)
       type_handler             field data type
-      field_visibility
+      invisible
       default value
     RETURN VALUE
       Create_field pointer
 */
 int mysql_add_invisible_field(THD *thd, List<Create_field> * field_list,
         const char *field_name, Type_handler *type_handler,
-        field_visible_type field_visibility, Item* default_value)
+        field_visibility_t invisible, Item* default_value)
 {
   Create_field *fld= new(thd->mem_root)Create_field();
   const char *new_name= NULL;
-  /* Get unique field name if field_visibility == COMPLETELY_INVISIBLE */
-  if (field_visibility == COMPLETELY_INVISIBLE)
+  /* Get unique field name if invisible == INVISIBLE_FULL */
+  if (invisible == INVISIBLE_FULL)
   {
     if ((new_name= make_unique_invisible_field_name(thd, field_name,
                                                      field_list)))
@@ -3307,7 +3307,7 @@ int mysql_add_invisible_field(THD *thd, List<Create_field> * field_list,
     fld->field_name.length= strlen(field_name);
   }
   fld->set_handler(type_handler);
-  fld->field_visibility= field_visibility;
+  fld->invisible= invisible;
   if (default_value)
   {
     Virtual_column_info *v= new (thd->mem_root) Virtual_column_info();
@@ -3380,12 +3380,12 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
 
   DBUG_EXECUTE_IF("test_pseudo_invisible",{
           mysql_add_invisible_field(thd, &alter_info->create_list,
-                      "invisible", &type_handler_long, SYSTEM_INVISIBLE,
+                      "invisible", &type_handler_long, INVISIBLE_SYSTEM,
                       new (thd->mem_root)Item_int(thd, 9));
           });
   DBUG_EXECUTE_IF("test_completely_invisible",{
           mysql_add_invisible_field(thd, &alter_info->create_list,
-                      "invisible", &type_handler_long, COMPLETELY_INVISIBLE,
+                      "invisible", &type_handler_long, INVISIBLE_FULL,
                       new (thd->mem_root)Item_int(thd, 9));
           });
   DBUG_EXECUTE_IF("test_invisible_index",{
@@ -3542,7 +3542,7 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
     */
     if (sql_field->stored_in_db())
       record_offset+= sql_field->pack_length;
-    if (sql_field->field_visibility == USER_DEFINED_INVISIBLE &&
+    if (sql_field->invisible == INVISIBLE_USER &&
         sql_field->flags & NOT_NULL_FLAG &&
         sql_field->flags & NO_DEFAULT_VALUE_FLAG)
     {
@@ -3562,7 +3562,7 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
       sql_field->offset= record_offset;
       record_offset+= sql_field->pack_length;
     }
-    if (sql_field->field_visibility == NOT_INVISIBLE)
+    if (sql_field->invisible == VISIBLE)
       is_all_invisible= false;
   }
   if (is_all_invisible)
@@ -3820,15 +3820,14 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
                             &sql_field->field_name))
 	field++;
       /*
-         Either field is not present or field visibility is >
-         USER_DEFINED_INVISIBLE
+         Either field is not present or field visibility is > INVISIBLE_USER
       */
       if (!sql_field)
       {
 	my_error(ER_KEY_COLUMN_DOES_NOT_EXITS, MYF(0), column->field_name.str);
 	DBUG_RETURN(TRUE);
       }
-      if (sql_field->field_visibility > USER_DEFINED_INVISIBLE &&
+      if (sql_field->invisible > INVISIBLE_USER &&
           !key->invisible && DBUG_EVALUATE_IF("test_invisible_index", 0, 1))
       {
         my_error(ER_KEY_COLUMN_DOES_NOT_EXITS, MYF(0), column->field_name.str);
@@ -5231,11 +5230,11 @@ static void make_unique_constraint_name(THD *thd, LEX_CSTRING *name,
 }
 
 /**
-  COMPLETELY_INVISIBLE are internally created. They are completely invisible
+  INVISIBLE_FULL are internally created. They are completely invisible
   to Alter command (Opposite of SYSTEM_INVISIBLE which throws an
   error when same name column is added by Alter). So in the case of when
-  user added a same column name as of COMPLETELY_INVISIBLE , we change
-  COMPLETELY_INVISIBLE column name.
+  user added a same column name as of INVISIBLE_FULL , we change
+  INVISIBLE_FULL column name.
 */
 static const
 char * make_unique_invisible_field_name(THD *thd, const char *field_name,
@@ -7685,7 +7684,7 @@ mysql_prepare_alter_table(THD *thd, TABLE *table,
   bitmap_clear_all(&table->tmp_set);
   for (f_ptr=table->field ; (field= *f_ptr) ; f_ptr++)
   {
-    if (field->field_visibility == COMPLETELY_INVISIBLE)
+    if (field->invisible == INVISIBLE_FULL)
         continue;
     Alter_drop *drop;
     if (field->type() == MYSQL_TYPE_VARCHAR)
@@ -7698,7 +7697,7 @@ mysql_prepare_alter_table(THD *thd, TABLE *table,
           !my_strcasecmp(system_charset_info,field->field_name.str, drop->name))
         break;
     }
-    if (drop && field->field_visibility < SYSTEM_INVISIBLE)
+    if (drop && field->invisible < INVISIBLE_SYSTEM)
     {
       /* Reset auto_increment value if it was dropped */
       if (MTYP_TYPENR(field->unireg_check) == Field::NEXT_NUMBER &&
@@ -7723,7 +7722,7 @@ mysql_prepare_alter_table(THD *thd, TABLE *table,
                           &def->change))
 	break;
     }
-    if (def && field->field_visibility < SYSTEM_INVISIBLE)
+    if (def && field->invisible < INVISIBLE_SYSTEM)
     {						// Field is changed
       def->field=field;
       /*

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -6431,7 +6431,7 @@ vcol_attribute:
         | COMMENT_SYM TEXT_STRING_sys { Lex->last_field->comment= $2; }
         | INVISIBLE_SYM
           {
-              Lex->last_field->field_visibility= USER_DEFINED_INVISIBLE;
+              Lex->last_field->invisible= INVISIBLE_USER;
           }
         ;
 

--- a/sql/sql_yacc_ora.yy
+++ b/sql/sql_yacc_ora.yy
@@ -6128,7 +6128,7 @@ vcol_attribute:
         | COMMENT_SYM TEXT_STRING_sys { Lex->last_field->comment= $2; }
         | INVISIBLE_SYM
           {
-            Lex->last_field->field_visibility= USER_DEFINED_INVISIBLE;
+            Lex->last_field->invisible= INVISIBLE_USER;
           }
         ;
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -1990,11 +1990,11 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
     if(field_properties!=NULL)
     {
       uint temp= *field_properties++;
-      reg_field->field_visibility= f_visibility(temp);
+      reg_field->invisible= f_visibility(temp);
     }
-    if (reg_field->field_visibility == USER_DEFINED_INVISIBLE)
+    if (reg_field->invisible == INVISIBLE_USER)
       status_var_increment(thd->status_var.feature_invisible_columns);
-    if (reg_field->field_visibility == NOT_INVISIBLE)
+    if (!reg_field->invisible)
       share->visible_fields++;
     if (field_type == MYSQL_TYPE_BIT && !f_bit_as_char(pack_flag))
     {
@@ -2247,7 +2247,7 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
 
         field= key_part->field= share->field[key_part->fieldnr-1];
         key_part->type= field->key_type();
-        if (field->field_visibility > USER_DEFINED_INVISIBLE)
+        if (field->invisible > INVISIBLE_USER)
           keyinfo->flags |= HA_INVISIBLE_KEY;
         if (field->null_ptr)
         {

--- a/sql/table.h
+++ b/sql/table.h
@@ -337,14 +337,17 @@ enum enum_vcol_update_mode
 
 /* Field visibility enums */
 
-enum  field_visible_type{
-	NOT_INVISIBLE= 0,
-	USER_DEFINED_INVISIBLE,
-    /* automatically added by the server. Can be queried explicitly
-      in SELECT, otherwise invisible from anything" */
-	SYSTEM_INVISIBLE,
-	COMPLETELY_INVISIBLE
+enum field_visibility_t {
+  VISIBLE= 0,
+  INVISIBLE_USER,
+  /* automatically added by the server. Can be queried explicitly
+  in SELECT, otherwise invisible from anything" */
+  INVISIBLE_SYSTEM,
+  INVISIBLE_FULL
 };
+
+#define INVISIBLE_MAX_BITS 3
+
 
 /**
   Category of table found in the table share.

--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -97,7 +97,7 @@ static uchar *extra2_write_additional_field_properties(uchar *pos,
   pos= extra2_write_len(pos, number_of_fields);
   Create_field *cf;
   while((cf=(*it)++))
-    *pos++= cf->field_visibility;
+    *pos++= cf->invisible;
   it->rewind();
   return pos;
 }
@@ -141,7 +141,7 @@ LEX_CUSTRING build_frm_image(THD *thd, const char *table,
   bool have_additional_field_properties= false;
   while ((field=it++))
   {
-    if (field->field_visibility != NOT_INVISIBLE)
+    if (field->invisible)
     {
       have_additional_field_properties= true;
       break;


### PR DESCRIPTION
There is no need to add `field_` prefix to all members of `Field` class:

```c++
if (field->invisible)
```
is much easier to read than
```c++
if (field->field_visibility != NOT_INVISIBLE)
```

`INVISIBLE_` should be prefix, not suffix: it is commonly used convention. Besides this allows to utilize IDE features.

@SachinSetiya please, review.




