### PR TITLE
MDEV-16371 - Fix for memory write order inversion and other issues related to MW-328A

### DIFF
--- a/mysys/thr_lock.c
+++ b/mysys/thr_lock.c
@@ -546,9 +546,11 @@ wait_for_lock(struct st_lock_list *wait, THR_LOCK_DATA *data,
   statistic_increment(locks_waited, &THR_LOCK_lock);
 
   /* Set up control struct to allow others to abort locks */
+  mysql_mutex_lock(&thread_var->mutex);
   thread_var->current_mutex= &data->lock->mutex;
   thread_var->current_cond=  cond;
   data->cond= cond;
+  mysql_mutex_unlock(&thread_var->mutex);
 
   proc_info_hook(NULL, &stage_waiting_for_table_level_lock,
                  &old_stage,

--- a/sql/debug_sync.cc
+++ b/sql/debug_sync.cc
@@ -1413,11 +1413,13 @@ static void debug_sync_execute(THD *thd, st_debug_sync_action *action)
       */
       if (thd->mysys_var)
       {
+        mysql_mutex_lock(&thd->mysys_var->mutex);
         old_mutex= thd->mysys_var->current_mutex;
         old_cond= thd->mysys_var->current_cond;
-        restore_current_mutex = true;
         thd->mysys_var->current_mutex= &debug_sync_global.ds_mutex;
         thd->mysys_var->current_cond= &debug_sync_global.ds_cond;
+        mysql_mutex_unlock(&thd->mysys_var->mutex);
+        restore_current_mutex = true;
       }
       else
         restore_current_mutex = false;

--- a/sql/event_scheduler.cc
+++ b/sql/event_scheduler.cc
@@ -768,11 +768,15 @@ Event_scheduler::cond_wait(THD *thd, struct timespec *abstime, const PSI_stage_i
     thd->enter_cond(&COND_state, &LOCK_scheduler_state, stage,
                     NULL, src_func, src_file, src_line);
 
-  DBUG_PRINT("info", ("mysql_cond_%swait", abstime? "timed":""));
-  if (!abstime)
-    mysql_cond_wait(&COND_state, &LOCK_scheduler_state);
-  else
-    mysql_cond_timedwait(&COND_state, &LOCK_scheduler_state, abstime);
+  if (!thd || !thd->killed)
+  {
+    DBUG_PRINT("info", ("mysql_cond_%swait", abstime? "timed":""));
+    if (!abstime)
+      mysql_cond_wait(&COND_state, &LOCK_scheduler_state);
+    else
+      mysql_cond_timedwait(&COND_state, &LOCK_scheduler_state, abstime);
+  }
+
   if (thd)
   {
     /*

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4339,8 +4339,10 @@ longlong Item_func_sleep::val_int()
   mysql_mutex_lock(&LOCK_item_func_sleep);
 
   THD_STAGE_INFO(thd, stage_user_sleep);
+  mysql_mutex_lock(&thd->mysys_var->mutex);
   thd->mysys_var->current_mutex= &LOCK_item_func_sleep;
   thd->mysys_var->current_cond=  &cond;
+  mysql_mutex_unlock(&thd->mysys_var->mutex);
 
   error= 0;
   thd_wait_begin(thd, THD_WAIT_SLEEP);

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -8253,7 +8253,10 @@ void MYSQL_BIN_LOG::wait_for_update_relay_log(THD* thd)
   thd->ENTER_COND(&COND_relay_log_updated, &LOCK_log,
                   &stage_slave_has_read_all_relay_log,
                   &old_stage);
-  mysql_cond_wait(&COND_relay_log_updated, &LOCK_log);
+  if (!thd->killed)
+  {
+    mysql_cond_wait(&COND_relay_log_updated, &LOCK_log);
+  }
   thd->EXIT_COND(&old_stage);
   DBUG_VOID_RETURN;
 }

--- a/sql/my_apc.cc
+++ b/sql/my_apc.cc
@@ -149,7 +149,8 @@ bool Apc_target::make_apc_call(THD *caller_thd, Apc_call *call,
     caller_thd->ENTER_COND(&apc_request.COND_request, LOCK_thd_kill_ptr,
                            &stage_show_explain, &old_stage);
     /* todo: how about processing other errors here? */
-    while (!apc_request.processed && (wait_res != ETIMEDOUT))
+    while (!apc_request.processed && (wait_res != ETIMEDOUT) &&
+           !caller_thd->killed)
     {
       /* We own LOCK_thd_kill_ptr */
       wait_res= mysql_cond_timedwait(&apc_request.COND_request,

--- a/sql/rpl_gtid.cc
+++ b/sql/rpl_gtid.cc
@@ -183,8 +183,11 @@ rpl_slave_state::check_duplicate_gtid(rpl_gtid *gtid, rpl_group_info *rgi)
                       &stage_gtid_wait_other_connection, &old_stage);
       did_enter_cond= true;
     }
-    mysql_cond_wait(&elem->COND_gtid_ignore_duplicates,
-                    &LOCK_slave_state);
+    if (!thd->killed)
+    {
+       mysql_cond_wait(&elem->COND_gtid_ignore_duplicates,
+                       &LOCK_slave_state);
+    }
   }
 
 err:

--- a/sql/rpl_parallel.cc
+++ b/sql/rpl_parallel.cc
@@ -118,7 +118,8 @@ wait_for_pending_deadlock_kill(THD *thd, rpl_group_info *rgi)
   mysql_mutex_lock(&thd->LOCK_wakeup_ready);
   thd->ENTER_COND(&thd->COND_wakeup_ready, &thd->LOCK_wakeup_ready,
                   &stage_waiting_for_deadlock_kill, &old_stage);
-  while (rgi->killed_for_retry == rpl_group_info::RETRY_KILL_PENDING)
+  while (rgi->killed_for_retry == rpl_group_info::RETRY_KILL_PENDING &&
+         !thd->killed)
     mysql_cond_wait(&thd->COND_wakeup_ready, &thd->LOCK_wakeup_ready);
   thd->EXIT_COND(&old_stage);
 }
@@ -1042,11 +1043,13 @@ handle_rpl_parallel_thread(void *arg)
          inside an event group; no more events will be queued to us, so we need
          to abort the group (force_abort==1).
        - Thread pool shutdown (rpt->stop==1).
+       - Thread has "killed" flag set (thd->killed==1).
     */
     while (!( (events= rpt->event_queue) ||
               (rpt->current_owner && !in_event_group) ||
               (rpt->current_owner && group_rgi->parallel_entry->force_abort) ||
-              rpt->stop))
+              rpt->stop) ||
+              thd->killed)
     {
       if (!wait_count++)
         thd->set_time_for_next_stage();
@@ -2069,7 +2072,10 @@ rpl_parallel_entry::choose_thread(rpl_group_info *rgi, bool *did_enter_cond,
                                           old_stage);
           *did_enter_cond= true;
         }
-        mysql_cond_wait(&thr->COND_rpl_thread_queue, &thr->LOCK_rpl_thread);
+        if (!thr->killed)
+        {
+           mysql_cond_wait(&thr->COND_rpl_thread_queue, &thr->LOCK_rpl_thread);
+        }
       }
     }
   }

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1859,20 +1859,17 @@ void THD::awake_no_mutex(killed_state state_to_set)
   /* Broadcast a condition to kick the target if it is waiting on it. */
   if (mysys_var)
   {
-    mysql_mutex_lock(&mysys_var->mutex);
     if (!system_thread)		// Don't abort locks
       mysys_var->abort=1;
 
+    mysql_mutex_lock(&mysys_var->mutex);
     /*
       This broadcast could be up in the air if the victim thread
       exits the cond in the time between read and broadcast, but that is
       ok since all we want to do is to make the victim thread get out
       of waiting on current_cond.
       If we see a non-zero current_cond: it cannot be an old value (because
-      then exit_cond() should have run and it can't because we have mutex); so
-      it is the true value but maybe current_mutex is not yet non-zero (we're
-      in the middle of enter_cond() and there is a "memory order
-      inversion"). So we test the mutex too to not lock 0.
+      then exit_cond() should have run and it can't because we have mutex);
 
       Note that there is a small chance we fail to kill. If victim has locked
       current_mutex, but hasn't yet entered enter_cond() (which means that
@@ -1883,16 +1880,12 @@ void THD::awake_no_mutex(killed_state state_to_set)
       see it immediately and so may have time to reach the cond_wait().
 
       However, where possible, we test for killed once again after
-      enter_cond(). This should make the signaling as safe as possible.
-      However, there is still a small chance of failure on platforms with
-      instruction or memory write reordering.
+      enter_cond().
 
       We have to do the loop with trylock, because if we would use
       pthread_mutex_lock(), we can cause a deadlock as we are here locking
       the mysys_var->mutex and mysys_var->current_mutex in a different order
       than in the thread we are trying to kill.
-      We only sleep for 2 seconds as we don't want to have LOCK_thd_data
-      locked too long time.
 
       There is a small change we may not succeed in aborting a thread that
       is not yet waiting for a mutex, but as this happens only for a
@@ -1900,20 +1893,14 @@ void THD::awake_no_mutex(killed_state state_to_set)
       which should detect the kill flag before it starts to wait, this
       should be good enough.
     */
-    if (mysys_var->current_cond && mysys_var->current_mutex)
+    if (mysys_var->current_cond)
     {
-      uint i;
-      for (i= 0; i < WAIT_FOR_KILL_TRY_TIMES * SECONDS_TO_WAIT_FOR_KILL; i++)
+      int ret= mysql_mutex_trylock(mysys_var->current_mutex);
+      mysql_cond_broadcast(mysys_var->current_cond);
+      if (!ret)
       {
-        int ret= mysql_mutex_trylock(mysys_var->current_mutex);
-        mysql_cond_broadcast(mysys_var->current_cond);
-        if (!ret)
-        {
-          /* Signal is sure to get through */
-          mysql_mutex_unlock(mysys_var->current_mutex);
-          break;
-        }
-        my_sleep(1000000L / WAIT_FOR_KILL_TRY_TIMES);
+        /* Signal is sure to get through */
+        mysql_mutex_unlock(mysys_var->current_mutex);
       }
     }
     mysql_mutex_unlock(&mysys_var->mutex);
@@ -1974,12 +1961,11 @@ bool THD::notify_shared_lock(MDL_context_owner *ctx_in_use,
       in_use->set_killed_no_mutex(KILL_CONNECTION);
     if (in_use->mysys_var)
     {
+      /* Abort if about to wait in thr_upgrade_write_delay_lock */
+      in_use->mysys_var->abort= 1;
       mysql_mutex_lock(&in_use->mysys_var->mutex);
       if (in_use->mysys_var->current_cond)
         mysql_cond_broadcast(in_use->mysys_var->current_cond);
-
-      /* Abort if about to wait in thr_upgrade_write_delay_lock */
-      in_use->mysys_var->abort= 1;
       mysql_mutex_unlock(&in_use->mysys_var->mutex);
     }
     mysql_mutex_unlock(&in_use->LOCK_thd_kill);

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3244,8 +3244,10 @@ public:
              int src_line)
   {
     mysql_mutex_assert_owner(mutex);
+    mysql_mutex_lock(&mysys_var->mutex);
     mysys_var->current_mutex = mutex;
     mysys_var->current_cond = cond;
+    mysql_mutex_unlock(&mysys_var->mutex);
     if (old_stage)
       backup_stage(old_stage);
     if (stage)

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2710,14 +2710,15 @@ void kill_delayed_threads(void)
       mysql_mutex_lock(&di->thd.mysys_var->mutex);
       if (di->thd.mysys_var->current_cond)
       {
+	int ret= 1;
 	/*
 	  We need the following test because the main mutex may be locked
 	  in handle_delayed_insert()
 	*/
 	if (&di->mutex != di->thd.mysys_var->current_mutex)
-          mysql_mutex_lock(di->thd.mysys_var->current_mutex);
+          ret= mysql_mutex_trylock(di->thd.mysys_var->current_mutex);
         mysql_cond_broadcast(di->thd.mysys_var->current_cond);
-	if (&di->mutex != di->thd.mysys_var->current_mutex)
+	if (!ret)
           mysql_mutex_unlock(di->thd.mysys_var->current_mutex);
       }
       mysql_mutex_unlock(&di->thd.mysys_var->mutex);

--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -1034,9 +1034,12 @@ static void kill_delayed_threads_for_table(TDC_element *element)
       mysql_mutex_lock(&in_use->mysys_var->mutex);
       if (in_use->mysys_var->current_cond)
       {
-        mysql_mutex_lock(in_use->mysys_var->current_mutex);
+        int ret= mysql_mutex_trylock(in_use->mysys_var->current_mutex);
         mysql_cond_broadcast(in_use->mysys_var->current_cond);
-        mysql_mutex_unlock(in_use->mysys_var->current_mutex);
+        if (!ret)
+        {
+          mysql_mutex_unlock(in_use->mysys_var->current_mutex);
+        }
       }
       mysql_mutex_unlock(&in_use->mysys_var->mutex);
     }

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2090,9 +2090,12 @@ static void wsrep_close_thread(THD *thd)
     mysql_mutex_lock(&thd->mysys_var->mutex);
     if (thd->mysys_var->current_cond)
     {
-      mysql_mutex_lock(thd->mysys_var->current_mutex);
+      int ret= mysql_mutex_trylock(thd->mysys_var->current_mutex);
       mysql_cond_broadcast(thd->mysys_var->current_cond);
-      mysql_mutex_unlock(thd->mysys_var->current_mutex);
+      if (!ret)
+      {
+        mysql_mutex_unlock(thd->mysys_var->current_mutex);
+      }
     }
     mysql_mutex_unlock(&thd->mysys_var->mutex);
   }

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -463,9 +463,11 @@ static void wsrep_rollback_process(THD *thd)
   wsrep_aborting_thd= NULL;
 
   while (thd->killed == NOT_KILLED) {
+    mysql_mutex_lock(&thd->mysys_var->mutex);
     thd_proc_info(thd, "WSREP aborter idle");
     thd->mysys_var->current_mutex= &LOCK_wsrep_rollback;
     thd->mysys_var->current_cond=  &COND_wsrep_rollback;
+    mysql_mutex_unlock(&thd->mysys_var->mutex);
 
     mysql_cond_wait(&COND_wsrep_rollback,&LOCK_wsrep_rollback);
 

--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -105,8 +105,15 @@ Rdb_cond_var::WaitFor(const std::shared_ptr<TransactionDBMutex> mutex_arg,
   bool killed = false;
 
   do {
+#ifndef STANDALONE_UNITTEST
+    if (current_thd)
+    {
+      killed= thd_killed(current_thd);
+      if (killed)
+        break;
+    }
+#endif
     res = mysql_cond_timedwait(&m_cond, mutex_ptr, &wait_timeout);
-
 #ifndef STANDALONE_UNITTEST
     if (current_thd)
       killed= thd_killed(current_thd);


### PR DESCRIPTION
This patch fixes problems with "memory write order inversion" and
other problems that lead to the inoperability of the MW-328A test
from the Galera test suite. The MariaDB code contains many places
where the values​of the variables "mysys_var->current_cond" and
"mysys_var->current_mutex" are synchronously changed. Usually,
the zeroing of these variables is protected by the capture of
"mysys_var->mutex" mutex, but their initialization with non-zero
values usually is not protected with this mutex. To avoid the
problems caused by memory write order inversion, one of the code
fragments (in the sql/sql_class.cc file) uses mysql_cond_broadcast
for "mysys_var->current_cond" with additional checks and loop with
sleep(). However, there are several other places in the MariaDB
code where the similar broadcast is performed without additional
checks. In addition, there are many code fragments where broadcast
can be ignored because the enter_cond() is called after the
"thd->killed" flag is set, but (possibly) before checking the
"mysys_var->current_cond" variable by another thread (before
broadcast). So I added additional checks for "thd->killed" to
the code.