### PR TITLE
fix a data race in debug build

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -188,19 +188,19 @@ bool
 fil_validate_skip(void)
 /*===================*/
 {
-	/** The fil_validate() call skip counter. Use a signed type
-	because of the race condition below. */
+	/** The fil_validate() call skip counter. */
 	static int fil_validate_count = FIL_VALIDATE_SKIP;
 
-	/* There is a race condition below, but it does not matter,
-	because this call is only for heuristic purposes. We want to
-	reduce the call frequency of the costly fil_validate() check
-	in debug builds. */
-	if (--fil_validate_count > 0) {
+	/* We want to reduce the call frequency of the costly fil_validate()
+	 * check in debug builds. */
+	int count = my_atomic_add32_explicit(&fil_validate_count, -1,
+					     MY_MEMORY_ORDER_RELAXED);
+	if (count > 0) {
 		return(true);
 	}
 
-	fil_validate_count = FIL_VALIDATE_SKIP;
+	my_atomic_store32_explicit(&fil_validate_count, FIL_VALIDATE_SKIP,
+				   MY_MEMORY_ORDER_RELAXED);
 	return(fil_validate());
 }
 #endif /* UNIV_DEBUG */

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -192,7 +192,7 @@ fil_validate_skip(void)
 	static int fil_validate_count = FIL_VALIDATE_SKIP;
 
 	/* We want to reduce the call frequency of the costly fil_validate()
-	 * check in debug builds. */
+	check in debug builds. */
 	int count = my_atomic_add32_explicit(&fil_validate_count, -1,
 					     MY_MEMORY_ORDER_RELAXED);
 	if (count > 0) {


### PR DESCRIPTION
```c++
WARNING: ThreadSanitizer: data race (pid=5043)
  Write of size 4 at 0x00000288cba0 by thread T3:
    #0 fil_validate_skip() storage/innobase/fil/fil0fil.cc:199:6 (mysqld+0x1af2648)
    #1 fil_aio_wait(unsigned long) storage/innobase/fil/fil0fil.cc:5288:2 (mysqld+0x1af3b96)
    #2 io_handler_thread storage/innobase/srv/srv0start.cc:340:3 (mysqld+0x21e9ede)

  Previous write of size 4 at 0x00000288cba0 by thread T2:
    #0 fil_validate_skip() storage/innobase/fil/fil0fil.cc:199:6 (mysqld+0x1af2648)
    #1 fil_aio_wait(unsigned long) storage/innobase/fil/fil0fil.cc:5288:2 (mysqld+0x1af3b96)
    #2 io_handler_thread storage/innobase/srv/srv0start.cc:340:3 (mysqld+0x21e9ede)

  Location is global 'fil_validate_skip()::fil_validate_count' of size 4 at 0x00000288cba0 (mysqld+0x00000288cba0)
```

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.