### PR TITLE
MDEV-15052 - Allow sysusers and tmpfiles install for non-systemd users

### DIFF
--- a/support-files/CMakeLists.txt
+++ b/support-files/CMakeLists.txt
@@ -104,21 +104,6 @@ IF(UNIX)
             ${CMAKE_CURRENT_BINARY_DIR}/mariadb.service
             DESTINATION ${inst_location}/systemd COMPONENT SupportFiles)
 
-    IF(INSTALL_SYSTEMD_SYSUSERSDIR)
-      CONFIGURE_FILE(sysusers.conf.in
-              ${CMAKE_CURRENT_BINARY_DIR}/sysusers.conf @ONLY)
-      INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/sysusers.conf
-              DESTINATION ${INSTALL_SYSTEMD_SYSUSERSDIR} COMPONENT Server)
-    ENDIF()
-
-    IF(INSTALL_SYSTEMD_TMPFILESDIR)
-      get_filename_component(MYSQL_UNIX_DIR ${MYSQL_UNIX_ADDR} DIRECTORY)
-      CONFIGURE_FILE(tmpfiles.conf.in
-              ${CMAKE_CURRENT_BINARY_DIR}/tmpfiles.conf @ONLY)
-      INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/tmpfiles.conf
-              DESTINATION ${INSTALL_SYSTEMD_TMPFILESDIR} COMPONENT Server)
-    ENDIF()
-
     # @ in directory name broken between CMake version 2.8.12.2 and 3.3
     # http://public.kitware.com/Bug/view.php?id=14782
     IF(NOT CMAKE_VERSION VERSION_LESS 3.3.0 OR NOT RPM)
@@ -143,6 +128,21 @@ IF(UNIX)
       ENDIF()
 
     ENDIF()
+  ENDIF()
+
+  IF(INSTALL_SYSTEMD_SYSUSERSDIR)
+    CONFIGURE_FILE(sysusers.conf.in
+            ${CMAKE_CURRENT_BINARY_DIR}/sysusers.conf @ONLY)
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/sysusers.conf
+            DESTINATION ${INSTALL_SYSTEMD_SYSUSERSDIR} COMPONENT Server)
+  ENDIF()
+
+  IF(INSTALL_SYSTEMD_TMPFILESDIR)
+    get_filename_component(MYSQL_UNIX_DIR ${MYSQL_UNIX_ADDR} DIRECTORY)
+    CONFIGURE_FILE(tmpfiles.conf.in
+            ${CMAKE_CURRENT_BINARY_DIR}/tmpfiles.conf @ONLY)
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/tmpfiles.conf
+            DESTINATION ${INSTALL_SYSTEMD_TMPFILESDIR} COMPONENT Server)
   ENDIF()
 
   IF (INSTALL_SYSCONFDIR)


### PR DESCRIPTION
..as they have their own tools that parses those files, such as
opensysusers[1] that handles sysusers file and opentmpfiles[2] that
handles tmpfiles.d settings

Because of this. Move both sysusers and tmpfiles 'if' function
outside systemd function, allowing independent install

Signed-off-by: Rafli Akmal <thefallenrat@artixlinux.org>

[1] - https://github.com/artix-linux/opensysusers
[2] - https://github.com/OpenRC/opentmpfiles