### PR TITLE
Tests: detect table count for some encryption tests

### DIFF
--- a/mysql-test/suite/encryption/t/debug_key_management.test
+++ b/mysql-test/suite/encryption/t/debug_key_management.test
@@ -8,13 +8,14 @@ if (`select count(*) = 0 from information_schema.plugins
 set global innodb_encrypt_tables=ON;
 show variables like 'innodb_encrypt%';
 
-let $wait_condition= select count(*) = 3 from information_schema.innodb_tablespaces_encryption where current_key_version=1;
+--let $tables_count= `select count(*) + 1 from information_schema.tables where engine = 'InnoDB'`
+let $wait_condition= select count(*) = $tables_count from information_schema.innodb_tablespaces_encryption where current_key_version=1;
 --source include/wait_condition.inc
 
 select count(*) from information_schema.innodb_tablespaces_encryption where current_key_version <> 1;
 set global debug_key_management_version=10;
 
-let $wait_condition= select count(*) = 3 from information_schema.innodb_tablespaces_encryption where current_key_version=10;
+let $wait_condition= select count(*) = $tables_count from information_schema.innodb_tablespaces_encryption where current_key_version=10;
 --source include/wait_condition.inc
 
 select count(*) from information_schema.innodb_tablespaces_encryption where current_key_version <> 10;

--- a/mysql-test/suite/encryption/t/encrypt_and_grep.test
+++ b/mysql-test/suite/encryption/t/encrypt_and_grep.test
@@ -60,7 +60,8 @@ SET GLOBAL innodb_encrypt_tables = off;
 
 --echo # Wait max 10 min for key encryption threads to decrypt all spaces
 --let $wait_timeout= 600
---let $wait_condition=SELECT COUNT(*) = 5 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND CURRENT_KEY_VERSION = 0;
+--let $tables_count= `select count(*) from information_schema.tables where engine = 'InnoDB'`
+--let $wait_condition=SELECT COUNT(*) = $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND CURRENT_KEY_VERSION = 0;
 --source include/wait_condition.inc
 
 SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0;

--- a/mysql-test/suite/encryption/t/innodb_encryption.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption.test
@@ -14,9 +14,11 @@ SHOW VARIABLES LIKE 'innodb_encrypt%';
 
 SET GLOBAL innodb_encrypt_tables = ON;
 
+--let $tables_count= `select count(*) + 1 from information_schema.tables where engine = 'InnoDB'`
+
 --echo # Wait max 10 min for key encryption threads to encrypt all spaces
 --let $wait_timeout= 600
---let $wait_condition=SELECT COUNT(*) >= 3 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
+--let $wait_condition=SELECT COUNT(*) >= $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
 --source include/wait_condition.inc
 
 SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0;
@@ -59,7 +61,7 @@ SET GLOBAL innodb_encryption_threads=@start_global_value;
 
 --echo # Wait max 10 min for key encryption threads to encrypt all spaces
 --let $wait_timeout= 600
---let $wait_condition=SELECT COUNT(*) >=3 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
+--let $wait_condition=SELECT COUNT(*) >= $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
 --source include/wait_condition.inc
 
 SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0;


### PR DESCRIPTION
If real table count is different from what is expected by the test, it just hangs on waiting to fulfill hardcoded number. And then exits with **failed** after 10 minutes of wait: quite unfriendly and hard to figure out what's going on.

@janlindstrom Please, review and merge.
  