### PR TITLE
MDEV-14881 Add hint to clear Cmake cache after installing libaio

### DIFF
--- a/cmake/build_configurations/mysql_release.cmake
+++ b/cmake/build_configurations/mysql_release.cmake
@@ -135,7 +135,10 @@ IF(UNIX)
           RedHat/Fedora/Oracle Linux: yum install libaio-devel
           SuSE:                       zypper install libaio-devel
 
-        If you really do not want it, pass -DIGNORE_AIO_CHECK to cmake.
+        Please also remember to clear the Cmake cache afterwards, e.g. by
+        removing the CMakeCache.txt file before re-running cmake.
+
+        If you really do not want aio, pass -DIGNORE_AIO_CHECK to cmake.
         ")
       ENDIF()
 


### PR DESCRIPTION
It can be confusing to see cmake continue to fail with the same error message after installing the missing library otherwise, at least for users not aware of cmakes caching behaviour.