### PR TITLE
MDEV-15027 - mtr: set @skip_auth_anonymous=1

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -3198,6 +3198,9 @@ sub mysql_install_db {
       mtr_appendfile_to_file("$sql_dir/mysql_performance_tables.sql",
                             $bootstrap_sql_file);
 
+      # Don't install anonymous users
+      mtr_tofile($bootstrap_sql_file, "set \@skip_auth_anonymous=1;\n");
+
       # Add the mysql system tables initial data
       # for a production system
       mtr_appendfile_to_file("$sql_dir/mysql_system_tables_data.sql",
@@ -3231,10 +3234,6 @@ sub mysql_install_db {
       mtr_tofile($bootstrap_sql_file,
            sql_to_bootstrap($text));
     }
-
-    # Remove anonymous users
-    mtr_tofile($bootstrap_sql_file,
-         "DELETE FROM mysql.user where user= '';\n");
 
     # Create mtr database
     mtr_tofile($bootstrap_sql_file,


### PR DESCRIPTION
MTR explicitly removes the anonymous users 36 lines below this. Its easier if it doesn't install them in the first place.

Since 736afe868094b9aa24211c3772fb3b297d62d8fc the mysql_system_tables_data.sql only installs the anonymous user if skip_auth_anonymous IS NULL. Installing anonymous users is prevented by setting this to 1.

I hesitated removing "DELETE FROM mysql.user where user= ''" because the install from 5.0/5.1 made it look like mtr was designed to be run against any version. It probably can be removed in an non-GA after this is merged.

I submit this under the MCA.