### PR TITLE
MDEV-14796: debian: insecure root password is only if plugin is empty

### DIFF
--- a/debian/additions/debian-start.inc.sh
+++ b/debian/additions/debian-start.inc.sh
@@ -65,7 +65,7 @@ function check_root_accounts() {
   
   logger -p daemon.info -i -t$0 "Checking for insecure root accounts."
 
-  ret=$( echo "SELECT count(*) FROM mysql.user WHERE user='root' and password='';" | $MYSQL --skip-column-names )
+  ret=$( echo "SELECT count(*) FROM mysql.user WHERE user='root' and password='' and plugin='';" | $MYSQL --skip-column-names )
   if [ "$ret" -ne "0" ]; then
     logger -p daemon.warn -i -t$0 "WARNING: mysql.user contains $ret root accounts without password!"
   fi


### PR DESCRIPTION

I submit this under the MCA.