### PR TITLE
MDEV-15111 - fix simple InnoDB data race

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -311,7 +311,8 @@ thd_destructor_proxy(void *)
 	myvar->current_cond = &thd_destructor_cond;
 
 	mysql_mutex_lock(&thd_destructor_mutex);
-	srv_running = myvar;
+	my_atomic_storeptr_explicit(&srv_running, myvar,
+				    MY_MEMORY_ORDER_RELAXED);
 	/* wait until the server wakes the THD to abort and die */
 	while (!srv_running->abort)
 		mysql_cond_wait(&thd_destructor_cond, &thd_destructor_mutex);
@@ -4209,7 +4210,8 @@ innobase_change_buffering_inited_ok:
 		mysql_thread_create(thd_destructor_thread_key,
 				    &thd_destructor_thread,
 				    NULL, thd_destructor_proxy, NULL);
-		while (!srv_running)
+		while (!my_atomic_loadptr_explicit(&srv_running,
+						   MY_MEMORY_ORDER_RELAXED))
 			os_thread_sleep(20);
 	}
 

--- a/storage/innobase/include/ib0mutex.h
+++ b/storage/innobase/include/ib0mutex.h
@@ -527,7 +527,8 @@ struct TTASEventMutex {
 	int32 state() const
 		UNIV_NOTHROW
 	{
-		return(m_lock_word);
+		return(my_atomic_load32_explicit(&m_lock_word,
+						 MY_MEMORY_ORDER_RELAXED));
 	}
 
 	/** The event that the mutex will wait in sync0arr.cc


### PR DESCRIPTION
```c++
==================
WARNING: ThreadSanitizer: data race (pid=12041)
  Write of size 8 at 0x000003949278 by thread T26 (mutexes: write M226445748578513120):
    #0 thd_destructor_proxy storage/innobase/handler/ha_innodb.cc:314:14 (mysqld+0x19b5505)

  Previous read of size 8 at 0x000003949278 by main thread:
    #0 innobase_init(void*) storage/innobase/handler/ha_innodb.cc:4180:11 (mysqld+0x1a03404)
    #1 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:522:31 (mysqld+0xc5ec73)
    #2 plugin_initialize(st_mem_root*, st_plugin_int*, int*, char**, bool) sql/sql_plugin.cc:1447:9 (mysqld+0x134908d)
    #3 plugin_init(int*, char**, int) sql/sql_plugin.cc:1729:15 (mysqld+0x13484f0)
    #4 init_server_components() sql/mysqld.cc:5345:7 (mysqld+0xbf720f)
    #5 mysqld_main(int, char**) sql/mysqld.cc:5940:7 (mysqld+0xbf107d)
    #6 main sql/main.cc:25:10 (mysqld+0xbe971b)

  Location is global 'srv_running' of size 8 at 0x000003949278 (mysqld+0x000003949278)

  Mutex M226445748578513120 is already destroyed.

  Thread T26 (tid=12070, running) created by main thread at:
    #0 pthread_create /home/kevg/fun/cpp_projects/llvm_toolchain/llvm/projects/compiler-rt/lib/tsan/rtl/tsan_interceptors.cc:992 (mysqld+0xb7a016)
    #1 spawn_thread_noop mysys/psi_noop.c:187:10 (mysqld+0x26fe403)
    #2 inline_mysql_thread_create(unsigned int, unsigned long*, pthread_attr_t const*, void* (*)(void*), void*) include/mysql/psi/mysql_thread.h:1239:11 (mysqld+0x1a1136d)
    #3 innobase_init(void*) storage/innobase/handler/ha_innodb.cc:4177:3 (mysqld+0x1a033e5)
    #4 ha_initialize_handlerton(st_plugin_int*) sql/handler.cc:522:31 (mysqld+0xc5ec73)
    #5 plugin_initialize(st_mem_root*, st_plugin_int*, int*, char**, bool) sql/sql_plugin.cc:1447:9 (mysqld+0x134908d)
    #6 plugin_init(int*, char**, int) sql/sql_plugin.cc:1729:15 (mysqld+0x13484f0)
    #7 init_server_components() sql/mysqld.cc:5345:7 (mysqld+0xbf720f)
    #8 mysqld_main(int, char**) sql/mysqld.cc:5940:7 (mysqld+0xbf107d)
    #9 main sql/main.cc:25:10 (mysqld+0xbe971b)

SUMMARY: ThreadSanitizer: data race storage/innobase/handler/ha_innodb.cc:314:14 in thd_destructor_proxy
==================
```

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.