### PR TITLE
MDEV-8765: mysqldump -use utf8mb4 by default

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -39,7 +39,7 @@
 ** 10 Jun 2003: SET NAMES and --no-set-names by Alexander Barkov
 */
 
-#define DUMP_VERSION "10.14"
+#define DUMP_VERSION "10.17"
 
 #include <my_global.h>
 #include <my_sys.h>

--- a/include/my_global.h
+++ b/include/my_global.h
@@ -1339,7 +1339,9 @@ do { doubleget_union _tmp; \
 
 #endif /* WORDS_BIGENDIAN */
 
-#ifdef HAVE_CHARSET_utf8
+#ifdef HAVE_CHARSET_utf8mb4
+#define MYSQL_UNIVERSAL_CLIENT_CHARSET "utf8mb4"
+#elif defined(HAVE_CHARSET_utf8)
 #define MYSQL_UNIVERSAL_CLIENT_CHARSET "utf8"
 #else
 #define MYSQL_UNIVERSAL_CLIENT_CHARSET MYSQL_DEFAULT_CHARSET_NAME


### PR DESCRIPTION
Even on 5.5 users are possibly using utf8mb4, even if they don't know it. If they are using mysqldump for backup they may be unaware their backups contain corrupted data that can't be represented in utf8.

I submit this under the MCA.