### PR TITLE
MDEV-15044 - sst use of mysqld --default* options, sst script enhancements, mtr tests

### DIFF
--- a/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
+++ b/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
@@ -12,6 +12,9 @@ wsrep-causal-reads=ON
 wsrep-sync-wait=15
 
 [mysqld.1]
+#galera_port=@OPT.port
+#ist_port=@OPT.port
+#sst_port=@OPT.port
 wsrep-cluster-address='gcomm://'
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S'
 

--- a/mysql-test/suite/galera_3nodes/include/have_ipv6.inc
+++ b/mysql-test/suite/galera_3nodes/include/have_ipv6.inc
@@ -1,0 +1,15 @@
+# Check if ipv6 is available.
+#
+--disable_query_log
+--disable_result_log
+connect (checkcon123456789,::1,root,,test);
+if($mysql_errno)
+{
+    skip No IPv6 support;
+}
+connection default;
+disconnect checkcon123456789;
+--enable_result_log
+--enable_query_log
+# end check
+

--- a/mysql-test/suite/galera_3nodes/t/galera_innobackupex_backup.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_innobackupex_backup.test
@@ -16,7 +16,7 @@ SELECT COUNT(*) = 10 FROM t1;
 --exec innobackupex --defaults-file=$MYSQLTEST_VARDIR/my.cnf --defaults-group=mysqld.2 $MYSQL_TMP_DIR/innobackupex_backup --galera-info --port=$NODE_MYPORT_2 --host=127.0.0.1 --no-timestamp > $MYSQL_TMP_DIR/innobackupex-backup.log
 --exec innobackupex --defaults-file=$MYSQLTEST_VARDIR/my.cnf --defaults-group=mysqld.2 $MYSQL_TMP_DIR/innobackupex_backup --apply-log --galera-info --port=$NODE_MYPORT_2 --host=127.0.0.1 --no-timestamp > $MYSQL_TMP_DIR/innobackupex-apply.log
 
---source include/kill_galera.inc
+--source ../galera/include/kill_galera.inc
 --sleep 1
 
 --connection node_1

--- a/mysql-test/suite/galera_3nodes/t/galera_safe_to_bootstrap.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_safe_to_bootstrap.test
@@ -109,7 +109,7 @@ SET SESSION wsrep_on = OFF;
 --let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 --source include/wait_condition.inc
 
---source include/kill_galera.inc
+--source ../galera/include/kill_galera.inc
 
 #
 # Only node #1 should have safe_to_bootstrap: 1

--- a/mysys/my_default.c
+++ b/mysys/my_default.c
@@ -88,15 +88,6 @@ static char my_defaults_extra_file_buffer[FN_REFLEN];
 
 static my_bool defaults_already_read= FALSE;
 
-#ifdef WITH_WSREP
-/*
-  The only purpose of this global array is to hold full name of my.cnf
-  which seems to be otherwise unavailable.
-*/
-char wsrep_defaults_file[FN_REFLEN + 10]= {0,};
-char wsrep_defaults_group_suffix[FN_EXTLEN]= {0,};
-#endif /* WITH_WSREP */
-
 /* Which directories are searched for options (and in which order) */
 
 #define MAX_DEFAULT_DIRS 7
@@ -442,16 +433,6 @@ int get_defaults_options(int argc, char **argv,
     if (!*group_suffix && is_prefix(*argv, "--defaults-group-suffix="))
     {
       *group_suffix= *argv + sizeof("--defaults-group-suffix=")-1;
-
-#ifdef WITH_WSREP
-      /* make sure we do this only once - for top-level file */
-      if ('\0' == wsrep_defaults_group_suffix[0])
-      {
-        strncpy(wsrep_defaults_group_suffix, *group_suffix,
-                sizeof(wsrep_defaults_group_suffix) - 1);
-      }
-#endif /* WITH_WSREP */
-
       argc--;
       continue;
     }
@@ -822,12 +803,6 @@ static int search_default_file_with_ext(Process_option_func opt_handler,
 #endif
   if (!(fp= mysql_file_fopen(key_file_cnf, name, O_RDONLY, MYF(0))))
     return 1;					/* Ignore wrong files */
-
-#ifdef WITH_WSREP
-  /* make sure we do this only once - for top-level file */
-  if ('\0' == wsrep_defaults_file[0])
-    strncpy(wsrep_defaults_file, name, sizeof(wsrep_defaults_file) - 1);
-#endif /* WITH_WSREP */
 
   while (mysql_file_fgets(buff, sizeof(buff) - 1, fp))
   {

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -35,19 +35,20 @@ case "$1" in
         #
         # Break address string into host:port/path parts
         #
-        if echo $WSREP_SST_OPT_ADDR | grep -qe '^\[.*\]'
+        readonly WSREP_SST_OPT_HOST=${WSREP_SST_OPT_ADDR%%[:/]*}
+        if [ ${WSREP_SST_OPT_HOST:0:1} = '[' ]
         then
             # IPv6 notation
-            readonly WSREP_SST_OPT_HOST=${WSREP_SST_OPT_ADDR/\]*/\]}
-            readonly WSREP_SST_OPT_HOST_UNESCAPED=$(echo $WSREP_SST_OPT_HOST | \
-                 cut -d '[' -f 2 | cut -d ']' -f 1)
-        else
-            # "traditional" notation
-            readonly WSREP_SST_OPT_HOST=${WSREP_SST_OPT_ADDR%%[:/]*}
+            readonly WSREP_SST_OPT_HOST_UNESCAPED=${WSREP_SST_OPT_HOST:1:-1}
         fi
         readonly WSREP_SST_OPT_PORT=$(echo $WSREP_SST_OPT_ADDR | \
                 cut -d ']' -f 2 | cut -s -d ':' -f 2 | cut -d '/' -f 1)
         readonly WSREP_SST_OPT_PATH=${WSREP_SST_OPT_ADDR#*/}
+        readonly WSREP_SST_OPT_MODULE=${WSREP_SST_OPT_PATH%%/*}
+        remain=${WSREP_SST_OPT_PATH#*/}
+        readonly WSREP_SST_OPT_LSN=${remain%%/*}
+        remain=${remain#*/}
+        readonly WSREP_SST_OPT_SST_VER=${remain%%/*}
         shift
         ;;
     '--bypass')

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -245,11 +245,10 @@ parse_cnf()
     local reval=""
 
     # normalize the variable names specified in cnf file (user can use _ or - for example log-bin or log_bin)
-    # then grep for needed variable
+    # then search for needed variable
     # finally get the variable value (if variables has been specified multiple time use the last value only)
 
-    # TODO: get awk to do the grep/cut bits as well
-    reval=$($MY_PRINT_DEFAULTS "${group}" | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
+    reval=$($MY_PRINT_DEFAULTS "${group}" | awk -v var="${var}" 'BEGIN { OFS=FS="=" } { gsub(/_/,"-",$1); if ( $1=="--"var) lastval=substr($0,length($1)+2) } END { print lastval}')
 
     # use default if we haven't found a value
     if [ -z $reval ]; then

--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -40,6 +40,8 @@ case "$1" in
         then
             # IPv6 notation
             readonly WSREP_SST_OPT_HOST_UNESCAPED=${WSREP_SST_OPT_HOST:1:-1}
+        else
+            readonly WSREP_SST_OPT_HOST_UNESCAPED=${WSREP_SST_OPT_HOST}
         fi
         readonly WSREP_SST_OPT_PORT=$(echo $WSREP_SST_OPT_ADDR | \
                 cut -d ']' -f 2 | cut -s -d ':' -f 2 | cut -d '/' -f 1)

--- a/scripts/wsrep_sst_mysqldump.sh
+++ b/scripts/wsrep_sst_mysqldump.sh
@@ -17,10 +17,6 @@
 
 # This is a reference script for mysqldump-based state snapshot tansfer
 
-# This variable is not used in mysqldump sst, so better initialize it
-# to avoid shell's "parameter not set" message.
-WSREP_SST_OPT_CONF=""
-
 . $(dirname $0)/wsrep_sst_common
 PATH=$PATH:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -106,7 +102,7 @@ GTID_BINLOG_STATE=$(echo "SHOW GLOBAL VARIABLES LIKE 'gtid_binlog_state'" |\
 $MYSQL_CLIENT $AUTH -S$WSREP_SST_OPT_SOCKET --disable-reconnect --connect_timeout=10 |\
 tail -1 | awk -F ' ' '{ print $2 }')
 
-MYSQL="$MYSQL_CLIENT --defaults-extra-file=$WSREP_SST_OPT_CONF "\
+MYSQL="$MYSQL_CLIENT $WSREP_SST_OPT_CONF "\
 "$AUTH -h${WSREP_SST_OPT_HOST_UNESCAPED:-$WSREP_SST_OPT_HOST} "\
 "-P$WSREP_SST_OPT_PORT --disable-reconnect --connect_timeout=10"
 

--- a/scripts/wsrep_sst_mysqldump.sh
+++ b/scripts/wsrep_sst_mysqldump.sh
@@ -103,7 +103,7 @@ $MYSQL_CLIENT $AUTH -S$WSREP_SST_OPT_SOCKET --disable-reconnect --connect_timeou
 tail -1 | awk -F ' ' '{ print $2 }')
 
 MYSQL="$MYSQL_CLIENT $WSREP_SST_OPT_CONF "\
-"$AUTH -h${WSREP_SST_OPT_HOST_UNESCAPED:-$WSREP_SST_OPT_HOST} "\
+"$AUTH -h${WSREP_SST_OPT_HOST_UNESCAPED} "\
 "-P$WSREP_SST_OPT_PORT --disable-reconnect --connect_timeout=10"
 
 # Check if binary logging is enabled on the joiner node.

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -102,19 +102,7 @@ fi
 WSREP_LOG_DIR=${WSREP_LOG_DIR:-""}
 # if WSREP_LOG_DIR env. variable is not set, try to get it from my.cnf
 if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf mariadb-10.0 innodb_log_group_home_dir "")
-fi
-if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf mysqld innodb_log_group_home_dir "")
-fi
-if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf server innodb_log_group_home_dir "")
-fi
-if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf mariadb innodb_log_group_home_dir "")
-fi
-if [ -z "$WSREP_LOG_DIR" ]; then
-    WSREP_LOG_DIR=$(parse_cnf mysqld-10.0 innodb_log_group_home_dir "")
+    WSREP_LOG_DIR=$(parse_cnf --mysqld innodb-log-group-home-dir '')
 fi
 
 if [ -n "$WSREP_LOG_DIR" ]; then

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -469,15 +469,15 @@ read_cnf()
     # Pull the parameters needed for encrypt=4
     ssl_ca=$(parse_cnf sst ssl-ca "")
     if [[ -z "$ssl_ca" ]]; then
-        ssl_ca=$(parse_cnf mysqld ssl-ca "")
+        ssl_ca=$(parse_cnf --mysqld ssl-ca "")
     fi
     ssl_cert=$(parse_cnf sst ssl-cert "")
     if [[ -z "$ssl_cert" ]]; then
-        ssl_cert=$(parse_cnf mysqld ssl-cert "")
+        ssl_cert=$(parse_cnf --mysqld ssl-cert "")
     fi
     ssl_key=$(parse_cnf sst ssl-key "")
     if [[ -z "$ssl_key" ]]; then
-        ssl_key=$(parse_cnf mysqld ssl-key "")
+        ssl_key=$(parse_cnf --mysqld ssl-key "")
     fi
 
     rlimit=$(parse_cnf sst rlimit "")
@@ -667,8 +667,8 @@ check_extra()
 {
     local use_socket=1
     if [[ $uextra -eq 1 ]];then 
-        if $MY_PRINT_DEFAULTS --mysqld | tr '_' '-' | grep -- "--thread-handling=" | grep -q 'pool-of-threads';then 
-            local eport=$($MY_PRINT_DEFAULTS --mysqld | tr '_' '-' | grep -- "--extra-port=" | cut -d= -f2)
+        if [ $(parse_cnf --mysqld thread-handling) = 'pool-of-threads'];then
+            local eport=$(parse_cnf --mysqld extra-port)
             if [[ -n $eport ]];then 
                 # Xtrabackup works only locally.
                 # Hence, setting host to 127.0.0.1 unconditionally. 
@@ -901,7 +901,7 @@ then
             exit 93
         fi
 
-        if [[ -z $(parse_cnf mysqld tmpdir "") && -z $(parse_cnf xtrabackup tmpdir "") ]];then 
+        if [[ -z $(parse_cnf --mysqld tmpdir "") && -z $(parse_cnf xtrabackup tmpdir "") ]];then 
             xtmpdir=$(mktemp -d)
             tmpopts=" --tmpdir=$xtmpdir "
             wsrep_log_info "Using $xtmpdir as xtrabackup temporary directory"
@@ -1015,9 +1015,9 @@ then
     [[ -e $SST_PROGRESS_FILE ]] && wsrep_log_info "Stale sst_in_progress file: $SST_PROGRESS_FILE"
     [[ -n $SST_PROGRESS_FILE ]] && touch $SST_PROGRESS_FILE
 
-    ib_home_dir=$(parse_cnf mysqld innodb-data-home-dir "")
-    ib_log_dir=$(parse_cnf mysqld innodb-log-group-home-dir "")
-    ib_undo_dir=$(parse_cnf mysqld innodb-undo-directory "")
+    ib_home_dir=$(parse_cnf --mysqld innodb-data-home-dir "")
+    ib_log_dir=$(parse_cnf --mysqld innodb-log-group-home-dir "")
+    ib_undo_dir=$(parse_cnf --mysqld innodb-undo-directory "")
 
     stagemsg="Joiner-Recv"
 
@@ -1079,7 +1079,7 @@ then
         wsrep_log_info "Cleaning the existing datadir and innodb-data/log directories"
         find $ib_home_dir $ib_log_dir $ib_undo_dir $DATA -mindepth 1  -regex $cpat  -prune  -o -exec rm -rfv {} 1>&2 \+
 
-        tempdir=$(parse_cnf mysqld log-bin "")
+        tempdir=$(parse_cnf --mysqld log-bin "")
         if [[ -n ${tempdir:-} ]];then
             binlog_dir=$(dirname $tempdir)
             binlog_file=$(basename $tempdir)

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -852,16 +852,9 @@ fi
 get_stream
 get_transfer
 
-# This is as close as innobackupex gets to mysqld defaults. Important note --defaults-extra-file passed to
-# mysqld is not passed to innobackupex.
-# WSREP_SST_OPT_SUFFIX_DEFAULT goes from --defaults-group-suffix=.X to --defaults-group=mysqld.X
-# Ref: https://bugs.launchpad.net/codership-mysql/+bug/1378355
-
-readonly INNOBACKUP_OPT_DEFAULT="${$WSREP_SST_OPT_DEFAULT} ${WSREP_SST_OPT_SUFFIX_DEFAULT/-suffix=/=mysqld}"
-
 INNOAPPLY="${INNOBACKUPEX_BIN} $disver $iapts --apply-log \$rebuildcmd \${DATA} ${INNOAPPLY}"
-INNOMOVE="${INNOBACKUPEX_BIN} ${INNOBACKUP_OPT_DEFAULT} $disver $impts  --move-back --force-non-empty-directories \${DATA} ${INNOMOVE}"
-INNOBACKUP="${INNOBACKUPEX_BIN} ${INNOBACKUP_OPT_DEFAULT} $disver $iopts \$tmpopts \$INNOEXTRA --galera-info --stream=\$sfmt \$itmpdir ${INNOBACKUP}"
+INNOMOVE="${INNOBACKUPEX_BIN} ${WSREP_SST_OPT_CONF} $disver $impts  --move-back --force-non-empty-directories \${DATA} ${INNOMOVE}"
+INNOBACKUP="${INNOBACKUPEX_BIN} ${WSREP_SST_OPT_CONF} $disver $iopts \$tmpopts \$INNOEXTRA --galera-info --stream=\$sfmt \$itmpdir ${INNOBACKUP}"
 
 if [ "$WSREP_SST_OPT_ROLE" = "donor" ]
 then

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -399,7 +399,7 @@ get_transfer()
 get_footprint()
 {
     pushd $WSREP_SST_OPT_DATA 1>/dev/null
-    payload=$(find . -regex '.*\.ibd$\|.*\.MYI$\|.*\.MYD$\|.*ibdata1$' -type f -print0 | du --files0-from=- --block-size=1 -c | awk 'END { print $1 }')
+    payload=$(find . -regex '.*\.ibd$\|.*\.MYI$\|.*\.MYD$\|.*ibdata1$' -type f -print0 | du --files0-from=- --block-size=1 -c -s | awk 'END { print $1 }')
     if $MY_PRINT_DEFAULTS xtrabackup | grep -q -- "--compress";then 
         # QuickLZ has around 50% compression ratio
         # When compression/compaction used, the progress is only an approximate.

--- a/scripts/wsrep_sst_xtrabackup.sh
+++ b/scripts/wsrep_sst_xtrabackup.sh
@@ -377,8 +377,8 @@ check_extra()
 {
     local use_socket=1
     if [[ $uextra -eq 1 ]];then 
-        if $MY_PRINT_DEFAULTS --mysqld | tr '_' '-' | grep -- "--thread-handling=" | grep -q 'pool-of-threads';then 
-            local eport=$($MY_PRINT_DEFAULTS --mysqld | tr '_' '-' | grep -- "--extra-port=" | cut -d= -f2)
+        if [ $(parse_cnf --mysqld thread-handling) = 'pool-of-threads'];then
+            local eport=$(parse_cnf --mysqld extra-port)
             if [[ -n $eport ]];then 
                 # Xtrabackup works only locally.
                 # Hence, setting host to 127.0.0.1 unconditionally. 

--- a/scripts/wsrep_sst_xtrabackup.sh
+++ b/scripts/wsrep_sst_xtrabackup.sh
@@ -398,16 +398,9 @@ setup_ports
 get_stream
 get_transfer
 
-# This is as close as innobackupex gets to mysqld defaults. Important note --defaults-extra-file passed to
-# mysqld is not passed to innobackupex.
-# WSREP_SST_OPT_SUFFIX_DEFAULT goes from --defaults-group-suffix=.X to --defaults-group=mysqld.X
-# Ref: https://bugs.launchpad.net/codership-mysql/+bug/1378355
-
-readonly INNOBACKUP_OPT_DEFAULT="${$WSREP_SST_OPT_DEFAULT} ${WSREP_SST_OPT_SUFFIX_DEFAULT/-suffix=/=mysqld}"
-
 INNOEXTRA=""
-INNOAPPLY="${INNOBACKUPEX_BIN} ${INNOBACKUP_OPT_DEFAULT} --apply-log \$rebuildcmd \${DATA} &>\${DATA}/innobackup.prepare.log"
-INNOBACKUP="${INNOBACKUPEX_BIN} ${INNOBACKUP_OPT_DEFAULT} \$INNOEXTRA --galera-info --stream=\$sfmt \${TMPDIR} 2>\${DATA}/innobackup.backup.log"
+INNOAPPLY="${INNOBACKUPEX_BIN} ${WSREP_SST_OPT_CONF} --apply-log \$rebuildcmd \${DATA} &>\${DATA}/innobackup.prepare.log"
+INNOBACKUP="${INNOBACKUPEX_BIN} ${WSREP_SST_OPT_CONF} \$INNOEXTRA --galera-info --stream=\$sfmt \${TMPDIR} 2>\${DATA}/innobackup.backup.log"
 
 if [ "$WSREP_SST_OPT_ROLE" = "donor" ]
 then
@@ -660,7 +653,7 @@ then
 
         if [[ $incremental -eq 1 ]];then 
             # Added --ibbackup=xtrabackup_55 because it fails otherwise citing connection issues.
-            INNOAPPLY="${INNOBACKUPEX_BIN} ${INNOBACKUP_OPT_DEFAULT} \
+            INNOAPPLY="${INNOBACKUPEX_BIN} ${WSREP_SST_OPT_CONF} \
                 --ibbackup=xtrabackup_55 --apply-log $rebuildcmd --redo-only $BDATA --incremental-dir=${DATA} &>>${BDATA}/innobackup.prepare.log"
         fi
 

--- a/scripts/wsrep_sst_xtrabackup.sh
+++ b/scripts/wsrep_sst_xtrabackup.sh
@@ -30,15 +30,13 @@ encrypt=0
 nproc=1
 ecode=0
 XTRABACKUP_PID=""
-SST_PORT=""
-REMOTEIP=""
 tcert=""
 tpem=""
 sockopt=""
 progress=""
 ttime=0
 totime=0
-lsn=""
+lsn="${WSREP_SST_OPT_LSN}"
 incremental=0
 ecmd=""
 rlimit=""
@@ -136,11 +134,7 @@ get_keys()
 
 get_transfer()
 {
-    if [[ -z $SST_PORT ]];then 
-        TSST_PORT=4444
-    else 
-        TSST_PORT=$SST_PORT
-    fi
+    TSST_PORT=${WSREP_SST_OPT_PORT:-4444}
 
     if [[ $tfmt == 'nc' ]];then
         if [[ ! -x `which nc` ]];then 
@@ -155,7 +149,7 @@ get_transfer()
                 tcmd="nc -dl ${TSST_PORT}"
             fi
         else
-            tcmd="nc ${REMOTEIP} ${TSST_PORT}"
+            tcmd="nc ${WSREP_SST_OPT_HOST_UNESCAPED} ${TSST_PORT}"
         fi
     else
         tfmt='socat'
@@ -181,13 +175,13 @@ get_transfer()
                 tcmd="socat -u openssl-listen:${TSST_PORT},reuseaddr,cert=$tpem,cafile=${tcert}${sockopt} stdio"
             else
                 wsrep_log_info "Encrypting with PEM $tpem, CA: $tcert"
-                tcmd="socat -u stdio openssl-connect:${REMOTEIP}:${TSST_PORT},cert=$tpem,cafile=${tcert}${sockopt}"
+                tcmd="socat -u stdio openssl-connect:${WSREP_SST_OPT_HOST}:${TSST_PORT},cert=$tpem,cafile=${tcert}${sockopt}"
             fi
         else 
             if [[ "$WSREP_SST_OPT_ROLE"  == "joiner" ]];then
                 tcmd="socat -u TCP-LISTEN:${TSST_PORT},reuseaddr${sockopt} stdio"
             else
-                tcmd="socat -u stdio TCP:${REMOTEIP}:${TSST_PORT}${sockopt}"
+                tcmd="socat -u stdio TCP:${WSREP_SST_OPT_HOST}:${TSST_PORT}${sockopt}"
             fi
         fi
     fi
@@ -343,17 +337,6 @@ kill_xtrabackup()
     rm -f "$XTRABACKUP_PID"
 }
 
-setup_ports()
-{
-    if [[ "$WSREP_SST_OPT_ROLE"  == "donor" ]];then
-        SST_PORT=$(echo $WSREP_SST_OPT_ADDR | awk -F '[:/]' '{ print $2 }')
-        REMOTEIP=$(echo $WSREP_SST_OPT_ADDR | awk -F ':' '{ print $1 }')
-        lsn=$(echo $WSREP_SST_OPT_ADDR | awk -F '[:/]' '{ print $4 }')
-    else
-        SST_PORT=$(echo ${WSREP_SST_OPT_ADDR} | awk -F ':' '{ print $2 }')
-    fi
-}
-
 # waits ~10 seconds for nc to open the port and then reports ready
 # (regardless of timeout)
 wait_for_listen()
@@ -462,7 +445,7 @@ then
 
         check_extra
 
-        wsrep_log_info "Streaming the backup to joiner at ${REMOTEIP} ${SST_PORT}"
+        wsrep_log_info "Streaming the backup to joiner at ${WSREP_SST_OPT_HOST} ${WSREP_SST_OPT_PORT}"
 
         if [[ -n $progress ]];then 
             get_footprint
@@ -542,14 +525,9 @@ then
     # May need xtrabackup_checkpoints later on
     rm -f ${DATA}/xtrabackup_binary ${DATA}/xtrabackup_galera_info  ${DATA}/xtrabackup_logfile
 
-    ADDR=${WSREP_SST_OPT_ADDR}
-    if [ -z "${SST_PORT}" ]
-    then
-        SST_PORT=4444
-        ADDR="$(echo ${WSREP_SST_OPT_ADDR} | awk -F ':' '{ print $1 }'):${SST_PORT}"
-    fi
+    ADDR="${WSREP_SST_OPT_HOST}:${WSREP_SST_OPT_PORT:-4444}"
 
-    wait_for_listen ${SST_PORT} ${ADDR} ${MODULE} &
+    wait_for_listen ${WSREP_SST_OPT_PORT:-4444} ${ADDR} ${MODULE} &
 
     trap sig_joiner_cleanup HUP PIPE INT TERM
     trap cleanup_joiner EXIT

--- a/scripts/wsrep_sst_xtrabackup.sh
+++ b/scripts/wsrep_sst_xtrabackup.sh
@@ -197,7 +197,7 @@ get_transfer()
 get_footprint()
 {
     pushd $WSREP_SST_OPT_DATA 1>/dev/null
-    payload=$(find . -regex '.*\.ibd$\|.*\.MYI$\|.*\.MYD$\|.*ibdata1$' -type f -print0 | du --files0-from=- --block-size=1 -c | awk 'END { print $1 }')
+    payload=$(find . -regex '.*\.ibd$\|.*\.MYI$\|.*\.MYD$\|.*ibdata1$' -type f -print0 | du --files0-from=- --block-size=1 -c -s | awk 'END { print $1 }')
     if $MY_PRINT_DEFAULTS xtrabackup | grep -q -- "--compress";then 
         # QuickLZ has around 50% compression ratio
         # When compression/compaction used, the progress is only an approximate.

--- a/sql/wsrep_sst.h
+++ b/sql/wsrep_sst.h
@@ -25,6 +25,7 @@
 #define WSREP_SST_OPT_DATA     "--datadir"
 #define WSREP_SST_OPT_CONF     "--defaults-file"
 #define WSREP_SST_OPT_CONF_SUFFIX "--defaults-group-suffix"
+#define WSREP_SST_OPT_CONF_EXTRA  "--defaults-extra-file"
 #define WSREP_SST_OPT_PARENT   "--parent"
 #define WSREP_SST_OPT_BINLOG   "--binlog"
 


### PR DESCRIPTION
group processing by parse_cnf (aka my_print_defaults) resulted in sst scripts fetching potentially a different set of settings than what the mysqld was running.

Replace a lot of group mysqld with --mysqld to be more accurate and now default-group-suffix and --defaults-file-extra a parse though like in 10.1.

Fix a few unnecessary use of grep/cut/tail for string processing.

I submit this under the MCA.