### PR TITLE
MDEV-15045 - wsrep_sst_mysqldump: enforce a minimum version only

### DIFF
--- a/scripts/wsrep_sst_mysqldump.sh
+++ b/scripts/wsrep_sst_mysqldump.sh
@@ -57,10 +57,10 @@ then
 fi
 
 # Check client version
-if ! $MYSQL_CLIENT --version | grep 'Distrib 10.1' >/dev/null
+if ! $MYSQL_CLIENT --version | grep 'Distrib 10\.[1-9]' >/dev/null
 then
     $MYSQL_CLIENT --version >&2
-    wsrep_log_error "this operation requires MySQL client version 10 or newer"
+    wsrep_log_error "this operation requires MySQL client version 10.1 or newer"
     exit $EINVAL
 fi
 


### PR DESCRIPTION
Take any 10.X (X > 1) for wsrep_sst_mysqldump.

Also escape . as its a pattern.

I  submit this under the MCA.