### PR TITLE
defaults-groups-suffix in print_defaults

### DIFF
--- a/mysql-test/r/mysqld--help.result
+++ b/mysql-test/r/mysqld--help.result
@@ -1,8 +1,10 @@
 The following options may be given as the first argument:
 --print-defaults Print the program argument list and exit.
 --no-defaults Don't read default options from any option file.
+The following specify which files/extra groups are read (specified before remaining options):
 --defaults-file=# Only read default options from the given file #.
 --defaults-extra-file=# Read this file after the global files are read.
+--defaults-group-suffix=# Additionally read default groups with # appended as a suffix.
 
  --allow-suspicious-udfs 
  Allows use of UDFs consisting of only one symbol xxx()

--- a/mysys/default.c
+++ b/mysys/default.c
@@ -1101,10 +1101,12 @@ void print_defaults(const char *conf_file, const char **groups)
     }
   }
   puts("\nThe following options may be given as the first argument:\n\
---print-defaults        Print the program argument list and exit.\n\
---no-defaults           Don't read default options from any option file.\n\
---defaults-file=#       Only read default options from the given file #.\n\
---defaults-extra-file=# Read this file after the global files are read.");
+--print-defaults          Print the program argument list and exit.\n\
+--no-defaults             Don't read default options from any option file.\n\
+The following specify which files/extra groups are read (specified before remaining options):\n\
+--defaults-file=#         Only read default options from the given file #.\n\
+--defaults-extra-file=#   Read this file after the global files are read.\n\
+--defaults-group-suffix=# Additionally read default groups with # appended as a suffix.");
 }
 
 


### PR DESCRIPTION
Also clarify the default options, if present, must be part of the first arguments.

I submit this under the MCA.