### PR TITLE
MDEV-15023 - wsrep_sst_mysqldump: safer test of version != 5

### DIFF
--- a/scripts/wsrep_sst_mysqldump.sh
+++ b/scripts/wsrep_sst_mysqldump.sh
@@ -124,7 +124,7 @@ SET_GTID_BINLOG_STATE=""
 SQL_LOG_BIN_OFF=""
 
 # Safety check
-if echo $SERVER_VERSION | grep '^10.0' > /dev/null
+if [ ${SERVER_VERSION%%.*} != '5' ]
 then
   # If binary logging is enabled on the joiner node, we need to copy donor's
   # gtid_binlog_state to joiner. In order to do that, a RESET MASTER must be


### PR DESCRIPTION
Any accidental missing of wsrep_sst_mysqldump and server version means we could miss this section.

Its safer just to say !=5.

I submit this under the MCA.