### PR TITLE
MDEV-15039 - Fix LibreSSL X509 (SSL) certificate hostname checking.

### DIFF
--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -1822,7 +1822,8 @@ static int ssl_verify_server_cert(Vio *vio, const char* server_hostname, const c
   */
 
 #ifdef HAVE_X509_check_host
-  ret_validation= X509_check_host(server_cert, server_hostname, 0, 0, 0) != 1;
+  ret_validation= X509_check_host(server_cert, server_hostname,
+                                  strlen(server_hostname), 0, 0) != 1;
 #else
   subject= X509_get_subject_name(server_cert);
   cn_loc= X509_NAME_get_index_by_NID(subject, NID_commonName, -1);


### PR DESCRIPTION
(Currently) LibreSSL doesn't calculate the string length of the hostname
that's passed to X509_check_host automatically in case namelen/chklen is 0.
This causes server certificate validation to fail when building MariaDB with
LibreSSL.

The proposed fix makes MariaDB determine the string length passed to
X509_check_host. As there are no ill side-effects (OpenSSL's X509_check_host
also simply calls strlen if namelen == 0, see also X509_check_host(3)), this
wasn't wrapped in any #ifdef like constructs.

Please see here for a proposed patch to modify LibreSSL's behavior:
https://github.com/libressl-portable/openbsd/pull/87