### PR TITLE
simplify and make counter atomic

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9697,11 +9697,9 @@ ha_innobase::index_read(
 		error = 0;
 		table->status = 0;
 		if (m_prebuilt->table->is_system_db) {
-			srv_stats.n_system_rows_read.add(
-				thd_get_thread_id(m_prebuilt->trx->mysql_thd), 1);
+			srv_stats.n_system_rows_read.inc();
 		} else {
-			srv_stats.n_rows_read.add(
-				thd_get_thread_id(m_prebuilt->trx->mysql_thd), 1);
+			srv_stats.n_rows_read.inc();
 		}
 		break;
 
@@ -10020,11 +10018,9 @@ ha_innobase::general_fetch(
 		error = 0;
 		table->status = 0;
 		if (m_prebuilt->table->is_system_db) {
-			srv_stats.n_system_rows_read.add(
-				thd_get_thread_id(trx->mysql_thd), 1);
+			srv_stats.n_system_rows_read.inc();
 		} else {
-			srv_stats.n_rows_read.add(
-				thd_get_thread_id(trx->mysql_thd), 1);
+			srv_stats.n_rows_read.inc();
 		}
 		break;
 	case DB_RECORD_NOT_FOUND:

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -60,7 +60,7 @@ Created 10/10/1995 Heikki Tuuri
 /** Global counters used inside InnoDB. */
 struct srv_stats_t
 {
-	typedef ib_counter_t<ulint, 64> ulint_ctr_64_t;
+	typedef ib_counter_t ulint_ctr_64_t;
 	typedef simple_counter<lsn_t> lsn_ctr_1_t;
 	typedef simple_counter<ulint> ulint_ctr_1_t;
 	typedef simple_counter<int64_t> int64_ctr_1_t;

--- a/storage/innobase/include/sync0rw.h
+++ b/storage/innobase/include/sync0rw.h
@@ -41,7 +41,7 @@ Created 9/11/1995 Heikki Tuuri
 
 /** Counters for RW locks. */
 struct rw_lock_stats_t {
-	typedef ib_counter_t<int64_t, IB_N_SLOTS> int64_counter_t;
+	typedef ib_counter_t	int64_counter_t;
 
 	/** number of spin waits on rw-latches,
 	resulted during shared (read) locks */

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1607,9 +1607,9 @@ error_exit:
 	que_thr_stop_for_mysql_no_error(thr, trx);
 
 	if (table->is_system_db) {
-		srv_stats.n_system_rows_inserted.inc(size_t(trx->id));
+		srv_stats.n_system_rows_inserted.inc();
 	} else {
-		srv_stats.n_rows_inserted.inc(size_t(trx->id));
+		srv_stats.n_rows_inserted.inc();
 	}
 
 	/* Not protected by dict_table_stats_lock() for performance
@@ -2146,11 +2146,11 @@ handle_error:
 			dict_table_n_rows_dec(node->table);
 
 			update_statistics = !srv_stats_include_delete_marked;
-			srv_stats.n_rows_deleted.inc(size_t(trx->id));
+			srv_stats.n_rows_deleted.inc();
 		} else {
 			update_statistics
 				= !(node->cmpl_info & UPD_NODE_NO_ORD_CHANGE);
-			srv_stats.n_rows_updated.inc(size_t(trx->id));
+			srv_stats.n_rows_updated.inc();
 		}
 
 		if (update_statistics) {
@@ -2171,17 +2171,17 @@ handle_error:
 		dict_table_n_rows_dec(prebuilt->table);
 
 		if (table->is_system_db) {
-			srv_stats.n_system_rows_deleted.inc(size_t(trx->id));
+			srv_stats.n_system_rows_deleted.inc();
 		} else {
-			srv_stats.n_rows_deleted.inc(size_t(trx->id));
+			srv_stats.n_rows_deleted.inc();
 		}
 
 		update_statistics = !srv_stats_include_delete_marked;
 	} else {
 		if (table->is_system_db) {
-			srv_stats.n_system_rows_updated.inc(size_t(trx->id));
+			srv_stats.n_system_rows_updated.inc();
 		} else {
-			srv_stats.n_rows_updated.inc(size_t(trx->id));
+			srv_stats.n_rows_updated.inc();
 		}
 
 		update_statistics

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -3283,8 +3283,7 @@ row_sel_get_clust_rec_for_mysql(
 	*out_rec = NULL;
 	trx = thr_get_trx(thr);
 
-	srv_stats.n_sec_rec_cluster_reads.inc(
-		thd_get_thread_id(trx->mysql_thd));
+	srv_stats.n_sec_rec_cluster_reads.inc();
 
 	row_build_row_ref_in_tuple(prebuilt->clust_ref, rec,
 				   sec_index, *offsets, trx);


### PR DESCRIPTION
additionally fix data race which looks like this:

```c++
WARNING: ThreadSanitizer: data race (pid=30515)
  Write of size 8 at 0x0000039ee908 by thread T21:
    #0 ib_counter_t<long, 64, counter_indexer_t>::add(unsigned long, long) storage/innobase/include/ut0counter.h:132:16 (mysqld+0x21cd166)
    #1 ib_counter_t<long, 64, counter_indexer_t>::add(long) storage/innobase/include/ut0counter.h:122:34 (mysqld+0x21cc102)
    #2 rw_lock_x_lock_wait_func(rw_lock_t*, unsigned long, long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:489:38 (mysqld+0x21cb91f)
    #3 rw_lock_x_lock_low(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:538:3 (mysqld+0x21c9339)
    #4 rw_lock_x_lock_func(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:698:6 (mysqld+0x21c8c4d)
    #5 pfs_rw_lock_x_lock_func(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/include/sync0rw.ic:568:3 (mysqld+0x1afbdb4)
    #6 buf_page_get_gen(page_id_t const&, page_size_t const&, unsigned long, buf_block_t*, unsigned long, char const*, unsigned int, mtr_t*, dberr_t*) storage/innobase/buf/buf0buf.cc:4782:3 (mysqld+0x1b04e28)
    #7 btr_cur_search_to_nth_level_func(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_cur_t*, rw_lock_t*, char const*, unsigned int, mtr_t*, unsigned long) storage/innobase/btr/btr0cur.cc:1312:10 (mysqld+0x1bf362c)
    #8 btr_pcur_open_low(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_pcur_t*, char const*, unsigned int, unsigned long, mtr_t*) storage/innobase/include/btr0pcur.ic:457:8 (mysqld+0x20eecd0)
    #9 row_search_on_row_ref(btr_pcur_t*, unsigned long, dict_table_t const*, dtuple_t const*, mtr_t*) storage/innobase/row/row0row.cc:1030:3 (mysqld+0x20ee1b4)
    #10 row_purge_reposition_pcur(unsigned long, purge_node_t*, mtr_t*) storage/innobase/row/row0purge.cc:103:23 (mysqld+0x20d7f6f)
    #11 row_purge_reset_trx_id(purge_node_t*, mtr_t*) storage/innobase/row/row0purge.cc:678:6 (mysqld+0x20dcbcd)
    #12 row_purge_record_func(purge_node_t*, unsigned char*, que_thr_t const*, bool) storage/innobase/row/row0purge.cc:1062:4 (mysqld+0x20db46f)
    #13 row_purge(purge_node_t*, unsigned char*, que_thr_t*) storage/innobase/row/row0purge.cc:1111:18 (mysqld+0x20d8aa4)
    #14 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1190:3 (mysqld+0x20d872c)
    #15 que_thr_step(que_thr_t*) storage/innobase/que/que0que.cc:1055:9 (mysqld+0x1fcfa6f)
    #16 que_run_threads_low(que_thr_t*) storage/innobase/que/que0que.cc:1117:14 (mysqld+0x1fcdd6e)
    #17 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1157:2 (mysqld+0x1fcd908)
    #18 srv_task_execute() storage/innobase/srv/srv0srv.cc:2520:3 (mysqld+0x21a6684)
    #19 srv_worker_thread storage/innobase/srv/srv0srv.cc:2567:7 (mysqld+0x21a6247)

  Previous write of size 8 at 0x0000039ee908 by thread T20:
    #0 ib_counter_t<long, 64, counter_indexer_t>::add(unsigned long, long) storage/innobase/include/ut0counter.h:132:16 (mysqld+0x21cd166)
    #1 ib_counter_t<long, 64, counter_indexer_t>::add(long) storage/innobase/include/ut0counter.h:122:34 (mysqld+0x21cc102)
    #2 rw_lock_x_lock_wait_func(rw_lock_t*, unsigned long, long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:489:38 (mysqld+0x21cb91f)
    #3 rw_lock_x_lock_low(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:538:3 (mysqld+0x21c9339)
    #4 rw_lock_x_lock_func(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/sync/sync0rw.cc:698:6 (mysqld+0x21c8c4d)
    #5 pfs_rw_lock_x_lock_func(rw_lock_t*, unsigned long, char const*, unsigned int) storage/innobase/include/sync0rw.ic:568:3 (mysqld+0x1afbdb4)
    #6 buf_page_get_gen(page_id_t const&, page_size_t const&, unsigned long, buf_block_t*, unsigned long, char const*, unsigned int, mtr_t*, dberr_t*) storage/innobase/buf/buf0buf.cc:4782:3 (mysqld+0x1b04e28)
    #7 btr_cur_search_to_nth_level_func(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_cur_t*, rw_lock_t*, char const*, unsigned int, mtr_t*, unsigned long) storage/innobase/btr/btr0cur.cc:1312:10 (mysqld+0x1bf362c)
    #8 btr_pcur_open_low(dict_index_t*, unsigned long, dtuple_t const*, page_cur_mode_t, unsigned long, btr_pcur_t*, char const*, unsigned int, unsigned long, mtr_t*) storage/innobase/include/btr0pcur.ic:457:8 (mysqld+0x20eecd0)
    #9 row_search_on_row_ref(btr_pcur_t*, unsigned long, dict_table_t const*, dtuple_t const*, mtr_t*) storage/innobase/row/row0row.cc:1030:3 (mysqld+0x20ee1b4)
    #10 row_purge_reposition_pcur(unsigned long, purge_node_t*, mtr_t*) storage/innobase/row/row0purge.cc:103:23 (mysqld+0x20d7f6f)
    #11 row_purge_reset_trx_id(purge_node_t*, mtr_t*) storage/innobase/row/row0purge.cc:678:6 (mysqld+0x20dcbcd)
    #12 row_purge_record_func(purge_node_t*, unsigned char*, que_thr_t const*, bool) storage/innobase/row/row0purge.cc:1062:4 (mysqld+0x20db46f)
    #13 row_purge(purge_node_t*, unsigned char*, que_thr_t*) storage/innobase/row/row0purge.cc:1111:18 (mysqld+0x20d8aa4)
    #14 row_purge_step(que_thr_t*) storage/innobase/row/row0purge.cc:1190:3 (mysqld+0x20d872c)
    #15 que_thr_step(que_thr_t*) storage/innobase/que/que0que.cc:1055:9 (mysqld+0x1fcfa6f)
    #16 que_run_threads_low(que_thr_t*) storage/innobase/que/que0que.cc:1117:14 (mysqld+0x1fcdd6e)
    #17 que_run_threads(que_thr_t*) storage/innobase/que/que0que.cc:1157:2 (mysqld+0x1fcd908)
    #18 srv_task_execute() storage/innobase/srv/srv0srv.cc:2520:3 (mysqld+0x21a6684)
    #19 srv_worker_thread storage/innobase/srv/srv0srv.cc:2567:7 (mysqld+0x21a6247)
```

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.