### PR TITLE
MDEV-15046 - "Address already in use" on restart

### DIFF
--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -264,7 +264,6 @@ process::process (const char* cmd, const char* type, char** env)
 
     err_ = posix_spawnattr_setflags (&attr, POSIX_SPAWN_SETSIGDEF  |
                                             POSIX_SPAWN_SETSIGMASK |
-            /* start a new process group */ POSIX_SPAWN_SETPGROUP  |
                                             POSIX_SPAWN_USEVFORK);
     if (err_)
     {


### PR DESCRIPTION
SST processes should inherit mysqld's process group.

This is a backport of Nirbhay's patch ebe061900b01e4b9ad69860a0e15df44b0ebbb92