### PR TITLE
systemd: revert to KillMode=control-group (default) for galera

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -85,7 +85,6 @@ ExecStart=@sbindir@/mysqld $MYSQLD_OPTS $_WSREP_NEW_CLUSTER $_WSREP_START_POSITI
 # Unset _WSREP_START_POSITION environment variable.
 ExecStartPost=/bin/sh -c "systemctl unset-environment _WSREP_START_POSITION"
 
-KillMode=process
 KillSignal=SIGTERM
 
 # Don't want to see an automated SIGKILL ever

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -106,7 +106,6 @@ ExecStart=@sbindir@/mysqld --defaults-file=@sysconf2dir@/my%I.cnf \
 # Unset _WSREP_START_POSITION environment variable.
 ExecStartPost=/bin/sh -c "systemctl unset-environment _WSREP_START_POSITION%I"
 
-KillMode=process
 KillSignal=SIGTERM
 
 # Don't want to see an automated SIGKILL ever


### PR DESCRIPTION
When galera is used, we want a stop to kill off not only the mysqld process, but the entire process group created by galera to perform sst or wsrep_notify_cmd.

This requires ebe0619, which currently only in 10.2+ so #570 pushes this back to 5.5-galera.

Warning minor merge conflicts with other outstanding systemd PRs like ##387 and #510.

I submit this under the MCA.