### PR TITLE
fix build for recent clang

### DIFF
--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -283,7 +283,7 @@ bool partition_default_handling(TABLE *table, partition_info *part_info,
     }
   }
   part_info->set_up_defaults_for_partitioning(table->file,
-                                              (ulonglong)0, (uint)0);
+                                              NULL, (uint)0);
   DBUG_RETURN(FALSE);
 }
 


### PR DESCRIPTION
```
/home/kevg/work/mariadb/sql/sql_partition.cc:286:47: error: cannot initialize a parameter of type 'HA_CREATE_INFO *' (aka 'st_ha_create_information *') with an rvalue of type 'ulonglong' (aka 'unsigned long long')
                                              (ulonglong)0, (uint)0);
                                              ^~~~~~~~~~~~
/home/kevg/work/mariadb/sql/partition_info.h:281:72: note: passing argument to parameter 'info' here
  bool set_up_defaults_for_partitioning(handler *file, HA_CREATE_INFO *info,
                                                                       ^
```
I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.