### PR TITLE
Fix 2038 error message typo

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4257,7 +4257,7 @@ static int init_common_variables()
   /* TODO: remove this when my_time_t is 64 bit compatible */
   if (!IS_TIME_T_VALID_FOR_TIMESTAMP(server_start_time))
   {
-    sql_print_error("This MySQL server doesn't support dates later then 2038");
+    sql_print_error("This MySQL server doesn't support dates later than 2038");
     exit(1);
   }
 


### PR DESCRIPTION
This pull request fixes a typo in the "This MySQL server doesn't support dates later then 2038" error message.