### PR TITLE
MDEV-14705: slow innodb startup/shutdown can exceed systemd timeout

### DIFF
--- a/include/my_service_manager.h
+++ b/include/my_service_manager.h
@@ -16,8 +16,8 @@
 */
 
 
-#ifndef MY_SYSTEMD_INCLUDED
-#define MY_SYSTEMD_INCLUDED
+#ifndef MY_SERVICE_MANAGER_INCLUDED
+#define MY_SERVICE_MANAGER_INCLUDED
 
 #if defined(HAVE_SYSTEMD) && !defined(EMBEDDED_LIBRARY)
 /*
@@ -26,9 +26,14 @@
 */
 #define __STDC_FORMAT_MACROS
 #include <systemd/sd-daemon.h>
+/** INTERVAL in seconds followed by printf style status */
+#define service_manager_extend_timeout(INTERVAL, FMTSTR, ...) \
+  sd_notifyf(0, "STATUS=" FMTSTR "\nEXTEND_TIMEOUT_USEC=%u\n", ##__VA_ARGS__, INTERVAL * 1000000)
+
 #else
 #define sd_notify(X, Y)
 #define sd_notifyf(E, F, ...)
+#define service_manager_extend_timeout(I, FMTSTR, ...)
 #endif
 
-#endif /* MY_SYSTEMD_INCLUDED */
+#endif /* MY_SERVICE_MANAGER_INCLUDED */

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -111,7 +111,7 @@
 #include <poll.h>
 #endif
 
-#include <my_systemd.h>
+#include <my_service_manager.h>
 
 #define mysqld_charset &my_charset_latin1
 
@@ -6462,7 +6462,7 @@ void handle_connections_sockets()
 #endif
 
   sd_notify(0, "READY=1\n"
-            "STATUS=Taking your SQL requests now...");
+            "STATUS=Taking your SQL requests now...\n");
 
   DBUG_PRINT("general",("Waiting for connections."));
   MAYBE_BROKEN_SYSCALL;
@@ -6680,7 +6680,7 @@ void handle_connections_sockets()
     set_current_thd(0);
   }
   sd_notify(0, "STOPPING=1\n"
-            "STATUS=Shutdown in progress");
+            "STATUS=Shutdown in progress\n");
   DBUG_VOID_RETURN;
 }
 

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -42,6 +42,7 @@ Created April 08, 2011 Vasil Dimov
 #include "ut0byte.h" /* ut_ull_create() */
 #include "ut0sort.h" /* UT_SORT_FUNCTION_BODY */
 #include "mysql/service_wsrep.h" /* wsrep_recovery */
+#include <my_service_manager.h>
 
 enum status_severity {
 	STATUS_INFO,
@@ -327,6 +328,14 @@ buf_dump(
 				counter = 0;
 				buf_dump_status(
 					STATUS_INFO,
+					"Dumping buffer pool "
+					ULINTPF "/" ULINTPF ", "
+					"page " ULINTPF "/" ULINTPF,
+					i + 1, srv_buf_pool_instances,
+					j + 1, n_pages);
+			}
+			if ( (j % 1024) == 0) {
+				service_manager_extend_timeout(INNODB_EXTEND_TIMEOUT_INTERVAL,
 					"Dumping buffer pool "
 					ULINTPF "/" ULINTPF ", "
 					"page " ULINTPF "/" ULINTPF,

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -55,7 +55,7 @@ MYSQL_PLUGIN_IMPORT extern char mysql_unpacked_real_data_home[];
 #include <io.h>
 #endif
 
-#include <my_systemd.h>
+#include <my_service_manager.h>
 
 /** @file ha_innodb.cc */
 

--- a/storage/innobase/include/univ.i
+++ b/storage/innobase/include/univ.i
@@ -65,6 +65,10 @@ component, i.e. we show M.N.P as M.N */
 	IB_TO_STR(INNODB_VERSION_MAJOR) "."		\
 	IB_TO_STR(INNODB_VERSION_MINOR) "/en/"
 
+/** How far ahead should we tell the service manager the timeout
+(time in seconds) */
+#define INNODB_EXTEND_TIMEOUT_INTERVAL 30
+
 #ifdef MYSQL_DYNAMIC_PLUGIN
 /* In the dynamic plugin, redefine some externally visible symbols
 in order not to conflict with the symbols of a builtin InnoDB. */

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -3455,23 +3455,6 @@ wait_suspend_loop:
 
 		mutex_exit(&log_sys->mutex);
 
-		fil_flush_file_spaces(FIL_TABLESPACE);
-		fil_flush_file_spaces(FIL_LOG);
-
-		/* The call fil_write_flushed_lsn_to_data_files() will
-		bypass the buffer pool: therefore it is essential that
-		the buffer pool has been completely flushed to disk! */
-
-		if (!buf_all_freed()) {
-			if (srv_print_verbose_log && count > 600) {
-				ib_logf(IB_LOG_LEVEL_INFO,
-					"Waiting for dirty buffer pages"
-					" to be flushed");
-				count = 0;
-			}
-
-			goto loop;
-		}
 	} else {
 		lsn = srv_start_lsn;
 	}
@@ -3513,8 +3496,6 @@ wait_suspend_loop:
 	/* Make some checks that the server really is quiet */
 	type = srv_get_active_thread_type();
 	ut_a(type == SRV_NONE);
-
-	buf_all_freed();
 
 	ut_a(lsn == log_sys->lsn);
 }

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -39,7 +39,7 @@ Created 12/9/1995 Heikki Tuuri
 
 #ifndef UNIV_HOTBACKUP
 #if MYSQL_VERSION_ID < 100200
-# include <my_systemd.h> /* sd_notifyf() */
+# include <my_service_manager.h>
 #endif
 
 #include "mem0mem.h"
@@ -1443,6 +1443,11 @@ log_write_up_to(
 		return;
 	}
 
+	if (srv_shutdown_state != SRV_SHUTDOWN_NONE) {
+		service_manager_extend_timeout(INNODB_EXTEND_TIMEOUT_INTERVAL,
+			"log write up to: %llu", lsn);
+	}
+
 loop:
 	ut_ad(++loop_count < 100);
 
@@ -2351,8 +2356,9 @@ loop:
 	if (recv_sys->report(ut_time())) {
 		ib_logf(IB_LOG_LEVEL_INFO, "Read redo log up to LSN=" LSN_PF,
 			start_lsn);
-		sd_notifyf(0, "STATUS=Read redo log up to LSN=" LSN_PF,
-			   start_lsn);
+		service_manager_extend_timeout(INNODB_EXTEND_TIMEOUT_INTERVAL,
+			"Read redo log up to LSN=" LSN_PF,
+			start_lsn);
 	}
 
 	if (start_lsn != end_lsn) {
@@ -3320,10 +3326,16 @@ wait_suspend_loop:
 	before proceeding further. */
 
 	count = 0;
+#define COUNT_INTERVAL 600
+#define CHECK_INTERVAL 100000
+	service_manager_extend_timeout(COUNT_INTERVAL * CHECK_INTERVAL/1000000 * 2,
+		"Waiting for page cleaner");
 	while (buf_page_cleaner_is_active) {
 		++count;
-		os_thread_sleep(100000);
-		if (srv_print_verbose_log && count > 600) {
+		os_thread_sleep(CHECK_INTERVAL);
+		if (srv_print_verbose_log && count > COUNT_INTERVAL) {
+			service_manager_extend_timeout(COUNT_INTERVAL * CHECK_INTERVAL/1000000 * 2,
+				"Waiting for page cleaner");
 			ib_logf(IB_LOG_LEVEL_INFO,
 				"Waiting for page_cleaner to "
 				"finish flushing of buffer pool");
@@ -3408,6 +3420,8 @@ wait_suspend_loop:
 	}
 
 	if (!srv_read_only_mode) {
+		service_manager_extend_timeout(INNODB_EXTEND_TIMEOUT_INTERVAL,
+			"ensuring dirty buffer pool are written to log");
 		log_make_checkpoint_at(LSN_MAX, TRUE);
 
 		mutex_enter(&log_sys->mutex);
@@ -3468,8 +3482,9 @@ wait_suspend_loop:
 	srv_thread_type	type = srv_get_active_thread_type();
 	ut_a(type == SRV_NONE);
 
-	bool	freed = buf_all_freed();
-	ut_a(freed);
+	service_manager_extend_timeout(INNODB_EXTEND_TIMEOUT_INTERVAL,
+		"Free innodb buffer pool");
+	buf_all_freed();
 
 	ut_a(lsn == log_sys->lsn);
 
@@ -3499,8 +3514,7 @@ wait_suspend_loop:
 	type = srv_get_active_thread_type();
 	ut_a(type == SRV_NONE);
 
-	freed = buf_all_freed();
-	ut_a(freed);
+	buf_all_freed();
 
 	ut_a(lsn == log_sys->lsn);
 }

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -30,7 +30,7 @@ Created 9/20/1997 Heikki Tuuri
 #include <stdio.h>                              // Solaris/x86 header file bug
 
 #include <vector>
-#include <my_systemd.h>
+#include <my_service_manager.h>
 
 #include "log0recv.h"
 
@@ -1717,8 +1717,8 @@ recv_recover_page_func(
 		if (recv_sys->report(time)) {
 			ib_logf(IB_LOG_LEVEL_INFO,
 				"To recover: " ULINTPF " pages from log", n);
-			sd_notifyf(0, "STATUS=To recover: " ULINTPF
-				   " pages from log", n);
+			service_manager_extend_timeout(
+				INNODB_EXTEND_TIMEOUT_INTERVAL, "To recover: " ULINTPF " pages from log", n);
 		}
 	}
 
@@ -2910,6 +2910,9 @@ recv_init_crash_recovery(void)
 	check if there are half-written pages in data files,
 	and restore them from the doublewrite buffer if
 	possible */
+
+	service_manager_extend_timeout(
+		INNODB_EXTEND_TIMEOUT_INTERVAL, "Starting Innodb crash recovery");
 
 	if (srv_force_recovery < SRV_FORCE_NO_LOG_REDO) {
 		buf_dblwr_process();

--- a/storage/innobase/row/row0undo.cc
+++ b/storage/innobase/row/row0undo.cc
@@ -349,8 +349,7 @@ row_undo_step(
 
 	ut_ad(que_node_get_type(node) == QUE_NODE_UNDO);
 
-	if (UNIV_UNLIKELY(trx == trx_roll_crash_recv_trx)
-	    && trx_roll_must_shutdown()) {
+	if (trx && trx_roll_crash_recv_trx && UNIV_UNLIKELY(trx_roll_must_shutdown())) {
 		/* Shutdown has been initiated. */
 		trx->error_state = DB_INTERRUPTED;
 		return(NULL);

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -77,6 +77,12 @@ Created 10/8/1995 Heikki Tuuri
 #include "fil0pagecompress.h"
 #include "btr0scrub.h"
 
+#include <my_service_manager.h>
+
+#ifdef WITH_WSREP
+extern int wsrep_debug;
+extern int wsrep_trx_is_aborting(void *thd_ptr);
+#endif
 /* The following is the maximum allowed duration of a lock wait. */
 UNIV_INTERN ulong	srv_fatal_semaphore_wait_threshold =  DEFAULT_SRV_FATAL_SEMAPHORE_TIMEOUT;
 
@@ -2727,6 +2733,10 @@ srv_do_purge(
 
 		*n_total_purged += n_pages_purged;
 
+		if (n_pages_purged > 0) {
+			service_manager_extend_timeout(
+				INNODB_EXTEND_TIMEOUT_INTERVAL, "Innodb %d pages purged", n_pages_purged);
+		}
 	} while (!srv_purge_should_exit(n_pages_purged)
 		 && n_pages_purged > 0
 		 && purge_sys->state == PURGE_STATE_RUN);

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -3104,6 +3104,7 @@ innodb_shutdown()
 		srv_undo_sources = false;
 	}
 
+
 	/* 1. Flush the buffer pool to disk, write the current lsn to
 	the tablespace header(s), and copy all log data to archive.
 	The step 1 is the real InnoDB shutdown. The remaining steps 2 - ...

--- a/storage/innobase/trx/trx0roll.cc
+++ b/storage/innobase/trx/trx0roll.cc
@@ -25,7 +25,7 @@ Created 3/26/1996 Heikki Tuuri
 *******************************************************/
 
 #include "my_config.h"
-#include <my_systemd.h>
+#include <my_service_manager.h>
 
 #include "trx0roll.h"
 
@@ -752,11 +752,17 @@ trx_roll_must_shutdown()
 				n_rows += t->undo_no;
 			}
 		}
+
+		if (n_rows > 0) {
+			service_manager_extend_timeout(
+				INNODB_EXTEND_TIMEOUT_INTERVAL,
+				"To roll back: " ULINTPF " transactions, "
+				"%llu rows", n_trx, n_rows);
+		}
+
 		ib_logf(IB_LOG_LEVEL_INFO,
 			"To roll back: " ULINTPF " transactions, "
 			"%llu rows", n_trx, n_rows);
-		sd_notifyf(0, "STATUS=To roll back: " ULINTPF " transactions, "
-			   "%llu rows", n_trx, n_rows);
 	}
 
 	mutex_exit(&recv_sys->mutex);

--- a/storage/xtradb/handler/ha_innodb.cc
+++ b/storage/xtradb/handler/ha_innodb.cc
@@ -50,7 +50,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include <io.h>
 #endif
 
-#include <my_systemd.h>
+#include <my_service_manager.h>
 
 /** @file ha_innodb.cc */
 

--- a/storage/xtradb/log/log0log.cc
+++ b/storage/xtradb/log/log0log.cc
@@ -49,7 +49,7 @@ Created 12/9/1995 Heikki Tuuri
 
 #ifndef UNIV_HOTBACKUP
 #if MYSQL_VERSION_ID < 100200
-# include <my_systemd.h> /* sd_notifyf() */
+# include <my_service_manager.h> /* sd_notifyf() */
 #endif
 
 #include "mem0mem.h"

--- a/storage/xtradb/log/log0recv.cc
+++ b/storage/xtradb/log/log0recv.cc
@@ -30,7 +30,7 @@ Created 9/20/1997 Heikki Tuuri
 #include <stdio.h>                              // Solaris/x86 header file bug
 
 #include <vector>
-#include <my_systemd.h>
+#include <my_service_manager.h>
 
 #include "log0recv.h"
 

--- a/storage/xtradb/trx/trx0roll.cc
+++ b/storage/xtradb/trx/trx0roll.cc
@@ -25,7 +25,7 @@ Created 3/26/1996 Heikki Tuuri
 *******************************************************/
 
 #include "my_config.h"
-#include <my_systemd.h>
+#include <my_service_manager.h>
 
 #include "trx0roll.h"
 


### PR DESCRIPTION
Use systemd EXTEND_TIMEOUT_USEC to advise systemd of progress in sections of innodb that are likely to take time in startup/shutdown.

I've only applied this to innodb at the moment. The plan is to patch against xtradb the same way once complete.

I submit this under the MCA.