### PR TITLE
versioning: add explict fallthough to prevent gcc warning

### DIFF
--- a/sql/table.cc
+++ b/sql/table.cc
@@ -2034,6 +2034,7 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
             versioned= VERS_TRX_ID;
             break;
           }
+          /* Fallthrough */
         default:
           my_error(ER_VERS_FIELD_WRONG_TYPE, MYF(0), fieldnames.type_names[i],
             versioned == VERS_TIMESTAMP ? "TIMESTAMP(6)" : "BIGINT(20) UNSIGNED",


### PR DESCRIPTION
gcc7 warning:

sql/table.cc: In member function ‘int TABLE_SHARE::init_from_binary_frm_image(THD*, bool, const uchar*, size_t)’:
sql/table.cc:2032:11: warning: this statement may fall through [-Wimplicit-fallthrough=]
           if (vers_can_native)
           ^~
sql/table.cc:2037:9: note: here
         default:
         ^~~~~~~

I'm assuming this is intentional.

I submit this under the MCA.