### PR TITLE
threadpool: release mutex on io_poll_create failure

### DIFF
--- a/sql/threadpool_generic.cc
+++ b/sql/threadpool_generic.cc
@@ -1698,10 +1698,9 @@ int TP_pool_generic::set_pool_size(uint size)
       if(!success)
       {
         sql_print_error("io_poll_create() failed, errno=%d\n", errno);
-        break;
       }
     }  
-    mysql_mutex_unlock(&all_groups[i].mutex);
+    mysql_mutex_unlock(&group->mutex);
     if (!success)
     {
       group_count= i;


### PR DESCRIPTION
This is a very minimal cleanup for 10.2. I have work in progress of other threadpool resource management issues that I'll target against 10.3.

I submit this under the MCA.