### PR TITLE
threadpool-generic - release resource

### DIFF
--- a/sql/threadpool_generic.cc
+++ b/sql/threadpool_generic.cc
@@ -358,7 +358,7 @@ static void *native_event_get_userdata(native_event *event)
 #endif
 
 
-TP_file_handle io_poll_create()
+static TP_file_handle io_poll_create()
 {
   return kqueue();
 }
@@ -1064,7 +1064,7 @@ int thread_group_init(thread_group_t *thread_group, pthread_attr_t* thread_attr)
 }
 
 
-void thread_group_destroy(thread_group_t *thread_group)
+static void thread_group_destroy(thread_group_t *thread_group)
 {
   mysql_mutex_destroy(&thread_group->mutex);
   if (thread_group->pollfd != INVALID_HANDLE_VALUE)

--- a/sql/threadpool_generic.cc
+++ b/sql/threadpool_generic.cc
@@ -1655,6 +1655,12 @@ int TP_pool_generic::init()
     sql_print_error("Can't set threadpool size to %d",threadpool_size);
     DBUG_RETURN(-1);
   }
+  else if (group_count != threadpool_size)
+  {
+    sql_print_warning("Could only set threadpool size to %d, requested size %d",
+                      group_count, threadpool_size);
+    threadpool_size= group_count;
+  }
   PSI_register(mutex);
   PSI_register(cond);
   PSI_register(thread);


### PR DESCRIPTION
Add a warning if the requested thread pool size could not be set. It should hint appropriately that you've run out of file descriptors. The thing that needs a file-descriptor next will undoubtly terminate the server due to insufficient file descriptors in the early part of initialisation and a message will be:
<pre>
2018-02-01 18:54:41 0 [ERROR] io_poll_create() failed, errno=24
2018-02-01 18:54:41 0 [Warning] Could only set threadpool size to 1004, requested size 1024
</pre>

The main change is in set_pool_size which when the thread_pool_size is reduced will close of the file descriptors in thread_group_destroy (called by thread_group_close). shutdown_group_count is set high so all_groups isn't prematurely freed extending on the concept introduced in a588de1fe8d6.

@svoy, do you know why get_connection_attrib defaults to PTHREAD_CREATE_DETACHED for most/all mysql threads? Seems like joining pthreads would be raceproof way to cleanup that was avoided.

I submit this under the MCA.