### PR TITLE
MDEV-15439 - CPack: packaging vendor as MariaDB corp

### DIFF
--- a/cmake/mysql_version.cmake
+++ b/cmake/mysql_version.cmake
@@ -96,8 +96,8 @@ IF(NOT CPACK_SOURCE_PACKAGE_FILE_NAME)
     SET(CPACK_SOURCE_PACKAGE_FILE_NAME "mysql-cluster-gpl-${NDBVERSION}")
   ENDIF()
 ENDIF()
-SET(CPACK_PACKAGE_CONTACT "MariaDB team <info@montyprogram.com>")
-SET(CPACK_PACKAGE_VENDOR "Monty Program AB")
+SET(CPACK_PACKAGE_CONTACT "MariaDB team <maria-developers@lists.launchpad.net>")
+SET(CPACK_PACKAGE_VENDOR "MariaDB Corporation")
 SET(CPACK_SOURCE_GENERATOR "TGZ")
 
 # Defintions for windows version resources

--- a/support-files/rpm/server-prein.sh
+++ b/support-files/rpm/server-prein.sh
@@ -17,7 +17,8 @@ if [ $? -eq 0 -a -n "$installed" ]; then
   [ -z "$new_family" ] && new_family="<bad package specification: version $myversion>"
 
   error_text=
-  if [ "$vendor" != "$myvendor" ]; then
+  if [ "$vendor" != "$myvendor" ] &&
+     [ "$vendor" != "Monty Program AB"  ]; then
     error_text="$error_text
 The current MariaDB server package is provided by a different
 vendor ($vendor) than $myvendor.  Some files may be installed


### PR DESCRIPTION
Seems like MariaDB corporation is the public face of packaging and Monty Program is more historical use. As such suggesting the vendor name in packages change. Apologises if I've misunderstood any business arrangements.

I submit this under the MCA.