### PR TITLE
MDEV-7066: Add CPACK_RPM_BUILDREQUIRES for systemd, auth_gssapi, cracklib

### DIFF
--- a/cmake/systemd.cmake
+++ b/cmake/systemd.cmake
@@ -13,6 +13,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
+SET(CPACK_RPM_BUILDREQUIRES "${CPACK_RPM_BUILDREQUIRES}"
+  "systemd-devel"
+)
+
 INCLUDE(FindPkgConfig)
 # http://www.cmake.org/cmake/help/v3.0/module/FindPkgConfig.html
 

--- a/plugin/auth_gssapi/CMakeLists.txt
+++ b/plugin/auth_gssapi/CMakeLists.txt
@@ -32,6 +32,9 @@ ELSE()
  ENDIF()
 ENDIF ()
 
+SET(CPACK_RPM_BUILDREQUIRES "${CPACK_RPM_BUILDREQUIRES}"
+  "krb5-devel"
+)
 
 MYSQL_ADD_PLUGIN(auth_gssapi server_plugin.cc ${GSSAPI_SERVER} ${GSSAPI_ERRMSG}
                  LINK_LIBRARIES ${GSSAPI_LIBS} 

--- a/plugin/cracklib_password_check/CMakeLists.txt
+++ b/plugin/cracklib_password_check/CMakeLists.txt
@@ -1,6 +1,11 @@
 INCLUDE (CheckIncludeFiles)
 INCLUDE (CheckLibraryExists)
 
+SET(CPACK_RPM_BUILDREQUIRES "${CPACK_RPM_BUILDREQUIRES}"
+  "cracklib-dicts"
+  "cracklib-devel"
+)
+
 CHECK_LIBRARY_EXISTS(crack FascistCheckUser "" HAVE_LIBCRACK)
 
 SET(CMAKE_REQUIRED_DEFINITIONS -Dsize_t=int) # debian hack, debian bug.


### PR DESCRIPTION
Note this is different from the 10.0 #589.

I submit this under the MCA.