### PR TITLE
MDEV-11045 systemd reload / rpm {pre|post}{inst|uninst}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,8 +144,6 @@ INCLUDE(mysql_version)
 INCLUDE(cpack_source_ignore_files)
 INCLUDE(install_layout)
 INCLUDE(wsrep)
-INCLUDE(cpack_rpm)
-INCLUDE(cpack_deb)
 
 # Add macros
 INCLUDE(character_sets)
@@ -344,6 +342,9 @@ CHECK_JEMALLOC()
 CHECK_PCRE()
 
 CHECK_SYSTEMD()
+# cpack_rpm makes decisions based on HAVE_SYSTEMD
+INCLUDE(cpack_rpm)
+INCLUDE(cpack_deb)
 
 IF(CMAKE_CROSSCOMPILING)
   SET(IMPORT_EXECUTABLES "IMPORTFILE-NOTFOUND" CACHE FILEPATH "Path to import_executables.cmake from a native build")

--- a/cmake/cpack_rpm.cmake
+++ b/cmake/cpack_rpm.cmake
@@ -69,6 +69,26 @@ SET(CPACK_RPM_SPEC_MORE_DEFINE "
 %define _sysconfdir ${INSTALL_SYSCONFDIR}
 ")
 
+# Take care on the logic of this syntax
+# %bcond_with means you add a "--with" option, default is "without this feature"
+# %bcond_without adds a"--without" so the feature is enabled by default
+# As cmake doesn't pass --with{out} X on rpmbuild we rely on defaults.
+IF(HAVE_SYSTEMD)
+  SET(CPACK_RPM_SPEC_MORE_DEFINE "
+${CPACK_RPM_SPEC_MORE_DEFINE}
+%bcond_without init_systemd
+%bcond_with init_sysv
+%global daemon_name mariadb"
+  )
+ELSE()
+  SET(CPACK_RPM_SPEC_MORE_DEFINE "
+${CPACK_RPM_SPEC_MORE_DEFINE}
+%bcond_with init_systemd
+%bcond_without init_sysv
+%global daemon_name mysql"
+  )
+ENDIF()
+
 # this creative hack is described here: http://www.cmake.org/pipermail/cmake/2012-January/048416.html
 # both /etc and /etc/init.d should be ignored as of 2.8.7
 # only /etc/init.d as of 2.8.8

--- a/cmake/cpack_rpm.cmake
+++ b/cmake/cpack_rpm.cmake
@@ -120,6 +120,14 @@ SET(ignored
   "%ignore ${CMAKE_INSTALL_PREFIX}/share/pkgconfig"
   )
 
+IF(HAVE_SYSTEMD)
+  SET(ignored
+    "${ignored}"
+    "%ignore ${INSTALL_SYSTEMD_SYSUSERSDIR_RPM}"
+    "%ignore ${INSTALL_SYSTEMD_TMPFILESDIR_RPM}"
+    )
+ENDIF()
+
 SET(CPACK_RPM_server_USER_FILELIST ${ignored} "%config(noreplace) ${INSTALL_SYSCONF2DIR}/*")
 SET(CPACK_RPM_common_USER_FILELIST ${ignored} "%config(noreplace) ${INSTALL_SYSCONFDIR}/my.cnf")
 SET(CPACK_RPM_shared_USER_FILELIST ${ignored} "%config(noreplace) ${INSTALL_SYSCONF2DIR}/*")

--- a/support-files/mysql.server.sh
+++ b/support-files/mysql.server.sh
@@ -365,6 +365,19 @@ case "$mode" in
       exit 1
     fi
     ;;
+
+  'condrestart')
+    # restart if already running
+    # concept ported from Fedora and used to restart in package upgrade
+    # where we want the restart only if the server is currently running
+    if test -f "$lock_file_path"
+    then
+      $0 restart
+    else
+      exit 0
+    fi
+    ;;
+
   'status')
     # First, check to see if pid file exists
     if test -s "$mysqld_pid_file_path" ; then 
@@ -398,6 +411,7 @@ case "$mode" in
       fi
     fi
     ;;
+
   'configtest')
     # Safeguard (relative paths, core dumps..)
     cd $basedir
@@ -425,6 +439,7 @@ case "$mode" in
     fi
     exit $r
     ;;
+
   'bootstrap')
       if test "$_use_systemctl" == 1 ; then
         log_failure_msg "Please use galera_new_cluster to start the mariadb service with --wsrep-new-cluster"
@@ -439,7 +454,7 @@ case "$mode" in
   *)
       # usage
       basename=`basename "$0"`
-      echo "Usage: $basename  {start|stop|restart|reload|force-reload|status|configtest|bootstrap}  [ MariaDB server options ]"
+      echo "Usage: $basename  {start|stop|restart|condrestart|reload|force-reload|status|configtest|bootstrap}  [ MariaDB server options ]"
       exit 1
     ;;
 esac

--- a/support-files/rpm/server-postin.sh
+++ b/support-files/rpm/server-postin.sh
@@ -11,7 +11,9 @@ if [ -f /usr/lib/systemd/system/mariadb.service -a -x /usr/bin/systemctl ]; then
     # Make sure old possibly non-systemd instance is down
     if [ $1 = 2 ]; then
       SYSTEMCTL_SKIP_REDIRECT=1 %{_sysconfdir}/init.d/mysql stop >/dev/null 2>&1 || :
+      systemctl start %{daemon_name}.service >/dev/null 2>&1 || :
     fi
+    systemctl enable %{daemon_name}.service >/dev/null 2>&1 || :
   fi
 fi
 

--- a/support-files/rpm/server-postun.sh
+++ b/support-files/rpm/server-postun.sh
@@ -1,15 +1,14 @@
+%if %{with init_systemd}
+%systemd_postun_with_restart %{daemon_name}.service
+%endif
+%if %{with init_sysv}
 if [ $1 -ge 1 ]; then
-  if [ -x %{_sysconfdir}/init.d/mysql ] ; then
+  if [ -x /sbin/servce ] ; then
+    /sbin/service %{daemon_name} condrestart >/dev/null 2>&1 || :
+  elif [ -x %{_sysconfdir}/init.d/%{daemon_name} ] ; then
     # only restart the server if it was alredy running
-    if %{_sysconfdir}/init.d/mysql status > /dev/null 2>&1; then
-      %{_sysconfdir}/init.d/mysql restart
+    if %{_sysconfdir}/init.d/%{daemon_name} status > /dev/null 2>&1; then
+      %{_sysconfdir}/init.d/%{daemon_name} restart
     fi
-  fi
 fi
-
-if [ $1 = 0 ] ; then
-  if [ -x /usr/bin/systemctl ] ; then
-    /usr/bin/systemctl daemon-reload > /dev/null 2>&1
-  fi
-fi
-
+%endif

--- a/support-files/rpm/server-preun.sh
+++ b/support-files/rpm/server-preun.sh
@@ -1,13 +1,19 @@
-if [ $1 = 0 ] ; then
-	# Stop MySQL before uninstalling it
-	if [ -x %{_sysconfdir}/init.d/mysql ] ; then
-		%{_sysconfdir}/init.d/mysql stop > /dev/null
-	fi
-        # Don't start it automatically anymore
-	if [ -x /sbin/chkconfig ] ; then
-		/sbin/chkconfig --del mysql
-	fi
+%if %{with init_systemd}
+%systemd_preun %{daemon_name}.service
+%endif
+%if %{with init_sysv}
+if [ $1 = 0 ]; then
+  # Stop MySQL before uninstalling it
+  if [ -x /sbin/service ]; then
+    /sbin/service %{daemon_name} stop >/dev/null 2>&1
+  elif [ -x %{_sysconfdir}/init.d/%{daemon_name} ] ; then
+    %{_sysconfdir}/init.d/%{daemon_name} stop > /dev/null
+  fi
+  if [ -x /sbin/chkconfig ] ; then
+    /sbin/chkconfig --del ${daemon_name}
+  fi
 fi
+%endif
 
 # We do not remove the mysql user since it may still own a lot of
 # database files.


### PR DESCRIPTION
I think 3b430c8 should be revert once it hits 10.3 unstable branch to make mariadb exhibit consistent packaging behaviour to other distro packages as per the systemd presets https://www.freedesktop.org/wiki/Software/systemd/Preset/ which is what `%systemd_post %{daemon_name}.service` expands to.

The original MDEV-11045 asked for a daemon-reload however given the date of creating I suspect this is addressed by the following systemd macros commit and has made it into RPM distros.
https://github.com/systemd/systemd/commit/873e413323dfff4023604849c70944674ae5cd29

This also clears the way for the fixing of MDEV-10797.

I submit this under the MCA.