### PR TITLE
MDEV-10797: sysv init script not in /etc/init.d for rpms with systemd

### DIFF
--- a/support-files/CMakeLists.txt
+++ b/support-files/CMakeLists.txt
@@ -148,9 +148,15 @@ IF(UNIX)
   IF (INSTALL_SYSCONFDIR)
     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/mysql-log-rotate DESTINATION ${INSTALL_SYSCONFDIR}/logrotate.d
             RENAME mysql COMPONENT SupportFiles)
-    INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mysql.server
-            DESTINATION  ${INSTALL_SYSCONFDIR}/init.d
-            RENAME mysql COMPONENT SupportFiles)
+    IF(NOT HAVE_SYSTEMD)
+      INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mysql.server
+              DESTINATION  ${INSTALL_SYSCONFDIR}/init.d
+              RENAME mysql COMPONENT SupportFiles)
+    ELSE()
+      INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mysql.server
+              DESTINATION  ${INSTALL_SHAREDIR}
+              RENAME mysql COMPONENT SupportFiles)
+    ENDIF()
 
     INSTALL(FILES rpm/my.cnf DESTINATION ${INSTALL_SYSCONFDIR}
             COMPONENT Common)


### PR DESCRIPTION
requires #592 first.

Install into sharedir for sysv case as suggested by @vuvova.

I submit this under the MCA.