### PR TITLE
MDEV-15176: comment fix "1 00:10:10" -> "24:10:10"

### DIFF
--- a/sql/compat56.cc
+++ b/sql/compat56.cc
@@ -47,7 +47,7 @@ longlong TIME_to_longlong_time_packed(const MYSQL_TIME *ltime)
 {
   DBUG_ASSERT(ltime->year == 0);
   DBUG_ASSERT(ltime->month == 0);
-  // Mix days with hours: "1 00:10:10" -> "24:00:10"
+  // Mix days with hours: "1 00:10:10" -> "24:10:10"
   long hms= ((ltime->day * 24 + ltime->hour) << 12) |
             (ltime->minute << 6) | ltime->second;
   longlong tmp= MY_PACKED_TIME_MAKE(hms, ltime->second_part);


### PR DESCRIPTION
@abarkov I was having trouble parsing the comment you moved in 28d4cf0c1b3366c6471866d144ef28fced1e5390 so I just fixed it.

Interesting set of discoveries there. Thanks for fixing them.

I submit this under the MCA.