### PR TITLE
MDEV-12301 - Use @libexecdir@ macro for mysqld location.

### DIFF
--- a/scripts/galera_recovery.sh
+++ b/scripts/galera_recovery.sh
@@ -68,7 +68,7 @@ parse_arguments() {
 
 wsrep_recover_position() {
   # Redirect server's error log to the log file.
-  eval /usr/sbin/mysqld $cmdline_args --user=$user --wsrep_recover \
+  eval @libexecdir@/mysqld $cmdline_args --user=$user --wsrep_recover \
     --disable-log-error 2> "$log_file"
   ret=$?
   if [ $ret -ne 0 ]; then


### PR DESCRIPTION
In Fedora the mysql reside under /usr/libexec location