### PR TITLE
MDEV-14265: my_load_defaults - don't call exit in embedded

### DIFF
--- a/mysys/my_default.c
+++ b/mysys/my_default.c
@@ -631,7 +631,11 @@ int my_load_defaults(const char *conf_file, const char **groups,
       if (!my_getopt_is_args_separator((*argv)[i])) /* skip arguments separator */
         printf("%s ", (*argv)[i]);
     puts("");
+#ifdef EMBEDDED_LIBRARY
+    DBUG_RETURN(2);
+#else
     exit(0);
+#endif
   }
 
   if (default_directories)
@@ -641,7 +645,7 @@ int my_load_defaults(const char *conf_file, const char **groups,
 
  err:
   fprintf(stderr,"Fatal error in defaults handling. Program aborted\n");
-  return 2;
+  DBUG_RETURN(2);
 }
 
 


### PR DESCRIPTION
my_load_defaults with --print-defaults previously called exit
from a shared library. Replace that with return 2 which from an
API point of view means that it isn't processed. The calling
program should handle this as a fatal error and assumedly do
its own exit (or continue based on embedded mariadb being unavailable).

Reported by Michal Schorm as RPMLint warning: shared-lib-calls-exit

I submit this under the MCA.