### PR TITLE
MDEV-788 - Make mysqlimport and mysql able to ignore foreign keys

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -138,7 +138,7 @@ enum enum_info_type { INFO_INFO,INFO_ERROR,INFO_RESULT};
 typedef enum enum_info_type INFO_TYPE;
 
 static MYSQL mysql;			/* The connection */
-static my_bool ignore_errors=0,wait_flag=0,quick=0,
+static my_bool ignore_errors=0,ignore_foreign_keys=0,wait_flag=0,quick=0,
                connected=0,opt_raw_data=0,unbuffered=0,output_tables=0,
 	       opt_rehash=1,skip_updates=0,safe_updates=0,one_database=0,
 	       opt_compress=0, using_opt_local_infile=0,
@@ -1239,6 +1239,12 @@ int main(int argc,char *argv[])
 
   put_info(ORACLE_WELCOME_COPYRIGHT_NOTICE("2000"), INFO_INFO);
 
+  if (ignore_foreign_keys){
+          mysql_query(&mysql, "SET FOREIGN_KEY_CHECKS = 0;");
+          put_info("Foreign key checks are disabled! \\g.",
+                   INFO_INFO);
+  }
+
 #ifdef HAVE_READLINE
   initialize_readline((char*) my_progname);
   if (!status.batch && !quick && !opt_html && !opt_xml)
@@ -1535,6 +1541,10 @@ static struct my_option my_long_options[] =
   {"force", 'f', "Continue even if we get an SQL error. Sets abort-source-on-error to 0",
    &ignore_errors, &ignore_errors, 0, GET_BOOL, NO_ARG, 0, 0,
    0, 0, 0, 0},
+  {"ignore-foreign-keys", 'k',
+     "Ignore foreign key checks while importing data.",
+     (uchar**) &ignore_foreign_keys, (uchar**) &ignore_foreign_keys, 0, GET_BOOL, NO_ARG,
+     0, 0, 0, 0, 0, 0},
   {"named-commands", 'G',
    "Enable named commands. Named commands mean this program's internal "
    "commands; see mysql> help . When enabled, the named commands can be "

--- a/client/mysqlimport.c
+++ b/client/mysqlimport.c
@@ -47,7 +47,7 @@ static char *field_escape(char *to,const char *from,uint length);
 static char *add_load_option(char *ptr,const char *object,
 			     const char *statement);
 
-static my_bool	verbose=0,lock_tables=0,ignore_errors=0,opt_delete=0,
+static my_bool	verbose=0,lock_tables=0,ignore_errors=0,opt_delete=0, ignore_foreign_keys=0,
 		replace=0,silent=0,ignore=0,opt_compress=0,
                 opt_low_priority= 0, tty_password= 0;
 static my_bool debug_info_flag= 0, debug_check_flag= 0;
@@ -121,6 +121,10 @@ static struct my_option my_long_options[] =
    0, 0, 0, 0, 0, 0},
   {"host", 'h', "Connect to host.", &current_host,
    &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"ignore-foreign-keys", 'k',
+   "Ignore foreign key checks while importing data.",
+   (uchar**) &ignore_foreign_keys, (uchar**) &ignore_foreign_keys, 0, GET_BOOL, NO_ARG,
+   0, 0, 0, 0, 0, 0},
   {"ignore", 'i', "If duplicate unique key was found, keep old row.",
    &ignore, &ignore, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-lines", OPT_IGN_LINES, "Ignore first n lines of data infile.",
@@ -488,6 +492,9 @@ static MYSQL *db_connect(char *host, char *database,
   {
     ignore_errors=0;
     db_error(mysql);
+  }
+  if (ignore_foreign_keys) {
+    mysql_query(mysql, "SET FOREIGN_KEY_CHECKS = 0;");
   }
   return mysql;
 }


### PR DESCRIPTION
Facebook patch from https://github.com/facebookarchive/mysql-5.1/commit/797596fed371dc8932ff91660c978615658d81b6

I submit it under the GPL-2 as Facebook provided it.