### PR TITLE
fix comment in my_decimal_set_zero()

### DIFF
--- a/sql/my_decimal.h
+++ b/sql/my_decimal.h
@@ -288,7 +288,7 @@ int my_decimal_set_zero(my_decimal *d)
 {
   /*
     We need the up-cast here, since my_decimal has sign() member functions,
-    which conflicts with decimal_t::size
+    which conflicts with decimal_t::sign
     (and decimal_make_zero is a macro, rather than a funcion).
   */
   decimal_make_zero(static_cast<decimal_t*>(d));


### PR DESCRIPTION
which says:

    We need the up-cast here, since my_decimal has sign() member functions,
    which conflicts with decimal_t::size

But decimal_t does not provide `size` field.

--------
I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.