### PR TITLE
MDEV-12642: Build deb source packages on buildbot, just not on Travis-CI

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -104,12 +104,20 @@ dch -b -D ${CODENAME} -v "${UPSTREAM}${PATCHLEVEL}~${CODENAME}" "Automatic build
 
 echo "Creating package version ${UPSTREAM}${PATCHLEVEL}~${CODENAME} ... "
 
+# On Travis CI, use -b to build binary only packages as there is no need to
+# waste time on generating the source package.
+if [[ $TRAVIS ]]
+then
+  BUILDPACKAGE_FLAGS="-b"
+fi
+
 # Build the package
 # Pass -I so that .git and other unnecessary temporary and source control files
 # will be ignored by dpkg-source when creating the tar.gz source package.
-# Use -b to build binary only packages as there is no need to waste time on
-# generating the source package.
-fakeroot dpkg-buildpackage -us -uc -I -b
+fakeroot dpkg-buildpackage -us -uc -I $BUILDPACKAGE_FLAGS
+
+# If the step above fails due to missing dependencies, you can manually run
+#   sudo mk-build-deps debian/control -r -i
 
 # Don't log package contents on Travis-CI to save time and log size
 if [[ ! $TRAVIS ]]


### PR DESCRIPTION
simple back-port of @ottok 

closes MDEV-14928 and MDEV-12642