### PR TITLE
MDEV-15511 - Use stunnel during rsync SST if available

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -41,6 +41,8 @@ cleanup_joiner()
     kill -9 $RSYNC_REAL_PID >/dev/null 2>&1 || \
     :
     rm -rf "$RSYNC_CONF"
+    rm -f "$STUNNEL_CONF"
+    rm -f "$STUNNEL_PID"
     rm -rf "$MAGIC_FILE"
     rm -rf "$RSYNC_PID"
     wsrep_log_info "Joiner cleanup done."
@@ -75,7 +77,7 @@ check_pid_and_port()
     local port_info=$(lsof -i :$rsync_port -Pn 2>/dev/null | \
         grep "(LISTEN)")
     local is_rsync=$(echo $port_info | \
-        grep -w '^rsync[[:space:]]\+'"$rsync_pid" 2>/dev/null)
+        grep -wE '^(rsync|stunnel)[[:space:]]+'"$rsync_pid" 2>/dev/null)
 
     if [ -n "$port_info" -a -z "$is_rsync" ]; then
         wsrep_log_error "rsync daemon port '$rsync_port' has been taken"
@@ -85,6 +87,12 @@ check_pid_and_port()
         [ -n "$port_info" ] && [ -n "$is_rsync" ] && \
         [ $(cat $pid_file) -eq $rsync_pid ]
 }
+
+STUNNEL_CONF="$WSREP_SST_OPT_DATA/stunnel.conf"
+rm -f "$STUNNEL_CONF"
+
+STUNNEL_PID="$WSREP_SST_OPT_DATA/stunnel.pid"
+rm -f "$STUNNEL_PID"
 
 MAGIC_FILE="$WSREP_SST_OPT_DATA/rsync_sst_complete"
 rm -rf "$MAGIC_FILE"
@@ -123,8 +131,27 @@ fi
 FILTER=(-f '- /lost+found' -f '- /.fseventsd' -f '- /.Trashes'
         -f '+ /wsrep_sst_binlog.tar' -f '+ /ib_lru_dump' -f '+ /ibdata*' -f '+ /*/' -f '- /*')
 
+SSTKEY=$(parse_cnf sst tkey "")
+SSTCERT=$(parse_cnf sst tcert "")
+STUNNEL=""
+if [ -f "$SSTKEY" ] && [ -f "$SSTCERT" ] && wsrep_check_programs stunnel
+then
+    STUNNEL="stunnel ${STUNNEL_CONF}"
+fi
+
 if [ "$WSREP_SST_OPT_ROLE" = "donor" ]
 then
+
+cat << EOF > "$STUNNEL_CONF"
+CApath = ${SSTCERT%/*}
+foreground = yes
+pid = $STUNNEL_PID
+debug = warning
+client = yes
+connect = ${WSREP_SST_OPT_ADDR%/*}
+TIMEOUTclose = 0
+verifyPeer = yes
+EOF
 
     if [ $WSREP_SST_OPT_BYPASS -eq 0 ]
     then
@@ -185,7 +212,8 @@ then
 
         # first, the normal directories, so that we can detect incompatible protocol
         RC=0
-        rsync --owner --group --perms --links --specials \
+        rsync ${STUNNEL:+--rsh="$STUNNEL"} \
+              --owner --group --perms --links --specials \
               --ignore-times --inplace --dirs --delete --quiet \
               $WHOLE_FILE_OPT "${FILTER[@]}" "$WSREP_SST_OPT_DATA/" \
               rsync://$WSREP_SST_OPT_ADDR >&2 || RC=$?
@@ -208,7 +236,8 @@ then
         fi
 
         # second, we transfer InnoDB log files
-        rsync --owner --group --perms --links --specials \
+        rsync ${STUNNEL:+--rsh="$STUNNEL"} \
+              --owner --group --perms --links --specials \
               --ignore-times --inplace --dirs --delete --quiet \
               $WHOLE_FILE_OPT -f '+ /ib_logfile[0-9]*' -f '- **' "$WSREP_LOG_DIR/" \
               rsync://$WSREP_SST_OPT_ADDR-log_dir >&2 || RC=$?
@@ -227,7 +256,8 @@ then
 
         find . -maxdepth 1 -mindepth 1 -type d -not -name "lost+found" \
              -print0 | xargs -I{} -0 -P $count \
-             rsync --owner --group --perms --links --specials \
+             rsync ${STUNNEL:+--rsh="$STUNNEL"} \
+             --owner --group --perms --links --specials \
              --ignore-times --inplace --recursive --delete --quiet \
              $WHOLE_FILE_OPT --exclude '*/ib_logfile*' "$WSREP_SST_OPT_DATA"/{}/ \
              rsync://$WSREP_SST_OPT_ADDR/{} >&2 || RC=$?
@@ -250,7 +280,8 @@ then
     echo "continue" # now server can resume updating data
 
     echo "$STATE" > "$MAGIC_FILE"
-    rsync --archive --quiet --checksum "$MAGIC_FILE" rsync://$WSREP_SST_OPT_ADDR
+    rsync ${STUNNEL:+--rsh="$STUNNEL"} \
+          --archive --quiet --checksum "$MAGIC_FILE" rsync://$WSREP_SST_OPT_ADDR
 
     echo "done $STATE"
 
@@ -308,8 +339,30 @@ EOF
 
     # listen at all interfaces (for firewalled setups)
     readonly RSYNC_PORT=${WSREP_SST_OPT_PORT:-4444}
-    rsync --daemon --no-detach --port $RSYNC_PORT --config "$RSYNC_CONF" &
-    RSYNC_REAL_PID=$!
+
+cat << EOF > "$STUNNEL_CONF"
+key = $SSTKEY
+cert = $SSTCERT
+foreground = yes
+pid = $STUNNEL_PID
+debug = warning
+client = no
+[rsync]
+accept = $RSYNC_PORT
+exec = $(which rsync)
+execargs = rsync --server --daemon --config=$RSYNC_CONF .
+EOF
+
+    if [ -z "$STUNNEL" ]
+    then
+        # listen at all interfaces (for firewalled setups)
+        rsync --daemon --no-detach --port $RSYNC_PORT --config "$RSYNC_CONF" &
+        RSYNC_REAL_PID=$!
+    else
+        stunnel "$STUNNEL_CONF" &
+        RSYNC_REAL_PID=$!
+        RSYNC_PID=$STUNNEL_PID
+    fi
 
     until check_pid_and_port $RSYNC_PID $RSYNC_REAL_PID $RSYNC_PORT
     do


### PR DESCRIPTION
Hi,

This PR adds the ability to use stunnel during rsync SST, thus encrypting data on the wire.

You then just have to have `stunnel` binary available, and the following in server configuration :
```
[sst]
tkey = /etc/mysql/certs/client-key.pem
tcert = /etc/mysql/certs/client-cert.pem
# ca-cert.pem is not needed in configuration but will be used for peer verification
```
`stunnel` will then be used.

You will also have to be sure your `certs` dir is hashed :
`openssl  rehash /etc/mysql/certs/`

Thank you 👍 

Ben