### PR TITLE
MDEV-15128 - Fix sh parse error when [sst] config value has spaces.

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -269,13 +269,13 @@ parse_cnf()
     fi
 
     # look in group
-    if [ -z $reval ]; then
+    if [ -z "$reval" ]; then
         reval=$($MY_PRINT_DEFAULTS $group | awk -F= '{if ($1 ~ /_/) { gsub(/_/,"-",$1); print $1"="$2 } else { print $0 }}' | grep -- "--$var=" | cut -d= -f2- | tail -1)
     fi
 
     # use default if we haven't found a value
-    if [ -z $reval ]; then
-        [ -n $3 ] && reval=$3
+    if [ -z "$reval" ]; then
+        [ -n "$3" ] && reval=$3
     fi
     echo $reval
 }


### PR DESCRIPTION
Example config:

```
[sst]
sst-syslog=-1
progress=/tmp/mysql-console/fifo
compressor="pigz --fast --processes 4"
decompressor="pigz --decompress"
```

Errors reported during SST:

```
/usr//bin/wsrep_sst_common: line 261: [: too many arguments
/usr//bin/wsrep_sst_common: line 261: [: pigz: binary operator expected
```