### PR TITLE
merge two the same consistently 'if' clauses into one

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5299,10 +5299,7 @@ static int init_server_components()
     {
       unireg_abort(1);
     }
-  }
 
-  if (opt_bin_log)
-  {
     log_bin_basename=
       rpl_make_log_name(opt_bin_logname, pidfile_name,
                         opt_bin_logname ? "" : "-bin");


### PR DESCRIPTION
we have two the same 'if' clauses that check opt_bin_log argument
in mysqld.cc and both clauses go successively one after another.
Let's merge them into one

---
I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.