### PR TITLE
MDEV-15513 - use EVP_MD_CTX_{new,free} instead of EVP_MD_CTX_{create, destroy}

### DIFF
--- a/mysys_ssl/openssl.c
+++ b/mysys_ssl/openssl.c
@@ -61,8 +61,8 @@ int check_openssl_compatibility()
     return 1;
 
   alloc_size= alloc_count= 0;
-  md5_ctx= EVP_MD_CTX_create();
-  EVP_MD_CTX_destroy(md5_ctx);
+  md5_ctx= EVP_MD_CTX_new();
+  EVP_MD_CTX_free(md5_ctx);
   if (alloc_count != 1 || !alloc_size || alloc_size > EVP_MD_CTX_SIZE)
     return 1;
 


### PR DESCRIPTION
for consistency with EVP_CIPHER_CTX_new() and EVP_CIPHER_CTX_free().

As the EVP_DIGESTINIT(3) man page says:

EVP_MD_CTX_create() and EVP_MD_CTX_destroy() were renamed to
EVP_MD_CTX_new() and EVP_MD_CTX_free() in OpenSSL 1.1.

---
I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.