### PR TITLE
MDEV-15356: tp_timeout_handler needs to call set_killed_no_mutex as i…

### DIFF
--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -470,7 +470,7 @@ void tp_timeout_handler(TP_connection *c)
     return;
   THD *thd=c->thd;
   mysql_mutex_lock(&thd->LOCK_thd_kill);
-  thd->set_killed(KILL_WAIT_TIMEOUT);
+  thd->set_killed_no_mutex(KILL_WAIT_TIMEOUT);
   c->priority= TP_PRIORITY_HIGH;
   post_kill_notification(thd);
   mysql_mutex_unlock(&thd->LOCK_thd_kill);


### PR DESCRIPTION
…t has the mutex

Regression introducted in c2118a08b144 where LOCK_thd_data was moveed
to LOCK_thd_kill

I submit this under the MCA.