### PR TITLE
MDEV-11254: innodb/xtradb unused srv_page_compression_trim_{op_saved,sect512,sect4096}

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -418,13 +418,10 @@ ulint	srv_truncated_status_writes;
 ulong	srv_available_undo_logs;
 
 UNIV_INTERN ib_uint64_t srv_page_compression_saved;
-UNIV_INTERN ib_uint64_t srv_page_compression_trim_sect512;
-UNIV_INTERN ib_uint64_t srv_page_compression_trim_sect4096;
 UNIV_INTERN ib_uint64_t srv_index_pages_written;
 UNIV_INTERN ib_uint64_t srv_non_index_pages_written;
 UNIV_INTERN ib_uint64_t srv_pages_page_compressed;
 UNIV_INTERN ib_uint64_t srv_page_compressed_trim_op;
-UNIV_INTERN ib_uint64_t srv_page_compressed_trim_op_saved;
 UNIV_INTERN ib_uint64_t srv_index_page_decompressed;
 
 /* Defragmentation */

--- a/storage/xtradb/srv/srv0srv.cc
+++ b/storage/xtradb/srv/srv0srv.cc
@@ -566,13 +566,10 @@ UNIV_INTERN ulint	srv_truncated_status_writes	= 0;
 UNIV_INTERN ulint	srv_available_undo_logs         = 0;
 
 UNIV_INTERN ib_uint64_t srv_page_compression_saved      = 0;
-UNIV_INTERN ib_uint64_t srv_page_compression_trim_sect512       = 0;
-UNIV_INTERN ib_uint64_t srv_page_compression_trim_sect4096      = 0;
 UNIV_INTERN ib_uint64_t srv_index_pages_written         = 0;
 UNIV_INTERN ib_uint64_t srv_non_index_pages_written     = 0;
 UNIV_INTERN ib_uint64_t srv_pages_page_compressed       = 0;
 UNIV_INTERN ib_uint64_t srv_page_compressed_trim_op     = 0;
-UNIV_INTERN ib_uint64_t srv_page_compressed_trim_op_saved     = 0;
 UNIV_INTERN ib_uint64_t srv_index_page_decompressed     = 0;
 
 /* Ensure status variables are on separate cache lines */


### PR DESCRIPTION
Commit 6495806e59cc27313375fa8d431b7b8e777f73ff missed the purging of these now unused variables.

I submit this purge under the MCA.