### PR TITLE
Misc. typos

### DIFF
--- a/Docs/README-wsrep
+++ b/Docs/README-wsrep
@@ -366,7 +366,7 @@ wsrep_forced_binlog_format=none
    format, regardless of what the client session has specified in binlog_format.
    Valid choices for wsrep_forced_binlog_format are: ROW, STATEMENT, MIXED and
    special value NONE, meaning that there is no forced binlog format in effect.
-   This variable was intruduced to support STATEMENT format replication during
+   This variable was introduced to support STATEMENT format replication during
    rolling schema upgrade processing. However, in most cases ROW replication 
    is valid for asymmetrict schema replication.
 

--- a/Docs/myisam.txt
+++ b/Docs/myisam.txt
@@ -95,7 +95,7 @@ Zero if the create is successful. Non-zero if an error occurs.
 
 HA_WRONG_CREATE_OPTION
  means that some of the arguments was wrong.
-appart from the above one can get any unix error that one can get from open(), write() or close().
+apart from the above one can get any unix error that one can get from open(), write() or close().
 
 #.#.4 Examples
 
@@ -169,7 +169,7 @@ The function parameter can be:
 HA_EXTRA_QUICK=1			Optimize for speed 
 HA_EXTRA_RESET=2			Reset database to after open 
 HA_EXTRA_CACHE=3			Cash record in HA_rrnd() 
-HA_EXTRA_NO_CACHE=4			End cacheing of records (def) 
+HA_EXTRA_NO_CACHE=4			End caching of records (def) 
 HA_EXTRA_NO_READCHECK=5		No readcheck on update 
 HA_EXTRA_READCHECK=6			Use readcheck (def) 
 HA_EXTRA_KEYREAD=7			Read only key to database 
@@ -335,7 +335,7 @@ int mi_rfirst(MI_INFO *mip , byte *buf, int inx)
 #.#.1 Description
 
 Reads the first row in the MyISAM file according to the specified index.
-If one want's to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
+If one wants to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
 
 mip is an MI_INFO pointer to the open handle.
 buf is the record buffer that will contain the row.
@@ -364,7 +364,7 @@ int mi_rkey(MI_INFO *mip, byte *buf, int inx, const byte *key, uint key_len, enu
 #.#.1 Description
 
 Reads the next row after the last row read, using the current index. 
-If one want's to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
+If one wants to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
 
 mip is an MI_INFO pointer to the open handle.
 buf is the record buffer that will contain the row.
@@ -397,7 +397,7 @@ int mi_rlast(MI_INFO *mip , byte *buf, int inx)
 #.#.1 Description
 
 Reads the last row in the MyISAM file according to the specified index.
-If one want's to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
+If one wants to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
 mip is an MI_INFO pointer to the open handle.
 buf is a pointer to the record buffer that will contain the row.
 Inx is the index (key) number, which must be the same as currently selected.
@@ -425,7 +425,7 @@ int mi_rnext(MI_INFO *mip , byte *buf, int inx )
 #.#.1 Description
 
 Reads the next row after the last row read, using the current index. 
-If one want's to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
+If one wants to read rows in physical sequences, then one should instead use mi_scan() or mi_rrnd().
 
 mip is an MI_INFO pointer to the open handle.
 buf is the record buffer that will contain the row.
@@ -520,7 +520,7 @@ int mi_rsame(MI_INFO *mip, byte *buf, int inx)
 
 Reads the current row to get its latest contents. This is useful to refresh the record buffer in case someone else has changed it.
 If inx is negative it reads by position. If inx is >= 0 it reads by key.
-With mi_rsame() one can switch to use any other index for the current row. This is good if you have a user application that lets the user do 'read-next' on a row.  In this case, if the user want's to start scanning on another index, one simply has to do a mi_rsame() on the new index to activate this.
+With mi_rsame() one can switch to use any other index for the current row. This is good if you have a user application that lets the user do 'read-next' on a row.  In this case, if the user wants to start scanning on another index, one simply has to do a mi_rsame() on the new index to activate this.
 
 mip is an MI_INFO pointer to the open handle.
 buf is the record buffer that will contain the row.
@@ -677,7 +677,7 @@ Zero if successful. Non-zero if an error occurred.
 HA_ERR_FOUND_DUPP_KEY
 A record already existed with a unique key same as this new record.
 HA_ERR_RECORD_FILE_FULL
-The error is given if you hit a system limit or if you try to create more rows in a table that you reserverd room for with mi_create().
+The error is given if you hit a system limit or if you try to create more rows in a table that you reserved room for with mi_create().
 ENOSPC
 The disk is full.
 EACCES
@@ -770,7 +770,7 @@ uint _mi_make_key( MI_INFO *mip, uint keynr, uchar *key, const char *record, my_
 Construct a key string for the given index, from the provided record buffer.
 ??? When packed records are used ...
 This is an internal function, not for use by applications. Monty says: "This can't be used to create an external key for an application from your record."
-See mi_make_application_key() for a similar function that is useable by applications.
+See mi_make_application_key() for a similar function that is usable by applications.
 
 The parameters are:
 A MI_INFO pointer mip.
@@ -872,7 +872,7 @@ HEAP tables only exists in memory so they are lost if `mysqld' is taken down or 
 
 The *MySQL* internal HEAP tables uses 100% dynamic hashing without overflow areas and don't have problems with delete. 
 
-You can only access things by equality using a index (usually by the `=' operator) whith a heap table. 
+You can only access things by equality using a index (usually by the `=' operator) with a heap table. 
 The downside with HEAPS are: 
   1. You need enough extra memory for all HEAP tables that you want to use at the same time. 
   2. You can't search on a part of a index. 

--- a/Docs/sp-imp-spec.txt
+++ b/Docs/sp-imp-spec.txt
@@ -294,15 +294,15 @@
 
     - Detecting and parsing a FUNCTION invocation
 
-      The existance of UDFs are checked during the lexical analysis (in
+      The existence of UDFs are checked during the lexical analysis (in
       sql_lex.cc:find_keyword()). This has the drawback that they must
-      exist before they are refered to, which was ok before SPs existed,
+      exist before they are referred to, which was ok before SPs existed,
       but then it becomes a problem. The first implementation of SP FUNCTIONs
       will work the same way, but this should be fixed a.s.a.p. (This will
       required some reworking of the way UDFs are handled, which is why it's
       not done from the start.)
       For the time being, a FUNCTION is detected the same way, and returns
-      the token SP_FUNC. During the parsing we only check for the *existance*
+      the token SP_FUNC. During the parsing we only check for the *existence*
       of the function, we don't parse it, since wa can't call the parser
       recursively.
 
@@ -329,7 +329,7 @@
       of the mysql.proc table during a query execution, but this it not
       possible at the present.
 
-      So, the solution is to collect the names of the refered FUNCTIONs during
+      So, the solution is to collect the names of the referred FUNCTIONs during
       parsing in the lex.
       Then, before doing anything else in mysql_execute_command(), read all
       functions from the database an keep them in the THD, where the function
@@ -390,7 +390,7 @@
     a method in the THD's sp_rcontext (if there is one). If a handler is
     found, this is recorded in the context and the routine returns without
     sending the error message.
-    The exectution loop (sp_head::execute()) checks for this after each
+    The execution loop (sp_head::execute()) checks for this after each
     statement and invokes the handler that has been found. If several
     errors or warnings occurs during one statement, only the first is
     caught, the rest are ignored.
@@ -402,7 +402,7 @@
     Calling and returning from a CONTINUE handler poses some special
     problems. Since we need to return to the point after its invocation,
     we push the return location on a stack in the sp_rcontext (this is
-    done by the exectution loop). The handler then ends with a special
+    done by the execution loop). The handler then ends with a special
     instruction, sp_instr_hreturn, which returns to this location.
 
     CONTINUE handlers have one additional problem: They are parsed at
@@ -546,7 +546,7 @@
 
     Unfortunately, we cannot use alternative 1 for the time being, as most
     of the data structures to be cached (lex and items) are not reentrant
-    and thread-safe. (Things are modifed at execution, we have THD pointers
+    and thread-safe. (Things are modified at execution, we have THD pointers
     stored everywhere, etc.)
     This leaves us with alternative 2, one cache per thread; or actually
     two, since we keep FUNCTIONs and PROCEDUREs in separate caches.

--- a/cmake/dtrace_prelink.cmake
+++ b/cmake/dtrace_prelink.cmake
@@ -34,7 +34,7 @@ ENDMACRO()
 IF(TYPE STREQUAL "MERGE")
   # Rerun dtrace on objects that are already in static libraries.
   # Object paths are stored in text files named 'dtrace_objects'
-  # in the input directores. We have to copy the objects into temp.
+  # in the input directories. We have to copy the objects into temp.
   # directory, as running dtrace -G on original files will change
   # timestamps and cause rebuilds or the libraries / excessive 
   # relink

--- a/cmake/libutils.cmake
+++ b/cmake/libutils.cmake
@@ -151,7 +151,7 @@ MACRO(MERGE_STATIC_LIBS TARGET OUTPUT_NAME LIBS_TO_MERGE)
       IF(LIB_TYPE STREQUAL "STATIC_LIBRARY")
         SET(STATIC_LIBS ${STATIC_LIBS} ${LIB_LOCATION})
         ADD_DEPENDENCIES(${TARGET} ${LIB})
-        # Extract dependend OS libraries
+        # Extract dependent OS libraries
         GET_DEPENDEND_OS_LIBS(${LIB} LIB_OSLIBS)
         LIST(APPEND OSLIBS ${LIB_OSLIBS})
       ELSE()

--- a/cmake/mysql_version.cmake
+++ b/cmake/mysql_version.cmake
@@ -95,7 +95,7 @@ SET(CPACK_PACKAGE_CONTACT "MariaDB Developers <maria-developers@lists.launchpad.
 SET(CPACK_PACKAGE_VENDOR "MariaDB Foundation")
 SET(CPACK_SOURCE_GENERATOR "TGZ")
 
-# Defintions for windows version resources
+# Definitions for windows version resources
 SET(PRODUCTNAME "MariaDB Server")
 SET(COMPANYNAME ${CPACK_PACKAGE_VENDOR})
 

--- a/dbug/dbug.c
+++ b/dbug/dbug.c
@@ -315,7 +315,7 @@ static void DbugVfprintf(FILE *stream, const char* format, va_list args);
 
 #undef EXISTS
 #if !defined(HAVE_ACCESS)
-#define EXISTS(pathname) (FALSE)        /* Assume no existance */
+#define EXISTS(pathname) (FALSE)        /* Assume no existence */
 #define Writable(name) (TRUE)
 #else
 #define EXISTS(pathname)         (access(pathname, F_OK) == 0)
@@ -2180,7 +2180,7 @@ static BOOLEAN Writable(const char *pathname)
 
 /*
   flush dbug-stream, free mutex lock & wait delay
-  This is because some systems (MSDOS!!) dosn't flush fileheader
+  This is because some systems (MSDOS!!) doesn't flush fileheader
   and dbug-file isn't readable after a system crash !!
 */
 

--- a/debian/additions/innotop/changelog.innotop
+++ b/debian/additions/innotop/changelog.innotop
@@ -77,7 +77,7 @@ Changelog for innotop:
    * remove cxn from $meta->{group_by} if there's only one connection displayed
    * fix for issue 19 - cxn column won't become visible when viewing two 
      connections after having viewed one connection
-   * supress errors resulting from the addition of a 'BACKGROUND THREAD' 
+   * suppress errors resulting from the addition of a 'BACKGROUND THREAD' 
      section in the output of 'show innodb status' 
    * possible fix for issue 22 - Useless use of a constant in void context
    * small change to set_to_tbl() around hiding the cxn column if there 

--- a/debian/additions/innotop/innotop
+++ b/debian/additions/innotop/innotop
@@ -4657,7 +4657,7 @@ my %stmt_maker_for = (
       my $sth;
       eval { # This can fail if the table doesn't exist, INFORMATION_SCHEMA doesn't exist, etc.
          my $cols = $dbh->selectall_arrayref(q{SHOW /*innotop*/ COLUMNS FROM INFORMATION_SCHEMA.PROCESSLIST LIKE 'TIME_MS'});
-         if ( @$cols ) { # The TIME_MS colum exists
+         if ( @$cols ) { # The TIME_MS column exists
             $sth = $dbh->prepare(q{SELECT /*innotop*/ ID, USER, HOST, DB, COMMAND, CASE WHEN TIME_MS/1000 > 365*86400 THEN TIME ELSE TIME_MS/1000 END AS TIME, STATE, INFO FROM INFORMATION_SCHEMA.PROCESSLIST});
          }
       };
@@ -11653,7 +11653,7 @@ show you something like this:
  pages_modified     Dirty Pages  Pages modified (dirty  IB_bp_pages_m
  buf_pool_hit_rate  Hit Rate     Buffer pool hit rate   IB_bp_buf_poo
  total_mem_alloc    Memory       Total memory allocate  IB_bp_total_m
- add_pool_alloc     Add'l Pool   Additonal pool alloca  IB_bp_add_poo
+ add_pool_alloc     Add'l Pool   Additional pool alloca  IB_bp_add_poo
 
 The first line shows which table you're editing, and reminds you again to press
 '?' for a list of key mappings.  The rest is a tabular representation of the

--- a/debian/additions/innotop/innotop.1
+++ b/debian/additions/innotop/innotop.1
@@ -1678,7 +1678,7 @@ show you something like this:
 \& pages_modified     Dirty Pages  Pages modified (dirty  IB_bp_pages_m
 \& buf_pool_hit_rate  Hit Rate     Buffer pool hit rate   IB_bp_buf_poo
 \& total_mem_alloc    Memory       Total memory allocate  IB_bp_total_m
-\& add_pool_alloc     Add\*(Aql Pool   Additonal pool alloca  IB_bp_add_poo
+\& add_pool_alloc     Add\*(Aql Pool   Additional pool alloca  IB_bp_add_poo
 .Ve
 .PP
 The first line shows which table you're editing, and reminds you again to press

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,7 +5,7 @@ The Debian package of MySQL was first debianzed on 1997-04-12 by Christian
 Schwarz <schwarz@debian.org> and ist maintained since 1999-04-20 by
 Christian Hammers <ch@debian.org>.
 
-The MariaDB packages were initally made by http://ourdelta.org/, and
+The MariaDB packages were initially made by http://ourdelta.org/, and
 are now managed by the MariaDB development team,
 maria-developers@lists.launchpad.net
 

--- a/debian/mariadb-server-10.3.README.Debian
+++ b/debian/mariadb-server-10.3.README.Debian
@@ -40,7 +40,7 @@ https://mariadb.com/kb
 * PASSWORDS:
 ============
 It is strongly recommended you create an admin users for your database
-adminstration needs.
+administration needs.
 
 If your local unix account is the one you want to have local super user
 access on your database with you can create the following account that will

--- a/include/json_lib.h
+++ b/include/json_lib.h
@@ -312,7 +312,7 @@ typedef const int *json_level_t;
 int json_skip_to_level(json_engine_t *j, int level);
 
 /*
-  json_skip_level() works as above with just current structre.
+  json_skip_level() works as above with just current structure.
   So it gets to the end of the current JSON array or object.
 */
 #define json_skip_level(json_engine) \

--- a/include/m_ctype.h
+++ b/include/m_ctype.h
@@ -48,7 +48,7 @@ extern "C" {
 /*
   On i386 we store Unicode->CS conversion tables for
   some character sets using Big-endian order,
-  to copy two bytes at onces.
+  to copy two bytes at once.
   This gives some performance improvement.
 */
 #ifdef __i386__
@@ -376,7 +376,7 @@ typedef size_t (*my_charset_conv_case)(CHARSET_INFO *,
   A structure to return the statistics of a native string copying,
   when no Unicode conversion is involved.
 
-  The stucture is OK to be uninitialized before calling a copying routine.
+  The structure is OK to be uninitialized before calling a copying routine.
   A copying routine must populate the structure as follows:
     - m_source_end_pos must be set by to a non-NULL value
       in the range of the input string.
@@ -517,7 +517,7 @@ struct my_charset_handler_st
   /**
     Write a character to the target string, using its native code.
     For Unicode character sets (utf8, ucs2, utf16, utf16le, utf32, filename)
-    native codes are equvalent to Unicode code points.
+    native codes are equivalent to Unicode code points.
     For 8bit character sets the native code is just the byte value.
     For Asian characters sets:
     - MB1 native code is just the byte value (e.g. on the ASCII range)
@@ -964,7 +964,7 @@ uint32 my_convert_using_func(char *to, size_t to_length, CHARSET_INFO *to_cs,
   Bad byte sequences as well as characters that cannot be
   encoded in the destination character set are replaced to '?'.
   Not more than "nchars" characters are copied.
-  Conversion statistics is returnd in "status" and is set as follows:
+  Conversion statistics is returned in "status" and is set as follows:
   - status->m_native_copy_status.m_source_end_pos - to the position
     between (src) and (src+src_length), where the function stopped reading
     the source string.

--- a/include/m_string.h
+++ b/include/m_string.h
@@ -14,8 +14,8 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-/* There may be prolems include all of theese. Try to test in
-   configure with ones are needed? */
+/* There may be problems included in all of these. Try to test in
+   configure which ones are needed? */
 
 /*  This is needed for the definitions of strchr... on solaris */
 

--- a/include/my_base.h
+++ b/include/my_base.h
@@ -270,7 +270,7 @@ enum ha_base_keytype {
 #define HA_UNIQUE_CHECK		256U	/* Check the key for uniqueness */
 #define HA_SPATIAL		1024U   /* For spatial search */
 #define HA_NULL_ARE_EQUAL	2048U	/* NULL in key are cmp as equal */
-#define HA_GENERATED_KEY	8192U	/* Automaticly generated key */
+#define HA_GENERATED_KEY	8192U	/* Automatically generated key */
 
         /* The combination of the above can be used for key type comparison. */
 #define HA_KEYFLAG_MASK (HA_NOSAME | HA_PACK_KEY | HA_AUTO_KEY | \

--- a/include/my_bit.h
+++ b/include/my_bit.h
@@ -45,7 +45,7 @@ Count bits in 32bit integer
   http://graphics.stanford.edu/~seander/bithacks.html
   under "Counting bits set, in parallel"
 
- (Orignal code public domain).
+ (Original code public domain).
 */
 static inline uint my_count_bits_uint32(uint32 v)
 {
@@ -77,7 +77,7 @@ static inline uint my_count_bits(ulonglong x)
   NOTES
     Algorithm by Sean Anderson, according to:
     http://graphics.stanford.edu/~seander/bithacks.html
-    (Orignal code public domain)
+    (Original code public domain)
 
     Comments shows how this works with 01100000000000000000000000001011
 */

--- a/include/my_dbug.h
+++ b/include/my_dbug.h
@@ -211,7 +211,7 @@ void debug_sync_point(const char* lock_name, uint lock_timeout);
 }
 /*
   DBUG_LOG() was initially intended for InnoDB. To be able to use it elsewhere
-  one should #include <sstream>. We intentially avoid including it here to save
+  one should #include <sstream>. We intentionally avoid including it here to save
   compilation time.
 */
 # ifdef DBUG_OFF

--- a/include/my_dir.h
+++ b/include/my_dir.h
@@ -50,7 +50,7 @@ extern "C" {
 #define MY_S_ISREG(m)	(((m) & MY_S_IFMT) == MY_S_IFREG)
 #define MY_S_ISFIFO(m)	(((m) & MY_S_IFMT) == MY_S_IFIFO)
 
-/* Ensure these dosn't clash with anything in my_sys.h */
+/* Ensure these doesn't clash with anything in my_sys.h */
 #define MY_WANT_SORT     8192   /* my_lib; sort files */
 #define MY_WANT_STAT	16384	/* my_lib; stat files */
 #define MY_DONT_SORT        0
@@ -63,7 +63,7 @@ typedef struct my_stat
 {
   dev_t		st_dev;		/* major & minor device numbers */
   ino_t		st_ino;		/* inode number */
-  ushort	st_mode;	/* file permissons (& suid sgid .. bits) */
+  ushort	st_mode;	/* file permissions (& suid sgid .. bits) */
   short		st_nlink;	/* number of links to file */
   ushort	st_uid;		/* user id */
   ushort	st_gid;		/* group id */
@@ -79,7 +79,7 @@ typedef struct my_stat
 #if(_MSC_VER)
 #define MY_STAT struct _stati64 /* 64 bit file size */
 #else
-#define MY_STAT struct stat	/* Orginal struct have what we need */
+#define MY_STAT struct stat	/* Original struct has what we need */
 #endif
 
 #endif /* USE_MY_STAT_STRUCT */

--- a/include/my_global.h
+++ b/include/my_global.h
@@ -460,7 +460,7 @@ extern "C" int madvise(void *addr, size_t len, int behav);
 #define UNINIT_VAR(x) x
 #endif
 
-/* This is only to be used when reseting variables in a class constructor */
+/* This is only to be used when resetting variables in a class constructor */
 #if defined(_lint) || defined(FORCE_INIT_OF_VARS)
 #define LINT_INIT(x) x= 0
 #else
@@ -553,7 +553,7 @@ C_MODE_START
 typedef int	(*qsort_cmp)(const void *,const void *);
 typedef int	(*qsort_cmp2)(void*, const void *,const void *);
 C_MODE_END
-#define qsort_t RETQSORTTYPE	/* Broken GCC cant handle typedef !!!! */
+#define qsort_t RETQSORTTYPE	/* Broken GCC can't handle typedef !!!! */
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif

--- a/include/my_net.h
+++ b/include/my_net.h
@@ -15,7 +15,7 @@
 
 /*
   This file is also used to make handling of sockets and ioctl()
-  portable accross systems.
+  portable across systems.
 
 */
 

--- a/include/my_pthread.h
+++ b/include/my_pthread.h
@@ -501,9 +501,9 @@ void safe_mutex_free_deadlock_data(safe_mutex_t *mp);
      MDL subsystem deadlock detector relies on this property for
      its correctness.
   2) They are optimized for uncontended wr-lock/unlock case.
-     This is scenario in which they are most oftenly used
+     This is a scenario in which they are most often used
      within MDL subsystem. Optimizing for it gives significant
-     performance improvements in some of tests involving many
+     performance improvements in some of the tests involving many
      connections.
 
   Another important requirement imposed on this type of rwlock

--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -60,8 +60,8 @@ typedef struct my_aio_result {
 
 	/* General bitmaps for my_func's */
 #define MY_FFNF		1U	/* Fatal if file not found */
-#define MY_FNABP	2U	/* Fatal if not all bytes read/writen */
-#define MY_NABP		4U	/* Error if not all bytes read/writen */
+#define MY_FNABP	2U	/* Fatal if not all bytes read/written */
+#define MY_NABP		4U	/* Error if not all bytes read/written */
 #define MY_FAE		8U	/* Fatal if any error */
 #define MY_WME		16U	/* Write message on error */
 #define MY_WAIT_IF_FULL 32U	/* Wait and try again if disk full error */
@@ -71,7 +71,7 @@ typedef struct my_aio_result {
 #define MY_FULL_IO     512U     /* my_read(): loop until I/O is complete */
 #define MY_DONT_CHECK_FILESIZE 128U /* Option to init_io_cache() */
 #define MY_LINK_WARNING 32U	/* my_redel() gives warning if links */
-#define MY_COPYTIME	64U	/* my_redel() copys time */
+#define MY_COPYTIME	64U	/* my_redel() copies time */
 #define MY_DELETE_OLD	256U	/* my_create_with_symlink() */
 #define MY_RESOLVE_LINK 128U	/* my_realpath(); Only resolve links */
 #define MY_HOLD_ORIGINAL_MODES 128U  /* my_copy() holds to file modes */
@@ -96,7 +96,7 @@ typedef struct my_aio_result {
 #define MY_SYNC_FILESIZE 65536U /* my_sync(): safe sync when file is extended */
 #define MY_THREAD_SPECIFIC 0x10000U /* my_malloc(): thread specific */
 #define MY_THREAD_MOVE     0x20000U /* realloc(); Memory can move */
-/* Tree that should delete things automaticly */
+/* Tree that should delete things automatically */
 #define MY_TREE_WITH_DELETE 0x40000U
 
 #define MY_CHECK_ERROR	1U	/* Params to my_end; Check open-close */
@@ -106,7 +106,7 @@ typedef struct my_aio_result {
 #define ME_BELL         4U      /* Ring bell then printing message */
 #define ME_WAITTANG     0       /* Wait for a user action  */
 #define ME_NOREFRESH    64U     /* Write the error message to error log */
-#define ME_NOINPUT      0       /* Dont use the input libary */
+#define ME_NOINPUT      0       /* Don't use the input library */
 #define ME_JUST_INFO    1024U   /**< not error but just info */
 #define ME_JUST_WARNING 2048U   /**< not error but just warning */
 #define ME_FATALERROR   4096U   /* Fatal statement error */
@@ -271,7 +271,7 @@ extern myf      my_global_flags;        /* Set to MY_WME for more error messages
 extern void (*my_sigtstp_cleanup)(void),
 					/* Executed before jump to shell */
 	    (*my_sigtstp_restart)(void);
-					/* Executed when comming from shell */
+					/* Executed when coming from shell */
 extern MYSQL_PLUGIN_IMPORT int my_umask;		/* Default creation mask  */
 extern int my_umask_dir,
 	   my_recived_signals,	/* Signals we have got */
@@ -311,7 +311,7 @@ enum flush_type
   FLUSH_KEEP_LAZY
 };
 
-typedef struct st_record_cache	/* Used when cacheing records */
+typedef struct st_record_cache	/* Used when caching records */
 {
   File file;
   int	rc_seek,error,inited;
@@ -391,7 +391,7 @@ typedef struct st_io_cache_share
 #endif
 } IO_CACHE_SHARE;
 
-typedef struct st_io_cache		/* Used when cacheing files */
+typedef struct st_io_cache		/* Used when caching files */
 {
   /* Offset in file corresponding to the first byte of uchar* buffer. */
   my_off_t pos_in_file;

--- a/include/my_time.h
+++ b/include/my_time.h
@@ -78,7 +78,7 @@ extern uchar days_in_month[];
 #define MYSQL_TIME_WARN_HAVE_WARNINGS(x) MY_TEST((x) & MYSQL_TIME_WARN_WARNINGS)
 #define MYSQL_TIME_WARN_HAVE_NOTES(x) MY_TEST((x) & MYSQL_TIME_WARN_NOTES)
 
-/* Usefull constants */
+/* Useful constants */
 #define SECONDS_IN_24H 86400L
 
 /* Limits for the TIME data type */

--- a/include/mysql/psi/mysql_socket.h
+++ b/include/mysql/psi/mysql_socket.h
@@ -103,7 +103,7 @@ mysql_socket_invalid()
   @param socket nstrumented socket
   @param fd socket descriptor
   @param addr unformatted socket address
-  @param adr_len length of socket addres
+  @param adr_len length of socket address
 */
 
 static inline void

--- a/include/mysql/psi/mysql_thread.h
+++ b/include/mysql/psi/mysql_thread.h
@@ -602,7 +602,7 @@ typedef struct st_mysql_cond mysql_cond_t;
 
 /**
   @def mysql_thread_set_psi_id(I)
-  Set the thread indentifier for the instrumentation.
+  Set the thread identifier for the instrumentation.
   @param I The thread identifier
 */
 #ifdef HAVE_PSI_THREAD_INTERFACE

--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -215,7 +215,7 @@ enum enum_indicator_type
                                              and truncate the index */
 
 /* The following can't be set with mysql_refresh() */
-#define REFRESH_ERROR_LOG       (1ULL << 8)  /* Rotate only the erorr log */
+#define REFRESH_ERROR_LOG       (1ULL << 8)  /* Rotate only the error log */
 #define REFRESH_ENGINE_LOG      (1ULL << 9)  /* Flush all storage engine logs */
 #define REFRESH_BINARY_LOG      (1ULL << 10) /* Flush the binary log */
 #define REFRESH_RELAY_LOG       (1ULL << 11) /* Flush the relay log */
@@ -433,7 +433,7 @@ typedef struct st_vio Vio;
 #define MAX_MEDIUMINT_WIDTH     8       /* Max width for a INT24 w.o. sign */
 #define MAX_INT_WIDTH           10      /* Max width for a LONG w.o. sign */
 #define MAX_BIGINT_WIDTH        20      /* Max width for a LONGLONG */
-#define MAX_CHAR_WIDTH		255	/* Max length for a CHAR colum */
+#define MAX_CHAR_WIDTH		255	/* Max length for a CHAR column */
 #define MAX_BLOB_WIDTH		16777216	/* Default width for blob */
 
 typedef struct st_net {

--- a/include/queues.h
+++ b/include/queues.h
@@ -25,7 +25,7 @@
 
 /*
   Code for generell handling of priority Queues.
-  Implemention of queues from "Algoritms in C" by Robert Sedgewick.
+  Implementation of queues from "Algorithms in C" by Robert Sedgewick.
 */
 
 #ifndef _queues_h

--- a/include/typelib.h
+++ b/include/typelib.h
@@ -33,7 +33,7 @@ extern int find_type_with_warning(const char *x, TYPELIB *typelib,
 #define FIND_TYPE_BASIC           0
 /** makes @c find_type() require the whole name, no prefix */
 #define FIND_TYPE_NO_PREFIX      (1U << 0)
-/** always implicitely on, so unused, but old code may pass it */
+/** always implicitly on, so unused, but old code may pass it */
 #define FIND_TYPE_NO_OVERWRITE   0
 /** makes @c find_type() accept a number. Not used either */
 #define FIND_TYPE_ALLOW_NUMBER   0

--- a/man/aria_chk.1
+++ b/man/aria_chk.1
@@ -57,7 +57,7 @@ Wait if table is locked.
 Check table for errors.
 .TP
 \fB\-e\fR, \fB\-\-extend\-check\fR
-Check the table VERY throughly.  Only use this in
+Check the table VERY thoroughly.  Only use this in
 extreme cases as aria_chk should normally be able to
 find out if the table is ok even without this switch.
 .TP

--- a/plugin/handler_socket/docs-en/protocol.en.txt
+++ b/plugin/handler_socket/docs-en/protocol.en.txt
@@ -46,7 +46,7 @@ Once an 'open_index' request is issued, the HandlerSocket plugin opens the
 specified index and keep it open until the client connection is closed. Each
 open index is identified by <indexid>. If <indexid> is already open, the old
 open index is closed. You can open the same combination of <dbname>
-<tablename> <indexname> multple times, possibly with different <columns>.
+<tablename> <indexname> multiple times, possibly with different <columns>.
 For efficiency, keep <indexid> small as far as possible.
 
 ----------------------------------------------------------------------------

--- a/plugin/win_auth_client/common.cc
+++ b/plugin/win_auth_client/common.cc
@@ -375,7 +375,7 @@ char* wchar_to_utf8(const wchar_t *string, size_t *len)
 
   /*
     A conversion from utf8 to wchar_t will never take more than 3 bytes per
-    character, so a buffer of length 3 * str_len schould be sufficient. 
+    character, so a buffer of length 3 * str_len should be sufficient. 
     We check that assumption with an assertion later.
   */
 

--- a/strings/ctype-big5.c
+++ b/strings/ctype-big5.c
@@ -15,7 +15,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 /*
- * This file is basicly usa7 character sets with some extra functions
+ * This file is basically usa7 character sets with some extra functions
  * for big5 handling
 */
 

--- a/strings/ctype-mb.c
+++ b/strings/ctype-mb.c
@@ -739,7 +739,7 @@ static void pad_max_char(CHARSET_INFO *cs, char *str, char *end)
   {
     if ((str + buflen) <= end)
     {
-      /* Enough space for the characer */
+      /* Enough space for the character */
       memcpy(str, buf, buflen);
       str+= buflen;
     }

--- a/strings/ctype-simple.c
+++ b/strings/ctype-simple.c
@@ -47,7 +47,7 @@ size_t my_strnxfrmlen_simple(CHARSET_INFO *cs, size_t len)
      is equal to comparing two original strings with my_strnncollsp_xxx().
      
      Not more than 'dstlen' bytes are written into 'dst'.
-     To garantee that the whole string is transformed, 'dstlen' must be
+     To guarantee that the whole string is transformed, 'dstlen' must be
      at least srclen*cs->strnxfrm_multiply bytes long. Otherwise,
      consequent memcmp() may return a non-accurate result.
      
@@ -1537,7 +1537,7 @@ static ulonglong d10[DIGITS_IN_ULONGLONG]=
   Convert a string to unsigned long long integer value
   with rounding.
   
-  SYNOPSYS
+  SYNOPSIS
     my_strntoull10_8bit()
       cs              in      pointer to character set
       str             in      pointer to the string to be converted

--- a/strings/ctype-tis620.c
+++ b/strings/ctype-tis620.c
@@ -22,7 +22,7 @@
 
 
 /*
-   This file is basicly tis620 character sets with some extra functions
+   This file is basically tis620 character sets with some extra functions
    for tis-620 handling
 */
 
@@ -502,7 +502,7 @@ static size_t thai2sortable(uchar *tstr, size_t len)
   string
 
   NOTE:
-    We can't cut strings at end \0 as this would break comparision with
+    We can't cut strings at end \0 as this would break comparison with
     LIKE characters, where the min range is stored as end \0
 
   Arg: 2 Strings and it compare length
@@ -594,7 +594,7 @@ int my_strnncollsp_tis620_nopad(CHARSET_INFO * cs __attribute__((unused)),
   strnxfrm replacment, convert Thai string to sortable string
 
   Arg: Destination buffer, source string, dest length and source length
-  Ret: Conveted string size
+  Ret: Converted string size
 */
 
 static size_t

--- a/strings/ctype-uca.c
+++ b/strings/ctype-uca.c
@@ -35542,7 +35542,7 @@ MY_COLLATION_HANDLER my_collation_any_uca_handler =
 
 /* 
   We consider bytes with code more than 127 as a letter.
-  This garantees that word boundaries work fine with regular
+  This guarantees that word boundaries work fine with regular
   expressions. Note, there is no need to mark byte 255  as a
   letter, it is illegal byte in UTF8.
 */

--- a/strings/ctype-ucs2.c
+++ b/strings/ctype-ucs2.c
@@ -1065,7 +1065,7 @@ my_fill_mb2(CHARSET_INFO *cs, char *s, size_t slen, int fill)
   */
   for (last= s + slen - buflen; s <= last; s+= buflen)
   {
-    /* Enough space for the characer */
+    /* Enough space for the character */
     memcpy(s, buf, buflen);
   }
 

--- a/strings/ctype-utf8.c
+++ b/strings/ctype-utf8.c
@@ -4914,7 +4914,7 @@ my_strnxfrmlen_unicode_full_bin(CHARSET_INFO *cs, size_t len)
 
 /*
   We consider bytes with code more than 127 as a letter.
-  This garantees that word boundaries work fine with regular
+  This guarantees that word boundaries work fine with regular
   expressions. Note, there is no need to mark byte 255  as a
   letter, it is illegal byte in UTF8.
 */
@@ -7305,7 +7305,7 @@ struct charset_info_st my_charset_filename=
 
 /*
   We consider bytes with code more than 127 as a letter.
-  This garantees that word boundaries work fine with regular
+  This guarantees that word boundaries work fine with regular
   expressions. Note, there is no need to mark byte 255  as a
   letter, it is illegal byte in UTF8.
 */

--- a/strings/ctype.c
+++ b/strings/ctype.c
@@ -40,7 +40,7 @@
 /*
   Avoid using my_snprintf
   We cannot use my_snprintf() here, because ctype.o is
-  used to build conf_to_src, which must require minimun
+  used to build conf_to_src, which must require minimum
   dependency.
 */
 

--- a/strings/decimal.c
+++ b/strings/decimal.c
@@ -739,7 +739,7 @@ int decimal_shift(decimal_t *dec, int shift)
   /*
     If there are gaps then fill ren with 0.
 
-    Only one of following 'for' loops will work becouse beg <= end
+    Only one of following 'for' loops will work because beg <= end
   */
   beg= ROUND_UP(beg + 1) - 1;
   end= ROUND_UP(end) - 1;
@@ -863,7 +863,7 @@ internal_str2dec(const char *from, decimal_t *to, char **end, my_bool fixed)
         intg=intg1*DIG_PER_DEC1;
     }
   }
-  /* Error is guranteed to be set here */
+  /* Error is guaranteed to be set here */
   to->intg=intg;
   to->frac=frac;
 

--- a/strings/dtoa.c
+++ b/strings/dtoa.c
@@ -269,7 +269,7 @@ size_t my_gcvt(double x, my_gcvt_arg_type type, int width, char *to,
     Assume that we don't have enough space to place all significant digits in
     the 'f' format. We have to choose between the 'e' format and the 'f' one
     to keep as many significant digits as possible.
-    Let E and F be the lengths of decimal representaion in the 'e' and 'f'
+    Let E and F be the lengths of decimal representation in the 'e' and 'f'
     formats, respectively. We want to use the 'f' format if, and only if F <= E.
     Consider the following cases:
     1. decpt <= 0.

--- a/strings/is_prefix.c
+++ b/strings/is_prefix.c
@@ -31,7 +31,7 @@
     Defines: is_prefix()
 
     is_prefix(s, t) returns 1 if s starts with t.
-    A empty t is allways a prefix.
+    A empty t is always a prefix.
 */
 
 #include "strings_def.h"

--- a/strings/json_lib.c
+++ b/strings/json_lib.c
@@ -185,7 +185,7 @@ static int read_array(json_engine_t *j)
 /*
   Character classes inside the JSON string constant.
   We mostly need this to parse escaping properly.
-  Escapings availabe in JSON are:
+  Escapings available in JSON are:
   \" - quotation mark
   \\ - backslash
   \b - backspace UNICODE 8

--- a/strings/longlong2str.c
+++ b/strings/longlong2str.c
@@ -47,7 +47,7 @@
 
   Note: The standard itoa() returns a pointer to the argument, when int2str
 	returns the pointer to the end-null.
-	itoa assumes that 10 -base numbers are allways signed and other arn't.
+	itoa assumes that 10 -base numbers are always signed and other aren't.
 */
 
 #include "strings_def.h"

--- a/strings/my_strtoll10.c
+++ b/strings/my_strtoll10.c
@@ -43,7 +43,7 @@ static unsigned long lfactor[9]=
 /*
   Convert a string to an to unsigned long long integer value
   
-  SYNOPSYS
+  SYNOPSIS
     my_strtoll10()
       nptr     in       pointer to the string to be converted
       endptr   in/out   pointer to the end of the string/

--- a/strings/my_vsnprintf.c
+++ b/strings/my_vsnprintf.c
@@ -312,7 +312,7 @@ static char *process_int_arg(char *to, const char *end, size_t length,
 
 
 /**
-  Procesed positional arguments.
+  Processed positional arguments.
 
   @param cs         string charset
   @param to         buffer where processed string will be place

--- a/strings/str2int.c
+++ b/strings/str2int.c
@@ -191,7 +191,7 @@ char *str2int(register const char *src, register int radix, long int lower,
   return (char*) src;
 }
 
-	/* Theese are so slow compared with ordinary, optimized atoi */
+	/* These are so slow compared with ordinary, optimized atoi */
 
 #ifdef WANT_OUR_ATOI
 

--- a/strings/strappend.c
+++ b/strings/strappend.c
@@ -33,7 +33,7 @@
 
     strappend(dest, len, fill) appends fill-characters to a string so that
     the result length == len. If the string is longer than len it's
-    trunked. The des+len character is allways set to NULL.
+    trunked. The des+len character is always set to NULL.
 */
 
 #include "strings_def.h"

--- a/strings/strfill.c
+++ b/strings/strfill.c
@@ -32,7 +32,7 @@
     Defines: strfill()
 
     strfill(dest, len, fill) makes a string of fill-characters. The result
-    string is of length == len. The des+len character is allways set to NULL.
+    string is of length == len. The des+len character is always set to NULL.
     strfill() returns pointer to dest+len;
 */
 

--- a/strings/strings_def.h
+++ b/strings/strings_def.h
@@ -18,8 +18,8 @@
 /* This file is to be include first in all files in the string directory */
 
 #undef DBUG_ASSERT_AS_PRINTF
-#include <my_global.h>		/* Define standar vars */
-#include "m_string.h"		/* Exernal defintions of string functions */
+#include <my_global.h>		/* Define standard vars */
+#include "m_string.h"		/* Exernal definitions of string functions */
 
 /*
   We can't use the original DBUG_ASSERT() (which includes _db_flush())


### PR DESCRIPTION
Found via `codespell -i 3 -w --skip="./debian/po" -I ../mariadb-server-word-whitelist.txt  ./cmake/ ./debian/ ./Docs/ ./include/ ./man/ ./plugin/ ./strings/`
Whitelist contains:
```
nd
ot
te
```