### PR TITLE
Add explain information to stderr in fatal signal handler

### DIFF
--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -223,6 +223,13 @@ extern "C" sig_handler handle_fatal_signal(int sig)
     my_safe_printf_stderr("\nConnection ID (thread ID): %lu\n",
                           (ulong) thd->thread_id);
     my_safe_printf_stderr("Status: %s\n\n", kreason);
+
+    StringBuffer<128> buf;
+    if (!print_explain_for_slow_log(thd->lex, thd, &buf))
+    {
+      my_safe_printf_stderr("%s\n",  buf.c_ptr_safe());
+    }
+
     my_safe_printf_stderr("%s", "Optimizer switch: ");
     ulonglong optsw= thd->variables.optimizer_switch;
     for (uint i= 0; optimizer_switch_names[i+1]; i++, optsw >>= 1)


### PR DESCRIPTION
Often asked in bug reports so may as well include it there to start with.

Eventually would also like to grab session status/session vars for added clarity however that setup is more complicated (```fill_status``` / ```fill_variables```).

I submit this under the MCA.