### PR TITLE
Explain_query::send_explain delete result

### DIFF
--- a/sql/sql_explain.cc
+++ b/sql/sql_explain.cc
@@ -178,6 +178,7 @@ int Explain_query::send_explain(THD *thd)
   else
     result->send_eof();
 
+  delete result;
   return res;
 }
 


### PR DESCRIPTION
I couldn't trigger a valgrind error because of the lack of deletion however running with a ```delete``` and running mtr didn't fault either.

It appears result is allocated and never freed.

If I've got this wrong I'd like to know how.

I submit this under the MCA.