### PR TITLE
MDEV-15548 - Deb: Remove versioning of MariaDB Backup and depend on client

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -672,13 +672,13 @@ Replaces: mariadb-gssapi-client-10.1,
 Description: GSSAPI authentication plugin for MariaDB client
  This package contains the client components.
 
-Package: mariadb-backup-10.3
+Package: mariadb-backup
 Architecture: any
 Breaks: mariadb-backup-10.1,
         mariadb-backup-10.2
 Replaces: mariadb-backup-10.1,
           mariadb-backup-10.2
-Depends: mariadb-server-10.3,
+Depends: mariadb-client-core-10.3,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Backup tool for MariaDB server


### PR DESCRIPTION
There is no need for MariaDB Backup package name to contain a version string. It is already versioned to the degree needed via its Depends metadata.

Other packages are very unlikely to need to depend on a certain generation of this package. For server or client it may be useful to in some cases have the version string in the package name and to be installed and fixed to a certain generation (10.x) but for the backup tool it does not make sense.

Also for MariaDB Backup to run, it does not need the server, but client, and from client only core parts.