### PR TITLE
MDEV-15443 Fix wsrep XID read from rollback segment header

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-15443.result
+++ b/mysql-test/suite/galera/r/MDEV-15443.result
@@ -1,0 +1,15 @@
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection node_2;
+SELECT * FROM t1;
+f1
+1
+SET GLOBAL wsrep_cluster_address='';
+SET SESSION wsrep_on=0;
+INSERT INTO t1 VALUES (2);
+DELETE FROM t1 WHERE f1 = 2;
+connection node_1;
+INSERT INTO t1 VALUES (2);
+connection node_2;
+connection node_1;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-15443.test
+++ b/mysql-test/suite/galera/t/MDEV-15443.test
@@ -1,0 +1,50 @@
+#
+# MDEV-15443
+#
+# If transactions are executed into InnoDB without wsrep_on,
+# rseg header trx_id gets incremented and the rseg header
+# corresponding to maximum trx_id may store undefined wsrep XID.
+# When the wsrep XID is read from the storage engine,
+# undefined XID may returned instead the valid one.
+#
+# This test demonstrates the problem by taking a node_2 out
+# of the cluster and writing and deleting a row with
+# wsrep_on=0. When the bug is present, node_2 will fail to
+# rejoin the cluster because an invalid XID is read from the
+# storage engine after startup/recovery.
+#
+
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+
+# Initialize table on node_1
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+# Go to node_2, verify that the previous INSERT completed.
+# Take node_2 out of the cluster, insert and delete a record
+# on a table with wsrep_on.
+--connection node_2
+SELECT * FROM t1;
+SET GLOBAL wsrep_cluster_address='';
+SET SESSION wsrep_on=0;
+INSERT INTO t1 VALUES (2);
+DELETE FROM t1 WHERE f1 = 2;
+
+# Shutdown node_2
+--source include/shutdown_mysqld.inc
+
+# On node_1, verify that the node has left the cluster.
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+# Insert into t1 to enforce IST on node_2 when it is restarted.
+INSERT INTO t1 VALUES (2);
+
+# Restart node_2
+--connection node_2
+--source include/start_mysqld.inc
+
+--connection node_1
+DROP TABLE t1;

--- a/storage/innobase/include/trx0rseg.h
+++ b/storage/innobase/include/trx0rseg.h
@@ -282,6 +282,11 @@ trx_rseg_update_wsrep_checkpoint(
 	mtr_t*		mtr);
 
 /** Update WSREP checkpoint XID in first rollback segment header.
+This function should be called only from innodbase_wsrep_set_checkopoint()
+when it is guaranteed that there are no wsrep transactions committing.
+If the UUID part of the wsrep XID does not match to the UUIDs of XIDs already
+stored into rollback segments, all the remaining XIDs will be reset to empty
+value.
 @param[in]	xid		WSREP XID */
 void trx_rseg_update_wsrep_checkpoint(const XID* xid);
 


### PR DESCRIPTION
The problem: If some transactions were done with wsrep_on=0, a
rollback segment header having the highest trx_id assigned might
store undefined wsrep XID. When reading the wsrep checkpoint
from InnodB, the undefined wsrep XID might be returned instead
of the highest valid one.

The fix is to check if the rollback segment header stores the
valid wsrep XID before assigning it to the output XID.

I submit this patch under BSD-new license.