### PR TITLE
Add error handling code for fopen

### DIFF
--- a/client/mysql_plugin.c
+++ b/client/mysql_plugin.c
@@ -365,6 +365,12 @@ static int get_default_values()
     }
     /* Now open the file and read the defaults we want. */
     file= fopen(defaults_file, "r");
+    if (file == NULL)
+    {
+      fprintf(stderr, "ERROR: failed to open file %s: %s.\n", defaults_file,
+              strerror(errno));
+      goto exit;
+    }
     while (fgets(line, FN_REFLEN, file) != NULL)
     {
       char *value= 0;

--- a/storage/tokudb/PerconaFT/tools/tokuftdump.cc
+++ b/storage/tokudb/PerconaFT/tools/tokuftdump.cc
@@ -1103,8 +1103,13 @@ static void run_iteractive_loop(int fd, FT ft, CACHEFILE cf) {
             uint64_t offset = getuint64(fields[1]);
             uint64_t size = getuint64(fields[2]);
             FILE *outfp = stdout;
-            if (nfields >= 4)
+            if (nfields >= 4) {
                 outfp = fopen(fields[3], "w");
+            	if (!outfp) {
+                	fprintf(stderr, "Can not open file %s: %s\n", fields[3], strerror(errno));
+                	continue;
+		}
+            }
             dump_file(fd, offset, size, outfp);
         } else if (strcmp(fields[0], "setfile") == 0 && nfields == 3) {
             uint64_t offset = getuint64(fields[1]);


### PR DESCRIPTION
When fopen fails, print error messages and add proper error handling code.