### PR TITLE
MDEV-8743: ib_logfile0 Use O_CLOEXEC so galera SST scripts don't get fd

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3578,7 +3578,7 @@ os_aio_native_aio_supported(void)
 
 		strcpy(name + dirnamelen, "ib_logfile0");
 
-		fd = ::open(name, O_RDONLY);
+		fd = ::open(name, O_RDONLY | O_CLOEXEC);
 
 		if (fd == -1) {
 


### PR DESCRIPTION

I submit this under the MCA.