### PR TITLE
MDEV-8743: wsrep_sst_common close FDs > 2

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -16,6 +16,28 @@
 
 # This is a common command line parser to be sourced by other SST scripts
 
+# Close file descriptors numbered above 2 just in case mysqld or the
+# wsrep_provider left a file descriptor open. We don't want a broken SST
+# script or called program from overwriting a tablespace because
+# its file descriptor was left open.
+if [ -d /proc/self/fd ]; then
+  for fd in /proc/self/fd/*; do
+    fd=${fd##*/}
+    # While bash would support the below syntax other sh's don't
+    #[ $fd -gt 2 ] && exec {fd}>&-
+    [ $fd -gt 2 ] && eval "exec ${fd}>&-" 2> /dev/null
+  done
+else
+  upper_no_file=$(ulimit -n)
+  [ "$upper_no_file" = "unlimited" ] || [ -z "$upper_no_file" ] && upper_no_file=1024
+
+  while [ $upper_no_file -gt 2 ]
+  do
+     eval "exec ${upper_no_file}>&-"
+     upper_no_file=$(( "$upper_no_file" - 1 ))
+  done
+fi
+
 set -u
 
 WSREP_SST_OPT_BYPASS=0


### PR DESCRIPTION
To prevent accidential overwriting of files due to mysqld file
descriptors being open we ensure where that only FDs 1, 2 and 3
are open of which SST scripts really only use stdout and stderr.

So this is the defence in depth of the other PRs to CLOEXEC within the server.

Passes galera test suite as much as without this patch.

I submit this under the MCA.