### PR TITLE
MDEV-15496: wsrep_sst_common - parse IPv6 correct

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -35,18 +35,25 @@ case "$1" in
         #
         # Break address string into host:port/path parts
         #
-        readonly WSREP_SST_OPT_HOST=${WSREP_SST_OPT_ADDR%%[:/]*}
-        if [ ${WSREP_SST_OPT_HOST:0:1} = '[' ]
-        then
-            # IPv6 notation
-            readonly WSREP_SST_OPT_HOST_UNESCAPED=${WSREP_SST_OPT_HOST:1:-1}
-        else
-            readonly WSREP_SST_OPT_HOST_UNESCAPED=${WSREP_SST_OPT_HOST}
-        fi
-        readonly WSREP_SST_OPT_PORT=$(echo $WSREP_SST_OPT_ADDR | \
-                cut -d ']' -f 2 | cut -s -d ':' -f 2 | cut -d '/' -f 1)
+        case "${WSREP_SST_OPT_ADDR}" in
+        \[*)
+            # IPv6
+            addr_no_bracket=${WSREP_SST_OPT_ADDR#\[}
+            readonly WSREP_SST_OPT_HOST_UNESCAPED=${addr_no_bracket%%\]*}
+            readonly WSREP_SST_OPT_HOST="[${WSREP_SST_OPT_HOST_UNESCAPED}]"
+            remain=${WSREP_SST_OPT_ADDR#*\]}
+            remain=${remain#*:}
+            ;;
+        *)
+            readonly WSREP_SST_OPT_HOST=${WSREP_SST_OPT_ADDR%%[:/]*}
+            readonly WSREP_SST_OPT_HOST_UNESCAPED=$WSREP_SST_OPT_HOST
+            remain=${WSREP_SST_OPT_ADDR#*:}
+            ;;
+        esac
+        readonly WSREP_SST_OPT_PORT=${remain%%/*}
+        remain=${remain#*/}
+        readonly WSREP_SST_OPT_MODULE=${remain%%/*}
         readonly WSREP_SST_OPT_PATH=${WSREP_SST_OPT_ADDR#*/}
-        readonly WSREP_SST_OPT_MODULE=${WSREP_SST_OPT_PATH%%/*}
         remain=${WSREP_SST_OPT_PATH#*/}
         readonly WSREP_SST_OPT_LSN=${remain%%/*}
         remain=${remain#*/}


### PR DESCRIPTION
@SachinSetiya sorry for the break. Unit tested as below so far.

Fix to e78e308e818a4a763ebb981302851f58f4c42bba, IPv6 got split at :

Also got rid of awk (yuck!) to parse port (commit: b4fbb4183b35f921efe079a312b0c1be87866b40)

Tested with dash to avoid bashisms:

$ dash -vx './wsrep_sst_common.sh' --address '128.0.0.5:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2' 2>&1  | more
+ readonly WSREP_SST_OPT_ADDR=128.0.0.5:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_HOST=128.0.0.5
+ readonly WSREP_SST_OPT_HOST_UNESCAPED=128.0.0.5
+ remain=3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_PORT=3333
+ remain=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_MODULE=module
+ readonly WSREP_SST_OPT_PATH=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ remain=lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_LSN=lsn_version
+ remain=sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_SST_VER=sst_ver

$ dash -vx './wsrep_sst_common.sh' --address '[2001:db8::1]:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2' 2>&1  | more
+ readonly WSREP_SST_OPT_ADDR=[2001:db8::1]:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ addr_no_bracket=2001:db8::1]:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_HOST_UNESCAPED=2001:db8::1
+ readonly WSREP_SST_OPT_HOST=[2001:db8::1]
+ remain=:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ remain=3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_PORT=3333
+ remain=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_MODULE=module
+ readonly WSREP_SST_OPT_PATH=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ remain=lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_LSN=lsn_version
+ remain=sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_SST_VER=sst_ver

And bash as well:

$ bash -vx './wsrep_sst_common.sh' --address '127.0.0.3:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2' 2>&1 | more
+ readonly WSREP_SST_OPT_ADDR=127.0.0.3:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ WSREP_SST_OPT_ADDR=127.0.0.3:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ case "${WSREP_SST_OPT_ADDR}" in
+ readonly WSREP_SST_OPT_HOST=127.0.0.3
+ WSREP_SST_OPT_HOST=127.0.0.3
+ readonly WSREP_SST_OPT_HOST_UNESCAPED=127.0.0.3
+ WSREP_SST_OPT_HOST_UNESCAPED=127.0.0.3
+ remain=3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_PORT=3333
+ WSREP_SST_OPT_PORT=3333
+ remain=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_MODULE=module
+ WSREP_SST_OPT_MODULE=module
+ readonly WSREP_SST_OPT_PATH=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ WSREP_SST_OPT_PATH=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ remain=lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_LSN=lsn_version
+ WSREP_SST_OPT_LSN=lsn_version
+ remain=sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_SST_VER=sst_ver
+ WSREP_SST_OPT_SST_VER=sst_ver

$ bash -vx './wsrep_sst_common.sh' --address '[2001:db8::1]:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2' 2>&1 | more
+ readonly 'WSREP_SST_OPT_ADDR=[2001:db8::1]:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2'
+ WSREP_SST_OPT_ADDR='[2001:db8::1]:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2'
+ case "${WSREP_SST_OPT_ADDR}" in
+ addr_no_bracket='2001:db8::1]:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2'
+ readonly WSREP_SST_OPT_HOST_UNESCAPED=2001:db8::1
+ WSREP_SST_OPT_HOST_UNESCAPED=2001:db8::1
+ readonly 'WSREP_SST_OPT_HOST=[2001:db8::1]'
+ WSREP_SST_OPT_HOST='[2001:db8::1]'
+ remain=:3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ remain=3333/module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_PORT=3333
+ WSREP_SST_OPT_PORT=3333
+ remain=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_MODULE=module
+ WSREP_SST_OPT_MODULE=module
+ readonly WSREP_SST_OPT_PATH=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ WSREP_SST_OPT_PATH=module/lsn_version/sst_ver/some_future_option1/some_future_option2
+ remain=lsn_version/sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_LSN=lsn_version
+ WSREP_SST_OPT_LSN=lsn_version
+ remain=sst_ver/some_future_option1/some_future_option2
+ readonly WSREP_SST_OPT_SST_VER=sst_ver
+ WSREP_SST_OPT_SST_VER=sst_ver

I submit this under the MCA.