### PR TITLE
MDEV-15549 - wsrep_sst_common: fix per shellcheck

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -255,7 +255,7 @@ parse_cnf()
 
     # use default if we haven't found a value
     if [ -z $reval ]; then
-        [ -n $3 ] && reval=$3
+        [ -n "$3" ] && reval=$3
     fi
     echo $reval
 }


### PR DESCRIPTION
POSIX shell support in 10.0-galera would require f16ead51fbbf03ca51db9343960785b431fab157 however this shellcheck component wasn't included.

shellcheck -s sh wsrep_sst_common.sh

In wsrep_sst_common.sh line 258:
        [ -n $3 ] && reval=$3
             ^-- SC2070: -n doesn't work with unquoted arguments. Quote or use [[ ]].
             ^-- SC2086: Double quote to prevent globbing and word splitting.

I submit this under the MCA.