### PR TITLE
MDEV-15540 fix for MTR tests using wsrep_recover.inc

### DIFF
--- a/mysql-test/suite/galera/include/galera_wsrep_recover.inc
+++ b/mysql-test/suite/galera/include/galera_wsrep_recover.inc
@@ -1,5 +1,5 @@
 --echo Performing --wsrep-recover ...
---exec $MYSQLD --defaults-group-suffix=.$galera_wsrep_recover_server_id --defaults-file=$MYSQLTEST_VARDIR/my.cnf --innodb --wsrep-recover > $MYSQL_TMP_DIR/galera_wsrep_recover.log 2>&1
+--exec $MYSQLD --defaults-group-suffix=.$galera_wsrep_recover_server_id --defaults-file=$MYSQLTEST_VARDIR/my.cnf --log-error=$MYSQL_TMP_DIR/galera_wsrep_recover.log --innodb --wsrep-recover > $MYSQL_TMP_DIR/galera_wsrep_recover.log 2>&1
 
 --perl
 	use strict;


### PR DESCRIPTION
The error log redirection for wsrep_recover run does not work in old version.
For the wsrep_recovery run, error logging is supposed to go into:
mysql-test/suite/galera/include/galera_wsrep_recover.inc
In old version, this works only partially, 4 first lines of error messages after mysql startup
do go into the galera_wsrep_recover.log, but after that the default error log file is enforced
and remaining error logging goes into the default error log file.

In this patch this problem is fixed by passing --log-error option in mysql startup

This fix was tested with galera_gcache_recover test, which is currently in disabled state.
Note that the test does not pass even after this fix, as there are further more issues
in later test phases.