### PR TITLE
MDEV-13549 Fix and re-enable test galera.galera_var_slave_threads

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -20,7 +20,6 @@ galera_binlog_rows_query_log_events: MariaDB does not support binlog_rows_query_
 GAL-419 : MDEV-13549 Galera test failures
 galera_toi_ddl_fk_insert : MDEV-13549 Galera test failures
 galera_var_notify_cmd : MDEV-13549 Galera test failures
-galera_var_slave_threads : MDEV-13549 Galera test failures
 mysql-wsrep#90 : MDEV-13549 Galera test failures
 galera_as_master_gtid : Requires MySQL GTID
 galera_as_master_gtid_change_master : Requires MySQL GTID

--- a/mysql-test/suite/galera/r/galera_var_slave_threads.result
+++ b/mysql-test/suite/galera/r/galera_var_slave_threads.result
@@ -1,6 +1,6 @@
-CALL mtr.add_suppression("WSREP: Refusing exit for the last slave thread.");
 CREATE TABLE t1 (f1 INT PRIMARY KEY) Engine=InnoDB;
 CREATE TABLE t2 (f1 INT AUTO_INCREMENT PRIMARY KEY) Engine=InnoDB;
+CALL mtr.add_suppression("WSREP: Refusing exit for the last slave thread.");
 SET GLOBAL wsrep_slave_threads = 0;
 Warnings:
 Warning	1292	Truncated incorrect wsrep_slave_threads value: '0'
@@ -21,9 +21,6 @@ SET GLOBAL wsrep_slave_threads = 64;
 INSERT INTO t1 VALUES (1);
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
-1
-SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
-COUNT(*) = @@wsrep_slave_threads + 1
 1
 SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep aborter%';
 COUNT(*) = 1
@@ -96,9 +93,6 @@ INSERT INTO t2 VALUES (DEFAULT);
 SELECT COUNT(*) = 64 FROM t2;
 COUNT(*) = 64
 1
-SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
-COUNT(*) = @@wsrep_slave_threads + 1
-1
 SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep aborter%';
 COUNT(*) = 1
 1
@@ -111,5 +105,11 @@ DROP TABLE t2;
 CREATE TABLE t1 (i INT AUTO_INCREMENT PRIMARY KEY) ENGINE=INNODB;
 SET GLOBAL wsrep_slave_threads = 4;
 SET GLOBAL wsrep_slave_threads = 1;
+INSERT INTO t1 VALUES (DEFAULT);
+INSERT INTO t1 VALUES (DEFAULT);
+INSERT INTO t1 VALUES (DEFAULT);
 DROP TABLE t1;
+SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep aborter%';
+COUNT(*) = 1
+1
 # End of tests

--- a/mysql-test/suite/galera/t/galera_var_slave_threads.test
+++ b/mysql-test/suite/galera/t/galera_var_slave_threads.test
@@ -6,7 +6,6 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
-CALL mtr.add_suppression("WSREP: Refusing exit for the last slave thread.");
 --let $wsrep_slave_threads_orig = `SELECT @@wsrep_slave_threads`
 
 --connection node_1
@@ -14,7 +13,7 @@ CREATE TABLE t1 (f1 INT PRIMARY KEY) Engine=InnoDB;
 CREATE TABLE t2 (f1 INT AUTO_INCREMENT PRIMARY KEY) Engine=InnoDB;
 
 --connection node_2
-
+CALL mtr.add_suppression("WSREP: Refusing exit for the last slave thread.");
 # Setting wsrep_slave_threads to zero triggers a warning
 SET GLOBAL wsrep_slave_threads = 0;
 SHOW WARNINGS;
@@ -30,15 +29,14 @@ SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system use
 #
 
 SET GLOBAL wsrep_slave_threads = 64;
---sleep 0.5
 
 --connection node_1
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
 SELECT COUNT(*) = 1 FROM t1;
-
-SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
+--let $wait_condition = SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
+--source include/wait_condition.inc
 SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep aborter%';
 
 #
@@ -59,8 +57,8 @@ while ($count)
 
 --connection node_2
 SELECT COUNT(*) = 64 FROM t2;
-
-SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
+--let $wait_condition = SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
+--source include/wait_condition.inc
 SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep aborter%';
 
 
@@ -78,7 +76,23 @@ CREATE TABLE t1 (i INT AUTO_INCREMENT PRIMARY KEY) ENGINE=INNODB;
 
 --connection node_2
 SET GLOBAL wsrep_slave_threads = 4;
+--let $wait_condition = SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user'
+--source include/wait_condition.inc
+
 SET GLOBAL wsrep_slave_threads = 1;
+
+--connection node_1
+INSERT INTO t1 VALUES (DEFAULT);
+INSERT INTO t1 VALUES (DEFAULT);
+INSERT INTO t1 VALUES (DEFAULT);
 DROP TABLE t1;
+
+--connection node_2
+#
+# make sure that we are left with exactly one applier thread before we leaving the test
+#
+--let $wait_condition = SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user'
+--source include/wait_condition.inc
+SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep aborter%';
 
 --echo # End of tests


### PR DESCRIPTION
Two changes were made to the test:

1) Suppress warning "Refusing exit for the last slave thread."
   This warning was already suppressed, but on the wrong node.

2) The test occasionally fails because it expects that the
   number of applier threads changes immediately after
   changing the value of ```variable wsrep_slave_threads```.
   Which is not true. This patch turns snippets like this:

   ```
   SET GLOBAL wsrep_slave_threads = x;
   SELECT COUNT(*) = x FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user';
   ```

   Into proper wait_conditions:

   ```
   SET GLOBAL wsrep_slave_threads = x;
   let $wait_condition = SELECT COUNT(*) = x FROM ...;
   --source include/wait_condition.inc
   ```