### PR TITLE
MDEV-15030 Add ASAN instrumentation

### DIFF
--- a/include/my_valgrind.h
+++ b/include/my_valgrind.h
@@ -35,6 +35,8 @@
 # define MEM_CHECK_DEFINED(a,len) VALGRIND_CHECK_MEM_IS_DEFINED(a,len)
 #elif defined(__SANITIZE_ADDRESS__)
 # include <sanitizer/asan_interface.h>
+/* How to do manual poisoning:
+https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
 # define MEM_UNDEFINED(a,len) ASAN_UNPOISON_MEMORY_REGION(a,len)
 # define MEM_NOACCESS(a,len) ASAN_POISON_MEMORY_REGION(a,len)
 # define MEM_CHECK_ADDRESSABLE(a,len) ((void) 0)

--- a/storage/innobase/mem/mem0mem.c
+++ b/storage/innobase/mem/mem0mem.c
@@ -404,7 +404,10 @@ mem_heap_create_block(
 		heap->total_size += len;
 	}
 
-	UNIV_MEM_FREE(block + 1, len - MEM_BLOCK_HEADER_SIZE);
+	/* Poison all available memory. Individual chunks will be unpoisoned on
+	every mem_heap_alloc() call. */
+	compile_time_assert(MEM_BLOCK_HEADER_SIZE >= sizeof *block);
+	UNIV_MEM_FREE(block + 1, len - sizeof *block);
 
 	ut_ad((ulint)MEM_BLOCK_HEADER_SIZE < len);
 

--- a/storage/innobase/mem/mem0mem.c
+++ b/storage/innobase/mem/mem0mem.c
@@ -404,6 +404,8 @@ mem_heap_create_block(
 		heap->total_size += len;
 	}
 
+	UNIV_MEM_FREE(block + 1, len - MEM_BLOCK_HEADER_SIZE);
+
 	ut_ad((ulint)MEM_BLOCK_HEADER_SIZE < len);
 
 	return(block);

--- a/storage/xtradb/mem/mem0mem.c
+++ b/storage/xtradb/mem/mem0mem.c
@@ -404,6 +404,11 @@ mem_heap_create_block(
 		heap->total_size += len;
 	}
 
+	/* Poison all available memory. Individual chunks will be unpoisoned on
+	every mem_heap_alloc() call. */
+	compile_time_assert(MEM_BLOCK_HEADER_SIZE >= sizeof *block);
+	UNIV_MEM_FREE(block + 1, len - sizeof *block);
+
 	ut_ad((ulint)MEM_BLOCK_HEADER_SIZE < len);
 
 	return(block);


### PR DESCRIPTION
Learn both valgrind and asan to catch this bug:
```c++
  mem_heap_t* heap = mem_heap_create(1024);
  byte* p = reinterpret_cast<byte*>(heap) + sizeof(mem_heap_t);
  *p = 123;
```

Overflows of the last allocation in a block will be catched too.

mem_heap_create_block(): poison newly allocated memory

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.