### PR TITLE
MDEV-15655: Add Linux abstract socket support

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -6010,9 +6010,10 @@ void do_connect(struct st_command *command)
   {
     /*
       If the socket is specified just as a name without path
+      or an abstract socket indicator ('@'), then
       append tmpdir in front
     */
-    if (*ds_sock.str != FN_LIBCHAR)
+    if (*ds_sock.str != FN_LIBCHAR && *ds_sock.str != '@')
     {
       char buff[FN_REFLEN];
       fn_format(buff, ds_sock.str, TMPDIR, "", 0);

--- a/mysql-test/main/connect-abstract.cnf
+++ b/mysql-test/main/connect-abstract.cnf
@@ -1,0 +1,9 @@
+
+!include include/default_my.cnf
+
+[mysqld.1]
+socket=       @ENV.ABSTRACT_SOCKET
+
+# Using @OPT.port here for uniqueness
+[ENV]
+ABSTRACT_SOCKET= @mtr-test-abstract-socket-@OPT.port

--- a/mysql-test/main/connect-abstract.result
+++ b/mysql-test/main/connect-abstract.result
@@ -1,0 +1,5 @@
+connect con1,localhost,root,,test,,$ABSTRACT_SOCKET;
+select 1;
+1
+1
+disconnect con1;

--- a/mysql-test/main/connect-abstract.test
+++ b/mysql-test/main/connect-abstract.test
@@ -1,0 +1,6 @@
+--source include/linux.inc
+--source include/not_embedded.inc
+
+connect(con1,localhost,root,,test,,$ABSTRACT_SOCKET);
+select 1;
+disconnect con1;


### PR DESCRIPTION
The functionality of the socket system varible is extended
here such that a preciding '@' indicates that the remainder of
the name is an abstract socket. This is consistent with the
approached used by systemd in socket activativation.

Client side: https://github.com/MariaDB/mariadb-connector-c/pull/43