### PR TITLE
increase upper value of max_prepared_stmt_count to 1G

### DIFF
--- a/mysql-test/r/ps.result
+++ b/mysql-test/r/ps.result
@@ -820,7 +820,7 @@ Warnings:
 Warning	1292	Truncated incorrect max_prepared_stmt_count value: '10000000000000000'
 select @@max_prepared_stmt_count;
 @@max_prepared_stmt_count
-1048576
+4294967295
 set global max_prepared_stmt_count=default;
 select @@max_prepared_stmt_count;
 @@max_prepared_stmt_count

--- a/mysql-test/suite/sys_vars/r/max_prepared_stmt_count_basic.result
+++ b/mysql-test/suite/sys_vars/r/max_prepared_stmt_count_basic.result
@@ -46,40 +46,40 @@ Warnings:
 Warning	1292	Truncated incorrect max_prepared_stmt_count value: '100000000000'
 SELECT @@global.max_prepared_stmt_count;
 @@global.max_prepared_stmt_count
-1048576
+4294967295
 SET @@global.max_prepared_stmt_count = 10000.01;
 ERROR 42000: Incorrect argument type to variable 'max_prepared_stmt_count'
 SELECT @@global.max_prepared_stmt_count;
 @@global.max_prepared_stmt_count
-1048576
+4294967295
 SET @@global.max_prepared_stmt_count = -1024;
 Warnings:
 Warning	1292	Truncated incorrect max_prepared_stmt_count value: '-1024'
 SELECT @@global.max_prepared_stmt_count;
 @@global.max_prepared_stmt_count
 0
-SET @@global.max_prepared_stmt_count = 1048577;
+SET @@global.max_prepared_stmt_count = 4294967296;
 Warnings:
-Warning	1292	Truncated incorrect max_prepared_stmt_count value: '1048577'
+Warning	1292	Truncated incorrect max_prepared_stmt_count value: '4294967296'
 SELECT @@global.max_prepared_stmt_count;
 @@global.max_prepared_stmt_count
-1048576
-SET @@global.max_prepared_stmt_count = 104857612;
+4294967295
+SET @@global.max_prepared_stmt_count = 4294967295*1024;
 Warnings:
-Warning	1292	Truncated incorrect max_prepared_stmt_count value: '104857612'
+Warning	1292	Truncated incorrect max_prepared_stmt_count value: '4398046510080'
 SELECT @@global.max_prepared_stmt_count;
 @@global.max_prepared_stmt_count
-1048576
+4294967295
 SET @@global.max_prepared_stmt_count = ON;
 ERROR 42000: Incorrect argument type to variable 'max_prepared_stmt_count'
 SELECT @@global.max_prepared_stmt_count;
 @@global.max_prepared_stmt_count
-1048576
+4294967295
 SET @@global.max_prepared_stmt_count = 'test';
 ERROR 42000: Incorrect argument type to variable 'max_prepared_stmt_count'
 SELECT @@global.max_prepared_stmt_count;
 @@global.max_prepared_stmt_count
-1048576
+4294967295
 '#-------------------FN_DYNVARS_081_05----------------------------#'
 SET @@session.max_prepared_stmt_count = 4096;
 ERROR HY000: Variable 'max_prepared_stmt_count' is a GLOBAL variable and should be set with SET GLOBAL

--- a/mysql-test/suite/sys_vars/t/max_prepared_stmt_count_basic.test
+++ b/mysql-test/suite/sys_vars/t/max_prepared_stmt_count_basic.test
@@ -92,9 +92,9 @@ SET @@global.max_prepared_stmt_count = 10000.01;
 SELECT @@global.max_prepared_stmt_count;
 SET @@global.max_prepared_stmt_count = -1024;
 SELECT @@global.max_prepared_stmt_count;
-SET @@global.max_prepared_stmt_count = 1048577;
+SET @@global.max_prepared_stmt_count = 4294967296;
 SELECT @@global.max_prepared_stmt_count;
-SET @@global.max_prepared_stmt_count = 104857612;
+SET @@global.max_prepared_stmt_count = 4294967295*1024;
 SELECT @@global.max_prepared_stmt_count;
 
 --Error ER_WRONG_TYPE_FOR_VAR

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -532,7 +532,7 @@ bool max_user_connections_checking=0;
   Limit of the total number of prepared statements in the server.
   Is necessary to protect the server against out-of-memory attacks.
 */
-ulong max_prepared_stmt_count;
+uint max_prepared_stmt_count;
 /**
   Current total number of prepared statements in the server. This number
   is exact, and therefore may not be equal to the difference between
@@ -543,7 +543,7 @@ ulong max_prepared_stmt_count;
   two different connections, this counts as two distinct prepared
   statements.
 */
-ulong prepared_stmt_count=0;
+uint prepared_stmt_count=0;
 ulong thread_id=1L,current_pid;
 ulong slow_launch_threads = 0;
 uint sync_binlog_period= 0, sync_relaylog_period= 0,

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -178,7 +178,7 @@ extern ulong slave_trans_retries;
 extern uint  slave_net_timeout;
 extern int max_user_connections;
 extern ulong what_to_log,flush_time;
-extern ulong max_prepared_stmt_count, prepared_stmt_count;
+extern uint max_prepared_stmt_count, prepared_stmt_count;
 extern ulong open_files_limit;
 extern ulonglong binlog_cache_size, binlog_stmt_cache_size;
 extern ulonglong max_binlog_cache_size, max_binlog_stmt_cache_size;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1932,11 +1932,11 @@ static Sys_var_ulong Sys_max_long_data_size(
        BLOCK_SIZE(1));
 
 static PolyLock_mutex PLock_prepared_stmt_count(&LOCK_prepared_stmt_count);
-static Sys_var_ulong Sys_max_prepared_stmt_count(
+static Sys_var_uint Sys_max_prepared_stmt_count(
        "max_prepared_stmt_count",
        "Maximum number of prepared statements in the server",
        GLOBAL_VAR(max_prepared_stmt_count), CMD_LINE(REQUIRED_ARG),
-       VALID_RANGE(0, 1024*1024), DEFAULT(16382), BLOCK_SIZE(1),
+       VALID_RANGE(0, UINT_MAX32), DEFAULT(16382), BLOCK_SIZE(1),
        &PLock_prepared_stmt_count);
 
 static Sys_var_ulong Sys_max_sort_length(


### PR DESCRIPTION
The upper 1M limit for max_prepared_stmt_count was set over 10 years
ago. It doesn't suite current hardware and a sysbench oltp_read_write
test with 512 threads will hit this limit.

I submit this under the MCA.

What are your thoughts on removing this in 10.3?