### PR TITLE
MDEV-13549 Fix and re-enable test galera.galera_suspend_slave

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -45,7 +45,6 @@ galera_as_master: MDEV-13549 Galera test failures 10.1
 galera_pc_ignore_sb : MDEV-13549 Galera test failures 10.1
 galera_lock_table : MDEV-13549 Galera test failures 10.1
 MW-284 : MDEV-13549 Galera test failures 10.1
-galera_suspend_slave : MDEV-13549 Galera test failures 10.1
 galera_gtid : MDEV-13549 Galera test failures 10.1
 galera_gtid_slave : MDEV-13549 Galera test failures 10.1
 galera_unicode_identifiers : MDEV-13549 Galera test failures 10.1

--- a/mysql-test/suite/galera/r/galera_suspend_slave.result
+++ b/mysql-test/suite/galera/r/galera_suspend_slave.result
@@ -1,11 +1,11 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 Suspending node_2 ...
+SET SESSION wsrep_sync_wait = 0;
 INSERT INTO t1 VALUES (1);
 Got one of the listed errors
 Resuming node_2 ...
-SET SESSION wsrep_sync_wait = 1;
 INSERT INTO t1 VALUES (1);
-SET SESSION wsrep_sync_wait = 1;
+SET SESSION wsrep_sync_wait = 0;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1

--- a/mysql-test/suite/galera/t/galera_suspend_slave.test
+++ b/mysql-test/suite/galera/t/galera_suspend_slave.test
@@ -29,6 +29,11 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 	exit(0);
 EOF
 
+SET SESSION wsrep_sync_wait = 0;
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
 --error ER_UNKNOWN_COM_ERROR,ER_LOCK_WAIT_TIMEOUT,ER_LOCK_DEADLOCK,ER_ERROR_DURING_COMMIT
 INSERT INTO t1 VALUES (1);
 
@@ -41,8 +46,6 @@ INSERT INTO t1 VALUES (1);
 	exit(0);
 EOF
 
-SET SESSION wsrep_sync_wait = 1;
---sleep 10
 --source include/wait_until_ready.inc
 INSERT INTO t1 VALUES (1);
 
@@ -51,7 +54,7 @@ INSERT INTO t1 VALUES (1);
 --source include/galera_connect.inc
 --connection node_2a
 
-SET SESSION wsrep_sync_wait = 1;
+SET SESSION wsrep_sync_wait = 0;
 --source include/wait_until_ready.inc
 SELECT COUNT(*) = 1 FROM t1;
 


### PR DESCRIPTION
Test galera_suspend_slave checks that after suspending a galera
node, like this:
```
--perl
        my $pid_filename = $ENV{'NODE_2_PIDFILE'};
        my $mysqld_pid = `cat $pid_filename`;
        chomp($mysqld_pid);
        system("kill -SIGSTOP $mysqld_pid");
        exit(0);
EOF
```

the remaining one node cluster is no longer able to successfully
INSERT new rows:
```
--error ER_UNKNOWN_COM_ERROR,ER_LOCK_WAIT_TIMEOUT,ER_LOCK_DEADLOCK,ER_ERROR_DURING_COMMIT
INSERT INTO t1 VALUES (1);
```

On rare occasions when the system is overloaded, it appears that
suspending the process with ```system("kill -SIGSTOP $mysqld_pid")```
takes some time, enough for the subsequent INSERT to succeed. In which
case the test fails because it rightly expects the INSERT to fail.

To fix the problem, the patch makes sure that the cluster has shrinked
to one node, before trying to INSERT the new value.