### PR TITLE
MDEV-13549 Fix and re-enable MTR test galera.galera_gtid_slave

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -46,7 +46,6 @@ galera_pc_ignore_sb : MDEV-13549 Galera test failures 10.1
 galera_lock_table : MDEV-13549 Galera test failures 10.1
 MW-284 : MDEV-13549 Galera test failures 10.1
 galera_gtid : MDEV-13549 Galera test failures 10.1
-galera_gtid_slave : MDEV-13549 Galera test failures 10.1
 galera_unicode_identifiers : MDEV-13549 Galera test failures 10.1
 galera.galera_gcs_fc_limit : MDEV-13549 Galera test failures 10.1
 galera.MW-329 : wsrep_local_replays not stable

--- a/mysql-test/suite/galera/r/galera_gtid_slave.result
+++ b/mysql-test/suite/galera/r/galera_gtid_slave.result
@@ -19,8 +19,8 @@ SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
 1-1-4,2-2-2,2-3-3
 DROP TABLE t1,t2;
-reset master;
 STOP SLAVE;
 RESET SLAVE ALL;
+reset master;
 reset master;
 reset master;

--- a/mysql-test/suite/galera/t/galera_gtid_slave.test
+++ b/mysql-test/suite/galera/t/galera_gtid_slave.test
@@ -38,7 +38,13 @@ SELECT @@global.gtid_binlog_state;
 
 --let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
 --source include/wait_condition.inc
---sleep 1
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t2;
+--source include/wait_condition.inc
+
 INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(3);
 SELECT @@global.gtid_binlog_state;
@@ -52,14 +58,6 @@ SELECT @@global.gtid_binlog_state;
 
 --connection node_1
 DROP TABLE t1,t2;
-reset master;
-#
-# Unfortunately without the sleep below the following statement fails with "query returned no rows", which
-# is difficult to understand given that it is an aggregate query. A "query execution was interrupted"
-# warning is also reported by MTR, which is also weird.
-#
-
---sleep 1
 
 --connection node_2
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
@@ -75,4 +73,7 @@ RESET SLAVE ALL;
 reset master;
 
 --connection node_3
+reset master;
+
+--connection node_1
 reset master;


### PR DESCRIPTION
This patch makes two changes:

* It replaces `--sleep 1` with appropriate wait_conditions, and
  removes another `--sleep 1` which is no longer necessary, after
  MDEV-14144 has been fixed.

* It moves the `RESET MASTER` from node_1 at the very end, when it
  it sure that the other nodes have applied the the final cleanup
  `DROP TABLE t1,t2.`
  This solves the problem with the `DROP TABLE` not being replicated
  to the asynchronous slaves, which would make the test fail with:
  `Timeout in wait_condition.inc for SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';`