### PR TITLE
MDEV-15724 - Possible crash in parser

### DIFF
--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -205,6 +205,7 @@ init_lex_with_single_table(THD *thd, TABLE *table, LEX *lex)
   table->map= 1; //To ensure correct calculation of const item
   table_list->table= table;
   table_list->cacheable_table= false;
+  lex->create_last_non_select_table= table_list;
   return FALSE;
 }
 


### PR DESCRIPTION
Parser: uninitialized Lex->create_last_non_select_table under
mysql_unpack_partition() fix.

Tested with main, parts suites. Related to MDEV-15346.

I submit this under the BSD-new license.

Please, review.