### PR TITLE
MDEV-14790 System versioning for system tables does not work as expected

### DIFF
--- a/mysql-test/suite/versioning/r/alter.result
+++ b/mysql-test/suite/versioning/r/alter.result
@@ -517,5 +517,12 @@ alter table t drop column sys_trx_end, drop period for system_time;
 ERROR HY000: Wrong parameters for `t`: missing 'DROP COLUMN `row_start`, DROP COLUMN `row_end`'
 alter table t add period for system_time(sys_trx_start, sys_trx_end);
 ERROR HY000: Table `t` is already system-versioned
+# MDEV-14790 System versioning for system tables does not work as expected
+use mysql;
+create or replace table t (x int) with system versioning;
+ERROR HY000: System versioning prohibited in `mysql` database
+alter table user add system versioning;
+ERROR HY000: System versioning prohibited in `mysql` database
+use test;
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -439,5 +439,13 @@ alter table t drop column sys_trx_end, drop period for system_time;
 --error ER_VERS_ALREADY_VERSIONED
 alter table t add period for system_time(sys_trx_start, sys_trx_end);
 
+--echo # MDEV-14790 System versioning for system tables does not work as expected
+use mysql;
+--error ER_VERS_DB_PROHIBITED
+create or replace table t (x int) with system versioning;
+--error ER_VERS_DB_PROHIBITED
+alter table user add system versioning;
+use test;
+
 drop database test;
 create database test;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7104,7 +7104,7 @@ bool Table_scope_and_contents_source_st::vers_fix_system_fields(
     return true;
   }
 
-  if (vers_info.check_with_conditions(create_table.table_name.str))
+  if (vers_info.check_conditions(create_table.table_name.str, create_table.db))
     return true;
 
   bool native= vers_native(thd);
@@ -7217,7 +7217,7 @@ bool Vers_parse_info::fix_alter_info(THD *thd, Alter_info *alter_info,
 
   if (alter_info->flags & Alter_info::ALTER_ADD_SYSTEM_VERSIONING)
   {
-    if (check_with_conditions(table_name))
+    if (check_conditions(table_name, share->db))
       return true;
     bool native= create_info->vers_native(thd);
     if (check_sys_fields(table_name, alter_info, native))
@@ -7294,7 +7294,8 @@ bool Vers_parse_info::need_check(const Alter_info *alter_info) const
          alter_info->flags & Alter_info::ALTER_DROP_SYSTEM_VERSIONING || *this;
 }
 
-bool Vers_parse_info::check_with_conditions(const char *table_name) const
+bool Vers_parse_info::check_conditions(const char *table_name,
+                                       const LString_fs db) const
 {
   if (!as_row.start || !as_row.end)
   {
@@ -7315,6 +7316,11 @@ bool Vers_parse_info::check_with_conditions(const char *table_name) const
     return true;
   }
 
+  if (db == MYSQL_SCHEMA_NAME)
+  {
+    my_error(ER_VERS_DB_PROHIBITED, MYF(0), MYSQL_SCHEMA_NAME.str);
+    return true;
+  }
   return false;
 }
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1780,7 +1780,7 @@ protected:
     return as_row.start || as_row.end || system_time.start || system_time.end;
   }
   bool need_check(const Alter_info *alter_info) const;
-  bool check_with_conditions(const char *table_name) const;
+  bool check_conditions(const char *table_name, const LString_fs db) const;
   bool check_sys_fields(const char *table_name, Alter_info *alter_info,
                         bool native);
 

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7913,3 +7913,6 @@ ER_INDEX_FILE_FULL
         eng "The index file for table '%-.192s' is full"
 ER_UPDATED_COLUMN_ONLY_ONCE
         eng "The column %`s.%`s cannot be changed more than once in a single UPDATE statement"
+
+ER_VERS_DB_PROHIBITED
+      eng "System versioning prohibited in %`s database"


### PR DESCRIPTION
Prohibited system versioning for CREATE TABLE and ALTER in `mysql` db.

I submit this under the BSD-new license. Please, review.