### PR TITLE
MDEV-15378 Valid query causes invalid view definition due to syntax limitation in FOR SYSTEM_TIME

### DIFF
--- a/mysql-test/suite/versioning/r/view.result
+++ b/mysql-test/suite/versioning/r/view.result
@@ -119,6 +119,7 @@ a
 drop database test;
 create database test;
 use test;
+# MDEV-15146 SQLError[4122]: View is not system versioned
 create table t1 (a int) with system versioning;
 insert t1 values (1),(2);
 set @a=now(6);
@@ -133,5 +134,11 @@ a
 show create view v1;
 View	Create View	character_set_client	collation_connection
 v1	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v1` AS select `t1`.`a` AS `a` from `t1`	latin1	latin1_swedish_ci
+# MDEV-15378 Valid query causes invalid view definition due to syntax limitation in FOR SYSTEM_TIME
+create or replace table t1 (i int) with system versioning;
+create or replace view v1 as select * from t1 for system_time as of date_sub(now(), interval 6 second);
+show create view v1;
+View	Create View	character_set_client	collation_connection
+v1	CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`localhost` SQL SECURITY DEFINER VIEW `v1` AS select `t1`.`i` AS `i` from `t1` FOR SYSTEM_TIME AS OF (current_timestamp() - interval 6 second)	latin1	latin1_swedish_ci
 drop view v1;
 drop table t1;

--- a/mysql-test/suite/versioning/t/view.test
+++ b/mysql-test/suite/versioning/t/view.test
@@ -100,10 +100,7 @@ drop database test;
 create database test;
 use test;
 
-#
-# MDEV-15146 SQLError[4122]: View is not system versioned
-#
-
+--echo # MDEV-15146 SQLError[4122]: View is not system versioned
 create table t1 (a int) with system versioning;
 insert t1 values (1),(2);
 set @a=now(6);
@@ -112,5 +109,11 @@ delete from t1;
 select * from v1;
 select * from v1 for system_time as of @a;
 show create view v1;
+
+--echo # MDEV-15378 Valid query causes invalid view definition due to syntax limitation in FOR SYSTEM_TIME
+create or replace table t1 (i int) with system versioning;
+create or replace view v1 as select * from t1 for system_time as of date_sub(now(), interval 6 second);
+show create view v1;
+
 drop view v1;
 drop table t1;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -8924,7 +8924,16 @@ void Vers_history_point::print(String *str, enum_query_type query_type,
   };
   str->append(prefix, plen);
   str->append(unit_type + unit);
-  item->print(str, query_type);
+  if (item->need_parentheses_in_default())
+  {
+    str->append('(');
+    item->print(str, query_type);
+    str->append(')');
+  }
+  else
+  {
+    item->print(str, query_type);
+  }
 }
 
 Field *TABLE::find_field_by_name(LEX_CSTRING *str) const


### PR DESCRIPTION
Vers SQL: Vers_history_point::print() adds parentheses based on
item->need_parentheses_in_default().

I submit this under the BSD-new license. Please, review.