### PR TITLE
MDEV-13549 Fix test galera.galera_wsrep_desync_wsrep_on

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_desync_wsrep_on.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_desync_wsrep_on.result
@@ -2,6 +2,9 @@ CREATE TABLE ten (f1 INTEGER);
 INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 INSERT INTO t1 (f1) SELECT 000000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3.f1) + (10 * a4.f1) + a5.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5;
+SELECT COUNT(*) = 100000 FROM t1;
+COUNT(*) = 100000
+1
 SET GLOBAL wsrep_desync = TRUE;
 SET SESSION wsrep_on = FALSE;
 ALTER TABLE t1 ADD PRIMARY KEY (f1);

--- a/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_desync_wsrep_on.test
@@ -17,6 +17,8 @@ CREATE TABLE t1 (f1 INTEGER) Engine=InnoDB;
 INSERT INTO t1 (f1) SELECT 000000 + (10000 * a1.f1) + (1000 * a2.f1) + (100 * a3.f1) + (10 * a4.f1) + a5.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5;
 
 --connection node_2
+SELECT COUNT(*) = 100000 FROM t1;
+
 SET GLOBAL wsrep_desync = TRUE;
 SET SESSION wsrep_on = FALSE;
 


### PR DESCRIPTION
The test tends to fail if many parallel instances of it are executed:

```
mysqltest: At line 23: query 'ALTER TABLE t1 ADD PRIMARY KEY (f1)' failed:
1317: Query execution was interrupted
```

The `ALTER` fails because it is BF aborted due to an earlier `INSERT SELECT`
that is being applied:

```
INSERT INTO t1 (f1) SELECT ...

--connection node_2
SET GLOBAL wsrep_desync = TRUE;
SET SESSION wsrep_on = FALSE;

ALTER TABLE t1 ADD PRIMARY KEY (f1);

SET SESSION wsrep_on = TRUE;
SET GLOBAL wsrep_desync = FALSE;
```

And because the `ALTER` is executed with `wsrep_on = OFF`, it does not
run in total order isolation.
To avoid the problem it must be ensured that the `ALTER` only after the
large `INSERT SELECT` is done. To do so it is sufficient to issue
`SELECT COUNT(*) FROM t1;` from `node_2` before turning off wsrep.
The `SELECT` will trigger `wsrep_sync_wait` and proceed only after the
`INSERT SELECT` from node_1 is done.