### PR TITLE
MDEV-15021 - For dumping routines before views

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -4701,6 +4701,15 @@ static int dump_selected_tables(char *db, char **table_names, int tables)
   if (opt_xml)
     print_xml_tag(md_result_file, "", "\n", "database", "name=", db, NullS);
 
+ /*
+   Obtain dump of routines (procs/functions)
+   This is done before dumping views as views can make use of routines.
+ */
+  if (opt_routines && mysql_get_server_version(mysql) >= 50009)
+  {
+    DBUG_PRINT("info", ("Dumping routines for database %s", db));
+    dump_routines_for_db(db);
+  }
   /* Dump each selected table */
   for (pos= dump_tables; pos < end; pos++)
   {
@@ -4728,12 +4737,6 @@ static int dump_selected_tables(char *db, char **table_names, int tables)
   {
     DBUG_PRINT("info", ("Dumping events for database %s", db));
     dump_events_for_db(db);
-  }
-  /* obtain dump of routines (procs/functions) */
-  if (opt_routines && mysql_get_server_version(mysql) >= 50009)
-  {
-    DBUG_PRINT("info", ("Dumping routines for database %s", db));
-    dump_routines_for_db(db);
   }
   free_root(&root, MYF(0));
   my_free(order_by);

--- a/mysql-test/r/mysqldump.result
+++ b/mysql-test/r/mysqldump.result
@@ -5401,3 +5401,18 @@ DELIMITER ;
 /*!50003 SET collation_connection  = @saved_col_connection */ ;
 ALTER DATABASE `a\"'``b` CHARACTER SET utf8 COLLATE utf8_general_ci ;
 DROP DATABASE `a\"'``b`;
+#
+# MDEV-15021: mysqldump --tables --routines generates non importable
+#             dump file
+#
+# Check the order in which routines are written in the dump. Routines
+# need to be printed before views, in case views make use of them.
+#
+use test;
+CREATE FUNCTION f() RETURNS INT RETURN 1;
+CREATE VIEW v1 AS SELECT f();
+DROP VIEW v1;
+DROP FUNCTION f;
+# Cleanup
+DROP VIEW v1;
+DROP FUNCTION f;

--- a/mysql-test/suite/plugins/t/server_audit.test
+++ b/mysql-test/suite/plugins/t/server_audit.test
@@ -42,8 +42,10 @@ select 1,
         3;
 insert into t2 values (1), (2);
 select * from t2;
+--disable_ps_protocol
 --error ER_NO_SUCH_TABLE
 select * from t_doesnt_exist;
+--enable_ps_protocol
 --error 1064
 syntax_error_query;
 drop table renamed_t1, t2;

--- a/mysql-test/t/mysqldump.test
+++ b/mysql-test/t/mysqldump.test
@@ -2567,3 +2567,25 @@ let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/bug11505.sql;
 let SEARCH_PATTERN=Database: mysql;
 exec $MYSQL_DUMP mysql func  > $SEARCH_FILE;
 source include/search_pattern_in_file.inc;
+
+--echo #
+--echo # MDEV-15021: mysqldump --tables --routines generates non importable
+--echo #             dump file
+--echo #
+--echo # Check the order in which routines are written in the dump. Routines
+--echo # need to be printed before views, in case views make use of them.
+--echo #
+use test;
+CREATE FUNCTION f() RETURNS INT RETURN 1;
+CREATE VIEW v1 AS SELECT f();
+ 
+--exec $MYSQL_DUMP -uroot test --routines --tables v1 > $MYSQLTEST_VARDIR/test.dmp
+ 
+DROP VIEW v1;
+DROP FUNCTION f;
+ 
+--exec $MYSQL -uroot test < $MYSQLTEST_VARDIR/test.dmp
+ 
+--echo # Cleanup
+DROP VIEW v1;
+DROP FUNCTION f;


### PR DESCRIPTION
Dump routines before views in mysqldump so that the views can use routines and mysqldump becomes importable.