### PR TITLE
MDEV-15843 - mysys: remove optimized memcpy from 18 years ago

### DIFF
--- a/mysys/ptr_cmp.c
+++ b/mysys/ptr_cmp.c
@@ -21,22 +21,6 @@
 
 #include "mysys_priv.h"
 #include <myisampack.h>
-/*
- * On some platforms, memcmp() is faster than the unrolled ptr_compare_N
- * functions, as memcmp() is usually a platform-specific implementation
- * written in assembler. for example one in /usr/lib/libc/libc_hwcap*.so.1.
- * on Solaris, or on Windows inside C runtime linrary.
- *
- * On Solaris, native implementation is also usually faster than the 
- * built-in memcmp supplied by GCC, so it is recommended to build 
- * with "-fno-builtin-memcmp"in CFLAGS if building with GCC on Solaris.
- */
-
-#if defined (__sun) || defined (_WIN32)
-#define USE_NATIVE_MEMCMP 1
-#endif
-
-#ifdef USE_NATIVE_MEMCMP
 
 #include <string.h>
 
@@ -45,151 +29,10 @@ static int native_compare(size_t *length, unsigned char **a, unsigned char **b)
   return memcmp(*a, *b, *length);
 }
 
-#else	/* USE_NATIVE_MEMCMP */
-
-static int ptr_compare(size_t *compare_length, uchar **a, uchar **b);
-static int ptr_compare_0(size_t *compare_length, uchar **a, uchar **b);
-static int ptr_compare_1(size_t *compare_length, uchar **a, uchar **b);
-static int ptr_compare_2(size_t *compare_length, uchar **a, uchar **b);
-static int ptr_compare_3(size_t *compare_length, uchar **a, uchar **b);
-#endif	/* __sun */
-
-	/* Get a pointer to a optimal byte-compare function for a given size */
-
-#ifdef USE_NATIVE_MEMCMP
 qsort2_cmp get_ptr_compare (size_t size __attribute__((unused)))
 {
   return (qsort2_cmp) native_compare;
 }
-#else
-qsort2_cmp get_ptr_compare (size_t size)
-{
-  if (size < 4)
-    return (qsort2_cmp) ptr_compare;
-  switch (size & 3) {
-    case 0: return (qsort2_cmp) ptr_compare_0;
-    case 1: return (qsort2_cmp) ptr_compare_1;
-    case 2: return (qsort2_cmp) ptr_compare_2;
-    case 3: return (qsort2_cmp) ptr_compare_3;
-    }
-  return 0;					/* Impossible */
-}
-#endif /* USE_NATIVE_MEMCMP */
-
-
-	/*
-	  Compare to keys to see witch is smaller.
-	  Loop unrolled to make it quick !!
-	*/
-
-#define cmp(N) if (first[N] != last[N]) return (int) first[N] - (int) last[N]
-
-#ifndef USE_NATIVE_MEMCMP
-
-static int ptr_compare(size_t *compare_length, uchar **a, uchar **b)
-{
-  size_t length= *compare_length;
-  uchar *first,*last;
-
-  DBUG_ASSERT(length > 0);
-  first= *a; last= *b;
-  while (--length)
-  {
-    if (*first++ != *last++)
-      return (int) first[-1] - (int) last[-1];
-  }
-  return (int) first[0] - (int) last[0];
-}
-
-
-static int ptr_compare_0(size_t *compare_length,uchar **a, uchar **b)
-{
-  size_t length= *compare_length;
-  uchar *first,*last;
-
-  first= *a; last= *b;
- loop:
-  cmp(0);
-  cmp(1);
-  cmp(2);
-  cmp(3);
-  if ((length-=4))
-  {
-    first+=4;
-    last+=4;
-    goto loop;
-  }
-  return (0);
-}
-
-
-static int ptr_compare_1(size_t *compare_length,uchar **a, uchar **b)
-{
-  size_t length= *compare_length-1;
-  uchar *first,*last;
-
-  first= *a+1; last= *b+1;
-  cmp(-1);
- loop:
-  cmp(0);
-  cmp(1);
-  cmp(2);
-  cmp(3);
-  if ((length-=4))
-  {
-    first+=4;
-    last+=4;
-    goto loop;
-  }
-  return (0);
-}
-
-static int ptr_compare_2(size_t *compare_length,uchar **a, uchar **b)
-{
-  size_t length= *compare_length-2;
-  uchar *first,*last;
-
-  first= *a +2 ; last= *b +2;
-  cmp(-2);
-  cmp(-1);
- loop:
-  cmp(0);
-  cmp(1);
-  cmp(2);
-  cmp(3);
-  if ((length-=4))
-  {
-    first+=4;
-    last+=4;
-    goto loop;
-  }
-  return (0);
-}
-
-static int ptr_compare_3(size_t *compare_length,uchar **a, uchar **b)
-{
-  size_t length= *compare_length-3;
-  uchar *first,*last;
-
-  first= *a +3 ; last= *b +3;
-  cmp(-3);
-  cmp(-2);
-  cmp(-1);
- loop:
-  cmp(0);
-  cmp(1);
-  cmp(2);
-  cmp(3);
-  if ((length-=4))
-  {
-    first+=4;
-    last+=4;
-    goto loop;
-  }
-  return (0);
-}
-
-#endif /* !__sun */
 
 void my_store_ptr(uchar *buff, size_t pack_length, my_off_t pos)
 {


### PR DESCRIPTION
While this code has remained dormant for 18 years, libc implementers
have used assembly features to gain improvements using architecture
features optimized and by the buffer length like:
* https://svnweb.freebsd.org/base/head/lib/libc/amd64/string/memcmp.S
* https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/aarch64/memcmp.S
* https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/powerpc/powerpc64/memcpy.S

While the perf results in commit message don't show a great improvement the varying length and codebase shows optimizations based on length.

I submit this code deletion under the MCA.