### PR TITLE
MDEV-15808 Fix and re-enable test galera.galera_gra_log

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -31,6 +31,5 @@ galera_var_retry_autocommit : MDEV-15794 Test failure on galera.galera_var_retry
 galera_var_auto_inc_control_on : MDEV-15803 Test failure on galera.galera_var_auto_inc_control_on
 pxc-421 : MDEV-15804 Test failure on galera.pxc-421
 query_cache : MDEV-15805 Test failure on galera.query_cache
-galera.galera_gra_log : MDEV-15808 Test failure on galera.galera_gra_log
 galera.MW-44 : MDEV-15809 Test failure on galera.MW-44
 galera.galera_pc_ignore_sb : MDEV-15811 Test failure on galera_pc_ignore_sb

--- a/mysql-test/suite/galera/r/galera_gra_log.result
+++ b/mysql-test/suite/galera/r/galera_gra_log.result
@@ -1,6 +1,7 @@
 SET SESSION wsrep_on=OFF;
 CREATE TABLE t1 (f1 INTEGER);
 CREATE TABLE t1 (f1 INTEGER);
+SET SESSION wsrep_on=ON;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
@@ -27,6 +28,5 @@ DELIMITER ;
 ROLLBACK /* added by mysqlbinlog */;
 /*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
 /*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
-SET SESSION wsrep_on=ON;
 CALL mtr.add_suppression("Slave SQL: Error 'Table 't1' already exists' on query");
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_gra_log.test
+++ b/mysql-test/suite/galera/t/galera_gra_log.test
@@ -17,14 +17,13 @@ CREATE TABLE t1 (f1 INTEGER);
 CREATE TABLE t1 (f1 INTEGER);
 
 --connection node_2
+SET SESSION wsrep_on=ON;
 SELECT COUNT(*) = 0 FROM t1;
 
 # Make sure the GRA file produced is readable and contains the failure
 
 --replace_regex /SET TIMESTAMP=[0-9]+/SET TIMESTAMP=<TIMESTAMP>/ /pseudo_thread_id=[0-9]+/pseudo_thread_id=<PSEUDO_THREAD_ID>/
 --exec $MYSQL_BINLOG --short-form $MYSQLTEST_VARDIR/mysqld.2/data/GRA_*.log
-
-SET SESSION wsrep_on=ON;
 
 CALL mtr.add_suppression("Slave SQL: Error 'Table 't1' already exists' on query");
 


### PR DESCRIPTION
Test would occasionally fail as follows:

```
mysqltest: At line 20: query 'SELECT COUNT(*) = 0 FROM t1' failed:
1317: Query execution was interrupted

```

This was due to a `CREATE TABLE` applied concurrently that would
occasionally cause the `SELECT` to be BF aborted, due to MDL
conflict.

The `SELECT` is executed while `wsrep_on=OFF`. The change makes sure
it is executed only after wsrep is enabled again.