### PR TITLE
MDEV-15804 Fix and re-enable MTR test galera.pxc-421

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -29,7 +29,6 @@ galera.MW-329 : wsrep_local_replays not stable
 galera.MW-328A : have_deadlocks test not stable
 galera_var_retry_autocommit : MDEV-15794 Test failure on galera.galera_var_retry_autocommit
 galera_var_auto_inc_control_on : MDEV-15803 Test failure on galera.galera_var_auto_inc_control_on
-pxc-421 : MDEV-15804 Test failure on galera.pxc-421
 query_cache : MDEV-15805 Test failure on galera.query_cache
 galera.galera_gra_log : MDEV-15808 Test failure on galera.galera_gra_log
 galera.MW-44 : MDEV-15809 Test failure on galera.MW-44

--- a/mysql-test/suite/galera/r/pxc-421.result
+++ b/mysql-test/suite/galera/r/pxc-421.result
@@ -6,7 +6,6 @@ set GLOBAL wsrep_slave_threads=16;
 SET GLOBAL wsrep_provider='none';
 INSERT INTO t1 VALUES (2);
 INSERT INTO t1 VALUES (3);
-set SESSION wsrep_sync_wait=0;
 INSERT INTO t1 VALUES (4);
 set GLOBAL wsrep_slave_threads=5;
 SELECT COUNT(*) = 5 FROM t1;

--- a/mysql-test/suite/galera/t/pxc-421.test
+++ b/mysql-test/suite/galera/t/pxc-421.test
@@ -36,9 +36,7 @@ INSERT INTO t1 VALUES (3);
 --eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
 --enable_query_log
 
-set SESSION wsrep_sync_wait=0;
 --source include/wait_until_connected_again.inc
---source include/galera_wait_ready.inc
 
 INSERT INTO t1 VALUES (4);
 set GLOBAL wsrep_slave_threads=5;


### PR DESCRIPTION
This patch makes two changes:

* Remove unnecessary `set SESSION wsrep_sync_wait=0`.
  Disabling `wsrep_sync_wait` caused the test to fail occasionally,
  due to subsequent `SELECT`s observing stale values.

* Remove redundant `--source include/galera_wait_ready.inc`,
  `galera_wait_ready.inc` is already included in the above
  `wait_until_connected_again.inc`