### PR TITLE
MDEV-9883: mysqldump does not support default-character-set=auto

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -1053,7 +1053,7 @@ static int get_options(int *argc, char ***argv)
             my_progname_short);
     return(EX_USAGE);
   }
-  if (strcmp(default_charset, charset_info->csname) &&
+  if (strcmp(default_charset, MYSQL_AUTODETECT_CHARSET_NAME) &&
       !(charset_info= get_charset_by_csname(default_charset,
                                             MY_CS_PRIMARY, MYF(MY_WME))))
     exit(1);

--- a/mysql-test/r/mysqldump_default_character_set_auto.result
+++ b/mysql-test/r/mysqldump_default_character_set_auto.result
@@ -1,0 +1,3 @@
+#
+# MDEV-9883 Mysqldump does not support --default-character-set=auto
+#

--- a/mysql-test/t/mysqldump_default_character_set_auto.test
+++ b/mysql-test/t/mysqldump_default_character_set_auto.test
@@ -1,0 +1,13 @@
+--echo #
+--echo # MDEV-9883 Mysqldump does not support --default-character-set=auto
+--echo #
+
+# By default default-character-set= MYSQL_DEFAULT_CHARSET_NAME  
+# which is curently set to utf8, but should be set to utf8mb4 according to MDEV-8765
+--exec $MYSQL_DUMP --databases test > $MYSQLTEST_VARDIR/1_default_charset.sql
+
+# When parameter is set to auto
+--exec $MYSQL_DUMP --databases test --default-character-set=auto > $MYSQLTEST_VARDIR/2_default_charset_auto.sql
+
+# By changing the parameter value to utf8mb4
+--exec $MYSQL_DUMP --databases test --default-character-set=utf8mb4 > $MYSQLTEST_VARDIR/3_default_charset_utf8mb4.sql


### PR DESCRIPTION

This patch is used to enable `--default-character-set=auto` for mysqldump.