### PR TITLE
MDEV-15789 - mysqlslap --auto-generate-sql-guid-primary uses incorrect table

### DIFF
--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -868,7 +868,7 @@ build_table_string(void)
       if (count) /* Except for the first pass we add a comma */
         dynstr_append(&table_string, ",");
 
-      if (snprintf(buf, HUGE_STRING_LENGTH, "id%d varchar(32) unique key", count) 
+      if (snprintf(buf, HUGE_STRING_LENGTH, "id%d varchar(36) unique key", count) 
           > HUGE_STRING_LENGTH)
       {
         fprintf(stderr, "Memory Allocation error in create table\n");

--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -853,7 +853,7 @@ build_table_string(void)
 
   if (auto_generate_sql_guid_primary)
   {
-    dynstr_append(&table_string, "id varchar(32) primary key");
+    dynstr_append(&table_string, "id varchar(36) primary key");
 
     if (num_int_cols || num_char_cols || auto_generate_sql_guid_primary)
       dynstr_append(&table_string, ",");

--- a/mysql-test/r/mysqlslap.result
+++ b/mysql-test/r/mysqlslap.result
@@ -255,3 +255,8 @@ Benchmark
 # MDEV-4684 - Enhancement request: --init-command support for mysqlslap
 #
 DROP TABLE t1;
+#
+# Bug MDEV-15789 (Upstream: #80329): MYSQLSLAP OPTIONS --AUTO-GENERATE-SQL-GUID-PRIMARY and --AUTO-GENERATE-SQL-SECONDARY-INDEXES DONT WORK
+#
+DROP TABLE t1;
+DROP TABLE t1;

--- a/mysql-test/t/mysqlslap.test
+++ b/mysql-test/t/mysqlslap.test
@@ -80,3 +80,13 @@ DROP DATABASE bug58090;
 
 --exec $MYSQL_SLAP --create-schema=test --init-command="CREATE TABLE t1(a INT)" --silent --concurrency=1 --iterations=1
 DROP TABLE t1;
+
+--echo #
+--echo # Bug MDEV-15789 (Upstream: #80329): MYSQLSLAP OPTIONS --AUTO-GENERATE-SQL-GUID-PRIMARY and --AUTO-GENERATE-SQL-SECONDARY-INDEXES DONT WORK
+--echo #
+
+--exec $MYSQL_SLAP --concurrency=1 --silent --iterations=1 --number-int-cols=2 --number-char-cols=3 --auto-generate-sql --auto-generate-sql-guid-primary --create-schema=slap
+DROP TABLE t1;
+--exec $MYSQL_SLAP --concurrency=1 --silent --iterations=1 --number-int-cols=2 --number-char-cols=3 --auto-generate-sql --auto-generate-sql-secondary-indexes=1 --create-schema=slap
+DROP TABLE t1;
+


### PR DESCRIPTION
This is a fix for MDEV-15789, a minor fix to mysqlslap when using --auto-generate-sql-guid-primary.