### PR TITLE
MDEV-15929 Fix lock wait timeout on `SELECT @@GLOBAL.WSREP_ON`

### DIFF
--- a/mysql-test/suite/galera/include/galera_st_kill_slave.inc
+++ b/mysql-test/suite/galera/include/galera_st_kill_slave.inc
@@ -24,7 +24,6 @@ COMMIT;
 --source include/kill_galera.inc
 
 --connection node_1
---source include/wait_until_connected_again.inc
 --let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
 --source include/wait_condition.inc
 


### PR DESCRIPTION
This patch fixes a lock wait timeout error on `SELECT @@GLOBAL.WSREP_ON`
in `wait_wsrep_ready.inc`:

```
--connection node_2
...
--source include/kill_galera.inc

--connection node_1
--source include/wait_until_connected_again.inc # This includes wait_wsrep_ready.inc

```

The problem is that on node_2, kill_galera.inc may return before
the node is killed. So node_1 may still see that node_1 is alive
and will attempt to sync wait when doing those `SELECT` statements.
But sync wait is doomed to fail given that node_1 is killed, hence
the lock wait timeout.
One possible fix is to disable wsrep_sync_wait before including
wait_until_connected_again.
However, it appears that including wait_until_connected_again is
not necessary at all in node_1, so this patch removes it altogether.