### PR TITLE
MDEV-15948 Fix error "Lost connection to MySQL server..." in test gal…

### DIFF
--- a/mysql-test/include/galera_wait_ready.inc
+++ b/mysql-test/include/galera_wait_ready.inc
@@ -1,2 +1,32 @@
-let $wait_condition = SELECT 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_ready' AND VARIABLE_VALUE = 'ON';
---source include/wait_condition.inc
+# include/galera_wait_ready.inc
+#
+# Waits for galera node to transition to READY state.
+#
+
+--enable_reconnect
+--disable_query_log
+--disable_result_log
+let $wait_counter = 300;
+while ($wait_counter)
+{
+  --disable_abort_on_error
+  let $success = `SELECT VARIABLE_VALUE = 'ON' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_ready'`;
+  --enable_abort_on_error
+  if ($success)
+  {
+    let $wait_counter = 0;
+  }
+  if (!$success)
+  {
+     real_sleep 0.1;
+     dec $wait_counter;
+  }
+}
+
+if (!$success)
+{
+  die "Server did not transition to READY state";
+}
+--disable_reconnect
+--enable_query_log
+--enable_result_log

--- a/mysql-test/include/galera_wait_ready.inc
+++ b/mysql-test/include/galera_wait_ready.inc
@@ -6,7 +6,7 @@
 --enable_reconnect
 --disable_query_log
 --disable_result_log
-let $wait_counter = 300;
+let $wait_counter = 600;
 while ($wait_counter)
 {
   --disable_abort_on_error

--- a/mysql-test/suite/galera/include/galera_load_provider.inc
+++ b/mysql-test/suite/galera/include/galera_load_provider.inc
@@ -5,6 +5,4 @@
 --eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_orig';
 --enable_query_log
 
---enable_reconnect
---source include/wait_until_connected_again.inc
---source include/wait_until_ready.inc
+--source include/galera_wait_ready.inc

--- a/mysql-test/suite/galera/include/galera_st_clean_slave.inc
+++ b/mysql-test/suite/galera/include/galera_st_clean_slave.inc
@@ -64,7 +64,9 @@ INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
 --connection node_2
 --echo Starting server ...
 --source include/start_mysqld.inc
---source include/wait_until_ready.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
 
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;

--- a/mysql-test/suite/galera/include/galera_st_kill_slave.inc
+++ b/mysql-test/suite/galera/include/galera_st_kill_slave.inc
@@ -59,7 +59,9 @@ INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
 
 --echo Starting server ...
 --source include/start_mysqld.inc
---source include/wait_until_ready.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
 
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;

--- a/mysql-test/suite/galera/include/galera_st_kill_slave_ddl.inc
+++ b/mysql-test/suite/galera/include/galera_st_kill_slave_ddl.inc
@@ -72,7 +72,9 @@ INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
 --connection node_2
 --echo Starting server ...
 --source include/start_mysqld.inc
---source include/wait_until_ready.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
 
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;

--- a/mysql-test/suite/galera/include/galera_st_shutdown_slave.inc
+++ b/mysql-test/suite/galera/include/galera_st_shutdown_slave.inc
@@ -56,7 +56,9 @@ INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
 --connection node_2
 --echo Starting server ...
 --source include/start_mysqld.inc
---source include/wait_until_ready.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
 
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;

--- a/mysql-test/suite/galera/include/start_mysqld.inc
+++ b/mysql-test/suite/galera/include/start_mysqld.inc
@@ -12,11 +12,4 @@ if ($galera_wsrep_start_position == '') {
 	--exec echo "restart:$start_mysqld_params" > $_expect_file_name
 }
 
-# Turn on reconnect
---enable_reconnect
-
-# Call script that will poll the server waiting for it to be back online again
---source include/wait_until_connected_again.inc
-
-# Turn off reconnect again
---disable_reconnect
+--source include/galera_wait_ready.inc


### PR DESCRIPTION
…era_sst_mysqldump

Test galera_sst_mysqldump often fails with error "2013: Lost connection
to MySQL server during query". The connection is lost after the test
restart one of the nodes. This happens because the server closes client
connections if it is joining a cluster through SST method mysqldump.
On unlucky runs of the test it is possible that mysqld is restarted,
and then mtr client is disconnected while it tries to determine if
galera is ready before going on with the test.
This patch rewrites galera_wait_ready.inc so that it is immune to
being disconnected.