### PR TITLE
MDEV-16630: Ambiguous error message when check constraint matches table name

### DIFF
--- a/mysql-test/r/check_constraint.result
+++ b/mysql-test/r/check_constraint.result
@@ -10,9 +10,9 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert into t1 values (100,100);
 insert into t1 values (1,1);
-ERROR 23000: CONSTRAINT `a` failed for `test`.`t1`
+ERROR 23000: CONSTRAINT `t1.a` failed for `test`.`t1`
 insert into t1 values (20,1);
-ERROR 23000: CONSTRAINT `b` failed for `test`.`t1`
+ERROR 23000: CONSTRAINT `t1.b` failed for `test`.`t1`
 insert into t1 values (20,30);
 ERROR 23000: CONSTRAINT `min` failed for `test`.`t1`
 insert into t1 values (500,500);
@@ -60,7 +60,7 @@ t1	CREATE TABLE `t1` (
   CONSTRAINT `CONSTRAINT_1` CHECK (`a` + `b` + `c` < 500)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert into t1 values(105,105,105);
-ERROR 23000: CONSTRAINT `c` failed for `test`.`t1`
+ERROR 23000: CONSTRAINT `t1.c` failed for `test`.`t1`
 insert into t1 values(249,249,9);
 ERROR 23000: CONSTRAINT `CONSTRAINT_1` failed for `test`.`t1`
 insert into t1 values(105,105,9);
@@ -145,7 +145,7 @@ ERROR HY000: Function or expression '@b' cannot be used in the CHECK clause of `
 create table t1 (a int check (a = 1));
 insert t1 values (1);
 insert t1 values (2);
-ERROR 23000: CONSTRAINT `a` failed for `test`.`t1`
+ERROR 23000: CONSTRAINT `t1.a` failed for `test`.`t1`
 insert t1 values (NULL);
 select * from t1;
 a
@@ -165,13 +165,13 @@ ERROR 22007: Truncated incorrect DOUBLE value: 'Ken'
 SHOW WARNINGS;
 Level	Code	Message
 Error	1292	Truncated incorrect DOUBLE value: 'Ken'
-Error	4025	CONSTRAINT `FirstName` failed for `test`.`t1`
+Error	4025	CONSTRAINT `t1.FirstName` failed for `test`.`t1`
 INSERT INTO t1 VALUES (NULL, 'Ken'),(NULL, 'Brian');
 ERROR 22007: Truncated incorrect DOUBLE value: 'Ken'
 SHOW WARNINGS;
 Level	Code	Message
 Error	1292	Truncated incorrect DOUBLE value: 'Ken'
-Error	4025	CONSTRAINT `FirstName` failed for `test`.`t1`
+Error	4025	CONSTRAINT `t1.FirstName` failed for `test`.`t1`
 INSERT IGNORE INTO t1 VALUES (NULL, 'Ken');
 Warnings:
 Warning	1292	Truncated incorrect DOUBLE value: 'Ken'
@@ -197,3 +197,28 @@ EmployeeID	FirstName
 5	Ken
 6	Brian
 drop table t1;
+#
+# MDEV-16630: Ambiguous error message when check constraint
+#             matches table name
+#
+use test;
+drop table if exists t;
+create table t(a int, b int check(b>0),
+constraint b check(a<b), constraint a check(a>0),
+constraint x check (a>10));
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) DEFAULT NULL CHECK (`b` > 0),
+  CONSTRAINT `b` CHECK (`a` < `b`),
+  CONSTRAINT `a` CHECK (`a` > 0),
+  CONSTRAINT `x` CHECK (`a` > 10)
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+# Field constraint 'b' will fail
+insert into t values (-1, 0);
+ERROR 23000: CONSTRAINT `t.b` failed for `test`.`t`
+# Table constraint 'b' will fail
+insert into t values (1,1);
+ERROR 23000: CONSTRAINT `b` failed for `test`.`t`
+drop table t;

--- a/mysql-test/r/constraints.result
+++ b/mysql-test/r/constraints.result
@@ -7,7 +7,7 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert into t1 values (1);
 insert into t1 values (0);
-ERROR 23000: CONSTRAINT `a` failed for `test`.`t1`
+ERROR 23000: CONSTRAINT `t1.a` failed for `test`.`t1`
 drop table t1;
 create table t1 (a int, b int, check (a>b));
 show create table t1;

--- a/mysql-test/r/type_json.result
+++ b/mysql-test/r/type_json.result
@@ -20,7 +20,7 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert t1 values ('[]');
 insert t1 values ('a');
-ERROR 23000: CONSTRAINT `a` failed for `test`.`t1`
+ERROR 23000: CONSTRAINT `t1.a` failed for `test`.`t1`
 set timestamp=unix_timestamp('2010:11:12 13:14:15');
 create or replace table t1(a json default(json_object('now', now())));
 show create table t1;

--- a/mysql-test/t/check_constraint.test
+++ b/mysql-test/t/check_constraint.test
@@ -135,3 +135,31 @@ INSERT INTO t1 VALUES (NULL, 'Ken'),(NULL, 'Brian');
 set sql_mode=default;
 select * from t1;
 drop table t1;
+
+--echo #
+--echo # MDEV-16630: Ambiguous error message when check constraint
+--echo #             matches table name
+--echo #
+
+use test;
+--disable_warnings
+drop table if exists t;
+--enable_warnings
+
+create table t(a int, b int check(b>0),
+               constraint b check(a<b), constraint a check(a>0),
+               constraint x check (a>10));
+
+show create table t;
+
+# Generate error when field constraint 'b' is violated
+--echo # Field constraint 'b' will fail
+--error ER_CONSTRAINT_FAILED
+insert into t values (-1, 0);
+
+# Generate error when table constraint 'b' is violated.
+--echo # Table constraint 'b' will fail
+--error ER_CONSTRAINT_FAILED
+insert into t values (1,1);
+
+drop table t;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -5142,8 +5142,18 @@ int TABLE::verify_constraints(bool ignore_failure)
       if (((*chk)->expr->val_int() == 0 && !(*chk)->expr->null_value) ||
           in_use->is_error())
       {
+        StringBuffer<MAX_FIELD_WIDTH> field_error(system_charset_info);
+        enum_vcol_info_type vcol_type= (*chk)->get_vcol_type();
+        DBUG_ASSERT(vcol_type == VCOL_CHECK_TABLE ||
+                    vcol_type == VCOL_CHECK_FIELD);
+        if (vcol_type == VCOL_CHECK_FIELD)
+        {
+          field_error.append(s->table_name.str);
+          field_error.append(".");
+        }
+        field_error.append((*chk)->name.str);
         my_error(ER_CONSTRAINT_FAILED,
-                 MYF(ignore_failure ? ME_JUST_WARNING : 0), (*chk)->name.str,
+                 MYF(ignore_failure ? ME_JUST_WARNING : 0), field_error.c_ptr(),
                  s->db.str, s->table_name.str);
         return ignore_failure ? VIEW_CHECK_SKIP : VIEW_CHECK_ERROR;
       }


### PR DESCRIPTION
One can create table with the same name for `field` and `table` `check` constraint.
For example:
`create table t(a int check(a>0), constraint a check(a>10));`
But when inserting new rows same error is always raised.
For example with
```insert into t values (-1);```
and
```insert into t values (10);```
same error `ER_CONSTRAINT_FAILED` is obtained.
By the assumption that previous error should be raised only in case of `table` constraints,
this patch will distinguish between `field` and `table` error message
by adding newly created `ER_FIELD_CONSTRAINT_FAILED` error which occurs only when `field`
constraint is violated.