### PR TITLE
MDEV-16006 Fix test galera_kill_nochanges

### DIFF
--- a/mysql-test/suite/galera/r/galera_kill_nochanges.result
+++ b/mysql-test/suite/galera/r/galera_kill_nochanges.result
@@ -1,6 +1,8 @@
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 Killing server ...
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = DEFAULT;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1

--- a/mysql-test/suite/galera/t/galera_kill_nochanges.test
+++ b/mysql-test/suite/galera/t/galera_kill_nochanges.test
@@ -11,6 +11,14 @@ INSERT INTO t1 VALUES (1);
 
 --connection node_2
 --source include/kill_galera.inc
+
+--connection node_1
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 'non-Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status'
+--source include/wait_condition.inc
+SET SESSION wsrep_sync_wait = DEFAULT;
+
+--connection node_2
 --source include/start_mysqld.inc
 
 --let $galera_connection_name = node_2a


### PR DESCRIPTION
The test performs a restart and while doing so it occasionally
fails with "Server did not transition to READY state" in
`include/start_mysqld.inc".
Fix is to wait for the cluster to shrink before restarting
the node.