### PR TITLE
MDEV-15979 DELETE HISTORY from a table with transaction-precise versioning causes Assertion `table_list->vers_conditions.type == SYSTEM_TIME_BEFORE' failure

### DIFF
--- a/mysql-test/suite/versioning/common.inc
+++ b/mysql-test/suite/versioning/common.inc
@@ -6,7 +6,7 @@ select ifnull(max(transaction_id), 0) into @start_trx_id from mysql.transaction_
 set @test_start=now(6);
 
 delimiter ~~;
-create procedure if not exists verify_vtq()
+create procedure if not exists verify_trt()
 begin
   set @i= 0;
   select
@@ -22,7 +22,7 @@ begin
   from mysql.transaction_registry;
 end~~
 
-create procedure if not exists verify_vtq_dummy(recs int)
+create procedure if not exists verify_trt_dummy(recs int)
 begin
   declare i int default 1;
   create temporary table tmp (No int, A bool, B bool, C bool, D bool);

--- a/mysql-test/suite/versioning/common_finish.inc
+++ b/mysql-test/suite/versioning/common_finish.inc
@@ -1,6 +1,6 @@
 --disable_query_log
-drop procedure verify_vtq;
-drop procedure verify_vtq_dummy;
+drop procedure verify_trt;
+drop procedure verify_trt_dummy;
 drop function current_row;
 drop function check_row;
 --enable_query_log

--- a/mysql-test/suite/versioning/r/alter.result
+++ b/mysql-test/suite/versioning/r/alter.result
@@ -265,14 +265,14 @@ t	CREATE TABLE `t` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
 alter table t drop system versioning;
 insert into t values(1);
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 alter table t
 add column trx_start bigint(20) unsigned as row start invisible,
 add column trx_end bigint(20) unsigned as row end invisible,
 add period for system_time(trx_start, trx_end),
 add system versioning;
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 1	1	1	1	1
 show create table t;
@@ -284,13 +284,13 @@ t	CREATE TABLE `t` (
   PERIOD FOR SYSTEM_TIME (`trx_start`, `trx_end`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 WITH SYSTEM VERSIONING
 alter table t drop column trx_start, drop column trx_end;
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 alter table t drop system versioning, algorithm=copy;
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 alter table t add system versioning, algorithm=copy;
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 show create table t;
 Table	Create Table
@@ -312,7 +312,7 @@ t	CREATE TABLE `t` (
 select * from t;
 a	b
 2	NULL
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 alter table t drop column b, algorithm=copy;
 show create table t;
@@ -324,7 +324,7 @@ select * from t for system_time all;
 a
 2
 1
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 alter table t drop system versioning, algorithm=copy;
 show create table t;
@@ -332,7 +332,7 @@ Table	Create Table
 t	CREATE TABLE `t` (
   `a` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 create or replace table t (a int);
 insert t values (1),(2),(3),(4);

--- a/mysql-test/suite/versioning/r/commit_id.result
+++ b/mysql-test/suite/versioning/r/commit_id.result
@@ -30,38 +30,38 @@ transaction_id = @tx2
 1
 set @ts3= now(6);
 select
-vtq_trx_id(@ts0) < @tx0 as A,
-vtq_trx_id(@ts0, true) = @tx0 as B,
-vtq_trx_id(@ts1) = @tx0 as C,
-vtq_trx_id(@ts1, true) = @tx1 as D,
-vtq_trx_id(@ts2) = @tx1 as E,
-vtq_trx_id(@ts2, true) = @tx2 as F,
-vtq_trx_id(@ts3) = @tx2 as G,
-vtq_trx_id(@ts3, true) is null as H;
+trt_trx_id(@ts0) < @tx0 as A,
+trt_trx_id(@ts0, true) = @tx0 as B,
+trt_trx_id(@ts1) = @tx0 as C,
+trt_trx_id(@ts1, true) = @tx1 as D,
+trt_trx_id(@ts2) = @tx1 as E,
+trt_trx_id(@ts2, true) = @tx2 as F,
+trt_trx_id(@ts3) = @tx2 as G,
+trt_trx_id(@ts3, true) is null as H;
 A	B	C	D	E	F	G	H
 1	1	1	1	1	1	1	1
 select
-vtq_commit_id(@ts0) < @tx0 as A,
-vtq_commit_id(@ts0, true) = vtq_commit_id(null, @tx0) as B,
-vtq_commit_id(@ts1) = vtq_commit_id(null, @tx0) as C,
-vtq_commit_id(@ts1, true) = vtq_commit_id(null, @tx1) as D,
-vtq_commit_id(@ts2) = vtq_commit_id(null, @tx1) as E,
-vtq_commit_id(@ts2, true) = vtq_commit_id(null, @tx2) as F,
-vtq_commit_id(@ts3) = vtq_commit_id(null, @tx2) as G,
-vtq_commit_id(@ts3, true) is null as H;
+trt_commit_id(@ts0) < @tx0 as A,
+trt_commit_id(@ts0, true) = trt_commit_id(null, @tx0) as B,
+trt_commit_id(@ts1) = trt_commit_id(null, @tx0) as C,
+trt_commit_id(@ts1, true) = trt_commit_id(null, @tx1) as D,
+trt_commit_id(@ts2) = trt_commit_id(null, @tx1) as E,
+trt_commit_id(@ts2, true) = trt_commit_id(null, @tx2) as F,
+trt_commit_id(@ts3) = trt_commit_id(null, @tx2) as G,
+trt_commit_id(@ts3, true) is null as H;
 A	B	C	D	E	F	G	H
 1	1	1	1	1	1	1	1
 select
-vtq_trx_sees(@tx1, @tx0) as A,
-not vtq_trx_sees(@tx0, @tx1) as B,
-vtq_trx_sees_eq(@tx1, @tx1) as C,
-not vtq_trx_sees(@tx1, @tx1) as D,
-vtq_trx_sees(@tx2, 0) as E,
-vtq_trx_sees(-1, @tx2) as F;
+trt_trx_sees(@tx1, @tx0) as A,
+not trt_trx_sees(@tx0, @tx1) as B,
+trt_trx_sees_eq(@tx1, @tx1) as C,
+not trt_trx_sees(@tx1, @tx1) as D,
+trt_trx_sees(@tx2, 0) as E,
+trt_trx_sees(-1, @tx2) as F;
 A	B	C	D	E	F
 1	1	1	1	1	1
-select vtq_trx_sees(0, @tx2);
-vtq_trx_sees(0, @tx2)
+select trt_trx_sees(0, @tx2);
+trt_trx_sees(0, @tx2)
 NULL
 set transaction isolation level read uncommitted;
 insert into t1 values ();
@@ -88,7 +88,7 @@ select isolation_level = 'REPEATABLE-READ' from mysql.transaction_registry where
 isolation_level = 'REPEATABLE-READ'
 1
 drop table t1;
-call verify_vtq;
+call verify_trt;
 No	A	B	C	D
 1	1	1	1	1
 2	1	1	1	1

--- a/mysql-test/suite/versioning/r/select.result
+++ b/mysql-test/suite/versioning/r/select.result
@@ -512,7 +512,7 @@ Warnings:
 Note	1003	select `test`.`t1`.`f1` AS `f1` from `test`.`t1` FOR SYSTEM_TIME ALL join `test`.`t2` left join (`test`.`t3` left join `test`.`t4` FOR SYSTEM_TIME ALL on(`test`.`t4`.`f4` = `test`.`t2`.`f2` and `test`.`t4`.`row_end` = TIMESTAMP'2038-01-19 03:14:07.999999')) on(`test`.`t3`.`f3` = `test`.`t2`.`f2`) where `test`.`t1`.`row_end` = TIMESTAMP'2038-01-19 03:14:07.999999'
 drop view v1;
 drop table t1, t2, t3, t4;
-call verify_vtq_dummy(34);
+call verify_trt_dummy(34);
 No	A	B	C	D
 1	1	1	1	1
 2	1	1	1	1

--- a/mysql-test/suite/versioning/r/select2,trx_id.rdiff
+++ b/mysql-test/suite/versioning/r/select2,trx_id.rdiff
@@ -5,7 +5,7 @@
  insert into t1(x, y) values(3, 33);
  select sys_start from t1 where x = 3 and y = 33 into @t1;
 +set @x1= @t1;
-+select vtq_commit_ts(@x1) into @t1;
++select trt_commit_ts(@x1) into @t1;
  select x, y from t1;
  x	y
  0	100

--- a/mysql-test/suite/versioning/r/truncate.result
+++ b/mysql-test/suite/versioning/r/truncate.result
@@ -1,7 +1,12 @@
 create table t (a int);
 delete history from t before system_time now();
 ERROR HY000: Table `t` is not system-versioned
-create or replace table t (a int) with system versioning;
+create or replace table t (
+a int,
+row_start SYS_TYPE as row start invisible,
+row_end SYS_TYPE as row end invisible,
+period for system_time (row_start, row_end))
+with system versioning;
 insert into t values (1);
 update t set a=2;
 set @test = 'correct';
@@ -12,7 +17,12 @@ select @test from t;
 @test
 correct
 drop table t;
-create table t (a int) with system versioning;
+create or replace table t (
+a int,
+row_start SYS_TYPE as row start invisible,
+row_end SYS_TYPE as row end invisible,
+period for system_time (row_start, row_end))
+with system versioning;
 insert into t values (1), (2);
 update t set a=11 where a=1;
 set @ts1=now(6);
@@ -48,7 +58,6 @@ drop procedure truncate_sp;
 # Truncate partitioned
 create or replace table t (a int)
 with system versioning
-engine myisam
 partition by system_time limit 1 (
 partition p0 history,
 partition p1 history,
@@ -61,7 +70,12 @@ select * from t for system_time all;
 a
 3
 # VIEW
-create or replace table t (i int) with system versioning;
+create or replace table t (
+i int,
+row_start SYS_TYPE as row start invisible,
+row_end SYS_TYPE as row end invisible,
+period for system_time (row_start, row_end))
+with system versioning;
 delete history from t;
 create or replace view v as select * from t;
 delete history from v;
@@ -86,3 +100,5 @@ ERROR 42S02: 'v' is a view
 unlock tables;
 drop view v;
 drop table t;
+drop database test;
+create database test;

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -172,23 +172,23 @@ alter table t drop system versioning;
 
 insert into t values(1);
 
-call verify_vtq;
+call verify_trt;
 alter table t
   add column trx_start bigint(20) unsigned as row start invisible,
   add column trx_end bigint(20) unsigned as row end invisible,
   add period for system_time(trx_start, trx_end),
   add system versioning;
-call verify_vtq;
+call verify_trt;
 
 show create table t;
 alter table t drop column trx_start, drop column trx_end;
 
-call verify_vtq;
+call verify_trt;
 alter table t drop system versioning, algorithm=copy;
-call verify_vtq;
+call verify_trt;
 
 alter table t add system versioning, algorithm=copy;
-call verify_vtq;
+call verify_trt;
 
 show create table t;
 
@@ -198,31 +198,31 @@ select * from t for system_time all;
 alter table t add column b int, algorithm=copy;
 show create table t;
 select * from t;
-call verify_vtq;
+call verify_trt;
 
 alter table t drop column b, algorithm=copy;
 show create table t;
 select * from t for system_time all;
-call verify_vtq;
+call verify_trt;
 
 ## FIXME: #414 IB: inplace for VERS_TIMESTAMP versioning
 if (0)
 {
 alter table t drop system versioning, algorithm=inplace;
-call verify_vtq;
+call verify_trt;
 
 alter table t add system versioning, algorithm=inplace;
-call verify_vtq;
+call verify_trt;
 show create table t;
 
 update t set a= 1;
 select * from t for system_time all;
-call verify_vtq;
+call verify_trt;
 
 alter table t add column b int, algorithm=inplace;
 show create table t;
 select * from t;
-call verify_vtq;
+call verify_trt;
 
 alter table t drop column b, algorithm=inplace;
 show create table t;
@@ -232,7 +232,7 @@ select * from t for system_time all;
 
 alter table t drop system versioning, algorithm=copy;
 show create table t;
-call verify_vtq;
+call verify_trt;
 
 # nullable autoinc test w/o versioning
 create or replace table t (a int);
@@ -341,7 +341,7 @@ select * from t;
 show create table t;
 
 
-call verify_vtq;
+call verify_trt;
 }
 
 create or replace table t (a int) with system versioning;

--- a/mysql-test/suite/versioning/t/commit_id.test
+++ b/mysql-test/suite/versioning/t/commit_id.test
@@ -10,7 +10,7 @@ with system versioning
 engine innodb;
 
 
-# VTQ_TRX_ID, VTQ_COMMIT_ID, VTQ_TRX_SEES #
+# TRT_TRX_ID, TRT_COMMIT_ID, TRT_TRX_SEES #
 
 insert into t1 values ();
 
@@ -36,36 +36,36 @@ order by transaction_id desc limit 1;
 set @ts3= now(6);
 
 select
-  vtq_trx_id(@ts0) < @tx0 as A,
-  vtq_trx_id(@ts0, true) = @tx0 as B,
-  vtq_trx_id(@ts1) = @tx0 as C,
-  vtq_trx_id(@ts1, true) = @tx1 as D,
-  vtq_trx_id(@ts2) = @tx1 as E,
-  vtq_trx_id(@ts2, true) = @tx2 as F,
-  vtq_trx_id(@ts3) = @tx2 as G,
-  vtq_trx_id(@ts3, true) is null as H;
+  trt_trx_id(@ts0) < @tx0 as A,
+  trt_trx_id(@ts0, true) = @tx0 as B,
+  trt_trx_id(@ts1) = @tx0 as C,
+  trt_trx_id(@ts1, true) = @tx1 as D,
+  trt_trx_id(@ts2) = @tx1 as E,
+  trt_trx_id(@ts2, true) = @tx2 as F,
+  trt_trx_id(@ts3) = @tx2 as G,
+  trt_trx_id(@ts3, true) is null as H;
 
 select
-  vtq_commit_id(@ts0) < @tx0 as A,
-  vtq_commit_id(@ts0, true) = vtq_commit_id(null, @tx0) as B,
-  vtq_commit_id(@ts1) = vtq_commit_id(null, @tx0) as C,
-  vtq_commit_id(@ts1, true) = vtq_commit_id(null, @tx1) as D,
-  vtq_commit_id(@ts2) = vtq_commit_id(null, @tx1) as E,
-  vtq_commit_id(@ts2, true) = vtq_commit_id(null, @tx2) as F,
-  vtq_commit_id(@ts3) = vtq_commit_id(null, @tx2) as G,
-  vtq_commit_id(@ts3, true) is null as H;
+  trt_commit_id(@ts0) < @tx0 as A,
+  trt_commit_id(@ts0, true) = trt_commit_id(null, @tx0) as B,
+  trt_commit_id(@ts1) = trt_commit_id(null, @tx0) as C,
+  trt_commit_id(@ts1, true) = trt_commit_id(null, @tx1) as D,
+  trt_commit_id(@ts2) = trt_commit_id(null, @tx1) as E,
+  trt_commit_id(@ts2, true) = trt_commit_id(null, @tx2) as F,
+  trt_commit_id(@ts3) = trt_commit_id(null, @tx2) as G,
+  trt_commit_id(@ts3, true) is null as H;
 
 select
-  vtq_trx_sees(@tx1, @tx0) as A,
-  not vtq_trx_sees(@tx0, @tx1) as B,
-  vtq_trx_sees_eq(@tx1, @tx1) as C,
-  not vtq_trx_sees(@tx1, @tx1) as D,
-  vtq_trx_sees(@tx2, 0) as E,
-  vtq_trx_sees(-1, @tx2) as F;
+  trt_trx_sees(@tx1, @tx0) as A,
+  not trt_trx_sees(@tx0, @tx1) as B,
+  trt_trx_sees_eq(@tx1, @tx1) as C,
+  not trt_trx_sees(@tx1, @tx1) as D,
+  trt_trx_sees(@tx2, 0) as E,
+  trt_trx_sees(-1, @tx2) as F;
 
-select vtq_trx_sees(0, @tx2);
+select trt_trx_sees(0, @tx2);
 
-# VTQ_ISO_LEVEL #
+# TRT_ISO_LEVEL #
 
 set transaction isolation level read uncommitted;
 insert into t1 values ();
@@ -89,6 +89,6 @@ select isolation_level = 'REPEATABLE-READ' from mysql.transaction_registry where
 
 
 drop table t1;
-call verify_vtq;
+call verify_trt;
 
 -- source suite/versioning/common_finish.inc

--- a/mysql-test/suite/versioning/t/insert2.test
+++ b/mysql-test/suite/versioning/t/insert2.test
@@ -1,6 +1,6 @@
 --source include/have_innodb.inc
 
-# VTQ test
+# TRT test
 
 create table t1(
   x int unsigned,

--- a/mysql-test/suite/versioning/t/select.test
+++ b/mysql-test/suite/versioning/t/select.test
@@ -41,7 +41,7 @@ if ($MTR_COMBINATION_TRX_ID)
 {
 --disable_query_log
   set @x1= @t1;
-  select vtq_commit_ts(@x1) into @t1;
+  select trt_commit_ts(@x1) into @t1;
 --enable_query_log
 }
 
@@ -326,6 +326,6 @@ select f1 from t1 join t2 left join t3 left join t4 on f3 = f4 on f3 = f2;
 drop view v1;
 drop table t1, t2, t3, t4;
 
-call verify_vtq_dummy(34);
+call verify_trt_dummy(34);
 
 -- source suite/versioning/common_finish.inc

--- a/mysql-test/suite/versioning/t/select2.test
+++ b/mysql-test/suite/versioning/t/select2.test
@@ -31,7 +31,7 @@ insert into t1(x, y) values(3, 33);
 select sys_start from t1 where x = 3 and y = 33 into @t1;
 if($MTR_COMBINATION_TRX_ID) {
   set @x1= @t1;
-  select vtq_commit_ts(@x1) into @t1;
+  select trt_commit_ts(@x1) into @t1;
 }
 
 select x, y from t1;

--- a/mysql-test/suite/versioning/t/truncate.test
+++ b/mysql-test/suite/versioning/t/truncate.test
@@ -1,3 +1,4 @@
+--source suite/versioning/common.inc
 --source include/have_partition.inc
 --source suite/versioning/engines.inc
 
@@ -6,7 +7,13 @@ create table t (a int);
 delete history from t before system_time now();
 
 # TRUNCATE is not DELETE and trigger must not be called.
-create or replace table t (a int) with system versioning;
+--replace_result $sys_datatype_expl SYS_TYPE
+eval create or replace table t (
+  a int,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end))
+with system versioning;
 insert into t values (1);
 update t set a=2;
 set @test = 'correct';
@@ -16,7 +23,13 @@ delete history from t;
 select @test from t;
 drop table t;
 
-create table t (a int) with system versioning;
+--replace_result $sys_datatype_expl SYS_TYPE
+eval create or replace table t (
+  a int,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end))
+with system versioning;
 insert into t values (1), (2);
 update t set a=11 where a=1;
 --real_sleep 0.01
@@ -45,7 +58,6 @@ drop procedure truncate_sp;
 --echo # Truncate partitioned
 create or replace table t (a int)
 with system versioning
-engine myisam
 partition by system_time limit 1 (
     partition p0 history,
     partition p1 history,
@@ -57,7 +69,13 @@ delete history from t;
 select * from t for system_time all;
 
 --echo # VIEW
-create or replace table t (i int) with system versioning;
+--replace_result $sys_datatype_expl SYS_TYPE
+eval create or replace table t (
+  i int,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end))
+with system versioning;
 delete history from t;
 create or replace view v as select * from t;
 --error ER_IT_IS_A_VIEW
@@ -88,3 +106,6 @@ delete history from v before system_time now(6);
 unlock tables;
 drop view v;
 drop table t;
+
+drop database test;
+create database test;

--- a/plugin/versioning/versioning.cc
+++ b/plugin/versioning/versioning.cc
@@ -24,26 +24,26 @@
 #include "item.h"
 #include "vers_utils.h"
 
-/* System Versioning: VTQ_TRX_ID(), VTQ_COMMIT_ID(), VTQ_BEGIN_TS(), VTQ_COMMIT_TS(), VTQ_ISO_LEVEL() */
-template <TR_table::field_id_t VTQ_FIELD>
-class Create_func_vtq : public Create_native_func
+/* System Versioning: TRT_TRX_ID(), TRT_COMMIT_ID(), TRT_BEGIN_TS(), TRT_COMMIT_TS(), TRT_ISO_LEVEL() */
+template <TR_table::field_id_t TRT_FIELD>
+class Create_func_trt : public Create_native_func
 {
 public:
   virtual Item *create_native(THD *thd, LEX_CSTRING *name, List<Item> *item_list);
 
-  static Create_func_vtq<VTQ_FIELD> s_singleton;
+  static Create_func_trt<TRT_FIELD> s_singleton;
 
 protected:
-  Create_func_vtq<VTQ_FIELD>() {}
-  virtual ~Create_func_vtq<VTQ_FIELD>() {}
+  Create_func_trt<TRT_FIELD>() {}
+  virtual ~Create_func_trt<TRT_FIELD>() {}
 };
 
-template<TR_table::field_id_t VTQ_FIELD>
-Create_func_vtq<VTQ_FIELD> Create_func_vtq<VTQ_FIELD>::s_singleton;
+template<TR_table::field_id_t TRT_FIELD>
+Create_func_trt<TRT_FIELD> Create_func_trt<TRT_FIELD>::s_singleton;
 
-template <TR_table::field_id_t VTQ_FIELD>
+template <TR_table::field_id_t TRT_FIELD>
 Item*
-Create_func_vtq<VTQ_FIELD>::create_native(THD *thd, LEX_CSTRING *name,
+Create_func_trt<TRT_FIELD>::create_native(THD *thd, LEX_CSTRING *name,
   List<Item> *item_list)
 {
   Item *func= NULL;
@@ -56,16 +56,16 @@ Create_func_vtq<VTQ_FIELD>::create_native(THD *thd, LEX_CSTRING *name,
   case 1:
   {
     Item *param_1= item_list->pop();
-    switch (VTQ_FIELD)
+    switch (TRT_FIELD)
     {
     case TR_table::FLD_BEGIN_TS:
     case TR_table::FLD_COMMIT_TS:
-      func= new (thd->mem_root) Item_func_vtq_ts(thd, param_1, VTQ_FIELD);
+      func= new (thd->mem_root) Item_func_trt_ts(thd, param_1, TRT_FIELD);
       break;
     case TR_table::FLD_TRX_ID:
     case TR_table::FLD_COMMIT_ID:
     case TR_table::FLD_ISO_LEVEL:
-      func= new (thd->mem_root) Item_func_vtq_id(thd, param_1, VTQ_FIELD);
+      func= new (thd->mem_root) Item_func_trt_id(thd, param_1, TRT_FIELD);
       break;
     default:
       DBUG_ASSERT(0);
@@ -76,11 +76,11 @@ Create_func_vtq<VTQ_FIELD>::create_native(THD *thd, LEX_CSTRING *name,
   {
     Item *param_1= item_list->pop();
     Item *param_2= item_list->pop();
-    switch (VTQ_FIELD)
+    switch (TRT_FIELD)
     {
     case TR_table::FLD_TRX_ID:
     case TR_table::FLD_COMMIT_ID:
-      func= new (thd->mem_root) Item_func_vtq_id(thd, param_1, param_2, VTQ_FIELD);
+      func= new (thd->mem_root) Item_func_trt_id(thd, param_1, param_2, TRT_FIELD);
       break;
     default:
       goto error;
@@ -98,8 +98,8 @@ Create_func_vtq<VTQ_FIELD>::create_native(THD *thd, LEX_CSTRING *name,
   return func;
 };
 
-template <class Item_func_vtq_trx_seesX>
-class Create_func_vtq_trx_sees : public Create_native_func
+template <class Item_func_trt_trx_seesX>
+class Create_func_trt_trx_sees : public Create_native_func
 {
 public:
   virtual Item *create_native(THD *thd, LEX_CSTRING *name, List<Item> *item_list)
@@ -115,7 +115,7 @@ public:
     {
       Item *param_1= item_list->pop();
       Item *param_2= item_list->pop();
-      func= new (thd->mem_root) Item_func_vtq_trx_seesX(thd, param_1, param_2);
+      func= new (thd->mem_root) Item_func_trt_trx_seesX(thd, param_1, param_2);
       break;
     }
     default:
@@ -126,27 +126,27 @@ public:
     return func;
   }
 
-  static Create_func_vtq_trx_sees<Item_func_vtq_trx_seesX> s_singleton;
+  static Create_func_trt_trx_sees<Item_func_trt_trx_seesX> s_singleton;
 
 protected:
-  Create_func_vtq_trx_sees<Item_func_vtq_trx_seesX>() {}
-  virtual ~Create_func_vtq_trx_sees<Item_func_vtq_trx_seesX>() {}
+  Create_func_trt_trx_sees<Item_func_trt_trx_seesX>() {}
+  virtual ~Create_func_trt_trx_sees<Item_func_trt_trx_seesX>() {}
 };
 
 template<class X>
-Create_func_vtq_trx_sees<X> Create_func_vtq_trx_sees<X>::s_singleton;
+Create_func_trt_trx_sees<X> Create_func_trt_trx_sees<X>::s_singleton;
 
 #define BUILDER(F) & F::s_singleton
 
 static Native_func_registry func_array[] =
 {
-  { { C_STRING_WITH_LEN("VTQ_BEGIN_TS") }, BUILDER(Create_func_vtq<TR_table::FLD_BEGIN_TS>)},
-  { { C_STRING_WITH_LEN("VTQ_COMMIT_ID") }, BUILDER(Create_func_vtq<TR_table::FLD_COMMIT_ID>)},
-  { { C_STRING_WITH_LEN("VTQ_COMMIT_TS") }, BUILDER(Create_func_vtq<TR_table::FLD_COMMIT_TS>)},
-  { { C_STRING_WITH_LEN("VTQ_ISO_LEVEL") }, BUILDER(Create_func_vtq<TR_table::FLD_ISO_LEVEL>)},
-  { { C_STRING_WITH_LEN("VTQ_TRX_ID") }, BUILDER(Create_func_vtq<TR_table::FLD_TRX_ID>)},
-  { { C_STRING_WITH_LEN("VTQ_TRX_SEES") }, BUILDER(Create_func_vtq_trx_sees<Item_func_vtq_trx_sees>)},
-  { { C_STRING_WITH_LEN("VTQ_TRX_SEES_EQ") }, BUILDER(Create_func_vtq_trx_sees<Item_func_vtq_trx_sees_eq>)},
+  { { C_STRING_WITH_LEN("TRT_BEGIN_TS") }, BUILDER(Create_func_trt<TR_table::FLD_BEGIN_TS>)},
+  { { C_STRING_WITH_LEN("TRT_COMMIT_ID") }, BUILDER(Create_func_trt<TR_table::FLD_COMMIT_ID>)},
+  { { C_STRING_WITH_LEN("TRT_COMMIT_TS") }, BUILDER(Create_func_trt<TR_table::FLD_COMMIT_TS>)},
+  { { C_STRING_WITH_LEN("TRT_ISO_LEVEL") }, BUILDER(Create_func_trt<TR_table::FLD_ISO_LEVEL>)},
+  { { C_STRING_WITH_LEN("TRT_TRX_ID") }, BUILDER(Create_func_trt<TR_table::FLD_TRX_ID>)},
+  { { C_STRING_WITH_LEN("TRT_TRX_SEES") }, BUILDER(Create_func_trt_trx_sees<Item_func_trt_trx_sees>)},
+  { { C_STRING_WITH_LEN("TRT_TRX_SEES_EQ") }, BUILDER(Create_func_trt_trx_sees<Item_func_trt_trx_sees_eq>)},
   { {0, 0}, NULL}
 };
 

--- a/sql/item_vers.cc
+++ b/sql/item_vers.cc
@@ -123,7 +123,7 @@ Item_func_trt_id::get_by_commit_ts(MYSQL_TIME &commit_ts, bool backwards)
   TR_table trt(thd);
   null_value= !trt.query(commit_ts, backwards);
   if (null_value)
-    return 0;
+    return backwards ? ULONGLONG_MAX : 0;
 
   return trt[trt_field]->val_int();
 }

--- a/sql/item_vers.cc
+++ b/sql/item_vers.cc
@@ -26,9 +26,9 @@
 #include "tztime.h"
 #include "item.h"
 
-Item_func_vtq_ts::Item_func_vtq_ts(THD *thd, Item* a, TR_table::field_id_t _vtq_field) :
+Item_func_trt_ts::Item_func_trt_ts(THD *thd, Item* a, TR_table::field_id_t _trt_field) :
   Item_datetimefunc(thd, a),
-  vtq_field(_vtq_field)
+  trt_field(_trt_field)
 {
   decimals= 6;
   null_value= true;
@@ -37,7 +37,7 @@ Item_func_vtq_ts::Item_func_vtq_ts(THD *thd, Item* a, TR_table::field_id_t _vtq_
 
 
 bool
-Item_func_vtq_ts::get_date(MYSQL_TIME *res, ulonglong fuzzy_date)
+Item_func_trt_ts::get_date(MYSQL_TIME *res, ulonglong fuzzy_date)
 {
   THD *thd= current_thd; // can it differ from constructor's?
   DBUG_ASSERT(thd);
@@ -67,14 +67,14 @@ Item_func_vtq_ts::get_date(MYSQL_TIME *res, ulonglong fuzzy_date)
     return true;
   }
 
-  return trt[vtq_field]->get_date(res, fuzzy_date);
+  return trt[trt_field]->get_date(res, fuzzy_date);
 }
 
 
-Item_func_vtq_id::Item_func_vtq_id(THD *thd, Item* a, TR_table::field_id_t _vtq_field,
+Item_func_trt_id::Item_func_trt_id(THD *thd, Item* a, TR_table::field_id_t _trt_field,
                                    bool _backwards) :
   Item_longlong_func(thd, a),
-  vtq_field(_vtq_field),
+  trt_field(_trt_field),
   backwards(_backwards)
 {
   decimals= 0;
@@ -83,9 +83,9 @@ Item_func_vtq_id::Item_func_vtq_id(THD *thd, Item* a, TR_table::field_id_t _vtq_
   DBUG_ASSERT(arg_count == 1 && args[0]);
 }
 
-Item_func_vtq_id::Item_func_vtq_id(THD *thd, Item* a, Item* b, TR_table::field_id_t _vtq_field) :
+Item_func_trt_id::Item_func_trt_id(THD *thd, Item* a, Item* b, TR_table::field_id_t _trt_field) :
   Item_longlong_func(thd, a, b),
-  vtq_field(_vtq_field),
+  trt_field(_trt_field),
   backwards(false)
 {
   decimals= 0;
@@ -95,7 +95,7 @@ Item_func_vtq_id::Item_func_vtq_id(THD *thd, Item* a, Item* b, TR_table::field_i
 }
 
 longlong
-Item_func_vtq_id::get_by_trx_id(ulonglong trx_id)
+Item_func_trt_id::get_by_trx_id(ulonglong trx_id)
 {
   THD *thd= current_thd;
   DBUG_ASSERT(thd);
@@ -111,11 +111,11 @@ Item_func_vtq_id::get_by_trx_id(ulonglong trx_id)
   if (null_value)
     return 0;
 
-  return trt[vtq_field]->val_int();
+  return trt[trt_field]->val_int();
 }
 
 longlong
-Item_func_vtq_id::get_by_commit_ts(MYSQL_TIME &commit_ts, bool backwards)
+Item_func_trt_id::get_by_commit_ts(MYSQL_TIME &commit_ts, bool backwards)
 {
   THD *thd= current_thd;
   DBUG_ASSERT(thd);
@@ -125,15 +125,15 @@ Item_func_vtq_id::get_by_commit_ts(MYSQL_TIME &commit_ts, bool backwards)
   if (null_value)
     return 0;
 
-  return trt[vtq_field]->val_int();
+  return trt[trt_field]->val_int();
 }
 
 longlong
-Item_func_vtq_id::val_int()
+Item_func_trt_id::val_int()
 {
   if (args[0]->is_null())
   {
-    if (arg_count < 2 || vtq_field == TR_table::FLD_TRX_ID)
+    if (arg_count < 2 || trt_field == TR_table::FLD_TRX_ID)
     {
       null_value= true;
       return 0;
@@ -157,7 +157,7 @@ Item_func_vtq_id::val_int()
   }
 }
 
-Item_func_vtq_trx_sees::Item_func_vtq_trx_sees(THD *thd, Item* a, Item* b) :
+Item_func_trt_trx_sees::Item_func_trt_trx_sees(THD *thd, Item* a, Item* b) :
   Item_bool_func(thd, a, b),
   accept_eq(false)
 {
@@ -166,7 +166,7 @@ Item_func_vtq_trx_sees::Item_func_vtq_trx_sees(THD *thd, Item* a, Item* b) :
 }
 
 longlong
-Item_func_vtq_trx_sees::val_int()
+Item_func_trt_trx_sees::val_int()
 {
   THD *thd= current_thd;
   DBUG_ASSERT(thd);

--- a/sql/item_vers.h
+++ b/sql/item_vers.h
@@ -22,47 +22,47 @@
 #pragma interface			/* gcc class implementation */
 #endif
 
-class Item_func_vtq_ts: public Item_datetimefunc
+class Item_func_trt_ts: public Item_datetimefunc
 {
-  TR_table::field_id_t vtq_field;
+  TR_table::field_id_t trt_field;
 public:
-  Item_func_vtq_ts(THD *thd, Item* a, TR_table::field_id_t _vtq_field);
+  Item_func_trt_ts(THD *thd, Item* a, TR_table::field_id_t _trt_field);
   const char *func_name() const
   {
-    if (vtq_field == TR_table::FLD_BEGIN_TS)
+    if (trt_field == TR_table::FLD_BEGIN_TS)
     {
-      return "vtq_begin_ts";
+      return "trt_begin_ts";
     }
-    return "vtq_commit_ts";
+    return "trt_commit_ts";
   }
   bool get_date(MYSQL_TIME *res, ulonglong fuzzy_date);
   Item *get_copy(THD *thd)
-  { return get_item_copy<Item_func_vtq_ts>(thd, this); }
+  { return get_item_copy<Item_func_trt_ts>(thd, this); }
   void fix_length_and_dec() { fix_attributes_datetime(decimals); }
 };
 
-class Item_func_vtq_id : public Item_longlong_func
+class Item_func_trt_id : public Item_longlong_func
 {
-  TR_table::field_id_t vtq_field;
+  TR_table::field_id_t trt_field;
   bool backwards;
 
   longlong get_by_trx_id(ulonglong trx_id);
   longlong get_by_commit_ts(MYSQL_TIME &commit_ts, bool backwards);
 
 public:
-  Item_func_vtq_id(THD *thd, Item* a, TR_table::field_id_t _vtq_field, bool _backwards= false);
-  Item_func_vtq_id(THD *thd, Item* a, Item* b, TR_table::field_id_t _vtq_field);
+  Item_func_trt_id(THD *thd, Item* a, TR_table::field_id_t _trt_field, bool _backwards= false);
+  Item_func_trt_id(THD *thd, Item* a, Item* b, TR_table::field_id_t _trt_field);
 
   const char *func_name() const
   {
-    switch (vtq_field)
+    switch (trt_field)
     {
     case TR_table::FLD_TRX_ID:
-      return "vtq_trx_id";
+      return "trt_trx_id";
     case TR_table::FLD_COMMIT_ID:
-        return "vtq_commit_id";
+        return "trt_commit_id";
     case TR_table::FLD_ISO_LEVEL:
-      return "vtq_iso_level";
+      return "trt_iso_level";
     default:
       DBUG_ASSERT(0);
     }
@@ -77,37 +77,37 @@ public:
 
   longlong val_int();
   Item *get_copy(THD *thd)
-  { return get_item_copy<Item_func_vtq_id>(thd, this); }
+  { return get_item_copy<Item_func_trt_id>(thd, this); }
 };
 
-class Item_func_vtq_trx_sees : public Item_bool_func
+class Item_func_trt_trx_sees : public Item_bool_func
 {
 protected:
   bool accept_eq;
 
 public:
-  Item_func_vtq_trx_sees(THD *thd, Item* a, Item* b);
+  Item_func_trt_trx_sees(THD *thd, Item* a, Item* b);
   const char *func_name() const
   {
-    return "vtq_trx_sees";
+    return "trt_trx_sees";
   }
   longlong val_int();
   Item *get_copy(THD *thd)
-  { return get_item_copy<Item_func_vtq_trx_sees>(thd, this); }
+  { return get_item_copy<Item_func_trt_trx_sees>(thd, this); }
 };
 
-class Item_func_vtq_trx_sees_eq :
-  public Item_func_vtq_trx_sees
+class Item_func_trt_trx_sees_eq :
+  public Item_func_trt_trx_sees
 {
 public:
-  Item_func_vtq_trx_sees_eq(THD *thd, Item* a, Item* b) :
-    Item_func_vtq_trx_sees(thd, a, b)
+  Item_func_trt_trx_sees_eq(THD *thd, Item* a, Item* b) :
+    Item_func_trt_trx_sees(thd, a, b)
   {
     accept_eq= true;
   }
   const char *func_name() const
   {
-    return "vtq_trx_sees_eq";
+    return "trt_trx_sees_eq";
   }
 };
 

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -324,13 +324,6 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
     DBUG_ASSERT(!conds);
     conds= table_list->on_expr;
     table_list->on_expr= NULL;
-
-    // trx_sees() in InnoDB reads row_start
-    if (!table->versioned(VERS_TIMESTAMP))
-    {
-      DBUG_ASSERT(table_list->vers_conditions.type == SYSTEM_TIME_BEFORE);
-      bitmap_set_bit(table->read_set, table->vers_end_field()->field_index);
-    }
   }
 
   if (mysql_handle_list_of_derived(thd->lex, table_list, DT_MERGE_FOR_INSERT))

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -901,27 +901,27 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
         break;
       case SYSTEM_TIME_AS_OF:
         trx_id0= vers_conditions.start.unit == VERS_TIMESTAMP
-          ?  newx Item_func_vtq_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID)
+          ?  newx Item_func_trt_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID)
           : vers_conditions.start.item;
-        cond1= newx Item_func_vtq_trx_sees_eq(thd, trx_id0, row_start);
-        cond2= newx Item_func_vtq_trx_sees(thd, row_end, trx_id0);
+        cond1= newx Item_func_trt_trx_sees_eq(thd, trx_id0, row_start);
+        cond2= newx Item_func_trt_trx_sees(thd, row_end, trx_id0);
         break;
       case SYSTEM_TIME_FROM_TO:
       case SYSTEM_TIME_BETWEEN:
         trx_id0= vers_conditions.start.unit == VERS_TIMESTAMP
-          ? newx Item_func_vtq_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID, true)
+          ? newx Item_func_trt_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID, true)
           : vers_conditions.start.item;
         trx_id1= vers_conditions.end.unit == VERS_TIMESTAMP
-          ? newx Item_func_vtq_id(thd, vers_conditions.end.item, TR_table::FLD_TRX_ID, false)
+          ? newx Item_func_trt_id(thd, vers_conditions.end.item, TR_table::FLD_TRX_ID, false)
           : vers_conditions.end.item;
         cond1= vers_conditions.type == SYSTEM_TIME_FROM_TO
-          ? newx Item_func_vtq_trx_sees(thd, trx_id1, row_start)
-          : newx Item_func_vtq_trx_sees_eq(thd, trx_id1, row_start);
-        cond2= newx Item_func_vtq_trx_sees_eq(thd, row_end, trx_id0);
+          ? newx Item_func_trt_trx_sees(thd, trx_id1, row_start)
+          : newx Item_func_trt_trx_sees_eq(thd, trx_id1, row_start);
+        cond2= newx Item_func_trt_trx_sees_eq(thd, row_end, trx_id0);
         break;
       case SYSTEM_TIME_BEFORE:
         trx_id0= vers_conditions.start.unit == VERS_TIMESTAMP
-          ? newx Item_func_vtq_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID)
+          ? newx Item_func_trt_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID)
           : vers_conditions.start.item;
         cond1= newx Item_func_lt(thd, row_end, trx_id0);
         break;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -921,9 +921,9 @@ int SELECT_LEX::vers_setup_conds(THD *thd, TABLE_LIST *tables)
         break;
       case SYSTEM_TIME_BEFORE:
         trx_id0= vers_conditions.start.unit == VERS_TIMESTAMP
-          ? newx Item_func_trt_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID)
+          ? newx Item_func_trt_id(thd, vers_conditions.start.item, TR_table::FLD_TRX_ID, true)
           : vers_conditions.start.item;
-        cond1= newx Item_func_lt(thd, row_end, trx_id0);
+        cond1= newx Item_func_trt_trx_sees(thd, trx_id0, row_end);
         break;
       default:
         DBUG_ASSERT(0);


### PR DESCRIPTION
Depends on MDEV-15893 (#707).

This code is submitted under the BSD-new license.