### PR TITLE
MDEV-15794 Fix and re-enable test galera_var_retry_autocommit

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -27,7 +27,5 @@ galera_ist_mysqldump : MDEV-13549 Galera test failures
 galera_ssl_upgrade : MDEV-13549 Galera test failures
 galera.MW-329 : wsrep_local_replays not stable
 galera.MW-328A : have_deadlocks test not stable
-galera_var_retry_autocommit : MDEV-15794 Test failure on galera.galera_var_retry_autocommit
 galera_var_auto_inc_control_on : MDEV-15803 Test failure on galera.galera_var_auto_inc_control_on
 query_cache : MDEV-15805 Test failure on galera.query_cache
-

--- a/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
+++ b/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
@@ -1,32 +1,54 @@
-CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=InnoDB;
-CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW SET NEW.f2 = SLEEP(5);
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 SET SESSION wsrep_retry_autocommit = 0;
-INSERT INTO t1 (f1) VALUES (1),(2);;
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue';
+INSERT INTO t1 (f1) VALUES (2);
+SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
 TRUNCATE TABLE t1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
-SET SESSION wsrep_retry_autocommit = 1;
-INSERT INTO t1 (f1) VALUES (3),(4);;
-TRUNCATE TABLE t1;
-SELECT * FROM test.t1;
-f1	f2
-3	0
-4	0
-CREATE PROCEDURE repeated_truncate ()
-BEGIN
-DECLARE i INT;
-DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
-SET i = 0;
-WHILE i <= 1000 DO
-TRUNCATE TABLE t1;
-SET i = i + 1;
-END WHILE;
-END|
-CALL repeated_truncate();
-SET SESSION wsrep_retry_autocommit = 1;
-INSERT INTO t1 (f1) VALUES (5),(6);
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
-SET SESSION wsrep_retry_autocommit = 1024;
-INSERT INTO t1 (f1) VALUES (7),(8);;
-include/diff_servers.inc [servers=1 2]
+SELECT COUNT(*) = 0 FROM t1;
+COUNT(*) = 0
+1
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
-DROP PROCEDURE repeated_truncate;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET SESSION wsrep_retry_autocommit = 1;
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue';
+INSERT INTO t1 (f1) VALUES (2);
+SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+TRUNCATE TABLE t1;
+SELECT COUNT(*) = 1 FROM t1;
+COUNT(*) = 1
+1
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET SESSION wsrep_retry_autocommit = 1;
+SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue EXECUTE 2';
+INSERT INTO t1 VALUES (2);;
+SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+TRUNCATE TABLE t1;
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_retry_autocommit_reached';
+SELECT COUNT(*) = 0 FROM t1;
+COUNT(*) = 0
+1
+SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue WAIT_FOR before_rep';
+TRUNCATE TABLE t1;
+SELECT COUNT(*) = 0 FROM t1;
+COUNT(*) = 0
+1
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = NULL;
+DROP TABLE t1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET SESSION wsrep_retry_autocommit = 64;
+SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue EXECUTE 64';
+INSERT INTO t1 VALUES (2);
+SELECT COUNT(*) = 1 FROM t1;
+COUNT(*) = 1
+1
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = NULL;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
+++ b/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
@@ -1,98 +1,141 @@
 #
-# Test that the wsrep_retry_autocommit variable is respected. We use an INSERT that
-# proceeds very slowly due to extra SLEEP() in a trigger
+# Test that the wsrep_retry_autocommit variable is respected.
 #
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_debug_sync.inc
 
---connection node_1
-CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 INTEGER) ENGINE=InnoDB;
-CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW SET NEW.f2 = SLEEP(5);
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
 
 #
 # With wsrep_retry_autocommit = 0, error is certain
 #
 
 --connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
 SET SESSION wsrep_retry_autocommit = 0;
---send INSERT INTO t1 (f1) VALUES (1),(2);
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue';
+--send INSERT INTO t1 (f1) VALUES (2)
+
+--connection node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
 
 --connection node_2
---sleep 1
 TRUNCATE TABLE t1;
 
 --connection node_1
 --error ER_LOCK_DEADLOCK
 --reap
+SELECT COUNT(*) = 0 FROM t1;
+
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+
 
 #
 # With wsrep_retry_autocommit = 1, success against one TRUNCATE
 #
 
 --connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
 SET SESSION wsrep_retry_autocommit = 1;
---send INSERT INTO t1 (f1) VALUES (3),(4);
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue';
+--send INSERT INTO t1 (f1) VALUES (2)
+
+--connection node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
 
 --connection node_2
---sleep 1
 TRUNCATE TABLE t1;
 
 --connection node_1
---error 0
 --reap
-SELECT * FROM test.t1;
+SELECT COUNT(*) = 1 FROM t1;
 
-#
-# With wsrep_retry_autocommit = 1, failure against multiple TRUNCATEs
-#
-
---connection node_2
-DELIMITER |;
-CREATE PROCEDURE repeated_truncate ()
-BEGIN
-	DECLARE i INT;
-	DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
-
-	SET i = 0;
-        WHILE i <= 1000 DO
-		TRUNCATE TABLE t1;
-		SET i = i + 1;
-        END WHILE;
-END|
-DELIMITER ;|
-
-# Begin streaming TRUNCATEs
---let $truncate_connection_id = `SELECT CONNECTION_ID()`
---send CALL repeated_truncate()
-
---connection node_1
-SET SESSION wsrep_retry_autocommit = 1;
---sleep 1
---error ER_LOCK_DEADLOCK
-INSERT INTO t1 (f1) VALUES (5),(6);
-
-#
-# With wsrep_retry_autocommit = 1024, success against multiple TRUNCATEs
-#
-
---connection node_1
-SET SESSION wsrep_retry_autocommit = 1024;
---send INSERT INTO t1 (f1) VALUES (7),(8);
-
---sleep 6
-
-# Once he stream of TRUNCATEs is complete
---connection node_2
---reap
-
-# the INSERT will eventually be sucessfull
---connection node_1
---error 0
---reap
-
---let $diff_servers = 1 2
---source include/diff_servers.inc
-
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
-DROP PROCEDURE repeated_truncate;
+
+
+#
+# With wsrep_retry_autcommit = 1, failure against multiple TRUNCATEs
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
+SET SESSION wsrep_retry_autocommit = 1;
+SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue EXECUTE 2';
+
+--send INSERT INTO t1 VALUES (2);
+
+--connection node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+
+--connection node_2
+TRUNCATE TABLE t1;
+
+--connection node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_retry_autocommit_reached';
+SELECT COUNT(*) = 0 FROM t1;
+SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue WAIT_FOR before_rep';
+
+--connection node_2
+TRUNCATE TABLE t1;
+
+--connection node_1a
+SELECT COUNT(*) = 0 FROM t1;
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = NULL;
+DROP TABLE t1;
+
+
+#
+# With wsrep_retry_autocommit = 64, success against 64 TRUNCATEs
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
+SET SESSION wsrep_retry_autocommit = 64;
+SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
+SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue EXECUTE 64';
+
+--send INSERT INTO t1 VALUES (2)
+
+--disable_query_log
+--disable_result_log
+--let $count = 64
+while ($count)
+{
+  --connection node_1a
+  SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+
+  --connection node_2
+  TRUNCATE TABLE t1;
+
+  --connection node_1a
+  SET DEBUG_SYNC = 'now WAIT_FOR wsrep_retry_autocommit_reached';
+  SELECT COUNT(*) = 1 FROM t1;
+  SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue';
+
+  --dec $count
+}
+--enable_result_log
+--enable_query_log
+
+--connection node_1
+--reap
+SELECT COUNT(*) = 1 FROM t1;
+
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = NULL;
+DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7187,6 +7187,15 @@ static void wsrep_mysql_parse(THD *thd, char *rawbuf, uint length,
 	      com_statement_info[thd->get_command()].m_key);
       MYSQL_SET_STATEMENT_TEXT(thd->m_statement_psi, thd->query(),
 	                       thd->query_length());
+
+      DBUG_EXECUTE_IF("sync.wsrep_retry_autocommit",
+                      {
+                        const char act[]=
+                          "now "
+                          "SIGNAL wsrep_retry_autocommit_reached "
+                          "WAIT_FOR wsrep_retry_autocommit_continue";
+                        DBUG_ASSERT(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+                      });
     }
     mysql_parse(thd, rawbuf, length, parser_state);
 


### PR DESCRIPTION
The test was not deterministic and would occasionally fail, due to the
use of `sleep`.
This patch is a complete rewrite of the test using proper sync points.