### PR TITLE
Save / restore auto_increment_offset in test galera_gcs_fragment

### DIFF
--- a/mysql-test/suite/galera/t/galera_gcs_fragment.test
+++ b/mysql-test/suite/galera/t/galera_gcs_fragment.test
@@ -3,6 +3,11 @@
 --source include/have_innodb.inc
 --source suite/galera/include/galera_have_debug_sync.inc
 
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source include/auto_increment_offset_save.inc
+
 # Prepare table
 CREATE TABLE t1 (f1 INT PRIMARY KEY, f2 TEXT);
 
@@ -65,3 +70,5 @@ SELECT * FROM t1;
 --connection node_1
 
 DROP TABLE t1;
+
+--source include/auto_increment_offset_restore.inc


### PR DESCRIPTION
Test galera_gcs_fragment performs cluster reconfiguration, so
`auto_increment_offset` may change, and check test case at the
end of test fails.