### PR TITLE
MDEV-12645: mysql_install_db --no-test (postfix)

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -350,7 +350,7 @@ create_system_tables="$srcpkgdatadir/mysql_system_tables.sql"
 create_system_tables2="$srcpkgdatadir/mysql_performance_tables.sql"
 fill_system_tables="$srcpkgdatadir/mysql_system_tables_data.sql"
 maria_add_gis_sp="$buildpkgdatadir/maria_add_gis_sp_bootstrap.sql"
-mysql_test_db="$buildpkgdatadir/mysql_test_db.sql"
+mysql_test_db="$srcpkgdatadir/mysql_test_db.sql"
 
 for f in "$fill_help_tables" "$create_system_tables" "$create_system_tables2" "$fill_system_tables" "$maria_add_gis_sp" "$mysql_test_db"
 do


### PR DESCRIPTION
mysql_test_db.sql is in the srcdir

Otherwise out of tree build:
<pre>
build-mariadb-server-10.3]$ scripts/mysql_install_db --datadir=/tmp/mysqldatadir-auth-dyn --plugin-dir=mysql-test/var/plugins/  --auth-root-socket-user=dan --auth-root-authentication-method=socket --builddir=.  --srcdir=../mariadb-server-10.3

FATAL ERROR: Could not find ./scripts/mysql_test_db.sql
</pre>

I submit this under the MCA.

attn: @svoj 