### PR TITLE
Ignore .cbp QtCreator project files and macOS .DS_Store Finder junk.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,5 +237,8 @@ storage/mroonga/vendor/groonga/src/groonga
 storage/mroonga/vendor/groonga/src/groonga-benchmark
 storage/mroonga/vendor/groonga/src/suggest/groonga-suggest-create-dataset
 
+# macOS garbage
+.DS_Store
+
 # QtCreator && CodeBlocks
 *.cbp

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,6 @@ storage/mroonga/vendor/groonga/src/grnslap
 storage/mroonga/vendor/groonga/src/groonga
 storage/mroonga/vendor/groonga/src/groonga-benchmark
 storage/mroonga/vendor/groonga/src/suggest/groonga-suggest-create-dataset
+
+# QtCreator && CodeBlocks
+*.cbp


### PR DESCRIPTION
I'm using the CMake project import in QtCreator IDE to browse the source. This import generates CodeBlocks .cbp files.