### PR TITLE
sp_cache_package_routine: fix compile warning

### DIFF
--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -2831,7 +2831,7 @@ Sp_handler::sp_cache_package_routine(THD *thd,
     sp_package *pkg= ph ? ph->get_package() : NULL;
     LEX_CSTRING tmp= name->m_name;
     const char *dot= strrchr(tmp.str, '.');
-    size_t prefix_length= dot ? dot - tmp.str + 1 : NULL;
+    size_t prefix_length= dot ? dot - tmp.str + 1 : 0;
     tmp.str+= prefix_length;
     tmp.length-= prefix_length;
     LEX *rlex= pkg ? pkg->m_routine_implementations.find(tmp, type()) : NULL;


### PR DESCRIPTION
(clang-3.8)
sql/sp.cc:2834:53: warning: implicit conversion of NULL constant to 'size_t' (aka 'unsigned long') [-Wnull-conversion]
    size_t prefix_length= dot ? dot - tmp.str + 1 : NULL;
           ~~~~~~~~~~~~~                            ^~~~
                                                    0

introduced 583eb96c2492

I submit this under the MCA.