### PR TITLE
Fix building mroonga with system lz4

### DIFF
--- a/storage/mroonga/vendor/groonga/CMakeLists.txt
+++ b/storage/mroonga/vendor/groonga/CMakeLists.txt
@@ -361,10 +361,7 @@ if(NOT ${GRN_WITH_LZ4} STREQUAL "no")
       pkg_check_modules(LIBLZ4 liblz4)
     endif()
     if(LIBLZ4_FOUND)
-      find_library(LZ4_LIBS
-	NAMES ${LIBLZ4_LIBRARIES}
-	PATHS ${LIBLZ4_LIBRARY_DIRS}
-	NO_DEFAULT_PATH)
+      set(LZ4_LIBS ${LZ4_LIBRARY})
       set(GRN_WITH_LZ4 TRUE)
     else()
       if(${GRN_WITH_LZ4} STREQUAL "yes")


### PR DESCRIPTION
LIBLZ4_LIBRARIES and LIBLZ4_LIBRARY_DIRS aren't defined anywhere,
which leads to LZ4_LIBS being set to NOT_FOUND, which aborts cmake
with an error.

Instead set LZ4_LIBS to the value of LZ4_LIBRARY, which comes from
FindLZ4.cmake.