### PR TITLE
MDEV-16075: Workaround to run MTR test suite for make test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,10 @@ INCLUDE(maintainer)
 
 IF(WITH_UNIT_TESTS)
  ENABLE_TESTING()
+ # This is the only instance where ADD_TEST should be used,
+ # to make sure that make test will run MTR,
+ # use MY_ADD_TEST macro to add other tests
+ ADD_TEST(NAME MTR COMMAND ./mysql-test-run WORKING_DIRECTORY "mysql-test")
  ADD_SUBDIRECTORY(unittest/mytap)
  ADD_SUBDIRECTORY(unittest/strings)
  ADD_SUBDIRECTORY(unittest/examples)

--- a/cmake/ctest.cmake
+++ b/cmake/ctest.cmake
@@ -2,7 +2,7 @@
 INCLUDE(${MYSQL_CMAKE_SCRIPT_DIR}/cmake_parse_arguments.cmake)
 
 MACRO(MY_ADD_TEST name)
-  ADD_TEST(${name} ${name}-t)
+  ADD_TEST(NAME ${name} COMMAND ${name}-t CONFIGURATIONS default_ignore)
 ENDMACRO()
 
 MACRO (MY_ADD_TESTS)

--- a/mysql-test/suite/unit/suite.pm
+++ b/mysql-test/suite/unit/suite.pm
@@ -31,7 +31,7 @@ sub start_test {
   return "Not run for embedded server" if $::opt_embedded_server;
   return "Not configured to run ctest" unless -f "../CTestTestfile.cmake";
   my ($ctest_vs)= $opt_vs_config ? "--build-config $opt_vs_config" : "";
-  my (@ctest_list)= `cd .. && ctest $opt_vs_config --show-only --verbose`;
+  my (@ctest_list)= `cd .. && ctest $opt_vs_config -E MTR -C default_ignore --show-only --verbose`;
   return "No ctest" if $?;
 
   my ($command, %tests);

--- a/unittest/sql/CMakeLists.txt
+++ b/unittest/sql/CMakeLists.txt
@@ -26,4 +26,4 @@ ELSE()
 ENDIF()
 
 TARGET_LINK_LIBRARIES(explain_filename-t sql mytap)
-ADD_TEST(explain_filename explain_filename-t)
+MY_ADD_TEST(explain_filename explain_filename-t)


### PR DESCRIPTION
Assign all tests added via MY_ADD_TEST to a bogus default_ignore target,
so that they are not ran by default when doing bare make test. Add default
test named MTR that calls mysql-test-run suite, which is now the single
test run by make test.

In consequence, modified unit/suite.pm to exclude the MTR test and run the
real ctests flagged for default_ignore target, thus no circular
loop.