### PR TITLE
MDEV-15778: 10.3 macOS build fixes

### DIFF
--- a/storage/innobase/include/sync0policy.h
+++ b/storage/innobase/include/sync0policy.h
@@ -50,7 +50,7 @@ public:
 			m_mutex(),
 			m_filename(),
 			m_line(),
-			m_thread_id(os_thread_id_t(ULINT_UNDEFINED))
+			m_thread_id(ULINT_UNDEFINED)
 		{
 			/* No op */
 		}
@@ -76,7 +76,7 @@ public:
 		{
 			m_mutex = mutex;
 
-			my_atomic_storelint(&m_thread_id, os_thread_get_curr_id());
+			my_atomic_storelint(&m_thread_id, reinterpret_cast<ulint>(os_thread_get_curr_id()));
 
 			m_filename = filename;
 

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -210,7 +210,7 @@ MYSQL_ADD_EXECUTABLE(sst_dump rocksdb/tools/sst_dump.cc COMPONENT rocksdb-engine
 TARGET_LINK_LIBRARIES(sst_dump rocksdblib)
 
 MYSQL_ADD_EXECUTABLE(mysql_ldb tools/mysql_ldb.cc COMPONENT rocksdb-engine)
-TARGET_LINK_LIBRARIES(mysql_ldb rocksdb_tools rocksdb_aux_lib)
+TARGET_LINK_LIBRARIES(mysql_ldb rocksdb_tools rocksdb_aux_lib dbug)
 
 INSTALL_SCRIPT(myrocks_hotbackup COMPONENT rocksdb-engine)
 


### PR DESCRIPTION
In addition to fixes from PR #752, issues from MDEV-15778 affecting only >=10.3, split from original PR#691. These changes enable a clean default options build of 10.0 on a bare macOS 10.13 system with only openssl extra installed:

cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/ -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib/libssl.a -DCMAKE_BUILD_TYPE=Debug
I.E. not excluding TokuDB.