### PR TITLE
MDEV-16153 Server crashes in Apc_target::disable, ASAN heap-use-after-free in Explain_query::~Explain_query upon/after EXECUTE IMMEDIATE

### DIFF
--- a/mysql-test/suite/versioning/r/select.result
+++ b/mysql-test/suite/versioning/r/select.result
@@ -538,6 +538,13 @@ a
 select * from t1 for system_time from @t2 to @t1;
 a
 drop table t1;
+#
+# MDEV-16153 Server crashes in Apc_target::disable, ASAN heap-use-after-free in Explain_query::~Explain_query upon/after EXECUTE IMMEDIATE
+#
+create or replace table t1 (a int) with system versioning;
+execute immediate "select * from t1 where exists (select 1)";
+a
+drop table t1;
 call verify_trt_dummy(34);
 No	A	B	C	D
 1	1	1	1	1

--- a/mysql-test/suite/versioning/t/select.test
+++ b/mysql-test/suite/versioning/t/select.test
@@ -348,6 +348,14 @@ select * from t1 for system_time from @t1 to @t2;
 select * from t1 for system_time from @t2 to @t1;
 drop table t1;
 
+--echo #
+--echo # MDEV-16153 Server crashes in Apc_target::disable, ASAN heap-use-after-free in Explain_query::~Explain_query upon/after EXECUTE IMMEDIATE
+--echo #
+create or replace table t1 (a int) with system versioning;
+execute immediate "select * from t1 where exists (select 1)";
+drop table t1;
+
+
 call verify_trt_dummy(34);
 
 -- source suite/versioning/common_finish.inc

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2513,6 +2513,9 @@ public:
   int binlog_flush_pending_rows_event(bool stmt_end, bool is_transactional);
   int binlog_remove_pending_rows_event(bool clear_maps, bool is_transactional);
 
+  void create_explain_query();
+  void create_explain_query_if_not_exists();
+
   /**
     Determine the binlog format of the current statement.
 

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -299,7 +299,7 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
   query_plan.index= MAX_KEY;
   query_plan.using_filesort= FALSE;
 
-  create_explain_query(thd->lex, thd->mem_root);
+  thd->create_explain_query();
   if (open_and_lock_tables(thd, table_list, TRUE, 0))
     DBUG_RETURN(TRUE);
 

--- a/sql/sql_explain.cc
+++ b/sql/sql_explain.cc
@@ -2410,21 +2410,20 @@ void delete_explain_query(LEX *lex)
 }
 
 
-void create_explain_query(LEX *lex, MEM_ROOT *mem_root)
+void THD::create_explain_query()
 {
   DBUG_ASSERT(!lex->explain);
-  DBUG_ENTER("create_explain_query");
+  DBUG_ENTER("THD::create_explain_query");
 
-  lex->explain= new (mem_root) Explain_query(lex->thd, mem_root);
-  DBUG_ASSERT(mem_root == current_thd->mem_root);
+  lex->explain= new (&main_mem_root) Explain_query(this, &main_mem_root);
 
   DBUG_VOID_RETURN;
 }
 
-void create_explain_query_if_not_exists(LEX *lex, MEM_ROOT *mem_root)
+void THD::create_explain_query_if_not_exists()
 {
   if (!lex->explain)
-    create_explain_query(lex, mem_root);
+    create_explain_query();
 }
 
 

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -728,7 +728,7 @@ bool mysql_insert(THD *thd,TABLE_LIST *table_list,
   Item *unused_conds= 0;
   DBUG_ENTER("mysql_insert");
 
-  create_explain_query(thd->lex, thd->mem_root);
+  thd->create_explain_query();
   /*
     Upgrade lock type if the requested lock is incompatible with
     the current connection mode or table operation.

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -736,8 +736,6 @@ class Procedure;
 class Explain_query;
 
 void delete_explain_query(LEX *lex);
-void create_explain_query(LEX *lex, MEM_ROOT *mem_root);
-void create_explain_query_if_not_exists(LEX *lex, MEM_ROOT *mem_root);
 bool print_explain_for_slow_log(LEX *lex, THD *thd, String *str);
 
 class st_select_lex_unit: public st_select_lex_node {

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -1392,7 +1392,7 @@ err:
 
 bool JOIN::build_explain()
 {
-  create_explain_query_if_not_exists(thd->lex, thd->mem_root);
+  thd->create_explain_query_if_not_exists();
   have_query_plan= QEP_AVAILABLE;
   if (save_explain_data(thd->lex->explain, false /* can overwrite */,
                         need_tmp,

--- a/sql/sql_tvc.cc
+++ b/sql/sql_tvc.cc
@@ -320,7 +320,7 @@ int table_value_constr::save_explain_data_intern(THD *thd,
 
 bool table_value_constr::optimize(THD *thd)
 {
-  create_explain_query_if_not_exists(thd->lex, thd->mem_root);
+  thd->create_explain_query_if_not_exists();
   have_query_plan= QEP_AVAILABLE;
 
   if (select_lex->select_number != UINT_MAX &&

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -1358,7 +1358,7 @@ bool st_select_lex_unit::exec()
   
   saved_error= optimize();
   
-  create_explain_query_if_not_exists(thd->lex, thd->mem_root);
+  thd->create_explain_query_if_not_exists();
 
   if (!saved_error && !was_executed)
     save_union_explain(thd->lex->explain);
@@ -1659,7 +1659,7 @@ bool st_select_lex_unit::exec_recursive()
   DBUG_ENTER("st_select_lex_unit::exec_recursive");
 
   executed= 1;
-  create_explain_query_if_not_exists(thd->lex, thd->mem_root);
+  thd->create_explain_query_if_not_exists();
   if (!was_executed)
     save_union_explain(thd->lex->explain);
 

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -334,7 +334,7 @@ int mysql_update(THD *thd,
 
   DBUG_ENTER("mysql_update");
 
-  create_explain_query(thd->lex, thd->mem_root);
+  thd->create_explain_query();
   if (open_tables(thd, &table_list, &table_count, 0))
     DBUG_RETURN(1);
 


### PR DESCRIPTION
Allocate Explain_query always on some THD::main_mem_root.
It should never be allocated on e.g. SP arena as it should be
accessible outside of SP.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.