### PR TITLE
MDEV-16296 - safemalloc: warn, flush after fprintf

### DIFF
--- a/mysys/safemalloc.c
+++ b/mysys/safemalloc.c
@@ -282,8 +282,8 @@ static void warn(const char *format,...)
   va_list args;
   DBUG_PRINT("error", ("%s", format));
   va_start(args,format);
-  fflush(stderr);
   vfprintf(stderr, format, args);
+  fflush(stderr);
   va_end(args);
 
 #ifdef HAVE_BACKTRACE


### PR DESCRIPTION
Not sure why this was added (94d722b6a43b86ee760f07915921cf58f9869a5d) however flushes normally happen after fprintf. Thought stderr was unbuffered so it wasn't needed. I assuming its to flush it out before a slow backtrace.

I submit this under the MCA.