### PR TITLE
MDEV-15578: MyRocks: support zstandard compression where the distro a…

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -73,6 +73,15 @@ then
   sed '/mariadb-service-convert/d' -i debian/mariadb-server-10.3.install
 fi
 
+# If libzstd-dev is not available (before Debian Stretch and Ubuntu Xenial)
+# remove the dependency from server and rocksdb so it can build properly
+if ! apt-cache madison libzstd-dev | grep 'libzstd-dev' >/dev/null 2>&1
+then
+  sed '/libzstd-dev/d' -i debian/control
+  sed '/libzstd1/d' -i debian/control
+fi
+
+
 # Convert gcc version to numberical value. Format is Mmmpp where M is Major
 # version, mm is minor version and p is patch.
 # -dumpfullversion & -dumpversion to make it uniform across old and new (>=7)

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Build-Depends: bison,
                libssl-dev | libssl1.0-dev,
                libsystemd-dev,
                libxml2-dev,
+               libzstd-dev,
                lsb-release,
                perl (>= 5.6.0),
                po-debconf,
@@ -536,6 +537,7 @@ Description: Connect storage engine for MariaDB
 Package: mariadb-plugin-rocksdb
 Architecture: amd64 arm64 mips64el ppc64el
 Depends: mariadb-server-10.3 (= ${binary:Version}),
+         libzstd1,
          ${misc:Depends},
          ${shlibs:Depends}
 Breaks: mariadb-rocksdb-engine-10.2,

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -231,6 +231,13 @@ IF(MSVC)
   ENDIF()
 ENDIF()
 
+# Enable ZSTD if available. Upstream rocksdb cmake will use WITH_ZSTD and set
+# defines within their code.
+FIND_PACKAGE(zstd)
+IF (ZSTD_FOUND)
+  SET(WITH_ZSTD ON)
+ENDIF()
+
 IF(GIT_EXECUTABLE)
   EXECUTE_PROCESS(
     COMMAND ${GIT_EXECUTABLE} rev-parse HEAD


### PR DESCRIPTION
…llows it

Add libzstd-dev as a build dependency to the server and libzstd1 as a
runtime dependency for rocksdb. libzstd is practially a mandatory
compression library to ensure adequate performance for RocksDB.