### PR TITLE
MDEV-15578 - travis: add zstd for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ addons:
 before_install:
   - if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then
       brew update;
-      brew install gnutls lz4 lzo xz snappy ccache jemalloc curl ossp-uuid pcre;
+      brew install gnutls lz4 lzo xz snappy ccache jemalloc curl ossp-uuid pcre zstd;
       brew link ccache;
     fi
 


### PR DESCRIPTION
rocksdb used zstd so lets install it for the osx test.

I submit this under the MCA.