### PR TITLE
MDEV-15778: On macOS pthread_t is opaque, requires explicit cast

### DIFF
--- a/storage/innobase/include/sync0policy.h
+++ b/storage/innobase/include/sync0policy.h
@@ -76,8 +76,13 @@ public:
 		{
 			m_mutex = mutex;
 
+#if defined(__APPLE__) && defined(__MACH__)
 			my_atomic_storelint(&m_thread_id,
-					    ulint(os_thread_get_curr_id()));
+					    reinterpret_cast<ulint>(os_thread_get_curr_id()));
+#else
+			my_atomic_storelint(&m_thread_id,
+					    os_thread_get_curr_id());
+#endif
 
 			m_filename = filename;
 


### PR DESCRIPTION
On macOS pthread id is a pointer to struct _opaque_pthread_t type,
requires explicit cast to ulint which in turn is size_t;
Was failing with Clang 9.1.0 Debug build on macOS 10.13.4:

sync0policy.h:53:4: error: cannot initialize a member subobject of type 'ulint'
(aka 'unsigned long') with an rvalue of type 'os_thread_id_t' (aka '_opaque_pthread_t *')
m_thread_id(os_thread_id_t(ULINT_UNDEFINED))
                        ^           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sync0policy.h:79:4: error: cannot initialize a parameter of type 'int64' (aka 'long long') with
an rvalue of type 'os_thread_id_t' (aka '_opaque_pthread_t *')
my_atomic_storelint(&m_thread_id, os_thread_get_curr_id());