### PR TITLE
MDEV-15869 Mariabackup is lacking some dependencies declaration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -449,7 +449,7 @@ Description: GSSAPI authentication plugin for MariaDB client
 Package: mariadb-backup-10.1
 Section: database
 Architecture: any
-Depends: libarchive12 | libarchive13,
+Depends: mariadb-client-core-10.1 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Backup tool for MariaDB server

--- a/debian/control
+++ b/debian/control
@@ -449,5 +449,7 @@ Description: GSSAPI authentication plugin for MariaDB client
 Package: mariadb-backup-10.1
 Section: database
 Architecture: any
-Depends: libarchive12 | libarchive13
+Depends: libarchive12 | libarchive13,
+         ${misc:Depends},
+         ${shlibs:Depends}
 Description: Backup tool for MariaDB server


### PR DESCRIPTION
Hi,
adding missing dependencies resolve the problem and `mariabackup` can be installed and run without problem:
https://jira.mariadb.org/browse/MDEV-15869