### PR TITLE
fix gcc row0trunc compilation error aarch64

### DIFF
--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -179,6 +179,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
       mtr/mtr0mtr.cc
       row/row0merge.cc
       row/row0mysql.cc
+      row/row0trunc.cc
       srv/srv0srv.cc
       COMPILE_FLAGS "-O0"
       )


### PR DESCRIPTION
Making this change to fix the build error on aarch64 platform 

Issue exists  on : 
QDF2400 ( aarch64 platform )
GCC < = 5.3.0 
Linux CentOS 7 

commit 745d0f872dc825a205c2b432621b3d3623a8d13a
Author: Ashutosh Parida <aparida.qdt@qualcommdatacenter.com>
