### PR TITLE
MDEV-16318 - mysqld_safe: use sh not bash

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Copyright Abandoned 1996 TCX DataKonsult AB & Monty Program KB & Detron HB
 # This file is public domain and comes with NO WARRANTY of any kind
 #


### PR DESCRIPTION
c902d5a4ded2a492eb47379910111717dbded2d3 changed this to bash.
This isn't appropriate as mysqld_safe is used by FreeBSD where there is no bash by default.

The original reason to use bash seems related to MDEV-3279 which
was a dash bug fixed in 2009 - https://git.kernel.org/pub/scm/utils/dash/dash.git/commit/?id=3800d4934391b144fd261a7957aea72ced7d47ea

Working around 9 year old fixed bugs shouldn't be done without considerations of other users. Debian/Ubuntu are using systemd now so the mysqld_safe implementation isn't as critical to them (right?).

Like 64094e12c0e265e4e41ff1d780598ba945344dc6, some actual analysis was done in MDEV-14900 that could of been used instead of "validity of this has thus been vetted in production" (or more correctly, "as no-one from the Debian community has complained so it must be right for everone").

I submit this two character deletion under the MCA.