### PR TITLE
MDEV-16210 FK constraints on versioned tables use historical rows, which may cause constraint violation

### DIFF
--- a/mysql-test/suite/versioning/key_type.combinations
+++ b/mysql-test/suite/versioning/key_type.combinations
@@ -1,2 +1,3 @@
 [unique]
 [pk]
+[sec]

--- a/mysql-test/suite/versioning/key_type.inc
+++ b/mysql-test/suite/versioning/key_type.inc
@@ -1,23 +1,14 @@
 --disable_query_log
 if ($MTR_COMBINATION_UNIQUE)
 {
-    set @KEY_TYPE= 'unique';
+    let $KEY_TYPE= unique;
 }
 if ($MTR_COMBINATION_PK)
 {
-    set @KEY_TYPE= 'primary key';
+    let $KEY_TYPE= primary key;
 }
-
-delimiter ~~;
-create procedure create_table(name varchar(255), cols varchar(255))
-begin
-  if (cols is null or cols = '') then
-    set cols= '';
-  else
-    set cols= concat(', ', cols);
-  end if;
-  set @str= concat('create or replace table ', name, '(id int ', @KEY_TYPE, cols, ') with system versioning');
-  prepare stmt from @str; execute stmt; drop prepare stmt;
-end~~
-delimiter ;~~
+if ($MTR_COMBINATION_SEC)
+{
+    let $KEY_TYPE= key;
+}
 --enable_query_log

--- a/mysql-test/suite/versioning/r/foreign.result
+++ b/mysql-test/suite/versioning/r/foreign.result
@@ -2,7 +2,8 @@
 # Test RESTRICT #
 #################
 create table parent(
-id int unique key
+id int,
+KEY_TYPE (id)
 ) engine innodb;
 create table child(
 parent_id int,
@@ -35,7 +36,8 @@ drop table parent;
 # Test when clustered index is a foreign key #
 ##############################################
 create table parent(
-id int(10) unsigned unique key
+id int(10) unsigned,
+KEY_TYPE (id)
 ) engine innodb;
 create table child(
 parent_id int(10) unsigned primary key,
@@ -54,7 +56,8 @@ drop table parent;
 # Test CASCADE #
 ################
 create table parent(
-id int unique key
+id int,
+KEY_TYPE (id)
 ) engine innodb;
 create table child(
 parent_id int,
@@ -87,7 +90,8 @@ parent_id
 drop table child;
 drop table parent;
 create or replace table parent (
-id int primary key,
+id int,
+KEY_TYPE(id),
 sys_start SYS_DATATYPE as row start invisible,
 sys_end SYS_DATATYPE as row end invisible,
 period for system_time(sys_start, sys_end)
@@ -110,7 +114,8 @@ x	parent_id
 drop table child;
 drop table parent;
 create or replace table parent (
-id int primary key
+id int,
+KEY_TYPE(id)
 )
 engine innodb;
 create or replace table child (
@@ -138,8 +143,9 @@ drop table parent;
 #################
 # Test SET NULL #
 #################
-create or replace table parent(
-id int unique key
+create table parent(
+id int,
+KEY_TYPE (id)
 ) engine innodb;
 create or replace table child(
 parent_id int,
@@ -183,7 +189,8 @@ drop table parent;
 # Parent table is foreign #
 ###########################
 create or replace table parent(
-id int unique key,
+id int,
+KEY_TYPE (id),
 sys_start SYS_DATATYPE as row start invisible,
 sys_end SYS_DATATYPE as row end invisible,
 period for system_time(sys_start, sys_end)
@@ -214,7 +221,8 @@ drop table parent;
 # crash on DELETE #
 ###################
 create or replace table a (
-cola int(10) primary key,
+cola int(10),
+KEY_TYPE (cola),
 v_cola int(10) as (cola mod 10) virtual,
 sys_start SYS_DATATYPE as row start invisible,
 sys_end SYS_DATATYPE as row end invisible,

--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -1,4 +1,11 @@
-call create_table('t', 'x int');
+create or replace table t(
+id int,
+KEY_TYPE(id),
+x int,
+row_start SYS_DATATYPE as row start invisible,
+row_end SYS_DATATYPE as row end invisible,
+period for system_time(row_start, row_end)
+) with system versioning;
 insert t values (1, 2);
 replace t values (1, 3);
 select *, row_end>TIMESTAMP'2038-01-01 00:00:00' as current from t for system_time all

--- a/mysql-test/suite/versioning/t/engines.combinations
+++ b/mysql-test/suite/versioning/t/engines.combinations
@@ -1,8 +1,0 @@
-[timestamp]
-default-storage-engine=innodb
-
-[trx_id]
-default-storage-engine=innodb
-
-[myisam]
-default-storage-engine=myisam

--- a/mysql-test/suite/versioning/t/foreign.test
+++ b/mysql-test/suite/versioning/t/foreign.test
@@ -1,11 +1,15 @@
 --source suite/versioning/common.inc
 
+let $KEY_TYPE= primary key;
+
 --echo #################
 --echo # Test RESTRICT #
 --echo #################
 
-create table parent(
-  id int unique key
+--replace_result "$KEY_TYPE" KEY_TYPE
+eval create table parent(
+  id int,
+  $KEY_TYPE (id)
 ) engine innodb;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE
@@ -42,8 +46,10 @@ drop table parent;
 --echo # Test when clustered index is a foreign key #
 --echo ##############################################
 
-create table parent(
-  id int(10) unsigned unique key
+--replace_result "$KEY_TYPE" KEY_TYPE
+eval create table parent(
+  id int(10) unsigned,
+  $KEY_TYPE (id)
 ) engine innodb;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE
@@ -68,8 +74,10 @@ drop table parent;
 --echo # Test CASCADE #
 --echo ################
 
-create table parent(
-  id int unique key
+--replace_result "$KEY_TYPE" KEY_TYPE
+eval create table parent(
+  id int,
+  $KEY_TYPE (id)
 ) engine innodb;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE
@@ -99,9 +107,10 @@ select * from child for system_time all;
 drop table child;
 drop table parent;
 
---replace_result $sys_datatype_expl SYS_DATATYPE
+--replace_result $sys_datatype_expl SYS_DATATYPE "$KEY_TYPE" KEY_TYPE
 eval create or replace table parent (
-  id int primary key,
+  id int,
+  $KEY_TYPE(id),
   sys_start $sys_datatype_expl as row start invisible,
   sys_end $sys_datatype_expl as row end invisible,
   period for system_time(sys_start, sys_end)
@@ -126,8 +135,10 @@ select * from child;
 drop table child;
 drop table parent;
 
-create or replace table parent (
-  id int primary key
+--replace_result "$KEY_TYPE" KEY_TYPE
+eval create or replace table parent (
+  id int,
+  $KEY_TYPE(id)
 )
 engine innodb;
 
@@ -158,8 +169,10 @@ drop table parent;
 --echo # Test SET NULL #
 --echo #################
 
-create or replace table parent(
-  id int unique key
+--replace_result "$KEY_TYPE" KEY_TYPE
+eval create table parent(
+  id int,
+  $KEY_TYPE (id)
 ) engine innodb;
 
 --replace_result $sys_datatype_expl SYS_DATATYPE
@@ -196,9 +209,10 @@ drop table parent;
 --echo # Parent table is foreign #
 --echo ###########################
 
---replace_result $sys_datatype_expl SYS_DATATYPE
+--replace_result $sys_datatype_expl SYS_DATATYPE "$KEY_TYPE" KEY_TYPE
 eval create or replace table parent(
-  id int unique key,
+  id int,
+  $KEY_TYPE (id),
   sys_start $sys_datatype_expl as row start invisible,
   sys_end $sys_datatype_expl as row end invisible,
   period for system_time(sys_start, sys_end)
@@ -236,9 +250,10 @@ drop table parent;
 --echo # crash on DELETE #
 --echo ###################
 
---replace_result $sys_datatype_expl SYS_DATATYPE
+--replace_result $sys_datatype_expl SYS_DATATYPE "$KEY_TYPE" KEY_TYPE
 eval create or replace table a (
-  cola int(10) primary key,
+  cola int(10),
+  $KEY_TYPE (cola),
   v_cola int(10) as (cola mod 10) virtual,
   sys_start $sys_datatype_expl as row start invisible,
   sys_end $sys_datatype_expl as row end invisible,

--- a/mysql-test/suite/versioning/t/foreign.test
+++ b/mysql-test/suite/versioning/t/foreign.test
@@ -1,6 +1,5 @@
+--source suite/versioning/key_type.inc
 --source suite/versioning/common.inc
-
-let $KEY_TYPE= primary key;
 
 --echo #################
 --echo # Test RESTRICT #

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -1,8 +1,21 @@
+if ($MTR_COMBINATION_SEC)
+{
+  --skip pk or unique only
+}
+
 --source suite/versioning/common.inc
 --source suite/versioning/key_type.inc
 --source suite/versioning/engines.inc
 
-call create_table('t', 'x int');
+--replace_result $sys_datatype_expl SYS_DATATYPE "$KEY_TYPE" KEY_TYPE
+eval create or replace table t(
+  id int,
+  $KEY_TYPE(id),
+  x int,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time(row_start, row_end)
+) with system versioning;
 
 insert t values (1, 2);
 replace t values (1, 3);

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -3172,7 +3172,7 @@ row_upd_clust_step(
 		row_upd_eval_new_vals(node->update);
 	}
 
-	if (node->cmpl_info & UPD_NODE_NO_ORD_CHANGE) {
+	if (!node->is_delete && node->cmpl_info & UPD_NODE_NO_ORD_CHANGE) {
 
 		err = row_upd_clust_rec(
 			flags, node, index, offsets, &heap, thr, &mtr);
@@ -3217,7 +3217,10 @@ row_upd_clust_step(
 			goto exit_func;
 		}
 
-		node->state = UPD_NODE_UPDATE_SOME_SEC;
+		ut_ad(node->is_delete != PLAIN_DELETE);
+		node->state = node->is_delete ?
+			UPD_NODE_UPDATE_ALL_SEC :
+			UPD_NODE_UPDATE_SOME_SEC;
 	}
 
 	node->index = dict_table_get_next_index(index);


### PR DESCRIPTION
This code is submitted under the BSD-new license.

Will be merged with that message:

Constraint check is done on secondary index update. F. ex. DELETE does row_upd_sec_index_entry() and checks constraints in row_upd_check_references_constraints(). UPDATE is optimized for the case when order is not changed (node->cmpl_info & UPD_NODE_NO_ORD_CHANGE) and doesn't do row_upd_sec_index_entry(), so it doesn't check constraints. Since for versioned DELETE we do UPDATE actually, but expect behaviour of DELETE in terms of constraints, we should deny this optimization to get constraints checked.