### PR TITLE
MDEV-16318: mysqld_safe - partial revert on 64094e1

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -36,6 +36,7 @@ skip_err_log=0
 syslog_tag_mysqld=mysqld
 syslog_tag_mysqld_safe=mysqld_safe
 
+trap '' 1 2 3 15			# we shouldn't let anyone kill us
 
 # MySQL-specific environment variable. First off, it's not really a umask,
 # it's the desired mode. Second, it follows umask(2), not umask(3) in that
@@ -159,7 +160,7 @@ eval_log_error () {
       # sed buffers output (only GNU sed supports a -u (unbuffered) option)
       # which means that messages may not get sent to syslog until the
       # mysqld process quits.
-      cmd="$cmd 2>&1 | logger -t '$syslog_tag_mysqld' -p daemon.error & wait"
+      cmd="$cmd 2>&1 | logger -t '$syslog_tag_mysqld' -p daemon.error"
       ;;
     *)
       echo "Internal program error (non-fatal):" \
@@ -875,13 +876,6 @@ then
   log_error "--flush-caches is not supported on this platform"
   exit 1
 fi
-
-#
-# From now on, we catch signals to do a proper shutdown of mysqld
-# when signalled to do so.
-#
-trap '/usr/bin/mysqladmin --defaults-extra-file=/etc/mysql/debian.cnf refresh & wait' 1 # HUP
-trap '/usr/bin/mysqladmin --defaults-extra-file=/etc/mysql/debian.cnf shutdown' 2 3 15 # INT QUIT and TERM
 
 #
 # Uncomment the following lines if you want all tables to be automatically


### PR DESCRIPTION
Revert part of 64094e1 because mysqld_safe isn't just used for Debian. As such references to specific packaging files like /etc/mysql/debian.cnf shouldn't have passed a review.

There's also no history of why 64094e1 was needed based on the history of debian/patches/38_scripts__mysqld_safe.sh__signals.dpatch

Other distros have survived without mysqld_safe handling signals.

Some actual analysis was done in MDEV-14900 as to mysqld signal handling, but no reason for this change. Maybe come up with a reason for patch rather than a debian specific implementation pushed want onto all users.

"validity of this has thus been vetted in production for years" didn't actually cover non-debian users.

I submit this revert under the MCA.