### PR TITLE
MDEV-15966: Behavior for TRUNCATE versioned table is not documented and not covered by tests

### DIFF
--- a/mysql-test/suite/federated/federatedx_versioning.result
+++ b/mysql-test/suite/federated/federatedx_versioning.result
@@ -46,8 +46,12 @@ x	check_row(row_start, row_end)
 4	HISTORICAL ROW
 select * from tf;
 x
-# TRUNCATE
+# MDEV-15966: Behavior for TRUNCATE versioned table is not documented
+# and not covered by tests
+# As of standard, TRUNCATE on versioned tables is forbidden
 truncate tf;
+ERROR HY000: Got error 10000 'Error on remote system: 4144: Cannot truncate a versioned table' from FEDERATED
+delete history from t1;
 select * from t1 for system_time all;
 x
 # REPLACE
@@ -81,8 +85,10 @@ x	check_row(row_start, row_end)
 3	HISTORICAL ROW
 4	HISTORICAL ROW
 # multi-UPDATE
-truncate t1;
-truncate t2;
+delete from t1;
+delete history from t1;
+delete from t2;
+delete history from t2;
 insert into t1 values (1);
 insert into t2 values (2, 2);
 update tf, t2f set tf.x= 11, t2f.y= 22;

--- a/mysql-test/suite/federated/federatedx_versioning.test
+++ b/mysql-test/suite/federated/federatedx_versioning.test
@@ -32,8 +32,13 @@ select *, check_row(row_start, row_end) from t1 for system_time all
 order by x;
 select * from tf;
 
---echo # TRUNCATE
+--echo # MDEV-15966: Behavior for TRUNCATE versioned table is not documented
+--echo # and not covered by tests
+--echo # As of standard, TRUNCATE on versioned tables is forbidden
+--error ER_GET_ERRMSG
 truncate tf;
+
+delete history from t1;
 select * from t1 for system_time all;
 
 --echo # REPLACE
@@ -62,8 +67,10 @@ select *, check_row(row_start, row_end) from t1 for system_time all
 order by x;
 
 --echo # multi-UPDATE
-truncate t1;
-truncate t2;
+delete from t1;
+delete history from t1;
+delete from t2;
+delete history from t2;
 insert into t1 values (1);
 insert into t2 values (2, 2);
 update tf, t2f set tf.x= 11, t2f.y= 22;

--- a/mysql-test/suite/versioning/r/partition.result
+++ b/mysql-test/suite/versioning/r/partition.result
@@ -359,14 +359,6 @@ create or replace table t2 (f int);
 create or replace trigger tr before insert on t2
 for each row select count(*) from t1 into @a;
 insert into t2 values (1);
-# MDEV-14741 Assertion `(trx)->start_file == 0' failed in row_truncate_table_for_mysql()
-create or replace table t1 (i int) with system versioning
-partition by system_time interval 1 hour (
-partition p1 history,
-partition pn current);
-set autocommit= off;
-truncate table t1;
-set autocommit= on;
 # MDEV-14747 ALTER PARTITION BY SYSTEM_TIME after LOCK TABLES
 create or replace table t1 (x int) with system versioning;
 lock table t1 write;

--- a/mysql-test/suite/versioning/r/truncate.result
+++ b/mysql-test/suite/versioning/r/truncate.result
@@ -106,5 +106,29 @@ call pr;
 call pr;
 drop procedure pr;
 drop table t1;
+# MDEV-15966 Behavior for TRUNCATE versioned table is not documented and not covered by tests
+create or replace table t1 (id int);
+create or replace table t2 (id int) with system versioning;
+# force cleaning table shares
+flush tables t1, t2;
+truncate table t1;
+truncate table t2;
+ERROR HY000: Cannot truncate a versioned table
+# fetch table shares
+describe t1;
+Field	Type	Null	Key	Default	Extra
+id	int(11)	YES		NULL
+describe t2;
+Field	Type	Null	Key	Default	Extra
+id	int(11)	YES		NULL
+truncate table t1;
+truncate table t2;
+ERROR HY000: Cannot truncate a versioned table
+# enter locked tables mode
+lock tables t1 WRITE, t2 WRITE;
+truncate t1;
+truncate t2;
+ERROR HY000: Cannot truncate a versioned table
+unlock tables;
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/partition.test
+++ b/mysql-test/suite/versioning/t/partition.test
@@ -315,15 +315,6 @@ create or replace trigger tr before insert on t2
 for each row select count(*) from t1 into @a;
 insert into t2 values (1);
 
---echo # MDEV-14741 Assertion `(trx)->start_file == 0' failed in row_truncate_table_for_mysql()
-create or replace table t1 (i int) with system versioning
-partition by system_time interval 1 hour (
-  partition p1 history,
-  partition pn current);
-set autocommit= off;
-truncate table t1;
-set autocommit= on;
-
 --echo # MDEV-14747 ALTER PARTITION BY SYSTEM_TIME after LOCK TABLES
 create or replace table t1 (x int) with system versioning;
 lock table t1 write;

--- a/mysql-test/suite/versioning/t/truncate.test
+++ b/mysql-test/suite/versioning/t/truncate.test
@@ -117,5 +117,33 @@ call pr;
 drop procedure pr;
 drop table t1;
 
+--echo # MDEV-15966 Behavior for TRUNCATE versioned table is not documented and not covered by tests
+create or replace table t1 (id int);
+create or replace table t2 (id int) with system versioning;
+
+-- echo  # force cleaning table shares
+flush tables t1, t2;
+
+truncate table t1;
+--error ER_TRUNCATE_ILLEGAL_VERS
+truncate table t2;
+
+-- echo # fetch table shares
+describe t1;
+describe t2;
+
+truncate table t1;
+--error ER_TRUNCATE_ILLEGAL_VERS
+truncate table t2;
+
+--echo # enter locked tables mode
+lock tables t1 WRITE, t2 WRITE;
+
+truncate t1;
+--error ER_TRUNCATE_ILLEGAL_VERS
+truncate t2;
+
+unlock tables;
+
 drop database test;
 create database test;

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7921,3 +7921,5 @@ ER_KEY_DOESNT_SUPPORT
         eng "%s index %`s does not support this operation"
 ER_ALTER_OPERATION_TABLE_OPTIONS_NEED_REBUILD
 	eng "Changing table options requires the table to be rebuilt"
+ER_TRUNCATE_ILLEGAL_VERS
+        eng "Cannot truncate a versioned table"


### PR DESCRIPTION
* add error for truncation of versioned tables: `ER_TRUNCATE_ILLEGAL_VERS`
* extract reading `extra2` section in function `dd_read_extra2`
* update `dd_frm_type` and `ha_table_exists` signatures: add new parameter `is_versioned`

test suites run: main, parts, versioning

[fixes tempesta-tech/mariadb#261]