### PR TITLE
MDEV-16231 make DELETE use mysql_update() internally

### DIFF
--- a/sql/sql_update.h
+++ b/sql/sql_update.h
@@ -28,6 +28,10 @@ typedef class st_select_lex_unit SELECT_LEX_UNIT;
 bool mysql_prepare_update(THD *thd, TABLE_LIST *table_list,
                           Item **conds, uint order_num, ORDER *order);
 bool check_unique_table(THD *thd, TABLE_LIST *table_list);
+int mysql_update_inner(THD *thd, TABLE_LIST *tables, List<Item> &fields,
+                       List<Item> &values, COND *conds, uint order_num,
+                       ORDER *order, ha_rows limit, bool ignore,
+                       ha_rows *found_return, ha_rows *updated_return);
 int mysql_update(THD *thd,TABLE_LIST *tables,List<Item> &fields,
 		 List<Item> &values,COND *conds,
 		 uint order_num, ORDER *order, ha_rows limit,

--- a/storage/innobase/include/row0upd.h
+++ b/storage/innobase/include/row0upd.h
@@ -510,7 +510,8 @@ struct upd_t{
 enum delete_mode_t {
 	NO_DELETE = 0,		/*!< this operation does not delete */
 	PLAIN_DELETE,		/*!< ordinary delete */
-	VERSIONED_DELETE	/*!< update old and insert a new row */
+	TRX_ID_DELETE,		/*!< update old and insert a new row */
+	TIMESTAMP_DELETE,	/*!< treat FOREIGN check as DELETE one */
 };
 
 /* Update node structure which also implements the delete operation

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1866,7 +1866,7 @@ row_update_for_mysql(row_prebuilt_t* prebuilt)
 	ut_ad(!prebuilt->versioned_write || node->table->versioned());
 
 	if (prebuilt->versioned_write) {
-		if (node->is_delete == VERSIONED_DELETE) {
+		if (node->is_delete == TRX_ID_DELETE) {
 			node->make_versioned_delete(trx);
 		} else if (node->update->affects_versioned()) {
 			node->make_versioned_update(trx);

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -3492,6 +3492,6 @@ Do not touch other fields at all.
 void upd_node_t::make_versioned_delete(const trx_t* trx)
 {
 	update->n_fields = 0;
-	is_delete = VERSIONED_DELETE;
+	is_delete = TRX_ID_DELETE;
 	make_versioned_helper(trx, table->vers_end);
 }


### PR DESCRIPTION
Perform ordinary DELETE as UPDATE. This is a pure internal thing
which doesn't have user-observable behavior.

Multi DELETE remains the same.

Trx_id versioning in InnoDB remains the same.

mysql_update(): split to mysql_update() + mysql_update_inner()

mysql_update_inner(): performs most of UPDATE job except for table opening

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.