### PR TITLE
MDEV-16470: session user variables tracker

### DIFF
--- a/include/mysql.h.pp
+++ b/include/mysql.h.pp
@@ -107,6 +107,7 @@ enum enum_session_state_type
   SESSION_TRACK_GTIDS,
   SESSION_TRACK_TRANSACTION_CHARACTERISTICS,
   SESSION_TRACK_TRANSACTION_STATE,
+  SESSION_TRACK_USER_VARIABLES,
   SESSION_TRACK_always_at_the_end
 };
 my_bool my_net_init(NET *net, Vio* vio, void *thd, unsigned int my_flags);

--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -600,6 +600,7 @@ enum enum_session_state_type
   SESSION_TRACK_GTIDS,
   SESSION_TRACK_TRANSACTION_CHARACTERISTICS,  /* Transaction chistics */
   SESSION_TRACK_TRANSACTION_STATE,            /* Transaction state */
+  SESSION_TRACK_USER_VARIABLES,               /* Session user variables */
   SESSION_TRACK_always_at_the_end             /* must be last */
 };
 

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4732,6 +4732,10 @@ Item_func_set_user_var::update_hash(void *ptr, size_t length,
     null_value= 1;
     return 1;
   }
+
+  THD *thd=current_thd;
+  SESSION_TRACKER_CHANGED(thd, SESSION_USRVARS_TRACKER, &name);
+
   return 0;
 }
 

--- a/sql/session_tracker.h
+++ b/sql/session_tracker.h
@@ -34,6 +34,7 @@ enum enum_session_tracker
   SESSION_STATE_CHANGE_TRACKER,
   SESSION_GTIDS_TRACKER,                         /* Tracks GTIDs */
   TRANSACTION_INFO_TRACKER,                      /* Transaction state */
+  SESSION_USRVARS_TRACKER,                       /* Session user variables */
   SESSION_TRACKER_END                            /* must be the last */
 };
 


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

Add session user variables tracker to tell proxy the session variable changes, let it is easy to make session state consist between different backends for proxy;