### PR TITLE
MDEV-16026: Global system_versioning_asof must not be used if client

### DIFF
--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -1,5 +1,7 @@
 create table t (a int) with system versioning;
+set @before= UNIX_TIMESTAMP(now(6));
 insert into t values (1);
+set @after= UNIX_TIMESTAMP(now(6));
 update t set a= 2;
 show global variables like 'system_versioning_asof';
 Variable_name	Value
@@ -40,58 +42,60 @@ ERROR 42000: Incorrect argument type to variable 'system_versioning_asof'
 set system_versioning_asof= 1.1;
 ERROR 42000: Incorrect argument type to variable 'system_versioning_asof'
 # GLOBAL @@system_versioning_asof
-set global system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set global system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set global system_versioning_asof= '1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set global system_versioning_asof= '1990-01-01 00:00:00';
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+system_versioning_asof	1990-01-01 00:00:00.000000
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set @ts= timestamp'1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set @ts= timestamp'1990-01-01 00:00:00';
 set global system_versioning_asof= @ts;
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
+system_versioning_asof	1990-01-01 00:00:00.000000
 set global system_versioning_asof= default;
 select @@global.system_versioning_asof;
 @@global.system_versioning_asof
 DEFAULT
 # SESSION @@system_versioning_asof
-set system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set system_versioning_asof= '1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set system_versioning_asof= '1990-01-01 00:00:00';
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
-set system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+system_versioning_asof	1990-01-01 00:00:00.000000
+set system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set @ts= timestamp'1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set @ts= timestamp'1990-01-01 00:00:00';
 set system_versioning_asof= @ts;
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
+system_versioning_asof	1990-01-01 00:00:00.000000
 # DEFAULT: value is copied from GLOBAL to SESSION
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.111111';
-set system_versioning_asof= '1900-01-01 00:00:00';
+set global time_zone= "+03:00";
+set time_zone= "+10:00";
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.111111';
+set system_versioning_asof= '1990-01-01 00:00:00';
 select @@global.system_versioning_asof != @@system_versioning_asof as different;
 different
 1
@@ -99,6 +103,8 @@ set system_versioning_asof= default;
 select @@global.system_versioning_asof = @@system_versioning_asof as equal;
 equal
 1
+set global time_zone= DEFAULT;
+set time_zone= DEFAULT;
 set global system_versioning_asof= DEFAULT;
 set system_versioning_asof= DEFAULT;
 select @@global.system_versioning_asof, @@system_versioning_asof;
@@ -126,6 +132,71 @@ select * from t for system_time between '0-0-0' and current_timestamp(6);
 a
 2
 1
+# MDEV-16026: Global system_versioning_asof must not be used if client sessions can have non-default time zone
+# changing time zone should not abuse `system_versioning_asof`
+set global time_zone = '+10:00';
+set global system_versioning_asof = '1999-09-08 00:00:00.000000';
+show global variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	1999-09-08 00:00:00.000000
+set global time_zone = '+03:00';
+show global variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	1999-09-07 17:00:00.000000
+set session time_zone = '+03:00';
+set session system_versioning_asof = '2000-09-08 00:00:00.000000';
+show session variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	2000-09-08 00:00:00.000000
+set session time_zone = '+10:00';
+show session variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	2000-09-08 07:00:00.000000
+# global and local time zones should not interfere
+show global variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	1999-09-07 17:00:00.000000
+set time_zone= "+10:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+a
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+a
+1
+set time_zone= "+03:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+a
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+a
+1
+set global system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+a
+1
+connect  subcon,127.0.0.1,root,,,$SERVER_MYPORT_1;
+connection subcon;
+select * from t as nonempty;
+a
+1
+disconnect subcon;
+connection default;
+set global system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as nonempty;
+a
+1
+connect  subcon,127.0.0.1,root,,,$SERVER_MYPORT_1;
+connection subcon;
+select * from t as empty;
+a
+disconnect subcon;
+connection default;
+set global time_zone= "SYSTEM";
+set time_zone= "SYSTEM";
+set global system_versioning_asof= "DEFAULT";
+set system_versioning_asof= "DEFAULT";
 show status like "Feature_system_versioning";
 Variable_name	Value
 Feature_system_versioning	2

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -1,5 +1,7 @@
 create table t (a int) with system versioning;
+set @before= UNIX_TIMESTAMP(now(6));
 insert into t values (1);
+set @after= UNIX_TIMESTAMP(now(6));
 update t set a= 2;
 
 show global variables like 'system_versioning_asof';
@@ -35,16 +37,16 @@ set system_versioning_asof= 1;
 set system_versioning_asof= 1.1;
 
 --echo # GLOBAL @@system_versioning_asof
-set global system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set global system_versioning_asof= '1991-11-11 11:11:11.1111119';
 show global variables like 'system_versioning_asof';
 
-set global system_versioning_asof= '1900-01-01 00:00:00';
+set global system_versioning_asof= '1990-01-01 00:00:00';
 show global variables like 'system_versioning_asof';
 
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 show global variables like 'system_versioning_asof';
 
-set @ts= timestamp'1900-01-01 00:00:00';
+set @ts= timestamp'1990-01-01 00:00:00';
 set global system_versioning_asof= @ts;
 show global variables like 'system_versioning_asof';
 
@@ -52,26 +54,30 @@ set global system_versioning_asof= default;
 select @@global.system_versioning_asof;
 
 --echo # SESSION @@system_versioning_asof
-set system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set system_versioning_asof= '1991-11-11 11:11:11.1111119';
 show variables like 'system_versioning_asof';
 
-set system_versioning_asof= '1900-01-01 00:00:00';
+set system_versioning_asof= '1990-01-01 00:00:00';
 show variables like 'system_versioning_asof';
 
-set system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+set system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 show variables like 'system_versioning_asof';
 
-set @ts= timestamp'1900-01-01 00:00:00';
+set @ts= timestamp'1990-01-01 00:00:00';
 set system_versioning_asof= @ts;
 show variables like 'system_versioning_asof';
 
 --echo # DEFAULT: value is copied from GLOBAL to SESSION
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.111111';
-set system_versioning_asof= '1900-01-01 00:00:00';
+set global time_zone= "+03:00";
+set time_zone= "+10:00";
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.111111';
+set system_versioning_asof= '1990-01-01 00:00:00';
 select @@global.system_versioning_asof != @@system_versioning_asof as different;
 set system_versioning_asof= default;
 select @@global.system_versioning_asof = @@system_versioning_asof as equal;
 
+set global time_zone= DEFAULT;
+set time_zone= DEFAULT;
 set global system_versioning_asof= DEFAULT;
 set system_versioning_asof= DEFAULT;
 select @@global.system_versioning_asof, @@system_versioning_asof;
@@ -83,6 +89,58 @@ select * from t for system_time as of timestamp current_timestamp(6);
 select * from t for system_time all;
 select * from t for system_time from '0-0-0' to current_timestamp(6);
 select * from t for system_time between '0-0-0' and current_timestamp(6);
+
+-- echo # MDEV-16026: Global system_versioning_asof must not be used if client sessions can have non-default time zone
+-- echo # changing time zone should not abuse `system_versioning_asof`
+
+set global time_zone = '+10:00';
+set global system_versioning_asof = '1999-09-08 00:00:00.000000';
+show global variables like 'system_versioning_asof';
+set global time_zone = '+03:00';
+show global variables like 'system_versioning_asof';
+
+set session time_zone = '+03:00';
+set session system_versioning_asof = '2000-09-08 00:00:00.000000';
+show session variables like 'system_versioning_asof';
+set session time_zone = '+10:00';
+show session variables like 'system_versioning_asof';
+-- echo # global and local time zones should not interfere
+show global variables like 'system_versioning_asof';
+
+set time_zone= "+10:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+
+set time_zone= "+03:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+
+set global system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+
+--connect (subcon,127.0.0.1,root,,,$SERVER_MYPORT_1)
+--connection subcon
+select * from t as nonempty;
+--disconnect subcon
+--connection default
+
+set global system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as nonempty;
+
+--connect (subcon,127.0.0.1,root,,,$SERVER_MYPORT_1)
+--connection subcon
+select * from t as empty;
+--disconnect subcon
+--connection default
+
+set global time_zone= "SYSTEM";
+set time_zone= "SYSTEM";
+set global system_versioning_asof= "DEFAULT";
+set system_versioning_asof= "DEFAULT";
 
 show status like "Feature_system_versioning";
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -193,7 +193,8 @@ enum vers_system_time_t
 struct vers_asof_timestamp_t
 {
   ulong type;
-  MYSQL_TIME ltime;
+  my_time_t unix_time;
+  ulong second_part;
   vers_asof_timestamp_t() :
     type(SYSTEM_TIME_UNSPECIFIED)
   {}

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -681,8 +681,12 @@ bool vers_select_conds_t::init_from_sysvar(THD *thd)
   if (type != SYSTEM_TIME_UNSPECIFIED && type != SYSTEM_TIME_ALL)
   {
     DBUG_ASSERT(type == SYSTEM_TIME_AS_OF);
+    MYSQL_TIME ltime;
+    thd->variables.time_zone->gmt_sec_to_TIME(&ltime, in.unix_time);
+    ltime.second_part = in.second_part;
+
     start.item= new (thd->mem_root)
-        Item_datetime_literal(thd, &in.ltime, TIME_SECOND_PART_DIGITS);
+        Item_datetime_literal(thd, &ltime, TIME_SECOND_PART_DIGITS);
     if (!start.item)
       return true;
   }

--- a/sql/sys_vars.ic
+++ b/sql/sys_vars.ic
@@ -2634,19 +2634,26 @@ public:
   }
 
 private:
-  bool update(set_var *var, vers_asof_timestamp_t &out)
+  bool update(set_var *var, vers_asof_timestamp_t &out, system_variables& pool)
   {
     bool res= false;
+    uint error;
+    MYSQL_TIME ltime;
     out.type= static_cast<enum_var_type>(var->save_result.ulonglong_value);
     if (out.type == SYSTEM_TIME_AS_OF)
     {
       if (var->value)
       {
-        res= var->value->get_date(&out.ltime, 0);
+        res= var->value->get_date(&ltime, 0);
+        out.unix_time= pool.time_zone->TIME_to_gmt_sec(&ltime, &error);
+        out.second_part= ltime.second_part;
+        res|= (error != 0);
       }
       else // set DEFAULT from global var
       {
         out= global_var(vers_asof_timestamp_t);
+        global_system_variables.time_zone->gmt_sec_to_TIME(&ltime, out.unix_time);
+        out.unix_time= pool.time_zone->TIME_to_gmt_sec(&ltime, &error);
         res= false;
       }
     }
@@ -2656,11 +2663,11 @@ private:
 public:
   virtual bool global_update(THD *thd, set_var *var)
   {
-    return update(var, global_var(vers_asof_timestamp_t));
+    return update(var, global_var(vers_asof_timestamp_t), global_system_variables);
   }
   virtual bool session_update(THD *thd, set_var *var)
   {
-    return update(var, session_var(thd, vers_asof_timestamp_t));
+    return update(var, session_var(thd, vers_asof_timestamp_t), thd->variables);
   }
 
 private:
@@ -2674,10 +2681,15 @@ private:
     case SYSTEM_TIME_AS_OF:
     {
       uchar *buf= (uchar*) thd->alloc(MAX_DATE_STRING_REP_LENGTH);
-      if (buf &&!my_datetime_to_str(&val.ltime, (char*) buf, 6))
+      MYSQL_TIME ltime;
+      system_variables *vars= (system_variables*)((uint8*)&val - offset);
+
+      vars->time_zone->gmt_sec_to_TIME(&ltime, val.unix_time);
+      ltime.second_part= val.second_part;
+
+      if (buf && !my_datetime_to_str(&ltime, (char*) buf, 6))
       {
-        // TODO: figure out variable name
-        my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), "system_versioning_asof_timestamp", "NULL (wrong datetime)");
+        my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name.str, "NULL (wrong datetime)");
         return (uchar*) thd->strdup("Error: wrong datetime");
       }
       return buf;
@@ -2685,7 +2697,7 @@ private:
     default:
       break;
     }
-    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), "system_versioning_asof_timestamp", "NULL (wrong range type)");
+    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name.str, "NULL (wrong range type)");
     return (uchar*) thd->strdup("Error: wrong range type");
   }
 


### PR DESCRIPTION
…sessions can have non-default time zone

* store `system_versioning_asof` in unix time;
* session var processed in session timezone; global var processed in global timezone;

As a regression, we cannot assign values below 1970 anymore