### PR TITLE
MDEV-15950 LOAD DATA INTO compex_view crashed

### DIFF
--- a/mysql-test/r/view.result
+++ b/mysql-test/r/view.result
@@ -5732,6 +5732,32 @@ t37, t38, t39, t40, t41, t42, t43, t44, t45,
 t46, t47, t48, t49, t50, t51, t52, t53, t54,
 t55, t56, t57, t58, t59,t60;
 drop view v60;
+#
+# MDEV-15950 LOAD DATA INTO compex_view crashed
+#
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY (a), UNIQUE(b));
+INSERT INTO t1 VALUES (1,2);
+CREATE TABLE t2 (c INT);
+CREATE VIEW v AS SELECT * FROM t2 join t1;
+SELECT a, b FROM t1 INTO OUTFILE '15950.data';
+delete from t1;
+LOAD DATA INFILE '15950.data' IGNORE INTO TABLE v (a,c);
+ERROR HY000: Can not modify more than one base table through a join view 'test.v'
+LOAD DATA INFILE '15950.data' IGNORE INTO TABLE v (a,b);
+LOAD DATA INFILE '15950.data' IGNORE INTO TABLE v (c);
+Warnings:
+Warning	1262	Row 1 was truncated; it contained more data than there were input columns
+select * from t1;
+a	b
+1	2
+select * from t2;
+c
+1
+select * from v;
+c	a	b
+1	1	2
+drop table t1, t2;
+drop view v;
 # -----------------------------------------------------------------
 # -- End of 5.5 tests.
 # -----------------------------------------------------------------

--- a/mysql-test/t/view.test
+++ b/mysql-test/t/view.test
@@ -5674,6 +5674,27 @@ t46, t47, t48, t49, t50, t51, t52, t53, t54,
 t55, t56, t57, t58, t59,t60;
 drop view v60;
 
+
+--echo #
+--echo # MDEV-15950 LOAD DATA INTO compex_view crashed
+--echo #
+CREATE TABLE t1 (a INT, b INT, PRIMARY KEY (a), UNIQUE(b));
+INSERT INTO t1 VALUES (1,2);
+CREATE TABLE t2 (c INT);
+CREATE VIEW v AS SELECT * FROM t2 join t1;
+SELECT a, b FROM t1 INTO OUTFILE '15950.data';
+delete from t1;
+--error ER_VIEW_MULTIUPDATE
+LOAD DATA INFILE '15950.data' IGNORE INTO TABLE v (a,c);
+LOAD DATA INFILE '15950.data' IGNORE INTO TABLE v (a,b);
+LOAD DATA INFILE '15950.data' IGNORE INTO TABLE v (c);
+select * from t1;
+select * from t2;
+select * from v;
+drop table t1, t2;
+drop view v;
+
+
 --echo # -----------------------------------------------------------------
 --echo # -- End of 5.5 tests.
 --echo # -----------------------------------------------------------------


### PR DESCRIPTION
INSERT ... SELECT chooses one of VIEWs underlying tables in a join list to insert.
LOAD DATA is similar but doesn't perform that step. This patch fixes it.

I have a very bad understanding of a code this patch changes. Thus this patch may be completely wrong. In that case please give me some directions.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.