### PR TITLE
 MDEV-16481, MDEV-16026: refactor Sys_var_vers_asof

### DIFF
--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -45,7 +45,6 @@ ERROR 42000: Incorrect argument type to variable 'system_versioning_asof'
 set global system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
 Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
-Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show global variables like 'system_versioning_asof';
 Variable_name	Value
 system_versioning_asof	1991-11-11 11:11:11.111111
@@ -71,7 +70,6 @@ DEFAULT
 # SESSION @@system_versioning_asof
 set system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show variables like 'system_versioning_asof';
 Variable_name	Value
@@ -197,6 +195,12 @@ select * from t as empty;
 a
 disconnect subcon;
 connection default;
+# MDEV-16481: set global system_versioning_asof=sf() crashes in specific case
+# Using global variable inside a stored function should not crash
+create or replace function now_global() returns timestamp
+return  CONVERT_TZ(now(), @@session.time_zone, @@global.time_zone);
+set global system_versioning_asof= now_global();
+drop function now_global;
 set global time_zone= "SYSTEM";
 set time_zone= "SYSTEM";
 set global system_versioning_asof= "DEFAULT";

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -203,8 +203,8 @@ set global system_versioning_asof= now_global();
 drop function now_global;
 set global time_zone= "SYSTEM";
 set time_zone= "SYSTEM";
-set global system_versioning_asof= "DEFAULT";
-set system_versioning_asof= "DEFAULT";
+set global system_versioning_asof= default;
+set system_versioning_asof= default;
 show status like "Feature_system_versioning";
 Variable_name	Value
 Feature_system_versioning	2

--- a/mysql-test/suite/versioning/r/sysvars.result
+++ b/mysql-test/suite/versioning/r/sysvars.result
@@ -1,5 +1,7 @@
 create table t (a int) with system versioning;
+set @before= UNIX_TIMESTAMP(now(6));
 insert into t values (1);
+set @after= UNIX_TIMESTAMP(now(6));
 update t set a= 2;
 show global variables like 'system_versioning_asof';
 Variable_name	Value
@@ -40,65 +42,73 @@ ERROR 42000: Incorrect argument type to variable 'system_versioning_asof'
 set system_versioning_asof= 1.1;
 ERROR 42000: Incorrect argument type to variable 'system_versioning_asof'
 # GLOBAL @@system_versioning_asof
-set global system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set global system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set global system_versioning_asof= '1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set global system_versioning_asof= '1990-01-01 00:00:00';
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+system_versioning_asof	1990-01-01 00:00:00.000000
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set @ts= timestamp'1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set @ts= timestamp'1990-01-01 00:00:00';
 set global system_versioning_asof= @ts;
 show global variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
+system_versioning_asof	1990-01-01 00:00:00.000000
 set global system_versioning_asof= default;
 select @@global.system_versioning_asof;
 @@global.system_versioning_asof
 DEFAULT
 # SESSION @@system_versioning_asof
-set system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set system_versioning_asof= '1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set system_versioning_asof= '1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set system_versioning_asof= '1990-01-01 00:00:00';
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
-set system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+system_versioning_asof	1990-01-01 00:00:00.000000
+set system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 Warnings:
-Note	1292	Truncated incorrect datetime value: '1911-11-11 11:11:11.1111119'
+Note	1292	Truncated incorrect datetime value: '1991-11-11 11:11:11.1111119'
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1911-11-11 11:11:11.111111
-set @ts= timestamp'1900-01-01 00:00:00';
+system_versioning_asof	1991-11-11 11:11:11.111111
+set @ts= timestamp'1990-01-01 00:00:00';
 set system_versioning_asof= @ts;
 show variables like 'system_versioning_asof';
 Variable_name	Value
-system_versioning_asof	1900-01-01 00:00:00.000000
+system_versioning_asof	1990-01-01 00:00:00.000000
 # DEFAULT: value is copied from GLOBAL to SESSION
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.111111';
-set system_versioning_asof= '1900-01-01 00:00:00';
+set global time_zone= "+03:00";
+set time_zone= "+10:00";
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.111111';
+set system_versioning_asof= '1990-01-01 00:00:00';
 select @@global.system_versioning_asof != @@system_versioning_asof as different;
 different
 1
 set system_versioning_asof= default;
+select @@global.system_versioning_asof != @@system_versioning_asof as different;
+different
+1
+set global system_versioning_asof= default;
 select @@global.system_versioning_asof = @@system_versioning_asof as equal;
 equal
 1
+set global time_zone= DEFAULT;
+set time_zone= DEFAULT;
 set global system_versioning_asof= DEFAULT;
 set system_versioning_asof= DEFAULT;
 select @@global.system_versioning_asof, @@system_versioning_asof;
@@ -126,6 +136,71 @@ select * from t for system_time between '0-0-0' and current_timestamp(6);
 a
 2
 1
+# MDEV-16026: Global system_versioning_asof must not be used if client sessions can have non-default time zone
+# changing time zone should not abuse `system_versioning_asof`
+set session time_zone = '+10:00';
+set global system_versioning_asof = '1999-09-08 00:00:00.000000';
+show global variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	1999-09-08 00:00:00.000000
+set session time_zone = '+03:00';
+show global variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	1999-09-07 17:00:00.000000
+set session time_zone = '+03:00';
+set session system_versioning_asof = '2000-09-08 00:00:00.000000';
+show session variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	2000-09-08 00:00:00.000000
+set session time_zone = '+10:00';
+show session variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	2000-09-08 07:00:00.000000
+# global and local time zones should not interfere
+show global variables like 'system_versioning_asof';
+Variable_name	Value
+system_versioning_asof	1999-09-08 00:00:00.000000
+set time_zone= "+10:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+a
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+a
+1
+set time_zone= "+03:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+a
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+a
+1
+set global system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+a
+1
+connect  subcon,127.0.0.1,root,,,$SERVER_MYPORT_1;
+connection subcon;
+select * from t as nonempty;
+a
+1
+disconnect subcon;
+connection default;
+set global system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as nonempty;
+a
+1
+connect  subcon,127.0.0.1,root,,,$SERVER_MYPORT_1;
+connection subcon;
+select * from t as empty;
+a
+disconnect subcon;
+connection default;
+set global time_zone= "SYSTEM";
+set time_zone= "SYSTEM";
+set global system_versioning_asof= "DEFAULT";
+set system_versioning_asof= "DEFAULT";
 show status like "Feature_system_versioning";
 Variable_name	Value
 Feature_system_versioning	2

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -1,5 +1,7 @@
 create table t (a int) with system versioning;
+set @before= UNIX_TIMESTAMP(now(6));
 insert into t values (1);
+set @after= UNIX_TIMESTAMP(now(6));
 update t set a= 2;
 
 show global variables like 'system_versioning_asof';
@@ -35,16 +37,16 @@ set system_versioning_asof= 1;
 set system_versioning_asof= 1.1;
 
 --echo # GLOBAL @@system_versioning_asof
-set global system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set global system_versioning_asof= '1991-11-11 11:11:11.1111119';
 show global variables like 'system_versioning_asof';
 
-set global system_versioning_asof= '1900-01-01 00:00:00';
+set global system_versioning_asof= '1990-01-01 00:00:00';
 show global variables like 'system_versioning_asof';
 
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 show global variables like 'system_versioning_asof';
 
-set @ts= timestamp'1900-01-01 00:00:00';
+set @ts= timestamp'1990-01-01 00:00:00';
 set global system_versioning_asof= @ts;
 show global variables like 'system_versioning_asof';
 
@@ -52,26 +54,32 @@ set global system_versioning_asof= default;
 select @@global.system_versioning_asof;
 
 --echo # SESSION @@system_versioning_asof
-set system_versioning_asof= '1911-11-11 11:11:11.1111119';
+set system_versioning_asof= '1991-11-11 11:11:11.1111119';
 show variables like 'system_versioning_asof';
 
-set system_versioning_asof= '1900-01-01 00:00:00';
+set system_versioning_asof= '1990-01-01 00:00:00';
 show variables like 'system_versioning_asof';
 
-set system_versioning_asof= timestamp'1911-11-11 11:11:11.1111119';
+set system_versioning_asof= timestamp'1991-11-11 11:11:11.1111119';
 show variables like 'system_versioning_asof';
 
-set @ts= timestamp'1900-01-01 00:00:00';
+set @ts= timestamp'1990-01-01 00:00:00';
 set system_versioning_asof= @ts;
 show variables like 'system_versioning_asof';
 
 --echo # DEFAULT: value is copied from GLOBAL to SESSION
-set global system_versioning_asof= timestamp'1911-11-11 11:11:11.111111';
-set system_versioning_asof= '1900-01-01 00:00:00';
+set global time_zone= "+03:00";
+set time_zone= "+10:00";
+set global system_versioning_asof= timestamp'1991-11-11 11:11:11.111111';
+set system_versioning_asof= '1990-01-01 00:00:00';
 select @@global.system_versioning_asof != @@system_versioning_asof as different;
 set system_versioning_asof= default;
+select @@global.system_versioning_asof != @@system_versioning_asof as different;
+set global system_versioning_asof= default;
 select @@global.system_versioning_asof = @@system_versioning_asof as equal;
 
+set global time_zone= DEFAULT;
+set time_zone= DEFAULT;
 set global system_versioning_asof= DEFAULT;
 set system_versioning_asof= DEFAULT;
 select @@global.system_versioning_asof, @@system_versioning_asof;
@@ -83,6 +91,58 @@ select * from t for system_time as of timestamp current_timestamp(6);
 select * from t for system_time all;
 select * from t for system_time from '0-0-0' to current_timestamp(6);
 select * from t for system_time between '0-0-0' and current_timestamp(6);
+
+-- echo # MDEV-16026: Global system_versioning_asof must not be used if client sessions can have non-default time zone
+-- echo # changing time zone should not abuse `system_versioning_asof`
+
+set session time_zone = '+10:00';
+set global system_versioning_asof = '1999-09-08 00:00:00.000000';
+show global variables like 'system_versioning_asof';
+set session time_zone = '+03:00';
+show global variables like 'system_versioning_asof';
+
+set session time_zone = '+03:00';
+set session system_versioning_asof = '2000-09-08 00:00:00.000000';
+show session variables like 'system_versioning_asof';
+set session time_zone = '+10:00';
+show session variables like 'system_versioning_asof';
+-- echo # global and local time zones should not interfere
+show global variables like 'system_versioning_asof';
+
+set time_zone= "+10:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+
+set time_zone= "+03:00";
+set system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as empty;
+set system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+
+set global system_versioning_asof= FROM_UNIXTIME(@after);
+select * from t as nonempty;
+
+--connect (subcon,127.0.0.1,root,,,$SERVER_MYPORT_1)
+--connection subcon
+select * from t as nonempty;
+--disconnect subcon
+--connection default
+
+set global system_versioning_asof= FROM_UNIXTIME(@before);
+select * from t as nonempty;
+
+--connect (subcon,127.0.0.1,root,,,$SERVER_MYPORT_1)
+--connection subcon
+select * from t as empty;
+--disconnect subcon
+--connection default
+
+set global time_zone= "SYSTEM";
+set time_zone= "SYSTEM";
+set global system_versioning_asof= "DEFAULT";
+set system_versioning_asof= "DEFAULT";
 
 show status like "Feature_system_versioning";
 

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -139,6 +139,13 @@ select * from t as empty;
 --disconnect subcon
 --connection default
 
+--echo # MDEV-16481: set global system_versioning_asof=sf() crashes in specific case
+--echo # Using global variable inside a stored function should not crash
+create or replace function now_global() returns timestamp
+  return  CONVERT_TZ(now(), @@session.time_zone, @@global.time_zone);
+set global system_versioning_asof= now_global();
+drop function now_global;
+
 set global time_zone= "SYSTEM";
 set time_zone= "SYSTEM";
 set global system_versioning_asof= "DEFAULT";

--- a/mysql-test/suite/versioning/t/sysvars.test
+++ b/mysql-test/suite/versioning/t/sysvars.test
@@ -148,8 +148,8 @@ drop function now_global;
 
 set global time_zone= "SYSTEM";
 set time_zone= "SYSTEM";
-set global system_versioning_asof= "DEFAULT";
-set system_versioning_asof= "DEFAULT";
+set global system_versioning_asof= default;
+set system_versioning_asof= default;
 
 show status like "Feature_system_versioning";
 

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -5630,7 +5630,7 @@ void Item_func_get_system_var::update_null_value()
 
 bool Item_func_get_system_var::fix_length_and_dec()
 {
-  char *cptr;
+  const char *cptr;
   maybe_null= TRUE;
   max_length= 0;
 
@@ -5664,9 +5664,12 @@ bool Item_func_get_system_var::fix_length_and_dec()
     case SHOW_CHAR:
     case SHOW_CHAR_PTR:
       mysql_mutex_lock(&LOCK_global_system_variables);
-      cptr= var->show_type() == SHOW_CHAR ? 
-        (char*) var->value_ptr(current_thd, var_type, &component) :
-        *(char**) var->value_ptr(current_thd, var_type, &component);
+      cptr= var->show_type() == SHOW_CHAR ?
+          reinterpret_cast<const char*>(var->value_ptr(current_thd, var_type,
+                                                       &component)) :
+          *reinterpret_cast<const char* const*>(var->value_ptr(current_thd,
+                                                               var_type,
+                                                               &component));
       if (cptr)
         max_length= (uint32)system_charset_info->cset->numchars(system_charset_info,
                                                         cptr,
@@ -5679,7 +5682,10 @@ bool Item_func_get_system_var::fix_length_and_dec()
     case SHOW_LEX_STRING:
       {
         mysql_mutex_lock(&LOCK_global_system_variables);
-        LEX_STRING *ls= ((LEX_STRING*)var->value_ptr(current_thd, var_type, &component));
+        const LEX_STRING *ls=
+                reinterpret_cast<const LEX_STRING*>(var->value_ptr(current_thd,
+                                                                   var_type,
+                                                                   &component));
         max_length= (uint32)system_charset_info->cset->numchars(system_charset_info,
                                                         ls->str,
                                                         ls->str + ls->length);

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -195,7 +195,8 @@ enum vers_system_time_t
 struct vers_asof_timestamp_t
 {
   ulong type;
-  MYSQL_TIME ltime;
+  my_time_t unix_time;
+  ulong second_part;
 };
 
 enum vers_alter_history_enum

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -233,12 +233,12 @@ bool sys_var::update(THD *thd, set_var *var)
   }
 }
 
-uchar *sys_var::session_value_ptr(THD *thd, const LEX_CSTRING *base)
+const uchar *sys_var::session_value_ptr(THD *thd, const LEX_CSTRING *base) const
 {
   return session_var_ptr(thd);
 }
 
-uchar *sys_var::global_value_ptr(THD *thd, const LEX_CSTRING *base)
+const uchar *sys_var::global_value_ptr(THD *thd, const LEX_CSTRING *base) const
 {
   return global_var_ptr();
 }
@@ -271,8 +271,8 @@ bool sys_var::check(THD *thd, set_var *var)
   return false;
 }
 
-uchar *sys_var::value_ptr(THD *thd, enum_var_type type,
-                          const LEX_CSTRING *base)
+const uchar *sys_var::value_ptr(THD *thd, enum_var_type type,
+                                const LEX_CSTRING *base) const
 {
   DBUG_ASSERT(base);
   if (type == OPT_GLOBAL || scope() == GLOBAL)
@@ -510,7 +510,7 @@ bool throw_bounds_warning(THD *thd, const char *name, bool fixed, double v)
   return false;
 }
 
-CHARSET_INFO *sys_var::charset(THD *thd)
+CHARSET_INFO *sys_var::charset(THD *thd) const
 {
   return is_os_charset ? thd->variables.character_set_filesystem :
     system_charset_info;
@@ -1037,7 +1037,7 @@ int set_var_collation_client::update(THD *thd)
  INFORMATION_SCHEMA.SYSTEM_VARIABLES
 *****************************************************************************/
 static void store_value_ptr(Field *field, sys_var *var, String *str,
-                            uchar *value_ptr)
+                            const uchar *value_ptr)
 {
   field->set_notnull();
   str= var->val_str_nolock(str, field->table->in_use, value_ptr);
@@ -1107,8 +1107,8 @@ int fill_sysvars(THD *thd, TABLE_LIST *tables, COND *cond)
     fields[3]->store(origin->str, origin->length, scs);
 
     // DEFAULT_VALUE
-    uchar *def= var->is_readonly() && var->option.id < 0
-                ? 0 : var->default_value_ptr(thd);
+    const uchar *def= var->is_readonly() && var->option.id < 0
+                      ? 0 : var->default_value_ptr(thd);
     if (def)
       store_value_ptr(fields[4], var, &strbuf, def);
 

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -112,7 +112,7 @@ public:
   virtual sys_var_pluginvar *cast_pluginvar() { return 0; }
 
   bool check(THD *thd, set_var *var);
-  uchar *value_ptr(THD *thd, enum_var_type type, const LEX_CSTRING *base);
+  const uchar *value_ptr(THD *thd, enum_var_type type, const LEX_CSTRING *base) const;
 
   /**
      Update the system variable with the default value from either
@@ -127,9 +127,9 @@ public:
   String *val_str(String *str, THD *thd, enum_var_type type, const LEX_CSTRING *base);
   double val_real(bool *is_null, THD *thd, enum_var_type type, const LEX_CSTRING *base);
 
-  SHOW_TYPE show_type() { return show_val_type; }
+  SHOW_TYPE show_type() const { return show_val_type; }
   int scope() const { return flags & SCOPE_MASK; }
-  CHARSET_INFO *charset(THD *thd);
+  CHARSET_INFO *charset(THD *thd) const;
   bool is_readonly() const { return flags & READONLY; }
   /**
     the following is only true for keycache variables,
@@ -208,7 +208,7 @@ public:
   */
   virtual bool session_is_default(THD *thd) { return false; }
 
-  virtual uchar *default_value_ptr(THD *thd)
+  virtual const uchar *default_value_ptr(THD *thd) const
   { return (uchar*)&option.def_value; }
 
 private:
@@ -230,18 +230,18 @@ protected:
     It must be of show_val_type type (my_bool for SHOW_MY_BOOL,
     int for SHOW_INT, longlong for SHOW_LONGLONG, etc).
   */
-  virtual uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base);
-  virtual uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base);
+  virtual const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const;
+  virtual const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
 
   /**
     A pointer to a storage area of the variable, to the raw data.
     Typically it's the same as session_value_ptr(), but it's different,
     for example, for ENUM, that is printed as a string, but stored as a number.
   */
-  uchar *session_var_ptr(THD *thd)
+  uchar *session_var_ptr(THD *thd) const
   { return ((uchar*)&(thd->variables)) + offset; }
 
-  uchar *global_var_ptr()
+  uchar *global_var_ptr() const
   { return ((uchar*)&global_system_variables) + offset; }
 
   void *max_var_ptr()

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -296,6 +296,7 @@ public:
     plugin_ref *plugins;                ///< for Sys_var_pluginlist
     Time_zone *time_zone;               ///< for Sys_var_tz
     LEX_STRING string_value;            ///< for Sys_var_charptr and others
+    MYSQL_TIME time;                    ///< for Sys_var_vers_asof
     const void *ptr;                    ///< for Sys_var_struct
   } save_result;
   LEX_CSTRING base; /**< for structured variables, like keycache_name.variable_name */

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -292,14 +292,14 @@ public:
   sys_var_pluginvar(sys_var_chain *chain, const char *name_arg,
                     st_plugin_int *p, st_mysql_sys_var *plugin_var_arg);
   sys_var_pluginvar *cast_pluginvar() { return this; }
-  uchar* real_value_ptr(THD *thd, enum_var_type type);
-  TYPELIB* plugin_var_typelib(void);
-  uchar* do_value_ptr(THD *thd, enum_var_type type, const LEX_CSTRING *base);
-  uchar* session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  uchar* real_value_ptr(THD *thd, enum_var_type type) const;
+  TYPELIB* plugin_var_typelib(void) const;
+  const uchar* do_value_ptr(THD *thd, enum_var_type type, const LEX_CSTRING *base) const;
+  const uchar* session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return do_value_ptr(thd, OPT_SESSION, base); }
-  uchar* global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar* global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return do_value_ptr(thd, OPT_GLOBAL, base); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return do_value_ptr(thd, OPT_DEFAULT, 0); }
   bool do_check(THD *thd, set_var *var);
   virtual void session_save_default(THD *thd, set_var *var) {}
@@ -3334,7 +3334,7 @@ sys_var_pluginvar::sys_var_pluginvar(sys_var_chain *chain, const char *name_arg,
   plugin_opt_set_limits(&option, pv);
 }
 
-uchar* sys_var_pluginvar::real_value_ptr(THD *thd, enum_var_type type)
+uchar* sys_var_pluginvar::real_value_ptr(THD *thd, enum_var_type type) const
 {
   if (type == OPT_DEFAULT)
   {
@@ -3408,7 +3408,7 @@ bool sys_var_pluginvar::session_is_default(THD *thd)
 }
 
 
-TYPELIB* sys_var_pluginvar::plugin_var_typelib(void)
+TYPELIB* sys_var_pluginvar::plugin_var_typelib(void) const
 {
   switch (plugin_var->flags & (PLUGIN_VAR_TYPEMASK | PLUGIN_VAR_THDLOCAL)) {
   case PLUGIN_VAR_ENUM:
@@ -3426,12 +3426,10 @@ TYPELIB* sys_var_pluginvar::plugin_var_typelib(void)
 }
 
 
-uchar* sys_var_pluginvar::do_value_ptr(THD *thd, enum_var_type type,
-                                       const LEX_CSTRING *base)
+const uchar* sys_var_pluginvar::do_value_ptr(THD *thd, enum_var_type type,
+                                             const LEX_CSTRING *base) const
 {
-  uchar* result;
-
-  result= real_value_ptr(thd, type);
+  const uchar* result= real_value_ptr(thd, type);
 
   if ((plugin_var->flags & PLUGIN_VAR_TYPEMASK) == PLUGIN_VAR_ENUM)
     result= (uchar*) get_type(plugin_var_typelib(), *(ulong*)result);

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -685,8 +685,12 @@ bool vers_select_conds_t::init_from_sysvar(THD *thd)
   if (type != SYSTEM_TIME_UNSPECIFIED && type != SYSTEM_TIME_ALL)
   {
     DBUG_ASSERT(type == SYSTEM_TIME_AS_OF);
+    MYSQL_TIME ltime;
+    thd->variables.time_zone->gmt_sec_to_TIME(&ltime, in.unix_time);
+    ltime.second_part = in.second_part;
+
     start.item= new (thd->mem_root)
-        Item_datetime_literal(thd, &in.ltime, TIME_SECOND_PART_DIGITS);
+        Item_datetime_literal(thd, &ltime, TIME_SECOND_PART_DIGITS);
     if (!start.item)
       return true;
   }

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -3558,16 +3558,35 @@ const char* get_one_variable(THD *thd,
                              const CHARSET_INFO **charset, char *buff,
                              size_t *length)
 {
-  void *value= variable->value;
+  union Any_pointer {
+    const void *as_void;
+    const uchar *as_uchar;
+    const char *as_char;
+    const char ** as_charptr;
+    const double *as_double;
+    const int * as_int;
+    const uint * as_uint;
+    const long *as_long;
+    const longlong *as_longlong;
+    const bool *as_bool;
+    const my_bool *as_my_bool;
+    const sys_var *as_sys_var;
+    const ha_rows *as_ha_rows;
+    const LEX_STRING *as_lex_cstring;
+    const SHOW_COMP_OPTION *as_show_comp_options;
+    const intptr as_intptr;
+  };
+  Any_pointer value {variable->value};
+  Any_pointer status_var_value {status_var};
   const char *pos= buff;
   const char *end= buff;
 
 
   if (show_type == SHOW_SYS)
   {
-    sys_var *var= (sys_var *) value;
+    const sys_var *var= value.as_sys_var;
     show_type= var->show_type();
-    value= var->value_ptr(thd, value_type, &null_clex_str);
+    value.as_uchar= var->value_ptr(thd, value_type, &null_clex_str);
     *charset= var->charset(thd);
   }
 
@@ -3577,66 +3596,65 @@ const char* get_one_variable(THD *thd,
   */
   switch (show_type) {
   case SHOW_DOUBLE_STATUS:
-    value= ((char *) status_var + (intptr) value);
+    value.as_char= status_var_value.as_char + value.as_intptr;
     /* fall through */
   case SHOW_DOUBLE:
     /* 6 is the default precision for '%f' in sprintf() */
-    end= buff + my_fcvt(*(double *) value, 6, buff, NULL);
+    end= buff + my_fcvt(*value.as_double, 6, buff, NULL);
     break;
   case SHOW_LONG_STATUS:
-    value= ((char *) status_var + (intptr) value);
+    value.as_char= status_var_value.as_char + value.as_intptr;
     /* fall through */
   case SHOW_ULONG:
   case SHOW_LONG_NOFLUSH: // the difference lies in refresh_status()
-    end= int10_to_str(*(long*) value, buff, 10);
+    end= int10_to_str(*value.as_long, buff, 10);
     break;
   case SHOW_LONGLONG_STATUS:
-    value= ((char *) status_var + (intptr) value);
+    value.as_char= status_var_value.as_char + value.as_intptr;
     /* fall through */
   case SHOW_ULONGLONG:
-    end= longlong10_to_str(*(longlong*) value, buff, 10);
+    end= longlong10_to_str(*value.as_longlong, buff, 10);
     break;
   case SHOW_HA_ROWS:
-    end= longlong10_to_str((longlong) *(ha_rows*) value, buff, 10);
+    end= longlong10_to_str((longlong) *value.as_ha_rows, buff, 10);
     break;
   case SHOW_BOOL:
-    end= strmov(buff, *(bool*) value ? "ON" : "OFF");
+    end= strmov(buff, *value.as_bool ? "ON" : "OFF");
     break;
   case SHOW_MY_BOOL:
-    end= strmov(buff, *(my_bool*) value ? "ON" : "OFF");
+    end= strmov(buff, *value.as_my_bool ? "ON" : "OFF");
     break;
   case SHOW_UINT32_STATUS:
-    value= ((char *) status_var + (intptr) value);
+    value.as_char= status_var_value.as_char + value.as_intptr;
     /* fall through */
   case SHOW_UINT:
-    end= int10_to_str((long) *(uint*) value, buff, 10);
+    end= int10_to_str((long) *value.as_uint, buff, 10);
     break;
   case SHOW_SINT:
-    end= int10_to_str((long) *(int*) value, buff, -10);
+    end= int10_to_str((long) *value.as_int, buff, -10);
     break;
   case SHOW_SLONG:
-    end= int10_to_str(*(long*) value, buff, -10);
+    end= int10_to_str(*value.as_long, buff, -10);
     break;
   case SHOW_SLONGLONG:
-    end= longlong10_to_str(*(longlong*) value, buff, -10);
+    end= longlong10_to_str(*value.as_longlong, buff, -10);
     break;
   case SHOW_HAVE:
     {
-      SHOW_COMP_OPTION tmp= *(SHOW_COMP_OPTION*) value;
-      pos= show_comp_option_name[(int) tmp];
+      pos= show_comp_option_name[(int) *value.as_show_comp_options];
       end= strend(pos);
       break;
     }
   case SHOW_CHAR:
     {
-      if (!(pos= (char*)value))
+      if (!(pos= value.as_char))
         pos= "";
       end= strend(pos);
       break;
     }
   case SHOW_CHAR_PTR:
     {
-      if (!(pos= *(char**) value))
+      if (!(pos= *value.as_charptr))
         pos= "";
 
       end= strend(pos);
@@ -3644,11 +3662,10 @@ const char* get_one_variable(THD *thd,
     }
   case SHOW_LEX_STRING:
     {
-      LEX_STRING *ls=(LEX_STRING*)value;
-      if (!(pos= ls->str))
+      if (!(pos= value.as_lex_cstring->str))
         end= pos= "";
       else
-        end= pos + ls->length;
+        end= pos + value.as_lex_cstring->length;
       break;
     }
   case SHOW_UNDEF:

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -438,11 +438,10 @@ static Sys_var_charptr Sys_my_bind_addr(
        READ_ONLY GLOBAL_VAR(my_bind_addr_str), CMD_LINE(REQUIRED_ARG),
        IN_FS_CHARSET, DEFAULT(0));
 
-const char *Sys_var_vers_asof::asof_keywords[]= {"DEFAULT", NULL};
 static Sys_var_vers_asof Sys_vers_asof_timestamp(
        "system_versioning_asof", "Default value for the FOR SYSTEM_TIME AS OF clause",
        SESSION_VAR(vers_asof_timestamp.type), NO_CMD_LINE,
-       Sys_var_vers_asof::asof_keywords, DEFAULT(SYSTEM_TIME_UNSPECIFIED));
+       DEFAULT(SYSTEM_TIME_UNSPECIFIED));
 
 static const char *vers_alter_history_keywords[]= {"ERROR", "KEEP", NullS};
 static Sys_var_enum Sys_vers_alter_history(

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1702,8 +1702,9 @@ static Sys_var_gtid_binlog_pos Sys_gtid_binlog_pos(
        READ_ONLY GLOBAL_VAR(opt_gtid_binlog_pos_dummy), NO_CMD_LINE);
 
 
-uchar *
-Sys_var_gtid_binlog_pos::global_value_ptr(THD *thd, const LEX_CSTRING *base)
+const uchar *
+Sys_var_gtid_binlog_pos::global_value_ptr(THD *thd,
+                                          const LEX_CSTRING *base) const
 {
   char buf[128];
   String str(buf, sizeof(buf), system_charset_info);
@@ -1730,8 +1731,9 @@ static Sys_var_gtid_current_pos Sys_gtid_current_pos(
        READ_ONLY GLOBAL_VAR(opt_gtid_current_pos_dummy), NO_CMD_LINE);
 
 
-uchar *
-Sys_var_gtid_current_pos::global_value_ptr(THD *thd, const LEX_CSTRING *base)
+const uchar *
+Sys_var_gtid_current_pos::global_value_ptr(THD *thd,
+                                           const LEX_CSTRING *base) const
 {
   String str;
   char *p;
@@ -1811,8 +1813,9 @@ Sys_var_gtid_slave_pos::global_update(THD *thd, set_var *var)
 }
 
 
-uchar *
-Sys_var_gtid_slave_pos::global_value_ptr(THD *thd, const LEX_CSTRING *base)
+const uchar *
+Sys_var_gtid_slave_pos::global_value_ptr(THD *thd,
+                                         const LEX_CSTRING *base) const
 {
   String str;
   char *p;
@@ -1932,8 +1935,9 @@ Sys_var_gtid_binlog_state::global_update(THD *thd, set_var *var)
 }
 
 
-uchar *
-Sys_var_gtid_binlog_state::global_value_ptr(THD *thd, const LEX_CSTRING *base)
+const uchar *
+Sys_var_gtid_binlog_state::global_value_ptr(THD *thd,
+                                            const LEX_CSTRING *base) const
 {
   char buf[512];
   String str(buf, sizeof(buf), system_charset_info);
@@ -1967,8 +1971,8 @@ static Sys_var_last_gtid Sys_last_gtid(
 export sys_var *Sys_last_gtid_ptr= &Sys_last_gtid; // for check changing
 
 
-uchar *
-Sys_var_last_gtid::session_value_ptr(THD *thd, const LEX_CSTRING *base)
+const uchar *
+Sys_var_last_gtid::session_value_ptr(THD *thd, const LEX_CSTRING *base) const
 {
   char buf[10+1+10+1+20+1];
   String str(buf, sizeof(buf), system_charset_info);
@@ -2119,9 +2123,10 @@ Sys_var_slave_parallel_mode::global_update(THD *thd, set_var *var)
 }
 
 
-uchar *
+const uchar *
 Sys_var_slave_parallel_mode::global_value_ptr(THD *thd,
-                                              const LEX_CSTRING *base_name)
+                                              const
+                                              LEX_CSTRING *base_name) const
 {
   Master_info *mi;
   enum_slave_parallel_mode val=
@@ -4925,8 +4930,9 @@ bool Sys_var_rpl_filter::set_filter_value(const char *value, Master_info *mi)
   return status;
 }
 
-uchar *Sys_var_rpl_filter::global_value_ptr(THD *thd,
-                                            const LEX_CSTRING *base_name)
+const uchar *
+Sys_var_rpl_filter::global_value_ptr(THD *thd,
+                                     const LEX_CSTRING *base_name) const
 {
   char buf[256];
   String tmp(buf, sizeof(buf), &my_charset_bin);
@@ -5038,7 +5044,7 @@ static Sys_var_uint Sys_slave_net_timeout(
 */
 
 ulonglong Sys_var_multi_source_ulonglong::
-get_master_info_ulonglong_value(THD *thd, ptrdiff_t offset)
+get_master_info_ulonglong_value(THD *thd, ptrdiff_t offset) const
 {
   Master_info *mi;
   ulonglong res= 0;                                  // Default value

--- a/sql/sys_vars.ic
+++ b/sql/sys_vars.ic
@@ -223,7 +223,7 @@ public:
   { var->save_result.ulonglong_value= option.def_value; }
   private:
   T get_max_var() { return *((T*) max_var_ptr()); }
-  uchar *default_value_ptr(THD *thd) { return (uchar*) &option.def_value; }
+  const uchar *default_value_ptr(THD *thd) const { return (uchar*) &option.def_value; }
 };
 
 typedef Sys_var_integer<int, GET_INT, SHOW_SINT> Sys_var_int;
@@ -234,25 +234,25 @@ typedef Sys_var_integer<ulonglong, GET_ULL, SHOW_ULONGLONG> Sys_var_ulonglong;
 typedef Sys_var_integer<long, GET_LONG, SHOW_SLONG> Sys_var_long;
 
 
-template<> uchar *Sys_var_int::default_value_ptr(THD *thd)
+template<> const uchar *Sys_var_int::default_value_ptr(THD *thd) const
 {
   thd->sys_var_tmp.int_value= (int)option.def_value;
   return (uchar*) &thd->sys_var_tmp.int_value;
 }
 
-template<> uchar *Sys_var_uint::default_value_ptr(THD *thd)
+template<> const uchar *Sys_var_uint::default_value_ptr(THD *thd) const
 {
   thd->sys_var_tmp.uint_value= (uint)option.def_value;
   return (uchar*) &thd->sys_var_tmp.uint_value;
 }
 
-template<> uchar *Sys_var_long::default_value_ptr(THD *thd)
+template<> const uchar *Sys_var_long::default_value_ptr(THD *thd) const
 {
   thd->sys_var_tmp.long_value= (long)option.def_value;
   return (uchar*) &thd->sys_var_tmp.long_value;
 }
 
-template<> uchar *Sys_var_ulong::default_value_ptr(THD *thd)
+template<> const uchar *Sys_var_ulong::default_value_ptr(THD *thd) const
 {
   thd->sys_var_tmp.ulong_value= (ulong)option.def_value;
   return (uchar*) &thd->sys_var_tmp.ulong_value;
@@ -382,13 +382,13 @@ public:
   { var->save_result.ulonglong_value= global_var(ulong); }
   void global_save_default(THD *thd, set_var *var)
   { var->save_result.ulonglong_value= option.def_value; }
-  uchar *valptr(THD *thd, ulong val)
-  { return (uchar*)typelib.type_names[val]; }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *valptr(THD *thd, ulong val) const
+  { return reinterpret_cast<const uchar*>(typelib.type_names[val]); }
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, session_var(thd, ulong)); }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(ulong)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return valptr(thd, (ulong)option.def_value); }
 
   ulong get_max_var() { return *((ulong *) max_var_ptr()); }
@@ -436,7 +436,7 @@ public:
   { var->save_result.ulonglong_value= (ulonglong)*(my_bool *)global_value_ptr(thd, 0); }
   void global_save_default(THD *thd, set_var *var)
   { var->save_result.ulonglong_value= option.def_value; }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   {
     thd->sys_var_tmp.my_bool_value=(my_bool) option.def_value;
     return (uchar*) &thd->sys_var_tmp.my_bool_value;
@@ -678,7 +678,7 @@ public:
   void global_save_default(THD *thd, set_var *var)
   { DBUG_ASSERT(FALSE); }
 protected:
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     return thd->security_ctx->proxy_user[0] ?
       (uchar *) &(thd->security_ctx->proxy_user[0]) : NULL;
@@ -694,7 +694,7 @@ public:
   {}
 
 protected:
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     return (uchar*)thd->security_ctx->external_user;
   }
@@ -734,7 +734,7 @@ public:
   bool global_update(THD *thd, set_var *var);
 
 protected:
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base);
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
   bool set_filter_value(const char *value, Master_info *mi);
 };
 
@@ -852,7 +852,7 @@ public:
   {
     DBUG_ASSERT(FALSE);
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(FALSE);
     return NULL;
@@ -922,19 +922,19 @@ public:
     char *ptr= (char*)(intptr)option.def_value;
     var->save_result.string_value.str= ptr;
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     char buf[256];
     DBUG_EXPLAIN(buf, sizeof(buf));
     return (uchar*) thd->strdup(buf);
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     char buf[256];
     DBUG_EXPLAIN_INITIAL(buf, sizeof(buf));
     return (uchar*) thd->strdup(buf);
   }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return (uchar*)""; }
 };
 #endif
@@ -1010,7 +1010,7 @@ public:
 
     return keycache_update(thd, key_cache, offset, new_value);
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     KEY_CACHE *key_cache= get_key_cache(base);
     if (!key_cache)
@@ -1195,7 +1195,7 @@ public:
               lock, binlog_status_arg, on_check_func, on_update_func,
               substitute)
   { }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     if (thd->user_connect && thd->user_connect->user_resources.user_conn)
       return (uchar*) &(thd->user_connect->user_resources.user_conn);
@@ -1307,13 +1307,13 @@ public:
   { var->save_result.ulonglong_value= global_var(ulonglong); }
   void global_save_default(THD *thd, set_var *var)
   { var->save_result.ulonglong_value= option.def_value; }
-  uchar *valptr(THD *thd, ulonglong val)
+  const uchar *valptr(THD *thd, ulonglong val) const
   { return (uchar*)flagset_to_string(thd, 0, val, typelib.type_names); }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, session_var(thd, ulonglong)); }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(ulonglong)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return valptr(thd, option.def_value); }
 };
 
@@ -1421,13 +1421,13 @@ public:
   { var->save_result.ulonglong_value= global_var(ulonglong); }
   void global_save_default(THD *thd, set_var *var)
   { var->save_result.ulonglong_value= option.def_value; }
-  uchar *valptr(THD *thd, ulonglong val)
-  { return (uchar*)set_to_string(thd, 0, val, typelib.type_names); }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *valptr(THD *thd, ulonglong val) const
+  { return reinterpret_cast<const uchar*>(set_to_string(thd, 0, val, typelib.type_names)); }
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, session_var(thd, ulonglong)); }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(ulonglong)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return valptr(thd, option.def_value); }
 
   ulonglong get_max_var() { return *((ulonglong*) max_var_ptr()); }
@@ -1524,7 +1524,7 @@ public:
     plugin_ref plugin= global_var(plugin_ref);
     var->save_result.plugin= plugin ? my_plugin_lock(thd, plugin) : 0;
   }
-  plugin_ref get_default(THD *thd)
+  plugin_ref get_default(THD *thd) const
   {
     char *default_value= *reinterpret_cast<char**>(option.def_value);
     if (!default_value)
@@ -1546,16 +1546,16 @@ public:
     var->save_result.plugin= get_default(thd);
   }
 
-  uchar *valptr(THD *thd, plugin_ref plugin)
+  uchar *valptr(THD *thd, plugin_ref plugin) const
   {
     return (uchar*)(plugin ? thd->strmake(plugin_name(plugin)->str,
                                           plugin_name(plugin)->length) : 0);
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, session_var(thd, plugin_ref)); }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(plugin_ref)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return valptr(thd, get_default(thd)); }
 };
 
@@ -1642,7 +1642,7 @@ public:
     plugin_ref* plugins= global_var(plugin_ref *);
     var->save_result.plugins= plugins ? temp_copy_engine_list(thd, plugins) : 0;
   }
-  plugin_ref *get_default(THD *thd)
+  plugin_ref *get_default(THD *thd) const
   {
     char *default_value= *reinterpret_cast<char**>(option.def_value);
     if (!default_value)
@@ -1656,15 +1656,15 @@ public:
     var->save_result.plugins= get_default(thd);
   }
 
-  uchar *valptr(THD *thd, plugin_ref *plugins)
+  uchar *valptr(THD *thd, plugin_ref *plugins) const
   {
-    return (uchar*)pretty_print_engine_list(thd, plugins);
+    return reinterpret_cast<uchar*>(pretty_print_engine_list(thd, plugins));
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, session_var(thd, plugin_ref*)); }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(plugin_ref*)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return valptr(thd, get_default(thd)); }
 };
 
@@ -1728,16 +1728,16 @@ public:
   {
     DBUG_ASSERT(FALSE);
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     return debug_sync_value_ptr(thd);
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return (uchar*)""; }
 };
 #endif /* defined(ENABLED_DEBUG_SYNC) */
@@ -1810,16 +1810,16 @@ public:
   void global_save_default(THD *thd, set_var *var)
   { var->save_result.ulonglong_value= option.def_value; }
 
-  uchar *valptr(THD *thd, ulonglong val)
+  uchar *valptr(THD *thd, ulonglong val) const
   {
     thd->sys_var_tmp.my_bool_value= reverse_semantics ^ ((val & bitmask) != 0);
     return (uchar*) &thd->sys_var_tmp.my_bool_value;
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, session_var(thd, ulonglong)); }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(ulonglong)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   {
     thd->sys_var_tmp.my_bool_value= option.def_value != 0;
     return (uchar*) &thd->sys_var_tmp.my_bool_value;
@@ -1878,17 +1878,17 @@ public:
   { var->value= 0; }
   void global_save_default(THD *thd, set_var *var)
   { DBUG_ASSERT(FALSE); }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     thd->sys_var_tmp.ulonglong_value= read_func(thd);
     return (uchar*) &thd->sys_var_tmp.ulonglong_value;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   {
     thd->sys_var_tmp.ulonglong_value= 0;
     return (uchar*) &thd->sys_var_tmp.ulonglong_value;
@@ -1944,18 +1944,18 @@ public:
   { var->value= 0; }
   void global_save_default(THD *thd, set_var *var)
   { DBUG_ASSERT(FALSE); }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     thd->sys_var_tmp.double_value= thd->start_time +
           thd->start_time_sec_part/(double)TIME_SECOND_PART_FACTOR;
     return (uchar*) &thd->sys_var_tmp.double_value;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   {
     thd->sys_var_tmp.double_value= 0;
     return (uchar*) &thd->sys_var_tmp.double_value;
@@ -2014,12 +2014,12 @@ public:
   }
   void session_save_default(THD *thd, set_var *var) { }
   void global_save_default(THD *thd, set_var *var) { }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     return (uchar*)show_comp_option_name[global_var(enum SHOW_COMP_OPTION)];
   }
@@ -2089,13 +2089,13 @@ public:
     void **default_value= reinterpret_cast<void**>(option.def_value);
     var->save_result.ptr= *default_value;
   }
-  uchar *valptr(THD *thd, uchar *val)
+  uchar *valptr(THD *thd, uchar *val) const
   { return val ? *(uchar**)(val+name_offset) : 0; }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, session_var(thd, uchar*)); }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(uchar*)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return valptr(thd, *(uchar**)option.def_value); }
 };
 
@@ -2165,9 +2165,9 @@ public:
     var->save_result.time_zone=
       *(Time_zone**)(intptr)option.def_value;
   }
-  uchar *valptr(THD *thd, Time_zone *val)
-  { return (uchar *)(val->get_name()->ptr()); }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *valptr(THD *thd, Time_zone *val) const
+  { return reinterpret_cast<const uchar*>(val->get_name()->ptr()); }
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     /*
       This is an ugly fix for replication: we don't replicate properly queries
@@ -2180,9 +2180,9 @@ public:
     thd->time_zone_used= 1;
     return valptr(thd, session_var(thd, Time_zone *));
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return valptr(thd, global_var(Time_zone*)); }
-  uchar *default_value_ptr(THD *thd)
+  const uchar *default_value_ptr(THD *thd) const
   { return valptr(thd, *(Time_zone**)option.def_value); }
 };
 
@@ -2341,7 +2341,7 @@ public:
     /* Use value given in variable declaration */
     global_save_default(thd, var);
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     ulonglong *tmp, res;
     tmp= (ulonglong*) (((uchar*)&(thd->variables)) + offset);
@@ -2349,11 +2349,11 @@ public:
     *tmp= res;
     return (uchar*) tmp;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     return session_value_ptr(thd, base);
   }
-  ulonglong get_master_info_ulonglong_value(THD *thd, ptrdiff_t offset);
+  ulonglong get_master_info_ulonglong_value(THD *thd, ptrdiff_t offset) const;
   bool update_variable(THD *thd, Master_info *mi)
   {
     return update_multi_source_variable_func(this, thd, mi);
@@ -2401,12 +2401,12 @@ public:
   {
     DBUG_ASSERT(false);
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base);
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
 };
 
 
@@ -2450,12 +2450,12 @@ public:
   {
     DBUG_ASSERT(false);
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base);
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
 };
 
 
@@ -2490,13 +2490,13 @@ public:
     /* Record the attempt to use default so we can error. */
     var->value= 0;
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base);
-  uchar *default_value_ptr(THD *thd)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
+  const uchar *default_value_ptr(THD *thd) const
   { return 0; }
 };
 
@@ -2532,13 +2532,13 @@ public:
     /* Record the attempt to use default so we can error. */
     var->value= 0;
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base);
-  uchar *default_value_ptr(THD *thd)
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
+  const uchar *default_value_ptr(THD *thd) const
   { return 0; }
 };
 
@@ -2582,8 +2582,8 @@ public:
   {
     DBUG_ASSERT(false);
   }
-  uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base);
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const;
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   {
     DBUG_ASSERT(false);
     return NULL;
@@ -2609,7 +2609,7 @@ public:
     SYSVAR_ASSERT(scope() == GLOBAL);
   }
   bool global_update(THD *thd, set_var *var);
-  uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base);
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
 };
 
 
@@ -2687,8 +2687,9 @@ public:
   }
 
 private:
-  uchar *value_ptr(THD *thd, vers_asof_timestamp_t &val)
+  const uchar *value_ptr(THD *thd, vers_asof_timestamp_t &val) const
   {
+    const char *value;
     switch (val.type)
     {
     case SYSTEM_TIME_UNSPECIFIED:
@@ -2696,29 +2697,30 @@ private:
       break;
     case SYSTEM_TIME_AS_OF:
     {
-      uchar *buf= (uchar*) thd->alloc(MAX_DATE_STRING_REP_LENGTH);
+      char *buf= (char*) thd->alloc(MAX_DATE_STRING_REP_LENGTH);
       MYSQL_TIME ltime;
 
       thd->variables.time_zone->gmt_sec_to_TIME(&ltime, val.unix_time);
       ltime.second_part= val.second_part;
 
-      if (buf && !my_datetime_to_str(&ltime, (char*) buf, 6))
+      value= buf;
+      if (buf && !my_datetime_to_str(&ltime, buf, 6))
       {
         my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name.str, "NULL (wrong datetime)");
-        return (uchar*) thd->strdup("Error: wrong datetime");
+        value= thd->strdup("Error: wrong datetime");
       }
-      return buf;
-    }
-    default:
       break;
     }
-    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name.str, "NULL (wrong range type)");
-    return (uchar*) thd->strdup("Error: wrong range type");
+    default:
+      my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name.str, "NULL (wrong range type)");
+      value= thd->strdup("Error: wrong range type");
+    }
+    return reinterpret_cast<const uchar *>(value);
   }
 
 public:
-  virtual uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base)
+  virtual const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return value_ptr(thd, session_var(thd, vers_asof_timestamp_t)); }
-  virtual uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base)
+  virtual const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
   { return value_ptr(thd, global_var(vers_asof_timestamp_t)); }
 };

--- a/sql/sys_vars.ic
+++ b/sql/sys_vars.ic
@@ -2632,49 +2632,45 @@ public:
   virtual bool do_check(THD *thd, set_var *var)
   {
     if (!Sys_var_enum::do_check(thd, var))
-      return false;
-    MYSQL_TIME ltime;
-    bool res= var->value->get_date(&ltime, 0);
-    if (!res)
     {
-      var->save_result.ulonglong_value= SYSTEM_TIME_AS_OF;
+      var->save_result.time.time_type= MYSQL_TIMESTAMP_NONE;
+      return false;
+    }
+    bool res= var->value->get_date(&var->save_result.time, 0);
+    if (res)
+    {
+      var->save_result.time.time_type= MYSQL_TIMESTAMP_ERROR;
     }
     return res;
   }
 
 private:
-  bool update(set_var *var, vers_asof_timestamp_t &out, system_variables& pool)
+  bool update(THD *thd, set_var *var, vers_asof_timestamp_t *out)
   {
-    bool res= false;
-    uint error;
-    MYSQL_TIME ltime;
-    out.type= static_cast<enum_var_type>(var->save_result.ulonglong_value);
-    if (out.type == SYSTEM_TIME_AS_OF)
+    MYSQL_TIME &ltime= var->save_result.time;
+    uint error= 0;
+
+    if (var->value && ltime.time_type >= 0) // any valid value is ok
     {
-      if (var->value)
-      {
-        res= var->value->get_date(&ltime, 0);
-        out.unix_time= pool.time_zone->TIME_to_gmt_sec(&ltime, &error);
-        out.second_part= ltime.second_part;
-        res|= (error != 0);
-      }
-      else // set DEFAULT from global var
-      {
-        out.type= SYSTEM_TIME_UNSPECIFIED;
-        res= false;
-      }
+      out->type       = SYSTEM_TIME_AS_OF;
+      out->unix_time  = thd->variables.time_zone->TIME_to_gmt_sec(&ltime, &error);
+      out->second_part= ltime.second_part;
     }
-    return res;
+    else // DEFAULT is set
+    {
+      out->type= SYSTEM_TIME_UNSPECIFIED;
+    }
+    return (error != 0);
   }
 
 public:
   virtual bool global_update(THD *thd, set_var *var)
   {
-    return update(var, global_var(vers_asof_timestamp_t), thd->variables);
+    return update(thd, var, &global_var(vers_asof_timestamp_t));
   }
   virtual bool session_update(THD *thd, set_var *var)
   {
-    return update(var, session_var(thd, vers_asof_timestamp_t), thd->variables);
+    return update(thd, var, &session_var(thd, vers_asof_timestamp_t));
   }
 
 private:

--- a/sql/sys_vars.ic
+++ b/sql/sys_vars.ic
@@ -2613,25 +2613,26 @@ public:
 };
 
 
-class Sys_var_vers_asof: public Sys_var_enum
+class Sys_var_vers_asof: public sys_var
 {
-public:
-  static const char *asof_keywords[];
-
 public:
   Sys_var_vers_asof(const char *name_arg,
           const char *comment, int flag_args, ptrdiff_t off, size_t size,
-          CMD_LINE getopt, const char *values[],
-          uint def_val)
-    : Sys_var_enum(name_arg, comment, flag_args, off, size,
-                   getopt, values, def_val)
+          CMD_LINE getopt, uint def_val,
+          PolyLock *lock= NO_MUTEX_GUARD,
+          binlog_status_enum binlog_status_arg= VARIABLE_NOT_IN_BINLOG,
+          on_check_function on_check_func= NULL,
+          on_update_function on_update_func= NULL,
+          const char *substitute= NULL)
+    : sys_var(&all_sys_vars, name_arg, comment, flag_args, off,
+              getopt.id, getopt.arg_type, SHOW_CHAR, def_val, lock,
+              binlog_status_arg, on_check_func, on_update_func, substitute)
   {
-    // setval() accepts string rather enum
     option.var_type= GET_STR;
   }
   virtual bool do_check(THD *thd, set_var *var)
   {
-    if (!Sys_var_enum::do_check(thd, var))
+    if (!var->value)
     {
       var->save_result.time.time_type= MYSQL_TIMESTAMP_NONE;
       return false;
@@ -2645,22 +2646,25 @@ public:
   }
 
 private:
-  bool update(THD *thd, set_var *var, vers_asof_timestamp_t *out)
+  static bool update(THD *thd, set_var *var, vers_asof_timestamp_t *out)
   {
     MYSQL_TIME &ltime= var->save_result.time;
     uint error= 0;
 
-    if (var->value && ltime.time_type >= 0) // any valid value is ok
+    if (var->value)
     {
+      DBUG_ASSERT(ltime.time_type >= 0);
       out->type       = SYSTEM_TIME_AS_OF;
       out->unix_time  = thd->variables.time_zone->TIME_to_gmt_sec(&ltime, &error);
       out->second_part= ltime.second_part;
     }
-    else // DEFAULT is set
-    {
-      out->type= SYSTEM_TIME_UNSPECIFIED;
-    }
     return (error != 0);
+  }
+
+  static void save_default(set_var *var, vers_asof_timestamp_t *out)
+  {
+    out->type= SYSTEM_TIME_UNSPECIFIED;
+    var->save_result.time.time_type= MYSQL_TIMESTAMP_NONE;
   }
 
 public:
@@ -2673,14 +2677,23 @@ public:
     return update(thd, var, &session_var(thd, vers_asof_timestamp_t));
   }
 
+  virtual void session_save_default(THD *thd, set_var *var)
+  {
+    save_default(var, &session_var(thd, vers_asof_timestamp_t));
+  }
+  virtual void global_save_default(THD *thd, set_var *var)
+  {
+    save_default(var, &global_var(vers_asof_timestamp_t));
+  }
+
 private:
   uchar *value_ptr(THD *thd, vers_asof_timestamp_t &val)
   {
     switch (val.type)
     {
     case SYSTEM_TIME_UNSPECIFIED:
-    case SYSTEM_TIME_ALL:
-      return (uchar*) thd->strdup(asof_keywords[val.type]);
+      return (uchar*)"DEFAULT";
+      break;
     case SYSTEM_TIME_AS_OF:
     {
       uchar *buf= (uchar*) thd->alloc(MAX_DATE_STRING_REP_LENGTH);

--- a/sql/sys_vars.ic
+++ b/sql/sys_vars.ic
@@ -2643,19 +2643,24 @@ public:
   }
 
 private:
-  bool update(set_var *var, vers_asof_timestamp_t &out)
+  bool update(set_var *var, vers_asof_timestamp_t &out, system_variables& pool)
   {
     bool res= false;
+    uint error;
+    MYSQL_TIME ltime;
     out.type= static_cast<enum_var_type>(var->save_result.ulonglong_value);
     if (out.type == SYSTEM_TIME_AS_OF)
     {
       if (var->value)
       {
-        res= var->value->get_date(&out.ltime, 0);
+        res= var->value->get_date(&ltime, 0);
+        out.unix_time= pool.time_zone->TIME_to_gmt_sec(&ltime, &error);
+        out.second_part= ltime.second_part;
+        res|= (error != 0);
       }
       else // set DEFAULT from global var
       {
-        out= global_var(vers_asof_timestamp_t);
+        out.type= SYSTEM_TIME_UNSPECIFIED;
         res= false;
       }
     }
@@ -2665,11 +2670,11 @@ private:
 public:
   virtual bool global_update(THD *thd, set_var *var)
   {
-    return update(var, global_var(vers_asof_timestamp_t));
+    return update(var, global_var(vers_asof_timestamp_t), thd->variables);
   }
   virtual bool session_update(THD *thd, set_var *var)
   {
-    return update(var, session_var(thd, vers_asof_timestamp_t));
+    return update(var, session_var(thd, vers_asof_timestamp_t), thd->variables);
   }
 
 private:
@@ -2683,10 +2688,14 @@ private:
     case SYSTEM_TIME_AS_OF:
     {
       uchar *buf= (uchar*) thd->alloc(MAX_DATE_STRING_REP_LENGTH);
-      if (buf &&!my_datetime_to_str(&val.ltime, (char*) buf, 6))
+      MYSQL_TIME ltime;
+
+      thd->variables.time_zone->gmt_sec_to_TIME(&ltime, val.unix_time);
+      ltime.second_part= val.second_part;
+
+      if (buf && !my_datetime_to_str(&ltime, (char*) buf, 6))
       {
-        // TODO: figure out variable name
-        my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), "system_versioning_asof_timestamp", "NULL (wrong datetime)");
+        my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name.str, "NULL (wrong datetime)");
         return (uchar*) thd->strdup("Error: wrong datetime");
       }
       return buf;
@@ -2694,7 +2703,7 @@ private:
     default:
       break;
     }
-    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), "system_versioning_asof_timestamp", "NULL (wrong range type)");
+    my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name.str, "NULL (wrong range type)");
     return (uchar*) thd->strdup("Error: wrong range type");
   }
 


### PR DESCRIPTION
Two bugs are fixed:
1. MDEV-16026: Global system_versioning_asof must not be used if client sessions can have non-default time zone
2. MDEV-16481: set global system_versioning_asof=sf() crashes in specific case

Two more commits are the refactorings -- see comments below.

Behavior changed:
* system_versioning_asof value is stored as unix timestamp. Temporal values are converted with respect to local time zone.
* "DEFAULT" string is not accepted anymore. DEFAULT sql keyword should be used instead.