### PR TITLE
connect engine: GetStringUTFChars takes pointer arg

### DIFF
--- a/storage/connect/javaconn.cpp
+++ b/storage/connect/javaconn.cpp
@@ -153,7 +153,7 @@ bool JAVAConn::Check(jint rc)
 
 		if (exc != nullptr && tid != nullptr) {
 			jstring s = (jstring)env->CallObjectMethod(exc, tid);
-			const char *utf = env->GetStringUTFChars(s, (jboolean)false);
+			const char *utf = env->GetStringUTFChars(s, NULL);
 			env->DeleteLocalRef(s);
 			Msg = PlugDup(m_G, utf);
 		} else
@@ -162,7 +162,7 @@ bool JAVAConn::Check(jint rc)
 		env->ExceptionClear();
 	} else if (rc < 0) {
 		s = (jstring)env->CallObjectMethod(job, errid);
-		Msg = (char*)env->GetStringUTFChars(s, (jboolean)false);
+		Msg = (char*)env->GetStringUTFChars(s, NULL);
 	} else
 		Msg = NULL;
 

--- a/storage/connect/jdbconn.cpp
+++ b/storage/connect/jdbconn.cpp
@@ -828,11 +828,11 @@ bool JDBConn::Connect(PJPARM sop)
 		jstring s = (jstring)env->CallObjectMethod(job, qcid);
 
 		if (s != nullptr) {
-			char *qch = (char*)env->GetStringUTFChars(s, (jboolean)false);
+			char *qch = (char*)env->GetStringUTFChars(s, NULL);
 			m_IDQuoteChar[0] = *qch;
 		} else {
 			s = (jstring)env->CallObjectMethod(job, errid);
-			Msg = (char*)env->GetStringUTFChars(s, (jboolean)false);
+			Msg = (char*)env->GetStringUTFChars(s, NULL);
 		}	// endif s
 
 	}	// endif qcid
@@ -1010,7 +1010,7 @@ void JDBConn::SetColumnValue(int rank, PSZ name, PVAL val)
 			cn = nullptr;
 
 		if (cn) {
-			field = env->GetStringUTFChars(cn, (jboolean)false);
+			field = env->GetStringUTFChars(cn, NULL);
 			val->SetValue_psz((PSZ)field);
 		} else
 			val->Reset();
@@ -1084,7 +1084,7 @@ void JDBConn::SetColumnValue(int rank, PSZ name, PVAL val)
 			cn = nullptr;
 
 		if (cn) {
-			const char *field = env->GetStringUTFChars(cn, (jboolean)false);
+			const char *field = env->GetStringUTFChars(cn, NULL);
 			val->SetValue_psz((PSZ)field);
 		} else
 			val->Reset();
@@ -1462,7 +1462,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 				return NULL;
 			} // endif label
 
-			name = env->GetStringUTFChars(label, (jboolean)false);
+			name = env->GetStringUTFChars(label, NULL);
 			crp = qrp->Colresp;                    // Column_Name
 			crp->Kdata->SetValue((char*)name, i);
 			n = env->GetIntArrayElements(val, 0);

--- a/storage/connect/jmgoconn.cpp
+++ b/storage/connect/jmgoconn.cpp
@@ -522,7 +522,7 @@ PSZ JMgoConn::GetDocument(void)
 		jdc = (jstring)env->CallObjectMethod(job, getdocid);
 
 		if (jdc)
-			doc = (PSZ)env->GetStringUTFChars(jdc, (jboolean)false);
+			doc = (PSZ)env->GetStringUTFChars(jdc, NULL);
 
 	} // endif getdocid
 
@@ -807,7 +807,7 @@ PSZ JMgoConn::GetColumnValue(PSZ path)
 		fn = (jstring)env->CallObjectMethod(job, objfldid, jn);
 
 		if (fn)
-			fld = (PSZ)env->GetStringUTFChars(fn, (jboolean)false);
+			fld = (PSZ)env->GetStringUTFChars(fn, NULL);
 
 	}	// endif objfldid
 

--- a/storage/connect/tabjmg.cpp
+++ b/storage/connect/tabjmg.cpp
@@ -101,7 +101,7 @@ bool JMGDISC::ColDesc(PGLOBAL g, jobject obj, char *pcn, char *pfmt,
 			continue;
 
 		jkey = (jstring)Jcp->env->CallObjectMethod(Jcp->job, bvnameid);
-		key = Jcp->env->GetStringUTFChars(jkey, (jboolean)false);
+		key = Jcp->env->GetStringUTFChars(jkey, NULL);
 
 		if (pcn) {
 			strncpy(colname, pcn, 64);


### PR DESCRIPTION
The argument takes a pointer, so casting ```false``` to ```jboolean``` and expecting an implicit conversion to NULL is just ugly.

Avoids compile errors of the from from clang are avoided:

/storage/connect/jdbconn.cpp:1473:41: error: cannot initialize a parameter of type 'jboolean *' (aka 'unsigned char *') with an rvalue of type 'jboolean' (aka 'unsigned char')
   name = env->GetStringUTFChars(label, (jboolean)false);
                                        ^~~~~~~~~~~~~~~
/usr/lib/jvm/java-8-oracle/include/jni.h:1616:58: note: passing argument to parameter 'isCopy' here
    const char* GetStringUTFChars(jstring str, jboolean *isCopy) {