### PR TITLE
MDEV-16658 Memory leak in mysqltest on connect failure

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -5910,6 +5910,7 @@ do_handle_error:
     var_set_errno(mysql_errno(con));
     handle_error(command, mysql_errno(con), mysql_error(con),
 		 mysql_sqlstate(con), ds);
+    mysql_close(con);
     return 0; /* Not connected */
   }
 


### PR DESCRIPTION
Close connection handler on connection failure. This fixes 14 failing tests in
main suite under clang+ASAN build.

ASAN repost looks like this:
```
=================================================================
==25495==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 146280 byte(s) in 115 object(s) allocated from:
    #0 0x4fba47 in calloc /fun/cpp_projects/llvm_toolchain/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:138
    #1 0x5a7a02 in mysql_init /work/mariadb/libmariadb/libmariadb/mariadb_lib.c:977:26
    #2 0x570a7a in do_connect(st_command*) /work/mariadb/client/mysqltest.cc:6096:26
    #3 0x584c39 in main /work/mariadb/client/mysqltest.cc:9321:9
    #4 0x7fd15514db96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310

Indirect leak of 7065600 byte(s) in 115 object(s) allocated from:
    #0 0x4fb80f in __interceptor_malloc /fun/cpp_projects/llvm_toolchain/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:129
    #1 0x637a83 in my_context_init /work/mariadb/libmariadb/libmariadb/ma_context.c:367:23
    #2 0x59fd16 in mysql_optionsv /work/mariadb/libmariadb/libmariadb/mariadb_lib.c:2738:9
    #3 0x5bc1d4 in mysql_options /work/mariadb/libmariadb/libmariadb/mariadb_lib.c:3242:10
    #4 0x570b94 in do_connect(st_command*) /work/mariadb/client/mysqltest.cc:6103:7
    #5 0x584c39 in main /work/mariadb/client/mysqltest.cc:9321:9
    #6 0x7fd15514db96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310

Indirect leak of 940240 byte(s) in 115 object(s) allocated from:
    #0 0x4fb80f in __interceptor_malloc /fun/cpp_projects/llvm_toolchain/llvm/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:129
    #1 0x64386e in ma_init_dynamic_array /work/mariadb/libmariadb/libmariadb/ma_array.c:49:31
    #2 0x649ead in _hash_init /work/mariadb/libmariadb/libmariadb/ma_hash.c:52:7
    #3 0x5a3080 in mysql_optionsv /work/mariadb/libmariadb/libmariadb/mariadb_lib.c:2938:13
    #4 0x5bc20c in mysql_options4 /work/mariadb/libmariadb/libmariadb/mariadb_lib.c:3248:10
    #5 0x56f63b in connect_n_handle_errors(st_command*, st_mysql*, char const*, char const*, char const*, char const*, int, char const*) /work/mariadb/client/mysqltest.cc:5874:3
    #6 0x57146b in do_connect(st_command*) /work/mariadb/client/mysqltest.cc:6193:7
    #7 0x584c39 in main /work/mariadb/client/mysqltest.cc:9321:9
    #8 0x7fd15514db96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
```

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.