### PR TITLE
travis: llvm repo gpg key missing - use travis defination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
-      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
+      - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-trusty-6.0
     packages: # make sure these include all compilers and all build dependencies (see list above)
       - gcc-5
       - g++-5


### PR DESCRIPTION
before @ottok explodes about travis breaking......

I submit this under the MCA.