### PR TITLE
MDEV-16764: Crash on delete from sql-versioned table with update trigger

### DIFF
--- a/mysql-test/suite/versioning/r/delete.result
+++ b/mysql-test/suite/versioning/r/delete.result
@@ -42,6 +42,20 @@ XNo_vt1
 2
 4
 5
+# MDEV-16764 Crash on delete from sql-versioned table with update trigger
+create or replace table log_tbl(log varchar(4));
+create or replace procedure log(s varchar(4)) insert into log_tbl values(s);
+create trigger tr2upd before update on t1 for each row call log('>UPD');
+create trigger tr1upd after  update on t1 for each row call log('<UPD');
+create trigger tr2del before delete on t1 for each row call log('>DEL');
+create trigger tr1del after  delete on t1 for each row call log('<DEL');
+delete from t1 where XNo = 4;
+select * from log_tbl;
+log
+>DEL
+<DEL
+drop procedure log;
+drop table log_tbl;
 drop view vt1;
 drop table t1;
 create or replace table t1(

--- a/mysql-test/suite/versioning/t/delete.test
+++ b/mysql-test/suite/versioning/t/delete.test
@@ -28,6 +28,20 @@ create view vt1 as select XNo from t1;
 select XNo as XNo_vt1 from vt1;
 delete from vt1 where XNo = 3;
 select XNo as XNo_vt1 from vt1;
+
+--echo # MDEV-16764 Crash on delete from sql-versioned table with update trigger
+create or replace table log_tbl(log varchar(4));
+create or replace procedure log(s varchar(4)) insert into log_tbl values(s);
+create trigger tr2upd before update on t1 for each row call log('>UPD');
+create trigger tr1upd after  update on t1 for each row call log('<UPD');
+create trigger tr2del before delete on t1 for each row call log('>DEL');
+create trigger tr1del after  delete on t1 for each row call log('<DEL');
+
+delete from t1 where XNo = 4;
+select * from log_tbl;
+
+drop procedure log;
+drop table log_tbl;
 drop view vt1;
 drop table t1;
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -8380,8 +8380,10 @@ fill_record_n_invoke_before_triggers(THD *thd, TABLE *table,
   int result;
   Table_triggers_list *triggers= table->triggers;
 
-  result= fill_record(thd, table, fields, values, ignore_errors,
-                      event == TRG_EVENT_UPDATE);
+  bool update= event == TRG_EVENT_UPDATE ||
+               (event == TRG_EVENT_DELETE && table->versioned(VERS_TIMESTAMP));
+
+  result= fill_record(thd, table, fields, values, ignore_errors, update);
 
   if (!result && triggers)
   {


### PR DESCRIPTION
* mysql_update_inner: use delete triggers for timestamp-versioned `DELETE`
* fill_record_n_invoke_before_triggers: respect timestamp-versioned `DELETE`

related to tempesta-tech/mariadb#517