### PR TITLE
MDEV-16252: MINIMAL binlog_row_image does not work for versioned tables

### DIFF
--- a/mysql-test/suite/versioning/r/rpl.result
+++ b/mysql-test/suite/versioning/r/rpl.result
@@ -164,4 +164,23 @@ update t1 set i = 0;
 connection slave;
 connection master;
 drop table t1;
+# MDEV-16372 ER_BASE64_DECODE_ERROR upon replaying binary log with system table
+flush logs;
+set @@session.time_zone='+00:00';
+create table t1 (
+x int unsigned,
+row_start SYS_TYPE as row start invisible,
+row_end SYS_TYPE as row end invisible,
+period for system_time (row_start, row_end))
+with system versioning;
+insert into t1 values (1);
+update t1 set x= 2 where x = 1;
+flush logs;
+drop table t1;
+select *, check_row(row_start, row_end) from t1 for system_time all;
+x	check_row(row_start, row_end)
+2	CURRENT ROW
+1	HISTORICAL ROW
+drop database test;
+create database test;
 include/rpl_end.inc

--- a/mysql-test/suite/versioning/r/rpl.result
+++ b/mysql-test/suite/versioning/r/rpl.result
@@ -181,6 +181,17 @@ select *, check_row(row_start, row_end) from t1 for system_time all;
 x	check_row(row_start, row_end)
 2	CURRENT ROW
 1	HISTORICAL ROW
+# MDEV-16252: MINIMAL binlog_row_image does not work for versioned tables
+set @old_row_image= @@binlog_row_image;
+set binlog_row_image= minimal;
+create or replace table t1 (pk int, i int, primary key(pk))
+with system versioning;
+insert into t1 values (1,10),(2,20);
+update t1 set i = 0;
+connection slave;
+connection master;
+drop table t1;
+set binlog_row_image= @old_row_image;
 drop database test;
 create database test;
 include/rpl_end.inc

--- a/mysql-test/suite/versioning/t/rpl.test
+++ b/mysql-test/suite/versioning/t/rpl.test
@@ -1,4 +1,5 @@
 --source suite/versioning/engines.inc
+--source suite/versioning/common.inc
 --source include/have_partition.inc
 --source include/master-slave.inc
 
@@ -132,5 +133,27 @@ update t1 set i = 0;
 sync_slave_with_master;
 connection master;
 drop table t1;
+
+--echo # MDEV-16372 ER_BASE64_DECODE_ERROR upon replaying binary log with system table
+flush logs;
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $datadir= `select @@datadir`
+set @@session.time_zone='+00:00';
+replace_result $sys_datatype_expl SYS_TYPE;
+eval create table t1 (
+  x int unsigned,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end))
+with system versioning;
+insert into t1 values (1);
+update t1 set x= 2 where x = 1;
+flush logs;
+drop table t1;
+--exec $MYSQL_BINLOG -v $datadir/$binlog_file | $MYSQL test
+select *, check_row(row_start, row_end) from t1 for system_time all;
+
+drop database test;
+create database test;
 
 --source include/rpl_end.inc

--- a/mysql-test/suite/versioning/t/rpl.test
+++ b/mysql-test/suite/versioning/t/rpl.test
@@ -153,6 +153,20 @@ drop table t1;
 --exec $MYSQL_BINLOG -v $datadir/$binlog_file | $MYSQL test
 select *, check_row(row_start, row_end) from t1 for system_time all;
 
+--echo # MDEV-16252: MINIMAL binlog_row_image does not work for versioned tables
+set @old_row_image= @@binlog_row_image;
+set binlog_row_image= minimal;
+
+create or replace table t1 (pk int, i int, primary key(pk))
+with system versioning;
+insert into t1 values (1,10),(2,20);
+update t1 set i = 0;
+
+--sync_slave_with_master
+--connection master
+drop table t1;
+set binlog_row_image= @old_row_image;
+
 drop database test;
 create database test;
 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -3672,6 +3672,10 @@ void free_table_map_log_event(Table_map_log_event *event)
   delete event;
 }
 
+static
+bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
+                    Rows_log_event *ev);
+
 bool Log_event::print_base64(IO_CACHE* file,
                              PRINT_EVENT_INFO* print_event_info,
                              bool more)
@@ -3741,13 +3745,21 @@ bool Log_event::print_base64(IO_CACHE* file,
     }
 
     if (my_b_tell(file) == 0)
+    {
       if (unlikely(my_b_write_string(file, "\nBINLOG '\n")))
         error= 1;
+      else
+        print_event_info->inside_binlog= true;
+    }
     if (likely(!error) && unlikely(my_b_printf(file, "%s\n", tmp_str)))
       error= 1;
     if (!more && likely(!error))
+    {
       if (unlikely(my_b_printf(file, "'%s\n", print_event_info->delimiter)))
         error= 1;
+      else
+        print_event_info->inside_binlog= false;
+    }
     my_free(tmp_str);
     if (unlikely(error))
       goto err;
@@ -3832,44 +3844,24 @@ bool Log_event::print_base64(IO_CACHE* file,
       break;
     }
 
-    if (ev)
+    if (print_event_info->inside_binlog && print_event_info->verbose)
     {
-      bool error= 0;
-
-#ifdef WHEN_FLASHBACK_REVIEW_READY
-      ev->need_flashback_review= need_flashback_review;
+      if (ev)
+        print_event_info->verbose_events.append(ev);
+    }
+    else
+    {
       if (print_event_info->verbose)
       {
-        if (ev->print_verbose(file, print_event_info))
-          goto err;
-      }
-      else
-      {
-        IO_CACHE tmp_cache;
-
-        if (open_cached_file(&tmp_cache, NULL, NULL, 0,
-                              MYF(MY_WME | MY_NABP)))
+        Dynamic_array<Rows_log_event *> &evs= print_event_info->verbose_events;
+        for (size_t i= 0; i < evs.elements(); ++i)
         {
-          delete ev;
-          goto err;
+          if (describe_event(file, print_event_info, evs.at(i)))
+            goto err;
         }
-
-        error= ev->print_verbose(&tmp_cache, print_event_info);
-        close_cached_file(&tmp_cache);
-        if (unlikely(error))
-        {
-          delete ev;
-          goto err;
-        }
+        evs.clear();
       }
-#else
-      if (print_event_info->verbose)
-        error= ev->print_verbose(file, print_event_info);
-      else
-        ev->count_row_events(print_event_info);
-#endif
-      delete ev;
-      if (unlikely(error))
+      if (ev && describe_event(file, print_event_info, ev))
         goto err;
     }
   }
@@ -3877,6 +3869,52 @@ bool Log_event::print_base64(IO_CACHE* file,
 
 err:
   DBUG_RETURN(1);
+}
+
+
+static
+bool describe_event(IO_CACHE* file, PRINT_EVENT_INFO* print_event_info,
+                    Rows_log_event *ev)
+{
+  bool error= 0;
+
+#ifdef WHEN_FLASHBACK_REVIEW_READY
+  ev->need_flashback_review= need_flashback_review;
+  if (print_event_info->verbose)
+  {
+    if (ev->print_verbose(file, print_event_info))
+    {
+      delete ev;
+      return true;
+    }
+  }
+  else
+  {
+    IO_CACHE tmp_cache;
+
+    if (open_cached_file(&tmp_cache, NULL, NULL, 0,
+                          MYF(MY_WME | MY_NABP)))
+    {
+      delete ev;
+      return true;
+    }
+
+    error= ev->print_verbose(&tmp_cache, print_event_info);
+    close_cached_file(&tmp_cache);
+    if (unlikely(error))
+    {
+      delete ev;
+      return true;
+    }
+  }
+#else
+  if (print_event_info->verbose)
+    error= ev->print_verbose(file, print_event_info);
+  else
+    ev->count_row_events(print_event_info);
+#endif
+  delete ev;
+  return error;
 }
 
 
@@ -5981,8 +6019,12 @@ bool Start_log_event_v3::print(FILE* file, PRINT_EVENT_INFO* print_event_info)
       !print_event_info->short_form)
   {
     if (print_event_info->base64_output_mode != BASE64_OUTPUT_DECODE_ROWS)
+    {
       if (my_b_printf(&cache, "BINLOG '\n"))
         goto err;
+      else
+        print_event_info->inside_binlog= true;
+    }
     if (print_base64(&cache, print_event_info, FALSE))
       goto err;
     print_event_info->printed_fd_event= TRUE;
@@ -14685,6 +14727,7 @@ st_print_event_info::st_print_event_info()
   short_form= false;
   skip_replication= 0;
   printed_fd_event=FALSE;
+  inside_binlog= false;
   file= 0;
   base64_output_mode=BASE64_OUTPUT_UNSPEC;
   open_cached_file(&head_cache, NULL, NULL, 0, flags);

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -51,6 +51,7 @@
 #endif
 
 #include "rpl_gtid.h"
+#include "sql_array.h"
 
 /* Forward declarations */
 #ifndef MYSQL_CLIENT
@@ -817,6 +818,8 @@ enum enum_base64_output_mode {
 
 bool copy_event_cache_to_string_and_reinit(IO_CACHE *cache, LEX_STRING *to);
 
+class Rows_log_event;
+
 /*
   A structure for mysqlbinlog to know how to print events
 
@@ -880,6 +883,8 @@ typedef struct st_print_event_info
     statement for it.
   */
   bool skip_replication;
+  bool inside_binlog;
+  Dynamic_array<Rows_log_event *> verbose_events;
 
   /*
      These two caches are used by the row-based replication events to

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -957,6 +957,7 @@ update_begin:
             if (table->versioned(VERS_TIMESTAMP))
             {
               store_record(table, record[2]);
+              table->mark_columns_per_binlog_row_image();
               error= vers_insert_history_row(table);
               restore_record(table, record[2]);
             }


### PR DESCRIPTION
* mark columns for binlog before inserting history row