### PR TITLE
MDEV-16783 Assertion `!conds' failed in mysql_delete upon 2nd executi…

### DIFF
--- a/mysql-test/suite/versioning/r/delete.result
+++ b/mysql-test/suite/versioning/r/delete.result
@@ -115,5 +115,11 @@ select x from t1 for system_time all;
 x
 2
 1
+# MDEV-16783 Assertion `!conds' failed in mysql_delete upon 2nd execution
+#   of SP with DELETE HISTORY
+create or replace table t1 (i int) with system versioning;
+create procedure pr() delete history from t1 before system_time now();
+call pr;
+call pr;
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/delete.test
+++ b/mysql-test/suite/versioning/t/delete.test
@@ -82,5 +82,12 @@ update t1 set x= 2;
 delete from t1;
 select x from t1 for system_time all;
 
+--echo # MDEV-16783 Assertion `!conds' failed in mysql_delete upon 2nd execution
+--echo #   of SP with DELETE HISTORY
+create or replace table t1 (i int) with system versioning;
+create procedure pr() delete history from t1 before system_time now();
+call pr;
+call pr;
+
 drop database test;
 create database test;

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -323,12 +323,16 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
     DBUG_ASSERT(table);
 
     DBUG_ASSERT(!conds || thd->stmt_arena->is_stmt_execute());
-    if (select_lex->vers_setup_conds(thd, table_list))
-      DBUG_RETURN(TRUE);
 
-    DBUG_ASSERT(!conds);
-    conds= table_list->on_expr;
-    table_list->on_expr= NULL;
+    // conds could be cached from previous SP call
+    if (!conds)
+    {
+      if (select_lex->vers_setup_conds(thd, table_list))
+        DBUG_RETURN(TRUE);
+
+      conds= table_list->on_expr;
+      table_list->on_expr= NULL;
+    }
   }
 
   if (mysql_handle_list_of_derived(thd->lex, table_list, DT_MERGE_FOR_INSERT))


### PR DESCRIPTION
…on of SP with DELETE HISTORY

* remove assertion
* do not setup `conds` if it's already cached