### PR TITLE
MDEV-16825 SIGSEGV after SIGINT in bootstrap mode

### DIFF
--- a/mysql-test/main/bootstrap.result
+++ b/mysql-test/main/bootstrap.result
@@ -26,3 +26,7 @@ select * from mysql.plugin;
 name	dl
 EXAMPLE	ha_example.so
 truncate table mysql.plugin;
+#
+# MDEV-16825 SIGSEGV after SIGINT in bootstrap mode
+#
+Success!

--- a/mysql-test/main/bootstrap.test
+++ b/mysql-test/main/bootstrap.test
@@ -106,3 +106,22 @@ use test;
 EOF
 --exec $MYSQLD_BOOTSTRAP_CMD --ignore-db-dirs='some_dir' --ignore-db-dirs='some_dir' < $MYSQLTEST_VARDIR/tmp/bootstrap_9969.sql >> $MYSQLTEST_VARDIR/tmp/bootstrap.log 2>&1
 --remove_file $MYSQLTEST_VARDIR/tmp/bootstrap_9969.sql
+
+--echo #
+--echo # MDEV-16825 SIGSEGV after SIGINT in bootstrap mode
+--echo #
+--perl
+use POSIX qw(WNOHANG);
+my $wait= 5; # seconds to wait process shutdown
+$|= 1;
+my $pid= open(BOOTSTRAP, '|-',  $ENV{'MYSQLD_BOOTSTRAP_CMD'})
+  or die $ENV{'MYSQLD_BOOTSTRAP_CMD'}. ": $!";
+print BOOTSTRAP "select 1;\n"; # make sure process accepts input
+kill INT => $pid;
+my $status;
+while ($wait-- && ($status= waitpid($pid, WNOHANG)) < 1)
+{
+  sleep 1;
+}
+print $status != $pid ? "Failed!\n" : "Success!\n";
+EOF

--- a/scripts/comp_sql.c
+++ b/scripts/comp_sql.c
@@ -40,6 +40,8 @@
 
 FILE *in, *out;
 
+volatile sig_atomic_t kill_in_progress= 0;
+
 static void die(const char *fmt, ...)
 {
   va_list args;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -29,6 +29,7 @@
 #include <my_rnd.h>
 #include "my_pthread.h"
 #include "my_rdtsc.h"
+#include <signal.h>
 
 class THD;
 class CONNECT;
@@ -178,6 +179,7 @@ extern char *opt_backup_history_logname, *opt_backup_progress_logname,
             *opt_backup_settings_name;
 extern const char *log_output_str;
 extern const char *log_backup_output_str;
+extern volatile sig_atomic_t kill_in_progress;
 
 /* System Versioning begin */
 enum vers_system_time_t

--- a/sql/sql_bootstrap.cc
+++ b/sql/sql_bootstrap.cc
@@ -17,7 +17,10 @@
 #include "mariadb.h"
 #include <ctype.h>
 #include <string.h>
+#include <signal.h>
 #include "sql_bootstrap.h"
+
+extern volatile sig_atomic_t kill_in_progress;
 
 int read_bootstrap_query(char *query, int *query_length,
                          fgets_input_t input, fgets_fn_t fgets_fn, int *error)
@@ -37,7 +40,7 @@ int read_bootstrap_query(char *query, int *query_length,
       *error= fgets_error;
 
     if (fgets_error != 0)
-      return READ_BOOTSTRAP_ERROR;
+      return kill_in_progress ? READ_BOOTSTRAP_EOF : READ_BOOTSTRAP_ERROR;
       
     if (line == NULL)
       return (query_len == 0) ? READ_BOOTSTRAP_EOF : READ_BOOTSTRAP_ERROR;


### PR DESCRIPTION
* Fixes segmentation fault on SIGINT;
* Interrupt blocked fgets() while daemon is in the shutting down progress.

[fixes tempesta-tech/mariadb#527]

This code is submitted under the BSD-new license.