### PR TITLE
Reserve memory before inserting to vector in a loop.

### DIFF
--- a/storage/innobase/sync/sync0rw.cc
+++ b/storage/innobase/sync/sync0rw.cc
@@ -1063,6 +1063,8 @@ rw_lock_get_debug_info(const rw_lock_t* lock, Infos* infos)
 
 	rw_lock_debug_mutex_enter();
 
+	infos->reserve(UT_LIST_GET_LEN(lock->debug_list));
+
 	for (info = UT_LIST_GET_FIRST(lock->debug_list);
 	     info != NULL;
 	     info = UT_LIST_GET_NEXT(list, info)) {


### PR DESCRIPTION
This makes './mtr -suite=innodb' run 3% faster on my setup.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.