### PR TITLE
MDEV-16768: fix blob key length

### DIFF
--- a/sql/field.cc
+++ b/sql/field.cc
@@ -8539,7 +8539,9 @@ void Field_blob::sort_string(uchar *to,uint length)
         Store length of blob last in blob to shorter blobs before longer blobs
       */
       length-= packlength;
-      store_bigendian(buf.length(), to + length, packlength);
+
+      uint key_length = MY_MIN(buf.length(), length);
+      store_bigendian(key_length, to + length, packlength);
     }
 
 #ifndef DBUG_OFF

--- a/storage/rocksdb/mysql-test/rocksdb_rpl/r/rpl_blob_key.result
+++ b/storage/rocksdb/mysql-test/rocksdb_rpl/r/rpl_blob_key.result
@@ -1,0 +1,9 @@
+include/master-slave.inc
+[connection master]
+CREATE TABLE t1 (b BLOB, i INT, KEY(b(8))) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (REPEAT('a',9),1);
+UPDATE t1 SET i = 2;
+connection slave;
+connection master;
+DROP TABLE t1;
+include/rpl_end.inc

--- a/storage/rocksdb/mysql-test/rocksdb_rpl/t/rpl_blob_key.test
+++ b/storage/rocksdb/mysql-test/rocksdb_rpl/t/rpl_blob_key.test
@@ -1,0 +1,15 @@
+--source include/have_rocksdb.inc
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+CREATE TABLE t1 (b BLOB, i INT, KEY(b(8))) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (REPEAT('a',9),1);
+
+UPDATE t1 SET i = 2;
+
+--sync_slave_with_master
+
+# Cleanup
+--connection master
+DROP TABLE t1;
+--source include/rpl_end.inc


### PR DESCRIPTION
The blob key length could be shorter than the length of the entire blob,
for example,

CREATE TABLE t1 (b BLOB, i INT, KEY(b(8)));
INSERT INTO t1 VALUES (REPEAT('a',9),1);

The key length is 8, while the blob length is 9.
So we need to set the correct key length in Field_blob::sort_string().