### PR TITLE
MDEV-16703: update AUTO_INCREMENT in the UPDATE statement

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9553,7 +9553,7 @@ int ha_rocksdb::update_pk(const Rdb_key_def &kd,
     }
   }
 
-  if (table->next_number_field) {
+  if (table->found_next_number_field) {
     update_auto_incr_val_from_field();
   }
 

--- a/storage/rocksdb/mysql-test/rocksdb/r/autoinc_vars.result
+++ b/storage/rocksdb/mysql-test/rocksdb/r/autoinc_vars.result
@@ -150,3 +150,11 @@ CREATE TABLE t0(c0 BLOB) ENGINE=ROCKSDB;
 INSERT INTO t0 VALUES(0);
 ALTER TABLE t0 AUTO_INCREMENT=0;
 DROP TABLE t0;
+#---------------------------------------------------------------
+# MDEV-16703 Assertion failed in load_auto_incr_value_from_index
+#---------------------------------------------------------------
+CREATE TABLE t1 (pk INT AUTO_INCREMENT, a INT, PRIMARY KEY(pk)) ENGINE=RocksDB;
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET pk = 3;
+ALTER TABLE t1 AUTO_INCREMENT 2;
+DROP TABLE t1;

--- a/storage/rocksdb/mysql-test/rocksdb/t/autoinc_vars.test
+++ b/storage/rocksdb/mysql-test/rocksdb/t/autoinc_vars.test
@@ -116,3 +116,13 @@ CREATE TABLE t0(c0 BLOB) ENGINE=ROCKSDB;
 INSERT INTO t0 VALUES(0);
 ALTER TABLE t0 AUTO_INCREMENT=0;
 DROP TABLE t0;
+
+--echo #---------------------------------------------------------------
+--echo # MDEV-16703 Assertion failed in load_auto_incr_value_from_index
+--echo #---------------------------------------------------------------
+
+CREATE TABLE t1 (pk INT AUTO_INCREMENT, a INT, PRIMARY KEY(pk)) ENGINE=RocksDB;
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET pk = 3;
+ALTER TABLE t1 AUTO_INCREMENT 2;
+DROP TABLE t1;


### PR DESCRIPTION
Currently RocksDB engine doesn't update AUTO_INCREMENT in the UPDATE statement.
For example,

CREATE TABLE t1 (pk INT AUTO_INCREMENT, a INT, PRIMARY KEY(pk)) ENGINE=RocksDB;
INSERT INTO t1 (a) VALUES (1);
UPDATE t1 SET pk = 3; ==> AUTO_INCREMENT should be updated to 4.