### PR TITLE
MDEV-15933 Cannot resume Node SYNCED state when wsrep_desync is done after FTWRL

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_desync_on.result
+++ b/mysql-test/suite/galera/r/galera_var_desync_on.result
@@ -1,7 +1,6 @@
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 SET GLOBAL wsrep_provider_options = 'gcs.fc_limit=1';
-SET GLOBAL wsrep_desync = TRUE;
 FLUSH TABLES WITH READ LOCK;
 INSERT INTO t1 VALUES (2);
 INSERT INTO t1 VALUES (3);
@@ -16,7 +15,6 @@ SET SESSION wsrep_sync_wait = 0;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
-SET GLOBAL wsrep_desync = FALSE;
 UNLOCK TABLES;
 SET SESSION wsrep_sync_wait = 1;
 SELECT COUNT(*) = 10 FROM t1;

--- a/mysql-test/suite/galera/t/galera_var_desync_on.test
+++ b/mysql-test/suite/galera/t/galera_var_desync_on.test
@@ -1,5 +1,7 @@
 #
-# Test wsrep_desync = ON . Node should temporarily not participate in flow control
+# Desync will be done once the global read lock is acquired and resync will be done when 
+# it is released.
+# Node should temporarily not participate in flow control
 # so even if fc_limit has been reached, the master should be able to continue to
 # commit transactions.
 #
@@ -13,7 +15,6 @@ INSERT INTO t1 VALUES (1);
 --connection node_2
 --let $wsrep_provider_options_orig = `SELECT @@wsrep_provider_options`
 SET GLOBAL wsrep_provider_options = 'gcs.fc_limit=1';
-SET GLOBAL wsrep_desync = TRUE;
 
 # Block the slave applier thread 
 FLUSH TABLES WITH READ LOCK;
@@ -37,8 +38,6 @@ SET SESSION wsrep_sync_wait = 0;
 # No updates have arrived after the FLUSH TABLES
 SELECT COUNT(*) = 1 FROM t1;
 
-# Resync the slave
-SET GLOBAL wsrep_desync = FALSE;
 --disable_query_log
 --eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_orig';
 --enable_query_log

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -587,6 +587,12 @@ bool wsrep_desync_check (sys_var *self, THD* thd, set_var* var)
     return true;
   }
 
+  if (thd->global_read_lock.is_acquired())
+  {
+    my_message (ER_CANNOT_USER, "Global read lock acquired. Can't set 'wsrep_desync'", MYF(0));
+    return true;
+  }
+
   bool new_wsrep_desync= (bool) var->save_result.ulonglong_value;
   if (wsrep_desync == new_wsrep_desync) {
     if (new_wsrep_desync) {


### PR DESCRIPTION
Manually setting wsrep_desync after FTWRL should not be allowed.