### PR TITLE
MDEV-17022: check if mtr --mem location is writeable

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1457,7 +1457,7 @@ sub command_line_setup {
 
     foreach my $fs (@tmpfs_locations)
     {
-      if ( -d $fs )
+      if ( -d $fs && -w $fs )
       {
 	my $template= "var_${opt_build_thread}_XXXX";
 	$opt_mem= tempdir( $template, DIR => $fs, CLEANUP => 0);


### PR DESCRIPTION
For e.g. on Ubuntu 14.04 /run/shm is not a symlink to /dev/shm, as in later versions of Ubuntu or Debian, nor is it world writeable. Adding this check will make MTR fall through to the next default location, which is /dev/shm.