### PR TITLE
MDEV-16211 Contents of transaction_registry not replicated by Galera

### DIFF
--- a/mysql-test/suite/galera/r/versioning_trx_id.result
+++ b/mysql-test/suite/galera/r/versioning_trx_id.result
@@ -1,0 +1,52 @@
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_1;
+create table t1 (a int, s bigint unsigned as row start, e bigint unsigned as row end, period for system_time(s,e)) engine=InnoDB with system versioning;
+insert into t1 (a) values (1),(2);
+connection node_2;
+insert into t1 (a) values (3),(4);
+select a from t1;
+a
+1
+2
+3
+4
+select count(*) from mysql.transaction_registry where begin_timestamp='0-0-0';
+count(*)
+0
+select count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+count(*)
+0
+connection node_3;
+insert into t1 (a) values (5),(6);
+select a from t1;
+a
+1
+2
+3
+4
+5
+6
+select count(*) from mysql.transaction_registry where begin_timestamp='0-0-0';
+count(*)
+0
+select count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+count(*)
+0
+connection node_1;
+select a from t1;
+a
+1
+2
+3
+4
+5
+6
+select count(*) from mysql.transaction_registry where begin_timestamp='0-0-0';
+count(*)
+0
+select count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+count(*)
+0
+drop table t1;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/versioning_trx_id.cnf
+++ b/mysql-test/suite/galera/t/versioning_trx_id.cnf
@@ -1,0 +1,1 @@
+!include ../galera_4nodes.cnf

--- a/mysql-test/suite/galera/t/versioning_trx_id.test
+++ b/mysql-test/suite/galera/t/versioning_trx_id.test
@@ -1,0 +1,28 @@
+--source include/galera_cluster.inc
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+--connection node_1
+create table t1 (a int, s bigint unsigned as row start, e bigint unsigned as row end, period for system_time(s,e)) engine=InnoDB with system versioning;
+insert into t1 (a) values (1),(2);
+
+--connection node_2
+insert into t1 (a) values (3),(4);
+select a from t1;
+select count(*) from mysql.transaction_registry where begin_timestamp='0-0-0';
+select count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+
+--connection node_3
+insert into t1 (a) values (5),(6);
+select a from t1;
+select count(*) from mysql.transaction_registry where begin_timestamp='0-0-0';
+select count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+
+--connection node_1
+select a from t1;
+select count(*) from mysql.transaction_registry where begin_timestamp='0-0-0';
+select count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+
+drop table t1;
+
+--source include/galera_end.inc

--- a/mysql-test/suite/versioning/r/trx_id.result
+++ b/mysql-test/suite/versioning/r/trx_id.result
@@ -475,3 +475,6 @@ COUNT(*)
 1
 DROP TABLE t;
 SET @@SYSTEM_VERSIONING_ALTER_HISTORY=ERROR;
+SELECT count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+count(*)
+0

--- a/mysql-test/suite/versioning/t/trx_id.test
+++ b/mysql-test/suite/versioning/t/trx_id.test
@@ -492,3 +492,5 @@ SELECT COUNT(*) FROM t FOR SYSTEM_TIME ALL;
 
 DROP TABLE t;
 SET @@SYSTEM_VERSIONING_ALTER_HISTORY=ERROR;
+
+SELECT count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -8763,6 +8763,7 @@ bool TR_table::update(ulonglong start_id, ulonglong end_id)
     return true;
 
   store(FLD_BEGIN_TS, thd->transaction_time());
+  thd->set_time();
   timeval end_time= {thd->query_start(), long(thd->query_start_sec_part())};
   store(FLD_TRX_ID, start_id);
   store(FLD_COMMIT_ID, end_id);

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -146,6 +146,7 @@ static wsrep_cb_status_t wsrep_apply_events(THD*        thd,
     /* Use the original server id for logging. */
     thd->set_server_id(ev->server_id);
     thd->set_time();                            // time the query
+    thd->transaction.start_time.reset(thd);
     wsrep_xid_init(&thd->transaction.xid_state.xid,
                    thd->wsrep_trx_meta.gtid.uuid,
                    thd->wsrep_trx_meta.gtid.seqno);


### PR DESCRIPTION
Patch fixes two bugs:
1) BEGIN_TIMESTAMP of MYSQL.TRANSACTION_REGISTY is '0-0-0' on replication record insertion
2) BEGIN_TIMESTAMP equals COMMMIT_TIMESTAMP in MYSQL.TRANSACTION_REGISTRY

Fixed by calling THD::set_time() at appropriate places

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.