### PR TITLE
Return code from starting MariaDB.

### DIFF
--- a/scripts/galera_new_cluster.sh
+++ b/scripts/galera_new_cluster.sh
@@ -27,4 +27,8 @@ COMPILATION_COMMENT="@COMPILATION_COMMENT@"
 systemctl set-environment _WSREP_NEW_CLUSTER='--wsrep-new-cluster' && \
     systemctl start ${1:-mariadb}
 
+extcode=$?
+
 systemctl set-environment _WSREP_NEW_CLUSTER=''
+
+return $extcode


### PR DESCRIPTION
- When bootstraping the galera cluster it's good to get correct return code from the (failed) execution.