### PR TITLE
Add condition when processing the apc request for unittest

### DIFF
--- a/unittest/sql/my_apc-t.cc
+++ b/unittest/sql/my_apc-t.cc
@@ -100,7 +100,8 @@ void *test_apc_service_thread(void *ptr)
     //apc_target.enable();
     for (int i = 0; i < 10 && !service_should_exit; i++)
     {
-      apc_target.process_apc_requests();
+      if(apc_target.have_apc_requests())
+        apc_target.process_apc_requests();
       my_sleep(int_rand(30));
     }
   }


### PR DESCRIPTION
In order to be consistent with suggestion of lightweight function `have_apc_requests` for frequent checks defined in `sql/my_apc.h` . The same is applied in function `check_killed()` of  `THD` class.