### PR TITLE
MDEV-15845 Test failure on galera.galera_concurrent_ctas

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -34,5 +34,4 @@ galera.MW-44 : MDEV-15809 Test failure on galera.MW-44
 galera.galera_pc_ignore_sb : MDEV-15811 Test failure on galera_pc_ignore_sb
 galera_kill_applier : race condition at the start of the test
 galera_ist_progress: MDEV-15236 galera_ist_progress fails when trying to read transfer status
-galera_concurrent_ctas : MDEV-15845 Test failure on galera.galera_concurrent_ctas
 pxc-421: Lock timeout exceeded

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -3807,6 +3807,10 @@ lock_table_names(THD *thd, const DDL_options_st &options,
     mdl_requests.push_front(&global_request);
 
     if (create_table)
+    #ifdef WITH_WSREP
+      if (thd->lex->sql_command != SQLCOM_CREATE_TABLE && 
+          thd->wsrep_exec_mode != REPL_RECV)
+    #endif
       lock_wait_timeout= 0;                     // Don't wait for timeout
   }
 


### PR DESCRIPTION
While executing CTAS galera applier thread can cause CTAS to abort and rollback. Rollback can take time causing applier thread to shutdown node after several unsuccessful retries to apply transaction. CTAS should finish before transaction is applied.