### PR TITLE
MDEV-16052 galera mtr galera_certification_double_failure fails with deadlock

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_certification_double_failure.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_certification_double_failure.result
@@ -11,6 +11,6 @@ connection node_3;
 INSERT INTO t2 VALUES (1);
 connection node_1;
 COMMIT;
-ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+ERROR 40001: Deadlock: wsrep aborted transaction
 DROP TABLE t1;
 DROP TABLE t2;


### PR DESCRIPTION
There was change in error reporting from my_error to my_message so this test was left unrecorded.