### PR TITLE
galera_new_cluster.sh: unused variables

### DIFF
--- a/scripts/galera_new_cluster.sh
+++ b/scripts/galera_new_cluster.sh
@@ -21,9 +21,6 @@ EOF
     exit 0
 fi
 
-VERSION="@VERSION@@MYSQL_SERVER_SUFFIX@"
-COMPILATION_COMMENT="@COMPILATION_COMMENT@"
-
 systemctl set-environment _WSREP_NEW_CLUSTER='--wsrep-new-cluster' && \
     systemctl start ${1:-mariadb}
 


### PR DESCRIPTION
Not sure why I added these in the first commit of this however they aren't used.

I submit this deletion under the MCA.