### PR TITLE
MDEV-17089 Updating a System Versioned Table always causes a row to b…

### DIFF
--- a/mysql-test/suite/versioning/r/update.result
+++ b/mysql-test/suite/versioning/r/update.result
@@ -239,5 +239,20 @@ B1	salary
 select @tmp2 = sys_trx_start as B2, salary from t2;
 B2	salary
 1	2500
+#
+# MDEV-17089 Updating a System Versioned Table always causes a row to be updated,
+# regardless if the data is the same or not
+#
+create or replace table t1 (
+x int primary key,
+row_start SYS_DATATYPE as row start invisible,
+row_end SYS_DATATYPE as row end invisible,
+period for system_time (row_start, row_end))
+with system versioning;
+insert into t1 values (1);
+update t1 set x= 1;
+select * from t1 for system_time all;
+x
+1
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/versioning/t/update.test
+++ b/mysql-test/suite/versioning/t/update.test
@@ -144,6 +144,22 @@ update t1, t2 set t1.salary= 2500, t2.salary= 2500 where t1.id = t2.id and t1.na
 select @tmp1 = sys_trx_start as B1, salary from t1;
 select @tmp2 = sys_trx_start as B2, salary from t2;
 
+--echo #
+--echo # MDEV-17089 Updating a System Versioned Table always causes a row to be updated,
+--echo # regardless if the data is the same or not
+--echo #
+replace_result $sys_datatype_expl SYS_DATATYPE;
+eval create or replace table t1 (
+  x int primary key,
+  row_start $sys_datatype_expl as row start invisible,
+  row_end $sys_datatype_expl as row end invisible,
+  period for system_time (row_start, row_end))
+with system versioning;
+
+insert into t1 values (1);
+update t1 set x= 1;
+select * from t1 for system_time all;
+
 drop table t1;
 drop table t2;
 

--- a/sql/sql_update.h
+++ b/sql/sql_update.h
@@ -40,6 +40,6 @@ bool mysql_multi_update(THD *thd, TABLE_LIST *table_list,
                         SELECT_LEX_UNIT *unit, SELECT_LEX *select_lex,
                         multi_update **result);
 bool records_are_comparable(const TABLE *table);
-bool compare_record(const TABLE *table);
+bool compare_record(const TABLE *table, uint32 skip_flags= 0);
 
 #endif /* SQL_UPDATE_INCLUDED */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8245,6 +8245,7 @@ between old_row and new_row.
 @param[in]	buff_len	length of upd_buff
 @param[in,out]	prebuilt	InnoDB execution context
 @param[out]	auto_inc	updated AUTO_INCREMENT value, or 0 if none
+@param[out]	vers_n_changed	count of changed system fields
 @return DB_SUCCESS or error code */
 static
 dberr_t
@@ -8256,7 +8257,8 @@ calc_row_difference(
 	uchar*		upd_buff,
 	ulint		buff_len,
 	row_prebuilt_t*	prebuilt,
-	ib_uint64_t&	auto_inc)
+	ib_uint64_t&	auto_inc,
+	ulint&		vers_n_changed)
 {
 	uchar*		original_upd_buff = upd_buff;
 	Field*		field;
@@ -8286,6 +8288,7 @@ calc_row_difference(
 
 	clust_index = dict_table_get_first_index(prebuilt->table);
 	auto_inc = 0;
+	vers_n_changed = 0;
 
 	/* We use upd_buff to convert changed fields */
 	buf = (byte*) upd_buff;
@@ -8522,6 +8525,10 @@ calc_row_difference(
 				}
 			}
 			n_changed++;
+			if (field->flags & VERS_SYSTEM_FIELD)
+			{
+				vers_n_changed++;
+			}
 
 			/* If an FTS indexed column was changed by this
 			UPDATE then we need to inform the FTS sub-system.
@@ -8782,13 +8789,14 @@ ha_innobase::update_row(
 
 	upd_t*		uvect = row_get_prebuilt_update_vector(m_prebuilt);
 	ib_uint64_t	autoinc;
+	ib_uint64_t	vers_n_changed;
 
 	/* Build an update vector from the modified fields in the rows
 	(uses m_upd_buf of the handle) */
 
 	error = calc_row_difference(
 		uvect, old_row, new_row, table, m_upd_buf, m_upd_buf_size,
-		m_prebuilt, autoinc);
+		m_prebuilt, autoinc, vers_n_changed);
 
 	if (error != DB_SUCCESS) {
 		goto func_exit;
@@ -8801,18 +8809,25 @@ ha_innobase::update_row(
 		This is fix for http://bugs.mysql.com/29157 */
 		DBUG_RETURN(HA_ERR_RECORD_IS_THE_SAME);
 	} else {
+		const int sqlcom = thd_sql_command(m_user_thd);
 		const bool vers_set_fields = m_prebuilt->versioned_write
 			&& m_prebuilt->upd_node->update->affects_versioned();
 		const bool vers_ins_row = vers_set_fields
-			&& thd_sql_command(m_user_thd) != SQLCOM_ALTER_TABLE;
+			&& sqlcom != SQLCOM_ALTER_TABLE;
 
 		/* This is not a delete */
 		m_prebuilt->upd_node->is_delete =
 			(vers_set_fields && !vers_ins_row) ||
-			(thd_sql_command(m_user_thd) == SQLCOM_DELETE &&
+			((sqlcom == SQLCOM_DELETE || sqlcom == SQLCOM_DELETE_MULTI) &&
 				table->versioned(VERS_TIMESTAMP))
 			? VERSIONED_DELETE
 			: NO_DELETE;
+
+		if ((sqlcom == SQLCOM_UPDATE || sqlcom == SQLCOM_UPDATE_MULTI) &&
+			uvect->n_fields == vers_n_changed &&
+			table->versioned_write(VERS_TIMESTAMP)) {
+			DBUG_RETURN(HA_ERR_RECORD_IS_THE_SAME);
+		}
 
 		innobase_srv_conc_enter_innodb(m_prebuilt);
 


### PR DESCRIPTION
…e updated, regardless if the data is the same or not

SQL, IB: ignore system fields in row comparison in case of versioned UPDATE

This code is submitted under the BSD-new license.