### PR TITLE
MDEV-17173: correct parsing of 12.13.14.15:4444/xtrabackup_sst leavin…

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -57,9 +57,18 @@ case "$1" in
         readonly WSREP_SST_OPT_MODULE=${remain%%/*}
         readonly WSREP_SST_OPT_PATH=${WSREP_SST_OPT_ADDR#*/}
         remain=${WSREP_SST_OPT_PATH#*/}
-        readonly WSREP_SST_OPT_LSN=${remain%%/*}
-        remain=${remain#*/}
-        readonly WSREP_SST_OPT_SST_VER=${remain%%/*}
+        if [ "$remain" != "${WSREP_SST_OPT_PATH}" ]; then
+            readonly WSREP_SST_OPT_LSN=${remain%%/*}
+            remain=${remain#*/}
+            if [ "$remain" != "${WSREP_SST_OPT_LSN}" ]; then
+                readonly WSREP_SST_OPT_SST_VER=${remain%%/*}
+            else
+                readonly WSREP_SST_OPT_SST_VER=""
+            fi
+        else
+            readonly WSREP_SST_OPT_LSN=""
+            readonly WSREP_SST_OPT_SST_VER=""
+        fi
         shift
         ;;
     '--bypass')


### PR DESCRIPTION
…g LSN/SST_VER blank

Correcting commit e78e308e818
$ . scripts/wsrep_sst_common.sh --address 12.13.14.15:4444/xtrabackup_sst ; set | grep WSREP_SST
WSREP_SST_OPT_ADDR=12.13.14.15:4444/xtrabackup_sst
WSREP_SST_OPT_ADDR_PORT=4444
WSREP_SST_OPT_AUTH=
WSREP_SST_OPT_BINLOG=
WSREP_SST_OPT_BINLOG_INDEX=
WSREP_SST_OPT_BYPASS=0
WSREP_SST_OPT_CONF='  '
WSREP_SST_OPT_DATA=
WSREP_SST_OPT_DEFAULT=
WSREP_SST_OPT_EXTRA_DEFAULT=
WSREP_SST_OPT_HOST=12.13.14.15
WSREP_SST_OPT_HOST_UNESCAPED=12.13.14.15
WSREP_SST_OPT_LSN=
WSREP_SST_OPT_MODULE=xtrabackup_sst
WSREP_SST_OPT_PATH=xtrabackup_sst
WSREP_SST_OPT_PORT=4444
WSREP_SST_OPT_PSWD=
WSREP_SST_OPT_SST_VER=
WSREP_SST_OPT_SUFFIX_DEFAULT=
WSREP_SST_OPT_SUFFIX_VALUE=
WSREP_SST_OPT_USER=

. scripts/wsrep_sst_common.sh --address 12.13.14.15:4444/xtrabackup_sst/1234/5676 ; set | grep WSREP_SST
WSREP_SST_OPT_ADDR=12.13.14.15:4444/xtrabackup_sst/1234/5676
WSREP_SST_OPT_ADDR_PORT=4444
WSREP_SST_OPT_AUTH=
WSREP_SST_OPT_BINLOG=
WSREP_SST_OPT_BINLOG_INDEX=
WSREP_SST_OPT_BYPASS=0
WSREP_SST_OPT_CONF='  '
WSREP_SST_OPT_DATA=
WSREP_SST_OPT_DEFAULT=
WSREP_SST_OPT_EXTRA_DEFAULT=
WSREP_SST_OPT_HOST=12.13.14.15
WSREP_SST_OPT_HOST_UNESCAPED=12.13.14.15
WSREP_SST_OPT_LSN=1234
WSREP_SST_OPT_MODULE=xtrabackup_sst
WSREP_SST_OPT_PATH=xtrabackup_sst/1234/5676
WSREP_SST_OPT_PORT=4444
WSREP_SST_OPT_PSWD=
WSREP_SST_OPT_SST_VER=5676
WSREP_SST_OPT_SUFFIX_DEFAULT=
WSREP_SST_OPT_SUFFIX_VALUE=
WSREP_SST_OPT_USER=

I submit this under the MCA.