### PR TITLE
MDEV-17248 Improve ASAN memory pool instrumentation

### DIFF
--- a/include/my_valgrind.h
+++ b/include/my_valgrind.h
@@ -49,9 +49,9 @@ https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
 #endif /* HAVE_VALGRIND */
 
 #ifndef DBUG_OFF
-#define TRASH_FILL(A,B,C) do { MEM_UNDEFINED(A,B); memset(A,C,B); } while(0)
+#define TRASH_FILL(A,B,C) do { const size_t trash_tmp= (B); MEM_UNDEFINED(A, trash_tmp); memset(A, C, trash_tmp); } while (0)
 #else
-#define TRASH_FILL(A,B,C)  do { MEM_UNDEFINED(A,B); } while(0)
+#define TRASH_FILL(A,B,C) do { const size_t trash_tmp __attribute__((unused))= (B); MEM_UNDEFINED(A,trash_tmp); } while (0)
 #endif
 #define TRASH_ALLOC(A,B) do { TRASH_FILL(A,B,0xA5); MEM_UNDEFINED(A,B); } while(0)
 #define TRASH_FREE(A,B) do { TRASH_FILL(A,B,0x8F); MEM_NOACCESS(A,B); } while(0)

--- a/mysys/my_alloc.c
+++ b/mysys/my_alloc.c
@@ -184,6 +184,7 @@ void *alloc_root(MEM_ROOT *mem_root, size_t length)
   uchar* point;
   reg1 USED_MEM *next= 0;
   reg2 USED_MEM **prev;
+  size_t original_length = length;
   DBUG_ENTER("alloc_root");
   DBUG_PRINT("enter",("root: 0x%lx", (long) mem_root));
   DBUG_ASSERT(alloc_root_inited(mem_root));
@@ -241,7 +242,7 @@ void *alloc_root(MEM_ROOT *mem_root, size_t length)
     mem_root->used= next;
     mem_root->first_block_usage= 0;
   }
-  TRASH_ALLOC(point, length);
+  TRASH_ALLOC(point, original_length);
   DBUG_PRINT("exit",("ptr: 0x%lx", (ulong) point));
   DBUG_RETURN((void*) point);
 #endif


### PR DESCRIPTION
alloc_root(): unpoison only requested amount of bytes instead of a
possible bigger aligned-sized buffer.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.