### PR TITLE
MDEV-17306 rw_lock_x_lock_wait_func() double increments rw_x_spin_round_count

### DIFF
--- a/storage/innobase/sync/sync0rw.cc
+++ b/storage/innobase/sync/sync0rw.cc
@@ -495,14 +495,6 @@ rw_lock_x_lock_wait_func(
 		lock->count_os_wait += static_cast<uint32_t>(count_os_wait);
 		rw_lock_stats.rw_x_os_wait_count.add(count_os_wait);
 	}
-
-	rw_lock_stats.rw_x_spin_round_count.add(n_spins);
-
-	if (count_os_wait > 0) {
-		lock->count_os_wait +=
-			static_cast<uint32_t>(count_os_wait);
-		rw_lock_stats.rw_x_os_wait_count.add(count_os_wait);
-	}
 }
 
 #ifdef UNIV_DEBUG


### PR DESCRIPTION
rw_lock_x_lock_wait_func(): remove duplicated logic added in incorrect merge

Affected counters are affected by InnoDB monitor. But they aren't stable and thus
can not be realiably tested.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.