### PR TITLE
MDEV-17332 use -f with pgrep

### DIFF
--- a/support-files/mysql.server.sh
+++ b/support-files/mysql.server.sh
@@ -377,7 +377,7 @@ case "$mode" in
       fi
     else
       # Try to find appropriate mysqld process
-      mysqld_pid=`pgrep $libexecdir/mysqld`
+      mysqld_pid=`pgrep -f $libexecdir/mysqld`
 
       # test if multiple pids exist
       pid_count=`echo $mysqld_pid | wc -w`


### PR DESCRIPTION
Summary:
`pgrep` will not be able to get the pid using the full path which is `$libexec/mysqld` unless `-f` is being used.

Tested on 10.2.18-MariaDB with CentOS 7

Description:
The following command is not working as expected:
```
pgrep $libexecdir/mysqld
```
which in my case resolves to:
```
pgrep /usr/sbin/mysqld
```
The expected output should be the pid of mysql/mariadb as it is running and can be found using `ps aux` but it returns nothing and this made the output of `service mysql status` not accurate as it gives the following message: 
```
MariaDB is not running
```
however after using `pgrep -f $libexec/mysqld` the output of `service mysql status` was more accurate than before:
```
MariaDB is running but PID file could not be found
```

This code is submitted under the BSD-new license.