### PR TITLE
MDEV-17358 my_reverse_bits() is incorrect due to UB

### DIFF
--- a/include/my_bit.h
+++ b/include/my_bit.h
@@ -115,10 +115,10 @@ static inline uint32 my_clear_highest_bit(uint32 v)
 static inline uint32 my_reverse_bits(uint32 key)
 {
   return
-    (_my_bits_reverse_table[ key      & 255] << 24) |
-    (_my_bits_reverse_table[(key>> 8) & 255] << 16) |
-    (_my_bits_reverse_table[(key>>16) & 255] <<  8) |
-     _my_bits_reverse_table[(key>>24)      ];
+    ((uint32)_my_bits_reverse_table[ key      & 255] << 24) |
+    ((uint32)_my_bits_reverse_table[(key>> 8) & 255] << 16) |
+    ((uint32)_my_bits_reverse_table[(key>>16) & 255] <<  8) |
+     (uint32)_my_bits_reverse_table[(key>>24)      ];
 }
 
 C_MODE_END


### PR DESCRIPTION
my_reverse_bits(): add a cast to fix a bit shift

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.0-MDEV-17358-reverse-bits)

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.