### PR TITLE
MDEV-17313 Data race in ib_counter_t

### DIFF
--- a/storage/innobase/include/sync0arr.ic
+++ b/storage/innobase/include/sync0arr.ic
@@ -44,8 +44,7 @@ sync_array_get()
 		return(sync_wait_array[0]);
 	}
 
-	return(sync_wait_array[default_indexer_t<>::get_rnd_index()
-			       % sync_array_size]);
+	return(sync_wait_array[get_rnd_value() % sync_array_size]);
 }
 
 /******************************************************************//**


### PR DESCRIPTION
ib_counter_t: make all reads/writes to m_counter relaxed atomical

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.