### PR TITLE
innobase: Fix compile error on clang/macOS

### DIFF
--- a/storage/innobase/include/ut0counter.h
+++ b/storage/innobase/include/ut0counter.h
@@ -58,7 +58,7 @@ get_rnd_value()
 	/* We may go here if my_timer_cycles() returns 0,
 	so we have to have the plan B for the counter. */
 #if !defined(_WIN32)
-	return static_cast<size_t>(os_thread_get_curr_id());
+	return reinterpret_cast<size_t>(os_thread_get_curr_id());
 #else
 	LARGE_INTEGER cnt;
 	QueryPerformanceCounter(&cnt);


### PR DESCRIPTION
On macOS pthread_t is opaque, requires reinterpret_cast since
pthread id is a pointer to struct _opaque_pthread_t type;

Was failing with Clang 10.0.0 Debug build on macOS 10.14:

10.4/storage/innobase/include/ut0counter.h:61:9: error: static_cast from 'os_thread_id_t' (aka '_opaque_pthread_t *') to 'size_t' (aka 'unsigned long') is not allowed
        return static_cast<size_t>(os_thread_get_curr_id());
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

Change introduced in:
be31c18e4a6 ib_counter_t code simplified without functional changes