### PR TITLE
MDEV-17377 invalid gap in auto-increment values after LOAD DATA

### DIFF
--- a/mysql-test/r/auto_increment_ranges_innodb.result
+++ b/mysql-test/r/auto_increment_ranges_innodb.result
@@ -264,3 +264,23 @@ delete from t1 where a=32767;
 insert into t1 values(NULL);
 ERROR 22003: Out of range value for column 'a' at row 1
 drop table t1;
+#
+# MDEV-17377 invalid gap in auto-increment values after LOAD DATA
+#
+create or replace table t1 (pk int auto_increment primary key, f varchar(20));
+create or replace table t2 (f varchar(20));
+insert t1 (f) values ('a'), ('b'), ('c'), ('d');
+select null, f into outfile 'load.data' from t1 limit 1;
+insert t2 (f) values ('a'), ('b'), ('c'), ('d'), ('e'), ('f'), ('g');
+load data infile 'load.data' into table t1;
+insert t1 (f) values ('<===');
+select * from t1;
+pk	f
+1	a
+2	b
+3	c
+4	d
+5	a
+6	<===
+drop table t1;
+drop table t2;

--- a/mysql-test/r/auto_increment_ranges_myisam.result
+++ b/mysql-test/r/auto_increment_ranges_myisam.result
@@ -270,3 +270,23 @@ delete from t1 where a=32767;
 insert into t1 values(NULL);
 ERROR 22003: Out of range value for column 'a' at row 1
 drop table t1;
+#
+# MDEV-17377 invalid gap in auto-increment values after LOAD DATA
+#
+create or replace table t1 (pk int auto_increment primary key, f varchar(20));
+create or replace table t2 (f varchar(20));
+insert t1 (f) values ('a'), ('b'), ('c'), ('d');
+select null, f into outfile 'load.data' from t1 limit 1;
+insert t2 (f) values ('a'), ('b'), ('c'), ('d'), ('e'), ('f'), ('g');
+load data infile 'load.data' into table t1;
+insert t1 (f) values ('<===');
+select * from t1;
+pk	f
+1	a
+2	b
+3	c
+4	d
+5	a
+6	<===
+drop table t1;
+drop table t2;

--- a/mysql-test/t/auto_increment_ranges.inc
+++ b/mysql-test/t/auto_increment_ranges.inc
@@ -238,3 +238,19 @@ delete from t1 where a=32767;
 --error HA_ERR_AUTOINC_ERANGE
 insert into t1 values(NULL);
 drop table t1;
+
+--echo #
+--echo # MDEV-17377 invalid gap in auto-increment values after LOAD DATA
+--echo #
+create or replace table t1 (pk int auto_increment primary key, f varchar(20));
+create or replace table t2 (f varchar(20));
+insert t1 (f) values ('a'), ('b'), ('c'), ('d');
+select null, f into outfile 'load.data' from t1 limit 1;
+insert t2 (f) values ('a'), ('b'), ('c'), ('d'), ('e'), ('f'), ('g');
+load data infile 'load.data' into table t1;
+insert t1 (f) values ('<===');
+select * from t1;
+let $mysqld_datadir= `select @@datadir`;
+--remove_file $mysqld_datadir/test/load.data
+drop table t1;
+drop table t2;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -3063,7 +3063,8 @@ int handler::update_auto_increment()
 
       if ((auto_inc_intervals_count == 0) && (estimation_rows_to_insert > 0))
         nb_desired_values= estimation_rows_to_insert;
-      else if ((auto_inc_intervals_count == 0) &&
+      else if (thd->lex->is_insert() &&
+               (auto_inc_intervals_count == 0) &&
                (thd->lex->many_values.elements > 0))
       {
         /*

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -1423,6 +1423,11 @@ public:
   */
   static const int binlog_stmt_unsafe_errcode[BINLOG_STMT_UNSAFE_COUNT];
 
+  inline bool is_insert()
+  {
+    return sql_command == SQLCOM_INSERT || sql_command == SQLCOM_INSERT_SELECT;
+  }
+
   /**
     Determine if this statement is marked as unsafe.
 


### PR DESCRIPTION

This code is submitted under the BSD-new license.

There is nothing wrong in gaps after LOAD DATA because of the
algorithm used to reserve auto-increment for a statement with unknown
record count (see how `m_prebuilt->autoinc_last_value` evaluates from
`nb_desired_values`).

Though it is wrong how `many_values` from previous statement creates
gaps in LOAD DATA auto-increment update. `many_values` is local to LEX
and is reinitialized with every parsed INSERT. This guarantees
`many_values` to be coupled with current INSERT but not with other
commands.

Also `many_values` is used for SELECT from value-constructed table:

select * from (values (1)) a;

Better fix would be to localize statement data into Sql_cmd hierarchy.