### PR TITLE
Use 'exit' instead of 'return'

### DIFF
--- a/scripts/galera_new_cluster.sh
+++ b/scripts/galera_new_cluster.sh
@@ -28,4 +28,4 @@ extcode=$?
 
 systemctl set-environment _WSREP_NEW_CLUSTER=''
 
-return $extcode
+exit $extcode


### PR DESCRIPTION
Running this script in shell leads to an error:
  "sh return: can only `return' from a function or sourced script"