### PR TITLE
improve(test) framework manual is moved

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -20,7 +20,7 @@
   Tool used for executing a .test file
 
   See the "MySQL Test framework manual" for more information
-  http://dev.mysql.com/doc/mysqltest/en/index.html
+  https://mariadb.com/kb/en/library/mysqltest/
 
   Please keep the test framework tools identical in all versions!
 

--- a/mysql-test/lib/v1/mysql-test-run.pl
+++ b/mysql-test/lib/v1/mysql-test-run.pl
@@ -23,7 +23,7 @@
 #  Tool used for executing a suite of .test file
 #
 #  See the "MySQL Test framework manual" for more information
-#  http://dev.mysql.com/doc/mysqltest/en/index.html
+#  https://mariadb.com/kb/en/library/mysqltest/
 #
 #  Please keep the test framework tools identical in all versions!
 #

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -25,7 +25,7 @@
 #  Tool used for executing a suite of .test files
 #
 #  See the "MySQL Test framework manual" for more information
-#  http://dev.mysql.com/doc/mysqltest/en/index.html
+#  https://mariadb.com/kb/en/library/mysqltest/
 #
 #
 ##############################################################################


### PR DESCRIPTION
Hello,
I was reading the source and found a small problem. 
A few link of some URL written in the comment seems to have moved.
I fixed the link of the URL I wanted to see.
But there seems to be another similar links.
If necessary, I can also fix it. How do you like it?