### PR TITLE
MDEV-13671 InnoDB should use case-insensitive column name comparisons like the rest of the server

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5982,7 +5982,8 @@ innobase_build_v_templ(
 			const char*	name = dict_table_get_col_name(
 						ib_table, j);
 
-			ut_ad(!ut_strcmp(name, field->field_name));
+			ut_ad(!my_strcasecmp(system_charset_info, name,
+					     field->field_name));
 #endif
 
 			s_templ->vtempl[j] = static_cast<


### PR DESCRIPTION
This is a 10.2 part of a 10.0 fix.

innobase_vcol_build_templ(): relax debug assertion

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.2-MDEV-13671-fields-case-sensitive)