### PR TITLE
travis: increase ccache size for linux jobs

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -22,7 +22,7 @@ if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
   exclude_modules;
   if which ccache ; then
     CMAKE_OPT="${CMAKE_OPT} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-    ccache --max-size=1200M
+    ccache --max-size=2200M
   fi
   if [[ "${CXX}" == 'clang++' ]]; then
     export CXX CC=${CXX/++/}


### PR DESCRIPTION
Apparently, there is room to squeeze a little bit more cache as seen in these build speedups:
https://travis-ci.org/shinnok/server/builds/449288361
https://travis-ci.org/shinnok/server/builds/449346985
