### PR TITLE
MDEV-15564 Avoid table rebuild in ALTER TABLE on collation or charset change

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_charset.result
+++ b/mysql-test/suite/innodb/r/instant_alter_charset.result
@@ -1,0 +1,1614 @@
+set names utf8;
+SET @old_instant=
+(SELECT variable_value FROM information_schema.global_status
+WHERE variable_name = 'innodb_instant_alter_column');
+create table no_rebuild (
+a char(150) charset utf8mb3 collate utf8mb3_general_ci
+) engine=innodb;
+create table rebuild (
+a varchar(150) charset ascii
+) engine=innodb;
+set @id = (select table_id from information_schema.innodb_sys_tables
+where name = 'test/no_rebuild');
+select name, prtype, len from information_schema.innodb_sys_columns
+where table_id = @id;
+name	prtype	len
+a	2162942	450
+select c.prtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+where t.name = 'test/rebuild' and c.name = 'a';
+prtype	len
+720911	150
+alter table no_rebuild
+change a a char(150) charset utf8mb3 collate utf8mb3_spanish_ci,
+algorithm=inplace;
+alter table rebuild
+change a a varchar(150) charset latin1 not null default 'asdf',
+algorithm=inplace;
+select name, prtype, len from information_schema.innodb_sys_columns
+where table_id = @id;
+name	prtype	len
+a	13041918	450
+select c.prtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+where t.name = 'test/rebuild' and c.name = 'a';
+prtype	len
+524559	150
+drop table no_rebuild, rebuild;
+create table supported_types (
+id int primary key auto_increment,
+a varchar(150) charset ascii,
+b text(150) charset ascii,
+c text charset ascii,
+d tinytext charset ascii,
+e mediumtext charset ascii,
+f longtext charset ascii
+) engine=innodb;
+alter table supported_types
+convert to charset latin1,
+algorithm=instant;
+drop table supported_types;
+create table various_cases (
+a char(150) charset ascii,
+b varchar(150) as (a) virtual,
+c varchar(150) as (a) persistent
+) engine=innodb;
+alter table various_cases
+change a a char(150) charset latin1,
+algorithm=inplace;
+alter table various_cases
+change a a varchar(222),
+algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table various_cases
+change b b varchar(150) as (a) virtual,
+algorithm=inplace;
+alter table various_cases
+change c c varchar(150) as (a) persistent,
+algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY
+alter table various_cases
+modify a char(150) charset utf8mb4,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table various_cases;
+create table all_texts (
+a tinytext charset ascii,
+b text charset ascii,
+c mediumtext charset ascii,
+d longtext charset ascii,
+footer int
+) engine=innodb;
+alter table all_texts
+convert to charset latin1 collate latin1_general_ci,
+algorithm=instant;
+drop table all_texts;
+create table all_binaries (
+a tinyblob,
+b blob,
+c mediumblob,
+d longblob,
+e varbinary(150),
+f binary(150)
+) engine=innodb;
+alter table all_binaries modify a tinytext, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_binaries modify b text, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_binaries modify c mediumtext, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_binaries modify d longtext, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_binaries modify e varchar(150), algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_binaries modify f char(150), algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table all_binaries;
+create table all_strings (
+a tinytext,
+b text,
+c mediumtext,
+d longtext,
+e varchar(150),
+f char(150)
+) engine=innodb;
+alter table all_strings modify a tinyblob, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify b blob, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify c mediumblob, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify d longblob, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify e varbinary(150), algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify f binary(150), algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table all_strings;
+create table key_part_change (
+a char(150) charset ascii,
+b char(150) charset ascii,
+c char(150) charset ascii,
+unique key ab (a,b)
+) engine=innodb;
+alter table key_part_change
+modify a char(150) charset utf8mb4,
+drop index ab,
+add unique key ab(a,c),
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table key_part_change;
+create table key_part_change_and_rename (
+a char(100) charset ascii,
+b char(100) charset ascii,
+unique key ab (a,b)
+) engine=innodb;
+alter table key_part_change_and_rename
+change a b char(100) charset utf8mb4,
+change b a char(100) charset utf8mb4,
+drop index ab,
+add unique key ab(a,b),
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table key_part_change_and_rename;
+create table enum_and_set (
+a enum('one', 'two') charset utf8mb3,
+b set('three', 'four') charset utf8mb3
+) engine=innodb;
+alter table enum_and_set
+modify a enum('one', 'two') charset utf8mb4,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table enum_and_set
+modify b enum('three', 'four') charset utf8mb4,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table enum_and_set;
+create table compressed (
+a varchar(255) charset utf8mb3 compressed
+) engine=innodb;
+insert into compressed values ('AAA'), ('bbb'), ('CCC');
+alter table compressed
+modify a varchar(255) charset utf8mb4 compressed,
+algorithm=instant;
+select * from compressed;
+a
+AAA
+bbb
+CCC
+check table compresed;
+Table	Op	Msg_type	Msg_text
+test.compresed	check	Error	Table 'test.compresed' doesn't exist
+test.compresed	check	status	Operation failed
+drop table compressed;
+create table key_part_bug (
+id int primary key auto_increment,
+a varchar(150) charset utf8mb3 unique key
+) engine=innodb;
+alter table key_part_bug
+modify a varchar(150) charset utf8mb4,
+algorithm=instant;
+drop table key_part_bug;
+create table latin1_swedish_special_case (
+copy1 varchar(150) charset ascii collate ascii_general_ci,
+copy2 char(150) charset ascii collate ascii_general_ci,
+instant1 varchar(150) charset ascii collate ascii_general_ci,
+instant2 char(150) charset ascii collate ascii_general_ci
+) engine=innodb;
+select c.name, c.prtype, c.mtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+where t.name = 'test/latin1_swedish_special_case';
+name	prtype	mtype	len
+copy1	720911	12	150
+copy2	721150	13	150
+instant1	720911	12	150
+instant2	721150	13	150
+alter table latin1_swedish_special_case
+modify copy1 varchar(150) charset latin1 collate latin1_swedish_ci,
+modify copy2 char(150) charset latin1 collate latin1_swedish_ci,
+algorithm=copy;
+alter table latin1_swedish_special_case
+modify instant1 varchar(150) charset latin1 collate latin1_swedish_ci,
+modify instant2 char(150) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+select c.name, c.prtype, c.mtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+where t.name = 'test/latin1_swedish_special_case';
+name	prtype	mtype	len
+copy1	524303	1	150
+copy2	524542	2	150
+instant1	524303	1	150
+instant2	524542	2	150
+alter table latin1_swedish_special_case
+modify copy1 varchar(150) charset latin1 collate latin1_general_ci,
+modify copy2 char(150) charset latin1 collate latin1_general_ci,
+algorithm=copy;
+alter table latin1_swedish_special_case
+modify instant1 varchar(150) charset latin1 collate latin1_general_ci,
+modify instant2 char(150) charset latin1 collate latin1_general_ci,
+algorithm=instant;
+select c.name, c.prtype, c.mtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+where t.name = 'test/latin1_swedish_special_case';
+name	prtype	mtype	len
+copy1	3145743	12	150
+copy2	3145982	13	150
+instant1	3145743	12	150
+instant2	3145982	13	150
+drop table latin1_swedish_special_case;
+create table regression (a varchar(100) charset utf8mb3 primary key, b int) engine=innodb;
+alter table regression convert to character set utf8mb4;
+drop table regression;
+create table boundary_255 (
+a varchar(50) charset ascii,
+b varchar(200) charset ascii,
+c varchar(300) charset ascii
+) engine=innodb;
+alter table boundary_255
+modify a varchar(50) charset utf8mb3,
+algorithm=instant;
+alter table boundary_255
+modify b varchar(200) charset utf8mb3,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table boundary_255
+modify c varchar(300) charset utf8mb3,
+algorithm=instant;
+drop table boundary_255;
+create table fully_compatible (
+id int auto_increment unique key,
+from_charset char(255),
+from_collate char(255),
+to_charset char(255),
+to_collate char(255)
+);
+insert into fully_compatible (from_charset, from_collate, to_charset, to_collate) values
+('utf8mb3', 'utf8mb3_general_ci',           'utf8mb4', 'utf8mb4_general_ci'),
+('utf8mb3', 'utf8mb3_bin',                  'utf8mb4', 'utf8mb4_bin'),
+('utf8mb3', 'utf8mb3_unicode_ci',           'utf8mb4', 'utf8mb4_unicode_ci'),
+('utf8mb3', 'utf8mb3_icelandic_ci',         'utf8mb4', 'utf8mb4_icelandic_ci'),
+('utf8mb3', 'utf8mb3_latvian_ci',           'utf8mb4', 'utf8mb4_latvian_ci'),
+('utf8mb3', 'utf8mb3_romanian_ci',          'utf8mb4', 'utf8mb4_romanian_ci'),
+('utf8mb3', 'utf8mb3_slovenian_ci',         'utf8mb4', 'utf8mb4_slovenian_ci'),
+('utf8mb3', 'utf8mb3_polish_ci',            'utf8mb4', 'utf8mb4_polish_ci'),
+('utf8mb3', 'utf8mb3_estonian_ci',          'utf8mb4', 'utf8mb4_estonian_ci'),
+('utf8mb3', 'utf8mb3_spanish_ci',           'utf8mb4', 'utf8mb4_spanish_ci'),
+('utf8mb3', 'utf8mb3_swedish_ci',           'utf8mb4', 'utf8mb4_swedish_ci'),
+('utf8mb3', 'utf8mb3_turkish_ci',           'utf8mb4', 'utf8mb4_turkish_ci'),
+('utf8mb3', 'utf8mb3_czech_ci',             'utf8mb4', 'utf8mb4_czech_ci'),
+('utf8mb3', 'utf8mb3_danish_ci',            'utf8mb4', 'utf8mb4_danish_ci'),
+('utf8mb3', 'utf8mb3_lithuanian_ci',        'utf8mb4', 'utf8mb4_lithuanian_ci'),
+('utf8mb3', 'utf8mb3_slovak_ci',            'utf8mb4', 'utf8mb4_slovak_ci'),
+('utf8mb3', 'utf8mb3_spanish2_ci',          'utf8mb4', 'utf8mb4_spanish2_ci'),
+('utf8mb3', 'utf8mb3_roman_ci',             'utf8mb4', 'utf8mb4_roman_ci'),
+('utf8mb3', 'utf8mb3_persian_ci',           'utf8mb4', 'utf8mb4_persian_ci'),
+('utf8mb3', 'utf8mb3_esperanto_ci',         'utf8mb4', 'utf8mb4_esperanto_ci'),
+('utf8mb3', 'utf8mb3_hungarian_ci',         'utf8mb4', 'utf8mb4_hungarian_ci'),
+('utf8mb3', 'utf8mb3_sinhala_ci',           'utf8mb4', 'utf8mb4_sinhala_ci'),
+('utf8mb3', 'utf8mb3_german2_ci',           'utf8mb4', 'utf8mb4_german2_ci'),
+('utf8mb3', 'utf8mb3_croatian_mysql561_ci', 'utf8mb4', 'utf8mb4_croatian_mysql561_ci'),
+('utf8mb3', 'utf8mb3_unicode_520_ci',       'utf8mb4', 'utf8mb4_unicode_520_ci'),
+('utf8mb3', 'utf8mb3_vietnamese_ci',        'utf8mb4', 'utf8mb4_vietnamese_ci'),
+('utf8mb3', 'utf8mb3_croatian_ci',          'utf8mb4', 'utf8mb4_croatian_ci'),
+('utf8mb3', 'utf8mb3_myanmar_ci',           'utf8mb4', 'utf8mb4_myanmar_ci'),
+('utf8mb3', 'utf8mb3_thai_520_w2',          'utf8mb4', 'utf8mb4_thai_520_w2'),
+('utf8mb3', 'utf8mb3_general_nopad_ci',     'utf8mb4', 'utf8mb4_general_nopad_ci'),
+('utf8mb3', 'utf8mb3_nopad_bin',            'utf8mb4', 'utf8mb4_nopad_bin'),
+('utf8mb3', 'utf8mb3_unicode_nopad_ci',     'utf8mb4', 'utf8mb4_unicode_nopad_ci'),
+('utf8mb3', 'utf8mb3_unicode_520_nopad_ci', 'utf8mb4', 'utf8mb4_unicode_520_nopad_ci'),
+('ascii', 'ascii_general_ci',       'utf8mb3', 'utf8mb3_general_ci'),
+('ascii', 'ascii_general_ci',       'utf8mb4', 'utf8mb4_general_ci'),
+('ascii', 'ascii_general_ci',       'latin1', 'latin1_general_ci'),
+('ascii', 'ascii_bin',              'latin1', 'latin1_bin'),
+('ascii', 'ascii_nopad_bin',        'latin1', 'latin1_nopad_bin'),
+('ascii', 'ascii_general_ci',       'latin2', 'latin2_general_ci'),
+('ascii', 'ascii_general_ci',       'latin7', 'latin7_general_ci'),
+('ascii', 'ascii_bin',              'koi8u',  'koi8u_bin'),
+('ascii', 'ascii_bin',              'ujis',   'ujis_bin'),
+('ascii', 'ascii_bin',              'big5',   'big5_bin'),
+('ascii', 'ascii_bin',              'gbk',    'gbk_bin')
+;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_general_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_general_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_bin,
+b varchar(50) charset utf8mb3 collate utf8mb3_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_bin,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_unicode_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_unicode_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_unicode_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_unicode_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_icelandic_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_icelandic_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_icelandic_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_icelandic_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_latvian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_latvian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_latvian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_latvian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_romanian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_romanian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_romanian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_romanian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_slovenian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_slovenian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_slovenian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_slovenian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_polish_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_polish_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_polish_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_polish_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_estonian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_estonian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_estonian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_estonian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_spanish_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_spanish_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_spanish_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_spanish_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_swedish_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_swedish_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_turkish_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_turkish_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_turkish_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_turkish_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_czech_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_czech_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_czech_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_czech_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_danish_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_danish_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_lithuanian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_lithuanian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_lithuanian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_lithuanian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_slovak_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_slovak_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_slovak_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_slovak_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_spanish2_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_spanish2_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_spanish2_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_spanish2_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_roman_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_roman_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_roman_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_roman_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_persian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_persian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_persian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_persian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_esperanto_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_esperanto_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_esperanto_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_esperanto_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_hungarian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_hungarian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_hungarian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_hungarian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_sinhala_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_sinhala_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_sinhala_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_sinhala_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_german2_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_german2_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_german2_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_german2_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_croatian_mysql561_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_croatian_mysql561_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_croatian_mysql561_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_croatian_mysql561_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_unicode_520_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_unicode_520_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_unicode_520_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_unicode_520_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_vietnamese_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_vietnamese_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_croatian_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_croatian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_croatian_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_croatian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_myanmar_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_myanmar_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_myanmar_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_myanmar_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_thai_520_w2,
+b varchar(50) charset utf8mb3 collate utf8mb3_thai_520_w2 primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_thai_520_w2,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_thai_520_w2,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_general_nopad_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_general_nopad_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_general_nopad_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_general_nopad_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_nopad_bin,
+b varchar(50) charset utf8mb3 collate utf8mb3_nopad_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_nopad_bin,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_nopad_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_unicode_nopad_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_unicode_nopad_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_unicode_nopad_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_unicode_nopad_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_unicode_520_nopad_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_unicode_520_nopad_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_unicode_520_nopad_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_unicode_520_nopad_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb3 collate utf8mb3_general_ci,
+modify b varchar(50) charset utf8mb3 collate utf8mb3_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_general_ci,
+modify b varchar(50) charset utf8mb4 collate utf8mb4_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_general_ci,
+modify b varchar(50) charset latin1 collate latin1_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_bin,
+modify b varchar(50) charset latin1 collate latin1_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_nopad_bin,
+b varchar(50) charset ascii collate ascii_nopad_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_nopad_bin,
+modify b varchar(50) charset latin1 collate latin1_nopad_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset latin2 collate latin2_general_ci,
+modify b varchar(50) charset latin2 collate latin2_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset latin7 collate latin7_general_ci,
+modify b varchar(50) charset latin7 collate latin7_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset koi8u collate koi8u_bin,
+modify b varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset ujis collate ujis_bin,
+modify b varchar(50) charset ujis collate ujis_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset big5 collate big5_bin,
+modify b varchar(50) charset big5 collate big5_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset gbk collate gbk_bin,
+modify b varchar(50) charset gbk collate gbk_bin,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+drop table fully_compatible;
+create table compatible_without_index (
+id int auto_increment unique key,
+from_charset char(255),
+from_collate char(255),
+to_charset char(255),
+to_collate char(255)
+);
+insert into compatible_without_index (from_charset, from_collate, to_charset, to_collate) values
+('ascii', 'ascii_general_ci',       'utf8mb3', 'utf8mb3_swedish_ci'),
+('ascii', 'ascii_bin',              'latin1', 'latin1_swedish_ci'),
+('ascii', 'ascii_general_nopad_ci', 'latin1', 'latin1_swedish_ci'),
+('ascii', 'ascii_nopad_bin',        'latin1', 'latin1_swedish_ci'),
+('ascii', 'ascii_general_ci',       'koi8u', 'koi8u_bin'),
+('ascii', 'ascii_general_nopad_ci', 'koi8u', 'koi8u_bin'),
+('ascii', 'ascii_nopad_bin',        'koi8u', 'koi8u_bin'),
+('ascii', 'ascii_general_ci',       'latin1', 'latin1_swedish_ci'),
+('ascii', 'ascii_bin',              'utf8mb3', 'utf8mb3_swedish_ci'),
+('ascii', 'ascii_general_nopad_ci', 'utf8mb3', 'utf8mb3_swedish_ci'),
+('ascii', 'ascii_nopad_bin',        'utf8mb3', 'utf8mb3_swedish_ci'),
+('ascii', 'ascii_general_ci',       'utf8mb4', 'utf8mb4_danish_ci'),
+('ascii', 'ascii_bin',              'utf8mb4', 'utf8mb4_danish_ci'),
+('ascii', 'ascii_general_nopad_ci', 'utf8mb4', 'utf8mb4_danish_ci'),
+('ascii', 'ascii_nopad_bin',        'utf8mb4', 'utf8mb4_danish_ci'),
+('utf8mb3', 'utf8mb3_general_ci',       'utf8mb4', 'utf8mb4_vietnamese_ci'),
+('utf8mb3', 'utf8mb3_bin',              'utf8mb4', 'utf8mb4_vietnamese_ci'),
+('utf8mb3', 'utf8mb3_general_nopad_ci', 'utf8mb4', 'utf8mb4_vietnamese_ci'),
+('utf8mb3', 'utf8mb3_nopad_bin',        'utf8mb4', 'utf8mb4_vietnamese_ci'),
+('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_ci'),
+('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_nopad_ci'),
+('ascii',   'ascii_general_ci',      'ascii',   'ascii_bin'),
+('utf8mb3', 'utf8mb3_roman_ci',      'utf8mb3', 'utf8mb3_lithuanian_ci'),
+('utf8mb4', 'utf8mb4_thai_520_w2',   'utf8mb4', 'utf8mb4_persian_ci'),
+('utf8mb3', 'utf8mb3_myanmar_ci',    'utf8mb4', 'utf8mb4_german2_ci'),
+('utf8mb3', 'utf8mb3_general_ci',    'utf8mb3', 'utf8mb3_unicode_ci'),
+('latin1',  'latin1_general_cs',     'latin1',  'latin1_general_ci'),
+('ascii',   'ascii_general_ci',      'ujis',    'ujis_japanese_ci'),
+('ascii',   'ascii_general_ci',      'big5',    'big5_chinese_ci'),
+('ascii',   'ascii_general_ci',      'latin2',  'latin2_croatian_ci'),
+('ascii',   'ascii_general_ci',      'latin7',  'latin7_estonian_cs'),
+('utf16',   'utf16_general_ci',      'utf16',   'utf16_german2_ci')
+;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin unique key,
+c varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_nopad_ci,
+b varchar(50) charset ascii collate ascii_general_nopad_ci unique key,
+c varchar(50) charset ascii collate ascii_general_nopad_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_nopad_bin,
+b varchar(50) charset ascii collate ascii_nopad_bin unique key,
+c varchar(50) charset ascii collate ascii_nopad_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_nopad_ci,
+b varchar(50) charset ascii collate ascii_general_nopad_ci unique key,
+c varchar(50) charset ascii collate ascii_general_nopad_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_nopad_bin,
+b varchar(50) charset ascii collate ascii_nopad_bin unique key,
+c varchar(50) charset ascii collate ascii_nopad_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset koi8u collate koi8u_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset latin1 collate latin1_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin unique key,
+c varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_nopad_ci,
+b varchar(50) charset ascii collate ascii_general_nopad_ci unique key,
+c varchar(50) charset ascii collate ascii_general_nopad_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_nopad_bin,
+b varchar(50) charset ascii collate ascii_nopad_bin unique key,
+c varchar(50) charset ascii collate ascii_nopad_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb3 collate utf8mb3_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_bin,
+b varchar(50) charset ascii collate ascii_bin unique key,
+c varchar(50) charset ascii collate ascii_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_nopad_ci,
+b varchar(50) charset ascii collate ascii_general_nopad_ci unique key,
+c varchar(50) charset ascii collate ascii_general_nopad_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_nopad_bin,
+b varchar(50) charset ascii collate ascii_nopad_bin unique key,
+c varchar(50) charset ascii collate ascii_nopad_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_danish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_general_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_general_ci unique key,
+c varchar(50) charset utf8mb3 collate utf8mb3_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_bin,
+b varchar(50) charset utf8mb3 collate utf8mb3_bin unique key,
+c varchar(50) charset utf8mb3 collate utf8mb3_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_general_nopad_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_general_nopad_ci unique key,
+c varchar(50) charset utf8mb3 collate utf8mb3_general_nopad_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_nopad_bin,
+b varchar(50) charset utf8mb3 collate utf8mb3_nopad_bin unique key,
+c varchar(50) charset utf8mb3 collate utf8mb3_nopad_bin primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_vietnamese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset gbk collate gbk_chinese_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset gbk collate gbk_chinese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset gbk collate gbk_chinese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset gbk collate gbk_chinese_nopad_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset gbk collate gbk_chinese_nopad_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset gbk collate gbk_chinese_nopad_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset ascii collate ascii_bin,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset ascii collate ascii_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset ascii collate ascii_bin,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_roman_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_roman_ci unique key,
+c varchar(50) charset utf8mb3 collate utf8mb3_roman_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb3 collate utf8mb3_lithuanian_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb3 collate utf8mb3_lithuanian_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb3 collate utf8mb3_lithuanian_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb4 collate utf8mb4_thai_520_w2,
+b varchar(50) charset utf8mb4 collate utf8mb4_thai_520_w2 unique key,
+c varchar(50) charset utf8mb4 collate utf8mb4_thai_520_w2 primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_persian_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_persian_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_persian_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_myanmar_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_myanmar_ci unique key,
+c varchar(50) charset utf8mb3 collate utf8mb3_myanmar_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb4 collate utf8mb4_german2_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb4 collate utf8mb4_german2_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb4 collate utf8mb4_german2_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf8mb3 collate utf8mb3_general_ci,
+b varchar(50) charset utf8mb3 collate utf8mb3_general_ci unique key,
+c varchar(50) charset utf8mb3 collate utf8mb3_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf8mb3 collate utf8mb3_unicode_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf8mb3 collate utf8mb3_unicode_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf8mb3 collate utf8mb3_unicode_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset latin1 collate latin1_general_cs,
+b varchar(50) charset latin1 collate latin1_general_cs unique key,
+c varchar(50) charset latin1 collate latin1_general_cs primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset latin1 collate latin1_general_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset latin1 collate latin1_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset latin1 collate latin1_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset ujis collate ujis_japanese_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset ujis collate ujis_japanese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset ujis collate ujis_japanese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset big5 collate big5_chinese_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset big5 collate big5_chinese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset big5 collate big5_chinese_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset latin2 collate latin2_croatian_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset latin2 collate latin2_croatian_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset latin2 collate latin2_croatian_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ascii collate ascii_general_ci,
+b varchar(50) charset ascii collate ascii_general_ci unique key,
+c varchar(50) charset ascii collate ascii_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset latin7 collate latin7_estonian_cs,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset latin7 collate latin7_estonian_cs,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset latin7 collate latin7_estonian_cs,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset utf16 collate utf16_general_ci,
+b varchar(50) charset utf16 collate utf16_general_ci unique key,
+c varchar(50) charset utf16 collate utf16_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_german2_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf16 collate utf16_german2_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf16 collate utf16_german2_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+drop table compatible_without_index;
+create table fully_incompatible (
+id int auto_increment unique key,
+from_charset char(255),
+from_collate char(255),
+to_charset char(255),
+to_collate char(255)
+);
+insert into fully_incompatible (from_charset, from_collate, to_charset, to_collate) values
+('utf8mb4', 'utf8mb4_general_ci', 'utf8mb3', 'utf8mb3_general_ci'),
+('utf8mb4', 'utf8mb4_general_ci', 'ascii', 'ascii_general_ci'),
+('utf8mb3', 'utf8mb3_general_ci', 'ascii', 'ascii_general_ci'),
+('utf8mb3', 'utf8mb3_general_ci', 'latin1', 'latin1_general_ci'),
+('utf16', 'utf16_general_ci', 'utf32', 'utf32_general_ci'),
+('latin1', 'latin1_general_ci',   'ascii', 'ascii_general_ci'),
+('ascii', 'ascii_general_ci',     'swe7', 'swe7_swedish_ci'),
+('eucjpms', 'eucjpms_japanese_nopad_ci', 'geostd8', 'geostd8_general_ci'),
+('latin1', 'latin1_general_ci',   'utf16', 'utf16_general_ci')
+;
+create table tmp (
+a varchar(150) charset utf8mb4 collate utf8mb4_general_ci,
+b text(150) charset utf8mb4 collate utf8mb4_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset utf8mb3 collate utf8mb3_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset utf8mb3 collate utf8mb3_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset utf8mb4 collate utf8mb4_general_ci,
+b text(150) charset utf8mb4 collate utf8mb4_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset ascii collate ascii_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset ascii collate ascii_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset utf8mb3 collate utf8mb3_general_ci,
+b text(150) charset utf8mb3 collate utf8mb3_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset ascii collate ascii_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset ascii collate ascii_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset utf8mb3 collate utf8mb3_general_ci,
+b text(150) charset utf8mb3 collate utf8mb3_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset latin1 collate latin1_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset latin1 collate latin1_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset utf16 collate utf16_general_ci,
+b text(150) charset utf16 collate utf16_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset utf32 collate utf32_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset utf32 collate utf32_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset latin1 collate latin1_general_ci,
+b text(150) charset latin1 collate latin1_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset ascii collate ascii_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset ascii collate ascii_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset ascii collate ascii_general_ci,
+b text(150) charset ascii collate ascii_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset swe7 collate swe7_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset swe7 collate swe7_swedish_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset eucjpms collate eucjpms_japanese_nopad_ci,
+b text(150) charset eucjpms collate eucjpms_japanese_nopad_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset geostd8 collate geostd8_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset geostd8 collate geostd8_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(150) charset latin1 collate latin1_general_ci,
+b text(150) charset latin1 collate latin1_general_ci,
+unique key b_idx (b(150))
+) engine=innodb;
+alter table tmp
+change a a varchar(150) charset utf16 collate utf16_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify b text charset utf16 collate utf16_general_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+drop table fully_incompatible;
+SELECT variable_value-@old_instant instants
+FROM information_schema.global_status
+WHERE variable_name = 'innodb_instant_alter_column';
+instants
+0

--- a/mysql-test/suite/innodb/r/instant_alter_charset.result
+++ b/mysql-test/suite/innodb/r/instant_alter_charset.result
@@ -1,7 +1,4 @@
 set names utf8;
-SET @old_instant=
-(SELECT variable_value FROM information_schema.global_status
-WHERE variable_name = 'innodb_instant_alter_column');
 create table no_rebuild (
 a char(150) charset utf8mb3 collate utf8mb3_general_ci
 ) engine=innodb;
@@ -291,6 +288,16 @@ insert into fully_compatible (from_charset, from_collate, to_charset, to_collate
 ('utf8mb3', 'utf8mb3_nopad_bin',            'utf8mb4', 'utf8mb4_nopad_bin'),
 ('utf8mb3', 'utf8mb3_unicode_nopad_ci',     'utf8mb4', 'utf8mb4_unicode_nopad_ci'),
 ('utf8mb3', 'utf8mb3_unicode_520_nopad_ci', 'utf8mb4', 'utf8mb4_unicode_520_nopad_ci'),
+('ucs2',    'ucs2_general_ci',       'utf16',   'utf16_general_ci'),
+('ucs2',    'ucs2_unicode_ci',       'utf16',   'utf16_unicode_ci'),
+('ucs2',    'ucs2_icelandic_ci',     'utf16',   'utf16_icelandic_ci'),
+('ucs2',    'ucs2_latvian_ci',       'utf16',   'utf16_latvian_ci'),
+('ucs2',    'ucs2_romanian_ci',      'utf16',   'utf16_romanian_ci'),
+('ucs2',    'ucs2_slovenian_ci',     'utf16',   'utf16_slovenian_ci'),
+('ucs2',    'ucs2_polish_ci',        'utf16',   'utf16_polish_ci'),
+('ucs2',    'ucs2_estonian_ci',      'utf16',   'utf16_estonian_ci'),
+('ucs2',    'ucs2_spanish_ci',       'utf16',   'utf16_spanish_ci'),
+('ucs2',    'ucs2_general_ci',       'utf16',   'utf16_general_ci'),
 ('ascii', 'ascii_general_ci',       'utf8mb3', 'utf8mb3_general_ci'),
 ('ascii', 'ascii_general_ci',       'utf8mb4', 'utf8mb4_general_ci'),
 ('ascii', 'ascii_general_ci',       'latin1', 'latin1_general_ci'),
@@ -733,6 +740,136 @@ Table	Op	Msg_type	Msg_text
 test.tmp	check	status	OK
 drop table tmp;
 create table tmp (
+a varchar(50) charset ucs2 collate ucs2_general_ci,
+b varchar(50) charset ucs2 collate ucs2_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_general_ci,
+modify b varchar(50) charset utf16 collate utf16_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_unicode_ci,
+b varchar(50) charset ucs2 collate ucs2_unicode_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_unicode_ci,
+modify b varchar(50) charset utf16 collate utf16_unicode_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_icelandic_ci,
+b varchar(50) charset ucs2 collate ucs2_icelandic_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_icelandic_ci,
+modify b varchar(50) charset utf16 collate utf16_icelandic_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_latvian_ci,
+b varchar(50) charset ucs2 collate ucs2_latvian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_latvian_ci,
+modify b varchar(50) charset utf16 collate utf16_latvian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_romanian_ci,
+b varchar(50) charset ucs2 collate ucs2_romanian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_romanian_ci,
+modify b varchar(50) charset utf16 collate utf16_romanian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_slovenian_ci,
+b varchar(50) charset ucs2 collate ucs2_slovenian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_slovenian_ci,
+modify b varchar(50) charset utf16 collate utf16_slovenian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_polish_ci,
+b varchar(50) charset ucs2 collate ucs2_polish_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_polish_ci,
+modify b varchar(50) charset utf16 collate utf16_polish_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_estonian_ci,
+b varchar(50) charset ucs2 collate ucs2_estonian_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_estonian_ci,
+modify b varchar(50) charset utf16 collate utf16_estonian_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_spanish_ci,
+b varchar(50) charset ucs2 collate ucs2_spanish_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_spanish_ci,
+modify b varchar(50) charset utf16 collate utf16_spanish_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_general_ci,
+b varchar(50) charset ucs2 collate ucs2_general_ci primary key
+) engine=innodb;
+insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_general_ci,
+modify b varchar(50) charset utf16 collate utf16_general_ci,
+algorithm=instant;
+check table tmp;
+Table	Op	Msg_type	Msg_text
+test.tmp	check	status	OK
+drop table tmp;
+create table tmp (
 a varchar(50) charset ascii collate ascii_general_ci,
 b varchar(50) charset ascii collate ascii_general_ci primary key
 ) engine=innodb;
@@ -905,6 +1042,9 @@ insert into compatible_without_index (from_charset, from_collate, to_charset, to
 ('utf8mb3', 'utf8mb3_nopad_bin',        'utf8mb4', 'utf8mb4_vietnamese_ci'),
 ('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_ci'),
 ('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_nopad_ci'),
+('ucs2',  'ucs2_myanmar_ci',          'utf16', 'utf16_thai_520_w2'),
+('ucs2',  'ucs2_general_ci',          'utf16', 'utf16_unicode_nopad_ci'),
+('ucs2',  'ucs2_general_mysql500_ci', 'utf16', 'utf16_spanish2_ci'),
 ('ascii',   'ascii_general_ci',      'ascii',   'ascii_bin'),
 ('utf8mb3', 'utf8mb3_roman_ci',      'utf8mb3', 'utf8mb3_lithuanian_ci'),
 ('utf8mb4', 'utf8mb4_thai_520_w2',   'utf8mb4', 'utf8mb4_persian_ci'),
@@ -1275,6 +1415,57 @@ algorithm=instant;
 ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
 drop table tmp;
 create table tmp (
+a varchar(50) charset ucs2 collate ucs2_myanmar_ci,
+b varchar(50) charset ucs2 collate ucs2_myanmar_ci unique key,
+c varchar(50) charset ucs2 collate ucs2_myanmar_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_thai_520_w2,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf16 collate utf16_thai_520_w2,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf16 collate utf16_thai_520_w2,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_general_ci,
+b varchar(50) charset ucs2 collate ucs2_general_ci unique key,
+c varchar(50) charset ucs2 collate ucs2_general_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_unicode_nopad_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf16 collate utf16_unicode_nopad_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf16 collate utf16_unicode_nopad_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
+a varchar(50) charset ucs2 collate ucs2_general_mysql500_ci,
+b varchar(50) charset ucs2 collate ucs2_general_mysql500_ci unique key,
+c varchar(50) charset ucs2 collate ucs2_general_mysql500_ci primary key
+) engine=innodb;
+alter table tmp
+change a a varchar(50) charset utf16 collate utf16_spanish2_ci,
+algorithm=instant;
+alter table tmp
+modify b varchar(50) charset utf16 collate utf16_spanish2_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table tmp
+modify c varchar(50) charset utf16 collate utf16_spanish2_ci,
+algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table tmp;
+create table tmp (
 a varchar(50) charset ascii collate ascii_general_ci,
 b varchar(50) charset ascii collate ascii_general_ci unique key,
 c varchar(50) charset ascii collate ascii_general_ci primary key
@@ -1607,8 +1798,3 @@ algorithm=instant;
 ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
 drop table tmp;
 drop table fully_incompatible;
-SELECT variable_value-@old_instant instants
-FROM information_schema.global_status
-WHERE variable_name = 'innodb_instant_alter_column';
-instants
-0

--- a/mysql-test/suite/innodb/r/instant_alter_charset.result
+++ b/mysql-test/suite/innodb/r/instant_alter_charset.result
@@ -119,6 +119,18 @@ alter table all_strings modify e varbinary(150), algorithm=instant;
 ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
 alter table all_strings modify f binary(150), algorithm=instant;
 ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify a tinytext charset binary, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify b text charset binary, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify c mediumtext charset binary, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify d longtext charset binary, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify e varchar(150) charset binary, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+alter table all_strings modify f char(150) charset binary, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
 drop table all_strings;
 create table key_part_change (
 a char(150) charset ascii,

--- a/mysql-test/suite/innodb/t/instant_alter_charset.test
+++ b/mysql-test/suite/innodb/t/instant_alter_charset.test
@@ -139,6 +139,19 @@ alter table all_strings modify e varbinary(150), algorithm=instant;
 --error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
 alter table all_strings modify f binary(150), algorithm=instant;
 
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify a tinytext charset binary, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify b text charset binary, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify c mediumtext charset binary, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify d longtext charset binary, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify e varchar(150) charset binary, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify f char(150) charset binary, algorithm=instant;
+
 drop table all_strings;
 
 create table key_part_change (

--- a/mysql-test/suite/innodb/t/instant_alter_charset.test
+++ b/mysql-test/suite/innodb/t/instant_alter_charset.test
@@ -1,0 +1,510 @@
+--source include/innodb_row_format.inc
+#--source include/innodb_page_size.inc
+
+set names utf8;
+
+SET @old_instant=
+  (SELECT variable_value FROM information_schema.global_status
+   WHERE variable_name = 'innodb_instant_alter_column');
+
+create table no_rebuild (
+  a char(150) charset utf8mb3 collate utf8mb3_general_ci
+) engine=innodb;
+create table rebuild (
+  a varchar(150) charset ascii
+) engine=innodb;
+
+set @id = (select table_id from information_schema.innodb_sys_tables
+  where name = 'test/no_rebuild');
+select name, prtype, len from information_schema.innodb_sys_columns
+  where table_id = @id;
+select c.prtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+  where t.name = 'test/rebuild' and c.name = 'a';
+alter table no_rebuild
+  change a a char(150) charset utf8mb3 collate utf8mb3_spanish_ci,
+  algorithm=inplace;
+alter table rebuild
+  change a a varchar(150) charset latin1 not null default 'asdf',
+  algorithm=inplace;
+select name, prtype, len from information_schema.innodb_sys_columns
+  where table_id = @id;
+select c.prtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+  where t.name = 'test/rebuild' and c.name = 'a';
+
+drop table no_rebuild, rebuild;
+
+create table supported_types (
+  id int primary key auto_increment,
+  a varchar(150) charset ascii,
+  b text(150) charset ascii,
+  c text charset ascii,
+  d tinytext charset ascii,
+  e mediumtext charset ascii,
+  f longtext charset ascii
+) engine=innodb;
+
+alter table supported_types
+  convert to charset latin1,
+  algorithm=instant;
+
+drop table supported_types;
+
+create table various_cases (
+  a char(150) charset ascii,
+  b varchar(150) as (a) virtual,
+  c varchar(150) as (a) persistent
+) engine=innodb;
+
+alter table various_cases
+  change a a char(150) charset latin1,
+  algorithm=inplace;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table various_cases
+  change a a varchar(222),
+  algorithm=inplace;
+
+alter table various_cases
+  change b b varchar(150) as (a) virtual,
+  algorithm=inplace;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+alter table various_cases
+  change c c varchar(150) as (a) persistent,
+  algorithm=inplace;
+
+# Can not grow storage in bytes from CHAR
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table various_cases
+  modify a char(150) charset utf8mb4,
+  algorithm=instant;
+
+drop table various_cases;
+
+
+create table all_texts (
+  a tinytext charset ascii,
+  b text charset ascii,
+  c mediumtext charset ascii,
+  d longtext charset ascii,
+  footer int
+) engine=innodb;
+
+alter table all_texts
+  convert to charset latin1 collate latin1_general_ci,
+  algorithm=instant;
+
+drop table all_texts;
+
+
+create table all_binaries (
+  a tinyblob,
+  b blob,
+  c mediumblob,
+  d longblob,
+  e varbinary(150),
+  f binary(150)
+) engine=innodb;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_binaries modify a tinytext, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_binaries modify b text, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_binaries modify c mediumtext, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_binaries modify d longtext, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_binaries modify e varchar(150), algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_binaries modify f char(150), algorithm=instant;
+
+drop table all_binaries;
+
+create table all_strings (
+  a tinytext,
+  b text,
+  c mediumtext,
+  d longtext,
+  e varchar(150),
+  f char(150)
+) engine=innodb;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify a tinyblob, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify b blob, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify c mediumblob, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify d longblob, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify e varbinary(150), algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table all_strings modify f binary(150), algorithm=instant;
+
+drop table all_strings;
+
+create table key_part_change (
+  a char(150) charset ascii,
+  b char(150) charset ascii,
+  c char(150) charset ascii,
+  unique key ab (a,b)
+) engine=innodb;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table key_part_change
+  modify a char(150) charset utf8mb4,
+  drop index ab,
+  add unique key ab(a,c),
+  algorithm=instant;
+
+drop table key_part_change;
+
+create table key_part_change_and_rename (
+  a char(100) charset ascii,
+  b char(100) charset ascii,
+  unique key ab (a,b)
+) engine=innodb;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table key_part_change_and_rename
+  change a b char(100) charset utf8mb4,
+  change b a char(100) charset utf8mb4,
+  drop index ab,
+  add unique key ab(a,b),
+  algorithm=instant;
+
+drop table key_part_change_and_rename;
+
+create table enum_and_set (
+  a enum('one', 'two') charset utf8mb3,
+  b set('three', 'four') charset utf8mb3
+) engine=innodb;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table enum_and_set
+  modify a enum('one', 'two') charset utf8mb4,
+  algorithm=instant;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table enum_and_set
+  modify b enum('three', 'four') charset utf8mb4,
+  algorithm=instant;
+
+drop table enum_and_set;
+
+create table compressed (
+  a varchar(255) charset utf8mb3 compressed
+) engine=innodb;
+
+insert into compressed values ('AAA'), ('bbb'), ('CCC');
+
+alter table compressed
+  modify a varchar(255) charset utf8mb4 compressed,
+  algorithm=instant;
+
+select * from compressed;
+check table compresed;
+
+drop table compressed;
+
+create table key_part_bug (
+  id int primary key auto_increment,
+  a varchar(150) charset utf8mb3 unique key
+) engine=innodb;
+
+alter table key_part_bug
+  modify a varchar(150) charset utf8mb4,
+  algorithm=instant;
+
+drop table key_part_bug;
+
+
+create table latin1_swedish_special_case (
+  copy1 varchar(150) charset ascii collate ascii_general_ci,
+  copy2 char(150) charset ascii collate ascii_general_ci,
+  instant1 varchar(150) charset ascii collate ascii_general_ci,
+  instant2 char(150) charset ascii collate ascii_general_ci
+) engine=innodb;
+
+select c.name, c.prtype, c.mtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+  where t.name = 'test/latin1_swedish_special_case';
+alter table latin1_swedish_special_case
+  modify copy1 varchar(150) charset latin1 collate latin1_swedish_ci,
+  modify copy2 char(150) charset latin1 collate latin1_swedish_ci,
+  algorithm=copy;
+alter table latin1_swedish_special_case
+  modify instant1 varchar(150) charset latin1 collate latin1_swedish_ci,
+  modify instant2 char(150) charset latin1 collate latin1_swedish_ci,
+  algorithm=instant;
+select c.name, c.prtype, c.mtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+  where t.name = 'test/latin1_swedish_special_case';
+alter table latin1_swedish_special_case
+  modify copy1 varchar(150) charset latin1 collate latin1_general_ci,
+  modify copy2 char(150) charset latin1 collate latin1_general_ci,
+  algorithm=copy;
+alter table latin1_swedish_special_case
+  modify instant1 varchar(150) charset latin1 collate latin1_general_ci,
+  modify instant2 char(150) charset latin1 collate latin1_general_ci,
+  algorithm=instant;
+select c.name, c.prtype, c.mtype, c.len from information_schema.innodb_sys_columns as c inner join information_schema.innodb_sys_tables t on c.table_id = t.table_id
+  where t.name = 'test/latin1_swedish_special_case';
+
+drop table latin1_swedish_special_case;
+
+create table regression (a varchar(100) charset utf8mb3 primary key, b int) engine=innodb;
+alter table regression convert to character set utf8mb4;
+drop table regression;
+
+# ROW_FORMAT=DYNAMIC limitation:
+# size in bytes cannot be increased from less of equal that 255 to more than 255
+create table boundary_255 (
+  a varchar(50) charset ascii,
+  b varchar(200) charset ascii,
+  c varchar(300) charset ascii
+) engine=innodb;
+
+alter table boundary_255
+  modify a varchar(50) charset utf8mb3,
+  algorithm=instant;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table boundary_255
+  modify b varchar(200) charset utf8mb3,
+  algorithm=instant;
+
+alter table boundary_255
+  modify c varchar(300) charset utf8mb3,
+  algorithm=instant;
+
+drop table boundary_255;
+
+create table fully_compatible (
+  id int auto_increment unique key,
+  from_charset char(255),
+  from_collate char(255),
+  to_charset char(255),
+  to_collate char(255)
+);
+
+insert into fully_compatible (from_charset, from_collate, to_charset, to_collate) values
+  ('utf8mb3', 'utf8mb3_general_ci',           'utf8mb4', 'utf8mb4_general_ci'),
+  ('utf8mb3', 'utf8mb3_bin',                  'utf8mb4', 'utf8mb4_bin'),
+  ('utf8mb3', 'utf8mb3_unicode_ci',           'utf8mb4', 'utf8mb4_unicode_ci'),
+  ('utf8mb3', 'utf8mb3_icelandic_ci',         'utf8mb4', 'utf8mb4_icelandic_ci'),
+  ('utf8mb3', 'utf8mb3_latvian_ci',           'utf8mb4', 'utf8mb4_latvian_ci'),
+  ('utf8mb3', 'utf8mb3_romanian_ci',          'utf8mb4', 'utf8mb4_romanian_ci'),
+  ('utf8mb3', 'utf8mb3_slovenian_ci',         'utf8mb4', 'utf8mb4_slovenian_ci'),
+  ('utf8mb3', 'utf8mb3_polish_ci',            'utf8mb4', 'utf8mb4_polish_ci'),
+  ('utf8mb3', 'utf8mb3_estonian_ci',          'utf8mb4', 'utf8mb4_estonian_ci'),
+  ('utf8mb3', 'utf8mb3_spanish_ci',           'utf8mb4', 'utf8mb4_spanish_ci'),
+  ('utf8mb3', 'utf8mb3_swedish_ci',           'utf8mb4', 'utf8mb4_swedish_ci'),
+  ('utf8mb3', 'utf8mb3_turkish_ci',           'utf8mb4', 'utf8mb4_turkish_ci'),
+  ('utf8mb3', 'utf8mb3_czech_ci',             'utf8mb4', 'utf8mb4_czech_ci'),
+  ('utf8mb3', 'utf8mb3_danish_ci',            'utf8mb4', 'utf8mb4_danish_ci'),
+  ('utf8mb3', 'utf8mb3_lithuanian_ci',        'utf8mb4', 'utf8mb4_lithuanian_ci'),
+  ('utf8mb3', 'utf8mb3_slovak_ci',            'utf8mb4', 'utf8mb4_slovak_ci'),
+  ('utf8mb3', 'utf8mb3_spanish2_ci',          'utf8mb4', 'utf8mb4_spanish2_ci'),
+  ('utf8mb3', 'utf8mb3_roman_ci',             'utf8mb4', 'utf8mb4_roman_ci'),
+  ('utf8mb3', 'utf8mb3_persian_ci',           'utf8mb4', 'utf8mb4_persian_ci'),
+  ('utf8mb3', 'utf8mb3_esperanto_ci',         'utf8mb4', 'utf8mb4_esperanto_ci'),
+  ('utf8mb3', 'utf8mb3_hungarian_ci',         'utf8mb4', 'utf8mb4_hungarian_ci'),
+  ('utf8mb3', 'utf8mb3_sinhala_ci',           'utf8mb4', 'utf8mb4_sinhala_ci'),
+  ('utf8mb3', 'utf8mb3_german2_ci',           'utf8mb4', 'utf8mb4_german2_ci'),
+  ('utf8mb3', 'utf8mb3_croatian_mysql561_ci', 'utf8mb4', 'utf8mb4_croatian_mysql561_ci'),
+  ('utf8mb3', 'utf8mb3_unicode_520_ci',       'utf8mb4', 'utf8mb4_unicode_520_ci'),
+  ('utf8mb3', 'utf8mb3_vietnamese_ci',        'utf8mb4', 'utf8mb4_vietnamese_ci'),
+  ('utf8mb3', 'utf8mb3_croatian_ci',          'utf8mb4', 'utf8mb4_croatian_ci'),
+  ('utf8mb3', 'utf8mb3_myanmar_ci',           'utf8mb4', 'utf8mb4_myanmar_ci'),
+  ('utf8mb3', 'utf8mb3_thai_520_w2',          'utf8mb4', 'utf8mb4_thai_520_w2'),
+  ('utf8mb3', 'utf8mb3_general_nopad_ci',     'utf8mb4', 'utf8mb4_general_nopad_ci'),
+  ('utf8mb3', 'utf8mb3_nopad_bin',            'utf8mb4', 'utf8mb4_nopad_bin'),
+  ('utf8mb3', 'utf8mb3_unicode_nopad_ci',     'utf8mb4', 'utf8mb4_unicode_nopad_ci'),
+  ('utf8mb3', 'utf8mb3_unicode_520_nopad_ci', 'utf8mb4', 'utf8mb4_unicode_520_nopad_ci'),
+
+  ('ascii', 'ascii_general_ci',       'utf8mb3', 'utf8mb3_general_ci'),
+  ('ascii', 'ascii_general_ci',       'utf8mb4', 'utf8mb4_general_ci'),
+  ('ascii', 'ascii_general_ci',       'latin1', 'latin1_general_ci'),
+  ('ascii', 'ascii_bin',              'latin1', 'latin1_bin'),
+  ('ascii', 'ascii_nopad_bin',        'latin1', 'latin1_nopad_bin'),
+  ('ascii', 'ascii_general_ci',       'latin2', 'latin2_general_ci'),
+  ('ascii', 'ascii_general_ci',       'latin7', 'latin7_general_ci'),
+  ('ascii', 'ascii_bin',              'koi8u',  'koi8u_bin'),
+  ('ascii', 'ascii_bin',              'ujis',   'ujis_bin'),
+  ('ascii', 'ascii_bin',              'big5',   'big5_bin'),
+  ('ascii', 'ascii_bin',              'gbk',    'gbk_bin')
+;
+
+let $data_size = `select count(*) from fully_compatible`;
+let $counter = 1;
+
+while ($counter <= $data_size) {
+  let $from_charset = `select from_charset from fully_compatible where id = $counter`;
+  let $from_collate = `select from_collate from fully_compatible where id = $counter`;
+  let $to_charset = `select to_charset from fully_compatible where id = $counter`;
+  let $to_collate = `select to_collate from fully_compatible where id = $counter`;
+
+  eval create table tmp (
+    a varchar(50) charset $from_charset collate $from_collate,
+    b varchar(50) charset $from_charset collate $from_collate primary key
+  ) engine=innodb;
+
+  insert into tmp values ('AAA', 'AAA'), ('bbb', 'bbb');
+
+  eval alter table tmp
+    change a a varchar(50) charset $to_charset collate $to_collate,
+    modify b varchar(50) charset $to_charset collate $to_collate,
+    algorithm=instant;
+
+  check table tmp;
+
+  drop table tmp;
+
+  inc $counter;
+}
+
+drop table fully_compatible;
+
+
+create table compatible_without_index (
+  id int auto_increment unique key,
+  from_charset char(255),
+  from_collate char(255),
+  to_charset char(255),
+  to_collate char(255)
+);
+
+insert into compatible_without_index (from_charset, from_collate, to_charset, to_collate) values
+  ('ascii', 'ascii_general_ci',       'utf8mb3', 'utf8mb3_swedish_ci'),
+  ('ascii', 'ascii_bin',              'latin1', 'latin1_swedish_ci'),
+  ('ascii', 'ascii_general_nopad_ci', 'latin1', 'latin1_swedish_ci'),
+  ('ascii', 'ascii_nopad_bin',        'latin1', 'latin1_swedish_ci'),
+
+  ('ascii', 'ascii_general_ci',       'koi8u', 'koi8u_bin'),
+  ('ascii', 'ascii_general_nopad_ci', 'koi8u', 'koi8u_bin'),
+  ('ascii', 'ascii_nopad_bin',        'koi8u', 'koi8u_bin'),
+
+  ('ascii', 'ascii_general_ci',       'latin1', 'latin1_swedish_ci'),
+  ('ascii', 'ascii_bin',              'utf8mb3', 'utf8mb3_swedish_ci'),
+  ('ascii', 'ascii_general_nopad_ci', 'utf8mb3', 'utf8mb3_swedish_ci'),
+  ('ascii', 'ascii_nopad_bin',        'utf8mb3', 'utf8mb3_swedish_ci'),
+
+  ('ascii', 'ascii_general_ci',       'utf8mb4', 'utf8mb4_danish_ci'),
+  ('ascii', 'ascii_bin',              'utf8mb4', 'utf8mb4_danish_ci'),
+  ('ascii', 'ascii_general_nopad_ci', 'utf8mb4', 'utf8mb4_danish_ci'),
+  ('ascii', 'ascii_nopad_bin',        'utf8mb4', 'utf8mb4_danish_ci'),
+
+  ('utf8mb3', 'utf8mb3_general_ci',       'utf8mb4', 'utf8mb4_vietnamese_ci'),
+  ('utf8mb3', 'utf8mb3_bin',              'utf8mb4', 'utf8mb4_vietnamese_ci'),
+  ('utf8mb3', 'utf8mb3_general_nopad_ci', 'utf8mb4', 'utf8mb4_vietnamese_ci'),
+  ('utf8mb3', 'utf8mb3_nopad_bin',        'utf8mb4', 'utf8mb4_vietnamese_ci'),
+
+  ('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_ci'),
+  ('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_nopad_ci'),
+
+  ('ascii',   'ascii_general_ci',      'ascii',   'ascii_bin'),
+  ('utf8mb3', 'utf8mb3_roman_ci',      'utf8mb3', 'utf8mb3_lithuanian_ci'),
+  ('utf8mb4', 'utf8mb4_thai_520_w2',   'utf8mb4', 'utf8mb4_persian_ci'),
+  ('utf8mb3', 'utf8mb3_myanmar_ci',    'utf8mb4', 'utf8mb4_german2_ci'),
+  ('utf8mb3', 'utf8mb3_general_ci',    'utf8mb3', 'utf8mb3_unicode_ci'),
+  ('latin1',  'latin1_general_cs',     'latin1',  'latin1_general_ci'),
+  ('ascii',   'ascii_general_ci',      'ujis',    'ujis_japanese_ci'),
+  ('ascii',   'ascii_general_ci',      'big5',    'big5_chinese_ci'),
+  ('ascii',   'ascii_general_ci',      'latin2',  'latin2_croatian_ci'),
+  ('ascii',   'ascii_general_ci',      'latin7',  'latin7_estonian_cs'),
+  ('utf16',   'utf16_general_ci',      'utf16',   'utf16_german2_ci')
+;
+
+let $data_size = `select count(*) from compatible_without_index`;
+let $counter = 1;
+
+while ($counter <= $data_size) {
+  let $from_charset = `select from_charset from compatible_without_index where id = $counter`;
+  let $from_collate = `select from_collate from compatible_without_index where id = $counter`;
+  let $to_charset = `select to_charset from compatible_without_index where id = $counter`;
+  let $to_collate = `select to_collate from compatible_without_index where id = $counter`;
+
+  eval create table tmp (
+    a varchar(50) charset $from_charset collate $from_collate,
+    b varchar(50) charset $from_charset collate $from_collate unique key,
+    c varchar(50) charset $from_charset collate $from_collate primary key
+  ) engine=innodb;
+
+  eval alter table tmp
+    change a a varchar(50) charset $to_charset collate $to_collate,
+    algorithm=instant;
+
+  --error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+  eval alter table tmp
+    modify b varchar(50) charset $to_charset collate $to_collate,
+    algorithm=instant;
+
+  --error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+  eval alter table tmp
+    modify c varchar(50) charset $to_charset collate $to_collate,
+    algorithm=instant;
+
+  drop table tmp;
+
+  inc $counter;
+}
+
+drop table compatible_without_index;
+
+
+create table fully_incompatible (
+  id int auto_increment unique key,
+  from_charset char(255),
+  from_collate char(255),
+  to_charset char(255),
+  to_collate char(255)
+);
+
+insert into fully_incompatible (from_charset, from_collate, to_charset, to_collate) values
+  ('utf8mb4', 'utf8mb4_general_ci', 'utf8mb3', 'utf8mb3_general_ci'),
+  ('utf8mb4', 'utf8mb4_general_ci', 'ascii', 'ascii_general_ci'),
+  ('utf8mb3', 'utf8mb3_general_ci', 'ascii', 'ascii_general_ci'),
+  ('utf8mb3', 'utf8mb3_general_ci', 'latin1', 'latin1_general_ci'),
+  ('utf16', 'utf16_general_ci', 'utf32', 'utf32_general_ci'),
+  ('latin1', 'latin1_general_ci',   'ascii', 'ascii_general_ci'),
+  ('ascii', 'ascii_general_ci',     'swe7', 'swe7_swedish_ci'),
+  ('eucjpms', 'eucjpms_japanese_nopad_ci', 'geostd8', 'geostd8_general_ci'),
+  ('latin1', 'latin1_general_ci',   'utf16', 'utf16_general_ci')
+;
+
+let $data_size = `select count(*) from fully_incompatible`;
+let $counter = 1;
+
+while ($counter <= $data_size) {
+  let $from_charset = `select from_charset from fully_incompatible where id = $counter`;
+  let $from_collate = `select from_collate from fully_incompatible where id = $counter`;
+  let $to_charset = `select to_charset from fully_incompatible where id = $counter`;
+  let $to_collate = `select to_collate from fully_incompatible where id = $counter`;
+
+  eval create table tmp (
+    a varchar(150) charset $from_charset collate $from_collate,
+    b text(150) charset $from_charset collate $from_collate,
+    unique key b_idx (b(150))
+  ) engine=innodb;
+
+  --error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+  eval alter table tmp
+    change a a varchar(150) charset $to_charset collate $to_collate,
+    algorithm=instant;
+
+  --error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+  eval alter table tmp
+    modify b text charset $to_charset collate $to_collate,
+    algorithm=instant;
+
+  drop table tmp;
+
+  inc $counter;
+}
+
+drop table fully_incompatible;
+
+SELECT variable_value-@old_instant instants
+  FROM information_schema.global_status
+  WHERE variable_name = 'innodb_instant_alter_column';

--- a/mysql-test/suite/innodb/t/instant_alter_charset.test
+++ b/mysql-test/suite/innodb/t/instant_alter_charset.test
@@ -3,10 +3,6 @@
 
 set names utf8;
 
-SET @old_instant=
-  (SELECT variable_value FROM information_schema.global_status
-   WHERE variable_name = 'innodb_instant_alter_column');
-
 create table no_rebuild (
   a char(150) charset utf8mb3 collate utf8mb3_general_ci
 ) engine=innodb;
@@ -323,6 +319,17 @@ insert into fully_compatible (from_charset, from_collate, to_charset, to_collate
   ('utf8mb3', 'utf8mb3_unicode_nopad_ci',     'utf8mb4', 'utf8mb4_unicode_nopad_ci'),
   ('utf8mb3', 'utf8mb3_unicode_520_nopad_ci', 'utf8mb4', 'utf8mb4_unicode_520_nopad_ci'),
 
+  ('ucs2',    'ucs2_general_ci',       'utf16',   'utf16_general_ci'),
+  ('ucs2',    'ucs2_unicode_ci',       'utf16',   'utf16_unicode_ci'),
+  ('ucs2',    'ucs2_icelandic_ci',     'utf16',   'utf16_icelandic_ci'),
+  ('ucs2',    'ucs2_latvian_ci',       'utf16',   'utf16_latvian_ci'),
+  ('ucs2',    'ucs2_romanian_ci',      'utf16',   'utf16_romanian_ci'),
+  ('ucs2',    'ucs2_slovenian_ci',     'utf16',   'utf16_slovenian_ci'),
+  ('ucs2',    'ucs2_polish_ci',        'utf16',   'utf16_polish_ci'),
+  ('ucs2',    'ucs2_estonian_ci',      'utf16',   'utf16_estonian_ci'),
+  ('ucs2',    'ucs2_spanish_ci',       'utf16',   'utf16_spanish_ci'),
+  ('ucs2',    'ucs2_general_ci',       'utf16',   'utf16_general_ci'),
+
   ('ascii', 'ascii_general_ci',       'utf8mb3', 'utf8mb3_general_ci'),
   ('ascii', 'ascii_general_ci',       'utf8mb4', 'utf8mb4_general_ci'),
   ('ascii', 'ascii_general_ci',       'latin1', 'latin1_general_ci'),
@@ -402,6 +409,10 @@ insert into compatible_without_index (from_charset, from_collate, to_charset, to
 
   ('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_ci'),
   ('ascii',  'ascii_general_ci',     'gbk',  'gbk_chinese_nopad_ci'),
+
+  ('ucs2',  'ucs2_myanmar_ci',          'utf16', 'utf16_thai_520_w2'),
+  ('ucs2',  'ucs2_general_ci',          'utf16', 'utf16_unicode_nopad_ci'),
+  ('ucs2',  'ucs2_general_mysql500_ci', 'utf16', 'utf16_spanish2_ci'),
 
   ('ascii',   'ascii_general_ci',      'ascii',   'ascii_bin'),
   ('utf8mb3', 'utf8mb3_roman_ci',      'utf8mb3', 'utf8mb3_lithuanian_ci'),
@@ -504,7 +515,3 @@ while ($counter <= $data_size) {
 }
 
 drop table fully_incompatible;
-
-SELECT variable_value-@old_instant instants
-  FROM information_schema.global_status
-  WHERE variable_name = 'innodb_instant_alter_column';

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -622,6 +622,8 @@ typedef ulonglong alter_table_operations;
 #define ALTER_KEYS_ONOFF            (1ULL <<  9)
 // Set for FORCE, ENGINE(same engine), by mysql_recreate_table()
 #define ALTER_RECREATE              (1ULL << 10)
+// Set for CONVERT TO
+#define ALTER_CONVERT_TO            (1ULL << 11)
 // Set for ADD FOREIGN KEY
 #define ALTER_ADD_FOREIGN_KEY       (1ULL << 21)
 // Set for DROP FOREIGN KEY

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -8219,6 +8219,9 @@ static bool charsets_are_compatible(const char *old_cs_name,
     }
   }
 
+  if (!strcmp(old_cs_name, "ucs2") && !strcmp(new_cs_name, "utf16"))
+    return true;
+
   return false;
 }
 

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -8206,18 +8206,8 @@ static bool charsets_are_compatible(const char *old_cs_name,
   if (!strcmp(old_cs_name, MY_UTF8MB3) && !strcmp(new_cs_name, MY_UTF8MB4))
     return true;
 
-  if (!strcmp(old_cs_name, "ascii"))
-  {
-    if (!strcmp(new_cs_name, MY_UTF8MB3) || !strcmp(new_cs_name, MY_UTF8MB4) ||
-        !strcmp(new_cs_name, "latin1") || !strcmp(new_cs_name, "latin2") ||
-        !strcmp(new_cs_name, "latin7") || !strcmp(new_cs_name, "koi8") ||
-        !strcmp(new_cs_name, "koi8u") || !strcmp(new_cs_name, "gbk") ||
-        !strcmp(new_cs_name, "ujis") || !strcmp(new_cs_name, "big5"))
-    {
-      DBUG_ASSERT(!(new_ci->state & MY_CS_NONASCII));
-      return true;
-    }
-  }
+  if (!strcmp(old_cs_name, "ascii") && !(new_ci->state & MY_CS_NONASCII))
+    return true;
 
   if (!strcmp(old_cs_name, "ucs2") && !strcmp(new_cs_name, "utf16"))
     return true;

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -3665,6 +3665,10 @@ public:
 
   virtual bool
   Vers_history_point_resolve_unit(THD *thd, Vers_history_point *point) const;
+
+  static bool Charsets_are_compatible(const CHARSET_INFO *old_ci,
+                                      const CHARSET_INFO *new_ci,
+                                      bool part_of_a_key);
 };
 
 

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -8432,7 +8432,7 @@ alter_list_item:
                                 $5->name, $4->csname));
             if (unlikely(Lex->create_info.add_alter_list_item_convert_to_charset($5)))
               MYSQL_YYABORT;
-            Lex->alter_info.flags|= ALTER_OPTIONS;
+            Lex->alter_info.flags|= ALTER_CONVERT_TO;
           }
         | create_table_options_space_separated
           {

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -9993,9 +9993,7 @@ to the data dictionary cache and the file system.
 @param ctx In-place ALTER TABLE context */
 inline MY_ATTRIBUTE((nonnull))
 void
-commit_cache_rebuild(
-	Alter_inplace_info*		ha_alter_info,
-	ha_innobase_inplace_ctx*	ctx)
+commit_cache_rebuild(ha_innobase_inplace_ctx* ctx)
 {
 	dberr_t		error;
 
@@ -11120,7 +11118,7 @@ ha_innobase::commit_inplace_alter_table(
 				   ("table: %s", ctx->old_table->name.m_name));
 
 			/* Rename the tablespace files. */
-			commit_cache_rebuild(ha_alter_info, ctx);
+			commit_cache_rebuild(ctx);
 
 			error = innobase_update_foreign_cache(ctx, m_user_thd);
 			if (error != DB_SUCCESS) {


### PR DESCRIPTION
Patch makes it's possible to in some cases 'increase' CHARSET length without
touching any data. Thus, only metadata is changed. And this has no penalty for
future DDL or DML queries. Additionally it optimizes UNIQUE and PRIMARY keys
dropping and creation if charset was changed for one of its key parts but only
if collate change does not require change of order in a key. If collations
are not 'compatible' operation can not be performed instantly.

Created_field::altered: member to easily check that this field was added by user

btr_index_rec_validate(): relax check to allow REDUNDANT field be shorter than
specified in index definition

fix_key_parts(): only fix key parts without checking anything. This is needed early
by INSTANT ALTER CHARSET check

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.4-MDEV-15564)