### PR TITLE
10.4 extend gitignore and fix bug in build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -513,3 +513,6 @@ compile_commands.json
 .editorconfig
 .kateconfig
 *.kdev4
+
+# Clion && other JetBrains ides
+.idea

--- a/storage/mroonga/vendor/groonga/vendor/plugins/CMakeLists.txt
+++ b/storage/mroonga/vendor/groonga/vendor/plugins/CMakeLists.txt
@@ -15,11 +15,12 @@
 
 file(GLOB
   PLUGIN_CMAKE_LISTS_LIST
+  RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
   "${CMAKE_CURRENT_SOURCE_DIR}/*/CMakeLists.txt")
 if(PLUGIN_CMAKE_LISTS_LIST)
   foreach(PLUGIN_CMAKE_LISTS "${PLUGIN_CMAKE_LISTS_LIST}")
     string(REGEX REPLACE
-      "(^${CMAKE_CURRENT_SOURCE_DIR}/+|/+CMakeLists\\.txt$)" ""
+      "(/+CMakeLists\\.txt$)" ""
       PLUGIN_DIR
       "${PLUGIN_CMAKE_LISTS}")
     add_subdirectory("${PLUGIN_DIR}")


### PR DESCRIPTION
I added Clion files in .idea folder to .gitignore and fix bug which arose when building a project in a folder with special characters