### PR TITLE
MDEV-16370 row-based binlog events (updates by primary key) can not be applied multiple times to system versioned tables

### DIFF
--- a/mysql-test/suite/versioning/r/rpl.result
+++ b/mysql-test/suite/versioning/r/rpl.result
@@ -164,4 +164,23 @@ update t1 set i = 0;
 connection slave;
 connection master;
 drop table t1;
+# MDEV-16370 row-based binlog events (updates by primary key)
+# can not be applied multiple times to system versioned tables
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+connection slave;
+flush logs;
+connection master;
+update t1 set x= 2;
+connection slave;
+select * from t1;
+pk	x
+1	2
+# Replaying binlog...
+select * from t1;
+pk	x
+1	2
+connection master;
+drop database test;
+create database test;
 include/rpl_end.inc

--- a/mysql-test/suite/versioning/r/rpl.result
+++ b/mysql-test/suite/versioning/r/rpl.result
@@ -182,7 +182,7 @@ select * from t1;
 pk	x
 1	2
 connection master;
-# Case 2: not versioned -> versioned replication
+# Case 2: not versioned -> versioned replication, UPDATE
 create or replace table t1 (pk int primary key, x int);
 insert into t1 values (1, 1);
 connection slave;
@@ -206,6 +206,22 @@ set timestamp= default;
 select * from t1;
 pk	x
 1	3
+connection master;
+# Case 3: not versioned -> versioned replication, DELETE
+create or replace table t1 (pk int primary key, x int);
+insert into t1 values (1, 1);
+connection slave;
+set timestamp= unix_timestamp() + 10;
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+flush logs;
+set timestamp= default;
+connection master;
+delete from t1;
+connection slave;
+select row_start <= row_end from t1 for system_time all;
+row_start <= row_end
+1
 connection master;
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/r/rpl.result
+++ b/mysql-test/suite/versioning/r/rpl.result
@@ -166,6 +166,7 @@ connection master;
 drop table t1;
 # MDEV-16370 row-based binlog events (updates by primary key)
 # can not be applied multiple times to system versioned tables
+# Case 1: versioned -> versioned replication
 create or replace table t1 (pk int primary key, x int) with system versioning;
 insert into t1 values (1, 1);
 connection slave;
@@ -180,6 +181,31 @@ pk	x
 select * from t1;
 pk	x
 1	2
+connection master;
+# Case 2: not versioned -> versioned replication
+create or replace table t1 (pk int primary key, x int);
+insert into t1 values (1, 1);
+connection slave;
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+flush logs;
+connection master;
+update t1 set x= 2 where pk = 1;
+update t1 set x= 3 where pk = 1;
+connection slave;
+select * from t1 for system_time all order by row_end;
+pk	x
+1	1
+1	2
+1	3
+set timestamp= unix_timestamp() + 10;
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+set timestamp= default;
+# Replaying binlog...
+select * from t1;
+pk	x
+1	3
 connection master;
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/rpl.test
+++ b/mysql-test/suite/versioning/t/rpl.test
@@ -133,4 +133,24 @@ sync_slave_with_master;
 connection master;
 drop table t1;
 
+--echo # MDEV-16370 row-based binlog events (updates by primary key)
+--echo # can not be applied multiple times to system versioned tables
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+--sync_slave_with_master
+flush logs;
+--connection master
+update t1 set x= 2;
+--sync_slave_with_master
+select * from t1;
+--let $datadir= `select @@datadir`
+--let $f2= query_get_value(SHOW SLAVE STATUS, Relay_Log_File, 1)
+--echo # Replaying binlog...
+--exec $MYSQL_BINLOG $datadir/$f2| $MYSQL -S $SLAVE_MYSOCK test
+select * from t1;
+--connection master
+
+drop database test;
+create database test;
+
 --source include/rpl_end.inc

--- a/mysql-test/suite/versioning/t/rpl.test
+++ b/mysql-test/suite/versioning/t/rpl.test
@@ -151,7 +151,7 @@ select * from t1;
 select * from t1;
 --connection master
 
---echo # Case 2: not versioned -> versioned replication
+--echo # Case 2: not versioned -> versioned replication, UPDATE
 create or replace table t1 (pk int primary key, x int);
 insert into t1 values (1, 1);
 --sync_slave_with_master
@@ -174,6 +174,21 @@ set timestamp= default;
 --exec $MYSQL_BINLOG $datadir/$f| $MYSQL -P $SLAVE_MYPORT -S $SLAVE_MYSOCK test
 --exec $MYSQL_BINLOG $datadir/$f| $MYSQL -P $SLAVE_MYPORT -S $SLAVE_MYSOCK test
 select * from t1;
+--connection master
+
+--echo # Case 3: not versioned -> versioned replication, DELETE
+create or replace table t1 (pk int primary key, x int);
+insert into t1 values (1, 1);
+--sync_slave_with_master
+set timestamp= unix_timestamp() + 10;
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+flush logs;
+set timestamp= default;
+--connection master
+delete from t1;
+--sync_slave_with_master
+select row_start <= row_end from t1 for system_time all;
 --connection master
 
 drop database test;

--- a/mysql-test/suite/versioning/t/rpl.test
+++ b/mysql-test/suite/versioning/t/rpl.test
@@ -135,6 +135,7 @@ drop table t1;
 
 --echo # MDEV-16370 row-based binlog events (updates by primary key)
 --echo # can not be applied multiple times to system versioned tables
+--echo # Case 1: versioned -> versioned replication
 create or replace table t1 (pk int primary key, x int) with system versioning;
 insert into t1 values (1, 1);
 --sync_slave_with_master
@@ -146,7 +147,32 @@ select * from t1;
 --let $datadir= `select @@datadir`
 --let $f2= query_get_value(SHOW SLAVE STATUS, Relay_Log_File, 1)
 --echo # Replaying binlog...
---exec $MYSQL_BINLOG $datadir/$f2| $MYSQL -S $SLAVE_MYSOCK test
+--exec $MYSQL_BINLOG $datadir/$f2| $MYSQL -P $SLAVE_MYPORT -S $SLAVE_MYSOCK test
+select * from t1;
+--connection master
+
+--echo # Case 2: not versioned -> versioned replication
+create or replace table t1 (pk int primary key, x int);
+insert into t1 values (1, 1);
+--sync_slave_with_master
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+flush logs;
+--connection master
+update t1 set x= 2 where pk = 1;
+update t1 set x= 3 where pk = 1;
+--sync_slave_with_master
+select * from t1 for system_time all order by row_end;
+
+set timestamp= unix_timestamp() + 10;
+create or replace table t1 (pk int primary key, x int) with system versioning;
+insert into t1 values (1, 1);
+--let $datadir= `select @@datadir`
+--let $f= query_get_value(SHOW SLAVE STATUS, Relay_Log_File, 1)
+set timestamp= default;
+--echo # Replaying binlog...
+--exec $MYSQL_BINLOG $datadir/$f| $MYSQL -P $SLAVE_MYPORT -S $SLAVE_MYSOCK test
+--exec $MYSQL_BINLOG $datadir/$f| $MYSQL -P $SLAVE_MYPORT -S $SLAVE_MYSOCK test
 select * from t1;
 --connection master
 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -13069,7 +13069,7 @@ is_duplicate_key_error(int errcode)
 
 int
 Rows_log_event::write_row(rpl_group_info *rgi,
-                          const bool overwrite)
+                          bool overwrite)
 {
   DBUG_ENTER("write_row");
   DBUG_ASSERT(m_table != NULL && thd != NULL);
@@ -13130,13 +13130,26 @@ Rows_log_event::write_row(rpl_group_info *rgi,
   }
 
   // Handle INSERT.
-  if (table->versioned(VERS_TIMESTAMP))
+  if (table->versioned())
   {
-    ulong sec_part;
-    bitmap_set_bit(table->read_set, table->vers_start_field()->field_index);
-    // Check whether a row came from unversioned table and fix vers fields.
-    if (table->vers_start_field()->get_timestamp(&sec_part) == 0 && sec_part == 0)
-      table->vers_update_fields();
+    if (table->versioned(VERS_TIMESTAMP))
+    {
+      // Set vers fields when replicating from not system-versioned table.
+      ulong sec_part;
+      bitmap_set_bit(table->read_set, table->vers_start_field()->field_index);
+      // Check whether a row came from unversioned table and fix vers fields.
+      if (table->vers_start_field()->get_timestamp(&sec_part) == 0 && sec_part == 0)
+        table->vers_update_fields();
+      else
+        goto overwrite_historical_row;
+    }
+    else
+    {
+overwrite_historical_row:
+      bitmap_set_bit(table->read_set, table->vers_end_field()->field_index);
+      if (!overwrite && !table->vers_end_field()->is_max())
+        overwrite= true;
+    }
   }
 
   /* 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -14354,6 +14354,8 @@ Update_rows_log_event::do_exec_row(rpl_group_info *rgi)
   {
     store_record(m_table, record[2]);
     error= vers_insert_history_row(m_table);
+    if (unlikely(error == HA_ERR_FOUND_DUPP_KEY))
+      error= 0;
     restore_record(m_table, record[2]);
   }
   m_table->default_column_bitmaps();

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -14353,7 +14353,7 @@ Update_rows_log_event::do_exec_row(rpl_group_info *rgi)
   if (m_vers_from_plain && m_table->versioned(VERS_TIMESTAMP))
   {
     store_record(m_table, record[2]);
-    error= vers_insert_history_row(m_table);
+    error= m_table->vers_insert_history_row();
     if (unlikely(error == HA_ERR_FOUND_DUPP_KEY))
       error= 0;
     restore_record(m_table, record[2]);

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -14072,10 +14072,8 @@ int Delete_rows_log_event::do_exec_row(rpl_group_info *rgi)
       m_table->mark_columns_per_binlog_row_image();
       if (m_vers_from_plain && m_table->versioned(VERS_TIMESTAMP))
       {
-        Field *end= m_table->vers_end_field();
-        bitmap_set_bit(m_table->write_set, end->field_index);
         store_record(m_table, record[1]);
-        end->set_time();
+        m_table->vers_update_end();
         error= m_table->file->ha_update_row(m_table->record[1],
                                             m_table->record[0]);
       }

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7921,3 +7921,5 @@ ER_KEY_DOESNT_SUPPORT
         eng "%s index %`s does not support this operation"
 ER_ALTER_OPERATION_TABLE_OPTIONS_NEED_REBUILD
 	eng "Changing table options requires the table to be rebuilt"
+ER_WARN_HISTORY_ROW_START_TIME
+        eng "History row start time changed for `%s.%s` from '%s' to '%s'"

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1639,7 +1639,7 @@ int TABLE::vers_insert_history_row()
   restore_record(this, record[1]);
 
   // Set Sys_end to now()
-  vers_update_end();
+  vers_update_end(false);
 
   Field *row_start= vers_start_field();
   Field *row_end= vers_end_field();

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1633,36 +1633,36 @@ static int last_uniq_key(TABLE *table,uint keynr)
  sets Sys_end to now() and calls ha_write_row() .
 */
 
-int vers_insert_history_row(TABLE *table)
+int TABLE::vers_insert_history_row()
 {
-  DBUG_ASSERT(table->versioned(VERS_TIMESTAMP));
-  restore_record(table,record[1]);
+  DBUG_ASSERT(versioned(VERS_TIMESTAMP));
+  restore_record(this, record[1]);
 
   // Set Sys_end to now()
-  table->vers_update_end();
+  vers_update_end();
 
-  Field *row_start= table->vers_start_field();
-  Field *row_end= table->vers_end_field();
+  Field *row_start= vers_start_field();
+  Field *row_end= vers_end_field();
   int cmp_res= row_start->cmp(row_start->ptr, row_end->ptr);
   if (cmp_res == 0)
     return 0;
   if (cmp_res > 0) {
     int err;
     String from, to;
-    table->vers_start_field()->val_str(&from);
-    if (table->vers_start_field()->store_timestamp(table->in_use->query_start() - 1, 0))
+    vers_start_field()->val_str(&from);
+    if (vers_start_field()->store_timestamp(in_use->query_start() - 1, 0))
       DBUG_ASSERT(0);
-    table->vers_start_field()->val_str(&to);
-    err= table->file->ha_write_row(table->record[0]);
+    vers_start_field()->val_str(&to);
+    err= file->ha_write_row(record[0]);
     if (!err)
-      push_warning_printf(table->in_use, Sql_condition::WARN_LEVEL_NOTE,
+      push_warning_printf(in_use, Sql_condition::WARN_LEVEL_NOTE,
                           ER_WARN_HISTORY_ROW_START_TIME,
-                          ER_THD(table->in_use, ER_WARN_HISTORY_ROW_START_TIME),
-                          table->s->db.str, table->s->table_name.str, from.c_ptr(), to.c_ptr());
+                          ER_THD(in_use, ER_WARN_HISTORY_ROW_START_TIME),
+                          s->db.str, s->table_name.str, from.c_ptr(), to.c_ptr());
     return err;
   }
 
-  return table->file->ha_write_row(table->record[0]);
+  return file->ha_write_row(record[0]);
 }
 
 /*
@@ -1876,7 +1876,7 @@ int write_record(THD *thd, TABLE *table,COPY_INFO *info)
               if (table->versioned(VERS_TIMESTAMP))
               {
                 store_record(table, record[2]);
-                if ((error= vers_insert_history_row(table)))
+                if ((error= table->vers_insert_history_row()))
                 {
                   info->last_errno= error;
                   table->file->print_error(error, MYF(0));
@@ -1962,7 +1962,7 @@ int write_record(THD *thd, TABLE *table,COPY_INFO *info)
             if (table->versioned(VERS_TIMESTAMP))
             {
               store_record(table, record[2]);
-              error= vers_insert_history_row(table);
+              error= table->vers_insert_history_row();
               restore_record(table, record[2]);
               if (unlikely(error))
                 goto err;

--- a/sql/sql_insert.h
+++ b/sql/sql_insert.h
@@ -37,7 +37,6 @@ void upgrade_lock_type_for_insert(THD *thd, thr_lock_type *lock_type,
                                   bool is_multi_insert);
 int check_that_all_fields_are_given_values(THD *thd, TABLE *entry,
                                            TABLE_LIST *table_list);
-int vers_insert_history_row(TABLE *table);
 int write_record(THD *thd, TABLE *table, COPY_INFO *info);
 void kill_delayed_threads(void);
 

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -957,7 +957,7 @@ update_begin:
             if (table->versioned(VERS_TIMESTAMP))
             {
               store_record(table, record[2]);
-              error= vers_insert_history_row(table);
+              error= table->vers_insert_history_row();
               restore_record(table, record[2]);
             }
             if (likely(!error))
@@ -2405,7 +2405,7 @@ int multi_update::send_data(List<Item> &not_used_values)
             if (table->versioned(VERS_TIMESTAMP))
             {
               store_record(table, record[2]);
-              if (vers_insert_history_row(table))
+              if (table->vers_insert_history_row())
               {
                 restore_record(table, record[2]);
                 error= 1;
@@ -2711,7 +2711,7 @@ int multi_update::do_updates()
             if (table->versioned(VERS_TIMESTAMP))
             {
               store_record(table, record[2]);
-              if ((local_error= vers_insert_history_row(table)))
+              if ((local_error= table->vers_insert_history_row()))
               {
                 restore_record(table, record[2]);
                 err_table = table;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -7910,11 +7910,30 @@ void TABLE::vers_update_fields()
 }
 
 
-void TABLE::vers_update_end()
+void TABLE::vers_update_end(bool fix_row_start)
 {
-  if (vers_end_field()->store_timestamp(in_use->query_start(),
-                                        in_use->query_start_sec_part()))
+  bitmap_set_bit(write_set, vers_end_field()->field_index);
+  if (vers_end_field()->set_time())
     DBUG_ASSERT(0);
+
+  if (fix_row_start)
+  {
+    Field *row_start= vers_start_field();
+    Field *row_end= vers_end_field();
+    int cmp_res= row_start->cmp(row_start->ptr, row_end->ptr);
+    if (cmp_res <= 0)
+      return;
+    String from, to;
+    vers_start_field()->val_str(&from);
+    bitmap_set_bit(write_set, vers_start_field()->field_index);
+    if (vers_start_field()->store_timestamp(in_use->query_start() - 1, 0))
+      DBUG_ASSERT(0);
+    vers_start_field()->val_str(&to);
+    push_warning_printf(in_use, Sql_condition::WARN_LEVEL_NOTE,
+                        ER_WARN_HISTORY_ROW_START_TIME,
+                        ER_THD(in_use, ER_WARN_HISTORY_ROW_START_TIME),
+                        s->db.str, s->table_name.str, from.c_ptr(), to.c_ptr());
+  }
 }
 
 /**

--- a/sql/table.h
+++ b/sql/table.h
@@ -1533,7 +1533,7 @@ public:
 
   int delete_row();
   void vers_update_fields();
-  void vers_update_end();
+  void vers_update_end(bool fix_row_start= true);
   int vers_insert_history_row();
 
 /** Number of additional fields used in versioned tables */

--- a/sql/table.h
+++ b/sql/table.h
@@ -1534,6 +1534,7 @@ public:
   int delete_row();
   void vers_update_fields();
   void vers_update_end();
+  int vers_insert_history_row();
 
 /** Number of additional fields used in versioned tables */
 #define VERSIONING_FIELDS 2


### PR DESCRIPTION
This code is submitted under the BSD-new license.