### PR TITLE
10.4 travis - newer compilers, ignore common clang warnings

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -31,6 +31,9 @@ if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
       export CXX=${CXX}-${CC_VERSION}
     fi
     export CC=${CXX/++/}
+    # excess warnings about unused include path
+    export CFLAGS='-Wno-unused-command-line-argument'
+    export CXXFLAGS='-Wno-unused-command-line-argument'
   elif [[ "${CXX}" == 'g++' ]]; then
     export CXX=g++-${CC_VERSION}
     export CC=gcc-${CC_VERSION}

--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -25,12 +25,17 @@ if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
     ccache --max-size=2200M
   fi
   if [[ "${CXX}" == 'clang++' ]]; then
-    export CXX CC=${CXX/++/}
+    if [[ "${CC_VERSION}" == '6' ]]; then
+      export CXX=${CXX}-${CC_VERSION}.0
+    else
+      export CXX=${CXX}-${CC_VERSION}
+    fi
+    export CC=${CXX/++/}
   elif [[ "${CXX}" == 'g++' ]]; then
     export CXX=g++-${CC_VERSION}
     export CC=gcc-${CC_VERSION}
   fi
-  if [[ ${CC_VERSION} == 6 ]]; then
+  if [[ ${CC_VERSION} == 7 ]]; then
     wget http://mirrors.kernel.org/ubuntu/pool/universe/p/percona-xtradb-cluster-galera-2.x/percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb ;
     ar vx percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb
     tar -xJvf data.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,15 @@ env:
     - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
     - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
     - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles
+    - CC_VERSION=8 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
 
 matrix:
   exclude:
     - os: osx
       compiler: gcc
+    - os: osx
+      compiler: clang
+      env: CC_VERSION=8 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
   include:
     - os: linux
       compiler: gcc
@@ -106,6 +110,9 @@ matrix:
     - os: osx
       compiler: clang
       env: CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles
+    - os: linux
+      compiler: clang
+      env: CC_VERSION=8 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
 
 addons:
   apt:
@@ -113,15 +120,20 @@ addons:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-trusty-6.0
       - llvm-toolchain-trusty-7
+      - llvm-toolchain-trusty
     packages: # make sure these include all compilers and all build dependencies (see list above)
       - gcc-6
       - g++-6
       - gcc-7
       - g++-7
+      - gcc-8
+      - g++-8
       - clang-6.0
       - llvm-6.0-dev
       - clang-7
       - llvm-7-dev
+      - clang-8
+      - llvm-8-dev
       - bison
       - chrpath
       - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ cache:
 
 env:
   matrix:
-    - CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
-    - CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
-    - CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
-    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
-    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
-    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles
+    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
+    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+    - CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
+    - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
+    - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
+    - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles
 
 matrix:
   exclude:
@@ -90,38 +90,38 @@ matrix:
   allow_failures:
     - os: osx
       compiler: clang
-      env: CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
+      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rpl
     - os: osx
       compiler: clang
-      env: CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
+      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
     - os: osx
       compiler: clang
-      env: CC_VERSION=5 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
+      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
     - os: osx
       compiler: clang
-      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
+      env: CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption
     - os: osx
       compiler: clang
-      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
+      env: CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=rocksdb
     - os: osx
       compiler: clang
-      env: CC_VERSION=6 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles
+      env: CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
       - llvm-toolchain-trusty-6.0
+      - llvm-toolchain-trusty-7
     packages: # make sure these include all compilers and all build dependencies (see list above)
-      - gcc-5
-      - g++-5
       - gcc-6
       - g++-6
-      - clang-5.0
-      - llvm-5.0-dev
+      - gcc-7
+      - g++-7
       - clang-6.0
       - llvm-6.0-dev
+      - clang-7
+      - llvm-7-dev
       - bison
       - chrpath
       - cmake


### PR DESCRIPTION
gcc supported releases are 7/8 (https://gcc.gnu.org/) and version 6 is getting bug fixes.

clang 6 is stable, 7 is quantification and 8 is development (hence being in allowed failures)

Wno-unused-command-line-argument was exceptionally common because of the way include paths are added globally to C{,XX}FLAGS so ignore for the time being. There are other warnings more important that should be rectified.

I submit this under the MCA.