### PR TITLE
MDEV-19205: Sphinx unable to connect using a host name

### DIFF
--- a/storage/sphinx/ha_sphinx.cc
+++ b/storage/sphinx/ha_sphinx.cc
@@ -2163,7 +2163,7 @@ int ha_sphinx::Connect ( const char * sHost, ushort uPort )
 #if MYSQL_VERSION_ID>=50515
 			struct addrinfo *hp = NULL;
 			tmp_errno = getaddrinfo ( sHost, NULL, NULL, &hp );
-			if ( !tmp_errno || !hp || !hp->ai_addr )
+			if ( tmp_errno || !hp || !hp->ai_addr )
 			{
 				bError = true;
 				if ( hp )
@@ -2190,8 +2190,9 @@ int ha_sphinx::Connect ( const char * sHost, ushort uPort )
 			}
 
 #if MYSQL_VERSION_ID>=50515
-			memcpy ( &sin.sin_addr, hp->ai_addr, Min ( sizeof(sin.sin_addr), (size_t)hp->ai_addrlen ) );
-			freeaddrinfo ( hp );
+			struct sockaddr_in *in = (sockaddr_in *)hp->ai_addr;
+			memcpy ( &sin.sin_addr, &in->sin_addr, Min ( sizeof(sin.sin_addr), sizeof(in->sin_addr) ) );
+ 			freeaddrinfo ( hp );
 #else
 			memcpy ( &sin.sin_addr, hp->h_addr, Min ( sizeof(sin.sin_addr), (size_t)hp->h_length ) );
 			my_gethostbyname_r_free();


### PR DESCRIPTION
There's an annoying bug that prevents a Sphinx table to connect to a searchd using a host name.
So the example table in the documentation https://mariadb.com/kb/en/library/about-sphinxse/#basic-usage that point's to "localhost" actually doesn't work.
After some investigation I found two errors. The first one is a wrong check after the getaddrinfo call. The second is a wrong usage of the returned struct.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.