### PR TITLE
Fixes to format and unused variable compilation warinings

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -515,8 +515,6 @@ static std::string wsrep_server_node_address()
     wsrep_data_home_dir = mysql_real_data_home;
 
   /* Initialize node address */
-  char node_addr[512]= { 0, };
-  size_t const node_addr_max= sizeof(node_addr) - 1;
   if (!wsrep_node_address || !strcmp(wsrep_node_address, ""))
   {
     char node_addr[512] = {0, };
@@ -1073,7 +1071,7 @@ bool wsrep_sync_wait (THD* thd, uint mask)
   if (wsrep_must_sync_wait(thd, mask))
   {
     WSREP_DEBUG("wsrep_sync_wait: thd->variables.wsrep_sync_wait = %u, "
-                "mask = %u, thd->variables.wsrep_on",
+                "mask = %u, thd->variables.wsrep_on = %d",
                 thd->variables.wsrep_sync_wait, mask,
                 thd->variables.wsrep_on);
     // This allows autocommit SELECTs and a first SELECT after SET AUTOCOMMIT=0

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18519,7 +18519,7 @@ wsrep_innobase_kill_one_trx(
 		    thd_get_thread_id(thd),
 		    victim_trx->id);
 
-	WSREP_DEBUG("Aborting query: %s conf %s trx: %" PRId64,
+	WSREP_DEBUG("Aborting query: %s conf %s trx: %lld",
 		    (thd && wsrep_thd_query(thd)) ? wsrep_thd_query(thd) : "void",
 		    wsrep_thd_transaction_state_str(thd),
 		    wsrep_thd_transaction_id(thd));


### PR DESCRIPTION
* warning: unused variable ‘node_addr_max’ [-Wunused-variable]
* Two warnings in WSREP_DEBUG() formats