### PR TITLE
Pull request codership/mariadb-wsrep#58

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_dirty_reads.result
+++ b/mysql-test/suite/galera/r/galera_var_dirty_reads.result
@@ -2,8 +2,6 @@ connection node_2;
 connection node_1;
 connection node_1;
 connection node_2;
-connection node_1;
-connection node_2;
 connection node_2;
 CREATE TABLE t1(i INT) ENGINE=INNODB;
 INSERT INTO t1 VALUES(1);
@@ -54,4 +52,3 @@ i
 DROP TABLE t1;
 disconnect node_2;
 disconnect node_1;
-# End of test

--- a/mysql-test/suite/galera/t/galera_var_dirty_reads.test
+++ b/mysql-test/suite/galera/t/galera_var_dirty_reads.test
@@ -11,11 +11,6 @@
 --let $node_2=node_2
 --source include/auto_increment_offset_save.inc
 
-# Save original auto_increment_offset values.
---let $node_1=node_1
---let $node_2=node_2
---source include/auto_increment_offset_save.inc
-
 --connection node_2
 --let $wsrep_cluster_address_saved = `SELECT @@global.wsrep_cluster_address`
 
@@ -74,6 +69,7 @@ SELECT * FROM t1;
 # Cleanup
 DROP TABLE t1;
 
---source include/galera_end.inc
---echo # End of test
+# Restore original auto_increment_offset values.
+--source include/auto_increment_offset_restore.inc
 
+--source include/galera_end.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5765,8 +5765,7 @@ int mysqld_main(int argc, char **argv)
       set_user(mysqld_user, user_info);
   }
 
-  if (WSREP_ON && wsrep_check_opts())
-    global_system_variables.wsrep_on= 0;
+  if (WSREP_ON && wsrep_check_opts()) unireg_abort(1);
 
   /* 
    The subsequent calls may take a long time : e.g. innodb log read.

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -156,25 +156,16 @@ static bool create_wsrep_THD(Wsrep_thd_args* args)
 
 void wsrep_create_appliers(long threads)
 {
-  /*
-    Todo: We should somehow verify here that the provider has been
-    connected. However, currently the wsrep_connected status variable
-    is updated in Wsrep_server_service::log_state_change() after the
-    Wsrep_server_state reaches connected state. Due to the differences
-    in Wsrep_server_state state machine with different SST methods,
-    it is not straightforward to wait for certain state. Perhaps
-    connecting state needs to be implemented separately.
-   */
-  if (false)
+  /*  Dont' start slave threads if wsrep-provider or wsrep-cluster-address
+      is not set.
+  */
+  if (!WSREP_PROVIDER_EXISTS) 
   {
-    /* see wsrep_replication_start() for the logic */
-    if (wsrep_cluster_address && strlen(wsrep_cluster_address) &&
-        wsrep_provider && strcasecmp(wsrep_provider, "none"))
-    {
-      WSREP_ERROR("Trying to launch slave threads before creating "
-                  "connection at '%s'", wsrep_cluster_address);
-      assert(0);
-    }
+    return; 
+  }
+
+  if (!wsrep_cluster_address || wsrep_cluster_address[0]== 0)
+  {
     return;
   }
 


### PR DESCRIPTION
* If wsrep_check_opts() failed during initialization abort execution
* Applier threads will not be created if provider or cluster address is not set