### PR TITLE
Pull request codership/mariadb-wsrep#60

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_ignore_apply_errors.result
+++ b/mysql-test/suite/galera/r/galera_var_ignore_apply_errors.result
@@ -1,4 +1,8 @@
+connection node_2;
+connection node_1;
+connection node_2;
 SET GLOBAL wsrep_ignore_apply_errors = 1;
+connection node_1;
 SET GLOBAL wsrep_on = OFF;
 CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = ON;
@@ -25,19 +29,24 @@ ALTER TABLE t1 ADD COLUMN f2 INTEGER;
 SET GLOBAL wsrep_on = ON;
 ALTER TABLE t1 DROP COLUMN f2;
 DROP TABLE t1;
+connection node_2;
 SET GLOBAL wsrep_ignore_apply_errors = 2;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = OFF;
 INSERT INTO t1 VALUES (1);
 SET GLOBAL wsrep_on = ON;
 DELETE FROM t1 WHERE f1 = 1;
+connection node_1;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
+connection node_2;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER);
 INSERT INTO t1 VALUES (2);
 SET GLOBAL wsrep_on = OFF;
@@ -48,22 +57,28 @@ INSERT INTO t1 VALUES (3);
 DELETE FROM t1 WHERE f1 = 1;
 DELETE FROM t1 WHERE f1 = 2;
 COMMIT;
+connection node_1;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
+connection node_2;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+connection node_2;
 SET SESSION wsrep_on = OFF;
 DELETE FROM t1 WHERE f1 = 3;
 SET SESSION wsrep_on = ON;
+connection node_1;
 DELETE FROM t1;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
+connection node_2;
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1
@@ -71,11 +86,14 @@ SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+connection node_2;
 SET SESSION wsrep_on = OFF;
 DELETE FROM t1 WHERE f1 = 3;
 SET SESSION wsrep_on = ON;
+connection node_1;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 DELETE FROM t1 WHERE f1 = 1;
@@ -88,6 +106,7 @@ SET AUTOCOMMIT=ON;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
+connection node_2;
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1
@@ -95,18 +114,22 @@ SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3);
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3);
+connection node_2;
 SET SESSION wsrep_on = OFF;
 DELETE FROM t2 WHERE f1 = 2;
 DELETE FROM t1 WHERE f1 = 3;
 SET SESSION wsrep_on = ON;
+connection node_1;
 DELETE t1, t2 FROM t1 JOIN t2 WHERE t1.f1 = t2.f1;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
+connection node_2;
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1
@@ -114,13 +137,16 @@ SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
 DROP TABLE t1,t2;
+connection node_1;
 CREATE TABLE parent (id INT NOT NULL, PRIMARY KEY (id)) ENGINE=INNODB;
 INSERT INTO parent VALUES (1),(2),(3);
 CREATE TABLE child (id INT, parent_id INT, INDEX par_ind (parent_id), FOREIGN KEY (parent_id) REFERENCES parent(id) ON DELETE CASCADE) ENGINE=INNODB;
 INSERT INTO child VALUES (1,1),(2,2),(3,3);
+connection node_2;
 SET SESSION wsrep_on = OFF;
 DELETE FROM child WHERE parent_id = 2;
 SET SESSION wsrep_on = ON;
+connection node_1;
 DELETE FROM parent;
 SELECT COUNT(*) = 0 FROM parent;
 COUNT(*) = 0
@@ -128,6 +154,7 @@ COUNT(*) = 0
 SELECT COUNT(*) = 0 FROM child;
 COUNT(*) = 0
 1
+connection node_2;
 SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
 VARIABLE_VALUE = 'Primary'
 1
@@ -138,13 +165,18 @@ SELECT COUNT(*) = 0 FROM child;
 COUNT(*) = 0
 1
 DROP TABLE child, parent;
+connection node_2;
 SET GLOBAL wsrep_ignore_apply_errors = 4;
+connection node_2;
 SET GLOBAL wsrep_on = OFF;
 CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = ON;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
 DROP TABLE t1;
+connection node_2;
 SET GLOBAL wsrep_ignore_apply_errors = 7;
+CALL mtr.add_suppression("Can't find record in 't.*'");
 CALL mtr.add_suppression("Slave SQL: Could not execute Delete_rows event");
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query. Default database: 'test'. Query: 'DROP TABLE t1', Error_code: 1051");
 CALL mtr.add_suppression("Slave SQL: Error 'Can't drop database 's1'; database doesn't exist' on query. Default database: 'test'. Query: 'DROP SCHEMA s1', Error_code: 1008");

--- a/mysql-test/suite/galera/t/galera_var_ignore_apply_errors.test
+++ b/mysql-test/suite/galera/t/galera_var_ignore_apply_errors.test
@@ -225,8 +225,8 @@ DROP TABLE t1;
 --connection node_2
 SET GLOBAL wsrep_ignore_apply_errors = 7;
 
+CALL mtr.add_suppression("Can't find record in 't.*'");
 CALL mtr.add_suppression("Slave SQL: Could not execute Delete_rows event");
-
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test.t1'' on query. Default database: 'test'. Query: 'DROP TABLE t1', Error_code: 1051");
 CALL mtr.add_suppression("Slave SQL: Error 'Can't drop database 's1'; database doesn't exist' on query. Default database: 'test'. Query: 'DROP SCHEMA s1', Error_code: 1008");
 CALL mtr.add_suppression("Slave SQL: Error 'Can't DROP 'idx1'; check that column/key exists' on query. Default database: 'test'. Query: 'DROP INDEX idx1 ON t1', Error_code: 1091");

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2808,7 +2808,8 @@ int wsrep_ignored_error_code(Log_event* ev, int error)
   if ((wsrep_ignore_apply_errors & WSREP_IGNORE_ERRORS_ON_RECONCILING_DML))
   {
     const int ev_type= ev->get_type_code();
-    if (ev_type == DELETE_ROWS_EVENT && error == ER_KEY_NOT_FOUND)
+    if ((ev_type == DELETE_ROWS_EVENT || ev_type == DELETE_ROWS_EVENT_V1)
+        && error == ER_KEY_NOT_FOUND)
       goto ignore_error;
   }
 


### PR DESCRIPTION
Event type DELETE_ROWS_EVENT_1 is used in MariaDB so it needs to be checked to ignore error.