### PR TITLE
Fix test galera.galera_var_slave_threads

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_slave_threads.result
+++ b/mysql-test/suite/galera/r/galera_var_slave_threads.result
@@ -1,6 +1,8 @@
 connection node_2;
 connection node_1;
 connection node_1;
+connection node_2;
+connection node_1;
 CREATE TABLE t1 (f1 INT PRIMARY KEY) Engine=InnoDB;
 CREATE TABLE t2 (f1 INT AUTO_INCREMENT PRIMARY KEY) Engine=InnoDB;
 connection node_2;
@@ -40,7 +42,6 @@ connection node_2;
 SELECT COUNT(*) = 64 FROM t2;
 COUNT(*) = 64
 1
-SET wsrep_sync_wait=0;
 SELECT COUNT(*) = @@wsrep_slave_threads + 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND COMMAND != 'Daemon';
 COUNT(*) = @@wsrep_slave_threads + 2
 1
@@ -55,7 +56,6 @@ SET GLOBAL wsrep_slave_threads = 1;
 connection node_2;
 Shutting down server ...
 connection node_1;
-SET wsrep_sync_wait=0;
 show status like 'wsrep_cluster_size';
 Variable_name	Value
 wsrep_cluster_size	1
@@ -202,23 +202,6 @@ INSERT INTO t2 VALUES (DEFAULT);
 INSERT INTO t2 VALUES (DEFAULT);
 INSERT INTO t2 VALUES (DEFAULT);
 connection node_2;
-SET GLOBAL wsrep_slave_threads = 4;
-Timeout in wait_condition.inc for SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND (STATE IS NULL OR STATE NOT LIKE 'InnoDB%')
-Id	User	Host	db	Command	Time	State	Info	Progress
-2	system user		NULL	Sleep	42	Waiting on cond	NULL	0.000
-1	system user		NULL	Sleep	42	wsrep aborter idle	NULL	0.000
-3	system user		NULL	Sleep	30	Committed 195	NULL	0.000
-4	system user		NULL	Daemon	NULL	InnoDB purge coordinator	NULL	0.000
-5	system user		NULL	Daemon	NULL	InnoDB purge worker	NULL	0.000
-7	system user		NULL	Daemon	NULL	InnoDB purge worker	NULL	0.000
-6	system user		NULL	Daemon	NULL	InnoDB purge worker	NULL	0.000
-8	system user		NULL	Daemon	NULL	InnoDB shutdown handler	NULL	0.000
-27	root	localhost:53510	test	Query	0	Init	show full processlist	0.000
-28	system user		NULL	Sleep	30	NULL	NULL	0.000
-30	system user		NULL	Sleep	30	NULL	NULL	0.000
-29	system user		NULL	Sleep	30	NULL	NULL	0.000
-SET GLOBAL wsrep_slave_threads = 1;
-connection node_1;
 DROP TABLE t1;
 DROP TABLE t2;
 # End of tests

--- a/mysql-test/suite/galera/t/galera_var_slave_threads.test
+++ b/mysql-test/suite/galera/t/galera_var_slave_threads.test
@@ -8,6 +8,11 @@
 --source include/have_innodb.inc
 --let $wsrep_slave_threads_orig = `SELECT @@wsrep_slave_threads`
 
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source include/auto_increment_offset_save.inc
+
 --connection node_1
 CREATE TABLE t1 (f1 INT PRIMARY KEY) Engine=InnoDB;
 CREATE TABLE t2 (f1 INT AUTO_INCREMENT PRIMARY KEY) Engine=InnoDB;
@@ -34,10 +39,6 @@ SET GLOBAL wsrep_slave_threads = 64;
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
---let $wait_timeout=600
---let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
---source include/wait_condition.inc
-
 SELECT COUNT(*) = 1 FROM t1;
 
 #
@@ -71,7 +72,6 @@ while ($count)
 
 --connection node_2
 SELECT COUNT(*) = 64 FROM t2;
-SET wsrep_sync_wait=0;
 
 SELECT COUNT(*) = @@wsrep_slave_threads + 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND COMMAND != 'Daemon';
 SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE LIKE '%wsrep aborter%';
@@ -100,7 +100,6 @@ SET GLOBAL wsrep_slave_threads = 1;
 
 # wait until node_1 is ready as one node cluster
 --connection node_1
-SET wsrep_sync_wait=0;
 --let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
 --source include/wait_condition.inc
 show status like 'wsrep_cluster_size';
@@ -166,17 +165,13 @@ while ($count)
 
 
 --connection node_2
-SET GLOBAL wsrep_slave_threads = 4;
---let $wait_condition = SELECT COUNT(*) = @@wsrep_slave_threads + 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND (STATE IS NULL OR STATE NOT LIKE 'InnoDB%')
---source include/wait_condition.inc
-
-SET GLOBAL wsrep_slave_threads = 1;
-
---connection node_1
 --let $wait_condition = SELECT COUNT(*) = @@wsrep_slave_threads + 2 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND COMMAND != 'Daemon'
 --source include/wait_condition.inc
 
 DROP TABLE t1;
 DROP TABLE t2;
+
+# Restore original auto_increment_offset values.
+--source include/auto_increment_offset_restore.inc
 
 --echo # End of tests


### PR DESCRIPTION
- Fixed cleanup phase, no more slave threads should be created
- Save/restore auto increment offsets
- Unnecessary disabling of wsrep_sync_wait, removed
- Fixed result file, was recorded with timeout on wait condition!