### PR TITLE
MDEV-17797 Add ASAN poisoning for mem_heap_t

### DIFF
--- a/include/my_valgrind.h
+++ b/include/my_valgrind.h
@@ -29,6 +29,8 @@
 
 #if defined(HAVE_VALGRIND) && defined(HAVE_valgrind)
 # include <valgrind/memcheck.h>
+# define MY_ASAN_POISON_MEMORY_REGION(a,len) ((void)(a), (void)(len))
+# define MY_ASAN_UNPOISON_MEMORY_REGION(a,len) ((void)(a), (void)(len))
 # define MEM_UNDEFINED(a,len) VALGRIND_MAKE_MEM_UNDEFINED(a,len)
 # define MEM_NOACCESS(a,len) VALGRIND_MAKE_MEM_NOACCESS(a,len)
 # define MEM_CHECK_ADDRESSABLE(a,len) VALGRIND_CHECK_MEM_IS_ADDRESSABLE(a,len)
@@ -37,11 +39,15 @@
 # include <sanitizer/asan_interface.h>
 /* How to do manual poisoning:
 https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
+# define MY_ASAN_POISON_MEMORY_REGION(a,len) ASAN_POISON_MEMORY_REGION(a,len)
+# define MY_ASAN_UNPOISON_MEMORY_REGION(a,len) ASAN_UNPOISON_MEMORY_REGION(a,len)
 # define MEM_UNDEFINED(a,len) ASAN_UNPOISON_MEMORY_REGION(a,len)
 # define MEM_NOACCESS(a,len) ASAN_POISON_MEMORY_REGION(a,len)
 # define MEM_CHECK_ADDRESSABLE(a,len) ((void) 0)
 # define MEM_CHECK_DEFINED(a,len) ((void) 0)
 #else
+# define MY_ASAN_POISON_MEMORY_REGION(a,len) ((void)(a), (void)(len))
+# define MY_ASAN_UNPOISON_MEMORY_REGION(a,len) ((void)(a), (void)(len))
 # define MEM_UNDEFINED(a,len) ((void) 0)
 # define MEM_NOACCESS(a,len) ((void) 0)
 # define MEM_CHECK_ADDRESSABLE(a,len) ((void) 0)

--- a/storage/innobase/include/mem0mem.ic
+++ b/storage/innobase/include/mem0mem.ic
@@ -24,6 +24,7 @@ Created 6/8/1994 Heikki Tuuri
 *************************************************************************/
 
 #include "mem0dbg.ic"
+#include "my_valgrind.h"
 #ifndef UNIV_HOTBACKUP
 # include "mem0pool.h"
 #endif /* !UNIV_HOTBACKUP */
@@ -222,6 +223,7 @@ mem_heap_alloc(
 	buf = (byte*) buf + MEM_FIELD_HEADER_SIZE;
 
 #endif
+	MY_ASAN_UNPOISON_MEMORY_REGION(buf, n);
 	UNIV_MEM_ALLOC(buf, n);
 	return(buf);
 }
@@ -315,6 +317,8 @@ mem_heap_free_heap_top(
 	mem_current_allocated_memory -= (total_size - size);
 	mutex_exit(&mem_hash_mutex);
 #endif /* UNIV_MEM_DEBUG */
+	MY_ASAN_POISON_MEMORY_REGION(old_top,
+				     (byte*)block + block->len - old_top);
 	UNIV_MEM_FREE(old_top, (byte*)block + block->len - old_top);
 
 	/* If free == start, we may free the block if it is not the first
@@ -412,6 +416,8 @@ mem_heap_free_top(
 				== mem_block_get_start(block))) {
 		mem_heap_block_free(heap, block);
 	} else {
+		MY_ASAN_POISON_MEMORY_REGION(
+		    (byte*)block + mem_block_get_free(block), n);
 		UNIV_MEM_FREE((byte*) block + mem_block_get_free(block), n);
 	}
 }

--- a/storage/innobase/mem/mem0mem.cc
+++ b/storage/innobase/mem/mem0mem.cc
@@ -409,6 +409,7 @@ mem_heap_create_block_func(
 	/* Poison all available memory. Individual chunks will be unpoisoned on
 	every mem_heap_alloc() call. */
 	compile_time_assert(MEM_BLOCK_HEADER_SIZE >= sizeof *block);
+	MY_ASAN_POISON_MEMORY_REGION(block + 1, len - sizeof *block);
 	UNIV_MEM_FREE(block + 1, len - sizeof *block);
 
 	ut_ad((ulint)MEM_BLOCK_HEADER_SIZE < len);
@@ -527,7 +528,7 @@ mem_heap_block_free(
 		mem_area_free(block, mem_comm_pool);
 	} else {
 		ut_ad(type & MEM_HEAP_BUFFER);
-
+		MY_ASAN_UNPOISON_MEMORY_REGION(block, len);
 		buf_block_free(buf_block);
 	}
 #else /* !UNIV_HOTBACKUP */

--- a/storage/xtradb/include/mem0mem.ic
+++ b/storage/xtradb/include/mem0mem.ic
@@ -24,6 +24,7 @@ Created 6/8/1994 Heikki Tuuri
 *************************************************************************/
 
 #include "mem0dbg.ic"
+#include "my_valgrind.h"
 #ifndef UNIV_HOTBACKUP
 # include "mem0pool.h"
 #endif /* !UNIV_HOTBACKUP */
@@ -222,6 +223,7 @@ mem_heap_alloc(
 	buf = (byte*) buf + MEM_FIELD_HEADER_SIZE;
 
 #endif
+	MY_ASAN_UNPOISON_MEMORY_REGION(buf, n);
 	UNIV_MEM_ALLOC(buf, n);
 	return(buf);
 }
@@ -315,6 +317,8 @@ mem_heap_free_heap_top(
 	mem_current_allocated_memory -= (total_size - size);
 	mutex_exit(&mem_hash_mutex);
 #endif /* UNIV_MEM_DEBUG */
+	MY_ASAN_POISON_MEMORY_REGION(old_top,
+				     (byte*)block + block->len - old_top);
 	UNIV_MEM_FREE(old_top, (byte*)block + block->len - old_top);
 
 	/* If free == start, we may free the block if it is not the first
@@ -412,6 +416,8 @@ mem_heap_free_top(
 				== mem_block_get_start(block))) {
 		mem_heap_block_free(heap, block);
 	} else {
+		MY_ASAN_POISON_MEMORY_REGION(
+		    (byte*)block + mem_block_get_free(block), n);
 		UNIV_MEM_FREE((byte*) block + mem_block_get_free(block), n);
 	}
 }

--- a/storage/xtradb/mem/mem0mem.cc
+++ b/storage/xtradb/mem/mem0mem.cc
@@ -409,6 +409,7 @@ mem_heap_create_block_func(
 	/* Poison all available memory. Individual chunks will be unpoisoned on
 	every mem_heap_alloc() call. */
 	compile_time_assert(MEM_BLOCK_HEADER_SIZE >= sizeof *block);
+	MY_ASAN_POISON_MEMORY_REGION(block + 1, len - sizeof *block);
 	UNIV_MEM_FREE(block + 1, len - sizeof *block);
 
 	ut_ad((ulint)MEM_BLOCK_HEADER_SIZE < len);
@@ -527,7 +528,7 @@ mem_heap_block_free(
 		mem_area_free(block, mem_comm_pool);
 	} else {
 		ut_ad(type & MEM_HEAP_BUFFER);
-
+		MY_ASAN_UNPOISON_MEMORY_REGION(block, len);
 		buf_block_free(buf_block);
 	}
 #else /* !UNIV_HOTBACKUP */


### PR DESCRIPTION
Introduce MY_ASAN_(UN)POISON_MEMORY_REGION() macros and use to it to instrument
mem_heap_t. It was previously instrumented in 5.5 but in a more obfuscating
manner. I think this patch makes things more clear and error-prone.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.0-MDEV-17797-mem-heap-asan)