### PR TITLE
Sporadic failures of galera.galera_FK_duplicate_client_insert test

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18539,16 +18539,6 @@ wsrep_innobase_kill_one_trx(
 				victim_trx->lock.was_chosen_as_deadlock_victim= TRUE;
 				lock_cancel_waiting_and_release(wait_lock);
 			}
-			wsrep_thd_awake((const void*)thd, signal); 
-		} else {
-			/* abort currently executing query */
-			DBUG_PRINT("wsrep",("sending KILL_QUERY to: %lu",
-					    thd_get_thread_id(thd)));
-			WSREP_DEBUG("kill query for: %lu",
-				    thd_get_thread_id(thd));
-			/* Note that innobase_kill_query will take lock_mutex
-			and trx_mutex */
-			wsrep_thd_awake((const void*)thd, signal);
 		}
 	}
 


### PR DESCRIPTION
Moved the before_command() hook to called as soon as possible, after my_net_read_packet()
returns. This is because before_command() entry has wait loop to pause client for as long
as background rollback for the client is processing.

before_command() call was earlier inside dispatch_command(), and some adjusting was needed to
handle in do_command() level, the case where clinet's transaction was brute force aborted and
deadlock error needs to be returned for the client.

In ha_innodb.cc:wsrep_kill_one_transaction(), THD::awake() used, when victim has already been
aborted by wsrep_thd_bf_abort(). This would only cause two awake() signals for same victim.
Also an idle THD would be signaled, which is now avoided.