### PR TITLE
galera_roles galera_toi_ddl_locking fixes

### DIFF
--- a/mysql-test/suite/galera/r/galera_toi_ddl_locking.result
+++ b/mysql-test/suite/galera/r/galera_toi_ddl_locking.result
@@ -48,6 +48,7 @@ COUNT(*) = 0
 SELECT COUNT(*) = 1 FROM t2;
 COUNT(*) = 1
 1
+SET debug_sync='RESET';
 connection node_2;
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0

--- a/mysql-test/suite/galera/t/galera_toi_ddl_locking.test
+++ b/mysql-test/suite/galera/t/galera_toi_ddl_locking.test
@@ -88,6 +88,7 @@ SET DEBUG_SYNC= 'now SIGNAL continue';
 
 SELECT COUNT(*) = 0 FROM t1;
 SELECT COUNT(*) = 1 FROM t2;
+SET debug_sync='RESET';
 
 --connection node_2
 SELECT COUNT(*) = 0 FROM t1;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1830,6 +1830,12 @@ static int wsrep_TOI_event_buf(THD* thd, uchar** buf, size_t* buf_len)
   case SQLCOM_DROP_TABLE:
     err= wsrep_drop_table_query(thd, buf, buf_len);
     break;
+  case SQLCOM_CREATE_ROLE:
+    if (sp_process_definer(thd))
+    {
+      WSREP_WARN("Failed to set CREATE ROLE definer for TOI.");
+    }
+    /* fallthrough */
   default:
     err= wsrep_to_buf_helper(thd, thd->query(), thd->query_length(), buf,
                              buf_len);


### PR DESCRIPTION
This commit contains mege from upstream galera 4 integration to handle CREATE ROLES replication.
This fix will enable galera_roles test to pass
galera_toi_ddl_locking.test was missing dbug_syn reset, which cused failure in post execution
environment checking