### PR TITLE
Fix USE_AFTER_FREE (CWE-416)

### DIFF
--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -2029,7 +2029,6 @@ end_of_index:
 					row = NULL;
 					mtr_commit(&mtr);
 					mem_heap_free(row_heap);
-					ut_free(nonnull);
 					goto write_buffers;
 				}
 			} else {


### PR DESCRIPTION
The "nonnul" variable will be freed on line 2756