### PR TITLE
Fixes for galera.galera_var_reject_queries and galera_bf_abort_shutdown

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1408,7 +1408,11 @@ out:
   DBUG_ASSERT(thd->m_digest == NULL);
   DBUG_ASSERT(thd->m_statement_psi == NULL);
 #ifdef WITH_WSREP
-  wsrep_after_command_after_result(thd);
+  if (packet_length != packet_error)
+  {
+    /* there was a command to process, and before_command() has been called */
+    wsrep_after_command_after_result(thd);
+  }
 #endif /* WITH_WSREP */
   DBUG_RETURN(return_value);
 }

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2613,12 +2613,7 @@ void wsrep_close_client_connections(my_bool wait_to_end, THD* except_caller_thd)
     /*
       instead of wsrep_close_thread() we do now  soft kill by THD::awake
      */
-    mysql_mutex_lock(&tmp->LOCK_thd_data);
-
     tmp->awake(KILL_CONNECTION);
-
-    mysql_mutex_unlock(&tmp->LOCK_thd_data);
-
   }
   mysql_mutex_unlock(&LOCK_thread_count);
 


### PR DESCRIPTION
wsrep_close_client_connections() called THD::awake() by holding LOCK_thd_data,
this caused doube locking of the mutex. This has been fixed

if client connection was killed while being idle, it would bail out immediately
after my_net_read_packet(), without calling before_command() hook.
However, in the end of do_command(), the after_command() hook is called unconditionally.
This caused an assert inside after_command() for bad client state,
in galera_var_reject_queries test, where such connection close was exercised.