### PR TITLE
Fixes for galera.mysql-wsrep#110 and galera.ev51914

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6504,6 +6504,7 @@ finish:
     transaction as empty.
   */
   if (!thd->in_active_multi_stmt_transaction() &&
+      !thd->in_sub_stmt &&
       thd->wsrep_trx().active() &&
       thd->wsrep_trx().state() == wsrep::transaction::s_executing)
   {


### PR DESCRIPTION
When executing sub statements don't call wsrep_commit_empty.