### PR TITLE
Record .rdiff files

### DIFF
--- a/mysql-test/suite/galera/r/galera_ist_mariabackup,debug.rdiff
+++ b/mysql-test/suite/galera/r/galera_ist_mariabackup,debug.rdiff
@@ -1,6 +1,22 @@
---- r/galera_ist_mariabackup.result	2018-11-21 22:30:21.968817468 +0200
-+++ r/galera_ist_mariabackup.reject	2018-11-22 09:16:27.832601754 +0200
-@@ -285,3 +285,111 @@
+--- galera_ist_mariabackup.result	2018-11-29 17:41:37.006000000 +0100
++++ galera_ist_mariabackup,debug.reject	2018-11-29 18:03:31.113429999 +0100
+@@ -1,3 +1,5 @@
++connection node_2;
++connection node_1;
+ connection node_1;
+ connection node_2;
+ Performing State Transfer on a server that has been temporarily disconnected
+@@ -47,6 +49,9 @@
+ INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+ connection node_2;
+ Loading wsrep provider ...
++disconnect node_2;
++connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2;
++connection node_2;
+ SET AUTOCOMMIT=OFF;
+ START TRANSACTION;
+ INSERT INTO t1 VALUES ('node2_committed_after');
+@@ -285,3 +290,111 @@
  DROP TABLE t1;
  COMMIT;
  SET AUTOCOMMIT=ON;

--- a/mysql-test/suite/galera/r/galera_sst_rsync,debug.rdiff
+++ b/mysql-test/suite/galera/r/galera_sst_rsync,debug.rdiff
@@ -1,6 +1,14 @@
---- galera_sst_rsync.result
-+++ galera_sst_rsync,debug.reject
-@@ -284,3 +284,111 @@
+--- galera_sst_rsync.result	2018-11-21 18:14:26.125258909 +0100
++++ galera_sst_rsync,debug.reject	2018-11-29 18:07:44.596107999 +0100
+@@ -1,5 +1,7 @@
+ connection node_2;
+ connection node_1;
++connection node_1;
++connection node_2;
+ Performing State Transfer on a server that has been shut down cleanly and restarted
+ connection node_1;
+ CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
+@@ -286,3 +288,111 @@
  DROP TABLE t1;
  COMMIT;
  SET AUTOCOMMIT=ON;

--- a/mysql-test/suite/galera/r/galera_sst_rsync2,debug.rdiff
+++ b/mysql-test/suite/galera/r/galera_sst_rsync2,debug.rdiff
@@ -1,6 +1,12 @@
---- suite/galera/r/galera_sst_rsync2.result	2018-09-12 13:09:35.352229478 +0200
-+++ suite/galera/r/galera_sst_rsync2,debug.reject	2018-09-12 17:00:51.601974979 +0200
-@@ -286,3 +286,111 @@
+--- galera_sst_rsync2.result	2018-11-29 17:57:53.288606346 +0100
++++ galera_sst_rsync2,debug.reject	2018-11-29 18:00:01.172512000 +0100
+@@ -1,3 +1,5 @@
++connection node_2;
++connection node_1;
+ connection node_1;
+ connection node_2;
+ Performing State Transfer on a server that has been shut down cleanly and restarted
+@@ -286,3 +288,111 @@
  DROP TABLE t1;
  COMMIT;
  SET AUTOCOMMIT=ON;


### PR DESCRIPTION
Records .rdiff files for tests galera_ist_mariabackup,
galera_sst_rsync, and galera_sst_rsync2.