### PR TITLE
Fix test galera_sr.galera_sr_conflict

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_sr_conflict.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_conflict.result
@@ -1,3 +1,6 @@
+connection node_2;
+connection node_1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 SET SESSION wsrep_trx_fragment_size = 1;
 SET AUTOCOMMIT=OFF;
@@ -7,8 +10,12 @@ INSERT INTO t1 VALUES (2);
 INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 INSERT INTO t1 VALUES (5);
+connection node_2;
 SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 INSERT INTO t1 VALUES(1);;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_1;
 COMMIT;
+connection node_2;
 ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
 DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_sr_conflict.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_conflict.test
@@ -28,7 +28,7 @@ SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 # Observe the block from a separate connection
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
 
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'committed%';
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'wsrep applier committed%';
 --source include/wait_condition.inc
 
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'update';

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -218,7 +218,7 @@ int Wsrep_high_priority_service::append_fragment_and_commit(
   const wsrep::ws_meta& ws_meta,
   const wsrep::const_buffer& data)
 {
-  DBUG_ENTER("Wsrep_high_priority_service::append_fragment");
+  DBUG_ENTER("Wsrep_high_priority_service::append_fragment_and_commit");
   int ret= start_transaction(ws_handle, ws_meta);
   ret= ret || wsrep_schema->append_fragment(m_thd,
                                             ws_meta.server_id(),
@@ -269,6 +269,9 @@ int Wsrep_high_priority_service::append_fragment_and_commit(
   }
   m_thd->wsrep_cs().after_applying();
   m_thd->mdl_context.release_transactional_locks();
+
+  thd_proc_info(m_thd, "wsrep applier committed");
+
   DBUG_RETURN(ret);
 }
 


### PR DESCRIPTION
Test fails due to timeout in wait condition error, which expects
applier thread to show up in process list state "committed".
This was not the case due to missing call to thd_proc_info() after
applier appends and commits a fragment.