### PR TITLE
MDEV-13301 Optimize DROP INDEX, ADD INDEX into RENAME INDEX

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-index-online.result
+++ b/mysql-test/suite/innodb/r/innodb-index-online.result
@@ -227,7 +227,7 @@ WHERE variable_name = 'innodb_encryption_n_rowlog_blocks_encrypted');
 connection con1;
 SET DEBUG_SYNC = 'row_log_apply_before SIGNAL c2e_created WAIT_FOR dml2_done';
 SET lock_wait_timeout = 10;
-ALTER TABLE t1 DROP INDEX c2d, ADD INDEX c2e(c2),
+ALTER TABLE t1 DROP INDEX c2d, ADD INDEX c2e(c2, c3(10)),
 ALGORITHM = INPLACE;
 connection default;
 INSERT INTO t1 SELECT  80 + c1, c2, c3 FROM t1;
@@ -286,6 +286,7 @@ INNER JOIN INFORMATION_SCHEMA.INNODB_SYS_FIELDS sf
 ON si.index_id = sf.index_id WHERE si.name = '?c2e';
 name	pos
 c2	0
+c3	1
 SET @merge_encrypt_1=
 (SELECT variable_value FROM information_schema.global_status
 WHERE variable_name = 'innodb_encryption_n_merge_blocks_encrypted');

--- a/mysql-test/suite/innodb/r/instant_alter_index_rename.result
+++ b/mysql-test/suite/innodb/r/instant_alter_index_rename.result
@@ -138,4 +138,15 @@ add unique key a_key2 (a),
 algorithm=instant;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 SET debug_dbug = @save_dbug;
+alter table t
+drop key a_key,
+add unique key `GEN_CLUST_INDEX` (a),
+algorithm=instant;
+ERROR 42000: Incorrect index name 'GEN_CLUST_INDEX'
+show create table t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+  UNIQUE KEY `a_key` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 STATS_PERSISTENT=1
 drop table t;

--- a/mysql-test/suite/innodb/r/instant_alter_index_rename.result
+++ b/mysql-test/suite/innodb/r/instant_alter_index_rename.result
@@ -95,6 +95,12 @@ add key b_key (b),
 drop key b_key,
 add key bb_key (b);
 ERROR 42000: Can't DROP INDEX `b_key`; check that it exists
+alter table errors
+drop key a_key,
+add key a_key2 (a),
+drop key a_key,
+add key a_key2 (a);
+ERROR 42000: Can't DROP INDEX `a_key`; check that it exists
 drop table errors;
 create table corrupted (
 a int,

--- a/mysql-test/suite/innodb/r/instant_alter_index_rename.result
+++ b/mysql-test/suite/innodb/r/instant_alter_index_rename.result
@@ -13,15 +13,25 @@ b int,
 c int,
 unique index a_key (a),
 key c_key (c)
-) engine=innodb;
+) engine=innodb stats_persistent=1;
 insert into t values (1, 1, 1, 1);
 set @table_id = (select table_id from information_schema.innodb_sys_tables where name='test/t');
 set @a_key_id = get_index_id(@table_id, 'a_key');
 set @c_key_id = get_index_id(@table_id, 'c_key');
 set @primary_id = get_index_id(@table_id, 'primary');
+select distinct(index_name) from mysql.innodb_index_stats where table_name = 't';
+index_name
+PRIMARY
+a_key
+c_key
 alter table t
 drop index a_key,
 add unique index a_key_strikes_back (a);
+select distinct(index_name) from mysql.innodb_index_stats where table_name = 't';
+index_name
+PRIMARY
+a_key_strikes_back
+c_key
 check table t;
 Table	Op	Msg_type	Msg_text
 test.t	check	status	OK
@@ -67,7 +77,8 @@ drop table t;
 drop function get_index_id;
 create table errors (
 a int,
-unique key a_key (a)
+unique key a_key (a),
+b int
 ) engine=innodb;
 alter table errors
 drop key a_key,
@@ -79,6 +90,11 @@ drop key a_key,
 drop key a_key2,
 add unique key a_key2 (a);
 ERROR 42000: Can't DROP INDEX `a_key2`; check that it exists
+alter table errors
+add key b_key (b),
+drop key b_key,
+add key bb_key (b);
+ERROR 42000: Can't DROP INDEX `b_key`; check that it exists
 drop table errors;
 create table corrupted (
 a int,

--- a/mysql-test/suite/innodb/r/instant_alter_index_rename.result
+++ b/mysql-test/suite/innodb/r/instant_alter_index_rename.result
@@ -1,0 +1,112 @@
+create function get_index_id(tbl_id int, index_name char(100))
+returns int
+begin
+declare res int;
+select index_id into res from information_schema.innodb_sys_indexes where
+name=index_name and table_id = tbl_id;
+return res;
+end|
+create table t (
+pk int primary key,
+a int,
+b int,
+c int,
+unique index a_key (a),
+key c_key (c)
+) engine=innodb;
+insert into t values (1, 1, 1, 1);
+set @table_id = (select table_id from information_schema.innodb_sys_tables where name='test/t');
+set @a_key_id = get_index_id(@table_id, 'a_key');
+set @c_key_id = get_index_id(@table_id, 'c_key');
+set @primary_id = get_index_id(@table_id, 'primary');
+alter table t
+drop index a_key,
+add unique index a_key_strikes_back (a);
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+select @a_key_id = get_index_id(@table_id, 'a_key_strikes_back'),
+@c_key_id = get_index_id(@table_id, 'c_key'),
+@primary_id = get_index_id(@table_id, 'primary');
+@a_key_id = get_index_id(@table_id, 'a_key_strikes_back')	@c_key_id = get_index_id(@table_id, 'c_key')	@primary_id = get_index_id(@table_id, 'primary')
+1	1	1
+set @a_key_strikes_back_id = get_index_id(@table_id, 'a_key_strikes_back');
+set @c_key_id = get_index_id(@table_id, 'c_key');
+set @primary_id = get_index_id(@table_id, 'primary');
+alter table t
+drop index a_key_strikes_back,
+add unique index a_key_returns (a),
+drop primary key,
+add primary key (pk),
+add unique index b_key (b);
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+select @a_key_strikes_back_id = get_index_id(@table_id, 'a_key_returns'),
+@c_key_id = get_index_id(@table_id, 'c_key'),
+@primary_id = get_index_id(@table_id, 'primary');
+@a_key_strikes_back_id = get_index_id(@table_id, 'a_key_returns')	@c_key_id = get_index_id(@table_id, 'c_key')	@primary_id = get_index_id(@table_id, 'primary')
+1	1	1
+set @a_key_returns_id = get_index_id(@table_id, 'a_key_returns');
+set @b_key_id = get_index_id(@table_id, 'b_key');
+set @c_key_id = get_index_id(@table_id, 'c_key');
+set @primary_id = get_index_id(@table_id, 'primary');
+alter table t
+drop key c_key,
+add key c_key2 (c);
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+select @a_key_returns_id = get_index_id(@table_id, 'a_key_returns'),
+@b_key_id = get_index_id(@table_id, 'b_key'),
+@c_key_id = get_index_id(@table_id, 'c_key2'),
+@primary_id = get_index_id(@table_id, 'primary');
+@a_key_returns_id = get_index_id(@table_id, 'a_key_returns')	@b_key_id = get_index_id(@table_id, 'b_key')	@c_key_id = get_index_id(@table_id, 'c_key2')	@primary_id = get_index_id(@table_id, 'primary')
+1	1	1	1
+drop table t;
+drop function get_index_id;
+create table errors (
+a int,
+unique key a_key (a)
+) engine=innodb;
+alter table errors
+drop key a_key,
+drop key a_key,
+add unique key a_key2 (a);
+ERROR 42000: Can't DROP INDEX `a_key`; check that it exists
+alter table errors
+drop key a_key,
+drop key a_key2,
+add unique key a_key2 (a);
+ERROR 42000: Can't DROP INDEX `a_key2`; check that it exists
+drop table errors;
+create table corrupted (
+a int,
+key a_key (a)
+) engine=innodb;
+insert into corrupted values (1);
+select * from corrupted;
+a
+1
+SET @save_dbug = @@SESSION.debug_dbug;
+SET debug_dbug = '+d,dict_set_index_corrupted';
+check table corrupted;
+Table	Op	Msg_type	Msg_text
+test.corrupted	check	Warning	InnoDB: Index a_key is marked as corrupted
+test.corrupted	check	error	Corrupt
+SET debug_dbug = @save_dbug;
+select * from corrupted;
+ERROR HY000: Index corrupted is corrupted
+alter table corrupted
+drop key a_key,
+add key a_key2 (a);
+ERROR HY000: Index a_key is corrupted
+alter table corrupted
+drop key a_key;
+select * from corrupted;
+a
+1
+check table corrupted;
+Table	Op	Msg_type	Msg_text
+test.corrupted	check	status	OK
+drop table corrupted;

--- a/mysql-test/suite/innodb/r/instant_alter_index_rename.result
+++ b/mysql-test/suite/innodb/r/instant_alter_index_rename.result
@@ -126,3 +126,16 @@ check table corrupted;
 Table	Op	Msg_type	Msg_text
 test.corrupted	check	status	OK
 drop table corrupted;
+create table t (
+a int,
+unique key a_key (a)
+) engine=innodb stats_persistent=1;
+SET @save_dbug = @@SESSION.debug_dbug;
+SET debug_dbug = '+d,ib_rename_index_fail1';
+alter table t
+drop key a_key,
+add unique key a_key2 (a),
+algorithm=instant;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET debug_dbug = @save_dbug;
+drop table t;

--- a/mysql-test/suite/innodb/t/innodb-index-online.test
+++ b/mysql-test/suite/innodb/t/innodb-index-online.test
@@ -223,7 +223,7 @@ SET lock_wait_timeout = 10;
 --send
 # FIXME: MDEV-13668
 #ALTER TABLE t1 CHANGE c2 c22 INT, DROP INDEX c2d, ADD INDEX c2e(c22),
-ALTER TABLE t1 DROP INDEX c2d, ADD INDEX c2e(c2),
+ALTER TABLE t1 DROP INDEX c2d, ADD INDEX c2e(c2, c3(10)),
 ALGORITHM = INPLACE;
 
 # Generate some log (delete-mark, delete-unmark, insert etc.)

--- a/mysql-test/suite/innodb/t/instant_alter_index_rename.test
+++ b/mysql-test/suite/innodb/t/instant_alter_index_rename.test
@@ -150,4 +150,12 @@ alter table t
   algorithm=instant;
 SET debug_dbug = @save_dbug;
 
+--error ER_WRONG_NAME_FOR_INDEX
+alter table t
+  drop key a_key,
+  add unique key `GEN_CLUST_INDEX` (a),
+  algorithm=instant;
+
+show create table t;
+
 drop table t;

--- a/mysql-test/suite/innodb/t/instant_alter_index_rename.test
+++ b/mysql-test/suite/innodb/t/instant_alter_index_rename.test
@@ -136,3 +136,18 @@ check table corrupted;
 
 drop table corrupted;
 
+create table t (
+  a int,
+  unique key a_key (a)
+) engine=innodb stats_persistent=1;
+
+SET @save_dbug = @@SESSION.debug_dbug;
+SET debug_dbug = '+d,ib_rename_index_fail1';
+-- error ER_LOCK_DEADLOCK
+alter table t
+  drop key a_key,
+  add unique key a_key2 (a),
+  algorithm=instant;
+SET debug_dbug = @save_dbug;
+
+drop table t;

--- a/mysql-test/suite/innodb/t/instant_alter_index_rename.test
+++ b/mysql-test/suite/innodb/t/instant_alter_index_rename.test
@@ -20,7 +20,7 @@ create table t (
   c int,
   unique index a_key (a),
   key c_key (c)
-) engine=innodb;
+) engine=innodb stats_persistent=1;
 
 insert into t values (1, 1, 1, 1);
 
@@ -30,9 +30,11 @@ set @a_key_id = get_index_id(@table_id, 'a_key');
 set @c_key_id = get_index_id(@table_id, 'c_key');
 set @primary_id = get_index_id(@table_id, 'primary');
 
+select distinct(index_name) from mysql.innodb_index_stats where table_name = 't';
 alter table t
   drop index a_key,
   add unique index a_key_strikes_back (a);
+select distinct(index_name) from mysql.innodb_index_stats where table_name = 't';
 
 check table t;
 select @a_key_id = get_index_id(@table_id, 'a_key_strikes_back'),
@@ -75,7 +77,8 @@ drop function get_index_id;
 
 create table errors (
   a int,
-  unique key a_key (a)
+  unique key a_key (a),
+  b int
 ) engine=innodb;
 
 --error ER_CANT_DROP_FIELD_OR_KEY
@@ -89,6 +92,12 @@ alter table errors
   drop key a_key,
   drop key a_key2,
   add unique key a_key2 (a);
+
+--error ER_CANT_DROP_FIELD_OR_KEY
+alter table errors
+  add key b_key (b),
+  drop key b_key,
+  add key bb_key (b);
 
 drop table errors;
 

--- a/mysql-test/suite/innodb/t/instant_alter_index_rename.test
+++ b/mysql-test/suite/innodb/t/instant_alter_index_rename.test
@@ -1,0 +1,129 @@
+--source include/have_innodb.inc
+--source include/have_debug.inc
+
+delimiter |;
+create function get_index_id(tbl_id int, index_name char(100))
+  returns int
+begin
+  declare res int;
+  select index_id into res from information_schema.innodb_sys_indexes where
+    name=index_name and table_id = tbl_id;
+  return res;
+end|
+
+delimiter ;|
+
+create table t (
+  pk int primary key,
+  a int,
+  b int,
+  c int,
+  unique index a_key (a),
+  key c_key (c)
+) engine=innodb;
+
+insert into t values (1, 1, 1, 1);
+
+set @table_id = (select table_id from information_schema.innodb_sys_tables where name='test/t');
+
+set @a_key_id = get_index_id(@table_id, 'a_key');
+set @c_key_id = get_index_id(@table_id, 'c_key');
+set @primary_id = get_index_id(@table_id, 'primary');
+
+alter table t
+  drop index a_key,
+  add unique index a_key_strikes_back (a);
+
+check table t;
+select @a_key_id = get_index_id(@table_id, 'a_key_strikes_back'),
+  @c_key_id = get_index_id(@table_id, 'c_key'),
+  @primary_id = get_index_id(@table_id, 'primary');
+
+set @a_key_strikes_back_id = get_index_id(@table_id, 'a_key_strikes_back');
+set @c_key_id = get_index_id(@table_id, 'c_key');
+set @primary_id = get_index_id(@table_id, 'primary');
+
+alter table t
+  drop index a_key_strikes_back,
+  add unique index a_key_returns (a),
+  drop primary key,
+  add primary key (pk),
+  add unique index b_key (b);
+
+check table t;
+select @a_key_strikes_back_id = get_index_id(@table_id, 'a_key_returns'),
+  @c_key_id = get_index_id(@table_id, 'c_key'),
+  @primary_id = get_index_id(@table_id, 'primary');
+
+set @a_key_returns_id = get_index_id(@table_id, 'a_key_returns');
+set @b_key_id = get_index_id(@table_id, 'b_key');
+set @c_key_id = get_index_id(@table_id, 'c_key');
+set @primary_id = get_index_id(@table_id, 'primary');
+
+alter table t
+  drop key c_key,
+  add key c_key2 (c);
+
+check table t;
+select @a_key_returns_id = get_index_id(@table_id, 'a_key_returns'),
+  @b_key_id = get_index_id(@table_id, 'b_key'),
+  @c_key_id = get_index_id(@table_id, 'c_key2'),
+  @primary_id = get_index_id(@table_id, 'primary');
+
+drop table t;
+drop function get_index_id;
+
+create table errors (
+  a int,
+  unique key a_key (a)
+) engine=innodb;
+
+--error ER_CANT_DROP_FIELD_OR_KEY
+alter table errors
+  drop key a_key,
+  drop key a_key,
+  add unique key a_key2 (a);
+
+--error ER_CANT_DROP_FIELD_OR_KEY
+alter table errors
+  drop key a_key,
+  drop key a_key2,
+  add unique key a_key2 (a);
+
+drop table errors;
+
+--disable_query_log
+call mtr.add_suppression("Flagged corruption of.* in table .* in .*");
+--enable_query_log
+
+create table corrupted (
+  a int,
+  key a_key (a)
+) engine=innodb;
+
+insert into corrupted values (1);
+
+select * from corrupted;
+
+SET @save_dbug = @@SESSION.debug_dbug;
+SET debug_dbug = '+d,dict_set_index_corrupted';
+check table corrupted;
+SET debug_dbug = @save_dbug;
+
+--error ER_INDEX_CORRUPT
+select * from corrupted;
+
+--error ER_INDEX_CORRUPT
+alter table corrupted
+  drop key a_key,
+  add key a_key2 (a);
+
+alter table corrupted
+  drop key a_key;
+
+select * from corrupted;
+
+check table corrupted;
+
+drop table corrupted;
+

--- a/mysql-test/suite/innodb/t/instant_alter_index_rename.test
+++ b/mysql-test/suite/innodb/t/instant_alter_index_rename.test
@@ -99,6 +99,13 @@ alter table errors
   drop key b_key,
   add key bb_key (b);
 
+--error ER_CANT_DROP_FIELD_OR_KEY
+alter table errors
+  drop key a_key,
+  add key a_key2 (a),
+  drop key a_key,
+  add key a_key2 (a);
+
 drop table errors;
 
 --disable_query_log

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -4519,6 +4519,29 @@ handler::check_if_supported_inplace_alter(TABLE *altered_table,
   DBUG_RETURN(HA_ALTER_INPLACE_NOT_SUPPORTED);
 }
 
+Alter_inplace_info::Alter_inplace_info(HA_CREATE_INFO *create_info_arg,
+                     Alter_info *alter_info_arg,
+                     KEY *key_info_arg, uint key_count_arg,
+                     partition_info *modified_part_info_arg,
+                     bool ignore_arg)
+    : create_info(create_info_arg),
+    alter_info(alter_info_arg),
+    key_info_buffer(key_info_arg),
+    key_count(key_count_arg),
+    index_drop_count(0),
+    index_drop_buffer(NULL),
+    index_add_count(0),
+    index_add_buffer(NULL),
+    rename_keys(current_thd->mem_root),
+    handler_ctx(NULL),
+    group_commit_ctx(NULL),
+    handler_flags(0),
+    modified_part_info(modified_part_info_arg),
+    ignore(ignore_arg),
+    online(false),
+    unsupported_reason(NULL)
+  {}
+
 void Alter_inplace_info::report_unsupported_error(const char *not_supported,
                                                   const char *try_instead) const
 {

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -43,6 +43,7 @@
 #include <keycache.h>
 #include <mysql/psi/mysql_table.h>
 #include "sql_sequence.h"
+#include <vector>
 
 class Alter_info;
 class Virtual_column_info;
@@ -607,6 +608,7 @@ typedef ulonglong alter_table_operations;
 #define ALTER_KEYS_ONOFF            (1ULL <<  9)
 // Set for FORCE, ENGINE(same engine), by mysql_recreate_table()
 #define ALTER_RECREATE              (1ULL << 10)
+#define ALTER_RENAME_INDEX          (1ULL << 11)
 // Set for ADD FOREIGN KEY
 #define ALTER_ADD_FOREIGN_KEY       (1ULL << 21)
 // Set for DROP FOREIGN KEY
@@ -2294,6 +2296,25 @@ public:
      sorted in increasing order.
   */
   uint *index_add_buffer;
+
+  /**
+     Old and new index names. Used for index rename.
+  */
+  struct Rename_key_pair
+  {
+    const KEY *old_key;
+    const KEY *new_key;
+  };
+  /**
+     Vector of key pairs from DROP/ADD index which can be renamed.
+  */
+  typedef std::vector<Rename_key_pair> Rename_keys_vector;
+
+  /**
+     A list of indexes which should be renamed.
+     Index definitions stays the same.
+  */
+  Rename_keys_vector rename_keys;
 
   /**
      Context information to allow handlers to keep context between in-place

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -43,7 +43,7 @@
 #include <keycache.h>
 #include <mysql/psi/mysql_table.h>
 #include "sql_sequence.h"
-#include <vector>
+#include "mem_root_array.h"
 
 class Alter_info;
 class Virtual_column_info;
@@ -2308,7 +2308,7 @@ public:
   /**
      Vector of key pairs from DROP/ADD index which can be renamed.
   */
-  typedef std::vector<Rename_key_pair> Rename_keys_vector;
+  typedef Mem_root_array<Rename_key_pair, true> Rename_keys_vector;
 
   /**
      A list of indexes which should be renamed.
@@ -2377,23 +2377,7 @@ public:
                      Alter_info *alter_info_arg,
                      KEY *key_info_arg, uint key_count_arg,
                      partition_info *modified_part_info_arg,
-                     bool ignore_arg)
-    : create_info(create_info_arg),
-    alter_info(alter_info_arg),
-    key_info_buffer(key_info_arg),
-    key_count(key_count_arg),
-    index_drop_count(0),
-    index_drop_buffer(NULL),
-    index_add_count(0),
-    index_add_buffer(NULL),
-    handler_ctx(NULL),
-    group_commit_ctx(NULL),
-    handler_flags(0),
-    modified_part_info(modified_part_info_arg),
-    ignore(ignore_arg),
-    online(false),
-    unsupported_reason(NULL)
-  {}
+                     bool ignore_arg);
 
   ~Alter_inplace_info()
   {

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -2302,6 +2302,10 @@ public:
   */
   struct Rename_key_pair
   {
+    Rename_key_pair(const KEY *old_key, const KEY *new_key)
+        : old_key(old_key), new_key(new_key)
+    {
+    }
     const KEY *old_key;
     const KEY *new_key;
   };

--- a/sql/mem_root_array.h
+++ b/sql/mem_root_array.h
@@ -87,9 +87,11 @@ public:
 
   // Returns a pointer to the first element in the array.
   Element_type *begin() { return &m_array[0]; }
+  const Element_type *begin() const { return &m_array[0]; }
 
   // Returns a pointer to the past-the-end element in the array.
   Element_type *end() { return &m_array[size()]; }
+  const Element_type *end() const { return &m_array[size()]; }
 
   // Erases all of the elements. 
   void clear()
@@ -226,6 +228,7 @@ public:
   size_t element_size() const { return sizeof(Element_type); }
   bool   empty()        const { return size() == 0; }
   size_t size()         const { return m_size; }
+  const MEM_ROOT *mem_root() const { return m_root; }
 
 private:
   MEM_ROOT *const m_root;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -6535,11 +6535,13 @@ static bool fill_alter_inplace_info(THD *thd,
   DBUG_PRINT("info", ("alter_info->flags: %llu", alter_info->flags));
 
   /* Allocate result buffers. */
+  DBUG_ASSERT(ha_alter_info->rename_keys.mem_root() == thd->mem_root);
   if (! (ha_alter_info->index_drop_buffer=
           (KEY**) thd->alloc(sizeof(KEY*) * table->s->keys)) ||
       ! (ha_alter_info->index_add_buffer=
           (uint*) thd->alloc(sizeof(uint) *
-                            alter_info->key_list.elements)))
+                            alter_info->key_list.elements)) ||
+      ha_alter_info->rename_keys.reserve(ha_alter_info->index_add_count))
     DBUG_RETURN(true);
 
   /*

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -6919,7 +6919,7 @@ static bool fill_alter_inplace_info(THD *thd,
       {
         ha_alter_info->handler_flags|= ALTER_RENAME_INDEX;
         ha_alter_info->rename_keys.push_back(
-            Alter_inplace_info::Rename_key_pair{old_key, new_key});
+            Alter_inplace_info::Rename_key_pair(old_key, new_key));
 
         memcpy(add_buffer + i, add_buffer + i + 1,
                sizeof(add_buffer[0]) * (add_count - i + 1));

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -6922,9 +6922,9 @@ static bool fill_alter_inplace_info(THD *thd,
             Alter_inplace_info::Rename_key_pair(old_key, new_key));
 
         memcpy(add_buffer + i, add_buffer + i + 1,
-               sizeof(add_buffer[0]) * (add_count - i + 1));
+               sizeof(add_buffer[0]) * (add_count - i - 1));
         memcpy(drop_buffer + j, drop_buffer + j + 1,
-               sizeof(drop_buffer[0]) * (drop_count - j + 1));
+               sizeof(drop_buffer[0]) * (drop_count - j - 1));
         --add_count;
         --drop_count;
         --i; // this index once again

--- a/sql/sql_table.h
+++ b/sql/sql_table.h
@@ -285,4 +285,8 @@ extern mysql_mutex_t LOCK_gdl;
 
 bool check_engine(THD *, const char *, const char *, HA_CREATE_INFO *);
 
+// Checks that key definition (not name!) has changed.
+bool key_has_changed(const KEY *table_key, const KEY *new_key,
+                     Alter_info *alter_info, const TABLE *table);
+
 #endif /* SQL_TABLE_INCLUDED */

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -3840,7 +3840,6 @@ dict_stats_rename_table(
 	return(ret);
 }
 
-#ifdef MYSQL_RENAME_INDEX
 /*********************************************************************//**
 Renames an index in InnoDB persistent stats storage.
 This function creates its own transaction and commits it.
@@ -3897,7 +3896,6 @@ dict_stats_rename_index(
 
 	return(ret);
 }
-#endif /* MYSQL_RENAME_INDEX */
 
 /* tests @{ */
 #ifdef UNIV_ENABLE_UNIT_TEST_DICT_STATS

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -9285,22 +9285,7 @@ alter_stats_rebuild(
 		DBUG_VOID_RETURN;
 	}
 
-#ifndef DBUG_OFF
-	bool	file_unreadable_orig = false;
-#endif /* DBUG_OFF */
-
-	DBUG_EXECUTE_IF(
-		"ib_rename_index_fail2",
-		file_unreadable_orig = table->file_unreadable;
-		table->file_unreadable = true;
-	);
-
 	dberr_t	ret = dict_stats_update(table, DICT_STATS_RECALC_PERSISTENT);
-
-	DBUG_EXECUTE_IF(
-		"ib_rename_index_fail2",
-		table->file_unreadable = file_unreadable_orig;
-	);
 
 	if (ret != DB_SUCCESS) {
 		push_warning_printf(
@@ -9952,11 +9937,6 @@ foreign_fail:
 			DBUG_ASSERT(0 == strcmp(ctx->old_table->name.m_name,
 						ctx->tmp_name));
 
-			DBUG_EXECUTE_IF(
-				"ib_rename_index_fail3",
-				DBUG_SET("+d,innodb_report_deadlock");
-			);
-
 			if (dict_stats_drop_table(
 				    ctx->new_table->name.m_name,
 				    errstr, sizeof(errstr))
@@ -9971,11 +9951,6 @@ foreign_fail:
 					table->s->table_name.str,
 					errstr);
 			}
-
-			DBUG_EXECUTE_IF(
-				"ib_rename_index_fail3",
-				DBUG_SET("-d,innodb_report_deadlock");
-			);
 
 			DBUG_EXECUTE_IF("ib_ddl_crash_before_commit",
 					DBUG_SUICIDE(););

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -6067,9 +6067,9 @@ static void innobase_rename_indexes_cache(
 {
 	DBUG_ASSERT(ha_alter_info->handler_flags & ALTER_RENAME_INDEX);
 
-	for (Alter_inplace_info::Rename_keys_vector::const_iterator it
+	for (const Alter_inplace_info::Rename_key_pair *it
 	     = ha_alter_info->rename_keys.begin(),
-	     end = ha_alter_info->rename_keys.end();
+	     *end = ha_alter_info->rename_keys.end();
 	     it != end; ++it) {
 		dict_index_t* index = dict_table_get_index_on_name(
 		    ctx->old_table, it->old_key->name.str);
@@ -6718,9 +6718,9 @@ err_exit:
 	}
 
 	if (ha_alter_info->handler_flags & ALTER_RENAME_INDEX) {
-		for (Alter_inplace_info::Rename_keys_vector::const_iterator it
+		for (const Alter_inplace_info::Rename_key_pair *it
 		     = ha_alter_info->rename_keys.begin(),
-		     end = ha_alter_info->rename_keys.end();
+		     *end = ha_alter_info->rename_keys.end();
 		     it != end; ++it) {
 			dict_index_t* index = dict_table_get_index_on_name(
 			    indexed_table, it->old_key->name.str);
@@ -8685,9 +8685,9 @@ static bool innobase_rename_index_try(
 {
 	DBUG_ASSERT(ha_alter_info->handler_flags & ALTER_RENAME_INDEX);
 
-	for (Alter_inplace_info::Rename_keys_vector::const_iterator it
+	for (const Alter_inplace_info::Rename_key_pair *it
 	     = ha_alter_info->rename_keys.begin(),
-	     end = ha_alter_info->rename_keys.end();
+	     *end = ha_alter_info->rename_keys.end();
 	     it != end; ++it) {
 		dict_index_t* index = dict_table_get_index_on_name(
 		    ctx->old_table, it->old_key->name.str);

--- a/storage/innobase/include/dict0stats.h
+++ b/storage/innobase/include/dict0stats.h
@@ -187,7 +187,6 @@ dict_stats_rename_table(
 	char*		errstr,		/*!< out: error string if != DB_SUCCESS
 					is returned */
 	size_t		errstr_sz);	/*!< in: errstr size */
-#ifdef MYSQL_RENAME_INDEX
 /*********************************************************************//**
 Renames an index in InnoDB persistent stats storage.
 This function creates its own transaction and commits it.
@@ -201,7 +200,6 @@ dict_stats_rename_index(
 	const char*		old_index_name,	/*!< in: old index name */
 	const char*		new_index_name)	/*!< in: new index name */
 	__attribute__((warn_unused_result));
-#endif /* MYSQL_RENAME_INDEX */
 
 /** Save an individual index's statistic into the persistent statistics
 storage.

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -40,7 +40,6 @@ class THD;
 // JAN: TODO missing features:
 #undef MYSQL_FT_INIT_EXT
 #undef MYSQL_PFS
-#undef MYSQL_RENAME_INDEX
 #undef MYSQL_STORE_FTS_DOC_ID
 
 /*******************************************************************//**


### PR DESCRIPTION
Just rename index in data dictionary and in InnoDB cache when it's possible.

Unused code between macro MYSQL_RENAME_INDEX was removed.

key_has_changed(): compary index definition but index name

ha_innobase_inplace_ctx::rename_keys: vector of rename indexes

innobase_get_change_field_keys(): get rename indexes from ADD and DROP lists

all_indexes_are_only_renamed_or_irrelevant(): check that every DROP and ADD of
an index is actually an index rename. Used by ha_innobase::check_if_supported_inplace_alter()
to check whether it's possible to do ALTER instant.

innobase_create_key_defs(): skip indexes which can be renamed

ha_innobase::prepare_inplace_alter_table(): gets and puts rename indexes into
ha_innobase_inplace_ctx

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.3-MDEV-13301-instant-index-rename)