### PR TITLE
Fixes for galera.galera_var_retry_autocommit test failure

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
+++ b/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
@@ -1,15 +1,17 @@
+connection node_2;
+connection node_1;
 connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 SET SESSION wsrep_retry_autocommit = 0;
-SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue';
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue';
 INSERT INTO t1 (f1) VALUES (2);
 connection node_1a;
-SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 connection node_2;
 TRUNCATE TABLE t1;
 connection node_1;
-ERROR 40001: Deadlock: wsrep aborted transaction
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
@@ -18,10 +20,10 @@ DROP TABLE t1;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 SET SESSION wsrep_retry_autocommit = 1;
-SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue';
-INSERT INTO t1 (f1) VALUES (2);
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue';
+INSERT INTO t1 (f1) VALUES (3);
 connection node_1a;
-SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 connection node_2;
 TRUNCATE TABLE t1;
 connection node_1;
@@ -34,10 +36,10 @@ connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 SET SESSION wsrep_retry_autocommit = 1;
 SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
-SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue EXECUTE 2';
-INSERT INTO t1 VALUES (2);;
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue EXECUTE 2';
+INSERT INTO t1 VALUES (4);;
 connection node_1a;
-SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 connection node_2;
 TRUNCATE TABLE t1;
 connection node_1a;
@@ -45,7 +47,7 @@ SET DEBUG_SYNC = 'now WAIT_FOR wsrep_retry_autocommit_reached';
 SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
-SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue WAIT_FOR before_rep';
+SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue WAIT_FOR before_cert';
 connection node_2;
 TRUNCATE TABLE t1;
 connection node_1a;
@@ -53,7 +55,7 @@ SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
 connection node_1;
-ERROR 40001: Deadlock: wsrep aborted transaction
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 SET DEBUG_SYNC = 'RESET';
 SET GLOBAL debug_dbug = NULL;
 DROP TABLE t1;
@@ -61,8 +63,8 @@ connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 SET SESSION wsrep_retry_autocommit = 64;
 SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
-SET DEBUG_SYNC = 'wsrep_before_replication SIGNAL before_rep WAIT_FOR continue EXECUTE 64';
-INSERT INTO t1 VALUES (2);
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue EXECUTE 64';
+INSERT INTO t1 VALUES (5);
 connection node_1;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1

--- a/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
+++ b/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
@@ -16,11 +16,11 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 SET SESSION wsrep_retry_autocommit = 0;
-SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_rep WAIT_FOR continue';
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue';
 --send INSERT INTO t1 (f1) VALUES (2)
 
 --connection node_1a
-SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 
 --connection node_2
 TRUNCATE TABLE t1;
@@ -42,11 +42,11 @@ DROP TABLE t1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 SET SESSION wsrep_retry_autocommit = 1;
-SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_rep WAIT_FOR continue';
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue';
 --send INSERT INTO t1 (f1) VALUES (3)
 
 --connection node_1a
-SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 
 --connection node_2
 TRUNCATE TABLE t1;
@@ -68,16 +68,12 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 SET SESSION wsrep_retry_autocommit = 1;
 SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
-SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_rep WAIT_FOR continue EXECUTE 2';
---sleep 5
-show processlist;
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue EXECUTE 2';
 
 --send INSERT INTO t1 VALUES (4);
 
 --connection node_1a
-SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
---sleep 5
-show processlist;
+SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 
 --connection node_2
 TRUNCATE TABLE t1;
@@ -85,7 +81,7 @@ TRUNCATE TABLE t1;
 --connection node_1a
 SET DEBUG_SYNC = 'now WAIT_FOR wsrep_retry_autocommit_reached';
 SELECT COUNT(*) = 0 FROM t1;
-SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue WAIT_FOR before_rep';
+SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue WAIT_FOR before_cert';
 
 --connection node_2
 TRUNCATE TABLE t1;
@@ -111,7 +107,7 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 SET SESSION wsrep_retry_autocommit = 64;
 SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
-SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_rep WAIT_FOR continue EXECUTE 64';
+SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue EXECUTE 64';
 
 --send INSERT INTO t1 VALUES (5)
 
@@ -121,7 +117,7 @@ SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_rep WAIT_FOR continue
 while ($count)
 {
   --connection node_1a
-  SET DEBUG_SYNC = 'now WAIT_FOR before_rep';
+  SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 
   --connection node_2
   TRUNCATE TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2403,6 +2403,10 @@ com_multi_end:
   /*
     BF aborted before sending response back to client
   */
+  if (thd->killed == KILL_QUERY)
+  {
+    WSREP_DEBUG("THD is killed at dispatch_end");
+  }
   wsrep_after_command_before_result(thd);
   if (wsrep_current_error(thd) &&
       !(command == COM_STMT_PREPARE          ||
@@ -7986,16 +7990,7 @@ static bool wsrep_mysql_parse(THD *thd, char *rawbuf, uint length,
   do
   {
     retry_autocommit= false;
-    DBUG_EXECUTE_IF("sync.wsrep_retry_autocommit",
-                    {
-                      const char act[]=
-                        "now "
-                        "SIGNAL wsrep_retry_autocommit_reached "
-       	                "WAIT_FOR wsrep_retry_autocommit_continue";
-       	              DBUG_ASSERT(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
-                    });
-      WSREP_DEBUG("Retry autocommit query: %s", thd->query());
-      mysql_parse(thd, rawbuf, length, parser_state, is_com_multi, is_next_command);
+    mysql_parse(thd, rawbuf, length, parser_state, is_com_multi, is_next_command);
 
     /*
       Convert all ER_QUERY_INTERRUPTED errors to ER_LOCK_DEADLOCK
@@ -8027,6 +8022,14 @@ static bool wsrep_mysql_parse(THD *thd, char *rawbuf, uint length,
           thd->lex->sql_command != SQLCOM_SELECT  &&
           thd->wsrep_retry_counter < thd->variables.wsrep_retry_autocommit)
       {
+	DBUG_EXECUTE_IF("sync.wsrep_retry_autocommit",
+                    {
+                      const char act[]=
+                        "now "
+                        "SIGNAL wsrep_retry_autocommit_reached "
+                        "WAIT_FOR wsrep_retry_autocommit_continue";
+                      DBUG_ASSERT(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
+                    });
         WSREP_DEBUG("wsrep retrying AC query: %lu  %s",
                     thd->wsrep_retry_counter, WSREP_QUERY(thd));
         wsrep_prepare_for_autocommit_retry(thd, rawbuf, length, parser_state);


### PR DESCRIPTION
The sync point for sync.wsrep_retry_autocommit was in wrong place in sql_parse.cc,
this is now fixed
The mtr test galera_var_retry_autocommit.test contained some apparently
debugging time additions, (like sleeps), these are rmoved
Also, sync point change from before_rep was changed to before_cert, due to
wsrep API change.