### PR TITLE
Fix for galera as slave tests

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_gtid_replicate_do_db.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_gtid_replicate_do_db.result
@@ -1,19 +1,18 @@
-connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2;
 connection node_1;
-connection node_1;
-RESET MASTER;
 connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
-connection node_3;
+connection node_1;
 SET global wsrep_on=OFF;
 RESET MASTER;
 SET global wsrep_on=ON;
+connection node_3;
+RESET MASTER;
 connection node_2;
 SET global wsrep_on=OFF;
 RESET MASTER;
 SET global wsrep_on=ON;
 START SLAVE;
-connection node_1;
+connection node_3;
 CREATE SCHEMA test1;
 CREATE SCHEMA test2;
 USE test1;
@@ -47,99 +46,99 @@ SHOW BINLOG EVENTS IN 'master-bin.000001' FROM 256;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	256	Gtid_list	2	285	[]
 master-bin.000001	285	Binlog_checkpoint	2	329	master-bin.000001
-master-bin.000001	329	Gtid	1	371	GTID 0-1-1
-master-bin.000001	371	Query	1	458	CREATE SCHEMA test1
-master-bin.000001	458	Gtid	1	500	GTID 0-1-3
-master-bin.000001	500	Query	1	647	use `test1`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY,f2 CHAR(5) DEFAULT 'abc') ENGINE=InnoDB
-master-bin.000001	647	Gtid	1	689	BEGIN GTID 0-1-5
-master-bin.000001	689	Annotate_rows	1	748	INSERT INTO test1.t1 (f1) VALUES (1)
-master-bin.000001	748	Table_map	1	797	table_id: ### (test1.t1)
-master-bin.000001	797	Write_rows_v1	1	839	table_id: ### flags: STMT_END_F
-master-bin.000001	839	Xid	1	870	COMMIT /* xid=### */
-master-bin.000001	870	Gtid	1	912	BEGIN GTID 0-1-7
-master-bin.000001	912	Annotate_rows	1	971	INSERT INTO test1.t1 (f1) VALUES (2)
-master-bin.000001	971	Table_map	1	1020	table_id: ### (test1.t1)
-master-bin.000001	1020	Write_rows_v1	1	1062	table_id: ### flags: STMT_END_F
-master-bin.000001	1062	Xid	1	1093	COMMIT /* xid=### */
-master-bin.000001	1093	Gtid	1	1135	BEGIN GTID 0-1-9
-master-bin.000001	1135	Annotate_rows	1	1194	INSERT INTO test1.t1 (f1) VALUES (3)
-master-bin.000001	1194	Table_map	1	1243	table_id: ### (test1.t1)
-master-bin.000001	1243	Write_rows_v1	1	1285	table_id: ### flags: STMT_END_F
-master-bin.000001	1285	Xid	1	1316	COMMIT /* xid=### */
-master-bin.000001	1316	Gtid	1	1358	BEGIN GTID 0-1-12
-master-bin.000001	1358	Annotate_rows	1	1451	UPDATE test1.t1, test2.t1 SET test1.t1.f2 = 'klm', test2.t1.f2 = 'xyz'
-master-bin.000001	1451	Table_map	1	1500	table_id: ### (test1.t1)
-master-bin.000001	1500	Update_rows_v1	1	1588	table_id: ### flags: STMT_END_F
-master-bin.000001	1588	Xid	1	1619	COMMIT /* xid=### */
-master-bin.000001	1619	Gtid	1	1661	BEGIN GTID 0-1-13
-master-bin.000001	1661	Annotate_rows	1	1795	DELETE test1.t1, test2.t1 FROM test1.t1 INNER JOIN test2.t1 WHERE test1.t1.f1 = test2.t1.f1 AND test1.t1.f1 = 3
-master-bin.000001	1795	Table_map	1	1844	table_id: ### (test1.t1)
-master-bin.000001	1844	Delete_rows_v1	1	1886	table_id: ### flags: STMT_END_F
-master-bin.000001	1886	Xid	1	1917	COMMIT /* xid=### */
-master-bin.000001	1917	Gtid	1	1959	BEGIN GTID 0-1-15
-master-bin.000001	1959	Annotate_rows	1	2020	INSERT INTO test1.t1 (f1) VALUES (111)
-master-bin.000001	2020	Table_map	1	2069	table_id: ### (test1.t1)
-master-bin.000001	2069	Write_rows_v1	1	2111	table_id: ### flags: STMT_END_F
-master-bin.000001	2111	Annotate_rows	1	2172	INSERT INTO test1.t1 (f1) VALUES (222)
-master-bin.000001	2172	Table_map	1	2221	table_id: ### (test1.t1)
-master-bin.000001	2221	Write_rows_v1	1	2263	table_id: ### flags: STMT_END_F
-master-bin.000001	2263	Xid	1	2294	COMMIT /* xid=### */
-master-bin.000001	2294	Gtid	1	2336	BEGIN GTID <effective_uuid>
-master-bin.000001	2336	Annotate_rows	1	2397	INSERT INTO test1.t1 (f1) VALUES (333)
-master-bin.000001	2397	Table_map	1	2446	table_id: ### (test1.t1)
-master-bin.000001	2446	Write_rows_v1	1	2488	table_id: ### flags: STMT_END_F
-master-bin.000001	2488	Xid	1	2519	COMMIT /* xid=### */
-connection node_3;
+master-bin.000001	329	Gtid	3	371	GTID 0-3-1
+master-bin.000001	371	Query	3	458	CREATE SCHEMA test1
+master-bin.000001	458	Gtid	3	500	GTID 0-3-3
+master-bin.000001	500	Query	3	647	use `test1`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY,f2 CHAR(5) DEFAULT 'abc') ENGINE=InnoDB
+master-bin.000001	647	Gtid	3	689	BEGIN GTID 0-3-5
+master-bin.000001	689	Annotate_rows	3	748	INSERT INTO test1.t1 (f1) VALUES (1)
+master-bin.000001	748	Table_map	3	797	table_id: ### (test1.t1)
+master-bin.000001	797	Write_rows_v1	3	839	table_id: ### flags: STMT_END_F
+master-bin.000001	839	Xid	3	870	COMMIT /* xid=### */
+master-bin.000001	870	Gtid	3	912	BEGIN GTID 0-3-7
+master-bin.000001	912	Annotate_rows	3	971	INSERT INTO test1.t1 (f1) VALUES (2)
+master-bin.000001	971	Table_map	3	1020	table_id: ### (test1.t1)
+master-bin.000001	1020	Write_rows_v1	3	1062	table_id: ### flags: STMT_END_F
+master-bin.000001	1062	Xid	3	1093	COMMIT /* xid=### */
+master-bin.000001	1093	Gtid	3	1135	BEGIN GTID 0-3-9
+master-bin.000001	1135	Annotate_rows	3	1194	INSERT INTO test1.t1 (f1) VALUES (3)
+master-bin.000001	1194	Table_map	3	1243	table_id: ### (test1.t1)
+master-bin.000001	1243	Write_rows_v1	3	1285	table_id: ### flags: STMT_END_F
+master-bin.000001	1285	Xid	3	1316	COMMIT /* xid=### */
+master-bin.000001	1316	Gtid	3	1358	BEGIN GTID 0-3-12
+master-bin.000001	1358	Annotate_rows	3	1451	UPDATE test1.t1, test2.t1 SET test1.t1.f2 = 'klm', test2.t1.f2 = 'xyz'
+master-bin.000001	1451	Table_map	3	1500	table_id: ### (test1.t1)
+master-bin.000001	1500	Update_rows_v1	3	1588	table_id: ### flags: STMT_END_F
+master-bin.000001	1588	Xid	3	1619	COMMIT /* xid=### */
+master-bin.000001	1619	Gtid	3	1661	BEGIN GTID 0-3-13
+master-bin.000001	1661	Annotate_rows	3	1795	DELETE test1.t1, test2.t1 FROM test1.t1 INNER JOIN test2.t1 WHERE test1.t1.f1 = test2.t1.f1 AND test1.t1.f1 = 3
+master-bin.000001	1795	Table_map	3	1844	table_id: ### (test1.t1)
+master-bin.000001	1844	Delete_rows_v1	3	1886	table_id: ### flags: STMT_END_F
+master-bin.000001	1886	Xid	3	1917	COMMIT /* xid=### */
+master-bin.000001	1917	Gtid	3	1959	BEGIN GTID 0-3-15
+master-bin.000001	1959	Annotate_rows	3	2020	INSERT INTO test1.t1 (f1) VALUES (111)
+master-bin.000001	2020	Table_map	3	2069	table_id: ### (test1.t1)
+master-bin.000001	2069	Write_rows_v1	3	2111	table_id: ### flags: STMT_END_F
+master-bin.000001	2111	Annotate_rows	3	2172	INSERT INTO test1.t1 (f1) VALUES (222)
+master-bin.000001	2172	Table_map	3	2221	table_id: ### (test1.t1)
+master-bin.000001	2221	Write_rows_v1	3	2263	table_id: ### flags: STMT_END_F
+master-bin.000001	2263	Xid	3	2294	COMMIT /* xid=### */
+master-bin.000001	2294	Gtid	3	2336	BEGIN GTID <effective_uuid>
+master-bin.000001	2336	Annotate_rows	3	2397	INSERT INTO test1.t1 (f1) VALUES (333)
+master-bin.000001	2397	Table_map	3	2446	table_id: ### (test1.t1)
+master-bin.000001	2446	Write_rows_v1	3	2488	table_id: ### flags: STMT_END_F
+master-bin.000001	2488	Xid	3	2519	COMMIT /* xid=### */
+connection node_1;
 gtid_executed_equal
 0
 SHOW BINLOG EVENTS IN 'master-bin.000001' FROM 256;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-master-bin.000001	256	Gtid_list	3	285	[]
-master-bin.000001	285	Binlog_checkpoint	3	329	master-bin.000001
-master-bin.000001	329	Gtid	1	371	GTID 0-1-1
-master-bin.000001	371	Query	1	458	CREATE SCHEMA test1
-master-bin.000001	458	Gtid	1	500	GTID 0-1-2
-master-bin.000001	500	Query	1	647	use `test1`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY,f2 CHAR(5) DEFAULT 'abc') ENGINE=InnoDB
-master-bin.000001	647	Gtid	1	689	BEGIN GTID 0-1-3
-master-bin.000001	689	Annotate_rows	1	748	INSERT INTO test1.t1 (f1) VALUES (1)
-master-bin.000001	748	Table_map	1	797	table_id: ### (test1.t1)
-master-bin.000001	797	Write_rows_v1	1	839	table_id: ### flags: STMT_END_F
-master-bin.000001	839	Xid	1	870	COMMIT /* xid=### */
-master-bin.000001	870	Gtid	1	912	BEGIN GTID 0-1-4
-master-bin.000001	912	Annotate_rows	1	971	INSERT INTO test1.t1 (f1) VALUES (2)
-master-bin.000001	971	Table_map	1	1020	table_id: ### (test1.t1)
-master-bin.000001	1020	Write_rows_v1	1	1062	table_id: ### flags: STMT_END_F
-master-bin.000001	1062	Xid	1	1093	COMMIT /* xid=### */
-master-bin.000001	1093	Gtid	1	1135	BEGIN GTID 0-1-5
-master-bin.000001	1135	Annotate_rows	1	1194	INSERT INTO test1.t1 (f1) VALUES (3)
-master-bin.000001	1194	Table_map	1	1243	table_id: ### (test1.t1)
-master-bin.000001	1243	Write_rows_v1	1	1285	table_id: ### flags: STMT_END_F
-master-bin.000001	1285	Xid	1	1316	COMMIT /* xid=### */
-master-bin.000001	1316	Gtid	1	1358	BEGIN GTID 0-1-6
-master-bin.000001	1358	Annotate_rows	1	1451	UPDATE test1.t1, test2.t1 SET test1.t1.f2 = 'klm', test2.t1.f2 = 'xyz'
-master-bin.000001	1451	Table_map	1	1500	table_id: ### (test1.t1)
-master-bin.000001	1500	Update_rows_v1	1	1588	table_id: ### flags: STMT_END_F
-master-bin.000001	1588	Xid	1	1619	COMMIT /* xid=### */
-master-bin.000001	1619	Gtid	1	1661	BEGIN GTID 0-1-7
-master-bin.000001	1661	Annotate_rows	1	1795	DELETE test1.t1, test2.t1 FROM test1.t1 INNER JOIN test2.t1 WHERE test1.t1.f1 = test2.t1.f1 AND test1.t1.f1 = 3
-master-bin.000001	1795	Table_map	1	1844	table_id: ### (test1.t1)
-master-bin.000001	1844	Delete_rows_v1	1	1886	table_id: ### flags: STMT_END_F
-master-bin.000001	1886	Xid	1	1917	COMMIT /* xid=### */
-master-bin.000001	1917	Gtid	1	1959	BEGIN GTID 0-1-8
-master-bin.000001	1959	Annotate_rows	1	2020	INSERT INTO test1.t1 (f1) VALUES (111)
-master-bin.000001	2020	Table_map	1	2069	table_id: ### (test1.t1)
-master-bin.000001	2069	Write_rows_v1	1	2111	table_id: ### flags: STMT_END_F
-master-bin.000001	2111	Annotate_rows	1	2172	INSERT INTO test1.t1 (f1) VALUES (222)
-master-bin.000001	2172	Table_map	1	2221	table_id: ### (test1.t1)
-master-bin.000001	2221	Write_rows_v1	1	2263	table_id: ### flags: STMT_END_F
-master-bin.000001	2263	Xid	1	2294	COMMIT /* xid=### */
-master-bin.000001	2294	Gtid	1	2336	BEGIN GTID 0-1-9
-master-bin.000001	2336	Annotate_rows	1	2397	INSERT INTO test1.t1 (f1) VALUES (333)
-master-bin.000001	2397	Table_map	1	2446	table_id: ### (test1.t1)
-master-bin.000001	2446	Write_rows_v1	1	2488	table_id: ### flags: STMT_END_F
-master-bin.000001	2488	Xid	1	2519	COMMIT /* xid=### */
-include/diff_servers.inc [servers=2 3]
-connection node_3;
+master-bin.000001	256	Gtid_list	1	285	[]
+master-bin.000001	285	Binlog_checkpoint	1	329	master-bin.000001
+master-bin.000001	329	Gtid	3	371	GTID 0-3-1
+master-bin.000001	371	Query	3	458	CREATE SCHEMA test1
+master-bin.000001	458	Gtid	3	500	GTID 0-3-2
+master-bin.000001	500	Query	3	647	use `test1`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY,f2 CHAR(5) DEFAULT 'abc') ENGINE=InnoDB
+master-bin.000001	647	Gtid	3	689	BEGIN GTID 0-3-3
+master-bin.000001	689	Annotate_rows	3	748	INSERT INTO test1.t1 (f1) VALUES (1)
+master-bin.000001	748	Table_map	3	797	table_id: ### (test1.t1)
+master-bin.000001	797	Write_rows_v1	3	839	table_id: ### flags: STMT_END_F
+master-bin.000001	839	Xid	3	870	COMMIT /* xid=### */
+master-bin.000001	870	Gtid	3	912	BEGIN GTID 0-3-4
+master-bin.000001	912	Annotate_rows	3	971	INSERT INTO test1.t1 (f1) VALUES (2)
+master-bin.000001	971	Table_map	3	1020	table_id: ### (test1.t1)
+master-bin.000001	1020	Write_rows_v1	3	1062	table_id: ### flags: STMT_END_F
+master-bin.000001	1062	Xid	3	1093	COMMIT /* xid=### */
+master-bin.000001	1093	Gtid	3	1135	BEGIN GTID 0-3-5
+master-bin.000001	1135	Annotate_rows	3	1194	INSERT INTO test1.t1 (f1) VALUES (3)
+master-bin.000001	1194	Table_map	3	1243	table_id: ### (test1.t1)
+master-bin.000001	1243	Write_rows_v1	3	1285	table_id: ### flags: STMT_END_F
+master-bin.000001	1285	Xid	3	1316	COMMIT /* xid=### */
+master-bin.000001	1316	Gtid	3	1358	BEGIN GTID 0-3-6
+master-bin.000001	1358	Annotate_rows	3	1451	UPDATE test1.t1, test2.t1 SET test1.t1.f2 = 'klm', test2.t1.f2 = 'xyz'
+master-bin.000001	1451	Table_map	3	1500	table_id: ### (test1.t1)
+master-bin.000001	1500	Update_rows_v1	3	1588	table_id: ### flags: STMT_END_F
+master-bin.000001	1588	Xid	3	1619	COMMIT /* xid=### */
+master-bin.000001	1619	Gtid	3	1661	BEGIN GTID 0-3-7
+master-bin.000001	1661	Annotate_rows	3	1795	DELETE test1.t1, test2.t1 FROM test1.t1 INNER JOIN test2.t1 WHERE test1.t1.f1 = test2.t1.f1 AND test1.t1.f1 = 3
+master-bin.000001	1795	Table_map	3	1844	table_id: ### (test1.t1)
+master-bin.000001	1844	Delete_rows_v1	3	1886	table_id: ### flags: STMT_END_F
+master-bin.000001	1886	Xid	3	1917	COMMIT /* xid=### */
+master-bin.000001	1917	Gtid	3	1959	BEGIN GTID 0-3-8
+master-bin.000001	1959	Annotate_rows	3	2020	INSERT INTO test1.t1 (f1) VALUES (111)
+master-bin.000001	2020	Table_map	3	2069	table_id: ### (test1.t1)
+master-bin.000001	2069	Write_rows_v1	3	2111	table_id: ### flags: STMT_END_F
+master-bin.000001	2111	Annotate_rows	3	2172	INSERT INTO test1.t1 (f1) VALUES (222)
+master-bin.000001	2172	Table_map	3	2221	table_id: ### (test1.t1)
+master-bin.000001	2221	Write_rows_v1	3	2263	table_id: ### flags: STMT_END_F
+master-bin.000001	2263	Xid	3	2294	COMMIT /* xid=### */
+master-bin.000001	2294	Gtid	3	2336	BEGIN GTID 0-3-9
+master-bin.000001	2336	Annotate_rows	3	2397	INSERT INTO test1.t1 (f1) VALUES (333)
+master-bin.000001	2397	Table_map	3	2446	table_id: ### (test1.t1)
+master-bin.000001	2446	Write_rows_v1	3	2488	table_id: ### flags: STMT_END_F
+master-bin.000001	2488	Xid	3	2519	COMMIT /* xid=### */
+include/diff_servers.inc [servers=1 2]
+connection node_1;
 SELECT COUNT(*) = 2 FROM test1.t1 WHERE f1 IN (1,2);
 COUNT(*) = 2
 1
@@ -151,10 +150,10 @@ COUNT(*) = 2
 1
 USE test2;
 ERROR 42000: Unknown database 'test2'
-connection node_1;
+connection node_3;
 DROP SCHEMA test1;
 DROP SCHEMA test2;
-connection node_3;
+connection node_1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;

--- a/mysql-test/suite/galera/r/galera_gtid_slave.result
+++ b/mysql-test/suite/galera/r/galera_gtid_slave.result
@@ -1,9 +1,9 @@
-connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2;
 connection node_1;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
 connection node_2;
 START SLAVE;
-connection node_1;
+connection node_3;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES(1);
@@ -13,32 +13,31 @@ insert into t2 values(22);
 commit;
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-1-1-4
+2-3-4
 connection node_2;
 INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(3);
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-1-1-4,2-2-2
-connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+0-2-2,2-3-4
+connection node_1;
 INSERT INTO t1 VALUES(4);
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-1-1-4,2-2-2,2-3-3
-connection node_1;
-DROP TABLE t1,t2;
-SET GLOBAL wsrep_on=OFF;
-reset master;
-SET GLOBAL wsrep_on=ON;
-connection node_2;
+1-1-1,2-3-4,2-2-6
 connection node_3;
+DROP TABLE t1,t2;
+connection node_2;
+connection node_1;
 connection node_2;
 STOP SLAVE;
 RESET SLAVE ALL;
 SET GLOBAL wsrep_on=OFF;
 reset master;
 SET GLOBAL wsrep_on=ON;
-connection node_3;
+connection node_1;
 SET GLOBAL wsrep_on=OFF;
 reset master;
 SET GLOBAL wsrep_on=ON;
+connection node_3;
+reset master;

--- a/mysql-test/suite/galera/r/galera_gtid_slave_sst_rsync.result
+++ b/mysql-test/suite/galera/r/galera_gtid_slave_sst_rsync.result
@@ -12,27 +12,27 @@ INSERT INTO t2 VALUES(2,22);
 INSERT INTO t2 VALUES(3,33);
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-2-1-4
+2-3-4
 include/save_master_gtid.inc
 #Connection 2
 connection node_2;
 include/sync_with_master_gtid.inc
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-2-1-4
+2-3-4
 INSERT INTO t2 VALUES(4,44);
 INSERT INTO t2 VALUES(5,55);
 INSERT INTO t2 VALUES(6,66);
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-0-2-3,2-1-4
+0-2-3,2-3-4
 #Connection 1
 connection node_1;
 INSERT INTO t2 VALUES(7,77);
 INSERT INTO t2 VALUES(8,88);
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-1-3-2,2-1-4,2-2-7
+1-1-2,2-3-4,2-2-7
 #Connection 3
 connection node_3;
 CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
@@ -100,12 +100,12 @@ node2_committed_before
 connection node_1;
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-1-3-3,2-1-6,2-2-9
+1-1-3,2-3-6,2-2-9
 #Connection 2
 connection node_2;
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-0-3-7,0-2-8,2-1-6
+0-1-7,0-2-8,2-3-6
 #Connection 3
 connection node_3;
 SET AUTOCOMMIT=ON;
@@ -134,7 +134,7 @@ count(*)
 12
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-0-3-7,0-2-11,2-1-7
+0-1-7,0-2-11,2-3-7
 #Connection 1
 connection node_1;
 SELECT count(*) from t1;
@@ -142,7 +142,7 @@ count(*)
 12
 SELECT @@global.gtid_binlog_state;
 @@global.gtid_binlog_state
-1-3-3,2-1-7,2-2-12
+1-1-3,2-3-7,2-2-12
 #Connection 3
 connection node_3;
 DROP TABLE t2,t1;

--- a/mysql-test/suite/galera/t/galera_as_slave_gtid_replicate_do_db.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_gtid_replicate_do_db.test
@@ -3,33 +3,31 @@
 #
 
 --source include/have_innodb.inc
+--source include/galera_cluster.inc
 --source include/have_log_bin.inc
 
-# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
---connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
---source include/galera_cluster.inc
+# As node #3 is not a Galera node, and galera_cluster.inc does not open connetion to it
+# we open the node_3 connection here
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 
 --connection node_1
 SET global wsrep_on=OFF;
 RESET MASTER;
 SET global wsrep_on=ON;
 
---connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
-SET global wsrep_on=OFF;
 RESET MASTER;
-SET global wsrep_on=ON;
 
 --connection node_2
 SET global wsrep_on=OFF;
 RESET MASTER;
 SET global wsrep_on=ON;
 --disable_query_log
---eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_1, MASTER_USER='root';
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$NODE_MYPORT_3, MASTER_USER='root';
 --enable_query_log
 START SLAVE;
 
---connection node_1
+--connection node_3
 CREATE SCHEMA test1;
 CREATE SCHEMA test2;
 USE test1;
@@ -102,7 +100,7 @@ COMMIT;
 --replace_regex /xid=[0-9]+/xid=###/ /table_id: [0-9]+/table_id: ###/
 SHOW BINLOG EVENTS IN 'master-bin.000001' FROM 256;
 
---connection node_3
+--connection node_1
 
 --disable_query_log
 --eval SELECT '$gtid_executed_node2' = @@global.gtid_current_pos AS gtid_executed_equal;
@@ -116,10 +114,10 @@ SHOW BINLOG EVENTS IN 'master-bin.000001' FROM 256;
 # Final consistency checks
 # 
 
---let $diff_servers = 2 3
+--let $diff_servers = 1 2
 --source include/diff_servers.inc
 
---connection node_3
+--connection node_1
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 
@@ -134,13 +132,13 @@ USE test2;
 # Cleanup
 #
 
---connection node_1
+--connection node_3
 DROP SCHEMA test1;
 DROP SCHEMA test2;
 
 --sleep 1
 
---connection node_3
+--connection node_1
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/galera/t/galera_gtid_slave.test
+++ b/mysql-test/suite/galera/t/galera_gtid_slave.test
@@ -8,18 +8,19 @@
 #
 
 --source include/have_innodb.inc
-
-# As node #1 is not a Galera node, we connect to node #2 in order to run include/galera_cluster.inc
---connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
 --source include/galera_cluster.inc
+
+# As node #3 is not a Galera node, and galera_cluster.inc does not open connetion to it
+# we open the node_3 connection here
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 
 --connection node_2
 --disable_query_log
---eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_PORT=$NODE_MYPORT_1;
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_PORT=$NODE_MYPORT_3;
 --enable_query_log
 START SLAVE;
 
---connection node_1
+--connection node_3
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES(1);
@@ -49,18 +50,16 @@ INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(3);
 SELECT @@global.gtid_binlog_state;
 
---connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_1
 --let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
 --source include/wait_condition.inc
 
 INSERT INTO t1 VALUES(4);
 SELECT @@global.gtid_binlog_state;
 
---connection node_1
+--connection node_3
 DROP TABLE t1,t2;
-SET GLOBAL wsrep_on=OFF;
-reset master;
-SET GLOBAL wsrep_on=ON;
+
 #
 # Unfortunately without the sleep below the following statement fails with "query returned no rows", which
 # is difficult to understand given that it is an aggregate query. A "query execution was interrupted"
@@ -73,7 +72,7 @@ SET GLOBAL wsrep_on=ON;
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 
---connection node_3
+--connection node_1
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc
 
@@ -84,10 +83,10 @@ SET GLOBAL wsrep_on=OFF;
 reset master;
 SET GLOBAL wsrep_on=ON;
 
---connection node_3
+--connection node_1
 SET GLOBAL wsrep_on=OFF;
 reset master;
 SET GLOBAL wsrep_on=ON;
 
---connection node_1
+--connection node_3
 reset master;

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -269,8 +269,9 @@ EOF
             cd $BINLOG_DIRNAME
 
             if ! [ -z $WSREP_SST_OPT_BINLOG_INDEX ]
-               binlog_files_full=$(tail -n $BINLOG_N_FILES ${BINLOG_FILENAME}.index)
             then
+               binlog_files_full=$(tail -n $BINLOG_N_FILES ${BINLOG_FILENAME}.index)
+            else
                cd $BINLOG_INDEX_DIRNAME
                binlog_files_full=$(tail -n $BINLOG_N_FILES ${BINLOG_INDEX_FILENAME}.index)
             fi
@@ -508,9 +509,10 @@ EOF
             for ii in $(ls -1 ${BINLOG_FILENAME}.*)
             do
                 if ! [ -z $WSREP_SST_OPT_BINLOG_INDEX ]
-                  echo ${BINLOG_DIRNAME}/${ii} >> ${BINLOG_FILENAME}.index
-		then
-                  echo ${BINLOG_DIRNAME}/${ii} >> ${BINLOG_INDEX_DIRNAME}/${BINLOG_INDEX_FILENAME}.index
+                then
+                    echo ${BINLOG_DIRNAME}/${ii} >> ${BINLOG_FILENAME}.index
+                else
+                    echo ${BINLOG_DIRNAME}/${ii} >> ${BINLOG_INDEX_DIRNAME}/${BINLOG_INDEX_FILENAME}.index
                 fi
             done
         fi


### PR DESCRIPTION
* Fixed: galera_gtid_slave, galera_gtid_slave_sst_rsync and galera_as_slave_gtid_replicate_do_db.
* Galera as slave configurations galera nodes are using mysqld.1 and mysqld.2. Fixed to use that nodes and re-recorded.
* Use different name for log-bin-index than log-bin.