### PR TITLE
MDEV-17883 CREATE TABLE IF NOT EXISTS locking changes in 10.3.10

### DIFF
--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -3856,8 +3856,8 @@ lock_table_names(THD *thd, const DDL_options_st &options,
 
     if (create_table)
 #ifdef WITH_WSREP
-      if (thd->lex->sql_command != SQLCOM_CREATE_TABLE &&
-          thd->wsrep_exec_mode != REPL_RECV)
+      if (!(thd->lex->sql_command == SQLCOM_CREATE_TABLE &&
+            thd->wsrep_exec_mode  == REPL_RECV))
 #endif
       lock_wait_timeout= 0;                     // Don't wait for timeout
   }


### PR DESCRIPTION
MDEV-15845 introduced IF statement which didn't allow to set lock_wait_timeout= 0. Intention was to keep provided value only if command is SQLCOM_CREATE_TABLE and thread is galera applier (REPL_RECV). 
MDEV-15845 introduced wrong logic so fixing it with this commit.