### PR TITLE
MDEV-19206: cmake: support new libedit interface

### DIFF
--- a/cmake/readline.cmake
+++ b/cmake/readline.cmake
@@ -160,8 +160,20 @@ MACRO (MYSQL_FIND_SYSTEM_LIBEDIT)
       int res= (*rl_completion_entry_function)(0,0);
       completion_matches(0,0);
     }"
-    LIBEDIT_INTERFACE)
-    SET(USE_LIBEDIT_INTERFACE ${LIBEDIT_INTERFACE})
+    LIBEDIT_HAVE_COMPLETION_INT)
+
+    CHECK_CXX_SOURCE_COMPILES("
+    #include <stdio.h>
+    #include <readline.h>
+    int main(int argc, char **argv)
+    {
+      char res= *(*rl_completion_entry_function)(0,0);
+      completion_matches(0,0);
+    }"
+    LIBEDIT_HAVE_COMPLETION_CHAR)
+    IF(LIBEDIT_HAVE_COMPLETION_INT OR LIBEDIT_HAVE_COMPLETION_CHAR)
+      SET(USE_LIBEDIT_INTERFACE 1)
+    ENDIF()
   ENDIF()
 ENDMACRO()
 
@@ -187,6 +199,7 @@ MACRO (MYSQL_CHECK_READLINE)
         IF(USE_LIBEDIT_INTERFACE)
           SET(MY_READLINE_INCLUDE_DIR ${LIBEDIT_INCLUDE_DIR})
           SET(MY_READLINE_LIBRARY ${LIBEDIT_LIBRARY} ${CURSES_LIBRARY})
+          SET(USE_NEW_READLINE_INTERFACE ${LIBEDIT_HAVE_COMPLETION_CHAR})
         ELSE()
           MYSQL_USE_BUNDLED_READLINE()
         ENDIF()


### PR DESCRIPTION
libedit changed it's interface a while ago. MariaDB's cmake file doesn't
recognize the new interface, the compile test fails:

/mariadb-10.2.19/CMakeFiles/CMakeTmp/src.cxx: In function 'int main(int, char**)':
/mariadb-10.2.19/CMakeFiles/CMakeTmp/src.cxx:6:47: error: invalid conversion from 'char*' to 'int' [-fpermissive]
  int res= (*rl_completion_entry_function)(0,0);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~

Fix this by adding a detection for the new interface as well.

In client/mysql.cc the ifdefs for the new readline interface are
extended to also check for the new libedit interface. They work the same
way.

Run-tested on a MIPS machine.

Signed-off-by: Sebastian Kemper <sebastian_ml@gmx.net>