### PR TITLE
MDEV-17965 Allow instant VARCHAR increase of indexed fields

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_varchar.result
+++ b/mysql-test/suite/innodb/r/instant_alter_varchar.result
@@ -1,0 +1,65 @@
+create table t (
+a varchar(25),
+b varchar(25) unique key,
+c varchar(25) primary key
+) engine=innodb;
+insert into t values
+('AAA', 'AAA', 'AAA'),
+('bbb', 'bbb', 'bbb'),
+('CCC', 'CCC', 'CCC');
+select a from t order by a;
+a
+AAA
+bbb
+CCC
+select b from t order by b;
+b
+AAA
+bbb
+CCC
+select c from t order by c;
+c
+AAA
+bbb
+CCC
+alter table t modify a varchar(50), algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify b varchar(50), algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify c varchar(50), algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+update t set a=concat(a, a), b=concat(b, b), c=concat(c, c);
+select a from t order by a;
+a
+AAAAAA
+bbbbbb
+CCCCCC
+select b from t order by b;
+b
+AAAAAA
+bbbbbb
+CCCCCC
+select c from t order by c;
+c
+AAAAAA
+bbbbbb
+CCCCCC
+drop table t;
+create table innodb_internals_specific (
+a varchar(150) unique key
+) engine=innodb;
+alter table innodb_internals_specific modify a varchar(350), algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table innodb_internals_specific;
+create table errors (
+a varchar(100) unique key
+) engine=innodb;
+alter table errors modify a varchar(99), algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY
+drop table errors;

--- a/mysql-test/suite/innodb/t/instant_alter_varchar.test
+++ b/mysql-test/suite/innodb/t/instant_alter_varchar.test
@@ -1,0 +1,52 @@
+--source include/innodb_row_format.inc
+
+create table t (
+  a varchar(25),
+  b varchar(25) unique key,
+  c varchar(25) primary key
+) engine=innodb;
+
+insert into t values
+  ('AAA', 'AAA', 'AAA'),
+  ('bbb', 'bbb', 'bbb'),
+  ('CCC', 'CCC', 'CCC');
+
+select a from t order by a;
+select b from t order by b;
+select c from t order by c;
+
+alter table t modify a varchar(50), algorithm=instant;
+check table t;
+
+alter table t modify b varchar(50), algorithm=instant;
+check table t;
+
+alter table t modify c varchar(50), algorithm=instant;
+check table t;
+
+update t set a=concat(a, a), b=concat(b, b), c=concat(c, c);
+
+select a from t order by a;
+select b from t order by b;
+select c from t order by c;
+
+drop table t;
+
+# can not increase size from less than 256 to more or equal than 256
+create table innodb_internals_specific (
+  a varchar(150) unique key
+) engine=innodb;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table innodb_internals_specific modify a varchar(350), algorithm=instant;
+
+drop table innodb_internals_specific;
+
+create table errors (
+  a varchar(100) unique key
+) engine=innodb;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table errors modify a varchar(99), algorithm=instant;
+
+drop table errors;


### PR DESCRIPTION
Allow instant increase of size of VARCHAR if field is indexed and engine
supports such stuff. Right now only InnoDB can do this.

Only metadata for table column is changes so it's safe to perform such operation
on indexed fields.

fill_inplace_alter_info(): when comparing key parts of an old and new index
do actually compare types and treat key parts as equal if types are
IS_EQUAL_PACK_LENGTH.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.4-MDEV-17965-increase-varchar-indexed)