### PR TITLE
MDEV-13095 Implement User Account locking

### DIFF
--- a/mysql-test/main/lock_user.result
+++ b/mysql-test/main/lock_user.result
@@ -1,0 +1,134 @@
+create user user1@localhost;
+create user user2@localhost;
+#
+# Only privileged users should be able to lock/unlock.
+#
+alter user user1@localhost account lock;
+alter user user1@localhost account unlock;
+create user user3@localhost account lock;
+drop user user3@localhost;
+connect con1,localhost,user1;
+connection con1;
+alter user user2@localhost account lock;
+ERROR 42000: Access denied; you need (at least one of) the CREATE USER privilege(s) for this operation
+disconnect con1;
+connection default;
+#
+# ALTER USER USER1 ACCOUNT LOCK should deny the connection of user1,
+# but it should allow user2 to connect.
+#
+alter user user1@localhost account lock;
+connect(localhost,user1,,test,MYSQL_PORT,MYSQL_SOCK);
+connect con1,localhost,user1;
+ERROR HY000: Access denied, this account is locked
+connect con2,localhost,user2;
+disconnect con2;
+connection default;
+alter user user1@localhost account unlock;
+#
+# Passing an incorrect user should return an error unless
+# IF EXISTS is used
+#
+alter user inexistentUser@localhost account lock;
+ERROR HY000: Operation ALTER USER failed for 'inexistentUser'@'localhost'
+alter if exists user inexistentUser@localhost account lock;
+Warnings:
+Error	1133	Can't find any matching row in the user table
+Note	1396	Operation ALTER USER failed for 'inexistentUser'@'localhost'
+#
+# Passing an existing user to CREATE should not be allowed
+# and it should not change the locking state of the current user
+#
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost'
+create user user1@localhost account lock;
+ERROR HY000: Operation CREATE USER failed for 'user1'@'localhost'
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost'
+#
+# Passing multiple users should lock them all
+#
+alter user user1@localhost, user2@localhost account lock;
+connect(localhost,user1,,test,MYSQL_PORT,MYSQL_SOCK);
+connect con1,localhost,user1;
+ERROR HY000: Access denied, this account is locked
+connect(localhost,user2,,test,MYSQL_PORT,MYSQL_SOCK);
+connect con2,localhost,user2;
+ERROR HY000: Access denied, this account is locked
+alter user user1@localhost, user2@localhost account unlock;
+#
+# The locking state is preserved after acl reload
+#
+alter user user1@localhost account lock;
+flush privileges;
+connect(localhost,user1,,test,MYSQL_PORT,MYSQL_SOCK);
+connect con1,localhost,user1;
+ERROR HY000: Access denied, this account is locked
+alter user user1@localhost account unlock;
+#
+# JSON functions on global_priv reflect the locking state of an account
+#
+alter user user1@localhost account lock;
+select host, user, JSON_VALUE(Priv, '$.account_locked') from mysql.global_priv where user='user1';
+host	user	JSON_VALUE(Priv, '$.account_locked')
+localhost	user1	1
+alter user user1@localhost account unlock;
+select host, user, JSON_VALUE(Priv, '$.account_locked') from mysql.global_priv where user='user1';
+host	user	JSON_VALUE(Priv, '$.account_locked')
+localhost	user1	0
+#
+# SHOW CREATE USER correctly displays the locking state of an user
+#
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost'
+alter user user1@localhost account lock;
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost' ACCOUNT LOCK
+alter user user1@localhost account unlock;
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost'
+create user newuser@localhost account lock;
+show create user newuser@localhost;
+CREATE USER for newuser@localhost
+CREATE USER 'newuser'@'localhost' ACCOUNT LOCK
+drop user newuser@localhost;
+#
+# Users should be able to lock themselves
+#
+grant CREATE USER on *.* to user1@localhost;
+connect con1,localhost,user1;
+connection con1;
+alter user user1@localhost account lock;
+disconnect con1;
+connection default;
+connect(localhost,user1,,test,MYSQL_PORT,MYSQL_SOCK);
+connect con1,localhost,user1;
+ERROR HY000: Access denied, this account is locked
+alter user user1@localhost account unlock;
+#
+# Users should be able to unlock themselves if the connections
+# had been established before the accounts were locked
+#
+grant CREATE USER on *.* to user1@localhost;
+connect con1,localhost,user1;
+alter user user1@localhost account lock;
+connection con1;
+alter user user1@localhost account unlock;
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost'
+disconnect con1;
+connection default;
+#
+# COM_CHANGE_USER should return error if the destination
+# account is locked
+#
+alter user user1@localhost account lock;
+ERROR HY000: Access denied, this account is locked
+drop user user1@localhost;
+drop user user2@localhost;

--- a/mysql-test/main/lock_user.test
+++ b/mysql-test/main/lock_user.test
@@ -1,0 +1,142 @@
+#
+# Test user account locking
+#
+
+--source include/not_embedded.inc
+
+create user user1@localhost;
+create user user2@localhost;
+
+--echo #
+--echo # Only privileged users should be able to lock/unlock.
+--echo #
+alter user user1@localhost account lock;
+alter user user1@localhost account unlock;
+create user user3@localhost account lock;
+drop user user3@localhost;
+
+connect(con1,localhost,user1);
+connection con1;
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+alter user user2@localhost account lock;
+disconnect con1;
+connection default;
+
+--echo #
+--echo # ALTER USER USER1 ACCOUNT LOCK should deny the connection of user1,
+--echo # but it should allow user2 to connect.
+--echo #
+
+alter user user1@localhost account lock;
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+connect(con1,localhost,user1);
+connect(con2,localhost,user2);
+disconnect con2;
+connection default;
+alter user user1@localhost account unlock;
+
+--echo #
+--echo # Passing an incorrect user should return an error unless
+--echo # IF EXISTS is used
+--echo #
+
+--error ER_CANNOT_USER
+alter user inexistentUser@localhost account lock;
+
+alter if exists user inexistentUser@localhost account lock;
+
+--echo #
+--echo # Passing an existing user to CREATE should not be allowed
+--echo # and it should not change the locking state of the current user
+--echo #
+
+show create user user1@localhost;
+--error ER_CANNOT_USER
+create user user1@localhost account lock;
+show create user user1@localhost;
+
+--echo #
+--echo # Passing multiple users should lock them all
+--echo #
+
+alter user user1@localhost, user2@localhost account lock;
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+connect(con1,localhost,user1);
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+connect(con2,localhost,user2);
+alter user user1@localhost, user2@localhost account unlock;
+
+--echo #
+--echo # The locking state is preserved after acl reload
+--echo #
+
+alter user user1@localhost account lock;
+flush privileges;
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+connect(con1,localhost,user1);
+alter user user1@localhost account unlock;
+
+--echo #
+--echo # JSON functions on global_priv reflect the locking state of an account
+--echo #
+
+alter user user1@localhost account lock;
+select host, user, JSON_VALUE(Priv, '$.account_locked') from mysql.global_priv where user='user1';
+alter user user1@localhost account unlock;
+select host, user, JSON_VALUE(Priv, '$.account_locked') from mysql.global_priv where user='user1';
+
+--echo #
+--echo # SHOW CREATE USER correctly displays the locking state of an user
+--echo #
+
+show create user user1@localhost;
+alter user user1@localhost account lock;
+show create user user1@localhost;
+alter user user1@localhost account unlock;
+show create user user1@localhost;
+create user newuser@localhost account lock;
+show create user newuser@localhost;
+drop user newuser@localhost;
+
+--echo #
+--echo # Users should be able to lock themselves
+--echo #
+grant CREATE USER on *.* to user1@localhost;
+connect(con1,localhost,user1);
+connection con1;
+alter user user1@localhost account lock;
+disconnect con1;
+connection default;
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+connect(con1,localhost,user1);
+alter user user1@localhost account unlock;
+
+--echo #
+--echo # Users should be able to unlock themselves if the connections
+--echo # had been established before the accounts were locked
+--echo #
+grant CREATE USER on *.* to user1@localhost;
+connect(con1,localhost,user1);
+alter user user1@localhost account lock;
+connection con1;
+alter user user1@localhost account unlock;
+show create user user1@localhost;
+disconnect con1;
+connection default;
+
+--echo #
+--echo # COM_CHANGE_USER should return error if the destination
+--echo # account is locked
+--echo #
+alter user user1@localhost account lock;
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+--change_user user1
+
+drop user user1@localhost;
+drop user user2@localhost;
+

--- a/mysql-test/main/system_mysql_db_507.result
+++ b/mysql-test/main/system_mysql_db_507.result
@@ -165,5 +165,26 @@ foo	%	Y	mysql_native_password	*E8D46CE25265E545D225A8A6F1BAF642FEBEE5CB
 goo	%	Y	mysql_native_password	*F3A2A51A9B0F2BE2468926B4132313728C250DBF
 ioo	%	Y	mysql_old_password	7a8f886d28473e85
 #
+# Test account locking
+#
+create user user1@localhost account lock;
+connect(localhost,user1,,test,MYSQL_PORT,MYSQL_SOCK);
+connect con1,localhost,user1;
+ERROR HY000: Access denied, this account is locked
+flush privileges;
+connect(localhost,user1,,test,MYSQL_PORT,MYSQL_SOCK);
+connect con1,localhost,user1;
+ERROR HY000: Access denied, this account is locked
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost' ACCOUNT LOCK
+alter user user1@localhost account unlock;
+connect con1,localhost,user1;
+disconnect con1;
+connection default;
+show create user user1@localhost;
+CREATE USER for user1@localhost
+CREATE USER 'user1'@'localhost'
+#
 # Reset to final original state.
 #

--- a/mysql-test/main/system_mysql_db_507.test
+++ b/mysql-test/main/system_mysql_db_507.test
@@ -89,6 +89,24 @@ where user like "%oo"
 order by user;
 
 --echo #
+--echo # Test account locking
+--echo #
+create user user1@localhost account lock;
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+connect(con1,localhost,user1);
+flush privileges;
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_ACCOUNT_HAS_BEEN_LOCKED
+connect(con1,localhost,user1);
+show create user user1@localhost;
+alter user user1@localhost account unlock;
+connect(con1,localhost,user1);
+disconnect con1;
+connection default;
+show create user user1@localhost;
+
+--echo #
 --echo # Reset to final original state.
 --echo #
 --source include/switch_to_mysql_global_priv.inc

--- a/mysql-test/main/system_mysql_db_fix40123.result
+++ b/mysql-test/main/system_mysql_db_fix40123.result
@@ -108,6 +108,7 @@ user	CREATE TABLE `user` (
   `plugin` char(64) CHARACTER SET latin1 NOT NULL DEFAULT '',
   `authentication_string` text COLLATE utf8_bin NOT NULL,
   `password_expired` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
+  `account_locked` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
   `is_role` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
   `default_role` char(80) COLLATE utf8_bin NOT NULL DEFAULT '',
   `max_statement_time` decimal(12,6) NOT NULL DEFAULT 0.000000,

--- a/mysql-test/main/system_mysql_db_fix50030.result
+++ b/mysql-test/main/system_mysql_db_fix50030.result
@@ -108,6 +108,7 @@ user	CREATE TABLE `user` (
   `plugin` char(64) CHARACTER SET latin1 NOT NULL DEFAULT '',
   `authentication_string` text COLLATE utf8_bin NOT NULL,
   `password_expired` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
+  `account_locked` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
   `is_role` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
   `default_role` char(80) COLLATE utf8_bin NOT NULL DEFAULT '',
   `max_statement_time` decimal(12,6) NOT NULL DEFAULT 0.000000,

--- a/mysql-test/main/system_mysql_db_fix50117.result
+++ b/mysql-test/main/system_mysql_db_fix50117.result
@@ -108,6 +108,7 @@ user	CREATE TABLE `user` (
   `plugin` char(64) CHARACTER SET latin1 NOT NULL DEFAULT '',
   `authentication_string` text COLLATE utf8_bin NOT NULL,
   `password_expired` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
+  `account_locked` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
   `is_role` enum('N','Y') CHARACTER SET utf8 NOT NULL DEFAULT 'N',
   `default_role` char(80) COLLATE utf8_bin NOT NULL DEFAULT '',
   `max_statement_time` decimal(12,6) NOT NULL DEFAULT 0.000000,

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -643,6 +643,7 @@ ALTER TABLE user ADD plugin char(64) CHARACTER SET latin1 DEFAULT '' NOT NULL,
 ALTER TABLE user MODIFY plugin char(64) CHARACTER SET latin1 DEFAULT '' NOT NULL,
                  MODIFY authentication_string TEXT NOT NULL;
 ALTER TABLE user ADD password_expired ENUM('N', 'Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL;
+ALTER TABLE user ADD account_locked enum('N', 'Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL after password_expired;
 ALTER TABLE user ADD is_role enum('N', 'Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL;
 ALTER TABLE user ADD default_role char(80) binary DEFAULT '' NOT NULL;
 ALTER TABLE user ADD max_statement_time decimal(12,6) DEFAULT 0 NOT NULL;
@@ -804,6 +805,7 @@ IF 'BASE TABLE' = (select table_type from information_schema.tables where table_
                     'max_statement_time', max_statement_time,
                     'plugin', if(plugin>'',plugin,if(length(password)=16,'mysql_old_password','mysql_native_password')),
                     'authentication_string', if(plugin>'' and authentication_string>'',authentication_string,password),
+                    'account_locked', 'Y'=account_locked,
                     'default_role', default_role,
                     'is_role', 'Y'=is_role)) as Priv
   FROM user;

--- a/sql/lex.h
+++ b/sql/lex.h
@@ -55,6 +55,7 @@ static SYMBOL symbols[] = {
   { ">>",		SYM(SHIFT_RIGHT)},
   { "<=>",		SYM(EQUAL_SYM)},
   { "ACCESSIBLE",	SYM(ACCESSIBLE_SYM)},
+  { "ACCOUNT",		SYM(ACCOUNT_SYM)},
   { "ACTION",		SYM(ACTION)},
   { "ADD",		SYM(ADD)},
   { "ADMIN",            SYM(ADMIN_SYM)},

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7933,3 +7933,6 @@ ER_BACKUP_UNKNOWN_STAGE
         eng "Unknown backup stage: '%s'. Stage should be one of START, FLUSH, BLOCK_DDL, BLOCK_COMMIT or END"
 ER_USER_IS_BLOCKED
         eng "User is blocked because of too many credential errors; unblock with 'FLUSH PRIVILEGES'"
+ER_ACCOUNT_HAS_BEEN_LOCKED
+        eng "Access denied, this account is locked"
+        rum "Acces refuzat, acest cont este blocat"

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -2923,6 +2923,27 @@ public:
   Explain_delete* save_explain_delete_data(MEM_ROOT *mem_root, THD *thd);
 };
 
+enum account_lock_type
+{
+  ACCOUNTLOCK_UNSPECIFIED,
+  ACCOUNTLOCK_LOCKED,
+  ACCOUNTLOCK_UNLOCKED
+};
+
+struct Account_options
+{
+  Account_options()
+    : account_locked(ACCOUNTLOCK_UNSPECIFIED)
+  { }
+
+  void reset()
+  {
+    account_locked= ACCOUNTLOCK_UNSPECIFIED;
+  }
+
+  account_lock_type account_locked;
+};
+
 
 class Query_arena_memroot;
 /* The state of the lex parsing. This is saved in the THD struct */
@@ -3013,6 +3034,9 @@ public:
     I.e. the value of DEFINER clause.
   */
   LEX_USER *definer;
+
+  /* Used in ALTER/CREATE user to store account locking options */
+  Account_options account_options;
 
   Table_type table_type;                        /* Used for SHOW CREATE */
   List<Key_part_spec> ref_list;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1151,6 +1151,7 @@ bool my_yyoverflow(short **a, YYSTYPE **b, size_t *yystacksize);
   Non-reserved keywords
 */
 
+%token  <kwd>  ACCOUNT_SYM                   /* MYSQL */
 %token  <kwd>  ACTION                        /* SQL-2003-N */
 %token  <kwd>  ADMIN_SYM                     /* SQL-2003-N */
 %token  <kwd>  ADDDATE_SYM                   /* MYSQL-FUNC */
@@ -2911,7 +2912,7 @@ create:
             Lex->pop_select(); //main select
           }
         | create_or_replace USER_SYM opt_if_not_exists clear_privileges
-          grant_list opt_require_clause opt_resource_options
+          grant_list opt_require_clause opt_resource_options opt_account_locking
           {
             if (unlikely(Lex->set_command_with_check(SQLCOM_CREATE_USER,
                                                      $1 | $3)))
@@ -3318,6 +3319,7 @@ clear_privileges:
            lex->ssl_type= SSL_TYPE_NOT_SPECIFIED;
            lex->ssl_cipher= lex->x509_subject= lex->x509_issuer= 0;
            bzero((char *)&(lex->mqh),sizeof(lex->mqh));
+           lex->account_options.reset();
          }
         ;
 
@@ -7975,7 +7977,7 @@ alter:
           } OPTIONS_SYM '(' server_options_list ')' { }
           /* ALTER USER foo is allowed for MySQL compatibility. */
         | ALTER opt_if_exists USER_SYM clear_privileges grant_list
-          opt_require_clause opt_resource_options
+          opt_require_clause opt_resource_options opt_account_locking
           {
             Lex->create_info.set($2);
             Lex->sql_command= SQLCOM_ALTER_USER;
@@ -8011,6 +8013,18 @@ alter:
             Lex->pop_select(); //main select
             if (Lex->check_main_unit_semantics())
               MYSQL_YYABORT;
+          }
+        ;
+
+opt_account_locking:
+        /* Nothing */ {}
+        | ACCOUNT_SYM LOCK_SYM
+          {
+            Lex->account_options.account_locked= ACCOUNTLOCK_LOCKED;
+          }
+        | ACCOUNT_SYM UNLOCK_SYM
+          {
+            Lex->account_options.account_locked= ACCOUNTLOCK_UNLOCKED;
           }
         ;
 
@@ -15851,6 +15865,7 @@ keyword_data_type:
 */
 keyword_sp_var_and_label:
           ACTION
+        | ACCOUNT_SYM
         | ADDDATE_SYM
         | ADMIN_SYM
         | AFTER_SYM

--- a/sql/sql_yacc_ora.yy
+++ b/sql/sql_yacc_ora.yy
@@ -646,6 +646,7 @@ bool my_yyoverflow(short **a, YYSTYPE **b, size_t *yystacksize);
   Non-reserved keywords
 */
 
+%token  <kwd>  ACCOUNT_SYM                   /* MYSQL */
 %token  <kwd>  ACTION                        /* SQL-2003-N */
 %token  <kwd>  ADMIN_SYM                     /* SQL-2003-N */
 %token  <kwd>  ADDDATE_SYM                   /* MYSQL-FUNC */
@@ -2417,7 +2418,7 @@ create:
             Lex->pop_select(); //main select
           }
         | create_or_replace USER_SYM opt_if_not_exists clear_privileges
-          grant_list opt_require_clause opt_resource_options
+          grant_list opt_require_clause opt_resource_options opt_account_locking
           {
             if (unlikely(Lex->set_command_with_check(SQLCOM_CREATE_USER,
                                                      $1 | $3)))
@@ -8005,7 +8006,7 @@ alter:
           } OPTIONS_SYM '(' server_options_list ')' { }
           /* ALTER USER foo is allowed for MySQL compatibility. */
         | ALTER opt_if_exists USER_SYM clear_privileges grant_list
-          opt_require_clause opt_resource_options
+          opt_require_clause opt_resource_options opt_account_locking
           {
             Lex->create_info.set($2);
             Lex->sql_command= SQLCOM_ALTER_USER;
@@ -8041,6 +8042,18 @@ alter:
             Lex->pop_select(); //main select
             if (Lex->check_main_unit_semantics())
               MYSQL_YYABORT;
+          }
+        ;
+
+opt_account_locking:
+        /* Nothing */ {}
+        | ACCOUNT_SYM LOCK_SYM
+          {
+            Lex->account_options.account_locked= ACCOUNTLOCK_LOCKED;
+          }
+        | ACCOUNT_SYM UNLOCK_SYM
+          {
+            Lex->account_options.account_locked= ACCOUNTLOCK_UNLOCKED;
           }
         ;
 
@@ -15939,6 +15952,7 @@ keyword_data_type:
 */
 keyword_sp_var_and_label:
           ACTION
+        | ACCOUNT_SYM
         | ADDDATE_SYM
         | ADMIN_SYM
         | AFTER_SYM


### PR DESCRIPTION
Add server support for user account locking.
This patch extends the ALTER/CREATE USER statements for denying a
user's subsequent login attempts:
    ALTER USER
        user [, user2] ACCOUNT [LOCK | UNLOCK]
    CREATE USER
        user [, user2] ACCOUNT [LOCK | UNLOCK]