### PR TITLE
Fix UNICODE issue of dlerror()

### DIFF
--- a/include/my_global.h
+++ b/include/my_global.h
@@ -1068,7 +1068,7 @@ typedef ulong		myf;	/* Type of MyFlags in my_funcs */
 static inline char *dlerror(void)
 {
   static char win_errormsg[2048];
-  FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
+  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM,
     0, GetLastError(), 0, win_errormsg, 2048, NULL);
   return win_errormsg;
 }


### PR DESCRIPTION
Current implementation is conflicting. If `UNICODE` is defined, `FormatMessage()` will be `FormatMessageW()`, and variable `win_errormsg` with type `char` can not be passed to it, which should be changed to `TCHAR` instead. Since we don't use UNICODE here, we can use `FormatMessageA()` directly to avoid conversion error.
```
my_global.h(1092): error C2664: 'DWORD FormatMessageW(D
WORD,LPCVOID,DWORD,DWORD,LPWSTR,DWORD,va_list *)' : cannot convert argument 5 from 'char [2048]' to 'LPWSTR'
```