### PR TITLE
Fixes for tests that fail in release build

### DIFF
--- a/mysql-test/suite/galera/r/galera_ist_mariabackup,debug.rdiff
+++ b/mysql-test/suite/galera/r/galera_ist_mariabackup,debug.rdiff
@@ -1,22 +1,6 @@
---- galera_ist_mariabackup.result	2018-11-29 17:41:37.006000000 +0100
-+++ galera_ist_mariabackup,debug.reject	2018-11-29 18:03:31.113429999 +0100
-@@ -1,3 +1,5 @@
-+connection node_2;
-+connection node_1;
- connection node_1;
- connection node_2;
- Performing State Transfer on a server that has been temporarily disconnected
-@@ -47,6 +49,9 @@
- INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
- connection node_2;
- Loading wsrep provider ...
-+disconnect node_2;
-+connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2;
-+connection node_2;
- SET AUTOCOMMIT=OFF;
- START TRANSACTION;
- INSERT INTO t1 VALUES ('node2_committed_after');
-@@ -285,3 +290,111 @@
+--- galera_ist_mariabackup.result	2018-12-11 13:33:56.728535840 +0100
++++ galera_ist_mariabackup.reject	2018-12-11 13:37:40.572535840 +0100
+@@ -290,3 +290,111 @@
  DROP TABLE t1;
  COMMIT;
  SET AUTOCOMMIT=ON;

--- a/mysql-test/suite/galera/r/galera_ist_mariabackup.result
+++ b/mysql-test/suite/galera/r/galera_ist_mariabackup.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 connection node_1;
 connection node_2;
 Performing State Transfer on a server that has been temporarily disconnected
@@ -47,6 +49,9 @@ INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
 INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
 connection node_2;
 Loading wsrep provider ...
+disconnect node_2;
+connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES ('node2_committed_after');

--- a/mysql-test/suite/galera/r/galera_ist_mariabackup_innodb_flush_logs.result
+++ b/mysql-test/suite/galera/r/galera_ist_mariabackup_innodb_flush_logs.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 Performing State Transfer on a server that has been killed and restarted
 connection node_1;
 CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;

--- a/mysql-test/suite/galera/r/galera_sst_mariabackup.result
+++ b/mysql-test/suite/galera/r/galera_sst_mariabackup.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 connection node_1;
 connection node_2;
 Performing State Transfer on a server that has been shut down cleanly and restarted

--- a/mysql-test/suite/galera/r/galera_sst_rsync,debug.rdiff
+++ b/mysql-test/suite/galera/r/galera_sst_rsync,debug.rdiff
@@ -1,14 +1,6 @@
---- galera_sst_rsync.result	2018-11-21 18:14:26.125258909 +0100
-+++ galera_sst_rsync,debug.reject	2018-11-29 18:07:44.596107999 +0100
-@@ -1,5 +1,7 @@
- connection node_2;
- connection node_1;
-+connection node_1;
-+connection node_2;
- Performing State Transfer on a server that has been shut down cleanly and restarted
- connection node_1;
- CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
-@@ -286,3 +288,111 @@
+--- galera_sst_rsync.result	2018-12-11 13:47:33.600535840 +0100
++++ galera_sst_rsync.reject	2018-12-11 13:52:05.780535840 +0100
+@@ -288,3 +288,111 @@
  DROP TABLE t1;
  COMMIT;
  SET AUTOCOMMIT=ON;

--- a/mysql-test/suite/galera/r/galera_sst_rsync.result
+++ b/mysql-test/suite/galera/r/galera_sst_rsync.result
@@ -1,5 +1,7 @@
 connection node_2;
 connection node_1;
+connection node_1;
+connection node_2;
 Performing State Transfer on a server that has been shut down cleanly and restarted
 connection node_1;
 CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;

--- a/mysql-test/suite/galera/t/galera_bf_abort_shutdown.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_shutdown.test
@@ -7,6 +7,7 @@
 
 --source include/have_innodb.inc
 --source include/galera_cluster.inc
+--source include/have_debug_sync.inc
 
 CREATE TABLE t1 (f1 INT PRIMARY KEY);
 


### PR DESCRIPTION
* Record .result and/or .rdiff files for galera_ist_mariabackup, galera_ist_mariabackup_innodb_flush_logs, galera_sst_mariabackup and galera_sst_rsync.

* Missing "have_debug_sync.inc" in galera_bf_abort_shutdown