### PR TITLE
MDEV-15854: added uuid_to_bin, bin_to_uuid and is_uuid functions

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -1002,6 +1002,9 @@ void my_uuid_init(ulong seed1, ulong seed2);
 void my_uuid(uchar *guid);
 void my_uuid2str(const uchar *guid, char *s);
 void my_uuid_end(void);
+int my_uuid_parse(const char *in_string, size_t len,
+                  unsigned char *out_str);
+my_bool my_uuid_is_valid(const char *s, size_t len);
 
 const char *my_dlerror(const char *dlpath);
 

--- a/mysql-test/collections/10.0-compatible.list
+++ b/mysql-test/collections/10.0-compatible.list
@@ -197,6 +197,7 @@ main.func_test
 main.func_time
 main.func_time_hires
 main.func_timestamp
+main.func_uuid
 main.function_defaults
 main.function_defaults_innodb
 main.gcc296

--- a/mysql-test/r/func_uuid.result
+++ b/mysql-test/r/func_uuid.result
@@ -1,0 +1,281 @@
+#
+# WL#8920: Improve usability of UUID manipulations
+#
+SELECT uuid_to_bin('{c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7}', TRUE) AS a, uuid_to_bin('{e60c88ba-083f-4ceb-be59-f67636d718a2}', TRUE) AS b;
+a	b
+HªÀ	»ÎKª≤Ê†∂¥’«	LÎ?Êà∫æYˆv6◊¢
+SELECT uuid_to_bin('c8eb4b15cb0948bbbbb2e6a0b6b4d5c7', TRUE) AS a, uuid_to_bin('e60c88ba083f4cebbe59f67636d718a2', TRUE) AS b;
+a	b
+HªÀ	»ÎKª≤Ê†∂¥’«	LÎ?Êà∫æYˆv6◊¢
+SELECT uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7', TRUE) AS a, uuid_to_bin('e60c88ba-083f-4ceb-be59-f67636d718a2', TRUE) AS b;
+a	b
+HªÀ	»ÎKª≤Ê†∂¥’«	LÎ?Êà∫æYˆv6◊¢
+# UUID too long
+SELECT uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5cc7', TRUE) AS a;
+ERROR HY000: Incorrect string value: 'c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5cc7' for function uuid_to_bin
+# UUID with invalid characters
+SELECT uuid_to_bin('12345678123456Z81234567812345678', TRUE) AS a;
+ERROR HY000: Incorrect string value: '12345678123456Z81234567812345678' for function uuid_to_bin
+SELECT uuid_to_bin('12345678-1234-5678-1234-56781234567Z', TRUE) AS a;
+ERROR HY000: Incorrect string value: '12345678-1234-5678-1234-56781234567Z' for function uuid_to_bin
+SELECT uuid_to_bin('e60c88ba-083f-4ceb-be59-f67636d718aa2', TRUE) AS b;
+ERROR HY000: Incorrect string value: 'e60c88ba-083f-4ceb-be59-f67636d718aa2' for function uuid_to_bin
+# UUID too short
+SELECT uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a04d5cc7', TRUE) AS a;
+ERROR HY000: Incorrect string value: 'c8eb4b15-cb09-48bb-bbb2-e6a04d5cc7' for function uuid_to_bin
+SELECT uuid_to_bin('e60c88ba-083f-4ceb-be59-f676318aa2', TRUE) AS b;
+ERROR HY000: Incorrect string value: 'e60c88ba-083f-4ceb-be59-f676318aa2' for function uuid_to_bin
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac798ffcc984ab68')) AS a, bin_to_uuid(unhex('7f9d04ae61b34468ac898ffcc984ab68'),TRUE) AS b;
+a	b
+7f9d04ae-61b3-4468-ac79-8ffcc984ab68	61b34468-04ae-7f9d-ac89-8ffcc984ab68
+# UUID too long
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac798ffcc984ab668')) AS a;
+ERROR HY000: Incorrect string value: '\x07\xF9\xD0J\xE6\x1B4F\x8A\xC7\x98\xFF\xCC\x98J\xB6h' for function bin_to_uuid
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac898ffcc984ab668'), TRUE) AS b;
+ERROR HY000: Incorrect string value: '\x07\xF9\xD0J\xE6\x1B4F\x8A\xC8\x98\xFF\xCC\x98J\xB6h' for function bin_to_uuid
+# UUID too short
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac798ffcc98468')) AS a;
+ERROR HY000: Incorrect string value: '\x7F\x9D\x04\xAEa\xB3Dh\xACy\x8F\xFC\xC9\x84h' for function bin_to_uuid
+SELECT bin_to_uuid(unhex('7f9d04ab34468ac898ffcc984ab668'), TRUE) AS b;
+ERROR HY000: Incorrect string value: '\x7F\x9D\x04\xAB4F\x8A\xC8\x98\xFF\xCC\x98J\xB6h' for function bin_to_uuid
+SELECT uuid_to_bin('{c8eb4b15-CB09-48bb-bbb2-e6a0b6b4d5c7}') = x'c8eb4b15cb0948bbbbb2e6a0b6b4d5c7';
+uuid_to_bin('{c8eb4b15-CB09-48bb-bbb2-e6a0b6b4d5c7}') = x'c8eb4b15cb0948bbbbb2e6a0b6b4d5c7'
+1
+SELECT uuid_to_bin('{c8eb4b15-CB09-48bb-bbb2-e6a0b6b4d5c7}', TRUE) = x'48bbcb09c8eb4b15bbb2e6a0b6b4d5c7';
+uuid_to_bin('{c8eb4b15-CB09-48bb-bbb2-e6a0b6b4d5c7}', TRUE) = x'48bbcb09c8eb4b15bbb2e6a0b6b4d5c7'
+1
+SELECT bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68') = '7f9d04ae-61b3-4468-ac79-8ffcc984ab68';
+bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68') = '7f9d04ae-61b3-4468-ac79-8ffcc984ab68'
+1
+SELECT bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68', TRUE) = '61b34468-04ae-7f9d-ac79-8ffcc984ab68';
+bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68', TRUE) = '61b34468-04ae-7f9d-ac79-8ffcc984ab68'
+1
+# null VALUES
+SELECT bin_to_uuid(NULL) AS a, bin_to_uuid(NULL, TRUE) AS b;
+a	b
+NULL	NULL
+SELECT uuid_to_bin(NULL) AS a, uuid_to_bin(NULL, TRUE) AS b;
+a	b
+NULL	NULL
+SELECT is_uuid(NULL);
+is_uuid(NULL)
+NULL
+# valid uuids
+SELECT is_uuid('{12345678-1234-5678-1234-567812345678}');
+is_uuid('{12345678-1234-5678-1234-567812345678}')
+1
+SELECT is_uuid('12345678123456781234567812345678');
+is_uuid('12345678123456781234567812345678')
+1
+SELECT is_uuid('12345678-1234-5678-1234-567812345678');
+is_uuid('12345678-1234-5678-1234-567812345678')
+1
+# shorter uuids
+SELECT is_uuid('{2345678-1234-5678-1234-567812345678}');
+is_uuid('{2345678-1234-5678-1234-567812345678}')
+0
+SELECT is_uuid('2345678123456781234567812345678');
+is_uuid('2345678123456781234567812345678')
+0
+SELECT is_uuid('2345678-1234-5678-1234-567812345678');
+is_uuid('2345678-1234-5678-1234-567812345678')
+0
+# longer uuids
+SELECT is_uuid('{9912345678-1234-5678-1234-567812345678}');
+is_uuid('{9912345678-1234-5678-1234-567812345678}')
+0
+SELECT is_uuid('9912345678123456781234567812345678');
+is_uuid('9912345678123456781234567812345678')
+0
+SELECT is_uuid('9912345678-1234-5678-1234-567812345678');
+is_uuid('9912345678-1234-5678-1234-567812345678')
+0
+# uuids with missing dash
+SELECT is_uuid('{12345678-12345678-1234-567812345678}');
+is_uuid('{12345678-12345678-1234-567812345678}')
+0
+SELECT is_uuid('1234567812345-6781234567812345678');
+is_uuid('1234567812345-6781234567812345678')
+0
+SELECT is_uuid('12345678-12345678-1234-567812345678');
+is_uuid('12345678-12345678-1234-567812345678')
+0
+# uuids with dash in wrong place
+SELECT is_uuid('{12345678-123456-78-1234-567812345678}');
+is_uuid('{12345678-123456-78-1234-567812345678}')
+0
+SELECT is_uuid('12345678-123456-78-1234-567812345678');
+is_uuid('12345678-123456-78-1234-567812345678')
+0
+# tests with tables
+CREATE TABLE t(a binary(16));
+INSERT into t VALUES(unhex('7f9d04ae61b34468ac798ffcc984ab68')),(unhex('d00653b290b940d193c2194456bd4f3d')),(unhex('e60c88ba083f4cebbe59f67636d718a2')),(unhex('c8eb4b15cb0948bbbbb2e6a0b6b4d5c7'));
+SELECT bin_to_uuid(a), bin_to_uuid(a,TRUE) FROM t;
+bin_to_uuid(a)	bin_to_uuid(a,TRUE)
+7f9d04ae-61b3-4468-ac79-8ffcc984ab68	61b34468-04ae-7f9d-ac79-8ffcc984ab68
+d00653b2-90b9-40d1-93c2-194456bd4f3d	90b940d1-53b2-d006-93c2-194456bd4f3d
+e60c88ba-083f-4ceb-be59-f67636d718a2	083f4ceb-88ba-e60c-be59-f67636d718a2
+c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7	cb0948bb-4b15-c8eb-bbb2-e6a0b6b4d5c7
+SELECT uuid_to_bin(bin_to_uuid(a)), uuid_to_bin(bin_to_uuid(a)) = a, uuid_to_bin(bin_to_uuid(a, TRUE), TRUE), uuid_to_bin(bin_to_uuid(a, TRUE), TRUE) = a FROM t;
+uuid_to_bin(bin_to_uuid(a))	uuid_to_bin(bin_to_uuid(a)) = a	uuid_to_bin(bin_to_uuid(a, TRUE), TRUE)	uuid_to_bin(bin_to_uuid(a, TRUE), TRUE) = a
+ùÆa≥Dh¨yè¸…Ñ´h	1	ùÆa≥Dh¨yè¸…Ñ´h	1
+–S≤êπ@—ì¬DVΩO=	1	–S≤êπ@—ì¬DVΩO=	1
+Êà∫?LÎæYˆv6◊¢	1	Êà∫?LÎæYˆv6◊¢	1
+»ÎKÀ	Hªª≤Ê†∂¥’«	1	»ÎKÀ	Hªª≤Ê†∂¥’«	1
+SELECT bin_to_uuid(uuid_to_bin(bin_to_uuid(a))), bin_to_uuid(uuid_to_bin(bin_to_uuid(a, TRUE), TRUE), TRUE) FROM t;
+bin_to_uuid(uuid_to_bin(bin_to_uuid(a)))	bin_to_uuid(uuid_to_bin(bin_to_uuid(a, TRUE), TRUE), TRUE)
+7f9d04ae-61b3-4468-ac79-8ffcc984ab68	61b34468-04ae-7f9d-ac79-8ffcc984ab68
+d00653b2-90b9-40d1-93c2-194456bd4f3d	90b940d1-53b2-d006-93c2-194456bd4f3d
+e60c88ba-083f-4ceb-be59-f67636d718a2	083f4ceb-88ba-e60c-be59-f67636d718a2
+c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7	cb0948bb-4b15-c8eb-bbb2-e6a0b6b4d5c7
+SELECT bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}')), bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}')) = '12345678-1234-5678-1234-567812345678';
+bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}'))	bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}')) = '12345678-1234-5678-1234-567812345678'
+12345678-1234-5678-1234-567812345678	1
+SELECT bin_to_uuid(uuid_to_bin('12345678123456781234567812345678')),bin_to_uuid(uuid_to_bin('12345678123456781234567812345678')) = '12345678-1234-5678-1234-567812345678';
+bin_to_uuid(uuid_to_bin('12345678123456781234567812345678'))	bin_to_uuid(uuid_to_bin('12345678123456781234567812345678')) = '12345678-1234-5678-1234-567812345678'
+12345678-1234-5678-1234-567812345678	1
+SELECT bin_to_uuid(uuid_to_bin('12345678-1234-5678-1234-567812345678')), bin_to_uuid(uuid_to_bin('12345678-1234-5678-1234-567812345678')) = '12345678-1234-5678-1234-567812345678';
+bin_to_uuid(uuid_to_bin('12345678-1234-5678-1234-567812345678'))	bin_to_uuid(uuid_to_bin('12345678-1234-5678-1234-567812345678')) = '12345678-1234-5678-1234-567812345678'
+12345678-1234-5678-1234-567812345678	1
+DROP TABLE t;
+CREATE TABLE at(_bin binary(16),
+_vbn varbinary(16),
+_tbl tinyblob,
+_ttx tinytext,
+_blb blob);
+INSERT into at VALUES(
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678');
+SELECT
+bin_to_uuid(_bin),
+bin_to_uuid(_vbn),
+bin_to_uuid(_tbl),
+bin_to_uuid(_ttx),
+bin_to_uuid(_blb)
+FROM at;
+bin_to_uuid(_bin)	bin_to_uuid(_vbn)	bin_to_uuid(_tbl)	bin_to_uuid(_ttx)	bin_to_uuid(_blb)
+12345678-1234-5678-1234-567812345678	12345678-1234-5678-1234-567812345678	12345678-1234-5678-1234-567812345678	12345678-1234-5678-1234-567812345678	12345678-1234-5678-1234-567812345678
+# Output types of bin_to_uuid:
+CREATE TABLE t3 AS SELECT
+bin_to_uuid(_bin),
+bin_to_uuid(_vbn),
+bin_to_uuid(_tbl),
+bin_to_uuid(_ttx),
+bin_to_uuid(_blb)
+FROM at;
+SHOW CREATE TABLE t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `bin_to_uuid(_bin)` varchar(36) DEFAULT NULL,
+  `bin_to_uuid(_vbn)` varchar(36) DEFAULT NULL,
+  `bin_to_uuid(_tbl)` varchar(36) DEFAULT NULL,
+  `bin_to_uuid(_ttx)` varchar(36) DEFAULT NULL,
+  `bin_to_uuid(_blb)` varchar(36) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+DROP TABLE t3;
+# Compare with hex:
+DELETE FROM at;
+INSERT into at(_bin,_blb) VALUES('c8eb4b15cb0948bb','c8eb4b15cb0948bb');
+CREATE TABLE t3 AS SELECT hex('c8eb4b15cb0948bb'),hex(_bin),hex(_blb) FROM at;
+SHOW CREATE TABLE t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `hex('c8eb4b15cb0948bb')` varchar(32) DEFAULT NULL,
+  `hex(_bin)` varchar(32) DEFAULT NULL,
+  `hex(_blb)` longtext DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+DROP TABLE t3;
+# Output types of uuid_to_bin
+CREATE TABLE t3 AS SELECT
+uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7') AS a,
+uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7', true) AS b;
+SHOW CREATE TABLE t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `a` varbinary(16) DEFAULT NULL,
+  `b` varbinary(16) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+DROP TABLE t3;
+# Compare with unhex:
+CREATE TABLE t3 AS SELECT unhex(_bin) FROM at;
+SHOW CREATE TABLE t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `unhex(_bin)` varbinary(8) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+DROP TABLE t3;
+DROP TABLE at;
+# Bad arguments
+SELECT bin_to_uuid(2);
+ERROR HY000: Incorrect string value: '2' for function bin_to_uuid
+SELECT uuid_to_bin(2);
+ERROR HY000: Incorrect string value: '2' for function uuid_to_bin
+SELECT bin_to_uuid();
+ERROR 42000: Incorrect parameter count in the call to native function 'bin_to_uuid'
+SELECT uuid_to_bin();
+ERROR 42000: Incorrect parameter count in the call to native function 'uuid_to_bin'
+SELECT bin_to_uuid(x'12345678123456781234567812345678', true, false);
+ERROR 42000: Incorrect parameter count in the call to native function 'bin_to_uuid'
+SELECT uuid_to_bin('12345678-1234-5678-1234-567812345678', true, false);
+ERROR 42000: Incorrect parameter count in the call to native function 'uuid_to_bin'
+SELECT bin_to_uuid(x'');
+ERROR HY000: Incorrect string value: '' for function bin_to_uuid
+SELECT bin_to_uuid(x'', true);
+ERROR HY000: Incorrect string value: '' for function bin_to_uuid
+SELECT uuid_to_bin('');
+ERROR HY000: Incorrect string value: '' for function uuid_to_bin
+SELECT uuid_to_bin('', true);
+ERROR HY000: Incorrect string value: '' for function uuid_to_bin
+set @a=uuid();
+SELECT bin_to_uuid(uuid_to_bin(@a)) = @a;
+bin_to_uuid(uuid_to_bin(@a)) = @a
+1
+# tests with prepared statements
+PREPARE s FROM "SELECT bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68',true)";
+EXECUTE s;
+bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68',true)
+61b34468-04ae-7f9d-ac79-8ffcc984ab68
+EXECUTE s;
+bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68',true)
+61b34468-04ae-7f9d-ac79-8ffcc984ab68
+PREPARE s2 FROM "SELECT bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}', true), true)";
+EXECUTE s2;
+bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}', true), true)
+12345678-1234-5678-1234-567812345678
+EXECUTE s2;
+bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}', true), true)
+12345678-1234-5678-1234-567812345678
+# Generated column
+CREATE TABLE t1(col1 varchar(100), gcol2 binary(16) AS (uuid_to_bin(col1)) virtual, index(gcol2));
+INSERT into t1(col1) VALUES
+('{12345678-1234-5678-1234-567812345678}'),
+('12345679123456781234567812345678'),
+('12345670-1234-5678-1234-567812345678');
+EXPLAIN SELECT * FROM t1 where gcol2=x'12345679123456781234567812345678';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ref	gcol2	gcol2	17	const	1	Using index condition
+SELECT * FROM t1 where gcol2=x'12345679123456781234567812345678';
+col1	gcol2
+12345679123456781234567812345678	4Vy4Vx4Vx4Vx
+CREATE TABLE t2(col1 binary(16), gcol2 varchar(36) AS (bin_to_uuid(col1)) virtual, index(col1), index(gcol2));
+INSERT into t2(col1) VALUES
+(x'12345678123456781234567812345678'),
+(x'12345679123456781234567812345678'),
+(x'12345670123456781234567812345678');
+EXPLAIN SELECT * FROM t2 where col1=x'12345679123456781234567812345678';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	ref	col1	col1	17	const	1	Using index condition
+SELECT * FROM t2 where col1=x'12345679123456781234567812345678';
+col1	gcol2
+4Vy4Vx4Vx4Vx	12345679-1234-5678-1234-567812345678
+EXPLAIN SELECT * FROM t2 where gcol2='12345679-1234-5678-1234-567812345678';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	ref	gcol2	gcol2	39	const	1	Using index condition
+SELECT * FROM t2 where gcol2='12345679-1234-5678-1234-567812345678';
+col1	gcol2
+4Vy4Vx4Vx4Vx	12345679-1234-5678-1234-567812345678
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/t/func_uuid.test
+++ b/mysql-test/t/func_uuid.test
@@ -1,0 +1,211 @@
+#####################################################################
+#                                                                   #
+# Tests for uuid_to_bin, bin_to_uuid and is_uuid functions.         #
+#                                                                   #
+#####################################################################
+--echo #
+--echo # WL#8920: Improve usability of UUID manipulations
+--echo #
+
+SELECT uuid_to_bin('{c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7}', TRUE) AS a, uuid_to_bin('{e60c88ba-083f-4ceb-be59-f67636d718a2}', TRUE) AS b;
+SELECT uuid_to_bin('c8eb4b15cb0948bbbbb2e6a0b6b4d5c7', TRUE) AS a, uuid_to_bin('e60c88ba083f4cebbe59f67636d718a2', TRUE) AS b;
+SELECT uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7', TRUE) AS a, uuid_to_bin('e60c88ba-083f-4ceb-be59-f67636d718a2', TRUE) AS b;
+
+--echo # UUID too long
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5cc7', TRUE) AS a;
+--echo # UUID with invalid characters
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('12345678123456Z81234567812345678', TRUE) AS a;
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('12345678-1234-5678-1234-56781234567Z', TRUE) AS a;
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('e60c88ba-083f-4ceb-be59-f67636d718aa2', TRUE) AS b;
+--echo # UUID too short
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a04d5cc7', TRUE) AS a;
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('e60c88ba-083f-4ceb-be59-f676318aa2', TRUE) AS b;
+
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac798ffcc984ab68')) AS a, bin_to_uuid(unhex('7f9d04ae61b34468ac898ffcc984ab68'),TRUE) AS b;
+--echo # UUID too long
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac798ffcc984ab668')) AS a;
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac898ffcc984ab668'), TRUE) AS b;
+-- echo # UUID too short
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT bin_to_uuid(unhex('7f9d04ae61b34468ac798ffcc98468')) AS a;
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT bin_to_uuid(unhex('7f9d04ab34468ac898ffcc984ab668'), TRUE) AS b;
+
+SELECT uuid_to_bin('{c8eb4b15-CB09-48bb-bbb2-e6a0b6b4d5c7}') = x'c8eb4b15cb0948bbbbb2e6a0b6b4d5c7';
+SELECT uuid_to_bin('{c8eb4b15-CB09-48bb-bbb2-e6a0b6b4d5c7}', TRUE) = x'48bbcb09c8eb4b15bbb2e6a0b6b4d5c7';
+SELECT bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68') = '7f9d04ae-61b3-4468-ac79-8ffcc984ab68';
+SELECT bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68', TRUE) = '61b34468-04ae-7f9d-ac79-8ffcc984ab68';
+
+-- echo # null VALUES
+SELECT bin_to_uuid(NULL) AS a, bin_to_uuid(NULL, TRUE) AS b;
+SELECT uuid_to_bin(NULL) AS a, uuid_to_bin(NULL, TRUE) AS b;
+SELECT is_uuid(NULL);
+
+-- echo # valid uuids
+SELECT is_uuid('{12345678-1234-5678-1234-567812345678}');
+SELECT is_uuid('12345678123456781234567812345678');
+SELECT is_uuid('12345678-1234-5678-1234-567812345678');
+
+-- echo # shorter uuids
+SELECT is_uuid('{2345678-1234-5678-1234-567812345678}');
+SELECT is_uuid('2345678123456781234567812345678');
+SELECT is_uuid('2345678-1234-5678-1234-567812345678');
+
+-- echo # longer uuids
+SELECT is_uuid('{9912345678-1234-5678-1234-567812345678}');
+SELECT is_uuid('9912345678123456781234567812345678');
+SELECT is_uuid('9912345678-1234-5678-1234-567812345678');
+
+-- echo # uuids with missing dash
+SELECT is_uuid('{12345678-12345678-1234-567812345678}');
+SELECT is_uuid('1234567812345-6781234567812345678');
+SELECT is_uuid('12345678-12345678-1234-567812345678');
+
+-- echo # uuids with dash in wrong place
+SELECT is_uuid('{12345678-123456-78-1234-567812345678}');
+SELECT is_uuid('12345678-123456-78-1234-567812345678');
+
+-- echo # tests with tables
+CREATE TABLE t(a binary(16));
+INSERT into t VALUES(unhex('7f9d04ae61b34468ac798ffcc984ab68')),(unhex('d00653b290b940d193c2194456bd4f3d')),(unhex('e60c88ba083f4cebbe59f67636d718a2')),(unhex('c8eb4b15cb0948bbbbb2e6a0b6b4d5c7'));
+
+SELECT bin_to_uuid(a), bin_to_uuid(a,TRUE) FROM t;
+SELECT uuid_to_bin(bin_to_uuid(a)), uuid_to_bin(bin_to_uuid(a)) = a, uuid_to_bin(bin_to_uuid(a, TRUE), TRUE), uuid_to_bin(bin_to_uuid(a, TRUE), TRUE) = a FROM t;
+SELECT bin_to_uuid(uuid_to_bin(bin_to_uuid(a))), bin_to_uuid(uuid_to_bin(bin_to_uuid(a, TRUE), TRUE), TRUE) FROM t;
+
+SELECT bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}')), bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}')) = '12345678-1234-5678-1234-567812345678';
+SELECT bin_to_uuid(uuid_to_bin('12345678123456781234567812345678')),bin_to_uuid(uuid_to_bin('12345678123456781234567812345678')) = '12345678-1234-5678-1234-567812345678';
+SELECT bin_to_uuid(uuid_to_bin('12345678-1234-5678-1234-567812345678')), bin_to_uuid(uuid_to_bin('12345678-1234-5678-1234-567812345678')) = '12345678-1234-5678-1234-567812345678';
+
+DROP TABLE t;
+
+CREATE TABLE at(_bin binary(16),
+                _vbn varbinary(16),
+                _tbl tinyblob,
+                _ttx tinytext,
+                _blb blob);
+
+INSERT into at VALUES(
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678',
+x'12345678123456781234567812345678');
+
+let $query=
+SELECT
+bin_to_uuid(_bin),
+bin_to_uuid(_vbn),
+bin_to_uuid(_tbl),
+bin_to_uuid(_ttx),
+bin_to_uuid(_blb)
+FROM at;
+
+EVAL $query;
+
+-- echo # Output types of bin_to_uuid:
+EVAL CREATE TABLE t3 AS $query;
+SHOW CREATE TABLE t3;
+DROP TABLE t3;
+
+-- echo # Compare with hex:
+DELETE FROM at;
+INSERT into at(_bin,_blb) VALUES('c8eb4b15cb0948bb','c8eb4b15cb0948bb');
+CREATE TABLE t3 AS SELECT hex('c8eb4b15cb0948bb'),hex(_bin),hex(_blb) FROM at;
+SHOW CREATE TABLE t3;
+DROP TABLE t3;
+
+-- echo # Output types of uuid_to_bin
+CREATE TABLE t3 AS SELECT
+uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7') AS a,
+uuid_to_bin('c8eb4b15-cb09-48bb-bbb2-e6a0b6b4d5c7', true) AS b;
+SHOW CREATE TABLE t3;
+DROP TABLE t3;
+
+-- echo # Compare with unhex:
+CREATE TABLE t3 AS SELECT unhex(_bin) FROM at;
+SHOW CREATE TABLE t3;
+DROP TABLE t3;
+
+DROP TABLE at;
+
+-- echo # Bad arguments
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT bin_to_uuid(2);
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin(2);
+
+--Error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT bin_to_uuid();
+--Error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT uuid_to_bin();
+
+--Error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT bin_to_uuid(x'12345678123456781234567812345678', true, false);
+--Error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT uuid_to_bin('12345678-1234-5678-1234-567812345678', true, false);
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT bin_to_uuid(x'');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT bin_to_uuid(x'', true);
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('');
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT uuid_to_bin('', true);
+
+set @a=uuid();
+SELECT bin_to_uuid(uuid_to_bin(@a)) = @a;
+
+-- echo # tests with prepared statements
+PREPARE s FROM "SELECT bin_to_uuid(x'7f9d04ae61b34468ac798ffcc984ab68',true)";
+EXECUTE s;
+EXECUTE s;
+
+PREPARE s2 FROM "SELECT bin_to_uuid(uuid_to_bin('{12345678-1234-5678-1234-567812345678}', true), true)";
+EXECUTE s2;
+EXECUTE s2;
+
+-- echo # Generated column
+
+CREATE TABLE t1(col1 varchar(100), gcol2 binary(16) AS (uuid_to_bin(col1)) virtual, index(gcol2));
+
+INSERT into t1(col1) VALUES
+('{12345678-1234-5678-1234-567812345678}'),
+('12345679123456781234567812345678'),
+('12345670-1234-5678-1234-567812345678');
+
+EXPLAIN SELECT * FROM t1 where gcol2=x'12345679123456781234567812345678';
+SELECT * FROM t1 where gcol2=x'12345679123456781234567812345678';
+
+# Not supported in MariaDB
+#-- echo # Gcol expression is recognized and gcol index is used:
+#EXPLAIN SELECT * FROM t1 where uuid_to_bin(col1)=x'12345679123456781234567812345678';
+#SELECT * FROM t1 where uuid_to_bin(col1)=x'12345679123456781234567812345678';
+
+CREATE TABLE t2(col1 binary(16), gcol2 varchar(36) AS (bin_to_uuid(col1)) virtual, index(col1), index(gcol2));
+
+INSERT into t2(col1) VALUES
+(x'12345678123456781234567812345678'),
+(x'12345679123456781234567812345678'),
+(x'12345670123456781234567812345678');
+
+EXPLAIN SELECT * FROM t2 where col1=x'12345679123456781234567812345678';
+SELECT * FROM t2 where col1=x'12345679123456781234567812345678';
+
+EXPLAIN SELECT * FROM t2 where gcol2='12345679-1234-5678-1234-567812345678';
+SELECT * FROM t2 where gcol2='12345679-1234-5678-1234-567812345678';
+# Not supported in MariaDB
+#EXPLAIN SELECT * FROM t2 where bin_to_uuid(col1)='12345679-1234-5678-1234-567812345678';
+#SELECT * FROM t2 where bin_to_uuid(col1)='12345679-1234-5678-1234-567812345678';
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -2259,6 +2259,43 @@ protected:
 };
 
 
+class Create_func_uuid_to_bin : public Create_native_func
+{
+public:
+  virtual Item* create_native(THD *thd, LEX_STRING name,
+                              List<Item> *item_list);
+  static Create_func_uuid_to_bin s_singleton;
+
+protected:
+  Create_func_uuid_to_bin() {}
+  virtual ~Create_func_uuid_to_bin() {}
+};
+
+class Create_func_is_uuid : public Create_func_arg1
+{
+public:
+  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  static Create_func_is_uuid s_singleton;
+
+protected:
+  Create_func_is_uuid() {}
+  virtual ~Create_func_is_uuid() {}
+};
+
+
+class Create_func_bin_to_uuid : public Create_native_func
+{
+public:
+  virtual Item* create_native(THD *thd, LEX_STRING name,
+                              List<Item> *item_list);
+  static Create_func_bin_to_uuid s_singleton;
+
+protected:
+  Create_func_bin_to_uuid() {}
+  virtual ~Create_func_bin_to_uuid() {}
+};
+
+
 class Create_func_ltrim : public Create_func_arg1
 {
 public:
@@ -5761,6 +5798,89 @@ Create_func_lpad::create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3)
 }
 
 
+Create_func_uuid_to_bin Create_func_uuid_to_bin::s_singleton;
+
+Item*
+Create_func_uuid_to_bin::create_native(THD *thd, LEX_STRING name,
+                                       List<Item> *item_list)
+{
+  Item *func= NULL;
+  int arg_count= 0;
+
+  if (item_list != NULL)
+    arg_count= item_list->elements;
+
+  switch (arg_count) {
+    case 1:
+    {
+      Item *param_1= item_list->pop();
+      func= new (thd->mem_root) Item_func_uuid_to_bin(thd, param_1);
+      break;
+    }
+    case 2:
+    {
+      Item *param_1= item_list->pop();
+      Item *param_2= item_list->pop();
+      func= new (thd->mem_root) Item_func_uuid_to_bin(thd, param_1, param_2);
+      break;
+    }
+    default:
+    {
+      my_error(ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, MYF(0), name.str);
+      break;
+    }
+  }
+
+  return func;
+}
+
+
+Create_func_bin_to_uuid Create_func_bin_to_uuid::s_singleton;
+
+Item*
+Create_func_bin_to_uuid::create_native(THD *thd, LEX_STRING name,
+                                       List<Item> *item_list)
+{
+  Item *func= NULL;
+  int arg_count= 0;
+
+  if (item_list != NULL)
+    arg_count= item_list->elements;
+
+  switch (arg_count) {
+    case 1:
+    {
+      Item *param_1= item_list->pop();
+      func= new (thd->mem_root) Item_func_bin_to_uuid(thd, param_1);
+      break;
+    }
+    case 2:
+    {
+      Item *param_1= item_list->pop();
+      Item *param_2= item_list->pop();
+      func= new (thd->mem_root) Item_func_bin_to_uuid(thd, param_1, param_2);
+      break;
+    }
+    default:
+    {
+      my_error(ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, MYF(0), name.str);
+      break;
+    }
+  }
+
+  return func;
+}
+
+
+Create_func_is_uuid Create_func_is_uuid::s_singleton;
+
+Item*
+Create_func_is_uuid::create_1_arg(THD *thd, Item *arg1)
+{
+  return new (thd->mem_root) Item_func_is_uuid(thd, arg1);
+}
+
+
 Create_func_ltrim Create_func_ltrim::s_singleton;
 
 Item*
@@ -6720,6 +6840,7 @@ static Native_func_registry func_array[] =
   { { C_STRING_WITH_LEN("ATAN2") }, BUILDER(Create_func_atan)},
   { { C_STRING_WITH_LEN("BENCHMARK") }, BUILDER(Create_func_benchmark)},
   { { C_STRING_WITH_LEN("BIN") }, BUILDER(Create_func_bin)},
+  { { C_STRING_WITH_LEN("BIN_TO_UUID") }, BUILDER(Create_func_bin_to_uuid)},
   { { C_STRING_WITH_LEN("BINLOG_GTID_POS") }, BUILDER(Create_func_binlog_gtid_pos)},
   { { C_STRING_WITH_LEN("BIT_COUNT") }, BUILDER(Create_func_bit_count)},
   { { C_STRING_WITH_LEN("BIT_LENGTH") }, BUILDER(Create_func_bit_length)},
@@ -6800,6 +6921,7 @@ static Native_func_registry func_array[] =
   { { C_STRING_WITH_LEN("IS_IPV6") }, BUILDER(Create_func_is_ipv6)},
   { { C_STRING_WITH_LEN("IS_IPV4_COMPAT") }, BUILDER(Create_func_is_ipv4_compat)},
   { { C_STRING_WITH_LEN("IS_IPV4_MAPPED") }, BUILDER(Create_func_is_ipv4_mapped)},
+  { { C_STRING_WITH_LEN("IS_UUID") }, BUILDER(Create_func_is_uuid)},
   { { C_STRING_WITH_LEN("INSTR") }, BUILDER(Create_func_instr)},
   { { C_STRING_WITH_LEN("INTERIORRINGN") }, GEOM_BUILDER(Create_func_interiorringn)},
   { { C_STRING_WITH_LEN("INTERSECTS") }, GEOM_BUILDER(Create_func_mbr_intersects)},
@@ -7031,6 +7153,7 @@ static Native_func_registry func_array[] =
   { { C_STRING_WITH_LEN("UPPER") }, BUILDER(Create_func_ucase)},
   { { C_STRING_WITH_LEN("UUID") }, BUILDER(Create_func_uuid)},
   { { C_STRING_WITH_LEN("UUID_SHORT") }, BUILDER(Create_func_uuid_short)},
+  { { C_STRING_WITH_LEN("UUID_TO_BIN") }, BUILDER(Create_func_uuid_to_bin)},
   { { C_STRING_WITH_LEN("VERSION") }, BUILDER(Create_func_version)},
   { { C_STRING_WITH_LEN("WEEKDAY") }, BUILDER(Create_func_weekday)},
   { { C_STRING_WITH_LEN("WEEKOFYEAR") }, BUILDER(Create_func_weekofyear)},

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -3222,6 +3222,112 @@ bool Item_func_lpad::fix_length_and_dec()
 }
 
 
+String* Item_func_uuid_to_bin::val_str(String *str)
+{
+  DBUG_ASSERT(fixed && (arg_count == 1 || arg_count == 2));
+  null_value= true;
+
+  String *res= args[0]->val_str(str);
+  if (!res || args[0]->null_value)
+    return NULL;
+
+  if (my_uuid_parse(res->ptr(), res->length(), m_bin_buf))
+    goto err;
+
+  /*
+    If there is a second argument which is true, it means
+    that the uuid is version 1 which has the time-low part at the beginning
+    of the uuid. So in order to make it index-friendly the time-low
+    will be swapped with the time-high and the time-mid groups.
+    Time-high has length 4, time-mid and time-low have length 2.
+    (time-low)-(time-mid)-(time-high) => (time-high)-(time-mid)-(time-low)
+  */
+  if (arg_count == 2 && args[1]->val_bool())
+  {
+    swap_variables(uchar, m_bin_buf[4], m_bin_buf[6]);
+    swap_variables(uchar, m_bin_buf[5], m_bin_buf[7]);
+    swap_variables(uchar, m_bin_buf[0], m_bin_buf[4]);
+    swap_variables(uchar, m_bin_buf[1], m_bin_buf[5]);
+    swap_variables(uchar, m_bin_buf[2], m_bin_buf[6]);
+    swap_variables(uchar, m_bin_buf[3], m_bin_buf[7]);
+  }
+
+  null_value= false;
+  str->set(reinterpret_cast<char *>(m_bin_buf), MY_UUID_SIZE,
+            &my_charset_bin);
+  return str;
+
+err:
+  ErrConvString err(res);
+  my_error(ER_WRONG_VALUE_FOR_TYPE, MYF(0), "string", err.ptr(), func_name());
+
+  return NULL;
+}
+
+String *Item_func_bin_to_uuid::val_str_ascii(String *str)
+{
+  DBUG_ASSERT(fixed && (arg_count == 1 || arg_count == 2));
+  null_value= true;
+
+  String *res= args[0]->val_str(str);
+  if (!res || args[0]->null_value)
+    return NULL;
+
+  if (res->length() != MY_UUID_SIZE)
+    goto err;
+
+  /*
+    If there is a second argument which is true,
+    the time-mid and time-high parts of uuid needs to be replaced
+    by time-low as they were previously shuffled to become index-friendly.
+    Time-high has length 4, time-mid and time-low have length 2.
+    (time-high)-(time-mid)-(time-low) => (time-low)-(time-mid)-(time-high)
+  */
+  if (arg_count == 2 && args[1]->val_bool())
+  {
+    uchar rearranged[MY_UUID_SIZE];
+    // The first 4 bytes are restored to "time-low".
+    memcpy(rearranged, &res->ptr()[4], 4);
+    // Bytes starting with 4th will be restored to "time-mid".
+    memcpy(&rearranged[4], &res->ptr()[2], 2);
+    // Bytes starting with 6th will be restored to "time-high".
+    memcpy(&rearranged[6], &res->ptr()[0], 2);
+    // The last 8 bytes were not changed so we just copy them.
+    memcpy(&rearranged[8], &res->ptr()[8], 8);
+    my_uuid2str(rearranged, m_text_buf);
+  }
+  else
+    my_uuid2str(reinterpret_cast<const uchar *>(res->ptr()),
+                                m_text_buf);
+
+  null_value= false;
+  str->set(m_text_buf, MY_UUID_STRING_LENGTH, default_charset());
+  return str;
+
+err:
+  ErrConvString err(res);
+  my_error(ER_WRONG_VALUE_FOR_TYPE, MYF(0), "string", err.ptr(), func_name());
+
+  return NULL;
+}
+
+
+longlong Item_func_is_uuid::val_int()
+{
+  DBUG_ASSERT(fixed && arg_count == 1);
+  null_value= true;
+
+  String buffer;
+  String *arg_str= args[0]->val_str(&buffer);
+
+  if (!arg_str)
+    return 0;
+
+  null_value= false;
+  return my_uuid_is_valid(arg_str->ptr(), arg_str->length());
+}
+
+
 String *Item_func_lpad::val_str(String *str)
 {
   DBUG_ASSERT(fixed == 1);

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -20,6 +20,7 @@
 
 
 /* This file defines all string functions */
+#include "item_cmpfunc.h"             // Item_bool_func
 
 #ifdef USE_PRAGMA_INTERFACE
 #pragma interface			/* gcc class implementation */
@@ -957,6 +958,68 @@ public:
   const char *func_name() const { return "lpad"; }
   Item *get_copy(THD *thd, MEM_ROOT *mem_root)
   { return get_item_copy<Item_func_lpad>(thd, mem_root, this); }
+};
+
+
+class Item_func_uuid_to_bin : public Item_str_func
+{
+  /// Buffer to store the binary result
+  uchar m_bin_buf[MY_UUID_SIZE];
+public:
+  Item_func_uuid_to_bin(THD *thd, Item *arg1)
+    :Item_str_func(thd, arg1)
+  {}
+  Item_func_uuid_to_bin(THD *thd, Item *arg1, Item *arg2)
+    :Item_str_func(thd, arg1, arg2)
+  {}
+  String *val_str(String *);
+  bool fix_length_and_dec()
+  {
+    collation.set(&my_charset_bin);
+    max_length= MY_UUID_SIZE;
+    maybe_null= 1;
+    return FALSE;
+  }
+  const char *func_name() const { return "uuid_to_bin"; }
+  Item *get_copy(THD *thd, MEM_ROOT *mem_root)
+  { return get_item_copy<Item_func_uuid_to_bin>(thd, mem_root, this); }
+};
+
+
+class Item_func_bin_to_uuid : public Item_str_ascii_func
+{
+  /// Buffer to store the text result
+  char m_text_buf[MY_UUID_STRING_LENGTH + 1];
+public:
+  Item_func_bin_to_uuid(THD *thd, Item *arg1)
+    :Item_str_ascii_func(thd, arg1)
+  {}
+  Item_func_bin_to_uuid(THD *thd, Item *arg1, Item *arg2)
+    :Item_str_ascii_func(thd, arg1, arg2)
+  {}
+  String *val_str_ascii(String *);
+  bool fix_length_and_dec()
+  {
+    decimals= 0;
+    fix_length_and_charset(MY_UUID_STRING_LENGTH, default_charset());
+    maybe_null= true;
+    return FALSE;
+  }
+  const char *func_name() const { return "bin_to_uuid"; }
+  Item *get_copy(THD *thd, MEM_ROOT *mem_root)
+  { return get_item_copy<Item_func_bin_to_uuid>(thd, mem_root, this); }
+};
+
+
+class Item_func_is_uuid : public Item_bool_func
+{
+  typedef Item_bool_func super;
+public:
+  Item_func_is_uuid(THD *thd, Item *a): Item_bool_func(thd, a) {}
+  longlong val_int();
+  const char *func_name() const { return "is_uuid"; }
+  Item *get_copy(THD *thd, MEM_ROOT *mem_root)
+  { return get_item_copy<Item_func_is_uuid>(thd, mem_root, this); }
 };
 
 


### PR DESCRIPTION
mostly MySQL's commit d6d1e197f0014dd816494624a255af9a171a5e13 submitted under GPL-2.

Differences to above commit I submit under the MCA.

Rather different item_* interfaces and otherwise functionally identical to 10.4 pr

Differences in `t3` table structure in output, `longtext` vs `mediumtext` for `CREATE TABLE .. SELECT`.