### PR TITLE
Fixes according to Bar's review

### DIFF
--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -18,45 +18,7 @@
 #include <my_pthread.h>
 #ifdef __cplusplus
 #endif
-enum wsrep_conflict_state {
-    NO_CONFLICT,
-    MUST_ABORT,
-    ABORTING,
-    ABORTED,
-    MUST_REPLAY,
-    REPLAYING,
-    RETRY_AUTOCOMMIT,
-    CERT_FAILURE,
-};
 
-enum wsrep_exec_mode {
-    /* Transaction processing before replication. */
-    LOCAL_STATE,
-    /* Slave thread applying write sets from other nodes or replaying thread. */
-    REPL_RECV,
-    /* Total-order-isolation mode. */
-    TOTAL_ORDER,
-    /*
-      Transaction procession after it has been replicated in prepare stage and
-      has passed certification.
-    */
-    LOCAL_COMMIT,
-    LOCAL_ROLLBACK,
-};
-
-enum wsrep_query_state {
-    QUERY_IDLE,
-    QUERY_EXEC,
-    QUERY_COMMITTING,
-    QUERY_EXITING,
-};
-
-enum wsrep_trx_status {
-    WSREP_TRX_OK,
-    WSREP_TRX_CERT_FAIL,      /* certification failure, must abort */
-    WSREP_TRX_SIZE_EXCEEDED,  /* trx size exceeded */
-    WSREP_TRX_ERROR,          /* native mysql error */
-};
 struct xid_t;
 struct wsrep_ws_handle;
 struct wsrep_buf;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6736,9 +6736,6 @@ void ha_fake_trx_id(THD *thd)
   {
     DBUG_VOID_RETURN;
   }
-#ifdef OUT
-  (void *)wsrep_ws_handle_for_trx(&thd->wsrep_ws_handle, thd->query_id);
-#endif
   DBUG_VOID_RETURN;
 }
 #endif /* WITH_WSREP */

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -2460,7 +2460,7 @@ void Item_func_rand::seed_random(Item *arg)
   THD *thd= current_thd;
   if (WSREP(thd))
   {
-    if (wsrep_thd_is_applying(current_thd)) 
+    if (wsrep_thd_is_applying(thd))
       tmp= thd->wsrep_rand;
     else
       tmp= thd->wsrep_rand= (uint32) arg->val_int();

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -1817,8 +1817,8 @@ public:
   String *val_str_ascii(String *);
   bool fix_length_and_dec()
   {
-    max_length = WSREP_GTID_STR_LEN;
-    maybe_null = true;
+    max_length= WSREP_GTID_STR_LEN;
+    maybe_null= true;
     return FALSE;
   }
   Item *get_copy(THD *thd)
@@ -1834,8 +1834,8 @@ public:
   String *val_str_ascii(String *);
   bool fix_length_and_dec()
   {
-    max_length = WSREP_GTID_STR_LEN;
-    maybe_null = true;
+    max_length= WSREP_GTID_STR_LEN;
+    maybe_null= true;
     return FALSE;
   }
   Item *get_copy(THD *thd)

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2047,9 +2047,11 @@ extern "C" void unireg_abort(int exit_code)
     wsrep_close_threads(NULL); /* this won't close all threads */
     sleep(1); /* so give some time to exit for those which can */
     WSREP_INFO("Some threads may fail to exit.");
-
+  }
+  if (WSREP_ON)
+  {
     /* In bootstrap mode we deinitialize wsrep here. */
-    if (opt_bootstrap)
+    if (opt_bootstrap || wsrep_recovery)
     {
       if (wsrep_inited) wsrep_deinit(true);
       wsrep_deinit_server();
@@ -2098,9 +2100,7 @@ static void mysqld_exit(int exit_code)
 #ifdef SAFEMALLOC
     sf_report_leaked_memory(0);
 #endif
-#ifdef TODO
     DBUG_SLOW_ASSERT(global_status_var.global_memory_used == 0);
-#endif
   }
   cleanup_tls();
   DBUG_LEAVE;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1841,13 +1841,6 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
         thd->mysys_var->abort     = 0;
         thd->wsrep_retry_counter  = 0;
         mysql_mutex_unlock(&thd->LOCK_thd_data);
-#ifdef WSREP_TODO
-        /*
-          Increment threads running to compensate dec_thread_running() called
-          after dispatch_end label.
-        */
-        inc_thread_running();
-#endif /* WSREP_TODO */
         goto dispatch_end;
       }
     }
@@ -1952,13 +1945,6 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
           thd->mysys_var->abort     = 0;
           thd->wsrep_retry_counter  = 0;
           mysql_mutex_unlock(&thd->LOCK_thd_data);
-#ifdef WSREP_TODO
-          /*
-            Increment threads running to compensate dec_thread_running() called
-            after dispatch_end label.
-          */
-          inc_thread_running();
-#endif /* WSREP_TODO */
 
           goto dispatch_end;
         }
@@ -7964,7 +7950,7 @@ static void wsrep_prepare_for_autocommit_retry(THD* thd,
 
   /* DTRACE begin */
   MYSQL_QUERY_START(rawbuf, thd->thread_id,
-	            (char *)(thd->db.str ? : thd->db.str : "unknown"),
+	            (char *)(thd->db.str ? thd->db.str : "unknown"),
                     &thd->security_ctx->priv_user[0],
                     (char *) thd->security_ctx->host_or_ip);
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -7950,7 +7950,7 @@ static void wsrep_prepare_for_autocommit_retry(THD* thd,
 
   /* DTRACE begin */
   MYSQL_QUERY_START(rawbuf, thd->thread_id,
-	            (char *)(thd->db.str ? thd->db.str : "unknown"),
+                    thd->get_db(),
                     &thd->security_ctx->priv_user[0],
                     (char *) thd->security_ctx->host_or_ip);
 

--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -39,7 +39,7 @@ static Log_event* wsrep_read_log_event(
   DBUG_ENTER("wsrep_read_log_event");
   char *head= (*arg_buf);
 
-  uint data_len = uint4korr(head + EVENT_LEN_OFFSET);
+  uint data_len= uint4korr(head + EVENT_LEN_OFFSET);
   char *buf= (*arg_buf);
   const char *error= 0;
   Log_event *res=  0;
@@ -99,7 +99,7 @@ void wsrep_apply_error::store(const THD* const thd)
     if (NULL == str_)
     {
       WSREP_ERROR("Failed to allocate %zu bytes for error buffer.", max_len);
-      len_ = 0;
+      len_= 0;
       return;
     }
   }
@@ -202,8 +202,8 @@ int wsrep_apply_events(THD*        thd,
       (thd->variables.option_bits & ~OPTION_SKIP_REPLICATION) |
       (ev->flags & LOG_EVENT_SKIP_REPLICATION_F ?  OPTION_SKIP_REPLICATION : 0);
 
-    ev->thd = thd;
-    exec_res = ev->apply_event(thd->wsrep_rgi);
+    ev->thd= thd;
+    exec_res= ev->apply_event(thd->wsrep_rgi);
     DBUG_PRINT("info", ("exec_event result: %d", exec_res));
 
     if (exec_res)

--- a/sql/wsrep_check_opts.cc
+++ b/sql/wsrep_check_opts.cc
@@ -33,7 +33,7 @@ int wsrep_check_opts()
         autoinc_lock_mode->val_int(&is_null, 0, OPT_GLOBAL, 0) != 2)
     {
       WSREP_ERROR("Parallel applying (wsrep_slave_threads > 1) requires"
-                  " innodb_autoinc_lock_mode = 2.");
+                  " innodb_autoinc_lock_mode= 2.");
       return 1;
     }
   }
@@ -88,7 +88,7 @@ int wsrep_check_opts()
   {
     if (global_system_variables.binlog_format != BINLOG_FORMAT_ROW)
     {
-      WSREP_ERROR("Only binlog_format = 'ROW' is currently supported. "
+      WSREP_ERROR("Only binlog_format= 'ROW' is currently supported. "
                   "Configured value: '%s'. Please adjust your "
                   "configuration.",
                   binlog_format_names[global_system_variables.binlog_format]);

--- a/sql/wsrep_dummy.cc
+++ b/sql/wsrep_dummy.cc
@@ -35,7 +35,7 @@ long long wsrep_xid_seqno(const XID* x)
 
 const unsigned char* wsrep_xid_uuid(const XID*)
 {
-    static const unsigned char uuid[16] = {0};
+    static const unsigned char uuid[16]= {0};
     return uuid;
 }
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -54,7 +54,7 @@
 /* wsrep-lib */
 Wsrep_server_state* Wsrep_server_state::m_instance;
 
-my_bool wsrep_emulate_bin_log   = FALSE; // activating parts of binlog interface
+my_bool wsrep_emulate_bin_log  = FALSE; // activating parts of binlog interface
 #ifdef GTID_SUPPORT
 /* Sidno in global_sid_map corresponding to group uuid */
 rpl_sidno wsrep_sidno= -1;
@@ -152,7 +152,7 @@ mysql_mutex_t LOCK_wsrep_thd_pool; /* locking policy:
                                    */
 
 int wsrep_replaying= 0;
-ulong  wsrep_running_threads = 0; // # of currently running wsrep threads
+ulong  wsrep_running_threads= 0; // # of currently running wsrep threads
 ulong  my_bind_addr;
 
 #ifdef HAVE_PSI_INTERFACE
@@ -205,10 +205,10 @@ static PSI_file_info wsrep_files[]=
 };
 #endif
 
-my_bool wsrep_inited                   = 0; // initialized ?
+my_bool wsrep_inited= 0; // initialized ?
 
 static wsrep_uuid_t node_uuid= WSREP_UUID_UNDEFINED;
-static wsrep_uuid_t cluster_uuid = WSREP_UUID_UNDEFINED;
+static wsrep_uuid_t cluster_uuid= WSREP_UUID_UNDEFINED;
 static char         cluster_uuid_str[40]= { 0, };
 
 static char provider_name[256]= { 0, };
@@ -219,26 +219,26 @@ static char provider_vendor[256]= { 0, };
  * Wsrep status variables. LOCK_status must be locked When modifying
  * these variables,
  */
-my_bool     wsrep_connected          = FALSE;
-my_bool     wsrep_ready              = FALSE;
-const char* wsrep_cluster_state_uuid = cluster_uuid_str;
-long long   wsrep_cluster_conf_id    = WSREP_SEQNO_UNDEFINED;
-const char* wsrep_cluster_status     = "Disconnected";
-long        wsrep_cluster_size       = 0;
-long        wsrep_local_index        = -1;
-long long   wsrep_local_bf_aborts    = 0;
-const char* wsrep_provider_name      = provider_name;
-const char* wsrep_provider_version   = provider_version;
-const char* wsrep_provider_vendor    = provider_vendor;
-char* wsrep_provider_capabilities    = NULL;
-char* wsrep_cluster_capabilities     = NULL;
+my_bool     wsrep_connected         = FALSE;
+my_bool     wsrep_ready             = FALSE;
+const char* wsrep_cluster_state_uuid= cluster_uuid_str;
+long long   wsrep_cluster_conf_id   = WSREP_SEQNO_UNDEFINED;
+const char* wsrep_cluster_status    = "Disconnected";
+long        wsrep_cluster_size      = 0;
+long        wsrep_local_index       = -1;
+long long   wsrep_local_bf_aborts   = 0;
+const char* wsrep_provider_name     = provider_name;
+const char* wsrep_provider_version  = provider_version;
+const char* wsrep_provider_vendor   = provider_vendor;
+char* wsrep_provider_capabilities   = NULL;
+char* wsrep_cluster_capabilities    = NULL;
 /* End wsrep status variables */
 
 wsp::Config_state *wsrep_config_state;
 
 
-wsrep_uuid_t               local_uuid        = WSREP_UUID_UNDEFINED;
-wsrep_seqno_t              local_seqno       = WSREP_SEQNO_UNDEFINED;
+wsrep_uuid_t               local_uuid       = WSREP_UUID_UNDEFINED;
+wsrep_seqno_t              local_seqno      = WSREP_SEQNO_UNDEFINED;
 wsp::node_status           local_status;
 
 /*
@@ -273,7 +273,6 @@ static void wsrep_log_cb(wsrep::log::level level, const char *msg)
   }
 }
 
-//#ifdef GTID_SUPPORT
 void wsrep_init_sidno(const wsrep::id& uuid)
 {
   /*
@@ -291,18 +290,17 @@ void wsrep_init_sidno(const wsrep::id& uuid)
     wsrep_uuid_t ltid_uuid;
     for (size_t i= 0; i < sizeof(ltid_uuid.data); ++i)
     {
-      ltid_uuid.data[i] = ~((const uchar*)uuid.data())[i];
+      ltid_uuid.data[i]= ~((const uchar*)uuid.data())[i];
     }
     memcpy((void*)&sid, (const uchar*)ltid_uuid.data,16);
   }
-#ifdef NOT_MERGED
+#ifdef GTID_SUPPORT
   global_sid_lock->wrlock();
   wsrep_sidno= global_sid_map->add_sid(sid);
   WSREP_INFO("Initialized wsrep sidno %d", wsrep_sidno);
   global_sid_lock->unlock();
 #endif
 }
-//#endif /* GTID_SUPPORT */
 
 void wsrep_init_schema()
 {
@@ -311,10 +309,8 @@ void wsrep_init_schema()
   WSREP_INFO("wsrep_init_schema_and_SR %p", wsrep_schema);
   if (!wsrep_schema)
   {
-    // if (wsrep_before_SE()) {
     DBUG_ASSERT(!wsrep_thd_pool);
     wsrep_thd_pool= new Wsrep_thd_pool(WSREP_THD_POOL_SIZE);
-    //}
     wsrep_schema= new Wsrep_schema(wsrep_thd_pool);
     if (wsrep_schema->init())
     {
@@ -373,13 +369,13 @@ static void wsrep_capabilities_export(wsrep_cap_t const cap, char** str)
   };
 
   std::string s;
-  for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); ++i)
+  for (size_t i= 0; i < sizeof(names) / sizeof(names[0]); ++i)
   {
     if (cap & (1ULL << i))
     {
       if (s.empty())
       {
-        s = ":";
+        s= ":";
       }
       s += names[i];
       s += ":";
@@ -389,9 +385,9 @@ static void wsrep_capabilities_export(wsrep_cap_t const cap, char** str)
   /* A read from the string pointed to by *str may be started at any time,
    * so it must never point to free(3)d memory or non '\0' terminated string. */
 
-  char* const previous = *str;
+  char* const previous= *str;
 
-  *str = strdup(s.c_str());
+  *str= strdup(s.c_str());
 
   if (previous != NULL)
   {
@@ -404,20 +400,6 @@ static void wsrep_capabilities_export(wsrep_cap_t const cap, char** str)
 void wsrep_verify_SE_checkpoint(const wsrep_uuid_t& uuid,
                                 wsrep_seqno_t const seqno)
 {
-#if 0
-  wsrep_get_SE_checkpoint(local_uuid, local_seqno);
-
-  if (memcmp(&local_uuid, &uuid, sizeof (wsrep_uuid_t)) ||
-             local_seqno > seqno)
-  {
-    WSREP_ERROR("Failed to update SE checkpoint. Can't continue.");
-    wsrep_log_states(WSREP_LOG_FATAL, &uuid, seqno,
-                     &local_uuid, local_seqno);
-    assert(0);
-    unireg_abort(1);
-  }
-#endif
-  // wsrep_init_sidno(local_uuid);
 }
 
 /*
@@ -451,37 +433,6 @@ void wsrep_update_cluster_state_uuid(const char* uuid)
 
 static void wsrep_init_position()
 {
-#if 0
-  /* read XIDs from storage engines */
-  wsrep_uuid_t uuid;
-  wsrep_seqno_t seqno;
-  wsrep_get_SE_checkpoint(uuid, seqno);
-
-  if (wsrep_uuid_compare(&uuid, &WSREP_UUID_UNDEFINED) == 0)
-  {
-    WSREP_INFO("Read nil XID from storage engines, skipping position init");
-    return;
-  }
-
-  char uuid_str[40] = {0, };
-  wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
-  WSREP_INFO("Storage engines initial position: %s:%lld",
-             uuid_str, (long long)seqno);
-
-  if (wsrep_uuid_compare(&local_uuid, &WSREP_UUID_UNDEFINED) == 0 &&
-      local_seqno == WSREP_SEQNO_UNDEFINED)
-  {
-    // Initial state
-    local_uuid= uuid;
-    local_seqno= seqno;
-  }
-  else if (memcmp(&local_uuid, &uuid, sizeof(local_uuid)) ||
-           local_seqno != seqno)
-  {
-    WSREP_WARN("Initial position was provided by configuration or SST, "
-               "avoiding override");
-  }
-#endif
 }
 
 /****************************************************************************
@@ -495,11 +446,6 @@ static std::string wsrep_server_name()
 
 static std::string wsrep_server_id()
 {
-#ifdef WSREP_TODO
-  std::stringstream ss;
-  ss << server_id;
-  return(ss.str());
-#endif
   /* using empty server_id, which enables view change handler to
      set final server_id later on
   */
@@ -512,12 +458,12 @@ static std::string wsrep_server_node_address()
 
   std::string ret;
   if (!wsrep_data_home_dir || strlen(wsrep_data_home_dir) == 0)
-    wsrep_data_home_dir = mysql_real_data_home;
+    wsrep_data_home_dir= mysql_real_data_home;
 
   /* Initialize node address */
   if (!wsrep_node_address || !strcmp(wsrep_node_address, ""))
   {
-    char node_addr[512] = {0, };
+    char node_addr[512]= {0, };
     const size_t node_addr_max= sizeof(node_addr) - 1;
     size_t guess_ip_ret= wsrep_guess_ip(node_addr, node_addr_max);
     if (!(guess_ip_ret > 0 && guess_ip_ret < node_addr_max))
@@ -527,12 +473,12 @@ static std::string wsrep_server_node_address()
     }
     else
     {
-      ret = node_addr;
+      ret= node_addr;
     }
   }
   else
   {
-    ret = wsrep_node_address;
+    ret= wsrep_node_address;
   }
   return ret;
 }
@@ -621,7 +567,7 @@ static std::string wsrep_server_incoming_address()
   }
   
  done:
-  ret = wsrep_node_incoming_address;
+  ret= wsrep_node_incoming_address;
   return ret;
 }
 
@@ -630,11 +576,11 @@ static std::string wsrep_server_working_dir()
   std::string ret;
   if (!wsrep_data_home_dir || strlen(wsrep_data_home_dir) == 0)
   {
-    ret = mysql_real_data_home;
+    ret= mysql_real_data_home;
   }
   else
   {
-    ret = wsrep_data_home_dir;
+    ret= wsrep_data_home_dir;
   }
   return ret;
 }
@@ -722,7 +668,7 @@ int wsrep_init()
       !strcmp(wsrep_provider, WSREP_NONE))
   {
     // enable normal operation in case no provider is specified
-    global_system_variables.wsrep_on = 0;
+    global_system_variables.wsrep_on= 0;
     int err= Wsrep_server_state::instance().load_provider(wsrep_provider, wsrep_provider_options ? wsrep_provider_options : "");
     if (err)
     {
@@ -732,7 +678,7 @@ int wsrep_init()
     return err;
   }
 
-  global_system_variables.wsrep_on = 1;
+  global_system_variables.wsrep_on= 1;
 
   if (wsrep_gtid_mode && opt_bin_log && !opt_log_slave_updates)
   {
@@ -743,7 +689,7 @@ int wsrep_init()
   }
 
   if (!wsrep_data_home_dir || strlen(wsrep_data_home_dir) == 0)
-    wsrep_data_home_dir = mysql_real_data_home;
+    wsrep_data_home_dir= mysql_real_data_home;
 
   if (Wsrep_server_state::instance().load_provider(wsrep_provider,
                                                    wsrep_provider_options))
@@ -779,7 +725,7 @@ int wsrep_init()
 void wsrep_thr_init()
 {
   DBUG_ENTER("wsrep_thr_init");
-  wsrep_config_state = new wsp::Config_state;
+  wsrep_config_state= new wsp::Config_state;
 #ifdef HAVE_PSI_INTERFACE
   mysql_mutex_register("sql", wsrep_mutexes, array_elements(wsrep_mutexes));
   mysql_cond_register("sql", wsrep_conds, array_elements(wsrep_conds));
@@ -879,8 +825,8 @@ void wsrep_deinit(bool free_options)
 
   if (wsrep_provider_capabilities != NULL)
   {
-    char* p = wsrep_provider_capabilities;
-    wsrep_provider_capabilities = NULL;
+    char* p= wsrep_provider_capabilities;
+    wsrep_provider_capabilities= NULL;
     free(p);
   }
 
@@ -916,8 +862,8 @@ void wsrep_thr_deinit()
 
   if (wsrep_cluster_capabilities != NULL)
   {
-    char* p = wsrep_cluster_capabilities;
-    wsrep_cluster_capabilities = NULL;
+    char* p= wsrep_cluster_capabilities;
+    wsrep_cluster_capabilities= NULL;
     free(p);
   }
 }
@@ -980,7 +926,6 @@ void wsrep_shutdown_replication()
   }
 
   wsrep_close_client_connections(TRUE);
-  // wsrep_close_SR_transactions(NULL);
 
   /* wait until appliers have stopped */
   wsrep_wait_appliers_close(NULL);
@@ -990,7 +935,6 @@ void wsrep_shutdown_replication()
   {
     /* Undocking the thread specific data. */
     my_pthread_setspecific_ptr(THR_THD, NULL);
-    //my_pthread_setspecific_ptr(THR_MALLOC, NULL);
   }
 }
 
@@ -1060,7 +1004,6 @@ bool wsrep_must_sync_wait (THD* thd, uint mask)
     thd->wsrep_trx().state() !=
     wsrep::transaction::s_replaying &&
     thd->wsrep_cs().sync_wait_gtid().is_undefined();
-    // thd->wsrep_sync_wait_gtid.seqno == WSREP_SEQNO_UNDEFINED;
   mysql_mutex_unlock(&thd->LOCK_thd_data);
   return ret;
 }
@@ -1069,22 +1012,25 @@ bool wsrep_sync_wait (THD* thd, uint mask)
 {
   if (wsrep_must_sync_wait(thd, mask))
   {
-    WSREP_DEBUG("wsrep_sync_wait: thd->variables.wsrep_sync_wait = %u, "
-                "mask = %u, thd->variables.wsrep_on = %d",
+    WSREP_DEBUG("wsrep_sync_wait: thd->variables.wsrep_sync_wait= %u, "
+                "mask= %u, thd->variables.wsrep_on= %d",
                 thd->variables.wsrep_sync_wait, mask,
                 thd->variables.wsrep_on);
-    // This allows autocommit SELECTs and a first SELECT after SET AUTOCOMMIT=0
-    // TODO: modify to check if thd has locked any rows.
-    // enum wsrep::provider::status ret = wsrep_sync_wait_upto(thd, NULL, -1);
+    /*
+      This allows autocommit SELECTs and a first SELECT after SET AUTOCOMMIT=0
+      TODO: modify to check if thd has locked any rows.
+    */
     if (thd->wsrep_cs().sync_wait(-1))
     {
       const char* msg;
       int err;
 
-      // Possibly relevant error codes:
-      // ER_CHECKREAD, ER_ERROR_ON_READ, ER_INVALID_DEFAULT, ER_EMPTY_QUERY,
-      // ER_FUNCTION_NOT_DEFINED, ER_NOT_ALLOWED_COMMAND, ER_NOT_SUPPORTED_YET,
-      // ER_FEATURE_DISABLED, ER_QUERY_INTERRUPTED
+      /*
+        Possibly relevant error codes:
+        ER_CHECKREAD, ER_ERROR_ON_READ, ER_INVALID_DEFAULT, ER_EMPTY_QUERY,
+        ER_FUNCTION_NOT_DEFINED, ER_NOT_ALLOWED_COMMAND, ER_NOT_SUPPORTED_YET,
+        ER_FEATURE_DISABLED, ER_QUERY_INTERRUPTED
+      */
 
       switch (thd->wsrep_cs().current_error())
       {
@@ -1170,7 +1116,6 @@ static bool wsrep_prepare_key_for_isolation(const char* db,
     *key_len= 0;
     if (db)
     {
-      // sql_print_information("%s.%s", db, table);
       key[*key_len].ptr= db;
       key[*key_len].len= strlen(db);
       ++(*key_len);
@@ -1312,10 +1257,10 @@ bool wsrep_prepare_key(const uchar* cache_key, size_t cache_key_len,
     {
     case 0:
     {
-        key[0].ptr = cache_key;
-        key[0].len = cache_key_len;
+        key[0].ptr= cache_key;
+        key[0].len= cache_key_len;
 
-        *key_len = 1;
+        *key_len= 1;
         break;
     }
     case 1:
@@ -1323,21 +1268,21 @@ bool wsrep_prepare_key(const uchar* cache_key, size_t cache_key_len,
     case 3:
     case 4:
     {
-        key[0].ptr = cache_key;
-        key[0].len = strlen( (char*)cache_key );
+        key[0].ptr= cache_key;
+        key[0].len= strlen( (char*)cache_key );
 
-        key[1].ptr = cache_key + strlen( (char*)cache_key ) + 1;
-        key[1].len = strlen( (char*)(key[1].ptr) );
+        key[1].ptr= cache_key + strlen( (char*)cache_key ) + 1;
+        key[1].len= strlen( (char*)(key[1].ptr) );
 
-        *key_len = 2;
+        *key_len= 2;
         break;
     }
     default:
         return false;
     }
 
-    key[*key_len].ptr = row_id;
-    key[*key_len].len = row_id_len;
+    key[*key_len].ptr= row_id;
+    key[*key_len].len= row_id_len;
     ++(*key_len);
 
     return true;
@@ -1514,7 +1459,7 @@ create_view_query(THD *thd, uchar** buf, size_t* buf_len)
     LEX *lex= thd->lex;
     SELECT_LEX *select_lex= lex->first_select_lex();
     TABLE_LIST *first_table= select_lex->table_list.first;
-    TABLE_LIST *views = first_table;
+    TABLE_LIST *views= first_table;
     LEX_USER *definer;
     String buff;
     const LEX_CSTRING command[3]=
@@ -1539,16 +1484,16 @@ create_view_query(THD *thd, uchar** buf, size_t* buf_len)
 
     if (definer)
     {
-      views->definer.user = definer->user;
-      views->definer.host = definer->host;
+      views->definer.user= definer->user;
+      views->definer.host= definer->host;
     } else {
       WSREP_ERROR("Failed to get DEFINER for VIEW.");
       return 1;
     }
 
-    views->algorithm    = lex->create_view->algorithm;
-    views->view_suid    = lex->create_view->suid;
-    views->with_check   = lex->create_view->check;
+    views->algorithm   = lex->create_view->algorithm;
+    views->view_suid   = lex->create_view->suid;
+    views->with_check  = lex->create_view->check;
 
     view_store_options(thd, views, &buff);
     buff.append(STRING_WITH_LEN("VIEW "));
@@ -1574,12 +1519,8 @@ create_view_query(THD *thd, uchar** buf, size_t* buf_len)
       buff.append(')');
     }
     buff.append(STRING_WITH_LEN(" AS "));
-    //buff.append(views->source.str, views->source.length);
     buff.append(thd->lex->create_view->select.str,
                 thd->lex->create_view->select.length);
-    //int errcode= query_error_code(thd, TRUE);
-    //if (thd->binlog_query(THD::STMT_QUERY_TYPE,
-    //                      buff.ptr(), buff.length(), FALSE, FALSE, FALSE, errcod
     return wsrep_to_buf_helper(thd, buff.ptr(), buff.length(), buf, buf_len);
 }
 
@@ -1775,7 +1716,7 @@ static bool wsrep_can_run_in_nbo(THD *thd)
 static int wsrep_create_sp(THD *thd, uchar** buf, size_t* buf_len)
 {
   String log_query;
-  sp_head *sp = thd->lex->sphead;
+  sp_head *sp= thd->lex->sphead;
   sql_mode_t saved_mode= thd->variables.sql_mode;
   String retstr(64);
   LEX_CSTRING returns= empty_clex_str;
@@ -1851,13 +1792,6 @@ static void wsrep_TOI_begin_failed(THD* thd, const wsrep_buf_t* /* const err */)
     /* GTID was granted and TO acquired - need to log event and release TO */
     if (wsrep_emulate_bin_log) wsrep_thd_binlog_trx_reset(thd);
     if (wsrep_write_dummy_event(thd, "TOI begin failed")) { goto fail; }
-#if 0
-    /* todo */
-    wsrep_xid_init(&thd->wsrep_xid,
-                   thd->wsrep_trx_meta.gtid.uuid,
-                   thd->wsrep_trx_meta.gtid.seqno);
-    if (tc_log) tc_log->commit(thd, true);
-#endif /* 0 */
     wsrep::client_state& cs(thd->wsrep_cs());
     int const ret= cs.leave_toi();
     if (ret)
@@ -1924,8 +1858,6 @@ static int wsrep_TOI_begin(THD *thd, const char *db, const char *table,
   bool run_in_nbo= (thd->variables.wsrep_OSU_method == WSREP_OSU_NBO &&
                     can_run_in_nbo);
 
-  // uint32_t flags= (run_in_nbo ? WSREP_FLAG_TRX_START :
-  //                WSREP_FLAG_TRX_START | WSREP_FLAG_TRX_END);
   uchar* buf= 0;
   size_t buf_len(0);
   int buf_err;
@@ -2030,13 +1962,8 @@ static int wsrep_TOI_begin(THD *thd, const char *db, const char *table,
         ::abort();
       }
 
-      // thd->wsrep_exec_mode= TOTAL_ORDER;
       ++wsrep_to_isolation;
 
-      // WSREP_DEBUG("TO BEGIN(%lu): %lld, %d, %s",
-      //          thd->thread_id,
-      //         (long long)wsrep_thd_trx_seqno(thd),
-      //            thd->wsrep_exec_mode, WSREP_QUERY(thd));
       rc= 0;
 
     }
@@ -2080,8 +2007,6 @@ static void wsrep_TOI_end(THD *thd) {
     {
       wsrep_apply_error err;
       err.store(thd);
-      // wsrep_buf_t const tmp= err.get_buf();
-      // ret= wsrep_ptr->to_execute_end(wsrep_ptr, thd->thread_id, &tmp);
       client_state.leave_toi();
     }
     else
@@ -2117,7 +2042,7 @@ static int wsrep_RSU_begin(THD *thd, const char *db_, const char *table_)
   }
   else
   {
-    thd->variables.wsrep_on = 0;
+    thd->variables.wsrep_on= 0;
   }
   return 0;
 }
@@ -2130,7 +2055,7 @@ static void wsrep_RSU_end(THD *thd)
   {
     WSREP_WARN("Failed to end RSU, server may need to be restarted");
   }
-  thd->variables.wsrep_on = 1;
+  thd->variables.wsrep_on= 1;
 }
 
 int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
@@ -2179,8 +2104,8 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
    */
   if (wsrep_auto_increment_control)
   {
-    thd->variables.auto_increment_offset = 1;
-    thd->variables.auto_increment_increment = 1;
+    thd->variables.auto_increment_offset= 1;
+    thd->variables.auto_increment_increment= 1;
   }
 
   if (thd->variables.wsrep_on && wsrep_thd_is_local(thd))
@@ -2203,7 +2128,7 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
     case 0: /* wsrep_TOI_begin sould set toi mode */ break;
     case 1:
       /* TOI replication skipped, treat as success */
-      ret = 0;
+      ret= 0;
       break;
     case -1:
       /* TOI replication failed, treat as error */
@@ -2238,95 +2163,11 @@ void wsrep_to_isolation_end(THD *thd)
 void wsrep_begin_nbo_unlock(THD* thd)
 {
   DBUG_ASSERT(0);
-#if 0
-  DBUG_ASSERT(thd->wsrep_nbo_ctx);
-  if (wsrep_thd_is_toi(thd))
-  {
-    if (wsrep_ptr->to_execute_end(wsrep_ptr, thd->thread_id, NULL) != WSREP_OK) {
-      WSREP_ERROR("Non-blocking operation failed to release provider "
-                  "resources, cannot continue");
-      unireg_abort(1);
-    }
-  }
-  else if (wsrep_thd_is_applying(thd))
-  {
-    thd->wsrep_nbo_ctx->signal();
-  }
-  thd->wsrep_nbo_ctx->set_toi_released(true);
-#endif
 }
 
 void wsrep_end_nbo_lock(THD* thd, const TABLE_LIST *table_list)
 {
   DBUG_ASSERT(0);
-#if 0
-  DBUG_ASSERT(thd->wsrep_nbo_ctx);
-
-  // Release TOI critical section if not released yet. This
-  // may happen if operation fails in early phase.
-  if (thd->wsrep_nbo_ctx->toi_released() == false) {
-    wsrep_begin_nbo_unlock(thd);
-  }
-
-  DBUG_ASSERT(wsrep_thd_is_toi(thd) || wsrep_thd_is_applying(thd));
-  wsrep_status_t ret;
-  uint32_t flags= WSREP_FLAG_TRX_END;
-
-  wsrep_key_arr_t key_arr= {0, 0};
-
-  if (wsrep_prepare_keys_for_isolation(thd, NULL, NULL, table_list, &key_arr))
-  {
-    WSREP_ERROR("Failed to prepare keys for NBO end. This is fatal, must abort");
-    unireg_abort(1);
-
-  }
-  thd_proc_info(thd, "acquiring total order isolation for NBO end");
-
-  DBUG_ASSERT(key_arr.keys_len > 0);
-
-  time_t wait_start= time(NULL);
-  while ((ret= wsrep_ptr->to_execute_start(wsrep_ptr, thd->thread_id,
-                                       key_arr.keys, key_arr.keys_len, 0, 0,
-                                       flags,
-                                       &thd->wsrep_trx_meta))
-         == WSREP_CONN_FAIL) {
-    if (thd->killed != NOT_KILLED) {
-      WSREP_ERROR("Non-blocking operation end failed to sync with group, "
-                  "thd killed %d", thd->killed);
-      /* Error handling happens outside of while() */
-      break;
-    }
-    usleep(100000);
-    if (ulong(time(NULL) - wait_start) >= thd->variables.lock_wait_timeout)
-    {
-      WSREP_ERROR("Lock wait timeout while waiting NBO end to replicate.");
-      break;
-    }
-  }
-
-  if (ret != WSREP_OK)
-  {
-    WSREP_ERROR("Failed to acquire total order isolation for non-blocking DDL "
-                "end event, provider returned error code %d: "
-                "(schema: %s, query: %s)",
-                ret, (thd->db.str ? thd->db.str : "(null)"),
-                WSREP_QUERY(thd));
-    thd->get_stmt_da()->set_overwrite_status(true);
-    my_error(ER_ERROR_DURING_COMMIT, MYF(0), ret);
-    thd->get_stmt_da()->set_overwrite_status(false);
-    WSREP_ERROR("This will leave database in inconsistent state since DDL "
-                "execution cannot be terminated in order. Node must rejoin "
-                "the cluster via SST");
-    wsrep_ptr->free_connection(wsrep_ptr, thd->thread_id);
-    wsrep_ptr->disconnect(wsrep_ptr);
-    // We let the operation to finish out of order in order to release
-    // all resources properly. However GTID is cleared so that the
-    // event won't be binlogged with incorrect GTID.
-    thd->wsrep_trx_meta.gtid= WSREP_GTID_UNDEFINED;
-  }
-
-  thd->wsrep_nbo_ctx->set_toi_released(false);
-#endif
 }
 
 #define WSREP_MDL_LOG(severity, msg, schema, schema_len, req, gra)             \
@@ -2387,7 +2228,7 @@ bool wsrep_grant_mdl_exception(MDL_context *requestor_ctx,
                       schema, schema_len, request_thd, granted_thd);
         mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
         wsrep_abort_thd((void*)request_thd, (void*)granted_thd, 1);
-        ret = FALSE;
+        ret= FALSE;
       }
       else
       {
@@ -2395,7 +2236,7 @@ bool wsrep_grant_mdl_exception(MDL_context *requestor_ctx,
                       request_thd, granted_thd);
         ticket->wsrep_report(true);
         mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
-        ret = TRUE;
+        ret= TRUE;
       }
     }
     else if (granted_thd->lex->sql_command == SQLCOM_FLUSH ||
@@ -2404,7 +2245,7 @@ bool wsrep_grant_mdl_exception(MDL_context *requestor_ctx,
       WSREP_DEBUG("BF thread waiting for FLUSH");
       ticket->wsrep_report(wsrep_debug);
       mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
-      ret = FALSE;
+      ret= FALSE;
     }
     else if (request_thd->lex->sql_command == SQLCOM_DROP_TABLE)
     {
@@ -2413,7 +2254,7 @@ bool wsrep_grant_mdl_exception(MDL_context *requestor_ctx,
       ticket->wsrep_report(wsrep_debug);
       mysql_mutex_unlock(&granted_thd->LOCK_thd_data);
       wsrep_abort_thd((void*)request_thd, (void*)granted_thd, 1);
-      ret = FALSE;
+      ret= FALSE;
     }
     else
     {
@@ -2688,9 +2529,11 @@ void wsrep_wait_appliers_close(THD *thd)
   /* Wait for wsrep appliers to gracefully exit */
   mysql_mutex_lock(&LOCK_thread_count);
   while (wsrep_running_threads > 2)
-  // 2 is for rollbacker thread which needs to be killed explicitly.
-  // This gotta be fixed in a more elegant manner if we gonna have arbitrary
-  // number of non-applier wsrep threads.
+    /*
+      2 is for rollbacker thread which needs to be killed explicitly.
+      This gotta be fixed in a more elegant manner if we gonna have arbitrary
+      number of non-applier wsrep threads.
+    */
   {
     if (thread_handling > SCHEDULER_ONE_THREAD_PER_CONNECTION)
     {
@@ -2745,7 +2588,6 @@ void wsrep_kill_mysql(THD *thd)
 void
 wsrep_last_committed_id(wsrep_gtid_t* gtid)
 {
-  // wsrep_ptr->last_committed_id(wsrep_ptr, gtid);
   wsrep::gtid ret= Wsrep_server_state::instance().last_committed_gtid();
   memcpy(gtid->uuid.data, ret.id().data(), sizeof(gtid->uuid.data));
   gtid->seqno= ret.seqno().get();
@@ -2754,7 +2596,7 @@ wsrep_last_committed_id(wsrep_gtid_t* gtid)
 void
 wsrep_node_uuid(wsrep_uuid_t& uuid)
 {
-  uuid = node_uuid;
+  uuid= node_uuid;
 }
 
 int wsrep_must_ignore_error(THD* thd)
@@ -3030,7 +2872,6 @@ int wsrep_create_trigger_query(THD *thd, uchar** buf, size_t* buf_len)
 void* start_wsrep_THD(void *arg)
 {
   THD *thd;
-  //wsrep_thd_processor_fun processor= (wsrep_thd_processor_fun)arg;
 
   Wsrep_thd_args* thd_args= (Wsrep_thd_args*) arg;
 
@@ -3103,7 +2944,6 @@ void* start_wsrep_THD(void *arg)
   thd->security_ctx->skip_grants();
 
   /* handle_one_connection() again... */
-  //thd->version= refresh_version;
   thd->proc_info= 0;
   thd->set_command(COM_SLEEP);
   thd->init_for_queries();
@@ -3134,10 +2974,12 @@ void* start_wsrep_THD(void *arg)
   mysql_cond_broadcast(&COND_thread_count);
   mysql_mutex_unlock(&LOCK_thread_count);
   DBUG_ASSERT(current_thd);
-  // Note: We can't call THD destructor without crashing
-  // if plugins have not been initialized. However, in most of the
-  // cases this means that pre SE initialization SST failed and
-  // we are going to exit anyway.
+  /*
+    Note: We can't call THD destructor without crashing
+    if plugins have not been initialized. However, in most of the
+    cases this means that pre SE initialization SST failed and
+    we are going to exit anyway.
+  */
   if (plugins_are_initialized)
   {
     net_end(&thd->net);
@@ -3145,9 +2987,11 @@ void* start_wsrep_THD(void *arg)
   }
   else
   {
-    // TODO: lightweight cleanup to get rid of:
-    // 'Error in my_thread_global_end(): 2 threads didn't exit'
-    // at server shutdown
+    /*
+      TODO: lightweight cleanup to get rid of:
+      'Error in my_thread_global_end(): 2 threads didn't exit'
+      at server shutdown
+    */
   }
 
   unlink_not_visible_thd(thd);
@@ -3203,25 +3047,7 @@ bool wsrep_consistency_check(THD *thd)
   return thd->wsrep_consistency_check == CONSISTENCY_CHECK_RUNNING;
 }
 
-//wsrep_t *get_wsrep()
-//{
-//  return wsrep;
-//}
-
 my_bool get_wsrep_certify_nonPK()
 {
   return wsrep_certify_nonPK;
 }
-
-#ifdef MARIADB_OLD
-void wsrep_lock_rollback()
-{
-  mysql_mutex_lock(&LOCK_wsrep_rollback);
-}
-
-void wsrep_unlock_rollback()
-{
-  mysql_cond_signal(&COND_wsrep_rollback);
-  mysql_mutex_unlock(&LOCK_wsrep_rollback);
-}
-#endif

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -49,7 +49,6 @@ enum wsrep_consistency_check_mode {
 };
 
 // Global wsrep parameters
-// extern wsrep_t*    wsrep_ptr;
 
 // MySQL wsrep options
 extern const char* wsrep_provider;
@@ -110,21 +109,21 @@ enum enum_wsrep_OSU_method {
 };
 
 enum enum_wsrep_sync_wait {
-    WSREP_SYNC_WAIT_NONE = 0x0,
+    WSREP_SYNC_WAIT_NONE= 0x0,
     // select, begin
-    WSREP_SYNC_WAIT_BEFORE_READ = 0x1,
-    WSREP_SYNC_WAIT_BEFORE_UPDATE_DELETE = 0x2,
-    WSREP_SYNC_WAIT_BEFORE_INSERT_REPLACE = 0x4,
-    WSREP_SYNC_WAIT_BEFORE_SHOW = 0x8,
-    WSREP_SYNC_WAIT_MAX = 0xF
+    WSREP_SYNC_WAIT_BEFORE_READ= 0x1,
+    WSREP_SYNC_WAIT_BEFORE_UPDATE_DELETE= 0x2,
+    WSREP_SYNC_WAIT_BEFORE_INSERT_REPLACE= 0x4,
+    WSREP_SYNC_WAIT_BEFORE_SHOW= 0x8,
+    WSREP_SYNC_WAIT_MAX= 0xF
 };
 
 enum enum_wsrep_ignore_apply_error {
-    WSREP_IGNORE_ERRORS_NONE = 0x0,
-    WSREP_IGNORE_ERRORS_ON_RECONCILING_DDL = 0x1,
-    WSREP_IGNORE_ERRORS_ON_RECONCILING_DML = 0x2,
-    WSREP_IGNORE_ERRORS_ON_DDL = 0x4,
-    WSREP_IGNORE_ERRORS_MAX = 0x7
+    WSREP_IGNORE_ERRORS_NONE= 0x0,
+    WSREP_IGNORE_ERRORS_ON_RECONCILING_DDL= 0x1,
+    WSREP_IGNORE_ERRORS_ON_RECONCILING_DML= 0x2,
+    WSREP_IGNORE_ERRORS_ON_DDL= 0x4,
+    WSREP_IGNORE_ERRORS_MAX= 0x7
 };
 
 // MySQL status variables
@@ -142,8 +141,6 @@ extern const char* wsrep_provider_vendor;
 extern char*       wsrep_provider_capabilities;
 extern char*       wsrep_cluster_capabilities;
 
-//int  wsrep_show_status(THD *thd, SHOW_VAR *var, char *buff,
-//                       enum enum_var_type scope);
 int  wsrep_show_status(THD *thd, SHOW_VAR *var, char *buff);
 int  wsrep_show_ready(THD *thd, SHOW_VAR *var, char *buff);
 void wsrep_free_status(THD *thd);
@@ -175,7 +172,7 @@ extern "C" void wsrep_fire_rollbacker(THD *thd);
 extern "C" uint32 wsrep_thd_wsrep_rand(THD *thd);
 extern "C" time_t wsrep_thd_query_start(THD *thd);
 extern void wsrep_close_client_connections(my_bool wait_to_end,
-                                           THD *except_caller_thd = NULL);
+                                           THD *except_caller_thd= NULL);
 //extern "C" query_id_t wsrep_thd_query_id(THD *thd);
 extern "C" query_id_t wsrep_thd_wsrep_last_query_id(THD *thd);
 extern "C" void wsrep_thd_set_wsrep_last_query_id(THD *thd, query_id_t id);
@@ -191,8 +188,8 @@ extern void wsrep_kill_mysql(THD *thd);
 extern void wsrep_stop_replication(THD *thd);
 extern bool wsrep_start_replication();
 extern void wsrep_shutdown_replication();
-extern bool wsrep_must_sync_wait (THD* thd, uint mask = WSREP_SYNC_WAIT_BEFORE_READ);
-extern bool wsrep_sync_wait (THD* thd, uint mask = WSREP_SYNC_WAIT_BEFORE_READ);
+extern bool wsrep_must_sync_wait (THD* thd, uint mask= WSREP_SYNC_WAIT_BEFORE_READ);
+extern bool wsrep_sync_wait (THD* thd, uint mask= WSREP_SYNC_WAIT_BEFORE_READ);
 extern enum wsrep::provider::status
 wsrep_sync_wait_upto (THD* thd, wsrep_gtid_t* upto, int timeout);
 extern void wsrep_last_committed_id (wsrep_gtid_t* gtid);
@@ -233,7 +230,7 @@ extern wsrep_seqno_t wsrep_locked_seqno;
 // prefix all messages with "WSREP"
 #define WSREP_LOG(fun, ...)                                       \
     do {                                                          \
-        char msg[1024] = {'\0'};                                  \
+        char msg[1024]= {'\0'};                                  \
         snprintf(msg, sizeof(msg) - 1, ## __VA_ARGS__);           \
         fun("WSREP: %s", msg);                                    \
     } while(0)
@@ -277,34 +274,8 @@ extern wsrep_seqno_t wsrep_locked_seqno;
 extern my_bool wsrep_ready_get();
 extern void wsrep_ready_wait();
 
-#ifdef OUT
-enum wsrep_trx_status {
-    WSREP_TRX_OK,
-    WSREP_TRX_CERT_FAIL,      /* certification failure, must abort */
-    WSREP_TRX_SIZE_EXCEEDED,  /* trx size exceeded */
-    WSREP_TRX_ERROR,          /* native mysql error */
-};
-#endif
-static inline
-wsrep_status_t wsrep_trx_status_to_wsrep_status(wsrep_trx_status status)
-{
-  switch (status)
-  {
-  case WSREP_TRX_OK:
-    return WSREP_OK;
-  case WSREP_TRX_CERT_FAIL:
-  case WSREP_TRX_ERROR:
-    return WSREP_TRX_FAIL;
-  case WSREP_TRX_SIZE_EXCEEDED:
-    return WSREP_SIZE_EXCEEDED;
-  }
-  return WSREP_NOT_IMPLEMENTED;
-}
-
 class Ha_trx_info;
 struct THD_TRANS;
-
-//extern "C" bool wsrep_consistency_check(void *thd_ptr);
 
 extern mysql_mutex_t LOCK_wsrep_ready;
 extern mysql_cond_t  COND_wsrep_ready;
@@ -359,7 +330,7 @@ struct TABLE_LIST;
 class Alter_info;
 int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
                              const TABLE_LIST* table_list,
-                             Alter_info* alter_info = NULL);
+                             Alter_info* alter_info= NULL);
 
 void wsrep_begin_nbo_unlock(THD*);
 void wsrep_end_nbo_lock(THD*, const TABLE_LIST *table_list);
@@ -410,7 +381,7 @@ class Wsrep_nbo_ctx
       mysql_mutex_init(key_LOCK_wsrep_nbo, &mutex_, MY_MUTEX_INIT_FAST);
       mysql_cond_init(key_COND_wsrep_nbo, &cond_, NULL);
 
-      if ((buf_ = malloc(buf_len_)) == 0) {
+      if ((buf_= malloc(buf_len_)) == 0) {
         throw std::exception();
       }
       memcpy(buf_, buf, buf_len);
@@ -439,18 +410,18 @@ class Wsrep_nbo_ctx
   void signal()
   {
     mysql_mutex_lock(&mutex_);
-    ready_ = true;
+    ready_= true;
     mysql_cond_signal(&cond_);
     mysql_mutex_unlock(&mutex_);
   }
 
   bool ready() const { return ready_; }
 
-  void set_executing(bool val) { executing_ = val; }
+  void set_executing(bool val) { executing_= val; }
 
   bool executing() const { return executing_; }
 
-  void set_toi_released(bool val) { toi_released_ = true; }
+  void set_toi_released(bool val) { toi_released_= true; }
 
   bool toi_released() const { return toi_released_; }
 
@@ -529,7 +500,6 @@ class Wsrep_thd_args
 void* start_wsrep_THD(void*);
 
 void wsrep_close_threads(THD *thd);
-//void wsrep_copy_query(THD *thd);
 bool wsrep_is_show_query(enum enum_sql_command command);
 void wsrep_replay_transaction(THD *thd);
 bool wsrep_create_like_table(THD* thd, TABLE_LIST* table,
@@ -568,7 +538,6 @@ int wsrep_ordered_commit_if_no_binlog(THD*, bool);
 wsrep_status_t wsrep_tc_log_commit(THD* thd);
 
 #include "wsrep_server_state.h"
-// #include "mysql/service_wsrep.h"
 
 /**
  * Initialize WSREP server instance.

--- a/sql/wsrep_notify.cc
+++ b/sql/wsrep_notify.cc
@@ -43,9 +43,9 @@ void wsrep_notify_status (wsrep_member_status_t    status,
   }
 
   char  cmd_buf[1 << 16]; // this can be long
-  long  cmd_len = sizeof(cmd_buf) - 1;
-  char* cmd_ptr = cmd_buf;
-  long  cmd_off = 0;
+  long  cmd_len= sizeof(cmd_buf) - 1;
+  char* cmd_ptr= cmd_buf;
+  long  cmd_off= 0;
 
   cmd_off += snprintf (cmd_ptr + cmd_off, cmd_len - cmd_off, "%s",
                        wsrep_notify_cmd);
@@ -80,7 +80,7 @@ void wsrep_notify_status (wsrep_member_status_t    status,
     {
         cmd_off += snprintf (cmd_ptr + cmd_off, cmd_len - cmd_off, " --members");
 
-        for (int i = 0; i < view->memb_num; i++)
+        for (int i= 0; i < view->memb_num; i++)
         {
             wsrep_uuid_print (&view->members[i].id, uuid_str, sizeof(uuid_str));
             cmd_off += snprintf (cmd_ptr + cmd_off, cmd_len - cmd_off,
@@ -101,7 +101,7 @@ void wsrep_notify_status (wsrep_member_status_t    status,
   wsp::process p(cmd_ptr, "r", NULL);
 
   p.wait();
-  int err = p.error();
+  int err= p.error();
 
   if (err)
   {

--- a/sql/wsrep_priv.h
+++ b/sql/wsrep_priv.h
@@ -47,6 +47,6 @@ void wsrep_sst_received(THD*, const wsrep_uuid_t&, wsrep_seqno_t,
                         const void*, size_t);
 
 void wsrep_notify_status (wsrep_member_status_t new_status,
-                          const wsrep_view_info_t* view = 0);
+                          const wsrep_view_info_t* view= 0);
 
 #endif /* WSREP_PRIV_H */

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -440,7 +440,7 @@ static int scan(TABLE* table, uint field, wsrep::id& id)
   assert(field < table->s->fields);
   String uuid_str;
   (void)table->field[field]->val_str(&uuid_str);
-  id = wsrep::id(std::string(uuid_str.c_ptr(), uuid_str.length()));
+  id= wsrep::id(std::string(uuid_str.c_ptr(), uuid_str.length()));
   return 0;
 }
 
@@ -457,7 +457,7 @@ static int scan(TABLE* table, uint field, char* strbuf, uint strbuf_len)
   String str;
   (void)table->field[field]->val_str(&str);
   strncpy(strbuf, str.c_ptr(), std::min(str.length(), strbuf_len));
-  strbuf[strbuf_len - 1] = '\0';
+  strbuf[strbuf_len - 1]= '\0';
   return 0;
 }
 
@@ -470,8 +470,8 @@ static int scan_member(TABLE* table,
                        std::vector<Wsrep_view::member>& members)
 {
   Wsrep_id member_id;
-  char member_name[128] = { 0, };
-  char member_incoming[128] = { 0, };
+  char member_name[128]= { 0, };
+  char member_incoming[128]= { 0, };
 
   if (scan(table, 0, member_id) ||
       scan(table, 2, member_name, sizeof(member_name)) ||
@@ -559,7 +559,7 @@ static void make_key(TABLE* table, uchar* key, key_part_map* map, int parts) {
   KEY_PART_INFO* key_part= table->key_info->key_part;
   for (int i=0; i < parts; i++)
     prefix_length += key_part[i].store_length;
-  *map = make_prev_keypart_map(parts);
+  *map= make_prev_keypart_map(parts);
   key_copy(key, table->record[0], table->key_info, prefix_length);
 }
 } /* namespace Wsrep_schema_impl */
@@ -736,8 +736,8 @@ Wsrep_view Wsrep_schema::restore_view(THD* thd, const Wsrep_id& own_id) const {
   std::vector<Wsrep_view::member> members;
 
   // we don't want causal waits for reading non-replicated private data
-  int const wsrep_sync_wait_saved = thd->variables.wsrep_sync_wait;
-  thd->variables.wsrep_sync_wait = 0;
+  int const wsrep_sync_wait_saved= thd->variables.wsrep_sync_wait;
+  thd->variables.wsrep_sync_wait= 0;
 
   if (trans_begin(thd, MYSQL_START_TRANS_OPT_READ_ONLY)) {
     WSREP_ERROR("wsrep_schema::restore_view(): Failed to start transaction");
@@ -825,7 +825,7 @@ Wsrep_view Wsrep_schema::restore_view(THD* thd, const Wsrep_id& own_id) const {
   }
   thd->mdl_context.release_transactional_locks();
 
-  thd->variables.wsrep_sync_wait = wsrep_sync_wait_saved;
+  thd->variables.wsrep_sync_wait= wsrep_sync_wait_saved;
 
   if (0 == ret) {
     Wsrep_view ret_view(
@@ -1281,7 +1281,7 @@ int Wsrep_schema::recover_sr_transactions()
                              flags);
 
       wsrep::high_priority_service* applier;
-      if (!(applier = server_state.find_streaming_applier(server_id,
+      if (!(applier= server_state.find_streaming_applier(server_id,
                                                           transaction_id)))
       {
         DBUG_ASSERT(wsrep::starts_transaction(flags));

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -48,7 +48,7 @@ wsrep::storage_service* Wsrep_server_service::storage_service(
 {
   Wsrep_client_service& cs=
     static_cast<Wsrep_client_service&>(client_service);
-  THD* thd = new THD(next_thread_id(), true, true);
+  THD* thd= new THD(next_thread_id(), true, true);
   init_service_thd(thd, cs.m_thd->thread_stack);
   WSREP_DEBUG("Created storage service with thread id %llu",
               thd->thread_id);
@@ -60,7 +60,7 @@ wsrep::storage_service* Wsrep_server_service::storage_service(
 {
   Wsrep_high_priority_service& hps=
     static_cast<Wsrep_high_priority_service&>(high_priority_service);
-  THD* thd = new THD(next_thread_id(), true, true);
+  THD* thd= new THD(next_thread_id(), true, true);
   init_service_thd(thd, hps.m_thd->thread_stack);
   WSREP_DEBUG("Created high priority storage service with thread id %llu",
               thd->thread_id);
@@ -158,7 +158,7 @@ void Wsrep_server_service::log_view(
   {
     global_system_variables.auto_increment_offset= view.own_index() + 1;
     global_system_variables.auto_increment_increment= view.members().size();
-    wsrep_protocol_version = view.protocol_version();
+    wsrep_protocol_version= view.protocol_version();
   }
   mysql_mutex_unlock(&LOCK_global_system_variables);
 

--- a/sql/wsrep_storage_service.cc
+++ b/sql/wsrep_storage_service.cc
@@ -20,7 +20,6 @@
 #include "wsrep_binlog.h"
 
 #include "sql_class.h"
-//#include "global_threads.h" /* LOCK_thread_count */
 #include "mysqld.h" /* next_query_id() */
 #include "slave.h" /* opt_log_slave_updates() */
 #include "transaction.h" /* trans_commit(), trans_rollback() */
@@ -55,8 +54,6 @@ Wsrep_storage_service::Wsrep_storage_service(THD* thd)
   thd->system_thread= SYSTEM_THREAD_SLAVE_SQL;
 
   /* No binlogging */
-  // thd->variables.sql_log_bin  = 0;
-  // thd->variables.option_bits &= ~OPTION_BIN_LOG;
 
   /* No general log */
   thd->variables.option_bits |= OPTION_LOG_OFF;
@@ -64,8 +61,6 @@ Wsrep_storage_service::Wsrep_storage_service(THD* thd)
   /* Read committed isolation to avoid gap locking */
   thd->variables.tx_isolation = ISO_READ_COMMITTED;
 
-  /* */
-  // thd->variables.wsrep_on= 0;
   /* Keep wsrep on to enter commit ordering hooks */
   thd->variables.wsrep_on= 1;
   thd->wsrep_skip_locking= true;
@@ -88,7 +83,6 @@ int Wsrep_storage_service::start_transaction(const wsrep::ws_handle& ws_handle)
   DBUG_PRINT("info", ("Wsrep_storage_service::start_transcation(%llu, %p)",
                       m_thd->thread_id, m_thd));
   m_thd->set_wsrep_next_trx_id(ws_handle.transaction_id().get());
-  // DBUG_RETURN(wsrep_start_transaction(m_thd, m_thd->wsrep_next_trx_id()));
   DBUG_RETURN(m_thd->wsrep_cs().start_transaction(
                 wsrep::transaction_id(m_thd->wsrep_next_trx_id())) ||
               trans_begin(m_thd, MYSQL_START_TRANS_OPT_READ_WRITE));

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -21,7 +21,6 @@
 #include "rpl_rli.h"
 #include "log_event.h"
 #include "sql_parse.h"
-//#include "global_threads.h" // LOCK_thread_count, etc.
 #include "sql_base.h" // close_thread_tables()
 #include "mysqld.h"   // start_wsrep_THD();
 #include "wsrep_applier.h"   // start_wsrep_THD();
@@ -31,8 +30,8 @@
 #include "rpl_rli.h"
 #include "rpl_mi.h"
 
-static Wsrep_thd_queue* wsrep_rollback_queue = 0;
-static Wsrep_thd_queue* wsrep_post_rollback_queue = 0;
+static Wsrep_thd_queue* wsrep_rollback_queue= 0;
+static Wsrep_thd_queue* wsrep_post_rollback_queue= 0;
 
 #if (__LP64__)
 static volatile int64 wsrep_bf_aborts_counter(0);
@@ -47,9 +46,9 @@ static volatile int32 wsrep_bf_aborts_counter(0);
 int wsrep_show_bf_aborts (THD *thd, SHOW_VAR *var, char *buff,
                           enum enum_var_type scope)
 {
-  wsrep_local_bf_aborts = WSREP_ATOMIC_LOAD_LONG(&wsrep_bf_aborts_counter);
-  var->type = SHOW_LONGLONG;
-  var->value = (char*)&wsrep_local_bf_aborts;
+  wsrep_local_bf_aborts= WSREP_ATOMIC_LOAD_LONG(&wsrep_bf_aborts_counter);
+  var->type= SHOW_LONGLONG;
+  var->value= (char*)&wsrep_local_bf_aborts;
   return 0;
 }
 
@@ -82,7 +81,7 @@ static rpl_group_info* wsrep_relay_group_init(const char* log_fname)
     to not free the "wsrep" rpl_filter. It will eventually be freed by
     free_all_rpl_filters() when server terminates.
   */
-  rli->mi = new Master_info(&connection_name, false);
+  rli->mi= new Master_info(&connection_name, false);
 
   struct rpl_group_info *rgi= new rpl_group_info(rli);
   rgi->thd= rli->sql_driver_thd= current_thd;
@@ -123,7 +122,7 @@ static void wsrep_replication_process(THD *thd,
   
   thd->wsrep_rgi->cleanup_after_session();
   delete thd->wsrep_rgi;
-  thd->wsrep_rgi = NULL;
+  thd->wsrep_rgi= NULL;
 
 
   if(thd->has_thd_temporary_tables())
@@ -371,17 +370,7 @@ void wsrep_create_rollbacker()
       WSREP_WARN("Can't create thread to manage wsrep post rollback");
    }
 }
-#if 0
-void wsrep_thd_set_PA_safe(void *thd_ptr, my_bool safe)
-{ 
-  if (thd_ptr) 
-  {
-    THD* thd = (THD*)thd_ptr;
-    thd->wsrep_PA_safe = safe;
-  }
-}
 
-#endif
 /*
   Start async rollback process
 
@@ -403,8 +392,8 @@ void wsrep_fire_rollbacker(THD *thd)
 int wsrep_abort_thd(void *bf_thd_ptr, void *victim_thd_ptr, my_bool signal)
 {
   DBUG_ENTER("wsrep_abort_thd");
-  THD *victim_thd = (THD *) victim_thd_ptr;
-  THD *bf_thd     = (THD *) bf_thd_ptr;
+  THD *victim_thd= (THD *) victim_thd_ptr;
+  THD *bf_thd= (THD *) bf_thd_ptr;
   mysql_mutex_lock(&victim_thd->LOCK_thd_data);
   if ( (WSREP(bf_thd) ||
          ( (WSREP_ON || bf_thd->variables.wsrep_OSU_method == WSREP_OSU_RSU) &&
@@ -425,22 +414,6 @@ int wsrep_abort_thd(void *bf_thd_ptr, void *victim_thd_ptr, my_bool signal)
   mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
   DBUG_RETURN(1);
 }
-#if 0
-int wsrep_thd_in_locking_session(void *thd_ptr)
-{
-  if (thd_ptr && ((THD *)thd_ptr)->in_lock_tables) {
-    return 1;
-  }
-  return 0;
-}
-
-bool wsrep_thd_has_explicit_locks(THD *thd)
-{
-  assert(thd);
-  return thd->mdl_context.has_explicit_locks();
-}
-
-#endif
 
 bool wsrep_bf_abort(const THD* bf_thd, THD* victim_thd)
 {

--- a/sql/wsrep_thd.h
+++ b/sql/wsrep_thd.h
@@ -229,10 +229,4 @@ static inline void wsrep_log_thd(THD *thd,
 
 #define WSREP_LOG_THD(thd_, message_) wsrep_log_thd(thd_, message_, __FUNCTION__)
 
-#else /* WITH_WSREP */
-
-//#define wsrep_thd_is_BF(T, S) (0)
-//#define wsrep_abort_thd(X,Y,Z) do { } while(0)
-//#define wsrep_create_appliers(T) do { } while(0)
-
 #endif /* WSREP_THD_H */

--- a/sql/wsrep_thd_pool.cc
+++ b/sql/wsrep_thd_pool.cc
@@ -20,13 +20,12 @@
 #include "wsrep_thd_pool.h"
 #include "wsrep_utils.h"
 #include "sql_class.h"
-//#include "global_threads.h"
 
 #include <list>
 
 static THD* wsrep_thd_pool_new_thd()
 {
-  THD *thd = new THD(next_thread_id());
+  THD *thd= new THD(next_thread_id());
   thd->thread_stack= (char*) &thd;
   thd->security_ctx->skip_grants();
   thd->system_thread= SYSTEM_THREAD_GENERIC;
@@ -41,14 +40,14 @@ static THD* wsrep_thd_pool_new_thd()
   (void) mysql_mutex_unlock(&LOCK_thread_count);
 
   /* */
-  thd->variables.wsrep_on     = 0;
+  thd->variables.wsrep_on    = 0;
   /* No binlogging */
-  thd->variables.sql_log_bin  = 0;
+  thd->variables.sql_log_bin = 0;
   thd->variables.option_bits &= ~OPTION_BIN_LOG;
   /* No general log */
   thd->variables.option_bits |= OPTION_LOG_OFF;
   /* Read committed isolation to avoid gap locking */
-  thd->variables.tx_isolation = ISO_READ_COMMITTED;
+  thd->variables.tx_isolation= ISO_READ_COMMITTED;
 
   return thd;
 }
@@ -72,7 +71,7 @@ Wsrep_thd_pool::~Wsrep_thd_pool()
   wsp::auto_lock lock(&LOCK_wsrep_thd_pool);
   while (!pool_.empty())
   {
-    THD *thd = pool_.back();
+    THD *thd= pool_.back();
     WSREP_DEBUG("Wsrep_thd_pool: closing thread %lld",
                 (long long)thd->thread_id);
 
@@ -97,7 +96,7 @@ THD* Wsrep_thd_pool::get_thd(THD* thd)
   }
   if (thd)
   {
-    ret->thread_stack = thd->thread_stack;
+    ret->thread_stack= thd->thread_stack;
   }
   else
   {

--- a/sql/wsrep_utils.cc
+++ b/sql/wsrep_utils.cc
@@ -49,7 +49,7 @@ static wsp::string wsrep_PATH;
 void
 wsrep_prepend_PATH (const char* path)
 {
-    int count = 0;
+    int count= 0;
 
     while (environ[count])
     {
@@ -74,7 +74,7 @@ wsrep_prepend_PATH (const char* path)
                       old_path + strlen("PATH="));
 
             wsrep_PATH.set (new_path);
-            environ[count] = new_path;
+            environ[count]= new_path;
         }
         else
         {
@@ -95,28 +95,28 @@ namespace wsp
 bool
 env::ctor_common(char** e)
 {
-    env_ = static_cast<char**>(malloc((len_ + 1) * sizeof(char*)));
+    env_= static_cast<char**>(malloc((len_ + 1) * sizeof(char*)));
 
     if (env_)
     {
         for (size_t i(0); i < len_; ++i)
         {
             assert(e[i]); // caller should make sure about len_
-            env_[i] = strdup(e[i]);
+            env_[i]= strdup(e[i]);
             if (!env_[i])
             {
-                errno_ = errno;
+                errno_= errno;
                 WSREP_ERROR("Failed to allocate env. var: %s", e[i]);
                 return true;
             }
         }
 
-        env_[len_] = NULL;
+        env_[len_]= NULL;
         return false;
     }
     else
     {
-        errno_ = errno;
+        errno_= errno;
         WSREP_ERROR("Failed to allocate env. var vector of length: %zu", len_);
         return true;
     }
@@ -130,15 +130,15 @@ env::dtor()
         /* don't need to go beyond the first NULL */
         for (size_t i(0); env_[i] != NULL; ++i) { free(env_[i]); }
         free(env_);
-        env_ = NULL;
+        env_= NULL;
     }
-    len_ = 0;
+    len_= 0;
 }
 
 env::env(char** e)
     : len_(0), env_(NULL), errno_(0)
 {
-    if (!e) { e = environ; }
+    if (!e) { e= environ; }
     /* count the size of the vector */
     while (e[len_]) { ++len_; }
 
@@ -156,21 +156,21 @@ env::~env() { dtor(); }
 int
 env::append(const char* val)
 {
-    char** tmp = static_cast<char**>(realloc(env_, (len_ + 2)*sizeof(char*)));
+    char** tmp= static_cast<char**>(realloc(env_, (len_ + 2)*sizeof(char*)));
 
     if (tmp)
     {
-        env_ = tmp;
-        env_[len_] = strdup(val);
+        env_= tmp;
+        env_[len_]= strdup(val);
 
         if (env_[len_])
         {
             ++len_;
-            env_[len_] = NULL;
+            env_[len_]= NULL;
         }
-        else errno_ = errno;
+        else errno_= errno;
     }
-    else errno_ = errno;
+    else errno_= errno;
 
     return errno_;
 }
@@ -191,7 +191,7 @@ process::process (const char* cmd, const char* type, char** env)
     if (0 == str_)
     {
         WSREP_ERROR ("Can't allocate command line of size: %zu", strlen(cmd));
-        err_ = ENOMEM;
+        err_= ENOMEM;
         return;
     }
 
@@ -207,12 +207,12 @@ process::process (const char* cmd, const char* type, char** env)
         return;
     }
 
-    if (NULL == env) { env = environ; } // default to global environment
+    if (NULL == env) { env= environ; } // default to global environment
 
-    int pipe_fds[2] = { -1, };
+    int pipe_fds[2]= { -1, };
     if (::pipe(pipe_fds))
     {
-        err_ = errno;
+        err_= errno;
         WSREP_ERROR ("pipe() failed: %d (%s)", err_, strerror(err_));
         return;
     }
@@ -222,16 +222,16 @@ process::process (const char* cmd, const char* type, char** env)
     int const child_end  (parent_end == PIPE_READ ? PIPE_WRITE : PIPE_READ);
     int const close_fd   (parent_end == PIPE_READ ? STDOUT_FD : STDIN_FD);
 
-    char* const pargv[4] = { strdup("sh"), strdup("-c"), strdup(str_), NULL };
+    char* const pargv[4]= { strdup("sh"), strdup("-c"), strdup(str_), NULL };
     if (!(pargv[0] && pargv[1] && pargv[2]))
     {
-        err_ = ENOMEM;
+        err_= ENOMEM;
         WSREP_ERROR ("Failed to allocate pargv[] array.");
         goto cleanup_pipe;
     }
 
     posix_spawnattr_t attr;
-    err_ = posix_spawnattr_init (&attr);
+    err_= posix_spawnattr_init (&attr);
     if (err_)
     {
         WSREP_ERROR ("posix_spawnattr_init() failed: %d (%s)",
@@ -241,7 +241,7 @@ process::process (const char* cmd, const char* type, char** env)
 
     /* make sure that no signlas are masked in child process */
     sigset_t sigmask_empty; sigemptyset(&sigmask_empty);
-    err_ = posix_spawnattr_setsigmask(&attr, &sigmask_empty);
+    err_= posix_spawnattr_setsigmask(&attr, &sigmask_empty);
     if (err_)
     {
         WSREP_ERROR ("posix_spawnattr_setsigmask() failed: %d (%s)",
@@ -257,7 +257,7 @@ process::process (const char* cmd, const char* type, char** env)
     sigaddset(&default_signals, SIGPIPE);
     sigaddset(&default_signals, SIGTERM);
     sigaddset(&default_signals, SIGCHLD);
-    err_ = posix_spawnattr_setsigdefault(&attr, &default_signals);
+    err_= posix_spawnattr_setsigdefault(&attr, &default_signals);
     if (err_)
     {
         WSREP_ERROR ("posix_spawnattr_setsigdefault() failed: %d (%s)",
@@ -265,7 +265,7 @@ process::process (const char* cmd, const char* type, char** env)
         goto cleanup_attr;
     }
 
-    err_ = posix_spawnattr_setflags (&attr, POSIX_SPAWN_SETSIGDEF  |
+    err_= posix_spawnattr_setflags (&attr, POSIX_SPAWN_SETSIGDEF  |
                                             POSIX_SPAWN_SETSIGMASK |
                                             POSIX_SPAWN_USEVFORK);
     if (err_)
@@ -276,7 +276,7 @@ process::process (const char* cmd, const char* type, char** env)
     }
 
     posix_spawn_file_actions_t fact;
-    err_ = posix_spawn_file_actions_init (&fact);
+    err_= posix_spawn_file_actions_init (&fact);
     if (err_)
     {
         WSREP_ERROR ("posix_spawn_file_actions_init() failed: %d (%s)",
@@ -285,7 +285,7 @@ process::process (const char* cmd, const char* type, char** env)
     }
 
     // close child's stdout|stdin depending on what we returning
-    err_ = posix_spawn_file_actions_addclose (&fact, close_fd);
+    err_= posix_spawn_file_actions_addclose (&fact, close_fd);
     if (err_)
     {
         WSREP_ERROR ("posix_spawn_file_actions_addclose() failed: %d (%s)",
@@ -294,7 +294,7 @@ process::process (const char* cmd, const char* type, char** env)
     }
 
     // substitute our pipe descriptor in place of the closed one
-    err_ = posix_spawn_file_actions_adddup2 (&fact,
+    err_= posix_spawn_file_actions_adddup2 (&fact,
                                              pipe_fds[child_end], close_fd);
     if (err_)
     {
@@ -303,30 +303,30 @@ process::process (const char* cmd, const char* type, char** env)
         goto cleanup_fact;
     }
 
-    err_ = posix_spawnp (&pid_, pargv[0], &fact, &attr, pargv, env);
+    err_= posix_spawnp (&pid_, pargv[0], &fact, &attr, pargv, env);
     if (err_)
     {
         WSREP_ERROR ("posix_spawnp(%s) failed: %d (%s)",
                      pargv[2], err_, strerror(err_));
-        pid_ = 0; // just to make sure it was not messed up in the call
+        pid_= 0; // just to make sure it was not messed up in the call
         goto cleanup_fact;
     }
 
-    io_ = fdopen (pipe_fds[parent_end], type);
+    io_= fdopen (pipe_fds[parent_end], type);
 
     if (io_)
     {
-        pipe_fds[parent_end] = -1; // skip close on cleanup
+        pipe_fds[parent_end]= -1; // skip close on cleanup
     }
     else
     {
-        err_ = errno;
+        err_= errno;
         WSREP_ERROR ("fdopen() failed: %d (%s)", err_, strerror(err_));
     }
 
 cleanup_fact:
     int err; // to preserve err_ code
-    err = posix_spawn_file_actions_destroy (&fact);
+    err= posix_spawn_file_actions_destroy (&fact);
     if (err)
     {
         WSREP_ERROR ("posix_spawn_file_actions_destroy() failed: %d (%s)\n",
@@ -334,7 +334,7 @@ cleanup_fact:
     }
 
 cleanup_attr:
-    err = posix_spawnattr_destroy (&attr);
+    err= posix_spawnattr_destroy (&attr);
     if (err)
     {
         WSREP_ERROR ("posix_spawnattr_destroy() failed: %d (%s)",
@@ -362,7 +362,7 @@ process::~process ()
 
         if (fclose (io_) == -1)
         {
-            err_ = errno;
+            err_= errno;
             WSREP_ERROR("fclose() failed: %d (%s)", err_, strerror(err_));
         }
     }
@@ -378,34 +378,34 @@ process::wait ()
       int status;
       if (-1 == waitpid(pid_, &status, 0))
       {
-          err_ = errno; assert (err_);
+          err_= errno; assert (err_);
           WSREP_ERROR("Waiting for process failed: %s, PID(%ld): %d (%s)",
                       str_, (long)pid_, err_, strerror (err_));
       }
       else
       {                // command completed, check exit status
           if (WIFEXITED (status)) {
-              err_ = WEXITSTATUS (status);
+              err_= WEXITSTATUS (status);
           }
           else {       // command didn't complete with exit()
               WSREP_ERROR("Process was aborted.");
-              err_ = errno ? errno : ECHILD;
+              err_= errno ? errno : ECHILD;
           }
 
           if (err_) {
               switch (err_) /* Translate error codes to more meaningful */
               {
-              case 126: err_ = EACCES; break; /* Permission denied */
-              case 127: err_ = ENOENT; break; /* No such file or directory */
-              case 143: err_ = EINTR;  break; /* Subprocess killed */
+              case 126: err_= EACCES; break; /* Permission denied */
+              case 127: err_= ENOENT; break; /* No such file or directory */
+              case 143: err_= EINTR;  break; /* Subprocess killed */
               }
               WSREP_ERROR("Process completed with error: %s: %d (%s)",
                           str_, err_, strerror(err_));
           }
 
-          pid_ = 0;
+          pid_= 0;
           if (io_) fclose (io_);
-          io_ = NULL;
+          io_= NULL;
       }
   }
   else {
@@ -423,7 +423,7 @@ thd::thd (my_bool won) : init(), ptr(new THD(0))
     ptr->thread_stack= (char*) &ptr;
     ptr->store_globals();
     ptr->variables.option_bits&= ~OPTION_BIN_LOG; // disable binlog
-    ptr->variables.wsrep_on = won;
+    ptr->variables.wsrep_on= won;
     ptr->security_ctx->master_access= ~(ulong)0;
     lex_start(ptr);
   }
@@ -443,7 +443,7 @@ thd::~thd ()
 /* Returns INADDR_NONE, INADDR_ANY, INADDR_LOOPBACK or something else */
 unsigned int wsrep_check_ip (const char* const addr, bool *is_ipv6)
 {
-  unsigned int ret = INADDR_NONE;
+  unsigned int ret= INADDR_NONE;
   struct addrinfo *res, hints;
 
   memset (&hints, 0, sizeof(hints));
@@ -453,7 +453,7 @@ unsigned int wsrep_check_ip (const char* const addr, bool *is_ipv6)
 
   *is_ipv6= false;
 
-  int gai_ret = getaddrinfo(addr, NULL, &hints, &res);
+  int gai_ret= getaddrinfo(addr, NULL, &hints, &res);
   if (0 == gai_ret)
   {
     if (AF_INET == res->ai_family) /* IPv4 */
@@ -541,7 +541,7 @@ size_t wsrep_guess_ip (char* buf, size_t buf_len)
 
   if (getifaddrs(&ifaddr) == 0)
   {
-    for (ifa= ifaddr; ifa != NULL; ifa = ifa->ifa_next)
+    for (ifa= ifaddr; ifa != NULL; ifa= ifa->ifa_next)
     {
       if (!ifa->ifa_addr)
         continue;

--- a/sql/wsrep_utils.h
+++ b/sql/wsrep_utils.h
@@ -27,12 +27,12 @@ class node_status
 public:
   node_status() : status(WSREP_MEMBER_UNDEFINED) {}
   void set(wsrep_member_status_t new_status,
-           const wsrep_view_info_t* view = 0)
+           const wsrep_view_info_t* view= 0)
   {
     if (status != new_status || 0 != view)
     {
       wsrep_notify_status(new_status, view);
-      status = new_status;
+      status= new_status;
     }
   }
   wsrep_member_status_t get() const { return status; }
@@ -329,7 +329,7 @@ public:
     string() : string_(0) {}
     explicit string(size_t s) : string_(static_cast<char*>(malloc(s))) {}
     char* operator()() { return string_; }
-    void set(char* str) { if (string_) free (string_); string_ = str; }
+    void set(char* str) { if (string_) free (string_); string_= str; }
     ~string() { set (0); }
 private:
     char* string_;
@@ -355,7 +355,7 @@ public:
 
   lock (pthread_mutex_t* mtx) : mtx_(mtx)
   {
-    int err = pthread_mutex_lock (mtx_);
+    int err= pthread_mutex_lock (mtx_);
 
     if (err)
     {
@@ -366,7 +366,7 @@ public:
 
   virtual ~lock ()
   {
-    int err = pthread_mutex_unlock (mtx_);
+    int err= pthread_mutex_unlock (mtx_);
 
     if (err)
     {

--- a/sql/wsrep_var.cc
+++ b/sql/wsrep_var.cc
@@ -51,7 +51,7 @@ bool wsrep_on_update (sys_var *self, THD* thd, enum_var_type var_type)
 {
   if (var_type == OPT_GLOBAL) {
     // FIXME: this variable probably should be changed only per session
-    thd->variables.wsrep_on = global_system_variables.wsrep_on;
+    thd->variables.wsrep_on= global_system_variables.wsrep_on;
   }
 
   return false;
@@ -75,10 +75,6 @@ bool wsrep_on_check(sys_var *self, THD* thd, set_var* var)
 
 bool wsrep_causal_reads_update (sys_var *self, THD* thd, enum_var_type var_type)
 {
-  // global setting should not affect session setting.
-  // if (var_type == OPT_GLOBAL) {
-  //   thd->variables.wsrep_causal_reads = global_system_variables.wsrep_causal_reads;
-  // }
   if (thd->variables.wsrep_causal_reads) {
     thd->variables.wsrep_sync_wait |= WSREP_SYNC_WAIT_BEFORE_READ;
   } else {
@@ -97,15 +93,11 @@ bool wsrep_causal_reads_update (sys_var *self, THD* thd, enum_var_type var_type)
 
 bool wsrep_sync_wait_update (sys_var* self, THD* thd, enum_var_type var_type)
 {
-  // global setting should not affect session setting.
-  // if (var_type == OPT_GLOBAL) {
-  //   thd->variables.wsrep_sync_wait = global_system_variables.wsrep_sync_wait;
-  // }
-  thd->variables.wsrep_causal_reads = thd->variables.wsrep_sync_wait &
+  thd->variables.wsrep_causal_reads= thd->variables.wsrep_sync_wait &
           WSREP_SYNC_WAIT_BEFORE_READ;
 
   // update global settings too
-  global_system_variables.wsrep_causal_reads = global_system_variables.wsrep_sync_wait &
+  global_system_variables.wsrep_causal_reads= global_system_variables.wsrep_sync_wait &
           WSREP_SYNC_WAIT_BEFORE_READ;
 
   return false;
@@ -127,7 +119,7 @@ bool wsrep_start_position_verify (const char* start_str)
   ssize_t       uuid_len;
 
   // Check whether it has minimum acceptable length.
-  start_len = strlen (start_str);
+  start_len= strlen (start_str);
   if (start_len < 34)
     return true;
 
@@ -135,7 +127,7 @@ bool wsrep_start_position_verify (const char* start_str)
     Parse the input to check whether UUID length is acceptable
     and seqno has been provided.
   */
-  uuid_len = wsrep_uuid_scan (start_str, start_len, &uuid);
+  uuid_len= wsrep_uuid_scan (start_str, start_len, &uuid);
   if (uuid_len < 0 || (start_len - uuid_len) < 2)
     return true;
 
@@ -159,15 +151,14 @@ bool wsrep_set_local_position(THD* thd, const char* const value,
                               size_t length, bool const sst)
 {
   wsrep_uuid_t uuid;
-  size_t const uuid_len = wsrep_uuid_scan(value, length, &uuid);
-  wsrep_seqno_t const seqno = strtoll(value + uuid_len + 1, NULL, 10);
+  size_t const uuid_len= wsrep_uuid_scan(value, length, &uuid);
+  wsrep_seqno_t const seqno= strtoll(value + uuid_len + 1, NULL, 10);
 
   if (sst) {
     wsrep_sst_received (thd, uuid, seqno, NULL, 0);
   } else {
-    // initialization
-    local_uuid = uuid;
-    local_seqno = seqno;
+    local_uuid= uuid;
+    local_seqno= seqno;
   }
   return false;
 }
@@ -357,7 +348,7 @@ bool wsrep_provider_update (sys_var *self, THD* thd, enum_var_type type)
   if (wsrep_init())
   {
     my_error(ER_CANT_OPEN_LIBRARY, MYF(0), tmp, my_error, "wsrep_init failed");
-    rcode = true;
+    rcode= true;
   }
   free(tmp);
 
@@ -385,7 +376,7 @@ void wsrep_provider_init (const char* value)
   }
 
   if (wsrep_provider) my_free((void *)wsrep_provider);
-  wsrep_provider = my_strdup(value, MYF(0));
+  wsrep_provider= my_strdup(value, MYF(0));
 }
 
 bool wsrep_provider_options_check(sys_var *self, THD* thd, set_var* var)
@@ -415,7 +406,7 @@ void wsrep_provider_options_init(const char* value)
 {
   if (wsrep_provider_options && wsrep_provider_options != value) 
     my_free((void *)wsrep_provider_options);
-  wsrep_provider_options = (value) ? my_strdup(value, MYF(0)) : NULL;
+  wsrep_provider_options= (value) ? my_strdup(value, MYF(0)) : NULL;
 }
 
 bool wsrep_reject_queries_update(sys_var *self, THD* thd, enum_var_type type)
@@ -578,13 +569,12 @@ void wsrep_node_address_init (const char* value)
   if (wsrep_node_address && strcmp(wsrep_node_address, value))
     my_free ((void*)wsrep_node_address);
 
-  wsrep_node_address = (value) ? my_strdup(value, MYF(0)) : NULL;
+  wsrep_node_address= (value) ? my_strdup(value, MYF(0)) : NULL;
 }
 
 static void wsrep_slave_count_change_update ()
 {
-  // wsrep_running_threads = appliers threads + 2 rollbacker threads
-  wsrep_slave_count_change = (wsrep_slave_threads - wsrep_running_threads + 2);
+  wsrep_slave_count_change= (wsrep_slave_threads - wsrep_running_threads + 2);
   WSREP_DEBUG("Change on slave threads: New %lu old %lu difference %d",
       wsrep_slave_threads, wsrep_running_threads, wsrep_slave_count_change);
 }
@@ -595,7 +585,7 @@ bool wsrep_slave_threads_update (sys_var *self, THD* thd, enum_var_type type)
   if (wsrep_slave_count_change > 0)
   {
     wsrep_create_appliers(wsrep_slave_count_change);
-    wsrep_slave_count_change = 0;
+    wsrep_slave_count_change= 0;
   }
   return false;
 }
@@ -659,7 +649,7 @@ bool wsrep_trx_fragment_size_check (sys_var *self, THD* thd, set_var* var)
     return false;
   }
 
-  const ulong new_trx_fragment_size = var->value->val_uint();
+  const ulong new_trx_fragment_size= var->value->val_uint();
 
   if (!WSREP(thd) && new_trx_fragment_size > 0) {
     push_warning (thd, Sql_condition::WARN_LEVEL_WARN,
@@ -750,43 +740,43 @@ static int show_var_cmp(const void *var1, const void *var2)
 static inline void
 wsrep_assign_to_mysql (SHOW_VAR* mysql, wsrep_stats_var* wsrep_var)
 {
-  mysql->name = wsrep_var->name;
+  mysql->name= wsrep_var->name;
   switch (wsrep_var->type) {
   case WSREP_VAR_INT64:
-    mysql->value = (char*) &wsrep_var->value._int64;
-    mysql->type  = SHOW_LONGLONG;
+    mysql->value= (char*) &wsrep_var->value._int64;
+    mysql->type= SHOW_LONGLONG;
     break;
   case WSREP_VAR_STRING:
-    mysql->value = (char*) &wsrep_var->value._string;
-    mysql->type  = SHOW_CHAR_PTR;
+    mysql->value= (char*) &wsrep_var->value._string;
+    mysql->type= SHOW_CHAR_PTR;
     break;
   case WSREP_VAR_DOUBLE:
-    mysql->value = (char*) &wsrep_var->value._double;
-    mysql->type  = SHOW_DOUBLE;
+    mysql->value= (char*) &wsrep_var->value._double;
+    mysql->type= SHOW_DOUBLE;
     break;
   }
 }
 
 #if DYNAMIC
 // somehow this mysql status thing works only with statically allocated arrays.
-static SHOW_VAR*          mysql_status_vars = NULL;
-static int                mysql_status_len  = -1;
+static SHOW_VAR*          mysql_status_vars= NULL;
+static int                mysql_status_len= -1;
 #else
 static SHOW_VAR           mysql_status_vars[512 + 1];
-static const int          mysql_status_len  = 512;
+static const int          mysql_status_len= 512;
 #endif
 
 static void export_wsrep_status_to_mysql(THD* thd)
 {
   int wsrep_status_len, i;
 
-  thd->wsrep_status_vars = Wsrep_server_state::instance().status();
+  thd->wsrep_status_vars= Wsrep_server_state::instance().status();
 
   wsrep_status_len= thd->wsrep_status_vars.size();
 
 #if DYNAMIC
   if (wsrep_status_len != mysql_status_len) {
-    void* tmp = realloc (mysql_status_vars,
+    void* tmp= realloc (mysql_status_vars,
                          (wsrep_status_len + 1) * sizeof(SHOW_VAR));
     if (!tmp) {
 
@@ -795,15 +785,15 @@ static void export_wsrep_status_to_mysql(THD* thd)
       return;
     }
 
-    mysql_status_len  = wsrep_status_len;
-    mysql_status_vars = (SHOW_VAR*)tmp;
+    mysql_status_len= wsrep_status_len;
+    mysql_status_vars= (SHOW_VAR*)tmp;
   }
   /* @TODO: fix this: */
 #else
   if (mysql_status_len < wsrep_status_len) wsrep_status_len= mysql_status_len;
 #endif
 
-  for (i = 0; i < wsrep_status_len; i++)
+  for (i= 0; i < wsrep_status_len; i++)
   {
     mysql_status_vars[i].name= (char*)thd->wsrep_status_vars[i].name().c_str();
     mysql_status_vars[i].value= (char*)thd->wsrep_status_vars[i].value().c_str();

--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -43,7 +43,7 @@ void wsrep_xid_init(XID* xid, const wsrep::gtid& wsgtid)
   xid->bqual_length= 0;
   memset(xid->data, 0, sizeof(xid->data));
   memcpy(xid->data, WSREP_XID_PREFIX, WSREP_XID_PREFIX_LEN);
-  xid->data[WSREP_XID_VERSION_OFFSET] = WSREP_XID_VERSION_2;
+  xid->data[WSREP_XID_VERSION_OFFSET]= WSREP_XID_VERSION_2;
   memcpy(xid->data + WSREP_XID_UUID_OFFSET,  wsgtid.id().data(),sizeof(wsrep::id));
   int8store(xid->data + WSREP_XID_SEQNO_OFFSET, wsgtid.seqno().get());
 }
@@ -111,7 +111,7 @@ static my_bool set_SE_checkpoint(THD* unused, plugin_ref plugin, void* arg)
   if (hton->set_checkpoint)
   {
     const unsigned char* uuid= wsrep_xid_uuid(xid);
-    char uuid_str[40] = {0, };
+    char uuid_str[40]= {0, };
     wsrep_uuid_print((const wsrep_uuid_t*)uuid, uuid_str, sizeof(uuid_str));
     WSREP_DEBUG("Set WSREPXid for InnoDB:  %s:%lld",
                 uuid_str, (long long)wsrep_xid_seqno(xid));
@@ -143,7 +143,7 @@ static my_bool get_SE_checkpoint(THD* unused, plugin_ref plugin, void* arg)
     hton->get_checkpoint(hton, xid);
     wsrep_uuid_t uuid;
     memcpy(&uuid, wsrep_xid_uuid(xid), sizeof(uuid));
-    char uuid_str[40] = {0, };
+    char uuid_str[40]= {0, };
     wsrep_uuid_print(&uuid, uuid_str, sizeof(uuid_str));
     WSREP_DEBUG("Read WSREPXid from InnoDB:  %s:%lld",
                 uuid_str, (long long)wsrep_xid_seqno(xid));


### PR DESCRIPTION
Cleaned up obsolete code from service_wsrep.h
The following enums are obsoloted by wsrep-lib and should no longer
be exposed: wsrep_conflict_state, wsrep_exec_mode, wsrep_query_state,
wsrep_trx_state.

Removed the enums from service_wsrep.h and cleaned up corresponding
dead code from wsrep_mysqld.h.

wsrep_recover run causing memory leaks
Enabling shutdown phase memory leak testing, triggered regression with tests, which
startup mysqld with --wsrep_recover option, following tests failed:

galera.galera_ist_mariabackup
galera.galera_ist_mysqldump
galera.galera_ist_restart_joiner
galera.galera_ist_rsync
galera.galera_pc_recovery
galera.galera_sst_rsync
galera.galera_sst_rsync2
galera.galera_sst_rsync_data_dir
galera.mysql-wsrep#31

This commit will gracefully tear down wsrep-lib use after --wsrep-recover run, and
no more memory leak warnings have been observed