### PR TITLE
MDEV-17470 Orphan temporary files after interrupted ALTER cause InnoDB: Operating system error number 17 and eventual fatal error 71

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-alter-debug.result
+++ b/mysql-test/suite/innodb/r/innodb-alter-debug.result
@@ -68,3 +68,24 @@ SET DEBUG_SYNC = 'now SIGNAL S2';
 ERROR 23000: Duplicate entry '1' for key 'a'
 SET DEBUG_SYNC='RESET';
 DROP TABLE t1;
+#
+# MDEV-MDEV-17470 Orphan temporary files after interrupted ALTER
+# cause InnoDB: Operating system error number 17 and eventual
+# fatal error 71
+#
+CREATE TABLE t1 (pk INT AUTO_INCREMENT PRIMARY KEY, i INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (NULL,1),(NULL,2),(NULL,3),(NULL,4),(NULL,5),(NULL,6),(NULL,7),(NULL,8);
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+LOCK TABLE t1 READ;
+SET max_statement_time= 1;
+ALTER TABLE t1 FORCE, ALGORITHM=COPY;
+ERROR 70100: Query execution was interrupted (max_statement_time exceeded)
+SET DEBUG_SYNC = 'now SIGNAL stop_waining';
+SET DEBUG_SYNC = 'now WAIT_FOR stop_waining';
+UNLOCK TABLES;
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';

--- a/mysql-test/suite/innodb/t/innodb-alter-debug.test
+++ b/mysql-test/suite/innodb/t/innodb-alter-debug.test
@@ -100,3 +100,31 @@ DROP TABLE t1;
 
 # Wait till all disconnects are completed
 --source include/wait_until_count_sessions.inc
+
+--echo #
+--echo # MDEV-MDEV-17470 Orphan temporary files after interrupted ALTER
+--echo # cause InnoDB: Operating system error number 17 and eventual
+--echo # fatal error 71
+--echo #
+CREATE TABLE t1 (pk INT AUTO_INCREMENT PRIMARY KEY, i INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (NULL,1),(NULL,2),(NULL,3),(NULL,4),(NULL,5),(NULL,6),(NULL,7),(NULL,8);
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+INSERT INTO t1 SELECT NULL, i FROM t1;
+
+LOCK TABLE t1 READ;
+
+--connect (con1,localhost,root,,test)
+SET max_statement_time= 1;
+--error ER_STATEMENT_TIMEOUT
+ALTER TABLE t1 FORCE, ALGORITHM=COPY;
+SET DEBUG_SYNC = 'now SIGNAL stop_waining';
+--disconnect con1
+
+--connection default
+SET DEBUG_SYNC = 'now WAIT_FOR stop_waining';
+UNLOCK TABLES;
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -4224,9 +4224,11 @@ row_drop_table_for_mysql(
 		calling btr_search_drop_page_hash_index() while we
 		hold the InnoDB dictionary lock, we will drop any
 		adaptive hash index entries upfront. */
+		const bool temporary_table
+		    = strstr(tablename_minus_db, tmp_file_prefix);
 		while (buf_LRU_drop_page_hash_for_tablespace(table)) {
 			if ((!dict_table_is_temporary(table)
-			     && trx_is_interrupted(trx))
+			     && trx_is_interrupted(trx) && !temporary_table)
 			    || srv_shutdown_state != SRV_SHUTDOWN_NONE) {
 				err = DB_INTERRUPTED;
 				goto funct_exit;

--- a/storage/xtradb/row/row0mysql.cc
+++ b/storage/xtradb/row/row0mysql.cc
@@ -4234,9 +4234,11 @@ row_drop_table_for_mysql(
 		calling btr_search_drop_page_hash_index() while we
 		hold the InnoDB dictionary lock, we will drop any
 		adaptive hash index entries upfront. */
+		const bool temporary_table
+		    = strstr(tablename_minus_db, tmp_file_prefix);
 		while (buf_LRU_drop_page_hash_for_tablespace(table)) {
 			if ((!dict_table_is_temporary(table)
-			     && trx_is_interrupted(trx))
+			     && trx_is_interrupted(trx) && !temporary_table)
 			    || srv_shutdown_state != SRV_SHUTDOWN_NONE) {
 				err = DB_INTERRUPTED;
 				goto funct_exit;


### PR DESCRIPTION
Orphan #sql-* temporary tables may appear after ALTER TABLE which was interrupted
by timeout. InnoDB has some kind of protection from too long removing of AHI
values while removing a table. This was intended to work only for DISCARD
TABLESPACE queries but irroneously work for #sql-* tables.

row_drop_table_for_mysql(): do not interrupt/abort removal of temporary tables.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.1-MDEV-17470-alter-copy-tmp-table)