### PR TITLE
Fixes for wsrep suite

### DIFF
--- a/mysql-test/suite/wsrep/my.cnf
+++ b/mysql-test/suite/wsrep/my.cnf
@@ -1,10 +1,8 @@
 # Use default setting for mysqld processes
 !include include/default_mysqld.cnf
 
-[mysqld]
-wsrep-on=1
-
 [mysqld.1]
+wsrep-on=OFF
 #galera_port=@OPT.port
 #ist_port=@OPT.port
 #sst_port=@OPT.port

--- a/mysql-test/suite/wsrep/t/binlog_format.cnf
+++ b/mysql-test/suite/wsrep/t/binlog_format.cnf
@@ -1,0 +1,8 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+wsrep-provider=@ENV.WSREP_PROVIDER
+wsrep-cluster-address=gcomm://
+innodb_autoinc_lock_mode=2
+

--- a/mysql-test/suite/wsrep/t/binlog_format.opt
+++ b/mysql-test/suite/wsrep/t/binlog_format.opt
@@ -1,1 +1,0 @@
---innodb_autoinc_lock_mode=2 --wsrep-provider=$WSREP_PROVIDER --wsrep-cluster-address=gcomm://

--- a/mysql-test/suite/wsrep/t/mdev_6832.cnf
+++ b/mysql-test/suite/wsrep/t/mdev_6832.cnf
@@ -1,0 +1,7 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+wsrep-provider=@ENV.WSREP_PROVIDER
+wsrep-cluster-address=gcomm://
+

--- a/mysql-test/suite/wsrep/t/mdev_6832.opt
+++ b/mysql-test/suite/wsrep/t/mdev_6832.opt
@@ -1,1 +1,0 @@
---wsrep-provider=$WSREP_PROVIDER --wsrep-cluster-address=gcomm:// --wsrep-on=1

--- a/mysql-test/suite/wsrep/t/mdev_6832.test
+++ b/mysql-test/suite/wsrep/t/mdev_6832.test
@@ -1,3 +1,4 @@
+--source include/have_innodb.inc
 --source include/have_wsrep_provider.inc
 --source include/have_binlog_format_row.inc
 

--- a/mysql-test/suite/wsrep/t/mdev_7798.cnf
+++ b/mysql-test/suite/wsrep/t/mdev_7798.cnf
@@ -1,0 +1,7 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+wsrep-provider=@ENV.WSREP_PROVIDER
+wsrep-cluster-address=gcomm://
+

--- a/mysql-test/suite/wsrep/t/mdev_7798.opt
+++ b/mysql-test/suite/wsrep/t/mdev_7798.opt
@@ -1,1 +1,0 @@
---wsrep-provider=$WSREP_PROVIDER --wsrep-cluster-address=gcomm:// --wsrep-on=1 

--- a/mysql-test/suite/wsrep/t/mdev_7798.test
+++ b/mysql-test/suite/wsrep/t/mdev_7798.test
@@ -1,3 +1,4 @@
+--source include/have_innodb.inc
 --source include/have_wsrep_provider.inc
 --source include/have_binlog_format_row.inc
 

--- a/mysql-test/suite/wsrep/t/pool_of_threads.cnf
+++ b/mysql-test/suite/wsrep/t/pool_of_threads.cnf
@@ -1,0 +1,8 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+wsrep-provider=@ENV.WSREP_PROVIDER
+wsrep-cluster-address=gcomm://
+thread_handling=pool-of-threads
+

--- a/mysql-test/suite/wsrep/t/pool_of_threads.opt
+++ b/mysql-test/suite/wsrep/t/pool_of_threads.opt
@@ -1,1 +1,0 @@
---innodb_autoinc_lock_mode=2 --wsrep-provider=$WSREP_PROVIDER --wsrep-cluster-address=gcomm:// --thread_handling=pool-of-threads

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -660,15 +660,13 @@ int wsrep_init_server()
     std::string working_dir;
     wsrep::gtid initial_position;
 
-    if (WSREP_ON)
-    {
-      server_name= wsrep_server_name();
-      server_id= wsrep_server_id();
-      node_address= wsrep_server_node_address();
-      incoming_address= wsrep_server_incoming_address();
-      working_dir= wsrep_server_working_dir();
-      initial_position= wsrep_server_initial_position();
-    }
+    server_name= wsrep_server_name();
+    server_id= wsrep_server_id();
+    node_address= wsrep_server_node_address();
+    incoming_address= wsrep_server_incoming_address();
+    working_dir= wsrep_server_working_dir();
+    initial_position= wsrep_server_initial_position();
+
 
     Wsrep_server_state::init_once(server_name,
                                   incoming_address,
@@ -707,12 +705,6 @@ void wsrep_deinit_server()
 
 int wsrep_init()
 {
-  const std::string server_name= wsrep_server_name();
-  const std::string server_id= wsrep_server_id();
-  const std::string node_address= wsrep_server_node_address();
-  const std::string incoming_address= wsrep_server_incoming_address();
-  const std::string working_dir= wsrep_server_working_dir();
-
   assert(wsrep_provider);
 
   wsrep_init_position();
@@ -732,7 +724,7 @@ int wsrep_init()
     return err;
   }
 
-  global_system_variables.wsrep_on = 1;
+  global_system_variables.wsrep_on= 1;
 
   if (wsrep_gtid_mode && opt_bin_log && !opt_log_slave_updates)
   {


### PR DESCRIPTION
* Disabled wsrep-on for all tests in wsrep suite.
* For test which need wsrep-on=ON additional .cnf file is created and .opt file removed.