### PR TITLE
Fixed galera.galera_sst_mysqldump

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_mysqldump,debug.rdiff
+++ b/mysql-test/suite/galera/r/galera_sst_mysqldump,debug.rdiff
@@ -1,6 +1,22 @@
---- galera_sst_mysqldump.result
-+++ galera_sst_mysqldump,debug.reject
-@@ -388,6 +388,114 @@
+--- galera_sst_mysqldump.result	2018-11-29 23:54:03.663607613 +0100
++++ galera_sst_mysqldump,debug.reject	2018-11-29 23:55:42.377562815 +0100
+@@ -1,3 +1,5 @@
++connection node_2;
++connection node_1;
+ Setting SST method to mysqldump ...
+ call mtr.add_suppression("WSREP: wsrep_sst_method is set to 'mysqldump' yet mysqld bind_address is set to '127.0.0.1'");
+ call mtr.add_suppression("Failed to load slave replication state from table mysql.gtid_slave_pos");
+@@ -56,6 +58,9 @@
+ INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
+ connection node_2;
+ Loading wsrep provider ...
++disconnect node_2;
++connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2;
++connection node_2;
+ SET AUTOCOMMIT=OFF;
+ START TRANSACTION;
+ INSERT INTO t1 VALUES ('node2_committed_after');
+@@ -390,6 +395,114 @@
  DROP TABLE t1;
  COMMIT;
  SET AUTOCOMMIT=ON;

--- a/mysql-test/suite/galera/r/galera_sst_mysqldump.result
+++ b/mysql-test/suite/galera/r/galera_sst_mysqldump.result
@@ -1,5 +1,3 @@
-connection node_2;
-connection node_1;
 Setting SST method to mysqldump ...
 call mtr.add_suppression("WSREP: wsrep_sst_method is set to 'mysqldump' yet mysqld bind_address is set to '127.0.0.1'");
 call mtr.add_suppression("Failed to load slave replication state from table mysql.gtid_slave_pos");
@@ -58,9 +56,6 @@ INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
 INSERT INTO t1 VALUES ('node1_to_be_rollbacked_after');
 connection node_2;
 Loading wsrep provider ...
-disconnect node_2;
-connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2;
-connection node_2;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
 INSERT INTO t1 VALUES ('node2_committed_after');
@@ -395,114 +390,6 @@ COUNT(*) = 0
 DROP TABLE t1;
 COMMIT;
 SET AUTOCOMMIT=ON;
-Performing State Transfer on a server that has been killed and restarted
-while a DDL was in progress on it
-connection node_1;
-CREATE TABLE t1 (f1 CHAR(255)) ENGINE=InnoDB;
-SET AUTOCOMMIT=OFF;
-START TRANSACTION;
-INSERT INTO t1 VALUES ('node1_committed_before');
-INSERT INTO t1 VALUES ('node1_committed_before');
-INSERT INTO t1 VALUES ('node1_committed_before');
-INSERT INTO t1 VALUES ('node1_committed_before');
-INSERT INTO t1 VALUES ('node1_committed_before');
-connection node_2;
-START TRANSACTION;
-INSERT INTO t1 VALUES ('node2_committed_before');
-INSERT INTO t1 VALUES ('node2_committed_before');
-INSERT INTO t1 VALUES ('node2_committed_before');
-INSERT INTO t1 VALUES ('node2_committed_before');
-INSERT INTO t1 VALUES ('node2_committed_before');
-COMMIT;
-SET GLOBAL debug_dbug = 'd,sync.alter_opened_table';
-connection node_1;
-ALTER TABLE t1 ADD COLUMN f2 INTEGER;
-connection node_2;
-SET wsrep_sync_wait = 0;
-Killing server ...
-connection node_1;
-SET AUTOCOMMIT=OFF;
-START TRANSACTION;
-INSERT INTO t1 (f1) VALUES ('node1_committed_during');
-INSERT INTO t1 (f1) VALUES ('node1_committed_during');
-INSERT INTO t1 (f1) VALUES ('node1_committed_during');
-INSERT INTO t1 (f1) VALUES ('node1_committed_during');
-INSERT INTO t1 (f1) VALUES ('node1_committed_during');
-COMMIT;
-START TRANSACTION;
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-connect node_1a_galera_st_kill_slave_ddl, 127.0.0.1, root, , test, $NODE_MYPORT_1;
-SET AUTOCOMMIT=OFF;
-START TRANSACTION;
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-connection node_2;
-Performing --wsrep-recover ...
-connection node_2;
-Starting server ...
-Using --wsrep-start-position when starting mysqld ...
-SET AUTOCOMMIT=OFF;
-START TRANSACTION;
-INSERT INTO t1 (f1) VALUES ('node2_committed_after');
-INSERT INTO t1 (f1) VALUES ('node2_committed_after');
-INSERT INTO t1 (f1) VALUES ('node2_committed_after');
-INSERT INTO t1 (f1) VALUES ('node2_committed_after');
-INSERT INTO t1 (f1) VALUES ('node2_committed_after');
-COMMIT;
-connection node_1;
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_committed_after');
-COMMIT;
-SET AUTOCOMMIT=OFF;
-START TRANSACTION;
-INSERT INTO t1 (f1) VALUES ('node1_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_committed_after');
-INSERT INTO t1 (f1) VALUES ('node1_committed_after');
-COMMIT;
-connection node_1a_galera_st_kill_slave_ddl;
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-INSERT INTO t1 (f1) VALUES ('node1_to_be_rollbacked_after');
-ROLLBACK;
-SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't1';
-COUNT(*) = 2
-1
-SELECT COUNT(*) = 35 FROM t1;
-COUNT(*) = 35
-1
-SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
-COUNT(*) = 0
-1
-COMMIT;
-SET AUTOCOMMIT=ON;
-connection node_1;
-SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 't1';
-COUNT(*) = 2
-1
-SELECT COUNT(*) = 35 FROM t1;
-COUNT(*) = 35
-1
-SELECT COUNT(*) = 0 FROM (SELECT COUNT(*) AS c, f1 FROM t1 GROUP BY f1 HAVING c NOT IN (5, 10)) AS a1;
-COUNT(*) = 0
-1
-DROP TABLE t1;
-COMMIT;
-SET AUTOCOMMIT=ON;
-SET GLOBAL debug_dbug = $debug_orig;
 connection node_1;
 CALL mtr.add_suppression("Slave SQL: Error 'The MySQL server is running with the --skip-grant-tables option so it cannot execute this statement' on query");
 DROP USER sst;

--- a/mysql-test/suite/galera/t/galera_sst_mysqldump.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_mysqldump.cnf
@@ -5,9 +5,7 @@
 
 [mysqld.1]
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=1;pc.ignore_sb=true'
-wsrep_causal_reads=0
 wsrep_sync_wait=0
 [mysqld.2]
 wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.size=1;pc.ignore_sb=true'
-wsrep_causal_reads=0
 wsrep_sync_wait=0


### PR DESCRIPTION
The test was probably not merged correctly, and a whole section of the .rdiff file was merged in .test file.
Restored the test and recorded it.
Part of fix also is in galera 4.x branch so latest commit should be used.