### PR TITLE
Fix MTR test galera_sr.galera_sr_cc_master

### DIFF
--- a/mysql-test/suite/galera_sr/t/galera_sr_cc_master.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_cc_master.test
@@ -56,7 +56,7 @@ SELECT COUNT(*) = 0 FROM wsrep_schema.SR;
 
 --connection node_2a
 --disable_query_log
---eval SET GLOBAL wsrep_cluster_address='gcomm://127.0.0.1:$NODE_GALERAPORT_1';
+--eval SET GLOBAL wsrep_cluster_address='$wsrep_cluster_address_orig'
 --enable_query_log
 
 --connection node_1


### PR DESCRIPTION
Fixed wrong wsrep_cluster_address usage, was still using environment
variable NODE_GALERAPORT_1.