### PR TITLE
Fix for test galera.galera_sst_mariabackup_encrypt_with_key

### DIFF
--- a/mysql-test/suite/galera/r/galera_sst_mariabackup_encrypt_with_key.result
+++ b/mysql-test/suite/galera/r/galera_sst_mariabackup_encrypt_with_key.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 SELECT 1;
 1
 1

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -905,6 +905,8 @@ static int sst_donate_mysqldump (const char*         addr,
   */
   if (!bypass && wsrep_sst_donor_rejects_queries) sst_reject_queries(TRUE);
 
+  make_wsrep_defaults_file();
+
   std::ostringstream uuid_oss;
   uuid_oss << gtid.id();
   int ret= snprintf (cmd_str(), cmd_len,
@@ -1299,6 +1301,8 @@ static int sst_donate_other (const char*        method,
     return ret;
   }
   if (strlen(binlog_opt_val)) binlog_opt= WSREP_SST_OPT_BINLOG;
+
+  make_wsrep_defaults_file();
 
   std::ostringstream uuid_oss;
   uuid_oss << gtid.id();


### PR DESCRIPTION
The address of mysql defaults file (my.snf) was not passed to SST script.
This lead to failures with tests, which need to read SST section from the configuration,
galera.galera_sst_mariabackup_encrypt_with_key is one example of such test failures

The fix is backporting the deafault file address build-up as it is done is 10.3 source code
Also new result file was recorded for galera.galera_sst_mariabackup_encrypt_with_key, the difference
was only "--connection node" lines appearing with debug build test run.