### PR TITLE
MDEV-18064: Packaging is broken for debian-based systems

### DIFF
--- a/debian/mariadb-server-10.3.install
+++ b/debian/mariadb-server-10.3.install
@@ -36,8 +36,6 @@ usr/bin/wsrep_sst_common
 usr/bin/wsrep_sst_mariabackup
 usr/bin/wsrep_sst_mysqldump
 usr/bin/wsrep_sst_rsync
-usr/bin/wsrep_sst_xtrabackup
-usr/bin/wsrep_sst_xtrabackup-v2
 usr/lib/mysql/plugin/auth_ed25519.so
 usr/lib/mysql/plugin/auth_pam.so
 usr/lib/mysql/plugin/auth_socket.so

--- a/man/wsrep_sst_xtrabackup-v2.1
+++ b/man/wsrep_sst_xtrabackup-v2.1
@@ -13,4 +13,6 @@ wsrep_sst_xtrabackup-v2 \- xtrabackup\-based state snapshot transfer
 .SH DESCRIPTION
 Use: xtrabackup-based state snapshot transfer\.
 .PP
+Note that the xtrabackup-v2 method is deprecated after version 10\.1, with newer versions you should use mariabackup instead\.
+.PP
 For more information, please refer to the MariaDB Knowledge Base, available online at https://mariadb.com/kb/

--- a/man/wsrep_sst_xtrabackup.1
+++ b/man/wsrep_sst_xtrabackup.1
@@ -13,4 +13,6 @@ wsrep_sst_xtrabackup \- xtrabackup\-based state snapshot transfer
 .SH DESCRIPTION
 Use: xtrabackup-based state snapshot transfer\.
 .PP
+Note that the xtrabackup method is deprecated after version 10\.1, with newer versions you should use mariabackup instead\.
+.PP
 For more information, please refer to the MariaDB Knowledge Base, available online at https://mariadb.com/kb/


### PR DESCRIPTION
Packaging is broken for debian-based systems after removing
xtrabackup scripts. This is due to the fact that links to the
scripts are not removed from the installation file
(from the debian/mariadb-server-10.3.install).

Also in this fix some comments have been added to the
documentation, indicating that using xtrabackup[-v2] is
an deprecated, therefore user should use mariabackup instead.

https://jira.mariadb.org/browse/MDEV-18064