### PR TITLE
Populate wsrep provider name, version and vendor status variables

### DIFF
--- a/mysql-test/suite/galera/r/galera#505.result
+++ b/mysql-test/suite/galera/r/galera#505.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 connection node_1;
 SET SESSION wsrep_sync_wait=0;
 SET SESSION wsrep_sync_wait=DEFAULT;

--- a/mysql-test/suite/galera/r/galera_defaults.result
+++ b/mysql-test/suite/galera/r/galera_defaults.result
@@ -1,11 +1,7 @@
 connection node_2;
 connection node_1;
-Warnings:
-Warning	1292	Truncated incorrect INTEGER value: '4.dev(r3810)'
-Warnings:
-Warning	1292	Truncated incorrect INTEGER value: '4.dev(r3810)'
-SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME LIKE 'wsrep_%';
-COUNT(*)
+SELECT COUNT(*) `expect 48` FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME LIKE 'wsrep_%';
+expect 48
 48
 SELECT VARIABLE_NAME, VARIABLE_VALUE
 FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES
@@ -62,4 +58,3 @@ WSREP_SST_METHOD	rsync
 WSREP_SYNC_WAIT	15
 WSREP_TRX_FRAGMENT_SIZE	0
 WSREP_TRX_FRAGMENT_UNIT	bytes
-<BASE_DIR>; <BASE_HOST>; <BASE_PORT>; cert.log_conflicts = no; debug = no; evs.auto_evict = 0; evs.causal_keepalive_period = PT1S; evs.debug_log_mask = 0x1; evs.delay_margin = PT1S; evs.delayed_keep_period = PT30S; evs.inactive_check_period = PT0.5S; evs.inactive_timeout = PT30S; evs.info_log_mask = 0; evs.install_timeout = PT15S; evs.join_retrans_period = PT1S; evs.keepalive_period = PT1S; evs.max_install_timeouts = 3; evs.send_window = 4; evs.stats_report_period = PT1M; evs.suspect_timeout = PT10S; evs.use_aggregate = true; evs.user_send_window = 2; evs.version = 1; evs.view_forget_timeout = P1D; <GCACHE_DIR>; gcache.keep_pages_size = 0; gcache.mem_size = 0; <GCACHE_NAME>; gcache.page_size = 128M; gcache.recover = yes; gcache.size = 10M; gcomm.thread_prio = ; gcs.fc_debug = 0; gcs.fc_factor = 1.0; gcs.fc_limit = 16; gcs.fc_master_slave = no; gcs.max_packet_size = 64500; gcs.max_throttle = 0.25; <GCS_RECV_Q_HARD_LIMIT>; gcs.recv_q_soft_limit = 0.25; gcs.sync_donor = no; <GMCAST_LISTEN_ADDR>; gmcast.mcast_addr = ; gmcast.mcast_ttl = 1; gmcast.peer_timeout = PT3S; gmcast.segment = 0; gmcast.time_wait = PT5S; gmcast.version = 0; <IST_RECV_ADDR>; pc.announce_timeout = PT3S; pc.checksum = false; pc.ignore_quorum = false; pc.ignore_sb = false; pc.linger = PT20S; pc.npvo = false; pc.recovery = true; pc.version = 0; pc.wait_prim = true; pc.wait_prim_timeout = PT30S; pc.weight = 1; protonet.backend = asio; protonet.version = 0; repl.causal_read_timeout = PT90S; repl.commit_order = 3; repl.key_format = FLAT8; repl.max_ws_size = 2147483647; <REPL_PROTO_MAX>; socket.checksum = 2; socket.recv_buf_size = 212992; 

--- a/mysql-test/suite/galera/t/galera_defaults.test
+++ b/mysql-test/suite/galera/t/galera_defaults.test
@@ -19,7 +19,7 @@ source ../wsrep/include/check_galera_version.inc;
 
 # Global Variables
 
-SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME LIKE 'wsrep_%';
+SELECT COUNT(*) `expect 48` FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME LIKE 'wsrep_%';
 
 SELECT VARIABLE_NAME, VARIABLE_VALUE
 FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES
@@ -36,28 +36,3 @@ AND VARIABLE_NAME NOT IN (
         'WSREP_PATCH_VERSION'
 )
 ORDER BY VARIABLE_NAME;
-
-# wsrep_provider_options
-#
-# We replace the ones that vary from run to run with placeholders
-
---let _WSREP_PROVIDER_OPTIONS = `SELECT @@wsrep_provider_options`
---perl
-	use strict;
-	my $wsrep_provider_options = $ENV{'_WSREP_PROVIDER_OPTIONS'};
-	$wsrep_provider_options =~ s/base_dir = .*?;/<BASE_DIR>;/sgio;
-	$wsrep_provider_options =~ s/base_host = .*?;/<BASE_HOST>;/sgio;
-	$wsrep_provider_options =~ s/base_port = .*?;/<BASE_PORT>;/sgio;
-	$wsrep_provider_options =~ s/gcache\.dir = .*?;/<GCACHE_DIR>;/sgio;
-	$wsrep_provider_options =~ s/gcache\.name = .*?;/<GCACHE_NAME>;/sgio;
-	$wsrep_provider_options =~ s/gmcast\.listen_addr = .*?;/<GMCAST_LISTEN_ADDR>;/sgio;
-	$wsrep_provider_options =~ s/gcs\.recv_q_hard_limit = .*?;/<GCS_RECV_Q_HARD_LIMIT>;/sgio;
-	$wsrep_provider_options =~ s/ist\.recv_addr = .*?;/<IST_RECV_ADDR>;/sgio;
-	$wsrep_provider_options =~ s/evs\.evict = .*?;/<EVS_EVICT>;/sgio;
-	$wsrep_provider_options =~ s/repl\.proto_max = .*?;/<REPL_PROTO_MAX>;/sgio;
-	$wsrep_provider_options =~ s/signal = .*?;\s*//sgio;
-	$wsrep_provider_options =~ s/dbug = .*?;\s*//sgio;
-	$wsrep_provider_options =~ s/gcs.recv_q_hard_limit = .*?;\s*/<RECV_Q_HARD_LIMIT>;/sgio;
-	$wsrep_provider_options =~ s/repl.proto_max = .*?;\s*/<REPL_PROTO_MAX>;/sgio;
-	print $wsrep_provider_options."\n";
-EOF

--- a/mysql-test/suite/wsrep/disabled.def
+++ b/mysql-test/suite/wsrep/disabled.def
@@ -1,2 +1,3 @@
 wsrep.foreign_key : Sporadic failure "WSREP has not yet prepared node for application use"
 wsrep.pool_of_threads : Sporadic failure "WSREP has not yet prepared node for application use"
+wsrep.variables : Global wsrep_on manipulation causes debug asserts

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -595,6 +595,21 @@ static wsrep::gtid wsrep_server_initial_position()
   return ret;
 }
 
+/*
+  Intitialize provider specific status variables
+ */
+static void wsrep_init_provider_status_variables()
+{
+  const wsrep::provider& provider=
+    Wsrep_server_state::instance().provider();
+  strncpy(provider_name,
+          provider.name().c_str(),    sizeof(provider_name) - 1);
+  strncpy(provider_version,
+          provider.version().c_str(), sizeof(provider_version) - 1);
+  strncpy(provider_vendor,
+          provider.vendor().c_str(),  sizeof(provider_vendor) - 1);
+}
+
 int wsrep_init_server()
 {
   wsrep::log::logger_fn(wsrep_log_cb);
@@ -667,6 +682,10 @@ int wsrep_init()
       DBUG_PRINT("wsrep",("wsrep::init() failed: %d", err));
       WSREP_ERROR("wsrep::init() failed: %d, must shutdown", err);
     }
+    else
+    {
+      wsrep_init_provider_status_variables();
+    }
     return err;
   }
 
@@ -704,6 +723,7 @@ int wsrep_init()
   }
   wsrep_inited= 1;
 
+  wsrep_init_provider_status_variables();
   wsrep_capabilities_export(Wsrep_server_state::instance().provider().capabilities(),
                             &wsrep_provider_capabilities);
 


### PR DESCRIPTION
This pull request consists of two commits:

The first commit adds initialization of wsrep provider status variables `wsrep_provider_name`, `wsrep_provider_vendor` and `wsrep_provider_version`. Submodule `wsrep-lib` position is updated to include support for getting provider name, position and version information via provider interface.

The second commit fixes merge error in `galera.galera_defaults`, records `galera.galera_defaults` and `galera.galera#505` and disables `wsrep.variables` which crashes in debug assert when manipulating global `wsrep_on`.