### PR TITLE
Make test galera_sr.mysql-wsrep-features#35 deterministic

### DIFF
--- a/mysql-test/suite/galera_sr/r/mysql-wsrep-features#35.result
+++ b/mysql-test/suite/galera_sr/r/mysql-wsrep-features#35.result
@@ -6,10 +6,9 @@ SELECT COUNT(*) = 0 FROM t1;
 COUNT(*) = 0
 1
 SET SESSION wsrep_sync_wait = 0;
-SET GLOBAL debug = 'd,sync.wsrep_apply_cb';
+SET GLOBAL debug = '+d,sync.wsrep_apply_cb';
 Warnings:
 Warning	1287	'@@debug' is deprecated and will be removed in a future release. Please use '@@debug_dbug' instead
-SET SESSION wsrep_sync_wait = 0;
 connection node_1;
 SET SESSION wsrep_trx_fragment_size = 1;
 SET AUTOCOMMIT=OFF;
@@ -19,6 +18,8 @@ INSERT INTO t1 VALUES (2);
 INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 INSERT INTO t1 VALUES (5);
+connection node_2a;
+SET SESSION debug_sync = "now WAIT_FOR sync.wsrep_apply_cb_reached";
 connection node_2;
 SET SESSION wsrep_sync_wait = 0;
 SELECT COUNT(*) = 0 FROM t1;
@@ -31,8 +32,10 @@ connection node_2a;
 SET GLOBAL debug = '';
 Warnings:
 Warning	1287	'@@debug' is deprecated and will be removed in a future release. Please use '@@debug_dbug' instead
-SET DEBUG_SYNC='now SIGNAL signal.wsrep_apply_cb';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 connection node_2;
 Got one of the listed errors
 ROLLBACK;
 DROP TABLE t1;
+connection node_2a;
+SET DEBUG_SYNC = "RESET";

--- a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#35.test
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#35.test
@@ -1,6 +1,5 @@
 --source include/have_debug_sync.inc
 --source include/galera_cluster.inc
---source include/have_innodb.inc
 
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
@@ -10,12 +9,9 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
 SELECT COUNT(*) = 0 FROM t1;
 SET SESSION wsrep_sync_wait = 0;
---let $debug_orig = `SELECT @@debug`
-SET GLOBAL debug = 'd,sync.wsrep_apply_cb';
-SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL debug = '+d,sync.wsrep_apply_cb';
 
 --connection node_1
---let $wsrep_trx_fragment_size_orig = `SELECT @@wsrep_trx_fragment_size`
 SET SESSION wsrep_trx_fragment_size = 1;
 SET AUTOCOMMIT=OFF;
 START TRANSACTION;
@@ -25,6 +21,9 @@ INSERT INTO t1 VALUES (2);
 INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 INSERT INTO t1 VALUES (5);
+
+--connection node_2a
+SET SESSION debug_sync = "now WAIT_FOR sync.wsrep_apply_cb_reached";
 
 --connection node_2
 SET SESSION wsrep_sync_wait = 0;
@@ -36,7 +35,7 @@ COMMIT;
 
 --connection node_2a
 SET GLOBAL debug = '';
-SET DEBUG_SYNC='now SIGNAL signal.wsrep_apply_cb';
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 
 --connection node_2
 --error ER_DUP_ENTRY,ER_LOCK_DEADLOCK
@@ -44,3 +43,6 @@ SET DEBUG_SYNC='now SIGNAL signal.wsrep_apply_cb';
 ROLLBACK;
 
 DROP TABLE t1;
+
+--connection node_2a
+SET DEBUG_SYNC = "RESET";


### PR DESCRIPTION
Test sets sync point sync.wsrep_apply_cb, but was not waiting for it
to be reached. Also, reset debug sync at the end of test, so that no
sync point are left behind after the test finishes.