### PR TITLE
MDEV-18186 assertion failure on missing InnoDB index

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-index-debug.result
+++ b/mysql-test/suite/innodb/r/innodb-index-debug.result
@@ -324,3 +324,19 @@ insert into t1 values(1,1,2),(2,2,1);
 alter table t1 drop primary key, add primary key(o1), lock=none;
 drop table t1;
 SET DEBUG_DBUG = @saved_debug_dbug;
+#
+#  MDEV-18186 assertion failure on missing InnoDB index
+#
+CREATE TABLE t (a INT, INDEX i1 (a)) ENGINE=INNODB;
+DROP TABLE t;
+CREATE TABLE t (a INT) ENGINE=INNODB;
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+  KEY `i1` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+Warnings:
+Warning	1082	InnoDB: Table test/t contains 0 indexes inside InnoDB, which is different from the number of indexes 1 defined in the MariaDB 
+Warning	1082	InnoDB: Table test/t contains 0 indexes inside InnoDB, which is different from the number of indexes 1 defined in the MariaDB 
+DROP TABLE t;

--- a/mysql-test/suite/innodb/t/innodb-index-debug.test
+++ b/mysql-test/suite/innodb/t/innodb-index-debug.test
@@ -166,3 +166,25 @@ SET DEBUG_DBUG = '+d,innodb_alter_table_pk_assert_no_sort';
 --source suite/innodb/include/alter_table_pk_no_sort.inc
 
 SET DEBUG_DBUG = @saved_debug_dbug;
+
+--echo #
+--echo #  MDEV-18186 assertion failure on missing InnoDB index
+--echo #
+
+--disable_query_log
+call mtr.add_suppression("Cannot find index i1 in InnoDB index dictionary");
+call mtr.add_suppression("InnoDB indexes are inconsistent with what defined");
+call mtr.add_suppression("Table test/t contains 0 indexes");
+call mtr.add_suppression("InnoDB could not find key no");
+--enable_query_log
+
+# Test an attempt to rename a nonexistent index inside InnoDB
+-- let $MYSQL_DATA_DIR = `SELECT @@datadir`
+CREATE TABLE t (a INT, INDEX i1 (a)) ENGINE=INNODB;
+-- copy_file $MYSQL_DATA_DIR/test/t.frm $MYSQL_DATA_DIR/test/t.fr_
+DROP TABLE t;
+CREATE TABLE t (a INT) ENGINE=INNODB;
+-- remove_file $MYSQL_DATA_DIR/test/t.frm
+-- move_file $MYSQL_DATA_DIR/test/t.fr_ $MYSQL_DATA_DIR/test/t.frm
+SHOW CREATE TABLE t;
+DROP TABLE t;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9534,7 +9534,6 @@ ha_innobase::innobase_get_index(
 	if (keynr != MAX_KEY && table->s->keys > 0) {
 		key = &table->key_info[keynr];
 		index = dict_table_get_index_on_name(ib_table, key->name);
-		ut_ad(index);
 	} else {
 		index = dict_table_get_first_index(ib_table);
 	}


### PR DESCRIPTION
This was introduced in 1a7a018939e19a0037808489be0fd1680581aec3
MDEV-16557 Remove INNOBASE_SHARE::idx_trans_tbl

ha_innobase::innobase_get_index: remove incorrect assertion. Index nullability
is checked in subsequent ifs.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.2-MDEV-18186-missing-innodb-index)