### PR TITLE
Do not import commands library as it is not used

### DIFF
--- a/storage/rocksdb/myrocks_hotbackup.py
+++ b/storage/rocksdb/myrocks_hotbackup.py
@@ -8,7 +8,6 @@ import os
 import stat
 import sys
 import re
-import commands
 import subprocess
 import logging
 import logging.handlers


### PR DESCRIPTION
It also makes the script not work on python3, but since the script already uses subprocess in practice, removing `commands` import is effectively no change and fixes the python3 compatibility.