### PR TITLE
[MDEV-17803] fixes wrong datatype (uint instead of ulong) for table_id

### DIFF
--- a/sql/table.h
+++ b/sql/table.h
@@ -1816,7 +1816,7 @@ struct TABLE_LIST
   /* Index names in a "... JOIN ... USE/IGNORE INDEX ..." clause. */
   List<Index_hint> *index_hints;
   TABLE        *table;                          /* opened table */
-  uint          table_id; /* table id (from binlog) for opened table */
+  ulong          table_id; /* table id (from binlog) for opened table */
   /*
     select_result for derived table to pass it from table creation to table
     filling procedure


### PR DESCRIPTION
see

https://jira.mariadb.org/browse/MDEV-17803
https://jira.mariadb.org/browse/MDEV-18175
https://bugs.mysql.com/bug.php?id=88754

The patch is licensed under BSD-new license.