### PR TITLE
MDEV-14580: mysql_install_db elements based on dirname of mysql_instal_db

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -287,6 +287,9 @@ then
     cannot_find_file my_print_defaults $basedir/bin $basedir/extra
     exit 1
   fi
+elif test -x "$(dirname $0)/../@bindir@/my_print_defaults"
+then
+  print_defaults="$(dirname $0)/../@bindir@/my_print_defaults"
 else
   print_defaults="@bindir@/my_print_defaults"
 fi
@@ -342,6 +345,16 @@ then
     exit 1
   fi
   plugindir=`find_in_dirs --dir auth_socket.so $basedir/lib*/plugin $basedir/lib*/mysql/plugin`
+# relative from where the script was run for a relocatable install
+elif test -x "$(dirname $0)/../@INSTALL_SBINDIR@/mysqld"
+then
+  basedir="$(dirname $0)/../"
+  bindir="$basedir/@INSTALL_SBINDIR@"
+  resolveip="$bindir/resolveip"
+  mysqld="$basedir/@INSTALL_SBINDIR@/mysqld"
+  srcpkgdatadir="$basedir/@INSTALL_MYSQLSHAREDIR@"
+  buildpkgdatadir="$basedir/@INSTALL_MYSQLSHAREDIR@"
+  plugindir="$basedir/@INSTALL_PLUGINDIR@"
 else
   basedir="@prefix@"
   bindir="@bindir@"


### PR DESCRIPTION
tested with the following with cwd at builddir:
<pre>
$ make DESTDIR=/tmp/m3 install
$  /tmp/m3/usr/local/mysql/scripts/mysql_install_db --datadir=/tmp/data_fullpath
$ mv /tmp/m3 /tmp/m4
$ /tmp/m4/usr/local/mysql/scripts/mysql_install_db --datadir=/tmp/data_moved
$ export PATH=/tmp/m4/usr/local/mysql/scripts:$PATH
$  mysql_install_db --datadir=/tmp/data_path
$ cd  /tmp/m4/usr/local/mysql/scripts
$ ./mysql_install_db --datadir /tmp/relative
</pre>

I submit this under the MCA.