### PR TITLE
Fixes to wsrep XID durability

### DIFF
--- a/mysql-test/suite/wsrep/r/wsrep-recover,binlogon.rdiff
+++ b/mysql-test/suite/wsrep/r/wsrep-recover,binlogon.rdiff
@@ -1,0 +1,28 @@
+--- r/wsrep-recover.result	2019-01-11 16:22:46.329012579 +0200
++++ r/wsrep-recover.reject	2019-01-11 16:23:55.313137675 +0200
+@@ -48,19 +48,17 @@
+ SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_1";
+ connection default;
+ # Kill the server
+-Expect seqno 9
+-9
++Expect seqno 7
++7
+ disconnect con1;
+ disconnect con2;
+ disconnect con_ctrl;
+ connection default;
+-SELECT VARIABLE_VALUE `expect 10` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+-expect 10
+-10
+-Expect rows 5, 9, 10
++SELECT VARIABLE_VALUE `expect 8` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
++expect 8
++8
++Expect row 5
+ SELECT * FROM t1;
+ f1
+ 5
+-9
+-10
+ DROP TABLE t1;

--- a/mysql-test/suite/wsrep/r/wsrep-recover.result
+++ b/mysql-test/suite/wsrep/r/wsrep-recover.result
@@ -1,0 +1,12 @@
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+# Kill the server
+Expect seqno 3
+3
+SELECT COUNT(*) `expect 1` FROM t1;
+expect 1
+1
+SELECT VARIABLE_VALUE `expect 4` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+expect 4
+4
+DROP TABLE t1;

--- a/mysql-test/suite/wsrep/r/wsrep-recover.result
+++ b/mysql-test/suite/wsrep/r/wsrep-recover.result
@@ -1,12 +1,66 @@
+# Kill the server
+Expect seqno 1
+1
 CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
-INSERT INTO t1 VALUES (1);
 # Kill the server
 Expect seqno 3
 3
-SELECT COUNT(*) `expect 1` FROM t1;
-expect 1
-1
-SELECT VARIABLE_VALUE `expect 4` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
-expect 4
-4
+INSERT INTO t1 VALUES (5);
+# Kill the server
+Expect seqno 5
+5
+SELECT VARIABLE_VALUE `expect 6` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+expect 6
+6
+connect con1, localhost, root;
+SET DEBUG_SYNC = "wsrep_after_certification SIGNAL after_certification_reached WAIT_FOR continue";
+INSERT INTO t1 VALUES (7);
+connect con_ctrl, localhost, root;
+SET DEBUG_SYNC = "now WAIT_FOR after_certification_reached";
+connect con2, localhost, root;
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached WAIT_FOR continue";
+INSERT INTO t1 VALUES (8);
+connection con_ctrl;
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached";
+connection default;
+# Kill the server
+Expect seqno 6
+6
+disconnect con1;
+disconnect con2;
+disconnect con_ctrl;
+connection default;
+SELECT VARIABLE_VALUE `expect 7` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+expect 7
+7
+connect con1, localhost, root;
+SET DEBUG_SYNC = "wsrep_after_certification SIGNAL after_certification_reached WAIT_FOR continue_after_certification";
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_1 WAIT_FOR continue_before_commit_order_1";
+INSERT INTO t1 VALUES (9);
+connect con_ctrl, localhost, root;
+SET DEBUG_SYNC = "now WAIT_FOR after_certification_reached";
+connect con2, localhost, root;
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_2 WAIT_FOR continue_before_commit_order_2";
+INSERT INTO t1 VALUES (10);
+connection con_ctrl;
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_2";
+SET DEBUG_SYNC = "now SIGNAL continue_after_certification";
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_1";
+connection default;
+# Kill the server
+Expect seqno 9
+9
+disconnect con1;
+disconnect con2;
+disconnect con_ctrl;
+connection default;
+SELECT VARIABLE_VALUE `expect 10` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+expect 10
+10
+Expect rows 5, 9, 10
+SELECT * FROM t1;
+f1
+5
+9
+10
 DROP TABLE t1;

--- a/mysql-test/suite/wsrep/t/wsrep-recover-step.inc
+++ b/mysql-test/suite/wsrep/t/wsrep-recover-step.inc
@@ -1,0 +1,41 @@
+#
+# Macro to run wsrep recovery step. This is adapted from
+# suite/galera/include/galera_wsrep_recover.inc, with additional
+# option to pass binlog argument to recovery command. The macro
+# returns recovered position split in uuid and seqno parts.
+#
+# Arguments:
+#
+# wsrep_recover_binlog_opt - Binlog options to recovery command
+#
+# Return:
+#
+# wsrep_recover_start_position_uuid - UUID corresponding to recovered position
+# wsrep_recover_start_position_seqno - seqno corresponding to recovered position
+#
+
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --log-error=$MYSQL_TMP_DIR/galera_wsrep_recover.log --innodb --wsrep-recover $wsrep_recover_binlog_opt --core-file > $MYSQL_TMP_DIR/galera_wsrep_recover.log 2>&1
+
+--perl
+	use strict;
+	my $wsrep_start_position = `grep 'WSREP: Recovered position:' $ENV{MYSQL_TMP_DIR}/galera_wsrep_recover.log | sed 's/.*WSREP\:\ Recovered\ position://' | sed 's/^[ \t]*//'`;
+	chomp($wsrep_start_position);
+        die if $wsrep_start_position eq '';
+	open(FILE, ">", "$ENV{MYSQL_TMP_DIR}/galera_wsrep_start_position.inc") or die;
+	my ($uuid, $seqno) = split /:/, $wsrep_start_position;
+	print FILE "--let \$wsrep_recover_start_position_uuid = $uuid\n";
+	print FILE "--let \$wsrep_recover_start_position_seqno = $seqno\n";
+	close FILE;
+EOF
+
+--source $MYSQL_TMP_DIR/galera_wsrep_start_position.inc
+
+if ($wsrep_recover_start_position_uuid == '') {
+   --die "Could not obtain start_position_uuid."
+}
+
+if ($wsrep_recover_start_position_seqno == '') {
+   --die "Could not obtain start_position_seqno."
+}
+
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_start_position.inc

--- a/mysql-test/suite/wsrep/t/wsrep-recover.cnf
+++ b/mysql-test/suite/wsrep/t/wsrep-recover.cnf
@@ -1,0 +1,9 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+binlog-format=ROW
+innodb-flush-log-at-trx-commit=1
+wsrep-cluster-address=gcomm://
+wsrep-provider=@ENV.WSREP_PROVIDER
+innodb-autoinc-lock-mode=2

--- a/mysql-test/suite/wsrep/t/wsrep-recover.combinations
+++ b/mysql-test/suite/wsrep/t/wsrep-recover.combinations
@@ -1,0 +1,4 @@
+[binlogon]
+log-bin
+
+[binlogoff]

--- a/mysql-test/suite/wsrep/t/wsrep-recover.test
+++ b/mysql-test/suite/wsrep/t/wsrep-recover.test
@@ -2,13 +2,24 @@
 # Verify that the wsrep XID gets updated in InnoDB rollback segment
 # properly and can be recovered with --wsrep-recover
 #
+# The test runs the following scenarios:
+#
+# 1) The server is started but no SQL is run
+# 2) DDL is executed
+# 3) INSERT is executed
+# 4) Two INSERTs are executed so that the first one in order will be
+#    blocked after certification and the second one before entering
+#    commit order critical section.
+# 5) Two DMLs are executed so that the prepare step is run out of order.
+#    Both transactions are blocked before commit order critical section.
+#
+# After each scenario server is killed and the recovered position
+# is validated.
+#
 
 --source include/have_wsrep.inc
 --source include/have_innodb.inc
 --source include/have_wsrep_provider.inc
-
-CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
-INSERT INTO t1 VALUES (1);
 
 #
 # Binlog option for recovery run. This must be set in the test because
@@ -17,59 +28,169 @@ INSERT INTO t1 VALUES (1);
 #
 --let $log_bin = `SELECT @@log_bin`
 if ($log_bin) {
---let $binlog_opt = --log-bin
+--let $wsrep_recover_binlog_opt = --log-bin
 }
 
 #
-# Kill server and run recovery step
+# Scenario 1
+# The expected recovered seqno is 1 corresponding to initial cluster
+# configuration change.
 #
 --source include/kill_mysqld.inc
+--source wsrep-recover-step.inc
+--echo Expect seqno 1
+--echo $wsrep_recover_start_position_seqno
 
---exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --log-error=$MYSQL_TMP_DIR/galera_wsrep_recover.log --innodb --wsrep-recover $binlog_opt --core-file > $MYSQL_TMP_DIR/galera_wsrep_recover.log 2>&1
-
---perl
-	use strict;
-	my $wsrep_start_position = `grep 'WSREP: Recovered position:' $ENV{MYSQL_TMP_DIR}/galera_wsrep_recover.log | sed 's/.*WSREP\:\ Recovered\ position://' | sed 's/^[ \t]*//'`;
-	chomp($wsrep_start_position);
-        die if $wsrep_start_position eq '';
-	open(FILE, ">", "$ENV{MYSQL_TMP_DIR}/galera_wsrep_start_position.inc") or die;
-	my ($uuid, $seqno) = split /:/, $wsrep_start_position;
-	print FILE "--let \$start_position_uuid = $uuid\n";
-	print FILE "--let \$start_position_seqno = $seqno\n";
-	close FILE;
-EOF
-
---source $MYSQL_TMP_DIR/galera_wsrep_start_position.inc
-
-if ($start_position_uuid == '') {
-   --die "Could not obtain start_position_uuid."
-}
-
-if ($start_position_seqno == '') {
-   --die "Could not obtain start_position_seqno."
-}
-
---remove_file $MYSQL_TMP_DIR/galera_wsrep_start_position.inc
-
-#
-# The sequence number at this point should be 3: Initial cluster config change,
-# CREATE TABLE and INSERT
-#
---echo Expect seqno 3
---echo $start_position_seqno
-
-#
-# Restart the server
-#
---let $restart_parameters = --wsrep-start-position=$start_position_uuid:$start_position_seqno
+--let $restart_parameters = --wsrep-start-position=$wsrep_recover_start_position_uuid:$wsrep_recover_start_position_seqno
 --source include/start_mysqld.inc
 --source include/wait_wsrep_ready.inc
 
 #
-# One row should be found from t1 and the wsrep_last_committed should have
-# value 4 (recovered position + cluster configuration change).
+# Senario 2
+# The expected recovered seqno is 3 corresponding to two configuration
+# change events and CREATE TABLE.
 #
-SELECT COUNT(*) `expect 1` FROM t1;
-SELECT VARIABLE_VALUE `expect 4` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+--source include/kill_mysqld.inc
+--source wsrep-recover-step.inc
+--echo Expect seqno 3
+--echo $wsrep_recover_start_position_seqno
+
+--let $restart_parameters = --wsrep-start-position=$wsrep_recover_start_position_uuid:$wsrep_recover_start_position_seqno
+--source include/start_mysqld.inc
+--source include/wait_wsrep_ready.inc
+
+#
+# Scenario 3
+# The expected recovered seqno is 5 corresponding to three configuration
+# change events, CREATE TABLE and INSERT.
+#
+
+INSERT INTO t1 VALUES (5);
+--source include/kill_mysqld.inc
+--source wsrep-recover-step.inc
+--echo Expect seqno 5
+--echo $wsrep_recover_start_position_seqno
+--let $restart_parameters = --wsrep-start-position=$wsrep_recover_start_position_uuid:$wsrep_recover_start_position_seqno
+--source include/start_mysqld.inc
+--source include/wait_wsrep_ready.inc
+
+SELECT VARIABLE_VALUE `expect 6` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+
+#
+# Scenario 4
+#
+# This will cause the following
+#
+# Seqno 7 - the first INSERT is blocked after it is certified but before
+#           it gets prepared
+# Seqno 8 - the second INSERT is blocked before it will be ordered for
+#           commit, so it becomes prepared
+#
+# As an outcome, the recovery process should return seqno 6 because
+# the range of prepared transactions found after the crash recovery
+# is not continuous up to 8.
+#
+
+# Send INSERT which will block after certification
+--connect con1, localhost, root
+SET DEBUG_SYNC = "wsrep_after_certification SIGNAL after_certification_reached WAIT_FOR continue";
+--send INSERT INTO t1 VALUES (7)
+
+--connect con_ctrl, localhost, root
+SET DEBUG_SYNC = "now WAIT_FOR after_certification_reached";
+
+# Send INSERT which will block before commit order critical section
+--connect con2, localhost, root
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached WAIT_FOR continue";
+--send INSERT INTO t1 VALUES (8)
+
+--connection con_ctrl
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached";
+
+--connection default
+--source include/kill_mysqld.inc
+--source wsrep-recover-step.inc
+--echo Expect seqno 6
+--echo $wsrep_recover_start_position_seqno
+--let $restart_parameters = --wsrep-start-position=$wsrep_recover_start_position_uuid:$wsrep_recover_start_position_seqno
+--source include/start_mysqld.inc
+--source include/wait_wsrep_ready.inc
+
+--disconnect con1
+--disconnect con2
+--disconnect con_ctrl
+--connection default
+
+SELECT VARIABLE_VALUE `expect 7` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+
+#
+# Scenario 5
+#
+# This scenario will run two INSERTs in parallel so that they are
+# prepared out of order. The execution is stopped before commit
+# and the server is killed. The outcome of this scenario depends
+# on binlog settings:
+#
+# If binlog is off, the transactions will be recovered from InnoDB and
+# committed during recovery.
+#
+# If binlog is on, the transactions will be recovered from InnoDB but
+# will be rolled back since they are not logged yet in binlog.
+#
+
+--connect con1, localhost, root
+SET DEBUG_SYNC = "wsrep_after_certification SIGNAL after_certification_reached WAIT_FOR continue_after_certification";
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_1 WAIT_FOR continue_before_commit_order_1";
+--send INSERT INTO t1 VALUES (9)
+
+--connect con_ctrl, localhost, root
+SET DEBUG_SYNC = "now WAIT_FOR after_certification_reached";
+
+--connect con2, localhost, root
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_2 WAIT_FOR continue_before_commit_order_2";
+--send INSERT INTO t1 VALUES (10)
+
+--connection con_ctrl
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_2";
+SET DEBUG_SYNC = "now SIGNAL continue_after_certification";
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_1";
+
+--connection default
+--source include/kill_mysqld.inc
+--source wsrep-recover-step.inc
+if ($log_bin) {
+   --echo Expect seqno 7
+}
+if (!$log_bin) {
+   --echo Expect seqno 9
+}
+--echo $wsrep_recover_start_position_seqno
+--let $restart_parameters = --wsrep-start-position=$wsrep_recover_start_position_uuid:$wsrep_recover_start_position_seqno
+--source include/start_mysqld.inc
+--source include/wait_wsrep_ready.inc
+
+--disconnect con1
+--disconnect con2
+--disconnect con_ctrl
+--connection default
+
+if ($log_bin) {
+   SELECT VARIABLE_VALUE `expect 8` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+}
+if (!$log_bin) {
+   SELECT VARIABLE_VALUE `expect 10` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+}
+
+#
+# Final sanity check: The successful inserts into t1 should result
+if ($log_bin) {
+   --echo Expect row 5
+}
+if (!$log_bin) {
+   --echo Expect rows 5, 9, 10
+}
+SELECT * FROM t1;
 
 DROP TABLE t1;

--- a/mysql-test/suite/wsrep/t/wsrep-recover.test
+++ b/mysql-test/suite/wsrep/t/wsrep-recover.test
@@ -1,0 +1,75 @@
+#
+# Verify that the wsrep XID gets updated in InnoDB rollback segment
+# properly and can be recovered with --wsrep-recover
+#
+
+--source include/have_wsrep.inc
+--source include/have_innodb.inc
+--source include/have_wsrep_provider.inc
+
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+#
+# Binlog option for recovery run. This must be set in the test because
+# combinations file causes log-bin option to be set from command line,
+# not via my.cnf.
+#
+--let $log_bin = `SELECT @@log_bin`
+if ($log_bin) {
+--let $binlog_opt = --log-bin
+}
+
+#
+# Kill server and run recovery step
+#
+--source include/kill_mysqld.inc
+
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --log-error=$MYSQL_TMP_DIR/galera_wsrep_recover.log --innodb --wsrep-recover $binlog_opt --core-file > $MYSQL_TMP_DIR/galera_wsrep_recover.log 2>&1
+
+--perl
+	use strict;
+	my $wsrep_start_position = `grep 'WSREP: Recovered position:' $ENV{MYSQL_TMP_DIR}/galera_wsrep_recover.log | sed 's/.*WSREP\:\ Recovered\ position://' | sed 's/^[ \t]*//'`;
+	chomp($wsrep_start_position);
+        die if $wsrep_start_position eq '';
+	open(FILE, ">", "$ENV{MYSQL_TMP_DIR}/galera_wsrep_start_position.inc") or die;
+	my ($uuid, $seqno) = split /:/, $wsrep_start_position;
+	print FILE "--let \$start_position_uuid = $uuid\n";
+	print FILE "--let \$start_position_seqno = $seqno\n";
+	close FILE;
+EOF
+
+--source $MYSQL_TMP_DIR/galera_wsrep_start_position.inc
+
+if ($start_position_uuid == '') {
+   --die "Could not obtain start_position_uuid."
+}
+
+if ($start_position_seqno == '') {
+   --die "Could not obtain start_position_seqno."
+}
+
+--remove_file $MYSQL_TMP_DIR/galera_wsrep_start_position.inc
+
+#
+# The sequence number at this point should be 3: Initial cluster config change,
+# CREATE TABLE and INSERT
+#
+--echo Expect seqno 3
+--echo $start_position_seqno
+
+#
+# Restart the server
+#
+--let $restart_parameters = --wsrep-start-position=$start_position_uuid:$start_position_seqno
+--source include/start_mysqld.inc
+--source include/wait_wsrep_ready.inc
+
+#
+# One row should be found from t1 and the wsrep_last_committed should have
+# value 4 (recovered position + cluster configuration change).
+#
+SELECT COUNT(*) `expect 1` FROM t1;
+SELECT VARIABLE_VALUE `expect 4` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed';
+
+DROP TABLE t1;

--- a/mysql-test/suite/wsrep/t/wsrep-recover.test
+++ b/mysql-test/suite/wsrep/t/wsrep-recover.test
@@ -67,6 +67,8 @@ CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
 # The expected recovered seqno is 5 corresponding to three configuration
 # change events, CREATE TABLE and INSERT.
 #
+# The expected wsrep_last_committed after the server is restarted is 6.
+#
 
 INSERT INTO t1 VALUES (5);
 --source include/kill_mysqld.inc
@@ -92,6 +94,8 @@ SELECT VARIABLE_VALUE `expect 6` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VAR
 # As an outcome, the recovery process should return seqno 6 because
 # the range of prepared transactions found after the crash recovery
 # is not continuous up to 8.
+#
+# The expected wsrep_last_committed after server is restarted is 7.
 #
 
 # Send INSERT which will block after certification
@@ -135,10 +139,13 @@ SELECT VARIABLE_VALUE `expect 7` FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VAR
 # on binlog settings:
 #
 # If binlog is off, the transactions will be recovered from InnoDB and
-# committed during recovery.
+# committed during recovery. The expected recovered seqno is 9, the
+# expected wsrep_last_committed after server is restarted is 10.
 #
 # If binlog is on, the transactions will be recovered from InnoDB but
-# will be rolled back since they are not logged yet in binlog.
+# will be rolled back since they are not logged yet in binlog. The
+# expected recovered seqno is 7, the expected wsrep_last_committed
+# after server is restarted is 8.
 #
 
 --connect con1, localhost, root

--- a/mysql-test/suite/wsrep/t/wsrep-recover.test
+++ b/mysql-test/suite/wsrep/t/wsrep-recover.test
@@ -20,6 +20,7 @@
 --source include/have_wsrep.inc
 --source include/have_innodb.inc
 --source include/have_wsrep_provider.inc
+--source include/have_debug_sync.inc
 
 #
 # Binlog option for recovery run. This must be set in the test because

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1538,7 +1538,11 @@ int ha_commit_trans(THD *thd, bool all)
                             wsrep_has_changes(thd, all));
     if (run_wsrep_commit)
       error= wsrep_before_commit(thd, all);
-    if (error) goto done;
+    if (error)
+    {
+      ha_rollback_trans(thd, FALSE);
+      goto wsrep_err;
+    }
 #endif /* WITH_WSREP */
     error= ha_commit_one_phase(thd, all);
 #ifdef WITH_WSREP
@@ -1578,7 +1582,7 @@ int ha_commit_trans(THD *thd, bool all)
 #ifdef WITH_WSREP
   if (!error && WSREP_ON)
   {
-    wsrep::seqno const s= wsrep_xid_seqno(thd->transaction.xid_state.xid);
+    wsrep::seqno const s= wsrep_xid_seqno(thd->wsrep_xid);
     if (!s.is_undefined())
     {
       // xid was rewritten by wsrep
@@ -2030,6 +2034,28 @@ static char* xid_to_str(char *buf, XID *xid)
 }
 #endif
 
+#ifdef WITH_WSREP
+static my_xid wsrep_order_and_check_continuity(XID *list, int len)
+{
+  wsrep_sort_xid_array(list, len);
+  wsrep::gtid cur_position= wsrep_get_SE_checkpoint();
+  long long cur_seqno= cur_position.seqno().get();
+  for (int i= 0; i < len; ++i)
+  {
+    if (!wsrep_is_wsrep_xid(list + i) ||
+        wsrep_xid_seqno(list + i) != cur_seqno + 1)
+    {
+      WSREP_WARN("Discovered discontinuity in recovered wsrep "
+                 "transaction XIDs. Truncating the recovery list to "
+                 "%d entries", i);
+      break;
+    }
+    ++cur_seqno;
+  }
+  WSREP_INFO("Last wsrep seqno to be recovered %lld", cur_seqno);
+  return (cur_seqno < 0 ? 0 : cur_seqno);
+}
+#endif /* WITH_WSREP */
 /**
   recover() step of xa.
 
@@ -2067,6 +2093,18 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
     {
       sql_print_information("Found %d prepared transaction(s) in %s",
                             got, hton_name(hton)->str);
+#ifdef WITH_WSREP
+      /* If wsrep_on=ON, XIDs are first ordered and then the range of
+         recovered XIDs is checked for continuity. All the XIDs which
+         are in continuous range can be safely committed if binlog
+         is off since they have already ordered and certified in the
+         cluster. */
+      my_xid wsrep_limit= 0;
+      if (WSREP_ON)
+      {
+        wsrep_limit= wsrep_order_and_check_continuity(info->list, got);
+      }
+#endif /* WITH_WSREP */
       for (int i=0; i < got; i ++)
       {
         my_xid x= IF_WSREP(WSREP_ON && wsrep_is_wsrep_xid(&info->list[i]) ?
@@ -2089,9 +2127,12 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
           continue;
         }
         // recovery mode
-        if (info->commit_list ?
-            my_hash_search(info->commit_list, (uchar *)&x, sizeof(x)) != 0 :
-            tc_heuristic_recover == TC_HEURISTIC_RECOVER_COMMIT)
+        if (IF_WSREP((wsrep_emulate_bin_log &&
+                      wsrep_is_wsrep_xid(info->list + i) &&
+                      x <= wsrep_limit), false) ||
+            (info->commit_list ?
+             my_hash_search(info->commit_list, (uchar *)&x, sizeof(x)) != 0 :
+             tc_heuristic_recover == TC_HEURISTIC_RECOVER_COMMIT))
         {
 #ifndef DBUG_OFF
           int rc=

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2098,7 +2098,17 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
          recovered XIDs is checked for continuity. All the XIDs which
          are in continuous range can be safely committed if binlog
          is off since they have already ordered and certified in the
-         cluster. */
+         cluster.
+
+         The discontinuity of wsrep XIDs may happen because the GTID
+         is assigned for transaction in wsrep_before_prepare(), but the
+         commit order is entered in wsrep_before_commit(). This means that
+         transactions may run prepare step out of order and may
+         result in gap in wsrep XIDs. This can be the case for example
+         if we have T1 with seqno 1 and T2 with seqno 2 and the server
+         crashes after T2 finishes prepare step but before T1 starts
+         the prepare.
+      */
       my_xid wsrep_limit= 0;
       if (WSREP_ON)
       {

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1146,6 +1146,13 @@ void *thd_memdup(MYSQL_THD thd, const void* str, size_t size)
 extern "C"
 void thd_get_xid(const MYSQL_THD thd, MYSQL_XID *xid)
 {
+#ifdef WITH_WSREP
+  if (!thd->wsrep_xid.is_null())
+  {
+    *xid = *(MYSQL_XID *) &thd->wsrep_xid;
+  }
+  else
+#endif /* WITH_WSREP */
   *xid = *(MYSQL_XID *) &thd->transaction.xid_state.xid;
 }
 

--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -23,6 +23,7 @@
 
 #include <mysql/service_wsrep.h>
 
+#include <algorithm> /* std::sort() */
 /*
  * WSREPXid
  */
@@ -179,4 +180,36 @@ wsrep::gtid wsrep_get_SE_checkpoint()
   }
 
   return wsrep::gtid(wsrep_xid_uuid(xid),wsrep_xid_seqno(xid));
+}
+
+/*
+  Sort order for XIDs. Wsrep XIDs are sorted according to
+  seqno in ascending order. Non-wsrep XIDs are considered
+  equal among themselves and and greater than with respect
+  to wsrep XIDs.
+ */
+struct Wsrep_xid_cmp
+{
+  bool operator()(const XID& left, const XID& right) const
+  {
+    const bool left_is_wsrep= wsrep_is_wsrep_xid(&left);
+    const bool right_is_wsrep= wsrep_is_wsrep_xid(&right);
+    if (left_is_wsrep && right_is_wsrep)
+    {
+      return (wsrep_xid_seqno(&left) < wsrep_xid_seqno(&right));
+    }
+    else if (left_is_wsrep)
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+};
+
+void wsrep_sort_xid_array(XID *array, int len)
+{
+  std::sort(array, array + len, Wsrep_xid_cmp());
 }

--- a/sql/wsrep_xid.cc
+++ b/sql/wsrep_xid.cc
@@ -185,7 +185,7 @@ wsrep::gtid wsrep_get_SE_checkpoint()
 /*
   Sort order for XIDs. Wsrep XIDs are sorted according to
   seqno in ascending order. Non-wsrep XIDs are considered
-  equal among themselves and and greater than with respect
+  equal among themselves and greater than with respect
   to wsrep XIDs.
  */
 struct Wsrep_xid_cmp

--- a/sql/wsrep_xid.h
+++ b/sql/wsrep_xid.h
@@ -32,5 +32,7 @@ bool wsrep_set_SE_checkpoint(const wsrep::gtid& gtid);
 //void wsrep_get_SE_checkpoint(XID&);             /* uncomment if needed */
 //void wsrep_set_SE_checkpoint(XID&);             /* uncomment if needed */
 
+void wsrep_sort_xid_array(XID *array, int len);
+
 #endif /* WITH_WSREP */
 #endif /* WSREP_UTILS_H */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4501,6 +4501,14 @@ innobase_commit_ordered_2(
 		trx->flush_log_later = true;
 	}
 
+#ifdef WITH_WSREP
+	/* If the transaction is not run in 2pc, we must assign wsrep
+	XID here in order to get it written in rollback segment. */
+	if (wsrep_on(thd)) {
+		thd_get_xid(thd, (MYSQL_XID*)trx->xid);
+	}
+#endif /* WITH_WSREP */
+
 	innobase_commit_low(trx);
 
 	if (!read_only) {
@@ -4703,6 +4711,15 @@ innobase_rollback(
 
 	dberr_t		error;
 
+#ifdef WITH_WSREP
+	/* If trx was assigned wsrep XID in prepare phase and the
+	trx is being rolled back due to BF abort, clear XID in order
+	to avoid writing it to rollback segment out of order. The XID
+	will be reassigned when the transaction is replayed. */
+	if (wsrep_is_wsrep_xid(trx->xid)) {
+		trx->xid->null();
+	}
+#endif /* WITH_WSREP */
 	if (rollback_trx
 	    || !thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN)) {
 
@@ -16991,6 +17008,14 @@ innobase_rollback_by_xid(
 	}
 
 	if (trx_t* trx = trx_get_trx_by_xid(xid)) {
+#ifdef WITH_WSREP
+		/* If a wsrep transaction is being rolled back during
+		the recovery, we must clear the xid in order to avoid
+		writing serialisation history for rolled back transaction. */
+		if (wsrep_is_wsrep_xid(trx->xid)) {
+			trx->xid->null();
+		}
+#endif /* WITH_WSREP */
 		int ret = innobase_rollback_trx(trx);
 		trx_deregister_from_2pc(trx);
 		ut_ad(!trx->will_lock);

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -2149,7 +2149,14 @@ static my_bool trx_get_trx_by_xid_callback(rw_trx_hash_element_t *element,
         arg->xid->eq(reinterpret_cast<XID*>(trx->xid)))
     {
       /* Invalidate the XID, so that subsequent calls will not find it. */
+#ifdef WITH_WSREP
+      if (!wsrep_is_wsrep_xid(trx->xid))
+      {
+#endif /* WITH_WSREP */
       trx->xid->null();
+#ifdef WITH_WSREP
+      }
+#endif /* WITH_WSREP */
       arg->trx= trx;
       found= 1;
     }


### PR DESCRIPTION
This pull request contains fixes required to make wsrep XID persisted properly in InnoDB rollback segment header. A test wsrep.wsrep-recovery was added to check that the XID is persisted properly and will be recovered properly after a crash.