### PR TITLE
MDEV-18233 Moving the hash_node_t to improve locality of reference

### DIFF
--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1443,6 +1443,9 @@ struct buf_page_t{
 					by buf_pool->mutex. */
 	ib_uint32_t	offset;		/*!< page number; also protected
 					by buf_pool->mutex. */
+	buf_page_t*	hash;		/*!< node used in chaining to
+					buf_pool->page_hash or
+					buf_pool->zip_hash */
 	/** count of how manyfold this block is currently bufferfixed */
 #ifdef PAGE_ATOMIC_REF_COUNT
 	ib_uint32_t	buf_fix_count;
@@ -1489,9 +1492,6 @@ struct buf_page_t{
 					zip.data == NULL means an active
 					buf_pool->watch */
 #ifndef UNIV_HOTBACKUP
-	buf_page_t*	hash;		/*!< node used in chaining to
-					buf_pool->page_hash or
-					buf_pool->zip_hash */
 #ifdef UNIV_DEBUG
 	ibool		in_page_hash;	/*!< TRUE if in buf_pool->page_hash */
 	ibool		in_zip_hash;	/*!< TRUE if in buf_pool->zip_hash */

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -926,8 +926,10 @@ struct dict_table_t{
 
 
 	table_id_t	id;	/*!< id of the table */
+	hash_node_t	id_hash; /*!< hash chain node */
 	mem_heap_t*	heap;	/*!< memory heap */
 	char*		name;	/*!< table name */
+	hash_node_t	name_hash; /*!< hash chain node */
 	const char*	dir_path_of_temp_table;/*!< NULL or the directory path
 				where a TEMPORARY table that was explicitly
 				created by a user should be placed if
@@ -983,8 +985,6 @@ struct dict_table_t{
 				dictionary information and
 				MySQL FRM information mismatch. */
 #ifndef UNIV_HOTBACKUP
-	hash_node_t	name_hash; /*!< hash chain node */
-	hash_node_t	id_hash; /*!< hash chain node */
 	UT_LIST_BASE_NODE_T(dict_index_t)
 			indexes; /*!< list of indexes of the table */
 

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -245,7 +245,9 @@ struct fil_node_t {
 struct fil_space_t {
 	char*		name;	/*!< space name = the path to the first file in
 				it */
+	hash_node_t	name_hash;/*!< hash chain the name_hash table */
 	ulint		id;	/*!< space id */
+	hash_node_t	hash;	/*!< hash chain node */
 	ib_int64_t	tablespace_version;
 				/*!< in DISCARD/IMPORT this timestamp
 				is used to check if we should ignore
@@ -292,8 +294,6 @@ struct fil_space_t {
 				trying to read a block.
 				Dropping of the tablespace is forbidden
 				if this is positive */
-	hash_node_t	hash;	/*!< hash chain node */
-	hash_node_t	name_hash;/*!< hash chain the name_hash table */
 #ifndef UNIV_HOTBACKUP
 	rw_lock_t	latch;	/*!< latch protecting the file space storage
 				allocation */

--- a/storage/xtradb/include/buf0buf.h
+++ b/storage/xtradb/include/buf0buf.h
@@ -1477,6 +1477,9 @@ struct buf_page_t{
 
 	ib_uint32_t	space;		/*!< tablespace id. */
 	ib_uint32_t	offset;		/*!< page number. */
+	buf_page_t*	hash;		/*!< node used in chaining to
+					buf_pool->page_hash or
+					buf_pool->zip_hash */
 	/** count of how manyfold this block is currently bufferfixed */
 #ifdef PAGE_ATOMIC_REF_COUNT
 	ib_uint32_t	buf_fix_count;
@@ -1530,9 +1533,6 @@ struct buf_page_t{
 					zip.data == NULL means an active
 					buf_pool->watch */
 #ifndef UNIV_HOTBACKUP
-	buf_page_t*	hash;		/*!< node used in chaining to
-					buf_pool->page_hash or
-					buf_pool->zip_hash */
 #ifdef UNIV_DEBUG
 	ibool		in_page_hash;	/*!< TRUE if in buf_pool->page_hash */
 	ibool		in_zip_hash;	/*!< TRUE if in buf_pool->zip_hash */

--- a/storage/xtradb/include/dict0mem.h
+++ b/storage/xtradb/include/dict0mem.h
@@ -937,8 +937,10 @@ struct dict_table_t{
 
 
 	table_id_t	id;	/*!< id of the table */
+	hash_node_t	id_hash; /*!< hash chain node */
 	mem_heap_t*	heap;	/*!< memory heap */
 	char*		name;	/*!< table name */
+	hash_node_t	name_hash; /*!< hash chain node */
 	const char*	dir_path_of_temp_table;/*!< NULL or the directory path
 				where a TEMPORARY table that was explicitly
 				created by a user should be placed if
@@ -994,8 +996,6 @@ struct dict_table_t{
 				dictionary information and
 				MySQL FRM information mismatch. */
 #ifndef UNIV_HOTBACKUP
-	hash_node_t	name_hash; /*!< hash chain node */
-	hash_node_t	id_hash; /*!< hash chain node */
 	UT_LIST_BASE_NODE_T(dict_index_t)
 			indexes; /*!< list of indexes of the table */
 

--- a/storage/xtradb/include/fil0fil.h
+++ b/storage/xtradb/include/fil0fil.h
@@ -238,7 +238,9 @@ struct fil_node_t {
 struct fil_space_t {
 	char*		name;	/*!< space name = the path to the first file in
 				it */
+	hash_node_t	name_hash;/*!< hash chain the name_hash table */
 	ulint		id;	/*!< space id */
+	hash_node_t	hash;	/*!< hash chain node */
 	ib_int64_t	tablespace_version;
 				/*!< in DISCARD/IMPORT this timestamp
 				is used to check if we should ignore
@@ -285,8 +287,6 @@ struct fil_space_t {
 				trying to read a block.
 				Dropping of the tablespace is forbidden
 				if this is positive */
-	hash_node_t	hash;	/*!< hash chain node */
-	hash_node_t	name_hash;/*!< hash chain the name_hash table */
 #ifndef UNIV_HOTBACKUP
 	prio_rw_lock_t	latch;	/*!< latch protecting the file space storage
 				allocation */


### PR DESCRIPTION
When performing a hash search via HASH_SEARCH we first look at a key of a node
and then at its pointer to the next node in chain. If we have those in one cache
line instead of a two we reduce memory reads.

I found dict_table_t, fil_space_t and buf_page_t suitable for such improvement.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.0-MDEV-18233-hash-cache)