### PR TITLE
MDEV-18176 Galera test failure on galera.galera_gtid_slave_sst_rsync

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -55,7 +55,6 @@ galera.galera_var_reject_queries : assertion in inline_mysql_socket_send
 query_cache : MDEV-18137: Galera test failure on query_cache
 galera.galera_ist_mariabackup : Leaves port open
 galera.galera_autoinc_sst_mariabackup : MDEV-18177 Galera test failure on galera_autoinc_sst_mariabackup
-galera.galera_gtid_slave_sst_rsync: MDEV-18176 Galera test failure on galera.galera_gtid_slave_sst_rsync
 galera.galera_sst_rsync2 : MDEV-18178 Galera test failure on galera_sst_rsync2
 galera.galera_kill_largechanges : MDEV-18179 Galera test failure on galera.galera_kill_largechanges
 galera.galera_concurrent_ctas : MDEV-18180 Galera test failure on galera.galera_concurrent_ctas

--- a/mysql-test/suite/galera/r/galera_gtid_slave_sst_rsync.result
+++ b/mysql-test/suite/galera/r/galera_gtid_slave_sst_rsync.result
@@ -157,6 +157,7 @@ RESET SLAVE ALL;
 set global wsrep_on=OFF;
 reset master;
 set global wsrep_on=ON;
+set global gtid_slave_pos="";
 #Connection 1
 connection node_1;
 set global wsrep_on=OFF;

--- a/mysql-test/suite/galera/t/galera_gtid_slave_sst_rsync.test
+++ b/mysql-test/suite/galera/t/galera_gtid_slave_sst_rsync.test
@@ -184,6 +184,7 @@ RESET SLAVE ALL;
 set global wsrep_on=OFF;
 reset master;
 set global wsrep_on=ON;
+set global gtid_slave_pos="";
 --echo #Connection 1
 --connection node_1
 set global wsrep_on=OFF;


### PR DESCRIPTION
If galera.galera_gtid_slave_sst_rsync is repeated more than once it will fail due incorrect GTID position. After stopping SLAVE node reset also GTID_SLAVE_POS variable.