### PR TITLE
MDEV-18124 PK on inplace-enlarged type fails

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_convert.result
+++ b/mysql-test/suite/innodb/r/instant_alter_convert.result
@@ -192,5 +192,36 @@ alter table t1 modify a varchar(25) not null;
 create or replace table t1(x int primary key, a varchar(20)) row_format=redundant;
 insert into t1 (x) values (1);
 update t1 set a= 'foo' where x = 2;
+#
+# MDEV-18124 PK on inplace-enlarged type fails
+#
+create or replace table t1 (x int, y int) row_format redundant;
+insert into t1 (x, y) values (11, 22);
+alter table t1 modify x bigint, algorithm instant;
+alter table t1 add primary key (x), algorithm inplace;
+check table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+create or replace table t1 (a varchar(10), y int) row_format redundant;
+insert into t1 (a, y) values ("0123456789", 33);
+alter table t1 modify a char(15), algorithm instant;
+alter table t1 add primary key (a), algorithm inplace;
+check table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+create or replace table t1 (x int primary key, y int) row_format redundant;
+insert into t1 (x, y) values (44, 55);
+alter table t1 modify x bigint, algorithm inplace;
+check table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+create or replace table t1 (x int primary key, y int) row_format redundant;
+insert into t1 values (66, 77);
+alter table t1 add column z int, algorithm instant;
+alter table t1 drop column y, algorithm instant;
+create or replace table t1 (x integer, a varchar(20)) row_format redundant;
+alter table t1 add index idx3 (a);
+insert into t1 (x, a) values (73, 'a');
+alter table t1 modify a char(20);
 drop database test;
 create database test;

--- a/mysql-test/suite/innodb/t/instant_alter_convert.test
+++ b/mysql-test/suite/innodb/t/instant_alter_convert.test
@@ -169,5 +169,35 @@ create or replace table t1(x int primary key, a varchar(20)) row_format=redundan
 insert into t1 (x) values (1);
 update t1 set a= 'foo' where x = 2;
 
+--echo #
+--echo # MDEV-18124 PK on inplace-enlarged type fails
+--echo #
+create or replace table t1 (x int, y int) row_format redundant;
+insert into t1 (x, y) values (11, 22);
+alter table t1 modify x bigint, algorithm instant;
+alter table t1 add primary key (x), algorithm inplace;
+check table t1;
+
+create or replace table t1 (a varchar(10), y int) row_format redundant;
+insert into t1 (a, y) values ("0123456789", 33);
+alter table t1 modify a char(15), algorithm instant;
+alter table t1 add primary key (a), algorithm inplace;
+check table t1;
+
+create or replace table t1 (x int primary key, y int) row_format redundant;
+insert into t1 (x, y) values (44, 55);
+alter table t1 modify x bigint, algorithm inplace;
+check table t1;
+
+create or replace table t1 (x int primary key, y int) row_format redundant;
+insert into t1 values (66, 77);
+alter table t1 add column z int, algorithm instant;
+alter table t1 drop column y, algorithm instant;
+
+create or replace table t1 (x integer, a varchar(20)) row_format redundant;
+alter table t1 add index idx3 (a);
+insert into t1 (x, a) values (73, 'a');
+alter table t1 modify a char(20);
+
 drop database test;
 create database test;

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -2222,6 +2222,13 @@ dict_index_too_big_for_tree(
 		}
 
 		field_max_size = dict_col_get_max_size(col);
+		if (!comp && (col->mtype == DATA_INT
+			      || col->mtype == DATA_CHAR)) {
+			/* DATA_INT and DATA_CHAR are of variable-length
+			(enlarged instantly), but are stored locally. */
+			field_ext_max_size = 0;
+			goto add_field_size;
+		}
 		field_ext_max_size = field_max_size < 256 ? 1 : 2;
 
 		if (field->prefix_len) {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9956,7 +9956,7 @@ innobase_fts_create_doc_id_key(
 	/* The unique Doc ID field should be an eight-bytes integer */
 	dict_field_t*	field = dict_index_get_nth_field(index, 0);
         ut_a(field->col->mtype == DATA_INT);
-	ut_ad(sizeof(*doc_id) == field->fixed_len);
+	ut_ad(sizeof(*doc_id) == field->col->len);
 	ut_ad(!strcmp(index->name, FTS_DOC_ID_INDEX_NAME));
 #endif /* UNIV_DEBUG */
 

--- a/storage/innobase/include/data0type.ic
+++ b/storage/innobase/include/data0type.ic
@@ -472,12 +472,18 @@ dtype_get_fixed_size_low(
 		}
 #endif /* UNIV_DEBUG */
 		/* fall through */
-	case DATA_CHAR:
 	case DATA_FIXBINARY:
-	case DATA_INT:
 	case DATA_FLOAT:
 	case DATA_DOUBLE:
 		return(len);
+	case DATA_CHAR:
+	case DATA_INT:
+		/* Treat DATA_INT and DATA_CHAR as variable length for redundant
+		row format. We can't rely on fixed_len anymore because record
+		can have shorter length from before instant enlargement
+		[MDEV-15563]. Note, that importing such tablespace to 10.3
+		produces ER_TABLE_SCHEMA_MISMATCH. */
+		return(comp ? len : 0);
 	case DATA_MYSQL:
 		if (prtype & DATA_BINARY_TYPE) {
 			return(len);
@@ -625,6 +631,9 @@ dtype_get_sql_null_size(
 	const dtype_t*	type,	/*!< in: type */
 	ulint		comp)	/*!< in: nonzero=ROW_FORMAT=COMPACT  */
 {
+	if (type->mtype == DATA_CHAR || type->mtype == DATA_INT) {
+		return(type->len);
+	}
 	return(dtype_get_fixed_size_low(type->mtype, type->prtype, type->len,
 					type->mbminlen, type->mbmaxlen, comp));
 }

--- a/storage/innobase/rem/rem0rec.cc
+++ b/storage/innobase/rem/rem0rec.cc
@@ -612,11 +612,12 @@ rec_init_offsets(
 	ulint	i	= 0;
 	ulint	offs;
 
-	ut_ad(index->n_core_null_bytes <= UT_BITS_IN_BYTES(index->n_nullable));
 	ut_d(offsets[2] = ulint(rec));
 	ut_d(offsets[3] = ulint(index));
 
 	if (dict_table_is_comp(index->table)) {
+		ut_ad(index->n_core_null_bytes
+		      <= UT_BITS_IN_BYTES(index->n_nullable));
 		const byte*	nulls;
 		const byte*	lens;
 		dict_field_t*	field;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -890,7 +890,7 @@ row_create_prebuilt(
 			ulint type = temp_index->fields[i].col->mtype;
 			if (type == DATA_INT) {
 				temp_len +=
-					temp_index->fields[i].fixed_len;
+					temp_index->fields[i].col->len;
 			}
 		}
 		srch_key_len = std::max(srch_key_len,temp_len);


### PR DESCRIPTION
Treat DATA_INT and DATA_CHAR as variable length for redundant row
format. We can't rely on fixed_len anymore because record can have
shorter length from before instant enlargement [MDEV-15563]. Note,
that importing such tablespace to 10.3 produces ER_TABLE_SCHEMA_MISMATCH.

[Fixes tempesta-tech/mariadb#568]

This code is submitted under the BSD-new license