### PR TITLE
MDEV-18177 Fixed SST processing on joiner

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -53,7 +53,6 @@ query_cache : MDEV-18137: Galera test failure on query_cache
 galera.galera_autoinc_sst_mariabackup : MDEV-18177 Galera test failure on galera_autoinc_sst_mariabackup
 galera_gcache_recover_manytrx : MDEV-15740
 galera.galera_ist_mariabackup : Leaves port open
-galera.galera_autoinc_sst_mariabackup : MDEV-18177 Galera test failure on galera_autoinc_sst_mariabackup
 galera.galera_sst_rsync2 : MDEV-18178 Galera test failure on galera_sst_rsync2
 galera.galera_kill_largechanges : MDEV-18179 Galera test failure on galera.galera_kill_largechanges
 galera.galera_concurrent_ctas : MDEV-18180 Galera test failure on galera.galera_concurrent_ctas

--- a/mysql-test/suite/galera/r/galera_autoinc_sst_mariabackup.result
+++ b/mysql-test/suite/galera/r/galera_autoinc_sst_mariabackup.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 connection node_1;
 connection node_2;
 connection node_1;

--- a/mysql-test/suite/galera/t/galera_autoinc_sst_mariabackup.cnf
+++ b/mysql-test/suite/galera/t/galera_autoinc_sst_mariabackup.cnf
@@ -5,7 +5,7 @@ wsrep_sst_method=mariabackup
 wsrep_sst_auth="root:"
 
 [mysqld.1]
-wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=1;pc.ignore_sb=true'
+wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=10M;pc.ignore_sb=true'
 
 [mysqld.2]
-wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.size=1;pc.ignore_sb=true'
+wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.size=10M;pc.ignore_sb=true'

--- a/mysql-test/suite/galera/t/galera_autoinc_sst_mariabackup.test
+++ b/mysql-test/suite/galera/t/galera_autoinc_sst_mariabackup.test
@@ -45,6 +45,8 @@ DELIMITER ;|
 --connection node_2a
 --source include/kill_galera.inc
 
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+
 --sleep 10
 --source include/start_mysqld.inc
 --sleep 25
@@ -59,7 +61,6 @@ INSERT INTO t1 VALUES (DEFAULT);
 --disable_query_log
 --eval KILL CONNECTION $connection_id
 --enable_query_log
-
 INSERT INTO t1 VALUES (DEFAULT);
 
 --connection node_1

--- a/sql/wsrep_server_service.h
+++ b/sql/wsrep_server_service.h
@@ -58,6 +58,8 @@ public:
 
   wsrep::view get_view(wsrep::client_service&, const wsrep::id& own_id);
 
+  wsrep::gtid get_position(wsrep::client_service&);
+
   void log_state_change(enum wsrep::server_state::state,
                         enum wsrep::server_state::state);
 

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -191,11 +191,10 @@ bool wsrep_before_SE()
 
 // Signal end of SST
 static void wsrep_sst_complete (THD*                thd,
-                                const wsrep::gtid&  sst_gtid,
                                 int const           rcode)
 {
   Wsrep_client_service client_service(thd, thd->wsrep_cs());
-  Wsrep_server_state::instance().sst_received(client_service, sst_gtid, rcode);
+  Wsrep_server_state::instance().sst_received(client_service, rcode);
 }
 
   /*
@@ -252,7 +251,7 @@ void wsrep_sst_received (THD*                thd,
     if (WSREP_ON)
     {
       int const rcode(seqno < 0 ? seqno : 0);
-      wsrep_sst_complete(thd, sst_gtid, rcode);
+      wsrep_sst_complete(thd,rcode);
     }
 }
 
@@ -526,7 +525,7 @@ err:
     /* Read committed isolation to avoid gap locking */
     thd->variables.tx_isolation= ISO_READ_COMMITTED;
 
-    wsrep_sst_complete (thd, ret_gtid, -err);
+    wsrep_sst_complete (thd, -err);
 
     delete thd;
     my_thread_end();

--- a/storage/innobase/trx/trx0rseg.cc
+++ b/storage/innobase/trx/trx0rseg.cc
@@ -43,6 +43,33 @@ static long long wsrep_seqno = -1;
 /** The latest known WSREP XID UUID */
 static unsigned char wsrep_uuid[16];
 
+/** Write the WSREP XID information into rollback segment header.
+@param[in,out]	rseg_header	rollback segment header
+@param[in]	xid		WSREP XID
+@param[in,out]	mtr		mini transaction */
+static void
+trx_rseg_write_wsrep_checkpoint(
+	trx_rsegf_t*	rseg_header,
+	const XID*	xid,
+	mtr_t*		mtr)
+{
+	mlog_write_ulint(TRX_RSEG_WSREP_XID_FORMAT + rseg_header,
+			 uint32_t(xid->formatID),
+			 MLOG_4BYTES, mtr);
+
+	mlog_write_ulint(TRX_RSEG_WSREP_XID_GTRID_LEN + rseg_header,
+			 uint32_t(xid->gtrid_length),
+			 MLOG_4BYTES, mtr);
+
+	mlog_write_ulint(TRX_RSEG_WSREP_XID_BQUAL_LEN + rseg_header,
+			 uint32_t(xid->bqual_length),
+			 MLOG_4BYTES, mtr);
+
+	mlog_write_string(TRX_RSEG_WSREP_XID_DATA + rseg_header,
+			  reinterpret_cast<const byte*>(xid->data),
+			  XIDDATASIZE, mtr);
+}
+
 /** Update the WSREP XID information in rollback segment header.
 @param[in,out]	rseg_header	rollback segment header
 @param[in]	xid		WSREP XID
@@ -68,22 +95,7 @@ trx_rseg_update_wsrep_checkpoint(
 	}
 	wsrep_seqno = xid_seqno;
 #endif /* UNIV_DEBUG */
-
-	mlog_write_ulint(TRX_RSEG_WSREP_XID_FORMAT + rseg_header,
-			 uint32_t(xid->formatID),
-			 MLOG_4BYTES, mtr);
-
-	mlog_write_ulint(TRX_RSEG_WSREP_XID_GTRID_LEN + rseg_header,
-			 uint32_t(xid->gtrid_length),
-			 MLOG_4BYTES, mtr);
-
-	mlog_write_ulint(TRX_RSEG_WSREP_XID_BQUAL_LEN + rseg_header,
-			 uint32_t(xid->bqual_length),
-			 MLOG_4BYTES, mtr);
-
-	mlog_write_string(TRX_RSEG_WSREP_XID_DATA + rseg_header,
-			  reinterpret_cast<const byte*>(xid->data),
-			  XIDDATASIZE, mtr);
+	trx_rseg_write_wsrep_checkpoint(rseg_header, xid, mtr);
 }
 
 /** Update WSREP checkpoint XID in first rollback segment header
@@ -98,6 +110,13 @@ void trx_rseg_update_wsrep_checkpoint(const XID* xid)
 	mtr_t	mtr;
 	mtr.start();
 
+	const byte* xid_uuid = wsrep_xid_uuid(xid);
+	/* We must make check against wsrep_uuid here, the
+	trx_rseg_update_wsrep_checkpoint() writes over wsrep_uuid with
+	xid contents in debug mode and the memcmp() will never give nonzero
+	result. */
+	const bool must_clear_rsegs = memcmp(wsrep_uuid, xid_uuid,
+					     sizeof wsrep_uuid);
 	const trx_rseg_t* rseg = trx_sys.rseg_array[0];
 
 	trx_rsegf_t* rseg_header = trx_rsegf_get(rseg->space, rseg->page_no,
@@ -108,10 +127,11 @@ void trx_rseg_update_wsrep_checkpoint(const XID* xid)
 
 	trx_rseg_update_wsrep_checkpoint(rseg_header, xid, &mtr);
 
-	const byte* xid_uuid = wsrep_xid_uuid(xid);
-	if (memcmp(wsrep_uuid, xid_uuid, sizeof wsrep_uuid)) {
+	if (must_clear_rsegs) {
+		XID null_xid;
+		memset(&null_xid, 0, sizeof null_xid);
+		null_xid.null();
 		memcpy(wsrep_uuid, xid_uuid, sizeof wsrep_uuid);
-
 		/* Because the UUID part of the WSREP XID differed
 		from current_xid_uuid, the WSREP group UUID was
 		changed, and we must reset the XID in all rollback
@@ -119,10 +139,12 @@ void trx_rseg_update_wsrep_checkpoint(const XID* xid)
 		for (ulint rseg_id = 1; rseg_id < TRX_SYS_N_RSEGS; ++rseg_id) {
 			if (const trx_rseg_t* rseg =
 			    trx_sys.rseg_array[rseg_id]) {
-				trx_rseg_update_wsrep_checkpoint(
+				trx_rseg_write_wsrep_checkpoint(
 					trx_rsegf_get(rseg->space,
-						      rseg->page_no, &mtr),
-					xid, &mtr);
+						      rseg->page_no,
+						      &mtr),
+					&null_xid,
+				        &mtr);
 			}
 		}
 	}


### PR DESCRIPTION
Wsrep lib was changed so that the sst_received() does not take GTID as argument, but rather fetches it via server_service interface after the storage has been initialized. The corresponding changes were made to Wsrep_server_service. This guarantees that the provider gets the correct start position after the storage engine recovery.

Wsrep_server_service::log_view() and trx_rseg_update_wsrep_checkpoint() were fixed to properly deal with group UUID change.

The test galera_autoinc_sst_mariabackup was fixed to work with gcache.size=10M configuration setting and recorded.