### PR TITLE
Fixup galera_sr.GCF-1051 after streaming log table renaming

### DIFF
--- a/mysql-test/suite/galera_sr/t/GCF-1051.test
+++ b/mysql-test/suite/galera_sr/t/GCF-1051.test
@@ -23,11 +23,11 @@ COMMIT;
 
 --connection node_1
 SELECT COUNT(*) = 0 FROM t1;
-SELECT COUNT(*) = 0 FROM .SR;
+SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 
 --connection node_2
 SELECT COUNT(*) = 0 FROM t1;
-SELECT COUNT(*) = 0 FROM .SR;
+SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 
 #
 # Test 2: AUTOCOMMIT OFF
@@ -41,12 +41,11 @@ COMMIT;
 
 --connection node_1
 SELECT COUNT(*) = 0 FROM t1;
-SELECT COUNT(*) = 0 FROM .SR;
+SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 
 --connection node_2
 SELECT COUNT(*) = 0 FROM t1;
-SELECT COUNT(*) = 0 FROM .SR;
+SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 
 
 DROP TABLE t1;
-


### PR DESCRIPTION
Test GCF-1051 was using wrong table name for streaming log table,
renamed to mysql.wsrep_streaming_log.