### PR TITLE
Removed THD_TRANS::rw_ha_count from wsrep patch

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1440,9 +1440,6 @@ int ha_commit_trans(THD *thd, bool all)
     thd->stmt_map.close_transient_cursors();
 
   uint rw_ha_count= ha_check_and_coalesce_trx_read_only(thd, ha_info, all);
-#ifdef WITH_WSREP
-  trans->rw_ha_count= rw_ha_count;
-#endif /* WITH_WSREP */
   /* rw_trans is TRUE when we in a transaction changing data */
   bool rw_trans= is_real_trans &&
                  (rw_ha_count > (thd->is_current_stmt_binlog_disabled()?0U:1U));
@@ -1756,9 +1753,6 @@ commit_one_phase_2(THD *thd, bool all, THD_TRANS *trans, bool is_real_trans)
     }
     trans->ha_list= 0;
     trans->no_2pc=0;
-#ifdef WITH_WSREP
-    trans->rw_ha_count= 0;
-#endif /* WITH_WSREP */
     if (all)
     {
 #ifdef HAVE_QUERY_CACHE
@@ -1870,9 +1864,6 @@ int ha_rollback_trans(THD *thd, bool all)
     }
     trans->ha_list= 0;
     trans->no_2pc=0;
-#ifdef WITH_WSREP
-    trans->rw_ha_count= 0;
-#endif /* WITH_WSREP */
   }
 
   /*
@@ -2463,9 +2454,6 @@ int ha_rollback_to_savepoint(THD *thd, SAVEPOINT *sv)
   DBUG_ENTER("ha_rollback_to_savepoint");
 
   trans->no_2pc=0;
-#ifdef WITH_WSREP
-  trans->rw_ha_count= 0;
-#endif /* WITH_WSREP */
   /*
     rolling back to savepoint in all storage engines that were part of the
     transaction when the savepoint was set

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1690,9 +1690,6 @@ struct THD_TRANS
 {
   /* true is not all entries in the ht[] support 2pc */
   bool        no_2pc;
-#ifdef WITH_WSREP
-  int         rw_ha_count;
-#endif /* WITH_WSREP */
   /* storage engines that registered in this transaction */
   Ha_trx_info *ha_list;
   /* 
@@ -1727,9 +1724,6 @@ struct THD_TRANS
 
   void reset() {
     no_2pc= FALSE;
-#ifdef WITH_WSREP
-    rw_ha_count= 0;
-#endif /* WITH_WSREP */
     modified_non_trans_table= FALSE;
     m_unsafe_rollback_flags= 0;
   }

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -54,16 +54,6 @@ Wsrep_client_service::Wsrep_client_service(THD* thd,
   , m_client_state(client_state)
 { }
 
-bool Wsrep_client_service::do_2pc() const
-{
-  DBUG_ASSERT(m_thd == current_thd);
-  THD_TRANS* trans= &m_thd->transaction.all.ha_list ?
-    &m_thd->transaction.all :
-    &m_thd->transaction.stmt;
-  return (!trans->no_2pc && trans->rw_ha_count > 1);
-
-}
-
 void Wsrep_client_service::store_globals()
 {
   DBUG_ENTER("Wsrep_client_service::store_globals");

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -36,7 +36,6 @@ class Wsrep_client_service : public wsrep::client_service
 public:
   Wsrep_client_service(THD*, Wsrep_client_state&);
 
-  bool do_2pc() const;
   bool interrupted() const;
   void reset_globals();
   void store_globals();


### PR DESCRIPTION
The THD_TRANS::rw_ha_count was originally used to decide
whether to run wsrep commit int 1PC or 2PC. However this is
not needed as the decision can be done internally in wsrep-lib.

Removed THD_TRANS::rw_ha_count and adapted to wsrep-lib change
to remove client_service::do_2pc().