### PR TITLE
Fix memleak after exit on cluster connect failure, fix galera_safe_to_bootstrap

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_safe_to_bootstrap.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_safe_to_bootstrap.result
@@ -1,23 +1,46 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
+connection node_2;
+connection node_1;
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
+connection node_3;
+connection node_1;
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 1']
+connection node_2;
+connection node_1;
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
 include/assert_grep.inc [grastate.dat does not have 'safe_to_bootstrap: 0']
+connection node_2;
+connection node_1;
 SET SESSION wsrep_on = OFF;
 Killing server ...
 safe_to_bootstrap: 1
 safe_to_bootstrap: 0
 safe_to_bootstrap: 0
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_2;
 CALL mtr.add_suppression("Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("It may not be safe to bootstrap the cluster from this node");
+CALL mtr.add_suppression("Aborting");
+connection node_3;
 CALL mtr.add_suppression("Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("It may not be safe to bootstrap the cluster from this node");
+CALL mtr.add_suppression("Aborting");
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/galera_3nodes/t/galera_safe_to_bootstrap.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_safe_to_bootstrap.test
@@ -3,6 +3,22 @@
 #
 
 --source include/galera_cluster.inc
+
+#
+# Create connection node_3 and save auto increment variables.
+#
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+--let $node_1 = node_1
+--let $node_2 = node_2
+--let $node_3 = node_3
+
+--source ../galera/include/auto_increment_offset_save.inc
+
+--connection node_1
+
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 
 #
@@ -48,7 +64,6 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 # Shut down one more node
 #
 
---connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
 --source include/shutdown_mysqld.inc
 
@@ -155,9 +170,18 @@ SET SESSION wsrep_on = OFF;
 
 --connection node_2
 CALL mtr.add_suppression("Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("It may not be safe to bootstrap the cluster from this node");
+CALL mtr.add_suppression("Aborting");
 
 --connection node_3
 CALL mtr.add_suppression("Failed to prepare for incremental state transfer");
+CALL mtr.add_suppression("It may not be safe to bootstrap the cluster from this node");
+CALL mtr.add_suppression("Aborting");
 SHOW CREATE TABLE t1;
 
 DROP TABLE t1;
+
+#
+# Restore auto increment variables.
+#
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2060,9 +2060,9 @@ extern "C" void unireg_abort(int exit_code)
     if (opt_bootstrap || wsrep_recovery)
     {
       if (wsrep_inited) wsrep_deinit(true);
-      wsrep_deinit_server();
     }
   }
+  wsrep_deinit_server();
 #endif // WITH_WSREP
 
   clean_up(!opt_abort && (exit_code || !opt_bootstrap)); /* purecov: inspected */

--- a/sql/wsrep_server_state.cc
+++ b/sql/wsrep_server_state.cc
@@ -71,7 +71,12 @@ void Wsrep_server_state::init_once(const std::string& name,
 
 void Wsrep_server_state::destroy()
 {
-  delete m_instance;
-  mysql_mutex_destroy(&LOCK_wsrep_server_state);
-  mysql_cond_destroy(&COND_wsrep_server_state);
+
+  if (m_instance)
+  {
+    delete m_instance;
+    m_instance= 0;
+    mysql_mutex_destroy(&LOCK_wsrep_server_state);
+    mysql_cond_destroy(&COND_wsrep_server_state);
+  }
 }


### PR DESCRIPTION
Made sure that the wsrep server state instance is always deleted at server shutdown if it has been allocated during server startup.

Fixed galera_safe_to_bootstrap to restore autoinc offsets after the test and recorded. The test does not report memory leaks anymore.