### PR TITLE
systemd: mariadb@bootstrap - clear ExecStartPre and ExecStartPost

### DIFF
--- a/support-files/use_galera_new_cluster.conf
+++ b/support-files/use_galera_new_cluster.conf
@@ -15,8 +15,13 @@ ConditionPathExists=
 Type=oneshot
 Restart=no
 
+# Don't install or try to prepare for galera SST.
+ExecStartPre=
+
 # Override the multi instance service for a bootstrap start instance
 ExecStart=
 ExecStart=/usr/bin/echo "Please use galera_new_cluster to start the mariadb service with --wsrep-new-cluster"
 ExecStart=/usr/bin/false
 
+# This isn't a service meant to execute anything but a message
+ExecStartPost=


### PR DESCRIPTION
This is just to make sure no ExecStartPre/Post actions from the multi-instance MariaDB service definition are executed when a user attempts to start mariadb@bootstrap.

Fixes consequence of 3723c70a3045

was originally part of #510 however is highly suitable for backport.

I submit this under the MCA.