### PR TITLE
Remove CMake SYSTEMD_EXECSTARTPRE

### DIFF
--- a/cmake/systemd.cmake
+++ b/cmake/systemd.cmake
@@ -63,7 +63,6 @@ MACRO(CHECK_SYSTEMD)
                                ${INSTALL_SYSTEMD_UNITDIR}/mariadb@.service
                                ${INSTALL_SYSTEMD_UNITDIR}/mariadb@bootstrap.service.d/use_galera_new_cluster.conf")
         IF(DEB)
-          SET(SYSTEMD_EXECSTARTPRE "ExecStartPre=/usr/bin/install -m 755 -o mysql -g root -d /var/run/mysqld")
           SET(SYSTEMD_EXECSTARTPOST "ExecStartPost=/etc/mysql/debian-start")
         ENDIF()
         MESSAGE(STATUS "Systemd features enabled")

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -61,8 +61,6 @@ ProtectHome=true
 # Execute pre and post scripts as root, otherwise it does it as User=
 PermissionsStartOnly=true
 
-@SYSTEMD_EXECSTARTPRE@
-
 # Perform automatic wsrep recovery. When server is started without wsrep,
 # galera_recovery simply returns an empty string. In any case, however,
 # the script is not expected to return with a non-zero status.


### PR DESCRIPTION
Since tmpfilesdir components where added (7bbc6c14d1), there is no longer a need for the systemd mariadb.service file to explicitly create the @MYSQL_UNIX_DIR@ directory.

I submit this under the MCA.