### PR TITLE
Fixes according to email:  Remainig items from all reviews

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5134,22 +5134,9 @@ static void innobase_kill_query(handlerton*, THD* thd, enum thd_kill_levels)
 #endif /* WITH_WSREP */
 
 	if (trx_t* trx = thd_to_trx(thd)) {
-#ifdef WITH_WSREP
-		bool locked= trx->lock.was_chosen_as_wsrep_victim;
-		if (locked) {
-			lock_mutex_exit();
-			trx_mutex_exit(trx);
-		}
-#endif /* WITH_WSREP */
 		ut_ad(trx->mysql_thd == thd);
 		/* Cancel a pending lock request if there are any */
 		lock_trx_handle_wait(trx);
-#ifdef WITH_WSREP
-		if (locked) {
-			lock_mutex_enter();
-			trx_mutex_enter(trx);
-		}
-#endif /* WITH_WSREP */
 	}
 
 	DBUG_VOID_RETURN;
@@ -18638,9 +18625,6 @@ wsrep_innobase_kill_one_trx(
 				lock_cancel_waiting_and_release(wait_lock);
 			}
 		}
-	} else {
-		/* victim was not BF aborted, after all */
-		victim_trx->lock.was_chosen_as_wsrep_victim = TRUE;
 	}
 
 	DBUG_RETURN(0);

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -6391,11 +6391,23 @@ lock_trx_handle_wait(
 /*=================*/
 	trx_t*	trx)	/*!< in/out: trx lock state */
 {
+#ifdef WITH_WSREP
+	if (!trx->lock.was_chosen_as_wsrep_victim) {
+#endif /* WITH_WSREP */
 	lock_mutex_enter();
 	trx_mutex_enter(trx);
+#ifdef WITH_WSREP
+	}
+#endif /* WITH_WSREP */
 	dberr_t err = lock_trx_handle_wait_low(trx);
+#ifdef WITH_WSREP
+	if (!trx->lock.was_chosen_as_wsrep_victim) {
+#endif /* WITH_WSREP */
 	lock_mutex_exit();
 	trx_mutex_exit(trx);
+#ifdef WITH_WSREP
+	}
+#endif /* WITH_WSREP */
 	return err;
 }
 


### PR DESCRIPTION
pushed the decision for innodb tranaction and system locking down to lock_trx_handle_wait()
level. With this, we can avoid releasing these mutexes for executions where these mutexes
were acquired upfront.

There remained old use of trx->lock.was_chosen_as_wsrep_victim in wsrep_innobase_kill_one_trx()
which is now removed as obsolete.