### PR TITLE
Fixed galera_gcache_recover_full_gcache commit error

### DIFF
--- a/mysql-test/suite/galera/t/galera_gcache_recover_full_gcache.test
+++ b/mysql-test/suite/galera/t/galera_gcache_recover_full_gcache.test
@@ -13,6 +13,14 @@ SET SESSION wsrep_sync_wait = 0;
 --source include/kill_galera.inc
 
 --connection node_1
+
+#
+# Wait until the configuration change is over in order to avoid
+# replication error due to configuration change.
+#
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
 INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));


### PR DESCRIPTION
The test failed because of error during write set replication
which was due to cluster configuration change. Worked around the
error by waiting the configuration change to happen before running
insert statements.