### PR TITLE
Support for wsrep provider-side encryption (AKA "GCache encryption")

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -3586,6 +3586,12 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
           // Start_encryption_log_event is written, enable the encryption
           if (crypto.init(sele.crypto_scheme, key_version))
             goto err;
+
+#ifdef WITH_WSREP
+          if (wsrep_set_encryption_key(crypto.key, crypto.key_length,
+                                       key_version))
+            goto err;
+#endif
         }
       }
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -692,7 +692,11 @@ int wsrep_init()
   {
     // enable normal operation in case no provider is specified
     global_system_variables.wsrep_on= 0;
-    int err= Wsrep_server_state::instance().load_provider(wsrep_provider, wsrep_provider_options ? wsrep_provider_options : "");
+    int err= Wsrep_server_state::instance().load_provider(
+      wsrep_provider,
+      wsrep_provider_options ? wsrep_provider_options : "",
+      encrypt_binlog
+    );
     if (err)
     {
       DBUG_PRINT("wsrep",("wsrep::init() failed: %d", err));
@@ -719,7 +723,8 @@ int wsrep_init()
     wsrep_data_home_dir= mysql_real_data_home;
 
   if (Wsrep_server_state::instance().load_provider(wsrep_provider,
-                                                   wsrep_provider_options))
+                                                   wsrep_provider_options,
+                                                   encrypt_binlog))
   {
     WSREP_ERROR("Failed to load provider");
     return 1;
@@ -2550,7 +2555,6 @@ bool wsrep_provider_is_SR_capable()
   return Wsrep_server_state::has_capability(wsrep::provider::capability::streaming);
 }
 
-
 int wsrep_ordered_commit_if_no_binlog(THD* thd, bool all)
 {
   if (((wsrep_thd_is_local(thd) &&
@@ -2884,6 +2888,38 @@ enum wsrep::streaming_context::fragment_unit wsrep_fragment_unit(ulong unit)
     DBUG_ASSERT(0);
     return wsrep::streaming_context::bytes;
   }
+}
+
+bool wsrep_set_encryption_key(const void* key, size_t size, unsigned int version)
+{
+    std::vector<unsigned char> input;
+    wsrep_key_serialize(input, key, size, version);
+    return Wsrep_server_state::instance().set_encryption_key(input);
+}
+
+static const unsigned int key_version_preamble_size = 8;
+
+void wsrep_key_serialize(std::vector<unsigned char>& input, const void* key,
+                         size_t size, unsigned int version)
+{
+  input.resize(key_version_preamble_size + size);
+  memcpy(input.data(), (void *)&version, sizeof(version));
+  memcpy(input.data() + key_version_preamble_size, key, size);
+}
+
+bool wsrep_key_deserialize(const void* input, const size_t& input_size,
+                           const void*& key_ptr, size_t& size,
+                           unsigned int& version)
+{
+  bool ret= true;
+  if(input_size >= key_version_preamble_size)
+  {
+    memcpy(&version, input, sizeof(version));
+    key_ptr= static_cast<const char*>(input) + key_version_preamble_size;
+    size= input_size - key_version_preamble_size;
+    ret= false;
+  }
+  return ret;
 }
 
 /***** callbacks for wsrep service ************/

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -478,6 +478,26 @@ void wsrep_deinit_server();
  */
 enum wsrep::streaming_context::fragment_unit wsrep_fragment_unit(ulong unit);
 
+/*
+ * Set encryption key. Serialize it and send to provider.
+ */
+bool wsrep_set_encryption_key(const void* key, size_t size,
+                              unsigned int version);
+
+/*
+ * Serialize key_version and key into buffer
+ */
+void wsrep_key_serialize(std::vector<unsigned char>& input,
+                         const void* key, size_t size,
+                         unsigned int version);
+
+/*
+ * De-serialize buffer into key_version, key_size & key_ptr
+ */
+bool wsrep_key_deserialize(const void* input, const size_t& input_size,
+                           const void*& key_ptr, size_t& size,
+                           unsigned int& version);
+
 #else /* !WITH_WSREP */
 
 /* These macros are needed to compile MariaDB without WSREP support

--- a/sql/wsrep_server_service.h
+++ b/sql/wsrep_server_service.h
@@ -73,9 +73,17 @@ public:
   int wait_committing_transactions(int);
 
   void debug_sync(const char*);
+
+  int do_crypt(void**                ctx,
+               wsrep::const_buffer&  key,
+               const char            (*iv)[32],
+               wsrep::const_buffer&  input,
+               void*                 output,
+               bool                  encrypt,
+               bool                  last);
+
 private:
   Wsrep_server_state& m_server_state;
 };
-
 
 #endif /* WSREP_SERVER_SERVICE */


### PR DESCRIPTION
This PR provides facilities for wsrep provider to use encryption for its files.
* Setting encryption key to provider on key change
* Implementation of do_crypt callback function used for encryption / decryption
* wsrep-lib update
