### PR TITLE
Fix MTR test wsrep_info.plugin

### DIFF
--- a/plugin/wsrep_info/mysql-test/wsrep_info/my.cnf
+++ b/plugin/wsrep_info/mysql-test/wsrep_info/my.cnf
@@ -2,17 +2,17 @@
 !include include/default_mysqld.cnf
 
 [mysqld]
-wsrep-on=1
 binlog-format=row
 innodb-autoinc-lock-mode=2
 innodb-locks-unsafe-for-binlog=1
-wsrep-cluster-address=gcomm://
 wsrep_provider=@ENV.WSREP_PROVIDER
 
 [mysqld.1]
 #galera_port=@OPT.port
 #ist_port=@OPT.port
 #sst_port=@OPT.port
+wsrep-on=1
+wsrep-cluster-address=gcomm://
 wsrep_provider_options='base_port=@mysqld.1.#galera_port'
 wsrep_sst_receive_address='127.0.0.1:@mysqld.1.#sst_port'
 wsrep_node_name=test-node-1
@@ -21,6 +21,7 @@ wsrep_node_name=test-node-1
 #galera_port=@OPT.port
 #ist_port=@OPT.port
 #sst_port=@OPT.port
+wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
 wsrep_provider_options='base_port=@mysqld.2.#galera_port'
 wsrep_sst_receive_address='127.0.0.1:@mysqld.2.#sst_port'


### PR DESCRIPTION
In the config file, options `wsrep-on` and `wsrep-cluster-address`
must be listed under each specific [mysqld.x] section.
Otherwise `mysql-test-run.pl` does not identify that the test has
wsrep-on, and when starting servers, it won't wait for the servers
to be ready.