### PR TITLE
Fixes for streaming applier recovery

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_sr_cc_slave.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_cc_slave.result
@@ -1,6 +1,10 @@
+connection node_2;
+connection node_1;
+connection node_2;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) = 0
 1
+connection node_1;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) = 0
 1
@@ -16,10 +20,15 @@ INSERT INTO t1 VALUES (5);
 SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) > 0
 1
+connection node_2;
 SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) > 0
 1
+connection node_2;
 SET GLOBAL wsrep_cluster_address = '';
+SET SESSION wsrep_sync_wait = 0;
+SET SESSION wsrep_sync_wait = default;
+connection node_1;
 INSERT INTO t1 VALUES (6);
 INSERT INTO t1 VALUES (7);
 INSERT INTO t1 VALUES (8);
@@ -28,9 +37,11 @@ INSERT INTO t1 VALUES (10);
 SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) > 0
 1
+connection node_2;
 SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) > 0
 1
+connection node_1;
 INSERT INTO t1 VALUES (11);
 INSERT INTO t1 VALUES (12);
 INSERT INTO t1 VALUES (13);
@@ -40,7 +51,9 @@ COMMIT;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) = 0
 1
+connection node_2;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) = 0
 1
 DROP TABLE t1;
+CALL mtr.add_suppression("points to own listening address, blacklisting");

--- a/mysql-test/suite/galera_sr/t/galera_sr_cc_slave.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_cc_slave.test
@@ -38,9 +38,19 @@ SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
 --connection node_2
 --let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
 SET GLOBAL wsrep_cluster_address = '';
---sleep 2
+
+# Wait until the node_2 disconnects from the cluster
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Disconnected' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status'
+--source include/wait_condition.inc
+SET SESSION wsrep_sync_wait = default;
 
 --connection node_1
+
+# Wait until the node_1 sees the cluster configuration change
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
 # Continue generating events in the transaction 
 
 INSERT INTO t1 VALUES (6);
@@ -55,9 +65,8 @@ SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
 
 --connection node_2
 --disable_query_log
---eval SET GLOBAL wsrep_cluster_address='gcomm://127.0.0.1:$NODE_GALERAPORT_1';
+--eval SET GLOBAL wsrep_cluster_address='$wsrep_cluster_address_orig';
 --enable_query_log
---sleep 2
 --source include/galera_wait_ready.inc
 
 # Confirm that the SR table still contains entries from ongoing transaction
@@ -84,3 +93,5 @@ SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 
 DROP TABLE t1;
+
+CALL mtr.add_suppression("points to own listening address, blacklisting");

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -219,6 +219,11 @@ int Wsrep_high_priority_service::append_fragment_and_commit(
 {
   DBUG_ENTER("Wsrep_high_priority_service::append_fragment_and_commit");
   int ret= start_transaction(ws_handle, ws_meta);
+  /*
+    Start transaction explicitly to avoid early commit via
+    trans_commit_stmt() in append_fragment()
+  */
+  ret= ret || trans_begin(m_thd);
   ret= ret || wsrep_schema->append_fragment(m_thd,
                                             ws_meta.server_id(),
                                             ws_meta.transaction_id(),

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -176,6 +176,9 @@ bool wsrep_before_SE(); // initialize wsrep before storage
  * @param before wsrep_before_SE() value */
 void wsrep_init_startup(bool before);
 
+/* Recover streaming transactions from fragment storage */
+void wsrep_recover_sr_from_storage(THD *);
+
 // Other wsrep global variables
 extern my_bool     wsrep_inited; // whether wsrep is initialized ?
 

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -329,7 +329,6 @@ static int update_or_insert(TABLE* table) {
                   table->s->db.str,
                   table->s->table_name.str,
                   error);
-      table->file->print_error(error, MYF(0));
       ret= 1;
     }
   }
@@ -344,7 +343,6 @@ static int update_or_insert(TABLE* table) {
                   table->s->db.str,
                   table->s->table_name.str,
                   error);
-      table->file->print_error(error, MYF(0));
       ret= 1;
     }
   }
@@ -374,7 +372,6 @@ static int insert(TABLE* table) {
                 table->s->db.str,
                 table->s->table_name.str,
                 error);
-    table->file->print_error(error, MYF(0));
     ret= 1;
   }
 
@@ -395,7 +392,6 @@ static int delete_row(TABLE* table) {
                 table->s->db.str,
                 table->s->table_name.str,
                 error);
-    table->file->print_error(error, MYF(0));
     return 1;
   }
   return 0;
@@ -941,7 +937,6 @@ int Wsrep_schema::update_fragment_meta(THD* thd,
                  frag_table->s->table_name.str,
                  error);
     }
-    frag_table->file->print_error(error, MYF(0));
     Wsrep_schema_impl::finish_stmt(thd);
     DBUG_RETURN(1);
   }
@@ -957,7 +952,6 @@ int Wsrep_schema::update_fragment_meta(THD* thd,
                 frag_table->s->db.str,
                 frag_table->s->table_name.str,
                 error);
-    frag_table->file->print_error(error, MYF(0));
     Wsrep_schema_impl::finish_stmt(thd);
     DBUG_RETURN(1);
   }
@@ -1008,7 +1002,6 @@ static int remove_fragment(THD*                  thd,
                  seqno.get(),
                  error);
     }
-    frag_table->file->print_error(error, MYF(0));
     ret= error;
   }
   else if (Wsrep_schema_impl::delete_row(frag_table))
@@ -1135,7 +1128,8 @@ int Wsrep_schema::replay_transaction(THD* thd,
                                                       key_map);
     if (error)
     {
-      frag_table->file->print_error(error, MYF(0));
+      WSREP_WARN("Failed to init streaming log table for index scan: %d",
+                 error);
       Wsrep_schema_impl::end_index_scan(frag_table);
       ret= 1;
       break;
@@ -1171,7 +1165,8 @@ int Wsrep_schema::replay_transaction(THD* thd,
                                                   key_map);
     if (error)
     {
-      frag_table->file->print_error(error, MYF(0));
+      WSREP_WARN("Failed to init streaming log table for index scan: %d",
+                 error);
       Wsrep_schema_impl::end_index_scan(frag_table);
       ret= 1;
       break;
@@ -1180,7 +1175,7 @@ int Wsrep_schema::replay_transaction(THD* thd,
     error= Wsrep_schema_impl::delete_row(frag_table);
     if (error)
     {
-      frag_table->file->print_error(error, MYF(0));
+      WSREP_WARN("Could not delete row from streaming log table: %d", error);
       Wsrep_schema_impl::end_index_scan(frag_table);
       ret= 1;
       break;

--- a/sql/wsrep_schema.h
+++ b/sql/wsrep_schema.h
@@ -141,9 +141,11 @@ class Wsrep_schema
      This method should be called after storage enignes are initialized.
      It will scan SR table and replay found streaming transactions.
 
+     @param orig_thd The THD object of the calling thread.
+
      @return Zero on success, non-zero on failure.
   */
-  int recover_sr_transactions();
+  int recover_sr_transactions(THD* orig_thd);
 
   /*
     Close wsrep schema.

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -227,6 +227,20 @@ void Wsrep_server_service::log_view(
   }
 }
 
+void Wsrep_server_service::recover_streaming_appliers(wsrep::client_service& cs)
+{
+  Wsrep_client_service& client_service= static_cast<Wsrep_client_service&>(cs);
+  wsrep_recover_sr_from_storage(client_service.m_thd);
+}
+
+void Wsrep_server_service::recover_streaming_appliers(
+  wsrep::high_priority_service& hs)
+{
+  Wsrep_high_priority_service& high_priority_service=
+    static_cast<Wsrep_high_priority_service&>(hs);
+  wsrep_recover_sr_from_storage(high_priority_service.m_thd);
+}
+
 wsrep::view Wsrep_server_service::get_view(wsrep::client_service& c,
                                            const wsrep::id& own_id)
 {

--- a/sql/wsrep_server_service.h
+++ b/sql/wsrep_server_service.h
@@ -56,6 +56,8 @@ public:
 
   void log_view(wsrep::high_priority_service*, const wsrep::view&);
 
+  void recover_streaming_appliers(wsrep::client_service&);
+  void recover_streaming_appliers(wsrep::high_priority_service&);
   wsrep::view get_view(wsrep::client_service&, const wsrep::id& own_id);
 
   wsrep::gtid get_position(wsrep::client_service&);


### PR DESCRIPTION
This pull request concerns the recovery of streaming appliers which are required to apply fragments received from the group. Without this patch the streaming appliers are not restored in all cases when the server leaves and joins the cluster, which may cause inconsistencies if streaming replication is used.

The only change outside streaming replication context is a change to wsrep_schema object deallocation, which is now done when the server exits.