### PR TITLE
MDEV-18326 Refactor some ALTER column operations to use innobase_instant_try()

### DIFF
--- a/mysql-test/suite/innodb/t/innodb-index.test
+++ b/mysql-test/suite/innodb/t/innodb-index.test
@@ -1183,12 +1183,3 @@ call mtr.add_suppression("Plugin 'InnoDB' init function returned error");
 call mtr.add_suppression("Plugin 'InnoDB' registration as a STORAGE ENGINE failed");
 
 --enable_query_log
-
-
-# test instant varchar enlarge
-# LEN must increase here
-create table t (a varchar(100)) engine=innodb;
-select name, pos, mtype, prtype, len from information_schema.innodb_sys_columns where name='a';
-alter table t modify a varchar(110), algorithm=instant;
-select name, pos, mtype, prtype, len from information_schema.innodb_sys_columns where name='a';
-drop table t;

--- a/mysql-test/suite/innodb/t/innodb-index.test
+++ b/mysql-test/suite/innodb/t/innodb-index.test
@@ -1183,3 +1183,12 @@ call mtr.add_suppression("Plugin 'InnoDB' init function returned error");
 call mtr.add_suppression("Plugin 'InnoDB' registration as a STORAGE ENGINE failed");
 
 --enable_query_log
+
+
+# test instant varchar enlarge
+# LEN must increase here
+create table t (a varchar(100)) engine=innodb;
+select name, pos, mtype, prtype, len from information_schema.innodb_sys_columns where name='a';
+alter table t modify a varchar(110), algorithm=instant;
+select name, pos, mtype, prtype, len from information_schema.innodb_sys_columns where name='a';
+drop table t;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -5584,7 +5584,8 @@ static bool innobase_instant_try(
 				      || i < ctx->first_alter_pos - 1);
 		DBUG_ASSERT(!old || col->same_format(*old));
 		if (update
-		    && old->prtype == d->type.prtype) {
+		    && old->prtype == d->type.prtype
+		    && old->len == d->type.len) {
 			/* The record is already present in SYS_COLUMNS. */
 		} else if (innodb_insert_sys_columns(user_table->id, i,
 						     (*af)->field_name.str,

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -2120,11 +2120,9 @@ ha_innobase::check_if_supported_inplace_alter(
 	cf_it.rewind();
 	Field **af = altered_table->field;
 	bool fts_need_rebuild = false;
-	need_rebuild
-	    = need_rebuild
-	      || innobase_need_rebuild(ha_alter_info, table,
-				       !m_prebuilt->table->supports_instant()
-					   || m_prebuilt->table->fts);
+	need_rebuild = need_rebuild
+		       || innobase_need_rebuild(ha_alter_info, table,
+						m_prebuilt->table->fts);
 
 	while (Create_field* cf = cf_it++) {
 		DBUG_ASSERT(cf->field

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -2121,7 +2121,7 @@ ha_innobase::check_if_supported_inplace_alter(
 	Field **af = altered_table->field;
 	bool fts_need_rebuild = false;
 	need_rebuild = need_rebuild
-		       || innobase_need_rebuild(ha_alter_info, table);
+		|| innobase_need_rebuild(ha_alter_info, table);
 
 	while (Create_field* cf = cf_it++) {
 		DBUG_ASSERT(cf->field

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -2121,7 +2121,7 @@ ha_innobase::check_if_supported_inplace_alter(
 	Field **af = altered_table->field;
 	bool fts_need_rebuild = false;
 	need_rebuild = need_rebuild
-		|| innobase_need_rebuild(ha_alter_info, table);
+		|| innobase_need_rebuild(ha_alter_info, table, true);
 
 	while (Create_field* cf = cf_it++) {
 		DBUG_ASSERT(cf->field

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -2120,9 +2120,11 @@ ha_innobase::check_if_supported_inplace_alter(
 	cf_it.rewind();
 	Field **af = altered_table->field;
 	bool fts_need_rebuild = false;
-	need_rebuild = need_rebuild
-		|| innobase_need_rebuild(ha_alter_info, table,
-					 !m_prebuilt->table->supports_instant());
+	need_rebuild
+	    = need_rebuild
+	      || innobase_need_rebuild(ha_alter_info, table,
+				       !m_prebuilt->table->supports_instant()
+					   || m_prebuilt->table->fts);
 
 	while (Create_field* cf = cf_it++) {
 		DBUG_ASSERT(cf->field
@@ -7937,7 +7939,7 @@ err_exit:
 		*ha_alter_info->create_info->option_struct;
 
 	alter_table_operations options = INNOBASE_ALTER_DATA;
-	if (m_prebuilt->table->supports_instant()) {
+	if (m_prebuilt->table->supports_instant() && !m_prebuilt->table->fts) {
 		options |= ALTER_COLUMN_EQUAL_PACK_LENGTH;
 		options |= ALTER_COLUMN_UNVERSIONED;
 	}

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -2121,8 +2121,7 @@ ha_innobase::check_if_supported_inplace_alter(
 	Field **af = altered_table->field;
 	bool fts_need_rebuild = false;
 	need_rebuild = need_rebuild
-		       || innobase_need_rebuild(ha_alter_info, table,
-						m_prebuilt->table->fts);
+		       || innobase_need_rebuild(ha_alter_info, table);
 
 	while (Create_field* cf = cf_it++) {
 		DBUG_ASSERT(cf->field


### PR DESCRIPTION
Those operations are ALTER_COLUMN_UNVERSIONED and ALTER_COLUMN_EQUAL_PACK_LENGTH

They're only INSTANT and affecting SYS_COLUMNS only.

innobase_rename_or_enlarge_columns_cache(): rename to innobase_rename_columns_cache()

innobase_enlarge_column_try():
innobase_enlarge_columns_try():
vers_change_field_try():
vers_change_fields_try():
vers_change_fields_cache():
  remove and replace with innobase_instant_try()

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.4-MDEV-18326-refactor-instant)