### PR TITLE
MDEV-16509 better performance when log_bin is enabled

### DIFF
--- a/sql/log.h
+++ b/sql/log.h
@@ -1168,6 +1168,14 @@ static inline TC_LOG *get_tc_log_implementation()
     return &tc_log_dummy;
   if (opt_bin_log)
     return &mysql_bin_log;
+#ifdef WITH_WSREP
+  if (wsrep_emulate_bin_log)
+  {
+    WSREP_DEBUG("Using tc_log_dummy due to binlog emulation, 2pc handlers %d",
+                total_ha_2pc);
+    return &tc_log_dummy;
+  }
+#endif /* WITH_WSREP */
   return &tc_log_mmap;
 }
 

--- a/sql/log.h
+++ b/sql/log.h
@@ -110,6 +110,10 @@ public:
   int log_and_order(THD *thd, my_xid xid, bool all,
                     bool need_prepare_ordered, bool need_commit_ordered)
   {
+#ifdef WITH_WSREP
+    /* when binlogging is disabled, we use TC_LOG_DUMMY in 2pc */
+    if (!wsrep_emulate_bin_log)
+#endif /* WITH_WSREP */
     DBUG_ASSERT(0);
     return 1;
   }


### PR DESCRIPTION
This patch is supposed to gain better transaction throughput for
execution where log_bin is not set (i.e no binlogging)
Affected bugs are MDEV-16509 and MDEV-14339

The actual fix, will change to use tc_log_dummy (instead of tc_log_mmap),
when log_bin is not set. The old version used tc_log_mmap, which may cause
additional disk IO for mmap, and for some platforms, that may have caused
performance degration.

But this is speculation still, this branch can be used for benchmarking and
finding out if using tc_log_dummy would cause other problems.