### PR TITLE
MDEV-18057 Assertion `(node->state == 5) || (node->state == 6)' failed in row_upd_sec_step upon DELETE after UPDATE failed due to FK violation

### DIFF
--- a/mysql-test/suite/versioning/r/foreign.result
+++ b/mysql-test/suite/versioning/r/foreign.result
@@ -290,3 +290,12 @@ select count(*) from subchild;
 count(*)
 0
 drop table subchild, child, parent;
+CREATE TABLE t1 (f1 INT, KEY(f1)) ENGINE=InnoDB;
+CREATE TABLE t2 (f2 INT, FOREIGN KEY (f2) REFERENCES t1 (f1)) ENGINE=InnoDB WITH SYSTEM VERSIONING;
+SET FOREIGN_KEY_CHECKS= OFF;
+INSERT IGNORE INTO t2 VALUES (1);
+SET FOREIGN_KEY_CHECKS= ON;
+UPDATE t2 SET f2= 2;
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`f2`) REFERENCES `t1` (`f1`))
+DELETE FROM t2;
+DROP TABLE t2, t1;

--- a/mysql-test/suite/versioning/t/foreign.test
+++ b/mysql-test/suite/versioning/t/foreign.test
@@ -317,4 +317,18 @@ select count(*) from subchild;
 drop table subchild, child, parent;
 
 
+CREATE TABLE t1 (f1 INT, KEY(f1)) ENGINE=InnoDB;
+CREATE TABLE t2 (f2 INT, FOREIGN KEY (f2) REFERENCES t1 (f1)) ENGINE=InnoDB WITH SYSTEM VERSIONING;
+
+SET FOREIGN_KEY_CHECKS= OFF;
+INSERT IGNORE INTO t2 VALUES (1);
+
+SET FOREIGN_KEY_CHECKS= ON;
+--error ER_NO_REFERENCED_ROW_2
+UPDATE t2 SET f2= 2;
+DELETE FROM t2;
+
+DROP TABLE t2, t1;
+
+
 --source suite/versioning/common_finish.inc

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -3193,6 +3193,7 @@ row_upd_clust_step(
 
 	if (node->cmpl_info & UPD_NODE_NO_ORD_CHANGE) {
 
+		node->index = NULL;
 		err = row_upd_clust_rec(
 			flags, node, index, offsets, &heap, thr, &mtr);
 		goto exit_func;


### PR DESCRIPTION
The idea of the fix: reset state from previous query.

row_upd_clust_step(): reset cached index before updating a clustered index

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.3-MDEV-18057-versioning-foreign-crash)