### PR TITLE
Fix for galera_3nodes galera_ipv6_mysqldump and galera_ipv6_mariabackup

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_ipv6_mariabackup.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_ipv6_mariabackup.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 SELECT VARIABLE_VALUE LIKE '%[::1]%' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_incoming_addresses';
 VARIABLE_VALUE LIKE '%[::1]%'
 1
@@ -19,4 +21,4 @@ connection node_1;
 include/assert_grep.inc [Streaming the backup to joiner at \[::1\]]
 include/assert_grep.inc [async IST sender starting to serve tcp://\[::1\]:]
 include/assert_grep.inc [IST receiver addr using tcp://\[::1\]]
-include/assert_grep.inc [Prepared IST receiver, listening at: tcp://\[::1\]]
+include/assert_grep.inc [Prepared IST receiver for 3-6, listening at: tcp://\[::1\]]

--- a/mysql-test/suite/galera_3nodes/r/galera_ipv6_mysqldump.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_ipv6_mysqldump.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 call mtr.add_suppression("WSREP: wsrep_sst_method is set to 'mysqldump' yet mysqld bind_address is set to'");
 call mtr.add_suppression("Failed to load slave replication state from table mysql.gtid_slave_pos");
 connection node_1;
@@ -33,5 +35,6 @@ CALL mtr.add_suppression("Can't open and lock time zone table");
 CALL mtr.add_suppression("Can't open and lock privilege tables");
 CALL mtr.add_suppression("Info table is not ready to be used");
 CALL mtr.add_suppression("Native table .* has the wrong structure");
+CALL mtr.add_suppression("Table \'mysql.gtid_slave_pos\' doesn\'t exist");
 connection node_2;
 CALL mtr.add_suppression("Unsupported protocol downgrade: incremental data collection disabled. Expect abort");

--- a/mysql-test/suite/galera_3nodes/t/galera_ipv6_mariabackup.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_ipv6_mariabackup.cnf
@@ -10,18 +10,23 @@ wsrep-cluster-address=gcomm://
 wsrep_provider_options='base_host=[::1];base_port=@mysqld.1.#galera_port;gmcast.listen_addr=tcp://[::]:@mysqld.1.#galera_port;ist.recv_addr=[::1]:@mysqld.1.#ist_port'
 wsrep_sst_receive_address='[::1]:@mysqld.1.#sst_port'
 wsrep_node_incoming_address='[::1]:@mysqld.1.port'
+wsrep_node_name=node_1
 
 [mysqld.2]
 wsrep_cluster_address='gcomm://[::1]:@mysqld.1.#galera_port'
 wsrep_provider_options='base_host=[::1];base_port=@mysqld.2.#galera_port;gmcast.listen_addr=tcp://[::]:@mysqld.2.#galera_port;ist.recv_addr=[::1]:@mysqld.2.#ist_port'
 wsrep_sst_receive_address='[::1]:@mysqld.2.#sst_port'
 wsrep_node_incoming_address='[::1]:@mysqld.2.port'
+wsrep_node_name=node_2
+wsrep_sst_donor=node_1
 
 [mysqld.3]
 wsrep_cluster_address='gcomm://[::1]:@mysqld.1.#galera_port'
 wsrep_provider_options='base_host=[::1];base_port=@mysqld.3.#galera_port;gmcast.listen_addr=tcp://[::]:@mysqld.3.#galera_port;ist.recv_addr=[::1]:@mysqld.3.#ist_port'
 wsrep_sst_receive_address='[::1]:@mysqld.3.#sst_port'
 wsrep_node_incoming_address='[::1]:@mysqld.3.port'
+wsrep_node_name=node_3
+wsrep_sst_donor=node_1
 
 [SST]
 transferfmt=@ENV.MTR_GALERA_TFMT

--- a/mysql-test/suite/galera_3nodes/t/galera_ipv6_mariabackup.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_ipv6_mariabackup.test
@@ -1,5 +1,5 @@
 --source include/galera_cluster.inc
---source include/have_ipv6.inc
+--source include/check_ipv6.inc
 --source include/have_mariabackup.inc
 
 # Confirm that initial handshake happened over ipv6
@@ -38,22 +38,31 @@ DROP TABLE t1;
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_only_after = CURRENT_TEST
 
+# The SSTs happen when nodes are started first time
 --let $assert_count = 2
 --let $assert_text = Streaming the backup to joiner at \[::1\]
 --let $assert_select = Streaming the backup to joiner at \[::1\]
 --source include/assert_grep.inc
 
---let $assert_count = 1
+# There will be 3 ISTs donated from node_1 in Galera 4.
+# Two first happen at the initial startup to populate the certification
+# index. The third one is from the IST which happens during the actual test.
+--let $assert_count = 3
 --let $assert_text = async IST sender starting to serve tcp://\[::1\]:
 --let $assert_select = async IST sender starting to serve tcp://\[::1\]:
 --source include/assert_grep.inc
 
 --let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
 
+# There are two ISTs on joiner, the first at the initial startup, the second
+# during the actual test.
+--let $assert_count = 2
 --let $assert_text = IST receiver addr using tcp://\[::1\]
 --let $assert_select = IST receiver addr using tcp://\[::1\]
 --source include/assert_grep.inc
 
---let $assert_text = Prepared IST receiver, listening at: tcp://\[::1\]
---let $assert_select = Prepared IST receiver, listening at: tcp://\[::1\]
+# The receiver expects seqnos 3-6 only once.
+--let $assert_count = 1
+--let $assert_text = Prepared IST receiver for 3-6, listening at: tcp://\[::1\]
+--let $assert_select = Prepared IST receiver for 3-6, listening at: tcp://\[::1\]
 --source include/assert_grep.inc

--- a/mysql-test/suite/galera_3nodes/t/galera_ipv6_mysqldump.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_ipv6_mysqldump.test
@@ -1,13 +1,6 @@
 --source include/galera_cluster.inc
 --source include/check_ipv6.inc
 
---connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
- # Save original auto_increment_offset values.
- --let $node_1=node_1
- --let $node_2=node_2
- --let $node_3=node_3
- --source ../galera/include/auto_increment_offset_save.inc
-
 call mtr.add_suppression("WSREP: wsrep_sst_method is set to 'mysqldump' yet mysqld bind_address is set to'");
 call mtr.add_suppression("Failed to load slave replication state from table mysql.gtid_slave_pos");
 


### PR DESCRIPTION
Fixed tests which started failing after merge from 10.3.

Asserts in galera_ipv6_mariabackup needed to be changed to match Galera 4 behavior. In Galera 4 the IST happens on every cluster configuration change to populate certification index and replay configuration change history on joiner. Also made galera_ipv6_mariabackup more deterministic in donor selection.

Removed extra connection to node_3 from galera_ipv6_mysqldump which was likely a merge error.

Wsrep-lib was updated to be more allowing for compiler warnings by default, -Werror is now enabled only if WSREP_LIB_MAINTAINER_MODE is explicitly passed in cmake options.