### PR TITLE
fix galera_recover with fs.protected_regular enabled

### DIFF
--- a/scripts/galera_recovery.sh
+++ b/scripts/galera_recovery.sh
@@ -101,8 +101,7 @@ wsrep_recover_position() {
 
 # Safety checks
 if [ -n "$log_file" -a -f "$log_file" ]; then
-  [ "$euid" = "0" ] && chown $user $log_file
-      chmod 600 $log_file
+  chmod 600 $log_file
 else
   log "WSREP: mktemp failed"
 fi


### PR DESCRIPTION
The fs.protected_regular sysctls was added in Linux 4.19 to make some
data spoofing attacks harder. With systemd v241 these will be enabled
by default.

With this protection enabled galera_recovery fails with EPERM
(permission denied). This is caused by a wrong security measure:
The script changes ownership of $log_file to $user, though $user never
touches it. The shell redirection writes output to the file, not mysqld.
So just drop chown to fix this.