### PR TITLE
MDEV-18214 remove some duplicated MONITOR counters

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_skip_innodb_is_tables.result
+++ b/mysql-test/suite/innodb/r/innodb_skip_innodb_is_tables.result
@@ -193,9 +193,9 @@ log_lsn_checkpoint_age	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL
 log_lsn_buf_pool_oldest	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	value	The oldest modified block LSN in the buffer pool
 log_max_modified_age_async	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	value	Maximum LSN difference; when exceeded, start asynchronous preflush
 log_max_modified_age_sync	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	value	Maximum LSN difference; when exceeded, start synchronous preflush
-log_pending_log_writes	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	counter	Pending log writes
-log_pending_checkpoint_writes	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	counter	Pending checkpoints
-log_num_log_io	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	counter	Number of log I/Os
+log_pending_log_writes	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	value	Pending log writes
+log_pending_checkpoint_writes	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	value	Pending checkpoints
+log_num_log_io	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	value	Number of log I/Os
 log_waits	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	status_counter	Number of log waits due to small log buffer (innodb_log_waits)
 log_write_requests	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	status_counter	Number of log write requests (innodb_log_write_requests)
 log_writes	recovery	0	NULL	NULL	NULL	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	disabled	status_counter	Number of log writes (innodb_log_writes)

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1197,7 +1197,6 @@ log_io_complete(
 
 	group->n_pending_writes--;
 	log_sys->n_pending_writes--;
-	MONITOR_DEC(MONITOR_PENDING_LOG_WRITE);
 
 	unlock = log_group_check_flush_completion(group);
 	unlock = unlock | log_sys_check_flush_completion();
@@ -1245,8 +1244,6 @@ log_group_file_header_flush(
 #endif /* UNIV_DEBUG */
 	if (log_do_write) {
 		log_sys->n_log_ios++;
-
-		MONITOR_INC(MONITOR_LOG_IO);
 
 		srv_stats.os_log_pending_writes.inc();
 
@@ -1372,8 +1369,6 @@ loop:
 
 	if (log_do_write) {
 		log_sys->n_log_ios++;
-
-		MONITOR_INC(MONITOR_LOG_IO);
 
 		srv_stats.os_log_pending_writes.inc();
 
@@ -1514,7 +1509,6 @@ loop:
 	}
 #endif /* UNIV_DEBUG */
 	log_sys->n_pending_writes++;
-	MONITOR_INC(MONITOR_PENDING_LOG_WRITE);
 
 	group = UT_LIST_GET_FIRST(log_sys->log_groups);
 	group->n_pending_writes++;	/*!< We assume here that we have only
@@ -1604,7 +1598,6 @@ loop:
 
 	group->n_pending_writes--;
 	log_sys->n_pending_writes--;
-	MONITOR_DEC(MONITOR_PENDING_LOG_WRITE);
 
 	unlock = log_group_check_flush_completion(group);
 	unlock = unlock | log_sys_check_flush_completion();
@@ -1788,7 +1781,6 @@ log_io_complete_checkpoint(void)
 	ut_ad(log_sys->n_pending_checkpoint_writes > 0);
 
 	log_sys->n_pending_checkpoint_writes--;
-	MONITOR_DEC(MONITOR_PENDING_CHECKPOINT_WRITE);
 
 	if (log_sys->n_pending_checkpoint_writes == 0) {
 		log_complete_checkpoint();
@@ -1936,11 +1928,8 @@ log_group_checkpoint(
 		}
 
 		log_sys->n_pending_checkpoint_writes++;
-		MONITOR_INC(MONITOR_PENDING_CHECKPOINT_WRITE);
 
 		log_sys->n_log_ios++;
-
-		MONITOR_INC(MONITOR_LOG_IO);
 
 		/* We send as the last parameter the group machine address
 		added with 1, as we want to distinguish between a normal log
@@ -2027,8 +2016,6 @@ log_group_read_checkpoint_info(
 	ut_ad(mutex_own(&(log_sys->mutex)));
 
 	log_sys->n_log_ios++;
-
-	MONITOR_INC(MONITOR_LOG_IO);
 
 	fil_io(OS_FILE_READ | OS_FILE_LOG, true, group->space_id, 0,
 	       field / UNIV_PAGE_SIZE, field % UNIV_PAGE_SIZE,
@@ -2325,8 +2312,6 @@ loop:
 
 	log_sys->n_log_ios++;
 
-	MONITOR_INC(MONITOR_LOG_IO);
-
 	ut_a(source_offset / UNIV_PAGE_SIZE <= ULINT_MAX);
 
 	fil_io(OS_FILE_READ | OS_FILE_LOG, sync, group->space_id, 0,
@@ -2417,8 +2402,6 @@ log_group_archive_file_header_write(
 
 	log_sys->n_log_ios++;
 
-	MONITOR_INC(MONITOR_LOG_IO);
-
 	fil_io(OS_FILE_WRITE | OS_FILE_LOG, true, group->archive_space_id,
 	       dest_offset / UNIV_PAGE_SIZE,
 	       dest_offset % UNIV_PAGE_SIZE,
@@ -2451,8 +2434,6 @@ log_group_archive_completed_header_write(
 	dest_offset = nth_file * group->file_size + LOG_FILE_ARCH_COMPLETED;
 
 	log_sys->n_log_ios++;
-
-	MONITOR_INC(MONITOR_LOG_IO);
 
 	fil_io(OS_FILE_WRITE | OS_FILE_LOG, true, group->archive_space_id,
 	       dest_offset / UNIV_PAGE_SIZE,
@@ -2580,8 +2561,6 @@ loop:
 	log_sys->n_pending_archive_ios++;
 
 	log_sys->n_log_ios++;
-
-	MONITOR_INC(MONITOR_LOG_IO);
 
 	//TODO (jonaso): This must be dead code??
 	log_encrypt_before_write(log_sys->next_checkpoint_no,

--- a/storage/innobase/srv/srv0mon.cc
+++ b/storage/innobase/srv/srv0mon.cc
@@ -873,15 +873,18 @@ static monitor_info_t	innodb_counter_info[] =
 	 MONITOR_DEFAULT_START, MONITOR_OVLD_MAX_AGE_SYNC},
 
 	{"log_pending_log_writes", "recovery", "Pending log writes",
-	 MONITOR_NONE,
+	 static_cast<monitor_type_t>(
+	 MONITOR_EXISTING | MONITOR_DISPLAY_CURRENT),
 	 MONITOR_DEFAULT_START, MONITOR_PENDING_LOG_WRITE},
 
 	{"log_pending_checkpoint_writes", "recovery", "Pending checkpoints",
-	 MONITOR_NONE,
+	 static_cast<monitor_type_t>(
+	 MONITOR_EXISTING | MONITOR_DISPLAY_CURRENT),
 	 MONITOR_DEFAULT_START, MONITOR_PENDING_CHECKPOINT_WRITE},
 
 	{"log_num_log_io", "recovery", "Number of log I/Os",
-	 MONITOR_NONE,
+	 static_cast<monitor_type_t>(
+	 MONITOR_EXISTING | MONITOR_DISPLAY_CURRENT),
 	 MONITOR_DEFAULT_START, MONITOR_LOG_IO},
 
 	{"log_waits", "recovery",
@@ -1968,6 +1971,25 @@ srv_mon_process_existing_counter(
 
 	case MONITOR_OVLD_LSN_CURRENT:
 		value = (mon_type_t) log_sys->lsn;
+		break;
+
+	case MONITOR_PENDING_LOG_WRITE:
+		mutex_enter(&log_sys->mutex);
+		value = static_cast<mon_type_t>(log_sys->n_pending_writes);
+		mutex_exit(&log_sys->mutex);
+		break;
+
+	case MONITOR_PENDING_CHECKPOINT_WRITE:
+		mutex_enter(&log_sys->mutex);
+		value = static_cast<mon_type_t>(
+		    log_sys->n_pending_checkpoint_writes);
+		mutex_exit(&log_sys->mutex);
+		break;
+
+	case MONITOR_LOG_IO:
+		mutex_enter(&log_sys->mutex);
+		value = static_cast<mon_type_t>(log_sys->n_log_ios);
+		mutex_exit(&log_sys->mutex);
 		break;
 
 	case MONITOR_OVLD_BUF_OLDEST_LSN:

--- a/storage/xtradb/log/log0log.cc
+++ b/storage/xtradb/log/log0log.cc
@@ -1305,7 +1305,6 @@ log_io_complete(
 
 	group->n_pending_writes--;
 	log_sys->n_pending_writes--;
-	MONITOR_DEC(MONITOR_PENDING_LOG_WRITE);
 
 	unlock = log_group_check_flush_completion(group);
 	unlock = unlock | log_sys_check_flush_completion();
@@ -1356,8 +1355,6 @@ log_group_file_header_flush(
 #endif /* UNIV_DEBUG */
 	if (log_do_write) {
 		log_sys->n_log_ios++;
-
-		MONITOR_INC(MONITOR_LOG_IO);
 
 		srv_stats.os_log_pending_writes.inc();
 
@@ -1482,8 +1479,6 @@ loop:
 
 	if (log_do_write) {
 		log_sys->n_log_ios++;
-
-		MONITOR_INC(MONITOR_LOG_IO);
 
 		srv_stats.os_log_pending_writes.inc();
 
@@ -1632,7 +1627,6 @@ loop:
 	}
 #endif /* UNIV_DEBUG */
 	log_sys->n_pending_writes++;
-	MONITOR_INC(MONITOR_PENDING_LOG_WRITE);
 
 	group = UT_LIST_GET_FIRST(log_sys->log_groups);
 	group->n_pending_writes++;	/*!< We assume here that we have only
@@ -1724,7 +1718,6 @@ loop:
 
 	group->n_pending_writes--;
 	log_sys->n_pending_writes--;
-	MONITOR_DEC(MONITOR_PENDING_LOG_WRITE);
 
 	unlock = log_group_check_flush_completion(group);
 	unlock = unlock | log_sys_check_flush_completion();
@@ -1939,7 +1932,6 @@ log_io_complete_checkpoint(void)
 	ut_ad(log_sys->n_pending_checkpoint_writes > 0);
 
 	log_sys->n_pending_checkpoint_writes--;
-	MONITOR_DEC(MONITOR_PENDING_CHECKPOINT_WRITE);
 
 	if (log_sys->n_pending_checkpoint_writes == 0) {
 		log_complete_checkpoint();
@@ -2086,11 +2078,8 @@ log_group_checkpoint(
 		}
 
 		log_sys->n_pending_checkpoint_writes++;
-		MONITOR_INC(MONITOR_PENDING_CHECKPOINT_WRITE);
 
 		log_sys->n_log_ios++;
-
-		MONITOR_INC(MONITOR_LOG_IO);
 
 		/* We send as the last parameter the group machine address
 		added with 1, as we want to distinguish between a normal log
@@ -2177,8 +2166,6 @@ log_group_read_checkpoint_info(
 	ut_ad(mutex_own(&(log_sys->mutex)));
 
 	log_sys->n_log_ios++;
-
-	MONITOR_INC(MONITOR_LOG_IO);
 
 	fil_io(OS_FILE_READ | OS_FILE_LOG, true, group->space_id, 0,
 	       field / UNIV_PAGE_SIZE, field % UNIV_PAGE_SIZE,
@@ -2564,8 +2551,6 @@ loop:
 
 	log_sys->n_log_ios++;
 
-	MONITOR_INC(MONITOR_LOG_IO);
-
 	ut_a(source_offset / UNIV_PAGE_SIZE <= ULINT_MAX);
 
 	if (release_mutex) {
@@ -2727,8 +2712,6 @@ log_group_archive_file_header_write(
 
 	log_sys->n_log_ios++;
 
-	MONITOR_INC(MONITOR_LOG_IO);
-
 	fil_io(OS_FILE_WRITE | OS_FILE_LOG, true, group->archive_space_id,
 	       0,
 	       dest_offset / UNIV_PAGE_SIZE,
@@ -2762,8 +2745,6 @@ log_group_archive_completed_header_write(
 	dest_offset = nth_file * group->file_size + LOG_FILE_ARCH_COMPLETED;
 
 	log_sys->n_log_ios++;
-
-	MONITOR_INC(MONITOR_LOG_IO);
 
 	fil_io(OS_FILE_WRITE | OS_FILE_LOG, true, group->archive_space_id,
 	       0,
@@ -2894,8 +2875,6 @@ loop:
 	log_sys->n_pending_archive_ios++;
 
 	log_sys->n_log_ios++;
-
-	MONITOR_INC(MONITOR_LOG_IO);
 
 	//TODO (jonaso): This must be dead code??
 	log_encrypt_before_write(log_sys->next_checkpoint_no,

--- a/storage/xtradb/srv/srv0mon.cc
+++ b/storage/xtradb/srv/srv0mon.cc
@@ -873,15 +873,18 @@ static monitor_info_t	innodb_counter_info[] =
 	 MONITOR_DEFAULT_START, MONITOR_OVLD_MAX_AGE_SYNC},
 
 	{"log_pending_log_writes", "recovery", "Pending log writes",
-	 MONITOR_NONE,
+	 static_cast<monitor_type_t>(
+	 MONITOR_EXISTING | MONITOR_DISPLAY_CURRENT),
 	 MONITOR_DEFAULT_START, MONITOR_PENDING_LOG_WRITE},
 
 	{"log_pending_checkpoint_writes", "recovery", "Pending checkpoints",
-	 MONITOR_NONE,
+	 static_cast<monitor_type_t>(
+	 MONITOR_EXISTING | MONITOR_DISPLAY_CURRENT),
 	 MONITOR_DEFAULT_START, MONITOR_PENDING_CHECKPOINT_WRITE},
 
 	{"log_num_log_io", "recovery", "Number of log I/Os",
-	 MONITOR_NONE,
+	 static_cast<monitor_type_t>(
+	 MONITOR_EXISTING | MONITOR_DISPLAY_CURRENT),
 	 MONITOR_DEFAULT_START, MONITOR_LOG_IO},
 
 	{"log_waits", "recovery",
@@ -1968,6 +1971,25 @@ srv_mon_process_existing_counter(
 
 	case MONITOR_OVLD_LSN_CURRENT:
 		value = (mon_type_t) log_sys->lsn;
+		break;
+
+	case MONITOR_PENDING_LOG_WRITE:
+		mutex_enter(&log_sys->mutex);
+		value = static_cast<mon_type_t>(log_sys->n_pending_writes);
+		mutex_exit(&log_sys->mutex);
+		break;
+
+	case MONITOR_PENDING_CHECKPOINT_WRITE:
+		mutex_enter(&log_sys->mutex);
+		value = static_cast<mon_type_t>(
+		    log_sys->n_pending_checkpoint_writes);
+		mutex_exit(&log_sys->mutex);
+		break;
+
+	case MONITOR_LOG_IO:
+		mutex_enter(&log_sys->mutex);
+		value = static_cast<mon_type_t>(log_sys->n_log_ios);
+		mutex_exit(&log_sys->mutex);
 		break;
 
 	case MONITOR_OVLD_BUF_OLDEST_LSN:


### PR DESCRIPTION
MONITOR_PENDING_LOG_WRITE
MONITOR_PENDING_CHECKPOINT_WRITE
MONITOR_LOG_IO: read values from log_t members instead of updating own
monitor variables

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.1-MDEV-18214-duplicate-monitor)