### PR TITLE
MDEV-18444 ROW_FORMAT=COMPRESSED unnecessarily requires NOCOPY for INSTANT operation

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_bugs.result
+++ b/mysql-test/suite/innodb/r/instant_alter_bugs.result
@@ -128,3 +128,21 @@ HANDLER h READ `PRIMARY` PREV WHERE 0;
 pk	f1	f2	f3	f4	f5	f6	f7	f8	filler
 HANDLER h CLOSE;
 DROP TABLE t1;
+create table t (
+a varchar(9),
+b int,
+c int,
+row_start bigint unsigned generated always as row start invisible,
+row_end bigint unsigned generated always as row end invisible,
+period for system_time (row_start, row_end)
+) engine=innodb row_format=compressed with system versioning;
+insert into t values (repeat('a', 9), 1, 1);
+set @@system_versioning_alter_history = keep;
+alter table t modify a varchar(10), algorithm=instant;
+alter table t change b bb int, algorithm=instant;
+alter table t modify c int without system versioning, algorithm=instant;
+set @@system_versioning_alter_history = error;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+drop table t;

--- a/mysql-test/suite/innodb/t/instant_alter_bugs.test
+++ b/mysql-test/suite/innodb/t/instant_alter_bugs.test
@@ -136,3 +136,21 @@ HANDLER h CLOSE;
 DROP TABLE t1;
 --let $datadir= `select @@datadir`
 --remove_file $datadir/test/load.data
+
+
+create table t (
+  a varchar(9),
+  b int,
+  c int,
+  row_start bigint unsigned generated always as row start invisible,
+  row_end bigint unsigned generated always as row end invisible,
+  period for system_time (row_start, row_end)
+) engine=innodb row_format=compressed with system versioning;
+insert into t values (repeat('a', 9), 1, 1);
+set @@system_versioning_alter_history = keep;
+alter table t modify a varchar(10), algorithm=instant;
+alter table t change b bb int, algorithm=instant;
+alter table t modify c int without system versioning, algorithm=instant;
+set @@system_versioning_alter_history = error;
+check table t;
+drop table t;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1465,7 +1465,14 @@ instant_alter_column_possible(
 	const TABLE*			table,
 	const TABLE*			altered_table)
 {
-	if (!ib_table.supports_instant()) {
+	static constexpr alter_table_operations avoid_rebuild
+		= ALTER_ADD_STORED_BASE_COLUMN
+		| ALTER_DROP_STORED_COLUMN
+		| ALTER_STORED_COLUMN_ORDER
+		| ALTER_COLUMN_NULLABLE;
+
+	if (!ib_table.supports_instant()
+	    && ha_alter_info->handler_flags & avoid_rebuild) {
 		return false;
 	}
 #if 1 // MDEV-17459: adjust fts_fetch_doc_from_rec() and friends; remove this
@@ -1500,12 +1507,6 @@ instant_alter_column_possible(
 	if (ha_alter_info->handler_flags & ALTER_ADD_SYSTEM_VERSIONING) {
 		return false;
 	}
-
-	static constexpr alter_table_operations avoid_rebuild
-		= ALTER_ADD_STORED_BASE_COLUMN
-		| ALTER_DROP_STORED_COLUMN
-		| ALTER_STORED_COLUMN_ORDER
-		| ALTER_COLUMN_NULLABLE;
 
 	if (!(ha_alter_info->handler_flags & avoid_rebuild)) {
 		alter_table_operations flags = ha_alter_info->handler_flags


### PR DESCRIPTION
instant_alter_column_possible(): allow some operations for ROW_FORMAT_COMPRESSED

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.4-MDEV-18444-instant-compressed)
