### PR TITLE
my_close: Don't retry on close

### DIFF
--- a/mysys/my_open.c
+++ b/mysys/my_open.c
@@ -89,10 +89,7 @@ int my_close(File fd, myf MyFlags)
     my_file_info[fd].type= UNOPEN;
   }
 #ifndef _WIN32
-  do
-  {
-    err= close(fd);
-  } while (err == -1 && errno == EINTR);
+  err= close(fd);
 #else
   err= my_win_close(fd);
 #endif


### PR DESCRIPTION
According to close(2) "Retrying the close() after a failure return is
the wrong thing to do"

I submit this under the MCA.