### PR TITLE
my_fclose: Don't retry on close

### DIFF
--- a/mysys/my_fopen.c
+++ b/mysys/my_fopen.c
@@ -171,10 +171,7 @@ int my_fclose(FILE *fd, myf MyFlags)
     my_file_info[file].type= UNOPEN;
   }
 #ifndef _WIN32
-  do
-  {
-    err= fclose(fd);
-  } while (err == -1 && errno == EINTR);
+  err= fclose(fd);
 #else
   err= my_win_fclose(fd);
 #endif


### PR DESCRIPTION
According to close(2) "Retrying the close() after a failure return is
the wrong thing to do"

Corrects 5c81cb880a054f34803e2821489533274ebf6c4e in MDEV-15635