### PR TITLE
Fix for failures on galera.galera_sst_mysqldump

### DIFF
--- a/mysql-test/suite/galera/t/galera_sst_mysqldump.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_mysqldump.cnf
@@ -5,7 +5,5 @@
 
 [mysqld.1]
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=1;pc.ignore_sb=true'
-wsrep_sync_wait=0
 [mysqld.2]
 wsrep_provider_options='base_port=@mysqld.2.#galera_port;gcache.size=1;pc.ignore_sb=true'
-wsrep_sync_wait=0


### PR DESCRIPTION
Test galera_sst_mysqldump could fail occasionally due certification failure. Enforcing stricter causality checks by removing wsrep_sync_wait=0 from test configuration.