### PR TITLE
Update mysqladmin.cc for MDEV-15736

### DIFF
--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -1583,7 +1583,7 @@ static void print_relative_row_vert(MYSQL_RES *result __attribute__((unused)),
 	 llstr((tmp - last_values[row]), buff));
 
   /* Find the minimum row length needed to output the relative value */
-  if ((length=(uint) strlen(buff) > ex_val_max_len[row]) && ex_status_printed)
+  if ((length=(uint) strlen(buff)) > ex_val_max_len[row] && ex_status_printed)
     ex_val_max_len[row] = length;
   last_values[row] = tmp;
 }


### PR DESCRIPTION
Update mysqladmin.cc for MDEV-15736:

client/mysqladmin.cc:1586]: (style) Suspicious condition

Original source code was:

`if ((length=(uint) strlen(buff) > ex_val_max_len[row]) && ex_status_printed)`

According to the bug, and was 'confirmed', this is better code:

`if ((length=(uint) strlen(buff)) > ex_val_max_len[row] && ex_status_printed)`