### PR TITLE
MDEV-15526 Systemd unit files naming and installation (alias in unit are not recommended, create symlink)

### DIFF
--- a/debian/mariadb-server-10.4.links
+++ b/debian/mariadb-server-10.4.links
@@ -7,3 +7,5 @@ usr/bin/mysqld_safe usr/bin/mariadbd-safe
 usr/bin/mysqld_safe_helper usr/bin/mariadbd-safe-helper
 usr/bin/mysqlhotcopy usr/bin/mariadb-hotcopy
 usr/bin/mysqlshow usr/bin/mariadb-show
+lib/systemd/system/mariadb.service lib/systemd/system/mysql.service
+lib/systemd/system/mariadb.service lib/systemd/system/mysqld.service

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -26,8 +26,6 @@ After=network.target
 
 [Install]
 WantedBy=multi-user.target
-Alias=mysql.service
-Alias=mysqld.service
 
 
 [Service]


### PR DESCRIPTION
This replace the of Alias in the systemd unit file and creates symlinks in post install script so that both mariadb and mysql systemctl command are supported.
This also permits to have a better synchronization between sysv init script and systemd (disable|enable) command.