### PR TITLE
Aggregate functions: only create list if args exist

### DIFF
--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -6330,17 +6330,20 @@ Item_func_sp::fix_fields(THD *thd, Item **ref)
 
   if (m_sp->agg_type() == GROUP_AGGREGATE)
   {
-    List<Item> list;
-    list.empty();
-    for (uint i=0; i < arg_count; i++)
-      list.push_back(*(args+i));
-
     Item_sum_sp *item_sp;
     Query_arena *arena, backup;
     arena= thd->activate_stmt_arena_if_needed(&backup);
 
     if (arg_count)
+    {
+      List<Item> list;
+      list.empty();
+      for (uint i=0; i < arg_count; i++)
+        list.push_back(*(args+i));
+
       item_sp= new (thd->mem_root) Item_sum_sp(thd, context, m_name, sp, list);
+      list.empty();
+    }
     else
       item_sp= new (thd->mem_root) Item_sum_sp(thd, context, m_name, sp);
 
@@ -6354,7 +6357,6 @@ Item_func_sp::fix_fields(THD *thd, Item **ref)
     if (err)
       DBUG_RETURN(TRUE);
 
-    list.empty();
     DBUG_RETURN(FALSE);
   }
 


### PR DESCRIPTION
Also always empty list rather than only if there is no error.

I submit this under the MCA.