### PR TITLE
cmake-wsrep: friendly error message about missing wsrep_api.h

### DIFF
--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -31,7 +31,7 @@ ENDIF()
 
 IF(update_result OR NOT EXISTS ${CMAKE_SOURCE_DIR}/libmariadb/CMakeLists.txt)
   MESSAGE(FATAL_ERROR "No MariaDB Connector/C! Run
-    git submodule update --init
+    git submodule update --init --recursive
 Then restart the build.
 ")
 ENDIF()

--- a/cmake/wsrep.cmake
+++ b/cmake/wsrep.cmake
@@ -32,6 +32,12 @@ IF(WITH_WSREP)
   # Set the patch version
   SET(WSREP_PATCH_VERSION "22")
 
+  IF(NOT EXISTS "${CMAKE_SOURCE_DIR}/wsrep-lib/wsrep-API/v26/wsrep_api.h")
+    MESSAGE(FATAL_ERROR "No MariaDB wsrep-API code! Run
+    ${GIT_EXECUTABLE} submodule update --init --recursive
+Then restart the build.
+")
+  ENDIF()
   # Obtain wsrep API version
   FILE(STRINGS "${CMAKE_SOURCE_DIR}/wsrep-lib/wsrep-API/v26/wsrep_api.h" WSREP_API_VERSION
        LIMIT_COUNT 1 REGEX "WSREP_INTERFACE_VERSION")


### PR DESCRIPTION
@janlindstrom, I suspect my PR yesterday was a result of not having `cmake.update-submodules` set (and not seeing the recursive submodule). This PR (and #1181) makes it more clear to the user (though these could be cleaned up a bit more once both are merged to the 10.4 branch).

Changed the  cmake/submodules.cmake message as this is the first time that we have recursive modules.

Without this commit the error message is:

$ cmake . -DWITH_WSREP=ON
-- Running cmake version 3.12.1
-- MariaDB 10.4.3
CMake Error at cmake/wsrep.cmake:36 (FILE):
  FILE STRINGS file
  ".../mariadb-server-10.4/wsrep-lib/wsrep-API/v26/wsrep_api.h"
  cannot be read.
Call Stack (most recent call first):
  CMakeLists.txt:147 (INCLUDE)

Having 'git config cmake.update-submodules yes' nicely updates the
build without error.

$ cmake . -DWITH_WSREP=ON
-- Running cmake version 3.12.1
-- MariaDB 10.4.3
Submodule path 'wsrep-lib': checked out 'e7d72ae7f6a6995a21d743389426a963429a1fff'
Submodule path 'wsrep-lib/wsrep-API/v26': checked out '75a5f452f2ba07b0f4a3a9a94825fccc71b27398'

I submit this under the MCA.