### PR TITLE
MDEV-18480, MDEV-18571 Rolling Galera upgrade from 10.3 to 10.4

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1729,11 +1729,23 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
   case COM_STMT_BULK_EXECUTE:
   {
     mysqld_stmt_bulk_execute(thd, packet, packet_length);
+#ifdef WITH_WSREP
+    if (WSREP_ON)
+    {
+        (void)wsrep_after_statement(thd);
+    }
+#endif /* WITH_WSREP */
     break;
   }
   case COM_STMT_EXECUTE:
   {
     mysqld_stmt_execute(thd, packet, packet_length);
+#ifdef WITH_WSREP
+    if (WSREP_ON)
+    {
+        (void)wsrep_after_statement(thd);
+    }
+#endif /* WITH_WSREP */
     break;
   }
   case COM_STMT_FETCH:


### PR DESCRIPTION
This pull request consists of two fixes:

* The assertion reported in MDEV-18480 was fixed by skipping setting wsrep SE checkpoint if the provider didn't assign unique sequence number for a view event.
* The assertion reported in MDEV-18571 was due to missing calls to wsrep_after_statement() if the PS protocol was in use.