### PR TITLE
MDEV-18588 Galera: Rolling upgrade: segfault during node1 upgrade withh log-bin and log-slave-updates enabled

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -337,7 +337,7 @@ static int generate_binlog_index_opt_val(char** ret)
 {
   DBUG_ASSERT(ret);
   *ret= NULL;
-  if (opt_bin_log)
+  if (opt_binlog_index_name)
   {
     *ret= strcmp(opt_binlog_index_name, "0") ?
       my_strdup(opt_binlog_index_name, MYF(0)) : my_strdup("", MYF(0));


### PR DESCRIPTION
When node is JOINER and bin-log is enabled but bin-log-index is not set in configuration, we would use NULL pointer which causes segfault. 
Fixed by checking for NULL pointer before using variable.