### PR TITLE
MDEV-18587 Don't reject DDLs if streaming replication is on

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_sr_create_drop.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_create_drop.result
@@ -1,0 +1,28 @@
+connection node_2;
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+connection node_2;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f1` int(11) NOT NULL,
+  PRIMARY KEY (`f1`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1
+connection node_1;
+DROP TABLE t1;
+connection node_2;
+SHOW CREATE TABLE t1;
+ERROR 42S02: Table 'test.t1' doesn't exist
+CREATE DATABASE mdev_18587;
+connection node_2;
+SHOW DATABASES LIKE 'mdev_18587';
+Database (mdev_18587)
+mdev_18587
+connection node_1;
+DROP DATABASE mdev_18587;
+connection node_2;
+SHOW DATABASES LIKE 'mdev_18587';
+Database (mdev_18587)
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=DEFAULT;

--- a/mysql-test/suite/galera_sr/t/galera_sr_create_drop.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_create_drop.test
@@ -1,0 +1,33 @@
+#
+# Verify that CREATE/DROP DDLs work when streaming replication is on.
+#
+
+--source include/galera_cluster.inc
+
+SET SESSION wsrep_trx_fragment_size=1;
+
+#
+# CREATE/DROP TABLE succeeds and the change is propagated to node_2.
+#
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+--connection node_2
+SHOW CREATE TABLE t1;
+--connection node_1
+DROP TABLE t1;
+--connection node_2
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t1;
+
+#
+# CREATE/DROP DATABASE succeeds and the change is propagated to node_2.
+#
+CREATE DATABASE mdev_18587;
+--connection node_2
+SHOW DATABASES LIKE 'mdev_18587';
+--connection node_1
+DROP DATABASE mdev_18587;
+--connection node_2
+SHOW DATABASES LIKE 'mdev_18587';
+--connection node_1
+
+SET SESSION wsrep_trx_fragment_size=DEFAULT;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -5987,7 +5987,8 @@ int THD::decide_logging_format(TABLE_LIST *tables)
     binlog by filtering rules.
   */
 #ifdef WITH_WSREP
-  if (WSREP_CLIENT_NNULL(this) && variables.wsrep_trx_fragment_size > 0)
+  if (WSREP_CLIENT_NNULL(this) && wsrep_thd_is_local(this) &&
+      variables.wsrep_trx_fragment_size > 0)
   {
     if (!is_current_stmt_binlog_format_row())
     {


### PR DESCRIPTION
The check for streaming replication logging format in
THD::decide_logging_format() did the check also for DDLs running
in TOI mode. This caused DROP DATABASE to fail if streaming
replication was enabled.

Added check for THD wsrep execution mode and perform the check
only if the THD is in local processing mode (i.e. not TOI).

Added galera_sr_create_drop test to verify that CREATE/DROP
statements pass even if streaming replication is on.