### PR TITLE
MDEV-18585 Avoid excessive Annotate_rows_log_events in binlog

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-18585.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-18585.result
@@ -1,0 +1,36 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INT PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_unit='ROWS';
+SET SESSION wsrep_trx_fragment_size=1;
+INSERT INTO t1 VALUES (1), (2);
+SET SESSION wsrep_trx_fragment_unit='BYTES';
+SET SESSION wsrep_trx_fragment_size=1;
+INSERT INTO t1 VALUES (3), (4);
+SET SESSION wsrep_trx_fragment_unit='STATEMENTS';
+SET SESSION wsrep_trx_fragment_size=1;
+INSERT INTO t1 VALUES (5), (6);
+SET SESSION wsrep_trx_fragment_unit=default;
+SET SESSION wsrep_trx_fragment_size=default;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000002' FROM 518;
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+mysqld-bin.000002	518	Gtid	1	560	BEGIN GTID 0-1-2
+mysqld-bin.000002	560	Annotate_rows	1	613	INSERT INTO t1 VALUES (1), (2)
+mysqld-bin.000002	613	Table_map	1	658	table_id: # (test.t1)
+mysqld-bin.000002	658	Write_rows_v1	1	696	table_id: # flags: STMT_END_F
+mysqld-bin.000002	696	Table_map	1	741	table_id: # (test.t1)
+mysqld-bin.000002	741	Write_rows_v1	1	779	table_id: # flags: STMT_END_F
+mysqld-bin.000002	779	Xid	1	810	COMMIT /* xid=# */
+mysqld-bin.000002	810	Gtid	1	852	BEGIN GTID 0-1-3
+mysqld-bin.000002	852	Annotate_rows	1	905	INSERT INTO t1 VALUES (3), (4)
+mysqld-bin.000002	905	Table_map	1	950	table_id: # (test.t1)
+mysqld-bin.000002	950	Write_rows_v1	1	988	table_id: # flags: STMT_END_F
+mysqld-bin.000002	988	Table_map	1	1033	table_id: # (test.t1)
+mysqld-bin.000002	1033	Write_rows_v1	1	1071	table_id: # flags: STMT_END_F
+mysqld-bin.000002	1071	Xid	1	1102	COMMIT /* xid=# */
+mysqld-bin.000002	1102	Gtid	1	1144	BEGIN GTID 0-1-4
+mysqld-bin.000002	1144	Annotate_rows	1	1197	INSERT INTO t1 VALUES (5), (6)
+mysqld-bin.000002	1197	Table_map	1	1242	table_id: # (test.t1)
+mysqld-bin.000002	1242	Write_rows_v1	1	1285	table_id: # flags: STMT_END_F
+mysqld-bin.000002	1285	Xid	1	1316	COMMIT /* xid=# */
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/r/mysql-wsrep-features#136.result
+++ b/mysql-test/suite/galera_sr/r/mysql-wsrep-features#136.result
@@ -29,7 +29,6 @@ mysqld-bin.000001	<Pos>	Gtid	1	<End_log_pos>	BEGIN GTID 0-1-2
 mysqld-bin.000001	<Pos>	Annotate_rows	1	<End_log_pos>	INSERT INTO t1 VALUES (1),(2)
 mysqld-bin.000001	<Pos>	Table_map	1	<End_log_pos>	table_id: ### (test.t1)
 mysqld-bin.000001	<Pos>	Write_rows_v1	1	<End_log_pos>	table_id: ### flags: STMT_END_F
-mysqld-bin.000001	<Pos>	Annotate_rows	1	<End_log_pos>	INSERT INTO t1 VALUES (1),(2)
 mysqld-bin.000001	<Pos>	Table_map	1	<End_log_pos>	table_id: ### (test.t1)
 mysqld-bin.000001	<Pos>	Write_rows_v1	1	<End_log_pos>	table_id: ### flags: STMT_END_F
 mysqld-bin.000001	<Pos>	Xid	1	<End_log_pos>	COMMIT /* xid=### */
@@ -52,7 +51,6 @@ mysqld-bin.000001	<Pos>	Gtid	1	<End_log_pos>	BEGIN GTID 0-1-2
 mysqld-bin.000001	<Pos>	Annotate_rows	1	<End_log_pos>	INSERT INTO t1 VALUES (1),(2)
 mysqld-bin.000001	<Pos>	Table_map	1	<End_log_pos>	table_id: ### (test.t1)
 mysqld-bin.000001	<Pos>	Write_rows_v1	1	<End_log_pos>	table_id: ### flags: STMT_END_F
-mysqld-bin.000001	<Pos>	Annotate_rows	1	<End_log_pos>	INSERT INTO t1 VALUES (1),(2)
 mysqld-bin.000001	<Pos>	Table_map	1	<End_log_pos>	table_id: ### (test.t1)
 mysqld-bin.000001	<Pos>	Write_rows_v1	1	<End_log_pos>	table_id: ### flags: STMT_END_F
 mysqld-bin.000001	<Pos>	Xid	1	<End_log_pos>	COMMIT /* xid=### */

--- a/mysql-test/suite/galera_sr/t/MDEV-18585.cnf
+++ b/mysql-test/suite/galera_sr/t/MDEV-18585.cnf
@@ -1,0 +1,5 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+log-bin
+log-slave-updates

--- a/mysql-test/suite/galera_sr/t/MDEV-18585.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-18585.test
@@ -1,0 +1,42 @@
+#
+# MDEV-18686 Verify that the Annotate_rows_log_event is written only
+# once per statement into binlog.
+#
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (f1 INT PRIMARY KEY);
+
+#
+# Unit ROW
+#
+SET SESSION wsrep_trx_fragment_unit='ROWS';
+SET SESSION wsrep_trx_fragment_size=1;
+
+INSERT INTO t1 VALUES (1), (2);
+
+#
+# Unit BYTE
+#
+SET SESSION wsrep_trx_fragment_unit='BYTES';
+SET SESSION wsrep_trx_fragment_size=1;
+
+INSERT INTO t1 VALUES (3), (4);
+
+#
+# Unit STATEMENT
+#
+SET SESSION wsrep_trx_fragment_unit='STATEMENTS';
+SET SESSION wsrep_trx_fragment_size=1;
+
+INSERT INTO t1 VALUES (5), (6);
+
+#
+# Reset to default settings
+#
+SET SESSION wsrep_trx_fragment_unit=default;
+SET SESSION wsrep_trx_fragment_size=default;
+
+--replace_regex /table_id: [0-9]+/table_id: #/ /xid=[0-9]+/xid=#/
+SHOW BINLOG EVENTS IN 'mysqld-bin.000002' FROM 518;
+
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -6256,7 +6256,9 @@ static int write_locked_table_maps(THD *thd)
   MYSQL_LOCK *locks[2];
   locks[0]= thd->extra_lock;
   locks[1]= thd->lock;
-  my_bool with_annotate= thd->variables.binlog_annotate_row_events &&
+  my_bool with_annotate= IF_WSREP(!wsrep_fragments_certified_for_stmt(thd),
+                                  true) &&
+    thd->variables.binlog_annotate_row_events &&
     thd->query() && thd->query_length();
 
   for (uint i= 0 ; i < sizeof(locks)/sizeof(*locks) ; ++i )

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -229,8 +229,12 @@ size_t Wsrep_client_service::bytes_generated() const
   IO_CACHE* cache= wsrep_get_trans_cache(m_thd);
   if (cache)
   {
-    m_thd->binlog_flush_pending_rows_event(true);
-    return my_b_tell(cache);
+    size_t pending_rows_event_length= 0;
+    if (Rows_log_event* ev= m_thd->binlog_get_pending_rows_event(true))
+    {
+      pending_rows_event_length= ev->get_data_size();
+    }
+    return my_b_tell(cache) + pending_rows_event_length;
   }
   return 0;
 }

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -83,6 +83,14 @@ static inline bool wsrep_streaming_enabled(THD* thd)
   return (thd->wsrep_sr().fragment_size() > 0);
 }
 
+/*
+  Return number of fragments succesfully certified for the
+  current statement.
+ */
+static inline size_t wsrep_fragments_certified_for_stmt(THD* thd)
+{
+    return thd->wsrep_trx().fragments_certified_for_statement();
+}
 
 static inline int wsrep_start_transaction(THD* thd, wsrep_trx_id_t trx_id)
 {


### PR DESCRIPTION
Make sure that the Annotate_rows_log_events is written into
binlog only for the first fragment of the current statement.
Also avoid flusing pending rows event when calculating bytes
generated by the transaction.

Added and recorded a test which verifies that the binlog
contains only one Annotate_rows_log_event per statement
with various SR settings. Recrded mysql-wsrep-features#136
which produced different output with excession log events
suppressed.