### PR TITLE
Fixes to streaming replication BF aborts and rollbacks

### DIFF
--- a/mysql-test/suite/galera_sr/r/mysql-wsrep-features#165.result
+++ b/mysql-test/suite/galera_sr/r/mysql-wsrep-features#165.result
@@ -1,35 +1,55 @@
+connection node_2;
+connection node_1;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect node_1c, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -37,6 +57,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -44,39 +65,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -84,6 +122,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -91,39 +130,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -131,6 +187,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -138,39 +195,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -178,6 +252,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -185,39 +260,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -225,6 +317,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -232,39 +325,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -272,6 +382,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -279,39 +390,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -319,6 +447,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -326,39 +455,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -366,6 +512,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -373,39 +520,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -413,6 +577,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -420,39 +585,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -460,6 +642,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -467,39 +650,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -507,6 +707,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -514,39 +715,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -554,6 +772,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -561,39 +780,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -601,6 +837,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -608,39 +845,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -648,6 +902,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -655,39 +910,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -695,6 +967,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -702,39 +975,56 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 VARCHAR(1)) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, 'x'), (2, 'x'), (4, 'x'), (5, 'x');
+connection node_1a;
 START TRANSACTION;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 1;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 4;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 5;
+connection node_1b;
 START TRANSACTION;
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t1 VALUES (3, 'b');
 UPDATE t1 SET f2 = 'b' WHERE f1 = 2;
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	x
 2	x
 4	x
 5	x
+connection node_1a;
 UPDATE t1 SET f2 = 'a' WHERE f1 = 2;
+connection node_1;
+connection node_1b;
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
 UPDATE t1 SET f2 = 'b' WHERE f1 = 1;
+connection node_1;
 SET DEBUG_SYNC = 'now WAIT_FOR wait';
+connection node_1;
 SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1c;
 UPDATE t1 SET f2 = 'x' WHERE f1 = 3;
+connection node_1a;
 COMMIT;
+connection node_1b;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -742,6 +1032,7 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_2;
 SELECT * FROM t1;
 f1	f2
 1	a
@@ -749,4 +1040,6 @@ f1	f2
 3	x
 4	a
 5	a
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
@@ -53,6 +53,10 @@ SELECT * FROM t1;
 --connection node_1a
 --send UPDATE t1 SET f2 = 'a' WHERE f1 = 2
 
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER != 'system user' AND STATE = 'Updating';
+--source include/wait_condition.inc
+
 # Will deadlock
 --connection node_1b
 SET DEBUG_SYNC = 'wsrep_before_SR_rollback SIGNAL wait WAIT_FOR continue';
@@ -101,4 +105,5 @@ SELECT * FROM t1;
 SELECT * FROM t1;
 
 --connection node_1
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -145,8 +145,11 @@ extern "C" void wsrep_handle_SR_rollback(THD *bf_thd,
               victim_thd->wsrep_trx_id(),
               victim_thd->wsrep_sr().fragments_certified(),
               wsrep_thd_transaction_state_str(victim_thd));
-  if (bf_thd) victim_thd->store_globals();
-  if (!bf_thd)
+  if (bf_thd && bf_thd != victim_thd)
+  {
+    victim_thd->store_globals();
+  }
+  else
   {
     DEBUG_SYNC(victim_thd, "wsrep_before_SR_rollback");
   }
@@ -158,7 +161,10 @@ extern "C" void wsrep_handle_SR_rollback(THD *bf_thd,
   {
     wsrep_thd_self_abort(victim_thd);
   }
-  if (bf_thd) bf_thd->store_globals();
+  if (bf_thd && bf_thd != victim_thd)
+  {
+    bf_thd->store_globals();
+  }
 }
 
 extern "C" my_bool wsrep_thd_bf_abort(const THD *bf_thd, THD *victim_thd,

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -36,7 +36,7 @@ class Wsrep_client_service : public wsrep::client_service
 public:
   Wsrep_client_service(THD*, Wsrep_client_state&);
 
-  bool interrupted() const;
+  bool interrupted(wsrep::unique_lock<wsrep::mutex>&) const;
   void reset_globals();
   void store_globals();
   int prepare_data_for_replication();

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -7084,6 +7084,12 @@ DeadlockChecker::check_and_resolve(const lock_t* lock, trx_t* trx)
 	if (victim_trx != NULL) {
 
 		print("*** WE ROLL BACK TRANSACTION (2)\n");
+#ifdef WITH_WSREP
+		if (wsrep_on(trx->mysql_thd)) {
+			wsrep_handle_SR_rollback(trx->mysql_thd,
+						 victim_trx->mysql_thd);
+		}
+#endif
 
 		lock_deadlock_found = true;
 	}


### PR DESCRIPTION
This PR consists of two commits
* The first one adds missing call to `wsrep_handle_SR_rollback()` in InnoDB `DeadlockChecker::check_and_resolve()`. After this addition the test `mysql-wsrep-features#165` started to pass. Fixed the test to be deterministic and recorded.
* Cleaned up `Wsrep_client_service::interrupted()` call. With updated wsrep-lib the library part handles the wsrep transaction state checks and guarantees that the method will be called with LOCK_wsrep_thd locked.