### PR TITLE
MDEV-18662 ib_wqueue_t has a data race

### DIFF
--- a/storage/innobase/ut/ut0wqueue.cc
+++ b/storage/innobase/ut/ut0wqueue.cc
@@ -203,7 +203,10 @@ ib_wqueue_is_empty(
 					else FALSE */
 	const ib_wqueue_t*	wq)	/* in: work queue */
 {
-	return(ib_list_is_empty(wq->items));
+	mutex_enter(&wq->mutex);
+	bool is_empty = ib_list_is_empty(wq->items);
+	mutex_exit(&wq->mutex);
+	return is_empty;
 }
 
 /********************************************************************


### PR DESCRIPTION
ib_wqueue_is_empty(): protect ib_list_is_empty() call

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.1-MDEV-18662-wqueue-race)
