### PR TITLE
Fixed and recorded galera_sr.galera_sr_rollback_statement

### DIFF
--- a/mysql-test/suite/galera_sr/disabled.def
+++ b/mysql-test/suite/galera_sr/disabled.def
@@ -1,1 +1,2 @@
 galera_sr_table_contents : missing file
+GCF-437 : test relies on InnoDB redo log size limtation

--- a/mysql-test/suite/galera_sr/r/galera_sr_rollback_statement.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_rollback_statement.result
@@ -1,22 +1,33 @@
-CREATE TABLE ten (f1 INTEGER);
-INSERT INTO ten VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
-CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 CHAR(255)) ENGINE=InnoDB;
-CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 CHAR(255)) ENGINE=InnoDB;
-INSERT INTO t1 (f2) SELECT REPEAT('a', 255) FROM ten AS a1, ten AS a2, ten AS a3;
-ALTER TABLE t1 CHANGE f1 f1 INTEGER;
-ALTER TABLE t1 DROP PRIMARY KEY;
-INSERT INTO t1 VALUES (1, 'abc');
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 CHAR) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, 'a'), (2, 'a'), (3, 'a');
+INSERT INTO t2 VALUES (3, 'b');
 SET SESSION wsrep_trx_fragment_size = 1;
 INSERT INTO t2 SELECT * FROM t1;
-ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
-INSERT INTO t2 VALUES (1, 'abc');
-INSERT INTO t2 VALUES (2, 'abc');
-SELECT COUNT(*) = 2 FROM t2;
-COUNT(*) = 2
-1
-SELECT COUNT(*) = 2 FROM t2;
-COUNT(*) = 2
-1
+ERROR 23000: Duplicate entry '3' for key 'PRIMARY'
+last_committed_diff
+3
+connection node_2;
+connection node_1;
+INSERT INTO t2 VALUES (1, 'c');
+connection node_2;
+INSERT INTO t2 VALUES (2, 'c');
+connection node_1;
+SELECT * FROM t2;
+f1	f2
+1	c
+2	c
+3	b
+connection node_2;
+SELECT * FROM t2;
+f1	f2
+1	c
+2	c
+3	b
+connection node_1;
+SET SESSION wsrep_trx_fragment_size = DEFAULT;
 DROP TABLE t1;
 DROP TABLE t2;
-DROP TABLE ten;

--- a/mysql-test/suite/galera_sr/t/galera_sr_rollback_statement.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_rollback_statement.test
@@ -1,61 +1,59 @@
+#
+# Test the case where a statement is rolled back due to an error while
+# Streaming Replication is in effect. We construct an INSERT ... SELECT
+# statement that will fail with a duplicate key error towards the end of
+# the statement, after a portion has already been replicated via SR.
+#
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
-#
-# Test the case where a statement is rolled back due to an error while Streaming Replication
-# is in effect. We construct an INSERT ... SELECT statement that will fail with a duplicate
-# key error towards the end of the statement, after a portion has already been replicated via SR.
-#
-
---disable_query_log
---let $auto_increment_offset_orig = `SELECT @@auto_increment_offset`
-SET GLOBAL auto_increment_offset=1;
---enable_query_log
-
 --connection node_1
-CREATE TABLE ten (f1 INTEGER);
-INSERT INTO ten VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 
-CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 CHAR(255)) ENGINE=InnoDB;
-CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 CHAR(255)) ENGINE=InnoDB;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY, f2 CHAR) ENGINE=InnoDB;
 
-INSERT INTO t1 (f2) SELECT REPEAT('a', 255) FROM ten AS a1, ten AS a2, ten AS a3;
-ALTER TABLE t1 CHANGE f1 f1 INTEGER;
-ALTER TABLE t1 DROP PRIMARY KEY;
+INSERT INTO t1 VALUES (1, 'a'), (2, 'a'), (3, 'a');
 
 # This poison value is used to cause the INSERT ... SELECT below to fail
-INSERT INTO t1 VALUES (1, 'abc');
+INSERT INTO t2 VALUES (3, 'b');
 
-
---let $wsrep_trx_fragment_size_orig = `SELECT @@wsrep_trx_fragment_size`
 SET SESSION wsrep_trx_fragment_size = 1;
+
+--disable_query_log
+--let $last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--enable_query_log
 
 --error ER_DUP_ENTRY
 INSERT INTO t2 SELECT * FROM t1;
 
+#
+# We should see three fragments replicated: Rows 1, 2 and rollback fragment.
+#
+--disable_query_log
+--let $last_committed_after = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+--eval SELECT $last_committed_after - $last_committed_before AS last_committed_diff
+--enable_query_log
+
 --connection node_2
---let $wait_condition = SELECT COUNT(*) = 0 FROM t2;
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t2;
 --source include/wait_condition.inc
 
 # Cluster continues to operate after the implicit ROLLBACK;
 --connection node_1
-INSERT INTO t2 VALUES (1, 'abc');
+INSERT INTO t2 VALUES (1, 'c');
 
 --connection node_2
-INSERT INTO t2 VALUES (2, 'abc');
+INSERT INTO t2 VALUES (2, 'c');
 
 --connection node_1
-SELECT COUNT(*) = 2 FROM t2;
+SELECT * FROM t2;
 
 --connection node_2
-SELECT COUNT(*) = 2 FROM t2;
+SELECT * FROM t2;
 
 --connection node_1
 
---disable_query_log
---eval SET GLOBAL auto_increment_offset=$auto_increment_offset_orig;
---enable_query_log
+SET SESSION wsrep_trx_fragment_size = DEFAULT;
 
 DROP TABLE t1;
 DROP TABLE t2;
-DROP TABLE ten;

--- a/mysql-test/suite/galera_sr/t/mysql-wsrep#215.test
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep#215.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_debug_sync.inc
 
 #
 # Test the following sequence of events:


### PR DESCRIPTION
Disabled GCF-437 which relies on InnoDB redo log size limitation
which does not seem to exist or is increased in MariaDB 10.4.

Require debug sync for mysql-wsrep#215.