### PR TITLE
MDEV-18512 using DATETIME(6) as row_start/row_end crashes server

### DIFF
--- a/mysql-test/suite/versioning/r/create.result
+++ b/mysql-test/suite/versioning/r/create.result
@@ -508,5 +508,12 @@ row_end bigint as row end,
 period for system_time (row_start, row_end)
 ) engine=myisam with system versioning;
 ERROR HY000: `row_start` must be of type TIMESTAMP(6) for system-versioned table `t1`
+create table t (
+a int,
+row_start datetime(6) generated always as row start,
+row_end datetime(6) generated always as row end,
+period for system_time(row_start, row_end)
+) with system versioning;
+ERROR HY000: `row_start` must be of type TIMESTAMP(6) for system-versioned table `t`
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/create.test
+++ b/mysql-test/suite/versioning/t/create.test
@@ -387,5 +387,14 @@ create or replace table t1 (
   period for system_time (row_start, row_end)
 ) engine=myisam with system versioning;
 
+--error ER_VERS_FIELD_WRONG_TYPE
+create table t (
+  a int,
+  row_start datetime(6) generated always as row start,
+  row_end datetime(6) generated always as row end,
+  period for system_time(row_start, row_end)
+) with system versioning;
+
+
 drop database test;
 create database test;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7433,8 +7433,7 @@ bool Vers_parse_info::check_conditions(const Lex_table_name &table_name,
 
 static bool is_versioning_timestamp(const Create_field *f)
 {
-  return (f->type_handler() == &type_handler_datetime2 ||
-          f->type_handler() == &type_handler_timestamp2) &&
+  return f->type_handler() == &type_handler_timestamp2 &&
          f->length == MAX_DATETIME_FULL_WIDTH;
 }
 

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -2025,7 +2025,6 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
         switch (field_type)
         {
         case MYSQL_TYPE_TIMESTAMP2:
-        case MYSQL_TYPE_DATETIME2:
           break;
         case MYSQL_TYPE_LONGLONG:
           if (vers_can_native)


### PR DESCRIPTION
Disallow DATETIME for SYSTEM VERSIONING tables.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.3-MDEV-18512-versioning-datetime)
