### PR TITLE
MDEV-12836 Avoid table rebuild when adding or removing of auto_increment settings

### DIFF
--- a/mysql-test/suite/innodb/r/instant_auto_inc.result
+++ b/mysql-test/suite/innodb/r/instant_auto_inc.result
@@ -1,0 +1,21 @@
+create table t(id int primary key, a int) engine=InnoDB;
+insert into t (id, a) values (1, 1);
+alter table t modify column id int auto_increment;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+insert into t (a) values (2);
+alter table t modify column id int, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+insert into t (id, a) values (3, 3);
+select * from t;
+id	a
+1	1
+2	2
+3	3
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+drop table t;

--- a/mysql-test/suite/innodb/t/instant_auto_inc.test
+++ b/mysql-test/suite/innodb/t/instant_auto_inc.test
@@ -1,0 +1,13 @@
+--source include/have_innodb.inc
+
+create table t(id int primary key, a int) engine=InnoDB;
+insert into t (id, a) values (1, 1);
+alter table t modify column id int auto_increment;
+check table t;
+insert into t (a) values (2);
+alter table t modify column id int, algorithm=instant;
+check table t;
+insert into t (id, a) values (3, 3);
+select * from t;
+check table t;
+drop table t;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -3507,7 +3507,7 @@ uint Field_new_decimal::is_equal(Create_field *new_field)
   return ((new_field->type_handler() == type_handler()) &&
           ((new_field->flags & UNSIGNED_FLAG) == 
            (uint) (flags & UNSIGNED_FLAG)) &&
-          ((new_field->flags & AUTO_INCREMENT_FLAG) ==
+          ((new_field->flags & AUTO_INCREMENT_FLAG) <=
            (uint) (flags & AUTO_INCREMENT_FLAG)) &&
           (new_field->length == max_display_length()) &&
           (new_field->decimals == dec));
@@ -9508,7 +9508,7 @@ uint Field_num::is_equal(Create_field *new_field)
   return ((new_field->type_handler() == type_handler()) &&
           ((new_field->flags & UNSIGNED_FLAG) == 
            (uint) (flags & UNSIGNED_FLAG)) &&
-	  ((new_field->flags & AUTO_INCREMENT_FLAG) ==
+	  ((new_field->flags & AUTO_INCREMENT_FLAG) <=
 	   (uint) (flags & AUTO_INCREMENT_FLAG)) &&
           (new_field->pack_length == pack_length()));
 }


### PR DESCRIPTION
I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.3-MDEV-12836-instant-auto-inc)
