### PR TITLE
Fix default_password_lifetime message typo

### DIFF
--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -192,7 +192,7 @@ The following specify which files/extra groups are read (specified before remain
  This defines the global password expiration policy. 0
  means automatic password expiration is disabled. If the
  value is a positive integer N, the passwords must be
- changed every N days. This behavior can be overriden
+ changed every N days. This behavior can be overridden
  using the password expiration options in ALTER USER.
  --default-regex-flags=name 
  Default flags for the regex library. Any combination of: 

--- a/mysql-test/suite/sys_vars/r/sysvars_server_embedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_embedded.result
@@ -719,7 +719,7 @@ GLOBAL_VALUE_ORIGIN	COMPILE-TIME
 DEFAULT_VALUE	0
 VARIABLE_SCOPE	GLOBAL
 VARIABLE_TYPE	INT UNSIGNED
-VARIABLE_COMMENT	This defines the global password expiration policy. 0 means automatic password expiration is disabled. If the value is a positive integer N, the passwords must be changed every N days. This behavior can be overriden using the password expiration options in ALTER USER.
+VARIABLE_COMMENT	This defines the global password expiration policy. 0 means automatic password expiration is disabled. If the value is a positive integer N, the passwords must be changed every N days. This behavior can be overridden using the password expiration options in ALTER USER.
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	4294967295
 NUMERIC_BLOCK_SIZE	1

--- a/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
@@ -733,7 +733,7 @@ GLOBAL_VALUE_ORIGIN	COMPILE-TIME
 DEFAULT_VALUE	0
 VARIABLE_SCOPE	GLOBAL
 VARIABLE_TYPE	INT UNSIGNED
-VARIABLE_COMMENT	This defines the global password expiration policy. 0 means automatic password expiration is disabled. If the value is a positive integer N, the passwords must be changed every N days. This behavior can be overriden using the password expiration options in ALTER USER.
+VARIABLE_COMMENT	This defines the global password expiration policy. 0 means automatic password expiration is disabled. If the value is a positive integer N, the passwords must be changed every N days. This behavior can be overridden using the password expiration options in ALTER USER.
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	4294967295
 NUMERIC_BLOCK_SIZE	1

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1522,7 +1522,7 @@ static Sys_var_uint Sys_default_password_lifetime(
        "This defines the global password expiration policy. 0 means "
        "automatic password expiration is disabled. If the value is a "
        "positive integer N, the passwords must be changed every N days. This "
-       "behavior can be overriden using the password expiration options in "
+       "behavior can be overridden using the password expiration options in "
        "ALTER USER.",
        GLOBAL_VAR(default_password_lifetime), CMD_LINE(REQUIRED_ARG),
        VALID_RANGE(0, UINT_MAX), DEFAULT(0), BLOCK_SIZE(1));


### PR DESCRIPTION
This patch fixes a typo in the server default_password_lifetime sysvar, kindly pointed out by @iangilfillan.