### PR TITLE
MDEV-18631 Fixed streaming replication with wsrep_gtid_mode=ON

### DIFF
--- a/mysql-test/suite/galera_3nodes/galera_2x3nodes.cnf
+++ b/mysql-test/suite/galera_3nodes/galera_2x3nodes.cnf
@@ -22,7 +22,7 @@ wsrep-sync-wait=15
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep-cluster-address='gcomm://'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.1.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.1.port
@@ -34,7 +34,7 @@ wsrep_sst_receive_address='127.0.0.1:@mysqld.1.#sst_port'
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.2.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.2.port
@@ -46,7 +46,7 @@ wsrep_sst_receive_address='127.0.0.1:@mysqld.2.#sst_port'
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.3.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.3.port
@@ -60,7 +60,7 @@ wsrep_cluster_name=cluster2
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep-cluster-address='gcomm://'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.4.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.4.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.4.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.4.port
@@ -73,7 +73,7 @@ wsrep_cluster_name=cluster2
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.4.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.5.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.5.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.5.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.5.port
@@ -86,7 +86,7 @@ wsrep_cluster_name=cluster2
 #sst_port=@OPT.port
 wsrep-on=1
 wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.4.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.6.#galera_port;evs.suspect_timeout=PT300S;evs.inactive_timeout=PT1000M;evs.install_timeout=PT155S;evs.keepalive_period = PT100S'
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.6.#galera_port;evs.suspect_timeout=PT30S;evs.inactive_timeout=PT90S;evs.install_timeout=PT60S;pc.wait_prim_timeout = PT60S'
 
 wsrep_sst_receive_address=127.0.0.2:@mysqld.6.#sst_port
 wsrep_node_incoming_address=127.0.0.1:@mysqld.6.port

--- a/mysql-test/suite/galera_sr/r/mdev_18631.result
+++ b/mysql-test/suite/galera_sr/r/mdev_18631.result
@@ -1,0 +1,21 @@
+connection node_2;
+connection node_1;
+# On node_1
+connection node_1;
+CREATE TABLE t1(f1 INT PRIMARY KEY) ENGINE=INNODB;
+INSERT INTO t1 VALUES (1), (2), (3);
+connection node_2;
+SELECT * FROM  t1;
+f1
+1
+2
+3
+connection node_1;
+SELECT * FROM t1;
+f1
+1
+2
+3
+DROP TABLE t1;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera_sr/t/galera_sr_mysqldump_sst.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_mysqldump_sst.test
@@ -44,7 +44,7 @@ UPDATE t1 SET f2 = REPEAT('y', 255);
 
 --connection node_2
 --echo Starting server ...
---let $start_mysqld_params = --wsrep_sst_auth=sst:sst --wsrep_sst_method=mysqldump --wsrep-sst-receive-address=127.0.0.1:$NODE_MYPORT_2
+--let $restart_parameters = --wsrep_sst_auth=sst:sst --wsrep_sst_method=mysqldump --wsrep-sst-receive-address=127.0.0.1:$NODE_MYPORT_2
 --source include/start_mysqld.inc
 
 --connection node_1

--- a/mysql-test/suite/galera_sr/t/mdev_18631.cnf
+++ b/mysql-test/suite/galera_sr/t/mdev_18631.cnf
@@ -1,0 +1,23 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+log-bin
+log-slave-updates
+log-bin-compress
+
+[mysqld.1]
+#gtid_domain_id=1
+wsrep_gtid_mode=ON
+# Maximum allowed wsrep_gtid_domain_id.
+wsrep_gtid_domain_id=4294967295
+wsrep_trx_fragment_size=1
+wsrep_trx_fragment_unit='ROWS'
+
+[mysqld.2]
+#gtid_domain_id=2
+wsrep_gtid_mode=ON
+wsrep_gtid_domain_id=4294967295
+wsrep_trx_fragment_size=1
+wsrep_trx_fragment_unit='ROWS'
+#wsrep_gitd_domain_id value will be inherited from donor node (mysqld.1)
+#wsrep_gitd_domain_id=X

--- a/mysql-test/suite/galera_sr/t/mdev_18631.test
+++ b/mysql-test/suite/galera_sr/t/mdev_18631.test
@@ -1,0 +1,24 @@
+#
+# Test that streaming replication works with wsrep_gtid_mode=ON.
+# The configuration is provided in mdev_18631.cnf.
+#
+
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--echo # On node_1
+--connection node_1
+CREATE TABLE t1(f1 INT PRIMARY KEY) ENGINE=INNODB;
+
+INSERT INTO t1 VALUES (1), (2), (3);
+
+--connection node_2
+SELECT * FROM  t1;
+
+--connection node_1
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+--source include/galera_end.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7686,7 +7686,7 @@ MYSQL_BIN_LOG::write_transaction_to_binlog_events(group_commit_entry *entry)
 {
   int is_leader= queue_for_group_commit(entry);
 #ifdef WITH_WSREP
-  if (is_leader >= 0 &&
+  if (wsrep_run_commit_hook(entry->thd, true) && is_leader >= 0 &&
       wsrep_ordered_commit(entry->thd, entry->all, wsrep_apply_error()))
     return true;
 #endif /* WITH_WSREP */

--- a/sql/wsrep_high_priority_service.h
+++ b/sql/wsrep_high_priority_service.h
@@ -36,7 +36,7 @@ public:
   int start_transaction(const wsrep::ws_handle&,
                         const wsrep::ws_meta&);
   const wsrep::transaction& transaction() const;
-  void adopt_transaction(const wsrep::transaction&);
+  int adopt_transaction(const wsrep::transaction&);
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&) = 0;
   int append_fragment_and_commit(const wsrep::ws_handle&,
                                  const wsrep::ws_meta&,


### PR DESCRIPTION
This PR reorganizes wsrep commit processing. Now commit hooks are entered from ha_commit_trans(), prepare_or_error() and write_transaction_to_binlog_events() in all wsrep execution modes (local, applying, replaying, storage access).

Additional commit includes stability improvement for galera_3nodes.galera_gtid_2_cluster test and fixes galera_sr.galera_sr_mysqldump_sst test.