### PR TITLE
MDEV-19207: systemd service: add instance name in description

### DIFF
--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -131,7 +131,7 @@
 # systemd.service(5)
 
 [Unit]
-Description=MariaDB @VERSION@ database server (multi-instance)
+Description=MariaDB @VERSION@ database server (multi-instance %I)
 Documentation=man:mysqld(8)
 Documentation=https://mariadb.com/kb/en/library/systemd/
 After=network.target


### PR DESCRIPTION
The unit files made systemd print:

systemd[1]: Started MariaDB 10.3.13 database server (multi-instance).

Let's add the instance name, so starting mariadb@foo.service
makes it print:

systemd[1]: Started MariaDB 10.3.13 database server (multi-instance foo).