### PR TITLE
MDEV-18946: innodb: fix deallocation on innodb pages - during shutdown and resizing innodb_buffer_pool_size

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1571,8 +1571,7 @@ buf_chunk_init(
 
 	DBUG_EXECUTE_IF("ib_buf_chunk_init_fails", return(NULL););
 
-	chunk->mem = buf_pool->allocator.allocate_large(mem_size,
-							&chunk->mem_pfx, true);
+	chunk->mem = buf_pool->allocator.allocate_large_dontdump(mem_size, &chunk->mem_pfx);
 
 	if (UNIV_UNLIKELY(chunk->mem == NULL)) {
 
@@ -1865,9 +1864,8 @@ buf_pool_init_instance(
 							&block->debug_latch));
 					}
 
-					buf_pool->allocator.deallocate_large(
-						chunk->mem, &chunk->mem_pfx, chunk->mem_size(),
-						true);
+					buf_pool->allocator.deallocate_large_dodump(
+						chunk->mem, &chunk->mem_pfx, chunk->mem_size());
 				}
 				ut_free(buf_pool->chunks);
 				buf_pool_mutex_exit(buf_pool);
@@ -2014,8 +2012,8 @@ buf_pool_free_instance(
 			ut_d(rw_lock_free(&block->debug_latch));
 		}
 
-		buf_pool->allocator.deallocate_large(
-			chunk->mem, &chunk->mem_pfx, chunk->mem_size(), true);
+		buf_pool->allocator.deallocate_large_dodump(
+			chunk->mem, &chunk->mem_pfx, chunk->mem_size());
 	}
 
 	for (ulint i = BUF_FLUSH_LRU; i < BUF_FLUSH_N_TYPES; ++i) {
@@ -2892,8 +2890,8 @@ withdraw_retry:
 						&block->debug_latch));
 				}
 
-				buf_pool->allocator.deallocate_large(
-					chunk->mem, &chunk->mem_pfx, chunk->mem_size(), true);
+				buf_pool->allocator.deallocate_large_dodump(
+					chunk->mem, &chunk->mem_pfx, chunk->mem_size());
 
 				sum_freed += chunk->size;
 

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2015,7 +2015,7 @@ buf_pool_free_instance(
 		}
 
 		buf_pool->allocator.deallocate_large(
-			chunk->mem, &chunk->mem_pfx, true);
+			chunk->mem, &chunk->mem_pfx, chunk->mem_size(), true);
 	}
 
 	for (ulint i = BUF_FLUSH_LRU; i < BUF_FLUSH_N_TYPES; ++i) {
@@ -2893,7 +2893,7 @@ withdraw_retry:
 				}
 
 				buf_pool->allocator.deallocate_large(
-					chunk->mem, &chunk->mem_pfx, true);
+					chunk->mem, &chunk->mem_pfx, chunk->mem_size(), true);
 
 				sum_freed += chunk->size;
 

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -654,13 +654,18 @@ public:
 		return(ptr);
 	}
 
+	pointer
+	allocate_large_dontdump(
+		size_type	n_elements,
+		ut_new_pfx_t*	pfx)
+	{
+		return allocate_large(n_elements, pfx, true);
+	}
 	/** Free a memory allocated by allocate_large() and trace the
 	deallocation.
 	@param[in,out]	ptr	pointer to memory to free
 	@param[in]	pfx	descriptor of the memory, as returned by
-	allocate_large().
-	@param[in]      dodump  if true, advise the OS to include this
-	memory again if a core dump occurs. */
+	allocate_large(). */
 	void
 	deallocate_large(
 		pointer			ptr,
@@ -669,12 +674,8 @@ public:
 		pfx
 #endif
 		,
-		size_t			size,
-		bool			dodump = false)
+		size_t			size)
 	{
-		if (dodump) {
-			ut_dodump(ptr, size);
-		}
 #ifdef UNIV_PFS_MEMORY
 		if (pfx) {
 			deallocate_trace(pfx);
@@ -684,8 +685,27 @@ public:
 		os_mem_free_large(ptr, size);
 	}
 
+	void
+	deallocate_large_dodump(
+		pointer			ptr,
+		const ut_new_pfx_t*
 #ifdef UNIV_PFS_MEMORY
+		pfx
+#endif
+		,
+		size_t			size)
+	{
+		ut_dodump(ptr, size);
+		deallocate_large(ptr,
+#ifdef UNIV_PFS_MEMORY
+		pfx,
+#else
+		NULL,
+#endif
+		size);
+	}
 
+#ifdef UNIV_PFS_MEMORY
 	/** Get the performance schema key to use for tracing allocations.
 	@param[in]	file	file name of the caller or NULL if unknown
 	@return performance schema key */


### PR DESCRIPTION
Fixed a bug I added in MDEV-10814 where a missing argument cased a later optional argument, true to be treated as the size.

While the first commit is the the minimal required fix, and the second commit cleans up the API so its harder to make the same mistake.

Mega culpa.

I submit this under the MCA.