### PR TITLE
post-RC app-periods fixes

### DIFF
--- a/mysql-test/main/features.result
+++ b/mysql-test/main/features.result
@@ -3,6 +3,7 @@ set sql_mode="";
 flush status;
 show status like "feature%";
 Variable_name	Value
+Feature_application_time_periods	0
 Feature_check_constraint	0
 Feature_custom_aggregate_functions	0
 Feature_delay_key_write	0

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -200,6 +200,7 @@ my @DEFAULT_SUITES= qw(
     unit-
     vcol-
     versioning-
+    period-
   );
 my $opt_suites;
 

--- a/mysql-test/suite/period/r/create.result
+++ b/mysql-test/suite/period/r/create.result
@@ -93,4 +93,7 @@ t	CREATE TABLE `t` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 insert t values (2, '2001-01-01', '2001-01-01');
 ERROR 23000: CONSTRAINT `mytime_1` failed for `test`.`t`
+show status like "Feature_application_time_periods";
+Variable_name	Value
+Feature_application_time_periods	6
 create or replace database test;

--- a/mysql-test/suite/period/r/delete.result
+++ b/mysql-test/suite/period/r/delete.result
@@ -291,7 +291,7 @@ ERROR 42S02: 'v' is a view
 # View can't be used
 create or replace view v as select t.* from t, t as t1;
 delete from v for portion of p from '2000-01-01' to '2018-01-01';
-ERROR 42S02: 'v' is a view
+ERROR HY000: Can not delete from join view 'test.v'
 # auto_increment field overflow
 create or replace table t (id tinyint auto_increment primary key,
 s date, e date, period for apptime(s,e));

--- a/mysql-test/suite/period/t/create.test
+++ b/mysql-test/suite/period/t/create.test
@@ -77,4 +77,6 @@ show create table t;
 --error ER_CONSTRAINT_FAILED
 insert t values (2, '2001-01-01', '2001-01-01');
 
+show status like "Feature_application_time_periods";
+
 create or replace database test;

--- a/mysql-test/suite/period/t/delete.test
+++ b/mysql-test/suite/period/t/delete.test
@@ -133,7 +133,7 @@ delete from v for portion of p from '2000-01-01' to '2018-01-01';
 
 --echo # View can't be used
 create or replace view v as select t.* from t, t as t1;
---error ER_IT_IS_A_VIEW
+--error ER_VIEW_DELETE_MERGE_VIEW
 delete from v for portion of p from '2000-01-01' to '2018-01-01';
 
 --echo # auto_increment field overflow

--- a/mysql-test/suite/period/t/delete.test
+++ b/mysql-test/suite/period/t/delete.test
@@ -1,4 +1,5 @@
 source suite/period/engines.inc;
+source include/have_log_bin.inc
 
 create or replace table t (id int, s date, e date, period for apptime(s,e));
 

--- a/mysql-test/suite/period/t/update.test
+++ b/mysql-test/suite/period/t/update.test
@@ -1,4 +1,5 @@
 source suite/period/engines.inc;
+source include/have_log_bin.inc
 
 create or replace table t (id int, s date, e date, period for apptime(s,e));
 
@@ -149,5 +150,11 @@ select * from t;
 update t for portion of apptime from '2000-01-01' to '2018-01-01' set x= x + 5;
 --sorted_result
 select *, xs=s and xe=e from t;
+
+--echo # MDEV-18921 Server crashes in bitmap_bits_set or bitmap_is_set upon
+--echo # UPDATE IGNORE .. FOR PORTION with binary logging
+create or replace table t1 (f int, s date, e date, period for app(s,e));
+insert into t1 values (1,'2016-09-21','2019-06-14');
+update ignore t1 for portion of app from '2019-03-13' to '2019-03-14' set f = 1;
 
 create or replace database test;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -7666,6 +7666,7 @@ SHOW_VAR status_vars[]= {
   {"Feature_locale",           (char*) offsetof(STATUS_VAR, feature_locale), SHOW_LONG_STATUS},
   {"Feature_subquery",         (char*) offsetof(STATUS_VAR, feature_subquery), SHOW_LONG_STATUS},
   {"Feature_system_versioning",   (char*) offsetof(STATUS_VAR, feature_system_versioning), SHOW_LONG_STATUS},
+  {"Feature_application_time_periods", (char*) offsetof(STATUS_VAR, feature_application_time_periods), SHOW_LONG_STATUS},
   {"Feature_timezone",         (char*) offsetof(STATUS_VAR, feature_timezone), SHOW_LONG_STATUS},
   {"Feature_trigger",          (char*) offsetof(STATUS_VAR, feature_trigger), SHOW_LONG_STATUS},
   {"Feature_window_functions", (char*) offsetof(STATUS_VAR, feature_window_functions), SHOW_LONG_STATUS},

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -861,6 +861,8 @@ typedef struct system_status_var
   ulong feature_locale;		    /* +1 when LOCALE is set */
   ulong feature_subquery;	    /* +1 when subqueries are used */
   ulong feature_system_versioning;  /* +1 opening a table WITH SYSTEM VERSIONING */
+  ulong feature_application_time_periods;
+                                    /* +1 opening a table with application-time period */
   ulong feature_timezone;	    /* +1 when XPATH is used */
   ulong feature_trigger;	    /* +1 opening a table with triggers */
   ulong feature_xml;		    /* +1 when XPATH is used */

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -718,9 +718,14 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
     goto got_error;
 
   if (table_list->has_period())
+  {
     table->use_all_columns();
+    table->rpl_write_set= table->write_set;
+  }
   else
+  {
     table->mark_columns_needed_for_delete();
+  }
 
   if ((table->file->ha_table_flags() & HA_CAN_FORCE_BULK_DELETE) &&
       !table->prepare_triggers_for_delete_stmt_or_event())

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -380,18 +380,6 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
       table_list->on_expr= NULL;
     }
   }
-  if (table_list->has_period())
-  {
-    if (table_list->is_view_or_derived())
-    {
-      my_error(ER_IT_IS_A_VIEW, MYF(0), table_list->table_name.str);
-      DBUG_RETURN(true);
-    }
-
-    conds= select_lex->period_setup_conds(thd, table_list, conds);
-    if (!conds)
-      DBUG_RETURN(true);
-  }
 
   if (thd->lex->handle_list_of_derived(table_list, DT_MERGE_FOR_INSERT))
     DBUG_RETURN(TRUE);
@@ -1055,6 +1043,20 @@ int mysql_prepare_delete(THD *thd, TABLE_LIST *table_list,
     if (select_lex->vers_setup_conds(thd, table_list))
       DBUG_RETURN(true);
   }
+
+  if (table_list->has_period())
+  {
+    if (table_list->is_view_or_derived())
+    {
+      my_error(ER_IT_IS_A_VIEW, MYF(0), table_list->table_name.str);
+      DBUG_RETURN(true);
+    }
+
+    *conds= select_lex->period_setup_conds(thd, table_list, *conds);
+    if (!*conds)
+      DBUG_RETURN(true);
+  }
+
   if ((wild_num && setup_wild(thd, table_list, field_list, NULL, wild_num,
                               &select_lex->hidden_bit_fields)) ||
       setup_fields(thd, Ref_ptr_array(),

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -433,6 +433,16 @@ int mysql_update(THD *thd,
   if (mysql_prepare_update(thd, table_list, &conds, order_num, order))
     DBUG_RETURN(1);
 
+  if (table_list->has_period())
+  {
+    if (!table_list->period_conditions.start.item->const_item()
+        || !table_list->period_conditions.end.item->const_item())
+    {
+      my_error(ER_NOT_CONSTANT_EXPRESSION, MYF(0), "FOR PORTION OF");
+      DBUG_RETURN(true);
+    }
+  }
+
   old_covering_keys= table->covering_keys;		// Keys used in WHERE
   /* Check the fields we are going to modify */
 #ifndef NO_EMBEDDED_ACCESS_CHECKS
@@ -1366,15 +1376,6 @@ bool mysql_prepare_update(THD *thd, TABLE_LIST *table_list,
       setup_ftfuncs(select_lex))
     DBUG_RETURN(TRUE);
 
-  if (table_list->has_period())
-  {
-    if (!table_list->period_conditions.start.item->const_item()
-        || !table_list->period_conditions.end.item->const_item())
-    {
-      my_error(ER_NOT_CONSTANT_EXPRESSION, MYF(0), "FOR PORTION OF");
-      DBUG_RETURN(true);
-    }
-  }
 
   select_lex->fix_prepare_information(thd, conds, &fake_conds);
   DBUG_RETURN(FALSE);
@@ -1664,6 +1665,17 @@ int mysql_multi_update_prepare(THD *thd)
 
   if (mysql_handle_derived(lex, DT_PREPARE))
     DBUG_RETURN(TRUE);
+
+  if (table_list->has_period())
+  {
+    /*
+      Multi-table update is not supported on syntax lexel. However it's possible
+      to get here through PREPARE with update of multi-table view.
+     */
+    DBUG_ASSERT(table_list->is_view_or_derived());
+    my_error(ER_IT_IS_A_VIEW, MYF(0), table_list->table_name.str);
+    DBUG_RETURN(TRUE);
+  }
 
   if (setup_tables_and_check_access(thd,
                                     &lex->first_select_lex()->context,

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -568,9 +568,14 @@ int mysql_update(THD *thd,
     goto err;
 
   if (table_list->has_period())
+  {
     table->use_all_columns();
+    table->rpl_write_set= table->write_set;
+  }
   else
+  {
     table->mark_columns_needed_for_update();
+  }
 
   table->update_const_key_parts(conds);
   order= simple_remove_const(order, conds);

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -2104,6 +2104,7 @@ int TABLE_SHARE::init_from_binary_frm_image(THD *thd, bool write,
 
     if (init_period_from_extra2(&period, pos, end))
       goto err;
+    status_var_increment(thd->status_var.feature_application_time_periods);
   }
 
   for (i=0 ; i < share->fields; i++, strpos+=field_pack_length, field_ptr++)


### PR DESCRIPTION
Here are three commits, fixing four bugs. They're quite small, so have put it in one PR.

In short:
* MDEV-18853 Assertion `0' failed in Protocol::end_statement upon DELETE .. FOR PORTION via prepared statement
  Query arena was not taken into account
* MDEV-18852 Server crashes in reinit_stmt_before_use upon UPDATE .. FOR PORTION via prepared statement
  Additionally fix incorrect `DBUG_RETURN(NULL)` in `period_setup_conds`;
* MDEV-18859 Server crashes in bitmap_bits_set / pack_row / THD::binlog_write_row upon DELETE .. FOR PORTION with binary logging
  `table->rpl_write_set` was NULL
* MDEV-18921 Server crashes in bitmap_bits_set or bitmap_is_set upon UPDATE IGNORE .. FOR PORTION with binary logging
  Same as previous one