### PR TITLE
travis: use galera-4 in 10.4 branch

### DIFF
--- a/.travis.compiler.sh
+++ b/.travis.compiler.sh
@@ -38,10 +38,7 @@ if [[ "${TRAVIS_OS_NAME}" == 'linux' ]]; then
     export CC=gcc-${CC_VERSION}
   fi
   if [[ ${CC_VERSION} == 7 ]]; then
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/p/percona-xtradb-cluster-galera-2.x/percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb ;
-    ar vx percona-xtradb-cluster-galera-2.x_165-0ubuntu1_amd64.deb
-    tar -xJvf data.tar.xz
-    export WSREP_PROVIDER=$PWD/usr/lib/libgalera_smm.so
+    export WSREP_PROVIDER=/usr/lib/galera/libgalera_smm.so
     MYSQL_TEST_SUITES="${MYSQL_TEST_SUITES},wsrep"
   fi
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,8 @@ addons:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-xenial-6.0
       - llvm-toolchain-xenial-7
+      - sourceline: 'deb [arch=amd64,arm64,i386,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.4/ubuntu xenial main'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?search=0xF1656F24C74CD1D8&op=get'
     packages: # make sure these include all compilers and all build dependencies (see list above)
       - gcc-6
       - g++-6
@@ -135,6 +137,7 @@ addons:
       - chrpath
       - cmake
       - gdb
+      - galera-4
       - libaio-dev
       - libboost-dev
       - libcurl3-dev


### PR DESCRIPTION
Fix travis galera tests on 10.4 branch by using galera-4 rather than 3.

success: https://travis-ci.org/grooverdan/mariadb-server/jobs/506052887 (in lieu of waiting)

I submit this under the MCA.