### PR TITLE
MDEV-18666 Fix MTR test galera_sr_kill_all_norecovery

### DIFF
--- a/mysql-test/suite/galera_sr/r/galera_sr_kill_all_norecovery.result
+++ b/mysql-test/suite/galera_sr/r/galera_sr_kill_all_norecovery.result
@@ -12,21 +12,22 @@ INSERT INTO t1 VALUES (3);
 INSERT INTO t1 VALUES (4);
 INSERT INTO t1 VALUES (5);
 connection node_2;
+connection node_2;
 Killing server ...
 connection node_1;
+SET SESSION wsrep_sync_wait = 0;
 Killing server ...
-connection node_1;
 connection node_2;
 connection node_1;
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
-COUNT(*) = 0
-1
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
 connection node_2;
 SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-SELECT COUNT(*) = 0 FROM t1;
-COUNT(*) = 0
-1
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
-COUNT(*) = 0
-1
+SELECT COUNT(*) `expect 0` FROM t1;
+expect 0
+0
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
+expect 0
+0
 DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/galera_sr_kill_all_norecovery.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_kill_all_norecovery.test
@@ -26,13 +26,17 @@ INSERT INTO t1 VALUES (5);
 --let $wait_condition = SELECT COUNT(*) > 0 FROM mysql.wsrep_streaming_log;
 --source include/wait_condition.inc
 
---source include/kill_galera.inc
---connection node_1
+
+#
+# Kill the entire cluster and restart
+#
+--connection node_2
 --source include/kill_galera.inc
 
---sleep 1
-
 --connection node_1
+SET SESSION wsrep_sync_wait = 0;
+--source include/kill_galera.inc
+
 --remove_file $MYSQLTEST_VARDIR/mysqld.1/data/grastate.dat
 --let $start_mysqld_params = "--wsrep-new-cluster"
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
@@ -43,18 +47,25 @@ INSERT INTO t1 VALUES (5);
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --source include/start_mysqld.inc
 
+
+#
+# Check that wsrep_streaming_log is empty
+#
 --connection node_1
 --source include/wait_until_connected_again.inc
 --source include/galera_wait_ready.inc
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
 
 --connection node_2
 SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
-SELECT COUNT(*) = 0 FROM t1;
-SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) `expect 0` FROM t1;
+SELECT COUNT(*) `expect 0` FROM mysql.wsrep_streaming_log;
 
+
+#
+# Cleanup
+#
 --source ../../galera/include/auto_increment_offset_restore.inc
-
 DROP TABLE t1;


### PR DESCRIPTION
* Disable `wsrep_sync_wait` before killing galera node which may be
  non-primary (kill_galera.inc causes lock wait timeouts  due to
  wsrep_sync_wait)

* Remove unnecessary `--sleep 1`

* Replace ```SELECT COUNT(*) = 0 ...``` with
  ```SELECT COUNT(*) `expect 0` ...```