### PR TITLE
MDEV-17702 fix unaligned access UB in sint4korr() and similar functions

### DIFF
--- a/include/byte_order_generic_x86_64.h
+++ b/include/byte_order_generic_x86_64.h
@@ -17,65 +17,88 @@
   Optimized function-like macros for the x86 architecture (_WIN32 included).
 */
 
-#define sint2korr(A)	(int16) (*((int16 *) (A)))
-#define sint3korr(A)	((int32) ((((uchar) (A)[2]) & 128) ? \
-				  (((uint32) 255L << 24) | \
-				   (((uint32) (uchar) (A)[2]) << 16) |\
-				   (((uint32) (uchar) (A)[1]) << 8) | \
-				   ((uint32) (uchar) (A)[0])) : \
-				  (((uint32) (uchar) (A)[2]) << 16) |\
-				  (((uint32) (uchar) (A)[1]) << 8) | \
-				  ((uint32) (uchar) (A)[0])))
-#define sint4korr(A)	(int32)  (*((int32 *) (A)))
-#define uint2korr(A)	(uint16) (*((uint16 *) (A)))
-#define uint3korr(A)	(uint32) (((uint32) ((uchar) (A)[0])) +\
-				  (((uint32) ((uchar) (A)[1])) << 8) +\
-				  (((uint32) ((uchar) (A)[2])) << 16))
-#define uint4korr(A)	(uint32) (*((uint32 *) (A)))
+#include <string.h>
 
-
-static inline ulonglong uint5korr(const void *p)
+inline static int16 sint2korr(const void *p)
 {
-  ulonglong a= *(uint32 *) p;
-  ulonglong b= *(4 + (uchar *) p);
-  return a | (b << 32);
-}
-static inline ulonglong uint6korr(const void *p)
-{
-  ulonglong a= *(uint32 *) p;
-  ulonglong b= *(uint16 *) (4 + (char *) p);
-  return a | (b << 32);
+  int16 result= 0;
+  memcpy(&result, p, 2);
+  return result;
 }
 
-#define uint8korr(A)	(ulonglong) (*((ulonglong *) (A)))
-#define sint8korr(A)	(longlong) (*((longlong *) (A)))
+inline static int32 sint3korr(const void *p)
+{
+  int32 result= 0;
+  const char *ptr= (const char *) p;
+  result= ptr[2];
+  result<<= 16;
+  memcpy(&result, ptr, 2);
+  return result;
+}
 
-#define int2store(T,A)	do { uchar *pT= (uchar*)(T);\
-                             *((uint16*)(pT))= (uint16) (A);\
-                        } while (0)
-  
-#define int3store(T,A)  do { *(T)=  (uchar) ((A));\
-                            *(T+1)=(uchar) (((uint) (A) >> 8));\
-                            *(T+2)=(uchar) (((A) >> 16));\
-                        } while (0)
+inline static int32 sint4korr(const void *p)
+{
+  int32 result= 0;
+  memcpy(&result, p, 4);
+  return result;
+}
 
-#define int4store(T,A)	do { uchar *pT= (uchar*)(T);\
-                             *((uint32 *) (pT))= (uint32) (A); \
-                        } while (0)
+inline static uint16 uint2korr(const void *p)
+{
+  uint16 result= 0;
+  memcpy(&result, p, 2);
+  return result;
+}
 
-#define int5store(T,A)  do { uchar *pT= (uchar*)(T);\
-                             *((uint32 *) (pT))= (uint32) (A); \
-                             *((pT)+4)=(uchar) (((A) >> 32));\
-                        } while (0)
+inline static uint32 uint3korr(const void *p)
+{
+  uint32 result= 0;
+  memcpy(&result, p, 3);
+  return result;
+}
 
-#define int6store(T,A)  do { uchar *pT= (uchar*)(T);\
-                             *((uint32 *) (pT))= (uint32) (A); \
-                             *((uint16*)(pT+4))= (uint16) (A >> 32);\
-                        } while (0)
+inline static uint32 uint4korr(const void *p)
+{
+  uint32 result= 0;
+  memcpy(&result, p, 4);
+  return result;
+}
 
-#define int8store(T,A)	do { uchar *pT= (uchar*)(T);\
-                             *((ulonglong *) (pT))= (ulonglong) (A);\
-                        } while(0)
+inline static ulonglong uint5korr(const void *p)
+{
+  ulonglong result= 0;
+  memcpy(&result, p, 5);
+  return result;
+}
+
+inline static ulonglong uint6korr(const void *p)
+{
+  ulonglong result= 0;
+  memcpy(&result, p, 6);
+  return result;
+}
+
+inline static ulonglong uint8korr(const void *p)
+{
+  ulonglong result= 0;
+  memcpy(&result, p, 8);
+  return result;
+}
+
+inline static longlong sint8korr(const void *p)
+{
+  longlong result= 0;
+  memcpy(&result, p, 8);
+  return result;
+}
+
+inline static void int2store(void *p, const int16 n) { memcpy(p, &n, 2); }
+inline static void int3store(void *p, const int32 n) { memcpy(p, &n, 3); }
+inline static void int4store(void *p, const int32 n) { memcpy(p, &n, 4); }
+inline static void int5store(void *p, const longlong n) { memcpy(p, &n, 5); }
+inline static void int6store(void *p, const longlong n) { memcpy(p, &n, 6); }
+inline static void int8store(void *p, const longlong n) { memcpy(p, &n, 8); }
+
 
 #if defined(__GNUC__)
 
@@ -88,35 +111,31 @@ static inline ulonglong uint6korr(const void *p)
 
 static inline ulonglong mi_uint5korr(const void *p)
 {
-  ulonglong a= *(uint32 *) p;
-  ulonglong b= *(4 + (uchar *) p);
-  ulonglong v= (a | (b << 32)) << 24;
+  ulonglong v= 0;
+  memcpy((uchar *) &v + 3, p, 5);
   asm ("bswapq %0" : "=r" (v) : "0" (v));
   return v;
 }
 
 static inline ulonglong mi_uint6korr(const void *p)
 {
-  ulonglong a= *(uint32 *) p;
-  ulonglong b= *(uint16 *) (4 + (char *) p);
-  ulonglong v= (a | (b << 32)) << 16;
+  ulonglong v= 0;
+  memcpy((uchar *) &v + 2, p, 6);
   asm ("bswapq %0" : "=r" (v) : "0" (v));
   return v;
 }
 
 static inline ulonglong mi_uint7korr(const void *p)
 {
-  ulonglong a= *(uint32 *) p;
-  ulonglong b= *(uint16 *) (4 + (char *) p);
-  ulonglong c= *(6 + (uchar *) p);
-  ulonglong v= (a | (b << 32) | (c << 48)) << 8;
+  ulonglong v= 0;
+  memcpy((uchar *) &v + 1, p, 7);
   asm ("bswapq %0" : "=r" (v) : "0" (v));
   return v;
 }
 
 static inline ulonglong mi_uint8korr(const void *p)
 {
-  ulonglong v= *(ulonglong *) p;
+  ulonglong v= uint8korr(p);
   asm ("bswapq %0" : "=r" (v) : "0" (v));
   return v;
 }

--- a/sql/gcalc_tools.cc
+++ b/sql/gcalc_tools.cc
@@ -124,7 +124,7 @@ int Gcalc_function::alloc_states()
 }
 
 
-int Gcalc_function::count_internal(const char *cur_func, uint set_type,
+int Gcalc_function::count_internal(char *cur_func, uint set_type,
                                    const char **end)
 {
   uint c_op= uint4korr(cur_func);
@@ -134,7 +134,7 @@ int Gcalc_function::count_internal(const char *cur_func, uint set_type,
   uint n_shape= c_op & ~(op_any | op_not | v_mask); /* same as n_ops */
   value v_state= (value) (c_op & v_mask);
   int result= 0;
-  const char *sav_cur_func= cur_func;
+  char *sav_cur_func= cur_func;
 
   // GCALC_DBUG_ENTER("Gcalc_function::count_internal");
 
@@ -161,14 +161,14 @@ int Gcalc_function::count_internal(const char *cur_func, uint set_type,
 
   if (next_func == op_border || next_func == op_internals)
   {
-    result= count_internal(cur_func,
-        (set_type == 1) ? set_type : next_func, &cur_func);
+    result= count_internal(cur_func, (set_type == 1) ? set_type : next_func,
+                           const_cast<const char **>(&cur_func));
     goto exit;
   }
 
   if (next_func == op_repeat)
   {
-    result= count_internal(function_buffer.ptr() + n_ops, set_type, 0);
+    result= count_internal(&function_buffer[0] + n_ops, set_type, 0);
     goto exit;
   }
 
@@ -176,11 +176,13 @@ int Gcalc_function::count_internal(const char *cur_func, uint set_type,
     return mask;
     //GCALC_DBUG_RETURN(mask);
 
-  result= count_internal(cur_func, set_type, &cur_func);
+  result=
+      count_internal(cur_func, set_type, const_cast<const char **>(&cur_func));
 
   while (--n_ops)
   {
-    int next_res= count_internal(cur_func, set_type, &cur_func);
+    int next_res= count_internal(cur_func, set_type,
+                                 const_cast<const char **>(&cur_func));
     switch (next_func)
     {
       case op_union:

--- a/sql/gcalc_tools.h
+++ b/sql/gcalc_tools.h
@@ -49,8 +49,8 @@ private:
   int *b_states;
   uint32 cur_object_id;
   uint n_shapes;
-  int count_internal(const char *cur_func, uint set_type,
-                     const char **end);
+  int count_internal(char *cur_func, uint set_type, const char **end);
+
 public:
   enum value
   {
@@ -121,9 +121,9 @@ public:
   int get_i_state(gcalc_shape_info shape) { return i_states[shape]; }
   int get_b_state(gcalc_shape_info shape) { return b_states[shape]; }
   int count()
-    { return count_internal(function_buffer.ptr(), 0, 0); }
+    { return count_internal(&function_buffer[0], 0, 0); }
   int count_last()
-    { return count_internal(function_buffer.ptr(), 1, 0); }
+    { return count_internal(&function_buffer[0], 1, 0); }
   void clear_i_states();
   void clear_b_states();
   void reset();

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -411,7 +411,7 @@ inline void fix_checksum(String *packet, ulong ev_offset)
               BINLOG_CHECKSUM_ALG_DESC_LEN + BINLOG_CHECKSUM_LEN);
   crc= my_checksum(0, (uchar *)packet->ptr() + ev_offset, data_len -
                    BINLOG_CHECKSUM_LEN);
-  int4store(packet->ptr() + ev_offset + data_len - BINLOG_CHECKSUM_LEN, crc);
+  int4store(&(*packet)[0] + ev_offset + data_len - BINLOG_CHECKSUM_LEN, crc);
 }
 
 

--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -557,7 +557,7 @@ static bool pack_expression(String *buf, Virtual_column_info *vcol,
     my_error(ER_EXPRESSION_IS_TOO_BIG, MYF(0), vcol_type_name(type));
     return 1;
   }
-  int2store(buf->ptr() + len_off, expr_len);
+  int2store(&(*buf)[0] + len_off, expr_len);
   return 0;
 }
 

--- a/storage/maria/ma_blockrec.c
+++ b/storage/maria/ma_blockrec.c
@@ -5745,7 +5745,7 @@ static size_t fill_insert_undo_parts(MARIA_HA *info, const uchar *record,
     /* Store length of all not empty char, varchar and blob fields */
     log_parts->str= field_lengths - 2;
     log_parts->length=   info->cur_row.field_lengths_length+2;
-    int2store(log_parts->str, info->cur_row.field_lengths_length);
+    int2store((void *) log_parts->str, info->cur_row.field_lengths_length);
     row_length+= log_parts->length;
     log_parts++;
   }


### PR DESCRIPTION
use memcpy() as a proper way for type punning

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10-2-MDEV-17702-korr)
