### PR TITLE
Fix deadlock in binlog heavy scenario

### DIFF
--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -4218,10 +4218,10 @@ bool show_binlogs(THD* thd)
                             Protocol::SEND_NUM_ROWS | Protocol::SEND_EOF))
     DBUG_RETURN(TRUE);
   
-  mysql_mutex_lock(mysql_bin_log.get_log_lock());
   mysql_bin_log.lock_index();
   index_file=mysql_bin_log.get_index_file();
-  
+
+  mysql_mutex_lock(mysql_bin_log.get_log_lock());
   mysql_bin_log.raw_get_current_log(&cur); // dont take mutex
   mysql_mutex_unlock(mysql_bin_log.get_log_lock()); // lockdep, OK
   


### PR DESCRIPTION
involves three connection handling threads:
- Thread1 ran "PURGE BINARY LOGS BEFORE ..."
- Thread2 ran "SHOW BINARY LOGS"
- Thread3 ran "SHOW VARIABLES"

There are three locks involved in three threads:
thread1: LOCK_index, thread3_thd->LOCK_thd_data 
thread2: LOCK_log, LOCK_index
thread3: thread3_thd->LOCK_thd_data, LOCK_log

This causes deadlock. The fix is changing thread2 lock order to lock index first then log. So three locks will follow the order:
Lock_Index
thd->LOCK_thd_data
Lock_LOG