### PR TITLE
MDEV-18875 MDEV-18865: trxid versioning fixes

### DIFF
--- a/mysql-test/suite/versioning/r/trx_id.result
+++ b/mysql-test/suite/versioning/r/trx_id.result
@@ -490,4 +490,13 @@ add column row_end bigint unsigned as row end,
 add period for system_time(row_start,row_end),
 with system versioning;
 set autocommit= 1;
+# MDEV-18865 Assertion `t->first->versioned_by_id()'
+# failed in innodb_prepare_commit_versioned
+create or replace table t (x int) engine=innodb;
+insert into t values (0);
+alter table t add `row_start` bigint unsigned as row start,
+add `row_end` bigint unsigned as row end,
+add period for system_time(`row_start`,`row_end`),
+modify x int after row_start,
+with system versioning;
 create or replace database test;

--- a/mysql-test/suite/versioning/r/trx_id.result
+++ b/mysql-test/suite/versioning/r/trx_id.result
@@ -478,3 +478,16 @@ SET @@SYSTEM_VERSIONING_ALTER_HISTORY=ERROR;
 SELECT count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
 count(*)
 0
+# MDEV-18875 Assertion `thd->transaction.stmt.ha_list == __null ||
+# trans == &thd->transaction.stmt' failed or bogus ER_DUP_ENTRY upon
+# ALTER TABLE with versioning
+create or replace table t (x int) engine=innodb;
+set autocommit= 0;
+alter table t
+algorithm=copy,
+add column row_start bigint unsigned as row start,
+add column row_end bigint unsigned as row end,
+add period for system_time(row_start,row_end),
+with system versioning;
+set autocommit= 1;
+create or replace database test;

--- a/mysql-test/suite/versioning/t/trx_id.test
+++ b/mysql-test/suite/versioning/t/trx_id.test
@@ -494,3 +494,18 @@ DROP TABLE t;
 SET @@SYSTEM_VERSIONING_ALTER_HISTORY=ERROR;
 
 SELECT count(*) from mysql.transaction_registry where begin_timestamp>=commit_timestamp;
+
+--echo # MDEV-18875 Assertion `thd->transaction.stmt.ha_list == __null ||
+--echo # trans == &thd->transaction.stmt' failed or bogus ER_DUP_ENTRY upon
+--echo # ALTER TABLE with versioning
+create or replace table t (x int) engine=innodb;
+set autocommit= 0;
+alter table t
+  algorithm=copy,
+  add column row_start bigint unsigned as row start,
+  add column row_end bigint unsigned as row end,
+  add period for system_time(row_start,row_end),
+  with system versioning;
+set autocommit= 1;
+
+create or replace database test;

--- a/mysql-test/suite/versioning/t/trx_id.test
+++ b/mysql-test/suite/versioning/t/trx_id.test
@@ -508,4 +508,16 @@ alter table t
   with system versioning;
 set autocommit= 1;
 
+--echo # MDEV-18865 Assertion `t->first->versioned_by_id()'
+--echo # failed in innodb_prepare_commit_versioned
+
+create or replace table t (x int) engine=innodb;
+insert into t values (0);
+alter table t add `row_start` bigint unsigned as row start,
+              add `row_end` bigint unsigned as row end,
+              add period for system_time(`row_start`,`row_end`),
+              modify x int after row_start,
+              with system versioning;
+
+
 create or replace database test;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1420,7 +1420,8 @@ int ha_commit_trans(THD *thd, bool all)
 
 #if 1 // FIXME: This should be done in ha_prepare().
   if (rw_trans || (thd->lex->sql_command == SQLCOM_ALTER_TABLE &&
-                   thd->lex->alter_info.flags & ALTER_ADD_SYSTEM_VERSIONING))
+                   thd->lex->alter_info.flags & ALTER_ADD_SYSTEM_VERSIONING &&
+                   is_real_trans))
   {
     ulonglong trx_start_id= 0, trx_end_id= 0;
     for (Ha_trx_info *ha_info= trans->ha_list; ha_info; ha_info= ha_info->next())

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -10948,7 +10948,8 @@ create_table_info_t::create_table_def()
 
 	heap = mem_heap_create(1000);
 
-    bool have_vers_start = false, have_vers_end = false;
+	ut_d(bool have_vers_start = false);
+	ut_d(bool have_vers_end = false);
 
 	for (ulint i = 0; i < n_cols; i++) {
 		Field*	field = m_form->field[i];
@@ -10957,10 +10958,10 @@ create_table_info_t::create_table_def()
 		if (m_form->versioned()) {
 			if (i == m_form->s->row_start_field) {
 				vers_row = DATA_VERS_START;
-				have_vers_start = true;
+				ut_d(have_vers_start = true);
 			} else if (i == m_form->s->row_end_field) {
 				vers_row = DATA_VERS_END;
-				have_vers_end = true;
+				ut_d(have_vers_end = true);
 			} else if (!(field->flags
 				     & VERS_UPDATE_UNVERSIONED_FLAG)) {
 				vers_row = DATA_VERSIONED;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -10948,6 +10948,8 @@ create_table_info_t::create_table_def()
 
 	heap = mem_heap_create(1000);
 
+    bool have_vers_start = false, have_vers_end = false;
+
 	for (ulint i = 0; i < n_cols; i++) {
 		Field*	field = m_form->field[i];
 		ulint vers_row = 0;
@@ -10955,8 +10957,10 @@ create_table_info_t::create_table_def()
 		if (m_form->versioned()) {
 			if (i == m_form->s->row_start_field) {
 				vers_row = DATA_VERS_START;
+				have_vers_start = true;
 			} else if (i == m_form->s->row_end_field) {
 				vers_row = DATA_VERS_END;
+				have_vers_end = true;
 			} else if (!(field->flags
 				     & VERS_UPDATE_UNVERSIONED_FLAG)) {
 				vers_row = DATA_VERSIONED;
@@ -11070,6 +11074,9 @@ err_col:
 				table, 0);
 		}
 	}
+
+	ut_ad(have_vers_start == have_vers_end && table->versioned() == have_vers_start);
+	ut_ad(!table->versioned() || table->vers_start != table->vers_end);
 
 	if (num_v) {
 		for (ulint i = 0; i < n_cols; i++) {

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -1540,7 +1540,7 @@ struct dict_table_t {
 	bool versioned() const { return vers_start || vers_end; }
 	bool versioned_by_id() const
 	{
-		return vers_start && cols[vers_start].mtype == DATA_INT;
+		return versioned() && cols[vers_start].mtype == DATA_INT;
 	}
 
 	void inc_fk_checks()

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -1537,7 +1537,15 @@ struct dict_table_t {
 	/** Add the table definition to the data dictionary cache */
 	void add_to_cache();
 
-	bool versioned() const { return vers_start || vers_end; }
+	/** Detects if the table is versioned.
+	It is assumed that both vers_start and vers_end set to 0
+	iff table is not versioned. In any other case this fields correspond to
+	actual column indexes.
+	 */
+	bool versioned() const
+	{
+		return vers_start || vers_end;
+	}
 	bool versioned_by_id() const
 	{
 		return versioned() && cols[vers_start].mtype == DATA_INT;


### PR DESCRIPTION
**MDEV-18875** Assertion `thd->transaction.stmt.ha_list == __null || trans == &thd->transaction.stmt' failed or bogus ER_DUP_ENTRY upon ALTER TABLE with versioning

Cause:
* when autocommit=0 (or transaction is issued by user),
 `ha_commit_trans` is called twice on ALTER TABLE, causing a duplicated
 insert into `transaction_registry` (ER_DUP_ENTRY).

Solution:
* ALTER TABLE makes an implicit commit by a second call. We actually
 need to make an insert only when it is a real commit. So is_real
 variable is additionally checked.


**MDEV-18865** Assertion `t->first->versioned_by_id()' failed in innodb_prepare_commit_versioned

Cause:
* row_start != 0 treated as it exists. Probably, possible row permutations had not been taken in mind.

Solution:
* Checking both row_start and row_end is correct, so versioned() function is used