### PR TITLE
Make test galera_sr.GCF-1018 deterministic

### DIFF
--- a/mysql-test/suite/galera_sr/r/GCF-1018.result
+++ b/mysql-test/suite/galera_sr/r/GCF-1018.result
@@ -9,6 +9,7 @@ connection node_2a;
 SET SESSION wsrep_sync_wait = 0;
 SET GLOBAL wsrep_provider_options = 'dbug=d,after_certify_apply_monitor_enter';
 connection node_2;
+SET SESSION wsrep_retry_autocommit = 0;
 SET SESSION wsrep_trx_fragment_size = 64;
 DELETE FROM t1 ORDER BY f1 DESC LIMIT 2;;
 connection node_2a;
@@ -20,5 +21,5 @@ connection node_2a;
 SET GLOBAL wsrep_provider_options = 'signal=after_certify_apply_monitor_enter';
 SET GLOBAL wsrep_provider_options = 'dbug=';
 connection node_2;
-Got one of the listed errors
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/GCF-1018.test
+++ b/mysql-test/suite/galera_sr/t/GCF-1018.test
@@ -18,6 +18,7 @@ SET SESSION wsrep_sync_wait = 0;
 --source include/galera_set_sync_point.inc
 
 --connection node_2
+SET SESSION wsrep_retry_autocommit = 0;
 SET SESSION wsrep_trx_fragment_size = 64;
 --send DELETE FROM t1 ORDER BY f1 DESC LIMIT 2;
 
@@ -32,7 +33,7 @@ INSERT INTO t1 (f2) VALUES ('d'),('e');
 --source include/galera_clear_sync_point.inc
 
 --connection node_2
---error ER_LOCK_DEADLOCK, ER_QUERY_INTERRUPTED
+--error ER_LOCK_DEADLOCK
 --reap
 
 DROP TABLE t1;


### PR DESCRIPTION
Disabled autocommit retry (set wsrep_retry_autocommit to 0) so that BF
aborted autocommit statement always results in ER_LOCK_DEADLOCK.