### PR TITLE
MDEV-19172 Reorder fields in PFS_events and PFS_events_waits to speed up memcpy()

### DIFF
--- a/storage/perfschema/pfs_events.h
+++ b/storage/perfschema/pfs_events.h
@@ -34,14 +34,8 @@ struct PFS_events
   ulonglong m_event_id;
   /** END_EVENT_ID. */
   ulonglong m_end_event_id;
-  /** (EVENT_TYPE) */
-  enum_event_type m_event_type;
   /** NESTING_EVENT_ID. */
   ulonglong m_nesting_event_id;
-  /** NESTING_EVENT_TYPE */
-  enum_event_type m_nesting_event_type;
-  /** Instrument metadata. */
-  PFS_instr_class *m_class;
   /**
     Timer start.
     This member is populated only if m_class->m_timed is true.
@@ -52,8 +46,14 @@ struct PFS_events
     This member is populated only if m_class->m_timed is true.
   */
   ulonglong m_timer_end;
+  /** Instrument metadata. */
+  PFS_instr_class *m_class;
   /** Location of the instrumentation in the source code (file name). */
   const char *m_source_file;
+  /** (EVENT_TYPE) */
+  enum_event_type m_event_type;
+  /** NESTING_EVENT_TYPE */
+  enum_event_type m_nesting_event_type;
   /** Location of the instrumentation in the source code (line number). */
   uint m_source_line;
 };

--- a/storage/perfschema/pfs_events_waits.h
+++ b/storage/perfschema/pfs_events_waits.h
@@ -54,6 +54,23 @@ enum events_waits_class
 /** A wait event record. */
 struct PFS_events_waits : public PFS_events
 {
+  /** Executing thread. */
+  PFS_thread *m_thread;
+  /** Table share, for table operations only. */
+  PFS_table_share *m_weak_table_share;
+  /** File, for file operations only. */
+  PFS_file *m_weak_file;
+  /** Address in memory of the object instance waited on. */
+  const void *m_object_instance_addr;
+  /** Socket, for socket operations only. */
+  PFS_socket *m_weak_socket;
+  /**
+    Number of bytes read/written.
+    This member is populated for file READ/WRITE operations only.
+  */
+  size_t m_number_of_bytes;
+  /** Flags */
+  ulong m_flags;
   /**
     The type of wait.
     Readers:
@@ -66,34 +83,17 @@ struct PFS_events_waits : public PFS_events
     - TRUNCATE EVENTS_WAITS_HISTORY_LONG
   */
   events_waits_class m_wait_class;
-  /** Executing thread. */
-  PFS_thread *m_thread;
   /** Object type */
   enum_object_type m_object_type;
-  /** Table share, for table operations only. */
-  PFS_table_share *m_weak_table_share;
-  /** File, for file operations only. */
-  PFS_file *m_weak_file;
-  /** Socket, for socket operations only. */
-  PFS_socket *m_weak_socket;
   /** For weak pointers, target object version. */
   uint32 m_weak_version;
-  /** Address in memory of the object instance waited on. */
-  const void *m_object_instance_addr;
   /** Operation performed. */
   enum_operation_type m_operation;
-  /**
-    Number of bytes read/written.
-    This member is populated for file READ/WRITE operations only.
-  */
-  size_t m_number_of_bytes;
   /**
     Index used.
     This member is populated for TABLE IO operations only.
   */
   uint m_index;
-  /** Flags */
-  ulong m_flags;
 };
 
 /** TIMED bit in the state flags bitfield. */


### PR DESCRIPTION
before:
(gdb) p sizeof(PFS_events_waits)
$1 = 184

after:
(gdb) p sizeof(PFS_events_waits)
$1 = 160

no functional changes

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.1-MDEV-19172-pfs-member-reordering)