### PR TITLE
MDEV-19212: large page allocations over 4G overflow

### DIFF
--- a/storage/innobase/include/os0proc.h
+++ b/storage/innobase/include/os0proc.h
@@ -46,7 +46,7 @@ extern ulint	os_total_large_mem_allocated;
 extern my_bool	os_use_large_pages;
 
 /** Large page size. This may be a boot-time option on some platforms */
-extern uint	os_large_page_size;
+extern ulint	os_large_page_size;
 
 /** Converts the current process id to a number.
 @return process id as a number */

--- a/storage/innobase/os/os0proc.cc
+++ b/storage/innobase/os/os0proc.cc
@@ -42,7 +42,7 @@ ulint	os_total_large_mem_allocated = 0;
 my_bool	os_use_large_pages;
 
 /** Large page size. This may be a boot-time option on some platforms */
-uint	os_large_page_size;
+ulint	os_large_page_size;
 
 /** Converts the current process id to a number.
 @return process id as a number */


### PR DESCRIPTION
When introduced, the type of os_large_page_size was dropped from ulint to uint. The assumption is this because the opt_large_page_size size was uint. The consequence was the explicit type of the memory allocation was smaller resulting in an integer overflow. Less memory is allocated, less than what was specified.

Introduced in MySQL commit https://github.com/mysql/mysql-server/commit/e5d9961b637f871b34d7741b9f3db336c59ddec4

And into MariaDB with: 2e814d4702d71a04388386a9f591d14a35980bfe

While os_large_page_size could of been changed to ulint, POWER after all does have a 16G huge page size, without MDEV-18726 being backported to 10.3, using it would be quite wasteful of memory. A 10.4 solution of MDEV-18851 (#1221), removed os_large_page_size completely, and does this rounding calculation with a size_t value, like the syscalls (quite radical).

I submit this under the MCA.