### PR TITLE
MDEV-19015: mysql_plugin doesn't read all server option groups

### DIFF
--- a/client/mysql_plugin.c
+++ b/client/mysql_plugin.c
@@ -321,7 +321,7 @@ static int get_default_values()
   int ret= 0;
   FILE *file= 0;
 
-  bzero(tool_path, FN_REFLEN);
+  memset(tool_path, 0, FN_REFLEN);
   if ((error= find_tool("my_print_defaults" FN_EXEEXT, tool_path)))
     goto exit;
   else
@@ -334,9 +334,9 @@ static int get_default_values()
       char *format_str= 0;
   
       if (has_spaces(tool_path) || has_spaces(defaults_file))
-        format_str = "\"%s mysqld > %s\"";
+        format_str = "\"%s --mysqld > %s\"";
       else
-        format_str = "%s mysqld > %s";
+        format_str = "%s --mysqld > %s";
   
       snprintf(defaults_cmd, sizeof(defaults_cmd), format_str,
                add_quotes(tool_path), add_quotes(defaults_file));
@@ -347,7 +347,7 @@ static int get_default_values()
     }
 #else
     snprintf(defaults_cmd, sizeof(defaults_cmd),
-             "%s mysqld > %s", tool_path, defaults_file);
+             "%s --mysqld > %s", tool_path, defaults_file);
 #endif
 
     /* Execute the command */


### PR DESCRIPTION
How to use it:
`$ echo -e "auth_socket\nunix_socket">>auth-ini.ini`
It was:
```
$ ./client/mysql_plugin -v -f ./extra --plugin_ini=./client/auth-ini.ini unix_socket ENABLE 
# Found tool 'my_print_defaults' as './extra/my_print_defaults'.
# Command: ./extra/my_print_defaults mysqld > /tmp/txtEOWJhN
```
Now is changed in `--mysqld` in order to read other groups
```
$ ./client/mysql_plugin -v -f ./extra --plugin_ini=./client/auth-ini.ini unix_socket ENABLE 
# Found tool 'my_print_defaults' as './extra/my_print_defaults'.
# Command: ./extra/my_print_defaults --mysqld > /tmp/txtEOWJhN
#    basedir = /home/anel/workspace/10.2/
# plugin_dir = /home/anel/workspace/10.2/plugin/auth_socket/
#    datadir = /home/anel/workspace/datadir-10.2/
# plugin_ini = ./client/auth-ini.ini
```
However I do have problem in enabling this (stopped in bootstrap):
```
$ ./client/mysql_plugin -v -f ./extra --plugin_ini=./client/auth-ini.ini unix_socket ENABLE 
# Found tool 'my_print_defaults' as './extra/my_print_defaults'.
# Command: ./extra/my_print_defaults --mysqld > /tmp/txtEOWJhN
#    basedir = /home/anel/workspace/10.2/
# plugin_dir = /home/anel/workspace/10.2/plugin/auth_socket/
#    datadir = /home/anel/workspace/datadir-10.2/
# plugin_ini = ./client/auth-ini.ini
# Found tool 'mysqld' as '/home/anel/workspace/10.2/sql/mysqld'.
# Found plugin 'unix_socket' as '/home/anel/workspace/10.2/plugin/auth_socket/auth_socket.so'
# Enabling unix_socket...
# Query: REPLACE INTO mysql.plugin VALUES ('unix_socket','auth_socket.so');

# Command: /home/anel/workspace/10.2/sql/mysqld --no-defaults --bootstrap --datadir=/home/anel/workspace/datadir-10.2/ --basedir=/home/anel/workspace/10.2/ < /tmp/sqlREOaFE
```