### PR TITLE
MDEV-17301 Change of COLLATE unnecessarily requires ALGORITHM=COPY

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_charset,redundant.rdiff
+++ b/mysql-test/suite/innodb/r/instant_alter_charset,redundant.rdiff
@@ -8,3 +8,42 @@
  drop table boundary_255;
  create table fully_compatible (
  id int auto_increment unique key,
+@@ -274,30 +274,19 @@
+ repeat('a', 10), repeat('a', 10)
+ );
+ alter table t modify a char(10) collate utf8mb4_general_ci, algorithm=instant;
+-check table t;
+-Table	Op	Msg_type	Msg_text
+-test.t	check	status	OK
++ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ alter table t modify b char(70) collate utf8mb4_general_ci, algorithm=instant;
+-check table t;
+-Table	Op	Msg_type	Msg_text
+-test.t	check	status	OK
++ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ alter table t modify c char(100) collate utf8mb4_general_ci, algorithm=instant;
+-check table t;
+-Table	Op	Msg_type	Msg_text
+-test.t	check	status	OK
++ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ alter table t modify aa char(10) collate utf8mb4_general_ci, algorithm=instant;
+-check table t;
+-Table	Op	Msg_type	Msg_text
+-test.t	check	status	OK
++ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ alter table t modify bb char(70) collate utf8mb4_general_ci, algorithm=instant;
+-check table t;
+-Table	Op	Msg_type	Msg_text
+-test.t	check	status	OK
++ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ alter table t modify cc char(100) collate utf8mb4_general_ci, algorithm=instant;
+-check table t;
+-Table	Op	Msg_type	Msg_text
+-test.t	check	status	OK
++ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ alter table t modify d char(10) collate utf8mb4_spanish_ci, algorithm=instant;
++ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ alter table t modify dd char(10) collate utf8mb4_spanish_ci, algorithm=instant;
+ ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ select * from t;
+

--- a/mysql-test/suite/innodb/r/instant_alter_charset.result
+++ b/mysql-test/suite/innodb/r/instant_alter_charset.result
@@ -281,6 +281,52 @@ modify a varchar(70) charset utf8mb4,
 algorithm=instant;
 ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
 drop table boundary_255;
+create table t (
+a char(10) collate utf8mb3_general_ci,
+b char(70) collate utf8mb3_general_ci,
+c char(100) collate utf8mb3_general_ci,
+aa char(10) collate utf8mb3_general_ci unique,
+bb char(70) collate utf8mb3_general_ci unique,
+cc char(100) collate utf8mb3_general_ci unique,
+d char(10) collate utf8mb3_general_ci,
+dd char(10) collate utf8mb3_general_ci unique
+) engine=innodb;
+insert into t values
+(repeat('a', 10), repeat('a', 70), repeat('a', 100),
+repeat('a', 10), repeat('a', 70), repeat('a', 100),
+repeat('a', 10), repeat('a', 10)
+);
+alter table t modify a char(10) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify b char(70) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify c char(100) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify aa char(10) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify bb char(70) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify cc char(100) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify d char(10) collate utf8mb4_spanish_ci, algorithm=instant;
+alter table t modify dd char(10) collate utf8mb4_spanish_ci, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+select * from t;
+a	b	c	aa	bb	cc	d	dd
+aaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	aaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	aaaaaaaaaa	aaaaaaaaaa
+drop table t;
 create table fully_compatible (
 id int auto_increment unique key,
 from_charset char(255),
@@ -852,7 +898,7 @@ algorithm=instant;
 alter table tmp
 modify b varchar(50) charset ascii collate ascii_bin,
 algorithm=instant;
-ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
 alter table tmp
 modify c varchar(50) charset ascii collate ascii_bin,
 algorithm=instant;
@@ -869,7 +915,7 @@ algorithm=instant;
 alter table tmp
 modify b varchar(50) charset utf8mb3 collate utf8mb3_lithuanian_ci,
 algorithm=instant;
-ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
 alter table tmp
 modify c varchar(50) charset utf8mb3 collate utf8mb3_lithuanian_ci,
 algorithm=instant;
@@ -886,7 +932,7 @@ algorithm=instant;
 alter table tmp
 modify b varchar(50) charset utf8mb4 collate utf8mb4_persian_ci,
 algorithm=instant;
-ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
 alter table tmp
 modify c varchar(50) charset utf8mb4 collate utf8mb4_persian_ci,
 algorithm=instant;
@@ -920,7 +966,7 @@ algorithm=instant;
 alter table tmp
 modify b varchar(50) charset utf8mb3 collate utf8mb3_unicode_ci,
 algorithm=instant;
-ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
 alter table tmp
 modify c varchar(50) charset utf8mb3 collate utf8mb3_unicode_ci,
 algorithm=instant;
@@ -937,7 +983,7 @@ algorithm=instant;
 alter table tmp
 modify b varchar(50) charset latin1 collate latin1_general_ci,
 algorithm=instant;
-ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
 alter table tmp
 modify c varchar(50) charset latin1 collate latin1_general_ci,
 algorithm=instant;
@@ -954,7 +1000,7 @@ algorithm=instant;
 alter table tmp
 modify b varchar(50) charset utf16 collate utf16_german2_ci,
 algorithm=instant;
-ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
 alter table tmp
 modify c varchar(50) charset utf16 collate utf16_german2_ci,
 algorithm=instant;
@@ -1827,3 +1873,48 @@ CREATE TABLE t1 (a VARCHAR(1), UNIQUE(a)) ENGINE=InnoDB;
 ALTER TABLE t1 MODIFY a INT, ADD b INT, ADD UNIQUE (b), ALGORITHM=INSTANT;
 ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
 DROP TABLE t1;
+#
+# MDEV-17301 Change of COLLATE unnecessarily requires ALGORITHM=COPY
+#
+create table t (
+a char(10) collate latin1_general_ci primary key,
+b char(10) collate latin1_general_ci,
+c char(10) collate latin1_general_ci,
+unique key b_key(b)
+) engine=innodb;
+insert into t values
+('aaa', 'aaa', 'aaa'), ('ccc', 'ccc', 'ccc'), ('bbb', 'bbb', 'bbb');
+alter table t modify a char(10) collate latin1_general_cs, algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+alter table t modify b char(10) collate latin1_general_cs, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
+alter table t modify b char(10) collate latin1_general_cs, algorithm=nocopy;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify c char(10) collate latin1_general_cs, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+drop table t;
+create table t (
+a varchar(10) collate latin1_general_ci primary key,
+b varchar(10) collate latin1_general_ci,
+c varchar(10) collate latin1_general_ci,
+unique key b_key(b)
+) engine=innodb;
+insert into t values
+('aaa', 'aaa', 'aaa'), ('ccc', 'ccc', 'ccc'), ('bbb', 'bbb', 'bbb');
+alter table t modify a varchar(10) collate latin1_general_cs, algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+alter table t modify b varchar(10) collate latin1_general_cs, algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: ADD INDEX. Try ALGORITHM=NOCOPY
+alter table t modify b varchar(10) collate latin1_general_cs, algorithm=nocopy;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+alter table t modify c varchar(10) collate latin1_general_cs, algorithm=instant;
+check table t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+drop table t;

--- a/mysql-test/suite/innodb/t/instant_alter_charset.test
+++ b/mysql-test/suite/innodb/t/instant_alter_charset.test
@@ -321,6 +321,67 @@ alter table boundary_255
 
 drop table boundary_255;
 
+
+create table t (
+  a char(10) collate utf8mb3_general_ci,
+  b char(70) collate utf8mb3_general_ci,
+  c char(100) collate utf8mb3_general_ci,
+
+  aa char(10) collate utf8mb3_general_ci unique,
+  bb char(70) collate utf8mb3_general_ci unique,
+  cc char(100) collate utf8mb3_general_ci unique,
+
+  d char(10) collate utf8mb3_general_ci,
+  dd char(10) collate utf8mb3_general_ci unique
+) engine=innodb;
+insert into t values
+  (repeat('a', 10), repeat('a', 70), repeat('a', 100),
+   repeat('a', 10), repeat('a', 70), repeat('a', 100),
+   repeat('a', 10), repeat('a', 10)
+);
+if ($row_format != 'redundant') {
+alter table t modify a char(10) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+alter table t modify b char(70) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+alter table t modify c char(100) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+
+alter table t modify aa char(10) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+alter table t modify bb char(70) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+alter table t modify cc char(100) collate utf8mb4_general_ci, algorithm=instant;
+check table t;
+
+alter table t modify d char(10) collate utf8mb4_spanish_ci, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify dd char(10) collate utf8mb4_spanish_ci, algorithm=instant;
+}
+if ($row_format == 'redundant') {
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify a char(10) collate utf8mb4_general_ci, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify b char(70) collate utf8mb4_general_ci, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify c char(100) collate utf8mb4_general_ci, algorithm=instant;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify aa char(10) collate utf8mb4_general_ci, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify bb char(70) collate utf8mb4_general_ci, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify cc char(100) collate utf8mb4_general_ci, algorithm=instant;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify d char(10) collate utf8mb4_spanish_ci, algorithm=instant;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify dd char(10) collate utf8mb4_spanish_ci, algorithm=instant;
+}
+select * from t;
+drop table t;
+
+
 create table fully_compatible (
   id int auto_increment unique key,
   from_charset char(255),
@@ -604,3 +665,53 @@ CREATE TABLE t1 (a VARCHAR(1), UNIQUE(a)) ENGINE=InnoDB;
 ALTER TABLE t1 MODIFY a INT, ADD b INT, ADD UNIQUE (b), ALGORITHM=INSTANT;
 DROP TABLE t1;
 
+
+--echo #
+--echo # MDEV-17301 Change of COLLATE unnecessarily requires ALGORITHM=COPY
+--echo #
+
+create table t (
+  a char(10) collate latin1_general_ci primary key,
+  b char(10) collate latin1_general_ci,
+  c char(10) collate latin1_general_ci,
+  unique key b_key(b)
+) engine=innodb;
+
+insert into t values
+  ('aaa', 'aaa', 'aaa'), ('ccc', 'ccc', 'ccc'), ('bbb', 'bbb', 'bbb');
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify a char(10) collate latin1_general_cs, algorithm=inplace;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify b char(10) collate latin1_general_cs, algorithm=instant;
+alter table t modify b char(10) collate latin1_general_cs, algorithm=nocopy;
+check table t;
+
+alter table t modify c char(10) collate latin1_general_cs, algorithm=instant;
+check table t;
+
+drop table t;
+
+create table t (
+  a varchar(10) collate latin1_general_ci primary key,
+  b varchar(10) collate latin1_general_ci,
+  c varchar(10) collate latin1_general_ci,
+  unique key b_key(b)
+) engine=innodb;
+
+insert into t values
+  ('aaa', 'aaa', 'aaa'), ('ccc', 'ccc', 'ccc'), ('bbb', 'bbb', 'bbb');
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify a varchar(10) collate latin1_general_cs, algorithm=inplace;
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t modify b varchar(10) collate latin1_general_cs, algorithm=instant;
+alter table t modify b varchar(10) collate latin1_general_cs, algorithm=nocopy;
+check table t;
+
+alter table t modify c varchar(10) collate latin1_general_cs, algorithm=instant;
+check table t;
+
+drop table t;

--- a/sql/sql_priv.h
+++ b/sql/sql_priv.h
@@ -354,6 +354,10 @@
   data dictionary without changing table rows
 */
 #define IS_EQUAL_PACK_LENGTH 2
+/**
+  Tests fields are equal in any aspect but a COLLATE
+*/
+#define IS_EQUAL_BUT_COLLATE 3
 
 enum enum_parsing_place
 {

--- a/sql/sql_string.h
+++ b/sql/sql_string.h
@@ -167,8 +167,19 @@ public:
   LEX_CSTRING collation_specific_name() const;
   bool encoding_allows_reinterpret_as(CHARSET_INFO *cs) const;
   bool encoding_and_order_allow_reinterpret_as(CHARSET_INFO *cs) const;
-};
 
+  static bool same_charset_but_not_collate(const CHARSET_INFO *a,
+                                           const CHARSET_INFO *b)
+  {
+    return !strcmp(a->csname, b->csname) && strcmp(a->name, b->name);
+  }
+
+  static bool have_different_collate(const CHARSET_INFO *a,
+                                     const CHARSET_INFO *b)
+  {
+    return strcmp(a->name + strlen(a->csname), b->name + strlen(b->csname));
+  }
+};
 
 /*
   A storage for String.

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -6568,14 +6568,16 @@ Compare_keys compare_keys_but_name(const KEY *table_key, const KEY *new_key,
                       ((Field_varstring *) old_field)->length_bytes);
     }
 
+    uint is_equal= key_part->field->is_equal(new_field);
     if (key_part->length == old_field_len &&
-        key_part->length < new_part->length &&
-        (key_part->field->is_equal((Create_field *) new_field) ==
-         IS_EQUAL_PACK_LENGTH))
+        key_part->length < new_part->length && is_equal == IS_EQUAL_PACK_LENGTH)
     {
       result= Compare_keys::EqualButKeyPartLength;
     }
     else if (key_part->length != new_part->length)
+      return Compare_keys::NotEqual;
+
+    if (is_equal == IS_EQUAL_BUT_COLLATE)
       return Compare_keys::NotEqual;
   }
 
@@ -6783,6 +6785,8 @@ static bool fill_alter_inplace_info(THD *thd, TABLE *table, bool varchar,
         */
         ha_alter_info->handler_flags|= ALTER_COLUMN_EQUAL_PACK_LENGTH;
         break;
+      case IS_EQUAL_BUT_COLLATE:
+	break;
       default:
         DBUG_ASSERT(0);
         /* Safety. */

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -9120,14 +9120,20 @@ innobase_rename_or_enlarge_column_try(
 	DBUG_ASSERT(col->len <= len);
 
 #ifdef UNIV_DEBUG
+	ut_ad(col->mbminlen <= col->mbmaxlen);
 	switch (mtype) {
+	case DATA_MYSQL:
+		if (!(prtype & DATA_BINARY_TYPE) || user_table->not_redundant()
+		    || col->mbminlen != col->mbmaxlen) {
+			/* NOTE: we could allow this when !(prtype &
+			DATA_BINARY_TYPE) and ROW_FORMAT is not REDUNDANT and
+			mbminlen<mbmaxlen. That is, we treat a UTF-8 CHAR(n)
+			column somewhat like a VARCHAR. */
+			break;
+		}
+		/* fall through */
 	case DATA_FIXBINARY:
 	case DATA_CHAR:
-	case DATA_MYSQL:
-		/* NOTE: we could allow this when !(prtype & DATA_BINARY_TYPE)
-		and ROW_FORMAT is not REDUNDANT and mbminlen<mbmaxlen.
-		That is, we treat a UTF-8 CHAR(n) column somewhat like
-		a VARCHAR. */
 		ut_ad(col->len == len);
 		break;
 	case DATA_BINARY:


### PR DESCRIPTION
For InnoDB allow ALGORITHM=NOCOPY when collation of a secondary index changes.
Also allow ALGORITHM=INSTANT for CHAR columns COLLATE changes
when ROW_FORMAT != REDUNDANT.

IS_EQUAL_BUT_COLLATE: Field::is_equal() result which means that fields differs
only in COLLATE attribute

Field_str::is_equal()
Field_varstring::is_equal(): change those to return IS_EQUAL_BUT_COLLATE when
needed.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.4-MDEV-17301-charset-nocopy)
