### PR TITLE
MDEV-19189 ASAN memcpy-param-overlap in fill_alter_inplace_info upon adding indexes

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_index_rename.result
+++ b/mysql-test/suite/innodb/r/instant_alter_index_rename.result
@@ -176,3 +176,7 @@ check table rename_column_and_index;
 Table	Op	Msg_type	Msg_text
 test.rename_column_and_index	check	status	OK
 drop table rename_column_and_index;
+create table t1 (f1 int, f2 int, f3 int) engine=heap;
+alter table t1 add foreign key f (f2) references xx(f2);
+alter table t1 add foreign key (f2) references t1(f2), add key (f3), add key (f1);
+drop table t1;

--- a/mysql-test/suite/innodb/t/instant_alter_index_rename.test
+++ b/mysql-test/suite/innodb/t/instant_alter_index_rename.test
@@ -184,3 +184,8 @@ alter table rename_column_and_index
 show create table rename_column_and_index;
 check table rename_column_and_index;
 drop table rename_column_and_index;
+
+create table t1 (f1 int, f2 int, f3 int) engine=heap;
+alter table t1 add foreign key f (f2) references xx(f2);
+alter table t1 add foreign key (f2) references t1(f2), add key (f3), add key (f1);
+drop table t1;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7048,6 +7048,9 @@ static bool fill_alter_inplace_info(THD *thd, TABLE *table, bool varchar,
       KEY **drop_buffer= ha_alter_info->index_drop_buffer;
       const KEY *old_key= drop_buffer[j];
 
+      if (old_key->flags & HA_GENERATED_KEY)
+        continue;
+
       if (compare_keys_but_name(old_key, new_key, alter_info, table, new_pk,
                                 old_pk) != Compare_keys::Equal)
       {


### PR DESCRIPTION
fill_alter_inplace_info(): ignore HA_GENERATED_KEY keys while searching for
indexes to rename instantly

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.4-MDEV-19189-asan-instant-index-rename)
