### PR TITLE
MDEV-19257: mysql_install_db: assume builddir is dirname0

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -245,7 +245,12 @@ if test -n "$srcdir"
 then
   if test -z "$builddir"
   then
-    builddir="$srcdir"
+    if test -x "$dirname0/extra/my_print_defaults"
+    then
+      builddir="$dirname0"
+    else
+      builddir="$srcdir"
+    fi
   fi
   print_defaults="$builddir/extra/my_print_defaults"
 elif test -n "$basedir"


### PR DESCRIPTION
The assumption in the original commit for --builddir (648d3cedbc09), was to assume that the without a --builddir, and when --srcdir is specified, that the builddir is the same as the srcdir. For out of tree builds, the only supported by CMake type, this isn't the case.

As mysql_install_db is in the builddir, we use dirname0 after a quick check that my_print_defaults is also located from dirname0.

I submit this under the MCA.