### PR TITLE
MDEV-19231 make DB_SUCCESS equals 0

### DIFF
--- a/extra/mariabackup/backup_copy.cc
+++ b/extra/mariabackup/backup_copy.cc
@@ -559,9 +559,9 @@ datafile_read(datafile_cur_t *cursor)
 		return(XB_FIL_CUR_EOF);
 	}
 
-	if (!os_file_read(IORequestRead,
+	if (os_file_read(IORequestRead,
 			  cursor->file, cursor->buf, cursor->buf_offset,
-			  to_read)) {
+			  to_read) != DB_SUCCESS) {
 		return(XB_FIL_CUR_ERROR);
 	}
 

--- a/extra/mariabackup/changed_page_bitmap.cc
+++ b/extra/mariabackup/changed_page_bitmap.cc
@@ -195,7 +195,7 @@ log_online_read_bitmap_page(
 	ut_a(bitmap_file->offset % MODIFIED_PAGE_BLOCK_SIZE == 0);
 	success = os_file_read(IORequestRead,
 			       bitmap_file->file, page, bitmap_file->offset,
-			       MODIFIED_PAGE_BLOCK_SIZE);
+			       MODIFIED_PAGE_BLOCK_SIZE) == DB_SUCCESS;
 
 	if (UNIV_UNLIKELY(!success)) {
 

--- a/extra/mariabackup/fil_cur.cc
+++ b/extra/mariabackup/fil_cur.cc
@@ -253,7 +253,7 @@ xb_fil_cur_open(
 	if (!node->space->crypt_data
 	    && os_file_read(IORequestRead,
 			    node->handle, cursor->buf, 0,
-			    page_size.physical())) {
+			    page_size.physical()) == DB_SUCCESS) {
 		mutex_enter(&fil_system->mutex);
 		if (!node->space->crypt_data) {
 			node->space->crypt_data
@@ -442,8 +442,8 @@ read_retry:
 	cursor->buf_offset = offset;
 	cursor->buf_page_no = (ulint)(offset / page_size);
 
-	if (!os_file_read(IORequestRead, cursor->file, cursor->buf, offset,
-			  (ulint) to_read)) {
+	if (os_file_read(IORequestRead, cursor->file, cursor->buf, offset,
+			  (ulint) to_read) != DB_SUCCESS) {
 		ret = XB_FIL_CUR_ERROR;
 		goto func_exit;
 	}

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -3304,8 +3304,8 @@ static dberr_t xb_assign_undo_space_start()
 	page = static_cast<byte*>(ut_align(buf, UNIV_PAGE_SIZE));
 
 retry:
-	if (!os_file_read(IORequestRead, file, page, TRX_SYS_PAGE_NO * UNIV_PAGE_SIZE,
-			  UNIV_PAGE_SIZE)) {
+	if (os_file_read(IORequestRead, file, page, TRX_SYS_PAGE_NO * UNIV_PAGE_SIZE,
+			  UNIV_PAGE_SIZE) != DB_SUCCESS) {
 		msg("Reading TRX_SYS page failed.");
 		error = DB_ERROR;
 		goto func_exit;
@@ -4657,7 +4657,7 @@ xb_space_create_file(
 
 	free(buf);
 
-	if (!ret) {
+	if (ret != DB_SUCCESS) {
 		msg("mariabackup: could not write the first page to %s",
 		    path);
 		os_file_close(*file);
@@ -4949,7 +4949,7 @@ xtrabackup_apply_delta(
 			 << page_size_shift);
 		success = os_file_read(IORequestRead, src_file,
 				       incremental_buffer, offset, page_size);
-		if (!success) {
+		if (success != DB_SUCCESS) {
 			goto error;
 		}
 
@@ -4982,7 +4982,7 @@ xtrabackup_apply_delta(
 		success = os_file_read(IORequestRead, src_file,
 				       incremental_buffer,
 				       offset, page_in_buffer * page_size);
-		if (!success) {
+		if (success != DB_SUCCESS) {
 			goto error;
 		}
 
@@ -5031,7 +5031,7 @@ xtrabackup_apply_delta(
 
 			success = os_file_write(IORequestWrite,
 						dst_path, dst_file, buf, off, page_size);
-			if (!success) {
+			if (success != DB_SUCCESS) {
 				goto error;
 			}
 		}

--- a/storage/innobase/btr/btr0bulk.cc
+++ b/storage/innobase/btr/btr0bulk.cc
@@ -1050,6 +1050,7 @@ BtrBulk::finish(dberr_t	err)
 
 	ut_ad(!sync_check_iterate(dict_sync_check()));
 
-	ut_ad(err != DB_SUCCESS || btr_validate_index(m_index, NULL, false));
+	ut_ad(err == DB_SUCCESS
+	      || btr_validate_index(m_index, NULL, false) == DB_SUCCESS);
 	return(err);
 }

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -539,7 +539,7 @@ bool fil_node_t::read_page0(bool first)
 	/* Align the memory for file i/o if we might have O_DIRECT set */
 	byte* page = static_cast<byte*>(ut_align(buf2, psize));
 	IORequest request(IORequest::READ);
-	if (!os_file_read(request, handle, page, 0, psize)) {
+	if (os_file_read(request, handle, page, 0, psize) != DB_SUCCESS) {
 		ib::error() << "Unable to read first page of file " << name;
 		ut_free(buf2);
 		return false;

--- a/storage/innobase/include/db0err.h
+++ b/storage/innobase/include/db0err.h
@@ -30,12 +30,13 @@ Created 5/24/1996 Heikki Tuuri
 /* Do not include univ.i because univ.i includes this. */
 
 enum dberr_t {
+	DB_SUCCESS,
+
 	DB_SUCCESS_LOCKED_REC = 9,	/*!< like DB_SUCCESS, but a new
 					explicit record lock was created */
-	DB_SUCCESS = 10,
 
 	/* The following are error codes */
-	DB_ERROR,
+	DB_ERROR = 11,
 	DB_INTERRUPTED,
 	DB_OUT_OF_MEMORY,
 	DB_OUT_OF_FILE_SPACE,

--- a/storage/innobase/que/que0que.cc
+++ b/storage/innobase/que/que0que.cc
@@ -1233,7 +1233,5 @@ que_eval_sql(
 		mutex_exit(&dict_sys->mutex);
 	}
 
-	ut_a(trx->error_state != 0);
-
 	DBUG_RETURN(trx->error_state);
 }


### PR DESCRIPTION
It's a micro optimization. On most platforms CPUs has instructions to compare
with 0 fast. DB_SUCCESS is the most popular outcome of functions and this patch
optimized code like (err == DB_SUCCESS)

BtrBulk::finish(): bogus assertion fixed

fil_node_t::read_page0(): corrected usage of os_file_read()

que_eval_sql(): bugus asserion removed. What did it check, maybe the fact
someone initilizes trx->error_state?

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.2-MDEV-19231-db_success)
