### PR TITLE
MDEV-19399 do not call slow my_timer_init() several times

### DIFF
--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -64,7 +64,7 @@ typedef Bitmap<((MAX_INDEXES+7)/8*8)> key_map; /* Used for finding keys */
 #define OPT_SESSION SHOW_OPT_SESSION
 #define OPT_GLOBAL SHOW_OPT_GLOBAL
 
-extern MY_TIMER_INFO sys_timer_info;
+extern MYSQL_PLUGIN_IMPORT MY_TIMER_INFO sys_timer_info;
 
 /*
   Values for --slave-parallel-mode

--- a/storage/innobase/ut/ut0timer.cc
+++ b/storage/innobase/ut/ut0timer.cc
@@ -46,6 +46,7 @@ Function pointer to point selected timer function.
 ulonglong (*ut_timer_now)(void) = &ut_timer_none;
 
 struct my_timer_unit_info ut_timer;
+extern MYSQL_PLUGIN_IMPORT MY_TIMER_INFO sys_timer_info;
 
 /**************************************************************//**
 Sets up the data required for use of my_timer_* functions.
@@ -57,30 +58,27 @@ void
 ut_init_timer(void)
 /*===============*/
 {
-	MY_TIMER_INFO all_timer_info;
-	my_timer_init(&all_timer_info);
-
-	if (all_timer_info.cycles.frequency > 1000000 &&
-	    all_timer_info.cycles.resolution == 1) {
-		ut_timer = all_timer_info.cycles;
+	if (sys_timer_info.cycles.frequency > 1000000 &&
+	    sys_timer_info.cycles.resolution == 1) {
+		ut_timer = sys_timer_info.cycles;
 		ut_timer_now = &my_timer_cycles;
-	} else if (all_timer_info.nanoseconds.frequency > 1000000 &&
-		 all_timer_info.nanoseconds.resolution == 1) {
-		ut_timer = all_timer_info.nanoseconds;
+	} else if (sys_timer_info.nanoseconds.frequency > 1000000 &&
+		 sys_timer_info.nanoseconds.resolution == 1) {
+		ut_timer = sys_timer_info.nanoseconds;
 		ut_timer_now = &my_timer_nanoseconds;
-	} else if (all_timer_info.microseconds.frequency >= 1000000 &&
-		all_timer_info.microseconds.resolution == 1) {
-		ut_timer = all_timer_info.microseconds;
+	} else if (sys_timer_info.microseconds.frequency >= 1000000 &&
+		sys_timer_info.microseconds.resolution == 1) {
+		ut_timer = sys_timer_info.microseconds;
 		ut_timer_now = &my_timer_microseconds;
 
-	} else if (all_timer_info.milliseconds.frequency >= 1000 &&
-		all_timer_info.milliseconds.resolution == 1) {
-		ut_timer = all_timer_info.milliseconds;
+	} else if (sys_timer_info.milliseconds.frequency >= 1000 &&
+		sys_timer_info.milliseconds.resolution == 1) {
+		ut_timer = sys_timer_info.milliseconds;
 		ut_timer_now = &my_timer_milliseconds;
-	} else if (all_timer_info.ticks.frequency >= 1000 &&
+	} else if (sys_timer_info.ticks.frequency >= 1000 &&
 		 /* Will probably be false */
-		all_timer_info.ticks.resolution == 1) {
-		ut_timer = all_timer_info.ticks;
+		sys_timer_info.ticks.resolution == 1) {
+		ut_timer = sys_timer_info.ticks;
 		ut_timer_now = &my_timer_ticks;
 	} else {
 		/* None are acceptable, so leave it as "None", and fill in struct */

--- a/storage/perfschema/pfs_timer.cc
+++ b/storage/perfschema/pfs_timer.cc
@@ -26,7 +26,6 @@ enum_timer_name idle_timer= TIMER_NAME_MICROSEC;
 enum_timer_name wait_timer= TIMER_NAME_CYCLE;
 enum_timer_name stage_timer= TIMER_NAME_NANOSEC;
 enum_timer_name statement_timer= TIMER_NAME_NANOSEC;
-MY_TIMER_INFO pfs_timer_info;
 
 static ulonglong cycle_v0;
 static ulonglong nanosec_v0;
@@ -65,41 +64,39 @@ void init_timers(void)
 {
   double pico_frequency= 1.0e12;
 
-  my_timer_init(&pfs_timer_info);
-
   cycle_v0= my_timer_cycles();
   nanosec_v0= my_timer_nanoseconds();
   microsec_v0= my_timer_microseconds();
   millisec_v0= my_timer_milliseconds();
   tick_v0= my_timer_ticks();
 
-  if (pfs_timer_info.cycles.frequency > 0)
+  if (sys_timer_info.cycles.frequency > 0)
     cycle_to_pico= round_to_ulong(pico_frequency/
-                                  (double)pfs_timer_info.cycles.frequency);
+                                  (double)sys_timer_info.cycles.frequency);
   else
     cycle_to_pico= 0;
 
-  if (pfs_timer_info.nanoseconds.frequency > 0)
+  if (sys_timer_info.nanoseconds.frequency > 0)
     nanosec_to_pico= round_to_ulong(pico_frequency/
-                                    (double)pfs_timer_info.nanoseconds.frequency);
+                                    (double)sys_timer_info.nanoseconds.frequency);
   else
     nanosec_to_pico= 0;
 
-  if (pfs_timer_info.microseconds.frequency > 0)
+  if (sys_timer_info.microseconds.frequency > 0)
     microsec_to_pico= round_to_ulong(pico_frequency/
-                                     (double)pfs_timer_info.microseconds.frequency);
+                                     (double)sys_timer_info.microseconds.frequency);
   else
     microsec_to_pico= 0;
 
-  if (pfs_timer_info.milliseconds.frequency > 0)
+  if (sys_timer_info.milliseconds.frequency > 0)
     millisec_to_pico= round_to_ulong(pico_frequency/
-                                     (double)pfs_timer_info.milliseconds.frequency);
+                                     (double)sys_timer_info.milliseconds.frequency);
   else
     millisec_to_pico= 0;
 
-  if (pfs_timer_info.ticks.frequency > 0)
+  if (sys_timer_info.ticks.frequency > 0)
     tick_to_pico= round_to_ulonglong(pico_frequency/
-                                     (double)pfs_timer_info.ticks.frequency);
+                                     (double)sys_timer_info.ticks.frequency);
   else
     tick_to_pico= 0;
 

--- a/storage/perfschema/pfs_timer.h
+++ b/storage/perfschema/pfs_timer.h
@@ -102,7 +102,7 @@ extern enum_timer_name statement_timer;
   Timer information data.
   Characteristics about each suported timer.
 */
-extern MY_TIMER_INFO pfs_timer_info;
+extern MYSQL_PLUGIN_IMPORT MY_TIMER_INFO sys_timer_info;
 
 /** Initialize the timer component. */
 void init_timers();

--- a/storage/perfschema/table_performance_timers.cc
+++ b/storage/perfschema/table_performance_timers.cc
@@ -58,23 +58,23 @@ table_performance_timers::table_performance_timers()
 
   index= (int)TIMER_NAME_CYCLE - FIRST_TIMER_NAME;
   m_data[index].m_timer_name= TIMER_NAME_CYCLE;
-  m_data[index].m_info= pfs_timer_info.cycles;
+  m_data[index].m_info= sys_timer_info.cycles;
 
   index= (int)TIMER_NAME_NANOSEC - FIRST_TIMER_NAME;
   m_data[index].m_timer_name= TIMER_NAME_NANOSEC;
-  m_data[index].m_info= pfs_timer_info.nanoseconds;
+  m_data[index].m_info= sys_timer_info.nanoseconds;
 
   index= (int)TIMER_NAME_MICROSEC - FIRST_TIMER_NAME;
   m_data[index].m_timer_name= TIMER_NAME_MICROSEC;
-  m_data[index].m_info= pfs_timer_info.microseconds;
+  m_data[index].m_info= sys_timer_info.microseconds;
 
   index= (int)TIMER_NAME_MILLISEC - FIRST_TIMER_NAME;
   m_data[index].m_timer_name= TIMER_NAME_MILLISEC;
-  m_data[index].m_info= pfs_timer_info.milliseconds;
+  m_data[index].m_info= sys_timer_info.milliseconds;
 
   index= (int)TIMER_NAME_TICK - FIRST_TIMER_NAME;
   m_data[index].m_timer_name= TIMER_NAME_TICK;
-  m_data[index].m_info= pfs_timer_info.ticks;
+  m_data[index].m_info= sys_timer_info.ticks;
 }
 
 void table_performance_timers::reset_position(void)

--- a/storage/perfschema/unittest/pfs_server_stubs.cc
+++ b/storage/perfschema/unittest/pfs_server_stubs.cc
@@ -43,3 +43,5 @@ enum sys_var::where get_sys_var_value_origin(void *ptr)
 {
   return sys_var::AUTO;
 }
+
+MY_TIMER_INFO sys_timer_info;

--- a/storage/perfschema/unittest/pfs_timer-t.cc
+++ b/storage/perfschema/unittest/pfs_timer-t.cc
@@ -33,6 +33,8 @@ void test_timers()
   ulonglong t4_b;
   ulonglong t5_b;
 
+  my_timer_init(&sys_timer_info);
+
   init_timers();
 
   t1_a= get_timer_pico_value(TIMER_NAME_CYCLE);

--- a/storage/xtradb/ut/ut0timer.cc
+++ b/storage/xtradb/ut/ut0timer.cc
@@ -47,6 +47,8 @@ ulonglong (*ut_timer_now)(void) = &ut_timer_none;
 
 struct my_timer_unit_info ut_timer;
 
+extern MYSQL_PLUGIN_IMPORT MY_TIMER_INFO sys_timer_info;
+
 /**************************************************************//**
 Sets up the data required for use of my_timer_* functions.
 Selects the best timer by high frequency, and tight resolution.
@@ -57,30 +59,27 @@ void
 ut_init_timer(void)
 /*===============*/
 {
-	MY_TIMER_INFO all_timer_info;
-	my_timer_init(&all_timer_info);
-
-	if (all_timer_info.cycles.frequency > 1000000 &&
-	    all_timer_info.cycles.resolution == 1) {
-		ut_timer = all_timer_info.cycles;
+	if (sys_timer_info.cycles.frequency > 1000000 &&
+	    sys_timer_info.cycles.resolution == 1) {
+		ut_timer = sys_timer_info.cycles;
 		ut_timer_now = &my_timer_cycles;
-	} else if (all_timer_info.nanoseconds.frequency > 1000000 &&
-		 all_timer_info.nanoseconds.resolution == 1) {
-		ut_timer = all_timer_info.nanoseconds;
+	} else if (sys_timer_info.nanoseconds.frequency > 1000000 &&
+		 sys_timer_info.nanoseconds.resolution == 1) {
+		ut_timer = sys_timer_info.nanoseconds;
 		ut_timer_now = &my_timer_nanoseconds;
-	} else if (all_timer_info.microseconds.frequency >= 1000000 &&
-		all_timer_info.microseconds.resolution == 1) {
-		ut_timer = all_timer_info.microseconds;
+	} else if (sys_timer_info.microseconds.frequency >= 1000000 &&
+		sys_timer_info.microseconds.resolution == 1) {
+		ut_timer = sys_timer_info.microseconds;
 		ut_timer_now = &my_timer_microseconds;
 
-	} else if (all_timer_info.milliseconds.frequency >= 1000 &&
-		all_timer_info.milliseconds.resolution == 1) {
-		ut_timer = all_timer_info.milliseconds;
+	} else if (sys_timer_info.milliseconds.frequency >= 1000 &&
+		sys_timer_info.milliseconds.resolution == 1) {
+		ut_timer = sys_timer_info.milliseconds;
 		ut_timer_now = &my_timer_milliseconds;
-	} else if (all_timer_info.ticks.frequency >= 1000 &&
+	} else if (sys_timer_info.ticks.frequency >= 1000 &&
 		 /* Will probably be false */
-		all_timer_info.ticks.resolution == 1) {
-		ut_timer = all_timer_info.ticks;
+		sys_timer_info.ticks.resolution == 1) {
+		ut_timer = sys_timer_info.ticks;
 		ut_timer_now = &my_timer_ticks;
 	} else {
 		/* None are acceptable, so leave it as "None", and fill in struct */


### PR DESCRIPTION
No functional change.

Call my_timer_init() only once and then reuse it from InnoDB and
perfschema storage engines.

This patch speeds up empty test for me like this:
./mtr -mem innodb.kevg,xtradb  1.21s user 0.84s system 34% cpu 5.999 total
./mtr -mem innodb.kevg,xtradb  1.12s user 0.60s system 31% cpu 5.385 total

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.1-MDEV-19399-slow-times)
