### PR TITLE
MDEV-19360 Disable _FORTIFY_SOURCE for ASAN builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,13 @@ INCLUDE(check_compiler_flag)
 
 OPTION(WITH_ASAN "Enable address sanitizer" OFF)
 IF (WITH_ASAN)
+  IF(SECURITY_HARDENED)
+    MESSAGE(WARNING "WITH_ASAN and SECURITY_HARDENED are mutually exclusive")
+  ENDIF()
+
+  # this flag might be set by default on some OS
+  MY_CHECK_AND_SET_COMPILER_FLAG("-U_FORTIFY_SOURCE" DEBUG RELWITHDEBINFO)
+
   # gcc 4.8.1 and new versions of clang
   MY_CHECK_AND_SET_COMPILER_FLAG("-fsanitize=address -O1 -Wno-error -fPIC"
     DEBUG RELWITHDEBINFO)
@@ -225,7 +232,7 @@ ENDIF()
 
 # enable security hardening features, like most distributions do
 # in our benchmarks that costs about ~1% of performance, depending on the load
-IF(CMAKE_C_COMPILER_VERSION VERSION_LESS "4.6")
+IF(CMAKE_C_COMPILER_VERSION VERSION_LESS "4.6" OR WITH_ASAN)
   SET(security_default OFF)
 ELSE()
   SET(security_default ON)

--- a/include/my_valgrind.h
+++ b/include/my_valgrind.h
@@ -35,6 +35,10 @@
 # define MEM_CHECK_DEFINED(a,len) VALGRIND_CHECK_MEM_IS_DEFINED(a,len)
 #elif defined(__SANITIZE_ADDRESS__)
 # include <sanitizer/asan_interface.h>
+
+# ifdef _FORTIFY_SOURCE
+#  warning ASAN and _FORTIFY_SOURCE are not recommended to work together
+# endif
 /* How to do manual poisoning:
 https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
 # define MEM_UNDEFINED(a,len) ASAN_UNPOISON_MEMORY_REGION(a,len)


### PR DESCRIPTION
Those two may work incorrectly together. Namely, ASAN may produce
false positives or false negatives.

make SECURITY_HARDENED disabled by default if WITH_ASAN=ON

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.1-MDEV-19360-asan-fortify-source)
