### PR TITLE
MDEV-13080 [ERROR] InnoDB: Missing MLOG_CHECKPOINT between the checkpoint x and the end y

### DIFF
--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -644,8 +644,6 @@ struct log_t{
 					later; this is advanced when a flush
 					operation is completed to all the log
 					groups */
-	volatile bool	is_extending;	/*!< this is set to true during extend
-					the log buffer size */
 	lsn_t		write_lsn;	/*!< last written lsn */
 	lsn_t		current_flush_lsn;/*!< end lsn for the current running
 					write + flush operation */


### PR DESCRIPTION
log_buffer_extend(): do not write to disk. Just allocate new bigger buffer and
copy contents of old one to it.

log_t::is_extending: removed as unneeded now

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.2-MDEV-13080-missing-checkpoint)
