### PR TITLE
MDEV-19486 Server crashes in row_upd or row_upd_del_mark_clust_rec on REPLACE into a versioned table

### DIFF
--- a/mysql-test/suite/versioning/r/replace.result
+++ b/mysql-test/suite/versioning/r/replace.result
@@ -32,5 +32,19 @@ insert into t1 values (1,1);
 create or replace table t2 (c int);
 create or replace view v as select t1.* from t1 join t2;
 replace into v (a, b) select a, b from t1;
+drop table t1;
+CREATE TABLE t1 (
+pk INT AUTO_INCREMENT,
+f INT,
+row_start SYS_DATATYPE AS ROW START INVISIBLE,
+row_end SYS_DATATYPE AS ROW END INVISIBLE,
+PRIMARY KEY(pk),
+UNIQUE(f),
+PERIOD FOR SYSTEM_TIME(row_start, row_end)
+) WITH SYSTEM VERSIONING;
+INSERT INTO t1 () VALUES (),(),(),(),(),();
+UPDATE IGNORE t1 SET f = 1;
+REPLACE t1 SELECT * FROM t1;
+DROP TABLE t1;
 drop database test;
 create database test;

--- a/mysql-test/suite/versioning/t/replace.test
+++ b/mysql-test/suite/versioning/t/replace.test
@@ -35,6 +35,23 @@ insert into t1 values (1,1);
 create or replace table t2 (c int);
 create or replace view v as select t1.* from t1 join t2;
 replace into v (a, b) select a, b from t1;
+drop table t1;
+
+--replace_result $sys_datatype_expl SYS_DATATYPE
+eval CREATE TABLE t1 (
+    pk INT AUTO_INCREMENT,
+    f INT,
+    row_start $sys_datatype_expl AS ROW START INVISIBLE,
+    row_end $sys_datatype_expl AS ROW END INVISIBLE,
+    PRIMARY KEY(pk),
+    UNIQUE(f),
+    PERIOD FOR SYSTEM_TIME(row_start, row_end)
+) WITH SYSTEM VERSIONING;
+INSERT INTO t1 () VALUES (),(),(),(),(),();
+UPDATE IGNORE t1 SET f = 1;
+REPLACE t1 SELECT * FROM t1;
+DROP TABLE t1;
+
 
 drop database test;
 create database test;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1417,26 +1417,24 @@ row_insert_for_mysql(
 	row_mysql_convert_row_to_innobase(node->row, prebuilt, mysql_rec,
 					  &blob_heap);
 
-	if (ins_mode != ROW_INS_NORMAL)
-	{
+	if (ins_mode != ROW_INS_NORMAL) {
 		ut_ad(table->vers_start != table->vers_end);
-		/* Return back modified fields into mysql_rec, so that
-		   upper logic may benefit from it (f.ex. 'on duplicate key'). */
-		const mysql_row_templ_t* t = prebuilt->get_template_by_col(table->vers_end);
+		const mysql_row_templ_t* t
+		    = prebuilt->get_template_by_col(table->vers_end);
 		ut_ad(t);
 		ut_ad(t->mysql_col_len == 8);
 
 		if (ins_mode == ROW_INS_HISTORICAL) {
-			set_tuple_col_8(node->row, table->vers_end, trx->id, node->vers_end_buf);
-		}
-		else /* ROW_INS_VERSIONED */ {
-			set_tuple_col_8(node->row, table->vers_end, TRX_ID_MAX, node->vers_end_buf);
-			int8store(&mysql_rec[t->mysql_col_offset], TRX_ID_MAX);
+			set_tuple_col_8(node->row, table->vers_end, trx->id,
+					node->vers_end_buf);
+		} else /* ROW_INS_VERSIONED */ {
+			set_tuple_col_8(node->row, table->vers_end, TRX_ID_MAX,
+					node->vers_end_buf);
 			t = prebuilt->get_template_by_col(table->vers_start);
 			ut_ad(t);
 			ut_ad(t->mysql_col_len == 8);
-			set_tuple_col_8(node->row, table->vers_start, trx->id, node->vers_start_buf);
-			int8store(&mysql_rec[t->mysql_col_offset], trx->id);
+			set_tuple_col_8(node->row, table->vers_start, trx->id,
+					node->vers_start_buf);
 		}
 	}
 

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -3485,9 +3485,16 @@ void upd_node_t::make_versioned_helper(const trx_t* trx, ulint idx)
 
 	dict_index_t* clust_index = dict_table_get_first_index(table);
 
+	ut_ad(update->n_fields < table->n_cols + table->n_v_cols);
+
+	upd_field_t* new_buf = static_cast<upd_field_t*>(mem_heap_alloc(
+	    update->heap, (update->n_fields + 1) * sizeof(update->fields[0])));
+	memcpy(new_buf, update->fields,
+	       update->n_fields * sizeof(update->fields[0]));
+	update->fields = new_buf;
+
 	update->n_fields++;
-	upd_field_t* ufield =
-		upd_get_nth_field(update, upd_get_n_fields(update) - 1);
+	upd_field_t* ufield = upd_get_nth_field(update, update->n_fields - 1);
 	const dict_col_t* col = dict_table_get_nth_col(table, idx);
 
 	upd_field_set_field_no(ufield, dict_col_get_clust_pos(col, clust_index),


### PR DESCRIPTION
row_insert_for_mysql(): InnoDB sets values for row_start and row_end. And this
function used to return those values to server in ha_innobase::write_row().
This buggy behavior was removed. Also, a piece of code in this function
was reformatted.

upd_node_t::make_versioned_helper(): here fixed a separate unrelated issue when
a bigger buffer wasn't allocated for array before appending a new value to it.
This issue would be catched by ASAN or asserion in case if std::vector was used
instead of plain memory array. Added asserion too.

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.3-MDEV-19486-write_row-changes-record)
