### PR TITLE
MDEV-19524 Server crashes in Bitmap<64u>::is_clear_all / Field_longstr::csinfo_change_allows_instant_alter

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_charset.result
+++ b/mysql-test/suite/innodb/r/instant_alter_charset.result
@@ -1820,3 +1820,10 @@ HEX(a)
 61
 62
 DROP TABLE t1;
+#
+# MDEV-19524 Server crashes in Bitmap<64u>::is_clear_all / Field_longstr::csinfo_change_allows_instant_alter
+#
+CREATE TABLE t1 (a VARCHAR(1), UNIQUE(a)) ENGINE=InnoDB;
+ALTER TABLE t1 MODIFY a INT, ADD b INT, ADD UNIQUE (b), ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Cannot change column type. Try ALGORITHM=COPY
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/instant_alter_charset.test
+++ b/mysql-test/suite/innodb/t/instant_alter_charset.test
@@ -1,5 +1,4 @@
 --source include/innodb_row_format.inc
-#--source include/innodb_page_size.inc
 
 --let $row_format= `SELECT @@GLOBAL.innodb_default_row_format`
 set names utf8;
@@ -593,3 +592,15 @@ ALTER TABLE t1 ALGORITHM=INSTANT, MODIFY a VARCHAR(10) CHARACTER SET latin1 COLL
 ALTER IGNORE TABLE t1 MODIFY a VARCHAR(10) CHARACTER SET latin1 COLLATE latin1_general_ci;
 SELECT HEX(a) FROM t1;
 DROP TABLE t1;
+
+
+
+--echo #
+--echo # MDEV-19524 Server crashes in Bitmap<64u>::is_clear_all / Field_longstr::csinfo_change_allows_instant_alter
+--echo #
+
+CREATE TABLE t1 (a VARCHAR(1), UNIQUE(a)) ENGINE=InnoDB;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 MODIFY a INT, ADD b INT, ADD UNIQUE (b), ALGORITHM=INSTANT;
+DROP TABLE t1;
+


### PR DESCRIPTION
innodb.instant_alter_charset: remove some garbage

Field_string::is_equal(): refactor and make this function strictier

supports_such_enlargement(): put non-obvious logic in a separate function

Field_varstring::is_equal(): fix crash with refactoring
and reordering of conditions

I'm contributing this new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.

[Buildbot](http://buildbot.askmonty.org/buildbot/grid?category=main&branch=tt-10.4-MDEV-19524-is_equal-crash)
