### PR TITLE
sql_list: gcc-9 -Werror=deprecated-copy fixes

### DIFF
--- a/sql/sql_list.h
+++ b/sql/sql_list.h
@@ -100,6 +100,14 @@ public:
     *next= NULL;
   }
 
+  constexpr SQL_I_List<T>& operator=(const SQL_I_List<T>&rhs)
+  {
+    elements= rhs.elements;
+    first= rhs.first;
+    next= rhs.next;
+    return *this;
+  }
+
   inline void save_and_clear(SQL_I_List<T> *save)
   {
     *save= *this;
@@ -174,6 +182,14 @@ public:
       elements == rhs.elements &&
       first == rhs.first &&
       last == rhs.last;
+  }
+
+  constexpr base_list& operator=(const base_list&rhs)
+  {
+    elements= rhs.elements;
+    first= rhs.first;
+    last= rhs.last;
+    return *this;
   }
 
   inline void empty() { elements=0; first= &end_of_list; last=&first;}
@@ -515,6 +531,7 @@ public:
   inline List(const List<T> &tmp) :base_list(tmp) {}
   inline List(const List<T> &tmp, MEM_ROOT *mem_root) :
     base_list(tmp, mem_root) {}
+  inline List<T>& operator=(const List<T>& other) = default;
   inline bool push_back(T *a) { return base_list::push_back(a); }
   inline bool push_back(T *a, MEM_ROOT *mem_root)
   { return base_list::push_back(a, mem_root); }


### PR DESCRIPTION
I submit under the MCA:

Shows with compiler:
c++ (GCC) 9.1.1 20190503 (Red Hat 9.1.1-1)
(Fedora 30 x86_64)

Fixes:

sql/item_cmpfunc.h:2335:33: error: implicitly-declared ‘constexpr List<Item_equal>& List<Item_equal>::operator=(const List<Item_equal>&)’ is deprecated [-Werror=deprecated-copy]
 2335 |       current_level= cond_equal.current_level;
      |                                 ^~~~~~~~~~~~~
In file included from sql/sql_plugin.h:43,
                 from sql/structs.h:23,
                 from sql/unireg.h:169,
                 from sql/item.h:26,
                 from storage/xtradb/handler/i_s.cc:31:
sql/sql_list.h:522:10: note: because ‘List<Item_equal>’ has user-provided ‘List<T>::List(const List<T>&) [with T = Item_equal]’
  522 |   inline List(const List<T> &tmp) :base_list(tmp) {}
      |          ^~~~

And:

In file included from sql/mysqld.h:26,
                 from sql/handler.h:29,
                 from sql/log.h:20,
                 from sql/sql_class.h:27,
                 from sql/sql_acl.h:21,
                 from storage/perfschema/pfs_engine_table.h:19,
                 from storage/perfschema/cursor_by_host.h:24,
                 from storage/perfschema/cursor_by_host.cc:22:
sql/sql_list.h: In member function ‘void base_list::append(base_list*)’:
sql/sql_list.h:256:17: error: implicitly-declared ‘constexpr base_list& base_list::operator=(const base_list&)’ is deprecated [-Werror=deprecated-copy]
  256 |         *this= *list;
      |                 ^~~~
sql/sql_list.h:190:10: note: because ‘base_list’ has user-provided ‘base_list::base_list(const base_list&)’
  190 |   inline base_list(const base_list &tmp) :Sql_alloc()
      |          ^~~~~~~~~

And:

sql/sql_list.h:105:10: error: implicitly-declared ‘constexpr SQL_I_List<TABLE_LIST>& SQL_I_List<TABLE_LIST>::operator=(const SQL_I_List<TABLE_LIST>&)’ is deprecated [-Werror=deprecated-copy]
  105 |     *save= *this;
      |     ~~~~~^~~~~~~
sql/sql_list.h:81:3: note: because ‘SQL_I_List<TABLE_LIST>’ has user-provided ‘SQL_I_List<T>::SQL_I_List(const SQL_I_List<T>&) [with T = TABLE_LIST]’
   81 |   SQL_I_List(const SQL_I_List &tmp) : Sql_alloc()
      |   ^~~~~~~~~~
cc1plus: all warnings being treated as errors