### PR TITLE
MDEV-18438 Don't stream xtrabackup_info of extra-lsndir

### DIFF
--- a/extra/mariabackup/backup_copy.cc
+++ b/extra/mariabackup/backup_copy.cc
@@ -1607,7 +1607,8 @@ bool backup_finish()
 		return(false);
 	}
 
-	if (!write_xtrabackup_info(mysql_connection, XTRABACKUP_INFO, opt_history != 0)) {
+	if (!write_xtrabackup_info(mysql_connection, XTRABACKUP_INFO,
+				    opt_history != 0, true)) {
 		return(false);
 	}
 

--- a/extra/mariabackup/backup_mysql.h
+++ b/extra/mariabackup/backup_mysql.h
@@ -68,7 +68,8 @@ bool
 write_binlog_info(MYSQL *connection);
 
 bool
-write_xtrabackup_info(MYSQL *connection, const char * filename, bool history);
+write_xtrabackup_info(MYSQL *connection, const char * filename, bool history,
+                       bool stream);
 
 bool
 write_backup_config_file();

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -3980,7 +3980,7 @@ static bool xtrabackup_backup_low()
 		}
 		sprintf(filename, "%s/%s", xtrabackup_extra_lsndir,
 			XTRABACKUP_INFO);
-		if (!write_xtrabackup_info(mysql_connection, filename, false)) {
+		if (!write_xtrabackup_info(mysql_connection, filename, false, false)) {
 			msg("Error: failed to write info "
 			 "to '%s'.", filename);
 			return false;

--- a/mysql-test/suite/mariabackup/extra_lsndir_stream.result
+++ b/mysql-test/suite/mariabackup/extra_lsndir_stream.result
@@ -1,0 +1,2 @@
+xtrabackup_checkpoints
+xtrabackup_info

--- a/mysql-test/suite/mariabackup/extra_lsndir_stream.test
+++ b/mysql-test/suite/mariabackup/extra_lsndir_stream.test
@@ -1,0 +1,7 @@
+let $extra_lsndir=$MYSQLTEST_VARDIR/tmp/extra_lsndir;
+mkdir $extra_lsndir;
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --stream=xbstream --extra-lsndir=$extra_lsndir;
+--enable_result_log
+list_files $extra_lsndir;
+rmdir $extra_lsndir;

--- a/mysql-test/suite/mariabackup/mdev-18438.result
+++ b/mysql-test/suite/mariabackup/mdev-18438.result
@@ -1,0 +1,1 @@
+stream.xb

--- a/mysql-test/suite/mariabackup/mdev-18438.test
+++ b/mysql-test/suite/mariabackup/mdev-18438.test
@@ -1,0 +1,9 @@
+let $basedir=$MYSQLTEST_VARDIR/tmp/mdev-18438;
+mkdir $basedir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --extra-lsndir=$basedir/extra_lsndir --stream=xbstream > $basedir/stream.xb 2>/dev/null;
+mkdir $basedir/backup;
+rmdir $basedir/extra_lsndir;
+exec $XBSTREAM -x -C $basedir/backup  < $basedir/stream.xb;
+rmdir $basedir/backup;
+list_files $basedir;
+rmdir $basedir;


### PR DESCRIPTION
Relevant Jira tickets : 

https://jira.mariadb.org/browse/MDEV-15071
https://jira.mariadb.org/browse/MDEV-18438

The fix for the first ticket (xtrabackup_info is not present in extra-lsndir) doesn’t works in the case of streaming (--stream=xbstream) and instead puts it in the stream, causing it to be extracted outside of mbstream working directory (which is the issue discussed in MDEV-18438).