### PR TITLE
MDEV-19694 - Deb: Implement proper version detection in maintainer scripts

### DIFF
--- a/debian/mariadb-server-10.1.postinst
+++ b/debian/mariadb-server-10.1.postinst
@@ -2,16 +2,16 @@
 
 . /usr/share/debconf/confmodule
 
-# assume the filename is /path/to/mariadb-server-##.#.postinst
-VER=${0: -13:4}
+# Automatically set version to ease maintenance of this file
+MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
 if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*" 1>&2 }
- 
+
 export PATH=$PATH:/sbin:/usr/sbin:/bin:/usr/bin
 
 # This command can be used as pipe to syslog. With "-s" it also logs to stderr.
-ERR_LOGGER="logger -p daemon.err -t mariadb-server-$VER.postinst -i"
+ERR_LOGGER="logger -p daemon.err -t mariadb-server-$MAJOR_VER.postinst -i"
 # This will make an error in a logged command immediately apparent by aborting
 # the install, rather than failing silently and leaving a broken install.
 set -o pipefail
@@ -134,8 +134,8 @@ EOF
     db_set mysql-server/postrm_remove_database false || true
 
     # To avoid downgrades.
-    touch $mysql_statedir/debian-$VER.flag
-    
+    touch $mysql_statedir/debian-$MAJOR_VER.flag
+
     ## On every reconfiguration the maintenance user is recreated.
     #
     # - It is easier to regenerate the password every time but as people


### PR DESCRIPTION
Fixes bug introduced in commit https://github.com/MariaDB/server/commit/541500295abdba7fa619065069291ac9c1dd6e83.

Using script run-time filename does not always work. One cannot assume
that the filename is always the same as there might be temporary file
names used by dpkg in certain situations. See Debian #920415.

The same fix has been successfully in use in Debian official packages
since February 2019:
https://salsa.debian.org/mariadb-team/mariadb-10.3/commit/6440c0d6e75