### PR TITLE
Deb: Make commands 'mariadb' and 'mariadbcheck' available via symlinks

### DIFF
--- a/debian/mariadb-client-core-10.4.links
+++ b/debian/mariadb-client-core-10.4.links
@@ -1,0 +1,4 @@
+usr/bin/mysql usr/bin/mariadb
+usr/bin/mysqlcheck usr/bin/mariadbcheck
+usr/share/man/man1/mysql.1.gz usr/share/man/man1/mariadb.1.gz
+usr/share/man/man1/mysqlcheck.1.gz usr/share/man/man1/mariadbcheck.1.gz


### PR DESCRIPTION
This commit has been in Debian since 2017:
https://salsa.debian.org/mariadb-team/mariadb-10.3/commit/d0466f74d543ac574dcd832e081fdc18538f3edd