### PR TITLE
MDEV-19755: Switch Perl DBI scripts from DBD::mysql to DBD::MariaDB driver

### DIFF
--- a/Docs/INSTALL-BINARY
+++ b/Docs/INSTALL-BINARY
@@ -154,7 +154,7 @@ shell> chown -R mysql data
        script itself and at
        https://mariadb.com/kb/en/starting-and-stopping-mariadb-automatically.
    10. You can set up new accounts using the bin/mysql_setpermission
-       script if you install the DBI and DBD::mysql Perl modules. See
+       script if you install the DBI and DBD::MariaDB Perl modules. See
        Section 4.6.14, "mysql_setpermission --- Interactively Set
        Permissions in Grant Tables." For Perl module installation
        instructions, see Section 2.15, "Perl Installation Notes."

--- a/debian/additions/innotop/innotop
+++ b/debian/additions/innotop/innotop
@@ -63,7 +63,7 @@ sub new {
          },
          F => {
             desc => 'Only read default options from the given file',
-            dsn  => 'mysql_read_default_file',
+            dsn  => 'mariadb_read_default_file',
             copy => 1,
          },
          h => {
@@ -83,7 +83,7 @@ sub new {
          },
          S => {
             desc => 'Socket file to use for connection',
-            dsn  => 'mysql_socket',
+            dsn  => 'mariadb_socket',
             copy => 1,
          },
          u => {
@@ -218,11 +218,11 @@ sub get_cxn_params {
                      qw(h P));
    }
    else {
-      $dsn = 'DBI:mysql:' . ( $info->{D} || '' ) . ';'
+      $dsn = 'DBI:MariaDB:' . ( $info->{D} || '' ) . ';'
          . join(';', map  { "$opts{$_}->{dsn}=$info->{$_}" }
                      grep { defined $info->{$_} }
                      qw(F h P S A))
-         . ';mysql_read_default_group=client';
+         . ';mariadb_read_default_group=client';
    }
    MKDEBUG && _d($dsn);
    return ($dsn, $info->{u}, $info->{p});
@@ -249,7 +249,6 @@ sub get_dbh {
       AutoCommit        => 0,
       RaiseError        => 1,
       PrintError        => 0,
-      mysql_enable_utf8 => ($cxn_string =~ m/charset=utf8/ ? 1 : 0),
    };
    @{$defaults}{ keys %$opts } = values %$opts;
    my $dbh;
@@ -276,10 +275,6 @@ sub get_dbh {
       };
       if ( !$dbh && $EVAL_ERROR ) {
          MKDEBUG && _d($EVAL_ERROR);
-         if ( $EVAL_ERROR =~ m/not a compiled character set|character set utf8/ ) {
-            MKDEBUG && _d("Going to try again without utf8 support");
-            delete $defaults->{mysql_enable_utf8};
-         }
          if ( !$tries ) {
             die $EVAL_ERROR;
          }
@@ -301,11 +296,11 @@ sub get_dbh {
       $dbh,
       Dumper($dbh->selectrow_hashref(
          'SELECT DATABASE(), CONNECTION_ID(), VERSION()/*!50038 , @@hostname*/')),
-      ' Connection info: ', ($dbh->{mysql_hostinfo} || 'undef'),
+      ' Connection info: ', ($dbh->{mariadb_hostinfo} || 'undef'),
       ' Character set info: ',
       Dumper($dbh->selectall_arrayref(
          'SHOW VARIABLES LIKE "character_set%"', { Slice => {}})),
-      ' $DBD::mysql::VERSION: ', $DBD::mysql::VERSION,
+      ' $DBD::MariaDB::VERSION: ', $DBD::MariaDB::VERSION,
       ' $DBI::VERSION: ', $DBI::VERSION,
    );
    return $dbh;
@@ -314,7 +309,7 @@ sub get_dbh {
 # Tries to figure out a hostname for the connection.
 sub get_hostname {
    my ( $self, $dbh ) = @_;
-   if ( my ($host) = ($dbh->{mysql_hostinfo} || '') =~ m/^(\w+) via/ ) {
+   if ( my ($host) = ($dbh->{mariadb_hostinfo} || '') =~ m/^(\w+) via/ ) {
       return $host;
    }
    my ( $hostname, $one ) = $dbh->selectrow_array(
@@ -4534,7 +4529,7 @@ my %stmt_maker_for = (
       eval { # This can fail if the table doesn't exist, INFORMATION_SCHEMA doesn't exist, etc.
          my $cols = $dbh->selectall_arrayref(q{SHOW /*innotop*/ COLUMNS FROM INFORMATION_SCHEMA.INNODB_LOCK_WAITS});
          if ( @$cols ) {
-          if ($dbh->{mysql_serverinfo} =~ /^5.1/) {
+          if ($dbh->{mariadb_serverinfo} =~ /^5.1/) {
             $sth = $dbh->prepare(q{
                SELECT /*innotop*/
                   r.trx_mysql_thread_id                            AS waiting_thread,
@@ -7259,7 +7254,7 @@ sub create_statusbar {
    my $cxn = '';
 
    if ( 1 == @cxns && $dbhs{$cxns[0]} && $dbhs{$cxns[0]}->{dbh} ) {
-      $cxn = $dbhs{$cxns[0]}->{dbh}->{mysql_serverinfo} || '';
+      $cxn = $dbhs{$cxns[0]}->{dbh}->{mariadb_serverinfo} || '';
    }
    else {
       if ( $modes{$mode}->{server_group} ) {
@@ -7341,11 +7336,11 @@ sub add_new_dsn {
    if ( !$dsn ) {
       do {
          $clear_screen_sub->();
-         print "Typical DSN strings look like\n   DBI:mysql:;host=hostname;port=port\n"
+         print "Typical DSN strings look like\n   DBI:MariaDB:;host=hostname;port=port\n"
             . "The db and port are optional and can usually be omitted.\n"
-            . "If you specify 'mysql_read_default_group=mysql' many options can be read\n"
+            . "If you specify 'mariadb_read_default_group=mysql' many options can be read\n"
             . "from your mysql options files (~/.my.cnf, /etc/my.cnf).\n\n";
-         $dsn = prompt("Enter a DSN string", undef, "DBI:mysql:;mysql_read_default_group=mysql;host=$name");
+         $dsn = prompt("Enter a DSN string", undef, "DBI:MariaDB:;mariadb_read_default_group=mysql;host=$name");
       } until ( $dsn );
    }
    if ( !$dl_table ) {
@@ -7674,7 +7669,7 @@ sub connect_to_db {
 # Compares versions like 5.0.27 and 4.1.15-standard-log
 sub version_ge {
    my ( $dbh, $target ) = @_;
-   my $version = sprintf('%03d%03d%03d', $dbh->{mysql_serverinfo} =~ m/^(\d+).(\d+).(\d+)/g);
+   my $version = sprintf('%03d%03d%03d', $dbh->{mariadb_serverinfo} =~ m/^(\d+).(\d+).(\d+)/g);
    return $version ge sprintf('%03d%03d%03d', $target =~ m/(\d+)/g);
 }
 
@@ -7686,7 +7681,7 @@ sub get_driver_status {
          next unless $dbhs{$cxn} && $dbhs{$cxn}->{dbh} && $dbhs{$cxn}->{dbh}->{Active};
          $vars{$cxn}->{$clock} ||= {};
          my $vars = $vars{$cxn}->{$clock};
-         my %res = map {  $_ =~ s/ +/_/g; $_ } $dbhs{$cxn}->{dbh}->{mysql_stat} =~ m/(\w[^:]+): ([\d\.]+)/g;
+         my %res = map {  $_ =~ s/ +/_/g; $_ } $dbhs{$cxn}->{dbh}->{mariadb_stat} =~ m/(\w[^:]+): ([\d\.]+)/g;
          map { $vars->{$_} ||= $res{$_} } keys %res;
          $vars->{Uptime_hires} ||= get_uptime($cxn);
          $vars->{cxn} = $cxn;
@@ -7703,14 +7698,14 @@ sub get_new_db_connection {
    my $dsn = $connections{$connection}
       or die "No connection named '$connection' is defined in your configuration";
 
-   # don't ask for a username if mysql_read_default_group=client is in the DSN
-   if ( !defined $dsn->{have_user} and $dsn->{dsn} !~ /mysql_read_default_group=client/ ) {
+   # don't ask for a username if mariadb_read_default_group=client is in the DSN
+   if ( !defined $dsn->{have_user} and $dsn->{dsn} !~ /mariadb_read_default_group=client/ ) {
       my $answer = prompt("Do you want to specify a username for $connection?", undef, 'n');
       $dsn->{have_user} = $answer && $answer =~ m/1|y/i;
    }
 
-   # don't ask for a password if mysql_read_default_group=client is in the DSN
-   if ( !defined $dsn->{have_pass} and $dsn->{dsn} !~ /mysql_read_default_group=client/ ) {
+   # don't ask for a password if mariadb_read_default_group=client is in the DSN
+   if ( !defined $dsn->{have_pass} and $dsn->{dsn} !~ /mariadb_read_default_group=client/ ) {
       my $answer = prompt("Do you want to specify a password for $connection?", undef, 'n');
       $dsn->{have_pass} = $answer && $answer =~ m/1|y/i;
    }
@@ -7939,10 +7934,10 @@ sub load_config {
       # write a config
       $config{readonly}->{val} = 0 if $opts{w};
       # If no connections have been defined, connect to a MySQL database 
-      # on localhost using mysql_read_default_group=client
+      # on localhost using mariadb_read_default_group=client
       if (!%connections) {
          add_new_dsn('localhost', 
-                     'DBI:mysql:;host=localhost;mysql_read_default_group=client', 
+                     'DBI:MariaDB:;host=localhost;mariadb_read_default_group=client', 
                      'test.innotop_dl');
       }
    }
@@ -9374,7 +9369,7 @@ sub choose_thread {
 
    my %thread_for = map {
       # Eliminate innotop's own threads.
-      $_ => $dbhs{$_}->{dbh} ? $dbhs{$_}->{dbh}->{mysql_thread_id} : 0
+      $_ => $dbhs{$_}->{dbh} ? $dbhs{$_}->{dbh}->{mariadb_thread_id} : 0
    } keys %connections;
 
    my @candidates = grep {
@@ -9899,7 +9894,7 @@ Enter; otherwise, you will need to change to innotop's directory and type "perl
 innotop".
 
 With no options specified, innotop will attempt to connect to a MySQL server on
-localhost using mysql_read_default_group=client for other connection
+localhost using mariadb_read_default_group=client for other connection
 parameters.  If you need to specify a different username and password, use the
 -u and -p options, respectively.  To monitor a MySQL database on another
 host, use the -h option.
@@ -10394,15 +10389,15 @@ inputs, as follows:
 A DSN is a Data Source Name, which is the initial argument passed to the DBI
 module for connecting to a server.  It is usually of the form
 
- DBI:mysql:;mysql_read_default_group=mysql;host=HOSTNAME
+ DBI:MariaDB:;mariadb_read_default_group=mysql;host=HOSTNAME
 
-Since this DSN is passed to the DBD::mysql driver, you should read the driver's
-documentation at L<"http://search.cpan.org/dist/DBD-mysql/lib/DBD/mysql.pm"> for
+Since this DSN is passed to the DBD::MariaDB driver, you should read the driver's
+documentation at L<https://metacpan.org/pod/DBD::MariaDB> for
 the exact details on all the options you can pass the driver in the DSN.  You
 can read more about DBI at L<http://dbi.perl.org/docs/>, and especially at
 L<http://search.cpan.org/~timb/DBI/DBI.pm>.
 
-The mysql_read_default_group=mysql option lets the DBD driver read your MySQL
+The mariadb_read_default_group=mysql option lets the DBD driver read your MySQL
 options files, such as ~/.my.cnf on UNIX-ish systems.  You can use this to avoid
 specifying a username or password for the connection.
 
@@ -12137,7 +12132,7 @@ You need appropriate privileges to create and drop the deadlock tables if needed
 =head1 SYSTEM REQUIREMENTS
 
 You need Perl to run innotop, of course.  You also need a few Perl modules: DBI,
-DBD::mysql,  Term::ReadKey, and Time::HiRes.  These should be included with most
+DBD::MariaDB,  Term::ReadKey, and Time::HiRes.  These should be included with most
 Perl distributions, but in case they are not, I recommend using versions
 distributed with your operating system or Perl distribution, not from CPAN.
 Term::ReadKey in particular has been known to cause problems if installed from

--- a/debian/additions/innotop/innotop.1
+++ b/debian/additions/innotop/innotop.1
@@ -184,7 +184,7 @@ Enter; otherwise, you will need to change to innotop's directory and type \*(L"p
 innotop\*(R".
 .PP
 With no options specified, innotop will attempt to connect to a MySQL server on
-localhost using mysql_read_default_group=client for other connection
+localhost using mariadb_read_default_group=client for other connection
 parameters.  If you need to specify a different username and password, use the
 \&\-u and \-p options, respectively.  To monitor a MySQL database on another
 host, use the \-h option.
@@ -626,16 +626,16 @@ A \s-1DSN\s0 is a Data Source Name, which is the initial argument passed to the 
 module for connecting to a server.  It is usually of the form
 .Sp
 .Vb 1
-\& DBI:mysql:;mysql_read_default_group=mysql;host=HOSTNAME
+\& DBI:MariaDB:;mariadb_read_default_group=mysql;host=HOSTNAME
 .Ve
 .Sp
-Since this \s-1DSN\s0 is passed to the DBD::mysql driver, you should read the driver's
-documentation at \*(L"/search.cpan.org/dist/DBD\-mysql/lib/DBD/mysql.pm\*(R"\*(L" in \*(R"http: for
+Since this \s-1DSN\s0 is passed to the DBD::MariaDB driver, you should read the driver's
+documentation at <https://metacpan.org/pod/DBD::MariaDB> for
 the exact details on all the options you can pass the driver in the \s-1DSN. \s0 You
 can read more about \s-1DBI\s0 at <http://dbi.perl.org/docs/>, and especially at
 <http://search.cpan.org/~timb/DBI/DBI.pm>.
 .Sp
-The mysql_read_default_group=mysql option lets the \s-1DBD\s0 driver read your MySQL
+The mariadb_read_default_group=mysql option lets the \s-1DBD\s0 driver read your MySQL
 options files, such as ~/.my.cnf on UNIX-ish systems.  You can use this to avoid
 specifying a username or password for the connection.
 .IP "InnoDB Deadlock Table" 4
@@ -2095,7 +2095,7 @@ You need appropriate privileges to create and drop the deadlock tables if needed
 .SH "SYSTEM REQUIREMENTS"
 .IX Header "SYSTEM REQUIREMENTS"
 You need Perl to run innotop, of course.  You also need a few Perl modules: \s-1DBI,\s0
-DBD::mysql,  Term::ReadKey, and Time::HiRes.  These should be included with most
+DBD::MariaDB,  Term::ReadKey, and Time::HiRes.  These should be included with most
 Perl distributions, but in case they are not, I recommend using versions
 distributed with your operating system or Perl distribution, not from \s-1CPAN.\s0
 Term::ReadKey in particular has been known to cause problems if installed from

--- a/debian/additions/mysqlreport
+++ b/debian/additions/mysqlreport
@@ -245,15 +245,15 @@ sub connect_to_MySQL
 
    if($mycnf{'socket'} && -S $mycnf{'socket'})
    {
-      $dsn = "DBI:mysql:mysql_socket=$mycnf{socket}";
+      $dsn = "DBI:MariaDB:mariadb_socket=$mycnf{socket}";
    }
    elsif($mycnf{'host'})
    {
-      $dsn = "DBI:mysql:host=$mycnf{host}" . ($mycnf{port} ? ";port=$mycnf{port}" : "");
+      $dsn = "DBI:MariaDB:host=$mycnf{host}" . ($mycnf{port} ? ";port=$mycnf{port}" : "");
    }
    else
    {
-      $dsn = "DBI:mysql:host=localhost";
+      $dsn = "DBI:MariaDB:host=localhost";
    }
 
    print "connect_to_MySQL: DBI DSN: $dsn\n" if $op{debug};

--- a/debian/additions/mysqlreport.1
+++ b/debian/additions/mysqlreport.1
@@ -160,7 +160,7 @@ command line option and operation. The FROM: field is
 \fB\-\-flush\-status\fR
 Execute a "FLUSH STATUS;" after generating the reports.
 If you do not have permissions in MySQL to do this an
-error from DBD::mysql::st will be printed after the
+error from DBD::MariaDB::st will be printed after the
 reports.
 
 .SH "AUTHORS"

--- a/debian/control
+++ b/debian/control
@@ -350,7 +350,7 @@ Provides: default-mysql-client,
           mysql-client-5.6,
           mysql-client-5.7,
           virtual-mysql-client
-Recommends: libdbd-mysql-perl (>= 1.2202),
+Recommends: libdbd-mariadb-perl,
             libdbi-perl,
             libterm-readkey-perl
 Description: MariaDB database client binaries

--- a/man/mysql_convert_table_format.1
+++ b/man/mysql_convert_table_format.1
@@ -26,7 +26,7 @@ by default)\&.
 is written in Perl and requires that the
 DBI
 and
-DBD::mysql
+DBD::MariaDB
 Perl modules be installed (see
 Section\ \&2.15, \(lqPerl Installation Notes\(rq)\&.
 .PP

--- a/man/mysql_setpermission.1
+++ b/man/mysql_setpermission.1
@@ -25,7 +25,7 @@ is a Perl script that was originally written and contributed by Luuk de Boer\&. 
 is written in Perl and requires that the
 DBI
 and
-DBD::mysql
+DBD::MariaDB
 Perl modules be installed\&.
 .PP
 Invoke

--- a/mysql-test/include/have_dbi_dbd-mariadb.inc
+++ b/mysql-test/include/have_dbi_dbd-mariadb.inc
@@ -1,7 +1,7 @@
 #
 # Originally created by John Embretsen, 2011-01-26.
 #
-# Checks for the existence of Perl modules DBI and DBD::mysql as seen from the
+# Checks for the existence of Perl modules DBI and DBD::MariaDB as seen from the
 # perl installation used by "external" executable perl scripts, i.e. scripts
 # that are executed as standalone scripts interpreted by the perl installation
 # specified by the "shebang" line in the top of these scripts.
@@ -30,7 +30,7 @@
 # We jump through some hoops since there is no direct way to check if an 
 # external command went OK or not from a mysql-test file:
 #
-#   - In theory, we could do as simple as "exec perl -MDBI -MDBD::mysql -e 1",
+#   - In theory, we could do as simple as "exec perl -MDBI -MDBD::MariaDB -e 1",
 #     however we cannot check the result (exit code) from within a test script. 
 #     Also, this may not yield the same result as other uses of perl due to the 
 #     shebang issue mentioned above.
@@ -55,8 +55,8 @@
 # Instead, we call a separate helper script which checks for the modules in its
 # own environment. We call it without "perl" in front.
 
---let $perlChecker= $MYSQLTEST_VARDIR/std_data/checkDBI_DBD-mysql.pl
---let $resultFile= $MYSQL_TMP_DIR/dbidbd-mysql.txt
+--let $perlChecker= $MYSQLTEST_VARDIR/std_data/checkDBI_DBD-MariaDB.pl
+--let $resultFile= $MYSQL_TMP_DIR/dbiDBD-MariaDB.txt
 
 --exec perl $perlChecker
 
@@ -64,7 +64,7 @@
 --source $resultFile
 
 if (!$dbidbd) {
-    --skip Test needs Perl modules DBI and DBD::mysql
+    --skip Test needs Perl modules DBI and DBD::MariaDB
 } 
 
 # Clean up

--- a/mysql-test/include/mysqlhotcopy.inc
+++ b/mysql-test/include/mysqlhotcopy.inc
@@ -4,7 +4,7 @@
 
 --source include/not_windows.inc
 --source include/not_embedded.inc
---source include/have_dbi_dbd-mysql.inc
+--source include/have_dbi_dbd-mariadb.inc
 
 if (!$MYSQLHOTCOPY)
 {
@@ -19,7 +19,7 @@ if (!$MYSQLHOTCOPY)
 #       executable, i.e. not necessarily using the perl interpreter in PATH,
 #       because that is how the documentation demonstrates it.
 #
-#       We include have_dbi_dbd-mysql.inc above so that the test will
+#       We include have_dbi_dbd-mariadb.inc above so that the test will
 #       be skipped if Perl modules required by the mysqlhotcopy tool are not
 #       found when the script is run this way.
 

--- a/mysql-test/std_data/checkDBI_DBD-MariaDB.pl
+++ b/mysql-test/std_data/checkDBI_DBD-MariaDB.pl
@@ -20,7 +20,7 @@
 ################################################################################
 #
 # This perl script checks for availability of the Perl modules DBI and
-# DBD::mysql using the "current" perl interpreter.
+# DBD::MariaDB using the "current" perl interpreter.
 #
 # Useful for test environment checking before testing executable perl scripts
 # in the MySQL Server distribution.
@@ -30,8 +30,8 @@
 #       support running perl scripts with such a shebang without specifying the
 #       perl interpreter on the command line. Such a script is mysqlhotcopy.
 #
-#       When run as "checkDBI_DBD-mysql.pl" the shebang line will be evaluated
-#       and used. When run as "perl checkDBI_DBD-mysql.pl" the shebang line is
+#       When run as "checkDBI_DBD-MariaDB.pl" the shebang line will be evaluated
+#       and used. When run as "perl checkDBI_DBD-MariaDB.pl" the shebang line is
 #       not used.
 #
 # NOTE: This script will create a temporary file in MTR's tmp dir.
@@ -43,13 +43,13 @@
 #
 #       Example:
 #
-#         --let $perlChecker= $MYSQLTEST_VARDIR/std_data/checkDBI_DBD-mysql.pl
-#         --let $resultFile= $MYSQL_TMP_DIR/dbidbd-mysql.txt
+#         --let $perlChecker= $MYSQLTEST_VARDIR/std_data/checkDBI_DBD-MariaDB.pl
+#         --let $resultFile= $MYSQL_TMP_DIR/dbiDBD-MariaDB.txt
 #         --chmod 0755 $perlChecker
 #         --exec $perlChecker
 #         --source $resultFile
 #         if (!$dbidbd) {
-#             --skip Test needs Perl modules DBI and DBD::mysql
+#             --skip Test needs Perl modules DBI and DBD::MariaDB
 #         } 
 #
 #       The calling script is also responsible for cleaning up after use:
@@ -59,7 +59,7 @@
 # Windows notes: 
 #   - shebangs may work differently - call this script with "perl " in front.
 #
-# See mysql-test/include/have_dbi_dbd-mysql.inc for example use of this script.
+# See mysql-test/include/have_dbi_dbd-mariadb.inc for example use of this script.
 # This script should be executable for the user running MTR.
 #
 ################################################################################
@@ -69,13 +69,13 @@ BEGIN {
     # We need to catch "Can't locate" as well as "Can't load" errors.
     eval{
         $FOUND_DBI=0;
-        $FOUND_DBD_MYSQL=0;
+        $FOUND_DBD_MARIADB=0;
 
         # Check for DBI module:
         $FOUND_DBI=1 if require DBI;
 
-        # Check for DBD::mysql module
-        $FOUND_DBD_MYSQL=1 if require DBD::mysql;
+        # Check for DBD::MariaDB module
+        $FOUND_DBD_MARIADB=1 if require DBD::MariaDB;
     };
 };
 
@@ -83,11 +83,11 @@ BEGIN {
 # The file must be created whether we write to it or not, otherwise mysql-test 
 # will complain if trying to source it. 
 # An empty file indicates failure to load modules.
-open(FILE, ">", $ENV{'MYSQL_TMP_DIR'}.'/dbidbd-mysql.txt');
+open(FILE, ">", $ENV{'MYSQL_TMP_DIR'}.'/dbiDBD-MariaDB.txt');
 
-if ($FOUND_DBI && $FOUND_DBD_MYSQL) {
+if ($FOUND_DBI && $FOUND_DBD_MARIADB) {
     # write a mysql-test command setting a variable to indicate success
-    print(FILE 'let $dbidbd= FOUND_DBI_DBD-MYSQL;'."\n");
+    print(FILE 'let $dbidbd= FOUND_DBI_DBD-MARIADB;'."\n");
 }
 
 # close the file.

--- a/plugin/handler_socket/client/hspool_test.pl
+++ b/plugin/handler_socket/client/hspool_test.pl
@@ -31,8 +31,8 @@ my $moreflds_prefix = get_conf("moreflds_prefix", "f");
 my $mysql_user = 'root';
 my $mysql_password = '';
 
-my $dsn = "DBI:mysql:database=;host=$host;port=$mysqlport"
-        . ";mysql_server_prepare=$ssps";
+my $dsn = "DBI:MariaDB:database=;host=$host;port=$mysqlport"
+        . ";mariadb_server_prepare=$ssps";
 my $dbh = DBI->connect($dsn, $mysql_user, $mysql_password,
 	{ RaiseError => 1 });
 my $hsargs = { 'host' => $host, 'port' => $hsport_rd };

--- a/plugin/handler_socket/client/hstest.pl
+++ b/plugin/handler_socket/client/hstest.pl
@@ -33,8 +33,8 @@ my $moreflds_prefix = get_conf("moreflds_prefix", "column0123456789_");
 my $keytype = get_conf("keytype", "varchar(32)");
 my $file = get_conf("file", undef);
 
-my $dsn = "DBI:mysql:database=;host=$host;port=$mysqlport"
-	. ";mysql_server_prepare=$ssps";
+my $dsn = "DBI:MariaDB:database=;host=$host;port=$mysqlport"
+	. ";mariadb_server_prepare=$ssps";
 my $dbh = DBI->connect($dsn, $mysqluser, $mysqlpass, { RaiseError => 1 });
 my $hsargs = { 'host' => $host, 'port' => $hsport };
 my $cli = new Net::HandlerSocket($hsargs);

--- a/plugin/handler_socket/regtest/common/hstest.pm
+++ b/plugin/handler_socket/regtest/common/hstest.pm
@@ -29,10 +29,10 @@ sub get_dbi_connection {
     = ($conf{dbname}, $conf{host}, $conf{myport}, $conf{ssps},
       $conf{user}, $conf{pass});
   my $mycnf = "binary_my.cnf";
-  my $dsn = "DBI:mysql:database=;host=$host;port=$myport"
-    . ";mysql_server_prepare=$ssps"
-    . ";mysql_read_default_group=perl"
-    . ";mysql_read_default_file=../common/$mycnf";
+  my $dsn = "DBI:MariaDB:database=;host=$host;port=$myport"
+    . ";mariadb_server_prepare=$ssps"
+    . ";mariadb_read_default_group=perl"
+    . ";mariadb_read_default_file=../common/$mycnf";
   my $dbh = DBI->connect($dsn, $user, $pass, { RaiseError => 1 });
   return $dbh;
 }

--- a/scripts/mysql_convert_table_format.sh
+++ b/scripts/mysql_convert_table_format.sh
@@ -57,10 +57,10 @@ if ($opt_port)
 }
 if (length($opt_socket))
 {
-  $connect_opt.=";mysql_socket=$opt_socket";
+  $connect_opt.=";mariadb_socket=$opt_socket";
 }
 
-$dbh = DBI->connect("DBI:mysql:$opt_database:${opt_host}$connect_opt",
+$dbh = DBI->connect("DBI:MariaDB:$opt_database:${opt_host}$connect_opt",
 		    $opt_user,
 		    $opt_password,
 		    { PrintError => 0})

--- a/scripts/mysql_setpermission.sh
+++ b/scripts/mysql_setpermission.sh
@@ -86,7 +86,7 @@ if ($opt_password eq '')
 
 
 # make the connection to MariaDB
-$dbh= DBI->connect("DBI:mysql:mysql:host=$sqlhost:port=$opt_port:mysql_socket=$opt_socket",$opt_user,$opt_password, {PrintError => 0}) ||
+$dbh= DBI->connect("DBI:MariaDB:mysql:host=$sqlhost:port=$opt_port:mariadb_socket=$opt_socket",$opt_user,$opt_password, {PrintError => 0}) ||
   die("Can't make a connection to the mysql server.\n The error: $DBI::errstr");
 
 # the start of the program

--- a/scripts/mysqlhotcopy.sh
+++ b/scripts/mysqlhotcopy.sh
@@ -192,12 +192,12 @@ $opt{allowold} = 1 if $opt{keepold};
 my $dsn;
 $dsn  = ";host=" . (defined($opt{host}) ? $opt{host} : "localhost");
 $dsn .= ";port=$opt{port}" if $opt{port};
-$dsn .= ";mysql_socket=$opt{socket}" if $opt{socket};
+$dsn .= ";mariadb_socket=$opt{socket}" if $opt{socket};
 
-# use mysql_read_default_group=mysqlhotcopy so that [client] and
+# use mariadb_read_default_group=mysqlhotcopy so that [client] and
 # [mysqlhotcopy] groups will be read from standard options files.
 
-my $dbh = DBI->connect("dbi:mysql:$dsn;mysql_read_default_group=mysqlhotcopy",
+my $dbh = DBI->connect("DBI:MariaDB:$dsn;mariadb_read_default_group=mysqlhotcopy",
                         $opt{user}, $opt{password},
 {
     RaiseError => 1,
@@ -796,7 +796,7 @@ sub record_log_pos {
 	
 	my $row_hash = get_row_hash( $dbh, "show slave status" );
 	my ($master_host, $log_file, $log_pos ); 
-	if ( $dbh->{mysql_serverinfo} =~ /^3\.23/ ) {
+	if ( $dbh->{mariadb_serverinfo} =~ /^3\.23/ ) {
 	    ($master_host, $log_file, $log_pos ) 
 	      = @{$row_hash}{ qw / Master_Host Log_File Pos / };
 	} else {

--- a/scripts/mytop.sh
+++ b/scripts/mytop.sh
@@ -230,11 +230,11 @@ my $dsn;
 
 ## Socket takes precedence.
 
-$dsn ="DBI:mysql:database=$config{db};mysql_read_default_group=mytop;";
+$dsn ="DBI:MariaDB:database=$config{db};mariadb_read_default_group=mytop;";
 
 if ($config{socket} and -S $config{socket})
 {
-    $dsn .= "mysql_socket=$config{socket}";
+    $dsn .= "mariadb_socket=$config{socket}";
 }
 else
 {
@@ -1877,7 +1877,7 @@ following:
 
   * Perl 5.005 or newer
   * Getopt::Long
-  * DBI and DBD::mysql
+  * DBI and DBD::MariaDB
   * Term::ReadKey from CPAN
 
 Most systems are likely to have all of those installed--except for

--- a/sql-bench/server-cfg.sh
+++ b/sql-bench/server-cfg.sh
@@ -116,8 +116,8 @@ sub new
   bless $self;
 
   $self->{'cmp_name'}		= "mysql";
-  $self->{'data_source'}	= "DBI:mysql:database=$database;host=$host";
-  $self->{'data_source'} .= ";mysql_socket=$socket" if($socket);
+  $self->{'data_source'}	= "DBI:MariaDB:database=$database;host=$host";
+  $self->{'data_source'} .= ";mariadb_socket=$socket" if($socket);
   $self->{'data_source'} .= ";$connect_options" if($connect_options);
   $self->{'limits'}		= \%limits;
   $self->{'blob'}		= "blob";

--- a/storage/maria/ma_ft_test1.h
+++ b/storage/maria/ma_ft_test1.h
@@ -311,7 +311,7 @@ struct { const char *f0, *f2; } data[NDATAS] = {
    {"18.4.49", "Problems linking with the C API"},
    {"18.4.50", "How to make a thread-safe client"},
    {"18.5", "MySQL Perl API's"},
-   {"18.5.1", "DBI with DBD::mysql"},
+   {"18.5.1", "DBI with DBD::MariaDB"},
    {"18.5.1.1", "The DBI interface"},
    {"18.5.1.2", "More DBI/DBD information"},
    {"18.6", "MySQL Java connectivity (JDBC)"},

--- a/storage/rocksdb/mysql-test/rocksdb/t/rqg.inc
+++ b/storage/rocksdb/mysql-test/rocksdb/t/rqg.inc
@@ -25,8 +25,8 @@ foreach $grammar_file (split(/ /, $ENV{'GRAMMAR_FILES'})) {
 
   # Errors from the gentest.pl file will be captured in the results file
   my $cmd = "perl $ENV{'RQG_BASE'}/gentest.pl " .
-      "--dsn=dbi:mysql:host=:port=:user=root:database=$ENV{'TESTDB'}" .
-      ":mysql_socket=$ENV{'MYSQL_SOCKET'} " .
+      "--dsn=DBI:MariaDB:host=:port=:user=root:database=$ENV{'TESTDB'}" .
+      ":mariadb_socket=$ENV{'MYSQL_SOCKET'} " .
       "--gendata=$ENV{'RQG_BASE'}/conf/$ENV{'TESTDIR'}/$ENV{'DATA_FILE'} " .
       "--grammar=$ENV{'RQG_BASE'}/conf/$ENV{'TESTDIR'}/$grammar_file " .
       "--threads=5 --queries=10000 --duration=60 --sqltrace 2>&1 >> " .

--- a/tests/big_record.pl
+++ b/tests/big_record.pl
@@ -37,9 +37,9 @@ GetOptions("host=s","db=s","user=s", "password=s", "table=s", "rows=i",
 print "Connection to database $test_db\n";
 
 $extra_options="";
-$extra_options.=":mysql_compression=1" if ($opt_compress);
+$extra_options.=":mariadb_compression=1" if ($opt_compress);
 
-$dbh = DBI->connect("DBI:mysql:$opt_db:$host$extra_options",$opt_user,$opt_password) || die "Can't connect: $DBI::errstr\n";
+$dbh = DBI->connect("DBI:MariaDB:$opt_db:$host$extra_options",$opt_user,$opt_password) || die "Can't connect: $DBI::errstr\n";
 
 $dbh->do("drop table if exists $opt_table");
 
@@ -65,7 +65,7 @@ for ($i=0 ; $i < $opt_rows ; $i++)
 
 print "\nReading records\n";
 
-$sth=$dbh->prepare("select * from $opt_table", { "mysql_use_result" => 1}) or die $dbh->errstr;
+$sth=$dbh->prepare("select * from $opt_table", { "mariadb_use_result" => 1}) or die $dbh->errstr;
 
 $sth->execute() or die $sth->errstr;
 

--- a/tests/check_async_queries.pl
+++ b/tests/check_async_queries.pl
@@ -13,7 +13,7 @@ my $D= [];
 die "Usage: $0 <host> <user> <password> <database>\n"
     unless @ARGV == 4;
 
-my $dbh= DBI->connect("DBI:mysql:database=$ARGV[3];host=$ARGV[0]",
+my $dbh= DBI->connect("DBI:MariaDB:database=$ARGV[3];host=$ARGV[0]",
                       $ARGV[1], $ARGV[2],
                       { RaiseError => 1, PrintError => 0 });
 

--- a/tests/consistent_snapshot.pl
+++ b/tests/consistent_snapshot.pl
@@ -17,7 +17,7 @@ my $DURATION= 20;
 my $stop_time= time() + $DURATION;
 
 sub my_connect {
-  my $dbh= DBI->connect("dbi:mysql:mysql_socket=/tmp/mysql.sock;database=test",
+  my $dbh= DBI->connect("DBI:MariaDB:mariadb_socket=/tmp/mysql.sock;database=test",
                         "root", undef, { RaiseError=>1, PrintError=>0, AutoCommit=>0});
   $dbh->do("SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ");
   $dbh->do("SET SESSION autocommit = 0");

--- a/tests/drop_test.pl
+++ b/tests/drop_test.pl
@@ -50,7 +50,7 @@ $firsttable  = "bench_f1";
 $start_time=new Benchmark;
 if (!$opt_skip_create)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table if exists $firsttable, ${firsttable}_1, ${firsttable}_2");
@@ -81,7 +81,7 @@ while (($pid=wait()) != -1)
 
 if (!$opt_skip_delete && !$errors)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table $firsttable");
@@ -103,7 +103,7 @@ sub test_insert
 {
   my ($dbh,$i);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   for ($i=0 ; $i < $opt_loop_count; $i++)
@@ -124,7 +124,7 @@ sub test_drop
   my ($id) = @_;
   my ($dbh,$i,$sth,$error_counter,$sleep_time);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $error_counter=0;
@@ -169,7 +169,7 @@ sub test_select
 {
   my ($dbh,$i,$sth,@row,$error_counter,$sleep_time);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -206,7 +206,7 @@ sub test_flush
 {
   my ($dbh,$i,$sth,@row,$error_counter,$sleep_time);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 

--- a/tests/fork_big.pl
+++ b/tests/fork_big.pl
@@ -65,7 +65,7 @@ srand 100;			# Make random numbers repeatable
 ####
 
 $start_time=new Benchmark;
-$dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+$dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		    $opt_user, $opt_password,
 		  { PrintError => 0}) || die $DBI::errstr;
 if (!$opt_skip_create)
@@ -155,7 +155,7 @@ while (($pid=wait()) != -1)
 if (!$opt_skip_delete && !$errors)
 {
   my $table_def;
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -189,7 +189,7 @@ sub test_insert
     $from_table=0; $to_table=$numtables-1;
   }
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -218,7 +218,7 @@ sub test_select
 {
   my ($dbh, $i, $j, $count, $loop, $count_query, $row_counts);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -255,7 +255,7 @@ sub test_select_count
 {
   my ($dbh, $i, $j, $count, $loop);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -285,7 +285,7 @@ sub test_join
 {
   my ($dbh, $i, $j, $count, $loop, $count_query, $row_counts);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -326,7 +326,7 @@ sub test_delete
 
   $table_count=2;
   $count=0;
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -360,7 +360,7 @@ sub test_delete
 sub test_update
 {
   my ($dbh, $i, $j, $row_counts, $count_query, $count, $loop);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -403,7 +403,7 @@ sub test_update
 sub test_check
 {
   my ($dbh, $sth, $row, $i, $j, $type, $table);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -440,7 +440,7 @@ sub test_check
 sub test_repair
 {
   my ($dbh, $sth, $row, $i, $type, $table);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -474,7 +474,7 @@ sub test_flush
 {
   my ($dbh,$count,$tables);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -502,7 +502,7 @@ sub test_database
 {
   my ($database) = @_;
   my ($dbh, $sth, $row, $i, $type, $tables);
-  $dbh = DBI->connect("DBI:mysql:$database:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$database:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -535,7 +535,7 @@ sub test_database
 sub test_alter
 {
   my ($dbh, $sth, $row, $i, $type, $table);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -559,7 +559,7 @@ sub test_alter
 sub signal_abort
 {
   my ($dbh);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 

--- a/tests/fork_big2.pl
+++ b/tests/fork_big2.pl
@@ -81,7 +81,7 @@ if ($opt_time == 0 && $opt_insert == 0)
 }
 
 $start_time=new Benchmark;
-$dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+$dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		    $opt_user, $opt_password,
 		  { PrintError => 0}) || die $DBI::errstr;
 if (!$opt_skip_create)
@@ -212,7 +212,7 @@ while (($pid=wait()) != -1)
 if (!$opt_skip_drop && !$errors)
 {
   my $table_def;
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -257,7 +257,7 @@ sub test_insert
     $from_table=0; $to_table=$numtables-1;
   }
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -286,7 +286,7 @@ sub test_select
 {
   my ($dbh, $i, $j, $count, $loop);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -323,7 +323,7 @@ sub test_select_count
 {
   my ($dbh, $i, $j, $count, $loop);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -353,7 +353,7 @@ sub test_join
 {
   my ($dbh, $i, $j, $count, $loop);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -391,7 +391,7 @@ sub test_join_count
 {
   my ($dbh, $i, $j, $count, $loop);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -446,7 +446,7 @@ sub test_delete
 
   $table_count=2;
   $count=0;
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -480,7 +480,7 @@ sub test_delete
 sub test_update
 {
   my ($dbh, $i, $j, $row_counts, $count_query, $count, $loop);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -523,7 +523,7 @@ sub test_update
 sub test_check
 {
   my ($dbh, $row, $i, $j, $type, $table);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -560,7 +560,7 @@ sub test_check
 sub test_repair
 {
   my ($dbh, $row, $i, $type, $table);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -594,7 +594,7 @@ sub test_flush
 {
   my ($dbh,$count,$tables);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -621,7 +621,7 @@ sub test_resize
 {
   my ($dbh, $key_buffer_size);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -648,7 +648,7 @@ sub test_database
 {
   my ($database) = @_;
   my ($dbh, $row, $i, $type, $tables);
-  $dbh = DBI->connect("DBI:mysql:$database:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$database:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -681,7 +681,7 @@ sub test_database
 sub test_alter
 {
   my ($dbh, $row, $i, $type, $table);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -705,7 +705,7 @@ sub test_alter
 sub signal_abort
 {
   my ($dbh);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 

--- a/tests/grant.pl
+++ b/tests/grant.pl
@@ -60,7 +60,7 @@ unlink($tmp_table);
 # clear grant tables
 #
 
-$dbh = DBI->connect("DBI:mysql:mysql:$opt_host",
+$dbh = DBI->connect("DBI:MariaDB:mysql:$opt_host",
 		    $opt_root_user,$opt_password,
 		    { PrintError => 0}) || die "Can't connect to mysql server with user '$opt_root_user': $DBI::errstr\n";
 
@@ -653,7 +653,7 @@ sub user_connect
   print "Connecting $opt_user\n" if ($opt_verbose);
   $user_dbh->disconnect if (defined($user_dbh));
 
-  $user_dbh=DBI->connect("DBI:mysql:$opt_database:$opt_host",$opt_user,
+  $user_dbh=DBI->connect("DBI:MariaDB:$opt_database:$opt_host",$opt_user,
 			 $password, { PrintError => 0});
   if (!$user_dbh)
   {

--- a/tests/index_corrupt.pl
+++ b/tests/index_corrupt.pl
@@ -51,7 +51,7 @@ $kill_file= "/tmp/mysqltest_index_corrupt.$$";
 $start_time=new Benchmark;
 if (!$opt_skip_create)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table if exists $firsttable, $secondtable");
@@ -111,7 +111,7 @@ while (($pid=wait()) != -1)
 
 if (!$opt_skip_delete && !$errors)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table $firsttable, $secondtable");
@@ -134,7 +134,7 @@ sub insert_in_bench
 {
   my ($dbh,$rows,$found,$i);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   for ($rows= 1; $rows <= $opt_loop_count ; $rows++)
@@ -179,7 +179,7 @@ sub select_from_bench
 {
   my ($dbh,$rows,$cursor);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   for ($rows= 1; $rows < $opt_loop_count ; $rows++)
@@ -206,7 +206,7 @@ sub delete_from_bench
 {
   my ($dbh,$row, $t_value, $t2_value, $statement, $cursor);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 

--- a/tests/insert_and_repair.pl
+++ b/tests/insert_and_repair.pl
@@ -49,7 +49,7 @@ $secondtable = "bench_f2";
 $start_time=new Benchmark;
 if (!$opt_skip_create)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table if exists $firsttable, $secondtable");
@@ -79,7 +79,7 @@ while (($pid=wait()) != -1)
 
 if (!$opt_skip_delete && !$errors)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table $firsttable,$secondtable");
@@ -100,7 +100,7 @@ sub insert_in_bench1
 {
   my ($dbh,$rows,$found,$i);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $rows=$found=0;
@@ -123,7 +123,7 @@ sub insert_in_bench2
 {
   my ($dbh,$rows,$found,$i);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $rows=$found=0;
@@ -149,7 +149,7 @@ sub repair_and_check
       $table);
   $found1=$found2=0; $last_found1=$last_found2= -1;
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 

--- a/tests/mail_to_db.pl
+++ b/tests/mail_to_db.pl
@@ -110,12 +110,12 @@ sub main
     die "FATAL: Can't find inbox file: $ARGV[$i]\n" if (! -f $ARGV[$i]);
   }
 
-  $connect_arg = "DBI:mysql:";
+  $connect_arg = "DBI:MariaDB:";
   push @args, "database=$opt_db" if defined($opt_db);
   push @args, "host=$opt_host" if defined($opt_host);
   push @args, "port=$opt_port" if defined($opt_port);
-  push @args, "mysql_socket=$opt_socket" if defined($opt_socket);
-  push @args, "mysql_read_default_group=mail_to_db";
+  push @args, "mariadb_socket=$opt_socket" if defined($opt_socket);
+  push @args, "mariadb_read_default_group=mail_to_db";
   $connect_arg .= join ';', @args;
   $dbh = DBI->connect("$connect_arg", $opt_user, $opt_password,
 		     { PrintError => 0})

--- a/tests/pmail.pl
+++ b/tests/pmail.pl
@@ -60,7 +60,7 @@ if ($opt_help || !$ARGV[0])
 #### Connect and parsing the query to MySQL
 ####
 
-$dbh= DBI->connect("DBI:mysql:$opt_db:$opt_host:port=$opt_port:mysql_socket=$opt_socket", $opt_user,$opt_password, { PrintError => 0})
+$dbh= DBI->connect("DBI:MariaDB:$opt_db:$opt_host:port=$opt_port:mariadb_socket=$opt_socket", $opt_user,$opt_password, { PrintError => 0})
 || die $DBI::errstr;
 
 main();

--- a/tests/rename_test.pl
+++ b/tests/rename_test.pl
@@ -48,7 +48,7 @@ $firsttable  = "bench_f1";
 $start_time=new Benchmark;
 if (!$opt_skip_create)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table if exists $firsttable, ${firsttable}_1, ${firsttable}_2");
@@ -81,7 +81,7 @@ while (($pid=wait()) != -1)
 
 if (!$opt_skip_delete && !$errors)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $dbh->do("drop table $firsttable");
@@ -103,7 +103,7 @@ sub test_insert
 {
   my ($dbh,$i,$error);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   for ($i=0 ; $i < $opt_loop_count; $i++)
@@ -128,7 +128,7 @@ sub test_rename
   my ($id) = @_;
   my ($dbh,$i,$error_counter,$sleep_time);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
   $error_counter=0;
@@ -158,7 +158,7 @@ sub test_select
 {
   my ($dbh,$i,$sth,@row,$sleep_time);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -192,7 +192,7 @@ sub test_flush
 {
   my ($dbh,$i,$sth,@row,$error_counter,$sleep_time);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 

--- a/tests/test_delayed_insert.pl
+++ b/tests/test_delayed_insert.pl
@@ -50,7 +50,7 @@ $secondtable = "bench_f2";
 $start_time=new Benchmark;
 if (!$opt_skip_create)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $Mysql::QUIET = 1;
   $dbh->do("drop table if exists $firsttable,$secondtable");
   $Mysql::QUIET = 0;
@@ -87,7 +87,7 @@ while (($pid=wait()) != -1)
 
 if (!$opt_skip_delete && !$errors)
 {
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $dbh->do("drop table $firsttable");
   $dbh->do("drop table $secondtable");
 }
@@ -107,7 +107,7 @@ sub test_1
 {
   my ($dbh,$tmpvar,$rows,$found,$i);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $tmpvar=1;
   $rows=$found=0;
   for ($i=0 ; $i < $opt_loop_count; $i++)
@@ -131,7 +131,7 @@ sub test_delayed_1
 {
   my ($dbh,$tmpvar,$rows,$found,$i,$id);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $tmpvar=1;
   $rows=$found=0;
   for ($i=0 ; $i < $opt_loop_count; $i++)
@@ -162,7 +162,7 @@ sub test_delayed_2
 {
   my ($dbh,$tmpvar,$rows,$found,$i,$id);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $tmpvar=1;
   $rows=$found=0;
   for ($i=0 ; $i < $opt_loop_count; $i++)
@@ -196,7 +196,7 @@ sub test_2
 {
   my ($dbh,$id,$tmpvar,$rows,$found,$i,$max_id,$tmp,$sth,$count);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $tmpvar=111111;
   $rows=$found=$max_id=$id=0;
   for ($i=0 ; $i < $opt_loop_count ; $i++)
@@ -245,7 +245,7 @@ sub test_2
 sub test_3
 {
   my ($dbh,$id,$tmpvar,$rows,$i,$count);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $tmpvar=222222;
   $rows=0;
   for ($i=0 ; $i < $opt_loop_count ; $i++)
@@ -269,7 +269,7 @@ sub test_3
 sub test_4
 {
   my ($dbh,$id,$tmpvar,$rows,$i,$count);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $tmpvar=333333;
   $rows=0;
   for ($i=0 ; $i < $opt_loop_count; $i++)
@@ -288,7 +288,7 @@ sub test_4
 sub test_5
 {
   my ($dbh,$id,$tmpvar,$rows,$i,$max_id,$count,$sth);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $tmpvar=444444;
   $rows=$max_id=0;
   for ($i=0 ; $i < $opt_loop_count ; $i++)
@@ -328,7 +328,7 @@ sub test_5
 sub test_del
 {
   my ($dbh,$min_id,$i,$sth,$rows);
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host") || die $DBI::errstr;
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host") || die $DBI::errstr;
   $rows=0;
   for ($i=0 ; $i < $opt_loop_count/3; $i++)
   {
@@ -357,7 +357,7 @@ sub test_flush
   my ($dbh,$sth,$found1,$last_found1,$i,@row);
   $found1=0; $last_found1=-1;
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 

--- a/tests/truncate.pl
+++ b/tests/truncate.pl
@@ -47,7 +47,7 @@ print "Testing truncate from $opt_threads multiple connections $opt_loop_count t
 ####
 
 $start_time=new Benchmark;
-$dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+$dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		    $opt_user, $opt_password,
 		  { PrintError => 0}) || die $DBI::errstr;
 if (!$opt_skip_create)
@@ -100,7 +100,7 @@ while (($pid=wait()) != -1)
 if (!$opt_skip_delete && !$errors)
 {
   my $table_def;
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 
@@ -127,7 +127,7 @@ sub test_truncate
 {
   my ($dbh,$i,$j,$count,$table_def,$table);
 
-  $dbh = DBI->connect("DBI:mysql:$opt_db:$opt_host",
+  $dbh = DBI->connect("DBI:MariaDB:$opt_db:$opt_host",
 		      $opt_user, $opt_password,
 		    { PrintError => 0}) || die $DBI::errstr;
 


### PR DESCRIPTION
Perl DBD::MariaDB driver is available CPAN and is already used in
production environment.