### PR TITLE
MDEV-19563 Removed references to deprecated option innodb_locks_unsaf…

### DIFF
--- a/Docs/README-wsrep
+++ b/Docs/README-wsrep
@@ -269,9 +269,6 @@ innodb_autoinc_lock_mode=2
    autoinc lock modes 0 and 1 can cause unresolved deadlock, and make
    the system unresponsive.
 
-innodb_locks_unsafe_for_binlog=1
-   This option is required for parallel applying.
-
 5.2 WSREP OPTIONS
 
 All options are optional except for wsrep_provider, wsrep_cluster_address, and

--- a/plugin/wsrep_info/mysql-test/wsrep_info/my.cnf
+++ b/plugin/wsrep_info/mysql-test/wsrep_info/my.cnf
@@ -5,7 +5,6 @@
 wsrep-on=1
 binlog-format=row
 innodb-autoinc-lock-mode=2
-innodb-locks-unsafe-for-binlog=1
 wsrep-cluster-address=gcomm://
 wsrep_provider=@ENV.WSREP_PROVIDER
 


### PR DESCRIPTION
…e_for_binlog

innodb_locks_unsafe_for_binlog variabe removed from wsrep_info test configuration and
recommendation to use this variable in README-wsrep was removed as well

Also relates to issue: MDEV-19544