### PR TITLE
MDEV-18940 Galera: Rolling upgrade: all nodes except upgraded node5 failed with Assertion `meta->gtid.seqno == wsrep_thd_trx_seqno(thd)' with SEQUENCEs

### DIFF
--- a/sql/wsrep_applier.cc
+++ b/sql/wsrep_applier.cc
@@ -360,7 +360,7 @@ wsrep_cb_status_t wsrep_commit_cb(void*         const     ctx,
 {
   THD* const thd((THD*)ctx);
 
-  assert(meta->gtid.seqno == wsrep_thd_trx_seqno(thd));
+  assert(meta->gtid.seqno >= wsrep_thd_trx_seqno(thd));
 
   wsrep_cb_status_t rcode;
 


### PR DESCRIPTION
Empty write sets will not trigger apply callback, and will not
update thread wsrep_trx_meta.gtid.seqno. Because of that assert will
be triggered when commit callback is called.