### PR TITLE
 - wsrep-lib update (streaming replication cleanups and voting support)

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -5824,7 +5824,7 @@ compare_errors:
                     thd->get_db(), query_arg);
       thd->is_slave_error= 1;
 #ifdef WITH_WSREP
-      if (thd->wsrep_apply_toi && wsrep_must_ignore_error(thd))
+      if (wsrep_thd_is_toi(thd) && wsrep_must_ignore_error(thd))
       {
         thd->clear_error(1);
         thd->killed= NOT_KILLED;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -664,7 +664,6 @@ THD::THD(my_thread_id id, bool is_wsrep_applier)
    wsrep_po_handle(WSREP_PO_INITIALIZER),
    wsrep_po_cnt(0),
    wsrep_apply_format(0),
-   wsrep_apply_toi(false),
    wsrep_rbr_buf(NULL),
    wsrep_sync_wait_gtid(WSREP_GTID_UNDEFINED),
    wsrep_affected_rows(0),

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4816,7 +4816,6 @@ public:
   rpl_sid                   wsrep_po_sid;
 #endif /* GTID_SUPPORT */
   void                      *wsrep_apply_format;
-  bool                      wsrep_apply_toi; /* applier processing in TOI */
   uchar*                    wsrep_rbr_buf;
   wsrep_gtid_t              wsrep_sync_wait_gtid;
   //  wsrep_gtid_t              wsrep_last_written_gtid;

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -1343,8 +1343,9 @@ int Wsrep_schema::recover_sr_transactions(THD *orig_thd)
                                    ws_meta);
       }
       applier->store_globals();
-      applier->apply_write_set(ws_meta, data);
-      applier->after_apply();
+      wsrep::mutable_buffer unused;
+      applier->apply_write_set(ws_meta, data, unused);
+      applier->after_apply(wsrep::const_buffer());
       storage_service.store_globals();
     }
     else if (error == HA_ERR_END_OF_FILE)

--- a/sql/wsrep_storage_service.cc
+++ b/sql/wsrep_storage_service.cc
@@ -174,7 +174,7 @@ int Wsrep_storage_service::commit(const wsrep::ws_handle& ws_handle,
                                            false);
     trans_rollback(m_thd);
   }
-  m_thd->wsrep_cs().after_applying();
+  m_thd->wsrep_cs().after_applying(wsrep::const_buffer());
   m_thd->mdl_context.release_transactional_locks();
   DBUG_RETURN(ret);
 }
@@ -189,7 +189,7 @@ int Wsrep_storage_service::rollback(const wsrep::ws_handle& ws_handle,
   int ret= (m_thd->wsrep_cs().prepare_for_ordering(
             ws_handle, ws_meta, false) ||
             trans_rollback(m_thd));
-  m_thd->wsrep_cs().after_applying();
+  m_thd->wsrep_cs().after_applying(wsrep::const_buffer());
   m_thd->mdl_context.release_transactional_locks();
   DBUG_RETURN(ret);
 }

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -171,7 +171,7 @@ static void wsrep_rollback_process(THD *rollbacker,
         DBUG_ASSERT(thd->wsrep_applier_service);
         thd->wsrep_applier_service->rollback(wsrep::ws_handle(),
                                              wsrep::ws_meta());
-        thd->wsrep_applier_service->after_apply();
+        thd->wsrep_applier_service->after_apply(wsrep::const_buffer());
         /* Will free THD */
         Wsrep_server_state::instance().server_service().
           release_high_priority_service(thd->wsrep_applier_service);
@@ -222,7 +222,7 @@ static void wsrep_rollback_process(THD *rollbacker,
       thd->wsrep_cs().store_globals();
       thd->wsrep_applier_service->rollback(wsrep::ws_handle(),
                                            wsrep::ws_meta());
-      thd->wsrep_applier_service->after_apply();
+      thd->wsrep_applier_service->after_apply(wsrep::const_buffer());
       /* Will free THD */
       Wsrep_server_state::instance().server_service()
         .release_high_priority_service(thd->wsrep_applier_service);

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -388,11 +388,11 @@ int wsrep_after_statement(THD* thd)
               thd->wsrep_cs().after_statement() : 0);
 }
 
-static inline void wsrep_after_apply(THD* thd)
+static inline int wsrep_after_apply(THD* thd)
 {
   DBUG_ASSERT(wsrep_thd_is_applying(thd));
   WSREP_DEBUG("wsrep_after_apply %lld", thd->thread_id);
-  thd->wsrep_cs().after_applying();
+  return thd->wsrep_cs().after_applying(wsrep::const_buffer());
 }
 
 static inline void wsrep_open(THD* thd)


### PR DESCRIPTION
 - TOI error ignoring fix (wsrep_ignore_apply_errors)

This wsrep-lib update completes in wsrep-lib functionality required for https://jira.mariadb.org/browse/MDEV-17048 (passing error description buffer from applier to provider), and fixes a number of bugs (like not returning an error code from `after_apply()` method). However it does not add any new features yet.