### PR TITLE
MDEV-17402 slave_transaction_retry_errors="12701" won't be enabled

### DIFF
--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -1046,7 +1046,7 @@ bool init_slave_transaction_retry_errors(const char* arg)
   {
     if (!(p= str2int(p, 10, 0, LONG_MAX, &err_code)))
       break;
-    if (err_code > 0 && err_code < ER_ERROR_LAST)
+    if (err_code > 0)
       slave_transaction_retry_errors[i++]= (uint) err_code;
     while (!my_isdigit(system_charset_info,*p) && *p)
       p++;

--- a/storage/spider/mysql-test/spider/bugfix/include/slave_transaction_retry_errors_5digit_deinit.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/slave_transaction_retry_errors_5digit_deinit.inc
@@ -1,0 +1,10 @@
+--connection slave1_1
+--disable_warnings
+--disable_query_log
+--disable_result_log
+--source ../include/deinit_spider.inc
+--source ../t/slave_test_deinit.inc
+--source ../t/test_deinit.inc
+--enable_result_log
+--enable_query_log
+--enable_warnings

--- a/storage/spider/mysql-test/spider/bugfix/include/slave_transaction_retry_errors_5digit_init.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/slave_transaction_retry_errors_5digit_init.inc
@@ -1,0 +1,10 @@
+--disable_warnings
+--disable_query_log
+--disable_result_log
+--source ../t/test_init.inc
+--source ../t/slave_test_init.inc
+--connection slave1_1
+--source ../include/init_spider.inc
+--enable_result_log
+--enable_query_log
+--enable_warnings

--- a/storage/spider/mysql-test/spider/bugfix/r/slave_transaction_retry_errors_5digit.result
+++ b/storage/spider/mysql-test/spider/bugfix/r/slave_transaction_retry_errors_5digit.result
@@ -1,0 +1,22 @@
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+for slave1_1
+
+connection slave1_1;
+SHOW VARIABLES LIKE 'slave_transaction_retry_errors';
+Variable_name	Value
+slave_transaction_retry_errors	1158,1159,1160,1161,1205,1213,1429,2013,12701,10000,20000,30000
+connection slave1_1;
+for slave1_1
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+
+end of test

--- a/storage/spider/mysql-test/spider/bugfix/t/slave_transaction_retry_errors_5digit.cnf
+++ b/storage/spider/mysql-test/spider/bugfix/t/slave_transaction_retry_errors_5digit.cnf
@@ -1,0 +1,6 @@
+!include include/default_mysqld.cnf
+!include ../my_1_1.cnf
+!include ../my_2_1.cnf
+!include ../my_4_1.cnf
+[mysqld.4.1]
+slave_transaction_retry_errors="10000,20000,30000"

--- a/storage/spider/mysql-test/spider/bugfix/t/slave_transaction_retry_errors_5digit.test
+++ b/storage/spider/mysql-test/spider/bugfix/t/slave_transaction_retry_errors_5digit.test
@@ -1,0 +1,9 @@
+--source ../include/slave_transaction_retry_errors_5digit_init.inc
+--echo
+
+--connection slave1_1
+SHOW VARIABLES LIKE 'slave_transaction_retry_errors';
+
+--source ../include/slave_transaction_retry_errors_5digit_deinit.inc
+--echo
+--echo end of test


### PR DESCRIPTION
error code 12701 is already included in default value, but other plugin specific error codes are ignored because of checking with ER_ERROR_LAST. ER_ERROR_LAST does not include plugin specific error codes. So I just removed it for fixing this issue.