### PR TITLE
MDEV-16508 spider: sql_mode not maintained between spider node and da…

### DIFF
--- a/storage/spider/mysql-test/spider/bugfix/include/sql_mode_deinit.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/sql_mode_deinit.inc
@@ -1,0 +1,13 @@
+--let $MASTER_1_COMMENT_2_1= $MASTER_1_COMMENT_2_1_BACKUP
+--let $CHILD2_1_DROP_TABLES= $CHILD2_1_DROP_TABLES_BACKUP
+--let $CHILD2_1_CREATE_TABLES= $CHILD2_1_CREATE_TABLES_BACKUP
+--let $CHILD2_1_SELECT_TABLES= $CHILD2_1_SELECT_TABLES_BACKUP
+--connection master_1
+set session sql_mode= @old_sql_mode;
+--disable_warnings
+--disable_query_log
+--disable_result_log
+--source ../t/test_deinit.inc
+--enable_result_log
+--enable_query_log
+--enable_warnings

--- a/storage/spider/mysql-test/spider/bugfix/include/sql_mode_init.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/sql_mode_init.inc
@@ -1,0 +1,40 @@
+--disable_warnings
+--disable_query_log
+--disable_result_log
+--source ../t/test_init.inc
+--enable_result_log
+--enable_query_log
+--enable_warnings
+--let $SQL_MODES= real_as_float,pipes_as_concat,ansi_quotes,ignore_space,ignore_bad_table_options,only_full_group_by,no_unsigned_subtraction,no_dir_in_create,postgresql,oracle,mssql,db2,maxdb,no_key_options,no_table_options,no_field_options,mysql323,mysql40,ansi,no_auto_value_on_zero,no_backslash_escapes,strict_trans_tables,strict_all_tables,no_zero_in_date,no_zero_date,allow_invalid_dates,error_for_division_by_zero,traditional,no_auto_create_user,high_not_precedence,no_engine_substitution,pad_char_to_full_length
+if (`SELECT IF(STRCMP('$SERVER_NAME', 'MariaDB') = 0, 1, 0)`)
+{
+  if (`SELECT IF($SERVER_MAJOR_VERSION = 10, 1, 0)`)
+  {
+    if (`SELECT IF($SERVER_MINOR_VERSION >= 3, 1, 0)`)
+    {
+      --let $SQL_MODES= $SQL_MODES,empty_string_is_null,simultaneous_assignment
+    }
+    if (`SELECT IF($SERVER_MINOR_VERSION >= 4, 1, 0)`)
+    {
+      --let $SQL_MODES= $SQL_MODES,time_round_fractional
+    }
+  }
+}
+--connection master_1
+set @old_sql_mode= @@sql_mode;
+eval set session sql_mode= '$SQL_MODES';
+--let $MASTER_1_COMMENT_2_1_BACKUP= $MASTER_1_COMMENT_2_1
+--let $CHILD2_1_DROP_TABLES_BACKUP= $CHILD2_1_DROP_TABLES
+let $CHILD2_1_DROP_TABLES=
+  DROP TABLE IF EXISTS tbl_a;
+--let $CHILD2_1_CREATE_TABLES_BACKUP= $CHILD2_1_CREATE_TABLES
+let $CHILD2_1_CREATE_TABLES=
+  CREATE TABLE tbl_a (
+    pkey int NOT NULL,
+    PRIMARY KEY (pkey)
+  ) $CHILD2_1_ENGINE $CHILD2_1_CHARSET;
+--let $CHILD2_1_SELECT_TABLES_BACKUP= $CHILD2_1_SELECT_TABLES
+let $CHILD2_1_SELECT_TABLES=
+  SELECT pkey FROM tbl_a ORDER BY pkey;
+let $CHILD2_1_SELECT_ARGUMENT1=
+  SELECT argument FROM mysql.general_log WHERE argument LIKE '%sql_mode%';

--- a/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mariadb_deinit.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mariadb_deinit.inc
@@ -1,0 +1,1 @@
+--source sql_mode_deinit.inc

--- a/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mariadb_init.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mariadb_init.inc
@@ -1,0 +1,3 @@
+--source sql_mode_init.inc
+let $MASTER_1_COMMENT_2_1=
+  COMMENT='table "tbl_a", srv "s_2_1", wrapper "mariadb"';

--- a/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mysql_deinit.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mysql_deinit.inc
@@ -1,0 +1,1 @@
+--source sql_mode_deinit.inc

--- a/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mysql_init.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/sql_mode_mysql_init.inc
@@ -1,0 +1,3 @@
+--source sql_mode_init.inc
+let $MASTER_1_COMMENT_2_1=
+  COMMENT='table "tbl_a", srv "s_2_1", wrapper "mysql"';

--- a/storage/spider/mysql-test/spider/bugfix/r/slave_trx_isolation.result
+++ b/storage/spider/mysql-test/spider/bugfix/r/slave_trx_isolation.result
@@ -50,7 +50,7 @@ SELECT argument FROM mysql.general_log WHERE argument LIKE '%set %';
 argument
 set session time_zone = '+00:00'
 SET NAMES utf8
-set session transaction isolation level read committed;set session autocommit = 1;set session wait_timeout = 604800;start transaction
+set session transaction isolation level read committed;set session autocommit = 1;set session wait_timeout = 604800;set session sql_mode = 'strict_trans_tables,error_for_division_by_zero,no_auto_create_user,no_engine_substitution';start transaction
 SELECT argument FROM mysql.general_log WHERE argument LIKE '%set %'
 SELECT pkey FROM tbl_a ORDER BY pkey;
 pkey

--- a/storage/spider/mysql-test/spider/bugfix/r/sql_mode_mariadb.result
+++ b/storage/spider/mysql-test/spider/bugfix/r/sql_mode_mariadb.result
@@ -1,0 +1,83 @@
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+connection master_1;
+set @old_sql_mode= @@sql_mode;
+set session sql_mode= 'real_as_float,pipes_as_concat,ansi_quotes,ignore_space,ignore_bad_table_options,only_full_group_by,no_unsigned_subtraction,no_dir_in_create,postgresql,oracle,mssql,db2,maxdb,no_key_options,no_table_options,no_field_options,mysql323,mysql40,ansi,no_auto_value_on_zero,no_backslash_escapes,strict_trans_tables,strict_all_tables,no_zero_in_date,no_zero_date,allow_invalid_dates,error_for_division_by_zero,traditional,no_auto_create_user,high_not_precedence,no_engine_substitution,pad_char_to_full_length,empty_string_is_null,simultaneous_assignment,time_round_fractional';
+
+this test is for MDEV-16508
+
+drop and create databases
+connection master_1;
+CREATE DATABASE auto_test_local;
+USE auto_test_local;
+connection child2_1;
+SET @old_log_output = @@global.log_output;
+SET GLOBAL log_output = 'TABLE,FILE';
+CREATE DATABASE auto_test_remote;
+USE auto_test_remote;
+
+create table and insert
+connection child2_1;
+CHILD2_1_CREATE_TABLES
+TRUNCATE TABLE mysql.general_log;
+connection master_1;
+CREATE TABLE tbl_a (
+pkey int NOT NULL,
+PRIMARY KEY (pkey)
+) MASTER_1_ENGINE MASTER_1_CHARSET MASTER_1_COMMENT_2_1
+INSERT INTO tbl_a (pkey) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+select test
+connection child2_1;
+TRUNCATE TABLE mysql.general_log;
+connection master_1;
+SELECT * FROM tbl_a ORDER BY pkey;
+pkey
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+connection child2_1;
+SELECT argument FROM mysql.general_log WHERE argument LIKE '%sql_mode%';
+argument
+set session transaction isolation level repeatable read;set session autocommit = 1;set session sql_log_off = 0;set session wait_timeout = 604800;set session sql_mode = 'real_as_float,ignore_bad_table_options,no_unsigned_subtraction,no_dir_in_create,no_auto_value_on_zero,strict_trans_tables,strict_all_tables,no_zero_in_date,no_zero_date,allow_invalid_dates,error_for_division_by_zero,no_auto_create_user,high_not_precedence,no_engine_substitution,pad_char_to_full_length,empty_string_is_null,simultaneous_assignment,time_round_fractional';set session time_zone = '+00:00';start transaction
+SELECT argument FROM mysql.general_log WHERE argument LIKE '%sql_mode%'
+SELECT pkey FROM tbl_a ORDER BY pkey;
+pkey
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+deinit
+connection master_1;
+DROP DATABASE IF EXISTS auto_test_local;
+connection child2_1;
+DROP DATABASE IF EXISTS auto_test_remote;
+SET GLOBAL log_output = @old_log_output;
+connection master_1;
+set session sql_mode= @old_sql_mode;
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+
+end of test

--- a/storage/spider/mysql-test/spider/bugfix/r/sql_mode_mysql.result
+++ b/storage/spider/mysql-test/spider/bugfix/r/sql_mode_mysql.result
@@ -1,0 +1,83 @@
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+connection master_1;
+set @old_sql_mode= @@sql_mode;
+set session sql_mode= 'real_as_float,pipes_as_concat,ansi_quotes,ignore_space,ignore_bad_table_options,only_full_group_by,no_unsigned_subtraction,no_dir_in_create,postgresql,oracle,mssql,db2,maxdb,no_key_options,no_table_options,no_field_options,mysql323,mysql40,ansi,no_auto_value_on_zero,no_backslash_escapes,strict_trans_tables,strict_all_tables,no_zero_in_date,no_zero_date,allow_invalid_dates,error_for_division_by_zero,traditional,no_auto_create_user,high_not_precedence,no_engine_substitution,pad_char_to_full_length,empty_string_is_null,simultaneous_assignment,time_round_fractional';
+
+this test is for MDEV-16508
+
+drop and create databases
+connection master_1;
+CREATE DATABASE auto_test_local;
+USE auto_test_local;
+connection child2_1;
+SET @old_log_output = @@global.log_output;
+SET GLOBAL log_output = 'TABLE,FILE';
+CREATE DATABASE auto_test_remote;
+USE auto_test_remote;
+
+create table and insert
+connection child2_1;
+CHILD2_1_CREATE_TABLES
+TRUNCATE TABLE mysql.general_log;
+connection master_1;
+CREATE TABLE tbl_a (
+pkey int NOT NULL,
+PRIMARY KEY (pkey)
+) MASTER_1_ENGINE MASTER_1_CHARSET MASTER_1_COMMENT_2_1
+INSERT INTO tbl_a (pkey) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+select test
+connection child2_1;
+TRUNCATE TABLE mysql.general_log;
+connection master_1;
+SELECT * FROM tbl_a ORDER BY pkey;
+pkey
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+connection child2_1;
+SELECT argument FROM mysql.general_log WHERE argument LIKE '%sql_mode%';
+argument
+set session transaction isolation level repeatable read;set session autocommit = 1;set session sql_log_off = 0;set session wait_timeout = 604800;set session sql_mode = 'real_as_float,ignore_bad_table_options,no_unsigned_subtraction,no_dir_in_create,no_auto_value_on_zero,strict_trans_tables,strict_all_tables,no_zero_in_date,no_zero_date,allow_invalid_dates,error_for_division_by_zero,no_auto_create_user,high_not_precedence,no_engine_substitution,pad_char_to_full_length';set session time_zone = '+00:00';start transaction
+SELECT argument FROM mysql.general_log WHERE argument LIKE '%sql_mode%'
+SELECT pkey FROM tbl_a ORDER BY pkey;
+pkey
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+deinit
+connection master_1;
+DROP DATABASE IF EXISTS auto_test_local;
+connection child2_1;
+DROP DATABASE IF EXISTS auto_test_remote;
+SET GLOBAL log_output = @old_log_output;
+connection master_1;
+set session sql_mode= @old_sql_mode;
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+
+end of test

--- a/storage/spider/mysql-test/spider/bugfix/t/sql_mode.inc
+++ b/storage/spider/mysql-test/spider/bugfix/t/sql_mode.inc
@@ -1,0 +1,65 @@
+--echo
+--echo this test is for MDEV-16508
+--echo
+--echo drop and create databases
+
+--connection master_1
+--disable_warnings
+CREATE DATABASE auto_test_local;
+USE auto_test_local;
+
+--connection child2_1
+SET @old_log_output = @@global.log_output;
+SET GLOBAL log_output = 'TABLE,FILE';
+CREATE DATABASE auto_test_remote;
+USE auto_test_remote;
+--enable_warnings
+
+--echo
+--echo create table and insert
+
+--connection child2_1
+--disable_query_log
+echo CHILD2_1_CREATE_TABLES;
+eval $CHILD2_1_CREATE_TABLES;
+--enable_query_log
+TRUNCATE TABLE mysql.general_log;
+
+--connection master_1
+--disable_query_log
+echo CREATE TABLE tbl_a (
+    pkey int NOT NULL,
+    PRIMARY KEY (pkey)
+) MASTER_1_ENGINE MASTER_1_CHARSET MASTER_1_COMMENT_2_1;
+eval CREATE TABLE tbl_a (
+    pkey int NOT NULL,
+    PRIMARY KEY (pkey)
+) $MASTER_1_ENGINE $MASTER_1_CHARSET $MASTER_1_COMMENT_2_1;
+--enable_query_log
+INSERT INTO tbl_a (pkey) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+--echo
+--echo select test
+
+--connection child2_1
+TRUNCATE TABLE mysql.general_log;
+
+--connection master_1
+SELECT * FROM tbl_a ORDER BY pkey;
+
+--connection child2_1
+eval $CHILD2_1_SELECT_ARGUMENT1;
+eval $CHILD2_1_SELECT_TABLES;
+
+--echo
+--echo deinit
+--disable_warnings
+
+--connection master_1
+DROP DATABASE IF EXISTS auto_test_local;
+
+--connection child2_1
+DROP DATABASE IF EXISTS auto_test_remote;
+SET GLOBAL log_output = @old_log_output;
+
+--enable_warnings

--- a/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mariadb.cnf
+++ b/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mariadb.cnf
@@ -1,0 +1,3 @@
+!include include/default_mysqld.cnf
+!include ../my_1_1.cnf
+!include ../my_2_1.cnf

--- a/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mariadb.test
+++ b/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mariadb.test
@@ -1,0 +1,5 @@
+--source ../include/sql_mode_mariadb_init.inc
+--source sql_mode.inc
+--source ../include/sql_mode_mariadb_deinit.inc
+--echo
+--echo end of test

--- a/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mysql.cnf
+++ b/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mysql.cnf
@@ -1,0 +1,3 @@
+!include include/default_mysqld.cnf
+!include ../my_1_1.cnf
+!include ../my_2_1.cnf

--- a/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mysql.test
+++ b/storage/spider/mysql-test/spider/bugfix/t/sql_mode_mysql.test
@@ -1,0 +1,5 @@
+--source ../include/sql_mode_mysql_init.inc
+--source sql_mode.inc
+--source ../include/sql_mode_mysql_deinit.inc
+--echo
+--echo end of test

--- a/storage/spider/mysql-test/spider/r/slave_trx_isolation.result
+++ b/storage/spider/mysql-test/spider/r/slave_trx_isolation.result
@@ -53,7 +53,7 @@ SELECT argument FROM mysql.general_log WHERE argument LIKE '%set %';
 argument
 set session time_zone = '+00:00'
 SET NAMES utf8
-set session transaction isolation level read committed;set session autocommit = 1;set session wait_timeout = 604800;start transaction
+set session transaction isolation level read committed;set session autocommit = 1;set session wait_timeout = 604800;set session sql_mode = 'strict_trans_tables,error_for_division_by_zero,no_auto_create_user,no_engine_substitution';start transaction
 SELECT argument FROM mysql.general_log WHERE argument LIKE '%set %'
 SELECT pkey FROM tbl_a ORDER BY pkey;
 pkey

--- a/storage/spider/spd_conn.h
+++ b/storage/spider/spd_conn.h
@@ -137,6 +137,11 @@ void spider_conn_queue_wait_timeout(
   int wait_timeout
 );
 
+void spider_conn_queue_sql_mode(
+  SPIDER_CONN *conn,
+  sql_mode_t sql_mode
+);
+
 void spider_conn_queue_time_zone(
   SPIDER_CONN *conn,
   Time_zone *time_zone

--- a/storage/spider/spd_db_handlersocket.cc
+++ b/storage/spider/spd_db_handlersocket.cc
@@ -1856,6 +1856,23 @@ int spider_db_handlersocket::set_wait_timeout(
   DBUG_RETURN(0);
 }
 
+bool spider_db_handlersocket::set_sql_mode_in_bulk_sql()
+{
+  DBUG_ENTER("spider_db_handlersocket::set_sql_mode_in_bulk_sql");
+  DBUG_PRINT("info",("spider this=%p", this));
+  DBUG_RETURN(FALSE);
+}
+
+int spider_db_handlersocket::set_sql_mode(
+  sql_mode_t sql_mode,
+  int *need_mon
+) {
+  DBUG_ENTER("spider_db_handlersocket::set_sql_mode");
+  DBUG_PRINT("info",("spider this=%p", this));
+  /* nothing to do */
+  DBUG_RETURN(0);
+}
+
 bool spider_db_handlersocket::set_time_zone_in_bulk_sql()
 {
   DBUG_ENTER("spider_db_handlersocket::set_time_zone_in_bulk_sql");
@@ -2697,6 +2714,16 @@ int spider_db_handlersocket_util::append_wait_timeout(
   int wait_timeout
 ) {
   DBUG_ENTER("spider_db_handlersocket_util::append_wait_timeout");
+  DBUG_PRINT("info",("spider this=%p", this));
+  /* nothing to do */
+  DBUG_RETURN(0);
+}
+
+int spider_db_handlersocket_util::append_sql_mode(
+  spider_string *str,
+  sql_mode_t sql_mode
+) {
+  DBUG_ENTER("spider_db_handlersocket_util::append_sql_mode");
   DBUG_PRINT("info",("spider this=%p", this));
   /* nothing to do */
   DBUG_RETURN(0);

--- a/storage/spider/spd_db_handlersocket.h
+++ b/storage/spider/spd_db_handlersocket.h
@@ -63,6 +63,10 @@ public:
     spider_string *str,
     int wait_timeout
   );
+  int append_sql_mode(
+    spider_string *str,
+    sql_mode_t sql_mode
+  );
   int append_time_zone(
     spider_string *str,
     Time_zone *time_zone
@@ -387,6 +391,11 @@ public:
   bool set_wait_timeout_in_bulk_sql();
   int set_wait_timeout(
     int wait_timeout,
+    int *need_mon
+  );
+  bool set_sql_mode_in_bulk_sql();
+  int set_sql_mode(
+    sql_mode_t sql_mode,
     int *need_mon
   );
   bool set_time_zone_in_bulk_sql();

--- a/storage/spider/spd_db_include.h
+++ b/storage/spider/spd_db_include.h
@@ -839,6 +839,10 @@ public:
     spider_string *str,
     int wait_timeout
   ) = 0;
+  virtual int append_sql_mode(
+    spider_string *str,
+    sql_mode_t sql_mode
+  ) = 0;
   virtual int append_time_zone(
     spider_string *str,
     Time_zone *time_zone
@@ -1141,6 +1145,11 @@ public:
   virtual bool set_wait_timeout_in_bulk_sql() = 0;
   virtual int set_wait_timeout(
     int wait_timeout,
+    int *need_mon
+  ) = 0;
+  virtual bool set_sql_mode_in_bulk_sql() = 0;
+  virtual int set_sql_mode(
+    sql_mode_t sql_mode,
     int *need_mon
   ) = 0;
   virtual bool set_time_zone_in_bulk_sql() = 0;

--- a/storage/spider/spd_db_mysql.cc
+++ b/storage/spider/spd_db_mysql.cc
@@ -91,6 +91,9 @@ static const char *name_quote_str = SPIDER_SQL_NAME_QUOTE_STR;
 #define SPIDER_SQL_WAIT_TIMEOUT_STR "set session wait_timeout = "
 #define SPIDER_SQL_WAIT_TIMEOUT_LEN sizeof(SPIDER_SQL_WAIT_TIMEOUT_STR) - 1
 
+#define SPIDER_SQL_SQL_MODE_STR "set session sql_mode = '"
+#define SPIDER_SQL_SQL_MODE_LEN sizeof(SPIDER_SQL_SQL_MODE_STR) - 1
+
 #define SPIDER_SQL_TIME_ZONE_STR "set session time_zone = '"
 #define SPIDER_SQL_TIME_ZONE_LEN sizeof(SPIDER_SQL_TIME_ZONE_STR) - 1
 
@@ -2782,6 +2785,54 @@ int spider_db_mbase::set_wait_timeout(
   DBUG_RETURN(0);
 }
 
+bool spider_db_mbase::set_sql_mode_in_bulk_sql()
+{
+  DBUG_ENTER("spider_db_mbase::set_sql_mode_in_bulk_sql");
+  DBUG_PRINT("info",("spider this=%p", this));
+  DBUG_RETURN(TRUE);
+}
+
+int spider_db_mbase::set_sql_mode(
+  sql_mode_t sql_mode,
+  int *need_mon
+) {
+  int error_num;
+  char sql_buf[MAX_FIELD_WIDTH];
+  spider_string sql_str(sql_buf, sizeof(sql_buf), &my_charset_bin);
+  DBUG_ENTER("spider_db_mbase::set_sql_mode");
+  DBUG_PRINT("info",("spider this=%p", this));
+  sql_str.init_calc_mem(265);
+  sql_str.length(0);
+  if (sql_str.reserve(SPIDER_SQL_SQL_MODE_LEN))
+    DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+  sql_str.q_append(SPIDER_SQL_SQL_MODE_STR, SPIDER_SQL_SQL_MODE_LEN);
+  if ((error_num = spider_db_mbase_utility->append_sql_mode_internal(&sql_str, sql_mode)))
+  {
+    DBUG_RETURN(error_num);
+  }
+  if (sql_str.length() > SPIDER_SQL_SQL_MODE_LEN)
+  {
+    sql_str.length(sql_str.length() - SPIDER_SQL_COMMA_LEN);
+  } else {
+    if (sql_str.reserve(SPIDER_SQL_VALUE_QUOTE_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+  }
+  sql_str.q_append(SPIDER_SQL_VALUE_QUOTE_STR, SPIDER_SQL_VALUE_QUOTE_LEN);
+  if (spider_db_query(
+    conn,
+    sql_str.ptr(),
+    sql_str.length(),
+    -1,
+    need_mon)
+  )
+    DBUG_RETURN(spider_db_errorno(conn));
+  SPIDER_CLEAR_FILE_POS(&conn->mta_conn_mutex_file_pos);
+  pthread_mutex_unlock(&conn->mta_conn_mutex);
+  DBUG_RETURN(0);
+}
+
 bool spider_db_mbase::set_time_zone_in_bulk_sql()
 {
   DBUG_ENTER("spider_db_mbase::set_time_zone_in_bulk_sql");
@@ -3772,6 +3823,861 @@ int spider_db_mbase_util::append_wait_timeout(
   }
   str->q_append(SPIDER_SQL_WAIT_TIMEOUT_STR, SPIDER_SQL_WAIT_TIMEOUT_LEN);
   str->q_append(timeout_str, timeout_str_length);
+  DBUG_RETURN(0);
+}
+
+#define SPIDER_REAL_AS_FLOAT_STR              "real_as_float"
+#define SPIDER_REAL_AS_FLOAT_LEN              (sizeof(SPIDER_REAL_AS_FLOAT_STR) - 1)
+#define SPIDER_PIPES_AS_CONCAT_STR            "pipes_as_concat"
+#define SPIDER_PIPES_AS_CONCAT_LEN            (sizeof(SPIDER_PIPES_AS_CONCAT_STR) - 1)
+#define SPIDER_ANSI_QUOTES_STR                "ansi_quotes"
+#define SPIDER_ANSI_QUOTES_LEN                (sizeof(SPIDER_ANSI_QUOTES_STR) - 1)
+#define SPIDER_IGNORE_SPACE_STR               "ignore_space"
+#define SPIDER_IGNORE_SPACE_LEN               (sizeof(SPIDER_IGNORE_SPACE_STR) - 1)
+#define SPIDER_IGNORE_BAD_TABLE_OPTIONS_STR   "ignore_bad_table_options"
+#define SPIDER_IGNORE_BAD_TABLE_OPTIONS_LEN   (sizeof(SPIDER_IGNORE_BAD_TABLE_OPTIONS_STR) - 1)
+#define SPIDER_ONLY_FULL_GROUP_BY_STR         "only_full_group_by"
+#define SPIDER_ONLY_FULL_GROUP_BY_LEN         (sizeof(SPIDER_ONLY_FULL_GROUP_BY_STR) - 1)
+#define SPIDER_NO_UNSIGNED_SUBTRACTION_STR    "no_unsigned_subtraction"
+#define SPIDER_NO_UNSIGNED_SUBTRACTION_LEN    (sizeof(SPIDER_NO_UNSIGNED_SUBTRACTION_STR) - 1)
+#define SPIDER_NO_DIR_IN_CREATE_STR           "no_dir_in_create"
+#define SPIDER_NO_DIR_IN_CREATE_LEN           (sizeof(SPIDER_NO_DIR_IN_CREATE_STR) - 1)
+#define SPIDER_POSTGRESQL_STR                 "postgresql"
+#define SPIDER_POSTGRESQL_LEN                 (sizeof(SPIDER_POSTGRESQL_STR) - 1)
+#define SPIDER_ORACLE_STR                     "oracle"
+#define SPIDER_ORACLE_LEN                     (sizeof(SPIDER_ORACLE_STR) - 1)
+#define SPIDER_MSSQL_STR                      "mssql"
+#define SPIDER_MSSQL_LEN                      (sizeof(SPIDER_MSSQL_STR) - 1)
+#define SPIDER_DB2_STR                        "db2"
+#define SPIDER_DB2_LEN                        (sizeof(SPIDER_DB2_STR) - 1)
+#define SPIDER_MAXDB_STR                      "maxdb"
+#define SPIDER_MAXDB_LEN                      (sizeof(SPIDER_MAXDB_STR) - 1)
+#define SPIDER_NO_KEY_OPTIONS_STR             "no_key_options"
+#define SPIDER_NO_KEY_OPTIONS_LEN             (sizeof(SPIDER_NO_KEY_OPTIONS_STR) - 1)
+#define SPIDER_NO_TABLE_OPTIONS_STR           "no_table_options"
+#define SPIDER_NO_TABLE_OPTIONS_LEN           (sizeof(SPIDER_NO_TABLE_OPTIONS_STR) - 1)
+#define SPIDER_NO_FIELD_OPTIONS_STR           "no_field_options"
+#define SPIDER_NO_FIELD_OPTIONS_LEN           (sizeof(SPIDER_NO_FIELD_OPTIONS_STR) - 1)
+#define SPIDER_MYSQL323_STR                   "mysql323"
+#define SPIDER_MYSQL323_LEN                   (sizeof(SPIDER_MYSQL323_STR) - 1)
+#define SPIDER_MYSQL40_STR                    "mysql40"
+#define SPIDER_MYSQL40_LEN                    (sizeof(SPIDER_MYSQL40_STR) - 1)
+#define SPIDER_ANSI_STR                       "ansi"
+#define SPIDER_ANSI_LEN                       (sizeof(SPIDER_ANSI_STR) - 1)
+#define SPIDER_NO_AUTO_VALUE_ON_ZERO_STR      "no_auto_value_on_zero"
+#define SPIDER_NO_AUTO_VALUE_ON_ZERO_LEN      (sizeof(SPIDER_NO_AUTO_VALUE_ON_ZERO_STR) - 1)
+#define SPIDER_NO_BACKSLASH_ESCAPES_STR       "no_backslash_escapes"
+#define SPIDER_NO_BACKSLASH_ESCAPES_LEN       (sizeof(SPIDER_NO_BACKSLASH_ESCAPES_STR) - 1)
+#define SPIDER_STRICT_TRANS_TABLES_STR        "strict_trans_tables"
+#define SPIDER_STRICT_TRANS_TABLES_LEN        (sizeof(SPIDER_STRICT_TRANS_TABLES_STR) - 1)
+#define SPIDER_STRICT_ALL_TABLES_STR          "strict_all_tables"
+#define SPIDER_STRICT_ALL_TABLES_LEN          (sizeof(SPIDER_STRICT_ALL_TABLES_STR) - 1)
+#define SPIDER_NO_ZERO_IN_DATE_STR            "no_zero_in_date"
+#define SPIDER_NO_ZERO_IN_DATE_LEN            (sizeof(SPIDER_NO_ZERO_IN_DATE_STR) - 1)
+#define SPIDER_NO_ZERO_DATE_STR               "no_zero_date"
+#define SPIDER_NO_ZERO_DATE_LEN               (sizeof(SPIDER_NO_ZERO_DATE_STR) - 1)
+#define SPIDER_INVALID_DATES_STR              "allow_invalid_dates"
+#define SPIDER_INVALID_DATES_LEN              (sizeof(SPIDER_INVALID_DATES_STR) - 1)
+#define SPIDER_ERROR_FOR_DIVISION_BY_ZERO_STR "error_for_division_by_zero"
+#define SPIDER_ERROR_FOR_DIVISION_BY_ZERO_LEN (sizeof(SPIDER_ERROR_FOR_DIVISION_BY_ZERO_STR) - 1)
+#define SPIDER_TRADITIONAL_STR                "traditional"
+#define SPIDER_TRADITIONAL_LEN                (sizeof(SPIDER_TRADITIONAL_STR) - 1)
+#define SPIDER_NO_AUTO_CREATE_USER_STR        "no_auto_create_user"
+#define SPIDER_NO_AUTO_CREATE_USER_LEN        (sizeof(SPIDER_NO_AUTO_CREATE_USER_STR) - 1)
+#define SPIDER_HIGH_NOT_PRECEDENCE_STR        "high_not_precedence"
+#define SPIDER_HIGH_NOT_PRECEDENCE_LEN        (sizeof(SPIDER_HIGH_NOT_PRECEDENCE_STR) - 1)
+#define SPIDER_NO_ENGINE_SUBSTITUTION_STR     "no_engine_substitution"
+#define SPIDER_NO_ENGINE_SUBSTITUTION_LEN     (sizeof(SPIDER_NO_ENGINE_SUBSTITUTION_STR) - 1)
+#define SPIDER_PAD_CHAR_TO_FULL_LENGTH_STR    "pad_char_to_full_length"
+#define SPIDER_PAD_CHAR_TO_FULL_LENGTH_LEN    (sizeof(SPIDER_PAD_CHAR_TO_FULL_LENGTH_STR) - 1)
+#define SPIDER_EMPTY_STRING_IS_NULL_STR       "empty_string_is_null"
+#define SPIDER_EMPTY_STRING_IS_NULL_LEN       (sizeof(SPIDER_EMPTY_STRING_IS_NULL_STR) - 1)
+#define SPIDER_SIMULTANEOUS_ASSIGNMENT_STR    "simultaneous_assignment"
+#define SPIDER_SIMULTANEOUS_ASSIGNMENT_LEN    (sizeof(SPIDER_SIMULTANEOUS_ASSIGNMENT_STR) - 1)
+#define SPIDER_TIME_ROUND_FRACTIONAL_STR      "time_round_fractional"
+#define SPIDER_TIME_ROUND_FRACTIONAL_LEN      (sizeof(SPIDER_TIME_ROUND_FRACTIONAL_STR) - 1)
+
+sql_mode_t full_sql_mode =
+#ifdef MODE_REAL_AS_FLOAT
+  MODE_REAL_AS_FLOAT |
+#endif
+#ifdef MODE_PIPES_AS_CONCAT
+  MODE_PIPES_AS_CONCAT |
+#endif
+#ifdef MODE_ANSI_QUOTES
+  MODE_ANSI_QUOTES |
+#endif
+#ifdef MODE_IGNORE_SPACE
+  MODE_IGNORE_SPACE |
+#endif
+#ifdef MODE_IGNORE_BAD_TABLE_OPTIONS
+  MODE_IGNORE_BAD_TABLE_OPTIONS |
+#endif
+#ifdef MODE_ONLY_FULL_GROUP_BY
+  MODE_ONLY_FULL_GROUP_BY |
+#endif
+#ifdef MODE_NO_UNSIGNED_SUBTRACTION
+  MODE_NO_UNSIGNED_SUBTRACTION |
+#endif
+#ifdef MODE_NO_DIR_IN_CREATE
+  MODE_NO_DIR_IN_CREATE |
+#endif
+#ifdef MODE_POSTGRESQL
+  MODE_POSTGRESQL |
+#endif
+#ifdef MODE_ORACLE
+  MODE_ORACLE |
+#endif
+#ifdef MODE_MSSQL
+  MODE_MSSQL |
+#endif
+#ifdef MODE_DB2
+  MODE_DB2 |
+#endif
+#ifdef MODE_MAXDB
+  MODE_MAXDB |
+#endif
+#ifdef MODE_NO_KEY_OPTIONS
+  MODE_NO_KEY_OPTIONS |
+#endif
+#ifdef MODE_NO_TABLE_OPTIONS
+  MODE_NO_TABLE_OPTIONS |
+#endif
+#ifdef MODE_NO_FIELD_OPTIONS
+  MODE_NO_FIELD_OPTIONS |
+#endif
+#ifdef MODE_MYSQL323
+  MODE_MYSQL323 |
+#endif
+#ifdef MODE_MYSQL40
+  MODE_MYSQL40 |
+#endif
+#ifdef MODE_ANSI
+  MODE_ANSI |
+#endif
+#ifdef MODE_NO_AUTO_VALUE_ON_ZERO
+  MODE_NO_AUTO_VALUE_ON_ZERO |
+#endif
+#ifdef MODE_NO_BACKSLASH_ESCAPES
+  MODE_NO_BACKSLASH_ESCAPES |
+#endif
+#ifdef MODE_STRICT_TRANS_TABLES
+  MODE_STRICT_TRANS_TABLES |
+#endif
+#ifdef MODE_STRICT_ALL_TABLES
+  MODE_STRICT_ALL_TABLES |
+#endif
+#ifdef MODE_NO_ZERO_IN_DATE
+  MODE_NO_ZERO_IN_DATE |
+#endif
+#ifdef MODE_NO_ZERO_DATE
+  MODE_NO_ZERO_DATE |
+#endif
+#ifdef MODE_INVALID_DATES
+  MODE_INVALID_DATES |
+#endif
+#ifdef MODE_ERROR_FOR_DIVISION_BY_ZERO
+  MODE_ERROR_FOR_DIVISION_BY_ZERO |
+#endif
+#ifdef MODE_TRADITIONAL
+  MODE_TRADITIONAL |
+#endif
+#ifdef MODE_NO_AUTO_CREATE_USER
+  MODE_NO_AUTO_CREATE_USER |
+#endif
+#ifdef MODE_HIGH_NOT_PRECEDENCE
+  MODE_HIGH_NOT_PRECEDENCE |
+#endif
+#ifdef MODE_NO_ENGINE_SUBSTITUTION
+  MODE_NO_ENGINE_SUBSTITUTION |
+#endif
+#ifdef MODE_PAD_CHAR_TO_FULL_LENGTH
+  MODE_PAD_CHAR_TO_FULL_LENGTH |
+#endif
+#ifdef MODE_EMPTY_STRING_IS_NULL
+  MODE_EMPTY_STRING_IS_NULL |
+#endif
+#ifdef MODE_SIMULTANEOUS_ASSIGNMENT
+  MODE_SIMULTANEOUS_ASSIGNMENT |
+#endif
+#ifdef MODE_TIME_ROUND_FRACTIONAL
+  MODE_TIME_ROUND_FRACTIONAL |
+#endif
+  0;
+
+#ifdef MODE_REAL_AS_FLOAT
+/* pushdown */
+#define SPIDER_SQL_MODE_REAL_AS_FLOAT
+#endif
+#ifdef MODE_PIPES_AS_CONCAT
+/* no pushdown */
+#endif
+#ifdef MODE_ANSI_QUOTES
+/* no pushdown */
+#endif
+#ifdef MODE_IGNORE_SPACE
+/* no pushdown */
+#endif
+#ifdef MODE_IGNORE_BAD_TABLE_OPTIONS
+/* pushdown */
+#define SPIDER_SQL_MODE_IGNORE_BAD_TABLE_OPTIONS
+#endif
+#ifdef MODE_ONLY_FULL_GROUP_BY
+/* no pushdown */
+#endif
+#ifdef MODE_NO_UNSIGNED_SUBTRACTION
+/* pushdown */
+#define SPIDER_SQL_MODE_NO_UNSIGNED_SUBTRACTION
+#endif
+#ifdef MODE_NO_DIR_IN_CREATE
+/* pushdown */
+#define SPIDER_SQL_MODE_NO_DIR_IN_CREATE
+#endif
+#ifdef MODE_POSTGRESQL
+/* no pushdown */
+#endif
+#ifdef MODE_ORACLE
+/* no pushdown */
+#endif
+#ifdef MODE_MSSQL
+/* no pushdown */
+#endif
+#ifdef MODE_DB2
+/* no pushdown */
+#endif
+#ifdef MODE_MAXDB
+/* no pushdown */
+#endif
+#ifdef MODE_NO_KEY_OPTIONS
+/* no pushdown */
+#endif
+#ifdef MODE_NO_TABLE_OPTIONS
+/* no pushdown */
+#endif
+#ifdef MODE_NO_FIELD_OPTIONS
+/* no pushdown */
+#endif
+#ifdef MODE_MYSQL323
+/* no pushdown */
+#endif
+#ifdef MODE_MYSQL40
+/* no pushdown */
+#endif
+#ifdef MODE_ANSI
+/* no pushdown */
+#endif
+#ifdef MODE_NO_AUTO_VALUE_ON_ZERO
+/* pushdown */
+#define SPIDER_SQL_MODE_NO_AUTO_VALUE_ON_ZERO
+#endif
+#ifdef MODE_NO_BACKSLASH_ESCAPES
+/* no pushdown */
+#endif
+#ifdef MODE_STRICT_TRANS_TABLES
+/* pushdown */
+#define SPIDER_SQL_MODE_STRICT_TRANS_TABLES
+#endif
+#ifdef MODE_STRICT_ALL_TABLES
+/* pushdown */
+#define SPIDER_SQL_MODE_STRICT_ALL_TABLES
+#endif
+#ifdef MODE_NO_ZERO_IN_DATE
+/* pushdown */
+#define SPIDER_SQL_MODE_NO_ZERO_IN_DATE
+#endif
+#ifdef MODE_NO_ZERO_DATE
+/* pushdown */
+#define SPIDER_SQL_MODE_NO_ZERO_DATE
+#endif
+#ifdef MODE_INVALID_DATES
+/* pushdown */
+#define SPIDER_SQL_MODE_INVALID_DATES
+#endif
+#ifdef MODE_ERROR_FOR_DIVISION_BY_ZERO
+/* pushdown */
+#define SPIDER_SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO
+#endif
+#ifdef MODE_TRADITIONAL
+/* no pushdown */
+#endif
+#ifdef MODE_NO_AUTO_CREATE_USER
+/* pushdown */
+#define SPIDER_SQL_MODE_NO_AUTO_CREATE_USER
+#endif
+#ifdef MODE_HIGH_NOT_PRECEDENCE
+/* pushdown */
+#define SPIDER_SQL_MODE_HIGH_NOT_PRECEDENCE
+#endif
+#ifdef MODE_NO_ENGINE_SUBSTITUTION
+/* pushdown */
+#define SPIDER_SQL_MODE_NO_ENGINE_SUBSTITUTION
+#endif
+#ifdef MODE_PAD_CHAR_TO_FULL_LENGTH
+/* pushdown */
+#define SPIDER_SQL_MODE_PAD_CHAR_TO_FULL_LENGTH
+#endif
+#ifdef MODE_EMPTY_STRING_IS_NULL
+/* pushdown */
+#define SPIDER_SQL_MODE_EMPTY_STRING_IS_NULL
+#endif
+#ifdef MODE_SIMULTANEOUS_ASSIGNMENT
+/* pushdown */
+#define SPIDER_SQL_MODE_SIMULTANEOUS_ASSIGNMENT
+#endif
+#ifdef MODE_TIME_ROUND_FRACTIONAL
+/* pushdown */
+#define SPIDER_SQL_MODE_TIME_ROUND_FRACTIONAL
+#endif
+
+sql_mode_t pushdown_sql_mode =
+#ifdef SPIDER_SQL_MODE_REAL_AS_FLOAT
+  MODE_REAL_AS_FLOAT |
+#endif
+#ifdef SPIDER_SQL_MODE_PIPES_AS_CONCAT
+  MODE_PIPES_AS_CONCAT |
+#endif
+#ifdef SPIDER_SQL_MODE_ANSI_QUOTES
+  MODE_ANSI_QUOTES |
+#endif
+#ifdef SPIDER_SQL_MODE_IGNORE_SPACE
+  MODE_IGNORE_SPACE |
+#endif
+#ifdef SPIDER_SQL_MODE_IGNORE_BAD_TABLE_OPTIONS
+  MODE_IGNORE_BAD_TABLE_OPTIONS |
+#endif
+#ifdef SPIDER_SQL_MODE_ONLY_FULL_GROUP_BY
+  MODE_ONLY_FULL_GROUP_BY |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_UNSIGNED_SUBTRACTION
+  MODE_NO_UNSIGNED_SUBTRACTION |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_DIR_IN_CREATE
+  MODE_NO_DIR_IN_CREATE |
+#endif
+#ifdef SPIDER_SQL_MODE_POSTGRESQL
+  MODE_POSTGRESQL |
+#endif
+#ifdef SPIDER_SQL_MODE_ORACLE
+  MODE_ORACLE |
+#endif
+#ifdef SPIDER_SQL_MODE_MSSQL
+  MODE_MSSQL |
+#endif
+#ifdef SPIDER_SQL_MODE_DB2
+  MODE_DB2 |
+#endif
+#ifdef SPIDER_SQL_MODE_MAXDB
+  MODE_MAXDB |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_KEY_OPTIONS
+  MODE_NO_KEY_OPTIONS |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_TABLE_OPTIONS
+  MODE_NO_TABLE_OPTIONS |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_FIELD_OPTIONS
+  MODE_NO_FIELD_OPTIONS |
+#endif
+#ifdef SPIDER_SQL_MODE_MYSQL323
+  MODE_MYSQL323 |
+#endif
+#ifdef SPIDER_SQL_MODE_MYSQL40
+  MODE_MYSQL40 |
+#endif
+#ifdef SPIDER_SQL_MODE_ANSI
+  MODE_ANSI |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_AUTO_VALUE_ON_ZERO
+  MODE_NO_AUTO_VALUE_ON_ZERO |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_BACKSLASH_ESCAPES
+  MODE_NO_BACKSLASH_ESCAPES |
+#endif
+#ifdef SPIDER_SQL_MODE_STRICT_TRANS_TABLES
+  MODE_STRICT_TRANS_TABLES |
+#endif
+#ifdef SPIDER_SQL_MODE_STRICT_ALL_TABLES
+  MODE_STRICT_ALL_TABLES |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_ZERO_IN_DATE
+  MODE_NO_ZERO_IN_DATE |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_ZERO_DATE
+  MODE_NO_ZERO_DATE |
+#endif
+#ifdef SPIDER_SQL_MODE_INVALID_DATES
+  MODE_INVALID_DATES |
+#endif
+#ifdef SPIDER_SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO
+  MODE_ERROR_FOR_DIVISION_BY_ZERO |
+#endif
+#ifdef SPIDER_SQL_MODE_TRADITIONAL
+  MODE_TRADITIONAL |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_AUTO_CREATE_USER
+  MODE_NO_AUTO_CREATE_USER |
+#endif
+#ifdef SPIDER_SQL_MODE_HIGH_NOT_PRECEDENCE
+  MODE_HIGH_NOT_PRECEDENCE |
+#endif
+#ifdef SPIDER_SQL_MODE_NO_ENGINE_SUBSTITUTION
+  MODE_NO_ENGINE_SUBSTITUTION |
+#endif
+#ifdef SPIDER_SQL_MODE_PAD_CHAR_TO_FULL_LENGTH
+  MODE_PAD_CHAR_TO_FULL_LENGTH |
+#endif
+#ifdef SPIDER_SQL_MODE_EMPTY_STRING_IS_NULL
+  MODE_EMPTY_STRING_IS_NULL |
+#endif
+#ifdef SPIDER_SQL_MODE_SIMULTANEOUS_ASSIGNMENT
+  MODE_SIMULTANEOUS_ASSIGNMENT |
+#endif
+#ifdef SPIDER_SQL_MODE_TIME_ROUND_FRACTIONAL
+  MODE_TIME_ROUND_FRACTIONAL |
+#endif
+  0;
+
+int spider_db_mbase_util::append_sql_mode_internal(
+  spider_string *str,
+  sql_mode_t sql_mode
+) {
+  DBUG_ENTER("spider_db_mbase_util::append_sql_mode_internal");
+  DBUG_PRINT("info",("spider this=%p", this));
+#ifdef SPIDER_SQL_MODE_REAL_AS_FLOAT
+  if (sql_mode & MODE_REAL_AS_FLOAT)
+  {
+    if (str->reserve(SPIDER_REAL_AS_FLOAT_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_REAL_AS_FLOAT_STR, SPIDER_REAL_AS_FLOAT_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_PIPES_AS_CONCAT
+  if (sql_mode & MODE_PIPES_AS_CONCAT)
+  {
+    if (str->reserve(SPIDER_PIPES_AS_CONCAT_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_PIPES_AS_CONCAT_STR, SPIDER_PIPES_AS_CONCAT_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_ANSI_QUOTES
+  if (sql_mode & MODE_ANSI_QUOTES)
+  {
+    if (str->reserve(SPIDER_ANSI_QUOTES_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_ANSI_QUOTES_STR, SPIDER_ANSI_QUOTES_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_IGNORE_SPACE
+  if (sql_mode & MODE_IGNORE_SPACE)
+  {
+    if (str->reserve(SPIDER_IGNORE_SPACE_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_IGNORE_SPACE_STR, SPIDER_IGNORE_SPACE_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_IGNORE_BAD_TABLE_OPTIONS
+  if (sql_mode & MODE_IGNORE_BAD_TABLE_OPTIONS)
+  {
+    if (str->reserve(SPIDER_IGNORE_BAD_TABLE_OPTIONS_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_IGNORE_BAD_TABLE_OPTIONS_STR, SPIDER_IGNORE_BAD_TABLE_OPTIONS_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_ONLY_FULL_GROUP_BY
+  if (sql_mode & MODE_ONLY_FULL_GROUP_BY)
+  {
+    if (str->reserve(SPIDER_ONLY_FULL_GROUP_BY_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_ONLY_FULL_GROUP_BY_STR, SPIDER_ONLY_FULL_GROUP_BY_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_UNSIGNED_SUBTRACTION
+  if (sql_mode & MODE_NO_UNSIGNED_SUBTRACTION)
+  {
+    if (str->reserve(SPIDER_NO_UNSIGNED_SUBTRACTION_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_UNSIGNED_SUBTRACTION_STR, SPIDER_NO_UNSIGNED_SUBTRACTION_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_DIR_IN_CREATE
+  if (sql_mode & MODE_NO_DIR_IN_CREATE)
+  {
+    if (str->reserve(SPIDER_NO_DIR_IN_CREATE_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_DIR_IN_CREATE_STR, SPIDER_NO_DIR_IN_CREATE_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_POSTGRESQL
+  if (sql_mode & MODE_POSTGRESQL)
+  {
+    if (str->reserve(SPIDER_POSTGRESQL_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_POSTGRESQL_STR, SPIDER_POSTGRESQL_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_ORACLE
+  if (sql_mode & MODE_ORACLE)
+  {
+    if (str->reserve(SPIDER_ORACLE_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_ORACLE_STR, SPIDER_ORACLE_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_MSSQL
+  if (sql_mode & MODE_MSSQL)
+  {
+    if (str->reserve(SPIDER_MSSQL_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_MSSQL_STR, SPIDER_MSSQL_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_DB2
+  if (sql_mode & MODE_DB2)
+  {
+    if (str->reserve(SPIDER_DB2_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_DB2_STR, SPIDER_DB2_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_MAXDB
+  if (sql_mode & MODE_MAXDB)
+  {
+    if (str->reserve(SPIDER_MAXDB_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_MAXDB_STR, SPIDER_MAXDB_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_KEY_OPTIONS
+  if (sql_mode & MODE_NO_KEY_OPTIONS)
+  {
+    if (str->reserve(SPIDER_NO_KEY_OPTIONS_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_KEY_OPTIONS_STR, SPIDER_NO_KEY_OPTIONS_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_TABLE_OPTIONS
+  if (sql_mode & MODE_NO_TABLE_OPTIONS)
+  {
+    if (str->reserve(SPIDER_NO_TABLE_OPTIONS_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_TABLE_OPTIONS_STR, SPIDER_NO_TABLE_OPTIONS_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_FIELD_OPTIONS
+  if (sql_mode & MODE_NO_FIELD_OPTIONS)
+  {
+    if (str->reserve(SPIDER_NO_FIELD_OPTIONS_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_FIELD_OPTIONS_STR, SPIDER_NO_FIELD_OPTIONS_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_MYSQL323
+  if (sql_mode & MODE_MYSQL323)
+  {
+    if (str->reserve(SPIDER_MYSQL323_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_MYSQL323_STR, SPIDER_MYSQL323_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_MYSQL40
+  if (sql_mode & MODE_MYSQL40)
+  {
+    if (str->reserve(SPIDER_MYSQL40_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_MYSQL40_STR, SPIDER_MYSQL40_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_ANSI
+  if (sql_mode & MODE_ANSI)
+  {
+    if (str->reserve(SPIDER_ANSI_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_ANSI_STR, SPIDER_ANSI_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_AUTO_VALUE_ON_ZERO
+  if (sql_mode & MODE_NO_AUTO_VALUE_ON_ZERO)
+  {
+    if (str->reserve(SPIDER_NO_AUTO_VALUE_ON_ZERO_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_AUTO_VALUE_ON_ZERO_STR, SPIDER_NO_AUTO_VALUE_ON_ZERO_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_BACKSLASH_ESCAPES
+  if (sql_mode & MODE_NO_BACKSLASH_ESCAPES)
+  {
+    if (str->reserve(SPIDER_NO_BACKSLASH_ESCAPES_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_BACKSLASH_ESCAPES_STR, SPIDER_NO_BACKSLASH_ESCAPES_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_STRICT_TRANS_TABLES
+  if (sql_mode & MODE_STRICT_TRANS_TABLES)
+  {
+    if (str->reserve(SPIDER_STRICT_TRANS_TABLES_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_STRICT_TRANS_TABLES_STR, SPIDER_STRICT_TRANS_TABLES_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_STRICT_ALL_TABLES
+  if (sql_mode & MODE_STRICT_ALL_TABLES)
+  {
+    if (str->reserve(SPIDER_STRICT_ALL_TABLES_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_STRICT_ALL_TABLES_STR, SPIDER_STRICT_ALL_TABLES_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_ZERO_IN_DATE
+  if (sql_mode & MODE_NO_ZERO_IN_DATE)
+  {
+    if (str->reserve(SPIDER_NO_ZERO_IN_DATE_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_ZERO_IN_DATE_STR, SPIDER_NO_ZERO_IN_DATE_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_ZERO_DATE
+  if (sql_mode & MODE_NO_ZERO_DATE)
+  {
+    if (str->reserve(SPIDER_NO_ZERO_DATE_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_ZERO_DATE_STR, SPIDER_NO_ZERO_DATE_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_INVALID_DATES
+  if (sql_mode & MODE_INVALID_DATES)
+  {
+    if (str->reserve(SPIDER_INVALID_DATES_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_INVALID_DATES_STR, SPIDER_INVALID_DATES_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_ERROR_FOR_DIVISION_BY_ZERO
+  if (sql_mode & MODE_ERROR_FOR_DIVISION_BY_ZERO)
+  {
+    if (str->reserve(SPIDER_ERROR_FOR_DIVISION_BY_ZERO_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_ERROR_FOR_DIVISION_BY_ZERO_STR, SPIDER_ERROR_FOR_DIVISION_BY_ZERO_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_TRADITIONAL
+  if (sql_mode & MODE_TRADITIONAL)
+  {
+    if (str->reserve(SPIDER_TRADITIONAL_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_TRADITIONAL_STR, SPIDER_TRADITIONAL_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_AUTO_CREATE_USER
+  if (sql_mode & MODE_NO_AUTO_CREATE_USER)
+  {
+    if (str->reserve(SPIDER_NO_AUTO_CREATE_USER_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_AUTO_CREATE_USER_STR, SPIDER_NO_AUTO_CREATE_USER_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_HIGH_NOT_PRECEDENCE
+  if (sql_mode & MODE_HIGH_NOT_PRECEDENCE)
+  {
+    if (str->reserve(SPIDER_HIGH_NOT_PRECEDENCE_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_HIGH_NOT_PRECEDENCE_STR, SPIDER_HIGH_NOT_PRECEDENCE_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_NO_ENGINE_SUBSTITUTION
+  if (sql_mode & MODE_NO_ENGINE_SUBSTITUTION)
+  {
+    if (str->reserve(SPIDER_NO_ENGINE_SUBSTITUTION_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_NO_ENGINE_SUBSTITUTION_STR, SPIDER_NO_ENGINE_SUBSTITUTION_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_PAD_CHAR_TO_FULL_LENGTH
+  if (sql_mode & MODE_PAD_CHAR_TO_FULL_LENGTH)
+  {
+    if (str->reserve(SPIDER_PAD_CHAR_TO_FULL_LENGTH_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_PAD_CHAR_TO_FULL_LENGTH_STR, SPIDER_PAD_CHAR_TO_FULL_LENGTH_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+  DBUG_RETURN(0);
+}
+
+int spider_db_mariadb_util::append_sql_mode_internal(
+  spider_string *str,
+  sql_mode_t sql_mode
+) {
+  int error_num;
+  DBUG_ENTER("spider_db_mbase_util::append_sql_mode_internal");
+  DBUG_PRINT("info",("spider this=%p", this));
+  if ((error_num = spider_db_mbase_util::append_sql_mode_internal(
+    str, sql_mode)))
+  {
+    DBUG_RETURN(error_num);
+  }
+#ifdef SPIDER_SQL_MODE_EMPTY_STRING_IS_NULL
+  if (sql_mode & MODE_EMPTY_STRING_IS_NULL)
+  {
+    if (str->reserve(SPIDER_EMPTY_STRING_IS_NULL_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_EMPTY_STRING_IS_NULL_STR, SPIDER_EMPTY_STRING_IS_NULL_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_SIMULTANEOUS_ASSIGNMENT
+  if (sql_mode & MODE_SIMULTANEOUS_ASSIGNMENT)
+  {
+    if (str->reserve(SPIDER_SIMULTANEOUS_ASSIGNMENT_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_SIMULTANEOUS_ASSIGNMENT_STR, SPIDER_SIMULTANEOUS_ASSIGNMENT_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+#ifdef SPIDER_SQL_MODE_TIME_ROUND_FRACTIONAL
+  if (sql_mode & MODE_TIME_ROUND_FRACTIONAL)
+  {
+    if (str->reserve(SPIDER_TIME_ROUND_FRACTIONAL_LEN + SPIDER_SQL_COMMA_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+    str->q_append(SPIDER_TIME_ROUND_FRACTIONAL_STR, SPIDER_TIME_ROUND_FRACTIONAL_LEN);
+    str->q_append(SPIDER_SQL_COMMA_STR, SPIDER_SQL_COMMA_LEN);
+  }
+#endif
+  DBUG_RETURN(0);
+}
+
+int spider_db_mbase_util::append_sql_mode(
+  spider_string *str,
+  sql_mode_t sql_mode
+) {
+  int error_num;
+  uint length;
+  DBUG_ENTER("spider_db_mbase_util::append_sql_mode");
+  DBUG_PRINT("info",("spider this=%p", this));
+  if (str->reserve(SPIDER_SQL_SEMICOLON_LEN + SPIDER_SQL_SQL_MODE_LEN))
+  {
+    DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+  }
+  if (str->length())
+  {
+    str->q_append(SPIDER_SQL_SEMICOLON_STR, SPIDER_SQL_SEMICOLON_LEN);
+  }
+  str->q_append(SPIDER_SQL_SQL_MODE_STR, SPIDER_SQL_SQL_MODE_LEN);
+  length = str->length();
+  if ((error_num = append_sql_mode_internal(str, sql_mode)))
+  {
+    DBUG_RETURN(error_num);
+  }
+  if (str->length() > length)
+  {
+    str->length(str->length() - SPIDER_SQL_COMMA_LEN);
+  } else {
+    if (str->reserve(SPIDER_SQL_VALUE_QUOTE_LEN))
+    {
+      DBUG_RETURN(HA_ERR_OUT_OF_MEM);
+    }
+  }
+  str->q_append(SPIDER_SQL_VALUE_QUOTE_STR, SPIDER_SQL_VALUE_QUOTE_LEN);
   DBUG_RETURN(0);
 }
 

--- a/storage/spider/spd_db_mysql.h
+++ b/storage/spider/spd_db_mysql.h
@@ -68,6 +68,14 @@ public:
     spider_string *str,
     int wait_timeout
   );
+  virtual int append_sql_mode_internal(
+    spider_string *str,
+    sql_mode_t sql_mode
+  );
+  int append_sql_mode(
+    spider_string *str,
+    sql_mode_t sql_mode
+  );
   int append_time_zone(
     spider_string *str,
     Time_zone *time_zone
@@ -190,6 +198,10 @@ class spider_db_mariadb_util: public spider_db_mbase_util
 public:
   spider_db_mariadb_util();
   ~spider_db_mariadb_util();
+  int append_sql_mode_internal(
+    spider_string *str,
+    sql_mode_t sql_mode
+  );
 };
 
 class spider_db_mbase_row: public spider_db_row
@@ -473,6 +485,11 @@ public:
   bool set_wait_timeout_in_bulk_sql();
   int set_wait_timeout(
     int wait_timeout,
+    int *need_mon
+  );
+  bool set_sql_mode_in_bulk_sql();
+  int set_sql_mode(
+    sql_mode_t sql_mode,
     int *need_mon
   );
   bool set_time_zone_in_bulk_sql();

--- a/storage/spider/spd_db_oracle.cc
+++ b/storage/spider/spd_db_oracle.cc
@@ -2121,6 +2121,23 @@ int spider_db_oracle::set_wait_timeout(
   DBUG_RETURN(0);
 }
 
+bool spider_db_oracle::set_sql_mode_in_bulk_sql()
+{
+  DBUG_ENTER("spider_db_oracle::set_sql_mode_in_bulk_sql");
+  DBUG_PRINT("info",("spider this=%p", this));
+  DBUG_RETURN(FALSE);
+}
+
+int spider_db_oracle::set_sql_mode(
+  sql_mode_t sql_mode,
+  int *need_mon
+) {
+  DBUG_ENTER("spider_db_oracle::set_sql_mode");
+  DBUG_PRINT("info",("spider this=%p", this));
+  /* nothing to do */
+  DBUG_RETURN(0);
+}
+
 bool spider_db_oracle::set_time_zone_in_bulk_sql()
 {
   DBUG_ENTER("spider_db_oracle::set_time_zone_in_bulk_sql");
@@ -2832,6 +2849,16 @@ int spider_db_oracle_util::append_wait_timeout(
   int wait_timeout
 ) {
   DBUG_ENTER("spider_db_oracle_util::append_wait_timeout");
+  DBUG_PRINT("info",("spider this=%p", this));
+  /* nothing to do */
+  DBUG_RETURN(0);
+}
+
+int spider_db_oracle_util::append_sql_mode(
+  spider_string *str,
+  sql_mode_t sql_mode
+) {
+  DBUG_ENTER("spider_db_oracle_util::append_sql_mode");
   DBUG_PRINT("info",("spider this=%p", this));
   /* nothing to do */
   DBUG_RETURN(0);

--- a/storage/spider/spd_db_oracle.h
+++ b/storage/spider/spd_db_oracle.h
@@ -71,6 +71,10 @@ public:
     spider_string *str,
     int wait_timeout
   );
+  int append_sql_mode(
+    spider_string *str,
+    sql_mode_t sql_mode
+  );
   int append_time_zone(
     spider_string *str,
     Time_zone *time_zone
@@ -437,6 +441,11 @@ public:
   bool set_wait_timeout_in_bulk_sql();
   int set_wait_timeout(
     int wait_timeout,
+    int *need_mon
+  );
+  bool set_sql_mode_in_bulk_sql();
+  int set_sql_mode(
+    sql_mode_t sql_mode,
     int *need_mon
   );
   bool set_time_zone_in_bulk_sql();

--- a/storage/spider/spd_include.h
+++ b/storage/spider/spd_include.h
@@ -260,7 +260,7 @@ const char SPIDER_empty_string = "";
 #define SPIDER_TMP_SHARE_LONG_COUNT         19
 #define SPIDER_TMP_SHARE_LONGLONG_COUNT      3
 
-#define SPIDER_MEM_CALC_LIST_NUM           265
+#define SPIDER_MEM_CALC_LIST_NUM           266
 #define SPIDER_CONN_META_BUF_LEN           64
 
 #define SPIDER_BACKUP_DASTATUS \
@@ -450,6 +450,7 @@ typedef struct st_spider_conn
   int                autocommit;
   int                sql_log_off;
   int                wait_timeout;
+  sql_mode_t         sql_mode;
   THD                *thd;
   void               *another_ha_first;
   void               *another_ha_last;
@@ -559,6 +560,7 @@ typedef struct st_spider_conn
   bool               queued_wait_timeout;
   bool               queued_autocommit;
   bool               queued_sql_log_off;
+  bool               queued_sql_mode;
   bool               queued_time_zone;
   bool               queued_trx_start;
   bool               queued_xa_start;
@@ -572,6 +574,7 @@ typedef struct st_spider_conn
   int                queued_wait_timeout_val;
   bool               queued_autocommit_val;
   bool               queued_sql_log_off_val;
+  sql_mode_t         queued_sql_mode_val;
   Time_zone          *queued_time_zone_val;
   XID                *queued_xa_start_xid;
 

--- a/storage/spider/spd_param.cc
+++ b/storage/spider/spd_param.cc
@@ -3405,6 +3405,26 @@ int spider_param_wait_timeout(
   DBUG_RETURN(604800);
 }
 
+/*
+  FALSE: no sync
+  TRUE:  sync
+ */
+static MYSQL_THDVAR_BOOL(
+  sync_sql_mode, /* name */
+  PLUGIN_VAR_OPCMDARG, /* opt */
+  "Sync sql_mode", /* comment */
+  NULL, /* check */
+  NULL, /* update */
+  TRUE /* def */
+);
+
+bool spider_param_sync_sql_mode(
+  THD *thd
+) {
+  DBUG_ENTER("spider_param_sync_sql_mode");
+  DBUG_RETURN(THDVAR(thd, sync_sql_mode));
+}
+
 static struct st_mysql_storage_engine spider_storage_engine =
 { MYSQL_HANDLERTON_INTERFACE_VERSION };
 
@@ -3557,6 +3577,7 @@ static struct st_mysql_sys_var* spider_system_variables[] = {
   MYSQL_SYSVAR(slave_trx_isolation),
   MYSQL_SYSVAR(remote_wait_timeout),
   MYSQL_SYSVAR(wait_timeout),
+  MYSQL_SYSVAR(sync_sql_mode),
   NULL
 };
 

--- a/storage/spider/spd_param.h
+++ b/storage/spider/spd_param.h
@@ -428,3 +428,6 @@ int spider_param_remote_wait_timeout(
 int spider_param_wait_timeout(
   THD *thd
 );
+bool spider_param_sync_sql_mode(
+  THD *thd
+);

--- a/storage/spider/spd_trx.cc
+++ b/storage/spider/spd_trx.cc
@@ -1684,6 +1684,16 @@ int spider_check_and_set_wait_timeout(
   DBUG_RETURN(0);
 }
 
+int spider_check_and_set_sql_mode(
+  THD *thd,
+  SPIDER_CONN *conn,
+  int *need_mon
+) {
+  DBUG_ENTER("spider_check_and_set_sql_mode");
+  spider_conn_queue_sql_mode(conn, thd->variables.sql_mode);
+  DBUG_RETURN(0);
+}
+
 int spider_check_and_set_time_zone(
   THD *thd,
   SPIDER_CONN *conn,
@@ -1885,6 +1895,9 @@ int spider_internal_start_trx(
       &spider->need_mons[link_idx])) ||
     (error_num = spider_check_and_set_wait_timeout(thd, conn,
       &spider->need_mons[link_idx])) ||
+    (spider_param_sync_sql_mode(thd) &&
+      (error_num = spider_check_and_set_sql_mode(thd, conn,
+        &spider->need_mons[link_idx]))) ||
     (sync_autocommit &&
       (error_num = spider_check_and_set_autocommit(thd, conn,
         &spider->need_mons[link_idx])))

--- a/storage/spider/spd_trx.h
+++ b/storage/spider/spd_trx.h
@@ -106,6 +106,12 @@ int spider_check_and_set_wait_timeout(
   int *need_mon
 );
 
+int spider_check_and_set_sql_mode(
+  THD *thd,
+  SPIDER_CONN *conn,
+  int *need_mon
+);
+
 int spider_check_and_set_time_zone(
   THD *thd,
   SPIDER_CONN *conn,


### PR DESCRIPTION
…ta nodes

Add the following parameter.

- spider_sync_sql_mode
  Local sql_mode synchronous existence to remote server.
   0 : It doesn't synchronize.
   1 : It synchronizes.
  The default value is 1