### PR TITLE
MDEV-11204: SHOW SLAVE HOSTS should show connection name

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_show_slave_hosts.result
+++ b/mysql-test/suite/rpl/r/rpl_show_slave_hosts.result
@@ -10,11 +10,11 @@ connection master;
 SHOW SLAVE HOSTS;
 Server_id	Host	Port	Master_id
 3	slave2	SLAVE_PORT	1
-2		SLAVE_PORT	1
+2	localhost	SLAVE_PORT	1
 connection slave2;
 include/stop_slave_io.inc
 connection master;
 SHOW SLAVE HOSTS;
 Server_id	Host	Port	Master_id
-2		SLAVE_PORT	1
+2	localhost	SLAVE_PORT	1
 include/rpl_end.inc

--- a/sql/repl_failsafe.cc
+++ b/sql/repl_failsafe.cc
@@ -148,7 +148,7 @@ int THD::register_slave(uchar *packet, size_t packet_length)
     si->master_id= global_system_variables.server_id;
 
   if (!*si->host)
-    strmake(si->host, thd->main_security_ctx.host_or_ip, sizeof(si->host));
+    ::strmake(si->host, main_security_ctx.host_or_ip, sizeof(si->host));
 
   unregister_slave();
   mysql_mutex_lock(&LOCK_thd_data);

--- a/sql/repl_failsafe.cc
+++ b/sql/repl_failsafe.cc
@@ -147,6 +147,9 @@ int THD::register_slave(uchar *packet, size_t packet_length)
   if (!(si->master_id= uint4korr(p)))
     si->master_id= global_system_variables.server_id;
 
+  if (!*si->host)
+    strmake(si->host, thd->main_security_ctx.host_or_ip, sizeof(si->host));
+
   unregister_slave();
   mysql_mutex_lock(&LOCK_thd_data);
   slave_info= si;


### PR DESCRIPTION
Since the client host can be extracted from the network connection, it can
always be printed. This makes it easier to find out where a slave is
replicating from. It could also be used to automatically discover slaves
that are replicating from a master.