### PR TITLE
MDEV-19508 Issue with: #define SI_KERNEL in include/my_pthread.h

### DIFF
--- a/include/my_pthread.h
+++ b/include/my_pthread.h
@@ -193,13 +193,13 @@ int sigwait(sigset_t *set, int *sig);
 
 static inline int my_sigwait(sigset_t *set, int *sig, int *code)
 {
+#define SI_KERNEL 128
 #ifdef HAVE_SIGWAITINFO
   siginfo_t siginfo;
   *sig= sigwaitinfo(set, &siginfo);
   *code= siginfo.si_code;
   return *sig < 0 ?  errno : 0;
 #else
-#define SI_KERNEL 128
   *code= 0;
   return sigwait(set, sig);
 #endif


### PR DESCRIPTION
Related to [MDEV-19508](https://jira.mariadb.org/browse/MDEV-19508).

SI_KERNEL is used on sql/mysqld.cc, line 3292 in all case. It is defined on include/my_pthread.h, line 866 only if HAVE_SIGWAITINFO is not defined.

On AIX, this causes an error during compilation. It can probably be reproduced on all system with HAVE_SIGWAITINFO defined.

With this patch, SI_KERNEL will be defined always.