### PR TITLE
MDEV-19831 find_select_handler() now tries its best to find a handlerton that is able to processes the whole query.

### DIFF
--- a/sql/select_handler.cc
+++ b/sql/select_handler.cc
@@ -45,6 +45,8 @@ Pushdown_select::Pushdown_select(SELECT_LEX *sel, select_handler *h)
 
 Pushdown_select::~Pushdown_select()
 {
+  if (handler->table)
+    free_tmp_table(handler->thd, handler->table);
   delete handler;
   select->select_h= NULL;
 }

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -28551,7 +28551,7 @@ select_handler *SELECT_LEX::find_select_handler(THD *thd)
       return 0;
   if (master_unit()->outer_select())
     return 0;
-  for (TABLE_LIST *tbl= join->tables_list; tbl; tbl= tbl->next_local)
+  for (TABLE_LIST *tbl= join->tables_list; tbl; tbl= tbl->next_global)
   {
     if (!tbl->table)
       continue;


### PR DESCRIPTION
find_select_handler() now tries its best to find a handlerton that is able to processes the whole query. For that it traverses tables from subqueries.

    Select_handler now cleans up temporary table structures on dctor call.