### PR TITLE
MDEV-5092 Implement UPDATE with result set

### DIFF
--- a/mysql-test/main/update_returning.result
+++ b/mysql-test/main/update_returning.result
@@ -1,0 +1,285 @@
+CREATE TABLE t1 (a int, b varchar(32));
+INSERT INTO t1 VALUES
+(7,'ggggggg'), (1,'a'), (3,'ccc'),
+(4,'dddd'), (1,'A'), (2,'BB'), (4,'DDDD'),
+(5,'EEEEE'), (7,'GGGGGGG'), (2,'bb');
+CREATE TABLE t1c SELECT * FROM t1;
+CREATE TABLE t2 (c int);
+INSERT INTO t2 VALUES 
+(4), (5), (7), (1);
+CREATE TABLE t2c SELECT * FROM t2;
+CREATE VIEW v1 AS SELECT a, UPPER(b) FROM t1;
+UPDATE t1 SET a = 1337 WHERE a=2 RETURNING * ;
+a	b
+1337	BB
+1337	bb
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	a
+3	ccc
+4	dddd
+1	A
+1337	BB
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+1337	bb
+UPDATE t1 SET a = 1338 WHERE a=1337 RETURNING b;
+b
+BB
+bb
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	a
+3	ccc
+4	dddd
+1	A
+1338	BB
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+1338	bb
+UPDATE t1 SET b = "AAA" WHERE a=1338 RETURNING b;
+b
+AAA
+AAA
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	a
+3	ccc
+4	dddd
+1	A
+1338	AAA
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+1338	AAA
+UPDATE t1 SET b = "BBBB" WHERE a=1338 RETURNING c;
+ERROR 42S22: Unknown column 'c' in 'field list'
+UPDATE t1 SET b = "AaAbbB1" WHERE a=1 RETURNING a, UPPER(b), 1338-1;
+a	UPPER(b)	1338-1
+1	AAABBB1	1337
+1	AAABBB1	1337
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	AaAbbB1
+3	ccc
+4	dddd
+1	AaAbbB1
+1338	AAA
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+1338	AAA
+UPDATE t1 SET a = 13 WHERE a < 0 RETURNING b;
+b
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	AaAbbB1
+3	ccc
+4	dddd
+1	AaAbbB1
+1338	AAA
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+1338	AAA
+UPDATE t1 SET b = "BBA" WHERE a=1 RETURNING MAX(a);
+ERROR HY000: Invalid use of group function
+DELETE FROM t1;
+INSERT INTO t1 SELECT * FROM t1c;
+UPDATE t1 SET b = "LessThanFive" WHERE a < 5 RETURNING a, (SELECT MIN(c) FROM t2 WHERE c=a+1);
+a	(SELECT MIN(c) FROM t2 WHERE c=a+1)
+1	NULL
+3	4
+4	5
+1	NULL
+2	NULL
+4	5
+2	NULL
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	LessThanFive
+3	LessThanFive
+4	LessThanFive
+1	LessThanFive
+2	LessThanFive
+4	LessThanFive
+5	EEEEE
+7	GGGGGGG
+2	LessThanFive
+DELETE FROM t1;
+INSERT INTO t1 SELECT * FROM t1c;
+UPDATE t2 SET c = 7 WHERE c < 5
+RETURNING (SELECT GROUP_CONCAT(b) FROM t1 GROUP BY a HAVING a=c);
+(SELECT GROUP_CONCAT(b) FROM t1 GROUP BY a HAVING a=c)
+GGGGGGG,ggggggg
+GGGGGGG,ggggggg
+SELECT * FROM t2;
+c
+7
+5
+7
+7
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+CREATE FUNCTION f(arg INT) RETURNS TEXT
+BEGIN
+RETURN (SELECT GROUP_CONCAT(b) FROM t1 WHERE a=arg);
+END|
+UPDATE t2 SET c = 7 WHERE c < 5 RETURNING f(c);
+f(c)
+ggggggg,GGGGGGG
+ggggggg,GGGGGGG
+SELECT * FROM t2;
+c
+7
+5
+7
+7
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+DROP FUNCTION f;
+UPDATE v1 SET a = a+1 WHERE a < 5 RETURNING *;
+a	UPPER(b)
+2	A
+4	CCC
+5	DDDD
+2	A
+3	BB
+5	DDDD
+3	BB
+SELECT * FROM t1;
+a	b
+7	ggggggg
+2	a
+4	ccc
+5	dddd
+2	A
+3	BB
+5	DDDD
+5	EEEEE
+7	GGGGGGG
+3	bb
+DELETE FROM t1;
+INSERT INTO t1 SELECT * FROM t1c;
+CREATE VIEW v11(a,c) AS SELECT a, COUNT(b) FROM t1 GROUP BY a;
+UPDATE v11 SET a = a + 1 WHERE a < 5 RETURNING * ;
+ERROR HY000: The target table v11 of the UPDATE is not updatable
+DROP VIEW v11;
+PREPARE stmt FROM 
+"UPDATE t1 SET a = 22 WHERE a=2 ORDER BY b LIMIT 1 RETURNING *, a, UPPER(b)";
+EXECUTE stmt;
+a	b	a	UPPER(b)
+22	BB	22	BB
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	a
+3	ccc
+4	dddd
+1	A
+22	BB
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+2	bb
+EXECUTE stmt;
+a	b	a	UPPER(b)
+22	bb	22	BB
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	a
+3	ccc
+4	dddd
+1	A
+22	BB
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+22	bb
+EXECUTE stmt;
+a	b	a	UPPER(b)
+SELECT * FROM t1;
+a	b
+7	ggggggg
+1	a
+3	ccc
+4	dddd
+1	A
+22	BB
+4	DDDD
+5	EEEEE
+7	GGGGGGG
+22	bb
+DEALLOCATE PREPARE stmt;
+ANALYZE UPDATE t2 SET c = 10 WHERE c < 7
+RETURNING (SELECT GROUP_CONCAT(b) FROM t1 GROUP BY a HAVING a=c);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	4	4.00	100.00	75.00	Using where
+2	DEPENDENT SUBQUERY	t1	ALL	NULL	NULL	NULL	NULL	10	10.00	100.00	100.00	Using filesort
+SELECT * FROM t2;
+c
+10
+10
+7
+10
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+EXPLAIN UPDATE t2 SET c = 10 WHERE c < 7
+RETURNING (SELECT GROUP_CONCAT(b) FROM t1 GROUP BY a HAVING a=c);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	4	Using where
+2	DEPENDENT SUBQUERY	t1	ALL	NULL	NULL	NULL	NULL	10	Using filesort
+SELECT * FROM t2;
+c
+4
+5
+7
+1
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+DROP VIEW v1;
+DROP TABLE t1,t2;
+DROP TABLE t1c,t2c;
+CREATE TABLE t1 (i1 int);
+INSERT INTO t1 VALUES (1),(2);
+CREATE TABLE t2 (i2 int);
+INSERT INTO t2 VALUES (1),(2);
+UPDATE t1 set i1 = 3 ORDER BY i1 RETURNING ( SELECT i2 FROM t2 );
+ERROR 21000: Subquery returns more than 1 row
+DROP TABLE t1,t2;
+CREATE TABLE t3 (id int, val varchar(32), PRIMARY KEY (id));
+INSERT INTO t3 VALUES (1, 'a');
+INSERT INTO t3 VALUES (3, 'b');
+INSERT INTO t3 VALUES (4, 'c');
+INSERT INTO t3 VALUES (5, 'd');
+UPDATE IGNORE t3 SET id= id+1 RETURNING id;
+id
+2
+6
+SELECT * FROM t3;
+id	val
+2	a
+3	b
+4	c
+6	d
+UPDATE IGNORE t3 SET id= 5 RETURNING id;
+id
+5
+UPDATE IGNORE t3 SET id= 5 RETURNING id;
+id
+SELECT * FROM t3;
+id	val
+5	a
+3	b
+4	c
+6	d
+DROP TABLE t3;

--- a/mysql-test/main/update_returning.test
+++ b/mysql-test/main/update_returning.test
@@ -1,0 +1,175 @@
+#
+#  Tests for UPDATE <table> ... RETURNING <expr>,...
+#
+
+CREATE TABLE t1 (a int, b varchar(32));
+INSERT INTO t1 VALUES
+  (7,'ggggggg'), (1,'a'), (3,'ccc'),
+  (4,'dddd'), (1,'A'), (2,'BB'), (4,'DDDD'),
+  (5,'EEEEE'), (7,'GGGGGGG'), (2,'bb');
+
+CREATE TABLE t1c SELECT * FROM t1;
+
+CREATE TABLE t2 (c int);
+INSERT INTO t2 VALUES 
+  (4), (5), (7), (1);
+
+CREATE TABLE t2c SELECT * FROM t2;
+
+CREATE VIEW v1 AS SELECT a, UPPER(b) FROM t1;
+
+# UPDATE <table> ...  RETURNING *
+ 
+UPDATE t1 SET a = 1337 WHERE a=2 RETURNING * ;
+SELECT * FROM t1;
+
+
+# UPDATE <table> ...  RETURNING <col>
+
+UPDATE t1 SET a = 1338 WHERE a=1337 RETURNING b;
+
+SELECT * FROM t1;
+
+# UPDATE <table> ...  RETURNING <col>
+
+UPDATE t1 SET b = "AAA" WHERE a=1338 RETURNING b;
+
+SELECT * FROM t1;
+
+# UPDATE <table> ...  RETURNING <not existing col>
+--error ER_BAD_FIELD_ERROR
+UPDATE t1 SET b = "BBBB" WHERE a=1338 RETURNING c;
+
+# UPDATE <table> ...  RETURNING <col>, <expr>
+
+UPDATE t1 SET b = "AaAbbB1" WHERE a=1 RETURNING a, UPPER(b), 1338-1;
+SELECT * FROM t1;
+
+# UPDATE <table> ...  RETURNING <col> with no rows to be updated
+
+UPDATE t1 SET a = 13 WHERE a < 0 RETURNING b;
+SELECT * FROM t1;
+
+# UPDATE <table> ... RETURNING <expr with aggr function>
+
+--error ER_INVALID_GROUP_FUNC_USE
+UPDATE t1 SET b = "BBA" WHERE a=1 RETURNING MAX(a);
+
+DELETE FROM t1;
+INSERT INTO t1 SELECT * FROM t1c;
+
+# UPDATE <table> ...  RETURNING <expr with subquery>
+
+UPDATE t1 SET b = "LessThanFive" WHERE a < 5 RETURNING a, (SELECT MIN(c) FROM t2 WHERE c=a+1);
+SELECT * FROM t1;
+
+DELETE FROM t1;
+INSERT INTO t1 SELECT * FROM t1c;
+
+# UPDATE <table> ...  RETURNING <expr with subquery>
+
+UPDATE t2 SET c = 7 WHERE c < 5
+  RETURNING (SELECT GROUP_CONCAT(b) FROM t1 GROUP BY a HAVING a=c);
+SELECT * FROM t2;
+
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+
+# UPDATE <table> ... RETURNING <expr with function invocation>
+
+DELIMITER |;
+
+CREATE FUNCTION f(arg INT) RETURNS TEXT
+BEGIN
+  RETURN (SELECT GROUP_CONCAT(b) FROM t1 WHERE a=arg);
+END|
+
+DELIMITER ;|
+
+UPDATE t2 SET c = 7 WHERE c < 5 RETURNING f(c);
+SELECT * FROM t2;
+
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+
+DROP FUNCTION f;
+
+# UPDATE <view> ...  RETURNING *
+
+UPDATE v1 SET a = a+1 WHERE a < 5 RETURNING *;
+SELECT * FROM t1;
+ 
+DELETE FROM t1;
+INSERT INTO t1 SELECT * FROM t1c;
+
+# UPDATE <view> ...  RETURNING <expr>
+
+CREATE VIEW v11(a,c) AS SELECT a, COUNT(b) FROM t1 GROUP BY a;
+-- error ER_NON_UPDATABLE_TABLE
+UPDATE v11 SET a = a + 1 WHERE a < 5 RETURNING * ;
+DROP VIEW v11;
+
+# prepared UPDATE <table> ... RETURNING <expr>
+
+PREPARE stmt FROM 
+"UPDATE t1 SET a = 22 WHERE a=2 ORDER BY b LIMIT 1 RETURNING *, a, UPPER(b)";
+EXECUTE stmt;
+SELECT * FROM t1;
+EXECUTE stmt;
+SELECT * FROM t1;
+EXECUTE stmt;
+SELECT * FROM t1;
+DEALLOCATE PREPARE stmt;
+
+
+# ANALYZE UPDATE ... RETURNING
+
+ANALYZE UPDATE t2 SET c = 10 WHERE c < 7
+  RETURNING (SELECT GROUP_CONCAT(b) FROM t1 GROUP BY a HAVING a=c);
+SELECT * FROM t2;
+
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+
+# EXPLAIN UPDATE ... RETURNING
+
+EXPLAIN UPDATE t2 SET c = 10 WHERE c < 7
+  RETURNING (SELECT GROUP_CONCAT(b) FROM t1 GROUP BY a HAVING a=c);
+SELECT * FROM t2;
+
+DELETE FROM t2;
+INSERT INTO t2 SELECT * FROM t2c;
+
+# Cleanup
+DROP VIEW v1;
+DROP TABLE t1,t2;
+DROP TABLE t1c,t2c;
+
+# UPDATE ... RETURNING subquery with more than 1 row
+
+CREATE TABLE t1 (i1 int);
+INSERT INTO t1 VALUES (1),(2);
+
+CREATE TABLE t2 (i2 int);
+INSERT INTO t2 VALUES (1),(2);
+
+--error ER_SUBQUERY_NO_1_ROW
+UPDATE t1 set i1 = 3 ORDER BY i1 RETURNING ( SELECT i2 FROM t2 );
+
+DROP TABLE t1,t2;
+
+# UPDATE IGNORE ... RETURNING with ignored duplicate key error
+
+CREATE TABLE t3 (id int, val varchar(32), PRIMARY KEY (id));
+INSERT INTO t3 VALUES (1, 'a');
+INSERT INTO t3 VALUES (3, 'b');
+INSERT INTO t3 VALUES (4, 'c');
+INSERT INTO t3 VALUES (5, 'd');
+UPDATE IGNORE t3 SET id= id+1 RETURNING id;
+SELECT * FROM t3;
+
+UPDATE IGNORE t3 SET id= 5 RETURNING id;
+UPDATE IGNORE t3 SET id= 5 RETURNING id;
+SELECT * FROM t3;
+
+DROP TABLE t3;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -6188,6 +6188,11 @@ public:
 
 class multi_update :public select_result_interceptor
 {
+  TABLE *ret_tmp_table; /* table containing rowids of tables used in RETURNING */
+  select_result *ret_sel_result; /* select result for RETURNING clause */
+  TMP_TABLE_PARAM *ret_tmp_param;   /* RETURNING Tmp table info */
+  List<Item> *ret_item_list; /* columns used in RETURNING */
+  TABLE_LIST *ret_tables; /* tables used in RETURNING */
   TABLE_LIST *all_tables; /* query/update command tables */
   List<TABLE_LIST> *leaves;     /* list of leves of join table tree */
   TABLE_LIST *update_tables;
@@ -6221,13 +6226,17 @@ class multi_update :public select_result_interceptor
   ha_rows updated_sys_ver;
 
   bool has_vers_fields;
+  /* ret_item_list is not empty */
+  bool is_returning;
 
 public:
   multi_update(THD *thd_arg, TABLE_LIST *ut, List<TABLE_LIST> *leaves_list,
 	       List<Item> *fields, List<Item> *values,
-	       enum_duplicates handle_duplicates, bool ignore);
+	       enum_duplicates handle_duplicates, bool ignore,
+	       select_result *ret_sel_result);
   ~multi_update();
   int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
+  bool send_result_set_metadata(List<Item> &list, uint flags);
   int send_data(List<Item> &items);
   bool initialize_tables (JOIN *join);
   int prepare2(JOIN *join);

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -2378,6 +2378,7 @@ void st_select_lex::init_query()
   leaf_tables_prep.empty();
   leaf_tables.empty();
   item_list.empty();
+  ret_item_list.empty();
   min_max_opt_list.empty();
   join= 0;
   having= prep_having= where= prep_where= 0;

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -1081,6 +1081,7 @@ public:
   Group_list_ptrs        *group_list_ptrs;
 
   List<Item>          item_list;  /* list of fields & expressions */
+  List<Item>          ret_item_list;  /* list of fields & expressions for RETURNING */
   List<Item>          pre_fix; /* above list before fix_fields */
   bool                is_item_list_lookup;
   /* 

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -1401,7 +1401,8 @@ static int mysql_test_update(Prepared_statement *stmt,
                    table_list->grant.want_privilege);
 #endif
 
-  if (mysql_prepare_update(thd, table_list, &select->where,
+  if (mysql_prepare_update(thd, table_list, select->with_wild,
+                           select->ret_item_list, &select->where,
                            select->order_list.elements,
                            select->order_list.first))
     goto error;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -17833,6 +17833,7 @@ create_tmp_table(THD *thd, TMP_TABLE_PARAM *param, List<Item> &fields,
   KEY *keyinfo;
   KEY_PART_INFO *key_part_info;
   Item **copy_func;
+  bool is_returning = !thd->lex->first_select_lex()->ret_item_list.is_empty();
   TMP_ENGINE_COLUMNDEF *recinfo;
   /*
     total_uneven_bit_length is uneven bit length for visible fields
@@ -18098,7 +18099,7 @@ create_tmp_table(THD *thd, TMP_TABLE_PARAM *param, List<Item> &fields,
                          tmp_from_field, &default_field[fieldnr],
                          group != 0,
                          !force_copy_fields &&
-                           (not_all_columns || group !=0),
+                           (not_all_columns || group !=0 || is_returning),
                          /*
                            If item->marker == 4 then we force create_tmp_field
                            to create a 64-bit longs for BIT fields because HEAP

--- a/sql/sql_update.h
+++ b/sql/sql_update.h
@@ -39,7 +39,7 @@ bool mysql_multi_update(THD *thd, TABLE_LIST *table_list,
                         COND *conds, ulonglong options,
                         enum enum_duplicates handle_duplicates, bool ignore,
                         SELECT_LEX_UNIT *unit, SELECT_LEX *select_lex,
-                        multi_update **result);
+                        multi_update **result, select_result *ret_sel_result);
 bool records_are_comparable(const TABLE *table);
 bool compare_record(const TABLE *table);
 

--- a/sql/sql_update.h
+++ b/sql/sql_update.h
@@ -26,12 +26,14 @@ typedef class st_select_lex SELECT_LEX;
 typedef class st_select_lex_unit SELECT_LEX_UNIT;
 
 bool mysql_prepare_update(THD *thd, TABLE_LIST *table_list,
+                          uint wild_num, List<Item> &field_list,
                           Item **conds, uint order_num, ORDER *order);
 bool check_unique_table(THD *thd, TABLE_LIST *table_list);
 int mysql_update(THD *thd,TABLE_LIST *tables,List<Item> &fields,
 		 List<Item> &values,COND *conds,
 		 uint order_num, ORDER *order, ha_rows limit,
-                 bool ignore, ha_rows *found_return, ha_rows *updated_return);
+                 bool ignore, ha_rows *found_return, ha_rows *updated_return,
+                 select_result *result);
 bool mysql_multi_update(THD *thd, TABLE_LIST *table_list,
                         List<Item> *fields, List<Item> *values,
                         COND *conds, ulonglong options,

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -13604,6 +13604,11 @@ update:
           }
           opt_where_clause opt_order_clause delete_limit_clause
           {
+            Select->ret_item_list.swap(Select->item_list);
+          }
+          opt_select_expressions
+          {
+            Select->ret_item_list.swap(Select->item_list);
             if ($10)
               Select->order_list= *($10);
             Lex->pop_select(); //main select


### PR DESCRIPTION
# GSoC 2019 with MariaDB
**Student**: Miroslav Koberskii  
**GitHub**: [@Mup0c](https://github.com/Mup0c)  
**Organization**: [MariaDB](https://mariadb.org)  
**Project Title**: [Implementing UPDATE with result set](https://summerofcode.withgoogle.com/projects/#5157398770089984), [MDEV-5092](https://jira.mariadb.org/browse/MDEV-5092)
## About
  The task is about adding `RETURNING` option to `UPDATE` clause in MariaDB server, that returns a result set of the changed rows to the client.  
```sql
UPDATE table SET table.item = table.item + 100 RETURNING table.item;
```
  It contains two parts: for single-table `UPDATE` and for multiple tables `UPDATE`. My main task was a single-table variant. And extra goal was doing the multiple table variant.  

## What's done:
* Extended parser to parse `RETURNING` option in `UPDATE` clause.
* Maked necessary preparations, passed `select_send` to `mysql_update` function and called it's functions where needed.
* Wrote tests for single-table `UPDATE .. RETURNING`.  
###### for multiple table variant:  
  Multiple table `UPDATE` is resolved by passing custom `select_result` (`multi_update`) to `mysql_select` that makes joins and calls `multi_update` functions. These functions contain all the logic of multiple table `UPDATE`, and intercept sending rows to the client.   
  **So I've added `select_send` to `multi_update` to be able to actually send result set rows to the client.**  
  Updates are made table by table with help of temporary tables, that store rowid (unique identificator for row in table) and values that will be inserted to the original table in the position that rowid points.  
  So we can not just call `send_data` when updates are done. Only one table will be in right position. Other tables' positions will not change during the update of each table.  
  **So I've added a new temporary table (`ret_tmp_table`) that contains rowids of tables used in `RETURNING` item list (columns referenced in `RETURNING`).  
  The table is filled with one row of current rowids of tables per one call of `multi_update::send_data()`.** They're in right positions for `RETURNING` because `mysql_select` set their positions as they would be when select should send rows to the client.  
  **After tables used in `RETURNING` are set to positions that are stored in `ret_tmp_table`, `send_data()` is called.** That outputs result set to the client  

## What's to be done:
* Solve an issue with InnoDB storage engine, that uses `PRIMARY_KEY` as rowid. So if we change it in update, later we can not set table in that position by stored rowid to send it to the client because the rowid is now changed. (Just replace old rowids with new in `ret_tmp_table`)
* Now it's returning all potentially updated rows, no matter if it was updated to the same value or duplicate key error occured and we skipped updating of that row (when using `IGNORE`, for example). It's better not to output rows that were not actually updated.
* Write tests for multiple table variant of `UPDATE .. RETURNING`