### PR TITLE
MDEV-20561 Galera node shutdown fails in non-Primary

### DIFF
--- a/mysql-test/suite/galera/r/galera_shutdown_nonprim.result
+++ b/mysql-test/suite/galera/r/galera_shutdown_nonprim.result
@@ -1,0 +1,9 @@
+connection node_1;
+connection node_2;
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.weight=2';
+connection node_2;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+SET SESSION wsrep_sync_wait = 0;
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.weight = 1';

--- a/mysql-test/suite/galera/t/galera_shutdown_nonprim.test
+++ b/mysql-test/suite/galera/t/galera_shutdown_nonprim.test
@@ -1,0 +1,36 @@
+#
+# Check that server can be shut down in non-primary configuration.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--let $node_1 = node_1
+--let $node_2 = node_2
+--source include/auto_increment_offset_save.inc
+
+--connection node_1
+# Set higher weight for node_1 to keep it in primary
+# while node_2 is isolated.
+SET GLOBAL wsrep_provider_options = 'pc.weight=2';
+
+--connection node_2
+# Isolate node_2 from the group and wait until wsrep_ready becomes OFF.
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate = 1';
+SET SESSION wsrep_sync_wait = 0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 'OFF' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_ready'
+--source include/wait_condition.inc
+
+# Verify that graceful shutdown succeeds.
+--source include/shutdown_mysqld.inc
+--source include/start_mysqld.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_1
+--source include/wait_condition.inc
+
+# Restore original settings.
+SET GLOBAL wsrep_provider_options = 'pc.weight = 1';
+--source include/auto_increment_offset_restore.inc

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -528,7 +528,6 @@ void init_update_queries(void)
   server_command_flags[COM_STMT_SEND_LONG_DATA]= CF_SKIP_WSREP_CHECK;
   server_command_flags[COM_REGISTER_SLAVE]= CF_SKIP_WSREP_CHECK;
   server_command_flags[COM_MULTI]= CF_SKIP_WSREP_CHECK | CF_NO_COM_MULTI;
-  server_command_flags[CF_NO_COM_MULTI]= CF_NO_COM_MULTI;
 
   /* Initialize the sql command flags array. */
   memset(sql_command_flags, 0, sizeof(sql_command_flags));


### PR DESCRIPTION
Command COM_SHUTDOWN was rejected in non-Primary because
server_command_flags[COM_SHUTDOWN] had value CF_NO_COM_MULTI
instead of CF_SKIP_WSREP_CHECK.

As a fix removed assignment
server_command_flags[CF_NO_COM_MULTI]= CF_NO_COM_MULTI
which overwrote server_command_flags[COM_SHUTDOWN].