### PR TITLE
MDEV-20684: innodb: use madvise CORE/NOCORE on FreeBSD for selective large allocations

### DIFF
--- a/include/my_global.h
+++ b/include/my_global.h
@@ -445,6 +445,20 @@ C_MODE_END
 #if HAVE_MADVISE && !HAVE_DECL_MADVISE && defined(__cplusplus)
 extern "C" int madvise(void *addr, size_t len, int behav);
 #endif
+#ifdef HAVE_SYS_MMAN_H
+#include <sys/mman.h>
+#endif
+/** FreeBSD equivalent */
+#if defined(MADV_CORE) && !defined(MADV_DODUMP)
+#define MADV_DODUMP MADV_CORE
+#define MADV_DONTDUMP MADV_NOCORE
+#define DODUMP_STR "MADV_CORE"
+#define DONTDUMP_STR "MADV_NOCORE"
+#else
+#define DODUMP_STR "MADV_DODUMP"
+#define DONTDUMP_STR "MADV_DONTDUMP"
+#endif
+
 
 #define QUOTE_ARG(x)		#x	/* Quote argument (before cpp) */
 #define STRINGIFY_ARG(x) QUOTE_ARG(x)	/* Quote argument, after cpp */

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -2662,7 +2662,7 @@ size_t Query_cache::init_cache()
 #if defined(DBUG_OFF) && defined(HAVE_MADVISE) &&  defined(MADV_DONTDUMP)
   if (madvise(cache, query_cache_size+additional_data_size, MADV_DONTDUMP))
   {
-    DBUG_PRINT("warning", ("coudn't mark query cache memory as MADV_DONTDUMP: %s",
+    DBUG_PRINT("warning", ("coudn't mark query cache memory as " DONTDUMP_STR ": %s",
 			 strerror(errno)));
   }
 #endif
@@ -2831,7 +2831,7 @@ void Query_cache::free_cache()
 #if defined(DBUG_OFF) && defined(HAVE_MADVISE) &&  defined(MADV_DODUMP)
   if (madvise(cache, query_cache_size+additional_data_size, MADV_DODUMP))
   {
-    DBUG_PRINT("warning", ("coudn't mark query cache memory as MADV_DODUMP: %s",
+    DBUG_PRINT("warning", ("coudn't mark query cache memory as " DODUMP_STR ": %s",
 			 strerror(errno)));
   }
 #endif

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -252,7 +252,7 @@ static inline void ut_allocate_trace_dontdump(void *ptr, size_t	bytes,
 
 #if defined(DBUG_OFF) && defined(HAVE_MADVISE) && defined(MADV_DONTDUMP)
 	if (dontdump && madvise(ptr, bytes, MADV_DONTDUMP)) {
-		ib::warn() << "Failed to set memory to DONTDUMP: "
+		ib::warn() << "Failed to set memory to " DONTDUMP_STR ": "
 			   << strerror(errno)
 			   << " ptr " << ptr
 			   << " size " << bytes;
@@ -270,7 +270,7 @@ static inline void ut_allocate_trace_dontdump(void *ptr, size_t	bytes,
 static inline void ut_dodump(void* ptr, size_t m_size)
 {
 	if (ptr && madvise(ptr, m_size, MADV_DODUMP)) {
-		ib::warn() << "Failed to set memory to DODUMP: "
+		ib::warn() << "Failed to set memory to " DODUMP_STR ": "
 			   << strerror(errno)
 			   << " ptr " << ptr
 			   << " size " << m_size;


### PR DESCRIPTION
This maps to the way Linux does it in MDEV-10814 except FreeBSD uses different constants.

Tested on FreeBSD-12.0 (x86_64)

Selected 10.3 as a target because that's when MDEV-10814 was added and because the concept is proved and the patch being FreeBSD has different constants.

I submit this under the MCA.