### PR TITLE
MDEV-20329 Fix S3 engine OpenSSL race

### DIFF
--- a/storage/maria/CMakeLists.txt
+++ b/storage/maria/CMakeLists.txt
@@ -104,6 +104,33 @@ OPTION(USE_ARIA_FOR_TMP_TABLES "Use Aria for temporary tables" ON)
 # S3
 #
 INCLUDE (CheckIncludeFiles)
+INCLUDE (CheckCSourceRuns)
+
+SET(CURL_SSL_TEST_SOURCE "\n
+   #include <curl/curl.h>\n
+   #include <stdlib.h>\n
+   #include <string.h>\n
+   int main(void)\n
+   {\n
+     curl_version_info_data *data = curl_version_info(CURLVERSION_NOW);\n
+\n
+     if (data->ssl_version)\n
+     {\n
+       if (strncmp(data->ssl_version, \"OpenSSL\", 7) != 0)\n
+       {\n
+         return EXIT_SUCCESS;\n
+       }\n
+       if (data->ssl_version[8] == '0')\n
+       {\n
+         return EXIT_FAILURE;\n
+       }\n
+       if ((data->ssl_version[8] == '1') && (data->ssl_version[10] == '0'))\n
+       {\n
+         return EXIT_FAILURE;\n
+       }\n
+     }\n
+     return EXIT_SUCCESS;\n
+   }")
 
 SET(S3_SOURCES ha_s3.cc s3_func.c
     libmarias3/src/debug.c libmarias3/src/error.c libmarias3/src/marias3.c
@@ -122,11 +149,20 @@ IF (LIBXML2_FOUND AND CURL_FOUND)
 ENDIF()
 
 IF(TARGET s3)
+  SET(CMAKE_REQUIRED_LIBRARIES curl)
+  CHECK_C_SOURCE_RUNS("${CURL_SSL_TEST_SOURCE}" FOUND_SAFE_CURL_SSL)
+  UNSET(CMAKE_REQUIRED_LIBRARIES)
   MYSQL_ADD_EXECUTABLE(aria_s3_copy aria_s3_copy.cc COMPONENT Server)
   TARGET_LINK_LIBRARIES(aria_s3_copy s3)
 
   INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/libmarias3 ${LIBXML2_INCLUDE_DIR})
   ADD_DEFINITIONS(-DWITH_S3_STORAGE_ENGINE)
+  IF (FOUND_SAFE_CURL_SSL)
+      MESSAGE(STATUS "Found thread safe curl ssl")
+  ELSE ()
+      MESSAGE(STATUS "Found thread unsafe curl ssl, locks added")
+      ADD_DEFINITIONS(-DHAVE_CURL_OPENSSL_UNSAFE)
+  ENDIF ()
 
   TARGET_LINK_LIBRARIES(aria s3)
 ENDIF()


### PR DESCRIPTION
With OpenSSL < 1.1 there is a potential for a race condition to occur.
This can cause the S3 engine to crash. The workaround is to add locking
callbacks to OpenSSL so that this doesn't happen.

https://curl.haxx.se/libcurl/c/threadsafe.html

There is a fix in libMariaS3 for this which when a certain flag is set
(HAVE_CURL_OPENSSL_UNSAFE) will add the required locks.

This patch adds CMake support so that the flag is set if it is found
that Curl is compiled with an unsafe OpenSSL version. For example Ubuntu
16.04 with libcurl4-openssl-dev.