### PR TITLE
MDEV-20767 writable-string error on OSX with 10.4.8

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -2671,7 +2671,7 @@ static int fake_magic_space(const char *, int)
 static void initialize_readline ()
 {
   /* Allow conditional parsing of the ~/.inputrc file. */
-  rl_readline_name= "mysql";
+  rl_readline_name= (char *) "mysql";
   rl_terminal_name= getenv("TERM");
 
   /* Tell the completer that we want a crack first. */


### PR DESCRIPTION
Fix for [MDEV-20767](https://jira.mariadb.org/browse/MDEV-20767) which causes broken builds on OSX with 10.4.8. This change is a copy/paste from 10.5, there was no specific commit could find in the 10.4 or 10.5 git history for this change but it showed up in the merge commit of https://github.com/MariaDB/server/commit/edef6a007428599fd249815f1dc59a02428090f4

I have previously signed the MCA.