### PR TITLE
Fix build on !glibc/powerpc*

### DIFF
--- a/storage/xtradb/include/ut0ut.h
+++ b/storage/xtradb/include/ut0ut.h
@@ -83,7 +83,7 @@ private:
    the YieldProcessor macro defined in WinNT.h. It is a CPU architecture-
    independent way by using YieldProcessor. */
 #  define UT_RELAX_CPU() YieldProcessor()
-# elif defined(__powerpc__)
+# elif defined(__powerpc__) && defined __GLIBC__
 #include <sys/platform/ppc.h>
 #  define UT_RELAX_CPU() __ppc_get_timebase()
 # else


### PR DESCRIPTION
Do the same that newer branches do and don't include glibc-related headers on non-glibc environment.