### PR TITLE
MDEV-16662: cmake: CMP0026 compatible for dtrace

### DIFF
--- a/cmake/dtrace.cmake
+++ b/cmake/dtrace.cmake
@@ -147,11 +147,10 @@ FUNCTION(DTRACE_INSTRUMENT target)
         # Note: DTrace probes in static libraries are  unusable currently 
         # (see explanation for DTRACE_INSTRUMENT_STATIC_LIBS below)
         # but maybe one day this will be fixed.
-        GET_TARGET_PROPERTY(target_location ${target} LOCATION)
         ADD_CUSTOM_COMMAND(
           TARGET ${target} POST_BUILD
-          COMMAND ${CMAKE_AR} r  ${target_location} ${outfile}
-	  COMMAND ${CMAKE_RANLIB} ${target_location}
+          COMMAND ${CMAKE_AR} r  $<TARGET_FILE:${target}> ${outfile}
+          COMMAND ${CMAKE_RANLIB} $<TARGET_FILE:${target}>
           )
         # Used in DTRACE_INSTRUMENT_WITH_STATIC_LIBS
         SET(TARGET_OBJECT_DIRECTORY_${target}  ${objdir} CACHE INTERNAL "")


### PR DESCRIPTION
cmake enabling -DENABLE_DTRACE=ON is particularly noisy with CMP0026
errors.

Fixed in the same way as 6b53f9d781cc19cbec96c3eb048e6407021685a2

I submit this under the MCA.