### PR TITLE
MDEV-20972: `or` alterative operator breaking windows build

### DIFF
--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -123,7 +123,7 @@ void Item_subselect::init(st_select_lex *select_lex,
                     NO_MATTER :
                     outer_select->parsing_place);
     if (unit->is_unit_op() &&
-        (unit->first_select()->next_select() or unit->fake_select_lex))
+        (unit->first_select()->next_select() || unit->fake_select_lex))
       engine= new subselect_union_engine(unit, result, this);
     else
       engine= new subselect_single_select_engine(select_lex, result, this);


### PR DESCRIPTION
This solves a build issue we had on VS2015. I've previously signed the MCA.

Jira ticket: https://jira.mariadb.org/browse/MDEV-20972