### PR TITLE
MDEV-20981 wsrep_sst_mariabackup fails silently when mariabackup is n…

### DIFF
--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -83,7 +83,14 @@ fi
 pcmd="pv $pvopts"
 declare -a RC
 
+set +e
 INNOBACKUPEX_BIN=$(which mariabackup)
+if test -z $INNOBACKUPEX_BIN
+then
+  wsrep_log_error 'mariabackup binary not found in $PATH'
+  exit 42
+fi
+set -e
 XBSTREAM_BIN=mbstream
 XBCRYPT_BIN=xbcrypt # Not available in MariaBackup
 


### PR DESCRIPTION
…ot installed

Make sure failure to find mariabackup binary does not terminate
the script silently, terminate with a clear error message instead