### PR TITLE
Fix a typo in mariadb-plugin-mroonga.prerm

### DIFF
--- a/debian/mariadb-plugin-mroonga.prerm
+++ b/debian/mariadb-plugin-mroonga.prerm
@@ -2,7 +2,7 @@
 
 set -e
 
-# Install Mroonga
+# Uninstall Mroonga
 mysql --defaults-file=/etc/mysql/debian.cnf < /usr/share/mysql/mroonga/uninstall.sql || true
 # Always exit with success instead of leaving dpkg in a broken state
 


### PR DESCRIPTION
This script is for uninstalling the plugin.
However, the comment in the script is "Install".