### PR TITLE
Fix MTR suppressions in inconsistency voting tests

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/GCF-376.result
+++ b/mysql-test/suite/galera_3nodes/r/GCF-376.result
@@ -69,3 +69,4 @@ CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table
 CALL mtr.add_suppression("WSREP: Event (.*) Write_rows_v1 apply failed: 121, seqno ");
 CALL mtr.add_suppression("WSREP: Inconsistency detected: Inconsistent by consensus on (.*)");
 CALL mtr.add_suppression("Plugin 'InnoDB' will be forced to shutdown");
+CALL mtr.add_suppression("WSREP: Failed to apply write set: ");

--- a/mysql-test/suite/galera_3nodes/r/galera-features#119.result
+++ b/mysql-test/suite/galera_3nodes/r/galera-features#119.result
@@ -28,6 +28,5 @@ connection node_2;
 CALL mtr.add_suppression("Inconsistent by consensus.");
 CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table test.t1; Duplicate entry '1' for key 'PRIMARY', Error_code: 1062; handler error HA_ERR_FOUND_DUPP_KEY; the event's master log FIRST");
 CALL mtr.add_suppression("WSREP: Event 3 Write_rows_v1 apply failed: 121, seqno");
-CALL mtr.add_suppression("WSREP: Failed to apply trx: source: ");
-CALL mtr.add_suppression("WSREP: Failed to apply app buffer: seqno:");
 CALL mtr.add_suppression("WSREP: Node consistency compromized, leaving cluster...");
+CALL mtr.add_suppression("WSREP: Failed to apply write set: ");

--- a/mysql-test/suite/galera_3nodes/r/inconsistency_shutdown.result
+++ b/mysql-test/suite/galera_3nodes/r/inconsistency_shutdown.result
@@ -138,3 +138,5 @@ DROP TABLE t1;
 CALL mtr.add_suppression('mysqld: Can\'t find record in \'t1\'');
 CALL mtr.add_suppression('Update_rows_v1 apply failed');
 CALL mtr.add_suppression('Inconsistency detected: Inconsistent by consensus on');
+CALL mtr.add_suppression('last left .* greater than drain seqno');
+CALL mtr.add_suppression('WSREP: Failed to apply write set:');

--- a/mysql-test/suite/galera_3nodes/t/GCF-376.test
+++ b/mysql-test/suite/galera_3nodes/t/GCF-376.test
@@ -92,3 +92,4 @@ CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table
 CALL mtr.add_suppression("WSREP: Event (.*) Write_rows_v1 apply failed: 121, seqno ");
 CALL mtr.add_suppression("WSREP: Inconsistency detected: Inconsistent by consensus on (.*)");
 CALL mtr.add_suppression("Plugin 'InnoDB' will be forced to shutdown");
+CALL mtr.add_suppression("WSREP: Failed to apply write set: ");

--- a/mysql-test/suite/galera_3nodes/t/galera-features#119.test
+++ b/mysql-test/suite/galera_3nodes/t/galera-features#119.test
@@ -63,9 +63,9 @@ DROP TABLE test.t1;
 CALL mtr.add_suppression("Inconsistent by consensus.");
 CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table test.t1; Duplicate entry '1' for key 'PRIMARY', Error_code: 1062; handler error HA_ERR_FOUND_DUPP_KEY; the event's master log FIRST");
 CALL mtr.add_suppression("WSREP: Event 3 Write_rows_v1 apply failed: 121, seqno");
-CALL mtr.add_suppression("WSREP: Failed to apply trx: source: ");
-CALL mtr.add_suppression("WSREP: Failed to apply app buffer: seqno:");
 CALL mtr.add_suppression("WSREP: Node consistency compromized, leaving cluster...");
+CALL mtr.add_suppression("WSREP: Failed to apply write set: ");
+
 
 # Restore original auto_increment_offset values.
 --source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_3nodes/t/inconsistency_shutdown.test
+++ b/mysql-test/suite/galera_3nodes/t/inconsistency_shutdown.test
@@ -174,6 +174,7 @@ CALL mtr.add_suppression('mysqld: Can\'t find record in \'t1\'');
 CALL mtr.add_suppression('Update_rows_v1 apply failed');
 CALL mtr.add_suppression('Inconsistency detected: Inconsistent by consensus on');
 CALL mtr.add_suppression('last left .* greater than drain seqno');
+CALL mtr.add_suppression('WSREP: Failed to apply write set:');
 
 # Restore original auto_increment_offset values.
 --source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_3nodes_sr/r/galera_vote_sr.result
+++ b/mysql-test/suite/galera_3nodes_sr/r/galera_vote_sr.result
@@ -193,3 +193,4 @@ CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table
 CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table test.t1; Duplicate entry '5' for key 'PRIMARY'");
 CALL mtr.add_suppression("Write_rows_v1 apply failed");
 CALL mtr.add_suppression("Inconsistent by consensus");
+CALL mtr.add_suppression("WSREP: Failed to apply write set: ");

--- a/mysql-test/suite/galera_3nodes_sr/suite.pm
+++ b/mysql-test/suite/galera_3nodes_sr/suite.pm
@@ -1,0 +1,49 @@
+package My::Suite::GALERA_3NODES_SR;
+use File::Basename;
+use My::Find;
+
+@ISA = qw(My::Suite);
+
+return "Not run for embedded server" if $::opt_embedded_server;
+
+return "WSREP is not compiled in" if not ::have_wsrep();
+
+return "No wsrep provider library" unless ::have_wsrep_provider();
+
+return ::wsrep_version_message() unless ::check_wsrep_version();
+
+push @::global_suppressions,
+  (
+     qr(WSREP: wsrep_sst_receive_address is set to '127.0.0.1),
+     qr(WSREP: Could not open saved state file for reading: .*),
+     qr(WSREP: Could not open state file for reading: .*),
+     qr(WSREP: Gap in state sequence. Need state transfer.),
+     qr(WSREP: Failed to prepare for incremental state transfer:),
+     qr(WSREP:.*down context.*),
+     qr(WSREP: Failed to send state UUID:),
+     qr(WSREP: last inactive check more than .* skipping check),
+     qr(WSREP: SQL statement was ineffective),
+     qr(WSREP: Releasing seqno [0-9]* before [0-9]* was assigned.),
+     qr|WSREP: access file\(.*gvwstate.dat\) failed\(No such file or directory\)|,
+     qr(WSREP: Quorum: No node with complete state),
+     qr(WSREP: Initial position was provided by configuration or SST, avoiding override),
+     qr|WSREP: discarding established \(time wait\) .*|,
+     qr(WSREP: There are no nodes in the same segment that will ever be able to become donors, yet there is a suitable donor outside. Will use that one.),
+     qr(WSREP: evs::proto.*),
+     qr|WSREP: Ignoring possible split-brain \(allowed by configuration\) from view:.*|,
+     qr(WSREP: no nodes coming from prim view, prim not possible),
+     qr(WSREP: Member .* requested state transfer from .* but it is impossible to select State Transfer donor: Resource temporarily unavailable),
+     qr(WSREP: user message in state LEAVING),
+     qr(WSREP: .* sending install message failed: Transport endpoint is not connected),
+     qr(WSREP: .* sending install message failed: Resource temporarily unavailable),
+     qr(WSREP: Sending JOIN failed: -107 \(Transport endpoint is not connected\). Will retry in new primary component.),
+     qr(WSREP: Could not find peer:),
+     qr|WSREP: gcs_caused\(\) returned .*|,
+     qr|WSREP: Protocol violation. JOIN message sender .* is not in state transfer \(SYNCED\). Message ignored.|,
+     qr|WSREP: Protocol violation. JOIN message sender .* is not in state transfer \(JOINED\). Message ignored.|,
+     qr(WSREP: Action message in non-primary configuration from member [0-9]*),
+     qr(WSREP: --wsrep-causal-reads=ON takes precedence over --wsrep-sync-wait=0. WSREP_SYNC_WAIT_BEFORE_READ is on),
+     qr(WSREP: JOIN message from member .* in non-primary configuration. Ignored.),
+   );
+
+bless { };

--- a/mysql-test/suite/galera_3nodes_sr/t/galera_vote_sr.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/galera_vote_sr.test
@@ -31,6 +31,7 @@ CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table
 CALL mtr.add_suppression("Slave SQL: Could not execute Write_rows event on table test.t1; Duplicate entry '5' for key 'PRIMARY'");
 CALL mtr.add_suppression("Write_rows_v1 apply failed");
 CALL mtr.add_suppression("Inconsistent by consensus");
+CALL mtr.add_suppression("WSREP: Failed to apply write set: ");
 #CALL mtr.add_suppression("no THD for trx");
 
 # Restore original auto_increment_offset values.


### PR DESCRIPTION
Message "WSREP: Failed to apply write set" has been turned into an
error, but tests were not adjusted accordingly.