### PR TITLE
Fix the line break warning (groff/lintian).

### DIFF
--- a/man/mysql-test-run.pl.1
+++ b/man/mysql-test-run.pl.1
@@ -1937,8 +1937,10 @@ Run stress test, providing options to mysql\-stress\-test\&.pl\&. Options are se
 .\" suite option: mysql-test-run.pl
 \fB\-\-suite[s]=\fR\fB\fIsuite_name...\fR\fR
 .sp
-Comma separated list of suite names to run. The default is: "main-,archive-,binlog-,csv-,federated-,funcs_1-,funcs_2-,handler-,heap-,innodb-,innodb_fts-,
-innodb_zip-,maria-,multi_source-,optimizer_unfixed_bugs-,parts-,perfschema-,
+Comma separated list of suite names to run. The default is:
+"main-,archive-,binlog-,csv-,federated-,funcs_1-,funcs_2-,
+handler-,heap-,innodb-,innodb_fts-,innodb_zip-,maria-,
+multi_source-,optimizer_unfixed_bugs-,parts-,perfschema-,
 plugins-,roles-,rpl-,sys_vars-,unit-,vcol-"\&.
 .RE
 .sp


### PR DESCRIPTION
The lintian Debian tool is complaining about:
> W: mariadb-test: manpage-has-errors-from-man usr/share/man/man1/mysql-test-run.pl.1.gz 246: warning [p 2, 6.0i, div  '3tbd1,1', 0.3i]: can't break line

See: https://salsa.debian.org/faust-guest/mariadb-10.3/-/jobs/431900

The following command permits to catch the problematic lines:
```bash
$ groff -man -Tascii ./mysql-test-run.pl.1 | less
```