### PR TITLE
MDEV-21476: auth_socket: add support for illumos with getpeerucred()

### DIFF
--- a/plugin/auth_socket/CMakeLists.txt
+++ b/plugin/auth_socket/CMakeLists.txt
@@ -57,9 +57,36 @@ IF (HAVE_XUCRED)
   SET(ok 1)
 ELSE()
 
+# illumos, is that you?
+CHECK_CXX_SOURCE_COMPILES(
+"#include <ucred.h>
+int main() {
+  ucred_t *cred = NULL;
+  getpeerucred(0, &cred);
+  }" HAVE_GETPEERUCRED)
+
+# Depending on the flags set in the compilation environment, illumos will have
+# either the POSIX.1c draft 6 or POSIX.1c final implementation of getpwuid_r()
+# Check that defining _POSIX_PTHREAD_SEMANTICS provides the final standard
+# version.
+
+CHECK_CXX_SOURCE_COMPILES(
+"#define _POSIX_PTHREAD_SEMANTICS
+#include <pwd.h>
+int main() {
+  getpwuid_r(0, NULL, NULL, 0, NULL);
+  }" HAVE_GETPWUID_POSIX_FINAL)
+
+IF (HAVE_GETPEERUCRED AND HAVE_GETPWUID_POSIX_FINAL)
+  ADD_DEFINITIONS(-DHAVE_GETPEERUCRED)
+  ADD_DEFINITIONS(-D_POSIX_PTHREAD_SEMANTICS)
+  SET(ok 1)
+ELSE()
+
 # Who else? Anyone?
 # C'mon, show your creativity, be different! ifdef's are fun, aren't they?
 
+ENDIF()
 ENDIF()
 ENDIF()
 ENDIF()

--- a/plugin/auth_socket/auth_socket.c
+++ b/plugin/auth_socket/auth_socket.c
@@ -47,6 +47,9 @@
 #define uid cr_uid
 #define ucred xucred
 
+#elif defined HAVE_GETPEERUCRED
+#include <ucred.h>
+
 #else
 #error impossible
 #endif
@@ -64,10 +67,15 @@ static int socket_auth(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info)
 {
   unsigned char *pkt;
   MYSQL_PLUGIN_VIO_INFO vio_info;
+#ifdef HAVE_GETPEERUCRED
+  ucred_t *cred = NULL;
+#else
   struct ucred cred;
   socklen_t cred_len= sizeof(cred);
+#endif
   struct passwd pwd_buf, *pwd;
   char buf[1024];
+  uid_t u;
 
   /* no user name yet ? read the client handshake packet with the user name */
   if (info->user_name == 0)
@@ -83,14 +91,23 @@ static int socket_auth(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info)
     return CR_ERROR;
 
   /* get the UID of the client process */
+#ifdef HAVE_GETPEERUCRED
+  if (getpeerucred(vio_info.socket, &cred) != 0)
+    return CR_ERROR;
+  u = ucred_geteuid(cred);
+  ucred_free(cred);
+#else
   if (getsockopt(vio_info.socket, level, SO_PEERCRED, &cred, &cred_len))
     return CR_ERROR;
 
   if (cred_len != sizeof(cred))
     return CR_ERROR;
 
+  u = cred.uid;
+#endif
+
   /* and find the username for this uid */
-  getpwuid_r(cred.uid, &pwd_buf, buf, sizeof(buf), &pwd);
+  getpwuid_r(u, &pwd_buf, buf, sizeof(buf), &pwd);
   if (pwd == NULL)
     return CR_ERROR;
 


### PR DESCRIPTION
I have been packaging MariaDB 10.4 for the OmniOS operating system, which is a distribution of illumos (née OpenSolaris), and wanted to enable support for the `auth_socket` plugin.

illumos has `getpeerucred()` and so here's a patch to make auth_socket work on illumos platforms.
(It may also allow it to work on Solaris, which also has getpeerucred(), but I have not tested)

```
root@database:~# uname -a
SunOS sparse 5.11 omnios-r151032-702376803e i86pc i386 i86pc

root@database:~# mysql
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 8
Server version: 10.4.11-MariaDB OmniOS MariaDB Server

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> select current_user() from dual;
+----------------+
| current_user() |
+----------------+
| root@localhost |
+----------------+
1 row in set (0.000 sec)

MariaDB [(none)]> select user, password from mysql.user where user != '';
+-------+----------+
| User  | Password |
+-------+----------+
| root  | invalid  |
| mysql | invalid  |
+-------+----------+
2 rows in set (0.001 sec)

MariaDB [(none)]> show plugins soname where name = 'unix_socket';
+-------------+--------+----------------+---------+---------+
| Name        | Status | Type           | Library | License |
+-------------+--------+----------------+---------+---------+
| unix_socket | ACTIVE | AUTHENTICATION | NULL    | GPL     |
+-------------+--------+----------------+---------+---------+
1 row in set (0.014 sec)
```