### PR TITLE
MDEV-21598 Galera test galera.galera_sst_mysqldump does not take wsrep-new-cluster into account

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5609,9 +5609,9 @@ int mysqld_main(int argc, char **argv)
       wsrep_init_globals();
       if (!wsrep_before_SE())
       {
-        wsrep_init_startup (false);
+        wsrep_init_startup(false);
       }
-
+      wsrep_new_cluster= false;
       WSREP_DEBUG("Startup creating %ld applier threads running %lu",
 	      wsrep_slave_threads - 1, wsrep_running_applier_threads);
       wsrep_create_appliers(wsrep_slave_threads - 1);

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -752,7 +752,6 @@ void wsrep_init_globals()
     wsrep_get_binlog_gtid_seqno(gtid);
     wsrep_gtid_server.seqno(gtid.seqno);
   }
-  wsrep_new_cluster= 0;
   wsrep_init_schema();
   if (WSREP_ON)
   {


### PR DESCRIPTION
Variable `wsrep_new_cluster` should be set to false after `wsrep_init_startup`.
Problem was that this was done before when mysqldump is used as SST method so option
wsrep-new-cluster didn't have any effect.