### PR TITLE
Incorrect behaviour of WSREP_SYNC_WAIT_UPTO_GTID

### DIFF
--- a/mysql-test/suite/galera/r/galera_sync_wait_upto.result
+++ b/mysql-test/suite/galera/r/galera_sync_wait_upto.result
@@ -16,11 +16,10 @@ WSREP_SYNC_WAIT_UPTO
 1
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection node_2;
-SELECT WSREP_SYNC_WAIT_UPTO_GTID('100-1-3');
 connection node_1;
 INSERT INTO t1 VALUES (2);
 connection node_2;
-WSREP_SYNC_WAIT_UPTO_GTID('100-1-3')
+WSREP_SYNC_WAIT_UPTO
 1
 connection node_1;
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_sync_wait_upto.test
+++ b/mysql-test/suite/galera/t/galera_sync_wait_upto.test
@@ -24,7 +24,9 @@ SELECT WSREP_SYNC_WAIT_UPTO_GTID('1-1-1,1-1-2');
 
 # Expected starting seqno
 
---let $start_seqno = 2
+--let $last_seen_gtid = `SELECT WSREP_LAST_SEEN_GTID()`
+--let $s1 = `SELECT SUBSTR('$last_seen_gtid', LOCATE('-', '$last_seen_gtid') + LENGTH('-'))`
+--let $start_seqno = `SELECT SUBSTR('$s1', LOCATE('-', '$s1') + LENGTH('-'))`
 
 # If set to low value, expect no waiting
 
@@ -57,9 +59,8 @@ SELECT WSREP_SYNC_WAIT_UPTO_GTID('1-1-1,1-1-2');
 --disable_query_log
 --let $wait_seqno = $start_seqno
 --inc $wait_seqno
+--send_eval SELECT WSREP_SYNC_WAIT_UPTO_GTID('100-1-$wait_seqno') AS WSREP_SYNC_WAIT_UPTO
 --enable_query_log
-
---send_eval SELECT WSREP_SYNC_WAIT_UPTO_GTID('100-1-$wait_seqno')
 
 --connection node_1
 INSERT INTO t1 VALUES (2);


### PR DESCRIPTION
Function `signal_waiters` assigned `m_committed_seqno` variable outside of
mutex lock which caused incorrect behavior of WSREP_SYNC_WAIT_UPTO_GTID.
Fixed by moving assignment inside lock. Added handling of OOM and now
error is reported.
Remove hard-coded seqno value and read seqno directly from current node state.