### PR TITLE
Deb: Run 'wrap-and-sort -a' so comparison across releases is easier

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -77,7 +77,6 @@ fi
 if ! apt-cache madison libzstd-dev | grep 'libzstd-dev' >/dev/null 2>&1
 then
   sed '/libzstd-dev/d' -i debian/control
-  sed '/libzstd1/d' -i debian/control
 fi
 
 # The binaries should be fully hardened by default. However TokuDB compilation seems to fail on

--- a/debian/control
+++ b/debian/control
@@ -538,7 +538,6 @@ Description: Connect storage engine for MariaDB
 Package: mariadb-plugin-rocksdb
 Architecture: amd64 arm64 mips64el ppc64el
 Depends: mariadb-server-10.3 (= ${binary:Version}),
-         libzstd1,
          ${misc:Depends},
          ${shlibs:Depends}
 Breaks: mariadb-rocksdb-engine-10.2,

--- a/debian/control
+++ b/debian/control
@@ -234,7 +234,8 @@ Description: MariaDB database common files (e.g. /etc/mysql/conf.d/mariadb.cnf)
 
 Package: mariadb-client-core-10.3
 Architecture: any
-Depends: mariadb-common (>= ${source:Version}), libmariadb3,
+Depends: libmariadb3,
+         mariadb-common (>= ${source:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Conflicts: mariadb-client-10.0,
@@ -569,8 +570,8 @@ Description: OQGraph storage engine for MariaDB
 
 Package: mariadb-plugin-tokudb
 Architecture: amd64
-Depends: mariadb-server-10.3 (= ${binary:Version}),
-         libjemalloc1 (>= 3.0.0~) | libjemalloc2,
+Depends: libjemalloc1 (>= 3.0.0~) | libjemalloc2,
+         mariadb-server-10.3 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Breaks: mariadb-server-10.0,

--- a/debian/libmariadb3.install
+++ b/debian/libmariadb3.install
@@ -3,4 +3,3 @@ usr/lib/mysql/plugin/client_ed25519.so
 usr/lib/mysql/plugin/dialog.so
 usr/lib/mysql/plugin/mysql_clear_password.so
 usr/lib/mysql/plugin/sha256_password.so
-usr/lib/mysql/plugin/client_ed25519.so

--- a/debian/libmariadbd-dev.install
+++ b/debian/libmariadbd-dev.install
@@ -1,4 +1,4 @@
-usr/lib/*/libmysqld.a
 usr/lib/*/libmariadbd.a
-usr/lib/*/libmysqld.so
 usr/lib/*/libmariadbd.so
+usr/lib/*/libmysqld.a
+usr/lib/*/libmysqld.so

--- a/debian/mariadb-plugin-rocksdb.install
+++ b/debian/mariadb-plugin-rocksdb.install
@@ -1,5 +1,5 @@
 etc/mysql/conf.d/rocksdb.cnf etc/mysql/mariadb.conf.d
-usr/bin/mysql_ldb
 usr/bin/myrocks_hotbackup
+usr/bin/mysql_ldb
 usr/bin/sst_dump
 usr/lib/mysql/plugin/ha_rocksdb.so

--- a/debian/mariadb-server-10.3.install
+++ b/debian/mariadb-server-10.3.install
@@ -4,8 +4,8 @@ debian/additions/echo_stderr usr/share/mysql
 debian/additions/mysqld_safe_syslog.cnf etc/mysql/conf.d
 etc/apparmor.d/usr.sbin.mysqld
 etc/security/user_map.conf
-lib/systemd/system/mariadb@bootstrap.service.d/use_galera_new_cluster.conf
 lib/*/security/pam_user_map.so
+lib/systemd/system/mariadb@bootstrap.service.d/use_galera_new_cluster.conf
 usr/bin/aria_chk
 usr/bin/aria_dump_log
 usr/bin/aria_ftdump
@@ -88,9 +88,9 @@ usr/share/man/man1/replace.1
 usr/share/man/man1/resolve_stack_dump.1
 usr/share/man/man1/resolveip.1
 usr/share/man/man1/wsrep_sst_common.1
+usr/share/man/man1/wsrep_sst_mariabackup.1
 usr/share/man/man1/wsrep_sst_mysqldump.1
 usr/share/man/man1/wsrep_sst_rsync.1
-usr/share/man/man1/wsrep_sst_mariabackup.1
 usr/share/mysql/errmsg-utf8.txt
 usr/share/mysql/fill_help_tables.sql
 usr/share/mysql/maria_add_gis_sp_bootstrap.sql

--- a/debian/mariadb-test-data.install
+++ b/debian/mariadb-test-data.install
@@ -1,7 +1,7 @@
 usr/share/mysql/mysql-test/collections
 usr/share/mysql/mysql-test/include
-usr/share/mysql/mysql-test/plugin
 usr/share/mysql/mysql-test/main
+usr/share/mysql/mysql-test/plugin
 usr/share/mysql/mysql-test/std_data
 usr/share/mysql/mysql-test/suite
 usr/share/mysql/mysql-test/unstable-tests


### PR DESCRIPTION
No functional changes.

Apply this in 10.3 so eventually it is merged to 10.4 and 10.5, which
in turn will have separate wrap-and-sort runs but only for new lines,
and thus not affecting badly next merges from 10.3 to 10.4 to 10.5.