### PR TITLE
mariadb{,@}.service comment typo open-file-limit -> open-files-limit

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -133,7 +133,7 @@ TimeoutStopSec=900
 ## isn't executed.
 ##
 
-# Number of files limit. previously [mysqld_safe] open-file-limit
+# Number of files limit. previously [mysqld_safe] open-files-limit
 LimitNOFILE=16364
 
 # Maximium core size. previously [mysqld_safe] core-file-size

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -154,7 +154,7 @@ TimeoutStopSec=900
 ## isn't executed.
 ##
 
-# Number of files limit. previously [mysqld_safe] open-file-limit
+# Number of files limit. previously [mysqld_safe] open-files-limit
 LimitNOFILE=16364
 
 # Maximium core size. previously [mysqld_safe] core-file-size


### PR DESCRIPTION
I submit this under the MCA.