### PR TITLE
MDEV-18768: Rename auth_socket to unix_socket on upgrades from MySQL

### DIFF
--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -171,6 +171,14 @@ ALTER TABLE user
 ALTER TABLE user
   ADD Password char(41) character set latin1 collate latin1_bin NOT NULL default '' AFTER User;
 
+# In MySQL the Unix socket authentication plugin has a different name. Thus the
+# references to it need to be renamed in the user table. Thanks to the WHERE
+# clauses this applies only to MySQL->MariaDB upgrades and nothing else.
+UPDATE user
+  SET plugin='unix_socket' WHERE plugin='auth_socket';
+DELETE FROM plugin
+  WHERE name='auth_socket';
+
 ALTER TABLE user
   MODIFY Password char(41) character set latin1 collate latin1_bin NOT NULL default '',
   MODIFY Select_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL,


### PR DESCRIPTION
This fixes bugs where upgrading MariaDB failed to start after an upgrade
from MySQL 5.7 in Ubuntu, where auth_socket has been the default for MySQL
as well for some time now.

This was adopted from Debian where this change has been since Apr 18, 2019:
https://salsa.debian.org/mariadb-team/mariadb-10.4/-/commit/3919860b6a4ef98c098fef35fb34601adbb132b2