### PR TITLE
MDEV-21213: mysql_upgrade / mariadb-upgrade error

### DIFF
--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -27,6 +27,7 @@
 set sql_mode='';
 set storage_engine=MyISAM;
 set enforce_storage_engine=NULL;
+set alter_algorithm=COPY;
 
 ALTER TABLE user add File_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL;
 


### PR DESCRIPTION
When alter_algorithm is set to a differernt value than DEFAULT
or COPY, mysql_upgrade will fail when trying to modify tables
in the mysql system schema.

Explicit "SET alter_algorithm=COPY" is needed at the beginnig
as "SET alter_algorithm=DEFAULT" will set the session variable
back to the global variables value instead (see also MDEV-21855)