### PR TITLE
innodb: fix typo in function description

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -2418,12 +2418,12 @@ AIO::is_linux_native_aio_supported()
 /** Retrieves the last error number if an error occurs in a file io function.
 The number should be retrieved before any other OS calls (because they may
 overwrite the error number). If the number is not known to this program,
-the OS error number + 100 is returned.
+the OS error number + OS_FILE_ERROR_MAX is returned.
 @param[in]	report_all_errors	true if we want an error message
 					printed of all errors
 @param[in]	on_error_silent		true then don't print any diagnostic
 					to the log
-@return error number, or OS error number + 100 */
+@return error number, or OS error number + OS_FILE_ERROR_MAX */
 static
 ulint
 os_file_get_last_error_low(


### PR DESCRIPTION
Function `os_file_get_last_error_low` returns error number +
`OS_FILE_ERROR_MAX` (which is currently set to 200) for unknown numbers to
this program.