### PR TITLE
Deb: Add support for legacy init systems

### DIFF
--- a/debian/additions/debian-start
+++ b/debian/additions/debian-start
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script is executed by "/etc/init.d/mysql" on every (re)start.
+# This script is executed by "/etc/init.d/mariadb" on every (re)start.
 #
 # Changes to this file will be preserved when updating the Debian package.
 #
@@ -9,8 +9,13 @@
 
 source /usr/share/mysql/debian-start.inc.sh
 
+# Read default/mysql first and then default/mariadb just like the init.d file does
 if [ -f /etc/default/mysql ]; then
   . /etc/default/mysql
+fi
+
+if [ -f /etc/default/mariadb ]; then
+  . /etc/default/mariadb
 fi
 
 MYSQL="/usr/bin/mysql --defaults-file=/etc/mysql/debian.cnf"

--- a/debian/mariadb-server-10.5.install
+++ b/debian/mariadb-server-10.5.install
@@ -1,7 +1,6 @@
 debian/additions/debian-start etc/mysql
 debian/additions/debian-start.inc.sh usr/share/mysql
 debian/additions/echo_stderr usr/share/mysql
-debian/additions/mysql.init usr/share/mysql
 debian/additions/mysqld_safe_syslog.cnf etc/mysql/conf.d
 debian/additions/source_mariadb-10.5.py usr/share/apport/package-hooks
 etc/apparmor.d/usr.sbin.mysqld

--- a/debian/mariadb-server-10.5.logcheck.ignore.paranoid
+++ b/debian/mariadb-server-10.5.logcheck.ignore.paranoid
@@ -1,8 +1,8 @@
-/etc/init.d/mysql\[[0-9]+\]: Check that mysqld is running and that the socket: '/var/run/mysqld/mysqld.sock' exists\!$
-/etc/init.d/mysql\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
+/etc/init.d/mariadb\[[0-9]+\]: Check that mysqld is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
+/etc/init.d/mariadb\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
 /etc/mysql/debian-start\[[0-9]+\]: Checking for crashed MySQL tables\.$
 mysqld\[[0-9]+\]: $
-mysqld\[[0-9]+\]: Version: .* socket: '/var/run/mysqld/mysqld.sock'  port: 3306$
+mysqld\[[0-9]+\]: Version: .* socket: '/run/mysqld/mysqld.sock'  port: 3306$
 mysqld\[[0-9]+\]: Warning: Ignoring user change to 'mysql' because the user was set to 'mysql' earlier on the command line$
 mysqld_safe\[[0-9]+\]: started$
 usermod\[[0-9]+\]: change user `mysql' GID from `([0-9]+)' to `\1'$

--- a/debian/mariadb-server-10.5.logcheck.ignore.server
+++ b/debian/mariadb-server-10.5.logcheck.ignore.server
@@ -1,6 +1,6 @@
-/etc/init.d/mysql\[[0-9]+\]: [0-9]+ processes alive and '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
-/etc/init.d/mysql\[[0-9]+\]: Check that mysqld is running and that the socket: '/var/run/mysqld/mysqld.sock' exists\!$
-/etc/init.d/mysql\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
+/etc/init.d/mariadb\[[0-9]+\]: [0-9]+ processes alive and '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
+/etc/init.d/mariadb\[[0-9]+\]: Check that mysqld is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
+/etc/init.d/mariadb\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
 /etc/mysql/debian-start\[[0-9]+\]: Checking for crashed MySQL tables\.$
 mysqld\[[0-9]+\]: ?$
 mysqld\[[0-9]+\]: .*InnoDB: Shutdown completed

--- a/debian/mariadb-server-10.5.logcheck.ignore.workstation
+++ b/debian/mariadb-server-10.5.logcheck.ignore.workstation
@@ -1,6 +1,6 @@
-/etc/init.d/mysql\[[0-9]+\]: [0-9]+ processes alive and '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
-/etc/init.d/mysql\[[0-9]+\]: Check that mysqld is running and that the socket: '/var/run/mysqld/mysqld.sock' exists\!$
-/etc/init.d/mysql\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
+/etc/init.d/mariadb\[[0-9]+\]: [0-9]+ processes alive and '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
+/etc/init.d/mariadb\[[0-9]+\]: Check that mysqld is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
+/etc/init.d/mariadb\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
 /etc/mysql/debian-start\[[0-9]+\]: Checking for crashed MySQL tables\.$
 mysqld\[[0-9]+\]: ?$
 mysqld\[[0-9]+\]: .*InnoDB: Shutdown completed

--- a/debian/mariadb-server-10.5.mariadb.init
+++ b/debian/mariadb-server-10.5.mariadb.init
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 ### BEGIN INIT INFO
-# Provides:          mysql
+# Provides:          mariadb
 # Required-Start:    $remote_fs $syslog
 # Required-Stop:     $remote_fs $syslog
 # Should-Start:      $network $named $time
@@ -26,10 +26,17 @@ SELF=$(cd $(dirname $0); pwd -P)/$(basename $0)
 MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 
 # priority can be overridden and "-s" adds output to stderr
-ERR_LOGGER="logger -p daemon.err -t /etc/init.d/mysql -i"
+ERR_LOGGER="logger -p daemon.err -t /etc/init.d/mariadb -i"
 
 if [ -f /etc/default/mysql ]; then
   . /etc/default/mysql
+fi
+
+# Also source default/mariadb in case the installation was upgraded from
+# packages originally installed from MariaDB.org repositories, which have
+# had support for reading /etc/default/mariadb since March 2016.
+if [ -f /etc/default/mariadb ]; then
+  . /etc/default/mariadb
 fi
 
 # Safeguard (relative paths, core dumps..)
@@ -108,7 +115,7 @@ case "${1:-''}" in
    log_end_msg 0
   else
     # Could be removed during boot
-    test -e /var/run/mysqld || install -m 755 -o mysql -g root -d /var/run/mysqld
+    test -e /run/mysqld || install -m 755 -o mysql -g root -d /run/mysqld
 
     # Start MariaDB!
     /usr/bin/mysqld_safe "${@:2}" 2>&1 >/dev/null | $ERR_LOGGER &
@@ -185,6 +192,13 @@ case "${1:-''}" in
     exit 3
   fi
   ;;
+
+  'bootstrap')
+	# Bootstrap the cluster, start the first node
+	# that initiates the cluster
+	log_daemon_msg "Bootstrapping the cluster" "mysqld"
+	$SELF start "${@:2}" --wsrep-new-cluster
+	;;
 
   *)
   echo "Usage: $SELF start|stop|restart|reload|force-reload|status"

--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -18,17 +18,42 @@ ERR_LOGGER="logger -p daemon.err -t mariadb-server-$MAJOR_VER.postinst -i"
 # the install, rather than failing silently and leaving a broken install.
 set -o pipefail
 
-invoke() {
-  systemctl $1 mysql
-}
-
 case "$1" in
   configure)
-    # This is needed because mysql_install_db removes the pid file in /var/run
+    # This is needed because mysql_install_db removes the pid file in /run
     # and because changed configuration options should take effect immediately.
     # In case the server wasn't running at all it should be ok if the stop
-    # script fails. I can't tell at this point because of the cleaned /var/run.
-    set +e; invoke stop; set -e
+    # script fails. I can't tell at this point because of the cleaned /run.
+    set +e; invoke-rc.d mariadb stop; set -e
+
+    # An existing /etc/init.d/mysql might be on the system if there was a
+    # previous MySQL or MariaDB installation, since /etc/init.d files are
+    # considered config files and stay around even after the package is removed.
+    #
+    # The install step of this package adds a new /etc/init.d/mariadb file. As
+    # we also want to ensure that there are no old (and potentially outdated)
+    # versions of /etc/init.d/mysql we simply replace it using a copy of the
+    # latest 'mariadb' file. This has also the added benefit that anything that
+    # invokes traditional sysv init with either 'mysql' or 'mariadb' will end up
+    # controlling this newly installed MariaDB, and thus we maintain better
+    # backwards compatiblity.
+    #
+    # Note that the 'Provides' line is also updated to avoid 'insserv' exiting
+    # on failure (when it is run by update-rc.d) because of duplicate service
+    # names.
+    if [ -f "/etc/init.d/mysql" ] && [ -f "/etc/init.d/mariadb" ]
+    then
+      # Copy init file and rename the service name and filename on the fly
+      sed 's/Provides:          mariadb/Provides:          mysql/g' /etc/init.d/mariadb > /etc/init.d/mysql
+      # NOTE: Number of spaces/tabs is important here!
+      # Confirm if the sed worked
+      if ! grep --quiet "Provides:          mysql" /etc/init.d/mysql
+      then
+        # If not, then delete the file to avoid failures later on
+        rm -f /etc/init.d/mysql
+        echo "Warning! Failed creating a mysql named copy of mariadb init.d file"
+      fi
+    fi
 
     mysql_statedir=/usr/share/mysql
     mysql_datadir=/var/lib/mysql
@@ -126,7 +151,7 @@ EOF
 
     # initiate databases. Output is not allowed by debconf :-(
     # This will fail if we are upgrading an existing database; in this case
-    # mysql_upgrade, called from the /etc/init.d/mysql start script, will
+    # mysql_upgrade, called from the /etc/init.d/mariadb start script, will
     # handle things.
     # Debian: beware of the bashisms...
     # Debian: can safely run on upgrades with existing databases
@@ -187,8 +212,9 @@ EOF
   triggered)
     if [ -x "$(command -v systemctl)" ]; then
       systemctl daemon-reload
+    else
+      invoke-rc.d mariadb restart
     fi
-    invoke restart
   ;;
 
   *)
@@ -199,7 +225,7 @@ esac
 
 db_stop # in case invoke failes
 
-# dh_systemd_start doesn't emit anything since we still ship /etc/init.d/mysql.
+# dh_systemd_start doesn't emit anything since we still ship /etc/init.d/mariadb.
 # Thus MariaDB server is started via init.d script, which in turn redirects to
 # systemctl. If we upgrade from MySQL mysql.service may be masked, which also
 # means init.d script is disabled. Unmask mysql service explicitly.

--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -235,3 +235,14 @@ if [ -x "$(command -v deb-systemd-helper)" ]; then
 fi
 
 #DEBHELPER#
+
+# Modified dh_systemd_start snippet that's not added automatically
+if [ -d /run/systemd/system ]; then
+	systemctl --system daemon-reload >/dev/null || true
+	deb-systemd-invoke start mariadb.service >/dev/null || true
+# Modified dh_installinit snippet to only run with sysvinit
+elif [ -x "/etc/init.d/mariadb" ]; then
+	if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+		invoke-rc.d mariadb start || exit $?
+	fi
+fi

--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -198,12 +198,6 @@ EOF
       fi
     fi
 
-    # copy out any mysqld_safe settings
-    systemd_conf=/etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf
-    if [ -x /usr/bin/mariadb-service-convert -a ! -f "${systemd_conf}" ]; then
-      mkdir -p /etc/systemd/system/mariadb.service.d
-      /usr/bin/mariadb-service-convert > "${systemd_conf}"
-    fi
   ;;
 
   abort-upgrade|abort-remove|abort-configure)

--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -198,6 +198,12 @@ EOF
       fi
     fi
 
+    # @TODO: Remove once buildbot.askmonty.org has been updated not to expect this file
+    mkdir -p /etc/systemd/system/mariadb.service.d/
+    # Note that file cannot be empty, otherwise systemd version in Ubuntu Bionic
+    # will think the service is masked
+    echo "# empty placeholder" > /etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf
+
   ;;
 
   abort-upgrade|abort-remove|abort-configure)

--- a/debian/mariadb-server-10.5.postrm
+++ b/debian/mariadb-server-10.5.postrm
@@ -13,19 +13,27 @@ MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 
 # Try to stop the server in a sane way. If it does not success let the admin
 # do it himself. No database directories should be removed while the server
-# is running!
+# is running! Another mysqld in e.g. a different chroot is fine for us.
 stop_server() {
-  set +e
-  systemctl stop mysql
-  errno=$?
-  set -e
+    # Return immediately if there are no mysql processes running
+    # as there is no point in trying to shutdown in that case.
+    if ! pgrep -x mysqld > /dev/null; then return; fi
 
-  if [ "$?" != 0 ]; then
-    echo "Trying to stop the MySQL server resulted in exitcode $?." 1>&2
-    echo "Stop it yourself and try again!" 1>&2
-    exit 1
-  fi
+    set +e
+    invoke-rc.d mariadb stop
+    errno=$?
+    set -e
+
+    # systemctl could emit exit code 100=no init script (fresh install)
+    if [ "$errno" != 0 -a "$errno" != 100 ]; then
+      echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
+      echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
+      echo "Stop it yourself and try again!" 1>&2
+      db_stop
+      exit 1
+    fi
 }
+
 
 case "$1" in
   purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
@@ -74,7 +82,7 @@ if [ "$1" = "purge" ] && [ -f "/var/lib/mysql/debian-$MAJOR_VER.flag" ]; then
       # /var/lib/mysql is a mount point
       rmdir --ignore-fail-on-non-empty /var/lib/mysql || true
     fi
-    rm -rf /var/run/mysqld # this directory is created by the init script, don't leave behind
+    rm -rf /run/mysqld # this directory is created by the init script, don't leave behind
     userdel mysql || true
   fi
 

--- a/debian/mariadb-server-10.5.postrm
+++ b/debian/mariadb-server-10.5.postrm
@@ -89,3 +89,8 @@ if [ "$1" = "purge" ] && [ -f "/var/lib/mysql/debian-$MAJOR_VER.flag" ]; then
 fi
 
 #DEBHELPER#
+
+# Modified dh_systemd_start snippet that's not added automatically
+if [ -d /run/systemd/system ]; then
+	systemctl --system daemon-reload >/dev/null || true
+fi

--- a/debian/mariadb-server-10.5.preinst
+++ b/debian/mariadb-server-10.5.preinst
@@ -33,14 +33,14 @@ stop_server() {
     if ! pgrep -x --ns $$ mysqld > /dev/null; then return; fi
 
     set +e
-    systemctl stop mysql
+    invoke-rc.d mariadb stop
     errno=$?
     set -e
 
-    # 0=ok, 100=no init script (fresh install)
+    # systemctl could emit exit code 100=no init script (fresh install)
     if [ "$errno" != 0 -a "$errno" != 100 ]; then
-      echo "'systemctl stop mysql' returned $errno" 1>&2
-      echo "There is a MySQL server running, but we failed in our attempts to stop it." 1>&2
+      echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
+      echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
       echo "Stop it yourself and try again!" 1>&2
       db_stop
       exit 1

--- a/debian/mariadb-server-10.5.prerm
+++ b/debian/mariadb-server-10.5.prerm
@@ -2,3 +2,11 @@
 set -e
 
 #DEBHELPER#
+
+# Modified dh_systemd_start snippet that's not added automatically
+if [ -d /run/systemd/system ]; then
+	deb-systemd-invoke stop mariadb.service >/dev/null
+# Modified dh_installinit snippet to only run with sysvinit
+elif [ -x "/etc/init.d/mariadb" ]; then
+	invoke-rc.d mariadb stop || exit $?
+fi

--- a/debian/rules
+++ b/debian/rules
@@ -170,7 +170,7 @@ override_dh_systemd_enable:
 # Start mysql at sequence number 19 before 20 where apache, proftpd etc gets
 # started which might depend on a running database server.
 override_dh_installinit-arch:
-	#dh_installinit --name=mysql -- defaults 19 21
+	dh_installinit --name=mariadb --no-start -- defaults 19 21
 	dh_systemd_start --restart-after-upgrade
 
 

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -110,7 +110,7 @@ fresh install:
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mysql status
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5
     - mkdir -p debug # Ensure dir exists before using it
     - find /var/lib/mysql -ls > debug/var-lib-mysql.list || true # Ignore errors about "no such file or directory"
     - cp -ra /etc/mysql debug/etc-mysql
@@ -147,7 +147,7 @@ mariadb-10.3.x to mariadb-10.5.y upgrade:
     - mariadb --skip-column-names -e "select @@version, @@version_comment"
     - echo 'SHOW DATABASES;' | mysql
     # Install MariaDB built in this commit
-    - apt-get install -y ./*.deb || true # Allow to proceed so debug artifacts get collected
+    - apt-get install -o Dpkg::Options::=--force-confnew -y ./*.deb || true # Allow to proceed so debug artifacts get collected
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
@@ -192,7 +192,7 @@ mariadb-10.3.x buster to mariadb-10.5 upgrade:
     - sed '/sid-updates/d' -i /etc/apt/sources.list # Remove repositories that don't exist for Sid
     - sed '/security/d' -i /etc/apt/sources.list # Remove repositories that don't exist for Sid
     - apt-get update; apt-get install -y apt # Uprade minimal stack first
-    - apt-get install -y ./*.deb || true # Allow to proceed so debug artifacts get collected
+    - apt-get install -o Dpkg::Options::=--force-confnew -y ./*.deb || true # Allow to proceed so debug artifacts get collected
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
@@ -237,7 +237,7 @@ mariadb-10.1 to mariadb-10.5 upgrade:
     - sed '/sid-updates/d' -i /etc/apt/sources.list # Remove repositories that don't exist for Sid
     - sed '/security/d' -i /etc/apt/sources.list # Remove repositories that don't exist for Sid
     - apt-get update; apt-get install -y apt # Uprade minimal stack first
-    - apt-get install -y ./*.deb || true # Allow to proceed so debug artifacts get collected
+    - apt-get install -o Dpkg::Options::=--force-confnew -y ./*.deb || true # Allow to proceed so debug artifacts get collected
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
@@ -275,7 +275,7 @@ test basic features:
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mysql status
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5
     - mkdir -p debug # Ensure dir exists before using it
     - find /var/lib/mysql -ls > debug/var-lib-mysql.list || true # Ignore errors about "no such file or directory"
     - cp -ra /etc/mysql debug/etc-mysql
@@ -516,7 +516,7 @@ mysql-5.5 to mariadb-10.5 upgrade:
     - sed '/security/d' -i /etc/apt/sources.list # Remove repositories that don't exist for Sid
     - apt-get update; apt-get install -y apt || true # Install apt 1.4.9 so the wildcard command below works
     - apt-get dist-upgrade -y || true # Upgrade all to avoid udev/systemd failures
-    - apt-get install -y ./*.deb || true # Allow to proceed so debug artifacts get collected
+    - apt-get install -o Dpkg::Options::=--force-confnew -y ./*.deb || true # Allow to proceed so debug artifacts get collected
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
@@ -648,14 +648,16 @@ mariadb.org-10.5.x to mariadb-10.5 upgrade:
     - cd ${WORKING_DIR} # Don't repeat this step, it's just cd ./debian/output
     - apt-get update
     - apt install -y curl systemctl # systemctl shim needed on platforms that don't have systemd
-    - curl https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
+    - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo 'deb [arch=amd64,i386] http://mirror.one.com/mariadb/repo/10.5/debian sid main' > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - apt-get install -y mariadb-server-10.5
     # Verify installation of MySQL from Sid
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
-    - service mysql status || true # Currently does not support service name 'mysql'
-    - service mariadb status
+    # MariaDB.org version of 10.4 and early 10.5 do not install an init file, so
+    # it must be installed here manually
+    - cp /usr/share/mysql/mysql.init /etc/init.d/mysql; chmod +x /etc/init.d/mysql; service mysql start; sleep 5
+    - service mysql status
     - mysql --skip-column-names -e "SELECT @@version, @@version_comment"
     - mysql -e "SELECT Host,User,plugin,authentication_string FROM user;" mysql
     - mysql -e "SELECT * FROM plugin;" mysql
@@ -665,7 +667,7 @@ mariadb.org-10.5.x to mariadb-10.5 upgrade:
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mysql status || true # Currently does not support service name 'mysql'
+    - service mysql status
     - service mariadb status
     - mkdir -p debug # Ensure dir exists before using it
     - find /var/lib/mysql -ls > debug/var-lib-mysql.list || true # Ignore errors about "no such file or directory"
@@ -698,14 +700,16 @@ mariadb.org-10.4 to mariadb-10.5 upgrade:
     - cd ${WORKING_DIR} # Don't repeat this step, it's just cd ./debian/output
     - apt-get update
     - apt install -y curl systemctl # systemctl shim needed on platforms that don't have systemd
-    - curl https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
+    - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo 'deb [arch=amd64,i386] http://mirror.one.com/mariadb/repo/10.4/debian sid main' > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - apt-get install -y mariadb-server-10.4
     # Verify installation of MySQL from Sid
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
-    - service mysql status || true # Currently does not support service name 'mysql'
-    - service mariadb status
+    # MariaDB.org version of 10.4 and early 10.5 do not install an init file, so
+    # it must be installed here manually
+    - cp /usr/share/mysql/mysql.init /etc/init.d/mysql; chmod +x /etc/init.d/mysql; service mysql start; sleep 5
+    - service mysql status
     - mysql --skip-column-names -e "SELECT @@version, @@version_comment"
     - mysql -e "SELECT Host,User,plugin,authentication_string FROM user;" mysql
     - mysql -e "SELECT * FROM plugin;" mysql
@@ -715,7 +719,7 @@ mariadb.org-10.4 to mariadb-10.5 upgrade:
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mysql status || true # Currently does not support service name 'mysql'
+    - service mysql status
     - service mariadb status
     - mkdir -p debug # Ensure dir exists before using it
     - find /var/lib/mysql -ls > debug/var-lib-mysql.list || true # Ignore errors about "no such file or directory"
@@ -748,7 +752,7 @@ mariadb.org-10.3 to mariadb-10.5 upgrade:
     - cd ${WORKING_DIR} # Don't repeat this step, it's just cd ./debian/output
     - apt-get update
     - apt install -y curl
-    - curl https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
+    - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo 'deb [arch=amd64,i386] http://mirror.one.com/mariadb/repo/10.3/debian sid main' > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - apt-get install -y mariadb-server-10.3
@@ -760,14 +764,11 @@ mariadb.org-10.3 to mariadb-10.5 upgrade:
     - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT Host,User,plugin,authentication_string FROM user;" mysql
     - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM plugin;" mysql
     - echo 'SHOW DATABASES;' | mysql --defaults-file=/etc/mysql/debian.cnf
-    # Additional systemctl hack since there is no real systemctl in Docker
-    - ln -s /bin/true /bin/systemctl
     # Install MariaDB built in this commit
     - apt-get install -y ./*.deb || true # Allow to proceed so debug artifacts get collected
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mysql restart # Needed due to systemctl hack and lack of real init support
     - service mysql status
     - mkdir -p debug # Ensure dir exists before using it
     - find /var/lib/mysql -ls > debug/var-lib-mysql.list || true # Ignore errors about "no such file or directory"
@@ -800,7 +801,7 @@ mariadb.org-10.2 to mariadb-10.5 upgrade:
     - cd ${WORKING_DIR} # Don't repeat this step, it's just cd ./debian/output
     - apt-get update
     - apt install -y curl
-    - curl https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
+    - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo 'deb [arch=amd64,i386] http://mirror.one.com/mariadb/repo/10.2/debian sid main' > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - apt-get install -y mariadb-server-10.2
@@ -812,14 +813,11 @@ mariadb.org-10.2 to mariadb-10.5 upgrade:
     - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT Host,User,plugin,authentication_string FROM user;" mysql
     - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM plugin;" mysql
     - echo 'SHOW DATABASES;' | mysql --defaults-file=/etc/mysql/debian.cnf
-    # Additional systemctl hack since there is no real systemctl in Docker
-    - ln -s /bin/true /bin/systemctl
     # Install MariaDB built in this commit
     - apt-get install -y ./*.deb || true # Allow to proceed so debug artifacts get collected
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mysql restart # Needed due to systemctl hack and lack of real init support
     - service mysql status
     - mkdir -p debug # Ensure dir exists before using it
     - find /var/lib/mysql -ls > debug/var-lib-mysql.list || true # Ignore errors about "no such file or directory"

--- a/debian/tests/smoke
+++ b/debian/tests/smoke
@@ -29,10 +29,10 @@ set -ex
 # be started manually.
 if ! which systemctl
 then
-  if ! /etc/init.d/mysql status
+  if ! /etc/init.d/mariadb status
   then
     echo "Did not find systemctl and deamon was not running, starting it.."
-    /etc/init.d/mysql start
+    /etc/init.d/mariadb start
   fi
 else
   # If systemd (and systemctl) is available, but the service did not start, then

--- a/mysql-test/unstable-tests
+++ b/mysql-test/unstable-tests
@@ -217,6 +217,7 @@ main.type_int                           : Modified in 10.4.12
 main.type_newdecimal                    : MDEV-20532 - Floating point differences
 main.type_ranges                        : MDEV-20532 - Floating point differences
 main.type_time                          : Modified in 10.4.12
+main.udf                                : MDEV-21976: Fails on Ubuntu Bionic 18.04, our Travis-CI platform
 main.union_crash-714                    : Modified in 10.4.12
 main.upgrade_MDEV-19650                 : Added in 10.4.13
 main.userstat                           : MDEV-12904 - SSL errors


### PR DESCRIPTION
While all current versions of Linux have systemd, support for traditional
init.d is still needed e.g. on Linux subsystem on Windows, kFreeBSD and
special variants of Debian/Ubuntu that for other reasons don't have
systemd.

Supporting traditional init.d is easy, since Debian has facilities for it.

Partially reverts commit a4cc6fb91f3855e0ed803a6e1762440cfcf8cb5c.

Depends on https://salsa.debian.org/mariadb-team/mariadb-10.4/-/merge_requests/2 and https://github.com/MariaDB/server/pull/1172 being merged first.