### PR TITLE
10.4 without server 20200316

### DIFF
--- a/cmake/plugin.cmake
+++ b/cmake/plugin.cmake
@@ -35,14 +35,22 @@ MACRO(MYSQL_ADD_PLUGIN)
     "LINK_LIBRARIES;DEPENDENCIES"
     ${ARGN}
   )
-  IF(NOT WITHOUT_SERVER OR ARG_CLIENT)
-
-  # Add common include directories
+  
+  # Find bug: Why not find my_global.h when install only client?(-DWITHOUT_SERVER)
   INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include 
                     ${CMAKE_SOURCE_DIR}/sql
                     ${PCRE_INCLUDES}
                     ${SSL_INCLUDE_DIRS}
                     ${ZLIB_INCLUDE_DIR})
+
+  IF(NOT WITHOUT_SERVER OR ARG_CLIENT)
+
+  # Move to above IF's codeblock 
+  #INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include 
+  #                  ${CMAKE_SOURCE_DIR}/sql
+  #                  ${PCRE_INCLUDES}
+  #                  ${SSL_INCLUDE_DIRS}
+  #                  ${ZLIB_INCLUDE_DIR})
 
   LIST(GET ARG_UNPARSED_ARGUMENTS 0 plugin)
   SET(SOURCES ${ARG_UNPARSED_ARGUMENTS})

--- a/mysql-test/suite/plugins/t/server_audit.test
+++ b/mysql-test/suite/plugins/t/server_audit.test
@@ -157,8 +157,6 @@ set global server_audit_logging= off;
 set global server_audit_incl_users='root';
 set global server_audit_logging= on;
 disconnect cn1;
-let $count_sessions=1;
-source include/wait_until_count_sessions.inc;
 
 drop user user1@localhost;
 

--- a/mysql-test/suite/plugins/t/server_audit.test
+++ b/mysql-test/suite/plugins/t/server_audit.test
@@ -157,6 +157,9 @@ set global server_audit_logging= off;
 set global server_audit_incl_users='root';
 set global server_audit_logging= on;
 disconnect cn1;
+let $count_sessions=1;
+source include/wait_until_count_sessions.inc;
+
 drop user user1@localhost;
 
 set global server_audit_events='';

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -270,7 +270,7 @@ IF(WIN32)
     INSTALL_SCRIPT(${CMAKE_CURRENT_BINARY_DIR}/${file}.pl COMPONENT Server_Scripts)
   ENDFOREACH()
 ELSE()
-  IF(WITH_WSREP)
+  IF(WITH_WSREP OR (NOT WITHOUT_SERVER)) #Find bug: Why create symlink wsrep_sst_rsync_wan with -DWITHOUT_SERVER in CentOS 7?
     SET(WSREP_SCRIPTS
       wsrep_sst_mysqldump
       wsrep_sst_rsync
@@ -333,35 +333,37 @@ ELSE()
      )
   ENDFOREACH()
 
-  SET (wsrep_sst_rsync_wan ${CMAKE_CURRENT_BINARY_DIR}/wsrep_sst_rsync_wan)
-  ADD_CUSTOM_COMMAND(
-    OUTPUT ${wsrep_sst_rsync_wan}
-    COMMAND ${CMAKE_COMMAND} ARGS -E create_symlink
-      wsrep_sst_rsync
-      wsrep_sst_rsync_wan
-  )
-  ADD_CUSTOM_TARGET(symlink_wsrep_sst_rsync
-      ALL
-      DEPENDS ${wsrep_sst_rsync_wan}
-  )
-  INSTALL(
-    FILES  ${wsrep_sst_rsync_wan}
-    DESTINATION ${INSTALL_BINDIR}
-    COMPONENT Server
-  )
-
-  FOREACH(file ${WSREP_SOURCE})
-    CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/${file}.sh
-      ${CMAKE_CURRENT_BINARY_DIR}/${file} ESCAPE_QUOTES @ONLY)
-    IF(NOT ${file}_COMPONENT)
-      SET(${file}_COMPONENT Server)
-    ENDIF()
-    INSTALL(FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/${file}
+  IF(NOT WITHOUT_SERVER)#Find bug: Why create symlink wsrep_sst_rsync_wan with -DWITHOUT_SERVER in CentOS 7?
+    SET (wsrep_sst_rsync_wan ${CMAKE_CURRENT_BINARY_DIR}/wsrep_sst_rsync_wan)
+    ADD_CUSTOM_COMMAND(
+      OUTPUT ${wsrep_sst_rsync_wan}
+      COMMAND ${CMAKE_COMMAND} ARGS -E create_symlink
+        wsrep_sst_rsync
+        wsrep_sst_rsync_wan
+    )
+    ADD_CUSTOM_TARGET(symlink_wsrep_sst_rsync
+        ALL
+        DEPENDS ${wsrep_sst_rsync_wan}
+    )
+    INSTALL(
+      FILES  ${wsrep_sst_rsync_wan}
       DESTINATION ${INSTALL_BINDIR}
-      COMPONENT ${${file}_COMPONENT}
-     )
-  ENDFOREACH()
+      COMPONENT Server
+    )
+
+    FOREACH(file ${WSREP_SOURCE})
+      CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/${file}.sh
+        ${CMAKE_CURRENT_BINARY_DIR}/${file} ESCAPE_QUOTES @ONLY)
+      IF(NOT ${file}_COMPONENT)
+        SET(${file}_COMPONENT Server)
+      ENDIF()
+      INSTALL(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${file}
+        DESTINATION ${INSTALL_BINDIR}
+        COMPONENT ${${file}_COMPONENT}
+      )
+    ENDFOREACH()
+  ENDIF()
 ENDIF()
 
 # Install libgcc as  mylibgcc.a


### PR DESCRIPTION
When build&compile with -DWITHOUT_SERVER=ON option using mariadb-10.4.11, i found two error.
First is my_global.h. 
When compile hs_client/hstcpcli.cpp, "my_global.h" is not found. So i changed ./cmake/plugin.cmake to using "INCLUDE_DIRECTORIES~~" on client install mode.
Last is wsrep_sst_rsync_wan.
I knew "wsrep~~" is require to server, but copmile is failed because making symbolic link "wsrep_sst_rsync_wan". So i changed ./scripts/CMakeLists.txt. What relating to wsrep is moved to "IF(NOT WITHOUT_SERVER)"