### PR TITLE
Correct FreeBSD cpuset_t type

### DIFF
--- a/mysys/my_getncpus.c
+++ b/mysys/my_getncpus.c
@@ -39,7 +39,11 @@ int my_getncpus(void)
       configured via core affinity.
     */
 #if (defined(__linux__) || defined(__FreeBSD__)) && defined(HAVE_PTHREAD_GETAFFINITY_NP)
+#ifdef __linux__
     cpu_set_t set;
+#else
+    cpuset_t set;
+#endif
     if (pthread_getaffinity_np(pthread_self(), sizeof(set), &set) == 0)
     {
 #ifdef CPU_COUNT


### PR DESCRIPTION
Per https://www.unix.com/man-page/freebsd/3/pthread_affinity_np/, underscores matter.