### PR TITLE
output_core_info - freebsd rlimits in different proc entry

### DIFF
--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -57,7 +57,11 @@ static inline void output_core_info()
     my_safe_printf_stderr("Writing a core file...\nWorking directory at %.*s\n",
                           (int) len, buff);
   }
+#ifdef __FreeBSD__
+  if ((fd= my_open("/proc/curproc/rlimit", O_RDONLY, MYF(0))) >= 0)
+#else
   if ((fd= my_open("/proc/self/limits", O_RDONLY, MYF(0))) >= 0)
+#endif
   {
     my_safe_printf_stderr("Resource Limits:\n");
     while ((len= my_read(fd, (uchar*)buff, sizeof(buff),  MYF(0))) > 0)


### PR DESCRIPTION
I didn't change the readlink /proc/self/cwd as there's no equivalent

FreeBSD-12.0
```
root@freebsd:/proc/58100 # ls -la /proc/curproc/
total 0
dr-xr-xr-x  1 root  wheel  0 Mar 27 03:46 .
dr-xr-xr-x  1 root  wheel  0 Mar 27 03:46 ..
-r--r--r--  1 root  wheel  0 Mar 27 03:46 cmdline
-rw-------  1 root  wheel  0 Mar 27 03:46 dbregs
-r--r--r--  1 root  wheel  0 Mar 27 03:46 etype
lr--r--r--  1 root  wheel  0 Mar 27 03:46 file -> /bin/ls
-rw-------  1 root  wheel  0 Mar 27 03:46 fpregs
-r--r--r--  1 root  wheel  0 Mar 27 03:46 map
-rw-------  1 root  wheel  0 Mar 27 03:46 mem
--w-------  1 root  wheel  0 Mar 27 03:46 note
--w-------  1 root  wheel  0 Mar 27 03:46 notepg
-rw-------  1 root  wheel  0 Mar 27 03:46 osrel
-rw-------  1 root  wheel  0 Mar 27 03:46 regs
-r--r--r--  1 root  wheel  0 Mar 27 03:46 rlimit
-r--r--r--  1 root  wheel  0 Mar 27 03:46 status
```