### PR TITLE
my.cnf: mention that config files must be *.cnf

### DIFF
--- a/support-files/rpm/my.cnf
+++ b/support-files/rpm/my.cnf
@@ -5,7 +5,7 @@
 [client-server]
 
 #
-# include all files from the config directory
+# include *.cnf from the config directory
 #
 !includedir /etc/my.cnf.d
 


### PR DESCRIPTION
It took me a long time to debug why my configs were not being loaded, and judging from online discussions I'm not the only one. Make the comment in the default my.cnf a bit more helpful so others don't waste time on this.