### PR TITLE
mtr: FreeBSD's patch has no --binary

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -3719,8 +3719,11 @@ sub do_before_run_mysqltest($)
     # to be able to distinguish them from manually created
     # version-controlled results, and to ignore them in bzr.
     my $dest = "$base_file$suites.result~";
-    my @cmd = ($exe_patch, qw/--binary -r - -f -s -o/,
-               $dest, $base_result, $resfile);
+    my @cmd = ($exe_patch);
+    if ($^O ne "freebsd") {
+      push @cmd, '--binary';
+    }
+    push @cmd, (qw/-r - -f -s -o/, $dest, $base_result, $resfile);
     if (-w $resdir) {
       # don't rebuild a file if it's up to date
       unless (-e $dest and -M $dest < -M $resfile


### PR DESCRIPTION
This is true in FreeBSD-12.0

$ patch --version
patch 2.0-12u11 FreeBSD
$ patch --binary
patch: unrecognized option `--binary'

tested on 10.5 however identical code all the way back and original 5.5 is meant to work on FreeBSD.

I submit this under the MCA.