### PR TITLE
MDEV-22051: Protocol::end_statement(): Assertion `0' failed on Galera node upon DDL attempt with conflicting lock

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-22051.result
+++ b/mysql-test/suite/galera/r/MDEV-22051.result
@@ -1,0 +1,20 @@
+connection node_2;
+connection node_1;
+FLUSH TABLES WITH READ LOCK;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+ERROR 08S01: Aborting TOI: Global Read-Lock (FTWRL) in place.
+SET wsrep_OSU_method=RSU;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+ERROR 08S01: Aborting TOI: Global Read-Lock (FTWRL) in place.
+SET wsrep_OSU_method=TOI;
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+ERROR 08S01: Aborting TOI: Global Read-Lock (FTWRL) in place.
+connection node_1;
+UNLOCK TABLES;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+FLUSH TABLES WITH READ LOCK;
+INSERT INTO t1 VALUES (1);
+ERROR HY000: Can't execute the query because you have a conflicting read lock
+UNLOCK TABLES;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-22051.test
+++ b/mysql-test/suite/galera/t/MDEV-22051.test
@@ -1,0 +1,33 @@
+#
+# If FTWRL is issued on node, DDL statement should report error back to
+# user.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+FLUSH TABLES WITH READ LOCK;
+
+--error ER_UNKNOWN_COM_ERROR
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+
+SET wsrep_OSU_method=RSU;
+--error ER_UNKNOWN_COM_ERROR
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+SET wsrep_OSU_method=TOI;
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--error ER_UNKNOWN_COM_ERROR
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+
+--connection node_1
+UNLOCK TABLES;
+
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+
+FLUSH TABLES WITH READ LOCK;
+--error ER_CANT_UPDATE_WITH_READLOCK
+INSERT INTO t1 VALUES (1);
+UNLOCK TABLES;
+
+DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3527,7 +3527,7 @@ mysql_execute_command(THD *thd)
      * and dirty reads (if configured)
      */
     if (!(thd->wsrep_applier) &&
-        !(wsrep_ready_get() && wsrep_reject_queries == WSREP_REJECT_NONE)    &&
+        !(wsrep_ready_get() && wsrep_reject_queries == WSREP_REJECT_NONE)  &&
         !(thd->variables.wsrep_dirty_reads &&
           (sql_command_flags[lex->sql_command] & CF_CHANGES_DATA) == 0)    &&
         !wsrep_tables_accessible_when_detached(all_tables)                 &&

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2028,10 +2028,10 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
   DBUG_ASSERT(wsrep_thd_is_local(thd));
   DBUG_ASSERT(thd->wsrep_trx().ws_meta().seqno().is_undefined());
 
-  if (thd->global_read_lock.is_acquired())
+  if (Wsrep_server_state::instance().desynced_on_pause())
   {
-    WSREP_DEBUG("Aborting TOI: Global Read-Lock (FTWRL) in place: %s %llu",
-                WSREP_QUERY(thd), thd->thread_id);
+    my_message(ER_UNKNOWN_COM_ERROR,
+               "Aborting TOI: Global Read-Lock (FTWRL) in place.", MYF(0));
     return -1;
   }
 


### PR DESCRIPTION
If FTWRL is issued, DDL statements should report error back to user before TOI is started.
PR also addresses MDEV-22052.