### PR TITLE
MDEV-20685/MDEV-21595: solaris compile fixes

### DIFF
--- a/include/my_alarm.h
+++ b/include/my_alarm.h
@@ -29,6 +29,13 @@ extern ulong my_time_to_wait_for_lock;
 
 #if defined(HAVE_ALARM) && !defined(NO_ALARM_LOOP)
 #include <signal.h>
+#ifdef HAVE_SIGHANDLER_T
+#define sig_return sighandler_t
+#elif defined(SOLARIS) || defined(__sun) || defined(__APPLE__)
+typedef void (*sig_return)(int); /* Returns type from signal */
+#else
+typedef void (*sig_return)(void); /* Returns type from signal */
+#endif
 #define ALARM_VARIABLES uint alarm_old=0; \
 			sig_return alarm_signal=0
 #define ALARM_INIT	my_have_got_alarm=0 ; \

--- a/include/my_global.h
+++ b/include/my_global.h
@@ -531,13 +531,6 @@ typedef int	my_socket;	/* File descriptor for sockets */
 #endif
 /* Type for fuctions that handles signals */
 #define sig_handler RETSIGTYPE
-C_MODE_START
-#ifdef HAVE_SIGHANDLER_T
-#define sig_return sighandler_t
-#else
-typedef void (*sig_return)(void); /* Returns type from signal */
-#endif
-C_MODE_END
 #if defined(__GNUC__) && !defined(_lint)
 typedef char	pchar;		/* Mixed prototypes can take char */
 typedef char	puchar;		/* Mixed prototypes can take char */

--- a/include/violite.h
+++ b/include/violite.h
@@ -138,6 +138,9 @@ typedef my_socket YASSL_SOCKET_T;
 #define YASSL_SOCKET_T_DEFINED
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#ifdef DEPRECATED
+#undef DEPRECATED
+#endif
 
 enum enum_ssl_init_error
 {

--- a/mysys/my_sync.c
+++ b/mysys/my_sync.c
@@ -133,8 +133,6 @@ int my_sync(File fd, myf my_flags)
 } /* my_sync */
 
 
-static const char cur_dir_name[]= {FN_CURLIB, 0};
-
 /*
   Force directory information to disk.
 
@@ -151,6 +149,7 @@ int my_sync_dir(const char *dir_name __attribute__((unused)),
                 myf my_flags __attribute__((unused)))
 {
 #ifdef NEED_EXPLICIT_SYNC_DIR
+  static const char cur_dir_name[]= {FN_CURLIB, 0};
   File dir_fd;
   int res= 0;
   const char *correct_dir_name;

--- a/plugin/auth_gssapi/gssapi_errmsg.cc
+++ b/plugin/auth_gssapi/gssapi_errmsg.cc
@@ -26,7 +26,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 */
 
+#if defined(__FreeBSD__) ||  defined(SOLARIS) || defined(__sun)
+#include <gssapi/gssapi.h>
+#else
 #include <gssapi.h>
+#endif
 #include <string.h>
 void gssapi_errmsg(OM_uint32 major, OM_uint32 minor, char *buf, size_t size)
 {

--- a/plugin/server_audit/server_audit.c
+++ b/plugin/server_audit/server_audit.c
@@ -2177,6 +2177,7 @@ struct mysql_event_general_v8
 
 static void auditing_v8(MYSQL_THD thd, struct mysql_event_general_v8 *ev_v8)
 {
+#ifdef __linux__
 #ifdef DBUG_OFF
   #ifdef __x86_64__
   static const int cmd_off= 4200;
@@ -2198,6 +2199,7 @@ static void auditing_v8(MYSQL_THD thd, struct mysql_event_general_v8 *ev_v8)
   static const int db_len_off= 68;
   #endif /*x86_64*/
 #endif /*DBUG_OFF*/
+#endif /*__linux*/
 
   struct mysql_event_general event;
 
@@ -2259,6 +2261,7 @@ static void auditing_v13(MYSQL_THD thd, unsigned int *ev_v0)
 
 int get_db_mysql57(MYSQL_THD thd, char **name, int *len)
 {
+#ifdef __linux__
   int db_off;
   int db_len_off;
   if (debug_server_started)
@@ -2282,7 +2285,6 @@ int get_db_mysql57(MYSQL_THD thd, char **name, int *len)
 #endif /*x86_64*/
   }
 
-#ifdef __linux__
   *name= *(char **) (((char *) thd) + db_off);
   *len= *((int *) (((char*) thd) + db_len_off));
   if (*name && (*name)[*len] != 0)

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1295,7 +1295,8 @@ bool do_command(THD *thd)
       mysql_mutex_lock(&thd->LOCK_thd_data);
       if (thd->wsrep_conflict_state == MUST_ABORT)
       {
-        DBUG_PRINT("wsrep",("aborted for wsrep rollback: %lu", thd->real_id));
+        DBUG_PRINT("wsrep",("aborted for wsrep rollback: %lu",
+                   (long unsigned int) thd->real_id));
         wsrep_client_rollback(thd);
       }
       mysql_mutex_unlock(&thd->LOCK_thd_data);

--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -777,7 +777,7 @@ btr_node_ptr_set_child_page_no(
 	rec_t*		rec,	/*!< in: node pointer record */
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page whose uncompressed
 				part will be updated, or NULL */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		page_no,/*!< in: child node address */
 	mtr_t*		mtr)	/*!< in: mtr */
 {
@@ -812,7 +812,7 @@ btr_node_ptr_get_child(
 /*===================*/
 	const rec_t*	node_ptr,/*!< in: node pointer */
 	dict_index_t*	index,	/*!< in: index */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	mtr_t*		mtr)	/*!< in: mtr */
 {
 	ut_ad(rec_offs_validate(node_ptr, index, offsets));
@@ -830,10 +830,10 @@ Returns the upper level node pointer to a page. It is assumed that mtr holds
 an sx-latch on the tree.
 @return rec_get_offsets() of the node pointer record */
 static
-offset_t*
+rec_offs*
 btr_page_get_father_node_ptr_func(
 /*==============================*/
-	offset_t*	offsets,/*!< in: work area for the return value */
+	rec_offs*	offsets,/*!< in: work area for the return value */
 	mem_heap_t*	heap,	/*!< in: memory heap to use */
 	btr_cur_t*	cursor,	/*!< in: cursor pointing to user record,
 				out: cursor on node pointer record,
@@ -937,10 +937,10 @@ Returns the upper level node pointer to a page. It is assumed that mtr holds
 an x-latch on the tree.
 @return rec_get_offsets() of the node pointer record */
 static
-offset_t*
+rec_offs*
 btr_page_get_father_block(
 /*======================*/
-	offset_t*	offsets,/*!< in: work area for the return value */
+	rec_offs*	offsets,/*!< in: work area for the return value */
 	mem_heap_t*	heap,	/*!< in: memory heap to use */
 	dict_index_t*	index,	/*!< in: b-tree index */
 	buf_block_t*	block,	/*!< in: child page in the index */
@@ -1814,7 +1814,7 @@ btr_root_raise_and_insert(
 				on the root page; when the function returns,
 				the cursor is positioned on the predecessor
 				of the inserted record */
-	offset_t**	offsets,/*!< out: offsets on inserted record */
+	rec_offs**	offsets,/*!< out: offsets on inserted record */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap, or NULL */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
@@ -2125,7 +2125,7 @@ btr_page_get_split_rec(
 	rec_t*		next_rec;
 	ulint		n;
 	mem_heap_t*	heap;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 
 	page = btr_cur_get_page(cursor);
 
@@ -2231,7 +2231,7 @@ btr_page_insert_fits(
 	const rec_t*	split_rec,/*!< in: suggestion for first record
 				on upper half-page, or NULL if
 				tuple to be inserted should be first */
-	offset_t**	offsets,/*!< in: rec_get_offsets(
+	rec_offs**	offsets,/*!< in: rec_get_offsets(
 				split_rec, cursor->index); out: garbage */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
@@ -2331,8 +2331,8 @@ btr_insert_on_non_leaf_level_func(
 	dberr_t		err;
 	rec_t*		rec;
 	mem_heap_t*	heap = NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets         = offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets         = offsets_;
 	rec_offs_init(offsets_);
 	rtr_info_t	rtr_info;
 
@@ -2441,7 +2441,7 @@ btr_attach_half_pages(
 	if (direction == FSP_DOWN) {
 
 		btr_cur_t	cursor;
-		offset_t*	offsets;
+		rec_offs*	offsets;
 
 		lower_page = buf_block_get_frame(new_block);
 		lower_page_no = new_block->page.id.page_no();
@@ -2564,7 +2564,7 @@ btr_page_tuple_smaller(
 /*===================*/
 	btr_cur_t*	cursor,	/*!< in: b-tree cursor */
 	const dtuple_t*	tuple,	/*!< in: tuple to consider */
-	offset_t**	offsets,/*!< in/out: temporary storage */
+	rec_offs**	offsets,/*!< in/out: temporary storage */
 	ulint		n_uniq,	/*!< in: number of unique fields
 				in the index page records */
 	mem_heap_t**	heap)	/*!< in/out: heap for offsets */
@@ -2604,7 +2604,7 @@ rec_t*
 btr_insert_into_right_sibling(
 	ulint		flags,
 	btr_cur_t*	cursor,
-	offset_t**	offsets,
+	rec_offs**	offsets,
 	mem_heap_t*	heap,
 	const dtuple_t*	tuple,
 	ulint		n_ext,
@@ -2741,7 +2741,7 @@ btr_page_split_and_insert(
 	btr_cur_t*	cursor,	/*!< in: cursor at which to insert; when the
 				function returns, the cursor is positioned
 				on the predecessor of the inserted record */
-	offset_t**	offsets,/*!< out: offsets on inserted record */
+	rec_offs**	offsets,/*!< out: offsets on inserted record */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap, or NULL */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
@@ -3302,7 +3302,7 @@ btr_lift_page_up(
 
 	{
 		btr_cur_t	cursor;
-		offset_t*	offsets	= NULL;
+		rec_offs*	offsets	= NULL;
 		mem_heap_t*	heap	= mem_heap_create(
 			sizeof(*offsets)
 			* (REC_OFFS_HEADER_SIZE + 1 + 1 + index->n_fields));
@@ -3487,7 +3487,7 @@ btr_compress(
 	page_t*		page;
 	btr_cur_t	father_cursor;
 	mem_heap_t*	heap;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	ulint		nth_rec = 0; /* remove bogus warning */
 	bool		mbr_changed = false;
 #ifdef UNIV_DEBUG
@@ -3631,7 +3631,7 @@ retry:
 	if (is_left) {
 		btr_cur_t	cursor2;
 		rtr_mbr_t	new_mbr;
-		offset_t*	offsets2 = NULL;
+		rec_offs*	offsets2 = NULL;
 
 		/* For rtree, we need to update father's mbr. */
 		if (dict_index_is_spatial(index)) {
@@ -3829,7 +3829,7 @@ retry:
 
 		/* For rtree, we need to update father's mbr. */
 		if (dict_index_is_spatial(index)) {
-			offset_t* offsets2;
+			rec_offs* offsets2;
 			ulint	rec_info;
 
 			offsets2 = rec_get_offsets(
@@ -4276,7 +4276,7 @@ btr_print_recursive(
 	ulint		width,	/*!< in: print this many entries from start
 				and end */
 	mem_heap_t**	heap,	/*!< in/out: heap for rec_get_offsets() */
-	offset_t**	offsets,/*!< in/out: buffer for rec_get_offsets() */
+	rec_offs**	offsets,/*!< in/out: buffer for rec_get_offsets() */
 	mtr_t*		mtr)	/*!< in: mtr */
 {
 	const page_t*	page	= buf_block_get_frame(block);
@@ -4340,8 +4340,8 @@ btr_print_index(
 	mtr_t		mtr;
 	buf_block_t*	root;
 	mem_heap_t*	heap	= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets	= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets	= offsets_;
 	rec_offs_init(offsets_);
 
 	fputs("--------------------------\n"
@@ -4375,7 +4375,7 @@ btr_check_node_ptr(
 {
 	mem_heap_t*	heap;
 	dtuple_t*	tuple;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	btr_cur_t	cursor;
 	page_t*		page = buf_block_get_frame(block);
 
@@ -4457,8 +4457,8 @@ btr_index_rec_validate(
 	ulint		i;
 	const page_t*	page;
 	mem_heap_t*	heap	= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets	= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets	= offsets_;
 	rec_offs_init(offsets_);
 
 	page = page_align(rec);
@@ -4691,8 +4691,8 @@ btr_validate_level(
 	bool		ret	= true;
 	mtr_t		mtr;
 	mem_heap_t*	heap	= mem_heap_create(256);
-	offset_t*	offsets	= NULL;
-	offset_t*	offsets2= NULL;
+	rec_offs*	offsets	= NULL;
+	rec_offs*	offsets2= NULL;
 #ifdef UNIV_ZIP_DEBUG
 	page_zip_des_t*	page_zip;
 #endif /* UNIV_ZIP_DEBUG */

--- a/storage/innobase/btr/btr0bulk.cc
+++ b/storage/innobase/btr/btr0bulk.cc
@@ -178,7 +178,7 @@ PageBulk::init()
 void
 PageBulk::insert(
 	const rec_t*		rec,
-	offset_t*		offsets)
+	rec_offs*		offsets)
 {
 	ulint		rec_size;
 
@@ -190,7 +190,7 @@ PageBulk::insert(
 	/* Check whether records are in order. */
 	if (!page_rec_is_infimum(m_cur_rec)) {
 		rec_t*	old_rec = m_cur_rec;
-		offset_t* old_offsets = rec_get_offsets(
+		rec_offs* old_offsets = rec_get_offsets(
 			old_rec, m_index, NULL,	page_rec_is_leaf(old_rec),
 			ULINT_UNDEFINED, &m_heap);
 
@@ -402,7 +402,7 @@ rec_t*
 PageBulk::getSplitRec()
 {
 	rec_t*		rec;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	ulint		total_used_size;
 	ulint		total_recs_size;
 	ulint		n_recs;
@@ -448,7 +448,7 @@ PageBulk::copyIn(
 {
 
 	rec_t*		rec = split_rec;
-	offset_t*	offsets = NULL;
+	rec_offs*	offsets = NULL;
 
 	ut_ad(m_rec_no == 0);
 	ut_ad(page_rec_is_user_rec(rec));
@@ -494,7 +494,7 @@ PageBulk::copyOut(
 	ut_ad(n > 0);
 
 	/* Set last record's next in page */
-	offset_t*	offsets = NULL;
+	rec_offs*	offsets = NULL;
 	rec = page_rec_get_prev(split_rec);
 	offsets = rec_get_offsets(rec, m_index, offsets,
 				  page_rec_is_leaf(split_rec),
@@ -604,7 +604,7 @@ the blob data is logged first, then the record is logged in bulk mode.
 dberr_t
 PageBulk::storeExt(
 	const big_rec_t*	big_rec,
-	offset_t*		offsets)
+	rec_offs*		offsets)
 {
 	/* Note: not all fileds are initialized in btr_pcur. */
 	btr_pcur_t	btr_pcur;
@@ -864,7 +864,7 @@ BtrBulk::insert(
 	ulint		rec_size = rec_get_converted_size(m_index, tuple, n_ext);
 	big_rec_t*	big_rec = NULL;
 	rec_t*		rec = NULL;
-	offset_t*	offsets = NULL;
+	rec_offs*	offsets = NULL;
 
 	if (page_bulk->needExt(tuple, rec_size)) {
 		/* The record is so big that we have to store some fields

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -162,7 +162,7 @@ btr_cur_unmark_extern_fields(
 				part will be updated, or NULL */
 	rec_t*		rec,	/*!< in/out: record in a clustered index */
 	dict_index_t*	index,	/*!< in: index of the page */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	mtr_t*		mtr);	/*!< in: mtr, or NULL if not logged */
 /*******************************************************************//**
 Adds path information to the cursor for the current page, for which
@@ -187,7 +187,7 @@ btr_rec_free_updated_extern_fields(
 	rec_t*		rec,	/*!< in: record */
 	page_zip_des_t*	page_zip,/*!< in: compressed page whose uncompressed
 				part will be updated, or NULL */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const upd_t*	update,	/*!< in: update vector */
 	bool		rollback,/*!< in: performing rollback? */
 	mtr_t*		mtr);	/*!< in: mini-transaction handle which contains
@@ -201,7 +201,7 @@ btr_rec_free_externally_stored_fields(
 	dict_index_t*	index,	/*!< in: index of the data, the index
 				tree MUST be X-latched */
 	rec_t*		rec,	/*!< in: record */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	page_zip_des_t*	page_zip,/*!< in: compressed page whose uncompressed
 				part will be updated, or NULL */
 	bool		rollback,/*!< in: performing rollback? */
@@ -943,10 +943,10 @@ btr_cur_search_to_nth_level(
 	btr_search_t*	info;
 #endif /* BTR_CUR_ADAPT */
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
-	offset_t	offsets2_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets2	= offsets2_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
+	rec_offs	offsets2_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets2	= offsets2_;
 	rec_offs_init(offsets_);
 	rec_offs_init(offsets2_);
 	/* Currently, PAGE_CUR_LE is the only search mode used for searches
@@ -2198,8 +2198,8 @@ btr_cur_open_at_index_side_func(
 	ulint		n_blocks = 0;
 	ulint		n_releases = 0;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	dberr_t		err = DB_SUCCESS;
 
 	rec_offs_init(offsets_);
@@ -2568,8 +2568,8 @@ btr_cur_open_at_rnd_pos_func(
 	ulint		n_blocks = 0;
 	ulint		n_releases = 0;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(!dict_index_is_spatial(index));
@@ -2859,7 +2859,7 @@ btr_cur_insert_if_possible(
 				cursor stays valid */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert; the size info need not
 				have been stored to tuple */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap, or NULL */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
 	mtr_t*		mtr)	/*!< in/out: mini-transaction */
@@ -3025,7 +3025,7 @@ btr_cur_optimistic_insert(
 				specified */
 	btr_cur_t*	cursor,	/*!< in: cursor on page after which to insert;
 				cursor stays valid */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap */
 	dtuple_t*	entry,	/*!< in/out: entry to insert */
 	rec_t**		rec,	/*!< out: pointer to inserted record if
@@ -3314,7 +3314,7 @@ btr_cur_pessimistic_insert(
 				insertion will certainly succeed */
 	btr_cur_t*	cursor,	/*!< in: cursor after which to insert;
 				cursor stays valid */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap
 				that can be emptied */
 	dtuple_t*	entry,	/*!< in/out: entry to insert */
@@ -3480,7 +3480,7 @@ btr_cur_upd_lock_and_undo(
 /*======================*/
 	ulint		flags,	/*!< in: undo logging and locking flags */
 	btr_cur_t*	cursor,	/*!< in: cursor on record to update */
-	const offset_t*	offsets,/*!< in: rec_get_offsets() on cursor */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets() on cursor */
 	const upd_t*	update,	/*!< in: update vector */
 	ulint		cmpl_info,/*!< in: compiler info on secondary index
 				updates */
@@ -3611,7 +3611,7 @@ btr_cur_parse_update_in_place(
 	roll_ptr_t	roll_ptr;
 	ulint		rec_offset;
 	mem_heap_t*	heap;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 
 	if (end_ptr < ptr + 1) {
 
@@ -3696,7 +3696,7 @@ btr_cur_update_alloc_zip_func(
 	page_cur_t*	cursor,	/*!< in/out: B-tree page cursor */
 	dict_index_t*	index,	/*!< in: the index corresponding to cursor */
 #ifdef UNIV_DEBUG
-	offset_t*	offsets,/*!< in/out: offsets of the cursor record */
+	rec_offs*	offsets,/*!< in/out: offsets of the cursor record */
 #endif /* UNIV_DEBUG */
 	ulint		length,	/*!< in: size needed */
 	bool		create,	/*!< in: true=delete-and-insert,
@@ -3777,7 +3777,7 @@ btr_cur_update_in_place(
 	btr_cur_t*	cursor,	/*!< in: cursor on the record to update;
 				cursor stays valid and positioned on the
 				same record */
-	offset_t*	offsets,/*!< in/out: offsets on cursor->page_cur.rec */
+	rec_offs*	offsets,/*!< in/out: offsets on cursor->page_cur.rec */
 	const upd_t*	update,	/*!< in: update vector */
 	ulint		cmpl_info,/*!< in: compiler info on secondary index
 				updates */
@@ -3942,7 +3942,7 @@ btr_cur_optimistic_update(
 	btr_cur_t*	cursor,	/*!< in: cursor on the record to update;
 				cursor stays valid and positioned on the
 				same record */
-	offset_t**	offsets,/*!< out: offsets on cursor->page_cur.rec */
+	rec_offs**	offsets,/*!< out: offsets on cursor->page_cur.rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to NULL or memory heap */
 	const upd_t*	update,	/*!< in: update vector; this must also
 				contain trx id and roll ptr fields */
@@ -4257,7 +4257,7 @@ btr_cur_pessimistic_update(
 	btr_cur_t*	cursor,	/*!< in/out: cursor on the record to update;
 				cursor may become invalid if *big_rec == NULL
 				|| !(flags & BTR_KEEP_POS_FLAG) */
-	offset_t**	offsets,/*!< out: offsets on cursor->page_cur.rec */
+	rec_offs**	offsets,/*!< out: offsets on cursor->page_cur.rec */
 	mem_heap_t**	offsets_heap,
 				/*!< in/out: pointer to memory heap
 				that can be emptied */
@@ -4779,7 +4779,7 @@ btr_cur_parse_del_mark_set_clust_rec(
 		clustered index fields. */
 		ut_ad(pos <= MAX_REF_PARTS);
 
-		offset_t offsets[REC_OFFS_HEADER_SIZE + MAX_REF_PARTS + 2];
+		rec_offs offsets[REC_OFFS_HEADER_SIZE + MAX_REF_PARTS + 2];
 		rec_offs_init(offsets);
 		mem_heap_t*	heap	= NULL;
 
@@ -4822,7 +4822,7 @@ btr_cur_del_mark_set_clust_rec(
 	buf_block_t*	block,	/*!< in/out: buffer block of the record */
 	rec_t*		rec,	/*!< in/out: record */
 	dict_index_t*	index,	/*!< in: clustered index of the record */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec) */
 	que_thr_t*	thr,	/*!< in: query thread */
 	const dtuple_t*	entry,	/*!< in: dtuple for the deleting record, also
 				contains the virtual cols if there are any */
@@ -5109,8 +5109,8 @@ btr_cur_optimistic_delete_func(
 	buf_block_t*	block;
 	rec_t*		rec;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	ibool		no_compress_needed;
 	rec_offs_init(offsets_);
 
@@ -5230,7 +5230,7 @@ btr_cur_pessimistic_delete(
 	bool		success;
 	ibool		ret		= FALSE;
 	mem_heap_t*	heap;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 #ifdef UNIV_DEBUG
 	bool		parent_latched	= false;
 #endif /* UNIV_DEBUG */
@@ -5329,7 +5329,7 @@ btr_cur_pessimistic_delete(
 			rtr_mbr_t	father_mbr;
 			rec_t*		father_rec;
 			btr_cur_t	father_cursor;
-			offset_t*	offsets;
+			rec_offs*	offsets;
 			bool		upd_ret;
 			ulint		len;
 
@@ -6090,7 +6090,7 @@ btr_record_not_null_field_in_rec(
 	ulint		n_unique,	/*!< in: dict_index_get_n_unique(index),
 					number of columns uniquely determine
 					an index entry */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec, index),
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec, index),
 					its size could be for all fields or
 					that of "n_unique" */
 	ib_uint64_t*	n_not_null)	/*!< in/out: array to record number of
@@ -6144,8 +6144,8 @@ btr_estimate_number_of_different_key_vals(
 	uintmax_t	add_on;
 	mtr_t		mtr;
 	mem_heap_t*	heap		= NULL;
-	offset_t*	offsets_rec	= NULL;
-	offset_t*	offsets_next_rec = NULL;
+	rec_offs*	offsets_rec	= NULL;
+	rec_offs*	offsets_next_rec = NULL;
 
 	/* For spatial index, there is no such stats can be
 	fetched. */
@@ -6333,7 +6333,7 @@ btr_estimate_number_of_different_key_vals(
 			and assign the old offsets_rec buffer to
 			offsets_next_rec. */
 			{
-				offset_t* offsets_tmp = offsets_rec;
+				rec_offs* offsets_tmp = offsets_rec;
 				offsets_rec = offsets_next_rec;
 				offsets_next_rec = offsets_tmp;
 			}
@@ -6418,7 +6418,7 @@ static
 ulint
 btr_rec_get_field_ref_offs(
 /*=======================*/
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		n)	/*!< in: index of the external field */
 {
 	ulint	field_ref_offs;
@@ -6447,7 +6447,7 @@ btr_rec_get_field_ref_offs(
 ulint
 btr_rec_get_externally_stored_len(
 	const rec_t*	rec,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	ulint	n_fields;
 	ulint	total_extern_len = 0;
@@ -6486,7 +6486,7 @@ btr_cur_set_ownership_of_extern_field(
 				part will be updated, or NULL */
 	rec_t*		rec,	/*!< in/out: clustered index record */
 	dict_index_t*	index,	/*!< in: index of the page */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		i,	/*!< in: field number */
 	ibool		val,	/*!< in: value to set */
 	mtr_t*		mtr)	/*!< in: mtr, or NULL if not logged */
@@ -6536,7 +6536,7 @@ btr_cur_disown_inherited_fields(
 				part will be updated, or NULL */
 	rec_t*		rec,	/*!< in/out: record in a clustered index */
 	dict_index_t*	index,	/*!< in: index of the page */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	const upd_t*	update,	/*!< in: update vector */
 	mtr_t*		mtr)	/*!< in/out: mini-transaction */
 {
@@ -6567,7 +6567,7 @@ btr_cur_unmark_extern_fields(
 				part will be updated, or NULL */
 	rec_t*		rec,	/*!< in/out: record in a clustered index */
 	dict_index_t*	index,	/*!< in: index of the page */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	mtr_t*		mtr)	/*!< in: mtr, or NULL if not logged */
 {
 	ulint	n;
@@ -6663,7 +6663,7 @@ struct btr_blob_log_check_t {
 	/** Mini transaction holding the latches for m_pcur */
 	mtr_t*		m_mtr;
 	/** rec_get_offsets(rec, index); offset of clust_rec */
-	const offset_t*	m_offsets;
+	const rec_offs*	m_offsets;
 	/** The block containing clustered record */
 	buf_block_t**	m_block;
 	/** The clustered record pointer */
@@ -6683,7 +6683,7 @@ struct btr_blob_log_check_t {
 	btr_blob_log_check_t(
 		btr_pcur_t*	pcur,
 		mtr_t*		mtr,
-		const offset_t*	offsets,
+		const rec_offs*	offsets,
 		buf_block_t**	block,
 		rec_t**		rec,
 		enum blob_op	op)
@@ -6757,7 +6757,7 @@ struct btr_blob_log_check_t {
 		*m_rec		= btr_pcur_get_rec(m_pcur);
 
 		ut_d(rec_offs_make_valid(
-			*m_rec, index, const_cast<offset_t*>(m_offsets)));
+			*m_rec, index, const_cast<rec_offs*>(m_offsets)));
 
 		ut_ad(m_mtr->memo_contains_page_flagged(
 		      *m_rec,
@@ -6788,7 +6788,7 @@ btr_store_big_rec_extern_fields(
 	btr_pcur_t*	pcur,		/*!< in/out: a persistent cursor. if
 					btr_mtr is restarted, then this can
 					be repositioned. */
-	offset_t*	offsets,	/*!< in/out: rec_get_offsets() on
+	rec_offs*	offsets,	/*!< in/out: rec_get_offsets() on
 					pcur. the "external storage" flags
 					in offsets will correctly correspond
 					to rec when this function returns */
@@ -7273,7 +7273,7 @@ btr_free_externally_stored_field(
 	byte*		field_ref,	/*!< in/out: field reference */
 	const rec_t*	rec,		/*!< in: record containing field_ref, for
 					page_zip_write_blob_ptr(), or NULL */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec, index),
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec, index),
 					or NULL */
 	page_zip_des_t*	page_zip,	/*!< in: compressed page corresponding
 					to rec, or NULL if rec == NULL */
@@ -7446,7 +7446,7 @@ btr_rec_free_externally_stored_fields(
 	dict_index_t*	index,	/*!< in: index of the data, the index
 				tree MUST be X-latched */
 	rec_t*		rec,	/*!< in/out: record */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	page_zip_des_t*	page_zip,/*!< in: compressed page whose uncompressed
 				part will be updated, or NULL */
 	bool		rollback,/*!< in: performing rollback? */
@@ -7487,7 +7487,7 @@ btr_rec_free_updated_extern_fields(
 	rec_t*		rec,	/*!< in/out: record */
 	page_zip_des_t*	page_zip,/*!< in: compressed page whose uncompressed
 				part will be updated, or NULL */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const upd_t*	update,	/*!< in: update vector */
 	bool		rollback,/*!< in: performing rollback? */
 	mtr_t*		mtr)	/*!< in: mini-transaction handle which contains
@@ -7885,7 +7885,7 @@ protected by a lock or a page latch
 byte*
 btr_rec_copy_externally_stored_field(
 	const rec_t*		rec,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	const page_size_t&	page_size,
 	ulint			no,
 	ulint*			len,

--- a/storage/innobase/btr/btr0defragment.cc
+++ b/storage/innobase/btr/btr0defragment.cc
@@ -341,8 +341,8 @@ btr_defragment_calc_n_recs_for_size(
 {
 	page_t* page = buf_block_get_frame(block);
 	ulint n_recs = 0;
-	offset_t offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t* offsets = offsets_;
+	rec_offs offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs* offsets = offsets_;
 	rec_offs_init(offsets_);
 	mem_heap_t* heap = NULL;
 	ulint size = 0;

--- a/storage/innobase/btr/btr0pcur.cc
+++ b/storage/innobase/btr/btr0pcur.cc
@@ -293,10 +293,10 @@ btr_pcur_restore_position_func(
 			if (cursor->rel_pos == BTR_PCUR_ON) {
 #ifdef UNIV_DEBUG
 				const rec_t*	rec;
-				offset_t	offsets1_[REC_OFFS_NORMAL_SIZE];
-				offset_t	offsets2_[REC_OFFS_NORMAL_SIZE];
-				offset_t*	offsets1 = offsets1_;
-				offset_t*	offsets2 = offsets2_;
+				rec_offs	offsets1_[REC_OFFS_NORMAL_SIZE];
+				rec_offs	offsets2_[REC_OFFS_NORMAL_SIZE];
+				rec_offs*	offsets1 = offsets1_;
+				rec_offs*	offsets2 = offsets2_;
 				rec = btr_pcur_get_rec(cursor);
 
 				rec_offs_init(offsets1_);
@@ -362,7 +362,7 @@ btr_pcur_restore_position_func(
 	ut_ad(cursor->rel_pos == BTR_PCUR_ON
 	      || cursor->rel_pos == BTR_PCUR_BEFORE
 	      || cursor->rel_pos == BTR_PCUR_AFTER);
-	offset_t offsets[REC_OFFS_NORMAL_SIZE];
+	rec_offs offsets[REC_OFFS_NORMAL_SIZE];
 	rec_offs_init(offsets);
 	if (cursor->rel_pos == BTR_PCUR_ON
 	    && btr_pcur_is_on_user_rec(cursor)

--- a/storage/innobase/btr/btr0scrub.cc
+++ b/storage/innobase/btr/btr0scrub.cc
@@ -481,7 +481,7 @@ btr_pessimistic_scrub(
 	/* arguments to btr_page_split_and_insert */
 	mem_heap_t* heap = NULL;
 	dtuple_t* entry = NULL;
-	offset_t* offsets = NULL;
+	rec_offs* offsets = NULL;
 	ulint n_ext = 0;
 	ulint flags = BTR_MODIFY_TREE;
 

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -629,7 +629,7 @@ btr_search_update_hash_ref(
 	    && (block->curr_n_bytes == info->n_bytes)
 	    && (block->curr_left_side == info->left_side)) {
 		mem_heap_t*	heap		= NULL;
-		offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
+		rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
 		rec_offs_init(offsets_);
 
 		rec = btr_cur_get_rec(cursor);
@@ -740,8 +740,8 @@ btr_search_check_guess(
 	ulint		match;
 	int		cmp;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	ibool		success		= FALSE;
 	rec_offs_init(offsets_);
 
@@ -1116,7 +1116,7 @@ btr_search_drop_page_hash_index(buf_block_t* block)
 	ulint			i;
 	mem_heap_t*		heap;
 	const dict_index_t*	index;
-	offset_t*		offsets;
+	rec_offs*		offsets;
 	rw_lock_t*		latch;
 	btr_search_t*		info;
 
@@ -1370,8 +1370,8 @@ btr_search_build_page_hash_index(
 	rec_t**		recs;
 	ulint		i;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 
 #ifdef MYSQL_INDEX_DISABLE_AHI
 	if (index->disable_ahi) return;
@@ -1619,7 +1619,7 @@ btr_search_update_hash_on_delete(btr_cur_t* cursor)
 	const rec_t*	rec;
 	ulint		fold;
 	dict_index_t*	index;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
 	mem_heap_t*	heap		= NULL;
 	rec_offs_init(offsets_);
 
@@ -1768,8 +1768,8 @@ btr_search_update_hash_on_insert(btr_cur_t* cursor)
 	ibool		left_side;
 	ibool		locked		= FALSE;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(page_is_leaf(btr_cur_get_page(cursor)));
@@ -1930,8 +1930,8 @@ btr_search_hash_table_validate(ulint hash_table_id)
 	ulint		i;
 	ulint		cell_count;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 
 	if (!btr_search_enabled) {
 		return(TRUE);

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -1018,8 +1018,8 @@ dict_stats_analyze_index_level(
 	bool		prev_rec_is_copied;
 	byte*		prev_rec_buf = NULL;
 	ulint		prev_rec_buf_size = 0;
-	offset_t*	rec_offsets;
-	offset_t*	prev_rec_offsets;
+	rec_offs*	rec_offsets;
+	rec_offs*	prev_rec_offsets;
 	ulint		i;
 
 	DEBUG_PRINTF("    %s(table=%s, index=%s, level=" ULINTPF ")\n",
@@ -1040,9 +1040,9 @@ dict_stats_analyze_index_level(
 	i = (REC_OFFS_HEADER_SIZE + 1 + 1) + index->n_fields;
 
 	heap = mem_heap_create((2 * sizeof *rec_offsets) * i);
-	rec_offsets = static_cast<offset_t*>(
+	rec_offsets = static_cast<rec_offs*>(
 		mem_heap_alloc(heap, i * sizeof *rec_offsets));
-	prev_rec_offsets = static_cast<offset_t*>(
+	prev_rec_offsets = static_cast<rec_offs*>(
 		mem_heap_alloc(heap, i * sizeof *prev_rec_offsets));
 	rec_offs_set_n_alloc(rec_offsets, i);
 	rec_offs_set_n_alloc(prev_rec_offsets, i);
@@ -1324,11 +1324,11 @@ to the number of externally stored pages which were encountered
 @return offsets1 or offsets2 (the offsets of *out_rec),
 or NULL if the page is empty and does not contain user records. */
 UNIV_INLINE
-offset_t*
+rec_offs*
 dict_stats_scan_page(
 	const rec_t**		out_rec,
-	offset_t*		offsets1,
-	offset_t*		offsets2,
+	rec_offs*		offsets1,
+	rec_offs*		offsets2,
 	const dict_index_t*	index,
 	const page_t*		page,
 	ulint			n_prefix,
@@ -1336,8 +1336,8 @@ dict_stats_scan_page(
 	ib_uint64_t*		n_diff,
 	ib_uint64_t*		n_external_pages)
 {
-	offset_t*	offsets_rec		= offsets1;
-	offset_t*	offsets_next_rec	= offsets2;
+	rec_offs*	offsets_rec		= offsets1;
+	rec_offs*	offsets_next_rec	= offsets2;
 	const rec_t*	rec;
 	const rec_t*	next_rec;
 	/* A dummy heap, to be passed to rec_get_offsets().
@@ -1450,9 +1450,9 @@ dict_stats_analyze_index_below_cur(
 	const page_t*	page;
 	mem_heap_t*	heap;
 	const rec_t*	rec;
-	offset_t*	offsets1;
-	offset_t*	offsets2;
-	offset_t*	offsets_rec;
+	rec_offs*	offsets1;
+	rec_offs*	offsets2;
+	rec_offs*	offsets_rec;
 	ulint		size;
 	mtr_t		mtr;
 
@@ -1470,10 +1470,10 @@ dict_stats_analyze_index_below_cur(
 
 	heap = mem_heap_create(size * (sizeof *offsets1 + sizeof *offsets2));
 
-	offsets1 = static_cast<offset_t*>(mem_heap_alloc(
+	offsets1 = static_cast<rec_offs*>(mem_heap_alloc(
 			heap, size * sizeof *offsets1));
 
-	offsets2 = static_cast<offset_t*>(mem_heap_alloc(
+	offsets2 = static_cast<rec_offs*>(mem_heap_alloc(
 			heap, size * sizeof *offsets2));
 
 	rec_offs_set_n_alloc(offsets1, size);

--- a/storage/innobase/fts/fts0fts.cc
+++ b/storage/innobase/fts/fts0fts.cc
@@ -3229,7 +3229,7 @@ fts_fetch_doc_from_rec(
 	dict_index_t*	clust_index,	/*!< in: cluster index */
 	btr_pcur_t*	pcur,		/*!< in: cursor whose position
 					has been stored */
-	offset_t*	offsets,	/*!< in: offsets */
+	rec_offs*	offsets,	/*!< in: offsets */
 	fts_doc_t*	doc)		/*!< out: fts doc to hold parsed
 					documents */
 {
@@ -3511,7 +3511,7 @@ fts_add_doc_by_id(
 		btr_pcur_t*	doc_pcur;
 		const rec_t*	clust_rec;
 		btr_pcur_t	clust_pcur;
-		offset_t*	offsets = NULL;
+		rec_offs*	offsets = NULL;
 		ulint		num_idx = ib_vector_size(cache->get_docs);
 
 		rec = btr_pcur_get_rec(&pcur);
@@ -3700,8 +3700,8 @@ fts_get_max_doc_id(
 
 	if (!page_is_empty(btr_pcur_get_page(&pcur))) {
 		const rec_t*    rec = NULL;
-		offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-		offset_t*	offsets = offsets_;
+		rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+		rec_offs*	offsets = offsets_;
 		mem_heap_t*	heap = NULL;
 		ulint		len;
 		const void*	data;
@@ -5208,8 +5208,8 @@ fts_get_doc_id_from_rec(
 	const byte*	data;
 	ulint		col_no;
 	doc_id_t	doc_id = 0;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets = offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets = offsets_;
 	mem_heap_t*	my_heap = heap;
 
 	ut_a(table->fts->doc_col != ULINT_UNDEFINED);

--- a/storage/innobase/gis/gis0rtree.cc
+++ b/storage/innobase/gis/gis0rtree.cc
@@ -50,7 +50,7 @@ rtr_page_split_initialize_nodes(
 	btr_cur_t*	cursor,	/*!< in: cursor at which to insert; when the
 				function returns, the cursor is positioned
 				on the predecessor of the inserted record */
-	offset_t**	offsets,/*!< in: offsets on inserted record */
+	rec_offs**	offsets,/*!< in: offsets on inserted record */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */
 	double**	buf_pos)/*!< in/out: current buffer position */
 {
@@ -193,7 +193,7 @@ rtr_update_mbr_field_in_place(
 /*==========================*/
 	dict_index_t*	index,		/*!< in: spatial index. */
 	rec_t*		rec,		/*!< in/out: rec to be modified.*/
-	offset_t*	offsets,	/*!< in/out: offsets on rec. */
+	rec_offs*	offsets,	/*!< in/out: offsets on rec. */
 	rtr_mbr_t*	mbr,		/*!< in: the new mbr. */
 	mtr_t*		mtr)		/*!< in: mtr */
 {
@@ -267,7 +267,7 @@ bool
 rtr_update_mbr_field(
 /*=================*/
 	btr_cur_t*	cursor,		/*!< in/out: cursor pointed to rec.*/
-	offset_t*	offsets,	/*!< in/out: offsets on rec. */
+	rec_offs*	offsets,	/*!< in/out: offsets on rec. */
 	btr_cur_t*	cursor2,	/*!< in/out: cursor pointed to rec
 					that should be deleted.
 					this cursor is for btr_compress to
@@ -297,7 +297,7 @@ rtr_update_mbr_field(
 	bool		ins_suc = true;
 	ulint		cur2_pos = 0;
 	ulint		del_page_no = 0;
-	offset_t*	offsets2;
+	rec_offs*	offsets2;
 
 	rec = btr_cur_get_rec(cursor);
 	page = page_align(rec);
@@ -384,7 +384,7 @@ rtr_update_mbr_field(
 		}
 
 		if (cursor2) {
-			offset_t* offsets2;
+			rec_offs* offsets2;
 
 			if (page_zip) {
 				cursor2->page_cur.rec
@@ -406,7 +406,7 @@ rtr_update_mbr_field(
 
 		page_cur_t		page_cur;
 		rec_t*			insert_rec;
-		offset_t*		insert_offsets = NULL;
+		rec_offs*		insert_offsets = NULL;
 		ulint			old_pos;
 		rec_t*			old_rec;
 
@@ -438,7 +438,7 @@ update_mbr:
 		/* When there're not only 1 rec in the page, we do delete/insert
 		to avoid page split. */
 		rec_t*			insert_rec;
-		offset_t*		insert_offsets = NULL;
+		rec_offs*		insert_offsets = NULL;
 		rec_t*			next_rec;
 
 		/* Delete the rec which cursor point to. */
@@ -639,7 +639,7 @@ rtr_adjust_upper_level(
 	page_zip_des_t*	new_page_zip;
 	dict_index_t*	index = sea_cur->index;
 	btr_cur_t	cursor;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	mem_heap_t*	heap;
 	ulint		level;
 	dtuple_t*	node_ptr_upper;
@@ -809,8 +809,8 @@ rtr_split_page_move_rec_list(
 	page_cur_t		new_page_cursor;
 	page_t*			page;
 	page_t*			new_page;
-	offset_t		offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*		offsets		= offsets_;
+	rec_offs		offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*		offsets		= offsets_;
 	page_zip_des_t*		new_page_zip
 		= buf_block_get_page_zip(new_block);
 	rec_t*			rec;
@@ -970,7 +970,7 @@ rtr_page_split_and_insert(
 	btr_cur_t*	cursor,	/*!< in/out: cursor at which to insert; when the
 				function returns, the cursor is positioned
 				on the predecessor of the inserted record */
-	offset_t**	offsets,/*!< out: offsets on inserted record */
+	rec_offs**	offsets,/*!< out: offsets on inserted record */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap, or NULL */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
@@ -1322,7 +1322,7 @@ rtr_ins_enlarge_mbr(
 	mem_heap_t*		heap;
 	dict_index_t*		index = btr_cur->index;
 	page_cur_t*		page_cursor;
-	offset_t*		offsets;
+	rec_offs*		offsets;
 	node_visit_t*		node_visit;
 	btr_cur_t		cursor;
 	page_t*			page;
@@ -1406,10 +1406,10 @@ rtr_page_copy_rec_list_end_no_locks(
 	page_cur_t	page_cur;
 	page_cur_t	cur1;
 	rec_t*		cur_rec;
-	offset_t	offsets_1[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets1 = offsets_1;
-	offset_t	offsets_2[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets2 = offsets_2;
+	rec_offs	offsets_1[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets1 = offsets_1;
+	rec_offs	offsets_2[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets2 = offsets_2;
 	ulint		moved = 0;
 	bool		is_leaf = page_is_leaf(new_page);
 
@@ -1532,10 +1532,10 @@ rtr_page_copy_rec_list_start_no_locks(
 {
 	page_cur_t	cur1;
 	rec_t*		cur_rec;
-	offset_t	offsets_1[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets1 = offsets_1;
-	offset_t	offsets_2[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets2 = offsets_2;
+	rec_offs	offsets_1[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets1 = offsets_1;
+	rec_offs	offsets_2[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets2 = offsets_2;
 	page_cur_t	page_cur;
 	ulint		moved = 0;
 	bool		is_leaf = page_is_leaf(buf_block_get_frame(block));
@@ -1642,8 +1642,8 @@ rtr_merge_mbr_changed(
 /*==================*/
 	btr_cur_t*		cursor,		/*!< in/out: cursor */
 	btr_cur_t*		cursor2,	/*!< in: the other cursor */
-	offset_t*		offsets,	/*!< in: rec offsets */
-	offset_t*		offsets2,	/*!< in: rec offsets */
+	rec_offs*		offsets,	/*!< in: rec offsets */
+	rec_offs*		offsets2,	/*!< in: rec offsets */
 	rtr_mbr_t*		new_mbr,	/*!< out: MBR to update */
 	buf_block_t*		merge_block,	/*!< in: page to merge */
 	buf_block_t*		block,		/*!< in: page be merged */
@@ -1689,8 +1689,8 @@ rtr_merge_and_update_mbr(
 /*=====================*/
 	btr_cur_t*		cursor,		/*!< in/out: cursor */
 	btr_cur_t*		cursor2,	/*!< in: the other cursor */
-	offset_t*		offsets,	/*!< in: rec offsets */
-	offset_t*		offsets2,	/*!< in: rec offsets */
+	rec_offs*		offsets,	/*!< in: rec offsets */
+	rec_offs*		offsets2,	/*!< in: rec offsets */
 	page_t*			child_page,	/*!< in: the page. */
 	buf_block_t*		merge_block,	/*!< in: page to merge */
 	buf_block_t*		block,		/*!< in: page be merged */
@@ -1759,7 +1759,7 @@ rtr_check_same_block(
 
 {
 	ulint		page_no = childb->page.id.page_no();
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	rec_t*		rec = page_rec_get_next(page_get_infimum_rec(
 				buf_block_get_frame(parentb)));
 
@@ -1790,7 +1790,7 @@ rtr_rec_cal_increase(
 				dtuple in some of the common fields, or which
 				has an equal number or more fields than
 				dtuple */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	double*		area)	/*!< out: increased area */
 {
 	const dfield_t*	dtuple_field;
@@ -1886,7 +1886,7 @@ rtr_estimate_n_rows_in_range(
 	rec_t*		rec;
 	byte*		field;
 	ulint		len;
-	offset_t*	offsets = NULL;
+	rec_offs*	offsets = NULL;
 	mem_heap_t*	heap;
 
 	heap = mem_heap_create(512);

--- a/storage/innobase/gis/gis0sea.cc
+++ b/storage/innobase/gis/gis0sea.cc
@@ -527,7 +527,7 @@ rtr_compare_cursor_rec(
 	mem_heap_t**	heap)		/*!< in: memory heap */
 {
 	const rec_t*	rec;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 
 	rec = btr_cur_get_rec(cursor);
 
@@ -669,7 +669,7 @@ rtr_page_get_father(
 {
 	mem_heap_t*	heap = mem_heap_create(100);
 #ifdef UNIV_DEBUG
-	offset_t*	offsets;
+	rec_offs*	offsets;
 
 	offsets = rtr_page_get_father_block(
 		NULL, heap, index, block, mtr, sea_cur, cursor);
@@ -690,9 +690,9 @@ rtr_page_get_father(
 that mtr holds an SX-latch or X-latch on the tree.
 @return	rec_get_offsets() of the node pointer record */
 static
-offset_t*
+rec_offs*
 rtr_page_get_father_node_ptr(
-	offset_t*	offsets,/*!< in: work area for the return value */
+	rec_offs*	offsets,/*!< in: work area for the return value */
 	mem_heap_t*	heap,	/*!< in: memory heap to use */
 	btr_cur_t*	sea_cur,/*!< in: search cursor */
 	btr_cur_t*	cursor,	/*!< in: cursor pointing to user record,
@@ -785,10 +785,10 @@ rtr_page_get_father_node_ptr(
 Returns the father block to a page. It is assumed that mtr holds
 an X or SX latch on the tree.
 @return rec_get_offsets() of the node pointer record */
-offset_t*
+rec_offs*
 rtr_page_get_father_block(
 /*======================*/
-	offset_t*	offsets,/*!< in: work area for the return value */
+	rec_offs*	offsets,/*!< in: work area for the return value */
 	mem_heap_t*	heap,	/*!< in: memory heap to use */
 	dict_index_t*	index,	/*!< in: b-tree index */
 	buf_block_t*	block,	/*!< in: child page in the index */
@@ -1303,8 +1303,8 @@ rtr_cur_restore_position(
 #ifdef UNIV_DEBUG
 		do {
 			const rec_t*	rec;
-			const offset_t*	offsets1;
-			const offset_t*	offsets2;
+			const rec_offs*	offsets1;
+			const rec_offs*	offsets2;
 			ulint		comp;
 
 			rec = btr_pcur_get_rec(r_cursor);
@@ -1377,8 +1377,8 @@ search_again:
 
 	if (low_match == r_cursor->old_n_fields) {
 		const rec_t*	rec;
-		const offset_t*	offsets1;
-		const offset_t*	offsets2;
+		const rec_offs*	offsets1;
+		const rec_offs*	offsets2;
 		ulint		comp;
 
 		rec = btr_pcur_get_rec(r_cursor);
@@ -1424,7 +1424,7 @@ rtr_leaf_push_match_rec(
 /*====================*/
 	const rec_t*	rec,		/*!< in: record to copy */
 	rtr_info_t*	rtr_info,	/*!< in/out: search stack */
-	offset_t*	offsets,	/*!< in: offsets */
+	rec_offs*	offsets,	/*!< in: offsets */
 	bool		is_comp)	/*!< in: is compact format */
 {
 	byte*		buf;
@@ -1610,7 +1610,7 @@ void
 rtr_get_mbr_from_rec(
 /*=================*/
 	const rec_t*	rec,	/*!< in: data tuple */
-	const offset_t*	offsets,/*!< in: offsets array */
+	const rec_offs*	offsets,/*!< in: offsets array */
 	rtr_mbr_t*	mbr)	/*!< out MBR */
 {
 	ulint		rec_f_len;
@@ -1657,8 +1657,8 @@ rtr_cur_search_with_match(
 	const page_t*	page;
 	const rec_t*	rec;
 	const rec_t*	last_rec;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	mem_heap_t*	heap = NULL;
 	int		cmp = 1;
 	double		least_inc = DBL_MAX;
@@ -1941,8 +1941,8 @@ rtr_cur_search_with_match(
 
 			test_rec = match_rec->matched_recs->back();
 #ifdef UNIV_DEBUG
-			offset_t	offsets_2[REC_OFFS_NORMAL_SIZE];
-			offset_t*	offsets2	= offsets_2;
+			rec_offs	offsets_2[REC_OFFS_NORMAL_SIZE];
+			rec_offs*	offsets2	= offsets_2;
 			rec_offs_init(offsets_2);
 
 			ut_ad(found);

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1805,7 +1805,7 @@ innobase_rec_to_mysql(
 	struct TABLE*		table,	/*!< in/out: MySQL table */
 	const rec_t*		rec,	/*!< in: record */
 	const dict_index_t*	index,	/*!< in: index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(
 					rec, index, ...) */
 {
 	uint	n_fields	= table->s->fields;

--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -3321,7 +3321,7 @@ ibuf_insert_low(
 	dtuple_t*	ibuf_entry;
 	mem_heap_t*	offsets_heap	= NULL;
 	mem_heap_t*	heap;
-	offset_t*	offsets		= NULL;
+	rec_offs*	offsets		= NULL;
 	ulint		buffered;
 	lint		min_n_recs;
 	rec_t*		ins_rec;
@@ -3786,7 +3786,7 @@ ibuf_insert_to_index_page_low(
 	buf_block_t*	block,	/*!< in/out: index page where the buffered
 				entry should be placed */
 	dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t*	heap,	/*!< in/out: memory heap */
 	mtr_t*		mtr,	/*!< in/out: mtr */
 	page_cur_t*	page_cur)/*!< in/out: cursor positioned on the record
@@ -3866,7 +3866,7 @@ ibuf_insert_to_index_page(
 	ulint		low_match;
 	page_t*		page		= buf_block_get_frame(block);
 	rec_t*		rec;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	mem_heap_t*	heap;
 
 	DBUG_ENTER("ibuf_insert_to_index_page");
@@ -4123,8 +4123,8 @@ ibuf_delete(
 		/* TODO: the below should probably be a separate function,
 		it's a bastardized version of btr_cur_optimistic_delete. */
 
-		offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-		offset_t*	offsets	= offsets_;
+		rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+		rec_offs*	offsets	= offsets_;
 		mem_heap_t*	heap = NULL;
 		ulint		max_ins_size = 0;
 

--- a/storage/innobase/include/btr0btr.h
+++ b/storage/innobase/include/btr0btr.h
@@ -306,7 +306,7 @@ ulint
 btr_node_ptr_get_child_page_no(
 /*===========================*/
 	const rec_t*	rec,	/*!< in: node pointer record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 	MY_ATTRIBUTE((warn_unused_result));
 
 /** Create the root node for a new index tree.
@@ -393,7 +393,7 @@ btr_root_raise_and_insert(
 				on the root page; when the function returns,
 				the cursor is positioned on the predecessor
 				of the inserted record */
-	offset_t**	offsets,/*!< out: offsets on inserted record */
+	rec_offs**	offsets,/*!< out: offsets on inserted record */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap
 				that can be emptied, or NULL */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */
@@ -476,7 +476,7 @@ btr_page_split_and_insert(
 	btr_cur_t*	cursor,	/*!< in: cursor at which to insert; when the
 				function returns, the cursor is positioned
 				on the predecessor of the inserted record */
-	offset_t**	offsets,/*!< out: offsets on inserted record */
+	rec_offs**	offsets,/*!< out: offsets on inserted record */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap
 				that can be emptied, or NULL */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */

--- a/storage/innobase/include/btr0btr.ic
+++ b/storage/innobase/include/btr0btr.ic
@@ -218,7 +218,7 @@ ulint
 btr_node_ptr_get_child_page_no(
 /*===========================*/
 	const rec_t*	rec,	/*!< in: node pointer record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	const byte*	field;
 	ulint		len;

--- a/storage/innobase/include/btr0bulk.h
+++ b/storage/innobase/include/btr0bulk.h
@@ -104,7 +104,7 @@ public:
 	/** Insert a record in the page.
 	@param[in]	rec		record
 	@param[in]	offsets		record offsets */
-	void insert(const rec_t* rec, offset_t* offsets);
+	void insert(const rec_t* rec, rec_offs* offsets);
 
 	/** Mark end of insertion to the page. Scan all records to set page
 	dirs, and set page header members. */
@@ -128,7 +128,7 @@ public:
 	@param[in]	big_rec		external recrod
 	@param[in]	offsets		record offsets
 	@return	error code */
-	dberr_t storeExt(const big_rec_t* big_rec, offset_t* offsets);
+	dberr_t storeExt(const big_rec_t* big_rec, rec_offs* offsets);
 
 	/** Get node pointer
 	@return node pointer */

--- a/storage/innobase/include/btr0cur.h
+++ b/storage/innobase/include/btr0cur.h
@@ -243,7 +243,7 @@ btr_cur_optimistic_insert(
 				specified */
 	btr_cur_t*	cursor,	/*!< in: cursor on page after which to insert;
 				cursor stays valid */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap */
 	dtuple_t*	entry,	/*!< in/out: entry to insert */
 	rec_t**		rec,	/*!< out: pointer to inserted record if
@@ -279,7 +279,7 @@ btr_cur_pessimistic_insert(
 				insertion will certainly succeed */
 	btr_cur_t*	cursor,	/*!< in: cursor after which to insert;
 				cursor stays valid */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap
 				that can be emptied */
 	dtuple_t*	entry,	/*!< in/out: entry to insert */
@@ -313,7 +313,7 @@ btr_cur_update_alloc_zip_func(
 	page_cur_t*	cursor,	/*!< in/out: B-tree page cursor */
 	dict_index_t*	index,	/*!< in: the index corresponding to cursor */
 #ifdef UNIV_DEBUG
-	offset_t*	offsets,/*!< in/out: offsets of the cursor record */
+	rec_offs*	offsets,/*!< in/out: offsets of the cursor record */
 #endif /* UNIV_DEBUG */
 	ulint		length,	/*!< in: size needed */
 	bool		create,	/*!< in: true=delete-and-insert,
@@ -340,7 +340,7 @@ btr_cur_update_in_place(
 	btr_cur_t*	cursor,	/*!< in: cursor on the record to update;
 				cursor stays valid and positioned on the
 				same record */
-	offset_t*	offsets,/*!< in/out: offsets on cursor->page_cur.rec */
+	rec_offs*	offsets,/*!< in/out: offsets on cursor->page_cur.rec */
 	const upd_t*	update,	/*!< in: update vector */
 	ulint		cmpl_info,/*!< in: compiler info on secondary index
 				updates */
@@ -382,7 +382,7 @@ btr_cur_optimistic_update(
 	btr_cur_t*	cursor,	/*!< in: cursor on the record to update;
 				cursor stays valid and positioned on the
 				same record */
-	offset_t**	offsets,/*!< out: offsets on cursor->page_cur.rec */
+	rec_offs**	offsets,/*!< out: offsets on cursor->page_cur.rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to NULL or memory heap */
 	const upd_t*	update,	/*!< in: update vector; this must also
 				contain trx id and roll ptr fields */
@@ -409,7 +409,7 @@ btr_cur_pessimistic_update(
 	btr_cur_t*	cursor,	/*!< in/out: cursor on the record to update;
 				cursor may become invalid if *big_rec == NULL
 				|| !(flags & BTR_KEEP_POS_FLAG) */
-	offset_t**	offsets,/*!< out: offsets on cursor->page_cur.rec */
+	rec_offs**	offsets,/*!< out: offsets on cursor->page_cur.rec */
 	mem_heap_t**	offsets_heap,
 				/*!< in/out: pointer to memory heap
 				that can be emptied */
@@ -441,7 +441,7 @@ btr_cur_del_mark_set_clust_rec(
 	buf_block_t*	block,	/*!< in/out: buffer block of the record */
 	rec_t*		rec,	/*!< in/out: record */
 	dict_index_t*	index,	/*!< in: clustered index of the record */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec) */
 	que_thr_t*	thr,	/*!< in: query thread */
 	const dtuple_t*	entry,	/*!< in: dtuple for the deleting record */
 	mtr_t*		mtr)	/*!< in/out: mini-transaction */
@@ -608,7 +608,7 @@ btr_estimate_number_of_different_key_vals(
 ulint
 btr_rec_get_externally_stored_len(
 	const rec_t*	rec,
-	const offset_t*	offsets);
+	const rec_offs*	offsets);
 
 /*******************************************************************//**
 Marks non-updated off-page fields as disowned by this record. The ownership
@@ -622,7 +622,7 @@ btr_cur_disown_inherited_fields(
 				part will be updated, or NULL */
 	rec_t*		rec,	/*!< in/out: record in a clustered index */
 	dict_index_t*	index,	/*!< in: index of the page */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	const upd_t*	update,	/*!< in: update vector */
 	mtr_t*		mtr)	/*!< in/out: mini-transaction */
 	MY_ATTRIBUTE((nonnull(2,3,4,5,6)));
@@ -661,7 +661,7 @@ btr_store_big_rec_extern_fields(
 	btr_pcur_t*	pcur,		/*!< in/out: a persistent cursor. if
 					btr_mtr is restarted, then this can
 					be repositioned. */
-	offset_t*	offsets,	/*!< in/out: rec_get_offsets() on
+	rec_offs*	offsets,	/*!< in/out: rec_get_offsets() on
 					pcur. the "external storage" flags
 					in offsets will correctly correspond
 					to rec when this function returns */
@@ -692,7 +692,7 @@ btr_free_externally_stored_field(
 	byte*		field_ref,	/*!< in/out: field reference */
 	const rec_t*	rec,		/*!< in: record containing field_ref, for
 					page_zip_write_blob_ptr(), or NULL */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec, index),
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec, index),
 					or NULL */
 	page_zip_des_t*	page_zip,	/*!< in: compressed page corresponding
 					to rec, or NULL if rec == NULL */
@@ -749,7 +749,7 @@ protected by a lock or a page latch
 byte*
 btr_rec_copy_externally_stored_field(
 	const rec_t*		rec,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	const page_size_t&	page_size,
 	ulint			no,
 	ulint*			len,

--- a/storage/innobase/include/gis0rtree.h
+++ b/storage/innobase/include/gis0rtree.h
@@ -91,7 +91,7 @@ rtr_page_split_and_insert(
 	btr_cur_t*	cursor,	/*!< in/out: cursor at which to insert; when the
 				function returns, the cursor is positioned
 				on the predecessor of the inserted record */
-	offset_t**	offsets,/*!< out: offsets on inserted record */
+	rec_offs**	offsets,/*!< out: offsets on inserted record */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap, or NULL */
 	const dtuple_t*	tuple,	/*!< in: tuple to insert */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
@@ -153,7 +153,7 @@ rtr_rec_cal_increase(
 				dtuple in some of the common fields, or which
 				has an equal number or more fields than
 				dtuple */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	double*		area);	/*!< out: increased area */
 
 /****************************************************************//**
@@ -277,7 +277,7 @@ void
 rtr_get_mbr_from_rec(
 /*=================*/
 	const rec_t*	rec,	/*!< in: data tuple */
-	const offset_t*	offsets,/*!< in: offsets array */
+	const rec_offs*	offsets,/*!< in: offsets array */
 	rtr_mbr_t*	mbr);	/*!< out MBR */
 
 /****************************************************************//**
@@ -309,10 +309,10 @@ rtr_page_get_father(
 Returns the father block to a page. It is assumed that mtr holds
 an X or SX latch on the tree.
 @return rec_get_offsets() of the node pointer record */
-offset_t*
+rec_offs*
 rtr_page_get_father_block(
 /*======================*/
-	offset_t*	offsets,/*!< in: work area for the return value */
+	rec_offs*	offsets,/*!< in: work area for the return value */
 	mem_heap_t*	heap,	/*!< in: memory heap to use */
 	dict_index_t*	index,	/*!< in: b-tree index */
 	buf_block_t*	block,	/*!< in: child page in the index */
@@ -419,8 +419,8 @@ rtr_merge_and_update_mbr(
 /*=====================*/
 	btr_cur_t*		cursor,		/*!< in/out: cursor */
 	btr_cur_t*		cursor2,	/*!< in: the other cursor */
-	offset_t*		offsets,	/*!< in: rec offsets */
-	offset_t*		offsets2,	/*!< in: rec offsets */
+	rec_offs*		offsets,	/*!< in: rec offsets */
+	rec_offs*		offsets2,	/*!< in: rec offsets */
 	page_t*			child_page,	/*!< in: the child page. */
 	buf_block_t*		merge_block,	/*!< in: page to merge */
 	buf_block_t*		block,		/*!< in: page be merged */
@@ -445,8 +445,8 @@ rtr_merge_mbr_changed(
 /*==================*/
 	btr_cur_t*	cursor,		/*!< in: cursor */
 	btr_cur_t*	cursor2,	/*!< in: the other cursor */
-	offset_t*	offsets,	/*!< in: rec offsets */
-	offset_t*	offsets2,	/*!< in: rec offsets */
+	rec_offs*	offsets,	/*!< in: rec offsets */
+	rec_offs*	offsets2,	/*!< in: rec offsets */
 	rtr_mbr_t*	new_mbr,	/*!< out: MBR to update */
 	buf_block_t*	merge_block,	/*!< in: page to merge */
 	buf_block_t*	block,		/*!< in: page be merged */
@@ -460,7 +460,7 @@ bool
 rtr_update_mbr_field(
 /*=================*/
 	btr_cur_t*	cursor,		/*!< in: cursor pointed to rec.*/
-	offset_t*	offsets,	/*!< in: offsets on rec. */
+	rec_offs*	offsets,	/*!< in: offsets on rec. */
 	btr_cur_t*	cursor2,	/*!< in/out: cursor pointed to rec
 					that should be deleted.
 					this cursor is for btr_compress to

--- a/storage/innobase/include/gis0rtree.ic
+++ b/storage/innobase/include/gis0rtree.ic
@@ -40,7 +40,7 @@ rtr_page_cal_mbr(
 	rec_t*		rec;
 	byte*		field;
 	ulint		len;
-	offset_t*	offsets = NULL;
+	rec_offs*	offsets = NULL;
 	double		bmin, bmax;
 	double*		amin;
 	double*		amax;

--- a/storage/innobase/include/handler0alter.h
+++ b/storage/innobase/include/handler0alter.h
@@ -32,7 +32,7 @@ innobase_rec_to_mysql(
 	struct TABLE*		table,	/*!< in/out: MySQL table */
 	const rec_t*		rec,	/*!< in: record */
 	const dict_index_t*	index,	/*!< in: index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(
 					rec, index, ...) */
 	MY_ATTRIBUTE((nonnull));
 

--- a/storage/innobase/include/lock0lock.h
+++ b/storage/innobase/include/lock0lock.h
@@ -317,7 +317,7 @@ lock_clust_rec_modify_check_and_lock(
 	const rec_t*		rec,	/*!< in: record which should be
 					modified */
 	dict_index_t*		index,	/*!< in: clustered index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	que_thr_t*		thr)	/*!< in: query thread */
 	MY_ATTRIBUTE((warn_unused_result));
 /*********************************************************************//**
@@ -355,7 +355,7 @@ lock_sec_rec_read_check_and_lock(
 					be read or passed over by a
 					read cursor */
 	dict_index_t*		index,	/*!< in: secondary index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	lock_mode		mode,	/*!< in: mode of the lock which
 					the read cursor should set on
 					records: LOCK_S or LOCK_X; the
@@ -383,7 +383,7 @@ lock_clust_rec_read_check_and_lock(
 					be read or passed over by a
 					read cursor */
 	dict_index_t*		index,	/*!< in: clustered index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	lock_mode		mode,	/*!< in: mode of the lock which
 					the read cursor should set on
 					records: LOCK_S or LOCK_X; the
@@ -432,7 +432,7 @@ lock_clust_rec_cons_read_sees(
 	const rec_t*	rec,	/*!< in: user record which should be read or
 				passed over by a read cursor */
 	dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ReadView*	view);	/*!< in: consistent read view */
 /*********************************************************************//**
 Checks that a non-clustered index record is seen in a consistent read.
@@ -577,7 +577,7 @@ lock_report_trx_id_insanity(
 	trx_id_t	trx_id,		/*!< in: trx id */
 	const rec_t*	rec,		/*!< in: user record */
 	dict_index_t*	index,		/*!< in: index */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec, index) */
 	trx_id_t	max_trx_id);	/*!< in: trx_sys_get_max_trx_id() */
 /*********************************************************************//**
 Prints info of locks for all transactions.
@@ -803,7 +803,7 @@ lock_check_trx_id_sanity(
 	trx_id_t	trx_id,		/*!< in: trx id */
 	const rec_t*	rec,		/*!< in: user record */
 	dict_index_t*	index,		/*!< in: index */
-	const offset_t*	offsets)	/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets)	/*!< in: rec_get_offsets(rec, index) */
 	MY_ATTRIBUTE((warn_unused_result));
 /*******************************************************************//**
 Check if the transaction holds any locks on the sys tables

--- a/storage/innobase/include/lock0priv.h
+++ b/storage/innobase/include/lock0priv.h
@@ -469,7 +469,7 @@ lock_clust_rec_some_has_impl(
 /*=========================*/
 	const rec_t*		rec,	/*!< in: user record */
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 	MY_ATTRIBUTE((warn_unused_result));
 
 /*********************************************************************//**

--- a/storage/innobase/include/lock0priv.ic
+++ b/storage/innobase/include/lock0priv.ic
@@ -59,7 +59,7 @@ lock_clust_rec_some_has_impl(
 /*=========================*/
 	const rec_t*		rec,	/*!< in: user record */
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 {
 	ut_ad(dict_index_is_clust(index));
 	ut_ad(page_rec_is_user_rec(rec));

--- a/storage/innobase/include/page0cur.h
+++ b/storage/innobase/include/page0cur.h
@@ -152,7 +152,7 @@ page_cur_tuple_insert(
 	page_cur_t*	cursor,	/*!< in/out: a page cursor */
 	const dtuple_t*	tuple,	/*!< in: pointer to a data tuple */
 	dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap, or NULL */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
 	mtr_t*		mtr,	/*!< in: mini-transaction handle, or NULL */
@@ -179,7 +179,7 @@ page_cur_rec_insert(
 	page_cur_t*	cursor,	/*!< in/out: a page cursor */
 	const rec_t*	rec,	/*!< in: record to insert */
 	dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mtr_t*		mtr);	/*!< in: mini-transaction handle, or NULL */
 /***********************************************************//**
 Inserts a record next to page cursor on an uncompressed page.
@@ -193,7 +193,7 @@ page_cur_insert_rec_low(
 				which the new record is inserted */
 	dict_index_t*	index,	/*!< in: record descriptor */
 	const rec_t*	rec,	/*!< in: pointer to a physical record */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mtr_t*		mtr)	/*!< in: mini-transaction handle, or NULL */
 	MY_ATTRIBUTE((nonnull(1,2,3,4), warn_unused_result));
 
@@ -215,7 +215,7 @@ page_cur_insert_rec_zip(
 	page_cur_t*	cursor,	/*!< in/out: page cursor */
 	dict_index_t*	index,	/*!< in: record descriptor */
 	const rec_t*	rec,	/*!< in: pointer to a physical record */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mtr_t*		mtr)	/*!< in: mini-transaction handle, or NULL */
 	MY_ATTRIBUTE((nonnull(1,2,3,4), warn_unused_result));
 /*************************************************************//**
@@ -241,7 +241,7 @@ page_cur_delete_rec(
 /*================*/
 	page_cur_t*		cursor,	/*!< in/out: a page cursor */
 	const dict_index_t*	index,	/*!< in: record descriptor */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(
 					cursor->rec, index) */
 	mtr_t*			mtr);	/*!< in: mini-transaction handle */
 
@@ -389,14 +389,14 @@ page_delete_rec(
 	page_cur_t*		pcur,	/*!< in/out: page cursor on record
 					to delete */
 	page_zip_des_t*		page_zip,/*!< in: compressed page descriptor */
-	const offset_t*		offsets);/*!< in: offsets for record */
+	const rec_offs*		offsets);/*!< in: offsets for record */
 
 /** Index page cursor */
 
 struct page_cur_t{
 	const dict_index_t*	index;
 	rec_t*		rec;	/*!< pointer to a record on page */
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	buf_block_t*	block;	/*!< pointer to the block containing rec */
 };
 

--- a/storage/innobase/include/page0cur.ic
+++ b/storage/innobase/include/page0cur.ic
@@ -259,7 +259,7 @@ page_cur_tuple_insert(
 	page_cur_t*	cursor,	/*!< in/out: a page cursor */
 	const dtuple_t*	tuple,	/*!< in: pointer to a data tuple */
 	dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t**	offsets,/*!< out: offsets on *rec */
+	rec_offs**	offsets,/*!< out: offsets on *rec */
 	mem_heap_t**	heap,	/*!< in/out: pointer to memory heap, or NULL */
 	ulint		n_ext,	/*!< in: number of externally stored columns */
 	mtr_t*		mtr,	/*!< in: mini-transaction handle, or NULL */
@@ -315,7 +315,7 @@ page_cur_rec_insert(
 	page_cur_t*	cursor,	/*!< in/out: a page cursor */
 	const rec_t*	rec,	/*!< in: record to insert */
 	dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mtr_t*		mtr)	/*!< in: mini-transaction handle, or NULL */
 {
 	if (buf_block_get_page_zip(cursor->block)) {

--- a/storage/innobase/include/page0page.h
+++ b/storage/innobase/include/page0page.h
@@ -936,7 +936,7 @@ page_mem_free(
 	rec_t*			rec,	/*!< in: pointer to the (origin of)
 					record */
 	const dict_index_t*	index,	/*!< in: index of rec */
-	const offset_t*		offsets);/*!< in: array returned by
+	const rec_offs*		offsets);/*!< in: array returned by
 					 rec_get_offsets() */
 /**********************************************************//**
 Create an uncompressed B-tree index page.
@@ -1157,7 +1157,7 @@ void
 page_rec_print(
 /*===========*/
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets);/*!< in: record descriptor */
+	const rec_offs*	offsets);/*!< in: record descriptor */
 # ifdef UNIV_BTR_PRINT
 /***************************************************************//**
 This is used to print the contents of the directory for
@@ -1204,7 +1204,7 @@ ibool
 page_rec_validate(
 /*==============*/
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets);/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets);/*!< in: array returned by rec_get_offsets() */
 #ifdef UNIV_DEBUG
 /***************************************************************//**
 Checks that the first directory slot points to the infimum record and

--- a/storage/innobase/include/page0page.ic
+++ b/storage/innobase/include/page0page.ic
@@ -1025,7 +1025,7 @@ page_mem_free(
 	rec_t*			rec,		/*!< in: pointer to the
 						(origin of) record */
 	const dict_index_t*	index,		/*!< in: index of rec */
-	const offset_t*		offsets)	/*!< in: array returned by
+	const rec_offs*		offsets)	/*!< in: array returned by
 						rec_get_offsets() */
 {
 	rec_t*		free;

--- a/storage/innobase/include/page0types.h
+++ b/storage/innobase/include/page0types.h
@@ -185,7 +185,7 @@ page_zip_dir_delete(
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page */
 	byte*		rec,	/*!< in: deleted record */
 	dict_index_t*	index,	/*!< in: index of rec */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec) */
 	const byte*	free)	/*!< in: previous start of the free list */
 	MY_ATTRIBUTE((nonnull(1,2,3,4)));
 

--- a/storage/innobase/include/page0zip.h
+++ b/storage/innobase/include/page0zip.h
@@ -288,7 +288,7 @@ page_zip_write_rec(
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page */
 	const byte*	rec,	/*!< in: record being written */
 	dict_index_t*	index,	/*!< in: the index the record belongs to */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint		create)	/*!< in: nonzero=insert, zero=update */
 	MY_ATTRIBUTE((nonnull));
 
@@ -313,7 +313,7 @@ page_zip_write_blob_ptr(
 	const byte*	rec,	/*!< in/out: record whose data is being
 				written */
 	dict_index_t*	index,	/*!< in: index of the page */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint		n,	/*!< in: column index */
 	mtr_t*		mtr);	/*!< in: mini-transaction handle,
 				or NULL if no logging is needed */
@@ -347,7 +347,7 @@ page_zip_write_trx_id_and_roll_ptr(
 /*===============================*/
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page */
 	byte*		rec,	/*!< in/out: record */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint		trx_id_col,/*!< in: column number of TRX_ID in rec */
 	trx_id_t	trx_id,	/*!< in: transaction identifier */
 	roll_ptr_t	roll_ptr)/*!< in: roll_ptr */
@@ -395,7 +395,7 @@ page_zip_dir_delete(
 	page_zip_des_t*		page_zip,	/*!< in/out: compressed page */
 	byte*			rec,		/*!< in: deleted record */
 	const dict_index_t*	index,		/*!< in: index of rec */
-	const offset_t*		offsets,	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*		offsets,	/*!< in: rec_get_offsets(rec) */
 	const byte*		free)		/*!< in: previous start of
 						the free list */
 	MY_ATTRIBUTE((nonnull(1,2,3,4)));

--- a/storage/innobase/include/rem0cmp.h
+++ b/storage/innobase/include/rem0cmp.h
@@ -89,7 +89,7 @@ cmp_dtuple_rec_with_gis(
 /*====================*/
 	const dtuple_t*	dtuple,
 	const rec_t*	rec,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	page_cur_mode_t	mode)
 	MY_ATTRIBUTE((nonnull));
 
@@ -105,7 +105,7 @@ int
 cmp_dtuple_rec_with_gis_internal(
 	const dtuple_t*	dtuple,
 	const rec_t*	rec,
-	const offset_t*	offsets);
+	const rec_offs*	offsets);
 
 /** Compare a data tuple to a physical record.
 @param[in] dtuple data tuple
@@ -121,7 +121,7 @@ int
 cmp_dtuple_rec_with_match_low(
 	const dtuple_t*	dtuple,
 	const rec_t*	rec,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	ulint		n_cmp,
 	ulint*		matched_fields)
 	MY_ATTRIBUTE((nonnull));
@@ -145,7 +145,7 @@ cmp_dtuple_rec_with_match_bytes(
 	const dtuple_t*		dtuple,
 	const rec_t*		rec,
 	const dict_index_t*	index,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	ulint*			matched_fields,
 	ulint*			matched_bytes)
 	MY_ATTRIBUTE((warn_unused_result));
@@ -162,7 +162,7 @@ int
 cmp_dtuple_rec(
 	const dtuple_t*	dtuple,
 	const rec_t*	rec,
-	const offset_t*	offsets);
+	const rec_offs*	offsets);
 /**************************************************************//**
 Checks if a dtuple is a prefix of a record. The last field in dtuple
 is allowed to be a prefix of the corresponding field in the record.
@@ -172,7 +172,7 @@ cmp_dtuple_is_prefix_of_rec(
 /*========================*/
 	const dtuple_t*	dtuple,	/*!< in: data tuple */
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets);/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets);/*!< in: array returned by rec_get_offsets() */
 /** Compare two physical records that contain the same number of columns,
 none of which are stored externally.
 @retval positive if rec1 (including non-ordering columns) is greater than rec2
@@ -183,8 +183,8 @@ cmp_rec_rec_simple(
 /*===============*/
 	const rec_t*		rec1,	/*!< in: physical record */
 	const rec_t*		rec2,	/*!< in: physical record */
-	const offset_t*		offsets1,/*!< in: rec_get_offsets(rec1, ...) */
-	const offset_t*		offsets2,/*!< in: rec_get_offsets(rec2, ...) */
+	const rec_offs*		offsets1,/*!< in: rec_get_offsets(rec1, ...) */
+	const rec_offs*		offsets2,/*!< in: rec_get_offsets(rec2, ...) */
 	const dict_index_t*	index,	/*!< in: data dictionary index */
 	struct TABLE*		table)	/*!< in: MySQL table, for reporting
 					duplicate key value if applicable,
@@ -211,8 +211,8 @@ int
 cmp_rec_rec(
 	const rec_t*		rec1,
 	const rec_t*		rec2,
-	const offset_t*		offsets1,
-	const offset_t*		offsets2,
+	const rec_offs*		offsets1,
+	const rec_offs*		offsets2,
 	const dict_index_t*	index,
 	bool			nulls_unequal = false,
 	ulint*			matched_fields = NULL)

--- a/storage/innobase/include/rem0rec.ic
+++ b/storage/innobase/include/rem0rec.ic
@@ -883,7 +883,7 @@ value.
 @return offset of the start of the field, SQL null flag and extern
 storage flag ORed */
 UNIV_INLINE
-offset_t
+rec_offs
 rec_2_get_field_end_info(
 /*=====================*/
 	const rec_t*	rec,	/*!< in: record */
@@ -922,7 +922,7 @@ UNIV_INLINE
 ulint
 rec_offs_get_n_alloc(
 /*=================*/
-	const offset_t*	offsets)/*!< in: array for rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array for rec_get_offsets() */
 {
 	ulint	n_alloc;
 	ut_ad(offsets);
@@ -939,13 +939,13 @@ UNIV_INLINE
 void
 rec_offs_set_n_alloc(
 /*=================*/
-	offset_t*offsets,	/*!< out: array for rec_get_offsets(),
+	rec_offs*offsets,	/*!< out: array for rec_get_offsets(),
 				must be allocated */
 	ulint	n_alloc)	/*!< in: number of elements */
 {
 	ut_ad(n_alloc > REC_OFFS_HEADER_SIZE);
 	UNIV_MEM_ALLOC(offsets, n_alloc * sizeof *offsets);
-	offsets[0] = static_cast<offset_t>(n_alloc);
+	offsets[0] = static_cast<rec_offs>(n_alloc);
 }
 
 /**********************************************************//**
@@ -955,7 +955,7 @@ UNIV_INLINE
 ulint
 rec_offs_n_fields(
 /*==============*/
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint	n_fields;
 	ut_ad(offsets);
@@ -976,7 +976,7 @@ rec_offs_validate(
 /*==============*/
 	const rec_t*		rec,	/*!< in: record or NULL */
 	const dict_index_t*	index,	/*!< in: record descriptor or NULL */
-	const offset_t*		offsets)/*!< in: array returned by
+	const rec_offs*		offsets)/*!< in: array returned by
 					rec_get_offsets() */
 {
 	ulint	i	= rec_offs_n_fields(offsets);
@@ -1016,7 +1016,7 @@ rec_offs_validate(
 		ut_a(!index->n_def || i <= max_n_fields);
 	}
 	while (i--) {
-		offset_t curr = get_value(rec_offs_base(offsets)[1 + i]);
+		rec_offs curr = get_value(rec_offs_base(offsets)[1 + i]);
 		ut_a(curr <= last);
 		last = curr;
 	}
@@ -1032,7 +1032,7 @@ rec_offs_make_valid(
 /*================*/
 	const rec_t*		rec,	/*!< in: record */
 	const dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t*		offsets)/*!< in: array returned by
+	rec_offs*		offsets)/*!< in: array returned by
 					rec_get_offsets() */
 {
 	ut_ad(rec);
@@ -1049,18 +1049,18 @@ The following function is used to get an offset to the nth
 data field in a record.
 @return offset from the origin of rec */
 UNIV_INLINE
-offset_t
+rec_offs
 rec_get_nth_field_offs(
 /*===================*/
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		n,	/*!< in: index of the field */
 	ulint*		len)	/*!< out: length of the field; UNIV_SQL_NULL
 				if SQL null */
 {
 	ut_ad(n < rec_offs_n_fields(offsets));
 
-	offset_t offs = n == 0 ? 0 : get_value(rec_offs_base(offsets)[n]);
-	offset_t next_offs = rec_offs_base(offsets)[1 + n];
+	rec_offs offs = n == 0 ? 0 : get_value(rec_offs_base(offsets)[n]);
+	rec_offs next_offs = rec_offs_base(offsets)[1 + n];
 
 	if (get_type(next_offs) == SQL_NULL) {
 		*len = UNIV_SQL_NULL;
@@ -1080,7 +1080,7 @@ UNIV_INLINE
 ulint
 rec_offs_comp(
 /*==========*/
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ut_ad(rec_offs_validate(NULL, NULL, offsets));
 	return(*rec_offs_base(offsets) & REC_OFFS_COMPACT);
@@ -1094,7 +1094,7 @@ UNIV_INLINE
 ulint
 rec_offs_any_extern(
 /*================*/
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ut_ad(rec_offs_validate(NULL, NULL, offsets));
 	return(*rec_offs_base(offsets) & REC_OFFS_EXTERNAL);
@@ -1108,7 +1108,7 @@ const byte*
 rec_offs_any_null_extern(
 /*=====================*/
 	const rec_t*	rec,		/*!< in: record */
-	const offset_t*	offsets)	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets)	/*!< in: rec_get_offsets(rec) */
 {
 	ulint	i;
 	ut_ad(rec_offs_validate(rec, NULL, offsets));
@@ -1143,7 +1143,7 @@ UNIV_INLINE
 ulint
 rec_offs_nth_extern(
 /*================*/
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		n)	/*!< in: nth field */
 {
 	ut_ad(rec_offs_validate(NULL, NULL, offsets));
@@ -1158,7 +1158,7 @@ UNIV_INLINE
 ulint
 rec_offs_nth_sql_null(
 /*==================*/
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		n)	/*!< in: nth field */
 {
 	ut_ad(rec_offs_validate(NULL, NULL, offsets));
@@ -1173,7 +1173,7 @@ UNIV_INLINE
 ulint
 rec_offs_nth_size(
 /*==============*/
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		n)	/*!< in: nth field */
 {
 	ut_ad(rec_offs_validate(NULL, NULL, offsets));
@@ -1192,7 +1192,7 @@ UNIV_INLINE
 ulint
 rec_offs_n_extern(
 /*==============*/
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint	n = 0;
 
@@ -1390,7 +1390,7 @@ void
 rec_set_nth_field(
 /*==============*/
 	rec_t*		rec,	/*!< in: record */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		n,	/*!< in: index number of the field */
 	const void*	data,	/*!< in: pointer to the data
 				if not SQL null */
@@ -1445,7 +1445,7 @@ UNIV_INLINE
 void
 rec_offs_set_n_fields(
 /*==================*/
-	offset_t*	offsets,	/*!< in/out: array returned by
+	rec_offs*	offsets,	/*!< in/out: array returned by
 				rec_get_offsets() */
 	ulint		n_fields)	/*!< in: number of fields */
 {
@@ -1454,7 +1454,7 @@ rec_offs_set_n_fields(
 	ut_ad(n_fields <= REC_MAX_N_FIELDS);
 	ut_ad(n_fields + REC_OFFS_HEADER_SIZE
 	      <= rec_offs_get_n_alloc(offsets));
-	offsets[1] = static_cast<offset_t>(n_fields);
+	offsets[1] = static_cast<rec_offs>(n_fields);
 }
 
 /**********************************************************//**
@@ -1467,7 +1467,7 @@ UNIV_INLINE
 ulint
 rec_offs_data_size(
 /*===============*/
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint	size;
 
@@ -1486,7 +1486,7 @@ UNIV_INLINE
 ulint
 rec_offs_extra_size(
 /*================*/
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint	size;
 	ut_ad(rec_offs_validate(NULL, NULL, offsets));
@@ -1502,7 +1502,7 @@ UNIV_INLINE
 ulint
 rec_offs_size(
 /*==========*/
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	return(rec_offs_data_size(offsets) + rec_offs_extra_size(offsets));
 }
@@ -1516,7 +1516,7 @@ byte*
 rec_get_end(
 /*========*/
 	const rec_t*	rec,	/*!< in: pointer to record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ut_ad(rec_offs_validate(rec, NULL, offsets));
 	return(const_cast<rec_t*>(rec + rec_offs_data_size(offsets)));
@@ -1530,7 +1530,7 @@ byte*
 rec_get_start(
 /*==========*/
 	const rec_t*	rec,	/*!< in: pointer to record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ut_ad(rec_offs_validate(rec, NULL, offsets));
 	return(const_cast<rec_t*>(rec - rec_offs_extra_size(offsets)));
@@ -1547,7 +1547,7 @@ rec_t*
 rec_copy(
 	void*		buf,
 	const rec_t*	rec,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	ulint	extra_len;
 	ulint	data_len;
@@ -1683,7 +1683,7 @@ UNIV_INLINE
 ulint
 rec_fold(
 	const rec_t*	rec,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	ulint		n_fields,
 	ulint		n_bytes,
 	index_id_t	tree_id)

--- a/storage/innobase/include/rem0types.h
+++ b/storage/innobase/include/rem0types.h
@@ -31,7 +31,7 @@ Created 5/30/1994 Heikki Tuuri
 typedef byte	rec_t;
 
 /** This type represents a field offset in a rec_t* */
-typedef unsigned short int offset_t;
+typedef unsigned short int rec_offs;
 
 /* Maximum values for various fields (for non-blob tuples) */
 #define REC_MAX_N_FIELDS	(1024 - 1)

--- a/storage/innobase/include/row0ftsort.h
+++ b/storage/innobase/include/row0ftsort.h
@@ -248,7 +248,7 @@ row_merge_fts_sel_propagate(
 	int*		sel_tree,	/*<! in: selection tree */
 	ulint		level,		/*<! in: selection tree level */
 	const mrec_t**	 mrec,		/*<! in: sort record */
-	offset_t**	offsets,	/*<! in: record offsets */
+	rec_offs**	offsets,	/*<! in: record offsets */
 	dict_index_t*	index);		/*<! in: FTS index */
 /********************************************************************//**
 Read sorted file containing index data tuples and insert these data

--- a/storage/innobase/include/row0log.h
+++ b/storage/innobase/include/row0log.h
@@ -132,7 +132,7 @@ row_log_table_delete(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec,index) */
 	const byte*	sys)	/*!< in: DB_TRX_ID,DB_ROLL_PTR that should
 				be logged, or NULL to use those in rec */
 	ATTRIBUTE_COLD __attribute__((nonnull(1,2,3)));
@@ -147,7 +147,7 @@ row_log_table_update(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec,index) */
 	const dtuple_t*	old_pk);/*!< in: row_log_table_get_pk()
 				before the update */
 
@@ -163,7 +163,7 @@ row_log_table_get_pk(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec,index),
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec,index),
 				or NULL */
 	byte*		sys,	/*!< out: DB_TRX_ID,DB_ROLL_PTR for
 				row_log_table_delete(), or NULL */
@@ -180,7 +180,7 @@ row_log_table_insert(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets);/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets);/*!< in: rec_get_offsets(rec,index) */
 /******************************************************//**
 Notes that a BLOB is being freed during online ALTER TABLE. */
 void

--- a/storage/innobase/include/row0merge.h
+++ b/storage/innobase/include/row0merge.h
@@ -477,7 +477,7 @@ row_merge_read_rec(
 	const mrec_t**		mrec,	/*!< out: pointer to merge record,
 					or NULL on end of list
 					(non-NULL on I/O error) */
-	offset_t*		offsets,/*!< out: offsets of mrec */
+	rec_offs*		offsets,/*!< out: offsets of mrec */
 	row_merge_block_t*	crypt_block, /*!< in: crypt buf or NULL */
 	ulint			space)	   /*!< in: space id */
 	MY_ATTRIBUTE((warn_unused_result));

--- a/storage/innobase/include/row0row.h
+++ b/storage/innobase/include/row0row.h
@@ -44,7 +44,7 @@ ulint
 row_get_trx_id_offset(
 /*==================*/
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: record offsets */
+	const rec_offs*		offsets)/*!< in: record offsets */
 	MY_ATTRIBUTE((nonnull, warn_unused_result));
 /*********************************************************************//**
 Reads the trx id field from a clustered index record.
@@ -55,7 +55,7 @@ row_get_rec_trx_id(
 /*===============*/
 	const rec_t*		rec,	/*!< in: record */
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 	MY_ATTRIBUTE((nonnull, warn_unused_result));
 /*********************************************************************//**
 Reads the roll pointer field from a clustered index record.
@@ -66,7 +66,7 @@ row_get_rec_roll_ptr(
 /*=================*/
 	const rec_t*		rec,	/*!< in: record */
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 	MY_ATTRIBUTE((nonnull, warn_unused_result));
 
 /* Flags for row build type. */
@@ -138,7 +138,7 @@ row_build(
 					this record must be at least
 					s-latched and the latch held
 					as long as the row dtuple is used! */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec,index)
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec,index)
 					or NULL, in which case this function
 					will invoke rec_get_offsets() */
 	const dict_table_t*	col_table,
@@ -189,7 +189,7 @@ row_build_w_add_vcol(
 	ulint			type,
 	const dict_index_t*	index,
 	const rec_t*		rec,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	const dict_table_t*	col_table,
 	const dtuple_t*		add_cols,
 	const dict_add_v_col_t*	add_v,
@@ -206,7 +206,7 @@ row_rec_to_index_entry_low(
 /*=======================*/
 	const rec_t*		rec,	/*!< in: record in the index */
 	const dict_index_t*	index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	mem_heap_t*		heap)	/*!< in: memory heap from which
 					the memory needed is allocated */
 	MY_ATTRIBUTE((warn_unused_result));
@@ -219,7 +219,7 @@ row_rec_to_index_entry(
 /*===================*/
 	const rec_t*		rec,	/*!< in: record in the index */
 	const dict_index_t*	index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in/out: rec_get_offsets(rec) */
+	const rec_offs*		offsets,/*!< in/out: rec_get_offsets(rec) */
 	mem_heap_t*		heap)	/*!< in: memory heap from which
 					the memory needed is allocated */
 	MY_ATTRIBUTE((warn_unused_result));
@@ -262,7 +262,7 @@ row_build_row_ref_in_tuple(
 					held as long as the row
 					reference is used! */
 	const dict_index_t*	index,	/*!< in: secondary index */
-	offset_t*		offsets,/*!< in: rec_get_offsets(rec, index)
+	rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index)
 					or NULL */
 	trx_t*			trx)	/*!< in: transaction or NULL */
 	MY_ATTRIBUTE((nonnull(1,2,3)));
@@ -281,7 +281,7 @@ row_build_row_ref_fast(
 	const rec_t*	rec,	/*!< in: record in the index; must be
 				preserved while ref is used, as we do
 				not copy field values to heap */
-	const offset_t*	offsets);/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets);/*!< in: array returned by rec_get_offsets() */
 /***************************************************************//**
 Searches the clustered index record for a row, if we have the row
 reference.

--- a/storage/innobase/include/row0row.ic
+++ b/storage/innobase/include/row0row.ic
@@ -36,7 +36,7 @@ ulint
 row_get_trx_id_offset(
 /*==================*/
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: record offsets */
+	const rec_offs*		offsets)/*!< in: record offsets */
 {
 	ulint	pos;
 	ulint	offset;
@@ -63,7 +63,7 @@ row_get_rec_trx_id(
 /*===============*/
 	const rec_t*		rec,	/*!< in: record */
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 {
 	ulint	offset;
 
@@ -88,7 +88,7 @@ row_get_rec_roll_ptr(
 /*=================*/
 	const rec_t*		rec,	/*!< in: record */
 	const dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 {
 	ulint	offset;
 
@@ -147,7 +147,7 @@ row_build_row_ref_fast(
 	const rec_t*	rec,	/*!< in: record in the index; must be
 				preserved while ref is used, as we do
 				not copy field values to heap */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	dfield_t*	dfield;
 	const byte*	field;

--- a/storage/innobase/include/row0upd.h
+++ b/storage/innobase/include/row0upd.h
@@ -124,7 +124,7 @@ row_upd_rec_sys_fields(
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page whose
 				uncompressed part will be updated, or NULL */
 	dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const trx_t*	trx,	/*!< in: transaction */
 	roll_ptr_t	roll_ptr);/*!< in: DB_ROLL_PTR to the undo log */
 /*********************************************************************//**
@@ -166,7 +166,7 @@ ibool
 row_upd_changes_field_size_or_external(
 /*===================================*/
 	dict_index_t*	index,	/*!< in: index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const upd_t*	update);/*!< in: update vector */
 /***********************************************************//**
 Returns true if row update contains disowned external fields.
@@ -187,7 +187,7 @@ row_upd_rec_in_place(
 /*=================*/
 	rec_t*		rec,	/*!< in/out: record where replaced */
 	dict_index_t*	index,	/*!< in: the index the record belongs to */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	const upd_t*	update,	/*!< in: update vector */
 	page_zip_des_t*	page_zip);/*!< in: compressed page with enough space
 				available, or NULL */
@@ -202,7 +202,7 @@ row_upd_build_sec_rec_difference_binary(
 /*====================================*/
 	const rec_t*	rec,	/*!< in: secondary index record */
 	dict_index_t*	index,	/*!< in: index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const dtuple_t*	entry,	/*!< in: entry to insert */
 	mem_heap_t*	heap)	/*!< in: memory heap from which allocated */
 	MY_ATTRIBUTE((warn_unused_result, nonnull));
@@ -228,7 +228,7 @@ row_upd_build_difference_binary(
 	dict_index_t*	index,
 	const dtuple_t*	entry,
 	const rec_t*	rec,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	bool		no_sys,
 	trx_t*		trx,
 	mem_heap_t*	heap,
@@ -398,7 +398,7 @@ row_upd_rec_sys_fields_in_recovery(
 /*===============================*/
 	rec_t*		rec,	/*!< in/out: record */
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page, or NULL */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		pos,	/*!< in: TRX_ID position in rec */
 	trx_id_t	trx_id,	/*!< in: transaction id */
 	roll_ptr_t	roll_ptr);/*!< in: roll ptr of the undo log record */

--- a/storage/innobase/include/row0upd.ic
+++ b/storage/innobase/include/row0upd.ic
@@ -163,7 +163,7 @@ row_upd_rec_sys_fields(
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page whose
 				uncompressed part will be updated, or NULL */
 	dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const trx_t*	trx,	/*!< in: transaction */
 	roll_ptr_t	roll_ptr)/*!< in: DB_ROLL_PTR to the undo log */
 {

--- a/storage/innobase/include/row0vers.h
+++ b/storage/innobase/include/row0vers.h
@@ -50,7 +50,7 @@ trx_t*
 row_vers_impl_x_locked(
 	const rec_t*	rec,
 	dict_index_t*	index,
-	const offset_t*	offsets);
+	const rec_offs*	offsets);
 
 /*****************************************************************//**
 Finds out if we must preserve a delete marked earlier version of a clustered
@@ -112,7 +112,7 @@ row_vers_build_for_consistent_read(
 	mtr_t*		mtr,	/*!< in: mtr holding the latch on rec; it will
 				also hold the latch on purge_view */
 	dict_index_t*	index,	/*!< in: the clustered index */
-	offset_t**	offsets,/*!< in/out: offsets returned by
+	rec_offs**	offsets,/*!< in/out: offsets returned by
 				rec_get_offsets(rec, index) */
 	ReadView*	view,	/*!< in: the consistent read view */
 	mem_heap_t**	offset_heap,/*!< in/out: memory heap from which
@@ -139,7 +139,7 @@ row_vers_build_for_semi_consistent_read(
 				of this records */
 	mtr_t*		mtr,	/*!< in: mtr holding the latch on rec */
 	dict_index_t*	index,	/*!< in: the clustered index */
-	offset_t**	offsets,/*!< in/out: offsets returned by
+	rec_offs**	offsets,/*!< in/out: offsets returned by
 				rec_get_offsets(rec, index) */
 	mem_heap_t**	offset_heap,/*!< in/out: memory heap from which
 				the offsets are allocated */

--- a/storage/innobase/include/trx0rec.h
+++ b/storage/innobase/include/trx0rec.h
@@ -207,7 +207,7 @@ trx_undo_report_row_operation(
 	const rec_t*	rec,		/*!< in: case of an update or delete
 					marking, the record in the clustered
 					index; NULL if insert */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec) */
 	roll_ptr_t*	roll_ptr)	/*!< out: DB_ROLL_PTR to the
 					undo log record */
 	MY_ATTRIBUTE((nonnull(1,2,8), warn_unused_result));
@@ -240,7 +240,7 @@ trx_undo_prev_version_build(
 				index_rec page and purge_view */
 	const rec_t*	rec,	/*!< in: version of a clustered index record */
 	dict_index_t*	index,	/*!< in: clustered index */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mem_heap_t*	heap,	/*!< in: memory heap from which the memory
 				needed is allocated */
 	rec_t**		old_vers,/*!< out, own: previous version, or NULL if

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -326,7 +326,7 @@ lock_report_trx_id_insanity(
 	trx_id_t	trx_id,		/*!< in: trx id */
 	const rec_t*	rec,		/*!< in: user record */
 	dict_index_t*	index,		/*!< in: index */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec, index) */
 	trx_id_t	max_trx_id)	/*!< in: trx_sys_get_max_trx_id() */
 {
 	ib::error()
@@ -352,7 +352,7 @@ lock_check_trx_id_sanity(
 	trx_id_t	trx_id,		/*!< in: trx id */
 	const rec_t*	rec,		/*!< in: user record */
 	dict_index_t*	index,		/*!< in: index */
-	const offset_t*	offsets)	/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets)	/*!< in: rec_get_offsets(rec, index) */
 {
 	ut_ad(rec_offs_validate(rec, index, offsets));
 
@@ -377,7 +377,7 @@ lock_clust_rec_cons_read_sees(
 	const rec_t*	rec,	/*!< in: user record which should be read or
 				passed over by a read cursor */
 	dict_index_t*	index,	/*!< in: clustered index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ReadView*	view)	/*!< in: consistent read view */
 {
 	ut_ad(dict_index_is_clust(index));
@@ -1214,7 +1214,7 @@ lock_sec_rec_some_has_impl(
 /*=======================*/
 	const rec_t*	rec,	/*!< in: user record */
 	dict_index_t*	index,	/*!< in: secondary index */
-	const offset_t*	offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets)/*!< in: rec_get_offsets(rec, index) */
 {
 	trx_t*		trx;
 	trx_id_t	max_trx_id;
@@ -4793,8 +4793,8 @@ static void lock_rec_print(FILE* file, const lock_t* lock, mtr_t& mtr)
 	putc('\n', file);
 
 	mem_heap_t*		heap		= NULL;
-	offset_t		offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*		offsets		= offsets_;
+	rec_offs		offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*		offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	mtr.start();
@@ -5187,7 +5187,7 @@ lock_rec_queue_validate(
 	const buf_block_t*	block,	/*!< in: buffer block containing rec */
 	const rec_t*		rec,	/*!< in: record to look at */
 	const dict_index_t*	index,	/*!< in: index, or NULL if not known */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 {
 	const lock_t*	lock;
 	ulint		heap_no;
@@ -5352,8 +5352,8 @@ lock_rec_validate_page(
 	ulint		nth_bit		= 0;
 	ulint		i;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(!lock_mutex_own());
@@ -5738,8 +5738,8 @@ lock_rec_insert_check_and_lock(
 #ifdef UNIV_DEBUG
 	{
 		mem_heap_t*	heap		= NULL;
-		offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-		const offset_t*	offsets;
+		rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+		const rec_offs*	offsets;
 		rec_offs_init(offsets_);
 
 		offsets = rec_get_offsets(next_rec, index, offsets_, true,
@@ -5804,7 +5804,7 @@ lock_rec_convert_impl_to_expl(
 	const buf_block_t*	block,	/*!< in: buffer block of rec */
 	const rec_t*		rec,	/*!< in: user record on page */
 	dict_index_t*		index,	/*!< in: index of record */
-	const offset_t*		offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets)/*!< in: rec_get_offsets(rec, index) */
 {
 	trx_t*		trx;
 
@@ -5859,7 +5859,7 @@ lock_clust_rec_modify_check_and_lock(
 	const rec_t*		rec,	/*!< in: record which should be
 					modified */
 	dict_index_t*		index,	/*!< in: clustered index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	que_thr_t*		thr)	/*!< in: query thread */
 {
 	dberr_t	err;
@@ -5959,8 +5959,8 @@ lock_sec_rec_modify_check_and_lock(
 #ifdef UNIV_DEBUG
 	{
 		mem_heap_t*	heap		= NULL;
-		offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-		const offset_t*	offsets;
+		rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+		const rec_offs*	offsets;
 		rec_offs_init(offsets_);
 
 		offsets = rec_get_offsets(rec, index, offsets_, true,
@@ -6004,7 +6004,7 @@ lock_sec_rec_read_check_and_lock(
 					be read or passed over by a
 					read cursor */
 	dict_index_t*		index,	/*!< in: secondary index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	lock_mode		mode,	/*!< in: mode of the lock which
 					the read cursor should set on
 					records: LOCK_S or LOCK_X; the
@@ -6082,7 +6082,7 @@ lock_clust_rec_read_check_and_lock(
 					be read or passed over by a
 					read cursor */
 	dict_index_t*		index,	/*!< in: clustered index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	lock_mode		mode,	/*!< in: mode of the lock which
 					the read cursor should set on
 					records: LOCK_S or LOCK_X; the
@@ -6166,8 +6166,8 @@ lock_clust_rec_read_check_and_lock_alt(
 	que_thr_t*		thr)	/*!< in: query thread */
 {
 	mem_heap_t*	tmp_heap	= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	dberr_t		err;
 	rec_offs_init(offsets_);
 

--- a/storage/innobase/page/page0cur.cc
+++ b/storage/innobase/page/page0cur.cc
@@ -67,8 +67,8 @@ page_cur_try_search_shortcut(
 	ibool		success		= FALSE;
 	const page_t*	page		= buf_block_get_frame(block);
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(dtuple_check_typed(tuple));
@@ -151,8 +151,8 @@ page_cur_try_search_shortcut_bytes(
 	ibool		success		= FALSE;
 	const page_t*	page		= buf_block_get_frame(block);
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(dtuple_check_typed(tuple));
@@ -223,7 +223,7 @@ page_cur_rec_field_extends(
 /*=======================*/
 	const dtuple_t*	tuple,	/*!< in: data tuple */
 	const rec_t*	rec,	/*!< in: record */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		n)	/*!< in: compare nth field */
 {
 	const dtype_t*	type;
@@ -299,8 +299,8 @@ page_cur_search_with_match(
 	const page_zip_des_t*	page_zip = buf_block_get_page_zip(block);
 #endif /* UNIV_ZIP_DEBUG */
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(dtuple_validate(tuple));
@@ -562,8 +562,8 @@ page_cur_search_with_match_bytes(
 	const page_zip_des_t*	page_zip = buf_block_get_page_zip(block);
 #endif /* UNIV_ZIP_DEBUG */
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(dtuple_validate(tuple));
@@ -832,11 +832,11 @@ page_cur_insert_rec_write_log(
 
 	{
 		mem_heap_t*	heap		= NULL;
-		offset_t	cur_offs_[REC_OFFS_NORMAL_SIZE];
-		offset_t	ins_offs_[REC_OFFS_NORMAL_SIZE];
+		rec_offs	cur_offs_[REC_OFFS_NORMAL_SIZE];
+		rec_offs	ins_offs_[REC_OFFS_NORMAL_SIZE];
 
-		offset_t*	cur_offs;
-		offset_t*	ins_offs;
+		rec_offs*	cur_offs;
+		rec_offs*	ins_offs;
 
 		rec_offs_init(cur_offs_);
 		rec_offs_init(ins_offs_);
@@ -1012,8 +1012,8 @@ page_cur_parse_insert_rec(
 	ulint		info_and_status_bits = 0; /* remove warning */
 	page_cur_t	cursor;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	page = block ? buf_block_get_frame(block) : NULL;
@@ -1188,7 +1188,7 @@ page_cur_insert_rec_low(
 				which the new record is inserted */
 	dict_index_t*	index,	/*!< in: record descriptor */
 	const rec_t*	rec,	/*!< in: pointer to a physical record */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mtr_t*		mtr)	/*!< in: mini-transaction handle, or NULL */
 {
 	byte*		insert_buf;
@@ -1239,8 +1239,8 @@ page_cur_insert_rec_low(
 	free_rec = page_header_get_ptr(page, PAGE_FREE);
 	if (UNIV_LIKELY_NULL(free_rec)) {
 		/* Try to allocate from the head of the free list. */
-		offset_t	foffsets_[REC_OFFS_NORMAL_SIZE];
-		offset_t*	foffsets	= foffsets_;
+		rec_offs	foffsets_[REC_OFFS_NORMAL_SIZE];
+		rec_offs*	foffsets	= foffsets_;
 		mem_heap_t*	heap		= NULL;
 
 		rec_offs_init(foffsets_);
@@ -1433,7 +1433,7 @@ page_cur_insert_rec_zip(
 	page_cur_t*	cursor,	/*!< in/out: page cursor */
 	dict_index_t*	index,	/*!< in: record descriptor */
 	const rec_t*	rec,	/*!< in: pointer to a physical record */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mtr_t*		mtr)	/*!< in: mini-transaction handle, or NULL */
 {
 	byte*		insert_buf;
@@ -1670,8 +1670,8 @@ page_cur_insert_rec_zip(
 	if (UNIV_LIKELY_NULL(free_rec)) {
 		/* Try to allocate from the head of the free list. */
 		lint	extra_size_diff;
-		offset_t	foffsets_[REC_OFFS_NORMAL_SIZE];
-		offset_t*	foffsets	= foffsets_;
+		rec_offs	foffsets_[REC_OFFS_NORMAL_SIZE];
+		rec_offs*	foffsets	= foffsets_;
 		mem_heap_t*	heap		= NULL;
 
 		rec_offs_init(foffsets_);
@@ -2002,8 +2002,8 @@ page_copy_rec_list_end_to_created_page(
 	byte*	log_ptr;
 	ulint	log_data_len;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(page_dir_get_n_heap(new_page) == PAGE_HEAP_NO_USER_LOW);
@@ -2224,7 +2224,7 @@ page_cur_parse_delete_rec(
 	if (block) {
 		page_t*		page		= buf_block_get_frame(block);
 		mem_heap_t*	heap		= NULL;
-		offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
+		rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
 		rec_t*		rec		= page + offset;
 		rec_offs_init(offsets_);
 
@@ -2252,7 +2252,7 @@ page_cur_delete_rec(
 /*================*/
 	page_cur_t*		cursor,	/*!< in/out: a page cursor */
 	const dict_index_t*	index,	/*!< in: record descriptor */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(
 					cursor->rec, index) */
 	mtr_t*			mtr)	/*!< in: mini-transaction handle
 					or NULL */

--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -583,8 +583,8 @@ page_copy_rec_list_end_no_locks(
 	page_cur_t	cur1;
 	rec_t*		cur2;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	page_cur_position(rec, block, &cur1);
@@ -815,8 +815,8 @@ page_copy_rec_list_start(
 	rtr_rec_move_t*	rec_move	= NULL;
 	rec_t*		ret
 		= page_rec_get_prev(page_get_supremum_rec(new_page));
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	/* Here, "ret" may be pointing to a user record or the
@@ -1050,8 +1050,8 @@ page_delete_rec_list_end(
 	page_zip_des_t*	page_zip	= buf_block_get_page_zip(block);
 	page_t*		page		= page_align(rec);
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(size == ULINT_UNDEFINED || size < UNIV_PAGE_SIZE);
@@ -1251,8 +1251,8 @@ page_delete_rec_list_start(
 	mtr_t*		mtr)	/*!< in: mtr */
 {
 	page_cur_t	cur1;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	mem_heap_t*	heap		= NULL;
 
 	rec_offs_init(offsets_);
@@ -1739,7 +1739,7 @@ void
 page_rec_print(
 /*===========*/
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets)/*!< in: record descriptor */
+	const rec_offs*	offsets)/*!< in: record descriptor */
 {
 	ut_a(!page_rec_is_comp(rec) == !rec_offs_comp(offsets));
 	rec_print_new(stderr, rec, offsets);
@@ -1814,8 +1814,8 @@ page_print_list(
 	ulint		count;
 	ulint		n_recs;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_a((ibool)!!page_is_comp(page) == dict_table_is_comp(index->table));
@@ -1925,7 +1925,7 @@ ibool
 page_rec_validate(
 /*==============*/
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint		n_owned;
 	ulint		heap_no;
@@ -2421,10 +2421,10 @@ page_validate(
 	ulint			n_slots;
 	ibool			ret		= FALSE;
 	ulint			i;
-	offset_t		offsets_1[REC_OFFS_NORMAL_SIZE];
-	offset_t		offsets_2[REC_OFFS_NORMAL_SIZE];
-	offset_t*		offsets		= offsets_1;
-	offset_t*		old_offsets	= offsets_2;
+	rec_offs		offsets_1[REC_OFFS_NORMAL_SIZE];
+	rec_offs		offsets_2[REC_OFFS_NORMAL_SIZE];
+	rec_offs*		offsets		= offsets_1;
+	rec_offs*		old_offsets	= offsets_2;
 
 	rec_offs_init(offsets_1);
 	rec_offs_init(offsets_2);
@@ -2815,7 +2815,7 @@ page_delete_rec(
 	page_cur_t*		pcur,	/*!< in/out: page cursor on record
 					to delete */
 	page_zip_des_t*		page_zip,/*!< in: compressed page descriptor */
-	const offset_t*		offsets)/*!< in: offsets for record */
+	const rec_offs*		offsets)/*!< in: offsets for record */
 {
 	bool		no_compress_needed;
 	buf_block_t*	block = pcur->block;

--- a/storage/innobase/page/page0zip.cc
+++ b/storage/innobase/page/page0zip.cc
@@ -878,7 +878,7 @@ page_zip_compress_node_ptrs(
 	mem_heap_t*	heap)		/*!< in: temporary memory heap */
 {
 	int	err	= Z_OK;
-	offset_t* offsets = NULL;
+	rec_offs* offsets = NULL;
 
 	do {
 		const rec_t*	rec = *recs++;
@@ -983,7 +983,7 @@ page_zip_compress_clust_ext(
 	FILE_LOGFILE
 	z_stream*	c_stream,	/*!< in/out: compressed page stream */
 	const rec_t*	rec,		/*!< in: record */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec) */
 	ulint		trx_id_col,	/*!< in: position of of DB_TRX_ID */
 	byte*		deleted,	/*!< in: dense directory entry pointing
 					to the head of the free list */
@@ -1122,7 +1122,7 @@ page_zip_compress_clust(
 	mem_heap_t*	heap)		/*!< in: temporary memory heap */
 {
 	int	err		= Z_OK;
-	offset_t* offsets		= NULL;
+	rec_offs* offsets		= NULL;
 	/* BTR_EXTERN_FIELD_REF storage */
 	byte*	externs		= storage - n_dense
 		* (DATA_TRX_ID_LEN + DATA_ROLL_PTR_LEN);
@@ -1982,7 +1982,7 @@ const byte*
 page_zip_apply_log_ext(
 /*===================*/
 	rec_t*		rec,		/*!< in/out: record */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec) */
 	ulint		trx_id_col,	/*!< in: position of of DB_TRX_ID */
 	const byte*	data,		/*!< in: modification log */
 	const byte*	end)		/*!< in: end of modification log */
@@ -2083,7 +2083,7 @@ page_zip_apply_log(
 				/*!< in: heap_no and status bits for
 				the next record to uncompress */
 	dict_index_t*	index,	/*!< in: index of the page */
-	offset_t*	offsets)/*!< in/out: work area for
+	rec_offs*	offsets)/*!< in/out: work area for
 				rec_get_offsets_reverse() */
 {
 	const byte* const end = data + size;
@@ -2151,7 +2151,7 @@ page_zip_apply_log(
 		if (val & 1) {
 			/* Clear the data bytes of the record. */
 			mem_heap_t*	heap	= NULL;
-			offset_t*	offs;
+			rec_offs*	offs;
 			offs = rec_get_offsets(rec, index, offsets, is_leaf,
 					       ULINT_UNDEFINED, &heap);
 			memset(rec, 0, rec_offs_data_size(offs));
@@ -2303,7 +2303,7 @@ page_zip_decompress_node_ptrs(
 					sorted by address */
 	ulint		n_dense,	/*!< in: size of recs[] */
 	dict_index_t*	index,		/*!< in: the index of the page */
-	offset_t*	offsets,	/*!< in/out: temporary offsets */
+	rec_offs*	offsets,	/*!< in/out: temporary offsets */
 	mem_heap_t*	heap)		/*!< in: temporary memory heap */
 {
 	ulint		heap_status = REC_STATUS_NODE_PTR
@@ -2492,7 +2492,7 @@ page_zip_decompress_sec(
 					sorted by address */
 	ulint		n_dense,	/*!< in: size of recs[] */
 	dict_index_t*	index,		/*!< in: the index of the page */
-	offset_t*	offsets)	/*!< in/out: temporary offsets */
+	rec_offs*	offsets)	/*!< in/out: temporary offsets */
 {
 	ulint	heap_status	= REC_STATUS_ORDINARY
 		| PAGE_HEAP_NO_USER_LOW << REC_HEAP_NO_SHIFT;
@@ -2624,7 +2624,7 @@ page_zip_decompress_clust_ext(
 /*==========================*/
 	z_stream*	d_stream,	/*!< in/out: compressed page stream */
 	rec_t*		rec,		/*!< in/out: record */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec) */
 	ulint		trx_id_col)	/*!< in: position of of DB_TRX_ID */
 {
 	ulint	i;
@@ -2739,7 +2739,7 @@ page_zip_decompress_clust(
 	ulint		n_dense,	/*!< in: size of recs[] */
 	dict_index_t*	index,		/*!< in: the index of the page */
 	ulint		trx_id_col,	/*!< index of the trx_id column */
-	offset_t*	offsets,	/*!< in/out: temporary offsets */
+	rec_offs*	offsets,	/*!< in/out: temporary offsets */
 	mem_heap_t*	heap)		/*!< in: temporary memory heap */
 {
 	int		err;
@@ -3042,7 +3042,7 @@ page_zip_decompress_low(
 	ulint		n_dense;/* number of user records on the page */
 	ulint		trx_id_col = ULINT_UNDEFINED;
 	mem_heap_t*	heap;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 
 	ut_ad(page_zip_simple_validate(page_zip));
 	UNIV_MEM_ASSERT_W(page, UNIV_PAGE_SIZE);
@@ -3166,7 +3166,7 @@ zlib_error:
 		ulint	n = 1 + 1/* node ptr */ + REC_OFFS_HEADER_SIZE
 			+ dict_index_get_n_fields(index);
 
-		offsets = static_cast<offset_t*>(
+		offsets = static_cast<rec_offs*>(
 			mem_heap_alloc(heap, n * sizeof(ulint)));
 
 		rec_offs_set_n_alloc(offsets, n);
@@ -3405,7 +3405,7 @@ page_zip_validate_low(
 		committed.  Let us tolerate that difference when we
 		are performing a sloppy validation. */
 
-		offset_t*	offsets;
+		rec_offs*	offsets;
 		mem_heap_t*	heap;
 		const rec_t*	rec;
 		const rec_t*	trec;
@@ -3573,7 +3573,7 @@ page_zip_write_rec_ext(
 	const page_t*	page,		/*!< in: page containing rec */
 	const byte*	rec,		/*!< in: record being written */
 	dict_index_t*	index,		/*!< in: record descriptor */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec, index) */
 	ulint		create,		/*!< in: nonzero=insert, zero=update */
 	ulint		trx_id_col,	/*!< in: position of DB_TRX_ID */
 	ulint		heap_no,	/*!< in: heap number of rec */
@@ -3692,7 +3692,7 @@ page_zip_write_rec(
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page */
 	const byte*	rec,	/*!< in: record being written */
 	dict_index_t*	index,	/*!< in: the index the record belongs to */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint		create)	/*!< in: nonzero=insert, zero=update */
 {
 	const page_t*	page;
@@ -3942,7 +3942,7 @@ page_zip_write_blob_ptr(
 	const byte*	rec,	/*!< in/out: record whose data is being
 				written */
 	dict_index_t*	index,	/*!< in: index of the page */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint		n,	/*!< in: column index */
 	mtr_t*		mtr)	/*!< in: mini-transaction handle,
 				or NULL if no logging is needed */
@@ -4160,7 +4160,7 @@ page_zip_write_trx_id_and_roll_ptr(
 /*===============================*/
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page */
 	byte*		rec,	/*!< in/out: record */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint		trx_id_col,/*!< in: column number of TRX_ID in rec */
 	trx_id_t	trx_id,	/*!< in: transaction identifier */
 	roll_ptr_t	roll_ptr)/*!< in: roll_ptr */
@@ -4227,7 +4227,7 @@ page_zip_clear_rec(
 	page_zip_des_t*	page_zip,	/*!< in/out: compressed page */
 	byte*		rec,		/*!< in: record to clear */
 	const dict_index_t*	index,	/*!< in: index of rec */
-	const offset_t*	offsets)	/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets)	/*!< in: rec_get_offsets(rec, index) */
 {
 	ulint	heap_no;
 	page_t*	page	= page_align(rec);
@@ -4433,7 +4433,7 @@ page_zip_dir_delete(
 	page_zip_des_t*		page_zip,	/*!< in/out: compressed page */
 	byte*			rec,		/*!< in: deleted record */
 	const dict_index_t*	index,		/*!< in: index of rec */
-	const offset_t*		offsets,	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*		offsets,	/*!< in: rec_get_offsets(rec) */
 	const byte*		free)		/*!< in: previous start of
 						the free list */
 {

--- a/storage/innobase/rem/rem0cmp.cc
+++ b/storage/innobase/rem/rem0cmp.cc
@@ -548,7 +548,7 @@ cmp_dtuple_rec_with_gis(
 				dtuple in some of the common fields, or which
 				has an equal number or more fields than
 				dtuple */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	page_cur_mode_t	mode)	/*!< in: compare mode */
 {
 	const dfield_t*	dtuple_field;	/* current field in logical record */
@@ -581,7 +581,7 @@ int
 cmp_dtuple_rec_with_gis_internal(
 	const dtuple_t*	dtuple,
 	const rec_t*	rec,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	const dfield_t*	dtuple_field;	/* current field in logical record */
 	ulint		dtuple_f_len;	/* the length of the current field
@@ -652,7 +652,7 @@ int
 cmp_dtuple_rec_with_match_low(
 	const dtuple_t*	dtuple,
 	const rec_t*	rec,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	ulint		n_cmp,
 	ulint*		matched_fields)
 {
@@ -781,7 +781,7 @@ cmp_dtuple_rec_with_match_bytes(
 	const dtuple_t*		dtuple,
 	const rec_t*		rec,
 	const dict_index_t*	index,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	ulint*			matched_fields,
 	ulint*			matched_bytes)
 {
@@ -944,7 +944,7 @@ int
 cmp_dtuple_rec(
 	const dtuple_t*	dtuple,
 	const rec_t*	rec,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	ulint	matched_fields	= 0;
 
@@ -962,7 +962,7 @@ cmp_dtuple_is_prefix_of_rec(
 /*========================*/
 	const dtuple_t*	dtuple,	/*!< in: data tuple */
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint	n_fields;
 	ulint	matched_fields	= 0;
@@ -990,8 +990,8 @@ cmp_rec_rec_simple_field(
 /*=====================*/
 	const rec_t*		rec1,	/*!< in: physical record */
 	const rec_t*		rec2,	/*!< in: physical record */
-	const offset_t*		offsets1,/*!< in: rec_get_offsets(rec1, ...) */
-	const offset_t*		offsets2,/*!< in: rec_get_offsets(rec2, ...) */
+	const rec_offs*		offsets1,/*!< in: rec_get_offsets(rec1, ...) */
+	const rec_offs*		offsets2,/*!< in: rec_get_offsets(rec2, ...) */
 	const dict_index_t*	index,	/*!< in: data dictionary index */
 	ulint			n)	/*!< in: field to compare */
 {
@@ -1021,8 +1021,8 @@ cmp_rec_rec_simple(
 /*===============*/
 	const rec_t*		rec1,	/*!< in: physical record */
 	const rec_t*		rec2,	/*!< in: physical record */
-	const offset_t*		offsets1,/*!< in: rec_get_offsets(rec1, ...) */
-	const offset_t*		offsets2,/*!< in: rec_get_offsets(rec2, ...) */
+	const rec_offs*		offsets1,/*!< in: rec_get_offsets(rec1, ...) */
+	const rec_offs*		offsets2,/*!< in: rec_get_offsets(rec2, ...) */
 	const dict_index_t*	index,	/*!< in: data dictionary index */
 	struct TABLE*		table)	/*!< in: MySQL table, for reporting
 					duplicate key value if applicable,
@@ -1108,8 +1108,8 @@ int
 cmp_rec_rec(
 	const rec_t*		rec1,
 	const rec_t*		rec2,
-	const offset_t*		offsets1,
-	const offset_t*		offsets2,
+	const rec_offs*		offsets1,
+	const rec_offs*		offsets2,
 	const dict_index_t*	index,
 	bool			nulls_unequal,
 	ulint*			matched_fields)

--- a/storage/innobase/rem/rem0rec.cc
+++ b/storage/innobase/rem/rem0rec.cc
@@ -242,12 +242,12 @@ rec_init_offsets_comp_ordinary(
 					format for temporary files in
 					index creation */
 	const dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t*		offsets)/*!< in/out: array of offsets;
+	rec_offs*		offsets)/*!< in/out: array of offsets;
 					in: n=rec_offs_n_fields(offsets) */
 {
 	ulint		i		= 0;
-	offset_t	offs		= 0;
-	offset_t	any_ext		= 0;
+	rec_offs	offs		= 0;
+	rec_offs	any_ext		= 0;
 	ulint		n_null		= index->n_nullable;
 	const byte*	nulls		= temp
 		? rec - 1
@@ -277,7 +277,7 @@ rec_init_offsets_comp_ordinary(
 			= dict_index_get_nth_field(index, i);
 		const dict_col_t*	col
 			= dict_field_get_col(field);
-		offset_t		len;
+		rec_offs		len;
 
 		if (!(col->prtype & DATA_NOT_NULL)) {
 			/* nullable field => read the null flag */
@@ -341,7 +341,7 @@ resolved:
 		rec_offs_base(offsets)[i + 1] = len;
 	} while (++i < rec_offs_n_fields(offsets));
 
-	*rec_offs_base(offsets) = static_cast<offset_t>(rec - (lens + 1))
+	*rec_offs_base(offsets) = static_cast<rec_offs>(rec - (lens + 1))
 				  | REC_OFFS_COMPACT | any_ext;
 }
 
@@ -364,11 +364,11 @@ rec_init_offsets(
 /*=============*/
 	const rec_t*		rec,	/*!< in: physical record */
 	const dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t*		offsets)/*!< in/out: array of offsets;
+	rec_offs*		offsets)/*!< in/out: array of offsets;
 					in: n=rec_offs_n_fields(offsets) */
 {
 	ulint	i	= 0;
-	offset_t	offs;
+	rec_offs	offs;
 
 	rec_offs_make_valid(rec, index, offsets);
 
@@ -406,7 +406,7 @@ rec_init_offsets(
 
 		/* read the lengths of fields 0..n */
 		do {
-			offset_t len;
+			rec_offs len;
 			if (UNIV_UNLIKELY(i == n_node_ptr_field)) {
 				len = offs += REC_NODE_PTR_SIZE;
 				goto resolved;
@@ -475,13 +475,13 @@ resolved:
 			rec_offs_base(offsets)[i + 1] = len;
 		} while (++i < rec_offs_n_fields(offsets));
 
-		*rec_offs_base(offsets) = static_cast<offset_t>(
+		*rec_offs_base(offsets) = static_cast<rec_offs>(
 			(rec - (lens + 1)) | REC_OFFS_COMPACT);
 	} else {
 		/* Old-style record: determine extra size and end offsets */
 		offs = REC_N_OLD_EXTRA_BYTES;
 		if (rec_get_1byte_offs_flag(rec)) {
-			offs += static_cast<offset_t>(
+			offs += static_cast<rec_offs>(
 				rec_offs_n_fields(offsets));
 			*rec_offs_base(offsets) = offs;
 			/* Determine offsets to fields */
@@ -495,7 +495,7 @@ resolved:
 			} while (++i < rec_offs_n_fields(offsets));
 		} else {
 			offs += 2
-				* static_cast<offset_t>(
+				* static_cast<rec_offs>(
 					rec_offs_n_fields(offsets));
 			*rec_offs_base(offsets) = offs;
 			/* Determine offsets to fields */
@@ -526,11 +526,11 @@ resolved:
 				(ULINT_UNDEFINED to compute all offsets)
 @param[in,out]	heap		memory heap
 @return the new offsets */
-offset_t*
+rec_offs*
 rec_get_offsets_func(
 	const rec_t*		rec,
 	const dict_index_t*	index,
-	offset_t*		offsets,
+	rec_offs*		offsets,
 #ifdef UNIV_DEBUG
 	bool			leaf,
 #endif /* UNIV_DEBUG */
@@ -611,7 +611,7 @@ rec_get_offsets_func(
 			*heap = mem_heap_create_at(size * sizeof(*offsets),
 						   file, line);
 		}
-		offsets = static_cast<offset_t*>(
+		offsets = static_cast<rec_offs*>(
 			mem_heap_alloc(*heap, size * sizeof(*offsets)));
 
 		rec_offs_set_n_alloc(offsets, size);
@@ -635,13 +635,13 @@ rec_get_offsets_reverse(
 	const dict_index_t*	index,	/*!< in: record descriptor */
 	ulint			node_ptr,/*!< in: nonzero=node pointer,
 					0=leaf node */
-	offset_t*		offsets)/*!< in/out: array consisting of
+	rec_offs*		offsets)/*!< in/out: array consisting of
 					offsets[0] allocated elements */
 {
 	ulint		n;
 	ulint		i;
-	offset_t	offs;
-	offset_t	any_ext = 0;
+	rec_offs	offs;
+	rec_offs	any_ext = 0;
 	const byte*	nulls;
 	const byte*	lens;
 	dict_field_t*	field;
@@ -669,7 +669,7 @@ rec_get_offsets_reverse(
 
 	/* read the lengths of fields 0..n */
 	do {
-		offset_t len;
+		rec_offs len;
 		if (UNIV_UNLIKELY(i == n_node_ptr_field)) {
 			len = offs += REC_NODE_PTR_SIZE;
 			goto resolved;
@@ -729,7 +729,7 @@ rec_get_offsets_reverse(
 
 			len = offs += len;
 		} else {
-			len = offs += static_cast<offset_t>(field->fixed_len);
+			len = offs += static_cast<rec_offs>(field->fixed_len);
 		}
 resolved:
 		rec_offs_base(offsets)[i + 1] = len;
@@ -737,7 +737,7 @@ resolved:
 
 	ut_ad(lens >= extra);
 	*rec_offs_base(offsets)
-		= static_cast<offset_t>((lens - extra + REC_N_NEW_EXTRA_BYTES)
+		= static_cast<rec_offs>((lens - extra + REC_N_NEW_EXTRA_BYTES)
 					| REC_OFFS_COMPACT | any_ext);
 }
 
@@ -1400,7 +1400,7 @@ rec_init_offsets_temp(
 /*==================*/
 	const rec_t*		rec,	/*!< in: temporary file record */
 	const dict_index_t*	index,	/*!< in: record descriptor */
-	offset_t*		offsets)/*!< in/out: array of offsets;
+	rec_offs*		offsets)/*!< in/out: array of offsets;
 					in: n=rec_offs_n_fields(offsets) */
 {
 	rec_init_offsets_comp_ordinary(rec, true, index, offsets);
@@ -1439,8 +1439,8 @@ rec_copy_prefix_to_dtuple_func(
 	ulint			n_fields,
 	mem_heap_t*		heap)
 {
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets	= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets	= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(is_leaf || n_fields
@@ -1700,7 +1700,7 @@ ibool
 rec_validate(
 /*=========*/
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint		len;
 	ulint		n_fields;
@@ -1802,7 +1802,7 @@ rec_print_comp(
 /*===========*/
 	FILE*		file,	/*!< in: file where to print */
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ulint	i;
 
@@ -1922,7 +1922,7 @@ rec_print_mbr_rec(
 /*==============*/
 	FILE*		file,	/*!< in: file where to print */
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ut_ad(rec_offs_validate(rec, NULL, offsets));
 
@@ -1989,7 +1989,7 @@ rec_print_new(
 /*==========*/
 	FILE*		file,	/*!< in: file where to print */
 	const rec_t*	rec,	/*!< in: physical record */
-	const offset_t*	offsets)/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets)/*!< in: array returned by rec_get_offsets() */
 {
 	ut_ad(rec_offs_validate(rec, NULL, offsets));
 
@@ -2029,7 +2029,7 @@ rec_print(
 		return;
 	} else {
 		mem_heap_t*	heap	= NULL;
-		offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
+		rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
 		rec_offs_init(offsets_);
 
 		rec_print_new(file, rec,
@@ -2052,7 +2052,7 @@ rec_print(
 	std::ostream&	o,
 	const rec_t*	rec,
 	ulint		info,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	const ulint	comp	= rec_offs_comp(offsets);
 	const ulint	n	= rec_offs_n_fields(offsets);
@@ -2104,7 +2104,7 @@ std::ostream&
 operator<<(std::ostream& o, const rec_index_print& r)
 {
 	mem_heap_t*	heap	= NULL;
-	offset_t*	offsets	= rec_get_offsets(
+	rec_offs*	offsets	= rec_get_offsets(
 		r.m_rec, r.m_index, NULL, page_rec_is_leaf(r.m_rec),
 		ULINT_UNDEFINED, &heap);
 	rec_print(o, r.m_rec,
@@ -2142,9 +2142,9 @@ rec_get_trx_id(
 	const byte*	trx_id;
 	ulint		len;
 	mem_heap_t*	heap		= NULL;
-	offset_t offsets_[REC_OFFS_HEADER_SIZE + MAX_REF_PARTS + 2];
+	rec_offs offsets_[REC_OFFS_HEADER_SIZE + MAX_REF_PARTS + 2];
 	rec_offs_init(offsets_);
-	offset_t* offsets = offsets_;
+	rec_offs* offsets = offsets_;
 
 	ut_ad(trx_id_col <= MAX_REF_PARTS);
 	ut_ad(dict_index_is_clust(index));
@@ -2171,7 +2171,7 @@ rec_get_trx_id(
 @param[in]	n		nth field */
 void
 rec_offs_make_nth_extern(
-	offset_t*	offsets,
+	rec_offs*	offsets,
 	const ulint	n)
 {
 	ut_ad(!rec_offs_nth_sql_null(offsets, n));
@@ -2195,8 +2195,8 @@ wsrep_rec_get_foreign_key(
 	ulint		i;
 	uint            key_parts;
 	mem_heap_t*	heap	= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	const offset_t* offsets;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	const rec_offs* offsets;
 
 	ut_ad(index_for);
 	ut_ad(index_ref);

--- a/storage/innobase/row/row0ftsort.cc
+++ b/storage/innobase/row/row0ftsort.cc
@@ -1371,7 +1371,7 @@ row_fts_sel_tree_propagate(
 	int		propogated,	/*<! in: tree node propagated */
 	int*		sel_tree,	/*<! in: selection tree */
 	const mrec_t**	mrec,		/*<! in: sort record */
-	offset_t**	offsets,	/*<! in: record offsets */
+	rec_offs**	offsets,	/*<! in: record offsets */
 	dict_index_t*	index)		/*<! in/out: FTS index */
 {
 	ulint	parent;
@@ -1421,7 +1421,7 @@ row_fts_sel_tree_update(
 	ulint		propagated,	/*<! in: node to propagate up */
 	ulint		height,		/*<! in: tree height */
 	const mrec_t**	mrec,		/*<! in: sort record */
-	offset_t**	offsets,	/*<! in: record offsets */
+	rec_offs**	offsets,	/*<! in: record offsets */
 	dict_index_t*	index)		/*<! in: index dictionary */
 {
 	ulint	i;
@@ -1443,7 +1443,7 @@ row_fts_build_sel_tree_level(
 	int*		sel_tree,	/*<! in/out: selection tree */
 	ulint		level,		/*<! in: selection tree level */
 	const mrec_t**	mrec,		/*<! in: sort record */
-	offset_t**	offsets,	/*<! in: record offsets */
+	rec_offs**	offsets,	/*<! in: record offsets */
 	dict_index_t*	index)		/*<! in: index dictionary */
 {
 	ulint	start;
@@ -1503,7 +1503,7 @@ row_fts_build_sel_tree(
 /*===================*/
 	int*		sel_tree,	/*<! in/out: selection tree */
 	const mrec_t**	mrec,		/*<! in: sort record */
-	offset_t**	offsets,	/*<! in: record offsets */
+	rec_offs**	offsets,	/*<! in: record offsets */
 	dict_index_t*	index)		/*<! in: index dictionary */
 {
 	ulint	treelevel = 1;
@@ -1553,7 +1553,7 @@ row_fts_merge_insert(
 	mem_heap_t*		heap;
 	dberr_t			error = DB_SUCCESS;
 	ulint*			foffs;
-	offset_t**		offsets;
+	rec_offs**		offsets;
 	fts_tokenizer_word_t	new_word;
 	ib_vector_t*		positions;
 	doc_id_t		last_doc_id;
@@ -1593,7 +1593,7 @@ row_fts_merge_insert(
 		heap, sizeof (*b) * fts_sort_pll_degree);
 	foffs = (ulint*) mem_heap_alloc(
 		heap, sizeof(*foffs) * fts_sort_pll_degree);
-	offsets = (offset_t**) mem_heap_alloc(
+	offsets = (rec_offs**) mem_heap_alloc(
 		heap, sizeof(*offsets) * fts_sort_pll_degree);
 	buf = (mrec_buf_t**) mem_heap_alloc(
 		heap, sizeof(*buf) * fts_sort_pll_degree);
@@ -1617,7 +1617,7 @@ row_fts_merge_insert(
 
 		num = 1 + REC_OFFS_HEADER_SIZE
 			+ dict_index_get_n_fields(index);
-		offsets[i] = static_cast<offset_t*>(mem_heap_zalloc(
+		offsets[i] = static_cast<rec_offs*>(mem_heap_zalloc(
 			heap, num * sizeof *offsets[i]));
 		rec_offs_set_n_alloc(offsets[i], num);
 		rec_offs_set_n_fields(offsets[i], dict_index_get_n_fields(index));

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -264,7 +264,7 @@ public:
 	bool remove(
 		const dict_index_t*	index,
 		page_zip_des_t*		page_zip,
-		offset_t*		offsets) UNIV_NOTHROW
+		rec_offs*		offsets) UNIV_NOTHROW
 	{
 		/* We can't end up with an empty page unless it is root. */
 		if (page_get_n_recs(m_cur.block->frame) <= 1) {
@@ -845,7 +845,7 @@ private:
 	@return DB_SUCCESS or error code */
 	dberr_t	adjust_cluster_index_blob_column(
 		rec_t*		rec,
-		const offset_t*	offsets,
+		const rec_offs*	offsets,
 		ulint		i) UNIV_NOTHROW;
 
 	/** Adjusts the BLOB reference in the clustered index row for all
@@ -855,7 +855,7 @@ private:
 	@return DB_SUCCESS or error code */
 	dberr_t	adjust_cluster_index_blob_columns(
 		rec_t*		rec,
-		const offset_t*	offsets) UNIV_NOTHROW;
+		const rec_offs*	offsets) UNIV_NOTHROW;
 
 	/** In the clustered index, adjist the BLOB pointers as needed.
 	Also update the BLOB reference, write the new space id.
@@ -864,13 +864,13 @@ private:
 	@return DB_SUCCESS or error code */
 	dberr_t	adjust_cluster_index_blob_ref(
 		rec_t*		rec,
-		const offset_t*	offsets) UNIV_NOTHROW;
+		const rec_offs*	offsets) UNIV_NOTHROW;
 
 	/** Purge delete-marked records, only if it is possible to do
 	so without re-organising the B+tree.
 	@param offsets current row offsets.
 	@retval true if purged */
-	bool	purge(const offset_t* offsets) UNIV_NOTHROW;
+	bool	purge(const rec_offs* offsets) UNIV_NOTHROW;
 
 	/** Adjust the BLOB references and sys fields for the current record.
 	@param index the index being converted
@@ -880,7 +880,7 @@ private:
 	dberr_t	adjust_cluster_record(
 		const dict_index_t*	index,
 		rec_t*			rec,
-		const offset_t*		offsets) UNIV_NOTHROW;
+		const rec_offs*		offsets) UNIV_NOTHROW;
 
 	/** Find an index with the matching id.
 	@return row_index_t* instance or 0 */
@@ -914,10 +914,10 @@ private:
 	RecIterator		m_rec_iter;
 
 	/** Record offset */
-	offset_t		m_offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs		m_offsets_[REC_OFFS_NORMAL_SIZE];
 
 	/** Pointer to m_offsets_ */
-	offset_t*		m_offsets;
+	rec_offs*		m_offsets;
 
 	/** Memory heap for the record offsets */
 	mem_heap_t*		m_heap;
@@ -1662,7 +1662,7 @@ inline
 dberr_t
 PageConverter::adjust_cluster_index_blob_column(
 	rec_t*		rec,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	ulint		i) UNIV_NOTHROW
 {
 	ulint		len;
@@ -1706,7 +1706,7 @@ inline
 dberr_t
 PageConverter::adjust_cluster_index_blob_columns(
 	rec_t*		rec,
-	const offset_t*	offsets) UNIV_NOTHROW
+	const rec_offs*	offsets) UNIV_NOTHROW
 {
 	ut_ad(rec_offs_any_extern(offsets));
 
@@ -1739,7 +1739,7 @@ inline
 dberr_t
 PageConverter::adjust_cluster_index_blob_ref(
 	rec_t*		rec,
-	const offset_t*	offsets) UNIV_NOTHROW
+	const rec_offs*	offsets) UNIV_NOTHROW
 {
 	if (rec_offs_any_extern(offsets)) {
 		dberr_t	err;
@@ -1760,7 +1760,7 @@ re-organising the B+tree.
 @return true if purge succeeded */
 inline
 bool
-PageConverter::purge(const offset_t* offsets) UNIV_NOTHROW
+PageConverter::purge(const rec_offs* offsets) UNIV_NOTHROW
 {
 	const dict_index_t*	index = m_index->m_srv_index;
 
@@ -1786,7 +1786,7 @@ dberr_t
 PageConverter::adjust_cluster_record(
 	const dict_index_t*	index,
 	rec_t*			rec,
-	const offset_t*		offsets) UNIV_NOTHROW
+	const rec_offs*		offsets) UNIV_NOTHROW
 {
 	dberr_t	err;
 
@@ -2369,8 +2369,8 @@ row_import_set_sys_max_row_id(
 		ulint		len;
 		const byte*	field;
 		mem_heap_t*	heap = NULL;
-		offset_t	offsets_[1 + REC_OFFS_HEADER_SIZE];
-		offset_t*	offsets;
+		rec_offs	offsets_[1 + REC_OFFS_HEADER_SIZE];
+		rec_offs*	offsets;
 
 		rec_offs_init(offsets_);
 

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -223,7 +223,7 @@ row_ins_sec_index_entry_by_modify(
 				depending on whether mtr holds just a leaf
 				latch or also a tree latch */
 	btr_cur_t*	cursor,	/*!< in: B-tree cursor */
-	offset_t**	offsets,/*!< in/out: offsets on cursor->page_cur.rec */
+	rec_offs**	offsets,/*!< in/out: offsets on cursor->page_cur.rec */
 	mem_heap_t*	offsets_heap,
 				/*!< in/out: memory heap that can be emptied */
 	mem_heap_t*	heap,	/*!< in/out: memory heap */
@@ -318,7 +318,7 @@ row_ins_clust_index_entry_by_modify(
 	ulint		mode,	/*!< in: BTR_MODIFY_LEAF or BTR_MODIFY_TREE,
 				depending on whether mtr holds just a leaf
 				latch or also a tree latch */
-	offset_t**	offsets,/*!< out: offsets on cursor->page_cur.rec */
+	rec_offs**	offsets,/*!< out: offsets on cursor->page_cur.rec */
 	mem_heap_t**	offsets_heap,
 				/*!< in/out: pointer to memory heap that can
 				be emptied, or NULL */
@@ -942,9 +942,9 @@ row_ins_foreign_fill_virtual(
 {
 	THD*		thd = current_thd;
 	row_ext_t*	ext;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
 	rec_offs_init(offsets_);
-	const offset_t*	offsets =
+	const rec_offs*	offsets =
 		rec_get_offsets(rec, index, offsets_, true,
 				ULINT_UNDEFINED, &cascade->heap);
 	mem_heap_t*	v_heap = NULL;
@@ -1483,7 +1483,7 @@ row_ins_set_shared_rec_lock(
 	const buf_block_t*	block,	/*!< in: buffer block of rec */
 	const rec_t*		rec,	/*!< in: record */
 	dict_index_t*		index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	que_thr_t*		thr)	/*!< in: query thread */
 {
 	dberr_t	err;
@@ -1514,7 +1514,7 @@ row_ins_set_exclusive_rec_lock(
 	const buf_block_t*	block,	/*!< in: buffer block of rec */
 	const rec_t*		rec,	/*!< in: record */
 	dict_index_t*		index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	que_thr_t*		thr)	/*!< in: query thread */
 {
 	dberr_t	err;
@@ -1561,8 +1561,8 @@ row_ins_check_foreign_constraint(
 	mtr_t		mtr;
 	trx_t*		trx		= thr_get_trx(thr);
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 
 	bool		skip_gap_lock;
 
@@ -2036,7 +2036,7 @@ row_ins_dupl_error_with_rec(
 				the record! */
 	const dtuple_t*	entry,	/*!< in: entry to insert */
 	dict_index_t*	index,	/*!< in: index */
-	const offset_t*	offsets)/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets)/*!< in: rec_get_offsets(rec, index) */
 {
 	ulint	matched_fields;
 	ulint	n_unique;
@@ -2095,8 +2095,8 @@ row_ins_scan_sec_index_for_duplicate(
 	btr_pcur_t	pcur;
 	dberr_t		err		= DB_SUCCESS;
 	ulint		allow_duplicates;
-	offset_t	offsets_[REC_OFFS_SEC_INDEX_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_SEC_INDEX_SIZE];
+	rec_offs*	offsets		= offsets_;
 	DBUG_ENTER("row_ins_scan_sec_index_for_duplicate");
 
 	rec_offs_init(offsets_);
@@ -2229,7 +2229,7 @@ row_ins_duplicate_online(
 	ulint		n_uniq,	/*!< in: offset of DB_TRX_ID */
 	const dtuple_t*	entry,	/*!< in: entry that is being inserted */
 	const rec_t*	rec,	/*!< in: clustered index record */
-	offset_t*	offsets)/*!< in/out: rec_get_offsets(rec) */
+	rec_offs*	offsets)/*!< in/out: rec_get_offsets(rec) */
 {
 	ulint	fields	= 0;
 
@@ -2268,7 +2268,7 @@ row_ins_duplicate_error_in_clust_online(
 	ulint		n_uniq,	/*!< in: offset of DB_TRX_ID */
 	const dtuple_t*	entry,	/*!< in: entry that is being inserted */
 	const btr_cur_t*cursor,	/*!< in: cursor on insert position */
-	offset_t**	offsets,/*!< in/out: rec_get_offsets(rec) */
+	rec_offs**	offsets,/*!< in/out: rec_get_offsets(rec) */
 	mem_heap_t**	heap)	/*!< in/out: heap for offsets */
 {
 	dberr_t		err	= DB_SUCCESS;
@@ -2315,8 +2315,8 @@ row_ins_duplicate_error_in_clust(
 	ulint	n_unique;
 	trx_t*	trx		= thr_get_trx(thr);
 	mem_heap_t*heap		= NULL;
-	offset_t offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t* offsets		= offsets_;
+	rec_offs offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs* offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(dict_index_is_clust(cursor->index));
@@ -2489,7 +2489,7 @@ dberr_t
 row_ins_index_entry_big_rec(
 	const dtuple_t*		entry,
 	const big_rec_t*	big_rec,
-	offset_t*		offsets,
+	rec_offs*		offsets,
 	mem_heap_t**		heap,
 	dict_index_t*		index,
 	const void*		thd __attribute__((unused)))
@@ -2564,8 +2564,8 @@ row_ins_clust_index_entry_low(
 	mtr_t		mtr;
 	ib_uint64_t	auto_inc	= 0;
 	mem_heap_t*	offsets_heap	= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets         = offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets         = offsets_;
 	rec_offs_init(offsets_);
 
 	DBUG_ENTER("row_ins_clust_index_entry_low");
@@ -2843,8 +2843,8 @@ row_ins_sec_index_entry_low(
 	dberr_t		err		= DB_SUCCESS;
 	ulint		n_unique;
 	mtr_t		mtr;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets         = offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets         = offsets_;
 	rec_offs_init(offsets_);
 	rtr_info_t	rtr_info;
 

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -592,7 +592,7 @@ row_log_table_delete(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec,index) */
 	const byte*	sys)	/*!< in: DB_TRX_ID,DB_ROLL_PTR that should
 				be logged, or NULL to use those in rec */
 {
@@ -835,7 +835,7 @@ row_log_table_low(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec,index) */
 	bool		insert,	/*!< in: true if insert, false if update */
 	const dtuple_t*	old_pk)	/*!< in: old PRIMARY KEY value (if !insert
 				and a PRIMARY KEY is being created) */
@@ -948,7 +948,7 @@ row_log_table_update(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec,index) */
 	const dtuple_t*	old_pk)	/*!< in: row_log_table_get_pk()
 				before the update */
 {
@@ -999,7 +999,7 @@ row_log_table_get_pk_col(
 	dfield_t*		dfield,
 	mem_heap_t*		heap,
 	const rec_t*		rec,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	ulint			i,
 	const page_size_t&	page_size,
 	ulint			max_len)
@@ -1053,7 +1053,7 @@ row_log_table_get_pk(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec,index) */
 	byte*		sys,	/*!< out: DB_TRX_ID,DB_ROLL_PTR for
 				row_log_table_delete(), or NULL */
 	mem_heap_t**	heap)	/*!< in/out: memory heap where allocated */
@@ -1246,7 +1246,7 @@ row_log_table_insert(
 				page X-latched */
 	dict_index_t*	index,	/*!< in/out: clustered index, S-latched
 				or X-latched */
-	const offset_t*	offsets)/*!< in: rec_get_offsets(rec,index) */
+	const rec_offs*	offsets)/*!< in: rec_get_offsets(rec,index) */
 {
 	row_log_table_low(rec, index, offsets, true, NULL);
 }
@@ -1337,7 +1337,7 @@ row_log_table_apply_convert_mrec(
 /*=============================*/
 	const mrec_t*		mrec,		/*!< in: merge record */
 	dict_index_t*		index,		/*!< in: index of mrec */
-	const offset_t*		offsets,	/*!< in: offsets of mrec */
+	const rec_offs*		offsets,	/*!< in: offsets of mrec */
 	const row_log_t*	log,		/*!< in: rebuild context */
 	mem_heap_t*		heap,		/*!< in/out: memory heap */
 	trx_id_t		trx_id,		/*!< in: DB_TRX_ID of mrec */
@@ -1569,7 +1569,7 @@ row_log_table_apply_insert(
 /*=======================*/
 	que_thr_t*		thr,		/*!< in: query graph */
 	const mrec_t*		mrec,		/*!< in: record to insert */
-	const offset_t*		offsets,	/*!< in: offsets of mrec */
+	const rec_offs*		offsets,	/*!< in: offsets of mrec */
 	mem_heap_t*		offsets_heap,	/*!< in/out: memory heap
 						that can be emptied */
 	mem_heap_t*		heap,		/*!< in/out: memory heap */
@@ -1621,7 +1621,7 @@ row_log_table_apply_delete_low(
 /*===========================*/
 	btr_pcur_t*		pcur,		/*!< in/out: B-tree cursor,
 						will be trashed */
-	const offset_t*		offsets,	/*!< in: offsets on pcur */
+	const rec_offs*		offsets,	/*!< in: offsets on pcur */
 	mem_heap_t*		heap,		/*!< in/out: memory heap */
 	mtr_t*			mtr)		/*!< in/out: mini-transaction,
 						will be committed */
@@ -1714,7 +1714,7 @@ row_log_table_apply_delete(
 						DB_TRX_ID in the new
 						clustered index */
 	const mrec_t*		mrec,		/*!< in: merge record */
-	const offset_t*		moffsets,	/*!< in: offsets of mrec */
+	const rec_offs*		moffsets,	/*!< in: offsets of mrec */
 	mem_heap_t*		offsets_heap,	/*!< in/out: memory heap
 						that can be emptied */
 	mem_heap_t*		heap,		/*!< in/out: memory heap */
@@ -1725,7 +1725,7 @@ row_log_table_apply_delete(
 	dtuple_t*	old_pk;
 	mtr_t		mtr;
 	btr_pcur_t	pcur;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 
 	ut_ad(rec_offs_n_fields(moffsets)
 	      == dict_index_get_n_unique(index) + 2);
@@ -1835,7 +1835,7 @@ row_log_table_apply_update(
 						DB_TRX_ID in the new
 						clustered index */
 	const mrec_t*		mrec,		/*!< in: new value */
-	const offset_t*		offsets,	/*!< in: offsets of mrec */
+	const rec_offs*		offsets,	/*!< in: offsets of mrec */
 	mem_heap_t*		offsets_heap,	/*!< in/out: memory heap
 						that can be emptied */
 	mem_heap_t*		heap,		/*!< in/out: memory heap */
@@ -1973,7 +1973,7 @@ func_exit_committed:
 	}
 
 	/* Prepare to update (or delete) the record. */
-	offset_t*		cur_offsets	= rec_get_offsets(
+	rec_offs*		cur_offsets	= rec_get_offsets(
 		btr_pcur_get_rec(&pcur), index, NULL, true,
 		ULINT_UNDEFINED, &offsets_heap);
 
@@ -2213,7 +2213,7 @@ row_log_table_apply_op(
 	mem_heap_t*		heap,		/*!< in/out: memory heap */
 	const mrec_t*		mrec,		/*!< in: merge record */
 	const mrec_t*		mrec_end,	/*!< in: end of buffer */
-	offset_t*		offsets)	/*!< in/out: work area
+	rec_offs*		offsets)	/*!< in/out: work area
 						for parsing mrec */
 {
 	row_log_t*	log	= dup->index->online_log;
@@ -2531,7 +2531,7 @@ row_log_table_apply_ops(
 	const mrec_t*	next_mrec_end;
 	mem_heap_t*	heap;
 	mem_heap_t*	offsets_heap;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	bool		has_index_lock;
 	dict_index_t*	index		= const_cast<dict_index_t*>(
 		dup->index);
@@ -2559,7 +2559,7 @@ row_log_table_apply_ops(
 
 	UNIV_MEM_INVALID(&mrec_end, sizeof mrec_end);
 
-	offsets = static_cast<offset_t*>(ut_malloc_nokey(i * sizeof *offsets));
+	offsets = static_cast<rec_offs*>(ut_malloc_nokey(i * sizeof *offsets));
 	rec_offs_set_n_alloc(offsets, i);
 	rec_offs_set_n_fields(offsets, dict_index_get_n_fields(index));
 
@@ -3073,7 +3073,7 @@ row_log_apply_op_low(
 {
 	mtr_t		mtr;
 	btr_cur_t	cursor;
-	offset_t*	offsets = NULL;
+	rec_offs*	offsets = NULL;
 
 	ut_ad(!dict_index_is_clust(index));
 
@@ -3307,7 +3307,7 @@ row_log_apply_op(
 					in exclusive mode */
 	const mrec_t*	mrec,		/*!< in: merge record */
 	const mrec_t*	mrec_end,	/*!< in: end of buffer */
-	offset_t*	offsets)	/*!< in/out: work area for
+	rec_offs*	offsets)	/*!< in/out: work area for
 					rec_init_offsets_temp() */
 
 {
@@ -3425,7 +3425,7 @@ row_log_apply_ops(
 	const mrec_t*	next_mrec_end;
 	mem_heap_t*	offsets_heap;
 	mem_heap_t*	heap;
-	offset_t*	offsets;
+	rec_offs*	offsets;
 	bool		has_index_lock;
 	const ulint	i	= 1 + REC_OFFS_HEADER_SIZE
 		+ dict_index_get_n_fields(index);
@@ -3436,7 +3436,7 @@ row_log_apply_ops(
 	ut_ad(index->online_log);
 	UNIV_MEM_INVALID(&mrec_end, sizeof mrec_end);
 
-	offsets = static_cast<offset_t*>(ut_malloc_nokey(i * sizeof *offsets));
+	offsets = static_cast<rec_offs*>(ut_malloc_nokey(i * sizeof *offsets));
 	rec_offs_set_n_alloc(offsets, i);
 	rec_offs_set_n_fields(offsets, dict_index_get_n_fields(index));
 

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -120,7 +120,7 @@ public:
 		btr_cur_t       ins_cur;
 		mtr_t           mtr;
 		rtr_info_t      rtr_info;
-		offset_t*	ins_offsets = NULL;
+		rec_offs*	ins_offsets = NULL;
 		dberr_t		error = DB_SUCCESS;
 		dtuple_t*	dtuple;
 		ulint		count = 0;
@@ -1046,8 +1046,8 @@ row_merge_heap_create(
 /*==================*/
 	const dict_index_t*	index,		/*!< in: record descriptor */
 	mrec_buf_t**		buf,		/*!< out: 3 buffers */
-	offset_t**		offsets1,	/*!< out: offsets */
-	offset_t**		offsets2)	/*!< out: offsets */
+	rec_offs**		offsets1,	/*!< out: offsets */
+	rec_offs**		offsets2)	/*!< out: offsets */
 {
 	ulint		i	= 1 + REC_OFFS_HEADER_SIZE
 		+ dict_index_get_n_fields(index);
@@ -1056,9 +1056,9 @@ row_merge_heap_create(
 
 	*buf = static_cast<mrec_buf_t*>(
 		mem_heap_alloc(heap, 3 * sizeof **buf));
-	*offsets1 = static_cast<offset_t*>(
+	*offsets1 = static_cast<rec_offs*>(
 		mem_heap_alloc(heap, i * sizeof **offsets1));
-	*offsets2 = static_cast<offset_t*>(
+	*offsets2 = static_cast<rec_offs*>(
 		mem_heap_alloc(heap, i * sizeof **offsets2));
 
 	rec_offs_set_n_alloc(*offsets1, i);
@@ -1181,7 +1181,7 @@ row_merge_read_rec(
 	const mrec_t**		mrec,	/*!< out: pointer to merge record,
 					or NULL on end of list
 					(non-NULL on I/O error) */
-	offset_t*		offsets,/*!< out: offsets of mrec */
+	rec_offs*		offsets,/*!< out: offsets of mrec */
 	row_merge_block_t*	crypt_block, /*!< in: crypt buf or NULL */
 	ulint			space) /*!< in: space id */
 {
@@ -1338,7 +1338,7 @@ row_merge_write_rec_low(
 	ulint		foffs,	/*!< in: file offset */
 #endif /* !DBUG_OFF */
 	const mrec_t*	mrec,	/*!< in: record to write */
-	const offset_t*	offsets)/*!< in: offsets of mrec */
+	const rec_offs*	offsets)/*!< in: offsets of mrec */
 #ifdef DBUG_OFF
 # define row_merge_write_rec_low(b, e, size, fd, foffs, mrec, offsets)	\
 	row_merge_write_rec_low(b, e, mrec, offsets)
@@ -1380,7 +1380,7 @@ row_merge_write_rec(
 	int			fd,	/*!< in: file descriptor */
 	ulint*			foffs,	/*!< in/out: file offset */
 	const mrec_t*		mrec,	/*!< in: record to write */
-	const offset_t*         offsets,/*!< in: offsets of mrec */
+	const rec_offs*         offsets,/*!< in: offsets of mrec */
 	row_merge_block_t*	crypt_block, /*!< in: crypt buf or NULL */
 	ulint			space)	   /*!< in: space id */
 {
@@ -1896,7 +1896,7 @@ row_merge_read_clustered_index(
 		}
 
 		const rec_t*	rec;
-		offset_t*	offsets;
+		rec_offs*	offsets;
 		dtuple_t*	row;
 		row_ext_t*	ext;
 		page_cur_t*	cur	= btr_pcur_get_page_cur(&pcur);
@@ -2818,8 +2818,8 @@ row_merge_blocks(
 	const mrec_t*	mrec0;	/*!< merge rec, points to block[0] or buf[0] */
 	const mrec_t*	mrec1;	/*!< merge rec, points to
 				block[srv_sort_buf_size] or buf[1] */
-	offset_t*	offsets0;/* offsets of mrec0 */
-	offset_t*	offsets1;/* offsets of mrec1 */
+	rec_offs*	offsets0;/* offsets of mrec0 */
+	rec_offs*	offsets1;/* offsets of mrec1 */
 
 	DBUG_ENTER("row_merge_blocks");
 	DBUG_LOG("ib_merge_sort",
@@ -2936,8 +2936,8 @@ row_merge_blocks_copy(
 	const byte*	b0;	/*!< pointer to block[0] */
 	byte*		b2;	/*!< pointer to block[2 * srv_sort_buf_size] */
 	const mrec_t*	mrec0;	/*!< merge rec, points to block[0] */
-	offset_t*	offsets0;/* offsets of mrec0 */
-	offset_t*	offsets1;/* dummy offsets */
+	rec_offs*	offsets0;/* offsets of mrec0 */
+	rec_offs*	offsets1;/* dummy offsets */
 
 	DBUG_ENTER("row_merge_blocks_copy");
 	DBUG_LOG("ib_merge_sort",
@@ -3276,7 +3276,7 @@ static
 void
 row_merge_copy_blobs(
 	const mrec_t*		mrec,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	const page_size_t&	page_size,
 	dtuple_t*		tuple,
 	mem_heap_t*		heap)
@@ -3385,7 +3385,7 @@ row_merge_insert_index_tuples(
 	mem_heap_t*		tuple_heap;
 	dberr_t			error = DB_SUCCESS;
 	ulint			foffs = 0;
-	offset_t*		offsets;
+	rec_offs*		offsets;
 	mrec_buf_t*		buf;
 	ulint			n_rows = 0;
 	dtuple_t*		dtuple;
@@ -3412,7 +3412,7 @@ row_merge_insert_index_tuples(
 		ulint i	= 1 + REC_OFFS_HEADER_SIZE
 			+ dict_index_get_n_fields(index);
 		heap = mem_heap_create(sizeof *buf + i * sizeof *offsets);
-		offsets = static_cast<offset_t*>(
+		offsets = static_cast<rec_offs*>(
 			mem_heap_alloc(heap, i * sizeof *offsets));
 		rec_offs_set_n_alloc(offsets, i);
 		rec_offs_set_n_fields(offsets, dict_index_get_n_fields(index));

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -2003,8 +2003,8 @@ row_unlock_for_mysql(
 						     + index->trx_id_offset);
 		} else {
 			mem_heap_t*	heap			= NULL;
-			offset_t offsets_[REC_OFFS_NORMAL_SIZE];
-			offset_t* offsets				= offsets_;
+			rec_offs offsets_[REC_OFFS_NORMAL_SIZE];
+			rec_offs* offsets				= offsets_;
 
 			rec_offs_init(offsets_);
 			offsets = rec_get_offsets(rec, index, offsets, true,
@@ -4671,8 +4671,8 @@ row_scan_index_for_mysql(
 	ulint		i;
 	ulint		cnt;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets;
 	rec_offs_init(offsets_);
 
 	*n_rows = 0;
@@ -4804,7 +4804,7 @@ not_ok:
 
 			tmp_heap = mem_heap_create(size);
 
-			offsets = static_cast<offset_t*>(
+			offsets = static_cast<rec_offs*>(
 				mem_heap_dup(tmp_heap, offsets, size));
 		}
 

--- a/storage/innobase/row/row0purge.cc
+++ b/storage/innobase/row/row0purge.cc
@@ -108,8 +108,8 @@ row_purge_remove_clust_if_poss_low(
 	mtr_t			mtr;
 	rec_t*			rec;
 	mem_heap_t*		heap		= NULL;
-	offset_t*		offsets;
-	offset_t		offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*		offsets;
+	rec_offs		offsets_[REC_OFFS_NORMAL_SIZE];
 	rec_offs_init(offsets_);
 
 	ut_ad(rw_lock_own(&dict_operation_lock, RW_LOCK_S)
@@ -1284,7 +1284,7 @@ purge_node_t::validate_pcur()
 
 	dict_index_t*	clust_index = pcur.btr_cur.index;
 
-	offset_t* offsets = rec_get_offsets(
+	rec_offs* offsets = rec_get_offsets(
 		pcur.old_rec, clust_index, NULL, true,
 		pcur.old_n_fields, &heap);
 

--- a/storage/innobase/row/row0row.cc
+++ b/storage/innobase/row/row0row.cc
@@ -372,7 +372,7 @@ row_build_low(
 	ulint			type,
 	const dict_index_t*	index,
 	const rec_t*		rec,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	const dict_table_t*	col_table,
 	const dtuple_t*		add_cols,
 	const dict_add_v_col_t*	add_v,
@@ -388,7 +388,7 @@ row_build_low(
 	byte*			buf;
 	ulint			j;
 	mem_heap_t*		tmp_heap	= NULL;
-	offset_t		offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs		offsets_[REC_OFFS_NORMAL_SIZE];
 	rec_offs_init(offsets_);
 
 	ut_ad(index != NULL);
@@ -435,7 +435,7 @@ row_build_low(
 	}
 
 	/* Avoid a debug assertion in rec_offs_validate(). */
-	rec_offs_make_valid(copy, index, const_cast<offset_t*>(offsets));
+	rec_offs_make_valid(copy, index, const_cast<rec_offs*>(offsets));
 
 	if (!col_table) {
 		ut_ad(!col_map);
@@ -525,7 +525,7 @@ row_build_low(
 		}
 	}
 
-	rec_offs_make_valid(rec, index, const_cast<offset_t*>(offsets));
+	rec_offs_make_valid(rec, index, const_cast<rec_offs*>(offsets));
 
 	ut_ad(dtuple_check_typed(row));
 
@@ -578,7 +578,7 @@ row_build(
 					this record must be at least
 					s-latched and the latch held
 					as long as the row dtuple is used! */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec,index)
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec,index)
 					or NULL, in which case this function
 					will invoke rec_get_offsets() */
 	const dict_table_t*	col_table,
@@ -631,7 +631,7 @@ row_build_w_add_vcol(
 	ulint			type,
 	const dict_index_t*	index,
 	const rec_t*		rec,
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	const dict_table_t*	col_table,
 	const dtuple_t*		add_cols,
 	const dict_add_v_col_t*	add_v,
@@ -652,7 +652,7 @@ row_rec_to_index_entry_low(
 /*=======================*/
 	const rec_t*		rec,	/*!< in: record in the index */
 	const dict_index_t*	index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	mem_heap_t*		heap)	/*!< in: memory heap from which
 					the memory needed is allocated */
 {
@@ -711,7 +711,7 @@ row_rec_to_index_entry(
 /*===================*/
 	const rec_t*		rec,	/*!< in: record in the index */
 	const dict_index_t*	index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec) */
 	mem_heap_t*		heap)	/*!< in: memory heap from which
 					the memory needed is allocated */
 {
@@ -730,10 +730,10 @@ row_rec_to_index_entry(
 
 	copy_rec = rec_copy(buf, rec, offsets);
 
-	rec_offs_make_valid(copy_rec, index, const_cast<offset_t*>(offsets));
+	rec_offs_make_valid(copy_rec, index, const_cast<rec_offs*>(offsets));
 	entry = row_rec_to_index_entry_low(
 		copy_rec, index, offsets, heap);
-	rec_offs_make_valid(rec, index, const_cast<offset_t*>(offsets));
+	rec_offs_make_valid(rec, index, const_cast<rec_offs*>(offsets));
 
 	dtuple_set_info_bits(entry,
 			     rec_get_info_bits(rec, rec_offs_comp(offsets)));
@@ -775,8 +775,8 @@ row_build_row_ref(
 	ulint		clust_col_prefix_len;
 	ulint		i;
 	mem_heap_t*	tmp_heap	= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(index != NULL);
@@ -871,7 +871,7 @@ row_build_row_ref_in_tuple(
 					held as long as the row
 					reference is used! */
 	const dict_index_t*	index,	/*!< in: secondary index */
-	offset_t*		offsets,/*!< in: rec_get_offsets(rec, index)
+	rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index)
 					or NULL */
 	trx_t*			trx)	/*!< in: transaction */
 {
@@ -884,7 +884,7 @@ row_build_row_ref_in_tuple(
 	ulint			clust_col_prefix_len;
 	ulint			i;
 	mem_heap_t*		heap		= NULL;
-	offset_t		offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs		offsets_[REC_OFFS_NORMAL_SIZE];
 	rec_offs_init(offsets_);
 
 	ut_ad(!dict_index_is_clust(index));

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -172,10 +172,10 @@ row_sel_sec_rec_is_for_clust_rec(
 	ulint		n;
 	ulint		i;
 	mem_heap_t*	heap		= NULL;
-	offset_t	clust_offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t	sec_offsets_[REC_OFFS_SMALL_SIZE];
-	offset_t*	clust_offs	= clust_offsets_;
-	offset_t*	sec_offs	= sec_offsets_;
+	rec_offs	clust_offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs	sec_offsets_[REC_OFFS_SMALL_SIZE];
+	rec_offs*	clust_offs	= clust_offsets_;
+	rec_offs*	sec_offs	= sec_offsets_;
 	ibool		is_equal	= TRUE;
 	VCOL_STORAGE*	vcol_storage= 0;
 	byte*		record;
@@ -494,7 +494,7 @@ row_sel_fetch_columns(
 	dict_index_t*	index,	/*!< in: record index */
 	const rec_t*	rec,	/*!< in: record in a clustered or non-clustered
 				index; must be protected by a page latch */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	sym_node_t*	column)	/*!< in: first column in a column list, or
 				NULL */
 {
@@ -761,7 +761,7 @@ row_sel_build_prev_vers(
 	ReadView*	read_view,	/*!< in: read view */
 	dict_index_t*	index,		/*!< in: plan node for table */
 	rec_t*		rec,		/*!< in: record in a clustered index */
-	offset_t**	offsets,	/*!< in/out: offsets returned by
+	rec_offs**	offsets,	/*!< in/out: offsets returned by
 					rec_get_offsets(rec, plan->index) */
 	mem_heap_t**	offset_heap,	/*!< in/out: memory heap from which
 					the offsets are allocated */
@@ -796,7 +796,7 @@ row_sel_build_committed_vers_for_mysql(
 	dict_index_t*	clust_index,	/*!< in: clustered index */
 	row_prebuilt_t*	prebuilt,	/*!< in: prebuilt struct */
 	const rec_t*	rec,		/*!< in: record in a clustered index */
-	offset_t**	offsets,	/*!< in/out: offsets returned by
+	rec_offs**	offsets,	/*!< in/out: offsets returned by
 					rec_get_offsets(rec, clust_index) */
 	mem_heap_t**	offset_heap,	/*!< in/out: memory heap from which
 					the offsets are allocated */
@@ -910,8 +910,8 @@ row_sel_get_clust_rec(
 	rec_t*		old_vers;
 	dberr_t		err;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	*out_rec = NULL;
@@ -1070,7 +1070,7 @@ sel_set_rtr_rec_lock(
 	btr_pcur_t*		pcur,	/*!< in: cursor */
 	const rec_t*		first_rec,/*!< in: record */
 	dict_index_t*		index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint			mode,	/*!< in: lock mode */
 	ulint			type,	/*!< in: LOCK_ORDINARY, LOCK_GAP, or
 					LOC_REC_NOT_GAP */
@@ -1082,8 +1082,8 @@ sel_set_rtr_rec_lock(
 	dberr_t		err = DB_SUCCESS;
 	trx_t*		trx = thr_get_trx(thr);
 	buf_block_t*	cur_block = btr_pcur_get_block(pcur);
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	my_offsets = const_cast<offset_t*>(offsets);
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	my_offsets = const_cast<rec_offs*>(offsets);
 	rec_t*		rec = const_cast<rec_t*>(first_rec);
 	rtr_rec_vector*	match_rec;
 	rtr_rec_vector::iterator end;
@@ -1235,7 +1235,7 @@ sel_set_rec_lock(
 	btr_pcur_t*		pcur,	/*!< in: cursor */
 	const rec_t*		rec,	/*!< in: record */
 	dict_index_t*		index,	/*!< in: index */
-	const offset_t*		offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*		offsets,/*!< in: rec_get_offsets(rec, index) */
 	ulint			mode,	/*!< in: lock mode */
 	ulint			type,	/*!< in: LOCK_ORDINARY, LOCK_GAP, or
 					LOC_REC_NOT_GAP */
@@ -1486,8 +1486,8 @@ row_sel_try_search_shortcut(
 	dict_index_t*	index;
 	rec_t*		rec;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	ulint		ret;
 	rec_offs_init(offsets_);
 
@@ -1612,8 +1612,8 @@ row_sel(
 	to the next non-clustered record */
 	dberr_t		err;
 	mem_heap_t*	heap				= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets				= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets				= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(thr->run_node == node);
@@ -2760,7 +2760,7 @@ row_sel_store_row_id_to_prebuilt(
 	row_prebuilt_t*		prebuilt,	/*!< in/out: prebuilt */
 	const rec_t*		index_rec,	/*!< in: record */
 	const dict_index_t*	index,		/*!< in: index of the record */
-	const offset_t*		offsets)	/*!< in: rec_get_offsets
+	const rec_offs*		offsets)	/*!< in: rec_get_offsets
 						(index_rec, index) */
 {
 	const byte*	data;
@@ -2996,7 +2996,7 @@ row_sel_store_mysql_field_func(
 #ifdef UNIV_DEBUG
 	const dict_index_t*	index,
 #endif
-	const offset_t*		offsets,
+	const rec_offs*		offsets,
 	ulint			field_no,
 	const mysql_row_templ_t*templ)
 {
@@ -3152,7 +3152,7 @@ static bool row_sel_store_mysql_rec(
 	const dtuple_t*	vrow,
 	bool		rec_clust,
 	const dict_index_t* index,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	DBUG_ENTER("row_sel_store_mysql_rec");
 
@@ -3283,7 +3283,7 @@ row_sel_build_prev_vers_for_mysql(
 	dict_index_t*	clust_index,	/*!< in: clustered index */
 	row_prebuilt_t*	prebuilt,	/*!< in: prebuilt struct */
 	const rec_t*	rec,		/*!< in: record in a clustered index */
-	offset_t**	offsets,	/*!< in/out: offsets returned by
+	rec_offs**	offsets,	/*!< in/out: offsets returned by
 					rec_get_offsets(rec, clust_index) */
 	mem_heap_t**	offset_heap,	/*!< in/out: memory heap from which
 					the offsets are allocated */
@@ -3321,7 +3321,7 @@ public:
 
 	dberr_t operator()(row_prebuilt_t *prebuilt, dict_index_t *sec_index,
 			const rec_t *rec, que_thr_t *thr, const rec_t **out_rec,
-			offset_t **offsets, mem_heap_t **offset_heap,
+			rec_offs **offsets, mem_heap_t **offset_heap,
 			dtuple_t **vrow, mtr_t *mtr);
 };
 
@@ -3344,7 +3344,7 @@ Row_sel_get_clust_rec_for_mysql::operator()(
 				it, NULL if the old version did not exist
 				in the read view, i.e., it was a fresh
 				inserted version */
-	offset_t**	offsets,/*!< in: offsets returned by
+	rec_offs**	offsets,/*!< in: offsets returned by
 				rec_get_offsets(rec, sec_index);
 				out: offsets returned by
 				rec_get_offsets(out_rec, clust_index) */
@@ -3918,7 +3918,7 @@ row_sel_try_search_shortcut_for_mysql(
 /*==================================*/
 	const rec_t**	out_rec,/*!< out: record if found */
 	row_prebuilt_t*	prebuilt,/*!< in: prebuilt struct */
-	offset_t**	offsets,/*!< in/out: for rec_get_offsets(*out_rec) */
+	rec_offs**	offsets,/*!< in/out: for rec_get_offsets(*out_rec) */
 	mem_heap_t**	heap,	/*!< in/out: heap for rec_get_offsets() */
 	mtr_t*		mtr)	/*!< in: started mtr */
 {
@@ -3989,7 +3989,7 @@ row_search_idx_cond_check(
 	row_prebuilt_t*		prebuilt,	/*!< in/out: prebuilt struct
 						for the table handle */
 	const rec_t*		rec,		/*!< in: InnoDB record */
-	const offset_t*		offsets)	/*!< in: rec_get_offsets() */
+	const rec_offs*		offsets)	/*!< in: rec_get_offsets() */
 {
 	ICP_RESULT	result;
 	ulint		i;
@@ -4077,8 +4077,8 @@ row_sel_fill_vrow(
 	dtuple_t**		vrow,
 	mem_heap_t*		heap)
 {
-	offset_t offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t* offsets	= offsets_;
+	rec_offs offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs* offsets	= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(!(*vrow));
@@ -4129,7 +4129,7 @@ rec_field_len_in_chars(
 	const dict_col_t*	col,
 	const ulint		field_no,
 	const rec_t*		rec,
-	const offset_t*		offsets)
+	const rec_offs*		offsets)
 {
 	const ulint cset = dtype_get_charset_coll(col->prtype);
 	const CHARSET_INFO* cs = all_charsets[cset];
@@ -4156,7 +4156,7 @@ static
 bool row_search_with_covering_prefix(
 	row_prebuilt_t*	prebuilt,
 	const rec_t*	rec,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	const dict_index_t*	index = prebuilt->index;
 	ut_ad(!dict_index_is_clust(index));
@@ -4285,8 +4285,8 @@ row_search_mvcc(
 	ibool		same_user_rec;
 	mtr_t		mtr;
 	mem_heap_t*	heap				= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets				= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets				= offsets_;
 	ibool		table_lock_waited		= FALSE;
 	byte*		next_buf			= 0;
 	bool		spatial_search			= false;
@@ -5995,8 +5995,8 @@ row_search_autoinc_read_column(
 	const byte*	data;
 	ib_uint64_t	value;
 	mem_heap_t*	heap = NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets	= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets	= offsets_;
 
 	rec_offs_init(offsets_);
 	ut_ad(page_rec_is_leaf(rec));

--- a/storage/innobase/row/row0uins.cc
+++ b/storage/innobase/row/row0uins.cc
@@ -114,7 +114,7 @@ row_undo_ins_remove_clust_rec(
 	if (online && dict_index_is_online_ddl(index)) {
 		const rec_t*	rec	= btr_cur_get_rec(btr_cur);
 		mem_heap_t*	heap	= NULL;
-		const offset_t*	offsets	= rec_get_offsets(
+		const rec_offs*	offsets	= rec_get_offsets(
 			rec, index, NULL, true, ULINT_UNDEFINED, &heap);
 		row_log_table_delete(rec, index, offsets, NULL);
 		mem_heap_free(heap);

--- a/storage/innobase/row/row0umod.cc
+++ b/storage/innobase/row/row0umod.cc
@@ -75,7 +75,7 @@ dberr_t
 row_undo_mod_clust_low(
 /*===================*/
 	undo_node_t*	node,	/*!< in: row undo node */
-	offset_t**	offsets,/*!< out: rec_get_offsets() on the record */
+	rec_offs**	offsets,/*!< out: rec_get_offsets() on the record */
 	mem_heap_t**	offsets_heap,
 				/*!< in/out: memory heap that can be emptied */
 	mem_heap_t*	heap,	/*!< in/out: memory heap */
@@ -187,7 +187,7 @@ row_undo_mod_remove_clust_low(
 	if (!trx_id_offset) {
 		mem_heap_t*	heap	= NULL;
 		ulint		trx_id_col;
-		const offset_t*	offsets;
+		const rec_offs*	offsets;
 		ulint		len;
 
 		trx_id_col = dict_index_get_sys_col_pos(
@@ -288,7 +288,7 @@ row_undo_mod_clust(
 
 	mem_heap_t*	heap		= mem_heap_create(1024);
 	mem_heap_t*	offsets_heap	= NULL;
-	offset_t*	offsets		= NULL;
+	rec_offs*	offsets		= NULL;
 	const dtuple_t*	rebuilt_old_pk;
 	byte		sys[DATA_TRX_ID_LEN + DATA_ROLL_PTR_LEN];
 
@@ -669,7 +669,7 @@ try_again:
 	switch (search_result) {
 		mem_heap_t*	heap;
 		mem_heap_t*	offsets_heap;
-		offset_t*	offsets;
+		rec_offs*	offsets;
 	case ROW_BUFFERED:
 	case ROW_NOT_DELETED_REF:
 		/* These are invalid outcomes, because the mode passed

--- a/storage/innobase/row/row0undo.cc
+++ b/storage/innobase/row/row0undo.cc
@@ -167,8 +167,8 @@ row_undo_search_clust_to_pcur(
 	row_ext_t**	ext;
 	const rec_t*	rec;
 	mem_heap_t*	heap		= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets		= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets		= offsets_;
 	rec_offs_init(offsets_);
 
 	ut_ad(!node->table->skip_alter_undo);

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -214,7 +214,7 @@ row_upd_check_references_constraints(
 				cursor position is lost in this function! */
 	dict_table_t*	table,	/*!< in: table in question */
 	dict_index_t*	index,	/*!< in: index of the cursor */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(pcur.rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(pcur.rec, index) */
 	que_thr_t*	thr,	/*!< in: query thread */
 	mtr_t*		mtr)	/*!< in: mtr */
 {
@@ -363,7 +363,7 @@ wsrep_row_upd_check_foreign_constraints(
 				cursor position is lost in this function! */
 	dict_table_t*	table,	/*!< in: table in question */
 	dict_index_t*	index,	/*!< in: index of the cursor */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(pcur.rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(pcur.rec, index) */
 	que_thr_t*	thr,	/*!< in: query thread */
 	mtr_t*		mtr)	/*!< in: mtr */
 {
@@ -502,7 +502,7 @@ row_upd_rec_sys_fields_in_recovery(
 /*===============================*/
 	rec_t*		rec,	/*!< in/out: record */
 	page_zip_des_t*	page_zip,/*!< in/out: compressed page, or NULL */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	ulint		pos,	/*!< in: TRX_ID position in rec */
 	trx_id_t	trx_id,	/*!< in: transaction id */
 	roll_ptr_t	roll_ptr)/*!< in: roll ptr of the undo log record */
@@ -568,7 +568,7 @@ ibool
 row_upd_changes_field_size_or_external(
 /*===================================*/
 	dict_index_t*	index,	/*!< in: index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const upd_t*	update)	/*!< in: update vector */
 {
 	const upd_field_t*	upd_field;
@@ -683,7 +683,7 @@ row_upd_rec_in_place(
 /*=================*/
 	rec_t*		rec,	/*!< in/out: record where replaced */
 	dict_index_t*	index,	/*!< in: the index the record belongs to */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	const upd_t*	update,	/*!< in: update vector */
 	page_zip_des_t*	page_zip)/*!< in: compressed page with enough space
 				available, or NULL */
@@ -961,7 +961,7 @@ row_upd_build_sec_rec_difference_binary(
 /*====================================*/
 	const rec_t*	rec,	/*!< in: secondary index record */
 	dict_index_t*	index,	/*!< in: index */
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec, index) */
 	const dtuple_t*	entry,	/*!< in: entry to insert */
 	mem_heap_t*	heap)	/*!< in: memory heap from which allocated */
 {
@@ -1041,7 +1041,7 @@ row_upd_build_difference_binary(
 	dict_index_t*	index,
 	const dtuple_t*	entry,
 	const rec_t*	rec,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	bool		no_sys,
 	trx_t*		trx,
 	mem_heap_t*	heap,
@@ -1054,7 +1054,7 @@ row_upd_build_difference_binary(
 	ulint		n_diff;
 	ulint		trx_id_pos;
 	ulint		i;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
 	ulint		n_fld = dtuple_get_n_fields(entry);
 	ulint		n_v_fld = dtuple_get_n_v_fields(entry);
 	rec_offs_init(offsets_);
@@ -2067,7 +2067,7 @@ void
 row_upd_copy_columns(
 /*=================*/
 	rec_t*		rec,	/*!< in: record in a clustered index */
-	const offset_t*	offsets,/*!< in: array returned by rec_get_offsets() */
+	const rec_offs*	offsets,/*!< in: array returned by rec_get_offsets() */
 	sym_node_t*	column)	/*!< in: first column in a column list, or
 				NULL */
 {
@@ -2217,8 +2217,8 @@ row_upd_store_row(
 	rec_t*		rec;
 	mem_heap_t*	heap		= NULL;
 	row_ext_t**	ext;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	const offset_t*	offsets;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	const rec_offs*	offsets;
 	rec_offs_init(offsets_);
 
 	ut_ad(node->pcur->latch_mode != BTR_NO_LATCHES);
@@ -2457,7 +2457,7 @@ row_upd_sec_index_entry(
 			    && wsrep_must_process_fk(node, trx)
 			    && !wsrep_thd_is_BF(trx->mysql_thd, FALSE)) {
 
-				offset_t* offsets = rec_get_offsets(
+				rec_offs* offsets = rec_get_offsets(
 					rec, index, NULL, true,
 					ULINT_UNDEFINED, &heap);
 
@@ -2502,7 +2502,7 @@ row_upd_sec_index_entry(
 
 		if (referenced) {
 
-			offset_t* offsets;
+			rec_offs* offsets;
 
 			offsets = rec_get_offsets(
 				rec, index, NULL, true, ULINT_UNDEFINED,
@@ -2584,7 +2584,7 @@ row_upd_clust_rec_by_insert_inherit_func(
 /*=====================================*/
 	const rec_t*	rec,	/*!< in: old record, or NULL */
 #ifdef UNIV_DEBUG
-	const offset_t*	offsets,/*!< in: rec_get_offsets(rec), or NULL */
+	const rec_offs*	offsets,/*!< in: rec_get_offsets(rec), or NULL */
 #endif /* UNIV_DEBUG */
 	dtuple_t*	entry,	/*!< in/out: updated entry to be
 				inserted into the clustered index */
@@ -2685,8 +2685,8 @@ row_upd_clust_rec_by_insert(
 	dtuple_t*	entry;
 	dberr_t		err;
 	rec_t*		rec;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets			= offsets_;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets			= offsets_;
 
 	ut_ad(dict_index_is_clust(index));
 
@@ -2826,7 +2826,7 @@ row_upd_clust_rec(
 	ulint		flags,  /*!< in: undo logging and locking flags */
 	upd_node_t*	node,	/*!< in: row update node */
 	dict_index_t*	index,	/*!< in: clustered index */
-	offset_t*	offsets,/*!< in: rec_get_offsets() on node->pcur */
+	rec_offs*	offsets,/*!< in: rec_get_offsets() on node->pcur */
 	mem_heap_t**	offsets_heap,
 				/*!< in/out: memory heap, can be emptied */
 	que_thr_t*	thr,	/*!< in: query thread */
@@ -2957,7 +2957,7 @@ row_upd_del_mark_clust_rec(
 /*=======================*/
 	upd_node_t*	node,	/*!< in: row update node */
 	dict_index_t*	index,	/*!< in: clustered index */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets() for the
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets() for the
 				record under the cursor */
 	que_thr_t*	thr,	/*!< in: query thread */
 	ibool		referenced,
@@ -3052,8 +3052,8 @@ row_upd_clust_step(
 	mtr_t		mtr;
 	rec_t*		rec;
 	mem_heap_t*	heap	= NULL;
-	offset_t	offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	offsets;
+	rec_offs	offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	offsets;
 	ibool		referenced;
 	trx_t*		trx = thr_get_trx(thr);
 

--- a/storage/innobase/row/row0vers.cc
+++ b/storage/innobase/row/row0vers.cc
@@ -86,12 +86,12 @@ row_vers_impl_x_locked_low(
 	dict_index_t*	clust_index,
 	const rec_t*	rec,
 	dict_index_t*	index,
-	const offset_t*	offsets,
+	const rec_offs*	offsets,
 	mtr_t*		mtr)
 {
 	rec_t*		prev_version = NULL;
-	offset_t	clust_offsets_[REC_OFFS_NORMAL_SIZE];
-	offset_t*	clust_offsets = clust_offsets_;
+	rec_offs	clust_offsets_[REC_OFFS_NORMAL_SIZE];
+	rec_offs*	clust_offsets = clust_offsets_;
 	mem_heap_t*	heap;
 	dtuple_t*	ientry = NULL;
 	mem_heap_t*	v_heap = NULL;
@@ -369,7 +369,7 @@ trx_t*
 row_vers_impl_x_locked(
 	const rec_t*	rec,
 	dict_index_t*	index,
-	const offset_t*	offsets)
+	const rec_offs*	offsets)
 {
 	mtr_t		mtr;
 	trx_t*		trx;
@@ -523,7 +523,7 @@ row_vers_build_cur_vrow_low(
 	bool			in_purge,
 	const rec_t*		rec,
 	dict_index_t*		clust_index,
-	offset_t*		clust_offsets,
+	rec_offs*		clust_offsets,
 	dict_index_t*		index,
 	roll_ptr_t		roll_ptr,
 	trx_id_t		trx_id,
@@ -637,7 +637,7 @@ row_vers_vc_matches_cluster(
 	const rec_t*	rec,
 	const dtuple_t* icentry,
 	dict_index_t*	clust_index,
-	offset_t*	clust_offsets,
+	rec_offs*	clust_offsets,
 	dict_index_t*	index,
 	const dtuple_t* ientry,
 	roll_ptr_t	roll_ptr,
@@ -808,7 +808,7 @@ row_vers_build_cur_vrow(
 	bool			in_purge,
 	const rec_t*		rec,
 	dict_index_t*		clust_index,
-	offset_t**		clust_offsets,
+	rec_offs**		clust_offsets,
 	dict_index_t*		index,
 	const dtuple_t*		ientry,
 	roll_ptr_t		roll_ptr,
@@ -893,7 +893,7 @@ row_vers_old_has_index_entry(
 	const rec_t*	version;
 	rec_t*		prev_version;
 	dict_index_t*	clust_index;
-	offset_t*	clust_offsets;
+	rec_offs*	clust_offsets;
 	mem_heap_t*	heap;
 	mem_heap_t*	heap2;
 	dtuple_t*	row;
@@ -1151,7 +1151,7 @@ row_vers_build_for_consistent_read(
 				of this records */
 	mtr_t*		mtr,	/*!< in: mtr holding the latch on rec */
 	dict_index_t*	index,	/*!< in: the clustered index */
-	offset_t**	offsets,/*!< in/out: offsets returned by
+	rec_offs**	offsets,/*!< in/out: offsets returned by
 				rec_get_offsets(rec, index) */
 	ReadView*	view,	/*!< in: the consistent read view */
 	mem_heap_t**	offset_heap,/*!< in/out: memory heap from which
@@ -1266,7 +1266,7 @@ row_vers_build_for_semi_consistent_read(
 				of this records */
 	mtr_t*		mtr,	/*!< in: mtr holding the latch on rec */
 	dict_index_t*	index,	/*!< in: the clustered index */
-	offset_t**	offsets,/*!< in/out: offsets returned by
+	rec_offs**	offsets,/*!< in/out: offsets returned by
 				rec_get_offsets(rec, index) */
 	mem_heap_t**	offset_heap,/*!< in/out: memory heap from which
 				the offsets are allocated */

--- a/storage/innobase/trx/trx0i_s.cc
+++ b/storage/innobase/trx/trx0i_s.cc
@@ -599,7 +599,7 @@ put_nth_field(
 	ulint			n,	/*!< in: number of field */
 	const dict_index_t*	index,	/*!< in: index */
 	const rec_t*		rec,	/*!< in: record */
-	const offset_t*		offsets)/*!< in: record offsets, returned
+	const rec_offs*		offsets)/*!< in: record offsets, returned
 					by rec_get_offsets() */
 {
 	const byte*	data;
@@ -680,8 +680,8 @@ fill_lock_data(
 	const dict_index_t*	index;
 	ulint			n_fields;
 	mem_heap_t*		heap;
-	offset_t		offsets_onstack[REC_OFFS_NORMAL_SIZE];
-	offset_t*		offsets;
+	rec_offs		offsets_onstack[REC_OFFS_NORMAL_SIZE];
+	rec_offs*		offsets;
 	char			buf[TRX_I_S_LOCK_DATA_MAX_LEN];
 	ulint			buf_used;
 	ulint			i;

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -848,7 +848,7 @@ trx_undo_page_report_modify(
 					delete marking is done */
 	const rec_t*	rec,		/*!< in: clustered index record which
 					has NOT yet been modified */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec, index) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec, index) */
 	const upd_t*	update,		/*!< in: update vector which tells the
 					columns to be updated; in the case of
 					a delete, this should be set to NULL */
@@ -2017,7 +2017,7 @@ trx_undo_report_row_operation(
 	const rec_t*	rec,		/*!< in: case of an update or delete
 					marking, the record in the clustered
 					index; NULL if insert */
-	const offset_t*	offsets,	/*!< in: rec_get_offsets(rec) */
+	const rec_offs*	offsets,	/*!< in: rec_get_offsets(rec) */
 	roll_ptr_t*	roll_ptr)	/*!< out: DB_ROLL_PTR to the
 					undo log record */
 {
@@ -2292,7 +2292,7 @@ trx_undo_prev_version_build(
 				index_rec page and purge_view */
 	const rec_t*	rec,	/*!< in: version of a clustered index record */
 	dict_index_t*	index,	/*!< in: clustered index */
-	offset_t*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
+	rec_offs*	offsets,/*!< in/out: rec_get_offsets(rec, index) */
 	mem_heap_t*	heap,	/*!< in: memory heap from which the memory
 				needed is allocated */
 	rec_t**		old_vers,/*!< out, own: previous version, or NULL if
@@ -2475,7 +2475,7 @@ trx_undo_prev_version_build(
 	}
 
 #if defined UNIV_DEBUG || defined UNIV_BLOB_LIGHT_DEBUG
-	offset_t offsets_dbg[REC_OFFS_NORMAL_SIZE];
+	rec_offs offsets_dbg[REC_OFFS_NORMAL_SIZE];
 	rec_offs_init(offsets_dbg);
 	ut_a(!rec_offs_any_null_extern(
 		*old_vers, rec_get_offsets(*old_vers, index, offsets_dbg, true,


### PR DESCRIPTION
This cleans up to get a compilable and running tests with:

`cmake  -DCONC_WITH_{UNITTEST,SSL}=OFF -DWITH_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DPLUGIN_{ARCHIVE,TOKUDB,MROONGA,OQGRAPH,ROCKSDB,CONNECT,SPIDER,SPHINX,AUTH_PAM}=NO ../mariadb-server-10.2`