### PR TITLE
MDEV-22010: mtr, "mariadbd" exists in mysys error messages

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4672,7 +4672,7 @@ sub extract_warning_lines ($$) {
 
   my @patterns =
     (
-     qr/^Warning|mysqld: Warning|\[Warning\]/,
+     qr/^Warning|(mysqld|mariadbd): Warning|\[Warning\]/,
      qr/^Error:|\[ERROR\]/,
      qr/^==\d+==\s+\S/, # valgrind errors
      qr/InnoDB: Warning|InnoDB: Error/,
@@ -4747,7 +4747,7 @@ sub extract_warning_lines ($$) {
      qr|Access denied for user|,
      qr|Aborted connection|,
      qr|table.*is full|,
-     qr|\[ERROR\] mysqld: \Z|,  # Warning from Aria recovery
+     qr/\[ERROR\] (mysqld|mariadbd): \Z/,  # Warning from Aria recovery
      qr|Linux Native AIO|, # warning that aio does not work on /dev/shm
      qr|InnoDB: io_setup\(\) attempt|,
      qr|InnoDB: io_setup\(\) failed with EAGAIN|,
@@ -6279,7 +6279,7 @@ sub valgrind_arguments {
   my $exe=  shift;
 
   # Ensure the jemalloc works with mysqld
-  if ($$exe =~ /mysqld/)
+  if ($$exe =~ /(mysqld|mariadbd)/)
   {
     my %somalloc=(
       'system jemalloc' => 'libjemalloc*',

--- a/mysql-test/suite/encryption/r/innodb-force-corrupt.result
+++ b/mysql-test/suite/encryption/r/innodb-force-corrupt.result
@@ -1,7 +1,7 @@
 call mtr.add_suppression("InnoDB: Table `test`\\.`t[13]` (has an unreadable root page|is corrupted)");
 call mtr.add_suppression("InnoDB: Encrypted page \\[page id: space=\\d+, page number=[36]\\] in file .*test.t[123]\\.ibd looks corrupted; key_version=");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: We detected index corruption in an InnoDB type table");
-call mtr.add_suppression("\\[ERROR\\] mysqld.*: Index for table 't2' is corrupt; try to repair it");
+call mtr.add_suppression("\\[ERROR\\] (mysqld|mariadb).*: Index for table 't2' is corrupt; try to repair it");
 SET GLOBAL innodb_file_per_table = ON;
 set global innodb_compression_algorithm = 1;
 # Create and populate tables to be corrupted

--- a/mysql-test/suite/encryption/t/innodb-force-corrupt.test
+++ b/mysql-test/suite/encryption/t/innodb-force-corrupt.test
@@ -10,7 +10,7 @@
 call mtr.add_suppression("InnoDB: Table `test`\\.`t[13]` (has an unreadable root page|is corrupted)");
 call mtr.add_suppression("InnoDB: Encrypted page \\[page id: space=\\d+, page number=[36]\\] in file .*test.t[123]\\.ibd looks corrupted; key_version=");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: We detected index corruption in an InnoDB type table");
-call mtr.add_suppression("\\[ERROR\\] mysqld.*: Index for table 't2' is corrupt; try to repair it");
+call mtr.add_suppression("\\[ERROR\\] (mysqld|mariadb).*: Index for table 't2' is corrupt; try to repair it");
 
 SET GLOBAL innodb_file_per_table = ON;
 set global innodb_compression_algorithm = 1;


### PR DESCRIPTION
Also executable can change for jemalloc.

Rather important one to correct bb errors like:

encryption.innodb-force-corrupt 'cbc,innodb' w1 [ fail ]  Found warnings/errors in server log file!
        Test ended at 2020-04-06 15:44:39
line
2020-04-06 15:44:36 3 [ERROR] mariadbd: Index for table 't2' is corrupt; try to repair it
^ Found warnings in /dev/shm/var/1/log/mysqld.1.err