### PR TITLE
MDEV-15526: remove mysql/mysqld service aliases for systemd

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -26,9 +26,6 @@ After=network.target
 
 [Install]
 WantedBy=multi-user.target
-Alias=mysql.service
-Alias=mysqld.service
-
 
 [Service]
 


### PR DESCRIPTION
per https://github.com/MariaDB/server/pull/1172#discussion_r325670057 the plan was to remove the aliases in 10.5 as they violate the [debian packaging rules](https://wiki.debian.org/Teams/pkg-systemd/Packaging#systemd_unit_files_naming_and_installation).

This didn't seem to happen.

Downstream want to keep the links https://salsa.debian.org/mariadb-team/mariadb-10.4/-/merge_requests/2.

No-one really needs them. They were really added without being aware of the total broken state of aliases.

Merge this and I'll write something in the kb release notes to be sure that the few that are surprised can get back to their happy state quickly.