### PR TITLE
MDEV-22150: qa_auth_client is a client plugin

### DIFF
--- a/plugin/auth_examples/CMakeLists.txt
+++ b/plugin/auth_examples/CMakeLists.txt
@@ -25,7 +25,7 @@ MYSQL_ADD_PLUGIN(qa_auth_server qa_auth_server.c
   MODULE_ONLY COMPONENT Test)
 
 MYSQL_ADD_PLUGIN(qa_auth_client qa_auth_client.c
-  MODULE_ONLY COMPONENT Test)
+  MODULE_ONLY CLIENT COMPONENT Test)
 
 MYSQL_ADD_PLUGIN(auth_0x0100 auth_0x0100.c MODULE_ONLY COMPONENT Test)
 


### PR DESCRIPTION
Mark it as such in CMake so when this eventually gets up to 10.5, debian doesn't hack things to install in in the right directory :)

https://github.com/MariaDB/server/pull/1478#discussion_r405958510