### PR TITLE
MDEV-22219: error on parsing negative unsigned options

### DIFF
--- a/mysys/my_getopt.c
+++ b/mysys/my_getopt.c
@@ -1048,21 +1048,30 @@ static ulonglong eval_num_suffix_ull(char *argument,
   ulonglong num;
   DBUG_ENTER("eval_num_suffix_ull");
 
+  if (*argument == '-')
+  {
+    my_getopt_error_reporter(ERROR_LEVEL,
+                             "Incorrect unsigned value: '%s' for %s",
+                             argument, option_name);
+    *error= 1;
+    DBUG_RETURN(0);
+  }
   *error= 0;
   errno= 0;
   num= strtoull(argument, &endchar, 10);
   if (errno == ERANGE)
   {
     my_getopt_error_reporter(ERROR_LEVEL,
-                             "Incorrect integer value: '%s'", argument);
+                             "Incorrect integer value: '%s' for %s",
+                             argument, option_name);
     *error= 1;
     DBUG_RETURN(0);
   }
   num*= eval_num_suffix(endchar, error);
   if (*error)
-    fprintf(stderr,
-	    "Unknown suffix '%c' used for variable '%s' (value '%s')\n",
-	    *endchar, option_name, argument);
+    my_getopt_error_reporter(ERROR_LEVEL,
+                             "Unknown suffix '%c' used for variable '%s' (value '%s')",
+                             *endchar, option_name, argument);
   DBUG_RETURN(num);
 }
 

--- a/unittest/mysys/my_getopt-t.c
+++ b/unittest/mysys/my_getopt-t.c
@@ -382,16 +382,11 @@ int main(int argc __attribute__((unused)), char **argv)
   ok(res==0 && arg_c==0 && opt_ull==100,
      "res:%d, argc:%d, opt_ull:%llu", res, arg_c, opt_ull);
 
-  /*
-    negative numbers are wrapped. this is kinda questionable,
-    we might want to fix it eventually. but it'd be a change in behavior,
-    users might've got used to "-1" meaning "max possible value"
-  */
   run("--ull=-100", NULL);
-  ok(res==0 && arg_c==0 && opt_ull==18446744073709551516ULL,
+  ok(res==9 && arg_c==1 && opt_ull==0ULL,
      "res:%d, argc:%d, opt_ull:%llu", res, arg_c, opt_ull);
   run("--ul=-100", NULL);
-  ok(res==0 && arg_c==0 && opt_ul==4294967295UL,
+  ok(res==9 && arg_c==1 && opt_ul==0UL,
      "res:%d, argc:%d, opt_ul:%lu", res, arg_c, opt_ul);
 
   my_end(0);


### PR DESCRIPTION
Slightly simplistic and got a few duplicates in the output, but better than the previous attempt at allocating LONGMAX bytes of memory.

$ sql/mysqld --no-defaults --skip-networking --datadir=/tmp/datadir --log-bin=/tmp/datadir/mysqlbin --socket /tmp/s.sock --lc-messages-dir=${PWD}/sql/share --verbose   --innodb-buffer-pool-size=-1
2020-04-11 15:31:48 0 [Note] sql/mysqld (mysqld 10.3.23-MariaDB-log) starting as process 17722 ...
2020-04-11 15:31:48 0 [Warning] Could not increase number of max_open_files to more than 4096 (request: 32190)
2020-04-11 15:31:48 0 [Warning] Changed limits: max_open_files: 4096  max_connections: 151 (was 151)  table_cache: 1957 (was 2000)
2020-04-11 15:31:48 0 [ERROR] Incorrect unsigned value: '-1' for innodb-buffer-pool-size
2020-04-11 15:31:48 0 [Warning] option 'innodb-buffer-pool-size': unsigned value 0 adjusted to 5242880
2020-04-11 15:31:48 0 [ERROR] sql/mysqld: Error while setting value '-1' to 'innodb-buffer-pool-size'
2020-04-11 15:31:48 0 [ERROR] Parsing options for plugin 'InnoDB' failed.
2020-04-11 15:31:48 0 [Note] Plugin 'FEEDBACK' is disabled.
2020-04-11 15:31:48 0 [ERROR] Could not open mysql.plugin table. Some plugins may be not loaded
2020-04-11 15:31:48 0 [ERROR] sql/mysqld: unknown variable 'innodb-buffer-pool-size=-1'
2020-04-11 15:31:48 0 [ERROR] Aborting