### PR TITLE
mtr no patch --binary

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: build-{build}~branch-{branch}
+
+before_build:
+  - md %APPVEYOR_BUILD_FOLDER%\win_build
+  - cd %APPVEYOR_BUILD_FOLDER%\win_build
+  - cmake ..  -G "Visual Studio 15 2017 Win64" -DWITH_UNIT_TESTS=0 -DWITH_MARIABACKUP=0 -DMYSQL_MAINTAINER_MODE=ERR -DPLUGIN_ROCKSDB=NO -DPLUGIN_CONNECT=NO -DBISON_EXECUTABLE=C:\cygwin64\bin\bison -DCMAKE_CXX_FLAGS='/W0' -DCMAKE_C_FLAGS='/W0'
+# note, don't merge /W0 to 10.2
+
+build:
+  project: win_build\MySQL.sln
+  parallel: true
+  verbosity: minimal
+
+configuration: RelWithDebInfo
+platform: x64
+
+test_script:
+  - set PATH=%PATH%;C:\Program Files (x86)\Windows Kits\10\Debuggers\x64
+  - cd %APPVEYOR_BUILD_FOLDER%\win_build\mysql-test
+  - perl mysql-test-run.pl --force --max-test-fail=10 --parallel=4 --testcase-timeout=10 --skip-test-list=unstable-tests --suite=main
+
+image: Visual Studio 2017

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -3385,7 +3385,7 @@ sub do_before_run_mysqltest($)
     # to be able to distinguish them from manually created
     # version-controlled results, and to ignore them in git.
     my $dest = "$base_file$suites.result~";
-    my @cmd = ($exe_patch, qw/--binary -r - -f -s -o/,
+    my @cmd = ($exe_patch, qw/-r - -f -s -o/,
                $dest, $base_result, $resfile);
     if (-w $resdir) {
       # don't rebuild a file if it's up to date


### PR DESCRIPTION

superseded version of #1488

windows doesn't require it:
https://ci.appveyor.com/project/grooverdan/mariadb-server/builds/32119201?fullLog=true

looked explicitly for tests:
<pre>
find mysql-test/ -name \*rdiff
mysql-test/r/subselect_sj2_jcl6,innodb_plugin.rdiff
mysql-test/r/innodb_bug878769,innodb_plugin.rdiff
mysql-test/r/mysqld--help,win.rdiff
mysql-test/r/innodb_mrr_cpk,innodb_plugin.rdiff
mysql-test/r/innodb_icp,innodb_plugin.rdiff
mysql-test/r/range_vs_index_merge_innodb,innodb_plugin.rdiff
mysql-test/suite/funcs_1/r/is_engines_innodb,innodb_plugin.rdiff
mysql-test/suite/rpl/r/rpl_insert_delayed,stmt.rdiff
</pre>

Took appveyor config from 10.2 to test, too many type conversion warnings so hence /W0