### PR TITLE
mtr: Only old windows patch-2.5.9 needs --binary

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -3385,8 +3385,11 @@ sub do_before_run_mysqltest($)
     # to be able to distinguish them from manually created
     # version-controlled results, and to ignore them in git.
     my $dest = "$base_file$suites.result~";
-    my @cmd = ($exe_patch, qw/--binary -r - -f -s -o/,
-               $dest, $base_result, $resfile);
+    my @cmd = ($exe_patch);
+    if ($^O eq "MSWin32") {
+      push @cmd, '--binary';
+    }
+    push @cmd, (qw/-r - -f -s -o/, $dest, $base_result, $resfile);
     if (-w $resdir) {
       # don't rebuild a file if it's up to date
       unless (-e $dest and -M $dest < -M $resfile


### PR DESCRIPTION
Windows is always MSWin32 according to https://perldoc.perl.org/perlvar.html#%24OSNAME

Windows GNU patch 2.7.6 per the appveyor version;

patch --version
GNU patch 2.7.6
Copyright (C) 2003, 2009-2012 Free Software Foundation, Inc.
Copyright (C) 1988 Larry Wall

This might be https://packages.msys2.org/package/patch per https://www.appveyor.com/docs/windows-images-software/#mingw-msys-cygwin

So sorry @vuvova, back to an OS version.