### PR TITLE
Deb: Include type_test.so in mariadb-test package

### DIFF
--- a/debian/mariadb-test.install
+++ b/debian/mariadb-test.install
@@ -6,6 +6,7 @@ usr/bin/mysql_client_test
 usr/bin/mysql_client_test_embedded
 usr/bin/mysqltest
 usr/bin/mysqltest_embedded
+usr/bin/test-connect-t
 usr/lib/*/libmariadb3/plugin/auth_test_plugin.so
 usr/lib/*/libmariadb3/plugin/qa_auth_client.so
 usr/lib/*/libmariadb3/plugin/qa_auth_interface.so
@@ -27,6 +28,7 @@ usr/lib/mysql/plugin/qa_auth_server.so
 usr/lib/mysql/plugin/test_sql_service.so
 usr/lib/mysql/plugin/test_versioning.so
 usr/lib/mysql/plugin/type_mysql_timestamp.so
+usr/lib/mysql/plugin/type_test.so
 usr/share/man/man1/mariadb-client-test-embedded.1
 usr/share/man/man1/mariadb-client-test.1
 usr/share/man/man1/mariadb-test-embedded.1

--- a/debian/not-installed
+++ b/debian/not-installed
@@ -22,10 +22,8 @@ usr/lib/x86_64-linux-gnu/libdbbc.a # ColumnStore header file
 usr/lib/x86_64-linux-gnu/libidbboot.a # ColumnStore header file
 usr/lib/x86_64-linux-gnu/libprocessor.a # ColumnStore header file
 usr/lib/x86_64-linux-gnu/libwe_xml.a # ColumnStore header file
-usr/bin/test-connect-t
 usr/bin/uca-dump
 usr/bin/wsrep_sst_backup
-usr/lib/mysql/plugin/type_test.so
 usr/lib/sysusers.d/mariadb.conf # Not used (yet) in Debian systemd
 usr/lib/tmpfiles.d/mariadb.conf # Not used (yet) in Debian systemd
 usr/sbin/rcmysql


### PR DESCRIPTION
File is built, but was missing from packaging, so add it.

Test however fail currently. Filed as MDEV-22243.

Attempted to disable test until it is fixed, but test runs despite being listed in unstable-tests.