### PR TITLE
Use LIKE operator with wildcards

### DIFF
--- a/scripts/mysql_secure_installation.sh
+++ b/scripts/mysql_secure_installation.sh
@@ -358,7 +358,7 @@ remove_test_database() {
     fi
 
     echo " - Removing privileges on test database..."
-    do_query "DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%'"
+    do_query "DELETE FROM mysql.db WHERE Db='test' OR Db LIKE 'test\\_%'"
     if [ $? -eq 0 ]; then
 	echo " ... Success!"
     else


### PR DESCRIPTION
In `mysq_secure_installation.sh`, test databases with name matching the SQL pattern `test\_%` are not actually deleted, because the character sequence `\_%` is interpreted literally.
In order to use wildcards, the SQL `LIKE` operator must be used.