### PR TITLE
MDEV-18851: fail --large-pages on all platforms

### DIFF
--- a/mysql-test/include/have_large_pages.inc
+++ b/mysql-test/include/have_large_pages.inc
@@ -1,0 +1,30 @@
+
+# Based off support_long_file_names.inc
+
+--error 0,3
+--perl
+
+my $ok= 0;
+foreach my $large_page (glob '/sys/kernel/mm/hugepages/*/free_hugepages')
+{
+  open FILE, '<', $large_page || continue;
+  $free= <FILE>;
+  close FILE;
+  if ($free > 0)
+  {
+    $ok= 1;
+  }
+}
+open (F, '>' . $ENV{'MYSQL_TMP_DIR'} . '/large_pages.inc');
+print F "let \$large_pages= $ok;\n";
+close F;
+EOF
+
+--source $MYSQL_TMP_DIR/large_pages.inc
+--remove_file $MYSQL_TMP_DIR/large_pages.inc
+
+
+if (!$large_pages)
+{
+  --skip No large pages available
+}

--- a/mysql-test/main/large_pages.opt
+++ b/mysql-test/main/large_pages.opt
@@ -1,1 +1,0 @@
---large-pages

--- a/mysql-test/main/large_pages.result
+++ b/mysql-test/main/large_pages.result
@@ -1,3 +1,4 @@
+# restart: --large-pages
 call mtr.add_suppression("\\[Warning\\] (mysqld|mariadbd): Couldn't allocate [0-9]+ bytes \\((Large/HugeTLB memory|MEMLOCK) page size [0-9]+\\).*");
 create table t1 (
 a int not null auto_increment,

--- a/mysql-test/main/large_pages.test
+++ b/mysql-test/main/large_pages.test
@@ -1,8 +1,12 @@
-# Test of large pages (or at least the fallback to conventional allocation)
+# Test of large pages
 
 # Windows needs SeLockMemoryPrivilege
 --source include/not_windows.inc
 --source include/have_innodb.inc
+--source include/have_large_pages.inc
+
+-- let $restart_parameters=--large-pages
+-- source include/restart_mysqld.inc
 
 call mtr.add_suppression("\\[Warning\\] (mysqld|mariadbd): Couldn't allocate [0-9]+ bytes \\((Large/HugeTLB memory|MEMLOCK) page size [0-9]+\\).*");
 


### PR DESCRIPTION
On all platforms, if there is no large pages sizes,
or if we don't have any large pages available we
fail immediately rather than continuing.

large-page test improved to run only if pages are available.

@vaintroub , fixes the inconsistency by failing on all if there's no large pages. Ok?

I didn't quite see how it was silent in your commit message (e2a932c9eaac47dc0fdf21ee0536f43386221601)