### PR TITLE
MDEV-22159: Don't redirect as root to a tmp file not owned by root

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -263,7 +263,9 @@ wsrep_recover_position() {
   fi
 
   if [ -f $wr_logfile ]; then
-    [ "$euid" = "0" ] && chown $user $wr_logfile
+    # NOTE! Do not change ownership of the temporary file, as on newer kernel
+    # versions fs.protected_regular is set to '2' and redirecting output with >
+    # as root to a file not owned by root will fail with "Permission denied"
     chmod 600 $wr_logfile
   else
     log_error "WSREP: mktemp failed"
@@ -277,6 +279,11 @@ wsrep_recover_position() {
   log_notice "WSREP: Running position recovery with $wr_options"
 
   eval "$mysqld_cmd --wsrep_recover $wr_options 2> $wr_logfile"
+
+  if [ ! -s "$wr_logfile" ]; then
+    log_error "Log file $wr_logfile was empty, cannot proceed. Is system running fs.protected_regular?"
+    exit 1
+  fi
 
   local rp="$(grep 'WSREP: Recovered position:' $wr_logfile)"
   if [ -z "$rp" ]; then


### PR DESCRIPTION
Also add a check for tmp file being empty and bail out with a clear
error message in such a case, as mysqld_safe prevents normal stderr
from being displayed anywhere and would fail silently on this.

This is a copy of https://github.com/MariaDB/server/pull/1510 but targetting on 10.2.

It is up to @janlindstrom to choose who to merge these, but I hope that this fix would be on the 10.5 branch as soon as possible so that the QA work on 10.5 can continue when this is not failing the CI for Ubuntu Focal and Debian Sid builders on buildbot.askmonty.org