### PR TITLE
output_core_info: include full working directory

### DIFF
--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -57,6 +57,10 @@ static inline void output_core_info()
   int fd;
   if ((len= readlink("/proc/self/cwd", buff, sizeof(buff))) >= 0)
   {
+    if (len < sizeof(buff))
+    {
+      buff[len]= '\0';
+    }
     my_safe_printf_stderr("Writing a core file...\nWorking directory at %.*s\n",
                           (int) len, buff);
   }


### PR DESCRIPTION
Since cb4da5da74b7a6f2e7c4f4ed1b0e5affe45fe2a2 / MDEV-20604

core info error message are like:

  Writing a core file...
  Working directory at /dev/shm/var_auto_7V8S/mysqld.1/d...

The last 3 characters of the path are truncated as my_readlink
populates the buffer but it isn't null terminating.

The enhanced process_str_arg (called by my_safe_printf_stderr)
treats the rest of the path buffer as something continuing
so just replaces ... at the end.

So we null terminate the buffer inline with the expectations of
process_str_arg if the readlink fell within the buffer. Otherwise
the ... behavior is appropriate.