### PR TITLE
MDEV-25424 my_multi_malloc large to use my_large_malloc

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -169,7 +169,7 @@ extern void set_malloc_size_cb(MALLOC_SIZE_CB func);
 	/* defines when allocating data */
 extern void *my_malloc(PSI_memory_key key, size_t size, myf MyFlags);
 extern void *my_multi_malloc(PSI_memory_key key, myf MyFlags, ...);
-extern void *my_multi_malloc_large(PSI_memory_key key, myf MyFlags, ...);
+extern void *my_multi_malloc_large(myf MyFlags, ...);
 extern void *my_realloc(PSI_memory_key key, void *ptr, size_t size, myf MyFlags);
 extern void my_free(void *ptr);
 extern void *my_memdup(PSI_memory_key key, const void *from,size_t length,myf MyFlags);

--- a/mysys/mf_keycache.c
+++ b/mysys/mf_keycache.c
@@ -557,18 +557,15 @@ int init_simple_key_cache(SIMPLE_KEY_CACHE_CB *keycache,
         */
         if (my_multi_malloc_large(MYF(MY_ZEROFILL),
                                   &keycache->block_root,
-                                  (ulonglong) (blocks * sizeof(BLOCK_LINK)),
+                                  blocks * sizeof(BLOCK_LINK),
                                   &keycache->hash_root,
-                                  (ulonglong) (sizeof(HASH_LINK*) *
-                                               keycache->hash_entries),
+                                  sizeof(HASH_LINK*) * keycache->hash_entries,
                                   &keycache->hash_link_root,
-                                  (ulonglong) (hash_links * sizeof(HASH_LINK)),
+                                  hash_links * sizeof(HASH_LINK),
                                   &keycache->changed_blocks,
-                                  (ulonglong) (sizeof(BLOCK_LINK*) *
-                                               changed_blocks_hash_size),
+                                  sizeof(BLOCK_LINK*) * changed_blocks_hash_size,
                                   &keycache->file_blocks,
-                                  (ulonglong) (sizeof(BLOCK_LINK*) *
-                                               changed_blocks_hash_size),
+                                  sizeof(BLOCK_LINK*) * changed_blocks_hash_size,
                                   NullS,
                                   &keycache->block_root_size))
           break;

--- a/mysys/mulalloc.c
+++ b/mysys/mulalloc.c
@@ -89,7 +89,7 @@ void *my_multi_malloc_large(myf myFlags, ...)
   tot_length=0;
   while ((ptr=va_arg(args, char **)))
   {
-    length=va_arg(args,ulonglong);
+    length=va_arg(args,size_t);
     tot_length+=ALIGN_SIZE(length);
   }
   ret_total_length= va_arg(args, size_t *);

--- a/storage/maria/ma_pagecache.c
+++ b/storage/maria/ma_pagecache.c
@@ -857,7 +857,7 @@ size_t init_pagecache(PAGECACHE *pagecache, size_t use_mem,
         Allocate memory for blocks, hash_links and hash entries;
         For each block 2 hash links are allocated
       */
-      if (my_multi_malloc_large(PSI_INSTRUMENT_ME, MYF(MY_ZEROFILL),
+      if (my_multi_malloc_large(MYF(MY_ZEROFILL),
                                 &pagecache->block_root,
                                 (ulonglong) (blocks *
                                              sizeof(PAGECACHE_BLOCK_LINK)),
@@ -873,7 +873,8 @@ size_t init_pagecache(PAGECACHE *pagecache, size_t use_mem,
                                 &pagecache->file_blocks,
                                 (ulonglong) (sizeof(PAGECACHE_BLOCK_LINK*) *
                                              changed_blocks_hash_size),
-                                NullS))
+                                NullS,
+                                &pagecache->block_root_size))
         break;
       my_large_free(pagecache->block_mem, pagecache->mem_size);
       pagecache->block_mem= 0;
@@ -931,7 +932,7 @@ err:
   }
   if (pagecache->block_root)
   {
-    my_free(pagecache->block_root);
+    my_large_free(pagecache->block_root, pagecache->block_root_size);
     pagecache->block_root= NULL;
   }
   my_errno= error;
@@ -1202,7 +1203,7 @@ void end_pagecache(PAGECACHE *pagecache, my_bool cleanup)
     {
       my_large_free(pagecache->block_mem, pagecache->mem_size);
       pagecache->block_mem= NULL;
-      my_free(pagecache->block_root);
+      my_large_free(pagecache->block_root, pagecache->block_root_size);
       pagecache->block_root= NULL;
     }
     pagecache->disk_blocks= -1;

--- a/storage/maria/ma_pagecache.c
+++ b/storage/maria/ma_pagecache.c
@@ -859,20 +859,17 @@ size_t init_pagecache(PAGECACHE *pagecache, size_t use_mem,
       */
       if (my_multi_malloc_large(MYF(MY_ZEROFILL),
                                 &pagecache->block_root,
-                                (ulonglong) (blocks *
-                                             sizeof(PAGECACHE_BLOCK_LINK)),
+                                blocks * sizeof(PAGECACHE_BLOCK_LINK),
                                 &pagecache->hash_root,
-                                (ulonglong) (sizeof(PAGECACHE_HASH_LINK*) *
-                                             pagecache->hash_entries),
+                                sizeof(PAGECACHE_HASH_LINK*) * pagecache->hash_entries,
                                 &pagecache->hash_link_root,
-                                (ulonglong) (hash_links *
-                                             sizeof(PAGECACHE_HASH_LINK)),
+                                hash_links * sizeof(PAGECACHE_HASH_LINK),
                                 &pagecache->changed_blocks,
-                                (ulonglong) (sizeof(PAGECACHE_BLOCK_LINK*) *
-                                             changed_blocks_hash_size),
+                                sizeof(PAGECACHE_BLOCK_LINK*) *
+                                  changed_blocks_hash_size,
                                 &pagecache->file_blocks,
-                                (ulonglong) (sizeof(PAGECACHE_BLOCK_LINK*) *
-                                             changed_blocks_hash_size),
+                                sizeof(PAGECACHE_BLOCK_LINK*) *
+                                  changed_blocks_hash_size,
                                 NullS,
                                 &pagecache->block_root_size))
         break;

--- a/storage/maria/ma_pagecache.h
+++ b/storage/maria/ma_pagecache.h
@@ -168,6 +168,7 @@ typedef struct st_pagecache
   PAGECACHE_HASH_LINK *free_hash_list;/* list of free hash links             */
   PAGECACHE_BLOCK_LINK *free_block_list;/* list of free blocks               */
   PAGECACHE_BLOCK_LINK *block_root;/* memory for block links                 */
+  size_t block_root_size;        /* size of memory allocated to block_root   */
   uchar *block_mem;              /* memory for block buffers                 */
   PAGECACHE_BLOCK_LINK *used_last;/* ptr to the last block of the LRU chain  */
   PAGECACHE_BLOCK_LINK *used_ins;/* ptr to the insertion block in LRU chain  */


### PR DESCRIPTION
There are sizes in use from this function that could benefit from large pages, and they are always bigger than the smallest page size so mmap can be used.

I submit this under the MCA.