### PR TITLE
INSTALL_UNIX_ADDRDIR for debian to /run/mysqld/mysqld.sock

### DIFF
--- a/cmake/install_layout.cmake
+++ b/cmake/install_layout.cmake
@@ -192,7 +192,7 @@ SET(INSTALL_SUPPORTFILESDIR_DEB         "share/mysql")
 #
 SET(INSTALL_MYSQLDATADIR_DEB            "/var/lib/mysql")
 
-SET(INSTALL_UNIX_ADDRDIR_DEB            "/var/run/mysqld/mysqld.sock")
+SET(INSTALL_UNIX_ADDRDIR_DEB            "/run/mysqld/mysqld.sock")
 SET(INSTALL_SYSTEMD_UNITDIR_DEB         "/lib/systemd/system")
 SET(INSTALL_SYSTEMD_SYSUSERSDIR_DEB     "/usr/lib/sysusers.d")
 SET(INSTALL_SYSTEMD_TMPFILESDIR_DEB     "/usr/lib/tmpfiles.d")


### PR DESCRIPTION
to match #1504

This will propagate to all the defaults of libmariadb so they default to the same socket path too.