### PR TITLE
MDEV-22173: socket accept - test for failure

### DIFF
--- a/include/mysql/psi/mysql_socket.h
+++ b/include/mysql/psi/mysql_socket.h
@@ -1048,10 +1048,14 @@ inline_mysql_socket_accept
 #else
     socket_accept.fd= accept(socket_listen.fd, addr, &addr_length);
 #ifdef FD_CLOEXEC
-    flags= fcntl(socket_accept.fd, F_GETFD);
-    if (flags != -1) {
-      flags |= FD_CLOEXEC;
-      fcntl(socket_accept.fd, F_SETFD, flags);
+    if (socket_accept.fd != INVALID_SOCKET)
+    {
+      flags= fcntl(socket_accept.fd, F_GETFD);
+      if (flags != -1)
+      {
+        flags |= FD_CLOEXEC;
+        fcntl(socket_accept.fd, F_SETFD, flags);
+      }
     }
 #endif
 #endif
@@ -1070,10 +1074,14 @@ inline_mysql_socket_accept
 #else
     socket_accept.fd= accept(socket_listen.fd, addr, &addr_length);
 #ifdef FD_CLOEXEC
-    flags= fcntl(socket_accept.fd, F_GETFD);
-    if (flags != -1) {
-      flags |= FD_CLOEXEC;
-      fcntl(socket_accept.fd, F_SETFD, flags);
+    if (socket_accept.fd != INVALID_SOCKET)
+    {
+      flags= fcntl(socket_accept.fd, F_GETFD);
+      if (flags != -1)
+      {
+        flags |= FD_CLOEXEC;
+        fcntl(socket_accept.fd, F_SETFD, flags);
+      }
     }
 #endif
 #endif


### PR DESCRIPTION
accept might return an error, including SOCKET_EAGAIN/
SOCKET_EINTR. The caller, usually handle_connections_sockets
can these however and invalid file descriptor isn't something
to call fcntl on.

Thanks to Etienne Guesnet (ATOS) for diagnosis, sample patch description and testing.