### PR TITLE
MDEV-22407: mtr: mysqld--help-aria test on OSX fail

### DIFF
--- a/mysql-test/main/mysqld--help-aria.test
+++ b/mysql-test/main/mysqld--help-aria.test
@@ -7,7 +7,7 @@
 
 --source include/not_windows.inc
 
---let $args=--table-cache=5 --max-connections=10 --log-warnings=1 --silent-startup --help --verbose
+--let $args=--table-cache=5 --max-connections=10 --log-warnings=1 --silent-startup --lower-case-table-names=1 --help --verbose
 
 --exec $MYSQLD_CMD $args > $MYSQL_TMP_DIR/mysqld--help2.txt 2> $MYSQL_TMP_DIR/mysqld--help2.err
 --replace_regex /mysqld/mariadbd/ /\d\d\d\d-\d*-\d* *\d*:\d*:\d* \d* // /control file '.*aria_log_control'/aria_log_control/ /error: \d+/error: #/


### PR DESCRIPTION
The remaining test failure on OSX (travis at least) after #1518 cleans up the major OSX test failures.

https://travis-ci.org/github/grooverdan/mariadb-server/jobs/680842564

sneakily use lower-case-table-names=1 that unix and OSX won't emit warnings about. Its a `mysqld--help` test after all so its importance doesn't matter that much (expect for the warning output)

Here's it working (on test rebased after the #1518 fix):
https://travis-ci.org/github/grooverdan/mariadb-server/jobs/680907510#L5954