### PR TITLE
mysql-test-run.pl - fix strict subs in HAVE_WIN32_CONSOLE

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -380,6 +380,8 @@ my $set_titlebar;
        $have_win32_console = 1;
      };
      eval 'sub HAVE_WIN32_CONSOLE { $have_win32_console }';
+   } else {
+     sub HAVE_WIN32_CONSOLE { 0 };
    }
 }
 


### PR DESCRIPTION
Fix mtr error:

Bareword "HAVE_WIN32_CONSOLE" not allowed while "strict subs" in use at mysql-test-run.pl line 387.
Execution of mysql-test-run.pl aborted due to compilation errors.

Added in e3f5789ac0b23a16bb71e06b05dec9cfec3161f0

@vaintroub  quick fix of non-win builds - e.g. http://buildbot.askmonty.org/buildbot/builders/bld-p9-rhel7/builds/3261/steps/mtr/logs/stdio