### PR TITLE
clang remove warnings on linker flags

### DIFF
--- a/cmake/check_compiler_flag.cmake
+++ b/cmake/check_compiler_flag.cmake
@@ -12,6 +12,7 @@ SET(fail_patterns
     FAIL_REGEX "warning:.*is valid for.*but not for"
     FAIL_REGEX "warning:.*redefined"
     FAIL_REGEX "[Ww]arning: [Oo]ption"
+    FAIL_REGEX "warning: .*'linker' input unused"
     )
 #The regex patterns above are not localized, thus LANG=C
 SET(ENV{LANG} C)


### PR DESCRIPTION
Clang doesn't like linker flags and without commit, the output is full of
warnings:

clang: warning: -Wl,-z,relro,-z,now: 'linker' input unused [-Wunused-command-line-argument]

So we prevent these at the source.

A proper fix would put the flags into `cmake -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,relro,-z,now  -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-z,relro,-z,now` however I'll quickly note there's no module/share linker test macro https://cmake.org/cmake/help/v3.9/manual/cmake-modules.7.html

As non-clang is used to build release binaries maybe this is an ok initial solution to buildbot output being full of clang warnings.