### PR TITLE
check_linker_flag: use for linker flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ ENDIF()
 OPTION(NOT_FOR_DISTRIBUTION "Allow linking with GPLv2-incompatible system libraries. Only set it you never plan to distribute the resulting binaries" OFF)
 
 INCLUDE(check_compiler_flag)
+INCLUDE(check_linker_flag)
 
 OPTION(WITH_ASAN "Enable address sanitizer" OFF)
 IF (WITH_ASAN)
@@ -236,7 +237,7 @@ IF(SECURITY_HARDENED)
   ENDIF()
   # security-enhancing flags
   MY_CHECK_AND_SET_COMPILER_FLAG("-pie -fPIC")
-  MY_CHECK_AND_SET_COMPILER_FLAG("-Wl,-z,relro,-z,now")
+  MY_CHECK_AND_SET_LINKER_FLAG("-Wl,-z,relro,-z,now")
   MY_CHECK_AND_SET_COMPILER_FLAG("-fstack-protector --param=ssp-buffer-size=4")
   MY_CHECK_AND_SET_COMPILER_FLAG("-D_FORTIFY_SOURCE=2" RELEASE RELWITHDEBINFO)
 ENDIF()

--- a/cmake/check_linker_flag.cmake
+++ b/cmake/check_linker_flag.cmake
@@ -1,0 +1,27 @@
+include(CheckCXXSourceCompiles)
+
+FUNCTION(MY_CHECK_AND_SET_LINKER_FLAG flag_to_set)
+  # Let's avoid expensive compiler tests on Windows:
+  IF(WIN32)
+    RETURN()
+  ENDIF()
+  STRING(REGEX REPLACE "[-,= +]" "_" result "HAVE_LINK_FLAG_${flag_to_set}")
+  SET(SAVE_CMAKE_REQUIRED_LINK_OPTIONS "${CMAKE_REQUIRED_LINK_OPTIONS}")
+  STRING(REGEX REPLACE "^-Wno-" "-W" flag_to_check ${flag_to_set})
+  SET(CMAKE_REQUIRED_LINK_OPTIONS ${CMAKE_REQUIRED_LINK_OPTIONS} ${flag_to_check})
+  CHECK_CXX_SOURCE_COMPILES("int main(void) { return 0; }" ${result})
+  SET(CMAKE_REQUIRED_LINK_OPTIONS "${SAVE_CMAKE_REQUIRED_LINK_OPTIONS}")
+  IF (${result})
+    FOREACH(linktype SHARED MODULE EXE)
+        IF(ARGN)
+          FOREACH(type ${ARGN})
+            SET(CMAKE_${linktype}_LINKER_FLAGS_${type}
+              "${CMAKE_${linktype}_LINKER_FLAGS_${type}} ${flag_to_set}" PARENT_SCOPE)
+          ENDFOREACH()
+        ELSE()
+          SET(CMAKE_${linktype}_LINKER_FLAGS
+            "${CMAKE_${linktype}_LINKER_FLAGS} ${flag_to_set}" PARENT_SCOPE)
+        ENDIF()
+    ENDFOREACH()
+  ENDIF()
+ENDFUNCTION()


### PR DESCRIPTION
Fixes noisy clang output like #1524

Treats "-Wl,-z,relro,-z,now" as an actual linker flags rather than compile flags.

Slightly WIP due to being a purely linker check rather than testing module and shared library builds separately, however it does have an advantage over #1524  in that the linker flags are still used in clang.