### PR TITLE
push_warning_printf: gain attribute(printf)

### DIFF
--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -185,8 +185,7 @@ String *Item_func_geometry_from_json::val_str(String *str)
     if (code)
     {
       THD *thd= current_thd;
-      push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN, code,
-                          ER_THD(thd, code));
+      push_warning(thd, Sql_condition::WARN_LEVEL_WARN, code, ER_THD(thd, code));
     }
     return 0;
   }

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -4154,9 +4154,8 @@ longlong Item_func_uncompressed_length::val_int()
   if (res->length() <= 4)
   {
     THD *thd= current_thd;
-    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-                        ER_ZLIB_Z_DATA_ERROR,
-                        ER_THD(thd, ER_ZLIB_Z_DATA_ERROR));
+    push_warning(thd, Sql_condition::WARN_LEVEL_WARN, ER_ZLIB_Z_DATA_ERROR,
+                 ER_THD(thd, ER_ZLIB_Z_DATA_ERROR));
     null_value= 1;
     return 0;
   }
@@ -4272,9 +4271,9 @@ String *Item_func_uncompress::val_str(String *str)
   if (res->length() <= 4)
   {
     THD *thd= current_thd;
-    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			ER_ZLIB_Z_DATA_ERROR,
-			ER_THD(thd, ER_ZLIB_Z_DATA_ERROR));
+    push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+                 ER_ZLIB_Z_DATA_ERROR,
+                 ER_THD(thd, ER_ZLIB_Z_DATA_ERROR));
     goto err;
   }
 

--- a/sql/my_decimal.cc
+++ b/sql/my_decimal.cc
@@ -59,8 +59,8 @@ int decimal_operation_results(int result, const char *value, const char *type)
 			value, type);
     break;
   case E_DEC_DIV_ZERO:
-    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			ER_DIVISION_BY_ZERO, ER_THD(thd, ER_DIVISION_BY_ZERO));
+    push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+                 ER_DIVISION_BY_ZERO, ER_THD(thd, ER_DIVISION_BY_ZERO));
     break;
   case E_DEC_BAD_NUM:
     push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,

--- a/sql/rpl_gtid.cc
+++ b/sql/rpl_gtid.cc
@@ -2188,7 +2188,7 @@ rpl_binlog_state::drop_domain(DYNAMIC_ARRAY *ids,
       push_warning_printf(current_thd, Sql_condition::WARN_LEVEL_WARN,
                           ER_BINLOG_CANT_DELETE_GTID_DOMAIN,
                           "The gtid domain being deleted ('%lu') is not in "
-                          "the current binlog state", *ptr_domain_id);
+                          "the current binlog state", (unsigned long) *ptr_domain_id);
       continue;
     }
 

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11823,9 +11823,9 @@ void Sql_cmd_grant::warn_hostname_requires_resolving(THD *thd,
   {
     if (specialflag & SPECIAL_NO_RESOLVE &&
         hostname_requires_resolving(user->host.str))
-      push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-                          ER_WARN_HOSTNAME_WONT_WORK,
-                          ER_THD(thd, ER_WARN_HOSTNAME_WONT_WORK));
+      push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+                   ER_WARN_HOSTNAME_WONT_WORK,
+                   ER_THD(thd, ER_WARN_HOSTNAME_WONT_WORK));
   }
 }
 

--- a/sql/sql_error.h
+++ b/sql/sql_error.h
@@ -1266,7 +1266,8 @@ void push_warning(THD *thd, Sql_condition::enum_warning_level level,
                   uint code, const char *msg);
 
 void push_warning_printf(THD *thd, Sql_condition::enum_warning_level level,
-                         uint code, const char *format, ...);
+                         uint code, const char *format, ...)
+                         __attribute__((format(printf,4,5)));
 
 bool mysqld_show_warnings(THD *thd, ulong levels_to_show);
 

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -1778,10 +1778,10 @@ bool add_table_for_trigger(THD *thd,
   {
     if (if_exists)
     {
-      push_warning_printf(thd,
-                          Sql_condition::WARN_LEVEL_NOTE,
-                          ER_TRG_DOES_NOT_EXIST,
-                          ER_THD(thd, ER_TRG_DOES_NOT_EXIST));
+      push_warning(thd,
+                   Sql_condition::WARN_LEVEL_NOTE,
+                   ER_TRG_DOES_NOT_EXIST,
+                   ER_THD(thd, ER_TRG_DOES_NOT_EXIST));
 
       *table= NULL;
 

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -2130,17 +2130,17 @@ master_def:
 
             if (unlikely(Lex->mi.heartbeat_period > slave_net_timeout))
             {
-              push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-                                  ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MAX,
-                                  ER_THD(thd, ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MAX));
+              push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+                           ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MAX,
+                           ER_THD(thd, ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MAX));
             }
             if (unlikely(Lex->mi.heartbeat_period < 0.001))
             {
               if (unlikely(Lex->mi.heartbeat_period != 0.0))
               {
-                push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-                                    ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MIN,
-                                    ER_THD(thd, ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MIN));
+                push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+                             ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MIN,
+                             ER_THD(thd, ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MIN));
                 Lex->mi.heartbeat_period= 0.0;
               }
               Lex->mi.heartbeat_opt=  LEX_MASTER_INFO::LEX_MI_DISABLE;

--- a/storage/example/ha_example.cc
+++ b/storage/example/ha_example.cc
@@ -979,7 +979,7 @@ ha_example::check_if_supported_inplace_alter(TABLE* altered_table,
       if (f_new)
       {
         push_warning_printf(ha_thd(), Sql_condition::WARN_LEVEL_NOTE,
-                            ER_UNKNOWN_ERROR, "EXAMPLE DEBUG: Field %`s COMPLEX '%s' -> '%s'",
+                            ER_UNKNOWN_ERROR, "EXAMPLE DEBUG: Field `%s` COMPLEX '%s' -> '%s'",
                             table->s->field[i]->field_name.str,
                             f_old->complex_param_to_parse_it_in_engine,
                             f_new->complex_param_to_parse_it_in_engine);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -11339,7 +11339,7 @@ create_table_info_t::check_table_options()
 			push_warning_printf(
 				m_thd, Sql_condition::WARN_LEVEL_WARN,
 				HA_WRONG_CREATE_OPTION,
-				"InnoDB: invalid PAGE_COMPRESSION_LEVEL = %lu."
+				"InnoDB: invalid PAGE_COMPRESSION_LEVEL = %llu."
 				" Valid values are [1, 2, 3, 4, 5, 6, 7, 8, 9]",
 				options->page_compression_level);
 			return "PAGE_COMPRESSION_LEVEL";
@@ -18815,9 +18815,8 @@ innodb_encrypt_tables_update(THD*, st_mysql_sys_var*, void*, const void* save)
 static void
 innodb_log_checksums_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 {
-	push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			    HA_ERR_UNSUPPORTED,
-			    deprecated::innodb_log_checksums_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+		     HA_ERR_UNSUPPORTED, deprecated::innodb_log_checksums_msg);
 }
 
 /** Issue a deprecation warning for SET GLOBAL innodb_log_compressed_pages.
@@ -18826,9 +18825,8 @@ static void
 innodb_log_compressed_pages_warn(THD* thd, st_mysql_sys_var*, void*,
 				 const void*)
 {
-	push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			    HA_ERR_UNSUPPORTED,
-			    deprecated::innodb_log_compressed_pages_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_log_compressed_pages_msg);
 }
 
 /** Issue a deprecation warning for SET GLOBAL innodb_log_optimize_ddl.
@@ -18836,9 +18834,8 @@ innodb_log_compressed_pages_warn(THD* thd, st_mysql_sys_var*, void*,
 static void
 innodb_log_optimize_ddl_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 {
-	push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			    HA_ERR_UNSUPPORTED,
-			    deprecated::innodb_log_optimize_ddl_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_log_optimize_ddl_msg);
 }
 
 /** Issue a deprecation warning for SET GLOBAL innodb_page_cleaners.
@@ -18846,9 +18843,8 @@ innodb_log_optimize_ddl_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 static void
 innodb_page_cleaners_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 {
-	push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			    HA_ERR_UNSUPPORTED,
-			    deprecated::innodb_page_cleaners_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+		     deprecated::innodb_page_cleaners_msg);
 }
 
 /** Issue a deprecation warning for SET GLOBAL innodb_undo_logs.
@@ -18856,9 +18852,8 @@ innodb_page_cleaners_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 static void
 innodb_undo_logs_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 {
-	push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			    HA_ERR_UNSUPPORTED,
-			    deprecated::innodb_undo_logs_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_undo_logs_msg);
 }
 
 /** Issue a deprecation warning for SET GLOBAL innodb_scrub_log_speed.
@@ -18866,49 +18861,40 @@ innodb_undo_logs_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 static void
 innodb_scrub_log_speed_warn(THD* thd, st_mysql_sys_var*, void*, const void*)
 {
-	push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
-			    HA_ERR_UNSUPPORTED,
-			    deprecated::innodb_scrub_log_speed_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_scrub_log_speed_msg);
 }
 
 static void
 innodb_background_scrub_data_uncompressed_warn(THD* thd, st_mysql_sys_var*,
 					       void*, const void*)
 {
-	push_warning_printf(
-		thd, Sql_condition::WARN_LEVEL_WARN,
-		HA_ERR_UNSUPPORTED,
-		deprecated::innodb_background_scrub_data_uncompressed_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_background_scrub_data_uncompressed_msg);
 }
 
 static void
 innodb_background_scrub_data_compressed_warn(THD* thd, st_mysql_sys_var*,
 					     void*, const void*)
 {
-	push_warning_printf(
-		thd, Sql_condition::WARN_LEVEL_WARN,
-		HA_ERR_UNSUPPORTED,
-		deprecated::innodb_background_scrub_data_compressed_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_background_scrub_data_compressed_msg);
 }
 
 static void
 innodb_background_scrub_data_check_interval_warn(
 	THD* thd, st_mysql_sys_var*, void*, const void*)
 {
-	push_warning_printf(
-		thd, Sql_condition::WARN_LEVEL_WARN,
-		HA_ERR_UNSUPPORTED,
-		deprecated::innodb_background_scrub_data_check_interval_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_background_scrub_data_check_interval_msg);
 }
 
 static void
 innodb_background_scrub_data_interval_warn(
 	THD* thd, st_mysql_sys_var*, void*, const void*)
 {
-	push_warning_printf(
-		thd, Sql_condition::WARN_LEVEL_WARN,
-		HA_ERR_UNSUPPORTED,
-		deprecated::innodb_background_scrub_data_interval_msg);
+	push_warning(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                     deprecated::innodb_background_scrub_data_interval_msg);
 }
 
 static SHOW_VAR innodb_status_variables_export[]= {
@@ -21598,7 +21584,7 @@ ib_push_warning(
 		buf = (char *)my_malloc(PSI_INSTRUMENT_ME, MAX_BUF_SIZE, MYF(MY_WME));
 		vsprintf(buf,format, args);
 
-		push_warning_printf(
+		push_warning(
 			thd, Sql_condition::WARN_LEVEL_WARN,
 			uint(convert_error_code_to_mysql(error, 0, thd)), buf);
 		my_free(buf);
@@ -21629,7 +21615,7 @@ ib_push_warning(
 		buf = (char *)my_malloc(PSI_INSTRUMENT_ME, MAX_BUF_SIZE, MYF(MY_WME));
 		vsprintf(buf,format, args);
 
-		push_warning_printf(
+		push_warning(
 			thd, Sql_condition::WARN_LEVEL_WARN,
 			uint(convert_error_code_to_mysql(error, 0, thd)), buf);
 		my_free(buf);
@@ -21675,7 +21661,7 @@ ib_foreign_warn(trx_t*	    trx,   /*!< in: trx */
 	if (trx && trx->mysql_thd) {
 		THD* thd = (THD*)trx->mysql_thd;
 
-		push_warning_printf(
+		push_warning(
 			thd, Sql_condition::WARN_LEVEL_WARN,
 			uint(convert_error_code_to_mysql(error, 0, thd)), buf);
 	}


### PR DESCRIPTION
Because printf mistakes are easy to make, and sometimes
hard to see, use __attribute__((format(printf,4,5)))
to highlight them very clearly.

Many uses of push_warning_printf push only a single string
so simplify these to push_warning.

The few warnings that this showed up have been corrected.