### PR TITLE
MDEV-22629: Remove fts_indexes field from struct fts_update_t

### DIFF
--- a/storage/innobase/fts/fts0fts.cc
+++ b/storage/innobase/fts/fts0fts.cc
@@ -584,7 +584,7 @@ fts_cache_init(
 
 	mutex_enter((ib_mutex_t*) &cache->deleted_lock);
 	cache->deleted_doc_ids = ib_vector_create(
-		cache->sync_heap, sizeof(fts_update_t), 4);
+		cache->sync_heap, sizeof(doc_id_t), 4);
 	mutex_exit((ib_mutex_t*) &cache->deleted_lock);
 
 	/* Reset the cache data for all the FTS indexes. */
@@ -2637,11 +2637,11 @@ dberr_t
 fts_cmp_set_sync_doc_id(
 /*====================*/
 	const dict_table_t*	table,		/*!< in: table */
-	doc_id_t		doc_id_cmp,	/*!< in: Doc ID to compare */
+	doc_id_t		cmp_doc_id,	/*!< in: Doc ID to compare */
 	ibool			read_only,	/*!< in: TRUE if read the
 						synced_doc_id only */
 	doc_id_t*		doc_id)		/*!< out: larger document id
-						after comparing "doc_id_cmp"
+						after comparing "cmp_doc_id"
 						to the one stored in CONFIG
 						table */
 {
@@ -2712,10 +2712,10 @@ retry:
 		goto func_exit;
 	}
 
-	if (doc_id_cmp == 0 && *doc_id) {
+	if (cmp_doc_id == 0 && *doc_id) {
 		cache->synced_doc_id = *doc_id - 1;
 	} else {
-		cache->synced_doc_id = ut_max(doc_id_cmp, *doc_id);
+		cache->synced_doc_id = ut_max(cmp_doc_id, *doc_id);
 	}
 
 	mutex_enter(&cache->doc_id_lock);
@@ -2726,7 +2726,7 @@ retry:
 	}
 	mutex_exit(&cache->doc_id_lock);
 
-	if (doc_id_cmp > *doc_id) {
+	if (cmp_doc_id > *doc_id) {
 		error = fts_update_sync_doc_id(
 			table, cache->synced_doc_id, trx);
 	}
@@ -2848,7 +2848,7 @@ fts_doc_ids_create(void)
 	fts_doc_ids->self_heap = ib_heap_allocator_create(heap);
 
 	fts_doc_ids->doc_ids = static_cast<ib_vector_t*>(ib_vector_create(
-		fts_doc_ids->self_heap, sizeof(fts_update_t), 32));
+		fts_doc_ids->self_heap, sizeof(doc_id_t), 32));
 
 	return(fts_doc_ids);
 }
@@ -3943,7 +3943,7 @@ fts_sync_add_deleted_cache(
 
 	ut_a(ib_vector_size(doc_ids) > 0);
 
-	ib_vector_sort(doc_ids, fts_update_doc_id_cmp);
+	ib_vector_sort(doc_ids, fts_doc_id_cmp);
 
 	info = pars_info_create();
 
@@ -3961,13 +3961,13 @@ fts_sync_add_deleted_cache(
 		"BEGIN INSERT INTO $table_name VALUES (:doc_id);");
 
 	for (i = 0; i < n_elems && error == DB_SUCCESS; ++i) {
-		fts_update_t*	update;
+		doc_id_t*	update;
 		doc_id_t	write_doc_id;
 
-		update = static_cast<fts_update_t*>(ib_vector_get(doc_ids, i));
+		update = static_cast<doc_id_t*>(ib_vector_get(doc_ids, i));
 
 		/* Convert to "storage" byte order. */
-		fts_write_doc_id((byte*) &write_doc_id, update->doc_id);
+		fts_write_doc_id((byte*) &write_doc_id, *update);
 		fts_bind_doc_id(info, "doc_id", &write_doc_id);
 
 		error = fts_eval_sql(sync->trx, graph);
@@ -5292,12 +5292,12 @@ fts_cache_append_deleted_doc_ids(
 
 
 	for (ulint i = 0; i < ib_vector_size(cache->deleted_doc_ids); ++i) {
-		fts_update_t*	update;
+		doc_id_t*	update;
 
-		update = static_cast<fts_update_t*>(
+		update = static_cast<doc_id_t*>(
 			ib_vector_get(cache->deleted_doc_ids, i));
 
-		ib_vector_push(vector, &update->doc_id);
+		ib_vector_push(vector, &update);
 	}
 
 	mutex_exit((ib_mutex_t*) &cache->deleted_lock);

--- a/storage/innobase/fts/fts0que.cc
+++ b/storage/innobase/fts/fts0que.cc
@@ -730,10 +730,10 @@ fts_query_union_doc_id(
 {
 	ib_rbt_bound_t	parent;
 	ulint		size = ib_vector_size(query->deleted->doc_ids);
-	fts_update_t*	array = (fts_update_t*) query->deleted->doc_ids->data;
+	doc_id_t*	updates = (doc_id_t*) query->deleted->doc_ids->data;
 
 	/* Check if the doc id is deleted and it's not already in our set. */
-	if (fts_bsearch(array, 0, static_cast<int>(size), doc_id) < 0
+	if (fts_bsearch(updates, 0, static_cast<int>(size), doc_id) < 0
 	    && rbt_search(query->doc_ids, &parent, &doc_id) != 0) {
 
 		fts_ranking_t	ranking;
@@ -761,10 +761,10 @@ fts_query_remove_doc_id(
 {
 	ib_rbt_bound_t	parent;
 	ulint		size = ib_vector_size(query->deleted->doc_ids);
-	fts_update_t*	array = (fts_update_t*) query->deleted->doc_ids->data;
+	doc_id_t*	updates = (doc_id_t*) query->deleted->doc_ids->data;
 
 	/* Check if the doc id is deleted and it's in our set. */
-	if (fts_bsearch(array, 0, static_cast<int>(size), doc_id) < 0
+	if (fts_bsearch(updates, 0, static_cast<int>(size), doc_id) < 0
 	    && rbt_search(query->doc_ids, &parent, &doc_id) == 0) {
 		ut_free(rbt_remove_node(query->doc_ids, parent.last));
 
@@ -791,10 +791,10 @@ fts_query_change_ranking(
 {
 	ib_rbt_bound_t	parent;
 	ulint		size = ib_vector_size(query->deleted->doc_ids);
-	fts_update_t*	array = (fts_update_t*) query->deleted->doc_ids->data;
+	doc_id_t*	updates = (doc_id_t*) query->deleted->doc_ids->data;
 
 	/* Check if the doc id is deleted and it's in our set. */
-	if (fts_bsearch(array, 0, static_cast<int>(size), doc_id) < 0
+	if (fts_bsearch(updates, 0, static_cast<int>(size), doc_id) < 0
 	    && rbt_search(query->doc_ids, &parent, &doc_id) == 0) {
 
 		fts_ranking_t*	ranking;
@@ -828,7 +828,7 @@ fts_query_intersect_doc_id(
 {
 	ib_rbt_bound_t	parent;
 	ulint		size = ib_vector_size(query->deleted->doc_ids);
-	fts_update_t*	array = (fts_update_t*) query->deleted->doc_ids->data;
+	doc_id_t*	updates = (doc_id_t*) query->deleted->doc_ids->data;
 	fts_ranking_t*	ranking= NULL;
 
 	/* There are three types of intersect:
@@ -840,7 +840,7 @@ fts_query_intersect_doc_id(
 	      if it matches 'b' and it's in doc_ids.(multi_exist = true). */
 
 	/* Check if the doc id is deleted and it's in our set */
-	if (fts_bsearch(array, 0, static_cast<int>(size), doc_id) < 0) {
+	if (fts_bsearch(updates, 0, static_cast<int>(size), doc_id) < 0) {
 		fts_ranking_t	new_ranking;
 
 		if (rbt_search(query->doc_ids, &parent, &doc_id) != 0) {
@@ -3649,8 +3649,8 @@ fts_query_prepare_result(
 	if (query->flags == FTS_OPT_RANKING) {
 		fts_word_freq_t*	word_freq;
 		ulint		size = ib_vector_size(query->deleted->doc_ids);
-		fts_update_t*	array =
-			(fts_update_t*) query->deleted->doc_ids->data;
+		doc_id_t*	updates =
+			(doc_id_t*) query->deleted->doc_ids->data;
 
 		node = rbt_first(query->word_freqs);
 		ut_ad(node);
@@ -3665,7 +3665,7 @@ fts_query_prepare_result(
 			doc_freq = rbt_value(fts_doc_freq_t, node);
 
 			/* Don't put deleted docs into result */
-			if (fts_bsearch(array, 0, static_cast<int>(size),
+			if (fts_bsearch(updates, 0, static_cast<int>(size),
 					doc_freq->doc_id) >= 0) {
 				/* one less matching doc count */
 				--word_freq->doc_count;
@@ -4016,7 +4016,7 @@ fts_query(
 	DEBUG_SYNC_C("fts_deleted_doc_ids_append");
 
 	/* Sort the vector so that we can do a binary search over the ids. */
-	ib_vector_sort(query.deleted->doc_ids, fts_update_doc_id_cmp);
+	ib_vector_sort(query.deleted->doc_ids, fts_doc_id_cmp);
 
 	/* Convert the query string to lower case before parsing. We own
 	the ut_malloc'ed result and so remember to free it before return. */

--- a/storage/innobase/include/fts0priv.h
+++ b/storage/innobase/include/fts0priv.h
@@ -239,7 +239,7 @@ Do a binary search for a doc id in the array
 int
 fts_bsearch(
 /*========*/
-	fts_update_t*	array,		/*!< in: array to sort */
+	doc_id_t*	array,		/*!< in: array to sort */
 	int		lower,		/*!< in: lower bound of array*/
 	int		upper,		/*!< in: upper bound of array*/
 	doc_id_t	doc_id)		/*!< in: doc id to lookup */

--- a/storage/innobase/include/fts0types.h
+++ b/storage/innobase/include/fts0types.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 
 Copyright (c) 2007, 2016, Oracle and/or its affiliates. All Rights Reserved.
-Copyright (c) 2017, 2019, MariaDB Corporation.
+Copyright (c) 2017, 2020, MariaDB Corporation.
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software
@@ -78,20 +78,6 @@ struct fts_index_cache_t {
 
 	que_t**		sel_graph;	/*!< Select query graphs */
 	CHARSET_INFO*	charset;	/*!< charset */
-};
-
-/** For supporting the tracking of updates on multiple FTS indexes we need
-to track which FTS indexes need to be updated. For INSERT and DELETE we
-update all fts indexes. */
-struct fts_update_t {
-	doc_id_t	doc_id;		/*!< The doc id affected */
-
-	ib_vector_t*	fts_indexes;	/*!< The FTS indexes that need to be
-					updated. A NULL value means all
-					indexes need to be updated.  This
-					vector is not allocated on the heap
-					and so must be freed explicitly,
-					when we are done with it */
 };
 
 /** Stop word control infotmation. */
@@ -319,10 +305,9 @@ fts_ranking_doc_id_cmp(
 	const void*	p2);			/*!< in: id2 */
 
 /******************************************************************//**
-Compare two fts_update_t instances doc_ids. */
+Compare two doc_ids. */
 UNIV_INLINE
-int
-fts_update_doc_id_cmp(
+int fts_doc_id_cmp(
 /*==================*/
 						/*!< out:
 						< 0 if n1 < n2,

--- a/storage/innobase/include/fts0types.ic
+++ b/storage/innobase/include/fts0types.ic
@@ -79,19 +79,18 @@ fts_ranking_doc_id_cmp(
 }
 
 /******************************************************************//**
-Compare two fts_update_t doc_ids.
+Compare two doc_ids.
 @return < 0 if n1 < n2, 0 if n1 == n2, > 0 if n1 > n2 */
 UNIV_INLINE
-int
-fts_update_doc_id_cmp(
+int fts_doc_id_cmp(
 /*==================*/
 	const void*	p1,			/*!< in: id1 */
 	const void*	p2)			/*!< in: id2 */
 {
-	const fts_update_t*	up1 = (const fts_update_t*) p1;
-	const fts_update_t*	up2 = (const fts_update_t*) p2;
+	const doc_id_t*	up1 = static_cast<const doc_id_t*>(p1);
+	const doc_id_t*	up2 = static_cast<const doc_id_t*>(p2);
 
-	return((int)(up1->doc_id - up2->doc_id));
+	return static_cast<int>(*up1 - *up2);
 }
 
 /******************************************************************//**


### PR DESCRIPTION
I noticed that `fts_indexes` field in `fts_update_t` was not used at all. 