### PR TITLE
MDEV-22569: Run bin/mariadbd instead of bin/mysqld

### DIFF
--- a/debian/additions/source_mariadb-10.5.py
+++ b/debian/additions/source_mariadb-10.5.py
@@ -26,7 +26,7 @@ def add_info(report):
     report[key] = ""
     for line in read_file('/var/log/daemon.log').split('\n'):
         try:
-            if 'mysqld' in line.split()[4]:
+            if 'mariadbd' in line.split()[4]:
                 report[key] += line + '\n'
         except IndexError:
             continue
@@ -35,8 +35,8 @@ def add_info(report):
         report[key] = ""
         for line in read_file('/var/log/mysql/error.log').split('\n'):
             report[key] += line + '\n'
-    attach_mac_events(report, '/usr/sbin/mysqld')
-    attach_file(report,'/etc/apparmor.d/usr.sbin.mysqld')
+    attach_mac_events(report, '/usr/sbin/mariadbd')
+    attach_file(report,'/etc/apparmor.d/usr.sbin.mariadbd')
     _add_my_conf_files(report, '/etc/mysql/mariadb.cnf')
     for f in os.listdir('/etc/mysql/conf.d'):
         _add_my_conf_files(report, os.path.join('/etc/mysql/conf.d', f))

--- a/debian/mariadb-server-10.5.install
+++ b/debian/mariadb-server-10.5.install
@@ -4,7 +4,7 @@ debian/additions/echo_stderr usr/share/mysql
 debian/additions/mariadb.conf.d/50-mysqld_safe.cnf etc/mysql/mariadb.conf.d
 debian/additions/mariadb.conf.d/50-server.cnf etc/mysql/mariadb.conf.d
 debian/additions/source_mariadb-10.5.py usr/share/apport/package-hooks
-etc/apparmor.d/usr.sbin.mysqld
+etc/apparmor.d/usr.sbin.mariadbd
 etc/security/user_map.conf
 lib/*/security/pam_user_map.so
 lib/systemd/system/mariadb@bootstrap.service.d/use_galera_new_cluster.conf
@@ -61,7 +61,7 @@ usr/lib/mysql/plugin/server_audit.so
 usr/lib/mysql/plugin/simple_password_check.so
 usr/lib/mysql/plugin/sql_errlog.so
 usr/lib/mysql/plugin/wsrep_info.so
-usr/share/doc/mariadb-server-10.5/mysqld.sym.gz
+usr/share/doc/mariadb-server-10.5/mariadbd.sym.gz
 usr/share/man/man1/aria_chk.1
 usr/share/man/man1/aria_dump_log.1
 usr/share/man/man1/aria_ftdump.1

--- a/debian/mariadb-server-10.5.logcheck.ignore.paranoid
+++ b/debian/mariadb-server-10.5.logcheck.ignore.paranoid
@@ -1,9 +1,9 @@
-/etc/init.d/mariadb\[[0-9]+\]: Check that mysqld is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
+/etc/init.d/mariadb\[[0-9]+\]: Check that mariadbd is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
 /etc/init.d/mariadb\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
 /etc/mysql/debian-start\[[0-9]+\]: Checking for crashed MySQL tables\.$
-mysqld\[[0-9]+\]: $
-mysqld\[[0-9]+\]: Version: .* socket: '/run/mysqld/mysqld.sock'  port: 3306$
-mysqld\[[0-9]+\]: Warning: Ignoring user change to 'mysql' because the user was set to 'mysql' earlier on the command line$
+mariadbd\[[0-9]+\]: $
+mariadbd\[[0-9]+\]: Version: .* socket: '/run/mysqld/mysqld.sock'  port: 3306$
+mariadbd\[[0-9]+\]: Warning: Ignoring user change to 'mysql' because the user was set to 'mysql' earlier on the command line$
 mysqld_safe\[[0-9]+\]: started$
 usermod\[[0-9]+\]: change user `mysql' GID from `([0-9]+)' to `\1'$
 usermod\[[0-9]+\]: change user `mysql' shell from `/bin/false' to `/bin/false'$

--- a/debian/mariadb-server-10.5.logcheck.ignore.server
+++ b/debian/mariadb-server-10.5.logcheck.ignore.server
@@ -1,18 +1,18 @@
 /etc/init.d/mariadb\[[0-9]+\]: [0-9]+ processes alive and '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
-/etc/init.d/mariadb\[[0-9]+\]: Check that mysqld is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
+/etc/init.d/mariadb\[[0-9]+\]: Check that mariadbd is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
 /etc/init.d/mariadb\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
 /etc/mysql/debian-start\[[0-9]+\]: Checking for crashed MySQL tables\.$
-mysqld\[[0-9]+\]: ?$
-mysqld\[[0-9]+\]: .*InnoDB: Shutdown completed
-mysqld\[[0-9]+\]: .*InnoDB: Started;
-mysqld\[[0-9]+\]: .*InnoDB: Starting shutdown\.\.\.$
-mysqld\[[0-9]+\]: .*\[Note\] /usr/sbin/mysqld: Normal shutdown$
-mysqld\[[0-9]+\]: .*\[Note\] /usr/sbin/mysqld: ready for connections\.$
-mysqld\[[0-9]+\]: .*\[Note\] /usr/sbin/mysqld: Shutdown complete$
-mysqld\[[0-9]+\]: /usr/sbin/mysqld: ready for connections\.$
-mysqld\[[0-9]+\]: .*/usr/sbin/mysqld: Shutdown Complete$
-mysqld\[[0-9]+\]: Version: .* socket
-mysqld\[[0-9]+\]: Warning: Ignoring user change to 'mysql' because the user was set to 'mysql' earlier on the command line$
+mariadbd\[[0-9]+\]: ?$
+mariadbd\[[0-9]+\]: .*InnoDB: Shutdown completed
+mariadbd\[[0-9]+\]: .*InnoDB: Started;
+mariadbd\[[0-9]+\]: .*InnoDB: Starting shutdown\.\.\.$
+mariadbd\[[0-9]+\]: .*\[Note\] /usr/sbin/mariadbd: Normal shutdown$
+mariadbd\[[0-9]+\]: .*\[Note\] /usr/sbin/mariadbd: ready for connections\.$
+mariadbd\[[0-9]+\]: .*\[Note\] /usr/sbin/mariadbd: Shutdown complete$
+mariadbd\[[0-9]+\]: /usr/sbin/mariadbd: ready for connections\.$
+mariadbd\[[0-9]+\]: .*/usr/sbin/mariadbd: Shutdown Complete$
+mariadbd\[[0-9]+\]: Version: .* socket
+mariadbd\[[0-9]+\]: Warning: Ignoring user change to 'mysql' because the user was set to 'mysql' earlier on the command line$
 mysqld_safe\[[0-9]+\]: ?$
 mysqld_safe\[[0-9]+\]: able to use the new GRANT command!$
 mysqld_safe\[[0-9]+\]: ended$

--- a/debian/mariadb-server-10.5.logcheck.ignore.workstation
+++ b/debian/mariadb-server-10.5.logcheck.ignore.workstation
@@ -1,18 +1,18 @@
 /etc/init.d/mariadb\[[0-9]+\]: [0-9]+ processes alive and '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
-/etc/init.d/mariadb\[[0-9]+\]: Check that mysqld is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
+/etc/init.d/mariadb\[[0-9]+\]: Check that mariadbd is running and that the socket: '/run/mysqld/mysqld.sock' exists\!$
 /etc/init.d/mariadb\[[0-9]+\]: '/usr/bin/mysqladmin --defaults-(extra-)?file=/etc/mysql/debian.cnf ping' resulted in$
 /etc/mysql/debian-start\[[0-9]+\]: Checking for crashed MySQL tables\.$
-mysqld\[[0-9]+\]: ?$
-mysqld\[[0-9]+\]: .*InnoDB: Shutdown completed
-mysqld\[[0-9]+\]: .*InnoDB: Started;
-mysqld\[[0-9]+\]: .*InnoDB: Starting shutdown\.\.\.$
-mysqld\[[0-9]+\]: .*\[Note\] /usr/sbin/mysqld: Normal shutdown$
-mysqld\[[0-9]+\]: .*\[Note\] /usr/sbin/mysqld: ready for connections\.$
-mysqld\[[0-9]+\]: .*\[Note\] /usr/sbin/mysqld: Shutdown complete$
-mysqld\[[0-9]+\]: /usr/sbin/mysqld: ready for connections\.$
-mysqld\[[0-9]+\]: .*/usr/sbin/mysqld: Shutdown Complete$
-mysqld\[[0-9]+\]: Version: .* socket
-mysqld\[[0-9]+\]: Warning: Ignoring user change to 'mysql' because the user was set to 'mysql' earlier on the command line$
+mariadbd\[[0-9]+\]: ?$
+mariadbd\[[0-9]+\]: .*InnoDB: Shutdown completed
+mariadbd\[[0-9]+\]: .*InnoDB: Started;
+mariadbd\[[0-9]+\]: .*InnoDB: Starting shutdown\.\.\.$
+mariadbd\[[0-9]+\]: .*\[Note\] /usr/sbin/mariadbd: Normal shutdown$
+mariadbd\[[0-9]+\]: .*\[Note\] /usr/sbin/mariadbd: ready for connections\.$
+mariadbd\[[0-9]+\]: .*\[Note\] /usr/sbin/mariadbd: Shutdown complete$
+mariadbd\[[0-9]+\]: /usr/sbin/mariadbd: ready for connections\.$
+mariadbd\[[0-9]+\]: .*/usr/sbin/mariadbd: Shutdown Complete$
+mariadbd\[[0-9]+\]: Version: .* socket
+mariadbd\[[0-9]+\]: Warning: Ignoring user change to 'mysql' because the user was set to 'mysql' earlier on the command line$
 mysqld_safe\[[0-9]+\]: ?$
 mysqld_safe\[[0-9]+\]: able to use the new GRANT command!$
 mysqld_safe\[[0-9]+\]: ended$

--- a/debian/mariadb-server-10.5.mariadb.init
+++ b/debian/mariadb-server-10.5.mariadb.init
@@ -9,7 +9,7 @@
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Start and stop the mysql database server daemon
-# Description:       Controls the main MariaDB database server daemon "mysqld"
+# Description:       Controls the main MariaDB database server daemon "mariadbd"
 #                    and its wrapper script "mysqld_safe".
 ### END INIT INFO
 #
@@ -17,7 +17,7 @@ set -e
 set -u
 ${DEBIAN_SCRIPT_DEBUG:+ set -v -x}
 
-test -x /usr/sbin/mysqld || exit 0
+test -x /usr/sbin/mariadbd || exit 0
 
 . /lib/lsb/init-functions
 
@@ -50,16 +50,16 @@ export HOME=/etc/mysql/
 
 ## Fetch a particular option from mysql's invocation.
 #
-# Usage: void mysqld_get_param option
-mysqld_get_param() {
-  /usr/sbin/mysqld --print-defaults \
+# Usage: void mariadbd_get_param option
+mariadbd_get_param() {
+  /usr/sbin/mariadbd --print-defaults \
     | tr " " "\n" \
     | grep -- "--$1" \
     | tail -n 1 \
     | cut -d= -f2
 }
 
-## Do some sanity checks before even trying to start mysqld.
+## Do some sanity checks before even trying to start mariadbd.
 sanity_checks() {
   # check for config file
   if [ ! -r /etc/mysql/my.cnf ]; then
@@ -68,7 +68,7 @@ sanity_checks() {
   fi
 
   # check for diskspace shortage
-  datadir=`mysqld_get_param datadir`
+  datadir=`mariadbd_get_param datadir`
   if LC_ALL=C BLOCKSIZE= df --portability $datadir/. | tail -n 1 | awk '{ exit ($4>4096) }'; then
     log_failure_msg "$0: ERROR: The partition with $datadir is too full!"
     echo                "ERROR: The partition with $datadir is too full!" | $ERR_LOGGER
@@ -79,14 +79,14 @@ sanity_checks() {
 ## Checks if there is a server running and if so if it is accessible.
 #
 # check_alive insists on a pingable server
-# check_dead also fails if there is a lost mysqld in the process list
+# check_dead also fails if there is a lost mariadbd in the process list
 #
-# Usage: boolean mysqld_status [check_alive|check_dead] [warn|nowarn]
-mysqld_status () {
+# Usage: boolean mariadbd_status [check_alive|check_dead] [warn|nowarn]
+mariadbd_status () {
   ping_output=`$MYADMIN ping 2>&1`; ping_alive=$(( ! $? ))
 
   ps_alive=0
-  pidfile=`mysqld_get_param pid-file`
+  pidfile=`mariadbd_get_param pid-file`
   if [ -f "$pidfile" ] && ps `cat $pidfile` >/dev/null 2>&1; then ps_alive=1; fi
 
   if [ "$1" = "check_alive"  -a  $ping_alive = 1 ] ||
@@ -109,8 +109,8 @@ case "${1:-''}" in
   'start')
   sanity_checks;
   # Start daemon
-  log_daemon_msg "Starting MariaDB database server" "mysqld"
-  if mysqld_status check_alive nowarn; then
+  log_daemon_msg "Starting MariaDB database server" "mariadbd"
+  if mariadbd_status check_alive nowarn; then
    log_progress_msg "already running"
    log_end_msg 0
   else
@@ -122,10 +122,10 @@ case "${1:-''}" in
 
     for i in $(seq 1 "${MYSQLD_STARTUP_TIMEOUT:-30}"); do
       sleep 1
-      if mysqld_status check_alive nowarn ; then break; fi
+      if mariadbd_status check_alive nowarn ; then break; fi
       log_progress_msg "."
     done
-    if mysqld_status check_alive warn; then
+    if mariadbd_status check_alive warn; then
       log_end_msg 0
       # Now start mysqlcheck or whatever the admin wants.
       output=$(/etc/mysql/debian-start)
@@ -144,26 +144,26 @@ case "${1:-''}" in
   # at least for cron, we can rely on it here, too. (although we have
   # to specify it explicit as e.g. sudo environments points to the normal
   # users home and not /root)
-  log_daemon_msg "Stopping MariaDB database server" "mysqld"
-  if ! mysqld_status check_dead nowarn; then
+  log_daemon_msg "Stopping MariaDB database server" "mariadbd"
+  if ! mariadbd_status check_dead nowarn; then
     set +e
     shutdown_out=`$MYADMIN shutdown 2>&1`; r=$?
     set -e
     if [ "$r" -ne 0 ]; then
       log_end_msg 1
       [ "$VERBOSE" != "no" ] && log_failure_msg "Error: $shutdown_out"
-      log_daemon_msg "Killing MariaDB database server by signal" "mysqld"
-      killall -15 mysqld
+      log_daemon_msg "Killing MariaDB database server by signal" "mariadbd"
+      killall -15 mariadbd
       server_down=
       for i in `seq 1 600`; do
         sleep 1
-        if mysqld_status check_dead nowarn; then server_down=1; break; fi
+        if mariadbd_status check_dead nowarn; then server_down=1; break; fi
       done
-      if test -z "$server_down"; then killall -9 mysqld; fi
+      if test -z "$server_down"; then killall -9 mariadbd; fi
     fi
   fi
 
-  if ! mysqld_status check_dead warn; then
+  if ! mariadbd_status check_dead warn; then
     log_end_msg 1
     log_failure_msg "Please stop MariaDB manually and read /usr/share/doc/mariadb-server-10.5/README.Debian.gz!"
     exit -1
@@ -179,13 +179,13 @@ case "${1:-''}" in
   ;;
 
   'reload'|'force-reload')
-  log_daemon_msg "Reloading MariaDB database server" "mysqld"
+  log_daemon_msg "Reloading MariaDB database server" "mariadbd"
   $MYADMIN reload
   log_end_msg 0
   ;;
 
   'status')
-  if mysqld_status check_alive nowarn; then
+  if mariadbd_status check_alive nowarn; then
     log_action_msg "$($MYADMIN version)"
   else
     log_action_msg "MariaDB is stopped."
@@ -196,7 +196,7 @@ case "${1:-''}" in
   'bootstrap')
 	# Bootstrap the cluster, start the first node
 	# that initiates the cluster
-	log_daemon_msg "Bootstrapping the cluster" "mysqld"
+	log_daemon_msg "Bootstrapping the cluster" "mariadbd"
 	$SELF start "${@:2}" --wsrep-new-cluster
 	;;
 

--- a/debian/mariadb-server-10.5.mysql-server.logrotate
+++ b/debian/mariadb-server-10.5.mysql-server.logrotate
@@ -11,7 +11,7 @@
 	sharedscripts
 	postrotate
           test -x /usr/bin/mysqladmin || exit 0
-          if [ -f `my_print_defaults --mysqld | grep -oP "pid-file=\K[^$]+"` ]; then
+          if [ -f `my_print_defaults --mariadbd | grep -oP "pid-file=\K[^$]+"` ]; then
             # If this fails, check debian.conf!
             mysqladmin --defaults-file=/etc/mysql/debian.cnf --local flush-error-log \
               flush-engine-log flush-general-log flush-slow-log

--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -189,12 +189,12 @@ EOF
     # This allows upgrade from old versions (that have an apparmor profile
     # on by default) to work both to disable a default profile, and to keep
     # any profile installed and maintained by users themselves.
-    profile="/etc/apparmor.d/usr.sbin.mysqld"
+    profile="/etc/apparmor.d/usr.sbin.mariadbd"
     if [ -f "$profile" ] && aa-status --enabled 2>/dev/null; then
-      if grep -q /usr/sbin/mysqld "$profile" 2>/dev/null ; then
+      if grep -q /usr/sbin/mariadbd "$profile" 2>/dev/null ; then
         apparmor_parser -r "$profile" || true
       else
-        echo "/usr/sbin/mysqld { }" | apparmor_parser --remove 2>/dev/null || true
+        echo "/usr/sbin/mariadbd { }" | apparmor_parser --remove 2>/dev/null || true
       fi
     fi
 

--- a/debian/mariadb-server-10.5.postrm
+++ b/debian/mariadb-server-10.5.postrm
@@ -13,11 +13,11 @@ MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 
 # Try to stop the server in a sane way. If it does not success let the admin
 # do it himself. No database directories should be removed while the server
-# is running! Another mysqld in e.g. a different chroot is fine for us.
+# is running! Another mariadbd in e.g. a different chroot is fine for us.
 stop_server() {
     # Return immediately if there are no mysql processes running
     # as there is no point in trying to shutdown in that case.
-    if ! pgrep -x mysqld > /dev/null; then return; fi
+    if ! pgrep -x mariadbd > /dev/null; then return; fi
 
     set +e
     invoke-rc.d mariadb stop

--- a/debian/mariadb-server-10.5.preinst
+++ b/debian/mariadb-server-10.5.preinst
@@ -26,11 +26,11 @@ mysql_upgradedir=/var/lib/mysql-upgrade
 
 # Try to stop the server in a sane way. If it does not success let the admin
 # do it himself. No database directories should be removed while the server
-# is running! Another mysqld in e.g. a different chroot is fine for us.
+# is running! Another mariadbd in e.g. a different chroot is fine for us.
 stop_server() {
     # Return immediately if there are no mysql processes running
     # as there is no point in trying to shutdown in that case.
-    if ! pgrep -x --ns $$ mysqld > /dev/null; then return; fi
+    if ! pgrep -x --ns $$ mariadbd > /dev/null; then return; fi
 
     set +e
     invoke-rc.d mariadb stop

--- a/debian/rules
+++ b/debian/rules
@@ -43,7 +43,7 @@ ifeq (32,$(DEB_HOST_ARCH_BITS))
     CMAKEFLAGS += -DWITHOUT_ROCKSDB=true
 endif
 
-# Add extra flag to avoid WolfSSL code crashing the entire mysqld on s390x. This
+# Add extra flag to avoid WolfSSL code crashing the entire mariadbd on s390x. This
 # can be removed once upstream has made the code s390x compatible, see
 # https://jira.mariadb.org/browse/MDEV-21705 and
 # https://github.com/wolfSSL/wolfssl/issues/2828
@@ -136,10 +136,10 @@ endif
 
 	# nm numeric soft is not enough, therefore extra sort in command
 	# to satisfy Debian reproducible build requirements
-	nm --defined-only $(BUILDDIR)/sql/mysqld | LC_ALL=C sort | gzip -n -9 > $(TMP)/usr/share/doc/mariadb-server-10.5/mysqld.sym.gz
+	nm --defined-only $(BUILDDIR)/sql/mariadbd | LC_ALL=C sort | gzip -n -9 > $(TMP)/usr/share/doc/mariadb-server-10.5/mariadbd.sym.gz
 
 	# rename and install AppArmor profile
-	install -D -m 644 debian/apparmor-profile $(TMP)/etc/apparmor.d/usr.sbin.mysqld
+	install -D -m 644 debian/apparmor-profile $(TMP)/etc/apparmor.d/usr.sbin.mariadbd
 
 	# Install libmariadbclient18 compatibility links
 	ln -s libmariadb.so.3 $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/libmariadbclient.so

--- a/mysql-test/lib/v1/mysql-test-run.pl
+++ b/mysql-test/lib/v1/mysql-test-run.pl
@@ -2,16 +2,16 @@
 # -*- cperl -*-
 
 # Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335 USA
@@ -572,7 +572,7 @@ sub command_line_setup () {
              'valgrind-path=s'          => \$opt_valgrind_path,
 	     'callgrind'                => \$opt_callgrind,
 
-             # Stress testing 
+             # Stress testing
              'stress'                   => \$opt_stress,
              'stress-suite=s'           => \$opt_stress_suite,
              'stress-threads=i'         => \$opt_stress_threads,
@@ -655,7 +655,7 @@ sub command_line_setup () {
     $glob_mysql_test_dir= `cygpath -m "$glob_mysql_test_dir"`;
     chomp($glob_mysql_test_dir);
   }
-  if (defined $ENV{MTR_BINDIR}) 
+  if (defined $ENV{MTR_BINDIR})
   {
     $default_vardir= "$ENV{MTR_BINDIR}/mysql-test/var";
   }
@@ -700,7 +700,7 @@ sub command_line_setup () {
     {
       my $lib_mysqld=
         mtr_path_exists(vs_config_dirs('libmysqld',''));
-	  $lib_mysqld= $glob_cygwin_perl ? ":".`cygpath "$lib_mysqld"` 
+	  $lib_mysqld= $glob_cygwin_perl ? ":".`cygpath "$lib_mysqld"`
                                      : ";".$lib_mysqld;
       chomp($lib_mysqld);
       $ENV{'PATH'}="$ENV{'PATH'}".$lib_mysqld;
@@ -738,7 +738,7 @@ sub command_line_setup () {
 					 "$glob_bindir/client",
 					 "$glob_bindir/bin");
   }
-  
+
   # Look for language files and charsetsdir, use same share
   $path_share=      mtr_path_exists("$glob_bindir/share/mysql",
                                     "$glob_bindir/sql/share",
@@ -761,8 +761,8 @@ sub command_line_setup () {
 				       "$path_client_bindir/mysqld-debug",
 				       "$path_client_bindir/mysqld-max",
 				       "$glob_bindir/libexec/mysqld",
-				       "$glob_bindir/bin/mysqld",
-				       "$glob_bindir/sbin/mysqld");
+				       "$glob_bindir/bin/mariadbd",
+				       "$glob_bindir/sbin/mariadbd");
 
     # Use the mysqld found above to find out what features are available
     collect_mysqld_features();
@@ -815,7 +815,7 @@ sub command_line_setup () {
       	$used_binlog_format= $1;
       }
     }
-    if (defined $used_binlog_format) 
+    if (defined $used_binlog_format)
     {
       mtr_report("Using binlog format '$used_binlog_format'");
     }
@@ -1619,7 +1619,7 @@ sub environment_setup () {
   $ENV{'CHARSETSDIR'}=              $path_charsetsdir;
   $ENV{'UMASK'}=              "0660"; # The octal *string*
   $ENV{'UMASK_DIR'}=          "0770"; # The octal *string*
-  
+
   #
   # MySQL tests can produce output in various character sets
   # (especially, ctype_xxx.test). To avoid confusing Perl
@@ -1630,7 +1630,7 @@ sub environment_setup () {
   #
   $ENV{'LC_ALL'}=             "C";
   $ENV{'LC_CTYPE'}=           "C";
-  
+
   $ENV{'LC_COLLATE'}=         "C";
   $ENV{'USE_RUNNING_SERVER'}= $opt_extern;
   $ENV{'MYSQL_TEST_DIR'}=     $glob_mysql_test_dir;
@@ -1803,7 +1803,7 @@ sub environment_setup () {
   $ENV{'MYSQLADMIN'}= mtr_native_path($exe_mysqladmin);
 
   # ----------------------------------------------------
-  # Setup env so childs can execute perror  
+  # Setup env so childs can execute perror
   # ----------------------------------------------------
   $ENV{'MY_PERROR'}= mtr_native_path($exe_perror);
 
@@ -2773,7 +2773,7 @@ sub run_testcase ($) {
     if ($glob_win32_perl)
     {
       #ActiveState perl hangs  when using normal exit, use  POSIX::_exit instead
-      use POSIX qw[ _exit ]; 
+      use POSIX qw[ _exit ];
       POSIX::_exit(0);
     }
     else
@@ -3157,10 +3157,10 @@ sub mysqld_arguments ($$$$) {
     {
 #      NOTE: the backport (see BUG#48048) originally removed the
 #            commented out lines below. However, given that they are
-#            protected with a version check (< 50200) now, it should be 
-#            safe to keep them. The problem is that the backported patch 
-#            was into a 5.1 GA codebase - mysql-5.1-rep+2 tree - so 
-#            version is 501XX, consequently check becomes worthless. It 
+#            protected with a version check (< 50200) now, it should be
+#            safe to keep them. The problem is that the backported patch
+#            was into a 5.1 GA codebase - mysql-5.1-rep+2 tree - so
+#            version is 501XX, consequently check becomes worthless. It
 #            should be safe to uncomment them when merging up to 5.5.
 #
 #            RQG semisync test runs on the 5.1 GA tree and needs MTR v1.
@@ -4322,4 +4322,3 @@ sub list_options ($) {
 
   mtr_exit(1);
 }
-

--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -518,25 +518,25 @@ then
   # BASEDIR is already overridden on command line.  Do not re-set.
 
   # Use BASEDIR to discover le.
-  if test -x "$MY_BASEDIR_VERSION/libexec/mysqld"
+  if test -x "$MY_BASEDIR_VERSION/libexec/mariadbd"
   then
     ledir="$MY_BASEDIR_VERSION/libexec"
-  elif test -x "$MY_BASEDIR_VERSION/sbin/mysqld"
+  elif test -x "$MY_BASEDIR_VERSION/sbin/mariadbd"
   then
     ledir="$MY_BASEDIR_VERSION/sbin"
   else
     ledir="$MY_BASEDIR_VERSION/bin"
   fi
-elif test -x "$MY_PWD/bin/mysqld"
+elif test -x "$MY_PWD/bin/mariadbd"
 then
   MY_BASEDIR_VERSION="$MY_PWD"		# Where bin, share and data are
   ledir="$MY_PWD/bin"			# Where mysqld is
 # Check for the directories we would expect from a source install
-elif test -x "$MY_PWD/libexec/mysqld"
+elif test -x "$MY_PWD/libexec/mariadbd"
 then
   MY_BASEDIR_VERSION="$MY_PWD"		# Where libexec, share and var are
   ledir="$MY_PWD/libexec"		# Where mysqld is
-elif test -x "$MY_PWD/sbin/mysqld"
+elif test -x "$MY_PWD/sbin/mariadbd"
 then
   MY_BASEDIR_VERSION="$MY_PWD"		# Where sbin, share and var are
   ledir="$MY_PWD/sbin"			# Where mysqld is
@@ -570,7 +570,7 @@ else
 fi
 
 if test -z "$MYSQL_HOME"
-then 
+then
   if test -r "$DATADIR/my.cnf"
   then
     log_error "WARNING: Found $DATADIR/my.cnf
@@ -659,7 +659,7 @@ then
 
     # mysqld does not add ".err" to "--log-error=foo."; it considers a
     # trailing "." as an extension
-    
+
     if expr "$err_log" : '.*\.[^/]*$' > /dev/null
     then
         :
@@ -741,10 +741,10 @@ then
   chmod 755 $mysql_unix_port_dir
 fi
 
-# If the user doesn't specify a binary, we assume name "mysqld"
+# If the user doesn't specify a binary, we assume name "mariadbd"
 if test -z "$MYSQLD"
 then
-  MYSQLD=mysqld
+  MYSQLD=mariadbd
 fi
 
 if test ! -x "$ledir/$MYSQLD"
@@ -1050,8 +1050,8 @@ do
     log_notice "Number of processes running now: $numofproces"
     I=1
     while test "$I" -le "$numofproces"
-    do 
-      PROC=`ps xaww | grep "$ledir/$MYSQLD\>" | grep -v "grep" | grep "pid-file=$pid_file" | sed -n '$p'` 
+    do
+      PROC=`ps xaww | grep "$ledir/$MYSQLD\>" | grep -v "grep" | grep "pid-file=$pid_file" | sed -n '$p'`
 
       for T in $PROC
       do

--- a/support-files/MacOSX/ReadMe.txt
+++ b/support-files/MacOSX/ReadMe.txt
@@ -73,7 +73,7 @@ Note
    /usr/local/mysql-5.1.39-osx10.5-x86_64 . The installation layout
    of the directory is as shown in the following table:
    Directory       Contents of Directory
-   bin             Client programs and the mysqld server
+   bin             Client programs and the mariadbd server
    data            Log files, databases
    docs            Manual in Info format
    include         Include (header) files
@@ -285,7 +285,7 @@ Note
    Directory                   Contents of Directory
    /usr/bin                    Client programs
    /var/mysql                  Log files, databases
-   /usr/libexec                The mysqld server
+   /usr/libexec                The mariadbd server
    /usr/share/man              Unix manual pages
    /usr/share/mysql/mysql-test MySQL test suite
    /usr/share/mysql            Contains the mysql_install_db script

--- a/support-files/binary-configure.sh
+++ b/support-files/binary-configure.sh
@@ -41,7 +41,7 @@ echo ""
 ./scripts/mysql_install_db --no-defaults
 if [ $? = 0 ]
 then
-  echo "Starting the mysqld server.  You can test that it is up and running"
+  echo "Starting the mariadbd server.  You can test that it is up and running"
   echo "with the command:"
   echo "./bin/mysqladmin version"
   ./bin/mysqld_safe --no-defaults &

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -20,7 +20,7 @@
 
 [Unit]
 Description=MariaDB @VERSION@ database server
-Documentation=man:mysqld(8)
+Documentation=man:mariadbd(8)
 Documentation=https://mariadb.com/kb/en/library/systemd/
 After=network.target
 
@@ -37,7 +37,7 @@ WantedBy=multi-user.target
 Type=notify
 
 # Setting this to true can break replication and the Type=notify settings
-# See also bind-address mysqld option.
+# See also bind-address mariadbd option.
 PrivateNetwork=false
 
 ##############################################################################
@@ -89,7 +89,7 @@ ExecStartPre=/bin/sh -c "[ ! -e @bindir@/galera_recovery ] && VAR= || \
 # Use the [Service] section and Environment="MYSQLD_OPTS=...".
 # This isn't a replacement for my.cnf.
 # _WSREP_NEW_CLUSTER is for the exclusive use of the script galera_new_cluster
-ExecStart=@sbindir@/mysqld $MYSQLD_OPTS $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION
+ExecStart=@sbindir@/mariadbd $MYSQLD_OPTS $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION
 
 # Unset _WSREP_START_POSITION environment variable.
 ExecStartPost=/bin/sh -c "systemctl unset-environment _WSREP_START_POSITION"
@@ -118,7 +118,7 @@ UMask=007
 
 # Useful options not previously available in [mysqld_safe]
 
-# Kernels like killing mysqld when out of memory because its big.
+# Kernels like killing mariadbd when out of memory because its big.
 # Lets temper that preference a little.
 # OOMScoreAdjust=-600
 
@@ -163,7 +163,7 @@ LimitNOFILE=16364
 # ExecStartPre=sysctl -q -w vm.drop_caches=3
 
 # numa-interleave=1 equalivant
-# Change ExecStart=numactl --interleave=all @sbindir@/mysqld......
+# Change ExecStart=numactl --interleave=all @sbindir@/mariadbd......
 
 # crash-script equalivent
 # FailureAction=

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -34,10 +34,10 @@
 # like network ports, sockets and data directories listed under CONFLICTING
 # VARIABLES below. The systemd environment variable MYSQLD_MULTI_INSTANCE
 # controls each instance to ensure it is run independently. It is passed to
-# mysqld and mysql_install
+# mariadbd and mysql_install
 #
 # By default, a group suffix exists and within the default configuration
-# files, a group [mysqld.{instancename}] is read for each service. Other
+# files, a group [mariadbd.{instancename}] is read for each service. Other
 # default groups, like [server.{instancename}] and [mariadb.{instancename}],
 # are also read. For each instance, one of the groups will need to contain
 # the conflicting variables listed below under CONFLICTING VARIABLES.
@@ -119,7 +119,7 @@
 # Before 10.4 MYSQLD_MULTI_INSTANCE was effectively --defaults-file=@sysconf2dir@/my%I.cnf
 # As @sysconfdir@/my.cnf included these files it was a bad choice as an
 # existing single instance would include all these files. If you want to
-# continue a file based multi-instance mysqld, recommend the Configuration File
+# continue a file based multi-instance mariadbd, recommend the Configuration File
 # Based Mechanism above and moving @sysconf2dir@/my%I.cnf files to @sysconfdir@/my%I.cnf.
 #
 #
@@ -145,7 +145,7 @@
 
 [Unit]
 Description=MariaDB @VERSION@ database server (multi-instance %I)
-Documentation=man:mysqld(8)
+Documentation=man:mariadbd(8)
 Documentation=https://mariadb.com/kb/en/library/systemd/
 After=network.target
 
@@ -170,7 +170,7 @@ WantedBy=multi-user.target
 Type=notify
 
 # Setting this to true can break replication and the Type=notify settings
-# See also bind-address mysqld option.
+# See also bind-address mariadbd option.
 PrivateNetwork=false
 
 ##############################################################################
@@ -206,7 +206,7 @@ ExecStartPre=@scriptdir@/mysql_install_db $MYSQLD_MULTI_INSTANCE
 # * MYSQLD_OPTS - user definable extras - not a replacement for my.cnf
 #
 # Note 1: Place $MYSQLD_OPTS at the very end for its options to take precedence.
-ExecStart=@sbindir@/mysqld $MYSQLD_MULTI_INSTANCE $MYSQLD_OPTS
+ExecStart=@sbindir@/mariadbd $MYSQLD_MULTI_INSTANCE $MYSQLD_OPTS
 
 @SYSTEMD_EXECSTARTPOST@
 
@@ -232,7 +232,7 @@ UMask=007
 
 # Useful options not previously available in [mysqld_safe]
 
-# Kernels like killing mysqld when out of memory because its big.
+# Kernels like killing mariadbd when out of memory because its big.
 # Lets temper that preference a little.
 # OOMScoreAdjust=-600
 
@@ -288,7 +288,7 @@ LimitNOFILE=16364
 # ExecStartPre=sysctl -q -w vm.drop_caches=3
 
 # numa-interleave=1 equalivant
-# Change ExecStart=numactl --interleave=all @sbindir@/mysqld......
+# Change ExecStart=numactl --interleave=all @sbindir@/mariadbd......
 
 # crash-script equalivent
 # FailureAction=

--- a/support-files/mysql-log-rotate.sh
+++ b/support-files/mysql-log-rotate.sh
@@ -26,7 +26,7 @@
         missingok
         compress
     postrotate
-	# just if mysqld is really running
+	# just if mariadbd is really running
 	if test -x @bindir@/mysqladmin && \
 	   @bindir@/mysqladmin ping &>/dev/null
 	then

--- a/support-files/mysql-multi.server.sh
+++ b/support-files/mysql-multi.server.sh
@@ -50,7 +50,7 @@ then
   exit 1
 fi
 
-echo "mysqld $svr $mode"
+echo "mariadbd $svr $mode"
 
 parse_arguments() {
   for arg do
@@ -107,7 +107,7 @@ fi
 datadir=@localstatedir@
 basedir=
 pid_file=
-parse_arguments `$print_defaults $defaults mysqld mysql_server mysql_multi_server`
+parse_arguments `$print_defaults $defaults mariadbd mysqld mysql_server mysql_multi_server`
 
 if test -z "$basedir"
 then
@@ -157,15 +157,15 @@ case "$mode" in
     # root password.
     if test -f "$pid_file"
     then
-      mysqld_pid=`cat $pid_file`
-      echo "Killing mysqld $svr with pid $mysqld_pid"
-      kill $mysqld_pid
-      # mysqld should remove the pid_file when it exits, so wait for it.
+      mariadbd_pid=`cat $pid_file`
+      echo "Killing mariadbd $svr with pid $mariadbd_pid"
+      kill $mariadbd_pid
+      # mariadbd should remove the pid_file when it exits, so wait for it.
 
       sleep 1
       while [ -s $pid_file -a "$flags" != aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ]
       do
-        [ -z "$flags" ] && echo "Wait for mysqld $svr to exit\c" || echo ".\c"
+        [ -z "$flags" ] && echo "Wait for mariadbd $svr to exit\c" || echo ".\c"
         flags=a$flags
         sleep 1
       done
@@ -180,7 +180,7 @@ case "$mode" in
         rm /var/lock/subsys/mysql
       fi
     else
-      echo "No mysqld pid file found. Looked for $pid_file."
+      echo "No mariadbd pid file found. Looked for $pid_file."
     fi
     ;;
 

--- a/support-files/mysql.server-sys5.sh
+++ b/support-files/mysql.server-sys5.sh
@@ -30,7 +30,7 @@ EOF
 
 
 do_start() {
-    nohup ./bin/mysqld --defaults-file="$MY_CFG" &
+    nohup ./bin/mariadbd --defaults-file="$MY_CFG" &
 }
 
 do_stop() {
@@ -45,7 +45,7 @@ do_kill_all() {
 }
 
 do_kill() {
-    MY_PIDFILE=`read_mysql_config "$MY_CFG" "mysqld" "pidfile" `
+    MY_PIDFILE=`read_mysql_config "$MY_CFG" "mariadbd" "pidfile" `
     read MY_PID < "$MY_PIDFILE"
     kill "$MY_PID"
     sleep 2
@@ -60,14 +60,14 @@ do_admin() {
 }
 
 do_repair() {
-    MY_DATADIR=`read_mysql_config "$MY_CFG" "mysqld" "datadir" `
+    MY_DATADIR=`read_mysql_config "$MY_CFG" "mariadbd" "datadir" `
     ./bin/isamchk --defaults-file="$MY_CFG" --repair "$MY_DATADIR/$1"
     shift
 }
 
 
 do_repair_all() {
-    MY_DATADIR=`read_mysql_config "$MY_CFG" "mysqld" "datadir" `
+    MY_DATADIR=`read_mysql_config "$MY_CFG" "mariadbd" "datadir" `
     for i in `find "$MY_DATADIR" -name "*.ISM"`
     do
         ./bin/isamchk --defaults-file="$MY_CFG" --repair "$MY_DATADIR/$i"
@@ -76,7 +76,7 @@ do_repair_all() {
 
 
 
-MY_BASEDIR=`read_mysql_config "$MY_CFG" "mysqld" "basedir"`
+MY_BASEDIR=`read_mysql_config "$MY_CFG" "mariadbd" "basedir"`
 cd "$MY_BASEDIR" || exit 1
 while test $# -gt 0
 do

--- a/support-files/policy/apparmor/usr.sbin.mysqld
+++ b/support-files/policy/apparmor/usr.sbin.mysqld
@@ -5,7 +5,7 @@
 
 #include <tunables/global>
 
-/usr/sbin/mysqld flags=(complain) {
+/usr/sbin/mariadbd flags=(complain) {
   #include <abstractions/base>
   #include <abstractions/mysql>
   #include <abstractions/nameservice>
@@ -46,7 +46,7 @@
   /tmp/** rw,
   /usr/lib/mysql/plugin/ r,
   /usr/lib/mysql/plugin/*.so* mr,
-  /usr/sbin/mysqld mr,
+  /usr/sbin/mariadbd mr,
   /usr/share/mysql/** r,
   /var/lib/mysql/ r,
   /var/lib/mysql/** rwk,
@@ -147,5 +147,5 @@
     /usr/bin/xbstream rix,
   }
   # Site-specific additions and overrides. See local/README for details.
-  #include <local/usr.sbin.mysqld>
+  #include <local/usr.sbin.mariadbd>
 }


### PR DESCRIPTION
Replace all references to /usr/sbin/mysqld (and bin and libexec) with
mariadbd, so that the binary server will always be 'mariadbd'.

Also update all places that reference the server binary in other ways,
such as AppArmor profiles and scripts that previously expected to find
a 'mysqld' in process lists.