### PR TITLE
mytop fall-back to DBD::mysql if DBD::MariaDB is not available

### DIFF
--- a/scripts/mytop.sh
+++ b/scripts/mytop.sh
@@ -242,7 +242,16 @@ my $dsn;
 
 ## Socket takes precedence.
 
-$dsn ="DBI:MariaDB:database=$config{db};mariadb_read_default_group=mytop;";
+eval "use DBD::MariaDB";
+if($@)
+{
+    # MariaDB DBI driver is not available, using the 'mysql' driver
+    $dsn = "DBI:mysql:database=$config{db};mariadb_read_default_group=mytop;";
+}
+else
+{
+    $dsn = "DBI:MariaDB:database=$config{db};mariadb_read_default_group=mytop;";
+}
 
 if ($config{socket} and -S $config{socket})
 {

--- a/scripts/mytop.sh
+++ b/scripts/mytop.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# $Id: mytop,v 1.99-maria6 2019/10/22 14:53:51 jweisbuch Exp $
+# $Id: mytop,v 1.99-maria7 2020/05/18 15:32:15 jweisbuch Exp $
 
 =pod
 


### PR DESCRIPTION
On mytop 1.99-maria6, the DSN uses the MariaDB DBD driver which might not be installed on every systems, especially on older ones, which breaks mytop that cannot start anymore with an error such as :

> install_driver(MariaDB) failed: Can't locate DBD/MariaDB.pm in @INC (you may need to install the DBD::MariaDB module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at (eval 14) line 3.
Perhaps the DBD::MariaDB perl module hasn't been fully installed,
or perhaps the capitalisation of 'MariaDB' isn't right.
Available drivers: DBM, ExampleP, File, Gofer, Proxy, Sponge, mysql.
 at /usr/bin/mytop line 266.


The commit checks if the DBD::MariaDB module is available and uses DBD::mysql as a fallback.