### PR TITLE
[perf] Accelerate buffer pool init

### DIFF
--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -683,6 +683,9 @@ buf_block_t* buf_LRU_get_free_only()
 			>= buf_pool.withdraw_target
 		    || !buf_pool.will_be_withdrawn(block->page)) {
 			/* found valid free block */
+			if (block->locks_inited == false) {
+				buf_block_init_locks(block);
+			}
 			buf_page_mutex_enter(block);
 			/* No adaptive hash index entries may point to
 			a free block. */

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -233,6 +233,13 @@ buf_block_free(
 /*===========*/
 	buf_block_t*	block);	/*!< in, own: block to be freed */
 
+/*********************************************************************//**
+Init buffer block mutex and rwlocks */
+void
+buf_block_init_locks(
+/*===========*/
+        buf_block_t*    block); /*!< in, out: block to be inited */
+
 /**************************************************************//**
 NOTE! The following macros should be used instead of buf_page_get_gen,
 to improve debugging. Only values RW_S_LATCH and RW_X_LATCH are allowed
@@ -1487,6 +1494,9 @@ struct buf_block_t{
 					and accessed; we introduce this new
 					mutex in InnoDB-5.1 to relieve
 					contention on the buffer pool mutex */
+	bool            locks_inited;   /* Mark if this block's locks has been
+					inited. */
+
 
   void fix() { page.fix(); }
   uint32_t unfix() { return page.unfix(); }
@@ -2152,6 +2162,7 @@ Use these instead of accessing buffer pool mutexes directly. */
 
 /** Acquire the block->mutex. */
 #define buf_page_mutex_enter(b) do {			\
+	ut_ad(b->locks_inited);				\
 	mutex_enter(&(b)->mutex);			\
 } while (0)
 

--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -804,6 +804,10 @@ inline buf_page_t *buf_page_hash_get_low(page_id_t page_id)
 		ut_a(buf_page_in_file(bpage));
 		ut_ad(bpage->in_page_hash);
 		ut_ad(!bpage->in_zip_hash);
+		ut_ad(buf_page_get_state(bpage) == BUF_BLOCK_ZIP_DIRTY
+		      || buf_page_get_state(bpage) == BUF_BLOCK_ZIP_PAGE
+		      || buf_page_get_state(bpage) == BUF_BLOCK_POOL_WATCH
+		      || ((buf_block_t*)bpage)->locks_inited);
 	}
 
 	return(bpage);


### PR DESCRIPTION
Delay to init mutex in buf_block_t, only init the block's mutexes
when it get from the buffer pool free list at the first time.