### PR TITLE
[Feature] Drop Table Force

### DIFF
--- a/sql/handler.h
+++ b/sql/handler.h
@@ -5105,6 +5105,9 @@ int ha_create_table(THD *thd, const char *path,
                     HA_CREATE_INFO *create_info, LEX_CUSTRING *frm);
 int ha_delete_table(THD *thd, handlerton *db_type, const char *path,
                     const LEX_CSTRING *db, const LEX_CSTRING *alias, bool generate_warning);
+int ha_delete_table_force(THD *thd, const char *path, const char *db,
+                          const char *alias, bool generate_warning, int default_error);
+
 void ha_prepare_for_backup();
 void ha_end_backup();
 void ha_pre_shutdown();

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1301,6 +1301,7 @@ void LEX::start(THD *thd_arg)
   period_conditions.empty();
 
   is_lex_started= TRUE;
+  is_force_drop= FALSE;
 
   next_is_main= FALSE;
   next_is_down= FALSE;

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3374,6 +3374,7 @@ public:
   uint8 context_analysis_only;
   bool local_file;
   bool check_exists;
+  bool is_force_drop;
   bool autocommit;
   bool verbose, no_write_to_binlog;
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4840,6 +4840,9 @@ mysql_execute_command(THD *thd)
     int result;
     DBUG_ASSERT(first_table == all_tables && first_table != 0);
 
+    if (thd->lex && lex->is_force_drop && (check_global_access(thd, SUPER_ACL)))
+      goto error;
+
     thd->open_options|= HA_OPEN_FOR_REPAIR;
     result= thd->open_temporary_tables(all_tables);
     thd->open_options&= ~HA_OPEN_FOR_REPAIR;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1369,7 +1369,7 @@ End SQL_MODE_ORACLE_SPECIFIC */
 
 %type <num>
         order_dir lock_option
-        udf_type opt_local opt_no_write_to_binlog
+        udf_type opt_force opt_local opt_no_write_to_binlog
         opt_temporary all_or_any opt_distinct opt_glimit_clause
         opt_ignore_leaves fulltext_options union_option
         opt_not
@@ -12631,8 +12631,10 @@ drop:
             YYPS->m_lock_type= TL_UNLOCK;
             YYPS->m_mdl_type= MDL_EXCLUSIVE;
           }
-          table_list opt_lock_wait_timeout opt_restrict
-          {}
+          table_list opt_lock_wait_timeout opt_force opt_restrict
+          {
+            Lex->is_force_drop = $8;
+          }
         | DROP INDEX_SYM
           {
             if (Lex->main_select_push())
@@ -12790,6 +12792,10 @@ opt_if_exists:
           $$.set(DDL_options_st::OPT_IF_EXISTS);
         }
         ;
+
+opt_force:
+          /* empty */ { $$= 0; }
+        | FORCE_SYM { $$= 1; }
 
 opt_temporary:
           /* empty */ { $$= 0; }


### PR DESCRIPTION
Add a new syntax drop table force. Tables can be dropped forcely if
missing .frm or .ibd files.