### PR TITLE
MDEV-22468: Server with WSREP hangs after INSERT, wrong usage of mutex 'LOCK_thd_data' and 'share->intern_lock' / 'lock->mutex'

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-22458.result
+++ b/mysql-test/suite/galera/r/MDEV-22458.result
@@ -1,0 +1,10 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (a INT);
+connect  con1,localhost,root,,test;
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+SHOW EXPLAIN FOR 18;
+ERROR HY000: Target is not running an EXPLAINable command
+connection con1;
+INSERT INTO t1 VALUES (5),(6),(7),(8);
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-22458.test
+++ b/mysql-test/suite/galera/t/MDEV-22458.test
@@ -1,0 +1,20 @@
+# MDEV-22458
+# 
+# When running SHOW command thread lock `LOCK_thd_data` will be taken
+# and not unlocked when APC calls is done.
+
+--source include/galera_cluster.inc
+CREATE TABLE t1 (a INT);
+
+--connect (con1,localhost,root,,test)
+--let $con1= `SELECT CONNECTION_ID()`
+
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+
+--error ER_TARGET_NOT_EXPLAINABLE
+eval SHOW EXPLAIN FOR $con1;
+
+--connection con1
+INSERT INTO t1 VALUES (5),(6),(7),(8);
+
+DROP TABLE t1;

--- a/sql/my_apc.cc
+++ b/sql/my_apc.cc
@@ -176,6 +176,11 @@ bool Apc_target::make_apc_call(THD *caller_thd, Apc_call *call,
       /* Request was successfully executed and dequeued by the target thread */
       res= FALSE;
     }
+#ifdef WITH_WSREP
+    /* If lock ptr is set due WSREP thread we need to unlock it*/
+    if (LOCK_thd_data_ptr)
+      mysql_mutex_unlock(LOCK_thd_data_ptr);
+#endif
     /* 
       exit_cond() will call mysql_mutex_unlock(LOCK_thd_kill_ptr) for us:
     */
@@ -186,6 +191,10 @@ bool Apc_target::make_apc_call(THD *caller_thd, Apc_call *call,
   }
   else
   {
+#ifdef WITH_WSREP
+    if (LOCK_thd_data_ptr)
+      mysql_mutex_unlock(LOCK_thd_data_ptr);
+#endif
     mysql_mutex_unlock(LOCK_thd_kill_ptr);
   }
   return res;

--- a/sql/my_apc.h
+++ b/sql/my_apc.h
@@ -101,6 +101,9 @@ public:
 #ifndef DBUG_OFF
   int n_calls_processed; /* Number of calls served by this target */
 #endif
+#ifdef WITH_WSREP
+  mysql_mutex_t *LOCK_thd_data_ptr; /* WSREP locks with `find_thread_by_id` */
+#endif
 private:
   class Call_request;
 


### PR DESCRIPTION
Running SHOW EXPLAIN will take lock on target->LOCK_thd_data if target is WSREP thread.
We need to unlock it in APC call before target->LOCK_thd_kill.