### PR TITLE
MDEV-22763 backporting MDEV-20225 fix into 10.1

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-20225.result
+++ b/mysql-test/suite/galera/r/MDEV-20225.result
@@ -1,0 +1,16 @@
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT, f2 INT) ENGINE=InnoDB;
+CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW INSERT INTO t2 VALUES (NULL, NEW.f1);
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_slave_threads = 2;
+SET GLOBAL debug_dbug = 'd,sync.mdev_20225';
+DROP TRIGGER tr1;
+INSERT INTO t1 VALUES (NULL);
+SET GLOBAL debug_dbug = 'RESET';
+SET DEBUG_SYNC = 'now SIGNAL signal.mdev_20225_continue';
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL wsrep_slave_threads = 1;
+SHOW TRIGGERS;
+Trigger	Event	Table	Statement	Timing	Created	sql_mode	Definer	character_set_client	collation_connection	Database Collation
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/MDEV-20225.test
+++ b/mysql-test/suite/galera/t/MDEV-20225.test
@@ -1,0 +1,49 @@
+#
+# MDEV-20225 - Verify that DROP TRIGGER gets keys assigned corresponding
+#              to all affected tables.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT, f2 INT) ENGINE=InnoDB;
+
+CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW INSERT INTO t2 VALUES (NULL, NEW.f1);
+
+--connection node_2
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_slave_threads = 2;
+SET GLOBAL debug_dbug = 'd,sync.mdev_20225';
+
+--let $galera_connection_name = node_1a
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+DROP TRIGGER tr1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'debug sync point: now'
+--source include/wait_condition.inc
+
+
+--connection node_1
+INSERT INTO t1 VALUES (NULL);
+# We must rely on sleep here. If the bug is fixed, the second applier
+# is not allowed to go past apply monitor which would trigger the bug,
+# so there is no sync point or condition to wait.
+--sleep 1
+
+--connection node_2
+SET GLOBAL debug_dbug = 'RESET';
+SET DEBUG_SYNC = 'now SIGNAL signal.mdev_20225_continue';
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL wsrep_slave_threads = 1;
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.t1;
+--source include/wait_condition.inc
+
+# Trigger should now be dropped on node_2.
+SHOW TRIGGERS;
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -34,7 +34,9 @@
 #include "sql_handler.h"                        // mysql_ha_rm_tables
 #include "sp_cache.h"                     // sp_invalidate_cache
 #include <mysys_err.h>
-
+#ifdef WITH_WSREP
+#include "debug_sync.h"
+#endif /* WITH_WSREP */
 /*************************************************************************/
 
 template <class T>
@@ -506,7 +508,7 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
 
 #ifdef WITH_WSREP
   if (thd->wsrep_exec_mode == LOCAL_STATE)
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL);
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, tables);
 #endif
 
   /* We should have only one table in table list. */
@@ -568,6 +570,16 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
       goto end;
   }
 
+#ifdef WITH_WSREP
+  DBUG_EXECUTE_IF("sync.mdev_20225",
+                  {
+                    const char act[]=
+                      "now "
+                      "wait_for signal.mdev_20225_continue";
+                    DBUG_ASSERT(!debug_sync_set_action(thd,
+                                                       STRING_WITH_LEN(act)));
+                  };);
+#endif /* WITH_WSREP */
   result= (create ?
            table->triggers->create_trigger(thd, tables, &stmt_query):
            table->triggers->drop_trigger(thd, tables, &stmt_query));

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1570,10 +1570,17 @@ static bool wsrep_can_run_in_toi(THD *thd, const char *db, const char *table,
 
   case SQLCOM_CREATE_TRIGGER:
 
-    DBUG_ASSERT(!table_list);
     DBUG_ASSERT(first_table);
 
     if (find_temporary_table(thd, first_table))
+    {
+      return false;
+    }
+    return true;
+
+  case SQLCOM_DROP_TRIGGER:
+    DBUG_ASSERT(table_list);
+    if (find_temporary_table(thd, table_list))
     {
       return false;
     }

--- a/sql/wsrep_thd.h
+++ b/sql/wsrep_thd.h
@@ -25,6 +25,7 @@
 int wsrep_show_bf_aborts (THD *thd, SHOW_VAR *var, char *buff,
                           enum enum_var_type scope);
 void wsrep_client_rollback(THD *thd);
+void wsrep_replay_sp_transaction(THD* thd);
 void wsrep_replay_transaction(THD *thd);
 void wsrep_create_appliers(long threads);
 void wsrep_create_rollbacker();


### PR DESCRIPTION
Backported the support for aborting and replaying stored procedure execution and fix for trigger
key assignments from 10.4 version.
Backported also two mtr tests: wsrep_sp_bf_abort and MDEV-20225