### PR TITLE
MDEV-22763 backporting MDEV-20225 fix into 10.1

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-20225.result
+++ b/mysql-test/suite/galera/r/MDEV-20225.result
@@ -1,0 +1,16 @@
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT, f2 INT) ENGINE=InnoDB;
+CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW INSERT INTO t2 VALUES (NULL, NEW.f1);
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_slave_threads = 2;
+SET GLOBAL debug_dbug = 'd,sync.mdev_20225';
+DROP TRIGGER tr1;
+INSERT INTO t1 VALUES (NULL);
+SET GLOBAL debug_dbug = 'RESET';
+SET DEBUG_SYNC = 'now SIGNAL signal.mdev_20225_continue';
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL wsrep_slave_threads = 1;
+SHOW TRIGGERS;
+Trigger	Event	Table	Statement	Timing	Created	sql_mode	Definer	character_set_client	collation_connection	Database Collation
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/r/galera_sp_bf_abort.result
+++ b/mysql-test/suite/galera/r/galera_sp_bf_abort.result
@@ -1,0 +1,294 @@
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+SET SESSION wsrep_sync_wait = 0;
+CREATE PROCEDURE proc_update_insert()
+BEGIN
+UPDATE t1 SET f2 = 'b';
+INSERT INTO t1 VALUES (4, 'd');
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_update_insert;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	b
+2	c
+3	b
+4	d
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_update_insert_with_exit_handler()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+UPDATE t1 SET f2 = 'b';
+INSERT INTO t1 VALUES (4, 'd');
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_update_insert_with_exit_handler;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	b
+2	c
+3	b
+4	d
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_update_insert_with_continue_handler()
+BEGIN
+DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+UPDATE t1 SET f2 = 'b';
+INSERT INTO t1 VALUES (4, 'd');
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_update_insert_with_continue_handler;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	b
+2	c
+3	b
+4	d
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_update_insert_transaction()
+BEGIN
+START TRANSACTION;
+UPDATE t1 SET f2 = 'b';
+INSERT INTO t1 VALUES (4, 'd');
+COMMIT;
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_update_insert_transaction;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+Warnings:
+Error	1317	Query execution was interrupted
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	b
+2	c
+3	b
+4	d
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_update_insert_transaction_with_continue_handler()
+BEGIN
+DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+START TRANSACTION;
+UPDATE t1 SET f2 = 'b';
+INSERT INTO t1 VALUES (4, 'd');
+COMMIT;
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_update_insert_transaction_with_continue_handler;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+Warnings:
+Error	1317	Query execution was interrupted
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	b
+2	c
+3	b
+4	d
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_update_insert_transaction_with_exit_handler()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+START TRANSACTION;
+UPDATE t1 SET f2 = 'b';
+INSERT INTO t1 VALUES (4, 'd');
+COMMIT;
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_update_insert_transaction_with_exit_handler;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+Warnings:
+Error	1317	Query execution was interrupted
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	b
+2	c
+3	b
+4	d
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_insert_insert_conflict()
+BEGIN
+INSERT INTO t1 VALUES (2, 'd');
+INSERT INTO t1 VALUES (4, 'd');
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_insert_insert_conflict;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+Got one of the listed errors
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	a
+2	c
+3	a
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_insert_insert_conflict_with_exit_handler()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION SELECT "Conflict exit handler";
+INSERT INTO t1 VALUES (2, 'd');
+INSERT INTO t1 VALUES (4, 'd');
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_insert_insert_conflict_with_exit_handler;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+Conflict exit handler
+Conflict exit handler
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	a
+2	c
+3	a
+wsrep_local_replays
+1
+DELETE FROM t1;
+CREATE PROCEDURE proc_insert_insert_conflict_with_continue_handler()
+BEGIN
+DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SELECT "Conflict continue handler";
+INSERT INTO t1 VALUES (2, 'd');
+INSERT INTO t1 VALUES (4, 'd');
+END|
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+INSERT INTO t1 VALUES (2, 'c');
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,after_replicate_sync';
+CALL proc_insert_insert_conflict_with_continue_handler;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'signal=after_replicate_sync';
+Conflict continue handler
+Conflict continue handler
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+f1	f2
+1	a
+2	c
+3	a
+4	d
+wsrep_local_replays
+1
+DELETE FROM t1;
+DROP PROCEDURE proc_update_insert;
+DROP PROCEDURE proc_update_insert_with_continue_handler;
+DROP PROCEDURE proc_update_insert_with_exit_handler;
+DROP PROCEDURE proc_update_insert_transaction;
+DROP PROCEDURE proc_update_insert_transaction_with_continue_handler;
+DROP PROCEDURE proc_update_insert_transaction_with_exit_handler;
+DROP PROCEDURE proc_insert_insert_conflict;
+DROP PROCEDURE proc_insert_insert_conflict_with_exit_handler;
+DROP PROCEDURE proc_insert_insert_conflict_with_continue_handler;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-20225.test
+++ b/mysql-test/suite/galera/t/MDEV-20225.test
@@ -1,0 +1,49 @@
+#
+# MDEV-20225 - Verify that DROP TRIGGER gets keys assigned corresponding
+#              to all affected tables.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+CREATE TABLE t1 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
+CREATE TABLE t2 (f1 INT NOT NULL PRIMARY KEY AUTO_INCREMENT, f2 INT) ENGINE=InnoDB;
+
+CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW INSERT INTO t2 VALUES (NULL, NEW.f1);
+
+--connection node_2
+SET SESSION wsrep_sync_wait = 0;
+SET GLOBAL wsrep_slave_threads = 2;
+SET GLOBAL debug_dbug = 'd,sync.mdev_20225';
+
+--let $galera_connection_name = node_1a
+--let $galera_server_number = 1
+--source include/galera_connect.inc
+DROP TRIGGER tr1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'debug sync point: now'
+--source include/wait_condition.inc
+
+
+--connection node_1
+INSERT INTO t1 VALUES (NULL);
+# We must rely on sleep here. If the bug is fixed, the second applier
+# is not allowed to go past apply monitor which would trigger the bug,
+# so there is no sync point or condition to wait.
+--sleep 1
+
+--connection node_2
+SET GLOBAL debug_dbug = 'RESET';
+SET DEBUG_SYNC = 'now SIGNAL signal.mdev_20225_continue';
+SET DEBUG_SYNC = 'RESET';
+SET GLOBAL wsrep_slave_threads = 1;
+
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.t1;
+--source include/wait_condition.inc
+
+# Trigger should now be dropped on node_2.
+SHOW TRIGGERS;
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/galera/t/galera_sp_bf_abort.inc
+++ b/mysql-test/suite/galera/t/galera_sp_bf_abort.inc
@@ -1,0 +1,36 @@
+#
+# Issue an INSERT for gap between 1 and 3 to node_2 and wait until it hits
+# apply monitor sync point on node_1
+#
+
+--connection node_1a
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_2
+--eval $galera_sp_bf_abort_conflict
+
+--connection node_1a
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Send a procedure to node_1 which should take a gap lock between
+# rows 1 and 3. It does not conflict with INSERT from node_2 in
+# certification. Park the UPDATE after replicate and let INSERT to
+# continue applying, generating a BF abort.
+
+--let $galera_sync_point = after_replicate_sync
+--source include/galera_set_sync_point.inc
+
+--connection node_1
+--send_eval CALL $galera_sp_bf_abort_proc
+
+--connection node_1a
+--let $galera_sync_point = after_replicate_sync apply_monitor_slave_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--let $galera_sync_point = after_replicate_sync
+--source include/galera_signal_sync_point.inc

--- a/mysql-test/suite/galera/t/galera_sp_bf_abort.test
+++ b/mysql-test/suite/galera/t/galera_sp_bf_abort.test
@@ -1,0 +1,347 @@
+#
+# Test cases for stored procedure BF aborts.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connection node_1
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1));
+
+# Control connection for Galera sync point management
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+SET SESSION wsrep_sync_wait = 0;
+
+--connection node_1
+#
+# Case 1a: Procedure does and UPDATE which will suffer BF abort
+# but there is no actual conflict and non-conflicting INSERT.
+# The expected outcome is that both UPDATE and INSERT will succedd
+# and no errors are reported to the client, wsrep_local_replays is
+# incremented by one.
+#
+DELIMITER |;
+CREATE PROCEDURE proc_update_insert()
+BEGIN
+  UPDATE t1 SET f2 = 'b';
+  INSERT INTO t1 VALUES (4, 'd');
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_update_insert
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 1 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+#
+# Case 1b: Procedure does and UPDATE which will suffer BF abort
+# but there is no actual conflict and non-conflicting INSERT.
+# An EXIT HANDLER is declared for the procedure.
+# The expected outcome is that both UPDATE and INSERT will succedd
+# and no errors are reported to the client, wsrep_local_replays is
+# incremented by one.
+#
+DELIMITER |;
+CREATE PROCEDURE proc_update_insert_with_exit_handler()
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+  UPDATE t1 SET f2 = 'b';
+  INSERT INTO t1 VALUES (4, 'd');
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_update_insert_with_exit_handler
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 1 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+#
+# Case 1c: Procedure does and UPDATE which will suffer BF abort
+# but there is no actual conflict and non-conflicting INSERT.
+# A CONTINUE HANDLER is declared for the procedure.
+# The expected outcome is that both UPDATE and INSERT will succedd
+# and no errors are reported to the client, wsrep_local_replays is
+# incremented by one.
+#
+DELIMITER |;
+CREATE PROCEDURE proc_update_insert_with_continue_handler()
+BEGIN
+
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+  UPDATE t1 SET f2 = 'b';
+  INSERT INTO t1 VALUES (4, 'd');
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+SET SESSION wsrep_sync_wait = 0;
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_update_insert_with_continue_handler
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 1 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+#
+# Case 2a: UPDATE and INSERT are run inside a transaction and the transaction
+# will be BF aborted on COMMIT. The expected outcome is that the transaction
+# succeeds and no errors are reported to the client, wsrep_local_replays
+# is incremented by one.
+#
+
+DELIMITER |;
+CREATE PROCEDURE proc_update_insert_transaction()
+BEGIN
+  START TRANSACTION;
+  UPDATE t1 SET f2 = 'b';
+  INSERT INTO t1 VALUES (4, 'd');
+  COMMIT;
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_update_insert_transaction
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+SET SESSION wsrep_sync_wait = 0;
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 1 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+#
+# Case 2b: UPDATE and INSERT are run inside a transaction and the transaction
+# will be BF aborted on COMMIT. A CONTINUE HANDLER is declared for the
+# procedure. The expected outcome is that the transaction
+# succeeds and no errors are reported to the client, wsrep_local_replays
+# is incremented by one.
+#
+
+DELIMITER |;
+CREATE PROCEDURE proc_update_insert_transaction_with_continue_handler()
+BEGIN
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+  START TRANSACTION;
+  UPDATE t1 SET f2 = 'b';
+  INSERT INTO t1 VALUES (4, 'd');
+  COMMIT;
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_update_insert_transaction_with_continue_handler
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+SET SESSION wsrep_sync_wait = 0;
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 1 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+#
+# Case 2c: UPDATE and INSERT are run inside a transaction and the transaction
+# will be BF aborted on COMMIT. An EXIT HANDLE is declared for the procedure.
+# The expected outcome is that the transaction succeeds and no errors are
+# reported to the client, wsrep_local_replays is incremented by one.
+#
+
+DELIMITER |;
+CREATE PROCEDURE proc_update_insert_transaction_with_exit_handler()
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION BEGIN END;
+  START TRANSACTION;
+  UPDATE t1 SET f2 = 'b';
+  INSERT INTO t1 VALUES (4, 'd');
+  COMMIT;
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_update_insert_transaction_with_exit_handler
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+SET SESSION wsrep_sync_wait = 0;
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 1 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+
+#
+# Case 3a: Two INSERTs are run inside stored procedure, this time
+# the first INSERT will have a BF abort and real conflict. The expected outcome
+# is that the INSERT fails and an error is reported to the client.
+# wsrep_local_replays is not incremented.
+#
+# Notice that the resulting error code may be both
+# ER_DUP_ENTRY (procedure will exit with cert failure conflict state and
+# will be) or ER_LOCK_DEADLOCK depending on timing.
+#
+DELIMITER |;
+CREATE PROCEDURE proc_insert_insert_conflict()
+BEGIN
+  INSERT INTO t1 VALUES (2, 'd');
+  INSERT INTO t1 VALUES (4, 'd');
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_insert_insert_conflict
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+SET SESSION wsrep_sync_wait = 0;
+--source galera_sp_bf_abort.inc
+--connection node_1
+--error ER_DUP_ENTRY,ER_LOCK_DEADLOCK, ER_ERROR_DURING_COMMIT
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 0 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+
+#
+# Case 3b: Two INSERTs are run inside stored procedure, this time
+# the first INSERT will have a BF abort and real conflict.
+# An EXIT HANDLER is declared for the procedure.  The expected outcome
+# is that the INSERT fails and an error is reported to the client.
+# wsrep_local_replays is not incremented.
+#
+DELIMITER |;
+CREATE PROCEDURE proc_insert_insert_conflict_with_exit_handler()
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION SELECT "Conflict exit handler";
+  INSERT INTO t1 VALUES (2, 'd');
+  INSERT INTO t1 VALUES (4, 'd');
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_insert_insert_conflict_with_exit_handler
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+SET SESSION wsrep_sync_wait = 0;
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 0 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+--connection node_1
+
+#
+# Case 3c: Two INSERTs are run inside stored procedure, this time
+# the first INSERT will have a BF abort and real conflict.
+# A CONTINUE HANDLER is declared for the procedure.  The expected outcome
+# is that the the first INSERT fails but the second is executed without
+# errors. wsrep_local_replays is not incremented.
+#
+DELIMITER |;
+CREATE PROCEDURE proc_insert_insert_conflict_with_continue_handler()
+BEGIN
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SELECT "Conflict continue handler";
+  INSERT INTO t1 VALUES (2, 'd');
+  INSERT INTO t1 VALUES (4, 'd');
+END|
+DELIMITER ;|
+
+INSERT INTO t1 VALUES (1, 'a'), (3, 'a');
+--let $wsrep_local_replays_orig = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--let $galera_sp_bf_abort_proc = proc_insert_insert_conflict_with_continue_handler
+--let $galera_sp_bf_abort_conflict = INSERT INTO t1 VALUES (2, 'c')
+SET SESSION wsrep_sync_wait = 0;
+--source galera_sp_bf_abort.inc
+--connection node_1
+--reap
+SET SESSION wsrep_sync_wait = default;
+SELECT * FROM t1;
+--let $wsrep_local_replays_curr = `SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_local_replays'`
+--disable_query_log
+--eval SELECT $wsrep_local_replays_curr - $wsrep_local_replays_orig = 0 AS wsrep_local_replays;
+--enable_query_log
+
+DELETE FROM t1;
+
+
+DROP PROCEDURE proc_update_insert;
+DROP PROCEDURE proc_update_insert_with_continue_handler;
+DROP PROCEDURE proc_update_insert_with_exit_handler;
+DROP PROCEDURE proc_update_insert_transaction;
+DROP PROCEDURE proc_update_insert_transaction_with_continue_handler;
+DROP PROCEDURE proc_update_insert_transaction_with_exit_handler;
+DROP PROCEDURE proc_insert_insert_conflict;
+DROP PROCEDURE proc_insert_insert_conflict_with_exit_handler;
+DROP PROCEDURE proc_insert_insert_conflict_with_continue_handler;
+DROP TABLE t1;

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -34,7 +34,9 @@
 #include "sql_handler.h"                        // mysql_ha_rm_tables
 #include "sp_cache.h"                     // sp_invalidate_cache
 #include <mysys_err.h>
-
+#ifdef WITH_WSREP
+#include "debug_sync.h"
+#endif /* WITH_WSREP */
 /*************************************************************************/
 
 template <class T>
@@ -506,7 +508,7 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
 
 #ifdef WITH_WSREP
   if (thd->wsrep_exec_mode == LOCAL_STATE)
-    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, NULL);
+    WSREP_TO_ISOLATION_BEGIN(WSREP_MYSQL_DB, NULL, tables);
 #endif
 
   /* We should have only one table in table list. */
@@ -568,6 +570,16 @@ bool mysql_create_or_drop_trigger(THD *thd, TABLE_LIST *tables, bool create)
       goto end;
   }
 
+#ifdef WITH_WSREP
+  DBUG_EXECUTE_IF("sync.mdev_20225",
+                  {
+                    const char act[]=
+                      "now "
+                      "wait_for signal.mdev_20225_continue";
+                    DBUG_ASSERT(!debug_sync_set_action(thd,
+                                                       STRING_WITH_LEN(act)));
+                  };);
+#endif /* WITH_WSREP */
   result= (create ?
            table->triggers->create_trigger(thd, tables, &stmt_query):
            table->triggers->drop_trigger(thd, tables, &stmt_query));

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1570,10 +1570,17 @@ static bool wsrep_can_run_in_toi(THD *thd, const char *db, const char *table,
 
   case SQLCOM_CREATE_TRIGGER:
 
-    DBUG_ASSERT(!table_list);
     DBUG_ASSERT(first_table);
 
     if (find_temporary_table(thd, first_table))
+    {
+      return false;
+    }
+    return true;
+
+  case SQLCOM_DROP_TRIGGER:
+    DBUG_ASSERT(table_list);
+    if (find_temporary_table(thd, table_list))
     {
       return false;
     }

--- a/sql/wsrep_thd.h
+++ b/sql/wsrep_thd.h
@@ -25,6 +25,7 @@
 int wsrep_show_bf_aborts (THD *thd, SHOW_VAR *var, char *buff,
                           enum enum_var_type scope);
 void wsrep_client_rollback(THD *thd);
+void wsrep_replay_sp_transaction(THD* thd);
 void wsrep_replay_transaction(THD *thd);
 void wsrep_create_appliers(long threads);
 void wsrep_create_rollbacker();


### PR DESCRIPTION
Backported the support for aborting and replaying stored procedure execution and fix for trigger
key assignments from 10.4 version.
Backported also two mtr tests: wsrep_sp_bf_abort.test and MDEV-20225.test