### PR TITLE
MDEV-35982 - Move duplicates from trx_t to row_prebuilt_t

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7765,7 +7765,7 @@ ha_innobase::write_row(
 
 			switch (thd_sql_command(m_user_thd)) {
 			case SQLCOM_LOAD:
-				if (!m_prebuilt->duplicates) {
+				if (!m_prebuilt->duplicates_allowed()) {
 					break;
 				}
 
@@ -15571,7 +15571,8 @@ ha_innobase::extra(
 		break;
 	case HA_EXTRA_RESET_STATE:
 		reset_template();
-		m_prebuilt->duplicates = 0;
+		m_prebuilt->on_dup_replace = 0;
+		m_prebuilt->on_dup_ignore = 0;
 		break;
 	case HA_EXTRA_NO_KEYREAD:
 		m_prebuilt->read_just_key = 0;
@@ -15590,16 +15591,16 @@ ha_innobase::extra(
 		either, because the calling threads may change.
 		CAREFUL HERE, OR MEMORY CORRUPTION MAY OCCUR! */
 	case HA_EXTRA_INSERT_WITH_UPDATE:
-		m_prebuilt->duplicates |= TRX_DUP_IGNORE;
+		m_prebuilt->on_dup_ignore = 1;
 		break;
 	case HA_EXTRA_NO_IGNORE_DUP_KEY:
-		m_prebuilt->duplicates &= ~TRX_DUP_IGNORE;
+		m_prebuilt->on_dup_ignore = 0;
 		break;
 	case HA_EXTRA_WRITE_CAN_REPLACE:
-		m_prebuilt->duplicates |= TRX_DUP_REPLACE;
+		m_prebuilt->on_dup_replace = 1;
 		break;
 	case HA_EXTRA_WRITE_CANNOT_REPLACE:
-		m_prebuilt->duplicates &= ~TRX_DUP_REPLACE;
+		m_prebuilt->on_dup_replace = 0;
 		break;
 	case HA_EXTRA_BEGIN_ALTER_COPY:
 		m_prebuilt->table->skip_alter_undo = 1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7765,7 +7765,7 @@ ha_innobase::write_row(
 
 			switch (thd_sql_command(m_user_thd)) {
 			case SQLCOM_LOAD:
-				if (!trx->duplicates) {
+				if (!m_prebuilt->duplicates) {
 					break;
 				}
 
@@ -15571,7 +15571,7 @@ ha_innobase::extra(
 		break;
 	case HA_EXTRA_RESET_STATE:
 		reset_template();
-		thd_to_trx(ha_thd())->duplicates = 0;
+		m_prebuilt->duplicates = 0;
 		break;
 	case HA_EXTRA_NO_KEYREAD:
 		m_prebuilt->read_just_key = 0;
@@ -15590,16 +15590,16 @@ ha_innobase::extra(
 		either, because the calling threads may change.
 		CAREFUL HERE, OR MEMORY CORRUPTION MAY OCCUR! */
 	case HA_EXTRA_INSERT_WITH_UPDATE:
-		thd_to_trx(ha_thd())->duplicates |= TRX_DUP_IGNORE;
+		m_prebuilt->duplicates |= TRX_DUP_IGNORE;
 		break;
 	case HA_EXTRA_NO_IGNORE_DUP_KEY:
-		thd_to_trx(ha_thd())->duplicates &= ~TRX_DUP_IGNORE;
+		m_prebuilt->duplicates &= ~TRX_DUP_IGNORE;
 		break;
 	case HA_EXTRA_WRITE_CAN_REPLACE:
-		thd_to_trx(ha_thd())->duplicates |= TRX_DUP_REPLACE;
+		m_prebuilt->duplicates |= TRX_DUP_REPLACE;
 		break;
 	case HA_EXTRA_WRITE_CANNOT_REPLACE:
-		thd_to_trx(ha_thd())->duplicates &= ~TRX_DUP_REPLACE;
+		m_prebuilt->duplicates &= ~TRX_DUP_REPLACE;
 		break;
 	case HA_EXTRA_BEGIN_ALTER_COPY:
 		m_prebuilt->table->skip_alter_undo = 1;

--- a/storage/innobase/include/row0mysql.h
+++ b/storage/innobase/include/row0mysql.h
@@ -632,6 +632,7 @@ struct row_prebuilt_t {
 					(VARCHAR can be off-page too) */
 	unsigned	versioned_write:1;/*!< whether this is
 					a versioned write */
+	ulint		duplicates;	/*!< TRX_DUP_IGNORE | TRX_DUP_REPLACE */
 	mysql_row_templ_t* mysql_template;/*!< template used to transform
 					rows fast between MySQL and Innobase
 					formats; memory for this template

--- a/storage/innobase/include/row0mysql.h
+++ b/storage/innobase/include/row0mysql.h
@@ -632,7 +632,12 @@ struct row_prebuilt_t {
 					(VARCHAR can be off-page too) */
 	unsigned	versioned_write:1;/*!< whether this is
 					a versioned write */
-	ulint		duplicates;	/*!< TRX_DUP_IGNORE | TRX_DUP_REPLACE */
+	unsigned	on_dup_ignore:1;/*!< 1 if ha_innobase::extra(
+					HA_EXTRA_INSERT_WITH_UPDATE) was called,
+					0 otherwise */
+	unsigned	on_dup_replace:1;/*!< 1 if ha_innobase::extra(
+					HA_EXTRA_WRITE_CAN_REPLACE) was called,
+					0 otherwise */
 	mysql_row_templ_t* mysql_template;/*!< template used to transform
 					rows fast between MySQL and Innobase
 					formats; memory for this template
@@ -826,6 +831,12 @@ struct row_prebuilt_t {
 			}
 		}
 		return NULL;
+	}
+
+	/** Determine if any of duplicates allowance flags were set. */
+	bool duplicates_allowed() const
+	{
+		return on_dup_ignore || on_dup_replace;
 	}
 };
 

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -1183,11 +1183,6 @@ inline bool trx_is_started(const trx_t* trx)
 						converted to LOCK IN SHARE
 						MODE reads */
 
-/* Treatment of duplicate values (trx->duplicates; for example, in inserts).
-Multiple flags can be combined with bitwise OR. */
-#define TRX_DUP_IGNORE	1U	/* duplicate rows are to be updated */
-#define TRX_DUP_REPLACE	2U	/* duplicate rows are to be replaced */
-
 
 /** Commit node states */
 enum commit_node_state {

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -860,7 +860,6 @@ public:
 					in that case we will
 					flush the log in
 					trx_commit_complete_for_mysql() */
-	ulint		duplicates;	/*!< TRX_DUP_IGNORE | TRX_DUP_REPLACE */
 	trx_dict_op_t	dict_operation;	/**< @see enum trx_dict_op_t */
 
 	/* Fields protected by the srv_conc_mutex. */

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2423,6 +2423,7 @@ lock_rec_inherit_to_gap(
 	     lock = lock_rec_get_next(heap_no, lock)) {
 
 		if (!lock_rec_get_insert_intention(lock)
+		    /* MDEV-20605 FIXME: Remove this code */
 		    && (lock->trx->isolation_level > TRX_ISO_READ_COMMITTED)) {
 			lock_rec_add_to_queue(
 				LOCK_REC | LOCK_GAP | lock_get_mode(lock),

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -2423,9 +2423,7 @@ lock_rec_inherit_to_gap(
 	     lock = lock_rec_get_next(heap_no, lock)) {
 
 		if (!lock_rec_get_insert_intention(lock)
-		    && (lock->trx->isolation_level > TRX_ISO_READ_COMMITTED
-			|| lock_get_mode(lock) !=
-			(lock->trx->duplicates ? LOCK_S : LOCK_X))) {
+		    && (lock->trx->isolation_level > TRX_ISO_READ_COMMITTED)) {
 			lock_rec_add_to_queue(
 				LOCK_REC | LOCK_GAP | lock_get_mode(lock),
 				heir_block, heir_heap_no, lock->index,

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2110,7 +2110,7 @@ row_ins_scan_sec_index_for_duplicate(
 		      : BTR_SEARCH_LEAF,
 		      &pcur, mtr);
 
-	allow_duplicates = thr->prebuilt->duplicates;
+	allow_duplicates = thr->prebuilt->duplicates_allowed();
 
 	/* Scan index records and check if there is a duplicate */
 
@@ -2333,7 +2333,7 @@ row_ins_duplicate_error_in_clust(
 			if (flags & BTR_NO_LOCKING_FLAG) {
 				/* Do nothing if no-locking is set */
 				err = DB_SUCCESS;
-			} else if (thr->prebuilt->duplicates) {
+			} else if (thr->prebuilt->duplicates_allowed()) {
 
 				/* If the SQL-query will update or replace
 				duplicate key we will take X-lock for
@@ -2379,7 +2379,7 @@ duplicate:
 						  true,
 						  ULINT_UNDEFINED, &heap);
 
-			if (thr->prebuilt->duplicates) {
+			if (thr->prebuilt->duplicates_allowed()) {
 
 				/* If the SQL-query will update or replace
 				duplicate key we will take X-lock for

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2110,7 +2110,7 @@ row_ins_scan_sec_index_for_duplicate(
 		      : BTR_SEARCH_LEAF,
 		      &pcur, mtr);
 
-	allow_duplicates = thr_get_trx(thr)->duplicates;
+	allow_duplicates = thr->prebuilt->duplicates;
 
 	/* Scan index records and check if there is a duplicate */
 
@@ -2333,7 +2333,7 @@ row_ins_duplicate_error_in_clust(
 			if (flags & BTR_NO_LOCKING_FLAG) {
 				/* Do nothing if no-locking is set */
 				err = DB_SUCCESS;
-			} else if (trx->duplicates) {
+			} else if (thr->prebuilt->duplicates) {
 
 				/* If the SQL-query will update or replace
 				duplicate key we will take X-lock for
@@ -2379,7 +2379,7 @@ duplicate:
 						  true,
 						  ULINT_UNDEFINED, &heap);
 
-			if (trx->duplicates) {
+			if (thr->prebuilt->duplicates) {
 
 				/* If the SQL-query will update or replace
 				duplicate key we will take X-lock for

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -3118,7 +3118,8 @@ row_log_table_apply(
 
 	thr_get_trx(thr)->error_key_num = 0;
 	DBUG_EXECUTE_IF("innodb_trx_duplicates",
-			thr->prebuilt->duplicates = TRX_DUP_REPLACE;);
+			thr->prebuilt->on_dup_ignore = 0;
+			thr->prebuilt->on_dup_replace = 1;);
 
 	stage->begin_phase_log_table();
 
@@ -3154,7 +3155,8 @@ row_log_table_apply(
 
 	rw_lock_x_unlock(dict_index_get_lock(clust_index));
 	DBUG_EXECUTE_IF("innodb_trx_duplicates",
-			thr->prebuilt->duplicates = 0;);
+			thr->prebuilt->on_dup_replace = 0;
+			thr->prebuilt->on_dup_ignore = 0;);
 
 	return(error);
 }

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -3118,7 +3118,7 @@ row_log_table_apply(
 
 	thr_get_trx(thr)->error_key_num = 0;
 	DBUG_EXECUTE_IF("innodb_trx_duplicates",
-			thr_get_trx(thr)->duplicates = TRX_DUP_REPLACE;);
+			thr->prebuilt->duplicates = TRX_DUP_REPLACE;);
 
 	stage->begin_phase_log_table();
 
@@ -3154,7 +3154,7 @@ row_log_table_apply(
 
 	rw_lock_x_unlock(dict_index_get_lock(clust_index));
 	DBUG_EXECUTE_IF("innodb_trx_duplicates",
-			thr_get_trx(thr)->duplicates = 0;);
+			thr->prebuilt->duplicates = 0;);
 
 	return(error);
 }


### PR DESCRIPTION
The field was placed in the wrong place, so it is relocated to `row_prebuilt_t`. In MDEV-17814, there is a backport of the similar fix from MySQL 8.0, but it's more complicated than mine.