### PR TITLE
MDEV-12130: Add break statement in mysqltest

### DIFF
--- a/mysql-test/main/mysqltest-break.result
+++ b/mysql-test/main/mysqltest-break.result
@@ -1,0 +1,9 @@
+3
+2
+OK
+OK
+OK
+1
+cnt=3
+cnt=2
+mysqltest: At line 1: Stray break was found

--- a/mysql-test/main/mysqltest-break.test
+++ b/mysql-test/main/mysqltest-break.test
@@ -1,3 +1,4 @@
+--source include/not_embedded.inc
 #
 # MDEV-12130 improve mysqltest language
 #

--- a/mysql-test/main/mysqltest-break.test
+++ b/mysql-test/main/mysqltest-break.test
@@ -1,0 +1,86 @@
+#
+# MDEV-12130 improve mysqltest language
+#
+# test "break" statement
+#
+
+# Break in a single loop
+
+let $cnt= 4;
+while($cnt > 1)
+{
+  dec $cnt;
+  break;
+  --echo $cnt
+  --echo Break did not stop a single loop
+}
+
+# Break stops inner loop
+
+let $outer= 4;
+while($outer > 1)
+{
+  let $inner= 4;
+  while($inner > 1)
+  {
+    if($outer == 2)
+    {
+      --echo OK
+    }
+    if($inner == 2)
+    {
+      break;
+    }
+    dec $inner;
+  }
+  dec $outer;
+  --echo $outer
+}
+
+# Break stops outer loop
+let $inner= 4;
+let $outer= 4;
+while($outer > 1)
+{
+  break;
+  while($inner > 1)
+  {
+    dec $inner;
+    --echo Outer loop`s break did not stop inner loop
+  }
+  dec $outer;
+  --echo $outer
+}
+
+# Break stops loop in if
+let $cnt= 4;
+if($cnt > 1)
+{
+  while($cnt)
+  {
+    break;
+  }
+  dec $cnt;
+}
+
+--echo cnt=$cnt
+
+# Break in inner if
+
+let $cnt= 4;
+while($cnt > 1)
+{
+  if($cnt == 2)
+  {
+    break;
+    --echo "if" is working after break
+  }
+  dec $cnt;
+}
+
+--echo cnt=$cnt
+
+# Stray break
+
+--error 1
+--exec echo "break;" | $MYSQL_TEST 2>&1


### PR DESCRIPTION
I've added `break` statement to `mysqltest.cc ` to improve flexibility of test framework.