### PR TITLE
Enable compressions: snappy for InnoDB

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -95,6 +95,7 @@ endif
 	    -DPLUGIN_TOKUDB=NO \
 	    -DPLUGIN_CASSANDRA=NO \
 	    -DPLUGIN_AWS_KEY_MANAGEMENT=NO \
+	    -DWITH_INNODB_SNAPPY=ON \
 	    -DDEB=$(DEB_VENDOR) ..'
 
 # This is needed, otherwise 'make test' will run before binaries have been built

--- a/debian/tests/smoke
+++ b/debian/tests/smoke
@@ -24,7 +24,7 @@
 echo "Running test 'smoke'"
 set -ex
 
-# Start the deamon if it was not running. For example in Docker testing
+# Start the daemon if it was not running. For example in Docker testing
 # environments there might not be any systemd et al and the service needs to
 # be started manually.
 if ! which systemctl
@@ -66,17 +66,24 @@ DROP DATABASE testdatabase;
 DROP USER 'testuser'@'localhost';
 EOT
 
-mysql <<EOT
+# List based on what is advertised at
+# https://mariadb.com/kb/en/innodb-page-compression/#configuring-the-innodb-page-compression-algorithm
+# but disabled  with '#' the options that are not available in this binary build
+mariadb <<EOT
 SET GLOBAL innodb_compression_algorithm=lz4;
+#SET GLOBAL innodb_compression_algorithm=lzo;
+#SET GLOBAL innodb_compression_algorithm=lzma;
+#SET GLOBAL innodb_compression_algorithm=bzip2;
 SET GLOBAL innodb_compression_algorithm=snappy;
 SET GLOBAL innodb_compression_algorithm=zlib;
 SET GLOBAL innodb_compression_algorithm=none;
 EOT
 
-# Check whether RocksDB should be installed or not.
+# Check whether RocksDB should be installed or not
 plugin=mariadb-plugin-rocksdb
 if [ "$(dpkg-architecture -qDEB_HOST_ARCH_BITS)" != 32 ] &&
-   [ "$(dpkg-architecture -qDEB_HOST_ARCH_ENDIAN)" = little ]; then
+   [ "$(dpkg-architecture -qDEB_HOST_ARCH_ENDIAN)" = little ]
+  then
   dpkg-query -W $plugin
 
   LOG=/var/lib/mysql/#rocksdb/LOG
@@ -84,8 +91,18 @@ if [ "$(dpkg-architecture -qDEB_HOST_ARCH_BITS)" != 32 ] &&
   #      mariadb-server-10.5, which happens before that of the plugin.
   [ -e $LOG ] || mysql -e "INSTALL PLUGIN RocksDB SONAME 'ha_rocksdb';"
   # XXX: rocksdb_supported_compression_types variable does not report ZSTD.
+
+  # Print RocksDB supported items so test log is easier to debug
+  grep -F " supported:" $LOG
+
+  # Check that the expected compression methods are supported
   for a in LZ4 Snappy Zlib ZSTD; do
-    grep -qE "k$a(Compression)? supported: 1" $LOG
+    if ! grep -qE "k$a(Compression)? supported: 1" $LOG
+    then
+      # Fail with explicit error message
+      echo "Error: Compression method $a not supported by RocksDB!" >&2
+      exit 1
+    fi
   done
 else
   ! dpkg-query -W $plugin


### PR DESCRIPTION
The autopkgtest used in Debian checks that certain compression methods work. This test has been running fine on MariaDB 10.3 in Debian for a long time.

However, running the same test on the 10.5 branch failed first because InnoDB lacked Snappy:
https://salsa.debian.org/mariadb-team/mariadb-server/-/jobs/790991

..and then because RocksDB lacked zstd
https://salsa.debian.org/mariadb-team/mariadb-server/-/jobs/791338

This PR fixes both issues.

Before:
```
root@e1cbb08df912:/etc/mysql# mariadb --version
mariadb  Ver 15.1 Distrib 10.5.4-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper
root@e1cbb08df912:/etc/mysql# mariadb -e 'SET GLOBAL innodb_compression_algorithm=none;'
root@e1cbb08df912:/etc/mysql# mariadb -e 'SET GLOBAL innodb_compression_algorithm=zlib;'
root@e1cbb08df912:/etc/mysql# mariadb -e 'SET GLOBAL innodb_compression_algorithm=lz4;'
root@e1cbb08df912:/etc/mysql# mariadb -e 'SET GLOBAL innodb_compression_algorithm=lzo;'
ERROR 1231 (42000) at line 1: Variable 'innodb_compression_algorithm' can't be set to the value of 'lzo'
root@e1cbb08df912:/etc/mysql# mariadb -e 'SET GLOBAL innodb_compression_algorithm=lzma;'
ERROR 1231 (42000) at line 1: Variable 'innodb_compression_algorithm' can't be set to the value of 'lzma'
root@e1cbb08df912:/etc/mysql# mariadb -e 'SET GLOBAL innodb_compression_algorithm=bzip2;'
ERROR 1231 (42000) at line 1: Variable 'innodb_compression_algorithm' can't be set to the value of 'bzip2'
root@e1cbb08df912:/etc/mysql# mariadb -e 'SET GLOBAL innodb_compression_algorithm=snappy;'
ERROR 1231 (42000) at line 1: Variable 'innodb_compression_algorithm' can't be set to the value of 'snappy'
 
 
root@e1cbb08df912:/etc/mysql# grep -E "(Compression)? supported:" /var/lib/mysql/#rocksdb/LOG
2020/06/06-08:50:16.909747 7f68390b5800 Compression algorithms supported:
2020/06/06-08:50:16.909748 7f68390b5800 	kZSTDNotFinalCompression supported: 0
2020/06/06-08:50:16.909749 7f68390b5800 	kZSTD supported: 0
2020/06/06-08:50:16.909750 7f68390b5800 	kXpressCompression supported: 0
2020/06/06-08:50:16.909751 7f68390b5800 	kLZ4HCCompression supported: 1
2020/06/06-08:50:16.909752 7f68390b5800 	kLZ4Compression supported: 1
2020/06/06-08:50:16.909753 7f68390b5800 	kBZip2Compression supported: 0
2020/06/06-08:50:16.909753 7f68390b5800 	kZlibCompression supported: 1
2020/06/06-08:50:16.909754 7f68390b5800 	kSnappyCompression supported: 1
2020/06/06-08:50:16.909756 7f68390b5800 Fast CRC32 supported: Supported on x86
```

After:
```
root@8cd22b795594:/build# mariadb --version
mariadb  Ver 15.1 Distrib 10.5.4-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper
root@8cd22b795594:/build# mariadb -e 'SET GLOBAL innodb_compression_algorithm=none;'
root@8cd22b795594:/build# mariadb -e 'SET GLOBAL innodb_compression_algorithm=zlib;'
root@8cd22b795594:/build# mariadb -e 'SET GLOBAL innodb_compression_algorithm=lz4;'
root@8cd22b795594:/build# mariadb -e 'SET GLOBAL innodb_compression_algorithm=lzo;'
ERROR 1231 (42000) at line 1: Variable 'innodb_compression_algorithm' can't be set to the value of 'lzo'
root@8cd22b795594:/build# mariadb -e 'SET GLOBAL innodb_compression_algorithm=lzma;'
ERROR 1231 (42000) at line 1: Variable 'innodb_compression_algorithm' can't be set to the value of 'lzma'
root@8cd22b795594:/build# mariadb -e 'SET GLOBAL innodb_compression_algorithm=bzip2;'
ERROR 1231 (42000) at line 1: Variable 'innodb_compression_algorithm' can't be set to the value of 'bzip2'
root@8cd22b795594:/build# mariadb -e 'SET GLOBAL innodb_compression_algorithm=snappy;'

root@8cd22b795594:/build# grep -E "(Compression)? supported:" /var/lib/mysql/#rocksdb/LOG
2020/06/06-22:37:40.156165 7f6485853800 Compression algorithms supported:
2020/06/06-22:37:40.156166 7f6485853800 	kZSTDNotFinalCompression supported: 1
2020/06/06-22:37:40.156167 7f6485853800 	kZSTD supported: 1
2020/06/06-22:37:40.156167 7f6485853800 	kXpressCompression supported: 0
2020/06/06-22:37:40.156168 7f6485853800 	kLZ4HCCompression supported: 1
2020/06/06-22:37:40.156169 7f6485853800 	kLZ4Compression supported: 1
2020/06/06-22:37:40.156170 7f6485853800 	kBZip2Compression supported: 0
2020/06/06-22:37:40.156170 7f6485853800 	kZlibCompression supported: 1
2020/06/06-22:37:40.156171 7f6485853800 	kSnappyCompression supported: 1
2020/06/06-22:37:40.156173 7f6485853800 Fast CRC32 supported: Supported on x86
```