### PR TITLE
cmake: merge_static_libs - correct duplicate assumptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 .*.swp
 *.ninja
 .ninja_*
+*.mri
+*.mri.tpl
 .gdb_history
 .vs/
 errmsg.sys

--- a/cmake/merge_archives_unix.cmake
+++ b/cmake/merge_archives_unix.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2009 Sun Microsystems, Inc.
+# Copyright (c) 2020 IBM
 # Use is subject to license terms.
 # 
 # This program is free software; you can redistribute it and/or modify
@@ -14,43 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1335  USA 
 
-FILE(REMOVE "${TARGET_LOCATION}")
-
-SET(TEMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/merge_archives_${TARGET})
-MAKE_DIRECTORY(${TEMP_DIR})
-# Extract each archive to its own subdirectory(avoid object filename clashes)
-SEPARATE_ARGUMENTS(STATIC_LIBS UNIX_COMMAND "${STATIC_LIBS}")
-FOREACH(LIB ${STATIC_LIBS})
-  GET_FILENAME_COMPONENT(NAME_NO_EXT ${LIB} NAME_WE)
-  SET(TEMP_SUBDIR ${TEMP_DIR}/${NAME_NO_EXT})
-  MAKE_DIRECTORY(${TEMP_SUBDIR})
-  EXECUTE_PROCESS(
-    COMMAND ${CMAKE_AR} -x ${LIB}
-    WORKING_DIRECTORY ${TEMP_SUBDIR}
-  )
-
-  FILE(GLOB_RECURSE LIB_OBJECTS "${TEMP_SUBDIR}/*")
-  SET(OBJECTS ${OBJECTS} ${LIB_OBJECTS})
-ENDFOREACH()
-
-# Use relative paths, makes command line shorter.
-GET_FILENAME_COMPONENT(ABS_TEMP_DIR ${TEMP_DIR} ABSOLUTE)
-FOREACH(OBJ ${OBJECTS})
-  FILE(RELATIVE_PATH OBJ ${ABS_TEMP_DIR} ${OBJ})
-  FILE(TO_NATIVE_PATH ${OBJ} OBJ)
-  SET(ALL_OBJECTS ${ALL_OBJECTS} ${OBJ})
-ENDFOREACH()
-
-FILE(TO_NATIVE_PATH ${TARGET_LOCATION} ${TARGET_LOCATION})
-# Now pack the objects into library with ar.
 EXECUTE_PROCESS(
-  COMMAND ${CMAKE_AR} -r ${TARGET_LOCATION} ${ALL_OBJECTS}
-  WORKING_DIRECTORY ${TEMP_DIR}
+  COMMAND ${CMAKE_AR} -M
+  INPUT_FILE ${TARGET_SCRIPT}
 )
-EXECUTE_PROCESS(
-  COMMAND ${CMAKE_RANLIB} ${TARGET_LOCATION}
-  WORKING_DIRECTORY ${TEMP_DIR}
-)
-
-# Cleanup
-FILE(REMOVE_RECURSE ${TEMP_DIR})


### PR DESCRIPTION
This corrects build failures on ppc64{,le} with the EMBEDDED_SERVER
option enabled.

MDEV-22641 added an unusual case in which the same object
file in different directories contained a different function
defination. The original cmake/merge_archives_unix.cmake
did not tolerate such eventualities.

So we move to the highest voted answer on Stack Overflow
for the merging of static libraries.
https://stackoverflow.com/questions/3821916/how-to-merge-two-ar-static-libraries-into-one

Thin archives generated compile failures and the libtool
mechanism would of been another dependency and using .la
files that isn't part of a normal cmake output. The straight
Apple mechanism of libtool with static archives also failed
on Linux.

This leaves the MRI script mechansim which was implemented
in this change.