### PR TITLE
MDEV-21759 galera.galera_parallel_autoinc_manytrx sporadic failures.

### DIFF
--- a/mysql-test/suite/galera/r/galera_parallel_autoinc_manytrx.result
+++ b/mysql-test/suite/galera/r/galera_parallel_autoinc_manytrx.result
@@ -18,6 +18,8 @@ COMMIT;
 SET current_num = current_num + 1;
 END WHILE;
 END|
+call p1(1000);
+connection node_1;
 connection node_1a;
 connection node_1b;
 connection node_2;

--- a/mysql-test/suite/galera/t/galera_parallel_autoinc_manytrx.test
+++ b/mysql-test/suite/galera/t/galera_parallel_autoinc_manytrx.test
@@ -57,6 +57,8 @@ send call p1(1000);
 
 --connection node_2
 --disable_query_log
+--let $wait_condition = select count(*)=1 from information_schema.routines WHERE routine_name='p1';
+--source include/wait_condition.inc
 send call p1(1000);
 
 --connection node_1


### PR DESCRIPTION
The galera.galera_parallel_autoinc_manytrx mtr test opens and runs test
scenario through 3 connections to node 1 and one connection to node 2.
In the test initialization phase, the test creates two tables 't1' and 'ten'
and then creates a stored procedure 'p1' to operate on these tables.
These 3 create DDL statements are issued through same connection to node 1.

In the next test phase, the mtr script uses send command to launch the call
for the p1 stored procedure through all 3 connections to node 1 and through
one connection to node 2. As the mtr send command is asynchronous,
this test phase is non blocking and fast operation.
Now, if the replication between nodes is slow, it may happen that the
initialization phase DDL statements have not been received or have not been
fully applied in node 2. Therefore there is no guarantee that the test tables
and the stored procedure have been created in node 2. Yet, the test is trying
to call p1 in node 2.

In the failure case error logs, there is error message
"MTR failed: query 'reap' failed: 1305: PROCEDURE test.p1 does not exist"

The reap command through connection to node 2, is the first place where test
execution may observe that test tables and/or stored procedure are not yet
created in node 2.

The fix in this commit adds a wait condition in connection to node 2, to wait
until the stored procedure is created before calling the stored procedure.
The wait is implemented by looking in information_schema.routines for the p1
stored procedure.