### PR TITLE
libutils: merge static libraries only once

### DIFF
--- a/cmake/libutils.cmake
+++ b/cmake/libutils.cmake
@@ -165,8 +165,18 @@ MACRO(MERGE_STATIC_LIBS TARGET OUTPUT_NAME LIBS_TO_MERGE)
       ENDIF()
     ENDIF()
   ENDFOREACH()
+  # With static libraries the order matter to some linkers.
+  # REMOVE_DUPLICATES will keep the first entry and because
+  # the linker requirement we want to keep the last.
+  IF(STATIC_LIBS)
+    LIST(REVERSE STATIC_LIBS)
+    LIST(REMOVE_DUPLICATES STATIC_LIBS)
+    LIST(REVERSE STATIC_LIBS)
+  ENDIF()
   IF(OSLIBS)
+    LIST(REVERSE OSLIBS)
     LIST(REMOVE_DUPLICATES OSLIBS)
+    LIST(REVERSE OSLIBS)
     TARGET_LINK_LIBRARIES(${TARGET} ${OSLIBS})
   ENDIF()
 


### PR DESCRIPTION
Because of common dependencies between the
static libraries list can contain duplicates.

We reduce these down to the single last one in
the list.

This reduces the relative time of a rebuild from:

$ (cd builddir/; time make -j)
...
real	0m30.789s
user	1m33.477s
sys	0m19.678s

and the LIB entries
$ grep ADDLIB builddir/libmysqld/mysqlserver-\$\<CONFIG\>.mri.tpl  | wc -l
179

$ du -h builddir/libmysqld/libmariadbd.a
4.1G	builddir/libmysqld/libmariadbd.a

To:

$ (cd builddir/; time make -j)
...
real	0m20.139s
user	1m32.423s
sys	0m12.208s

$ grep ADDLIB builddir/libmysqld/mysqlserver-\$\<CONFIG\>.mri.tpl  | wc -l
25

$ du -h builddir/libmysqld/libmariadbd.a
688M	builddir/libmysqld/libmariadbd.a