### PR TITLE
debian: use WITH_EMBEDDED_SERVER=ON for libmariadbd-dev

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -88,7 +88,7 @@ endif
 	    -DWITHOUT_TOKUDB=true \
 	    -DWITHOUT_CASSANDRA=true \
 	    -DPLUGIN_AWS_KEY_MANAGEMENT=NO \
-	    -WITH_EMBEDDED_SERVER=OFF \
+	    -DWITH_EMBEDDED_SERVER=ON \
 	    -DDEB=$(DEB_VENDOR) ..'
 
 # This is needed, otherwise 'make test' will run before binaries have been built


### PR DESCRIPTION
Pre-10.5, -WITH_EMBEDDED_SERVER=OFF existed as a malformed option (didn't begin with -D)
in autobake.sh for reducing the size of travis builds.

Debian however does need embedded server in libmariadbd-dev.

With the malformed option changed:
 (cd builddir/; mysql-test/mtr --mem --parallel=160 --embedded-server --force --max-test-fail=30)

Completed: Failed 1/2057 tests, 99.95% were successful.

Failing test(s): type_test.type_test_double
(which is MDEV-22243)

And the output shows:

libmariadbd-dev
drwxr-xr-x root/root ./
drwxr-xr-x root/root ./usr/
...
-rw-r--r-- root/root ./usr/lib/powerpc64le-linux-gnu/libmariadbd.a
lrwxrwxrwx root/root ./usr/lib/powerpc64le-linux-gnu/libmariadbd.so -> libmariadbd.so.19
lrwxrwxrwx root/root ./usr/lib/powerpc64le-linux-gnu/libmysqld.a -> libmariadbd.a
lrwxrwxrwx root/root ./usr/lib/powerpc64le-linux-gnu/libmysqld.so -> libmariadbd.so.19

 find . -name libmariadbd.a -ls
 62133757 697388 -rw-rw-r--   1 dan      dan      714119672 Jun 17 22:22 ./builddir/libmysqld/libmariadbd.a
 52585687  49208 -rw-r--r--   1 dan      dan       50387288 Jun 17 22:22 ./debian/libmariadbd-dev/usr/lib/powerpc64le-linux-gnu/libmariadbd.a
 64230363 697388 -rw-r--r--   1 dan      dan      714119672 Jun 17 22:22 ./debian/tmp/usr/lib/powerpc64le-linux-gnu/libmariadbd.a

So it builds fine.

@ottok for review. I am a bit confused that it doesn't seem to make a difference especially with WITH_EMBEDDED_SERVER defaulting to off and it off status would preclude the build of libmysqld. However debian package libmariadbd-dev expects it built so that's my reason for changing to ON.