### PR TITLE
MDEV-22621: perfschema add FreeBSD include header for pthread_getthre…

### DIFF
--- a/storage/perfschema/my_thread.h
+++ b/storage/perfschema/my_thread.h
@@ -10,6 +10,10 @@
 #include <sys/syscall.h>
 #endif
 
+#ifdef HAVE_PTHREAD_GETTHREADID_NP
+#include <pthread_np.h>
+#endif
+
 typedef pthread_key_t thread_local_key_t;
 typedef pthread_t my_thread_handle;
 typedef pthread_attr_t my_thread_attr_t;


### PR DESCRIPTION
The cmake checks when with this header included, so the real implementation should include it too.

FYI @vuvova 