### PR TITLE
rocksdb: mtr - rocksdb.concurrent_alter use sh

### DIFF
--- a/storage/rocksdb/mysql-test/rocksdb/t/concurrent_alter.test
+++ b/storage/rocksdb/mysql-test/rocksdb/t/concurrent_alter.test
@@ -30,7 +30,7 @@ $MYSQL_SLAP --silent --delimiter=";" --query="select * from a1 where b=1" --conc
 wait
 EOF
 
---exec bash $MYSQL_TMP_DIR/concurrent_alter.sh
+--exec sh $MYSQL_TMP_DIR/concurrent_alter.sh
 
 let $server_charset=`select @@character_set_server`;
 --replace_result $server_charset DEFAULT_CHARSET


### PR DESCRIPTION
FreeBSD doesn't have bash installed by default and sh
has sufficient job control for this test.

Test on 10.5 but the test hasn't changed since 10.2

$  mysql-test/mtr --mem --max-test-fail=30 --force --parallel=1 rocksdb.concurrent_alter
Logging: /home/dan/mariadb-server-10.5/mysql-test/mysql-test-run.pl  --mem --max-test-fail=30 --force --parallel=1 rocksdb.concurrent_alter
vardir: /usr/home/dan/build-mariadb-server-10.5/mysql-test/var
Checking leftover processes...
Removing old var directory...
Creating var directory '/usr/home/dan/build-mariadb-server-10.5/mysql-test/var'...
 - symlinking 'var' to '/tmp/var_auto_P81m'
Checking supported features...
MariaDB Version 10.5.4-MariaDB
 - SSL connections supported

 - binaries built with wsrep patch
Collecting tests...
Installing system database...

==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 16000..16019
rocksdb.concurrent_alter 'write_committed' [ pass ]  16348
rocksdb.concurrent_alter 'write_prepared' [ pass ]  16771
--------------------------------------------------------------------------
The servers were restarted 1 times
Spent 33.119 of 41 seconds executing testcases

Completed: All 2 tests were successful.

$ uname -a
FreeBSD freebsd 12.1-RELEASE-p6 FreeBSD 12.1-RELEASE-p6 GENERIC  amd64

ATTN: @spetrunia 