### PR TITLE
short-circuit when explaining a pushed down select

### DIFF
--- a/mysql-test/suite/federated/federatedx_create_handlers.result
+++ b/mysql-test/suite/federated/federatedx_create_handlers.result
@@ -321,6 +321,14 @@ select @var;
 @var
 xxx
 select name into outfile 'tmp.txt' from federated.t1;
+#
+# CLX-251: EXPLAIN with subselect crashes MariaDB server
+#
+explain
+select * from federated.t1
+where name in (select name from federated.t2);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PUSHED SELECT	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
 DROP TABLE federated.t1, federated.t2, federated.t3, federated.t4;
 connection slave;
 DROP TABLE federated.t1, federated.t2;

--- a/mysql-test/suite/federated/federatedx_create_handlers.test
+++ b/mysql-test/suite/federated/federatedx_create_handlers.test
@@ -167,6 +167,13 @@ select name into outfile 'tmp.txt' from federated.t1;
 let $path=`select concat(@@datadir, 'test/tmp.txt')`;
 remove_file $path;
 
+--echo #
+--echo # CLX-251: EXPLAIN with subselect crashes MariaDB server
+--echo #
+explain
+select * from federated.t1
+where name in (select name from federated.t2);
+
 DROP TABLE federated.t1, federated.t2, federated.t3, federated.t4;
 
 connection slave;

--- a/sql/sql_explain.cc
+++ b/sql/sql_explain.cc
@@ -773,11 +773,13 @@ int Explain_select::print_explain(Explain_query *query,
 
   if (select_type == pushed_derived_text || select_type == pushed_select_text)
   {
-     print_explain_message_line(output, explain_flags, is_analyze,
-                                select_id /*select number*/,
-                                select_type,
-                                NULL, /* rows */
-                                NULL);
+    print_explain_message_line(output, explain_flags, is_analyze,
+                               select_id /*select number*/,
+                               select_type,
+                               NULL, /* rows */
+                               NULL);
+    if (select_type == pushed_select_text)
+      return 0;
   }
   else if (message)
   {
@@ -918,7 +920,8 @@ void Explain_select::print_explain_json(Explain_query *query,
                                           message);
     writer->end_object();
 
-    print_explain_json_for_children(query, writer, is_analyze);
+    if (select_type != pushed_select_text)
+      print_explain_json_for_children(query, writer, is_analyze);
     writer->end_object();
   }
   else

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -27097,6 +27097,9 @@ static void select_describe(JOIN *join, bool need_tmp_table, bool need_order,
   select_result *result=join->result;
   DBUG_ENTER("select_describe");
   
+  if (join->select_lex->pushdown_select)
+    DBUG_VOID_RETURN;
+
   /* Update the QPF with latest values of using_temporary, using_filesort */
   for (SELECT_LEX_UNIT *unit= join->select_lex->first_inner_unit();
        unit;


### PR DESCRIPTION
in a couple of places, explain would recurse into the pushed-down part
of the parse tree.  because it had not been initialized, a crash would
result.