### PR TITLE
MDEV-23266: Display the hashed password only for SUPER user

### DIFF
--- a/mysql-test/main/ps_grant.result
+++ b/mysql-test/main/ps_grant.result
@@ -20,7 +20,7 @@ current_user()
 second_user@localhost
 show grants for current_user();
 Grants for second_user@localhost
-GRANT USAGE ON *.* TO `second_user`@`localhost` IDENTIFIED BY PASSWORD '*13843FE600B19A81E32AF50D4A6FED25875FF1F3'
+GRANT USAGE ON *.* TO `second_user`@`localhost`
 GRANT SELECT ON `mysqltest`.`t9` TO `second_user`@`localhost`
 prepare s_t9 from 'select c1 as my_col 
                                  from t9 where c1= 1' ;
@@ -48,7 +48,7 @@ show grants for second_user@localhost ;
 Grants for second_user@localhost
 GRANT SELECT ON `mysqltest`.`t1` TO `second_user`@`localhost`
 GRANT SELECT ON `mysqltest`.`t9` TO `second_user`@`localhost`
-GRANT USAGE ON *.* TO `second_user`@`localhost` IDENTIFIED BY PASSWORD '*13843FE600B19A81E32AF50D4A6FED25875FF1F3'
+GRANT USAGE ON *.* TO `second_user`@`localhost`
 prepare s_t1 from 'select a as my_col from t1' ;
 execute s_t1 ;
 my_col
@@ -69,7 +69,7 @@ connection con3;
 show grants for second_user@localhost ;
 Grants for second_user@localhost
 GRANT SELECT ON `mysqltest`.`t9` TO `second_user`@`localhost`
-GRANT USAGE ON *.* TO `second_user`@`localhost` IDENTIFIED BY PASSWORD '*13843FE600B19A81E32AF50D4A6FED25875FF1F3'
+GRANT USAGE ON *.* TO `second_user`@`localhost`
 execute s_t1 ;
 ERROR 42000: SELECT command denied to user 'second_user'@'localhost' for table 't1'
 connection default;

--- a/mysql-test/main/set_password.result
+++ b/mysql-test/main/set_password.result
@@ -171,7 +171,7 @@ user()	current_user()
 foo@localhost	foo@localhost
 show grants;
 Grants for foo@localhost
-GRANT USAGE ON *.* TO `foo`@`localhost` IDENTIFIED BY PASSWORD '*E8D46CE25265E545D225A8A6F1BAF642FEBEE5CB'
+GRANT USAGE ON *.* TO `foo`@`localhost`
 disconnect foo;
 connection default;
 select user,host,password,plugin,authentication_string from mysql.user where user='foo';

--- a/mysql-test/main/sp_notembedded.result
+++ b/mysql-test/main/sp_notembedded.result
@@ -331,19 +331,19 @@ update mysql.user set authentication_string = replace(authentication_string, '*'
 connect  foo,localhost,foo1,foo;
 show grants;
 Grants for foo1@localhost
-GRANT USAGE ON *.* TO `foo1`@`localhost` IDENTIFIED BY PASSWORD '*F3A2A51A9B0F2BE2468926B4132313728C250DBF'
+GRANT USAGE ON *.* TO `foo1`@`localhost`
 GRANT CREATE ROUTINE ON `test`.* TO `foo1`@`localhost`
 connection default;
 flush privileges;
 connection foo;
 show grants;
 Grants for foo1@localhost
-GRANT USAGE ON *.* TO `foo1`@`localhost` IDENTIFIED BY PASSWORD '-F3A2A51A9B0F2BE2468926B4132313728C250DBF'
+GRANT USAGE ON *.* TO `foo1`@`localhost`
 GRANT CREATE ROUTINE ON `test`.* TO `foo1`@`localhost`
 create procedure spfoo() select 1;
 show grants;
 Grants for foo1@localhost
-GRANT USAGE ON *.* TO `foo1`@`localhost` IDENTIFIED BY PASSWORD '-F3A2A51A9B0F2BE2468926B4132313728C250DBF'
+GRANT USAGE ON *.* TO `foo1`@`localhost`
 GRANT CREATE ROUTINE ON `test`.* TO `foo1`@`localhost`
 GRANT EXECUTE, ALTER ROUTINE ON PROCEDURE `test`.`spfoo` TO `foo1`@`localhost`
 connection default;

--- a/mysql-test/suite/funcs_1/r/innodb_trig_03.result
+++ b/mysql-test/suite/funcs_1/r/innodb_trig_03.result
@@ -209,7 +209,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT UPDATE, TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT UPDATE, TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 create trigger trg4a_2 before INSERT  on t1 for each row
 set new.f1 = 'trig 3.5.3.7-2a';
 connection default;
@@ -247,7 +247,7 @@ connection default;
 connection no_privs_424b;
 show grants;
 Grants for test_noprivs@localhost
-GRANT USAGE ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT, INSERT, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, DELETE HISTORY ON `priv_db`.* TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4b_1 before UPDATE on t1 for each row
@@ -276,7 +276,7 @@ drop trigger trg4b_1;
 connection yes_privs_424b;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE ON `priv_db`.* TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4b_2 before UPDATE  on t1 for each row
@@ -328,7 +328,7 @@ connection default;
 connection no_privs_424c;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT, INSERT, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE VIEW, SHOW VIEW, TRIGGER, DELETE HISTORY ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4c_1 before INSERT on t1 for each row
@@ -349,7 +349,7 @@ drop trigger trg4c_1;
 connection yes_privs_424c;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4c_2 before INSERT  on t1 for each row
@@ -390,7 +390,7 @@ connection default;
 connection no_privs_424d;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT (f1), INSERT (f1) ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4d_1 before INSERT on t1 for each row
@@ -412,7 +412,7 @@ drop trigger trg4d_1;
 connection yes_privs_424d;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE (f1) ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4d_2 before INSERT  on t1 for each row
@@ -478,7 +478,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT SELECT, TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT SELECT, TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 create trigger trg5a_2 before INSERT  on t1 for each row
 set @test_var= new.f1;
 connection default;
@@ -517,7 +517,7 @@ connection default;
 connection no_privs_425b;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, DELETE HISTORY ON `priv_db`.* TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5b_1 before UPDATE on t1 for each row
@@ -537,7 +537,7 @@ drop trigger trg5b_1;
 connection yes_privs_425b;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT ON `priv_db`.* TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5b_2 before UPDATE  on t1 for each row
@@ -579,7 +579,7 @@ connection default;
 connection no_privs_425c;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE VIEW, SHOW VIEW, TRIGGER, DELETE HISTORY ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5c_1 before INSERT on t1 for each row
@@ -595,7 +595,7 @@ drop trigger trg5c_1;
 connection yes_privs_425c;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5c_2 before INSERT  on t1 for each row
@@ -632,7 +632,7 @@ connection default;
 connection no_privs_425d;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT (f1), UPDATE (f1) ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5d_1 before INSERT on t1 for each row
@@ -648,7 +648,7 @@ drop trigger trg5d_1;
 connection yes_privs_425d;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT (f1) ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5d_2 before INSERT  on t1 for each row

--- a/mysql-test/suite/funcs_1/r/innodb_trig_03e.result
+++ b/mysql-test/suite/funcs_1/r/innodb_trig_03e.result
@@ -152,7 +152,7 @@ current_user
 test_yesprivs@localhost
 show grants for test_yesprivs@localhost;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT, UPDATE, TRIGGER ON `priv_db`.* TO `test_yesprivs`@`localhost`
 drop trigger trg1_2;
 ERROR 42000: TRIGGER command denied to user 'test_yesprivs'@'localhost' for table 't1'
@@ -421,7 +421,7 @@ current_user
 test_yesprivs@localhost
 show grants for test_yesprivs@localhost;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT, INSERT, UPDATE, TRIGGER ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 drop trigger trg1_2;
 connection no_privs;
@@ -1379,7 +1379,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT TRIGGER ON `priv_db`.* TO `test_yesprivs`@`localhost` WITH GRANT OPTION
 GRANT SELECT, INSERT, UPDATE, TRIGGER ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 create definer=not_ex_user@localhost trigger trg1_3

--- a/mysql-test/suite/funcs_1/r/memory_trig_03.result
+++ b/mysql-test/suite/funcs_1/r/memory_trig_03.result
@@ -209,7 +209,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT UPDATE, TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT UPDATE, TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 create trigger trg4a_2 before INSERT  on t1 for each row
 set new.f1 = 'trig 3.5.3.7-2a';
 connection default;
@@ -247,7 +247,7 @@ connection default;
 connection no_privs_424b;
 show grants;
 Grants for test_noprivs@localhost
-GRANT USAGE ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT, INSERT, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, DELETE HISTORY ON `priv_db`.* TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4b_1 before UPDATE on t1 for each row
@@ -276,7 +276,7 @@ drop trigger trg4b_1;
 connection yes_privs_424b;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE ON `priv_db`.* TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4b_2 before UPDATE  on t1 for each row
@@ -328,7 +328,7 @@ connection default;
 connection no_privs_424c;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT, INSERT, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE VIEW, SHOW VIEW, TRIGGER, DELETE HISTORY ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4c_1 before INSERT on t1 for each row
@@ -349,7 +349,7 @@ drop trigger trg4c_1;
 connection yes_privs_424c;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4c_2 before INSERT  on t1 for each row
@@ -390,7 +390,7 @@ connection default;
 connection no_privs_424d;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT (f1), INSERT (f1) ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4d_1 before INSERT on t1 for each row
@@ -412,7 +412,7 @@ drop trigger trg4d_1;
 connection yes_privs_424d;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE (f1) ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4d_2 before INSERT  on t1 for each row
@@ -478,7 +478,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT SELECT, TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT SELECT, TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 create trigger trg5a_2 before INSERT  on t1 for each row
 set @test_var= new.f1;
 connection default;
@@ -517,7 +517,7 @@ connection default;
 connection no_privs_425b;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, DELETE HISTORY ON `priv_db`.* TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5b_1 before UPDATE on t1 for each row
@@ -537,7 +537,7 @@ drop trigger trg5b_1;
 connection yes_privs_425b;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT ON `priv_db`.* TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5b_2 before UPDATE  on t1 for each row
@@ -579,7 +579,7 @@ connection default;
 connection no_privs_425c;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE VIEW, SHOW VIEW, TRIGGER, DELETE HISTORY ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5c_1 before INSERT on t1 for each row
@@ -595,7 +595,7 @@ drop trigger trg5c_1;
 connection yes_privs_425c;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5c_2 before INSERT  on t1 for each row
@@ -632,7 +632,7 @@ connection default;
 connection no_privs_425d;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT (f1), UPDATE (f1) ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5d_1 before INSERT on t1 for each row
@@ -648,7 +648,7 @@ drop trigger trg5d_1;
 connection yes_privs_425d;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT (f1) ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5d_2 before INSERT  on t1 for each row

--- a/mysql-test/suite/funcs_1/r/memory_trig_03e.result
+++ b/mysql-test/suite/funcs_1/r/memory_trig_03e.result
@@ -153,7 +153,7 @@ current_user
 test_yesprivs@localhost
 show grants for test_yesprivs@localhost;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT, UPDATE, TRIGGER ON `priv_db`.* TO `test_yesprivs`@`localhost`
 drop trigger trg1_2;
 ERROR 42000: TRIGGER command denied to user 'test_yesprivs'@'localhost' for table 't1'
@@ -422,7 +422,7 @@ current_user
 test_yesprivs@localhost
 show grants for test_yesprivs@localhost;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT, INSERT, UPDATE, TRIGGER ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 drop trigger trg1_2;
 connection no_privs;
@@ -1380,7 +1380,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT TRIGGER ON `priv_db`.* TO `test_yesprivs`@`localhost` WITH GRANT OPTION
 GRANT SELECT, INSERT, UPDATE, TRIGGER ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 create definer=not_ex_user@localhost trigger trg1_3

--- a/mysql-test/suite/funcs_1/r/myisam_trig_03.result
+++ b/mysql-test/suite/funcs_1/r/myisam_trig_03.result
@@ -209,7 +209,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT UPDATE, TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT UPDATE, TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 create trigger trg4a_2 before INSERT  on t1 for each row
 set new.f1 = 'trig 3.5.3.7-2a';
 connection default;
@@ -247,7 +247,7 @@ connection default;
 connection no_privs_424b;
 show grants;
 Grants for test_noprivs@localhost
-GRANT USAGE ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT, INSERT, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, DELETE HISTORY ON `priv_db`.* TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4b_1 before UPDATE on t1 for each row
@@ -276,7 +276,7 @@ drop trigger trg4b_1;
 connection yes_privs_424b;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE ON `priv_db`.* TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4b_2 before UPDATE  on t1 for each row
@@ -328,7 +328,7 @@ connection default;
 connection no_privs_424c;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT, INSERT, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE VIEW, SHOW VIEW, TRIGGER, DELETE HISTORY ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4c_1 before INSERT on t1 for each row
@@ -349,7 +349,7 @@ drop trigger trg4c_1;
 connection yes_privs_424c;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4c_2 before INSERT  on t1 for each row
@@ -390,7 +390,7 @@ connection default;
 connection no_privs_424d;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT SELECT (f1), INSERT (f1) ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg4d_1 before INSERT on t1 for each row
@@ -412,7 +412,7 @@ drop trigger trg4d_1;
 connection yes_privs_424d;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT UPDATE (f1) ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg4d_2 before INSERT  on t1 for each row
@@ -478,7 +478,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT SELECT, TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT SELECT, TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 create trigger trg5a_2 before INSERT  on t1 for each row
 set @test_var= new.f1;
 connection default;
@@ -517,7 +517,7 @@ connection default;
 connection no_privs_425b;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER, DELETE HISTORY ON `priv_db`.* TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5b_1 before UPDATE on t1 for each row
@@ -537,7 +537,7 @@ drop trigger trg5b_1;
 connection yes_privs_425b;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT ON `priv_db`.* TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5b_2 before UPDATE  on t1 for each row
@@ -579,7 +579,7 @@ connection default;
 connection no_privs_425c;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE VIEW, SHOW VIEW, TRIGGER, DELETE HISTORY ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5c_1 before INSERT on t1 for each row
@@ -595,7 +595,7 @@ drop trigger trg5c_1;
 connection yes_privs_425c;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5c_2 before INSERT  on t1 for each row
@@ -632,7 +632,7 @@ connection default;
 connection no_privs_425d;
 show grants;
 Grants for test_noprivs@localhost
-GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_noprivs`@`localhost`
 GRANT INSERT (f1), UPDATE (f1) ON `priv_db`.`t1` TO `test_noprivs`@`localhost`
 use priv_db;
 create trigger trg5d_1 before INSERT on t1 for each row
@@ -648,7 +648,7 @@ drop trigger trg5d_1;
 connection yes_privs_425d;
 show grants;
 Grants for test_yesprivs@localhost
-GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT TRIGGER ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT (f1) ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 use priv_db;
 create trigger trg5d_2 before INSERT  on t1 for each row

--- a/mysql-test/suite/funcs_1/r/myisam_trig_03e.result
+++ b/mysql-test/suite/funcs_1/r/myisam_trig_03e.result
@@ -153,7 +153,7 @@ current_user
 test_yesprivs@localhost
 show grants for test_yesprivs@localhost;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT, UPDATE, TRIGGER ON `priv_db`.* TO `test_yesprivs`@`localhost`
 drop trigger trg1_2;
 ERROR 42000: TRIGGER command denied to user 'test_yesprivs'@'localhost' for table 't1'
@@ -422,7 +422,7 @@ current_user
 test_yesprivs@localhost
 show grants for test_yesprivs@localhost;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT SELECT, INSERT, UPDATE, TRIGGER ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 drop trigger trg1_2;
 connection no_privs;
@@ -1380,7 +1380,7 @@ current_user
 test_yesprivs@localhost
 show grants;
 Grants for test_yesprivs@localhost
-GRANT USAGE ON *.* TO `test_yesprivs`@`localhost` IDENTIFIED BY PASSWORD '*C49735D016A099C0CF104EF9183F374A54CA2576'
+GRANT USAGE ON *.* TO `test_yesprivs`@`localhost`
 GRANT TRIGGER ON `priv_db`.* TO `test_yesprivs`@`localhost` WITH GRANT OPTION
 GRANT SELECT, INSERT, UPDATE, TRIGGER ON `priv_db`.`t1` TO `test_yesprivs`@`localhost`
 create definer=not_ex_user@localhost trigger trg1_3

--- a/mysql-test/suite/funcs_1/r/processlist_priv_no_prot.result
+++ b/mysql-test/suite/funcs_1/r/processlist_priv_no_prot.result
@@ -151,7 +151,7 @@ GRANT INSERT,UPDATE ON processlist TO current_user;
 ERROR 42000: Access denied for user 'ddicttestuser1'@'localhost' to database 'information_schema'
 SHOW GRANTS;
 Grants for ddicttestuser1@localhost
-GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost`
 CREATE INDEX i_processlist ON processlist (user);
 ERROR 42000: Access denied for user 'ddicttestuser1'@'localhost' to database 'information_schema'
 DROP TABLE processlist;
@@ -187,7 +187,7 @@ SHOW/SELECT shows only the processes (1) of the user.
 connection con100;
 SHOW GRANTS;
 Grants for ddicttestuser1@localhost
-GRANT PROCESS ON *.* TO `ddicttestuser1`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT PROCESS ON *.* TO `ddicttestuser1`@`localhost`
 SHOW processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 ID	ddicttestuser1	HOST_NAME	information_schema	Query	TIME	Init	SHOW processlist	TIME_MS
@@ -201,7 +201,7 @@ SHOW/SELECT shows all processes/threads.
 connect  con101,localhost,ddicttestuser1,ddictpass,information_schema;
 SHOW GRANTS;
 Grants for ddicttestuser1@localhost
-GRANT PROCESS ON *.* TO `ddicttestuser1`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT PROCESS ON *.* TO `ddicttestuser1`@`localhost`
 SHOW processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 ID	root	HOST_NAME	information_schema	Sleep	TIME		NULL	TIME_MS
@@ -254,7 +254,7 @@ ddicttestuser1 are visible.
 ####################################################################################
 SHOW GRANTS;
 Grants for ddicttestuser1@localhost
-GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost`
 SHOW processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 ID	ddicttestuser1	HOST_NAME	information_schema	Sleep	TIME		NULL	TIME_MS
@@ -324,7 +324,7 @@ Only the processes of ddicttestuser1 are visible.
 ####################################################################################
 SHOW GRANTS FOR 'ddicttestuser1'@'localhost';
 Grants for ddicttestuser1@localhost
-GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost`
 SHOW processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 ID	ddicttestuser1	HOST_NAME	information_schema	Sleep	TIME		NULL	TIME_MS
@@ -377,7 +377,7 @@ ddicttestuser2 has now the PROCESS privilege and sees all connections
 ####################################################################################
 SHOW GRANTS FOR 'ddicttestuser2'@'localhost';
 Grants for ddicttestuser2@localhost
-GRANT PROCESS ON *.* TO `ddicttestuser2`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT PROCESS ON *.* TO `ddicttestuser2`@`localhost`
 SHOW processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 ID	root	HOST_NAME	information_schema	Sleep	TIME		NULL	TIME_MS
@@ -417,7 +417,7 @@ ddicttestuser2 has no more the PROCESS privilege and can only see own connects
 ####################################################################################
 SHOW GRANTS;
 Grants for ddicttestuser2@localhost
-GRANT USAGE ON *.* TO `ddicttestuser2`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT USAGE ON *.* TO `ddicttestuser2`@`localhost`
 SHOW processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 ID	ddicttestuser2	HOST_NAME	information_schema	Sleep	TIME		NULL	TIME_MS
@@ -440,7 +440,7 @@ He is also unable to GRANT the PROCESS privilege to ddicttestuser2
 ####################################################################################
 SHOW GRANTS FOR 'ddicttestuser1'@'localhost';
 Grants for ddicttestuser1@localhost
-GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost`
 GRANT PROCESS ON *.* TO 'ddicttestuser2'@'localhost';
 ERROR 28000: Access denied for user 'ddicttestuser1'@'localhost' (using password: YES)
 SHOW processlist;
@@ -479,7 +479,7 @@ Therefore the missing SELECT privilege does not affect SELECTs on PROCESSLIST.
 ####################################################################################
 SHOW GRANTS FOR 'ddicttestuser1'@'localhost';
 Grants for ddicttestuser1@localhost
-GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost` IDENTIFIED BY PASSWORD '*22DA61451703738F203CDB9DB041ACBA1F4760B1'
+GRANT USAGE ON *.* TO `ddicttestuser1`@`localhost`
 SHOW processlist;
 Id	User	Host	db	Command	Time	State	Info	Progress
 ID	ddicttestuser1	HOST_NAME	information_schema	Sleep	TIME		NULL	TIME_MS

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -8713,7 +8713,7 @@ static void add_user_parameters(THD *thd, String *result, ACL_USER* acl_user,
       (acl_user->auth->plugin.str == native_password_plugin_name.str ||
        acl_user->auth->plugin.str == old_password_plugin_name.str))
   {
-    if (acl_user->auth->auth_string.length)
+    if (acl_user->auth->auth_string.length && (thd->main_security_ctx.master_access & SUPER_ACL))
     {
       result->append(STRING_WITH_LEN(" IDENTIFIED BY PASSWORD '"));
       result->append(&acl_user->auth->auth_string);


### PR DESCRIPTION
Displaying the hashed password is a security vulnerability flag. This would prevent obtaining FedRamp compliance approval.

Especially when using proxied user, it should not be possible to see the hashed password of the real user. Regardless of the difficulty of determining the real password from the hashed password, this exposure should be prevented.

This PR updates the output of the `show grants` and `show create user` to include the `auth_string` only for users with SUPER privs. Otherwise, do not output the `auth_string`.