### PR TITLE
MDEV-21905: Galera test galera_var_notify_cmd causes hang

### DIFF
--- a/mysql-test/std_data/wsrep_notify.sh
+++ b/mysql-test/std_data/wsrep_notify.sh
@@ -56,7 +56,7 @@ configuration_change()
 
 status_update()
 {
-    echo "SET wsrep_on=0; BEGIN; UPDATE $STATUS_TABLE SET status='$STATUS'; COMMIT;"
+    echo "$BEGIN; UPDATE $STATUS_TABLE SET status='$STATUS'; $END;"
 }
 
 COM=status_update # not a configuration change by default
@@ -89,11 +89,11 @@ do
     shift
 done
 
-# Undefined means node is shutting down
-if [ "$STATUS" != "Undefined" ]
-then
-    $COM | mysql -B -u$USER -h$HOST -P$PORT
-fi
-
-exit 0
-#
+case $STATUS in
+    "joined" | "donor" | "synced")
+        $COM | mysql -B -u$USER -h$HOST -P$PORT
+        ;;
+    *) 
+        exit 0
+        ;;
+esac

--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -40,7 +40,6 @@ galera_toi_ddl_nonconflicting : MDEV-21518 galera.galera_toi_ddl_nonconflicting
 galera_toi_truncate : MDEV-22996 Hang on galera_toi_truncate test case
 galera_var_innodb_disallow_writes : MDEV-20928 galera.galera_var_innodb_disallow_writes
 galera_var_node_address : MDEV-20485 Galera test failure
-galera_var_notify_cmd : MDEV-21905 Galera test galera_var_notify_cmd causes hang
 galera_var_reject_queries : assertion in inline_mysql_socket_send
 galera_var_retry_autocommit: MDEV-18181 Galera test failure on galera.galera_var_retry_autocommit
 galera_wan : MDEV-17259 Test failure on galera.galera_wan

--- a/mysql-test/suite/galera/r/galera_var_notify_cmd.result
+++ b/mysql-test/suite/galera/r/galera_var_notify_cmd.result
@@ -1,3 +1,5 @@
+connection node_2;
+connection node_1;
 connection node_1;
 SELECT COUNT(DISTINCT uuid) AS EXPECT_2 FROM mtr_wsrep_notify.membership;
 EXPECT_2


### PR DESCRIPTION
Fixed wsrep_notify.sh script so it only reports status changes on
'joined', 'synced', 'donor'.