### PR TITLE
Add man page for new command aria_s3_copy

### DIFF
--- a/debian/mariadb-plugin-s3.install
+++ b/debian/mariadb-plugin-s3.install
@@ -1,3 +1,4 @@
 etc/mysql/mariadb.conf.d/s3.cnf
 usr/bin/aria_s3_copy
 usr/lib/mysql/plugin/ha_s3.so
+usr/share/man/man1/aria_s3_copy.1

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 SET(MAN1_SERVER innochecksum.1 my_print_defaults.1 myisam_ftdump.1 myisamchk.1
                 aria_chk.1 aria_dump_log.1 aria_ftdump.1 aria_pack.1 aria_read_log.1
+                aria_s3_copy.1
 		myisamlog.1 myisampack.1 mysql.server.1 mariadb-conv.1
 		mysql_convert_table_format.1 mysql_fix_extensions.1
 		mysql_install_db.1

--- a/man/aria_s3_copy.1
+++ b/man/aria_s3_copy.1
@@ -1,0 +1,52 @@
+.TH ARIA_S3_COPY "1" "June 2020" "aria_s3_copy Ver 1.0" "User Commands"
+.SH NAME
+aria_s3_copy \- Copy an Aria table to and from s3
+.SH DESCRIPTION
+Usage: aria_s3_copy \-\-aws\-access\-key=# \-\-aws\-secret\-access\-key=# \-\-aws\-region=# \-\-op=(from_s3 | to_s3 | delete_from_s3) [OPTIONS] tables[.MAI]
+.TP
+\fB\-?\fR, \fB\-h\fR, \fB\-\-help\fR
+Display help and exit.
+.TP
+\fB\-k\fR, \fB\-\-s3\-access\-key=name\fR
+AWS access key ID
+.TP
+\fB\-r\fR, \fB\-s3\-region=name\fR
+AWS region
+.TP
+\fB\-K\fR, \fB\-s3\-secret\-key=name\fR
+AWS secret access key ID
+.TP
+\fB\-b\fR, \fB\-s3\-bucket=name\fR
+AWS prefix for tables
+.TP
+\fB\-h\fR, \fB\-s3\-host\-name=name\fR
+Host name to S3 provider
+.TP
+\fB\-c\fR, \fB\-compress\fR
+Use compression
+.TP
+\fB\-o\fR, \fB\-op=name\fR
+Operation to execute. One of 'from_s3', 'to_s3' or 'delete_from_s3'
+.TP
+\fB\-d\fR, \fB\-database=name\fR
+Database for copied table (second prefix). If not given, the directory of the table file is used
+.TP
+\fB\-B\fR, \fB\-s3\-block\-size=#\fR
+Block size for data/index blocks in s3
+.TP
+\fB\-L\fR, \fB\-s3\-protocol\-version=name\fR
+Protocol used to communication with S3. One of "Auto", "Amazon" or "Original".
+.TP
+\fB\-f\fR, \fB\-force\fR
+Force copy even if target exists
+.TP
+\fB\-V\fR, \fB\-version\fR
+Print version and exit.
+.TP
+\fB\-\-s3\-debug\fR
+Output debug log from marias3 to stdout
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Be verbose.
+.PP
+For more information, please refer to the MariaDB Knowledge Base page https://mariadb.com/kb/en/aria_s3_copy/

--- a/storage/maria/aria_s3_copy.cc
+++ b/storage/maria/aria_s3_copy.cc
@@ -67,7 +67,7 @@ static struct my_option my_long_options[] =
     GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"compress", 'c', "Use compression", &opt_compression, &opt_compression,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"op", 'o', "Operation to excecute. One of 'from_s3', 'to_s3' or "
+  {"op", 'o', "Operation to execute. One of 'from_s3', 'to_s3' or "
    "'delete_from_s3'",
    &opt_operation, &opt_operation, &op_typelib,
    GET_ENUM, REQUIRED_ARG, OP_IMPOSSIBLE, 0, 0, 0, 0, 0},


### PR DESCRIPTION
Based on output of 'aria_s3_copy --help'.

Also fix a typo in command help.