### PR TITLE
Deb: Stop shipping mariadb-plugin-spider separately, include in server

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -781,7 +781,8 @@ Depends: galera-4 (>= 26.4),
          ${misc:Depends},
          ${perl:Depends},
          ${shlibs:Depends}
-Conflicts: mariadb-server-10.0,
+Conflicts: mariadb-plugin-spider (<< ${source:Version}),
+           mariadb-server-10.0,
            mariadb-server-10.1,
            mariadb-server-10.2,
            mariadb-server-10.3,
@@ -824,6 +825,7 @@ Replaces: handlersocket-mysql-5.5,
           mariadb-client-10.6,
           mariadb-client-10.7,
           mariadb-client-10.8,
+          mariadb-plugin-spider (<< ${source:Version}),
           mariadb-server-10.0,
           mariadb-server-10.1,
           mariadb-server-10.2,
@@ -1054,27 +1056,6 @@ Description: Mroonga storage engine for MariaDB server
  Mroonga (formerly named Groonga Storage Engine) is a storage engine that
  provides fast CJK-ready full text searching using column store.
  This package contains the Mroonga plugin for MariaDB server.
-
-Package: mariadb-plugin-spider
-Architecture: any
-Depends: mariadb-server (= ${server:Version}),
-         ${misc:Depends},
-         ${shlibs:Depends}
-Breaks: mariadb-server-10.0,
-        mariadb-server-10.1,
-        mariadb-server-10.2,
-        mariadb-server-10.3,
-        mariadb-server-10.4
-Replaces: mariadb-server-10.0,
-          mariadb-server-10.1,
-          mariadb-server-10.2,
-          mariadb-server-10.3,
-          mariadb-server-10.4
-Description: Spider storage engine for MariaDB server
- The Spider storage engine with built-in sharding features. It supports
- partitioning and xa transactions, and allows tables of different MariaDB server
- instances to be handled as if they were on the same instance. It refers to one
- possible implementation of ISO/IEC 9075-9:2008 SQL/MED.
 
 Package: mariadb-plugin-gssapi-server
 Architecture: any

--- a/debian/mariadb-plugin-spider.install
+++ b/debian/mariadb-plugin-spider.install
@@ -1,2 +1,0 @@
-etc/mysql/mariadb.conf.d/spider.cnf
-usr/lib/mysql/plugin/ha_spider.so

--- a/debian/mariadb-server.install
+++ b/debian/mariadb-server.install
@@ -5,6 +5,7 @@ debian/additions/mariadb.conf.d/50-server.cnf etc/mysql/mariadb.conf.d
 debian/additions/source_mariadb.py usr/share/apport/package-hooks
 etc/apparmor.d/usr.sbin.mariadbd
 etc/logrotate.d/mariadb
+etc/mysql/mariadb.conf.d/spider.cnf
 etc/security/user_map.conf
 lib/*/security/pam_user_map.so
 lib/systemd/system/mariadb@bootstrap.service.d/use_galera_new_cluster.conf
@@ -42,6 +43,7 @@ usr/lib/mysql/plugin/ha_blackhole.so
 usr/lib/mysql/plugin/ha_federated.so
 usr/lib/mysql/plugin/ha_federatedx.so
 usr/lib/mysql/plugin/ha_sphinx.so
+usr/lib/mysql/plugin/ha_spider.so
 usr/lib/mysql/plugin/handlersocket.so
 usr/lib/mysql/plugin/locales.so
 usr/lib/mysql/plugin/metadata_lock_info.so


### PR DESCRIPTION
Instead of having a separate plugin, simply include Spider in the main
MariaDB Server package and let users manually enable on server installs
where they want to run it.

***

Created on request by @vuvova in https://jira.mariadb.org/browse/MDEV-13033?page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel&focusedCommentId=157462#comment-157462

This is pending on ColumnStore to be fixed on 10.5 trunk first so that I can run all the QA tools to verify this does not regress and all upgrades work.