### PR TITLE
load mariadb.conf.d defaults before conf.d

### DIFF
--- a/debian/additions/mariadb.cnf
+++ b/debian/additions/mariadb.cnf
@@ -22,5 +22,5 @@ socket                  = /run/mysqld/mysqld.sock
 #port                   = 3306
 
 # Import all .cnf files from configuration directory
-!includedir /etc/mysql/conf.d/
 !includedir /etc/mysql/mariadb.conf.d/
+!includedir /etc/mysql/conf.d/


### PR DESCRIPTION
Mariadb defaults (files inside mariadb.conf.d) are created by default in server installation. However, conf.d stays empty. This comes in handy while running a docker as we can easily bind conf.d to a blank folder to override any defaults, while mounting mariadb.conf.d will cause all auto-created defaults to be dropped or be maintained explicitly by user. 

Simply loading mariadb.conf.d before conf.d lets users override any defaults. Any user specific defaults can be maintained in the conf.d.