### PR TITLE
MDEV-22966- Hang on galera_toi_truncate test case

### DIFF
--- a/mysql-test/suite/galera/r/galera_toi_truncate.result
+++ b/mysql-test/suite/galera/r/galera_toi_truncate.result
@@ -7,12 +7,12 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 connection node_2;
 SET SESSION wsrep_retry_autocommit = 0;
 INSERT INTO t1 (f1) SELECT 1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7, ten AS a8;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2a;
 connection node_1;
-TRUNCATE TABLE t1;;
+TRUNCATE TABLE t1;
 connection node_2;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
-connection node_1;
-connection node_2;
 SELECT COUNT(*) AS EXPECT_0 FROM t1;
 EXPECT_0
 0

--- a/mysql-test/suite/galera/t/galera_toi_truncate.test
+++ b/mysql-test/suite/galera/t/galera_toi_truncate.test
@@ -25,17 +25,18 @@ CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 SET SESSION wsrep_retry_autocommit = 0;
 --send INSERT INTO t1 (f1) SELECT 1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7, ten AS a8
 
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Sending data%' AND INFO LIKE 'INSERT INTO t1 (f1)%';
+--source include/wait_condition.inc
+
 --connection node_1
---send TRUNCATE TABLE t1;
+TRUNCATE TABLE t1;
 
 --connection node_2
 --error ER_LOCK_DEADLOCK
 --reap
 
---connection node_1
---reap
-
---connection node_2
 SELECT COUNT(*) AS EXPECT_0 FROM t1;
 
 --connection node_1


### PR DESCRIPTION
galera_toi_truncate test launches a long term INSERT statement in node 2,
and then submits an offending TRUNCATE through node 1. The idea is that
the replicated TRUNCATE will conflict with INSERT in node 2, and force
the INSERT to abort.

The test first issues --send INSERT in node 2, and then switches to node 1
to launch --send TRUNCATE. As the INSERT is launched asynchronously by --send,
it may happen that INSERT has not yet started to process, before the TRUNCATE
is replicated. The net effect may be that TRUCATE processes to completion in node 2,
and only after that INSERT starts to execute. As the INSERT is very long query,
it will last longer than mtr test suite max test time, the test will fail for timeout.

The fix in this commit uses another connection in node 2, to wait until the INSERT
has started to process in node 2. TRUNCATE in node 1, will be submitted in node 1
after this wait condition.