### PR TITLE
MDEV-23001 Precreate static Item_bool() to simplify code

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -55,6 +55,8 @@ const char *item_empty_name="";
 const char *item_used_name= "\0";
 
 static int save_field_in_field(Field *, bool *, Field *, bool);
+Item_bool_static Item_false("FALSE", 0);
+Item_bool_static Item_true("TRUE", 1);
 
 
 /**
@@ -405,7 +407,6 @@ Item::Item(THD *thd):
   is_expensive_cache(-1), rsize(0), name(null_clex_str), orig_name(0),
   common_flags(IS_AUTO_GENERATED_NAME)
 {
-  DBUG_ASSERT(thd);
   marker= 0;
   maybe_null= null_value= with_window_func= with_field= false;
   in_rollup= 0;
@@ -414,6 +415,10 @@ Item::Item(THD *thd):
    /* Initially this item is not attached to any JOIN_TAB. */
   join_tab_idx= MAX_TABLES;
 
+   /* Thd is NULL in case of static items like Item_true */
+  if (!thd) 
+    return;  
+    
   /* Put item in free list so that we can free all items at end */
   next= thd->free_list;
   thd->free_list= this;
@@ -3557,6 +3562,19 @@ void Item_int::print(String *str, enum_query_type query_type)
   // my_charset_bin is good enough for numbers
   str_value.set_int(value, unsigned_flag, &my_charset_bin);
   str->append(str_value);
+}
+
+
+/*
+  This function is needed to ensure that Item_bool_static doesn't change
+  the value of the member str_value.
+*/
+
+void Item_bool::print(String *str, enum_query_type query_type)
+{
+  // my_charset_bin is good enough for numbers
+  String tmp(value ? (char*) "1" : (char*) "0" , 1, &my_charset_bin);
+  str->append(tmp);
 }
 
 

--- a/sql/item.h
+++ b/sql/item.h
@@ -1924,7 +1924,7 @@ public:
   virtual bool limit_index_condition_pushdown_processor(void *arg) { return 0; }
   virtual bool exists2in_processor(void *arg) { return 0; }
   virtual bool find_selective_predicates_list_processor(void *arg) { return 0; }
-  bool cleanup_is_expensive_cache_processor(void *arg)
+  virtual bool cleanup_is_expensive_cache_processor(void *arg)
   {
     is_expensive_cache= (int8)(-1);
     return 0;
@@ -3167,6 +3167,8 @@ public:
   enum Type type() const { return CONST_ITEM; }
   bool check_partition_func_processor(void *int_arg) { return false;}
   bool const_item() const { return true; }
+  bool is_expensive() { return false; }
+  bool cleanup_is_expensive_cache_processor(void *arg) { return 0; }
   bool basic_const_item() const { return true; }
 };
 
@@ -4150,6 +4152,7 @@ public:
     Item_int(thd, str_arg, i, 1) {}
   Item_bool(THD *thd, bool i) :Item_int(thd, (longlong) i, 1) { }
   bool is_bool_literal() const { return true; }
+  void print(String *str, enum_query_type query_type);
   Item *neg_transformer(THD *thd);
   const Type_handler *type_handler() const
   { return &type_handler_bool; }
@@ -4163,6 +4166,16 @@ public:
     */
   }
 };
+
+
+class Item_bool_static :public Item_bool
+{
+public:
+  Item_bool_static(const char *str_arg, longlong i):
+    Item_bool(NULL, str_arg, i) {};
+};
+
+extern Item_bool_static Item_false, Item_true;
 
 
 class Item_uint :public Item_int

--- a/sql/item_xmlfunc.cc
+++ b/sql/item_xmlfunc.cc
@@ -1172,13 +1172,13 @@ my_xpath_keyword(MY_XPATH *x,
 
 static Item *create_func_true(MY_XPATH *xpath, Item **args, uint nargs)
 {
-  return new (xpath->thd->mem_root) Item_bool(xpath->thd, "xpath_bool", 1);
+  return &Item_true;
 }
 
 
 static Item *create_func_false(MY_XPATH *xpath, Item **args, uint nargs)
 {
-  return new (xpath->thd->mem_root) Item_bool(xpath->thd, "xpath_bool", 0);
+  return &Item_false;
 }
 
 

--- a/sql/opt_index_cond_pushdown.cc
+++ b/sql/opt_index_cond_pushdown.cc
@@ -185,8 +185,8 @@ bool uses_index_fields_only(Item *item, TABLE *tbl, uint keyno,
 static Item *make_cond_for_index(THD *thd, Item *cond, TABLE *table, uint keyno,
                                  bool other_tbls_ok)
 {
-  if (!cond)
-    return NULL;
+  if (!cond || cond->basic_const_item())
+    return cond;
   if (cond->type() == Item::COND_ITEM)
   {
     uint n_marked= 0;
@@ -218,7 +218,7 @@ static Item *make_cond_for_index(THD *thd, Item *cond, TABLE *table, uint keyno,
       case 0:
 	return (COND*) 0;
       case 1:
-        new_cond->used_tables_cache= used_tables;
+        /* remove AND level if there is only one argument */
 	return new_cond->argument_list()->head();
       default:
 	new_cond->quick_fix_field();

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -7258,7 +7258,7 @@ store_top_level_join_columns(THD *thd, TABLE_LIST *table_ref,
     /* Add a TRUE condition to outer joins that have no common columns. */
     if (table_ref_2->outer_join &&
         !table_ref_1->on_expr && !table_ref_2->on_expr)
-      table_ref_2->on_expr= new (thd->mem_root) Item_int(thd, (longlong) 1, 1); // Always true.
+      table_ref_2->on_expr= &Item_true;
 
     /* Change this table reference to become a leaf for name resolution. */
     if (left_neighbor)

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1138,6 +1138,7 @@ void cleanup_items(Item *item)
   DBUG_VOID_RETURN;
 }
 
+#ifndef EMBEDDED_LIBRARY
 static enum enum_server_command fetch_command(THD *thd, char *packet)
 {
   enum enum_server_command
@@ -1153,6 +1154,7 @@ static enum enum_server_command fetch_command(THD *thd, char *packet)
                      command_name[command].str));
   DBUG_RETURN(command);
 }
+#endif
 
 
 #ifdef WITH_WSREP
@@ -1167,7 +1169,6 @@ static bool wsrep_tables_accessible_when_detached(const TABLE_LIST *tables)
   return true;
 }
 #endif /* WITH_WSREP */
-#ifndef EMBEDDED_LIBRARY
 
 /**
   Read one command from connection and execute it (query or simple command).
@@ -1180,6 +1181,7 @@ static bool wsrep_tables_accessible_when_detached(const TABLE_LIST *tables)
   @retval
     1  request of thread shutdown (see dispatch_command() description)
 */
+#ifndef EMBEDDED_LIBRARY
 
 bool do_command(THD *thd)
 {

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -2368,7 +2368,7 @@ int JOIN::optimize_stage2()
   if (!conds && outer_join)
   {
     /* Handle the case where we have an OUTER JOIN without a WHERE */
-    conds= new (thd->mem_root) Item_bool(thd, true); // Always true
+    conds= &Item_true;
   }
 
   if (impossible_where)
@@ -2525,7 +2525,7 @@ int JOIN::optimize_stage2()
   if (conds && const_table_map != found_const_table_map &&
       (select_options & SELECT_DESCRIBE))
   {
-    conds=new (thd->mem_root) Item_bool(thd, false); // Always false
+    conds= &Item_false;
   }
 
   /* Cache constant expressions in WHERE, HAVING, ON clauses. */
@@ -2815,7 +2815,7 @@ int JOIN::optimize_stage2()
     having= having->remove_eq_conds(thd, &select_lex->having_value, true);
     if (select_lex->having_value == Item::COND_FALSE)
     {
-      having= new (thd->mem_root) Item_bool(thd, false);
+      having= &Item_false;
       zero_result_cause= "Impossible HAVING noticed after reading const tables";
       error= 0;
       select_lex->mark_const_derived(zero_result_cause);
@@ -5310,7 +5310,7 @@ make_join_statistics(JOIN *join, List<TABLE_LIST> &tables_list,
     if (join->cond_value == Item::COND_FALSE)
     {
       join->impossible_where= true;
-      conds= new (join->thd->mem_root) Item_bool(join->thd, false);
+      conds= &Item_false;
     }
 
     join->cond_equal= NULL;
@@ -11544,7 +11544,7 @@ make_join_select(JOIN *join,SQL_SELECT *select,COND *cond)
             below to check if we should use 'quick' instead.
           */
           DBUG_PRINT("info", ("Item_int"));
-          tmp= new (thd->mem_root) Item_bool(thd, true); // Always true
+          tmp= &Item_true;
         }
 
       }
@@ -15093,7 +15093,7 @@ COND *Item_cond_and::build_equal_items(THD *thd,
   if (!cond_args->elements && 
       !cond_equal.current_level.elements && 
       !eq_list.elements)
-    return new (thd->mem_root) Item_bool(thd, true);
+    return &Item_true;
 
   List_iterator_fast<Item_equal> it(cond_equal.current_level);
   while ((item_equal= it++))
@@ -15200,7 +15200,7 @@ COND *Item_func_eq::build_equal_items(THD *thd,
     Item_equal *item_equal;
     int n= cond_equal.current_level.elements + eq_list.elements;
     if (n == 0)
-      return new (thd->mem_root) Item_bool(thd, true);
+      return &Item_true;
     else if (n == 1)
     {
       if ((item_equal= cond_equal.current_level.pop()))
@@ -15594,7 +15594,7 @@ Item *eliminate_item_equal(THD *thd, COND *cond, COND_EQUAL *upper_levels,
   List<Item> eq_list;
   Item_func_eq *eq_item= 0;
   if (((Item *) item_equal)->const_item() && !item_equal->val_int())
-    return new (thd->mem_root) Item_bool(thd, false);
+    return &Item_false;
   Item *item_const= item_equal->get_const();
   Item_equal_fields_iterator it(*item_equal);
   Item *head;
@@ -15739,7 +15739,7 @@ Item *eliminate_item_equal(THD *thd, COND *cond, COND_EQUAL *upper_levels,
   switch (eq_list.elements)
   {
   case 0:
-    res= cond ? cond : new (thd->mem_root) Item_bool(thd, true);
+    res= cond ? cond : &Item_true;
     break;
   case 1:
     if (!cond || cond->is_bool_literal())
@@ -17567,7 +17567,7 @@ Item_func_isnull::remove_eq_conds(THD *thd, Item::cond_result *cond_value,
 
       */
 
-      Item *item0= new(thd->mem_root) Item_bool(thd, false);
+      Item *item0= &Item_false;
       Item *eq_cond= new(thd->mem_root) Item_func_eq(thd, args[0], item0);
       if (!eq_cond)
         return this;
@@ -22575,6 +22575,8 @@ make_cond_for_table_from_pred(THD *thd, Item *root_cond, Item *cond,
       return new_cond;
     }
   }
+  else if (cond->basic_const_item())
+    return cond;
 
   if (is_top_and_level && used_table == rand_table_bit &&
       (cond->used_tables() & ~OUTER_REF_TABLE_BIT) != rand_table_bit)
@@ -29102,17 +29104,13 @@ void JOIN::make_notnull_conds_for_range_scans()
   if (conds && build_notnull_conds_for_range_scans(this, conds,
                                                    conds->used_tables()))
   {
-    Item *false_cond= new (thd->mem_root) Item_int(thd, (longlong) 0, 1);
-    if (false_cond)
-    {
-      /*
-        Found a IS NULL conjunctive predicate for a null-rejected field
-        in the WHERE clause
-      */
-      conds= false_cond;
-      cond_equal= 0;
-      impossible_where= true;
-    }
+    /*
+      Found a IS NULL conjunctive predicate for a null-rejected field
+      in the WHERE clause
+    */
+    conds= &Item_false;
+    cond_equal= 0;
+    impossible_where= true;
     DBUG_VOID_RETURN;
   }
 
@@ -29133,9 +29131,7 @@ void JOIN::make_notnull_conds_for_range_scans()
           Found a IS NULL conjunctive predicate for a null-rejected field
           of the inner table of an outer join with ON expression tbl->on_expr
         */
-        Item *false_cond= new (thd->mem_root) Item_int(thd, (longlong) 0, 1);
-        if (false_cond)
-          tbl->on_expr= false_cond;
+        tbl->on_expr= &Item_false;
       }
     }
   }
@@ -29276,7 +29272,6 @@ void build_notnull_conds_for_inner_nest_of_outer_join(JOIN *join,
 {
   TABLE_LIST *tbl;
   table_map used_tables= 0;
-  THD *thd= join->thd;
   List_iterator<TABLE_LIST> li(nest_tbl->nested_join->join_list);
 
   while ((tbl= li++))
@@ -29287,9 +29282,7 @@ void build_notnull_conds_for_inner_nest_of_outer_join(JOIN *join,
   if (used_tables &&
       build_notnull_conds_for_range_scans(join, nest_tbl->on_expr, used_tables))
   {
-    Item *false_cond= new (thd->mem_root) Item_int(thd, (longlong) 0, 1);
-    if (false_cond)
-      nest_tbl->on_expr= false_cond;
+    nest_tbl->on_expr= &Item_false;
   }
 
   li.rewind();
@@ -29304,9 +29297,7 @@ void build_notnull_conds_for_inner_nest_of_outer_join(JOIN *join,
       else if (build_notnull_conds_for_range_scans(join, tbl->on_expr,
                                                    tbl->table->map))
       {
-        Item *false_cond= new (thd->mem_root) Item_int(thd, (longlong) 0, 1);
-        if (false_cond)
-          tbl->on_expr= false_cond;
+        tbl->on_expr= &Item_false;
       }
     }
   }


### PR DESCRIPTION
- Created static item's Item_bool and Item_false.

- Replace all created items of the following types to Item_true or Item_false:
  1. Item_bool(thd, true)
  2. Item_bool(thd, false)
  3. Item_int(thd, (longlong) 0, 1)
  4. Item_int(thd, (longlong) 1, 1)