### PR TITLE
The solution to minor upgrade issue

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,6 @@ Build-Depends: bison,
                libnuma-dev [!armhf],
                libpam0g-dev,
                libpcre2-dev,
-               libreadline-gplv2-dev [i386 amd64],
                libsnappy-dev,
                libssl-dev | libssl1.0-dev,
                libsystemd-dev [linux-any],
@@ -662,7 +661,6 @@ Description: RocksDB storage engine for MariaDB
 Package: mariadb-plugin-columnstore
 Architecture: amd64 i386
 Depends: binutils,
-         expect,
          libjemalloc1 | libjemalloc2,
          libsnappy1 | libsnappy1v5,
          mariadb-server-10.5 (= ${binary:Version}),

--- a/debian/mariadb-plugin-columnstore.postinst
+++ b/debian/mariadb-plugin-columnstore.postinst
@@ -3,6 +3,6 @@
 set -e
 
 # Install ColumnStore
-columnstore-post-install --rpmmode=install
+columnstore-post-install install
 
 #DEBHELPER#

--- a/storage/columnstore/CMakeLists.txt
+++ b/storage/columnstore/CMakeLists.txt
@@ -22,7 +22,7 @@ CMAKE_SYSTEM_PROCESSOR STREQUAL "i686")
         # Needed to bump the component changes up to the main scope
         APPEND_FOR_CPACK(CPACK_COMPONENTS_ALL)
         IF (RPM)
-            APPEND_FOR_CPACK(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES " binutils net-tools python3")
+            APPEND_FOR_CPACK(CPACK_RPM_columnstore-engine_PACKAGE_REQUIRES " binutils jemalloc net-tools python3")
             APPEND_FOR_CPACK(CPACK_RPM_columnstore-engine_USER_FILELIST ";%ignore /var/lib;%ignore /var")
             APPEND_FOR_CPACK(CPACK_RPM_columnstore-engine_PACKAGE_CONFLICTS " thrift MariaDB-columnstore-platform MariaDB-columnstore-libs")
             # these three don't have the list semantics, so no append here


### PR DESCRIPTION
MCS doesn't need expect and libreadline as dependencies