### PR TITLE
MDEV-19177: Geometry support by the partition feature

### DIFF
--- a/mysql-test/main/partition_geometries.result
+++ b/mysql-test/main/partition_geometries.result
@@ -1,0 +1,118 @@
+#
+# MDEV-19177: Geometry support for partition feature
+# Test partition/geometry type cross-compatibility for the 4 storage engines that support
+# geometries (Aria, MyISAM, InnoDB, Archive)
+# Geometries to test - point, multipolygon, geometry collection 
+# Note: Archive does not support additional indices.
+#
+SET @point = Point(3,3);
+SET @poly = MultiPolygon(Polygon(LineString(Point(0, 3), Point(3, 3), Point(3, 0), Point(0, 3))));
+SET @collection = GeometryCollection(Point(1,1), Polygon(LineString(Point(0, 3), Point(3, 3), Point(3, 0), Point(0, 3))));
+#
+# Aria engine
+#
+CREATE TABLE t1 (
+`id` int(11) NOT NULL AUTO_INCREMENT,
+`geom` geometry NOT NULL,
+PRIMARY KEY (id),
+SPATIAL INDEX(geom)
+) Engine=Aria PARTITION BY HASH (id)
+PARTITIONS 10;
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+ST_AsGeoJSON(geom)
+{"type": "Point", "coordinates": [3, 3]}
+{"type": "MultiPolygon", "coordinates": [[[[0, 3], [3, 3], [3, 0], [0, 3]]]]}
+{"type": "GeometryCollection", "geometries": [{"type": "Point", "coordinates": [1, 1]}, {"type": "Polygon", "coordinates": [[[0, 3], [3, 3], [3, 0], [0, 3]]]}]}
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `geom` geometry NOT NULL,
+  PRIMARY KEY (`id`),
+  SPATIAL KEY `geom` (`geom`)
+) ENGINE=Aria AUTO_INCREMENT=4 DEFAULT CHARSET=latin1
+ PARTITION BY HASH (`id`)
+PARTITIONS 10
+DROP TABLE t1;
+#
+# MyISAM engine
+#
+CREATE TABLE t1 (
+`id` int(11) NOT NULL AUTO_INCREMENT,
+`geom` geometry NOT NULL,
+PRIMARY KEY (id),
+SPATIAL INDEX(geom)
+) Engine=myisam PARTITION BY HASH (id)
+PARTITIONS 10;
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+ST_AsGeoJSON(geom)
+{"type": "Point", "coordinates": [3, 3]}
+{"type": "MultiPolygon", "coordinates": [[[[0, 3], [3, 3], [3, 0], [0, 3]]]]}
+{"type": "GeometryCollection", "geometries": [{"type": "Point", "coordinates": [1, 1]}, {"type": "Polygon", "coordinates": [[[0, 3], [3, 3], [3, 0], [0, 3]]]}]}
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `geom` geometry NOT NULL,
+  PRIMARY KEY (`id`),
+  SPATIAL KEY `geom` (`geom`)
+) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=latin1
+ PARTITION BY HASH (`id`)
+PARTITIONS 10
+DROP TABLE t1;
+#
+# InnoDB engine
+#
+CREATE TABLE t1 (
+`id` int(11) NOT NULL AUTO_INCREMENT,
+`geom` geometry NOT NULL,
+PRIMARY KEY (id),
+SPATIAL INDEX(geom)
+) Engine=innodb PARTITION BY HASH (id)
+PARTITIONS 10;
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+ST_AsGeoJSON(geom)
+{"type": "Point", "coordinates": [3, 3]}
+{"type": "MultiPolygon", "coordinates": [[[[0, 3], [3, 3], [3, 0], [0, 3]]]]}
+{"type": "GeometryCollection", "geometries": [{"type": "Point", "coordinates": [1, 1]}, {"type": "Polygon", "coordinates": [[[0, 3], [3, 3], [3, 0], [0, 3]]]}]}
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `geom` geometry NOT NULL,
+  PRIMARY KEY (`id`),
+  SPATIAL KEY `geom` (`geom`)
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1
+ PARTITION BY HASH (`id`)
+PARTITIONS 10
+DROP TABLE t1;
+#
+# Archive engine
+#
+INSTALL SONAME 'ha_archive';
+CREATE TABLE t1 (
+`id` int(11) NOT NULL AUTO_INCREMENT,
+`geom` geometry,
+PRIMARY KEY (id)
+) Engine=archive PARTITION BY HASH (id)
+PARTITIONS 10;
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+ST_AsGeoJSON(geom)
+{"type": "Point", "coordinates": [3, 3]}
+{"type": "MultiPolygon", "coordinates": [[[[0, 3], [3, 3], [3, 0], [0, 3]]]]}
+{"type": "GeometryCollection", "geometries": [{"type": "Point", "coordinates": [1, 1]}, {"type": "Polygon", "coordinates": [[[0, 3], [3, 3], [3, 0], [0, 3]]]}]}
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `geom` geometry DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=ARCHIVE AUTO_INCREMENT=4 DEFAULT CHARSET=latin1
+ PARTITION BY HASH (`id`)
+PARTITIONS 10
+DROP TABLE t1;
+UNINSTALL SONAME 'ha_archive';

--- a/mysql-test/main/partition_geometries.test
+++ b/mysql-test/main/partition_geometries.test
@@ -1,0 +1,80 @@
+--echo #
+--echo # MDEV-19177: Geometry support for partition feature
+--echo # Test partition/geometry type cross-compatibility for the 4 storage engines that support
+--echo # geometries (Aria, MyISAM, InnoDB, Archive)
+--echo # Geometries to test - point, multipolygon, geometry collection 
+--echo # Note: Archive does not support additional indices.
+--echo #
+SET @point = Point(3,3);
+SET @poly = MultiPolygon(Polygon(LineString(Point(0, 3), Point(3, 3), Point(3, 0), Point(0, 3))));
+SET @collection = GeometryCollection(Point(1,1), Polygon(LineString(Point(0, 3), Point(3, 3), Point(3, 0), Point(0, 3))));
+
+--source include/have_partition.inc
+
+--echo #
+--echo # Aria engine
+--echo #
+CREATE TABLE t1 (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`geom` geometry NOT NULL,
+	PRIMARY KEY (id),
+	SPATIAL INDEX(geom)
+) Engine=Aria PARTITION BY HASH (id)
+PARTITIONS 10;
+
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--echo #
+--echo # MyISAM engine
+--echo #
+CREATE TABLE t1 (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`geom` geometry NOT NULL,
+	PRIMARY KEY (id),
+	SPATIAL INDEX(geom)
+) Engine=myisam PARTITION BY HASH (id)
+PARTITIONS 10;
+
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--echo #
+--echo # InnoDB engine
+--echo #
+--source include/have_innodb.inc
+CREATE TABLE t1 (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`geom` geometry NOT NULL,
+	PRIMARY KEY (id),
+	SPATIAL INDEX(geom)
+) Engine=innodb PARTITION BY HASH (id)
+PARTITIONS 10;
+
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+--echo #
+--echo # Archive engine
+--echo #
+
+INSTALL SONAME 'ha_archive';
+CREATE TABLE t1 (
+	`id` int(11) NOT NULL AUTO_INCREMENT,
+	`geom` geometry,
+	PRIMARY KEY (id)
+) Engine=archive PARTITION BY HASH (id)
+PARTITIONS 10;
+
+INSERT INTO t1 VALUES (NULL, @point), (NULL, @poly), (NULL, @collection);
+SELECT ST_AsGeoJSON(geom) FROM t1;
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+UNINSTALL SONAME 'ha_archive';

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -74,8 +74,7 @@
                                        HA_REC_NOT_IN_SEQ | \
                                        HA_CAN_REPAIR | \
                                        HA_REUSES_FILE_NAMES)
-#define PARTITION_DISABLED_TABLE_FLAGS (HA_CAN_GEOMETRY | \
-                                        HA_DUPLICATE_POS | \
+#define PARTITION_DISABLED_TABLE_FLAGS (HA_DUPLICATE_POS | \
                                         HA_CAN_INSERT_DELAYED | \
                                         HA_READ_BEFORE_WRITE_REMOVAL |\
                                         HA_CAN_TABLES_WITHOUT_ROLLBACK)


### PR DESCRIPTION
Fairly straightforward - the geospatial capabilities of the 4 supporting storage engines (Archive, Aria, InnoDB, MyISAM) should function in partitioned mode.

For all:
* GEOMETRY columns should work in a CREATE TABLE statement, as should basic insertion, selection and ST_AsGeoJSON.

Additionally, for MyISAM, Aria and InnoDB:
* SPATIAL INDEX should at least work for CREATE TABLE statements.

Should these tests include any deeper verification of spatial indices?