### PR TITLE
[WIP] MDEV-23143: Adding a JSON_EQUALS function

### DIFF
--- a/mysql-test/suite/json/r/json_no_table.result
+++ b/mysql-test/suite/json/r/json_no_table.result
@@ -2366,6 +2366,58 @@ SELECT JSON_ARRAY();
 JSON_ARRAY()
 []
 # ----------------------------------------------------------------------
+# Bug #MDEV-23143: missing a JSON_EQUALS function
+# ----------------------------------------------------------------------
+# should give NULL
+select JSON_EQUALS(NULL, NULL);
+JSON_EQUALS(NULL, NULL)
+NULL
+select JSON_EQUALS(json_compact('{"a": 1, "b": 2}'), NULL);
+JSON_EQUALS(json_compact('{"a": 1, "b": 2}'), NULL)
+NULL
+select JSON_EQUALS(NULL, '[1, 2]');
+JSON_EQUALS(NULL, '[1, 2]')
+NULL
+# should give 0: no type conversion
+select JSON_EQUALS(json_compact(3.14), json_compact(3));
+JSON_EQUALS(json_compact(3.14), json_compact(3))
+0
+# returns 0: one candidate element doesn't match
+SELECT JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 7, "C": 9, "B": 8}');
+JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 7, "C": 9, "B": 8}')
+0
+SELECT JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 0, "B": {"C": 2}, "D": 2}');
+JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 0, "B": {"C": 2}, "D": 2}')
+0
+#returns 1
+SELECT JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 0, "B": {"C": 1}, "D": 2}');
+JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 0, "B": {"C": 1}, "D": 2}')
+1
+SELECT JSON_EQUALS('{}', '{}');
+JSON_EQUALS('{}', '{}')
+1
+SELECT JSON_EQUALS('[]', '[]');
+JSON_EQUALS('[]', '[]')
+1
+#returns 1: fine with different types that compare equal
+SELECT JSON_EQUALS('[3.0]', '[3]');
+JSON_EQUALS('[3.0]', '[3]')
+1
+#returns 0 : contains would have returned 1
+SELECT JSON_EQUALS('[null,1,[2,3],true,false]', '[null,1,[2],false]');
+JSON_EQUALS('[null,1,[2,3],true,false]', '[null,1,[2],false]')
+0
+#returns 1 : duplicates are also equal (trying to resolve this)
+SELECT JSON_EQUALS('[1,2,4,4,5]', '[1,2,4,5]');
+JSON_EQUALS('[1,2,4,4,5]', '[1,2,4,5]')
+1
+SELECT JSON_EQUALS();
+ERROR 42000: Incorrect parameter count in the call to native function 'JSON_EQUALS'
+SELECT JSON_EQUALS('[1,2,3]');
+ERROR 42000: Incorrect parameter count in the call to native function 'JSON_EQUALS'
+SELECT JSON_EQUALS('{"A": 1}', '{"A": 1}', '{"A": 1}');
+ERROR 42000: Incorrect parameter count in the call to native function 'JSON_EQUALS'
+# ----------------------------------------------------------------------
 # Test of JSON_OBJECT function.
 # ----------------------------------------------------------------------
 select json_object( 'a' );

--- a/mysql-test/suite/json/t/json_no_table.test
+++ b/mysql-test/suite/json/t/json_no_table.test
@@ -1484,6 +1484,46 @@ select json_array(b'0', b'1', b'10');
 # returns the empty array: []
 SELECT JSON_ARRAY();
 
+
+--echo # ----------------------------------------------------------------------
+--echo # Bug #MDEV-23143: missing a JSON_EQUALS function
+--echo # ----------------------------------------------------------------------
+
+--echo # should give NULL
+select JSON_EQUALS(NULL, NULL);
+select JSON_EQUALS(json_compact('{"a": 1, "b": 2}'), NULL);
+select JSON_EQUALS(NULL, '[1, 2]');
+
+--echo # should give 0: no type conversion
+select JSON_EQUALS(json_compact(3.14), json_compact(3));
+
+--echo # returns 0: one candidate element doesn't match
+SELECT JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 7, "C": 9, "B": 8}');
+SELECT JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 0, "B": {"C": 2}, "D": 2}');
+
+--echo #returns 1
+SELECT JSON_EQUALS('{"A": 0, "B": {"C": 1}, "D": 2}', '{"A": 0, "B": {"C": 1}, "D": 2}');
+SELECT JSON_EQUALS('{}', '{}');
+SELECT JSON_EQUALS('[]', '[]');
+
+--echo #returns 1: fine with different types that compare equal
+SELECT JSON_EQUALS('[3.0]', '[3]');
+
+--echo #returns 0 : contains would have returned 1
+SELECT JSON_EQUALS('[null,1,[2,3],true,false]', '[null,1,[2],false]');
+
+--echo #returns 1 : duplicates are also equal (trying to resolve this)
+SELECT JSON_EQUALS('[1,2,4,4,5]', '[1,2,4,5]');
+
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT JSON_EQUALS();
+
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT JSON_EQUALS('[1,2,3]');
+
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT JSON_EQUALS('{"A": 1}', '{"A": 1}', '{"A": 1}');
+
 --echo # ----------------------------------------------------------------------
 --echo # Test of JSON_OBJECT function.
 --echo # ----------------------------------------------------------------------

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -1057,6 +1057,19 @@ protected:
 };
 
 
+class Create_func_json_equals: public Create_native_func
+{
+public:
+  virtual Item *create_native(THD *thd, LEX_CSTRING *name, List<Item> *item_list);
+
+  static Create_func_json_equals s_singleton;
+
+protected:
+  Create_func_json_equals() {}
+  virtual ~Create_func_json_equals() {}
+};
+
+
 class Create_func_json_extract : public Create_native_func
 {
 public:
@@ -4075,6 +4088,32 @@ Create_func_json_contains_path::create_native(THD *thd, LEX_CSTRING *name,
 }
 
 
+Create_func_json_equals Create_func_json_equals::s_singleton;
+
+Item*
+Create_func_json_equals::create_native(THD *thd, LEX_CSTRING *name,
+                                                List<Item> *item_list)
+{
+  Item *func= NULL;
+  int arg_count= 0;
+
+  if(item_list != NULL)
+    arg_count= item_list->elements;
+
+  if(unlikely(arg_count < 2 || arg_count > 2)/* json_doc, json_doc */)
+  {
+     my_error(ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, MYF(0), name->str);
+  }
+  else
+  {
+    func= new (thd->mem_root) Item_func_json_equals(thd, *item_list);
+  }
+
+  status_var_increment(current_thd->status_var.feature_json); 
+  return func;
+}
+
+
 Create_func_json_extract Create_func_json_extract::s_singleton;
 
 Item*
@@ -5479,6 +5518,7 @@ static Native_func_registry func_array[] =
   { { STRING_WITH_LEN("JSON_CONTAINS_PATH") }, BUILDER(Create_func_json_contains_path)},
   { { STRING_WITH_LEN("JSON_DEPTH") }, BUILDER(Create_func_json_depth)},
   { { STRING_WITH_LEN("JSON_DETAILED") }, BUILDER(Create_func_json_detailed)},
+  { { STRING_WITH_LEN("JSON_EQUALS") }, BUILDER(Create_func_json_equals)},
   { { STRING_WITH_LEN("JSON_EXISTS") }, BUILDER(Create_func_json_exists)},
   { { STRING_WITH_LEN("JSON_EXTRACT") }, BUILDER(Create_func_json_extract)},
   { { STRING_WITH_LEN("JSON_INSERT") }, BUILDER(Create_func_json_insert)},

--- a/sql/item_jsonfunc.h
+++ b/sql/item_jsonfunc.h
@@ -290,6 +290,20 @@ public:
 };
 
 
+class Item_func_json_equals: public Item_func_json_contains
+{
+protected:
+  String tmp_js;
+public:
+  Item_func_json_equals(THD *thd, List<Item> &list):
+    Item_func_json_contains(thd, list) {}
+  const char *func_name() const { return "json_equals"; }
+  longlong val_int();
+  Item *get_copy(THD *thd)
+  { return get_item_copy<Item_func_json_equals>(thd, this); }
+};
+
+
 class Item_func_json_array: public Item_json_func
 {
 protected:


### PR DESCRIPTION
JSON_CONTAINS is currently used twice to test for equality between two json strings. A new function JSON_EQUALS is added to test for equality directly.

Item_func_json_equals subclasses Item_func_json_contains and implements the val_int() function for the equality comparison.
Create_func_json_equals is added in item_create.cc so the function is identified by the parser.