### PR TITLE
MDEV-23088: Change LimitNOFILE default from 16364 to 16384

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -134,7 +134,7 @@ TimeoutStopSec=900
 ##
 
 # Number of files limit. previously [mysqld_safe] open-files-limit
-LimitNOFILE=16364
+LimitNOFILE=16384
 
 # Maximium core size. previously [mysqld_safe] core-file-size
 # LimitCore=

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -155,7 +155,7 @@ TimeoutStopSec=900
 ##
 
 # Number of files limit. previously [mysqld_safe] open-files-limit
-LimitNOFILE=16364
+LimitNOFILE=16384
 
 # Maximium core size. previously [mysqld_safe] core-file-size
 # LimitCore=


### PR DESCRIPTION
Correct to a true 2^14 rather than some different number that
was actually just a number typo.

Bug report thanks to Hartmut Holzgraefe.