### PR TITLE
MDEV-23137: RocksDB fails to build on arm64: undefined reference to

### DIFF
--- a/storage/rocksdb/build_rocksdb.cmake
+++ b/storage/rocksdb/build_rocksdb.cmake
@@ -442,6 +442,17 @@ else()
       util/crc32c_ppc.c
       util/crc32c_ppc_asm.S)
   endif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64")
+  # aarch
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
+    CHECK_CXX_COMPILER_FLAG("-march=armv8-a+crc+crypto" HAS_ARMV8_CRC)
+    if(HAS_ARMV8_CRC)
+      message(STATUS " HAS_ARMV8_CRC yes")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a+crc+crypto -Wno-unused-function")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a+crc+crypto -Wno-unused-function")
+      list(APPEND ROCKSDB_SOURCES
+        util/crc32c_arm64.cc)
+    endif(HAS_ARMV8_CRC)
+  endif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
 endif()
 SET(SOURCES)
 FOREACH(s ${ROCKSDB_SOURCES})


### PR DESCRIPTION
            `crc32c_arm64(unsigned int, unsigned char const*, unsigned int)'

MariaDB uses storage/rocksdb/build_rocksdb.cmake to compile RocksDB.
Said cmake missed adding crc32c_arm64 compilation target so if
machine native architecture supported crc32 then complier would enable
usage of function defined in crc32c_arm64 causing the listed error.

Added crc32c_arm64 complition target.