### PR TITLE
MDEV-23030: ARM crash on Raspberry Pi 4

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -911,6 +911,9 @@ extern MYSQL_PLUGIN_IMPORT my_crc32_t my_checksum;
 
 #if defined(__GNUC__) && defined(HAVE_ARMV8_CRC)
 int crc32_aarch64_available(void);
+#if defined(HAVE_ARMV8_CRYPTO)
+int crc32c_aarch64_available(void);
+#endif
 #endif
 
 #ifdef DBUG_ASSERT_EXISTS

--- a/mysys/CMakeLists.txt
+++ b/mysys/CMakeLists.txt
@@ -90,7 +90,8 @@ ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
       __asm__(\"pmull  v2.1q,          v2.1d,  v1.1d\");
       return ret;
     }
-    int main() { foo(0); }" HAVE_ARMV8_CRYPTO)
+    #include <sys/auxv.h>
+    int main() { foo(0); getauxval(AT_HWCAP); }" HAVE_ARMV8_CRYPTO)
 
     CHECK_C_COMPILER_FLAG(-march=armv8-a+crc+crypto HAVE_ARMV8_CRC_CRYPTO_INTRINSICS)
     IF(HAVE_ARMV8_CRC_CRYPTO_INTRINSICS)

--- a/mysys/crc32/crc32_arm64.c
+++ b/mysys/crc32/crc32_arm64.c
@@ -18,7 +18,20 @@ int crc32_aarch64_available(void)
   unsigned long auxv= getauxval(AT_HWCAP);
   return (auxv & HWCAP_CRC32) != 0;
 }
+
+#if defined(HAVE_ARMV8_CRYPTO)
+
+#ifndef HWCAP_PMULL
+#define HWCAP_PMULL (1 << 4)
 #endif
+
+/* Check if target ARM machine support crc32 + pmull for computing crc32c */
+int crc32c_aarch64_available(void)
+{
+  return !(~getauxval(AT_HWCAP) & (HWCAP_CRC32 | HWCAP_PMULL));
+}
+#endif /* HAVE_ARMV8_CRYPTO */
+#endif /* HAVE_ARMV8_CRC */
 
 #ifndef HAVE_ARMV8_CRC_CRYPTO_INTRINSICS
 

--- a/storage/innobase/ut/ut0crc32.cc
+++ b/storage/innobase/ut/ut0crc32.cc
@@ -342,11 +342,11 @@ allocations, would not hurt if called twice, but would be pointless. */
 void ut_crc32_init()
 {
 #ifndef HAVE_CRC32_VPMSUM
-# if defined(__GNUC__) && defined(HAVE_ARMV8_CRC)
-  if (crc32_aarch64_available())
+# if defined(__GNUC__) && defined(HAVE_ARMV8_CRC) && defined(HAVE_ARMV8_CRYPTO)
+  if (crc32c_aarch64_available())
   {
     ut_crc32_low= crc32c_aarch64;
-    ut_crc32_implementation= "Using ARMv8 crc32 instructions";
+    ut_crc32_implementation= "Using ARMv8 crc32 + pmull instructions";
     return;
   }
 # elif defined(TRY_SSE4_2)


### PR DESCRIPTION
MariaDB adopted a hardware optimized crc32c approach on ARM64 starting 10.5.
Said implementation of crc32c needs support from target hardware for crc32
and pmull instructions. Existing logic is checking only for crc32 support
from target hardware through a runtime check and so if target hardware
doesn't support pmull it would cause things to fail/crash.

Expanded runtime check to ensure pmull support is also checked on the target
hardware along with existing crc32.

Thanks to Marko and Daniel for review.