### PR TITLE
Deb: Refactor autopkgtests

### DIFF
--- a/debian/tests/smoke
+++ b/debian/tests/smoke
@@ -24,7 +24,7 @@
 echo "Running test 'smoke'"
 set -ex
 
-# Start the deamon if it was not running. For example in Docker testing
+# Start the daemon if it was not running. For example in Docker testing
 # environments there might not be any systemd et al and the service needs to
 # be started manually.
 if ! which systemctl
@@ -66,16 +66,24 @@ DROP DATABASE testdatabase;
 DROP USER 'testuser'@'localhost';
 EOT
 
-mysql <<EOT
+# List based on what is advertised at
+# https://mariadb.com/kb/en/innodb-page-compression/#configuring-the-innodb-page-compression-algorithm
+# but disabled  with '#' the options that are not available in this binary build
+mariadb <<EOT
 SET GLOBAL innodb_compression_algorithm=lz4;
+#SET GLOBAL innodb_compression_algorithm=lzo;
+#SET GLOBAL innodb_compression_algorithm=lzma;
+#SET GLOBAL innodb_compression_algorithm=bzip2;
+#SET GLOBAL innodb_compression_algorithm=snappy;
 SET GLOBAL innodb_compression_algorithm=zlib;
 SET GLOBAL innodb_compression_algorithm=none;
 EOT
 
-# Check whether RocksDB should be installed or not.
+# Check whether RocksDB should be installed or not
 plugin=mariadb-plugin-rocksdb
 if [ "$(dpkg-architecture -qDEB_HOST_ARCH_BITS)" != 32 ] &&
-   [ "$(dpkg-architecture -qDEB_HOST_ARCH_ENDIAN)" = little ]; then
+   [ "$(dpkg-architecture -qDEB_HOST_ARCH_ENDIAN)" = little ]
+  then
   dpkg-query -W $plugin
 
   LOG=/var/lib/mysql/#rocksdb/LOG
@@ -83,8 +91,18 @@ if [ "$(dpkg-architecture -qDEB_HOST_ARCH_BITS)" != 32 ] &&
   #      mariadb-server-10.5, which happens before that of the plugin.
   [ -e $LOG ] || mysql -e "INSTALL PLUGIN RocksDB SONAME 'ha_rocksdb';"
   # XXX: rocksdb_supported_compression_types variable does not report ZSTD.
+
+  # Print RocksDB supported items so test log is easier to debug
+  grep -F " supported:" $LOG
+
+  # Check that the expected compression methods are supported
   for a in LZ4 Snappy Zlib ZSTD; do
-    grep -qE "k$a(Compression)? supported: 1" $LOG
+    if ! grep -qE "k$a(Compression)? supported: 1" $LOG
+    then
+      # Fail with explicit error message
+      echo "Error: Compression method $a not supported by RocksDB!" >&2
+      exit 1
+    fi
   done
 else
   ! dpkg-query -W $plugin

--- a/debian/tests/upstream
+++ b/debian/tests/upstream
@@ -50,8 +50,12 @@ EOF
 fi
 
 ARCH=$(dpkg --print-architecture)
-if [ "$ARCH" = "s390x" ]; then
-    echo "main.func_regexp_pcre : recursion fails on s390x https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1723947" >> $SKIP_TEST_LST
+if [ "$ARCH" = "s390x" ]
+then
+  echo "main.func_regexp_pcre : recursion fails on s390x https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1723947" >> $SKIP_TEST_LST
+elif [ "$ARCH" = "armhf" ] || [ "$ARCH" = "i386" ]
+then
+  echo "main.failed_auth_unixsocket : Test returns wrong exit code on armhf and i386 (but only in debci) https://jira.mariadb.org/browse/MDEV-23933" >> $SKIP_TEST_LST
 fi
 
 cd /usr/share/mysql/mysql-test


### PR DESCRIPTION
Extend Debian autopkgtest to test for all InnoDB compression methods
that are expected to work and disable those that should not (e.g. Snappy).

This upstreams the changes of downstream Debian commit
https://salsa.debian.org/mariadb-team/mariadb-10.3/-/commit/278531a7dfa7d60a60b067d089860c92a4e1221b
apart from having Snappy support.

In addition, simplify Debian autopkgtest RocksDB part and make it more
verbose so that future regressions like this are easier to debug.

Snappy is still used in RocksDB and ColumnStore and autopkgtests thus
also check that it is available in RocksDB.

This is a follow-up to PR#1582 without enabling Snappy for InnoDB but still fixing autopkgtests so they expect the compressions that currently the server is compiled to have support for.