### PR TITLE
MDEV-22485: mysqlslap does not use current user as default

### DIFF
--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -1196,9 +1196,6 @@ get_options(int *argc,char ***argv)
   if (debug_check_flag)
     my_end_arg= MY_CHECK_ERROR;
 
-  if (!user)
-    user= (char *)"root";
-
   /*
     If something is created and --no-drop is not specified, we drop the
     schema.


### PR DESCRIPTION
The help documentation specifically mentions that if --user is not specified, it will use current user. At the same time for mysqldump in documentation written --user The MariaDB user name to use when connecting to the server.
This patch makes behaviour of mysqlslap consistent only for a local cases.
For the network connection mysqlslap, mysqlcheck, mysqlshow and mysqldump work correcttly only when username and password specified togerther. If we pass only the password all mentioned tools (mysqlslap, mysqlcheck, mysqlshow and mysqldump) use it for root. Documentation for user key more correct for mysqldump and should be used as a sample for mysqlslap (and desirable for mysqlcheck and mysqlshow)