### PR TITLE
MDEV-23424: unireg to prevent win32 overflows use size_t

### DIFF
--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -191,9 +191,9 @@ class Field_data_type_info_image: public BinaryStringBuffer<512>
     memcpy(pos, str->ptr(), str->length());
     return pos + str->length();
   }
-  static uint store_length_required_length(ulonglong length)
+  static size_t store_length_required_length(ulonglong length)
   {
-    return net_length_size(length);
+    return (size_t) net_length_size(length);
   }
 public:
   Field_data_type_info_image() { }


### PR DESCRIPTION
Attempt to prevent compile errors:

C:\Buildbot\win32-1809\build\sql\unireg.cc(1253,15): error C2220: the following warning is treated as an error [C:\Buildbot\win32-1809\build\sql\sql.vcxproj]
C:\Buildbot\win32-1809\build\sql\unireg.cc(1253,15): error C2220:   if (reserve(store_size)) [C:\Buildbot\win32-1809\build\sql\sql.vcxproj]
C:\Buildbot\win32-1809\build\sql\unireg.cc(1253,15): error C2220:               ^ [C:\Buildbot\win32-1809\build\sql\sql.vcxproj]
C:\Buildbot\win32-1809\build\sql\unireg.cc(1253,15): warning C4244: 'argument': conversion from 'ulonglong' to 'size_t', possible loss of data [C:\Buildbot\win32-1809\build\sql\sql.vcxproj]
C:\Buildbot\win32-1809\build\sql\unireg.cc(1253,15): warning C4244:   if (reserve(store_size)) [C:\Buildbot\win32-1809\build\sql\sql.vcxproj]
C:\Buildbot\win32-1809\build\sql\unireg.cc(1253,15): warning C4244:               ^ [C:\Buildbot\win32-1809\build\sql\sql.vcxproj]