### PR TITLE
InnoDB: handle EOPNOTSUPP from posix_fallocate()

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3628,6 +3628,7 @@ fallback:
 		errno = err;
 		return false;
 	case EINVAL:
+	case EOPNOTSUPP:
 		/* fall back to the code below */
 		break;
 	}


### PR DESCRIPTION
On some libc (like musl[1]), posix_fallocate() is a fallocate() syscall
wrapper, and does not include fallback code like glibc does. In that
case, EOPNOTSUPP is returned if underlying filesystem does not
support fallocate() with mode = 0.

This patch enables falling back to writing zeros when EOPNOTSUPP, fixes
some cases like running on filesystem without proper fallocate support
on Alpine.

[1]: https://git.musl-libc.org/cgit/musl/tree/src/fcntl/posix_fallocate.c?h=v1.2.1