### PR TITLE
Define variable to override endpoint url

### DIFF
--- a/plugin/aws_key_management/aws_key_management_plugin.cc
+++ b/plugin/aws_key_management/aws_key_management_plugin.cc
@@ -81,6 +81,7 @@ static unsigned long key_spec;
 static unsigned long log_level;
 static int rotate_key;
 static int request_timeout;
+static char* endpoint_url;
 
 #ifndef DBUG_OFF
 #define WITH_AWS_MOCK 1
@@ -228,6 +229,10 @@ static int aws_init()
   if (region && region[0])
   {
     clientConfiguration.region = region;
+  }
+  if (endpoint_url && endpoint_url[0])
+  {
+    clientConfiguration.endpointOverride = endpoint_url;
   }
   if (request_timeout)
   {
@@ -711,6 +716,11 @@ static MYSQL_SYSVAR_STR(region, region,
   "AWS region. For example us-east-1, or eu-central-1. If no value provided, SDK default is used.",
   NULL, NULL, "");
 
+static MYSQL_SYSVAR_STR(endpoint_url, endpoint_url,
+  PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+  "Used to override the default AWS API endpoint. If not set, the default will be used",
+  NULL, NULL, "");
+
 #if WITH_AWS_MOCK
 static MYSQL_SYSVAR_BOOL(mock, mock,
   PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
@@ -725,6 +735,7 @@ static struct st_mysql_sys_var* settings[]= {
   MYSQL_SYSVAR(log_level),
   MYSQL_SYSVAR(request_timeout),
   MYSQL_SYSVAR(region),
+  MYSQL_SYSVAR(endpoint_url),
 #if WITH_AWS_MOCK
   MYSQL_SYSVAR(mock),
 #endif


### PR DESCRIPTION
Define new `aws_key_management_endpoint_url` plugin variable to use a different endpoint url for KMS operations.