### PR TITLE
MDEV-23564: Hiding OSX CMAKE warning for GSSAPI

### DIFF
--- a/plugin/auth_gssapi/cmake/FindGSSAPI.cmake
+++ b/plugin/auth_gssapi/cmake/FindGSSAPI.cmake
@@ -97,7 +97,7 @@ else(GSSAPI_LIBS AND GSSAPI_FLAVOR)
 
     # Until new gssapi is used MDEV-23564
     IF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-      string(APPEND CMAKE_C_FLAGS " -Wno-deprecated-declarations")
+      MY_CHECK_AND_SET_COMPILER_FLAG(-Wno-deprecated-declarations)
     ENDIF()
 
 endif(GSSAPI_LIBS AND GSSAPI_FLAVOR)

--- a/plugin/auth_gssapi/cmake/FindGSSAPI.cmake
+++ b/plugin/auth_gssapi/cmake/FindGSSAPI.cmake
@@ -95,4 +95,9 @@ else(GSSAPI_LIBS AND GSSAPI_FLAVOR)
   
   endif(KRB5_CONFIG)
 
+    # Until new gssapi is used MDEV-23564
+    IF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+      string(APPEND CMAKE_C_FLAGS " -Wno-deprecated-declarations")
+    ENDIF()
+
 endif(GSSAPI_LIBS AND GSSAPI_FLAVOR)


### PR DESCRIPTION
This change only hides the warning whenever building on OSX automatically,
moving on the path should be port GSSAPI to Mac OSX and others.

This is a port from https://github.com/grooverdan/mariadb-connector-c/commits/gssapi_nowarn