### PR TITLE
travis: osx build time out storing cache. Ensure not Cellar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ cache:
   timeout: 500
   apt: true
   ccache: true
-  directories:
-    - /usr/local/Cellar # Fails do to permission error: https://github.com/travis-ci/travis-ci/issues/8092
 
 addons:
   apt:


### PR DESCRIPTION
Passes this test case.
https://travis-ci.org/github/grooverdan/mariadb-server/jobs/723046285

pushing as a pr to do a second test.