### PR TITLE
MDEV-23077: flashbacking the update/delete + join statements has some bugs

### DIFF
--- a/mysql-test/suite/binlog/r/flashback.result
+++ b/mysql-test/suite/binlog/r/flashback.result
@@ -702,6 +702,354 @@ include/assert.inc [Table t1 should have 0 rows.]
 # 6- Rows must be present upon restoring from flashback
 include/assert.inc [Table t1 should have six rows.]
 DROP TABLE t1;
+# < CASE 8 >
+# Update join, Delete join, --flashback and --table=student,class
+#
+create table school(
+schoolID int not null default 0 primary key,
+schoolName blob not null
+)ENGINE=InnoDB;
+create table class(
+classID int not null default 0 primary key,
+className blob not null,
+schoolID int not null default 0
+)ENGINE=InnoDB;
+create table student(
+stdID int not null default 0 primary key,
+stdName blob not null,
+classID int not null default 0,
+schoolID int not null default 0
+)ENGINE=InnoDB;
+INSERT INTO school (schoolID,schoolName) VALUES (1,"S-a"),(2,"S-b");
+INSERT INTO class(classID,className,schoolID) VALUES (1,"C-a",1),(2,"C-b",1),(3,"C-c",1),(4,"C-d",1);
+INSERT INTO student(stdID,stdName,classID,schoolID) VALUES (1,"S-a",1,1),(2,"S-b",1,1),(3,"S-c",1,1),(4,"S-d",4,1),(5,"S-e",2,1),(6,"S-f",3,1),(7,"S-g",4,1);
+SELECT * FROM school;
+schoolID	schoolName
+1	S-a
+2	S-b
+SELECT * FROM class;
+classID	className	schoolID
+1	C-a	1
+2	C-b	1
+3	C-c	1
+4	C-d	1
+SELECT * FROM student;
+stdID	stdName	classID	schoolID
+1	S-a	1	1
+2	S-b	1	1
+3	S-c	1	1
+4	S-d	4	1
+5	S-e	2	1
+6	S-f	3	1
+7	S-g	4	1
+RESET MASTER;
+BEGIN;
+UPDATE school,student,class 
+SET school.schoolName='school_deleted',student.schoolID=2,class.schoolID=2
+WHERE school.schoolID= class.schoolID AND class.schoolID = student.schoolID AND school.schoolID=1;
+DELETE school,student,class
+FROM school INNER JOIN student INNER JOIN class  
+WHERE school.schoolID IN (2);
+COMMIT;
+SELECT * FROM school;
+schoolID	schoolName
+1	school_deleted
+SELECT * FROM class;
+classID	className	schoolID
+SELECT * FROM student;
+stdID	stdName	classID	schoolID
+FLUSH LOGS;
+# < CASE 8 >
+# Show mysqlbinlog result with -B
+#
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
+/*!40019 SET @@session.max_insert_delayed_threads=0*/;
+/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
+DELIMITER /*!*/;
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Start: binlog v 4, server v #.##.## created 010909  9:46:40 at startup
+ROLLBACK/*!*/;
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Gtid list []
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Binlog checkpoint master-bin.000001
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Annotate_rows:
+#Q> UPDATE school,student,class 
+#Q> SET school.schoolName='school_deleted',student.schoolID=2,class.schoolID=2
+#Q> WHERE school.schoolID= class.schoolID AND class.schoolID = student.schoolID AND school.schoolID
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`student` mapped to number #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`class` mapped to number #
+# Number of rows: 11
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Annotate_rows:
+#Q> DELETE school,student,class
+#Q> FROM school INNER JOIN student INNER JOIN class  
+#Q> WHERE school.schoolID IN (
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`student` mapped to number #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Table_map: `test`.`class` mapped to number #
+# Number of rows: 11
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Rotate to master-bin.000002  pos: 4
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Xid = #
+START TRANSACTION/*!*/;
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Write_rows: table id #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Write_rows: table id # flags: STMT_END_F
+### INSERT INTO `test`.`student`
+### SET
+###   @1=7 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-g' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`student`
+### SET
+###   @1=6 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-f' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`student`
+### SET
+###   @1=5 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-e' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`student`
+### SET
+###   @1=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-d' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`student`
+### SET
+###   @1=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-c' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`student`
+### SET
+###   @1=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-b' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`student`
+### SET
+###   @1=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-a' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`class`
+### SET
+###   @1=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-d' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`class`
+### SET
+###   @1=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-c' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`class`
+### SET
+###   @1=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-b' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+### INSERT INTO `test`.`class`
+### SET
+###   @1=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-a' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Update_rows: table id #
+#010909  9:46:40 server id 1  end_log_pos # CRC32 XXX 	Update_rows: table id # flags: STMT_END_F
+### UPDATE `test`.`class`
+### WHERE
+###   @1=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-d' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-d' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`class`
+### WHERE
+###   @1=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-c' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-c' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`class`
+### WHERE
+###   @1=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-b' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-b' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`class`
+### WHERE
+###   @1=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-a' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='C-a' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`student`
+### WHERE
+###   @1=7 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-g' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=7 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-g' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`student`
+### WHERE
+###   @1=6 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-f' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=6 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-f' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`student`
+### WHERE
+###   @1=5 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-e' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=5 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-e' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`student`
+### WHERE
+###   @1=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-d' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-d' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=4 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`student`
+### WHERE
+###   @1=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-c' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=3 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-c' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`student`
+### WHERE
+###   @1=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-b' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=2 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-b' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=1 /* INT meta=0 nullable=0 is_null=0 */
+### UPDATE `test`.`student`
+### WHERE
+###   @1=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-a' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=2 /* INT meta=0 nullable=0 is_null=0 */
+### SET
+###   @1=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @2='S-a' /* BLOB/TEXT meta=2 nullable=0 is_null=0 */
+###   @3=1 /* INT meta=0 nullable=0 is_null=0 */
+###   @4=1 /* INT meta=0 nullable=0 is_null=0 */
+COMMIT
+/*!*/;
+COMMIT
+/*!*/;
+DELIMITER ;
+# End of log file
+ROLLBACK /* added by mysqlbinlog */;
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
+# < CASE 8 >
+# Flashback & Check the result
+#
+SELECT * FROM school;
+schoolID	schoolName
+1	school_deleted
+SELECT * FROM class;
+classID	className	schoolID
+1	C-a	1
+2	C-b	1
+3	C-c	1
+4	C-d	1
+SELECT * FROM student;
+stdID	stdName	classID	schoolID
+1	S-a	1	1
+2	S-b	1	1
+3	S-c	1	1
+4	S-d	4	1
+5	S-e	2	1
+6	S-f	3	1
+7	S-g	4	1
+DROP TABLE school;
+DROP TABLE class;
+DROP TABLE student;
+# < CASE 9 >
+# --flashback and --database=D1,D3
+#
+create database D1;
+create table D1.T1(
+id int not null default 0
+)ENGINE=InnoDB;
+create database D2;
+create table D2.T2(
+id int not null default 0
+)ENGINE=InnoDB;
+create database D3;
+create table D3.T3(
+id int not null default 0
+)ENGINE=InnoDB;
+insert into D1.T1 values(1),(2);
+insert into D2.T2 values(3),(4);
+insert into D3.T3 values(5),(6);
+SELECT * FROM D1.T1;
+id
+1
+2
+SELECT * FROM D2.T2;
+id
+3
+4
+SELECT * FROM D3.T3;
+id
+5
+6
+RESET MASTER;
+DELETE FROM D1.T1;
+DELETE FROM D2.T2;
+DELETE FROM D3.T3;
+FLUSH LOGS;
+# < CASE 9 >
+# Flashback & Check the result
+#
+SELECT * FROM D1.T1;
+id
+2
+1
+SELECT * FROM D2.T2;
+id
+SELECT * FROM D3.T3;
+id
+6
+5
+DROP DATABASE D1;
+DROP DATABASE D2;
+DROP DATABASE D3;
 SET binlog_format=statement;
 Warnings:
 Warning	1105	MariaDB Galera and flashback do not support binlog format: STATEMENT

--- a/mysql-test/suite/binlog/t/flashback.test
+++ b/mysql-test/suite/binlog/t/flashback.test
@@ -364,6 +364,143 @@ FLUSH LOGS;
 
 DROP TABLE t1;
 
+--echo # < CASE 8 >
+--echo # Update join, Delete join, --flashback and --table=student,class
+--echo #
+
+create table school(
+        schoolID int not null default 0 primary key,
+        schoolName blob not null
+)ENGINE=InnoDB;
+create table class(
+        classID int not null default 0 primary key,
+        className blob not null,
+        schoolID int not null default 0
+)ENGINE=InnoDB;
+create table student(
+        stdID int not null default 0 primary key,
+        stdName blob not null,
+        classID int not null default 0,
+        schoolID int not null default 0
+)ENGINE=InnoDB;
+INSERT INTO school (schoolID,schoolName) VALUES (1,"S-a"),(2,"S-b");
+INSERT INTO class(classID,className,schoolID) VALUES (1,"C-a",1),(2,"C-b",1),(3,"C-c",1),(4,"C-d",1);
+INSERT INTO student(stdID,stdName,classID,schoolID) VALUES (1,"S-a",1,1),(2,"S-b",1,1),(3,"S-c",1,1),(4,"S-d",4,1),(5,"S-e",2,1),(6,"S-f",3,1),(7,"S-g",4,1);
+
+SELECT * FROM school;
+
+SELECT * FROM class;
+
+SELECT * FROM student;
+
+RESET MASTER;
+
+# Update and Delete test data
+BEGIN;
+
+UPDATE school,student,class 
+SET school.schoolName='school_deleted',student.schoolID=2,class.schoolID=2
+WHERE school.schoolID= class.schoolID AND class.schoolID = student.schoolID AND school.schoolID=1;
+
+DELETE school,student,class
+FROM school INNER JOIN student INNER JOIN class  
+WHERE school.schoolID IN (2);
+
+COMMIT;
+
+SELECT * FROM school;
+
+SELECT * FROM class;
+
+SELECT * FROM student;
+
+FLUSH LOGS;
+
+--echo # < CASE 8 >
+--echo # Show mysqlbinlog result with -B
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--replace_regex /SQL_LOAD_MB-[0-9]-[0-9]/SQL_LOAD_MB-#-#/ /exec_time=[0-9]*/exec_time=#/ /end_log_pos [0-9]*/end_log_pos #/ /# at [0-9]*/# at #/ /Xid = [0-9]*/Xid = #/ /thread_id=[0-9]*/thread_id=#/ /table id [0-9]*/table id #/ /mapped to number [0-9]*/mapped to number #/ /server v [^ ]*/server v #.##.##/ /CRC32 0x[0-9a-f]*/CRC32 XXX/ /collation_server=[0-9]+/collation_server=X/ /character_set_client=[0-9]+/character_set_client=X/ /collation_connection=[0-9]+/collation_connection=X/
+--exec $MYSQL_BINLOG -B --table=student,class --base64-output=decode-rows -v -v $MYSQLD_DATADIR/master-bin.000001
+
+--echo # < CASE 8 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG  -vv $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_8.sql
+--exec $MYSQL_BINLOG --flashback --table=student,class -vv $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_8.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_8.sql;"
+
+SELECT * FROM school;
+
+SELECT * FROM class;
+
+SELECT * FROM student;
+
+DROP TABLE school;
+DROP TABLE class;
+DROP TABLE student;
+
+--echo # < CASE 9 >
+--echo # --flashback and --database=D1,D3
+--echo #
+
+create database D1;
+create table D1.T1(
+	id int not null default 0
+)ENGINE=InnoDB;
+create database D2;
+create table D2.T2(
+	id int not null default 0
+)ENGINE=InnoDB;
+create database D3;
+create table D3.T3(
+	id int not null default 0
+)ENGINE=InnoDB;
+insert into D1.T1 values(1),(2);
+insert into D2.T2 values(3),(4);
+insert into D3.T3 values(5),(6);
+
+SELECT * FROM D1.T1;
+
+SELECT * FROM D2.T2;
+
+SELECT * FROM D3.T3;
+
+RESET MASTER;
+
+# delete all data
+
+DELETE FROM D1.T1;
+DELETE FROM D2.T2;
+DELETE FROM D3.T3;
+
+FLUSH LOGS;
+
+--echo # < CASE 9 >
+--echo # Flashback & Check the result
+--echo #
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--exec $MYSQL_BINLOG  -vv $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_original_9.sql
+--exec $MYSQL_BINLOG --flashback --database=D1,D3 -vv $MYSQLD_DATADIR/master-bin.000001 > $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_9.sql
+--exec $MYSQL -e "SET binlog_format= ROW; source $MYSQLTEST_VARDIR/tmp/mysqlbinlog_row_flashback_9.sql;"
+
+SELECT * FROM D1.T1;
+
+SELECT * FROM D2.T2;
+
+SELECT * FROM D3.T3;
+
+DROP DATABASE D1;
+DROP DATABASE D2;
+DROP DATABASE D3;
+
 ## Clear
 SET binlog_format=statement;
 --error ER_FLASHBACK_NOT_SUPPORTED


### PR DESCRIPTION
1. Extend the --table --database option of mysqlbinlog to allow --table and --database to support plural values;
2. Fix bug 2 and bug 3 described by [MDEV-23077](https://jira.mariadb.org/browse/MDEV-23077);