### PR TITLE
MDEV-21910 backporting 10.4 fixes for BF abort vs manual kill

### DIFF
--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -95,6 +95,7 @@ int encryption_scheme_decrypt(const unsigned char* src, unsigned int slen,
                               unsigned int i32_2, unsigned long long i64);
 enum thd_kill_levels {
   THD_IS_NOT_KILLED=0,
+  THD_WSREP_MARK_VICTIM=10,
   THD_ABORT_SOFTLY=50,
   THD_ABORT_ASAP=100,
 };

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -95,6 +95,7 @@ int encryption_scheme_decrypt(const unsigned char* src, unsigned int slen,
                               unsigned int i32_2, unsigned long long i64);
 enum thd_kill_levels {
   THD_IS_NOT_KILLED=0,
+  THD_WSREP_MARK_VICTIM=10,
   THD_ABORT_SOFTLY=50,
   THD_ABORT_ASAP=100,
 };

--- a/include/mysql/plugin_encryption.h.pp
+++ b/include/mysql/plugin_encryption.h.pp
@@ -95,6 +95,7 @@ int encryption_scheme_decrypt(const unsigned char* src, unsigned int slen,
                               unsigned int i32_2, unsigned long long i64);
 enum thd_kill_levels {
   THD_IS_NOT_KILLED=0,
+  THD_WSREP_MARK_VICTIM=10,
   THD_ABORT_SOFTLY=50,
   THD_ABORT_ASAP=100,
 };

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -95,6 +95,7 @@ int encryption_scheme_decrypt(const unsigned char* src, unsigned int slen,
                               unsigned int i32_2, unsigned long long i64);
 enum thd_kill_levels {
   THD_IS_NOT_KILLED=0,
+  THD_WSREP_MARK_VICTIM=10,
   THD_ABORT_SOFTLY=50,
   THD_ABORT_ASAP=100,
 };

--- a/include/mysql/plugin_password_validation.h.pp
+++ b/include/mysql/plugin_password_validation.h.pp
@@ -95,6 +95,7 @@ int encryption_scheme_decrypt(const unsigned char* src, unsigned int slen,
                               unsigned int i32_2, unsigned long long i64);
 enum thd_kill_levels {
   THD_IS_NOT_KILLED=0,
+  THD_WSREP_MARK_VICTIM=10,
   THD_ABORT_SOFTLY=50,
   THD_ABORT_ASAP=100,
 };

--- a/include/mysql/service_kill_statement.h
+++ b/include/mysql/service_kill_statement.h
@@ -41,6 +41,7 @@ extern "C" {
 
 enum thd_kill_levels {
   THD_IS_NOT_KILLED=0,
+  THD_WSREP_MARK_VICTIM=10,
   THD_ABORT_SOFTLY=50, /**< abort when possible, don't leave tables corrupted */
   THD_ABORT_ASAP=100,  /**< abort asap */
 };

--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -117,6 +117,7 @@ extern struct wsrep_service_st {
   my_bool                     (*wsrep_thd_is_applier_func)(MYSQL_THD);
   void                        (*wsrep_report_bf_lock_wait_func)(MYSQL_THD thd,
                                                                 unsigned long long trx_id);
+  bool                        (*wsrep_thd_set_wsrep_aborter_func)(MYSQL_THD bf_thd, MYSQL_THD thd);
 } *wsrep_service;
 
 #ifdef MYSQL_DYNAMIC_PLUGIN
@@ -172,6 +173,7 @@ extern struct wsrep_service_st {
 #define wsrep_drupal_282555_workaround get_wsrep_drupal_282555_workaround()
 #define wsrep_recovery get_wsrep_recovery()
 #define wsrep_protocol_version get_wsrep_protocol_version()
+#define wsrep_thd_set_wsrep_aborter(T) wsrep_service->wsrep_thd_set_wsrep_aborter_func(T1, T2)
 
 #else
 
@@ -228,6 +230,8 @@ void wsrep_set_data_home_dir(const char *data_dir);
 my_bool wsrep_thd_is_applier(MYSQL_THD thd);
 void wsrep_report_bf_lock_wait(THD *thd,
                                unsigned long long trx_id);
+/* set wsrep_aborter for the target THD */
+extern "C" bool wsrep_thd_set_wsrep_aborter(MYSQL_THD bf_thd, MYSQL_THD victim_thd);
 #endif
 
 #ifdef __cplusplus

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1725,9 +1725,12 @@ void THD::awake(killed_state state_to_set)
       MYSQL_CALLBACK(scheduler, post_kill_notification, (this));
   }
 
-  /* Interrupt target waiting inside a storage engine. */
-  if (state_to_set != NOT_KILLED)
-    ha_kill_query(this, thd_kill_level(this));
+  if (wsrep_aborter == 0)
+  {
+    /* Interrupt target waiting inside a storage engine. */
+    if (state_to_set != NOT_KILLED)
+      ha_kill_query(this, thd_kill_level(this));
+  }
 
   /* Broadcast a condition to kick the target if it is waiting on it. */
   if (mysys_var)

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -652,7 +652,8 @@ THD::THD(my_thread_id id, bool is_wsrep_applier)
    wsrep_po_handle(WSREP_PO_INITIALIZER),
    wsrep_po_cnt(0),
    wsrep_apply_format(0),
-   wsrep_ignore_table(false)
+   wsrep_ignore_table(false),
+   wsrep_aborter(0)
 #endif
 {
   ulong tmp;
@@ -1225,6 +1226,7 @@ void THD::init(void)
   wsrep_replicate_GTID    = false;
   wsrep_skip_wsrep_GTID   = false;
   wsrep_split_flag        = false;
+  wsrep_aborter           = 0;
 #endif /* WITH_WSREP */
 
   if (variables.sql_log_bin)

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3760,6 +3760,11 @@ public:
       killed_err= 0;
       mysql_mutex_unlock(&LOCK_thd_kill);
     }
+#ifdef WITH_WSREP
+    mysql_mutex_lock(&LOCK_thd_data);
+    wsrep_aborter= 0;
+    mysql_mutex_unlock(&LOCK_thd_data);
+#endif /* WITH_WSREP */
   }
   inline void reset_kill_query()
   {
@@ -4458,6 +4463,8 @@ public:
     table updates from being replicated to other nodes via galera replication.
   */
   bool                      wsrep_ignore_table;
+  /* thread who has started kill for this THD protected by LOCK_thd_data*/
+  my_thread_id              wsrep_aborter;
   wsrep_gtid_t              wsrep_sync_wait_gtid;
   ulong                     wsrep_affected_rows;
   bool                      wsrep_replicate_GTID;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -8896,6 +8896,17 @@ kill_one_thread(THD *thd, longlong id, killed_state kill_signal, killed_type typ
         thd->security_ctx->user_matches(tmp->security_ctx)) &&
 	!wsrep_thd_is_BF(tmp, false))
     {
+#ifdef WITH_WSREP
+      DEBUG_SYNC(thd, "before_awake_no_mutex");
+      if (tmp->wsrep_aborter && tmp->wsrep_aborter != thd->thread_id)
+      {
+        /* victim is in hit list already, bail out */
+       WSREP_DEBUG("victim has wsrep aborter: %lu, skipping awake()",
+                    tmp->wsrep_aborter);
+        error= 0;
+      }
+      else
+#endif /* WITH_WSREP */
       tmp->awake(kill_signal);
       error=0;
     }

--- a/sql/sql_plugin_services.ic
+++ b/sql/sql_plugin_services.ic
@@ -185,8 +185,9 @@ static struct wsrep_service_st wsrep_handler = {
   wsrep_unlock_rollback,
   wsrep_set_data_home_dir,
   wsrep_thd_is_applier,
-  wsrep_report_bf_lock_wait
-};
+  wsrep_report_bf_lock_wait,
+  wsrep_thd_set_wsrep_aborter
+ };
 
 static struct thd_specifics_service_st thd_specifics_handler=
 {

--- a/sql/wsrep_dummy.cc
+++ b/sql/wsrep_dummy.cc
@@ -158,3 +158,5 @@ my_bool wsrep_thd_is_applier(MYSQL_THD thd)
 void wsrep_report_bf_lock_wait(MYSQL_THD thd,
                                unsigned long long id)
 {}
+bool wsrep_thd_set_wsrep_aborter(THD*, THD*)
+{ return 0;}

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -836,6 +836,24 @@ bool wsrep_thd_has_explicit_locks(THD *thd)
   return thd->mdl_context.has_explicit_locks();
 }
 
+extern "C" bool wsrep_thd_set_wsrep_aborter(THD *bf_thd, THD *victim_thd)
+{
+  if (!bf_thd)
+  {
+    victim_thd->wsrep_aborter = 0;
+    WSREP_DEBUG("wsrep_thd_set_wsrep_aborter resetting wsrep_aborter");
+    return false;
+  }
+  if (victim_thd->wsrep_aborter && victim_thd->wsrep_aborter != bf_thd->thread_id)
+  {
+    return true;
+  }
+  victim_thd->wsrep_aborter = bf_thd->thread_id;
+  WSREP_DEBUG("wsrep_thd_set_wsrep_aborter setting wsrep_aborter %u",
+              victim_thd->wsrep_aborter);
+  return false;
+}
+
 /*
   Get auto increment variables for THD. Use global settings for
   applier threads.

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -19586,6 +19586,13 @@ wsrep_innobase_kill_one_trx(
 		DBUG_RETURN(0);
 	}
 
+	if (wsrep_thd_set_wsrep_aborter(bf_thd, thd))
+	{
+	  WSREP_DEBUG("innodb kill transaction skipped due to wsrep_aborter set");
+	  wsrep_thd_UNLOCK(thd);
+	  DBUG_RETURN(0);
+	}
+
 	if (wsrep_thd_exec_mode(thd) != LOCAL_STATE) {
 		WSREP_DEBUG("withdraw for BF trx: " TRX_ID_FMT ", state: %d",
 			    victim_trx->id,


### PR DESCRIPTION
This pull request backports the original fix for MDEV-21910
from 10.4 branch into 10.2
In 10.2, a similar issue has been filed with jira tracker id MDEV-23328,
however, the symptoms and underlying problem should be the same with
these reported issues.

The fix here, introduces new THD class member: wsrep_aborter, which
is used to mark a THD as victim for the first high priority thread
who calls for aborting the victim. Further information can be found in
issue MDEV-21910 and related commit and pull request comments.