### PR TITLE
MDEV-23910: build warnings and errors on mac OS

### DIFF
--- a/sql/structs.h
+++ b/sql/structs.h
@@ -874,7 +874,12 @@ public:
   Timeval(my_time_t sec, ulong usec)
   {
     tv_sec= sec;
+/* apple timeval tv_usec is __darwin_suseconds_t aka int */
+#ifdef __APPLE__
+    tv_usec= static_cast<int>(usec);
+#else
     tv_usec= usec;
+#endif
   }
   explicit Timeval(const timeval &tv)
    :timeval(tv)

--- a/storage/maria/ha_s3.h
+++ b/storage/maria/ha_s3.h
@@ -31,52 +31,52 @@ public:
   ~ha_s3() {}
 
   int create(const char *name, TABLE *table_arg,
-             HA_CREATE_INFO *ha_create_info);
-  int open(const char *name, int mode, uint open_flags);
-  int write_row(const uchar *buf);
-  int update_row(const uchar * old_data, const uchar * new_data)
+             HA_CREATE_INFO *ha_create_info) override;
+  int open(const char *name, int mode, uint open_flags) override;
+  int write_row(const uchar *buf) override;
+  int update_row(const uchar * old_data, const uchar * new_data) override
   {
     DBUG_ENTER("update_row");
     DBUG_RETURN(HA_ERR_WRONG_COMMAND);
   }
-  int delete_row(const uchar * buf)
+  int delete_row(const uchar * buf) override
   {
     DBUG_ENTER("delete_row");
     DBUG_RETURN(HA_ERR_WRONG_COMMAND);
   }
-  int check(THD * thd, HA_CHECK_OPT * check_opt)
+  int check(THD * thd, HA_CHECK_OPT * check_opt) override
   {
     DBUG_ENTER("delete_row");
     DBUG_RETURN(HA_ERR_WRONG_COMMAND);
   }
-  int analyze(THD * thd, HA_CHECK_OPT * check_opt)
+  int analyze(THD * thd, HA_CHECK_OPT * check_opt) override
   {
     DBUG_ENTER("analyze");
     DBUG_RETURN(HA_ERR_WRONG_COMMAND);
   }
-  int repair(THD * thd, HA_CHECK_OPT * check_opt)
+  int repair(THD * thd, HA_CHECK_OPT * check_opt) override
   {
     DBUG_ENTER("repair");
     DBUG_RETURN(HA_ERR_WRONG_COMMAND);
   }
-  int preload_keys(THD * thd, HA_CHECK_OPT * check_opt)
+  int preload_keys(THD * thd, HA_CHECK_OPT * check_opt) override
   {
     DBUG_ENTER("preload_keys");
     DBUG_RETURN(HA_ERR_WRONG_COMMAND);
   }
-  int external_lock(THD * thd, int lock_type);
+  int external_lock(THD * thd, int lock_type) override;
   /*
     drop_table() is only used for internal temporary tables,
     not applicable for s3
   */
-  void drop_table(const char *name)
+  void drop_table(const char *name) override
   {
   }
-  int delete_table(const char *name);
-  int rename_table(const char *from, const char *to);
+  int delete_table(const char *name) override;
+  int rename_table(const char *from, const char *to) override;
   int discover_check_version() override;
   int rebind();
-  S3_INFO *s3_open_args() { return open_args; }
-  void register_handler(MARIA_HA *file);
+  S3_INFO *s3_open_args() override { return open_args; }
+  void register_handler (MARIA_HA *file) override;
 };
 #endif /* HA_S3_INCLUDED */


### PR DESCRIPTION
Fixes multiple clang++ compiler warnings in macOS related to loss of
precision in timeval and missing override specifiers in ha_s3

Provided under BSD New 3 Clause License