### PR TITLE
MDEV-22596: Check if deletion period is specified by constant

### DIFF
--- a/mysql-test/suite/period/r/delete.result
+++ b/mysql-test/suite/period/r/delete.result
@@ -176,6 +176,10 @@ delete from t for portion of othertime from '2000-01-01' to '2018-01-01';
 ERROR HY000: Period `othertime` is not found in table
 delete from t for portion of system_time from '2000-01-01' to '2018-01-01';
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'of system_time from '2000-01-01' to '2018-01-01'' at line 1
+# MDEV-22596 DELETE FOR PORTION does not obey
+# "Expression in FOR PORTION OF must be constant" limitation, data can be easily lost
+delete from t for portion of apptime from s to e;
+ERROR HY000: Expression in FOR PORTION OF must be constant
 create or replace table t (id int, str text, s date, e date,
 period for apptime(s,e));
 insert into t values(1, 'data', '1999-01-01', '2018-12-12');

--- a/mysql-test/suite/period/t/delete.test
+++ b/mysql-test/suite/period/t/delete.test
@@ -67,6 +67,11 @@ delete from t for portion of othertime from '2000-01-01' to '2018-01-01';
 --error ER_PARSE_ERROR
 delete from t for portion of system_time from '2000-01-01' to '2018-01-01';
 
+--echo # MDEV-22596 DELETE FOR PORTION does not obey
+--echo # "Expression in FOR PORTION OF must be constant" limitation, data can be easily lost
+--error ER_NOT_CONSTANT_EXPRESSION
+delete from t for portion of apptime from s to e;
+
 create or replace table t (id int, str text, s date, e date,
     period for apptime(s,e));
 

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -357,6 +357,16 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, COND *conds,
   if (mysql_prepare_delete(thd, table_list, &conds, &delete_while_scanning))
     DBUG_RETURN(TRUE);
 
+  if (table_list->has_period())
+  {
+    if (!table_list->period_conditions.start.item->const_item()
+        || !table_list->period_conditions.end.item->const_item())
+    {
+      my_error(ER_NOT_CONSTANT_EXPRESSION, MYF(0), "FOR PORTION OF");
+      DBUG_RETURN(true);
+    }
+  }
+
   if (delete_history)
     table->vers_write= false;
 


### PR DESCRIPTION
DELETE...FOR PORTION OF... statement accepted non-constant FROM...TO clause. This contradicts the documentation and is inconsistent with the behavior of UPDATE statement. 

I add a validation that checks if a given deletion period is specified by constant.