### PR TITLE
Travis-CI: Optimize rate of false negatives vs true failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,8 +114,8 @@ compiler:
   - clang
 env:
   - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=archive,optimizer_unfixed_bugs,parts,sys_vars,unit,vcol,innodb,innodb_gis,innodb_zip,innodb_fts
-  - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,encryption,rocksdb,versioning,rpl
-  - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles
+  - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=binlog,binlog_encryption,rocksdb,versioning,rpl
+  - CC_VERSION=7 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=csv,federated,funcs_1,funcs_2,gcol,handler,heap,json,maria,perfschema,plugins,multi_source,roles,encryption
   - CC_VERSION=10 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
 
 jobs:
@@ -191,10 +191,10 @@ jobs:
       arch: s390x
       compiler: gcc
       env: CC_VERSION=10 TYPE=RelWithDebInfo MYSQL_TEST_SUITES=main
-    # Sporadically fails on main.multi_update_big test (MDEV-23955)
-    - arch: arm64
     # Until OSX becomes a bit more stable
     - os: osx
+    # ppc64el builder frequently runs out of memory
+    - arch: ppc64le
 
 before_install:
   - if [[ "${TRAVIS_OS_NAME}" == 'osx' ]]; then


### PR DESCRIPTION
The base distro version was changed from bionic to focal and GCC/Clang to 10, and I expect there will be some regressions/bugs that will need fine tuning and a follow-up commit.

## Update Dec 21st

I reviewed status of Travis-CI. Most jobs timeout/are skipped due too much traffic on Travis. Of the jobs that actually run, the majority pass OK. Examples:
- https://travis-ci.org/github/MariaDB/server/builds/747444463
- https://travis-ci.org/github/MariaDB/server/builds/748092290
- https://travis-ci.org/github/MariaDB/server/builds/749059547

I looked at the couple of failures e.g.
- https://travis-ci.org/github/MariaDB/server/jobs/750378268
- https://travis-ci.org/github/MariaDB/server/jobs/749049920

The end result is an optimization of the .travis-ci.yml file that should serve us well into the future.
