### PR TITLE
MDEV-18842 Unfortunate error message when the same column is used for…

### DIFF
--- a/mysql-test/suite/period/r/create.result
+++ b/mysql-test/suite/period/r/create.result
@@ -45,6 +45,10 @@ ERROR 42000: Incorrect column specifier for column 's'
 create or replace table t (id int primary key, s date, e date,
 period for mytime(s,x));
 ERROR 42S22: Unknown column 'x' in 'mytime'
+# MDEV-18842: Unfortunate error message when the same column is used
+# for application period start and end
+create or replace table t (s date, t date, period for apt(s,s));
+ERROR 42000: Column 's' specified twice
 create or replace table t (id int primary key, s date, e date,
 period for mytime(s,e),
 period for mytime2(s,e));

--- a/mysql-test/suite/period/t/create.test
+++ b/mysql-test/suite/period/t/create.test
@@ -31,6 +31,12 @@ create or replace table t (id int primary key, s time, e time,
 --error ER_BAD_FIELD_ERROR
 create or replace table t (id int primary key, s date, e date,
                            period for mytime(s,x));
+
+--echo # MDEV-18842: Unfortunate error message when the same column is used
+--echo # for application period start and end
+--error ER_FIELD_SPECIFIED_TWICE
+create or replace table t (s date, t date, period for apt(s,s));
+
 --error ER_MORE_THAN_ONE_PERIOD
 create or replace table t (id int primary key, s date, e date,
                            period for mytime(s,e),

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -4361,6 +4361,12 @@ public:
 
   int add_period(Lex_ident name, Lex_ident_sys_st start, Lex_ident_sys_st end)
   {
+    if (lex_string_cmp(system_charset_info, &start, &end) == 0)
+    {
+      my_error(ER_FIELD_SPECIFIED_TWICE, MYF(0), start.str);
+      return 1;
+    }
+
     Table_period_info &info= create_info.period_info;
 
     if (check_exists && info.name.streq(name))


### PR DESCRIPTION
… application period start and end

An application-time period must be composed of two different temporal columns. We added a check that ensures that the above condition is met.

https://jira.mariadb.org/browse/MDEV-18842