### PR TITLE
MDEV-23081 Stray XA transactions at startup, with wsrep_on=OFF

### DIFF
--- a/mysql-test/suite/wsrep/r/MDEV-23081.result
+++ b/mysql-test/suite/wsrep/r/MDEV-23081.result
@@ -1,0 +1,24 @@
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+connect con1, localhost, root;
+SET DEBUG_SYNC = "wsrep_after_certification SIGNAL after_certification_reached WAIT_FOR continue_after_certification";
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_1 WAIT_FOR continue_before_commit_order_1";
+INSERT INTO t1 VALUES (9);
+connect con_ctrl, localhost, root;
+SET DEBUG_SYNC = "now WAIT_FOR after_certification_reached";
+connect con2, localhost, root;
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_2 WAIT_FOR continue_before_commit_order_2";
+INSERT INTO t1 VALUES (10);
+connection con_ctrl;
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_2";
+SET DEBUG_SYNC = "now SIGNAL continue_after_certification";
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_1";
+connection default;
+# Kill the server
+XA RECOVER;
+formatID	gtrid_length	bqual_length	data
+disconnect con1;
+disconnect con2;
+disconnect con_ctrl;
+connection default;
+DROP TABLE t1;
+CALL mtr.add_suppression("You need to use --log-bin to make --binlog-format work");

--- a/mysql-test/suite/wsrep/t/MDEV-23081.cnf
+++ b/mysql-test/suite/wsrep/t/MDEV-23081.cnf
@@ -1,0 +1,9 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+binlog-format=ROW
+innodb-flush-log-at-trx-commit=1
+wsrep-cluster-address=gcomm://
+wsrep-provider=@ENV.WSREP_PROVIDER
+innodb-autoinc-lock-mode=2

--- a/mysql-test/suite/wsrep/t/MDEV-23081.combinations
+++ b/mysql-test/suite/wsrep/t/MDEV-23081.combinations
@@ -1,0 +1,4 @@
+[binlogon]
+log-bin
+
+[binlogoff]

--- a/mysql-test/suite/wsrep/t/MDEV-23081.test
+++ b/mysql-test/suite/wsrep/t/MDEV-23081.test
@@ -1,0 +1,57 @@
+#
+# MDEV-23081: Stray XA transactions at startup
+# if node restarts with wsrep_on=OFF
+#
+--source include/have_wsrep.inc
+--source include/have_innodb.inc
+--source include/have_wsrep_provider.inc
+--source include/have_debug_sync.inc
+
+CREATE TABLE t1 (f1 INT PRIMARY KEY) ENGINE=InnoDB;
+
+#
+# Execute two inserts on block those after becoming
+# prepared, and before they are committed
+#
+--connect con1, localhost, root
+SET DEBUG_SYNC = "wsrep_after_certification SIGNAL after_certification_reached WAIT_FOR continue_after_certification";
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_1 WAIT_FOR continue_before_commit_order_1";
+--send INSERT INTO t1 VALUES (9)
+
+--connect con_ctrl, localhost, root
+SET DEBUG_SYNC = "now WAIT_FOR after_certification_reached";
+
+--connect con2, localhost, root
+SET DEBUG_SYNC = "wsrep_before_commit_order_enter SIGNAL before_commit_order_reached_2 WAIT_FOR continue_before_commit_order_2";
+--send INSERT INTO t1 VALUES (10)
+
+--connection con_ctrl
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_2";
+SET DEBUG_SYNC = "now SIGNAL continue_after_certification";
+SET DEBUG_SYNC = "now WAIT_FOR before_commit_order_reached_1";
+
+#
+# Kill the server
+#
+--connection default
+--source include/kill_mysqld.inc
+
+#
+# and restart it with wsrep-on=OFF
+#
+let $restart_noprint=2;
+--let $restart_parameters=--wsrep-on=OFF
+--source include/start_mysqld.inc
+
+#
+# Expect no prepared XA transactions to be reported
+#
+XA RECOVER;
+
+--disconnect con1
+--disconnect con2
+--disconnect con_ctrl
+--connection default
+
+DROP TABLE t1;
+CALL mtr.add_suppression("You need to use --log-bin to make --binlog-format work");

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2167,7 +2167,7 @@ static my_bool xarecover_handlerton(THD *unused, plugin_ref plugin,
 
       for (int i=0; i < got; i ++)
       {
-        my_xid x= IF_WSREP(WSREP_ON && wsrep_is_wsrep_xid(&info->list[i]) ?
+        my_xid x= IF_WSREP(wsrep_is_wsrep_xid(&info->list[i]) ?
                            wsrep_xid_seqno(&info->list[i]) :
                            info->list[i].get_my_xid(),
                            info->list[i].get_my_xid());


### PR DESCRIPTION
Change xarecover_handlerton so that transaction with WSREP prefixed
xids are rolled back when Galera is disabled.