### PR TITLE
Update description of mariadb-common package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -121,14 +121,14 @@ Description: MariaDB database common files (e.g. /etc/mysql/my.cnf)
 Package: mariadb-common
 Architecture: all
 Depends: mysql-common, ${misc:Depends}, ${shlibs:Depends}
-Description: MariaDB database common files (e.g. /etc/mysql/conf.d/mariadb.cnf)
+Description: MariaDB database common files (e.g. /etc/mysql/mariadb.conf.d/)
  MariaDB is a fast, stable and true multi-user, multi-threaded SQL database
  server. SQL (Structured Query Language) is the most popular database query
  language in the world. The main goals of MariaDB are speed, robustness and
  ease of use.
  .
  This package includes files needed by all versions of the client library
- (e.g. /etc/mysql/conf.d/mariadb.cnf).
+ (e.g. /etc/mysql/mariadb.conf.d/ or /etc/mysql/mariadb.cnf).
 
 Package: mariadb-client-core-10.1
 Architecture: any


### PR DESCRIPTION
- Commit https://github.com/mariadb/server/commit/438ed0408c69
introduced `mariadb-common` package and added description. Example in
description is confusing since files referred to are not installed and
not related/owned by the `mariadb-common` package.
- Patch is updating real file/directory description section pointing to
the real examples owned by the package.
- Example:
```
$ dpkg --get-selections maria*
mariadb-client-10.3				install
mariadb-client-core-10.3			install
mariadb-common					install
mariadb-server					install
mariadb-server-10.3				install
mariadb-server-core-10.3			install

$ dpkg -L mariadb-common
/.
/etc
/etc/mysql
/etc/mysql/mariadb.cnf
/etc/mysql/mariadb.conf.d
/usr
/usr/share
/usr/share/doc
/usr/share/doc/mariadb-common
/usr/share/doc/mariadb-common/changelog.Debian.gz
/usr/share/doc/mariadb-common/copyright

$ ls /etc/mysql/
conf.d/          debian-start     debian.cnf       mariadb.cnf      mariadb.conf.d/  my.cnf           my.cnf.fallback  

```