### PR TITLE
[WIP] MDEV-21842: auto_increment does not increment with compound primary k…

### DIFF
--- a/mysql-test/suite/parts/r/MDEV-21842.result
+++ b/mysql-test/suite/parts/r/MDEV-21842.result
@@ -1,0 +1,47 @@
+#
+# MDEV-21842: auto_increment does not increment with compound primary
+# key on partitioned table
+#
+create or replace table `t` (
+`id` bigint(20) unsigned not null auto_increment,
+`a` int(10) not null ,
+`dt` date not null,
+primary key (`id`, `dt`) ,
+unique key (`a`, `dt`)
+) engine=innodb
+partition by range  columns(`dt`)
+(
+partition `p202002` values less than ('2020-03-01'),
+partition `P202003` values less than ('2020-04-01')
+);
+connect  con1, localhost, root,,;
+connect  con2, localhost, root,,;
+connection con1;
+start transaction;
+insert into t (a, dt) values (1, '2020-02-29');
+connection con2;
+start transaction;
+insert into t (a, dt) values (1, '2020-02-29');
+connection con1;
+insert into t (a, dt) values (2, '2020-02-29');
+select auto_increment from information_schema.tables where table_name='t';
+auto_increment
+4
+commit;
+select auto_increment from information_schema.tables where table_name='t';
+auto_increment
+4
+insert into t (a, dt) values (3, '2020-02-29');
+insert into t (a, dt) values (4, '2020-02-29');
+connection con2;
+ERROR 23000: Duplicate entry '1-2020-02-29' for key 'a'
+select auto_increment from information_schema.tables where table_name='t';
+auto_increment
+6
+select * from t;
+id	a	dt
+1	1	2020-02-29
+3	2	2020-02-29
+4	3	2020-02-29
+5	4	2020-02-29
+drop table t;

--- a/mysql-test/suite/parts/t/MDEV-21842.test
+++ b/mysql-test/suite/parts/t/MDEV-21842.test
@@ -1,0 +1,50 @@
+--source include/have_partition.inc
+--source include/have_innodb.inc
+let $engine= 'innodb';
+
+--echo #
+--echo # MDEV-21842: auto_increment does not increment with compound primary
+--echo # key on partitioned table
+--echo #
+
+create or replace table `t` (
+  `id` bigint(20) unsigned not null auto_increment,
+  `a` int(10) not null ,
+  `dt` date not null,
+  primary key (`id`, `dt`) ,
+  unique key (`a`, `dt`)
+) engine=innodb
+ partition by range  columns(`dt`)
+(
+ partition `p202002` values less than ('2020-03-01'),
+ partition `P202003` values less than ('2020-04-01')
+);
+
+connect (con1, localhost, root,,);
+connect (con2, localhost, root,,);
+
+--connection con1
+start transaction;
+insert into t (a, dt) values (1, '2020-02-29');
+
+--connection con2
+start transaction;
+send insert into t (a, dt) values (1, '2020-02-29');
+
+--connection con1
+insert into t (a, dt) values (2, '2020-02-29');
+select auto_increment from information_schema.tables where table_name='t';
+commit;
+
+select auto_increment from information_schema.tables where table_name='t';
+
+insert into t (a, dt) values (3, '2020-02-29');
+insert into t (a, dt) values (4, '2020-02-29');
+
+--connection con2
+--error ER_DUP_ENTRY
+reap;
+select auto_increment from information_schema.tables where table_name='t';
+
+select * from t;
+drop table t;

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -92,7 +92,6 @@ public:
   bool auto_inc_initialized;
   mysql_mutex_t auto_inc_mutex;                /**< protecting auto_inc val */
   ulonglong next_auto_inc_val;                 /**< first non reserved value */
-  ulonglong prev_auto_inc_val;                 /**< stored next_auto_inc_val */
   /**
     Hash of partition names. Initialized in the first ha_partition::open()
     for the table_share. After that it is read-only, i.e. no locking required.
@@ -104,7 +103,6 @@ public:
   Partition_share()
     : auto_inc_initialized(false),
     next_auto_inc_val(0),
-    prev_auto_inc_val(0),
     partition_name_hash_initialized(false),
     partition_names(NULL)
   {
@@ -435,19 +433,12 @@ private:
   {
     handler::restore_auto_increment(prev_insert_id);
   }
-  /** Store and restore next_auto_inc_val over duplicate key errors. */
-  virtual void store_auto_increment()
-  {
-    DBUG_ASSERT(part_share);
-    part_share->prev_auto_inc_val= part_share->next_auto_inc_val;
-    handler::store_auto_increment();
-  }
-  virtual void restore_auto_increment()
-  {
-    DBUG_ASSERT(part_share);
-    part_share->next_auto_inc_val= part_share->prev_auto_inc_val;
-    handler::restore_auto_increment();
-  }
+  /**
+    MDEV-21842: we do nothing on duplicate key errors in order to avoid
+    generating duplicate auto-increment values.
+  */
+  virtual void store_auto_increment() {}
+  virtual void restore_auto_increment() {}
   /** Temporary storage for new partitions Handler_shares during ALTER */
   List<Parts_share_refs> m_new_partitions_share_refs;
   /** Sorted array of partition ids in descending order of number of rows. */


### PR DESCRIPTION
…ey on partitioned table

part_share->next_auto_inc_val is literally shared stuff, and thus we should not decrement it without careful synchronization. The current implementation of ha_partition::restore_auto_increment() seems to do a sort of blind write.

We can fix [MDEV-21842](
https://jira.mariadb.org/browse/MDEV-21842), without reoccurring [MDEV-17333](https://jira.mariadb.org/browse/MDEV-17333), by stopping decrementing both next_insert_id and next_auto_inc_val . This possibly results in a waste of auto-increment counter on duplicate key errors in some cases (e.g., bulk load). However, generating duplicated value is a much more critical issue than causing gaps in an auto-increment column.
The test case is based on one appeared in [this blog post](https://techblog.gmo-ap.jp/2020/05/26/mariadb_auto_increment/) (in Japanese). It is different from the one provided in the JIRA issue but I prefer a deterministic test.