### PR TITLE
MDEV-23872 Crash in galera::TrxHandle::state()

### DIFF
--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -122,7 +122,10 @@ When one supplies long data for a placeholder:
 #include "lock.h"                               // MYSQL_OPEN_FORCE_SHARED_MDL
 #include "sql_handler.h"
 #include "transaction.h"                        // trans_rollback_implicit
+#ifdef WITH_WSREP
 #include "wsrep_mysqld.h"
+#include "wsrep_trans_observer.h"
+#endif /* WITH_WSREP */
 
 /**
   A result class used to send cursor rows using the binary protocol.
@@ -4414,6 +4417,23 @@ reexecute:
 
     thd->m_reprepare_observer= NULL;
 
+#ifdef WITH_WSREP
+    if (WSREP(thd) &&
+        !(sql_command_flags[lex->sql_command] & CF_PS_ARRAY_BINDING_OPTIMIZED))
+    {
+      if (wsrep_after_statement(thd))
+      {
+        /*
+          Re-execution success is unlikely after an error from
+          wsrep_after_statement(), so retrun error immediately.
+        */
+        thd->get_stmt_da()->reset_diagnostics_area();
+        wsrep_override_error(thd, thd->wsrep_cs().current_error(),
+                             thd->wsrep_cs().current_error_status());
+      }
+    }
+    else
+#endif /* WITH_WSREP */
     if (unlikely(error) &&
         (sql_command_flags[lex->sql_command] & CF_REEXECUTION_FRAGILE) &&
         !thd->is_fatal_error && !thd->killed &&


### PR DESCRIPTION
Prepared statements which were run over binary protocol crashed
a server if the statement did not have CF_PS_ARRAY_BINDING_OPTIMIZED
flag and the statement was executed in bulk mode and a BF abort occrurred.
This was because the bulk execution resulted in several statements without
calling wsrep_after_statement() between, which confused wsrep transaction
state tracking.

As a fix, call wsrep_after_statement() in bulk loop after each execution
if CF_PS_ARRAY_BINDING_OPTIMIZED is not set.

Note that this PR does not have test as there does not seem to be a way to test PS binary protocol bulk execution with MTR.