### PR TITLE
MDEV-24063 Assertion during graceful shutdown with wsrep_on=OFF

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-24063.result
+++ b/mysql-test/suite/galera/r/MDEV-24063.result
@@ -1,0 +1,8 @@
+connection node_2;
+connection node_1;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2a;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+connection node_2;
+SET GLOBAL wsrep_on=OFF;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-24063.test
+++ b/mysql-test/suite/galera/t/MDEV-24063.test
@@ -1,0 +1,20 @@
+#
+# MDEV-24063
+#
+# my_bool wsrep_thd_is_aborting(const THD*):
+# Assertion `((&(&thd->LOCK_thd_data)->m_mutex)->count > 0 &&
+# pthread_equal(pthread_self(), (&(&thd->LOCK_thd_data)->m_mutex)->thread))' failed.
+#
+
+--source include/galera_cluster.inc
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connection node_2a
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+--connection node_2
+SET GLOBAL wsrep_on=OFF;
+--source include/shutdown_mysqld.inc
+--source include/start_mysqld.inc
+
+DROP TABLE t1;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3308,7 +3308,7 @@ public:
   void awake_no_mutex(killed_state state_to_set);
   void awake(killed_state state_to_set)
   {
-    bool wsrep_on_local= WSREP_NNULL(this);
+    bool wsrep_on_local= variables.wsrep_on;
     /*
       mutex locking order (LOCK_thd_data - LOCK_thd_kill)) requires
       to grab LOCK_thd_data here


### PR DESCRIPTION
During graceful shutdowns, client connections are closed and
eventually and THD::awake() acquires LOCK_thd_data mutex which is
required later on in wsrep_thd_is_aborting(). Make sure LOCK_thd_data
is acquired, even if global wsrep_on is disabled.