### PR TITLE
MDEV-21842: auto_increment does not increment with compound primary k…

### DIFF
--- a/mysql-test/main/auto_increment_ranges_innodb.result
+++ b/mysql-test/main/auto_increment_ranges_innodb.result
@@ -289,3 +289,51 @@ pk	f
 5	a
 6	<===
 drop table t1;
+#
+# MDEV-21842: auto_increment does not increment with compound primary
+# key on partitioned table
+#
+create or replace table `t` (
+`id` bigint(20) unsigned not null auto_increment,
+`a` int(10) not null ,
+`dt` date not null,
+primary key (`id`, `dt`) ,
+unique key (`a`, `dt`)
+)
+partition by range  columns(`dt`)
+(
+partition `p202002` values less than ('2020-03-01'),
+partition `P202003` values less than ('2020-04-01')
+);
+connect  con1, localhost, root,,;
+connect  con2, localhost, root,,;
+connection con1;
+start transaction;
+insert into t (a, dt) values (1, '2020-02-29');
+connection con2;
+start transaction;
+insert into t (a, dt) values (1, '2020-02-29');
+connection con1;
+insert into t (a, dt) values (2, '2020-02-29');
+select auto_increment from information_schema.tables where table_name='t';
+auto_increment
+4
+commit;
+connection con2;
+ERROR 23000: Duplicate entry '1-2020-02-29' for key 'a'
+connection con1;
+select auto_increment from information_schema.tables where table_name='t';
+auto_increment
+4
+insert into t (a, dt) values (3, '2020-02-29');
+insert into t (a, dt) values (4, '2020-02-29');
+disconnect con1;
+disconnect con2;
+connection default;
+select * from t;
+id	a	dt
+1	1	2020-02-29
+3	2	2020-02-29
+4	3	2020-02-29
+5	4	2020-02-29
+drop table t;

--- a/mysql-test/main/auto_increment_ranges_innodb.test
+++ b/mysql-test/main/auto_increment_ranges_innodb.test
@@ -18,3 +18,61 @@ select * from t1;
 drop table t1;
 --let $datadir=`select @@datadir`
 --remove_file $datadir/test/load.data
+
+--echo #
+--echo # MDEV-21842: auto_increment does not increment with compound primary
+--echo # key on partitioned table
+--echo #
+
+create or replace table `t` (
+  `id` bigint(20) unsigned not null auto_increment,
+  `a` int(10) not null ,
+  `dt` date not null,
+  primary key (`id`, `dt`) ,
+  unique key (`a`, `dt`)
+)
+ partition by range  columns(`dt`)
+(
+ partition `p202002` values less than ('2020-03-01'),
+ partition `P202003` values less than ('2020-04-01')
+);
+
+connect (con1, localhost, root,,);
+connect (con2, localhost, root,,);
+
+--connection con1
+start transaction;
+insert into t (a, dt) values (1, '2020-02-29');
+
+--connection con2
+start transaction;
+let $conn2_id= `SELECT CONNECTION_ID()`;
+send insert into t (a, dt) values (1, '2020-02-29');
+
+--connection con1
+# Ensure that the above insert via conn2 increments next_auto_inc_val
+# before the following insert via conn1 starts.
+let $wait_condition=select 1 from Information_schema.INNODB_TRX
+    where trx_mysql_thread_id = $conn2_id and trx_state = 'LOCK WAIT'
+    and trx_query = "insert into t (a, dt) values (1, '2020-02-29')";
+--source include/wait_condition.inc
+
+insert into t (a, dt) values (2, '2020-02-29');
+select auto_increment from information_schema.tables where table_name='t';
+commit;
+
+--connection con2
+--error ER_DUP_ENTRY
+reap;
+
+--connection con1
+select auto_increment from information_schema.tables where table_name='t';
+insert into t (a, dt) values (3, '2020-02-29');
+insert into t (a, dt) values (4, '2020-02-29');
+
+disconnect con1;
+disconnect con2;
+
+--connection default
+select * from t;
+drop table t;

--- a/mysql-test/main/partition_innodb.result
+++ b/mysql-test/main/partition_innodb.result
@@ -1046,10 +1046,10 @@ INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
 a
 -1
-1
 3
 4
 6
+7
 DROP TABLE t1;
 #
 # End of 10.3 tests

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -4341,7 +4341,8 @@ int ha_partition::write_row(uchar * buf)
 
   tmp_disable_binlog(thd); /* Do not replicate the low-level changes. */
   error= m_file[part_id]->ha_write_row(buf);
-  if (have_auto_increment && !table->s->next_number_keypart)
+  /* Update next_auto_inc_val only when ha_write_row() returns no error. */
+  if (!error && have_auto_increment && !table->s->next_number_keypart)
     set_auto_increment_if_higher(table->next_number_field);
   reenable_binlog(thd);
 

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -92,7 +92,6 @@ public:
   bool auto_inc_initialized;
   mysql_mutex_t auto_inc_mutex;                /**< protecting auto_inc val */
   ulonglong next_auto_inc_val;                 /**< first non reserved value */
-  ulonglong prev_auto_inc_val;                 /**< stored next_auto_inc_val */
   /**
     Hash of partition names. Initialized in the first ha_partition::open()
     for the table_share. After that it is read-only, i.e. no locking required.
@@ -104,7 +103,6 @@ public:
   Partition_share()
     : auto_inc_initialized(false),
     next_auto_inc_val(0),
-    prev_auto_inc_val(0),
     partition_name_hash_initialized(false),
     partition_names(NULL)
   {
@@ -430,24 +428,6 @@ private:
   MY_BITMAP m_locked_partitions;
   /** Stores shared auto_increment etc. */
   Partition_share *part_share;
-  /** Fix spurious -Werror=overloaded-virtual in GCC 9 */
-  virtual void restore_auto_increment(ulonglong prev_insert_id)
-  {
-    handler::restore_auto_increment(prev_insert_id);
-  }
-  /** Store and restore next_auto_inc_val over duplicate key errors. */
-  virtual void store_auto_increment()
-  {
-    DBUG_ASSERT(part_share);
-    part_share->prev_auto_inc_val= part_share->next_auto_inc_val;
-    handler::store_auto_increment();
-  }
-  virtual void restore_auto_increment()
-  {
-    DBUG_ASSERT(part_share);
-    part_share->next_auto_inc_val= part_share->prev_auto_inc_val;
-    handler::restore_auto_increment();
-  }
   /** Temporary storage for new partitions Handler_shares during ALTER */
   List<Parts_share_refs> m_new_partitions_share_refs;
   /** Sorted array of partition ids in descending order of number of rows. */


### PR DESCRIPTION
…ey on partitioned table

When a partitioned table has an auto-increment column and the column is placed at the first column of a key, the auto-increment gives out duplicate numbers under concurrent inserts on the table.

The bug's root cause is that when there are concurrent inserts and some of them cause duplicate key errors,
ha_partition::restore_auto_increment() unproperly decrement part_share->next_auto_inc_val by blind write.

This bug is introduced by [c9cba59749e1b5a39a9e3a0a5b8bd762507245f9](https://github.com/MariaDB/server/commit/c9cba59749e1b5a39a9e3a0a5b8bd762507245f9), which fixed MDEV-17333. We almost revert the commit but we can prevent recurrence of MDEV-17333 by updating next_auto_inc_val in ha_partition::write_row() only when handler::ha_write_row() returns no error. The point is to prevent next_auto_inc_val from being incremented rather than to restore it after increment.

* The test case is based on one appeared in [this blog post](https://techblog.gmo-ap.jp/2020/05/26/mariadb_auto_increment/) (in Japanese). It is different from the one provided in the JIRA issue but I prefer a deterministic test. If you execute the test case on the HEAD of 10.3, it would raise a duplicate key error.
* I noticed that the test main.partition_innodb failed by my fix. However, the current behavior looks more correct than the old one. Inserting a negative integer into the auto-increment column should not reset the auto-increment counter. Thus, I fixed the corresponding result file along with the current behavior.