### PR TITLE
Fix MTR test galera.galera_trigger

### DIFF
--- a/mysql-test/suite/galera/r/galera_trigger.result
+++ b/mysql-test/suite/galera/r/galera_trigger.result
@@ -45,34 +45,34 @@ connection node_2;
 set session wsrep_sync_wait=15;
 insert into t1(value) values (3);
 insert into t1(value) values (4);
-select * from t2;
-id	tbl	action
-1	t1	INSERT
-3	t1	INSERT
-4	t1	INSERT
-6	t1	INSERT
+select tbl, action from t2;
+tbl	action
+t1	INSERT
+t1	INSERT
+t1	INSERT
+t1	INSERT
 connection node_1;
 drop trigger if exists log_insert;
 insert into t1(value) values (5);
-select * from t2;
-id	tbl	action
-1	t1	INSERT
-3	t1	INSERT
-4	t1	INSERT
-6	t1	INSERT
+select tbl, action from t2;
+tbl	action
+t1	INSERT
+t1	INSERT
+t1	INSERT
+t1	INSERT
 connection node_2;
 insert into t1(value) values (6);
-select * from t2;
-id	tbl	action
-1	t1	INSERT
-3	t1	INSERT
-4	t1	INSERT
-6	t1	INSERT
+select tbl, action from t2;
+tbl	action
+t1	INSERT
+t1	INSERT
+t1	INSERT
+t1	INSERT
 connection node_1;
-select * from t2;
-id	tbl	action
-1	t1	INSERT
-3	t1	INSERT
-4	t1	INSERT
-6	t1	INSERT
+select tbl, action from t2;
+tbl	action
+t1	INSERT
+t1	INSERT
+t1	INSERT
+t1	INSERT
 drop table t1, t2;

--- a/mysql-test/suite/galera/t/galera_trigger.test
+++ b/mysql-test/suite/galera/t/galera_trigger.test
@@ -55,18 +55,18 @@ insert into t1(value) values (2);
 set session wsrep_sync_wait=15;
 insert into t1(value) values (3);
 insert into t1(value) values (4);
-select * from t2;
+select tbl, action from t2;
 
 --connection node_1
 drop trigger if exists log_insert;
 insert into t1(value) values (5);
-select * from t2;
+select tbl, action from t2;
 
 --connection node_2
 insert into t1(value) values (6);
-select * from t2;
+select tbl, action from t2;
 
 --connection node_1
-select * from t2;
+select tbl, action from t2;
 
 drop table t1, t2;


### PR DESCRIPTION
Changed the test so that it does not rely on specific auto increment
ids. With Galera's default wsrep_auto_increment_control setting it is
not guaranteed that auto increments always start from 1. The test was
occasionally failing due to result content mismatch.