### PR TITLE
MDEV-24366 Add a S3 storage engine test case for Huawei OBS

### DIFF
--- a/mysql-test/suite/s3/my.cnf
+++ b/mysql-test/suite/s3/my.cnf
@@ -5,6 +5,15 @@
 plugin-maturity = gamma
 plugin-load-add=@ENV.HA_S3_SO
 s3=ON
+s3-host-name=@ENV.S3_HOST_NAME
+s3-protocol-version=@ENV.S3_PROTOCOL_VERSION
+s3-bucket=@ENV.S3_BUCKET
+s3-access-key=@ENV.S3_ACCESS_KEY
+s3-secret-key=@ENV.S3_SECRET_KEY
+s3-region=@ENV.S3_REGION
+s3-port=@ENV.S3_PORT
+s3-use-http=@ENV.S3_USE_HTTP
+
 #s3-host-name=s3.amazonaws.com
 #s3-protocol-version=Amazon
 #s3-bucket=MariaDB
@@ -15,11 +24,11 @@ s3=ON
 ##
 ## Configuration for local MinIO
 ##
-s3-host-name="127.0.0.1"
-# Note: s3-host-name="localhost" doesn't work. It causes
-# libmarias3 to use the wrong variant of the protocol.
-s3-bucket=storage-engine
-s3-access-key=minio
-s3-secret-key=minioadmin
-s3-port=9000
-s3-use-http=ON
+#s3-host-name="127.0.0.1"
+## Note: s3-host-name="localhost" doesn't work. It causes
+## libmarias3 to use the wrong variant of the protocol.
+#s3-bucket=storage-engine
+#s3-access-key=minio
+#s3-secret-key=minioadmin
+#s3-port=9000
+#s3-use-http=ON

--- a/mysql-test/suite/s3/slave.cnf
+++ b/mysql-test/suite/s3/slave.cnf
@@ -3,6 +3,14 @@ plugin-maturity = gamma
 plugin-load-add=@ENV.HA_S3_SO
 s3=ON
 s3-slave-ignore-updates=1
+s3-host-name=@ENV.S3_HOST_NAME
+s3-protocol-version=@ENV.S3_PROTOCOL_VERSION
+s3-bucket=@ENV.S3_BUCKET
+s3-access-key=@ENV.S3_ACCESS_KEY
+s3-secret-key=@ENV.S3_SECRET_KEY
+s3-region=@ENV.S3_REGION
+s3-port=@ENV.S3_PORT
+s3-use-http=@ENV.S3_USE_HTTP
 
 # You can change the following when running the tests against
 # your own S3 setup
@@ -17,11 +25,11 @@ s3-slave-ignore-updates=1
 ##
 ## Configuration for local MinIO
 ##
-s3-host-name="127.0.0.1"
-# Note: s3-host-name="localhost" doesn't work. It causes
-# libmarias3 to use the wrong variant of the protocol.
-s3-bucket=storage-engine
-s3-access-key=minio
-s3-secret-key=minioadmin
-s3-port=9000
-s3-use-http=ON
+#s3-host-name="127.0.0.1"
+## Note: s3-host-name="localhost" doesn't work. It causes
+## libmarias3 to use the wrong variant of the protocol.
+#s3-bucket=storage-engine
+#s3-access-key=minio
+#s3-secret-key=minioadmin
+#s3-port=9000
+#s3-use-http=ON

--- a/mysql-test/suite/s3/suite.pm
+++ b/mysql-test/suite/s3/suite.pm
@@ -1,8 +1,67 @@
 package My::Suite::S3;
 
+use Socket;
+
 @ISA = qw(My::Suite);
 
 return "Need S3 engine" unless $::mysqld_variables{'s3'} eq "ON" or $ENV{HA_S3_SO};
 
+my $paddr = sockaddr_in(9000, INADDR_ANY);
+my $protocol = getprotobyname("tcp");
+socket(SOCK, PF_INET, SOCK_STREAM, $protocol);
+
+if(connect(SOCK, $paddr))
+{
+  $ENV{'S3_HOST_NAME'} = "127.0.0.1";
+  $ENV{'S3_PORT'} = 9000;
+  $ENV{'S3_BUCKET'} = "storage-engine";
+  $ENV{'S3_ACCESS_KEY'} = "minio";
+  $ENV{'S3_SECRET_KEY'} = "minioadmin";
+  $ENV{'S3_REGION'} = "";
+  $ENV{'S3_PROTOCOL_VERSION'} = "Auto";
+  $ENV{'S3_USE_HTTP'} = "ON";
+}
+else
+{
+  if (!$ENV{'S3_HOST_NAME'})
+  {
+    return "Environment variable S3_HOST_NAME need to be set";
+  }
+
+  if (!$ENV{'S3_BUCKET'})
+  {
+    return "Environment variable S3_BUCKET need to be set";
+  }
+
+  if (!$ENV{'S3_REGION'})
+  {
+    $ENV{'S3_REGION'} = "";
+  }
+
+  if (!$ENV{'S3_ACCESS_KEY'})
+  {
+    return "Environment variable S3_ACCESS_KEY need to be set";
+  }
+
+  if (!$ENV{'S3_SECRET_KEY'})
+  {
+    return "Environment variable S3_SECRET_KEY need to be set";
+  }
+
+  if (!$ENV{'S3_PROTOCOL_VERSION'})
+  {
+    $ENV{'S3_PROTOCOL_VERSION'} = "Auto";
+  }
+
+  if (!$ENV{'S3_PORT'})
+  {
+    $ENV{'S3_PORT'} = 0;
+  }
+
+  if (!$ENV{'S3_USE_HTTP'})
+  {
+    $ENV{'S3_USE_HTTP'} = "OFF";
+  }
+}
 bless { };
 


### PR DESCRIPTION
If we use Huawei OBS for S3 storage engine, the amazon test case
will be skiiped, so here we need add a test case for Huawei OBS.