### PR TITLE
MDEV-24031: remove maria_ft_boolean_check_syntax_string()

### DIFF
--- a/storage/maria/ma_ft_parser.c
+++ b/storage/maria/ma_ft_parser.c
@@ -81,27 +81,6 @@ FT_WORD * maria_ft_linearize(TREE *wtree, MEM_ROOT *mem_root)
   DBUG_RETURN(wlist);
 }
 
-my_bool maria_ft_boolean_check_syntax_string(const uchar *str)
-{
-  uint i, j;
-
-  if (!str ||
-      (strlen((const char *) str) != strlen(ft_boolean_syntax)) ||
-      (str[0] != ' ' && str[1] != ' '))
-    return 1;
-  for (i=0; i<strlen(ft_boolean_syntax); i++)
-  {
-    /* limiting to 7-bit ascii only */
-    if ((unsigned char)(str[i]) > 127 ||
-        my_isalnum(default_charset_info, str[i]))
-      return 1;
-    for (j=0; j<i; j++)
-      if (str[i] == str[j] && (i != 11 || j != 10))
-        return 1;
-  }
-  return 0;
-}
-
 /*
   RETURN VALUE
   0 - eof

--- a/storage/maria/ma_ft_parser.c
+++ b/storage/maria/ma_ft_parser.c
@@ -86,7 +86,7 @@ my_bool maria_ft_boolean_check_syntax_string(const uchar *str)
   uint i, j;
 
   if (!str ||
-      (strlen((const char *) str) + 1 != strlen(ft_boolean_syntax)) ||
+      (strlen((const char *) str) != strlen(ft_boolean_syntax)) ||
       (str[0] != ' ' && str[1] != ' '))
     return 1;
   for (i=0; i<strlen(ft_boolean_syntax); i++)

--- a/storage/maria/ma_ft_parser.c
+++ b/storage/maria/ma_ft_parser.c
@@ -86,10 +86,10 @@ my_bool maria_ft_boolean_check_syntax_string(const uchar *str)
   uint i, j;
 
   if (!str ||
-      (strlen((const char *) str) + 1 != sizeof(ft_boolean_syntax)) ||
+      (strlen((const char *) str) + 1 != strlen(ft_boolean_syntax)) ||
       (str[0] != ' ' && str[1] != ' '))
     return 1;
-  for (i=0; i<sizeof(ft_boolean_syntax); i++)
+  for (i=0; i<strlen(ft_boolean_syntax); i++)
   {
     /* limiting to 7-bit ascii only */
     if ((unsigned char)(str[i]) > 127 ||


### PR DESCRIPTION
Jira issue number：MDEV-24031

summary： Aria storage engine uses sizeof(ft_boolean_syntax) as a replacement for strlen() but "ft_boolean_syntax" has "const char *" type.

problem description：The sizeof(ft_boolean_syntax) in maria_ft_boolean_check_syntax_string() may be intended to compute its length, but the ft_boolean_syntax's type is const char *. 

solution:  remove the maria_ft_boolean_check_syntax_string function since it's never used.

The modification will not hurt any other areas since this function isn't called at ay place. And the server can still be compiled successfully.