### PR TITLE
Fix commit 113f18686d0 and d1809097966: PLUGIN_COLUMNSTORE=NO by default

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -22,9 +22,9 @@ if [[ -d storage/columnstore/columnstore/debian ]]; then
   cp -v storage/columnstore/columnstore/debian/mariadb-plugin-columnstore.* debian/
   echo >> debian/control
   cat storage/columnstore/columnstore/debian/control >> debian/control
-  # Don't build ColumnStore as part of the native build, only build it when triggered
-  # by autobake-deb.sh
-  sed 's|#CMAKEFLAGS += -DPLUGIN_COLUMNSTORE=YES|CMAKEFLAGS += -DPLUGIN_COLUMNSTORE=YES|' -i debian/rules
+  # ColumnStore is explcitly disabled in the native build, so allow it now
+  # when build it when triggered by autobake-deb.sh
+  sed '/-DPLUGIN_COLUMNSTORE=NO/d' -i debian/rules
 fi
 
 # General CI optimizations to keep build output smaller
@@ -36,7 +36,7 @@ then
 
   # MCOL-4149: ColumnStore builds are so slow and big that they must be skipped on
   # both Travis-CI and Gitlab-CI
-  sed 's|-DPLUGIN_COLUMNSTORE=YES|-DPLUGIN_COLUMNSTORE=NO|' -i debian/rules
+  sed 's|$(CMAKEFLAGS)|$(CMAKEFLAGS) -DPLUGIN_COLUMNSTORE=NO|' -i debian/rules
   sed "/Package: mariadb-plugin-columnstore/,/^$/d" -i debian/control
 fi
 

--- a/debian/rules
+++ b/debian/rules
@@ -51,9 +51,7 @@ endif
 # ColumnStore only attempts to build on a few platforms as dictated by CMake checks
 # Also note in debian/control the CS-only build deps marked '[amd64]'
 ifeq ($(DEB_HOST_ARCH),$(filter $(DEB_HOST_ARCH),amd64))
-    # Don't build ColumnStore as part of the native build, only build it when triggered
-    # by autobake-deb.sh. Saves build time and disk space.
-    #CMAKEFLAGS += -DPLUGIN_COLUMNSTORE=YES
+    CMAKEFLAGS += -DPLUGIN_COLUMNSTORE=YES
 endif
 
 # Add extra flag to avoid WolfSSL code crashing the entire mariadbd on s390x. This
@@ -87,6 +85,8 @@ ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
 	dh_auto_build --builddirectory=builddir-native -- import_executables
 endif
 
+	# Don't build ColumnStore as part of the native build, only build it when
+	# triggered by autobake-deb.sh. Saves build time and disk space.
 	mkdir -p $(BUILDDIR) && cd $(BUILDDIR) && \
 	sh -c  'PATH=$${MYSQL_BUILD_PATH:-"/usr/lib/ccache:/usr/local/bin:/usr/bin:/bin"} \
 	    	CC=${CC} \
@@ -101,6 +101,7 @@ endif
 	    -DPLUGIN_TOKUDB=NO \
 	    -DPLUGIN_CASSANDRA=NO \
 	    -DPLUGIN_AWS_KEY_MANAGEMENT=NO \
+	    -DPLUGIN_COLUMNSTORE=NO \
 	    -DDEB=$(DEB_VENDOR) ..'
 
 # This is needed, otherwise 'make test' will run before binaries have been built

--- a/debian/rules
+++ b/debian/rules
@@ -48,12 +48,6 @@ ifeq (32,$(DEB_HOST_ARCH_BITS))
     CMAKEFLAGS += -DPLUGIN_ROCKSDB=NO
 endif
 
-# ColumnStore only attempts to build on a few platforms as dictated by CMake checks
-# Also note in debian/control the CS-only build deps marked '[amd64]'
-ifeq ($(DEB_HOST_ARCH),$(filter $(DEB_HOST_ARCH),amd64))
-    CMAKEFLAGS += -DPLUGIN_COLUMNSTORE=YES
-endif
-
 # Add extra flag to avoid WolfSSL code crashing the entire mariadbd on s390x. This
 # can be removed once upstream has made the code s390x compatible, see
 # https://jira.mariadb.org/browse/MDEV-21705 and


### PR DESCRIPTION
ColumnStore seems to build by default, so it must be explicitly disabled with a build flag, so that it does not build at all and thus build machine disk space and CPU will be spared.

This reverts commit 113f18686d004788f13e3a5bb60ea1c77847c963 and adds to it.