### PR TITLE
-s stands for silent, copy-paste mistake?

### DIFF
--- a/man/mysqlcheck.1
+++ b/man/mysqlcheck.1
@@ -855,7 +855,6 @@ Silent mode\&. Print only error messages\&.
 .\" mysqlcheck: skip-database option
 .\" skip-database option: mysqlcheck
 \fB\-\-skip\-database=\fB\fIdb_name\fR
-\fB\-s\fR
 .sp
 Don't process the database (case-sensitive) specified as argument\&.
 .RE


### PR DESCRIPTION
Possible bug in `mysqlcheck` man page.
```
 •   --skip-database=db_name -s
           Don't process the database (case-sensitive) specified as argument.
```