### PR TITLE
MDEV-24523 Execution of JSON_REPLACE failed on Spider

### DIFF
--- a/sql/item_jsonfunc.h
+++ b/sql/item_jsonfunc.h
@@ -375,7 +375,7 @@ public:
   const char *func_name() const
   {
     return mode_insert ?
-             (mode_replace ? "json_set" : "json_insert") : "json_update";
+             (mode_replace ? "json_set" : "json_insert") : "json_replace";
   }
   Item *get_copy(THD *thd)
   { return get_item_copy<Item_func_json_insert>(thd, this); }

--- a/storage/spider/mysql-test/spider/bugfix/include/mdev_24523_deinit.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/mdev_24523_deinit.inc
@@ -1,0 +1,11 @@
+--let $MASTER_1_COMMENT_P_2_1= $MASTER_1_COMMENT_P_2_1_BACKUP
+--let $CHILD2_1_DROP_TABLES= $CHILD2_1_DROP_TABLES_BACKUP
+--let $CHILD2_1_CREATE_TABLES= $CHILD2_1_CREATE_TABLES_BACKUP
+--let $CHILD2_1_SELECT_TABLES= $CHILD2_1_SELECT_TABLES_BACKUP
+--disable_warnings
+--disable_query_log
+--disable_result_log
+--source ../t/test_deinit.inc
+--enable_result_log
+--enable_query_log
+--enable_warnings

--- a/storage/spider/mysql-test/spider/bugfix/include/mdev_24523_init.inc
+++ b/storage/spider/mysql-test/spider/bugfix/include/mdev_24523_init.inc
@@ -1,0 +1,43 @@
+--disable_warnings
+--disable_query_log
+--disable_result_log
+--source ../t/test_init.inc
+--enable_result_log
+--enable_query_log
+--enable_warnings
+--let $MASTER_1_COMMENT_P_2_1_BACKUP= $MASTER_1_COMMENT_P_2_1
+let $MASTER_1_COMMENT_P_2_1=
+  PARTITION BY RANGE(i) (
+    PARTITION pt1 VALUES LESS THAN (5) COMMENT='srv "s_2_1", table "ta_r2"',
+    PARTITION pt2 VALUES LESS THAN (10) COMMENT='srv "s_2_1", table "ta_r3"',
+    PARTITION pt3 VALUES LESS THAN MAXVALUE COMMENT='srv "s_2_1", table "ta_r4"'
+  );
+--let $CHILD2_1_DROP_TABLES_BACKUP= $CHILD2_1_DROP_TABLES
+let $CHILD2_1_DROP_TABLES=
+  DROP TABLE IF EXISTS ta_r2 $STR_SEMICOLON
+  DROP TABLE IF EXISTS ta_r3 $STR_SEMICOLON
+  DROP TABLE IF EXISTS ta_r4;
+--let $CHILD2_1_CREATE_TABLES_BACKUP= $CHILD2_1_CREATE_TABLES
+let $CHILD2_1_CREATE_TABLES=
+  CREATE TABLE ta_r2 (
+    i INT,
+    j JSON,
+    PRIMARY KEY(i)
+  ) $CHILD2_1_ENGINE $CHILD2_1_CHARSET $STR_SEMICOLON
+  CREATE TABLE ta_r3 (
+    i INT,
+    j JSON,
+    PRIMARY KEY(i)
+  ) $CHILD2_1_ENGINE $CHILD2_1_CHARSET $STR_SEMICOLON
+  CREATE TABLE ta_r4 (
+    i INT,
+    j JSON,
+    PRIMARY KEY(i)
+  ) $CHILD2_1_ENGINE $CHILD2_1_CHARSET;
+--let $CHILD2_1_SELECT_TABLES_BACKUP= $CHILD2_1_SELECT_TABLES
+let $CHILD2_1_SELECT_TABLES=
+  SELECT i, j FROM ta_r2 ORDER BY i $STR_SEMICOLON
+  SELECT i, j FROM ta_r3 ORDER BY i $STR_SEMICOLON
+  SELECT i, j FROM ta_r4 ORDER BY i;
+let $CHILD2_1_SELECT_ARGUMENT1=
+  SELECT argument FROM mysql.general_log WHERE argument LIKE '%select %';

--- a/storage/spider/mysql-test/spider/bugfix/r/mdev_24523.result
+++ b/storage/spider/mysql-test/spider/bugfix/r/mdev_24523.result
@@ -1,0 +1,64 @@
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+
+this test is for MDEV-24523
+
+drop and create databases
+connection master_1;
+CREATE DATABASE auto_test_local;
+USE auto_test_local;
+connection child2_1;
+SET @old_log_output = @@global.log_output;
+SET GLOBAL log_output = 'TABLE,FILE';
+CREATE DATABASE auto_test_remote;
+USE auto_test_remote;
+
+create table and insert
+connection child2_1;
+CHILD2_1_CREATE_TABLES
+TRUNCATE TABLE mysql.general_log;
+connection master_1;
+CREATE TABLE tbl_a (
+i INT,
+j JSON,
+PRIMARY KEY(i)
+) ENGINE=Spider PARTITION BY RANGE(i) (
+PARTITION pt1 VALUES LESS THAN (5) COMMENT='srv "s_2_1", table "ta_r2"',
+PARTITION pt2 VALUES LESS THAN (10) COMMENT='srv "s_2_1", table "ta_r3"',
+PARTITION pt3 VALUES LESS THAN MAXVALUE COMMENT='srv "s_2_1", table "ta_r4"'
+  )
+INSERT INTO tbl_a VALUES (1, '{ "a": 1, "b": [2, 3]}');
+
+test 1
+connection child2_1;
+TRUNCATE TABLE mysql.general_log;
+connection master_1;
+UPDATE tbl_a SET j = JSON_REPLACE(j, '$.a', 10, '$.c', '[1, 2]');
+SELECT * FROM tbl_a;
+i	j
+1	{"a": 10, "b": [2, 3]}
+TRUNCATE TABLE tbl_a;
+INSERT INTO tbl_a VALUES (1, '{ "a": 1, "b": [2, 3]}');
+UPDATE tbl_a SET j = JSON_REPLACE(j, '$.a', 10, '$.b', '[1, 2]');
+SELECT * FROM tbl_a;
+i	j
+1	{"a": 10, "b": "[1, 2]"}
+
+deinit
+connection master_1;
+DROP DATABASE IF EXISTS auto_test_local;
+connection child2_1;
+DROP DATABASE IF EXISTS auto_test_remote;
+SET GLOBAL log_output = @old_log_output;
+for master_1
+for child2
+child2_1
+child2_2
+child2_3
+for child3
+
+end of test

--- a/storage/spider/mysql-test/spider/bugfix/t/mdev_24523.cnf
+++ b/storage/spider/mysql-test/spider/bugfix/t/mdev_24523.cnf
@@ -1,0 +1,3 @@
+!include include/default_mysqld.cnf
+!include ../my_1_1.cnf
+!include ../my_2_1.cnf

--- a/storage/spider/mysql-test/spider/bugfix/t/mdev_24523.test
+++ b/storage/spider/mysql-test/spider/bugfix/t/mdev_24523.test
@@ -1,0 +1,71 @@
+--source ../include/mdev_24523_init.inc
+--echo
+--echo this test is for MDEV-24523
+--echo
+--echo drop and create databases
+
+--connection master_1
+--disable_warnings
+CREATE DATABASE auto_test_local;
+USE auto_test_local;
+
+--connection child2_1
+SET @old_log_output = @@global.log_output;
+SET GLOBAL log_output = 'TABLE,FILE';
+CREATE DATABASE auto_test_remote;
+USE auto_test_remote;
+--enable_warnings
+
+--echo
+--echo create table and insert
+
+--connection child2_1
+--disable_query_log
+echo CHILD2_1_CREATE_TABLES;
+eval $CHILD2_1_CREATE_TABLES;
+--enable_query_log
+TRUNCATE TABLE mysql.general_log;
+
+--connection master_1
+--disable_query_log
+echo CREATE TABLE tbl_a (
+  i INT,
+  j JSON,
+  PRIMARY KEY(i)
+) $MASTER_1_ENGINE $MASTER_1_COMMENT_P_2_1;
+eval CREATE TABLE tbl_a (
+  i INT,
+  j JSON,
+  PRIMARY KEY(i)
+) $MASTER_1_ENGINE $MASTER_1_COMMENT_P_2_1;
+--enable_query_log
+INSERT INTO tbl_a VALUES (1, '{ "a": 1, "b": [2, 3]}');
+
+--echo
+--echo test 1
+
+--connection child2_1
+TRUNCATE TABLE mysql.general_log;
+
+--connection master_1
+UPDATE tbl_a SET j = JSON_REPLACE(j, '$.a', 10, '$.c', '[1, 2]');
+SELECT * FROM tbl_a;
+TRUNCATE TABLE tbl_a;
+INSERT INTO tbl_a VALUES (1, '{ "a": 1, "b": [2, 3]}');
+UPDATE tbl_a SET j = JSON_REPLACE(j, '$.a', 10, '$.b', '[1, 2]');
+SELECT * FROM tbl_a;
+--echo
+--echo deinit
+--disable_warnings
+
+--connection master_1
+DROP DATABASE IF EXISTS auto_test_local;
+
+--connection child2_1
+DROP DATABASE IF EXISTS auto_test_remote;
+SET GLOBAL log_output = @old_log_output;
+
+--enable_warnings
+--source ../include/mdev_24523_deinit.inc
+--echo
+--echo end of test


### PR DESCRIPTION
how to repeat:
```sql
CREATE TABLE tbl_a (
i INT,
j JSON,
PRIMARY KEY(i)
) ENGINE=SPIDER, PARTITION BY ...;

INSERT INTO tbl_a VALUES (1, '{ "a": 1, "b": [2, 3]}');
UPDATE tbl_a SET j = JSON_REPLACE(j, '$.a', 10, '$.c', '[1, 2]'); -- query failed
```

I think it is a typo of `Item_func_json_replace::func_name`.