### PR TITLE
Fix MTR test galera_as_slave_replay

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_replay.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_replay.result
@@ -1,10 +1,13 @@
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2a;
+connection node_2;
 connection node_1;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_3;
 RESET MASTER;
 connection node_2a;
 START SLAVE;
-connection node_1;
+connection node_3;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1)) engine=innodb;
 INSERT INTO t1 VALUES (1, 'a');
 INSERT INTO t1 VALUES (3, 'a');
@@ -18,15 +21,14 @@ f1	f2
 UPDATE t1 SET f2 = 'c' WHERE f1 > 1;
 connection node_2a;
 SET SESSION wsrep_sync_wait = 0;
-connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
-connection node_3;
+connection node_1;
 SET SESSION wsrep_sync_wait = 0;
 connection node_2a;
-SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
 SET GLOBAL debug_dbug = "d,sync.wsrep_apply_cb";
-connection node_3;
-INSERT INTO test.t1 VALUES (2, 'b');
 connection node_1;
+INSERT INTO test.t1 VALUES (2, 'b');
+connection node_3;
 COMMIT;
 connection node_2a;
 SET SESSION wsrep_on = 0;
@@ -35,8 +37,8 @@ SET GLOBAL debug_dbug = "";
 SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 connection node_2a;
 SET GLOBAL wsrep_provider_options = 'dbug=';
-SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_enter_sync';
-connection node_1;
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
+connection node_3;
 SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'a';
 COUNT(*) = 1
 1
@@ -61,7 +63,7 @@ SET DEBUG_SYNC = "RESET";
 #
 # test phase with real abort
 #
-connection node_1;
+connection node_3;
 set binlog_format=ROW;
 insert into t1 values (4, 'd');
 SET AUTOCOMMIT=ON;
@@ -70,9 +72,9 @@ UPDATE t1 SET f2 = 'd' WHERE f1 = 3;
 connection node_2a;
 SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_enter_sync';
 SET GLOBAL debug_dbug = "d,sync.wsrep_apply_cb";
-connection node_3;
-UPDATE test.t1 SET f2 = 'e' WHERE f1 = 3;
 connection node_1;
+UPDATE test.t1 SET f2 = 'e' WHERE f1 = 3;
+connection node_3;
 COMMIT;
 connection node_2a;
 SET GLOBAL debug_dbug = "";
@@ -90,6 +92,6 @@ set session wsrep_sync_wait=0;
 STOP SLAVE;
 RESET SLAVE;
 DROP TABLE t1;
-connection node_1;
+connection node_3;
 DROP TABLE t1;
 RESET MASTER;

--- a/mysql-test/suite/galera/t/galera_as_slave_replay.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_replay.test
@@ -18,9 +18,10 @@
 #--source suite/galera/include/galera_have_debug_sync.inc
 
 #
-# node 1 is native MariaDB server operating as async replication master
+# node 3 is native MariaDB server operating as async replication master
 #
---connection node_1
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connection node_3
 RESET MASTER;
 
 --connection node_2a
@@ -31,14 +32,14 @@ RESET MASTER;
 
 
 #
-# nodes 2 and 3 form a galera cluster, node 2 operates as slave for native MariaDB naster in node 1
+# nodes 1 and 2 form a galera cluster, node 2 operates as slave for native MariaDB naster in node 3
 #
 --disable_query_log
---eval CHANGE MASTER TO  MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_PORT=$NODE_MYPORT_1;
+--eval CHANGE MASTER TO  MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_PORT=$NODE_MYPORT_3;
 --enable_query_log
 START SLAVE;
 
---connection node_1
+--connection node_3
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 CHAR(1)) engine=innodb;
 INSERT INTO t1 VALUES (1, 'a');
 INSERT INTO t1 VALUES (3, 'a');
@@ -63,15 +64,14 @@ SET SESSION wsrep_sync_wait = 0;
 --source include/wait_condition.inc
 
 # wait for create table and inserts to be replicated in cluster
---connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
---connection node_3
+--connection node_1
 SET SESSION wsrep_sync_wait = 0;
 --let $wait_condition = SELECT COUNT(*) = 2 FROM test.t1;
 --source include/wait_condition.inc
 
 --connection node_2a
 # Block the future commit of async replication
---let $galera_sync_point = commit_monitor_enter_sync
+--let $galera_sync_point = commit_monitor_master_enter_sync
 --source include/galera_set_sync_point.inc
 
 # block also the applier before applying begins
@@ -81,13 +81,13 @@ SET GLOBAL debug_dbug = "d,sync.wsrep_apply_cb";
 # now inject a conflicting insert from node 3, it will replicate with
 # earlier seqno (than async transaction) and pause before applying in node 2
 #
---connection node_3
+--connection node_1
 INSERT INTO test.t1 VALUES (2, 'b');
 
 #
 # send the update from master, this will succeed here, beceuase of async replication.
 # async replication will apply this in node 2 and pause before commit phase,
---connection node_1
+--connection node_3
 --error 0
 COMMIT;
 
@@ -108,7 +108,7 @@ SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
 --source include/galera_clear_sync_point.inc
 --source include/galera_signal_sync_point.inc
 
---connection node_1
+--connection node_3
 
 SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'a';
 SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'c';
@@ -139,7 +139,7 @@ SET DEBUG_SYNC = "RESET";
 --echo # test phase with real abort
 --echo #
 
---connection node_1
+--connection node_3
 
 set binlog_format=ROW;
 
@@ -163,11 +163,11 @@ UPDATE t1 SET f2 = 'd' WHERE f1 = 3;
 SET GLOBAL debug_dbug = "d,sync.wsrep_apply_cb";
 
 # Inject a conflicting update from node 3
---connection node_3
+--connection node_1
 UPDATE test.t1 SET f2 = 'e' WHERE f1 = 3;
 
 # send the update from master
---connection node_1
+--connection node_3
 --error 0
 COMMIT;
 
@@ -195,6 +195,6 @@ RESET SLAVE;
 
 DROP TABLE t1;
 
---connection node_1
+--connection node_3
 DROP TABLE t1;
 RESET MASTER;


### PR DESCRIPTION
- Galera cluster must be in node 1 and 2, and acts as slave for node 3
- Sync point commit_monitor_enter_sync was renamed to
  commit_monitor_master_enter_sync in 4.x