### PR TITLE
MDEV-24721 galera.mysql-wsrep-bugs-607 test failure

### DIFF
--- a/sql/wsrep_binlog.cc
+++ b/sql/wsrep_binlog.cc
@@ -381,9 +381,7 @@ void wsrep_register_for_group_commit(THD *thd)
 
 void wsrep_unregister_from_group_commit(THD *thd)
 {
-  DBUG_ASSERT(thd->wsrep_trx().state() == wsrep::transaction::s_ordered_commit||
-              // ordered_commit() failure results in s_aborting state
-              thd->wsrep_trx().state() == wsrep::transaction::s_aborting);
+  DBUG_ASSERT(thd->wsrep_trx().ordered());
   wait_for_commit *wfc= thd->wait_for_commit_ptr;
 
   if (wfc)


### PR DESCRIPTION
The implementation for MDEV-17048 apperas to be direct copy from mysql version.
The group commit works differently in mariadb and the assert in wsrep_unregister_from_group_commit() is too strict.

The reason is that in: Wsrep_high_priority_service::log_dummy_write_set(), the transaction will undergo full rollback:
    {
      cs.before_rollback();
      cs.after_rollback();
    }

After that, the client's transaction state is set to be:  wsrep::transaction::s_aborted.
The execution then continues execution by:

...
 wsrep_register_for_group_commit(m_thd);
...
 wsrep_unregister_from_group_commit(m_thd);

The bogus assert in wsrep_unregister_from_group_commit() allows only transactions states of :s_ordered_commit or s_aborting.

As the fix, I brought back the same assert as is present in MariaDB 10.4 version.