### PR TITLE
MDEV-25264: Include extended metadata in Query_cache_query_flags

### DIFF
--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -1417,6 +1417,8 @@ void Query_cache::store_query(THD *thd, TABLE_LIST *tables_used)
                                       CLIENT_PROTOCOL_41);
     flags.client_depr_eof= MY_TEST(thd->client_capabilities &
                                       CLIENT_DEPRECATE_EOF);
+    flags.client_extended_metadata= MY_TEST(thd->client_capabilities &
+                                      MARIADB_CLIENT_EXTENDED_METADATA);
     /*
       Protocol influences result format, so statement results in the binary
       protocol (COM_EXECUTE) cannot be served to statements asking for results
@@ -1447,13 +1449,14 @@ void Query_cache::store_query(THD *thd, TABLE_LIST *tables_used)
     flags.div_precision_increment= thd->variables.div_precincrement;
     flags.default_week_format= thd->variables.default_week_format;
     DBUG_PRINT("qcache", ("\
-long %d, 4.1: %d, eof: %d, bin_proto: %d, more results %d, pkt_nr: %d, \
+long %d, 4.1: %d, eof: %d, extended: %d, bin_proto: %d, more results %d, pkt_nr: %d, \
 CS client: %u, CS result: %u, CS conn: %u, limit: %llu, TZ: %p, \
 sql mode: 0x%llx, sort len: %llu, concat len: %u, div_precision: %zu, \
 def_week_frmt: %zu, in_trans: %d, autocommit: %d",
                           (int)flags.client_long_flag,
                           (int)flags.client_protocol_41,
                           (int)flags.client_depr_eof,
+                          (int)flags.client_extended_metadata,
                           (int)flags.protocol_type,
                           (int)flags.more_results_exists,
                           flags.pkt_nr,
@@ -1926,6 +1929,8 @@ Query_cache::send_result_to_client(THD *thd, char *org_sql, uint query_length)
                                     CLIENT_PROTOCOL_41);
   flags.client_depr_eof= MY_TEST(thd->client_capabilities &
                                     CLIENT_DEPRECATE_EOF);
+  flags.client_extended_metadata= MY_TEST(thd->client_capabilities &
+                                    MARIADB_CLIENT_EXTENDED_METADATA);
   flags.protocol_type= (unsigned int) thd->protocol->type();
   flags.more_results_exists= MY_TEST(thd->server_status &
                                      SERVER_MORE_RESULTS_EXISTS);
@@ -1947,13 +1952,14 @@ Query_cache::send_result_to_client(THD *thd, char *org_sql, uint query_length)
   flags.default_week_format= thd->variables.default_week_format;
   flags.lc_time_names= thd->variables.lc_time_names;
   DBUG_PRINT("qcache", ("\
-long %d, 4.1: %d, eof: %d, bin_proto: %d, more results %d, pkt_nr: %d, \
+long %d, 4.1: %d, eof: %d, extended: %d, bin_proto: %d, more results %d, pkt_nr: %d, \
 CS client: %u, CS result: %u, CS conn: %u, limit: %llu, TZ: %p, \
 sql mode: 0x%llx, sort len: %llu, concat len: %u, div_precision: %zu, \
 def_week_frmt: %zu, in_trans: %d, autocommit: %d",
                           (int)flags.client_long_flag,
                           (int)flags.client_protocol_41,
                           (int)flags.client_depr_eof,
+                          (int)flags.client_extended_metadata,
                           (int)flags.protocol_type,
                           (int)flags.more_results_exists,
                           flags.pkt_nr,

--- a/sql/sql_cache.h
+++ b/sql/sql_cache.h
@@ -550,6 +550,7 @@ struct Query_cache_query_flags
   unsigned int client_long_flag:1;
   unsigned int client_protocol_41:1;
   unsigned int client_depr_eof:1;
+  unsigned int client_extended_metadata:1;
   unsigned int protocol_type:2;
   unsigned int more_results_exists:1;
   unsigned int in_trans:1;


### PR DESCRIPTION
Extended metadata affects the column definition packet. If clients differ in their support, some will be sent malformed packets.