### PR TITLE
MDEV-24858 SIGABRT in DbugExit from my_malloc in Query_cache::init_cache Regression

### DIFF
--- a/mysql-test/main/query_cache.result
+++ b/mysql-test/main/query_cache.result
@@ -2207,6 +2207,12 @@ Variable_name	Value
 Qcache_queries_in_cache	0
 DROP FUNCTION foo;
 drop table t1;
+#
+# MDEV-24858 SIGABRT in DbugExit from my_malloc in Query_cache::init_cache Regression
+#
+set global Query_cache_size=18446744073709547520;
+Warnings:
+Warning	1282	Query cache failed to set size 18446744073709547520; new query cache size is 0
 restore defaults
 SET GLOBAL query_cache_type= default;
 SET GLOBAL query_cache_size=@save_query_cache_size;

--- a/mysql-test/main/query_cache.test
+++ b/mysql-test/main/query_cache.test
@@ -1800,6 +1800,11 @@ show status like "Qcache_queries_in_cache";
 DROP FUNCTION foo;
 drop table t1;
 
+--echo #
+--echo # MDEV-24858 SIGABRT in DbugExit from my_malloc in Query_cache::init_cache Regression
+--echo #
+set global Query_cache_size=18446744073709547520;
+
 --echo restore defaults
 SET GLOBAL query_cache_type= default;
 SET GLOBAL query_cache_size=@save_query_cache_size;

--- a/mysys/my_malloc.c
+++ b/mysys/my_malloc.c
@@ -79,7 +79,7 @@ void *my_malloc(PSI_memory_key key, size_t size, myf my_flags)
   if (!size)
     size=1;
   if (size > SIZE_T_MAX - 1024L*1024L*16L)           /* Wrong call */
-    return 0;
+    DBUG_RETURN(0);
 
   /* We have to align size as we store MY_THREAD_SPECIFIC flag in the LSB */
   size= ALIGN_SIZE(size);


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-24858

The cause of the bug is just a missing DBUG_RETURN, as pointed out in the stack trace. I added a missing DBUG_RETURN to my_malloc.
```
#6  0x0000563552410a79 in DbugExit (why=why@entry=0x1469308ef920 "missing DBUG_RETURN or DBUG_VOID_RETURN macro in function \"my_malloc\"\n") at /test/10.6_dbg/dbug/dbug.c:2043
```
The bug is introduced by  https://github.com/MariaDB/server/commit/eacefbca3596fa9cb853272265855d4efafd5f24.