### PR TITLE
MDEV-24453 mysql_upgrade honor --verbose parameter

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -591,7 +591,7 @@ static int run_query(const char *query, DYNAMIC_STRING *ds_res,
                 defaults_file,
                 "--database=mysql",
                 "--batch", /* Turns off pager etc. */
-                opt_verbose >= 4 ? "--verbose" : "",
+                opt_verbose >= 5 ? "--verbose" : "",
                 force ? "--force": "--skip-force",
                 ds_res || opt_silent ? "--silent": "",
                 "<",

--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -591,6 +591,7 @@ static int run_query(const char *query, DYNAMIC_STRING *ds_res,
                 defaults_file,
                 "--database=mysql",
                 "--batch", /* Turns off pager etc. */
+                opt_verbose >= 4 ? "--verbose" : "",
                 force ? "--force": "--skip-force",
                 ds_res || opt_silent ? "--silent": "",
                 "<",

--- a/man/mysql_upgrade.1
+++ b/man/mysql_upgrade.1
@@ -641,7 +641,7 @@ The MariaDB user name to use when connecting to the server and not using the cur
 Display more output about the process\&. Using it twice will print connection 
 arguments; using it 3 times will print out all CHECK, RENAME and ALTER TABLE 
 commands used during the check phase; using it 4 times (added in MariaDB 10.0.14)
-will also write out all mysqlcheck commands used\&.
+will also write out all mysqlcheck commands used. Added support for 4x verbose\&.
 .RE
 .sp
 .RS 4

--- a/man/mysql_upgrade.1
+++ b/man/mysql_upgrade.1
@@ -641,7 +641,8 @@ The MariaDB user name to use when connecting to the server and not using the cur
 Display more output about the process\&. Using it twice will print connection 
 arguments; using it 3 times will print out all CHECK, RENAME and ALTER TABLE 
 commands used during the check phase; using it 4 times (added in MariaDB 10.0.14)
-will also write out all mysqlcheck commands used. Added support for 4x verbose\&.
+will also write out all mysqlcheck commands used; using it 5 times will log the binary 
+logging for the current session\&.
 .RE
 .sp
 .RS 4


### PR DESCRIPTION
- Add support for `mysql_upgrade` to honor `--verbose` parameter
- Fixes [MDEV-24453](https://jira.mariadb.org/browse/MDEV-24453)