### PR TITLE
MDEV-24963: Document `flush-ssl` in the mysqladmin manpage.

### DIFF
--- a/man/mysqladmin.1
+++ b/man/mysqladmin.1
@@ -276,6 +276,19 @@ Flush slow query log\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+flush\-ssl
+.sp
+Flush SSL certificates\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 flush\-status
 .sp
 Clear status variables\&.


### PR DESCRIPTION
Relates to #1749 

Closes [MDEV-24963](https://jira.mariadb.org/browse/MDEV-24963)