### PR TITLE
Delete duplicated #include "sql_parse.h"

### DIFF
--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -49,7 +49,6 @@
 #include "sp_head.h"
 #include "sp.h"
 #include "sql_trigger.h"
-#include "sql_parse.h"
 #include "sql_show.h"
 #include "transaction.h"
 #include "sql_audit.h"


### PR DESCRIPTION
Hello. I just found that a header file "sql_parse.h" is included twice in "sql_table.cc".
I think that's a sort of typo, but to be honest I'm not so used to handle source code written in c++, I can't assure.
Would anyone check this one? thank you.