### PR TITLE
MDEV-24868 Server crashes in optimize_schema_tables_memory_usage after select from information_schema.innodb_sys_columns

### DIFF
--- a/mysql-test/main/information_schema.result
+++ b/mysql-test/main/information_schema.result
@@ -2316,5 +2316,12 @@ count(*)
 2
 DROP TABLE t1;
 #
+# MDEV-24868 Server crashes in optimize_schema_tables_memory_usage after select from information_schema.innodb_sys_columns
+#
+create table t1 ( name varchar(64) character set utf8, len int);
+select * from t1 where (name, len) in (select  name, len from information_schema.innodb_sys_columns having len = 8);
+name	len
+drop table t1;
+#
 # End of 10.3 tests
 #

--- a/mysql-test/main/information_schema.test
+++ b/mysql-test/main/information_schema.test
@@ -2044,6 +2044,14 @@ INSERT INTO t1 VALUES ('2012-12-12'),('2021-11-11');
 SELECT count(*) FROM t1 AS t1a LEFT JOIN (t1 AS t1b JOIN INFORMATION_SCHEMA.ROUTINES) ON (t1b.a IS NULL);
 SELECT count(*) FROM t1 AS t1a LEFT JOIN (t1 AS t1b JOIN INFORMATION_SCHEMA.PROFILING) ON (t1b.a IS NULL);
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-24868 Server crashes in optimize_schema_tables_memory_usage after select from information_schema.innodb_sys_columns
+--echo #
+create table t1 ( name varchar(64) character set utf8, len int);
+select * from t1 where (name, len) in (select  name, len from information_schema.innodb_sys_columns having len = 8);
+drop table t1;
+
 --echo #
 --echo # End of 10.3 tests
 --echo #

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -8672,14 +8672,19 @@ end:
 
 bool optimize_schema_tables_memory_usage(List<TABLE_LIST> &tables)
 {
+  DBUG_ENTER("optimize_schema_tables_memory_usage");
+
   List_iterator<TABLE_LIST> tli(tables);
 
   while (TABLE_LIST *table_list= tli++)
   {
+    if (!table_list->schema_table)
+      continue;
+
     TABLE *table= table_list->table;
     THD *thd=table->in_use;
 
-    if (!table_list->schema_table || !thd->fill_information_schema_tables())
+    if (!thd->fill_information_schema_tables())
       continue;
 
     if (!table->is_created())
@@ -8726,10 +8731,10 @@ bool optimize_schema_tables_memory_usage(List<TABLE_LIST> &tables)
       // TODO switch from Aria to Memory if all blobs were optimized away?
       if (instantiate_tmp_table(table, p->keyinfo, p->start_recinfo, &p->recinfo,
                    table_list->select_lex->options | thd->variables.option_bits))
-        return 1;
+        DBUG_RETURN(1);
     }
   }
-  return 0;
+  DBUG_RETURN(0);
 }
 
 


### PR DESCRIPTION
`optimize_schema_tables_memory_usage()` crashed when its argument included `TABLE` struct that was not fully initialized (see the below example).

To prevent such a crash, we check if a table is an information schema table at the beginning of each iteration. 

```
#
# gdb debug on PR branch executing `select * from t1 where (name, len) in (select  name, len from information_schema.innodb_sys_columns having len = 8);`
#
...
(gdb) b sql/sql_show.cc:8680
Breakpoint 1 at 0x7ba9ae: file /home/vagrant/server/sql/sql_show.cc, line 8681.
(gdb) run
...
Thread 28 "mysqld" hit Breakpoint 1, optimize_schema_tables_memory_usage (tables=...) at /home/vagrant/server/sql/sql_show.cc:8681
8681        if (!table_list->schema_table)
(gdb) p table_list
$1 = (TABLE_LIST *) 0x7fffa4014fc8
(gdb) p table_list->table_name
$2 = {str = 0x7fffa4014f90 "t1", length = 2}
(gdb) c
Continuing.

Thread 28 "mysqld" hit Breakpoint 1, optimize_schema_tables_memory_usage (tables=...) at /home/vagrant/server/sql/sql_show.cc:8681
8681        if (!table_list->schema_table)
#
# NOTE: mysqld fails on this table if the binary is generated from 10.3
#
(gdb) p table_list
$3 = (TABLE_LIST *) 0x7fffa40196a8
(gdb) p table_list->table_name
$4 = {str = 0x0, length = 0}
(gdb) p *table_list
$5 = {next_local = 0x0, next_global = 0x0, prev_global = 0x0, db = {str = 0x0, length = 0}, table_name = {str = 0x0, length = 0}, schema_table_name = {str = 0x0,
    length = 0}, alias = {str = 0x7fffa4019690 "<subquery2>", length = 11}, option = 0x0, on_expr = 0x0, on_context = 0x0, sj_on_expr = 0x0, sj_inner_tables = 0,
  sj_in_exprs = 0, sj_subq_pred = 0x0, original_subq_pred_used_tables = 0, jtbm_subselect = 0x7fffa4017158, jtbm_table_no = 1, sj_mat_info = 0x0,
  prep_on_expr = 0x0, cond_equal = 0x0, natural_join = 0x0, is_natural_join = false, join_using_fields = 0x0, join_columns = 0x0, is_join_columns_complete = false,
  next_name_resolution_table = 0x0, index_hints = 0x0, table = 0x0, table_id = 0, derived_result = 0x0, map = 0, correspondent_table = 0x0, derived = 0x0,
  with = 0x0, with_internal_reference_map = 0, next_with_rec_ref = 0x0, is_derived_with_recursive_reference = false, block_handle_derived = false,
  schema_table = 0x0, schema_select_lex = 0x0, schema_table_reformed = false, schema_table_param = 0x0, select_lex = 0x0, view = 0x0, field_translation = 0x0,
  field_translation_end = 0x0, field_translation_updated = false, merge_underlying_list = 0x0, view_tables = 0x0, belong_to_view = 0x0, belong_to_derived = 0x0,
  referencing_view = 0x0, view_used_tables = 0, map_exec = 0, tablenr_exec = 0, maybe_null_exec = 0, parent_l = 0x0, security_ctx = 0x0, view_sctx = 0x0,
  allowed_show = false, where = 0x0, check_option = 0x0, select_stmt = {str = 0x0, length = 0}, md5 = {str = 0x0, length = 0}, source = {str = 0x0, length = 0},
  view_db = {str = 0x0, length = 0}, view_name = {str = 0x0, length = 0}, timestamp = {str = 0x0, length = 0}, definer = {<AUTHID> = {user = {str = 0x0,
        length = 0}, host = {str = 0x0, length = 0}}, plugin = {str = 0x0, length = 0}, auth = {str = 0x0, length = 0}, pwtext = {str = 0x0, length = 0}, pwhash = {
      str = 0x0, length = 0}}, file_version = 0, mariadb_version = 0, updatable_view = 0, algorithm = 0, view_suid = 0, with_check = 0,
  effective_with_check = 0 '\000', derived_type = 0 '\000', grant = {grant_table_user = 0x0, grant_table_role = 0x0, version = 0, privilege = 0, want_privilege = 0,
    orig_want_privilege = 0, m_internal = {m_schema_lookup_done = false, m_schema_access = 0x0, m_table_lookup_done = false, m_table_access = 0x0}},
  engine_data = 0, callback_func = 0x0, lock_type = TL_UNLOCK, outer_join = 0, shared = 0, updatable = false, straight = false, updating = false,
  force_index = false, ignore_leaves = false, crashed = false, dep_tables = 0, on_expr_dep_tables = 0, nested_join = 0x0, embedding = 0x0,
  join_list = 0x7fffa4005580, lifted = false, cacheable_table = false, table_in_first_from_clause = false, open_type = OT_TEMPORARY_OR_BASE,
  contain_auto_increment = false, compact_view_format = false, where_processed = false, check_option_processed = false, required_type = TABLE_TYPE_UNKNOWN,
  db_type = 0x0, timestamp_buffer = '\000' <repeats 19 times>, prelocking_placeholder = TABLE_LIST::PRELOCK_NONE, open_strategy = TABLE_LIST::OPEN_NORMAL,
  is_alias = false, is_fqtn = false, fill_me = false, merged = false, merged_for_insert = false, sequence = false,
  used_items = {<base_list> = {<Sql_alloc> = {<No data fields>}, first = 0x0, last = 0x0, elements = 0}, <No data fields>},
  persistent_used_items = {<base_list> = {<Sql_alloc> = {<No data fields>}, first = 0x0, last = 0x0, elements = 0}, <No data fields>}, view_creation_ctx = 0x0,
  view_client_cs_name = {str = 0x0, length = 0}, view_connection_cl_name = {str = 0x0, length = 0}, view_body_utf8 = {str = 0x0, length = 0},
  trg_event_map = 0 '\000', slave_fk_event_map = 0 '\000', optimized_away = false, materialized = false, i_s_requested_object = 0, prohibit_cond_pushdown = false,
  table_open_method = 0, schema_table_state = NOT_PROCESSED, is_table_read_plan = 0x0, mdl_request = {type = MDL_INTENTION_EXCLUSIVE, duration = MDL_STATEMENT,
    next_in_list = 0x0, prev_in_list = 0x0, ticket = 0x0, key = {m_length = 0, m_db_name_length = 0, m_hash_value = 0, m_ptr = '\000' <repeats 386 times>,
      static m_namespace_to_wait_state_name = {{m_key = 138, m_name = 0x55555690eb99 "Waiting for global read lock", m_flags = 0}, {m_key = 139,
          m_name = 0x55555690ebb8 "Waiting for schema metadata lock", m_flags = 0}, {m_key = 140, m_name = 0x55555690ebe0 "Waiting for table metadata lock",
          m_flags = 0}, {m_key = 141, m_name = 0x55555690ec00 "Waiting for stored function metadata lock", m_flags = 0}, {m_key = 142,
          m_name = 0x55555690ec30 "Waiting for stored procedure metadata lock", m_flags = 0}, {m_key = 143,
          m_name = 0x55555690ec60 "Waiting for stored package body metadata lock", m_flags = 0}, {m_key = 144,
          m_name = 0x55555690ec90 "Waiting for trigger metadata lock", m_flags = 0}, {m_key = 145, m_name = 0x55555690ecb8 "Waiting for event metadata lock",
          m_flags = 0}, {m_key = 146, m_name = 0x55555690ecd8 "Waiting for commit lock", m_flags = 0}, {m_key = 101, m_name = 0x55555690ecf0 "User lock",
          m_flags = 0}}}}, partition_names = 0x0, vers_conditions = {type = SYSTEM_TIME_UNSPECIFIED, orig_type = SYSTEM_TIME_UNSPECIFIED, used = false,
    delete_history = false, start = {<vers_history_point_t> = {unit = VERS_UNDEFINED, item = 0x0}, <No data fields>}, end = {<vers_history_point_t> = {
        unit = VERS_UNDEFINED, item = 0x0}, <No data fields>}}, for_insert_data = 0 '\000', m_table_ref_type = TABLE_REF_NULL, m_table_ref_version = 0}
(gdb) c
Continuing.

Thread 28 "mysqld" hit Breakpoint 1, optimize_schema_tables_memory_usage (tables=...) at /home/vagrant/server/sql/sql_show.cc:8681
8681        if (!table_list->schema_table)
(gdb) p table_list
$6 = (TABLE_LIST *) 0x7fffa40167e8
(gdb) p table_list->table_name
$7 = {str = 0x7fffa4016790 "innodb_sys_columns", length = 18}
```