### PR TITLE
Add Pull Request template file to the MariaDB/server repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+<!--
+Thank you for contributing to the MariaDB Server repository!
+
+You can help us review your changes faster by filling this template <3
+
+If you have any questions related to MariaDB or you just want to
+hang out and meet other community members, please join us on
+https://mariadb.zulipchat.com/ .
+-->
+
+<!--
+If you've already identified a https://jira.mariadb.org/ issue
+that seems to track this bug/feature, please add its number below.
+-->
+- [x] *The Jira issue number for this PR is: MDEV-_____*
+
+<!--
+An amazing description should answer some questions like:
+1. What problem is the patch trying to solve?
+2. If some output changed, what was it looking like before
+   the change and how it's looking with this patch applied
+3. Do you think this patch might introduce side-effects in
+   other parts of the server?
+-->
+## Description
+TODO: fill description here
+
+## How can this PR be tested?
+TODO: fill steps to reproduce here, if applicable,
+      or remove the section
+
+<!--
+Tick one of the following boxes [x] to help us understand
+if the base branch for the PR is correct
+-->
+## Basing the PR against the correct MariaDB version
+- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
+- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
+
+<!--
+You might consider answering some questions like:
+1. Does this affect the on-disk format used by MariaDB?
+2. Does this change any behavior experienced by a user
+   who upgrades from a version prior to this patch?
+3. Would a user be able to start MariaDB on a datadir
+   created prior to your fix?
+-->
+## Backward compatibility
+TODO: fill details here, if applicable, or remove the section
+


### PR DESCRIPTION
I would love for this to be a starting point for a discussion on whether or not we should add a PR template file for the server repository, whether there is a particular format that we should follow if a PR template file is desired, etc.
Basically, I would love to hear your opinions on this.

I made a case in this [comment](https://github.com/MariaDB/server/pull/1776#issuecomment-796783537) for why I believe we definitely need something like this in our daily workflow.

### This is what the contributor needs to edit whilst opening a new PR
<img width="1440" alt="Screenshot 2021-03-11 at 23 04 16" src="https://user-images.githubusercontent.com/3465430/110856619-8adcf400-82c0-11eb-81c0-011460c08f17.png">

### This is how the empty PR template looks like in Preview mode
<img width="1440" alt="Screenshot 2021-03-11 at 23 04 22" src="https://user-images.githubusercontent.com/3465430/110856733-aea03a00-82c0-11eb-91fe-8a2f68e02249.png">

### This is how the new Pull Request should look like when the sections are filled
<img width="1440" alt="Screenshot 2021-03-11 at 23 09 33" src="https://user-images.githubusercontent.com/3465430/110856824-cd9ecc00-82c0-11eb-8307-d6ae2bee7aed.png">
