### PR TITLE
Don't pass password to innobackup via command line

### DIFF
--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -868,10 +868,10 @@ then
         fi
 
         if [ -n "${WSREP_SST_OPT_PSWD:-}" ]; then
-           INNOEXTRA+=" --password=$WSREP_SST_OPT_PSWD"
+            export MYSQL_PWD=$WSREP_SST_OPT_PSWD
         elif [[ $usrst -eq 1 ]];then
-           # Empty password, used for testing, debugging etc.
-           INNOEXTRA+=" --password="
+            # Empty password, used for testing, debugging etc.
+            unset MYSQL_PWD
         fi
 
         get_keys

--- a/scripts/wsrep_sst_xtrabackup-v2.sh
+++ b/scripts/wsrep_sst_xtrabackup-v2.sh
@@ -958,10 +958,10 @@ then
         fi
 
         if [ -n "${WSREP_SST_OPT_PSWD:-}" ]; then
-           INNOEXTRA+=" --password=$WSREP_SST_OPT_PSWD"
+            export MYSQL_PWD=$WSREP_SST_OPT_PSWD
         elif [[ $usrst -eq 1 ]];then
-           # Empty password, used for testing, debugging etc.
-           INNOEXTRA+=" --password="
+            # Empty password, used for testing, debugging etc.
+            unset MYSQL_PWD
         fi
 
         get_keys


### PR DESCRIPTION
Use environment instead

Debian maintainers expressed concern about passing unencrypted password to mariabackup script via environment and on the command line. While environment in modern systems can be read only by the privileged user, and so is practically as secure as a file, passing password to innobackup via command line is absolutely unnecessary.