### PR TITLE
MDEV-24966 Galera multi-master regression

### DIFF
--- a/mysql-test/suite/galera/r/galera_UK_conflict.result
+++ b/mysql-test/suite/galera/r/galera_UK_conflict.result
@@ -119,12 +119,15 @@ SET debug_sync='RESET';
 connection node_1;
 SET GLOBAL wsrep_slave_threads = DEFAULT;
 connection node_2;
+SET SESSION wsrep_sync_wait=15;
 SELECT * FROM t1;
 f1	f2	f3
 1	1	0
 3	3	1
 4	4	2
 5	5	2
+7	7	7
+8	8	8
 10	10	0
 INSERT INTO t1 VALUES (7,7,7);
 INSERT INTO t1 VALUES (8,8,8);

--- a/mysql-test/suite/galera/t/galera_UK_conflict.test
+++ b/mysql-test/suite/galera/t/galera_UK_conflict.test
@@ -266,6 +266,7 @@ SET debug_sync='RESET';
 SET GLOBAL wsrep_slave_threads = DEFAULT;
 
 --connection node_2
+SET SESSION wsrep_sync_wait=15;
 SELECT * FROM t1;
 
 # replicate some transactions, so that wsrep slave thread count can reach

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7985,22 +7985,6 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
       result= -3;
   }
   else
-    DBUG_ASSERT(result != -2 && result != -3);
-#endif /* WITH_WSREP */
-
-#ifdef WITH_WSREP
-  if (wsrep_is_active(entry->thd) &&
-      wsrep_run_commit_hook(entry->thd, entry->all))
-  {
-    /*  Release commit order here */
-    if (wsrep_ordered_commit(entry->thd, entry->all))
-      result= -2;
-
-    /* return -3, if this is leader */
-    if (orig_queue == NULL)
-      result= -3;
-  }
-  else
     DBUG_ASSERT(result == 0);
 #endif /* WITH_WSREP */
 

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -8001,7 +8001,7 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
       result= -3;
   }
   else
-    DBUG_ASSERT(result != -2 && result != -3);
+    DBUG_ASSERT(result == 0);
 #endif /* WITH_WSREP */
 
   if (opt_binlog_commit_wait_count > 0 && orig_queue != NULL)

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7978,13 +7978,14 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
   {
     /*  Release commit order here */
     if (wsrep_ordered_commit(entry->thd, entry->all))
-    {
       result= -2;
-    }
+
     /* return -3, if this is leader */
     if (orig_queue == NULL)
-        result= -3;
+      result= -3;
   }
+  else
+    DBUG_ASSERT(result != -2 && result != -3);
 #endif /* WITH_WSREP */
 
 #ifdef WITH_WSREP

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1207,7 +1207,7 @@ dispatch_command_return do_command(THD *thd, bool blocking)
   DBUG_ENTER("do_command");
 
   DBUG_ASSERT(!thd->async_state.pending_ops() ||
-	      (WSREP(thd) && thd->wsrep_trx().state() == wsrep::transaction::s_aborted));
+              (WSREP(thd) && thd->wsrep_trx().state() == wsrep::transaction::s_aborted));
   if (thd->async_state.m_state == thd_async_state::enum_async_state::RESUMED)
   {
     /*

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1206,7 +1206,8 @@ dispatch_command_return do_command(THD *thd, bool blocking)
   enum enum_server_command command;
   DBUG_ENTER("do_command");
 
-  DBUG_ASSERT(!thd->async_state.pending_ops());
+  DBUG_ASSERT(!thd->async_state.pending_ops() ||
+	      (WSREP(thd) && thd->wsrep_trx().state() == wsrep::transaction::s_aborted));
   if (thd->async_state.m_state == thd_async_state::enum_async_state::RESUMED)
   {
     /*

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -349,20 +349,20 @@ bool wsrep_bf_abort(const THD* bf_thd, THD* victim_thd)
   mysql_mutex_lock(&victim_thd->LOCK_thd_data);
   if (WSREP(victim_thd) && !victim_thd->wsrep_trx().active())
   {
-     WSREP_DEBUG("wsrep_bf_abort, BF abort for non active transaction");
-     switch (victim_thd->wsrep_trx().state()) {
-     case wsrep::transaction::s_aborting: /* fall through */
-     case wsrep::transaction::s_aborted:
-       WSREP_DEBUG("victim is aborting or has aborted");
-       mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
+    WSREP_DEBUG("wsrep_bf_abort, BF abort for non active transaction");
+    switch (victim_thd->wsrep_trx().state()) {
+    case wsrep::transaction::s_aborting: /* fall through */
+    case wsrep::transaction::s_aborted:
+      WSREP_DEBUG("victim is aborting or has aborted");
+      mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
       return false;
-     default: break;
-     }
-     /* the need to start wsrep transaction for BF aborting should be obsolete now
-        using debug assert to confirm this by testing
-      */
-     DBUG_ASSERT(0);
-     wsrep_start_transaction(victim_thd, victim_thd->wsrep_next_trx_id());
+    default: break;
+    }
+    /* the need to start wsrep transaction for BF aborting should be obsolete now
+       using debug assert to confirm this by testing
+    */
+    DBUG_ASSERT(0);
+    wsrep_start_transaction(victim_thd, victim_thd->wsrep_next_trx_id());
   }
   mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
 

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -346,7 +346,6 @@ bool wsrep_bf_abort(const THD* bf_thd, THD* victim_thd)
   WSREP_LOG_THD(victim_thd, "victim before");
   wsrep::seqno bf_seqno(bf_thd->wsrep_trx().ws_meta().seqno());
 
-  mysql_mutex_lock(&victim_thd->LOCK_thd_data);
   if (WSREP(victim_thd) && !victim_thd->wsrep_trx().active())
   {
     WSREP_DEBUG("wsrep_bf_abort, BF abort for non active transaction");
@@ -354,7 +353,6 @@ bool wsrep_bf_abort(const THD* bf_thd, THD* victim_thd)
     case wsrep::transaction::s_aborting: /* fall through */
     case wsrep::transaction::s_aborted:
       WSREP_DEBUG("victim is aborting or has aborted");
-      mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
       return false;
     default: break;
     }
@@ -364,7 +362,6 @@ bool wsrep_bf_abort(const THD* bf_thd, THD* victim_thd)
     DBUG_ASSERT(0);
     wsrep_start_transaction(victim_thd, victim_thd->wsrep_next_trx_id());
   }
-  mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
 
   bool ret;
   if (wsrep_thd_is_toi(bf_thd))

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18084,7 +18084,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
   {
     bool aborting= false;
     wsrep_thd_LOCK(vthd);
-    trx_t *vtrx = thd_to_trx(vthd);
+    trx_t *vtrx= thd_to_trx(vthd);
     if (vtrx)
     {
       lock_sys.wr_lock(SRW_LOCK_CALL);
@@ -18093,7 +18093,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
       /* victim transaction is either active or prepared, if it has already
 	 proceeded to replication phase */
       if (vtrx->id == trx_id && (vtrx->state == TRX_STATE_ACTIVE ||
-				 vtrx->state == TRX_STATE_PREPARED))
+         (wsrep_is_wsrep_xid(vtrx->xid) && vtrx->state == TRX_STATE_PREPARED)))
       {
         WSREP_LOG_CONFLICT(bf_thd, vthd, TRUE);
         WSREP_DEBUG("Aborter BF trx_id: " TRX_ID_FMT " thread: %ld "
@@ -18120,7 +18120,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
         /* Mark transaction as a victim for Galera abort */
         vtrx->lock.was_chosen_as_deadlock_victim.fetch_or(2);
         if (!wsrep_thd_set_wsrep_aborter(bf_thd, vthd))
-          aborting = true;
+          aborting= true;
         else
           WSREP_DEBUG("kill transaction skipped due to wsrep_aborter set");
       }
@@ -18134,16 +18134,8 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
       /* if victim is waiting for some other lock, we have to cancel
          that waiting
       */
-      lock_sys.wr_lock(SRW_LOCK_CALL);
-      mysql_mutex_lock(&lock_sys.wait_mutex);
-      if (lock_t *lock= vtrx->lock.wait_lock)
-      {
-        /* check if victim is still waiting */
-        if (lock->is_waiting())
-          lock_sys.lock_cancel_waiting_and_release(lock);
-      }
-      mysql_mutex_unlock(&lock_sys.wait_mutex);
-      lock_sys.wr_unlock();
+      lock_sys.cancel_lock_wait_for_trx(vtrx);
+
       DEBUG_SYNC(bf_thd, "before_wsrep_thd_abort");
       wsrep_thd_bf_abort(bf_thd, vthd, true);
     }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18084,7 +18084,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
   {
     bool aborting= false;
     wsrep_thd_LOCK(vthd);
-    trx_t *vtrx= thd_to_trx(vthd);
+    trx_t *vtrx = thd_to_trx(vthd);
     if (vtrx)
     {
       lock_sys.wr_lock(SRW_LOCK_CALL);
@@ -18120,9 +18120,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
         /* Mark transaction as a victim for Galera abort */
         vtrx->lock.was_chosen_as_deadlock_victim.fetch_or(2);
         if (!wsrep_thd_set_wsrep_aborter(bf_thd, vthd))
-        {
-          aborting= true;
-        }
+          aborting = true;
         else
           WSREP_DEBUG("kill transaction skipped due to wsrep_aborter set");
       }
@@ -18136,17 +18134,16 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
       /* if victim is waiting for some other lock, we have to cancel
          that waiting
       */
+      lock_sys.wr_lock(SRW_LOCK_CALL);
+      mysql_mutex_lock(&lock_sys.wait_mutex);
       if (lock_t *lock= vtrx->lock.wait_lock)
       {
-        lock_sys.wr_lock(SRW_LOCK_CALL);
-        mysql_mutex_lock(&lock_sys.wait_mutex);
-	/* check if victim is still waiting */
-	if (lock->is_waiting())
-	  lock_cancel_waiting_and_release(lock);
-
-        mysql_mutex_unlock(&lock_sys.wait_mutex);
-        lock_sys.wr_unlock();
+        /* check if victim is still waiting */
+        if (lock->is_waiting())
+          lock_sys.lock_cancel_waiting_and_release(lock);
       }
+      mysql_mutex_unlock(&lock_sys.wait_mutex);
+      lock_sys.wr_unlock();
       DEBUG_SYNC(bf_thd, "before_wsrep_thd_abort");
       wsrep_thd_bf_abort(bf_thd, vthd, true);
     }
@@ -18175,7 +18172,7 @@ wsrep_abort_transaction(
 	ut_ad(bf_thd);
 	ut_ad(victim_thd);
 
-	trx_t* victim_trx	= thd_to_trx(victim_thd);
+	trx_t* victim_trx = thd_to_trx(victim_thd);
 
 	WSREP_DEBUG("abort transaction: BF: %s victim: %s victim conf: %s",
 			wsrep_thd_query(bf_thd),

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18092,37 +18092,45 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
       vtrx->mutex_lock();
       /* victim transaction is either active or prepared, if it has already
 	 proceeded to replication phase */
-      if (vtrx->id == trx_id && (vtrx->state == TRX_STATE_ACTIVE ||
-         (wsrep_is_wsrep_xid(vtrx->xid) && vtrx->state == TRX_STATE_PREPARED)))
+      if (vtrx->id == trx_id)
       {
-        WSREP_LOG_CONFLICT(bf_thd, vthd, TRUE);
-        WSREP_DEBUG("Aborter BF trx_id: " TRX_ID_FMT " thread: %ld "
-                    "seqno: %lld client_state: %s "
-                    "client_mode: %s transaction_mode: %s query: %s",
-                    bf_trx->id,
-                    thd_get_thread_id(bf_thd),
-                    wsrep_thd_trx_seqno(bf_thd),
-                    wsrep_thd_client_state_str(bf_thd),
-                    wsrep_thd_client_mode_str(bf_thd),
-                    wsrep_thd_transaction_state_str(bf_thd),
-                    wsrep_thd_query(bf_thd));
-        WSREP_DEBUG("Victim %s trx_id: " TRX_ID_FMT " thread: %ld "
-                    "seqno: %lld client_state: %s "
-                    "client_mode: %s transaction_mode: %s query: %s",
-                    wsrep_thd_is_BF(vthd, false) ? "BF" : "normal",
-                    vtrx->id,
-                    thd_get_thread_id(vthd),
-                    wsrep_thd_trx_seqno(vthd),
-                    wsrep_thd_client_state_str(vthd),
-                    wsrep_thd_client_mode_str(vthd),
-                    wsrep_thd_transaction_state_str(vthd),
-                    wsrep_thd_query(vthd));
-        /* Mark transaction as a victim for Galera abort */
-        vtrx->lock.was_chosen_as_deadlock_victim.fetch_or(2);
-        if (!wsrep_thd_set_wsrep_aborter(bf_thd, vthd))
-          aborting= true;
-        else
-          WSREP_DEBUG("kill transaction skipped due to wsrep_aborter set");
+        switch (vtrx->state) {
+        default:
+          break;
+        case TRX_STATE_PREPARED:
+          if (!wsrep_is_wsrep_xid(vtrx->xid))
+            break;
+          /* fall through */
+        case TRX_STATE_ACTIVE:
+          WSREP_LOG_CONFLICT(bf_thd, vthd, TRUE);
+          WSREP_DEBUG("Aborter BF trx_id: " TRX_ID_FMT " thread: %ld "
+                      "seqno: %lld client_state: %s "
+                      "client_mode: %s transaction_mode: %s query: %s",
+                      bf_trx->id,
+                      thd_get_thread_id(bf_thd),
+                      wsrep_thd_trx_seqno(bf_thd),
+                      wsrep_thd_client_state_str(bf_thd),
+                      wsrep_thd_client_mode_str(bf_thd),
+                      wsrep_thd_transaction_state_str(bf_thd),
+                      wsrep_thd_query(bf_thd));
+          WSREP_DEBUG("Victim %s trx_id: " TRX_ID_FMT " thread: %ld "
+                      "seqno: %lld client_state: %s "
+                      "client_mode: %s transaction_mode: %s query: %s",
+                      wsrep_thd_is_BF(vthd, false) ? "BF" : "normal",
+                      vtrx->id,
+                      thd_get_thread_id(vthd),
+                      wsrep_thd_trx_seqno(vthd),
+                      wsrep_thd_client_state_str(vthd),
+                      wsrep_thd_client_mode_str(vthd),
+                      wsrep_thd_transaction_state_str(vthd),
+                      wsrep_thd_query(vthd));
+          /* Mark transaction as a victim for Galera abort */
+          vtrx->lock.was_chosen_as_deadlock_victim.fetch_or(2);
+          if (!wsrep_thd_set_wsrep_aborter(bf_thd, vthd))
+            aborting= true;
+          else
+            WSREP_DEBUG("kill transaction skipped due to wsrep_aborter set");
+        }
       }
       lock_sys.wr_unlock();
       mysql_mutex_unlock(&lock_sys.wait_mutex);

--- a/storage/innobase/include/lock0lock.h
+++ b/storage/innobase/include/lock0lock.h
@@ -857,6 +857,10 @@ public:
   @param id   page to be discarded
   @param page whether to discard also from lock_sys.prdt_hash */
   void prdt_page_free_from_discard(const page_id_t id, bool all= false);
+#ifdef WITH_WSREP
+  /** Cancel a waiting lock request and release possibly waiting transactions */
+  static void lock_cancel_waiting_and_release(lock_t *lock);
+#endif /* WITH_WSREP */
 };
 
 /** The lock system */
@@ -1022,9 +1026,6 @@ lock_rtr_move_rec_list(
 	rtr_rec_move_t*		rec_move,	/*!< in: recording records
 						moved */
 	ulint			num_move);	/*!< in: num of rec to move */
-
-/** Cancel a waiting lock request and release possibly waiting transactions */
-void lock_cancel_waiting_and_release(lock_t *lock);
 
 #include "lock0lock.ic"
 

--- a/storage/innobase/include/lock0lock.h
+++ b/storage/innobase/include/lock0lock.h
@@ -1023,6 +1023,9 @@ lock_rtr_move_rec_list(
 						moved */
 	ulint			num_move);	/*!< in: num of rec to move */
 
+/** Cancel a waiting lock request and release possibly waiting transactions */
+void lock_cancel_waiting_and_release(lock_t *lock);
+
 #include "lock0lock.ic"
 
 #endif

--- a/storage/innobase/include/lock0lock.h
+++ b/storage/innobase/include/lock0lock.h
@@ -857,9 +857,10 @@ public:
   @param id   page to be discarded
   @param page whether to discard also from lock_sys.prdt_hash */
   void prdt_page_free_from_discard(const page_id_t id, bool all= false);
+
 #ifdef WITH_WSREP
-  /** Cancel a waiting lock request and release possibly waiting transactions */
-  static void lock_cancel_waiting_and_release(lock_t *lock);
+  /** Cancel possible lock waiting for a transaction */
+  static void cancel_lock_wait_for_trx(trx_t *trx);
 #endif /* WITH_WSREP */
 };
 

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -5346,7 +5346,7 @@ static void lock_release_autoinc_locks(trx_t *trx)
 }
 
 /** Cancel a waiting lock request and release possibly waiting transactions */
-void lock_cancel_waiting_and_release(lock_t *lock)
+static void lock_cancel_waiting_and_release(lock_t *lock)
 {
   lock_sys.assert_locked(*lock);
   mysql_mutex_assert_owner(&lock_sys.wait_mutex);
@@ -5387,8 +5387,8 @@ void lock_sys_t::cancel_lock_wait_for_trx(trx_t *trx)
     if (lock->is_waiting())
       lock_cancel_waiting_and_release(lock);
   }
-  mysql_mutex_unlock(&lock_sys.wait_mutex);
   lock_sys.wr_unlock();
+  mysql_mutex_unlock(&lock_sys.wait_mutex);
 }
 #endif /* WITH_WSREP */
 


### PR DESCRIPTION
After the merging of MDEV-24915, 10.6 branch has regressions with handling of concurrent write load against two or more cluster nodes.
These regressions may surface as cluster hanging, node crashes or data inconsistency.
With some test scenarios, the only visible symptom could be that the BF victim aborting happens only by innodb lock wait timeout expiration.
This would result only to poor performance (by default 50 sec hang for each BF conflict), and could be somewhat difficult to diagnose.

This pull request has following fixes to handle concurrent write load from multiple nodes:

In lock_wait_wsrep_kill(), the victim trx was expected to be only in TRX_STATE_ACTIVE state.
With the delayed BF conflict handling, it can happen that victim has advanced into pre commit state.
This was fixed by choosing victim both in TRX_STATE_ACTIVE and TRX_STATE_PREPARED states.

Victim transaction may be in several different states at the time of detected lock conflict, and due to delayed BF aborting practice in MDEV-24915, the victim may advance further before the actual BF aborting takes place.
The BF aborting in MDEV-24915 did not wake the victim, if it was in the state of waiting for some other lock (than the one that was blocking the high priority thread).
This anomaly caused the innodb lock wait timeout expiration delays and poor performance symptom.
To fix this, lock_wait_wsrep_kill() now looks if victim is in lock waiting state, and uses lock_cancel_waiting_and_release() to cancel this lock wait.

wsrep_bf_abort() checks if the victim has active transaction (in wsrep-lib), and starts a new transaction if there was no active transaction before.
Due to late BF aborting, the victim may have e.g. failed in certification and is already aborting or has aborted at this stage.
This has caused problems in testing where BF aborter tries to BF abort himself.
The fix in wsrep_bf_abort() now skips the BF abort, if victim is aborting or has aborted.

BF aborting could cause BF-BF conflict scenario, if victim was already aborted and changed to replayer having high priority as well.
This BF-BF conflict scenario is now avoided in lock_wait_wsrep() where we now check if blocking lock holder is also high priority and is ordered before, caller should wait for the lock in this situation.

The natural innodb deadlock resolving algorithm could pick BF thread as deadlock victim. This is fixed by giving max weigh to BF threads in  Deadlock::report().

binlog group commit could lead to a situation where group commit leader accesses participant thd's wsrep client state concurrently with the thread executing the participant thd.
This is because of race condition in MYSQL_BIN_LOG::write_transaction_to_binlog_events(), and was fixed by moving wsrep_ordered_commit() to happen in MYSQL_BIN_LOG::queue_for_group_commit() under protection of LOCK_prepare_ordered mutex.

MDEV-24341 has changed excution paths in do_command() and this affects BF aborted victim execution. This PR fixes one assert in do_command():
 DBUG_ASSERT(!thd->async_state.pending_ops())
Which fired if the thd was BF aborted earlier. This assert is now changed to allow pending_ops() if thd was BF aborted before.

Finally, the test galera.galera_UK_conflict is apparently merged from 10.2 level, and as it has galera 3 sync point conventions, the test does not work at all.
Also, only first half of the test is present in 10.6. Fixed the test so that it works with galera 4, but the latter half of the test is still missing.

With these fixes, long term highly conflicting write load could be run against to node cluster.
If binlogging is configured, log_slave_updates should be also set.
Issues faced when not setting log_slave_updates, have not been properly troubleshooted yet.