### PR TITLE
MDEV-5536: add systemd socket activation - change debian packaging to enable it by default

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -191,11 +191,11 @@ override_dh_installlogrotate-arch:
 	dh_installlogrotate --name mysql-server
 
 override_dh_systemd_enable:
-	dh_systemd_enable --name=mariadb
-	dh_systemd_enable --no-enable --name=mariadb mariadb.socket
-	dh_systemd_enable --no-enable --name=mariadb-extra mariadb-extra.socket
+	dh_systemd_enable --name=mariadb mariadb.socket
+	dh_systemd_enable --name=mariadb-extra mariadb-extra.socket
 	dh_systemd_enable --no-enable --name=mariadb@ mariadb.socket
 	dh_systemd_enable --no-enable --name=mariadb-extra@ mariadb-extra.socket
+	dh_systemd_enable --no-enable --name=mariadb  mariadb.service
 	dh_systemd_enable --no-enable --name=mariadb@ mariadb@.service
 
 # Start MariaDB at sequence number 19 before 20 where apache, proftpd etc gets


### PR DESCRIPTION
@ottok My initial reads of dh_installsystemd, dh_systemd_start, and dh_systemd_enable where of the assumption that they applied only to service files. This appears not to be the case.

as such it probably needs:
* debian/not-installed on the socket files

in rules
* cp $(BUILDDIR)/support-files/mariadb.socket debian/mariadb-server-10.6.mariadb.socket
* same for multinstance
* change override_dh_systemd_enable / override_dh_installinit-arch to be explicit about service/socket names rather than being an implicit service.

The previous behaviour of mariadb.service from a user's prespective is totally unchange. They can start/stop those as they please and the added socket activation support has no impacts.

From a packaging point of view, on greenfields installs do you want socket activation there so its very light weight until a user connects?