### PR TITLE
Fix postinst trigger when systemd is not running (Closes: #983563)

### DIFF
--- a/debian/mariadb-server-10.2.postinst
+++ b/debian/mariadb-server-10.2.postinst
@@ -247,8 +247,8 @@ EOF
   ;;
 
   triggered)
-    if [ -x "$(command -v systemctl)" ]; then
-      systemctl daemon-reload
+    if [ -d /run/systemd/system ]; then
+      systemctl --system daemon-reload
     fi
     invoke restart
   ;;


### PR DESCRIPTION
Checking for the existence of the systemctl command only tells us that
systemd is installed, however it does not tell us if systemd is running.
What we really want to do here is reload systemd if it's installed AND
if it's running. The usual way to check if systemd is running is to
check for the existence of '/run/systemd/system'.

Why would systemd be installed but not running? This is something that
happens when one sets up or upgrade a system in a chroot or container.

For more details refer to the bug report:
<https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=983563>