### PR TITLE
MDEV-24630: MY_RELAX_CPU assembly instruction upgrade/research for

### DIFF
--- a/include/my_cpu.h
+++ b/include/my_cpu.h
@@ -84,7 +84,7 @@ static inline void MY_RELAX_CPU(void)
   __ppc_get_timebase();
 #elif defined __GNUC__ && (defined __arm__ || defined __aarch64__)
   /* Mainly, prevent the compiler from optimizing away delay loops */
-  __asm__ __volatile__ ("":::"memory");
+  __asm__ __volatile__ ("isb":::"memory");
 #else
   int32 var, oldval = 0;
   my_atomic_cas32_strong_explicit(&var, &oldval, 1, MY_MEMORY_ORDER_RELAXED,


### PR DESCRIPTION
            memory barrier on ARM

As suggested in the said JIRA ticket based on the contribution done by
the community (in an attempt to optimize the spin-loop) the said approach
was evaluated against MariaDB Server 10.5 and found to help improve
throughput in the range of 2-5%.

Note: 10.6 timing graph and model are different as home-brew
mutexes are replaced with pthread mutexes. Said patch has mixed
impact on 10.6 so not recommended for 10.6.