### PR TITLE
MDEV-23538: Rename mariadb.pc to mariadb-embedded-server.pc to avoid confusion

### DIFF
--- a/debian/libmariadb-dev.install
+++ b/debian/libmariadb-dev.install
@@ -29,6 +29,7 @@ usr/lib/*/libmariadbclient.a
 usr/lib/*/libmariadbclient.so
 usr/lib/*/libmysqlservices.a
 usr/lib/*/pkgconfig/libmariadb.pc
+usr/lib/*/pkgconfig/mariadb.pc
 usr/share/aclocal/mysql.m4
 usr/share/man/man1/mariadb_config.1
 usr/share/man/man1/mysql_config.1

--- a/debian/libmariadbd-dev.install
+++ b/debian/libmariadbd-dev.install
@@ -3,3 +3,5 @@ usr/lib/*/libmariadbd.a
 usr/lib/*/libmariadbd.so
 usr/lib/*/libmysqld.a
 usr/lib/*/libmysqld.so
+usr/lib/*/pkgconfig/libmariadbd.pc
+usr/lib/*/pkgconfig/mariadb-embedded-server.pc

--- a/debian/rules
+++ b/debian/rules
@@ -161,6 +161,17 @@ override_dh_auto_install:
 	# Rename and install AppArmor profile
 	install -D -m 644 debian/apparmor-profile $(TMP)/etc/apparmor.d/usr.sbin.mariadbd
 
+	# Rename mariadb.pc as mariadb-embedded-server.pc as to be more descriptive
+	mv -v $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/mariadb.pc $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/mariadb-embedded-server.pc
+	# Keep libmariadbd.pc around for backwards compatibility as all Debian users
+	# have had it for embedded server since April 2021
+	ln -sf mariadb-embedded-server.pc $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/libmariadbd.pc
+
+	# Rename libmariadb.pc as mariadb.pc as it better fits the client library,
+	# and keep old libmariadb.pc as symlink for backwards compatibility
+	mv -v $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/libmariadb.pc $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/mariadb.pc
+	ln -sf mariadb.pc $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/libmariadb.pc
+
 	# Install libmariadbclient18 compatibility links
 	ln -s libmariadb.so.3 $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/libmariadbclient.so
 	ln -s libmariadb.so.3 $(TMP)/usr/lib/$(DEB_HOST_MULTIARCH)/libmariadbclient.so.18


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-23538

Change so that the client library config can be accessed using the name
libmariadb.pc or mariadb.pc. Rename old mariadb.pc to mariadbd.pc to better
indicate that the config is for the daemon build, not client.

In downstream Debian we already ship the libmariadb.pc as mariadb.pc:
https://salsa.debian.org/mariadb-team/mariadb-10.5/-/commit/2f183af990fbe1cfa8c343998c7640f45f45368b