### PR TITLE
More fixes for variable wsrep_on

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_wsrep_on_off.result
+++ b/mysql-test/suite/galera/r/galera_var_wsrep_on_off.result
@@ -22,12 +22,14 @@ SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 3;
 COUNT(*) = 1
 1
 DROP TABLE t1;
+connection node_1;
 START TRANSACTION;
 SET SESSION wsrep_on=OFF;
 ERROR 25000: You are not allowed to execute this command in a transaction
 SET GLOBAL wsrep_on=OFF;
 ERROR 25000: You are not allowed to execute this command in a transaction
 COMMIT;
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
 START TRANSACTION;
 INSERT INTO t1 VALUES (1);
@@ -68,3 +70,58 @@ SET GLOBAL wsrep_on = ON;
 SHOW SESSION VARIABLES LIKE 'wsrep_on';
 Variable_name	Value
 wsrep_on	ON
+disconnect node_1b;
+connection node_1;
+SET GLOBAL wsrep_on = OFF;
+SET SESSION wsrep_on = ON;
+ERROR HY000: Can't enable @@session.wsrep_on, while @@global.wsrep_on is disabled
+SET GLOBAL wsrep_on = ON;
+SET SESSION wsrep_on = ON;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET GLOBAL wsrep_on = OFF;
+connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;;
+connection node_1b;
+SHOW SESSION VARIABLES LIKE 'wsrep_on';
+Variable_name	Value
+wsrep_on	OFF
+SHOW GLOBAL VARIABLES LIKE 'wsrep_on';
+Variable_name	Value
+wsrep_on	OFF
+SET GLOBAL wsrep_on = ON;
+START TRANSACTION;
+INSERT INTO t1 VALUES(1);
+COMMIT;
+SELECT * FROM t1;
+f1
+1
+connection node_2;
+SELECT * FROM t1;
+f1
+1
+DROP TABLE t1;
+connection node_1;
+SET SESSION wsrep_on = OFF;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+START TRANSACTION;
+INSERT INTO t1 VALUES (2);
+COMMIT;
+DROP TABLE t1;
+connection node_2;
+SHOW TABLES;
+Tables_in_test
+connection node_1;
+SET SESSION wsrep_on = ON;
+SET GLOBAL wsrep_on = OFF;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+START TRANSACTION;
+INSERT INTO t1 VALUES (2);
+COMMIT;
+connection node_2;
+SHOW TABLES;
+Tables_in_test
+connection node_1;
+DROP TABLE t1;
+SET GLOBAL wsrep_on = ON;

--- a/mysql-test/suite/galera/t/galera_var_wsrep_on_off.test
+++ b/mysql-test/suite/galera/t/galera_var_wsrep_on_off.test
@@ -36,6 +36,7 @@ DROP TABLE t1;
 # active transaction.
 #
 
+--connection node_1
 START TRANSACTION;
 --error ER_CANT_DO_THIS_DURING_AN_TRANSACTION
 SET SESSION wsrep_on=OFF;
@@ -49,6 +50,7 @@ COMMIT;
 # @@session.wsrep_on of current sessions
 #
 
+--connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
 START TRANSACTION;
 INSERT INTO t1 VALUES (1);
@@ -75,6 +77,7 @@ DROP TABLE t1;
 #
 # New connections inherit @@session.wsrep_on from @@global.wsrep_on
 #
+
 --connection node_1
 SET GLOBAL wsrep_on = OFF;
 
@@ -87,3 +90,78 @@ DROP TABLE t2;
 
 SET GLOBAL wsrep_on = ON;
 SHOW SESSION VARIABLES LIKE 'wsrep_on';
+
+--disconnect node_1b
+
+
+#
+# Can't set @@session.wsrep_on = ON, while @@global.wsrep_on = OFF
+#
+
+--connection node_1
+SET GLOBAL wsrep_on = OFF;
+--error ER_WRONG_ARGUMENTS
+SET SESSION wsrep_on = ON;
+
+SET GLOBAL wsrep_on = ON;
+SET SESSION wsrep_on = ON;
+
+
+#
+# @@global.wsrep_on = OFF followed by @@global.wsrep_on = ON
+# in a new connection
+#
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET GLOBAL wsrep_on = OFF;
+--connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+--connection node_1b
+SHOW SESSION VARIABLES LIKE 'wsrep_on';
+SHOW GLOBAL VARIABLES LIKE 'wsrep_on';
+SET GLOBAL wsrep_on = ON;
+START TRANSACTION;
+INSERT INTO t1 VALUES(1);
+COMMIT;
+
+SELECT * FROM t1;
+
+--connection node_2
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+
+#
+# Test single statement, multi statement, and
+# TOI tansactions while @@session.wsrep_on = OFF
+# and then same @@global.wsrep_on = OFF.
+# Notice, the combination @@global.wsrep_on = OFF
+# and @@session.wsrep_on = ON is not not possible,
+# (as tested above in this test case)
+#
+
+--connection node_1
+SET SESSION wsrep_on = OFF;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+START TRANSACTION;
+INSERT INTO t1 VALUES (2);
+COMMIT;
+DROP TABLE t1;
+--connection node_2
+SHOW TABLES;
+--connection node_1
+SET SESSION wsrep_on = ON;
+
+SET GLOBAL wsrep_on = OFF;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+START TRANSACTION;
+INSERT INTO t1 VALUES (2);
+COMMIT;
+--connection node_2
+SHOW TABLES;
+--connection node_1
+DROP TABLE t1;
+SET GLOBAL wsrep_on = ON;

--- a/mysql-test/suite/sys_vars/r/wsrep_on_without_provider.result
+++ b/mysql-test/suite/sys_vars/r/wsrep_on_without_provider.result
@@ -1,0 +1,5 @@
+SET GLOBAL wsrep_on=ON;
+ERROR HY000: WSREP (galera) can't be enabled if the wsrep_provider is unset or set to 'none'
+SELECT @@global.wsrep_on;
+@@global.wsrep_on
+0

--- a/mysql-test/suite/sys_vars/t/wsrep_on_without_provider.test
+++ b/mysql-test/suite/sys_vars/t/wsrep_on_without_provider.test
@@ -1,0 +1,9 @@
+--source include/not_embedded.inc
+
+#
+# @@global.wsrep_on is not allowed if there
+# is no wsrep_provider
+#
+--error ER_WRONG_ARGUMENTS
+SET GLOBAL wsrep_on=ON;
+SELECT @@global.wsrep_on;

--- a/mysql-test/suite/wsrep/disabled.def
+++ b/mysql-test/suite/wsrep/disabled.def
@@ -14,3 +14,4 @@
 mdev_6832: wsrep_provider is read-only for security reasons
 MDEV-23092: wsrep_provider is read-only for security reasons
 wsrep_variables_no_provider: wsrep_provider is read-only for security reasons
+MDEV-22443: it is no longer allowed enable wsrep_on if wsrep_provider is 'none'

--- a/mysql-test/suite/wsrep/r/variables_debug.result
+++ b/mysql-test/suite/wsrep/r/variables_debug.result
@@ -14,7 +14,6 @@ SET SESSION wsrep_replicate_myisam= ON;
 ERROR HY000: Variable 'wsrep_replicate_myisam' is a GLOBAL variable and should be set with SET GLOBAL
 SET GLOBAL wsrep_replicate_myisam= ON;
 SET GLOBAL wsrep_replicate_myisam= OFF;
-SET GLOBAL wsrep_provider=none;
 #
 # MDEV#5790: SHOW GLOBAL STATUS LIKE does not show the correct list of
 # variables when using "_"
@@ -66,7 +65,15 @@ wsrep_cert_interval	#
 wsrep_open_transactions	#
 wsrep_open_connections	#
 wsrep_incoming_addresses	#
+wsrep_cluster_weight	#
 wsrep_debug_sync_waiters	#
+wsrep_desync_count	#
+wsrep_evs_delayed	#
+wsrep_evs_evict_list	#
+wsrep_evs_repl_latency	#
+wsrep_evs_state	#
+wsrep_gcomm_uuid	#
+wsrep_gmcast_segment	#
 wsrep_applier_thread_count	#
 wsrep_cluster_capabilities	#
 wsrep_cluster_conf_id	#
@@ -130,7 +137,15 @@ wsrep_cert_interval	#
 wsrep_open_transactions	#
 wsrep_open_connections	#
 wsrep_incoming_addresses	#
+wsrep_cluster_weight	#
 wsrep_debug_sync_waiters	#
+wsrep_desync_count	#
+wsrep_evs_delayed	#
+wsrep_evs_evict_list	#
+wsrep_evs_repl_latency	#
+wsrep_evs_state	#
+wsrep_gcomm_uuid	#
+wsrep_gmcast_segment	#
 wsrep_applier_thread_count	#
 wsrep_cluster_capabilities	#
 wsrep_cluster_conf_id	#
@@ -153,7 +168,6 @@ wsrep_local_state_comment	#
 # Should show nothing.
 SHOW STATUS LIKE 'x';
 Variable_name	Value
-SET GLOBAL wsrep_provider=none;
 
 SHOW STATUS LIKE 'wsrep_local_state_uuid';
 Variable_name	Value
@@ -162,7 +176,6 @@ wsrep_local_state_uuid	#
 SHOW STATUS LIKE 'wsrep_last_committed';
 Variable_name	Value
 wsrep_last_committed	#
-SET GLOBAL wsrep_provider=none;
 
 #
 # MDEV#6206: wsrep_slave_threads subtracts from max_connections
@@ -176,7 +189,7 @@ SELECT @@global.wsrep_slave_threads;
 1
 SELECT @@global.wsrep_cluster_address;
 @@global.wsrep_cluster_address
-
+gcomm://
 SELECT @@global.wsrep_on;
 @@global.wsrep_on
 1
@@ -185,14 +198,14 @@ Variable_name	Value
 Threads_connected	1
 SHOW STATUS LIKE 'wsrep_thread_count';
 Variable_name	Value
-wsrep_thread_count	0
+wsrep_thread_count	2
 
 SELECT @@global.wsrep_provider;
 @@global.wsrep_provider
 libgalera_smm.so
 SELECT @@global.wsrep_cluster_address;
 @@global.wsrep_cluster_address
-
+gcomm://
 SELECT @@global.wsrep_on;
 @@global.wsrep_on
 1
@@ -201,7 +214,7 @@ Variable_name	Value
 Threads_connected	1
 SHOW STATUS LIKE 'wsrep_thread_count';
 Variable_name	Value
-wsrep_thread_count	0
+wsrep_thread_count	2
 
 # Setting wsrep_cluster_address triggers the creation of
 # applier/rollbacker threads.
@@ -269,7 +282,7 @@ SELECT @@global.wsrep_sst_auth;
 SET @@global.wsrep_sst_auth= '';
 SELECT @@global.wsrep_sst_auth;
 @@global.wsrep_sst_auth
-
+NULL
 SET @@global.wsrep_sst_auth= NULL;
 SELECT @@global.wsrep_sst_auth;
 @@global.wsrep_sst_auth

--- a/mysql-test/suite/wsrep/r/wsrep_on_basic.result
+++ b/mysql-test/suite/wsrep/r/wsrep_on_basic.result
@@ -7,10 +7,10 @@ SET @wsrep_on_session_saved = @@session.wsrep_on;
 # default
 SELECT @@global.wsrep_on;
 @@global.wsrep_on
-0
+1
 SELECT @@session.wsrep_on;
 @@session.wsrep_on
-0
+1
 
 # scope and valid values
 SET @@global.wsrep_on=OFF;

--- a/mysql-test/suite/wsrep/t/variables_debug.test
+++ b/mysql-test/suite/wsrep/t/variables_debug.test
@@ -23,7 +23,6 @@ SET GLOBAL wsrep_replicate_myisam= ON;
 
 # Reset it back.
 SET GLOBAL wsrep_replicate_myisam= OFF;
-SET GLOBAL wsrep_provider=none;
 
 --echo #
 --echo # MDEV#5790: SHOW GLOBAL STATUS LIKE does not show the correct list of
@@ -31,10 +30,6 @@ SET GLOBAL wsrep_provider=none;
 --echo #
 
 CALL mtr.add_suppression("WSREP: Could not open saved state file for reading.*");
-
---disable_query_log
-eval SET GLOBAL wsrep_provider= '$WSREP_PROVIDER';
---enable_query_log
 
 --replace_column 2 #
 SHOW GLOBAL STATUS LIKE 'wsrep%';
@@ -49,12 +44,6 @@ SHOW GLOBAL STATUS LIKE 'wsrep_local_state_comment';
 --echo # Should show nothing.
 SHOW STATUS LIKE 'x';
 
-# Reset it back.
-SET GLOBAL wsrep_provider=none;
-
---disable_query_log
-eval SET GLOBAL wsrep_provider= '$WSREP_PROVIDER';
---enable_query_log
 
 # The following 2 variables are used by mariabackup
 # SST.
@@ -65,18 +54,11 @@ SHOW STATUS LIKE 'wsrep_local_state_uuid';
 --replace_column 2 #
 SHOW STATUS LIKE 'wsrep_last_committed';
 
-# Reset it back.
-SET GLOBAL wsrep_provider=none;
-
 --echo
 --echo #
 --echo # MDEV#6206: wsrep_slave_threads subtracts from max_connections
 --echo #
 call mtr.add_suppression("WSREP: Failed to get provider options");
-
---disable_query_log
-eval SET GLOBAL wsrep_provider= '$WSREP_PROVIDER';
---enable_query_log
 
 --replace_regex /.*libgalera_smm.*/libgalera_smm.so/
 SELECT @@global.wsrep_provider;
@@ -88,7 +70,7 @@ SHOW STATUS LIKE 'wsrep_thread_count';
 --echo
 
 --disable_query_log
-eval SET GLOBAL wsrep_provider= '$WSREP_PROVIDER';
+#eval SET GLOBAL wsrep_provider= '$WSREP_PROVIDER';
 --enable_query_log
 
 --replace_regex /.*libgalera_smm.*/libgalera_smm.so/
@@ -166,7 +148,7 @@ SET @@global.wsrep_sst_auth= @wsrep_sst_auth_saved;
 
 --disable_query_log
 SET GLOBAL wsrep_slave_threads= @wsrep_slave_threads_saved;
-eval SET GLOBAL wsrep_provider= '$WSREP_PROVIDER';
+#eval SET GLOBAL wsrep_provider= '$WSREP_PROVIDER';
 SET GLOBAL wsrep_cluster_address= @wsrep_cluster_address_saved;
 SET GLOBAL wsrep_provider_options= @wsrep_provider_options_saved;
 --enable_query_log

--- a/mysql-test/suite/wsrep/t/wsrep_on_basic.opt
+++ b/mysql-test/suite/wsrep/t/wsrep_on_basic.opt
@@ -1,0 +1,1 @@
+--wsrep-provider=$WSREP_PROVIDER --binlog_format=ROW --wsrep-cluster-address=gcomm://

--- a/mysql-test/suite/wsrep/t/wsrep_on_basic.test
+++ b/mysql-test/suite/wsrep/t/wsrep_on_basic.test
@@ -1,4 +1,6 @@
 --source include/have_wsrep.inc
+--source include/have_wsrep_provider.inc
+--source include/have_innodb.inc
 
 --echo #
 --echo # wsrep_on

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -120,15 +120,23 @@ extern "C" my_bool wsrep_get_debug()
   return wsrep_debug;
 }
 
+/*
+  Test if this connection is a true local (user) connection and not
+  a replication or wsrep applier thread.
+
+  Note that this is only usable for galera (as there are other kinds
+  of system threads, and only if WSREP_NNULL() is tested by the caller.
+ */
 extern "C" my_bool wsrep_thd_is_local(const THD *thd)
 {
   /*
-    async replication IO and background threads have nothing to replicate in the cluster,
-    marking them as non-local here to prevent write set population and replication
+    async replication IO and background threads have nothing to
+    replicate in the cluster, marking them as non-local here to
+    prevent write set population and replication
 
-    async replication SQL thread, applies client transactions from mariadb master
-    and will be replicated into cluster
-   */
+    async replication SQL thread, applies client transactions from
+    mariadb master and will be replicated into cluster
+  */
   return (
           thd->system_thread != SYSTEM_THREAD_SLAVE_BACKGROUND &&
           thd->system_thread != SYSTEM_THREAD_SLAVE_IO &&

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -433,6 +433,16 @@ static inline void wsrep_close(THD* thd)
   DBUG_VOID_RETURN;
 }
 
+static inline void wsrep_cleanup(THD* thd)
+{
+  DBUG_ENTER("wsrep_cleanup");
+  if (thd->wsrep_cs().state() != wsrep::client_state::s_none)
+  {
+    thd->wsrep_cs().cleanup();
+  }
+  DBUG_VOID_RETURN;
+}
+
 static inline void
 wsrep_wait_rollback_complete_and_acquire_ownership(THD *thd)
 {


### PR DESCRIPTION
This PR contains two unrelated commits:

1. Fixup wsrep.variables_debug. This is a followup related wsrep_provider read-only.
2. Fixes for variable wsrep_on
