### PR TITLE
Unused flag creates cleaning issue (piuparts)

### DIFF
--- a/debian/mariadb-server-10.6.postinst
+++ b/debian/mariadb-server-10.6.postinst
@@ -36,7 +36,7 @@ case "$1" in
     # latest 'mariadb' file. This has also the added benefit that anything that
     # invokes traditional sysv init with either 'mysql' or 'mariadb' will end up
     # controlling this newly installed MariaDB, and thus we maintain better
-    # backwards compatiblity.
+    # backwards compatibility.
     #
     # Note that the 'Provides' line is also updated to avoid 'insserv' exiting
     # on failure (when it is run by update-rc.d) because of duplicate service
@@ -124,7 +124,7 @@ EOF
     if [ ! -d "$mysql_datadir"  ] && [ ! -L "$mysql_datadir" ]; then mkdir -Z "$mysql_datadir" ; fi
     if [ ! -d "$mysql_logdir"   ] && [ ! -L "$mysql_logdir"  ]; then mkdir -Z "$mysql_logdir"  ; fi
     # When creating an ext3 jounal on an already mounted filesystem like e.g.
-    # /var/lib/mysql, you get a .journal file that is not modifyable by chown.
+    # /var/lib/mysql, you get a .journal file that is not modifiable by chown.
     # The mysql_statedir must not be writable by the mysql user under any
     # circumstances as it contains scripts that are executed by root.
     set +e
@@ -174,9 +174,6 @@ EOF
                                    --disable-log-bin  --skip-test-db 2>&1 | \
                                    $ERR_LOGGER
     set -e
-
-    # To avoid downgrades.
-    touch "$mysql_statedir/debian-$MAJOR_VER.flag"
 
     # On new installations root user can connect via unix_socket.
     # But on upgrades, scripts rely on debian-sys-maint user and
@@ -251,7 +248,7 @@ EOF
   ;;
 esac
 
-db_stop # in case invoke failes
+db_stop # in case invoke fails
 
 # dh_systemd_start doesn't emit anything since we still ship /etc/init.d/mariadb.
 # Thus MariaDB server is started via init.d script, which in turn redirects to


### PR DESCRIPTION
The `$mysql_statedir/debian-$MAJOR_VER.flag` is not used by any
maintainer script (`$mysql_datadir/debian-$MAJOR_VER.flag` is used,
https://github.com/MariaDB/server/blob/10.6/debian/mariadb-server-10.6.postinst#L164).

See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=985870

Fix also some minor typo.