### PR TITLE
WIP: MDEV-23755: Ensure safe shutdown on upgrades and removals

### DIFF
--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -6,6 +6,9 @@ set -e
 # Automatically set version to ease maintenance of this file
 MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
+echo "= Debian script trace ="
+echo "RUNNING $0 $*" 1>&2
+
 if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*" 1>&2 }
 

--- a/debian/mariadb-server-10.5.postrm
+++ b/debian/mariadb-server-10.5.postrm
@@ -6,6 +6,9 @@ set -e
 # Automatically set version to ease maintenance of this file
 MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
+echo "= Debian script trace ="
+echo "RUNNING $0 $*" 1>&2
+
 if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*" 1>&2 }
 

--- a/debian/mariadb-server-10.5.preinst
+++ b/debian/mariadb-server-10.5.preinst
@@ -12,6 +12,21 @@
 # Automatically set version to ease maintenance of this file
 MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
+echo "= Debian script trace ="
+echo "RUNNING $0 $*" 1>&2
+echo "Operation: $1"
+OLD_MARIADB_VERSION=$(echo "$2" | grep -m 1 -oE "[0-9]+\.[0-9]+\.[0-9]+") || true
+NEW_MARIADB_VERSION=$(echo "$3" | grep -m 1 -oE "[0-9]+\.[0-9]+\.[0-9]+") || true
+echo "Old: Release = $2 - MariaDB version = $OLD_MARIADB_VERSION"
+echo "New: Release = $3 - MariaDB version = $NEW_MARIADB_VERSION"
+if [ -n "$OLD_MARIADB_VERSION" ] && [ -n "$NEW_MARIADB_VERSION" ] && \
+   [ "$OLD_MARIADB_VERSION" != "$NEW_MARIADB_VERSION" ]
+then
+  echo "New MariaDB version $NEW_MARIADB_VERSION detected!"
+  # Shut down gracefully, if possible
+  mariadb --defaults-file=/etc/mysql/debian.cnf -e 'SET GLOBAL innodb_max_purge_lag_wait=0' || true
+fi
+
 # Just kill the invalid insserv.conf.d directory without fallback
 if [ -d "/etc/insserv.conf.d/mariadb/" ]; then
     rm -rf "/etc/insserv.conf.d/mariadb/"

--- a/debian/mariadb-server-10.5.prerm
+++ b/debian/mariadb-server-10.5.prerm
@@ -1,7 +1,13 @@
 #!/bin/sh
 set -e
 
+echo "= Debian script trace ="
+echo "RUNNING $0 $*" 1>&2
+
 #DEBHELPER#
+
+# Shut down gracefully, if possible
+mariadb --defaults-file=/etc/mysql/debian.cnf -e 'SET GLOBAL innodb_max_purge_lag_wait=0' || true
 
 # Modified dh_systemd_start snippet that's not added automatically
 if [ -d /run/systemd/system ]; then


### PR DESCRIPTION
If MariaDB Server is removed/purged (and the next version is unknown) or
if it is upgraded so that the minor version changes (not just Debian
revision), then run a safe (but slower) shutdown procedure to ensure data
is properly written to disk and next startup on a new binary and or
a mariadb-upgrade run will run as smoothly as possible.

**Work-in-progress - do not merge, no review requested**