### PR TITLE
Deb: Innotop: Add support for MariaDB 10.5+

### DIFF
--- a/debian/additions/innotop/innotop
+++ b/debian/additions/innotop/innotop
@@ -466,7 +466,7 @@ sub parse_status_text {
    # too many locks to print, the output might be truncated)
 
    my $time_text;
-   if ( ($mysqlversion =~ /^5\.[67]\./) || ($mysqlversion =~ /^10\.[012]\./) ) {
+   if ( ($mysqlversion =~ /^5\.[67]\./) || ($mysqlversion =~ /^10\.[0-9]\./) ) {
       ( $time_text ) = $fulltext =~ m/^([0-9-]* [0-9:]*) [0-9a-fx]* INNODB MONITOR OUTPUT/m;
       $innodb_data{'ts'} = [ parse_innodb_timestamp_56( $time_text ) ];
    } else {
@@ -634,7 +634,7 @@ sub parse_fk_section {
    return 0 unless $fulltext;
 
    my ( $ts, $type );
-   if ( ($mysqlversion =~ /^5.[67]\./) || ($mysqlversion =~ /^10.[012]\./) ) {
+   if ( ($mysqlversion =~ /^5.[67]\./) || ($mysqlversion =~ /^10.[0-9]\./) ) {
       ( $ts, $type ) = $fulltext =~ m/^([0-9-]* [0-9:]*)\s[0-9a-fx]*\s+(\w+)/m;
       $section->{'ts'} = [ parse_innodb_timestamp_56( $ts ) ];
    } else {
@@ -894,7 +894,7 @@ sub parse_dl_section {
    my ( $ts ) = $fulltext =~ m/^$s$/m;
    return 0 unless $ts;
 
-   if ( ($mysqlversion =~ /^5\.[67]\./) || ($mysqlversion =~ /^10\.[012]\./) ) {
+   if ( ($mysqlversion =~ /^5\.[67]\./) || ($mysqlversion =~ /^10\.[0-9]\./) ) {
       $dl->{'ts'} = [ parse_innodb_timestamp_56( $ts ) ];
    }
    else {
@@ -12064,7 +12064,7 @@ This data is from the TRANSACTIONS section of SHOW INNODB STATUS.
 
 =item IO_THREADS
 
-This data is from the list of threads in the the FILE I/O section of SHOW INNODB
+This data is from the list of threads in the FILE I/O section of SHOW INNODB
 STATUS.
 
 =item INNODB_LOCKS

--- a/debian/additions/innotop/innotop.1
+++ b/debian/additions/innotop/innotop.1
@@ -2048,7 +2048,7 @@ the processlist.
 This data is from the \s-1TRANSACTIONS\s0 section of \s-1SHOW INNODB STATUS.\s0
 .IP "\s-1IO_THREADS\s0" 4
 .IX Item "IO_THREADS"
-This data is from the list of threads in the the \s-1FILE I/O\s0 section of \s-1SHOW INNODB
+This data is from the list of threads in the \s-1FILE I/O\s0 section of \s-1SHOW INNODB
 STATUS.\s0
 .IP "\s-1INNODB_LOCKS\s0" 4
 .IX Item "INNODB_LOCKS"


### PR DESCRIPTION
Synced from downstream Debian:
https://salsa.debian.org/mariadb-team/mariadb-10.5/-/commit/7015e8e4b5ed3a7727a8e442039fceb2c5b1a6b9

Also fix two spelling errors.