### PR TITLE
Deb: Misc cleanup and autobake-deb.sh and Salsa-CI fixes

### DIFF
--- a/debian/mariadb-server-10.5.README.Debian
+++ b/debian/mariadb-server-10.5.README.Debian
@@ -31,13 +31,13 @@ name has been kept as a symbolic link to the new name for backwards compatibilit
 * NATIVE SYSTEMD SERVICE INTRODUCED IN MARIADB 10.1
 ===================================================
 
-From MariaDB 10.1 onwards the upstream mariadb.service and mariadb@.service are
+From MariaDB 10.1 onward the upstream mariadb.service and mariadb@.service are
 used to provide the full systemd experience. Some features available in
 traditional /etc/init.d/mysql have been changed. For details see
 https://mariadb.com/kb/en/mariadb/systemd/
 
 
-* MIXING PACKAGES FROM MARIAD.ORG AND OFFICIAL DEBIAN REPOSITORIES
+* MIXING PACKAGES FROM MARIADB.ORG AND OFFICIAL DEBIAN REPOSITORIES
 ==================================================================
 
 Please note that the MariaDB packaging in official Debian repositories are of
@@ -57,7 +57,7 @@ revision string.
 
 On new installs no root password is set and no debian-sys-maint user is
 created anymore. Instead the MariaDB root account is set to be authenticated
-using the unix socket, e.g. any mysqld invocation by root or via sudo will
+using the Unix socket, e.g. any mysqld invocation by root or via sudo will
 let the user see the mysqld prompt.
 
 You may never ever delete the mysql user "root". Although it has no password
@@ -65,7 +65,7 @@ is set, the unix_auth plugin ensure that it can only be run locally as the root
 user.
 
 The credentials in /etc/mysql/debian.cnf specify the user which is used by the
-init scripts to stop the server and perform logrotation. This used to be the
+init scripts to stop the server and perform log rotation. This used to be the
 debian-sys-maint user which is no longer used as root can run directly.
 
 If you have start/stop problems make sure that the /etc/mysql/debian.cnf file
@@ -79,7 +79,7 @@ file as is has been obsoleted.
 MariaDB in Debian is secure by default, because:
 
 - It only listens to the localhost socket and cannot be accessed remotely unless
-  the sysadmin changes the configurationin /etc/mysql to allow so.
+  the sysadmin changes the configuration in /etc/mysql to allow so.
 - There is no debian-sys-maint with password in /etc/mysql/debian.cnf anymore.
 - There is no root account with password anymore. The system admin needs to
   create one themselves if they need it. With no password, all issues related
@@ -141,9 +141,9 @@ https://mariadb.com/kb
 It is recommended you create additional admin users for your database
 administration needs in addition to the default root user.
 
-If your local unix account is the one you want to have local super user
+If your local Unix account is the one you want to have local super user
 access on your database with you can create the following account that will
-only work for the local unix user connecting to the database locally.
+only work for the local Unix user connecting to the database locally.
 
   sudo /usr/bin/mysql -e "GRANT ALL ON *.* TO '$USER'@'localhost' IDENTIFIED VIA unix_socket WITH GRANT OPTION"
 
@@ -176,7 +176,7 @@ https://mariadb.com/kb/en/configuring-mariadb-with-mycnf/.
 ==============================
 
 If the MySQL server is acting as a replication slave, you should not
-set --tmpdir to point to a directory on a memory-based filesystem or to
+set --tmpdir to point to a directory on a memory-based file system or to
 a directory that is cleared when the server host restarts. A replication
 slave needs some of its temporary files to survive a machine restart so
 that it can replicate temporary tables or LOAD DATA INFILE operations. If

--- a/debian/mariadb-server-10.5.mysql.default
+++ b/debian/mariadb-server-10.5.mysql.default
@@ -1,9 +1,9 @@
 #
 # NOTE: This file is read only by the traditional SysV init script.
-# Debian 9 and Ubuntu 17.04 onwards do not normally read this file as they use
+# Debian 9 and Ubuntu 17.04 onward do not normally read this file as they use
 # systemd by default.
 #
-# For similar behaviour, systemd users should override ExecStart by dropping
+# For similar behavior, systemd users should override ExecStart by dropping
 # files into /etc/systemd/system/mariadb.service.d/
 #
 # See also:

--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -36,7 +36,7 @@ case "$1" in
     # latest 'mariadb' file. This has also the added benefit that anything that
     # invokes traditional sysv init with either 'mysql' or 'mariadb' will end up
     # controlling this newly installed MariaDB, and thus we maintain better
-    # backwards compatiblity.
+    # backwards compatibility.
     #
     # Note that the 'Provides' line is also updated to avoid 'insserv' exiting
     # on failure (when it is run by update-rc.d) because of duplicate service

--- a/debian/rules
+++ b/debian/rules
@@ -143,7 +143,7 @@ endif
 	# If mariadb-test package is removed, also remove most of it's files
 	grep --quiet "Package: mariadb-test" debian/control || rm -rf $(TMP)/usr/share/mysql/mysql-test
 
-	# Delete private files from libraries so they don't get shipped in the -dev pacakges
+	# Delete private files from libraries so they don't get shipped in the -dev packages
 	rm -r $(TMP)/usr/include/mariadb/server/private
 
 	# Don't ship sql-bench at all, just delete it completely even though it builds

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -69,9 +69,6 @@ build i386:
   image: $SALSA_CI_IMAGES_BASE_I386
   variables:
     ARCH: 'i386'
-  except:
-    variables:
-      - $SALSA_CI_DISABLE_BUILD_PACKAGE_I386 =~ /^(1|yes|true)$/
 
 build native deb:
   extends: .build-package
@@ -545,8 +542,6 @@ mysql-8.0 Sid to mariadb-10.5 upgrade:
   except:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-  # Installation often fails (not a MariaDB reason), so do not require this test to pass
-  allow_failure: true
 
 # Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
 # The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
@@ -638,12 +633,12 @@ mariadb.org-10.5 to mariadb-10.5 upgrade:
     - echo 'deb http://mirror.one.com/mariadb/repo/10.5/debian sid main' > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - *test-install-readline-in-sid-for-backwards-compat
-    # The 10.5.9 relase is missing mariadb-plugin-columnstore, define all other packages but it to avoid hitting the error:
+    # The 10.5.9 release is missing mariadb-plugin-columnstore, define all other packages but it to avoid hitting the error:
     #   The following packages have unmet dependencies:
     #   mariadb-plugin-columnstore : Depends: mariadb-server-10.5 (= 1:10.5.8+maria~sid) but 1:10.5.9+maria~sid is to be installed
     - apt-get install -y libmariadb3 'libmariadb-*' 'libmariadbd*' 'mariadb-c*' 'mariadb-b*' 'mariadb-s*' 'mariadb-t*' 'mariadb-plugin-con*' 'mariadb-plugin-cr*' 'mariadb-plugin-g*' 'mariadb-plugin-m*' 'mariadb-plugin-o*' 'mariadb-plugin-s*'
     # Once 10.5.10 is out, revert back to:
-    # Package libmariadbclient-dev from mariadb.org conficts with libmariadb-dev in Sid, so cannot use wildcard that would include it
+    # Package libmariadbclient-dev from mariadb.org conflicts with libmariadb-dev in Sid, so cannot use wildcard that would include it
     #- apt-get install -y 'mariadb*' libmariadb3 'libmariadb-*' 'libmariadbd*'
     - *test-verify-initial
     # Install MariaDB built in this commit

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,7 +1,7 @@
 Tests: smoke
 # RocksDB is not built for all archs. Rather than duplicating the condition
 # for its existence (see the list in debian/control), install it if available
-# and check in the test if it's funcational when it should be.
+# and check in the test if it's functional when it should be.
 # The plugin package also already depends on the other one.
 Depends: mariadb-plugin-rocksdb | mariadb-server-10.5
 Restrictions: allow-stderr needs-root isolation-container

--- a/debian/tests/smoke
+++ b/debian/tests/smoke
@@ -31,7 +31,7 @@ if ! which systemctl
 then
   if ! /etc/init.d/mariadb status
   then
-    echo "Did not find systemctl and deamon was not running, starting it.."
+    echo "Did not find systemctl and daemon was not running, starting it.."
     /etc/init.d/mariadb start
   fi
 else


### PR DESCRIPTION
* Clean up autobake-deb.sh

  - No need to define any TokuDB rules, there is no such package
  - No need to define RocksDB arch, it already has "Architecture:" line
  - No need to dh-systemd backwards compat stanza, neither Debian Jessie
    nor Ubuntu Xenial has any new MariaDB 10.5 releases anymore
  - Minor spelling fixes

* Ensure dch runs non-interactively so builds pass with new dch version

  A recent version of dch (available in Ubuntu Hirsute and Debian Bullseye)
  had a change in behaviour that it started prompting if the DEBEMAIL or
  EMAIL variable as unset, asking for confirmation. We can't have anything
  interactive in our build scripts, so prevent this prompt by giving
  --controlmaint to the command, so it always uses the name and email from
  the debian/control file and does not prompt anything.

  The command-line argument has been around for a long time, so it is safe
  to use on all Debian/Ubuntu builds we have.

  See https://manpages.debian.org/jessie/devscripts/dch.1.en.html

  Since MariaDB 10.5 is the oldest release we still release for Ubuntu Hisute
  and Debian Bullseye, merge this on 10.5 and from there merge up to latest.
  No need to consider 10.2, 10.3 and 10.4 as those will not be released for
  Ubuntu Bullseye or Ubuntu Hirsute.

* Minor Salsa-CI cleanup

  - Fix spelling (synced from downstream Debian)
  - Extend with libmariadb-dev using test to verify client library
    continues to work and actually can be used to compile a program

* Many minor spelling fixes (synced from downstream Debian)