### PR TITLE
my_thread: Use unsigned long long for storing pthread IDs

### DIFF
--- a/storage/perfschema/my_thread.h
+++ b/storage/perfschema/my_thread.h
@@ -17,7 +17,7 @@
 typedef pthread_key_t thread_local_key_t;
 typedef pthread_t my_thread_handle;
 typedef pthread_attr_t my_thread_attr_t;
-typedef uint32 my_thread_os_id_t;
+typedef unsigned long long my_thread_os_id_t;
 
 #define LOCK_plugin_delete LOCK_plugin
 
@@ -73,7 +73,7 @@ static inline my_thread_os_id_t my_thread_os_id()
 #else
 #ifdef HAVE_INTEGER_PTHREAD_SELF
   /* Unknown platform, fallback. */
-  return pthread_self();
+  return (unsigned long long)pthread_self();
 #else
   /* Feature not available. */
   return 0;


### PR DESCRIPTION
This is a fix for operating systems that have pthread_t defined
as a pointer and use the default pthread_self() mechanism for
identifying threads. More specifically, this is a build fix
for NetBSD.

Any changes I submit are freely available under the new BSD
license.

Signed-off-by: Nia Alarie <nia@NetBSD.org>