### PR TITLE
Support future NetBSD kqueue versions

### DIFF
--- a/sql/threadpool_generic.cc
+++ b/sql/threadpool_generic.cc
@@ -234,14 +234,19 @@ static void *native_event_get_userdata(native_event *event)
 #elif defined(HAVE_KQUEUE)
 
 /*
-  NetBSD is incompatible with other BSDs , last parameter in EV_SET macro
-  (udata, user data) needs to be intptr_t, whereas it needs to be void*
-  everywhere else.
+  NetBSD prior to 9.99.17 is incompatible with other BSDs, last parameter
+  in EV_SET macro (udata, user data) needs to be intptr_t, whereas it needs
+  to be void* everywhere else.
 */
 
 #ifdef __NetBSD__
+#include <sys/param.h>
+#  if !__NetBSD_Prereq__(9,99,17)
 #define MY_EV_SET(a, b, c, d, e, f, g) EV_SET(a, b, c, d, e, f, (intptr_t)g)
-#else
+#  endif
+#endif
+
+#ifndef MY_EV_SET
 #define MY_EV_SET(a, b, c, d, e, f, g) EV_SET(a, b, c, d, e, f, g)
 #endif
 


### PR DESCRIPTION
In NetBSD 9.x and prior, udata is an intptr_t, but in 10.x (current
development branch) it was changed to be a void * for compatibility
with other BSDs a year or so ago.

Unfortunately, this does not simplify the code, as NetBSD 8.x and 9.x
are still supported and will be for a few more years.

All of my contributions are freely available under the new BSD license.