### PR TITLE
Fix malloc/delete mismatch. This causes a double free in the cleanup of the event scheduler.

### DIFF
--- a/sql/event_scheduler.cc
+++ b/sql/event_scheduler.cc
@@ -448,7 +448,7 @@ Event_scheduler::start(int *err_no)
     scheduler_thd= NULL;
     deinit_event_thread(new_thd);
 
-    delete scheduler_param_value;
+    my_free(scheduler_param_value);
     ret= true;
   }
 


### PR DESCRIPTION
## Description
Due to a malloc/delete mismatch a double free is happening in the cleanup of the event scheduler. This can be triggered once an event is scheduled with a huge thread_stack size.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*


## Backward compatibility
Should be backwards compatible.

