### PR TITLE
MDEV-25698 SIGSEGV in wsrep_should_replicate_ddl

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_mode.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_mode.result
@@ -10,3 +10,7 @@ Warning	1290	WSREP: wsrep_mode = REQUIRED_PRIMARY_KEY enabled. Table should have
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 DROP TABLE t1;
 SET GLOBAL wsrep_mode = default;
+SET GLOBAL wsrep_mode = STRICT_REPLICATION;
+CREATE VIEW v AS SELECT * FROM JSON_TABLE ('{"a":0}',"$" COLUMNS (a DECIMAL(1,1) path '$.a')) foo;
+DROP VIEW v;
+SET GLOBAL wsrep_mode = default;

--- a/mysql-test/suite/galera/t/galera_wsrep_mode.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_mode.test
@@ -15,3 +15,11 @@ CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 DROP TABLE t1;
 SET GLOBAL wsrep_mode = default;
+
+
+# MDEV-25698 SIGSEGV in wsrep_should_replicate_ddl
+
+SET GLOBAL wsrep_mode = STRICT_REPLICATION;
+CREATE VIEW v AS SELECT * FROM JSON_TABLE ('{"a":0}',"$" COLUMNS (a DECIMAL(1,1) path '$.a')) foo;
+DROP VIEW v;
+SET GLOBAL wsrep_mode = default;

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2229,6 +2229,9 @@ bool wsrep_should_replicate_ddl(THD* thd, const handlerton *hton)
   if (!wsrep_check_mode(WSREP_MODE_STRICT_REPLICATION))
     return true;
 
+  if (!hton)
+    return true;
+
   switch (hton->db_type)
   {
     case DB_TYPE_INNODB:


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25698*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: Internal temporary tables doesn't have hton set, so using function can lead to dereferencing NULL pointer.

## How can this PR be tested?
TODO: Extended galera.galera_wsrep_mode MTR 

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


