### PR TITLE
Revert "CONNECT: move jar files to /usr/share and include them in DEBs"

### DIFF
--- a/debian/mariadb-plugin-connect.install
+++ b/debian/mariadb-plugin-connect.install
@@ -1,6 +1,2 @@
 etc/mysql/conf.d/connect.cnf
 usr/lib/mysql/plugin/ha_connect.so
-usr/share/mysql/Mongo2.jar
-usr/share/mysql/Mongo3.jar
-usr/share/mysql/JavaWrappers.jar
-usr/share/mysql/JdbcInterface.jar


### PR DESCRIPTION
This partially reverts commit d7321893d8c50071632a102e17a7869da9cb03a5.

The *.jar files are not being built and all Debian builds are failing
as dh_install stops on missing files. To build them we would need to also
add new Java build dependencies.

In a stable release (10.2->10.5) we shouldn't add new files and certainly
not any new build dependencies, so reverting commit.

Also, the files are located in a different path, and already included
in the mariadb-test-data package:

  /usr/share/mysql/mysql-test/plugin/connect/connect/std_data/JavaWrappers.jar
  /usr/share/mysql/mysql-test/plugin/connect/connect/std_data/JdbcMariaDB.jar
  /usr/share/mysql/mysql-test/plugin/connect/connect/std_data/Mongo2.jar
  /usr/share/mysql/mysql-test/plugin/connect/connect/std_data/Mongo3.jar

This change needs to be redesigned and applies only on 10.6 or newer.