### PR TITLE
MDEV-26188 Extend mysqlbinlog with argument --progress-log

### DIFF
--- a/man/mysqlbinlog.1
+++ b/man/mysqlbinlog.1
@@ -752,6 +752,40 @@ Directory for client-side plugins\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mysqlbinlog: progress-log option
+.\" progress-log option: mysqlbinlog
+\fB\-\-progress\-log=\fIfile_name\fR
+.sp
+This progress log provides information on mysqlbinlog's progress in processing binlogs. If the file does not exist, it is created. If it already exists, it is appended.
+.sp
+The following information is emitted to the progress log:
+.RS 4
+OPEN  : mysqlbinlog successfully opened file.
+.RE
+.RS 4
+EOF   : The end of the file was reached before a stop condition was found. Pos should = file size.
+.RE
+.RS 4
+LAST  : The last event applied (assuming the output is being applied).
+.RE
+.RS 4
+FINAL : The last event applied before a stop condition was found. If --stop--datetime (or .stop-position) was given, this is the event that signals point-in-time restore is complete.
+.RE
+.RS 4
+STOP  : The event that satisfied the stop conditions.
+.RE
+.RS 4
+EXIT  : mysqlbinlog exited. See stderr for errors, if any.
+.fi
+.sp
+.RE
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mysqlbinlog: print-defaults option
 .\" print-defaults option: mysqlbinlog
 \fB\-\-print\-defaults\fR

--- a/mysql-test/suite/binlog/r/binlog_mysqlbinlog_progress_log.result
+++ b/mysql-test/suite/binlog/r/binlog_mysqlbinlog_progress_log.result
@@ -1,0 +1,94 @@
+reset master;
+set timestamp=1000000000;
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+update t1 set a=a+2 where a=2;
+update t1 set a=a+2 where a=3;
+flush logs;
+
+--- parse binlog and verify progress-log ---
+--- binlog output ---
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
+/*!40019 SET @@session.max_insert_delayed_threads=0*/;
+/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
+DELIMITER /*!*/;
+ROLLBACK/*!*/;
+use `test`/*!*/;
+SET TIMESTAMP=1000000000/*!*/;
+SET @@session.pseudo_thread_id=999999999/*!*/;
+SET @@session.foreign_key_checks=1, @@session.sql_auto_is_null=0, @@session.unique_checks=1, @@session.autocommit=1, @@session.check_constraint_checks=1, @@session.sql_if_exists=0/*!*/;
+SET @@session.sql_mode=1411383296/*!*/;
+SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/;
+/*!\C latin1 *//*!*/;
+SET @@session.character_set_client=8,@@session.collation_connection=8,@@session.collation_server=8/*!*/;
+SET @@session.lc_time_names=0/*!*/;
+SET @@session.collation_database=DEFAULT/*!*/;
+create table t1 (a int)
+/*!*/;
+START TRANSACTION
+/*!*/;
+# Annotate_rows:
+#Q> insert into t1 values (1)
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+START TRANSACTION
+/*!*/;
+# Annotate_rows:
+#Q> insert into t1 values (2)
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+START TRANSACTION
+/*!*/;
+# Annotate_rows:
+#Q> insert into t1 values (3)
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+START TRANSACTION
+/*!*/;
+# Annotate_rows:
+#Q> update t1 set a=a+2 where a=2
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+START TRANSACTION
+/*!*/;
+# Annotate_rows:
+#Q> update t1 set a=a+2 where a=3
+SET TIMESTAMP=1000000000/*!*/;
+COMMIT
+/*!*/;
+DELIMITER ;
+# End of log file
+ROLLBACK /* added by mysqlbinlog */;
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
+
+--- progress log output ---
+# OPEN /master-bin.000001 with starting position 4
+# EOF reached on /master-bin.000001 at position 1768
+# LAST applied event: logfile /master-bin.000001 Time: XXX Pos: 1720
+EXIT
+
+--- parse binlog with --stop-position and verify progress-log ---
+--- binlog output ---
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
+/*!40019 SET @@session.max_insert_delayed_threads=0*/;
+/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
+DELIMITER /*!*/;
+ROLLBACK/*!*/;
+DELIMITER ;
+# End of log file
+ROLLBACK /* added by mysqlbinlog */;
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
+
+--- progress log output ---
+# OPEN /master-bin.000001 with starting position 256
+# FINAL applied event: logfile /master-bin.000001 Time: XXX Pos: 256
+# STOP event (not applied): logfile /master-bin.000001 Time: XXX Pos: 285
+EXIT

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_progress_log.test
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_progress_log.test
@@ -1,0 +1,57 @@
+-- source include/have_binlog_format_row.inc
+-- source include/binlog_start_pos.inc
+
+#
+# Reset master to cleanup binlog
+#
+reset master;
+set timestamp=1000000000;
+
+#
+#  Write different events to binlog
+#
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+insert into t1 values (3);
+update t1 set a=a+2 where a=2;
+update t1 set a=a+2 where a=3;
+
+#
+#  Save binlog
+#
+flush logs;
+
+
+let $MYSQLD_DATADIR=`select @@datadir`;
+let $start_pos= `select @binlog_start_pos`;
+let $stop_pos= `select @binlog_start_pos + 1`;
+
+
+--echo
+--echo --- parse binlog and verify progress-log ---
+--enable_query_log
+--echo --- binlog output ---
+--exec $MYSQL_BINLOG --short-form $MYSQLD_DATADIR/master-bin.000001 --progress-log $MYSQLTEST_VARDIR/tmp/progress_log_1.event
+--echo
+--echo --- progress log output ---
+--replace_result $MYSQLD_DATADIR ""
+--replace_regex /Time.+Pos/Time: XXX Pos/
+--exec cat $MYSQLTEST_VARDIR/tmp/progress_log_1.event
+--disable_query_log
+
+
+--echo
+--echo --- parse binlog with --stop-position and verify progress-log ---
+--enable_query_log
+--echo --- binlog output ---
+--exec $MYSQL_BINLOG --short-form --start-position=$start_pos --stop-position $stop_pos $MYSQLD_DATADIR/master-bin.000001 --progress-log $MYSQLTEST_VARDIR/tmp/progress_log_2.event
+--echo
+--echo --- progress log output ---
+--replace_result $MYSQLD_DATADIR ""
+--replace_regex /Time.+Pos/Time: XXX Pos/
+--exec cat $MYSQLTEST_VARDIR/tmp/progress_log_2.event
+--disable_query_log
+
+drop table t1;
+RESET MASTER;


### PR DESCRIPTION
## Description
Binlogs can be very large and processing them might take a long time without visible activity. Enabling users to get progress updates written in a logfile makes it possible to follow the progress of mysqlbinlog by humans and programmatic systems.
Commit includes a test and also updates the man page.
## How can this PR be tested?
Execute the binlog suite in mysql-test-run. This commit adds a test in that suite.
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
This is a new feature that should go into 10.7 or any later new release of MariaDB. It is unlikely to introduce any side-effects as other parts of the server do not use the `--progress` code path.
## Backward compatibility
This is a new feature introducing a new command-line argument that should not affect backwards compatibility.
## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.