### PR TITLE
Detect logical space amplification of storage device with transparent compression

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -187,7 +187,7 @@ void my_init_atomic_write(void);
 my_bool my_test_if_atomic_write(File handle, int pagesize);
 my_bool my_test_if_disable_punch_hole(File handle);
 #else
-#define my_test_if_atomic_write(A, B) 0
+#define my_test_if_atomic_write(A, B)       0
 #define my_test_if_disable_punch_hole(A, B) 0
 #endif /* __linux__ */
 extern my_bool my_may_have_atomic_write;

--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -188,7 +188,7 @@ my_bool my_test_if_atomic_write(File handle, int pagesize);
 my_bool my_test_if_disable_punch_hole(File handle);
 #else
 #define my_test_if_atomic_write(A, B)       0
-#define my_test_if_disable_punch_hole(A, B) 0
+#define my_test_if_disable_punch_hole(A)    0
 #endif /* __linux__ */
 extern my_bool my_may_have_atomic_write;
 

--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -185,8 +185,10 @@ extern BOOL my_obtain_privilege(LPCSTR lpPrivilege);
 void my_init_atomic_write(void);
 #ifdef __linux__
 my_bool my_test_if_atomic_write(File handle, int pagesize);
+my_bool my_test_if_disable_punch_hole(File handle);
 #else
 #define my_test_if_atomic_write(A, B) 0
+#define my_test_if_disable_punch_hole(A, B) 0
 #endif /* __linux__ */
 extern my_bool my_may_have_atomic_write;
 

--- a/mysys/my_atomic_writes.c
+++ b/mysys/my_atomic_writes.c
@@ -269,7 +269,7 @@ static my_bool shannon_has_atomic_write(File file, int page_size)
 
 /**
   Threshold for logical_space / physical_space
-  No less than the threshold means we can disable hole punch
+  No less than the threshold means we can disable hole punching
 */
 #define SFX_DISABLE_PUNCH_HOLE_RATIO (2)
 

--- a/mysys/my_atomic_writes.c
+++ b/mysys/my_atomic_writes.c
@@ -21,6 +21,7 @@ my_bool my_may_have_atomic_write= IF_WIN(1,0);
 
 my_bool has_shannon_atomic_write= 0, has_fusion_io_atomic_write= 0,
         has_sfx_atomic_write= 0;
+my_bool has_sfx_card= 0;
 
 #include <sys/ioctl.h>
 
@@ -254,20 +255,30 @@ static my_bool shannon_has_atomic_write(File file, int page_size)
  return 0;
 }
 
-
 /***********************************************************************
   ScaleFlux
 ************************************************************************/
 
-#define SFX_GET_ATOMIC_SIZE  _IO('N', 0x244)
-#define SFX_MAX_DEVICES 32
-#define SFX_NO_ATOMIC_SIZE_YET -2
+#define SFX_GET_ATOMIC_SIZE          _IOR('N', 0x243, int)
+#define SFX_MAX_DEVICES              (32)
+#define SFX_UNKNOWN_ATOMIC_WRITE_YET (-2)
+#define SFX_MAX_ATOMIC_SIZE          (256 * 1024)
+
+#define SFX_GET_SPACE_RATIO          _IO('N', 0x244)
+#define SFX_UNKNOWN_PUNCH_HOLE_YET   (-3)
+
+/**
+  Threshold for logical_space / physical_space
+  No less than the threshold means we can disable hole punch
+*/
+#define SFX_DISABLE_PUNCH_HOLE_RATIO (2)
 
 struct sfx_dev
 {
   char dev_name[32];
   dev_t st_dev;
-  int atomic_size;
+  int atomic_write;
+  int disable_punch_hole;
 };
 
 static struct sfx_dev sfx_devices[SFX_MAX_DEVICES + 1];
@@ -275,7 +286,8 @@ static struct sfx_dev sfx_devices[SFX_MAX_DEVICES + 1];
 /**
    Check if the system has a ScaleFlux card
    If card exists, record device numbers to allow us to later check if
-   a given file is on this device.
+   a given file is on this device
+   Variables for atomic_write and disable_punch_hole will be initialized
    @return TRUE   Card exists
 */
 
@@ -299,35 +311,41 @@ static my_bool test_if_sfx_card_exists()
       The atomic size will be checked on first access. This is needed
       as a normal user can't open the /dev/sfdvXn1 file
     */
-    sfx_devices[sfx_found_devices].atomic_size = SFX_NO_ATOMIC_SIZE_YET;
+    sfx_devices[sfx_found_devices].atomic_write = SFX_UNKNOWN_ATOMIC_WRITE_YET;
+    sfx_devices[sfx_found_devices].disable_punch_hole = SFX_UNKNOWN_PUNCH_HOLE_YET;
     if (++sfx_found_devices == SFX_MAX_DEVICES)
       goto end;
   }
 end:
   sfx_devices[sfx_found_devices].st_dev= 0;
+  has_sfx_card = (sfx_found_devices > 0);
+
   return sfx_found_devices > 0;
 }
 
 static my_bool sfx_dev_has_atomic_write(struct sfx_dev *dev,
                                             int page_size)
 {
-  if (dev->atomic_size == SFX_NO_ATOMIC_SIZE_YET)
+  int result = -1, max_atomic_size = SFX_MAX_ATOMIC_SIZE;
+
+  if (dev->atomic_write == SFX_UNKNOWN_ATOMIC_WRITE_YET)
   {
     int fd= open(dev->dev_name, 0);
     if (fd < 0)
     {
       perror("open() failed!");
-      dev->atomic_size= 0;                      /* Don't try again */
+      dev->atomic_write= 0;                      /* Don't try again */
       return FALSE;
     }
 
-    dev->atomic_size= ioctl(fd, SFX_GET_ATOMIC_SIZE);
+    result= ioctl(fd, SFX_GET_ATOMIC_SIZE, &max_atomic_size);
     close(fd);
+
+    dev->atomic_write= ((result == 0) && (page_size <= max_atomic_size));
   }
 
-  return (page_size <= dev->atomic_size);
+  return dev->atomic_write;
 }
-
 
 /**
    Check if a file is on a ScaleFlux device and that it supports atomic_write
@@ -336,9 +354,9 @@ static my_bool sfx_dev_has_atomic_write(struct sfx_dev *dev,
    @return TRUE                 Atomic write supported
 
    @notes
-   This is called only at first open of a file.  In this case it's doesn't
-   matter so much that we loop over all cards.
-   We update the atomic size on first access.
+   This is called only at first open of a file. In this case it's doesn't
+   matter so much that we loop over all cards
+   We update the atomic size on first access
 */
 
 static my_bool sfx_has_atomic_write(File file, int page_size)
@@ -358,12 +376,68 @@ static my_bool sfx_has_atomic_write(File file, int page_size)
   }
   return 0;
 }
+
+static my_bool sfx_dev_could_disable_punch_hole(struct sfx_dev *dev, File file)
+{
+  int result = 0;
+
+  if (dev->disable_punch_hole == SFX_UNKNOWN_PUNCH_HOLE_YET)
+  {
+    int fd= open(dev->dev_name, 0);
+    if (fd < 0)
+    {
+      perror("open() failed!");
+      dev->disable_punch_hole= 0;                      /* Don't try again */
+      return FALSE;
+    }
+
+    /*
+      Ratio left-shifts 8 (multiplies 256) inside the ioctl;
+      will also add 1 to guarantee a round-up integer.
+    */
+    result= ioctl(fd, SFX_GET_SPACE_RATIO);
+    result+= 1;
+    dev->disable_punch_hole= (result >= (((double)SFX_DISABLE_PUNCH_HOLE_RATIO) * 256));
+  }
+
+  return dev->disable_punch_hole;
+}
+
+/**
+   Check if a file is on a ScaleFlux device and whether it is possible to
+   disable hole punch.
+   @param[in] file              OS file handle
+   @return TRUE                 Could disable hole punch
+
+   @notes
+   This is called only at first open of a file. In this case it's doesn't
+   matter so much that we loop over all cards
+*/
+
+static my_bool sfx_could_disable_punch_hole(File file)
+{
+  struct sfx_dev *dev;
+  struct stat stat_buff;
+
+  if (fstat(file, &stat_buff) < 0)
+  {
+    return 0;
+  }
+
+  for (dev = sfx_devices; dev->st_dev; dev++)
+  {
+    if (stat_buff.st_dev == dev->st_dev)
+      return sfx_dev_could_disable_punch_hole(dev, file);
+  }
+  return 0;
+}
+
 /***********************************************************************
   Generic atomic write code
 ************************************************************************/
 
-/*
-  Initialize automic write sub systems.
+/**
+  Initialize automic write sub systems
   Checks if we have any devices that supports atomic write
 */
 
@@ -380,7 +454,6 @@ void my_init_atomic_write(void)
           my_may_have_atomic_write);
 #endif
 }
-
 
 /**
   Check if a file supports atomic write
@@ -410,6 +483,21 @@ my_bool my_test_if_atomic_write(File handle, int page_size)
 
   if (has_sfx_atomic_write &&
       sfx_has_atomic_write(handle, page_size))
+    return 1;
+
+  return 0;
+}
+
+/**
+  Check if a file could disable hole punch
+
+  @return FALSE   File cannot disable hole punch
+          TRUE    File could disable hole punch
+*/
+
+my_bool my_test_if_disable_punch_hole(File handle)
+{
+  if (has_sfx_card && sfx_could_disable_punch_hole(handle))
     return 1;
 
   return 0;

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -947,7 +947,8 @@ static bool buf_flush_page(buf_page_t *bpage, bool lru, fil_space_t *space)
     else
       buf_pool.n_flush_list++;
 
-    /* Write data with uncompressed size when hole punching disabled. */
+    /* Write data with uncompressed size when hole punching disabled. In 
+    such case, the compressed page is padded with 0 to uncompressed size. */
     if (space->punch_hole) {
       if (status != buf_page_t::NORMAL || !space->use_doublewrite())
         space->io(IORequest(type, bpage),

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -892,7 +892,9 @@ static bool buf_flush_page(buf_page_t *bpage, bool lru, fil_space_t *space)
 #if defined HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE || defined _WIN32
     size_t orig_size;
 #endif
+#ifdef UNIV_LINUX
     size_t write_size;
+#endif
 
     IORequest::Type type= lru ? IORequest::WRITE_LRU : IORequest::WRITE_ASYNC;
 
@@ -904,7 +906,9 @@ static bool buf_flush_page(buf_page_t *bpage, bool lru, fil_space_t *space)
 #if defined HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE || defined _WIN32
       orig_size= size;
 #endif
+#ifdef UNIV_LINUX
       write_size= size;
+#endif
       buf_flush_update_zip_checksum(frame, size);
       frame= buf_page_encrypt(space, bpage, frame, &size);
       ut_ad(size == bpage->zip_size());
@@ -916,8 +920,9 @@ static bool buf_flush_page(buf_page_t *bpage, bool lru, fil_space_t *space)
 #if defined HAVE_FALLOC_PUNCH_HOLE_AND_KEEP_SIZE || defined _WIN32
       orig_size= size;
 #endif
+#ifdef UNIV_LINUX
       write_size= size;
-
+#endif
       if (space->full_crc32())
       {
         /* innodb_checksum_algorithm=full_crc32 is not implemented for

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2044,7 +2044,7 @@ fil_ibd_create(
 	}
 
 	const bool is_compressed = fil_space_t::is_compressed(flags);
-	bool punch_hole = is_compressed;
+	bool punch_hole = is_compressed && !my_test_if_disable_punch_hole(file);
 	fil_space_crypt_t* crypt_data = nullptr;
 #ifdef _WIN32
 	if (is_compressed) {

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -3436,7 +3436,11 @@ fil_iterate(
 	required by buf_zip_decompress() */
 	dberr_t		err = DB_SUCCESS;
 	bool		page_compressed = false;
+#ifdef UNIV_LINUX
+	bool		punch_hole = !my_test_if_disable_punch_hole(iter.file);
+#else
 	bool		punch_hole = true;
+#endif
 
 	for (offset = iter.start; offset < iter.end; offset += n_bytes) {
 		if (callback.is_interrupted()) {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
1. This patch is to detect logical space amplification of storage device with transparent compression. The goal is to disable hole punching when logical space amplification is large enough, say 2x the physical space. An example is like this: MariaDB turns on compression and a 16KB data page is compressed to 9KB; instead of punching hole to save storage space, MariaDB could still write 16KB data page (9KB compressed data + 7KB zero's) to storage device; with transparent compression, the 7KB zero's can still be highly compressed without wasting physical space.
2. Output unchanged.
3. There should be no side-effects in other parts of the server.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ x ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
1. This does not affect the on-disk format used by MariaDB.
2. This does not change any behavior experienced by a user who upgrades from a version prior to this patch.
3. A user would still be able to start MariaDB on a datadir created prior to this patch.
