### PR TITLE
MDEV-25760: resubmit IO job on -EAGAIN error code from io_uring.

### DIFF
--- a/tpool/aio_liburing.cc
+++ b/tpool/aio_liburing.cc
@@ -162,6 +162,13 @@ private:
 
       io_uring_cqe_seen(&aio->uring_, cqe);
 
+      if (res == -EAGAIN) {
+        // If we need to resubmit the IO operation, but the ring is full,
+        // then just go the same path as for any other error codes.
+        if (!aio->submit_io(iocb))
+          continue;
+      }
+
       iocb->m_internal_task.m_func= iocb->m_callback;
       iocb->m_internal_task.m_arg= iocb;
       iocb->m_internal_task.m_group= iocb->m_group;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25760*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Resubmit IO job on -EAGAIN error code from io_uring.
The server still may abort if there is no enough free space in the
ring buffer to resubmit the IO job, but the behavior is equal to
the failure of os_aio() -> submit_io().


## How can this PR be tested?
The test scenario is described in https://jira.mariadb.org/browse/MDEV-25760 . Basically, I need several runs of `sysbench-tpcc prepare` to hit the bug.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
