### PR TITLE
First Prototype

### DIFF
--- a/mysql-test/main/sformat.result
+++ b/mysql-test/main/sformat.result
@@ -1,0 +1,9 @@
+select sformat("string test");
+sformat("string test")
+string test
+select sformat('string test');
+sformat('string test')
+string test
+select sformat('string test') from dual;
+sformat('string test')
+string test

--- a/mysql-test/main/sformat.test
+++ b/mysql-test/main/sformat.test
@@ -1,0 +1,7 @@
+# Description
+# -----------
+# Test cases for the sformat function
+
+select sformat("string test");
+select sformat('string test');
+select sformat('string test') from dual;

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -1896,6 +1896,17 @@ protected:
   virtual ~Create_func_sec_to_time() {}
 };
 
+class Create_func_sformat : public Create_func_arg1
+{
+public:
+  virtual Item *create_1_arg(THD *thd, Item *arg1);
+
+  static Create_func_sformat s_singleton;
+
+protected:
+  Create_func_sformat() {}
+  virtual ~Create_func_sformat() {}
+};
 
 class Create_func_sha : public Create_func_arg1
 {
@@ -4965,6 +4976,14 @@ Create_func_sec_to_time::create_1_arg(THD *thd, Item *arg1)
   return new (thd->mem_root) Item_func_sec_to_time(thd, arg1);
 }
 
+Create_func_sformat Create_func_sformat::s_singleton;
+
+Item*
+Create_func_sformat::create_1_arg(THD *thd, Item *arg1)
+{
+  return new (thd->mem_root) Item_func_sformat(thd, arg1);
+}
+
 
 Create_func_sha Create_func_sha::s_singleton;
 
@@ -5631,6 +5650,7 @@ static Native_func_registry func_array[] =
   { { STRING_WITH_LEN("RTRIM") }, BUILDER(Create_func_rtrim)},
   { { STRING_WITH_LEN("RTRIM_ORACLE") }, BUILDER(Create_func_rtrim_oracle)},
   { { STRING_WITH_LEN("SEC_TO_TIME") }, BUILDER(Create_func_sec_to_time)},
+  { { STRING_WITH_LEN("SFORMAT") }, BUILDER(Create_func_sformat)},
   { { STRING_WITH_LEN("SHA") }, BUILDER(Create_func_sha)},
   { { STRING_WITH_LEN("SHA1") }, BUILDER(Create_func_sha)},
   { { STRING_WITH_LEN("SHA2") }, BUILDER(Create_func_sha2)},

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -1302,6 +1302,26 @@ bool Item_func_replace::fix_length_and_dec()
 }
 
 
+bool Item_func_sformat::fix_length_and_dec()
+{
+  return FALSE;
+}
+
+String *Item_func_sformat::val_str(String *str)
+{
+  String *res;
+  DBUG_ASSERT(fixed());
+  
+  if (!(res=args[0]->val_str(str)))
+  {
+    null_value= 1;
+    return NULL;
+  }
+  return res;
+}
+
+
+
 /*********************************************************************/
 bool Item_func_regexp_replace::fix_length_and_dec()
 {

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -586,6 +586,21 @@ public:
   { return get_item_copy<Item_func_substr>(thd, this); }
 };
 
+class Item_func_sformat :public Item_str_func
+{
+public:
+  Item_func_sformat(THD *thd, Item *format): Item_str_func(thd, format) {}
+  LEX_CSTRING func_name_cstring() const override
+  {
+    static LEX_CSTRING name= {STRING_WITH_LEN("sformat") };
+    return name;
+  }
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
+  { return get_item_copy<Item_func_sformat>(thd, this); }
+};
+
 class Item_func_substr_oracle :public Item_func_substr
 {
 protected:


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25015*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
The sformat function is a custom formatting of strings in MariaDB queries. This query simplify formatting more complex strings in a SELECT statement can get awkward when there are many concat(), format(), etc calls involved.

## How can this PR be tested?
NOTE: test case is not finished
`./mysql-test/ntr sformat`

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

