### PR TITLE
MENT-1202 too eager replaying causing cluster hang

### DIFF
--- a/mysql-test/suite/galera/r/MENT-1202.result
+++ b/mysql-test/suite/galera/r/MENT-1202.result
@@ -1,0 +1,72 @@
+connection node_2;
+connection node_1;
+CREATE TABLE p (
+i VARCHAR(100) PRIMARY KEY,
+j INT
+);
+CREATE TABLE c (
+i INT PRIMARY KEY AUTO_INCREMENT,
+fk VARCHAR(100),
+KEY (fk),
+CONSTRAINT FOREIGN KEY (fk) REFERENCES p(i)
+);
+INSERT INTO p VALUES('aaaa', 0);
+INSERT INTO p VALUES('aaab', 0);
+INSERT INTO p VALUES('aaac', 0);
+SET GLOBAL wsrep_slave_threads = 3;
+SET GLOBAL DEBUG_DBUG = "d,sync.wsrep_apply_cb";
+connection node_1;
+SET SESSION wsrep_sync_wait=0;
+START TRANSACTION;
+INSERT INTO c VALUES(1, 'aaab');
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1a;
+SET SESSION wsrep_sync_wait=0;
+connection node_2;
+UPDATE p SET j = 20;
+connection node_1a;
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET GLOBAL wsrep_provider_options = 'dbug=d,apply_monitor_slave_enter_sync';
+connection node_2;
+UPDATE p SET j = 21;
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
+connection node_1;
+COMMIT;
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL DEBUG_DBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug_dbug = NULL;
+SET debug_sync='RESET';
+SET GLOBAL wsrep_provider_options = 'signal=apply_monitor_slave_enter_sync';
+SET GLOBAL wsrep_provider_options = 'dbug=';
+connection node_1;
+SELECT * FROM p;
+i	j
+aaaa	21
+aaab	21
+aaac	21
+SELECT * FROM c;
+i	fk
+1	aaab
+SET GLOBAL wsrep_slave_threads = DEFAULT;
+connection node_2;
+SELECT * FROM p;
+i	j
+aaaa	21
+aaab	21
+aaac	21
+SELECT * FROM c;
+i	fk
+1	aaab
+connection node_1;
+DROP TABLE c;
+DROP TABLE p;

--- a/mysql-test/suite/galera/t/MENT-1202.test
+++ b/mysql-test/suite/galera/t/MENT-1202.test
@@ -1,0 +1,127 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+--source include/galera_have_debug_sync.inc
+
+
+
+CREATE TABLE p (
+	i VARCHAR(100) PRIMARY KEY,
+	j INT
+);
+
+CREATE TABLE c (
+	i INT PRIMARY KEY AUTO_INCREMENT,
+	fk VARCHAR(100),
+	KEY (fk),
+	CONSTRAINT FOREIGN KEY (fk) REFERENCES p(i)
+);
+
+INSERT INTO p VALUES('aaaa', 0);
+INSERT INTO p VALUES('aaab', 0);
+INSERT INTO p VALUES('aaac', 0);
+
+
+SET GLOBAL wsrep_slave_threads = 3;
+
+# Set sync point for first UPDATE
+SET GLOBAL DEBUG_DBUG = "d,sync.wsrep_apply_cb";
+
+--connection node_1
+
+SET SESSION wsrep_sync_wait=0;
+START TRANSACTION;
+
+INSERT INTO c VALUES(1, 'aaab');
+
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+SET SESSION wsrep_sync_wait=0;
+
+
+--connection node_2
+UPDATE p SET j = 20;
+
+
+# Wait for first UPDATE to arrive in sync point
+--connection node_1a
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+
+
+# Set sync point for second UPDATE
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_set_sync_point.inc
+
+
+--connection node_2
+UPDATE p SET j = 21;
+
+
+# Wait for second UPDATE to arrive in sync point
+--connection node_1a
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Set sync point for local INSERT
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+
+
+
+--connection node_1
+--send COMMIT
+
+
+# Wait for the INSERT to arrive in sync point
+--connection node_1a
+--let $galera_sync_point = apply_monitor_slave_enter_sync commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+
+# Release the INSERT
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# Release first UPDATE
+SET GLOBAL DEBUG_DBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug_dbug = NULL;
+SET debug_sync='RESET';
+
+--sleep 5
+
+# Release second UPDATE
+--let $galera_sync_point = apply_monitor_slave_enter_sync
+--source include/galera_signal_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+
+--connection node_1
+--reap
+
+SELECT * FROM p;
+SELECT * FROM c;
+
+SET GLOBAL wsrep_slave_threads = DEFAULT;
+
+
+--connection node_2
+SELECT * FROM p;
+SELECT * FROM c;
+
+--connection node_1
+DROP TABLE c;
+DROP TABLE p;
+
+
+
+
+
+
+
+
+
+

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -2476,7 +2476,14 @@ row_upd_sec_index_entry(
 #endif /* WITH_WSREP */
 		}
 
+#ifdef WITH_WSREP
+		ut_ad(err == DB_SUCCESS ||
+                      err == DB_LOCK_WAIT ||
+                      err == DB_LOCK_WAIT_TIMEOUT ||
+                      err == DB_INTERRUPTED);
+#else
 		ut_ad(err == DB_SUCCESS);
+#endif /* WITH_WSREP */
 
 		if (referenced) {
 			rec_offs* offsets = rec_get_offsets(


### PR DESCRIPTION
new mtr test (galera.MENT-1202) for reproducing the crash
Fix for debug level assert in row_upd_sec_index_entry() to take in consideration all possible error codes for BF aborted transaction

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MENT-1202_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Actual fix is in PR for MDEV-25114

## How can this PR be tested?
This PR contains new mtr test galera.MENT-1202, for reproducing the issue 

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [*] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

