### PR TITLE
MDEV-26015: Set DH param automatically

### DIFF
--- a/mysql-test/main/MDEV-26015.result
+++ b/mysql-test/main/MDEV-26015.result
@@ -1,0 +1,2 @@
+Variable_name	Value
+Ssl_cipher	DHE-RSA-AES128-SHA256

--- a/mysql-test/main/MDEV-26015.test
+++ b/mysql-test/main/MDEV-26015.test
@@ -1,0 +1,11 @@
+# Tests for SSL connections, only run if mysqld is compiled
+# with support for SSL.
+
+-- source include/have_ssl_communication.inc
+
+#
+# MDEV-26015 - using DHE cipher will fail if DH public key size doesn't match
+# RSA key size of server certificate
+#
+--exec $MYSQL -uroot --ssl-cipher=DHE-RSA-AES128-SHA256 --tls_version=TLSv1.2 -e"show status like 'ssl_cipher'" 2>&1
+


### PR DESCRIPTION
Jira issue number: MDEV-26015

Description:

So far  MariaDB Server creates a DH (Diffie Hellman) parameter with a
fixed length (= 2048). This leads to the limitation that, for example, the
use of a DHE cipher suite requires a server certificate with an RSA key
of the same length.

To remedy this, the DH parameter is now automatically set by OpenSSL or WolfSSL
during the TLS handshake (taking into account the key length used
of the server certificate).

While WoldSSL supports this by default, OpenSSL has to activate this using the
SSL_CTX_set_dh_auto macro. OpenSSL versions < 1.0.2  doesn't support this feature
and use the previous implementation with a DH parameter with a fixed size.

Tests:
MDEV-26015.test which sets a DHE cipher suite (using the default certificate with RSA key size = 4096).
