### PR TITLE
MDEV-26015: Set DH param automatically

### DIFF
--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -20079,7 +20079,6 @@ static void test_mdev19838()
 #endif // EMBEDDED_LIBRARY
 
 static struct my_tests_st my_tests[]= {
-  { "test_mdev26015", test_mdev26015 },
   { "disable_query_logs", disable_query_logs },
   { "test_view_sp_list_fields", test_view_sp_list_fields },
   { "client_query", client_query },

--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -19900,6 +19900,38 @@ static void test_ps_params_in_ctes()
 #ifndef EMBEDDED_LIBRARY
 #define MDEV19838_MAX_PARAM_COUNT 32
 #define MDEV19838_FIELDS_COUNT 17
+
+static void test_mdev26015()
+{
+  MYSQL *my;
+  int rc;
+
+  myheader("test_mdev16025");
+
+  my= mysql_client_init(NULL);
+
+  rc= mysql_options(my, MARIADB_OPT_TLS_VERSION, "TLSv1.2");
+  myquery(rc);
+  rc= mysql_ssl_set(my, NULL, NULL, NULL, NULL, "DHE-RSA-AES128-SHA256");
+  myquery(rc);
+
+  if (!(mysql_real_connect(my, opt_host, opt_user,
+                           opt_password, current_db, opt_port,
+                           opt_unix_socket, 0)))
+  {
+    fprintf(stderr, "\n connection failed(%s)", mysql_error(my));
+    mysql_close(my);
+    exit(1);
+  }
+
+  fprintf(stdout, "cipher in use: %s\n", mysql_get_ssl_cipher(my));
+
+  DIE_UNLESS(!mysql_get_ssl_cipher(my) ||
+             strcmp(mysql_get_ssl_cipher(my), "DHE-RSA-AES128-SHA256") == 0);
+
+  mysql_close(my);
+}
+
 static void test_mdev19838()
 {
   int rc;
@@ -20047,6 +20079,7 @@ static void test_mdev19838()
 #endif // EMBEDDED_LIBRARY
 
 static struct my_tests_st my_tests[]= {
+  { "test_mdev26015", test_mdev26015 },
   { "disable_query_logs", disable_query_logs },
   { "test_view_sp_list_fields", test_view_sp_list_fields },
   { "client_query", client_query },
@@ -20334,6 +20367,7 @@ static struct my_tests_st my_tests[]= {
 #ifndef EMBEDDED_LIBRARY
   { "test_mdev19838", test_mdev19838 },
 #endif
+  { "test_mdev26015", test_mdev26015 },
   { 0, 0 }
 };
 

--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -26,7 +26,12 @@
 static my_bool     ssl_algorithms_added    = FALSE;
 static my_bool     ssl_error_strings_loaded= FALSE;
 
-/* the function below was generated with "openssl dhparam -2 -C 2048" */
+#if !defined(WOLFSSL) && !defined(SSL_CTRL_SET_DH_AUTO)
++/* Older OpenSSL versions (< 1.0.2) don't handle dhparam
++   setting automatically during TLS handshake.
++
++   The function below was generated with "openssl dhparam -2 -C 2048"
++*/
 
 static
 DH *get_dh2048()
@@ -74,6 +79,7 @@ DH *get_dh2048()
     }
     return dh;
 }
+#endif
 
 static const char*
 ssl_error_string[] =
@@ -174,7 +180,6 @@ new_VioSSLFd(const char *key_file, const char *cert_file,
              enum enum_ssl_init_error *error,
              const char *crl_file, const char *crl_path)
 {
-  DH *dh;
   struct st_VioSSLFd *ssl_fd;
   long ssl_ctx_options= SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
   DBUG_ENTER("new_VioSSLFd");
@@ -269,25 +274,40 @@ new_VioSSLFd(const char *key_file, const char *cert_file,
     goto err2;
   }
 
-  /* DH stuff */
+#if !defined(WOLFSSL)
+  /* DH stuff:
+
+     WolfSSL chooses right DH public key automatically depending
+     on RSA key size of server certificate during TLS handshake.
+     For OpenSSL >=  1.0.2 this feature needs to be explicitly turned on.
+     OpenSSL versions < 1.0.2 will still use the old get_dh2048() method
+     to obtain and set DH public key (see also MDEV-26015).
+  */
   if (!is_client_method)
   {
-    dh=get_dh2048();
+#if !defined(SSL_CTRL_SET_DH_AUTO)
+    DH *dh=get_dh2048();
     if (!SSL_CTX_set_tmp_dh(ssl_fd->ssl_context, dh))
     {
       *error= SSL_INITERR_DH;
-      goto err3;
+      DH_free(dh);
+      goto err2;
     }
-
     DH_free(dh);
+#else
+    if (!SSL_CTX_set_dh_auto(ssl_fd->ssl_context, 1))
+    {
+      *error= SSL_INITERR_DH;
+      goto err2;
+    }
+#endif
   }
+#endif
 
   DBUG_PRINT("exit", ("OK 1"));
 
   DBUG_RETURN(ssl_fd);
 
-err3:
-  DH_free(dh);
 err2:
   SSL_CTX_free(ssl_fd->ssl_context);
 err1:


### PR DESCRIPTION
So far  MariaDB Server creates a DH (Diffie Hellman) parameter with a
fixed length (= 2048). This leads to the limitation that, for example, the
use of a DHE cipher suite requires a server certificate with an RSA key
of the same length.

To remedy this, the DH parameter is now automatically set by OpenSSL or WolfSSL
during the TLS handshake (taking into account the key length used
of the server certificate).

While WoldSSL supports this by default, OpenSSL has to activate this using the
SSL_CTX_set_dh_auto macro. OpenSSL versions < 1.0.2  doesn't support this feature
and use the previous implementation with a DH parameter with a fixed size.

Since command line client < 10.4.6 doesn't support tls_version parameter, testing
with DHE cipher suite was implemented in mysql_client_test.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?
TODO: fill steps to reproduce here, if applicable,
      or remove the section

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

