### PR TITLE
debian/salsa: Show complete auth and plugin situtation

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -751,8 +751,8 @@ mariadb.org-10.2 to mariadb-10.5 upgrade:
     # prepending with --defaults-file=/etc/mysql/debian.cnf is needed in upstream 5.5–10.3
     - mysql --defaults-file=/etc/mysql/debian.cnf --skip-column-names -e "SELECT @@version, @@version_comment"
     - echo 'SHOW DATABASES;' | mysql --defaults-file=/etc/mysql/debian.cnf
-    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT Host,User,plugin,authentication_string FROM user;" mysql
-    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM plugin;" mysql
+    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM mysql.global_priv; SHOW CREATE USER root@localhost; SHOW CREATE USER 'mariadb.sys'@localhost"
+    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM mysql.plugin; SHOW PLUGINS"
     - *test-install
     - service mysql status
     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server


### PR DESCRIPTION
SHOW PLUGINS has a more complete view of the installed
plugins into the server.

The mysql.user is a compatibility view that doesn't
show the complete authentication picture. Use global_priv.

Add `show create user` for default users to more clearly
represent its contents.

No JIRA Issue.

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

As mentioned previously the mysql.user view isn't predicatable. This adds the right extraction of system users/ plugins so that it can be more accurately read.

## How can this PR be tested?

Pushing through salsa when it ends up there.

## Basing the PR against the correct MariaDB version

This is the first branch with a salsa file.

## Backward compatibility

no considerations necessary.