### PR TITLE
MDEV-25740 Assertion `!wsrep_has_changes(thd) || (thd->lex->sql_comm…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-25740.result
+++ b/mysql-test/suite/galera/r/MDEV-25740.result
@@ -1,0 +1,9 @@
+connection node_2;
+connection node_1;
+SET AUTOCOMMIT = OFF;
+SET completion_type = CHAIN;
+CREATE TABLE t1(f1 INT) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1);
+ROLLBACK;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-25740.test
+++ b/mysql-test/suite/galera/t/MDEV-25740.test
@@ -1,0 +1,14 @@
+#
+# When `completion_type = CHAIN` is used, transaction started should not have previous writeset.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+SET AUTOCOMMIT = OFF;
+SET completion_type = CHAIN;
+CREATE TABLE t1(f1 INT) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1);
+ROLLBACK;
+DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5752,6 +5752,11 @@ mysql_execute_command(THD *thd)
     /* Begin transaction with the same isolation level. */
     if (tx_chain)
     {
+#ifdef WITH_WSREP
+      /* If there are pending changes after rollback we should clear them */
+      if (wsrep_on(thd) && wsrep_has_changes(thd))
+        wsrep_after_statement(thd);
+#endif
       if (trans_begin(thd))
         goto error;
     }


### PR DESCRIPTION
…and == SQLCOM_CREATE_TABLE && !thd->is_current_stmt_binlog_format_row())' failed in void wsrep_commit_empty(THD*, bool)

Using ROLLBACK with `completion_type = CHAIN` result in start of
transaction and implicit commit before previous WSREP internal data is
cleared.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25740*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: `completion_type=CHAIN` starts transaction after rollback is done. We should do internal WSREP housekeeping for this case. 

## How can this PR be tested?
TODO: MTR test provided with PR

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

