### PR TITLE
Increase the number of SUPER user connections from 1 to 3

### DIFF
--- a/mysql-test/main/connect.result
+++ b/mysql-test/main/connect.result
@@ -230,12 +230,20 @@ disconnect default;
 # -- Establishing connection 'con_super_1' (user: root)...
 # -- Connection 'con_super_1' has been established.
 
-# -- Connecting super (2) [should fail]...
+# -- Connecting super (2)...
 # -- Establishing connection 'con_super_2' (user: root)...
-# -- Error: can not establish connection 'con_super_2'.
+# -- Connection 'con_super_2' has been established.
+
+# -- Connecting super (3)...
+# -- Establishing connection 'con_super_3' (user: root)...
+# -- Connection 'con_super_3' has been established.
+
+# -- Connecting super (4) [should fail]...
+# -- Establishing connection 'con_super_4' (user: root)...
+# -- Error: can not establish connection 'con_super_4'.
 
 # -- Ensure that we have Event Scheduler thread, 3 ordinary user
-# -- connections and one extra super-user connection.
+# -- connections and three extra super-user connections.
 SELECT user FROM information_schema.processlist ORDER BY id;
 user
 event_scheduler
@@ -249,6 +257,8 @@ mysqltest_u1
 mysqltest_u1
 mysqltest_u1
 mysqltest_u1
+root
+root
 root
 
 # -- Resetting variables...
@@ -264,6 +274,8 @@ disconnect con_1;
 disconnect con_2;
 disconnect con_3;
 disconnect con_super_1;
+disconnect con_super_2;
+disconnect con_super_3;
 disconnect tmp_con1;
 disconnect tmp_con2;
 disconnect tmp_con3;
@@ -319,7 +331,17 @@ connect extracon2,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,;
 SELECT 'Connection on extra port 2 ok';
 Connection on extra port 2 ok
 Connection on extra port 2 ok
-# -- Success: more than --extra-max-connections + 1 normal connections not possible
+connect extracon3,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,;
+connection extracon3;
+SELECT 'Connection on extra port 3 ok';
+Connection on extra port 3 ok
+Connection on extra port 3 ok
+connect extracon4,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,;
+connection extracon4;
+SELECT 'Connection on extra port 4 ok';
+Connection on extra port 4 ok
+Connection on extra port 4 ok
+# -- Success: more than --extra-max-connections + 3 normal connections not possible
 #
 # -- Bug#49752: 2469.126.2 unintentionally breaks authentication
 #               against MySQL 5.1 server

--- a/mysql-test/main/connect.test
+++ b/mysql-test/main/connect.test
@@ -204,15 +204,27 @@ let $con_user_name = root;
 --source include/connect2.inc
 
 --echo
---echo # -- Connecting super (2) [should fail]...
+--echo # -- Connecting super (2)...
 let $con_name = con_super_2;
+let $con_user_name = root;
+--source include/connect2.inc
+
+--echo
+--echo # -- Connecting super (3)...
+let $con_name = con_super_3;
+let $con_user_name = root;
+--source include/connect2.inc
+
+--echo
+--echo # -- Connecting super (4) [should fail]...
+let $con_name = con_super_4;
 let $con_user_name = root;
 let $wait_timeout = 5;
 --source include/connect2.inc
 
 --echo
 --echo # -- Ensure that we have Event Scheduler thread, 3 ordinary user
---echo # -- connections and one extra super-user connection.
+--echo # -- connections and three extra super-user connections.
 SELECT user FROM information_schema.processlist ORDER BY id;
 
 --echo
@@ -238,6 +250,8 @@ let $wait_condition =
 --disconnect con_2
 --disconnect con_3
 --disconnect con_super_1
+--disconnect con_super_2
+--disconnect con_super_3
 --disconnect tmp_con1
 --disconnect tmp_con2
 --disconnect tmp_con3
@@ -315,21 +329,29 @@ SELECT 'Connection on extra port ok';
 connect(extracon2,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
 SELECT 'Connection on extra port 2 ok';
 
+connect(extracon3,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
+connection extracon3;
+SELECT 'Connection on extra port 3 ok';
+
+connect(extracon4,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
+connection extracon4;
+SELECT 'Connection on extra port 4 ok';
+
 --disable_abort_on_error
 --disable_result_log
 --disable_query_log
-connect(extracon3,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
+connect(extracon5,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
 --enable_query_log
 --enable_result_log
 --enable_abort_on_error
 let $error = $mysql_errno;
 if (!$error)
 {
-  --echo # -- Error: managed to establish more than --extra-max-connections + 1 connections
+  --echo # -- Error: managed to establish more than --extra-max-connections + 3 connections
 }
 if ($error)
 {
-  --echo # -- Success: more than --extra-max-connections + 1 normal connections not possible
+  --echo # -- Success: more than --extra-max-connections + 3 normal connections not possible
 }
 
 ###########################################################################

--- a/mysql-test/main/mdev375.result
+++ b/mysql-test/main/mdev375.result
@@ -17,6 +17,14 @@ connect  con2,localhost,root,,;
 SELECT 2;
 2
 2
+connect  con3,localhost,root,,;
+SELECT 3;
+3
+3
+connect  con4,localhost,root,,;
+SELECT 4;
+4
+4
 ERROR HY000: Too many connections
 connection default;
 SELECT 0;
@@ -24,6 +32,6 @@ SELECT 0;
 0
 show status like "Threads_connected";
 Variable_name	Value
-Threads_connected	11
+Threads_connected	13
 SET GLOBAL log_warnings=@save_log_warnings;
 SET GLOBAL max_connections=@save_max_connections;

--- a/mysql-test/main/mdev375.test
+++ b/mysql-test/main/mdev375.test
@@ -20,14 +20,18 @@ SET GLOBAL max_connections=10;
 SELECT 1;
 --connect (con2,localhost,root,,)
 SELECT 2;
+--connect (con3,localhost,root,,)
+SELECT 3;
+--connect (con4,localhost,root,,)
+SELECT 4;
 --disable_query_log
 --error ER_CON_COUNT_ERROR
---connect (con3,localhost,root,,)
+--connect (con5,localhost,root,,)
 --enable_query_log
 
 --connection default
 SELECT 0;
-let $count_sessions=11;
+let $count_sessions=13;
 --source include/wait_until_count_sessions.inc
 show status like "Threads_connected";
 

--- a/mysql-test/main/pool_of_threads.result
+++ b/mysql-test/main/pool_of_threads.result
@@ -2175,8 +2175,19 @@ connection extracon2;
 SELECT 'Connection on extra port 2 ok';
 Connection on extra port 2 ok
 Connection on extra port 2 ok
-# -- Success: more than --extra-max-connections + 1 normal connections not possible
-connection extracon2;
+SELECT sleep(5.5);
+connect extracon3,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,;
+connection extracon3;
+SELECT 'Connection on extra port 3 ok';
+Connection on extra port 3 ok
+Connection on extra port 3 ok
+SELECT sleep(5.5);
+connect extracon4,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,;
+connection extracon4;
+SELECT 'Connection on extra port 4 ok';
+Connection on extra port 4 ok
+Connection on extra port 4 ok
+# -- Success: more than --extra-max-connections + 3 normal connections not possible
 KILL QUERY <default_connection_ID>;
 KILL QUERY <con2_connection_ID>;
 connection default;

--- a/mysql-test/main/pool_of_threads.test
+++ b/mysql-test/main/pool_of_threads.test
@@ -57,15 +57,24 @@ SELECT 'Connection on extra port ok';
 # (abort in interruptible wait connection check).
 send SELECT sleep(5.5);
 
-
 connect(extracon2,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
 connection extracon2;
 SELECT 'Connection on extra port 2 ok';
+send SELECT sleep(5.5);
+
+connect(extracon3,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
+connection extracon3;
+SELECT 'Connection on extra port 3 ok';
+send SELECT sleep(5.5);
+
+connect(extracon4,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,);
+connection extracon4;
+SELECT 'Connection on extra port 4 ok';
 
 --disable_abort_on_error
 --disable_result_log
 --disable_query_log
-connect(extracon3,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,,connect_timeout=2);
+connect(extracon5,127.0.0.1,root,,test,$MASTER_EXTRA_PORT,,connect_timeout=2);
 --enable_query_log
 --enable_result_log
 --enable_abort_on_error
@@ -76,10 +85,9 @@ if (!$error)
 }
 if ($error)
 {
-  --echo # -- Success: more than --extra-max-connections + 1 normal connections not possible
+  --echo # -- Success: more than --extra-max-connections + 3 normal connections not possible
 }
 
-connection extracon2;
 --replace_result $con1_id <default_connection_ID>
 eval KILL QUERY $con1_id;
 --replace_result $con2_id <con2_connection_ID>

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5968,10 +5968,10 @@ void create_new_thread(CONNECT *connect)
 
   /*
     Don't allow too many connections. We roughly check here that we allow
-    only (max_connections + 1) connections.
+    only (max_connections + 3) connections.
   */
   if ((*connect->scheduler->connection_count)++ >=
-      *connect->scheduler->max_connections + 1)
+      *connect->scheduler->max_connections + 3)
   {
     DBUG_PRINT("error",("Too many connections"));
     connect->close_with_error(0, NullS, ER_CON_COUNT_ERROR);


### PR DESCRIPTION
## Description

A database manager often need more than 1 extra connections to help a
database recover from overload, such as monitoring threads, killing
connections, and other manual actions. Therefore, it is necessary to
increase the number of SUPER user connections.

Also, three extra connections is a balanced choice in the sense that it
increases database management capacity by 300% but the cost on total
MariaDB memory consumption is less than 1%.

## Basing the PR against the correct MariaDB version

- [x] *This is a new feature and the PR is based against the latest MariaDB development branch* (10.7)

## How can this PR be tested?

The setting is already covered by MTR tests. This PR updates the tests to match the new functionality.

## Backward compatibility

Since the change is about increasing a limit of an existing configuration variable, it should be fully backwards compatible and do not require anything special for old installations that upgrade to using this version.

## Copyright

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.
