### PR TITLE
auth_socket: Add SO_PEERCRED definitions for NetBSD

### DIFF
--- a/plugin/auth_socket/CMakeLists.txt
+++ b/plugin/auth_socket/CMakeLists.txt
@@ -57,6 +57,21 @@ IF (HAVE_XUCRED)
   SET(ok 1)
 ELSE()
 
+# NetBSD, is that you?
+CHECK_CXX_SOURCE_COMPILES(
+"#include <sys/un.h>
+#include <sys/socket.h>
+int main() {
+  struct unpcbid unp;
+  socklen_t unpl = sizeof(unp);
+  getsockopt(0, 0, LOCAL_PEEREID, &unp, &unpl);
+  }" HAVE_UNPCBID)
+
+IF (HAVE_UNPCBID)
+  ADD_DEFINITIONS(-DHAVE_UNPCBID)
+  SET(ok 1)
+ELSE()
+
 # illumos, is that you?
 CHECK_CXX_SOURCE_COMPILES(
 "#include <ucred.h>
@@ -99,6 +114,7 @@ ELSE()
 # Who else? Anyone?
 # C'mon, show your creativity, be different! ifdef's are fun, aren't they?
 
+ENDIF()
 ENDIF()
 ENDIF()
 ENDIF()

--- a/plugin/auth_socket/auth_socket.c
+++ b/plugin/auth_socket/auth_socket.c
@@ -47,6 +47,13 @@
 #define uid cr_uid
 #define ucred xucred
 
+#elif defined HAVE_UNPCBID
+#include <sys/un.h>
+#define level 0
+#define SO_PEERCRED LOCAL_PEEREID
+#define uid unp_euid
+#define ucred unpcbid
+
 #elif defined HAVE_GETPEERUCRED
 #include <ucred.h>
 


### PR DESCRIPTION
Documentation for LOCAL_PEEREID: https://man.netbsd.org/unix.4
License: 2 clause BSD