### PR TITLE
Workaround to allow users to drop a table if .frm file is missing

### DIFF
--- a/mysql-test/r/drop-orphaned_table.result
+++ b/mysql-test/r/drop-orphaned_table.result
@@ -1,0 +1,13 @@
+create database droptest;
+use droptest;
+set @@SESSION.force_drop_table_mode='INNODB';
+create table t1(a int);
+create table t2(a int);
+create trigger tr1 before insert on t1 for each row insert into t2 values (new.a);
+insert into t1 values (1);
+insert into t1 values (3);
+insert into t1 values (3);
+insert into t1 values (7);
+drop table t1;
+set @@SESSION.force_drop_table_mode='NONE';
+drop database droptest;

--- a/mysql-test/t/drop-orphaned_table.test
+++ b/mysql-test/t/drop-orphaned_table.test
@@ -1,0 +1,20 @@
+create database droptest;
+use droptest;
+set @@SESSION.force_drop_table_mode='INNODB';
+create table t1(a int);
+create table t2(a int);
+create trigger tr1 before insert on t1 for each row insert into t2 values (new.a);
+
+let $MYSQLD_DATADIR= `select concat(@@datadir, 'droptest');`;
+
+insert into t1 values (1);
+insert into t1 values (3);
+insert into t1 values (3);
+insert into t1 values (7);
+
+file_exists $MYSQLD_DATADIR/t1.frm;
+remove_file $MYSQLD_DATADIR/t1.frm;
+
+drop table t1;
+set @@SESSION.force_drop_table_mode='NONE';
+drop database droptest;

--- a/sql/datadict.h
+++ b/sql/datadict.h
@@ -37,6 +37,8 @@ enum frm_type_enum
 */
 frm_type_enum dd_frm_type(THD *thd, char *path, LEX_STRING *engine_name);
 
+frm_type_enum dd_frm_type_for_force_drop(THD *thd, char *path, LEX_STRING *engine_name);
+
 static inline bool dd_frm_is_view(THD *thd, char *path)
 {
   return dd_frm_type(thd, path, NULL) == FRMTYPE_VIEW;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -4327,6 +4327,8 @@ int ha_discover_table_names(THD *thd, LEX_STRING *db, MY_DIR *dirp,
                             Discovered_table_list *result, bool reusable);
 bool ha_table_exists(THD *thd, const char *db, const char *table_name,
                      handlerton **hton= 0);
+bool ha_table_exists_force_drop(THD *thd, const char *db, const char *table_name,
+                     handlerton **hton= 0);                     
 #endif
 
 /* key cache */

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -106,6 +106,12 @@ enum enum_binlog_row_image {
   BINLOG_ROW_IMAGE_FULL= 2
 };
 
+enum force_drop_table_mode
+ {
+   NONE=0,
+   INNODB,
+   MYISAM
+ };
 
 /* Bits for different SQL modes modes (including ANSI mode) */
 #define MODE_REAL_AS_FLOAT              (1ULL << 0)
@@ -718,6 +724,7 @@ typedef struct system_variables
   my_bool session_track_state_change;
 
   ulong threadpool_priority;
+  ulong force_drop_table_mode;
 } SV;
 
 /**

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -2372,7 +2372,7 @@ int mysql_rm_table_no_locks(THD *thd, TABLE_LIST *tables, bool if_exists,
     DEBUG_SYNC(thd, "rm_table_no_locks_before_delete_table");
     error= 0;
     if (drop_temporary ||
-        (ha_table_exists(thd, db, alias, &table_type) == 0 && table_type == 0) ||
+        (ha_table_exists_force_drop(thd, db, alias, &table_type) == 0 && table_type == 0) ||
         (!drop_view && (was_view= (table_type == view_pseudo_hton))))
     {
       /*
@@ -2474,7 +2474,7 @@ int mysql_rm_table_no_locks(THD *thd, TABLE_LIST *tables, bool if_exists,
         }
         else
           frm_delete_error= mysql_file_delete(key_file_frm, path,
-                                              MYF(MY_WME));
+                                              MYF(MY_WME)) && !thd->variables.force_drop_table_mode;
         if (frm_delete_error)
           frm_delete_error= my_errno;
         else

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5792,3 +5792,15 @@ static Sys_var_mybool Sys_session_track_state_change(
        ON_UPDATE(update_session_track_state_change));
 
 #endif //EMBEDDED_LIBRARY
+static const char *force_drop_table_mode_names[]=
+   { "NONE", "INNODB", "MYISAM", NULL };
+ 
+ static Sys_var_enum Sys_force_drop_table_mode(
+        "force_drop_table_mode",
+        "Select an engine type to drop an orphaned table. Default value is INNODB",
+        SESSION_VAR(force_drop_table_mode), 
+        NO_CMD_LINE, 
+        force_drop_table_mode_names, 
+        DEFAULT(NONE)
+ );
+


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Workaround to allow users to drop a table if .frm file is missing

In some rare cases (e.g. MariaDB server experienced a crash duringan ongoing DDL operation), data dictionary might get inconsistent with a table representation files (.frm) being stored on a disk, simply put - .frm file may get corrupt or missing.

In such cases, a DB user is not able to recreate nor drop the affected table. This behavior is observed on MariaDB versions up to 10.5.

This commit introduces a new session variable 'force_drop_table_mode' which allows user to manually select a storage engine in case if .frm file is not readable (thus MariaDB can't determine the storage engine), allowing the DROP TABLE query to be handled by a storage engine specified in this session variable.

## How can this PR be tested?
Execute mysql-test-run with a test included in this commit. The behavior can be reproduced manually with a similar steps to those in a test file.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
This fix should not affect backward compatibility. The only code path being modified is the DROP TABLE query handler.

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.