### PR TITLE
MDEV-26474: Fix mysql_setpermission hostname logic

### DIFF
--- a/scripts/mysql_setpermission.sh
+++ b/scripts/mysql_setpermission.sh
@@ -283,7 +283,6 @@ sub addall {
        $sth = $dbh->do("REVOKE ALL ON $db.* FROM \'$user\'\@\'$host\'") || die $dbh->errstr;
     }
     }
-  $dbh->do("FLUSH PRIVILEGES") || print STDERR "Can't flush privileges\n";
   print "Everything is inserted and mysql privileges have been reloaded.\n\n";
 }
 

--- a/scripts/mysql_setpermission.sh
+++ b/scripts/mysql_setpermission.sh
@@ -52,6 +52,7 @@ use strict;
 use vars qw($dbh $sth $hostname $opt_user $opt_password $opt_help $opt_host
 	    $opt_socket $opt_port $host $version);
 
+my $sqlport = "";
 my $sqlhost = "";
 my $user = "";
 
@@ -84,9 +85,13 @@ if ($opt_password eq '')
   print "\n";
 }
 
+# Using port argument with 'localhost' will cause an error
+if ($sqlhost ne "localhost") {
+  $sqlport = ":port=$opt_port";
+}
 
 # make the connection to MariaDB
-$dbh= DBI->connect("DBI:mysql:mysql:host=$sqlhost:port=$opt_port:mysql_socket=$opt_socket",$opt_user,$opt_password, {PrintError => 0}) ||
+$dbh= DBI->connect("DBI:mysql:mysql:host=$sqlhost$sqlport:mysql_socket=$opt_socket",$opt_user,$opt_password, {PrintError => 0}) ||
   die("Can't make a connection to the mysql server.\n The error: $DBI::errstr");
 
 # the start of the program


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-_____*


## Description
Hi,

It seems that there is some kind of logic confusion in mysql set_permission perl script. By default all connections parameters are read from configuration file of mariadb:

https://github.com/MariaDB/server/blob/10.7/scripts/mysql_setpermission.sh#L61

Fresh installation of mariadb on Fedora does not contain any connection information in configuration file. It falls back automatically to localhost DB. Nothing wrong with that.

Trying to execute mysql_setpermission with this configuration will fail:

```
mysql_setpermission fails to connect to local mariadb, claiming that 
DBI connect(';host=localhost;port=3306','newuser',...) failed: Connection error: port cannot be specified when host is localhost or embedded at /usr/bin/mysql_setpermission line 116.
```

I don't think that's correct behavior. It should be possible to use it on default installation without additional configuration.

Here is what's going on. Reading host from my.cnf file will result in no information, so script will fallback to 'localhost' string:

https://github.com/MariaDB/server/blob/10.7/scripts/mysql_setpermission.sh#L76

Seems like a good idea but unfortunately DBD module in perl will treat is as socket connection:

The hostname, if not specified or specified as '' or 'localhost', will default to a MySQL server running on the local machine using the default for the UNIX socket. To connect to a MySQL server on the local machine via TCP, you must specify the loopback IP address (127.0.0.1) as the host.

Changing it to 127.0.0.1 will solve the issue, although I can see another confusion. User might specify hostname in my.cnf file as localhost fot TCP connection and that will be totally fine for mariasb but not for this module, so another condition is required to catch this exception.

## How can this PR be tested?
```
# systemctl start mariadb
# mysql
mysql> CREATE USER 'newuser'@'localhost' IDENTIFIED BY 'password';
mysql> GRANT ALL PRIVILEGES ON *.*  TO 'newuser'@'localhost' WITH GRANT OPTION;
mysql> FLUSH PRIVILEGES;
# mysql_setpermission  --user newuser
```

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*


