### PR TITLE
Deb: Fix Gitlab-CI/Salsa-CI builds failures

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -22,12 +22,14 @@ if [[ $TRAVIS ]] || [[ $GITLAB_CI ]]
 then
   # On both Travis and Gitlab the output log must stay under 4MB so make the
   # build less verbose
-  # MCOL-4149: ColumnStore builds are so slow and big that they must be skipped on
-  # both Travis-CI and Gitlab-CI
-   sed -e 's|$(CMAKEFLAGS)|$(CMAKEFLAGS) -DPLUGIN_COLUMNSTORE=NO|' \
-	  -i debian/rules
+  sed '/Add support for verbose builds/,/^$/d' -i debian/rules
 elif [ -d storage/columnstore/columnstore/debian ]
 then
+  # ColumnStore is explicitly disabled in the native Debian build, so allow it
+  # now when build is triggered by autobake-deb.sh (MariaDB.org) and when the
+  # build is not running on Travis or Gitlab-CI
+  sed '/-DPLUGIN_COLUMNSTORE=NO/d' -i debian/rules
+  # Take the files and part of control from MCS directory
   cp -v storage/columnstore/columnstore/debian/mariadb-plugin-columnstore.* debian/
   echo >> debian/control
   cat storage/columnstore/columnstore/debian/control >> debian/control

--- a/debian/rules
+++ b/debian/rules
@@ -38,6 +38,16 @@ else
     NUMJOBS = 1
 endif
 
+# RocksDB cannot build on 32-bit platforms
+ifeq (32,$(DEB_HOST_ARCH_BITS))
+    CMAKEFLAGS += -DPLUGIN_ROCKSDB=NO
+endif
+
+# ColumnStore can build only on amd64 and arm64
+ifneq (,$(filter $(DEB_HOST_ARCH_CPU),amd64 arm64))
+    CMAKEFLAGS += -DPLUGIN_COLUMNSTORE=NO
+endif
+
 ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
     ifneq (,$(filter $(DEB_HOST_ARCH_CPU),alpha amd64 arm arm64 i386 ia64 m68k mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sh4 sparc64))
         CMAKEFLAGS += -DSTACK_DIRECTION=-1
@@ -72,13 +82,15 @@ endif
 
 	echo "server:Version=$(DEB_VERSION)" >> debian/substvars
 
-	# RocksDB and Column Store cannot build on 32-bit platforms
+	# Don't build ColumnStore as part of the native build as it does not meet the
+	# quality standards in Debian. Also building it requires an extra 4 GB of disk
+	# space which makes native Debian builds fail as the total disk space needed
+	# for MariaDB becomes over 10 GB. Only build CS via autobake-deb.sh.
 	PATH=$${MYSQL_BUILD_PATH:-"/usr/lib/ccache:/usr/local/bin:/usr/bin:/bin"} \
 	    NO_UPDATE_BUILD_VERSION=1 \
 	    dh_auto_configure --builddirectory=$(BUILDDIR) -- \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	    $(CMAKEFLAGS) \
-	    $(if $(findstring $(DEB_HOST_ARCH_BITS),32),-DPLUGIN_ROCKSDB=NO -DPLUGIN_COLUMNSTORE=NO) \
 	    $(if $(filter $(DEB_BUILD_ARCH),$(DEB_HOST_ARCH)),,-DIMPORT_EXECUTABLES=$(CURDIR)/builddir-native/import_executables.cmake) \
 	    -DCOMPILATION_COMMENT="mariadb.org binary distribution" \
 	    -DMYSQL_SERVER_SUFFIX="-$(DEB_VERSION_REVISION)" \
@@ -88,6 +100,7 @@ endif
 	    -DPLUGIN_TOKUDB=NO \
 	    -DPLUGIN_CASSANDRA=NO \
 	    -DPLUGIN_AWS_KEY_MANAGEMENT=NO \
+			-DPLUGIN_COLUMNSTORE=NO \
 	    -DDEB=$(DEB_VENDOR)
 
 # This is needed, otherwise 'make test' will run before binaries have been built

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -278,6 +278,8 @@ mariadb-10.1 Stretch to mariadb-10.5 upgrade:
     - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadbd*' 'libmariadbclient*'
     # Verify installation of MariaDB from Stretch
     - *test-verify-initial
+    # Remove manpages 4.10 that conflicts with manpages-dev 5.10 on console_ioctl.4.gz
+    - apt-get remove -y manpages
     - *test-enable-sid-repos
     - *test-install
     - service mysql status
@@ -486,28 +488,8 @@ default-libmysqlclient-dev Stretch upgrade:
     - *test-prepare-container
     - apt-get install -y pkg-config default-libmysqlclient-dev
     - pkg-config --list-all
-    - *test-enable-sid-repos
-    - *test-install-all-libs
-    - *test-verify-libs
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-mariadb-connector-c Stretch upgrade:
-  stage: upgrade from Buster/Stretch
-  needs:
-    - job: build
-      artifacts: true
-  image: debian:stretch
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - apt-get install -y pkg-config libmariadb2 libmariadb-dev libmariadb-dev-compat
-    - pkg-config --list-all
+    # Remove manpages 4.10 that conflicts with manpages-dev 5.10 on console_ioctl.4.gz
+    - apt-get remove -y manpages
     - *test-enable-sid-repos
     - *test-install-all-libs
     - *test-verify-libs
@@ -751,7 +733,7 @@ mariadb.org-10.2 to mariadb-10.5 upgrade:
     # prepending with --defaults-file=/etc/mysql/debian.cnf is needed in upstream 5.5–10.3
     - mysql --defaults-file=/etc/mysql/debian.cnf --skip-column-names -e "SELECT @@version, @@version_comment"
     - echo 'SHOW DATABASES;' | mysql --defaults-file=/etc/mysql/debian.cnf
-    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM mysql.global_priv; SHOW CREATE USER root@localhost; SHOW CREATE USER 'mariadb.sys'@localhost"
+    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM mysql.user; SHOW CREATE USER root@localhost"
     - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM mysql.plugin; SHOW PLUGINS"
     - *test-install
     - service mysql status

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -22,3 +22,9 @@ version-substvar-for-external-package mariadb-client-10.5 -> mysql-client-core-8
 version-substvar-for-external-package libmariadbd-dev -> libmariadbclient-dev
 # ColumnStore not used in Debian, safe to ignore. Reported upstream in https://jira.mariadb.org/browse/MDEV-24124
 source-is-missing storage/columnstore/columnstore/utils/jemalloc/libjemalloc.so.2
+# Must be fixed upstream
+source-is-missing storage/mroonga/vendor/groonga/examples/dictionary/html/js/jquery-ui-1.8.18.custom.js line 58 is 273 characters long (>256)
+# Intentional control relationships
+version-substvar-for-external-package Replaces (line 216) ${source:Version} libmariadbd-dev -> libmariadbclient-dev
+version-substvar-for-external-package Replaces (line 66) ${source:Version} libmariadb-dev -> libmysqlclient-dev
+version-substvar-for-external-package Replaces (line 66) ${source:Version} libmariadb-dev -> libmysqld-dev


### PR DESCRIPTION
The debian/salsa-ci.yml used to work also on upstream MariaDB.org branches,
but has recently regressed and several jobs stopped working. These fixes
are necessary to get it working again.

* Partially revert 8642f592 that never worked, as MariaDB 10.2 does not
  have a mysql.global table nor a mariadb.sys user. Those features weren't
  introduced until MariaDB 10.4.

* Partially revert 0268b871 as we don't want ColumnStore as part of the
  native Debian build. It should build only when the build is triggered
  via autobake-deb.sh (MariaDB.org builds).

* Add Lintian overrides for systemd service file location error that is
  most likely a bug in Lintian or incompatibility with dh_systemd.

* Adjust salsa-ci.yml to cope with various Stretch to Sid upgrade issues
  and remove the legacy mariadb-connector-c job completely as that package
  hasn't been around for years anymore.

## Before

https://salsa.debian.org/mariadb-team/mariadb-server/-/pipelines/285955
![image](https://user-images.githubusercontent.com/668724/132168802-0252cf03-666f-43ad-b107-b1e6487f1507.png)

## After

https://salsa.debian.org/mariadb-team/mariadb-server/-/pipelines/286406
![image](https://user-images.githubusercontent.com/668724/132168842-41717467-ea2f-4660-b8d4-3afb7c20d739.png)
