### PR TITLE
MDEV-25177: Indicate user during DEB-package postint if SystemD 'ProtectSystem' or 'ProtectHome' will cause problems

### DIFF
--- a/debian/mariadb-server-10.2.install
+++ b/debian/mariadb-server-10.2.install
@@ -13,6 +13,7 @@ usr/bin/aria_pack
 usr/bin/aria_read_log
 usr/bin/galera_new_cluster
 usr/bin/galera_recovery
+usr/bin/mariadb-execstartpre-check
 usr/bin/mariadb-service-convert
 usr/bin/msql2mysql
 usr/bin/my_print_defaults

--- a/support-files/CMakeLists.txt
+++ b/support-files/CMakeLists.txt
@@ -123,6 +123,11 @@ IF(UNIX)
             ${CMAKE_CURRENT_BINARY_DIR}/mariadb.service
             DESTINATION ${inst_location}/systemd COMPONENT SupportFiles)
 
+    CONFIGURE_FILE(mariadb-execstartpre-check.sh
+                   ${CMAKE_CURRENT_BINARY_DIR}/mariadb-execstartpre-check @ONLY)
+    INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mariadb-execstartpre-check
+      DESTINATION ${bindir} COMPONENT Server_Scripts)
+
     # @ in directory name broken between CMake version 2.8.12.2 and 3.3
     # http://public.kitware.com/Bug/view.php?id=14782
     IF(NOT CMAKE_VERSION VERSION_LESS 3.3.0 OR NOT RPM)

--- a/support-files/CMakeLists.txt
+++ b/support-files/CMakeLists.txt
@@ -126,7 +126,7 @@ IF(UNIX)
     CONFIGURE_FILE(mariadb-execstartpre-check.sh
                    ${CMAKE_CURRENT_BINARY_DIR}/mariadb-execstartpre-check @ONLY)
     INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/mariadb-execstartpre-check
-      DESTINATION ${bindir} COMPONENT Server_Scripts)
+            DESTINATION ${bindir} COMPONENT Server_Scripts)
 
     # @ in directory name broken between CMake version 2.8.12.2 and 3.3
     # http://public.kitware.com/Bug/view.php?id=14782

--- a/support-files/mariadb-execstartpre-check.sh
+++ b/support-files/mariadb-execstartpre-check.sh
@@ -12,51 +12,70 @@
 # If you want to get rid of this checking then
 # you have add service file or profile.d enviromental
 # variable (with value = 1):
-# MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
+# MARIADB_DO_NOT_PRECHECK=1
 #
-# And if you don't like to use systemd then add
-# variable
-# MARIADB_DO_NOT_EXECSTARTPRE_SYSTEMCTL=1
+# And if you don't wish to use systemd then add
+# variable:
+# MARIADB_DO_NOT_SYSTEMCTL_CHECK=1
 #
 # Example add file /etc/systemd/system/mariadb.service.d/nocheck.conf
 # [Service]
-# Environment=MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
-#
+# Environment=MARIADB_DO_NOT_PRECHECK=1
 
-# If ENV variable MARIADB_DO_NOT_EXECSTARTPRE_CHECK is set
-# Then just exit
-if [ -n "${MARIADB_DO_NOT_EXECSTARTPRE_CHECK}" ]
+if [ -n "${MARIADB_DO_NOT_PRECHECK}" ]
 then
     exit 0
 fi
 
 MY_PRINT_DEFAULTS=""
 
-if [ -x "@bindir@/my_print_defaults" ]
+if [ -z "${MY_PRINT_DEFAULTS}" ]
 then
-   MY_PRINT_DEFAULTS="@bindir@/my_print_defaults"
+    if [ -x "@bindir@/my_print_defaults" ]
+    then
+        MY_PRINT_DEFAULTS="@bindir@/my_print_defaults"
+    elif my_print_defaults -n
+    then
+        MY_PRINT_DEFAULTS=my_print_defaults
+    fi
+else
+    if ! "${MY_PRINT_DEFAULTS}" -n
+    then
+        echo "Can't find tool: '$MY_PRINT_DEFAULTS' in path."
+        echo "You need to check set MY_PRINT_DEFAULTS to the correct my_print_defaults executable"
+        echo "or set environment variable MARIADB_DO_NOT_PRECHECK=1 to disable this check"
+        exit 1
+    fi
 fi
 
 if [ -z "${MY_PRINT_DEFAULTS}" ]
 then
-    echo "Can't find tool: 'my_print_defaults' in path."
-    echo "You need to check your system settings or set enviromental"
-    echo "variable: MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1 to prevent this error"
+    echo "Can't find tool my_print_defaults in expected locations."
+    echo "You can set the environment variable MY_PRINT_DEFAULTS to the location"
     exit 1
 fi
 
+SERVICE_NAME=${1:-mariadb.service}
+if [ $# -ge 1 ]
+then
+    shift
+fi
 MARIADB_PROTECTSYSTEM=""
 MARIADB_PROTECTHOME=""
 
-# If ENV variable MARIADB_DO_NOT_EXECSTARTPRE_SYSTEMCTL is set
+# If ENV variable MARIADB_DO_NOT_SYSTEMCTL_CHECK is set
 # then do not use system stuff
-if [ -z "${MARIADB_DO_NOT_EXECSTARTPRE_SYSTEMCTL}" ]
+if [ -z "${MARIADB_DO_NOT_SYSTEMCTL_CHECK}" ]
 then
+    # Check with systemctl cat mariadb*.service
+    # if user has already altered service file to
+    # allow writing to there locations
+
     # Check service file should we even check
     # anything. If ProtectHome and ProtectSystem
     # are disabled then there is not issues
-    MARIADB_PROTECTSYSTEM=$(systemctl cat mariadb.service | grep -e "^ProtectSystem=no")
-    MARIADB_PROTECTHOME=$(systemctl cat mariadb.service | grep -e "^ProtectHome=no")
+    MARIADB_PROTECTSYSTEM=$(systemctl cat "${SERVICE_NAME}" | grep -e "^ProtectSystem=no")
+    MARIADB_PROTECTHOME=$(systemctl cat "${SERVICE_NAME}" | grep -e "^ProtectHome=no")
 
     # If both are set then just exit as everything is fine
     if [ -n "${MARIADB_PROTECTSYSTEM}" ] && [ -n "${MARIADB_PROTECTHOME}" ]
@@ -65,33 +84,55 @@ then
     fi
 fi
 
-
 #
 # Check with my_print_defaults that any
 # path in configuration is not pointing somewhere
-# we can't write or it is invisible
+# we can't read/write or it is invisible
 #
-# Check with systemctl cat mariadb*.service
-# if user has already altered service file to
-# allow writing to there locations
-#
-my_print_defaults --mysqld | while read -r setting
+# Additional arguments like --defaults-(extra-file,file,group-suffix)
+# can be added to the script to match the server configuration.
+
+"${MY_PRINT_DEFAULTS}" "$@" --mysqld | while read -r setting
 do
     conf_var=${setting%%=*}
     conf_var=${conf_var#--}
     conf_val=${setting#*=}
     conf_problem=""
+    conf_read_x_paths="Write"
 
+    # Read only conf_vars
+    # https://github.com/MariaDB/server/pull/1906#discussion_r714422253
+    case "$conf_var" in
+        basedir) ;&
+        plugin[-_]dir) ;&
+        file[-_]key[-_]management[-_]filename) ;&
+        secure[-_]file[-_]priv)
+            if [ ! -r "${conf_val}" ]
+            then
+                echo "server variable $conf_var location $conf_val is not readable"
+                conf_read_x_paths="Only"
+            else
+                continue
+            fi
+            ;;
+        *)
+            if [ "${conf_val:1:1}" = '/' ] && [ ! -w "$conf_val" ]
+            then
+                echo "server variable $conf_var location $conf_val is not writable"
+            else
+                continue
+            fi
+            ;;
+    esac
     # These are the places that systemd
     # is prevented currently to write or access
+    conf_problem=""
     case "$conf_val" in
             # ProtectSystem prevents writes to /usr, /boot and /efi
         /usr|/usr/*|/boot|/boot/*|/efi|/efi/*)
             if [ -z "${MARIADB_PROTECTSYSTEM}" ]
             then
                 conf_problem="ProtectSystem"
-            else
-                conf_problem=""
             fi
             ;;
             # ProtectHome prevents access to /home, /root and /run/user
@@ -99,22 +140,20 @@ do
             if [ -z "${MARIADB_PROTECTHOME}" ]
             then
                 conf_problem="ProtectHome"
-            else
-                conf_problem=""
             fi
             ;;
     esac
 
     if [ -n "${conf_problem}" ]
     then
-
         echo "Your MariaDB server variable '${conf_var}' points to '${conf_val}' location and currently MariaDB systemd service file prevents that."
-        echo "To solve configuration problem you should create '/etc/systemd/system/mariadb.service.d/overwrite.conf'"
-        echo "In that file, under a [Service] section, recommend configure ReadWritePaths=${conf_val}"
+        echo "To solve configuration problem you should 'systemctl edit $SERVICE_NAME'"
+
+        echo "In this editor, under a [Service] section, recommend configure Read${conf_read_x_paths}Paths=${conf_val}."
         echo "Alternately disable protection with ${conf_problem}=No"
         echo -e "\nWithout modification of your '${conf_var}' configuration or suggested systemd service file changes"
         echo -e "it's most likely your MariaDB database won't start!\n"
         echo "Read more from systemd.exec(5) man page or https://www.freedesktop.org/software/systemd/man/systemd.exec.html"
-        return 1
+        exit 1
     fi
 done

--- a/support-files/mariadb-execstartpre-check.sh
+++ b/support-files/mariadb-execstartpre-check.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# This script purpose is to check if MariaDB
+# configuration has problematic configurations
+# and make more reasonable error messages than
+# it does now
+#
+# To make this script work you need:
+#   * my_print_defaults from MariaDB package
+#   * systemctl from systemd package
+#
+# If you want to get rid of this checking then
+# you have add service file or profile.d enviromental
+# variable (with value = 1):
+# MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
+#
+# And if you don't like to use systemd then add
+# variable
+# MARIADB_DO_NOT_EXECSTARTPRE_SYSTEMCTL=1
+#
+# Example add file /etc/systemd/system/mariadb.service.d/nocheck.conf
+# [Service]
+# Environment=MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
+#
+
+# If ENV variable MARIADB_DO_NOT_EXECSTARTPRE_CHECK is set
+# Then just exit
+if [ -n "${MARIADB_DO_NOT_EXECSTARTPRE_CHECK}" ]
+then
+    exit 0
+fi
+
+MY_PRINT_DEFAULTS=""
+
+if [ -x "@bindir@/my_print_defaults" ]
+then
+   MY_PRINT_DEFAULTS="@bindir@/my_print_defaults"
+fi
+
+if [ -z "${MY_PRINT_DEFAULTS}" ]
+then
+    echo "Can't find tool: 'my_print_defaults' in path."
+    echo "You need to check your system settings or set enviromental"
+    echo "variable: MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1 to prevent this error"
+    exit 1
+fi
+
+MARIADB_PROTECTSYSTEM=""
+MARIADB_PROTECTHOME=""
+
+# If ENV variable MARIADB_DO_NOT_EXECSTARTPRE_SYSTEMCTL is set
+# then do not use system stuff
+if [ -z "${MARIADB_DO_NOT_EXECSTARTPRE_SYSTEMCTL}" ]
+then
+    # Check service file should we even check
+    # anything. If ProtectHome and ProtectSystem
+    # are disabled then there is not issues
+    MARIADB_PROTECTSYSTEM=$(systemctl cat mariadb.service | grep -e "^ProtectSystem=no")
+    MARIADB_PROTECTHOME=$(systemctl cat mariadb.service | grep -e "^ProtectHome=no")
+
+    # If both are set then just exit as everything is fine
+    if [ -n "${MARIADB_PROTECTSYSTEM}" ] && [ -n "${MARIADB_PROTECTHOME}" ]
+    then
+        exit 0
+    fi
+fi
+
+
+#
+# Check with my_print_defaults that any
+# path in configuration is not pointing somewhere
+# we can't write or it is invisible
+#
+# Check with systemctl cat mariadb*.service
+# if user has already altered service file to
+# allow writing to there locations
+#
+my_print_defaults --mysqld | while read -r setting
+do
+    conf_var=${setting%%=*}
+    conf_var=${conf_var#--}
+    conf_val=${setting#*=}
+    conf_problem=""
+
+    # These are the places that systemd
+    # is prevented currently to write or access
+    case "$conf_val" in
+            # ProtectSystem prevents writes to /usr, /boot and /efi
+        /usr|/usr/*|/boot|/boot/*|/efi|/efi/*)
+            if [ -z "${MARIADB_PROTECTSYSTEM}" ]
+            then
+                conf_problem="ProtectSystem"
+            else
+                conf_problem=""
+            fi
+            ;;
+            # ProtectHome prevents access to /home, /root and /run/user
+        /home|/home/*|/root|/root/*|/run/user|/run/user*)
+            if [ -z "${MARIADB_PROTECTHOME}" ]
+            then
+                conf_problem="ProtectHome"
+            else
+                conf_problem=""
+            fi
+            ;;
+    esac
+
+    if [ -n "${conf_problem}" ]
+    then
+
+        echo "Your MariaDB server variable '${conf_var}' points to '${conf_val}' location and currently MariaDB systemd service file prevents that."
+        echo "To solve configuration problem you should create '/etc/systemd/system/mariadb.service.d/overwrite.conf'"
+        echo "In that file, under a [Service] section, recommend configure ReadWritePaths=${conf_val}"
+        echo "Alternately disable protection with ${conf_problem}=No"
+        echo -e "\nWithout modification of your '${conf_var}' configuration or suggested systemd service file changes"
+        echo -e "it's most likely your MariaDB database won't start!\n"
+        echo "Read more from systemd.exec(5) man page or https://www.freedesktop.org/software/systemd/man/systemd.exec.html"
+        return 1
+    fi
+done

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -68,6 +68,17 @@ PermissionsStartOnly=true
 
 @SYSTEMD_EXECSTARTPRE@
 
+# Check if there is some problem that prevents to start
+# turn off with enviromenta variable:
+# MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
+#
+# This can be done with systemd service file by
+# adding file '/etc/systemd/system/mariadb.service.d/nocheck.conf'
+# with content:
+# [Service]
+# Environment=MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
+ExecStart=@bindir@/mariadb-execstartpre-check
+
 # Perform automatic wsrep recovery. When server is started without wsrep,
 # galera_recovery simply returns an empty string. In any case, however,
 # the script is not expected to return with a non-zero status.

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -68,16 +68,12 @@ PermissionsStartOnly=true
 
 @SYSTEMD_EXECSTARTPRE@
 
-# Check if there is some problem that prevents to start
-# turn off with enviromenta variable:
-# MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
-#
-# This can be done with systemd service file by
-# adding file '/etc/systemd/system/mariadb.service.d/nocheck.conf'
-# with content:
+# Check if there is system variables/path permission problems prevent starting.
+# Turn off with:
 # [Service]
-# Environment=MARIADB_DO_NOT_EXECSTARTPRE_CHECK=1
-ExecStart=@bindir@/mariadb-execstartpre-check
+# Environment=MARIADB_DO_NOT_PRE_CHECK=1
+# per the instructions at the top of this file.
+ExecStartPre=@bindir@/mariadb-execstartpre-check
 
 # Perform automatic wsrep recovery. When server is started without wsrep,
 # galera_recovery simply returns an empty string. In any case, however,

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -76,6 +76,13 @@ PermissionsStartOnly=true
 
 @SYSTEMD_EXECSTARTPRE@
 
+# Check if there is system variables/path permission problems prevent starting.
+# Turn off with:
+# [Service]
+# Environment=MARIADB_DO_NOT_PRE_CHECK=1
+# per the instructions at the top of this file.
+ExecStartPre=@bindir@/mariadb-execstartpre-check mariadb@%i.service
+
 # Perform automatic wsrep recovery. When server is started without wsrep,
 # galera_recovery simply returns an empty string. In any case, however,
 # the script is not expected to return with a non-zero status.


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-25177*

## Description
SystemD parameter ProtectSystem prevents writing to '/usr', '/boot' and '/efi' (also /etc). If for example datadir if located '/usr/lib/mariadb' then MariaDB will just die away without much notice to user. Same goes with 'ProtectHome' that hides '/home', '/root' and '/run/user'

## How can this PR be tested?
Create /etc/my.cnf with 'datadir'-parameter or other config with incorrect location and install deb-package it should print warning.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
