### PR TITLE
result of wsrep logic in queue_for_group_commit was being ignored

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7784,6 +7784,8 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
     cur= entry->thd->wait_for_commit_ptr;
   }
 
+  result= orig_queue == NULL;
+
 #ifdef WITH_WSREP
   if (wsrep_is_active(entry->thd) &&
       wsrep_run_commit_hook(entry->thd, entry->all))
@@ -7807,7 +7809,6 @@ MYSQL_BIN_LOG::queue_for_group_commit(group_commit_entry *orig_entry)
 
   DBUG_PRINT("info", ("Queued for group commit as %s",
                       (orig_queue == NULL) ? "leader" : "participant"));
-  result= orig_queue == NULL;
 
 end:
   if (backup_lock_released)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
The result of wsrep logic in `MYSQL_BIN_LOG::queue_for_group_commit` was being ignored.
This could cause out of order wsrep checkpoints due wsrep specific leader code not being executed in `MYSQL_BIN_LOG::write_transaction_to_binlog_events`, resulting in a race for the checkpoint.
This patch moves the "original" result assignment to before wsrep logic to prevent that.

## How can this PR be tested?
Check that this doesn't introduce any other issues.
The out of order checkpoint triggers an assertion for `xid_seqno > wsrep_seqno` inside `trx_rseg_update_wsrep_checkpoint`.
Without the fix, this would trigger sporadically on highly conflicting multi-master load (a race situation).
There are a few JIRA tickets referencing this assertion, but they're all closed.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [X] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


