### PR TITLE
Bugfix: Re-enable events_statements_current by default

### DIFF
--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -759,6 +759,7 @@ The following specify which files/extra groups are read (specified before remain
  --performance-schema-consumer-events-statements-current 
  Default startup value for the events_statements_current
  consumer.
+ (Defaults to on; use --skip-performance-schema-consumer-events-statements-current to disable.)
  --performance-schema-consumer-events-statements-history 
  Default startup value for the events_statements_history
  consumer.
@@ -1653,7 +1654,7 @@ performance-schema-accounts-size -1
 performance-schema-consumer-events-stages-current FALSE
 performance-schema-consumer-events-stages-history FALSE
 performance-schema-consumer-events-stages-history-long FALSE
-performance-schema-consumer-events-statements-current FALSE
+performance-schema-consumer-events-statements-current TRUE
 performance-schema-consumer-events-statements-history FALSE
 performance-schema-consumer-events-statements-history-long FALSE
 performance-schema-consumer-events-transactions-current FALSE

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -781,7 +781,7 @@ static struct my_option pfs_early_options[]=
     "Default startup value for the events_statements_current consumer.",
     &pfs_param.m_consumer_events_statements_current_enabled,
     &pfs_param.m_consumer_events_statements_current_enabled, 0, GET_BOOL,
-    OPT_ARG, FALSE, 0, 0, 0, 0, 0},
+    OPT_ARG, TRUE, 0, 0, 0, 0, 0},
   {"performance_schema_consumer_events_statements_history", 0,
     "Default startup value for the events_statements_history consumer.",
     &pfs_param.m_consumer_events_statements_history_enabled,


### PR DESCRIPTION
The Performance Schema events_statements_current table was enabled by default at
least in MariaDB 10.2 to 10.4. However in commit 7af733a5a2 in 10.5 it was
disabled without being mentioned as an intentional change in the commit message,
nor is there an MDEV issue or mention in the 10.5 release notes.

It seems that this setting was disabled unintentionally. The table is relevant
for Performance Schema to be useful in MariaDB 10.5 and onwards and most users
with Performance Schema enabled would have this table enabled as well, so it
makes sense to continue to keep it enabled and revert the unmotivated change
done in 10.5.

All new code of the whole pull request, including one or several files that are
either new files or modified ones, are contributed under the BSD-new license. I
am contributing on behalf of my employer Amazon Web Services, Inc.