### PR TITLE
MDEV-24978 crash with transaction on table with no PK and long fulltext column

### DIFF
--- a/mysql-test/suite/galera/r/galera_fulltext.result
+++ b/mysql-test/suite/galera/r/galera_fulltext.result
@@ -36,6 +36,34 @@ DROP TABLE t1;
 DROP TABLE ten;
 connection node_1;
 SET @value=REPEAT (1,5001);
+CREATE TABLE t (a VARCHAR(5000),FULLTEXT (a)) engine=innodb;
+INSERT IGNORE INTO t VALUES(@value);
+Warnings:
+Warning	1265	Data truncated for column 'a' at row 1
+SELECT COUNT(*) FROM t;
+COUNT(*)
+1
+connection node_2;
+SELECT COUNT(*) FROM t;
+COUNT(*)
+1
+connection node_1;
+DROP TABLE t;
+CREATE TABLE t (a VARCHAR(5000)) engine=innodb;
+INSERT IGNORE INTO t VALUES(@value);
+Warnings:
+Warning	1265	Data truncated for column 'a' at row 1
+SELECT COUNT(*) FROM t;
+COUNT(*)
+1
+connection node_2;
+SELECT COUNT(*) FROM t;
+COUNT(*)
+1
+connection node_1;
+DROP TABLE t;
+connection node_1;
+SET @value=REPEAT (1,5001);
 CREATE TABLE t (a VARCHAR(5000),FULLTEXT (a)) engine=innodb DEFAULT CHARSET=utf8;
 INSERT IGNORE INTO t VALUES(@value);
 Warnings:

--- a/mysql-test/suite/galera/t/galera_fulltext.test
+++ b/mysql-test/suite/galera/t/galera_fulltext.test
@@ -60,7 +60,30 @@ SELECT COUNT(f1) = 1000 FROM t1 WHERE MATCH(f1) AGAINST ('abcdefjhk');
 
 DROP TABLE t1;
 DROP TABLE ten;
+#
+# MDEV-24978 : SIGABRT in __libc_message
+#
+--connection node_1
+SET @value=REPEAT (1,5001);
+CREATE TABLE t (a VARCHAR(5000),FULLTEXT (a)) engine=innodb;
+INSERT IGNORE INTO t VALUES(@value);
+SELECT COUNT(*) FROM t;
 
+--connection node_2
+SELECT COUNT(*) FROM t;
+
+--connection node_1
+DROP TABLE t;
+CREATE TABLE t (a VARCHAR(5000)) engine=innodb;
+INSERT IGNORE INTO t VALUES(@value);
+SELECT COUNT(*) FROM t;
+
+--connection node_2
+SELECT COUNT(*) FROM t;
+
+--connection node_1
+DROP TABLE t;
+ 
 #
 # Case 2: UTF-8
 #

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7103,9 +7103,13 @@ wsrep_store_key_val_for_row(
 
 			/* In a column prefix index, we may need to truncate
 			the stored value: */
-
 			if (true_len > key_len) {
 				true_len = key_len;
+			}
+			/* cannot exceed max column lenght either, we may need to truncate
+			the stored value: */
+			if (true_len > sizeof(sorted)) {
+			  true_len = sizeof(sorted);
 			}
 
 			memcpy(sorted, data, true_len);
@@ -7119,8 +7123,8 @@ wsrep_store_key_val_for_row(
 				actual data. The rest of the space was reset to zero
 				in the bzero() call above. */
 				if (true_len > buff_space) {
-					fprintf (stderr,
-						 "WSREP: key truncated: %s\n",
+					WSREP_DEBUG (
+						 "write set key truncated for: %s\n",
 						 wsrep_thd_query(thd));
 					true_len = buff_space;
 				}


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-24978*
## Description
If a table has no unique indexes, write set key information for cluster replication, will be collected from all the columns in the table.
However, the write set key information has space only for max 3500 bytes for individual column, and if a varchar column of such a table with no primary key, is longer than this limit, currently a crash follows.
The fix in this commit, is to truncate key values extracted from such long varchar columns to max 3500 bytes.

## How can this PR be tested?
This pull request brings back a, previously reverted,  test scenario in galera.galera_fulltext test, for verifying if the fix is present or not.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
The fix may potentially lead to false positive certification failures for transactions, which operate on separate cluster nodes, and update/insert/delete table rows, which differ only in the part of such long columns after 3500 bytes border.
