### PR TITLE
MDEV-22708 Assertion `!mysql_bin_log.is_open() || thd.is_current_stmt…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-22708.result
+++ b/mysql-test/suite/galera/r/MDEV-22708.result
@@ -1,0 +1,11 @@
+connection node_2;
+connection node_1;
+SET @wsrep_forced_binlog_format_saved = @@GLOBAL.wsrep_forced_binlog_format;
+SET @@GLOBAL.wsrep_forced_binlog_format = STATEMENT;
+CREATE TABLE t1(c INT PRIMARY KEY) ENGINE = MyISAM;
+INSERT DELAYED INTO t1 VALUES (1),(2),(3);
+SELECT SLEEP(1);
+SLEEP(1)
+0
+DROP TABLE t1;
+SET @@GLOBAL.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_saved;

--- a/mysql-test/suite/galera/t/MDEV-22708.cnf
+++ b/mysql-test/suite/galera/t/MDEV-22708.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+log-bin

--- a/mysql-test/suite/galera/t/MDEV-22708.test
+++ b/mysql-test/suite/galera/t/MDEV-22708.test
@@ -1,0 +1,14 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+SET @wsrep_forced_binlog_format_saved = @@GLOBAL.wsrep_forced_binlog_format;
+SET @@GLOBAL.wsrep_forced_binlog_format = STATEMENT;
+
+CREATE TABLE t1(c INT PRIMARY KEY) ENGINE = MyISAM;
+
+INSERT DELAYED INTO t1 VALUES (1),(2),(3);
+SELECT SLEEP(1);
+
+DROP TABLE t1;
+
+SET @@GLOBAL.wsrep_forced_binlog_format = @wsrep_forced_binlog_format_saved;

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -474,7 +474,7 @@ void upgrade_lock_type(THD *thd, thr_lock_type *lock_type,
     }
 
     bool log_on= (thd->variables.option_bits & OPTION_BIN_LOG);
-    if (global_system_variables.binlog_format == BINLOG_FORMAT_STMT &&
+    if (thd->wsrep_binlog_format() == BINLOG_FORMAT_STMT &&
         log_on && mysql_bin_log.is_open())
     {
       /*


### PR DESCRIPTION
…_binlog_format_row()' failed in Delayed_insert::handle_inserts and in Diagnostics_area::set_eof_status

Variable wsrep_forced_binlog_format has higher priority than
binlog_format. In situation where STATEMENT is used and DELAYED INSERT
is executing we should fall back to non-delay INSERT.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-22708*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
If used `wsrep_forced_binlog_format` has higher priority, so for DELAYED INSERT this need to be checked as well. In case of STATEMENT used we should skip DELAY logic.

## How can this PR be tested?
MTR test included in PR.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


