### PR TITLE
MDEV-27066 Fixed scientific notation parsing bug

### DIFF
--- a/mysql-test/r/parser.result
+++ b/mysql-test/r/parser.result
@@ -1338,3 +1338,34 @@ Select view_definition from information_schema.views where table_schema='test' a
 view_definition
 select 1 not between 2 like 3 and 4 AS `1 not between (2 like 3) and 4`
 drop view v1;
+#
+# Start of 10.2 tests
+#
+#
+# MDEV-27066 Fixed scientific notation parser
+#
+SELECT 1 1.e*1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e*1' at line 1
+SELECT 1 1.e/1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e/1' at line 1
+SELECT 1 1.e^1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e^1' at line 1
+SELECT 1 1.e%1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e%1' at line 1
+SELECT 1 1.e&1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e&1' at line 1
+SELECT 1 1.e|1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e|1' at line 1
+SELECT 1.e(1);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e(1)' at line 1
+SELECT (1 1.e);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e)' at line 1
+SELECT 1 1.e, 1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e, 1' at line 1
+CREATE TABLE scientific_notation (test int);
+SELECT tmp 1.e.test FROM scientific_notation AS tmp;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '1.e.test FROM scientific_notation AS tmp' at line 1
+DROP TABLE scientific_notation;
+#
+# End of 10.2 tests
+#

--- a/mysql-test/t/parser.test
+++ b/mysql-test/t/parser.test
@@ -1365,3 +1365,49 @@ create or replace view v1 as select 1 not between (2 like 3) and 4;
 Select view_definition from information_schema.views where table_schema='test' and table_name='v1';
 
 drop view v1;
+
+--echo #
+--echo # Start of 10.2 tests
+--echo #
+--echo #
+
+--echo # MDEV-27066 Fixed scientific notation parser
+--echo #
+
+--error ER_PARSE_ERROR
+SELECT 1 1.e*1;
+
+--error ER_PARSE_ERROR
+SELECT 1 1.e/1;
+
+--error ER_PARSE_ERROR
+SELECT 1 1.e^1;
+
+--error ER_PARSE_ERROR
+SELECT 1 1.e%1;
+
+--error ER_PARSE_ERROR
+SELECT 1 1.e&1;
+
+--error ER_PARSE_ERROR
+SELECT 1 1.e|1;
+
+--error ER_PARSE_ERROR
+SELECT 1.e(1);
+
+--error ER_PARSE_ERROR
+SELECT (1 1.e);
+
+--error ER_PARSE_ERROR
+SELECT 1 1.e, 1;
+
+CREATE TABLE scientific_notation (test int);
+
+--error ER_PARSE_ERROR
+SELECT tmp 1.e.test FROM scientific_notation AS tmp;
+
+DROP TABLE scientific_notation;
+
+--echo #
+--echo # End of 10.2 tests
+--echo #

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1664,8 +1664,7 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
           c = lip->yyGet();                     // Skip sign
 	if (!my_isdigit(cs,c))
 	{				// No digit after sign
-	  state= MY_LEX_CHAR;
-	  break;
+	  return (ABORT_SYM);
 	}
         while (my_isdigit(cs,lip->yyGet())) ;
         yylval->lex_str=get_token(lip, 0, lip->yyLength());


### PR DESCRIPTION
## Description
There is a scientific notation bug that uses the e notation which was discovered many years ago and was used to bypass some Web Application Firewall.

With more research, I found out more use case to this bug and that it is possible to bypass modern WAF as the query seems to be invalid but is valid.

So the following query that seems to be invalid:

```
mysql> select id 1.e, char 10.e(id 2.e), concat 3.e('a'12356.e,'b'1.e,'c'1.1234e)1.e, 12 1.e*2 1.e, 12 1.e/2 1.e, 12 1.e|2 1.e, 12 1.e^2 1.e, 12 1.e%2 1.e, 12 1.e&2 from test;
+------+--------------------------------------+------------------------------------------+----------+----------+----------+----------+----------+----------+
| id   | char 10.e(id 2.e)                    | concat 3.e('a'12356.e,'b'1.e,'c'1.1234e) | 12 1.e*2 | 12 1.e/2 | 12 1.e|2 | 12 1.e^2 | 12 1.e%2 | 12 1.e&2 |
+------+--------------------------------------+------------------------------------------+----------+----------+----------+----------+----------+----------+
|    1 | 0x01                                 | abc                                      |       24 |   6.0000 |       14 |       14 |        0 |        0 |
|    2 | 0x02                                 | abc                                      |       24 |   6.0000 |       14 |       14 |        0 |        0 |
|    3 | 0x03                                 | abc                                      |       24 |   6.0000 |       14 |       14 |        0 |        0 |
+------+--------------------------------------+------------------------------------------+----------+----------+----------+----------+----------+----------+
3 rows in set (0.00 sec)
```

Is in fact valid and the same as this query:

```
mysql> select id, char(id), concat('a','b','c'), 12*2, 12/2, 12|2, 12^2, 12%2, 12&2 from test.test;
+------+--------------------+---------------------+------+--------+------+------+------+------+
| id   | char(id)           | concat('a','b','c') | 12*2 | 12/2   | 12|2 | 12^2 | 12%2 | 12&2 |
+------+--------------------+---------------------+------+--------+------+------+------+------+
|    1 | 0x01               | abc                 |   24 | 6.0000 |   14 |   14 |    0 |    0 |
|    2 | 0x02               | abc                 |   24 | 6.0000 |   14 |   14 |    0 |    0 |
|    3 | 0x03               | abc                 |   24 | 6.0000 |   14 |   14 |    0 |    0 |
+------+--------------------+---------------------+------+--------+------+------+------+------+
3 rows in set (0.00 sec)
```

The bug is that when the code think that it is a float token containing a dot and the e notion, it does a check if the following character is a digit and if not, set the state to "MY_LEX_CHAR" which is the equivalent to "MY_LEX_SKIP" and drop the token completely. Therefore, all the "1.e" that you see in the previous query are dropped from the query completely. Note that that number in front or after the dot does not matter and that the dot is mandatory for it to work.

The bug works by following any of these characters to the notation:
```
( ) . , | & % * ^ /
```

The fix should be enough to simply abort the query if no digit follows the "dot e notation". I tested it locally and it worked, however, more tests should be done to make sure it does not break anything else.

## How can this PR be tested?
Since the bug happens only with the "dot e notation" followed by any of these characters:

```
( ) . , | & % * ^ /
```

It would only require you to write a query with any of these about. Also, the query provided in the description could be used (or any part of it individually).

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

1. Does this affect the on-disk format used by MariaDB? **No**
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch? **No**
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix? **No**