### PR TITLE
MDEV-26779 : reduce lock_sys.wait_mutex contention by using spinloop …

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18576,7 +18576,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
       /* Do not bother with lock elision using transactional memory here;
       this is rather complex code */
       LockMutexGuard g{SRW_LOCK_CALL};
-      mysql_mutex_lock(&lock_sys.wait_mutex);
+      lock_sys.wait_mutex_lock();
       vtrx->mutex_lock();
       /* victim transaction is either active or prepared, if it has already
 	 proceeded to replication phase */
@@ -18620,7 +18620,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
             WSREP_DEBUG("kill transaction skipped due to wsrep_aborter set");
         }
       }
-      mysql_mutex_unlock(&lock_sys.wait_mutex);
+      lock_sys.wait_mutex_unlock();
       vtrx->mutex_unlock();
     }
     wsrep_thd_UNLOCK(vthd);

--- a/storage/innobase/srv/srv0mon.cc
+++ b/storage/innobase/srv/srv0mon.cc
@@ -1687,14 +1687,14 @@ srv_mon_process_existing_counter(
 
 	/* innodb_row_lock_time_avg */
 	case MONITOR_OVLD_LOCK_AVG_WAIT_TIME:
-		mysql_mutex_lock(&lock_sys.wait_mutex);
+		lock_sys.wait_mutex_lock();
 		if (auto count = lock_sys.get_wait_cumulative()) {
 			value = lock_sys.get_wait_time_cumulative() / 1000
 				/ count;
 		} else {
 			value = 0;
 		}
-		mysql_mutex_unlock(&lock_sys.wait_mutex);
+		lock_sys.wait_mutex_unlock();
 		break;
 
 	/* innodb_row_lock_waits */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1116,7 +1116,7 @@ srv_export_innodb_status(void)
 
 	export_vars.innodb_log_writes = srv_stats.log_writes;
 
-	mysql_mutex_lock(&lock_sys.wait_mutex);
+	lock_sys.wait_mutex_lock();
 	export_vars.innodb_row_lock_waits = lock_sys.get_wait_cumulative();
 
 	export_vars.innodb_row_lock_current_waits= lock_sys.get_wait_pending();
@@ -1125,7 +1125,7 @@ srv_export_innodb_status(void)
 		/ 1000;
 	export_vars.innodb_row_lock_time_max = lock_sys.get_wait_time_max()
 		/ 1000;
-	mysql_mutex_unlock(&lock_sys.wait_mutex);
+	lock_sys.wait_mutex_unlock();
 
 	export_vars.innodb_row_lock_time_avg= export_vars.innodb_row_lock_waits
 		? static_cast<ulint>(export_vars.innodb_row_lock_time


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-26779*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
MDEV-26779: reduce lock_sys.wait_mutex contention by using spinloop construct

* wait_mutex plays an important role when the workload involves
  conflicting transactions.

* On a heavily contented system with increasing scalability
  quite possible that the majority of the transactions may have to wait
  before acquiring resources.

* This causes a lot of contention of wait_mutex but most of this
  the contention is short-lived that tend to suggest the use of spin loop
  to avoid giving up compute core that in turn will involve os-scheduler
  with additional latency.

## How can this PR be tested?
* Execute performance test (sysbench zipfian helps produce contention-based workload).

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
- [x ] *This is a performance improvement*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
Not Applicable.
