### PR TITLE
remove assignment in wsrep_innobase_kill_one_trx causing deadlocks

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18693,7 +18693,6 @@ wsrep_innobase_kill_one_trx(
 		WSREP_DEBUG("kill trx QUERY_EXEC for " TRX_ID_FMT,
 			    victim_trx->id);
 
-		victim_trx->lock.was_chosen_as_deadlock_victim= TRUE;
 		if (victim_trx->lock.wait_lock) {
 			WSREP_DEBUG("victim has wait flag: %ld",
 				thd_get_thread_id(thd));


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Remove extra assignment of `victim_trx->lock.was_chosen_as_deadlock_victim=TRUE`.
It's already assigned under the `victim_trx->lock.wait_lock` test.
Under heavy load, this could sporadically cause a deadlock due to the flag not being reset
when the transaction object gets reused for the next operation, preventing this next
operation from being BF aborted (the flag already being set causes relevant code to be skipped).
This affects MariaDB up to version 10.3.

## How can this PR be tested?
This should introduce no regressions.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [X] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*


