### PR TITLE
MDEV-21252: Support extra initialization file for mysql_install_db

### DIFF
--- a/man/mysql_install_db.1
+++ b/man/mysql_install_db.1
@@ -345,6 +345,21 @@ runs using your current login name and files and directories that it creates wil
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mysql_install_db: extra-file option
+.\" extra-file option: mysql_install_db
+\fB\-\-extra-file=\fR\fB\fIfile_path\fR\fR
+.sp
+Add user defined SQL file, to be executed following regular database initialization.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mysql_install_db: verbose option
 .\" verbose option: mysql_install_db
 \fB\-\-verbose\fR

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -40,6 +40,7 @@ cross_bootstrap=0
 auth_root_authentication_method=socket
 auth_root_socket_user=""
 skip_test_db=0
+extra_file=""
 
 dirname0=`dirname $0 2>/dev/null`
 dirname0=`dirname $dirname0 2>/dev/null`
@@ -95,6 +96,8 @@ Usage: $0 [OPTIONS]
                        user.  You must be root to use this option.  By default
                        mysqld runs using your current login name and files and
                        directories that it creates will be owned by you.
+  --extra-file=file    Add user defined SQL file, to be executed following
+                       regular database initialization.
 
 All other options are passed to the mysqld program
 
@@ -178,6 +181,8 @@ parse_arguments()
       --auth-root-socket-user=*)
         auth_root_socket_user="$(parse_arg "$arg")" ;;
       --skip-test-db) skip_test_db=1 ;;
+      --extra-file=*)
+        extra_file="$(parse_arg "$arg")" ;;
 
       *)
         if test -n "$pick_args"
@@ -399,6 +404,13 @@ do
   fi
 done
 
+# Verify extra file exists if it's not null
+if test ! -z "$extra_file" -a ! -f "$extra_file"
+then
+  cannot_find_file "$extra_file"
+  exit 1
+fi
+
 if test ! -x "$mysqld"
 then
   cannot_find_file "$mysqld"
@@ -553,6 +565,12 @@ cat_sql()
   if test "$skip_test_db" -eq 0
   then
     cat "$mysql_test_db"
+  fi
+
+  # cat extra file if it's not null
+  if test ! -z "$extra_file"
+  then
+    cat "$extra_file"
   fi
 }
 


### PR DESCRIPTION
## Description

The mysql_install_db script is used to initialize the data directory.
However, if the user needs to apply some customized init commands (for
example to change user or password) they have to start the database
with `--skip-grant-tables` after the install script, and then restart
the database with normal mode.

To make it easier to include customization in the mysql_install_db
script, in this commit, a new parameter `extra-init-file` is added in
mysql_install_db script to support some extra customized init commands.

With this option we can support applying extra init file for
mysql_install_db command line at runtime, which reduces the complexity
of customized initialization process.

This script is only used for install and is not included in the mtr
bootstrap file. Commit also updates the man page.

## How can this PR be tested?

This script is only used for install and is not included in the mtr bootstrap files.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility

This is a new feature introducing a new command-line argument that should not affect backwards compatibility.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.