### PR TITLE
add JSON_HB to system variables and mysqld help text

### DIFF
--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -368,7 +368,8 @@ The following specify which files/extra groups are read (specified before remain
  Specifies type of the histograms created by ANALYZE.
  Possible values are: SINGLE_PREC_HB - single precision
  height-balanced, DOUBLE_PREC_HB - double precision
- height-balanced.
+ height-balanced.JSON_HB - height-balanced, stores values
+ not fractions
  --host-cache-size=# How many host names should be cached to avoid resolving.
  (Automatically configured unless set explicitly)
  --idle-readonly-transaction-timeout=# 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6494,7 +6494,8 @@ static Sys_var_enum Sys_histogram_type(
        "Specifies type of the histograms created by ANALYZE. "
        "Possible values are: "
        "SINGLE_PREC_HB - single precision height-balanced, "
-       "DOUBLE_PREC_HB - double precision height-balanced.",
+       "DOUBLE_PREC_HB - double precision height-balanced."
+       "JSON_HB - height-balanced, stores values not fractions",
        SESSION_VAR(histogram_type), CMD_LINE(REQUIRED_ARG),
        histogram_types, DEFAULT(1));
 


### PR DESCRIPTION
Following Ian's [comment on Jira](https://jira.mariadb.org/browse/MDEV-21130?focusedCommentId=200162&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-200162), this updates the `histogram_type` system variable to include `JSON_HB`.

Signed-off-by: Michael Okoko <okokomichaels@outlook.com>

