### PR TITLE
MDEV-26855: Enable spinning for log_sys_mutex and log_flush_order_mutex

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -175,8 +175,14 @@ void log_t::create()
   ut_ad(!is_initialised());
   m_initialised= true;
 
+#if defined(__aarch64__)
+  mysql_mutex_init(log_sys_mutex_key, &mutex, MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(
+    log_flush_order_mutex_key, &flush_order_mutex, MY_MUTEX_INIT_FAST);
+#else
   mysql_mutex_init(log_sys_mutex_key, &mutex, nullptr);
   mysql_mutex_init(log_flush_order_mutex_key, &flush_order_mutex, nullptr);
+#endif
 
   /* Start the lsn from one log block from zero: this way every
   log record has a non-zero start lsn, a fact which we will use */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-26855*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
As part of MDEV-26779 we first discovered the effect of enabling spinning for
some critical mutex. MDEV-26779 tried enabling it for lock_sys.wait_mutex and
observed a good gain in performance.

In yet another discussion, Mark Callaghan pointed a reference to pthread based
mutex spin using PTHREAD_MUTEX_ADAPTIVE_NP (MDEV-26769 Intel RTM).

Given the strong references, Marko Makela as part of his comment in #1923
pointed an idea to enable spinning for other mutexes. Based on perf profiling
we decided to explore spinning for log_sys_mutex and log_flush_order_mutex as
they are occupying the top slots in the contented mutex list.

The evaluation showed promising results for ARM64 but not for x86.
So a patch is here-by proposed to enable the spinning of the mutex for
ARM64-based platform.

## How can this PR be tested?
* Benchmark baseline against patched version using sysbench or similar test-case on ARM.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
- [X] *This is performance improvement to existing feature* 

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
Not applicable
