### PR TITLE
MDEV-22200: Include header row in txt files exported by mysqldump

### DIFF
--- a/man/mysqldump.1
+++ b/man/mysqldump.1
@@ -1003,6 +1003,21 @@ Available from MariaDB 10.0.13, and is used together with \fB\-\-master\-data\fR
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mysqldump: header option
+.\" header option: mysqldump
+\fB\-\-header\fR
+.sp
+Used together with --tab. When enabled, adds header with column names to the top of output txt files.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mysqldump: hex-blob option
 .\" hex-blob option: mysqldump
 \fB\-\-hex\-blob\fR

--- a/mysql-test/main/mysqldump-header.result
+++ b/mysql-test/main/mysqldump-header.result
@@ -1,0 +1,90 @@
+CREATE TABLE `courses` (
+`course_id` smallint(20) PRIMARY KEY,
+`name` varchar(50),
+`description` varchar(100),
+`num_years` tinyint(1),
+`escape_çÇÁá!#%"'` varchar(10)
+);
+desc courses;
+Field	Type	Null	Key	Default	Extra
+course_id	smallint(20)	NO	PRI	NULL	
+name	varchar(50)	YES		NULL	
+description	varchar(100)	YES		NULL	
+num_years	tinyint(1)	YES		NULL	
+escape_çÇÁá!#%"'	varchar(10)	YES		NULL	
+INSERT INTO `courses` VALUES (5, 'Course 1', 'Course Description 1', 3, NULL);
+#
+# Dump only data rows into outfile with default options
+#
+5	Course 1	Course Description 1	3	\N
+#
+# Dump header and data rows into outfile with default options
+#
+course_id	name	description	num_years	escape_çÇÁá!#%"'
+5	Course 1	Course Description 1	3	\N
+#
+# Dump header and data rows into outfile with comma delimited fields
+#
+course_id,name,description,num_years,escape_çÇÁá!#%"'
+5,Course 1,Course Description 1,3,\N
+#
+# Dump header and data rows into outfile with single quote enclosed fields
+#
+'course_id'	'name'	'description'	'num_years'	'escape_çÇÁá!#%"\''
+'5'	'Course 1'	'Course Description 1'	'3'	\N
+#
+# Dump header and data rows into outfile with optional single quote enclosed fields
+#
+'course_id'	'name'	'description'	'num_years'	'escape_çÇÁá!#%"\''
+'5'	'Course 1'	'Course Description 1'	'3'	\N
+#
+# Dump header and data rows into outfile with semicolon terminated data rows
+#
+course_id	name	description	num_years	escape_çÇÁá!#%"';5	Course 1	Course Description 1	3	\N;
+#
+# Dump header and data rows into outfile with several options above combined
+#
+'course_id','name','description','num_years','escape_çÇÁá!#%"\'';'5','Course 1','Course Description 1','3',\N;
+'course_id','name','description','num_years','escape_çÇÁá!#%"\'';'5','Course 1','Course Description 1','3',\N;INSERT INTO `courses` VALUES (4, 'Course 2', 'Course Description 2', 4, NULL);
+INSERT INTO `courses` VALUES (3, 'Course 3', 'Course Description 3', 3, NULL);
+INSERT INTO `courses` VALUES (2, 'Course 4', 'Course Description 4', 5, NULL);
+INSERT INTO `courses` VALUES (1, 'Course 5', 'Course Description 5', 3, NULL);
+
+#
+# Dump data rows into outfile with --where clause
+#
+2	Course 4	Course Description 4	5	\N
+#
+# Dump header and data rows into outfile with --where clause. The header must remain on top and not meddle among data rows
+#
+course_id	name	description	num_years	escape_çÇÁá!#%"'
+2	Course 4	Course Description 4	5	\N
+#
+# Dump data rows ordered by primary key.
+#
+1	Course 5	Course Description 5	3	\N
+2	Course 4	Course Description 4	5	\N
+3	Course 3	Course Description 3	3	\N
+4	Course 2	Course Description 2	4	\N
+5	Course 1	Course Description 1	3	\N
+#
+# Dump header and data rows ordered by primary key. The header must remain on top and not meddle among data rows
+#
+course_id	name	description	num_years	escape_çÇÁá!#%"'
+1	Course 5	Course Description 5	3	\N
+2	Course 4	Course Description 4	5	\N
+3	Course 3	Course Description 3	3	\N
+4	Course 2	Course Description 2	4	\N
+5	Course 1	Course Description 1	3	\N
+#
+# Dump data rows from an empty table, must generate no output
+#
+DELETE FROM `courses`;
+#
+# Dump header and data rows from an empty table, must generate a single header line as output
+#
+course_id	name	description	num_years	escape_çÇÁá!#%"'
+#
+# Use header without the --tab option. Must produce an error
+#
+DROP TABLE `courses`;

--- a/mysql-test/main/mysqldump-header.test
+++ b/mysql-test/main/mysqldump-header.test
@@ -1,0 +1,112 @@
+--source include/not_embedded.inc
+
+CREATE TABLE `courses` (
+  `course_id` smallint(20) PRIMARY KEY,
+  `name` varchar(50),
+  `description` varchar(100),
+  `num_years` tinyint(1),
+  `escape_çÇÁá!#%"'` varchar(10)
+);
+
+desc courses;
+
+INSERT INTO `courses` VALUES (5, 'Course 1', 'Course Description 1', 3, NULL);
+
+--echo #
+--echo # Dump only data rows into outfile with default options
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows into outfile with default options
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows into outfile with comma delimited fields
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header --fields-terminated-by , test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows into outfile with single quote enclosed fields
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header --fields-enclosed-by \' test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows into outfile with optional single quote enclosed fields
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header --fields-optionally-enclosed-by \' test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows into outfile with semicolon terminated data rows
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header --lines-terminated-by \; test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo
+--echo #
+--echo # Dump header and data rows into outfile with several options above combined
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header --fields-terminated-by , --fields-enclosed-by \' --lines-terminated-by \; test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+--echo
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header --fields-terminated-by , --fields-optionally-enclosed-by \' --lines-terminated-by \; test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+INSERT INTO `courses` VALUES (4, 'Course 2', 'Course Description 2', 4, NULL);
+INSERT INTO `courses` VALUES (3, 'Course 3', 'Course Description 3', 3, NULL);
+INSERT INTO `courses` VALUES (2, 'Course 4', 'Course Description 4', 5, NULL);
+INSERT INTO `courses` VALUES (1, 'Course 5', 'Course Description 5', 3, NULL);
+
+--echo
+--echo #
+--echo # Dump data rows into outfile with --where clause
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --where "num_years=5" test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows into outfile with --where clause. The header must remain on top and not meddle among data rows
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --where "num_years=5" --header test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump data rows ordered by primary key.
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --order-by-primary test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows ordered by primary key. The header must remain on top and not meddle among data rows
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --order-by-primary --header test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump data rows from an empty table, must generate no output
+--echo #
+DELETE FROM `courses`;
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Dump header and data rows from an empty table, must generate a single header line as output
+--echo #
+--exec $MYSQL_DUMP -u root --tab $MYSQLTEST_VARDIR/ --header test
+--cat_file $MYSQLTEST_VARDIR/courses.txt
+
+--echo #
+--echo # Use header without the --tab option. Must produce an error
+--echo #
+--error 1
+--exec $MYSQL_DUMP -u root --header test
+
+DROP TABLE `courses`;
+--remove_file $MYSQLTEST_VARDIR/courses.txt
+--remove_file $MYSQLTEST_VARDIR/courses.sql


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-22200*

## Description
This PR improves *mysqldump* tool with a *--header* flag for the *--tab* option, so that a row of column headers is included in the exported txt files, providing further compliance to the standard CSV format. Invoking *mysqldump database --tab \<path\> --header* adds a header row with column names to the text files generated by *--tab*. The options *--fields-terminated-by*, *--fields-enclosed-by*, *--fields-optionally-enclosed-by* and *--lines-terminated-by* also apply to the header row. If the *--header* option is used without a leading *--tab* option, an error occurs.

## How can this PR be tested?
It can be tested by running *test_issue_22200.sh* and checking its output against *test_issue_22200.output*.
The bash script file *test_issue_22200.sh* creates a small database with a single table from the file *test_issue_22200.sql*, runs a set of dumps with the *--tab* option in several different conditions (field termination, enclosing, lines termination, illegal use, etc.) and analyses the resulting output. The aggregated output of all the tests should match the *test_issue_22200.output* file which contains the correct expected output. The test kit comprises the following attached files:

- test_issue_22200.sh
- test_issue_22200.sql
- test_issue_22200.output

[test_issue_22200.zip](https://github.com/MariaDB/server/files/7406429/test_issue_22200.zip)

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
Not relevant