### PR TITLE
Remove DYNAMIC_ARRAY get_index_dynamic()

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -850,7 +850,6 @@ extern void delete_dynamic(DYNAMIC_ARRAY *array);
 extern void delete_dynamic_element(DYNAMIC_ARRAY *array, size_t array_index);
 extern void delete_dynamic_with_callback(DYNAMIC_ARRAY *array, FREE_FUNC f);
 extern void freeze_size(DYNAMIC_ARRAY *array);
-extern int  get_index_dynamic(DYNAMIC_ARRAY *array, void *element);
 #define dynamic_array_ptr(array,array_index) ((array)->buffer+(array_index)*(array)->size_of_element)
 #define dynamic_element(array,array_index,type) ((type)((array)->buffer) +(array_index))
 #define push_dynamic(A,B) insert_dynamic((A),(B))

--- a/mysys/array.c
+++ b/mysys/array.c
@@ -375,29 +375,3 @@ void freeze_size(DYNAMIC_ARRAY *array)
     array->max_element= elements;
   }
 }
-
-#ifdef NOT_USED
-/*
-  Get the index of a dynamic element
-
-  SYNOPSIS
-    get_index_dynamic()
-     array	Array
-     element Whose element index
-
-*/
-
-int get_index_dynamic(DYNAMIC_ARRAY *array, void* element)
-{
-  size_t ret;
-  if (array->buffer > (uchar*) element)
-    return -1;
-
-  ret= ((uchar*) element - array->buffer) /  array->size_of_element;
-  if (ret > array->elements)
-    return -1;
-
-  return ret;
-
-}
-#endif


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: https://jira.mariadb.org/browse/MDEV-26981 *

## Description

The DYNAMIC_ARRAY copies values in and copies values out.

Without a comparitor function, get_index_dynamic() does not make a lot of sense, especially once the array grows.

If we have a need for a function like it in the future, I propose we write a new one with unit tests showing how it is used and demonstrating that it behaves as expected.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This function was not used, and wouldn't have given reasonable results (in all but the most exceptional cases) if it was.