### PR TITLE
MDEV-26989: Fix PCRE2 download URL in CMake

### DIFF
--- a/cmake/pcre.cmake
+++ b/cmake/pcre.cmake
@@ -44,8 +44,8 @@ MACRO(BUNDLE_PCRE2)
   ExternalProject_Add(
     pcre2
     PREFIX   "${dir}"
-    URL      "http://ftp.pcre.org/pub/pcre/pcre2-10.37.zip"
-    URL_MD5  8c1699a725d4b28410adf4b964ebbcb7
+    GIT_REPOSITORY "https://github.com/PhilipHazel/pcre2.git"
+    GIT_TAG "pcre2-10.37"
     INSTALL_COMMAND ""
     CMAKE_ARGS
       "-DPCRE2_BUILD_TESTS=OFF"


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-26989*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Currently, we fail to build MariaDB 10.5 or later for Windows as below.
https://github.com/mroonga/mroonga/runs/4127863361?check_suite_focus=true#step:12:581

Because MariaDB can't download PCRE2 source codes when MariaDB is built by CMake.

The following URL for downloading PCRE2 is already invalid.
http://ftp.pcre.org/

https://www.pcre.org/ says "Note that the former
ftp.pcre.org FTP site is no longer available.
You will need to update any scripts that download PCRE
source code to download via HTTPS, Git, or Subversion
from the new home on GitHub instead.".

We need to use the following URL for downloading PCRE2 source codes.
https://github.com/PhilipHazel/pcre2.git

MariaDB 10.5 or later has this issue.

This patch resolves the builds error on CMake.

The version of PCRE2 that is installed by this patch same version until now.
Therefore, I think that this patch does not introduce side effects in other parts of the server.

## How can this PR be tested?

1. cmake ../${mariadb-source-dir} -A "winx64" -G  "Visual Studio 16 2019"
2. cmake --build . --config RelWithDebInfo --target package

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

1. Does this affect the on-disk format used by MariaDB?

No.

2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?

No.

3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?

Yes.