### PR TITLE
Debian: comment default config

### DIFF
--- a/debian/additions/mariadb.conf.d/50-server.cnf
+++ b/debian/additions/mariadb.conf.d/50-server.cnf
@@ -12,14 +12,11 @@
 # * Basic Settings
 #
 
-user                    = mysql
+#user                    = mysql
 pid-file                = /run/mysqld/mysqld.pid
 basedir                 = /usr
-datadir                 = /var/lib/mysql
-tmpdir                  = /tmp
-lc-messages-dir         = /usr/share/mysql
-lc-messages             = en_US
-skip-external-locking
+#datadir                 = /var/lib/mysql
+#tmpdir                  = /tmp
 
 # Broken reverse DNS slows down connections considerably and name resolve is
 # safe to skip if there are no "host by domain name" access grants


### PR DESCRIPTION
There's no need for Debian to set config items to their
default. Left commented socket, user, datadir and tmpdir as
these may want to be changed. lc-messages and skip-external-locks
are so infrequently set even listing them looks overly verbose.