### PR TITLE
MDEV-26558: Fix a deadlock due to cyclic dependence

### DIFF
--- a/extra/mariabackup/xbstream.cc
+++ b/extra/mariabackup/xbstream.cc
@@ -440,8 +440,8 @@ extract_worker_thread_func(void *arg)
 		}
 
 		if (chunk.type == XB_CHUNK_TYPE_EOF) {
-			pthread_mutex_lock(ctxt->mutex);
 			pthread_mutex_unlock(&entry->mutex);
+			pthread_mutex_lock(ctxt->mutex);
 			my_hash_delete(ctxt->filehash, (uchar *) entry);
 			pthread_mutex_unlock(ctxt->mutex);
 


### PR DESCRIPTION
Fix a potential deadlock bug between locks ctrl_mutex and entry->mutex

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
https://jira.mariadb.org/browse/MDEV-26558?filter=-2

## How can this PR be tested?
TODO: fill steps to reproduce here, if applicable,
      or remove the section

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

