### PR TITLE
MDEV-26317: Make sure that tar-ball has write permissions to default database path

### DIFF
--- a/cmake/systemd.cmake
+++ b/cmake/systemd.cmake
@@ -49,6 +49,12 @@ MACRO(CHECK_SYSTEMD)
           SET(SYSTEMD_EXECSTARTPRE "ExecStartPre=/usr/bin/install -m 755 -o mysql -g root -d /var/run/mysqld")
           SET(SYSTEMD_EXECSTARTPOST "ExecStartPost=/etc/mysql/debian-start")
         ENDIF()
+        IF(NOT DEB AND NOT RPM)
+          SET(SYSTEMD_READWRITEPATH "# Database dir: '${MYSQL_DATADIR}' should be writable even
+# ProtectSystem=full prevents it
+ReadWritePaths=-${MYSQL_DATADIR}\n")
+        ENDIF()
+
         MESSAGE_ONCE(systemd "Systemd features enabled")
       ELSE()
         UNSET(LIBSYSTEMD)

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -55,6 +55,8 @@ CapabilityBoundingSet=CAP_IPC_LOCK
 # Prevent writes to /usr, /boot, and /etc
 ProtectSystem=full
 
+@SYSTEMD_READWRITEPATH@
+
 # Doesn't yet work properly with SELinux enabled
 # NoNewPrivileges=true
 

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -63,6 +63,8 @@ CapabilityBoundingSet=CAP_IPC_LOCK
 # Prevent writes to /usr, /boot, and /etc
 ProtectSystem=full
 
+@SYSTEMD_READWRITEPATH@
+
 # Doesn't yet work properly with SELinux enabled
 # NoNewPrivileges=true
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-26317*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Add SYSTEMD_READWRITEPATH-variable to mariadb.service.in to make sure that
if one is not building RPM or DEB packages then make sure there is ReadWritePaths
directive is defined in systemd service file.
This ensures that tar-ball installation has right to write database default
installation path (default: /usr/local/mysql/data) even if it's located
under /usr. Writing to that location is prevented by 'ProtectSystem=full'
systemd directive by default.

## How can this PR be tested?
Merge PR and make cpack tar ball. Then in support-files/mariadb.service file there should be ReadWritePaths-directive pointing to /usr/local/mysql/data.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This is upward compatible
