### PR TITLE
MDEV-26674: Set innodb_use_native_aio=OFF when using io_uring on a potentially affected kernel

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -19396,7 +19396,14 @@ bool innodb_use_native_aio_default()
 #ifdef HAVE_URING
   utsname &u= uname_for_io_uring;
   if (!uname(&u) && u.release[0] == '5' && u.release[1] == '.' &&
-      u.release[2] == '1' && u.release[3] > '0' && u.release[3] < '6')
+      u.release[2] == '1' && u.release[3] > '0' && u.release[3] < '6' /* 5.10 > && < 5.16 */
+      && !(u.release[3] == '4' && u.release[4] == '.' && /* 5.14. */
+        ((u.release[5] >= '2' && isdigit(u.release[6])) || /* 5.14.[2+]\d is ok */
+	(isdigit(u.release[5]) && isdigit(u.release[6]) && isdigit(u.release[7])) || /* 5.14.\d\d\d* is ok */
+        (u.release[5] == '1' && u.release[6] == '9'))) /* 5.14.19 is ok */
+      && !(u.release[3] == '5' && u.release[4] == '.' && /* 5.15. */
+        (u.release[5] >= '3' || isdigit(u.release[6])))  /* 5.15.3+ and 5.15.X\d* are ok */
+      )
   {
     io_uring_may_be_unsafe= u.release;
     return false; /* working around io_uring hangs (MDEV-26674) */


### PR DESCRIPTION
This appends 1193a793c40b806c6f1f007bbd87f4d9a73e686d to include the
stable kernel versions between 5.10 and 5.16.

5.15.3 includes the kernel fix https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.15.3
5.14.19 includes the kernel fix https://cdn.kernel.org/pub/linux/kernel/v5.x/ChangeLog-5.14.19

To confirm the previous assumption that 5.16 is going to be fixed
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v5.16-rc1&id=d3e3c102d107bb84251455a298cf475f24bab995
is the applicable commit.

Tested:
```
$ uname -r
5.14.20-200.fc34.x86_64
$ mariadblocal
Installing MariaDB/MySQL system tables in '/tmp/build-mariadb-server-10.6-datadir' ...
2021-11-23 11:37:23 0 [Note] /home/dan/repos/build-mariadb-server-10.6/sql/mysqld (server 10.6.6-MariaDB) starting as process 3805 ...
2021-11-23 11:37:23 0 [Note] InnoDB: The first data file './ibdata1' did not exist. A new tablespace will be created!
2021-11-23 11:37:23 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
2021-11-23 11:37:23 0 [Note] InnoDB: Number of pools: 1
2021-11-23 11:37:23 0 [Note] InnoDB: Using crc32 + pclmulqdq instructions
2021-11-23 11:37:23 0 [Note] InnoDB: Using liburing
2021-11-23 11:37:23 0 [Note] InnoDB: Initializing buffer pool, total size = 134217728, chunk size = 134217728
...

$ mc -e 'show global variables like "%aio"'
+-----------------------+-------+
| Variable_name         | Value |
+-----------------------+-------+
| innodb_use_native_aio | ON    |
+-----------------------+-------+
```