### PR TITLE
MDEV-27143 Different result when group by with correct function

### DIFF
--- a/mysql-test/r/olap.result
+++ b/mysql-test/r/olap.result
@@ -844,3 +844,24 @@ DROP TABLE t1;
 #
 # End of 10.1 tests
 #
+#
+# MDEV-27143 Rollup results should have NULL for non-aggregated result columns
+#
+create table t (c int);
+insert into t values (20121212),(9),(19800101),(20121212),(19800101);
+select c, count(*) from t group by c desc with rollup;
+c	count(*)
+20121212	2
+19800101	2
+9	1
+NULL	5
+select c, count(*) from t group by convert(c, int) desc with rollup;
+c	count(*)
+20121212	2
+19800101	2
+9	1
+NULL	5
+drop table t;
+#
+# End of 10.2 tests
+#

--- a/mysql-test/t/olap.test
+++ b/mysql-test/t/olap.test
@@ -466,3 +466,17 @@ DROP TABLE t1;
 --echo #
 --echo # End of 10.1 tests
 --echo #
+
+--echo #
+--echo # MDEV-27143 Rollup results should have NULL for non-aggregated result columns
+--echo #
+
+create table t (c int);
+insert into t values (20121212),(9),(19800101),(20121212),(19800101);
+select c, count(*) from t group by c desc with rollup;
+select c, count(*) from t group by convert(c, int) desc with rollup;
+drop table t;
+
+--echo #
+--echo # End of 10.2 tests
+--echo #

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -24407,7 +24407,22 @@ bool JOIN::rollup_make_fields(List<Item> &fields_arg, List<Item> &sel_fields,
             null_item->result_field= item->get_tmp_table_field();
             item= null_item;
 	    break;
-	  }
+          }
+          else
+          {
+             if(group_tmp->item_ptr->type() != Item::FIELD_ITEM &&
+                item->type() == Item::FIELD_ITEM &&
+                item->eq(group_tmp->item_ptr->next,0))
+             {
+                Item_null_result *null_item= new (thd->mem_root) Item_null_result(thd);
+                if (!null_item)
+                  return 1;
+                item->maybe_null= 1;          // Value will be null sometimes
+                null_item->result_field= item->get_tmp_table_field();
+                item= null_item;
+                break;
+             }
+          }
 	}
       }
       ref_array_start[ref_array_ix]= item;


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-27143

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27143*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
