### PR TITLE
 MDEV-25424 my_multi_malloc large to use my_large_malloc

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -166,10 +166,13 @@ typedef void (*MALLOC_SIZE_CB) (long long size, my_bool is_thread_specific);
 extern void set_malloc_size_cb(MALLOC_SIZE_CB func);
 
 	/* defines when allocating data */
+#define MY_MEMORY_HEADER_SIZE 24
 extern void *my_malloc(PSI_memory_key key, size_t size, myf MyFlags);
+extern void *my_psi_key_init(PSI_memory_key key, void *mh, size_t size, myf my_flags);
 extern void *my_multi_malloc(PSI_memory_key key, myf MyFlags, ...);
 extern void *my_multi_malloc_large(PSI_memory_key key, myf MyFlags, ...);
 extern void *my_realloc(PSI_memory_key key, void *ptr, size_t size, myf MyFlags);
+extern void *my_psi_key_free(void *ptr);
 extern void my_free(void *ptr);
 extern void *my_memdup(PSI_memory_key key, const void *from,size_t length,myf MyFlags);
 extern char *my_strdup(PSI_memory_key key, const char *from,myf MyFlags);

--- a/mysys/mulalloc.c
+++ b/mysys/mulalloc.c
@@ -69,11 +69,13 @@ void* my_multi_malloc(PSI_memory_key key, myf myFlags, ...)
 
   SYNOPSIS
     my_multi_malloc()
+      key                  Memory instrumentation key
       myFlags              Flags
 	ptr1, length1      Multiple arguments terminated by null ptr
 	ptr2, length2      ...
         ...
 	NULL
+	ret_total_length   size_t pointer that gets the size allocated
 */
 
 void *my_multi_malloc_large(PSI_memory_key key, myf myFlags, ...)
@@ -81,7 +83,8 @@ void *my_multi_malloc_large(PSI_memory_key key, myf myFlags, ...)
   va_list args;
   char **ptr,*start,*res;
   ulonglong tot_length,length;
-  DBUG_ENTER("my_multi_malloc");
+  size_t *ret_total_length;
+  DBUG_ENTER("my_multi_malloc_large");
 
   va_start(args,myFlags);
   tot_length=0;
@@ -90,11 +93,15 @@ void *my_multi_malloc_large(PSI_memory_key key, myf myFlags, ...)
     length=va_arg(args,ulonglong);
     tot_length+=ALIGN_SIZE(length);
   }
+  ret_total_length= va_arg(args, size_t *);
+  *ret_total_length= tot_length + MY_MEMORY_HEADER_SIZE;
   va_end(args);
 
-  if (!(start=(char *) my_malloc(key, (size_t) tot_length, myFlags)))
+  if (!(start=(char *) my_large_malloc(ret_total_length,
+                                       myFlags)))
     DBUG_RETURN(0); /* purecov: inspected */
 
+  start= my_psi_key_init(key, start, tot_length, myFlags);
   va_start(args,myFlags);
   res=start;
   while ((ptr=va_arg(args, char **)))

--- a/mysys/my_malloc.c
+++ b/mysys/my_malloc.c
@@ -26,7 +26,7 @@ struct my_memory_header
   PSI_memory_key m_key;
 };
 typedef struct my_memory_header my_memory_header;
-#define HEADER_SIZE 24
+#define HEADER_SIZE MY_MEMORY_HEADER_SIZE
 
 #define USER_TO_HEADER(P) ((my_memory_header*)((char *)(P) - HEADER_SIZE))
 #define HEADER_TO_USER(P) ((char*)(P) + HEADER_SIZE)
@@ -54,8 +54,35 @@ void set_malloc_size_cb(MALLOC_SIZE_CB func)
 {
   update_malloc_size= func ? func : dummy;
 }
-    
-    
+
+
+/**
+  Initialize a memory key at the location.
+
+  @param ptr    Pointer to the allocated memory of size= size+HEADER_SIZE
+  @param size   The size of the user portion of the memory block in bytes.
+  @param flags  Failure action modifiers (bitmasks).
+
+  @return A pointer to the user memory
+*/
+void *my_psi_key_init(PSI_memory_key key, void *ptr, size_t size, myf my_flags)
+{
+  my_memory_header *mh = (my_memory_header *) ptr;
+  void *point;
+  int flag= MY_TEST(my_flags & MY_THREAD_SPECIFIC);
+  mh->m_size= size | flag;
+  mh->m_key= PSI_CALL_memory_alloc(key, size, & mh->m_owner);
+  update_malloc_size(size + HEADER_SIZE, flag);
+  point= HEADER_TO_USER(mh);
+  if (my_flags & MY_ZEROFILL)
+    bzero(point, size);
+  else
+    TRASH_ALLOC(point, size);
+
+  return point;
+}
+
+
 /**
   Allocate a sized block of memory.
 
@@ -101,17 +128,7 @@ void *my_malloc(PSI_memory_key key, size_t size, myf my_flags)
     point= NULL;
   }
   else
-  {
-    int flag= MY_TEST(my_flags & MY_THREAD_SPECIFIC);
-    mh->m_size= size | flag;
-    mh->m_key= PSI_CALL_memory_alloc(key, size, & mh->m_owner);
-    update_malloc_size(size + HEADER_SIZE, flag);
-    point= HEADER_TO_USER(mh);
-    if (my_flags & MY_ZEROFILL)
-      bzero(point, size);
-    else
-      TRASH_ALLOC(point, size);
-  }
+    point= my_psi_key_init(key, mh, size, my_flags);
   DBUG_PRINT("exit",("ptr: %p", point));
   DBUG_RETURN(point);
 }
@@ -179,6 +196,27 @@ void *my_realloc(PSI_memory_key key, void *old_point, size_t size, myf my_flags)
 
 
 /**
+  Mark the PSI key assocated with this memory to be free.
+
+  @param ptr Pointer to user memory returned by my_psi_key_init.
+  @returns ptr to start of memory allocated.
+*/
+void *my_psi_key_free(void *ptr)
+{
+  my_memory_header *mh;
+  size_t old_size;
+  my_bool old_flags;
+  mh= USER_TO_HEADER(ptr);
+  old_size= mh->m_size & ~1;
+  old_flags= mh->m_size & 1;
+  PSI_CALL_memory_free(mh->m_key, old_size, mh->m_owner);
+
+  update_malloc_size(- (longlong) old_size - HEADER_SIZE, old_flags);
+  return mh;
+}
+
+
+/**
   Free memory allocated with my_malloc.
 
   @param ptr Pointer to the memory allocated by my_malloc.
@@ -186,8 +224,9 @@ void *my_realloc(PSI_memory_key key, void *old_point, size_t size, myf my_flags)
 void my_free(void *ptr)
 {
   my_memory_header *mh;
+#ifndef SAFEMALLOC
   size_t old_size;
-  my_bool old_flags;
+#endif
   DBUG_ENTER("my_free");
   DBUG_PRINT("my",("ptr: %p", ptr));
 
@@ -195,18 +234,17 @@ void my_free(void *ptr)
     DBUG_VOID_RETURN;
 
   mh= USER_TO_HEADER(ptr);
-  old_size= mh->m_size & ~1;
-  old_flags= mh->m_size & 1;
-  PSI_CALL_memory_free(mh->m_key, old_size, mh->m_owner);
-
-  update_malloc_size(- (longlong) old_size - HEADER_SIZE, old_flags);
-
 #ifndef SAFEMALLOC
+  old_size= mh->m_size & ~1;
+  my_psi_key_free(ptr);
+
   /*
     Trash memory if not safemalloc. We don't have to do this if safemalloc
     is used as safemalloc will also do trashing
   */
   TRASH_FREE(ptr, old_size);
+#else
+  my_psi_key_free(ptr);
 #endif
   sf_free(mh);
   DBUG_VOID_RETURN;

--- a/storage/maria/ma_pagecache.c
+++ b/storage/maria/ma_pagecache.c
@@ -874,7 +874,7 @@ size_t init_pagecache(PAGECACHE *pagecache, size_t use_mem,
                                 &pagecache->file_blocks,
                                 (ulonglong) (sizeof(PAGECACHE_BLOCK_LINK*) *
                                              changed_blocks_hash_size),
-                                NullS))
+                                NullS, &pagecache->block_root_size))
         break;
       my_large_free(pagecache->block_mem, pagecache->mem_size);
       pagecache->block_mem= 0;
@@ -932,7 +932,8 @@ err:
   }
   if (pagecache->block_root)
   {
-    my_free(pagecache->block_root);
+    my_large_free(my_psi_key_free(pagecache->block_root),
+                  pagecache->block_root_size);
     pagecache->block_root= NULL;
   }
   my_errno= error;
@@ -1201,9 +1202,11 @@ void end_pagecache(PAGECACHE *pagecache, my_bool cleanup)
 
     if (pagecache->block_mem)
     {
-      my_large_free(pagecache->block_mem, pagecache->mem_size);
+      my_large_free(pagecache->block_mem,
+                    pagecache->mem_size);
       pagecache->block_mem= NULL;
-      my_free(pagecache->block_root);
+      my_large_free(my_psi_key_free(pagecache->block_root),
+                    pagecache->block_root_size);
       pagecache->block_root= NULL;
     }
     pagecache->disk_blocks= -1;

--- a/storage/maria/ma_pagecache.h
+++ b/storage/maria/ma_pagecache.h
@@ -162,6 +162,7 @@ typedef struct st_pagecache
   size_t warm_blocks;            /* number of blocks in warm sub-chain       */
   size_t cnt_for_resize_op;      /* counter to block resize operation        */
   size_t blocks_available;       /* number of blocks available in the LRU chain */
+  size_t block_root_size;        /* size of memory allocated to block_root   */
   ssize_t blocks;                /* max number of blocks in the cache        */
   uint32 block_size;             /* size of the page buffer of a cache block */
   PAGECACHE_HASH_LINK **hash_root;/* arr. of entries into hash table buckets */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25424*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

As the default Key cache and page cache are > 2MB, it makes sense to use a large memory pages when these are allocated. As these are rather fixed RAM areas keeping the minimal number of TLB entries is preferred.

The current my_multi_malloc_large doesn't actually do large allocations currently.


## How can this PR be tested?

Boot with kernel arguments `hugepagesz=2M hugepages=256` or run with the Windows permission `LockPagesInMemory`.

mysql-test/mtr  --mysqld=--large-pages --suite=maria,main --big-test --force

(force to ignore the default values of large pages test in main).

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

A user who previous has large-pages enable, will get more large pages used. Not a big problem as large page allocations fall back to normal memoy allocation if insufficient memory.
