### PR TITLE
MDEV-27206: [ERROR] Duplicated key: "cause" assertion 

### DIFF
--- a/mysql-test/main/explain_json.result
+++ b/mysql-test/main/explain_json.result
@@ -2000,3 +2000,16 @@ EXPLAIN
   }
 }
 DROP TABLE t1;
+#
+# MDEV-27206: [ERROR] Duplicated key: cause, Assertion `is_uniq_key' failed with optimizer trace
+#
+CREATE TABLE t1 (a INT) ENGINE=MyISAM;
+CREATE TABLE t2 (pk TIME, b INT, primary key (pk), key (b)) ENGINE=MyISAM;
+INSERT INTO t2 VALUES
+('00:13:33',0),('00:13:34',1),('00:13:35',2),('00:13:36',3),
+('00:13:37',4),('00:13:38',5),('00:13:39',6),('00:13:40',7),
+('00:13:41',8),('00:13:42',9);
+SET optimizer_trace = 'enabled=on';
+SELECT * FROM t1 WHERE a IN ( SELECT b FROM t2 INNER JOIN t1 ON (a = pk) );
+a
+DROP TABLE t1, t2;

--- a/mysql-test/main/explain_json.test
+++ b/mysql-test/main/explain_json.test
@@ -429,3 +429,17 @@ explain FORMAT=JSON
 SELECT * FROM t1 t0 
 WHERE t0.a IN (SELECT t2.a FROM t1 t2 WHERE t0.a IN (SELECT t3.a FROM t1 t3));
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-27206: [ERROR] Duplicated key: cause, Assertion `is_uniq_key' failed with optimizer trace
+--echo #
+
+CREATE TABLE t1 (a INT) ENGINE=MyISAM;
+CREATE TABLE t2 (pk TIME, b INT, primary key (pk), key (b)) ENGINE=MyISAM;
+INSERT INTO t2 VALUES
+  ('00:13:33',0),('00:13:34',1),('00:13:35',2),('00:13:36',3),
+  ('00:13:37',4),('00:13:38',5),('00:13:39',6),('00:13:40',7),
+  ('00:13:41',8),('00:13:42',9);
+SET optimizer_trace = 'enabled=on';
+SELECT * FROM t1 WHERE a IN ( SELECT b FROM t2 INNER JOIN t1 ON (a = pk) );
+DROP TABLE t1, t2;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -7891,7 +7891,7 @@ best_access_path(JOIN      *join,
                 /* quick_range couldn't use key! */
                 records= (double) s->records/rec;
                 trace_access_idx.add("used_range_estimates", false)
-                                .add("cause", "not available");
+                                .add("reason", "not available");
               }
             }
             else


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27206*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
use "reason" for used_range_estimates in best_access_path
## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
