### PR TITLE
Fix for the test galera.galera_UK_conflict

### DIFF
--- a/mysql-test/suite/galera/r/galera_UK_conflict.result
+++ b/mysql-test/suite/galera/r/galera_UK_conflict.result
@@ -71,6 +71,31 @@ INSERT INTO t1 VALUES (8,8,8);
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 7
+SELECT * FROM t1;
+f1	f2	f3
+1	1	0
+3	3	1
+4	4	2
+5	5	2
+7	7	7
+8	8	8
+10	10	0
+connection node_1;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+7
+SELECT * FROM t1;
+f1	f2	f3
+1	1	0
+3	3	1
+4	4	2
+5	5	2
+7	7	7
+8	8	8
+10	10	0
+DROP TABLE t1;
+test scenario 2
+connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 int, f3 int,  unique key keyj (f2));
 INSERT INTO t1 VALUES (1, 1, 0);
 INSERT INTO t1 VALUES (3, 3, 0);
@@ -92,9 +117,9 @@ SET SESSION wsrep_on = 1;
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
 connection node_1;
-SELECT COUNT(*) FROM t1;
-COUNT(*)
-7
+COMMIT;
+connection node_1a;
+SET SESSION wsrep_on = 0;
 SET SESSION wsrep_on = 1;
 SET GLOBAL wsrep_provider_options = 'dbug=';
 SET GLOBAL DEBUG_DBUG = "d,sync.wsrep_replay_cb";
@@ -125,8 +150,32 @@ f1	f2	f3
 3	3	1
 4	4	2
 5	5	2
-8	8	8
 10	10	0
 INSERT INTO t1 VALUES (7,7,7);
 INSERT INTO t1 VALUES (8,8,8);
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+7
+SELECT * FROM t1;
+f1	f2	f3
+1	1	0
+3	3	1
+4	4	2
+5	5	2
+7	7	7
+8	8	8
+10	10	0
+connection node_1;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+7
+SELECT * FROM t1;
+f1	f2	f3
+1	1	0
+3	3	1
+4	4	2
+5	5	2
+7	7	7
+8	8	8
+10	10	0
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_UK_conflict.test
+++ b/mysql-test/suite/galera/t/galera_UK_conflict.test
@@ -207,13 +207,15 @@ INSERT INTO t1 VALUES (5, 5, 2);
 --source include/galera_set_sync_point.inc
 
 --connection node_1
---let $wait_condition = SELECT COUNT(*) = 7 FROM t1
---source include/wait_condition.inc
-SELECT COUNT(*) FROM t1;
+--send COMMIT
+
+--connection node_1a
 # wait for the local commit to enter in commit monitor wait state
 --let $galera_sync_point = apply_monitor_slave_enter_sync commit_monitor_master_enter_sync
 --source include/galera_wait_sync_point.inc
 --source include/galera_clear_sync_point.inc
+
+# first applier is now  waiting in before commit, and local trx in commit monitor
 
 # set sync point before replaying
 SET GLOBAL DEBUG_DBUG = "d,sync.wsrep_replay_cb";


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here
mtr test galera.galera_UK_conflict, has rather distorted logic in test scenario 2.

The test would fail always with:

CURRENT_TEST: galera.galera_UK_conflict
mysqltest: In included file "./include/galera_wait_sync_point.inc":
included from /home/seppo/work/wsrep/mariadb-server/mysql-test/suite/galera/t/galera_UK_conflict.test at line 216:
At line 3: query 'SET SESSION wsrep_on = 0' failed: 1179: You are not allowed to execute this command in a transaction

This happens because wait_condition is called in wrong connection (node_1, which is executing MST transaction)

This test is fixed by using control connection for wait condition checking, and new result is recorded as well


<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
