### PR TITLE
Deb: Adapt custom build steps to be compatible with latest Salsa-CI

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -32,11 +32,11 @@ build:
     # Run Salsa-CI .build-before-script equivalent
     - mkdir -p ${WORKING_DIR} ${CCACHE_WORK_DIR}
     - mv ${CCACHE_WORK_DIR} ${CCACHE_TMP_DIR}
-    # Run Salsa-CI .build-script equivalent
-    - export CCACHE_DIR="${CCACHE_TMP_DIR}"
-    - apt-get update && eatmydata apt-get install --yes --no-install-recommends aptitude devscripts ccache equivs
+    # Run Salsa-CI .build-script equivalent, with extra devscripts so autobake-deb.sh can run 'dch'
+    - export CCACHE_DIR=${CCACHE_TMP_DIR}
+    - apt-get update && eatmydata apt-get install --no-install-recommends -y ccache fakeroot build-essential devscripts
     - cd ${WORKING_DIR}/${SOURCE_DIR}
-    - eatmydata install-build-deps.sh .
+    - eatmydata apt-get build-dep --no-install-recommends -y .
     - update-ccache-symlinks; ccache -z # Zero out ccache counters
     - while true; do sleep 600; echo "10 minutes passed" >&2; done & # Progress keeper since build is long and silent
     - debian/autobake-deb.sh |& tail -n 10000 # Keep Gitlab-CI output under 4 MB
@@ -44,7 +44,7 @@ build:
     - rm -rf ${WORKING_DIR}/${SOURCE_DIR}
     - du -shc ${WORKING_DIR}/* # Show total file size of artifacts. Must stay are under 100 MB.
     - ccache -s # Show ccache stats to validate it worked
-    - mv ${CCACHE_TMP_DIR} ${CCACHE_WORK_DIR} || true
+    - mv ${CCACHE_TMP_DIR} ${CCACHE_WORK_DIR}
 
 build bullseye-backports:
   extends: .build-package
@@ -77,45 +77,6 @@ build i386:
 
 build native deb:
   extends: .build-package
-  script: &buildpackage-script |
-    mkdir -p ${WORKING_DIR} ${CCACHE_WORK_DIR}
-    mv ${CCACHE_WORK_DIR} ${CCACHE_TMP_DIR}
-    export CCACHE_DIR=${CCACHE_TMP_DIR}
-    # Add deb-src entries
-    sed -n '/^deb\s/s//deb-src /p' /etc/apt/sources.list > /etc/apt/sources.list.d/deb-src.list
-    apt-get update && eatmydata apt-get install --no-install-recommends -y \
-     aptitude \
-     devscripts \
-     ccache \
-     equivs \
-     build-essential \
-     python3
-    # Enter source package dir
-    cd ${WORKING_DIR}/${SOURCE_DIR}
-    # Install package build dependencies
-    eatmydata install-build-deps.sh .
-    # Generate ccache links
-    dpkg-reconfigure ccache
-    PATH="/usr/lib/ccache/:${PATH}"
-    # Reset ccache stats
-    ccache -z
-    # Create salsaci user and fix permissions
-    useradd salsaci
-    chown -R salsaci. ${WORKING_DIR} ${CCACHE_DIR}
-    # Define buildlog filename
-    BUILD_LOGFILE_SOURCE=$(dpkg-parsechangelog -S Source)
-    BUILD_LOGFILE_VERSION=$(dpkg-parsechangelog -S Version)
-    BUILD_LOGFILE_VERSION=${BUILD_LOGFILE_VERSION#*:}
-    BUILD_LOGFILE_ARCH=$(dpkg --print-architecture)
-    BUILD_LOGFILE="${WORKING_DIR}/${BUILD_LOGFILE_SOURCE}_${BUILD_LOGFILE_VERSION}_${BUILD_LOGFILE_ARCH}.build"
-    # Build package as user salsaci
-    su salsaci -c "eatmydata dpkg-buildpackage ${DB_BUILD_PARAM}" |& OUTPUT_FILENAME=${BUILD_LOGFILE} filter-output
-    # Restore PWD to ${WORKING_DIR}
-    cd ${WORKING_DIR}
-    rm -rf ${WORKING_DIR}/${SOURCE_DIR}
-    # Print ccache stats on job log
-    ccache -s
-    mv ${CCACHE_TMP_DIR} ${CCACHE_WORK_DIR}
 
 piuparts:
   extends: .test-piuparts


### PR DESCRIPTION
Upstream Salsa-CI refactored the build process in
https://salsa.debian.org/salsa-ci-team/pipeline/-/commit/58880fcef5b742cb9c661121a8c8707bf392b3b5

This broke our custom direct invocation of install-build-deps.sh as the
Salsa-CI images no longer contain them. Adapt the .build-script
equivalent to follow new Salsa-CI method so builds work again.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
Only affects Salsa-CI.
