### PR TITLE
MDEV-27544 database() function should return 64 characters

### DIFF
--- a/mysql-test/r/func_system.result
+++ b/mysql-test/r/func_system.result
@@ -46,7 +46,7 @@ create table t1 (version char(60)) select database(), user(), version() as 'vers
 show create table t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `database()` varchar(34) CHARACTER SET utf8 DEFAULT NULL,
+  `database()` varchar(64) CHARACTER SET utf8 DEFAULT NULL,
   `user()` varchar(141) CHARACTER SET utf8 DEFAULT NULL,
   `version` char(60) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
@@ -95,3 +95,21 @@ select left(concat(a,version()),1) from t1;
 left(concat(a,version()),1)
 a
 drop table t1;
+#
+# Start of 10.2 tests
+#
+
+MDEV-27544 database() function under UNION ALL truncates results to 34 characters
+
+
+SET NAMES utf8;
+create database betäubungsmittelverschreibungsverordnung;
+use betäubungsmittelverschreibungsverordnung;
+select database() as "database" union all select database();
+database
+betäubungsmittelverschreibungsverordnung
+betäubungsmittelverschreibungsverordnung
+drop database betäubungsmittelverschreibungsverordnung;
+#
+# End of 10.2 tests
+#

--- a/mysql-test/t/func_system.test
+++ b/mysql-test/t/func_system.test
@@ -55,3 +55,23 @@ select left(concat(a,version()),1) from t1;
 drop table t1;
 
 # End of 4.1 tests
+
+--echo #
+--echo # Start of 10.2 tests
+--echo #
+
+--echo
+--echo MDEV-27544 database() function under UNION ALL truncates results to 34 characters
+--echo
+--echo
+
+SET NAMES utf8;
+create database betäubungsmittelverschreibungsverordnung;
+use betäubungsmittelverschreibungsverordnung;
+select database() as "database" union all select database();
+drop database betäubungsmittelverschreibungsverordnung;
+
+
+--echo #
+--echo # End of 10.2 tests
+--echo #

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -717,7 +717,7 @@ public:
   String *val_str(String *);
   bool fix_length_and_dec()
   {
-    max_length= MAX_FIELD_NAME * system_charset_info->mbmaxlen;
+    max_length= NAME_CHAR_LEN * system_charset_info->mbmaxlen;
     maybe_null=1;
     return FALSE;
   }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-27544*

## Description

Database names are 64 utf8 characters per the system tables
that refer to them.

The current database() function is returning 34 characters.

The result of limiting this function results to max length of 34
became apparent when used in a UNION ALL where the results are
truncated to 34 characters.

For (uninvestigated) reasons, SELECT DATABASE() on its own
would always return the right number of characters.

Thanks Alexander Barkov for the review.

Thanks dave for noticing the bug in the stackexchange post
https://dba.stackexchange.com/questions/306183/why-is-my-database-name-truncated

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->

## How can this PR be tested?

mtr test case include

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

Previous tables auto created from `database()` might be 34 characters (like the test result change) leading to the occasional error. Its more correct now. It seems unlikely that `database()` is used in any context that  depends on its length, or if so,  would be relying on the previous truncating behaviour.