### PR TITLE
MDEV-27033: Clean lintian 'extended-description-is-empty' errors

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -960,6 +960,13 @@ Depends: mariadb-server-10.8,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: BZip2 compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides BZip2 (https://sourceware.org/bzip2/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-lz4
 Architecture: any
@@ -967,6 +974,13 @@ Depends: mariadb-server-10.8,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: LZ4 compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides LZ4 (http://lz4.github.io/lz4/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-lzma
 Architecture: any
@@ -974,6 +988,13 @@ Depends: mariadb-server-10.8,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: LZMA compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides LZMA (https://tukaani.org/lzma/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-lzo
 Architecture: any
@@ -981,6 +1002,13 @@ Depends: mariadb-server-10.8,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: LZO compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides LZO (http://www.oberhumer.com/opensource/lzo/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-snappy
 Architecture: any
@@ -988,6 +1016,13 @@ Depends: mariadb-server-10.8,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Snappy compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides Snappy (https://github.com/google/snappy) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-test
 Architecture: any


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-27033*

## Description
Currently Debian package build against 10.8 branch cause several Debian Lintian errors to raise. To make sure there is no false-positives those should be cleaned up. This is first PR to clean-up lintian errors and warnings. This takes care of `extended-description-is-empty` errors.
```
  E: mariadb-plugin-provider-bzip2: extended-description-is-empty
  E: mariadb-plugin-provider-lz4: extended-description-is-empty
  E: mariadb-plugin-provider-lzma: extended-description-is-empty
  E: mariadb-plugin-provider-lzo: extended-description-is-empty
  E: mariadb-plugin-provider-snappy: extended-description-is-empty
```
Which is cause missing Debian Policy Manual section 3.4 (The description
of a package) extended descriptions in mariadb-plugin-provide-*
packages

## How can this PR be tested?
Currently lintian is not automaticly run against packages. In Salsa-CI this is done with every build. Manually build Debian packages with `debian/autobake-deb.sh` and run lintian *.changes in directory where Debian packages are (mostly `../´ of `pwd`directory). 

```
apt install lintian
cd mariadb-server
debian/autobake-deb.sh
..wait..
cd ..
lintian *.changes
```
No more extended-description-is-empty should be in print out.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This should no affect backward compatibility
