### PR TITLE
MDEV-27553 Assertion `inited==INDEX' failed: in ha_index_end()

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-27553.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-27553.result
@@ -1,0 +1,23 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+connection node_1;
+SET SESSION wsrep_trx_fragment_size=1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+SET @@global.debug_dbug="+d,ha_index_init_fail";
+ROLLBACK;
+connection node_2;
+SELECT COUNT(*) `Expect 0` FROM mysql.wsrep_streaming_log;
+Expect 0
+0
+connection node_1;
+SET @@global.debug_dbug="";
+SELECT COUNT(*) `Expect 1` FROM mysql.wsrep_streaming_log;
+Expect 1
+1
+SET SESSION wsrep_on=OFF;
+DELETE FROM mysql.wsrep_streaming_log;
+SET SESSION wsrep_on=ON;
+DROP TABLE t1;
+CALL mtr.add_suppression("WSREP: Failed to init table for index scan");

--- a/mysql-test/suite/galera_sr/t/MDEV-27553.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-27553.test
@@ -1,0 +1,32 @@
+#
+# MDEV-27553 Assertion `inited==INDEX' failed: int handler::ha_index_end()
+#
+
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+--connection node_1
+--let $wsrep_cluster_address_orig = `SELECT @@wsrep_cluster_address`
+SET SESSION wsrep_trx_fragment_size=1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+# This will result in failure to remove fragments
+# from streaming log, in the following ROLLBACK.
+SET @@global.debug_dbug="+d,ha_index_init_fail";
+ROLLBACK;
+
+--connection node_2
+SELECT COUNT(*) `Expect 0` FROM mysql.wsrep_streaming_log;
+
+
+--connection node_1
+SET @@global.debug_dbug="";
+SELECT COUNT(*) `Expect 1` FROM mysql.wsrep_streaming_log;
+
+SET SESSION wsrep_on=OFF;
+DELETE FROM mysql.wsrep_streaming_log;
+SET SESSION wsrep_on=ON;
+DROP TABLE t1;
+
+CALL mtr.add_suppression("WSREP: Failed to init table for index scan");

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -598,9 +598,11 @@ static int init_for_index_scan(TABLE* table, const uchar* key,
  */
 static int end_index_scan(TABLE* table) {
   int error;
-  if ((error= table->file->ha_index_end())) {
-    WSREP_ERROR("Failed to end scan: %d", error);
-    return 1;
+  if (table->file->inited) {
+    if ((error= table->file->ha_index_end())) {
+      WSREP_ERROR("Failed to end scan: %d", error);
+      return 1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
In wsrep_schema code, call ha_index_end() only if the corresponding
ha_index_init() call succeeded.
