### PR TITLE
Include stdint.h in my_thread.h for uintptr_t

### DIFF
--- a/storage/perfschema/my_thread.h
+++ b/storage/perfschema/my_thread.h
@@ -24,6 +24,7 @@ typedef uint32 my_thread_os_id_t;
 #elif defined(HAVE_PTHREAD_GETTHREADID_NP)
 typedef int my_thread_os_id_t;
 #elif defined(HAVE_INTEGER_PTHREAD_SELF)
+#include <stdint.h>
 typedef uintptr_t my_thread_os_id_t;
 #else
 typedef unsigned long long my_thread_os_id_t;


### PR DESCRIPTION
## Description
Include stdint.h in my_thread.h for uintptr_t

Fixes platform-specific build issue (kfreebsd-amd64) reported in
https://salsa.debian.org/mariadb-team/mariadb-10.5/-/merge_requests/12

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
       (Although this fix applies to earlier branches, the PR is against latest MariaDB development branch)

Similar include is in storage/connect/array.cpp: `#include <stdint.h>      // for uintprt_h`  (sic)