### PR TITLE
MDEV-27607: mysql_install_db to install mysql_upgrade_info

### DIFF
--- a/debian/mariadb-server-10.2.postinst
+++ b/debian/mariadb-server-10.2.postinst
@@ -144,7 +144,7 @@ EOF
     # Debian: beware of the bashisms...
     # Debian: can safely run on upgrades with existing databases
     set +e
-    bash /usr/bin/mysql_install_db --rpm --cross-bootstrap --user=mysql --disable-log-bin 2>&1 | $ERR_LOGGER
+    bash /usr/bin/mysql_install_db --rpm --cross-bootstrap --user=mysql --disable-log-bin --upgrade-info 2>&1 | $ERR_LOGGER
     set -e
 
     ## On every reconfiguration the maintenance user is recreated.

--- a/man/mysql_install_db.1
+++ b/man/mysql_install_db.1
@@ -276,6 +276,21 @@ This must be given as the first argument\&.
 .sp -1
 .IP \(bu 2.3
 .\}
+.\" mysql_install_db: upgrade-info option
+.\" upgrade-info option: mysql_install_db
+\fB\-\-upgrade\-info\fR
+.sp
+This places a mysql_upgrade_info file containing the server version in the data directory\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
 .\" mysql_install_db: rpm option
 .\" rpm option: mysql_install_db
 \fB\-\-rpm\fR

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -41,6 +41,7 @@ create database if not exists test;
 use mysql;"
 auth_root_authentication_method=normal
 auth_root_socket_user='root'
+upgrade_info=0
 
 dirname0=`dirname $0 2>/dev/null`
 dirname0=`dirname $dirname0 2>/dev/null`
@@ -97,6 +98,7 @@ Usage: $0 [OPTIONS]
                        user.  You must be root to use this option.  By default
                        mysqld runs using your current login name and files and
                        directories that it creates will be owned by you.
+  --upgrade-info       Store mysql_upgrade_info in the installed data directory.
 
 All other options are passed to the mysqld program
 
@@ -152,6 +154,7 @@ parse_arguments()
       --skip-name-resolve) ip_only=1 ;;
       --verbose) verbose=1 ; silent_startup="" ;;
       --rpm) in_rpm=1 ;;
+      --upgrade-info) upgrade_info=1 ;;
       --help) usage ;;
       --no-defaults|--defaults-file=*|--defaults-extra-file=*)
         defaults="$arg" ;;
@@ -509,6 +512,10 @@ SET @auth_root_socket='$auth_root_socket_user';" ;;
 esac
 if { echo "$install_params"; cat "$create_system_tables" "$create_system_tables2" "$fill_system_tables" "$fill_help_tables" "$maria_add_gis_sp"; } | eval "$filter_cmd_line" | mysqld_install_cmd_line > /dev/null
 then
+  if test "$upgrade_info" -eq 1
+  then
+    printf "@VERSION@-MariaDB" > "$ldata/mysql_upgade_info"
+  fi
   s_echo "OK"
 else
   echo


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-27607*

## Description

For compatibility this is under an extra option --upgrade-info

The goal here is to install a data directory with the required
info to let mysql_upgrade know that an upgrade isn't required.


<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->

## How can this PR be tested?

```
$ scripts/mysql_install_db --no-defaults --srcdir=$OLDPWD --builddir=$PWD --datadir=/tmp/${PWD##*/}-datadir --verbose  --upgrade-info
...
$ od -h /tmp/build-mariadb-server-10.2_second-datadir/mysql_upgrade_info 
0000000 3031 322e 342e 2d32 614d 6972 4461 0042
0000017

$ cat /tmp/build-mariadb-server-10.2_second-datadir/mysql_upgrade_info 
10.2.42-MariaDB

```

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
- [*] *This is a feature that adds significant value by back-porting to the earliest version with clear compatibility goals*
- 
<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

As a new option that default to off the previous behaviour is preserved.