### PR TITLE
MDEV-27615 Assertion `server_id.is_undefined() == false' failed

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-27615.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-27615.result
@@ -1,0 +1,27 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connection node_2;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+SET DEBUG_SYNC='wsrep_before_fragment_certification SIGNAL before_fragment WAIT_FOR continue';
+SET SESSION wsrep_trx_fragment_size=1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);;
+connection node_2a;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC='now WAIT_FOR before_fragment';
+SET GLOBAL wsrep_cluster_address = '';
+SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_2;
+ERROR HY000: Lost connection to MySQL server during query
+connection node_2a;
+SELECT * FROM mysql.wsrep_streaming_log;
+node_uuid	trx_id	seqno	flags	frag
+SELECT * FROM t1;
+f1
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';
+disconnect node_2;
+connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2;

--- a/mysql-test/suite/galera_sr/t/MDEV-27615.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-27615.test
@@ -1,0 +1,72 @@
+#
+# MDEV-27615 - Assertion `server_id.is_undefined() == false'
+# failed in wsrep::transaction::certify_fragment()
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+
+--let $node_1=node_1
+--let $node_2=node_2
+--source suite/galera/include/auto_increment_offset_save.inc
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+--connection node_2
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) Engine=InnoDB;
+
+#
+# Set debug sync point right before the assert
+#
+SET DEBUG_SYNC='wsrep_before_fragment_certification SIGNAL before_fragment WAIT_FOR continue';
+
+SET SESSION wsrep_trx_fragment_size=1;
+START TRANSACTION;
+--send INSERT INTO t1 VALUES (1);
+
+
+#
+# Disconnect node_2 from cluster
+#
+--connection node_2a
+SET SESSION wsrep_sync_wait = 0;
+--let $node_2_cluster_address = `SELECT @@wsrep_cluster_address`
+SET DEBUG_SYNC='now WAIT_FOR before_fragment';
+SET GLOBAL wsrep_cluster_address = '';
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Disconnected' FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+SET DEBUG_SYNC = 'now SIGNAL continue';
+
+
+#
+# Disconnect causes connection to node_2 to be closed
+#
+--connection node_2
+--error 2013 # CR_SERVER_LOST
+--reap
+
+
+#
+# Reconnect node 2
+#
+--connection node_2a
+--disable_query_log
+--eval SET GLOBAL wsrep_cluster_address = '$node_2_cluster_address';
+--enable_query_log
+--source include/wait_wsrep_ready.inc
+
+#
+# Expect the transaction to be rolled back and cleanup
+#
+SELECT * FROM mysql.wsrep_streaming_log;
+SELECT * FROM t1;
+
+DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';
+
+--disconnect node_2
+--connect node_2, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+
+--source suite/galera/include/auto_increment_offset_restore.inc


### PR DESCRIPTION
Add test case that reproduces the issue and update wsrep-lib submodule
to include the fix.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
