### PR TITLE
MDEV-9020: Connect issues ALTER TABLE DISABLE KEYS when inserting data

### DIFF
--- a/storage/connect/tabmysql.cpp
+++ b/storage/connect/tabmysql.cpp
@@ -941,15 +941,6 @@ bool TDBMYSQL::OpenDB(PGLOBAL g)
 
       } // endif MakeInsert
 
-    if (m_Rc != RC_FX) {
-      char cmd[64];
-      int  w;
-
-      sprintf(cmd, "ALTER TABLE `%s` DISABLE KEYS", TableName);
-      
-      m_Rc = Myc.ExecSQL(g, cmd, &w);   // may fail for some engines
-      } // endif m_Rc
-
   } else
 //  m_Rc = (Mode == MODE_DELETE) ? MakeDelete(g) : MakeUpdate(g);
     m_Rc = (MakeCommand(g)) ? RC_FX : RC_OK;
@@ -1211,16 +1202,6 @@ int TDBMYSQL::DeleteDB(PGLOBAL g, int irc)
 void TDBMYSQL::CloseDB(PGLOBAL g)
   {
   if (Myc.Connected()) {
-    if (Mode == MODE_INSERT) {
-      char cmd[64];
-      int  w;
-      PDBUSER dup = PlgGetUser(g);
-
-      dup->Step = "Enabling indexes";
-      sprintf(cmd, "ALTER TABLE `%s` ENABLE KEYS", TableName);
-      Myc.m_Rows = -1;      // To execute the query
-      m_Rc = Myc.ExecSQL(g, cmd, &w);  // May fail for some engines
-      } // endif m_Rc
 
     Myc.Close();
     } // endif Myc


### PR DESCRIPTION
*The Jira issue number for this PR is: MDEV-9020*

## Description
This removes the anti-optimization that is the disable keys / enable keys in the CONNECT engine's mysql module.

## How can this PR be tested?

It's an incredibly simple patch but you can verify it by doing an insert on a CONNECT table with a MYSQL backend.

## Basing the PR against the correct MariaDB version
This bug goes back to 10.1 ish. 10.6 being latest stable is a suitable patch recipient but this patch should be applied against all future versions and is expected to apply as is (code not modified in future versions).

## Backward compatibility
Yes