### PR TITLE
MDEV-27737 Wsrep SST scripts not working on FreeBSD

### DIFF
--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -ue
+#!/usr/bin/env bash
+
+set -ue
+
 # Copyright (C) 2017-2021 MariaDB
 # Copyright (C) 2013 Percona Inc
 #

--- a/scripts/wsrep_sst_mysqldump.sh
+++ b/scripts/wsrep_sst_mysqldump.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -ue
+#!/usr/bin/env bash
+
+set -ue
+
 # Copyright (C) 2009-2015 Codership Oy
 # Copyright (C) 2017-2021 MariaDB
 #

--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -ue
+#!/usr/bin/env bash
+
+set -ue
 
 # Copyright (C) 2017-2021 MariaDB
 # Copyright (C) 2010-2014 Codership Oy
@@ -740,7 +742,7 @@ EOF
             elif [ "$OS" = 'Linux' ]; then
                tmpfile=$(mktemp "--tmpdir=$tmpdir")
             else
-               tmpfile=$(TMPDIR="$tmpdir"; mktemp '-d')
+               tmpfile=$(TMPDIR="$tmpdir"; mktemp)
             fi
 
             wsrep_log_info "Extracting binlog files:"


### PR DESCRIPTION
- Changed SST scripts to use /usr/bin/env bash instead of
  /bin/bash for better portability.
- Fixed use of mktemp on non-Linux platforms to produce
  temporary file instead of directory.
