### PR TITLE
MDEV-27804 Fails to build - perf schema - thread id of type uintptr_t requires header

### DIFF
--- a/storage/perfschema/my_thread.h
+++ b/storage/perfschema/my_thread.h
@@ -14,6 +14,10 @@
 #include <pthread_np.h>
 #endif
 
+#if defined(HAVE_INTEGER_PTHREAD_SELF)
+#include <cstdint>
+#endif
+
 typedef pthread_key_t thread_local_key_t;
 typedef pthread_t my_thread_handle;
 typedef pthread_attr_t my_thread_attr_t;


### PR DESCRIPTION
This uses uintptr_t, so needs including cstdint

## Description

While building on GNU/Hurd, I got a build error in perfschema, because uintptr_t is used in my_thread.h but cstdint is not included.

## How can this PR be tested?

This would need to introduce in the CI a profile that exercices the  HAVE_INTEGER_PTHREAD_SELF case.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [X] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*