### PR TITLE
Fix build with NO_ELISION

### DIFF
--- a/storage/innobase/include/buf0types.h
+++ b/storage/innobase/include/buf0types.h
@@ -169,7 +169,7 @@ enum rw_lock_type_t
 #include "sux_lock.h"
 
 #ifdef SUX_LOCK_GENERIC
-class page_hash_latch : private rw_lock
+class page_hash_latch : public rw_lock
 {
   /** Wait for a shared lock */
   void read_lock_wait();


### PR DESCRIPTION
In that case, the transactional_shared_lock_guard class wants to access
m.is_write_locked, which in the page_hash_latch class case is coming from the
rw_lock class, so we have to make that heritage public.

## Description

When building on GNU/Hurd with NO_ELISION, I'm getting:

```
In file included from /build/mariadb-10.6-10.6.5/storage/innobase/include/buf0buf.h:43,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/dict0mem.h:45,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/dict0dict.h:32,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/btr0btr.h:31,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/btr/btr0btr.cc:28:
/build/mariadb-10.6-10.6.5/storage/innobase/include/transactional_lock_guard.h: In instantiation of 'transactional_shared_lock_guard<mutex>::transactional_shared_lock_guard(mutex&) [with mutex = page_hash_latch]':
/build/mariadb-10.6-10.6.5/storage/innobase/include/buf0buf.h:1541:33:   required from here
/build/mariadb-10.6-10.6.5/storage/innobase/include/transactional_lock_guard.h:145:29: error: 'bool rw_lock::is_write_locked() const' is inaccessible within this context
  145 |       if (!m.is_write_locked())
      |            ~~~~~~~~~~~~~~~~~^~
In file included from /build/mariadb-10.6-10.6.5/storage/innobase/include/srw_lock.h:21,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/sux_lock.h:20,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/buf0types.h:179,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/mtr0types.h:29,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/mach0data.h:32,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/data0type.ic:27,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/data0type.h:591,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/data0data.h:31,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/dict0dict.h:31,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/btr0btr.h:31,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/btr/btr0btr.cc:28:
/build/mariadb-10.6-10.6.5/storage/innobase/include/rw_lock.h:225:8: note: declared here
  225 |   bool is_write_locked() const { return !!(value() & WRITER); }
      |        ^~~~~~~~~~~~~~~
In file included from /build/mariadb-10.6-10.6.5/storage/innobase/include/buf0buf.h:43,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/dict0mem.h:45,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/dict0dict.h:32,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/include/btr0btr.h:31,
                 from /build/mariadb-10.6-10.6.5/storage/innobase/btr/btr0btr.cc:28:
/build/mariadb-10.6-10.6.5/storage/innobase/include/transactional_lock_guard.h:145:29: error: 'rw_lock' is not an accessible base of 'page_hash_latch'
  145 |       if (!m.is_write_locked())
      |            ~~~~~~~~~~~~~~~~~^~
```

That's because rw_lock's is_write_locked is inherited privately, so the transactional_lock_guard can't access it.

## How can this PR be tested?

This would need to introduce in the CI a profile that exercise the NO_ELISION case.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [X] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*