### PR TITLE
MDEV-27766: add INSERT ignore option

### DIFF
--- a/storage/connect/mysql-test/connect/t/mysql.test
+++ b/storage/connect/mysql-test/connect/t/mysql.test
@@ -470,3 +470,19 @@ SELECT * FROM t2;
 DROP TABLE t2;
 DROP TABLE t1;
 
+
+--echo #
+--echo # MDEV-27766 CONNECT Engine Support for INSERT IGNORE with Mysql Table type
+--echo #
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (10),(20),(30);
+--replace_result $PORT PORT
+--eval CREATE TABLE t2 ENGINE=CONNECT TABLE_TYPE=MYSQL CONNECTION='mysql://root@localhost:$PORT/test/t1' OPTION_LIST="Delayed=1,Ignored=1"
+INSERT INTO t2 VALUES (10),(20),(30),(40);
+DROP TABLE t2;
+DROP TABLE t1;
+
+--echo #
+--echo # End of 10.6 tests
+--echo #

--- a/storage/connect/tabmysql.cpp
+++ b/storage/connect/tabmysql.cpp
@@ -94,6 +94,7 @@ MYSQLDEF::MYSQLDEF(void)
   Isview = false;
   Bind = false;
   Delayed = false;
+  Ignored = false;
 //Xsrc = false;
   Huge = false;
   } // end of MYSQLDEF constructor
@@ -320,6 +321,9 @@ bool MYSQLDEF::DefineAM(PGLOBAL g, LPCSTR am, int)
   char *url;
 
   Desc = "MySQL Table";
+  
+  Delayed = !!GetIntCatInfo("Delayed", 0);
+  Ignored = !!GetIntCatInfo("Ignored", 0);
 
   if (stricmp(am, "MYPRX")) {
     // Normal case of specific MYSQL table
@@ -339,7 +343,6 @@ bool MYSQLDEF::DefineAM(PGLOBAL g, LPCSTR am, int)
       return true;
 
     Bind = !!GetIntCatInfo("Bind", 0);
-    Delayed = !!GetIntCatInfo("Delayed", 0);
   } else {
     // MYSQL access from a PROXY table 
 		TABLE_SHARE* s;
@@ -425,6 +428,7 @@ TDBMYSQL::TDBMYSQL(PMYDEF tdp) : TDBEXT(tdp)
     Isview = tdp->Isview;
     Prep = tdp->Bind;
     Delayed = tdp->Delayed;
+    Ignored = tdp->Ignored;
     Myc.m_Use = tdp->Huge;
   } else {
     Host = NULL;
@@ -440,6 +444,7 @@ TDBMYSQL::TDBMYSQL(PMYDEF tdp) : TDBEXT(tdp)
     Isview = false;
     Prep = false;
     Delayed = false;
+    Ignored = false;
   } // endif tdp
 
   Bind = NULL;
@@ -466,6 +471,7 @@ TDBMYSQL::TDBMYSQL(PTDBMY tdbp) : TDBEXT(tdbp)
   Isview = tdbp->Isview;
   Prep = tdbp->Prep;
   Delayed = tdbp->Delayed;
+  Ignored = tdbp->Ignored;
   Bind = NULL;
 //Query = tdbp->Query;
   Fetched = tdbp->Fetched;
@@ -625,6 +631,8 @@ bool TDBMYSQL::MakeInsert(PGLOBAL g)
 
   if (Delayed)
     Query->Set("INSERT DELAYED INTO ");
+  else if(Ignored) 
+    Query->Set("INSERT IGNORE INTO ");
   else
     Query->Set("INSERT INTO ");
 

--- a/storage/connect/tabmysql.cpp
+++ b/storage/connect/tabmysql.cpp
@@ -629,13 +629,13 @@ bool TDBMYSQL::MakeInsert(PGLOBAL g)
   len += (strlen(TableName) + 40);
   Query = new(g) STRING(g, len);
 
+  Query->Set("INSERT ");
   if (Delayed)
-    Query->Set("INSERT DELAYED INTO ");
-  else if(Ignored) 
-    Query->Set("INSERT IGNORE INTO ");
-  else
-    Query->Set("INSERT INTO ");
+    Query->Append("DELAYED ");
+  if(Ignored) 
+    Query->Append("IGNORE ");
 
+  Query->Append("INTO ");
   Query->Append(tk);
   Query->Append(TableName);
   Query->Append("` (");

--- a/storage/connect/tabmysql.h
+++ b/storage/connect/tabmysql.h
@@ -60,7 +60,7 @@ class MYSQLDEF : public EXTDEF           {/* Logical table description */
   bool    Isview;             /* true if this table is a MySQL view    */
   bool    Bind;               /* Use prepared statement on insert      */
   bool    Delayed;            /* Delayed insert                        */
-  bool    Ignored;            /* Use inssert IGNORE                    */
+  bool    Ignored;            /* Use insert IGNORE                     */
 //bool    Xsrc;               /* Execution type                        */
   bool    Huge;               /* True for big table                    */
   }; // end of MYSQLDEF

--- a/storage/connect/tabmysql.h
+++ b/storage/connect/tabmysql.h
@@ -60,6 +60,7 @@ class MYSQLDEF : public EXTDEF           {/* Logical table description */
   bool    Isview;             /* true if this table is a MySQL view    */
   bool    Bind;               /* Use prepared statement on insert      */
   bool    Delayed;            /* Delayed insert                        */
+  bool    Ignored;            /* Use inssert IGNORE                    */
 //bool    Xsrc;               /* Execution type                        */
   bool    Huge;               /* True for big table                    */
   }; // end of MYSQLDEF
@@ -132,6 +133,7 @@ class TDBMYSQL : public TDBEXT {
   bool        Isview;         // True if this table is a MySQL view
   bool        Prep;           // Use prepared statement on insert
   bool        Delayed;        // Use delayed insert
+  bool        Ignored;        // Use insert IGNORE
   int         m_Rc;           // Return code from command
 //int         AftRows;        // The number of affected rows
   int         N;              // The current table index


### PR DESCRIPTION
## Description

This:

1. Adds an "Ignored=1" parameter for the CONNECT engine MySQL table type. This is implemneted similarly to the undocumented "Delayed=1" parameter,
2.  "Delayed=1" was ignored when using a with CONNECT URL. This commit fixes that bug as well.

## How can this PR be tested?

```
CREATE TABLE `history` (
  `itemid` bigint(20) unsigned NOT NULL,
  `clock` int(11) NOT NULL DEFAULT 0,
  `value` double(16,4) NOT NULL DEFAULT 0.0000,
  `ns` int(11) NOT NULL DEFAULT 0
) ENGINE=CONNECT DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin `table_type`=MYSQL `option_list`='ignored=1,connect=mysql://***@localhost/zabbix-development-partitions/history_%s'
 PARTITION BY RANGE (`clock`)
(PARTITION `p202202070000` VALUES LESS THAN (1644195600) ENGINE = CONNECT,
[...]
)
```


## Basing the PR against the correct MariaDB version

This is a small patch and directly appliable with 10.8

## Backward compatibility

This patch does not change any [expected] existing behaviour and is fully backwards compatible. Small change in behaviour exists now that `Delayed` works when using a URL, however with that option being both undocumented and assumed to work previously I beleive this a bug fix element not a change in behaviour (previously the option had no effect, no error either)