### PR TITLE
MDEV-27790: Fix mis-matched braces for compiling on non-Linux targets

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -1303,8 +1303,9 @@ use_o_direct:
 		default:
 			break;
 		}
+	}
 # ifdef __linux__
-	} else if (type == OS_LOG_FILE && !log_sys.is_opened()) {
+	else if (type == OS_LOG_FILE && !log_sys.is_opened()) {
 		struct stat st;
 		char b[20 + sizeof "/sys/dev/block/" ":"
 		       "/../queue/physical_block_size"];


### PR DESCRIPTION
Ran into this while compiling on FreeBSD 13.0-RELEASE

After this one change, it compiles and runs just fine on my FreeBSD Aarch64 server.
