### PR TITLE
Remove unused header from crc32c.cc

### DIFF
--- a/mysys/crc32/crc32c.cc
+++ b/mysys/crc32/crc32c.cc
@@ -18,7 +18,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <string>
 #include <my_global.h>
 #include <my_byteorder.h>
 static inline uint32_t DecodeFixed32(const char *ptr)


### PR DESCRIPTION
Remove C++ `<string>` from `crc32c.cc` since it is not used by  `crc32c.cc`