### PR TITLE
MDEV-27891: SIGSEGV in InnoDB buffer pool resize

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_buffer_pool_resize_bigtest.result
+++ b/mysql-test/suite/innodb/r/innodb_buffer_pool_resize_bigtest.result
@@ -1,0 +1,13 @@
+
+MDEV-27891: Delayed SIGSEGV in InnoDB buffer pool resize
+after or during DROP TABLE
+
+select @@innodb_buffer_pool_chunk_size;
+@@innodb_buffer_pool_chunk_size
+1048576
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+SET GLOBAL innodb_buffer_pool_size=256*1024*1024;
+DROP TABLE t1;
+SET GLOBAL innodb_buffer_pool_size=@@innodb_buffer_pool_size + @@innodb_buffer_pool_chunk_size;
+# end of 10.6 test
+set global innodb_buffer_pool_size = 8388608;;

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_bigtest.opt
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_bigtest.opt
@@ -1,0 +1,1 @@
+--innodb-buffer-pool-chunk-size=1M

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_bigtest.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_bigtest.test
@@ -1,0 +1,28 @@
+--source include/have_innodb.inc
+--source include/big_test.inc
+
+--let $save_size= `SELECT @@GLOBAL.innodb_buffer_pool_size`
+
+let $wait_timeout = 60;
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
+  FROM information_schema.global_status
+  WHERE variable_name = 'INNODB_BUFFER_POOL_RESIZE_STATUS';
+
+--echo
+--echo MDEV-27891: Delayed SIGSEGV in InnoDB buffer pool resize
+--echo after or during DROP TABLE
+--echo
+
+select @@innodb_buffer_pool_chunk_size;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+SET GLOBAL innodb_buffer_pool_size=256*1024*1024;
+DROP TABLE t1;
+--source include/wait_condition.inc
+SET GLOBAL innodb_buffer_pool_size=@@innodb_buffer_pool_size + @@innodb_buffer_pool_chunk_size;
+--source include/wait_condition.inc
+
+--echo # end of 10.6 test
+
+--eval set global innodb_buffer_pool_size = $save_size;
+--source include/wait_condition.inc

--- a/storage/innobase/buf/buf0buddy.cc
+++ b/storage/innobase/buf/buf0buddy.cc
@@ -298,7 +298,7 @@ static buf_buddy_free_t* buf_buddy_alloc_zip(ulint i)
 
 	buf = UT_LIST_GET_FIRST(buf_pool.zip_free[i]);
 
-	if (buf_pool.curr_size < buf_pool.old_size
+	if (buf_pool.is_shrinking()
 	    && UT_LIST_GET_LEN(buf_pool.withdraw)
 	    < buf_pool.withdraw_target) {
 
@@ -609,7 +609,7 @@ recombine:
 	We may waste up to 15360*max_len bytes to free blocks
 	(1024 + 2048 + 4096 + 8192 = 15360) */
 	if (UT_LIST_GET_LEN(buf_pool.zip_free[i]) < 16
-	    && buf_pool.curr_size >= buf_pool.old_size) {
+	    && !buf_pool.is_shrinking()) {
 		goto func_exit;
 	}
 
@@ -715,7 +715,7 @@ buf_buddy_realloc(void* buf, ulint size)
 void buf_buddy_condense_free()
 {
 	mysql_mutex_assert_owner(&buf_pool.mutex);
-	ut_ad(buf_pool.curr_size < buf_pool.old_size);
+	ut_ad(buf_pool.is_shrinking());
 
 	for (ulint i = 0; i < UT_ARR_SIZE(buf_pool.zip_free); ++i) {
 		buf_buddy_free_t* buf =

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -1225,7 +1225,7 @@ static void buf_flush_LRU_list_batch(ulint max, flush_counters_t *n)
   ulint free_limit= srv_LRU_scan_depth;
 
   mysql_mutex_assert_owner(&buf_pool.mutex);
-  if (buf_pool.withdraw_target && buf_pool.curr_size < buf_pool.old_size)
+  if (buf_pool.withdraw_target && buf_pool.is_shrinking())
     free_limit+= buf_pool.withdraw_target - UT_LIST_GET_LEN(buf_pool.withdraw);
 
   const auto neighbors= UT_LIST_GET_LEN(buf_pool.LRU) < BUF_LRU_OLD_MIN_LEN


### PR DESCRIPTION
During an increase in resize, the new curr_size got a value
less than old_size.

As n_chunks_new and n_chunks have a strong correlation to the
resizing operation in progress, we can use them and remove the
need for old_size.

n_chunks_new and n_chunks are always read and altered under
the pool mutex, the running_out function does the same. Also
the volatile compiler optimization is removed.

Added test case of a smaller size than the Marko/Roel original
in JIRA reducing the size to 200M. SEGV hits roughly 1/10 times
but its better than a 21G memory size.


----

Existing innodb buffer pool resize tests included sizes/options that where incompatible with triggering this bug hence the new test file.

Original cause of old_size error unidentified. gdb and rr on the test case failed to trigger the bug.