### PR TITLE
MDEV-27568 Parallel async replication hangs on a Galera node

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4924,7 +4924,11 @@ public:
   {
     return m_wsrep_next_trx_id;
   }
-
+  /*
+    If node is async slave and have parallel execution, wait for prior commits.
+   */
+  bool wsrep_parallel_slave_wait_for_prior_commit();
+  
 private:
   wsrep_trx_id_t m_wsrep_next_trx_id; /* cast from query_id_t */
   /* wsrep-lib */


### PR DESCRIPTION
Using parallel slave applying can cause deadlock between between DDL and
other events. GTID with lower seqno can be blocked in galera when node
entered TOI mode, but DDL GTID which has higher node can be blocked
before previous GTIDs are applied locally.

Fix is to check prior commits before entering TOI.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27568*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
There is deadlock when mutiple parallel slave are applying when one of events is TOI. This fix addresses this issue. 
It can happen, still, that events are added out of order so `strict_gtid_mode=OFF` should be used when galera node is slave node.

## How can this PR be tested?

Jira ticket has steps how to reproduce this bug. 

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

