### PR TITLE
Fix various spelling errors

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -604,7 +604,7 @@ void CorruptedPages::zero_out_free_pages()
           die("Can't zero out corrupted page " UINT32PF " of tablespace %s",
               *page_it, space_name.c_str());
         msg("Corrupted page " UINT32PF
-            " of tablespace %s was successfuly fixed.",
+            " of tablespace %s was successfully fixed.",
             *page_it, space_name.c_str());
       }
     }

--- a/mysql-test/main/dyncol.result
+++ b/mysql-test/main/dyncol.result
@@ -1508,7 +1508,7 @@ select column_get(column_create("1212", 2, "адын", 1, 3, 3), "4" as int);
 column_get(column_create("1212", 2, "адын", 1, 3, 3), "4" as int)
 NULL
 set names latin1;
-# column existance test (names)
+# column existence test (names)
 set names utf8;
 select column_exists(column_create("адын", 1212), "адын");
 column_exists(column_create("адын", 1212), "адын")

--- a/mysql-test/main/dyncol.test
+++ b/mysql-test/main/dyncol.test
@@ -689,7 +689,7 @@ select column_get(column_create("1212", 2, "адын", 1, 3, 3), 4 as int);
 select column_get(column_create("1212", 2, "адын", 1, 3, 3), "4" as int);
 set names latin1;
 
---echo # column existance test (names)
+--echo # column existence test (names)
 set names utf8;
 select column_exists(column_create("адын", 1212), "адын");
 select column_exists(column_create("адын", 1212), "aады");

--- a/mysql-test/suite/archive/discover.result
+++ b/mysql-test/suite/archive/discover.result
@@ -84,7 +84,7 @@ drop table t1;
 db.opt
 t0.ARZ
 #
-# discover of table non-existance on drop
+# discover of table non-existence on drop
 #
 select * from t0;
 a

--- a/mysql-test/suite/archive/discover.test
+++ b/mysql-test/suite/archive/discover.test
@@ -67,7 +67,7 @@ drop table t1;
 --list_files $mysqld_datadir/test
 
 --echo #
---echo # discover of table non-existance on drop
+--echo # discover of table non-existence on drop
 --echo #
 select * from t0;
 remove_file $mysqld_datadir/test/t0.ARZ;
@@ -119,7 +119,7 @@ select * from t1;
 --list_files $mysqld_datadir/test
 
 #
-# MDEV-4955 discover of table non-existance on CREATE
+# MDEV-4955 discover of table non-existence on CREATE
 #
 create table t1 (a int) engine=archive;
 select * from t1;

--- a/mysql-test/suite/mariabackup/log_page_corruption.result
+++ b/mysql-test/suite/mariabackup/log_page_corruption.result
@@ -98,12 +98,12 @@ test/t3_inc
 ------
 # Full backup prepare
 # "innodb_corrupted_pages" file must not exist after successful prepare
-FOUND 1 /was successfuly fixed.*/ in backup.log
+FOUND 1 /was successfully fixed.*/ in backup.log
 # Check that fixed pages are zero-filled
 # Incremental backup prepare
 # "innodb_corrupted_pages" file must not exist after successful prepare
 # do not remove "innodb_corrupted_pages" in incremental dir
-FOUND 1 /was successfuly fixed.*/ in backup.log
+FOUND 1 /was successfully fixed.*/ in backup.log
 # Check that fixed pages are zero-filled
 # shutdown server
 # remove datadir

--- a/mysql-test/suite/mariabackup/log_page_corruption.test
+++ b/mysql-test/suite/mariabackup/log_page_corruption.test
@@ -323,7 +323,7 @@ exec $XTRABACKUP  --prepare --target-dir=$targetdir > $backuplog;
 --echo # "innodb_corrupted_pages" file must not exist after successful prepare
 --error 1
 --file_exists $targetdir/innodb_corrupted_pages
---let SEARCH_PATTERN=was successfuly fixed.*
+--let SEARCH_PATTERN=was successfully fixed.*
 --let SEARCH_FILE=$backuplog
 --source include/search_pattern_in_file.inc
 
@@ -347,7 +347,7 @@ exec $XTRABACKUP --prepare --target-dir=$targetdir --incremental-dir=$incdir > $
 --file_exists $targetdir/innodb_corrupted_pages
 --echo # do not remove "innodb_corrupted_pages" in incremental dir
 --file_exists $incdir/innodb_corrupted_pages
---let SEARCH_PATTERN=was successfuly fixed.*
+--let SEARCH_PATTERN=was successfully fixed.*
 --let SEARCH_FILE=$backuplog
 --source include/search_pattern_in_file.inc
 

--- a/scripts/sys_schema/README.md
+++ b/scripts/sys_schema/README.md
@@ -5367,9 +5367,9 @@ name, then 'TEMPORARY' will be returned.
 
 ##### Parameters
 
-* in_db (VARCHAR(64)): The database name to check for the existance of the table in.
+* in_db (VARCHAR(64)): The database name to check for the existence of the table in.
 
-* in_table (VARCHAR(64)): The name of the table to check the existance of.
+* in_table (VARCHAR(64)): The name of the table to check the existence of.
 
 * out_exists ENUM('', 'BASE TABLE', 'VIEW', 'TEMPORARY'):  The return value: whether the table exists. The value is one of:
    - ''           - the table does not exist neither as a base table, view, nor temporary table.

--- a/scripts/sys_schema/procedures/table_exists.sql
+++ b/scripts/sys_schema/procedures/table_exists.sql
@@ -34,10 +34,10 @@ CREATE DEFINER='mariadb.sys'@'localhost' PROCEDURE table_exists (
              -----------
 
              in_db (VARCHAR(64)):
-               The database name to check for the existance of the table in.
+               The database name to check for the existence of the table in.
 
              in_table (VARCHAR(64)):
-               The name of the table to check the existance of.
+               The name of the table to check the existence of.
 
              out_exists ENUM('''', ''BASE TABLE'', ''VIEW'', ''TEMPORARY''):
                The return value: whether the table exists. The value is one of:

--- a/sql/semisync_master_ack_receiver.h
+++ b/sql/semisync_master_ack_receiver.h
@@ -183,7 +183,7 @@ public:
 
   bool listen_on_sockets()
   {
-    /* Reinitialze the fds with active fds before calling select */
+    /* Reinitialize the fds with active fds before calling select */
     m_fds= m_init_fds;
     struct timeval tv= {1,0};
     /* select requires max fd + 1 for the first argument */

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -4357,7 +4357,7 @@ int create_table_impl(THD *thd,
       else if (options.if_not_exists())
       {
         /*
-          We never come here as part of normal create table as table existance
+          We never come here as part of normal create table as table existence
           is  checked in open_and_lock_tables(). We may come here as part of
           ALTER TABLE when converting a table for a distributed engine to a
           a local one.

--- a/storage/maria/ha_s3.cc
+++ b/storage/maria/ha_s3.cc
@@ -789,13 +789,13 @@ static int s3_discover_table(handlerton *hton, THD* thd, TABLE_SHARE *share)
    @return 1 frm exists
 */
 
-static int s3_discover_table_existance(handlerton *hton, const char *db,
+static int s3_discover_table_existence(handlerton *hton, const char *db,
                                        const char *table_name)
 {
   S3_INFO s3_info;
   ms3_st *s3_client;
   int res;
-  DBUG_ENTER("s3_discover_table_existance");
+  DBUG_ENTER("s3_discover_table_existence");
 
   /* Ignore names in "mysql" database to speed up boot */
   if (!strcmp(db, MYSQL_SCHEMA_NAME.str))
@@ -1019,7 +1019,7 @@ static int ha_s3_init(void *p)
   s3_hton->table_options= s3_table_option_list;
   s3_hton->discover_table= s3_discover_table;
   s3_hton->discover_table_names= s3_discover_table_names;
-  s3_hton->discover_table_existence= s3_discover_table_existance;
+  s3_hton->discover_table_existence= s3_discover_table_existence;
   s3_hton->notify_tabledef_changed= s3_notify_tabledef_changed;
   s3_hton->create_partitioning_metadata= s3_create_partitioning_metadata;
   s3_hton->tablefile_extensions= no_exts;


### PR DESCRIPTION
Fix various spelling errors
    
Among others:
existance -> existence
reinitialze -> reinitialize
successfuly -> successfully

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the *somewhat** earliest branch in which the bug can be reproduced*
