### PR TITLE
Fix failing Gitlab-CI by adding pcre2-devel as a build dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,7 +172,7 @@ fedora-clang:
 
 centos8:
   stage: build
-  image: centos:8
+  image: quay.io/centos/centos:stream8 # CentOS 8 is deprecated, use this Stream8 instead
   variables:
     GIT_STRATEGY: fetch
     GIT_SUBMODULE_STRATEGY: normal
@@ -186,7 +186,7 @@ centos8:
     # - package Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.i686 is filtered out by modular filtering
     # - package Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64 is filtered out by modular filtering
     # Solution: install Judy-devel directly from downloaded rpm file:
-    - yum install -y http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm
+    - yum install -y http://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm
     # Use eatmydata to speed up build
     - yum install -y https://github.com/stewartsmith/libeatmydata/releases/download/v129/libeatmydata-129-1.fc33.x86_64.rpm
     - yum install -y ccache  # From EPEL

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,7 +177,7 @@ centos8:
     GIT_STRATEGY: fetch
     GIT_SUBMODULE_STRATEGY: normal
   script:
-    - yum install -y yum-utils rpm-build openssl-devel
+    - yum install -y yum-utils rpm-build openssl-devel pcre2-devel
     - yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
     # dnf --enablerepo=powertools install Judy-devel  #--> not found
     - dnf config-manager --set-enabled powertools
@@ -226,7 +226,7 @@ centos7:
     # This repository does not have any .spec files, so install dependencies based on Fedora spec file
     - yum-builddep -y mariadb-server
     # ..with a few extra ones, as CentOS 7 is very old and these are added in newer MariaDB releases
-    - yum install -y yum-utils rpm-build gcc gcc-c++ bison libxml2-devel libevent-devel openssl-devel
+    - yum install -y yum-utils rpm-build gcc gcc-c++ bison libxml2-devel libevent-devel openssl-devel pcre2-devel
     - mkdir builddir; cd builddir
     - cmake -DRPM=$CI_JOB_NAME $CMAKE_FLAGS .. 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
     - make package -j 2 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log


### PR DESCRIPTION
The commits a73acf6c068a39d0bb9437e05b0b60a87e46bba8 and
4d74bac8bc8c14c2b217391b3b8860f3dc701202 updated the PCRE library to a new
version, which in turn requires CMake 3.0. That does not exist in CentOS 7
nor 8, so builds started failing.

Actually the build should not be downloading anything at all. The root
cause was that pcre2-devel was missing from the dependencies. This was
originally not detected, as the download fallback had masked the issue.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*