### PR TITLE
MDEV-24845 Oddities around innodb_fatal_semaphore_wait_threshold and …

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_garbd_backup.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_garbd_backup.result
@@ -1,0 +1,43 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
+SET GLOBAL innodb_max_dirty_pages_pct=99;
+SET GLOBAL innodb_max_dirty_pages_pct_lwm=99;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER, f2 varchar(1024)) Engine=InnoDB;
+CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
+INSERT INTO ten VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+INSERT INTO t1 (f2) SELECT REPEAT('x', 1024) FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4;
+connection node_2;
+Killing node #3 to free ports for garbd ...
+connection node_3;
+connection node_1;
+SET GLOBAL debug_dbug = "+d,sync.wsrep_donor_state";
+Starting garbd ...
+SET SESSION debug_sync = "now WAIT_FOR sync.wsrep_donor_state_reached";
+SET GLOBAL innodb_max_dirty_pages_pct_lwm=0;
+SET GLOBAL innodb_max_dirty_pages_pct=0;
+SET SESSION debug_sync = "now SIGNAL signal.wsrep_donor_state";
+SET GLOBAL debug_dbug = "";
+SET debug_sync='RESET';
+connection node_2;
+Killing garbd ...
+connection node_1;
+connection node_2;
+DROP TABLE t1;
+DROP TABLE ten;
+Restarting node #3 to satisfy MTR's end-of-test checks
+connection node_3;
+connection node_1;
+SET GLOBAL innodb_max_dirty_pages_pct = 90.000000;
+SET GLOBAL innodb_max_dirty_pages_pct_lwm = 0.000000;
+connection node_1;
+CALL mtr.add_suppression("WSREP: Protocol violation\. JOIN message sender 1\.0 \(.*\) is not in state transfer \(SYNCED\)");
+connection node_2;
+CALL mtr.add_suppression("WSREP: Protocol violation\. JOIN message sender 1\.0 \(.*\) is not in state transfer \(SYNCED\)");
+connection node_3;
+CALL mtr.add_suppression("WSREP: Protocol violation\. JOIN message sender 1\.0 \(.*\) is not in state transfer \(SYNCED\)");

--- a/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.cnf
@@ -1,0 +1,13 @@
+!include ../galera_3nodes.cnf
+
+[mysqld]
+wsrep_sst_method=rsync
+
+[mysqld.1]
+wsrep_node_name=node1
+
+[mysqld.2]
+wsrep_node_name=node2
+
+[mysqld.3]
+wsrep_node_name=node3

--- a/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.test
@@ -65,6 +65,7 @@ SET SESSION debug_sync = "now WAIT_FOR sync.wsrep_donor_state_reached";
 #
 --exec find $datadir -type f -exec md5sum {} \; | md5sum >$MYSQLTEST_VARDIR/tmp/innodb_before
 
+# this should force buffer pool flushing, if not already done by donor state change transfer
 SET GLOBAL innodb_max_dirty_pages_pct_lwm=0;
 SET GLOBAL innodb_max_dirty_pages_pct=0;
 
@@ -75,6 +76,15 @@ select * from ten;
 --enable_result_log
 --enable_query_log
 
+# buffer pool flushing may create tables_flushed file, ignore this 
+--error 0,1
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/tables_flushed
+
+# wsrep_sst_backup will create backup_sst_complete file, ignore this in diff as well
+--error 0,1
+--remove_file $MYSQLTEST_VARDIR/mysqld.1/backup_sst_complete
+
+#
 #
 # record the hash of data directory contents after BP dirty page flushing
 #

--- a/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.test
@@ -1,0 +1,130 @@
+#
+# A very basic test for the galera arbitrator. We shut down node #3 and use its port allocation to start garbd.
+# As MTR does not allow multiple servers to be down at the same time, we are limited as to what we can test.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_garbd.inc
+--source include/big_test.inc
+
+--connection node_1
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+--source suite/galera/include/galera_base_port.inc
+--let $NODE_GALERAPORT_3 = $_NODE_GALERAPORT
+
+--source ../galera/include/auto_increment_offset_save.inc
+
+# Save galera ports
+--connection node_1
+--source suite/galera/include/galera_base_port.inc
+--let $NODE_GALERAPORT_1 = $_NODE_GALERAPORT
+--let $datadir= `SELECT @@datadir`
+
+--let $innodb_max_dirty_pages_pct = `SELECT @@innodb_max_dirty_pages_pct`
+--let $innodb_max_dirty_pages_pct_lwm = `SELECT @@innodb_max_dirty_pages_pct_lwm`
+
+SET GLOBAL innodb_max_dirty_pages_pct=99;
+SET GLOBAL innodb_max_dirty_pages_pct_lwm=99;
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER, f2 varchar(1024)) Engine=InnoDB;
+CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
+INSERT INTO ten VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+INSERT INTO t1 (f2) SELECT REPEAT('x', 1024) FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4;
+ 
+--connection node_2
+--source suite/galera/include/galera_base_port.inc
+--let $NODE_GALERAPORT_2 = $_NODE_GALERAPORT
+
+--echo Killing node #3 to free ports for garbd ...
+--connection node_3
+--source include/shutdown_mysqld.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+# stop SST donor thread when node is in donor state
+SET GLOBAL debug_dbug = "+d,sync.wsrep_donor_state";
+
+--echo Starting garbd ...
+--exec $MTR_GARBD_EXE --address "gcomm://127.0.0.1:$NODE_GALERAPORT_1" --group my_wsrep_cluster --donor node1 --sst backup --options 'base_port=$NODE_GALERAPORT_3' > $MYSQL_TMP_DIR/garbd.log 2>&1 &
+
+SET SESSION debug_sync = "now WAIT_FOR sync.wsrep_donor_state_reached";
+
+#
+# get hash of data directory contents before BP dirty page flushing
+#
+--exec find $datadir -type f -exec md5sum {} \; | md5sum >$MYSQLTEST_VARDIR/tmp/innodb_before
+
+SET GLOBAL innodb_max_dirty_pages_pct_lwm=0;
+SET GLOBAL innodb_max_dirty_pages_pct=0;
+
+--disable_query_log
+--disable_result_log
+select f1 from t1;
+select * from ten;
+--enable_result_log
+--enable_query_log
+
+#
+# record the hash of data directory contents after BP dirty page flushing
+#
+--exec find $datadir -type f -exec md5sum {} \; | md5sum >$MYSQLTEST_VARDIR/tmp/innodb_after
+
+# there should be no disk writes
+--diff_files $MYSQLTEST_VARDIR/tmp/innodb_before $MYSQLTEST_VARDIR/tmp/innodb_after
+
+SET SESSION debug_sync = "now SIGNAL signal.wsrep_donor_state";
+SET GLOBAL debug_dbug = "";
+SET debug_sync='RESET';
+
+--connection node_2
+
+#
+# garbd will die automatically, because of the backup SST script
+# but just to be sure, sending explicit kill here, as well
+#
+--echo Killing garbd ...
+# FreeBSD's /bin/pkill only supports short versions of the options:
+# -o Select only the oldest (least recently started)
+# -f Match against full argument lists
+--error 0,1
+--exec pkill -o -f garbd.*$NODE_GALERAPORT_3
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_2
+
+DROP TABLE t1;
+DROP TABLE ten;
+
+--echo Restarting node #3 to satisfy MTR's end-of-test checks
+--connection node_3
+let $restart_noprint=2;
+--source include/start_mysqld.inc
+
+--connection node_1
+--eval SET GLOBAL innodb_max_dirty_pages_pct = $innodb_max_dirty_pages_pct
+--eval SET GLOBAL innodb_max_dirty_pages_pct_lwm = $innodb_max_dirty_pages_pct_lwm
+
+--source ../galera/include/auto_increment_offset_restore.inc
+
+--connection node_1
+CALL mtr.add_suppression("WSREP: Protocol violation\. JOIN message sender 1\.0 \(.*\) is not in state transfer \(SYNCED\)");
+
+--connection node_2
+CALL mtr.add_suppression("WSREP: Protocol violation\. JOIN message sender 1\.0 \(.*\) is not in state transfer \(SYNCED\)");
+
+--connection node_3
+CALL mtr.add_suppression("WSREP: Protocol violation\. JOIN message sender 1\.0 \(.*\) is not in state transfer \(SYNCED\)");

--- a/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_garbd_backup.test
@@ -63,7 +63,7 @@ SET SESSION debug_sync = "now WAIT_FOR sync.wsrep_donor_state_reached";
 #
 # get hash of data directory contents before BP dirty page flushing
 #
---exec find $datadir -type f -exec md5sum {} \; | md5sum >$MYSQLTEST_VARDIR/tmp/innodb_before
+--exec find $datadir -type f ! -name tables_flushed ! -name backup_sst_complete -exec md5sum {} \; | md5sum >$MYSQLTEST_VARDIR/tmp/innodb_before
 
 # this should force buffer pool flushing, if not already done by donor state change transfer
 SET GLOBAL innodb_max_dirty_pages_pct_lwm=0;
@@ -76,19 +76,11 @@ select * from ten;
 --enable_result_log
 --enable_query_log
 
-# buffer pool flushing may create tables_flushed file, ignore this 
---error 0,1
---remove_file $MYSQLTEST_VARDIR/mysqld.1/tables_flushed
-
-# wsrep_sst_backup will create backup_sst_complete file, ignore this in diff as well
---error 0,1
---remove_file $MYSQLTEST_VARDIR/mysqld.1/backup_sst_complete
-
 #
 #
 # record the hash of data directory contents after BP dirty page flushing
 #
---exec find $datadir -type f -exec md5sum {} \; | md5sum >$MYSQLTEST_VARDIR/tmp/innodb_after
+--exec find $datadir -type f ! -name tables_flushed ! -name backup_sst_complete -exec md5sum {} \; | md5sum >$MYSQLTEST_VARDIR/tmp/innodb_after
 
 # there should be no disk writes
 --diff_files $MYSQLTEST_VARDIR/tmp/innodb_before $MYSQLTEST_VARDIR/tmp/innodb_after

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -287,6 +287,7 @@ ELSE()
       wsrep_sst_mysqldump
       wsrep_sst_rsync
       wsrep_sst_mariabackup
+      wsrep_sst_backup
     )
     # The following script is sourced from other SST scripts, so it should
     # not be made executable.

--- a/scripts/wsrep_sst_backup.sh
+++ b/scripts/wsrep_sst_backup.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -ue
+
+# Copyright (C) 2017-2021 MariaDB
+# Copyright (C) 2010-2014 Codership Oy
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not, write to the
+# Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston
+# MA  02110-1335  USA.
+
+# This is a reference script for rsync-based state snapshot transfer
+
+RSYNC_REAL_PID=0   # rsync process id
+STUNNEL_REAL_PID=0 # stunnel process id
+
+OS="$(uname)"
+[ "$OS" = 'Darwin' ] && export -n LD_LIBRARY_PATH
+
+. $(dirname "$0")/wsrep_sst_common
+wsrep_check_datadir
+
+MAGIC_FILE="$WSREP_SST_OPT_DATA/rsync_sst_complete"
+
+WSREP_LOG_DIR="$INNODB_LOG_GROUP_HOME"
+
+WSREP_LOG_DIR=$(pwd -P)
+
+if [ "$WSREP_SST_OPT_ROLE" = 'donor' ]
+then
+
+    [ -f "$MAGIC_FILE"      ] && rm -f "$MAGIC_FILE"
+
+    RC=0
+
+    if [ $WSREP_SST_OPT_BYPASS -eq 0 ]; then
+
+        FLUSHED="$WSREP_SST_OPT_DATA/tables_flushed"
+        ERROR="$WSREP_SST_OPT_DATA/sst_error"
+
+        [ -f "$FLUSHED" ] && rm -f "$FLUSHED"
+        [ -f "$ERROR"   ] && rm -f "$ERROR"
+
+         echo "flush tables"
+
+        # Wait for :
+        # (a) Tables to be flushed, AND
+        # (b) Cluster state ID & wsrep_gtid_domain_id to be written to the file, OR
+        # (c) ERROR file, in case flush tables operation failed.
+
+        while [ ! -r "$FLUSHED" ] && \
+                ! grep -q -F ':' '--' "$FLUSHED" >/dev/null 2>&1
+        do
+            # Check whether ERROR file exists.
+            if [ -f "$ERROR" ]; then
+                # Flush tables operation failed.
+                rm -f "$ERROR"
+                exit 255
+            fi
+            sleep 0.2
+        done
+
+        STATE=$(cat "$FLUSHED")
+        rm -f "$FLUSHED"
+
+
+    else # BYPASS
+
+        wsrep_log_info "Bypassing state dump."
+    fi
+
+    echo 'continue' # now server can resume updating data
+
+    echo "$STATE" > "$MAGIC_FILE"
+
+    echo "done $STATE"
+
+elif [ "$WSREP_SST_OPT_ROLE" = 'joiner' ]
+then
+    wsrep_log_error "Unrecognized role: '$WSREP_SST_OPT_ROLE'"
+    exit 22 # EINVAL
+
+
+else
+    wsrep_log_error "Unrecognized role: '$WSREP_SST_OPT_ROLE'"
+    exit 22 # EINVAL
+fi
+
+exit 0

--- a/scripts/wsrep_sst_backup.sh
+++ b/scripts/wsrep_sst_backup.sh
@@ -30,7 +30,7 @@ OS="$(uname)"
 . $(dirname "$0")/wsrep_sst_common
 wsrep_check_datadir
 
-MAGIC_FILE="$WSREP_SST_OPT_DATA/rsync_sst_complete"
+MAGIC_FILE="$WSREP_SST_OPT_DATA/backup_sst_complete"
 
 WSREP_LOG_DIR="$INNODB_LOG_GROUP_HOME"
 

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -33,6 +33,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include "debug_sync.h"
 
 #include <my_service_manager.h>
 
@@ -1704,6 +1705,15 @@ wait_signal:
           }
 
           locked= true;
+          DBUG_EXECUTE_IF("sync.wsrep_donor_state",
+                  {
+                    const char act[]=
+                      "now "
+                      "SIGNAL sync.wsrep_donor_state_reached "
+                      "WAIT_FOR signal.wsrep_donor_state";
+                    DBUG_ASSERT(!debug_sync_set_action(thd.ptr,
+                                                       STRING_WITH_LEN(act)));
+                  };);
           goto wait_signal;
         }
       }


### PR DESCRIPTION
…global.innodb_disallow_writes

This commit adds a mtr test for reproducing a test scenario where despite of
innodb_disallow_writes, writes to file system can still happen.

The test launches a garbd node, which triggers one of the cluster node to switch to
SST donor state. In this state, all disk activity should be halted, and e.g.
innodb_disallow_writes has been set. The test records md5sum aggregate over mariadb
data directory when the node enters the donor state, and records another md5sum
when the node leaves the donor state. If there is no IO activity in data directory, these
hashes should be equal.

For this tetst, the Donor state processing, has beeen instrumented so that, SST donor thread can be
stopped when entering the donor state. The test uses this new dbug sync point,
to control when to record the md5sums.

New SST script was added: wsrep_sst_backup, and garbd uses backup method to lauch the donor
node to call this script, and to enter in donor state.

The backup script could be later extended as general purpose backup method for the cluster.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
