### PR TITLE
MDEV-27957 Select from view with subselect fails with lost connection

### DIFF
--- a/mysql-test/main/in_subq_groupby.result
+++ b/mysql-test/main/in_subq_groupby.result
@@ -1,0 +1,21 @@
+#
+# MDEV-27957 Select from view with subselect fails with lost connection
+#
+CREATE TABLE t1 (id INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2);
+CREATE OR REPLACE VIEW v1 AS SELECT
+1 IN (
+SELECT
+(SELECT COUNT(id)
+FROM t1
+WHERE t1_outer.id <> id
+) AS f
+FROM
+t1 AS t1_outer
+GROUP BY f
+);
+SELECT * FROM v1;
+Name_exp_1
+1
+DROP VIEW v1;
+DROP TABLE t1;

--- a/mysql-test/main/in_subq_groupby.test
+++ b/mysql-test/main/in_subq_groupby.test
@@ -1,0 +1,22 @@
+--echo #
+--echo # MDEV-27957 Select from view with subselect fails with lost connection
+--echo #
+
+CREATE TABLE t1 (id INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1),(2);
+ 
+CREATE OR REPLACE VIEW v1 AS SELECT
+  1 IN (
+    SELECT
+      (SELECT COUNT(id)
+       FROM t1
+       WHERE t1_outer.id <> id
+       ) AS f
+    FROM
+      t1 AS t1_outer
+    GROUP BY f
+  );
+ 
+SELECT * FROM v1;
+DROP VIEW v1;
+DROP TABLE t1;

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -3253,8 +3253,9 @@ void st_select_lex_node::exclude_from_tree()
 */
 void st_select_lex_node::exclude()
 {
-  /* exclude from global list */
-  fast_exclude();
+  /* if current slave exists, exclude from global list */
+  if (slave)
+    slave->fast_exclude();
   /* exclude from other structures */
   exclude_from_tree();
   /* 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27957*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
The issue is caused by the change of [this commit](https://github.com/MariaDB/server/commit/7e9a6b7f09bfb00e781d8ca63dfe7701900c368b#diff-13bc2276d1ed01506e4f6b46563b57b5e731c30fb02599ecc0c61ed5bee23572R4910). In this commit, to run prepared statement successfully, st_select_lex_node::exclude() is called. However, because fast_exclude() in exclude() overwrites st_select_lex_node's slave to 0x0, the query which issue ticket shows are failed.

So I fixed st_select_lex_node::exclude() that if slave exists, we call fast_exclude() as a slave's instance method.

## How can this PR be tested?
I added `/mysql-test/main/in_subq_groupby.test`, it is same as issue ticket's query I just add comments. It runs with and without `--view-protocol` flag.
In addition, to run prepared statements properly, we also should run `main.ps` cases with `--ps-control` flag. I already verified the test cases.
<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
