### PR TITLE
MDEV-27978 fix wrong opt name when max_session_mem_used exceeded

### DIFF
--- a/mysql-test/main/error_simulation.result
+++ b/mysql-test/main/error_simulation.result
@@ -128,3 +128,9 @@ SELECT f1(1);
 Got one of the listed errors
 DROP FUNCTION f1;
 SET debug_dbug= @saved_dbug;
+#
+# MDEV-27978 wrong option name in error when exceeding max_session_mem_used
+#
+SET SESSION max_session_mem_used = 8192;
+SELECT * FROM information_schema.processlist;
+ERROR HY000: The MariaDB server is running with the --max-session-mem-used=8192 option so it cannot execute this statement

--- a/mysql-test/main/error_simulation.test
+++ b/mysql-test/main/error_simulation.test
@@ -158,3 +158,10 @@ SET SESSION debug_dbug="+d,simulate_create_virtual_tmp_table_out_of_memory";
 SELECT f1(1);
 DROP FUNCTION f1;
 SET debug_dbug= @saved_dbug;
+
+--echo #
+--echo # MDEV-27978 wrong option name in error when exceeding max_session_mem_used
+--echo #
+SET SESSION max_session_mem_used = 8192;
+--error ER_OPTION_PREVENTS_STATEMENT
+SELECT * FROM information_schema.processlist;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3747,7 +3747,7 @@ static void my_malloc_size_cb_func(long long size, my_bool is_thread_specific)
       /* Ensure we don't get called here again */
       char buf[50], *buf2;
       thd->set_killed(KILL_QUERY);
-      my_snprintf(buf, sizeof(buf), "--max-thread-mem-used=%llu",
+      my_snprintf(buf, sizeof(buf), "--max-session-mem-used=%llu",
                   thd->variables.max_mem_used);
       if ((buf2= (char*) thd->alloc(256)))
       {


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-27978

## Description
When `max_session_mem_used` is set and exceeded, the server responds with an error, but call the option name as `max-thread-mem-used`. This is due to a type in `my_malloc_size_cb_func` inside `sql/mysqld.cc`. There is no `max-thread-mem-used` option in MariaDB, only `max-session-mem-used`.

## How can this PR be tested?

Test case and result is included in `error_simulation.test` and `error_simulation.result`. It was tested successfully in my local branch.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*