### PR TITLE
MDEV-28022: Debian stretch has zstd too old

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -42,6 +42,14 @@ GCCVERSION=$(gcc -dumpfullversion -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g
 # Debian policy and targeting Debian Sid. Then case-by-case run in autobake-deb.sh
 # tests for backwards compatibility and strip away parts on older builders.
 
+CODENAME="$(lsb_release -sc)"
+case "${CODENAME}" in
+	stretch)
+		# MDEV-28022 libzstd-dev-1.1.3 minimum version
+		sed -i -e '/libzstd-dev/d' debian/control
+		;;
+esac
+
 # If libcrack2 (>= 2.9.0) is not available (before Debian Jessie and Ubuntu Trusty)
 # clean away the cracklib stanzas so the package can build without them.
 if ! apt-cache madison libcrack2-dev | grep 'libcrack2-dev *| *2\.9' >/dev/null 2>&1
@@ -70,13 +78,6 @@ then
   sed '/galera_new_cluster/d' -i debian/mariadb-server-10.3.install
   sed '/galera_recovery/d' -i debian/mariadb-server-10.3.install
   sed '/mariadb-service-convert/d' -i debian/mariadb-server-10.3.install
-fi
-
-# If libzstd-dev is not available (before Debian Stretch and Ubuntu Xenial)
-# remove the dependency from server and rocksdb so it can build properly
-if ! apt-cache madison libzstd-dev | grep 'libzstd-dev' >/dev/null 2>&1
-then
-  sed '/libzstd-dev/d' -i debian/control
 fi
 
 # The binaries should be fully hardened by default. However TokuDB compilation seems to fail on
@@ -139,7 +140,6 @@ source ./VERSION
 UPSTREAM="${MYSQL_VERSION_MAJOR}.${MYSQL_VERSION_MINOR}.${MYSQL_VERSION_PATCH}${MYSQL_VERSION_EXTRA}"
 PATCHLEVEL="+maria"
 LOGSTRING="MariaDB build"
-CODENAME="$(lsb_release -sc)"
 EPOCH="1:"
 
 dch -b -D ${CODENAME} -v "${EPOCH}${UPSTREAM}${PATCHLEVEL}~${CODENAME}" "Automatic build with ${LOGSTRING}."


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28022*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

zstd-1.1.3 is needed however stretch has only 1.1.2.

Move to distro version based checks as checks against the
apt-cache are unreliable if there is no cache.

## How can this PR be tested?

See if it builds on stretch
<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

No issues identified.