### PR TITLE
MDEV-27713 Crash after a conflict of applier thread with stored proce…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-27713.result
+++ b/mysql-test/suite/galera/r/MDEV-27713.result
@@ -1,0 +1,46 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (
+f1 INT,
+f2 VARCHAR(255) PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO t1 VALUES(1, 'abc');
+connection node_1;
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (2,'def');
+connection node_2;
+SET GLOBAL event_scheduler=ON;
+CREATE PROCEDURE update_table()
+BEGIN
+SET AUTOCOMMIT=OFF;
+DO GET_LOCK('local_lock', 0);
+SET DEBUG_SYNC = 'innodb_row_update_for_mysql_begin SIGNAL blocked WAIT_FOR continue';
+UPDATE t1 SET f2 = 'jkl' WHERE f1 != 2;
+DO RELEASE_LOCK('local_lock');
+END|
+CREATE DEFINER=current_user 
+EVENT event
+ON SCHEDULE AT CURRENT_TIMESTAMP
+ON COMPLETION PRESERVE
+ENABLE
+DO CALL update_table();
+connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+SET DEBUG_SYNC = 'now WAIT_FOR blocked';
+connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+SET GLOBAL debug_dbug = "+d,sync.wsrep_apply_cb";
+connection node_1;
+COMMIT;
+connection node_2b;
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+connection node_2a;
+SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_2;
+SET GLOBAL event_scheduler=default;
+DROP PROCEDURE update_table;
+DROP EVENT event;
+SET DEBUG_SYNC='reset';
+SET GLOBAL debug_dbug = DEFAULT;
+connection node_1;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-27713.test
+++ b/mysql-test/suite/galera/t/MDEV-27713.test
@@ -1,0 +1,64 @@
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+CREATE TABLE t1 (
+  f1 INT,
+  f2 VARCHAR(255) PRIMARY KEY
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO t1 VALUES(1, 'abc');
+
+--connection node_1
+SET AUTOCOMMIT=OFF;
+START TRANSACTION;
+INSERT INTO t1 VALUES (2,'def');
+
+--connection node_2
+
+SET GLOBAL event_scheduler=ON;
+
+DELIMITER |;
+CREATE PROCEDURE update_table()
+BEGIN
+  SET AUTOCOMMIT=OFF;
+  DO GET_LOCK('local_lock', 0);
+  SET DEBUG_SYNC = 'innodb_row_update_for_mysql_begin SIGNAL blocked WAIT_FOR continue';
+  UPDATE t1 SET f2 = 'jkl' WHERE f1 != 2;
+  DO RELEASE_LOCK('local_lock');
+END|
+DELIMITER ;|
+
+CREATE DEFINER=current_user 
+  EVENT event
+  ON SCHEDULE AT CURRENT_TIMESTAMP
+  ON COMPLETION PRESERVE
+  ENABLE
+  DO CALL update_table();
+
+--connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+SET DEBUG_SYNC = 'now WAIT_FOR blocked';
+
+# Applier control thread
+--connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2
+SET GLOBAL debug_dbug = "+d,sync.wsrep_apply_cb";
+
+--connection node_1
+COMMIT;
+
+# Applier control thread
+--connection node_2b
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+
+--connection node_2a
+SET DEBUG_SYNC = 'now SIGNAL continue';
+
+--connection node_2
+SET GLOBAL event_scheduler=default;
+DROP PROCEDURE update_table;
+DROP EVENT event;
+SET DEBUG_SYNC='reset';
+SET GLOBAL debug_dbug = DEFAULT;
+
+--connection node_1
+DROP TABLE t1;

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -342,6 +342,7 @@ int Wsrep_client_service::bf_rollback()
     m_thd->global_read_lock.unlock_global_read_lock(m_thd);
   }
   m_thd->release_transactional_locks();
+  mysql_ull_cleanup(m_thd);
   m_thd->mdl_context.release_explicit_locks();
 
   DBUG_RETURN(ret);

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -380,6 +380,7 @@ int Wsrep_high_priority_service::rollback(const wsrep::ws_handle& ws_handle,
   }
   int ret= (trans_rollback_stmt(m_thd) || trans_rollback(m_thd));
   m_thd->release_transactional_locks();
+  mysql_ull_cleanup(m_thd);
   m_thd->mdl_context.release_explicit_locks();
 
   free_root(m_thd->mem_root, MYF(MY_KEEP_PREALLOC));


### PR DESCRIPTION
…dure call by event scheduler

When thread is BF aborted by high priority service, ULL (user level
locks need to be removed and released). Calling directly release of lock for
MDL_EXPLICIT type doesn't clear also `thd->ull_hash`. Method
`mysql_ull_cleanup` will properly clear all information about ULL locks
for thread.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27713*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
When BF abort happens, we need to correctly clear thread ULL structures and MDL locks.

## How can this PR be tested?
MTR test is part of this PR


<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
