### PR TITLE
MDEV-28032 "git submodule update --depth 1" may fail with old Git

### DIFF
--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -17,20 +17,29 @@ IF(GIT_EXECUTABLE AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
     ${GIT_EXECUTABLE} config cmake.update-submodules yes")
   ELSEIF(git_config_get_result EQUAL 128)
     SET(update_result 0)
-  ELSEIF (cmake_update_submodules MATCHES force)
-    MESSAGE(STATUS "Updating submodules (forced)")
-    EXECUTE_PROCESS(COMMAND "${GIT_EXECUTABLE}" submodule update --init --force --recursive --depth=1
-                    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-                    RESULT_VARIABLE update_result)
-  ELSEIF (cmake_update_submodules MATCHES yes)
-    EXECUTE_PROCESS(COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive --depth=1
-                    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-                    RESULT_VARIABLE update_result)
   ELSE()
-    MESSAGE(STATUS "Updating submodules")
-    EXECUTE_PROCESS(COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive --depth=1
-                    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-                    RESULT_VARIABLE update_result)
+    SET(UPDATE_SUBMODULES_COMMAND
+        "${GIT_EXECUTABLE}" submodule update --init --recursive)
+    # Old Git may not work with "--depth 1".
+    # See also: https://github.com/git/git/commit/fb43e31f2b43076e7a30c9cd00d0241cb8cf97eb
+    IF(NOT GIT_VERSION_STRING VERSION_LESS "2.8.0")
+      SET(UPDATE_SUBMODULES_COMMAND ${UPDATE_SUBMODULES_COMMAND} --depth 1)
+    ENDIF()
+    IF(cmake_update_submodules MATCHES force)
+      MESSAGE(STATUS "Updating submodules (forced)")
+      EXECUTE_PROCESS(COMMAND ${UPDATE_SUBMODULES_COMMAND} --force
+                      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                      RESULT_VARIABLE update_result)
+    ELSEIF(cmake_update_submodules MATCHES yes)
+      EXECUTE_PROCESS(COMMAND ${UPDATE_SUBMODULES_COMMAND}
+                      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                      RESULT_VARIABLE update_result)
+    ELSE()
+      MESSAGE(STATUS "Updating submodules")
+      EXECUTE_PROCESS(COMMAND ${UPDATE_SUBMODULES_COMMAND}
+                      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+                      RESULT_VARIABLE update_result)
+    ENDIF()
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28032*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Old Git may not work with "--depth 1" when the referenced commit hash
is far from HEAD.

Here is an example of a failed case:

https://buildbot.askmonty.org/buildbot/builders/kvm-tarbake-jaunty-x86/builds/46427/steps/compile/logs/stdio

    fatal: reference is not a tree: 2ceda83fd7880d00eaf1a84a835c466c0167d46c

Note that this branch isn't included in upstream yet. This branch is a
working branch to update bundled Mroonga.

Newer Git improves the situation. For example:
https://github.com/git/git/commit/fb43e31f2b43076e7a30c9cd00d0241cb8cf97eb

It's safe to not use "--depth 1" with old Git.

## How can this PR be tested?

https://github.com/mroonga/mariadb-server/tree/mrn-10.7-master has this change and "make dist" can be succeeded with this change:

https://buildbot.askmonty.org/buildbot/builders/kvm-tarbake-jaunty-x86/builds/46462/steps/compile/logs/stdio

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

I will update bundled Mroonga only for MariaDB 10.7 or later. So it's OK to me that only 10.7 or later include this change.

Should I change base branch to 10.2? 

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

This change doesn't break backward compatibility.
