### PR TITLE
MDEV-28153: Debian autobake- use absolute dependencies rather than a buildtime detection (10.5)

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -50,23 +50,45 @@ remove_rocksdb_tools()
   fi
 }
 
+architecture=$(dpkg-architecture -q DEB_BUILD_ARCH)
+
 CODENAME="$(lsb_release -sc)"
 case "${CODENAME}" in
-	stretch)
-		# MDEV-28022 libzstd-dev-1.1.3 minimum version
-		sed -i -e '/libzstd-dev/d' \
-                       -e 's/libcurl4/libcurl3/g' -i debian/control
-		remove_rocksdb_tools
-		;;
-	bionic)
-		remove_rocksdb_tools
-		;;
+  stretch)
+    # MDEV-16525 libzstd-dev-1.1.3 minimum version
+    sed -e '/libzstd-dev/d' \
+        -e 's/libcurl4/libcurl3/g' -i debian/control
+    remove_rocksdb_tools
+    ;&
+  buster)
+    ;&
+  bullseye|bookworm)
+    # mariadb-plugin-rocksdb in control is 4 arches covered by the distro rocksdb-tools
+    # so no removal is necessary.
+    ;&
+  sid)
+    # should always be empty here.
+    # need to match here to avoid the default Error however
+    ;;
+  # UBUNTU
+  bionic)
+    remove_rocksdb_tools
+    ;&
+  focal)
+    ;&
+  impish|jammy)
+    # mariadb-plugin-rocksdb s390x not supported by us (yet)
+    # ubuntu doesn't support mips64el yet, so keep this just
+    # in case something changes.
+    if [[ ! "$architecture" =~ amd64|arm64|ppc64el|s390x ]]
+    then
+      remove_rocksdb_tools
+    fi
+    ;;
+  *)
+    echo "Error - unknown release codename $CODENAME" >&2
+    exit 1
 esac
-
-if [[ ! "$(dpkg-architecture -q DEB_BUILD_ARCH)" =~ amd64|arm64|ppc64el|s390x ]]
-then
-  remove_rocksdb_tools
-fi
 
 # Adjust changelog, add new version
 echo "Incrementing changelog and starting build scripts"


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28153*

## Description

While moving to a prescribed dependencies, an
error was made in the merge. The Ubuntu and
Debian supported architectures of rocksdb-tools are different
and need to be treated as such.

This moves covering all the Debian and Ubuntu branches,
and removing when there isn't support for a package
under a specific architecture.

The differentiation and grouping of distro codenames
is for convenience in merging upwards as more dependencies
change across distro versions.

The fixing of versions rather than relying on apt-cache
to be correct prevents changes, and potentially uninstallable
packages like happened in MDEV-28014.

## How can this PR be tested?

verify the contents of debian/{control,not-installed,mariadb-plugin-rocksdb.install} are identical before and after this change across the various deb based distros after running autobake-deb.sh

## Basing the PR against the correct MariaDB version
- [X] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*