### PR TITLE
MDEV-28120: Clean lintian 'extended-description-is-empty' errors

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -944,6 +944,13 @@ Depends: mariadb-server-10.7,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: BZip2 compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides BZip2 (https://sourceware.org/bzip2/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-lz4
 Architecture: any
@@ -951,6 +958,13 @@ Depends: mariadb-server-10.7,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: LZ4 compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides LZ4 (http://lz4.github.io/lz4/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-lzma
 Architecture: any
@@ -958,6 +972,13 @@ Depends: mariadb-server-10.7,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: LZMA compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides LZMA (https://tukaani.org/lzma/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-lzo
 Architecture: any
@@ -965,6 +986,13 @@ Depends: mariadb-server-10.7,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: LZO compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides LZO (http://www.oberhumer.com/opensource/lzo/) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-plugin-provider-snappy
 Architecture: any
@@ -972,6 +1000,13 @@ Depends: mariadb-server-10.7,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Snappy compression support in the server and storage engines
+ The various MariaDB storage engines, such as InnoDB, RocksDB, Mroonga,
+ can use different compression libraries.
+ .
+ Plugin provides Snappy (https://github.com/google/snappy) compression
+ .
+ Note that these affect InnoDB and Mroonga only;
+ RocksDB still uses the compression algorithms from its own library
 
 Package: mariadb-test
 Architecture: any


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28120*

## Description
There is not Extended description available for compression provider package which are requires in `Debian Policy Manual section 3.4` 

PR fixes Lintian errors:

```
  E: mariadb-plugin-provider-bzip2: extended-description-is-empty
  E: mariadb-plugin-provider-lz4: extended-description-is-empty
  E: mariadb-plugin-provider-lzma: extended-description-is-empty
  E: mariadb-plugin-provider-lzo: extended-description-is-empty
  E: mariadb-plugin-provider-snappy: extended-description-is-empty
```
Which is cause missing Debian Policy Manual section 3.4 (The description
of a package) extended descriptions in mariadb-plugin-provide-*
packages

## How can this PR be tested?
Salsa-CI has CI run located https://salsa.debian.org/illuusio/mariadb-server/-/jobs/2581906/raw that does not contain errors. Manually:

```
apt install lintian
cd mariadb-server
debian/autobake-deb.sh
..wait..
cd ..
lintian *.changes
```
No more `extended-description-is-empty` should be in print out.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This should no affect backward compatibility