### PR TITLE
MDEV-28120: Remove false-positive Lintian linking error

### DIFF
--- a/debian/mariadb-plugin-provider-bzip2.lintian-overrides
+++ b/debian/mariadb-plugin-provider-bzip2.lintian-overrides
@@ -1,0 +1,3 @@
+# It's intentional that bzip2 compression plugin doesn't have symbols from libc
+# More info https://jira.mariadb.org/browse/MDEV-28120
+library-not-linked-against-libc usr/lib/mysql/plugin/provider_bzip2.so

--- a/debian/mariadb-plugin-provider-lz4.lintian-overrides
+++ b/debian/mariadb-plugin-provider-lz4.lintian-overrides
@@ -1,0 +1,3 @@
+# It's intentional that LZ4 compression plugin doesn't have symbols from libc
+# More info https://jira.mariadb.org/browse/MDEV-28120
+library-not-linked-against-libc usr/lib/mysql/plugin/provider_lz4.so

--- a/debian/mariadb-plugin-provider-lzma.lintian-overrides
+++ b/debian/mariadb-plugin-provider-lzma.lintian-overrides
@@ -1,0 +1,3 @@
+# It's intentional that LZMA compression plugin doesn't have symbols from libc
+# More info https://jira.mariadb.org/browse/MDEV-28120
+library-not-linked-against-libc usr/lib/mysql/plugin/provider_lzma.so

--- a/debian/mariadb-plugin-provider-lzo.lintian-overrides
+++ b/debian/mariadb-plugin-provider-lzo.lintian-overrides
@@ -1,0 +1,3 @@
+# It's intentional that LZO compression plugin doesn't have symbols from libc
+# More info https://jira.mariadb.org/browse/MDEV-28120
+library-not-linked-against-libc usr/lib/mysql/plugin/provider_lzo.so

--- a/debian/mariadb-plugin-provider-snappy.lintian-overrides
+++ b/debian/mariadb-plugin-provider-snappy.lintian-overrides
@@ -1,0 +1,3 @@
+# It's intentional that Snappy compression plugin doesn't have symbols from libc
+# More info https://jira.mariadb.org/browse/MDEV-28120
+library-not-linked-against-libc usr/lib/mysql/plugin/provider_snappy.so


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28120*

## Description
Provider Plugins throws Lintian False-Positive Errors. This because these shared objects does not share any symbols from Glibc and Lintian uses command `objdump -X` to check exactly which symbols are required by shared object. As Lintian error itself if correct it's not error and it's false-positive which should be overrided with `.lintian-overrides`-files

PR fixes Lintian errors:

```
    E: mariadb-plugin-provider-bzip2: library-not-linked-against-libc usr/lib/mysql/plugin/provider_bzip2.so
    E: mariadb-plugin-provider-lz4: library-not-linked-against-libc usr/lib/mysql/plugin/provider_lz4.so
    E: mariadb-plugin-provider-lzma: library-not-linked-against-libc usr/lib/mysql/plugin/provider_lzma.so
    E: mariadb-plugin-provider-lzo: library-not-linked-against-libc usr/lib/mysql/plugin/provider_lzo.so
    E: mariadb-plugin-provider-snappy: library-not-linked-against-libc usr/lib/mysql/plugin/provider_snappy.so
```

## How can this PR be tested?
Salsa-CI has CI run located https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/359422 that does not contain errors. Manually:

```
apt install lintian
cd mariadb-server
debian/autobake-deb.sh
..wait..
cd ..
lintian *.changes
```
No more `library-not-linked-against-libc` should be in print out.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This should no affect backward compatibility
