### PR TITLE
MDEV-28121: Add new compression plugins as autopkg dependencies

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -3,7 +3,12 @@ Tests: smoke
 # for its existence (see the list in debian/control), install it if available
 # and check in the test if it's functional when it should be.
 # The plugin package also already depends on the other one.
-Depends: mariadb-plugin-rocksdb | mariadb-server-10.7
+Depends: mariadb-plugin-rocksdb | mariadb-server-10.7,
+         mariadb-plugin-provider-bzip2,
+         mariadb-plugin-provider-lz4,
+         mariadb-plugin-provider-lzma,
+         mariadb-plugin-provider-lzo,
+         mariadb-plugin-provider-snappy
 Restrictions: allow-stderr needs-root isolation-container
 
 Tests: upstream

--- a/debian/tests/smoke
+++ b/debian/tests/smoke
@@ -38,6 +38,11 @@ else
   # If systemd (and systemctl) is available, but the service did not start, then
   # this smoke test is supposed to fail if next commands don't work.
   echo "Found systemctl, continuing smoke test.."
+  # Compression plugins are separated from main server package
+  # to own packages (for example LZ4 package mariadb-plugin-provider-lz4)
+  # and they are installed after mariadb-server.
+  # which means that they don't exist if MariaDB is not restarted
+  systemctl restart mariadb
 fi
 
 mysql <<EOT
@@ -71,10 +76,10 @@ EOT
 # but disabled  with '#' the options that are not available in this binary build
 mariadb <<EOT
 SET GLOBAL innodb_compression_algorithm=lz4;
-#SET GLOBAL innodb_compression_algorithm=lzo;
-#SET GLOBAL innodb_compression_algorithm=lzma;
-#SET GLOBAL innodb_compression_algorithm=bzip2;
-#SET GLOBAL innodb_compression_algorithm=snappy;
+SET GLOBAL innodb_compression_algorithm=lzo;
+SET GLOBAL innodb_compression_algorithm=lzma;
+SET GLOBAL innodb_compression_algorithm=bzip2;
+SET GLOBAL innodb_compression_algorithm=snappy;
 SET GLOBAL innodb_compression_algorithm=zlib;
 SET GLOBAL innodb_compression_algorithm=none;
 EOT


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28121*

## Description
Add compression plugins:
  * bzip2
  * lz4
  * lzma
  * lzo
  * snappy
To Autopkg's basic smoke-test dependencies.

Also make sure that MariaDB service is reloaded
when smoke-test is executed.

## How can this PR be tested?
Salsa-CI has CI run located https://salsa.debian.org/illuusio/mariadb-server/-/jobs/2582162/raw that does not contain errors. Manually:

```
apt install debci
cd mariadb-server
debian/autobake-deb.sh
..wait..
cd ..
debci -c "debci localtest $WORKING_DIR/*.changes"
```
Smoke test should pass

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This should no affect backward compatibility
