### PR TITLE
MDEV-28153: Debian autobake- use absolute dependencies

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -30,9 +30,12 @@ then
   # build is not running on Travis or Gitlab-CI
   sed '/-DPLUGIN_COLUMNSTORE=NO/d' -i debian/rules
   # Take the files and part of control from MCS directory
-  cp -v storage/columnstore/columnstore/debian/mariadb-plugin-columnstore.* debian/
-  echo >> debian/control
-  cat storage/columnstore/columnstore/debian/control >> debian/control
+  if [ ! -f debian/mariadb-plugin-columnstore.install ]
+  then
+    cp -v storage/columnstore/columnstore/debian/mariadb-plugin-columnstore.* debian/
+    echo >> debian/control
+    cat storage/columnstore/columnstore/debian/control >> debian/control
+  fi
 fi
 
 # Look up distro-version specific stuff
@@ -90,6 +93,11 @@ case "${CODENAME}" in
     echo "Error - unknown release codename $CODENAME" >&2
     exit 1
 esac
+
+if [ -n "${AUTOBAKE_PREP_CONTROL_RULES_ONLY:-}" ]
+then
+  exit 0
+fi
 
 # Adjust changelog, add new version
 echo "Incrementing changelog and starting build scripts"

--- a/debian/rules
+++ b/debian/rules
@@ -108,7 +108,7 @@ override_dh_auto_build:
 	@echo "RULES.$@"
 	# Print build env info to help debug builds on different platforms
 	dpkg-architecture
-	cd $(BUILDDIR) && $(MAKE)
+	cd $(BUILDDIR) && $(MAKE) --output-sync=target
 
 override_dh_auto_test:
 	@echo "RULES.$@"

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -34,7 +34,7 @@ build:
     - mv ${CCACHE_WORK_DIR} ${CCACHE_TMP_DIR}
     # Run Salsa-CI .build-script equivalent, with extra devscripts so autobake-deb.sh can run 'dch'
     - export CCACHE_DIR=${CCACHE_TMP_DIR}
-    - apt-get update && eatmydata apt-get install --no-install-recommends -y ccache fakeroot build-essential devscripts
+    - apt-get update && eatmydata apt-get install --no-install-recommends -y ccache fakeroot build-essential devscripts lsb-release
     - cd ${WORKING_DIR}/${SOURCE_DIR}
     - eatmydata apt-get build-dep --no-install-recommends -y .
     - update-ccache-symlinks; ccache -z # Zero out ccache counters


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28153*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

With autobake-deb.sh no doing explicit dependencies, we need to run this
explicitly as a prep step in salsa-ci so the dependencies can be pulled
before the real compilation begins.

Resolves 10.5 part of salsa in #2039.

## How can this PR be tested?

Currently running on https://salsa.debian.org/grooverdan/mariadb-server/-/pipelines/361865)

(10.8 test timed out)

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [X] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
