### PR TITLE
MDEV-25912 wsrep does not identify  checksummed events correctly

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -5841,6 +5841,8 @@ THD::binlog_start_trans_and_stmt()
         }
         Gtid_log_event gtid_event(this, seqno, domain_id, true,
                                   LOG_EVENT_SUPPRESS_USE_F, true, 0);
+        // Replicated events in writeset doesn't have checksum
+        gtid_event.checksum_alg= BINLOG_CHECKSUM_ALG_OFF;
         gtid_event.server_id= server_id;
         writer.write(&gtid_event);
         wsrep_write_cache_buf(&tmp_io_cache, &buf, &len);

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2624,11 +2624,6 @@ Gtid_log_event::Gtid_log_event(const uchar *buf, uint event_len,
   */
   DBUG_ASSERT(static_cast<uint>(buf - buf_0) <= event_len);
   /* and the last of them is tested. */
-#ifdef MYSQL_SERVER
-#ifdef WITH_WSREP
-  if (!WSREP_ON)
-#endif
-#endif
   DBUG_ASSERT(static_cast<uint>(buf - buf_0) == event_len ||
               buf_0[event_len - 1] == 0);
 }


### PR DESCRIPTION
For GTID consistenty, GTID events was artificialy added before
replication happned. This event should not contain CHECKSUM calculated.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25912*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Artifical GTID that was added for GTID cluster consistency should not have checksum calculated.

## How can this PR be tested?
Issue was reproducible with galera.galera_as_slave_gtid_auto_engine
<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


