### PR TITLE
MDEV-28177: Update the offset of dbName on the aarch64 platform.

### DIFF
--- a/plugin/server_audit/server_audit.c
+++ b/plugin/server_audit/server_audit.c
@@ -2328,6 +2328,9 @@ int get_db_mysql57(MYSQL_THD thd, char **name, int *len)
 #ifdef __x86_64__
     db_off= 608;
     db_len_off= 616;
+#elif __aarch64__
+    db_off= 632;
+    db_len_off= 640;
 #else
     db_off= 0;
     db_len_off= 0;
@@ -2338,6 +2341,9 @@ int get_db_mysql57(MYSQL_THD thd, char **name, int *len)
 #ifdef __x86_64__
     db_off= 536;
     db_len_off= 544;
+#elif __aarch64__
+    db_off= 552;
+    db_len_off= 560;
 #else
     db_off= 0;
     db_len_off= 0;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-28177](https://jira.mariadb.org/browse/MDEV-28177)

## Description
On the aarch64 platform, MySQL 5.7.33 cannot install the audit plugin of Mariadb-10.2.43 version, but it can run normally on the X86_64 platform.

## How can this PR be tested?
Install the audit plugin of version 10.2.43 on MySQL 5.7.33 on aarch64 platform.
