### PR TITLE
MDEV-15718: check for exact mysqld process

### DIFF
--- a/debian/mariadb-server-10.2.preinst
+++ b/debian/mariadb-server-10.2.preinst
@@ -25,7 +25,7 @@ stop_server() {
 
     # Return immediately if there are no mysql processes running
     # as there is no point in trying to shutdown in that case.
-    if ! pgrep --ns $$ mysqld > /dev/null; then return; fi
+    if ! pgrep -x --ns $$ mysqld > /dev/null; then return; fi
 
     set +e
     if [ -x /usr/sbin/invoke-rc.d ]; then


### PR DESCRIPTION
## Description

Debian dpkg preinst checks if mysql is running using `pgrep` and we can have other processes running containing 'mysqld' for  instance `prometheus/mysqld_exporter`.

## How can this PR be tested?

This is a rare case where another process running contains `mysqld` in it's name. In that case `pgrep` will return program's pid even if mysqld is stopped.