### PR TITLE
MDEV-21331: sync preinst and postrm script

### DIFF
--- a/debian/mariadb-server-10.5.postrm
+++ b/debian/mariadb-server-10.5.postrm
@@ -17,9 +17,9 @@ MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 stop_server() {
     # Return immediately if there are no mysql processes running
     # as there is no point in trying to shutdown in that case.
-    if ! pgrep -x mariadbd > /dev/null; then return; fi
+    if ! pgrep -x --ns $$ mariadbd > /dev/null; then return; fi
     # Compatibility with versions that ran 'mysqld'
-    if ! pgrep -x mysqld > /dev/null; then return; fi
+    if ! pgrep -x --ns $$ mysqld > /dev/null; then return; fi
 
     set +e
     invoke-rc.d mariadb stop


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-21331](https://jira.mariadb.org/browse/MDEV-21331)*

Not exactly related to but the same problem could appear on uninstallation.

## Description

When detecting running mysqld/mariadbd processes to stop, ignore processes in different namespaces.

## How can this PR be tested?

Install mariadb and start a mariadb docker container on the same host, test upgrade/uninstall.