### PR TITLE
Deb: Fix Salsa-CI autopkgtest failure

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -105,13 +105,6 @@ dch -b -D "${CODENAME}" -v "${VERSION}" "Automatic build with ${LOGSTRING}." --c
 
 echo "Creating package version ${VERSION} ... "
 
-# On Gitlab-CI, use -b to build binary only packages as there is
-# no need to waste time on generating the source package.
-if [[ $GITLAB_CI ]]
-then
-  BUILDPACKAGE_FLAGS="-b"
-fi
-
 # Use eatmydata is available to build faster with less I/O, skipping fsync()
 # during the entire build process (safe because a build can always be restarted)
 if which eatmydata > /dev/null


### PR DESCRIPTION
The autopkgtest was failing due to missing *.changes file. This is part
of source build, so revert autobake-deb.sh back to NOT using -b for
Gitlab-CI/Salsa-CI runs.

## How can this PR be tested?

Before, failing autopkgtestin CI: https://salsa.debian.org/mariadb-team/mariadb-server/-/pipelines/362475
After, successful CI: https://salsa.debian.org/mariadb-team/mariadb-server/-/pipelines/362464

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
