### PR TITLE
Galera test failure on galera_bf_abort_ps_bind

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -8535,7 +8535,10 @@ void run_prepare_stmt(struct st_connection *cn, struct st_command *command, cons
     separate string
   */
   if (!disable_warnings)
+  {
     append_warnings(&ds_prepare_warnings, mysql);
+    dynstr_free(&ds_prepare_warnings);
+  }
  end:
   DBUG_VOID_RETURN;
 }
@@ -8611,7 +8614,7 @@ void run_bind_stmt(struct st_connection *cn, struct st_command *command,
       else
       {
         ps_params[i].buffer_type= MYSQL_TYPE_STRING;
-        ps_params[i].buffer= strdup(p);
+        ps_params[i].buffer= my_strdup(p, MYF(MY_WME));
         ps_params[i].buffer_length= (unsigned long)strlen(p);
       }
     }

--- a/mysql-test/suite/galera/r/galera_bf_abort_ps_bind.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_ps_bind.result
@@ -28,6 +28,7 @@ PS_execute;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 PS_execute;
 commit;
+PS_close;
 select * from t;
 i	j
 1	node2

--- a/mysql-test/suite/galera/t/galera_bf_abort_ps_bind.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_ps_bind.test
@@ -53,6 +53,8 @@ update t set j='node2' where i=1;
 --PS_execute
 commit;
 
+--PS_close
+
 select * from t;
 
 drop table t;


### PR DESCRIPTION
Fix a possible crash on my_free() due to the use of strdup() versus
my_strdup(), and a memory leak.