### PR TITLE
Use proper pid namespace

### DIFF
--- a/debian/mariadb-server-10.2.postrm
+++ b/debian/mariadb-server-10.2.postrm
@@ -11,6 +11,11 @@ MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 # do it himself. No database directories should be removed while the server
 # is running!
 stop_server() {
+  # Return immediately if there are no mysql processes running
+  # as there is no point in trying to shutdown in that case.
+  # Compatibility with versions that ran 'mariadbd'
+  if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
+
   set +e
   if [ -x /usr/sbin/invoke-rc.d ]; then
     invoke-rc.d mysql stop

--- a/debian/mariadb-server-10.2.preinst
+++ b/debian/mariadb-server-10.2.preinst
@@ -22,10 +22,11 @@ mysql_upgradedir=/var/lib/mysql-upgrade
 # is running! Another mysqld in e.g. a different chroot is fine for us.
 stop_server() {
     if [ ! -x /etc/init.d/mysql ]; then return; fi
-
-    # Return immediately if there are no mysql processes running
+    # Return immediately if there are no mysql processes running on a host
+    # (leave containerized processes with the same name in other namespaces)
     # as there is no point in trying to shutdown in that case.
-    if ! pgrep --ns $$ mysqld > /dev/null; then return; fi
+    # Compatibility with versions that ran 'mariadbd'
+    if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
 
     set +e
     if [ -x /usr/sbin/invoke-rc.d ]; then


### PR DESCRIPTION
#### Problem:
==============
By testing `pgrep` with `--ns` option,
introduced with MDEV-21331, commit https://github.com/MariaDB/server/commit/fb7c1b9415c9a8b0dc2e86ae44f0e7a2634e5d7e,
I noted that:
a) `--ns`  cannot use more than single PID.
b) `--ns` is returning the processes of the namespace to which supplied PID belongs to.
So by that sense command `pgrep -x --ns $$ mysqld` will always return an error and skip
checking of the existing PID of the server.

#### Solution:
==============
    Suggested solution is to add `--nslist pid`, since `--ns` needs to know in which namespace type it should look for.
    See `pgrep --help` for different namespace types.
    Note also that this works *only* if script is run as a `root` (we have that case here).

Current PR is a part of:
1. MDEV-21331: sync preinst and postrm script
2. MDEV-15718: check for exact mysqld process

This commit:
a) fixes https://github.com/MariaDB/server/commit/fb7c1b9415c9a8b0dc2e86ae44f0e7a2634e5d7e
b) Closes PR https://github.com/MariaDB/server/pull/2068 (obsolete)
c) Closes PR https://github.com/MariaDB/server/pull/2069 (obsolete)

See more in JIRA comment of MDEV-15718.
Thanks Faustin Lammler <faustin@mariadb.org> for testing and verifying

Reviewed by: <>
## How can this PR be tested?

Please take a look into https://github.com/MariaDB/mariadb.org-tools/tree/master/anel/shell_scripts/pid_namespace
