### PR TITLE
Change MDBF mirror URL

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -519,7 +519,7 @@ mariadb.org-10.5 to mariadb-10.5 upgrade:
     - *test-prepare-container
     - apt install -y curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://deb.mariadb.org/repo/10.5/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.5/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     # The 10.5.9 release is missing mariadb-plugin-columnstore, define all other packages but it to avoid hitting the error:
     #   The following packages have unmet dependencies:
@@ -539,7 +539,7 @@ mariadb.org-10.5 to mariadb-10.5 upgrade:
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
-    RELEASE: bullseye # Last Debian release that MariaDB.org publised 10.5 binaries for
+    RELEASE: bullseye # Last Debian release that MariaDB.org published 10.5 binaries for
   except:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
@@ -558,7 +558,7 @@ mariadb.org-10.4 to mariadb-10.5 upgrade:
     - *test-prepare-container
     - apt install -y curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://deb.mariadb.org/repo/10.4/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.4/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - apt-get install -y mariadb-server-10.4
     # MariaDB.org version of 10.4 and early 10.5 do not install an init file, so
@@ -572,7 +572,7 @@ mariadb.org-10.4 to mariadb-10.5 upgrade:
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
-    RELEASE: buster # Last Debian release that MariaDB.org publised 10.4 binaries for
+    RELEASE: buster # Last Debian release that MariaDB.org published 10.4 binaries for
   except:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
@@ -591,7 +591,7 @@ mariadb.org-10.3 to mariadb-10.5 upgrade:
     - *test-prepare-container
     - apt install -y curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://deb.mariadb.org/repo/10.3/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.3/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - apt-get install -y mariadb-server-10.3
     - *test-verify-initial
@@ -605,7 +605,7 @@ mariadb.org-10.3 to mariadb-10.5 upgrade:
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
-    RELEASE: buster # Last Debian release that MariaDB.org publised 10.3 binaries for
+    RELEASE: buster # Last Debian release that MariaDB.org published 10.3 binaries for
   except:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
@@ -624,7 +624,7 @@ mariadb.org-10.2 to mariadb-10.5 upgrade:
     - *test-prepare-container
     - apt install -y curl apt-transport-https
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://deb.mariadb.org/repo/10.2/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.2/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
     - apt-get install -y mariadb-server-10.2
     # Verify initial state before upgrade
@@ -657,7 +657,7 @@ mariadb.org-10.2 to mariadb-10.5 upgrade:
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
-    RELEASE: stretch # Last Debian release that MariaDB.org publised 10.2 binaries for
+    RELEASE: stretch # Last Debian release that MariaDB.org published 10.2 binaries for
   except:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/


### PR DESCRIPTION
As as discussed with @dbart we decided to move https://deb.mariadb.org/repo to https://deb.mariadb.org so that a
request on https://deb.mariadb.org will end up directly in https://mirror.mariadb.org/repo.

The same behavior was configured for rpms (https://rpm.mariadb.org --> https://mirror.mariadb.org/yum) this also makes the old yum.mariadb.org service transparently compatible with this new service (after DNS change to point to rpm.mariadb.org).

See also: https://jira.mariadb.org/browse/MDBF-297