### PR TITLE
MDBF-348: innodb aix htm support

### DIFF
--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -387,7 +387,8 @@ ENDIF()
 # s390x because of the way it defines the high level intrinsics
 # as not-inline in the header file can only be included by one
 # source file that has -mhtm enabled.
-IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|powerpc64|s390x")
+IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|powerpc64|s390x"
+   OR CMAKE_SYSTEM_NAME MATCHES "AIX")
   ADD_COMPILE_FLAGS(
       sync/srw_lock.cc
       COMPILE_FLAGS "-mhtm"


### PR DESCRIPTION
CMAKE_SYSTEM_PROCESSOR on AIX is "powerpc". To
de-conflict with the Linux 32bit arch of the same
name, CMAKE_SYSTEM_NAME was used in the CMakeLists.txt
test to enable -mhtm in the same way that was required
for Linux ppc64{,le} compilers in MDEV-27936