### PR TITLE
MDBF-348: Correct AIX cast warning (my_time.h)

### DIFF
--- a/include/my_time.h
+++ b/include/my_time.h
@@ -244,9 +244,12 @@ static inline void my_time_trunc(MYSQL_TIME *ltime, uint decimals)
       !ltime->hour && !ltime->minute && !ltime->second)
     ltime->neg= FALSE;
 }
+#ifdef __WIN__
+#define suseconds_t long
+#endif
 static inline void my_timeval_trunc(struct timeval *tv, uint decimals)
 {
-  tv->tv_usec-= my_time_fraction_remainder(tv->tv_usec, decimals);
+  tv->tv_usec-= (suseconds_t) my_time_fraction_remainder(tv->tv_usec, decimals);
 }
 
 


### PR DESCRIPTION
tv_usec is a (suseconds_t) so we cast to it. Prevents the warning that occurs quite significantly on AIX:

include/my_time.h: In function 'void my_timeval_trunc(timeval*, uint)':
include/my_time.h:249:65: warning: conversion from 'long int' to 'suseconds_t' {aka 'int'} may change value [-Wconversion]
  249 |   tv->tv_usec-= my_time_fraction_remainder(tv->tv_usec, decimals);
      |

(gcc-10)

On Windows suseconds_t isn't defined so we use the existing
long return type of my_time_fraction_remainder.