### PR TITLE
MDEV-28076: Deb: Sync Salsa-CI from Debian MariaDB 10.6 (10.9)

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -21,7 +21,7 @@ stages:
   - build
   - test
   - upgrade in Sid
-  - upgrade from Bullseye/Buster/Stretch
+  - upgrade from Bullseye/Buster
   - upgrade extras
   - test extras
   - publish # Stage referenced by Salsa-CI template aptly stanza, so must exist even though not used
@@ -54,6 +54,15 @@ build bullseye-backports:
 build buster-backports:
   extends: .build-package
   script:
+    # Force installation of liburing-dev from buster-backports
+    - apt-get update && apt-cache policy && eatmydata apt-get install liburing-dev
+    # Increase default backports priority policy from '100' to '500' so it can actually be used
+    - |
+      cat << EOF > /etc/apt/preferences.d/enable-backports-to-satisfy-dependencies
+      Package: *
+      Pin: release n=buster-*
+      Pin-Priority: 500
+      EOF
     - *autobake-deb-steps
   variables:
     RELEASE: buster-backports
@@ -68,8 +77,16 @@ build i386:
   variables:
     ARCH: 'i386'
 
+# Build native deb without using autobake-deb.sh. This way we will detect
+# if the debian/control file and other packaging is correct as-is for Debian Sid.
 build native deb:
   extends: .build-package
+
+autopkgtest:
+  extends: .test-autopkgtest
+  artifacts:
+    reports:
+      junit: ${WORKING_DIR}/debci/artifacts/mysql-test-run-junit.xml
 
 piuparts:
   extends: .test-piuparts
@@ -78,6 +95,7 @@ piuparts:
 blhc:
   extends: .test-blhc
   stage: test extras
+  # Build log checker needs a .build file and thus only works on native build
   needs:
     - job: build native deb
 
@@ -96,11 +114,17 @@ blhc:
   # Prime the apt cache so later apt commands can run
   apt-get update
 
+# Readline was removed from Debian Sid (and Bullseye) in Feb 2021. To be able to install older
+# versions of MariaDB that depend on it, fetch and install it from Buster.
+.test-install-readline-in-sid-for-backwards-compat: &test-install-readline-in-sid-for-backwards-compat |
+  curl -O http://ftp.de.debian.org/debian/pool/main/r/readline5/libreadline5_5.2+dfsg-3+b13_amd64.deb
+  apt install -y ./libreadline5_5.2+dfsg-3+b13_amd64.deb
+
 .test-verify-initial: &test-verify-initial |
   dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
   service mysql status || service mariadb status # Early MariaDB 10.5 only had 'mariadb'
   mysql --skip-column-names -e "select @@version, @@version_comment" # Show version
-  mysql --table -e 'SHOW DATABASES;' # List databases before upgrade
+  mysql --table -e "SHOW DATABASES;" # List databases before upgrade
   mysql --table -e "SELECT host,user,plugin,authentication_string FROM user;" mysql
   mysql --table -e "SELECT * FROM plugin;" mysql
   mysql --table -e "SHOW PLUGINS;" mysql
@@ -125,7 +149,7 @@ blhc:
   cp -ra /etc/mysql debug/etc-mysql
   cp -ra /var/log/mysql debug/var-log-mysql
   mariadb --skip-column-names -e "select @@version, @@version_comment" # Show version
-  mariadb --table -e 'SHOW DATABASES;' # List databases
+  mariadb --table -e "SHOW DATABASES;" # List databases
   mariadb --table -e "SELECT host,user,plugin,authentication_string FROM user;" mysql
   mariadb --table -e "SELECT * FROM plugin;" mysql
   mariadb --table -e "SHOW PLUGINS;" mysql
@@ -221,7 +245,7 @@ mariadb-10.9 Sid upgrade:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
 mariadb-10.5 Bullseye to mariadb-10.9 upgrade:
-  stage: upgrade from Bullseye/Buster/Stretch
+  stage: upgrade from Bullseye/Buster
   needs:
     - job: build
   image: debian:bullseye
@@ -247,7 +271,7 @@ mariadb-10.5 Bullseye to mariadb-10.9 upgrade:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
 mariadb-10.3 Buster to mariadb-10.9 upgrade:
-  stage: upgrade from Bullseye/Buster/Stretch
+  stage: upgrade from Bullseye/Buster
   needs:
     - job: build
   image: debian:buster
@@ -262,34 +286,6 @@ mariadb-10.3 Buster to mariadb-10.9 upgrade:
     - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
     # Verify installation of MariaDB from Buster
     - *test-verify-initial
-    - *test-enable-sid-repos
-    - *test-install
-    - service mysql status
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-mariadb-10.1 Stretch to mariadb-10.9 upgrade:
-  stage: upgrade from Bullseye/Buster/Stretch
-  needs:
-    - job: build
-  image: debian:stretch
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    # Install almost everything currently in Debian Stretch,
-    # omitting libmariadbclient-dev-compat as it would conflict
-    - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadbd*' 'libmariadbclient*'
-    # Verify installation of MariaDB from Stretch
-    - *test-verify-initial
-    - apt-get remove -y manpages  # Workaround for Bug#99375
     - *test-enable-sid-repos
     - *test-install
     - service mysql status
@@ -457,8 +453,29 @@ default-libmysqlclient-dev Sid upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
+default-libmysqlclient-dev Bullseye upgrade:
+  stage: upgrade from Bullseye/Buster
+  needs:
+    - job: build
+  image: debian:bullseye
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - ${WORKING_DIR}/debug
+  script:
+    - *test-prepare-container
+    - apt-get install -y pkg-config default-libmysqlclient-dev
+    - pkg-config --list-all
+    - *test-enable-sid-repos
+    - *test-install-all-libs
+    - *test-verify-libs
+  except:
+    variables:
+      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+
 default-libmysqlclient-dev Buster upgrade:
-  stage: upgrade from Bullseye/Buster/Stretch
+  stage: upgrade from Bullseye/Buster
   needs:
     - job: build
   image: debian:buster
@@ -477,52 +494,6 @@ default-libmysqlclient-dev Buster upgrade:
   except:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-default-libmysqlclient-dev Stretch upgrade:
-  stage: upgrade from Bullseye/Buster/Stretch
-  needs:
-    - job: build
-  image: debian:stretch
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - apt-get install -y pkg-config default-libmysqlclient-dev
-    - pkg-config --list-all
-    - apt-get remove -y manpages  # Workaround for Bug#99375
-    - *test-enable-sid-repos
-    - *test-install-all-libs
-    - *test-verify-libs
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-mariadb-connector-c Stretch upgrade:
-  stage: upgrade from Bullseye/Buster/Stretch
-  needs:
-    - job: build
-  image: debian:stretch
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - apt-get install -y pkg-config libmariadb2 libmariadb-dev libmariadb-dev-compat
-    - pkg-config --list-all
-    - apt-get remove -y manpages  # Workaround for Bug#99375
-    - *test-enable-sid-repos
-    - *test-install-all-libs
-    - *test-verify-libs
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-  allow_failure: true
-  # Upgrading libc from Stretch to Bookworm is not possible due to Bug#993755
 
 # Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
 # The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
@@ -568,14 +539,14 @@ mysql-8.0 Focal to mariadb-10.9 upgrade:
     # Add Ubuntu Focal archive keys and repository
     - apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
     - apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 871920D1991BC93C 3B4FE6ACC0B21F32
-    - echo 'deb http://archive.ubuntu.com/ubuntu/ focal main restricted' > /etc/apt/sources.list.d/ubuntu.list
+    - echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" > /etc/apt/sources.list.d/ubuntu.list
     - apt-get update
     # First install often fail due to bug in mysql-8.0
     - apt-get install -y mysql-server 'libmysqlc*' || true
     - sleep 10 && apt-get install -f
     - *test-verify-initial
     # Enable backports to make galera-4 available
-    - echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list && apt-get update
+    - echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update
     - *test-install
     - service mysql status
     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
@@ -586,12 +557,11 @@ mysql-8.0 Focal to mariadb-10.9 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-
-mariadb.org-10.5 to mariadb-10.9 upgrade:
+mariadb.org-10.6 to mariadb-10.9 upgrade:
   stage: upgrade extras
   needs:
     - job: build
-  image: debian:sid
+  image: debian:${RELEASE}
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -601,19 +571,51 @@ mariadb.org-10.5 to mariadb-10.9 upgrade:
     - *test-prepare-container
     - apt install -y curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo 'deb http://mirror.one.com/mariadb/repo/10.5/debian sid main' > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.6/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
-    # The 10.5.9 release is missing mariadb-plugin-columnstore, define all other packages but it to avoid hitting the error:
-    #   The following packages have unmet dependencies:
-    #   mariadb-plugin-columnstore : Depends: mariadb-server-10.5 (= 1:10.5.8+maria~sid) but 1:10.5.9+maria~sid is to be installed
-    - apt-get install -y libmariadb3 'libmariadb-*' 'libmariadbd*' 'mariadb-c*' 'mariadb-b*' 'mariadb-s*' 'mariadb-t*' 'mariadb-plugin-con*' 'mariadb-plugin-cr*' 'mariadb-plugin-g*' 'mariadb-plugin-m*' 'mariadb-plugin-o*' 'mariadb-plugin-s*'
-    # Once 10.5.10 is out, revert back to:
     # Package libmariadbclient-dev from mariadb.org conflicts with libmariadb-dev in Sid, so cannot use wildcard that would include it
-    #- apt-get install -y 'mariadb*' libmariadb3 'libmariadb-*' 'libmariadbd*'
+    # Enable this line when there is a way to install them only from the mariadb.org repo
+    # - apt-get install -y 'mariadb*' libmariadb3 'libmariadb-*' 'libmariadbd*'
+    - apt-get install -y mariadb-server-10.6
     - *test-verify-initial
     # Install MariaDB built in this commit
     # Force downgrades so our version installs on top of upstream revision, e.g. 1:10.5.5-1 vs 1:10.5.5+mariadb~sid
     - apt-get install -y --allow-downgrades ./*.deb
+    # Verify installation of MariaDB built in this commit
+    - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
+    - mariadb --version # Client version
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.9
+    - *test-verify-final
+  variables:
+    GIT_STRATEGY: none
+  except:
+    variables:
+      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+  allow_failure: true
+  # Installation on Sid fails on missing liburing1 because upstream 10.9
+  # MariaDB.org buildbot has not run 'apt upgrade' for a long time.
+  # Remove this allow_failure once buildbot has built a new 10.9
+  # release using latest liburing-dev in Debian Sid.
+
+mariadb.org-10.5 to mariadb-10.9 upgrade:
+  stage: upgrade extras
+  needs:
+    - job: build
+  image: debian:${RELEASE}
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - ${WORKING_DIR}/debug
+  script:
+    - *test-prepare-container
+    - apt install -y curl
+    - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
+    - echo "deb https://deb.mariadb.org/10.5/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
+    - apt-get update
+    - apt-get install -y mariadb-server-10.5
+    - *test-verify-initial
+    # Install MariaDB built in this commit
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
@@ -629,7 +631,7 @@ mariadb.org-10.4 to mariadb-10.9 upgrade:
   stage: upgrade extras
   needs:
     - job: build
-  image: debian:sid
+  image: debian:${RELEASE}
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -639,8 +641,9 @@ mariadb.org-10.4 to mariadb-10.9 upgrade:
     - *test-prepare-container
     - apt install -y curl systemctl # systemctl shim needed on platforms that don't have systemd
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo 'deb http://mirror.one.com/mariadb/repo/10.4/debian sid main' > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.4/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
+    - *test-install-readline-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.4
     # MariaDB.org version of 10.4 and early 10.5 do not install an init file, so
     # it must be installed here manually
@@ -661,7 +664,7 @@ mariadb.org-10.3 to mariadb-10.9 upgrade:
   stage: upgrade extras
   needs:
     - job: build
-  image: debian:sid
+  image: debian:${RELEASE}
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -671,20 +674,16 @@ mariadb.org-10.3 to mariadb-10.9 upgrade:
     - *test-prepare-container
     - apt install -y curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo 'deb http://mirror.one.com/mariadb/repo/10.3/debian sid main' > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.3/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
+    - *test-install-readline-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.3
-    # Verify initial state before upgrade
-    - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
-    - service mysql status
-    # prepending with --defaults-file=/etc/mysql/debian.cnf is needed in upstream 5.5–10.3
-    - mysql --defaults-file=/etc/mysql/debian.cnf --skip-column-names -e "SELECT @@version, @@version_comment"
-    - echo 'SHOW DATABASES;' | mysql --defaults-file=/etc/mysql/debian.cnf
-    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT Host,User,plugin,authentication_string FROM user;" mysql
-    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM plugin;" mysql
+    - *test-verify-initial
     - *test-install
     - service mysql status
-    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+    # Give the mariadb-upgrade plenty of time to complete, otherwise next commands
+    # fail on non-existing mariadb.sys user
+    - sleep 15
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -696,7 +695,7 @@ mariadb.org-10.2 to mariadb-10.9 upgrade:
   stage: upgrade extras
   needs:
     - job: build
-  image: debian:sid
+  image: debian:${RELEASE}
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -706,20 +705,24 @@ mariadb.org-10.2 to mariadb-10.9 upgrade:
     - *test-prepare-container
     - apt install -y curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo 'deb http://mirror.one.com/mariadb/repo/10.2/debian sid main' > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://deb.mariadb.org/10.2/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update
+    - *test-install-readline-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.2
     # Verify initial state before upgrade
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - service mysql status
     # prepending with --defaults-file=/etc/mysql/debian.cnf is needed in upstream 5.5–10.3
-    - mysql --defaults-file=/etc/mysql/debian.cnf --skip-column-names -e "SELECT @@version, @@version_comment"
-    - echo 'SHOW DATABASES;' | mysql --defaults-file=/etc/mysql/debian.cnf
-    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM mysql.user; SHOW CREATE USER root@localhost"
-    - mysql --defaults-file=/etc/mysql/debian.cnf -e "SELECT * FROM mysql.plugin; SHOW PLUGINS"
+    - |
+      mysql --defaults-file=/etc/mysql/debian.cnf --skip-column-names -e "SELECT @@version, @@version_comment"
+      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SHOW DATABASES;"
+      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SELECT * FROM mysql.user; SHOW CREATE USER root@localhost;"
+      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SELECT * FROM mysql.plugin; SHOW PLUGINS;"
     - *test-install
     - service mysql status
-    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+    # Give the mariadb-upgrade plenty of time to complete, otherwise next commands
+    # fail on non-existing mariadb.sys user
+    - sleep 15
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -741,16 +744,16 @@ mysql.com-5.7 to mariadb-10.9 upgrade:
     - *test-prepare-container
     - |
       apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
-      apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 8C718D3B5072E1F5
-      echo 'deb https://repo.mysql.com/apt/debian/ buster mysql-5.7' > /etc/apt/sources.list.d/mysql.list
+      apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 467B942D3A79BD29
+      echo "deb https://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
       apt-get update
       apt-get install -y 'mysql*' 'libmysqlc*'
     - *test-verify-initial
     # Enable backports to make galera-4 available
-    - echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list.d/backports.list && apt-get update
+    - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
     - *test-install
     - service mysql status
-    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+    - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -773,16 +776,16 @@ percona-xtradb-5.7 to mariadb-10.9 upgrade (MDEV-22679):
     - |
       apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
       apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 9334A25F8507EFA5
-      echo 'deb https://repo.percona.com/apt/ buster main' > /etc/apt/sources.list.d/mysql.list
+      echo "deb https://repo.percona.com/apt/ buster main" > /etc/apt/sources.list.d/mysql.list
       apt-get update
       apt-get install -y percona-xtradb-cluster-full-57 percona-xtrabackup-24 percona-toolkit pmm2-client
     - service mysql status
     - *test-verify-initial
     # Enable backports to make galera-4 available
-    - echo 'deb http://deb.debian.org/debian buster-backports main' >> /etc/apt/sources.list.d/backports.list && apt-get update
+    - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
     - *test-install
     - service mysql status
-    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+    - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server
     - *test-verify-final
   variables:
     GIT_STRATEGY: none

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -23,10 +23,10 @@ version-substvar-for-external-package libmariadbd-dev -> libmariadbclient-dev
 # ColumnStore not used in Debian, safe to ignore. Reported upstream in https://jira.mariadb.org/browse/MDEV-24124
 source-is-missing storage/columnstore/columnstore/utils/jemalloc/libjemalloc.so.2
 # Must be fixed upstream
-source-is-missing storage/mroonga/vendor/groonga/examples/dictionary/html/js/jquery-ui-1.8.18.custom.js *
+source-is-missing storage/mroonga/vendor/groonga/examples/dictionary/html/js/jquery-ui-1.8.18.custom.js*
 # Intentional control relationships
-version-substvar-for-external-package Replaces (line 216) ${source:Version} libmariadbd-dev -> libmariadbclient-dev
-version-substvar-for-external-package Replaces (line 66) ${source:Version} libmariadb-dev -> libmysqlclient-dev
-version-substvar-for-external-package Replaces (line 66) ${source:Version} libmariadb-dev -> libmysqld-dev
+version-substvar-for-external-package Replaces * ${source:Version} libmariadbd-dev -> libmariadbclient-dev
+version-substvar-for-external-package Replaces * ${source:Version} libmariadb-dev -> libmysqlclient-dev
+version-substvar-for-external-package Replaces * ${source:Version} libmariadb-dev -> libmysqld-dev
 # We can't change build dependencies on a stable branch (10.5..10.8) so just override this
-missing-build-dependency-for-dh-addon systemd *
+missing-build-dependency-for-dh-addon systemd


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28076*

## Description
This is upstreaming PR #2039 to MariaDB 10.9

As MariaDB 10.5 has been removed from Debian Sid and MariaDB 10.6 has
entered it, the Salsa-CI testing needs to adapt.

To achieve this, essentially sync most the the salsa-ci.yml contents from
https://salsa.debian.org/mariadb-team/mariadb-server/-/tree/debian/latest

This includes removing Stretch builds, as Stretch does not support uring
nor pmem libraries, which MariaDB 10.6 depends on.

Also add a couple Lintian overrides to make Salsa-CI pass.

MERGERS: This commit is made on 10.6 branch and can be merged to
all later branches (10.7, 10.8, 10.9..) for now, but later somebody needs
to go in and update all the testing stages to do the upgrade testing
correctly for 10.6->10.7->10.8->10.9 etc.

## How can this PR be tested?
This is tested on Salsa-CI as:
https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/365718
It should be mostly green to get this merged

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
Sid is not tested anymore but it's not supported by Debian neither