### PR TITLE
aix mtr fixes MDEV-28250 + disable threadpool test

### DIFF
--- a/extra/innochecksum.cc
+++ b/extra/innochecksum.cc
@@ -1893,6 +1893,18 @@ unexpected_eof:
 			}
 
 			if (ferror(fil_in)) {
+#ifdef _AIX
+				/*
+				  AIX fseeko can go past eof without error.
+				  the error occurs on read, hence output the
+				  same error here as would show up on other
+				  platforms. This shows up in the mtr test
+				  innodb_zip.innochecksum_3-4k,crc32,innodb
+				*/
+				if (errno == EFBIG) {
+					goto unexpected_eof;
+				}
+#endif
 				fprintf(stderr, "Error reading " ULINTPF " bytes",
 					physical_page_size);
 				perror(" ");

--- a/mysql-test/main/thread_pool_info.test
+++ b/mysql-test/main/thread_pool_info.test
@@ -1,4 +1,5 @@
 source include/not_embedded.inc;
+source include/not_aix.inc;
 
 let $have_plugin = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_STATUS='ACTIVE' AND PLUGIN_NAME = 'THREAD_POOL_GROUPS'`;
 if(!$have_plugin)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28250

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Aix now that its enabled again, has a few mtr failures.

First AIX has no threadpool, so disable the test.

The second innochecksum has different behaviour in the OS fseeko function as described in the commit message.

## How can this PR be tested?

innodb_zip.innochecksum_3,4k,crc32,innodb covers the innochecksum test.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

AIX supported from 10.5
