### PR TITLE
change getopt_compare_strings function to make it compare strings cas…

### DIFF
--- a/mysys/my_getopt.c
+++ b/mysys/my_getopt.c
@@ -41,6 +41,7 @@ static void fini_one_value(const struct my_option *, void *, longlong);
 static int setval(const struct my_option *, void *, char *, my_bool);
 static char *check_struct_option(char *cur_arg, char *key_name);
 
+int tolower (int c){ return (c >= 'A' && c <= 'Z')?(c - 'A' + 'a'):c; }
 /*
   The following three variables belong to same group and the number and
   order of their arguments must correspond to each other.
@@ -952,7 +953,8 @@ my_bool getopt_compare_strings(register const char *s, register const char *t,
 
   for (;s != end ; s++, t++)
   {
-    if ((*s != '-' ? *s : '_') != (*t != '-' ? *t : '_'))
+    if ((*s != '-' ? tolower((unsigned char)*s) : '_') !=
+        (*t != '-' ? tolower((unsigned char)*t) : '_'))
       DBUG_RETURN(1);
   }
   DBUG_RETURN(0);


### PR DESCRIPTION
…e-insensitive

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MCOL-4730*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Change getopt_compare_strings function to make it compare strings case-insensitive.
## How can this PR be tested?
All existing tests should pass.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

