### PR TITLE
MDEV-27448: MTR returns success (zero) upon invalid option

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -5726,7 +5726,7 @@ sub usage ($) {
   {
     print STDERR "$message\n";
     print STDERR "For full list of options, use $0 --help\n";
-    exit;      
+    exit(1);
   }
 
   local $"= ','; # for @DEFAULT_SUITES below


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27448*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
This issue is caused by a function `usage()` in mariadb-test-run.pl.
When we try to run `perl ./mtr` with the wrong option (in the example, `perl ./mtr --ps--protocol`), a function `usage()` in mariadb-test-run.pl is called with the wrong option as its argument. In this case, because the function call `exit;` in a first if statement, we get exit status `0`. However, the expected status is `1`.

## How can this PR be tested?
Call these commands on a terminal
```bash
$ perl ./mtr --ps--protocol
$ echo $?
```
The expected output is as follows:
```bash
$ perl ./mtr --ps--protocol
Logging: ./mtr  --ps--protocol
VS config: 
Invalid option "--ps--protocol"
For full list of options, use ./mtr --help
$ echo $?
1
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*