### PR TITLE
MDEV-27981 Deprecate spider_internal_limit

### DIFF
--- a/storage/spider/mysql-test/spider/r/variable_deprecation.result
+++ b/storage/spider/mysql-test/spider/r/variable_deprecation.result
@@ -26,6 +26,8 @@ Warning	1287	The table parameter 'uhd' is deprecated and will be removed in a fu
 CREATE TABLE tbl_b (a INT) ENGINE=Spider COMMENT='use_handler "3"';
 Warnings:
 Warning	1287	The table parameter 'use_handler' is deprecated and will be removed in a future release
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
 # MDEV-28005 Deprecate Spider plugin variables regarding UDFs
 SET GLOBAL spider_udf_ds_bulk_insert_rows = 1;
 Warnings:
@@ -57,6 +59,21 @@ Warning	1287	'@@spider_udf_ct_bulk_insert_rows' is deprecated and will be remove
 SHOW VARIABLES LIKE "spider_udf_ct_bulk_insert_rows";
 Variable_name	Value
 spider_udf_ct_bulk_insert_rows	1
+# MDEV-27981 Deprecate spider_internal_limit 
+SET spider_internal_limit = 1;
+Warnings:
+Warning	1287	'@@spider_internal_limit' is deprecated and will be removed in a future release
+SHOW VARIABLES LIKE "spider_internal_limit";
+Variable_name	Value
+spider_internal_limit	9223372032559808513
+CREATE TABLE tbl_a (a INT) ENGINE=Spider COMMENT='ilm "1"';
+Warnings:
+Warning	1287	The table parameter 'ilm' is deprecated and will be removed in a future release
+CREATE TABLE tbl_b (a INT) ENGINE=Spider COMMENT='internal_limit "1"';
+Warnings:
+Warning	1287	The table parameter 'internal_limit' is deprecated and will be removed in a future release
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
 DROP DATABASE auto_test_local;
 for master_1
 for child2

--- a/storage/spider/mysql-test/spider/t/variable_deprecation.test
+++ b/storage/spider/mysql-test/spider/t/variable_deprecation.test
@@ -18,6 +18,9 @@ SHOW VARIABLES LIKE "spider_use_handler";
 eval CREATE TABLE tbl_a (a INT) $MASTER_1_ENGINE COMMENT='uhd "3"';
 eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='use_handler "3"';
 
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
+
 --echo # MDEV-28005 Deprecate Spider plugin variables regarding UDFs
 SET GLOBAL spider_udf_ds_bulk_insert_rows = 1;
 SHOW VARIABLES LIKE "spider_udf_ds_bulk_insert_rows";
@@ -33,6 +36,15 @@ SHOW VARIABLES LIKE "spider_udf_ct_bulk_insert_interval";
 
 SET GLOBAL spider_udf_ct_bulk_insert_rows = 1;
 SHOW VARIABLES LIKE "spider_udf_ct_bulk_insert_rows";
+
+--echo # MDEV-27981 Deprecate spider_internal_limit 
+SET spider_internal_limit = 1;
+SHOW VARIABLES LIKE "spider_internal_limit";
+eval CREATE TABLE tbl_a (a INT) $MASTER_1_ENGINE COMMENT='ilm "1"';
+eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='internal_limit "1"';
+
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
 
 DROP DATABASE auto_test_local;
 

--- a/storage/spider/spd_param.cc
+++ b/storage/spider/spd_param.cc
@@ -494,7 +494,7 @@ longlong spider_param_internal_offset(
  */
 static MYSQL_THDVAR_LONGLONG(
   internal_limit, /* name */
-  PLUGIN_VAR_RQCMDARG, /* opt */
+  PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_DEPRECATED, /* opt */
   "Internal limit", /* comment */
   NULL, /* check */
   spider_use_table_value_deprecated, /* update */

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -2375,6 +2375,7 @@ int spider_parse_connect_info(
 #endif
           SPIDER_PARAM_INT("isa", init_sql_alloc_size, 0);
           SPIDER_PARAM_INT_WITH_MAX("idl", internal_delayed, 0, 1);
+          SPIDER_PARAM_DEPRECATED_WARNING("ilm");
           SPIDER_PARAM_LONGLONG("ilm", internal_limit, 0);
           SPIDER_PARAM_LONGLONG("ios", internal_offset, 0);
           SPIDER_PARAM_INT_WITH_MAX("iom", internal_optimize, 0, 1);
@@ -2563,6 +2564,7 @@ int spider_parse_connect_info(
           error_num = connect_string_parse.print_param_error();
           goto error;
         case 14:
+          SPIDER_PARAM_DEPRECATED_WARNING("internal_limit");
           SPIDER_PARAM_LONGLONG("internal_limit", internal_limit, 0);
 #ifndef WITHOUT_SPIDER_BG_SEARCH
           SPIDER_PARAM_LONGLONG("bgs_first_read", bgs_first_read, 0);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27981*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
There is not much use of the variable ```spider_internal_limit```.

The variable ```spider_internal_limit``` and the corresponding table option are deprecated.


## How can this PR be tested?

Test case is included in the pull request.


<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*