### PR TITLE
mtr: extend gdb backtace to -frame-arguments all full

### DIFF
--- a/mysql-test/lib/My/CoreDump.pm
+++ b/mysql-test/lib/My/CoreDump.pm
@@ -78,7 +78,10 @@ sub _gdb {
   my ($tmp, $tmp_name) = tempfile();
   print $tmp
     "bt\n",
-    "thread apply all bt\n",
+    "set print sevenbit on\n",
+    "set print static-members off\n",
+    "set print frame-arguments all\n",
+    "thread apply all bt full\n",
     "quit\n";
   close $tmp or die "Error closing $tmp_name: $!";
 


### PR DESCRIPTION
GDB has supported -frame-arguments and full for a while.

Let's make our bb logs give a little bit more detail on those
hard to reproduce bugs.

Tested with:
```
$ while [ 1 ]; do sleep 2; killall -SEGV mysqld ; done
```
and
```
 mysql-test/mtr innodb_fts.innodb_fts_stopword_charset
...
Thread 27 (Thread 0x7f4d0a8a9640 (LWP 332030)):
#0  0x00007f4d1010823b in fsync () from /lib64/libc.so.6
No symbol table info available.
#1  0x000000000092eb4f in os_file_fsync_posix (file=72) at /home/dan/repos/mariadb-server-10.2/storage/innobase/os/os0file.cc:2526
        ret = <optimized out>
        failures = 0
#2  os_file_flush_func (file=file@entry=72) at /home/dan/repos/mariadb-server-10.2/storage/innobase/os/os0file.cc:2619
        ret = <optimized out>
#3  0x0000000000a6825f in pfs_os_file_flush_func (file={m_file = 72, m_psi = 0x7f4d0eeca980}, src_line=3753, src_file=<optimized out>) at /home/dan/repos/mariadb-server-10.2/storage/innobase/include/os0file.inl:496
        state = {m_flags = 7, m_operation = PSI_FILE_SYNC, m_file = 0x7f4d0eeca980, m_name = 0x0, m_class = 0x28a9900, m_thread = 0x7f4d10242700, m_number_of_bytes = 139968866047176, m_timer_start = 47553245109992, m_timer = 0xbcfdd0 <my_timer_cycles>, m_wait = 0x7f4d10242838}
        locker = 0x7f4d0a8a5480
        result = <optimized out>
#4  fil_ibd_create (space_id=<optimized out>, name=0x7f4cb80700e0 "test/FTS_", '0' <repeats 14 times>, "2d_", '0' <repeats 14 times>, "33_INDEX_2", path=<optimized out>, path@entry=0x7f4cb8030dd0 "./test/FTS_", '0' <repeats 14 times>, "2d_", '0' <repeats 14 times>, "33_INDEX_2.ibd", flags=<optimized out>, flags@entry=33, size=size@entry=4, mode=FIL_ENCRYPTION_DEFAULT, key_id=1) at /home/dan/repos/mariadb-server-10.2/storage/innobase/fil/fil0fil.cc:3753
        request = {m_bpage = 0x0, m_fil_node = 0x0, m_type = 2}
        crypt_data = <optimized out>
```