### PR TITLE
MDEV-28297 Deprecate spider_internal_offset

### DIFF
--- a/storage/spider/mysql-test/spider/r/variable_deprecation.result
+++ b/storage/spider/mysql-test/spider/r/variable_deprecation.result
@@ -28,6 +28,21 @@ Warnings:
 Warning	1287	The table parameter 'use_handler' is deprecated and will be removed in a future release
 DROP TABLE tbl_a;
 DROP TABLE tbl_b;
+# MDEV-28297 Deprecate spider_internal_offset
+SET spider_internal_offset = 1;
+Warnings:
+Warning	1287	'@@spider_internal_offset' is deprecated and will be removed in a future release
+SHOW VARIABLES LIKE "spider_internal_offset";
+Variable_name	Value
+spider_internal_offset	1
+CREATE TABLE tbl_a (a INT) ENGINE=Spider COMMENT='ios "1"';
+Warnings:
+Warning	1287	The table parameter 'ios' is deprecated and will be removed in a future release
+CREATE TABLE tbl_b (a INT) ENGINE=Spider COMMENT='internal_offset "1"';
+Warnings:
+Warning	1287	The table parameter 'internal_offset' is deprecated and will be removed in a future release
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
 # MDEV-28005 Deprecate Spider plugin variables regarding UDFs
 SET GLOBAL spider_udf_ds_bulk_insert_rows = 1;
 Warnings:

--- a/storage/spider/mysql-test/spider/t/variable_deprecation.test
+++ b/storage/spider/mysql-test/spider/t/variable_deprecation.test
@@ -17,7 +17,15 @@ SET spider_use_handler = 3;
 SHOW VARIABLES LIKE "spider_use_handler";
 eval CREATE TABLE tbl_a (a INT) $MASTER_1_ENGINE COMMENT='uhd "3"';
 eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='use_handler "3"';
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
 
+--echo # MDEV-28297 Deprecate spider_internal_offset
+SET spider_internal_offset = 1;
+SHOW VARIABLES LIKE "spider_internal_offset";
+
+eval CREATE TABLE tbl_a (a INT) $MASTER_1_ENGINE COMMENT='ios "1"';
+eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='internal_offset "1"';
 DROP TABLE tbl_a;
 DROP TABLE tbl_b;
 

--- a/storage/spider/spd_param.cc
+++ b/storage/spider/spd_param.cc
@@ -469,7 +469,7 @@ uint spider_param_xa_register_mode(
  */
 static MYSQL_THDVAR_LONGLONG(
   internal_offset, /* name */
-  PLUGIN_VAR_RQCMDARG, /* opt */
+  PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_DEPRECATED, /* opt */
   "Internal offset", /* comment */
   NULL, /* check */
   spider_use_table_value_deprecated, /* update */

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -2380,6 +2380,7 @@ int spider_parse_connect_info(
           SPIDER_PARAM_INT_WITH_MAX("idl", internal_delayed, 0, 1);
           SPIDER_PARAM_DEPRECATED_WARNING("ilm");
           SPIDER_PARAM_LONGLONG("ilm", internal_limit, 0);
+          SPIDER_PARAM_DEPRECATED_WARNING("ios");
           SPIDER_PARAM_LONGLONG("ios", internal_offset, 0);
           SPIDER_PARAM_INT_WITH_MAX("iom", internal_optimize, 0, 1);
           SPIDER_PARAM_INT_WITH_MAX("iol", internal_optimize_local, 0, 1);
@@ -2590,6 +2591,7 @@ int spider_parse_connect_info(
           error_num = connect_string_parse.print_param_error();
           goto error;
         case 15:
+          SPIDER_PARAM_DEPRECATED_WARNING("internal_offset");
           SPIDER_PARAM_LONGLONG("internal_offset", internal_offset, 0);
           SPIDER_PARAM_INT_WITH_MAX("reset_sql_alloc", reset_sql_alloc, 0, 1);
           SPIDER_PARAM_INT_WITH_MAX("semi_table_lock", semi_table_lock, 0, 1);


### PR DESCRIPTION
Deprecate the server variable spider_internal_offset and the corresponding
table parameters "ios" and "internal_offset".

We believe this variable is not much use to users, therefore decided to
deprecate it.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28297

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Deprecate the server variable spider_internal_offset and the corresponding
table parameters "ios" and "internal_offset".

## How can this PR be tested?
All existing tests should pass.
Test cases are added in `spider.variable_deprecation`

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
It just deprecates the variable, therefore backward compatibility is kept. We may delete the variable in a future release.
