### PR TITLE
MDEV-28227 Error message Chinese translation

### DIFF
--- a/mysql-test/suite/gcol/r/innodb_virtual_fk.result
+++ b/mysql-test/suite/gcol/r/innodb_virtual_fk.result
@@ -705,7 +705,7 @@ ALTER TABLE t1 ADD CONSTRAINT fk FOREIGN KEY (v4) REFERENCES nosuch(col);
 ERROR HY000: Can't create table `test`.`t1` (errno: 150 "Foreign key constraint is incorrectly formed")
 SET foreign_key_checks=0;
 ALTER TABLE t1 ADD CONSTRAINT fk FOREIGN KEY (v4) REFERENCES nosuch(col);
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk' in the foreign table 't1'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk' in the foreign table 't1'
 ALTER TABLE t1 ADD INDEX(v4);
 ALTER TABLE t1 ADD CONSTRAINT fk FOREIGN KEY (v4) REFERENCES nosuch(col);
 SET foreign_key_checks=1;

--- a/mysql-test/suite/innodb/r/innodb-index-online-fk.result
+++ b/mysql-test/suite/innodb/r/innodb-index-online-fk.result
@@ -36,13 +36,13 @@ SET foreign_key_checks = 0;
 ALTER TABLE child ADD CONSTRAINT fk_20 FOREIGN KEY (a1, a2)
 REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
 ALGORITHM = INPLACE;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_20' in the referenced table 'parent'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_20' in the referenced table 'parent'
 SHOW WARNINGS;
 Level	Code	Message
-Error	1822	Failed to add the foreign key constaint. Missing index for constraint 'fk_20' in the referenced table 'parent'
+Error	1822	Failed to add the foreign key constraint. Missing index for constraint 'fk_20' in the referenced table 'parent'
 SHOW ERRORS;
 Level	Code	Message
-Error	1822	Failed to add the foreign key constaint. Missing index for constraint 'fk_20' in the referenced table 'parent'
+Error	1822	Failed to add the foreign key constraint. Missing index for constraint 'fk_20' in the referenced table 'parent'
 CREATE INDEX idx1 on parent(a, b);
 ALTER TABLE child ADD CONSTRAINT fk_10 FOREIGN KEY (a1, a2)
 REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -143,11 +143,11 @@ SET DEBUG_DBUG = '+d,innodb_test_no_foreign_idx';
 ALTER TABLE `#child` ADD CONSTRAINT fk_40 FOREIGN KEY (a1, a2)
 REFERENCES `#parent`(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
 ALGORITHM = INPLACE;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_40' in the foreign table '#child'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_40' in the foreign table '#child'
 SET DEBUG_DBUG = @saved_debug_dbug;
 SHOW ERRORS;
 Level	Code	Message
-Error	1821	Failed to add the foreign key constaint. Missing index for constraint 'fk_40' in the foreign table '#child'
+Error	1821	Failed to add the foreign key constraint. Missing index for constraint 'fk_40' in the foreign table '#child'
 SELECT * FROM information_schema.INNODB_SYS_FOREIGN;
 ID	FOR_NAME	REF_NAME	N_COLS	TYPE
 test/fk_1	test/child	test/parent	1	6
@@ -170,11 +170,11 @@ SET DEBUG_DBUG = '+d,innodb_test_no_reference_idx';
 ALTER TABLE child ADD CONSTRAINT fk_42 FOREIGN KEY (a1, a2)
 REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
 ALGORITHM = INPLACE;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_42' in the referenced table 'parent'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_42' in the referenced table 'parent'
 SET DEBUG_DBUG = @saved_debug_dbug;
 SHOW ERRORS;
 Level	Code	Message
-Error	1822	Failed to add the foreign key constaint. Missing index for constraint 'fk_42' in the referenced table 'parent'
+Error	1822	Failed to add the foreign key constraint. Missing index for constraint 'fk_42' in the referenced table 'parent'
 SET DEBUG_DBUG = '+d,innodb_test_wrong_fk_option';
 ALTER TABLE child ADD CONSTRAINT fk_42 FOREIGN KEY (a1, a2)
 REFERENCES parent(a, b) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -480,7 +480,7 @@ ADD CONSTRAINT fk_new_1 FOREIGN KEY (a1_new) REFERENCES parent(b),
 ADD CONSTRAINT fk_new_2 FOREIGN KEY (a2_new) REFERENCES parent(a),
 ADD CONSTRAINT fk_new_3 FOREIGN KEY (a3) REFERENCES parent(c),
 ALGORITHM = INPLACE;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_new_3' in the referenced table 'parent'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_new_3' in the referenced table 'parent'
 SHOW CREATE TABLE child;
 Table	Create Table
 child	CREATE TABLE `child` (
@@ -542,7 +542,7 @@ ADD CONSTRAINT fk_new_1 FOREIGN KEY (a1) REFERENCES parent(b),
 ADD CONSTRAINT fk_new_2 FOREIGN KEY (a2) REFERENCES parent(a),
 ADD CONSTRAINT fk_new_3 FOREIGN KEY (a3) REFERENCES parent(c),
 ALGORITHM = INPLACE;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_new_3' in the referenced table 'parent'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_new_3' in the referenced table 'parent'
 SHOW CREATE TABLE child;
 Table	Create Table
 child	CREATE TABLE `child` (

--- a/mysql-test/suite/innodb/r/innodb-index.result
+++ b/mysql-test/suite/innodb/r/innodb-index.result
@@ -958,13 +958,13 @@ FOREIGN KEY (c3,c2) REFERENCES t1(c1,c1), ALGORITHM=COPY;
 ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c1);
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2), ALGORITHM=COPY;
 ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2);
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c2,c1), ALGORITHM=INPLACE;
 ERROR HY000: Failed to add the foreign key constraint on table 't2'. Incorrect options in FOREIGN KEY constraint 'test/fk_t2_ca'
@@ -979,7 +979,7 @@ FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2), ALGORITHM=COPY;
 ERROR HY000: Can't create table `test`.`t2` (errno: 150 "Foreign key constraint is incorrectly formed")
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c1,c2);
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'fk_t2_ca' in the referenced table 't1'
 ALTER TABLE t2 ADD CONSTRAINT fk_t2_ca
 FOREIGN KEY (c3,c2) REFERENCES t1(c2,c1);
 affected rows: 0

--- a/mysql-test/suite/innodb/r/stored_fk.result
+++ b/mysql-test/suite/innodb/r/stored_fk.result
@@ -49,7 +49,7 @@ CREATE TABLE s (a INT, b INT GENERATED ALWAYS AS (0) STORED,  c INT,
 d INT GENERATED ALWAYS AS (0) VIRTUAL, e INT) ENGINE=innodb;
 CREATE TABLE t (a INT) ENGINE=innodb;
 ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (e) REFERENCES t(a) ON UPDATE SET null;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'c' in the referenced table 't'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'c' in the referenced table 't'
 ALTER  TABLE t ADD PRIMARY KEY(a);
 ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (e) REFERENCES t(a) ON UPDATE SET null;
 DROP TABLE s,t;
@@ -57,7 +57,7 @@ CREATE TABLE s (a INT GENERATED ALWAYS AS (0) VIRTUAL,
 b INT GENERATED ALWAYS AS (0) STORED,  c INT) ENGINE=innodb;
 CREATE TABLE t (a INT) ENGINE=innodb;
 ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (c) REFERENCES t(a) ON UPDATE SET null;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'c' in the referenced table 't'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'c' in the referenced table 't'
 ALTER  TABLE t ADD PRIMARY KEY(a);
 ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (c) REFERENCES t(a) ON UPDATE SET null;
 DROP TABLE s,t;
@@ -68,7 +68,7 @@ DROP TABLE s,t;
 CREATE TABLE s (a INT, b INT) ENGINE=innodb;
 CREATE TABLE t (a INT) ENGINE=innodb;
 ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (a) REFERENCES t(a) ON UPDATE SET null;
-ERROR HY000: Failed to add the foreign key constaint. Missing index for constraint 'c' in the referenced table 't'
+ERROR HY000: Failed to add the foreign key constraint. Missing index for constraint 'c' in the referenced table 't'
 ALTER  TABLE t ADD PRIMARY KEY(a);
 ALTER TABLE s ADD CONSTRAINT c FOREIGN KEY (a) REFERENCES t(a) ON UPDATE SET null;
 DROP TABLE s,t;

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -1,4 +1,4 @@
-languages czech=cze latin2, danish=dan latin1, dutch=nla latin1, english=eng latin1, estonian=est latin7, french=fre latin1, german=ger latin1, greek=greek greek, hungarian=hun latin2, italian=ita latin1, japanese=jpn ujis, korean=kor euckr, norwegian-ny=norwegian-ny latin1, norwegian=nor latin1, polish=pol latin2, portuguese=por latin1, romanian=rum latin2, russian=rus koi8r, serbian=serbian cp1250, slovak=slo latin2, spanish=spa latin1, swedish=swe latin1, ukrainian=ukr koi8u, bulgarian=bgn cp1251, hindi=hindi utf8;
+languages chinese=chi gbk, czech=cze latin2, danish=dan latin1, dutch=nla latin1, english=eng latin1, estonian=est latin7, french=fre latin1, german=ger latin1, greek=greek greek, hungarian=hun latin2, italian=ita latin1, japanese=jpn ujis, korean=kor euckr, norwegian-ny=norwegian-ny latin1, norwegian=nor latin1, polish=pol latin2, portuguese=por latin1, romanian=rum latin2, russian=rus koi8r, serbian=serbian cp1250, slovak=slo latin2, spanish=spa latin1, swedish=swe latin1, ukrainian=ukr koi8u, bulgarian=bgn cp1251, hindi=hindi utf8;
 
 default-language eng
 
@@ -9,9 +9,9 @@ ER_HASHCHK
 ER_NISAMCHK  
         eng "isamchk"
 ER_NO  
+        chi "不"
         cze "NE"
         dan "NEJ"
-        nla "NEE"
         eng "NO"
         est "EI"
         fre "NON"
@@ -20,6 +20,7 @@ ER_NO
         hindi "नहीं"
         hun "NEM"
         kor "아니오"
+        nla "NEE"
         nor "NEI"
         norwegian-ny "NEI"
         pol "NIE"
@@ -30,9 +31,9 @@ ER_NO
         slo "NIE"
         ukr "НІ"
 ER_YES  
+        chi "是的"
         cze "ANO"
         dan "JA"
-        nla "JA"
         eng "YES"
         est "JAH"
         fre "OUI"
@@ -42,6 +43,7 @@ ER_YES
         hun "IGEN"
         ita "SI"
         kor "예"
+        nla "JA"
         nor "JA"
         norwegian-ny "JA"
         pol "TAK"
@@ -53,9 +55,9 @@ ER_YES
         spa "SI"
         ukr "ТАК"
 ER_CANT_CREATE_FILE  
+        chi "无法创建文件'%-.200s'（错误号码：%M）"
         cze "Nemohu vytvořit soubor '%-.200s' (chybový kód: %M)"
         dan "Kan ikke oprette filen '%-.200s' (Fejlkode: %M)"
-        nla "Kan file '%-.200s' niet aanmaken (Errcode: %M)"
         eng "Can't create file '%-.200s' (errno: %M)"
         est "Ei suuda luua faili '%-.200s' (veakood: %M)"
         fre "Ne peut créer le fichier '%-.200s' (Errcode: %M)"
@@ -66,6 +68,7 @@ ER_CANT_CREATE_FILE
         ita "Impossibile creare il file '%-.200s' (errno: %M)"
         jpn "ファイル '%-.200s' を作成できません。(エラー番号: %M)"
         kor "화일 '%-.200s'를 만들지 못했습니다. (에러번호: %M)"
+        nla "Kan file '%-.200s' niet aanmaken (Errcode: %M)"
         nor "Kan ikke opprette fila '%-.200s' (Feilkode: %M)"
         norwegian-ny "Kan ikkje opprette fila '%-.200s' (Feilkode: %M)"
         pol "Nie można stworzyć pliku '%-.200s' (Kod błędu: %M)"
@@ -78,11 +81,10 @@ ER_CANT_CREATE_FILE
         swe "Kan inte skapa filen '%-.200s' (Felkod: %M)"
         ukr "Не можу створити файл '%-.200s' (помилка: %M)"
 ER_CANT_CREATE_TABLE  
+        chi "无法创建表%`s.%`s（错误号码：%M）"
         cze "Nemohu vytvořit tabulku %`s.%`s (chybový kód: %M)"
         dan "Kan ikke oprette tabellen %`s.%`s (Fejlkode: %M)"
-        nla "Kan tabel %`s.%`s niet aanmaken (Errcode: %M)"
         eng "Can't create table %`s.%`s (errno: %M)"
-        jps "%`s.%`s テーブルが作れません.(errno: %M)",
         est "Ei suuda luua tabelit %`s.%`s (veakood: %M)"
         fre "Ne peut créer la table %`s.%`s (Errcode: %M)"
         ger "Kann Tabelle %`s.%`s nicht erzeugen (Fehler: %M)"
@@ -92,6 +94,7 @@ ER_CANT_CREATE_TABLE
         ita "Impossibile creare la tabella %`s.%`s (errno: %M)"
         jpn "%`s.%`s テーブルが作れません.(errno: %M)"
         kor "테이블 %`s.%`s를 만들지 못했습니다. (에러번호: %M)"
+        nla "Kan tabel %`s.%`s niet aanmaken (Errcode: %M)"
         nor "Kan ikke opprette tabellen %`s.%`s (Feilkode: %M)"
         norwegian-ny "Kan ikkje opprette tabellen %`s.%`s (Feilkode: %M)"
         pol "Nie można stworzyć tabeli %`s.%`s (Kod błędu: %M)"
@@ -104,9 +107,9 @@ ER_CANT_CREATE_TABLE
         swe "Kan inte skapa tabellen %`s.%`s (Felkod: %M)"
         ukr "Не можу створити таблицю %`s.%`s (помилка: %M)"
 ER_CANT_CREATE_DB  
+        chi "无法创建数据库'%-.192s'（错误号码：%M）"
         cze "Nemohu vytvořit databázi '%-.192s' (chybový kód: %M)"
         dan "Kan ikke oprette databasen '%-.192s' (Fejlkode: %M)"
-        nla "Kan database '%-.192s' niet aanmaken (Errcode: %M)"
         eng "Can't create database '%-.192s' (errno: %M)"
         est "Ei suuda luua andmebaasi '%-.192s' (veakood: %M)"
         fre "Ne peut créer la base '%-.192s' (Erreur %M)"
@@ -117,6 +120,7 @@ ER_CANT_CREATE_DB
         ita "Impossibile creare il database '%-.192s' (errno: %M)"
         jpn "データベース '%-.192s' を作成できません。(エラー番号: %M)"
         kor "데이타베이스 '%-.192s'를 만들지 못했습니다.. (에러번호: %M)"
+        nla "Kan database '%-.192s' niet aanmaken (Errcode: %M)"
         nor "Kan ikke opprette databasen '%-.192s' (Feilkode: %M)"
         norwegian-ny "Kan ikkje opprette databasen '%-.192s' (Feilkode: %M)"
         pol "Nie można stworzyć bazy danych '%-.192s' (Kod błędu: %M)"
@@ -129,9 +133,9 @@ ER_CANT_CREATE_DB
         swe "Kan inte skapa databasen '%-.192s' (Felkod: %M)"
         ukr "Не можу створити базу данних '%-.192s' (помилка: %M)"
 ER_DB_CREATE_EXISTS  
+        chi "无法创建数据库'%-.192s';已经存在"
         cze "Nemohu vytvořit databázi '%-.192s'; databáze již existuje"
         dan "Kan ikke oprette databasen '%-.192s'; databasen eksisterer"
-        nla "Kan database '%-.192s' niet aanmaken; database bestaat reeds"
         eng "Can't create database '%-.192s'; database exists"
         est "Ei suuda luua andmebaasi '%-.192s': andmebaas juba eksisteerib"
         fre "Ne peut créer la base '%-.192s'; elle existe déjà"
@@ -142,6 +146,7 @@ ER_DB_CREATE_EXISTS
         ita "Impossibile creare il database '%-.192s'; il database esiste"
         jpn "データベース '%-.192s' を作成できません。データベースはすでに存在します。"
         kor "데이타베이스 '%-.192s'를 만들지 못했습니다.. 데이타베이스가 존재함"
+        nla "Kan database '%-.192s' niet aanmaken; database bestaat reeds"
         nor "Kan ikke opprette databasen '%-.192s'; databasen eksisterer"
         norwegian-ny "Kan ikkje opprette databasen '%-.192s'; databasen eksisterer"
         pol "Nie można stworzyć bazy danych '%-.192s'; baza danych już istnieje"
@@ -154,9 +159,9 @@ ER_DB_CREATE_EXISTS
         swe "Databasen '%-.192s' existerar redan"
         ukr "Не можу створити базу данних '%-.192s'. База данних існує"
 ER_DB_DROP_EXISTS  
+        chi "无法删除数据库'%-.192s';数据库不存在"
         cze "Nemohu zrušit databázi '%-.192s', databáze neexistuje"
         dan "Kan ikke slette (droppe) '%-.192s'; databasen eksisterer ikke"
-        nla "Kan database '%-.192s' niet verwijderen; database bestaat niet"
         eng "Can't drop database '%-.192s'; database doesn't exist"
         est "Ei suuda kustutada andmebaasi '%-.192s': andmebaasi ei eksisteeri"
         fre "Ne peut effacer la base '%-.192s'; elle n'existe pas"
@@ -167,6 +172,7 @@ ER_DB_DROP_EXISTS
         ita "Impossibile cancellare '%-.192s'; il database non esiste"
         jpn "データベース '%-.192s' を削除できません。データベースは存在しません。"
         kor "데이타베이스 '%-.192s'를 제거하지 못했습니다. 데이타베이스가 존재하지 않음 "
+        nla "Kan database '%-.192s' niet verwijderen; database bestaat niet"
         nor "Kan ikke fjerne (drop) '%-.192s'; databasen eksisterer ikke"
         norwegian-ny "Kan ikkje fjerne (drop) '%-.192s'; databasen eksisterer ikkje"
         pol "Nie można usun?ć bazy danych '%-.192s'; baza danych nie istnieje"
@@ -179,9 +185,9 @@ ER_DB_DROP_EXISTS
         swe "Kan inte radera databasen '%-.192s'; databasen finns inte"
         ukr "Не можу видалити базу данних '%-.192s'. База данних не існує"
 ER_DB_DROP_DELETE  
+        chi "删除数据库错误（无法删除'%-.192s'，错误号码：%M）"
         cze "Chyba při rušení databáze (nemohu vymazat '%-.192s', chyba %M)"
         dan "Fejl ved sletning (drop) af databasen (kan ikke slette '%-.192s', Fejlkode %M)"
-        nla "Fout bij verwijderen database (kan '%-.192s' niet verwijderen, Errcode: %M)"
         eng "Error dropping database (can't delete '%-.192s', errno: %M)"
         est "Viga andmebaasi kustutamisel (ei suuda kustutada faili '%-.192s', veakood: %M)"
         fre "Ne peut effacer la base '%-.192s' (erreur %M)"
@@ -192,6 +198,7 @@ ER_DB_DROP_DELETE
         ita "Errore durante la cancellazione del database (impossibile cancellare '%-.192s', errno: %M)"
         jpn "データベース削除エラー ('%-.192s' を削除できません。エラー番号: %M)"
         kor "데이타베이스 제거 에러('%-.192s'를 삭제할 수 없습니다, 에러번호: %M)"
+        nla "Fout bij verwijderen database (kan '%-.192s' niet verwijderen, Errcode: %M)"
         nor "Feil ved fjerning (drop) av databasen (kan ikke slette '%-.192s', feil %M)"
         norwegian-ny "Feil ved fjerning (drop) av databasen (kan ikkje slette '%-.192s', feil %M)"
         pol "Bł?d podczas usuwania bazy danych (nie można usun?ć '%-.192s', bł?d %M)"
@@ -204,9 +211,9 @@ ER_DB_DROP_DELETE
         swe "Fel vid radering av databasen (Kan inte radera '%-.192s'. Felkod: %M)"
         ukr "Не можу видалити базу данних (Не можу видалити '%-.192s', помилка: %M)"
 ER_DB_DROP_RMDIR  
+        chi "删除数据库错误（无法rmdir '%-.192s'，错误号码：%M）"
         cze "Chyba při rušení databáze (nemohu vymazat adresář '%-.192s', chyba %M)"
         dan "Fejl ved sletting af database (kan ikke slette folderen '%-.192s', Fejlkode %M)"
-        nla "Fout bij verwijderen database (kan rmdir '%-.192s' niet uitvoeren, Errcode: %M)"
         eng "Error dropping database (can't rmdir '%-.192s', errno: %M)"
         est "Viga andmebaasi kustutamisel (ei suuda kustutada kataloogi '%-.192s', veakood: %M)"
         fre "Erreur en effaçant la base (rmdir '%-.192s', erreur %M)"
@@ -215,8 +222,9 @@ ER_DB_DROP_RMDIR
         hindi "डेटाबेस ड्रॉप में त्रुटि हुई ('%-.192s' rmdir नहीं कर सकते, errno: %M)"
         hun "Adatbazis megszuntetesi hiba ('%-.192s' nem szuntetheto meg, hibakod: %M)"
         ita "Errore durante la cancellazione del database (impossibile rmdir '%-.192s', errno: %M)"
-       jpn "データベース削除エラー (ディレクトリ '%-.192s' を削除できません。エラー番号: %M)"
+        jpn "データベース削除エラー (ディレクトリ '%-.192s' を削除できません。エラー番号: %M)"
         kor "데이타베이스 제거 에러(rmdir '%-.192s'를 할 수 없습니다, 에러번호: %M)"
+        nla "Fout bij verwijderen database (kan rmdir '%-.192s' niet uitvoeren, Errcode: %M)"
         nor "Feil ved sletting av database (kan ikke slette katalogen '%-.192s', feil %M)"
         norwegian-ny "Feil ved sletting av database (kan ikkje slette katalogen '%-.192s', feil %M)"
         pol "Bł?d podczas usuwania bazy danych (nie można wykonać rmdir '%-.192s', bł?d %M)"
@@ -229,9 +237,9 @@ ER_DB_DROP_RMDIR
         swe "Fel vid radering av databasen (Kan inte radera biblioteket '%-.192s'. Felkod: %M)"
         ukr "Не можу видалити базу данних (Не можу видалити теку '%-.192s', помилка: %M)"
 ER_CANT_DELETE_FILE  
+        chi "删除'%-.192s'出错（错误号码：%M）"
         cze "Chyba při výmazu '%-.192s' (chybový kód: %M)"
         dan "Fejl ved sletning af '%-.192s' (Fejlkode: %M)"
-        nla "Fout bij het verwijderen van '%-.192s' (Errcode: %M)"
         eng "Error on delete of '%-.192s' (errno: %M)"
         est "Viga '%-.192s' kustutamisel (veakood: %M)"
         fre "Erreur en effaçant '%-.192s' (Errcode: %M)"
@@ -240,8 +248,9 @@ ER_CANT_DELETE_FILE
         hindi "'%-.192s' के हटाने पर त्रुटि हुई (errno: %M)"
         hun "Torlesi hiba: '%-.192s' (hibakod: %M)"
         ita "Errore durante la cancellazione di '%-.192s' (errno: %M)"
-	jpn "ファイル '%-.192s' の削除エラー (エラー番号: %M)"
+        jpn "ファイル '%-.192s' の削除エラー (エラー番号: %M)"
         kor "'%-.192s' 삭제 중 에러 (에러번호: %M)"
+        nla "Fout bij het verwijderen van '%-.192s' (Errcode: %M)"
         nor "Feil ved sletting av '%-.192s' (Feilkode: %M)"
         norwegian-ny "Feil ved sletting av '%-.192s' (Feilkode: %M)"
         pol "Bł?d podczas usuwania '%-.192s' (Kod błędu: %M)"
@@ -254,9 +263,9 @@ ER_CANT_DELETE_FILE
         swe "Kan inte radera filen '%-.192s' (Felkod: %M)"
         ukr "Не можу видалити '%-.192s' (помилка: %M)"
 ER_CANT_FIND_SYSTEM_REC  
+        chi "无法在系统表中读取记录"
         cze "Nemohu číst záznam v systémové tabulce"
         dan "Kan ikke læse posten i systemfolderen"
-        nla "Kan record niet lezen in de systeem tabel"
         eng "Can't read record in system table"
         est "Ei suuda lugeda kirjet süsteemsest tabelist"
         fre "Ne peut lire un enregistrement de la table 'system'"
@@ -267,6 +276,7 @@ ER_CANT_FIND_SYSTEM_REC
         ita "Impossibile leggere il record dalla tabella di sistema"
         jpn "システム表のレコードを読み込めません。"
         kor "system 테이블에서 레코드를 읽을 수 없습니다."
+        nla "Kan record niet lezen in de systeem tabel"
         nor "Kan ikke lese posten i systemkatalogen"
         norwegian-ny "Kan ikkje lese posten i systemkatalogen"
         pol "Nie można odczytać rekordu z tabeli systemowej"
@@ -279,9 +289,9 @@ ER_CANT_FIND_SYSTEM_REC
         swe "Hittar inte posten i systemregistret"
         ukr "Не можу зчитати запис з системної таблиці"
 ER_CANT_GET_STAT  
+        chi "无法获得'%-.200s'的状态（错误号码：%M）"
         cze "Nemohu získat stav '%-.200s' (chybový kód: %M)"
         dan "Kan ikke læse status af '%-.200s' (Fejlkode: %M)"
-        nla "Kan de status niet krijgen van '%-.200s' (Errcode: %M)"
         eng "Can't get status of '%-.200s' (errno: %M)"
         est "Ei suuda lugeda '%-.200s' olekut (veakood: %M)"
         fre "Ne peut obtenir le status de '%-.200s' (Errcode: %M)"
@@ -292,6 +302,7 @@ ER_CANT_GET_STAT
         ita "Impossibile leggere lo stato di '%-.200s' (errno: %M)"
         jpn "'%-.200s' の状態を取得できません。(エラー番号: %M)"
         kor "'%-.200s'의 상태를 얻지 못했습니다. (에러번호: %M)"
+        nla "Kan de status niet krijgen van '%-.200s' (Errcode: %M)"
         nor "Kan ikke lese statusen til '%-.200s' (Feilkode: %M)"
         norwegian-ny "Kan ikkje lese statusen til '%-.200s' (Feilkode: %M)"
         pol "Nie można otrzymać statusu '%-.200s' (Kod błędu: %M)"
@@ -304,9 +315,9 @@ ER_CANT_GET_STAT
         swe "Kan inte läsa filinformationen (stat) från '%-.200s' (Felkod: %M)"
         ukr "Не можу отримати статус '%-.200s' (помилка: %M)"
 ER_CANT_GET_WD  
+        chi "无法获取工作目录（错误号码：%M）"
         cze "Chyba při zjišťování pracovní adresář (chybový kód: %M)"
         dan "Kan ikke læse aktive folder (Fejlkode: %M)"
-        nla "Kan de werkdirectory niet krijgen (Errcode: %M)"
         eng "Can't get working directory (errno: %M)"
         est "Ei suuda identifitseerida jooksvat kataloogi (veakood: %M)"
         fre "Ne peut obtenir le répertoire de travail (Errcode: %M)"
@@ -317,6 +328,7 @@ ER_CANT_GET_WD
         ita "Impossibile leggere la directory di lavoro (errno: %M)"
         jpn "作業ディレクトリを取得できません。(エラー番号: %M)"
         kor "수행 디렉토리를 찾지 못했습니다. (에러번호: %M)"
+        nla "Kan de werkdirectory niet krijgen (Errcode: %M)"
         nor "Kan ikke lese aktiv katalog(Feilkode: %M)"
         norwegian-ny "Kan ikkje lese aktiv katalog(Feilkode: %M)"
         pol "Nie można rozpoznać aktualnego katalogu (Kod błędu: %M)"
@@ -329,9 +341,9 @@ ER_CANT_GET_WD
         swe "Kan inte inte läsa aktivt bibliotek. (Felkod: %M)"
         ukr "Не можу визначити робочу теку (помилка: %M)"
 ER_CANT_LOCK  
+        chi "无法锁定文件（错误号码：%M）"
         cze "Nemohu uzamknout soubor (chybový kód: %M)"
         dan "Kan ikke låse fil (Fejlkode: %M)"
-        nla "Kan de file niet blokeren (Errcode: %M)"
         eng "Can't lock file (errno: %M)"
         est "Ei suuda lukustada faili (veakood: %M)"
         fre "Ne peut verrouiller le fichier (Errcode: %M)"
@@ -342,6 +354,7 @@ ER_CANT_LOCK
         ita "Impossibile il locking il file (errno: %M)"
         jpn "ファイルをロックできません。(エラー番号: %M)"
         kor "화일을 잠그지(lock) 못했습니다. (에러번호: %M)"
+        nla "Kan de file niet blokeren (Errcode: %M)"
         nor "Kan ikke låse fila (Feilkode: %M)"
         norwegian-ny "Kan ikkje låse fila (Feilkode: %M)"
         pol "Nie można zablokować pliku (Kod błędu: %M)"
@@ -354,9 +367,9 @@ ER_CANT_LOCK
         swe "Kan inte låsa filen. (Felkod: %M)"
         ukr "Не можу заблокувати файл (помилка: %M)"
 ER_CANT_OPEN_FILE  
-	cze "Nemohu otevřít soubor '%-.200s' (chybový kód: %M)"
+        chi "无法打开文件：'%-.200s'（错误号码：%M）"
+        cze "Nemohu otevřít soubor '%-.200s' (chybový kód: %M)"
         dan "Kan ikke åbne fil: '%-.200s' (Fejlkode: %M)"
-        nla "Kan de file '%-.200s' niet openen (Errcode: %M)"
         eng "Can't open file: '%-.200s' (errno: %M)"
         est "Ei suuda avada faili '%-.200s' (veakood: %M)"
         fre "Ne peut ouvrir le fichier: '%-.200s' (Errcode: %M)"
@@ -367,6 +380,7 @@ ER_CANT_OPEN_FILE
         ita "Impossibile aprire il file: '%-.200s' (errno: %M)"
         jpn "ファイル '%-.200s' をオープンできません。(エラー番号: %M)"
         kor "화일을 열지 못했습니다.: '%-.200s' (에러번호: %M)"
+        nla "Kan de file '%-.200s' niet openen (Errcode: %M)"
         nor "Kan ikke åpne fila: '%-.200s' (Feilkode: %M)"
         norwegian-ny "Kan ikkje åpne fila: '%-.200s' (Feilkode: %M)"
         pol "Nie można otworzyć pliku: '%-.200s' (Kod błędu: %M)"
@@ -379,9 +393,9 @@ ER_CANT_OPEN_FILE
         swe "Kan inte använda '%-.200s' (Felkod: %M)"
         ukr "Не можу відкрити файл: '%-.200s' (помилка: %M)"
 ER_FILE_NOT_FOUND  
+        chi "找不到文件：'%-.200s'（错误号码：%M）"
         cze "Nemohu najít soubor '%-.200s' (chybový kód: %M)"
         dan "Kan ikke finde fila: '%-.200s' (Fejlkode: %M)"
-        nla "Kan de file: '%-.200s' niet vinden (Errcode: %M)"
         eng "Can't find file: '%-.200s' (errno: %M)"
         est "Ei suuda leida faili '%-.200s' (veakood: %M)"
         fre "Ne peut trouver le fichier: '%-.200s' (Errcode: %M)"
@@ -392,6 +406,7 @@ ER_FILE_NOT_FOUND
         ita "Impossibile trovare il file: '%-.200s' (errno: %M)"
         jpn "ファイル '%-.200s' が見つかりません。(エラー番号: %M)"
         kor "화일을 찾지 못했습니다.: '%-.200s' (에러번호: %M)"
+        nla "Kan de file: '%-.200s' niet vinden (Errcode: %M)"
         nor "Kan ikke finne fila: '%-.200s' (Feilkode: %M)"
         norwegian-ny "Kan ikkje finne fila: '%-.200s' (Feilkode: %M)"
         pol "Nie można znaleĽć pliku: '%-.200s' (Kod błędu: %M)"
@@ -404,9 +419,9 @@ ER_FILE_NOT_FOUND
         swe "Hittar inte filen '%-.200s' (Felkod: %M)"
         ukr "Не можу знайти файл: '%-.200s' (помилка: %M)"
 ER_CANT_READ_DIR  
+        chi "无法读取'%-.192s'的文件夹（错误号码：%M）"
         cze "Nemohu číst adresář '%-.192s' (chybový kód: %M)"
         dan "Kan ikke læse folder '%-.192s' (Fejlkode: %M)"
-        nla "Kan de directory niet lezen van '%-.192s' (Errcode: %M)"
         eng "Can't read dir of '%-.192s' (errno: %M)"
         est "Ei suuda lugeda kataloogi '%-.192s' (veakood: %M)"
         fre "Ne peut lire le répertoire de '%-.192s' (Errcode: %M)"
@@ -417,6 +432,7 @@ ER_CANT_READ_DIR
         ita "Impossibile leggere la directory di '%-.192s' (errno: %M)"
         jpn "ディレクトリ '%-.192s' を読み込めません。(エラー番号: %M)"
         kor "'%-.192s'디렉토리를 읽지 못했습니다. (에러번호: %M)"
+        nla "Kan de directory niet lezen van '%-.192s' (Errcode: %M)"
         nor "Kan ikke lese katalogen '%-.192s' (Feilkode: %M)"
         norwegian-ny "Kan ikkje lese katalogen '%-.192s' (Feilkode: %M)"
         pol "Nie można odczytać katalogu '%-.192s' (Kod błędu: %M)"
@@ -429,9 +445,9 @@ ER_CANT_READ_DIR
         swe "Kan inte läsa från bibliotek '%-.192s' (Felkod: %M)"
         ukr "Не можу прочитати теку '%-.192s' (помилка: %M)"
 ER_CANT_SET_WD  
-	cze "Nemohu změnit adresář na '%-.192s' (chybový kód: %M)"
+        chi "无法将dir更改为'%-.192s'（错误号码：%M）"
+        cze "Nemohu změnit adresář na '%-.192s' (chybový kód: %M)"
         dan "Kan ikke skifte folder til '%-.192s' (Fejlkode: %M)"
-        nla "Kan de directory niet veranderen naar '%-.192s' (Errcode: %M)"
         eng "Can't change dir to '%-.192s' (errno: %M)"
         est "Ei suuda siseneda kataloogi '%-.192s' (veakood: %M)"
         fre "Ne peut changer le répertoire pour '%-.192s' (Errcode: %M)"
@@ -442,6 +458,7 @@ ER_CANT_SET_WD
         ita "Impossibile cambiare la directory in '%-.192s' (errno: %M)"
         jpn "ディレクトリ '%-.192s' に移動できません。(エラー番号: %M)"
         kor "'%-.192s'디렉토리로 이동할 수 없었습니다. (에러번호: %M)"
+        nla "Kan de directory niet veranderen naar '%-.192s' (Errcode: %M)"
         nor "Kan ikke skifte katalog til '%-.192s' (Feilkode: %M)"
         norwegian-ny "Kan ikkje skifte katalog til '%-.192s' (Feilkode: %M)"
         pol "Nie można zmienić katalogu na '%-.192s' (Kod błędu: %M)"
@@ -454,9 +471,9 @@ ER_CANT_SET_WD
         swe "Kan inte byta till '%-.192s' (Felkod: %M)"
         ukr "Не можу перейти у теку '%-.192s' (помилка: %M)"
 ER_CHECKREAD  
+        chi "这个表自上次读后数据有变化'%-.192s'"
         cze "Záznam byl změněn od posledního čtení v tabulce '%-.192s'"
         dan "Posten er ændret siden sidste læsning '%-.192s'"
-        nla "Record is veranderd sinds de laatste lees activiteit in de tabel '%-.192s'"
         eng "Record has changed since last read in table '%-.192s'"
         est "Kirje tabelis '%-.192s' on muutunud viimasest lugemisest saadik"
         fre "Enregistrement modifié depuis sa dernière lecture dans la table '%-.192s'"
@@ -467,6 +484,7 @@ ER_CHECKREAD
         ita "Il record e` cambiato dall'ultima lettura della tabella '%-.192s'"
         jpn "表 '%-.192s' の最後の読み込み時点から、レコードが変化しました。"
         kor "테이블 '%-.192s'에서 마지막으로 읽은 후 Record가 변경되었습니다."
+        nla "Record is veranderd sinds de laatste lees activiteit in de tabel '%-.192s'"
         nor "Posten har blitt endret siden den ble lest '%-.192s'"
         norwegian-ny "Posten har vorte endra sidan den sist vart lesen '%-.192s'"
         pol "Rekord został zmieniony od ostaniego odczytania z tabeli '%-.192s'"
@@ -479,9 +497,9 @@ ER_CHECKREAD
         swe "Posten har förändrats sedan den lästes i register '%-.192s'"
         ukr "Запис було змінено з часу останнього читання з таблиці '%-.192s'"
 ER_DISK_FULL
+        chi "磁盘已满(%s);等待释放一些空间...（错误号码：%M）"
         cze "Disk je plný (%s), čekám na uvolnění nějakého místa ... (chybový kód: %M)"
         dan "Ikke mere diskplads (%s). Venter på at få frigjort plads... (Fejlkode: %M)"
-        nla "Schijf vol (%s). Aan het wachten totdat er ruimte vrij wordt gemaakt... (Errcode: %M)"
         eng "Disk full (%s); waiting for someone to free some space... (errno: %M)"
         est "Ketas täis (%s). Ootame kuni tekib vaba ruumi... (veakood: %M)"
         fre "Disque plein (%s). J'attend que quelqu'un libère de l'espace... (Errcode: %M)"
@@ -492,6 +510,7 @@ ER_DISK_FULL
         ita "Disco pieno (%s). In attesa che qualcuno liberi un po' di spazio... (errno: %M)"
         jpn "ディスク領域不足です(%s)。(エラー番号: %M)"
         kor "Disk full (%s). 다른 사람이 지울때까지 기다립니다... (에러번호: %M)"
+        nla "Schijf vol (%s). Aan het wachten totdat er ruimte vrij wordt gemaakt... (Errcode: %M)"
         nor "Ikke mer diskplass (%s). Venter på å få frigjort plass... (Feilkode: %M)"
         norwegian-ny "Ikkje meir diskplass (%s). Ventar på å få frigjort plass... (Feilkode: %M)"
         pol "Dysk pełny (%s). Oczekiwanie na zwolnienie miejsca... (Kod błędu: %M)"
@@ -504,9 +523,9 @@ ER_DISK_FULL
         swe "Disken är full (%s). Väntar tills det finns ledigt utrymme... (Felkod: %M)"
         ukr "Диск заповнений (%s). Вичикую, доки звільниться трохи місця... (помилка: %M)"
 ER_DUP_KEY 23000 
+        chi "不能写;表'%-.192s'中有重复索引"
         cze "Nemohu zapsat, zdvojený klíč v tabulce '%-.192s'"
         dan "Kan ikke skrive, flere ens nøgler i tabellen '%-.192s'"
-        nla "Kan niet schrijven, dubbele zoeksleutel in tabel '%-.192s'"
         eng "Can't write; duplicate key in table '%-.192s'"
         est "Ei saa kirjutada, korduv võti tabelis '%-.192s'"
         fre "Ecriture impossible, doublon dans une clé de la table '%-.192s'"
@@ -517,6 +536,7 @@ ER_DUP_KEY 23000
         ita "Scrittura impossibile: chiave duplicata nella tabella '%-.192s'"
         jpn "書き込めません。表 '%-.192s' に重複するキーがあります。"
         kor "기록할 수 없습니다., 테이블 '%-.192s'에서 중복 키"
+        nla "Kan niet schrijven, dubbele zoeksleutel in tabel '%-.192s'"
         nor "Kan ikke skrive, flere like nøkler i tabellen '%-.192s'"
         norwegian-ny "Kan ikkje skrive, flere like nyklar i tabellen '%-.192s'"
         pol "Nie można zapisać, powtórzone klucze w tabeli '%-.192s'"
@@ -529,9 +549,9 @@ ER_DUP_KEY 23000
         swe "Kan inte skriva, dubbel söknyckel i register '%-.192s'"
         ukr "Не можу записати, дублюючийся ключ в таблиці '%-.192s'"
 ER_ERROR_ON_CLOSE  
-	cze "Chyba při zavírání '%-.192s' (chybový kód: %M)"
+        chi "'%-.192s'关闭时出错（错误号码：%M）"
+        cze "Chyba při zavírání '%-.192s' (chybový kód: %M)"
         dan "Fejl ved lukning af '%-.192s' (Fejlkode: %M)"
-        nla "Fout bij het sluiten van '%-.192s' (Errcode: %M)"
         eng "Error on close of '%-.192s' (errno: %M)"
         est "Viga faili '%-.192s' sulgemisel (veakood: %M)"
         fre "Erreur a la fermeture de '%-.192s' (Errcode: %M)"
@@ -542,6 +562,7 @@ ER_ERROR_ON_CLOSE
         ita "Errore durante la chiusura di '%-.192s' (errno: %M)"
         jpn "'%-.192s' のクローズ時エラー (エラー番号: %M)"
         kor "'%-.192s'닫는 중 에러 (에러번호: %M)"
+        nla "Fout bij het sluiten van '%-.192s' (Errcode: %M)"
         nor "Feil ved lukking av '%-.192s' (Feilkode: %M)"
         norwegian-ny "Feil ved lukking av '%-.192s' (Feilkode: %M)"
         pol "Bł?d podczas zamykania '%-.192s' (Kod błędu: %M)"
@@ -554,9 +575,9 @@ ER_ERROR_ON_CLOSE
         swe "Fick fel vid stängning av '%-.192s' (Felkod: %M)"
         ukr "Не можу закрити '%-.192s' (помилка: %M)"
 ER_ERROR_ON_READ  
+        chi "读取文件'%-.200s'错误（错误号码：%M）"
         cze "Chyba při čtení souboru '%-.200s' (chybový kód: %M)"
         dan "Fejl ved læsning af '%-.200s' (Fejlkode: %M)"
-        nla "Fout bij het lezen van file '%-.200s' (Errcode: %M)"
         eng "Error reading file '%-.200s' (errno: %M)"
         est "Viga faili '%-.200s' lugemisel (veakood: %M)"
         fre "Erreur en lecture du fichier '%-.200s' (Errcode: %M)"
@@ -567,6 +588,7 @@ ER_ERROR_ON_READ
         ita "Errore durante la lettura del file '%-.200s' (errno: %M)"
         jpn "ファイル '%-.200s' の読み込みエラー (エラー番号: %M)"
         kor "'%-.200s'화일 읽기 에러 (에러번호: %M)"
+        nla "Fout bij het lezen van file '%-.200s' (Errcode: %M)"
         nor "Feil ved lesing av '%-.200s' (Feilkode: %M)"
         norwegian-ny "Feil ved lesing av '%-.200s' (Feilkode: %M)"
         pol "Bł?d podczas odczytu pliku '%-.200s' (Kod błędu: %M)"
@@ -579,9 +601,9 @@ ER_ERROR_ON_READ
         swe "Fick fel vid läsning av '%-.200s' (Felkod %M)"
         ukr "Не можу прочитати файл '%-.200s' (помилка: %M)"
 ER_ERROR_ON_RENAME  
+        chi "重命名'%-.210s'到'%-.210s'错误（错误号码：%M）"
         cze "Chyba při přejmenování '%-.210s' na '%-.210s' (chybový kód: %M)"
         dan "Fejl ved omdøbning af '%-.210s' til '%-.210s' (Fejlkode: %M)"
-        nla "Fout bij het hernoemen van '%-.210s' naar '%-.210s' (Errcode: %M)"
         eng "Error on rename of '%-.210s' to '%-.210s' (errno: %M)"
         est "Viga faili '%-.210s' ümbernimetamisel '%-.210s'-ks (veakood: %M)"
         fre "Erreur en renommant '%-.210s' en '%-.210s' (Errcode: %M)"
@@ -592,6 +614,7 @@ ER_ERROR_ON_RENAME
         ita "Errore durante la rinominazione da '%-.210s' a '%-.210s' (errno: %M)"
         jpn "'%-.210s' の名前を '%-.210s' に変更できません (エラー番号: %M)"
         kor "'%-.210s'를 '%-.210s'로 이름 변경중 에러 (에러번호: %M)"
+        nla "Fout bij het hernoemen van '%-.210s' naar '%-.210s' (Errcode: %M)"
         nor "Feil ved omdøping av '%-.210s' til '%-.210s' (Feilkode: %M)"
         norwegian-ny "Feil ved omdøyping av '%-.210s' til '%-.210s' (Feilkode: %M)"
         pol "Bł?d podczas zmieniania nazwy '%-.210s' na '%-.210s' (Kod błędu: %M)"
@@ -604,9 +627,9 @@ ER_ERROR_ON_RENAME
         swe "Kan inte byta namn från '%-.210s' till '%-.210s' (Felkod: %M)"
         ukr "Не можу перейменувати '%-.210s' у '%-.210s' (помилка: %M)"
 ER_ERROR_ON_WRITE  
-	cze "Chyba při zápisu do souboru '%-.200s' (chybový kód: %M)"
+        chi "写文件'%-.200s'错误（错误号码：%M）"
+        cze "Chyba při zápisu do souboru '%-.200s' (chybový kód: %M)"
         dan "Fejl ved skriving av filen '%-.200s' (Fejlkode: %M)"
-        nla "Fout bij het wegschrijven van file '%-.200s' (Errcode: %M)"
         eng "Error writing file '%-.200s' (errno: %M)"
         est "Viga faili '%-.200s' kirjutamisel (veakood: %M)"
         fre "Erreur d'écriture du fichier '%-.200s' (Errcode: %M)"
@@ -617,6 +640,7 @@ ER_ERROR_ON_WRITE
         ita "Errore durante la scrittura del file '%-.200s' (errno: %M)"
         jpn "ファイル '%-.200s' の書き込みエラー (エラー番号: %M)"
         kor "'%-.200s'화일 기록 중 에러 (에러번호: %M)"
+        nla "Fout bij het wegschrijven van file '%-.200s' (Errcode: %M)"
         nor "Feil ved skriving av fila '%-.200s' (Feilkode: %M)"
         norwegian-ny "Feil ved skriving av fila '%-.200s' (Feilkode: %M)"
         pol "Bł?d podczas zapisywania pliku '%-.200s' (Kod błędu: %M)"
@@ -629,9 +653,9 @@ ER_ERROR_ON_WRITE
         swe "Fick fel vid skrivning till '%-.200s' (Felkod %M)"
         ukr "Не можу записати файл '%-.200s' (помилка: %M)"
 ER_FILE_USED  
+        chi "'%-.192s'被锁定，不能改变"
         cze "'%-.192s' je zamčen proti změnám"
         dan "'%-.192s' er låst mod opdateringer"
-        nla "'%-.192s' is geblokeerd tegen veranderingen"
         eng "'%-.192s' is locked against change"
         est "'%-.192s' on lukustatud muudatuste vastu"
         fre "'%-.192s' est verrouillé contre les modifications"
@@ -642,6 +666,7 @@ ER_FILE_USED
         ita "'%-.192s' e` soggetto a lock contro i cambiamenti"
         jpn "'%-.192s' はロックされています。"
         kor "'%-.192s'가 변경할 수 없도록 잠겨있습니다."
+        nla "'%-.192s' is geblokeerd tegen veranderingen"
         nor "'%-.192s' er låst mot oppdateringer"
         norwegian-ny "'%-.192s' er låst mot oppdateringar"
         pol "'%-.192s' jest zablokowany na wypadek zmian"
@@ -654,9 +679,9 @@ ER_FILE_USED
         swe "'%-.192s' är låst mot användning"
         ukr "'%-.192s' заблокований на внесення змін"
 ER_FILSORT_ABORT  
+        chi "排序中止"
         cze "Třídění přerušeno"
         dan "Sortering afbrudt"
-        nla "Sorteren afgebroken"
         eng "Sort aborted"
         est "Sorteerimine katkestatud"
         fre "Tri alphabétique abandonné"
@@ -667,6 +692,7 @@ ER_FILSORT_ABORT
         ita "Operazione di ordinamento abbandonata"
         jpn "ソート処理を中断しました。"
         kor "소트가 중단되었습니다."
+        nla "Sorteren afgebroken"
         nor "Sortering avbrutt"
         norwegian-ny "Sortering avbrote"
         pol "Sortowanie przerwane"
@@ -679,9 +705,9 @@ ER_FILSORT_ABORT
         swe "Sorteringen avbruten"
         ukr "Сортування перервано"
 ER_FORM_NOT_FOUND  
+        chi "视图'%-.192s'不存在'%-.192s'"
         cze "Pohled '%-.192s' pro '%-.192s' neexistuje"
         dan "View '%-.192s' eksisterer ikke for '%-.192s'"
-        nla "View '%-.192s' bestaat niet voor '%-.192s'"
         eng "View '%-.192s' doesn't exist for '%-.192s'"
         est "Vaade '%-.192s' ei eksisteeri '%-.192s' jaoks"
         fre "La vue (View) '%-.192s' n'existe pas pour '%-.192s'"
@@ -692,6 +718,7 @@ ER_FORM_NOT_FOUND
         ita "La view '%-.192s' non esiste per '%-.192s'"
         jpn "ビュー '%-.192s' は '%-.192s' に存在しません。"
         kor "뷰 '%-.192s'가 '%-.192s'에서는 존재하지 않습니다."
+        nla "View '%-.192s' bestaat niet voor '%-.192s'"
         nor "View '%-.192s' eksisterer ikke for '%-.192s'"
         norwegian-ny "View '%-.192s' eksisterar ikkje for '%-.192s'"
         pol "Widok '%-.192s' nie istnieje dla '%-.192s'"
@@ -704,13 +731,14 @@ ER_FORM_NOT_FOUND
         swe "Formulär '%-.192s' finns inte i '%-.192s'"
         ukr "Вигляд '%-.192s' не існує для '%-.192s'"
 ER_GET_ERRNO  
-        nla "Fout %M van tabel handler %s"
+        chi "错误 %M, 来自存储引擎 %s"
         eng "Got error %M from storage engine %s"
         fre "Reçu l'erreur %M du handler de la table %s"
         ger "Fehler %M von Speicher-Engine %s"
         greek "Ελήφθη μήνυμα λάθους %M από τον χειριστή πίνακα (table handler) %s"
         hindi "%M त्रुटि %s स्टोरेज इंजन से"
         ita "Rilevato l'errore %M dal gestore delle tabelle %s"
+        nla "Fout %M van tabel handler %s"
         nor "Mottok feil %M fra tabell håndterer %s"
         norwegian-ny "Mottok feil %M fra tabell handterar %s"
         pol "Otrzymano bł?d %M z obsługi tabeli %s"
@@ -721,15 +749,16 @@ ER_GET_ERRNO
         swe "Fick felkod %M från databashanteraren %s"
         ukr "Отримано помилку %M від дескриптора таблиці %s"
 ER_ILLEGAL_HA  
+        chi "存储引擎%s %`s.%`s 表没有该选项"
         eng "Storage engine %s of the table %`s.%`s doesn't have this option"
         ger "Diese Option gibt es nicht in Speicher-Engine %s für %`s.%`s"
         hindi "स्टोरेज इंजन %s में यह विकल्प उपलब्ध नहीं है (टेबल: %`s.%`s)"
         rus "Обработчик %s таблицы %`s.%`s не поддерживает эту возможность"
         ukr "Дескриптор %s таблиці %`s.%`s не має цієї властивості"
 ER_KEY_NOT_FOUND  
+        chi "无法在'%-.192s'中找到记录"
         cze "Nemohu najít záznam v '%-.192s'"
         dan "Kan ikke finde posten i '%-.192s'"
-        nla "Kan record niet vinden in '%-.192s'"
         eng "Can't find record in '%-.192s'"
         est "Ei suuda leida kirjet '%-.192s'-s"
         fre "Ne peut trouver l'enregistrement dans '%-.192s'"
@@ -740,6 +769,7 @@ ER_KEY_NOT_FOUND
         ita "Impossibile trovare il record in '%-.192s'"
         jpn "'%-.192s' にレコードが見つかりません。"
         kor "'%-.192s'에서 레코드를 찾을 수 없습니다."
+        nla "Kan record niet vinden in '%-.192s'"
         nor "Kan ikke finne posten i '%-.192s'"
         norwegian-ny "Kan ikkje finne posten i '%-.192s'"
         pol "Nie można znaleĽć rekordu w '%-.192s'"
@@ -749,12 +779,12 @@ ER_KEY_NOT_FOUND
         serbian "Ne mogu da pronađem slog u '%-.192s'"
         slo "Nemôžem nájsť záznam v '%-.192s'"
         spa "No puedo encontrar el registro en '%-.192s'"
-	swe "Hittar inte posten '%-.192s'"
+        swe "Hittar inte posten '%-.192s'"
         ukr "Не можу записати у '%-.192s'"
 ER_NOT_FORM_FILE  
+        chi "文件中的信息不正确：'%-.200s'"
         cze "Nesprávná informace v souboru '%-.200s'"
         dan "Forkert indhold i: '%-.200s'"
-        nla "Verkeerde info in file: '%-.200s'"
         eng "Incorrect information in file: '%-.200s'"
         est "Vigane informatsioon failis '%-.200s'"
         fre "Information erronnée dans le fichier: '%-.200s'"
@@ -765,6 +795,7 @@ ER_NOT_FORM_FILE
         ita "Informazione errata nel file: '%-.200s'"
         jpn "ファイル '%-.200s' 内の情報が不正です。"
         kor "화일의 부정확한 정보: '%-.200s'"
+        nla "Verkeerde info in file: '%-.200s'"
         nor "Feil informasjon i filen: '%-.200s'"
         norwegian-ny "Feil informasjon i fila: '%-.200s'"
         pol "Niewła?ciwa informacja w pliku: '%-.200s'"
@@ -777,9 +808,9 @@ ER_NOT_FORM_FILE
         swe "Felaktig fil: '%-.200s'"
         ukr "Хибна інформація у файлі: '%-.200s'"
 ER_NOT_KEYFILE  
+        chi "表'%-.200s'的索引损坏;试着修复"
         cze "Nesprávný klíč pro tabulku '%-.200s'; pokuste se ho opravit"
         dan "Fejl i indeksfilen til tabellen '%-.200s'; prøv at reparere den"
-        nla "Verkeerde zoeksleutel file voor tabel: '%-.200s'; probeer het te repareren"
         eng "Index for table '%-.200s' is corrupt; try to repair it"
         est "Tabeli '%-.200s' võtmefail on vigane; proovi seda parandada"
         fre "Index corrompu dans la table: '%-.200s'; essayez de le réparer"
@@ -790,6 +821,7 @@ ER_NOT_KEYFILE
         ita "File chiave errato per la tabella : '%-.200s'; prova a riparalo"
         jpn "表 '%-.200s' の索引ファイル(key file)の内容が不正です。修復を試行してください。"
         kor "'%-.200s' 테이블의 부정확한 키 존재. 수정하시오!"
+        nla "Verkeerde zoeksleutel file voor tabel: '%-.200s'; probeer het te repareren"
         nor "Tabellen '%-.200s' har feil i nøkkelfilen; forsøk å reparer den"
         norwegian-ny "Tabellen '%-.200s' har feil i nykkelfila; prøv å reparere den"
         pol "Niewła?ciwy plik kluczy dla tabeli: '%-.200s'; spróbuj go naprawić"
@@ -802,9 +834,9 @@ ER_NOT_KEYFILE
         swe "Fatalt fel vid hantering av register '%-.200s'; kör en reparation"
         ukr "Хибний файл ключей для таблиці: '%-.200s'; Спробуйте його відновити"
 ER_OLD_KEYFILE  
+        chi "表'%-.192s'的老索引文件损坏; 修复!"
         cze "Starý klíčový soubor pro '%-.192s'; opravte ho"
         dan "Gammel indeksfil for tabellen '%-.192s'; reparer den"
-        nla "Oude zoeksleutel file voor tabel '%-.192s'; repareer het!"
         eng "Old key file for table '%-.192s'; repair it!"
         est "Tabeli '%-.192s' võtmefail on aegunud; paranda see!"
         fre "Vieux fichier d'index pour la table '%-.192s'; réparez le!"
@@ -815,6 +847,7 @@ ER_OLD_KEYFILE
         ita "File chiave vecchio per la tabella '%-.192s'; riparalo!"
         jpn "表 '%-.192s' の索引ファイル(key file)は古い形式です。修復してください。"
         kor "'%-.192s' 테이블의 이전버젼의 키 존재. 수정하시오!"
+        nla "Oude zoeksleutel file voor tabel '%-.192s'; repareer het!"
         nor "Gammel nøkkelfil for tabellen '%-.192s'; reparer den!"
         norwegian-ny "Gammel nykkelfil for tabellen '%-.192s'; reparer den!"
         pol "Plik kluczy dla tabeli '%-.192s' jest starego typu; napraw go!"
@@ -827,9 +860,9 @@ ER_OLD_KEYFILE
         swe "Gammal nyckelfil '%-.192s'; reparera registret"
         ukr "Старий файл ключей для таблиці '%-.192s'; Відновіть його!"
 ER_OPEN_AS_READONLY  
+        chi "表'%-.192s'只可读"
         cze "'%-.192s' je jen pro čtení"
         dan "'%-.192s' er skrivebeskyttet"
-        nla "'%-.192s' is alleen leesbaar"
         eng "Table '%-.192s' is read only"
         est "Tabel '%-.192s' on ainult lugemiseks"
         fre "'%-.192s' est en lecture seulement"
@@ -840,6 +873,7 @@ ER_OPEN_AS_READONLY
         ita "'%-.192s' e` di sola lettura"
         jpn "表 '%-.192s' は読み込み専用です。"
         kor "테이블 '%-.192s'는 읽기전용 입니다."
+        nla "'%-.192s' is alleen leesbaar"
         nor "'%-.192s' er skrivebeskyttet"
         norwegian-ny "'%-.192s' er skrivetryggja"
         pol "'%-.192s' jest tylko do odczytu"
@@ -852,9 +886,9 @@ ER_OPEN_AS_READONLY
         swe "'%-.192s' är skyddad mot förändring"
         ukr "Таблиця '%-.192s' тільки для читання"
 ER_OUTOFMEMORY HY001 S1001
+        chi "内存不足; 重启后重试(需要 %d bytes)"
         cze "Málo paměti. Přestartujte daemona a zkuste znovu (je potřeba %d bytů)"
         dan "Ikke mere hukommelse. Genstart serveren og prøv igen (mangler %d bytes)"
-        nla "Geen geheugen meer. Herstart server en probeer opnieuw (%d bytes nodig)"
         eng "Out of memory; restart server and try again (needed %d bytes)"
         est "Mälu  sai otsa. Proovi MariaDB uuesti käivitada (puudu jäi %d baiti)"
         fre "Manque de mémoire. Redémarrez le démon et ré-essayez (%d octets nécessaires)"
@@ -864,6 +898,7 @@ ER_OUTOFMEMORY HY001 S1001
         ita "Memoria esaurita. Fai ripartire il demone e riprova (richiesti %d bytes)"
         jpn "メモリが不足しています。サーバーを再起動してみてください。(%d バイトの割り当てに失敗)"
         kor "Out of memory. 데몬을 재 실행 후 다시 시작하시오 (needed %d bytes)"
+        nla "Geen geheugen meer. Herstart server en probeer opnieuw (%d bytes nodig)"
         nor "Ikke mer minne. Star på nytt tjenesten og prøv igjen (trengte %d byter)"
         norwegian-ny "Ikkje meir minne. Start på nytt tenesten og prøv igjen (trengte %d bytar)"
         pol "Zbyt mało pamięci. Uruchom ponownie demona i spróbuj ponownie (potrzeba %d bajtów)"
@@ -876,9 +911,9 @@ ER_OUTOFMEMORY HY001 S1001
         swe "Oväntat slut på minnet, starta om programmet och försök på nytt (Behövde %d bytes)"
         ukr "Брак пам'яті. Рестартуйте сервер та спробуйте знову (потрібно %d байтів)"
 ER_OUT_OF_SORTMEMORY HY001 S1001
+        chi "排序内存不足，可以考虑增加实例排序缓存量"
         cze "Málo paměti pro třídění. Zvyšte velikost třídícího bufferu"
         dan "Ikke mere sorteringshukommelse. Øg sorteringshukommelse (sort buffer size) for serveren"
-        nla "Geen geheugen om te sorteren. Verhoog de server sort buffer size"
         eng "Out of sort memory, consider increasing server sort buffer size"
         est "Mälu sai sorteerimisel otsa. Suurenda MariaDB-i sorteerimispuhvrit"
         fre "Manque de mémoire pour le tri. Augmentez-la"
@@ -888,6 +923,7 @@ ER_OUT_OF_SORTMEMORY HY001 S1001
         ita "Memoria per gli ordinamenti esaurita. Incrementare il 'sort_buffer' al demone"
         jpn "ソートメモリが不足しています。ソートバッファサイズ(sort buffer size)の増加を検討してください。"
         kor "Out of sort memory. daemon sort buffer의 크기를 증가시키세요"
+        nla "Geen geheugen om te sorteren. Verhoog de server sort buffer size"
         nor "Ikke mer sorteringsminne. Vurder å øke sorteringsminnet (sort buffer size) for tjenesten"
         norwegian-ny "Ikkje meir sorteringsminne. Vurder å auke sorteringsminnet (sorteringsbuffer storleik) for tenesten"
         pol "Zbyt mało pamięci dla sortowania. Zwiększ wielko?ć bufora demona dla sortowania"
@@ -900,9 +936,9 @@ ER_OUT_OF_SORTMEMORY HY001 S1001
         swe "Sorteringsbufferten räcker inte till. Kontrollera startparametrarna"
         ukr "Брак пам'яті для сортування. Треба збільшити розмір буфера сортування у сервера"
 ER_UNEXPECTED_EOF  
-	cze "Neočekávaný konec souboru při čtení '%-.192s' (chybový kód: %M)"
+        chi "阅读文件'%-.192s'时出现意外的EOF（错误号码：%M）"
+        cze "Neočekávaný konec souboru při čtení '%-.192s' (chybový kód: %M)"
         dan "Uventet afslutning på fil (eof) ved læsning af filen '%-.192s' (Fejlkode: %M)"
-        nla "Onverwachte eof gevonden tijdens het lezen van file '%-.192s' (Errcode: %M)"
         eng "Unexpected EOF found when reading file '%-.192s' (errno: %M)"
         est "Ootamatu faililõpumärgend faili '%-.192s' lugemisel (veakood: %M)"
         fre "Fin de fichier inattendue en lisant '%-.192s' (Errcode: %M)"
@@ -912,6 +948,7 @@ ER_UNEXPECTED_EOF
         ita "Fine del file inaspettata durante la lettura del file '%-.192s' (errno: %M)"
         jpn "ファイル '%-.192s' を読み込み中に予期せずファイルの終端に達しました。(エラー番号: %M)"
         kor "'%-.192s' 화일을 읽는 도중 잘못된 eof을 발견 (에러번호: %M)"
+        nla "Onverwachte eof gevonden tijdens het lezen van file '%-.192s' (Errcode: %M)"
         nor "Uventet slutt på fil (eof) ved lesing av filen '%-.192s' (Feilkode: %M)"
         norwegian-ny "Uventa slutt på fil (eof) ved lesing av fila '%-.192s' (Feilkode: %M)"
         pol "Nieoczekiwany 'eof' napotkany podczas czytania z pliku '%-.192s' (Kod błędu: %M)"
@@ -924,9 +961,9 @@ ER_UNEXPECTED_EOF
         swe "Oväntat filslut vid läsning från '%-.192s' (Felkod: %M)"
         ukr "Хибний кінець файлу '%-.192s' (помилка: %M)"
 ER_CON_COUNT_ERROR 08004 
+        chi "太多连接"
         cze "Příliš mnoho spojení"
         dan "For mange forbindelser (connections)"
-        nla "Te veel verbindingen"
         eng "Too many connections"
         est "Liiga palju samaaegseid ühendusi"
         fre "Trop de connexions"
@@ -937,6 +974,7 @@ ER_CON_COUNT_ERROR 08004
         ita "Troppe connessioni"
         jpn "接続が多すぎます。"
         kor "너무 많은 연결... max_connection을 증가 시키시오..."
+        nla "Te veel verbindingen"
         nor "For mange tilkoblinger (connections)"
         norwegian-ny "For mange tilkoplingar (connections)"
         pol "Zbyt wiele poł?czeń"
@@ -949,9 +987,9 @@ ER_CON_COUNT_ERROR 08004
         swe "För många anslutningar"
         ukr "Забагато з'єднань"
 ER_OUT_OF_RESOURCES  
+        chi "内存不足."
         cze "Málo prostoru/paměti pro thread"
         dan "Udgået for tråde/hukommelse"
-        nla "Geen thread geheugen meer; controleer of mysqld of andere processen al het beschikbare geheugen gebruikt. Zo niet, dan moet u wellicht 'ulimit' gebruiken om mysqld toe te laten meer geheugen te benutten, of u kunt extra swap ruimte toevoegen"
         eng "Out of memory."
         est "Mälu sai otsa. Võimalik, et aitab swap-i lisamine või käsu 'ulimit' abil MariaDB-le rohkema mälu kasutamise lubamine"
         fre "Manque de 'threads'/mémoire"
@@ -961,6 +999,7 @@ ER_OUT_OF_RESOURCES
         ita "Fine dello spazio/memoria per i thread"
         jpn "メモリが不足しています。mysqld やその他のプロセスがメモリーを使い切っていないか確認して下さい。メモリーを使い切っていない場合、'ulimit'の設定等で mysqld のメモリー使用最大量を多くするか、スワップ領域を増やす必要があるかもしれません。"
 # This message failed to convert from euc-kr, skipped
+        nla "Geen thread geheugen meer; controleer of mysqld of andere processen al het beschikbare geheugen gebruikt. Zo niet, dan moet u wellicht 'ulimit' gebruiken om mysqld toe te laten meer geheugen te benutten, of u kunt extra swap ruimte toevoegen"
         nor "Tomt for tråd plass/minne"
         norwegian-ny "Tomt for tråd plass/minne"
         pol "Zbyt mało miejsca/pamięci dla w?tku"
@@ -973,9 +1012,9 @@ ER_OUT_OF_RESOURCES
         swe "Fick slut på minnet."
         ukr "Брак пам'яті."
 ER_BAD_HOST_ERROR 08S01 
+        chi "不能从你的地址获取主机名称"
         cze "Nemohu zjistit jméno stroje pro Vaši adresu"
         dan "Kan ikke få værtsnavn for din adresse"
-        nla "Kan de hostname niet krijgen van uw adres"
         eng "Can't get hostname for your address"
         est "Ei suuda lahendada IP aadressi masina nimeks"
         fre "Ne peut obtenir de hostname pour votre adresse"
@@ -986,6 +1025,7 @@ ER_BAD_HOST_ERROR 08S01
         ita "Impossibile risalire al nome dell'host dall'indirizzo (risoluzione inversa)"
         jpn "IPアドレスからホスト名を解決できません。"
         kor "당신의 컴퓨터의 호스트이름을 얻을 수 없습니다."
+        nla "Kan de hostname niet krijgen van uw adres"
         nor "Kan ikke få tak i vertsnavn for din adresse"
         norwegian-ny "Kan ikkje få tak i vertsnavn for di adresse"
         pol "Nie można otrzymać nazwy hosta dla twojego adresu"
@@ -998,9 +1038,9 @@ ER_BAD_HOST_ERROR 08S01
         swe "Kan inte hitta 'hostname' för din adress"
         ukr "Не можу визначити ім'я хосту для вашої адреси"
 ER_HANDSHAKE_ERROR 08S01 
+        chi "坏握手"
         cze "Chyba při ustavování spojení"
         dan "Forkert håndtryk (handshake)"
-        nla "Verkeerde handshake"
         eng "Bad handshake"
         est "Väär handshake"
         fre "Mauvais 'handshake'"
@@ -1010,6 +1050,7 @@ ER_HANDSHAKE_ERROR 08S01
         hun "A kapcsolatfelvetel nem sikerult (Bad handshake)"
         ita "Negoziazione impossibile"
         jpn "ハンドシェイクエラー"
+        nla "Verkeerde handshake"
         nor "Feil håndtrykk (handshake)"
         norwegian-ny "Feil handtrykk (handshake)"
         pol "Zły uchwyt(handshake)"
@@ -1022,20 +1063,20 @@ ER_HANDSHAKE_ERROR 08S01
         swe "Fel vid initiering av kommunikationen med klienten"
         ukr "Невірна установка зв'язку"
 ER_DBACCESS_DENIED_ERROR 42000 
+        chi "用户'%s'@'%s'无权访问数据库'%-.192s'"
         cze "Přístup pro uživatele '%s'@'%s' k databázi '%-.192s' není povolen"
         dan "Adgang nægtet bruger: '%s'@'%s' til databasen '%-.192s'"
-        nla "Toegang geweigerd voor gebruiker: '%s'@'%s' naar database '%-.192s'"
         eng "Access denied for user '%s'@'%s' to database '%-.192s'"
-        jps "ユーザー '%s'@'%s' の '%-.192s' データベースへのアクセスを拒否します",
         est "Ligipääs keelatud kasutajale '%s'@'%s' andmebaasile '%-.192s'"
         fre "Accès refusé pour l'utilisateur: '%s'@'%s'. Base '%-.192s'"
         ger "Benutzer '%s'@'%s' hat keine Zugriffsberechtigung für Datenbank '%-.192s'"
         greek "Δεν επιτέρεται η πρόσβαση στο χρήστη: '%s'@'%s' στη βάση δεδομένων '%-.192s'"
-        hun "A(z) '%s'@'%s' felhasznalo szamara tiltott eleres az '%-.192s' adabazishoz"
         hindi "यूज़र '%s'@'%s' को डेटाबेस '%-.192s' की अनुमति नहीं है"
+        hun "A(z) '%s'@'%s' felhasznalo szamara tiltott eleres az '%-.192s' adabazishoz"
         ita "Accesso non consentito per l'utente: '%s'@'%s' al database '%-.192s'"
         jpn "ユーザー '%s'@'%s' の '%-.192s' データベースへのアクセスを拒否します"
         kor "'%s'@'%s' 사용자는 '%-.192s' 데이타베이스에 접근이 거부 되었습니다."
+        nla "Toegang geweigerd voor gebruiker: '%s'@'%s' naar database '%-.192s'"
         nor "Tilgang nektet for bruker: '%s'@'%s' til databasen '%-.192s' nektet"
         norwegian-ny "Tilgang ikkje tillate for brukar: '%s'@'%s' til databasen '%-.192s' nekta"
         por "Acesso negado para o usuário '%s'@'%s' ao banco de dados '%-.192s'"
@@ -1047,11 +1088,10 @@ ER_DBACCESS_DENIED_ERROR 42000
         swe "Användare '%s'@'%s' är ej berättigad att använda databasen %-.192s"
         ukr "Доступ заборонено для користувача: '%s'@'%s' до бази данних '%-.192s'"
 ER_ACCESS_DENIED_ERROR 28000 
+        chi "'%s'@'%s' 用户无权访问 (使用密码: %s)"
         cze "Přístup pro uživatele '%s'@'%s' (s heslem %s)"
         dan "Adgang nægtet bruger: '%s'@'%s' (Bruger adgangskode: %s)"
-        nla "Toegang geweigerd voor gebruiker: '%s'@'%s' (Wachtwoord gebruikt: %s)"
         eng "Access denied for user '%s'@'%s' (using password: %s)"
-        jps "ユーザー '%s'@'%s' を拒否します.uUsing password: %s)",
         est "Ligipääs keelatud kasutajale '%s'@'%s' (kasutab parooli: %s)"
         fre "Accès refusé pour l'utilisateur: '%s'@'%s' (mot de passe: %s)"
         ger "Benutzer '%s'@'%s' hat keine Zugriffsberechtigung (verwendetes Passwort: %s)"
@@ -1061,6 +1101,7 @@ ER_ACCESS_DENIED_ERROR 28000
         ita "Accesso non consentito per l'utente: '%s'@'%s' (Password: %s)"
         jpn "ユーザー '%s'@'%s' を拒否します.uUsing password: %s)"
         kor "'%s'@'%s' 사용자는 접근이 거부 되었습니다. (using password: %s)"
+        nla "Toegang geweigerd voor gebruiker: '%s'@'%s' (Wachtwoord gebruikt: %s)"
         nor "Tilgang nektet for bruker: '%s'@'%s' (Bruker passord: %s)"
         norwegian-ny "Tilgang ikke tillate for brukar: '%s'@'%s' (Brukar passord: %s)"
         por "Acesso negado para o usuário '%s'@'%s' (senha usada: %s)"
@@ -1072,9 +1113,9 @@ ER_ACCESS_DENIED_ERROR 28000
         swe "Användare '%s'@'%s' är ej berättigad att logga in (Använder lösen: %s)"
         ukr "Доступ заборонено для користувача: '%s'@'%s' (Використано пароль: %s)"
 ER_NO_DB_ERROR 3D000 
+        chi "没有选择数据库"
         cze "Nebyla vybrána žádná databáze"
         dan "Ingen database valgt"
-        nla "Geen database geselecteerd"
         eng "No database selected"
         est "Andmebaasi ei ole valitud"
         fre "Aucune base n'a été sélectionnée"
@@ -1085,6 +1126,7 @@ ER_NO_DB_ERROR 3D000
         ita "Nessun database selezionato"
         jpn "データベースが選択されていません。"
         kor "선택된 데이타베이스가 없습니다."
+        nla "Geen database geselecteerd"
         nor "Ingen database valgt"
         norwegian-ny "Ingen database vald"
         pol "Nie wybrano żadnej bazy danych"
@@ -1097,9 +1139,9 @@ ER_NO_DB_ERROR 3D000
         swe "Ingen databas i användning"
         ukr "Базу данних не вибрано"
 ER_UNKNOWN_COM_ERROR 08S01 
+        chi "未知的命令"
         cze "Neznámý příkaz"
         dan "Ukendt kommando"
-        nla "Onbekend commando"
         eng "Unknown command"
         est "Tundmatu käsk"
         fre "Commande inconnue"
@@ -1110,6 +1152,7 @@ ER_UNKNOWN_COM_ERROR 08S01
         ita "Comando sconosciuto"
         jpn "不明なコマンドです。"
         kor "명령어가 뭔지 모르겠어요..."
+        nla "Onbekend commando"
         nor "Ukjent kommando"
         norwegian-ny "Ukjent kommando"
         pol "Nieznana komenda"
@@ -1122,9 +1165,9 @@ ER_UNKNOWN_COM_ERROR 08S01
         swe "Okänt kommando"
         ukr "Невідома команда"
 ER_BAD_NULL_ERROR 23000 
+        chi "列'%-.192s'不能为NULL"
         cze "Sloupec '%-.192s' nemůže být null"
         dan "Kolonne '%-.192s' kan ikke være NULL"
-        nla "Kolom '%-.192s' kan niet null zijn"
         eng "Column '%-.192s' cannot be null"
         est "Tulp '%-.192s' ei saa omada nullväärtust"
         fre "Le champ '%-.192s' ne peut être vide (null)"
@@ -1135,6 +1178,7 @@ ER_BAD_NULL_ERROR 23000
         ita "La colonna '%-.192s' non puo` essere nulla"
         jpn "列 '%-.192s' は null にできません。"
         kor "칼럼 '%-.192s'는 널(Null)이 되면 안됩니다. "
+        nla "Kolom '%-.192s' kan niet null zijn"
         nor "Kolonne '%-.192s' kan ikke vere null"
         norwegian-ny "Kolonne '%-.192s' kan ikkje vere null"
         pol "Kolumna '%-.192s' nie może być null"
@@ -1147,9 +1191,9 @@ ER_BAD_NULL_ERROR 23000
         swe "Kolumn '%-.192s' får inte vara NULL"
         ukr "Стовбець '%-.192s' не може бути нульовим"
 ER_BAD_DB_ERROR 42000 
+        chi "未知数据库'%-.192s'"
         cze "Neznámá databáze '%-.192s'"
         dan "Ukendt database '%-.192s'"
-        nla "Onbekende database '%-.192s'"
         eng "Unknown database '%-.192s'"
         est "Tundmatu andmebaas '%-.192s'"
         fre "Base '%-.192s' inconnue"
@@ -1160,6 +1204,7 @@ ER_BAD_DB_ERROR 42000
         ita "Database '%-.192s' sconosciuto"
         jpn "'%-.192s' は不明なデータベースです。"
         kor "데이타베이스 '%-.192s'는 알수 없음"
+        nla "Onbekende database '%-.192s'"
         nor "Ukjent database '%-.192s'"
         norwegian-ny "Ukjent database '%-.192s'"
         pol "Nieznana baza danych '%-.192s'"
@@ -1172,9 +1217,9 @@ ER_BAD_DB_ERROR 42000
         swe "Okänd databas: '%-.192s'"
         ukr "Невідома база данних '%-.192s'"
 ER_TABLE_EXISTS_ERROR 42S01 
+        chi "表'%-.192s'已经存在"
         cze "Tabulka '%-.192s' již existuje"
         dan "Tabellen '%-.192s' findes allerede"
-        nla "Tabel '%-.192s' bestaat al"
         eng "Table '%-.192s' already exists"
         est "Tabel '%-.192s' juba eksisteerib"
         fre "La table '%-.192s' existe déjà"
@@ -1185,6 +1230,7 @@ ER_TABLE_EXISTS_ERROR 42S01
         ita "La tabella '%-.192s' esiste gia`"
         jpn "表 '%-.192s' はすでに存在します。"
         kor "테이블 '%-.192s'는 이미 존재함"
+        nla "Tabel '%-.192s' bestaat al"
         nor "Tabellen '%-.192s' eksisterer allerede"
         norwegian-ny "Tabellen '%-.192s' eksisterar allereide"
         pol "Tabela '%-.192s' już istnieje"
@@ -1197,9 +1243,9 @@ ER_TABLE_EXISTS_ERROR 42S01
         swe "Tabellen '%-.192s' finns redan"
         ukr "Таблиця '%-.192s' вже існує"
 ER_BAD_TABLE_ERROR 42S02 
+        chi "未知表'%-.100T'"
         cze "Neznámá tabulka '%-.100T'"
         dan "Ukendt tabel '%-.100T'"
-        nla "Onbekende tabel '%-.100T'"
         eng "Unknown table '%-.100T'"
         est "Tundmatu tabel '%-.100T'"
         fre "Table '%-.100T' inconnue"
@@ -1210,6 +1256,7 @@ ER_BAD_TABLE_ERROR 42S02
         ita "Tabella '%-.100T' sconosciuta"
         jpn "'%-.100T' は不明な表です。"
         kor "테이블 '%-.100T'는 알수 없음"
+        nla "Onbekende tabel '%-.100T'"
         nor "Ukjent tabell '%-.100T'"
         norwegian-ny "Ukjent tabell '%-.100T'"
         pol "Nieznana tabela '%-.100T'"
@@ -1222,9 +1269,9 @@ ER_BAD_TABLE_ERROR 42S02
         swe "Okänd tabell '%-.100T'"
         ukr "Невідома таблиця '%-.100T'"
 ER_NON_UNIQ_ERROR 23000 
+        chi "列名 '%-.192s' 在 %-.192s 定义模糊"
         cze "Sloupec '%-.192s' v %-.192s není zcela jasný"
         dan "Felt: '%-.192s' i tabel %-.192s er ikke entydigt"
-        nla "Kolom: '%-.192s' in %-.192s is niet eenduidig"
         eng "Column '%-.192s' in %-.192s is ambiguous"
         est "Väli '%-.192s' %-.192s-s ei ole ühene"
         fre "Champ: '%-.192s' dans %-.192s est ambigu"
@@ -1235,6 +1282,7 @@ ER_NON_UNIQ_ERROR 23000
         ita "Colonna: '%-.192s' di %-.192s e` ambigua"
         jpn "列 '%-.192s' は %-.192s 内で曖昧です。"
         kor "칼럼: '%-.192s' in '%-.192s' 이 모호함"
+        nla "Kolom: '%-.192s' in %-.192s is niet eenduidig"
         nor "Felt: '%-.192s' i tabell %-.192s er ikke entydig"
         norwegian-ny "Kolonne: '%-.192s' i tabell %-.192s er ikkje eintydig"
         pol "Kolumna: '%-.192s' w  %-.192s jest dwuznaczna"
@@ -1247,9 +1295,9 @@ ER_NON_UNIQ_ERROR 23000
         swe "Kolumn '%-.192s' i %-.192s är inte unik"
         ukr "Стовбець '%-.192s' у %-.192s визначений неоднозначно"
 ER_SERVER_SHUTDOWN 08S01 
+        chi "服务器正在关闭"
         cze "Probíhá ukončování práce serveru"
         dan "Database nedlukning er i gang"
-        nla "Bezig met het stoppen van de server"
         eng "Server shutdown in progress"
         est "Serveri seiskamine käib"
         fre "Arrêt du serveur en cours"
@@ -1260,6 +1308,7 @@ ER_SERVER_SHUTDOWN 08S01
         ita "Shutdown del server in corso"
         jpn "サーバーをシャットダウン中です。"
         kor "Server가 셧다운 중입니다."
+        nla "Bezig met het stoppen van de server"
         nor "Database nedkobling er i gang"
         norwegian-ny "Tenar nedkopling er i gang"
         pol "Trwa kończenie działania serwera"
@@ -1272,9 +1321,9 @@ ER_SERVER_SHUTDOWN 08S01
         swe "Servern går nu ned"
         ukr "Завершується работа сервера"
 ER_BAD_FIELD_ERROR 42S22 S0022
+        chi "未知列'%-.192s'在'%-.192s'"
         cze "Neznámý sloupec '%-.192s' v %-.192s"
         dan "Ukendt kolonne '%-.192s' i tabel %-.192s"
-        nla "Onbekende kolom '%-.192s' in %-.192s"
         eng "Unknown column '%-.192s' in '%-.192s'"
         est "Tundmatu tulp '%-.192s' '%-.192s'-s"
         fre "Champ '%-.192s' inconnu dans %-.192s"
@@ -1285,6 +1334,7 @@ ER_BAD_FIELD_ERROR 42S22 S0022
         ita "Colonna sconosciuta '%-.192s' in '%-.192s'"
         jpn "列 '%-.192s' は '%-.192s' にはありません。"
         kor "Unknown 칼럼 '%-.192s' in '%-.192s'"
+        nla "Onbekende kolom '%-.192s' in %-.192s"
         nor "Ukjent kolonne '%-.192s' i tabell %-.192s"
         norwegian-ny "Ukjent felt '%-.192s' i tabell %-.192s"
         pol "Nieznana kolumna '%-.192s' w  %-.192s"
@@ -1297,9 +1347,9 @@ ER_BAD_FIELD_ERROR 42S22 S0022
         swe "Okänd kolumn '%-.192s' i %-.192s"
         ukr "Невідомий стовбець '%-.192s' у '%-.192s'"
 ER_WRONG_FIELD_WITH_GROUP 42000 S1009
+        chi "'%-.192s' 不在 GROUP BY"
         cze "Použité '%-.192s' nebylo v group by"
         dan "Brugte '%-.192s' som ikke var i group by"
-        nla "Opdracht gebruikt '%-.192s' dat niet in de GROUP BY voorkomt"
         eng "'%-.192s' isn't in GROUP BY"
         est "'%-.192s' puudub GROUP BY klauslis"
         fre "'%-.192s' n'est pas dans 'group by'"
@@ -1310,6 +1360,7 @@ ER_WRONG_FIELD_WITH_GROUP 42000 S1009
         ita "Usato '%-.192s' che non e` nel GROUP BY"
         jpn "'%-.192s' はGROUP BY句で指定されていません。"
         kor "'%-.192s'은 GROUP BY속에 없음"
+        nla "Opdracht gebruikt '%-.192s' dat niet in de GROUP BY voorkomt"
         nor "Brukte '%-.192s' som ikke var i group by"
         norwegian-ny "Brukte '%-.192s' som ikkje var i group by"
         pol "Użyto '%-.192s' bez umieszczenia w group by"
@@ -1322,9 +1373,9 @@ ER_WRONG_FIELD_WITH_GROUP 42000 S1009
         swe "'%-.192s' finns inte i GROUP BY"
         ukr "'%-.192s' не є у GROUP BY"
 ER_WRONG_GROUP_FIELD 42000 S1009
+        chi "不能在'%-.192s'上分组"
         cze "Nemohu použít group na '%-.192s'"
         dan "Kan ikke gruppere på '%-.192s'"
-        nla "Kan '%-.192s' niet groeperen"
         eng "Can't group on '%-.192s'"
         est "Ei saa grupeerida '%-.192s' järgi"
         fre "Ne peut regrouper '%-.192s'"
@@ -1335,6 +1386,7 @@ ER_WRONG_GROUP_FIELD 42000 S1009
         ita "Impossibile raggruppare per '%-.192s'"
         jpn "'%-.192s' でのグループ化はできません。"
         kor "'%-.192s'를 그룹할 수 없음"
+        nla "Kan '%-.192s' niet groeperen"
         nor "Kan ikke gruppere på '%-.192s'"
         norwegian-ny "Kan ikkje gruppere på '%-.192s'"
         pol "Nie można grupować po '%-.192s'"
@@ -1347,9 +1399,9 @@ ER_WRONG_GROUP_FIELD 42000 S1009
         swe "Kan inte använda GROUP BY med '%-.192s'"
         ukr "Не можу групувати по '%-.192s'"
 ER_WRONG_SUM_SELECT 42000 S1009
+        chi "语句在同一语句里有求和函数和列"
         cze "Příkaz obsahuje zároveň funkci sum a sloupce"
         dan "Udtrykket har summer (sum) funktioner og kolonner i samme udtryk"
-        nla "Opdracht heeft totaliseer functies en kolommen in dezelfde opdracht"
         eng "Statement has sum functions and columns in same statement"
         est "Lauses on korraga nii tulbad kui summeerimisfunktsioonid"
         fre "Vous demandez la fonction sum() et des champs dans la même commande"
@@ -1358,6 +1410,7 @@ ER_WRONG_SUM_SELECT 42000 S1009
         ita "Il comando ha una funzione SUM e una colonna non specificata nella GROUP BY"
         jpn "集計関数と通常の列が同時に指定されています。"
         kor "Statement 가 sum기능을 동작중이고 칼럼도 동일한 statement입니다."
+        nla "Opdracht heeft totaliseer functies en kolommen in dezelfde opdracht"
         nor "Uttrykket har summer (sum) funksjoner og kolonner i samme uttrykk"
         norwegian-ny "Uttrykket har summer (sum) funksjoner og kolonner i same uttrykk"
         pol "Zapytanie ma funkcje sumuj?ce i kolumny w tym samym zapytaniu"
@@ -1370,9 +1423,9 @@ ER_WRONG_SUM_SELECT 42000 S1009
         swe "Kommandot har både sum functions och enkla funktioner"
         ukr "У виразі використано підсумовуючі функції поряд з іменами стовбців"
 ER_WRONG_VALUE_COUNT 21S01 
+        chi "列数与值数不匹配"
         cze "Počet sloupců neodpovídá zadané hodnotě"
         dan "Kolonne tæller stemmer ikke med antallet af værdier"
-        nla "Het aantal kolommen komt niet overeen met het aantal opgegeven waardes"
         eng "Column count doesn't match value count"
         est "Tulpade arv erineb väärtuste arvust"
         ger "Die Anzahl der Spalten entspricht nicht der Anzahl der Werte"
@@ -1382,6 +1435,7 @@ ER_WRONG_VALUE_COUNT 21S01
         ita "Il numero delle colonne non e` uguale al numero dei valori"
         jpn "列数が値の個数と一致しません。"
         kor "칼럼의 카운트가 값의 카운트와 일치하지 않습니다."
+        nla "Het aantal kolommen komt niet overeen met het aantal opgegeven waardes"
         nor "Felt telling stemmer verdi telling"
         norwegian-ny "Kolonne telling stemmer verdi telling"
         pol "Liczba kolumn nie odpowiada liczbie warto?ci"
@@ -1394,9 +1448,9 @@ ER_WRONG_VALUE_COUNT 21S01
         swe "Antalet kolumner motsvarar inte antalet värden"
         ukr "Кількість стовбців не співпадає з кількістю значень"
 ER_TOO_LONG_IDENT 42000 S1009
+        chi "标识符'%-.100T'太长"
         cze "Jméno identifikátoru '%-.100T' je příliš dlouhé"
         dan "Navnet '%-.100T' er for langt"
-        nla "Naam voor herkenning '%-.100T' is te lang"
         eng "Identifier name '%-.100T' is too long"
         est "Identifikaatori '%-.100T' nimi on liiga pikk"
         fre "Le nom de l'identificateur '%-.100T' est trop long"
@@ -1407,6 +1461,7 @@ ER_TOO_LONG_IDENT 42000 S1009
         ita "Il nome dell'identificatore '%-.100T' e` troppo lungo"
         jpn "識別子名 '%-.100T' は長すぎます。"
         kor "Identifier '%-.100T'는 너무 길군요."
+        nla "Naam voor herkenning '%-.100T' is te lang"
         nor "Identifikator '%-.100T' er for lang"
         norwegian-ny "Identifikator '%-.100T' er for lang"
         pol "Nazwa identyfikatora '%-.100T' jest zbyt długa"
@@ -1419,9 +1474,9 @@ ER_TOO_LONG_IDENT 42000 S1009
         swe "Kolumnnamn '%-.100T' är för långt"
         ukr "Ім'я ідентифікатора '%-.100T' задовге"
 ER_DUP_FIELDNAME 42S21 S1009
+        chi "列名重复 '%-.192s'"
         cze "Zdvojené jméno sloupce '%-.192s'"
         dan "Feltnavnet '%-.192s' findes allerede"
-        nla "Dubbele kolom naam '%-.192s'"
         eng "Duplicate column name '%-.192s'"
         est "Kattuv tulba nimi '%-.192s'"
         fre "Nom du champ '%-.192s' déjà utilisé"
@@ -1432,6 +1487,7 @@ ER_DUP_FIELDNAME 42S21 S1009
         ita "Nome colonna duplicato '%-.192s'"
         jpn "列名 '%-.192s' は重複してます。"
         kor "중복된 칼럼 이름: '%-.192s'"
+        nla "Dubbele kolom naam '%-.192s'"
         nor "Feltnavnet '%-.192s' eksisterte fra før"
         norwegian-ny "Feltnamnet '%-.192s' eksisterte frå før"
         pol "Powtórzona nazwa kolumny '%-.192s'"
@@ -1444,9 +1500,9 @@ ER_DUP_FIELDNAME 42S21 S1009
         swe "Kolumnnamn '%-.192s finns flera gånger"
         ukr "Дублююче ім'я стовбця '%-.192s'"
 ER_DUP_KEYNAME 42000 S1009
+        chi "索引名重复 '%-.192s'"
         cze "Zdvojené jméno klíče '%-.192s'"
         dan "Indeksnavnet '%-.192s' findes allerede"
-        nla "Dubbele zoeksleutel naam '%-.192s'"
         eng "Duplicate key name '%-.192s'"
         est "Kattuv võtme nimi '%-.192s'"
         fre "Nom de clef '%-.192s' déjà utilisé"
@@ -1457,6 +1513,7 @@ ER_DUP_KEYNAME 42000 S1009
         ita "Nome chiave duplicato '%-.192s'"
         jpn "索引名 '%-.192s' は重複しています。"
         kor "중복된 키 이름 : '%-.192s'"
+        nla "Dubbele zoeksleutel naam '%-.192s'"
         nor "Nøkkelnavnet '%-.192s' eksisterte fra før"
         norwegian-ny "Nøkkelnamnet '%-.192s' eksisterte frå før"
         pol "Powtórzony nazwa klucza '%-.192s'"
@@ -1471,34 +1528,35 @@ ER_DUP_KEYNAME 42000 S1009
 # When using this error code, please use ER(ER_DUP_ENTRY_WITH_KEY_NAME)
 # for the message string.  See, for example, code in handler.cc.
 ER_DUP_ENTRY 23000 S1009
-	cze "Zdvojený klíč '%-.192T' (číslo klíče %d)"
-	dan "Ens værdier '%-.192T' for indeks %d"
-	nla "Dubbele ingang '%-.192T' voor zoeksleutel %d"
-	eng "Duplicate entry '%-.192T' for key %d"
-	est "Kattuv väärtus '%-.192T' võtmele %d"
-	fre "Duplicata du champ '%-.192T' pour la clef %d"
-	ger "Doppelter Eintrag '%-.192T' für Schlüssel %d"
-	greek "Διπλή εγγραφή '%-.192T' για το κλειδί %d"
+	chi "重复条目'%-.192T'在索引%d"
+        cze "Zdvojený klíč '%-.192T' (číslo klíče %d)"
+        dan "Ens værdier '%-.192T' for indeks %d"
+        eng "Duplicate entry '%-.192T' for key %d"
+        est "Kattuv väärtus '%-.192T' võtmele %d"
+        fre "Duplicata du champ '%-.192T' pour la clef %d"
+        ger "Doppelter Eintrag '%-.192T' für Schlüssel %d"
+        greek "Διπλή εγγραφή '%-.192T' για το κλειδί %d"
         hindi "सामान प्रवेश '%-.192T' KEY %d के लिए"
-	hun "Duplikalt bejegyzes '%-.192T' a %d kulcs szerint"
-	ita "Valore duplicato '%-.192T' per la chiave %d"
-	jpn "'%-.192T' は索引 %d で重複しています。"
-	kor "중복된 입력 값 '%-.192T': key %d"
-	nor "Like verdier '%-.192T' for nøkkel %d"
-	norwegian-ny "Like verdiar '%-.192T' for nykkel %d"
-	pol "Powtórzone wystąpienie '%-.192T' dla klucza %d"
-	por "Entrada '%-.192T' duplicada para a chave %d"
-	rum "Cimpul '%-.192T' e duplicat pentru cheia %d"
-	rus "Дублирующаяся запись '%-.192T' по ключу %d"
-	serbian "Dupliran unos '%-.192T' za ključ '%d'"
-	slo "Opakovaný kľúč '%-.192T' (číslo kľúča %d)"
-	spa "Entrada duplicada '%-.192T' para la clave %d"
-	swe "Dublett '%-.192T' för nyckel %d"
-	ukr "Дублюючий запис '%-.192T' для ключа %d"
+        hun "Duplikalt bejegyzes '%-.192T' a %d kulcs szerint"
+        ita "Valore duplicato '%-.192T' per la chiave %d"
+        jpn "'%-.192T' は索引 %d で重複しています。"
+        kor "중복된 입력 값 '%-.192T': key %d"
+        nla "Dubbele ingang '%-.192T' voor zoeksleutel %d"
+        nor "Like verdier '%-.192T' for nøkkel %d"
+        norwegian-ny "Like verdiar '%-.192T' for nykkel %d"
+        pol "Powtórzone wystąpienie '%-.192T' dla klucza %d"
+        por "Entrada '%-.192T' duplicada para a chave %d"
+        rum "Cimpul '%-.192T' e duplicat pentru cheia %d"
+        rus "Дублирующаяся запись '%-.192T' по ключу %d"
+        serbian "Dupliran unos '%-.192T' za ključ '%d'"
+        slo "Opakovaný kľúč '%-.192T' (číslo kľúča %d)"
+        spa "Entrada duplicada '%-.192T' para la clave %d"
+        swe "Dublett '%-.192T' för nyckel %d"
+        ukr "Дублюючий запис '%-.192T' для ключа %d"
 ER_WRONG_FIELD_SPEC 42000 S1009
+        chi "列的说明符不对 '%-.192s'"
         cze "Chybná specifikace sloupce '%-.192s'"
         dan "Forkert kolonnespecifikaton for felt '%-.192s'"
-        nla "Verkeerde kolom specificatie voor kolom '%-.192s'"
         eng "Incorrect column specifier for column '%-.192s'"
         est "Vigane tulba kirjeldus tulbale '%-.192s'"
         fre "Mauvais paramètre de champ pour le champ '%-.192s'"
@@ -1509,6 +1567,7 @@ ER_WRONG_FIELD_SPEC 42000 S1009
         ita "Specifica errata per la colonna '%-.192s'"
         jpn "列 '%-.192s' の定義が不正です。"
         kor "칼럼 '%-.192s'의 부정확한 칼럼 정의자"
+        nla "Verkeerde kolom specificatie voor kolom '%-.192s'"
         nor "Feil kolonne spesifikator for felt '%-.192s'"
         norwegian-ny "Feil kolonne spesifikator for kolonne '%-.192s'"
         pol "Błędna specyfikacja kolumny dla kolumny '%-.192s'"
@@ -1521,9 +1580,9 @@ ER_WRONG_FIELD_SPEC 42000 S1009
         swe "Felaktigt kolumntyp för kolumn '%-.192s'"
         ukr "Невірний специфікатор стовбця '%-.192s'"
 ER_PARSE_ERROR 42000 s1009
+        chi "%s 附近'%-.80T'在第%d行"
         cze "%s blízko '%-.80T' na řádku %d"
         dan "%s nær '%-.80T' på linje %d"
-        nla "%s bij '%-.80T' in regel %d"
         eng "%s near '%-.80T' at line %d"
         est "%s '%-.80T' ligidal real %d"
         fre "%s près de '%-.80T' à la ligne %d"
@@ -1534,6 +1593,7 @@ ER_PARSE_ERROR 42000 s1009
         ita "%s vicino a '%-.80T' linea %d"
         jpn "%s : '%-.80T' 付近 %d 行目"
         kor "'%s' 에러 같습니다. ('%-.80T' 명령어 라인 %d)"
+        nla "%s bij '%-.80T' in regel %d"
         nor "%s nær '%-.80T' på linje %d"
         norwegian-ny "%s attmed '%-.80T' på line %d"
         pol "%s obok '%-.80T' w linii %d"
@@ -1546,9 +1606,9 @@ ER_PARSE_ERROR 42000 s1009
         swe "%s nära '%-.80T' på rad %d"
         ukr "%s біля '%-.80T' в строці %d"
 ER_EMPTY_QUERY 42000  
+        chi "查询为空"
         cze "Výsledek dotazu je prázdný"
         dan "Forespørgsel var tom"
-        nla "Query was leeg"
         eng "Query was empty"
         est "Tühi päring"
         fre "Query est vide"
@@ -1559,6 +1619,7 @@ ER_EMPTY_QUERY 42000
         ita "La query e` vuota"
         jpn "クエリが空です。"
         kor "쿼리결과가 없습니다."
+        nla "Query was leeg"
         nor "Forespørsel var tom"
         norwegian-ny "Førespurnad var tom"
         pol "Zapytanie było puste"
@@ -1571,9 +1632,9 @@ ER_EMPTY_QUERY 42000
         swe "Frågan var tom"
         ukr "Пустий запит"
 ER_NONUNIQ_TABLE 42000 S1009
+        chi "表或别名不唯一:'%-.192s'"
         cze "Nejednoznačná tabulka/alias: '%-.192s'"
         dan "Tabellen/aliaset: '%-.192s' er ikke unikt"
-        nla "Niet unieke waarde tabel/alias: '%-.192s'"
         eng "Not unique table/alias: '%-.192s'"
         est "Ei ole unikaalne tabel/alias '%-.192s'"
         fre "Table/alias: '%-.192s' non unique"
@@ -1584,6 +1645,7 @@ ER_NONUNIQ_TABLE 42000 S1009
         ita "Tabella/alias non unico: '%-.192s'"
         jpn "表名／別名 '%-.192s' は一意ではありません。"
         kor "Unique 하지 않은 테이블/alias: '%-.192s'"
+        nla "Niet unieke waarde tabel/alias: '%-.192s'"
         nor "Ikke unikt tabell/alias: '%-.192s'"
         norwegian-ny "Ikkje unikt tabell/alias: '%-.192s'"
         pol "Tabela/alias nie s? unikalne: '%-.192s'"
@@ -1596,9 +1658,9 @@ ER_NONUNIQ_TABLE 42000 S1009
         swe "Icke unikt tabell/alias: '%-.192s'"
         ukr "Неунікальна таблиця/псевдонім: '%-.192s'"
 ER_INVALID_DEFAULT 42000 S1009
+        chi "'%-.192s'的默认值无效"
         cze "Chybná defaultní hodnota pro '%-.192s'"
         dan "Ugyldig standardværdi for '%-.192s'"
-        nla "Foutieve standaard waarde voor '%-.192s'"
         eng "Invalid default value for '%-.192s'"
         est "Vigane vaikeväärtus '%-.192s' jaoks"
         fre "Valeur par défaut invalide pour '%-.192s'"
@@ -1609,6 +1671,7 @@ ER_INVALID_DEFAULT 42000 S1009
         ita "Valore di default non valido per '%-.192s'"
         jpn "'%-.192s' へのデフォルト値が無効です。"
         kor "'%-.192s'의 유효하지 못한 디폴트 값을 사용하셨습니다."
+        nla "Foutieve standaard waarde voor '%-.192s'"
         nor "Ugyldig standardverdi for '%-.192s'"
         norwegian-ny "Ugyldig standardverdi for '%-.192s'"
         pol "Niewła?ciwa warto?ć domy?lna dla '%-.192s'"
@@ -1621,9 +1684,9 @@ ER_INVALID_DEFAULT 42000 S1009
         swe "Ogiltigt DEFAULT värde för '%-.192s'"
         ukr "Невірне значення по замовчуванню для '%-.192s'"
 ER_MULTIPLE_PRI_KEY 42000 S1009
+        chi "定义了多个主键"
         cze "Definováno více primárních klíčů"
         dan "Flere primærnøgler specificeret"
-        nla "Meerdere primaire zoeksleutels gedefinieerd"
         eng "Multiple primary key defined"
         est "Mitut primaarset võtit ei saa olla"
         fre "Plusieurs clefs primaires définies"
@@ -1634,6 +1697,7 @@ ER_MULTIPLE_PRI_KEY 42000 S1009
         ita "Definite piu` chiave primarie"
         jpn "PRIMARY KEY が複数定義されています。"
         kor "Multiple primary key가 정의되어 있슴"
+        nla "Meerdere primaire zoeksleutels gedefinieerd"
         nor "Fleire primærnøkle spesifisert"
         norwegian-ny "Fleire primærnyklar spesifisert"
         pol "Zdefiniowano wiele kluczy podstawowych"
@@ -1646,19 +1710,20 @@ ER_MULTIPLE_PRI_KEY 42000 S1009
         swe "Flera PRIMARY KEY använda"
         ukr "Первинного ключа визначено неодноразово"
 ER_TOO_MANY_KEYS 42000 S1009
+        chi "定义的索引太多; 最多允许%d 个索引"
         cze "Zadáno příliš mnoho klíčů, je povoleno nejvíce %d klíčů"
         dan "For mange nøgler specificeret. Kun %d nøgler må bruges"
-        nla "Teveel zoeksleutels gedefinieerd. Maximaal zijn %d zoeksleutels toegestaan"
         eng "Too many keys specified; max %d keys allowed"
         est "Liiga palju võtmeid. Maksimaalselt võib olla %d võtit"
         fre "Trop de clefs sont définies. Maximum de %d clefs alloué"
         ger "Zu viele Schlüssel definiert. Maximal %d Schlüssel erlaubt"
         greek "Πάρα πολλά key ορίσθηκαν. Το πολύ %d επιτρέπονται"
-        hun "Tul sok kulcs. Maximum %d kulcs engedelyezett"
         hindi "बहुत सारी KEYS निर्दिष्ट हैं; अधिकतम %d KEYS की अनुमति है"
+        hun "Tul sok kulcs. Maximum %d kulcs engedelyezett"
         ita "Troppe chiavi. Sono ammesse max %d chiavi"
         jpn "索引の数が多すぎます。最大 %d 個までです。"
         kor "너무 많은 키가 정의되어 있습니다.. 최대 %d의 키가 가능함"
+        nla "Teveel zoeksleutels gedefinieerd. Maximaal zijn %d zoeksleutels toegestaan"
         nor "For mange nøkler spesifisert. Maks %d nøkler tillatt"
         norwegian-ny "For mange nykler spesifisert. Maks %d nyklar tillatt"
         pol "Okre?lono zbyt wiele kluczy. Dostępnych jest maksymalnie %d kluczy"
@@ -1671,9 +1736,9 @@ ER_TOO_MANY_KEYS 42000 S1009
         swe "För många nycklar använda. Man får ha högst %d nycklar"
         ukr "Забагато ключів зазначено. Дозволено не більше %d ключів"
 ER_TOO_MANY_KEY_PARTS 42000 S1009
+        chi "指定的索引部分过多; 最多允许%d个部分"
         cze "Zadáno příliš mnoho část klíčů, je povoleno nejvíce %d částí"
         dan "For mange nøgledele specificeret. Kun %d dele må bruges"
-        nla "Teveel zoeksleutel onderdelen gespecificeerd. Maximaal %d onderdelen toegestaan"
         eng "Too many key parts specified; max %d parts allowed"
         est "Võti koosneb liiga paljudest osadest. Maksimaalselt võib olla %d osa"
         fre "Trop de parties specifiées dans la clef. Maximum de %d parties"
@@ -1684,6 +1749,7 @@ ER_TOO_MANY_KEY_PARTS 42000 S1009
         ita "Troppe parti di chiave specificate. Sono ammesse max %d parti"
         jpn "索引のキー列指定が多すぎます。最大 %d 個までです。"
         kor "너무 많은 키 부분(parts)들이 정의되어 있습니다.. 최대 %d 부분이 가능함"
+        nla "Teveel zoeksleutel onderdelen gespecificeerd. Maximaal %d onderdelen toegestaan"
         nor "For mange nøkkeldeler spesifisert. Maks %d deler tillatt"
         norwegian-ny "For mange nykkeldelar spesifisert. Maks %d delar tillatt"
         pol "Okre?lono zbyt wiele czę?ci klucza. Dostępnych jest maksymalnie %d czę?ci"
@@ -1696,9 +1762,9 @@ ER_TOO_MANY_KEY_PARTS 42000 S1009
         swe "För många nyckeldelar använda. Man får ha högst %d nyckeldelar"
         ukr "Забагато частин ключа зазначено. Дозволено не більше %d частин"
 ER_TOO_LONG_KEY 42000 S1009
+        chi "指定索引太长; 最大索引长度是 %d字节"
         cze "Zadaný klíč byl příliš dlouhý, největší délka klíče je %d"
         dan "Specificeret nøgle var for lang. Maksimal nøglelængde er %d"
-        nla "Gespecificeerde zoeksleutel was te lang. De maximale lengte is %d"
         eng "Specified key was too long; max key length is %d bytes"
         est "Võti on liiga pikk. Maksimaalne võtmepikkus on %d"
         fre "La clé est trop longue. Longueur maximale: %d"
@@ -1709,6 +1775,7 @@ ER_TOO_LONG_KEY 42000 S1009
         ita "La chiave specificata e` troppo lunga. La max lunghezza della chiave e` %d"
         jpn "索引のキーが長すぎます。最大 %d バイトまでです。"
         kor "정의된 키가 너무 깁니다. 최대 키의 길이는 %d입니다."
+        nla "Gespecificeerde zoeksleutel was te lang. De maximale lengte is %d"
         nor "Spesifisert nøkkel var for lang. Maks nøkkellengde er is %d"
         norwegian-ny "Spesifisert nykkel var for lang. Maks nykkellengde er %d"
         pol "Zdefinowany klucz jest zbyt długi. Maksymaln? długo?ci? klucza jest %d"
@@ -1721,9 +1788,9 @@ ER_TOO_LONG_KEY 42000 S1009
         swe "För lång nyckel. Högsta tillåtna nyckellängd är %d"
         ukr "Зазначений ключ задовгий. Найбільша довжина ключа %d байтів"
 ER_KEY_COLUMN_DOES_NOT_EXITS 42000 S1009
+        chi "索引列'%-.192s'不在表里"
         cze "Klíčový sloupec '%-.192s' v tabulce neexistuje"
         dan "Nøglefeltet '%-.192s' eksisterer ikke i tabellen"
-        nla "Zoeksleutel kolom '%-.192s' bestaat niet in tabel"
         eng "Key column '%-.192s' doesn't exist in table"
         est "Võtme tulp '%-.192s' puudub tabelis"
         fre "La clé '%-.192s' n'existe pas dans la table"
@@ -1734,6 +1801,7 @@ ER_KEY_COLUMN_DOES_NOT_EXITS 42000 S1009
         ita "La colonna chiave '%-.192s' non esiste nella tabella"
         jpn "キー列 '%-.192s' は表にありません。"
         kor "Key 칼럼 '%-.192s'는 테이블에 존재하지 않습니다."
+        nla "Zoeksleutel kolom '%-.192s' bestaat niet in tabel"
         nor "Nøkkel felt '%-.192s' eksiterer ikke i tabellen"
         norwegian-ny "Nykkel kolonne '%-.192s' eksiterar ikkje i tabellen"
         pol "Kolumna '%-.192s' zdefiniowana w kluczu nie istnieje w tabeli"
@@ -1746,15 +1814,16 @@ ER_KEY_COLUMN_DOES_NOT_EXITS 42000 S1009
         swe "Nyckelkolumn '%-.192s' finns inte"
         ukr "Ключовий стовбець '%-.192s' не існує у таблиці"
 ER_BLOB_USED_AS_KEY 42000 S1009
+        chi "索引里不能含有BLOB列%`s表%s"
         eng "BLOB column %`s can't be used in key specification in the %s table"
         ger "BLOB-Feld %`s kann beim %s Tabellen nicht als Schlüssel verwendet werden"
         hindi "BLOB कॉलम %`s टेबल %s में KEY विनिर्देश में इस्तेमाल नहीं किया जा सकता"
         rus "Столбец типа BLOB %`s не может быть использован как значение ключа в %s таблице"
         ukr "BLOB стовбець %`s не може бути використаний у визначенні ключа в %s таблиці"
 ER_TOO_BIG_FIELDLENGTH 42000 S1009
+        chi "数据太长超过列容量 '%-.192s' (最长 = %lu); 用 BLOB 或 TEXT 替代"
         cze "Příliš velká délka sloupce '%-.192s' (nejvíce %lu). Použijte BLOB"
         dan "For stor feltlængde for kolonne '%-.192s' (maks = %lu). Brug BLOB i stedet"
-        nla "Te grote kolomlengte voor '%-.192s' (max = %lu). Maak hiervoor gebruik van het type BLOB"
         eng "Column length too big for column '%-.192s' (max = %lu); use BLOB or TEXT instead"
         est "Tulba '%-.192s' pikkus on liiga pikk (maksimaalne pikkus: %lu). Kasuta BLOB väljatüüpi"
         fre "Champ '%-.192s' trop long (max = %lu). Utilisez un BLOB"
@@ -1765,6 +1834,7 @@ ER_TOO_BIG_FIELDLENGTH 42000 S1009
         ita "La colonna '%-.192s' e` troppo grande (max=%lu). Utilizza un BLOB"
         jpn "列 '%-.192s' のサイズ定義が大きすぎます (最大 %lu まで)。代わりに BLOB または TEXT を使用してください。"
         kor "칼럼 '%-.192s'의 칼럼 길이가 너무 깁니다 (최대 = %lu). 대신에 BLOB를 사용하세요."
+        nla "Te grote kolomlengte voor '%-.192s' (max = %lu). Maak hiervoor gebruik van het type BLOB"
         nor "For stor nøkkellengde for kolonne '%-.192s' (maks = %lu). Bruk BLOB istedenfor"
         norwegian-ny "For stor nykkellengde for felt '%-.192s' (maks = %lu). Bruk BLOB istadenfor"
         pol "Zbyt duża długo?ć kolumny '%-.192s' (maks. = %lu). W zamian użyj typu BLOB"
@@ -1777,9 +1847,9 @@ ER_TOO_BIG_FIELDLENGTH 42000 S1009
         swe "För stor kolumnlängd angiven för '%-.192s' (max= %lu). Använd en BLOB instället"
         ukr "Задовга довжина стовбця '%-.192s' (max = %lu). Використайте тип BLOB"
 ER_WRONG_AUTO_KEY 42000 S1009
+        chi "表定义不正确；只能有一个自动列，并且必须将其定义为索引"
         cze "Můžete mít pouze jedno AUTO pole a to musí být definováno jako klíč"
         dan "Der kan kun specificeres eet AUTO_INCREMENT-felt, og det skal være indekseret"
-        nla "Er kan slechts 1 autofield zijn en deze moet als zoeksleutel worden gedefinieerd"
         eng "Incorrect table definition; there can be only one auto column and it must be defined as a key"
         est "Vigane tabelikirjeldus; Tabelis tohib olla üks auto_increment tüüpi tulp ning see peab olema defineeritud võtmena"
         fre "Un seul champ automatique est permis et il doit être indexé"
@@ -1790,6 +1860,7 @@ ER_WRONG_AUTO_KEY 42000 S1009
         ita "Puo` esserci solo un campo AUTO e deve essere definito come chiave"
         jpn "不正な表定義です。AUTO_INCREMENT列は１個までで、索引を定義する必要があります。"
         kor "부정확한 테이블 정의; 테이블은 하나의 auto 칼럼이 존재하고 키로 정의되어져야 합니다."
+        nla "Er kan slechts 1 autofield zijn en deze moet als zoeksleutel worden gedefinieerd"
         nor "Bare ett auto felt kan være definert som nøkkel"
         norwegian-ny "Bare eitt auto felt kan være definert som nøkkel"
         pol "W tabeli może być tylko jedno pole auto i musi ono być zdefiniowane jako klucz"
@@ -1802,12 +1873,13 @@ ER_WRONG_AUTO_KEY 42000 S1009
         swe "Det får finnas endast ett AUTO_INCREMENT-fält och detta måste vara en nyckel"
         ukr "Хибне визначення таблиці; Може бути лише один автоматичний стовбець, що повинен бути визначений як ключ"
 ER_BINLOG_CANT_DELETE_GTID_DOMAIN
-	eng "Could not delete gtid domain. Reason: %s."
+        chi "无法删除gtid域. 原因: %s."
+        eng "Could not delete gtid domain. Reason: %s."
         ukr "Не можу видалити домен gtid. Причина: %s."
 ER_NORMAL_SHUTDOWN  
+        chi "%s（%s）:正常关闭"
         cze "%s (%s): normální ukončení"
         dan "%s (%s): Normal nedlukning"
-        nla "%s (%s): Normaal afgesloten "
         eng "%s (initiated by: %s): Normal shutdown"
         est "%s (%s): MariaDB lõpetas"
         fre "%s (%s): Arrêt normal du serveur"
@@ -1818,6 +1890,7 @@ ER_NORMAL_SHUTDOWN
         ita "%s (%s): Shutdown normale"
         jpn "%s (%s): 通常シャットダウン"
         kor "%s (%s): 정상적인 shutdown"
+        nla "%s (%s): Normaal afgesloten "
         nor "%s (%s): Normal avslutning"
         norwegian-ny "%s (%s): Normal nedkopling"
         pol "%s (%s): Standardowe zakończenie działania"
@@ -1830,9 +1903,9 @@ ER_NORMAL_SHUTDOWN
         swe "%s (%s): Normal avslutning"
         ukr "%s (%s): Нормальне завершення"
 ER_GOT_SIGNAL  
+        chi "%s: 收到信号 %d. 强行中止!\n"
         cze "%s: přijat signal %d, končím\n"
         dan "%s: Fangede signal %d. Afslutter!!\n"
-        nla "%s: Signaal %d. Systeem breekt af!\n"
         eng "%s: Got signal %d. Aborting!\n"
         est "%s: sain signaali %d. Lõpetan!\n"
         fre "%s: Reçu le signal %d. Abandonne!\n"
@@ -1843,6 +1916,7 @@ ER_GOT_SIGNAL
         ita "%s: Ricevuto segnale %d. Interruzione!\n"
         jpn "%s: シグナル %d を受信しました。強制終了します！\n"
         kor "%s: %d 신호가 들어왔음. 중지!\n"
+        nla "%s: Signaal %d. Systeem breekt af!\n"
         nor "%s: Oppdaget signal %d. Avslutter!\n"
         norwegian-ny "%s: Oppdaga signal %d. Avsluttar!\n"
         pol "%s: Otrzymano sygnał %d. Kończenie działania!\n"
@@ -1855,9 +1929,9 @@ ER_GOT_SIGNAL
         swe "%s: Fick signal %d. Avslutar!\n"
         ukr "%s: Отримано сигнал %d. Перериваюсь!\n"
 ER_SHUTDOWN_COMPLETE  
+        chi "%s：关闭完成\n"
         cze "%s: ukončení práce hotovo\n"
         dan "%s: Server lukket\n"
-        nla "%s: Afsluiten afgerond\n"
         eng "%s: Shutdown complete\n"
         est "%s: Lõpp\n"
         fre "%s: Arrêt du serveur terminé\n"
@@ -1868,6 +1942,7 @@ ER_SHUTDOWN_COMPLETE
         ita "%s: Shutdown completato\n"
         jpn "%s: シャットダウン完了\n"
         kor "%s: Shutdown 이 완료됨!\n"
+        nla "%s: Afsluiten afgerond\n"
         nor "%s: Avslutning komplett\n"
         norwegian-ny "%s: Nedkopling komplett\n"
         pol "%s: Zakończenie działania wykonane\n"
@@ -1880,9 +1955,9 @@ ER_SHUTDOWN_COMPLETE
         swe "%s: Avslutning klar\n"
         ukr "%s: Роботу завершено\n"
 ER_FORCING_CLOSE 08S01 
+        chi "%s: 强行关闭线程 %ld  用户: '%-.48s'\n"
         cze "%s: násilné uzavření threadu %ld uživatele '%-.48s'\n"
         dan "%s: Forceret nedlukning af tråd: %ld  bruger: '%-.48s'\n"
-        nla "%s: Afsluiten afgedwongen van thread %ld  gebruiker: '%-.48s'\n"
         eng "%s: Forcing close of thread %ld  user: '%-.48s'\n"
         est "%s: Sulgen jõuga lõime %ld  kasutaja: '%-.48s'\n"
         fre "%s: Arrêt forcé de la tâche (thread) %ld  utilisateur: '%-.48s'\n"
@@ -1893,6 +1968,7 @@ ER_FORCING_CLOSE 08S01
         ita "%s: Forzata la chiusura del thread %ld utente: '%-.48s'\n"
         jpn "%s: スレッド %ld を強制終了します (ユーザー: '%-.48s')\n"
         kor "%s: thread %ld의 강제 종료 user: '%-.48s'\n"
+        nla "%s: Afsluiten afgedwongen van thread %ld  gebruiker: '%-.48s'\n"
         nor "%s: Påtvinget avslutning av tråd %ld  bruker: '%-.48s'\n"
         norwegian-ny "%s: Påtvinga avslutning av tråd %ld  brukar: '%-.48s'\n"
         pol "%s: Wymuszenie zamknięcia w?tku %ld  użytkownik: '%-.48s'\n"
@@ -1905,9 +1981,9 @@ ER_FORCING_CLOSE 08S01
         swe "%s: Stänger av tråd %ld; användare: '%-.48s'\n"
         ukr "%s: Прискорюю закриття гілки %ld користувача: '%-.48s'\n"
 ER_IPSOCK_ERROR 08S01 
+        chi "无法创建IP插口"
         cze "Nemohu vytvořit IP socket"
         dan "Kan ikke oprette IP socket"
-        nla "Kan IP-socket niet openen"
         eng "Can't create IP socket"
         est "Ei suuda luua IP socketit"
         fre "Ne peut créer la connexion IP (socket)"
@@ -1918,6 +1994,7 @@ ER_IPSOCK_ERROR 08S01
         ita "Impossibile creare il socket IP"
         jpn "IPソケットを作成できません。"
         kor "IP 소켓을 만들지 못했습니다."
+        nla "Kan IP-socket niet openen"
         nor "Kan ikke opprette IP socket"
         norwegian-ny "Kan ikkje opprette IP socket"
         pol "Nie można stworzyć socket'u IP"
@@ -1930,9 +2007,9 @@ ER_IPSOCK_ERROR 08S01
         swe "Kan inte skapa IP-socket"
         ukr "Не можу створити IP роз'єм"
 ER_NO_SUCH_INDEX 42S12 S1009
+        chi "表 '%-.192s' 没有像 CREATE INDEX 中使用的索引；重新创建表"
         cze "Tabulka '%-.192s' nemá index odpovídající CREATE INDEX. Vytvořte tabulku znovu"
         dan "Tabellen '%-.192s' har ikke den nøgle, som blev brugt i CREATE INDEX. Genopret tabellen"
-        nla "Tabel '%-.192s' heeft geen INDEX zoals deze gemaakt worden met CREATE INDEX. Maak de tabel opnieuw"
         eng "Table '%-.192s' has no index like the one used in CREATE INDEX; recreate the table"
         est "Tabelil '%-.192s' puuduvad võtmed. Loo tabel uuesti"
         fre "La table '%-.192s' n'a pas d'index comme celle utilisée dans CREATE INDEX. Recréez la table"
@@ -1943,6 +2020,7 @@ ER_NO_SUCH_INDEX 42S12 S1009
         ita "La tabella '%-.192s' non ha nessun indice come quello specificatato dalla CREATE INDEX. Ricrea la tabella"
         jpn "表 '%-.192s' に以前CREATE INDEXで作成された索引がありません。表を作り直してください。"
         kor "테이블 '%-.192s'는 인덱스를 만들지 않았습니다. alter 테이블명령을 이용하여 테이블을 수정하세요..."
+        nla "Tabel '%-.192s' heeft geen INDEX zoals deze gemaakt worden met CREATE INDEX. Maak de tabel opnieuw"
         nor "Tabellen '%-.192s' har ingen index som den som er brukt i CREATE INDEX. Gjenopprett tabellen"
         norwegian-ny "Tabellen '%-.192s' har ingen index som den som er brukt i CREATE INDEX. Oprett tabellen på nytt"
         pol "Tabela '%-.192s' nie ma indeksu takiego jak w CREATE INDEX. Stwórz tabelę"
@@ -1955,9 +2033,9 @@ ER_NO_SUCH_INDEX 42S12 S1009
         swe "Tabellen '%-.192s' har inget index som motsvarar det angivna i CREATE INDEX. Skapa om tabellen"
         ukr "Таблиця '%-.192s' має індекс, що не співпадає з вказанним у CREATE INDEX. Створіть таблицю знову"
 ER_WRONG_FIELD_TERMINATORS 42000 S1009
+        chi "字段分隔符参数不合预期；查看文档"
         cze "Argument separátoru položek nebyl očekáván. Přečtěte si manuál"
         dan "Felt adskiller er ikke som forventet, se dokumentationen"
-        nla "De argumenten om velden te scheiden zijn anders dan verwacht. Raadpleeg de handleiding"
         eng "Field separator argument is not what is expected; check the manual"
         est "Väljade eraldaja erineb oodatust. Tutvu kasutajajuhendiga"
         fre "Séparateur de champs inconnu.  Vérifiez dans le manuel"
@@ -1968,6 +2046,7 @@ ER_WRONG_FIELD_TERMINATORS 42000 S1009
         ita "L'argomento 'Field separator' non e` quello atteso. Controlla il manuale"
         jpn "フィールド区切り文字が予期せぬ使われ方をしています。マニュアルを確認して下さい。"
         kor "필드 구분자 인수들이 완전하지 않습니다. 메뉴얼을 찾아 보세요."
+        nla "De argumenten om velden te scheiden zijn anders dan verwacht. Raadpleeg de handleiding"
         nor "Felt skiller argumentene er ikke som forventet, se dokumentasjonen"
         norwegian-ny "Felt skiljer argumenta er ikkje som venta, sjå dokumentasjonen"
         pol "Nie oczekiwano separatora. SprawdĽ podręcznik"
@@ -1980,9 +2059,9 @@ ER_WRONG_FIELD_TERMINATORS 42000 S1009
         swe "Fältseparatorerna är vad som förväntades. Kontrollera mot manualen"
         ukr "Хибний розділювач полів. Почитайте документацію"
 ER_BLOBS_AND_NO_TERMINATED 42000 S1009
+        chi "您不能对 BLOB 使用固定的行长度；请使用 'fields terminated by'"
         cze "Není možné použít pevný rowlength s BLOBem. Použijte 'fields terminated by'"
         dan "Man kan ikke bruge faste feltlængder med BLOB. Brug i stedet 'fields terminated by'"
-        nla "Bij het gebruik van BLOBs is het niet mogelijk om vaste rijlengte te gebruiken. Maak s.v.p. gebruik van 'fields terminated by'"
         eng "You can't use fixed rowlength with BLOBs; please use 'fields terminated by'"
         est "BLOB-tüüpi väljade olemasolul ei saa kasutada fikseeritud väljapikkust. Vajalik 'fields terminated by' määrang"
         fre "Vous ne pouvez utiliser des lignes de longueur fixe avec des BLOBs. Utiliser 'fields terminated by'"
@@ -1993,6 +2072,7 @@ ER_BLOBS_AND_NO_TERMINATED 42000 S1009
         ita "Non possono essere usate righe a lunghezza fissa con i BLOB. Usa 'FIELDS TERMINATED BY'"
         jpn "BLOBには固定長レコードが使用できません。'FIELDS TERMINATED BY'句を使用して下さい。"
         kor "BLOB로는 고정길이의 lowlength를 사용할 수 없습니다. 'fields terminated by'를 사용하세요."
+        nla "Bij het gebruik van BLOBs is het niet mogelijk om vaste rijlengte te gebruiken. Maak s.v.p. gebruik van 'fields terminated by'"
         nor "En kan ikke bruke faste feltlengder med BLOB. Vennlisgt bruk 'fields terminated by'"
         norwegian-ny "Ein kan ikkje bruke faste feltlengder med BLOB. Vennlisgt bruk 'fields terminated by'"
         pol "Nie można użyć stałej długo?ci wiersza z polami typu BLOB. Użyj 'fields terminated by'"
@@ -2005,9 +2085,9 @@ ER_BLOBS_AND_NO_TERMINATED 42000 S1009
         swe "Man kan inte använda fast radlängd med blobs. Använd 'fields terminated by'"
         ukr "Не можна використовувати сталу довжину строки з BLOB. Зкористайтеся 'fields terminated by'"
 ER_TEXTFILE_NOT_READABLE  
+        chi "文件'%-.128s'必须位于数据库目录中，或所有人都可以读取"
         cze "Soubor '%-.128s' musí být v adresáři databáze nebo čitelný pro všechny"
         dan "Filen '%-.128s' skal være i database-folderen, eller kunne læses af alle"
-        nla "Het bestand '%-.128s' dient in de database directory voor the komen of leesbaar voor iedereen te zijn"
         eng "The file '%-.128s' must be in the database directory or be readable by all"
         est "Fail '%-.128s' peab asuma andmebaasi kataloogis või olema kõigile loetav"
         fre "Le fichier '%-.128s' doit être dans le répertoire de la base et lisible par tous"
@@ -2018,6 +2098,7 @@ ER_TEXTFILE_NOT_READABLE
         ita "Il file '%-.128s' deve essere nella directory del database e deve essere leggibile da tutti"
         jpn "ファイル '%-.128s' はデータベースディレクトリにあるか、全てのユーザーから読める必要があります。"
         kor "'%-.128s' 화일는 데이타베이스 디렉토리에 존재하거나 모두에게 읽기 가능하여야 합니다."
+        nla "Het bestand '%-.128s' dient in de database directory voor the komen of leesbaar voor iedereen te zijn"
         nor "Filen '%-.128s' må være i database-katalogen for å være lesbar for alle"
         norwegian-ny "Filen '%-.128s' må være i database-katalogen for å være lesbar for alle"
         pol "Plik '%-.128s' musi znajdować sie w katalogu bazy danych lub mieć prawa czytania przez wszystkich"
@@ -2030,9 +2111,9 @@ ER_TEXTFILE_NOT_READABLE
         swe "Textfilen '%-.128s' måste finnas i databasbiblioteket eller vara läsbar för alla"
         ukr "Файл '%-.128s' повинен бути у теці бази данних або мати встановлене право на читання для усіх"
 ER_FILE_EXISTS_ERROR  
+        chi "文件'%-.200s'已经存在"
         cze "Soubor '%-.200s' již existuje"
         dan "Filen '%-.200s' eksisterer allerede"
-        nla "Het bestand '%-.200s' bestaat reeds"
         eng "File '%-.200s' already exists"
         est "Fail '%-.200s' juba eksisteerib"
         fre "Le fichier '%-.200s' existe déjà"
@@ -2043,6 +2124,7 @@ ER_FILE_EXISTS_ERROR
         ita "Il file '%-.200s' esiste gia`"
         jpn "ファイル '%-.200s' はすでに存在します。"
         kor "'%-.200s' 화일은 이미 존재합니다."
+        nla "Het bestand '%-.200s' bestaat reeds"
         nor "Filen '%-.200s' eksisterte allerede"
         norwegian-ny "Filen '%-.200s' eksisterte allereide"
         pol "Plik '%-.200s' już istnieje"
@@ -2055,9 +2137,9 @@ ER_FILE_EXISTS_ERROR
         swe "Filen '%-.200s' existerar redan"
         ukr "Файл '%-.200s' вже існує"
 ER_LOAD_INFO  
+        chi "记录：%ld删除：%ld跳过：%ld警告：%ld"
         cze "Záznamů: %ld  Vymazáno: %ld  Přeskočeno: %ld  Varování: %ld"
         dan "Poster: %ld  Fjernet: %ld  Sprunget over: %ld  Advarsler: %ld"
-        nla "Records: %ld  Verwijderd: %ld  Overgeslagen: %ld  Waarschuwingen: %ld"
         eng "Records: %ld  Deleted: %ld  Skipped: %ld  Warnings: %ld"
         est "Kirjeid: %ld  Kustutatud: %ld  Vahele jäetud: %ld  Hoiatusi: %ld"
         fre "Enregistrements: %ld  Effacés: %ld  Non traités: %ld  Avertissements: %ld"
@@ -2068,6 +2150,7 @@ ER_LOAD_INFO
         ita "Records: %ld  Cancellati: %ld  Saltati: %ld  Avvertimenti: %ld"
         jpn "レコード数: %ld  削除: %ld  スキップ: %ld  警告: %ld"
         kor "레코드: %ld개  삭제: %ld개  스킵: %ld개  경고: %ld개"
+        nla "Records: %ld  Verwijderd: %ld  Overgeslagen: %ld  Waarschuwingen: %ld"
         nor "Poster: %ld  Fjernet: %ld  Hoppet over: %ld  Advarsler: %ld"
         norwegian-ny "Poster: %ld  Fjerna: %ld  Hoppa over: %ld  Åtvaringar: %ld"
         pol "Recordów: %ld  Usuniętych: %ld  Pominiętych: %ld  Ostrzeżeń: %ld"
@@ -2080,9 +2163,9 @@ ER_LOAD_INFO
         swe "Rader: %ld  Bortagna: %ld  Dubletter: %ld  Varningar: %ld"
         ukr "Записів: %ld  Видалено: %ld  Пропущено: %ld  Застережень: %ld"
 ER_ALTER_INFO  
+        chi "记录: %ld  重复: %ld"
         cze "Záznamů: %ld  Zdvojených: %ld"
         dan "Poster: %ld  Ens: %ld"
-        nla "Records: %ld  Dubbel: %ld"
         eng "Records: %ld  Duplicates: %ld"
         est "Kirjeid: %ld  Kattuvaid: %ld"
         fre "Enregistrements: %ld  Doublons: %ld"
@@ -2093,6 +2176,7 @@ ER_ALTER_INFO
         ita "Records: %ld  Duplicati: %ld"
         jpn "レコード数: %ld  重複: %ld"
         kor "레코드: %ld개  중복: %ld개"
+        nla "Records: %ld  Dubbel: %ld"
         nor "Poster: %ld  Like: %ld"
         norwegian-ny "Poster: %ld  Like: %ld"
         pol "Rekordów: %ld  Duplikatów: %ld"
@@ -2105,9 +2189,9 @@ ER_ALTER_INFO
         swe "Rader: %ld  Dubletter: %ld"
         ukr "Записів: %ld  Дублікатів: %ld"
 ER_WRONG_SUB_KEY  
+        chi "前缀索引不正确；使用的索引部分不是字符串，使用的长度比索引部分长，或者存储引擎不支持独特前缀索引"
         cze "Chybná podčást klíče -- není to řetězec nebo je delší než délka části klíče"
         dan "Forkert indeksdel. Den anvendte nøgledel er ikke en streng eller længden er større end nøglelængden"
-        nla "Foutief sub-gedeelte van de zoeksleutel. De gebruikte zoeksleutel is geen onderdeel van een string of of de gebruikte lengte is langer dan de zoeksleutel"
         eng "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys"
         est "Vigane võtme osa. Kasutatud võtmeosa ei ole string tüüpi, määratud pikkus on pikem kui võtmeosa või tabelihandler ei toeta seda tüüpi võtmeid"
         fre "Mauvaise sous-clef. Ce n'est pas un 'string' ou la longueur dépasse celle définie dans la clef"
@@ -2117,6 +2201,7 @@ ER_WRONG_SUB_KEY
         ita "Sotto-parte della chiave errata. La parte di chiave utilizzata non e` una stringa o la lunghezza e` maggiore della parte di chiave"
         jpn "キーのプレフィックスが不正です。キーが文字列ではないか、プレフィックス長がキーよりも長いか、ストレージエンジンが一意索引のプレフィックス指定をサポートしていません。"
         kor "부정확한 서버 파트 키. 사용된 키 파트가 스트링이 아니거나 키 파트의 길이가 너무 깁니다."
+        nla "Foutief sub-gedeelte van de zoeksleutel. De gebruikte zoeksleutel is geen onderdeel van een string of of de gebruikte lengte is langer dan de zoeksleutel"
         nor "Feil delnøkkel. Den brukte delnøkkelen er ikke en streng eller den oppgitte lengde er lengre enn nøkkel lengden"
         norwegian-ny "Feil delnykkel. Den brukte delnykkelen er ikkje ein streng eller den oppgitte lengda er lengre enn nykkellengden"
         pol "Błędna podczę?ć klucza. Użyta czę?ć klucza nie jest łańcuchem lub użyta długo?ć  jest większa niż czę?ć klucza"
@@ -2129,9 +2214,9 @@ ER_WRONG_SUB_KEY
         swe "Felaktig delnyckel. Nyckeldelen är inte en sträng eller den angivna längden är längre än kolumnlängden"
         ukr "Невірна частина ключа. Використана частина ключа не є строкою, задовга або вказівник таблиці не підтримує унікальних частин ключей"
 ER_CANT_REMOVE_ALL_FIELDS 42000 
+        chi "您不能使用 ALTER TABLE 删除所有列；改用 DROP TABLE"
         cze "Není možné vymazat všechny položky s ALTER TABLE. Použijte DROP TABLE"
         dan "Man kan ikke slette alle felter med ALTER TABLE. Brug DROP TABLE i stedet"
-        nla "Het is niet mogelijk alle velden te verwijderen met ALTER TABLE. Gebruik a.u.b. DROP TABLE hiervoor!"
         eng "You can't delete all columns with ALTER TABLE; use DROP TABLE instead"
         est "ALTER TABLE kasutades ei saa kustutada kõiki tulpasid. Kustuta tabel DROP TABLE abil"
         fre "Vous ne pouvez effacer tous les champs avec ALTER TABLE. Utilisez DROP TABLE"
@@ -2142,6 +2227,7 @@ ER_CANT_REMOVE_ALL_FIELDS 42000
         ita "Non si possono cancellare tutti i campi con una ALTER TABLE. Utilizzare DROP TABLE"
         jpn "ALTER TABLE では全ての列の削除はできません。DROP TABLE を使用してください。"
         kor "ALTER TABLE 명령으로는 모든 칼럼을 지울 수 없습니다. DROP TABLE 명령을 이용하세요."
+        nla "Het is niet mogelijk alle velden te verwijderen met ALTER TABLE. Gebruik a.u.b. DROP TABLE hiervoor!"
         nor "En kan ikke slette alle felt med ALTER TABLE. Bruk DROP TABLE isteden"
         norwegian-ny "Ein kan ikkje slette alle felt med ALTER TABLE. Bruk DROP TABLE istadenfor"
         pol "Nie można usun?ć wszystkich pól wykorzystuj?c ALTER TABLE. W zamian użyj DROP TABLE"
@@ -2154,9 +2240,9 @@ ER_CANT_REMOVE_ALL_FIELDS 42000
         swe "Man kan inte radera alla fält med ALTER TABLE. Använd DROP TABLE istället"
         ukr "Не можливо видалити всі стовбці за допомогою ALTER TABLE. Для цього скористайтеся DROP TABLE"
 ER_CANT_DROP_FIELD_OR_KEY 42000 
+        chi "不能 DROP %s %`-.192s; 检查它是否存在"
         cze "Nemohu zrušit (DROP %s) %`-.192s. Zkontrolujte, zda neexistují záznamy/klíče"
         dan "Kan ikke udføre DROP %s %`-.192s. Undersøg om feltet/nøglen eksisterer"
-        nla "DROP %s: Kan %`-.192s niet weggooien. Controleer of het veld of de zoeksleutel daadwerkelijk bestaat"
         eng "Can't DROP %s %`-.192s; check that it exists"
         est "Ei suuda kustutada (DROP %s) %`-.192s. Kontrolli kas tulp/võti eksisteerib"
         fre "Ne peut effacer (DROP %s) %`-.192s. Vérifiez s'il existe"
@@ -2165,6 +2251,7 @@ ER_CANT_DROP_FIELD_OR_KEY 42000
         hindi "%s %`-.192s को ड्रॉप नहीं कर सकते हैं; कृपया जाँच करें कि यह मौजूद है"
         hun "A DROP %s %`-.192s nem lehetseges. Ellenorizze, hogy a mezo/kulcs letezik-e"
         ita "Impossibile cancellare (DROP %s) %`-.192s. Controllare che il campo chiave esista"
+        nla "DROP %s: Kan %`-.192s niet weggooien. Controleer of het veld of de zoeksleutel daadwerkelijk bestaat"
         nor "Kan ikke DROP %s %`-.192s. Undersøk om felt/nøkkel eksisterer"
         norwegian-ny "Kan ikkje DROP %s %`-.192s. Undersøk om felt/nøkkel eksisterar"
         pol "Nie można wykonać operacji DROP %s %`-.192s. SprawdĽ, czy to pole/klucz istnieje"
@@ -2177,9 +2264,9 @@ ER_CANT_DROP_FIELD_OR_KEY 42000
         swe "Kan inte ta bort (DROP %s) %`-.192s. Kontrollera att begränsningen/fältet/nyckel finns"
         ukr "Не можу DROP %s %`-.192s. Перевірте, чи він існує"
 ER_INSERT_INFO  
+        chi "记录: %ld  重复: %ld  警告: %ld"
         cze "Záznamů: %ld  Zdvojených: %ld  Varování: %ld"
         dan "Poster: %ld  Ens: %ld  Advarsler: %ld"
-        nla "Records: %ld  Dubbel: %ld  Waarschuwing: %ld"
         eng "Records: %ld  Duplicates: %ld  Warnings: %ld"
         est "Kirjeid: %ld  Kattuvaid: %ld  Hoiatusi: %ld"
         fre "Enregistrements: %ld  Doublons: %ld  Avertissements: %ld"
@@ -2190,6 +2277,7 @@ ER_INSERT_INFO
         ita "Records: %ld  Duplicati: %ld  Avvertimenti: %ld"
         jpn "レコード数: %ld  重複数: %ld  警告: %ld"
         kor "레코드: %ld개  중복: %ld개  경고: %ld개"
+        nla "Records: %ld  Dubbel: %ld  Waarschuwing: %ld"
         nor "Poster: %ld  Like: %ld  Advarsler: %ld"
         norwegian-ny "Postar: %ld  Like: %ld  Åtvaringar: %ld"
         pol "Rekordów: %ld  Duplikatów: %ld  Ostrzeżeń: %ld"
@@ -2202,13 +2290,14 @@ ER_INSERT_INFO
         swe "Rader: %ld  Dubletter: %ld  Varningar: %ld"
         ukr "Записів: %ld  Дублікатів: %ld  Застережень: %ld"
 ER_UPDATE_TABLE_USED
+        chi "表 '%-.192s' 被指定了两次, 即作为 '%s' 的目标，又作为数据的独立源"
         eng "Table '%-.192s' is specified twice, both as a target for '%s' and as a separate source for data"
         swe "Table '%-.192s' är använd två gånger. Både för '%s' och för att hämta data"
         ukr "Таблиця '%-.192s' вказується двічі, як цільова для '%s', так і як окреме джерело даних"
 ER_NO_SUCH_THREAD  
+        chi "未知线程ID：%lu"
         cze "Neznámá identifikace threadu: %lu"
         dan "Ukendt tråd id: %lu"
-        nla "Onbekend thread id: %lu"
         eng "Unknown thread id: %lu"
         est "Tundmatu lõim: %lu"
         fre "Numéro de tâche inconnu: %lu"
@@ -2219,6 +2308,7 @@ ER_NO_SUCH_THREAD
         ita "Thread id: %lu sconosciuto"
         jpn "不明なスレッドIDです: %lu"
         kor "알수 없는 쓰레드 id: %lu"
+        nla "Onbekend thread id: %lu"
         nor "Ukjent tråd id: %lu"
         norwegian-ny "Ukjent tråd id: %lu"
         pol "Nieznany identyfikator w?tku: %lu"
@@ -2231,9 +2321,9 @@ ER_NO_SUCH_THREAD
         swe "Finns ingen tråd med id %lu"
         ukr "Невідомий ідентифікатор гілки: %lu"
 ER_KILL_DENIED_ERROR  
+        chi "你不是线程%lld的所有者"
         cze "Nejste vlastníkem threadu %lld"
         dan "Du er ikke ejer af tråden %lld"
-        nla "U bent geen bezitter van thread %lld"
         eng "You are not owner of thread %lld"
         est "Ei ole lõime %lld omanik"
         fre "Vous n'êtes pas propriétaire de la tâche no: %lld"
@@ -2244,6 +2334,7 @@ ER_KILL_DENIED_ERROR
         ita "Utente non proprietario del thread %lld"
         jpn "スレッド %lld のオーナーではありません。"
         kor "쓰레드(Thread) %lld의 소유자가 아닙니다."
+        nla "U bent geen bezitter van thread %lld"
         nor "Du er ikke eier av tråden %lld"
         norwegian-ny "Du er ikkje eigar av tråd %lld"
         pol "Nie jeste? wła?cicielem w?tku %lld"
@@ -2256,9 +2347,9 @@ ER_KILL_DENIED_ERROR
         swe "Du är inte ägare till tråd %lld"
         ukr "Ви не володар гілки %lld"
 ER_NO_TABLES_USED  
+        chi "没有使用表"
         cze "Nejsou použity žádné tabulky"
         dan "Ingen tabeller i brug"
-        nla "Geen tabellen gebruikt"
         eng "No tables used"
         est "Ühtegi tabelit pole kasutusel"
         fre "Aucune table utilisée"
@@ -2269,6 +2360,7 @@ ER_NO_TABLES_USED
         ita "Nessuna tabella usata"
         jpn "表が指定されていません。"
         kor "어떤 테이블도 사용되지 않았습니다."
+        nla "Geen tabellen gebruikt"
         nor "Ingen tabeller i bruk"
         norwegian-ny "Ingen tabellar i bruk"
         pol "Nie ma żadej użytej tabeli"
@@ -2281,9 +2373,9 @@ ER_NO_TABLES_USED
         swe "Inga tabeller angivna"
         ukr "Не використано таблиць"
 ER_TOO_BIG_SET  
+        chi "列 %-.192s 和SET的字符串过多"
         cze "Příliš mnoho řetězců pro sloupec %-.192s a SET"
         dan "For mange tekststrenge til specifikationen af SET i kolonne %-.192s"
-        nla "Teveel strings voor kolom %-.192s en SET"
         eng "Too many strings for column %-.192s and SET"
         est "Liiga palju string tulbale %-.192s tüübile SET"
         fre "Trop de chaînes dans la colonne %-.192s avec SET"
@@ -2293,6 +2385,7 @@ ER_TOO_BIG_SET
         ita "Troppe stringhe per la colonna %-.192s e la SET"
         jpn "SET型の列 '%-.192s' のメンバーの数が多すぎます。"
         kor "칼럼 %-.192s와 SET에서 스트링이 너무 많습니다."
+        nla "Teveel strings voor kolom %-.192s en SET"
         nor "For mange tekststrenger kolonne %-.192s og SET"
         norwegian-ny "For mange tekststrengar felt %-.192s og SET"
         pol "Zbyt wiele łańcuchów dla kolumny %-.192s i polecenia SET"
@@ -2305,9 +2398,9 @@ ER_TOO_BIG_SET
         swe "För många alternativ till kolumn %-.192s för SET"
         ukr "Забагато строк для стовбця %-.192s та SET"
 ER_NO_UNIQUE_LOGFILE  
+        chi "无法生成唯一的log-filename%-.200s.(1-999)\ n"
         cze "Nemohu vytvořit jednoznačné jméno logovacího souboru %-.200s.(1-999)\n"
         dan "Kan ikke lave unikt log-filnavn %-.200s.(1-999)\n"
-        nla "Het is niet mogelijk een unieke naam te maken voor de logfile %-.200s.(1-999)\n"
         eng "Can't generate a unique log-filename %-.200s.(1-999)\n"
         est "Ei suuda luua unikaalset logifaili nime %-.200s.(1-999)\n"
         fre "Ne peut générer un unique nom de journal %-.200s.(1-999)\n"
@@ -2318,6 +2411,7 @@ ER_NO_UNIQUE_LOGFILE
         ita "Impossibile generare un nome del file log unico %-.200s.(1-999)\n"
         jpn "一意なログファイル名 %-.200s.(1-999) を生成できません。\n"
         kor "Unique 로그화일 '%-.200s'를 만들수 없습니다.(1-999)\n"
+        nla "Het is niet mogelijk een unieke naam te maken voor de logfile %-.200s.(1-999)\n"
         nor "Kan ikke lage unikt loggfilnavn %-.200s.(1-999)\n"
         norwegian-ny "Kan ikkje lage unikt loggfilnavn %-.200s.(1-999)\n"
         pol "Nie można stworzyć unikalnej nazwy pliku z logiem %-.200s.(1-999)\n"
@@ -2330,9 +2424,9 @@ ER_NO_UNIQUE_LOGFILE
         swe "Kan inte generera ett unikt filnamn %-.200s.(1-999)\n"
         ukr "Не можу згенерувати унікальне ім'я log-файлу %-.200s.(1-999)\n"
 ER_TABLE_NOT_LOCKED_FOR_WRITE  
+        chi "表 '%-.192s' 有 READ 锁，无法更新"
         cze "Tabulka '%-.192s' byla zamčena s READ a nemůže být změněna"
         dan "Tabellen '%-.192s' var låst med READ lås og kan ikke opdateres"
-        nla "Tabel '%-.192s' was gelocked met een lock om te lezen. Derhalve kunnen geen wijzigingen worden opgeslagen"
         eng "Table '%-.192s' was locked with a READ lock and can't be updated"
         est "Tabel '%-.192s' on lukustatud READ lukuga ning ei ole muudetav"
         fre "Table '%-.192s' verrouillée lecture (READ): modification impossible"
@@ -2343,6 +2437,7 @@ ER_TABLE_NOT_LOCKED_FOR_WRITE
         ita "La tabella '%-.192s' e` soggetta a lock in lettura e non puo` essere aggiornata"
         jpn "表 '%-.192s' はREADロックされていて、更新できません。"
         kor "테이블 '%-.192s'는 READ 락이 잠겨있어서 갱신할 수 없습니다."
+        nla "Tabel '%-.192s' was gelocked met een lock om te lezen. Derhalve kunnen geen wijzigingen worden opgeslagen"
         nor "Tabellen '%-.192s' var låst med READ lås og kan ikke oppdateres"
         norwegian-ny "Tabellen '%-.192s' var låst med READ lås og kan ikkje oppdaterast"
         pol "Tabela '%-.192s' została zablokowana przez READ i nie może zostać zaktualizowana"
@@ -2355,9 +2450,9 @@ ER_TABLE_NOT_LOCKED_FOR_WRITE
         swe "Tabell '%-.192s' kan inte uppdateras emedan den är låst för läsning"
         ukr "Таблицю '%-.192s' заблоковано тільки для читання, тому її не можна оновити"
 ER_TABLE_NOT_LOCKED  
+        chi "表 '%-.192s' 未使用 LOCK TABLES 锁定"
         cze "Tabulka '%-.192s' nebyla zamčena s LOCK TABLES"
         dan "Tabellen '%-.192s' var ikke låst med LOCK TABLES"
-        nla "Tabel '%-.192s' was niet gelocked met LOCK TABLES"
         eng "Table '%-.192s' was not locked with LOCK TABLES"
         est "Tabel '%-.192s' ei ole lukustatud käsuga LOCK TABLES"
         fre "Table '%-.192s' non verrouillée: utilisez LOCK TABLES"
@@ -2368,6 +2463,7 @@ ER_TABLE_NOT_LOCKED
         ita "Non e` stato impostato il lock per la tabella '%-.192s' con LOCK TABLES"
         jpn "表 '%-.192s' は LOCK TABLES でロックされていません。"
         kor "테이블 '%-.192s'는 LOCK TABLES 명령으로 잠기지 않았습니다."
+        nla "Tabel '%-.192s' was niet gelocked met LOCK TABLES"
         nor "Tabellen '%-.192s' var ikke låst med LOCK TABLES"
         norwegian-ny "Tabellen '%-.192s' var ikkje låst med LOCK TABLES"
         pol "Tabela '%-.192s' nie została zablokowana poleceniem LOCK TABLES"
@@ -2380,11 +2476,12 @@ ER_TABLE_NOT_LOCKED
         swe "Tabell '%-.192s' är inte låst med LOCK TABLES"
         ukr "Таблицю '%-.192s' не було блоковано з LOCK TABLES"
 ER_UNUSED_17
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_WRONG_DB_NAME 42000 
+        chi "数据库名称不正确'%-.100T'"
         cze "Nepřípustné jméno databáze '%-.100T'"
         dan "Ugyldigt database navn '%-.100T'"
-        nla "Databasenaam '%-.100T' is niet getoegestaan"
         eng "Incorrect database name '%-.100T'"
         est "Vigane andmebaasi nimi '%-.100T'"
         fre "Nom de base de donnée illégal: '%-.100T'"
@@ -2395,6 +2492,7 @@ ER_WRONG_DB_NAME 42000
         ita "Nome database errato '%-.100T'"
         jpn "データベース名 '%-.100T' は不正です。"
         kor "'%-.100T' 데이타베이스의 이름이 부정확합니다."
+        nla "Databasenaam '%-.100T' is niet getoegestaan"
         nor "Ugyldig database navn '%-.100T'"
         norwegian-ny "Ugyldig database namn '%-.100T'"
         pol "Niedozwolona nazwa bazy danych '%-.100T'"
@@ -2407,9 +2505,9 @@ ER_WRONG_DB_NAME 42000
         swe "Felaktigt databasnamn '%-.100T'"
         ukr "Невірне ім'я бази данних '%-.100T'"
 ER_WRONG_TABLE_NAME 42000 
+        chi "表名不正确'%-.100s'"
         cze "Nepřípustné jméno tabulky '%-.100s'"
         dan "Ugyldigt tabel navn '%-.100s'"
-        nla "Niet toegestane tabelnaam '%-.100s'"
         eng "Incorrect table name '%-.100s'"
         est "Vigane tabeli nimi '%-.100s'"
         fre "Nom de table illégal: '%-.100s'"
@@ -2420,6 +2518,7 @@ ER_WRONG_TABLE_NAME 42000
         ita "Nome tabella errato '%-.100s'"
         jpn "表名 '%-.100s' は不正です。"
         kor "'%-.100s' 테이블 이름이 부정확합니다."
+        nla "Niet toegestane tabelnaam '%-.100s'"
         nor "Ugyldig tabell navn '%-.100s'"
         norwegian-ny "Ugyldig tabell namn '%-.100s'"
         pol "Niedozwolona nazwa tabeli '%-.100s'..."
@@ -2432,19 +2531,20 @@ ER_WRONG_TABLE_NAME 42000
         swe "Felaktigt tabellnamn '%-.100s'"
         ukr "Невірне ім'я таблиці '%-.100s'"
 ER_TOO_BIG_SELECT 42000 
+        chi "SELECT 将检查超过 MAX_JOIN_SIZE 行；检查您的 WHERE 并使用 SET SQL_BIG_SELECTS=1 或 SET MAX_JOIN_SIZE=# 如果 SELECT 没问题"
         cze "Zadaný SELECT by procházel příliš mnoho záznamů a trval velmi dlouho. Zkontrolujte tvar WHERE a je-li SELECT v pořádku, použijte SET SQL_BIG_SELECTS=1"
         dan "SELECT ville undersøge for mange poster og ville sandsynligvis tage meget lang tid. Undersøg WHERE delen og brug SET SQL_BIG_SELECTS=1 hvis udtrykket er korrekt"
-        nla "Het SELECT-statement zou te veel records analyseren en dus veel tijd in beslagnemen. Kijk het WHERE-gedeelte van de query na en kies SET SQL_BIG_SELECTS=1 als het stament in orde is"
         eng "The SELECT would examine more than MAX_JOIN_SIZE rows; check your WHERE and use SET SQL_BIG_SELECTS=1 or SET MAX_JOIN_SIZE=# if the SELECT is okay"
         est "SELECT lause peab läbi vaatama suure hulga kirjeid ja võtaks tõenäoliselt liiga kaua aega. Tasub kontrollida WHERE klauslit ja vajadusel kasutada käsku SET SQL_BIG_SELECTS=1"
         fre "SELECT va devoir examiner beaucoup d'enregistrements ce qui va prendre du temps. Vérifiez la clause WHERE et utilisez SET SQL_BIG_SELECTS=1 si SELECT se passe bien"
         ger "Die Ausführung des SELECT würde zu viele Datensätze untersuchen und wahrscheinlich sehr lange dauern. Bitte WHERE-Klausel überprüfen und gegebenenfalls SET SQL_BIG_SELECTS=1 oder SET MAX_JOIN_SIZE=# verwenden"
         greek "Το SELECT θα εξετάσει μεγάλο αριθμό εγγραφών και πιθανώς θα καθυστερήσει. Παρακαλώ εξετάστε τις παραμέτρους του WHERE και χρησιμοποιείστε SET SQL_BIG_SELECTS=1 αν το SELECT είναι σωστό"
-        hun "A SELECT tul sok rekordot fog megvizsgalni es nagyon sokaig fog tartani. Ellenorizze a WHERE-t es hasznalja a SET SQL_BIG_SELECTS=1 beallitast, ha a SELECT okay"
         hindi "SELECT कमांड MAX_JOIN_SIZE पंक्तियों से भी ज्यादा की जांच करेगा; कृपया WHERE क्लॉज़ को जाचें अथवा SET SQL_BIG_SELECTS=1 या SET MAX_JOIN_SIZE=# का इस्तेमाल करें"
+        hun "A SELECT tul sok rekordot fog megvizsgalni es nagyon sokaig fog tartani. Ellenorizze a WHERE-t es hasznalja a SET SQL_BIG_SELECTS=1 beallitast, ha a SELECT okay"
         ita "La SELECT dovrebbe esaminare troppi record e usare troppo tempo. Controllare la WHERE e usa SET SQL_BIG_SELECTS=1 se e` tutto a posto"
         jpn "SELECTがMAX_JOIN_SIZEを超える行数を処理しました。WHERE句を確認し、SELECT文に問題がなければ、 SET SQL_BIG_SELECTS=1 または SET MAX_JOIN_SIZE=# を使用して下さい。"
         kor "SELECT 명령에서 너무 많은 레코드를 찾기 때문에 많은 시간이 소요됩니다. 따라서 WHERE 문을 점검하거나, 만약 SELECT가 ok되면  SET SQL_BIG_SELECTS=1 옵션을 사용하세요."
+        nla "Het SELECT-statement zou te veel records analyseren en dus veel tijd in beslagnemen. Kijk het WHERE-gedeelte van de query na en kies SET SQL_BIG_SELECTS=1 als het stament in orde is"
         nor "SELECT ville undersøke for mange poster og ville sannsynligvis ta veldig lang tid. Undersøk WHERE klausulen og bruk SET SQL_BIG_SELECTS=1 om SELECTen er korrekt"
         norwegian-ny "SELECT ville undersøkje for mange postar og ville sannsynligvis ta veldig lang tid. Undersøk WHERE klausulen og bruk SET SQL_BIG_SELECTS=1 om SELECTen er korrekt"
         pol "Operacja SELECT będzie dotyczyła zbyt wielu rekordów i prawdopodobnie zajmie bardzo dużo czasu. SprawdĽ warunek WHERE i użyj SQL_OPTION BIG_SELECTS=1 je?li operacja SELECT jest poprawna"
@@ -2457,9 +2557,9 @@ ER_TOO_BIG_SELECT 42000
         swe "Den angivna frågan skulle läsa mer än MAX_JOIN_SIZE rader.  Kontrollera din WHERE och använd SET SQL_BIG_SELECTS=1 eller SET MAX_JOIN_SIZE=# ifall du vill hantera stora joins"
         ukr "Запиту SELECT потрібно обробити багато записів, що, певне, займе дуже багато часу. Перевірте ваше WHERE та використовуйте SET SQL_BIG_SELECTS=1, якщо цей запит SELECT є вірним"
 ER_UNKNOWN_ERROR  
+        chi "未知错误"
         cze "Neznámá chyba"
         dan "Ukendt fejl"
-        nla "Onbekende Fout"
         eng "Unknown error"
         est "Tundmatu viga"
         fre "Erreur inconnue"
@@ -2470,6 +2570,7 @@ ER_UNKNOWN_ERROR
         ita "Errore sconosciuto"
         jpn "不明なエラー"
         kor "알수 없는 에러입니다."
+        nla "Onbekende Fout"
         nor "Ukjent feil"
         norwegian-ny "Ukjend feil"
         por "Erro desconhecido"
@@ -2481,9 +2582,9 @@ ER_UNKNOWN_ERROR
         swe "Okänt fel"
         ukr "Невідома помилка"
 ER_UNKNOWN_PROCEDURE 42000 
+        chi "未知存储过程 '%-.192s'"
         cze "Neznámá procedura %-.192s"
         dan "Ukendt procedure %-.192s"
-        nla "Onbekende procedure %-.192s"
         eng "Unknown procedure '%-.192s'"
         est "Tundmatu protseduur '%-.192s'"
         fre "Procédure %-.192s inconnue"
@@ -2494,6 +2595,7 @@ ER_UNKNOWN_PROCEDURE 42000
         ita "Procedura '%-.192s' sconosciuta"
         jpn "'%-.192s' は不明なプロシージャです。"
         kor "알수 없는 수행문 : '%-.192s'"
+        nla "Onbekende procedure %-.192s"
         nor "Ukjent prosedyre %-.192s"
         norwegian-ny "Ukjend prosedyre %-.192s"
         pol "Unkown procedure %-.192s"
@@ -2506,9 +2608,9 @@ ER_UNKNOWN_PROCEDURE 42000
         swe "Okänd procedur: %-.192s"
         ukr "Невідома процедура '%-.192s'"
 ER_WRONG_PARAMCOUNT_TO_PROCEDURE 42000 
+        chi "存储过程 '%-.192s' 需要的参数和提供的参数不吻合"
         cze "Chybný počet parametrů procedury %-.192s"
         dan "Forkert antal  parametre til proceduren %-.192s"
-        nla "Foutief aantal parameters doorgegeven aan procedure %-.192s"
         eng "Incorrect parameter count to procedure '%-.192s'"
         est "Vale parameetrite hulk protseduurile '%-.192s'"
         fre "Mauvais nombre de paramètres pour la procedure %-.192s"
@@ -2519,6 +2621,7 @@ ER_WRONG_PARAMCOUNT_TO_PROCEDURE 42000
         ita "Numero di parametri errato per la procedura '%-.192s'"
         jpn "プロシージャ '%-.192s' へのパラメータ数が不正です。"
         kor "'%-.192s' 수행문에 대한 부정확한 파라메터"
+        nla "Foutief aantal parameters doorgegeven aan procedure %-.192s"
         nor "Feil parameter antall til prosedyren %-.192s"
         norwegian-ny "Feil parameter tal til prosedyra %-.192s"
         pol "Incorrect parameter count to procedure %-.192s"
@@ -2531,9 +2634,9 @@ ER_WRONG_PARAMCOUNT_TO_PROCEDURE 42000
         swe "Felaktigt antal parametrar till procedur %-.192s"
         ukr "Хибна кількість параметрів процедури '%-.192s'"
 ER_WRONG_PARAMETERS_TO_PROCEDURE  
+        chi "存储过程 '%-.192s' 的参数不对"
         cze "Chybné parametry procedury %-.192s"
         dan "Forkert(e) parametre til proceduren %-.192s"
-        nla "Foutieve parameters voor procedure %-.192s"
         eng "Incorrect parameters to procedure '%-.192s'"
         est "Vigased parameetrid protseduurile '%-.192s'"
         fre "Paramètre erroné pour la procedure %-.192s"
@@ -2544,6 +2647,7 @@ ER_WRONG_PARAMETERS_TO_PROCEDURE
         ita "Parametri errati per la procedura '%-.192s'"
         jpn "プロシージャ '%-.192s' へのパラメータが不正です。"
         kor "'%-.192s' 수행문에 대한 부정확한 파라메터"
+        nla "Foutieve parameters voor procedure %-.192s"
         nor "Feil parametre til prosedyren %-.192s"
         norwegian-ny "Feil parameter til prosedyra %-.192s"
         pol "Incorrect parameters to procedure %-.192s"
@@ -2556,9 +2660,9 @@ ER_WRONG_PARAMETERS_TO_PROCEDURE
         swe "Felaktiga parametrar till procedur %-.192s"
         ukr "Хибний параметер процедури '%-.192s'"
 ER_UNKNOWN_TABLE 42S02 
+        chi "未知表名 '%-.192s' 在 %-.32s"
         cze "Neznámá tabulka '%-.192s' v %-.32s"
         dan "Ukendt tabel '%-.192s' i %-.32s"
-        nla "Onbekende tabel '%-.192s' in %-.32s"
         eng "Unknown table '%-.192s' in %-.32s"
         est "Tundmatu tabel '%-.192s' %-.32s-s"
         fre "Table inconnue '%-.192s' dans %-.32s"
@@ -2569,6 +2673,7 @@ ER_UNKNOWN_TABLE 42S02
         ita "Tabella '%-.192s' sconosciuta in %-.32s"
         jpn "'%-.192s' は %-.32s では不明な表です。"
         kor "알수 없는 테이블 '%-.192s' (데이타베이스 %-.32s)"
+        nla "Onbekende tabel '%-.192s' in %-.32s"
         nor "Ukjent tabell '%-.192s' i %-.32s"
         norwegian-ny "Ukjend tabell '%-.192s' i %-.32s"
         pol "Unknown table '%-.192s' in %-.32s"
@@ -2581,9 +2686,9 @@ ER_UNKNOWN_TABLE 42S02
         swe "Okänd tabell '%-.192s' i '%-.32s'"
         ukr "Невідома таблиця '%-.192s' у %-.32s"
 ER_FIELD_SPECIFIED_TWICE 42000 
+        chi "列 '%-.192s' 被指定了两次"
         cze "Položka '%-.192s' je zadána dvakrát"
         dan "Feltet '%-.192s' er anvendt to gange"
-        nla "Veld '%-.192s' is dubbel gespecificeerd"
         eng "Column '%-.192s' specified twice"
         est "Tulp '%-.192s' on määratletud topelt"
         fre "Champ '%-.192s' spécifié deux fois"
@@ -2594,6 +2699,7 @@ ER_FIELD_SPECIFIED_TWICE 42000
         ita "Campo '%-.192s' specificato 2 volte"
         jpn "列 '%-.192s' は2回指定されています。"
         kor "칼럼 '%-.192s'는 두번 정의되어 있습니다."
+        nla "Veld '%-.192s' is dubbel gespecificeerd"
         nor "Feltet '%-.192s' er spesifisert to ganger"
         norwegian-ny "Feltet '%-.192s' er spesifisert to gangar"
         pol "Field '%-.192s' specified twice"
@@ -2606,9 +2712,9 @@ ER_FIELD_SPECIFIED_TWICE 42000
         swe "Fält '%-.192s' är redan använt"
         ukr "Стовбець '%-.192s' зазначено двічі"
 ER_INVALID_GROUP_FUNC_USE  
+        chi "组函数使用无效"
         cze "Nesprávné použití funkce group"
         dan "Forkert brug af grupperings-funktion"
-        nla "Ongeldig gebruik van GROUP-functie"
         eng "Invalid use of group function"
         est "Vigane grupeerimisfunktsiooni kasutus"
         fre "Utilisation invalide de la clause GROUP"
@@ -2619,6 +2725,7 @@ ER_INVALID_GROUP_FUNC_USE
         ita "Uso non valido di una funzione di raggruppamento"
         jpn "集計関数の使用方法が不正です。"
         kor "잘못된 그룹 함수를 사용하였습니다."
+        nla "Ongeldig gebruik van GROUP-functie"
         por "Uso inválido de função de agrupamento (GROUP)"
         rum "Folosire incorecta a functiei group"
         rus "Неправильное использование групповых функций"
@@ -2628,9 +2735,9 @@ ER_INVALID_GROUP_FUNC_USE
         swe "Felaktig användning av SQL grupp function"
         ukr "Хибне використання функції групування"
 ER_UNSUPPORTED_EXTENSION 42000 
+        chi "表'%-.192s'使用此MariaDB版本不存在的扩展"
         cze "Tabulka '%-.192s' používá rozšíření, které v této verzi MariaDB není"
         dan "Tabellen '%-.192s' bruger et filtypenavn som ikke findes i denne MariaDB version"
-        nla "Tabel '%-.192s' gebruikt een extensie, die niet in deze MariaDB-versie voorkomt"
         eng "Table '%-.192s' uses an extension that doesn't exist in this MariaDB version"
         est "Tabel '%-.192s' kasutab laiendust, mis ei eksisteeri antud MariaDB versioonis"
         fre "Table '%-.192s' : utilise une extension invalide pour cette version de MariaDB"
@@ -2639,8 +2746,9 @@ ER_UNSUPPORTED_EXTENSION 42000
         hindi "टेबल '%-.192s' जिस इक्स्टेन्शन का उपयोग कर रहा है, वह इस MariaDB संस्करण में उपलब्ध नहीं है"
         hun "A(z) '%-.192s' tabla olyan bovitest hasznal, amely nem letezik ebben a MariaDB versioban"
         ita "La tabella '%-.192s' usa un'estensione che non esiste in questa versione di MariaDB"
-	jpn "表 '%-.192s' は、このMariaDBバージョンには無い機能を使用しています。"
+        jpn "表 '%-.192s' は、このMariaDBバージョンには無い機能を使用しています。"
         kor "테이블 '%-.192s'는 확장명령을 이용하지만 현재의 MariaDB 버젼에서는 존재하지 않습니다."
+        nla "Tabel '%-.192s' gebruikt een extensie, die niet in deze MariaDB-versie voorkomt"
         nor "Table '%-.192s' uses a extension that doesn't exist in this MariaDB version"
         norwegian-ny "Table '%-.192s' uses a extension that doesn't exist in this MariaDB version"
         pol "Table '%-.192s' uses a extension that doesn't exist in this MariaDB version"
@@ -2653,9 +2761,9 @@ ER_UNSUPPORTED_EXTENSION 42000
         swe "Tabell '%-.192s' har en extension som inte finns i denna version av MariaDB"
         ukr "Таблиця '%-.192s' використовує розширення, що не існує у цій версії MariaDB"
 ER_TABLE_MUST_HAVE_COLUMNS 42000 
+        chi "表必须至少有1列"
         cze "Tabulka musí mít alespoň jeden sloupec"
         dan "En tabel skal have mindst een kolonne"
-        nla "Een tabel moet minstens 1 kolom bevatten"
         eng "A table must have at least 1 column"
         est "Tabelis peab olema vähemalt üks tulp"
         fre "Une table doit comporter au moins une colonne"
@@ -2666,6 +2774,7 @@ ER_TABLE_MUST_HAVE_COLUMNS 42000
         ita "Una tabella deve avere almeno 1 colonna"
         jpn "表には最低でも1個の列が必要です。"
         kor "하나의 테이블에서는 적어도 하나의 칼럼이 존재하여야 합니다."
+        nla "Een tabel moet minstens 1 kolom bevatten"
         por "Uma tabela tem que ter pelo menos uma (1) coluna"
         rum "O tabela trebuie sa aiba cel putin o coloana"
         rus "В таблице должен быть как минимум один столбец"
@@ -2675,9 +2784,9 @@ ER_TABLE_MUST_HAVE_COLUMNS 42000
         swe "Tabeller måste ha minst 1 kolumn"
         ukr "Таблиця повинна мати хочаб один стовбець"
 ER_RECORD_FILE_FULL  
+        chi "表'%-.192s'已满"
         cze "Tabulka '%-.192s' je plná"
         dan "Tabellen '%-.192s' er fuld"
-        nla "De tabel '%-.192s' is vol"
         eng "The table '%-.192s' is full"
         est "Tabel '%-.192s' on täis"
         fre "La table '%-.192s' est pleine"
@@ -2688,6 +2797,7 @@ ER_RECORD_FILE_FULL
         ita "La tabella '%-.192s' e` piena"
         jpn "表 '%-.192s' は満杯です。"
         kor "테이블 '%-.192s'가 full났습니다. "
+        nla "De tabel '%-.192s' is vol"
         por "Tabela '%-.192s' está cheia"
         rum "Tabela '%-.192s' e plina"
         rus "Таблица '%-.192s' переполнена"
@@ -2697,9 +2807,9 @@ ER_RECORD_FILE_FULL
         swe "Tabellen '%-.192s' är full"
         ukr "Таблиця '%-.192s' заповнена"
 ER_UNKNOWN_CHARACTER_SET 42000 
+        chi "未知字符集：'%-.64s'"
         cze "Neznámá znaková sada: '%-.64s'"
         dan "Ukendt tegnsæt: '%-.64s'"
-        nla "Onbekende character set: '%-.64s'"
         eng "Unknown character set: '%-.64s'"
         est "Vigane kooditabel '%-.64s'"
         fre "Jeu de caractères inconnu: '%-.64s'"
@@ -2710,6 +2820,7 @@ ER_UNKNOWN_CHARACTER_SET 42000
         ita "Set di caratteri '%-.64s' sconosciuto"
         jpn "不明な文字コードセット: '%-.64s'"
         kor "알수없는 언어 Set: '%-.64s'"
+        nla "Onbekende character set: '%-.64s'"
         por "Conjunto de caracteres '%-.64s' desconhecido"
         rum "Set de caractere invalid: '%-.64s'"
         rus "Неизвестная кодировка '%-.64s'"
@@ -2719,9 +2830,9 @@ ER_UNKNOWN_CHARACTER_SET 42000
         swe "Okänd teckenuppsättning: '%-.64s'"
         ukr "Невідома кодова таблиця: '%-.64s'"
 ER_TOO_MANY_TABLES  
+        chi "表太多; MariaDB 只能在join中使用 %d 个表"
         cze "Příliš mnoho tabulek, MariaDB jich může mít v joinu jen %d"
         dan "For mange tabeller. MariaDB kan kun bruge %d tabeller i et join"
-        nla "Teveel tabellen. MariaDB kan slechts %d tabellen in een join bevatten"
         eng "Too many tables; MariaDB can only use %d tables in a join"
         est "Liiga palju tabeleid. MariaDB suudab JOINiga ühendada kuni %d tabelit"
         fre "Trop de tables. MariaDB ne peut utiliser que %d tables dans un JOIN"
@@ -2732,6 +2843,7 @@ ER_TOO_MANY_TABLES
         ita "Troppe tabelle. MariaDB puo` usare solo %d tabelle in una join"
         jpn "表が多すぎます。MariaDBがJOINできる表は %d 個までです。"
         kor "너무 많은 테이블이 Join되었습니다. MariaDB에서는 JOIN시 %d개의 테이블만 사용할 수 있습니다."
+        nla "Teveel tabellen. MariaDB kan slechts %d tabellen in een join bevatten"
         por "Tabelas demais. O MariaDB pode usar somente %d tabelas em uma junção (JOIN)"
         rum "Prea multe tabele. MariaDB nu poate folosi mai mult de %d tabele intr-un join"
         rus "Слишком много таблиц. MariaDB может использовать только %d таблиц в соединении"
@@ -2741,9 +2853,9 @@ ER_TOO_MANY_TABLES
         swe "För många tabeller. MariaDB can ha högst %d tabeller i en och samma join"
         ukr "Забагато таблиць. MariaDB може використовувати лише %d таблиць у об'єднанні"
 ER_TOO_MANY_FIELDS  
+        chi "太多列"
         cze "Příliš mnoho položek"
         dan "For mange felter"
-        nla "Te veel velden"
         eng "Too many columns"
         est "Liiga palju tulpasid"
         fre "Trop de champs"
@@ -2754,6 +2866,7 @@ ER_TOO_MANY_FIELDS
         ita "Troppi campi"
         jpn "列が多すぎます。"
         kor "칼럼이 너무 많습니다."
+        nla "Te veel velden"
         por "Colunas demais"
         rum "Prea multe coloane"
         rus "Слишком много столбцов"
@@ -2763,9 +2876,9 @@ ER_TOO_MANY_FIELDS
         swe "För många fält"
         ukr "Забагато стовбців"
 ER_TOO_BIG_ROWSIZE 42000 
+        chi "行尺寸太大. 不包括BLOB，表的最大的行大小是 %ld. 这包括存储开销，请查看文档。您必须将某些列更改为 TEXT 或 BLOB"
         cze "Řádek je příliš velký. Maximální velikost řádku, nepočítaje položky blob, je %ld. Musíte změnit některé položky na blob"
         dan "For store poster. Max post størrelse, uden BLOB's, er %ld. Du må lave nogle felter til BLOB's"
-        nla "Rij-grootte is groter dan toegestaan. Maximale rij grootte, blobs niet meegeteld, is %ld. U dient sommige velden in blobs te veranderen"
         eng "Row size too large. The maximum row size for the used table type, not counting BLOBs, is %ld. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs"
         est "Liiga pikk kirje. Kirje maksimumpikkus arvestamata BLOB-tüüpi välju on %ld. Muuda mõned väljad BLOB-tüüpi väljadeks"
         fre "Ligne trop grande. Le taille maximale d'une ligne, sauf les BLOBs, est %ld. Changez le type de quelques colonnes en BLOB"
@@ -2775,6 +2888,7 @@ ER_TOO_BIG_ROWSIZE 42000
         ita "Riga troppo grande. La massima grandezza di una riga, non contando i BLOB, e` %ld. Devi cambiare alcuni campi in BLOB"
         jpn "行サイズが大きすぎます。この表の最大行サイズは BLOB を含まずに %ld です。格納時のオーバーヘッドも含まれます(マニュアルを確認してください)。列をTEXTまたはBLOBに変更する必要があります。"
         kor "너무 큰 row 사이즈입니다. BLOB를 계산하지 않고 최대 row 사이즈는 %ld입니다. 일부열을 BLOB 또는 TEXT로 변경해야 합니다."
+        nla "Rij-grootte is groter dan toegestaan. Maximale rij grootte, blobs niet meegeteld, is %ld. U dient sommige velden in blobs te veranderen"
         por "Tamanho de linha grande demais. O máximo tamanho de linha, não contando BLOBs, é %ld. Você tem que mudar alguns campos para BLOBs"
         rum "Marimea liniei (row) prea mare. Marimea maxima a liniei, excluzind BLOB-urile este de %ld. Trebuie sa schimbati unele cimpuri in BLOB-uri"
         rus "Слишком большой размер записи. Максимальный размер строки, исключая поля BLOB, - %ld. Возможно, вам следует изменить тип некоторых полей на BLOB"
@@ -2784,9 +2898,9 @@ ER_TOO_BIG_ROWSIZE 42000
         swe "För stor total radlängd. Den högst tillåtna radlängden, förutom BLOBs, är %ld. Ändra några av dina fält till BLOB"
         ukr "Задовга строка. Найбільшою довжиною строки, не рахуючи BLOB, є %ld. Вам потрібно привести деякі стовбці до типу BLOB"
 ER_STACK_OVERRUN  
+        chi "线程栈溢出:  已使用了: %ld 堆栈 %ld.  使用 'mysqld --thread_stack=#' 指定更大的堆栈"
         cze "Přetečení zásobníku threadu: použito %ld z %ld. Použijte 'mysqld --thread_stack=#' k zadání většího zásobníku"
         dan "Thread stack brugt:  Brugt: %ld af en %ld stak.  Brug 'mysqld --thread_stack=#' for at allokere en større stak om nødvendigt"
-        nla "Thread stapel overrun:  Gebruikte: %ld van een %ld stack. Gebruik 'mysqld --thread_stack=#' om een grotere stapel te definieren (indien noodzakelijk)"
         eng "Thread stack overrun:  Used: %ld of a %ld stack.  Use 'mysqld --thread_stack=#' to specify a bigger stack if needed"
         fre "Débordement de la pile des tâches (Thread stack). Utilisées: %ld pour une pile de %ld.  Essayez 'mysqld --thread_stack=#' pour indiquer une plus grande valeur"
         ger "Thread-Stack-Überlauf. Benutzt: %ld von %ld Stack. 'mysqld --thread_stack=#' verwenden, um bei Bedarf einen größeren Stack anzulegen"
@@ -2795,6 +2909,7 @@ ER_STACK_OVERRUN
         ita "Thread stack overrun:  Usati: %ld di uno stack di %ld.  Usa 'mysqld --thread_stack=#' per specificare uno stack piu` grande"
         jpn "スレッドスタック不足です(使用: %ld ; サイズ: %ld)。必要に応じて、より大きい値で 'mysqld --thread_stack=#' の指定をしてください。"
         kor "쓰레드 스택이 넘쳤습니다.  사용: %ld개 스택: %ld개.  만약 필요시 더큰 스택을 원할때에는 'mysqld --thread_stack=#' 를 정의하세요"
+        nla "Thread stapel overrun:  Gebruikte: %ld van een %ld stack. Gebruik 'mysqld --thread_stack=#' om een grotere stapel te definieren (indien noodzakelijk)"
         por "Estouro da pilha do 'thread'. Usados %ld de uma pilha de %ld. Use 'mysqld --thread_stack=#' para especificar uma pilha maior, se necessário"
         rum "Stack-ul thread-ului a fost depasit (prea mic):  Folositi: %ld intr-un stack de %ld.  Folositi 'mysqld --thread_stack=#' ca sa specifici un stack mai mare"
         rus "Стек потоков переполнен:  использовано: %ld из %ld стека.  Применяйте 'mysqld --thread_stack=#' для указания большего размера стека, если необходимо"
@@ -2804,9 +2919,9 @@ ER_STACK_OVERRUN
         swe "Trådstacken tog slut:  Har använt %ld av %ld bytes.  Använd 'mysqld --thread_stack=#' ifall du behöver en större stack"
         ukr "Стек гілок переповнено:  Використано: %ld з %ld. Використовуйте 'mysqld --thread_stack=#' аби зазначити більший стек, якщо необхідно"
 ER_WRONG_OUTER_JOIN 42000 
+        chi "在 OUTER JOIN 中发现交叉依赖；检查您的 ON 条件"
         cze "V OUTER JOIN byl nalezen křížový odkaz. Prověřte ON podmínky"
         dan "Krydsreferencer fundet i OUTER JOIN; check dine ON conditions"
-        nla "Gekruiste afhankelijkheid gevonden in OUTER JOIN. Controleer uw ON-conditions"
         eng "Cross dependency found in OUTER JOIN; examine your ON conditions"
         est "Ristsõltuvus OUTER JOIN klauslis. Kontrolli oma ON tingimusi"
         fre "Dépendance croisée dans une clause OUTER JOIN. Vérifiez la condition ON"
@@ -2815,6 +2930,7 @@ ER_WRONG_OUTER_JOIN 42000
         hun "Keresztfuggoseg van az OUTER JOIN-ban. Ellenorizze az ON felteteleket"
         ita "Trovata una dipendenza incrociata nella OUTER JOIN. Controlla le condizioni ON"
         jpn "OUTER JOINに相互依存が見つかりました。ON句の条件を確認して下さい。"
+        nla "Gekruiste afhankelijkheid gevonden in OUTER JOIN. Controleer uw ON-conditions"
         por "Dependência cruzada encontrada em junção externa (OUTER JOIN); examine as condições utilizadas nas cláusulas 'ON'"
         rum "Dependinta incrucisata (cross dependency) gasita in OUTER JOIN.  Examinati conditiile ON"
         rus "В OUTER JOIN обнаружена перекрестная зависимость. Внимательно проанализируйте свои условия ON"
@@ -2824,13 +2940,14 @@ ER_WRONG_OUTER_JOIN 42000
         swe "Felaktigt referens i OUTER JOIN.  Kontrollera ON-uttrycket"
         ukr "Перехресна залежність у OUTER JOIN. Перевірте умову ON"
 ER_NULL_COLUMN_IN_INDEX 42000 
+        chi "表处理程序不支持给定索引中的 NULL. 请将列 '%-.192s' 改为 NOT NULL 或使用其他处理程序"
         eng "Table handler doesn't support NULL in given index. Please change column '%-.192s' to be NOT NULL or use another handler"
         swe "Tabell hanteraren kan inte indexera NULL kolumner för den givna index typen. Ändra '%-.192s' till NOT NULL eller använd en annan hanterare"
         ukr "Вказівник таблиці не підтримує NULL у зазначенному індексі. Будь ласка, зменіть стовпчик '%-.192s' на NOT NULL або використайте інший вказівник таблиці."
 ER_CANT_FIND_UDF  
+        chi "无法加载函数'%-.192s'"
         cze "Nemohu načíst funkci '%-.192s'"
         dan "Kan ikke læse funktionen '%-.192s'"
-        nla "Kan functie '%-.192s' niet laden"
         eng "Can't load function '%-.192s'"
         est "Ei suuda avada funktsiooni '%-.192s'"
         fre "Imposible de charger la fonction '%-.192s'"
@@ -2841,6 +2958,7 @@ ER_CANT_FIND_UDF
         ita "Impossibile caricare la funzione '%-.192s'"
         jpn "関数 '%-.192s' をロードできません。"
         kor "'%-.192s' 함수를 로드하지 못했습니다."
+        nla "Kan functie '%-.192s' niet laden"
         por "Não pode carregar a função '%-.192s'"
         rum "Nu pot incarca functia '%-.192s'"
         rus "Невозможно загрузить функцию '%-.192s'"
@@ -2850,9 +2968,9 @@ ER_CANT_FIND_UDF
         swe "Kan inte ladda funktionen '%-.192s'"
         ukr "Не можу завантажити функцію '%-.192s'"
 ER_CANT_INITIALIZE_UDF  
+        chi "无法初始化函数 '%-.192s'; %-.80s"
         cze "Nemohu inicializovat funkci '%-.192s'; %-.80s"
         dan "Kan ikke starte funktionen '%-.192s'; %-.80s"
-        nla "Kan functie '%-.192s' niet initialiseren; %-.80s"
         eng "Can't initialize function '%-.192s'; %-.80s"
         est "Ei suuda algväärtustada funktsiooni '%-.192s'; %-.80s"
         fre "Impossible d'initialiser la fonction '%-.192s'; %-.80s"
@@ -2863,6 +2981,7 @@ ER_CANT_INITIALIZE_UDF
         ita "Impossibile inizializzare la funzione '%-.192s'; %-.80s"
         jpn "関数 '%-.192s' を初期化できません。; %-.80s"
         kor "'%-.192s' 함수를 초기화 하지 못했습니다.; %-.80s"
+        nla "Kan functie '%-.192s' niet initialiseren; %-.80s"
         por "Não pode inicializar a função '%-.192s' - '%-.80s'"
         rum "Nu pot initializa functia '%-.192s'; %-.80s"
         rus "Невозможно инициализировать функцию '%-.192s'; %-.80s"
@@ -2872,9 +2991,9 @@ ER_CANT_INITIALIZE_UDF
         swe "Kan inte initialisera funktionen '%-.192s'; '%-.80s'"
         ukr "Не можу ініціалізувати функцію '%-.192s'; %-.80s"
 ER_UDF_NO_PATHS  
+        chi "共享库不允许使用路径"
         cze "Pro sdílenou knihovnu nejsou povoleny cesty"
         dan "Angivelse af sti ikke tilladt for delt bibliotek"
-        nla "Geen pad toegestaan voor shared library"
         eng "No paths allowed for shared library"
         est "Teegi nimes ei tohi olla kataloogi"
         fre "Chemin interdit pour les bibliothèques partagées"
@@ -2884,6 +3003,7 @@ ER_UDF_NO_PATHS
         ita "Non sono ammessi path per le librerie condivisa"
         jpn "共有ライブラリにはパスを指定できません。"
         kor "공유 라이버러리를 위한 패스가 정의되어 있지 않습니다."
+        nla "Geen pad toegestaan voor shared library"
         por "Não há caminhos (paths) permitidos para biblioteca compartilhada"
         rum "Nici un paths nu e permis pentru o librarie shared"
         rus "Недопустимо указывать пути для динамических библиотек"
@@ -2893,9 +3013,9 @@ ER_UDF_NO_PATHS
         swe "Man får inte ange sökväg för dynamiska bibliotek"
         ukr "Не дозволено використовувати путі для розділюваних бібліотек"
 ER_UDF_EXISTS  
+        chi "函数 '%-.192s' 已经存在"
         cze "Funkce '%-.192s' již existuje"
         dan "Funktionen '%-.192s' findes allerede"
-        nla "Functie '%-.192s' bestaat reeds"
         eng "Function '%-.192s' already exists"
         est "Funktsioon '%-.192s' juba eksisteerib"
         fre "La fonction '%-.192s' existe déjà"
@@ -2906,6 +3026,7 @@ ER_UDF_EXISTS
         ita "La funzione '%-.192s' esiste gia`"
         jpn "関数 '%-.192s' はすでに定義されています。"
         kor "'%-.192s' 함수는 이미 존재합니다."
+        nla "Functie '%-.192s' bestaat reeds"
         por "Função '%-.192s' já existe"
         rum "Functia '%-.192s' exista deja"
         rus "Функция '%-.192s' уже существует"
@@ -2915,9 +3036,9 @@ ER_UDF_EXISTS
         swe "Funktionen '%-.192s' finns redan"
         ukr "Функція '%-.192s' вже існує"
 ER_CANT_OPEN_LIBRARY  
+        chi "不能打开共享库 '%-.192s' (错误号码: %d, %-.128s)"
         cze "Nemohu otevřít sdílenou knihovnu '%-.192s' (errno: %d, %-.128s)"
         dan "Kan ikke åbne delt bibliotek '%-.192s' (errno: %d, %-.128s)"
-        nla "Kan shared library '%-.192s' niet openen (Errcode: %d, %-.128s)"
         eng "Can't open shared library '%-.192s' (errno: %d, %-.128s)"
         est "Ei suuda avada jagatud teeki '%-.192s' (veakood: %d, %-.128s)"
         fre "Impossible d'ouvrir la bibliothèque partagée '%-.192s' (errno: %d, %-.128s)"
@@ -2927,6 +3048,7 @@ ER_CANT_OPEN_LIBRARY
         ita "Impossibile aprire la libreria condivisa '%-.192s' (errno: %d, %-.128s)"
         jpn "共有ライブラリ '%-.192s' を開く事ができません。(エラー番号: %d, %-.128s)"
         kor "'%-.192s' 공유 라이버러리를 열수 없습니다.(에러번호: %d, %-.128s)"
+        nla "Kan shared library '%-.192s' niet openen (Errcode: %d, %-.128s)"
         nor "Can't open shared library '%-.192s' (errno: %d, %-.128s)"
         norwegian-ny "Can't open shared library '%-.192s' (errno: %d, %-.128s)"
         pol "Can't open shared library '%-.192s' (errno: %d, %-.128s)"
@@ -2939,9 +3061,9 @@ ER_CANT_OPEN_LIBRARY
         swe "Kan inte öppna det dynamiska biblioteket '%-.192s' (Felkod: %d, %-.128s)"
         ukr "Не можу відкрити розділювану бібліотеку '%-.192s' (помилка: %d, %-.128s)"
 ER_CANT_FIND_DL_ENTRY
+        chi "在库中找不到符号 '%-.128s'"
         cze "Nemohu najít funkci '%-.128s' v knihovně"
         dan "Kan ikke finde funktionen '%-.128s' i bibliotek"
-        nla "Kan functie '%-.128s' niet in library vinden"
         eng "Can't find symbol '%-.128s' in library"
         est "Ei leia funktsiooni '%-.128s' antud teegis"
         fre "Impossible de trouver la fonction '%-.128s' dans la bibliothèque"
@@ -2951,6 +3073,7 @@ ER_CANT_FIND_DL_ENTRY
         ita "Impossibile trovare la funzione '%-.128s' nella libreria"
         jpn "関数 '%-.128s' は共有ライブラリー中にありません。"
         kor "라이버러리에서 '%-.128s' 함수를 찾을 수 없습니다."
+        nla "Kan functie '%-.128s' niet in library vinden"
         por "Não pode encontrar a função '%-.128s' na biblioteca"
         rum "Nu pot gasi functia '%-.128s' in libraria"
         rus "Невозможно отыскать символ '%-.128s' в библиотеке"
@@ -2960,9 +3083,9 @@ ER_CANT_FIND_DL_ENTRY
         swe "Hittar inte funktionen '%-.128s' in det dynamiska biblioteket"
         ukr "Не можу знайти функцію '%-.128s' у бібліотеці"
 ER_FUNCTION_NOT_DEFINED  
+        chi "未定义函数 '%-.192s'"
         cze "Funkce '%-.192s' není definována"
         dan "Funktionen '%-.192s' er ikke defineret"
-        nla "Functie '%-.192s' is niet gedefinieerd"
         eng "Function '%-.192s' is not defined"
         est "Funktsioon '%-.192s' ei ole defineeritud"
         fre "La fonction '%-.192s' n'est pas définie"
@@ -2973,6 +3096,7 @@ ER_FUNCTION_NOT_DEFINED
         ita "La funzione '%-.192s' non e` definita"
         jpn "関数 '%-.192s' は定義されていません。"
         kor "'%-.192s' 함수가 정의되어 있지 않습니다."
+        nla "Functie '%-.192s' is niet gedefinieerd"
         por "Função '%-.192s' não está definida"
         rum "Functia '%-.192s' nu e definita"
         rus "Функция '%-.192s' не определена"
@@ -2982,9 +3106,9 @@ ER_FUNCTION_NOT_DEFINED
         swe "Funktionen '%-.192s' är inte definierad"
         ukr "Функцію '%-.192s' не визначено"
 ER_HOST_IS_BLOCKED  
+        chi "主机 '%-.64s' 由于许多连接错误而被阻止；使用 'mysqladmin flush-hosts' 解除阻塞"
         cze "Stroj '%-.64s' je zablokován kvůli mnoha chybám při připojování. Odblokujete použitím 'mysqladmin flush-hosts'"
         dan "Værten '%-.64s' er blokeret på grund af mange fejlforespørgsler. Lås op med 'mysqladmin flush-hosts'"
-        nla "Host '%-.64s' is geblokkeeerd vanwege te veel verbindings fouten. Deblokkeer met 'mysqladmin flush-hosts'"
         eng "Host '%-.64s' is blocked because of many connection errors; unblock with 'mysqladmin flush-hosts'"
         est "Masin '%-.64s' on blokeeritud hulgaliste ühendusvigade tõttu. Blokeeringu saab tühistada 'mysqladmin flush-hosts' käsuga"
         fre "L'hôte '%-.64s' est bloqué à cause d'un trop grand nombre d'erreur de connexion. Débloquer le par 'mysqladmin flush-hosts'"
@@ -2995,6 +3119,7 @@ ER_HOST_IS_BLOCKED
         ita "Sistema '%-.64s' bloccato a causa di troppi errori di connessione. Per sbloccarlo: 'mysqladmin flush-hosts'"
         jpn "接続エラーが多いため、ホスト '%-.64s' は拒否されました。'mysqladmin flush-hosts' で解除できます。"
         kor "너무 많은 연결오류로 인하여 호스트 '%-.64s'는 블락되었습니다. 'mysqladmin flush-hosts'를 이용하여 블락을 해제하세요"
+        nla "Host '%-.64s' is geblokkeeerd vanwege te veel verbindings fouten. Deblokkeer met 'mysqladmin flush-hosts'"
         por "'Host' '%-.64s' está bloqueado devido a muitos erros de conexão. Desbloqueie com 'mysqladmin flush-hosts'"
         rum "Host-ul '%-.64s' e blocat din cauza multelor erori de conectie. Poti deploca folosind 'mysqladmin flush-hosts'"
         rus "Хост '%-.64s' заблокирован из-за слишком большого количества ошибок соединения. Разблокировать его можно с помощью 'mysqladmin flush-hosts'"
@@ -3003,9 +3128,9 @@ ER_HOST_IS_BLOCKED
         swe "Denna dator, '%-.64s', är blockerad pga många felaktig paket. Gör 'mysqladmin flush-hosts' för att ta bort alla blockeringarna"
         ukr "Хост '%-.64s' заблоковано з причини великої кількості помилок з'єднання. Для розблокування використовуйте 'mysqladmin flush-hosts'"
 ER_HOST_NOT_PRIVILEGED  
+        chi "Host'%-.64s'不允许连接到此MariaDB服务器"
         cze "Stroj '%-.64s' nemá povoleno se k tomuto MariaDB serveru připojit"
         dan "Værten '%-.64s' kan ikke tilkoble denne MariaDB-server"
-        nla "Het is host '%-.64s' is niet toegestaan verbinding te maken met deze MariaDB server"
         eng "Host '%-.64s' is not allowed to connect to this MariaDB server"
         est "Masinal '%-.64s' puudub ligipääs sellele MariaDB serverile"
         fre "Le hôte '%-.64s' n'est pas authorisé à se connecter à ce serveur MariaDB"
@@ -3016,6 +3141,7 @@ ER_HOST_NOT_PRIVILEGED
         ita "Al sistema '%-.64s' non e` consentita la connessione a questo server MariaDB"
         jpn "ホスト '%-.64s' からのこの MariaDB server への接続は許可されていません。"
         kor "'%-.64s' 호스트는 이 MariaDB서버에 접속할 허가를 받지 못했습니다."
+        nla "Het is host '%-.64s' is niet toegestaan verbinding te maken met deze MariaDB server"
         por "'Host' '%-.64s' não tem permissão para se conectar com este servidor MariaDB"
         rum "Host-ul '%-.64s' nu este permis a se conecta la aceste server MariaDB"
         rus "Хосту '%-.64s' не разрешается подключаться к этому серверу MariaDB"
@@ -3024,9 +3150,9 @@ ER_HOST_NOT_PRIVILEGED
         swe "Denna dator, '%-.64s', har inte privileger att använda denna MariaDB server"
         ukr "Хосту '%-.64s' не доволено зв'язуватись з цим сервером MariaDB"
 ER_PASSWORD_ANONYMOUS_USER 42000 
+        chi "您正在以匿名用户身份使用 MariaDB，匿名用户不能修改用户设置"
         cze "Používáte MariaDB jako anonymní uživatel a anonymní uživatelé nemají povoleno měnit hesla"
         dan "Du bruger MariaDB som anonym bruger. Anonyme brugere må ikke ændre adgangskoder"
-        nla "U gebruikt MariaDB als anonieme gebruiker en deze mogen geen wachtwoorden wijzigen"
         eng "You are using MariaDB as an anonymous user and anonymous users are not allowed to modify user settings"
         est "Te kasutate MariaDB-i anonüümse kasutajana, kelledel pole parooli muutmise õigust"
         fre "Vous utilisez un utilisateur anonyme et les utilisateurs anonymes ne sont pas autorisés à changer les mots de passe"
@@ -3037,6 +3163,7 @@ ER_PASSWORD_ANONYMOUS_USER 42000
         ita "Impossibile cambiare la password usando MariaDB come utente anonimo"
         jpn "MariaDB を匿名ユーザーで使用しているので、パスワードの変更はできません。"
         kor "당신은 MariaDB서버에 익명의 사용자로 접속을 하셨습니다.익명의 사용자는 암호를 변경할 수 없습니다."
+        nla "U gebruikt MariaDB als anonieme gebruiker en deze mogen geen wachtwoorden wijzigen"
         por "Você está usando o MariaDB como usuário anônimo e usuários anônimos não têm permissão para mudar senhas"
         rum "Dumneavoastra folositi MariaDB ca un utilizator anonim si utilizatorii anonimi nu au voie sa schimbe setarile utilizatorilor"
         rus "Вы используете MariaDB от имени анонимного пользователя, а анонимным пользователям не разрешается менять пароли"
@@ -3045,9 +3172,9 @@ ER_PASSWORD_ANONYMOUS_USER 42000
         swe "Du använder MariaDB som en anonym användare och som sådan får du inte ändra ditt lösenord"
         ukr "Ви використовуєте MariaDB як анонімний користувач, тому вам не дозволено змінювати паролі"
 ER_PASSWORD_NOT_ALLOWED 42000 
+        chi "您必须具有更新 mysql 数据库中的表的权限才能更改其他人的密码"
         cze "Na změnu hesel ostatním musíte mít právo provést update tabulek v databázi mysql"
         dan "Du skal have tilladelse til at opdatere tabeller i MariaDB databasen for at ændre andres adgangskoder"
-        nla "U moet tabel update priveleges hebben in de mysql database om wachtwoorden voor anderen te mogen wijzigen"
         eng "You must have privileges to update tables in the mysql database to be able to change passwords for others"
         est "Teiste paroolide muutmiseks on nõutav tabelite muutmisõigus 'mysql' andmebaasis"
         fre "Vous devez avoir le privilège update sur les tables de la base de donnée mysql pour pouvoir changer les mots de passe des autres"
@@ -3057,6 +3184,7 @@ ER_PASSWORD_NOT_ALLOWED 42000
         ita "E` necessario il privilegio di update sulle tabelle del database mysql per cambiare le password per gli altri utenti"
         jpn "他のユーザーのパスワードを変更するためには、mysqlデータベースの表を更新する権限が必要です。"
         kor "당신은 다른사용자들의 암호를 변경할 수 있도록 데이타베이스 변경권한을 가져야 합니다."
+        nla "U moet tabel update priveleges hebben in de mysql database om wachtwoorden voor anderen te mogen wijzigen"
         por "Você deve ter privilégios para atualizar tabelas no banco de dados mysql para ser capaz de mudar a senha de outros"
         rum "Trebuie sa aveti privilegii sa actualizati tabelele in bazele de date mysql ca sa puteti sa schimati parolele altora"
         rus "Для того чтобы изменять пароли других пользователей, у вас должны быть привилегии на изменение таблиц в базе данных mysql"
@@ -3065,9 +3193,9 @@ ER_PASSWORD_NOT_ALLOWED 42000
         swe "För att ändra lösenord för andra måste du ha rättigheter att uppdatera mysql-databasen"
         ukr "Ви повині мати право на оновлення таблиць у базі данних mysql, аби мати можливість змінювати пароль іншим"
 ER_PASSWORD_NO_MATCH 28000 
+        chi "在用户表中找不到任何匹配的行"
         cze "V tabulce user není žádný odpovídající řádek"
         dan "Kan ikke finde nogen tilsvarende poster i bruger tabellen"
-        nla "Kan geen enkele passende rij vinden in de gebruikers tabel"
         eng "Can't find any matching row in the user table"
         est "Ei leia vastavat kirjet kasutajate tabelis"
         fre "Impossible de trouver un enregistrement correspondant dans la table user"
@@ -3078,6 +3206,7 @@ ER_PASSWORD_NO_MATCH 28000
         ita "Impossibile trovare la riga corrispondente nella tabella user"
         jpn "ユーザーテーブルに該当するレコードが見つかりません。"
         kor "사용자 테이블에서 일치하는 것을 찾을 수 없습니다."
+        nla "Kan geen enkele passende rij vinden in de gebruikers tabel"
         por "Não pode encontrar nenhuma linha que combine na tabela usuário (user table)"
         rum "Nu pot gasi nici o linie corespunzatoare in tabela utilizatorului"
         rus "Невозможно отыскать подходящую запись в таблице пользователей"
@@ -3086,9 +3215,9 @@ ER_PASSWORD_NO_MATCH 28000
         swe "Hittade inte användaren i 'user'-tabellen"
         ukr "Не можу знайти відповідних записів у таблиці користувача"
 ER_UPDATE_INFO  
+        chi "匹配行：%ld已更改：%ld警告：%ld"
         cze "Nalezených řádků: %ld  Změněno: %ld  Varování: %ld"
         dan "Poster fundet: %ld  Ændret: %ld  Advarsler: %ld"
-        nla "Passende rijen: %ld  Gewijzigd: %ld  Waarschuwingen: %ld"
         eng "Rows matched: %ld  Changed: %ld  Warnings: %ld"
         est "Sobinud kirjeid: %ld  Muudetud: %ld  Hoiatusi: %ld"
         fre "Enregistrements correspondants: %ld  Modifiés: %ld  Warnings: %ld"
@@ -3097,6 +3226,7 @@ ER_UPDATE_INFO
         ita "Rows riconosciute: %ld  Cambiate: %ld  Warnings: %ld"
         jpn "該当した行: %ld  変更: %ld  警告: %ld"
         kor "일치하는 Rows : %ld개 변경됨: %ld개  경고: %ld개"
+        nla "Passende rijen: %ld  Gewijzigd: %ld  Waarschuwingen: %ld"
         por "Linhas que combinaram: %ld - Alteradas: %ld - Avisos: %ld"
         rum "Linii identificate (matched): %ld  Schimbate: %ld  Atentionari (warnings): %ld"
         rus "Совпало записей: %ld  Изменено: %ld  Предупреждений: %ld"
@@ -3105,9 +3235,9 @@ ER_UPDATE_INFO
         swe "Rader: %ld  Uppdaterade: %ld  Varningar: %ld"
         ukr "Записів відповідає: %ld  Змінено: %ld  Застережень: %ld"
 ER_CANT_CREATE_THREAD  
+        chi "无法创建新线程 (错误号码 %M); 如果您没有用完剩余内存，您可以查阅文档以了解可能与操作系统相关的错误"
         cze "Nemohu vytvořit nový thread (errno %M). Pokud je ještě nějaká volná paměť, podívejte se do manuálu na část o chybách specifických pro jednotlivé operační systémy"
         dan "Kan ikke danne en ny tråd (fejl nr. %M). Hvis computeren ikke er løbet tør for hukommelse, kan du se i brugervejledningen for en mulig operativ-system - afhængig fejl"
-        nla "Kan geen nieuwe thread aanmaken (Errcode: %M). Indien er geen tekort aan geheugen is kunt u de handleiding consulteren over een mogelijke OS afhankelijke fout"
         eng "Can't create a new thread (errno %M); if you are not out of available memory, you can consult the manual for a possible OS-dependent bug"
         est "Ei suuda luua uut lõime (veakood %M). Kui mälu ei ole otsas, on tõenäoliselt tegemist operatsioonisüsteemispetsiifilise veaga"
         fre "Impossible de créer une nouvelle tâche (errno %M). S'il reste de la mémoire libre, consultez le manual pour trouver un éventuel bug dépendant de l'OS"
@@ -3116,6 +3246,7 @@ ER_CANT_CREATE_THREAD
         ita "Impossibile creare un nuovo thread (errno %M). Se non ci sono problemi di memoria disponibile puoi consultare il manuale per controllare possibili problemi dipendenti dal SO"
         jpn "新規にスレッドを作成できません。(エラー番号 %M) もしも使用可能メモリーの不足でなければ、OS依存のバグである可能性があります。"
         kor "새로운 쓰레드를 만들 수 없습니다.(에러번호 %M). 만약 여유메모리가 있다면 OS-dependent버그 의 메뉴얼 부분을 찾아보시오."
+        nla "Kan geen nieuwe thread aanmaken (Errcode: %M). Indien er geen tekort aan geheugen is kunt u de handleiding consulteren over een mogelijke OS afhankelijke fout"
         nor "Can't create a new thread (errno %M); if you are not out of available memory you can consult the manual for any possible OS dependent bug"
         norwegian-ny "Can't create a new thread (errno %M); if you are not out of available memory you can consult the manual for any possible OS dependent bug"
         pol "Can't create a new thread (errno %M); if you are not out of available memory you can consult the manual for any possible OS dependent bug"
@@ -3127,9 +3258,9 @@ ER_CANT_CREATE_THREAD
         swe "Kan inte skapa en ny tråd (errno %M)"
         ukr "Не можу створити нову гілку (помилка %M). Якщо ви не використали усю пам'ять, то прочитайте документацію до вашої ОС - можливо це помилка ОС"
 ER_WRONG_VALUE_COUNT_ON_ROW 21S01 
+        chi "列计数与行%lu的值计数不匹配"
         cze "Počet sloupců neodpovídá počtu hodnot na řádku %lu"
         dan "Kolonne antallet stemmer ikke overens med antallet af værdier i post %lu"
-        nla "Kolom aantal komt niet overeen met waarde aantal in rij %lu"
         eng "Column count doesn't match value count at row %lu"
         est "Tulpade hulk erineb väärtuste hulgast real %lu"
         ger "Anzahl der Felder stimmt nicht mit der Anzahl der Werte in Zeile %lu überein"
@@ -3137,6 +3268,7 @@ ER_WRONG_VALUE_COUNT_ON_ROW 21S01
         ita "Il numero delle colonne non corrisponde al conteggio alla riga %lu"
         jpn "%lu 行目で、列の数が値の数と一致しません。"
         kor "Row %lu에서 칼럼 카운트와 value 카운터와 일치하지 않습니다."
+        nla "Kolom aantal komt niet overeen met waarde aantal in rij %lu"
         por "Contagem de colunas não confere com a contagem de valores na linha %lu"
         rum "Numarul de coloane nu corespunde cu numarul de valori la linia %lu"
         rus "Количество столбцов не совпадает с количеством значений в записи %lu"
@@ -3145,9 +3277,9 @@ ER_WRONG_VALUE_COUNT_ON_ROW 21S01
         swe "Antalet kolumner motsvarar inte antalet värden på rad: %lu"
         ukr "Кількість стовбців не співпадає з кількістю значень у строці %lu"
 ER_CANT_REOPEN_TABLE  
+        chi "无法重新打开表：'%-.192s'"
         cze "Nemohu znovuotevřít tabulku: '%-.192s"
         dan "Kan ikke genåbne tabel '%-.192s"
-        nla "Kan tabel niet opnieuw openen: '%-.192s"
         eng "Can't reopen table: '%-.192s'"
         est "Ei suuda taasavada tabelit '%-.192s'"
         fre "Impossible de réouvrir la table: '%-.192s"
@@ -3157,6 +3289,7 @@ ER_CANT_REOPEN_TABLE
         ita "Impossibile riaprire la tabella: '%-.192s'"
         jpn "表を再オープンできません。: '%-.192s'"
         kor "테이블을 다시 열수 없군요: '%-.192s"
+        nla "Kan tabel niet opnieuw openen: '%-.192s"
         nor "Can't reopen table: '%-.192s"
         norwegian-ny "Can't reopen table: '%-.192s"
         pol "Can't reopen table: '%-.192s"
@@ -3169,9 +3302,9 @@ ER_CANT_REOPEN_TABLE
         swe "Kunde inte stänga och öppna tabell '%-.192s"
         ukr "Не можу перевідкрити таблицю: '%-.192s'"
 ER_INVALID_USE_OF_NULL 22004 
+        chi "无效使用 NULL 值"
         cze "Neplatné užití hodnoty NULL"
         dan "Forkert brug af nulværdi (NULL)"
-        nla "Foutief gebruik van de NULL waarde"
         eng "Invalid use of NULL value"
         est "NULL väärtuse väärkasutus"
         fre "Utilisation incorrecte de la valeur NULL"
@@ -3181,6 +3314,7 @@ ER_INVALID_USE_OF_NULL 22004
         ita "Uso scorretto del valore NULL"
         jpn "NULL 値の使用方法が不適切です。"
         kor "NULL 값을 잘못 사용하셨군요..."
+        nla "Foutief gebruik van de NULL waarde"
         por "Uso inválido do valor NULL"
         rum "Folosirea unei value NULL e invalida"
         rus "Неправильное использование величины NULL"
@@ -3189,9 +3323,9 @@ ER_INVALID_USE_OF_NULL 22004
         swe "Felaktig använding av NULL"
         ukr "Хибне використання значення NULL"
 ER_REGEXP_ERROR 42000 
+        chi "正则表达错误 '%-.64s'"
         cze "Regulární výraz vrátil chybu '%-.64s'"
         dan "Fik fejl '%-.64s' fra regexp"
-        nla "Fout '%-.64s' ontvangen van regexp"
         eng "Got error '%-.64s' from regexp"
         est "regexp tagastas vea '%-.64s'"
         fre "Erreur '%-.64s' provenant de regexp"
@@ -3201,6 +3335,7 @@ ER_REGEXP_ERROR 42000
         ita "Errore '%-.64s' da regexp"
         jpn "regexp がエラー '%-.64s' を返しました。"
         kor "regexp에서 '%-.64s'가 났습니다."
+        nla "Fout '%-.64s' ontvangen van regexp"
         por "Obteve erro '%-.64s' em regexp"
         rum "Eroarea '%-.64s' obtinuta din expresia regulara (regexp)"
         rus "Получена ошибка '%-.64s' от регулярного выражения"
@@ -3209,9 +3344,9 @@ ER_REGEXP_ERROR 42000
         swe "Fick fel '%-.64s' från REGEXP"
         ukr "Отримано помилку '%-.64s' від регулярного виразу"
 ER_MIX_OF_GROUP_FUNC_AND_FIELDS 42000 
+        chi "如果没有 GROUP BY 子句，不能混合没有 GROUP 列的 GROUP 列 (MIN(),MAX(),COUNT(),...)"
         cze "Pokud není žádná GROUP BY klauzule, není dovoleno současné použití GROUP položek (MIN(),MAX(),COUNT()...) s ne GROUP položkami"
         dan "Sammenblanding af GROUP kolonner (MIN(),MAX(),COUNT()...) uden GROUP kolonner er ikke tilladt, hvis der ikke er noget GROUP BY prædikat"
-        nla "Het mixen van GROUP kolommen (MIN(),MAX(),COUNT()...) met no-GROUP kolommen is foutief indien er geen GROUP BY clausule is"
         eng "Mixing of GROUP columns (MIN(),MAX(),COUNT(),...) with no GROUP columns is illegal if there is no GROUP BY clause"
         est "GROUP tulpade (MIN(),MAX(),COUNT()...) kooskasutamine tavaliste tulpadega ilma GROUP BY klauslita ei ole lubatud"
         fre "Mélanger les colonnes GROUP (MIN(),MAX(),COUNT()...) avec des colonnes normales est interdit s'il n'y a pas de clause GROUP BY"
@@ -3220,6 +3355,7 @@ ER_MIX_OF_GROUP_FUNC_AND_FIELDS 42000
         ita "Il mescolare funzioni di aggregazione (MIN(),MAX(),COUNT()...) e non e` illegale se non c'e` una clausula GROUP BY"
         jpn "GROUP BY句が無い場合、集計関数(MIN(),MAX(),COUNT(),...)と通常の列を同時に使用できません。"
         kor "GROUP BY 절 없이 혼합된 GROUP 함수 (MIN(),MAX(),COUNT(),...) 를 사용할 수 없습니다."
+        nla "Het mixen van GROUP kolommen (MIN(),MAX(),COUNT()...) met no-GROUP kolommen is foutief indien er geen GROUP BY clausule is"
         por "Mistura de colunas agrupadas (com MIN(), MAX(), COUNT(), ...) com colunas não agrupadas é ilegal, se não existir uma cláusula de agrupamento (cláusula GROUP BY)"
         rum "Amestecarea de coloane GROUP (MIN(),MAX(),COUNT()...) fara coloane GROUP este ilegala daca nu exista o clauza GROUP BY"
         rus "Одновременное использование сгруппированных (GROUP) столбцов (MIN(),MAX(),COUNT(),...) с несгруппированными столбцами является некорректным, если в выражении есть GROUP BY"
@@ -3228,9 +3364,9 @@ ER_MIX_OF_GROUP_FUNC_AND_FIELDS 42000
         swe "Man får ha både GROUP-kolumner (MIN(),MAX(),COUNT()...) och fält i en fråga om man inte har en GROUP BY-del"
         ukr "Змішування GROUP стовбців (MIN(),MAX(),COUNT()...) з не GROUP стовбцями є забороненим, якщо не має GROUP BY"
 ER_NONEXISTING_GRANT 42000 
+        chi "用户 '%-.48s' 来自主机 '%-.64s'没有此类授权"
         cze "Neexistuje odpovídající grant pro uživatele '%-.48s' na stroji '%-.64s'"
         dan "Denne tilladelse findes ikke for brugeren '%-.48s' på vært '%-.64s'"
-        nla "Deze toegang (GRANT) is niet toegekend voor gebruiker '%-.48s' op host '%-.64s'"
         eng "There is no such grant defined for user '%-.48s' on host '%-.64s'"
         est "Sellist õigust ei ole defineeritud kasutajale '%-.48s' masinast '%-.64s'"
         fre "Un tel droit n'est pas défini pour l'utilisateur '%-.48s' sur l'hôte '%-.64s'"
@@ -3239,6 +3375,7 @@ ER_NONEXISTING_GRANT 42000
         ita "GRANT non definita per l'utente '%-.48s' dalla macchina '%-.64s'"
         jpn "ユーザー '%-.48s' (ホスト '%-.64s' 上) は許可されていません。"
         kor "사용자 '%-.48s' (호스트 '%-.64s')를 위하여 정의된 그런 승인은 없습니다."
+        nla "Deze toegang (GRANT) is niet toegekend voor gebruiker '%-.48s' op host '%-.64s'"
         por "Não existe tal permissão (grant) definida para o usuário '%-.48s' no 'host' '%-.64s'"
         rum "Nu exista un astfel de grant definit pentru utilzatorul '%-.48s' de pe host-ul '%-.64s'"
         rus "Такие права не определены для пользователя '%-.48s' на хосте '%-.64s'"
@@ -3247,11 +3384,10 @@ ER_NONEXISTING_GRANT 42000
         swe "Det finns inget privilegium definierat för användare '%-.48s' på '%-.64s'"
         ukr "Повноважень не визначено для користувача '%-.48s' з хосту '%-.64s'"
 ER_TABLEACCESS_DENIED_ERROR 42000 
+        chi "%-.100T 命令的权限拒绝用户 '%s'@'%s' 用在表 '%-.192s'"
         cze "%-.100T příkaz nepřístupný pro uživatele: '%s'@'%s' pro tabulku '%-.192s'"
         dan "%-.100T-kommandoen er ikke tilladt for brugeren '%s'@'%s' for tabellen '%-.192s'"
-        nla "%-.100T commando geweigerd voor gebruiker: '%s'@'%s' voor tabel '%-.192s'"
         eng "%-.100T command denied to user '%s'@'%s' for table '%-.192s'"
-        jps "コマンド %-.100T は ユーザー '%s'@'%s' ,テーブル '%-.192s' に対して許可されていません",
         est "%-.100T käsk ei ole lubatud kasutajale '%s'@'%s' tabelis '%-.192s'"
         fre "La commande '%-.100T' est interdite à l'utilisateur: '%s'@'%s' sur la table '%-.192s'"
         ger "%-.100T Befehl nicht erlaubt für Benutzer '%s'@'%s' auf Tabelle '%-.192s'"
@@ -3259,6 +3395,7 @@ ER_TABLEACCESS_DENIED_ERROR 42000
         ita "Comando %-.100T negato per l'utente: '%s'@'%s' sulla tabella '%-.192s'"
         jpn "コマンド %-.100T は ユーザー '%s'@'%s' ,テーブル '%-.192s' に対して許可されていません"
         kor "'%-.100T' 명령은 다음 사용자에게 거부되었습니다. : '%s'@'%s' for 테이블 '%-.192s'"
+        nla "%-.100T commando geweigerd voor gebruiker: '%s'@'%s' voor tabel '%-.192s'"
         por "Comando '%-.100T' negado para o usuário '%s'@'%s' na tabela '%-.192s'"
         rum "Comanda %-.100T interzisa utilizatorului: '%s'@'%s' pentru tabela '%-.192s'"
         rus "Команда %-.100T запрещена пользователю '%s'@'%s' для таблицы '%-.192s'"
@@ -3267,11 +3404,10 @@ ER_TABLEACCESS_DENIED_ERROR 42000
         swe "%-.100T ej tillåtet för '%s'@'%s' för tabell '%-.192s'"
         ukr "%-.100T команда заборонена користувачу: '%s'@'%s' у таблиці '%-.192s'"
 ER_COLUMNACCESS_DENIED_ERROR 42000 
+        chi "%-.32s 命令的权限拒绝用户 '%s'@'%s' 用在列 '%-.192s' 在表 '%-.192s'"
         cze "%-.32s příkaz nepřístupný pro uživatele: '%s'@'%s' pro sloupec '%-.192s' v tabulce '%-.192s'"
         dan "%-.32s-kommandoen er ikke tilladt for brugeren '%s'@'%s' for kolonne '%-.192s' in tabellen '%-.192s'"
-        nla "%-.32s commando geweigerd voor gebruiker: '%s'@'%s' voor kolom '%-.192s' in tabel '%-.192s'"
         eng "%-.32s command denied to user '%s'@'%s' for column '%-.192s' in table '%-.192s'"
-        jps "コマンド %-.32s は ユーザー '%s'@'%s'¥n カラム '%-.192s' テーブル '%-.192s' に対して許可されていません",
         est "%-.32s käsk ei ole lubatud kasutajale '%s'@'%s' tulbale '%-.192s' tabelis '%-.192s'"
         fre "La commande '%-.32s' est interdite à l'utilisateur: '%s'@'%s' sur la colonne '%-.192s' de la table '%-.192s'"
         ger "%-.32s Befehl nicht erlaubt für Benutzer '%s'@'%s' und Feld '%-.192s' in Tabelle '%-.192s'"
@@ -3279,6 +3415,7 @@ ER_COLUMNACCESS_DENIED_ERROR 42000
         ita "Comando %-.32s negato per l'utente: '%s'@'%s' sulla colonna '%-.192s' della tabella '%-.192s'"
         jpn "コマンド %-.32s は ユーザー '%s'@'%s'\n カラム '%-.192s' テーブル '%-.192s' に対して許可されていません"
         kor "'%-.32s' 명령은 다음 사용자에게 거부되었습니다. : '%s'@'%s' for 칼럼 '%-.192s' in 테이블 '%-.192s'"
+        nla "%-.32s commando geweigerd voor gebruiker: '%s'@'%s' voor kolom '%-.192s' in tabel '%-.192s'"
         por "Comando '%-.32s' negado para o usuário '%s'@'%s' na coluna '%-.192s', na tabela '%-.192s'"
         rum "Comanda %-.32s interzisa utilizatorului: '%s'@'%s' pentru coloana '%-.192s' in tabela '%-.192s'"
         rus "Команда %-.32s запрещена пользователю '%s'@'%s' для столбца '%-.192s' в таблице '%-.192s'"
@@ -3287,9 +3424,9 @@ ER_COLUMNACCESS_DENIED_ERROR 42000
         swe "%-.32s ej tillåtet för '%s'@'%s' för kolumn '%-.192s' i tabell '%-.192s'"
         ukr "%-.32s команда заборонена користувачу: '%s'@'%s' для стовбця '%-.192s' у таблиці '%-.192s'"
 ER_ILLEGAL_GRANT_FOR_TABLE 42000 
+        chi "非法的 GRANT/REVOKE 命令；请查阅文档查看可以使用哪些权限"
         cze "Neplatný příkaz GRANT/REVOKE. Prosím, přečtěte si v manuálu, jaká privilegia je možné použít"
         dan "Forkert GRANT/REVOKE kommando. Se i brugervejledningen hvilke privilegier der kan specificeres"
-        nla "Foutief GRANT/REVOKE commando. Raadpleeg de handleiding welke priveleges gebruikt kunnen worden"
         eng "Illegal GRANT/REVOKE command; please consult the manual to see which privileges can be used"
         est "Vigane GRANT/REVOKE käsk. Tutvu kasutajajuhendiga"
         fre "Commande GRANT/REVOKE incorrecte. Consultez le manuel"
@@ -3299,6 +3436,7 @@ ER_ILLEGAL_GRANT_FOR_TABLE 42000
         ita "Comando GRANT/REVOKE illegale. Prego consultare il manuale per sapere quali privilegi possono essere usati"
         jpn "不正な GRANT/REVOKE コマンドです。どの権限で利用可能かはマニュアルを参照して下さい。"
         kor "잘못된 GRANT/REVOKE 명령. 어떤 권리와 승인이 사용되어 질 수 있는지 메뉴얼을 보시오."
+        nla "Foutief GRANT/REVOKE commando. Raadpleeg de handleiding welke priveleges gebruikt kunnen worden"
         nor "Illegal GRANT/REVOKE command; please consult the manual to see which privleges can be used"
         norwegian-ny "Illegal GRANT/REVOKE command; please consult the manual to see which privleges can be used"
         pol "Illegal GRANT/REVOKE command; please consult the manual to see which privleges can be used"
@@ -3311,9 +3449,9 @@ ER_ILLEGAL_GRANT_FOR_TABLE 42000
         swe "Felaktigt GRANT-privilegium använt"
         ukr "Хибна GRANT/REVOKE команда; прочитайте документацію стосовно того, які права можна використовувати"
 ER_GRANT_WRONG_HOST_OR_USER 42000 
+        chi "GRANT 语句的主机或用户参数太长"
         cze "Argument příkazu GRANT uživatel nebo stroj je příliš dlouhý"
         dan "Værts- eller brugernavn for langt til GRANT"
-        nla "De host of gebruiker parameter voor GRANT is te lang"
         eng "The host or user argument to GRANT is too long"
         est "Masina või kasutaja nimi GRANT lauses on liiga pikk"
         fre "L'hôte ou l'utilisateur donné en argument à GRANT est trop long"
@@ -3323,6 +3461,7 @@ ER_GRANT_WRONG_HOST_OR_USER 42000
         ita "L'argomento host o utente per la GRANT e` troppo lungo"
         jpn "GRANTコマンドへの、ホスト名やユーザー名が長すぎます。"
         kor "승인(GRANT)을 위하여 사용한 사용자나 호스트의 값들이 너무 깁니다."
+        nla "De host of gebruiker parameter voor GRANT is te lang"
         por "Argumento de 'host' ou de usuário para o GRANT é longo demais"
         rum "Argumentul host-ului sau utilizatorului pentru GRANT e prea lung"
         rus "Слишком длинное имя пользователя/хоста для GRANT"
@@ -3331,9 +3470,9 @@ ER_GRANT_WRONG_HOST_OR_USER 42000
         swe "Felaktigt maskinnamn eller användarnamn använt med GRANT"
         ukr "Аргумент host або user для GRANT задовгий"
 ER_NO_SUCH_TABLE 42S02 
+        chi "表 '%-.192s.%-.192s' 不存在"
         cze "Tabulka '%-.192s.%-.192s' neexistuje"
         dan "Tabellen '%-.192s.%-.192s' eksisterer ikke"
-        nla "Tabel '%-.192s.%-.192s' bestaat niet"
         eng "Table '%-.192s.%-.192s' doesn't exist"
         est "Tabelit '%-.192s.%-.192s' ei eksisteeri"
         fre "La table '%-.192s.%-.192s' n'existe pas"
@@ -3343,6 +3482,7 @@ ER_NO_SUCH_TABLE 42S02
         ita "La tabella '%-.192s.%-.192s' non esiste"
         jpn "表 '%-.192s.%-.192s' は存在しません。"
         kor "테이블 '%-.192s.%-.192s' 는 존재하지 않습니다."
+        nla "Tabel '%-.192s.%-.192s' bestaat niet"
         nor "Table '%-.192s.%-.192s' doesn't exist"
         norwegian-ny "Table '%-.192s.%-.192s' doesn't exist"
         pol "Table '%-.192s.%-.192s' doesn't exist"
@@ -3355,9 +3495,9 @@ ER_NO_SUCH_TABLE 42S02
         swe "Det finns ingen tabell som heter '%-.192s.%-.192s'"
         ukr "Таблиця '%-.192s.%-.192s' не існує"
 ER_NONEXISTING_TABLE_GRANT 42000 
+        chi "没有为用户 '%-.48s' 来自主机 '%-.64s' 在表 '%-.192s' 上授权"
         cze "Neexistuje odpovídající grant pro uživatele '%-.48s' na stroji '%-.64s' pro tabulku '%-.192s'"
         dan "Denne tilladelse eksisterer ikke for brugeren '%-.48s' på vært '%-.64s' for tabellen '%-.192s'"
-        nla "Deze toegang (GRANT) is niet toegekend voor gebruiker '%-.48s' op host '%-.64s' op tabel '%-.192s'"
         eng "There is no such grant defined for user '%-.48s' on host '%-.64s' on table '%-.192s'"
         est "Sellist õigust ei ole defineeritud kasutajale '%-.48s' masinast '%-.64s' tabelile '%-.192s'"
         fre "Un tel droit n'est pas défini pour l'utilisateur '%-.48s' sur l'hôte '%-.64s' sur la table '%-.192s'"
@@ -3366,6 +3506,7 @@ ER_NONEXISTING_TABLE_GRANT 42000
         ita "GRANT non definita per l'utente '%-.48s' dalla macchina '%-.64s' sulla tabella '%-.192s'"
         jpn "ユーザー '%-.48s' (ホスト '%-.64s' 上) の表 '%-.192s' への権限は定義されていません。"
         kor "사용자 '%-.48s'(호스트 '%-.64s')는 테이블 '%-.192s'를 사용하기 위하여 정의된 승인은 없습니다. "
+        nla "Deze toegang (GRANT) is niet toegekend voor gebruiker '%-.48s' op host '%-.64s' op tabel '%-.192s'"
         por "Não existe tal permissão (grant) definido para o usuário '%-.48s' no 'host' '%-.64s', na tabela '%-.192s'"
         rum "Nu exista un astfel de privilegiu (grant) definit pentru utilizatorul '%-.48s' de pe host-ul '%-.64s' pentru tabela '%-.192s'"
         rus "Такие права не определены для пользователя '%-.48s' на компьютере '%-.64s' для таблицы '%-.192s'"
@@ -3374,9 +3515,9 @@ ER_NONEXISTING_TABLE_GRANT 42000
         swe "Det finns inget privilegium definierat för användare '%-.48s' på '%-.64s' för tabell '%-.192s'"
         ukr "Повноважень не визначено для користувача '%-.48s' з хосту '%-.64s' для таблиці '%-.192s'"
 ER_NOT_ALLOWED_COMMAND 42000 
+        chi "本 MariaDB 版本不允许使用这个命令"
         cze "Použitý příkaz není v této verzi MariaDB povolen"
         dan "Den brugte kommando er ikke tilladt med denne udgave af MariaDB"
-        nla "Het used commando is niet toegestaan in deze MariaDB versie"
         eng "The used command is not allowed with this MariaDB version"
         est "Antud käsk ei ole lubatud käesolevas MariaDB versioonis"
         fre "Cette commande n'existe pas dans cette version de MariaDB"
@@ -3386,6 +3527,7 @@ ER_NOT_ALLOWED_COMMAND 42000
         ita "Il comando utilizzato non e` supportato in questa versione di MariaDB"
         jpn "このMariaDBバージョンでは利用できないコマンドです。"
         kor "사용된 명령은 현재의 MariaDB 버젼에서는 이용되지 않습니다."
+        nla "Het used commando is niet toegestaan in deze MariaDB versie"
         por "Comando usado não é permitido para esta versão do MariaDB"
         rum "Comanda folosita nu este permisa pentru aceasta versiune de MariaDB"
         rus "Эта команда не допускается в данной  версии MariaDB"
@@ -3394,9 +3536,9 @@ ER_NOT_ALLOWED_COMMAND 42000
         swe "Du kan inte använda detta kommando med denna MariaDB version"
         ukr "Використовувана команда не дозволена у цій версії MariaDB"
 ER_SYNTAX_ERROR 42000 
+        chi "您的 SQL 语法有错误；请查看相关文档"
         cze "Vaše syntaxe je nějaká divná"
         dan "Der er en fejl i SQL syntaksen"
-        nla "Er is iets fout in de gebruikte syntax"
         eng "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use"
         est "Viga SQL süntaksis"
         fre "Erreur de syntaxe"
@@ -3407,6 +3549,7 @@ ER_SYNTAX_ERROR 42000
         ita "Errore di sintassi nella query SQL"
         jpn "SQL構文エラーです。バージョンに対応するマニュアルを参照して正しい構文を確認してください。"
         kor "SQL 구문에 오류가 있습니다."
+        nla "Er is iets fout in de gebruikte syntax"
         nor "Something is wrong in your syntax"
         norwegian-ny "Something is wrong in your syntax"
         pol "Something is wrong in your syntax"
@@ -3419,9 +3562,9 @@ ER_SYNTAX_ERROR 42000
         swe "Du har något fel i din syntax"
         ukr "У вас помилка у синтаксисі SQL"
 ER_DELAYED_CANT_CHANGE_LOCK  
+        chi "延迟插入线程无法获得 %-.192s 的请求锁定"
         cze "Zpožděný insert threadu nebyl schopen získat požadovaný zámek pro tabulku %-.192s"
         dan "Forsinket indsættelse tråden (delayed insert thread) kunne ikke opnå lås på tabellen %-.192s"
-        nla "'Delayed insert' thread kon de aangevraagde 'lock' niet krijgen voor tabel %-.192s"
         eng "Delayed insert thread couldn't get requested lock for table %-.192s"
         est "INSERT DELAYED lõim ei suutnud saada soovitud lukku tabelile %-.192s"
         fre "La tâche 'delayed insert' n'a pas pu obtenir le verrou démandé sur la table %-.192s"
@@ -3430,6 +3573,7 @@ ER_DELAYED_CANT_CHANGE_LOCK
         ita "Il thread di inserimento ritardato non riesce ad ottenere il lock per la tabella %-.192s"
         jpn "'Delayed insert'スレッドが表 '%-.192s' のロックを取得できませんでした。"
         kor "지연된 insert 쓰레드가 테이블 %-.192s의 요구된 락킹을 처리할 수 없었습니다."
+        nla "'Delayed insert' thread kon de aangevraagde 'lock' niet krijgen voor tabel %-.192s"
         por "'Thread' de inserção retardada (atrasada) pois não conseguiu obter a trava solicitada para tabela '%-.192s'"
         rum "Thread-ul pentru inserarea aminata nu a putut obtine lacatul (lock) pentru tabela %-.192s"
         rus "Поток, обслуживающий отложенную вставку (delayed insert), не смог получить запрашиваемую блокировку на таблицу %-.192s"
@@ -3438,9 +3582,9 @@ ER_DELAYED_CANT_CHANGE_LOCK
         swe "DELAYED INSERT-tråden kunde inte låsa tabell '%-.192s'"
         ukr "Гілка для INSERT DELAYED не може отримати блокування для таблиці %-.192s"
 ER_TOO_MANY_DELAYED_THREADS  
+        chi "使用中的延迟线程太多"
         cze "Příliš mnoho zpožděných threadů"
         dan "For mange slettede tråde (threads) i brug"
-        nla "Te veel 'delayed' threads in gebruik"
         eng "Too many delayed threads in use"
         est "Liiga palju DELAYED lõimesid kasutusel"
         fre "Trop de tâche 'delayed' en cours"
@@ -3450,6 +3594,7 @@ ER_TOO_MANY_DELAYED_THREADS
         ita "Troppi threads ritardati in uso"
         jpn "'Delayed insert'スレッドが多すぎます。"
         kor "너무 많은 지연 쓰레드를 사용하고 있습니다."
+        nla "Te veel 'delayed' threads in gebruik"
         por "Excesso de 'threads' retardadas (atrasadas) em uso"
         rum "Prea multe threaduri aminate care sint in uz"
         rus "Слишком много потоков, обслуживающих отложенную вставку (delayed insert)"
@@ -3458,9 +3603,9 @@ ER_TOO_MANY_DELAYED_THREADS
         swe "Det finns redan 'max_delayed_threads' trådar i använding"
         ukr "Забагато затриманих гілок використовується"
 ER_ABORTING_CONNECTION 08S01 
+        chi "终止连线 %ld 数据库: '%-.192s' 用户: '%-.48s' (%-.64s)"
         cze "Zrušeno spojení %ld do databáze: '%-.192s' uživatel: '%-.48s' (%-.64s)"
         dan "Afbrudt forbindelse %ld til database: '%-.192s' bruger: '%-.48s' (%-.64s)"
-        nla "Afgebroken verbinding %ld naar db: '%-.192s' gebruiker: '%-.48s' (%-.64s)"
         eng "Aborted connection %ld to db: '%-.192s' user: '%-.48s' (%-.64s)"
         est "Ühendus katkestatud %ld andmebaasile: '%-.192s' kasutajale: '%-.48s' (%-.64s)"
         fre "Connection %ld avortée vers la bd: '%-.192s' utilisateur: '%-.48s' (%-.64s)"
@@ -3469,6 +3614,7 @@ ER_ABORTING_CONNECTION 08S01
         ita "Interrotta la connessione %ld al db: '%-.192s' utente: '%-.48s' (%-.64s)"
         jpn "接続 %ld が中断されました。データベース: '%-.192s' ユーザー: '%-.48s' (%-.64s)"
         kor "데이타베이스 접속을 위한 연결 %ld가 중단됨 : '%-.192s' 사용자: '%-.48s' (%-.64s)"
+        nla "Afgebroken verbinding %ld naar db: '%-.192s' gebruiker: '%-.48s' (%-.64s)"
         nor "Aborted connection %ld to db: '%-.192s' user: '%-.48s' (%-.64s)"
         norwegian-ny "Aborted connection %ld to db: '%-.192s' user: '%-.48s' (%-.64s)"
         pol "Aborted connection %ld to db: '%-.192s' user: '%-.48s' (%-.64s)"
@@ -3481,9 +3627,9 @@ ER_ABORTING_CONNECTION 08S01
         swe "Avbröt länken för tråd %ld till db '%-.192s', användare '%-.48s' (%-.64s)"
         ukr "Перервано з'єднання %ld до бази данних: '%-.192s' користувача: '%-.48s' (%-.64s)"
 ER_NET_PACKET_TOO_LARGE 08S01 
+        chi "收到的数据包大于 'max_allowed_packet' 字节"
         cze "Zjištěn příchozí packet delší než 'max_allowed_packet'"
         dan "Modtog en datapakke som var større end 'max_allowed_packet'"
-        nla "Groter pakket ontvangen dan 'max_allowed_packet'"
         eng "Got a packet bigger than 'max_allowed_packet' bytes"
         est "Saabus suurem pakett kui lubatud 'max_allowed_packet' muutujaga"
         fre "Paquet plus grand que 'max_allowed_packet' reçu"
@@ -3493,6 +3639,7 @@ ER_NET_PACKET_TOO_LARGE 08S01
         ita "Ricevuto un pacchetto piu` grande di 'max_allowed_packet'"
         jpn "'max_allowed_packet'よりも大きなパケットを受信しました。"
         kor "'max_allowed_packet'보다 더큰 패킷을 받았습니다."
+        nla "Groter pakket ontvangen dan 'max_allowed_packet'"
         por "Obteve um pacote maior do que a taxa máxima de pacotes definida (max_allowed_packet)"
         rum "Un packet mai mare decit 'max_allowed_packet' a fost primit"
         rus "Полученный пакет больше, чем 'max_allowed_packet'"
@@ -3501,9 +3648,9 @@ ER_NET_PACKET_TOO_LARGE 08S01
         swe "Kommunkationspaketet är större än 'max_allowed_packet'"
         ukr "Отримано пакет більший ніж max_allowed_packet"
 ER_NET_READ_ERROR_FROM_PIPE 08S01 
+        chi "连接管道读取错误"
         cze "Zjištěna chyba při čtení z roury spojení"
         dan "Fik læsefejl fra forbindelse (connection pipe)"
-        nla "Kreeg leesfout van de verbindings pipe"
         eng "Got a read error from the connection pipe"
         est "Viga ühendustoru lugemisel"
         fre "Erreur de lecture reçue du pipe de connexion"
@@ -3513,6 +3660,7 @@ ER_NET_READ_ERROR_FROM_PIPE 08S01
         ita "Rilevato un errore di lettura dalla pipe di connessione"
         jpn "接続パイプの読み込みエラーです。"
         kor "연결 파이프로부터 에러가 발생하였습니다."
+        nla "Kreeg leesfout van de verbindings pipe"
         por "Obteve um erro de leitura no 'pipe' da conexão"
         rum "Eroare la citire din cauza lui 'connection pipe'"
         rus "Получена ошибка чтения от потока соединения (connection pipe)"
@@ -3521,9 +3669,9 @@ ER_NET_READ_ERROR_FROM_PIPE 08S01
         swe "Fick läsfel från klienten vid läsning från 'PIPE'"
         ukr "Отримано помилку читання з комунікаційного каналу"
 ER_NET_FCNTL_ERROR 08S01 
+        chi "fcntl（）的错误"
         cze "Zjištěna chyba fcntl()"
         dan "Fik fejlmeddelelse fra fcntl()"
-        nla "Kreeg fout van fcntl()"
         eng "Got an error from fcntl()"
         est "fcntl() tagastas vea"
         fre "Erreur reçue de fcntl() "
@@ -3533,6 +3681,7 @@ ER_NET_FCNTL_ERROR 08S01
         ita "Rilevato un errore da fcntl()"
         jpn "fcntl()がエラーを返しました。"
         kor "fcntl() 함수로부터 에러가 발생하였습니다."
+        nla "Kreeg fout van fcntl()"
         por "Obteve um erro em fcntl()"
         rum "Eroare obtinuta de la fcntl()"
         rus "Получена ошибка от fcntl()"
@@ -3541,9 +3690,9 @@ ER_NET_FCNTL_ERROR 08S01
         swe "Fick fatalt fel från 'fcntl()'"
         ukr "Отримано помилкку від fcntl()"
 ER_NET_PACKETS_OUT_OF_ORDER 08S01 
+        chi "数据包乱序"
         cze "Příchozí packety v chybném pořadí"
         dan "Modtog ikke datapakker i korrekt rækkefølge"
-        nla "Pakketten in verkeerde volgorde ontvangen"
         eng "Got packets out of order"
         est "Paketid saabusid vales järjekorras"
         fre "Paquets reçus dans le désordre"
@@ -3553,6 +3702,7 @@ ER_NET_PACKETS_OUT_OF_ORDER 08S01
         ita "Ricevuti pacchetti non in ordine"
         jpn "不正な順序のパケットを受信しました。"
         kor "순서가 맞지않는 패킷을 받았습니다."
+        nla "Pakketten in verkeerde volgorde ontvangen"
         por "Obteve pacotes fora de ordem"
         rum "Packets care nu sint ordonati au fost gasiti"
         rus "Пакеты получены в неверном порядке"
@@ -3561,9 +3711,9 @@ ER_NET_PACKETS_OUT_OF_ORDER 08S01
         swe "Kommunikationspaketen kom i fel ordning"
         ukr "Отримано пакети у неналежному порядку"
 ER_NET_UNCOMPRESS_ERROR 08S01 
+        chi "无法解压缩通信数据包"
         cze "Nemohu rozkomprimovat komunikační packet"
         dan "Kunne ikke dekomprimere kommunikations-pakke (communication packet)"
-        nla "Communicatiepakket kon niet worden gedecomprimeerd"
         eng "Couldn't uncompress communication packet"
         est "Viga andmepaketi lahtipakkimisel"
         fre "Impossible de décompresser le paquet reçu"
@@ -3573,6 +3723,7 @@ ER_NET_UNCOMPRESS_ERROR 08S01
         ita "Impossibile scompattare i pacchetti di comunicazione"
         jpn "圧縮パケットの展開ができませんでした。"
         kor "통신 패킷의 압축해제를 할 수 없었습니다."
+        nla "Communicatiepakket kon niet worden gedecomprimeerd"
         por "Não conseguiu descomprimir pacote de comunicação"
         rum "Nu s-a putut decompresa pachetul de comunicatie (communication packet)"
         rus "Невозможно распаковать пакет, полученный через коммуникационный протокол"
@@ -3581,9 +3732,9 @@ ER_NET_UNCOMPRESS_ERROR 08S01
         swe "Kunde inte packa up kommunikationspaketet"
         ukr "Не можу декомпресувати комунікаційний пакет"
 ER_NET_READ_ERROR 08S01 
+        chi "读取通信数据包出错"
         cze "Zjištěna chyba při čtení komunikačního packetu"
         dan "Fik fejlmeddelelse ved læsning af kommunikations-pakker (communication packets)"
-        nla "Fout bij het lezen van communicatiepakketten"
         eng "Got an error reading communication packets"
         est "Viga andmepaketi lugemisel"
         fre "Erreur de lecture des paquets reçus"
@@ -3593,6 +3744,7 @@ ER_NET_READ_ERROR 08S01
         ita "Rilevato un errore ricevendo i pacchetti di comunicazione"
         jpn "パケットの受信でエラーが発生しました。"
         kor "통신 패킷을 읽는 중 오류가 발생하였습니다."
+        nla "Fout bij het lezen van communicatiepakketten"
         por "Obteve um erro na leitura de pacotes de comunicação"
         rum "Eroare obtinuta citind pachetele de comunicatie (communication packets)"
         rus "Получена ошибка в процессе получения пакета через коммуникационный протокол "
@@ -3601,9 +3753,9 @@ ER_NET_READ_ERROR 08S01
         swe "Fick ett fel vid läsning från klienten"
         ukr "Отримано помилку читання комунікаційних пакетів"
 ER_NET_READ_INTERRUPTED 08S01 
+        chi "读取通信包超时"
         cze "Zjištěn timeout při čtení komunikačního packetu"
         dan "Timeout-fejl ved læsning af kommunukations-pakker (communication packets)"
-        nla "Timeout bij het lezen van communicatiepakketten"
         eng "Got timeout reading communication packets"
         est "Kontrollaja ületamine andmepakettide lugemisel"
         fre "Timeout en lecture des paquets reçus"
@@ -3613,6 +3765,7 @@ ER_NET_READ_INTERRUPTED 08S01
         ita "Rilevato un timeout ricevendo i pacchetti di comunicazione"
         jpn "パケットの受信でタイムアウトが発生しました。"
         kor "통신 패킷을 읽는 중 timeout이 발생하였습니다."
+        nla "Timeout bij het lezen van communicatiepakketten"
         por "Obteve expiração de tempo (timeout) na leitura de pacotes de comunicação"
         rum "Timeout obtinut citind pachetele de comunicatie (communication packets)"
         rus "Получен таймаут ожидания пакета через коммуникационный протокол "
@@ -3621,9 +3774,9 @@ ER_NET_READ_INTERRUPTED 08S01
         swe "Fick 'timeout' vid läsning från klienten"
         ukr "Отримано затримку читання комунікаційних пакетів"
 ER_NET_ERROR_ON_WRITE 08S01 
+        chi "写入通信包时出错"
         cze "Zjištěna chyba při zápisu komunikačního packetu"
         dan "Fik fejlmeddelelse ved skrivning af kommunukations-pakker (communication packets)"
-        nla "Fout bij het schrijven van communicatiepakketten"
         eng "Got an error writing communication packets"
         est "Viga andmepaketi kirjutamisel"
         fre "Erreur d'écriture des paquets envoyés"
@@ -3633,6 +3786,7 @@ ER_NET_ERROR_ON_WRITE 08S01
         ita "Rilevato un errore inviando i pacchetti di comunicazione"
         jpn "パケットの送信でエラーが発生しました。"
         kor "통신 패킷을 기록하는 중 오류가 발생하였습니다."
+        nla "Fout bij het schrijven van communicatiepakketten"
         por "Obteve um erro na escrita de pacotes de comunicação"
         rum "Eroare in scrierea pachetelor de comunicatie (communication packets)"
         rus "Получена ошибка при передаче пакета через коммуникационный протокол "
@@ -3641,9 +3795,9 @@ ER_NET_ERROR_ON_WRITE 08S01
         swe "Fick ett fel vid skrivning till klienten"
         ukr "Отримано помилку запису комунікаційних пакетів"
 ER_NET_WRITE_INTERRUPTED 08S01 
+        chi "写入通信包超时"
         cze "Zjištěn timeout při zápisu komunikačního packetu"
         dan "Timeout-fejl ved skrivning af kommunukations-pakker (communication packets)"
-        nla "Timeout bij het schrijven van communicatiepakketten"
         eng "Got timeout writing communication packets"
         est "Kontrollaja ületamine andmepakettide kirjutamisel"
         fre "Timeout d'écriture des paquets envoyés"
@@ -3653,6 +3807,7 @@ ER_NET_WRITE_INTERRUPTED 08S01
         ita "Rilevato un timeout inviando i pacchetti di comunicazione"
         jpn "パケットの送信でタイムアウトが発生しました。"
         kor "통신 패팃을 기록하는 중 timeout이 발생하였습니다."
+        nla "Timeout bij het schrijven van communicatiepakketten"
         por "Obteve expiração de tempo ('timeout') na escrita de pacotes de comunicação"
         rum "Timeout obtinut scriind pachetele de comunicatie (communication packets)"
         rus "Получен таймаут в процессе передачи пакета через коммуникационный протокол "
@@ -3661,18 +3816,19 @@ ER_NET_WRITE_INTERRUPTED 08S01
         swe "Fick 'timeout' vid skrivning till klienten"
         ukr "Отримано затримку запису комунікаційних пакетів"
 ER_TOO_LONG_STRING 42000 
+        chi "结果字符串长于'max_allowed_packet'字节"
         cze "Výsledný řetězec je delší než 'max_allowed_packet'"
         dan "Strengen med resultater er større end 'max_allowed_packet'"
-        nla "Resultaat string is langer dan 'max_allowed_packet'"
         eng "Result string is longer than 'max_allowed_packet' bytes"
         est "Tulemus on pikem kui lubatud 'max_allowed_packet' muutujaga"
         fre "La chaîne résultat est plus grande que 'max_allowed_packet'"
         ger "Ergebnis-String ist länger als 'max_allowed_packet' Bytes"
-        kor "결과 문자열이 설정된 max_allowed_packet 값보다 큽니다."
         hindi "रिजल्ट स्ट्रिंग 'max_allowed_packet' से लंबा है"
         hun "Ez eredmeny sztring nagyobb, mint a lehetseges maximum: 'max_allowed_packet'"
         ita "La stringa di risposta e` piu` lunga di 'max_allowed_packet'"
         jpn "結果の文字列が 'max_allowed_packet' よりも大きいです。"
+        kor "결과 문자열이 설정된 max_allowed_packet 값보다 큽니다."
+        nla "Resultaat string is langer dan 'max_allowed_packet'"
         por "'String' resultante é mais longa do que 'max_allowed_packet'"
         rum "Sirul rezultat este mai lung decit 'max_allowed_packet'"
         rus "Результирующая строка больше, чем 'max_allowed_packet'"
@@ -3681,17 +3837,18 @@ ER_TOO_LONG_STRING 42000
         swe "Resultatsträngen är längre än max_allowed_packet"
         ukr "Строка результату довша ніж max_allowed_packet"
 ER_TABLE_CANT_HANDLE_BLOB 42000 
+        chi "存储引擎%s不支持blob / text列"
         cze "Typ použité tabulky (%s) nepodporuje BLOB/TEXT sloupce"
         dan "Denne tabeltype (%s) understøtter ikke brug af BLOB og TEXT kolonner"
-        nla "Het gebruikte tabel type (%s) ondersteunt geen BLOB/TEXT kolommen"
         eng "Storage engine %s doesn't support BLOB/TEXT columns"
         est "Valitud tabelitüüp (%s) ei toeta BLOB/TEXT tüüpi välju"
         fre "Ce type de table (%s) ne supporte pas les colonnes BLOB/TEXT"
         ger "Der verwendete Tabellentyp (%s) unterstützt keine BLOB- und TEXT-Felder"
         hindi "स्टोरेज इंजन %s BLOB/TEXT कॉलम्स को सपोर्ट नहीं करता"
         hun "A hasznalt tabla tipus (%s) nem tamogatja a BLOB/TEXT mezoket"
-        kor "스토리지 엔진 (%s)는 BLOB/TEXT 컬럼을 지원하지 않습니다."
         ita "Il tipo di tabella usata (%s) non supporta colonne di tipo BLOB/TEXT"
+        kor "스토리지 엔진 (%s)는 BLOB/TEXT 컬럼을 지원하지 않습니다."
+        nla "Het gebruikte tabel type (%s) ondersteunt geen BLOB/TEXT kolommen"
         por "Tipo de tabela usado (%s) não permite colunas BLOB/TEXT"
         rum "Tipul de tabela folosit (%s) nu suporta coloane de tip BLOB/TEXT"
         rus "%s таблицы не поддерживают типы BLOB/TEXT"
@@ -3700,17 +3857,18 @@ ER_TABLE_CANT_HANDLE_BLOB 42000
         swe "Den använda tabelltypen (%s) kan inte hantera BLOB/TEXT-kolumner"
         ukr "%s таблиці не підтримують BLOB/TEXT стовбці"
 ER_TABLE_CANT_HANDLE_AUTO_INCREMENT 42000 
+        chi "存储引擎%s不支持auto_increment列"
         cze "Typ použité tabulky (%s) nepodporuje AUTO_INCREMENT sloupce"
         dan "Denne tabeltype understøtter (%s) ikke brug af AUTO_INCREMENT kolonner"
-        nla "Het gebruikte tabel type (%s) ondersteunt geen AUTO_INCREMENT kolommen"
         eng "Storage engine %s doesn't support AUTO_INCREMENT columns"
         est "Valitud tabelitüüp (%s) ei toeta AUTO_INCREMENT tüüpi välju"
         fre "Ce type de table (%s) ne supporte pas les colonnes AUTO_INCREMENT"
         ger "Der verwendete Tabellentyp (%s) unterstützt keine AUTO_INCREMENT-Felder"
         hindi "स्टोरेज इंजन %s AUTO_INCREMENT कॉलम्स को सपोर्ट नहीं करता"
-        kor "스토리지 엔진 (%s)는 AUTO_INCREMENT를 지원하지 않습니다."
         hun "A hasznalt tabla tipus (%s) nem tamogatja az AUTO_INCREMENT tipusu mezoket"
         ita "Il tipo di tabella usata (%s) non supporta colonne di tipo AUTO_INCREMENT"
+        kor "스토리지 엔진 (%s)는 AUTO_INCREMENT를 지원하지 않습니다."
+        nla "Het gebruikte tabel type (%s) ondersteunt geen AUTO_INCREMENT kolommen"
         por "Tipo de tabela usado (%s) não permite colunas AUTO_INCREMENT"
         rum "Tipul de tabela folosit (%s) nu suporta coloane de tip AUTO_INCREMENT"
         rus "%s таблицы не поддерживают автоинкрементные столбцы"
@@ -3719,9 +3877,9 @@ ER_TABLE_CANT_HANDLE_AUTO_INCREMENT 42000
         swe "Den använda tabelltypen (%s) kan inte hantera AUTO_INCREMENT-kolumner"
         ukr "%s таблиці не підтримують AUTO_INCREMENT стовбці"
 ER_DELAYED_INSERT_TABLE_LOCKED  
+        chi "INSERT DELAYED 不能用在表 '%-.192s' 因为它被LOCK TABLES 锁定"
         cze "INSERT DELAYED není možno s tabulkou '%-.192s' použít, protože je zamčená pomocí LOCK TABLES"
         dan "INSERT DELAYED kan ikke bruges med tabellen '%-.192s', fordi tabellen er låst med LOCK TABLES"
-        nla "INSERT DELAYED kan niet worden gebruikt bij table '%-.192s', vanwege een 'lock met LOCK TABLES"
         eng "INSERT DELAYED can't be used with table '%-.192s' because it is locked with LOCK TABLES"
         est "INSERT DELAYED ei saa kasutada tabeli '%-.192s' peal, kuna see on lukustatud LOCK TABLES käsuga"
         fre "INSERT DELAYED ne peut être utilisé avec la table '%-.192s', car elle est verrouée avec LOCK TABLES"
@@ -3731,6 +3889,7 @@ ER_DELAYED_INSERT_TABLE_LOCKED
         ita "L'inserimento ritardato (INSERT DELAYED) non puo` essere usato con la tabella '%-.192s', perche` soggetta a lock da 'LOCK TABLES'"
         jpn "表 '%-.192s' はLOCK TABLESでロックされているため、INSERT DELAYEDを使用できません。"
         kor "INSERT DELAYED can't be used with table '%-.192s', because it is locked with LOCK TABLES"
+        nla "INSERT DELAYED kan niet worden gebruikt bij table '%-.192s', vanwege een 'lock met LOCK TABLES"
         nor "INSERT DELAYED can't be used with table '%-.192s', because it is locked with LOCK TABLES"
         norwegian-ny "INSERT DELAYED can't be used with table '%-.192s', because it is locked with LOCK TABLES"
         pol "INSERT DELAYED can't be used with table '%-.192s', because it is locked with LOCK TABLES"
@@ -3743,9 +3902,9 @@ ER_DELAYED_INSERT_TABLE_LOCKED
         swe "INSERT DELAYED kan inte användas med tabell '%-.192s', emedan den är låst med LOCK TABLES"
         ukr "INSERT DELAYED не може бути використано з таблицею '%-.192s', тому що її заблоковано з LOCK TABLES"
 ER_WRONG_COLUMN_NAME 42000 
+        chi "错误列名 '%-.100s'"
         cze "Nesprávné jméno sloupce '%-.100s'"
         dan "Forkert kolonnenavn '%-.100s'"
-        nla "Incorrecte kolom naam '%-.100s'"
         eng "Incorrect column name '%-.100s'"
         est "Vigane tulba nimi '%-.100s'"
         fre "Nom de colonne '%-.100s' incorrect"
@@ -3754,6 +3913,7 @@ ER_WRONG_COLUMN_NAME 42000
         hun "Ervenytelen mezonev: '%-.100s'"
         ita "Nome colonna '%-.100s' non corretto"
         jpn "列名 '%-.100s' は不正です。"
+        nla "Incorrecte kolom naam '%-.100s'"
         por "Nome de coluna '%-.100s' incorreto"
         rum "Nume increct de coloana '%-.100s'"
         rus "Неверное имя столбца '%-.100s'"
@@ -3762,15 +3922,16 @@ ER_WRONG_COLUMN_NAME 42000
         swe "Felaktigt kolumnnamn '%-.100s'"
         ukr "Невірне ім'я стовбця '%-.100s'"
 ER_WRONG_KEY_COLUMN 42000 
+        chi "存储引擎 %s 不能给 %`s 列建索引"
         eng "The storage engine %s can't index column %`s"
         ger "Die Speicher-Engine %s kann die Spalte %`s nicht indizieren"
         hindi "स्टोरेज इंजन %s, कॉलम %`s को इंडेक्स नहीं कर सकता"
         rus "Обработчик таблиц %s не может проиндексировать столбец %`s"
         ukr "Вказівник таблиц %s не може індексувати стовбець %`s"
 ER_WRONG_MRG_TABLE  
+        chi "无法打开定义不同或非 MyISAM 类型或不存在的表"
         cze "Všechny tabulky v MERGE tabulce nejsou definovány stejně"
         dan "Tabellerne i MERGE er ikke defineret ens"
-        nla "Niet alle tabellen in de MERGE tabel hebben identieke gedefinities"
         eng "Unable to open underlying table which is differently defined or of non-MyISAM type or doesn't exist"
         est "Kõik tabelid MERGE tabeli määratluses ei ole identsed"
         fre "Toutes les tables de la table de type MERGE n'ont pas la même définition"
@@ -3779,6 +3940,7 @@ ER_WRONG_MRG_TABLE
         ita "Non tutte le tabelle nella tabella di MERGE sono definite in maniera identica"
         jpn "MERGE表の構成表がオープンできません。列定義が異なるか、MyISAM表ではないか、存在しません。"
         kor "All tables in the MERGE table are not defined identically"
+        nla "Niet alle tabellen in de MERGE tabel hebben identieke gedefinities"
         nor "All tables in the MERGE table are not defined identically"
         norwegian-ny "All tables in the MERGE table are not defined identically"
         pol "All tables in the MERGE table are not defined identically"
@@ -3791,16 +3953,17 @@ ER_WRONG_MRG_TABLE
         swe "Tabellerna i MERGE-tabellen är inte identiskt definierade"
         ukr "Таблиці у MERGE TABLE мають різну структуру"
 ER_DUP_UNIQUE 23000 
+        chi "因为表'%-.192s' 唯一约束，无法写入"
         cze "Kvůli unique constraintu nemozu zapsat do tabulky '%-.192s'"
         dan "Kan ikke skrive til tabellen '%-.192s' fordi det vil bryde CONSTRAINT regler"
-        nla "Kan niet opslaan naar table '%-.192s' vanwege 'unique' beperking"
         eng "Can't write, because of unique constraint, to table '%-.192s'"
         est "Ei suuda kirjutada tabelisse '%-.192s', kuna see rikub ühesuse kitsendust"
         fre "Écriture impossible à cause d'un index UNIQUE sur la table '%-.192s'"
         ger "Schreiben in Tabelle '%-.192s' nicht möglich wegen einer Eindeutigkeitsbeschränkung (unique constraint)"
         hun "A '%-.192s' nem irhato, az egyedi mezok miatt"
-        jpn "一意性制約違反のため、表 '%-.192s' に書き込めません。"
         ita "Impossibile scrivere nella tabella '%-.192s' per limitazione di unicita`"
+        jpn "一意性制約違反のため、表 '%-.192s' に書き込めません。"
+        nla "Kan niet opslaan naar table '%-.192s' vanwege 'unique' beperking"
         por "Não pode gravar, devido à restrição UNIQUE, na tabela '%-.192s'"
         rum "Nu pot scrie pe hard-drive, din cauza constraintului unic (unique constraint) pentru tabela '%-.192s'"
         rus "Невозможно записать в таблицу '%-.192s' из-за ограничений уникального ключа"
@@ -3809,9 +3972,9 @@ ER_DUP_UNIQUE 23000
         swe "Kan inte skriva till tabell '%-.192s'; UNIQUE-test"
         ukr "Не можу записати до таблиці '%-.192s', з причини вимог унікальності"
 ER_BLOB_KEY_WITHOUT_LENGTH 42000 
+        chi "BLOB/TEXT 列 '%-.192s' 在没有索引长度的索引规范中使用"
         cze "BLOB sloupec '%-.192s' je použit ve specifikaci klíče bez délky"
         dan "BLOB kolonnen '%-.192s' brugt i nøglespecifikation uden nøglelængde"
-        nla "BLOB kolom '%-.192s' gebruikt in zoeksleutel specificatie zonder zoeksleutel lengte"
         eng "BLOB/TEXT column '%-.192s' used in key specification without a key length"
         est "BLOB-tüüpi tulp '%-.192s' on kasutusel võtmes ilma pikkust määratlemata"
         fre "La colonne '%-.192s' de type BLOB est utilisée dans une définition d'index sans longueur d'index"
@@ -3821,6 +3984,7 @@ ER_BLOB_KEY_WITHOUT_LENGTH 42000
         ita "La colonna '%-.192s' di tipo BLOB e` usata in una chiave senza specificarne la lunghezza"
         jpn "BLOB列 '%-.192s' をキーに使用するには長さ指定が必要です。"
         kor "BLOB column '%-.192s' used in key specification without a key length"
+        nla "BLOB kolom '%-.192s' gebruikt in zoeksleutel specificatie zonder zoeksleutel lengte"
         nor "BLOB column '%-.192s' used in key specification without a key length"
         norwegian-ny "BLOB column '%-.192s' used in key specification without a key length"
         pol "BLOB column '%-.192s' used in key specification without a key length"
@@ -3833,9 +3997,9 @@ ER_BLOB_KEY_WITHOUT_LENGTH 42000
         swe "Du har inte angett någon nyckellängd för BLOB '%-.192s'"
         ukr "Стовбець BLOB '%-.192s' використано у визначенні ключа без вказання довжини ключа"
 ER_PRIMARY_CANT_HAVE_NULL 42000 
+        chi "PRIMARY KEY 的所有部分都不能为NULL；如果您需要在键中使用 NULL，请改用 UNIQUE"
         cze "Všechny části primárního klíče musejí být NOT NULL; pokud potřebujete NULL, použijte UNIQUE"
         dan "Alle dele af en PRIMARY KEY skal være NOT NULL;  Hvis du skal bruge NULL i nøglen, brug UNIQUE istedet"
-        nla "Alle delen van een PRIMARY KEY moeten NOT NULL zijn; Indien u NULL in een zoeksleutel nodig heeft kunt u UNIQUE gebruiken"
         eng "All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead"
         est "Kõik PRIMARY KEY peavad olema määratletud NOT NULL piiranguga; vajadusel kasuta UNIQUE tüüpi võtit"
         fre "Toutes les parties d'un index PRIMARY KEY doivent être NOT NULL; Si vous avez besoin d'un NULL dans l'index, utilisez un index UNIQUE"
@@ -3844,6 +4008,7 @@ ER_PRIMARY_CANT_HAVE_NULL 42000
         hun "Az elsodleges kulcs teljes egeszeben csak NOT NULL tipusu lehet; Ha NULL mezot szeretne a kulcskent, hasznalja inkabb a UNIQUE-ot"
         ita "Tutte le parti di una chiave primaria devono essere dichiarate NOT NULL; se necessitano valori NULL nelle chiavi utilizzare UNIQUE"
         jpn "PRIMARY KEYの列は全てNOT NULLでなければいけません。UNIQUE索引であればNULLを含むことが可能です。"
+        nla "Alle delen van een PRIMARY KEY moeten NOT NULL zijn; Indien u NULL in een zoeksleutel nodig heeft kunt u UNIQUE gebruiken"
         por "Todas as partes de uma chave primária devem ser não-nulas. Se você precisou usar um valor nulo (NULL) em uma chave, use a cláusula UNIQUE em seu lugar"
         rum "Toate partile unei chei primare (PRIMARY KEY) trebuie sa fie NOT NULL; Daca aveti nevoie de NULL in vreo cheie, folositi UNIQUE in schimb"
         rus "Все части первичного ключа (PRIMARY KEY) должны быть определены как NOT NULL; Если вам нужна поддержка величин NULL в ключе, воспользуйтесь индексом UNIQUE"
@@ -3852,9 +4017,9 @@ ER_PRIMARY_CANT_HAVE_NULL 42000
         swe "Alla delar av en PRIMARY KEY måste vara NOT NULL;  Om du vill ha en nyckel med NULL, använd UNIQUE istället"
         ukr "Усі частини PRIMARY KEY повинні бути NOT NULL; Якщо ви потребуєте NULL у ключі, скористайтеся UNIQUE"
 ER_TOO_MANY_ROWS 42000 
+        chi "结果多于一行"
         cze "Výsledek obsahuje více než jeden řádek"
         dan "Resultatet bestod af mere end een række"
-        nla "Resultaat bevatte meer dan een rij"
         eng "Result consisted of more than one row"
         est "Tulemis oli rohkem kui üks kirje"
         fre "Le résultat contient plus d'un enregistrement"
@@ -3863,6 +4028,7 @@ ER_TOO_MANY_ROWS 42000
         hun "Az eredmeny tobb, mint egy sort tartalmaz"
         ita "Il risultato consiste di piu` di una riga"
         jpn "結果が2行以上です。"
+        nla "Resultaat bevatte meer dan een rij"
         por "O resultado consistiu em mais do que uma linha"
         rum "Resultatul constista din mai multe linii"
         rus "В результате возвращена более чем одна строка"
@@ -3871,9 +4037,9 @@ ER_TOO_MANY_ROWS 42000
         swe "Resultet bestod av mera än en rad"
         ukr "Результат знаходиться у більше ніж одній строці"
 ER_REQUIRES_PRIMARY_KEY 42000 
+        chi "此表类型需要主索引"
         cze "Tento typ tabulky vyžaduje primární klíč"
         dan "Denne tabeltype kræver en primærnøgle"
-        nla "Dit tabel type heeft een primaire zoeksleutel nodig"
         eng "This table type requires a primary key"
         est "Antud tabelitüüp nõuab primaarset võtit"
         fre "Ce type de table nécessite une clé primaire (PRIMARY KEY)"
@@ -3882,6 +4048,7 @@ ER_REQUIRES_PRIMARY_KEY 42000
         hun "Az adott tablatipushoz elsodleges kulcs hasznalata kotelezo"
         ita "Questo tipo di tabella richiede una chiave primaria"
         jpn "使用のストレージエンジンでは、PRIMARY KEYが必要です。"
+        nla "Dit tabel type heeft een primaire zoeksleutel nodig"
         por "Este tipo de tabela requer uma chave primária"
         rum "Aceast tip de tabela are nevoie de o cheie primara"
         rus "Этот тип таблицы требует определения первичного ключа"
@@ -3890,9 +4057,9 @@ ER_REQUIRES_PRIMARY_KEY 42000
         swe "Denna tabelltyp kräver en PRIMARY KEY"
         ukr "Цей тип таблиці потребує первинного ключа"
 ER_NO_RAID_COMPILED  
+        chi "这个版本的 MariaDB 编译时不支持 RAID"
         cze "Tato verze MariaDB není zkompilována s podporou RAID"
         dan "Denne udgave af MariaDB er ikke oversat med understøttelse af RAID"
-        nla "Deze versie van MariaDB is niet gecompileerd met RAID ondersteuning"
         eng "This version of MariaDB is not compiled with RAID support"
         est "Antud MariaDB versioon on kompileeritud ilma RAID toeta"
         fre "Cette version de MariaDB n'est pas compilée avec le support RAID"
@@ -3901,6 +4068,7 @@ ER_NO_RAID_COMPILED
         hun "Ezen leforditott MariaDB verzio nem tartalmaz RAID support-ot"
         ita "Questa versione di MYSQL non e` compilata con il supporto RAID"
         jpn "このバージョンのMariaDBはRAIDサポートを含めてコンパイルされていません。"
+        nla "Deze versie van MariaDB is niet gecompileerd met RAID ondersteuning"
         por "Esta versão do MariaDB não foi compilada com suporte a RAID"
         rum "Aceasta versiune de MariaDB, nu a fost compilata cu suport pentru RAID"
         rus "Эта версия MariaDB скомпилирована без поддержки RAID"
@@ -3909,9 +4077,9 @@ ER_NO_RAID_COMPILED
         swe "Denna version av MariaDB är inte kompilerad med RAID"
         ukr "Ця версія MariaDB не зкомпільована з підтримкою RAID"
 ER_UPDATE_WITHOUT_KEY_IN_SAFE_MODE  
+        chi "您正在使用安全更新模式，同时您尝试更新时没有使用含有 KEY 列的 WHERE 语句"
         cze "Update tabulky bez WHERE s klíčem není v módu bezpečných update dovoleno"
         dan "Du bruger sikker opdaterings modus ('safe update mode') og du forsøgte at opdatere en tabel uden en WHERE klausul, der gør brug af et KEY felt"
-        nla "U gebruikt 'safe update mode' en u probeerde een tabel te updaten zonder een WHERE met een KEY kolom"
         eng "You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column"
         est "Katse muuta tabelit turvalises rezhiimis ilma WHERE klauslita"
         fre "Vous êtes en mode 'safe update' et vous essayez de faire un UPDATE sans clause WHERE utilisant un index"
@@ -3919,6 +4087,7 @@ ER_UPDATE_WITHOUT_KEY_IN_SAFE_MODE
         hun "On a biztonsagos update modot hasznalja, es        WHERE that uses a KEY column"
         ita "In modalita` 'safe update' si e` cercato di aggiornare una tabella senza clausola WHERE su una chiave"
         jpn "'safe update mode'で、索引を利用するWHERE句の無い更新処理を実行しようとしました。"
+        nla "U gebruikt 'safe update mode' en u probeerde een tabel te updaten zonder een WHERE met een KEY kolom"
         por "Você está usando modo de atualização seguro e tentou atualizar uma tabela sem uma cláusula WHERE que use uma coluna chave"
         rus "Вы работаете в режиме безопасных обновлений (safe update mode) и попробовали изменить таблицу без использования ключевого столбца в части WHERE"
         serbian "Vi koristite safe update mod servera, a probali ste da promenite podatke bez 'WHERE' komande koja koristi kolonu ključa"
@@ -3926,9 +4095,9 @@ ER_UPDATE_WITHOUT_KEY_IN_SAFE_MODE
         swe "Du använder 'säker uppdateringsmod' och försökte uppdatera en tabell utan en WHERE-sats som använder sig av en nyckel"
         ukr "Ви у режимі безпечного оновлення та намагаєтесь оновити таблицю без оператора WHERE, що використовує KEY стовбець"
 ER_KEY_DOES_NOT_EXITS 42000 S1009
+        chi "索引 '%-.192s' 在表 '%-.192s' 里不存在"
         cze "Klíč '%-.192s' v tabulce '%-.192s' neexistuje"
         dan "Nøglen '%-.192s' eksisterer ikke i tabellen '%-.192s'"
-        nla "Zoeksleutel '%-.192s' bestaat niet in tabel '%-.192s'"
         eng "Key '%-.192s' doesn't exist in table '%-.192s'"
         est "Võti '%-.192s' ei eksisteeri tabelis '%-.192s'"
         fre "L'index '%-.192s' n'existe pas sur la table '%-.192s'"
@@ -3937,6 +4106,7 @@ ER_KEY_DOES_NOT_EXITS 42000 S1009
         hun "A '%-.192s' kulcs nem letezik a '%-.192s' tablaban"
         ita "La chiave '%-.192s' non esiste nella tabella '%-.192s'"
         jpn "索引 '%-.192s' は表 '%-.192s' には存在しません。"
+        nla "Zoeksleutel '%-.192s' bestaat niet in tabel '%-.192s'"
         por "Chave '%-.192s' não existe na tabela '%-.192s'"
         rus "Ключ '%-.192s' не существует в таблице '%-.192s'"
         serbian "Ključ '%-.192s' ne postoji u tabeli '%-.192s'"
@@ -3944,9 +4114,9 @@ ER_KEY_DOES_NOT_EXITS 42000 S1009
         swe "Nyckel '%-.192s' finns inte in tabell '%-.192s'"
         ukr "Ключ '%-.192s' не існує в таблиці '%-.192s'"
 ER_CHECK_NO_SUCH_TABLE 42000 
+        chi "无法打开表"
         cze "Nemohu otevřít tabulku"
         dan "Kan ikke åbne tabellen"
-        nla "Kan tabel niet openen"
         eng "Can't open table"
         est "Ei suuda avada tabelit"
         fre "Impossible d'ouvrir la table"
@@ -3955,6 +4125,7 @@ ER_CHECK_NO_SUCH_TABLE 42000
         hun "Nem tudom megnyitni a tablat"
         ita "Impossibile aprire la tabella"
         jpn "表をオープンできません。"
+        nla "Kan tabel niet openen"
         por "Não pode abrir a tabela"
         rus "Невозможно открыть таблицу"
         serbian "Ne mogu da otvorim tabelu"
@@ -3962,9 +4133,9 @@ ER_CHECK_NO_SUCH_TABLE 42000
         swe "Kan inte öppna tabellen"
         ukr "Не можу відкрити таблицю"
 ER_CHECK_NOT_IMPLEMENTED 42000 
+        chi "该表的存储引擎不支持%s"
         cze "Handler tabulky nepodporuje %s"
         dan "Denne tabeltype understøtter ikke %s"
-        nla "De 'handler' voor de tabel ondersteund geen %s"
         eng "The storage engine for the table doesn't support %s"
         est "Antud tabelitüüp ei toeta %s käske"
         fre "Ce type de table ne supporte pas les %s"
@@ -3975,6 +4146,7 @@ ER_CHECK_NOT_IMPLEMENTED 42000
         ita "Il gestore per la tabella non supporta il %s"
         jpn "この表のストレージエンジンは '%s' を利用できません。"
         kor "The handler for the table doesn't support %s"
+        nla "De 'handler' voor de tabel ondersteund geen %s"
         nor "The handler for the table doesn't support %s"
         norwegian-ny "The handler for the table doesn't support %s"
         pol "The handler for the table doesn't support %s"
@@ -3987,9 +4159,9 @@ ER_CHECK_NOT_IMPLEMENTED 42000
         swe "Tabellhanteraren för denna tabell kan inte göra %s"
         ukr "Вказівник таблиці не підтримуе %s"
 ER_CANT_DO_THIS_DURING_AN_TRANSACTION 25000 
+        chi "不允许在事务中执行此命令"
         cze "Provedení tohoto příkazu není v transakci dovoleno"
         dan "Du må ikke bruge denne kommando i en transaktion"
-        nla "Het is u niet toegestaan dit commando uit te voeren binnen een transactie"
         eng "You are not allowed to execute this command in a transaction"
         est "Seda käsku ei saa kasutada transaktsiooni sees"
         fre "Vous n'êtes pas autorisé à exécute cette commande dans une transaction"
@@ -3997,6 +4169,7 @@ ER_CANT_DO_THIS_DURING_AN_TRANSACTION 25000
         hun "Az On szamara nem engedelyezett a parancs vegrehajtasa a tranzakcioban"
         ita "Non puoi eseguire questo comando in una transazione"
         jpn "このコマンドはトランザクション内で実行できません。"
+        nla "Het is u niet toegestaan dit commando uit te voeren binnen een transactie"
         por "Não lhe é permitido executar este comando em uma transação"
         rus "Вам не разрешено выполнять эту команду в транзакции"
         serbian "Nije Vam dozvoljeno da izvršite ovu komandu u transakciji"
@@ -4004,9 +4177,9 @@ ER_CANT_DO_THIS_DURING_AN_TRANSACTION 25000
         swe "Du får inte utföra detta kommando i en transaktion"
         ukr "Вам не дозволено виконувати цю команду в транзакції"
 ER_ERROR_DURING_COMMIT  
+        chi "COMMIT时发生错误 %M "
         cze "Chyba %M při COMMIT"
         dan "Modtog fejl %M mens kommandoen COMMIT blev udført"
-        nla "Kreeg fout %M tijdens COMMIT"
         eng "Got error %M during COMMIT"
         est "Viga %M käsu COMMIT täitmisel"
         fre "Erreur %M lors du COMMIT"
@@ -4015,6 +4188,7 @@ ER_ERROR_DURING_COMMIT
         hun "%M hiba a COMMIT vegrehajtasa soran"
         ita "Rilevato l'errore %M durante il COMMIT"
         jpn "COMMIT中にエラー %M が発生しました。"
+        nla "Kreeg fout %M tijdens COMMIT"
         por "Obteve erro %M durante COMMIT"
         rus "Получена ошибка %M в процессе COMMIT"
         serbian "Greška %M za vreme izvršavanja komande 'COMMIT'"
@@ -4022,9 +4196,9 @@ ER_ERROR_DURING_COMMIT
         swe "Fick fel %M vid COMMIT"
         ukr "Отримано помилку %M під час COMMIT"
 ER_ERROR_DURING_ROLLBACK  
+        chi "回滚时出错%M"
         cze "Chyba %M při ROLLBACK"
         dan "Modtog fejl %M mens kommandoen ROLLBACK blev udført"
-        nla "Kreeg fout %M tijdens ROLLBACK"
         eng "Got error %M during ROLLBACK"
         est "Viga %M käsu ROLLBACK täitmisel"
         fre "Erreur %M lors du ROLLBACK"
@@ -4033,6 +4207,7 @@ ER_ERROR_DURING_ROLLBACK
         hun "%M hiba a ROLLBACK vegrehajtasa soran"
         ita "Rilevato l'errore %M durante il ROLLBACK"
         jpn "ROLLBACK中にエラー %M が発生しました。"
+        nla "Kreeg fout %M tijdens ROLLBACK"
         por "Obteve erro %M durante ROLLBACK"
         rus "Получена ошибка %M в процессе ROLLBACK"
         serbian "Greška %M za vreme izvršavanja komande 'ROLLBACK'"
@@ -4040,9 +4215,9 @@ ER_ERROR_DURING_ROLLBACK
         swe "Fick fel %M vid ROLLBACK"
         ukr "Отримано помилку %M під час ROLLBACK"
 ER_ERROR_DURING_FLUSH_LOGS  
+        chi "flush_logs时出错%M"
         cze "Chyba %M při FLUSH_LOGS"
         dan "Modtog fejl %M mens kommandoen FLUSH_LOGS blev udført"
-        nla "Kreeg fout %M tijdens FLUSH_LOGS"
         eng "Got error %M during FLUSH_LOGS"
         est "Viga %M käsu FLUSH_LOGS täitmisel"
         fre "Erreur %M lors du FLUSH_LOGS"
@@ -4051,6 +4226,7 @@ ER_ERROR_DURING_FLUSH_LOGS
         hun "%M hiba a FLUSH_LOGS vegrehajtasa soran"
         ita "Rilevato l'errore %M durante il FLUSH_LOGS"
         jpn "FLUSH_LOGS中にエラー %M が発生しました。"
+        nla "Kreeg fout %M tijdens FLUSH_LOGS"
         por "Obteve erro %M durante FLUSH_LOGS"
         rus "Получена ошибка %M в процессе FLUSH_LOGS"
         serbian "Greška %M za vreme izvršavanja komande 'FLUSH_LOGS'"
@@ -4058,9 +4234,9 @@ ER_ERROR_DURING_FLUSH_LOGS
         swe "Fick fel %M vid FLUSH_LOGS"
         ukr "Отримано помилку %M під час FLUSH_LOGS"
 ER_ERROR_DURING_CHECKPOINT  
+        chi "CHECKPOINT时出错%M "
         cze "Chyba %M při CHECKPOINT"
         dan "Modtog fejl %M mens kommandoen CHECKPOINT blev udført"
-        nla "Kreeg fout %M tijdens CHECKPOINT"
         eng "Got error %M during CHECKPOINT"
         est "Viga %M käsu CHECKPOINT täitmisel"
         fre "Erreur %M lors du CHECKPOINT"
@@ -4069,6 +4245,7 @@ ER_ERROR_DURING_CHECKPOINT
         hun "%M hiba a CHECKPOINT vegrehajtasa soran"
         ita "Rilevato l'errore %M durante il CHECKPOINT"
         jpn "CHECKPOINT中にエラー %M が発生しました。"
+        nla "Kreeg fout %M tijdens CHECKPOINT"
         por "Obteve erro %M durante CHECKPOINT"
         rus "Получена ошибка %M в процессе CHECKPOINT"
         serbian "Greška %M za vreme izvršavanja komande 'CHECKPOINT'"
@@ -4076,15 +4253,16 @@ ER_ERROR_DURING_CHECKPOINT
         swe "Fick fel %M vid CHECKPOINT"
         ukr "Отримано помилку %M під час CHECKPOINT"
 ER_NEW_ABORTING_CONNECTION 08S01 
+        chi "终止的连接 %lld 到数据库: '%-.192s' 用户: '%-.48s' 主机: '%-.64s' (%-.64s)"
         cze "Spojení %lld do databáze: '%-.192s' uživatel: '%-.48s' stroj: '%-.64s' (%-.64s) bylo přerušeno"
         dan "Afbrød forbindelsen %lld til databasen '%-.192s' bruger: '%-.48s' vært: '%-.64s' (%-.64s)"
-        nla "Afgebroken verbinding %lld naar db: '%-.192s' gebruiker: '%-.48s' host: '%-.64s' (%-.64s)"
         eng "Aborted connection %lld to db: '%-.192s' user: '%-.48s' host: '%-.64s' (%-.64s)"
         est "Ühendus katkestatud %lld andmebaas: '%-.192s' kasutaja: '%-.48s' masin: '%-.64s' (%-.64s)"
         fre "Connection %lld avortée vers la bd: '%-.192s' utilisateur: '%-.48s' hôte: '%-.64s' (%-.64s)"
         ger "Abbruch der Verbindung %lld zur Datenbank '%-.192s'. Benutzer: '%-.48s', Host: '%-.64s' (%-.64s)"
         ita "Interrotta la connessione %lld al db: ''%-.192s' utente: '%-.48s' host: '%-.64s' (%-.64s)"
         jpn "接続 %lld が中断されました。データベース: '%-.192s' ユーザー: '%-.48s' ホスト: '%-.64s' (%-.64s)"
+        nla "Afgebroken verbinding %lld naar db: '%-.192s' gebruiker: '%-.48s' host: '%-.64s' (%-.64s)"
         por "Conexão %lld abortada para banco de dados '%-.192s' - usuário '%-.48s' - 'host' '%-.64s' ('%-.64s')"
         rus "Прервано соединение %lld к базе данных '%-.192s' пользователя '%-.48s' с хоста '%-.64s' (%-.64s)"
         serbian "Prekinuta konekcija broj %lld ka bazi: '%-.192s' korisnik je bio: '%-.48s' a host: '%-.64s' (%-.64s)"
@@ -4092,8 +4270,10 @@ ER_NEW_ABORTING_CONNECTION 08S01
         swe "Avbröt länken för tråd %lld till db '%-.192s', användare '%-.48s', host '%-.64s' (%-.64s)"
         ukr "Перервано з'єднання %lld до бази данних: '%-.192s' користувач: '%-.48s' хост: '%-.64s' (%-.64s)"
 ER_UNUSED_10
+        chi "你应当永远看不到这个"
         eng "You should never see it"
 ER_FLUSH_MASTER_BINLOG_CLOSED  
+        chi "Binlog 已关闭, 不能 RESET MASTER"
         eng "Binlog closed, cannot RESET MASTER"
         ger "Binlog geschlossen. Kann RESET MASTER nicht ausführen"
         jpn "バイナリログがクローズされています。RESET MASTER を実行できません。"
@@ -4102,9 +4282,9 @@ ER_FLUSH_MASTER_BINLOG_CLOSED
         serbian "Binarni log file zatvoren, ne mogu da izvršim komandu 'RESET MASTER'"
         ukr "Реплікаційний лог закрито, не можу виконати RESET MASTER"
 ER_INDEX_REBUILD  
+        chi "重建 dumped table '%-.192s' 的索引失败"
         cze "Přebudování indexu dumpnuté tabulky '%-.192s' nebylo úspěšné"
         dan "Kunne ikke genopbygge indekset for den dumpede tabel '%-.192s'"
-        nla "Gefaald tijdens heropbouw index van gedumpte tabel '%-.192s'"
         eng "Failed rebuilding the index of  dumped table '%-.192s'"
         fre "La reconstruction de l'index de la table copiée '%-.192s' a échoué"
         ger "Neuerstellung des Index der Dump-Tabelle '%-.192s' fehlgeschlagen"
@@ -4112,20 +4292,22 @@ ER_INDEX_REBUILD
         hun "Failed rebuilding the index of dumped table '%-.192s'"
         ita "Fallita la ricostruzione dell'indice della tabella copiata '%-.192s'"
         jpn "ダンプ表 '%-.192s' の索引再構築に失敗しました。"
+        nla "Gefaald tijdens heropbouw index van gedumpte tabel '%-.192s'"
         por "Falhou na reconstrução do índice da tabela 'dumped' '%-.192s'"
         rus "Ошибка перестройки индекса сохраненной таблицы '%-.192s'"
         serbian "Izgradnja indeksa dump-ovane tabele '%-.192s' nije uspela"
         spa "Falla reconstruyendo el indice de la tabla dumped '%-.192s'"
         ukr "Невдале відновлення індекса переданої таблиці '%-.192s'"
 ER_MASTER  
+        chi "Master错误：'%-.64s'"
         cze "Chyba masteru: '%-.64s'"
         dan "Fejl fra master: '%-.64s'"
-        nla "Fout van master: '%-.64s'"
         eng "Error from master: '%-.64s'"
         fre "Erreur reçue du maître: '%-.64s'"
         ger "Fehler vom Master: '%-.64s'"
         ita "Errore dal master: '%-.64s"
         jpn "マスターでエラーが発生: '%-.64s'"
+        nla "Fout van master: '%-.64s'"
         por "Erro no 'master' '%-.64s'"
         rus "Ошибка от головного сервера: '%-.64s'"
         serbian "Greška iz glavnog servera '%-.64s' u klasteru"
@@ -4133,14 +4315,15 @@ ER_MASTER
         swe "Fel från master: '%-.64s'"
         ukr "Помилка від головного: '%-.64s'"
 ER_MASTER_NET_READ 08S01 
+        chi "读master时有网络错误"
         cze "Síťová chyba při čtení z masteru"
         dan "Netværksfejl ved læsning fra master"
-        nla "Net fout tijdens lezen van master"
         eng "Net error reading from master"
         fre "Erreur de lecture réseau reçue du maître"
         ger "Netzfehler beim Lesen vom Master"
         ita "Errore di rete durante la ricezione dal master"
         jpn "マスターからのデータ受信中のネットワークエラー"
+        nla "Net fout tijdens lezen van master"
         por "Erro de rede lendo do 'master'"
         rus "Возникла ошибка чтения в процессе коммуникации с головным сервером"
         serbian "Greška u primanju mrežnih paketa sa glavnog servera u klasteru"
@@ -4148,14 +4331,15 @@ ER_MASTER_NET_READ 08S01
         swe "Fick nätverksfel vid läsning från master"
         ukr "Мережева помилка читання від головного"
 ER_MASTER_NET_WRITE 08S01 
+        chi "写master时有网络错误"
         cze "Síťová chyba při zápisu na master"
         dan "Netværksfejl ved skrivning til master"
-        nla "Net fout tijdens schrijven naar master"
         eng "Net error writing to master"
         fre "Erreur d'écriture réseau reçue du maître"
         ger "Netzfehler beim Schreiben zum Master"
         ita "Errore di rete durante l'invio al master"
         jpn "マスターへのデータ送信中のネットワークエラー"
+        nla "Net fout tijdens schrijven naar master"
         por "Erro de rede gravando no 'master'"
         rus "Возникла ошибка записи в процессе коммуникации с головным сервером"
         serbian "Greška u slanju mrežnih paketa na glavni server u klasteru"
@@ -4163,15 +4347,16 @@ ER_MASTER_NET_WRITE 08S01
         swe "Fick nätverksfel vid skrivning till master"
         ukr "Мережева помилка запису до головного"
 ER_FT_MATCHING_KEY_NOT_FOUND  
+        chi "找不到与列列表匹配的全文索引"
         cze "Žádný sloupec nemá vytvořen fulltextový index"
         dan "Kan ikke finde en FULLTEXT nøgle som svarer til kolonne listen"
-        nla "Kan geen FULLTEXT index vinden passend bij de kolom lijst"
         eng "Can't find FULLTEXT index matching the column list"
         est "Ei suutnud leida FULLTEXT indeksit, mis kattuks kasutatud tulpadega"
         fre "Impossible de trouver un index FULLTEXT correspondant à cette liste de colonnes"
         ger "Kann keinen FULLTEXT-Index finden, der der Feldliste entspricht"
         ita "Impossibile trovare un indice FULLTEXT che corrisponda all'elenco delle colonne"
         jpn "列リストに対応する全文索引(FULLTEXT)が見つかりません。"
+        nla "Kan geen FULLTEXT index vinden passend bij de kolom lijst"
         por "Não pode encontrar um índice para o texto todo que combine com a lista de colunas"
         rus "Невозможно отыскать полнотекстовый (FULLTEXT) индекс, соответствующий списку столбцов"
         serbian "Ne mogu da pronađem 'FULLTEXT' indeks koli odgovara listi kolona"
@@ -4179,15 +4364,16 @@ ER_FT_MATCHING_KEY_NOT_FOUND
         swe "Hittar inte ett FULLTEXT-index i kolumnlistan"
         ukr "Не можу знайти FULLTEXT індекс, що відповідає переліку стовбців"
 ER_LOCK_OR_ACTIVE_TRANSACTION  
+        chi "无法执行给定的命令，因为表上有锁或有活动事务"
         cze "Nemohu provést zadaný příkaz, protože existují aktivní zamčené tabulky nebo aktivní transakce"
         dan "Kan ikke udføre den givne kommando fordi der findes aktive, låste tabeller eller fordi der udføres en transaktion"
-        nla "Kan het gegeven commando niet uitvoeren, want u heeft actieve gelockte tabellen of een actieve transactie"
         eng "Can't execute the given command because you have active locked tables or an active transaction"
         est "Ei suuda täita antud käsku kuna on aktiivseid lukke või käimasolev transaktsioon"
         fre "Impossible d'exécuter la commande car vous avez des tables verrouillées ou une transaction active"
         ger "Kann den angegebenen Befehl wegen einer aktiven Tabellensperre oder einer aktiven Transaktion nicht ausführen"
         ita "Impossibile eseguire il comando richiesto: tabelle sotto lock o transazione in atto"
         jpn "すでにアクティブな表ロックやトランザクションがあるため、コマンドを実行できません。"
+        nla "Kan het gegeven commando niet uitvoeren, want u heeft actieve gelockte tabellen of een actieve transactie"
         por "Não pode executar o comando dado porque você tem tabelas ativas travadas ou uma transação ativa"
         rus "Невозможно выполнить указанную команду, поскольку у вас присутствуют активно заблокированные таблица или открытая транзакция"
         serbian "Ne mogu da izvršim datu komandu zbog toga što su tabele zaključane ili je transakcija u toku"
@@ -4195,9 +4381,9 @@ ER_LOCK_OR_ACTIVE_TRANSACTION
         swe "Kan inte utföra kommandot emedan du har en låst tabell eller an aktiv transaktion"
         ukr "Не можу виконати подану команду тому, що таблиця заблокована або виконується транзакція"
 ER_UNKNOWN_SYSTEM_VARIABLE  
+        chi "未知系统变量 '%-.*s'"
         cze "Neznámá systémová proměnná '%-.*s'"
         dan "Ukendt systemvariabel '%-.*s'"
-        nla "Onbekende systeem variabele '%-.*s'"
         eng "Unknown system variable '%-.*s'"
         est "Tundmatu süsteemne muutuja '%-.*s'"
         fre "Variable système '%-.*s' inconnue"
@@ -4205,6 +4391,7 @@ ER_UNKNOWN_SYSTEM_VARIABLE
         hindi "अज्ञात सिस्टम वैरिएबल '%-.*s'"
         ita "Variabile di sistema '%-.*s' sconosciuta"
         jpn "'%-.*s' は不明なシステム変数です。"
+        nla "Onbekende systeem variabele '%-.*s'"
         por "Variável de sistema '%-.*s' desconhecida"
         rus "Неизвестная системная переменная '%-.*s'"
         serbian "Nepoznata sistemska promenljiva '%-.*s'"
@@ -4212,15 +4399,16 @@ ER_UNKNOWN_SYSTEM_VARIABLE
         swe "Okänd systemvariabel: '%-.*s'"
         ukr "Невідома системна змінна '%-.*s'"
 ER_CRASHED_ON_USAGE  
+        chi "表'%-.192s'标记为崩溃，应该修复"
         cze "Tabulka '%-.192s' je označena jako porušená a měla by být opravena"
         dan "Tabellen '%-.192s' er markeret med fejl og bør repareres"
-        nla "Tabel '%-.192s' staat als gecrashed gemarkeerd en dient te worden gerepareerd"
         eng "Table '%-.192s' is marked as crashed and should be repaired"
         est "Tabel '%-.192s' on märgitud vigaseks ja tuleb parandada"
         fre "La table '%-.192s' est marquée 'crashed' et devrait être réparée"
         ger "Tabelle '%-.192s' ist als defekt markiert und sollte repariert werden"
         ita "La tabella '%-.192s' e` segnalata come corrotta e deve essere riparata"
         jpn "表 '%-.192s' は壊れています。修復が必要です。"
+        nla "Tabel '%-.192s' staat als gecrashed gemarkeerd en dient te worden gerepareerd"
         por "Tabela '%-.192s' está marcada como danificada e deve ser reparada"
         rus "Таблица '%-.192s' помечена как испорченная и должна пройти проверку и ремонт"
         serbian "Tabela '%-.192s' je markirana kao oštećena i trebala bi biti popravljena"
@@ -4228,15 +4416,16 @@ ER_CRASHED_ON_USAGE
         swe "Tabell '%-.192s' är trasig och bör repareras med REPAIR TABLE"
         ukr "Таблицю '%-.192s' марковано як зіпсовану та її потрібно відновити"
 ER_CRASHED_ON_REPAIR  
+        chi "表 '%-.192s' 被标记为崩溃，上一次的修复（自动？）失败"
         cze "Tabulka '%-.192s' je označena jako porušená a poslední (automatická?) oprava se nezdařila"
         dan "Tabellen '%-.192s' er markeret med fejl og sidste (automatiske?) REPAIR fejlede"
-        nla "Tabel '%-.192s' staat als gecrashed gemarkeerd en de laatste (automatische?) reparatie poging mislukte"
         eng "Table '%-.192s' is marked as crashed and last (automatic?) repair failed"
         est "Tabel '%-.192s' on märgitud vigaseks ja viimane (automaatne?) parandus ebaõnnestus"
         fre "La table '%-.192s' est marquée 'crashed' et le dernier 'repair' a échoué"
         ger "Tabelle '%-.192s' ist als defekt markiert und der letzte (automatische?) Reparaturversuch schlug fehl"
         ita "La tabella '%-.192s' e` segnalata come corrotta e l'ultima ricostruzione (automatica?) e` fallita"
         jpn "表 '%-.192s' は壊れています。修復(自動？)にも失敗しています。"
+        nla "Tabel '%-.192s' staat als gecrashed gemarkeerd en de laatste (automatische?) reparatie poging mislukte"
         por "Tabela '%-.192s' está marcada como danificada e a última reparação (automática?) falhou"
         rus "Таблица '%-.192s' помечена как испорченная и последний (автоматический?) ремонт не был успешным"
         serbian "Tabela '%-.192s' je markirana kao oštećena, a zadnja (automatska?) popravka je bila neuspela"
@@ -4244,14 +4433,15 @@ ER_CRASHED_ON_REPAIR
         swe "Tabell '%-.192s' är trasig och senast (automatiska?) reparation misslyckades"
         ukr "Таблицю '%-.192s' марковано як зіпсовану та останнє (автоматичне?) відновлення не вдалося"
 ER_WARNING_NOT_COMPLETE_ROLLBACK  
+        chi "某些非事务性更改的表无法回滚"
         dan "Advarsel: Visse data i tabeller der ikke understøtter transaktioner kunne ikke tilbagestilles"
-        nla "Waarschuwing: Roll back mislukt voor sommige buiten transacties gewijzigde tabellen"
         eng "Some non-transactional changed tables couldn't be rolled back"
         est "Hoiatus: mõnesid transaktsioone mittetoetavaid tabeleid ei suudetud tagasi kerida"
         fre "Attention: certaines tables ne supportant pas les transactions ont été changées et elles ne pourront pas être restituées"
         ger "Änderungen an einigen nicht transaktionalen Tabellen konnten nicht zurückgerollt werden"
         ita "Attenzione: Alcune delle modifiche alle tabelle non transazionali non possono essere ripristinate (roll back impossibile)"
         jpn "トランザクション対応ではない表への変更はロールバックされません。"
+        nla "Waarschuwing: Roll back mislukt voor sommige buiten transacties gewijzigde tabellen"
         por "Aviso: Algumas tabelas não-transacionais alteradas não puderam ser reconstituídas (rolled back)"
         rus "Внимание: по некоторым измененным нетранзакционным таблицам невозможно будет произвести откат транзакции"
         serbian "Upozorenje: Neke izmenjene tabele ne podržavaju komandu 'ROLLBACK'"
@@ -4259,26 +4449,28 @@ ER_WARNING_NOT_COMPLETE_ROLLBACK
         swe "Warning:  Några icke transaktionella tabeller kunde inte återställas vid ROLLBACK"
         ukr "Застереження: Деякі нетранзакційні зміни таблиць не можна буде повернути"
 ER_TRANS_CACHE_FULL  
+        chi "多语句事务需要超过 'max_binlog_cache_size' 字节的存储空间；增加这个 mysqld 变量后再试一次"
         dan "Fler-udtryks transaktion krævede mere plads en 'max_binlog_cache_size' bytes. Forhøj værdien af denne variabel og prøv igen"
-        nla "Multi-statement transactie vereist meer dan 'max_binlog_cache_size' bytes opslag. Verhoog deze mysqld variabele en probeer opnieuw"
         eng "Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mysqld variable and try again"
         est "Mitme lausendiga transaktsioon nõudis rohkem ruumi kui lubatud 'max_binlog_cache_size' muutujaga. Suurenda muutuja väärtust ja proovi uuesti"
         fre "Cette transaction à commandes multiples nécessite plus de 'max_binlog_cache_size' octets de stockage, augmentez cette variable de mysqld et réessayez"
         ger "Transaktionen, die aus mehreren Befehlen bestehen, benötigten mehr als 'max_binlog_cache_size' Bytes an Speicher. Btte vergrössern Sie diese Server-Variable versuchen Sie es noch einmal"
         ita "La transazione a comandi multipli (multi-statement) ha richiesto piu` di 'max_binlog_cache_size' bytes di disco: aumentare questa variabile di mysqld e riprovare"
         jpn "複数ステートメントから成るトランザクションが 'max_binlog_cache_size' 以上の容量を必要としました。このシステム変数を増加して、再試行してください。"
+        nla "Multi-statement transactie vereist meer dan 'max_binlog_cache_size' bytes opslag. Verhoog deze mysqld variabele en probeer opnieuw"
         por "Transações multi-declaradas (multi-statement transactions) requeriram mais do que o valor limite (max_binlog_cache_size) de bytes para armazenagem. Aumente o valor desta variável do mysqld e tente novamente"
         rus "Транзакции, включающей большое количество команд, потребовалось более чем 'max_binlog_cache_size' байт. Увеличьте эту переменную сервера mysqld и попробуйте еще раз"
         spa "Multipla transición necesita mas que 'max_binlog_cache_size' bytes de almacenamiento. Aumente esta variable mysqld y tente de nuevo"
         swe "Transaktionen krävde mera än 'max_binlog_cache_size' minne. Öka denna mysqld-variabel och försök på nytt"
         ukr "Транзакція з багатьма виразами вимагає більше ніж 'max_binlog_cache_size' байтів для зберігання. Збільште цю змінну mysqld та спробуйте знову"
 ER_SLAVE_MUST_STOP  
+        chi "这个操作不能执行，因为你有个正在运行的 slave '%2$*1$s'; 先运行 STOP SLAVE '%2$*1$s' 后再试"
         dan "Denne handling kunne ikke udføres med kørende slave '%2$*1$s', brug først kommandoen STOP SLAVE '%2$*1$s'"
-        nla "Deze operatie kan niet worden uitgevoerd met een actieve slave '%2$*1$s', doe eerst STOP SLAVE '%2$*1$s'"
         eng "This operation cannot be performed as you have a running slave '%2$*1$s'; run STOP SLAVE '%2$*1$s' first"
         fre "Cette opération ne peut être réalisée avec un esclave '%2$*1$s' actif, faites STOP SLAVE '%2$*1$s' d'abord"
         ger "Diese Operation kann bei einem aktiven Slave '%2$*1$s' nicht durchgeführt werden. Bitte zuerst STOP SLAVE '%2$*1$s' ausführen"
         ita "Questa operazione non puo' essere eseguita con un database 'slave' '%2$*1$s' che gira, lanciare prima STOP SLAVE '%2$*1$s'"
+        nla "Deze operatie kan niet worden uitgevoerd met een actieve slave '%2$*1$s', doe eerst STOP SLAVE '%2$*1$s'"
         por "Esta operação não pode ser realizada com um 'slave' '%2$*1$s' em execução. Execute STOP SLAVE '%2$*1$s' primeiro"
         rus "Эту операцию невозможно выполнить при работающем потоке подчиненного сервера %2$*1$s. Сначала выполните STOP SLAVE '%2$*1$s'"
         serbian "Ova operacija ne može biti izvršena dok je aktivan podređeni '%2$*1$s' server. Zadajte prvo komandu 'STOP SLAVE '%2$*1$s'' da zaustavite podređeni server"
@@ -4286,13 +4478,14 @@ ER_SLAVE_MUST_STOP
         swe "Denna operation kan inte göras under replikering; Du har en aktiv förbindelse till '%2$*1$s'. Gör STOP SLAVE '%2$*1$s' först"
         ukr "Операція не може бути виконана з запущеним підлеглим '%2$*1$s', спочатку виконайте STOP SLAVE '%2$*1$s'"
 ER_SLAVE_NOT_RUNNING  
+        chi "这个操作需要一个正在运行的slave；配置从机并执行 START SLAVE"
         dan "Denne handling kræver en kørende slave. Konfigurer en slave og brug kommandoen START SLAVE"
-        nla "Deze operatie vereist een actieve slave, configureer slave en doe dan START SLAVE"
         eng "This operation requires a running slave; configure slave and do START SLAVE"
         fre "Cette opération nécessite un esclave actif, configurez les esclaves et faites START SLAVE"
         ger "Diese Operation benötigt einen aktiven Slave. Bitte Slave konfigurieren und mittels START SLAVE aktivieren"
         ita "Questa operaione richiede un database 'slave', configurarlo ed eseguire START SLAVE"
         jpn "この処理は、稼働中のスレーブでなければ実行できません。スレーブの設定をしてSTART SLAVEコマンドを実行してください。"
+        nla "Deze operatie vereist een actieve slave, configureer slave en doe dan START SLAVE"
         por "Esta operação requer um 'slave' em execução. Configure  o 'slave' e execute START SLAVE"
         rus "Для этой операции требуется работающий подчиненный сервер. Сначала выполните START SLAVE"
         serbian "Ova operacija zahteva da je aktivan podređeni server. Konfigurišite prvo podređeni server i onda izvršite komandu 'START SLAVE'"
@@ -4300,13 +4493,14 @@ ER_SLAVE_NOT_RUNNING
         swe "Denna operation kan endast göras under replikering; Konfigurera slaven och gör START SLAVE"
         ukr "Операція вимагає запущеного підлеглого, зконфігуруйте підлеглого та виконайте START SLAVE"
 ER_BAD_SLAVE  
+        chi "服务器未配置为从站;修复配置文件或使用CHANGE MASTER TO"
         dan "Denne server er ikke konfigureret som slave. Ret in config-filen eller brug kommandoen CHANGE MASTER TO"
-        nla "De server is niet geconfigureerd als slave, fix in configuratie bestand of met CHANGE MASTER TO"
         eng "The server is not configured as slave; fix in config file or with CHANGE MASTER TO"
         fre "Le server n'est pas configuré comme un esclave, changez le fichier de configuration ou utilisez CHANGE MASTER TO"
         ger "Der Server ist nicht als Slave konfiguriert. Bitte in der Konfigurationsdatei oder mittels CHANGE MASTER TO beheben"
         ita "Il server non e' configurato come 'slave', correggere il file di configurazione cambiando CHANGE MASTER TO"
         jpn "このサーバーはスレーブとして設定されていません。コンフィグファイルかCHANGE MASTER TOコマンドで設定して下さい。"
+        nla "De server is niet geconfigureerd als slave, fix in configuratie bestand of met CHANGE MASTER TO"
         por "O servidor não está configurado como 'slave'. Acerte o arquivo de configuração ou use CHANGE MASTER TO"
         rus "Этот сервер не настроен как подчиненный. Внесите исправления в конфигурационном файле или с помощью CHANGE MASTER TO"
         serbian "Server nije konfigurisan kao podređeni server, ispravite konfiguracioni file ili na njemu izvršite komandu 'CHANGE MASTER TO'"
@@ -4314,6 +4508,7 @@ ER_BAD_SLAVE
         swe "Servern är inte konfigurerade som en replikationsslav. Ändra konfigurationsfilen eller gör CHANGE MASTER TO"
         ukr "Сервер не зконфігуровано як підлеглий, виправте це у файлі конфігурації або з CHANGE MASTER TO"
 ER_MASTER_INFO  
+        chi "无法初始化'%.*s'的master info structure;MariaDB错误日志中可以找到更多错误消息"
         eng "Could not initialize master info structure for '%.*s'; more error messages can be found in the MariaDB error log"
         fre "Impossible d'initialiser les structures d'information de maître '%.*s', vous trouverez des messages d'erreur supplémentaires dans le journal des erreurs de MariaDB"
         ger "Konnte Master-Info-Struktur '%.*s' nicht initialisieren. Weitere Fehlermeldungen können im MariaDB-Error-Log eingesehen werden"
@@ -4322,13 +4517,14 @@ ER_MASTER_INFO
         swe "Kunde inte initialisera replikationsstrukturerna för '%.*s'. See MariaDB fel fil för mera information"
         ukr "Інформаційна структура з'єднання головного і підлеглого (master.info) для '%.*s' не може бути ініціалізована"
 ER_SLAVE_THREAD
+        chi "无法创建slave线程;检查系统资源"
         dan "Kunne ikke danne en slave-tråd; check systemressourcerne"
-        nla "Kon slave thread niet aanmaken, controleer systeem resources"
         eng "Could not create slave thread; check system resources"
         fre "Impossible de créer une tâche esclave, vérifiez les ressources système"
         ger "Konnte Slave-Thread nicht starten. Bitte System-Ressourcen überprüfen"
         ita "Impossibile creare il thread 'slave', controllare le risorse di sistema"
         jpn "スレーブスレッドを作成できません。システムリソースを確認してください。"
+        nla "Kon slave thread niet aanmaken, controleer systeem resources"
         por "Não conseguiu criar 'thread' de 'slave'. Verifique os recursos do sistema"
         rus "Невозможно создать поток подчиненного сервера. Проверьте системные ресурсы"
         serbian "Nisam mogao da startujem thread za podređeni server, proverite sistemske resurse"
@@ -4336,8 +4532,8 @@ ER_SLAVE_THREAD
         swe "Kunde inte starta en tråd för replikering"
         ukr "Не можу створити підлеглу гілку, перевірте системні ресурси"
 ER_TOO_MANY_USER_CONNECTIONS 42000 
+        chi "用户%-.64s已经拥有超过“max_user_conections”的活连接"
         dan "Brugeren %-.64s har allerede mere end 'max_user_connections' aktive forbindelser"
-        nla "Gebruiker %-.64s heeft reeds meer dan 'max_user_connections' actieve verbindingen"
         eng "User %-.64s already has more than 'max_user_connections' active connections"
         est "Kasutajal %-.64s on juba rohkem ühendusi kui lubatud 'max_user_connections' muutujaga"
         fre "L'utilisateur %-.64s possède déjà plus de 'max_user_connections' connexions actives"
@@ -4345,6 +4541,7 @@ ER_TOO_MANY_USER_CONNECTIONS 42000
         hindi "यूज़र %-.64s के पहले से ही 'max_user_connections' से अधिक सक्रिय कनेक्शन्स हैं"
         ita "L'utente %-.64s ha gia' piu' di 'max_user_connections' connessioni attive"
         jpn "ユーザー '%-.64s' はすでに 'max_user_connections' 以上のアクティブな接続を行っています。"
+        nla "Gebruiker %-.64s heeft reeds meer dan 'max_user_connections' actieve verbindingen"
         por "Usuário '%-.64s' já possui mais que o valor máximo de conexões (max_user_connections) ativas"
         rus "У пользователя %-.64s уже больше чем 'max_user_connections' активных соединений"
         serbian "Korisnik %-.64s već ima više aktivnih konekcija nego što je to određeno 'max_user_connections' promenljivom"
@@ -4352,8 +4549,8 @@ ER_TOO_MANY_USER_CONNECTIONS 42000
         swe "Användare '%-.64s' har redan 'max_user_connections' aktiva inloggningar"
         ukr "Користувач %-.64s вже має більше ніж 'max_user_connections' активних з'єднань"
 ER_SET_CONSTANTS_ONLY  
+        chi "您只能在此语句中使用常量表达式"
         dan "Du må kun bruge konstantudtryk med SET"
-        nla "U mag alleen constante expressies gebruiken bij SET"
         eng "You may only use constant expressions in this statement"
         est "Ainult konstantsed suurused on lubatud SET klauslis"
         fre "Seules les expressions constantes sont autorisées avec SET"
@@ -4361,6 +4558,7 @@ ER_SET_CONSTANTS_ONLY
         hindi "इस स्टेटमेंट में आप केवल CONSTANT EXPRESSIONS का उपयोग कर सकते हैं"
         ita "Si possono usare solo espressioni costanti con SET"
         jpn "SET処理が失敗しました。"
+        nla "U mag alleen constante expressies gebruiken bij SET"
         por "Você pode usar apenas expressões constantes com SET"
         rus "С этой командой вы можете использовать только константные выражения"
         serbian "Možete upotrebiti samo konstantan iskaz sa komandom 'SET'"
@@ -4368,14 +4566,15 @@ ER_SET_CONSTANTS_ONLY
         swe "Man kan endast använda konstantuttryck med SET"
         ukr "Можна використовувати лише вирази зі сталими у SET"
 ER_LOCK_WAIT_TIMEOUT  
+        chi "锁等待超时;尝试重新启动事务"
         dan "Lock wait timeout overskredet"
-        nla "Lock wacht tijd overschreden"
         eng "Lock wait timeout exceeded; try restarting transaction"
         est "Kontrollaeg ületatud luku järel ootamisel; Proovi transaktsiooni otsast alata"
         fre "Timeout sur l'obtention du verrou"
         ger "Beim Warten auf eine Sperre wurde die zulässige Wartezeit überschritten. Bitte versuchen Sie, die Transaktion neu zu starten"
         ita "E' scaduto il timeout per l'attesa del lock"
         jpn "ロック待ちがタイムアウトしました。トランザクションを再試行してください。"
+        nla "Lock wacht tijd overschreden"
         por "Tempo de espera (timeout) de travamento excedido. Tente reiniciar a transação"
         rus "Таймаут ожидания блокировки истек; попробуйте перезапустить транзакцию"
         serbian "Vremenski limit za zaključavanje tabele je istekao; Probajte da ponovo startujete transakciju"
@@ -4383,8 +4582,8 @@ ER_LOCK_WAIT_TIMEOUT
         swe "Fick inte ett lås i tid ; Försök att starta om transaktionen"
         ukr "Затримку очікування блокування вичерпано"
 ER_LOCK_TABLE_FULL  
+        chi "锁的总数超过锁定表大小"
         dan "Det totale antal låse overstiger størrelsen på låse-tabellen"
-        nla "Het totale aantal locks overschrijdt de lock tabel grootte"
         eng "The total number of locks exceeds the lock table size"
         est "Lukkude koguarv ületab lukutabeli suuruse"
         fre "Le nombre total de verrou dépasse la taille de la table des verrous"
@@ -4392,6 +4591,7 @@ ER_LOCK_TABLE_FULL
         hindi "लॉक्स की कुल संख्या लॉक टेबल के साइज से अधिक है"
         ita "Il numero totale di lock e' maggiore della grandezza della tabella di lock"
         jpn "ロックの数が多すぎます。"
+        nla "Het totale aantal locks overschrijdt de lock tabel grootte"
         por "O número total de travamentos excede o tamanho da tabela de travamentos"
         rus "Общее количество блокировок превысило размеры таблицы блокировок"
         serbian "Broj totalnih zaključavanja tabele premašuje veličinu tabele zaključavanja"
@@ -4399,14 +4599,15 @@ ER_LOCK_TABLE_FULL
         swe "Antal lås överskrider antalet reserverade lås"
         ukr "Загальна кількість блокувань перевищила розмір блокувань для таблиці"
 ER_READ_ONLY_TRANSACTION 25000 
+        chi "在READ UNCOMMITTED事务期间无法获取更新锁定"
         dan "Update lås kan ikke opnås under en READ UNCOMMITTED transaktion"
-        nla "Update locks kunnen niet worden verkregen tijdens een READ UNCOMMITTED transactie"
         eng "Update locks cannot be acquired during a READ UNCOMMITTED transaction"
         est "Uuenduslukke ei saa kasutada READ UNCOMMITTED transaktsiooni käigus"
         fre "Un verrou en update ne peut être acquit pendant une transaction READ UNCOMMITTED"
         ger "Während einer READ-UNCOMMITTED-Transaktion können keine UPDATE-Sperren angefordert werden"
         ita "I lock di aggiornamento non possono essere acquisiti durante una transazione 'READ UNCOMMITTED'"
         jpn "読み込み専用トランザクションです。"
+        nla "Update locks kunnen niet worden verkregen tijdens een READ UNCOMMITTED transactie"
         por "Travamentos de atualização não podem ser obtidos durante uma transação de tipo READ UNCOMMITTED"
         rus "Блокировки обновлений нельзя получить в процессе чтения не принятой (в режиме READ UNCOMMITTED) транзакции"
         serbian "Zaključavanja izmena ne mogu biti realizovana sve dok traje 'READ UNCOMMITTED' transakcija"
@@ -4414,14 +4615,15 @@ ER_READ_ONLY_TRANSACTION 25000
         swe "Updateringslås kan inte göras när man använder READ UNCOMMITTED"
         ukr "Оновити блокування не можливо на протязі транзакції READ UNCOMMITTED"
 ER_DROP_DB_WITH_READ_LOCK  
+        chi "线程持有全局读锁时，不允许删除数据库"
         dan "DROP DATABASE er ikke tilladt mens en tråd holder på globalt read lock"
-        nla "DROP DATABASE niet toegestaan terwijl thread een globale 'read lock' bezit"
         eng "DROP DATABASE not allowed while thread is holding global read lock"
         est "DROP DATABASE ei ole lubatud kui lõim omab globaalset READ lukku"
         fre "DROP DATABASE n'est pas autorisée pendant qu'une tâche possède un verrou global en lecture"
         ger "DROP DATABASE ist nicht erlaubt, solange der Thread eine globale Lesesperre hält"
         ita "DROP DATABASE non e' permesso mentre il thread ha un lock globale di lettura"
         jpn "グローバルリードロックを保持している間は、DROP DATABASE を実行できません。"
+        nla "DROP DATABASE niet toegestaan terwijl thread een globale 'read lock' bezit"
         por "DROP DATABASE não permitido enquanto uma 'thread' está mantendo um travamento global de leitura"
         rus "Не допускается DROP DATABASE, пока поток держит глобальную блокировку чтения"
         serbian "Komanda 'DROP DATABASE' nije dozvoljena dok thread globalno zaključava čitanje podataka"
@@ -4429,14 +4631,15 @@ ER_DROP_DB_WITH_READ_LOCK
         swe "DROP DATABASE är inte tillåtet när man har ett globalt läslås"
         ukr "DROP DATABASE не дозволено доки гілка перебуває під загальним блокуванням читання"
 ER_CREATE_DB_WITH_READ_LOCK  
+        chi "线程持有全局读锁时，不允许创建数据库"
         dan "CREATE DATABASE er ikke tilladt mens en tråd holder på globalt read lock"
-        nla "CREATE DATABASE niet toegestaan terwijl thread een globale 'read lock' bezit"
         eng "CREATE DATABASE not allowed while thread is holding global read lock"
         est "CREATE DATABASE ei ole lubatud kui lõim omab globaalset READ lukku"
         fre "CREATE DATABASE n'est pas autorisée pendant qu'une tâche possède un verrou global en lecture"
         ger "CREATE DATABASE ist nicht erlaubt, solange der Thread eine globale Lesesperre hält"
         ita "CREATE DATABASE non e' permesso mentre il thread ha un lock globale di lettura"
         jpn "グローバルリードロックを保持している間は、CREATE DATABASE を実行できません。"
+        nla "CREATE DATABASE niet toegestaan terwijl thread een globale 'read lock' bezit"
         por "CREATE DATABASE não permitido enquanto uma 'thread' está mantendo um travamento global de leitura"
         rus "Не допускается CREATE DATABASE, пока поток держит глобальную блокировку чтения"
         serbian "Komanda 'CREATE DATABASE' nije dozvoljena dok thread globalno zaključava čitanje podataka"
@@ -4444,7 +4647,7 @@ ER_CREATE_DB_WITH_READ_LOCK
         swe "CREATE DATABASE är inte tillåtet när man har ett globalt läslås"
         ukr "CREATE DATABASE не дозволено доки гілка перебуває під загальним блокуванням читання"
 ER_WRONG_ARGUMENTS  
-        nla "Foutieve parameters voor %s"
+        chi "%s的参数不正确"
         eng "Incorrect arguments to %s"
         est "Vigased parameetrid %s-le"
         fre "Mauvais arguments à %s"
@@ -4452,6 +4655,7 @@ ER_WRONG_ARGUMENTS
         hindi "%s को गलत आर्ग्यूमेंट्स"
         ita "Argomenti errati a %s"
         jpn "%s の引数が不正です"
+        nla "Foutieve parameters voor %s"
         por "Argumentos errados para %s"
         rus "Неверные параметры для %s"
         serbian "Pogrešni argumenti prosleđeni na %s"
@@ -4459,13 +4663,14 @@ ER_WRONG_ARGUMENTS
         swe "Felaktiga argument till %s"
         ukr "Хибний аргумент для %s"
 ER_NO_PERMISSION_TO_CREATE_USER 42000 
-        nla "'%s'@'%s' mag geen nieuwe gebruikers creeren"
+        chi "'%s'@'%s'不允许创建新用户"
         eng "'%s'@'%s' is not allowed to create new users"
         est "Kasutajal '%s'@'%s' ei ole lubatud luua uusi kasutajaid"
         fre "'%s'@'%s' n'est pas autorisé à créer de nouveaux utilisateurs"
         ger "'%s'@'%s' ist nicht berechtigt, neue Benutzer hinzuzufügen"
         hindi "'%s'@'%s' को नए यूज़र्स बनाने की अनुमति नहीं है"
         ita "A '%s'@'%s' non e' permesso creare nuovi utenti"
+        nla "'%s'@'%s' mag geen nieuwe gebruikers creeren"
         por "Não é permitido a '%s'@'%s' criar novos usuários"
         rus "'%s'@'%s' не разрешается создавать новых пользователей"
         serbian "Korisniku '%s'@'%s' nije dozvoljeno da kreira nove korisnike"
@@ -4473,13 +4678,14 @@ ER_NO_PERMISSION_TO_CREATE_USER 42000
         swe "'%s'@'%s' har inte rättighet att skapa nya användare"
         ukr "Користувачу '%s'@'%s' не дозволено створювати нових користувачів"
 ER_UNION_TABLES_IN_DIFFERENT_DIR  
-        nla "Incorrecte tabel definitie; alle MERGE tabellen moeten tot dezelfde database behoren"
+        chi "表定义不正确;所有合并表必须在同一数据库中"
         eng "Incorrect table definition; all MERGE tables must be in the same database"
         est "Vigane tabelimääratlus; kõik MERGE tabeli liikmed peavad asuma samas andmebaasis"
         fre "Définition de table incorrecte; toutes les tables MERGE doivent être dans la même base de donnée"
         ger "Falsche Tabellendefinition. Alle MERGE-Tabellen müssen sich in derselben Datenbank befinden"
         ita "Definizione della tabella errata; tutte le tabelle di tipo MERGE devono essere nello stesso database"
         jpn "不正な表定義です。MERGE表の構成表はすべて同じデータベース内になければなりません。"
+        nla "Incorrecte tabel definitie; alle MERGE tabellen moeten tot dezelfde database behoren"
         por "Definição incorreta da tabela. Todas as tabelas contidas na junção devem estar no mesmo banco de dados"
         rus "Неверное определение таблицы; Все таблицы в MERGE должны принадлежать одной и той же базе данных"
         serbian "Pogrešna definicija tabele; sve 'MERGE' tabele moraju biti u istoj bazi podataka"
@@ -4487,13 +4693,14 @@ ER_UNION_TABLES_IN_DIFFERENT_DIR
         swe "Felaktig tabelldefinition; alla tabeller i en MERGE-tabell måste vara i samma databas"
         ukr "Хибне визначення таблиці; всі MERGE-таблиці повинні належити до однієї бази ланних."
 ER_LOCK_DEADLOCK 40001 
-        nla "Deadlock gevonden tijdens lock-aanvraag poging; Probeer herstart van de transactie"
+        chi "试图锁定时发现僵局;尝试重新启动事务"
         eng "Deadlock found when trying to get lock; try restarting transaction"
         est "Lukustamisel tekkis tupik (deadlock); alusta transaktsiooni otsast"
         fre "Deadlock découvert en essayant d'obtenir les verrous : essayez de redémarrer la transaction"
         ger "Beim Versuch, eine Sperre anzufordern, ist ein Deadlock aufgetreten. Versuchen Sie, die Transaktion neu zu starten"
         ita "Trovato deadlock durante il lock; Provare a far ripartire la transazione"
         jpn "ロック取得中にデッドロックが検出されました。トランザクションを再試行してください。"
+        nla "Deadlock gevonden tijdens lock-aanvraag poging; Probeer herstart van de transactie"
         por "Encontrado um travamento fatal (deadlock) quando tentava obter uma trava. Tente reiniciar a transação"
         rus "Возникла тупиковая ситуация в процессе получения блокировки; Попробуйте перезапустить транзакцию"
         serbian "Unakrsno zaključavanje pronađeno kada sam pokušao da dobijem pravo na zaključavanje; Probajte da restartujete transakciju"
@@ -4501,13 +4708,14 @@ ER_LOCK_DEADLOCK 40001
         swe "Fick 'DEADLOCK' vid låsförsök av block/rad. Försök att starta om transaktionen"
         ukr "Взаємне блокування знайдено під час спроби отримати блокування; спробуйте перезапустити транзакцію."
 ER_TABLE_CANT_HANDLE_FT  
-        nla "Het gebruikte tabel type (%s) ondersteund geen FULLTEXT indexen"
+        chi "存储引擎%s不支持fulltext索引"
         eng "The storage engine %s doesn't support FULLTEXT indexes"
         est "Antud tabelitüüp (%s) ei toeta FULLTEXT indekseid"
         fre "Le type de table utilisé (%s) ne supporte pas les index FULLTEXT"
         ger "Der verwendete Tabellentyp (%s) unterstützt keine FULLTEXT-Indizes"
         hindi "स्टोरेज इंजन '%s' FULLTEXT इन्डेक्सेस को सपोर्ट नहीं करता"
         ita "La tabella usata (%s) non supporta gli indici FULLTEXT"
+        nla "Het gebruikte tabel type (%s) ondersteund geen FULLTEXT indexen"
         por "O tipo de tabela utilizado (%s) não suporta índices de texto completo (fulltext indexes)"
         rus "Используемый тип таблиц (%s) не поддерживает полнотекстовых индексов"
         serbian "Upotrebljeni tip tabele (%s) ne podržava 'FULLTEXT' indekse"
@@ -4515,12 +4723,13 @@ ER_TABLE_CANT_HANDLE_FT
         swe "Tabelltypen (%s) har inte hantering av FULLTEXT-index"
         ukr "Використаний тип таблиці (%s) не підтримує FULLTEXT індексів"
 ER_CANNOT_ADD_FOREIGN
-        nla "Kan foreign key beperking niet toevoegen vor `%s`"
+        chi "不能为`%s`添加外键约束"
         eng "Cannot add foreign key constraint for `%s`"
         fre "Impossible d'ajouter des contraintes d'index externe à `%s`"
         ger "Fremdschlüssel-Beschränkung kann nicht hinzugefügt werden für `%s`"
         ita "Impossibile aggiungere il vincolo di integrita' referenziale (foreign key constraint) a `%s`"
         jpn "`%s` 外部キー制約を追加できません。"
+        nla "Kan foreign key beperking niet toevoegen vor `%s`"
         por "Não pode acrescentar uma restrição de chave estrangeira para `%s`"
         rus "Невозможно добавить ограничения внешнего ключа для `%s`"
         serbian "Ne mogu da dodam proveru spoljnog ključa na `%s`"
@@ -4528,7 +4737,7 @@ ER_CANNOT_ADD_FOREIGN
         swe "Kan inte lägga till 'FOREIGN KEY constraint' för `%s`'"
         ukr "Не можу додати обмеження зовнішнього ключа Ha `%s`"
 ER_NO_REFERENCED_ROW 23000 
-        nla "Kan onderliggende rij niet toevoegen: foreign key beperking gefaald"
+        chi "无法添加或更新子行：外键约束失败"
         eng "Cannot add or update a child row: a foreign key constraint fails"
         fre "Impossible d'ajouter un enregistrement fils : une constrainte externe l'empèche"
         ger "Hinzufügen oder Aktualisieren eines Kind-Datensatzes schlug aufgrund einer Fremdschlüssel-Beschränkung fehl"
@@ -4536,6 +4745,7 @@ ER_NO_REFERENCED_ROW 23000
         hun "Cannot add a child row: a foreign key constraint fails"
         ita "Impossibile aggiungere la riga: un vincolo d'integrita' referenziale non e' soddisfatto"
         jpn "親キーがありません。外部キー制約違反です。"
+        nla "Kan onderliggende rij niet toevoegen: foreign key beperking gefaald"
         norwegian-ny "Cannot add a child row: a foreign key constraint fails"
         por "Não pode acrescentar uma linha filha: uma restrição de chave estrangeira falhou"
         rus "Невозможно добавить или обновить дочернюю строку: проверка ограничений внешнего ключа не выполняется"
@@ -4543,6 +4753,7 @@ ER_NO_REFERENCED_ROW 23000
         swe "FOREIGN KEY-konflikt:  Kan inte skriva barn"
         ukr "Не вдається додати або оновити дочірній рядок: невдала перевірка обмеження зовнішнього ключа"
 ER_ROW_IS_REFERENCED 23000 
+        chi "无法删除或更新父行：外键约束失败"
         eng "Cannot delete or update a parent row: a foreign key constraint fails"
         fre "Impossible de supprimer un enregistrement père : une constrainte externe l'empèche"
         ger "Löschen oder Aktualisieren eines Eltern-Datensatzes schlug aufgrund einer Fremdschlüssel-Beschränkung fehl"
@@ -4556,44 +4767,48 @@ ER_ROW_IS_REFERENCED 23000
         spa "No puede deletar una línea padre: falla de clave extranjera constraint"
         swe "FOREIGN KEY-konflikt:  Kan inte radera fader"
 ER_CONNECT_TO_MASTER 08S01 
-        nla "Fout bij opbouwen verbinding naar master: %-.128s"
+        chi "连接master时出错：%-.128s"
         eng "Error connecting to master: %-.128s"
         ger "Fehler bei der Verbindung zum Master: %-.128s"
         ita "Errore durante la connessione al master: %-.128s"
         jpn "マスターへの接続エラー: %-.128s"
+        nla "Fout bij opbouwen verbinding naar master: %-.128s"
         por "Erro conectando com o master: %-.128s"
         rus "Ошибка соединения с головным сервером: %-.128s"
         spa "Error de coneccion a master: %-.128s"
         swe "Fick fel vid anslutning till master: %-.128s"
 ER_QUERY_ON_MASTER  
-        nla "Fout bij uitvoeren query op master: %-.128s"
+        chi "在Master上运行查询时出错：%-.128s"
         eng "Error running query on master: %-.128s"
         ger "Beim Ausführen einer Abfrage auf dem Master trat ein Fehler auf: %-.128s"
         ita "Errore eseguendo una query sul master: %-.128s"
         jpn "マスターでのクエリ実行エラー: %-.128s"
+        nla "Fout bij uitvoeren query op master: %-.128s"
         por "Erro rodando consulta no master: %-.128s"
         rus "Ошибка выполнения запроса на головном сервере: %-.128s"
         spa "Error executando el query en master: %-.128s"
         swe "Fick fel vid utförande av command på mastern: %-.128s"
 ER_ERROR_WHEN_EXECUTING_COMMAND  
-        nla "Fout tijdens uitvoeren van commando %s: %-.128s"
+        chi "执行命令%s时出错：%-.128s"
         eng "Error when executing command %s: %-.128s"
         est "Viga käsu %s täitmisel: %-.128s"
         ger "Fehler beim Ausführen des Befehls %s: %-.128s"
         ita "Errore durante l'esecuzione del comando %s: %-.128s"
         jpn "%s コマンドの実行エラー: %-.128s"
+        nla "Fout tijdens uitvoeren van commando %s: %-.128s"
         por "Erro quando executando comando %s: %-.128s"
         rus "Ошибка при выполнении команды %s: %-.128s"
         serbian "Greška pri izvršavanju komande %s: %-.128s"
         spa "Error de %s: %-.128s"
         swe "Fick fel vid utförande av %s: %-.128s"
 ER_WRONG_USAGE  
-        nla "Foutief gebruik van %s en %s"
+        chi "%s和%s使用不正确"
         eng "Incorrect usage of %s and %s"
         est "Vigane %s ja %s kasutus"
         ger "Falsche Verwendung von %s und %s"
         ita "Uso errato di %s e %s"
         jpn "%s の %s に関する不正な使用法です。"
+        nla "Foutief gebruik van %s en %s"
         por "Uso errado de %s e %s"
         rus "Неверное использование %s и %s"
         serbian "Pogrešna upotreba %s i %s"
@@ -4601,164 +4816,180 @@ ER_WRONG_USAGE
         swe "Felaktig använding av %s and %s"
         ukr "Wrong usage of %s and %s"
 ER_WRONG_NUMBER_OF_COLUMNS_IN_SELECT 21000 
-        nla "De gebruikte SELECT commando's hebben een verschillend aantal kolommen"
+        chi "使用的SELECT语句具有不同数量的列"
         eng "The used SELECT statements have a different number of columns"
         est "Tulpade arv kasutatud SELECT lausetes ei kattu"
         ger "Die verwendeten SELECT-Befehle liefern unterschiedliche Anzahlen von Feldern zurück"
         ita "La SELECT utilizzata ha un numero di colonne differente"
         jpn "使用のSELECT文が返す列数が違います。"
+        nla "De gebruikte SELECT commando's hebben een verschillend aantal kolommen"
         por "Os comandos SELECT usados têm diferente número de colunas"
         rus "Использованные операторы выборки (SELECT) дают разное количество столбцов"
         serbian "Upotrebljene 'SELECT' komande adresiraju različit broj kolona"
         spa "El comando SELECT usado tiene diferente número de columnas"
         swe "SELECT-kommandona har olika antal kolumner"
 ER_CANT_UPDATE_WITH_READLOCK  
-        nla "Kan de query niet uitvoeren vanwege een conflicterende read lock"
+        chi "无法执行查询，因为您有冲突的读锁"
         eng "Can't execute the query because you have a conflicting read lock"
         est "Ei suuda täita päringut konfliktse luku tõttu"
         ger "Augrund eines READ-LOCK-Konflikts kann die Abfrage nicht ausgeführt werden"
         ita "Impossibile eseguire la query perche' c'e' un conflitto con in lock di lettura"
         jpn "競合するリードロックを保持しているので、クエリを実行できません。"
+        nla "Kan de query niet uitvoeren vanwege een conflicterende read lock"
         por "Não posso executar a consulta porque você tem um conflito de travamento de leitura"
         rus "Невозможно исполнить запрос, поскольку у вас установлены конфликтующие блокировки чтения"
         serbian "Ne mogu da izvršim upit zbog toga što imate zaključavanja čitanja podataka u konfliktu"
         spa "No puedo ejecutar el query  porque usted tiene conflicto de traba de lectura"
         swe "Kan inte utföra kommandot emedan du har ett READ-lås"
 ER_MIXING_NOT_ALLOWED  
-        nla "Het combineren van transactionele en niet-transactionele tabellen is uitgeschakeld"
+        chi "事务和非事务表的混合被禁用"
         eng "Mixing of transactional and non-transactional tables is disabled"
         est "Transaktsioone toetavate ning mittetoetavate tabelite kooskasutamine ei ole lubatud"
         ger "Die gleichzeitige Verwendung von Tabellen mit und ohne Transaktionsunterstützung ist deaktiviert"
         ita "E' disabilitata la possibilita' di mischiare tabelle transazionali e non-transazionali"
         jpn "トランザクション対応の表と非対応の表の同時使用は無効化されています。"
+        nla "Het combineren van transactionele en niet-transactionele tabellen is uitgeschakeld"
         por "Mistura de tabelas transacional e não-transacional está desabilitada"
         rus "Использование транзакционных таблиц наряду с нетранзакционными запрещено"
         serbian "Mešanje tabela koje podržavaju transakcije i onih koje ne podržavaju transakcije je isključeno"
         spa "Mezla de transancional y no-transancional tablas está deshabilitada"
         swe "Blandning av transaktionella och icke-transaktionella tabeller är inaktiverat"
 ER_DUP_ARGUMENT  
-        nla "Optie '%s' tweemaal gebruikt in opdracht"
+        chi "选项'%s'在语句中使用两次"
         eng "Option '%s' used twice in statement"
         est "Määrangut '%s' on lauses kasutatud topelt"
         ger "Option '%s' wird im Befehl zweimal verwendet"
         ita "L'opzione '%s' e' stata usata due volte nel comando"
         jpn "オプション '%s' が2度使用されています。"
+        nla "Optie '%s' tweemaal gebruikt in opdracht"
         por "Opção '%s' usada duas vezes no comando"
         rus "Опция '%s' дважды использована в выражении"
         spa "Opción '%s' usada dos veces en el comando"
         swe "Option '%s' användes två gånger"
 ER_USER_LIMIT_REACHED 42000 
-        nla "Gebruiker '%-.64s' heeft het maximale gebruik van de '%s' faciliteit overschreden (huidige waarde: %ld)"
+        chi "用户'%-.64s'已超过'%s'资源（当前值：%ld）"
         eng "User '%-.64s' has exceeded the '%s' resource (current value: %ld)"
         ger "Benutzer '%-.64s' hat die Ressourcenbeschränkung '%s' überschritten (aktueller Wert: %ld)"
         ita "L'utente '%-.64s' ha ecceduto la risorsa '%s' (valore corrente: %ld)"
         jpn "ユーザー '%-.64s' はリソースの上限 '%s' に達しました。(現在値: %ld)"
+        nla "Gebruiker '%-.64s' heeft het maximale gebruik van de '%s' faciliteit overschreden (huidige waarde: %ld)"
         por "Usuário '%-.64s' tem excedido o '%s' recurso (atual valor: %ld)"
         rus "Пользователь '%-.64s' превысил использование ресурса '%s' (текущее значение: %ld)"
         spa "Usuario '%-.64s' ha excedido el recurso '%s' (actual valor: %ld)"
         swe "Användare '%-.64s' har överskridit '%s' (nuvarande värde: %ld)"
 ER_SPECIFIC_ACCESS_DENIED_ERROR 42000 
-        nla "Toegang geweigerd. U moet het %-.128s privilege hebben voor deze operatie"
+        chi "拒绝访问;您需要（至少一个）%-.128s特权用于此操作"
         eng "Access denied; you need (at least one of) the %-.128s privilege(s) for this operation"
         ger "Kein Zugriff. Hierfür wird die Berechtigung %-.128s benötigt"
         ita "Accesso non consentito. Serve il privilegio %-.128s per questa operazione"
         jpn "アクセスは拒否されました。この操作には %-.128s 権限が(複数の場合はどれか1つ)必要です。"
+        nla "Toegang geweigerd. U moet het %-.128s privilege hebben voor deze operatie"
         por "Acesso negado. Você precisa o privilégio %-.128s para essa operação"
         rus "В доступе отказано. Вам нужны привилегии %-.128s для этой операции"
         spa "Acceso negado. Usted necesita el privilegio %-.128s para esta operación"
         swe "Du har inte privlegiet '%-.128s' som behövs för denna operation"
         ukr "Access denied. You need the %-.128s privilege for this operation"
 ER_LOCAL_VARIABLE  
-        nla "Variabele '%-.64s' is SESSION en kan niet worden gebruikt met SET GLOBAL"
+        chi "变量'%-.64s'是一个SESSION变量，不能与Set Global一起使用"
         eng "Variable '%-.64s' is a SESSION variable and can't be used with SET GLOBAL"
         ger "Variable '%-.64s' ist eine lokale Variable und kann nicht mit SET GLOBAL verändert werden"
         ita "La variabile '%-.64s' e' una variabile locale ( SESSION ) e non puo' essere cambiata usando SET GLOBAL"
         jpn "変数 '%-.64s' はセッション変数です。SET GLOBALでは使用できません。"
+        nla "Variabele '%-.64s' is SESSION en kan niet worden gebruikt met SET GLOBAL"
         por "Variável '%-.64s' é uma SESSION variável e não pode ser usada com SET GLOBAL"
         rus "Переменная '%-.64s' является потоковой (SESSION) переменной и не может быть изменена с помощью SET GLOBAL"
         spa "Variable '%-.64s' es una SESSION variable y no puede ser usada con SET GLOBAL"
         swe "Variabel '%-.64s' är en SESSION variabel och kan inte ändrad med SET GLOBAL"
 ER_GLOBAL_VARIABLE  
-        nla "Variabele '%-.64s' is GLOBAL en dient te worden gewijzigd met SET GLOBAL"
+        chi "变量'%-.64s'是全局变量，应该用SET GLOBAL设置"
         eng "Variable '%-.64s' is a GLOBAL variable and should be set with SET GLOBAL"
         ger "Variable '%-.64s' ist eine globale Variable und muss mit SET GLOBAL verändert werden"
         ita "La variabile '%-.64s' e' una variabile globale ( GLOBAL ) e deve essere cambiata usando SET GLOBAL"
         jpn "変数 '%-.64s' はグローバル変数です。SET GLOBALを使用してください。"
+        nla "Variabele '%-.64s' is GLOBAL en dient te worden gewijzigd met SET GLOBAL"
         por "Variável '%-.64s' é uma GLOBAL variável e deve ser configurada com SET GLOBAL"
         rus "Переменная '%-.64s' является глобальной (GLOBAL) переменной, и ее следует изменять с помощью SET GLOBAL"
         spa "Variable '%-.64s' es una GLOBAL variable y no puede ser configurada con SET GLOBAL"
         swe "Variabel '%-.64s' är en GLOBAL variabel och bör sättas med SET GLOBAL"
 ER_NO_DEFAULT 42000 
-        nla "Variabele '%-.64s' heeft geen standaard waarde"
+        chi "变量'%-.64s'没有默认值"
         eng "Variable '%-.64s' doesn't have a default value"
         ger "Variable '%-.64s' hat keinen Vorgabewert"
         ita "La variabile '%-.64s' non ha un valore di default"
         jpn "変数 '%-.64s' にはデフォルト値がありません。"
+        nla "Variabele '%-.64s' heeft geen standaard waarde"
         por "Variável '%-.64s' não tem um valor padrão"
         rus "Переменная '%-.64s' не имеет значения по умолчанию"
         spa "Variable '%-.64s' no tiene un valor patrón"
         swe "Variabel '%-.64s' har inte ett DEFAULT-värde"
 ER_WRONG_VALUE_FOR_VAR 42000 
-        nla "Variabele '%-.64s' kan niet worden gewijzigd naar de waarde '%-.200T'"
+        chi "变量'%-.64s'无法设置为'%-.200T'的值"
         eng "Variable '%-.64s' can't be set to the value of '%-.200T'"
         ger "Variable '%-.64s' kann nicht auf '%-.200T' gesetzt werden"
         ita "Alla variabile '%-.64s' non puo' essere assegato il valore '%-.200T'"
         jpn "変数 '%-.64s' に値 '%-.200T' を設定できません。"
+        nla "Variabele '%-.64s' kan niet worden gewijzigd naar de waarde '%-.200T'"
         por "Variável '%-.64s' não pode ser configurada para o valor de '%-.200T'"
         rus "Переменная '%-.64s' не может быть установлена в значение '%-.200T'"
         spa "Variable '%-.64s' no puede ser configurada para el valor de '%-.200T'"
         swe "Variabel '%-.64s' kan inte sättas till '%-.200T'"
 ER_WRONG_TYPE_FOR_VAR 42000 
-        nla "Foutief argumenttype voor variabele '%-.64s'"
+        chi "变量'%-.64s'的参数类型不正确"
         eng "Incorrect argument type to variable '%-.64s'"
         ger "Falscher Argumenttyp für Variable '%-.64s'"
         ita "Tipo di valore errato per la variabile '%-.64s'"
         jpn "変数 '%-.64s' への値の型が不正です。"
+        nla "Foutief argumenttype voor variabele '%-.64s'"
         por "Tipo errado de argumento para variável '%-.64s'"
         rus "Неверный тип аргумента для переменной '%-.64s'"
         spa "Tipo de argumento equivocado para variable '%-.64s'"
         swe "Fel typ av argument till variabel '%-.64s'"
 ER_VAR_CANT_BE_READ  
-        nla "Variabele '%-.64s' kan alleen worden gewijzigd, niet gelezen"
+        chi "变量'%-.64s'只能设置，不能读"
         eng "Variable '%-.64s' can only be set, not read"
         ger "Variable '%-.64s' kann nur verändert, nicht gelesen werden"
         ita "Alla variabile '%-.64s' e' di sola scrittura quindi puo' essere solo assegnato un valore, non letto"
         jpn "変数 '%-.64s' は書き込み専用です。読み込みはできません。"
+        nla "Variabele '%-.64s' kan alleen worden gewijzigd, niet gelezen"
         por "Variável '%-.64s' somente pode ser configurada, não lida"
         rus "Переменная '%-.64s' может быть только установлена, но не считана"
         spa "Variable '%-.64s' solamente puede ser configurada, no leída"
         swe "Variabeln '%-.64s' kan endast sättas, inte läsas"
 ER_CANT_USE_OPTION_HERE 42000 
-        nla "Foutieve toepassing/plaatsing van '%s'"
+        chi "'%s'的使用/放置不正确"
         eng "Incorrect usage/placement of '%s'"
         ger "Falsche Verwendung oder Platzierung von '%s'"
         ita "Uso/posizione di '%s' sbagliato"
         jpn "'%s' の使用法または場所が不正です。"
+        nla "Foutieve toepassing/plaatsing van '%s'"
         por "Errado uso/colocação de '%s'"
         rus "Неверное использование или в неверном месте указан '%s'"
         spa "Equivocado uso/colocación de '%s'"
         swe "Fel använding/placering av '%s'"
 ER_NOT_SUPPORTED_YET 42000 
-        nla "Deze versie van MariaDB ondersteunt nog geen '%s'"
+        chi "此版本的MariaDB尚未支持'%s'"
         eng "This version of MariaDB doesn't yet support '%s'"
         ger "Diese MariaDB-Version unterstützt '%s' nicht"
         ita "Questa versione di MariaDB non supporta ancora '%s'"
         jpn "このバージョンのMariaDBでは、まだ '%s' を利用できません。"
+        nla "Deze versie van MariaDB ondersteunt nog geen '%s'"
         por "Esta versão de MariaDB não suporta ainda '%s'"
         rus "Эта версия MariaDB пока еще не поддерживает '%s'"
         spa "Esta versión de MariaDB no soporta todavia '%s'"
         swe "Denna version av MariaDB kan ännu inte utföra '%s'"
 ER_MASTER_FATAL_ERROR_READING_BINLOG  
-        nla "Kreeg fatale fout %d: '%-.320s' van master tijdens lezen van data uit binaire log"
+        chi "从二进制日志读取数据时，从master遇到致命错误%d：'%-.320s'"
         eng "Got fatal error %d from master when reading data from binary log: '%-.320s'"
         ger "Schwerer Fehler %d: '%-.320s vom Master beim Lesen des binären Logs"
         ita "Errore fatale %d: '%-.320s' dal master leggendo i dati dal log binario"
         jpn "致命的なエラー %d: '%-.320s' がマスターでバイナリログ読み込み中に発生しました。"
+        nla "Kreeg fatale fout %d: '%-.320s' van master tijdens lezen van data uit binaire log"
         por "Obteve fatal erro %d: '%-.320s' do master quando lendo dados do binary log"
         rus "Получена неисправимая ошибка %d: '%-.320s' от головного сервера в процессе выборки данных из двоичного журнала"
         spa "Recibió fatal error %d: '%-.320s' del master cuando leyendo datos del binary log"
         swe "Fick fatalt fel %d: '%-.320s' från master vid läsning av binärloggen"
 ER_SLAVE_IGNORED_TABLE  
+        chi "由于复制replicate-*-table规则，Slave SQL线程忽略了查询"
         eng "Slave SQL thread ignored the query because of replicate-*-table rules"
         ger "Slave-SQL-Thread hat die Abfrage aufgrund von replicate-*-table-Regeln ignoriert"
         jpn "replicate-*-table ルールに従って、スレーブSQLスレッドはクエリを無視しました。"
@@ -4767,14 +4998,16 @@ ER_SLAVE_IGNORED_TABLE
         spa "Slave SQL thread ignorado el query debido a las reglas de replicación-*-tabla"
         swe "Slav SQL tråden ignorerade frågan pga en replicate-*-table regel"
 ER_INCORRECT_GLOBAL_LOCAL_VAR  
+        chi "变量'%-.192s'是一个%s变量"
         eng "Variable '%-.192s' is a %s variable"
-        serbian "Promenljiva '%-.192s' je %s promenljiva"
         ger "Variable '%-.192s' ist eine %s-Variable"
         jpn "変数 '%-.192s' は %s 変数です。"
         nla "Variabele '%-.192s' is geen %s variabele"
+        serbian "Promenljiva '%-.192s' je %s promenljiva"
         spa "Variable '%-.192s' es una %s variable"
         swe "Variabel '%-.192s' är av typ %s"
 ER_WRONG_FK_DEF 42000 
+        chi "'%-.192s'的外键定义不正确：%s"
         eng "Incorrect foreign key definition for '%-.192s': %s"
         ger "Falsche Fremdschlüssel-Definition für '%-.192s': %s"
         jpn "外部キー '%-.192s' の定義の不正: %s"
@@ -4783,6 +5016,7 @@ ER_WRONG_FK_DEF 42000
         spa "Equivocada definición de llave extranjera para '%-.192s': %s"
         swe "Felaktig FOREIGN KEY-definition för '%-.192s': %s"
 ER_KEY_REF_DO_NOT_MATCH_TABLE_REF  
+        chi "索引参考和表参考不匹配"
         eng "Key reference and table reference don't match"
         ger "Schlüssel- und Tabellenverweis passen nicht zusammen"
         jpn "外部キーの参照表と定義が一致しません。"
@@ -4791,6 +5025,7 @@ ER_KEY_REF_DO_NOT_MATCH_TABLE_REF
         spa "Referencia de llave y referencia de tabla no coinciden"
         swe "Nyckelreferensen och tabellreferensen stämmer inte överens"
 ER_OPERAND_COLUMNS 21000 
+        chi "操作数应包含%d列"
         eng "Operand should contain %d column(s)"
         ger "Operand sollte %d Spalte(n) enthalten"
         jpn "オペランドに %d 個の列が必要です。"
@@ -4799,6 +5034,7 @@ ER_OPERAND_COLUMNS 21000
         spa "Operando debe tener %d columna(s)"
         ukr "Операнд має складатися з %d стовбців"
 ER_SUBQUERY_NO_1_ROW 21000 
+        chi "子查询返回超过1行"
         eng "Subquery returns more than 1 row"
         ger "Unterabfrage lieferte mehr als einen Datensatz zurück"
         jpn "サブクエリが2行以上の結果を返します。"
@@ -4809,6 +5045,7 @@ ER_SUBQUERY_NO_1_ROW 21000
         swe "Subquery returnerade mer än 1 rad"
         ukr "Підзапит повертає більш нiж 1 запис"
 ER_UNKNOWN_STMT_HANDLER  
+        chi "未知prepared statement处理程序(%.*s)给予%s"
         dan "Unknown prepared statement handler (%.*s) given to %s"
         eng "Unknown prepared statement handler (%.*s) given to %s"
         ger "Unbekannter Prepared-Statement-Handler (%.*s) für %s angegeben"
@@ -4819,6 +5056,7 @@ ER_UNKNOWN_STMT_HANDLER
         swe "Okänd PREPARED STATEMENT id (%.*s) var given till %s"
         ukr "Unknown prepared statement handler (%.*s) given to %s"
 ER_CORRUPT_HELP_DB  
+        chi "帮助数据库已损坏或不存在"
         eng "Help database is corrupt or does not exist"
         ger "Die Hilfe-Datenbank ist beschädigt oder existiert nicht"
         jpn "ヘルプデータベースは壊れているか存在しません。"
@@ -4827,6 +5065,7 @@ ER_CORRUPT_HELP_DB
         spa "Base de datos Help está corrupto o no existe"
         swe "Hjälpdatabasen finns inte eller är skadad"
 ER_CYCLIC_REFERENCE  
+        chi "亚查询的死环参考"
         eng "Cyclic reference on subqueries"
         ger "Zyklischer Verweis in Unterabfragen"
         jpn "サブクエリの参照がループしています。"
@@ -4837,6 +5076,7 @@ ER_CYCLIC_REFERENCE
         swe "Cyklisk referens i subqueries"
         ukr "Циклічне посилання на підзапит"
 ER_AUTO_CONVERT  
+        chi "将列'%s'从%s转换为%s"
         eng "Converting column '%s' from %s to %s"
         ger "Feld '%s' wird von %s nach %s umgewandelt"
         jpn "列 '%s' を %s から %s へ変換します。"
@@ -4847,6 +5087,7 @@ ER_AUTO_CONVERT
         swe "Konvertar kolumn '%s' från %s till %s"
         ukr "Перетворення стовбца '%s' з %s у %s"
 ER_ILLEGAL_REFERENCE 42S22 
+        chi "参考'%-.64s'不支持(%s)"
         eng "Reference '%-.64s' not supported (%s)"
         ger "Verweis '%-.64s' wird nicht unterstützt (%s)"
         jpn "'%-.64s' の参照はできません。(%s)"
@@ -4857,6 +5098,7 @@ ER_ILLEGAL_REFERENCE 42S22
         swe "Referens '%-.64s' stöds inte (%s)"
         ukr "Посилання '%-.64s' не пiдтримуется (%s)"
 ER_DERIVED_MUST_HAVE_ALIAS 42000 
+        chi "每个派生的表必须有自己的别名"
         eng "Every derived table must have its own alias"
         ger "Für jede abgeleitete Tabelle muss ein eigener Alias angegeben werden"
         jpn "導出表には別名が必須です。"
@@ -4865,6 +5107,7 @@ ER_DERIVED_MUST_HAVE_ALIAS 42000
         spa "Cada tabla derivada debe tener su propio alias"
         swe "Varje 'derived table' måste ha sitt eget alias"
 ER_SELECT_REDUCED 01000 
+        chi "SELECT %u在优化期间被减"
         eng "Select %u was reduced during optimization"
         ger "Select %u wurde während der Optimierung reduziert"
         jpn "Select %u は最適化によって減らされました。"
@@ -4875,6 +5118,7 @@ ER_SELECT_REDUCED 01000
         swe "Select %u reducerades vid optimiering"
         ukr "Select %u was скасовано при оптимiзацii"
 ER_TABLENAME_NOT_ALLOWED_HERE 42000 
+        chi "表'%-.192s'从其中一个SELECT中不能用于%-.32s"
         eng "Table '%-.192s' from one of the SELECTs cannot be used in %-.32s"
         ger "Tabelle '%-.192s', die in einem der SELECT-Befehle verwendet wurde, kann nicht in %-.32s verwendet werden"
         jpn "特定のSELECTのみで使用の表 '%-.192s' は %-.32s では使用できません。"
@@ -4883,6 +5127,7 @@ ER_TABLENAME_NOT_ALLOWED_HERE 42000
         spa "Tabla '%-.192s' de uno de los SELECT no puede ser usada en %-.32s"
         swe "Tabell '%-.192s' från en SELECT kan inte användas i %-.32s"
 ER_NOT_SUPPORTED_AUTH_MODE 08004 
+        chi "客户端不支持服务器请求的身份验证协议;考虑升级MariaDB客户端"
         eng "Client does not support authentication protocol requested by server; consider upgrading MariaDB client"
         ger "Client unterstützt das vom Server erwartete Authentifizierungsprotokoll nicht. Bitte aktualisieren Sie Ihren MariaDB-Client"
         jpn "クライアントはサーバーが要求する認証プロトコルに対応できません。MariaDBクライアントのアップグレードを検討してください。"
@@ -4891,6 +5136,7 @@ ER_NOT_SUPPORTED_AUTH_MODE 08004
         spa "Cliente no soporta protocolo de autenticación solicitado por el servidor; considere actualizar el cliente MariaDB"
         swe "Klienten stöder inte autentiseringsprotokollet som begärts av servern; överväg uppgradering av klientprogrammet"
 ER_SPATIAL_CANT_HAVE_NULL 42000 
+        chi "SPATIAL索引的所有部分必须不为null"
         eng "All parts of a SPATIAL index must be NOT NULL"
         ger "Alle Teile eines SPATIAL-Index müssen als NOT NULL deklariert sein"
         jpn "空間索引のキー列は NOT NULL でなければいけません。"
@@ -4899,6 +5145,7 @@ ER_SPATIAL_CANT_HAVE_NULL 42000
         spa "Todas las partes de una SPATIAL index deben ser NOT NULL"
         swe "Alla delar av en SPATIAL index måste vara NOT NULL"
 ER_COLLATION_CHARSET_MISMATCH 42000 
+        chi "COLLATION'%s'无效地用于字符集'%s'"
         eng "COLLATION '%s' is not valid for CHARACTER SET '%s'"
         ger "COLLATION '%s' ist für CHARACTER SET '%s' ungültig"
         jpn "COLLATION '%s' は CHARACTER SET '%s' に適用できません。"
@@ -4907,6 +5154,7 @@ ER_COLLATION_CHARSET_MISMATCH 42000
         spa "COLLATION '%s' no es válido para CHARACTER SET '%s'"
         swe "COLLATION '%s' är inte tillåtet för CHARACTER SET '%s'"
 ER_SLAVE_WAS_RUNNING  
+        chi "Slave已经在运行"
         eng "Slave is already running"
         ger "Slave läuft bereits"
         jpn "スレーブはすでに稼働中です。"
@@ -4915,6 +5163,7 @@ ER_SLAVE_WAS_RUNNING
         spa "Slave ya está funcionando"
         swe "Slaven har redan startat"
 ER_SLAVE_WAS_NOT_RUNNING  
+        chi "slave已经停止了"
         eng "Slave already has been stopped"
         ger "Slave wurde bereits angehalten"
         jpn "スレーブはすでに停止しています。"
@@ -4923,6 +5172,7 @@ ER_SLAVE_WAS_NOT_RUNNING
         spa "Slave ya fué parado"
         swe "Slaven har redan stoppat"
 ER_TOO_BIG_FOR_UNCOMPRESS  
+        chi "未压缩的数据量太大;最大量为%d（可能未压缩数据的长度已损坏）"
         eng "Uncompressed data size too large; the maximum size is %d (probably, length of uncompressed data was corrupted)"
         ger "Unkomprimierte Daten sind zu groß. Die maximale Größe beträgt %d (wahrscheinlich wurde die Länge der unkomprimierten Daten beschädigt)"
         jpn "展開後のデータが大きすぎます。最大サイズは %d です。(展開後データの長さ情報が壊れている可能性もあります。)"
@@ -4930,6 +5180,7 @@ ER_TOO_BIG_FOR_UNCOMPRESS
         por "Tamanho muito grande dos dados des comprimidos. O máximo tamanho é %d. (provavelmente, o comprimento dos dados descomprimidos está corrupto)"
         spa "Tamaño demasiado grande para datos descomprimidos. El máximo tamaño es %d. (probablemente, extensión de datos descomprimidos fué corrompida)"
 ER_ZLIB_Z_MEM_ERROR  
+        chi "ZLIB：内存不足"
         eng "ZLIB: Not enough memory"
         ger "ZLIB: Nicht genug Speicher"
         jpn "ZLIB: メモリ不足です。"
@@ -4937,6 +5188,7 @@ ER_ZLIB_Z_MEM_ERROR
         por "ZLIB: Não suficiente memória disponível"
         spa "Z_MEM_ERROR: No suficiente memoria para zlib"
 ER_ZLIB_Z_BUF_ERROR  
+        chi "ZLIB：输出缓冲区中没有足够的空间（可能未压缩数据的长度已损坏）"
         eng "ZLIB: Not enough room in the output buffer (probably, length of uncompressed data was corrupted)"
         ger "ZLIB: Im Ausgabepuffer ist nicht genug Platz vorhanden (wahrscheinlich wurde die Länge der unkomprimierten Daten beschädigt)"
         jpn "ZLIB: 出力バッファに十分な空きがありません。(展開後データの長さ情報が壊れている可能性もあります。)"
@@ -4944,6 +5196,7 @@ ER_ZLIB_Z_BUF_ERROR
         por "ZLIB: Não suficiente espaço no buffer emissor (provavelmente, o comprimento dos dados descomprimidos está corrupto)"
         spa "Z_BUF_ERROR: No suficiente espacio en el búfer de salida para zlib (probablemente, extensión de datos descomprimidos fué corrompida)"
 ER_ZLIB_Z_DATA_ERROR  
+        chi "ZLIB：输入数据已损坏"
         eng "ZLIB: Input data corrupted"
         ger "ZLIB: Eingabedaten beschädigt"
         jpn "ZLIB: 入力データが壊れています。"
@@ -4951,8 +5204,10 @@ ER_ZLIB_Z_DATA_ERROR
         por "ZLIB: Dados de entrada está corrupto"
         spa "ZLIB: Dato de entrada fué corrompido para zlib"
 ER_CUT_VALUE_GROUP_CONCAT  
+        chi "group_concat（）削减了行%u."
         eng "Row %u was cut by GROUP_CONCAT()"
 ER_WARN_TOO_FEW_RECORDS 01000 
+        chi "行%lu不包含所有列的数据"
         eng "Row %lu doesn't contain data for all columns"
         ger "Zeile %lu enthält nicht für alle Felder Daten"
         jpn "行 %lu はすべての列へのデータを含んでいません。"
@@ -4960,6 +5215,7 @@ ER_WARN_TOO_FEW_RECORDS 01000
         por "Conta de registro é menor que a conta de coluna na linha %lu"
         spa "Línea %lu no contiene datos para todas las columnas"
 ER_WARN_TOO_MANY_RECORDS 01000 
+        chi "行%lu被截断;它包含的数据比输入列更多"
         eng "Row %lu was truncated; it contained more data than there were input columns"
         ger "Zeile %lu gekürzt, die Zeile enthielt mehr Daten, als es Eingabefelder gibt"
         jpn "行 %lu はデータを切り捨てられました。列よりも多いデータを含んでいました。"
@@ -4967,20 +5223,24 @@ ER_WARN_TOO_MANY_RECORDS 01000
         por "Conta de registro é maior que a conta de coluna na linha %lu"
         spa "Línea %lu fué truncada; La misma contine mas datos que las que existen en las columnas de entrada"
 ER_WARN_NULL_TO_NOTNULL 22004 
+        chi "列设置为默认值; NULL在行'%s'中提供给了NOT NULL列%lu"
         eng "Column set to default value; NULL supplied to NOT NULL column '%s' at row %lu"
         ger "Feld auf Vorgabewert gesetzt, da NULL für NOT-NULL-Feld '%s' in Zeile %lu angegeben"
         jpn "列にデフォルト値が設定されました。NOT NULLの列 '%s' に 行 %lu で NULL が与えられました。"
         por "Dado truncado, NULL fornecido para NOT NULL coluna '%s' na linha %lu"
         spa "Datos truncado, NULL suministrado para NOT NULL columna '%s' en la línea %lu"
 ER_WARN_DATA_OUT_OF_RANGE 22003 
+	chi "列'%s'行%lu的值超出范围"
         eng "Out of range value for column '%s' at row %lu"
 WARN_DATA_TRUNCATED 01000 
+        chi "数据被截断，在列'%s', 行%lu"
         eng "Data truncated for column '%s' at row %lu"
         ger "Daten abgeschnitten für Feld '%s' in Zeile %lu"
         jpn "列 '%s' の 行 %lu でデータが切り捨てられました。"
         por "Dado truncado para coluna '%s' na linha %lu"
         spa "Datos truncados para columna '%s' en la línea %lu"
 ER_WARN_USING_OTHER_HANDLER  
+        chi "使用存储引擎%s 表格'%s'"
         eng "Using storage engine %s for table '%s'"
         ger "Speicher-Engine %s wird für Tabelle '%s' benutzt"
         hindi "स्टोरेज इंजन %s का इस्तेमाल टेबल '%s' के लिए  किया जा रहा है"
@@ -4989,51 +5249,60 @@ ER_WARN_USING_OTHER_HANDLER
         spa "Usando motor de almacenamiento %s para tabla '%s'"
         swe "Använder handler %s för tabell '%s'"
 ER_CANT_AGGREGATE_2COLLATIONS
+        chi "非法混合collations（%s，%s）和（%s，%s），用于操作'%s'"
         eng "Illegal mix of collations (%s,%s) and (%s,%s) for operation '%s'"
         ger "Unerlaubte Mischung von Sortierreihenfolgen (%s, %s) und (%s, %s) für Operation '%s'"
         jpn "照合順序 (%s,%s) と (%s,%s) の混在は操作 '%s' では不正です。"
         por "Combinação ilegal de collations (%s,%s) e (%s,%s) para operação '%s'"
         spa "Ilegal mezcla de collations (%s,%s) y (%s,%s) para operación '%s'"
 ER_DROP_USER  
+        chi "无法删除一个或多个请求的用户"
         eng "Cannot drop one or more of the requested users"
         ger "Kann einen oder mehrere der angegebenen Benutzer nicht löschen"
 ER_REVOKE_GRANTS  
+        chi "无法为一个或多个请求的用户撤消所有权限"
         eng "Can't revoke all privileges for one or more of the requested users"
         ger "Kann nicht alle Berechtigungen widerrufen, die für einen oder mehrere Benutzer gewährt wurden"
         jpn "指定されたユーザーから指定された全ての権限を剥奪することができませんでした。"
         por "Não pode revocar todos os privilégios, grant para um ou mais dos usuários pedidos"
         spa "No puede revocar todos los privilegios, derecho para uno o mas de los usuarios solicitados"
 ER_CANT_AGGREGATE_3COLLATIONS  
+        chi "非法混合collations（%s，%s）,（%s，%s）和（%s，%s），用于操作'%s'"
         eng "Illegal mix of collations (%s,%s), (%s,%s), (%s,%s) for operation '%s'"
         ger "Unerlaubte Mischung von Sortierreihenfolgen (%s, %s), (%s, %s), (%s, %s) für Operation '%s'"
         jpn "照合順序 (%s,%s), (%s,%s), (%s,%s) の混在は操作 '%s' では不正です。"
         por "Ilegal combinação de collations (%s,%s), (%s,%s), (%s,%s) para operação '%s'"
         spa "Ilegal mezcla de collations (%s,%s), (%s,%s), (%s,%s) para operación '%s'"
 ER_CANT_AGGREGATE_NCOLLATIONS  
+        chi "非法混合collations操作'%s'"
         eng "Illegal mix of collations for operation '%s'"
         ger "Unerlaubte Mischung von Sortierreihenfolgen für Operation '%s'"
         jpn "操作 '%s' では不正な照合順序の混在です。"
         por "Ilegal combinação de collations para operação '%s'"
         spa "Ilegal mezcla de collations para operación '%s'"
 ER_VARIABLE_IS_NOT_STRUCT  
+        chi "变量'%-.64s'不是可变组件（不能用作xxxx.variable_name）"
         eng "Variable '%-.64s' is not a variable component (can't be used as XXXX.variable_name)"
         ger "Variable '%-.64s' ist keine Variablen-Komponente (kann nicht als XXXX.variablen_name verwendet werden)"
         jpn "変数 '%-.64s' は構造変数の構成要素ではありません。(XXXX.変数名 という指定はできません。)"
         por "Variável '%-.64s' não é uma variável componente (Não pode ser usada como XXXX.variável_nome)"
         spa "Variable '%-.64s' no es una variable componente (No puede ser usada como XXXX.variable_name)"
 ER_UNKNOWN_COLLATION  
+        chi "未知的collation：'%-.64s'"
         eng "Unknown collation: '%-.64s'"
         ger "Unbekannte Sortierreihenfolge: '%-.64s'"
         jpn "不明な照合順序: '%-.64s'"
         por "Collation desconhecida: '%-.64s'"
         spa "Collation desconocida: '%-.64s'"
 ER_SLAVE_IGNORED_SSL_PARAMS  
+        chi "CHANGE MASTER中的SSL参数被忽略，因为此MariaDB从站未在没有SSL支持的情况下编译;如果启动了SSL的MariaDB从站，则可以使用它们"
         eng "SSL parameters in CHANGE MASTER are ignored because this MariaDB slave was compiled without SSL support; they can be used later if MariaDB slave with SSL is started"
         ger "SSL-Parameter in CHANGE MASTER werden ignoriert, weil dieser MariaDB-Slave ohne SSL-Unterstützung kompiliert wurde. Sie können aber später verwendet werden, wenn ein MariaDB-Slave mit SSL gestartet wird"
         jpn "このMariaDBスレーブはSSLサポートを含めてコンパイルされていないので、CHANGE MASTER のSSLパラメータは無視されました。今後SSLサポートを持つMariaDBスレーブを起動する際に利用されます。"
         por "SSL parâmetros em CHANGE MASTER são ignorados porque este escravo MariaDB foi compilado sem o SSL suporte. Os mesmos podem ser usados mais tarde quando o escravo MariaDB com SSL seja iniciado."
         spa "Parametros SSL en CHANGE MASTER son ignorados porque este slave MariaDB fue compilado sin soporte SSL; pueden ser usados despues cuando el slave MariaDB con SSL sea inicializado"
 ER_SERVER_IS_IN_SECURE_AUTH_MODE  
+        chi "服务器在--secure-auth模式下运行，但'%s'@'%s'具有旧格式的密码;请将密码更改为新格式"
         eng "Server is running in --secure-auth mode, but '%s'@'%s' has a password in the old format; please change the password to the new format"
         ger "Server läuft im Modus --secure-auth, aber '%s'@'%s' hat ein Passwort im alten Format. Bitte Passwort ins neue Format ändern"
         jpn "サーバーは --secure-auth モードで稼働しています。しかし '%s'@'%s' は古い形式のパスワードを使用しています。新しい形式のパスワードに変更してください。"
@@ -5041,6 +5310,7 @@ ER_SERVER_IS_IN_SECURE_AUTH_MODE
         rus "Сервер запущен в режиме --secure-auth (безопасной авторизации), но для пользователя '%s'@'%s' пароль сохранён в старом формате; необходимо обновить формат пароля"
         spa "Servidor está rodando en modo --secure-auth, pero '%s'@'%s' tiene clave en el antiguo formato; por favor cambie la clave para el nuevo formato"
 ER_WARN_FIELD_RESOLVED  
+        chi "列或参考'%-.192s%s%-.192s%s%-.192s' 在SELECT #%d 中, 在SELECT #%d中得到解决"
         eng "Field or reference '%-.192s%s%-.192s%s%-.192s' of SELECT #%d was resolved in SELECT #%d"
         ger "Feld oder Verweis '%-.192s%s%-.192s%s%-.192s' im SELECT-Befehl Nr. %d wurde im SELECT-Befehl Nr. %d aufgelöst"
         jpn "フィールドまたは参照 '%-.192s%s%-.192s%s%-.192s' は SELECT #%d ではなく、SELECT #%d で解決されました。"
@@ -5049,24 +5319,28 @@ ER_WARN_FIELD_RESOLVED
         spa "Campo o referencia '%-.192s%s%-.192s%s%-.192s' de SELECT #%d fue resolvido en SELECT #%d"
         ukr "Стовбець або посилання '%-.192s%s%-.192s%s%-.192s' із SELECTу #%d було знайдене у SELECTі #%d"
 ER_BAD_SLAVE_UNTIL_COND  
+        chi "START SLAVE UNTIL的参数或参数的组合不正确"
         eng "Incorrect parameter or combination of parameters for START SLAVE UNTIL"
         ger "Falscher Parameter oder falsche Kombination von Parametern für START SLAVE UNTIL"
         jpn "START SLAVE UNTIL へのパラメータまたはその組み合わせが不正です。"
         por "Parâmetro ou combinação de parâmetros errado para START SLAVE UNTIL"
         spa "Parametro equivocado o combinación de parametros para START SLAVE UNTIL"
 ER_MISSING_SKIP_SLAVE  
+        chi "START SLAVE UNTIL进行逐步复制时建议使用--skip-slave-start;否则，如果有意外的Slave的MySQLD重启，可能有问题"
         eng "It is recommended to use --skip-slave-start when doing step-by-step replication with START SLAVE UNTIL; otherwise, you will get problems if you get an unexpected slave's mysqld restart"
         ger "Es wird empfohlen, mit --skip-slave-start zu starten, wenn mit START SLAVE UNTIL eine Schritt-für-Schritt-Replikation ausgeführt wird. Ansonsten gibt es Probleme, wenn ein Slave-Server unerwartet neu startet"
         jpn "START SLAVE UNTIL で段階的にレプリケーションを行う際には、--skip-slave-start オプションを使うことを推奨します。使わない場合、スレーブのmysqldが不慮の再起動をすると問題が発生します。"
         por "É recomendado para rodar com --skip-slave-start quando fazendo replicação passo-por-passo com START SLAVE UNTIL, de outra forma você não está seguro em caso de inesperada reinicialição do mysqld escravo"
         spa "Es recomendado rodar con --skip-slave-start cuando haciendo replicación step-by-step con START SLAVE UNTIL, a menos que usted no esté seguro en caso de inesperada reinicialización del mysqld slave"
 ER_UNTIL_COND_IGNORED  
+        chi "不能启动SQL线程所以UNTIL选项被忽略"
         eng "SQL thread is not to be started so UNTIL options are ignored"
         ger "SQL-Thread soll nicht gestartet werden. Daher werden UNTIL-Optionen ignoriert"
         jpn "スレーブSQLスレッドが開始されないため、UNTILオプションは無視されました。"
         por "Thread SQL não pode ser inicializado tal que opções UNTIL são ignoradas"
         spa "SQL thread no es inicializado tal que opciones UNTIL son ignoradas"
 ER_WRONG_NAME_FOR_INDEX 42000 
+        chi "索引名称'%-.100s'不正确"
         eng "Incorrect index name '%-.100s'"
         ger "Falscher Indexname '%-.100s'"
         jpn "索引名 '%-.100s' は不正です。"
@@ -5074,6 +5348,7 @@ ER_WRONG_NAME_FOR_INDEX 42000
         spa "Nombre de índice incorrecto '%-.100s'"
         swe "Felaktigt index namn '%-.100s'"
 ER_WRONG_NAME_FOR_CATALOG 42000 
+        chi "目录名称'%-.100s'不正确"
         eng "Incorrect catalog name '%-.100s'"
         ger "Falscher Katalogname '%-.100s'"
         jpn "カタログ名 '%-.100s' は不正です。"
@@ -5081,6 +5356,7 @@ ER_WRONG_NAME_FOR_CATALOG 42000
         spa "Nombre de catalog incorrecto '%-.100s'"
         swe "Felaktigt katalog namn '%-.100s'"
 ER_WARN_QC_RESIZE  
+        chi "设置查询缓存值%llu失败;新查询缓存值为%lu"
         eng "Query cache failed to set size %llu; new query cache size is %lu"
         ger "Änderung der Query-Cache-Größe auf %llu fehlgeschlagen; neue Query-Cache-Größe ist %lu"
         por "Falha em Query cache para configurar tamanho %llu, novo tamanho de query cache é %lu"
@@ -5089,6 +5365,7 @@ ER_WARN_QC_RESIZE
         swe "Storleken av "Query cache" kunde inte sättas till %llu, ny storlek är %lu"
         ukr "Кеш запитів неспроможен встановити розмір %llu, новий розмір кеша запитів - %lu"
 ER_BAD_FT_COLUMN  
+        chi "列'%-.192s'不能成为全文索引的一部分"
         eng "Column '%-.192s' cannot be part of FULLTEXT index"
         ger "Feld '%-.192s' kann nicht Teil eines FULLTEXT-Index sein"
         jpn "列 '%-.192s' は全文索引のキーにはできません。"
@@ -5096,6 +5373,7 @@ ER_BAD_FT_COLUMN
         spa "Columna '%-.192s' no puede ser parte de FULLTEXT index"
         swe "Kolumn '%-.192s' kan inte vara del av ett FULLTEXT index"
 ER_UNKNOWN_KEY_CACHE  
+        chi "未知索引缓存'%-.100s'"
         eng "Unknown key cache '%-.100s'"
         ger "Unbekannter Schlüssel-Cache '%-.100s'"
         jpn "'%-.100s' は不明なキーキャッシュです。"
@@ -5103,12 +5381,14 @@ ER_UNKNOWN_KEY_CACHE
         spa "Desconocida key cache '%-.100s'"
         swe "Okänd nyckel cache '%-.100s'"
 ER_WARN_HOSTNAME_WONT_WORK  
+        chi "MariaDB以-skip-name-resolve模式启动;想用grant，您必须重新启动，不用这个选项"
         eng "MariaDB is started in --skip-name-resolve mode; you must restart it without this switch for this grant to work"
         ger "MariaDB wurde mit --skip-name-resolve gestartet. Diese Option darf nicht verwendet werden, damit diese Rechtevergabe möglich ist"
         jpn "MariaDBは --skip-name-resolve モードで起動しています。このオプションを外して再起動しなければ、この権限操作は機能しません。"
         por "MariaDB foi inicializado em modo --skip-name-resolve. Você necesita reincializá-lo sem esta opção para este grant funcionar"
         spa "MariaDB esta inicializado en modo --skip-name-resolve. Usted necesita reinicializarlo sin esta opción para este derecho funcionar"
 ER_UNKNOWN_STORAGE_ENGINE 42000 
+        chi "未知的存储引擎'%s'"
         eng "Unknown storage engine '%s'"
         ger "Unbekannte Speicher-Engine '%s'"
         hindi "अज्ञात स्टोरेज इंजन '%s'"
@@ -5116,12 +5396,14 @@ ER_UNKNOWN_STORAGE_ENGINE 42000
         por "Motor de tabela desconhecido '%s'"
         spa "Desconocido motor de tabla '%s'"
 ER_WARN_DEPRECATED_SYNTAX  
+        chi "弃用'%s'，将在将来的版本中删除。请使用%s"
         eng "'%s' is deprecated and will be removed in a future release. Please use %s instead"
         ger "'%s' ist veraltet. Bitte benutzen Sie '%s'"
         jpn "'%s' は将来のリリースで廃止予定です。代わりに %s を使用してください。"
         por "'%s' é desatualizado. Use '%s' em seu lugar"
         spa "'%s' está desaprobado, use '%s' en su lugar"
 ER_NON_UPDATABLE_TABLE  
+        chi "目标表%-.100s多个%s不可更新"
         eng "The target table %-.100s of the %s is not updatable"
         ger "Die Zieltabelle %-.100s von %s ist nicht aktualisierbar"
         jpn "対象表 %-.100s は更新可能ではないので、%s を行えません。"
@@ -5131,6 +5413,7 @@ ER_NON_UPDATABLE_TABLE
         swe "Tabell %-.100s använd med '%s' är inte uppdateringsbar"
         ukr "Таблиця %-.100s у %s не може оновлюватись"
 ER_FEATURE_DISABLED  
+        chi "'%s'功能被禁用;您需要MariaDB以'%s'构建以使其工作"
         eng "The '%s' feature is disabled; you need MariaDB built with '%s' to have it working"
         ger "Das Feature '%s' ist ausgeschaltet, Sie müssen MariaDB mit '%s' übersetzen, damit es verfügbar ist"
         jpn "機能 '%s' は無効です。利用するためには '%s' を含めてビルドしたMariaDBが必要です。"
@@ -5138,6 +5421,7 @@ ER_FEATURE_DISABLED
         spa "El recurso '%s' fue deshabilitado; usted necesita construir MariaDB con '%s' para tener eso funcionando"
         swe "'%s' är inte aktiverad; För att aktivera detta måste du bygga om MariaDB med '%s' definierad"
 ER_OPTION_PREVENTS_STATEMENT  
+        chi "MariaDB服务器使用%s选项运行，因此无法执行此语句"
         eng "The MariaDB server is running with the %s option so it cannot execute this statement"
         ger "Der MariaDB-Server läuft mit der Option %s und kann diese Anweisung deswegen nicht ausführen"
         jpn "MariaDBサーバーが %s オプションで実行されているので、このステートメントは実行できません。"
@@ -5145,33 +5429,39 @@ ER_OPTION_PREVENTS_STATEMENT
         spa "El servidor MariaDB está rodando con la opción %s tal que no puede ejecutar este comando"
         swe "MariaDB är startad med %s. Pga av detta kan du inte använda detta kommando"
 ER_DUPLICATED_VALUE_IN_TYPE  
+        chi "列'%-.100s'有重复的值'%-.64s'在%s"
         eng "Column '%-.100s' has duplicated value '%-.64s' in %s"
         ger "Feld '%-.100s' hat doppelten Wert '%-.64s' in %s"
         jpn "列 '%-.100s' で、重複する値 '%-.64s' が %s に指定されています。"
         por "Coluna '%-.100s' tem valor duplicado '%-.64s' em %s"
         spa "Columna '%-.100s' tiene valor doblado '%-.64s' en %s"
 ER_TRUNCATED_WRONG_VALUE 22007 
+        chi "截断的不正确%-.32T值：'%-.128T'"
         eng "Truncated incorrect %-.32T value: '%-.128T'"
         ger "Falscher %-.32T-Wert gekürzt: '%-.128T'"
         jpn "不正な %-.32T の値が切り捨てられました。: '%-.128T'"
         por "Truncado errado %-.32T valor: '%-.128T'"
         spa "Equivocado truncado %-.32T valor: '%-.128T'"
 ER_TOO_MUCH_AUTO_TIMESTAMP_COLS  
+        chi "表定义不正确;默认或ON UPDATE中只能有一个带有CURRENT_TIMESTAMP的TIMESTAMP列"
         eng "Incorrect table definition; there can be only one TIMESTAMP column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause"
         ger "Fehlerhafte Tabellendefinition. Es kann nur eine einzige TIMESTAMP-Spalte mit CURRENT_TIMESTAMP als DEFAULT oder in einer ON-UPDATE-Klausel geben"
         jpn "不正な表定義です。DEFAULT句またはON UPDATE句に CURRENT_TIMESTAMP をともなうTIMESTAMP型の列は1つまでです。"
         por "Incorreta definição de tabela; Pode ter somente uma coluna TIMESTAMP com CURRENT_TIMESTAMP em DEFAULT ou ON UPDATE cláusula"
         spa "Incorrecta definición de tabla; Solamente debe haber una columna TIMESTAMP con CURRENT_TIMESTAMP en DEFAULT o ON UPDATE cláusula"
 ER_INVALID_ON_UPDATE  
+        chi "在'%-.192s'列的ON UPDATE子句上无效"
         eng "Invalid ON UPDATE clause for '%-.192s' column"
         ger "Ungültige ON-UPDATE-Klausel für Spalte '%-.192s'"
         jpn "列 '%-.192s' に ON UPDATE句は無効です。"
         por "Inválida cláusula ON UPDATE para campo '%-.192s'"
         spa "Inválido ON UPDATE cláusula para campo '%-.192s'"
 ER_UNSUPPORTED_PS  
+        chi "尚未在prepared statement协议中支持此命令"
         eng "This command is not supported in the prepared statement protocol yet"
         ger "Dieser Befehl wird im Protokoll für vorbereitete Anweisungen noch nicht unterstützt"
 ER_GET_ERRMSG  
+        chi "出错%d '%-.200s'来自%s"
         dan "Modtog fejl %d '%-.200s' fra %s"
         eng "Got error %d '%-.200s' from %s"
         ger "Fehler %d '%-.200s' von %s"
@@ -5179,195 +5469,248 @@ ER_GET_ERRMSG
         nor "Mottok feil %d '%-.200s' fa %s"
         norwegian-ny "Mottok feil %d '%-.200s' fra %s"
 ER_GET_TEMPORARY_ERRMSG  
+        chi "出临时错误%d '%-.200s'来自%s"
         dan "Modtog temporary fejl %d '%-.200s' fra %s"
         eng "Got temporary error %d '%-.200s' from %s"
-        jpn "一時エラー %d '%-.200s' が %s から返されました。"
         ger "Temporärer Fehler %d '%-.200s' von %s"
+        jpn "一時エラー %d '%-.200s' が %s から返されました。"
         nor "Mottok temporary feil %d '%-.200s' fra %s"
         norwegian-ny "Mottok temporary feil %d '%-.200s' fra %s"
 ER_UNKNOWN_TIME_ZONE  
+        chi "未知或不正确的时区：'%-.64s'"
         eng "Unknown or incorrect time zone: '%-.64s'"
         ger "Unbekannte oder falsche Zeitzone: '%-.64s'"
 ER_WARN_INVALID_TIMESTAMP  
+        chi "无效TIMESTAMP值：列'%s' 行'%lu'"
         eng "Invalid TIMESTAMP value in column '%s' at row %lu"
         ger "Ungültiger TIMESTAMP-Wert in Feld '%s', Zeile %lu"
 ER_INVALID_CHARACTER_STRING  
+        chi "无效的%s字符串：'%.64T'"
         eng "Invalid %s character string: '%.64T'"
         ger "Ungültiger %s-Zeichen-String: '%.64T'"
 ER_WARN_ALLOWED_PACKET_OVERFLOWED  
+        chi "%s（）的结果大于max_allowed_packet（%ld） - 截断"
         eng "Result of %s() was larger than max_allowed_packet (%ld) - truncated"
         ger "Ergebnis von %s() war größer als max_allowed_packet (%ld) Bytes und wurde deshalb gekürzt"
 ER_CONFLICTING_DECLARATIONS  
+        chi "矛盾语句：'%s%s'和'%s%s'"
         eng "Conflicting declarations: '%s%s' and '%s%s'"
         ger "Widersprüchliche Deklarationen: '%s%s' und '%s%s'"
 ER_SP_NO_RECURSIVE_CREATE 2F003 
+        chi "无法从另一个存储过程中创建%s"
         eng "Can't create a %s from within another stored routine"
         ger "Kann kein %s innerhalb einer anderen gespeicherten Routine erzeugen"
 ER_SP_ALREADY_EXISTS 42000 
+        chi "%s%s已经存在"
         eng "%s %s already exists"
         ger "%s %s existiert bereits"
         hindi "%s %s पहले से ही मौजूद है"
 ER_SP_DOES_NOT_EXIST 42000 
+        chi "%s%s不存在"
         eng "%s %s does not exist"
         ger "%s %s existiert nicht"
         hindi "%s %s मौजूद नहीं है"
 ER_SP_DROP_FAILED  
+        chi "未能DROP%s%s"
         eng "Failed to DROP %s %s"
         ger "DROP %s %s ist fehlgeschlagen"
         hindi "%s %s को ड्रॉप करने में असफल रहे"
 ER_SP_STORE_FAILED  
+        chi "无法创建%s%s"
         eng "Failed to CREATE %s %s"
         ger "CREATE %s %s ist fehlgeschlagen"
         hindi "%s %s को बनाने में असफल रहे"
 ER_SP_LILABEL_MISMATCH 42000 
+        chi "%s，没有匹配标签：%s"
         eng "%s with no matching label: %s"
         ger "%s ohne passende Marke: %s"
 ER_SP_LABEL_REDEFINE 42000 
+        chi "重新定义标签%s"
         eng "Redefining label %s"
         ger "Neudefinition der Marke %s"
 ER_SP_LABEL_MISMATCH 42000 
+        chi "没有匹配的最终标签%s"
         eng "End-label %s without match"
         ger "Ende-Marke %s ohne zugehörigen Anfang"
 ER_SP_UNINIT_VAR 01000 
+        chi "参考未初始化的变量%s"
         eng "Referring to uninitialized variable %s"
         ger "Zugriff auf nichtinitialisierte Variable %s"
 ER_SP_BADSELECT 0A000 
+        chi "PROCEDURE%s不能返回给定上下文中的结果集"
         eng "PROCEDURE %s can't return a result set in the given context"
         ger "PROCEDURE %s kann im gegebenen Kontext keine Ergebnismenge zurückgeben"
 ER_SP_BADRETURN 42000 
+        chi "RETURN仅允许在函数中"
         eng "RETURN is only allowed in a FUNCTION"
         ger "RETURN ist nur innerhalb einer FUNCTION erlaubt"
         hindi "RETURN को केवल FUNCTION में इस्तेमाल किया जा सकता है"
 ER_SP_BADSTATEMENT 0A000 
+        chi "%s不允许在存储过程中"
         eng "%s is not allowed in stored procedures"
         ger "%s ist in gespeicherten Prozeduren nicht erlaubt"
         hindi "%s को STORED PROCEDURE में इस्तेमाल नहीं किया जा सकता है"
 ER_UPDATE_LOG_DEPRECATED_IGNORED 42000 
+        chi "更新日志被弃用并由二进制日志替换;SET SQL_LOG_UPDATE已被忽略。此选项将在MariaDB 5.6中删除"
         eng "The update log is deprecated and replaced by the binary log; SET SQL_LOG_UPDATE has been ignored. This option will be removed in MariaDB 5.6"
         ger "Das Update-Log ist veraltet und wurde durch das Binär-Log ersetzt. SET SQL_LOG_UPDATE wird ignoriert. Diese Option wird in MariaDB 5.6 entfernt"
 ER_UPDATE_LOG_DEPRECATED_TRANSLATED 42000 
+        chi "更新日志被弃用并由二进制日志替换;SET SQL_LOG_UPDATE已被转换为设置SQL_LOG_BIN。此选项将在MariaDB 5.6中删除"
         eng "The update log is deprecated and replaced by the binary log; SET SQL_LOG_UPDATE has been translated to SET SQL_LOG_BIN. This option will be removed in MariaDB 5.6"
         ger "Das Update-Log ist veraltet und wurde durch das Binär-Log ersetzt. SET SQL_LOG_UPDATE wurde in SET SQL_LOG_BIN übersetzt. Diese Option wird in MariaDB 5.6 entfernt"
 ER_QUERY_INTERRUPTED 70100 
+        chi "查询执行中断"
         eng "Query execution was interrupted"
         ger "Ausführung der Abfrage wurde unterbrochen"
 ER_SP_WRONG_NO_OF_ARGS 42000 
+        chi "%s%s的参数数量不正确;预期%u，得到%u"
         eng "Incorrect number of arguments for %s %s; expected %u, got %u"
         ger "Falsche Anzahl von Argumenten für %s %s; erwarte %u, erhalte %u"
 ER_SP_COND_MISMATCH 42000 
+        chi "未定义的CONDITION：%s"
         eng "Undefined CONDITION: %s"
         ger "Undefinierte CONDITION: %s"
 ER_SP_NORETURN 42000 
+        chi "FUNCTION%s中没有RETURN"
         eng "No RETURN found in FUNCTION %s"
         ger "Kein RETURN in FUNCTION %s gefunden"
         hindi "FUNCTION %s में कोई RETURN है"
 ER_SP_NORETURNEND 2F005 
+        chi "FUNCTION%s结束但无RETURN"
         eng "FUNCTION %s ended without RETURN"
         ger "FUNCTION %s endete ohne RETURN"
         hindi "FUNCTION %s RETURN के बिना समाप्त हो गया"
 ER_SP_BAD_CURSOR_QUERY 42000 
+        chi "Cursor语句必须是选择"
         eng "Cursor statement must be a SELECT"
         ger "Cursor-Anweisung muss ein SELECT sein"
 ER_SP_BAD_CURSOR_SELECT 42000 
+        chi "Cursor SELECT不能有INTO"
         eng "Cursor SELECT must not have INTO"
         ger "Cursor-SELECT darf kein INTO haben"
 ER_SP_CURSOR_MISMATCH 42000 
+        chi "未定义的CURSOR：%s"
         eng "Undefined CURSOR: %s"
         ger "Undefinierter CURSOR: %s"
         hindi "CURSOR %s अपरिभाषित है"
 ER_SP_CURSOR_ALREADY_OPEN 24000 
+        chi "Cursor已经打开"
         eng "Cursor is already open"
         ger "Cursor ist schon geöffnet"
         hindi "CURSOR पहले से ही खुला है"
 ER_SP_CURSOR_NOT_OPEN 24000 
+        chi "Cursor未打开"
         eng "Cursor is not open"
         ger "Cursor ist nicht geöffnet"
 ER_SP_UNDECLARED_VAR 42000 
+        chi "未定义的变量：%s"
         eng "Undeclared variable: %s"
         ger "Nicht deklarierte Variable: %s"
 ER_SP_WRONG_NO_OF_FETCH_ARGS  
+        chi "FETCH变量数不正确"
         eng "Incorrect number of FETCH variables"
         ger "Falsche Anzahl von FETCH-Variablen"
 ER_SP_FETCH_NO_DATA 02000 
+        chi "没有数据 - 零行被选择或处理"
         eng "No data - zero rows fetched, selected, or processed"
         ger "Keine Daten - null Zeilen geholt (fetch), ausgewählt oder verarbeitet"
 ER_SP_DUP_PARAM 42000 
+        chi "重复参数：%s"
         eng "Duplicate parameter: %s"
         ger "Doppelter Parameter: %s"
 ER_SP_DUP_VAR 42000 
+        chi "重复变量：%s"
         eng "Duplicate variable: %s"
         ger "Doppelte Variable: %s"
 ER_SP_DUP_COND 42000 
+        chi "重复条件：%s"
         eng "Duplicate condition: %s"
         ger "Doppelte Bedingung: %s"
 ER_SP_DUP_CURS 42000 
+        chi "重复Cursor：%s"
         eng "Duplicate cursor: %s"
         ger "Doppelter Cursor: %s"
 ER_SP_CANT_ALTER  
+        chi "未能ALTER %s%s"
         eng "Failed to ALTER %s %s"
         ger "ALTER %s %s fehlgeschlagen"
         hindi "%s %s को ALTER करने में असफल रहे"
 ER_SP_SUBSELECT_NYI 0A000 
+        chi "不支持子查询值"
         eng "Subquery value not supported"
         ger "Subquery-Wert wird nicht unterstützt"
 ER_STMT_NOT_ALLOWED_IN_SF_OR_TRG 0A000
+        chi "在存储的函数或触发中不允许%s"
         eng "%s is not allowed in stored function or trigger"
         ger "%s ist in gespeicherten Funktionen und in Triggern nicht erlaubt"
 ER_SP_VARCOND_AFTER_CURSHNDLR 42000 
+        chi "变量或条件声明在cursor或处理程序定义之后"
         eng "Variable or condition declaration after cursor or handler declaration"
         ger "Deklaration einer Variablen oder einer Bedingung nach der Deklaration eines Cursors oder eines Handlers"
 ER_SP_CURSOR_AFTER_HANDLER 42000 
+        chi "处理程序声明后的cursor声明"
         eng "Cursor declaration after handler declaration"
         ger "Deklaration eines Cursors nach der Deklaration eines Handlers"
 ER_SP_CASE_NOT_FOUND 20000 
+        chi "未能在CASE语句找到Case"
         eng "Case not found for CASE statement"
         ger "Fall für CASE-Anweisung nicht gefunden"
 ER_FPARSER_TOO_BIG_FILE  
+        chi "配置文件'%-.192s'太大了"
         eng "Configuration file '%-.192s' is too big"
         ger "Konfigurationsdatei '%-.192s' ist zu groß"
         rus "Слишком большой конфигурационный файл '%-.192s'"
         ukr "Занадто великий конфігураційний файл '%-.192s'"
 ER_FPARSER_BAD_HEADER  
+        chi "文件'%-.192s'中的文件类型格式有问题"
         eng "Malformed file type header in file '%-.192s'"
         ger "Nicht wohlgeformter Dateityp-Header in Datei '%-.192s'"
         rus "Неверный заголовок типа файла '%-.192s'"
         ukr "Невірний заголовок типу у файлі '%-.192s'"
 ER_FPARSER_EOF_IN_COMMENT  
+        chi "解析评论'%-.200s'时意外碰到EOF"
         eng "Unexpected end of file while parsing comment '%-.200s'"
         ger "Unerwartetes Dateiende beim Parsen des Kommentars '%-.200s'"
         rus "Неожиданный конец файла в коментарии '%-.200s'"
         ukr "Несподіванний кінець файлу у коментарі '%-.200s'"
 ER_FPARSER_ERROR_IN_PARAMETER  
+        chi "解析参数'%-.192s'时出错（行：'%-.192s'）"
         eng "Error while parsing parameter '%-.192s' (line: '%-.192s')"
         ger "Fehler beim Parsen des Parameters '%-.192s' (Zeile: '%-.192s')"
         rus "Ошибка при распознавании параметра '%-.192s' (строка: '%-.192s')"
         ukr "Помилка в роспізнаванні параметру '%-.192s' (рядок: '%-.192s')"
 ER_FPARSER_EOF_IN_UNKNOWN_PARAMETER  
+        chi "跳过未知参数'%-.192s'时意外碰到EOF"
         eng "Unexpected end of file while skipping unknown parameter '%-.192s'"
         ger "Unerwartetes Dateiende beim Überspringen des unbekannten Parameters '%-.192s'"
         rus "Неожиданный конец файла при пропуске неизвестного параметра '%-.192s'"
         ukr "Несподіванний кінець файлу у спробі проминути невідомий параметр '%-.192s'"
 ER_VIEW_NO_EXPLAIN  
+        chi "ANALYZE/EXPLAIN/SHOW无法进行;缺乏底层表的特权"
         eng "ANALYZE/EXPLAIN/SHOW can not be issued; lacking privileges for underlying table"
         ger "ANALYZE/EXPLAIN/SHOW kann nicht verlangt werden. Rechte für zugrunde liegende Tabelle fehlen"
         rus "ANALYZE/EXPLAIN/SHOW не может быть выполнено; недостаточно прав на таблицы запроса"
         ukr "ANALYZE/EXPLAIN/SHOW не може бути виконано; немає прав на таблиці запиту"
 ER_FRM_UNKNOWN_TYPE  
+        chi "文件'%-.192s'在其标题中有未知的'%-.64s'"
         eng "File '%-.192s' has unknown type '%-.64s' in its header"
         ger "Datei '%-.192s' hat unbekannten Typ '%-.64s' im Header"
         rus "Файл '%-.192s' содержит неизвестный тип '%-.64s' в заголовке"
         ukr "Файл '%-.192s' має невідомий тип '%-.64s' у заголовку"
 ER_WRONG_OBJECT  
+        chi "'%-.192s.%-.192s'不是'%s'类"
         eng "'%-.192s.%-.192s' is not of type '%s'"
         ger "'%-.192s.%-.192s' ist nicht %s"
         rus "'%-.192s.%-.192s' - не %s"
         ukr "'%-.192s.%-.192s' не є %s"
 ER_NONUPDATEABLE_COLUMN  
+        chi "列'%-.192s'不可更新"
         eng "Column '%-.192s' is not updatable"
         ger "Feld '%-.192s' ist nicht aktualisierbar"
         rus "Столбец '%-.192s' не обновляемый"
         ukr "Стовбець '%-.192s' не може бути зминений"
 ER_VIEW_SELECT_DERIVED  
+        chi "View的Select的FROM包含子查询"
         eng "View's SELECT contains a subquery in the FROM clause"
         ger "SELECT der View enthält eine Subquery in der FROM-Klausel"
         rus "View SELECT содержит подзапрос в конструкции FROM"
@@ -5375,810 +5718,1046 @@ ER_VIEW_SELECT_DERIVED
 
 # Not used any more, syntax error is returned instead
 ER_VIEW_SELECT_CLAUSE  
+        chi "View的Select包含“%s”子句"
         eng "View's SELECT contains a '%s' clause"
         ger "SELECT der View enthält eine '%s'-Klausel"
         rus "View SELECT содержит конструкцию '%s'"
         ukr "View SELECT має конструкцію '%s'"
 ER_VIEW_SELECT_VARIABLE  
+        chi "View的选择包含变量或参数"
         eng "View's SELECT contains a variable or parameter"
         ger "SELECT der View enthält eine Variable oder einen Parameter"
         rus "View SELECT содержит переменную или параметр"
         ukr "View SELECT має зминну або параметер"
 ER_VIEW_SELECT_TMPTABLE  
+        chi "View的SELECT指的是临时表'%-.192s'"
         eng "View's SELECT refers to a temporary table '%-.192s'"
         ger "SELECT der View verweist auf eine temporäre Tabelle '%-.192s'"
         rus "View SELECT содержит ссылку на временную таблицу '%-.192s'"
         ukr "View SELECT використовує тимчасову таблицю '%-.192s'"
 ER_VIEW_WRONG_LIST  
+        chi "View的选择和VIEW的字段列表具有不同的列计数"
         eng "View's SELECT and view's field list have different column counts"
         ger "SELECT- und Feldliste der Views haben unterschiedliche Anzahlen von Spalten"
         rus "View SELECT и список полей view имеют разное количество столбцов"
         ukr "View SELECT і перелік стовбців view мають різну кількість сковбців"
 ER_WARN_VIEW_MERGE  
+        chi "View合并算法目前不能使用（假设未定义的算法）"
         eng "View merge algorithm can't be used here for now (assumed undefined algorithm)"
         ger "View-Merge-Algorithmus kann hier momentan nicht verwendet werden (undefinierter Algorithmus wird angenommen)"
         rus "Алгоритм слияния view не может быть использован сейчас (алгоритм будет неопеределенным)"
         ukr "Алгоритм зливання view не може бути використаний зараз (алгоритм буде невизначений)"
 ER_WARN_VIEW_WITHOUT_KEY  
+        chi "更新的视图没有底层表的完整键"
         eng "View being updated does not have complete key of underlying table in it"
         ger "Die aktualisierte View enthält nicht den vollständigen Schlüssel der zugrunde liegenden Tabelle"
         rus "Обновляемый view не содержит ключа использованных(ой) в нем таблиц(ы)"
         ukr "View, що оновлюеться, не містить повного ключа таблиці(ь), що викорістана в ньюому"
 ER_VIEW_INVALID  
+        chi "View'%-.192s.%-.192s'引用无效的表、列、函数、或者函数或View缺乏使用权"
         eng "View '%-.192s.%-.192s' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them"
 ER_SP_NO_DROP_SP  
+        chi "无法从另一个存储的例程中删除或更改%s"
         eng "Can't drop or alter a %s from within another stored routine"
         ger "Kann eine %s nicht von innerhalb einer anderen gespeicherten Routine löschen oder ändern"
 ER_SP_GOTO_IN_HNDLR  
+        chi "在存储过程处理程序中不允许GOTO"
         eng "GOTO is not allowed in a stored procedure handler"
         ger "GOTO ist im Handler einer gespeicherten Prozedur nicht erlaubt"
 ER_TRG_ALREADY_EXISTS  
+        chi "触发'%s'已经存在"
         eng "Trigger '%s' already exists"
         ger "Trigger '%s' existiert bereits"
         hindi "TRIGGER '%s' पहले से मौजूद है"
 ER_TRG_DOES_NOT_EXIST  
+        chi "触发不存在"
         eng "Trigger does not exist"
         ger "Trigger existiert nicht"
         hindi "TRIGGER मौजूद नहीं है"
 ER_TRG_ON_VIEW_OR_TEMP_TABLE  
+        chi "触发器的'%-.192s'是视图或临时表"
         eng "Trigger's '%-.192s' is view, temporary table or sequence"
         hindi "'%-.192s' एक व्यू, टेम्पररी टेबल या सीक्वेंस है"
+        ger "'%-.192s' des Triggers ist View oder temporäre Tabelle"
 ER_TRG_CANT_CHANGE_ROW  
+        chi "更新%s行在%s触发器中不允许"
         eng "Updating of %s row is not allowed in %strigger"
         ger "Aktualisieren einer %s-Zeile ist in einem %s-Trigger nicht erlaubt"
 ER_TRG_NO_SUCH_ROW_IN_TRG  
+        chi "没有%s行，触发%s"
         eng "There is no %s row in %s trigger"
         ger "Es gibt keine %s-Zeile im %s-Trigger"
 ER_NO_DEFAULT_FOR_FIELD  
+        chi "字段'%-.192s'没有默认值"
         eng "Field '%-.192s' doesn't have a default value"
         ger "Feld '%-.192s' hat keinen Vorgabewert"
 ER_DIVISION_BY_ZERO 22012 
+        chi "除0错误"
         eng "Division by 0"
         ger "Division durch 0"
         hindi "0 से विभाजन"
 ER_TRUNCATED_WRONG_VALUE_FOR_FIELD  22007
+        chi "不正确的%-.32s值：'%-.128T'用于列`%.192s`%.192s`%.192s`在%lu行"
         eng "Incorrect %-.32s value: '%-.128T' for column `%.192s`.`%.192s`.`%.192s` at row %lu"
         ger "Falscher %-.32s-Wert: '%-.128T' für Feld '`%.192s`.`%.192s`.`%.192s` in Zeile %lu"
 ER_ILLEGAL_VALUE_FOR_TYPE 22007 
+        chi "在解析期间发现的非法%s '%-.192T'值"
         eng "Illegal %s '%-.192T' value found during parsing"
         ger "Nicht zulässiger %s-Wert '%-.192T' beim Parsen gefunden"
 ER_VIEW_NONUPD_CHECK  
+        chi "在不可更新的视图%`-.192s.%`-.192s上CHECK OPTION"
         eng "CHECK OPTION on non-updatable view %`-.192s.%`-.192s"
         ger "CHECK OPTION auf nicht-aktualisierbarem View %`-.192s.%`-.192s"
         rus "CHECK OPTION для необновляемого VIEW %`-.192s.%`-.192s"
         ukr "CHECK OPTION для VIEW %`-.192s.%`-.192s що не може бути оновленним"
 ER_VIEW_CHECK_FAILED 44000
+        chi "CHECK OPTION失败%`-.192s.%`-.192s"
         eng "CHECK OPTION failed %`-.192s.%`-.192s"
         ger "CHECK OPTION fehlgeschlagen: %`-.192s.%`-.192s"
         rus "Проверка CHECK OPTION для VIEW %`-.192s.%`-.192s провалилась"
         ukr "Перевірка CHECK OPTION для VIEW %`-.192s.%`-.192s не пройшла"
 ER_PROCACCESS_DENIED_ERROR 42000 
+        chi "%-.32s命令被拒绝。用户为'%s'@'%s' 例程'%-.192s'"
         eng "%-.32s command denied to user '%s'@'%s' for routine '%-.192s'"
         ger "Befehl %-.32s nicht zulässig für Benutzer '%s'@'%s' in Routine '%-.192s'"
 ER_RELAY_LOG_FAIL  
+        chi "清除旧继relay日志失败：%s"
         eng "Failed purging old relay logs: %s"
         ger "Bereinigen alter Relais-Logs fehlgeschlagen: %s"
 ER_PASSWD_LENGTH  
+        chi "密码哈希应该是一个%d-digit十六进制数"
         eng "Password hash should be a %d-digit hexadecimal number"
         ger "Passwort-Hash sollte eine Hexdaezimalzahl mit %d Stellen sein"
 ER_UNKNOWN_TARGET_BINLOG  
+        chi "在Binlog索引中找不到目标日志"
         eng "Target log not found in binlog index"
         ger "Ziel-Log im Binlog-Index nicht gefunden"
 ER_IO_ERR_LOG_INDEX_READ  
+        chi "读取日志索引文件时I/O错误"
         eng "I/O error reading log index file"
         ger "Fehler beim Lesen der Log-Index-Datei"
 ER_BINLOG_PURGE_PROHIBITED  
+        chi "服务器配置不允许Binlog清除"
         eng "Server configuration does not permit binlog purge"
         ger "Server-Konfiguration erlaubt keine Binlog-Bereinigung"
 ER_FSEEK_FAIL  
+        chi "fseek（）失败"
         eng "Failed on fseek()"
         ger "fseek() fehlgeschlagen"
         hindi "fseek() विफल रहा"
 ER_BINLOG_PURGE_FATAL_ERR  
+        chi "日志清除期间的致命错误"
         eng "Fatal error during log purge"
         ger "Schwerwiegender Fehler bei der Log-Bereinigung"
 ER_LOG_IN_USE  
+        chi "日志在用，不会清除"
         eng "A purgeable log is in use, will not purge"
         ger "Ein zu bereinigendes Log wird gerade benutzt, daher keine Bereinigung"
 ER_LOG_PURGE_UNKNOWN_ERR  
+        chi "日志清除期间未知错误"
         eng "Unknown error during log purge"
         ger "Unbekannter Fehler bei Log-Bereinigung"
 ER_RELAY_LOG_INIT  
+        chi "初始化relay日志失败。位置：%s"
         eng "Failed initializing relay log position: %s"
         ger "Initialisierung der Relais-Log-Position fehlgeschlagen: %s"
 ER_NO_BINARY_LOGGING  
+        chi "您不使用二进制日志记录"
         eng "You are not using binary logging"
         ger "Sie verwenden keine Binärlogs"
 ER_RESERVED_SYNTAX  
+        chi "'%-.64s'语法保留用于MariaDB服务器内部"
         eng "The '%-.64s' syntax is reserved for purposes internal to the MariaDB server"
         ger "Die Schreibweise '%-.64s' ist für interne Zwecke des MariaDB-Servers reserviert"
 ER_WSAS_FAILED  
+        chi "WSAStartup失败了"
         eng "WSAStartup Failed"
         ger "WSAStartup fehlgeschlagen"
 ER_DIFF_GROUPS_PROC  
+        chi "无法处理具有不同组的过程"
         eng "Can't handle procedures with different groups yet"
         ger "Kann Prozeduren mit unterschiedlichen Gruppen noch nicht verarbeiten"
 ER_NO_GROUP_FOR_PROC  
+        chi "SELECT必须具有此过程的组"
         eng "Select must have a group with this procedure"
         ger "SELECT muss bei dieser Prozedur ein GROUP BY haben"
 ER_ORDER_WITH_PROC  
+        chi "无法在次存储过程使用ORDER子句"
         eng "Can't use ORDER clause with this procedure"
         ger "Kann bei dieser Prozedur keine ORDER-BY-Klausel verwenden"
 ER_LOGGING_PROHIBIT_CHANGING_OF  
+        chi "二进制日志记录和复制禁止更改全局服务器%s"
         eng "Binary logging and replication forbid changing the global server %s"
         ger "Binärlogs und Replikation verhindern Wechsel des globalen Servers %s"
 ER_NO_FILE_MAPPING  
+        chi "无法映射文件：%-.200s，错误号码：%M"
         eng "Can't map file: %-.200s, errno: %M"
         ger "Kann Datei nicht abbilden: %-.200s, Fehler: %M"
 ER_WRONG_MAGIC  
+        chi "魔法错误%-.64s"
         eng "Wrong magic in %-.64s"
         ger "Falsche magische Zahlen in %-.64s"
 ER_PS_MANY_PARAM  
+        chi "Prepared statement包含太多占位符"
         eng "Prepared statement contains too many placeholders"
         ger "Vorbereitete Anweisung enthält zu viele Platzhalter"
 ER_KEY_PART_0  
+        chi "索引部分'%-.192s'长度不能为0"
         eng "Key part '%-.192s' length cannot be 0"
         ger "Länge des Schlüsselteils '%-.192s' kann nicht 0 sein"
 ER_VIEW_CHECKSUM  
+        chi "查看文本checksum失败"
         eng "View text checksum failed"
         ger "View-Text-Prüfsumme fehlgeschlagen"
         rus "Проверка контрольной суммы текста VIEW провалилась"
         ukr "Перевірка контрольної суми тексту VIEW не пройшла"
 ER_VIEW_MULTIUPDATE  
+        chi "无法通过JOIN视图'%-.192s.%-.192s'修改多个基础表。"
         eng "Can not modify more than one base table through a join view '%-.192s.%-.192s'"
         ger "Kann nicht mehr als eine Basistabelle über Join-View '%-.192s.%-.192s' ändern"
         rus "Нельзя изменить больше чем одну базовую таблицу используя многотабличный VIEW '%-.192s.%-.192s'"
         ukr "Неможливо оновити більш ниж одну базову таблицю выкористовуючи VIEW '%-.192s.%-.192s', що містіть декілька таблиць"
 ER_VIEW_NO_INSERT_FIELD_LIST  
+        chi "无法写入JOIN视图'%-.192s.%-.192s'没有字段列表"
         eng "Can not insert into join view '%-.192s.%-.192s' without fields list"
         ger "Kann nicht ohne Feldliste in Join-View '%-.192s.%-.192s' einfügen"
         rus "Нельзя вставлять записи в многотабличный VIEW '%-.192s.%-.192s' без списка полей"
         ukr "Неможливо уставити рядки у VIEW '%-.192s.%-.192s', що містить декілька таблиць, без списку стовбців"
 ER_VIEW_DELETE_MERGE_VIEW  
+        chi "无法从JOIN视图'%-.192s.%-.192s'删除"
         eng "Can not delete from join view '%-.192s.%-.192s'"
         ger "Kann nicht aus Join-View '%-.192s.%-.192s' löschen"
         rus "Нельзя удалять из многотабличного VIEW '%-.192s.%-.192s'"
         ukr "Неможливо видалити рядки у VIEW '%-.192s.%-.192s', що містить декілька таблиць"
 ER_CANNOT_USER  
+        chi "操作%s失败%.256s"
         eng "Operation %s failed for %.256s"
         ger "Operation %s schlug fehl für %.256s"
         norwegian-ny "Operation %s failed for '%.256s'"
 ER_XAER_NOTA XAE04
+        chi "XAER_NOTA：未知的XID"
         eng "XAER_NOTA: Unknown XID"
         ger "XAER_NOTA: Unbekannte XID"
 ER_XAER_INVAL XAE05
+        chi "XAER_INVAL：无效的参数（或不支持的命令）"
         eng "XAER_INVAL: Invalid arguments (or unsupported command)"
         ger "XAER_INVAL: Ungültige Argumente (oder nicht unterstützter Befehl)"
 ER_XAER_RMFAIL XAE07
+        chi "XAER_RMFAIL：当全局事务处于%.64s状态时，无法执行该命令"
         eng "XAER_RMFAIL: The command cannot be executed when global transaction is in the  %.64s state"
         ger "XAER_RMFAIL: DEr Befehl kann nicht ausgeführt werden, wenn die globale Transaktion im Zustand %.64s ist"
         rus "XAER_RMFAIL: эту команду нельзя выполнять когда глобальная транзакция находится в состоянии '%.64s'"
 ER_XAER_OUTSIDE XAE09
+        chi "XAER_OUTSIDE：一些工作是在全局交易之外完成的"
         eng "XAER_OUTSIDE: Some work is done outside global transaction"
         ger "XAER_OUTSIDE: Einige Arbeiten werden außerhalb der globalen Transaktion verrichtet"
 ER_XAER_RMERR XAE03
+        chi "XAER_RMERR：事务分支中发生致命错误 - 检查您的数据以获得一致性"
         eng "XAER_RMERR: Fatal error occurred in the transaction branch - check your data for consistency"
         ger "XAER_RMERR: Schwerwiegender Fehler im Transaktionszweig - prüfen Sie Ihre Daten auf Konsistenz"
 ER_XA_RBROLLBACK XA100
+        chi "XA_RBROLBACK：交易分支回滚"
         eng "XA_RBROLLBACK: Transaction branch was rolled back"
         ger "XA_RBROLLBACK: Transaktionszweig wurde zurückgerollt"
 ER_NONEXISTING_PROC_GRANT 42000 
+        chi "无授权：用户'%-.48s'主机'%-.64s'ROUTINE'%-.192s'"
         eng "There is no such grant defined for user '%-.48s' on host '%-.64s' on routine '%-.192s'"
         ger "Es gibt diese Berechtigung für Benutzer '%-.48s' auf Host '%-.64s' für Routine '%-.192s' nicht"
 ER_PROC_AUTO_GRANT_FAIL
+        chi "无法授予EXECUTE和ALTER ROUTINE权限"
         eng "Failed to grant EXECUTE and ALTER ROUTINE privileges"
         ger "Gewährung von EXECUTE- und ALTER-ROUTINE-Rechten fehlgeschlagen"
 ER_PROC_AUTO_REVOKE_FAIL
+        chi "无法撤消所有权限以删除例程"
         eng "Failed to revoke all privileges to dropped routine"
         ger "Rücknahme aller Rechte für die gelöschte Routine fehlgeschlagen"
 ER_DATA_TOO_LONG 22001
+        chi "列'%s'行%lu数据太长"
         eng "Data too long for column '%s' at row %lu"
         ger "Daten zu lang für Feld '%s' in Zeile %lu"
 ER_SP_BAD_SQLSTATE 42000
+        chi "坏SQLSTATE：'%s'"
         eng "Bad SQLSTATE: '%s'"
         ger "Ungültiger SQLSTATE: '%s'"
 ER_STARTUP
+        chi "%s：已经准备好接受连接\nVersion：'%s'套接字：'%s'端口：%d %s"
         eng "%s: ready for connections.\nVersion: '%s'  socket: '%s'  port: %d  %s"
         ger "%s: bereit für Verbindungen.\nVersion: '%s'  Socket: '%s'  Port: %d  %s"
 ER_LOAD_FROM_FIXED_SIZE_ROWS_TO_VAR
+        chi "无法从带有固定大小行的文件中加载值到变量"
         eng "Can't load value from file with fixed size rows to variable"
         ger "Kann Wert aus Datei mit Zeilen fester Größe nicht in Variable laden"
 ER_CANT_CREATE_USER_WITH_GRANT 42000
+        chi "您不允许使用创建用户时给予GRANT"
         eng "You are not allowed to create a user with GRANT"
         ger "Sie dürfen keinen Benutzer mit GRANT anlegen"
 ER_WRONG_VALUE_FOR_TYPE  
+        chi "不正确的%-.32s值：'%-.128T' 函数：%-.32s"
         eng "Incorrect %-.32s value: '%-.128T' for function %-.32s"
         ger "Falscher %-.32s-Wert: '%-.128T' für Funktion %-.32s"
 ER_TABLE_DEF_CHANGED
+        chi "表定义已更改，请重试"
         eng "Table definition has changed, please retry transaction"
         ger "Tabellendefinition wurde geändert, bitte starten Sie die Transaktion neu"
 ER_SP_DUP_HANDLER 42000
+        chi "在同一块中声明的处理程序重复"
         eng "Duplicate handler declared in the same block"
         ger "Doppelter Handler im selben Block deklariert"
 ER_SP_NOT_VAR_ARG 42000
+        chi "OUT或INOUT参数%d 例程 %s的不是BEFORE触发器里的变量或新伪变量"
         eng "OUT or INOUT argument %d for routine %s is not a variable or NEW pseudo-variable in BEFORE trigger"
         ger "OUT- oder INOUT-Argument %d für Routine %s ist keine Variable"
 ER_SP_NO_RETSET 0A000
+        chi "不允许从%s返回结果集"
         eng "Not allowed to return a result set from a %s"
         ger "Rückgabe einer Ergebnismenge aus einer %s ist nicht erlaubt"
 ER_CANT_CREATE_GEOMETRY_OBJECT 22003 
+        chi "无法从发送到几何字段的数据中获取几何对象"
         eng "Cannot get geometry object from data you send to the GEOMETRY field"
         ger "Kann kein Geometrieobjekt aus den Daten machen, die Sie dem GEOMETRY-Feld übergeben haben"
 ER_FAILED_ROUTINE_BREAK_BINLOG
+        chi "ROUTINE失败，定义中既没有NO SQL也没有READ SQL DAT。启用二进制日志记录;如果更新非事务性表，则二进制日志将会错过其更改"
         eng "A routine failed and has neither NO SQL nor READS SQL DATA in its declaration and binary logging is enabled; if non-transactional tables were updated, the binary log will miss their changes"
         ger "Eine Routine, die weder NO SQL noch READS SQL DATA in der Deklaration hat, schlug fehl und Binärlogging ist aktiv. Wenn Nicht-Transaktions-Tabellen aktualisiert wurden, enthält das Binärlog ihre Änderungen nicht"
 ER_BINLOG_UNSAFE_ROUTINE
+        chi "此函数定义中没有DETERMINISTIC，NO SQL，或者READS SQL DATA，并且已启用二进制日志记录（您*可能*希望使用较少的安全性的log_bin_trust_function_creators变量）"
         eng "This function has none of DETERMINISTIC, NO SQL, or READS SQL DATA in its declaration and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable)"
         ger "Diese Routine hat weder DETERMINISTIC, NO SQL noch READS SQL DATA in der Deklaration und Binärlogging ist aktiv (*vielleicht* sollten Sie die weniger sichere Variable log_bin_trust_function_creators verwenden)"
 ER_BINLOG_CREATE_ROUTINE_NEED_SUPER
+        chi "您没有超级特权和二进制日志记录已启用（您*可能*想要使用较少的安全log_bin_trust_function_creators变量）"
         eng "You do not have the SUPER privilege and binary logging is enabled (you *might* want to use the less safe log_bin_trust_function_creators variable)"
         ger "Sie haben keine SUPER-Berechtigung und Binärlogging ist aktiv (*vielleicht* sollten Sie die weniger sichere Variable log_bin_trust_function_creators verwenden)"
 ER_EXEC_STMT_WITH_OPEN_CURSOR
+        chi "您无法执行具有与之关联的打开Cursor的prepared statement。重置语句以重新执行它"
         eng "You can't execute a prepared statement which has an open cursor associated with it. Reset the statement to re-execute it"
         ger "Sie können keine vorbereitete Anweisung ausführen, die mit einem geöffneten Cursor verknüpft ist. Setzen Sie die Anweisung zurück, um sie neu auszuführen"
 ER_STMT_HAS_NO_OPEN_CURSOR
+        chi "语句（%lu）没有开放的Cursor"
         eng "The statement (%lu) has no open cursor"
         ger "Die Anweisung (%lu) hat keinen geöffneten Cursor"
 ER_COMMIT_NOT_ALLOWED_IN_SF_OR_TRG
+        chi "在存储的函数或触发器中不允许显式或隐式提交"
         eng "Explicit or implicit commit is not allowed in stored function or trigger"
         ger "Explizites oder implizites Commit ist in gespeicherten Funktionen und in Triggern nicht erlaubt"
 ER_NO_DEFAULT_FOR_VIEW_FIELD
+        chi "VIEW的列'%-.192s.%-.192s'底层表没有默认值"
         eng "Field of view '%-.192s.%-.192s' underlying table doesn't have a default value"
         ger "Ein Feld der dem View '%-.192s.%-.192s' zugrundeliegenden Tabelle hat keinen Vorgabewert"
 ER_SP_NO_RECURSION
+        chi "不允许递归存储功能和触发器"
         eng "Recursive stored functions and triggers are not allowed"
         ger "Rekursive gespeicherte Routinen und Triggers sind nicht erlaubt"
 ER_TOO_BIG_SCALE 42000 S1009
+        chi "指定的大规模%llu为'%-.192s'。最大是%u"
         eng "Too big scale %llu specified for '%-.192s'. Maximum is %u"
         ger "Zu großer Skalierungsfaktor %llu für '%-.192s' angegeben. Maximum ist %u"
 ER_TOO_BIG_PRECISION 42000 S1009
+        chi "指定的精度%llu太大 '%-.192s'。最大是%u"
         eng "Too big precision %llu specified for '%-.192s'. Maximum is %u"
         ger "Zu große Genauigkeit %llu für '%-.192s' angegeben. Maximum ist %u"
 ER_M_BIGGER_THAN_D 42000 S1009
+        chi "对于FLOAT（M，D），DOUBLE（M，D）或DECIMAL（M，D），M必须> = D（列'%-.192s'）"
         eng "For float(M,D), double(M,D) or decimal(M,D), M must be >= D (column '%-.192s')"
         ger "Für FLOAT(M,D), DOUBLE(M,D) oder DECIMAL(M,D) muss M >= D sein (Feld '%-.192s')"
 ER_WRONG_LOCK_OF_SYSTEM_TABLE
+        chi "您无法将系统表的写入锁定与其他表或锁定类型相结合"
         eng "You can't combine write-locking of system tables with other tables or lock types"
-	ger "Sie können Schreibsperren auf der Systemtabelle nicht mit anderen Tabellen kombinieren"
+        ger "Sie können Schreibsperren auf der Systemtabelle nicht mit anderen Tabellen kombinieren"
 ER_CONNECT_TO_FOREIGN_DATA_SOURCE
+        chi "无法连接到外数据源：%.64s"
         eng "Unable to connect to foreign data source: %.64s"
         ger "Kann nicht mit Fremddatenquelle verbinden: %.64s"
 ER_QUERY_ON_FOREIGN_DATA_SOURCE
+        chi "处理对外数据源上的查询时出现问题。数据源错误：%-.64s"
         eng "There was a problem processing the query on the foreign data source. Data source error: %-.64s"
         ger "Bei der Verarbeitung der Abfrage ist in der Fremddatenquelle ein Problem aufgetreten. Datenquellenfehlermeldung: %-.64s"
 ER_FOREIGN_DATA_SOURCE_DOESNT_EXIST
+        chi "您尝试引用的外数据源不存在。数据源错误：%-.64s"
         eng "The foreign data source you are trying to reference does not exist. Data source error:  %-.64s"
         ger "Die Fremddatenquelle, auf die Sie zugreifen wollen, existiert nicht. Datenquellenfehlermeldung:  %-.64s"
 ER_FOREIGN_DATA_STRING_INVALID_CANT_CREATE
+        chi "无法创建联合表。数据源连接字符串'%-.64s'不是正确的格式"
         eng "Can't create federated table. The data source connection string '%-.64s' is not in the correct format"
         ger "Kann föderierte Tabelle nicht erzeugen. Der Datenquellen-Verbindungsstring '%-.64s' hat kein korrektes Format"
 ER_FOREIGN_DATA_STRING_INVALID
+        chi "数据源连接字符串'%-.64s'不是正确的格式"
         eng "The data source connection string '%-.64s' is not in the correct format"
         ger "Der Datenquellen-Verbindungsstring '%-.64s' hat kein korrektes Format"
 ER_CANT_CREATE_FEDERATED_TABLE  
+        chi "无法创建联合表。外数据SRC错误：%-.64s"
         eng "Can't create federated table. Foreign data src error:  %-.64s"
         ger "Kann föderierte Tabelle nicht erzeugen. Fremddatenquellenfehlermeldung:  %-.64s"
 ER_TRG_IN_WRONG_SCHEMA  
+        chi "触发在错的SCHEMA"
         eng "Trigger in wrong schema"
         ger "Trigger im falschen Schema"
 ER_STACK_OVERRUN_NEED_MORE
+        chi "线程堆栈溢出：%ld字节堆栈的%ld字节，以及所需的%ld字节。使用'mysqld --thread_stack =＃'指定更大的堆栈"
         eng "Thread stack overrun:  %ld bytes used of a %ld byte stack, and %ld bytes needed.  Use 'mysqld --thread_stack=#' to specify a bigger stack"
         ger "Thread-Stack-Überlauf: %ld Bytes eines %ld-Byte-Stacks in Verwendung, und %ld Bytes benötigt. Verwenden Sie 'mysqld --thread_stack=#', um einen größeren Stack anzugeben"
         jpn "スレッドスタック不足です(使用: %ld ; サイズ: %ld ; 要求: %ld)。より大きい値で 'mysqld --thread_stack=#' の指定をしてください。"
 ER_TOO_LONG_BODY 42000 S1009
+        chi "'%-.100s”的ROUTINE太长了"
         eng "Routine body for '%-.100s' is too long"
         ger "Routinen-Body für '%-.100s' ist zu lang"
 ER_WARN_CANT_DROP_DEFAULT_KEYCACHE
+        chi "无法删除默认索引缓存"
         eng "Cannot drop default keycache"
         ger "Der vorgabemäßige Schlüssel-Cache kann nicht gelöscht werden"
 ER_TOO_BIG_DISPLAYWIDTH 42000 S1009
+        chi "显示宽度超过'%-.192s'的范围（max =%lu）"
         eng "Display width out of range for '%-.192s' (max = %lu)"
         ger "Anzeigebreite außerhalb des zulässigen Bereichs für '%-.192s' (Maximum = %lu)"
 ER_XAER_DUPID XAE08
+        chi "XAER_DUPID：xid已存在"
         eng "XAER_DUPID: The XID already exists"
         ger "XAER_DUPID: Die XID existiert bereits"
 ER_DATETIME_FUNCTION_OVERFLOW 22008
+        chi "DateTime函数：%-.32s字段溢出"
         eng "Datetime function: %-.32s field overflow"
         ger "Datetime-Funktion: %-.32s Feldüberlauf"
 ER_CANT_UPDATE_USED_TABLE_IN_SF_OR_TRG
+        chi "在存储的函数/触发器中无法更新表'%-.192s'，因为它已被调用此存储的函数/触发器调用的语句"
         eng "Can't update table '%-.192s' in stored function/trigger because it is already used by statement which invoked this stored function/trigger"
         ger "Kann Tabelle '%-.192s' in gespeicherter Funktion oder Trigger nicht aktualisieren, weil sie bereits von der Anweisung verwendet wird, die diese gespeicherte Funktion oder den Trigger aufrief"
 ER_VIEW_PREVENT_UPDATE
-        eng "The definition of table '%-.192s' prevents operation %.192s on table '%-.192s'"
-        ger "Die Definition der Tabelle '%-.192s' verhindert die Operation %.192s auf Tabelle '%-.192s'"
+        chi "表'%-.192s'的定义可防止在表'%-.192s'上的操作'%-.192s'"
+        eng "The definition of table '%-.192s' prevents operation %-.192s on table '%-.192s'"
+        ger "Die Definition der Tabelle '%-.192s' verhindert die Operation %-.192s auf Tabelle '%-.192s'"
 ER_PS_NO_RECURSION
+        chi "prepared statement包含一个有关该语句的存储例程调用。它不允许以这种递归方式执行prepared statement"
         eng "The prepared statement contains a stored routine call that refers to that same statement. It's not allowed to execute a prepared statement in such a recursive manner"
         ger "Die vorbereitete Anweisung enthält einen Aufruf einer gespeicherten Routine, die auf eben dieselbe Anweisung verweist. Es ist nicht erlaubt, eine vorbereitete Anweisung in solch rekursiver Weise auszuführen"
 ER_SP_CANT_SET_AUTOCOMMIT
+        chi "不允许从存储的函数或触发器设置自动判处"
         eng "Not allowed to set autocommit from a stored function or trigger"
         ger "Es ist nicht erlaubt, innerhalb einer gespeicherten Funktion oder eines Triggers AUTOCOMMIT zu setzen"
 ER_MALFORMED_DEFINER 0L000
+        chi "无效的定义"
         eng "Invalid definer"
 ER_VIEW_FRM_NO_USER
+        chi "VIEW'%-.192s'。'%-.192s'没有绝定的信息（旧表格式）。当前用户用作定义。请重新创建视图！"
         eng "View '%-.192s'.'%-.192s' has no definer information (old table format). Current user is used as definer. Please recreate the view!"
         ger "View '%-.192s'.'%-.192s' hat keine Definierer-Information (altes Tabellenformat). Der aktuelle Benutzer wird als Definierer verwendet. Bitte erstellen Sie den View neu"
 ER_VIEW_OTHER_USER
+        chi "您需要使用'%-.192s'@'%-.192s'的创建视图的超级特权"
         eng "You need the SUPER privilege for creation view with '%-.192s'@'%-.192s' definer"
         ger "Sie brauchen die SUPER-Berechtigung, um einen View mit dem Definierer '%-.192s'@'%-.192s' zu erzeugen"
 ER_NO_SUCH_USER
+        chi "指定为定义的用户（'%-.64s'@'%-.64s'）不存在"
         eng "The user specified as a definer ('%-.64s'@'%-.64s') does not exist"
         ger "Der als Definierer angegebene Benutzer ('%-.64s'@'%-.64s') existiert nicht"
 ER_FORBID_SCHEMA_CHANGE
+        chi "不允许从'%-.192s'到'%-.192s'的SCHEMA更改"
         eng "Changing schema from '%-.192s' to '%-.192s' is not allowed"
         ger "Wechsel des Schemas von '%-.192s' auf '%-.192s' ist nicht erlaubt"
 ER_ROW_IS_REFERENCED_2 23000
+        chi "无法删除或更新父行：外键约束失败（%.192s）"
         eng "Cannot delete or update a parent row: a foreign key constraint fails (%.192s)"
         ger "Kann Eltern-Zeile nicht löschen oder aktualisieren: eine Fremdschlüsselbedingung schlägt fehl (%.192s)"
 ER_NO_REFERENCED_ROW_2 23000
+        chi "无法添加或更新子行：外键约束失败（%.192s）"
         eng "Cannot add or update a child row: a foreign key constraint fails (%.192s)"
         ger "Kann Kind-Zeile nicht hinzufügen oder aktualisieren: eine Fremdschlüsselbedingung schlägt fehl (%.192s)"
 ER_SP_BAD_VAR_SHADOW 42000
+        chi "变量'%-.64s'必须用`...`，或重命名"
         eng "Variable '%-.64s' must be quoted with `...`, or renamed"
         ger "Variable '%-.64s' muss mit `...` geschützt oder aber umbenannt werden"
 ER_TRG_NO_DEFINER
+        chi "触发'%-.192s'的绝对属性。'%-.192s'。触发器将在调用者的授权下激活，该权限可能不足。请重新创建触发器"
         eng "No definer attribute for trigger '%-.192s'.'%-.192s'. The trigger will be activated under the authorization of the invoker, which may have insufficient privileges. Please recreate the trigger"
         ger "Kein Definierer-Attribut für Trigger '%-.192s'.'%-.192s'. Der Trigger wird mit der Autorisierung des Aufrufers aktiviert, der möglicherweise keine zureichenden Berechtigungen hat. Bitte legen Sie den Trigger neu an"
 ER_OLD_FILE_FORMAT
+        chi "'%-.192s'具有旧格式，您应该重新创建'%s'对象"
         eng "'%-.192s' has an old format, you should re-create the '%s' object(s)"
         ger "'%-.192s' hat altes Format, Sie sollten die '%s'-Objekt(e) neu erzeugen"
 ER_SP_RECURSION_LIMIT
+        chi "递归限制%d（如max_sp_recursion_depth变量设置）的例程%.192s"
         eng "Recursive limit %d (as set by the max_sp_recursion_depth variable) was exceeded for routine %.192s"
         ger "Rekursionsgrenze %d (durch Variable max_sp_recursion_depth gegeben) wurde für Routine %.192s überschritten"
 ER_SP_PROC_TABLE_CORRUPT
+        chi "无法加载常规%-.192s（内部代码%d）。有关更多详细信息，请运行SHOW WARNINGS"
         eng "Failed to load routine %-.192s (internal code %d). For more details, run SHOW WARNINGS"
         ger "Routine %-.192s (interner Code %d) konnte nicht geladen werden. Weitere Einzelheiten erhalten Sie, wenn Sie SHOW WARNINGS ausführen"
         ukr "Невдала спроба завантажити процедуру %-.192s (внутрішний код %d). Для отримання детальної інформації використовуйте SHOW WARNINGS"
 ER_SP_WRONG_NAME 42000
+        chi "常规名称错误不正确'%-.192s'"
         eng "Incorrect routine name '%-.192s'"
         ger "Ungültiger Routinenname '%-.192s'"
 ER_TABLE_NEEDS_UPGRADE
+        chi "需要升级。请做\"修复%s%`s \"或转储/重新加载以修复！"
         eng "Upgrade required. Please do \"REPAIR %s %`s\" or dump/reload to fix it!"
         ger "Aktualisierung erforderlich. Bitte zum Reparieren \"REPAIR %s %`s\" eingeben!"
 ER_SP_NO_AGGREGATE 42000
+        chi "存储函数不支持聚合"
         eng "AGGREGATE is not supported for stored functions"
         ger "AGGREGATE wird bei gespeicherten Funktionen nicht unterstützt"
 ER_MAX_PREPARED_STMT_COUNT_REACHED 42000
+        chi "无法创建超过max_prepared_stmt_count语句（当前值：%u）"
         eng "Can't create more than max_prepared_stmt_count statements (current value: %u)"
         ger "Kann nicht mehr Anweisungen als max_prepared_stmt_count erzeugen (aktueller Wert: %u)"
 ER_VIEW_RECURSIVE
+        chi "%`s.%`s包含视图递归"
         eng "%`s.%`s contains view recursion"
         ger "%`s.%`s enthält View-Rekursion"
 ER_NON_GROUPING_FIELD_USED 42000
+        chi "非分组字段'%-.192s'用于%-.64s条款"
         eng "Non-grouping field '%-.192s' is used in %-.64s clause"
         ger "In der %-.192s-Klausel wird das die Nicht-Gruppierungsspalte '%-.64s' verwendet"
 ER_TABLE_CANT_HANDLE_SPKEYS
+        chi "存储引擎%s不支持SPATIAL索引"
         eng "The storage engine %s doesn't support SPATIAL indexes"
         ger "Der verwendete Tabellentyp (%s) unterstützt keine SPATIAL-Indizes"
 ER_NO_TRIGGERS_ON_SYSTEM_SCHEMA
+        chi "无法在系统表上创建触发器"
         eng "Triggers can not be created on system tables"
         ger "Trigger können nicht auf Systemtabellen erzeugt werden"
 ER_REMOVED_SPACES
+        chi "前面的空格从名称'%s'删除"
         eng "Leading spaces are removed from name '%s'"
         ger "Führende Leerzeichen werden aus dem Namen '%s' entfernt"
 ER_AUTOINC_READ_FAILED
+        chi "无法从存储引擎读取自动增量值"
         eng "Failed to read auto-increment value from storage engine"
         ger "Lesen des Autoincrement-Werts von der Speicher-Engine fehlgeschlagen"
         hindi "स्टोरेज इंजन से auto-increment का मान पढ़ने में असफल रहे"
 ER_USERNAME
+        chi "用户名"
         eng "user name"
         ger "Benutzername"
         hindi "यूज़र का नाम"
 ER_HOSTNAME
+        chi "主机名"
         eng "host name"
         ger "Hostname"
         hindi "होस्ट का नाम"
 ER_WRONG_STRING_LENGTH
+        chi "字符串'%-.70T'对于%s（应不超过%d）太长"
         eng "String '%-.70T' is too long for %s (should be no longer than %d)"
         ger "String '%-.70T' ist zu lang für %s (sollte nicht länger sein als %d)"
 ER_NON_INSERTABLE_TABLE  
+        chi "目标表%-.100s %s不可插入"
         eng "The target table %-.100s of the %s is not insertable-into"
         ger "Die Zieltabelle %-.100s von %s ist nicht einfügbar"
         jpn "対象表 %-.100s は挿入可能ではないので、%s を行えません。"
 ER_ADMIN_WRONG_MRG_TABLE
-  eng "Table '%-.64s' is differently defined or of non-MyISAM type or doesn't exist"
-  ger "Tabelle '%-.64s' ist unterschiedlich definiert, nicht vom Typ MyISAM oder existiert nicht"
+        chi "表'%-.64s'不同定义、或非myisam类型、或不存在"
+        eng "Table '%-.64s' is differently defined or of non-MyISAM type or doesn't exist"
+        ger "Tabelle '%-.64s' ist unterschiedlich definiert, nicht vom Typ MyISAM oder existiert nicht"
 ER_TOO_HIGH_LEVEL_OF_NESTING_FOR_SELECT
-  eng "Too high level of nesting for select"
-  ger "Zu tief verschachtelte SELECT-Anweisungen"
+        chi "太高的嵌套SELECT"
+        eng "Too high level of nesting for select"
+        ger "Zu tief verschachtelte SELECT-Anweisungen"
 ER_NAME_BECOMES_EMPTY
-  eng "Name '%-.64s' has become ''"
-  ger "Name '%-.64s' wurde zu ''"
+        chi "名'%-.64s'已成为''"
+        eng "Name '%-.64s' has become ''"
+        ger "Name '%-.64s' wurde zu ''"
 ER_AMBIGUOUS_FIELD_TERM
-  eng "First character of the FIELDS TERMINATED string is ambiguous; please use non-optional and non-empty FIELDS ENCLOSED BY"
-  ger "Das erste Zeichen der Zeichenkette FIELDS TERMINATED ist mehrdeutig; bitte benutzen Sie nicht optionale und nicht leere FIELDS ENCLOSED BY"
+        chi "FIELDS TERMINATED字符串的第一个字符是模棱两可的;请使用非空字段FIELDS ENCLOSED BY"
+        eng "First character of the FIELDS TERMINATED string is ambiguous; please use non-optional and non-empty FIELDS ENCLOSED BY"
+        ger "Das erste Zeichen der Zeichenkette FIELDS TERMINATED ist mehrdeutig; bitte benutzen Sie nicht optionale und nicht leere FIELDS ENCLOSED BY"
 ER_FOREIGN_SERVER_EXISTS
-  eng "The foreign server, %s, you are trying to create already exists"
-  ger "Der entfernte Server %s, den Sie versuchen zu erzeugen, existiert schon"
+        chi "您正在尝试创建的外来服务器%s已存在"
+        eng "The foreign server, %s, you are trying to create already exists"
+        ger "Der entfernte Server %s, den Sie versuchen zu erzeugen, existiert schon"
 ER_FOREIGN_SERVER_DOESNT_EXIST
+        chi "您尝试引用的外部服务器名称不存在。数据源错误：%-.64s"
         eng "The foreign server name you are trying to reference does not exist. Data source error:  %-.64s"
-	ger "Die externe Verbindung, auf die Sie zugreifen wollen, existiert nicht. Datenquellenfehlermeldung:  %-.64s"
+        ger "Die externe Verbindung, auf die Sie zugreifen wollen, existiert nicht. Datenquellenfehlermeldung:  %-.64s"
 ER_ILLEGAL_HA_CREATE_OPTION
+        chi "表存储引擎'%-.64s'不支持创建选项'%.64s'"
         eng "Table storage engine '%-.64s' does not support the create option '%.64s'"
         ger "Speicher-Engine '%-.64s' der Tabelle unterstützt die Option '%.64s' nicht"
 ER_PARTITION_REQUIRES_VALUES_ERROR
+        chi "语法错误：%-.64s PARTITIONING需要定义给每个分区VALUES %-.64s"
         eng "Syntax error: %-.64s PARTITIONING requires definition of VALUES %-.64s for each partition"
         ger "Fehler in der SQL-Syntax: %-.64s-PARTITIONierung erfordert Definition von VALUES %-.64s für jede Partition"
         swe "Syntaxfel: %-.64s PARTITIONering kräver definition av VALUES %-.64s för varje partition"
 ER_PARTITION_WRONG_VALUES_ERROR
+        chi "只有%-.64s PARTITIONING可以使用VALUES %-.64s在分区定义中"
         eng "Only %-.64s PARTITIONING can use VALUES %-.64s in partition definition"
         ger "Nur %-.64s-PARTITIONierung kann VALUES %-.64s in der Partitionsdefinition verwenden"
         swe "Endast %-.64s partitionering kan använda VALUES %-.64s i definition av partitionen" 
 ER_PARTITION_MAXVALUE_ERROR
+        chi "MAXVALUE只能在最后一个分区定义中使用"
         eng "MAXVALUE can only be used in last partition definition"
         ger "MAXVALUE kann nur für die Definition der letzten Partition verwendet werden"
         swe "MAXVALUE kan bara användas i definitionen av den sista partitionen"
 ER_PARTITION_SUBPARTITION_ERROR
+        chi "子分区只能是哈希分区和分区列"
         eng "Subpartitions can only be hash partitions and by key"
         ger "Unterpartitionen dürfen nur HASH- oder KEY-Partitionen sein"
         swe "Subpartitioner kan bara vara hash och key partitioner"
 ER_PARTITION_SUBPART_MIX_ERROR
+        chi "如果在一个分区上，必须在所有分区上定义子组分"
         eng "Must define subpartitions on all partitions if on one partition"
         ger "Wenn Sie Unterpartitionen auf einer Partition definieren, müssen Sie das für alle Partitionen tun"
         swe "Subpartitioner måste definieras på alla partitioner om på en"
 ER_PARTITION_WRONG_NO_PART_ERROR
+        chi "定义了错误的分区数，与以前的设置不匹配"
         eng "Wrong number of partitions defined, mismatch with previous setting"
         ger "Falsche Anzahl von Partitionen definiert, stimmt nicht mit vorherigen Einstellungen überein"
         swe "Antal partitioner definierade och antal partitioner är inte lika"
 ER_PARTITION_WRONG_NO_SUBPART_ERROR
+        chi "错误的子组分数定义，与以前的设置不匹配"
         eng "Wrong number of subpartitions defined, mismatch with previous setting"
         ger "Falsche Anzahl von Unterpartitionen definiert, stimmt nicht mit vorherigen Einstellungen überein"
         swe "Antal subpartitioner definierade och antal subpartitioner är inte lika"
 ER_WRONG_EXPR_IN_PARTITION_FUNC_ERROR
+        chi "不允许（子）分区功能中的常量，随机或时区依赖表达式"
         eng "Constant, random or timezone-dependent expressions in (sub)partitioning function are not allowed"
         ger "Konstante oder Random-Ausdrücke in (Unter-)Partitionsfunktionen sind nicht erlaubt"
         swe "Konstanta uttryck eller slumpmässiga uttryck är inte tillåtna (sub)partitioneringsfunktioner"
 ER_NOT_CONSTANT_EXPRESSION
+        chi "%s中的表达必须是恒定的"
         eng "Expression in %s must be constant"
         ger "Ausdrücke in %s müssen konstant sein"
         swe "Uttryck i %s måste vara ett konstant uttryck"
 ER_FIELD_NOT_FOUND_PART_ERROR
+        chi "在表中找不到分区功能的字段列表中的字段"
         eng "Field in list of fields for partition function not found in table"
         ger "Felder in der Feldliste der Partitionierungsfunktion wurden in der Tabelle nicht gefunden"
         swe "Fält i listan av fält för partitionering med key inte funnen i tabellen"
 ER_LIST_OF_FIELDS_ONLY_IN_HASH_ERROR
+        chi "只允许在索引分区中允许字段列表"
         eng "List of fields is only allowed in KEY partitions"
         ger "Eine Feldliste ist nur in KEY-Partitionen erlaubt"
         swe "En lista av fält är endast tillåtet för KEY partitioner"
 ER_INCONSISTENT_PARTITION_INFO_ERROR
+        chi "FRM文件中的分区信息不与可以写入FRM文件的内容一致"
         eng "The partition info in the frm file is not consistent with what can be written into the frm file"
         ger "Die Partitionierungsinformationen in der frm-Datei stimmen nicht mit dem überein, was in die frm-Datei geschrieben werden kann"
         swe "Partitioneringsinformationen i frm-filen är inte konsistent med vad som kan skrivas i frm-filen"
 ER_PARTITION_FUNC_NOT_ALLOWED_ERROR
+        chi "%-.192s函数返回错误的类型"
         eng "The %-.192s function returns the wrong type"
         ger "Die %-.192s-Funktion gibt einen falschen Typ zurück"
         swe "%-.192s-funktionen returnerar felaktig typ"
 ER_PARTITIONS_MUST_BE_DEFINED_ERROR
+        chi "对于%-.64s分区必须定义每个分区"
         eng "For %-.64s partitions each partition must be defined"
         ger "Für %-.64s-Partitionen muss jede Partition definiert sein"
         swe "För %-.64s partitionering så måste varje partition definieras"
 ER_RANGE_NOT_INCREASING_ERROR
+        chi "每个分区的VALUES LESS THAN的值必须严格增加"
         eng "VALUES LESS THAN value must be strictly increasing for each partition"
         ger "Werte in VALUES LESS THAN müssen für jede Partition strikt aufsteigend sein"
         swe "Värden i VALUES LESS THAN måste vara strikt växande för varje partition"
 ER_INCONSISTENT_TYPE_OF_FUNCTIONS_ERROR
+        chi "VALUES值必须与分区函数相同"
         eng "VALUES value must be of same type as partition function"
         ger "VALUES-Werte müssen vom selben Typ wie die Partitionierungsfunktion sein"
         swe "Värden i VALUES måste vara av samma typ som partitioneringsfunktionen"
 ER_MULTIPLE_DEF_CONST_IN_LIST_PART_ERROR
+        chi "列表分区中相同常量的多个定义"
         eng "Multiple definition of same constant in list partitioning"
         ger "Mehrfachdefinition derselben Konstante bei Listen-Partitionierung"
         swe "Multipel definition av samma konstant i list partitionering"
 ER_PARTITION_ENTRY_ERROR
+        chi "分区不能在查询中独立使用"
         eng "Partitioning can not be used stand-alone in query"
         ger "Partitionierung kann in einer Abfrage nicht alleinstehend benutzt werden"
         swe "Partitioneringssyntax kan inte användas på egen hand i en SQL-fråga"
 ER_MIX_HANDLER_ERROR
+        chi "此版本的MariaDB中不允许分区中的处理程序混合"
         eng "The mix of handlers in the partitions is not allowed in this version of MariaDB"
         ger "Das Vermischen von Handlern in Partitionen ist in dieser Version von MariaDB nicht erlaubt"
         swe "Denna mix av lagringsmotorer är inte tillåten i denna version av MariaDB"
 ER_PARTITION_NOT_DEFINED_ERROR
+        chi "对于分区引擎，需要定义所有%-.64s"
         eng "For the partitioned engine it is necessary to define all %-.64s"
         ger "Für die partitionierte Engine müssen alle %-.64s definiert sein"
         swe "För partitioneringsmotorn så är det nödvändigt att definiera alla %-.64s"
 ER_TOO_MANY_PARTITIONS_ERROR
+        chi "定义了太多分区（包括子组分）"
         eng "Too many partitions (including subpartitions) were defined"
         ger "Es wurden zu vielen Partitionen (einschließlich Unterpartitionen) definiert"
         swe "För många partitioner (inkluderande subpartitioner) definierades"
 ER_SUBPARTITION_ERROR
+        chi "只有在子节分节的HASH/KEY分区中可以混合RANGE/LIST分区"
         eng "It is only possible to mix RANGE/LIST partitioning with HASH/KEY partitioning for subpartitioning"
         ger "RANGE/LIST-Partitionierung kann bei Unterpartitionen nur zusammen mit HASH/KEY-Partitionierung verwendet werden"
         swe "Det är endast möjligt att blanda RANGE/LIST partitionering med HASH/KEY partitionering för subpartitionering"
 ER_CANT_CREATE_HANDLER_FILE
+        chi "无法创建特定的处理程序文件"
         eng "Failed to create specific handler file"
         ger "Erzeugen einer spezifischen Handler-Datei fehlgeschlagen"
         swe "Misslyckades med att skapa specifik fil i lagringsmotor"
 ER_BLOB_FIELD_IN_PART_FUNC_ERROR
+        chi "分区功能中不允许BLOB字段"
         eng "A BLOB field is not allowed in partition function"
         ger "In der Partitionierungsfunktion sind BLOB-Spalten nicht erlaubt"
         swe "Ett BLOB-fält är inte tillåtet i partitioneringsfunktioner"
 ER_UNIQUE_KEY_NEED_ALL_FIELDS_IN_PF
+        chi "A%-.192s必须包含表的分区功能中的所有列"
         eng "A %-.192s must include all columns in the table's partitioning function"
 ER_NO_PARTS_ERROR
+        chi "不允许%-.64s = 0"
         eng "Number of %-.64s = 0 is not an allowed value"
         ger "Eine Anzahl von %-.64s = 0 ist kein erlaubter Wert"
         swe "Antal %-.64s = 0 är inte ett tillåten värde"
 ER_PARTITION_MGMT_ON_NONPARTITIONED
+        chi "不分区表上的分区管理是不可能的"
         eng "Partition management on a not partitioned table is not possible"
         ger "Partitionsverwaltung einer nicht partitionierten Tabelle ist nicht möglich"
         swe "Partitioneringskommando på en opartitionerad tabell är inte möjligt"
 ER_FOREIGN_KEY_ON_PARTITIONED
+        chi "不支持外键子句和分区结合使用"
         eng "Foreign key clause is not yet supported in conjunction with partitioning"
         ger "Fremdschlüssel-Beschränkungen sind im Zusammenhang mit Partitionierung nicht zulässig"
         swe "Foreign key klausul är inte ännu implementerad i kombination med partitionering"
 ER_DROP_PARTITION_NON_EXISTENT
+        chi "分区列表错误%-.64s"
         eng "Error in list of partitions to %-.64s"
         ger "Fehler in der Partitionsliste bei %-.64s"
         swe "Fel i listan av partitioner att %-.64s"
 ER_DROP_LAST_PARTITION
+        chi "无法删除所有分区，请使用删除表"
         eng "Cannot remove all partitions, use DROP TABLE instead"
         ger "Es lassen sich nicht sämtliche Partitionen löschen, benutzen Sie statt dessen DROP TABLE"
         swe "Det är inte tillåtet att ta bort alla partitioner, använd DROP TABLE istället"
 ER_COALESCE_ONLY_ON_HASH_PARTITION
+        chi "COALESCE分区只能用于哈希/索引分区"
         eng "COALESCE PARTITION can only be used on HASH/KEY partitions"
         ger "COALESCE PARTITION kann nur auf HASH- oder KEY-Partitionen benutzt werden"
         swe "COALESCE PARTITION kan bara användas på HASH/KEY partitioner"
 ER_REORG_HASH_ONLY_ON_SAME_NO
+        chi "REORGANIZE PARTITION只能用于重新组织不改变他们的数字的分区"
         eng "REORGANIZE PARTITION can only be used to reorganize partitions not to change their numbers"
         ger "REORGANIZE PARTITION kann nur zur Reorganisation von Partitionen verwendet werden, nicht, um ihre Nummern zu ändern"
         swe "REORGANIZE PARTITION kan bara användas för att omorganisera partitioner, inte för att ändra deras antal"
 ER_REORG_NO_PARAM_ERROR
+        chi "没有参数的REORGANIZE PARTITION只能用于HASH PARTITION的自动分区表"
         eng "REORGANIZE PARTITION without parameters can only be used on auto-partitioned tables using HASH PARTITIONs"
         ger "REORGANIZE PARTITION ohne Parameter kann nur für auto-partitionierte Tabellen verwendet werden, die HASH-Partitionierung benutzen"
         swe "REORGANIZE PARTITION utan parametrar kan bara användas på auto-partitionerade tabeller som använder HASH partitionering"
 ER_ONLY_ON_RANGE_LIST_PARTITION
+        chi "%-.64s分区只能用于RANGE/LIST分区"
         eng "%-.64s PARTITION can only be used on RANGE/LIST partitions"
         ger "%-.64s PARTITION kann nur für RANGE- oder LIST-Partitionen verwendet werden"
         swe "%-.64s PARTITION kan bara användas på RANGE/LIST-partitioner"
 ER_ADD_PARTITION_SUBPART_ERROR
+        chi "尝试用错误数量的子分区添加分区"
         eng "Trying to Add partition(s) with wrong number of subpartitions"
         ger "Es wurde versucht, eine oder mehrere Partitionen mit der falschen Anzahl von Unterpartitionen hinzuzufügen"
         swe "ADD PARTITION med fel antal subpartitioner"
 ER_ADD_PARTITION_NO_NEW_PARTITION
+        chi "必须添加至少一个分区"
         eng "At least one partition must be added"
         ger "Es muss zumindest eine Partition hinzugefügt werden"
         swe "Åtminstone en partition måste läggas till vid ADD PARTITION"
 ER_COALESCE_PARTITION_NO_PARTITION
+        chi "至少一个分区必须合并"
         eng "At least one partition must be coalesced"
         ger "Zumindest eine Partition muss mit COALESCE PARTITION zusammengefügt werden"
         swe "Åtminstone en partition måste slås ihop vid COALESCE PARTITION"
 ER_REORG_PARTITION_NOT_EXIST
+        chi "分区重组量超过而不是分区量"
         eng "More partitions to reorganize than there are partitions"
         ger "Es wurde versucht, mehr Partitionen als vorhanden zu reorganisieren"
         swe "Fler partitioner att reorganisera än det finns partitioner"
 ER_SAME_NAME_PARTITION
+        chi "重复分区名称%-.192s"
         eng "Duplicate partition name %-.192s"
         ger "Doppelter Partitionsname: %-.192s"
         swe "Duplicerat partitionsnamn %-.192s"
 ER_NO_BINLOG_ERROR
+        chi "在此命令上不允许关闭binlog"
         eng "It is not allowed to shut off binlog on this command"
         ger "Es es nicht erlaubt, bei diesem Befehl binlog abzuschalten"
         swe "Det är inte tillåtet att stänga av binlog på detta kommando"
 ER_CONSECUTIVE_REORG_PARTITIONS
+        chi "在重新组织一组分区时，它们必须按照次序"
         eng "When reorganizing a set of partitions they must be in consecutive order"
         ger "Bei der Reorganisation eines Satzes von Partitionen müssen diese in geordneter Reihenfolge vorliegen"
         swe "När ett antal partitioner omorganiseras måste de vara i konsekutiv ordning"
 ER_REORG_OUTSIDE_RANGE
+        chi "重组范围分区无法更改除最后分区之外的总范围，无法扩展范围"
         eng "Reorganize of range partitions cannot change total ranges except for last partition where it can extend the range"
         ger "Die Reorganisation von RANGE-Partitionen kann Gesamtbereiche nicht verändern, mit Ausnahme der letzten Partition, die den Bereich erweitern kann"
         swe "Reorganisering av rangepartitioner kan inte ändra den totala intervallet utom för den sista partitionen där intervallet kan utökas"
 ER_PARTITION_FUNCTION_FAILURE
+        chi "此版不支持此处理程序的分区功能"
         eng "Partition function not supported in this version for this handler"
         ger "Partitionsfunktion in dieser Version dieses Handlers nicht unterstützt"
 ER_PART_STATE_ERROR
+        chi "无法从CREATE/ALTER表中定义分区状态"
         eng "Partition state cannot be defined from CREATE/ALTER TABLE"
         ger "Partitionszustand kann nicht von CREATE oder ALTER TABLE aus definiert werden"
         swe "Partition state kan inte definieras från CREATE/ALTER TABLE"
 ER_LIMITED_PART_RANGE
+        chi "%-.64s处理程序仅支持32-bit整数"
         eng "The %-.64s handler only supports 32 bit integers in VALUES"
         ger "Der Handler %-.64s unterstützt in VALUES nur 32-Bit-Integers"
         swe "%-.64s stödjer endast 32 bitar i integers i VALUES"
 ER_PLUGIN_IS_NOT_LOADED
+        chi "插件'%-.192s'未加载"
         eng "Plugin '%-.192s' is not loaded"
         ger "Plugin '%-.192s' ist nicht geladen"
 ER_WRONG_VALUE
+        chi "错误%-.32s值：'%-.128T'"
         eng "Incorrect %-.32s value: '%-.128T'"
         ger "Falscher %-.32s-Wert: '%-.128T'"
 ER_NO_PARTITION_FOR_GIVEN_VALUE
+        chi "表没有%-.64s的分区"
         eng "Table has no partition for value %-.64s"
         ger "Tabelle hat für den Wert %-.64s keine Partition"
 ER_FILEGROUP_OPTION_ONLY_ONCE
+        chi "设置%s不能超过一次"
         eng "It is not allowed to specify %s more than once"
         ger "%s darf nicht mehr als einmal angegegeben werden"
 ER_CREATE_FILEGROUP_FAILED
+        chi "无法创建%s"
         eng "Failed to create %s"
         ger "Anlegen von %s fehlgeschlagen"
         hindi "%s को बनाने में असफल रहे"
 ER_DROP_FILEGROUP_FAILED
+        chi "未能DROP%s"
         eng "Failed to drop %s"
         ger "Löschen von %s fehlgeschlagen"
         hindi "%s को हटाने में असफल रहे"
 ER_TABLESPACE_AUTO_EXTEND_ERROR
+        chi "处理程序不支持表空间的自动扩展名"
         eng "The handler doesn't support autoextend of tablespaces"
         ger "Der Handler unterstützt keine automatische Erweiterung (Autoextend) von Tablespaces"
 ER_WRONG_SIZE_NUMBER
+        chi "尺寸参数被错误地指定，编号或表单10M"
         eng "A size parameter was incorrectly specified, either number or on the form 10M"
         ger "Ein Größen-Parameter wurde unkorrekt angegeben, muss entweder Zahl sein oder im Format 10M"
 ER_SIZE_OVERFLOW_ERROR
+        chi "尺寸编号是正确的，但我们不允许数字部分超过20亿"
         eng "The size number was correct but we don't allow the digit part to be more than 2 billion"
         ger "Die Zahl für die Größe war korrekt, aber der Zahlanteil darf nicht größer als 2 Milliarden sein"
 ER_ALTER_FILEGROUP_FAILED
+        chi "未能改变：%s"
         eng "Failed to alter: %s"
         ger "Änderung von %s fehlgeschlagen"
         hindi "%s को ALTER करने में असफल रहे"
 ER_BINLOG_ROW_LOGGING_FAILED
+        chi "将一行写入基于行的二进制日志失败"
         eng "Writing one row to the row-based binary log failed"
         ger "Schreiben einer Zeilen ins zeilenbasierte Binärlog fehlgeschlagen"
 ER_BINLOG_ROW_WRONG_TABLE_DEF
+        chi "表定义主机和从站不匹配：%s"
         eng "Table definition on master and slave does not match: %s"
         ger "Tabellendefinition auf Master und Slave stimmt nicht überein: %s"
 ER_BINLOG_ROW_RBR_TO_SBR
+        chi "使用--log-slave-updates的从站必须使用基于行的二进制日志记录，以便能够复制基于行的二进制日志事件"
         eng "Slave running with --log-slave-updates must use row-based binary logging to be able to replicate row-based binary log events"
         ger "Slave, die mit --log-slave-updates laufen, müssen zeilenbasiertes Loggen verwenden, um zeilenbasierte Binärlog-Ereignisse loggen zu können"
 ER_EVENT_ALREADY_EXISTS
+        chi "事件'%-.192s'已经存在"
         eng "Event '%-.192s' already exists"
         ger "Event '%-.192s' existiert bereits"
 ER_EVENT_STORE_FAILED
+        chi "无法存储事件%s。错误代码%M来自存储引擎"
         eng "Failed to store event %s. Error code %M from storage engine"
         ger "Speichern von Event %s fehlgeschlagen. Fehlercode der Speicher-Engine: %M"
 ER_EVENT_DOES_NOT_EXIST
+        chi "未知事件'%-.192s'"
         eng "Unknown event '%-.192s'"
         ger "Unbekanntes Event '%-.192s'"
 ER_EVENT_CANT_ALTER
+        chi "无法改变事件'%-.192s'"
         eng "Failed to alter event '%-.192s'"
         ger "Ändern des Events '%-.192s' fehlgeschlagen"
         hindi "'%-.192s' EVENT को ALTER करने में असफल रहे"
 ER_EVENT_DROP_FAILED
+        chi "未能DROP%s"
         eng "Failed to drop %s"
         ger "Löschen von %s fehlgeschlagen"
         hindi "%s को हटाने में असफल रहे"
 ER_EVENT_INTERVAL_NOT_POSITIVE_OR_TOO_BIG
+        chi "INTERVAL为负或太大"
         eng "INTERVAL is either not positive or too big"
         ger "INTERVAL ist entweder nicht positiv oder zu groß"
 ER_EVENT_ENDS_BEFORE_STARTS
+        chi "ENDS无效的或在STARTS之前"
         eng "ENDS is either invalid or before STARTS"
         ger "ENDS ist entweder ungültig oder liegt vor STARTS"
 ER_EVENT_EXEC_TIME_IN_THE_PAST
-  eng "Event execution time is in the past. Event has been disabled"
-  ger "Ausführungszeit des Events liegt in der Vergangenheit. Event wurde deaktiviert"
+        chi "事件执行时间在过去。事件已被禁用"
+        eng "Event execution time is in the past. Event has been disabled"
+        ger "Ausführungszeit des Events liegt in der Vergangenheit. Event wurde deaktiviert"
 ER_EVENT_OPEN_TABLE_FAILED
+        chi "无法打开mysql.event"
         eng "Failed to open mysql.event"
         ger "Öffnen von mysql.event fehlgeschlagen"
         hindi "mysql.event को खोलने में असफल रहे"
 ER_EVENT_NEITHER_M_EXPR_NOR_M_AT
+        chi "没有提供DateTime表达式"
         eng "No datetime expression provided"
         ger "Kein DATETIME-Ausdruck angegeben"
-
 ER_UNUSED_2
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_UNUSED_3
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_EVENT_CANNOT_DELETE
+        chi "无法从mysql.event删除该事件"
         eng "Failed to delete the event from mysql.event"
         ger "Löschen des Events aus mysql.event fehlgeschlagen"
         hindi "EVENT को mysql.event से हटाने मैं असफल रहे"
 ER_EVENT_COMPILE_ERROR
+        chi "在汇编事件的主体时出错"
         eng "Error during compilation of event's body"
         ger "Fehler beim Kompilieren des Event-Bodys"
 ER_EVENT_SAME_NAME
+        chi "相同的旧活动名称"
         eng "Same old and new event name"
         ger "Alter und neuer Event-Name sind gleich"
 ER_EVENT_DATA_TOO_LONG
+        chi "列'%s'数据太长"
         eng "Data for column '%s' too long"
         ger "Daten der Spalte '%s' zu lang"
 ER_DROP_INDEX_FK
+        chi "无法删除索引'%-.192s'：外部索引约束中需要它"
         eng "Cannot drop index '%-.192s': needed in a foreign key constraint"
         ger "Kann Index '%-.192s' nicht löschen: wird für eine Fremdschlüsselbeschränkung benötigt"
 # When using this error message, use the ER_WARN_DEPRECATED_SYNTAX error
 # code.
 ER_WARN_DEPRECATED_SYNTAX_WITH_VER  
+        chi "语法'%s'被弃用，将在Mariadb%s中删除。请使用%s"
         eng  "The syntax '%s' is deprecated and will be removed in MariaDB %s. Please use %s instead"
         ger "Die Syntax '%s' ist veraltet und wird in MariaDB %s entfernt. Bitte benutzen Sie statt dessen %s"
 ER_CANT_WRITE_LOCK_LOG_TABLE
+        chi "您无法获得日志表的写锁。只有读访问是可能的"
         eng "You can't write-lock a log table. Only read access is possible"
         ger "Eine Log-Tabelle kann nicht schreibgesperrt werden. Es ist ohnehin nur Lesezugriff möglich"
 ER_CANT_LOCK_LOG_TABLE
+        chi "您无法使用带日志表的锁"
         eng "You can't use locks with log tables"
         ger "Log-Tabellen können nicht gesperrt werden"
 ER_UNUSED_4
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_COL_COUNT_DOESNT_MATCH_PLEASE_UPDATE
+        chi "mysql的列计数。%s是错误的。预期%d，找到%d。使用MariaDB%d创建，现在运行%d。请使用mysql_upgrade来修复此错误"
         eng "Column count of mysql.%s is wrong. Expected %d, found %d. Created with MariaDB %d, now running %d. Please use mysql_upgrade to fix this error"
         ger "Spaltenanzahl von mysql.%s falsch. %d erwartet, aber %d erhalten. Erzeugt mit MariaDB %d, jetzt unter %d. Bitte benutzen Sie mysql_upgrade, um den Fehler zu beheben"
 ER_TEMP_TABLE_PREVENTS_SWITCH_OUT_OF_RBR
+        chi "当会话打开临时表时，无法切换出基于行的二进制日志格式"
         eng "Cannot switch out of the row-based binary log format when the session has open temporary tables"
         ger "Kann nicht aus dem zeilenbasierten Binärlog-Format herauswechseln, wenn die Sitzung offene temporäre Tabellen hat"
 ER_STORED_FUNCTION_PREVENTS_SWITCH_BINLOG_FORMAT
+        chi "无法更改存储函数或触发器内的二进制记录格式"
         eng "Cannot change the binary logging format inside a stored function or trigger"
         ger "Das Binärlog-Format kann innerhalb einer gespeicherten Funktion oder eines Triggers nicht geändert werden"
 ER_UNUSED_13
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_PARTITION_NO_TEMPORARY
+        chi "无法使用分区创建临时表"
         eng "Cannot create temporary table with partitions"
         ger "Anlegen temporärer Tabellen mit Partitionen nicht möglich"
         hindi "अस्थाई टेबल को पार्टिशन्स के साथ नहीं बनाया जा सकता"
 ER_PARTITION_CONST_DOMAIN_ERROR
+        chi "分区常量超出分区功能域"
         eng "Partition constant is out of partition function domain"
         ger "Partitionskonstante liegt außerhalb der Partitionsfunktionsdomäne"
         swe "Partitionskonstanten är utanför partitioneringsfunktionens domän"
 ER_PARTITION_FUNCTION_IS_NOT_ALLOWED
+        chi "不允许此分区功能"
         eng "This partition function is not allowed"
         ger "Diese Partitionierungsfunktion ist nicht erlaubt"
         swe "Denna partitioneringsfunktion är inte tillåten"
 ER_DDL_LOG_ERROR
+        chi "DDL日志中的错误"
         eng "Error in DDL log"
         ger "Fehler im DDL-Log"
         hindi "DDL लॉग में त्रुटि हुई"
 ER_NULL_IN_VALUES_LESS_THAN
+        chi "VALUES LESS THAN不允许使用NULL"
         eng "Not allowed to use NULL value in VALUES LESS THAN"
         ger "In VALUES LESS THAN dürfen keine NULL-Werte verwendet werden"
         swe "Det är inte tillåtet att använda NULL-värden i VALUES LESS THAN"
 ER_WRONG_PARTITION_NAME
+        chi "分区名称不正确"
         eng "Incorrect partition name"
         ger "Falscher Partitionsname"
         hindi "पार्टीशन का नाम गलत है"
         swe "Felaktigt partitionsnamn"
 ER_CANT_CHANGE_TX_CHARACTERISTICS 25001
+        chi "交易正在进行，无法更改事务特性"
         eng "Transaction characteristics can't be changed while a transaction is in progress"
 ER_DUP_ENTRY_AUTOINCREMENT_CASE
+        chi "ALTER TABLE表会导致AUTO_INCREMENT重建，导致重复的条目'%-.192T'用于索引'%-.192s'"
         eng "ALTER TABLE causes auto_increment resequencing, resulting in duplicate entry '%-.192T' for key '%-.192s'"
         ger "ALTER TABLE führt zur Neusequenzierung von auto_increment, wodurch der doppelte Eintrag '%-.192T' für Schlüssel '%-.192s' auftritt"
 ER_EVENT_MODIFY_QUEUE_ERROR
+        chi "内部调度器错误%d"
         eng "Internal scheduler error %d"
         ger "Interner Scheduler-Fehler %d"
 ER_EVENT_SET_VAR_ERROR
+        chi "在开始/停止调度程序期间出错。错误代码%M"
         eng "Error during starting/stopping of the scheduler. Error code %M"
         ger "Fehler während des Startens oder Anhalten des Schedulers. Fehlercode %M"
 ER_PARTITION_MERGE_ERROR
+        chi "引擎不能用于分区表"
         eng "Engine cannot be used in partitioned tables"
         ger "Engine kann in partitionierten Tabellen nicht verwendet werden"
         swe "Engine inte användas i en partitionerad tabell"
 ER_CANT_ACTIVATE_LOG
+        chi "无法激活'%-.64s'日志"
         eng "Cannot activate '%-.64s' log"
         ger "Kann Logdatei '%-.64s' nicht aktivieren"
 ER_RBR_NOT_AVAILABLE
+        chi "服务器不是基于行的复制构建的"
         eng "The server was not built with row-based replication"
         ger "Der Server wurde nicht mit zeilenbasierter Replikation gebaut"
 ER_BASE64_DECODE_ERROR
+        chi "Base64字符串的解码失败"
         eng "Decoding of base64 string failed"
-        swe "Avkodning av base64 sträng misslyckades"
         ger "Der Server hat keine zeilenbasierte Replikation"
+        swe "Avkodning av base64 sträng misslyckades"
 ER_EVENT_RECURSION_FORBIDDEN
+        chi "EVENT主体存在时EVENT DDL语句递归被禁止"
         eng "Recursion of EVENT DDL statements is forbidden when body is present"
         ger "Rekursivität von EVENT-DDL-Anweisungen ist unzulässig wenn ein Hauptteil (Body) existiert"
 ER_EVENTS_DB_ERROR
+        chi "无法继续，因为事件调度程序已禁用"
         eng "Cannot proceed, because event scheduler is disabled"
         ger "Die Operation kann nicht fortgesetzt werden, da Event Scheduler deaktiviert ist."
 ER_ONLY_INTEGERS_ALLOWED
+        chi "这里只允许整数作为数字"
         eng "Only integers allowed as number here"
         ger "An dieser Stelle sind nur Ganzzahlen zulässig"
 ER_UNSUPORTED_LOG_ENGINE
+        chi "存储引擎%s不能用于日志表"
         eng "Storage engine %s cannot be used for log tables"
         ger "Speicher-Engine %s kann für Logtabellen nicht verwendet werden"
         hindi "स्टोरेज इंजन %s को लॉग टेबल्स के लिए इस्तेमाल नहीं किया जा सकता है"
 ER_BAD_LOG_STATEMENT
+        chi "如果启用日志记录，则无法'%s'日志表"
         eng "You cannot '%s' a log table if logging is enabled"
         ger "Sie können eine Logtabelle nicht '%s', wenn Loggen angeschaltet ist"
 ER_CANT_RENAME_LOG_TABLE
+        chi "无法重命名'%s'。启用日志记录时，重命名日志表必须重命名两个表：日志表到存档表，另一个表返回'%s'"
         eng "Cannot rename '%s'. When logging enabled, rename to/from log table must rename two tables: the log table to an archive table and another table back to '%s'"
         ger "Kann '%s' nicht umbenennen. Wenn Loggen angeschaltet ist, müssen zwei Tabellen umbenannt werden: die Logtabelle zu einer Archivtabelle, und eine weitere Tabelle zu '%s'"
 ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT 42000
+        chi "对本机函数的呼叫中的参数计数不正确'%-.192s'"
         eng "Incorrect parameter count in the call to native function '%-.192s'"
         ger "Falsche Anzahl von Parametern beim Aufruf der nativen Funktion '%-.192s'"
 ER_WRONG_PARAMETERS_TO_NATIVE_FCT 42000
+        chi "对本机函数'%-.192s'呼叫中的参数不正确"
         eng "Incorrect parameters in the call to native function '%-.192s'"
         ger "Falscher Parameter beim Aufruf der nativen Funktion '%-.192s'"
 ER_WRONG_PARAMETERS_TO_STORED_FCT 42000  
+        chi "呼叫中的参数不正确为存储函数'%-.192s'"
         eng "Incorrect parameters in the call to stored function '%-.192s'"
         ger "Falsche Parameter beim Aufruf der gespeicherten Funktion '%-.192s'"
 ER_NATIVE_FCT_NAME_COLLISION
+        chi "此功能'%-.192s'具有与本机函数相同的名称"
         eng "This function '%-.192s' has the same name as a native function"
         ger "Die Funktion '%-.192s' hat denselben Namen wie eine native Funktion"
 # When using this error message, use the ER_DUP_ENTRY error code.  See, for
 # example, code in handler.cc.
 ER_DUP_ENTRY_WITH_KEY_NAME 23000 S1009
+        chi "重复条目'%-.64T'键'%-.192s'"
         cze "Zvojený klíč '%-.64T' (číslo klíče '%-.192s')"
         dan "Ens værdier '%-.64T' for indeks '%-.192s'"
-        nla "Dubbele ingang '%-.64T' voor zoeksleutel '%-.192s'"
         eng "Duplicate entry '%-.64T' for key '%-.192s'"
         est "Kattuv väärtus '%-.64T' võtmele '%-.192s'"
         fre "Duplicata du champ '%-.64T' pour la clef '%-.192s'"
@@ -6188,6 +6767,7 @@ ER_DUP_ENTRY_WITH_KEY_NAME 23000 S1009
         ita "Valore duplicato '%-.64T' per la chiave '%-.192s'"
         jpn "'%-.64T' は索引 '%-.192s' で重複しています。"
         kor "중복된 입력 값 '%-.64T': key '%-.192s'"
+        nla "Dubbele ingang '%-.64T' voor zoeksleutel '%-.192s'"
         nor "Like verdier '%-.64T' for nøkkel '%-.192s'"
         norwegian-ny "Like verdiar '%-.64T' for nykkel '%-.192s'"
         pol "Powtórzone wystąpienie '%-.64T' dla klucza '%-.192s'"
@@ -6200,344 +6780,437 @@ ER_DUP_ENTRY_WITH_KEY_NAME 23000 S1009
         swe "Dublett '%-.64T' för nyckel '%-.192s'"
         ukr "Дублюючий запис '%-.64T' для ключа '%-.192s'"
 ER_BINLOG_PURGE_EMFILE
-  eng "Too many files opened, please execute the command again"
-  ger "Zu viele offene Dateien, bitte führen Sie den Befehl noch einmal aus"
+        chi "打开太多文件，请再次执行命令"
+        eng "Too many files opened, please execute the command again"
+        ger "Zu viele offene Dateien, bitte führen Sie den Befehl noch einmal aus"
 ER_EVENT_CANNOT_CREATE_IN_THE_PAST
-  eng "Event execution time is in the past and ON COMPLETION NOT PRESERVE is set. The event was dropped immediately after creation"
-  ger "Ausführungszeit des Events liegt in der Vergangenheit, und es wurde ON COMPLETION NOT PRESERVE gesetzt. Das Event wurde unmittelbar nach Erzeugung gelöscht"
+        chi "事件执行时间在过去，并ON COMPLETION NOT PRESERVE。创建后，事件立即丢弃"
+        eng "Event execution time is in the past and ON COMPLETION NOT PRESERVE is set. The event was dropped immediately after creation"
+        ger "Ausführungszeit des Events liegt in der Vergangenheit, und es wurde ON COMPLETION NOT PRESERVE gesetzt. Das Event wurde unmittelbar nach Erzeugung gelöscht"
 ER_EVENT_CANNOT_ALTER_IN_THE_PAST
-  eng "Event execution time is in the past and ON COMPLETION NOT PRESERVE is set. The event was not changed. Specify a time in the future"
-  ger "Execution Zeitpunkt des Ereignisses in der Vergangenheit liegt, und es war NACH ABSCHLUSS Set nicht erhalten. Die Veranstaltung wurde nicht verändert. Geben Sie einen Zeitpunkt in der Zukunft"
+        chi "事件执行时间在过去，并ON COMPLETION NOT PRESERVE。事件没有改变。指定将来的时间"
+        eng "Event execution time is in the past and ON COMPLETION NOT PRESERVE is set. The event was not changed. Specify a time in the future"
+        ger "Execution Zeitpunkt des Ereignisses in der Vergangenheit liegt, und es war NACH ABSCHLUSS Set nicht erhalten. Die Veranstaltung wurde nicht verändert. Geben Sie einen Zeitpunkt in der Zukunft"
 ER_SLAVE_INCIDENT
-  eng "The incident %s occurred on the master. Message: %-.64s"
-  ger "Der Vorfall %s passierte auf dem Master. Meldung: %-.64s"
+        chi "事件%s发生在master上。消息：%-.64s"
+        eng "The incident %s occurred on the master. Message: %-.64s"
+        ger "Der Vorfall %s passierte auf dem Master. Meldung: %-.64s"
 ER_NO_PARTITION_FOR_GIVEN_VALUE_SILENT
-  eng "Table has no partition for some existing values"
-  ger "Tabelle hat für einige bestehende Werte keine Partition"
+        chi "表对某些现有值没有分区"
+        eng "Table has no partition for some existing values"
+        ger "Tabelle hat für einige bestehende Werte keine Partition"
 ER_BINLOG_UNSAFE_STATEMENT
-  eng "Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. %s"
-  swe "Detta är inte säkert att logga i statement-format, för BINLOG_FORMAT = STATEMENT. %s"
-  ger "Unsichere Anweisung ins Binärlog geschrieben, weil Anweisungsformat BINLOG_FORMAT = STATEMENT. %s"
+        chi "自从BINLOG_FORMAT =STATEMENT以来，使用语句格式写入二进制日志的不安全语句。%s."
+        eng "Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. %s"
+        ger "Unsichere Anweisung ins Binärlog geschrieben, weil Anweisungsformat BINLOG_FORMAT = STATEMENT. %s"
+        swe "Detta är inte säkert att logga i statement-format, för BINLOG_FORMAT = STATEMENT. %s"
 ER_SLAVE_FATAL_ERROR
-  eng "Fatal error: %s"
-  ger "Fataler Fehler: %s"
+        chi "致命错误：%s"
+        eng "Fatal error: %s"
+        ger "Fataler Fehler: %s"
 ER_SLAVE_RELAY_LOG_READ_FAILURE
-  eng "Relay log read failure: %s"
-  ger "Relaylog-Lesefehler: %s"
+        chi "relay日志读取失败：%s"
+        eng "Relay log read failure: %s"
+        ger "Relaylog-Lesefehler: %s"
 ER_SLAVE_RELAY_LOG_WRITE_FAILURE
-  eng "Relay log write failure: %s"
-  ger "Relaylog-Schreibfehler: %s"
+        chi "relay日志写入失败：%s"
+        eng "Relay log write failure: %s"
+        ger "Relaylog-Schreibfehler: %s"
 ER_SLAVE_CREATE_EVENT_FAILURE
-  eng "Failed to create %s"
-  ger "Erzeugen von %s fehlgeschlagen"
-  hindi "%s को बनाने मैं असफल रहे"
+        chi "无法创建%s"
+        eng "Failed to create %s"
+        ger "Erzeugen von %s fehlgeschlagen"
+        hindi "%s को बनाने मैं असफल रहे"
 ER_SLAVE_MASTER_COM_FAILURE
-  eng "Master command %s failed: %s"
-  ger "Master-Befehl %s fehlgeschlagen: %s"
+        chi "Master命令%s失败：%s"
+        eng "Master command %s failed: %s"
+        ger "Master-Befehl %s fehlgeschlagen: %s"
 ER_BINLOG_LOGGING_IMPOSSIBLE
-  eng "Binary logging not possible. Message: %s"
-  ger "Binärlogging nicht möglich. Meldung: %s"
+        chi "二进制记录不可能。消息：%s"
+        eng "Binary logging not possible. Message: %s"
+        ger "Binärlogging nicht möglich. Meldung: %s"
 ER_VIEW_NO_CREATION_CTX
-  eng "View %`s.%`s has no creation context"
-  ger "View %`s.%`s hat keinen Erzeugungskontext"
+        chi "View%`s.%`s没有创建上下文"
+        eng "View %`s.%`s has no creation context"
+        ger "View %`s.%`s hat keinen Erzeugungskontext"
 ER_VIEW_INVALID_CREATION_CTX
-  eng "Creation context of view %`s.%`s is invalid"
-  ger "Erzeugungskontext des Views%`s.%`s ist ungültig"
+        chi "Creation View%`s.%`s的上下文无效"
+        eng "Creation context of view %`s.%`s is invalid"
+        ger "Erzeugungskontext des Views%`s.%`s ist ungültig"
 ER_SR_INVALID_CREATION_CTX
-  eng "Creation context of stored routine %`s.%`s is invalid"
-  ger "Erzeugungskontext der gespeicherten Routine%`s.%`s ist ungültig"
+        chi "存储例程%`s.%`s的创建上下文无效"
+        eng "Creation context of stored routine %`s.%`s is invalid"
+        ger "Erzeugungskontext der gespeicherten Routine%`s.%`s ist ungültig"
 ER_TRG_CORRUPTED_FILE
-  eng "Corrupted TRG file for table %`s.%`s"
-  ger "Beschädigte TRG-Datei für Tabelle %`s.%`s"
+        chi "表的trg文件损坏了。%`s.%`s"
+        eng "Corrupted TRG file for table %`s.%`s"
+        ger "Beschädigte TRG-Datei für Tabelle %`s.%`s"
 ER_TRG_NO_CREATION_CTX
-  eng "Triggers for table %`s.%`s have no creation context"
-  ger "Trigger für Tabelle %`s.%`s haben keinen Erzeugungskontext"
+        chi "表%`s.%`s的触发器没有创建上下文"
+        eng "Triggers for table %`s.%`s have no creation context"
+        ger "Trigger für Tabelle %`s.%`s haben keinen Erzeugungskontext"
 ER_TRG_INVALID_CREATION_CTX
-  eng "Trigger creation context of table %`s.%`s is invalid"
-  ger "Trigger-Erzeugungskontext der Tabelle %`s.%`s ist ungültig"
+        chi "触发表%`s.%`s的创建上下文无效"
+        eng "Trigger creation context of table %`s.%`s is invalid"
+        ger "Trigger-Erzeugungskontext der Tabelle %`s.%`s ist ungültig"
 ER_EVENT_INVALID_CREATION_CTX
-  eng "Creation context of event %`s.%`s is invalid"
-  ger "Erzeugungskontext des Events %`s.%`s ist ungültig"
+        chi "事件%`s.%`s的创建上下文无效"
+        eng "Creation context of event %`s.%`s is invalid"
+        ger "Erzeugungskontext des Events %`s.%`s ist ungültig"
 ER_TRG_CANT_OPEN_TABLE
-  eng "Cannot open table for trigger %`s.%`s"
-  ger "Kann Tabelle für den Trigger %`s.%`s nicht öffnen"
+        chi "无法打开触发%`s.%`s的表"
+        eng "Cannot open table for trigger %`s.%`s"
+        ger "Kann Tabelle für den Trigger %`s.%`s nicht öffnen"
 ER_CANT_CREATE_SROUTINE
-  eng "Cannot create stored routine %`s. Check warnings"
-  ger "Kann gespeicherte Routine %`s nicht erzeugen. Beachten Sie die Warnungen"
+        chi "无法创建存储过程%`s。检查警告"
+        eng "Cannot create stored routine %`s. Check warnings"
+        ger "Kann gespeicherte Routine %`s nicht erzeugen. Beachten Sie die Warnungen"
 ER_UNUSED_11
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_NO_FORMAT_DESCRIPTION_EVENT_BEFORE_BINLOG_STATEMENT
-  eng "The BINLOG statement of type %s was not preceded by a format description BINLOG statement"
-  ger "Der BINLOG-Anweisung vom Typ %s ging keine BINLOG-Anweisung zur Formatbeschreibung voran"
+        chi "类型%s的Binlog语句未在格式描述binlog语句之前"
+        eng "The BINLOG statement of type %s was not preceded by a format description BINLOG statement"
+        ger "Der BINLOG-Anweisung vom Typ %s ging keine BINLOG-Anweisung zur Formatbeschreibung voran"
 ER_SLAVE_CORRUPT_EVENT
-  eng "Corrupted replication event was detected"
-  ger "Beschädigtes Replikationsereignis entdeckt"
+        chi "检测到损坏的复制事件"
+        eng "Corrupted replication event was detected"
+        ger "Beschädigtes Replikationsereignis entdeckt"
 ER_LOAD_DATA_INVALID_COLUMN
-  eng "Invalid column reference (%-.64s) in LOAD DATA"
-  ger "Ungültige Spaltenreferenz (%-.64s) bei LOAD DATA"
+        chi "LOAD DATA中的列引用（%-.64s）无效"
+        eng "Invalid column reference (%-.64s) in LOAD DATA"
+        ger "Ungültige Spaltenreferenz (%-.64s) bei LOAD DATA"
 ER_LOG_PURGE_NO_FILE
-  eng "Being purged log %s was not found"
-  ger "Zu bereinigende Logdatei %s wurde nicht gefunden"
+        chi "未找到清除的log%s"
+        eng "Being purged log %s was not found"
+        ger "Zu bereinigende Logdatei %s wurde nicht gefunden"
 ER_XA_RBTIMEOUT XA106
-  eng "XA_RBTIMEOUT: Transaction branch was rolled back: took too long"
-  ger "XA_RBTIMEOUT: Transaktionszweig wurde zurückgerollt: Zeitüberschreitung"
+        chi "XA_RBTIMEOUT：交易分支回滚：花了太久了"
+        eng "XA_RBTIMEOUT: Transaction branch was rolled back: took too long"
+        ger "XA_RBTIMEOUT: Transaktionszweig wurde zurückgerollt: Zeitüberschreitung"
 ER_XA_RBDEADLOCK XA102
-  eng "XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected"
-  ger "XA_RBDEADLOCK: Transaktionszweig wurde zurückgerollt: Deadlock entdeckt"
+        chi "XA_RBDEADLOCK：交易分支回滚：检测到死锁"
+        eng "XA_RBDEADLOCK: Transaction branch was rolled back: deadlock was detected"
+        ger "XA_RBDEADLOCK: Transaktionszweig wurde zurückgerollt: Deadlock entdeckt"
 ER_NEED_REPREPARE
-  eng "Prepared statement needs to be re-prepared"
-  ger "Vorbereitete Anweisungen müssen noch einmal vorbereitet werden"
+        chi "prepared statement需要重新准备"
+        eng "Prepared statement needs to be re-prepared"
+        ger "Vorbereitete Anweisungen müssen noch einmal vorbereitet werden"
 ER_DELAYED_NOT_SUPPORTED
-  eng "DELAYED option not supported for table '%-.192s'"
-  ger "Die DELAYED-Option wird für Tabelle '%-.192s' nicht unterstützt"
+        chi "表'%-.192s'不支持延迟选项"
+        eng "DELAYED option not supported for table '%-.192s'"
+        ger "Die DELAYED-Option wird für Tabelle '%-.192s' nicht unterstützt"
 WARN_NO_MASTER_INFO  
-  eng "There is no master connection '%.*s'"
-  ger "Die Master-Info-Struktur existiert nicht '%.*s'"
+        eng "There is no master connection '%.*s'"
+        ger "Die Master-Info-Struktur existiert nicht '%.*s'"
 WARN_OPTION_IGNORED
-  eng "<%-.64s> option ignored"
-  ger "Option <%-.64s> ignoriert"
+        eng "<%-.64s> option ignored"
+        ger "Option <%-.64s> ignoriert"
 ER_PLUGIN_DELETE_BUILTIN
-  eng "Built-in plugins cannot be deleted"
-  ger "Eingebaute Plugins können nicht gelöscht werden"
+        chi "内置插件无法删除"
+        eng "Built-in plugins cannot be deleted"
+        ger "Eingebaute Plugins können nicht gelöscht werden"
 WARN_PLUGIN_BUSY
-  eng "Plugin is busy and will be uninstalled on shutdown"
-  ger "Plugin wird verwendet und wird erst beim Herunterfahren deinstalliert"
+        chi "插件很忙，将在关机时卸载"
+        eng "Plugin is busy and will be uninstalled on shutdown"
+        ger "Plugin wird verwendet und wird erst beim Herunterfahren deinstalliert"
 ER_VARIABLE_IS_READONLY
-  eng "%s variable '%s' is read-only. Use SET %s to assign the value"
-  ger "%s Variable '%s' ist nur lesbar. Benutzen Sie SET %s, um einen Wert zuzuweisen"
+        chi "%s变量'%s'是只读的。使用set%s付值"
+        eng "%s variable '%s' is read-only. Use SET %s to assign the value"
+        ger "%s Variable '%s' ist nur lesbar. Benutzen Sie SET %s, um einen Wert zuzuweisen"
 ER_WARN_ENGINE_TRANSACTION_ROLLBACK
-  eng "Storage engine %s does not support rollback for this statement. Transaction rolled back and must be restarted"
-  ger "Speicher-Engine %s unterstützt für diese Anweisung kein Rollback. Transaktion wurde zurückgerollt und muss neu gestartet werden"
+        chi "存储引擎%s不支持此语句的回滚。交易回滚并必须重新启动"
+        eng "Storage engine %s does not support rollback for this statement. Transaction rolled back and must be restarted"
+        ger "Speicher-Engine %s unterstützt für diese Anweisung kein Rollback. Transaktion wurde zurückgerollt und muss neu gestartet werden"
 ER_SLAVE_HEARTBEAT_FAILURE
-  eng "Unexpected master's heartbeat data: %s"
-  ger "Unerwartete Daten vom Heartbeat des Masters: %s"
+        chi "意外的master心跳数据：%s"
+        eng "Unexpected master's heartbeat data: %s"
+        ger "Unerwartete Daten vom Heartbeat des Masters: %s"
 ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE
-  eng "The requested value for the heartbeat period is either negative or exceeds the maximum allowed (%u seconds)"
+        chi "心跳周期的请求值是负的或超过允许的最大值（%u秒）"
+        eng "The requested value for the heartbeat period is either negative or exceeds the maximum allowed (%u seconds)"
 ER_UNUSED_14
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 ER_CONFLICT_FN_PARSE_ERROR
-  eng "Error in parsing conflict function. Message: %-.64s"
-  ger "Fehler beim Parsen einer Konflikt-Funktion. Meldung: %-.64s"
+        chi "解析冲突功能时出错。消息：%-.64s"
+        eng "Error in parsing conflict function. Message: %-.64s"
+        ger "Fehler beim Parsen einer Konflikt-Funktion. Meldung: %-.64s"
 ER_EXCEPTIONS_WRITE_ERROR
-  eng "Write to exceptions table failed. Message: %-.128s""
-  ger "Schreiben in Ausnahme-Tabelle fehlgeschlagen. Meldung: %-.128s""
+        chi "写入异常表失败。消息：%-.128s"
+        eng "Write to exceptions table failed. Message: %-.128s""
+        ger "Schreiben in Ausnahme-Tabelle fehlgeschlagen. Meldung: %-.128s""
 ER_TOO_LONG_TABLE_COMMENT
-  eng "Comment for table '%-.64s' is too long (max = %u)"
-  por "Comentário para a tabela '%-.64s' é longo demais (max = %u)"
-  ger "Kommentar für Tabelle '%-.64s' ist zu lang (max = %u)"
+        chi "表格备注'%-.64s'太长（max =%u）"
+        eng "Comment for table '%-.64s' is too long (max = %u)"
+        ger "Kommentar für Tabelle '%-.64s' ist zu lang (max = %u)"
+        por "Comentário para a tabela '%-.64s' é longo demais (max = %u)"
 ER_TOO_LONG_FIELD_COMMENT
-  eng "Comment for field '%-.64s' is too long (max = %u)"
-  por "Comentário para o campo '%-.64s' é longo demais (max = %u)"
-  ger "Kommentar für Feld '%-.64s' ist zu lang (max = %u)"
+        chi "字段'%-.64s'太长（max =%u）"
+        eng "Comment for field '%-.64s' is too long (max = %u)"
+        ger "Kommentar für Feld '%-.64s' ist zu lang (max = %u)"
+        por "Comentário para o campo '%-.64s' é longo demais (max = %u)"
 ER_FUNC_INEXISTENT_NAME_COLLISION 42000 
-  eng "FUNCTION %s does not exist. Check the 'Function Name Parsing and Resolution' section in the Reference Manual"
-  ger "FUNCTION %s existiert nicht. Erläuterungen im Abschnitt 'Function Name Parsing and Resolution' im Referenzhandbuch"
+        chi "FUNCTION %s不存在。在参考手册中查看“函数名称解析”部分"
+        eng "FUNCTION %s does not exist. Check the 'Function Name Parsing and Resolution' section in the Reference Manual"
+        ger "FUNCTION %s existiert nicht. Erläuterungen im Abschnitt 'Function Name Parsing and Resolution' im Referenzhandbuch"
 # When updating these, please update EXPLAIN_FILENAME_MAX_EXTRA_LENGTH in
 # sql_table.h with the new maximal additional length for explain_filename.
 ER_DATABASE_NAME
-  eng "Database"
-  swe "Databas"
-  ger "Datenbank"
-  hindi "डेटाबेस"
+        chi "数据库"
+        eng "Database"
+        ger "Datenbank"
+        hindi "डेटाबेस"
+        swe "Databas"
 ER_TABLE_NAME
-  eng "Table"
-  swe "Tabell"
-  ger "Tabelle"
-  hindi "टेबल"
+        chi "表"
+        eng "Table"
+        ger "Tabelle"
+        hindi "टेबल"
+        swe "Tabell"
 ER_PARTITION_NAME
-  eng "Partition"
-  swe "Partition"
-  ger "Partition"
-  hindi "पार्टीशन"
+        chi "分区"
+        eng "Partition"
+        ger "Partition"
+        hindi "पार्टीशन"
+        swe "Partition"
 ER_SUBPARTITION_NAME
-  eng "Subpartition"
-  swe "Subpartition"
-  ger "Unterpartition"
-  hindi "सब-पार्टीशन"
+        chi "下分区"
+        eng "Subpartition"
+        ger "Unterpartition"
+        hindi "सब-पार्टीशन"
+        swe "Subpartition"
 ER_TEMPORARY_NAME
-  eng "Temporary"
-  swe "Temporär"
-  ger "Temporär"
-  hindi "अस्थायी"
+        chi "暂时的"
+        eng "Temporary"
+        ger "Temporär"
+        hindi "अस्थायी"
+        swe "Temporär"
 ER_RENAMED_NAME
-  eng "Renamed"
-  swe "Namnändrad"
-  ger "Umbenannt"
+        chi "重命名"
+        eng "Renamed"
+        ger "Umbenannt"
+        swe "Namnändrad"
 ER_TOO_MANY_CONCURRENT_TRXS
-  eng  "Too many active concurrent transactions"
-  ger  "Zu viele aktive simultane Transaktionen"
+        chi "“太多并发交易"
+        eng "Too many active concurrent transactions"
+        ger "Zu viele aktive simultane Transaktionen"
 WARN_NON_ASCII_SEPARATOR_NOT_IMPLEMENTED
-  eng "Non-ASCII separator arguments are not fully supported"
-  ger "Nicht-ASCII-Trennargumente werden nicht vollständig unterstützt"
+        chi "非ASCII分隔符参数不完全支持"
+        eng "Non-ASCII separator arguments are not fully supported"
+        ger "Nicht-ASCII-Trennargumente werden nicht vollständig unterstützt"
 ER_DEBUG_SYNC_TIMEOUT
-  eng "debug sync point wait timed out"
-  ger "Debug Sync Point Wartezeit überschritten"
+        chi "调试同步点等待超时"
+        eng "debug sync point wait timed out"
+        ger "Debug Sync Point Wartezeit überschritten"
 ER_DEBUG_SYNC_HIT_LIMIT
-  eng "debug sync point hit limit reached"
-  ger "Debug Sync Point Hit Limit erreicht"
+        chi "调试同步点限制达到"
+        eng "debug sync point hit limit reached"
+        ger "Debug Sync Point Hit Limit erreicht"
 ER_DUP_SIGNAL_SET 42000
-  eng "Duplicate condition information item '%s'"
-  ger "Informationselement '%s' für Duplikatbedingung"
+        chi "重复条件信息项'%s'"
+        eng "Duplicate condition information item '%s'"
+        ger "Informationselement '%s' für Duplikatbedingung"
 # Note that the SQLSTATE is not 01000, it is provided by SIGNAL/RESIGNAL
 ER_SIGNAL_WARN 01000
-  eng "Unhandled user-defined warning condition"
-  ger "Unbehandelte benutzerdefinierte Warnbedingung"
+        chi "未处理用户定义的警告条件"
+        eng "Unhandled user-defined warning condition"
+        ger "Unbehandelte benutzerdefinierte Warnbedingung"
 # Note that the SQLSTATE is not 02000, it is provided by SIGNAL/RESIGNAL
 ER_SIGNAL_NOT_FOUND 02000
-  eng "Unhandled user-defined not found condition"
-  ger "Unbehandelte benutzerdefinierte Nicht-gefunden-Bedingung"
+        chi "未找到的用户定义未找到条件"
+        eng "Unhandled user-defined not found condition"
+        ger "Unbehandelte benutzerdefinierte Nicht-gefunden-Bedingung"
 # Note that the SQLSTATE is not HY000, it is provided by SIGNAL/RESIGNAL
 ER_SIGNAL_EXCEPTION HY000
-  eng "Unhandled user-defined exception condition"
-  ger "Unbehandelte benutzerdefinierte Ausnahmebedingung"
+        chi "未处理用户定义的异常条件"
+        eng "Unhandled user-defined exception condition"
+        ger "Unbehandelte benutzerdefinierte Ausnahmebedingung"
 ER_RESIGNAL_WITHOUT_ACTIVE_HANDLER 0K000
-  eng "RESIGNAL when handler not active"
-  ger "RESIGNAL bei nicht aktivem Handler"
+        chi "RESIGNAL处理程序不活跃"
+        eng "RESIGNAL when handler not active"
+        ger "RESIGNAL bei nicht aktivem Handler"
 ER_SIGNAL_BAD_CONDITION_TYPE
-  eng "SIGNAL/RESIGNAL can only use a CONDITION defined with SQLSTATE"
-  ger "SIGNAL/RESIGNAL kann nur mit einer Bedingung (CONDITION) benutzt werden, die bei SQLSTATE definiert wurde"
+        chi "SIGNAL/RESIGNAL只能使用SQLState定义的条件"
+        eng "SIGNAL/RESIGNAL can only use a CONDITION defined with SQLSTATE"
+        ger "SIGNAL/RESIGNAL kann nur mit einer Bedingung (CONDITION) benutzt werden, die bei SQLSTATE definiert wurde"
 WARN_COND_ITEM_TRUNCATED
-  eng "Data truncated for condition item '%s'"
-  ger "Daten gekürzt für Bedingungselement '%s'"
+        chi "数据被截断为条件项目'%s'"
+        eng "Data truncated for condition item '%s'"
+        ger "Daten gekürzt für Bedingungselement '%s'"
 ER_COND_ITEM_TOO_LONG
-  eng "Data too long for condition item '%s'"
-  ger "Daten zu lang für Bedingungselement '%s'"
+        chi "条件项目'%s'的数据太长"
+        eng "Data too long for condition item '%s'"
+        ger "Daten zu lang für Bedingungselement '%s'"
 ER_UNKNOWN_LOCALE
-  eng "Unknown locale: '%-.64s'"
-  ger "Unbekannte Locale: '%-.64s'"
+        chi "未知区域设置：'%-.64s'"
+        eng "Unknown locale: '%-.64s'"
+        ger "Unbekannte Locale: '%-.64s'"
 ER_SLAVE_IGNORE_SERVER_IDS
-  eng "The requested server id %d clashes with the slave startup option --replicate-same-server-id"
-  ger "Die angeforderte Server-ID %d steht im Konflikt mit der Startoption --replicate-same-server-id für den Slave"
+        chi "请求的服务器ID%d与SLAVE启动选项--replicate-same-server-id冲突"
+        eng "The requested server id %d clashes with the slave startup option --replicate-same-server-id"
+        ger "Die angeforderte Server-ID %d steht im Konflikt mit der Startoption --replicate-same-server-id für den Slave"
 ER_QUERY_CACHE_DISABLED
-  eng "Query cache is disabled; set query_cache_type to ON or DEMAND to enable it"
+        chi "查询缓存已禁用;将query_cache_type设置为ON或DEMAND启用它"
+        eng "Query cache is disabled; set query_cache_type to ON or DEMAND to enable it"
 ER_SAME_NAME_PARTITION_FIELD
-  eng "Duplicate partition field name '%-.192s'"
-  ger "Partitionsfeld '%-.192s' ist ein Duplikat"
+        chi "重复分区字段名称'%-.192s'"
+        eng "Duplicate partition field name '%-.192s'"
+        ger "Partitionsfeld '%-.192s' ist ein Duplikat"
 ER_PARTITION_COLUMN_LIST_ERROR
-  eng "Inconsistency in usage of column lists for partitioning"
-  ger "Inkonsistenz bei der Benutzung von Spaltenlisten für Partitionierung"
+        chi "分区用的列和列表使用不一致"
+        eng "Inconsistency in usage of column lists for partitioning"
+        ger "Inkonsistenz bei der Benutzung von Spaltenlisten für Partitionierung"
 ER_WRONG_TYPE_COLUMN_VALUE_ERROR
-  eng "Partition column values of incorrect type"
-  ger "Partitionsspaltenwerte sind vom falschen Typ"
+        chi "不正确类型的分区列值"
+        eng "Partition column values of incorrect type"
+        ger "Partitionsspaltenwerte sind vom falschen Typ"
 ER_TOO_MANY_PARTITION_FUNC_FIELDS_ERROR
-  eng "Too many fields in '%-.192s'"
-  ger "Zu viele Felder in '%-.192s'"
+        chi "'%-.192s'中的太多字段"
+        eng "Too many fields in '%-.192s'"
+        ger "Zu viele Felder in '%-.192s'"
 ER_MAXVALUE_IN_VALUES_IN
-  eng "Cannot use MAXVALUE as value in VALUES IN"
-  ger "MAXVALUE kann nicht als Wert in VALUES IN verwendet werden"
+        chi "不能在VALUES IN使用MAXVALUE"
+        eng "Cannot use MAXVALUE as value in VALUES IN"
+        ger "MAXVALUE kann nicht als Wert in VALUES IN verwendet werden"
 ER_TOO_MANY_VALUES_ERROR
-  eng "Cannot have more than one value for this type of %-.64s partitioning"
-  ger "Für den Partionierungstyp %-.64s darf es nicht mehr als einen Wert geben"
+        chi "这种类型不能有多个值%-.64s 分区"
+        eng "Cannot have more than one value for this type of %-.64s partitioning"
+        ger "Für den Partionierungstyp %-.64s darf es nicht mehr als einen Wert geben"
 ER_ROW_SINGLE_PARTITION_FIELD_ERROR
-  eng "Row expressions in VALUES IN only allowed for multi-field column partitioning"
-  ger "Zeilenausdrücke in VALUES IN sind nur für Mehrfeld-Spaltenpartionierung erlaubt"
+        chi "仅允许的多字段列分区的VALUES IN的行表达式"
+        eng "Row expressions in VALUES IN only allowed for multi-field column partitioning"
+        ger "Zeilenausdrücke in VALUES IN sind nur für Mehrfeld-Spaltenpartionierung erlaubt"
 ER_FIELD_TYPE_NOT_ALLOWED_AS_PARTITION_FIELD
-  eng "Field '%-.192s' is of a not allowed type for this type of partitioning"
-  ger "Feld '%-.192s' ist für diese Art von Partitionierung von einem nicht zulässigen Typ"
+        chi "字段'%-.192s'类型不允许为此类型的分区类型"
+        eng "Field '%-.192s' is of a not allowed type for this type of partitioning"
+        ger "Feld '%-.192s' ist für diese Art von Partitionierung von einem nicht zulässigen Typ"
 ER_PARTITION_FIELDS_TOO_LONG
-  eng "The total length of the partitioning fields is too large"
-  ger "Die Gesamtlänge der Partitionsfelder ist zu groß"
+        chi "分区字段的总长度太大"
+        eng "The total length of the partitioning fields is too large"
+        ger "Die Gesamtlänge der Partitionsfelder ist zu groß"
 ER_BINLOG_ROW_ENGINE_AND_STMT_ENGINE
-  eng "Cannot execute statement: impossible to write to binary log since both row-incapable engines and statement-incapable engines are involved"
+        chi "无法执行语句：由于引擎不能支持行和语句，因此无法写入二进制日志"
+        eng "Cannot execute statement: impossible to write to binary log since both row-incapable engines and statement-incapable engines are involved"
 ER_BINLOG_ROW_MODE_AND_STMT_ENGINE
-  eng "Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = ROW and at least one table uses a storage engine limited to statement-based logging"
+        chi "无法执行语句：由于BINLOG_FORMAT =ROW和至少一个表使用存储引擎限制为基于语句的日志记录，因此无法写入二进制日志"
+        eng "Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = ROW and at least one table uses a storage engine limited to statement-based logging"
 ER_BINLOG_UNSAFE_AND_STMT_ENGINE
-  eng "Cannot execute statement: impossible to write to binary log since statement is unsafe, storage engine is limited to statement-based logging, and BINLOG_FORMAT = MIXED. %s"
+        chi "无法执行语句：由于语句不安全，无法写入二进制日志，存储引擎仅限于基于语句的日志记录，而BINLOG_FORMAT = MIXED。%s."
+        eng "Cannot execute statement: impossible to write to binary log since statement is unsafe, storage engine is limited to statement-based logging, and BINLOG_FORMAT = MIXED. %s"
 ER_BINLOG_ROW_INJECTION_AND_STMT_ENGINE
-  eng "Cannot execute statement: impossible to write to binary log since statement is in row format and at least one table uses a storage engine limited to statement-based logging"
+        chi "无法执行语句：由于语句以行格式，至少一个表使用基于语句的日志记录的存储引擎，因此无法写入二进制日志。"
+        eng "Cannot execute statement: impossible to write to binary log since statement is in row format and at least one table uses a storage engine limited to statement-based logging"
 ER_BINLOG_STMT_MODE_AND_ROW_ENGINE
-  eng "Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging.%s"
+        chi "无法执行语句：由于BINLOG_FORMAT = STATEMENT，并且至少一个表使用存储引擎限制为基于行的日志记录，因此无法写入二进制日志。%s"
+        eng "Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT and at least one table uses a storage engine limited to row-based logging.%s"
 ER_BINLOG_ROW_INJECTION_AND_STMT_MODE
-  eng "Cannot execute statement: impossible to write to binary log since statement is in row format and BINLOG_FORMAT = STATEMENT"
+        chi "无法执行语句：由于语句的正常格式和BINLOG_FORMAT = STATEMENT，因此无法写入二进制日志"
+        eng "Cannot execute statement: impossible to write to binary log since statement is in row format and BINLOG_FORMAT = STATEMENT"
 ER_BINLOG_MULTIPLE_ENGINES_AND_SELF_LOGGING_ENGINE
-  eng "Cannot execute statement: impossible to write to binary log since more than one engine is involved and at least one engine is self-logging"
-
+        chi "无法执行语句：由于涉及多个引擎并且至少有一个引擎是自记录的，因此无法写入二进制日志。"
+        eng "Cannot execute statement: impossible to write to binary log since more than one engine is involved and at least one engine is self-logging"
 ER_BINLOG_UNSAFE_LIMIT
-  eng "The statement is unsafe because it uses a LIMIT clause. This is unsafe because the set of rows included cannot be predicted"
+        chi "该语句不安全，因为它使用限制子句。这不安全，因为所包含的一组行无法预测"
+        eng "The statement is unsafe because it uses a LIMIT clause. This is unsafe because the set of rows included cannot be predicted"
 ER_BINLOG_UNSAFE_INSERT_DELAYED
-  eng "The statement is unsafe because it uses INSERT DELAYED. This is unsafe because the times when rows are inserted cannot be predicted"
+        chi "该声明不安全，因为它使用插入延迟。这是不安全的，因为无法预测插入行的时间"
+        eng "The statement is unsafe because it uses INSERT DELAYED. This is unsafe because the times when rows are inserted cannot be predicted"
 ER_BINLOG_UNSAFE_SYSTEM_TABLE
-  eng "The statement is unsafe because it uses the general log, slow query log, or performance_schema table(s). This is unsafe because system tables may differ on slaves"
+        chi "该声明不安全，因为它使用常规日志，慢查询日志或performance_schema表。这是不安全的，因为系统表可能在slave上不同"
+        eng "The statement is unsafe because it uses the general log, slow query log, or performance_schema table(s). This is unsafe because system tables may differ on slaves"
 ER_BINLOG_UNSAFE_AUTOINC_COLUMNS
-  eng "Statement is unsafe because it invokes a trigger or a stored function that inserts into an AUTO_INCREMENT column. Inserted values cannot be logged correctly"
+        chi "语句不安全，因为它调用了插入AUTO_INCREMENT列的触发器或存储函数。插入的值无法正确记录"
+        eng "Statement is unsafe because it invokes a trigger or a stored function that inserts into an AUTO_INCREMENT column. Inserted values cannot be logged correctly"
 ER_BINLOG_UNSAFE_UDF
-  eng "Statement is unsafe because it uses a UDF which may not return the same value on the slave"
+        chi "语句不安全，因为它使用了一个可能在从设备上返回相同值的UDF"
+        eng "Statement is unsafe because it uses a UDF which may not return the same value on the slave"
 ER_BINLOG_UNSAFE_SYSTEM_VARIABLE
-  eng "Statement is unsafe because it uses a system variable that may have a different value on the slave"
+        chi "语句不安全，因为它使用的系统变量可能在从站上具有不同的值"
+        eng "Statement is unsafe because it uses a system variable that may have a different value on the slave"
 ER_BINLOG_UNSAFE_SYSTEM_FUNCTION
-  eng "Statement is unsafe because it uses a system function that may return a different value on the slave"
+        chi "语句不安全，因为它使用系统函数可能在从站上返回不同的值"
+        eng "Statement is unsafe because it uses a system function that may return a different value on the slave"
 ER_BINLOG_UNSAFE_NONTRANS_AFTER_TRANS
-  eng "Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction"
-
+        chi "语句不安全，因为它在访问同一事务中访问事务表后访问非事务性表"
+        eng "Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction"
 ER_MESSAGE_AND_STATEMENT
-  eng "%s Statement: %s"
-
+        chi "%s语句：%s"
+        eng "%s Statement: %s"
 ER_SLAVE_CONVERSION_FAILED
-  eng "Column %d of table '%-.192s.%-.192s' cannot be converted from type '%-.50s' to type '%-.50s'"
+        chi "列%d表'%-.192s.%-.192s'无法从'%-.50s'类型为'%-.50s'"
+        eng "Column %d of table '%-.192s.%-.192s' cannot be converted from type '%-.50s' to type '%-.50s'"
 ER_SLAVE_CANT_CREATE_CONVERSION
-  eng "Can't create conversion table for table '%-.192s.%-.192s'"
+        chi "无法为表创建转换表'%-.192s.%-.192s'"
+        eng "Can't create conversion table for table '%-.192s.%-.192s'"
 ER_INSIDE_TRANSACTION_PREVENTS_SWITCH_BINLOG_FORMAT
-  eng "Cannot modify @@session.binlog_format inside a transaction"
+        chi "无法在事务中修改@@session.binlog_format"
+        eng "Cannot modify @@session.binlog_format inside a transaction"
 ER_PATH_LENGTH
-  eng "The path specified for %.64T is too long"
-  hindi "%.64T के लिए निर्दिष्ट पथ बहुत लंबा है"
+        chi "指定%.64T的路径太长了"
+        eng "The path specified for %.64T is too long"
+        hindi "%.64T के लिए निर्दिष्ट पथ बहुत लंबा है"
 ER_WARN_DEPRECATED_SYNTAX_NO_REPLACEMENT  
-  eng "'%s' is deprecated and will be removed in a future release"
-  ger "'%s' ist veraltet und wird in einer zukünftigen Version entfernt werden"
-
+        chi "'%s'被弃用，将在将来的版本中删除"
+        eng "'%s' is deprecated and will be removed in a future release"
+        ger "'%s' ist veraltet und wird in einer zukünftigen Version entfernt werden"
 ER_WRONG_NATIVE_TABLE_STRUCTURE
+        chi "本机表'%-.64s'。'%-.64s'具有错误的结构"
         eng "Native table '%-.64s'.'%-.64s' has the wrong structure"
-
 ER_WRONG_PERFSCHEMA_USAGE
+        chi "performance_schema使用无效"
         eng "Invalid performance_schema usage"
         hindi "performance_schema का अवैध उपयोग"
 ER_WARN_I_S_SKIPPED_TABLE
-  eng "Table '%s'.'%s' was skipped since its definition is being modified by concurrent DDL statement"
-
+        chi "表'%s'.'%s'由于并发DDL语句正在修改其定义，因此跳过"
+        eng "Table '%s'.'%s' was skipped since its definition is being modified by concurrent DDL statement"
 ER_INSIDE_TRANSACTION_PREVENTS_SWITCH_BINLOG_DIRECT
-  eng "Cannot modify @@session.binlog_direct_non_transactional_updates inside a transaction"
+        chi "无法在交易事务中修改@@session.binlog_direct_non_transactional_updates"
+        eng "Cannot modify @@session.binlog_direct_non_transactional_updates inside a transaction"
 ER_STORED_FUNCTION_PREVENTS_SWITCH_BINLOG_DIRECT
-  eng "Cannot change the binlog direct flag inside a stored function or trigger"
+        chi "无法在存储的函数或触发器内更改Binlog Direct标志"
+        eng "Cannot change the binlog direct flag inside a stored function or trigger"
 ER_SPATIAL_MUST_HAVE_GEOM_COL 42000
-  eng "A SPATIAL index may only contain a geometrical type column"
-  ger "Ein raumbezogener Index (SPATIAL) darf nur Spalten geometrischen Typs enthalten"
+        chi "空间索引可以仅包含几何类型列"
+        eng "A SPATIAL index may only contain a geometrical type column"
+        ger "Ein raumbezogener Index (SPATIAL) darf nur Spalten geometrischen Typs enthalten"
 ER_TOO_LONG_INDEX_COMMENT
-  eng "Comment for index '%-.64s' is too long (max = %lu)"
-
+        chi "索引评论'%-.64s'太长（max =%lu）"
+        eng "Comment for index '%-.64s' is too long (max = %lu)"
 ER_LOCK_ABORTED
-  eng "Wait on a lock was aborted due to a pending exclusive lock"
-
+        chi "由于待处理的独家锁，等待锁被中止"
+        eng "Wait on a lock was aborted due to a pending exclusive lock"
 ER_DATA_OUT_OF_RANGE 22003 
-  eng "%s value is out of range in '%s'"
-
+        chi "%s值超出'%s'范围"
+        eng "%s value is out of range in '%s'"
 ER_WRONG_SPVAR_TYPE_IN_LIMIT
-  eng "A variable of a non-integer based type in LIMIT clause"
-
+        chi "基于非整数类型的基于LIMIT子句的变量"
+        eng "A variable of a non-integer based type in LIMIT clause"
 ER_BINLOG_UNSAFE_MULTIPLE_ENGINES_AND_SELF_LOGGING_ENGINE
-  eng "Mixing self-logging and non-self-logging engines in a statement is unsafe"
-
+        chi "混合声明中的自记录和非自动记录引擎是不安全的"
+        eng "Mixing self-logging and non-self-logging engines in a statement is unsafe"
 ER_BINLOG_UNSAFE_MIXED_STATEMENT
-  eng "Statement accesses nontransactional table as well as transactional or temporary table, and writes to any of them"
-
+        chi "语句访问非致突变表以及事务性或临时表，并写入其中任何一个"
+        eng "Statement accesses nontransactional table as well as transactional or temporary table, and writes to any of them"
 ER_INSIDE_TRANSACTION_PREVENTS_SWITCH_SQL_LOG_BIN
-  eng "Cannot modify @@session.sql_log_bin inside a transaction"
-
+        chi "无法修改事务中的@@sessient.sql_log_bin"
+        eng "Cannot modify @@session.sql_log_bin inside a transaction"
 ER_STORED_FUNCTION_PREVENTS_SWITCH_SQL_LOG_BIN
-  eng "Cannot change the sql_log_bin inside a stored function or trigger"
-
+        chi "无法在存储的函数或触发器内更改SQL_LOG_BIN"
+        eng "Cannot change the sql_log_bin inside a stored function or trigger"
 ER_FAILED_READ_FROM_PAR_FILE
-  eng "Failed to read from the .par file"
-  hindi ".par फ़ाइल से पढ़ने में असफल रहे"
-  swe "Misslyckades läsa från .par filen"
-
+        chi "无法从.par文件中读取"
+        eng "Failed to read from the .par file"
+        hindi ".par फ़ाइल से पढ़ने में असफल रहे"
+        swe "Misslyckades läsa från .par filen"
 ER_VALUES_IS_NOT_INT_TYPE_ERROR
-  eng "VALUES value for partition '%-.64s' must have type INT"
-  swe "Värden i VALUES för partition '%-.64s' måste ha typen INT"
-
+        chi "分区的值'%-.64s'必须具有类型INT"
+        eng "VALUES value for partition '%-.64s' must have type INT"
+        swe "Värden i VALUES för partition '%-.64s' måste ha typen INT"
 ER_ACCESS_DENIED_NO_PASSWORD_ERROR 28000 
+        chi "拒绝用户'%s'@'%s'"
         cze "Přístup pro uživatele '%s'@'%s'"
         dan "Adgang nægtet bruger: '%s'@'%s'"
-        nla "Toegang geweigerd voor gebruiker: '%s'@'%s'"
         eng "Access denied for user '%s'@'%s'"
         est "Ligipääs keelatud kasutajale '%s'@'%s'"
         fre "Accès refusé pour l'utilisateur: '%s'@'%s'"
@@ -6547,6 +7220,7 @@ ER_ACCESS_DENIED_NO_PASSWORD_ERROR 28000
         hun "A(z) '%s'@'%s' felhasznalo szamara tiltott eleres"
         ita "Accesso non consentito per l'utente: '%s'@'%s'"
         kor "'%s'@'%s' 사용자는 접근이 거부 되었습니다."
+        nla "Toegang geweigerd voor gebruiker: '%s'@'%s'"
         nor "Tilgang nektet for bruker: '%s'@'%s'"
         norwegian-ny "Tilgang ikke tillate for brukar: '%s'@'%s'"
         por "Acesso negado para o usuário '%s'@'%s'"
@@ -6559,800 +7233,1056 @@ ER_ACCESS_DENIED_NO_PASSWORD_ERROR 28000
         ukr "Доступ заборонено для користувача: '%s'@'%s'"
 
 ER_SET_PASSWORD_AUTH_PLUGIN
+        chi "通过%s插件验证的用户忽略SET PASSWORD"
         eng "SET PASSWORD is ignored for users authenticating via %s plugin"
 
 ER_GRANT_PLUGIN_USER_EXISTS
+        chi "由于用户%-.*s已经存在，GRANT IDENTIFIED WITH授权是非法的"
         eng "GRANT with IDENTIFIED WITH is illegal because the user %-.*s already exists"
 
 ER_TRUNCATE_ILLEGAL_FK 42000
-  eng "Cannot truncate a table referenced in a foreign key constraint (%.192s)"
+        chi "无法截断外键约束中引用的表（%.192s）"
+        eng "Cannot truncate a table referenced in a foreign key constraint (%.192s)"
 
 ER_PLUGIN_IS_PERMANENT
-  eng "Plugin '%s' is force_plus_permanent and can not be unloaded"
+        chi "插件'%s'是force_plus_permanent，无法卸载"
+        eng "Plugin '%s' is force_plus_permanent and can not be unloaded"
 
 ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MIN
-  eng "The requested value for the heartbeat period is less than 1 millisecond. The value is reset to 0, meaning that heartbeating will effectively be disabled"
+        chi "心跳期的要求值小于1毫秒。该值重置为0，这意味着心跳将有效地禁用"
+        eng "The requested value for the heartbeat period is less than 1 millisecond. The value is reset to 0, meaning that heartbeating will effectively be disabled"
 
 ER_SLAVE_HEARTBEAT_VALUE_OUT_OF_RANGE_MAX
-  eng "The requested value for the heartbeat period exceeds the value of `slave_net_timeout' seconds. A sensible value for the period should be less than the timeout"
+        chi "心跳期的请求值超出了“slave_net_timeout”秒的值。该期间的明智价值应小于超时"
+        eng "The requested value for the heartbeat period exceeds the value of `slave_net_timeout' seconds. A sensible value for the period should be less than the timeout"
 
 ER_STMT_CACHE_FULL  
+        chi "需要多行语句超过“max_binlog_stmt_cache_size”字节的存储;增加这个mysqld变量，然后重试"
         eng "Multi-row statements required more than 'max_binlog_stmt_cache_size' bytes of storage; increase this mysqld variable and try again"
 
 ER_MULTI_UPDATE_KEY_CONFLICT
-  eng "Primary key/partition key update is not allowed since the table is updated both as '%-.192s' and '%-.192s'"
-
+        chi "由于表格被更新为'%-.192s'和'%-.192s'，因此不允许允许主键/分区索引更新。"
+        eng "Primary key/partition key update is not allowed since the table is updated both as '%-.192s' and '%-.192s'"
 # When translating this error message make sure to include "ALTER TABLE" in the
 # message as mysqlcheck parses the error message looking for ALTER TABLE.
-ER_TABLE_NEEDS_REBUILD
-        eng "Table rebuild required. Please do \"ALTER TABLE %`s FORCE\" or dump/reload to fix it!"
 
+ER_TABLE_NEEDS_REBUILD
+        chi "表需重建。请做ALTER TABLE %`s FORCE”或转储/重新加载以修复它！"
+        eng "Table rebuild required. Please do \"ALTER TABLE %`s FORCE\" or dump/reload to fix it!"
 WARN_OPTION_BELOW_LIMIT
-  eng "The value of '%s' should be no less than the value of '%s'"
+        chi "'%s'的值应该不小于'%s'的值"
+        eng "The value of '%s' should be no less than the value of '%s'"
 
 ER_INDEX_COLUMN_TOO_LONG
-  eng "Index column size too large. The maximum column size is %lu bytes"
+        chi "索引列太大。最大列大小为%lu字节"
+        eng "Index column size too large. The maximum column size is %lu bytes"
 
 ER_ERROR_IN_TRIGGER_BODY
-  eng "Trigger '%-.64s' has an error in its body: '%-.256s'"
+        chi "触发器'%-.64s'内存在错误：'%-.256s'"
+        eng "Trigger '%-.64s' has an error in its body: '%-.256s'"
 
 ER_ERROR_IN_UNKNOWN_TRIGGER_BODY
-  eng "Unknown trigger has an error in its body: '%-.256s'"
+        chi "未知触发器内存在错误：'%-.256s'"
+        eng "Unknown trigger has an error in its body: '%-.256s'"
 
 ER_INDEX_CORRUPT
-  eng "Index %s is corrupted"
+        chi "索引%s已损坏"
+        eng "Index %s is corrupted"
 
 ER_UNDO_RECORD_TOO_BIG
-  eng "Undo log record is too big"
+        chi "撤消日志记录太大"
+        eng "Undo log record is too big"
 
 ER_BINLOG_UNSAFE_INSERT_IGNORE_SELECT
-  eng "INSERT IGNORE... SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are ignored. This order cannot be predicted and may differ on master and the slave"
+        chi "INSERT IGNORE...SELECT不安全，因为选择由select检索行的顺序确定哪个（如果有）行被忽略。无法预测此顺序，并且在master和slave方面可能有所不同" 
+        eng "INSERT IGNORE... SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are ignored. This order cannot be predicted and may differ on master and the slave"
 
 ER_BINLOG_UNSAFE_INSERT_SELECT_UPDATE
-  eng "INSERT... SELECT... ON DUPLICATE KEY UPDATE is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are updated. This order cannot be predicted and may differ on master and the slave"
+        chi "INSERT... SELECT... ON DUPLICATE KEY UPDATE是不安全的，因为SELECT检索行的顺序确定哪个（如果有的话）是更新的。无法预测此顺序，并且在master和slave方面可能有所不同"
+        eng "INSERT... SELECT... ON DUPLICATE KEY UPDATE is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are updated. This order cannot be predicted and may differ on master and the slave"
 
 ER_BINLOG_UNSAFE_REPLACE_SELECT
- eng "REPLACE... SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are replaced. This order cannot be predicted and may differ on master and the slave"
+        chi "REPLACE... SELECT 不安全，因为选择由select检索行的顺序确定哪个（如果有）行被替换。无法预测此顺序，并且在master和slave方面可能有所不同"
+        eng "REPLACE... SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are replaced. This order cannot be predicted and may differ on master and the slave"
 
 ER_BINLOG_UNSAFE_CREATE_IGNORE_SELECT
-  eng "CREATE... IGNORE SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are ignored. This order cannot be predicted and may differ on master and the slave"
+        chi "CREATE... IGNORE SELECT是不安全，因为选择由SELECT检索行的顺序确定哪个（如果有）行被忽略。无法预测此顺序，并且在master和slave方面可能有所不同"
+        eng "CREATE... IGNORE SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are ignored. This order cannot be predicted and may differ on master and the slave"
 
 ER_BINLOG_UNSAFE_CREATE_REPLACE_SELECT
-  eng "CREATE... REPLACE SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are replaced. This order cannot be predicted and may differ on master and the slave"
+        chi "CREATE... REPLACE SELECT不安全，因为选择由SELECT检索行的顺序确定哪个（如果有）是替换哪个（如果有的话）。无法预测此顺序，并且在master和slave方面可能有所不同"
+        eng "CREATE... REPLACE SELECT is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are replaced. This order cannot be predicted and may differ on master and the slave"
 
 ER_BINLOG_UNSAFE_UPDATE_IGNORE
-  eng "UPDATE IGNORE is unsafe because the order in which rows are updated determines which (if any) rows are ignored. This order cannot be predicted and may differ on master and the slave"
+        chi "UPDATE IGNORE不安全，因为更新行的顺序确定了哪个（如果有）行被忽略。无法预测此顺序，并且在master和slave方面可能有所不同"
+        eng "UPDATE IGNORE is unsafe because the order in which rows are updated determines which (if any) rows are ignored. This order cannot be predicted and may differ on master and the slave"
 
 ER_UNUSED_15
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 
 ER_UNUSED_16
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 
 ER_BINLOG_UNSAFE_WRITE_AUTOINC_SELECT
-  eng "Statements writing to a table with an auto-increment column after selecting from another table are unsafe because the order in which rows are retrieved determines what (if any) rows will be written. This order cannot be predicted and may differ on master and the slave"
+        chi "从另一个表选择后，使用自动增量列的表格写入的语句是不安全的，因为检索行的顺序确定将写入哪些（如果有）行。无法预测此顺序，并且在主站和slave方面可能有所不同"
+        eng "Statements writing to a table with an auto-increment column after selecting from another table are unsafe because the order in which rows are retrieved determines what (if any) rows will be written. This order cannot be predicted and may differ on master and the slave"
 
 ER_BINLOG_UNSAFE_CREATE_SELECT_AUTOINC
-  eng "CREATE TABLE... SELECT...  on a table with an auto-increment column is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are inserted. This order cannot be predicted and may differ on master and the slave"
+        chi "创建表...在具有自动增量列的表上选择...不安全，因为选择的顺序是由select检索行的顺序，确定插入哪个（如果有）行。无法预测此订单，并且在主站和slave方面可能有所不同"
+        eng "CREATE TABLE... SELECT...  on a table with an auto-increment column is unsafe because the order in which rows are retrieved by the SELECT determines which (if any) rows are inserted. This order cannot be predicted and may differ on master and the slave"
 
 ER_BINLOG_UNSAFE_INSERT_TWO_KEYS
-  eng "INSERT... ON DUPLICATE KEY UPDATE  on a table with more than one UNIQUE KEY is unsafe"
+        chi "在具有多个唯一键的表上INSERT... ON DUPLICATE KEY UPDATE的重复索引更新是不安全的"
+        eng "INSERT... ON DUPLICATE KEY UPDATE  on a table with more than one UNIQUE KEY is unsafe"
 
 ER_TABLE_IN_FK_CHECK
-  eng "Table is being used in foreign key check"
+        chi "外键检查在用此表"
+        eng "Table is being used in foreign key check"
 
 ER_VERS_NOT_ALLOWED
-  eng "Not allowed for system-versioned table %`s.%`s"
+        chi "系统版本的表%`s.%`s不允许"
+        eng "Not allowed for system-versioned table %`s.%`s"
 
 ER_BINLOG_UNSAFE_AUTOINC_NOT_FIRST
-  eng "INSERT into autoincrement field which is not the first part in the composed primary key is unsafe"
-
+        chi "插入AutoIncrement字段，该字段不是组成的主键中的第一部分是不安全的"
+        eng "INSERT into autoincrement field which is not the first part in the composed primary key is unsafe"
 #
 #  End of 5.5 error messages.
 #
 
 ER_CANNOT_LOAD_FROM_TABLE_V2
-  eng "Cannot load from %s.%s. The table is probably corrupted"
-  ger "Kann %s.%s nicht einlesen. Tabelle ist wahrscheinlich beschädigt"
+        chi "不能从加载%s.%s。表可能损坏了"
+        eng "Cannot load from %s.%s. The table is probably corrupted"
+        ger "Kann %s.%s nicht einlesen. Tabelle ist wahrscheinlich beschädigt"
 
 ER_MASTER_DELAY_VALUE_OUT_OF_RANGE
-  eng "The requested value %lu for the master delay exceeds the maximum %lu"
+        chi "主延迟的所需值%lu超过最大%lu"
+        eng "The requested value %lu for the master delay exceeds the maximum %lu"
 ER_ONLY_FD_AND_RBR_EVENTS_ALLOWED_IN_BINLOG_STATEMENT
-  eng "Only Format_description_log_event and row events are allowed in BINLOG statements (but %s was provided)"
+        chi "在Binlog语句中只允许Format_Description_Log_Event和行事件（但是提供了%s）"
+        eng "Only Format_description_log_event and row events are allowed in BINLOG statements (but %s was provided)"
 
 ER_PARTITION_EXCHANGE_DIFFERENT_OPTION
-  eng "Non matching attribute '%-.64s' between partition and table"
-  swe "Attributet '%-.64s' är olika mellan partition och tabell"
+        chi "分区和表之间的非匹配属性'%-.64s'"
+        eng "Non matching attribute '%-.64s' between partition and table"
+        swe "Attributet '%-.64s' är olika mellan partition och tabell"
 ER_PARTITION_EXCHANGE_PART_TABLE
-  eng "Table to exchange with partition is partitioned: '%-.64s'"
-  swe "Tabellen att byta ut mot partition är partitionerad: '%-.64s'"
+        chi "用分区交换的表是分区：'%-.64s'"
+        eng "Table to exchange with partition is partitioned: '%-.64s'"
+        swe "Tabellen att byta ut mot partition är partitionerad: '%-.64s'"
 ER_PARTITION_EXCHANGE_TEMP_TABLE
-  eng "Table to exchange with partition is temporary: '%-.64s'"
-  swe "Tabellen att byta ut mot partition är temporär: '%-.64s'"
+        chi "与分区交换的表是临时的：'%-.64s'"
+        eng "Table to exchange with partition is temporary: '%-.64s'"
+        swe "Tabellen att byta ut mot partition är temporär: '%-.64s'"
 ER_PARTITION_INSTEAD_OF_SUBPARTITION
-  eng "Subpartitioned table, use subpartition instead of partition"
-  swe "Subpartitionerad tabell, använd subpartition istället för partition"
+        chi "子分区表，使用子分区代替分区"
+        eng "Subpartitioned table, use subpartition instead of partition"
+        swe "Subpartitionerad tabell, använd subpartition istället för partition"
 ER_UNKNOWN_PARTITION
-  eng "Unknown partition '%-.64s' in table '%-.64s'"
-  swe "Okänd partition '%-.64s' i tabell '%-.64s'"
+        chi "未知分区'%-.64s'在表'%-.64s'"
+        eng "Unknown partition '%-.64s' in table '%-.64s'"
+        swe "Okänd partition '%-.64s' i tabell '%-.64s'"
 ER_TABLES_DIFFERENT_METADATA
-  eng "Tables have different definitions"
-  swe "Tabellerna har olika definitioner"
+        chi "表有不同的定义"
+        eng "Tables have different definitions"
+        swe "Tabellerna har olika definitioner"
 ER_ROW_DOES_NOT_MATCH_PARTITION
-  eng "Found a row that does not match the partition"
-  swe "Hittade en rad som inte passar i partitionen"
+        chi "找到了与分区不匹配的行"
+        eng "Found a row that does not match the partition"
+        swe "Hittade en rad som inte passar i partitionen"
 ER_BINLOG_CACHE_SIZE_GREATER_THAN_MAX
-  eng "Option binlog_cache_size (%lu) is greater than max_binlog_cache_size (%lu); setting binlog_cache_size equal to max_binlog_cache_size"
+        chi "选项binlog_cache_size（%lu）大于max_binlog_cache_size（%lu）;设置binlog_cache_size等于max_binlog_cache_size"
+        eng "Option binlog_cache_size (%lu) is greater than max_binlog_cache_size (%lu); setting binlog_cache_size equal to max_binlog_cache_size"
 ER_WARN_INDEX_NOT_APPLICABLE
-  eng "Cannot use %-.64s access on index '%-.64s' due to type or collation conversion on field '%-.64s'"
+        chi "不能使用%-.64s在索引'%-.64s'上的访问，由于字段'%-.64s”的类型或排序规则转换"
+        eng "Cannot use %-.64s access on index '%-.64s' due to type or collation conversion on field '%-.64s'"
 
 ER_PARTITION_EXCHANGE_FOREIGN_KEY
-  eng "Table to exchange with partition has foreign key references: '%-.64s'"
-  swe "Tabellen att byta ut mot partition har foreign key referenser: '%-.64s'"
+        chi "与分区交换的表具有外键参考：'%-.64s'"
+        eng "Table to exchange with partition has foreign key references: '%-.64s'"
+        swe "Tabellen att byta ut mot partition har foreign key referenser: '%-.64s'"
 ER_NO_SUCH_KEY_VALUE
-  eng "Key value '%-.192s' was not found in table '%-.192s.%-.192s'"
+        chi "键值'%-.192s'在表'%-.192s%-.192s'不存在"
+        eng "Key value '%-.192s' was not found in table '%-.192s.%-.192s'"
 ER_VALUE_TOO_LONG
-  eng "Too long value for '%s'"
+        chi "'%s'的价值太长了"
+        eng "Too long value for '%s'"
 ER_NETWORK_READ_EVENT_CHECKSUM_FAILURE
-  eng "Replication event checksum verification failed while reading from network"
+        chi "从网络读取时，复制事件校验和验证失败"
+        eng "Replication event checksum verification failed while reading from network"
 ER_BINLOG_READ_EVENT_CHECKSUM_FAILURE
-  eng "Replication event checksum verification failed while reading from a log file"
+        chi "从日志文件读取时复制事件校验和验证失败"
+        eng "Replication event checksum verification failed while reading from a log file"
 
 ER_BINLOG_STMT_CACHE_SIZE_GREATER_THAN_MAX
-  eng "Option binlog_stmt_cache_size (%lu) is greater than max_binlog_stmt_cache_size (%lu); setting binlog_stmt_cache_size equal to max_binlog_stmt_cache_size"
+        chi "选项binlog_stmt_cache_size（%lu）大于max_binlog_stmt_cache_size（%lu）;设置binlog_stmt_cache_size等于max_binlog_stmt_cache_size"
+        eng "Option binlog_stmt_cache_size (%lu) is greater than max_binlog_stmt_cache_size (%lu); setting binlog_stmt_cache_size equal to max_binlog_stmt_cache_size"
 ER_CANT_UPDATE_TABLE_IN_CREATE_TABLE_SELECT
-  eng "Can't update table '%-.192s' while '%-.192s' is being created"
+        chi "无法更新表'%-.192s'正在创建'%-.192s'"
+        eng "Can't update table '%-.192s' while '%-.192s' is being created"
 
 ER_PARTITION_CLAUSE_ON_NONPARTITIONED
-  eng "PARTITION () clause on non partitioned table"
-  swe "PARTITION () klausul för en icke partitionerad tabell"
+        chi "非分区表上的PARTITION（）子句"
+        eng "PARTITION () clause on non partitioned table"
+        swe "PARTITION () klausul för en icke partitionerad tabell"
 ER_ROW_DOES_NOT_MATCH_GIVEN_PARTITION_SET
-  eng "Found a row not matching the given partition set"
-  swe "Hittade en rad som inte passar i någon given partition"
+        chi "发现不匹配给定分区集的行"
+        eng "Found a row not matching the given partition set"
+        swe "Hittade en rad som inte passar i någon given partition"
 
 ER_UNUSED_5
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 
 ER_CHANGE_RPL_INFO_REPOSITORY_FAILURE
-  eng "Failure while changing the type of replication repository: %s"
+        chi "更改Replication存储库类型时失败：%s"
+        eng "Failure while changing the type of replication repository: %s"
 
 ER_WARNING_NOT_COMPLETE_ROLLBACK_WITH_CREATED_TEMP_TABLE
-  eng "The creation of some temporary tables could not be rolled back"
+        chi "无法回滚一些临时表的创建"
+        eng "The creation of some temporary tables could not be rolled back"
 ER_WARNING_NOT_COMPLETE_ROLLBACK_WITH_DROPPED_TEMP_TABLE
-  eng "Some temporary tables were dropped, but these operations could not be rolled back"
+        chi "一些临时表被删除，但这些操作无法回滚"
+        eng "Some temporary tables were dropped, but these operations could not be rolled back"
 
 ER_MTS_FEATURE_IS_NOT_SUPPORTED
-  eng "%s is not supported in multi-threaded slave mode. %s"
+        chi "%s不支持多线程从模式。%s."
+        eng "%s is not supported in multi-threaded slave mode. %s"
 ER_MTS_UPDATED_DBS_GREATER_MAX
-  eng "The number of modified databases exceeds the maximum %d; the database names will not be included in the replication event metadata"
+        chi "修改的数据库的数量超过了最大%d;数据库名称不会包含在Replication事件元数据中"
+        eng "The number of modified databases exceeds the maximum %d; the database names will not be included in the replication event metadata"
 ER_MTS_CANT_PARALLEL
-  eng "Cannot execute the current event group in the parallel mode. Encountered event %s, relay-log name %s, position %s which prevents execution of this event group in parallel mode. Reason: %s"
+        chi "无法以并行模式执行当前事件组。遇到事件%s，中继日志名称%s，position%s，它防止并行模式执行此事件组。原因：%s"
+        eng "Cannot execute the current event group in the parallel mode. Encountered event %s, relay-log name %s, position %s which prevents execution of this event group in parallel mode. Reason: %s"
 ER_MTS_INCONSISTENT_DATA
-  eng "%s"
+        eng "%s"
 
 ER_FULLTEXT_NOT_SUPPORTED_WITH_PARTITIONING
-  eng "FULLTEXT index is not supported for partitioned tables"
-  swe "FULLTEXT index stöds ej för partitionerade tabeller"
+        chi "分区表不支持FullText索引"
+        eng "FULLTEXT index is not supported for partitioned tables"
+        swe "FULLTEXT index stöds ej för partitionerade tabeller"
 
 ER_DA_INVALID_CONDITION_NUMBER 35000
-  eng "Invalid condition number"
-  por "Número de condição inválido"
+        chi "无效条件号"
+        eng "Invalid condition number"
+        por "Número de condição inválido"
 
 ER_INSECURE_PLAIN_TEXT
-  eng "Sending passwords in plain text without SSL/TLS is extremely insecure"
+        chi "在没有SSL/TLS的纯文本中发送密码非常不安全"
+        eng "Sending passwords in plain text without SSL/TLS is extremely insecure"
 
 ER_INSECURE_CHANGE_MASTER
-  eng "Storing MariaDB user name or password information in the master.info repository is not secure and is therefore not recommended. Please see the MariaDB Manual for more about this issue and possible alternatives"
+        chi "在Master.Info存储库中存储MariaDB用户名或密码信息不安全，因此不建议使用。有关此问题和可能的替代方案，请参阅MariaDB手册"
+        eng "Storing MariaDB user name or password information in the master.info repository is not secure and is therefore not recommended. Please see the MariaDB Manual for more about this issue and possible alternatives"
 
 ER_FOREIGN_DUPLICATE_KEY_WITH_CHILD_INFO 23000 S1009
+        chi "表'%.192s'的外键约束，记录'%-.192s'会导致表'%.192s'中的重复条目，键'%.192s'"
         eng "Foreign key constraint for table '%.192s', record '%-.192s' would lead to a duplicate entry in table '%.192s', key '%.192s'"
         ger "Fremdschlüssel-Beschränkung für Tabelle '%.192s', Datensatz '%-.192s' würde zu einem doppelten Eintrag in Tabelle '%.192s', Schlüssel '%.192s' führen"
         swe "FOREIGN KEY constraint för tabell '%.192s', posten '%-.192s' kan inte uppdatera barntabell '%.192s' på grund av nyckel '%.192s'"
 
 ER_FOREIGN_DUPLICATE_KEY_WITHOUT_CHILD_INFO 23000 S1009
+        chi "表'%.192s'的外键约束，记录'%-.192s'会导致子表中的重复条目"
         eng "Foreign key constraint for table '%.192s', record '%-.192s' would lead to a duplicate entry in a child table"
         ger "Fremdschlüssel-Beschränkung für Tabelle '%.192s', Datensatz '%-.192s' würde zu einem doppelten Eintrag in einer Kind-Tabelle führen"
         swe "FOREIGN KEY constraint för tabell '%.192s', posten '%-.192s' kan inte uppdatera en barntabell på grund av UNIQUE-test"
 
 ER_SQLTHREAD_WITH_SECURE_SLAVE
-  eng "Setting authentication options is not possible when only the Slave SQL Thread is being started"
+        chi "仅在启动从SQL线程时无法设置身份验证选项"
+        eng "Setting authentication options is not possible when only the Slave SQL Thread is being started"
 
 ER_TABLE_HAS_NO_FT
-  eng "The table does not have FULLTEXT index to support this query"
+        chi "该表没有全文索引来支持此查询"
+        eng "The table does not have FULLTEXT index to support this query"
 
 ER_VARIABLE_NOT_SETTABLE_IN_SF_OR_TRIGGER
-  eng "The system variable %.200s cannot be set in stored functions or triggers"
+        chi "无法在存储的函数或触发器中设置系统变量%.200s"
+        eng "The system variable %.200s cannot be set in stored functions or triggers"
 
 ER_VARIABLE_NOT_SETTABLE_IN_TRANSACTION
-  eng "The system variable %.200s cannot be set when there is an ongoing transaction"
+        chi "持续交易时，无法设置系统变量%.200s"
+        eng "The system variable %.200s cannot be set when there is an ongoing transaction"
 
 ER_GTID_NEXT_IS_NOT_IN_GTID_NEXT_LIST
-  eng "The system variable @@SESSION.GTID_NEXT has the value %.200s, which is not listed in @@SESSION.GTID_NEXT_LIST"
+        chi "系统变量@@session.gtid_next具有值%.200s，该值未在@@session.gtid_next_list中列出"
+        eng "The system variable @@SESSION.GTID_NEXT has the value %.200s, which is not listed in @@SESSION.GTID_NEXT_LIST"
 
 ER_CANT_CHANGE_GTID_NEXT_IN_TRANSACTION_WHEN_GTID_NEXT_LIST_IS_NULL
-  eng "When @@SESSION.GTID_NEXT_LIST == NULL, the system variable @@SESSION.GTID_NEXT cannot change inside a transaction"
+        chi "当@@session.gtid_next_list == null时，系统变量@@session.gtid_next无法在事务内更改"
+        eng "When @@SESSION.GTID_NEXT_LIST == NULL, the system variable @@SESSION.GTID_NEXT cannot change inside a transaction"
 
 ER_SET_STATEMENT_CANNOT_INVOKE_FUNCTION
-  eng "The statement 'SET %.200s' cannot invoke a stored function"
+        chi "语句'SET %.200s'无法调用存储的函数"
+        eng "The statement 'SET %.200s' cannot invoke a stored function"
 
 ER_GTID_NEXT_CANT_BE_AUTOMATIC_IF_GTID_NEXT_LIST_IS_NON_NULL
-  eng "The system variable @@SESSION.GTID_NEXT cannot be 'AUTOMATIC' when @@SESSION.GTID_NEXT_LIST is non-NULL"
+        chi "系统变量@@sessient.gtid_next不能是'自动'@@sessient.gtid_next_list非null时"
+        eng "The system variable @@SESSION.GTID_NEXT cannot be 'AUTOMATIC' when @@SESSION.GTID_NEXT_LIST is non-NULL"
 
 ER_SKIPPING_LOGGED_TRANSACTION
-  eng "Skipping transaction %.200s because it has already been executed and logged"
+        chi "跳过事务%.200s，因为它已经被执行和记录"
+        eng "Skipping transaction %.200s because it has already been executed and logged"
 
 ER_MALFORMED_GTID_SET_SPECIFICATION
-  eng "Malformed GTID set specification '%.200s'"
+        chi "畸形GTID设置规范'%.200s'"
+        eng "Malformed GTID set specification '%.200s'"
 
 ER_MALFORMED_GTID_SET_ENCODING
-  eng "Malformed GTID set encoding"
+        chi "格式错误的GTID集编码"
+        eng "Malformed GTID set encoding"
 
 ER_MALFORMED_GTID_SPECIFICATION
-  eng "Malformed GTID specification '%.200s'"
+        chi "畸形GTID规范'%.200s'"
+        eng "Malformed GTID specification '%.200s'"
 
 ER_GNO_EXHAUSTED
-  eng "Impossible to generate Global Transaction Identifier: the integer component reached the maximal value. Restart the server with a new server_uuid"
+        chi "无法生成全局事务标识符：整数组件达到了最大值。用新server_uuId重新启动服务器"
+        eng "Impossible to generate Global Transaction Identifier: the integer component reached the maximal value. Restart the server with a new server_uuid"
 
 ER_BAD_SLAVE_AUTO_POSITION
-  eng "Parameters MASTER_LOG_FILE, MASTER_LOG_POS, RELAY_LOG_FILE and RELAY_LOG_POS cannot be set when MASTER_AUTO_POSITION is active"
+        chi "当MASTER_AUTO_POSITION处于活动状态时，无法设置参数MASTER_LOG_FILE，MASTER_LOG_POS，RELAY_LOG_FILE和RELAY_LOG_POS"
+        eng "Parameters MASTER_LOG_FILE, MASTER_LOG_POS, RELAY_LOG_FILE and RELAY_LOG_POS cannot be set when MASTER_AUTO_POSITION is active"
 
 ER_AUTO_POSITION_REQUIRES_GTID_MODE_ON
-  eng "CHANGE MASTER TO MASTER_AUTO_POSITION = 1 can only be executed when GTID_MODE = ON"
+        chi "CHANGE Master TO MASTER_AUTO_POSITION = 1只能在GTID_MODE =ON上执行"
+        eng "CHANGE MASTER TO MASTER_AUTO_POSITION = 1 can only be executed when GTID_MODE = ON"
 
 ER_CANT_DO_IMPLICIT_COMMIT_IN_TRX_WHEN_GTID_NEXT_IS_SET
-  eng "Cannot execute statements with implicit commit inside a transaction when GTID_NEXT != AUTOMATIC or GTID_NEXT_LIST != NULL"
+        chi "当GTID_Next！= AUTOMATIC 或GTID_NEXT_LIST != NULL时，无法在事务中执行语句"
+        eng "Cannot execute statements with implicit commit inside a transaction when GTID_NEXT != AUTOMATIC or GTID_NEXT_LIST != NULL"
 
 ER_GTID_MODE_2_OR_3_REQUIRES_ENFORCE_GTID_CONSISTENCY_ON
-  eng "GTID_MODE = ON or GTID_MODE = UPGRADE_STEP_2 requires ENFORCE_GTID_CONSISTENCY = 1"
+        chi "GTID_MODE = ON或GTID_MODE = UPGRADE_STEP_2需要ENFORCE_GTID_CONSISTY = 1"
+        eng "GTID_MODE = ON or GTID_MODE = UPGRADE_STEP_2 requires ENFORCE_GTID_CONSISTENCY = 1"
 
 ER_GTID_MODE_REQUIRES_BINLOG
-  eng "GTID_MODE = ON or UPGRADE_STEP_1 or UPGRADE_STEP_2 requires --log-bin and --log-slave-updates"
+        chi "GTID_MODE = ON或UPGRADE_STEP_1或UPGRADE_STEP_2需要--log-bin和-log-slave-updates"
+        eng "GTID_MODE = ON or UPGRADE_STEP_1 or UPGRADE_STEP_2 requires --log-bin and --log-slave-updates"
 
 ER_CANT_SET_GTID_NEXT_TO_GTID_WHEN_GTID_MODE_IS_OFF
-  eng "GTID_NEXT cannot be set to UUID:NUMBER when GTID_MODE = OFF"
+        chi "GTID_NEXT无法设置为UUID:NUMBER 当GTID_MODE = OFF"
+        eng "GTID_NEXT cannot be set to UUID:NUMBER when GTID_MODE = OFF"
 
 ER_CANT_SET_GTID_NEXT_TO_ANONYMOUS_WHEN_GTID_MODE_IS_ON
-  eng "GTID_NEXT cannot be set to ANONYMOUS when GTID_MODE = ON"
+        chi "GTID_NEXT无法在当GTID_MODE = ON上时设置为ANONYMOUS"
+        eng "GTID_NEXT cannot be set to ANONYMOUS when GTID_MODE = ON"
 
 ER_CANT_SET_GTID_NEXT_LIST_TO_NON_NULL_WHEN_GTID_MODE_IS_OFF
-  eng "GTID_NEXT_LIST cannot be set to a non-NULL value when GTID_MODE = OFF"
+        chi "GTID_NEXT_LIST无法设置为非空值当GTID_MODE = OFF"
+        eng "GTID_NEXT_LIST cannot be set to a non-NULL value when GTID_MODE = OFF"
 
 ER_FOUND_GTID_EVENT_WHEN_GTID_MODE_IS_OFF
-  eng "Found a Gtid_log_event or Previous_gtids_log_event when GTID_MODE = OFF"
+        chi "找到一个Gtid_log_event或Previous_gtids_log_event，当gtid_mode = OFF时"
+        eng "Found a Gtid_log_event or Previous_gtids_log_event when GTID_MODE = OFF"
 
 ER_GTID_UNSAFE_NON_TRANSACTIONAL_TABLE
-  eng "When ENFORCE_GTID_CONSISTENCY = 1, updates to non-transactional tables can only be done in either autocommitted statements or single-statement transactions, and never in the same statement as updates to transactional tables"
+        chi "当Enforce_gtid_consistenty = 1时，对非事务性表的更新只能在Autocomated语句或单一语句事务中完成，而不是在与事务表中的更新相同的语句中"
+        eng "When ENFORCE_GTID_CONSISTENCY = 1, updates to non-transactional tables can only be done in either autocommitted statements or single-statement transactions, and never in the same statement as updates to transactional tables"
 
 ER_GTID_UNSAFE_CREATE_SELECT
-  eng "CREATE TABLE ... SELECT is forbidden when ENFORCE_GTID_CONSISTENCY = 1"
+        chi "CREATE TABLE...SELECT在ENFORCE_GTID_CONSISTENCY = 1时被禁止"
+        eng "CREATE TABLE ... SELECT is forbidden when ENFORCE_GTID_CONSISTENCY = 1"
 
 ER_GTID_UNSAFE_CREATE_DROP_TEMPORARY_TABLE_IN_TRANSACTION
- eng "When ENFORCE_GTID_CONSISTENCY = 1, the statements CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE can be executed in a non-transactional context only, and require that AUTOCOMMIT = 1"
+        chi "当ENFORCE_GTID_CONSISTENCY = 1时，语句CREATE TEMPORARY TABL和DROP TEMPORARY TABLE，只能在非事务性上下文中执行，并且要求autocommit = 1"
+        eng "When ENFORCE_GTID_CONSISTENCY = 1, the statements CREATE TEMPORARY TABLE and DROP TEMPORARY TABLE can be executed in a non-transactional context only, and require that AUTOCOMMIT = 1"
 
 ER_GTID_MODE_CAN_ONLY_CHANGE_ONE_STEP_AT_A_TIME
-  eng "The value of GTID_MODE can only change one step at a time: OFF <-> UPGRADE_STEP_1 <-> UPGRADE_STEP_2 <-> ON. Also note that this value must be stepped up or down simultaneously on all servers; see the Manual for instructions." 
+        chi "GTID_MODE的值只能一次更改一步：OFF<-> UPGRODE_STEP_1 <-> UPGRODE_STEP_2 <-> ON。另请注意，此值必须在所有服务器上同时上升或下降;有关说明，请参阅手册。“"
+        eng "The value of GTID_MODE can only change one step at a time: OFF <-> UPGRADE_STEP_1 <-> UPGRADE_STEP_2 <-> ON. Also note that this value must be stepped up or down simultaneously on all servers; see the Manual for instructions." 
 
 ER_MASTER_HAS_PURGED_REQUIRED_GTIDS
-  eng "The slave is connecting using CHANGE MASTER TO MASTER_AUTO_POSITION = 1, but the master has purged binary logs containing GTIDs that the slave requires"
+        chi "从机更改主站到Master_Auto_Position = 1，因此主站连接，但主设备已清除了slave需要的GTID的二进制日志"
+        eng "The slave is connecting using CHANGE MASTER TO MASTER_AUTO_POSITION = 1, but the master has purged binary logs containing GTIDs that the slave requires"
 
 ER_CANT_SET_GTID_NEXT_WHEN_OWNING_GTID
-  eng "GTID_NEXT cannot be changed by a client that owns a GTID. The client owns %s. Ownership is released on COMMIT or ROLLBACK"
+        chi "无法由拥有GTID的客户端更改GTID_NEXT。客户拥有%s。所有权在提交或回滚上发布"
+        eng "GTID_NEXT cannot be changed by a client that owns a GTID. The client owns %s. Ownership is released on COMMIT or ROLLBACK"
 
 ER_UNKNOWN_EXPLAIN_FORMAT
-  eng "Unknown %s format name: '%s'"
-  rus "Неизвестное имя формата команды %s: '%s'"
+        chi "未知%s格式名称：'%s'"
+        eng "Unknown %s format name: '%s'"
+        rus "Неизвестное имя формата команды %s: '%s'"
 
 ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION 25006
-  eng "Cannot execute statement in a READ ONLY transaction"
+        chi "无法在只读事务中执行语句"
+        eng "Cannot execute statement in a READ ONLY transaction"
 
 ER_TOO_LONG_TABLE_PARTITION_COMMENT
-  eng "Comment for table partition '%-.64s' is too long (max = %lu)"
+        chi "表分区的评论'%-.64s'太长（max =%lu）"
+        eng "Comment for table partition '%-.64s' is too long (max = %lu)"
 
 ER_SLAVE_CONFIGURATION
-  eng "Slave is not configured or failed to initialize properly. You must at least set --server-id to enable either a master or a slave. Additional error messages can be found in the MariaDB error log"
+        chi "从站未配置或未能正确初始化。您必须至少set --server-id以启用主站或从站。可以在MariaDB错误日志中找到其他错误消息"
+        eng "Slave is not configured or failed to initialize properly. You must at least set --server-id to enable either a master or a slave. Additional error messages can be found in the MariaDB error log"
 
 ER_INNODB_FT_LIMIT
-  eng "InnoDB presently supports one FULLTEXT index creation at a time"
+        chi "InnoDB目前一次支持一个全文索引创建"
+        eng "InnoDB presently supports one FULLTEXT index creation at a time"
 
 ER_INNODB_NO_FT_TEMP_TABLE
-  eng "Cannot create FULLTEXT index on temporary InnoDB table"
+        chi "无法在临时InnoDB表上创建FullText索引"
+        eng "Cannot create FULLTEXT index on temporary InnoDB table"
 
 ER_INNODB_FT_WRONG_DOCID_COLUMN
-  eng "Column '%-.192s' is of wrong type for an InnoDB FULLTEXT index"
+        chi "列'%-.192s'是innodb fulltext索引的错误类型"
+        eng "Column '%-.192s' is of wrong type for an InnoDB FULLTEXT index"
 
 ER_INNODB_FT_WRONG_DOCID_INDEX
-  eng "Index '%-.192s' is of wrong type for an InnoDB FULLTEXT index"
+
+        chi "InnoDB全文索引的索引'%-.192s'是错误的类型错误"
+        eng "Index '%-.192s' is of wrong type for an InnoDB FULLTEXT index"
 
 ER_INNODB_ONLINE_LOG_TOO_BIG
-  eng "Creating index '%-.192s' required more than 'innodb_online_alter_log_max_size' bytes of modification log. Please try again"
+        chi "创建索引'%-.192s'所需的多于'innodb_online_alter_log_max_size'字节的修改日志。请再试一次"
+        eng "Creating index '%-.192s' required more than 'innodb_online_alter_log_max_size' bytes of modification log. Please try again"
 
 ER_UNKNOWN_ALTER_ALGORITHM
-  eng "Unknown ALGORITHM '%s'"
+        chi "未知算法'%s'"
+        eng "Unknown ALGORITHM '%s'"
 
 ER_UNKNOWN_ALTER_LOCK
-  eng "Unknown LOCK type '%s'"
+        chi "未知锁定类型'%s'"
+        eng "Unknown LOCK type '%s'"
 
 ER_MTS_CHANGE_MASTER_CANT_RUN_WITH_GAPS
-  eng "CHANGE MASTER cannot be executed when the slave was stopped with an error or killed in MTS mode. Consider using RESET SLAVE or START SLAVE UNTIL"
+        chi "当从站因为错误停止或以MTS模式终止时，不呢执行CHANGE MASTER。考虑使用RESET SLAVE或START SLAVE UNTIL"
+        eng "CHANGE MASTER cannot be executed when the slave was stopped with an error or killed in MTS mode. Consider using RESET SLAVE or START SLAVE UNTIL"
 
 ER_MTS_RECOVERY_FAILURE
-  eng "Cannot recover after SLAVE errored out in parallel execution mode. Additional error messages can be found in the MariaDB error log"
+        chi "从并行执行模式下的从站错误后无法恢复。可以在MariaDB错误日志中找到其他错误消息"
+        eng "Cannot recover after SLAVE errored out in parallel execution mode. Additional error messages can be found in the MariaDB error log"
 
 ER_MTS_RESET_WORKERS
-  eng "Cannot clean up worker info tables. Additional error messages can be found in the MariaDB error log"
+        chi "无法清理工作者信息表。可以在MariaDB错误日志中找到其他错误消息"
+        eng "Cannot clean up worker info tables. Additional error messages can be found in the MariaDB error log"
 
 ER_COL_COUNT_DOESNT_MATCH_CORRUPTED_V2
-  eng "Column count of %s.%s is wrong. Expected %d, found %d. The table is probably corrupted"
-  ger "Spaltenanzahl von %s.%s falsch. %d erwartet, aber %d gefunden. Tabelle ist wahrscheinlich beschädigt"
+        chi "列数为%s.%s是错误的。预期的%d，找到%d。表可能损坏了"
+        eng "Column count of %s.%s is wrong. Expected %d, found %d. The table is probably corrupted"
+        ger "Spaltenanzahl von %s.%s falsch. %d erwartet, aber %d gefunden. Tabelle ist wahrscheinlich beschädigt"
 
 ER_SLAVE_SILENT_RETRY_TRANSACTION
-  eng "Slave must silently retry current transaction"
+        chi "从站必须静默地重试当前事务"
+        eng "Slave must silently retry current transaction"
 
 ER_UNUSED_22
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 
 ER_TABLE_SCHEMA_MISMATCH
-  eng "Schema mismatch (%s)"
+        chi "架构不匹配(%s)"
+        eng "Schema mismatch (%s)"
 
 ER_TABLE_IN_SYSTEM_TABLESPACE
-  eng "Table %-.192s in system tablespace"
+        chi "表%-.192s在系统表空间中"
+        eng "Table %-.192s in system tablespace"
 
 ER_IO_READ_ERROR
-  eng "IO Read error: (%lu, %s) %s"
+        chi "IO读取错误:(%lu，%s）%s"
+        eng "IO Read error: (%lu, %s) %s"
 
 ER_IO_WRITE_ERROR
-  eng "IO Write error: (%lu, %s) %s"
+        chi "IO写错错误:(%lu，%s）%s"
+        eng "IO Write error: (%lu, %s) %s"
 
 ER_TABLESPACE_MISSING
-  eng "Tablespace is missing for table '%-.192s'"
+        chi "表空间缺少表'%-.192s'"
+        eng "Tablespace is missing for table '%-.192s'"
 
 ER_TABLESPACE_EXISTS
-  eng "Tablespace for table '%-.192s' exists. Please DISCARD the tablespace before IMPORT"
+        chi "表格'%-.192s'的表空间。请在导入之前丢弃表空间"
+        eng "Tablespace for table '%-.192s' exists. Please DISCARD the tablespace before IMPORT"
 
 ER_TABLESPACE_DISCARDED
-  eng "Tablespace has been discarded for table %`s"
+        chi "表空间已被丢弃为表%`s"
+        eng "Tablespace has been discarded for table %`s"
 
 ER_INTERNAL_ERROR
-  eng "Internal error: %-.192s"
+        chi "内部错误：%-.192s"
+        eng "Internal error: %-.192s"
 
 ER_INNODB_IMPORT_ERROR
-  eng "ALTER TABLE '%-.192s' IMPORT TABLESPACE failed with error %lu : '%s'"
+        chi "ALTER TABLE '%-.192s' IMPORT TABLESPACE 失败，错误%lu：'%s'"
+        eng "ALTER TABLE '%-.192s' IMPORT TABLESPACE failed with error %lu : '%s'"
 
 ER_INNODB_INDEX_CORRUPT
-  eng "Index corrupt: %s"
+        chi "索引损坏：%s"
+        eng "Index corrupt: %s"
 
 ER_INVALID_YEAR_COLUMN_LENGTH
-  eng "YEAR(%lu) column type is deprecated. Creating YEAR(4) column instead"
-  rus "Тип YEAR(%lu) более не поддерживается, вместо него будет создана колонка с типом YEAR(4)"
+        chi "已弃用YEAR（%lu）列类型。创建YEAR(4)列代替"
+        eng "YEAR(%lu) column type is deprecated. Creating YEAR(4) column instead"
+        rus "Тип YEAR(%lu) более не поддерживается, вместо него будет создана колонка с типом YEAR(4)"
 
 ER_NOT_VALID_PASSWORD
-  eng "Your password does not satisfy the current policy requirements"
+        chi "您的密码不满足当前的政策要求"
+        eng "Your password does not satisfy the current policy requirements"
 
 ER_MUST_CHANGE_PASSWORD
-  eng "You must SET PASSWORD before executing this statement"
-  bgn "Трябва първо да си смените паролата със SET PASSWORD за да можете да изпълните тази команда"
-  rum "Trebuie sa iti schimbi parola folosind SET PASSWORD inainte de a executa aceasta comanda"
+        bgn "Трябва първо да си смените паролата със SET PASSWORD за да можете да изпълните тази команда"
+        chi "您必须在执行此语句之前设置密码"
+        eng "You must SET PASSWORD before executing this statement"
+        rum "Trebuie sa iti schimbi parola folosind SET PASSWORD inainte de a executa aceasta comanda"
 
 ER_FK_NO_INDEX_CHILD
-        eng "Failed to add the foreign key constaint. Missing index for constraint '%s' in the foreign table '%s'"
+        chi "无法添加外键约束。外表'%s'中的约束'%s'缺少索引"
+        eng "Failed to add the foreign key constraint. Missing index for constraint '%s' in the foreign table '%s'"
 
 ER_FK_NO_INDEX_PARENT
-        eng "Failed to add the foreign key constaint. Missing index for constraint '%s' in the referenced table '%s'"
+        chi "无法添加外键约束。引用的表'%s'中的约束'%s'缺少索引"
+        eng "Failed to add the foreign key constraint. Missing index for constraint '%s' in the referenced table '%s'"
 
 ER_FK_FAIL_ADD_SYSTEM
+        chi "无法将外键约束'%s'添加到系统表"
         eng "Failed to add the foreign key constraint '%s' to system tables"
 
 ER_FK_CANNOT_OPEN_PARENT
+        chi "无法打开引用的表'%s'"
         eng "Failed to open the referenced table '%s'"
 
 ER_FK_INCORRECT_OPTION
+        chi "无法在表'%s'上添加外键约束。外键约束'%s'中的选项不正确"
         eng "Failed to add the foreign key constraint on table '%s'. Incorrect options in FOREIGN KEY constraint '%s'"
 
 ER_DUP_CONSTRAINT_NAME
-       eng "Duplicate %s constraint name '%s'"
+        chi "重复%s约束名称'%s'"
+        eng "Duplicate %s constraint name '%s'"
 
 ER_PASSWORD_FORMAT
-  eng "The password hash doesn't have the expected format. Check if the correct password algorithm is being used with the PASSWORD() function"
+        chi "密码哈希没有预期的格式。检查密码（）函数是否使用正确的密码算法"
+        eng "The password hash doesn't have the expected format. Check if the correct password algorithm is being used with the PASSWORD() function"
 
 ER_FK_COLUMN_CANNOT_DROP
+        chi "无法删除'%-.192s'列：在外部索引约束'%-.192s'中需要"
         eng "Cannot drop column '%-.192s': needed in a foreign key constraint '%-.192s'"
         ger "Kann Spalte '%-.192s' nicht löschen: wird für eine Fremdschlüsselbeschränkung '%-.192s' benötigt"
 
 ER_FK_COLUMN_CANNOT_DROP_CHILD
+        chi "无法删除列'%-.192s'：在外键约束'%-.192s'中需要，表%-.192s"
         eng "Cannot drop column '%-.192s': needed in a foreign key constraint '%-.192s' of table %-.192s"
         ger "Kann Spalte '%-.192s' nicht löschen: wird für eine Fremdschlüsselbeschränkung '%-.192s' der Tabelle %-.192s benötigt"
 
 ER_FK_COLUMN_NOT_NULL
+        chi "列'%-.192s'不能没有null：在外键约束'%-.192s'设置为null"
         eng "Column '%-.192s' cannot be NOT NULL: needed in a foreign key constraint '%-.192s' SET NULL"
         ger "Spalte '%-.192s' kann nicht NOT NULL sein: wird für eine Fremdschlüsselbeschränkung '%-.192s' SET NULL benötigt"
 
 ER_DUP_INDEX
-  eng "Duplicate index %`s. This is deprecated and will be disallowed in a future release"
+        chi "重复索引%`s。这已弃用，将在未来的版本中不允许"
+        eng "Duplicate index %`s. This is deprecated and will be disallowed in a future release"
 
 ER_FK_COLUMN_CANNOT_CHANGE
-  eng "Cannot change column '%-.192s': used in a foreign key constraint '%-.192s'"
+        chi "无法更改列'%-.192s'：用于外部键约束'%-.192s'"
+        eng "Cannot change column '%-.192s': used in a foreign key constraint '%-.192s'"
 
 ER_FK_COLUMN_CANNOT_CHANGE_CHILD
-  eng "Cannot change column '%-.192s': used in a foreign key constraint '%-.192s' of table '%-.192s'"
+        chi "无法更改列'%-.192s'：用于在外部键约束'%-.192s'的表'%-.192s'"
+        eng "Cannot change column '%-.192s': used in a foreign key constraint '%-.192s' of table '%-.192s'"
 
 ER_FK_CANNOT_DELETE_PARENT
-  eng "Cannot delete rows from table which is parent in a foreign key constraint '%-.192s' of table '%-.192s'"
+        chi "无法从表中删除来自表中的父级的表中的行'%-.192s”表'%-.192s'"
+        eng "Cannot delete rows from table which is parent in a foreign key constraint '%-.192s' of table '%-.192s'"
 
 ER_MALFORMED_PACKET
-  eng "Malformed communication packet"
+        chi "畸形通信包"
+        eng "Malformed communication packet"
 
 ER_READ_ONLY_MODE
+        chi "以只读模式运行"
         eng "Running in read-only mode"
 
 ER_GTID_NEXT_TYPE_UNDEFINED_GROUP
-  eng "When GTID_NEXT is set to a GTID, you must explicitly set it again after a COMMIT or ROLLBACK. If you see this error message in the slave SQL thread, it means that a table in the current transaction is transactional on the master and non-transactional on the slave. In a client connection, it means that you executed SET GTID_NEXT before a transaction and forgot to set GTID_NEXT to a different identifier or to 'AUTOMATIC' after COMMIT or ROLLBACK. Current GTID_NEXT is '%s'"
+        chi "当GTID_NEXT设置为GTID时，必须在提交或回滚后立即将其再次设置。如果在从SQL线程中看到此错误消息，则表示当前事务中的表是在主站和从站上的非交易的事务性。在客户端连接中，它意味着您在事务之前执行SET GTID_NEXT并忘记将GTID_NEXT设置为不同的标识符或在提交或回滚后“自动”。当前gtid_next是'%s'"
+        eng "When GTID_NEXT is set to a GTID, you must explicitly set it again after a COMMIT or ROLLBACK. If you see this error message in the slave SQL thread, it means that a table in the current transaction is transactional on the master and non-transactional on the slave. In a client connection, it means that you executed SET GTID_NEXT before a transaction and forgot to set GTID_NEXT to a different identifier or to 'AUTOMATIC' after COMMIT or ROLLBACK. Current GTID_NEXT is '%s'"
 
 ER_VARIABLE_NOT_SETTABLE_IN_SP
-  eng "The system variable %.200s cannot be set in stored procedures"
+        chi "无法在存储过程中设置系统变量%.200s"
+        eng "The system variable %.200s cannot be set in stored procedures"
 
 ER_CANT_SET_GTID_PURGED_WHEN_GTID_MODE_IS_OFF
-  eng "GTID_PURGED can only be set when GTID_MODE = ON"
+        chi "只能在GTID_MODE = ON设置GTID_PURGED"
+        eng "GTID_PURGED can only be set when GTID_MODE = ON"
 
 ER_CANT_SET_GTID_PURGED_WHEN_GTID_EXECUTED_IS_NOT_EMPTY
-  eng "GTID_PURGED can only be set when GTID_EXECUTED is empty"
+        chi "只有在GTID_EXECUTED为空时才可以设置GTID_PURGED"
+        eng "GTID_PURGED can only be set when GTID_EXECUTED is empty"
 
 ER_CANT_SET_GTID_PURGED_WHEN_OWNED_GTIDS_IS_NOT_EMPTY
-  eng "GTID_PURGED can only be set when there are no ongoing transactions (not even in other clients)"
+        chi "只有在没有持续的事务时才可以设置GTID_PURGED（即使在其他客户端中不）"
+        eng "GTID_PURGED can only be set when there are no ongoing transactions (not even in other clients)"
 
 ER_GTID_PURGED_WAS_CHANGED
-  eng "GTID_PURGED was changed from '%s' to '%s'"
+        chi "GTID_PURGED从'%s'更改为'%s'"
+        eng "GTID_PURGED was changed from '%s' to '%s'"
 
 ER_GTID_EXECUTED_WAS_CHANGED
-  eng "GTID_EXECUTED was changed from '%s' to '%s'"
+        chi "GTID_EXECUTE从'%s'更改为'%s'"
+        eng "GTID_EXECUTED was changed from '%s' to '%s'"
 
 ER_BINLOG_STMT_MODE_AND_NO_REPL_TABLES
-  eng "Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT, and both replicated and non replicated tables are written to"
+        chi "无法执行语句：由于BINLOG_FORMAT = STATEMENT，因此无法写入二进制日志，并将复制和非复制表写入"
+        eng "Cannot execute statement: impossible to write to binary log since BINLOG_FORMAT = STATEMENT, and both replicated and non replicated tables are written to"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED 0A000
-  eng "%s is not supported for this operation. Try %s"
+        chi "此操作不支持%s。试试%s"
+        eng "%s is not supported for this operation. Try %s"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON 0A000
-  eng "%s is not supported. Reason: %s. Try %s"
+        chi "不支持%s。原因：%s。试试%s"
+        eng "%s is not supported. Reason: %s. Try %s"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_COPY
-  eng "COPY algorithm requires a lock"
+        chi "复制算法需要锁定"
+        eng "COPY algorithm requires a lock"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_PARTITION
-  eng "Partition specific operations do not yet support LOCK/ALGORITHM"
+        chi "分区特定操作尚不支持锁定/算法"
+        eng "Partition specific operations do not yet support LOCK/ALGORITHM"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_FK_RENAME
-  eng "Columns participating in a foreign key are renamed"
+        chi "参与外键的列被更名"
+        eng "Columns participating in a foreign key are renamed"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_COLUMN_TYPE
-  eng "Cannot change column type"
+        chi "无法更改列类型"
+        eng "Cannot change column type"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_FK_CHECK
-  eng "Adding foreign keys needs foreign_key_checks=OFF"
+        chi "添加外键需要figner_key_checks = OFF"
+        eng "Adding foreign keys needs foreign_key_checks=OFF"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_IGNORE
-  eng "Creating unique indexes with IGNORE requires COPY algorithm to remove duplicate rows"
+        chi "使用忽略创建唯一索引需要复制算法删除重复行"
+        eng "Creating unique indexes with IGNORE requires COPY algorithm to remove duplicate rows"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_NOPK
-  eng "Dropping a primary key is not allowed without also adding a new primary key"
+        chi "不允许删除主键，而不添加新的主键"
+        eng "Dropping a primary key is not allowed without also adding a new primary key"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_AUTOINC
-  eng "Adding an auto-increment column requires a lock"
+        chi "添加自动增量列需要锁定"
+        eng "Adding an auto-increment column requires a lock"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_HIDDEN_FTS
-  eng "Cannot replace hidden FTS_DOC_ID with a user-visible one"
+        chi "无法使用用户可见的替换隐藏的FTS_DOC_ID"
+        eng "Cannot replace hidden FTS_DOC_ID with a user-visible one"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_CHANGE_FTS
-  eng "Cannot drop or rename FTS_DOC_ID"
+        chi "无法删除或重命名FTS_DOC_ID"
+        eng "Cannot drop or rename FTS_DOC_ID"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_FTS
-  eng "Fulltext index creation requires a lock"
+        chi "fulltext索引创建需要锁定"
+        eng "Fulltext index creation requires a lock"
 
 ER_SQL_SLAVE_SKIP_COUNTER_NOT_SETTABLE_IN_GTID_MODE
-  eng "sql_slave_skip_counter can not be set when the server is running with GTID_MODE = ON. Instead, for each transaction that you want to skip, generate an empty transaction with the same GTID as the transaction"
+        chi "使用GTID_Mode = ON运行时，无法设置SQL_SLAVE_SKIP_COUNTER。相反，对于要跳过的每个事务，使用与事务相同的GTID生成空事务"
+        eng "sql_slave_skip_counter can not be set when the server is running with GTID_MODE = ON. Instead, for each transaction that you want to skip, generate an empty transaction with the same GTID as the transaction"
 
 ER_DUP_UNKNOWN_IN_INDEX 23000
-  cze "Zdvojený klíč (číslo klíče '%-.192s')"
-  dan "Flere ens nøgler for indeks '%-.192s'"
-  nla "Dubbele ingang voor zoeksleutel '%-.192s'"
-  eng "Duplicate entry for key '%-.192s'"
-  est "Kattuv väärtus võtmele '%-.192s'"
-  fre "Duplicata du champ pour la clef '%-.192s'"
-  ger "Doppelter Eintrag für Schlüssel '%-.192s'"
-  greek "Διπλή εγγραφή για το κλειδί '%-.192s'"
-  hun "Duplikalt bejegyzes a '%-.192s' kulcs szerint"
-  ita "Valore duplicato per la chiave '%-.192s'"
-  jpn "は索引 '%-.192s' で重複しています。"
-  kor "중복된 입력 값: key '%-.192s'"
-  nor "Like verdier for nøkkel '%-.192s'"
-  norwegian-ny "Like verdiar for nykkel '%-.192s'"
-  pol "Powtórzone wystąpienie dla klucza '%-.192s'"
-  por "Entrada duplicada para a chave '%-.192s'"
-  rum "Cimpul e duplicat pentru cheia '%-.192s'"
-  rus "Дублирующаяся запись по ключу '%-.192s'"
-  serbian "Dupliran unos za ključ '%-.192s'"
-  slo "Opakovaný kľúč (číslo kľúča '%-.192s')"
-  spa "Entrada duplicada para la clave '%-.192s'"
-  swe "Dublett för nyckel '%-.192s'"
-  ukr "Дублюючий запис для ключа '%-.192s'"
+        chi "索引的重复条目'%-.192s'"
+        cze "Zdvojený klíč (číslo klíče '%-.192s')"
+        dan "Flere ens nøgler for indeks '%-.192s'"
+        eng "Duplicate entry for key '%-.192s'"
+        est "Kattuv väärtus võtmele '%-.192s'"
+        fre "Duplicata du champ pour la clef '%-.192s'"
+        ger "Doppelter Eintrag für Schlüssel '%-.192s'"
+        greek "Διπλή εγγραφή για το κλειδί '%-.192s'"
+        hun "Duplikalt bejegyzes a '%-.192s' kulcs szerint"
+        ita "Valore duplicato per la chiave '%-.192s'"
+        jpn "は索引 '%-.192s' で重複しています。"
+        kor "중복된 입력 값: key '%-.192s'"
+        nla "Dubbele ingang voor zoeksleutel '%-.192s'"
+        nor "Like verdier for nøkkel '%-.192s'"
+        norwegian-ny "Like verdiar for nykkel '%-.192s'"
+        pol "Powtórzone wystąpienie dla klucza '%-.192s'"
+        por "Entrada duplicada para a chave '%-.192s'"
+        rum "Cimpul e duplicat pentru cheia '%-.192s'"
+        rus "Дублирующаяся запись по ключу '%-.192s'"
+        serbian "Dupliran unos za ključ '%-.192s'"
+        slo "Opakovaný kľúč (číslo kľúča '%-.192s')"
+        spa "Entrada duplicada para la clave '%-.192s'"
+        swe "Dublett för nyckel '%-.192s'"
+        ukr "Дублюючий запис для ключа '%-.192s'"
 
 ER_IDENT_CAUSES_TOO_LONG_PATH
-  eng "Long database name and identifier for object resulted in path length exceeding %d characters. Path: '%s'"
+        chi "对象的长数据库名称和标识符导致路径长度超过%d字符。路径：'%s'"
+        eng "Long database name and identifier for object resulted in path length exceeding %d characters. Path: '%s'"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_NOT_NULL
-  eng "cannot convert NULL to non-constant DEFAULT"
+        chi "无法将null转换为非常量默认值"
+        eng "cannot convert NULL to non-constant DEFAULT"
 
 ER_MUST_CHANGE_PASSWORD_LOGIN
-  eng "Your password has expired. To log in you must change it using a client that supports expired passwords"
-  bgn "Паролата ви е изтекла. За да влезете трябва да я смените използвайки клиент който поддрържа такива пароли"
-  rum "Parola ta a expirat. Pentru a te loga, trebuie sa o schimbi folosind un client ce suporta parole expirate"
+        bgn "Паролата ви е изтекла. За да влезете трябва да я смените използвайки клиент който поддрържа такива пароли"
+        chi "您的密码已过期。要登录您必须使用支持过期密码的客户端更改它"
+        eng "Your password has expired. To log in you must change it using a client that supports expired passwords"
+        rum "Parola ta a expirat. Pentru a te loga, trebuie sa o schimbi folosind un client ce suporta parole expirate"
 
 ER_ROW_IN_WRONG_PARTITION
-  eng "Found a row in wrong partition %s"
-  swe "Hittade en rad i fel partition %s"
+        chi "在错误分区%s中找到了一行"
+        eng "Found a row in wrong partition %s"
+        swe "Hittade en rad i fel partition %s"
 
 ER_MTS_EVENT_BIGGER_PENDING_JOBS_SIZE_MAX
-  eng "Cannot schedule event %s, relay-log name %s, position %s to Worker thread because its size %lu exceeds %lu of slave_pending_jobs_size_max"
+        chi "无法安排事件%s，中继日志名称%s，position%s对工作线程，因为它的大小%lu超过了slave_pending_jobs_size_max (%lu)"
+        eng "Cannot schedule event %s, relay-log name %s, position %s to Worker thread because its size %lu exceeds %lu of slave_pending_jobs_size_max"
 
 ER_INNODB_NO_FT_USES_PARSER
-  eng "Cannot CREATE FULLTEXT INDEX WITH PARSER on InnoDB table"
+        chi "无法在InnoDB表上CREATE FULLTEXT INDEX WITH PARSER"
+        eng "Cannot CREATE FULLTEXT INDEX WITH PARSER on InnoDB table"
 ER_BINLOG_LOGICAL_CORRUPTION
-  eng "The binary log file '%s' is logically corrupted: %s"
+        chi "二进制日志文件'%s'逻辑损坏：%s"
+        eng "The binary log file '%s' is logically corrupted: %s"
 
 ER_WARN_PURGE_LOG_IN_USE
-  eng "file %s was not purged because it was being read by %d thread(s), purged only %d out of %d files"
+        chi "未清除文件%s，因为它被%d线程读取，只清除%d文件中的%d"
+        eng "file %s was not purged because it was being read by %d thread(s), purged only %d out of %d files"
 
 ER_WARN_PURGE_LOG_IS_ACTIVE
-  eng "file %s was not purged because it is the active log file"
+        chi "文件%s未清除，因为它是活动日志文件"
+        eng "file %s was not purged because it is the active log file"
 
 ER_AUTO_INCREMENT_CONFLICT
-  eng "Auto-increment value in UPDATE conflicts with internally generated values"
-
+        chi "更新中的自动增量值与内部生成的值冲突"
+        eng "Auto-increment value in UPDATE conflicts with internally generated values"
 WARN_ON_BLOCKHOLE_IN_RBR
-  eng "Row events are not logged for %s statements that modify BLACKHOLE tables in row format. Table(s): '%-.192s'"
+        chi "未记录行事件的%s语句，该语句以行格式修改BlackHole表。表：'%-.192s'"
+        eng "Row events are not logged for %s statements that modify BLACKHOLE tables in row format. Table(s): '%-.192s'"
 
 ER_SLAVE_MI_INIT_REPOSITORY
-  eng "Slave failed to initialize master info structure from the repository"
+        chi "从设备无法从存储库初始化主信息结构"
+        eng "Slave failed to initialize master info structure from the repository"
 
 ER_SLAVE_RLI_INIT_REPOSITORY
-  eng "Slave failed to initialize relay log info structure from the repository"
+        chi "从站无法从存储库初始化中继日志信息结构"
+        eng "Slave failed to initialize relay log info structure from the repository"
 
 ER_ACCESS_DENIED_CHANGE_USER_ERROR 28000 
-        eng "Access denied trying to change to user '%-.48s'@'%-.64s' (using password: %s). Disconnecting"
         bgn "Отказан достъп при опит за смяна към потребител %-.48s'@'%-.64s' (използвана парола: %s). Затваряне на връзката"
+        chi "访问拒绝尝试更改为用户'%-.48s'@'%-.64s'（使用密码：%s）。断开连接"
+        eng "Access denied trying to change to user '%-.48s'@'%-.64s' (using password: %s). Disconnecting"
 
 ER_INNODB_READ_ONLY
-  eng "InnoDB is in read only mode"
-  hindi "InnoDB केवल READ-ONLY मोड में है"
+        chi "innodb是只读模式"
+        eng "InnoDB is in read only mode"
+        hindi "InnoDB केवल READ-ONLY मोड में है"
 
 ER_STOP_SLAVE_SQL_THREAD_TIMEOUT
-  eng "STOP SLAVE command execution is incomplete: Slave SQL thread got the stop signal, thread is busy, SQL thread will stop once the current task is complete"
+        chi "STOP SLAVE命令执行不完整：从SQL线程获得停止信号，线程正忙，一旦当前任务完成后，SQL线程将停止"
+        eng "STOP SLAVE command execution is incomplete: Slave SQL thread got the stop signal, thread is busy, SQL thread will stop once the current task is complete"
 
 ER_STOP_SLAVE_IO_THREAD_TIMEOUT
-  eng "STOP SLAVE command execution is incomplete: Slave IO thread got the stop signal, thread is busy, IO thread will stop once the current task is complete"
+        chi "STOP SLAVE命令执行不完整：从机动程线程得到停止信号，线程很忙，一旦当前任务完成后，IO线程将停止。"
+        eng "STOP SLAVE command execution is incomplete: Slave IO thread got the stop signal, thread is busy, IO thread will stop once the current task is complete"
 
 ER_TABLE_CORRUPT
-  eng "Operation cannot be performed. The table '%-.64s.%-.64s' is missing, corrupt or contains bad data"
+        chi "无法执行操作。表'%-.64s。%-.64s'丢失，损坏或包含不良数据"
+        eng "Operation cannot be performed. The table '%-.64s.%-.64s' is missing, corrupt or contains bad data"
 
 ER_TEMP_FILE_WRITE_FAILURE
-  eng "Temporary file write failure"
+        chi "临时文件写入失败"
+        eng "Temporary file write failure"
 
 ER_INNODB_FT_AUX_NOT_HEX_ID
-  eng "Upgrade index name failed, please use create index(alter table) algorithm copy to rebuild index"
-
-
+        chi "升级索引名称失败，请使用创建索引（ALTER TABLE）算法复制来重建索引"
+        eng "Upgrade index name failed, please use create index(alter table) algorithm copy to rebuild index"
+#
 #
 # MariaDB error messages section starts here
-#
+
 
 # The following is here to allow us to detect if there was missing
 # error messages in the errmsg.sys file
 
 ER_LAST_MYSQL_ERROR_MESSAGE
-   eng ""
+        eng ""
 
 # MariaDB error numbers starts from 1900
 start-error-number 1900
 
 ER_UNUSED_18
-  eng ""
+        eng ""
 ER_GENERATED_COLUMN_FUNCTION_IS_NOT_ALLOWED
-  eng "Function or expression '%s' cannot be used in the %s clause of %`s"
+        chi "函数或表达式'%s'不能用于%s的%`s"
+        eng "Function or expression '%s' cannot be used in the %s clause of %`s"
 ER_UNUSED_19
-  eng ""
+        eng ""
 ER_PRIMARY_KEY_BASED_ON_GENERATED_COLUMN
-  eng "Primary key cannot be defined upon a generated column"
+        chi "主键无法在生成的列上定义"
+        eng "Primary key cannot be defined upon a generated column"
 ER_KEY_BASED_ON_GENERATED_VIRTUAL_COLUMN
-  eng "Key/Index cannot be defined on a virtual generated column"
+        chi "无法在虚拟生成的列上定义键/索引"
+        eng "Key/Index cannot be defined on a virtual generated column"
 ER_WRONG_FK_OPTION_FOR_GENERATED_COLUMN
-  eng "Cannot define foreign key with %s clause on a generated column"
+        chi "无法在生成的列上定义%s子句的外键"
+        eng "Cannot define foreign key with %s clause on a generated column"
 ER_WARNING_NON_DEFAULT_VALUE_FOR_GENERATED_COLUMN
-  eng "The value specified for generated column '%s' in table '%s' has been ignored"
+        chi "忽略了表'%s'中为生成的列'%s'指定的值已被忽略"
+        eng "The value specified for generated column '%s' in table '%s' has been ignored"
 ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN
-  eng "This is not yet supported for generated columns"
+        chi "生成的列尚未支持这一点"
+        eng "This is not yet supported for generated columns"
 ER_UNUSED_20
-  eng ""
+        eng ""
 ER_UNUSED_21
-  eng ""
+        eng ""
 ER_UNSUPPORTED_ENGINE_FOR_GENERATED_COLUMNS
-  eng "%s storage engine does not support generated columns"
-  hindi "स्टोरेज इंजन %s COMPUTED कॉलम्स को सपोर्ट नहीं करता"
+        chi "%s存储引擎不支持生成的列"
+        eng "%s storage engine does not support generated columns"
+        hindi "स्टोरेज इंजन %s COMPUTED कॉलम्स को सपोर्ट नहीं करता"
 ER_UNKNOWN_OPTION
-  eng "Unknown option '%-.64s'"
-  hindi "अज्ञात विकल्प '%-.64s'"
+        chi "未知选项'%-.64s'"
+        eng "Unknown option '%-.64s'"
+        hindi "अज्ञात विकल्प '%-.64s'"
 ER_BAD_OPTION_VALUE
-  eng "Incorrect value '%-.64T' for option '%-.64s'"
-  hindi "गलत मान '%-.64T' विकल्प '%-.64s' के लिए"
+        chi "值不正确'%-.64T'选项'%-.64s'"
+        eng "Incorrect value '%-.64T' for option '%-.64s'"
+        hindi "गलत मान '%-.64T' विकल्प '%-.64s' के लिए"
 ER_UNUSED_6
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 ER_UNUSED_7
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 ER_UNUSED_8
-  eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 ER_DATA_OVERFLOW 22003
+        chi "转换'%-.128s'到%-.32s时溢出。值截断"
         eng "Got overflow when converting '%-.128s' to %-.32s. Value truncated"
 ER_DATA_TRUNCATED 22003
+        chi "转换'%-.128s'到%-.32s时值截断"
         eng "Truncated value '%-.128s' when converting to %-.32s"
 ER_BAD_DATA 22007
+        chi "非法值'%-.128s'，在转换%-.32s时遇到"
         eng "Encountered illegal value '%-.128s' when converting to %-.32s"
 ER_DYN_COL_WRONG_FORMAT
+        chi "遇到非法格式的动态列字符串"
         eng "Encountered illegal format of dynamic column string"
 ER_DYN_COL_IMPLEMENTATION_LIMIT
+        chi "达到动态列实现限制"
         eng "Dynamic column implementation limit reached"
 ER_DYN_COL_DATA 22007
+        chi "非法值用作动态列函数的参数"
         eng "Illegal value used as argument of dynamic column function"
 ER_DYN_COL_WRONG_CHARSET
+        chi "动态列包含未知字符集"
         eng "Dynamic column contains unknown character set"
 ER_ILLEGAL_SUBQUERY_OPTIMIZER_SWITCHES
+        chi "“in_to_exists”或'materialization'optimizer_switch标志中的至少一个必须是'开启'"
         eng "At least one of the 'in_to_exists' or 'materialization' optimizer_switch flags must be 'on'"
         hindi "कम से कम 'in_to_exists' या 'materialization' optimizer_switch फ्लैग 'ON' होना चाहिए"
 ER_QUERY_CACHE_IS_DISABLED
+        chi "查询缓存已禁用（调整大小或类似命令正在进行中）;稍后重复此命令"
         eng "Query cache is disabled (resize or similar command in progress); repeat this command later"
 ER_QUERY_CACHE_IS_GLOBALY_DISABLED
+        chi "查询缓存全局禁用，您无法为此会话启用它"
         eng "Query cache is globally disabled and you can't enable it only for this session"
         hindi "क्वेरी कैश ग्लोबल स्तर पर DISABLED है और आप इसे केवल सत्र के लिए ENABLE नहीं कर सकते"
 ER_VIEW_ORDERBY_IGNORED
+        chi "查看'%-.192s'.'%-.192s's ORDER BY子句被忽略，因为还有其他ORDER BY子句"
         eng "View '%-.192s'.'%-.192s' ORDER BY clause ignored because there is other ORDER BY clause already"
 ER_CONNECTION_KILLED 70100 
+        chi "连接被杀死"
         eng "Connection was killed"
         hindi "कनेक्शन को समाप्त कर दिया गया है"
 ER_UNUSED_12
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_INSIDE_TRANSACTION_PREVENTS_SWITCH_SKIP_REPLICATION
+        chi "无法修改事务中的@@session.skip_replication"
         eng "Cannot modify @@session.skip_replication inside a transaction"
 ER_STORED_FUNCTION_PREVENTS_SWITCH_SKIP_REPLICATION
+        chi "无法修改存储函数或触发器内的@@session.skip_replication"
         eng "Cannot modify @@session.skip_replication inside a stored function or trigger"
 ER_QUERY_EXCEEDED_ROWS_EXAMINED_LIMIT
+        chi "查询执行被中断。查询检查至少%llu行，超过限制行（%llu）。查询结果可能是不完整的"
         eng "Query execution was interrupted. The query examined at least %llu rows, which exceeds LIMIT ROWS EXAMINED (%llu). The query result may be incomplete"
 ER_NO_SUCH_TABLE_IN_ENGINE 42S02 
+        chi "表'%-.192s.%-.192s'在引擎中不存在"
         eng "Table '%-.192s.%-.192s' doesn't exist in engine"
         hindi "टेबल '%-.192s.%-.192s' इंजन में मौजूद नहीं है"
         swe "Det finns ingen tabell som heter '%-.192s.%-.192s' i handlern"
 ER_TARGET_NOT_EXPLAINABLE
+        chi "目标未运行可解释的命令"
         eng "Target is not running an EXPLAINable command"
 ER_CONNECTION_ALREADY_EXISTS
+        chi "连接'%.*s'与现有连接'%.*s'冲突"
         eng "Connection '%.*s' conflicts with existing connection '%.*s'"
 ER_MASTER_LOG_PREFIX
+        chi "Master'%.*s'："
         eng "Master '%.*s': "
 ER_CANT_START_STOP_SLAVE
+        chi "不能%sSLAVE'%.*s'"
         eng "Can't %s SLAVE '%.*s'"
 ER_SLAVE_STARTED
+        chi "SLAVE '%.*s'开始了"
         eng "SLAVE '%.*s' started"
 ER_SLAVE_STOPPED
+        chi "slave'%.*s'停止了"
         eng "SLAVE '%.*s' stopped"
 ER_SQL_DISCOVER_ERROR
+        chi "引擎%s无法发现表%`-.192s.%`-.192s，'%s'"
         eng "Engine %s failed to discover table %`-.192s.%`-.192s with '%s'"
 ER_FAILED_GTID_STATE_INIT
+        chi "初始化复制GTID状态失败"
         eng "Failed initializing replication GTID state"
 ER_INCORRECT_GTID_STATE
+        chi "无法解析GTID列表"
         eng "Could not parse GTID list"
 ER_CANNOT_UPDATE_GTID_STATE
+        chi "无法更新Replication Slave GTID状态"
         eng "Could not update replication slave gtid state"
 ER_DUPLICATE_GTID_DOMAIN
-	eng "GTID %u-%u-%llu and %u-%u-%llu conflict (duplicate domain id %u)"
+        chi "GTID %u-%u-%llu和%u-%u-%llu冲突（重复域ID%u）"
+        eng "GTID %u-%u-%llu and %u-%u-%llu conflict (duplicate domain id %u)"
 ER_GTID_OPEN_TABLE_FAILED
+        chi "未能打开%s.%s"
         eng "Failed to open %s.%s"
         ger "Öffnen von %s.%s fehlgeschlagen"
 ER_GTID_POSITION_NOT_FOUND_IN_BINLOG
-	eng "Connecting slave requested to start from GTID %u-%u-%llu, which is not in the master's binlog"
+        chi "连接从站请求从GTID%u-%u-%llu开始，这不在Master的Binlog中"
+        eng "Connecting slave requested to start from GTID %u-%u-%llu, which is not in the master's binlog"
 ER_CANNOT_LOAD_SLAVE_GTID_STATE
-	eng "Failed to load replication slave GTID position from table %s.%s"
+        chi "无法从表%s中加载Replication Slave GTID位置。%s"
+        eng "Failed to load replication slave GTID position from table %s.%s"
 ER_MASTER_GTID_POS_CONFLICTS_WITH_BINLOG
-	eng "Specified GTID %u-%u-%llu conflicts with the binary log which contains a more recent GTID %u-%u-%llu. If MASTER_GTID_POS=CURRENT_POS is used, the binlog position will override the new value of @@gtid_slave_pos"
+        chi "指定的GTID%u-%u-%llu与二进制日志冲突，其中包含更新的GTID%u-%u-%llu。如果使用master_gtid_pos = current_pos，则Binlog位置将覆盖@@gtid_slave_pos的新值"
+        eng "Specified GTID %u-%u-%llu conflicts with the binary log which contains a more recent GTID %u-%u-%llu. If MASTER_GTID_POS=CURRENT_POS is used, the binlog position will override the new value of @@gtid_slave_pos"
 ER_MASTER_GTID_POS_MISSING_DOMAIN
-	eng "Specified value for @@gtid_slave_pos contains no value for replication domain %u. This conflicts with the binary log which contains GTID %u-%u-%llu. If MASTER_GTID_POS=CURRENT_POS is used, the binlog position will override the new value of @@gtid_slave_pos"
+        chi "指定值为@@gtid_slave_pos不包含复制域%u的值。这与二进制日志冲突，其中包含gtid%u-%u-%llu。如果使用master_gtid_pos = current_pos，则Binlog位置将覆盖@@ gtid_slave_pos的新值"
+        eng "Specified value for @@gtid_slave_pos contains no value for replication domain %u. This conflicts with the binary log which contains GTID %u-%u-%llu. If MASTER_GTID_POS=CURRENT_POS is used, the binlog position will override the new value of @@gtid_slave_pos"
 ER_UNTIL_REQUIRES_USING_GTID
-	eng "START SLAVE UNTIL master_gtid_pos requires that slave is using GTID"
+        chi "启动从站，直到master_gtid_pos要求从站使用gtid"
+        eng "START SLAVE UNTIL master_gtid_pos requires that slave is using GTID"
 ER_GTID_STRICT_OUT_OF_ORDER
-	eng "An attempt was made to binlog GTID %u-%u-%llu which would create an out-of-order sequence number with existing GTID %u-%u-%llu, and gtid strict mode is enabled"
+        chi "尝试对Binlog GTID%u-%u-%llu进行，这将创建具有现有GTID%u-%u-%llu的订单无序序列号，并且启用了GTID严格模式"
+        eng "An attempt was made to binlog GTID %u-%u-%llu which would create an out-of-order sequence number with existing GTID %u-%u-%llu, and gtid strict mode is enabled"
 ER_GTID_START_FROM_BINLOG_HOLE
-	eng "The binlog on the master is missing the GTID %u-%u-%llu requested by the slave (even though a subsequent sequence number does exist), and GTID strict mode is enabled"
+        chi "主机上的Binlog缺少从站所需请求的GTID%u-%u-%llu（即使存在后续的序列号），并启用GTID严格模式"
+        eng "The binlog on the master is missing the GTID %u-%u-%llu requested by the slave (even though a subsequent sequence number does exist), and GTID strict mode is enabled"
 ER_SLAVE_UNEXPECTED_MASTER_SWITCH
-	eng "Unexpected GTID received from master after reconnect. This normally indicates that the master server was replaced without restarting the slave threads. %s"
+        chi "重新连接后，从master收到意外的GTID。这通常表示在不重新启动从线程的情况下替换主服务器。%s."
+        eng "Unexpected GTID received from master after reconnect. This normally indicates that the master server was replaced without restarting the slave threads. %s"
 ER_INSIDE_TRANSACTION_PREVENTS_SWITCH_GTID_DOMAIN_ID_SEQ_NO
+        chi "无法修改@@sessient.gtid_domain_id或@@session.gtid_seq_no"
         eng "Cannot modify @@session.gtid_domain_id or @@session.gtid_seq_no inside a transaction"
 ER_STORED_FUNCTION_PREVENTS_SWITCH_GTID_DOMAIN_ID_SEQ_NO
+        chi "无法修改@@sessient.gtid_domain_id或@@session.gtid_seq_no或触发器"
         eng "Cannot modify @@session.gtid_domain_id or @@session.gtid_seq_no inside a stored function or trigger"
 ER_GTID_POSITION_NOT_FOUND_IN_BINLOG2
-	eng "Connecting slave requested to start from GTID %u-%u-%llu, which is not in the master's binlog. Since the master's binlog contains GTIDs with higher sequence numbers, it probably means that the slave has diverged due to executing extra erroneous transactions"
+        chi "连接从站请求从GTID%u-%u-%llu开始，这不在Master的Binlog中。由于Master的Binlog包含具有更高序列号的GTID，因此它可能意味着由于执行额外错误的交易，因此slave已经分歧"
+        eng "Connecting slave requested to start from GTID %u-%u-%llu, which is not in the master's binlog. Since the master's binlog contains GTIDs with higher sequence numbers, it probably means that the slave has diverged due to executing extra erroneous transactions"
 ER_BINLOG_MUST_BE_EMPTY
-	eng "This operation is not allowed if any GTID has been logged to the binary log. Run RESET MASTER first to erase the log"
+        chi "如果已将任何GTID记录到二进制日志，则不允许此操作。首先运行RESET MASTER擦除日志"
+        eng "This operation is not allowed if any GTID has been logged to the binary log. Run RESET MASTER first to erase the log"
 ER_NO_SUCH_QUERY
+        chi "未知查询ID：%lld"
         eng "Unknown query id: %lld"
         ger "Unbekannte Abfrage-ID: %lld"
         hindi "अज्ञात क्वेरी ID: %lld"
         rus "Неизвестный номер запроса: %lld"
 ER_BAD_BASE64_DATA
-	eng "Bad base64 data as position %u"
+        chi "错误Base64数据作为位置%u"
+        eng "Bad base64 data as position %u"
 ER_INVALID_ROLE OP000
-       eng "Invalid role specification %`s"
-       hindi "अमान्य रोल विनिर्देश %`s"
-       rum "Rolul %`s este invalid"
+        chi "无效的角色规范%`s"
+        eng "Invalid role specification %`s"
+        hindi "अमान्य रोल विनिर्देश %`s"
+        rum "Rolul %`s este invalid"
 ER_INVALID_CURRENT_USER 0L000
-	eng "The current user is invalid"
+        chi "当前用户无效"
+        eng "The current user is invalid"
         hindi "वर्तमान यूज़र अमान्य है"
-	rum "Utilizatorul curent este invalid"
+        rum "Utilizatorul curent este invalid"
 ER_CANNOT_GRANT_ROLE
-	eng "Cannot grant role '%s' to: %s"
+        chi "无法将角色'%s'授予：%s"
+        eng "Cannot grant role '%s' to: %s"
         hindi "रोल '%s', %s को प्रदान नहीं कर सकते"
-	rum "Rolul '%s' nu poate fi acordat catre: %s"
+        rum "Rolul '%s' nu poate fi acordat catre: %s"
 ER_CANNOT_REVOKE_ROLE
-	eng "Cannot revoke role '%s' from: %s"
+        chi "无法撤消来自：%s的角色'%s'"
+        eng "Cannot revoke role '%s' from: %s"
         hindi "रोल '%s', %s से हटाया नहीं जा सका"
-	rum "Rolul '%s' nu poate fi revocat de la: %s"
+        rum "Rolul '%s' nu poate fi revocat de la: %s"
 ER_CHANGE_SLAVE_PARALLEL_THREADS_ACTIVE
-	eng "Cannot change @@slave_parallel_threads while another change is in progress"
+        chi "无法更改@@slave_parallel_threads，而另一个更改正在进行中"
+        eng "Cannot change @@slave_parallel_threads while another change is in progress"
 ER_PRIOR_COMMIT_FAILED
-	eng "Commit failed due to failure of an earlier commit on which this one depends"
+        chi "由于早期提交的失败取决于依赖于哪个依赖性，提交失败"
+        eng "Commit failed due to failure of an earlier commit on which this one depends"
 ER_IT_IS_A_VIEW 42S02
+        chi "'%-.192s'是一个VIEW"
         eng "'%-.192s' is a view"
         hindi "'%-.192s' एक VIEW है"
 ER_SLAVE_SKIP_NOT_IN_GTID
-	eng "When using parallel replication and GTID with multiple replication domains, @@sql_slave_skip_counter can not be used. Instead, setting @@gtid_slave_pos explicitly can be used to skip to after a given GTID position"
+        chi "使用并行复制和带有多个复制域的GTID时，无法使用@@SQL_SLAVE_SKIP_COUNTER。相反，可以使用明确设置@@gtid_slave_pos以在给定的gtid位置之后跳到"
+        eng "When using parallel replication and GTID with multiple replication domains, @@sql_slave_skip_counter can not be used. Instead, setting @@gtid_slave_pos explicitly can be used to skip to after a given GTID position"
 ER_TABLE_DEFINITION_TOO_BIG
+        chi "表%`s的定义太大了"
         eng "The definition for table %`s is too big"
         hindi "टेबल %`s की परिभाषा बहुत बड़ी है"
 ER_PLUGIN_INSTALLED
+        chi "插件'%-.192s'已安装"
         eng "Plugin '%-.192s' already installed"
         hindi "प्लग-इन '%-.192s' पहले से ही इन्स्टॉल्ड है"
         rus "Плагин '%-.192s' уже установлен"
 ER_STATEMENT_TIMEOUT 70100
+        chi "查询执行中断（超出MAX_STATEMENT_TIME）"
         eng "Query execution was interrupted (max_statement_time exceeded)"
 ER_SUBQUERIES_NOT_SUPPORTED 42000
+        chi "%s不支持子查询或存储的函数"
         eng "%s does not support subqueries or stored functions"
 ER_SET_STATEMENT_NOT_SUPPORTED 42000
+        chi "系统变量%.200s无法在set语句中设置。“"
         eng "The system variable %.200s cannot be set in SET STATEMENT." 
 ER_UNUSED_9
+        chi "你永远不应该看到它"
         eng "You should never see it"
 ER_USER_CREATE_EXISTS
+        chi "无法创建用户'%-.64s'@'%-.64s';它已经存在"
         eng "Can't create user '%-.64s'@'%-.64s'; it already exists"
         hindi "यूज़र '%-.64s'@'%-.64s' को नहीं बना सकते; यह पहले से ही मौजूद है"
 ER_USER_DROP_EXISTS
+        chi "无法删除用户'%-.64s'@'%-.64s';它不存在"
         eng "Can't drop user '%-.64s'@'%-.64s'; it doesn't exist"
         hindi "यूज़र '%-.64s'@'%-.64s' को ड्रॉप नहीं कर सकते; यह मौजूद नहीं है"
 ER_ROLE_CREATE_EXISTS
+        chi "无法创建角色'%-.64s';它已经存在"
         eng "Can't create role '%-.64s'; it already exists"
         hindi "रोल '%-.64s' को नहीं बना सकते; यह पहले से ही मौजूद है"
 ER_ROLE_DROP_EXISTS
+        chi "无法删除'%-.64s'。它不存在"
         eng "Can't drop role '%-.64s'; it doesn't exist"
         hindi "रोल '%-.64s' को ड्रॉप नहीं कर सकते; यह मौजूद नहीं है"
 ER_CANNOT_CONVERT_CHARACTER
+        chi "无法将'%s'字符0x转换为0x%-.64s到'%s'"
         eng "Cannot convert '%s' character 0x%-.64s to '%s'"
 ER_INVALID_DEFAULT_VALUE_FOR_FIELD  22007
+        chi "列的默认值不正确'%-.128T' '%.192s'"
         eng "Incorrect default value '%-.128T' for column '%.192s'"
         hindi "गलत डिफ़ॉल्ट मान '%-.128T' कॉलम '%.192s' के लिए"
 ER_KILL_QUERY_DENIED_ERROR
+        chi "你不是查询%lu的所有者"
         eng "You are not owner of query %lu"
         ger "Sie sind nicht Eigentümer von Abfrage %lu"
         hindi "आप क्वेरी %lu के OWNER नहीं हैं"
         rus "Вы не являетесь владельцем запроса %lu"
 ER_NO_EIS_FOR_FIELD
+        chi "没有收集无关的统计信息列'%s'"
         eng "Engine-independent statistics are not collected for column '%s'"
         hindi "Engine-independent सांख्यिकी कॉलम '%s' के लिए एकत्रित नहीं किया जा रहा है"
         ukr "Незалежна від типу таблиці статистика не збирається для стовбця '%s'"
 ER_WARN_AGGFUNC_DEPENDENCE
+        chi "聚合函数'%-.192s）'SELECT＃%d的属于选择＃%d"
         eng "Aggregate function '%-.192s)' of SELECT #%d belongs to SELECT #%d"
         ukr "Агрегатна функція '%-.192s)' з SELECTу #%d належить до SELECTу #%d"
 WARN_INNODB_PARTITION_OPTION_IGNORED
+        chi "<%-.64s> innodb分区忽略的选项"
         eng "<%-.64s> option ignored for InnoDB partition"
 
 #
@@ -7364,584 +8294,798 @@ skip-to-error-number 2000
 skip-to-error-number 3000
 
 ER_FILE_CORRUPT
-  eng "File %s is corrupted"
+        chi "文件%s已损坏"
+        eng "File %s is corrupted"
 
 ER_ERROR_ON_MASTER
-  eng "Query partially completed on the master (error on master: %d) and was aborted. There is a chance that your master is inconsistent at this point. If you are sure that your master is ok, run this query manually on the slave and then restart the slave with SET GLOBAL SQL_SLAVE_SKIP_COUNTER=1; START SLAVE;. Query:'%s'" 
+        chi "查询在主设备上部分完成（主设备：%d）并中止。你的master在这一点上有可能不一致。如果您确定您的主站是可以的，请在从站上手动运行此查询，然后使用SET GLOBAL SQL_SLAVE_SKIP_COUNTER = 1; START SLAVE ;查询：'%s'"
+        eng "Query partially completed on the master (error on master: %d) and was aborted. There is a chance that your master is inconsistent at this point. If you are sure that your master is ok, run this query manually on the slave and then restart the slave with SET GLOBAL SQL_SLAVE_SKIP_COUNTER=1; START SLAVE;. Query:'%s'" 
 
 ER_INCONSISTENT_ERROR
-  eng "Query caused different errors on master and slave. Error on master: message (format)='%s' error code=%d; Error on slave:actual message='%s', error code=%d. Default database:'%s'. Query:'%s'"
+        chi "查询在主站和从站上引起了不同的错误。主站错误：消息（格式）='%s'错误代码=%d;从站错误：实际消息='%s'，错误代码=%d。默认数据库：'%s'。查询：'%s'"
+        eng "Query caused different errors on master and slave. Error on master: message (format)='%s' error code=%d; Error on slave:actual message='%s', error code=%d. Default database:'%s'. Query:'%s'"
 
 ER_STORAGE_ENGINE_NOT_LOADED
+        chi "表'%s'的存储引擎'%s'没有加载。"
         eng "Storage engine for table '%s'.'%s' is not loaded."
 
 ER_GET_STACKED_DA_WITHOUT_ACTIVE_HANDLER 0Z002
-  eng "GET STACKED DIAGNOSTICS when handler not active"
+        chi "处理程序未激活时GET STACKED DIAGNOSTICS"
+        eng "GET STACKED DIAGNOSTICS when handler not active"
 
 ER_WARN_LEGACY_SYNTAX_CONVERTED
-  eng "%s is no longer supported. The statement was converted to %s."
+        chi "不再支持%s。该语句被转换为%s。"
+        eng "%s is no longer supported. The statement was converted to %s."
 
 ER_BINLOG_UNSAFE_FULLTEXT_PLUGIN
-  eng "Statement is unsafe because it uses a fulltext parser plugin which may not return the same value on the slave."
+        chi "语句不安全，因为它使用全文解析器插件，它可能不会在从站上返回相同的值。"
+        eng "Statement is unsafe because it uses a fulltext parser plugin which may not return the same value on the slave."
 
 ER_CANNOT_DISCARD_TEMPORARY_TABLE
-  eng "Cannot DISCARD/IMPORT tablespace associated with temporary table"
+        chi "无法丢弃与临时表相关联的/导入表空间"
+        eng "Cannot DISCARD/IMPORT tablespace associated with temporary table"
 
 ER_FK_DEPTH_EXCEEDED
-  eng "Foreign key cascade delete/update exceeds max depth of %d."
+        chi "外键级联删除/更新超出了%d的最大深度。"
+        eng "Foreign key cascade delete/update exceeds max depth of %d."
 
 ER_COL_COUNT_DOESNT_MATCH_PLEASE_UPDATE_V2
+        chi "列数为%s.%s是错误的。预期的%d，找到%d。使用MariaDB%d创建，现在运行%d。请使用mysql_upgrade来修复此错误。"
         eng "Column count of %s.%s is wrong. Expected %d, found %d. Created with MariaDB %d, now running %d. Please use mysql_upgrade to fix this error."
         ger "Spaltenanzahl von %s.%s falsch. %d erwartet, aber %d erhalten. Erzeugt mit MariaDB %d, jetzt unter %d. Bitte benutzen Sie mysql_upgrade, um den Fehler zu beheben"
 
 ER_WARN_TRIGGER_DOESNT_HAVE_CREATED
-  eng "Trigger %s.%s.%s does not have CREATED attribute."
+        chi "触发器%s.%s.%s没有CREATE属性。"
+        eng "Trigger %s.%s.%s does not have CREATED attribute."
 
 ER_REFERENCED_TRG_DOES_NOT_EXIST_MYSQL
-  eng "Referenced trigger '%s' for the given action time and event type does not exist."
+        chi "引用的触发器'%s'用于给定的动作时间和事件类型不存在。"
+        eng "Referenced trigger '%s' for the given action time and event type does not exist."
 
 ER_EXPLAIN_NOT_SUPPORTED
+        chi "EXPLAIN FOR CONNECTION仅支持SELECT/UPDATE/INSERT/DELETE/REPLACE"
         eng "EXPLAIN FOR CONNECTION command is supported only for SELECT/UPDATE/INSERT/DELETE/REPLACE"
 ER_INVALID_FIELD_SIZE
+        chi "列'%-.192s'的大小无效。"
         eng "Invalid size for column '%-.192s'."
 
 ER_MISSING_HA_CREATE_OPTION
+        chi "表存储引擎'%-.64s'所找到的必备创建选项丢失"
         eng "Table storage engine '%-.64s' found required create option missing"
 
 ER_ENGINE_OUT_OF_MEMORY
-  eng "Out of memory in storage engine '%-.64s'."
+        chi "存储引擎'%-.64s'中的内存不足。"
+        eng "Out of memory in storage engine '%-.64s'."
 
 ER_PASSWORD_EXPIRE_ANONYMOUS_USER
-  eng "The password for anonymous user cannot be expired."
+        chi "匿名用户的密码不能过期。"
+        eng "The password for anonymous user cannot be expired."
 
 ER_SLAVE_SQL_THREAD_MUST_STOP
-  eng "This operation cannot be performed with a running slave sql thread; run STOP SLAVE SQL_THREAD first"
+        chi "无法使用正在运行的从SQL线程执行此操作;首先运行STOP SLAVE SQL_THREAD"
+        eng "This operation cannot be performed with a running slave sql thread; run STOP SLAVE SQL_THREAD first"
 
 ER_NO_FT_MATERIALIZED_SUBQUERY
-  eng "Cannot create FULLTEXT index on materialized subquery"
+        chi "无法在物化的子查询上创建FullText索引"
+        eng "Cannot create FULLTEXT index on materialized subquery"
 
 ER_INNODB_UNDO_LOG_FULL
-  eng "Undo Log error: %s"
+        chi "撤消日志错误：%s"
+        eng "Undo Log error: %s"
 
 ER_INVALID_ARGUMENT_FOR_LOGARITHM 2201E
-  eng "Invalid argument for logarithm"
+        chi "对数的参数无效"
+        eng "Invalid argument for logarithm"
 
 ER_SLAVE_CHANNEL_IO_THREAD_MUST_STOP
-  eng "This operation cannot be performed with a running slave io thread; run STOP SLAVE IO_THREAD FOR CHANNEL '%s' first."
+        chi "无法使用正在运行的slave IO线程执行此操作;首先运行STOP SLAVE IO_THREAD FOR CHANNEL'%s'。"
+        eng "This operation cannot be performed with a running slave io thread; run STOP SLAVE IO_THREAD FOR CHANNEL '%s' first."
 
 ER_WARN_OPEN_TEMP_TABLES_MUST_BE_ZERO
-  eng "This operation may not be safe when the slave has temporary tables. The tables will be kept open until the server restarts or until the tables are deleted by any replicated DROP statement. Suggest to wait until slave_open_temp_tables = 0."
+        chi "当从站具有临时表时，此操作可能不安全。表将保持打开，直到服务器重新启动或通过任何复制的DROP语句删除表。建议等到Slave_open_temp_tables = 0。"
+        eng "This operation may not be safe when the slave has temporary tables. The tables will be kept open until the server restarts or until the tables are deleted by any replicated DROP statement. Suggest to wait until slave_open_temp_tables = 0."
 
 ER_WARN_ONLY_MASTER_LOG_FILE_NO_POS
-  eng "CHANGE MASTER TO with a MASTER_LOG_FILE clause but no MASTER_LOG_POS clause may not be safe. The old position value may not be valid for the new binary log file."
+        chi "使用CHANGE MASTER TO master_log_file子句更改master，但没有master_log_pos子句可能不安全。旧位置值可能对新的二进制日志文件无效。"
+        eng "CHANGE MASTER TO with a MASTER_LOG_FILE clause but no MASTER_LOG_POS clause may not be safe. The old position value may not be valid for the new binary log file."
 
 ER_QUERY_TIMEOUT 
-  eng "Query execution was interrupted, maximum statement execution time exceeded"
+        chi "查询执行中断，超过了最大语句执行时间"
+        eng "Query execution was interrupted, maximum statement execution time exceeded"
 
 ER_NON_RO_SELECT_DISABLE_TIMER
-  eng "Select is not a read only statement, disabling timer"
+        chi "SELECT不是只读语句，禁用计时器"
+        eng "Select is not a read only statement, disabling timer"
 
 ER_DUP_LIST_ENTRY
-  eng "Duplicate entry '%-.192s'."
+        chi "重复条目'%-.192s'。"
+        eng "Duplicate entry '%-.192s'."
 
 ER_SQL_MODE_NO_EFFECT
-  eng "'%s' mode no longer has any effect. Use STRICT_ALL_TABLES or STRICT_TRANS_TABLES instead."
+        chi "'%s'模式不再有任何效果。使用STRICT_ALL_TABLES或STRICT_TRANS_TABLES。"
+        eng "'%s' mode no longer has any effect. Use STRICT_ALL_TABLES or STRICT_TRANS_TABLES instead."
 
 ER_AGGREGATE_ORDER_FOR_UNION
-  eng "Expression #%u of ORDER BY contains aggregate function and applies to a UNION"
+        chi "表达式＃%u ORDER BY包含聚合函数并适用于UNION"
+        eng "Expression #%u of ORDER BY contains aggregate function and applies to a UNION"
 
 ER_AGGREGATE_ORDER_NON_AGG_QUERY
-  eng "Expression #%u of ORDER BY contains aggregate function and applies to the result of a non-aggregated query"
+        chi "表达式＃%u通过包含聚合函数，并适用于非聚合查询的结果"
+        eng "Expression #%u of ORDER BY contains aggregate function and applies to the result of a non-aggregated query"
 
 ER_SLAVE_WORKER_STOPPED_PREVIOUS_THD_ERROR
-  eng "Slave worker has stopped after at least one previous worker encountered an error when slave-preserve-commit-order was enabled. To preserve commit order, the last transaction executed by this thread has not been committed. When restarting the slave after fixing any failed threads, you should fix this worker as well."
+        chi "在启用了slave保存提交次序时至少有一个以前的工人遇到错误后，slave工作者已停止。要保留提交次序，此线程执行的最后一项事务尚未提交。在修复任何故障线程后重新启动从站时，您也应该修复此工作人。"
+        eng "Slave worker has stopped after at least one previous worker encountered an error when slave-preserve-commit-order was enabled. To preserve commit order, the last transaction executed by this thread has not been committed. When restarting the slave after fixing any failed threads, you should fix this worker as well."
 
 ER_DONT_SUPPORT_SLAVE_PRESERVE_COMMIT_ORDER
-  eng "slave_preserve_commit_order is not supported %s."
+        chi "slave_preerve_commit_order不支持%s。"
+        eng "slave_preserve_commit_order is not supported %s."
 
 ER_SERVER_OFFLINE_MODE
-  eng "The server is currently in offline mode"
+        chi "服务器目前处于离线模式"
+        eng "The server is currently in offline mode"
 
 ER_GIS_DIFFERENT_SRIDS
-  eng "Binary geometry function %s given two geometries of different srids: %u and %u, which should have been identical."
+        chi "二进制几何函数%s给定两个不同SRID的几何形状：%u和%u，应该是相同的。"
+        eng "Binary geometry function %s given two geometries of different srids: %u and %u, which should have been identical."
 
 ER_GIS_UNSUPPORTED_ARGUMENT
-  eng "Calling geometry function %s with unsupported types of arguments."
+        chi "调用几何函数%s与不受支持类型的参数。"
+        eng "Calling geometry function %s with unsupported types of arguments."
 
 ER_GIS_UNKNOWN_ERROR
-  eng "Unknown GIS error occurred in function %s."
+        chi "未知的GIS错误发生在功能%s中。"
+        eng "Unknown GIS error occurred in function %s."
 
 ER_GIS_UNKNOWN_EXCEPTION
-  eng "Unknown exception caught in GIS function %s."
+        chi "在GIS功能%s中捕获的未知异常。"
+        eng "Unknown exception caught in GIS function %s."
 
 ER_GIS_INVALID_DATA 22023
-  eng "Invalid GIS data provided to function %s."
+        chi "提供给功能%s的GIS数据无效。"
+        eng "Invalid GIS data provided to function %s."
 
 ER_BOOST_GEOMETRY_EMPTY_INPUT_EXCEPTION
-  eng "The geometry has no data in function %s."
+        chi "几何形状在功能%s中没有数据。"
+        eng "The geometry has no data in function %s."
 
 ER_BOOST_GEOMETRY_CENTROID_EXCEPTION
-  eng "Unable to calculate centroid because geometry is empty in function %s."
+        chi "无法计算质心，因为在功能%s中几何为空。"
+        eng "Unable to calculate centroid because geometry is empty in function %s."
 
 ER_BOOST_GEOMETRY_OVERLAY_INVALID_INPUT_EXCEPTION
-  eng "Geometry overlay calculation error: geometry data is invalid in function %s."
+        chi "几何叠加计算错误：几何数据在功能%s中无效。"
+        eng "Geometry overlay calculation error: geometry data is invalid in function %s."
 
 ER_BOOST_GEOMETRY_TURN_INFO_EXCEPTION
-  eng "Geometry turn info calculation error: geometry data is invalid in function %s."
+        chi "几何旋转信息计算错误：几何数据在功能%s中无效。"
+        eng "Geometry turn info calculation error: geometry data is invalid in function %s."
 
 ER_BOOST_GEOMETRY_SELF_INTERSECTION_POINT_EXCEPTION
-  eng "Analysis procedures of intersection points interrupted unexpectedly in function %s."
+        chi "在功能%s中出乎意料地中断交叉点的分析程序。"
+        eng "Analysis procedures of intersection points interrupted unexpectedly in function %s."
 
 ER_BOOST_GEOMETRY_UNKNOWN_EXCEPTION
-  eng "Unknown exception thrown in function %s."
+        chi "在功能%s中抛出的未知异常。"
+        eng "Unknown exception thrown in function %s."
 
 ER_STD_BAD_ALLOC_ERROR
-  eng "Memory allocation error: %-.256s in function %s."
+        chi "内存分配错误：%-.256s。函数%s。"
+        eng "Memory allocation error: %-.256s in function %s."
 
 ER_STD_DOMAIN_ERROR
-  eng "Domain error: %-.256s in function %s."
+        chi "域名错误：%-.256s. 函数%s"
+        eng "Domain error: %-.256s in function %s."
 
 ER_STD_LENGTH_ERROR
-  eng "Length error: %-.256s in function %s."
+        chi "长度误差：%-.256s函数%s。"
+        eng "Length error: %-.256s in function %s."
 
 ER_STD_INVALID_ARGUMENT
-  eng "Invalid argument error: %-.256s in function %s."
+        chi "无效的参数错误：%-.256s函数%s。"
+        eng "Invalid argument error: %-.256s in function %s."
 
 ER_STD_OUT_OF_RANGE_ERROR
-  eng "Out of range error: %-.256s in function %s."
+        chi "超出范围错误：%-.256s 函数%s。"
+        eng "Out of range error: %-.256s in function %s."
 
 ER_STD_OVERFLOW_ERROR
-  eng "Overflow error error: %-.256s in function %s."
+        chi "溢出错误：%-.256s。功能%s。"
+        eng "Overflow error: %-.256s in function %s."
 
 ER_STD_RANGE_ERROR
-  eng "Range error: %-.256s in function %s."
+        chi "范围错误：%-.256s函数%s。"
+        eng "Range error: %-.256s in function %s."
 
 ER_STD_UNDERFLOW_ERROR
-  eng "Underflow error: %-.256s in function %s."
+        chi "下溢错误：%-.256s函数%s。"
+        eng "Underflow error: %-.256s in function %s."
 
 ER_STD_LOGIC_ERROR
-  eng "Logic error: %-.256s in function %s."
+        chi "逻辑错误：%-.256s 函数%s。"
+        eng "Logic error: %-.256s in function %s."
 
 ER_STD_RUNTIME_ERROR
-  eng "Runtime error: %-.256s in function %s."
+        chi "运行时错误：%-.256s函数%s。"
+        eng "Runtime error: %-.256s in function %s."
 
 ER_STD_UNKNOWN_EXCEPTION
-  eng "Unknown exception: %-.384s in function %s."
+        chi "未知例外：%-.384s在函数%s中。"
+        eng "Unknown exception: %-.384s in function %s."
 
 ER_GIS_DATA_WRONG_ENDIANESS
-  eng "Geometry byte string must be little endian."
+        chi "几何字节字符串必须是小endian。"
+        eng "Geometry byte string must be little endian."
 
 ER_CHANGE_MASTER_PASSWORD_LENGTH
-  eng "The password provided for the replication user exceeds the maximum length of 32 characters"
+        chi "为Replication User提供的密码超过32个字符的最大长度"
+        eng "The password provided for the replication user exceeds the maximum length of 32 characters"
 
 ER_USER_LOCK_WRONG_NAME 42000
+        chi "用户级锁名名称'%-.192s'不正确。"
         eng "Incorrect user-level lock name '%-.192s'."
 
 # Should be different from ER_LOCK_DEADLOCK since it doesn't cause implicit
 # rollback. Should not be mapped to SQLSTATE 40001 for the same reason.
 ER_USER_LOCK_DEADLOCK
-  eng "Deadlock found when trying to get user-level lock; try rolling back transaction/releasing locks and restarting lock acquisition."
+        chi "在尝试获得用户级锁时发现死锁;尝试回滚交易/释放锁定并重新启动锁定采集。"
+        eng "Deadlock found when trying to get user-level lock; try rolling back transaction/releasing locks and restarting lock acquisition."
 
 ER_REPLACE_INACCESSIBLE_ROWS
-  eng "REPLACE cannot be executed as it requires deleting rows that are not in the view"
+        chi "无法执行REPLACE，因为它需要删除不在视图中的行"
+        eng "REPLACE cannot be executed as it requires deleting rows that are not in the view"
 
 ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_GIS
-  eng "Do not support online operation on table with GIS index"
-
+        chi "不要支持使用GIS索引的表中的在线操作"
+        eng "Do not support online operation on table with GIS index"
 # MariaDB extra error numbers starts from 4000
 skip-to-error-number 4000
 
 ER_COMMULTI_BADCONTEXT 0A000
+        chi "COM_MULTI无法返回给定上下文中的结果集"
         eng "COM_MULTI can't return a result set in the given context"
         ger "COM_MULTI kann im gegebenen Kontext keine Ergebnismenge zurückgeben"
         ukr "COM_MULTI не може повернути результати у цьому контексті"
 ER_BAD_COMMAND_IN_MULTI
+        chi "COM_MULTI不允许命令'%s'"
         eng "Command '%s' is not allowed for COM_MULTI"
         ukr "Команда '%s' не дозволена для COM_MULTI"
 ER_WITH_COL_WRONG_LIST
+        chi "使用列列表并选择字段列表具有不同的列计数"
         eng "WITH column list and SELECT field list have different column counts"
 ER_TOO_MANY_DEFINITIONS_IN_WITH_CLAUSE
+        chi "WITH条款中的元素太多了"
         eng "Too many WITH elements in WITH clause"
 ER_DUP_QUERY_NAME
+        chi "WITH子句重复查询名称%`-.64s"
         eng "Duplicate query name %`-.64s in WITH clause"
 ER_RECURSIVE_WITHOUT_ANCHORS
+        chi "没有元素'%s'递归的锚点"
         eng "No anchors for recursive WITH element '%s'"
 ER_UNACCEPTABLE_MUTUAL_RECURSION
+        chi "锚定表'%s'不可接受的相互递归"
         eng "Unacceptable mutual recursion with anchored table '%s'"
 ER_REF_TO_RECURSIVE_WITH_TABLE_IN_DERIVED
+        chi "物质化的衍生参考指向递归的WITH 表'%s'"
         eng "Reference to recursive WITH table '%s' in materialized derived"
 ER_NOT_STANDARD_COMPLIANT_RECURSIVE
+        chi "表'%s'R_WRONG_WINDOW_SPEC_NAME违反了递归定义的限制"
         eng "Restrictions imposed on recursive definitions are violated for table '%s'"R_WRONG_WINDOW_SPEC_NAME
 ER_WRONG_WINDOW_SPEC_NAME
-       eng "Window specification with name '%s' is not defined"
+        chi "没有定义名称'%s'的窗口规范"
+        eng "Window specification with name '%s' is not defined"
 ER_DUP_WINDOW_NAME
+        chi "具有相同名称'%s'的多个窗口规范"
         eng "Multiple window specifications with the same name '%s'"
 ER_PARTITION_LIST_IN_REFERENCING_WINDOW_SPEC
+        chi "窗口规范引用另一个'%s'不能包含分区列表"
         eng "Window specification referencing another one '%s' cannot contain partition list"
 ER_ORDER_LIST_IN_REFERENCING_WINDOW_SPEC
+        chi "引用的窗口规范'%s'已包含次序列表"
         eng "Referenced window specification '%s' already contains order list"
 ER_WINDOW_FRAME_IN_REFERENCED_WINDOW_SPEC
+        chi "引用的窗口规范'%s'不能包含窗口框架"
         eng "Referenced window specification '%s' cannot contain window frame"
 ER_BAD_COMBINATION_OF_WINDOW_FRAME_BOUND_SPECS
+        chi "窗框绑定规格的不可接受的组合"
         eng "Unacceptable combination of window frame bound specifications"
 ER_WRONG_PLACEMENT_OF_WINDOW_FUNCTION
+        chi "窗口函数仅在SELECT列表和ORDER BY子句中允许"
         eng "Window function is allowed only in SELECT list and ORDER BY clause"
 ER_WINDOW_FUNCTION_IN_WINDOW_SPEC
+        chi "窗口规范中不允许窗口功能"
         eng "Window function is not allowed in window specification"
 ER_NOT_ALLOWED_WINDOW_FRAME
+        chi "窗框不允许使用'%s'"
         eng "Window frame is not allowed with '%s'"
 ER_NO_ORDER_LIST_IN_WINDOW_SPEC
+        chi "在“%s”的窗口规范中没有订单列表"
         eng "No order list in window specification for '%s'"
 ER_RANGE_FRAME_NEEDS_SIMPLE_ORDERBY
+        chi "范围型框架需要单个排序键订购逐个条款"
         eng "RANGE-type frame requires ORDER BY clause with single sort key"
 ER_WRONG_TYPE_FOR_ROWS_FRAME
+        chi "行类型框架需要整数"
         eng "Integer is required for ROWS-type frame"
 ER_WRONG_TYPE_FOR_RANGE_FRAME
+        chi "范围类型框架需要数字数据类型"
         eng "Numeric datatype is required for RANGE-type frame"
 ER_FRAME_EXCLUSION_NOT_SUPPORTED
+        chi "帧排除尚不支持"
         eng "Frame exclusion is not supported yet"
 ER_WINDOW_FUNCTION_DONT_HAVE_FRAME
+        chi "此窗口功能可能没有窗口框架"
         eng "This window function may not have a window frame"
 ER_INVALID_NTILE_ARGUMENT
+        chi "NTILE的参数必须大于0"
         eng "Argument of NTILE must be greater than 0"
 ER_CONSTRAINT_FAILED 23000
+        chi "CONSTRAINT %`s失败的%`-.192s。%`-.192s"
         eng "CONSTRAINT %`s failed for %`-.192s.%`-.192s"
         ger "CONSTRAINT %`s fehlgeschlagen: %`-.192s.%`-.192s"
         rus "проверка CONSTRAINT %`s для %`-.192s.%`-.192s провалилась"
         ukr "Перевірка CONSTRAINT %`s для %`-.192s.%`-.192s не пройшла"
 ER_EXPRESSION_IS_TOO_BIG
+        chi "%s条款中的表达太大了"
         eng "Expression in the %s clause is too big"
 ER_ERROR_EVALUATING_EXPRESSION
+        chi "获得了一个错误评估存储的表达式%s"
         eng "Got an error evaluating stored expression %s"
 ER_CALCULATING_DEFAULT_VALUE
+        chi "计算默认值为%`s时出错"
         eng "Got an error when calculating default value for %`s"
 ER_EXPRESSION_REFERS_TO_UNINIT_FIELD 01000
+        chi "字段%`-.64s的表达指的是未初始化的字段%`s"
         eng "Expression for field %`-.64s is referring to uninitialized field %`s"
 ER_PARTITION_DEFAULT_ERROR
+        chi "只允许一个默认分区"
         eng "Only one DEFAULT partition allowed"
         ukr "Припустимо мати тільки один DEFAULT розділ" 
 ER_REFERENCED_TRG_DOES_NOT_EXIST
-  eng "Referenced trigger '%s' for the given action time and event type does not exist"
+        chi "给定动作时间和事件类型的引用触发'%s'不存在"
+        eng "Referenced trigger '%s' for the given action time and event type does not exist"
 ER_INVALID_DEFAULT_PARAM
+        chi "此类参数使用不支持默认/忽略值"
         eng "Default/ignore value is not supported for such parameter usage"
         ukr "Значення за замовчуванням або ігнороване значення не підтримано для цього випадку використання параьетра"
 ER_BINLOG_NON_SUPPORTED_BULK
+        chi "仅支持基于行的复制，支持批量操作"
         eng "Only row based replication supported for bulk operations"
 ER_BINLOG_UNCOMPRESS_ERROR
+        chi "解压压缩的binlog失败"
         eng "Uncompress the compressed binlog failed"
 ER_JSON_BAD_CHR
+        chi "坏JSON，参数%d 函数'%s' 位置%d"
         eng "Broken JSON string in argument %d to function '%s' at position %d"
 ER_JSON_NOT_JSON_CHR
+        chi "变量%d出现禁止字符，函数'%s'在%d处"
         eng "Character disallowed in JSON in argument %d to function '%s' at position %d"
 ER_JSON_EOS
+        chi "JSON文本中的意外结尾，参数%d 函数'%s'"
         eng "Unexpected end of JSON text in argument %d to function '%s'"
 ER_JSON_SYNTAX
+        chi "JSON文本语法错误 参数%d 函数'%s' 位置%d"
         eng "Syntax error in JSON text in argument %d to function '%s' at position %d"
 ER_JSON_ESCAPING
+        chi "JSON文本中逸出不正确 参数%d 函数'%s' 位置%d"
         eng "Incorrect escaping in JSON text in argument %d to function '%s' at position %d"
 ER_JSON_DEPTH
+        chi "超过JSON嵌套深度的%d限制 参数%d 函数'%s' 位置%d的"
         eng "Limit of %d on JSON nested strucures depth is reached in argument %d to function '%s' at position %d"
 ER_JSON_PATH_EOS
+        chi "JSON文本路径错误 参数%d 函数'%s'"
         eng "Unexpected end of JSON path in argument %d to function '%s'"
 ER_JSON_PATH_SYNTAX
+        chi "JSON路径语法错误 参数%d 函数'%s' 位置%d"
         eng "Syntax error in JSON path in argument %d to function '%s' at position %d"
 ER_JSON_PATH_DEPTH
+        chi "JSON路径深度上限达到：%d 参数%d 函数'%s' 位置%d"
         eng "Limit of %d on JSON path depth is reached in argument %d to function '%s' at position %d"
 ER_JSON_PATH_NO_WILDCARD
+        chi "JSON路径中的通配符不允许 参数%d 函数'%s'"
         eng "Wildcards in JSON path not allowed in argument %d to function '%s'"
 ER_JSON_PATH_ARRAY
+        chi "JSON路径应当以排列为终 参数%d 函数'%s'"
         eng "JSON path should end with an array identifier in argument %d to function '%s'"
 ER_JSON_ONE_OR_ALL
+        chi "函数'%s'的第二个参数必须是'一个'或'全部'"
         eng "Argument 2 to function '%s' must be "one" or "all"."
 ER_UNSUPPORT_COMPRESSED_TEMPORARY_TABLE
-	eng "CREATE TEMPORARY TABLE is not allowed with ROW_FORMAT=COMPRESSED or KEY_BLOCK_SIZE."
+        chi "CREATE TEMPORARY TABLE 不允许用ROW_FORMAT=COMPRESSED或KEY_BLOCK_SIZE"
+        eng "CREATE TEMPORARY TABLE is not allowed with ROW_FORMAT=COMPRESSED or KEY_BLOCK_SIZE."
 ER_GEOJSON_INCORRECT
+        chi "为st_geomfromgeojson函数指定了不正确的GeoJSON格式。"
         eng "Incorrect GeoJSON format specified for st_geomfromgeojson function."
 ER_GEOJSON_TOO_FEW_POINTS
+        chi "Geojson格式不正确 -  Linestring指定的太少点。"
         eng "Incorrect GeoJSON format - too few points for linestring specified."
 ER_GEOJSON_NOT_CLOSED
+        chi "Geojson格式不正确 - 多边形未关闭。"
         eng "Incorrect GeoJSON format - polygon not closed."
 ER_JSON_PATH_EMPTY
+        chi "path表达式'$'不允许在参数%d中允许运行'%s'。"
         eng "Path expression '$' is not allowed in argument %d to function '%s'."
 ER_SLAVE_SAME_ID
+        chi "与此从站相同的server_uuId / server_id的从站已连接到主设备"
         eng "A slave with the same server_uuid/server_id as this slave has connected to the master"
 ER_FLASHBACK_NOT_SUPPORTED
+        chi "闪回不支持%s%s"
         eng "Flashback does not support %s %s"
-
-
-
 # 
 # MyRocks error messages
 #
 ER_KEYS_OUT_OF_ORDER
-  eng "Keys are out order during bulk load"
+        chi "钥匙在散装负载期间出现订单"
+        eng "Keys are out order during bulk load"
 
 ER_OVERLAPPING_KEYS
-  eng "Bulk load rows overlap existing rows"
+        chi "批量负载行重叠现有行"
+        eng "Bulk load rows overlap existing rows"
 
 ER_REQUIRE_ROW_BINLOG_FORMAT
-  eng "Can't execute updates on master with binlog_format != ROW."
+        chi "binlog_format != ROW时无法在master上执行更新"
+        eng "Can't execute updates on master with binlog_format != ROW."
 
 ER_ISOLATION_MODE_NOT_SUPPORTED
-  eng "MyRocks supports only READ COMMITTED and REPEATABLE READ isolation levels. Please change from current isolation level %s"
+        chi "MyRocks仅支持读取承诺和可重复读取隔离级别。请从当前隔离级别的%s改变"
+        eng "MyRocks supports only READ COMMITTED and REPEATABLE READ isolation levels. Please change from current isolation level %s"
 
 ER_ON_DUPLICATE_DISABLED
-  eng "When unique checking is disabled in MyRocks, INSERT,UPDATE,LOAD statements with clauses that update or replace the key (i.e. INSERT ON DUPLICATE KEY UPDATE, REPLACE) are not allowed. Query: %s"
+        chi "当在MyRocks禁用唯一检查时，INSERT，UPDATE, LOAD，使用Clauses更新或替换索引的子句（即，在重复的重复键更新，替换）中，不允许使用。查询：%s"
+        eng "When unique checking is disabled in MyRocks, INSERT,UPDATE,LOAD statements with clauses that update or replace the key (i.e. INSERT ON DUPLICATE KEY UPDATE, REPLACE) are not allowed. Query: %s"
 
 ER_UPDATES_WITH_CONSISTENT_SNAPSHOT
-  eng "Can't execute updates when you started a transaction with START TRANSACTION WITH CONSISTENT [ROCKSDB] SNAPSHOT."
+        chi "START TRANSACTION WITH CONSISTENT [ROCKSDB] SNAPSHOT时，无法执行更新。"
+        eng "Can't execute updates when you started a transaction with START TRANSACTION WITH CONSISTENT [ROCKSDB] SNAPSHOT."
 
 ER_ROLLBACK_ONLY
-  eng "This transaction was rolled back and cannot be committed. Only supported operation is to roll it back, so all pending changes will be discarded. Please restart another transaction."
+        chi "此交易回滚并无法承诺。只支持支持的操作是滚动，因此将丢弃所有待处理的更改。请重新启动其他事务。"
+        eng "This transaction was rolled back and cannot be committed. Only supported operation is to roll it back, so all pending changes will be discarded. Please restart another transaction."
 
 ER_ROLLBACK_TO_SAVEPOINT
-  eng "MyRocks currently does not support ROLLBACK TO SAVEPOINT if modifying rows."
+        chi "如果修改行，MyRocks目前不支持保存点的回滚。"
+        eng "MyRocks currently does not support ROLLBACK TO SAVEPOINT if modifying rows."
 
 ER_ISOLATION_LEVEL_WITH_CONSISTENT_SNAPSHOT
-  eng "Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine."
+        chi "在RockSDB存储引擎中，START TRANSACTION WITH CONSISTENT SNAPSHOT 只支持REPEATABLE READ隔离"
+        eng "Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine."
 
 ER_UNSUPPORTED_COLLATION
-  eng "Unsupported collation on string indexed column %s.%s Use binary collation (%s)."
+        chi "字符串索引列%s的不受支持的归类。%s使用二进制校构(%s)。"
+        eng "Unsupported collation on string indexed column %s.%s Use binary collation (%s)."
 
 ER_METADATA_INCONSISTENCY
-  eng "Table '%s' does not exist, but metadata information exists inside MyRocks. This is a sign of data inconsistency. Please check if '%s.frm' exists, and try to restore it if it does not exist."
+        chi "表'%s'不存在，但MyRocks内存存在元数据信息。这是数据不一致的标志。请检查是否存在'%s.frm'，并尝试恢复如果它不存在。"
+        eng "Table '%s' does not exist, but metadata information exists inside MyRocks. This is a sign of data inconsistency. Please check if '%s.frm' exists, and try to restore it if it does not exist."
 
 ER_CF_DIFFERENT
-  eng "Column family ('%s') flag (%d) is different from an existing flag (%d). Assign a new CF flag, or do not change existing CF flag."
+        chi "列族（'%s'）标志（%d）与现有标志（%d）不同。分配新的CF标志，或者不要更改现有的CF标志。"
+        eng "Column family ('%s') flag (%d) is different from an existing flag (%d). Assign a new CF flag, or do not change existing CF flag."
 
 ER_RDB_TTL_DURATION_FORMAT
-  eng "TTL duration (%s) in MyRocks must be an unsigned non-null 64-bit integer."
+        chi "Myrocks中的TTL持续时间(%s)必须是无符号非空64位整数。"
+        eng "TTL duration (%s) in MyRocks must be an unsigned non-null 64-bit integer."
 
 ER_RDB_STATUS_GENERAL
+        chi "状态误差%d从RockSDB收到：%s"
         eng "Status error %d received from RocksDB: %s"
 
 ER_RDB_STATUS_MSG
+        chi "%s，状态误差%d从rocksdb收到：%s"
         eng "%s, Status error %d received from RocksDB: %s"
 
 ER_RDB_TTL_UNSUPPORTED
-  eng "TTL support is currently disabled when table has a hidden PK."
+        chi "当表有隐藏的PK时，目前禁用TTL支持。"
+        eng "TTL support is currently disabled when table has a hidden PK."
 
 ER_RDB_TTL_COL_FORMAT
-  eng "TTL column (%s) in MyRocks must be an unsigned non-null 64-bit integer, exist inside the table, and have an accompanying ttl duration."
+        chi "Myrocks中的TTL列(%s)必须是一个无符号的非空64位整数，存在于表内，并具有伴随的TTL持续时间。"
+        eng "TTL column (%s) in MyRocks must be an unsigned non-null 64-bit integer, exist inside the table, and have an accompanying ttl duration."
 
 ER_PER_INDEX_CF_DEPRECATED
-  eng "The per-index column family option has been deprecated"
+        chi "已弃用每个索引列族选项"
+        eng "The per-index column family option has been deprecated"
 
 ER_KEY_CREATE_DURING_ALTER
-  eng "MyRocks failed creating new key definitions during alter."
+        chi "MyRocks在Alter期间创建新的索引定义失败。"
+        eng "MyRocks failed creating new key definitions during alter."
 
 ER_SK_POPULATE_DURING_ALTER
-  eng "MyRocks failed populating secondary key during alter."
-
+        chi "MyRocks在Alter期间失败填充次要索引。"
+        eng "MyRocks failed populating secondary key during alter."
 # MyRocks messages end
+
 ER_SUM_FUNC_WITH_WINDOW_FUNC_AS_ARG
-  eng "Window functions can not be used as arguments to group functions."
+        chi "窗口函数不能用作组函数的参数。"
+        eng "Window functions can not be used as arguments to group functions."
 
 ER_NET_OK_PACKET_TOO_LARGE
-  eng "OK packet too large"
+        chi "好的包太大了"
+        eng "OK packet too large"
 
 ER_GEOJSON_EMPTY_COORDINATES
+        chi "Geojson格式不正确 - 空的'coordinates'阵列。"
         eng "Incorrect GeoJSON format - empty 'coordinates' array."
 
 ER_MYROCKS_CANT_NOPAD_COLLATION
-  eng "MyRocks doesn't currently support collations with \"No pad\" attribute."
+        chi "MyRocks目前不支持与“No Pad \”属性的归类。"
+        eng "MyRocks doesn't currently support collations with \"No pad\" attribute."
 
 ER_ILLEGAL_PARAMETER_DATA_TYPES2_FOR_OPERATION
+        chi "非法参数数据类型%s和%s为操作'%s'"
         eng "Illegal parameter data types %s and %s for operation '%s'"
 ER_ILLEGAL_PARAMETER_DATA_TYPE_FOR_OPERATION
+        chi "非法参数数据类型%s用于操作'%s'"
         eng "Illegal parameter data type %s for operation '%s'"
 ER_WRONG_PARAMCOUNT_TO_CURSOR 42000
+        chi "对Cursor的参数计数不正确'%-.192s'"
         eng "Incorrect parameter count to cursor '%-.192s'"
         rus "Некорректное количество параметров для курсора '%-.192s'"
 ER_UNKNOWN_STRUCTURED_VARIABLE
+        chi "未知的结构系统变量或行程变量'%-.*s'"
         eng "Unknown structured system variable or ROW routine variable '%-.*s'"
 ER_ROW_VARIABLE_DOES_NOT_HAVE_FIELD
+        chi "行变量'%-.192s'没有字段'%-.192s'"
         eng "Row variable '%-.192s' does not have a field '%-.192s'"
 ER_END_IDENTIFIER_DOES_NOT_MATCH
+        chi "结束标识符'%-.192s'不匹配'%-.192s'"
         eng "END identifier '%-.192s' does not match '%-.192s'"
 ER_SEQUENCE_RUN_OUT
+        chi "序列'%-.64s。%-.64s'已经用完了"
         eng "Sequence '%-.64s.%-.64s' has run out"
 ER_SEQUENCE_INVALID_DATA
+        chi "序列'%-.64s。%-.64s的值冲突"
         eng "Sequence '%-.64s.%-.64s' has out of range value for options"
 ER_SEQUENCE_INVALID_TABLE_STRUCTURE
+        chi "序列'%-.64s。%-.64s'表结构无效(%s)"
         eng "Sequence '%-.64s.%-.64s' table structure is invalid (%s)"
 ER_SEQUENCE_ACCESS_ERROR
+        chi "序列'%-.64s。%-.64s的访问错误"
         eng "Sequence '%-.64s.%-.64s' access error"
 ER_SEQUENCE_BINLOG_FORMAT
           eng "Sequences requires binlog_format mixed or row"
 ER_NOT_SEQUENCE 42S02
+        chi "'%-.64s。%-.64s'不是序列"
         eng "'%-.64s.%-.64s' is not a SEQUENCE"
 ER_NOT_SEQUENCE2 42S02
+        chi "'%-.192s'不是序列"
         eng "'%-.192s' is not a SEQUENCE"
 ER_UNKNOWN_SEQUENCES 42S02
+        chi "未知序列：'%-.300s'"
         eng "Unknown SEQUENCE: '%-.300s'"
 ER_UNKNOWN_VIEW 42S02
+        chi "未知视图：'%-.300s'"
         eng "Unknown VIEW: '%-.300s'"
 ER_WRONG_INSERT_INTO_SEQUENCE
+        chi "错误插入序列。人们只能将单表插入到序列对象（与mysqldump）中进行。如果要更改序列，请使用更改序列。"
         eng "Wrong INSERT into a SEQUENCE. One can only do single table INSERT into a sequence object (like with mysqldump).  If you want to change the SEQUENCE, use ALTER SEQUENCE instead."
 ER_SP_STACK_TRACE
+        chi "在%u中以%s"
         eng "At line %u in %s"
 ER_PACKAGE_ROUTINE_IN_SPEC_NOT_DEFINED_IN_BODY
+        chi "在包规范中声明子程序'%-.192s'，但未在包主体中定义"
         eng "Subroutine '%-.192s' is declared in the package specification but is not defined in the package body"
 ER_PACKAGE_ROUTINE_FORWARD_DECLARATION_NOT_DEFINED
+        chi "子程序'%-.192s'具有前向声明但未定义"
         eng "Subroutine '%-.192s' has a forward declaration but is not defined"
 ER_COMPRESSED_COLUMN_USED_AS_KEY
-  eng "Compressed column '%-.192s' can't be used in key specification"
+        chi "压缩列'%-.192s'不能用于索引规范"
+        eng "Compressed column '%-.192s' can't be used in key specification"
 ER_UNKNOWN_COMPRESSION_METHOD
-  eng "Unknown compression method: %s"
+        chi "未知压缩方法：%s"
+        eng "Unknown compression method: %s"
 ER_WRONG_NUMBER_OF_VALUES_IN_TVC
+        chi "使用的表值构造函数具有不同数量的值"
         eng "The used table value constructor has a different number of values"
 ER_FIELD_REFERENCE_IN_TVC
-	eng "Field reference '%-.192s' can't be used in table value constructor"
+        chi "字段参考'%-.192s'不能用于表值构造函数"
+        eng "Field reference '%-.192s' can't be used in table value constructor"
 ER_WRONG_TYPE_FOR_PERCENTILE_FUNC
+        chi "%s函数需要数字数据类型"
         eng "Numeric datatype is required for %s function"
 ER_ARGUMENT_NOT_CONSTANT
+        chi "%s函数的参数不是分区的常量"
         eng "Argument to the %s function is not a constant for a partition"
 ER_ARGUMENT_OUT_OF_RANGE
+        chi "%s函数的参数不属于范围[0,1]"
         eng "Argument to the %s function does not belong to the range [0,1]"
 ER_WRONG_TYPE_OF_ARGUMENT
+        chi "%s函数仅接受可以转换为数字类型的参数"
         eng "%s function only accepts arguments that can be converted to numerical types"
 ER_NOT_AGGREGATE_FUNCTION
+        chi "在错误的上下文中使用的聚合特定指令（fetch组下一行）"
         eng "Aggregate specific instruction (FETCH GROUP NEXT ROW) used in a wrong context"
 ER_INVALID_AGGREGATE_FUNCTION
+        chi "聚合函数丢失的聚合特定指令（fetch组下一行）"
         eng "Aggregate specific instruction(FETCH GROUP NEXT ROW) missing from the aggregate function"
 ER_INVALID_VALUE_TO_LIMIT
+        chi "限制仅接受整数值"
         eng "Limit only accepts integer values"
 ER_INVISIBLE_NOT_NULL_WITHOUT_DEFAULT
+        chi "隐形列%`s必须具有默认值"
         eng "Invisible column %`s must have a default value"
-
-
 # MariaDB error numbers related to System Versioning
 
+
 ER_UPDATE_INFO_WITH_SYSTEM_VERSIONING
+        chi "匹配的行：%ld已更改：%ld插入：%ld警告：%ld"
         eng "Rows matched: %ld  Changed: %ld  Inserted: %ld  Warnings: %ld"
 
 ER_VERS_FIELD_WRONG_TYPE
+        chi "%`s必须为系统版本为表%s的类型%`s"
         eng "%`s must be of type %s for system-versioned table %`s"
 
 ER_VERS_ENGINE_UNSUPPORTED
+        chi "Transaction-Precise系统版本控制%`s不受支持"
         eng "Transaction-precise system versioning for %`s is not supported"
 
 ER_UNUSED_23
+        chi "你永远不应该看到它"
         eng "You should never see it"
 
 ER_PARTITION_WRONG_TYPE
+        chi "错误的分区类型，预期类型：%`s"
         eng "Wrong partitioning type, expected type: %`s"
 
 WARN_VERS_PART_FULL
+        chi "版本化表%`s.%`s：partition%`s已满，添加更多历史分区"
         eng "Versioned table %`s.%`s: partition %`s is full, add more HISTORY partitions"
 
 WARN_VERS_PARAMETERS
+        chi "也许缺少参数：%s"
         eng "Maybe missing parameters: %s"
 
 ER_VERS_DROP_PARTITION_INTERVAL
+        chi "只能在旋转间隔时丢弃最旧的分区"
         eng "Can only drop oldest partitions when rotating by INTERVAL"
 
 ER_UNUSED_25
+        chi "你永远不应该看到它"
         eng "You should never see it"
-
 WARN_VERS_PART_NON_HISTORICAL
+        chi "分区%`s包含非历史数据"
         eng "Partition %`s contains non-historical data"
 
 ER_VERS_ALTER_NOT_ALLOWED
+        chi "系统版本为%`s.%`s不允许。更改@@system_versioning_alter_history用ALTER。"
         eng "Not allowed for system-versioned %`s.%`s. Change @@system_versioning_alter_history to proceed with ALTER."
 
 ER_VERS_ALTER_ENGINE_PROHIBITED
+        chi "不允许系统版本为%`s.%`s。不支持更改返回/来自本机系统版本传输引擎。"
         eng "Not allowed for system-versioned %`s.%`s. Change to/from native system versioning engine is not supported."
 
 ER_VERS_RANGE_PROHIBITED
+        chi "不允许使用SYSTEM_TIME范围选择器"
         eng "SYSTEM_TIME range selector is not allowed"
 
 ER_CONFLICTING_FOR_SYSTEM_TIME
+        chi "与递归的System_time子句相冲突"
         eng "Conflicting FOR SYSTEM_TIME clauses in WITH RECURSIVE"
 
 ER_VERS_TABLE_MUST_HAVE_COLUMNS
+        chi "表%`s必须至少有一个版本后的列"
         eng "Table %`s must have at least one versioned column"
 
 ER_VERS_NOT_VERSIONED
+        chi "表%`s不是系统版本的"
         eng "Table %`s is not system-versioned"
 
 ER_MISSING
+        chi "%`s的错误参数：缺少'%s'"
         eng "Wrong parameters for %`s: missing '%s'"
 
 ER_VERS_PERIOD_COLUMNS
+        chi "system_time的时期必须使用列%`s和%`s"
         eng "PERIOD FOR SYSTEM_TIME must use columns %`s and %`s"
 
 ER_PART_WRONG_VALUE
+        chi "用于分区%`s的错误参数：'%s'的错误值"
         eng "Wrong parameters for partitioned %`s: wrong value for '%s'"
 
 ER_VERS_WRONG_PARTS
+        chi "%`s的错误分区：必须至少有一个HISTORY，只能有一个CURRENT"
         eng "Wrong partitions for %`s: must have at least one HISTORY and exactly one last CURRENT"
 
 ER_VERS_NO_TRX_ID
+        chi "TRX_ID%llu在`mysql.transaction_registry`中找不到"
         eng "TRX_ID %llu not found in `mysql.transaction_registry`"
 
 ER_VERS_ALTER_SYSTEM_FIELD
+        chi "无法更改系统版本配置字段%`s"
         eng "Can not change system versioning field %`s"
 
 ER_DROP_VERSIONING_SYSTEM_TIME_PARTITION
+        chi "无法删除由SYSTEM_TIME分区的表%`s的系统版本"
         eng "Can not DROP SYSTEM VERSIONING for table %`s partitioned BY SYSTEM_TIME"
 
 ER_VERS_DB_NOT_SUPPORTED
-      eng "System-versioned tables in the %`s database are not supported"
+        chi "不支持%`s数据库中的系统版本化表"
+        eng "System-versioned tables in the %`s database are not supported"
 
 ER_VERS_TRT_IS_DISABLED
+        chi "事务注册表已禁用"
         eng "Transaction registry is disabled"
 
 ER_VERS_DUPLICATE_ROW_START_END
-	eng "Duplicate ROW %s column %`s"
+        chi "重复行%s列%`s"
+        eng "Duplicate ROW %s column %`s"
 
 ER_VERS_ALREADY_VERSIONED
+        chi "表%`s已经是系统版本的"
         eng "Table %`s is already system-versioned"
 
 ER_UNUSED_24
-	eng "You should never see it"
+        chi "你永远不应该看到它"
+        eng "You should never see it"
 
 ER_VERS_NOT_SUPPORTED
-	eng "System-versioned tables do not support %s"
+        chi "系统版本的表不支持%s"
+        eng "System-versioned tables do not support %s"
 
 ER_VERS_TRX_PART_HISTORIC_ROW_NOT_SUPPORTED
+        chi "事务 - 精确的系统 - 版本的表不支持按行开始或行末端分区"
         eng "Transaction-precise system-versioned tables do not support partitioning by ROW START or ROW END"
 ER_INDEX_FILE_FULL
+        chi "表'%-.192s'的索引文件已满"
         eng "The index file for table '%-.192s' is full"
 ER_UPDATED_COLUMN_ONLY_ONCE
+        chi "列%`s.%`s在单个更新语句中不能更换一次"
         eng "The column %`s.%`s cannot be changed more than once in a single UPDATE statement"
 ER_EMPTY_ROW_IN_TVC
+        chi "在此上下文中，表值构造函数不允许在没有元素的行"
         eng "Row with no elements is not allowed in table value constructor in this context"
 ER_VERS_QUERY_IN_PARTITION
+        chi "表%`s的SYSTEM_TIME分区不支持历史查询"
         eng "SYSTEM_TIME partitions in table %`s does not support historical query"
 ER_KEY_DOESNT_SUPPORT
+        chi "%s索引%`s不支持此操作"
         eng "%s index %`s does not support this operation"
 ER_ALTER_OPERATION_TABLE_OPTIONS_NEED_REBUILD
-	eng "Changing table options requires the table to be rebuilt"
+        chi "更改表选项需要将要重建的表格重建"
+        eng "Changing table options requires the table to be rebuilt"
 ER_BACKUP_LOCK_IS_ACTIVE
+        chi "由于您在运行BACKUP STAGE，无法执行命令"
         eng "Can't execute the command as you have a BACKUP STAGE active"
 ER_BACKUP_NOT_RUNNING
+        chi "您必须启动备份“备份阶段开始”"
         eng "You must start backup with \"BACKUP STAGE START\""
 ER_BACKUP_WRONG_STAGE
+        chi "备份阶段'%s'相同或在当前备份阶段'%s'之前"
         eng "Backup stage '%s' is same or before current backup stage '%s'"
 ER_BACKUP_STAGE_FAILED
+        chi "备份阶段'%s'失败"
         eng "Backup stage '%s' failed"
 ER_BACKUP_UNKNOWN_STAGE
+        chi "未知备份阶段：'%s'。阶段应该是START，FLUSH，BLOCK_DDL，BLOCK_COMIT或END之一"
         eng "Unknown backup stage: '%s'. Stage should be one of START, FLUSH, BLOCK_DDL, BLOCK_COMMIT or END"
 ER_USER_IS_BLOCKED
+        chi "由于凭证错误太多，用户被阻止;用'FLUSH PRIVILEGES'解锁"
         eng "User is blocked because of too many credential errors; unblock with 'FLUSH PRIVILEGES'"
 ER_ACCOUNT_HAS_BEEN_LOCKED
+        chi "访问拒绝，此帐户已锁定"
         eng "Access denied, this account is locked"
         rum "Acces refuzat, acest cont este blocat"
 ER_PERIOD_TEMPORARY_NOT_ALLOWED
+        chi "应用程序时间段表不能临时"
         eng "Application-time period table cannot be temporary"
 ER_PERIOD_TYPES_MISMATCH
+        chi "%`s的期间的字段有不同的类型"
         eng "Fields of PERIOD FOR %`s have different types"
 ER_MORE_THAN_ONE_PERIOD
+        chi "无法指定多个应用程序时间段"
         eng "Cannot specify more than one application-time period"
 ER_PERIOD_FIELD_WRONG_ATTRIBUTES
+        chi "期间字段%`s不能是%s"
         eng "Period field %`s cannot be %s"
 ER_PERIOD_NOT_FOUND
+        chi "期间%`s未在表中找到"
         eng "Period %`s is not found in table"
 ER_PERIOD_COLUMNS_UPDATED
+        chi "列%`s在更新集列表中指定的周期%`s中使用"
         eng "Column %`s used in period %`s specified in update SET list"
 ER_PERIOD_CONSTRAINT_DROP
+        chi "无法DROP CONSTRAINT `%s`。使用DROP PERIOD `%s`"
         eng "Can't DROP CONSTRAINT `%s`. Use DROP PERIOD `%s` for this"
 ER_TOO_LONG_KEYPART 42000 S1009
+        chi "指定的索引部分太长；最大索引部分长度为 %u 个字节"
         eng "Specified key part was too long; max key part length is %u bytes"


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28227*

## Description
- Simplified Chinese translation added
- Character encoding is gdk
-- gdk covers more characters
-- gdk includes both Simplified and Traditional
-- best option I think, may need to work along with other locale
settings
- Other cleanup
-- Within each error, messages are sorted according to language code
-- More consistent formatting (8 spaces proceeding each translation)
-- The formatting consistency change makes merging difficult initially. I think we can suffer through the pain now, and subsequent change will be much easier.

## How can this PR be tested?
This PR is for error message translation. It shouldn't affection any functions of MariaDB. Visual verification and subsequent refinement will be needed after release.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
The translation is based on MariaDB 10.4's error messages in English.