### PR TITLE
MDEV-28380: Remove obsolette liburing installing from Debian Buster Backports

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -54,8 +54,6 @@ build bullseye-backports:
 build buster-backports:
   extends: .build-package
   script:
-    # Force installation of liburing-dev from buster-backports
-    - apt-get update && apt-cache policy && eatmydata apt-get install liburing-dev
     # Increase default backports priority policy from '100' to '500' so it can actually be used
     - |
       cat << EOF > /etc/apt/preferences.d/enable-backports-to-satisfy-dependencies


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28380*

## Description
In 10.9 Salsa-CI `.salsa-ci` file there is line where `liburing` is tried to install as it's installed correctly.

## How can this PR be tested?
As this is purely Salsa-CI problem it can't be tested otherwise than in Salsa-CI or with correct Docker image.
Current build without commit is here:
https://salsa.debian.org/illuusio/mariadb-server/-/jobs/2662193/raw
and with commit it can be found here:
https://salsa.debian.org/illuusio/mariadb-server/-/jobs/2687878/raw
Where it drop to correctly to libfmt-dev problem which will handled in PR #2103


## Basing the PR against the correct MariaDB version
- [*] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility
Provides same functionality as earlier