### PR TITLE
MDEV-28379: Remove libfmt-dev requirement when building buster-backports

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -51,19 +51,22 @@ build bullseye-backports:
   variables:
     RELEASE: bullseye-backports
 
-build buster-backports:
-  extends: .build-package
-  script:
-    # Increase default backports priority policy from '100' to '500' so it can actually be used
-    - |
-      cat << EOF > /etc/apt/preferences.d/enable-backports-to-satisfy-dependencies
-      Package: *
-      Pin: release n=buster-*
-      Pin-Priority: 500
-      EOF
-    - *autobake-deb-steps
-  variables:
-    RELEASE: buster-backports
+# Commented out because:
+# Debian Buster Backports does not provide libfmt 7.0 or above (Only version 6.x)
+# and version builded from source tree is not preferred. If dependencies are satified in future enable again.
+# build buster-backports:
+#   extends: .build-package
+#   script:
+#     # Increase default backports priority policy from '100' to '500' so it can actually be used
+#     - |
+#       cat << EOF > /etc/apt/preferences.d/enable-backports-to-satisfy-dependencies
+#       Package: *
+#       Pin: release n=buster-*
+#       Pin-Priority: 500
+#       EOF
+#     - *autobake-deb-steps
+#   variables:
+#     RELEASE: buster-backports
 
 # base image missing git
 build i386:
@@ -520,40 +523,41 @@ mysql-8.0 Sid to mariadb-10.7 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
+# Build 'buster-backports' is commented out and does not exist currently
 # Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
 # The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
-mysql-8.0 Focal to mariadb-10.7 upgrade:
-  stage: upgrade extras
-  needs:
-    - job: build buster-backports
-  image: debian:buster
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    # Add Ubuntu Focal archive keys and repository
-    - apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
-    - apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 871920D1991BC93C 3B4FE6ACC0B21F32
-    - echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" > /etc/apt/sources.list.d/ubuntu.list
-    - apt-get update
-    # First install often fail due to bug in mysql-8.0
-    - apt-get install -y mysql-server 'libmysqlc*' || true
-    - sleep 10 && apt-get install -f
-    - *test-verify-initial
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update
-    - *test-install
-    - service mysql status
-    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+# mysql-8.0 Focal to mariadb-10.7 upgrade:
+#   stage: upgrade extras
+#   needs:
+#     - job: build buster-backports
+#   image: debian:buster
+#   artifacts:
+#     when: always
+#     name: "$CI_BUILD_NAME"
+#     paths:
+#       - ${WORKING_DIR}/debug
+#   script:
+#     - *test-prepare-container
+#     # Add Ubuntu Focal archive keys and repository
+#     - apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
+#     - apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 871920D1991BC93C 3B4FE6ACC0B21F32
+#     - echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" > /etc/apt/sources.list.d/ubuntu.list
+#     - apt-get update
+#     # First install often fail due to bug in mysql-8.0
+#     - apt-get install -y mysql-server 'libmysqlc*' || true
+#     - sleep 10 && apt-get install -f
+#     - *test-verify-initial
+#     # Enable backports to make galera-4 available
+#     - echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update
+#     - *test-install
+#     - service mysql status
+#     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+#     - *test-verify-final
+#   variables:
+#     GIT_STRATEGY: none
+#   except:
+#     variables:
+#       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
 mariadb.org-10.6 to mariadb-10.7 upgrade:
   stage: upgrade extras
@@ -728,65 +732,67 @@ mariadb.org-10.2 to mariadb-10.7 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mysql.com-5.7 to mariadb-10.7 upgrade:
-  stage: upgrade extras
-  needs:
-    - job: build buster-backports
-  image: debian:buster
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - |
-      apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
-      apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 467B942D3A79BD29
-      echo "deb https://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
-      apt-get update
-      apt-get install -y 'mysql*' 'libmysqlc*'
-    - *test-verify-initial
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
-    - *test-install
-    - service mysql status
-    - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+# Build 'buster-backports' is commented out currently
+# mysql.com-5.7 to mariadb-10.7 upgrade:
+#   stage: upgrade extras
+#   needs:
+#     - job: build buster-backports
+#   image: debian:buster
+#   artifacts:
+#     when: always
+#     name: "$CI_BUILD_NAME"
+#     paths:
+#       - ${WORKING_DIR}/debug
+#   script:
+#     - *test-prepare-container
+#     - |
+#       apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
+#       apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 467B942D3A79BD29
+#       echo "deb https://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+#       apt-get update
+#       apt-get install -y 'mysql*' 'libmysqlc*'
+#     - *test-verify-initial
+#     # Enable backports to make galera-4 available
+#     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
+#     - *test-install
+#     - service mysql status
+#     - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server
+#     - *test-verify-final
+#   variables:
+#     GIT_STRATEGY: none
+#   except:
+#     variables:
+#       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-percona-xtradb-5.7 to mariadb-10.7 upgrade (MDEV-22679):
-  stage: upgrade extras
-  needs:
-    - job: build buster-backports
-  image: debian:buster
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - |
-      apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
-      apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 9334A25F8507EFA5
-      echo "deb https://repo.percona.com/apt/ buster main" > /etc/apt/sources.list.d/mysql.list
-      apt-get update
-      apt-get install -y percona-xtradb-cluster-full-57 percona-xtrabackup-24 percona-toolkit pmm2-client
-    - service mysql status
-    - *test-verify-initial
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
-    - *test-install
-    - service mysql status
-    - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+# Build 'buster-backports' is commented out currently
+# percona-xtradb-5.7 to mariadb-10.7 upgrade (MDEV-22679):
+#   stage: upgrade extras
+#   needs:
+#     - job: build buster-backports
+#   image: debian:buster
+#   artifacts:
+#     when: always
+#     name: "$CI_BUILD_NAME"
+#     paths:
+#       - ${WORKING_DIR}/debug
+#   script:
+#     - *test-prepare-container
+#     - |
+#       apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
+#       apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 9334A25F8507EFA5
+#       echo "deb https://repo.percona.com/apt/ buster main" > /etc/apt/sources.list.d/mysql.list
+#       apt-get update
+#       apt-get install -y percona-xtradb-cluster-full-57 percona-xtrabackup-24 percona-toolkit pmm2-client
+#     - service mysql status
+#     - *test-verify-initial
+#     # Enable backports to make galera-4 available
+#     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
+#     - *test-install
+#     - service mysql status
+#     - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server
+#     - *test-verify-final
+#   variables:
+#     GIT_STRATEGY: none
+#   except:
+#     variables:
+#       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28379*

## Description
Buster-backports only have libfmt-dev version 6.0 and MariaDB requires libfmt-dev version 7.0. If it's not provided CMake will handle download and it will be build during compilation. **This should not be done no where else than using Buster Backports.**

So this fixes problem:
```
The following packages have unmet dependencies:
 builddeps:. : Depends: libfmt-dev (>= 7.0.0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.

```

## How can this PR be tested?
This one can be tested on Debian Buster Image with enabled backports repository.
Salsa-CI run this one is from here:
https://salsa.debian.org/illuusio/mariadb-server/-/jobs/2689802/raw
Currently it fails because lack of space which should be investigated later on.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
More testing is more backward compatibility