### PR TITLE
MDEV-6655: mysqld_multi default log location in wrong directory

### DIFF
--- a/scripts/mysqld_multi.sh
+++ b/scripts/mysqld_multi.sh
@@ -241,7 +241,7 @@ sub init_log
   }
   if (!defined($logdir))
   {
-    $logdir= "@datadir@" if (-d "@datadir@" && -w "@datadir@");
+    $logdir= "@localstatedir@" if (-d "@localstatedir@" && -w "@localstatedir@");
   }
   if (!defined($logdir))
   {


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-6655

## Description
The mysqld_multi script template used @datadir@ as default log
destination, this is not the MariaDB datadir in this context though
but rather the -- typically write-only -- /share dir.

The correct placeholder to use here is @localstatedir@ which gets
replaced with the actual MariaDB datadir

## How can this PR be tested?
Check resulting mysqld_multi script, without patch it has

```
  if (!defined($logdir))
  {
    $logdir= "/usr/share/mysql" if (-d "/usr/share/mysql" && -w "/usr/share/mysql");
  }
```
by default, with `/usr/share/mysql` typically being a read-only directory. With the patch pulled it will read

```
  if (!defined($logdir))
  {
    $logdir= "/usr/local/mysql/data" if (-d "/usr/local/mysql/data" && -w "/usr/local/mysql/data");
  }
```

instead, so now using the actual server default datadir for log output.


## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

Submitted against dev branch only for now, but may be worth considering to merge this into all supported releases

## Backward compatibility
Should not have any backwards compatibility related issues as nobody should be relying on the current behavior anyway
