### PR TITLE
MDEV-28053 Sysbench data load crashes Galera secondary node in async

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-28053.result
+++ b/mysql-test/suite/galera/r/MDEV-28053.result
@@ -1,0 +1,14 @@
+connection node_2;
+connection node_1;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connection node_3;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
+connection node_2;
+connection node_3;
+DROP TABLE t1;
+connection node_2;
+connection node_2;
+STOP SLAVE;
+RESET SLAVE ALL;
+connection node_3;
+RESET MASTER;

--- a/mysql-test/suite/galera/t/MDEV-28053.cnf
+++ b/mysql-test/suite/galera/t/MDEV-28053.cnf
@@ -1,0 +1,6 @@
+!include ../galera_2nodes_as_slave.cnf
+
+[mysqld]
+slave_parallel_threads=4
+slave_parallel_mode=optimistic
+gtid_strict_mode=1

--- a/mysql-test/suite/galera/t/MDEV-28053.test
+++ b/mysql-test/suite/galera/t/MDEV-28053.test
@@ -1,0 +1,61 @@
+#
+# MDEV-28053 - Sysbench data load crashes Galera secondary node in
+# async master slave setup
+#
+# Setup: node 3 is a regular MariaDB server, nodes 1 and 2 are members
+# of a Galera cluster. Node 2 connects to node 3 through async replication.
+#
+# Test uses multiple parallel async applier threads (see MDEV-28053.cnf)
+#
+
+--source include/have_innodb.inc
+--source include/galera_cluster.inc
+
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+
+--connection node_3
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
+
+#
+# Execute a few INSERTs, to simulate sysbench data load phase
+#
+--let $counter=100
+--disable_query_log
+while ($counter) {
+  --connection node_3
+  INSERT INTO t1 VALUES();
+  --dec $counter
+}
+--enable_query_log
+--let gtid = `SELECT @@last_gtid`
+
+#
+# Start async replication on node 2.
+# If bug is present, expect a crash when applying
+# events concurrently.
+#
+--connection node_2
+--disable_query_log
+--disable_result_log
+--eval CHANGE MASTER TO  MASTER_HOST='127.0.0.1', MASTER_USER='root', MASTER_PORT=$NODE_MYPORT_3;
+START SLAVE;
+--eval SELECT MASTER_GTID_WAIT('$gtid', 600)
+--enable_result_log
+--enable_query_log
+
+#
+# Cleanup
+#
+--connection node_3
+DROP TABLE t1;
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+
+--connection node_2
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--connection node_3
+RESET MASTER;

--- a/sql/wsrep_trans_observer.h
+++ b/sql/wsrep_trans_observer.h
@@ -229,6 +229,10 @@ static inline int wsrep_before_prepare(THD* thd, bool all)
   WSREP_DEBUG("wsrep_before_prepare: %d", wsrep_is_real(thd, all));
   int ret= 0;
   DBUG_ASSERT(wsrep_run_commit_hook(thd, all));
+  if ((ret= thd->wsrep_parallel_slave_wait_for_prior_commit()))
+  {
+    DBUG_RETURN(ret);
+  }
   if ((ret= thd->wsrep_cs().before_prepare()) == 0)
   {
     DBUG_ASSERT(!thd->wsrep_trx().ws_meta().gtid().is_undefined());


### PR DESCRIPTION
master slave setup

This patch fixes a problem that arises when a Galera node acts as a
replica for native replication. When parallel applying is enabled, it
is possible to end up with attempts to write binlog events with gtids
out of order. This happens because when multiple events are delivered
from the native replication stream and applied in concurrently, it is
for them to be replicated to the Galera cluster in an order which is
different from the original order in which they were committed in the
aync replication master.
To correct this behavior we now wait_for_prior_commit() before
replicating changes though galera. As a consequence, parallel appliers
may apply events in parallel until the galera replication step, which
is now serialized.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
