### PR TITLE
MDEV-27314 Condense innodb buffer pool resize message

### DIFF
--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_resize.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_resize.test
@@ -7,7 +7,7 @@
 
 let $wait_timeout = 180;
 let $wait_condition =
-  SELECT SUBSTR(variable_value, 1, 31) = 'Completed resizing buffer pool.'
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
   FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
 

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_temporary.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_temporary.test
@@ -15,7 +15,7 @@ SET GLOBAL innodb_buffer_pool_size=8388608;
 
 let $wait_timeout = 60;
 let $wait_condition =
-  SELECT SUBSTR(variable_value, 1, 31) = 'Completed resizing buffer pool.'
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
   FROM information_schema.global_status
   WHERE variable_name = 'INNODB_BUFFER_POOL_RESIZE_STATUS';
 --source include/wait_condition.inc

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_with_chunks.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_with_chunks.test
@@ -8,7 +8,7 @@
 
 let $wait_timeout = 180;
 let $wait_condition =
-  SELECT SUBSTR(variable_value, 1, 31) = 'Completed resizing buffer pool.'
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
   FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
 

--- a/mysql-test/suite/innodb/t/restart.test
+++ b/mysql-test/suite/innodb/t/restart.test
@@ -93,7 +93,7 @@ DROP TABLE tr,tc,td;
 
 let $wait_timeout = 180;
 let $wait_condition =
-  SELECT SUBSTR(variable_value, 1, 31) = 'Completed resizing buffer pool.'
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
   FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
 

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_size_basic.test
@@ -25,7 +25,7 @@
 --source include/have_innodb.inc
 
 let $wait_condition =
-  SELECT SUBSTR(variable_value, 1, 31) = 'Completed resizing buffer pool.'
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
   FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
 

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1933,9 +1933,8 @@ calc_buf_pool_size:
 
 	if (srv_buf_pool_old_size != srv_buf_pool_size) {
 
-		ib::info() << "Completed resizing buffer pool from "
-			<< srv_buf_pool_old_size
-			<< " to " << srv_buf_pool_size << " bytes.";
+	        buf_resize_status("Completed resizing buffer pool from %zu to %zu bytes."
+			    ,srv_buf_pool_old_size, srv_buf_pool_size);
 		srv_buf_pool_old_size = srv_buf_pool_size;
 	}
 
@@ -1947,11 +1946,8 @@ calc_buf_pool_size:
 	}
 #endif /* BTR_CUR_HASH_ADAPT */
 
-	if (!warning) {
-		buf_resize_status("Completed resizing buffer pool.");
-	} else {
+	if (warning)
 		buf_resize_status("Resizing buffer pool failed");
-	}
 
 	ut_d(validate());
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17419,9 +17419,6 @@ innodb_buffer_pool_size_update(THD*,st_mysql_sys_var*,void*, const void* save)
 		"Buffer pool resize requested");
 
 	buf_resize_start();
-
-	ib::info() << export_vars.innodb_buffer_pool_resize_status
-		<< " (New size: " << in_val << " bytes).";
 }
 
 /** The latest assigned innodb_ft_aux_table name */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-27314*

## Description
InnoDB buffer pool resize messages are more succinct from this change:

Before:
```
2022-05-07 17:10:33 0 [Note] InnoDB: Completed resizing buffer pool from 14745600 to 19660800 bytes.
2022-05-07 17:10:33 0 [Note] InnoDB: Completed resizing buffer pool.
2022-05-07 17:10:33 8 [Note] InnoDB: Completed resizing buffer pool. (New size: 19660800 bytes).
```
After:
```
2022-05-07 17:10:33 0 [Note] InnoDB: Completed resizing buffer pool from 14745600 to 19660800 bytes.
```

## How can this PR be tested?
This PR just cleans up the output/log messages. Test case may not be necessary.

I have verified the correct, more condensed messages are written to the error log. Reviewers and engineer who wrote the issue originally should be able to manually verify the output change also.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

