### PR TITLE
MDEV-28586: GPLv2 and LGPLv2.1 are not correct license names for SUSE based distros

### DIFF
--- a/cmake/cpack_rpm.cmake
+++ b/cmake/cpack_rpm.cmake
@@ -43,14 +43,26 @@ ELSE()
 ENDIF()
 
 SET(CPACK_RPM_PACKAGE_RELEASE "1%{?dist}")
-SET(CPACK_RPM_PACKAGE_LICENSE "GPLv2")
+IF(RPM MATCHES "opensuse|sles")
+  # openSUSE and SLES RPM names licenses are based on SPDX specification
+  # https://spdx.org/licenses/
+  SET(CPACK_RPM_PACKAGE_LICENSE "GPL-2.0-only")
+ELSE()
+  # Fedora and RHEL follow these guidelines
+  # https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Software_License_List
+  SET(CPACK_RPM_PACKAGE_LICENSE "GPLv2")
+ENDIF()
 SET(CPACK_RPM_PACKAGE_RELOCATABLE FALSE)
 SET(CPACK_PACKAGE_RELOCATABLE FALSE)
 SET(CPACK_RPM_PACKAGE_GROUP "Applications/Databases")
 SET(CPACK_RPM_PACKAGE_URL ${CPACK_PACKAGE_URL})
 
 SET(CPACK_RPM_shared_PACKAGE_VENDOR "MariaDB Corporation Ab")
-SET(CPACK_RPM_shared_PACKAGE_LICENSE "LGPLv2.1")
+IF(RPM MATCHES "opensuse|sles")
+  SET(CPACK_RPM_shared_PACKAGE_LICENSE "LGPL-2.1-only")
+ELSE()
+  SET(CPACK_RPM_shared_PACKAGE_LICENSE "LGPLv2.1")
+ENDIF()
 
 # Set default description for packages
 SET(CPACK_RPM_PACKAGE_DESCRIPTION "MariaDB: a very fast and robust SQL database server


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28586*

## Description
As Linux distros has diffrent rpmlint conventions this should be addressed to make sure that there is no `invalid-license` rpmlint output

* Fedora has [Software License List](https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#Software_License_List) how license should be applied.
* openSUSE has [Packaging_guidelines](https://en.opensuse.org/openSUSE:Packaging_guidelines#Spec_Files) and [Spreadheet](https://docs.google.com/spreadsheets/u/0/d/14AdaJ6cmU0kvQ4ulq9pWpjdZL5tkR03exRSYJmPGdfs/pub)
* CentOS and RHEL are more conservative with this

Current RPM licenses GPLv2 and LGPLv2.1 are correct names for licenses in RHEL and Fedora but SUSE prefers use of SPDX names of licenses as they are harmonized.

 * [GPLv2 SPDX name is GPL-2.0-only](https://spdx.org/licenses/GPL-2.0-only.html)
 * [LGPLv2 SPDX name is LGPL-2.1-only](https://spdx.org/licenses/LGPL-2.1-only.html)

Having correct SPDX names (besides rpmlint likes them) gives software license BOM checking applications easier job.

This problem exist every version from 10.3 to 10.10 rpm creation. This PR is part of [MDBF-403](https://jira.mariadb.org/browse/MDBF-403)

## How can this PR be tested?
Install `rpmlint` (it depends on distro how make it) but it should be available.
then add RPM to CMake Cpack (fedora can be sles or rhel):
```
mkdir build
cd build
cmake -DRPM=fedora ..
make package
rpmlint *.rpm
```
After that you have huge amount of warnings and plenty situations that are considered errors but there shouldn't be `invalid-license` problems appearing.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
Should be more compatible with distros but can confuse earlier users.
