### PR TITLE
MDEV-28566: Assertion `!expr->is_fixed()' failed in bool Virtual_column_info::fix_session_expr(THD*)

### DIFF
--- a/mysql-test/suite/vcol/r/read_lock.result
+++ b/mysql-test/suite/vcol/r/read_lock.result
@@ -1,0 +1,8 @@
+CREATE TABLE t (c1 CHAR AS (CONCAT (0,DAYNAME (0))));
+FLUSH TABLES WITH READ LOCK;
+UPDATE t SET c1=1;
+ERROR HY000: Can't execute the query because you have a conflicting read lock
+SELECT * FROM t;
+c1
+UNLOCK TABLES;
+DROP TABLE t;

--- a/mysql-test/suite/vcol/t/read_lock.test
+++ b/mysql-test/suite/vcol/t/read_lock.test
@@ -1,0 +1,10 @@
+#
+# MDEV-28566 Assertion `!expr->is_fixed()' failed in bool Virtual_column_info::fix_session_expr(THD*)
+#
+CREATE TABLE t (c1 CHAR AS (CONCAT (0,DAYNAME (0))));
+FLUSH TABLES WITH READ LOCK;
+--error 1223
+UPDATE t SET c1=1;
+SELECT * FROM t;
+UNLOCK TABLES;
+DROP TABLE t;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -3405,7 +3405,7 @@ bool TABLE::vcol_fix_expr(THD *thd)
 
   List_iterator_fast<Virtual_column_info> it(vcol_refix_list);
   while (Virtual_column_info *vcol= it++)
-    if (vcol->fix_session_expr(thd))
+    if (!vcol->expr->is_fixed() && vcol->fix_session_expr(thd))
       goto error;
 
   return false;


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28566*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
When we try to write to locked table, at the first the table is [stored to table caches](https://github.com/MariaDB/server/blob/mariadb-10.4.25/sql/sql_base.cc#L2139) then failed, and the cache is [moved to free_tables](https://github.com/MariaDB/server/blob/mariadb-10.4.25/sql/sql_base.cc#L2188). In the next query, we try to read the table, and the table is [opened from free_tables](https://github.com/MariaDB/server/blob/mariadb-10.4.25/sql/sql_base.cc#L1965). But in this case, `vcol_fix_expr(thd)` is called because `from_share` is false (`from_share` [only becomes true](https://github.com/MariaDB/server/blob/mariadb-10.4.25/sql/sql_base.cc#L2140) when a table is opened without table caches).
In `vcol_fix_expr(thd)`, `vcol->fix_session_expr(thd)` is called even though vcol->expr->is_fixed() is true and it fails because of the assertion.

Therefore, I will add an additional expression to `TABLE::vcol_fix_expr(THD*)` in order to prevent to call unwanted `vcol->fix_session_expr(thd)`.

## How can this PR be tested?
I added the test code
```bash
#
# MDEV-28566 Assertion `!expr->is_fixed()' failed in bool Virtual_column_info::fix_session_expr(THD*)
#
CREATE TABLE t (c1 CHAR AS (CONCAT (0,DAYNAME (0))));
FLUSH TABLES WITH READ LOCK;
--error 1223
UPDATE t SET c1=1;
SELECT * FROM t;
UNLOCK TABLES;
DROP TABLE t;
```

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
