### PR TITLE
Properly introduce wsrep_sst_backup script in project packaging

### DIFF
--- a/debian/mariadb-server-10.5.install
+++ b/debian/mariadb-server-10.5.install
@@ -100,6 +100,7 @@ usr/share/man/man1/mysqlhotcopy.1
 usr/share/man/man1/perror.1
 usr/share/man/man1/replace.1
 usr/share/man/man1/resolve_stack_dump.1
+usr/share/man/man1/wsrep_sst_backup.1
 usr/share/man/man1/wsrep_sst_common.1
 usr/share/man/man1/wsrep_sst_mariabackup.1
 usr/share/man/man1/wsrep_sst_mysqldump.1

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -14,7 +14,8 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1335 USA
 
 SET(MAN1_WSREP wsrep_sst_rsync.1 wsrep_sst_common.1 wsrep_sst_mariabackup.1
-    wsrep_sst_mysqldump.1 wsrep_sst_rsync_wan.1 galera_recovery.1 galera_new_cluster.1)
+    wsrep_sst_mysqldump.1 wsrep_sst_rsync_wan.1 galera_recovery.1 galera_new_cluster.1
+    wsrep_sst_backup.1)
 SET(MAN1_SERVER innochecksum.1 myisam_ftdump.1 myisamchk.1
                 aria_chk.1 aria_dump_log.1 aria_ftdump.1 aria_pack.1 aria_read_log.1
                 aria_s3_copy.1

--- a/man/wsrep_sst_backup.1
+++ b/man/wsrep_sst_backup.1
@@ -1,0 +1,16 @@
+'\" t
+.\"
+.TH "\FBWSREP_SST_BACKUP\FR" "1" "22 May 2022" "MariaDB 10\&.3" "MariaDB Database System"
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.SH NAME
+wsrep_sst_backup \- backup helper script for the MariaDB Galera Cluster
+.SH DESCRIPTION
+Use: See source code of script\.
+.PP
+For more information, please refer to the MariaDB Knowledge Base, available online at https://mariadb.com/kb/


### PR DESCRIPTION
## Description

The script wsrep_sst_backup was introduced on MariaDB 10.3 in commit
9b2fa2a. The new script was automatically included in RPM packages but not
in Debian packages (which started to fail on waring about stray file).

Include wsrep_sst_backup in the mariadb-server-10.{3..8} package, and
also include a stub man page so that packaging of a new script is complete.

## How can this PR be tested?

Build packages and compare file listings before and after. Also see Buildbot Debian builders and Salsa-CI which cover this change.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility

I would refrain from introducing new stuff on very old releases, but since 9b2fa2a already happened on 10.3, also this commit should be made to make the introduction of a new script complete.