### PR TITLE
MDEV-28653: Remove MariaDB 10.2 upgrade test version is EOL

### DIFF
--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -610,58 +610,6 @@ mariadb.org-10.3 to mariadb-10.5 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mariadb.org-10.2 to mariadb-10.5 upgrade:
-  stage: upgrade extras
-  needs:
-    - job: build stretch-backports
-  image: debian:${RELEASE}
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - apt install -y curl apt-transport-https
-    - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://deb.mariadb.org/10.2/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
-    - apt-get update
-    - apt-get install -y mariadb-server-10.2
-    # Verify initial state before upgrade
-    - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
-    - service mysql status
-    # prepending with --defaults-file=/etc/mysql/debian.cnf is needed in upstream 5.5–10.3
-    - |
-      mysql --defaults-file=/etc/mysql/debian.cnf --skip-column-names -e "SELECT @@version, @@version_comment"
-      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SHOW DATABASES;"
-      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SELECT * FROM mysql.user; SHOW CREATE USER root@localhost;"
-      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SELECT * FROM mysql.plugin; SHOW PLUGINS;"
-    # Enable backports to make libzstd1, rocksdb-tools
-    - echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list.d/backports.list
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian stretch-backports-sloppy main" >> /etc/apt/sources.list.d/backports.list && apt-get update
-    # Increase default backports priority policy from '100' to '500' so it can actually be used
-    - |
-      cat << EOF > /etc/apt/preferences.d/enable-backports-to-satisfy-dependencies
-      Package: *
-      Pin: release n=stretch-*
-      Pin-Priority: 500
-      EOF
-    # Remove plugin that requires libcurl4, not available in Debian Stretch
-    - rm mariadb-plugin-s3*.deb
-    - *test-install
-    - service mysql status
-    # Give the mariadb-upgrade plenty of time to complete, otherwise next commands
-    # fail on non-existing mariadb.sys user
-    - sleep 15
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-    RELEASE: stretch # Last Debian release that MariaDB.org published 10.2 binaries for
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
 mysql.com-5.7 to mariadb-10.5 upgrade:
   stage: upgrade extras
   needs:


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28653*

## Description
Remove 10.2 upgrade test from Salsa-CI as version is currently EOL and hopefully everyone have been upgraded to 10.3.

## How can this PR be tested?
This is Salsa-CI removing of 10.2 upgrading so it can't be manually tested. Salsa-CI run can be found:
https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/381417

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
After this MariaDB 10.2 is not tested anymore