### PR TITLE
MDEV-7567 Add slow queries variable aliases

### DIFF
--- a/mysql-test/main/log_slow.result
+++ b/mysql-test/main/log_slow.result
@@ -13,6 +13,11 @@ Variable_name	Value
 log_slow_admin_statements	ON
 log_slow_disabled_statements	sp
 log_slow_filter	admin,filesort,filesort_on_disk,filesort_priority_queue,full_join,full_scan,query_cache,query_cache_miss,tmp_table,tmp_table_on_disk
+log_slow_min_examined_row_limit	0
+log_slow_queries_not_using_indexes	OFF
+log_slow_query_enable	ON
+log_slow_query_file_name	$PATH/mysqld-slow.log
+log_slow_query_time	10.000000
 log_slow_rate_limit	1
 log_slow_slave_statements	ON
 log_slow_verbosity	

--- a/mysql-test/main/log_slow.test
+++ b/mysql-test/main/log_slow.test
@@ -7,6 +7,7 @@ set @@log_slow_verbosity="";
 select @@log_slow_filter;
 select @@log_slow_rate_limit;
 select @@log_slow_verbosity;
+--replace_regex /\S+mysqld-slow.log/$PATH\/mysqld-slow.log/
 show variables like "log_slow%";
 set @org_slow_query_log= @@global.slow_query_log;
 

--- a/mysql-test/main/mysqld--help,win.rdiff
+++ b/mysql-test/main/mysqld--help,win.rdiff
@@ -1,6 +1,6 @@
 --- a/mysql-test/r/mysqld--help.result
 +++ b/mysql-test/r/mysqld--help.result
-@@ -647,6 +646,7 @@
+@@ -686,6 +686,7 @@
   Use MySQL-5.6 (instead of MariaDB-5.3) format for TIME,
   DATETIME, TIMESTAMP columns.
   (Defaults to on; use --skip-mysql56-temporal-format to disable.)
@@ -8,18 +8,18 @@
   --net-buffer-length=# 
   Buffer length for TCP/IP and socket communication
   --net-read-timeout=# 
-@@ -1236,6 +1236,10 @@
-  Log slow queries to given log file. Defaults logging to
-  'hostname'-slow.log. Must be enabled to activate other
-  slow log options
+@@ -1275,6 +1276,10 @@
+  will be written to the binlog. ENFORCE means that
+  triggers will always be run on the slave, even if there
+  are triggers on the master. ENFORCE implies LOGGING.
 + --slow-start-timeout=# 
 + Maximum number of milliseconds that the service control
 + manager should wait before trying to kill the windows
 + service during startup(Default: 15000).
-  --socket=name       Socket file to use for connection
-  --sort-buffer-size=# 
-  Each thread that needs to do a sort allocates a buffer of
-@@ -1260,6 +1264,7 @@
+  --slave-skip-errors=name 
+  Tells the slave thread to continue replication when a
+  query event returns an error from the provided list
+@@ -1343,6 +1348,7 @@
   deleting or updating every row in a table.
   --stack-trace       Print a symbolic stack trace on failure
   (Defaults to on; use --skip-stack-trace to disable.)
@@ -27,7 +27,7 @@
   --standard-compliant-cte 
   Allow only CTEs compliant to SQL standard
   (Defaults to on; use --skip-standard-compliant-cte to disable.)
-@@ -1330,6 +1335,11 @@
+@@ -1418,6 +1424,11 @@
   --thread-pool-max-threads=# 
   Maximum allowed number of worker threads in the thread
   pool
@@ -39,7 +39,7 @@
   --thread-pool-oversubscribe=# 
   How many additional active worker threads in a group are
   allowed.
-@@ -1370,8 +1380,8 @@
+@@ -1456,8 +1467,8 @@
   automatically convert it to an on-disk MyISAM or Aria
   table.
   -t, --tmpdir=name   Path for temporary files. Several paths may be specified,
@@ -50,7 +50,7 @@
   --transaction-alloc-block-size=# 
   Allocation block size for transactions to be stored in
   binary log
-@@ -1587,6 +1596,7 @@
+@@ -1678,6 +1689,7 @@
  myisam-stats-method NULLS_UNEQUAL
  myisam-use-mmap FALSE
  mysql56-temporal-format TRUE
@@ -58,7 +58,7 @@
  net-buffer-length 16384
  net-read-timeout 30
  net-retry-count 10
-@@ -1726,6 +1736,7 @@
+@@ -1832,6 +1844,7 @@
  slave-type-conversions 
  slow-launch-time 2
  slow-query-log FALSE
@@ -66,8 +66,8 @@
  sort-buffer-size 2097152
  sql-mode STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
  sql-safe-updates FALSE
-@@ -1753,6 +1764,8 @@
- thread-cache-size 151
+@@ -1858,6 +1871,8 @@
+ thread-pool-exact-stats FALSE
  thread-pool-idle-timeout 60
  thread-pool-max-threads 65536
 +thread-pool-min-threads 1

--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -497,8 +497,9 @@ The following specify which files/extra groups are read (specified before remain
  --log-output=name   How logs should be written. Any combination of: NONE, 
  FILE, TABLE
  --log-queries-not-using-indexes 
- Log queries that are executed without benefit of any
- index to the slow log if it is open. Same as
+ Alias for log_slow_queries_not_using_indexes. Log queries
+ that are executed without benefit of any index to the
+ slow log if it is open. Same as
  log_slow_filter='not_using_index'
  --log-short-format  Don't log extra information to update and slow-query
  logs.
@@ -523,6 +524,27 @@ The following specify which files/extra groups are read (specified before remain
  filesort_priority_queue, full_join, full_scan, 
  not_using_index, query_cache, query_cache_miss, tmp_table,
  tmp_table_on_disk
+ --log-slow-min-examined-row-limit=# 
+ Don't write queries to slow log that examine fewer rows
+ than that
+ --log-slow-queries-not-using-indexes 
+ Log queries that are executed without benefit of any
+ index to the slow log if it is open. Same as
+ log_slow_filter='not_using_index'
+ --log-slow-query-enable 
+ Log slow queries to a table or log file. Defaults logging
+ to a file 'hostname'-slow.log or a table mysql.slow_log
+ if --log-output=TABLE is used. Must be enabled to
+ activate other slow log options.
+ --log-slow-query-file-name=name 
+ Log slow queries to given log file. Defaults logging to
+ 'hostname'-slow.log. Must be enabled to activate other
+ slow log options
+ --log-slow-query-time=# 
+ Log all queries that have taken more than
+ log_slow_query_time seconds to execute to the slow query
+ log file. The argument will be treated as a decimal value
+ with microsecond precision
  --log-slow-rate-limit=# 
  Write to slow log every #th slow query. Set to 1 to log
  everything. Increase it to reduce the size of the slow or
@@ -543,10 +565,10 @@ The following specify which files/extra groups are read (specified before remain
  Log some not critical warnings to the general log
  file.Value can be between 0 and 11. Higher values mean
  more verbosity
- --long-query-time=# Log all queries that have taken more than long_query_time
- seconds to execute to the slow query log file. The
- argument will be treated as a decimal value with
- microsecond precision
+ --long-query-time=# Alias for log_slow_query_time. Log all queries that have
+ taken more than long_query_time seconds to execute to the
+ slow query log file. The argument will be treated as a
+ decimal value with microsecond precision
  --low-priority-updates 
  INSERT/DELETE/UPDATE has lower priority than selects
  --lower-case-table-names[=#] 
@@ -635,8 +657,8 @@ The following specify which files/extra groups are read (specified before remain
  --metadata-locks-hash-instances=# 
  Unused
  --min-examined-row-limit=# 
- Don't write queries to slow log that examine fewer rows
- than that
+ Alias for log_slow_min_examined_row_limit. Don't write
+ queries to slow log that examine fewer rows than that
  --mrr-buffer-size=# Size of buffer to use when using MRR with range access
  --myisam-block-size=# 
  Block size to be used for MyISAM index pages
@@ -1304,14 +1326,15 @@ The following specify which files/extra groups are read (specified before remain
  If creating the thread takes longer than this value (in
  seconds), the Slow_launch_threads counter will be
  incremented
- --slow-query-log    Log slow queries to a table or log file. Defaults logging
- to a file 'hostname'-slow.log or a table mysql.slow_log
- if --log-output=TABLE is used. Must be enabled to
- activate other slow log options.
+ --slow-query-log    Alias for log_slow_query_enable. Log slow queries to a
+ table or log file. Defaults logging to a file
+ 'hostname'-slow.log or a table mysql.slow_log if
+ --log-output=TABLE is used. Must be enabled to activate
+ other slow log options.
  --slow-query-log-file=name 
- Log slow queries to given log file. Defaults logging to
- 'hostname'-slow.log. Must be enabled to activate other
- slow log options
+ Alias for log_slow_query_file_name. Log slow queries to
+ given log file. Defaults logging to 'hostname'-slow.log.
+ Must be enabled to activate other slow log options
  --socket=name       Socket file to use for connection
  --sort-buffer-size=# 
  Each thread that needs to do a sort allocates a buffer of
@@ -1617,6 +1640,10 @@ log-slave-updates FALSE
 log-slow-admin-statements TRUE
 log-slow-disabled-statements sp
 log-slow-filter admin,filesort,filesort_on_disk,filesort_priority_queue,full_join,full_scan,query_cache,query_cache_miss,tmp_table,tmp_table_on_disk
+log-slow-min-examined-row-limit 0
+log-slow-queries-not-using-indexes FALSE
+log-slow-query-enable FALSE
+log-slow-query-time 10
 log-slow-rate-limit 1
 log-slow-slave-statements TRUE
 log-slow-verbosity 

--- a/mysql-test/main/mysqld--help.test
+++ b/mysql-test/main/mysqld--help.test
@@ -23,6 +23,7 @@ perl;
   # their paths may vary:
   @skipvars=qw/basedir open-files-limit general-log-file log plugin-dir plugin-maturity
                log-slow-queries pid-file slow-query-log-file log-basename
+               log-slow-query-file-name
                datadir slave-load-tmpdir tmpdir socket thread-pool-size
                large-files-support lower-case-file-system system-time-zone
                collation-server character-set-server log-tc-size table-cache

--- a/mysql-test/suite/sys_vars/r/sysvars_server_embedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_embedded.result
@@ -1655,7 +1655,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	LOG_QUERIES_NOT_USING_INDEXES
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Log queries that are executed without benefit of any index to the slow log if it is open. Same as log_slow_filter='not_using_index'
+VARIABLE_COMMENT	Alias for log_slow_queries_not_using_indexes. Log queries that are executed without benefit of any index to the slow log if it is open. Same as log_slow_filter='not_using_index'
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL
@@ -1690,6 +1690,56 @@ NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL
 ENUM_VALUE_LIST	admin,filesort,filesort_on_disk,filesort_priority_queue,full_join,full_scan,not_using_index,query_cache,query_cache_miss,tmp_table,tmp_table_on_disk
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	REQUIRED
+VARIABLE_NAME	LOG_SLOW_MIN_EXAMINED_ROW_LIMIT
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	BIGINT UNSIGNED
+VARIABLE_COMMENT	Don't write queries to slow log that examine fewer rows than that
+NUMERIC_MIN_VALUE	0
+NUMERIC_MAX_VALUE	4294967295
+NUMERIC_BLOCK_SIZE	1
+ENUM_VALUE_LIST	NULL
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	REQUIRED
+VARIABLE_NAME	LOG_SLOW_QUERIES_NOT_USING_INDEXES
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	BOOLEAN
+VARIABLE_COMMENT	Log queries that are executed without benefit of any index to the slow log if it is open. Same as log_slow_filter='not_using_index'
+NUMERIC_MIN_VALUE	NULL
+NUMERIC_MAX_VALUE	NULL
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	OFF,ON
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	OPTIONAL
+VARIABLE_NAME	LOG_SLOW_QUERY_ENABLE
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	BOOLEAN
+VARIABLE_COMMENT	Log slow queries to a table or log file. Defaults logging to a file 'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is used. Must be enabled to activate other slow log options.
+NUMERIC_MIN_VALUE	NULL
+NUMERIC_MAX_VALUE	NULL
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	OFF,ON
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	OPTIONAL
+VARIABLE_NAME	LOG_SLOW_QUERY_FILE_NAME
+VARIABLE_SCOPE	GLOBAL
+VARIABLE_TYPE	VARCHAR
+VARIABLE_COMMENT	Log slow queries to given log file. Defaults logging to 'hostname'-slow.log. Must be enabled to activate other slow log options
+NUMERIC_MIN_VALUE	NULL
+NUMERIC_MAX_VALUE	NULL
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	NULL
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	REQUIRED
+VARIABLE_NAME	LOG_SLOW_QUERY_TIME
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	DOUBLE
+VARIABLE_COMMENT	Log all queries that have taken more than log_slow_query_time seconds to execute to the slow query log file. The argument will be treated as a decimal value with microsecond precision
+NUMERIC_MIN_VALUE	0
+NUMERIC_MAX_VALUE	31536000
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	NULL
 READ_ONLY	NO
 COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	LOG_SLOW_RATE_LIMIT
@@ -1735,7 +1785,7 @@ COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	LONG_QUERY_TIME
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	DOUBLE
-VARIABLE_COMMENT	Log all queries that have taken more than long_query_time seconds to execute to the slow query log file. The argument will be treated as a decimal value with microsecond precision
+VARIABLE_COMMENT	Alias for log_slow_query_time. Log all queries that have taken more than long_query_time seconds to execute to the slow query log file. The argument will be treated as a decimal value with microsecond precision
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	31536000
 NUMERIC_BLOCK_SIZE	NULL
@@ -1875,7 +1925,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	MAX_INSERT_DELAYED_THREADS
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BIGINT UNSIGNED
-VARIABLE_COMMENT	Don't start more than this number of threads to handle INSERT DELAYED statements. If set to zero INSERT DELAYED will be not used
+VARIABLE_COMMENT	Alias for max_delayed_threads. Don't start more than this number of threads to handle INSERT DELAYED statements. If set to zero INSERT DELAYED will be not used
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	16384
 NUMERIC_BLOCK_SIZE	1
@@ -2045,7 +2095,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	MIN_EXAMINED_ROW_LIMIT
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BIGINT UNSIGNED
-VARIABLE_COMMENT	Don't write queries to slow log that examine fewer rows than that
+VARIABLE_COMMENT	Alias for log_slow_min_examined_row_limit. Don't write queries to slow log that examine fewer rows than that
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	4294967295
 NUMERIC_BLOCK_SIZE	1
@@ -3185,7 +3235,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	SLOW_QUERY_LOG
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Log slow queries to a table or log file. Defaults logging to a file 'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is used. Must be enabled to activate other slow log options.
+VARIABLE_COMMENT	Alias for log_slow_query_enable. Log slow queries to a table or log file. Defaults logging to a file 'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is used. Must be enabled to activate other slow log options.
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL
@@ -3195,7 +3245,7 @@ COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	SLOW_QUERY_LOG_FILE
 VARIABLE_SCOPE	GLOBAL
 VARIABLE_TYPE	VARCHAR
-VARIABLE_COMMENT	Log slow queries to given log file. Defaults logging to 'hostname'-slow.log. Must be enabled to activate other slow log options
+VARIABLE_COMMENT	Alias for log_slow_query_file_name. Log slow queries to given log file. Defaults logging to 'hostname'-slow.log. Must be enabled to activate other slow log options
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL

--- a/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
@@ -1795,7 +1795,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	LOG_QUERIES_NOT_USING_INDEXES
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Log queries that are executed without benefit of any index to the slow log if it is open. Same as log_slow_filter='not_using_index'
+VARIABLE_COMMENT	Alias for log_slow_queries_not_using_indexes. Log queries that are executed without benefit of any index to the slow log if it is open. Same as log_slow_filter='not_using_index'
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL
@@ -1842,6 +1842,56 @@ NUMERIC_BLOCK_SIZE	NULL
 ENUM_VALUE_LIST	admin,filesort,filesort_on_disk,filesort_priority_queue,full_join,full_scan,not_using_index,query_cache,query_cache_miss,tmp_table,tmp_table_on_disk
 READ_ONLY	NO
 COMMAND_LINE_ARGUMENT	REQUIRED
+VARIABLE_NAME	LOG_SLOW_MIN_EXAMINED_ROW_LIMIT
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	BIGINT UNSIGNED
+VARIABLE_COMMENT	Don't write queries to slow log that examine fewer rows than that
+NUMERIC_MIN_VALUE	0
+NUMERIC_MAX_VALUE	4294967295
+NUMERIC_BLOCK_SIZE	1
+ENUM_VALUE_LIST	NULL
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	REQUIRED
+VARIABLE_NAME	LOG_SLOW_QUERIES_NOT_USING_INDEXES
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	BOOLEAN
+VARIABLE_COMMENT	Log queries that are executed without benefit of any index to the slow log if it is open. Same as log_slow_filter='not_using_index'
+NUMERIC_MIN_VALUE	NULL
+NUMERIC_MAX_VALUE	NULL
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	OFF,ON
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	OPTIONAL
+VARIABLE_NAME	LOG_SLOW_QUERY_ENABLE
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	BOOLEAN
+VARIABLE_COMMENT	Log slow queries to a table or log file. Defaults logging to a file 'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is used. Must be enabled to activate other slow log options.
+NUMERIC_MIN_VALUE	NULL
+NUMERIC_MAX_VALUE	NULL
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	OFF,ON
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	OPTIONAL
+VARIABLE_NAME	LOG_SLOW_QUERY_FILE_NAME
+VARIABLE_SCOPE	GLOBAL
+VARIABLE_TYPE	VARCHAR
+VARIABLE_COMMENT	Log slow queries to given log file. Defaults logging to 'hostname'-slow.log. Must be enabled to activate other slow log options
+NUMERIC_MIN_VALUE	NULL
+NUMERIC_MAX_VALUE	NULL
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	NULL
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	REQUIRED
+VARIABLE_NAME	LOG_SLOW_QUERY_TIME
+VARIABLE_SCOPE	SESSION
+VARIABLE_TYPE	DOUBLE
+VARIABLE_COMMENT	Log all queries that have taken more than log_slow_query_time seconds to execute to the slow query log file. The argument will be treated as a decimal value with microsecond precision
+NUMERIC_MIN_VALUE	0
+NUMERIC_MAX_VALUE	31536000
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	NULL
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	LOG_SLOW_RATE_LIMIT
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BIGINT UNSIGNED
@@ -1885,7 +1935,7 @@ COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	LONG_QUERY_TIME
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	DOUBLE
-VARIABLE_COMMENT	Log all queries that have taken more than long_query_time seconds to execute to the slow query log file. The argument will be treated as a decimal value with microsecond precision
+VARIABLE_COMMENT	Alias for log_slow_query_time. Log all queries that have taken more than long_query_time seconds to execute to the slow query log file. The argument will be treated as a decimal value with microsecond precision
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	31536000
 NUMERIC_BLOCK_SIZE	NULL
@@ -2035,7 +2085,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	MAX_INSERT_DELAYED_THREADS
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BIGINT UNSIGNED
-VARIABLE_COMMENT	Don't start more than this number of threads to handle INSERT DELAYED statements. If set to zero INSERT DELAYED will be not used
+VARIABLE_COMMENT	Alias for max_delayed_threads. Don't start more than this number of threads to handle INSERT DELAYED statements. If set to zero INSERT DELAYED will be not used
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	16384
 NUMERIC_BLOCK_SIZE	1
@@ -2215,7 +2265,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	MIN_EXAMINED_ROW_LIMIT
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BIGINT UNSIGNED
-VARIABLE_COMMENT	Don't write queries to slow log that examine fewer rows than that
+VARIABLE_COMMENT	Alias for log_slow_min_examined_row_limit. Don't write queries to slow log that examine fewer rows than that
 NUMERIC_MIN_VALUE	0
 NUMERIC_MAX_VALUE	4294967295
 NUMERIC_BLOCK_SIZE	1
@@ -3865,7 +3915,7 @@ COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	SLOW_QUERY_LOG
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Log slow queries to a table or log file. Defaults logging to a file 'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is used. Must be enabled to activate other slow log options.
+VARIABLE_COMMENT	Alias for log_slow_query_enable. Log slow queries to a table or log file. Defaults logging to a file 'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is used. Must be enabled to activate other slow log options.
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL
@@ -3875,7 +3925,7 @@ COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	SLOW_QUERY_LOG_FILE
 VARIABLE_SCOPE	GLOBAL
 VARIABLE_TYPE	VARCHAR
-VARIABLE_COMMENT	Log slow queries to given log file. Defaults logging to 'hostname'-slow.log. Must be enabled to activate other slow log options
+VARIABLE_COMMENT	Alias for log_slow_query_file_name. Log slow queries to given log file. Defaults logging to 'hostname'-slow.log. Must be enabled to activate other slow log options
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1498,6 +1498,14 @@ static Sys_var_charptr_fscs Sys_log_error(
 
 static Sys_var_bit Sys_log_queries_not_using_indexes(
        "log_queries_not_using_indexes",
+       "Alias for log_slow_queries_not_using_indexes. "
+       "Log queries that are executed without benefit of any index to the "
+       "slow log if it is open. Same as log_slow_filter='not_using_index'",
+       SESSION_VAR(log_slow_filter), CMD_LINE(OPT_ARG), QPLAN_NOT_USING_INDEX,
+       DEFAULT(FALSE));
+
+static Sys_var_bit Sys_log_slow_queries_not_using_indexes(
+       "log_slow_queries_not_using_indexes",
        "Log queries that are executed without benefit of any index to the "
        "slow log if it is open. Same as log_slow_filter='not_using_index'",
        SESSION_VAR(log_slow_filter), CMD_LINE(OPT_ARG), QPLAN_NOT_USING_INDEX,
@@ -1541,6 +1549,7 @@ static bool update_cached_long_query_time(sys_var *self, THD *thd,
 
 static Sys_var_double Sys_long_query_time(
        "long_query_time",
+       "Alias for log_slow_query_time. "
        "Log all queries that have taken more than long_query_time seconds "
        "to execute to the slow query log file. The argument will be treated "
        "as a decimal value with microsecond precision",
@@ -1549,6 +1558,15 @@ static Sys_var_double Sys_long_query_time(
        NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
        ON_UPDATE(update_cached_long_query_time));
 
+static Sys_var_double Sys_log_slow_query_time(
+       "log_slow_query_time",
+       "Log all queries that have taken more than log_slow_query_time seconds "
+       "to execute to the slow query log file. The argument will be treated "
+       "as a decimal value with microsecond precision",
+       SESSION_VAR(long_query_time_double),
+       CMD_LINE(REQUIRED_ARG), VALID_RANGE(0, LONG_TIMEOUT), DEFAULT(10),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
+       ON_UPDATE(update_cached_long_query_time));
 
 static bool update_cached_max_statement_time(sys_var *self, THD *thd,
                                          enum_var_type type)
@@ -1766,9 +1784,9 @@ static bool check_max_delayed_threads(sys_var *self, THD *thd, set_var *var)
                            global_system_variables.max_insert_delayed_threads;
 }
 
-// Alias for max_delayed_threads
 static Sys_var_ulong Sys_max_insert_delayed_threads(
        "max_insert_delayed_threads",
+       "Alias for max_delayed_threads. "
        "Don't start more than this number of threads to handle INSERT "
        "DELAYED statements. If set to zero INSERT DELAYED will be not used",
        SESSION_VAR(max_insert_delayed_threads),
@@ -2597,6 +2615,14 @@ static Sys_var_ulong Sys_max_write_lock_count(
 
 static Sys_var_ulong Sys_min_examined_row_limit(
        "min_examined_row_limit",
+       "Alias for log_slow_min_examined_row_limit. "
+       "Don't write queries to slow log that examine fewer rows "
+       "than that",
+       SESSION_VAR(min_examined_row_limit), CMD_LINE(REQUIRED_ARG),
+       VALID_RANGE(0, UINT_MAX), DEFAULT(0), BLOCK_SIZE(1));
+
+static Sys_var_ulong Sys_log_slow_min_examined_row_limit(
+       "log_slow_min_examined_row_limit",
        "Don't write queries to slow log that examine fewer rows "
        "than that",
        SESSION_VAR(min_examined_row_limit), CMD_LINE(REQUIRED_ARG),
@@ -5136,8 +5162,19 @@ static bool fix_slow_log_file(sys_var *self, THD *thd, enum_var_type type)
   return fix_log(&opt_slow_logname, opt_log_basename, "-slow.log",
                  global_system_variables.sql_log_slow, reopen_slow_log);
 }
+
 static Sys_var_charptr_fscs Sys_slow_log_path(
-       "slow_query_log_file", "Log slow queries to given log file. "
+       "slow_query_log_file", 
+       "Alias for log_slow_query_file_name. "
+       "Log slow queries to given log file. "
+       "Defaults logging to 'hostname'-slow.log. Must be enabled to activate "
+       "other slow log options",
+       PREALLOCATED GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG),
+       DEFAULT(0), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(check_log_path), ON_UPDATE(fix_slow_log_file));
+
+static Sys_var_charptr_fscs Sys_log_slow_query_file_name(
+       "log_slow_query_file_name", "Log slow queries to given log file. "
        "Defaults logging to 'hostname'-slow.log. Must be enabled to activate "
        "other slow log options",
        PREALLOCATED GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG),
@@ -5238,6 +5275,16 @@ static Sys_var_mybool Sys_general_log(
 
 static Sys_var_mybool Sys_slow_query_log(
        "slow_query_log",
+       "Alias for log_slow_query_enable. "
+       "Log slow queries to a table or log file. Defaults logging to a file "
+       "'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is "
+       "used. Must be enabled to activate other slow log options.",
+       SESSION_VAR(sql_log_slow), CMD_LINE(OPT_ARG),
+       DEFAULT(FALSE), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(0), ON_UPDATE(fix_log_state));
+
+static Sys_var_mybool Sys_log_slow_query_enable(
+       "log_slow_query_enable",
        "Log slow queries to a table or log file. Defaults logging to a file "
        "'hostname'-slow.log or a table mysql.slow_log if --log-output=TABLE is "
        "used. Must be enabled to activate other slow log options.",


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-7567*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Add aliases with prefix "log_slow" for system variables relating to slow query log.

Thus, all these variables will be grouped together and more logically named.

Descriptions for the old variables were updated to indicate they are
now aliases for the newly introduced variables with prefix log_slow.

log_slow_queries_not_using_indexes_filter will not be addressed
in this merge request.
log_throttle_queries_not_using_indexes seems to no longer be in use.

MTR tests are also updated to include the new variable names.

## How can this PR be tested?

All tests pass. MTR tests have been updated using --result.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
Target branch is 10.10

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.