### PR TITLE
MDEV-27926 Deprecate spider_init_sql_alloc_size

### DIFF
--- a/storage/spider/mysql-test/spider/r/variable_deprecation.result
+++ b/storage/spider/mysql-test/spider/r/variable_deprecation.result
@@ -196,6 +196,21 @@ Warnings:
 Warning	1287	The table parameter 'buffer_size' is deprecated and will be removed in a future release
 DROP TABLE tbl_a;
 DROP TABLE tbl_b;
+# MDEV-27926 Deprecate spider_init_sql_alloc_size
+SET spider_init_sql_alloc_size = 1;
+Warnings:
+Warning	1287	'@@spider_init_sql_alloc_size' is deprecated and will be removed in a future release
+SHOW VARIABLES LIKE "spider_init_sql_alloc_size";
+Variable_name	Value
+spider_init_sql_alloc_size	1
+CREATE TABLE tbl_a (a INT) ENGINE=Spider COMMENT='isa "1"';
+Warnings:
+Warning	1287	The table parameter 'isa' is deprecated and will be removed in a future release
+CREATE TABLE tbl_b (a INT) ENGINE=Spider COMMENT='init_sql_alloc_size "1"';
+Warnings:
+Warning	1287	The table parameter 'init_sql_alloc_size' is deprecated and will be removed in a future release
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
 DROP DATABASE auto_test_local;
 for master_1
 for child2

--- a/storage/spider/mysql-test/spider/t/variable_deprecation.test
+++ b/storage/spider/mysql-test/spider/t/variable_deprecation.test
@@ -117,6 +117,15 @@ eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='buffer_size "1"';
 DROP TABLE tbl_a;
 DROP TABLE tbl_b;
 
+--echo # MDEV-27926 Deprecate spider_init_sql_alloc_size
+SET spider_init_sql_alloc_size = 1;
+SHOW VARIABLES LIKE "spider_init_sql_alloc_size";
+eval CREATE TABLE tbl_a (a INT) $MASTER_1_ENGINE COMMENT='isa "1"';
+eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='init_sql_alloc_size "1"';
+
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
+
 DROP DATABASE auto_test_local;
 
 --disable_query_log

--- a/storage/spider/spd_param.cc
+++ b/storage/spider/spd_param.cc
@@ -596,7 +596,7 @@ longlong spider_param_semi_split_read_limit(
  */
 static MYSQL_THDVAR_INT(
   init_sql_alloc_size, /* name */
-  PLUGIN_VAR_RQCMDARG, /* opt */
+  PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_DEPRECATED, /* opt */
   "Initial sql string alloc size", /* comment */
   NULL, /* check */
   spider_use_table_value_deprecated, /* update */

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -2377,6 +2377,7 @@ int spider_parse_connect_info(
             "hwr", hs_write_to_reads, 0, 1);
           SPIDER_PARAM_STR_LIST("hws", hs_write_socks);
 #endif
+          SPIDER_PARAM_DEPRECATED_WARNING("isa");
           SPIDER_PARAM_INT("isa", init_sql_alloc_size, 0);
           SPIDER_PARAM_INT_WITH_MAX("idl", internal_delayed, 0, 1);
           SPIDER_PARAM_DEPRECATED_WARNING("ilm");
@@ -2682,6 +2683,7 @@ int spider_parse_connect_info(
           error_num = connect_string_parse.print_param_error();
           goto error;
         case 19:
+          SPIDER_PARAM_DEPRECATED_WARNING("init_sql_alloc_size");
           SPIDER_PARAM_INT("init_sql_alloc_size", init_sql_alloc_size, 0);
           SPIDER_PARAM_INT_WITH_MAX(
             "auto_increment_mode", auto_increment_mode, 0, 3);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-27926*

## Description
https://jira.mariadb.org/browse/MDEV-27926

The variable `spider_init_sql_alloc_size` is for specifying the initial size of the local SQL buffer. The parameters for this kind of tweaks shouldn't be exposed to users.

The corresponding table option should also be deprecated.

## How can this PR be tested?
Test case for these changes is added.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*