### PR TITLE
fix: fix a syntax error

### DIFF
--- a/support-files/mysql.server.sh
+++ b/support-files/mysql.server.sh
@@ -100,6 +100,7 @@ fi
 
 if test -f $init_functions; then
   . $init_functions
+else
   log_success_msg()
   {
     echo " SUCCESS! $@"


### PR DESCRIPTION
## Description
Fix mysql startup script error in mac os.

/usr/local/bin/mysql.server  
log_success_msg: command not found

## How can this PR be tested?

Run the command in mac os.
```shell
mysql.server start 
```
or 
```
mysql.server stop
```

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
