### PR TITLE
MDEV-18873 Server crashes in Compare_identifiers::operator or in my_strcasecmp_utf8 upon ADD PERIOD IF NOT EXISTS with empty name

### DIFF
--- a/mysql-test/suite/period/r/alter.result
+++ b/mysql-test/suite/period/r/alter.result
@@ -190,3 +190,17 @@ alter table t1 add primary key(x, s, e);
 ERROR 23000: Duplicate entry '1-2020-03-01-2020-03-02' for key 'PRIMARY'
 alter table t1 add system versioning;
 drop table t1;
+#
+# MDEV-18873 Server crashes in Compare_identifiers::operator or in 
+# my_strcasecmp_utf8 upon ADD PERIOD IF NOT EXISTS with empty name
+#
+alter table t add period if not exists for `` (s,e);
+ERROR 42000: Incorrect column name ''
+create table t(s DATE, e DATE);
+alter table t add period if not exists for `` (s,e);
+ERROR 42000: Incorrect column name ''
+alter table t add period if not exists for ` ` (s,e);
+ERROR 42000: Incorrect column name ' '
+create table t2 (period for `` (s,e)) select * from t;
+ERROR 42000: Incorrect column name ''
+drop table t;

--- a/mysql-test/suite/period/t/alter.test
+++ b/mysql-test/suite/period/t/alter.test
@@ -151,3 +151,26 @@ alter table t1 add system versioning;
 
 # cleanup
 drop table t1;
+
+--echo #
+--echo # MDEV-18873 Server crashes in Compare_identifiers::operator or in 
+--echo # my_strcasecmp_utf8 upon ADD PERIOD IF NOT EXISTS with empty name
+--echo #
+
+# When there is no table defined.
+--error ER_WRONG_COLUMN_NAME
+alter table t add period if not exists for `` (s,e);
+
+# When there is an actual table.
+create table t(s DATE, e DATE);
+--error ER_WRONG_COLUMN_NAME
+alter table t add period if not exists for `` (s,e);
+
+# When the last character is space
+--error ER_WRONG_COLUMN_NAME
+alter table t add period if not exists for ` ` (s,e);
+
+# Create table with an empty period name
+--error ER_WRONG_COLUMN_NAME
+create table t2 (period for `` (s,e)) select * from t;
+drop table t;

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -33,6 +33,7 @@
 #include "sql_tvc.h"
 #include "item.h"
 #include "sql_schema.h"
+#include "table.h"
 
 /* Used for flags of nesting constructs */
 #define SELECT_NESTING_MAP_SIZE 64
@@ -4449,6 +4450,11 @@ public:
 
   int add_period(Lex_ident name, Lex_ident_sys_st start, Lex_ident_sys_st end)
   {
+    if (check_period_name(name.str)) {
+      my_error(ER_WRONG_COLUMN_NAME, MYF(0), name.str);
+      return 1;
+    }
+
     if (lex_string_cmp(system_charset_info, &start, &end) == 0)
     {
       my_error(ER_FIELD_SPECIFIED_TWICE, MYF(0), start.str);

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -4918,6 +4918,12 @@ bool check_column_name(const char *name)
 }
 
 
+bool check_period_name(const char *name)
+{
+  return check_column_name(name);
+}
+
+
 /**
   Checks whether a table is intact. Should be done *just* after the table has
   been opened.

--- a/sql/table.h
+++ b/sql/table.h
@@ -3231,6 +3231,7 @@ void open_table_error(TABLE_SHARE *share, enum open_frm_error error,
 void update_create_info_from_table(HA_CREATE_INFO *info, TABLE *form);
 bool check_db_name(LEX_STRING *db);
 bool check_column_name(const char *name);
+bool check_period_name(const char *name);
 bool check_table_name(const char *name, size_t length, bool check_for_path_chars);
 int rename_file_ext(const char * from,const char * to,const char * ext);
 char *get_field(MEM_ROOT *mem, Field *field);

--- a/sql/vers_string.h
+++ b/sql/vers_string.h
@@ -39,6 +39,8 @@ struct Compare_identifiers
 {
   int operator()(const LEX_CSTRING& a, const LEX_CSTRING& b) const
   {
+    DBUG_ASSERT(a.str != NULL);
+    DBUG_ASSERT(b.str != NULL);
     DBUG_ASSERT(a.str[a.length] == 0);
     DBUG_ASSERT(b.str[b.length] == 0);
     return my_strcasecmp(system_charset_info, a.str, b.str);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-18873*

https://jira.mariadb.org/browse/MDEV-18873

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
The crash was due to period names being empty, which was causing unexpected errors in other places.

To eliminate those errors, this patch adds a validation logic for period names in a query.  Because We execute the validation when parsing a query, any queries with invalid period names won't go further, preventing errors on the later stage. As far as I've read the code, this strategy is commonly used also for column names or table names.

Note that currently we use the same validation logic as column names, assuming the requirement for period names is the same as column names. 


## How can this PR be tested?
Added a test case to check if the crash won't reproduce.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [X] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*


<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
In this patch, we introduced a validation for period names. It rejects some period names that has been accepted prior to this patch. e.g. a name that ends with a whitespace.