### PR TITLE
MDEV-28127 SIGSEGV in row_mysql_store_col_in_innobase_format, and Ass…

### DIFF
--- a/mysql-test/main/partition_exchange.result
+++ b/mysql-test/main/partition_exchange.result
@@ -1321,3 +1321,34 @@ CREATE TABLE t2 (a INT, PRIMARY KEY(a)) CHECKSUM=1, ENGINE=InnoDB;
 ALTER TABLE t1 EXCHANGE PARTITION p0 WITH TABLE t2;
 ERROR HY000: Tables have different definitions
 DROP TABLE t1, t2;
+#
+# MDEV-28127 SIGSEGV in row_mysql_store_col_in_innobase_format, and Assertion  
+# `pos < table->n_v_def' failed in dict_table_get_nth_v_col, and Assertion
+# `table->s->db_options_in_use == part_table->s->db_options_in_use' failed 
+# in compare_table_with_partition
+#
+SET sql_mode='';
+CREATE TABLE t1 (a INT,KEY(a)) ENGINE=InnoDB PARTITION BY RANGE (a) (PARTITION p VALUES LESS THAN (1));
+CREATE TABLE t2 (a INT GENERATED ALWAYS AS (1) VIRTUAL,KEY(a)) ENGINE=InnoDB;
+ALTER TABLE t1 EXCHANGE PARTITION p WITH TABLE t2;
+ERROR HY000: Tables have different definitions
+INSERT INTO t2 VALUES (1);
+Warnings:
+Warning	1906	The value specified for generated column 'a' in table 't2' has been ignored
+DROP TABLE t1, t2;
+CREATE TABLE t1 (a INT,KEY(a)) ENGINE=MyISAM PARTITION BY RANGE (a) (PARTITION p VALUES LESS THAN (1));
+CREATE TABLE t2 (a INT GENERATED ALWAYS AS (1) VIRTUAL,KEY(a)) ENGINE=MyISAM;
+ALTER TABLE t1 EXCHANGE PARTITION p WITH TABLE t2;
+ERROR HY000: Tables have different definitions
+INSERT INTO t2 VALUES (1);
+Warnings:
+Warning	1906	The value specified for generated column 'a' in table 't2' has been ignored
+DROP TABLE t1, t2;
+CREATE TABLE t1 (a INT) ENGINE=Aria PARTITION BY RANGE (a) (PARTITION p VALUES LESS THAN (1));
+CREATE TABLE t2 (a INT GENERATED ALWAYS AS (1) VIRTUAL) ENGINE=Aria;
+ALTER TABLE t1 EXCHANGE PARTITION p WITH TABLE t2;
+ERROR HY000: Tables have different definitions
+INSERT INTO t2 VALUES (1);
+Warnings:
+Warning	1906	The value specified for generated column 'a' in table 't2' has been ignored
+DROP TABLE t1, t2;

--- a/mysql-test/main/partition_exchange.test
+++ b/mysql-test/main/partition_exchange.test
@@ -554,3 +554,34 @@ ALTER TABLE t1 EXCHANGE PARTITION p0 WITH TABLE t2;
 
 # Cleanup
 DROP TABLE t1, t2;
+
+--echo #
+--echo # MDEV-28127 SIGSEGV in row_mysql_store_col_in_innobase_format, and Assertion  
+--echo # `pos < table->n_v_def' failed in dict_table_get_nth_v_col, and Assertion
+--echo # `table->s->db_options_in_use == part_table->s->db_options_in_use' failed 
+--echo # in compare_table_with_partition
+--echo #
+SET sql_mode='';
+CREATE TABLE t1 (a INT,KEY(a)) ENGINE=InnoDB PARTITION BY RANGE (a) (PARTITION p VALUES LESS THAN (1));
+CREATE TABLE t2 (a INT GENERATED ALWAYS AS (1) VIRTUAL,KEY(a)) ENGINE=InnoDB;
+--error ER_TABLES_DIFFERENT_METADATA
+ALTER TABLE t1 EXCHANGE PARTITION p WITH TABLE t2;
+INSERT INTO t2 VALUES (1);
+# Cleanup
+DROP TABLE t1, t2;
+
+CREATE TABLE t1 (a INT,KEY(a)) ENGINE=MyISAM PARTITION BY RANGE (a) (PARTITION p VALUES LESS THAN (1));
+CREATE TABLE t2 (a INT GENERATED ALWAYS AS (1) VIRTUAL,KEY(a)) ENGINE=MyISAM;
+--error ER_TABLES_DIFFERENT_METADATA
+ALTER TABLE t1 EXCHANGE PARTITION p WITH TABLE t2;
+INSERT INTO t2 VALUES (1);
+# Cleanup
+DROP TABLE t1, t2;
+
+CREATE TABLE t1 (a INT) ENGINE=Aria PARTITION BY RANGE (a) (PARTITION p VALUES LESS THAN (1));
+CREATE TABLE t2 (a INT GENERATED ALWAYS AS (1) VIRTUAL) ENGINE=Aria;
+--error ER_TABLES_DIFFERENT_METADATA
+ALTER TABLE t1 EXCHANGE PARTITION p WITH TABLE t2;
+INSERT INTO t2 VALUES (1);
+# Cleanup
+DROP TABLE t1, t2;

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -256,6 +256,11 @@ static bool compare_table_with_partition(THD *thd, TABLE *table,
     DBUG_RETURN(TRUE);
   }
 
+  if (table->s->stored_fields != part_table->s->stored_fields) {
+    my_error(ER_TABLES_DIFFERENT_METADATA, MYF(0));
+    DBUG_RETURN(TRUE);
+  }
+
   DBUG_ASSERT(table->s->db_options_in_use ==
               part_table->s->db_options_in_use);
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28127*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
MDEV-28127 SIGSEGV in row_mysql_store_col_in_innobase_format, and Assertion `pos < table->n_v_def` failed in dict_table_get_nth_v_col, and Assertion `table->s->db_options_in_use == part_table->s->db_options_in_use` failed in compare_table_with_partition

With InnoDB, executing an exchange partition that has a virtual column and a table that doesn't have a virtual column was allowed. Then when trying to insert a value to the table,
Assertion `pos < table->n_v_def'` failed.


With MyISAM, when trying to execute an exchange partition that has a virtual column and a table that doesn't have a virtual column,
Assertion `table->s->db_options_in_use == part_table->s->db_options_in_use'` failed.

However, these executions should not be allowed since a normal column and a virtual column (a constant one at that) are not really interchangeable.

To fix the problem, I added the code that confirms the number of virtual columns is equal when executing exchange partition. 


## How can this PR be tested?
The test cases are included in pull request.
I added code that test InnoDB, MyISAM, Aria.


<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*