### PR TITLE
MCOL-5114 Removing ctor specialization b/c it violates c++20 syntax n…

### DIFF
--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -3450,7 +3450,7 @@ protected:
   Item_equal *item_equal;
   Item *curr_item;
 public:
-  Item_equal_iterator<LI,T>(Item_equal &item_eq) 
+  Item_equal_iterator(Item_equal &item_eq)
     :LI<T> (item_eq.equal_items)
   {
     curr_item= NULL;


### PR DESCRIPTION
This PR is made to allow ColumnStore to compile with c++20 with modern compilers, e.g. gcc 11.2. 
BB returns the same results as w/o this patch. 