### PR TITLE
MDEV-28666: Add correct 'Breaks' to make sure upgrade from 10.2 succeeds

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -179,7 +179,8 @@ Depends: libmariadb-dev (= ${binary:Version}),
          libmariadbd19 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
-Breaks: libmysqld-dev
+Breaks: libmysqld-dev,
+        libmariadbd-dev (<= 10.2)
 Replaces: libmysqld-dev
 Description: MariaDB embedded database, development files
  MariaDB is a fast, stable and true multi-user, multi-threaded SQL database


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28666*

## Description
File '/usr/bin/mariadb_config' has been moved from Debian package libmariadbd-dev to libmariadb-dev since MariaDB version 10.2 this leads to situation where upgrade will no succeed but fail with this kind of error message: `trying to overwrite '/usr/bin/mariadb_config', which is also in package libmariadbd-dev 1:10.2.44+maria~bionic`

Add libmariadbd-dev to libmariadb-dev Debian control files 'Breaks' solve situation and upgrading won't error anymore

## How can this PR be tested?
For example Ubuntu 18.04 (Bionic) this can be testes manually (sorry no other way). Preassume is that one is in correct Git branch. It's convenient to test this on Podman or Docker container. 

```
sudo apt update
sudo apt-get install -y git-buildpackage apt-transport-https curl
sudo mk-build-deps -r -i debian/control -t "apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends"
debian/autobake-deb.sh

sudo curl -o /etc/apt/trusted.gpg.d/mariadb_release_signing_key.asc 'https://mariadb.org/mariadb_release_signing_key.asc'
sudo sh -c "echo 'deb https://mirrors.xtom.ee/mariadb/repo/10.2/ubuntu bionic main' >>/etc/apt/sources.list"
sudo apt update
sudo apt install -y libmariadbd-dev
```
Wait for building which can take long time and if everything goes correctly then
```
sudo dpkg -i ../libmariadb-dev_10.3.36+maria~bionic_amd64.deb ../libmariadbd-dev_10.3.36+maria~bionic_amd64.deb ../libmariadb3_10.3.36+maria~bionic_amd64.deb ../libmariadbd19_10.3.36+maria~bionic_amd64.deb
```

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This adds more compatibility as one can upgrade from version 10.2 to any above version without error