### PR TITLE
Fix Ninja builds on Gitlab-CI by limiting parallelism

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -118,8 +118,10 @@ fedora-ninja:
     - mkdir builddir; cd builddir
     - cmake -DRPM=generic $CMAKE_FLAGS -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -G Ninja .. 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
     - ninja -t graph > ../dependencies.dot && dot -Tpng -o ../dependencies.png ../dependencies.dot
-    - eatmydata ninja package --verbose 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
-    # Ninja builds are not affected by bug https://jira.mariadb.org/browse/MDEV-25968
+    - eatmydata ninja package -j 2 --verbose 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
+    # @TODO: Unlike other builds, the Ninja builds using Gitlab.com runners don't get stuck, but they do get
+    # stuck on runners with more processors, see https://jira.mariadb.org/browse/MDEV-25968.
+    # Thus, use the same limitation on Ninja builds as well to ensure it never gets stuck due to this bug.
     - ninja test
     - *rpm_listfiles
     - mkdir ../rpm; mv *.rpm ../rpm


### PR DESCRIPTION
## Description

All but the Ninja builds were restricted to 2 parallel builds due to compiler
otherwise crashing (MDEV-25968). The 'fedora-ninja' job was not failing on
Gitlab.com default runners, but on runners with more processors the crash was
repeatable for Ninja too. Thus also the Ninja build should be limited
with "-j 2".

Using more parallelism might speed up the build, but when testing the build
with '-j' values 2, 4, 8, 16 and 32, the improvement in build times was less
than 10%, indicating that the typical bottleneck is I/O and not CPU cores.
Therefore, "-j 2" is not a big drawback and it was chosen in order to remain
consistent with the other builds affected by MDEV-25968.

## How can this PR be tested?

Run Gitlab-CI on a custom runner that has a high amount of CPU cores and observe that `fedora-ninja` job fails. With this commit and limit to 2 CPUs the build does not fail.

## Basing the PR against the correct MariaDB version

* [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.