### PR TITLE
MDEV-28605: Change wrong plugin config installation location

### DIFF
--- a/debian/mariadb-plugin-gssapi-server.install
+++ b/debian/mariadb-plugin-gssapi-server.install
@@ -1,2 +1,2 @@
-etc/mysql/conf.d/auth_gssapi.cnf etc/mysql/mariadb.conf.d
+etc/mysql/conf.d/auth_gssapi.cnf
 usr/lib/mysql/plugin/auth_gssapi.so

--- a/debian/mariadb-plugin-oqgraph.install
+++ b/debian/mariadb-plugin-oqgraph.install
@@ -1,2 +1,2 @@
-etc/mysql/conf.d/oqgraph.cnf etc/mysql/mariadb.conf.d
+etc/mysql/conf.d/oqgraph.cnf
 usr/lib/mysql/plugin/ha_oqgraph.so

--- a/debian/mariadb-plugin-rocksdb.install
+++ b/debian/mariadb-plugin-rocksdb.install
@@ -1,4 +1,4 @@
-etc/mysql/conf.d/rocksdb.cnf etc/mysql/mariadb.conf.d
+etc/mysql/conf.d/rocksdb.cnf
 usr/bin/myrocks_hotbackup
 usr/bin/mysql_ldb
 usr/bin/sst_dump

--- a/debian/mariadb-plugin-tokudb.install
+++ b/debian/mariadb-plugin-tokudb.install
@@ -1,4 +1,4 @@
-etc/mysql/conf.d/tokudb.cnf etc/mysql/mariadb.conf.d
+etc/mysql/conf.d/tokudb.cnf
 etc/systemd/system/mariadb.service.d/tokudb.conf
 usr/bin/tokuft_logprint
 usr/bin/tokuftdump


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28605*

## Description
Preset include directory for configuration files below MariaDB 10.5 is `/etc/mysql/conf.d` not `/etc/mysql/mariadb.d`

Change installation location wrong plugin installation location from `/etc/mysql/mariadb.d` to default include directory `/etc/mysql/conf.d`. Change makes _gssapi-server_, _oqgraph_, _rocksdb_ and _tokudb_ plugins loading work after installation

## How can this PR be tested?
This can be tested manually (for example Ubuntu 20.04. Please remove old version before testing):

To compile you need to have correct branch

```
sudo apt update
sudo apt-get install -y git-buildpackage apt-transport-https curl
sudo mk-build-deps -r -i debian/control -t "apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends"
debian/autobake-deb.sh
cd ..

sudo dpkg -i mariadb-common_10.3.36+maria~ubu1804_all.deb mysql-common_10.3.36+maria~ubu1804_all.deb mariadb-server-core-10.3_10.3.36+maria~ubu1804_amd64.deb mariadb-client-core-10.3_10.3.36+maria~ubu1804_amd64.deb mariadb-client-10.3_10.3.36+maria~ubu1804_amd64.deb libmariadb3_10.3.36+maria~ubu1804_amd64.deb
sudo dpkg -i mariadb-server-10.3_10.3.36+maria~ubu1804_amd64.deb
sudo dpkg -i mariadb-plugin-rocksdb_10.3.36+maria~ubu1804_amd64.deb mariadb-plugin-tokudb_10.3.36+maria~ubu1804_amd64.deb mariadb-plugin-gssapi-server_10.3.36+maria~ubu1804_amd64.deb mariadb-plugin-oqgraph_10.3.36+maria~ubu1804_amd64.deb
```
Default `/etc/mysql/my.cnf` should contain line `!includedir /etc/mysql/conf.d` as last line and there should be
```
auth_gssapi.cnf
mysqld_safe_syslog.cnf
oqgraph.cnf
rocksdb.cnf
tokudb.cnf
```
Inside `/etc/mysql/conf.d` and command
 
`mysql -p -u root -e "SHOW PLUGINS;"`

output should be:

```
Name	Status	Type	Library	License
binlog	ACTIVE	STORAGE ENGINE	NULL	GPL
mysql_native_password	ACTIVE	AUTHENTICATION	NULL	GPL
mysql_old_password	ACTIVE	AUTHENTICATION	NULL	GPL
wsrep	ACTIVE	STORAGE ENGINE	NULL	GPL
CSV	ACTIVE	STORAGE ENGINE	NULL	GPL
MEMORY	ACTIVE	STORAGE ENGINE	NULL	GPL
MyISAM	ACTIVE	STORAGE ENGINE	NULL	GPL
MRG_MyISAM	ACTIVE	STORAGE ENGINE	NULL	GPL
CLIENT_STATISTICS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INDEX_STATISTICS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
TABLE_STATISTICS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
USER_STATISTICS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
SQL_SEQUENCE	ACTIVE	STORAGE ENGINE	NULL	GPL
InnoDB	ACTIVE	STORAGE ENGINE	NULL	GPL
INNODB_TRX	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_LOCKS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_LOCK_WAITS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_CMP	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_CMP_RESET	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_CMPMEM	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_CMPMEM_RESET	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_CMP_PER_INDEX	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_CMP_PER_INDEX_RESET	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_BUFFER_PAGE	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_BUFFER_PAGE_LRU	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_BUFFER_POOL_STATS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_METRICS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_FT_DEFAULT_STOPWORD	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_FT_DELETED	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_FT_BEING_DELETED	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_FT_CONFIG	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_FT_INDEX_CACHE	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_FT_INDEX_TABLE	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_TABLES	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_TABLESTATS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_INDEXES	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_COLUMNS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_FIELDS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_FOREIGN	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_FOREIGN_COLS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_TABLESPACES	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_DATAFILES	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_VIRTUAL	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_MUTEXES	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_SYS_SEMAPHORE_WAITS	ACTIVE	INFORMATION SCHEMA	NULL	GPL
INNODB_TABLESPACES_ENCRYPTION	ACTIVE	INFORMATION SCHEMA	NULL	BSD
INNODB_TABLESPACES_SCRUBBING	ACTIVE	INFORMATION SCHEMA	NULL	BSD
Aria	ACTIVE	STORAGE ENGINE	NULL	GPL
PERFORMANCE_SCHEMA	ACTIVE	STORAGE ENGINE	NULL	GPL
SEQUENCE	ACTIVE	STORAGE ENGINE	NULL	GPL
FEEDBACK	DISABLED	INFORMATION SCHEMA	NULL	GPL
user_variables	ACTIVE	INFORMATION SCHEMA	NULL	GPL
partition	ACTIVE	STORAGE ENGINE	NULL	GPL
OQGRAPH	ACTIVE	STORAGE ENGINE	ha_oqgraph.so	GPL
ROCKSDB	ACTIVE	STORAGE ENGINE	ha_rocksdb.so	GPL
ROCKSDB_CFSTATS	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_DBSTATS	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_PERF_CONTEXT	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_PERF_CONTEXT_GLOBAL	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_CF_OPTIONS	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_COMPACTION_STATS	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_GLOBAL_INFO	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_DDL	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_SST_PROPS	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_INDEX_FILE_MAP	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_LOCKS	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_TRX	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
ROCKSDB_DEADLOCK	ACTIVE	INFORMATION SCHEMA	ha_rocksdb.so	GPL
TokuDB	ACTIVE	STORAGE ENGINE	ha_tokudb.so	GPL
TokuDB_trx	ACTIVE	INFORMATION SCHEMA	ha_tokudb.so	GPL
TokuDB_lock_waits	ACTIVE	INFORMATION SCHEMA	ha_tokudb.so	GPL
TokuDB_locks	ACTIVE	INFORMATION SCHEMA	ha_tokudb.so	GPL
TokuDB_file_map	ACTIVE	INFORMATION SCHEMA	ha_tokudb.so	GPL
TokuDB_fractal_tree_info	ACTIVE	INFORMATION SCHEMA	ha_tokudb.so	GPL
TokuDB_fractal_tree_block_map	ACTIVE	INFORMATION SCHEMA	ha_tokudb.so	GPL
TokuDB_background_job_status	ACTIVE	INFORMATION SCHEMA	ha_tokudb.so	GPL

```
or crap BB deb packages while they are fresh to install if you want to skip building and do the same maneuvers 

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
Should bring more compatibility