### PR TITLE
Fix building the Hashicorp plugin on OpenBSD / NetBSD and DragonFlyBSD

### DIFF
--- a/plugin/hashicorp_key_management/hashicorp_key_management_plugin.cc
+++ b/plugin/hashicorp_key_management/hashicorp_key_management_plugin.cc
@@ -26,7 +26,7 @@
 #ifdef _WIN32
 #include <malloc.h>
 #define alloca _alloca
-#elif !defined(__FreeBSD__)
+#elif !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
 #include <alloca.h>
 #endif
 #include <algorithm>


### PR DESCRIPTION
OpenBSD / NetBSD and DragonFlyBSD do not have the alloca.h header just as FreeBSD.