### PR TITLE
MDEV-28795 Deprecate spider_bka_table_name_type

### DIFF
--- a/storage/spider/mysql-test/spider/r/variable_deprecation.result
+++ b/storage/spider/mysql-test/spider/r/variable_deprecation.result
@@ -240,6 +240,21 @@ Warnings:
 Warning	1287	The table parameter 'semi_table_lock_connection' is deprecated and will be removed in a future release
 DROP TABLE tbl_a;
 DROP TABLE tbl_b;
+# MDEV-28795 Deprecate spider_bka_table_name_type
+SET spider_bka_table_name_type = 1;
+Warnings:
+Warning	1287	'@@spider_bka_table_name_type' is deprecated and will be removed in a future release
+SHOW VARIABLES LIKE "spider_bka_table_name_type";
+Variable_name	Value
+spider_bka_table_name_type	1
+CREATE TABLE tbl_a (a INT) ENGINE=Spider COMMENT='btt "1"';
+Warnings:
+Warning	1287	The table parameter 'btt' is deprecated and will be removed in a future release
+CREATE TABLE tbl_b (a INT) ENGINE=Spider COMMENT='bka_table_name_type "1"';
+Warnings:
+Warning	1287	The table parameter 'bka_table_name_type' is deprecated and will be removed in a future release
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
 DROP DATABASE auto_test_local;
 for master_1
 for child2

--- a/storage/spider/mysql-test/spider/t/variable_deprecation.test
+++ b/storage/spider/mysql-test/spider/t/variable_deprecation.test
@@ -143,6 +143,15 @@ eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='semi_table_lock_connec
 DROP TABLE tbl_a;
 DROP TABLE tbl_b;
 
+--echo # MDEV-28795 Deprecate spider_bka_table_name_type
+SET spider_bka_table_name_type = 1;
+SHOW VARIABLES LIKE "spider_bka_table_name_type";
+eval CREATE TABLE tbl_a (a INT) $MASTER_1_ENGINE COMMENT='btt "1"';
+eval CREATE TABLE tbl_b (a INT) $MASTER_1_ENGINE COMMENT='bka_table_name_type "1"';
+
+DROP TABLE tbl_a;
+DROP TABLE tbl_b;
+
 DROP DATABASE auto_test_local;
 
 --disable_query_log

--- a/storage/spider/spd_param.cc
+++ b/storage/spider/spd_param.cc
@@ -3184,7 +3184,7 @@ int spider_param_delete_all_rows_type(
  */
 static MYSQL_THDVAR_INT(
   bka_table_name_type, /* name */
-  PLUGIN_VAR_RQCMDARG, /* opt */
+  PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_DEPRECATED, /* opt */
   "The type of temporary table name for bka", /* comment */
   NULL, /* check */
   spider_var_deprecated_int, /* update */

--- a/storage/spider/spd_table.cc
+++ b/storage/spider/spd_table.cc
@@ -2339,6 +2339,7 @@ int spider_parse_connect_info(
           SPIDER_PARAM_STR("bke", bka_engine);
           SPIDER_PARAM_INT_WITH_MAX("bkm", bka_mode, 0, 2);
           SPIDER_PARAM_INT("bsz", bulk_size, 0);
+          SPIDER_PARAM_DEPRECATED_WARNING("btt");
           SPIDER_PARAM_LONG_LIST_WITH_MAX("btt", bka_table_name_types,
             0, 1);
           SPIDER_PARAM_INT_WITH_MAX("bum", bulk_update_mode, 0, 2);
@@ -2700,6 +2701,7 @@ int spider_parse_connect_info(
 #if defined(HS_HAS_SQLCOM) && defined(HAVE_HANDLERSOCKET)
           SPIDER_PARAM_LONGLONG("hs_result_free_size", hs_result_free_size, 0);
 #endif
+          SPIDER_PARAM_DEPRECATED_WARNING("bka_table_name_type");
           SPIDER_PARAM_LONG_LIST_WITH_MAX("bka_table_name_type",
             bka_table_name_types, 0, 1);
           SPIDER_PARAM_INT_WITH_MAX(


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28795

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Deprecate spider_param_bka_table_name_type

## How can this PR be tested?
Testcases of this PR.
`./mysql-test/mtr spider.variable_deprecation`

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
