### PR TITLE
MDEV-28914 Extend MTR command "copy_file" to support recursive copy and wildcard

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -3867,24 +3867,266 @@ end:
 
 /*
   SYNOPSIS
+  recursive_copy
+  ds_source      - pointer to dynamic string containing source
+                   directory information
+  ds_destination - pointer to dynamic string containing destination
+                   directory information
+  DESCRIPTION
+    Recursive copy of <ds_source> to <ds_destination>
+
+    For simplicity, always create directory <ds_destination>/<source_dir_name>
+    and then copy the content to it. For example `copy_file a/b $dst -r` will
+    always create directory $dst/b
+
+    Note: When symlink appears, copy the target file
+*/
+
+static int recursive_copy(DYNAMIC_STRING *ds_source,
+                          DYNAMIC_STRING *ds_destination,
+                          int do_not_overwrite,
+                          bool create_new_dir_in_dst)
+{
+  /* Note that my_dir sorts the list if not given any flags */
+  MY_DIR *src_dir_info= my_dir(ds_source->str,
+                               MYF(MY_DONT_SORT | MY_WANT_STAT));
+
+  int error= 0;
+
+  /* Source directory exists */
+  if (src_dir_info)
+  {
+    /* Note that my_dir sorts the list if not given any flags */
+    MY_DIR *dest_dir_info= my_dir(ds_destination->str,
+                                  MYF(MY_DONT_SORT | MY_WANT_STAT));
+
+    /* Create destination directory if it doesn't exist */
+    if (!dest_dir_info)
+    {
+      error= my_mkdir(ds_destination->str, 0777, MYF(0)) != 0;
+      if (error)
+      {
+        my_dirend(dest_dir_info);
+        goto end;
+      }
+    }
+
+    /* Extracting the source basename */
+    if (ds_source->str[strlen(ds_source->str) - 1] == '/')
+    {
+      ds_source->str[strlen(ds_source->str) - 1]= '\0';
+      ds_source->length= ds_source->length - 1;
+    }
+    char *src_dir_name= strrchr(ds_source->str, '/');
+
+    /* Create <destination_directory>/<source_dir_name> if it doesn't exist
+       Use create_new_dir_in_dst flag because this is only and always needed
+       for the first level of recursive copy */
+    if (create_new_dir_in_dst)
+    {
+      dynstr_append_mem(ds_destination, src_dir_name, strlen(src_dir_name));
+      my_dirend(dest_dir_info);
+      dest_dir_info= my_dir(ds_destination->str,
+                            MYF(MY_DONT_SORT | MY_WANT_STAT));
+
+      if (!dest_dir_info)
+      {
+        error= my_mkdir(ds_destination->str, 0777, MYF(0)) != 0;
+        if (error)
+        {
+          my_dirend(dest_dir_info);
+          goto end;
+        }
+      }
+    }
+
+    char dir_separator[2]= {FN_LIBCHAR, 0};
+    dynstr_append_mem(ds_source, dir_separator, strlen(dir_separator));
+    dynstr_append_mem(ds_destination, dir_separator, strlen(dir_separator));
+
+    /*
+      Storing the length of source and destination
+      directory paths so it can be reused.
+    */
+    size_t source_dir_length= ds_source->length;
+    size_t destination_dir_length= ds_destination->length;
+    ;
+
+    for (uint i= 0; i < src_dir_info->number_of_files; i++)
+    {
+      ds_source->length= source_dir_length;
+      ds_destination->length= destination_dir_length;
+      FILEINFO *file= src_dir_info->dir_entry + i;
+
+      dynstr_append_mem(ds_source, file->name, strlen(file->name));
+      dynstr_append_mem(ds_destination, file->name, strlen(file->name));
+
+      if (MY_S_ISDIR(file->mystat->st_mode))
+      {
+        if (recursive_copy(ds_source, ds_destination, do_not_overwrite, false) != 0)
+          error= 1;
+      }
+      else
+      {
+        DBUG_PRINT("info", ("Copying file: %s to %s", ds_source->str,
+                            ds_destination->str));
+
+        /* MY_HOLD_ORIGINAL_MODES prevents attempts to chown the file */
+        if (my_copy(ds_source->str, ds_destination->str,
+                    MYF(do_not_overwrite | MY_WME)) != 0)
+          error= 1;
+      }
+    }
+    my_dirend(dest_dir_info);
+  }
+  /* Source directory does not exist or access denied */
+  else
+    error= 1;
+
+end:
+  my_dirend(src_dir_info);
+  return error;
+}
+
+
+
+/*
+  Copy files from source directory to destination directory, by matching
+  a specified file name pattern.
+
+  Copy will fail if no files match the pattern. Copy will also
+  fail if source directory or destination directory or both do not
+  exist.
+
+  ds_source      - pointer to dynamic string containing source
+                   directory information
+  ds_destination - pointer to dynamic string containing destination
+                   directory information
+  ds_wild        - pointer to dynamic string containing wildcard pattern
+  recursive      - indicating whether to copy directory recursively
+*/
+static int wildcard_copy(DYNAMIC_STRING *ds_source,
+                         DYNAMIC_STRING *ds_destination,
+                         DYNAMIC_STRING *ds_wild,
+                         bool recursive,
+                         int do_not_overwrite)
+{
+  int error= 0;
+
+  /* Note that my_dir sorts the list if not given any flags */
+  MY_DIR *src_dir_info= my_dir(ds_source->str,
+                               MYF(MY_DONT_SORT | MY_WANT_STAT));
+  MY_DIR *dst_dir_info= my_dir(ds_destination->str,
+                               MYF(MY_DONT_SORT | MY_WANT_STAT));
+
+  /* Either one of directories does not exist or access denied */
+  if (!src_dir_info || !dst_dir_info)
+  {
+    error= 1;
+    goto end;
+  }
+
+  char dir_separator[2];
+  dir_separator[0]= FN_LIBCHAR;
+  dir_separator[1]= 0;
+  dynstr_append_mem(ds_source, dir_separator, strlen(dir_separator));
+  dynstr_append_mem(ds_destination, dir_separator, strlen(dir_separator));
+
+  /* Storing the length of the path to the file, so it can be reused */
+  size_t source_file_length;
+  size_t dest_file_length;
+  dest_file_length= ds_destination->length;
+  source_file_length= ds_source->length;
+  uint match_count;
+  match_count= 0;
+
+  for (uint i= 0; i < src_dir_info->number_of_files; i++)
+  {
+    ds_source->length= source_file_length;
+    ds_destination->length= dest_file_length;
+    FILEINFO *file= src_dir_info->dir_entry + i;
+
+    /* Skip directories if recursive copy is not requested */
+    if (MY_S_ISDIR(file->mystat->st_mode) && !recursive)
+      continue;
+
+    /* Copy only those files which the pattern matches */
+    if (ds_wild->length &&
+        wild_compare(file->name, ds_wild->str, false))
+      continue;
+
+    match_count++;
+    dynstr_append_mem(ds_source, file->name, strlen(file->name));
+    dynstr_append_mem(ds_destination, file->name, strlen(file->name));
+
+    if (MY_S_ISDIR(file->mystat->st_mode))
+    {
+      DBUG_PRINT("info", ("Recursive copy files of %s to %s",
+                          ds_source->str, ds_destination->str));
+      DBUG_PRINT("info", ("listing directory: %s", ds_source->str));
+      error= recursive_copy(ds_source, ds_destination, do_not_overwrite, false);
+    }
+    else
+    {
+      DBUG_PRINT("info", ("Copying file: %s to %s",
+                          ds_source->str, ds_destination->str));
+      /* MY_HOLD_ORIGINAL_MODES prevents attempts to chown the file */
+      error= (my_copy(ds_source->str, ds_destination->str,
+              MYF(MY_HOLD_ORIGINAL_MODES)) != 0);
+    }
+
+    if (error) goto end;
+  }
+
+  /* Pattern did not match any files */
+  if (!match_count)
+  {
+    error= 1;
+  }
+
+end:
+  my_dirend(src_dir_info);
+  my_dirend(dst_dir_info);
+  return error;
+}
+
+
+/*
+  SYNOPSIS
   do_copy_file
   command	command handle
 
   DESCRIPTION
-  copy_file <from_file> <to_file>
-  Copy <from_file> to <to_file>
+  copy_file <source> <destination> [-r|-f|-rf]
 
-  NOTE! Will fail if <to_file> exists
+  <source> can be a file, a directory, or a path with wildcard pattern
+
+  - When <source> is a directory, '-r' must be given to copy recursively
+  - When <source> is a wildcard pattern, '-r' is optional. If given, then
+    directories that match the pattern will also be copied.
+  - When '-f' is given, files in destination with same name will be overwritten
+  - Wildcard is only supported in the basename of path
+    (e.g. src/(wildcard)/(wildcard) will not work)
 */
 
 void do_copy_file(struct st_command *command)
 {
   int error;
-  static DYNAMIC_STRING ds_from_file;
-  static DYNAMIC_STRING ds_to_file;
-  const struct command_arg copy_file_args[] = {
-    { "from_file", ARG_STRING, TRUE, &ds_from_file, "Filename to copy from" },
-    { "to_file", ARG_STRING, TRUE, &ds_to_file, "Filename to copy to" }
+  static DYNAMIC_STRING ds_source;
+  static DYNAMIC_STRING ds_destination;
+  static DYNAMIC_STRING ds_wild;
+  static DYNAMIC_STRING ds_options;
+  static bool recursive;
+  static int do_not_overwrite; // Flags for my_copy()
+  MY_STAT src_stat_buff;
+  MY_STAT dst_stat_buff;
+  const struct command_arg copy_file_args[]=
+  {
+    { "source", ARG_STRING, TRUE, &ds_source, "File/dir name to copy from" },
+    { "destination", ARG_STRING, TRUE, &ds_destination,
+      "File/dir name to copy to" },
+    { "option", ARG_STRING, FALSE, &ds_options,
+      "Optional flags to use recursive (-r) and/or force (-f) copy" }
   };
   DBUG_ENTER("do_copy_file");
 
@@ -3893,16 +4135,88 @@ void do_copy_file(struct st_command *command)
                      sizeof(copy_file_args)/sizeof(struct command_arg),
                      ' ');
 
-  if (bad_path(ds_to_file.str))
-    DBUG_VOID_RETURN;
+  /*
+    MY_HOLD_ORIGINAL_MODES prevents attempts to chown the file, but if '-f' is
+    used and overwrites the file, we should allow chown as well.
+  */
+  recursive= 0;
+  do_not_overwrite= MY_DONT_OVERWRITE_FILE | MY_HOLD_ORIGINAL_MODES;
+  if (ds_options.str[0] == '-')
+    for (uint i= 1; i < ds_options.length; i++)
+      if (ds_options.str[i] == 'r')
+        recursive= 1;
+      else if (ds_options.str[i] == 'f')
+        do_not_overwrite= 0;
+      else
+      {
+        error= 1;
+        goto end;
+      }
+  else if (ds_options.length != 0)
+  {
+    error= 1;
+    goto end;
+  }
 
-  DBUG_PRINT("info", ("Copy %s to %s", ds_from_file.str, ds_to_file.str));
-  /* MY_HOLD_ORIGINAL_MODES prevents attempts to chown the file */
-  error= (my_copy(ds_from_file.str, ds_to_file.str,
-                  MYF(MY_DONT_OVERWRITE_FILE | MY_WME | MY_HOLD_ORIGINAL_MODES)) != 0);
+  /*
+    Throw an error if destination path is invalid, or source and destination
+    paths are same.
+  */
+  if (bad_path(ds_destination.str) ||
+      !strcmp(ds_source.str, ds_destination.str))
+  {
+    error= 1;
+  }
+  else if (my_stat(ds_source.str, &src_stat_buff, MYF(0)))
+  {
+    /* For source as regular file, check if destination is also a regular file */
+    if (MY_S_ISREG(src_stat_buff.st_mode))
+    {
+      /* If destination is a directory, append the file name */
+      if (my_stat(ds_destination.str, &dst_stat_buff, MYF(0)) && MY_S_ISDIR(dst_stat_buff.st_mode))
+      {
+        const char *wild= my_basename(ds_source.str);
+        char dir_separator[2]= {FN_LIBCHAR, 0};
+        dynstr_append_mem(&ds_destination, dir_separator, strlen(dir_separator));
+        dynstr_append_mem(&ds_destination, wild, strlen(wild));
+
+      }
+      DBUG_PRINT("info", ("Copy %s to %s", ds_source.str, ds_destination.str));
+      error= (my_copy(ds_source.str, ds_destination.str,
+              MYF(do_not_overwrite | MY_WME)) != 0);
+    }
+    /* For directory, copy if recursive is enabled */
+    else if (recursive)
+    {
+      DBUG_PRINT("info", ("Recursive copy files of %s to %s",
+                          ds_source.str, ds_destination.str));
+      DBUG_PRINT("info", ("listing directory: %s", ds_source.str));
+      error= recursive_copy(&ds_source, &ds_destination, do_not_overwrite, true);
+    }
+    else
+    {
+      error= 1;
+    }
+  }
+  else
+  {
+    /*
+      Cannot get file stat. Could be a wildcard pattern. Extract the basename
+      as wildcard pattern.  If it is not a valid wildcard pattern,
+      wildcard_copy() will return error.
+    */
+    const char *wild= my_basename(ds_source.str);
+    init_dynamic_string(&ds_wild, wild, strlen(wild) + 1, 0);
+    dynstr_trunc(&ds_source, ds_wild.length+1);
+    error= wildcard_copy(&ds_source, &ds_destination, &ds_wild, recursive, do_not_overwrite);
+  }
+
+end:
   handle_command_error(command, error, my_errno);
-  dynstr_free(&ds_from_file);
-  dynstr_free(&ds_to_file);
+  dynstr_free(&ds_source);
+  dynstr_free(&ds_destination);
+  dynstr_free(&ds_wild);
+  dynstr_free(&ds_options);
   DBUG_VOID_RETURN;
 }
 

--- a/mysql-test/main/mysqltest.result
+++ b/mysql-test/main/mysqltest.result
@@ -738,8 +738,22 @@ for cat_file command
 of mysqltest
 mysqltest: At line 1: command "cat_file" failed with error: 1  my_errno: 2  errno: 2
 mysqltest: At line 1: Missing required argument 'filename' to command 'file_exists'
-mysqltest: At line 1: Missing required argument 'from_file' to command 'copy_file'
-mysqltest: At line 1: Missing required argument 'to_file' to command 'copy_file'
+file1
+file1
+file1 more content
+file1.tmp
+file2.tmp
+file1 content
+file2 content
+file1 content
+file2 content
+file1 more content
+file2 more content
+file1 content
+file2 content
+mysqltest: At line 1: Missing required argument 'source' to command 'copy_file'
+mysqltest: At line 1: Missing required argument 'destination' to command 'copy_file'
+mysqltest: At line 1: command "copy_file" failed with error: 1  my_errno: 0  errno: 0
 mysqltest: At line 1: Missing required argument 'from_file' to command 'move_file'
 mysqltest: At line 1: Missing required argument 'to_file' to command 'move_file'
 mysqltest: At line 1: Missing required argument 'mode' to command 'chmod'

--- a/mysql-test/main/mysqltest.test
+++ b/mysql-test/main/mysqltest.test
@@ -2369,20 +2369,211 @@ file_exists $MYSQLTEST_VARDIR/tmp/test_file1.tmp;
 # ----------------------------------------------------------------------------
 # test for copy_file
 # ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Test #1: Basic file copying (destination is a file)
+# ----------------------------------------------------------------------------
 --write_file $MYSQLTEST_VARDIR/tmp/file1.tmp
 file1
 EOF
 
 copy_file $MYSQLTEST_VARDIR/tmp/file1.tmp $MYSQLTEST_VARDIR/tmp/file2.tmp;
 file_exists $MYSQLTEST_VARDIR/tmp/file2.tmp;
+
+# clean up
 remove_file $MYSQLTEST_VARDIR/tmp/file1.tmp;
 remove_file $MYSQLTEST_VARDIR/tmp/file2.tmp;
 
+# ----------------------------------------------------------------------------
+# Test #1: Basic file copying (destination is a directory)
+# ----------------------------------------------------------------------------
+--write_file $MYSQLTEST_VARDIR/tmp/file1.tmp
+file1
+EOF
+
+mkdir $MYSQLTEST_VARDIR/tmp/testdir;
+copy_file $MYSQLTEST_VARDIR/tmp/file1.tmp $MYSQLTEST_VARDIR/tmp/testdir/file1.tmp;
+file_exists $MYSQLTEST_VARDIR/tmp/testdir/file1.tmp;
+
+# clean up
+remove_file $MYSQLTEST_VARDIR/tmp/file1.tmp;
+remove_file $MYSQLTEST_VARDIR/tmp/testdir/file1.tmp;
+rmdir $MYSQLTEST_VARDIR/tmp/testdir;
+
+# ----------------------------------------------------------------------------
+# Test #2: Copy with force override "-f"
+# ----------------------------------------------------------------------------
+--write_file $MYSQLTEST_VARDIR/tmp/file1.tmp
+file1
+EOF
+
+mkdir $MYSQLTEST_VARDIR/tmp/testdir;
+
+copy_file $MYSQLTEST_VARDIR/tmp/file1.tmp $MYSQLTEST_VARDIR/tmp/testdir;
+cat_file $MYSQLTEST_VARDIR/tmp/file1.tmp;
+
+remove_file $MYSQLTEST_VARDIR/tmp/file1.tmp;
+--write_file $MYSQLTEST_VARDIR/tmp/file1.tmp
+file1 more content
+EOF
+
+# Copy again without -f to make sure the file is not overwritten
+# Not logging the error back to MTR result as it contains local paths
+--error 1
+--exec echo "copy_file $MYSQLTEST_VARDIR/tmp/file1.tmp $MYSQLTEST_VARDIR/tmp/testdir;" | $MYSQL_TEST
+cat_file $MYSQLTEST_VARDIR/tmp/testdir/file1.tmp;
+
+# Copy again with -f to make sure the file is overwritten
+copy_file $MYSQLTEST_VARDIR/tmp/file1.tmp $MYSQLTEST_VARDIR/tmp/testdir -f;
+cat_file $MYSQLTEST_VARDIR/tmp/testdir/file1.tmp;
+
+# clean up
+remove_file $MYSQLTEST_VARDIR/tmp/file1.tmp;
+remove_file $MYSQLTEST_VARDIR/tmp/testdir/file1.tmp;
+rmdir $MYSQLTEST_VARDIR/tmp/testdir;
+
+# ----------------------------------------------------------------------------
+# Test #3: Copy with wildcard
+# ----------------------------------------------------------------------------
+mkdir $MYSQLTEST_VARDIR/tmp/testdir;
+--write_file $MYSQLTEST_VARDIR/tmp/file1.tmp
+file1
+EOF
+--write_file $MYSQLTEST_VARDIR/tmp/file2.tmp
+file1
+EOF
+copy_file $MYSQLTEST_VARDIR/tmp/file*.tmp $MYSQLTEST_VARDIR/tmp/testdir;
+list_files $MYSQLTEST_VARDIR/tmp/testdir;
+
+# Clean up
+remove_file $MYSQLTEST_VARDIR/tmp/file1.tmp;
+remove_file $MYSQLTEST_VARDIR/tmp/file2.tmp;
+rmdir $MYSQLTEST_VARDIR/tmp/testdir;
+
+# ----------------------------------------------------------------------------
+# Test #4: Copy directory recursively
+# ----------------------------------------------------------------------------
+
+# Generate the directory structure and files
+# - d1
+#   |- f1.tmp
+#   `- d2
+#      `- f2.tmp
+mkdir $MYSQLTEST_VARDIR/tmp/d1;
+--write_file $MYSQLTEST_VARDIR/tmp/d1/f1.tmp
+file1 content
+EOF
+mkdir $MYSQLTEST_VARDIR/tmp/d1/d2;
+--write_file $MYSQLTEST_VARDIR/tmp/d1/d2/f2.tmp
+file2 content
+EOF
+
+mkdir $MYSQLTEST_VARDIR/tmp/dst;
+
+# Copy to new directory
+copy_file $MYSQLTEST_VARDIR/tmp/d1 $MYSQLTEST_VARDIR/tmp/dst -r;
+
+# Verify that the copy succeeds
+# - dst
+#   `- d1
+#      |- f1.tmp
+#      `- d2
+#         `- f2.tmp
+cat_file $MYSQLTEST_VARDIR/tmp/dst/d1/f1.tmp;
+cat_file $MYSQLTEST_VARDIR/tmp/dst/d1/d2/f2.tmp;
+
+# Change source file content
+remove_file $MYSQLTEST_VARDIR/tmp/d1/f1.tmp;
+--write_file $MYSQLTEST_VARDIR/tmp/d1/f1.tmp
+file1 more content
+EOF
+
+remove_file $MYSQLTEST_VARDIR/tmp/d1/d2/f2.tmp;
+--write_file $MYSQLTEST_VARDIR/tmp/d1/d2/f2.tmp
+file2 more content
+EOF
+
+# Copy again to new directory with -r but wihtout -f to make sure that the existing files are not overwritten
+# Not logging the error back to MTR result as it contains local paths
+--error 1
+--exec echo "copy_file $MYSQLTEST_VARDIR/tmp/d1 $MYSQLTEST_VARDIR/tmp/dst -r;" | $MYSQL_TEST
+
+# Verify that the file content are not overwritten
+cat_file $MYSQLTEST_VARDIR/tmp/dst/d1/f1.tmp;
+cat_file $MYSQLTEST_VARDIR/tmp/dst/d1/d2/f2.tmp;
+
+# Copy again to new directory with -r but with -f to make sure that the existing files are successfully overwritten
+copy_file $MYSQLTEST_VARDIR/tmp/d1 $MYSQLTEST_VARDIR/tmp/dst -rf;
+
+# Verify that the copy succeeds
+cat_file $MYSQLTEST_VARDIR/tmp/dst/d1/f1.tmp;
+cat_file $MYSQLTEST_VARDIR/tmp/dst/d1/d2/f2.tmp;
+
+# Clean up
+remove_file $MYSQLTEST_VARDIR/tmp/dst/d1/d2/f2.tmp;
+remove_file $MYSQLTEST_VARDIR/tmp/dst/d1/f1.tmp;
+rmdir $MYSQLTEST_VARDIR/tmp/dst/d1/d2;
+rmdir $MYSQLTEST_VARDIR/tmp/dst/d1;
+
+remove_file $MYSQLTEST_VARDIR/tmp/d1/d2/f2.tmp;
+remove_file $MYSQLTEST_VARDIR/tmp/d1/f1.tmp;
+rmdir $MYSQLTEST_VARDIR/tmp/d1/d2;
+rmdir $MYSQLTEST_VARDIR/tmp/d1;
+
+# ----------------------------------------------------------------------------
+# Test #5: Copy recursively with wildcard
+# ----------------------------------------------------------------------------
+
+# Generate the directory structure and files
+# - d1
+#   |- f1.tmp
+#   `- d2
+#      `- f2.tmp
+mkdir $MYSQLTEST_VARDIR/tmp/d1;
+--write_file $MYSQLTEST_VARDIR/tmp/d1/f1.tmp
+file1 content
+EOF
+mkdir $MYSQLTEST_VARDIR/tmp/d1/d2;
+--write_file $MYSQLTEST_VARDIR/tmp/d1/d2/f2.tmp
+file2 content
+EOF
+
+# Copy with wildcard pattern
+copy_file $MYSQLTEST_VARDIR/tmp/d1/* $MYSQLTEST_VARDIR/tmp/dst -r;
+
+
+# Verify that the copy succeeds
+# - dst
+#   |- f1.tmp
+#   `- d2
+#      `- f2.tmp
+cat_file $MYSQLTEST_VARDIR/tmp/dst/f1.tmp;
+cat_file $MYSQLTEST_VARDIR/tmp/dst/d2/f2.tmp;
+
+# Clean up
+remove_file $MYSQLTEST_VARDIR/tmp/dst/d2/f2.tmp;
+remove_file $MYSQLTEST_VARDIR/tmp/dst/f1.tmp;
+rmdir $MYSQLTEST_VARDIR/tmp/dst/d2;
+rmdir $MYSQLTEST_VARDIR/tmp/dst;
+
+remove_file $MYSQLTEST_VARDIR/tmp/d1/d2/f2.tmp;
+remove_file $MYSQLTEST_VARDIR/tmp/d1/f1.tmp;
+rmdir $MYSQLTEST_VARDIR/tmp/d1/d2;
+rmdir $MYSQLTEST_VARDIR/tmp/d1;
+
+# ----------------------------------------------------------------------------
+# Test #6: Invalid argument
+# ----------------------------------------------------------------------------
+# Use '--exec' to spawn a separate process because syntax errors will terminate
+# the running process.
 --error 1
 --exec echo "copy_file ;" | $MYSQL_TEST 2>&1
 
 --error 1
 --exec echo "copy_file from_file;" | $MYSQL_TEST 2>&1
+
+--error 1
+--exec echo "copy_file from_file to_file -i;" | $MYSQL_TEST 2>&1
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28914*
## Description
A few commands have been missing in MariaDB MTR compare to MySQL MTR:

- "force_cpdir" is useful when trying to duplicate the data directory for destructive tests
- "copy_files_wildcard" is useful when trying to copy all files related to a specific table to another location

However instead of introducing these commands to MariaDB, it is better to extend the existing command "copy_file" to support both recursive copy and wildcard.

With this commit, "copy_file" can be used in similar way as "cp" in bash.

- Copy a regular file:
  copy_file file1 file2;

- Copy a directory:
  copy_file dir1 dir2 -r;

- Copy with wildcard:
  copy_file file.* dir2;

## How can this PR be tested?
All existing test cases in main suite including the ones that test mysqltest itself passed.
New test cases added into mysqltest.test regarding for the new commands.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility
New commands added will not compromise any backward compatibility

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.