### PR TITLE
Format properly mtr report for the test case that is not completed

### DIFF
--- a/mysql-test/mariadb-test-run.pl
+++ b/mysql-test/mariadb-test-run.pl
@@ -509,11 +509,12 @@ sub main {
   }
 
   if ( not @$completed ) {
-    my $test_name= mtr_grab_file($path_current_testlog);
+    my $test_name= mtr_grab_file($path_testlog);
     $test_name =~ s/^CURRENT_TEST:\s//;
+    chomp($test_name);
     my $tinfo = My::Test->new(name => $test_name);
     $tinfo->{result}= 'MTR_RES_FAILED';
-    $tinfo->{logfile}=$path_current_testlog;
+    $tinfo->{comment}=' ';
     mtr_report_test($tinfo);
     mtr_error("Test suite aborted");
   }


### PR DESCRIPTION
1. What problem is the patch trying to solve?
When running `mtr` for the test that is not completed we get the output that is not properly formatted
- status of the test is not inline with test name
- path to the log file is showed that is not needed at all.
Reported by @dr-m.
3. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied

Example for the test
```sql
CREATE TABLE `#mysql50#T#` (a INT);
```
Output is
```bash
worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 16000..16019
CREATE TABLE `#mysql50#T#` (a INT);
***Warnings generated in error logs during shutdown after running tests: innodb.f

2022-06-28 17:04:26 6 [ERROR] Invalid (old?) table or database name 'T#'
2022-06-28 17:04:26 6 [ERROR] Invalid (old?) table or database name 'T#'

innodb.f
                                [ fail ]
        Test ended at 2022-06-28 17:04:26

/dev/shm/10.6/mysql-test/var/log/current_test

mysql-test-run: *** ERROR: Test suite aborted
```
- Output with the patch
```bash
worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 16000..16019
CREATE TABLE `#mysql50#T#` (a INT);
***Warnings generated in error logs during shutdown after running tests: main.anel

2022-06-30  6:51:43 6 [ERROR] Invalid (old?) table or database name 'T#'
2022-06-30  6:51:43 6 [ERROR] Invalid (old?) table or database name 'T#'

main.anel                                [ fail ]
        Test ended at 2022-06-30 06:51:43

 

mysql-test-run: *** ERROR: Test suite aborted
```
- Note that the suite gets aborted only for single test case.

4. Do you think this patch might introduce side-effects in
   other parts of the server?
No tested in buildbots
- https://buildbot.mariadb.org/#/grid?branch=bb-10.6-anel-mtr-not-completed-test (new),
- https://buildbot.askmonty.org/buildbot/grid?category=main&category=package&branch=bb-10.6-anel-mtr-not-completed-test&width=8 (old)
-->
## Description
TODO: fill description here

## How can this PR be tested?
See 3. and the output after applying the patch

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*


