### PR TITLE
MDEV-29076: If thd->time_zone_used is not used, do not store time…

### DIFF
--- a/mysql-test/main/query_cache.result
+++ b/mysql-test/main/query_cache.result
@@ -2316,3 +2316,59 @@ improbable
 drop table t1;
 set global query_cache_type= @qcache;
 # End of 10.10 tests
+#
+# MDEV-29076 Query_cache stored identical select queries
+#
+set @qcache= @@global.query_cache_type;
+set global query_cache_type= 1;
+set query_cache_type= 1;
+set @save_time_zone=@@time_zone;
+set local time_zone = SYSTEM;
+reset query cache;
+flush status;
+create table t1 (i int not null);
+insert into t1 (i) values (1);
+select * from t1 order by i;
+i
+1
+select from_unixtime(i), i from t1 order by i;
+from_unixtime(i)	i
+1970-01-01 10:00:01	1
+select * from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME in ('Qcache_hits','Qcache_inserts','Qcache_not_cached','Qcache_queries_in_cache') ORDER BY VARIABLE_NAME;
+VARIABLE_NAME	VARIABLE_VALUE
+QCACHE_HITS	0
+QCACHE_INSERTS	2
+QCACHE_NOT_CACHED	1
+QCACHE_QUERIES_IN_CACHE	2
+set time_zone = "+9:00";
+select * from t1 order by i;
+i
+1
+select from_unixtime(i), i from t1 order by i;
+from_unixtime(i)	i
+1970-01-01 10:00:01	1
+select * from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME in ('Qcache_hits','Qcache_inserts','Qcache_not_cached','Qcache_queries_in_cache') ORDER BY VARIABLE_NAME;
+VARIABLE_NAME	VARIABLE_VALUE
+QCACHE_HITS	2
+QCACHE_INSERTS	2
+QCACHE_NOT_CACHED	2
+QCACHE_QUERIES_IN_CACHE	2
+set time_zone = "+10:00";
+select * from t1 order by i;
+i
+1
+select from_unixtime(i), i from t1 order by i;
+from_unixtime(i)	i
+1970-01-01 10:00:01	1
+select * from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME in ('Qcache_hits','Qcache_inserts','Qcache_not_cached','Qcache_queries_in_cache') ORDER BY VARIABLE_NAME;
+VARIABLE_NAME	VARIABLE_VALUE
+QCACHE_HITS	4
+QCACHE_INSERTS	2
+QCACHE_NOT_CACHED	3
+QCACHE_QUERIES_IN_CACHE	2
+drop table t1;
+set time_zone=@save_time_zone;
+set global query_cache_type= @qcache;
+#
+# End of 10.11 tests
+#

--- a/mysql-test/main/query_cache.test
+++ b/mysql-test/main/query_cache.test
@@ -1934,4 +1934,43 @@ set global query_cache_type= @qcache;
 
 --echo # End of 10.10 tests
 
+--echo #
+--echo # MDEV-29076 Query_cache stored identical select queries
+--echo #
+
+set @qcache= @@global.query_cache_type;
+set global query_cache_type= 1;
+set query_cache_type= 1;
+
+set @save_time_zone=@@time_zone;
+set local time_zone = SYSTEM;
+reset query cache;
+flush status;
+
+create table t1 (i int not null);
+insert into t1 (i) values (1);
+
+select * from t1 order by i;
+select from_unixtime(i), i from t1 order by i;
+select * from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME in ('Qcache_hits','Qcache_inserts','Qcache_not_cached','Qcache_queries_in_cache') ORDER BY VARIABLE_NAME;
+
+set time_zone = "+9:00";
+select * from t1 order by i;
+select from_unixtime(i), i from t1 order by i;
+select * from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME in ('Qcache_hits','Qcache_inserts','Qcache_not_cached','Qcache_queries_in_cache') ORDER BY VARIABLE_NAME;
+
+set time_zone = "+10:00";
+select * from t1 order by i;
+select from_unixtime(i), i from t1 order by i;
+select * from information_schema.GLOBAL_STATUS WHERE VARIABLE_NAME in ('Qcache_hits','Qcache_inserts','Qcache_not_cached','Qcache_queries_in_cache') ORDER BY VARIABLE_NAME;
+
+drop table t1;
+set time_zone=@save_time_zone;
+
+set global query_cache_type= @qcache;
+
+--echo #
+--echo # End of 10.11 tests
+--echo #
+
 --enable_ps2_protocol

--- a/mysql-test/suite/plugins/r/qc_info.result
+++ b/mysql-test/suite/plugins/r/qc_info.result
@@ -2,16 +2,26 @@ set @save_query_cache_size=@@global.query_cache_size;
 set global query_cache_type=ON;
 set local query_cache_type=ON;
 set global query_cache_size=1355776;
-create table t1 (a int not null);
+create table t1 (a int not null) with system versioning;
 insert into t1 values (1),(2),(3);
+create table t2 (a timestamp);
+insert t2 () values (0);
 select * from t1;
 a
 1
 2
 3
-select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info;
+select * from t1 for system_time as of timestamp'2016-01-30 08:07:06';
+a
+select * from t2;
+a
+0000-00-00 00:00:00
+select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info
+order by statement_schema, statement_text;
 statement_schema	statement_text	result_blocks_count	result_blocks_size
 test	select * from t1	1	512
+test	select * from t1 for system_time as of timestamp'2016-01-30 08:07:06'	1	512
+test	select * from t2	1	512
 select @@time_zone into @time_zone;
 select @@default_week_format into @default_week_format;
 select @@character_set_client into @character_set_client;
@@ -28,8 +38,10 @@ select * from t1;
 set time_zone= @time_zone, default_week_format= @default_week_format, character_set_client= @character_set_client,character_set_results= @character_set_results, sql_mode= @sql_mode, div_precision_increment= @div_precision_increment, lc_time_names= @lc_time_names, autocommit= @autocommit, group_concat_max_len= @group_concat_max_len, max_sort_length= @max_sort_length;
 select * from information_schema.query_cache_info;
 STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	CLIENT_EXTENDED_METADATA	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER	HITS
-test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	Europe/Moscow	4	7	STRICT_ALL_TABLES	ar_SD	1	1	1	#	0	0	0	#	0
-test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	SYSTEM	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
+test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	NULL	4	7	STRICT_ALL_TABLES	ar_SD	1	1	1	#	0	0	0	#	0
+test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	NULL	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
+test	select * from t1 for system_time as of timestamp'2016-01-30 08:07:06'	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	NULL	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
+test	select * from t2	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	NULL	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
 reset query cache;
 select * from t1;
 a
@@ -44,7 +56,7 @@ a
 select hits, statement_text from information_schema.query_cache_info;
 hits	statement_text
 1	select * from t1
-drop table t1;
+drop table t1, t2;
 select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info;
 statement_schema	statement_text	result_blocks_count	result_blocks_size
 set global query_cache_size = 0;

--- a/mysql-test/suite/plugins/r/qc_info_priv.result
+++ b/mysql-test/suite/plugins/r/qc_info_priv.result
@@ -2,16 +2,26 @@ set @save_query_cache_size=@@global.query_cache_size;
 set global query_cache_type=ON;
 set local query_cache_type=ON;
 set global query_cache_size=1355776;
-create table t1 (a int not null);
+create table t1 (a int not null) with system versioning;
 insert into t1 values (1),(2),(3);
+create table t2 (a timestamp);
+insert t2 () values (0);
 select * from t1;
 a
 1
 2
 3
-select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info;
+select * from t1 for system_time as of timestamp'2016-01-30 08:07:06';
+a
+select * from t2;
+a
+0000-00-00 00:00:00
+select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info
+order by statement_schema, statement_text;
 statement_schema	statement_text	result_blocks_count	result_blocks_size
 test	select * from t1	1	512
+test	select * from t1 for system_time as of timestamp'2016-01-30 08:07:06'	1	512
+test	select * from t2	1	512
 select @@time_zone into @time_zone;
 select @@default_week_format into @default_week_format;
 select @@character_set_client into @character_set_client;
@@ -28,8 +38,10 @@ select * from t1;
 set time_zone= @time_zone, default_week_format= @default_week_format, character_set_client= @character_set_client,character_set_results= @character_set_results, sql_mode= @sql_mode, div_precision_increment= @div_precision_increment, lc_time_names= @lc_time_names, autocommit= @autocommit, group_concat_max_len= @group_concat_max_len, max_sort_length= @max_sort_length;
 select * from information_schema.query_cache_info;
 STATEMENT_SCHEMA	STATEMENT_TEXT	RESULT_BLOCKS_COUNT	RESULT_BLOCKS_SIZE	RESULT_BLOCKS_SIZE_USED	LIMIT	MAX_SORT_LENGTH	GROUP_CONCAT_MAX_LENGTH	CHARACTER_SET_CLIENT	CHARACTER_SET_RESULT	COLLATION	TIMEZONE	DEFAULT_WEEK_FORMAT	DIV_PRECISION_INCREMENT	SQL_MODE	LC_TIME_NAMES	CLIENT_LONG_FLAG	CLIENT_PROTOCOL_41	CLIENT_EXTENDED_METADATA	PROTOCOL_TYPE	MORE_RESULTS_EXISTS	IN_TRANS	AUTOCOMMIT	PACKET_NUMBER	HITS
-test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	Europe/Moscow	4	7	STRICT_ALL_TABLES	ar_SD	1	1	1	#	0	0	0	#	0
-test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	SYSTEM	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
+test	select * from t1	1	512	#	-1	1011	513	binary	utf32	utf32_bin	NULL	4	7	STRICT_ALL_TABLES	ar_SD	1	1	1	#	0	0	0	#	0
+test	select * from t1	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	NULL	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
+test	select * from t1 for system_time as of timestamp'2016-01-30 08:07:06'	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	NULL	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
+test	select * from t2	1	512	#	-1	1024	1048576	latin1	latin1	latin1_swedish_ci	NULL	0	4	STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	en_US	1	1	1	#	0	0	1	#	0
 create user mysqltest;
 grant select on test.* to mysqltest;
 connect  conn1,localhost,mysqltest,,;
@@ -44,6 +56,6 @@ count(*)
 0
 connection default;
 drop user mysqltest;
-drop table t1;
+drop table t1, t2;
 set @@global.query_cache_size=@save_query_cache_size;
 set global query_cache_type=default;

--- a/mysql-test/suite/plugins/t/qc_info.test
+++ b/mysql-test/suite/plugins/t/qc_info.test
@@ -12,7 +12,7 @@ select * from t1;
 --enable_cursor_protocol
 select hits, statement_text from information_schema.query_cache_info;
 
-drop table t1;
+drop table t1, t2;
 # the query was invalidated
 select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info;
 

--- a/mysql-test/suite/plugins/t/qc_info_init.inc
+++ b/mysql-test/suite/plugins/t/qc_info_init.inc
@@ -7,14 +7,19 @@ set global query_cache_type=ON;
 set local query_cache_type=ON;
 set global query_cache_size=1355776;
 
-create table t1 (a int not null);
+create table t1 (a int not null) with system versioning;
 insert into t1 values (1),(2),(3);
+create table t2 (a timestamp);
+insert t2 () values (0);
 --disable_cursor_protocol
 --disable_ps2_protocol
 select * from t1;
+select * from t1 for system_time as of timestamp'2016-01-30 08:07:06';
+select * from t2;
 --enable_ps2_protocol
 --enable_cursor_protocol
-select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info;
+select statement_schema, statement_text, result_blocks_count, result_blocks_size from information_schema.query_cache_info
+order by statement_schema, statement_text;
 
 --disable_cursor_protocol
 select @@time_zone into @time_zone;

--- a/mysql-test/suite/plugins/t/qc_info_priv.test
+++ b/mysql-test/suite/plugins/t/qc_info_priv.test
@@ -11,7 +11,7 @@ select a from t1;
 select count(*) from information_schema.query_cache_info;
 connection default;
 drop user mysqltest;
-drop table t1;
+drop table t1, t2;
 
 set @@global.query_cache_size=@save_query_cache_size;
 set global query_cache_type=default;

--- a/plugin/qc_info/qc_info.cc
+++ b/plugin/qc_info/qc_info.cc
@@ -97,7 +97,7 @@ static ST_FIELD_INFO qc_info_fields[]=
   Column("CHARACTER_SET_CLIENT",  CSName(),                           NOT_NULL),
   Column("CHARACTER_SET_RESULT",  CSName(),                           NOT_NULL),
   Column("COLLATION",             CLName(),                           NOT_NULL),
-  Column("TIMEZONE",              Varchar(50),                        NOT_NULL),
+  Column("TIMEZONE",              Varchar(50),                        NULLABLE),
   Column("DEFAULT_WEEK_FORMAT",   SLong(),                            NOT_NULL),
   Column("DIV_PRECISION_INCREMENT",SLong(),                           NOT_NULL),
   Column("SQL_MODE",              Varchar(250),                       NOT_NULL),
@@ -203,11 +203,18 @@ static int qc_info_fill_table(THD *thd, TABLE_LIST *tables,
     else
       table->field[COLUMN_COLLATION]-> store(STRING_WITH_LEN(unknown), scs);
 
-    tz= flags.time_zone->get_name();
-    if (likely(tz))
-      table->field[COLUMN_TIMEZONE]->store(tz->ptr(), tz->length(), scs);
+    if (flags.time_zone)
+    {
+      tz= flags.time_zone->get_name();
+      if (likely(tz))
+        table->field[COLUMN_TIMEZONE]->store(tz->ptr(), tz->length(), scs);
+      else
+        table->field[COLUMN_TIMEZONE]->store(STRING_WITH_LEN(unknown), scs);
+    }
     else
-      table->field[COLUMN_TIMEZONE]-> store(STRING_WITH_LEN(unknown), scs);
+    {
+      table->field[COLUMN_TIMEZONE]->set_null();
+    }
     table->field[COLUMN_DEFAULT_WEEK_FORMAT]->store(flags.default_week_format, 0);
     table->field[COLUMN_DIV_PRECISION_INCREMENT]->store(flags.div_precision_increment, 0);
 

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -952,6 +952,7 @@ bool vers_select_conds_t::init_from_sysvar(THD *thd)
   {
     DBUG_ASSERT(type == SYSTEM_TIME_AS_OF);
     Datetime dt(in.unix_time, in.second_part, thd->variables.time_zone);
+    thd->used|= THD::TIME_ZONE_USED;
 
     start.item= new (thd->mem_root)
         Item_datetime_literal(thd, &dt, TIME_SECOND_PART_DIGITS);


### PR DESCRIPTION
The Jira issue number for this PR is: MDEV-29076 Dynamically update time_zone caused Query_cache stored repetitive select queries.

## Description
For the same "Select *" operation, the Query_cache failed to identify them and stores the redundant queries, if changing the option "time_zone" dynamically. This patch identifies whether the query used time_zone, and reduces the redundant queries when changing option "time_zone". Specially, If thd->time_zone_used is not used, do not store 'time_zone' as Query_cache_query_flags.


