### PR TITLE
MDEV-28953 sporadic failures with galera_sr.mysql-wsrep-features#165

### DIFF
--- a/mysql-test/suite/galera_sr/r/mysql-wsrep-features#165.result
+++ b/mysql-test/suite/galera_sr/r/mysql-wsrep-features#165.result
@@ -26,6 +26,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -91,6 +92,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -156,6 +158,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -221,6 +224,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -286,6 +290,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -351,6 +356,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -416,6 +422,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -481,6 +488,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -546,6 +554,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -611,6 +620,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -676,6 +686,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -741,6 +752,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -806,6 +818,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -871,6 +884,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -936,6 +950,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2
@@ -1001,6 +1016,7 @@ f1	f2
 connection node_1c;
 SET AUTOCOMMIT=ON;
 INSERT INTO t1 VALUES (3, 'c');
+connection node_1;
 connection node_2;
 SELECT * FROM t1;
 f1	f2

--- a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
@@ -46,6 +46,10 @@ SELECT * FROM t1;
 SET AUTOCOMMIT=ON;
 --send INSERT INTO t1 VALUES (3, 'c')
 
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.INNODB_LOCK_WAITS;
+--source include/wait_condition.inc
+
 --connection node_2
 SELECT * FROM t1;
 
@@ -54,8 +58,8 @@ SELECT * FROM t1;
 --send UPDATE t1 SET f2 = 'a' WHERE f1 = 2
 
 --connection node_1
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER != 'system user' AND STATE = 'Updating';
---source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.INNODB_LOCK_WAITS;
+--source include/wait_condition.inc 
 
 # Will deadlock
 --connection node_1b


### PR DESCRIPTION
Modified galera_sr.mysql-wsrep-features#165 test to be deterministic:
Added one wait condition to catch execution state after --send command.
Changed another wait condition to better match the execution state of the test thread.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28953*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Fixed test to be deterministic.

## How can this PR be tested?


<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
