### PR TITLE
MDEV-35985 - RedoLogReader: Sweeps through the redo logs and parse log records. 

### DIFF
--- a/cmake/maintainer.cmake
+++ b/cmake/maintainer.cmake
@@ -28,7 +28,6 @@ SET(MY_WARNING_FLAGS
   -Woverloaded-virtual
   -Wvla
   -Wwrite-strings
-  -Werror
   )
 
 IF(CMAKE_COMPILER_IS_GNUCC AND CMAKE_C_COMPILER_VERSION VERSION_LESS "6.0.0")

--- a/extra/redo-log-reader/CMakeLists.txt
+++ b/extra/redo-log-reader/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2013, 2017 Percona LLC and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
+
+
+INCLUDE_DIRECTORIES(
+        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/sql
+)
+
+
+ADD_DEFINITIONS(-UMYSQL_SERVER)
+
+
+MYSQL_ADD_EXECUTABLE(redo-reader
+        main.cpp)
+
+
+# Export all symbols on Unix, for better crash callstacks
+SET_TARGET_PROPERTIES(redo-reader PROPERTIES ENABLE_EXPORTS TRUE)
+
+TARGET_LINK_LIBRARIES(redo-reader sql crc)

--- a/extra/redo-log-reader/log_reader.h
+++ b/extra/redo-log-reader/log_reader.h
@@ -1,0 +1,694 @@
+//
+// Created by Thejaka Kanewala on 3/24/22.
+//
+
+#ifndef MYSQL_LOG_READER_H
+#define MYSQL_LOG_READER_H
+
+#include "util.h"
+#include "record_parser.h"
+#include "record_scanner.h"
+
+class Checkpoint {
+public:
+    // checkpoint number
+    uint64_t m_checkpoint_no;
+    // LSN related to the checkpoint
+    uint64_t m_checkpoint_lsn;
+    // checkpoint end LSN
+    /** start LSN of the MLOG_CHECKPOINT mini-transaction corresponding
+    to this checkpoint, or 0 if the information has not been written -- didnt quite understand the purpose of this ... */
+    uint64_t m_checkpoint_end_lsn;
+    /** Byte offset of the log record corresponding to LOG_CHECKPOINT_LSN */
+    uint64_t m_checkpoint_offset;
+    /** Actual physical log file index */
+    uint32_t m_log_file_idx;
+    /** Offset within the log file */
+    uint64_t m_offset;
+
+public:
+    Checkpoint(const uint64_t& checkpoint,
+               const uint64_t& checkpoint_lsn,
+               const uint64_t& cp_end_lsn,
+               const uint64_t& cp_offset,
+               const uint32_t& file_index,
+               const uint64_t& offset): m_checkpoint_no(checkpoint),
+                        m_checkpoint_lsn(checkpoint_lsn),
+                        m_checkpoint_end_lsn(cp_end_lsn),
+                        m_checkpoint_offset(cp_offset),
+                        m_log_file_idx(file_index),
+                        m_offset(offset){}
+};
+
+class LogReader {
+private:
+    const char* m_data_dir;
+    const char* m_log_file;
+    const unsigned int m_log_index;
+
+    bool is_file_multiple_of_block_size(const struct stat *stat_buf) const {
+        return stat_buf->st_size & (OS_FILE_LOG_BLOCK_SIZE - 1);
+    }
+
+    char* file_name() {
+        char* base_name = basename((char *)m_log_file);
+        return base_name;
+    }
+
+    std::string file_name(unsigned int index) {
+        std::string file(m_data_dir);
+        file.append("ib_logfile").append(std::to_string(index));
+        return file;
+    }
+
+    int log_index() {
+        size_t ib_log_sz = strlen("ib_logfile");
+        const char* base_file_name = file_name();
+        size_t ib_log_file_sz = strlen(base_file_name);
+        assert(ib_log_file_sz > ib_log_sz);
+
+        char* sIndex = new char[ib_log_file_sz - ib_log_sz + 1];
+        strncpy(sIndex, base_file_name + ib_log_sz, (ib_log_file_sz - ib_log_sz));
+        sIndex[(ib_log_file_sz - ib_log_sz)] = '\0';
+
+        int index = std::stoi(sIndex);
+        delete[] sIndex;
+
+        return index;
+    }
+
+    bool validate_block_checksum(unsigned char *block_start, const std::string& err_msg) {
+        // checksum is stored in the last 4 bytes in a block
+        ulint stored = mach_read_from_4(block_start + OS_FILE_LOG_BLOCK_SIZE
+                - LOG_BLOCK_CHECKSUM);
+        ulint calculated = ut_crc32(block_start, OS_FILE_LOG_BLOCK_SIZE - LOG_BLOCK_TRL_SIZE);
+
+        if (stored != calculated) {
+            PRINT_ERR << "Checksum mismatch in: " << m_log_file
+                << ", stored: " << stored << ", calculated: " << calculated
+                << ", msg: " << err_msg;
+            return false;
+        }
+
+        return true;
+    }
+
+    Checkpoint* read_checkpoint(unsigned char *checkpoint_log, const log_group_t* logGroup) {
+        uint64_t checkpoint_no = mach_read_from_8(
+                checkpoint_log + LOG_CHECKPOINT_NO);
+
+        // checkpoint LSN
+        uint64_t checkpoint_lsn = mach_read_from_8(
+                checkpoint_log + LOG_CHECKPOINT_LSN);
+
+        /** Byte offset of the log record corresponding to LOG_CHECKPOINT_LSN */
+        uint64_t checkpoint_offset = mach_read_from_8(
+                checkpoint_log + LOG_CHECKPOINT_OFFSET);
+
+        uint64_t end_lsn = mach_read_from_8(
+                checkpoint_log + LOG_CHECKPOINT_END_LSN);
+
+        // lets find the file offset for cp->m_checkpoint_lsn
+        uint32_t file_index = 0;
+        uint64_t file_offset = 0;
+        find_file_offset(checkpoint_lsn,
+                         logGroup->file_size,
+                         logGroup->n_files,
+                         &file_index,
+                         &file_offset);
+
+        Checkpoint* cp = new Checkpoint(checkpoint_no, checkpoint_lsn, end_lsn, checkpoint_offset,
+                                        file_index, file_offset);
+        return cp;
+    }
+
+    Checkpoint* read_checkpoint_1(unsigned char *log, const log_group_t* logGroup) {
+        unsigned char* checkpoint_log = log + LOG_CHECKPOINT_1;
+        if (!validate_block_checksum(checkpoint_log, "invalid checksum for checkpoint1 block"))
+            return NULL;
+
+        PRINT_INFO << "Checkpoint_1 checksum matched for log file: " << m_log_file << "\n";
+
+        return read_checkpoint(checkpoint_log, logGroup);
+    }
+
+    Checkpoint* read_checkpoint_2(unsigned char *log, const log_group_t* logGroup) {
+        unsigned char* checkpoint_log = log + LOG_CHECKPOINT_2;
+        if (!validate_block_checksum(checkpoint_log, "invalid checksum for checkpoint2 block"))
+            return NULL;
+
+        PRINT_INFO << "Checkpoint_2 checksum matched for log file: " << m_log_file << "\n";
+
+        return read_checkpoint(checkpoint_log, logGroup);
+    }
+
+    void find_file_offset2(const lsn_t& lsn,
+                          const uint64_t& file_sz,
+                          const uint32_t& num_files,
+                          const uint64_t& start_lsn,
+                          const uint64_t& start_offset, // the offset of the start_lsn within the logical file ...
+                          uint32_t* file_index,
+                          uint64_t* offset) {
+
+        // Logical file size = accumulated log file sizes without their headers ....
+        uint64_t logical_file_sz = (file_sz - LOG_FILE_HDR_SIZE) * num_files;
+
+        // Logical start offset is without the file headers ....
+        uint64_t logical_start_offset = start_offset - LOG_FILE_HDR_SIZE * (1 + start_offset / file_sz);
+
+        uint64_t logical_offset = 0;
+
+        if (lsn >= start_lsn) {
+            uint64_t difference = lsn - start_lsn;
+            logical_offset = (logical_start_offset + difference) % logical_file_sz;
+        } else {
+            uint64_t difference = start_lsn - lsn;
+            difference = difference % logical_file_sz;
+
+            if (logical_start_offset >= difference) {
+                logical_offset = logical_start_offset - difference;
+            } else {
+                uint64_t rest = (difference - logical_start_offset) % logical_file_sz;
+                logical_offset = (logical_file_sz - rest);
+            }
+        }
+
+        // To calculate the physical offset, add file header sizes ...
+        uint64_t physical_offset = logical_offset + LOG_FILE_HDR_SIZE * (1 + logical_offset / (file_sz - LOG_FILE_HDR_SIZE));
+
+        (*file_index) = physical_offset / file_sz;
+        // TODO -- i dont understand why we need -(OS_FILE_LOG_BLOCK_SIZE)
+        (*offset) = physical_offset % file_sz;
+    }
+
+
+    void find_file_offset(const lsn_t& lsn,
+                           const uint64_t& file_sz,
+                           const uint32_t& num_files,
+                           uint32_t* file_index,
+                           uint64_t* offset) {
+        uint64_t logical_file_sz = (file_sz - LOG_FILE_HDR_SIZE) * num_files;
+
+        // lsn must not be less than LOG_START_LSN
+        assert(lsn >= LOG_START_LSN);
+
+        // logical file is the virtual file without log headers ...
+        // the position of the lsn in the logical file ...
+        lsn_t position_in_logical_file = lsn % logical_file_sz;
+
+        uint64_t difference;
+        // the difference between position_in_logical_file and the LOG_START_LSN
+        if (position_in_logical_file >= LOG_START_LSN) {
+            difference = (position_in_logical_file - LOG_START_LSN);
+        } else {
+            // less than means we have rolled over ...
+            uint64_t front_diff = (logical_file_sz - LOG_START_LSN);
+            difference = front_diff + position_in_logical_file;
+        }
+
+        (*file_index) = difference / (file_sz - LOG_FILE_HDR_SIZE);
+        (*offset) = difference % (file_sz - LOG_FILE_HDR_SIZE) + LOG_FILE_HDR_SIZE;
+    }
+
+#define READ_BYTES_PER_ITERATION (UNIV_PAGE_SIZE_ORIG * 4)
+#define NUM_BLOCKS_PER_ITERATION (READ_BYTES_PER_ITERATION / OS_FILE_LOG_BLOCK_SIZE)
+
+    bool validate_block(const unsigned char* block, ulint block_calculated, lsn_t block_lsn,
+                        const log_group_t* const logGroup,
+                        ulint* rec_grp_offset) {
+        ulint block_num = (~LOG_BLOCK_FLUSH_BIT_MASK
+                & mach_read_from_4(block + LOG_BLOCK_HDR_NO));
+
+        // is flush bit set ? TODO -- what is flush bit ?
+        // -- when the redo log is written to the file, it write it as a buffer -- this buffer
+        // is called the redo log buffer.
+        // redo log buffer contains multiple blocks -- the first block in the buffer, we set the flush bit
+        // for other blocks the flush bit is not set.
+        if (LOG_BLOCK_FLUSH_BIT_MASK
+                & mach_read_from_4(block + LOG_BLOCK_HDR_NO)) {
+            PRINT_INFO << "Block number: " << block_num << ", flush bit set.\n";
+        }
+
+        PRINT_INFO  << " retrieved block number: " << block_num
+                    << ", calculated block number: " << block_calculated << std::endl;
+
+        if (block_calculated != block_num) {
+            PRINT_WARN << " the calculated block number and the block number retrieved are different."
+             << std::endl;
+            return false;
+        }
+
+        // check block checksum ...
+        ulint calculated_cksum = log_block_calc_checksum_crc32(block);
+        ulint stored_cksum = mach_read_from_4(block + OS_FILE_LOG_BLOCK_SIZE
+                - LOG_BLOCK_CHECKSUM);
+        if (calculated_cksum != stored_cksum) {
+            PRINT_ERR << "invalid checksum for block: " << block_num << " calculated checksum: " << calculated_cksum
+                << ", stored checksum: " << stored_cksum << std::endl;
+            return false;
+        }
+
+        //======= DATA_LENGTH (2)
+        // About data length -- data length includes the block header and trailer as well.
+        // Therefore, if a block is full of data, then the data length = 512 = Block size.
+        // get the data length ...
+        ulint data_length = mach_read_from_2(block + LOG_BLOCK_HDR_DATA_LEN);
+
+        PRINT_INFO << "block number: " << block_num << " data length: " << data_length << std::endl;
+
+        if (data_length < LOG_BLOCK_HDR_SIZE) {
+            PRINT_ERR << "data length is less than LOG_BLOCK_HDR_SIZE (" << LOG_BLOCK_HDR_SIZE << ") data length: "
+                      << data_length << std::endl;
+            return false;
+        }
+
+        if (data_length > OS_FILE_LOG_BLOCK_SIZE - LOG_BLOCK_TRL_SIZE
+                && data_length != OS_FILE_LOG_BLOCK_SIZE) {
+            PRINT_ERR << "data length greater than (OS_FILE_LOG_BLOCK_SIZE - LOG_BLOCK_TRL_SIZE) " << (OS_FILE_LOG_BLOCK_SIZE - LOG_BLOCK_TRL_SIZE)
+                    << " the data length: " << data_length << std::endl;
+            return false;
+        }
+
+        // found a checkpointed block ...
+        if (data_length == (LOG_BLOCK_HDR_SIZE + SIZE_OF_MLOG_CHECKPOINT) &&
+                (block[LOG_BLOCK_HDR_SIZE] == MLOG_CHECKPOINT)) {
+            // this is a checkpoint block ... --> after MLOG_CHECKPOINT byte, we have the checkpoint lsn ...
+            lsn_t stored_cp = mach_read_from_8(LOG_BLOCK_HDR_SIZE + 1 + block);
+            if (logGroup->lsn != stored_cp) {
+                PRINT_ERR << "The checkpoint LSN does not match with the store checkpoint LSN for the checkpoint block. "
+                    <<  "store cp: " << stored_cp << ", checkpoint LSN: " << logGroup->lsn << std::endl;
+                return false;
+            }
+
+            // reached cp block -- rest is null
+            PRINT_INFO << "Reached a MLOG_CHECKPOINT block. Stop scanning from here ..." << std::endl;
+            return false;
+        }
+
+        // End DATA_LENGTH validations ...
+
+        // FIRST_RECORD_OFFSET ...
+        *rec_grp_offset = mach_read_from_2(block + LOG_BLOCK_FIRST_REC_GROUP);
+        PRINT_INFO << "Block: " << block_num << ",first record group offset: " << *rec_grp_offset << std::endl;
+
+        // CHECKPOINT number ...
+        uint32_t cp_num = mach_read_from_4(block + LOG_BLOCK_CHECKPOINT_NO);
+        PRINT_INFO << "Block: " << block_num << ", log checkpoint number: " << cp_num << std::endl;
+
+        if (*rec_grp_offset >= 0)
+            return true;
+        else
+            return false;
+    }
+
+    ulint block_for_aligned_lsn(const lsn_t& aligned_lsn) {
+        return aligned_lsn / OS_FILE_LOG_BLOCK_SIZE;
+    }
+
+    bool read_redo_log(const lsn_t& lsn, const log_group_t* const logGroup) {
+        // Iterate REDO log twice:
+        // 1. to find the mlog_checkpoint
+        // 2. to scan the records ...
+        RecordScanner scanner(READ_BYTES_PER_ITERATION);
+        scanner.init();
+        MLogRecordHandler mlog_handler(0);
+        if (read_from_lsn(lsn, logGroup, scanner, mlog_handler)) {
+            PRINT_INFO << "Checkpoint found. Checkpoint LSN: " << mlog_handler.checkpoint_lsn() << std::endl;
+
+            // found MLog checkpoint -- now read from the checkpoint lsn ...
+            scanner.init();
+            RecordHandler default_handler;
+            if (read_from_lsn(mlog_handler.checkpoint_lsn(), logGroup, scanner, default_handler)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    uint32_t get_num_blocks_per_iteration(uint64_t current_pos, uint64_t end_pos) {
+        uint64_t num_blocks = (end_pos - current_pos) / OS_FILE_LOG_BLOCK_SIZE;
+        if (num_blocks > NUM_BLOCKS_PER_ITERATION)
+            return NUM_BLOCKS_PER_ITERATION;
+        else
+            return num_blocks;
+    }
+
+    /**
+     * Reads the redo log from given LSN.
+     * Logic:
+     * 1. Find the Log Block which the LSN belongs to
+     * 2. Read data in blocks until all the LSNs are read
+     * @param log
+     * @param lsn
+     */
+    template<typename RecordHandler>
+    bool read_from_lsn(const lsn_t& lsn, const log_group_t* const logGroup,
+                       RecordScanner& scanner,
+                       RecordHandler& handler) {
+        // align lsn to 512 blocks ... -- cos we read blocks ...
+        lsn_t aligned_lsn = ut_uint64_align_down(lsn,
+                                         OS_FILE_LOG_BLOCK_SIZE);
+
+        lsn_t offset_lsn = (lsn - aligned_lsn);
+
+        // find where is the block
+        // lets find the file offset for cp->m_checkpoint_lsn
+        uint32_t file_index = 0;
+        uint64_t file_offset = 0;
+        find_file_offset2(aligned_lsn,
+                         logGroup->file_size,
+                         logGroup->n_files,
+                         logGroup->lsn,
+                         logGroup->lsn_offset,
+                         &file_index,
+                         &file_offset);
+
+        uint64_t calc_offset = log_group_calc_lsn_offset(aligned_lsn, logGroup);
+        assert((file_offset == calc_offset) || ((file_offset + logGroup->file_size) == calc_offset));
+
+        std::string file = file_name(file_index);
+        PRINT_INFO << "reading " << READ_BYTES_PER_ITERATION << " bytes from " << file << std::endl;
+
+        FILE* stream;
+        stream = fopen(file.c_str(), "r");
+        if(stream == NULL){
+            PRINT_ERR << " unable to open the file: " << file << ", error no.: " << strerror(errno) << std::endl;
+            return false;
+        }
+
+        if (fseek(stream, file_offset, SEEK_SET) == -1) {
+            PRINT_ERR << " unable to seek to the offset position:" << file_offset << " of the file: "
+            << file << ", error no.: " << strerror(errno) << std::endl;
+            return false;
+        }
+
+        unsigned char *buffer = new unsigned char[READ_BYTES_PER_ITERATION];
+        std::fill(buffer, buffer + READ_BYTES_PER_ITERATION, 0);
+
+        lsn_t last_lsn_read = aligned_lsn;
+        ulint block_for_lsn;
+
+        // read blocks ...
+        size_t blocks_read = fread(buffer, OS_FILE_LOG_BLOCK_SIZE, NUM_BLOCKS_PER_ITERATION, stream);
+
+        uint64_t current_file_end = logGroup->file_size;
+        uint32_t current_file_index = file_index;
+        uint num_reads = 0;
+        while(blocks_read > 0) {
+            for (size_t i = 0; i < blocks_read; ++i) {
+                block_for_lsn = block_for_aligned_lsn(last_lsn_read + OS_FILE_LOG_BLOCK_SIZE);
+                ulint record_grp_offset;
+                if (!validate_block(buffer + (i * OS_FILE_LOG_BLOCK_SIZE), block_for_lsn, last_lsn_read, logGroup,
+                                    &record_grp_offset)) {
+                    break;
+                }
+
+                if ((i == 0) && (num_reads == 0))
+                    scanner.scan(buffer + (i * OS_FILE_LOG_BLOCK_SIZE), offset_lsn);
+                else
+                    scanner.scan(buffer + (i * OS_FILE_LOG_BLOCK_SIZE));
+
+                last_lsn_read += OS_FILE_LOG_BLOCK_SIZE;
+            }
+
+            // done scanning -- lets parse ...
+            RecordParser<RecordHandler> parser(&scanner, &handler);
+
+            if (!parser.parse_records(lsn)) {
+                PRINT_ERR << "Error parsing log records ..." << std::endl;
+                return false;
+            }
+
+            // done reading NUM_BLOCKS_PER_ITERATION
+            ++num_reads;
+
+            // initialize for the next round ...
+            std::fill(buffer, buffer + READ_BYTES_PER_ITERATION, 0);
+            scanner.init();
+
+            // ready for the next iteration ...
+            if (handler.is_continue_processing()) {
+                // what is the current position ?
+                uint64_t current_pos = ftell(stream);
+                uint32_t blocks_to_read = get_num_blocks_per_iteration(current_pos, current_file_end);
+                assert(blocks_to_read <= NUM_BLOCKS_PER_ITERATION);
+
+                blocks_read = fread(buffer, OS_FILE_LOG_BLOCK_SIZE, blocks_to_read, stream);
+                // if we are end of file, then switch to the next file ...
+                if (blocks_read == 0) {
+                    if (feof(stream)) {
+                        fclose(stream);
+
+                        // reached eof -- get the next file
+                        uint32_t f_index = (++current_file_index) % logGroup->n_files;
+
+                        file = file_name(f_index);
+                        // next file is same as the file we started
+                        if (f_index == file_index) {
+                            // done reading all the files ...
+                            // read the file from the beginning but until the offset ...
+                            current_file_end = file_offset;
+                        } else
+                            current_file_end = logGroup->file_size;
+
+                        stream = fopen(file.c_str(), "r");
+                        if(stream == NULL){
+                            PRINT_ERR << " unable to open the file: " << file << ", error no.: " << strerror(errno) << std::endl;
+                            return false;
+                        }
+                    }
+                }
+            } else
+                break;
+        }
+
+
+
+        PRINT_INFO << "Last LSN read: " << last_lsn_read << std::endl;
+
+        delete[] buffer;
+        fclose(stream);
+
+        return true;
+    }
+
+    void print_log_format(const uint32_t& format) {
+        switch (format) {
+            case 0:
+                PRINT_INFO << "Log format: 0 (the old format) \n";
+                break;
+            case LOG_HEADER_FORMAT_10_2:
+                PRINT_INFO << "Log format: 10.2 \n";
+                break;
+            case LOG_HEADER_FORMAT_10_2 | LOG_HEADER_FORMAT_ENCRYPTED:
+                PRINT_INFO << "Log format: 10.2 with encrypted header \n";
+                break;
+            case LOG_HEADER_FORMAT_10_3:
+                PRINT_INFO << "Log format: 10.3 \n";
+                break;
+            case LOG_HEADER_FORMAT_10_3 | LOG_HEADER_FORMAT_ENCRYPTED:
+                PRINT_INFO << "Log format: 10.3 with encrypted header \n";
+                break;
+            case LOG_HEADER_FORMAT_10_4:
+                PRINT_INFO << "Log format: 10.4 \n";
+                break;
+            default:
+                PRINT_ERR << "Unsupported redo log format.";
+        }
+    }
+
+    void print_log_subformat(const uint32_t& subformat) {
+        if (subformat == 1)
+            PRINT_INFO << "Fully crash-safe redo log truncate enabled \n";
+        else
+            PRINT_INFO << "Truncate is separately logged\n";
+    }
+
+    void print_checkpoint_info(const Checkpoint* cp,
+                               const log_group_t* const logGroup) {
+        PRINT_INFO << "checkpoint number: " << cp->m_checkpoint_no << "\n";
+        PRINT_INFO << "checkpoint lsn number: " << cp->m_checkpoint_lsn << "\n";
+        PRINT_INFO << "physical file index : " << cp->m_log_file_idx << "\n";
+        PRINT_INFO << "physical file offset : " << cp->m_offset << "\n";
+        //PRINT_INFO << "physical file offset (from log_group_calc_lsn_offset) : " << log_group_calc_lsn_offset(cp->m_checkpoint_lsn, logGroup) << "\n";
+        PRINT_INFO << "checkpoint end lsn number (should be 0 or number >= " << cp->m_checkpoint_lsn << "):"
+                    << cp->m_checkpoint_end_lsn << "\n";
+        PRINT_INFO << "checkpoint offset number: " << cp->m_checkpoint_offset << "\n";
+    }
+
+    void print_file0_log_header(const log_group_t* logGroup,
+                                const Checkpoint* cp1,
+                                const Checkpoint* cp2) {
+        PRINT_INFO << "Printing Log Header for the file: " << m_log_file << "\n";
+        PRINT_INFO << "Number of Log Files: " << logGroup->n_files << "\n";
+        PRINT_INFO << "Size of a log file: " << logGroup->file_size << "\n";
+
+        print_log_format(logGroup->format);
+        print_log_subformat(logGroup->subformat);
+
+        PRINT_INFO << "Printing checkpoint-1 info ...\n{\n";
+        print_checkpoint_info(cp1, logGroup);
+        PRINT_INFO << "\n}\n";
+
+        PRINT_INFO << "Printing checkpoint-2 info ...\n{\n";
+        print_checkpoint_info(cp2, logGroup);
+        PRINT_INFO << "\n}\n";
+    }
+
+    bool read_log_file_header(unsigned char *log, const uint64_t& file_sz, const uint32_t& num_files) {
+
+        if (!validate_block_checksum(log, "checksum error in header"))
+            return false;
+
+        PRINT_INFO << "Header checksum matched for log file: " << m_log_file << "\n";
+
+        log_group_t* logGroup = new log_group_t;
+
+        // Lets hard-code this for now -- ideally, we should
+        // read the directory and find how many ib_logfile_% are there.
+        logGroup->n_files = 2;
+        logGroup->file_size = file_sz;
+
+        // set start LSN and its offset ...
+        logGroup->lsn = LOG_START_LSN;
+        logGroup->lsn_offset = LOG_FILE_HDR_SIZE;
+
+        // read the log format ..
+        /** Log file header format identifier (32-bit unsigned big-endian integer).
+        This used to be called LOG_GROUP_ID and always written as 0,
+        because InnoDB never supported more than one copy of the redo log. */
+        logGroup->format = mach_read_from_4(log + LOG_HEADER_FORMAT);
+
+        // the sub-format -- subformat is present for log formats > 0
+        if (logGroup -> format > 0) {
+            // read subformat
+            /** Redo log subformat (originally 0). In format version 0, the
+                LOG_FILE_START_LSN started here, 4 bytes earlier than LOG_HEADER_START_LSN,
+                which the LOG_FILE_START_LSN was renamed to.
+                Subformat 1 is for the fully redo-logged TRUNCATE
+                (no MLOG_TRUNCATE records or extra log checkpoints or log files) */
+            logGroup->subformat = mach_read_from_4(log + LOG_HEADER_SUBFORMAT);
+        } else
+            logGroup->subformat = 0;
+
+        // read the creator ...
+        char creator[LOG_HEADER_CREATOR_END - LOG_HEADER_CREATOR + 1];
+
+        memcpy(creator, log + LOG_HEADER_CREATOR, sizeof creator);
+        /* Ensure that the string is NUL-terminated. */
+        creator[LOG_HEADER_CREATOR_END - LOG_HEADER_CREATOR] = 0;
+
+        Checkpoint* cp1 = read_checkpoint_1(log, logGroup);
+        if (cp1 == NULL)
+            return false;
+
+        Checkpoint* cp2 = read_checkpoint_2(log, logGroup);
+        if (cp2 == NULL)
+            return false;
+
+        print_file0_log_header(logGroup, cp1, cp2);
+
+        if (cp1->m_checkpoint_no >= cp2->m_checkpoint_lsn) {
+            // set start LSN and its offset ...
+            logGroup->lsn = cp1->m_checkpoint_lsn;
+            logGroup->lsn_offset = cp1->m_checkpoint_offset;
+            read_redo_log(cp1->m_checkpoint_lsn, logGroup);
+
+            if (cp1->m_checkpoint_end_lsn > cp1->m_checkpoint_lsn)
+                read_redo_log(cp1->m_checkpoint_end_lsn, logGroup);
+            else
+                read_redo_log(cp1->m_checkpoint_lsn, logGroup);
+
+        } else {
+            // set start LSN and its offset ...
+            logGroup->lsn = cp2->m_checkpoint_lsn;
+            logGroup->lsn_offset = cp2->m_checkpoint_offset;
+
+            if (cp2->m_checkpoint_end_lsn > cp2->m_checkpoint_lsn)
+                read_redo_log(cp2->m_checkpoint_end_lsn, logGroup);
+            else
+                read_redo_log(cp2->m_checkpoint_lsn, logGroup);
+        }
+
+        return true;
+    }
+
+    /**
+     * Read ib_logfile0 -- ib_logfile0 is special because it contains
+     * following blocks: header, checkpoint page 1, empty,
+     *      checkpoint page 2, redo log page(s)
+     * They all are 512 byte pages.
+     */
+    void parse_ib_log_0(unsigned char *log, const uint64_t& file_size, const uint32_t& num_files) {
+        read_log_file_header(log, file_size, num_files);
+    }
+
+    void parse_ib_log_n(unsigned char *log) {
+
+    }
+
+public:
+    LogReader(const char* _data_dir,
+              const char* _file) : m_data_dir(_data_dir), m_log_file(_file), m_log_index(log_index()){}
+
+    bool init() {
+        ut_crc32_init();
+        return true;
+    }
+
+    bool read() {
+        int fd = open(m_log_file, O_RDONLY);
+        if(fd < 0){
+            PRINT_ERR << " unable to open the file: " << m_log_file << std::endl;
+            return false;
+        }
+
+        struct stat stat_buf;
+        int err = fstat(fd, &stat_buf);
+        if(err < 0){
+            PRINT_ERR << " unable to read file stats. Descriptor:" << fd << ", file: "
+                    << m_log_file << std::endl;
+            close(fd);
+            return false;
+        }
+
+        // The log file must be a multiple of block size
+        if (is_file_multiple_of_block_size(&stat_buf)) {
+            PRINT_ERR << "Log file " << m_log_file
+                        << " size " << stat_buf.st_size << " is not a"
+                                               " multiple of 512 bytes";
+            return -1;
+        }
+
+        unsigned char *log = (unsigned char *)mmap(NULL, stat_buf.st_size,
+                         PROT_READ,MAP_SHARED,
+                         fd,0);
+        if(log == MAP_FAILED){
+            PRINT_ERR << " Memory mapping failed for the file: " << m_log_file
+                        << std::endl;
+            close(fd);
+            return false;
+        }
+
+        uint32_t num_files = 2;
+        if (m_log_index == 0)
+            parse_ib_log_0(log, stat_buf.st_size, num_files);
+        else
+            parse_ib_log_n(log);
+
+        // Free up the space ...
+        err = munmap(log, stat_buf.st_size);
+        if(err != 0){
+            PRINT_ERR << " Error un-mapping redo log."
+                      << std::endl;
+            close(fd);
+            return false;
+        }
+
+        close(fd);
+        return true;
+    }
+};
+
+#endif //MYSQL_LOG_READER_H

--- a/extra/redo-log-reader/main.cpp
+++ b/extra/redo-log-reader/main.cpp
@@ -1,0 +1,23 @@
+//
+// Created by Thejaka Kanewala on 3/24/22.
+//
+#include <iostream>
+#include "log_reader.h"
+
+int main() {
+    std::cout << "Starting redo-log reader ..." << std::endl;
+    LogReader logReader("/Users/thejaka.kanewala/git/mysql/mariadb-build/configurations/mysql-replication/primary/data/",
+                        "/Users/thejaka.kanewala/git/mysql/mariadb-build/configurations/mysql-replication/primary/data/ib_logfile0");
+
+    if (!logReader.init()) {
+        std::cout << "[ERROR] Error initializing the log reader!" << std::endl;
+        return -1;
+    }
+
+    if (logReader.read())
+        return 0;
+    else {
+        std::cout << "[ERROR] Log reader failed!" << std::endl;
+        return -1;
+    }
+}

--- a/extra/redo-log-reader/record_handler.h
+++ b/extra/redo-log-reader/record_handler.h
@@ -1,0 +1,733 @@
+//
+// Created by Thejaka Kanewala on 6/17/22.
+//
+
+#ifndef MYSQL_RECORD_HANDLER_H
+#define MYSQL_RECORD_HANDLER_H
+
+#include <trx0undo.h>
+#include "util.h"
+
+class RecordHandler {
+private:
+    bool m_continue;
+
+    int64_t calculate_bytes_consumed_4bytes(const unsigned char* buffer, ulint* val, const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        (*val) = mach_parse_compressed(&ptr, end_ptr);
+        return (ptr - buffer);
+    }
+protected:
+    int64_t handle_mlog_file_name(const unsigned char* buffer, uint32_t space_id, uint32_t page_id, ulint len,
+                                  const unsigned char* end_ptr) {
+        // nothing to do ..
+        return len;
+    }
+
+    int64_t handle_mlog_file_delete(const unsigned char* buffer, uint32_t space_id, uint32_t page_id, ulint len,
+                                    const unsigned char* end_ptr) {
+        return len;
+    }
+
+    int64_t handle_mlog_file_create2(const unsigned char* buffer, uint32_t space_id, uint32_t page_id, ulint len,
+                                     const unsigned char* end_ptr) {
+        return len;
+    }
+
+    int64_t handle_mlog_file_rename2(const unsigned char* buffer, uint32_t space_id, uint32_t page_id, ulint len,
+                                     const unsigned char* end_ptr) {
+        // we have the new name ...
+        // new name length ...
+        ulint new_name_len = mach_read_from_2(buffer + len);
+        return len + 2 + new_name_len;
+    }
+
+    int64_t handle_mlog_file_x(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id, uint32_t page_id,
+                               const unsigned char* end_ptr) {
+        uint64_t offset = 0;
+        ulint len = mach_read_from_2(buffer);
+        offset += 2; // length 2 bytes ...
+
+        switch (type) {
+            case MLOG_FILE_NAME:
+                return (2 + handle_mlog_file_name(buffer, space_id, page_id, len, end_ptr));
+            case MLOG_FILE_DELETE:
+                return (2 + handle_mlog_file_delete(buffer, space_id, page_id, len, end_ptr));
+            case MLOG_FILE_CREATE2:
+                return (2 + handle_mlog_file_create2(buffer, space_id, page_id, len, end_ptr));
+            case MLOG_FILE_RENAME2:
+                return (2 + handle_mlog_file_rename2(buffer, space_id, page_id, len, end_ptr));
+            default:{
+                assert(false);
+            }
+        }
+    }
+
+    int64_t handle_mlog_index_load(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id, uint32_t page_id,
+                                   const unsigned char* end_ptr) {
+        return 0;
+    }
+
+    int64_t handle_mlog_truncate(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id, uint32_t page_id,
+                                 const unsigned char* end_ptr) {
+        // truncate contains the truncated LSN
+        return sizeof (lsn_t);
+    }
+
+    int64_t handle_mlog_nbytes(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id, uint32_t page_id,
+                               const unsigned char* end_ptr) {
+        // mlog_nbytes contain an offset and then the value ...
+        // offset is 2 bytes -- this is the offset within the page ...
+        ulint page_offset = mach_read_from_2(buffer);
+        int64_t buffer_offset = 2; //cos 2 bytes is for the page offset ...
+
+        switch(type) {
+            case MLOG_1BYTE:
+                return (buffer_offset + handle_mlog_1byte(type, (buffer + buffer_offset), space_id, page_id,
+                                                          page_offset, end_ptr));
+            case MLOG_2BYTES:
+                return (buffer_offset + handle_mlog_2bytes(type, (buffer + buffer_offset), space_id, page_id,
+                                                           page_offset, end_ptr));
+            case MLOG_4BYTES:
+                return (buffer_offset + handle_mlog_4bytes(type, (buffer + buffer_offset), space_id, page_id,
+                                                           page_offset, end_ptr));
+            case MLOG_8BYTES:
+                return (buffer_offset + handle_mlog_8bytes(type, (buffer + buffer_offset), space_id, page_id,
+                                                           page_offset, end_ptr));
+            default:
+                assert(false);
+        }
+    }
+
+    int64_t handle_mlog_1byte(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                               uint32_t page_id,
+                               ulint page_offset,
+                              const unsigned char* end_ptr) {
+        ulint val;
+        return calculate_bytes_consumed_4bytes(buffer, &val, end_ptr);
+    }
+
+    int64_t handle_mlog_2bytes(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                              uint32_t page_id,
+                              ulint page_offset,
+                               const unsigned char* end_ptr) {
+        ulint val;
+        return calculate_bytes_consumed_4bytes(buffer, &val, end_ptr);
+    }
+
+    int64_t handle_mlog_4bytes(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                               uint32_t page_id,
+                               ulint page_offset,
+                               const unsigned char* end_ptr) {
+        ulint val;
+        return calculate_bytes_consumed_4bytes(buffer, &val, end_ptr);
+    }
+
+    int64_t handle_mlog_8bytes(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                               uint32_t page_id,
+                               ulint page_offset,
+                               const unsigned char* end_ptr) {
+        // could take variable number of bytes ...
+        const unsigned char* ptr = buffer;
+        ib_uint64_t	dval = mach_u64_parse_compressed(&ptr, end_ptr);
+
+        int64_t buffer_offset = (ptr - buffer);
+        return buffer_offset;
+    }
+
+    int64_t handle_mlog_init_file_page2(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                        uint32_t page_id,
+                                        const unsigned char* end_ptr) {
+        return 0;
+    }
+
+    int64_t handle_mlog_write_string(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                     uint32_t page_id,
+                                     const unsigned char* end_ptr) {
+        // a string includes the page offset; i.e., to where the string should be written in a page
+        // and the string's length.
+        int64_t page_offset = mach_read_from_2(buffer);
+        int64_t len = mach_read_from_2(buffer + 2);
+        std::string s((const char*)(buffer+4), len);
+        return (2 + 2 + len);
+    }
+
+    int64_t handle_mlog_undo_hdr_reuse(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                       uint32_t page_id,
+                                       const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        trx_id_t trx_id = mach_u64_parse_compressed(&ptr, end_ptr);
+        return (ptr - buffer);
+    }
+
+    int64_t handle_mlog_undo_hdr_create(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                       uint32_t page_id,
+                                        const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        trx_id_t trx_id = mach_u64_parse_compressed(&ptr, end_ptr);
+        return (ptr - buffer);
+    }
+
+    int64_t handle_index_info(const char* operation,
+                              const mlog_id_t& type,
+                              const unsigned char* buffer,
+                              uint32_t space_id,
+                              uint32_t page_id,
+                              const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        // 1. first the index ...
+
+        // number of fields in the index ..
+        ulint n_fields = mach_read_from_2(ptr);
+        ptr += 2;
+        ulint n_uniq_fields = mach_read_from_2(ptr);
+        ptr += 2;
+
+        // if n_fields == n_uniq_fields, then this is a normal index; otherwise
+        // we are dealing with a clustered index ...
+        for (ulint i = 0; i < n_fields; i++) {
+            ulint	len = mach_read_from_2(ptr);
+            ptr += 2;
+            /* The high-order bit of len is the NOT NULL flag;
+            the rest is 0 or 0x7fff for variable-length fields,
+            and 1..0x7ffe for fixed-length fields. */
+        }
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_mlog_rec_insert(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                        uint32_t page_id,
+                                        const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        // 1. first the index ...
+        // no index stuff for non-compact records ....
+
+        // 2. now the record itself ...
+        // page offset ...
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        ulint end_seg_len = mach_parse_compressed(&ptr, end_ptr);
+
+        if (end_seg_len & 0x1UL) {
+            /* Read the info bits */
+            ulint info_and_status_bits = mach_read_from_1(ptr);
+            ptr++;
+
+            ulint origin_offset = mach_parse_compressed(&ptr, end_ptr);
+            ulint mismatch_index = mach_parse_compressed(&ptr, end_ptr);
+        }
+
+        ptr += (end_seg_len >> 1);
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_mlog_rec_insert_comp(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                        uint32_t page_id,
+                                        const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        // 1. first the index ...
+        ptr += handle_index_info("insert_comp", type, buffer, space_id, page_id, end_ptr);
+        ptr += handle_mlog_rec_insert(type, ptr, space_id, page_id, end_ptr);
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_mlog_rec_delete_mark(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                        uint32_t page_id,
+                                        const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        // 2. now the record itself ...
+        // page offset ...
+        ulint flags = mach_read_from_1(ptr);
+        ptr++;
+        ulint val = mach_read_from_1(ptr);
+        ptr++;
+
+        ulint pos = mach_parse_compressed(&ptr, end_ptr);
+
+        ulint roll_ptr = trx_read_roll_ptr(ptr);
+        ptr += DATA_ROLL_PTR_LEN;
+
+        ulint trx_id = mach_u64_parse_compressed(&ptr, end_ptr);
+
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_mlog_rec_delete_mark_comp(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                             uint32_t page_id,
+                                             const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        // 1. first the index ...
+        ptr += handle_index_info("delete_comp", type, buffer, space_id, page_id, end_ptr);
+        ptr += handle_mlog_rec_delete_mark(type, ptr, space_id, page_id, end_ptr);
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_secondary_index_delete(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                        uint32_t page_id,
+                                        const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        ulint val = mach_read_from_1(ptr);
+        ptr++;
+
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_rec_update_inplace(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                          uint32_t page_id,
+                                          const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        ulint flags = mach_read_from_1(ptr);
+        ptr++;
+
+        ulint pos = mach_parse_compressed(&ptr, end_ptr);
+
+        roll_ptr_t roll_ptr = trx_read_roll_ptr(ptr);
+        ptr += DATA_ROLL_PTR_LEN;
+
+        trx_id_t trx_id = mach_u64_parse_compressed(&ptr, end_ptr);
+
+        ulint rec_offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        // index info ....
+        ulint info_bits = mach_read_from_1(ptr);
+        ptr++;
+        ulint n_fields = mach_parse_compressed(&ptr, end_ptr);
+
+        for (ulint i = 0; i < n_fields; i++) {
+            ulint	field_no;
+            field_no = mach_parse_compressed(&ptr, end_ptr);
+            ulint len = mach_parse_compressed(&ptr, end_ptr);
+
+            if (len != UNIV_SQL_NULL) {
+                ptr += len;
+            }
+        }
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_rec_update_inplace_comp(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                      uint32_t page_id,
+                                      const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        // 1. first the index ...
+        ptr += handle_index_info("update_inplace_comp", type, buffer, space_id, page_id, end_ptr);
+        ptr += handle_rec_update_inplace(type, ptr, space_id, page_id, end_ptr);
+        return (ptr - buffer);
+    }
+
+    int64_t handle_delete_record_list(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                                   uint32_t page_id,
+                                                   const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_delete_record_list_comp(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                      uint32_t page_id,
+                                      const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        // 1. first the index ...
+        ptr += handle_index_info("delete_record_list", type, buffer, space_id, page_id, end_ptr);
+        ptr += handle_delete_record_list(type, ptr, space_id, page_id, end_ptr);
+        return (ptr - buffer);
+    }
+
+    int64_t handle_copy_rec_list_to_created_page(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                      uint32_t page_id,
+                                      const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        ulint log_data_len = mach_read_from_4(ptr);
+        ptr += 4;
+        ptr += log_data_len;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_copy_rec_list_to_created_page_comp(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                                 uint32_t page_id,
+                                                 const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        // 1. first the index ...
+        ptr += handle_index_info("copy_rec_list_to_created_page", type, buffer, space_id, page_id, end_ptr);
+        ptr += handle_copy_rec_list_to_created_page(type, ptr, space_id, page_id, end_ptr);
+        return (ptr - buffer);
+    }
+
+    int64_t handle_page_reorganize(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                                 uint32_t page_id,
+                                                 const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        if (type != MLOG_PAGE_REORGANIZE) {
+            ptr += handle_index_info("page_reorganize", type, buffer, space_id, page_id, end_ptr);
+        }
+
+        if (type == MLOG_ZIP_PAGE_REORGANIZE) {
+            ulint level = mach_read_from_1(ptr);
+            ++ptr;
+        }
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_page_create(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                   uint32_t page_id,
+                                   const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_add_undo_rec(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                               uint32_t page_id,
+                               const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        ulint len = mach_read_from_2(ptr);
+        ptr += 2;
+
+        ptr += len;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_undo_erase_page_end(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                uint32_t page_id,
+                                const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_undo_init(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                       uint32_t page_id,
+                                       const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        ulint undo_type = mach_parse_compressed(&ptr, end_ptr);
+        return (ptr - buffer);
+    }
+
+    int64_t handle_rec_min_mark(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                             uint32_t page_id,
+                             const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_mlog_rec_delete(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                uint32_t page_id,
+                                const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        if (type == MLOG_COMP_REC_DELETE)
+            ptr += handle_index_info("delete_rec", type, buffer, space_id, page_id, end_ptr);
+
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_bitmap_init(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                   uint32_t page_id,
+                                   const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_zip_write_node_ptr(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                               uint32_t page_id,
+                               const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+        ulint z_offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        ptr += REC_NODE_PTR_SIZE;
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_zip_write_blob_ptr(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                      uint32_t page_id,
+                                      const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        ulint offset = mach_read_from_2(ptr);
+        ptr += 2;
+        ulint z_offset = mach_read_from_2(ptr);
+        ptr += 2;
+
+        ptr += BTR_EXTERN_FIELD_REF_SIZE;
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_zip_write_header(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                      uint32_t page_id,
+                                      const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        ulint offset = (ulint) *ptr++;
+        ulint len = (ulint) *ptr++;
+        ptr += len;
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_zip_page_compress(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                    uint32_t page_id,
+                                    const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+
+        ulint size = mach_read_from_2(ptr);
+        ptr += 2;
+        ulint trailer_size = mach_read_from_2(ptr);
+        ptr += 2;
+
+        ptr += (8 + size + trailer_size);
+
+        return (ptr - buffer);
+    }
+
+    int64_t handle_zip_page_compress_no_data(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                     uint32_t page_id,
+                                     const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        ptr += handle_index_info("zip_page_compress_no_data", type, buffer, space_id, page_id, end_ptr);
+        ulint level = mach_read_from_1(ptr);
+        ptr += 1;
+        return (ptr - buffer);
+    }
+
+    int64_t handle_file_crypt_data(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id,
+                                             uint32_t page_id,
+                                             const unsigned char* end_ptr) {
+        const unsigned char* ptr = buffer;
+        uint entry_size =
+                4 + // size of space_id
+                        2 + // size of offset
+                        1 + // size of type
+                        1 + // size of iv-len
+                        4 +  // size of min_key_version
+                        4 +  // size of key_id
+                        1; // fil_encryption_t
+
+        ulint en_space_id = mach_read_from_4(ptr);
+        ptr += 4;
+        uint offset = mach_read_from_2(ptr);
+        ptr += 2;
+        uint en_type = mach_read_from_1(ptr);
+        ptr += 1;
+        uint len = mach_read_from_1(ptr);
+        ptr += 1;
+
+        uint min_key_version = mach_read_from_4(ptr);
+        ptr += 4;
+
+        uint key_id = mach_read_from_4(ptr);
+        ptr += 4;
+
+        fil_encryption_t encryption = (fil_encryption_t)mach_read_from_1(ptr);
+        ptr +=1;
+
+        ptr += len;
+        //TODO
+
+        return (ptr - buffer);
+    }
+
+    virtual int64_t handle_mlog_checkpoint(const unsigned char* buffer, const unsigned char* end_ptr) {
+        // mlog checkpoint contains the checkpoint LSN which is 8 bytes ...
+        lsn_t lsn = mach_read_from_8(buffer);
+        PRINT_INFO << "Checkpoint LSN: " << lsn << std::endl;
+        return (SIZE_OF_MLOG_CHECKPOINT - 1);
+    }
+
+public:
+
+    RecordHandler():m_continue(true){}
+
+    int64_t handle_system_records(const mlog_id_t& type, const unsigned char* buffer, const lsn_t& lsn,
+                                  const unsigned char* end_ptr) {
+        if (type == MLOG_CHECKPOINT)
+            return handle_mlog_checkpoint(buffer, end_ptr);
+
+        return 0;
+    }
+
+    void suspend_processing() {
+        m_continue = false;
+    }
+
+    void resume_processing() {
+        m_continue = true;
+    }
+
+    bool is_continue_processing() {
+        return m_continue;
+    }
+
+    template<typename mlog_id_t>
+    int64_t operator()(const mlog_id_t& type, const unsigned char* buffer, uint32_t space_id, uint32_t page_id,
+            const lsn_t& lsn, const unsigned char* end_ptr) {
+
+        switch (type) {
+            case MLOG_FILE_NAME:
+            case MLOG_FILE_DELETE:
+            case MLOG_FILE_CREATE2:
+            case MLOG_FILE_RENAME2:
+                return handle_mlog_file_x(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_INDEX_LOAD:
+                return handle_mlog_index_load(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_TRUNCATE:
+                return handle_mlog_truncate(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_1BYTE:
+            case MLOG_2BYTES:
+            case MLOG_4BYTES:
+            case MLOG_8BYTES:
+                return handle_mlog_nbytes(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_COMP_REC_INSERT:
+                return handle_mlog_rec_insert_comp(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_REC_INSERT:
+                return handle_mlog_rec_insert(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_REC_CLUST_DELETE_MARK:
+                return handle_mlog_rec_delete_mark(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_COMP_REC_CLUST_DELETE_MARK:
+                return handle_mlog_rec_delete_mark_comp(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_REC_SEC_DELETE_MARK:
+                return handle_secondary_index_delete(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_REC_UPDATE_IN_PLACE:
+                return handle_rec_update_inplace(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_COMP_REC_UPDATE_IN_PLACE:
+                return handle_rec_update_inplace_comp(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_LIST_END_DELETE:
+            case MLOG_LIST_START_DELETE:
+                return handle_delete_record_list(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_COMP_LIST_END_DELETE:
+            case MLOG_COMP_LIST_START_DELETE:
+                return handle_delete_record_list_comp(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_LIST_END_COPY_CREATED:
+                return handle_copy_rec_list_to_created_page(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_COMP_LIST_END_COPY_CREATED:
+                return handle_copy_rec_list_to_created_page_comp(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_PAGE_REORGANIZE:
+            case MLOG_COMP_PAGE_REORGANIZE:
+            case MLOG_ZIP_PAGE_REORGANIZE:
+                return handle_page_reorganize(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_PAGE_CREATE:
+            case MLOG_COMP_PAGE_CREATE:
+            case MLOG_PAGE_CREATE_RTREE:
+            case MLOG_COMP_PAGE_CREATE_RTREE:
+                return handle_page_create(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_UNDO_INSERT:
+                return handle_add_undo_rec(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_UNDO_ERASE_END:
+                return handle_undo_erase_page_end(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_UNDO_INIT:
+                return handle_undo_init(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_UNDO_HDR_REUSE:
+                return handle_mlog_undo_hdr_reuse(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_UNDO_HDR_CREATE:
+                return handle_mlog_undo_hdr_create(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_REC_MIN_MARK:
+            case MLOG_COMP_REC_MIN_MARK:
+                return handle_rec_min_mark(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_REC_DELETE:
+            case MLOG_COMP_REC_DELETE:
+                return handle_mlog_rec_delete(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_IBUF_BITMAP_INIT:
+                return handle_bitmap_init(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_INIT_FILE_PAGE2:
+                return handle_mlog_init_file_page2(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_WRITE_STRING:
+                return handle_mlog_write_string(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_ZIP_WRITE_NODE_PTR:
+                return handle_zip_write_node_ptr(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_ZIP_WRITE_BLOB_PTR:
+                return handle_zip_write_blob_ptr(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_ZIP_WRITE_HEADER:
+                return handle_zip_write_header(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_ZIP_PAGE_COMPRESS:
+                return handle_zip_page_compress(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_ZIP_PAGE_COMPRESS_NO_DATA:
+                return handle_zip_page_compress_no_data(type, buffer, space_id, page_id, end_ptr);
+            case MLOG_FILE_WRITE_CRYPT_DATA:
+                return handle_file_crypt_data(type, buffer, space_id, page_id, end_ptr);
+            default:
+                ib::error() << "Unidentified redo log record type "
+                            << ib::hex(unsigned(type));
+                return -1;
+        }
+
+    }
+};
+
+
+class MLogRecordHandler : public RecordHandler {
+private:
+    bool mlog_checkpoint_found;
+    lsn_t given_cp_lsn;
+public:
+    MLogRecordHandler(const lsn_t& checkpoint_lsn): mlog_checkpoint_found(false), given_cp_lsn(checkpoint_lsn) {
+    }
+
+    bool is_mlog_cp_found() {
+        return mlog_checkpoint_found;
+    }
+
+    lsn_t checkpoint_lsn() {
+        return given_cp_lsn;
+    }
+
+    virtual int64_t handle_mlog_checkpoint(const unsigned char* buffer, const unsigned char* end_ptr) {
+
+        // mlog checkpoint contains the checkpoint LSN which is 8 bytes ...
+        lsn_t lsn = mach_read_from_8(buffer);
+
+        if (given_cp_lsn == 0) {
+            given_cp_lsn = lsn;
+            mlog_checkpoint_found = true;
+        } else {
+            if (given_cp_lsn == lsn)
+                mlog_checkpoint_found = true;
+            else {
+                PRINT_INFO << "Checkpoints mismatch. Given CP LSN: " << given_cp_lsn << ", actual lsn read: " << lsn
+                           << std::endl;
+                return -1;
+            }
+        }
+
+        PRINT_INFO << "Checkpoint LSN: " << lsn << std::endl;
+
+        // once we find the m_log_checkpoint, we do not want to continue the processing ...
+        suspend_processing();
+
+        return (SIZE_OF_MLOG_CHECKPOINT - 1);
+    }
+
+
+};
+
+#endif //MYSQL_RECORD_HANDLER_H

--- a/extra/redo-log-reader/record_parser.h
+++ b/extra/redo-log-reader/record_parser.h
@@ -1,0 +1,254 @@
+//
+// Created by Thejaka Kanewala on 6/9/22.
+//
+
+#ifndef MYSQL_RECORD_PARSER_H
+#define MYSQL_RECORD_PARSER_H
+
+#include "record_scanner.h"
+#include "record_handler.h"
+
+template<typename RecordHandler>
+class RecordParser {
+private:
+    RecordScanner* p_Scanner;
+    RecordHandler* p_Handler;
+    uint32_t record_offset;
+
+private:
+    bool get_record_type(const unsigned char* buffer, mlog_id_t* type) {
+
+        *type = mlog_id_t(buffer[record_offset] & ~MLOG_SINGLE_REC_FLAG);
+        if (UNIV_UNLIKELY(*type > MLOG_BIGGEST_TYPE
+                                  && !EXTRA_CHECK_MLOG_NUMBER(*type))) {
+            PRINT_ERR << "Found an invalid redo log record type at offset: " << record_offset << "." << std::endl;
+            return false;
+        }
+
+        // increase the offset
+        ++record_offset;
+        return true;
+    }
+
+    lsn_t offset_to_lsn(const lsn_t& chunk_start_lsn) {
+
+        const lsn_t block_sz_wo_hdr_trl = (OS_FILE_LOG_BLOCK_SIZE - LOG_BLOCK_HDR_SIZE - LOG_BLOCK_TRL_SIZE);
+        // how many blocks are there in the offset ?
+        lsn_t blocks = record_offset / block_sz_wo_hdr_trl;
+        lsn_t remainder = record_offset % block_sz_wo_hdr_trl;
+
+        lsn_t adjustment = 0;
+        if (remainder > 0) {
+            // is the start lsn is in the middle of the block ?
+            lsn_t lsn_mod = chunk_start_lsn % OS_FILE_LOG_BLOCK_SIZE;
+
+            if (lsn_mod == 0)
+                adjustment = LOG_BLOCK_HDR_SIZE;
+            else {
+                assert (lsn_mod > LOG_BLOCK_HDR_SIZE);
+
+                lsn_t lsn_remain = OS_FILE_LOG_BLOCK_SIZE - lsn_mod;
+                assert (lsn_remain > LOG_BLOCK_TRL_SIZE);
+                lsn_remain -= LOG_BLOCK_TRL_SIZE;
+
+                if (lsn_remain == 0)
+                    adjustment = LOG_BLOCK_HDR_SIZE;
+                else if (remainder > lsn_remain)
+                    adjustment = (LOG_BLOCK_HDR_SIZE + LOG_BLOCK_TRL_SIZE);
+                else if (remainder == lsn_remain)
+                    adjustment = LOG_BLOCK_TRL_SIZE;
+                else
+                    adjustment = 0;
+            }
+        }
+
+        lsn_t lsn_at_offset = chunk_start_lsn + record_offset + blocks * (LOG_BLOCK_HDR_SIZE + LOG_BLOCK_TRL_SIZE) + adjustment;
+        return lsn_at_offset;
+    }
+
+    bool parse_record(const unsigned char* buffer, const lsn_t& chunk_start_lsn) {
+
+        // get the type of the record -- type is 1 byte
+        mlog_id_t type;
+        if (!get_record_type(buffer, &type))
+            return false;
+
+        PRINT_INFO << "[Handler] [LSN=" << offset_to_lsn(chunk_start_lsn) - 1 << "] Record Type: " << get_mlog_string(type) << std::endl;
+
+        // handle record types that does not involve a page/space id
+        switch(type) {
+            case MLOG_MULTI_REC_END:
+            case MLOG_DUMMY_RECORD:
+            case MLOG_CHECKPOINT: {
+                record_offset += p_Handler->handle_system_records(type, buffer + record_offset, offset_to_lsn(chunk_start_lsn), p_Scanner->end_ptr());
+                return true;
+            }
+        }
+
+        // read the space id and page id
+        // space id and page id is stored in 2 bytes, 2 bytes fields in some compressed format ...
+        byte* ptr = const_cast<byte *>(buffer + record_offset);
+        uint32_t space_id = mach_parse_compressed(const_cast<const byte **>(&ptr), p_Scanner->end_ptr());
+
+        uint32_t page_id = 0;
+        if (ptr != NULL) {
+            page_id = mach_parse_compressed(const_cast<const byte **>(&ptr), p_Scanner->end_ptr());
+        } else {
+            PRINT_ERR << "LSN: " << (record_offset) << ", unable to retrieve page id for space id: " << space_id << std::endl;
+            return false;
+        }
+
+        record_offset += (ptr - (buffer + record_offset));
+
+        int64_t length = (*p_Handler)(type, buffer+record_offset, space_id, page_id, offset_to_lsn(chunk_start_lsn), p_Scanner->end_ptr());
+        if (length < 0) {
+            PRINT_ERR << "Error parsing record " << get_mlog_string(type) << std::endl;
+            return false;
+        }
+
+        record_offset += length;
+
+        return true;
+    }
+
+public:
+    RecordParser(RecordScanner* _pScanner, RecordHandler* _pHandler): p_Scanner(_pScanner), p_Handler(_pHandler),
+                                                    record_offset(0){
+    }
+
+    // returns false if a parse record failed
+    bool parse_records(const lsn_t& chunk_start_lsn) {
+        while ((record_offset < p_Scanner->get_length()) &&
+                p_Handler->is_continue_processing())
+            if (!parse_record(p_Scanner->parse_buffer, chunk_start_lsn)) {
+                return false;
+            }
+
+        return true;
+    }
+
+    bool scanner_full() {
+        return (record_offset >= p_Scanner->get_length());
+    }
+};
+
+/*class RecordParser {
+public:
+    RecordParser(const unsigned char* _block, uint32_t _offset, const uint32_t& _data_length):
+        block(_block), record_offset(_offset), data_length(_data_length){}
+
+private:
+    bool is_single_record(const unsigned char* record, const uint32_t& offset) {
+        // What is a single (mtr) record ? -- this means mtr makes only change a single
+        // page. If the mtr has multiple page modifications, then it will not be a single record ...
+
+        // by default MLOG_CHECKPOINT and MLOG_DUMMY_RECORD are considered single record mtrs
+        if ((record[offset] == MLOG_CHECKPOINT) || (record[offset] == MLOG_DUMMY_RECORD))
+            return true;
+        else
+            return (record[offset] & MLOG_SINGLE_REC_FLAG); // otherwise, first bit of type says whether
+        // it is a single record or not ...
+    }
+
+    bool get_record_type(const unsigned char* record, uint32_t& offset, mlog_id_t* type) {
+
+        *type = mlog_id_t(record[offset] & ~MLOG_SINGLE_REC_FLAG);
+        if (UNIV_UNLIKELY(*type > MLOG_BIGGEST_TYPE
+                                  && !EXTRA_CHECK_MLOG_NUMBER(*type))) {
+            PRINT_ERR << "Found an invalid redo log record type." << std::endl;
+            return false;
+        }
+
+        // increase the offset
+        ++offset;
+        return true;
+    }
+
+    bool parse_mlog_file_name(const unsigned char *block, uint32_t space_id, uint32_t& record_offset, const lsn_t& record_lsn) {
+        ulint len = mach_read_from_2(block);
+        std::string file_name(reinterpret_cast<const char *>(block + 2), len - 1);
+        record_offset += (2 + len);
+
+        PRINT_INFO << "LSN: " << (record_lsn + record_offset) << ", Space Id: " << space_id << " file name: " << file_name << std::endl;
+
+        return true;
+    }
+
+    bool parse_mlog_checkpoint(const unsigned char *block, uint32_t& record_offset, const lsn_t& record_lsn) {
+        lsn_t cp_lsn = mach_read_from_8(block);
+        record_offset += 8;
+
+        PRINT_INFO << "LSN: " << (record_lsn + record_offset) << ", Found MLOG_CHECKPOINT and LSN=" << cp_lsn << std::endl;
+        return true;
+    }
+
+    bool parse_record(const uint32_t& _block_id, const lsn_t& record_lsn) {
+
+        // within a block we cannot have an offset greater than 508
+        // cos block size = 512
+        // block trailer has a checksum field of 4 bytes
+        // then, offset can go to the maximum 512 - 4 = 508
+
+        if (record_offset >= 506)
+            return false;
+
+        // get the type of the record -- type is 1 byte
+        mlog_id_t type;
+        if (!get_record_type(block, record_offset, &type))
+            return false;
+
+        if (type == MLOG_CHECKPOINT) {
+            return parse_mlog_checkpoint(block + record_offset, record_offset, record_lsn);
+        }
+
+        // for dummy records and checkpoint records we do not have the space id and the page id ...
+        if (type == MLOG_DUMMY_RECORD) {
+            PRINT_INFO << "LSN: " << (record_lsn + record_offset) << ", Found a single record of type: " << get_mlog_string(type) << std::endl;
+            return true;
+        }
+
+        if (type == MLOG_MULTI_REC_END) {
+            // do nothing ..
+            return true;
+        }
+
+        // read the space id and page id
+        // space id and page id is stored in 2 bytes, 2 bytes fields in some compressed format ...
+        byte* ptr = const_cast<byte *>(block + record_offset);
+        uint32_t space_id = mach_parse_compressed(const_cast<const byte **>(&ptr), (block + data_length));
+
+        uint32_t page_id = 0;
+        if (ptr != NULL) {
+            page_id = mach_parse_compressed(const_cast<const byte **>(&ptr), (block + data_length));
+        } else {
+            PRINT_ERR << "LSN: " << (record_lsn + record_offset) << ", Block: " << _block_id << ", unable to retrieve page id for space id: " << space_id << std::endl;
+            return false;
+        }
+
+        record_offset += 2;
+
+        if (is_single_record(block, record_offset)) {
+            PRINT_INFO << "LSN: " << (record_lsn + record_offset) << ", Found a single record of type: " << get_mlog_string(type) << " space id: " << space_id
+                       << " page id: " << page_id << std::endl;
+        } else {
+            PRINT_INFO << "LSN: " << (record_lsn + record_offset) << ", Found a multi record of type: " << get_mlog_string(type) << " space id: " << space_id
+                       << " page id: " << page_id << std::endl;
+            if (type == MLOG_FILE_NAME)
+                parse_mlog_file_name(block + record_offset, space_id, record_offset, record_lsn);
+        }
+
+        return true;
+    }
+
+public:
+    bool parse_records(const uint32_t& _block_id, const lsn_t record_lsn) {
+        while (record_offset < data_length)
+            if (!parse_record(_block_id, record_lsn))
+                break;
+    }
+private:
+    const unsigned char* block;
+    uint32_t record_offset;
+    const uint32_t& data_length;
+};*/
+#endif //MYSQL_RECORD_PARSER_H

--- a/extra/redo-log-reader/record_scanner.h
+++ b/extra/redo-log-reader/record_scanner.h
@@ -1,0 +1,68 @@
+//
+// Created by Thejaka Kanewala on 6/17/22.
+//
+
+#ifndef MYSQL_RECORD_SCANNER_H
+#define MYSQL_RECORD_SCANNER_H
+
+class RecordScanner {
+private:
+    const uint64_t& size;
+    uint64_t length;
+
+public:
+    RecordScanner(const uint64_t& _size): size(_size), parse_buffer(NULL){}
+
+    bool init() {
+        if (parse_buffer == NULL)
+            parse_buffer = new unsigned char[size];
+
+        std::fill(parse_buffer, parse_buffer + size, 0);
+        length = 0;
+        return true;
+    }
+
+    unsigned char* end_ptr() {
+        return (parse_buffer + size);
+    }
+
+    /**
+     * Scans a block and add necessary parts to the parse_buffer
+     * @param block
+     * @return
+     */
+    bool scan(const unsigned char* block, const uint32_t& offset=LOG_BLOCK_HDR_SIZE) {
+        assert(offset >= LOG_BLOCK_HDR_SIZE);
+        assert(offset < (OS_FILE_LOG_BLOCK_SIZE - LOG_BLOCK_TRL_SIZE));
+
+        ulint data_length = mach_read_from_2(block + LOG_BLOCK_HDR_DATA_LEN);
+        assert(data_length >= offset);
+
+        uint32_t cp_sz;
+        if (data_length == OS_FILE_LOG_BLOCK_SIZE)
+            cp_sz = data_length - (offset + LOG_BLOCK_TRL_SIZE);
+        else {
+            assert(data_length < OS_FILE_LOG_BLOCK_SIZE);
+            cp_sz = data_length - offset;
+        }
+
+
+        // not enough space in the buffer to copy the data
+        if ((size - length) < cp_sz)
+            return false;
+
+        memcpy(parse_buffer+length, (block+offset), cp_sz);
+        length += cp_sz;
+
+        return true;
+    }
+
+    uint64_t get_length() {
+        return length;
+    }
+
+    unsigned char* parse_buffer;
+
+};
+
+#endif //MYSQL_RECORD_SCANNER_H

--- a/extra/redo-log-reader/util.h
+++ b/extra/redo-log-reader/util.h
@@ -1,0 +1,188 @@
+//
+// Created by Thejaka Kanewala on 6/9/22.
+//
+
+#ifndef MYSQL_REDO_READER_UTIL_H
+#define MYSQL_REDO_READER_UTIL_H
+
+#include <stdio.h>
+#include <sys/mman.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <os0file.h>
+#include <libgen.h>
+#include <log0log.h>
+
+#define PRINT_INFO std::cout << "[INFO] "
+#define PRINT_ERR std::cout << "[ERROR] "
+#define PRINT_WARN std::cout << "[WARN] "
+
+static const char* get_mlog_string(mlog_id_t type)
+{
+    switch (type) {
+        case MLOG_SINGLE_REC_FLAG:
+            return("MLOG_SINGLE_REC_FLAG");
+
+        case MLOG_1BYTE:
+            return("MLOG_1BYTE");
+
+        case MLOG_2BYTES:
+            return("MLOG_2BYTES");
+
+        case MLOG_4BYTES:
+            return("MLOG_4BYTES");
+
+        case MLOG_8BYTES:
+            return("MLOG_8BYTES");
+
+        case MLOG_REC_INSERT:
+            return("MLOG_REC_INSERT");
+
+        case MLOG_REC_CLUST_DELETE_MARK:
+            return("MLOG_REC_CLUST_DELETE_MARK");
+
+        case MLOG_REC_SEC_DELETE_MARK:
+            return("MLOG_REC_SEC_DELETE_MARK");
+
+        case MLOG_REC_UPDATE_IN_PLACE:
+            return("MLOG_REC_UPDATE_IN_PLACE");
+
+        case MLOG_REC_DELETE:
+            return("MLOG_REC_DELETE");
+
+        case MLOG_LIST_END_DELETE:
+            return("MLOG_LIST_END_DELETE");
+
+        case MLOG_LIST_START_DELETE:
+            return("MLOG_LIST_START_DELETE");
+
+        case MLOG_LIST_END_COPY_CREATED:
+            return("MLOG_LIST_END_COPY_CREATED");
+
+        case MLOG_PAGE_REORGANIZE:
+            return("MLOG_PAGE_REORGANIZE");
+
+        case MLOG_PAGE_CREATE:
+            return("MLOG_PAGE_CREATE");
+
+        case MLOG_UNDO_INSERT:
+            return("MLOG_UNDO_INSERT");
+
+        case MLOG_UNDO_ERASE_END:
+            return("MLOG_UNDO_ERASE_END");
+
+        case MLOG_UNDO_INIT:
+            return("MLOG_UNDO_INIT");
+
+        case MLOG_UNDO_HDR_REUSE:
+            return("MLOG_UNDO_HDR_REUSE");
+
+        case MLOG_UNDO_HDR_CREATE:
+            return("MLOG_UNDO_HDR_CREATE");
+
+        case MLOG_REC_MIN_MARK:
+            return("MLOG_REC_MIN_MARK");
+
+        case MLOG_IBUF_BITMAP_INIT:
+            return("MLOG_IBUF_BITMAP_INIT");
+
+        case MLOG_WRITE_STRING:
+            return("MLOG_WRITE_STRING");
+
+        case MLOG_MULTI_REC_END:
+            return("MLOG_MULTI_REC_END");
+
+        case MLOG_DUMMY_RECORD:
+            return("MLOG_DUMMY_RECORD");
+
+        case MLOG_FILE_DELETE:
+            return("MLOG_FILE_DELETE");
+
+        case MLOG_COMP_REC_MIN_MARK:
+            return("MLOG_COMP_REC_MIN_MARK");
+
+        case MLOG_COMP_PAGE_CREATE:
+            return("MLOG_COMP_PAGE_CREATE");
+
+        case MLOG_COMP_REC_INSERT:
+            return("MLOG_COMP_REC_INSERT");
+
+        case MLOG_COMP_REC_CLUST_DELETE_MARK:
+            return("MLOG_COMP_REC_CLUST_DELETE_MARK");
+
+        case MLOG_COMP_REC_UPDATE_IN_PLACE:
+            return("MLOG_COMP_REC_UPDATE_IN_PLACE");
+
+        case MLOG_COMP_REC_DELETE:
+            return("MLOG_COMP_REC_DELETE");
+
+        case MLOG_COMP_LIST_END_DELETE:
+            return("MLOG_COMP_LIST_END_DELETE");
+
+        case MLOG_COMP_LIST_START_DELETE:
+            return("MLOG_COMP_LIST_START_DELETE");
+
+        case MLOG_COMP_LIST_END_COPY_CREATED:
+            return("MLOG_COMP_LIST_END_COPY_CREATED");
+
+        case MLOG_COMP_PAGE_REORGANIZE:
+            return("MLOG_COMP_PAGE_REORGANIZE");
+
+        case MLOG_FILE_CREATE2:
+            return("MLOG_FILE_CREATE2");
+
+        case MLOG_ZIP_WRITE_NODE_PTR:
+            return("MLOG_ZIP_WRITE_NODE_PTR");
+
+        case MLOG_ZIP_WRITE_BLOB_PTR:
+            return("MLOG_ZIP_WRITE_BLOB_PTR");
+
+        case MLOG_ZIP_WRITE_HEADER:
+            return("MLOG_ZIP_WRITE_HEADER");
+
+        case MLOG_ZIP_PAGE_COMPRESS:
+            return("MLOG_ZIP_PAGE_COMPRESS");
+
+        case MLOG_ZIP_PAGE_COMPRESS_NO_DATA:
+            return("MLOG_ZIP_PAGE_COMPRESS_NO_DATA");
+
+        case MLOG_ZIP_PAGE_REORGANIZE:
+            return("MLOG_ZIP_PAGE_REORGANIZE");
+
+        case MLOG_FILE_RENAME2:
+            return("MLOG_FILE_RENAME2");
+
+        case MLOG_FILE_NAME:
+            return("MLOG_FILE_NAME");
+
+        case MLOG_CHECKPOINT:
+            return("MLOG_CHECKPOINT");
+
+        case MLOG_PAGE_CREATE_RTREE:
+            return("MLOG_PAGE_CREATE_RTREE");
+
+        case MLOG_COMP_PAGE_CREATE_RTREE:
+            return("MLOG_COMP_PAGE_CREATE_RTREE");
+
+        case MLOG_INIT_FILE_PAGE2:
+            return("MLOG_INIT_FILE_PAGE2");
+
+        case MLOG_INDEX_LOAD:
+            return("MLOG_INDEX_LOAD");
+
+        case MLOG_TRUNCATE:
+            return("MLOG_TRUNCATE");
+
+        case MLOG_FILE_WRITE_CRYPT_DATA:
+            return("MLOG_FILE_WRITE_CRYPT_DATA");
+
+        default: {
+            PRINT_ERR << "Invalid log record type: " << type << std::endl;
+            return NULL;
+        }
+    }
+}
+
+#endif

--- a/mysql-test/include/max_indexes.inc
+++ b/mysql-test/include/max_indexes.inc
@@ -1,2 +1,2 @@
 # Warning: This is an auto-generated file. Please do not modify it.
---let $max_indexes = 64U
+--let $max_indexes = 128

--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -187,6 +187,7 @@ IF(MSVC)
 ENDIF()
 
 ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/extra/mariabackup ${CMAKE_BINARY_DIR}/extra/mariabackup)
+ADD_SUBDIRECTORY(${CMAKE_SOURCE_DIR}/extra/redo-log-reader ${CMAKE_BINARY_DIR}/extra/redo-log-reader)
 
 IF(TARGET innobase)
   ADD_DEPENDENCIES(innobase GenError)


### PR DESCRIPTION
For every log record a method in the handler will be invoked. This code can be used as a diagnosing tool. E.g., we can use this to find which tablespaces are changed in most recent transactions. We can implement custom handlers find other information we need.

Not intended to push back to Maria but anyone interested can make use of this tool.