### PR TITLE
MDEV-28782: modify mariadb-tzinfo-to-sql to set 'wsrep*' variables appropriately in cases where Galera is not compiled in

### DIFF
--- a/mysql-test/main/mysql_tzinfo_to_sql_symlink.result
+++ b/mysql-test/main/mysql_tzinfo_to_sql_symlink.result
@@ -7,9 +7,9 @@ CREATE TABLE time_zone_leap_second LIKE mysql.time_zone_leap_second;
 # MDEV-5226 mysql_tzinfo_to_sql errors with tzdata 2013f and above
 #
 # Verbose run
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone'", 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, 'ALTER TABLE time_zone ENGINE=InnoDB', 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_name_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone_name'", 'do 0');
@@ -56,9 +56,9 @@ execute immediate if(@wsrep_cannot_replicate_tz, concat('ALTER TABLE time_zone_t
 # MDEV-28263: mariadb-tzinfo-to-sql improve wsrep and binlog cases
 #
 # Run on zoneinfo directory
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone'", 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, 'ALTER TABLE time_zone ENGINE=InnoDB', 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_name_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone_name'", 'do 0');
@@ -116,9 +116,9 @@ COUNT(*)
 #
 # Run on zoneinfo directory --skip-write-binlog
 #
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_is_on, 'SET @save_wsrep_on=@@WSREP_ON, WSREP_ON=OFF', 'do 0');
 SET @save_sql_log_bin=@@SQL_LOG_BIN;
 SET SESSION SQL_LOG_BIN=0;
@@ -188,9 +188,9 @@ TRUNCATE TABLE time_zone_leap_second;
 #
 # Testing with explicit timezonefile
 #
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone'", 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, 'ALTER TABLE time_zone ENGINE=InnoDB', 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_name_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone_name'", 'do 0');
@@ -252,9 +252,9 @@ TRUNCATE TABLE time_zone_leap_second;
 #
 # Testing with explicit timezonefile --skip-write-binlog
 #
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_is_on, 'SET @save_wsrep_on=@@WSREP_ON, WSREP_ON=OFF', 'do 0');
 SET @save_sql_log_bin=@@SQL_LOG_BIN;
 SET SESSION SQL_LOG_BIN=0;
@@ -310,9 +310,9 @@ TRUNCATE TABLE time_zone_leap_second;
 #
 # Testing --leap
 #
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone'", 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, 'ALTER TABLE time_zone ENGINE=InnoDB', 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_name_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone_name'", 'do 0');
@@ -373,9 +373,9 @@ TRUNCATE TABLE time_zone_leap_second;
 #
 # Testing --skip-write-binlog --leap
 #
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_is_on, 'SET @save_wsrep_on=@@WSREP_ON, WSREP_ON=OFF', 'do 0');
 SET @save_sql_log_bin=@@SQL_LOG_BIN;
 SET SESSION SQL_LOG_BIN=0;
@@ -425,9 +425,9 @@ COM_TRUNCATE	1
 #
 # Testing --skip-write-binlog
 #
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_is_on, 'SET @save_wsrep_on=@@WSREP_ON, WSREP_ON=OFF', 'do 0');
 SET @save_sql_log_bin=@@SQL_LOG_BIN;
 SET SESSION SQL_LOG_BIN=0;
@@ -447,9 +447,9 @@ UNLOCK TABLES;
 COMMIT;
 SET SESSION SQL_LOG_BIN=@save_sql_log_bin;
 execute immediate if(@wsrep_is_on, 'SET SESSION WSREP_ON=@save_wsrep_on', 'do 0');
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_is_on, 'SET @save_wsrep_on=@@WSREP_ON, WSREP_ON=OFF', 'do 0');
 SET @save_sql_log_bin=@@SQL_LOG_BIN;
 SET SESSION SQL_LOG_BIN=0;
@@ -471,9 +471,9 @@ execute immediate if(@wsrep_is_on, 'SET SESSION WSREP_ON=@save_wsrep_on', 'do 0'
 #
 # MDEV-6236 - [PATCH] mysql_tzinfo_to_sql may produce invalid SQL
 #
-set @wsrep_is_on=(select sum(SESSION_VALUE='ON') from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
+set @wsrep_is_on=(select coalesce(sum(SESSION_VALUE='ON'), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on');
 SELECT concat('%', GROUP_CONCAT(OPTION), '%') INTO @replicate_opt  FROM   (SELECT DISTINCT concat('REPLICATE_', UPPER(ENGINE)) AS OPTION    FROM information_schema.TABLES    WHERE TABLE_SCHEMA=DATABASE()      AND TABLE_NAME IN ('time_zone',                         'time_zone_name',                         'time_zone_transition',                         'time_zone_transition_type',                         'time_zone_leap_second')      AND ENGINE in ('MyISAM',                     'Aria')) AS o ORDER BY OPTION DESC;
-set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select sum(GLOBAL_VALUE NOT LIKE @replicate_opt) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
+set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0) from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone'", 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, 'ALTER TABLE time_zone ENGINE=InnoDB', 'do 0');
 execute immediate if(@wsrep_cannot_replicate_tz, "select ENGINE into @time_zone_name_engine from information_schema.TABLES where TABLE_SCHEMA=DATABASE() and TABLE_NAME='time_zone_name'", 'do 0');

--- a/mysql-test/main/mysql_tzinfo_to_sql_symlink.test
+++ b/mysql-test/main/mysql_tzinfo_to_sql_symlink.test
@@ -3,8 +3,6 @@
 --source include/not_windows.inc
 --source include/no_protocol.inc
 
-let $is_embedded=`select version() like '%embedded%'`;
-
 CREATE TABLE time_zone LIKE mysql.time_zone;
 CREATE TABLE time_zone_name LIKE mysql.time_zone_name;
 CREATE TABLE time_zone_transition LIKE mysql.time_zone_transition;
@@ -63,9 +61,6 @@ SELECT COUNT(*) FROM time_zone_transition;
 SELECT COUNT(*) FROM time_zone_transition_type;
 SELECT COUNT(*) FROM time_zone_leap_second;
 
-if ($is_embedded) {
---replace_column 1 0 2 0
-}
 SELECT @wsrep_is_on,  @wsrep_cannot_replicate_tz, @save_wsrep_on, @save_sql_log_bin, @@SQL_LOG_BIN;
 SELECT g.VARIABLE_NAME, g.VARIABLE_VALUE - b.VARIABLE_VALUE AS diff
   FROM information_schema.global_status g
@@ -100,9 +95,6 @@ SELECT COUNT(*) FROM time_zone_transition;
 SELECT COUNT(*) FROM time_zone_transition_type;
 SELECT COUNT(*) FROM time_zone_leap_second;
 
-if ($is_embedded) {
---replace_column 1 0 2 0
-}
 SELECT @wsrep_is_on,  @wsrep_cannot_replicate_tz, @save_wsrep_on, @save_sql_log_bin, @@SQL_LOG_BIN;
 SELECT g.VARIABLE_NAME, g.VARIABLE_VALUE - b.VARIABLE_VALUE AS diff
   FROM information_schema.global_status g
@@ -135,9 +127,6 @@ SELECT COUNT(*) FROM time_zone_transition;
 SELECT COUNT(*) FROM time_zone_transition_type;
 SELECT COUNT(*) FROM time_zone_leap_second;
 
-if ($is_embedded) {
---replace_column 1 0 2 0
-}
 SELECT @wsrep_is_on,  @wsrep_cannot_replicate_tz, @save_wsrep_on, @save_sql_log_bin, @@SQL_LOG_BIN;
 SELECT g.VARIABLE_NAME, g.VARIABLE_VALUE - b.VARIABLE_VALUE AS diff
   FROM information_schema.global_status g
@@ -170,9 +159,6 @@ SELECT COUNT(*) FROM time_zone_transition;
 SELECT COUNT(*) FROM time_zone_transition_type;
 SELECT COUNT(*) FROM time_zone_leap_second;
 
-if ($is_embedded) {
---replace_column 1 0 2 0
-}
 SELECT @wsrep_is_on,  @wsrep_cannot_replicate_tz, @save_wsrep_on, @save_sql_log_bin, @@SQL_LOG_BIN;
 SELECT g.VARIABLE_NAME, g.VARIABLE_VALUE - b.VARIABLE_VALUE AS diff
   FROM information_schema.global_status g
@@ -205,9 +191,6 @@ SELECT COUNT(*) FROM time_zone_transition;
 SELECT COUNT(*) FROM time_zone_transition_type;
 SELECT COUNT(*) FROM time_zone_leap_second;
 
-if ($is_embedded) {
---replace_column 1 0 2 0
-}
 SELECT @wsrep_is_on,  @wsrep_cannot_replicate_tz, @save_wsrep_on, @save_sql_log_bin, @@SQL_LOG_BIN;
 SELECT g.VARIABLE_NAME, g.VARIABLE_VALUE - b.VARIABLE_VALUE AS diff
   FROM information_schema.global_status g

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -1798,7 +1798,7 @@ end:
   delete thd;
   if (org_thd)
     org_thd->store_globals();			/* purecov: inspected */
-  
+
   default_tz= default_tz_name ? global_system_variables.time_zone
                               : my_tz_SYSTEM;
 
@@ -1873,7 +1873,7 @@ tz_load_from_open_tables(const String *tz_name, TABLE_LIST *tz_tables)
 #ifdef ABBR_ARE_USED
   char chars[MY_MAX(TZ_MAX_CHARS + 1, (2 * (MY_TZNAME_MAX + 1)))];
 #endif
-  /* 
+  /*
     Used as a temporary tz_info until we decide that we actually want to
     allocate and keep the tz info and tz name in tz_storage.
   */
@@ -2026,7 +2026,7 @@ tz_load_from_open_tables(const String *tz_name, TABLE_LIST *tz_tables)
     mysql.time_zone_transition table. Here we additionally need records
     in ascending order by index scan also satisfies us.
   */
-  table= tz_tables->table; 
+  table= tz_tables->table;
   table->field[0]->store((longlong) tzid, TRUE);
   if (table->file->ha_index_init(0, 1))
     goto end;
@@ -2361,7 +2361,7 @@ my_tz_find(THD *thd, const String *name)
 /**
   Convert leap seconds into non-leap
 
-  This function will convert the leap seconds added by the OS to 
+  This function will convert the leap seconds added by the OS to
   non-leap seconds, e.g. 23:59:59, 23:59:60 -> 23:59:59, 00:00:01 ...
   This check is not checking for years on purpose : although it's not a
   complete check this way it doesn't require looking (and having installed)
@@ -2725,11 +2725,20 @@ static const char *trunc_tables_const=
   "TRUNCATE TABLE time_zone_name;\n"
   "TRUNCATE TABLE time_zone_transition;\n"
   "TRUNCATE TABLE time_zone_transition_type;\n";
+
+/*
+   These queries need to return FALSE/0 when the 'wsrep*' variables do not
+   exist at all.
+   Moving the WHERE clause into the sum(...) seems like the obvious solution
+   here, but it does not work in bootstrap mode (see MDEV-28782 and
+   0e4cf497ca11a7298e2bd896cb594bd52085a1d4).
+   Thus we use coalesce(..., 0) instead,
+*/
 static const char *wsrep_is_on=
-  "select sum(SESSION_VALUE='ON')"
+  "select coalesce(sum(SESSION_VALUE='ON'), 0)"
   " from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_on'";
 static const char *wsrep_cannot_replicate_tz=
-  "select sum(GLOBAL_VALUE NOT LIKE @replicate_opt)"
+  "select coalesce(sum(GLOBAL_VALUE NOT LIKE @replicate_opt), 0)"
   " from information_schema.SYSTEM_VARIABLES WHERE VARIABLE_NAME='wsrep_mode'";
 
 int
@@ -2770,7 +2779,7 @@ main(int argc, char **argv)
          " ORDER BY OPTION DESC;\n");
   printf("set @wsrep_cannot_replicate_tz=@wsrep_is_on AND (%s);\n", wsrep_cannot_replicate_tz);
   if (opt_skip_write_binlog)
-    /* If turn off session wsrep if we cannot replicate using galera.
+    /* We turn off session wsrep if we cannot replicate using galera.
        Disable sql_log_bin as the name implies. */
     printf("execute immediate if(@wsrep_is_on, 'SET @save_wsrep_on=@@WSREP_ON, WSREP_ON=OFF', 'do 0');\n"
            "SET @save_sql_log_bin=@@SQL_LOG_BIN;\n"


### PR DESCRIPTION
## Description

In 3b662c6ebd26b54ce534d9e7451cdc31e6c0046c, @dr-m appears to have discovered that the values of the `wsrep_is_on` and `wsrep_cannot_replicate_tz` variables need to be overridden for embedded builds.

    However, there are other build configurations where these variables also
    have NULL values.  The mariadb-tzinfo-to-sql script (implemented in
    sql/tztime.cc) can be slightly modified to set its 'wsrep_is_on' and
    'wsrep_cannot_replicate_tz' variables more predictably in all such cases,
    thus allowing the mysql_tzinfo_to_sql_symlink.test test to pass without
    any special-casing for particular build types.
    
    See comments:
    
    - https://github.com/MariaDB/server/commit/3b662c6ebd26b54ce534d9e7451cdc31e6c0046c#r78994411
    - https://jira.mariadb.org/browse/MDEV-28782?focusedCommentId=230038&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-230038

## How can this PR be tested?

All MTR tests, including `mysql_tzinfo_to_sql_symlink.test`, should still be passing in Buildbot as well as GitLab-CI, including in configurations where the [`wsrep_on`](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_on) and [`wsrep_mode`](https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_mode) variables _do not exist_.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

10.6 is the earliest upstream branch containing 13e77930e615f05cc74d408110e887b00e1abcc9 (which led to this issue) and 3b662c6ebd26b54ce534d9e7451cdc31e6c0046c (partial fix for the embedded-server case), so it appears to be the correct place to apply this change.

## Backward compatibility

This is a fix for compatibility of a test, and should be fully backward-compatible.

---

All new code of the whole pull request, including one or several files that
are either new files or modified ones, are contributed under the BSD-new
license.  I am contributing on behalf of my employer Amazon Web Services,
Inc.
