### PR TITLE
Use memory safe snprintf() in Connect Engine

### DIFF
--- a/storage/connect/array.cpp
+++ b/storage/connect/array.cpp
@@ -89,7 +89,7 @@ PARRAY MakeValueArray(PGLOBAL g, PPARM pp)
   /*********************************************************************/
   for (n = 0, parmp = pp; parmp; n++, parmp = parmp->Next)
     if (parmp->Type != valtyp) {
-      sprintf(g->Message, MSG(BAD_PARAM_TYPE), "MakeValueArray", parmp->Type);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_PARAM_TYPE), "MakeValueArray", parmp->Type);
       return NULL;
     } else if (valtyp == TYPE_STRING)
       len = MY_MAX(len, strlen((char*)parmp->Value));
@@ -176,7 +176,7 @@ ARRAY::ARRAY(PGLOBAL g, int type, int size, int length, int prec)
       break;
 #endif // 0
     default:  // This is illegal an causes an ill formed array building
-      sprintf(g->Message, MSG(BAD_ARRAY_TYPE), type);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_ARRAY_TYPE), type);
       Type = TYPE_ERROR;
       return;
     } // endswitch type
@@ -224,7 +224,7 @@ ARRAY::ARRAY(PGLOBAL g, PQUERY qryp) : CSORT(false)
 //    Value = qryp->GetColValue(0);
 //    break;
     default:  // This is illegal an causes an ill formed array building
-      sprintf(g->Message, MSG(BAD_ARRAY_TYPE), Type);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_ARRAY_TYPE), Type);
       Type = TYPE_ERROR;
     } // endswitch type
 
@@ -285,7 +285,7 @@ void ARRAY::Empty(void)
 bool ARRAY::AddValue(PGLOBAL g, PSZ strp)
 {
   if (Type != TYPE_STRING) {
-    sprintf(g->Message, MSG(ADD_BAD_TYPE), GetTypeName(Type), "CHAR");
+    snprintf(g->Message, sizeof(g->Message), MSG(ADD_BAD_TYPE), GetTypeName(Type), "CHAR");
     return true;
   } // endif Type
 
@@ -300,7 +300,7 @@ bool ARRAY::AddValue(PGLOBAL g, PSZ strp)
 bool ARRAY::AddValue(PGLOBAL g, void *p)
 {
   if (Type != TYPE_PCHAR) {
-    sprintf(g->Message, MSG(ADD_BAD_TYPE), GetTypeName(Type), "PCHAR");
+    snprintf(g->Message, sizeof(g->Message), MSG(ADD_BAD_TYPE), GetTypeName(Type), "PCHAR");
     return true;
   } // endif Type
 
@@ -315,7 +315,7 @@ bool ARRAY::AddValue(PGLOBAL g, void *p)
 bool ARRAY::AddValue(PGLOBAL g, short n)
 {
   if (Type != TYPE_SHORT) {
-    sprintf(g->Message, MSG(ADD_BAD_TYPE), GetTypeName(Type), "SHORT");
+    snprintf(g->Message, sizeof(g->Message), MSG(ADD_BAD_TYPE), GetTypeName(Type), "SHORT");
     return true;
   } // endif Type
 
@@ -330,7 +330,7 @@ bool ARRAY::AddValue(PGLOBAL g, short n)
 bool ARRAY::AddValue(PGLOBAL g, int n)
 {
   if (Type != TYPE_INT) {
-    sprintf(g->Message, MSG(ADD_BAD_TYPE), GetTypeName(Type), "INTEGER");
+    snprintf(g->Message, sizeof(g->Message), MSG(ADD_BAD_TYPE), GetTypeName(Type), "INTEGER");
     return true;
   } // endif Type
 
@@ -345,7 +345,7 @@ bool ARRAY::AddValue(PGLOBAL g, int n)
 bool ARRAY::AddValue(PGLOBAL g, double d)
 {
   if (Type != TYPE_DOUBLE) {
-    sprintf(g->Message, MSG(ADD_BAD_TYPE), GetTypeName(Type), "DOUBLE");
+    snprintf(g->Message, sizeof(g->Message), MSG(ADD_BAD_TYPE), GetTypeName(Type), "DOUBLE");
     return true;
   } // endif Type
 
@@ -361,7 +361,7 @@ bool ARRAY::AddValue(PGLOBAL g, double d)
 bool ARRAY::AddValue(PGLOBAL g, PXOB xp)
 {
 	if (Type != xp->GetResultType()) {
-		sprintf(g->Message, MSG(ADD_BAD_TYPE),
+		snprintf(g->Message, sizeof(g->Message), MSG(ADD_BAD_TYPE),
 			GetTypeName(xp->GetResultType()), GetTypeName(Type));
 		return true;
 	} // endif Type
@@ -377,7 +377,7 @@ bool ARRAY::AddValue(PGLOBAL g, PXOB xp)
 bool ARRAY::AddValue(PGLOBAL g, PVAL vp)
 {
   if (Type != vp->GetType()) {
-    sprintf(g->Message, MSG(ADD_BAD_TYPE),
+    snprintf(g->Message, sizeof(g->Message), MSG(ADD_BAD_TYPE),
             GetTypeName(vp->GetType()), GetTypeName(Type));
     return true;
   } // endif Type
@@ -404,7 +404,7 @@ bool ARRAY::GetSubValue(PGLOBAL g, PVAL valp, int *kp)
   PVBLK vblp;
 
   if (Type != TYPE_LIST) {
-    sprintf(g->Message, MSG(NO_SUB_VAL), Type);
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_SUB_VAL), Type);
     return true;
     } // endif Type
 
@@ -500,7 +500,7 @@ bool ARRAY::FilTest(PGLOBAL g, PVAL valp, OPVAL opc, int opm)
       vp = valp;
 
   } else if (opc != OP_EXIST) {
-		sprintf(g->Message, MSG(MISSING_ARG), opc);
+		snprintf(g->Message, sizeof(g->Message), MSG(MISSING_ARG), opc);
 		throw (int)TYPE_ARRAY;
   } else    // OP_EXIST
     return Nval > 0;
@@ -581,7 +581,7 @@ int ARRAY::Convert(PGLOBAL g, int k, PVAL vp)
       Len = 1;
       break;
     default:
-      sprintf(g->Message, MSG(BAD_CONV_TYPE), Type);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_CONV_TYPE), Type);
       return TYPE_ERROR;
     } // endswitch k
 

--- a/storage/connect/blkfil.cpp
+++ b/storage/connect/blkfil.cpp
@@ -594,7 +594,7 @@ BLKFILIN::BLKFILIN(PGLOBAL g, PTDBDOS tdbp, int op, int opm, PXOB *xp)
   Type = Arap->GetResultType();
 
   if (Colp->GetResultType() != Type) {
-    sprintf(g->Message, "BLKFILIN: %s", MSG(VALTYPE_NOMATCH));
+    snprintf(g->Message, sizeof(g->Message), "BLKFILIN: %s", MSG(VALTYPE_NOMATCH));
 		throw g->Message;
 	} else if (Colp->GetValue()->IsCi())
     Arap->SetPrecision(g, 1);        // Case insensitive

--- a/storage/connect/bson.cpp
+++ b/storage/connect/bson.cpp
@@ -135,7 +135,7 @@ PBVAL BDOC::ParseJson(PGLOBAL g, char* js, size_t lng)
           break;
         } // endif pretty
 
-        sprintf(g->Message, "Unexpected ',' (pretty=%d)", pretty);
+        snprintf(g->Message, sizeof(g->Message), "Unexpected ',' (pretty=%d)", pretty);
         throw 3;
       case '(':
         b = true;
@@ -159,7 +159,7 @@ PBVAL BDOC::ParseJson(PGLOBAL g, char* js, size_t lng)
       }; // endswitch s[i]
 
     if (bvp->Type == TYPE_UNKNOWN)
-      sprintf(g->Message, "Invalid Json string '%.*s'", MY_MIN((int)len, 50), s);
+      snprintf(g->Message, sizeof(g->Message), "Invalid Json string '%.*s'", MY_MIN((int)len, 50), s);
     else if (pretty == 3) {
       for (i = 0; i < 3; i++)
         if (pty[i]) {
@@ -606,7 +606,7 @@ PSZ BDOC::Serialize(PGLOBAL g, PBVAL bvp, char* fn, int pretty)
       b = pretty == 1;
     } else {
       if (!(fs = fopen(fn, "wb"))) {
-        sprintf(g->Message, MSG(OPEN_MODE_ERROR),
+        snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR),
           "w", (int)errno, fn);
         strcat(strcat(g->Message, ": "), strerror(errno));
         throw 2;

--- a/storage/connect/bsonudf.cpp
+++ b/storage/connect/bsonudf.cpp
@@ -239,7 +239,7 @@ my_bool BJNX::SetArrayOptions(PGLOBAL g, char* p, int i, PSZ nm)
 		jnp->Rank = atoi(p) - B;
 		jnp->Op = OP_EQ;
 	} else if (Wr) {
-		sprintf(g->Message, "Invalid specification %s in a write path", p);
+		snprintf(g->Message, sizeof(g->Message), "Invalid specification %s in a write path", p);
 		return true;
 	} else if (n == 1) {
 		// Set the Op value;
@@ -252,7 +252,7 @@ my_bool BJNX::SetArrayOptions(PGLOBAL g, char* p, int i, PSZ nm)
 		case '#': jnp->Op = OP_NUM;  break;
 		case '*': jnp->Op = OP_EXP;  break;
 		default:
-			sprintf(g->Message, "Invalid function specification %c", *p);
+			snprintf(g->Message, sizeof(g->Message), "Invalid function specification %c", *p);
 			return true;
 		} // endswitch *p
 
@@ -344,7 +344,7 @@ my_bool BJNX::ParseJpath(PGLOBAL g)
 
 		} else if (*p == '*') {
 			if (Wr) {
-				sprintf(g->Message, "Invalid specification %c in a write path", *p);
+				snprintf(g->Message, sizeof(g->Message), "Invalid specification %c in a write path", *p);
 				return true;
 			} else     			// Return JSON
 				Nodes[i].Op = OP_XX;
@@ -597,7 +597,7 @@ PBVAL BJNX::GetRowValue(PGLOBAL g, PBVAL row, int i)
 			vlp = row;
 			break;
 		default:
-			sprintf(g->Message, "Invalid row JSON type %d", row->Type);
+			snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->Type);
 			vlp = NULL;
 		} // endswitch Type
 
@@ -842,7 +842,7 @@ PBVAL BJNX::GetRow(PGLOBAL g)
 			val = MVP(row->To_Val);
 			break;
 		default:
-			sprintf(g->Message, "Invalid row JSON type %d", row->Type);
+			snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->Type);
 			val = NULL;
 		} // endswitch Type
 
@@ -1034,7 +1034,7 @@ my_bool BJNX::CheckPath(PGLOBAL g)
 				val = row;
 				break;
 			default:
-				sprintf(g->Message, "Invalid row JSON type %d", row->Type);
+				snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->Type);
 		} // endswitch Type
 
 		if (i < Nod-1)
@@ -1063,7 +1063,7 @@ my_bool BJNX::CheckPath(PGLOBAL g, UDF_ARGS *args, PBVAL jsp, PBVAL& jvp, int n)
 					return true;
 
 				if (!(jvp = GetJson(g))) {
-					sprintf(g->Message, "No sub-item at '%s'", path);
+					snprintf(g->Message, sizeof(g->Message), "No sub-item at '%s'", path);
 					return true;
 				} else
 					return false;
@@ -1631,7 +1631,7 @@ PBVAL BJNX::ParseJsonFile(PGLOBAL g, char *fn, int& pty, size_t& len)
 		DWORD rc = GetLastError();
 
 		if (!(*g->Message))
-			sprintf(g->Message, MSG(OPEN_MODE_ERROR), "map", (int)rc, fn);
+			snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR), "map", (int)rc, fn);
 
 		return NULL;
 	} // endif hFile
@@ -1651,7 +1651,7 @@ PBVAL BJNX::ParseJsonFile(PGLOBAL g, char *fn, int& pty, size_t& len)
 
 	if (!memory) {
 		CloseFileHandle(hFile);
-		sprintf(g->Message, MSG(MAP_VIEW_ERROR), fn, GetLastError());
+		snprintf(g->Message, sizeof(g->Message), MSG(MAP_VIEW_ERROR), fn, GetLastError());
 		return NULL;
 	} // endif Memory
 
@@ -4766,7 +4766,7 @@ char *bfile_bjson(UDF_INIT *initid, UDF_ARGS *args, char *result,
 
 					if (!fgets(buf, lrecl, fin)) {
 						if (!feof(fin)) {
-							sprintf(g->Message, "Error %d reading %zd bytes from %s",
+							snprintf(g->Message, sizeof(g->Message), "Error %d reading %zd bytes from %s",
 								errno, lrecl, fn);
 							str = strcpy(result, g->Message);
 						}	else
@@ -4778,11 +4778,11 @@ char *bfile_bjson(UDF_INIT *initid, UDF_ARGS *args, char *result,
 							binszp = newloc - (size_t)jsp;
 
 							if (fwrite(&binszp, sizeof(binszp), 1, fout) != 1) {
-								sprintf(g->Message, "Error %d writing %zd bytes to %s", 
+								snprintf(g->Message, sizeof(g->Message), "Error %d writing %zd bytes to %s", 
 									errno, sizeof(binszp), ofn);
 								str = strcpy(result, g->Message);
 							} else if (fwrite(jsp, binszp, 1, fout) != 1) {
-								sprintf(g->Message, "Error %d writing %zd bytes to %s", 
+								snprintf(g->Message, sizeof(g->Message), "Error %d writing %zd bytes to %s", 
 									errno, binszp, ofn);
 								str = strcpy(result, g->Message);
 							} else

--- a/storage/connect/cmgoconn.cpp
+++ b/storage/connect/cmgoconn.cpp
@@ -175,7 +175,7 @@ bool CMgoConn::Connect(PGLOBAL g)
 	Uri = mongoc_uri_new_with_error(Pcg->Uristr, &Error);
 
 	if (!Uri) {
-		sprintf(g->Message, "Failed to parse URI: \"%s\" Msg: %s",
+		snprintf(g->Message, sizeof(g->Message), "Failed to parse URI: \"%s\" Msg: %s",
 			Pcg->Uristr, Error.message);
 		return true;
 	}	// endif Uri
@@ -196,7 +196,7 @@ bool CMgoConn::Connect(PGLOBAL g)
 	Client = mongoc_client_new_from_uri (Uri);
 
 	if (!Client) {
-		sprintf(g->Message, "Failed to get Client");
+		snprintf(g->Message, sizeof(g->Message), "Failed to get Client");
 		return true;
 	}	// endif Client
 
@@ -212,7 +212,7 @@ bool CMgoConn::Connect(PGLOBAL g)
 	Collection = mongoc_client_get_collection(Client, Pcg->Db_name, Pcg->Coll_name);
 
 	if (!Collection) {
-		sprintf(g->Message, "Failed to get Collection %s.%s",
+		snprintf(g->Message, sizeof(g->Message), "Failed to get Collection %s.%s",
 			      Pcg->Db_name, Pcg->Coll_name);
 		return true;
 	}	// endif Collection
@@ -420,7 +420,7 @@ bool CMgoConn::MakeCursor(PGLOBAL g)
 		Query = bson_new_from_json((const uint8_t *)p, -1, &Error);
 
 		if (!Query) {
-			sprintf(g->Message, "Wrong pipeline: %s", Error.message);
+			snprintf(g->Message, sizeof(g->Message), "Wrong pipeline: %s", Error.message);
 			return true;
 		}	// endif Query
 
@@ -428,7 +428,7 @@ bool CMgoConn::MakeCursor(PGLOBAL g)
 			                                   Query, NULL, NULL);
 
 		if (mongoc_cursor_error(Cursor, &Error)) {
-			sprintf(g->Message, "Mongo aggregate Failure: %s", Error.message);
+			snprintf(g->Message, sizeof(g->Message), "Mongo aggregate Failure: %s", Error.message);
 			return true;
 		} // endif error
 
@@ -468,7 +468,7 @@ bool CMgoConn::MakeCursor(PGLOBAL g)
 			Query = bson_new_from_json((const uint8_t *)s->GetStr(), -1, &Error);
 
 			if (!Query) {
-				sprintf(g->Message, "Wrong filter: %s", Error.message);
+				snprintf(g->Message, sizeof(g->Message), "Wrong filter: %s", Error.message);
 				return true;
 			}	// endif Query
 
@@ -503,7 +503,7 @@ bool CMgoConn::MakeCursor(PGLOBAL g)
 			Opts = bson_new_from_json((const uint8_t *)p, -1, &Error);
 
 			if (!Opts) {
-				sprintf(g->Message, "Wrong options: %s", Error.message);
+				snprintf(g->Message, sizeof(g->Message), "Wrong options: %s", Error.message);
 				return true;
 			} // endif Opts
 
@@ -532,7 +532,7 @@ int CMgoConn::ReadNext(PGLOBAL g)
 			htrc("%s\n", GetDocument(g));
 
 	} else if (mongoc_cursor_error(Cursor, &Error)) {
-		sprintf(g->Message, "Mongo Cursor Failure: %s", Error.message);
+		snprintf(g->Message, sizeof(g->Message), "Mongo Cursor Failure: %s", Error.message);
 		rc = RC_FX;
 	} else
 		rc = RC_EF;
@@ -683,7 +683,7 @@ int CMgoConn::Write(PGLOBAL g)
 
 			if (!mongoc_collection_insert(Collection, MONGOC_INSERT_NONE,
 				                            Fpc->Child, NULL, &Error)) {
-				sprintf(g->Message, "Mongo insert: %s", Error.message);
+				snprintf(g->Message, sizeof(g->Message), "Mongo insert: %s", Error.message);
 				rc = RC_FX;
 			} // endif insert
 
@@ -698,11 +698,11 @@ int CMgoConn::Write(PGLOBAL g)
 			} // endif trace
 
 			if (!doc) {
-				sprintf(g->Message, "bson_new_from_json: %s", Error.message);
+				snprintf(g->Message, sizeof(g->Message), "bson_new_from_json: %s", Error.message);
 				rc = RC_FX;
 			}	else if (!mongoc_collection_insert(Collection,
 				         MONGOC_INSERT_NONE, doc, NULL, &Error)) {
-				sprintf(g->Message, "Mongo insert: %s", Error.message);
+				snprintf(g->Message, sizeof(g->Message), "Mongo insert: %s", Error.message);
 				bson_destroy(doc);
 				rc = RC_FX;
 			} // endif insert
@@ -759,14 +759,14 @@ int CMgoConn::Write(PGLOBAL g)
 				if (rc == RC_OK)
 					if (!mongoc_collection_update(Collection, MONGOC_UPDATE_NONE,
 						query, update, NULL, &Error)) {
-						sprintf(g->Message, "Mongo update: %s", Error.message);
+						snprintf(g->Message, sizeof(g->Message), "Mongo update: %s", Error.message);
 						rc = RC_FX;
 					} // endif update
 
 				bson_destroy(update);
 			} else if (!mongoc_collection_remove(Collection,
 				MONGOC_REMOVE_SINGLE_REMOVE, query, NULL, &Error)) {
-				sprintf(g->Message, "Mongo delete: %s", Error.message);
+				snprintf(g->Message, sizeof(g->Message), "Mongo delete: %s", Error.message);
 				rc = RC_FX;
 			} // endif remove
 
@@ -790,7 +790,7 @@ bool CMgoConn::DocDelete(PGLOBAL g)
 
 	if (!mongoc_collection_remove(Collection, MONGOC_REMOVE_NONE,
 		                            Query, NULL, &Error)) {
-		sprintf(g->Message, "Mongo remove all: %s", Error.message);
+		snprintf(g->Message, sizeof(g->Message), "Mongo remove all: %s", Error.message);
 		return true;
 	}	// endif remove
 
@@ -843,7 +843,7 @@ char *CMgoConn::Mini(PGLOBAL g, PCOL colp, const bson_t *bson, bool b)
 		s = str = bson_as_json(bson, &len);
 
 	if (len > (size_t)colp->GetLength()) {
-		sprintf(g->Message, "Value too long for column %s", colp->GetName());
+		snprintf(g->Message, sizeof(g->Message), "Value too long for column %s", colp->GetName());
 		bson_free(str);
 		throw (int)TYPE_AM_MGO;
 	}	// endif len
@@ -1061,7 +1061,7 @@ bool CMgoConn::AddValue(PGLOBAL g, PCOL colp, bson_t *doc, char *key, bool upd)
 			rc = BSON_APPEND_DATE_TIME(doc, key, value->GetBigintValue() * 1000);
 			break;
 		default:
-			sprintf(g->Message, "Type %d not supported yet", colp->GetResultType());
+			snprintf(g->Message, sizeof(g->Message), "Type %d not supported yet", colp->GetResultType());
 			return true;
 	} // endswitch Buf_Type
 

--- a/storage/connect/colblk.cpp
+++ b/storage/connect/colblk.cpp
@@ -177,7 +177,7 @@ bool COLBLK::InitValue(PGLOBAL g)
 /***********************************************************************/
 bool COLBLK::SetBuffer(PGLOBAL g, PVAL, bool, bool)
   {
-  sprintf(g->Message, MSG(UNDEFINED_AM), "SetBuffer");
+  snprintf(g->Message, sizeof(g->Message), MSG(UNDEFINED_AM), "SetBuffer");
   return true;
   } // end of SetBuffer
 
@@ -196,7 +196,7 @@ int COLBLK::GetLengthEx(void)
 /***********************************************************************/
 void COLBLK::ReadColumn(PGLOBAL g)
 {
-  sprintf(g->Message, MSG(UNDEFINED_AM), "ReadColumn");
+  snprintf(g->Message, sizeof(g->Message), MSG(UNDEFINED_AM), "ReadColumn");
 	throw (int)TYPE_COLBLK;
 } // end of ReadColumn
 
@@ -207,7 +207,7 @@ void COLBLK::ReadColumn(PGLOBAL g)
 /***********************************************************************/
 void COLBLK::WriteColumn(PGLOBAL g)
 {
-  sprintf(g->Message, MSG(UNDEFINED_AM), "WriteColumn");
+  snprintf(g->Message, sizeof(g->Message), MSG(UNDEFINED_AM), "WriteColumn");
 	throw (int)TYPE_COLBLK;
 } // end of WriteColumn
 
@@ -261,7 +261,7 @@ SPCBLK::SPCBLK(PCOLUMN cp)
 /***********************************************************************/
 void SPCBLK::WriteColumn(PGLOBAL g)
 {
-  sprintf(g->Message, MSG(SPCOL_READONLY), Name);
+  snprintf(g->Message, sizeof(g->Message), MSG(SPCOL_READONLY), Name);
 	throw (int)TYPE_COLBLK;
 } // end of WriteColumn
 

--- a/storage/connect/connect.cc
+++ b/storage/connect/connect.cc
@@ -148,7 +148,7 @@ bool CntCheckDB(PGLOBAL g, PHC handler, const char *pathname)
   /*********************************************************************/
   /*  All is correct.                                                  */
   /*********************************************************************/
-  sprintf(g->Message, MSG(DATABASE_LOADED), "???");
+  snprintf(g->Message, sizeof(g->Message), MSG(DATABASE_LOADED), "???");
 
   if (trace(1))
     printf("msg=%s\n", g->Message);
@@ -268,7 +268,7 @@ bool CntOpenTable(PGLOBAL g, PTDB tdbp, MODE mode, char *c1, char *c2,
 
 			if (!colp && !(mode == MODE_INSERT && tdbp->IsSpecial(p))) {
 				if (g->Message[0] == 0)
-					sprintf(g->Message, MSG(COL_ISNOT_TABLE), p, tdbp->GetName());
+					snprintf(g->Message, sizeof(g->Message), MSG(COL_ISNOT_TABLE), p, tdbp->GetName());
 
 				throw 1;
 			} // endif colp
@@ -304,7 +304,7 @@ bool CntOpenTable(PGLOBAL g, PTDB tdbp, MODE mode, char *c1, char *c2,
             throw 7;
           }
         }
-				sprintf(g->Message, MSG(INV_UPDT_TABLE), tdbp->GetName());
+				snprintf(g->Message, sizeof(g->Message), MSG(INV_UPDT_TABLE), tdbp->GetName());
 				throw 4;
 			} // endif tp
 
@@ -633,7 +633,7 @@ int CntIndexInit(PGLOBAL g, PTDB ptdb, int id, bool sorted)
   if (!ptdb)
     return -1;
   else if (!ptdb->GetDef()->Indexable()) {
-    sprintf(g->Message, MSG(TABLE_NO_INDEX), ptdb->GetName());
+    snprintf(g->Message, sizeof(g->Message), MSG(TABLE_NO_INDEX), ptdb->GetName());
     return 0;
   } else if (ptdb->GetDef()->Indexable() == 3) {
     return 1;
@@ -666,7 +666,7 @@ int CntIndexInit(PGLOBAL g, PTDB ptdb, int id, bool sorted)
       break;
 
   if (!xdp) {
-    sprintf(g->Message, "Wrong index ID %d", id);
+    snprintf(g->Message, sizeof(g->Message), "Wrong index ID %d", id);
     return 0;
     } // endif xdp
 
@@ -725,7 +725,7 @@ RCODE CntIndexRead(PGLOBAL g, PTDB ptdb, OPVAL op,
     x= ptdb->GetDef()->Indexable();
 
   if (!x) {
-    sprintf(g->Message, MSG(TABLE_NO_INDEX), ptdb->GetName());
+    snprintf(g->Message, sizeof(g->Message), MSG(TABLE_NO_INDEX), ptdb->GetName());
     return RC_FX;
   } else if (x == 2) {
     // Remote index. Only used in read mode
@@ -748,13 +748,13 @@ RCODE CntIndexRead(PGLOBAL g, PTDB ptdb, OPVAL op,
   // Set reference values and index operator
   if (!tdbp->GetLink() || !tdbp->GetKindex()) {
 //  if (!tdbp->To_Xdp) {
-      sprintf(g->Message, "Index not initialized for table %s", tdbp->GetName());
+      snprintf(g->Message, sizeof(g->Message), "Index not initialized for table %s", tdbp->GetName());
       return RC_FX;
 #if 0
       } // endif !To_Xdp
     // Now it's time to make the dynamic index
     if (tdbp->InitialyzeIndex(g, NULL, false)) {
-      sprintf(g->Message, "Fail to make dynamic index %s", 
+      snprintf(g->Message, sizeof(g->Message), "Fail to make dynamic index %s", 
                           tdbp->To_Xdp->GetName());
       return RC_FX;
       } // endif MakeDynamicIndex
@@ -794,10 +794,10 @@ RCODE CntIndexRead(PGLOBAL g, PTDB ptdb, OPVAL op,
 
         if (rcb) {
           if (tdbp->RowNumber(g))
-            sprintf(g->Message, "Out of range value for column %s at row %d",
+            snprintf(g->Message, sizeof(g->Message), "Out of range value for column %s at row %d",
                     colp->GetName(), tdbp->RowNumber(g));
           else
-            sprintf(g->Message, "Out of range value for column %s",
+            snprintf(g->Message, sizeof(g->Message), "Out of range value for column %s",
                     colp->GetName());
 
           PushWarning(g, tdbp);
@@ -856,7 +856,7 @@ int CntIndexRange(PGLOBAL g, PTDB ptdb, const uchar* *key, uint *len,
   x= ptdb->GetDef()->Indexable();
 
   if (!x) {
-    sprintf(g->Message, MSG(TABLE_NO_INDEX), ptdb->GetName());
+    snprintf(g->Message, sizeof(g->Message), MSG(TABLE_NO_INDEX), ptdb->GetName());
     DBUG_PRINT("Range", ("%s", g->Message));
     return -1;
   } else if (x == 2) {
@@ -876,7 +876,7 @@ int CntIndexRange(PGLOBAL g, PTDB ptdb, const uchar* *key, uint *len,
 
   if (!tdbp->GetKindex() || !tdbp->GetLink()) {
     if (!tdbp->GetXdp()) {
-      sprintf(g->Message, "Index not initialized for table %s", tdbp->GetName());
+      snprintf(g->Message, sizeof(g->Message), "Index not initialized for table %s", tdbp->GetName());
       DBUG_PRINT("Range", ("%s", g->Message));
       return -1;
     } else       // Dynamic index
@@ -917,11 +917,11 @@ int CntIndexRange(PGLOBAL g, PTDB ptdb, const uchar* *key, uint *len,
 
           if (rcb) {
             if (tdbp->RowNumber(g))
-              sprintf(g->Message,
+              snprintf(g->Message, sizeof(g->Message),
                       "Out of range value for column %s at row %d",
                       colp->GetName(), tdbp->RowNumber(g));
             else
-              sprintf(g->Message, "Out of range value for column %s",
+              snprintf(g->Message, sizeof(g->Message), "Out of range value for column %s",
                       colp->GetName());
 
             PushWarning(g, tdbp);

--- a/storage/connect/domdoc.cpp
+++ b/storage/connect/domdoc.cpp
@@ -33,7 +33,7 @@ using namespace MSXML2;
 inline bool TestHr(PGLOBAL g, HRESULT hr)
   {
   if FAILED(hr) {
-    sprintf(g->Message, "%s, hr=%d", MSG(COM_ERROR), hr);
+    snprintf(g->Message, sizeof(g->Message), "%s, hr=%d", MSG(COM_ERROR), hr);
     return true;
   } else
     return false;
@@ -65,7 +65,7 @@ void CloseXMLFile(PGLOBAL g, PFBLOCK fp, bool all)
 
     } catch(_com_error e)  {
 			char *p = _com_util::ConvertBSTRToString(e.Description());
-      sprintf(g->Message, "%s %s", MSG(COM_ERROR), p);
+      snprintf(g->Message, sizeof(g->Message), "%s %s", MSG(COM_ERROR), p);
 			delete[] p;
     } catch(...) {}
 
@@ -242,7 +242,7 @@ int DOMDOC::DumpDoc(PGLOBAL g, char *ofn)
   try {
     Docp->save(ofn);
   } catch(_com_error e)  {
-    sprintf(g->Message, "%s: %s", MSG(COM_ERROR), 
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", MSG(COM_ERROR), 
             _com_util::ConvertBSTRToString(e.Description()));
     rc = -1;
   }  catch(...) {}
@@ -332,16 +332,16 @@ RCODE DOMNODE::GetContent(PGLOBAL g, char *buf, int len)
       switch (lsr) {
         case 0:
         case ERROR_INSUFFICIENT_BUFFER:      // 122L
-          sprintf(g->Message, "Truncated %s content", GetName(g));
+          snprintf(g->Message, sizeof(g->Message), "Truncated %s content", GetName(g));
           rc = RC_INFO;
           break;
         case ERROR_NO_UNICODE_TRANSLATION:   // 1113L
-          sprintf(g->Message, "Invalid character(s) in %s content",
+          snprintf(g->Message, sizeof(g->Message), "Invalid character(s) in %s content",
                               GetName(g));
           rc = RC_INFO;
           break;
         default:
-          sprintf(g->Message, "System error getting %s content",
+          snprintf(g->Message, sizeof(g->Message), "System error getting %s content",
                               GetName(g));
           rc = RC_FX;
           break;
@@ -370,7 +370,7 @@ bool DOMNODE::SetContent(PGLOBAL g, char *txtp, int len)
 
   if (!MultiByteToWideChar(CP_UTF8, 0, txtp, strlen(txtp) + 1,
                                        Ws, Len + 1)) {
-    sprintf(g->Message, MSG(WS_CONV_ERR), txtp);
+    snprintf(g->Message, sizeof(g->Message), MSG(WS_CONV_ERR), txtp);
     return true;
     } // endif
 
@@ -451,7 +451,7 @@ PXNODE DOMNODE::SelectSingleNode(PGLOBAL g, char *xp, PXNODE np)
       } // endif dnp
 
   } catch(_com_error e) {
-    sprintf(g->Message, "%s: %s", MSG(COM_ERROR), 
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", MSG(COM_ERROR), 
             _com_util::ConvertBSTRToString(e.Description()));
   } catch(...) {}
 
@@ -710,16 +710,16 @@ RCODE DOMATTR::GetText(PGLOBAL g, char *buf, int len)
     switch (lsr) {
       case 0:
       case ERROR_INSUFFICIENT_BUFFER:      // 122L
-        sprintf(g->Message, "Truncated %s content", GetName(g));
+        snprintf(g->Message, sizeof(g->Message), "Truncated %s content", GetName(g));
         rc = RC_INFO;
         break;
       case ERROR_NO_UNICODE_TRANSLATION:   // 1113L
-        sprintf(g->Message, "Invalid character(s) in %s content",
+        snprintf(g->Message, sizeof(g->Message), "Invalid character(s) in %s content",
                             GetName(g));
         rc = RC_INFO;
         break;
       default:
-        sprintf(g->Message, "System error getting %s content",
+        snprintf(g->Message, sizeof(g->Message), "System error getting %s content",
                             GetName(g));
         rc = RC_FX;
         break;
@@ -745,7 +745,7 @@ bool DOMATTR::SetText(PGLOBAL g, char *txtp, int len)
 
   if (!MultiByteToWideChar(CP_UTF8, 0, txtp, strlen(txtp) + 1,
                                        Ws, Len + 1)) {
-    sprintf(g->Message, MSG(WS_CONV_ERR), txtp);
+    snprintf(g->Message, sizeof(g->Message), MSG(WS_CONV_ERR), txtp);
     return true;
     } // endif
 

--- a/storage/connect/filamap.cpp
+++ b/storage/connect/filamap.cpp
@@ -163,7 +163,7 @@ bool MAPFAM::OpenTableFile(PGLOBAL g)
       DWORD rc = GetLastError();
 
       if (!(*g->Message))
-        sprintf(g->Message, MSG(OPEN_MODE_ERROR),
+        snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR),
                 "map", (int) rc, filename);
 
       if (trace(1))
@@ -192,7 +192,7 @@ bool MAPFAM::OpenTableFile(PGLOBAL g)
 
     if (!Memory) {
       CloseFileHandle(hFile);
-      sprintf(g->Message, MSG(MAP_VIEW_ERROR),
+      snprintf(g->Message, sizeof(g->Message), MSG(MAP_VIEW_ERROR),
                           filename, GetLastError());
       return true;
       } // endif Memory
@@ -473,7 +473,7 @@ int MAPFAM::DeleteRecords(PGLOBAL g, int irc)
       DWORD drc = SetFilePointer(fp->Handle, n, NULL, FILE_BEGIN);
 
       if (drc == 0xFFFFFFFF) {
-        sprintf(g->Message, MSG(FUNCTION_ERROR),
+        snprintf(g->Message, sizeof(g->Message), MSG(FUNCTION_ERROR),
                             "SetFilePointer", GetLastError());
         CloseHandle(fp->Handle);
         return RC_FX;
@@ -483,7 +483,7 @@ int MAPFAM::DeleteRecords(PGLOBAL g, int irc)
        htrc("done, Tpos=%p newsize=%d drc=%d\n", Tpos, n, drc);
 
       if (!SetEndOfFile(fp->Handle)) {
-        sprintf(g->Message, MSG(FUNCTION_ERROR),
+        snprintf(g->Message, sizeof(g->Message), MSG(FUNCTION_ERROR),
                             "SetEndOfFile", GetLastError());
         CloseHandle(fp->Handle);
         return RC_FX;
@@ -491,7 +491,7 @@ int MAPFAM::DeleteRecords(PGLOBAL g, int irc)
 
 #else    // UNIX
       if (ftruncate(fp->Handle, (off_t)n)) {
-        sprintf(g->Message, MSG(TRUNCATE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(TRUNCATE_ERROR), strerror(errno));
         close(fp->Handle);
         return RC_FX;
         } // endif

--- a/storage/connect/filamdbf.cpp
+++ b/storage/connect/filamdbf.cpp
@@ -158,7 +158,7 @@ static int dbfhead(PGLOBAL g, FILE *file, PCSZ fn, DBFHEADER *buf)
 
   // Check last byte(s) of header
   if (fseek(file, buf->Headlen() - dbc, SEEK_SET) != 0) {
-    sprintf(g->Message, MSG(BAD_HEADER), fn);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_HEADER), fn);
     return RC_FX;
   } // endif fseek
 
@@ -169,7 +169,7 @@ static int dbfhead(PGLOBAL g, FILE *file, PCSZ fn, DBFHEADER *buf)
 
   // Some files have just 1D others have 1D00 following fields
   if (endmark[0] != EOH && endmark[1] != EOH) {
-    sprintf(g->Message, MSG(NO_0DH_HEAD), dbc);
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_0DH_HEAD), dbc);
 
     if (rc == RC_OK)
       return RC_FX;
@@ -215,7 +215,7 @@ static int dbfields(PGLOBAL g, DBFHEADER* hdrp)
 
 	// Some headers just have 1D others have 1D00 following fields
 	if (endmark[0] != EOH && endmark[1] != EOH) {
-		sprintf(g->Message, MSG(NO_0DH_HEAD), dbc);
+		snprintf(g->Message, sizeof(g->Message), MSG(NO_0DH_HEAD), dbc);
 
 		if (rc == RC_OK)
 			return RC_FX;
@@ -353,7 +353,7 @@ PQRYRES DBFColumns(PGLOBAL g, PCSZ dp, PCSZ fn, PTOS topt, bool info)
 		if (topt->zipped) {
 			tfp = (DESCRIPTOR*)((char*)tfp + HEADLEN);
 		} else if (fread(tfp, HEADLEN, 1, infile) != 1) {
-      sprintf(g->Message, MSG(ERR_READING_REC), field+1, fn);
+      snprintf(g->Message, sizeof(g->Message), MSG(ERR_READING_REC), field+1, fn);
       goto err;
     } // endif fread
 
@@ -394,7 +394,7 @@ PQRYRES DBFColumns(PGLOBAL g, PCSZ dp, PCSZ fn, PTOS topt, bool info)
         break;
       default:
         if (!info) {
-          sprintf(g->Message, MSG(BAD_DBF_TYPE), tfp->Type
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_DBF_TYPE), tfp->Type
                                                , tfp->Name);
           goto err;
           } // endif info
@@ -543,7 +543,7 @@ int DBFFAM::Cardinality(PGLOBAL g)
 
 		if (rln && Lrecl != rln) {
 			// This happens always on some Linux platforms
-			sprintf(g->Message, MSG(BAD_LRECL), Lrecl, (ushort)rln);
+			snprintf(g->Message, sizeof(g->Message), MSG(BAD_LRECL), Lrecl, (ushort)rln);
 
 			if (Accept) {
 				Lrecl = rln;
@@ -610,7 +610,7 @@ bool DBFFAM::OpenTableFile(PGLOBAL g)
       strcpy(opmode, "a+");
       break;
     default:
-      sprintf(g->Message, MSG(BAD_OPEN_MODE), mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
       return true;
     } // endswitch Mode
 
@@ -657,7 +657,7 @@ bool DBFFAM::AllocateBuffer(PGLOBAL g)
     /*  translating 0A bytes (LF) into 0D0A (CRLF) by Windows in text mode. */
     /************************************************************************/
     if (_setmode(_fileno(Stream), _O_BINARY) == -1) {
-      sprintf(g->Message, MSG(BIN_MODE_FAIL), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(BIN_MODE_FAIL), strerror(errno));
       return true;
       } // endif setmode
 #endif   // _WIN32
@@ -686,7 +686,7 @@ bool DBFFAM::AllocateBuffer(PGLOBAL g)
           } // endif Flags
 
       if (Lrecl != reclen) {
-        sprintf(g->Message, MSG(BAD_LRECL), Lrecl, reclen);
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_LRECL), Lrecl, reclen);
 
 				if (Accept) {
 					Lrecl = reclen;
@@ -728,7 +728,7 @@ bool DBFFAM::AllocateBuffer(PGLOBAL g)
             case 'D':           // Date
               break;
             default:            // Should never happen
-              sprintf(g->Message, MSG(BAD_DBF_TYPE),
+              snprintf(g->Message, sizeof(g->Message), MSG(BAD_DBF_TYPE),
                                   c, cdp->GetName());
               return true;
             } // endswitch c
@@ -742,7 +742,7 @@ bool DBFFAM::AllocateBuffer(PGLOBAL g)
 
       //  Now write the header
       if (fwrite(header, 1, hlen, Stream) != (unsigned)hlen) {
-        sprintf(g->Message, MSG(FWRITE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(FWRITE_ERROR), strerror(errno));
         return true;
         } // endif fwrite
 
@@ -770,7 +770,7 @@ bool DBFFAM::AllocateBuffer(PGLOBAL g)
 
     if ((rc = dbfhead(g, Stream, Tdbp->GetFile(g), &header)) == RC_OK) {
       if (Lrecl != (int)header.Reclen()) {
-        sprintf(g->Message, MSG(BAD_LRECL), Lrecl, header.Reclen());
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_LRECL), Lrecl, header.Reclen());
 
 				if (Accept) {
 					Lrecl = header.Reclen();
@@ -800,7 +800,7 @@ bool DBFFAM::AllocateBuffer(PGLOBAL g)
     rc = fseek(Stream, Headlen, SEEK_SET);
 
   if (rc) {
-    sprintf(g->Message, MSG(BAD_DBF_FILE), Tdbp->GetFile(g));
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_DBF_FILE), Tdbp->GetFile(g));
     return true;
     } // endif fseek
 
@@ -858,7 +858,7 @@ int DBFFAM::ReadBuffer(PGLOBAL g)
       break;
     default:
       if (++Nerr >= Maxerr && !Accept) {
-        sprintf(g->Message, MSG(BAD_DBF_REC), Tdbp->GetFile(g), GetRowID());
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_DBF_REC), Tdbp->GetFile(g), GetRowID());
         rc = RC_FX;
       } else
         rc = (Accept) ? RC_OK : RC_NF;
@@ -883,9 +883,9 @@ bool DBFFAM::CopyHeader(PGLOBAL g)
     if (fseek(Stream, 0, SEEK_SET))
       strcpy(g->Message, "Seek error in CopyHeader");
     else if ((n = fread(hdr, 1, hlen, Stream)) != hlen)
-      sprintf(g->Message, MSG(BAD_READ_NUMBER), (int) n, To_File);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_READ_NUMBER), (int) n, To_File);
     else if ((n = fwrite(hdr, 1, hlen, T_Stream)) != hlen)
-      sprintf(g->Message, MSG(WRITE_STRERROR), To_Fbt->Fname
+      snprintf(g->Message, sizeof(g->Message), MSG(WRITE_STRERROR), To_Fbt->Fname
                                              , strerror(errno));
     else if (fseek(Stream, pos, SEEK_SET))
       strcpy(g->Message, "Seek error in CopyHeader");
@@ -911,16 +911,16 @@ int DBFFAM::InitDelete(PGLOBAL g, int fpos, int spos)
   if (Nrec != 1)
     strcpy(g->Message, "Cannot delete in block mode");
   else if (fseek(Stream, Headlen + fpos * Lrecl, SEEK_SET))
-    sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+    snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
   else if (fread(To_Buf, 1, lrecl, Stream) != lrecl)
-    sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(errno));
   else
     *To_Buf = '*';
 
   if (fseek(Stream, Headlen + fpos * Lrecl, SEEK_SET))
-    sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+    snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
   else if (fwrite(To_Buf, 1, lrecl, Stream) != lrecl)
-    sprintf(g->Message, MSG(FWRITE_ERROR), strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(FWRITE_ERROR), strerror(errno));
   else
     rc = RC_NF;     // Ok, Nothing else to do 
 
@@ -1064,7 +1064,7 @@ int DBMFAM::Cardinality(PGLOBAL g)
 
 		if (rln && Lrecl != rln) {
 			// This happens always on some Linux platforms
-			sprintf(g->Message, MSG(BAD_LRECL), Lrecl, (ushort)rln);
+			snprintf(g->Message, sizeof(g->Message), MSG(BAD_LRECL), Lrecl, (ushort)rln);
 
 			if (Accept) {
 				Lrecl = rln;
@@ -1117,7 +1117,7 @@ bool DBMFAM::AllocateBuffer(PGLOBAL g)
     DBFHEADER *hp = (DBFHEADER*)Memory;
 
     if (Lrecl != (int)hp->Reclen()) {
-      sprintf(g->Message, MSG(BAD_LRECL), Lrecl, hp->Reclen());
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_LRECL), Lrecl, hp->Reclen());
 
 			if (Accept) {
 				Lrecl = hp->Reclen();
@@ -1170,7 +1170,7 @@ int DBMFAM::ReadBuffer(PGLOBAL g)
       break;
     default:
       if (++Nerr >= Maxerr && !Accept) {
-        sprintf(g->Message, MSG(BAD_DBF_REC), Tdbp->GetFile(g), GetRowID());
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_DBF_REC), Tdbp->GetFile(g), GetRowID());
         rc = RC_FX;
       } else
         rc = (Accept) ? RC_OK : RC_NF;

--- a/storage/connect/filamfix.cpp
+++ b/storage/connect/filamfix.cpp
@@ -236,10 +236,10 @@ int FIXFAM::WriteModifiedBlock(PGLOBAL g)
 
   // Fpos is last position, Headlen is DBF file header length
   else if (!moved && fseek(Stream, Headlen + Fpos * Lrecl, SEEK_SET)) {
-    sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+    snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
     rc = RC_FX;
   } else if (fwrite(To_Buf, Lrecl, Rbuf, T_Stream) != (size_t)Rbuf) {
-    sprintf(g->Message, MSG(FWRITE_ERROR), strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(FWRITE_ERROR), strerror(errno));
     rc = RC_FX;
   } else
     Spos = Fpos + Nrec;           // + Rbuf ???
@@ -316,7 +316,7 @@ int FIXFAM::ReadBuffer(PGLOBAL g)
   if (CurBlk != OldBlk + 1)
     // Note: Headlen is for DBF tables
     if (fseek(Stream, Headlen + Fpos * Lrecl, SEEK_SET)) {
-      sprintf(g->Message, MSG(FSETPOS_ERROR), Fpos);
+      snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), Fpos);
       return RC_FX;
       } // endif fseek
 
@@ -337,9 +337,9 @@ int FIXFAM::ReadBuffer(PGLOBAL g)
     rc = RC_EF;
   } else {
 #if defined(_WIN32)
-    sprintf(g->Message, MSG(READ_ERROR), To_File, _strerror(NULL));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, _strerror(NULL));
 #else
-    sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(errno));
 #endif
 
     if (trace(1))
@@ -377,7 +377,7 @@ int FIXFAM::WriteBuffer(PGLOBAL g)
 
     //  Now start the writing process.
     if (fwrite(To_Buf, Lrecl, Rbuf, Stream) != (size_t)Rbuf) {
-      sprintf(g->Message, MSG(FWRITE_ERROR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(FWRITE_ERROR), strerror(errno));
       Closing = true;      // To tell CloseDB about a Write error
       return RC_FX;
       } // endif size
@@ -482,7 +482,7 @@ int FIXFAM::DeleteRecords(PGLOBAL g, int irc)
 
     if (moved) {
       if (fseek(Stream, Spos * Lrecl, SEEK_SET)) {
-        sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+        snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
         return RC_FX;
         } // endif fseek
 
@@ -524,13 +524,13 @@ int FIXFAM::DeleteRecords(PGLOBAL g, int irc)
       /*****************************************************************/
 #if defined(UNIX)
       if (ftruncate(h, (off_t)(Tpos * Lrecl))) {
-        sprintf(g->Message, MSG(TRUNCATE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(TRUNCATE_ERROR), strerror(errno));
         close(h);
         return RC_FX;
         } // endif
 #else
       if (chsize(h, Tpos * Lrecl)) {
-        sprintf(g->Message, MSG(CHSIZE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(CHSIZE_ERROR), strerror(errno));
         close(h);
         return RC_FX;
         } // endif
@@ -563,7 +563,7 @@ bool FIXFAM::MoveIntermediateLines(PGLOBAL g, bool *b)
     /*******************************************************************/
     if (!UseTemp || !*b)
       if (fseek(Stream, Headlen + Spos * Lrecl, SEEK_SET)) {
-        sprintf(g->Message, MSG(READ_SEEK_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(READ_SEEK_ERROR), strerror(errno));
         return true;
         } // endif
 
@@ -574,18 +574,18 @@ bool FIXFAM::MoveIntermediateLines(PGLOBAL g, bool *b)
       htrc("after read req=%d len=%d\n", req, len);
 
     if (len != req) {
-      sprintf(g->Message, MSG(DEL_READ_ERROR), (int) req, (int) len);
+      snprintf(g->Message, sizeof(g->Message), MSG(DEL_READ_ERROR), (int) req, (int) len);
       return true;
       } // endif len
 
     if (!UseTemp)         // Delete mode, cannot be a DBF file
       if (fseek(T_Stream, Tpos * Lrecl, SEEK_SET)) {
-        sprintf(g->Message, MSG(WRITE_SEEK_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(WRITE_SEEK_ERR), strerror(errno));
         return true;
         } // endif
 
     if ((len = fwrite(DelBuf, Lrecl, req, T_Stream)) != req) {
-      sprintf(g->Message, MSG(DEL_WRITE_ERROR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(DEL_WRITE_ERROR), strerror(errno));
       return true;
       } // endif
 
@@ -689,13 +689,13 @@ bool BGXFAM::BigSeek(PGLOBAL g, HANDLE h, BIGINT pos, int org)
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                   FORMAT_MESSAGE_IGNORE_INSERTS, NULL, drc, 0,
                   (LPTSTR)buf, sizeof(buf), NULL);
-    sprintf(g->Message, MSG(SFP_ERROR), buf);
+    snprintf(g->Message, sizeof(g->Message), MSG(SFP_ERROR), buf);
     return true;
     } // endif
 #else   // !_WIN32
   if (lseek64(h, pos, org) < 0) {
-//  sprintf(g->Message, MSG(ERROR_IN_LSK), errno);
-    sprintf(g->Message, "lseek64: %s", strerror(errno));
+//  snprintf(g->Message, sizeof(g->Message), MSG(ERROR_IN_LSK), errno);
+    snprintf(g->Message, sizeof(g->Message), "lseek64: %s", strerror(errno));
     printf("%s\n", g->Message);
     return true;
     } // endif
@@ -726,7 +726,7 @@ int BGXFAM::BigRead(PGLOBAL g __attribute__((unused)),
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                   FORMAT_MESSAGE_IGNORE_INSERTS, NULL, drc, 0,
                   (LPTSTR)buf, sizeof(buf), NULL);
-    sprintf(g->Message, MSG(READ_ERROR), To_File, buf);
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, buf);
 
     if (trace(2))
       htrc("BIGREAD: %s\n", g->Message);
@@ -771,7 +771,7 @@ bool BGXFAM::BigWrite(PGLOBAL g, HANDLE h, void *inbuf, int req)
                     (LPTSTR)buf, sizeof(buf), NULL);
       } // endelse brc
 
-    sprintf(g->Message, MSG(WRITE_STRERROR), fn, buf);
+    snprintf(g->Message, sizeof(g->Message), MSG(WRITE_STRERROR), fn, buf);
 
     if (trace(2))
       htrc("BIGWRITE: nbw=%d len=%d errno=%d %s\n",
@@ -786,7 +786,7 @@ bool BGXFAM::BigWrite(PGLOBAL g, HANDLE h, void *inbuf, int req)
   if (nbw != (ssize_t)len) {
     const char *fn = (h == Hfile) ? To_File : "Tempfile";
 
-    sprintf(g->Message, MSG(WRITE_STRERROR), fn, strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(WRITE_STRERROR), fn, strerror(errno));
 
     if (trace(2))
       htrc("BIGWRITE: nbw=%d len=%d errno=%d %s\n",
@@ -820,7 +820,7 @@ bool BGXFAM::OpenTableFile(PGLOBAL g)
   PDBUSER dbuserp = PlgGetUser(g);
 
   if ((To_Fb && To_Fb->Count) || Hfile != INVALID_HANDLE_VALUE) {
-    sprintf(g->Message, MSG(FILE_OPEN_YET), To_File);
+    snprintf(g->Message, sizeof(g->Message), MSG(FILE_OPEN_YET), To_File);
     return true;
     } // endif
 
@@ -869,7 +869,7 @@ bool BGXFAM::OpenTableFile(PGLOBAL g)
       creation = OPEN_ALWAYS;
       break;
     default:
-      sprintf(g->Message, MSG(BAD_OPEN_MODE), mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
       return true;
     } // endswitch
 
@@ -878,7 +878,7 @@ bool BGXFAM::OpenTableFile(PGLOBAL g)
 
   if (Hfile == INVALID_HANDLE_VALUE) {
     rc = GetLastError();
-    sprintf(g->Message, MSG(OPEN_ERROR), rc, mode, filename);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPEN_ERROR), rc, mode, filename);
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                   FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
                   (LPTSTR)filename, sizeof(filename), NULL);
@@ -929,7 +929,7 @@ bool BGXFAM::OpenTableFile(PGLOBAL g)
  //   tmode = S_IREAD | S_IWRITE;
       break;
     default:
-      sprintf(g->Message, MSG(BAD_OPEN_MODE), mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
       return true;
     } // endswitch
 
@@ -999,7 +999,7 @@ int BGXFAM::Cardinality(PGLOBAL g)
 
       if (h == INVALID_HANDLE_VALUE)
         if ((rc = GetLastError()) != ERROR_FILE_NOT_FOUND) {
-          sprintf(g->Message, MSG(OPEN_ERROR), rc, 10, filename);
+          snprintf(g->Message, sizeof(g->Message), MSG(OPEN_ERROR), rc, 10, filename);
           FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                         FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
                         (LPTSTR)filename, sizeof(filename), NULL);
@@ -1015,7 +1015,7 @@ int BGXFAM::Cardinality(PGLOBAL g)
       len.LowPart = GetFileSize(Hfile, (LPDWORD)&len.HighPart);
 
     if (len.LowPart == 0xFFFFFFFF && (rc = GetLastError()) != NO_ERROR) {
-      sprintf(g->Message, MSG(FILELEN_ERROR), "GetFileSize", filename);
+      snprintf(g->Message, sizeof(g->Message), MSG(FILELEN_ERROR), "GetFileSize", filename);
       return -2;
     } else
       fsize = len.QuadPart;
@@ -1032,7 +1032,7 @@ int BGXFAM::Cardinality(PGLOBAL g)
           htrc("  errno=%d ENOENT=%d\n", errno, ENOENT);
 
         if (errno != ENOENT) {
-          sprintf(g->Message, MSG(OPEN_ERROR_IS),
+          snprintf(g->Message, sizeof(g->Message), MSG(OPEN_ERROR_IS),
                               filename, strerror(errno));
           return -1;
         } else
@@ -1051,7 +1051,7 @@ int BGXFAM::Cardinality(PGLOBAL g)
     } // endif Hfile
 
     if (fsize < 0) {
-      sprintf(g->Message, MSG(FILELEN_ERROR), "lseek64", filename);
+      snprintf(g->Message, sizeof(g->Message), MSG(FILELEN_ERROR), "lseek64", filename);
       return -2;
       } // endif fsize
 
@@ -1060,14 +1060,14 @@ int BGXFAM::Cardinality(PGLOBAL g)
     // Check the real size of the file
     if (Padded && Blksize) {
       if (fsize % (BIGINT)Blksize) {
-        sprintf(g->Message, MSG(NOT_FIXED_LEN),
+        snprintf(g->Message, sizeof(g->Message), MSG(NOT_FIXED_LEN),
                             filename, (int)fsize, Lrecl);
         return -3;
       } else
         card = (int)(fsize / (BIGINT)Blksize) * Nrec;
 
     } else if (fsize % (BIGINT)Lrecl) {
-      sprintf(g->Message, MSG(NOT_FIXED_LEN), filename, (int)fsize, Lrecl);
+      snprintf(g->Message, sizeof(g->Message), MSG(NOT_FIXED_LEN), filename, (int)fsize, Lrecl);
       return -3;
     } else
       card = (int)(fsize / (BIGINT)Lrecl); // Fixed length file
@@ -1353,12 +1353,12 @@ int BGXFAM::DeleteRecords(PGLOBAL g, int irc)
       if (!SetEndOfFile(Hfile)) {
         DWORD drc = GetLastError();
 
-        sprintf(g->Message, MSG(SETEOF_ERROR), drc);
+        snprintf(g->Message, sizeof(g->Message), MSG(SETEOF_ERROR), drc);
         return RC_FX;
         } // endif error
 #else   // !_WIN32
       if (ftruncate64(Hfile, (BIGINT)(Tpos * Lrecl))) {
-        sprintf(g->Message, MSG(TRUNCATE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(TRUNCATE_ERROR), strerror(errno));
         return RC_FX;
         } // endif
 #endif  // !_WIN32
@@ -1392,7 +1392,7 @@ bool BGXFAM::OpenTempFile(PGLOBAL g)
 
   if (Tfile == INVALID_HANDLE_VALUE) {
     DWORD rc = GetLastError();
-    sprintf(g->Message, MSG(OPEN_ERROR), rc, MODE_INSERT, tempname);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPEN_ERROR), rc, MODE_INSERT, tempname);
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
               FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
               (LPTSTR)tempname, _MAX_PATH, NULL);
@@ -1404,7 +1404,7 @@ bool BGXFAM::OpenTempFile(PGLOBAL g)
 
   if (Tfile == INVALID_HANDLE_VALUE) {
     int rc = errno;
-    sprintf(g->Message, MSG(OPEN_ERROR), rc, MODE_INSERT, tempname);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPEN_ERROR), rc, MODE_INSERT, tempname);
     strcat(g->Message, strerror(errno));
     return true;
     } //endif Tfile
@@ -1442,7 +1442,7 @@ bool BGXFAM::MoveIntermediateLines(PGLOBAL g, bool *b)
     req = MY_MIN(n, Dbflen) * Lrecl;
 
     if ((nbr = BigRead(g, Hfile, DelBuf, req)) != req) {
-      sprintf(g->Message, MSG(DEL_READ_ERROR), req, nbr);
+      snprintf(g->Message, sizeof(g->Message), MSG(DEL_READ_ERROR), req, nbr);
       return true;
       } // endif nbr
 

--- a/storage/connect/filamgz.cpp
+++ b/storage/connect/filamgz.cpp
@@ -90,9 +90,9 @@ int GZFAM::Zerror(PGLOBAL g)
 
   if (errnum == Z_ERRNO)
 #if defined(_WIN32)
-    sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(NULL));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(NULL));
 #else   // !_WIN32
-    sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(errno));
 #endif  // !_WIN32
 
     return (errnum == Z_STREAM_END) ? RC_EF : RC_FX;
@@ -152,7 +152,7 @@ bool GZFAM::OpenTableFile(PGLOBAL g)
 //      Last = Nrec;              // For ZBKFAM
         Tdbp->ResetSize();
       } else {
-        sprintf(g->Message, MSG(NO_PART_DEL), "GZ");
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_PART_DEL), "GZ");
         return true;
       } // endif filter
 
@@ -161,7 +161,7 @@ bool GZFAM::OpenTableFile(PGLOBAL g)
       strcpy(opmode, "a+");
       break;
     default:
-      sprintf(g->Message, MSG(BAD_OPEN_MODE), mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
       return true;
     } // endswitch Mode
 
@@ -174,7 +174,7 @@ bool GZFAM::OpenTableFile(PGLOBAL g)
   Zfile = gzopen(PlugSetPath(filename, To_File, Tdbp->GetPath()), opmode);
 
   if (Zfile == NULL) {
-    sprintf(g->Message, MSG(GZOPEN_ERROR),
+    snprintf(g->Message, sizeof(g->Message), MSG(GZOPEN_ERROR),
             opmode, (int)errno, filename);
     strcat(strcat(g->Message, ": "), strerror(errno));
     return (mode == MODE_READ && errno == ENOENT)
@@ -249,13 +249,13 @@ int GZFAM::GetNextPos(void)
 /***********************************************************************/
 bool GZFAM::SetPos(PGLOBAL g, int pos __attribute__((unused)))
   {
-  sprintf(g->Message, MSG(NO_SETPOS_YET), "GZ");
+  snprintf(g->Message, sizeof(g->Message), MSG(NO_SETPOS_YET), "GZ");
   return true;
 #if 0
   Fpos = pos;
 
   if (fseek(Stream, Fpos, SEEK_SET)) {
-    sprintf(g->Message, MSG(FSETPOS_ERROR), Fpos);
+    snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), Fpos);
     return true;
     } // endif
 
@@ -655,7 +655,7 @@ int ZBKFAM::DeleteRecords(PGLOBAL g, int irc)
 
     if (!defp->SetIntCatInfo("Blocks", 0) ||
         !defp->SetIntCatInfo("Last", 0)) {
-      sprintf(g->Message, MSG(UPDATE_ERROR), "Header");
+      snprintf(g->Message, sizeof(g->Message), MSG(UPDATE_ERROR), "Header");
       return RC_FX;
     } else
       return RC_OK;
@@ -932,7 +932,7 @@ bool ZLBFAM::AllocateBuffer(PGLOBAL g)
 
 #if defined(NOLIB)
   if (!zlib && LoadZlib()) {
-    sprintf(g->Message, MSG(DLL_LOAD_ERROR), GetLastError(), "zlib.dll");
+    snprintf(g->Message, sizeof(g->Message), MSG(DLL_LOAD_ERROR), GetLastError(), "zlib.dll");
     return TRUE;
     } // endif zlib
 #endif
@@ -964,9 +964,9 @@ bool ZLBFAM::AllocateBuffer(PGLOBAL g)
 
   if (zrc != Z_OK) {
     if (Zstream->msg)
-      sprintf(g->Message, "%s error: %s", msg, Zstream->msg);
+      snprintf(g->Message, sizeof(g->Message), "%s error: %s", msg, Zstream->msg);
     else
-      sprintf(g->Message, "%s error: %d", msg, zrc);
+      snprintf(g->Message, sizeof(g->Message), "%s error: %d", msg, zrc);
 
     return TRUE;
     } // endif zrc
@@ -1017,9 +1017,9 @@ bool ZLBFAM::AllocateBuffer(PGLOBAL g)
         return FALSE;
       case RC_FX:
 #if defined(UNIX)
-        sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(errno));
 #else
-        sprintf(g->Message, MSG(READ_ERROR), To_File, _strerror(NULL));
+        snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, _strerror(NULL));
 #endif
         /* falls through */
       case RC_NF:
@@ -1028,7 +1028,7 @@ bool ZLBFAM::AllocateBuffer(PGLOBAL g)
 
     // Some old tables can have PlugDB in their header
     if (strcmp(To_Buf, "PlugDB")) {
-      sprintf(g->Message, MSG(BAD_HEADER), Tdbp->GetFile(g));
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_HEADER), Tdbp->GetFile(g));
       return TRUE;
       } // endif strcmp
 
@@ -1063,7 +1063,7 @@ int ZLBFAM::GetNextPos(void)
 /***********************************************************************/
 bool ZLBFAM::SetPos(PGLOBAL g, int pos __attribute__((unused)))
   {
-  sprintf(g->Message, MSG(NO_SETPOS_YET), "GZ");
+  snprintf(g->Message, sizeof(g->Message), MSG(NO_SETPOS_YET), "GZ");
   return true;
 #if 0 // All this must be checked
   if (pos < 0) {
@@ -1146,7 +1146,7 @@ int ZLBFAM::ReadBuffer(PGLOBAL g)
     // fseek is required only in non sequential reading
     if (CurBlk != OldBlk + 1)
       if (fseek(Stream, Fpos, SEEK_SET)) {
-        sprintf(g->Message, MSG(FSETPOS_ERROR), Fpos);
+        snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), Fpos);
         return RC_FX;
         } // endif fseek
 
@@ -1208,9 +1208,9 @@ int ZLBFAM::ReadBuffer(PGLOBAL g)
 
  err:
 #if defined(UNIX)
-  sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(errno));
+  snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(errno));
 #else
-  sprintf(g->Message, MSG(READ_ERROR), To_File, _strerror(NULL));
+  snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, _strerror(NULL));
 #endif
   return RC_FX;
   } // end of ReadBuffer
@@ -1226,7 +1226,7 @@ int ZLBFAM::ReadCompressedBuffer(PGLOBAL g, void *rdbuf)
     num_read++;
 
     if (Optimized && BlkLen != signed(*Zlenp + sizeof(int))) {
-      sprintf(g->Message, MSG(BAD_BLK_SIZE), CurBlk + 1);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_BLK_SIZE), CurBlk + 1);
       return RC_NF;
       } // endif BlkLen
 
@@ -1239,9 +1239,9 @@ int ZLBFAM::ReadCompressedBuffer(PGLOBAL g, void *rdbuf)
 
     if (zrc != Z_OK) {
       if (Zstream->msg)
-        sprintf(g->Message, MSG(FUNC_ERR_S), "inflate", Zstream->msg);
+        snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERR_S), "inflate", Zstream->msg);
       else
-        sprintf(g->Message, MSG(FUNCTION_ERROR), "inflate", (int)zrc);
+        snprintf(g->Message, sizeof(g->Message), MSG(FUNCTION_ERROR), "inflate", (int)zrc);
 
       return RC_NF;
       } // endif zrc
@@ -1329,9 +1329,9 @@ bool ZLBFAM::WriteCompressedBuffer(PGLOBAL g)
 
   if (zrc != Z_OK) {
     if (Zstream->msg)
-      sprintf(g->Message, MSG(FUNC_ERR_S), "deflate", Zstream->msg);
+      snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERR_S), "deflate", Zstream->msg);
     else
-      sprintf(g->Message, MSG(FUNCTION_ERROR), "deflate", (int)zrc);
+      snprintf(g->Message, sizeof(g->Message), MSG(FUNCTION_ERROR), "deflate", (int)zrc);
 
     return TRUE;
   } else
@@ -1341,7 +1341,7 @@ bool ZLBFAM::WriteCompressedBuffer(PGLOBAL g)
   BlkLen = *Zlenp + sizeof(int);
 
   if (fwrite(Zlenp, 1, BlkLen, Stream) != (size_t)BlkLen) {
-    sprintf(g->Message, MSG(FWRITE_ERROR), strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(FWRITE_ERROR), strerror(errno));
     return TRUE;
     } // endif size
 

--- a/storage/connect/filamtxt.cpp
+++ b/storage/connect/filamtxt.cpp
@@ -211,7 +211,7 @@ int TXTFAM::GetFileLength(PGLOBAL g)
 
   } else {
     if ((len = _filelength(h)) < 0)
-      sprintf(g->Message, MSG(FILELEN_ERROR), "_filelength", filename);
+      snprintf(g->Message, sizeof(g->Message), MSG(FILELEN_ERROR), "_filelength", filename);
 
     if (Eof && len)
       len--;              // Do not count the EOF character
@@ -240,13 +240,13 @@ int TXTFAM::Cardinality(PGLOBAL g)
         if (!(len % Blksize))
           card = (len / Blksize) * Nrec;
         else
-          sprintf(g->Message, MSG(NOT_FIXED_LEN), To_File, len, Lrecl);
+          snprintf(g->Message, sizeof(g->Message), MSG(NOT_FIXED_LEN), To_File, len, Lrecl);
 
       } else {
         if (!(len % Lrecl))
           card = len / (int)Lrecl;           // Fixed length file
         else
-          sprintf(g->Message, MSG(NOT_FIXED_LEN), To_File, len, Lrecl);
+          snprintf(g->Message, sizeof(g->Message), MSG(NOT_FIXED_LEN), To_File, len, Lrecl);
 
       } // endif Padded
 
@@ -511,7 +511,7 @@ int DOSFAM::GetFileLength(PGLOBAL g)
     len = TXTFAM::GetFileLength(g);
   else
     if ((len = _filelength(_fileno(Stream))) < 0)
-      sprintf(g->Message, MSG(FILELEN_ERROR), "_filelength", To_File);
+      snprintf(g->Message, sizeof(g->Message), MSG(FILELEN_ERROR), "_filelength", To_File);
 
   if (trace(1))
     htrc("File length=%d\n", len);
@@ -588,7 +588,7 @@ bool DOSFAM::OpenTableFile(PGLOBAL g)
       strcpy(opmode, "a+");
       break;
     default:
-      sprintf(g->Message, MSG(BAD_OPEN_MODE), mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
       return true;
     } // endswitch Mode
 
@@ -682,7 +682,7 @@ bool DOSFAM::SetPos(PGLOBAL g, int pos)
   Fpos = pos;
 
   if (fseek(Stream, Fpos, SEEK_SET)) {
-    sprintf(g->Message, MSG(FSETPOS_ERROR), Fpos);
+    snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), Fpos);
     return true;
     } // endif
 
@@ -696,7 +696,7 @@ bool DOSFAM::SetPos(PGLOBAL g, int pos)
 bool DOSFAM::RecordPos(PGLOBAL g)
   {
   if ((Fpos = ftell(Stream)) < 0) {
-    sprintf(g->Message, MSG(FTELL_ERROR), 0, strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(FTELL_ERROR), 0, strerror(errno));
 //  strcat(g->Message, " (possible wrong ENDING option value)");
     return true;
     } // endif Fpos
@@ -712,7 +712,7 @@ int DOSFAM::InitDelete(PGLOBAL g, int fpos, int spos)
   Fpos = fpos;
 
   if (fseek(Stream, spos, SEEK_SET)) {
-    sprintf(g->Message, MSG(FSETPOS_ERROR), Fpos);
+    snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), Fpos);
     return RC_FX;
     } // endif
 
@@ -732,9 +732,9 @@ int DOSFAM::SkipRecord(PGLOBAL g, bool header)
       return RC_EF;
 
 #if defined(_WIN32)
-    sprintf(g->Message, MSG(READ_ERROR), To_File, _strerror(NULL));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, _strerror(NULL));
 #else
-    sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(0));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(0));
 #endif
     return RC_FX;
     } // endif fgets
@@ -849,9 +849,9 @@ int DOSFAM::ReadBuffer(PGLOBAL g)
     rc = RC_EF;
   } else {
 #if defined(_WIN32)
-    sprintf(g->Message, MSG(READ_ERROR), To_File, _strerror(NULL));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, _strerror(NULL));
 #else
-    sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(0));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(0));
 #endif
 
     if (trace(1))
@@ -913,7 +913,7 @@ int DOSFAM::WriteBuffer(PGLOBAL g)
       // Update is directly written back into the file,
       //   with this (fast) method, record size cannot change.
       if (fseek(Stream, Fpos, SEEK_SET)) {
-        sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+        snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
         return RC_FX;
         } // endif
 
@@ -928,13 +928,13 @@ int DOSFAM::WriteBuffer(PGLOBAL g)
   /*  Now start the writing process.                                   */
   /*********************************************************************/
   if ((fputs(To_Buf, T_Stream)) == EOF) {
-    sprintf(g->Message, MSG(FPUTS_ERROR), strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(FPUTS_ERROR), strerror(errno));
     return RC_FX;
     } // endif EOF
 
   if (Tdbp->Mode == MODE_UPDATE && moved)
     if (fseek(Stream, curpos, SEEK_SET)) {
-      sprintf(g->Message, MSG(FSEEK_ERROR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(FSEEK_ERROR), strerror(errno));
       return RC_FX;
       } // endif
 
@@ -1010,7 +1010,7 @@ int DOSFAM::DeleteRecords(PGLOBAL g, int irc)
     /*******************************************************************/
     if (!UseTemp || moved)
       if (fseek(Stream, curpos, SEEK_SET)) {
-        sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+        snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
         return RC_FX;
         } // endif
 
@@ -1045,13 +1045,13 @@ int DOSFAM::DeleteRecords(PGLOBAL g, int irc)
       /*****************************************************************/
 #if defined(_WIN32)
       if (chsize(h, Tpos)) {
-        sprintf(g->Message, MSG(CHSIZE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(CHSIZE_ERROR), strerror(errno));
         close(h);
         return RC_FX;
         } // endif
 #else
       if (ftruncate(h, (off_t)Tpos)) {
-        sprintf(g->Message, MSG(TRUNCATE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(TRUNCATE_ERROR), strerror(errno));
         close(h);
         return RC_FX;
         } // endif
@@ -1106,7 +1106,7 @@ bool DOSFAM::MoveIntermediateLines(PGLOBAL g, bool *b)
   for (*b = false, n = Fpos - Spos; n > 0; n -= req) {
     if (!UseTemp || !*b)
       if (fseek(Stream, Spos, SEEK_SET)) {
-        sprintf(g->Message, MSG(READ_SEEK_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(READ_SEEK_ERROR), strerror(errno));
         return true;
         } // endif
 
@@ -1117,18 +1117,18 @@ bool DOSFAM::MoveIntermediateLines(PGLOBAL g, bool *b)
       htrc("after read req=%d len=%d\n", req, len);
 
     if (len != req) {
-      sprintf(g->Message, MSG(DEL_READ_ERROR), (int) req, (int) len);
+      snprintf(g->Message, sizeof(g->Message), MSG(DEL_READ_ERROR), (int) req, (int) len);
       return true;
       } // endif len
 
     if (!UseTemp)
       if (fseek(T_Stream, Tpos, SEEK_SET)) {
-        sprintf(g->Message, MSG(WRITE_SEEK_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(WRITE_SEEK_ERR), strerror(errno));
         return true;
         } // endif
 
     if ((len = fwrite(DelBuf, 1, req, T_Stream)) != req) {
-      sprintf(g->Message, MSG(DEL_WRITE_ERROR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(DEL_WRITE_ERROR), strerror(errno));
       return true;
       } // endif
 
@@ -1174,16 +1174,16 @@ int DOSFAM::RenameTempFile(PGLOBAL g)
     remove(filetemp);   // May still be there from previous error
 
     if (rename(filename, filetemp)) {    // Save file for security
-      snprintf(g->Message, MAX_STR, MSG(RENAME_ERROR),
+      snprintf(g->Message, sizeof(g->Message), MSG(RENAME_ERROR),
               filename, filetemp, strerror(errno));
 			throw 51;
 		} else if (rename(tempname, filename)) {
-      snprintf(g->Message, MAX_STR, MSG(RENAME_ERROR),
+      snprintf(g->Message, sizeof(g->Message), MSG(RENAME_ERROR),
               tempname, filename, strerror(errno));
       rc = rename(filetemp, filename);   // Restore saved file
 			throw 52;
 		} else if (remove(filetemp)) {
-      sprintf(g->Message, MSG(REMOVE_ERROR),
+      snprintf(g->Message, sizeof(g->Message), MSG(REMOVE_ERROR),
               filetemp, strerror(errno));
       rc = RC_INFO;                      // Acceptable
     } // endif's
@@ -1447,7 +1447,7 @@ int BLKFAM::ReadBuffer(PGLOBAL g)
   // fseek is required only in non sequential reading
   if (CurBlk != OldBlk + 1)
     if (fseek(Stream, BlkPos[CurBlk], SEEK_SET)) {
-      sprintf(g->Message, MSG(FSETPOS_ERROR), BlkPos[CurBlk]);
+      snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), BlkPos[CurBlk]);
       return RC_FX;
       } // endif fseek
 
@@ -1483,9 +1483,9 @@ int BLKFAM::ReadBuffer(PGLOBAL g)
     rc = RC_EF;
   } else {
 #if defined(_WIN32)
-    sprintf(g->Message, MSG(READ_ERROR), To_File, _strerror(NULL));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, _strerror(NULL));
 #else
-    sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(errno));
 #endif
 
     if (trace(1))
@@ -1529,7 +1529,7 @@ int BLKFAM::WriteBuffer(PGLOBAL g)
     BlkLen = (int)(NxtLine - To_Buf);
 
     if (fwrite(To_Buf, 1, BlkLen, Stream) != (size_t)BlkLen) {
-      sprintf(g->Message, MSG(FWRITE_ERROR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(FWRITE_ERROR), strerror(errno));
       Closing = true;      // To tell CloseDB about a Write error
       return RC_FX;
       } // endif size
@@ -1577,7 +1577,7 @@ int BLKFAM::WriteBuffer(PGLOBAL g)
       len = strlen(OutBuf);
     } else {
       if (fseek(Stream, Fpos, SEEK_SET)) {   // Fpos is last position
-        sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+        snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
         return RC_FX;
         } // endif fseek
 
@@ -1588,13 +1588,13 @@ int BLKFAM::WriteBuffer(PGLOBAL g)
     } // endif UseTemp
 
     if (fwrite(OutBuf, 1, len, T_Stream) != (size_t)len) {
-      sprintf(g->Message, MSG(FWRITE_ERROR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(FWRITE_ERROR), strerror(errno));
       return RC_FX;
       } // endif fwrite
 
     if (moved)
       if (fseek(Stream, curpos, SEEK_SET)) {
-        sprintf(g->Message, MSG(FSEEK_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(FSEEK_ERROR), strerror(errno));
         return RC_FX;
         } // endif
 
@@ -1678,7 +1678,7 @@ int BINFAM::GetFileLength(PGLOBAL g)
 		len = TXTFAM::GetFileLength(g);
 	else
 		if ((len = _filelength(_fileno(Stream))) < 0)
-			sprintf(g->Message, MSG(FILELEN_ERROR), "_filelength", To_File);
+			snprintf(g->Message, sizeof(g->Message), MSG(FILELEN_ERROR), "_filelength", To_File);
 
 	xtrc(1, "File length=%d\n", len);
 	return len;
@@ -1710,7 +1710,7 @@ bool BINFAM::OpenTableFile(PGLOBAL g) {
 		strcpy(opmode, "wb");
 		break;
 	default:
-		sprintf(g->Message, MSG(BAD_OPEN_MODE), mode);
+		snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
 		return true;
 	} // endswitch Mode
 
@@ -1802,7 +1802,7 @@ bool BINFAM::SetPos(PGLOBAL g, int pos) {
 	Fpos = pos;
 
 	if (fseek(Stream, Fpos, SEEK_SET)) {
-		sprintf(g->Message, MSG(FSETPOS_ERROR), Fpos);
+		snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), Fpos);
 		return true;
 	} // endif
 
@@ -1815,7 +1815,7 @@ bool BINFAM::SetPos(PGLOBAL g, int pos) {
 /***********************************************************************/
 bool BINFAM::RecordPos(PGLOBAL g) {
 	if ((Fpos = ftell(Stream)) < 0) {
-		sprintf(g->Message, MSG(FTELL_ERROR), 0, strerror(errno));
+		snprintf(g->Message, sizeof(g->Message), MSG(FTELL_ERROR), 0, strerror(errno));
 		//  strcat(g->Message, " (possible wrong ENDING option value)");
 		return true;
 	} // endif Fpos
@@ -1861,7 +1861,7 @@ int BINFAM::ReadBuffer(PGLOBAL g)
 			return RC_EF;
 
 	} else if (Recsize > (unsigned)Buflen) {
-		sprintf(g->Message, "Record too big (Recsize=%zd Buflen=%d)\n", Recsize, Buflen);
+		snprintf(g->Message, sizeof(g->Message), "Record too big (Recsize=%zd Buflen=%d)\n", Recsize, Buflen);
 		return RC_FX;
 	}	// endif Recsize
 
@@ -1873,9 +1873,9 @@ int BINFAM::ReadBuffer(PGLOBAL g)
 		rc = RC_EF;
 	} else {
 #if defined(_WIN32)
-		sprintf(g->Message, MSG(READ_ERROR), To_File, _strerror(NULL));
+		snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, _strerror(NULL));
 #else
-		sprintf(g->Message, MSG(READ_ERROR), To_File, strerror(0));
+		snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), To_File, strerror(0));
 #endif
 		xtrc(2, "%s\n", g->Message);
 		rc = RC_FX;
@@ -1932,7 +1932,7 @@ int BINFAM::WriteBuffer(PGLOBAL g)
       // Update is directly written back into the file,
       //   with this (fast) method, record size cannot change.
       if (fseek(Stream, Fpos, SEEK_SET)) {
-        sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+        snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
         return RC_FX;
       } // endif
 
@@ -1947,18 +1947,18 @@ int BINFAM::WriteBuffer(PGLOBAL g)
 	/*  Now start the writing process.                                   */
 	/*********************************************************************/
 	if (fwrite(&Recsize, sizeof(size_t), 1, T_Stream) != 1) {
-		sprintf(g->Message, "Error %d writing prefix to %s",
+		snprintf(g->Message, sizeof(g->Message), "Error %d writing prefix to %s",
 			errno, To_File);
 		return RC_FX;
 	} else if (fwrite(To_Buf, Recsize, 1, T_Stream) != 1) {
-		sprintf(g->Message, "Error %d writing %zd bytes to %s",
+		snprintf(g->Message, sizeof(g->Message), "Error %d writing %zd bytes to %s",
 			errno, Recsize, To_File);
 		return RC_FX;
 	} // endif fwrite
 
   if (Tdbp->GetMode() == MODE_UPDATE && moved)
     if (fseek(Stream, curpos, SEEK_SET)) {
-      sprintf(g->Message, MSG(FSEEK_ERROR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(FSEEK_ERROR), strerror(errno));
       return RC_FX;
     } // endif
 
@@ -2033,7 +2033,7 @@ int DOSFAM::DeleteRecords(PGLOBAL g, int irc)
     /*******************************************************************/
     if (!UseTemp || moved)
       if (fseek(Stream, curpos, SEEK_SET)) {
-        sprintf(g->Message, MSG(FSETPOS_ERROR), 0);
+        snprintf(g->Message, sizeof(g->Message), MSG(FSETPOS_ERROR), 0);
         return RC_FX;
       } // endif
 
@@ -2068,13 +2068,13 @@ int DOSFAM::DeleteRecords(PGLOBAL g, int irc)
       /*****************************************************************/
 #if defined(_WIN32)
       if (chsize(h, Tpos)) {
-        sprintf(g->Message, MSG(CHSIZE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(CHSIZE_ERROR), strerror(errno));
         close(h);
         return RC_FX;
       } // endif
 #else
       if (ftruncate(h, (off_t)Tpos)) {
-        sprintf(g->Message, MSG(TRUNCATE_ERROR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(TRUNCATE_ERROR), strerror(errno));
         close(h);
         return RC_FX;
       } // endif

--- a/storage/connect/filamzip.cpp
+++ b/storage/connect/filamzip.cpp
@@ -114,7 +114,7 @@ static bool ZipFile(PGLOBAL g, ZIPUTIL *zutp, PCSZ fn, PCSZ entry, char *buf)
 	if (zutp->addEntry(g, entry))
 		return true;
 	else if (!(fin = fopen(fn, "rb"))) {
-		sprintf(g->Message, "error in opening %s for reading", fn);
+		snprintf(g->Message, sizeof(g->Message), "error in opening %s for reading", fn);
 		return true;
 	} // endif fin
 
@@ -122,7 +122,7 @@ static bool ZipFile(PGLOBAL g, ZIPUTIL *zutp, PCSZ fn, PCSZ entry, char *buf)
 		size_read = (int)fread(buf, 1, size_buf, fin);
 
 		if (size_read < size_buf && feof(fin) == 0) {
-			sprintf(g->Message, "error in reading %s", fn);
+			snprintf(g->Message, sizeof(g->Message), "error in reading %s", fn);
 			rc = RC_FX;
 		}	// endif size_read
 
@@ -130,7 +130,7 @@ static bool ZipFile(PGLOBAL g, ZIPUTIL *zutp, PCSZ fn, PCSZ entry, char *buf)
 			rc = zutp->writeEntry(g, buf, size_read);
 
 			if (rc == RC_FX)
-				sprintf(g->Message, "error in writing %s in the zipfile", fn);
+				snprintf(g->Message, sizeof(g->Message), "error in writing %s in the zipfile", fn);
 
 		}	// endif size_read
 
@@ -170,7 +170,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 		if (rc != ERROR_FILE_NOT_FOUND) {
 			FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 				NULL, GetLastError(), 0, (LPTSTR)&filename, sizeof(filename), NULL);
-			sprintf(g->Message, MSG(BAD_FILE_HANDLE), filename);
+			snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILE_HANDLE), filename);
 			return true;
 		} else {
 			strcpy(g->Message, "Cannot find any file to load");
@@ -194,7 +194,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 			rc = GetLastError();
 
 			if (rc != ERROR_NO_MORE_FILES) {
-				sprintf(g->Message, MSG(NEXT_FILE_ERROR), rc);
+				snprintf(g->Message, sizeof(g->Message), MSG(NEXT_FILE_ERROR), rc);
 				FindClose(hSearch);
 				return true;
 			} // endif rc
@@ -221,7 +221,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 
 	// Start searching files in the target directory.
 	if (!(dir = opendir(direc))) {
-		sprintf(g->Message, MSG(BAD_DIRECTORY), direc, strerror(errno));
+		snprintf(g->Message, sizeof(g->Message), MSG(BAD_DIRECTORY), direc, strerror(errno));
 		return true;
 	} // endif dir
 
@@ -229,7 +229,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 		strcat(strcpy(fn, direc), entry->d_name);
 
 		if (lstat(fn, &fileinfo) < 0) {
-			sprintf(g->Message, "%s: %s", fn, strerror(errno));
+			snprintf(g->Message, sizeof(g->Message), "%s: %s", fn, strerror(errno));
 			return true;
 		} else if (!S_ISREG(fileinfo.st_mode))
 			continue;      // Not a regular file (should test for links)
@@ -343,7 +343,7 @@ bool ZIPUTIL::open(PGLOBAL g, PCSZ filename, bool append)
 	if (!zipfile && !(zipfile = zipOpen64(filename,
 		                               append ? APPEND_STATUS_ADDINZIP
 																	        : APPEND_STATUS_CREATE)))
-		sprintf(g->Message, "Zipfile open error on %s", filename);
+		snprintf(g->Message, sizeof(g->Message), "Zipfile open error on %s", filename);
 
 	return (zipfile == NULL);
 }	// end of open
@@ -430,7 +430,7 @@ bool ZIPUTIL::addEntry(PGLOBAL g, PCSZ entry)
 int ZIPUTIL::writeEntry(PGLOBAL g, char *buf, int len)
 {
 	if (zipWriteInFileInZip(zipfile, buf, len) < 0) {
-		sprintf(g->Message, "Error writing %s in the zipfile", target);
+		snprintf(g->Message, sizeof(g->Message), "Error writing %s in the zipfile", target);
 		return RC_FX;
 	}	// endif zipWriteInFileInZip
 
@@ -549,7 +549,7 @@ starCheck:
 bool UNZIPUTL::open(PGLOBAL g, PCSZ filename)
 {
 	if (!zipfile && !(zipfile = unzOpen64(filename)))
-		sprintf(g->Message, "Zipfile open error on %s", filename);
+		snprintf(g->Message, sizeof(g->Message), "Zipfile open error on %s", filename);
 
 	return (zipfile == NULL);
 }	// end of open
@@ -584,7 +584,7 @@ int UNZIPUTL::findEntry(PGLOBAL g, bool next)
 			if (rc == UNZ_END_OF_LIST_OF_FILE)
 				return RC_EF;
 			else if (rc != UNZ_OK) {
-				sprintf(g->Message, "unzGoToNextFile rc = %d", rc);
+				snprintf(g->Message, sizeof(g->Message), "unzGoToNextFile rc = %d", rc);
 				return RC_FX;
 			} // endif rc
 
@@ -598,7 +598,7 @@ int UNZIPUTL::findEntry(PGLOBAL g, bool next)
 					return RC_OK;
 
 			} else {
-				sprintf(g->Message, "GetCurrentFileInfo rc = %d", rc);
+				snprintf(g->Message, sizeof(g->Message), "GetCurrentFileInfo rc = %d", rc);
 				return RC_FX;
 			} // endif rc
 
@@ -655,10 +655,10 @@ bool UNZIPUTL::OpenTable(PGLOBAL g, MODE mode, PCSZ fn)
 					rc = unzLocateFile(zipfile, target, 0);
 
 					if (rc == UNZ_END_OF_LIST_OF_FILE) {
-						sprintf(g->Message, "Target file %s not in %s", target, fn);
+						snprintf(g->Message, sizeof(g->Message), "Target file %s not in %s", target, fn);
 						return true;
 					} else if (rc != UNZ_OK) {
-						sprintf(g->Message, "unzLocateFile rc=%d", rc);
+						snprintf(g->Message, sizeof(g->Message), "unzLocateFile rc=%d", rc);
 						return true;
 					}	// endif's rc
 
@@ -666,7 +666,7 @@ bool UNZIPUTL::OpenTable(PGLOBAL g, MODE mode, PCSZ fn)
 					if ((rc = findEntry(g, false)) == RC_FX)
 						return true;
 					else if (rc == RC_EF) {
-						sprintf(g->Message, "No match of %s in %s", target, fn);
+						snprintf(g->Message, sizeof(g->Message), "No match of %s in %s", target, fn);
 						return true;
 					} // endif rc
 
@@ -741,10 +741,10 @@ bool UNZIPUTL::openEntry(PGLOBAL g)
 		NULL, 0, NULL, 0);
 
 	if (rc != UNZ_OK) {
-		sprintf(g->Message, "unzGetCurrentFileInfo64 rc=%d", rc);
+		snprintf(g->Message, sizeof(g->Message), "unzGetCurrentFileInfo64 rc=%d", rc);
 		return true;
 	} else if ((rc = unzOpenCurrentFilePassword(zipfile, pwd)) != UNZ_OK) {
-		sprintf(g->Message, "unzOpen fn=%s rc=%d", fn, rc);
+		snprintf(g->Message, sizeof(g->Message), "unzOpen fn=%s rc=%d", fn, rc);
 		return true;
 	}	// endif rc
 
@@ -758,7 +758,7 @@ bool UNZIPUTL::openEntry(PGLOBAL g)
 	} // end try/catch
 
 	if ((rc = unzReadCurrentFile(zipfile, memory, size)) < 0) {
-		sprintf(g->Message, "unzReadCurrentFile rc = %d", rc);
+		snprintf(g->Message, sizeof(g->Message), "unzReadCurrentFile rc = %d", rc);
 		unzCloseCurrentFile(zipfile);
 		delete[] memory;
 		memory = NULL;
@@ -1020,7 +1020,7 @@ int UZXFAM::Cardinality(PGLOBAL g)
 	if (!(len % Lrecl))
 		card = len / (int)Lrecl;           // Fixed length file
 	else
-		sprintf(g->Message, MSG(NOT_FIXED_LEN), zutp->fn, len, Lrecl);
+		snprintf(g->Message, sizeof(g->Message), MSG(NOT_FIXED_LEN), zutp->fn, len, Lrecl);
 
 	// Set number of blocks for later use
 	Block = (card > 0) ? (card + Nrec - 1) / Nrec : 0;
@@ -1074,7 +1074,7 @@ int UZXFAM::GetNext(PGLOBAL g)
 	int len = zutp->size;
 
 	if (len % Lrecl) {
-		sprintf(g->Message, MSG(NOT_FIXED_LEN), zutp->fn, len, Lrecl);
+		snprintf(g->Message, sizeof(g->Message), MSG(NOT_FIXED_LEN), zutp->fn, len, Lrecl);
 		return RC_FX;
 	}	// endif size
 
@@ -1144,7 +1144,7 @@ int UZDFAM::dbfhead(PGLOBAL g, void* buf)
 
 	// Some headers just have 1D others have 1D00 following fields
 	if (endmark[0] != EOH && endmark[1] != EOH) {
-		sprintf(g->Message, MSG(NO_0DH_HEAD), dbc);
+		snprintf(g->Message, sizeof(g->Message), MSG(NO_0DH_HEAD), dbc);
 
 		if (rc == RC_OK)
 			return RC_FX;
@@ -1263,7 +1263,7 @@ int UZDFAM::GetNext(PGLOBAL g)
 
 #if 0
 	if (len % Lrecl) {
-		sprintf(g->Message, MSG(NOT_FIXED_LEN), zutp->fn, len, Lrecl);
+		snprintf(g->Message, sizeof(g->Message), MSG(NOT_FIXED_LEN), zutp->fn, len, Lrecl);
 		return RC_FX;
 	}	// endif size
 #endif // 0

--- a/storage/connect/filter.cpp
+++ b/storage/connect/filter.cpp
@@ -83,7 +83,7 @@ BYTE OpBmp(PGLOBAL g, OPVAL opc)
     case OP_LE: bt = 0x04; break;
     case OP_EXIST: bt = 0x00; break;
     default:
-      sprintf(g->Message, MSG(BAD_FILTER_OP), opc);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILTER_OP), opc);
 			throw (int)TYPE_FILTER;
 	} // endswitch opc
 
@@ -1021,7 +1021,7 @@ bool FILTER::Convert(PGLOBAL g, bool having)
     // Special case of the LIKE operator.
     if (Opc == OP_LIKE) {
       if (!IsTypeChar((int)Test[i].B_T)) {
-        sprintf(g->Message, MSG(BAD_TYPE_LIKE), i, Test[i].B_T);
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_TYPE_LIKE), i, Test[i].B_T);
         return TRUE;
         } // endif
 
@@ -1129,11 +1129,11 @@ bool FILTER::Convert(PGLOBAL g, bool having)
 
   //  Last check to be sure all is correct.
   if (Test[0].B_T != Test[1].B_T) {
-    sprintf(g->Message, MSG(BAD_FILTER_CONV), Test[0].B_T, Test[1].B_T);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILTER_CONV), Test[0].B_T, Test[1].B_T);
     return TRUE;
 //} else if (Test[0].B_T == TYPE_LIST &&
 //          ((LSTVAL*)Val(0))->GetN() != ((LSTVAL*)Val(1))->GetN()) {
-//  sprintf(g->Message, MSG(ROW_ARGNB_ERR),
+//  snprintf(g->Message, sizeof(g->Message), MSG(ROW_ARGNB_ERR),
 //          ((LSTVAL*)Val(0))->GetN(), ((LSTVAL*)Val(1))->GetN());
 //  return TRUE;
   } // endif's B_T
@@ -1372,7 +1372,7 @@ bool FILTER::Eval(PGLOBAL g)
   return FALSE;
 
  FilterError:
-  sprintf(g->Message, MSG(BAD_FILTER),
+  snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILTER),
           Opc, Test[0].B_T, Test[1].B_T, GetArgType(0), GetArgType(1));
   return TRUE;
   } // end of Eval

--- a/storage/connect/ha_connect.cc
+++ b/storage/connect/ha_connect.cc
@@ -1403,7 +1403,9 @@ char *ha_connect::GetRealString(PCSZ s)
 
   if (IsPartitioned() && s && *partname) {
     sv= (char*)PlugSubAlloc(xp->g, NULL, 0);
-    sprintf(sv, s, partname);
+    PPOOLHEADER pph;
+    pph = (PPOOLHEADER)xp->g->Sarea;
+    snprintf(sv, xp->g->Sarea_Size - pph->To_Free, s, partname);
     PlugSubAlloc(xp->g, NULL, strlen(sv) + 1);
   } else
     sv= (char*)s;
@@ -2079,7 +2081,7 @@ int ha_connect::OpenTable(PGLOBAL g, bool del)
             // Trying to update a column used for partitioning
             // This cannot be currently done because it may require
             // a row to be moved in another partition.
-            sprintf(g->Message, 
+            snprintf(g->Message, sizeof(g->Message),
               "Cannot update column %s because it is used for partitioning",
               p);
             return HA_ERR_INTERNAL_ERROR;
@@ -2134,7 +2136,7 @@ bool ha_connect::CheckColumnList(PGLOBAL g)
           for (field= table->field; (fp= *field); field++)
       if (bitmap_is_set(map, fp->field_index)) {
         if (!(colp= tdbp->ColDB(g, (PSZ)fp->field_name.str, 0))) {
-          sprintf(g->Message, "Column %s not found in %s", 
+          snprintf(g->Message, sizeof(g->Message), "Column %s not found in %s", 
                   fp->field_name.str, tdbp->GetName());
 					throw 1;
 				} // endif colp
@@ -2293,7 +2295,7 @@ int ha_connect::MakeRecord(char *buf)
           char buf[256];
           THD *thd= ha_thd();
 
-          sprintf(buf, "Out of range value %.140s for column '%s' at row %ld",
+          snprintf(buf, 256, "Out of range value %.140s for column '%s' at row %ld",
             value->GetCharString(val),
             fp->field_name.str,
             thd->get_stmt_da()->current_row_for_warning());
@@ -2575,7 +2577,7 @@ bool ha_connect::MakeKeyWhere(PGLOBAL g, PSTRG qry, OPVAL vop, char q,
 				op= OP_LE;
 				break;
 			default:
-				sprintf(g->Message, "cannot handle flag %d", ranges[i]->flag);
+				snprintf(g->Message, sizeof(g->Message), "cannot handle flag %d", ranges[i]->flag);
 				goto err;
 			}	// endswitch flag
 
@@ -4897,7 +4899,7 @@ int ha_connect::external_lock(THD *thd, int lock_type)
                            && sqlcom != SQLCOM_FLUSH
                            && sqlcom != SQLCOM_BEGIN
                            && sqlcom != SQLCOM_DROP_TABLE) {
-      sprintf(g->Message, "external_lock: unexpected command %d", sqlcom);
+      snprintf(g->Message, sizeof(g->Message), "external_lock: unexpected command %d", sqlcom);
       push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
       DBUG_RETURN(0);
     } else if (g->Xchk) {
@@ -4907,7 +4909,7 @@ int ha_connect::external_lock(THD *thd, int lock_type)
 					push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
 					DBUG_RETURN(0);
 				} else if (!tdbp->GetDef()->Indexable()) {
-          sprintf(g->Message, "external_lock: Table %s is not indexable", tdbp->GetName());
+          snprintf(g->Message, sizeof(g->Message), "external_lock: Table %s is not indexable", tdbp->GetName());
 //        DBUG_RETURN(HA_ERR_INTERNAL_ERROR);  causes assert error
           push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
           DBUG_RETURN(0);
@@ -5818,7 +5820,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 #endif   // PROMPT_OK
 
 				} else if (!dsn) {
-					sprintf(g->Message, "Missing %s connection string", topt->type);
+					snprintf(g->Message, sizeof(g->Message), "Missing %s connection string", topt->type);
 				} else {
 					// Store ODBC additional parameters
 					sop= (POPARM)PlugSubAlloc(g, NULL, sizeof(ODBCPARM));
@@ -5873,9 +5875,9 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 				// fall through
 			case TAB_CSV:
 				if (!fn && fnc != FNC_NO)
-					sprintf(g->Message, "Missing %s file name", topt->type);
+					snprintf(g->Message, sizeof(g->Message), "Missing %s file name", topt->type);
 				else if (sep && strlen(sep) > 1)
-					sprintf(g->Message, "Invalid separator %s", sep);
+					snprintf(g->Message, sizeof(g->Message), "Invalid separator %s", sep);
 				else
 					ok= true;
 
@@ -5933,7 +5935,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 			case TAB_OCCUR:
 				if (!src && !stricmp(tab, create_info->alias.str) &&
 					(!db || !stricmp(db, table_s->db.str)))
-					sprintf(g->Message, "A %s table cannot refer to itself", topt->type);
+					snprintf(g->Message, sizeof(g->Message), "A %s table cannot refer to itself", topt->type);
 				else
 					ok= true;
 
@@ -5955,7 +5957,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
         dsn= strz(g, create_info->connect_string);
 
 				if (!fn && !zfn && !mul && !dsn)
-					sprintf(g->Message, "Missing %s file name", topt->type);
+					snprintf(g->Message, sizeof(g->Message), "Missing %s file name", topt->type);
 				else if (dsn && !topt->tabname)
           topt->tabname= tab;
 
@@ -5982,13 +5984,13 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 				ok= true;
 				break;
 			default:
-				sprintf(g->Message, "Cannot get column info for table type %s", topt->type);
+				snprintf(g->Message, sizeof(g->Message), "Cannot get column info for table type %s", topt->type);
 				break;
 		} // endif ttp
 
 	// Check for supported catalog function
 		if (ok && !(supfnc & fnc)) {
-			sprintf(g->Message, "Unsupported catalog function %s for table type %s",
+			snprintf(g->Message, sizeof(g->Message), "Unsupported catalog function %s for table type %s",
 				fncn, topt->type);
 			ok= false;
 		} // endif supfnc
@@ -6044,7 +6046,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 							qrp= ODBCDrivers(g, mxr, true);
 							break;
 						default:
-							sprintf(g->Message, "invalid catfunc %s", fncn);
+							snprintf(g->Message, sizeof(g->Message), "invalid catfunc %s", fncn);
 							break;
 					} // endswitch info
 
@@ -6075,7 +6077,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 							qrp= JDBCDrivers(g, mxr, true);
 							break;
 						default:
-							sprintf(g->Message, "invalid catfunc %s", fncn);
+							snprintf(g->Message, sizeof(g->Message), "invalid catfunc %s", fncn);
 							break;
 					} // endswitch info
 
@@ -6182,9 +6184,9 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 				// Not a catalog table
 				if (!qrp->Nblin) {
 					if (tab)
-						sprintf(g->Message, "Cannot get columns from %s", tab);
+						snprintf(g->Message, sizeof(g->Message), "Cannot get columns from %s", tab);
 					else
-						strcpy(g->Message, "Fail to retrieve columns");
+						strncpy(g->Message, "Fail to retrieve columns", sizeof(g->Message));
 
 					rc= HA_ERR_INTERNAL_ERROR;
 					goto err;
@@ -6271,7 +6273,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 #if defined(ODBC_SUPPORT) || defined(JAVA_SUPPORT)
 								if ((ttp == TAB_ODBC || ttp == TAB_JDBC) && crp->Kdata) {
 									if (schem && stricmp(schem, crp->Kdata->GetCharValue(i))) {
-										sprintf(g->Message,
+										snprintf(g->Message, sizeof(g->Message),
 											"Several %s tables found, specify DBNAME", tab);
 										rc= HA_ERR_INTERNAL_ERROR;
 										goto err;
@@ -6293,12 +6295,12 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 						if (!(plgtyp= TranslateSQLType(typ, dec, prec, v, w))) {
 							if (GetTypeConv() == TPC_SKIP) {
 								// Skip this column
-								sprintf(g->Message, "Column %s skipped (unsupported type %d)",
+								snprintf(g->Message, sizeof(g->Message), "Column %s skipped (unsupported type %d)",
 									cnm, typ);
 								push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
 								continue;
 							} else {
-								sprintf(g->Message, "Unsupported SQL type %d", typ);
+								snprintf(g->Message, sizeof(g->Message), "Unsupported SQL type %d", typ);
 								rc= HA_ERR_INTERNAL_ERROR;
 								goto err;
 							} // endif type_conv
@@ -6309,7 +6311,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 						switch (typ) {
 							case TYPE_STRING:
 								if (w) {
-									sprintf(g->Message, "Column %s is wide characters", cnm);
+									snprintf(g->Message, sizeof(g->Message), "Column %s is wide characters", cnm);
 									push_warning(thd, Sql_condition::WARN_LEVEL_NOTE, 0, g->Message);
 								} // endif w
 
@@ -6335,12 +6337,12 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 							if (!(plgtyp= TranslateJDBCType(typ, tn, dec, prec, v))) {
 								if (GetTypeConv() == TPC_SKIP) {
 									// Skip this column
-									sprintf(g->Message, "Column %s skipped (unsupported type %d)",
+									snprintf(g->Message, sizeof(g->Message), "Column %s skipped (unsupported type %d)",
 										cnm, typ);
 									push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
 									continue;
 								} else {
-									sprintf(g->Message, "Unsupported SQL type %d", typ);
+									snprintf(g->Message, sizeof(g->Message), "Unsupported SQL type %d", typ);
 									rc= HA_ERR_INTERNAL_ERROR;
 									goto err;
 								} // endif type_conv
@@ -6499,13 +6501,13 @@ int ha_connect::create(const char *name, TABLE *table_arg,
 #endif   // REST_SUPPORT
                    (options->tabname) ? "PROXY" : "DOS";
     type= GetTypeID(options->type);
-    sprintf(g->Message, "No table_type. Will be set to %s", options->type);
+    snprintf(g->Message, sizeof(g->Message), "No table_type. Will be set to %s", options->type);
 
     if (sqlcom == SQLCOM_CREATE_TABLE)
       push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
 
   } else if (type == TAB_NIY) {
-    sprintf(g->Message, "Unsupported table type %s", options->type);
+    snprintf(g->Message, sizeof(g->Message), "Unsupported table type %s", options->type);
     my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
     DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
   } // endif ttp
@@ -6556,7 +6558,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
           if (!stricmp(options->tabname, create_info->alias.str) &&
              (!options->dbname || 
               !stricmp(options->dbname, table_arg->s->db.str))) {
-            sprintf(g->Message, "A %s table cannot refer to itself",
+            snprintf(g->Message, sizeof(g->Message), "A %s table cannot refer to itself",
                                 options->type);
             my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
             DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
@@ -6665,7 +6667,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
     int pretty= atoi(GetListOption(g, "Pretty", options->oplist, "2"));
 
     if (!options->lrecl && pretty != 2) {
-      sprintf(g->Message, "LRECL must be specified for pretty=%d", pretty);
+      snprintf(g->Message, sizeof(g->Message), "LRECL must be specified for pretty=%d", pretty);
       my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
       rc= HA_ERR_INTERNAL_ERROR;
       DBUG_RETURN(rc);
@@ -6677,7 +6679,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
 		const char *sep= options->separator;
 
 		if (sep && strlen(sep) > 1) {
-			sprintf(g->Message, "Invalid separator %s", sep);
+			snprintf(g->Message, sizeof(g->Message), "Invalid separator %s", sep);
 			my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
 			rc= HA_ERR_INTERNAL_ERROR;
 			DBUG_RETURN(rc);
@@ -6700,7 +6702,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
       } // endif flags
 
     if (fp->flags & (BLOB_FLAG | ENUM_FLAG | SET_FLAG)) {
-      sprintf(g->Message, "Unsupported type for column %s",
+      snprintf(g->Message, sizeof(g->Message), "Unsupported type for column %s",
                           fp->field_name.str);
       my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
       rc= HA_ERR_INTERNAL_ERROR;
@@ -6737,7 +6739,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
       case MYSQL_TYPE_STRING:
 #if 0
         if (!fp->field_length) {
-          sprintf(g->Message, "Unsupported 0 length for column %s",
+          snprintf(g->Message, sizeof(g->Message), "Unsupported 0 length for column %s",
                               fp->field_name.str);
           rc= HA_ERR_INTERNAL_ERROR;
           my_printf_error(ER_UNKNOWN_ERROR,
@@ -6758,7 +6760,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
       case MYSQL_TYPE_GEOMETRY:
       default:
 //      fprintf(stderr, "Unsupported type column %s\n", fp->field_name.str);
-        sprintf(g->Message, "Unsupported type for column %s",
+        snprintf(g->Message, sizeof(g->Message), "Unsupported type for column %s",
                             fp->field_name.str);
         rc= HA_ERR_INTERNAL_ERROR;
         my_printf_error(ER_UNKNOWN_ERROR, "Unsupported type for column %s",
@@ -6778,10 +6780,10 @@ int ha_connect::create(const char *name, TABLE *table_arg,
       bool b= false;
 
       if ((b= fp->field_name.length > 10))
-        sprintf(g->Message, "DBF: Column name '%s' is too long (max=10)",
+        snprintf(g->Message, sizeof(g->Message), "DBF: Column name '%s' is too long (max=10)",
                             fp->field_name.str);
       else if ((b= fp->field_length > 255))
-        sprintf(g->Message, "DBF: Column length too big for '%s' (max=255)",
+        snprintf(g->Message, sizeof(g->Message), "DBF: Column length too big for '%s' (max=255)",
                             fp->field_name.str);
 
       if (b) {
@@ -6844,7 +6846,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
       *p= 0;
     } else {
       strcat(strcat(strcpy(buf, GetTableName()), "."), lwt);
-      sprintf(g->Message, "No file name. Table will use %s", buf);
+      snprintf(g->Message, sizeof(g->Message), "No file name. Table will use %s", buf);
   
       if (sqlcom == SQLCOM_CREATE_TABLE)
         push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
@@ -6856,9 +6858,9 @@ int ha_connect::create(const char *name, TABLE *table_arg,
 
     if ((h= ::open(fn, O_CREAT | O_EXCL, 0666)) == -1) {
       if (errno == EEXIST)
-        sprintf(g->Message, "Default file %s already exists", fn);
+        snprintf(g->Message, sizeof(g->Message), "Default file %s already exists", fn);
       else
-        sprintf(g->Message, "Error %d creating file %s", errno, fn);
+        snprintf(g->Message, sizeof(g->Message), "Error %d creating file %s", errno, fn);
 
       push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
     } else
@@ -6921,7 +6923,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
     if (g->Alchecked == 0 &&
         (!IsFileType(type) || FileExists(options->filename, false))) {
       if (part_info) {
-        sprintf(g->Message, "Data repartition in %s is unchecked", partname); 
+        snprintf(g->Message, sizeof(g->Message), "Data repartition in %s is unchecked", partname); 
         push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
       } else if (sqlcom == SQLCOM_ALTER_TABLE) {
         // This is an ALTER to CONNECT from another engine.
@@ -6973,7 +6975,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
           } // endif Check
 
       } else if (!GetIndexType(type)) {
-        sprintf(g->Message, "Table type %s is not indexable", options->type);
+        snprintf(g->Message, sizeof(g->Message), "Table type %s is not indexable", options->type);
         my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
         rc= HA_ERR_UNSUPPORTED;
       } // endif index type
@@ -7017,7 +7019,7 @@ bool ha_connect::FileExists(const char *fn, bool bf)
     s= "/";
 #endif  // !_WIN32
     if (IsPartitioned()) {
-      sprintf(tfn, fn, GetPartName());
+      snprintf(tfn, _MAX_PATH, fn, GetPartName());
 
       // This is to avoid an initialization error raised by the
       // test on check_table_flags made in ha_partition::open
@@ -7034,7 +7036,7 @@ bool ha_connect::FileExists(const char *fn, bool bf)
       if (errno != ENOENT) {
         char buf[_MAX_PATH + 20];
 
-        sprintf(buf, "Error %d for file %s", errno, filename);
+        snprintf(buf, _MAX_PATH + 20,  "Error %d for file %s", errno, filename);
         push_warning(table->in_use, Sql_condition::WARN_LEVEL_WARN, 0, buf);
         return true;
       } else
@@ -7262,7 +7264,7 @@ ha_connect::check_if_supported_inplace_alter(TABLE *altered_table,
         } // endif Check
 
     } else if (!GetIndexType(type)) {
-      sprintf(g->Message, "Table type %s is not indexable", oldopt->type);
+      snprintf(g->Message, sizeof(g->Message), "Table type %s is not indexable", oldopt->type);
       my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
       DBUG_RETURN(HA_ALTER_ERROR);
     } // endif index type

--- a/storage/connect/javaconn.cpp
+++ b/storage/connect/javaconn.cpp
@@ -272,25 +272,25 @@ bool JAVAConn::GetJVM(PGLOBAL g)
 			char  buf[256];
 			DWORD rc = GetLastError();
 
-			sprintf(g->Message, MSG(DLL_LOAD_ERROR), rc, soname);
+			snprintf(g->Message, sizeof(g->Message), MSG(DLL_LOAD_ERROR), rc, soname);
 			FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
 										FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
 				            (LPTSTR)buf, sizeof(buf), NULL);
 			strcat(strcat(g->Message, ": "), buf);
 		} else if (!(CreateJavaVM = (CRTJVM)GetProcAddress((HINSTANCE)LibJvm,
 			                                       "JNI_CreateJavaVM"))) {
-			sprintf(g->Message, MSG(PROCADD_ERROR), GetLastError(), "JNI_CreateJavaVM");
+			snprintf(g->Message, sizeof(g->Message), MSG(PROCADD_ERROR), GetLastError(), "JNI_CreateJavaVM");
 			FreeLibrary((HMODULE)LibJvm);
 			LibJvm = NULL;
 		} else if (!(GetCreatedJavaVMs = (GETJVM)GetProcAddress((HINSTANCE)LibJvm,
 			                                       "JNI_GetCreatedJavaVMs"))) {
-			sprintf(g->Message, MSG(PROCADD_ERROR), GetLastError(), "JNI_GetCreatedJavaVMs");
+			snprintf(g->Message, sizeof(g->Message), MSG(PROCADD_ERROR), GetLastError(), "JNI_GetCreatedJavaVMs");
 			FreeLibrary((HMODULE)LibJvm);
 			LibJvm = NULL;
 #if defined(_DEBUG)
 		} else if (!(GetDefaultJavaVMInitArgs = (GETDEF)GetProcAddress((HINSTANCE)LibJvm,
 			                                       "JNI_GetDefaultJavaVMInitArgs"))) {
-			sprintf(g->Message, MSG(PROCADD_ERROR), GetLastError(),
+			snprintf(g->Message, sizeof(g->Message), MSG(PROCADD_ERROR), GetLastError(),
 				"JNI_GetDefaultJavaVMInitArgs");
 			FreeLibrary((HMODULE)LibJvm);
 			LibJvm = NULL;
@@ -317,22 +317,22 @@ bool JAVAConn::GetJVM(PGLOBAL g)
 			// Load the desired shared library
 		if (!LibJvm) {
 			error = dlerror();
-			sprintf(g->Message, MSG(SHARED_LIB_ERR), soname, SVP(error));
+			snprintf(g->Message, sizeof(g->Message), MSG(SHARED_LIB_ERR), soname, SVP(error));
 		} else if (!(CreateJavaVM = (CRTJVM)dlsym(LibJvm, "JNI_CreateJavaVM"))) {
 			error = dlerror();
-			sprintf(g->Message, MSG(GET_FUNC_ERR), "JNI_CreateJavaVM", SVP(error));
+			snprintf(g->Message, sizeof(g->Message), MSG(GET_FUNC_ERR), "JNI_CreateJavaVM", SVP(error));
 			dlclose(LibJvm);
 			LibJvm = NULL;
 		} else if (!(GetCreatedJavaVMs = (GETJVM)dlsym(LibJvm, "JNI_GetCreatedJavaVMs"))) {
 			error = dlerror();
-			sprintf(g->Message, MSG(GET_FUNC_ERR), "JNI_GetCreatedJavaVMs", SVP(error));
+			snprintf(g->Message, sizeof(g->Message), MSG(GET_FUNC_ERR), "JNI_GetCreatedJavaVMs", SVP(error));
 			dlclose(LibJvm);
 			LibJvm = NULL;
 #if defined(_DEBUG)
 		} else if (!(GetDefaultJavaVMInitArgs = (GETDEF)dlsym(LibJvm,
 			"JNI_GetDefaultJavaVMInitArgs"))) {
 			error = dlerror();
-			sprintf(g->Message, MSG(GET_FUNC_ERR), "JNI_GetDefaultJavaVMInitArgs", SVP(error));
+			snprintf(g->Message, sizeof(g->Message), MSG(GET_FUNC_ERR), "JNI_GetDefaultJavaVMInitArgs", SVP(error));
 			dlclose(LibJvm);
 			LibJvm = NULL;
 #endif   // _DEBUG
@@ -473,7 +473,7 @@ bool JAVAConn::Open(PGLOBAL g)
 				strcpy(g->Message, "Invalid arguments");
 				break;
 			default:
-				sprintf(g->Message, "Unknown return code %d", (int)rc);
+				snprintf(g->Message, sizeof(g->Message), "Unknown return code %d", (int)rc);
 				break;
 		} // endswitch rc
 
@@ -492,7 +492,7 @@ bool JAVAConn::Open(PGLOBAL g)
 	jdi = env->FindClass(m_Wrap);
 
 	if (jdi == nullptr) {
-		sprintf(g->Message, "ERROR: class %s not found!", m_Wrap);
+		snprintf(g->Message, sizeof(g->Message), "ERROR: class %s not found!", m_Wrap);
 		return true;
 	} // endif jdi
 
@@ -538,13 +538,13 @@ bool JAVAConn::Open(PGLOBAL g)
 	jmethodID ctor = env->GetMethodID(jdi, "<init>", "(Z)V");
 
 	if (ctor == nullptr) {
-		sprintf(g->Message, "ERROR: %s constructor not found!", m_Wrap);
+		snprintf(g->Message, sizeof(g->Message), "ERROR: %s constructor not found!", m_Wrap);
 		return true;
 	} else
 		job = env->NewObject(jdi, ctor, jt);
 
 	if (job == nullptr) {
-		sprintf(g->Message, "%s class object not constructed!", m_Wrap);
+		snprintf(g->Message, sizeof(g->Message), "%s class object not constructed!", m_Wrap);
 		return true;
 	} // endif job
 

--- a/storage/connect/jdbconn.cpp
+++ b/storage/connect/jdbconn.cpp
@@ -689,17 +689,17 @@ bool JDBConn::SetUUID(PGLOBAL g, PTDBJDBC tjp)
 		ncol = env->CallIntMethod(job, catid, parms);
 
 		if (Check(ncol)) {
-			sprintf(g->Message, "%s: %s", fnc, Msg);
+			snprintf(g->Message, sizeof(g->Message), "%s: %s", fnc, Msg);
 			goto err;
 		}	// endif Check
 
 		rc = env->CallBooleanMethod(job, readid);
 
 		if (Check(rc)) {
-			sprintf(g->Message, "ReadNext: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "ReadNext: %s", Msg);
 			goto err;
 		} else if (rc == 0) {
-			sprintf(g->Message, "table %s does not exist", tjp->TableName);
+			snprintf(g->Message, sizeof(g->Message), "table %s does not exist", tjp->TableName);
 			goto err;
 		}	// endif rc
 
@@ -707,7 +707,7 @@ bool JDBConn::SetUUID(PGLOBAL g, PTDBJDBC tjp)
 		ctyp = (int)env->CallIntMethod(job, intfldid, 5, nullptr);
 
 		//if (Check((ctyp == 666) ? -1 : 1)) {
-		//	sprintf(g->Message, "Getting ctyp: %s", Msg);
+		//	snprintf(g->Message, sizeof(g->Message), "Getting ctyp: %s", Msg);
 		//	goto err;
 		//} // endif ctyp
 
@@ -813,7 +813,7 @@ bool JDBConn::Connect(PJPARM sop)
 	env->DeleteLocalRef(parms);				 	// Not used anymore
 
 	if (err) {
-		sprintf(g->Message, "Connecting: %s rc=%d", Msg, (int)rc);
+		snprintf(g->Message, sizeof(g->Message), "Connecting: %s rc=%d", Msg, (int)rc);
 		return true;
 	}	// endif Msg
 
@@ -861,14 +861,14 @@ int JDBConn::ExecuteCommand(PCSZ sql)
 	env->DeleteLocalRef(qry);
 
 	if (Check(n)) {
-		sprintf(g->Message, "Execute: %s", Msg);
+		snprintf(g->Message, sizeof(g->Message), "Execute: %s", Msg);
 		return RC_FX;
 	} // endif n
 
 	m_Ncol = env->CallIntMethod(job, grs);
 
 	if (Check(m_Ncol)) {
-		sprintf(g->Message, "GetResult: %s", Msg);
+		snprintf(g->Message, sizeof(g->Message), "GetResult: %s", Msg);
 		rc = RC_FX;
 	} else if (m_Ncol) {
 		strcpy(g->Message, "Result set column number");
@@ -917,7 +917,7 @@ int JDBConn::Fetch(int pos)
 
 			m_Rows += (int)rc;
 		} else
-			sprintf(g->Message, "Fetch: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "Fetch: %s", Msg);
 
 	} // endif pos
 
@@ -959,7 +959,7 @@ void JDBConn::SetColumnValue(int rank, PSZ name, PVAL val)
 
 	if (rank == 0)
 		if (!name || (jn = env->NewStringUTF(name)) == nullptr) {
-			sprintf(g->Message, "Fail to allocate jstring %s", SVP(name));
+			snprintf(g->Message, sizeof(g->Message), "Fail to allocate jstring %s", SVP(name));
 			throw (int)TYPE_AM_JDBC;
 		}	// endif name
 
@@ -967,7 +967,7 @@ void JDBConn::SetColumnValue(int rank, PSZ name, PVAL val)
 	ctyp = env->CallIntMethod(job, typid, rank, jn);
 
 	if (Check((ctyp == 666) ? -1 : 1)) {
-		sprintf(g->Message, "Getting ctyp: %s", Msg);
+		snprintf(g->Message, sizeof(g->Message), "Getting ctyp: %s", Msg);
 		throw (int)TYPE_AM_JDBC;
 	} // endif Check
 
@@ -976,7 +976,7 @@ void JDBConn::SetColumnValue(int rank, PSZ name, PVAL val)
 			jb = env->CallObjectMethod(job, objfldid, (jint)rank, jn);
 
 			if (Check(0)) {
-				sprintf(g->Message, "Getting jp: %s", Msg);
+				snprintf(g->Message, sizeof(g->Message), "Getting jp: %s", Msg);
 				throw (int)TYPE_AM_JDBC;
 			} // endif Check
 
@@ -1096,7 +1096,7 @@ void JDBConn::SetColumnValue(int rank, PSZ name, PVAL val)
 		if (rank == 0)
 			env->DeleteLocalRef(jn);
 
-		sprintf(g->Message, "SetColumnValue: %s rank=%d ctyp=%d", Msg, rank, (int)ctyp);
+		snprintf(g->Message, sizeof(g->Message), "SetColumnValue: %s rank=%d ctyp=%d", Msg, rank, (int)ctyp);
 		throw (int)TYPE_AM_JDBC;
 	} // endif Check
 
@@ -1118,7 +1118,7 @@ bool JDBConn::PrepareSQL(PCSZ sql)
 		jstring qry = env->NewStringUTF(sql);
 
 		if (Check(env->CallBooleanMethod(job, prepid, qry)))
-			sprintf(g->Message, "CreatePrepStmt: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "CreatePrepStmt: %s", Msg);
 		else
 			b = false;
 
@@ -1148,7 +1148,7 @@ int JDBConn::ExecuteQuery(PCSZ sql)
 			m_Aff = 0;			  // Affected rows
 			rc = RC_OK;
 		} else
-			sprintf(g->Message, "ExecuteQuery: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "ExecuteQuery: %s", Msg);
 
 		env->DeleteLocalRef(qry);
 	} // endif xqid
@@ -1176,7 +1176,7 @@ int JDBConn::ExecuteUpdate(PCSZ sql)
 			m_Aff = (int)n;			  // Affected rows
 			rc = RC_OK;
 		} else
-			sprintf(g->Message, "ExecuteUpdate: %s n=%d", Msg, n);
+			snprintf(g->Message, sizeof(g->Message), "ExecuteUpdate: %s n=%d", Msg, n);
 
 		env->DeleteLocalRef(qry);
 	} // endif xuid
@@ -1226,7 +1226,7 @@ int JDBConn::ExecuteSQL(void)
 		if (n == -3)
 			strcpy(g->Message, "SQL statement is not prepared");
 		else if (Check(n))
-			sprintf(g->Message, "ExecutePrep: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "ExecutePrep: %s", Msg);
 		else {
 			m_Aff = (int)n;
 			rc = RC_OK;
@@ -1325,12 +1325,12 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 			env->CallVoidMethod(job, setid, i, datobj);
 			break;
 		default:
-			sprintf(g->Message, "Parm type %d not supported", val->GetType());
+			snprintf(g->Message, sizeof(g->Message), "Parm type %d not supported", val->GetType());
 			return true;
 		}	// endswitch Type
 
 	if (Check(jrc)) {
-		sprintf(g->Message, "SetParam: col=%s msg=%s", colp->GetName(), Msg);
+		snprintf(g->Message, sizeof(g->Message), "SetParam: col=%s msg=%s", colp->GetName(), Msg);
 		rc = true;
 	} // endif msg
 
@@ -1453,7 +1453,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 		for (i = 0; i < m_Ncol; i++) {
 			if (!(label = (jstring)env->CallObjectMethod(job, colid, i + 1, val))) {
 				if (Check())
-					sprintf(g->Message, "ColumnDesc: %s", Msg);
+					snprintf(g->Message, sizeof(g->Message), "ColumnDesc: %s", Msg);
 				else
 					strcpy(g->Message, "No result metadata");
 
@@ -1535,7 +1535,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 			break;
 #endif // 0
 		default:
-			sprintf(g->Message, "Invalid SQL function id");
+			snprintf(g->Message, sizeof(g->Message), "Invalid SQL function id");
 			return -1;
 		} // endswitch infotype
 
@@ -1546,7 +1546,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 		ncol = env->CallIntMethod(job, catid, parms);
 
 		if (Check(ncol)) {
-			sprintf(g->Message, "%s: %s", fnc, Msg);
+			snprintf(g->Message, sizeof(g->Message), "%s: %s", fnc, Msg);
 			env->DeleteLocalRef(parms);
 			return -1;
 		}	// endif Check
@@ -1571,7 +1571,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 		// Prepare retrieving column values
 		for (n = 0, crp = qrp->Colresp; crp; crp = crp->Next) {
 			if (!(tp = GetJDBCType(crp->Type))) {
-				sprintf(g->Message, MSG(INV_COLUMN_TYPE), crp->Type, crp->Name);
+				snprintf(g->Message, sizeof(g->Message), MSG(INV_COLUMN_TYPE), crp->Type, crp->Name);
 				return -1;
 			} // endif tp
 
@@ -1596,7 +1596,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 		// Now fetch the result
 		for (i = 0; i < qrp->Maxres; i++) {
 			if (Check(rc = Fetch(0))) {
-				sprintf(g->Message, "Fetch: %s", Msg);
+				snprintf(g->Message, sizeof(g->Message), "Fetch: %s", Msg);
 				return -1;
 			} if (rc == 0) {
         if (trace(1))
@@ -1665,7 +1665,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 
 				if (!(crp->Kdata = AllocValBlock(g, NULL, crp->Type, m_Rows,
 					crp->Clen, 0, FALSE, TRUE, uns))) {
-					sprintf(g->Message, MSG(INV_RESULT_TYPE),
+					snprintf(g->Message, sizeof(g->Message), MSG(INV_RESULT_TYPE),
 						GetFormatType(crp->Type));
 					return NULL;
 				} // endif Kdata

--- a/storage/connect/jmgoconn.cpp
+++ b/storage/connect/jmgoconn.cpp
@@ -193,7 +193,7 @@ bool JMgoConn::Connect(PJPARM sop)
 	env->DeleteLocalRef(parms);				 	// Not used anymore
 
 	if (err) {
-		sprintf(g->Message, "Connecting: %s rc=%d", Msg, (int)rc);
+		snprintf(g->Message, sizeof(g->Message), "Connecting: %s rc=%d", Msg, (int)rc);
 		return true;
 	}	// endif Msg
 
@@ -208,7 +208,7 @@ bool JMgoConn::Connect(PJPARM sop)
 	env->DeleteLocalRef(cln);
 
 	if (Check(brc ? -1 : 0)) {
-		sprintf(g->Message, "GetCollection: %s", Msg);
+		snprintf(g->Message, sizeof(g->Message), "GetCollection: %s", Msg);
 		return true;
 	}	// endif Msg
 
@@ -429,7 +429,7 @@ bool JMgoConn::FindCollection(PCSZ query, PCSZ proj)
 		if (!Check(brc ? -1 : 0)) {
 			rc = false;
 		} else
-			sprintf(g->Message, "FindColl: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "FindColl: %s", Msg);
 
 		if (query)
 			env->DeleteLocalRef(qry);
@@ -461,7 +461,7 @@ bool JMgoConn::AggregateCollection(PCSZ pipeline)
 		if (!Check(brc ? -1 : 0)) {
 			rc = false;
 		} else
-			sprintf(g->Message, "AggregateColl: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "AggregateColl: %s", Msg);
 
 		env->DeleteLocalRef(pip);
 	} // endif acollid
@@ -506,7 +506,7 @@ int JMgoConn::Fetch(int pos)
 			rc = MY_MIN(rc, 1);
 			m_Rows += rc;
 		} else
-			sprintf(g->Message, "Fetch: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "Fetch: %s", Msg);
 
 	//} // endif pos
 
@@ -633,13 +633,13 @@ jobject JMgoConn::MakeObject(PGLOBAL g, PCOL colp, bool&error )
 				val = env->NewObject(cls, cns, valp->GetFloatValue());
 				break;
 			default:
-				sprintf(g->Message, "Cannot make object from %d type", valp->GetType());
+				snprintf(g->Message, sizeof(g->Message), "Cannot make object from %d type", valp->GetType());
 				error = true;
 				break;
 		}	// endswitch Type
 
 	} catch (...) {
-		sprintf(g->Message, "Cannot make object from %s value", colp->GetName());
+		snprintf(g->Message, sizeof(g->Message), "Cannot make object from %s value", colp->GetName());
 		error = true;
 	}	// end try/catch
 
@@ -723,9 +723,9 @@ jobject JMgoConn::MakeDoc(PGLOBAL g, PJNCOL jcp)
 
 			} else if (env->CallBooleanMethod(job, araddid, parent, kp->N, val, j)) {
 				if (Check(-1))
-					sprintf(g->Message, "ArrayAdd: %s", Msg);
+					snprintf(g->Message, sizeof(g->Message), "ArrayAdd: %s", Msg);
 				else
-					sprintf(g->Message, "ArrayAdd: unknown error");
+					snprintf(g->Message, sizeof(g->Message), "ArrayAdd: unknown error");
 
 				return NULL;
 			}	// endif ArrayAdd
@@ -766,9 +766,9 @@ int JMgoConn::DocWrite(PGLOBAL g, PCSZ line)
 
 	if (env->CallBooleanMethod(job, insertid, doc)) {
 		if (Check(-1))
-			sprintf(g->Message, "CollInsert: %s", Msg);
+			snprintf(g->Message, sizeof(g->Message), "CollInsert: %s", Msg);
 		else
-			sprintf(g->Message, "CollInsert: unknown error");
+			snprintf(g->Message, sizeof(g->Message), "CollInsert: unknown error");
 
 		rc = RC_FX;
 	} // endif Insert
@@ -823,7 +823,7 @@ int JMgoConn::DocUpdate(PGLOBAL g, PTDB tdbp)
 		htrc("DocUpdate: ar = %ld\n", ar);
 
 	if (Check((int)ar)) {
-		sprintf(g->Message, "CollUpdate: %s", Msg);
+		snprintf(g->Message, sizeof(g->Message), "CollUpdate: %s", Msg);
 		rc = RC_FX;
 	} // endif ar
 
@@ -842,7 +842,7 @@ int JMgoConn::DocDelete(PGLOBAL g, bool all)
 		htrc("DocDelete: ar = %ld\n", ar);
 
 	if (Check((int)ar)) {
-		sprintf(g->Message, "CollDelete: %s", Msg);
+		snprintf(g->Message, sizeof(g->Message), "CollDelete: %s", Msg);
 		rc = RC_FX;
 	} // endif ar
 
@@ -867,7 +867,7 @@ PSZ JMgoConn::GetColumnValue(PSZ path)
 	jstring  fn, jn = nullptr;
 
 	if (!path || (jn = env->NewStringUTF(path)) == nullptr) {
-		sprintf(g->Message, "Fail to allocate jstring %s", SVP(path));
+		snprintf(g->Message, sizeof(g->Message), "Fail to allocate jstring %s", SVP(path));
 		throw (int)TYPE_AM_MGO;
 	}	// endif name
 

--- a/storage/connect/json.cpp
+++ b/storage/connect/json.cpp
@@ -208,7 +208,7 @@ PJSON ParseJson(PGLOBAL g, char* s, size_t len, int* ptyp, bool* comma)
           break;
         } // endif pretty
 
-        sprintf(g->Message, "Unexpected ',' (pretty=%d)", pretty);
+        snprintf(g->Message, sizeof(g->Message), "Unexpected ',' (pretty=%d)", pretty);
         throw 3;
       case '(':
         b = true;
@@ -229,7 +229,7 @@ PJSON ParseJson(PGLOBAL g, char* s, size_t len, int* ptyp, bool* comma)
       }; // endswitch s[i]
 
     if (!jsp)
-      sprintf(g->Message, "Invalid Json string '%.*s'", MY_MIN((int)len, 50), s);
+      snprintf(g->Message, sizeof(g->Message), "Invalid Json string '%.*s'", MY_MIN((int)len, 50), s);
     else if (ptyp && pretty == 3) {
       *ptyp = 3;     // Not recognized pretty
 
@@ -278,7 +278,7 @@ PSZ Serialize(PGLOBAL g, PJSON jsp, char* fn, int pretty) {
       b = pretty == 1;
     } else {
       if (!(fs = fopen(fn, "wb"))) {
-        sprintf(g->Message, MSG(OPEN_MODE_ERROR),
+        snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR),
           "w", (int)errno, fn);
         strcat(strcat(g->Message, ": "), strerror(errno));
         throw 2;
@@ -571,7 +571,7 @@ PJAR JDOC::ParseArray(PGLOBAL g, int& i)
     switch (s[i]) {
       case ',':
         if (level < 2) {
-          sprintf(g->Message, "Unexpected ',' near %.*s",ARGS);
+          snprintf(g->Message, sizeof(g->Message), "Unexpected ',' near %.*s",ARGS);
           throw 1;
         } else
           level = 1;
@@ -579,7 +579,7 @@ PJAR JDOC::ParseArray(PGLOBAL g, int& i)
         break;
       case ']':
         if (level == 1) {
-          sprintf(g->Message, "Unexpected ',]' near %.*s", ARGS);
+          snprintf(g->Message, sizeof(g->Message), "Unexpected ',]' near %.*s", ARGS);
           throw 1;
         } // endif level
 
@@ -594,7 +594,7 @@ PJAR JDOC::ParseArray(PGLOBAL g, int& i)
         break;
       default:
         if (level == 2) {
-          sprintf(g->Message, "Unexpected value near %.*s", ARGS);
+          snprintf(g->Message, sizeof(g->Message), "Unexpected value near %.*s", ARGS);
           throw 1;
         } else
           jarp->AddArrayValue(g, ParseValue(g, i));
@@ -630,7 +630,7 @@ PJOB JDOC::ParseObject(PGLOBAL g, int& i)
           jpp = jobp->AddPair(g, key);
           level = 1;
         } else {
-          sprintf(g->Message, "misplaced string near %.*s", ARGS);
+          snprintf(g->Message, sizeof(g->Message), "misplaced string near %.*s", ARGS);
           throw 2;
         } // endif level
 
@@ -640,14 +640,14 @@ PJOB JDOC::ParseObject(PGLOBAL g, int& i)
           jpp->Val = ParseValue(g, ++i);
           level = 2;
         } else {
-          sprintf(g->Message, "Unexpected ':' near %.*s", ARGS);
+          snprintf(g->Message, sizeof(g->Message), "Unexpected ':' near %.*s", ARGS);
           throw 2;
         } // endif level
 
         break;
       case ',':
         if (level < 2) {
-          sprintf(g->Message, "Unexpected ',' near %.*s", ARGS);
+          snprintf(g->Message, sizeof(g->Message), "Unexpected ',' near %.*s", ARGS);
           throw 2;
         } else
           level = 0;
@@ -655,7 +655,7 @@ PJOB JDOC::ParseObject(PGLOBAL g, int& i)
         break;
       case '}':
         if (level == 0 || level == 1) {
-          sprintf(g->Message, "Unexpected '}' near %.*s", ARGS);
+          snprintf(g->Message, sizeof(g->Message), "Unexpected '}' near %.*s", ARGS);
           throw 2;
           } // endif level
 
@@ -667,7 +667,7 @@ PJOB JDOC::ParseObject(PGLOBAL g, int& i)
       case '\t':
         break;
       default:
-        sprintf(g->Message, "Unexpected character '%c' near %.*s",
+        snprintf(g->Message, sizeof(g->Message), "Unexpected character '%c' near %.*s",
                 s[i], ARGS);
         throw 2;
     }; // endswitch s[i]
@@ -750,7 +750,7 @@ PJVAL JDOC::ParseValue(PGLOBAL g, int& i)
   return jvp;
 
 err:
-  sprintf(g->Message, "Unexpected character '%c' near %.*s", s[i], ARGS);
+  snprintf(g->Message, sizeof(g->Message), "Unexpected character '%c' near %.*s", s[i], ARGS);
   throw 3;
 } // end of ParseValue
 
@@ -1767,7 +1767,7 @@ void JVALUE::SetValue(PGLOBAL g, PVAL valp)
     DataType = TYPE_BINT;
     break;
   default:
-    sprintf(g->Message, "Unsupported typ %d\n", valp->GetType());
+    snprintf(g->Message, sizeof(g->Message), "Unsupported typ %d\n", valp->GetType());
     throw(777);
   } // endswitch Type
 

--- a/storage/connect/jsonudf.cpp
+++ b/storage/connect/jsonudf.cpp
@@ -160,7 +160,7 @@ my_bool JSNX::SetArrayOptions(PGLOBAL g, char *p, int i, PSZ nm)
 		jnp->Rank = atoi(p) - B;
 		jnp->Op = OP_EQ;
 	} else if (Wr) {
-		sprintf(g->Message, "Invalid specification %s in a write path", p);
+		snprintf(g->Message, sizeof(g->Message), "Invalid specification %s in a write path", p);
 		return true;
 	} else if (n == 1) {
 		// Set the Op value;
@@ -175,7 +175,7 @@ my_bool JSNX::SetArrayOptions(PGLOBAL g, char *p, int i, PSZ nm)
 			strcpy(g->Message, "Expand not supported by this function");
 			return true;
 		default:
-			sprintf(g->Message, "Invalid function specification %c", *p);
+			snprintf(g->Message, sizeof(g->Message), "Invalid function specification %c", *p);
 			return true;
 		} // endswitch *p
 
@@ -267,7 +267,7 @@ my_bool JSNX::ParseJpath(PGLOBAL g)
 
 		} else if (*p == '*') {
 			if (Wr) {
-				sprintf(g->Message, "Invalid specification %c in a write path", *p);
+				snprintf(g->Message, sizeof(g->Message), "Invalid specification %c in a write path", *p);
 				return true;
 			}	else     			// Return JSON
 				Nodes[i].Op = OP_XX;
@@ -477,7 +477,7 @@ PJVAL JSNX::GetRowValue(PGLOBAL g, PJSON row, int i, my_bool b)
 				val = (PJVAL)row;
 				break;
 			default:
-				sprintf(g->Message, "Invalid row JSON type %d", row->GetType());
+				snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->GetType());
 				val = NULL;
 			} // endswitch Type
 
@@ -708,7 +708,7 @@ my_bool JSNX::CheckPath(PGLOBAL g)
 			val = (PJVAL)row;
 			break;
 		default:
-			sprintf(g->Message, "Invalid row JSON type %d", row->GetType());
+			snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->GetType());
 		} // endswitch Type
 
 		if (i < Nod-1)
@@ -760,7 +760,7 @@ PJSON JSNX::GetRow(PGLOBAL g)
 			val = (PJVAL)row;
 			break;
 		default:
-			sprintf(g->Message, "Invalid row JSON type %d", row->GetType());
+			snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->GetType());
 			val = NULL;
 		} // endswitch Type
 
@@ -1397,7 +1397,7 @@ static my_bool CheckPath(PGLOBAL g, UDF_ARGS *args, PJSON jsp, PJVAL& jvp, int n
 					return true;
 
 				if (!(jvp = jsx->GetJson(g))) {
-					sprintf(g->Message, "No sub-item at '%s'", path);
+					snprintf(g->Message, sizeof(g->Message), "No sub-item at '%s'", path);
 					return true;
 				} // endif jvp
 
@@ -1854,7 +1854,7 @@ static PJSON ParseJsonFile(PGLOBAL g, char *fn, int *pretty, size_t& len)
 		DWORD rc = GetLastError();
 
 		if (!(*g->Message))
-			sprintf(g->Message, MSG(OPEN_MODE_ERROR), "map", (int)rc, fn);
+			snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR), "map", (int)rc, fn);
 
 		return NULL;
 	} // endif hFile
@@ -1876,7 +1876,7 @@ static PJSON ParseJsonFile(PGLOBAL g, char *fn, int *pretty, size_t& len)
 
 	if (!memory) {
 		CloseFileHandle(hFile);
-		sprintf(g->Message, MSG(MAP_VIEW_ERROR), fn, GetLastError());
+		snprintf(g->Message, sizeof(g->Message), MSG(MAP_VIEW_ERROR), fn, GetLastError());
 		return NULL;
 	} // endif Memory
 
@@ -1906,19 +1906,19 @@ char *GetJsonFile(PGLOBAL g, char *fn)
 #endif
 
 	if (h == -1) {
-		sprintf(g->Message, "Error %d opening %-.1024s", errno, fn);
+		snprintf(g->Message, sizeof(g->Message), "Error %d opening %-.1024s", errno, fn);
 		return NULL;
 	} // endif h
 
 	if ((len = _filelength(h)) < 0) {
-		sprintf(g->Message, MSG(FILELEN_ERROR), "_filelength", fn);
+		snprintf(g->Message, sizeof(g->Message), MSG(FILELEN_ERROR), "_filelength", fn);
 		close(h);
 		return NULL;
 	} // endif len
 
 	if ((str = (char*)PlgDBSubAlloc(g, NULL, len + 1))) {
 		if ((n = read(h, str, len)) < 0) {
-			sprintf(g->Message, "Error %d reading %d bytes from %-.1024s", errno, len, fn);
+			snprintf(g->Message, sizeof(g->Message), "Error %d reading %d bytes from %-.1024s", errno, len, fn);
 			return NULL;
 		} // endif n
 
@@ -3372,7 +3372,7 @@ char *json_item_merge(UDF_INIT *initid, UDF_ARGS *args, char *result,
 			if (!i) top = jvp->GetJson();
 
 			if (jvp->GetValType() != TYPE_JAR && jvp->GetValType() != TYPE_JOB) {
-				sprintf(g->Message, "Argument %d is not an array or object", i);
+				snprintf(g->Message, sizeof(g->Message), "Argument %d is not an array or object", i);
 				PUSH_WARNING(g->Message);
 			} else
 				jsp[i] = jvp->GetJsp();
@@ -5535,7 +5535,7 @@ char *jbin_item_merge(UDF_INIT *initid, UDF_ARGS *args, char *result,
 			if (!i) top = jvp->GetJson();
 
 			if (jvp->GetValType() != TYPE_JAR && jvp->GetValType() != TYPE_JOB) {
-				sprintf(g->Message, "Argument %d is not an array or object", i);
+				snprintf(g->Message, sizeof(g->Message), "Argument %d is not an array or object", i);
 				PUSH_WARNING(g->Message);
 			} else
 				jsp[i] = jvp->GetJsp();
@@ -6033,7 +6033,7 @@ char *jfile_bjson(UDF_INIT *initid, UDF_ARGS *args, char *result,
 
 					if (!fgets(buf, lrecl, fin)) {
 						if (!feof(fin)) {
-							sprintf(g->Message, "Error %d reading %zd bytes from %s", errno, lrecl, fn);
+							snprintf(g->Message, sizeof(g->Message), "Error %d reading %zd bytes from %s", errno, lrecl, fn);
 							str = strcpy(result, g->Message);
 						}	else
 							str = strcpy(result, ofn);
@@ -6047,11 +6047,11 @@ char *jfile_bjson(UDF_INIT *initid, UDF_ARGS *args, char *result,
 							swp->SwapJson(jsp, true);
 
 							if (fwrite(binszp, sizeof(binszp), 1, fout) != 1) {
-								sprintf(g->Message, "Error %d writing %zd bytes to %s", 
+								snprintf(g->Message, sizeof(g->Message), "Error %d writing %zd bytes to %s", 
 																		errno, sizeof(binszp), ofn);
 								str = strcpy(result, g->Message);
 							} else if (fwrite(jsp, *binszp, 1, fout) != 1) {
-								sprintf(g->Message, "Error %d writing %zd bytes to %s", 
+								snprintf(g->Message, sizeof(g->Message), "Error %d writing %zd bytes to %s", 
 																		errno, *binszp, ofn);
 								str = strcpy(result, g->Message);
 							} else
@@ -6129,7 +6129,7 @@ char* JUP::UnprettyJsonFile(PGLOBAL g, char *fn, char *outfn, int lrecl) {
 		DWORD rc = GetLastError();
 
 		if (!(*g->Message))
-			sprintf(g->Message, MSG(OPEN_MODE_ERROR), "map", (int)rc, fn);
+			snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR), "map", (int)rc, fn);
 
 		return NULL;
 	} // endif hFile
@@ -6150,7 +6150,7 @@ char* JUP::UnprettyJsonFile(PGLOBAL g, char *fn, char *outfn, int lrecl) {
 
 	if (!mm.memory) {
 		CloseFileHandle(hFile);
-		sprintf(g->Message, MSG(MAP_VIEW_ERROR), fn, GetLastError());
+		snprintf(g->Message, sizeof(g->Message), MSG(MAP_VIEW_ERROR), fn, GetLastError());
 		return NULL;
 	} else
 		s = (char*)mm.memory;
@@ -6161,7 +6161,7 @@ char* JUP::UnprettyJsonFile(PGLOBAL g, char *fn, char *outfn, int lrecl) {
 	/*  Parse the json file and allocate its tree structure.                         */
 	/*********************************************************************************/
 	if (!(fs = fopen(outfn, "wb"))) {
-		sprintf(g->Message, MSG(OPEN_MODE_ERROR),
+		snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR),
 			"w", (int)errno, outfn);
 		strcat(strcat(g->Message, ": "), strerror(errno));
 		CloseMemMap(mm.memory, len);
@@ -6226,7 +6226,7 @@ bool JUP::unPretty(PGLOBAL g, int lrecl) {
 					go = next = false;
 					break;
 				default:
-					sprintf(g->Message, "Unexpected '%c' near %.*s", s[i], ARGS);
+					snprintf(g->Message, sizeof(g->Message), "Unexpected '%c' near %.*s", s[i], ARGS);
 					throw 4;
 					break;
 				}; // endswitch s[i]
@@ -6239,7 +6239,7 @@ bool JUP::unPretty(PGLOBAL g, int lrecl) {
 			buff[k] = 0;
 
 			if ((fputs(buff, fs)) == EOF) {
-				sprintf(g->Message, MSG(FPUTS_ERROR), strerror(errno));
+				snprintf(g->Message, sizeof(g->Message), MSG(FPUTS_ERROR), strerror(errno));
 				throw 5;
 			} // endif EOF
 
@@ -6273,7 +6273,7 @@ void JUP::CopyObject(PGLOBAL g) {
 				CopyString(g);
 				level = 1;
 			} else {
-				sprintf(g->Message, "misplaced string near %.*s", ARGS);
+				snprintf(g->Message, sizeof(g->Message), "misplaced string near %.*s", ARGS);
 				throw 3;
 			} // endif level
 
@@ -6285,7 +6285,7 @@ void JUP::CopyObject(PGLOBAL g) {
 				CopyValue(g);
 				level = 2;
 			} else {
-				sprintf(g->Message, "Unexpected ':' near %.*s", ARGS);
+				snprintf(g->Message, sizeof(g->Message), "Unexpected ':' near %.*s", ARGS);
 				throw 3;
 			} // endif level
 
@@ -6294,7 +6294,7 @@ void JUP::CopyObject(PGLOBAL g) {
 			AddBuff(s[i]);
 
 			if (level < 2) {
-				sprintf(g->Message, "Unexpected ',' near %.*s", ARGS);
+				snprintf(g->Message, sizeof(g->Message), "Unexpected ',' near %.*s", ARGS);
 				throw 3;
 			} else
 				level = 0;
@@ -6304,7 +6304,7 @@ void JUP::CopyObject(PGLOBAL g) {
 			AddBuff(s[i]);
 
 			if (level == 1) {
-				sprintf(g->Message, "Unexpected '}' near %.*s", ARGS);
+				snprintf(g->Message, sizeof(g->Message), "Unexpected '}' near %.*s", ARGS);
 				throw 3;
 			} // endif level
 
@@ -6315,7 +6315,7 @@ void JUP::CopyObject(PGLOBAL g) {
 		case '\t':
 			break;
 		default:
-			sprintf(g->Message, "Unexpected character '%c' near %.*s", s[i], ARGS);
+			snprintf(g->Message, sizeof(g->Message), "Unexpected character '%c' near %.*s", s[i], ARGS);
 			throw 3;
 		}; // endswitch s[i]
 
@@ -6332,7 +6332,7 @@ void JUP::CopyArray(PGLOBAL g) {
 		switch (s[i]) {
 		case ',':
 			if (level < 2) {
-				sprintf(g->Message, "Unexpected ',' near %.*s", ARGS);
+				snprintf(g->Message, sizeof(g->Message), "Unexpected ',' near %.*s", ARGS);
 				throw 2;
 			} else
 				level = 1;
@@ -6341,7 +6341,7 @@ void JUP::CopyArray(PGLOBAL g) {
 			break;
 		case ']':
 			if (level == 1) {
-				sprintf(g->Message, "Unexpected ',]' near %.*s", ARGS);
+				snprintf(g->Message, sizeof(g->Message), "Unexpected ',]' near %.*s", ARGS);
 				throw 2;
 			} // endif level
 
@@ -6354,7 +6354,7 @@ void JUP::CopyArray(PGLOBAL g) {
 			break;
 		default:
 			if (level == 2) {
-				sprintf(g->Message, "Unexpected value near %.*s", ARGS);
+				snprintf(g->Message, sizeof(g->Message), "Unexpected value near %.*s", ARGS);
 				throw 2;
 			} // endif level
 
@@ -6437,7 +6437,7 @@ suite:
 	return;
 
 err:
-	sprintf(g->Message, "Unexpected character '%c' near %.*s", s[i], ARGS);
+	snprintf(g->Message, sizeof(g->Message), "Unexpected character '%c' near %.*s", s[i], ARGS);
 	throw 1;
 } // end of CopyValue
 

--- a/storage/connect/libdoc.cpp
+++ b/storage/connect/libdoc.cpp
@@ -661,7 +661,7 @@ xmlNodeSetPtr LIBXMLDOC::GetNodeList(PGLOBAL g, xmlNodePtr np, char *xp)
 
       if (xmlXPathRegisterNs(Ctxp, BAD_CAST nsp->Prefix,
                                    BAD_CAST nsp->Uri)) {
-        sprintf(g->Message, MSG(REGISTER_ERR), nsp->Prefix, nsp->Uri);
+        snprintf(g->Message, sizeof(g->Message), MSG(REGISTER_ERR), nsp->Prefix, nsp->Uri);
 
         if (trace(1))
           htrc("Ns error: %-.256s\n", g->Message);
@@ -703,7 +703,7 @@ xmlNodeSetPtr LIBXMLDOC::GetNodeList(PGLOBAL g, xmlNodePtr np, char *xp)
 
   // Evaluate table xpath
   if (!(Xop = xmlXPathEval(BAD_CAST xp, Ctxp))) {
-    sprintf(g->Message, MSG(XPATH_EVAL_ERR), xp);
+    snprintf(g->Message, sizeof(g->Message), MSG(XPATH_EVAL_ERR), xp);
 
     if (trace(1))
       htrc("Path error: %-.256s\n", g->Message);
@@ -882,7 +882,7 @@ RCODE XML2NODE::GetContent(PGLOBAL g, char *buf, int len)
         } // endif p1
 
       } else {
-        sprintf(g->Message, "Truncated %-.256s content", Nodep->name);
+        snprintf(g->Message, sizeof(g->Message), "Truncated %-.256s content", Nodep->name);
         rc = RC_INFO;
       } // endif len
 
@@ -1260,7 +1260,7 @@ RCODE XML2ATTR::GetText(PGLOBAL g, char *buf, int len)
     if (strlen((char*)txt) >= (unsigned)len) {
       memcpy(buf, txt, len - 1);
       buf[len - 1] = 0;
-      sprintf(g->Message, "Truncated %-.256s content", Atrp->name);
+      snprintf(g->Message, sizeof(g->Message), "Truncated %-.256s content", Atrp->name);
       rc = RC_INFO;
     } else
       strcpy(buf, (const char*)txt);

--- a/storage/connect/macutil.cpp
+++ b/storage/connect/macutil.cpp
@@ -53,7 +53,7 @@ MACINFO::MACINFO(bool adap, bool fix)
 void MACINFO::MakeErrorMsg(PGLOBAL g, DWORD drc)
   {
   if (drc == ERROR_BUFFER_OVERFLOW)
-    sprintf(g->Message,
+    snprintf(g->Message, sizeof(g->Message),
       "GetAdaptersInfo: Buffer Overflow buflen=%d nbofadap=%d",
       Buflen, N);
   else if (drc == ERROR_INVALID_PARAMETER)
@@ -146,7 +146,7 @@ bool MACINFO::GetFixedInfo(PGLOBAL g)
     } // endif drc
 
   if (drc != ERROR_SUCCESS) {
-    sprintf(g->Message, "GetNetworkParams failed. Rc=%08x\n", drc);
+    snprintf(g->Message, sizeof(g->Message), "GetNetworkParams failed. Rc=%08x\n", drc);
     return true;
     } // endif drc
 
@@ -305,7 +305,7 @@ bool MACINFO::GetOneInfo(PGLOBAL g, int flag, void *v, int lv)
       n = (int)Curp->LeaseExpires;
       break;
     default:
-      sprintf(g->Message, "Invalid flag value %d", flag);
+      snprintf(g->Message, sizeof(g->Message), "Invalid flag value %d", flag);
       return true;
     } // endswitch flag
 

--- a/storage/connect/maputil.cpp
+++ b/storage/connect/maputil.cpp
@@ -50,7 +50,7 @@ HANDLE CreateFileMap(PGLOBAL g, LPCSTR filename,
       disposition = OPEN_ALWAYS;
       break;
     default:
-      sprintf(g->Message, MSG(BAD_FUNC_MODE), "CreateFileMap", mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_FUNC_MODE), "CreateFileMap", mode);
       return INVALID_HANDLE_VALUE;
     } // endswitch
 
@@ -69,11 +69,11 @@ HANDLE CreateFileMap(PGLOBAL g, LPCSTR filename,
         DWORD ler = GetLastError();
       
         if (ler && ler != 1006) {
-          sprintf(g->Message, MSG(FILE_MAP_ERROR), filename, ler);
+          snprintf(g->Message, sizeof(g->Message), MSG(FILE_MAP_ERROR), filename, ler);
           CloseHandle(hFile);
           return INVALID_HANDLE_VALUE;
         } else {
-          sprintf(g->Message, MSG(FILE_IS_EMPTY), filename);
+          snprintf(g->Message, sizeof(g->Message), MSG(FILE_IS_EMPTY), filename);
           return hFile;
         } // endif ler
       
@@ -84,7 +84,7 @@ HANDLE CreateFileMap(PGLOBAL g, LPCSTR filename,
       if (!(mm->memory = MapViewOfFile(hFileMap, access, 0, 0, 0))) {
         DWORD ler = GetLastError();
       
-        sprintf(g->Message, "Error %ld in MapViewOfFile %s", 
+        snprintf(g->Message, sizeof(g->Message), "Error %ld in MapViewOfFile %s", 
                 ler, filename);
         CloseHandle(hFile);
         return INVALID_HANDLE_VALUE;
@@ -149,7 +149,7 @@ HANDLE CreateFileMap(PGLOBAL g, LPCSTR fileName,
       protmode = PROT_WRITE;
       break;
      default:
-      sprintf(g->Message, MSG(BAD_FUNC_MODE), "CreateFileMap", mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_FUNC_MODE), "CreateFileMap", mode);
       return INVALID_HANDLE_VALUE;
    } // endswitch
 
@@ -159,7 +159,7 @@ HANDLE CreateFileMap(PGLOBAL g, LPCSTR fileName,
   if (fd != INVALID_HANDLE_VALUE && mode != MODE_INSERT) {
     /* We must know about the size of the file. */
     if (fstat(fd, &st)) {
-      sprintf(g->Message, MSG(FILE_MAP_ERROR), fileName, errno);
+      snprintf(g->Message, sizeof(g->Message), MSG(FILE_MAP_ERROR), fileName, errno);
       close(fd);
       return INVALID_HANDLE_VALUE;
       }  // endif fstat

--- a/storage/connect/mongo.cpp
+++ b/storage/connect/mongo.cpp
@@ -152,14 +152,14 @@ PQRYRES MGOColumns(PGLOBAL g, PCSZ db, PCSZ uri, PTOS topt, bool info)
 #if defined(CMGO_SUPPORT)
 		cmgd = new(g) CMGDISC(g, (int*)length);
 #else
-		sprintf(g->Message, "Mongo %s Driver not available", "C");
+		snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "C");
 		goto err;
 #endif
 	} else if (drv && toupper(*drv) == 'J') {
 #if defined(JAVA_SUPPORT)
 		cmgd = new(g) JMGDISC(g, (int*)length);
 #else
-		sprintf(g->Message, "Mongo %s Driver not available", "Java");
+		snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "Java");
 		goto err;
 #endif
 	} else {						 // Driver not specified
@@ -421,7 +421,7 @@ PTDB MGODEF::GetTable(PGLOBAL g, MODE m)
 		else
 			return new(g) TDBCMG(this);
 #else
-		sprintf(g->Message, "Mongo %s Driver not available", "C");
+		snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "C");
 		return NULL;
 #endif
 	} else if (Driver && toupper(*Driver) == 'J') {
@@ -431,7 +431,7 @@ PTDB MGODEF::GetTable(PGLOBAL g, MODE m)
 		else
 			return new(g) TDBJMG(this);
 #else
-		sprintf(g->Message, "Mongo %s Driver not available", "Java");
+		snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "Java");
 		return NULL;
 #endif
 	} else {						 // Driver not specified

--- a/storage/connect/mycat.cc
+++ b/storage/connect/mycat.cc
@@ -520,7 +520,7 @@ PTABDEF MYCAT::MakeTableDesc(PGLOBAL g, PTABLE tablep, LPCSTR am)
       /* fall through */
 #endif   // JAVA_SUPPORT || CMGO_SUPPORT
     default:
-      sprintf(g->Message, MSG(BAD_TABLE_TYPE), am, name);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_TABLE_TYPE), am, name);
     } // endswitch
 
   // Do make the table/view definition

--- a/storage/connect/myconn.cpp
+++ b/storage/connect/myconn.cpp
@@ -272,7 +272,7 @@ PQRYRES MyColumns(PGLOBAL g, THD *thd, const char *host, const char *db,
         nf = sscanf(fld, "%s %s %s", buf, uns, zero) + 2;
         break;
       default:
-        sprintf(g->Message, MSG(BAD_FIELD_TYPE), fld);
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_FIELD_TYPE), fld);
         myc.Close();
         return NULL;
       } // endswitch nf
@@ -280,19 +280,19 @@ PQRYRES MyColumns(PGLOBAL g, THD *thd, const char *host, const char *db,
     if ((type = MYSQLtoPLG(buf, &v)) == TYPE_ERROR) {
       if (v == 'K') {
         // Skip this column
-        sprintf(g->Message, "Column %s skipped (unsupported type %s)",
+        snprintf(g->Message, sizeof(g->Message), "Column %s skipped (unsupported type %s)",
                 colname, buf);
         PushWarning(g, thd);
         continue;
         } // endif v
 
-      sprintf(g->Message, "Column %s unsupported type %s", colname, buf);
+      snprintf(g->Message, sizeof(g->Message), "Column %s unsupported type %s", colname, buf);
       myc.Close();
       return NULL;
     } else if (type == TYPE_STRING) {
       if (v == 'X') {
         len = GetConvSize();
-        sprintf(g->Message, "Column %s converted to varchar(%d)",
+        snprintf(g->Message, sizeof(g->Message), "Column %s converted to varchar(%d)",
                 colname, len);
         PushWarning(g, thd);
         v = 'V';
@@ -532,10 +532,10 @@ int MYSQLC::Open(PGLOBAL g, const char *host, const char *db,
   if (!mysql_real_connect(m_DB, host, user, pwd, db, pt, pipe,
 		CLIENT_MULTI_RESULTS | CLIENT_REMEMBER_OPTIONS)) {
 #if defined(_DEBUG)
-    sprintf(g->Message, "mysql_real_connect failed: (%d) %s",
+    snprintf(g->Message, sizeof(g->Message), "mysql_real_connect failed: (%d) %s",
                         mysql_errno(m_DB), mysql_error(m_DB));
 #else   // !_DEBUG
-    sprintf(g->Message, "(%d) %s", mysql_errno(m_DB), mysql_error(m_DB));
+    snprintf(g->Message, sizeof(g->Message), "(%d) %s", mysql_errno(m_DB), mysql_error(m_DB));
 #endif  // !_DEBUG
     mysql_close(m_DB);
     m_DB = NULL;
@@ -616,7 +616,7 @@ int MYSQLC::PrepareSQL(PGLOBAL g, const char *stmt)
 #if defined(ALPHA)
   if (!(m_Stmt = mysql_prepare(m_DB, stmt, strlen(stmt)))) {
 
-    sprintf(g->Message, "mysql_prepare failed: %s [%s]",
+    snprintf(g->Message, sizeof(g->Message), "mysql_prepare failed: %s [%s]",
                          mysql_error(m_DB), stmt);
     return -1;
     } // endif m_Stmt
@@ -630,7 +630,7 @@ int MYSQLC::PrepareSQL(PGLOBAL g, const char *stmt)
     } // endif m_Stmt
 
   if (mysql_stmt_prepare(m_Stmt, stmt, strlen(stmt))) {
-    sprintf(g->Message, "mysql_stmt_prepare() failed: (%d) %s",
+    snprintf(g->Message, sizeof(g->Message), "mysql_stmt_prepare() failed: (%d) %s",
             mysql_stmt_errno(m_Stmt), mysql_stmt_error(m_Stmt));
     return -3;
     } // endif prepare
@@ -653,11 +653,11 @@ int MYSQLC::BindParams(PGLOBAL g, MYSQL_BIND *bind)
 
 #if defined(ALPHA)
   if (mysql_bind_param(m_Stmt, bind)) {
-    sprintf(g->Message, "mysql_bind_param() failed: %s",
+    snprintf(g->Message, sizeof(g->Message), "mysql_bind_param() failed: %s",
                         mysql_stmt_error(m_Stmt));
 #else   // !ALPHA
   if (mysql_stmt_bind_param(m_Stmt, bind)) {
-    sprintf(g->Message, "mysql_stmt_bind_param() failed: %s",
+    snprintf(g->Message, sizeof(g->Message), "mysql_stmt_bind_param() failed: %s",
                         mysql_stmt_error(m_Stmt));
 #endif  // !ALPHA
     return RC_FX;
@@ -677,13 +677,13 @@ int MYSQLC::ExecStmt(PGLOBAL g)
 
 #if defined(ALPHA)
   if (mysql_execute(m_Stmt)) {
-    sprintf(g->Message, "mysql_execute() failed: %s",
+    snprintf(g->Message, sizeof(g->Message), "mysql_execute() failed: %s",
                         mysql_stmt_error(m_Stmt));
     return RC_FX;
     } // endif execute
 #else   // !ALPHA
   if (mysql_stmt_execute(m_Stmt)) {
-    sprintf(g->Message, "mysql_stmt_execute() failed: %s",
+    snprintf(g->Message, sizeof(g->Message), "mysql_stmt_execute() failed: %s",
                         mysql_stmt_error(m_Stmt));
     return RC_FX;
     } // endif execute
@@ -691,7 +691,7 @@ int MYSQLC::ExecStmt(PGLOBAL g)
 
   // Check the total number of affected rows
   if (mysql_stmt_affected_rows(m_Stmt) != 1) {
-    sprintf(g->Message, "Invalid affected rows by MySQL");
+    snprintf(g->Message, sizeof(g->Message), "Invalid affected rows by MySQL");
     return RC_FX;
     } // endif affected_rows
 
@@ -757,7 +757,7 @@ int MYSQLC::ExecSQL(PGLOBAL g, const char *query, int *w)
   } else {
 //  m_Rows = (int)mysql_affected_rows(m_DB);
     m_Rows = (int)m_DB->affected_rows;
-    sprintf(g->Message, "Affected rows: %d\n", m_Rows);
+    snprintf(g->Message, sizeof(g->Message), "Affected rows: %d\n", m_Rows);
     rc = RC_NF;
   } // endif field count
 
@@ -892,7 +892,7 @@ PQRYRES MYSQLC::GetResult(PGLOBAL g, bool pdb)
   MYSQL_ROW    row;
 
   if (!m_Res || !m_Fields) {
-    sprintf(g->Message, "%s result", (m_Res) ? "Void" : "No");
+    snprintf(g->Message, sizeof(g->Message), "%s result", (m_Res) ? "Void" : "No");
     return NULL;
     } // endif m_Res
 
@@ -926,7 +926,7 @@ PQRYRES MYSQLC::GetResult(PGLOBAL g, bool pdb)
 		crp->Name = name;
 
     if ((crp->Type = MYSQLtoPLG(fld->type, &v)) == TYPE_ERROR) {
-      sprintf(g->Message, "Type %d not supported for column %s",
+      snprintf(g->Message, sizeof(g->Message), "Type %d not supported for column %s",
                           fld->type, crp->Name);
       return NULL;
     } else if (crp->Type == TYPE_DATE && !pdb)
@@ -944,7 +944,7 @@ PQRYRES MYSQLC::GetResult(PGLOBAL g, bool pdb)
 
     if (!(crp->Kdata = AllocValBlock(g, NULL, crp->Type, m_Rows,
                                      crp->Clen, 0, FALSE, TRUE, uns))) {
-      sprintf(g->Message, MSG(INV_RESULT_TYPE),
+      snprintf(g->Message, sizeof(g->Message), MSG(INV_RESULT_TYPE),
                           GetFormatType(crp->Type));
       return NULL;
     } else if (crp->Type == TYPE_DATE) {
@@ -973,7 +973,7 @@ PQRYRES MYSQLC::GetResult(PGLOBAL g, bool pdb)
   /*********************************************************************/
   for (n = 0; n < m_Rows; n++) {
     if (!(m_Row = mysql_fetch_row(m_Res))) {
-      sprintf(g->Message, "Missing row %d from result", n + 1);
+      snprintf(g->Message, sizeof(g->Message), "Missing row %d from result", n + 1);
       return NULL;
       } // endif m_Row
 
@@ -1051,7 +1051,7 @@ int MYSQLC::ExecSQLcmd(PGLOBAL g, const char *query, int *w)
 //if (mysql_query(m_DB, query) != 0) {
   if (mysql_real_query(m_DB, query, strlen(query))) {
     m_Afrw = (int)mysql_errno(m_DB);
-    sprintf(g->Message, "Remote: %s", mysql_error(m_DB));
+    snprintf(g->Message, sizeof(g->Message), "Remote: %s", mysql_error(m_DB));
     rc = RC_FX;
 //} else if (!(m_Fields = mysql_field_count(m_DB))) {
   } else if (!(m_Fields = (int)m_DB->field_count)) {

--- a/storage/connect/odbconn.cpp
+++ b/storage/connect/odbconn.cpp
@@ -1183,7 +1183,7 @@ int ODBConn::Open(PCSZ ConnectString, POPARM sop, DWORD options)
 //  VerifyConnect();         Deprecated
     GetConnectInfo();
   } catch(DBX *xp) {
-    sprintf(g->Message, "%s: %s", xp->m_Msg, xp->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", xp->m_Msg, xp->GetErrorMessage(0));
     Close();
 //  Free();
     return -1;
@@ -1646,7 +1646,7 @@ int ODBConn::Fetch(int pos)
       for (int i = 0; i < MAX_NUM_OF_MSG && x->m_ErrMsg[i]; i++)
         htrc(x->m_ErrMsg[i]);
 
-    sprintf(g->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     irc = -1;
   } // end try/catch
 
@@ -1682,7 +1682,7 @@ int ODBConn::PrepareSQL(char *sql)
         for (int i = 0; i < MAX_NUM_OF_MSG && x->m_ErrMsg[i]; i++)
           htrc(x->m_ErrMsg[i]);
 
-    sprintf(g->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     } // end try/catch
 
     } // endif Mode
@@ -1728,7 +1728,7 @@ int ODBConn::PrepareSQL(char *sql)
       for (int i = 0; i < MAX_NUM_OF_MSG && x->m_ErrMsg[i]; i++)
         htrc(x->m_ErrMsg[i]);
 
-    sprintf(g->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
 
     if (b)
       SQLCancel(hstmt);
@@ -1928,7 +1928,7 @@ bool ODBConn::ExecSQLcommand(char *sql)
 			for (int i = 0; i < MAX_NUM_OF_MSG && x->m_ErrMsg[i]; i++)
 				htrc(x->m_ErrMsg[i]);
 
-    sprintf(g->Message, "Remote %s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "Remote %s: %s", x->m_Msg, x->GetErrorMessage(0));
 
     if (b)
       SQLCancel(hstmt);
@@ -1938,17 +1938,17 @@ bool ODBConn::ExecSQLcommand(char *sql)
   } // end try/catch
 
   if (!Check(rc = SQLFreeStmt(hstmt, SQL_CLOSE)))
-    sprintf(g->Message, "SQLFreeStmt: rc=%d", rc);
+    snprintf(g->Message, sizeof(g->Message), "SQLFreeStmt: rc=%d", rc);
 
   if (m_Transact) {
     // Terminate the transaction
     if (!Check(rc = SQLEndTran(SQL_HANDLE_DBC, m_hdbc, 
                        (rcd) ? SQL_ROLLBACK : SQL_COMMIT)))
-      sprintf(g->Message, "SQLEndTran: rc=%d", rc);
+      snprintf(g->Message, sizeof(g->Message), "SQLEndTran: rc=%d", rc);
 
     if (!Check(rc = SQLSetConnectAttr(m_hdbc, SQL_ATTR_AUTOCOMMIT,
                (SQLPOINTER)SQL_AUTOCOMMIT_ON, SQL_IS_UINTEGER)))
-      sprintf(g->Message, "SQLSetConnectAttr: rc=%d", rc);
+      snprintf(g->Message, sizeof(g->Message), "SQLSetConnectAttr: rc=%d", rc);
 
     m_Transact = false;
     } // endif m_Transact
@@ -2013,7 +2013,7 @@ PQRYRES ODBConn::GetMetaData(PGLOBAL g, PCSZ dsn, PCSZ src)
       } // endfor i
 
   } catch(DBX *x) {
-    sprintf(g->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     goto err;
   } // end try/catch
 
@@ -2064,7 +2064,7 @@ PQRYRES ODBConn::GetMetaData(PGLOBAL g, PCSZ dsn, PCSZ src)
       } // endfor i
 
   } catch(DBX *x) {
-    sprintf(g->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     qrp = NULL;
   } // end try/catch
 
@@ -2374,7 +2374,7 @@ int ODBConn::GetCatInfo(CATPARM *cap)
     // Now bind the column buffers
     for (n = 0, crp = qrp->Colresp; crp; crp = crp->Next) {
       if ((tp = GetSQLCType(crp->Type)) == SQL_TYPE_NULL) {
-        sprintf(g->Message, MSG(INV_COLUMN_TYPE), crp->Type, crp->Name);
+        snprintf(g->Message, sizeof(g->Message), MSG(INV_COLUMN_TYPE), crp->Type, crp->Name);
         ThrowDBX(g->Message);
         } // endif tp
 
@@ -2460,9 +2460,9 @@ int ODBConn::GetCatInfo(CATPARM *cap)
 
     if (rc == SQL_NO_DATA_FOUND) {
       if (cap->Pat)
-        sprintf(g->Message, MSG(NO_TABCOL_DATA), cap->Tab, cap->Pat);
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_TABCOL_DATA), cap->Tab, cap->Pat);
       else
-        sprintf(g->Message, MSG(NO_TAB_DATA), cap->Tab);
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_TAB_DATA), cap->Tab);
 
       ThrowDBX(g->Message);
     } else if (rc == SQL_SUCCESS) {
@@ -2487,7 +2487,7 @@ int ODBConn::GetCatInfo(CATPARM *cap)
       for (int i = 0; i < MAX_NUM_OF_MSG && x->m_ErrMsg[i]; i++)
         htrc(x->m_ErrMsg[i]);
 
-    sprintf(g->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(g->Message, sizeof(g->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     irc = -1;
   } // end try/catch
 
@@ -2549,7 +2549,7 @@ PQRYRES ODBConn::AllocateResult(PGLOBAL g)
 
       if (!(crp->Kdata = AllocValBlock(g, NULL, crp->Type, m_Rows,
                                      crp->Clen, 0, FALSE, TRUE, uns))) {
-        sprintf(g->Message, MSG(INV_RESULT_TYPE),
+        snprintf(g->Message, sizeof(g->Message), MSG(INV_RESULT_TYPE),
                           GetFormatType(crp->Type));
         return NULL;
         } // endif Kdata

--- a/storage/connect/plgdbutl.cpp
+++ b/storage/connect/plgdbutl.cpp
@@ -313,7 +313,7 @@ PDBUSER PlgMakeUser(PGLOBAL g)
   PDBUSER dbuserp;
 
   if (!(dbuserp = (PDBUSER)malloc(sizeof(DBUSERBLK)))) {
-    sprintf(g->Message, MSG(MALLOC_ERROR), "PlgMakeUser");
+    snprintf(g->Message, sizeof(g->Message), MSG(MALLOC_ERROR), "PlgMakeUser");
     return NULL;
     } // endif dbuserp
 
@@ -416,7 +416,7 @@ char *ExtractFromPath(PGLOBAL g, char *pBuff, char *FileName, OPVAL op)
     case OP_FNAME: fname = pBuff; break;
     case OP_FTYPE: ftype = pBuff; break;
     default:
-      sprintf(g->Message, MSG(INVALID_OPER), op, "ExtractFromPath");
+      snprintf(g->Message, sizeof(g->Message), MSG(INVALID_OPER), op, "ExtractFromPath");
       return NULL;
     } // endswitch op
 
@@ -1399,7 +1399,7 @@ void *PlgDBSubAlloc(PGLOBAL g, void *memp, size_t size)
          memp, size, pph->To_Free, pph->FreeBlk);
 
   if (size > pph->FreeBlk) {   /* Not enough memory left in pool */
-    sprintf(g->Message,
+    snprintf(g->Message, sizeof(g->Message),
     "Not enough memory in Work area for request of %zd (used=%zd free=%zd)",
             size, pph->To_Free, pph->FreeBlk);
 
@@ -1530,7 +1530,7 @@ DllExport void NewPointer(PTABS t, void *oldv, void *newv)
     if (!(tp = new TABPTR)) {
       PGLOBAL g = t->G;
 
-      sprintf(g->Message, "NewPointer: %s", MSG(MEM_ALLOC_ERROR));
+      snprintf(g->Message, sizeof(g->Message), "NewPointer: %s", MSG(MEM_ALLOC_ERROR));
 			throw 3;
 		} else {
       tp->Next = t->P1;
@@ -1565,7 +1565,7 @@ int FileComp(PGLOBAL g, char *file1, char *file2)
 
     if (h[i] == -1) {
 //      if (errno != ENOENT) {
-        sprintf(g->Message, MSG(OPEN_MODE_ERROR),
+        snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR),
                 "rb", (int)errno, fn[i]);
         strcat(strcat(g->Message, ": "), strerror(errno));
 				throw 666;
@@ -1574,7 +1574,7 @@ int FileComp(PGLOBAL g, char *file1, char *file2)
 
     } else {
       if ((len[i] = _filelength(h[i])) < 0) {
-        sprintf(g->Message, MSG(FILELEN_ERROR), "_filelength", fn[i]);
+        snprintf(g->Message, sizeof(g->Message), MSG(FILELEN_ERROR), "_filelength", fn[i]);
 				throw 666;
 			} // endif len
 
@@ -1588,7 +1588,7 @@ int FileComp(PGLOBAL g, char *file1, char *file2)
   while (rc == -1) {
     for (i = 0; i < 2; i++)
       if ((n[i] = read(h[i], bp[i], 4096)) < 0) {
-        sprintf(g->Message, MSG(READ_ERROR), fn[i], strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), fn[i], strerror(errno));
         goto fin;
         } // endif n
 

--- a/storage/connect/plgxml.cpp
+++ b/storage/connect/plgxml.cpp
@@ -52,7 +52,7 @@ bool XMLDOCUMENT::InitZip(PGLOBAL g, PCSZ entry)
 	zip = new(g) UNZIPUTL(entry, NULL, mul);
 	return zip == NULL;
 #else   // !ZIP_SUPPORT
-	sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+	snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
 	return true;
 #endif  // !ZIP_SUPPORT
 } // end of InitZip

--- a/storage/connect/plugutil.cpp
+++ b/storage/connect/plugutil.cpp
@@ -478,7 +478,7 @@ bool AllocSarea(PGLOBAL g, size_t size)
 		g->Sarea = malloc(size);
 
 	if (!g->Sarea) {
-		sprintf(g->Message, MSG(MALLOC_ERROR), "malloc");
+		snprintf(g->Message, sizeof(g->Message), MSG(MALLOC_ERROR), "malloc");
 		g->Sarea_Size = 0;
 	}	else {
     g->Sarea_Size = size;
@@ -574,7 +574,7 @@ void *PlugSubAlloc(PGLOBAL g, void *memp, size_t size)
   if (size > pph->FreeBlk) {   /* Not enough memory left in pool */
     PCSZ pname = "Work";
 
-    sprintf(g->Message,
+    snprintf(g->Message, sizeof(g->Message),
       "Not enough memory in %-.256s area for request of %zu (used=%zu free=%zu)",
                           pname, size, pph->To_Free, pph->FreeBlk);
 

--- a/storage/connect/reldef.cpp
+++ b/storage/connect/reldef.cpp
@@ -114,7 +114,7 @@ PQRYRES OEMColumns(PGLOBAL g, PTOS topt, char* tab, char* db, bool info)
 		char  buf[256];
 		DWORD rc = GetLastError();
 
-		sprintf(g->Message, MSG(DLL_LOAD_ERROR), rc, soname);
+		snprintf(g->Message, sizeof(g->Message), MSG(DLL_LOAD_ERROR), rc, soname);
 		FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
 			FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
 			(LPTSTR)buf, sizeof(buf), NULL);
@@ -124,7 +124,7 @@ PQRYRES OEMColumns(PGLOBAL g, PTOS topt, char* tab, char* db, bool info)
 
 // Get the function returning an instance of the external DEF class
 	if (!(coldef = (XCOLDEF)GetProcAddress((HINSTANCE)hdll, getname))) {
-		sprintf(g->Message, MSG(PROCADD_ERROR), GetLastError(), getname);
+		snprintf(g->Message, sizeof(g->Message), MSG(PROCADD_ERROR), GetLastError(), getname);
 		FreeLibrary((HMODULE)hdll);
 		return NULL;
 	} // endif coldef
@@ -134,21 +134,21 @@ PQRYRES OEMColumns(PGLOBAL g, PTOS topt, char* tab, char* db, bool info)
 	// Load the desired shared library
 	if (!(hdll = dlopen(soname, RTLD_LAZY))) {
 		error = dlerror();
-		sprintf(g->Message, MSG(SHARED_LIB_ERR), soname, SVP(error));
+		snprintf(g->Message, sizeof(g->Message), MSG(SHARED_LIB_ERR), soname, SVP(error));
 		return NULL;
 	} // endif Hdll
 
 // Get the function returning an instance of the external DEF class
 	if (!(coldef = (XCOLDEF)dlsym(hdll, getname))) {
 		error = dlerror();
-		sprintf(g->Message, MSG(GET_FUNC_ERR), getname, SVP(error));
+		snprintf(g->Message, sizeof(g->Message), MSG(GET_FUNC_ERR), getname, SVP(error));
 		dlclose(hdll);
 		return NULL;
 	} // endif coldef
 #endif  // !_WIN32
 
 	// Just in case the external Get function does not set error messages
-	sprintf(g->Message, "Error getting column info from %s", subtype);
+	snprintf(g->Message, sizeof(g->Message), "Error getting column info from %s", subtype);
 
 	// Get the table column definition
 	qrp = coldef(g, topt, tab, db, info);
@@ -520,7 +520,7 @@ int TABDEF::GetColCatInfo(PGLOBAL g)
             case 'T': nof = sizeof(char);     break;
             case 'G': nof = sizeof(longlong); break;
             default:  /* Wrong format */
-              sprintf(g->Message, "Invalid format %c", fty);
+              snprintf(g->Message, sizeof(g->Message), "Invalid format %c", fty);
               return -1;
             } // endswitch fty
 
@@ -638,7 +638,7 @@ PTABDEF OEMDEF::GetXdef(PGLOBAL g)
       char  buf[256];
       DWORD rc = GetLastError();
 
-      sprintf(g->Message, MSG(DLL_LOAD_ERROR), rc, soname);
+      snprintf(g->Message, sizeof(g->Message), MSG(DLL_LOAD_ERROR), rc, soname);
       FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                     FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
                     (LPTSTR)buf, sizeof(buf), NULL);
@@ -658,7 +658,7 @@ PTABDEF OEMDEF::GetXdef(PGLOBAL g)
     char  buf[256];
     DWORD rc = GetLastError();
 
-    sprintf(g->Message, MSG(PROCADD_ERROR), rc, getname);
+    snprintf(g->Message, sizeof(g->Message), MSG(PROCADD_ERROR), rc, getname);
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
       FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
       (LPTSTR)buf, sizeof(buf), NULL);
@@ -676,13 +676,13 @@ PTABDEF OEMDEF::GetXdef(PGLOBAL g)
   if (dladdr(&connect_hton, &dl_info)) {
     if (dlopen(dl_info.dli_fname, RTLD_NOLOAD | RTLD_NOW | RTLD_GLOBAL) == 0) {
       error = dlerror();
-      sprintf(g->Message, "dlopen failed: %s, OEM not supported", SVP(error));
+      snprintf(g->Message, sizeof(g->Message), "dlopen failed: %s, OEM not supported", SVP(error));
       return NULL;
       } // endif dlopen
 
   } else {
     error = dlerror();
-    sprintf(g->Message, "dladdr failed: %s, OEM not supported", SVP(error));
+    snprintf(g->Message, sizeof(g->Message), "dladdr failed: %s, OEM not supported", SVP(error));
     return NULL;
   } // endif dladdr
 #endif // 0
@@ -690,7 +690,7 @@ PTABDEF OEMDEF::GetXdef(PGLOBAL g)
   // Load the desired shared library
   if (!Hdll && !(Hdll = dlopen(soname, RTLD_LAZY))) {
     error = dlerror();
-    sprintf(g->Message, MSG(SHARED_LIB_ERR), soname, SVP(error));
+    snprintf(g->Message, sizeof(g->Message), MSG(SHARED_LIB_ERR), soname, SVP(error));
     return NULL;
     } // endif Hdll
 
@@ -704,14 +704,14 @@ PTABDEF OEMDEF::GetXdef(PGLOBAL g)
   // Get the function returning an instance of the external DEF class
   if (!(getdef = (XGETDEF)dlsym(Hdll, getname))) {
     error = dlerror();
-    sprintf(g->Message, MSG(GET_FUNC_ERR), getname, SVP(error));
+    snprintf(g->Message, sizeof(g->Message), MSG(GET_FUNC_ERR), getname, SVP(error));
     dlclose(Hdll);
     return NULL;
     } // endif getdef
 #endif  // !_WIN32
 
   // Just in case the external Get function does not set error messages
-  sprintf(g->Message, MSG(DEF_ALLOC_ERROR), Subtype);
+  snprintf(g->Message, sizeof(g->Message), MSG(DEF_ALLOC_ERROR), Subtype);
 
   // Get the table definition block
   if (!(xdefp = getdef(g, NULL)))
@@ -921,7 +921,7 @@ int COLDEF::Define(PGLOBAL g, void *, PCOLINFO cfp, int poff)
     Buf_Type = cfp->Type;
 
     if ((Clen = GetTypeSize(Buf_Type, cfp->Length)) < 0) {
-      sprintf(g->Message, MSG(BAD_COL_TYPE), GetTypeName(Buf_Type), Name);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_COL_TYPE), GetTypeName(Buf_Type), Name);
       return -1;
       } // endswitch
 

--- a/storage/connect/tabbson.cpp
+++ b/storage/connect/tabbson.cpp
@@ -233,7 +233,7 @@ int BSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
       (tdp->Version == 2) ? "Mongo2Interface" : "Mongo3Interface");
     tdp->Pretty = 0;
 #else   // !MONGO_SUPPORT
-    sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
     return 0;
 #endif  // !MONGO_SUPPORT
   } // endif Uri
@@ -245,7 +245,7 @@ int BSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #if defined(ZIP_SUPPORT)
       tjsp = new(g) TDBBSON(g, tdp, new(g) UNZFAM(tdp));
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return 0;
 #endif  // !ZIP_SUPPORT
     } else
@@ -261,7 +261,7 @@ int BSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
   } else {
     if (!((tdp->Lrecl = GetIntegerTableOption(g, topt, "Lrecl", 0)))) {
       if (!mgo) {
-        sprintf(g->Message, "LRECL must be specified for pretty=%d", tdp->Pretty);
+        snprintf(g->Message, sizeof(g->Message), "LRECL must be specified for pretty=%d", tdp->Pretty);
         return 0;
       } else
         tdp->Lrecl = 8192;       // Should be enough
@@ -276,7 +276,7 @@ int BSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #if defined(ZIP_SUPPORT)
       tjnp = new(g)TDBBSN(g, tdp, new(g) UNZFAM(tdp));
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return NULL;
 #endif  // !ZIP_SUPPORT
     } else if (tdp->Uri) {
@@ -284,14 +284,14 @@ int BSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #if defined(CMGO_SUPPORT)
         tjnp = new(g) TDBBSN(g, tdp, new(g) CMGFAM(tdp));
 #else
-        sprintf(g->Message, "Mongo %s Driver not available", "C");
+        snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "C");
         return 0;
 #endif
       } else if (tdp->Driver && toupper(*tdp->Driver) == 'J') {
 #if defined(JAVA_SUPPORT)
         tjnp = new(g) TDBBSN(g, tdp, new(g) JMGFAM(tdp));
 #else
-        sprintf(g->Message, "Mongo %s Driver not available", "Java");
+        snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "Java");
         return 0;
 #endif
       } else {             // Driver not specified
@@ -300,7 +300,7 @@ int BSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #elif defined(JAVA_SUPPORT)
         tjnp = new(g) TDBBSN(g, tdp, new(g) JMGFAM(tdp));
 #else
-        sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
         return 0;
 #endif
       } // endif Driver
@@ -503,7 +503,7 @@ bool BSONDISC::Find(PGLOBAL g, PBVAL jvp, PCSZ key, int j)
 
       return false;
     default:
-      sprintf(g->Message, "Logical error after %s", fmt);
+      snprintf(g->Message, sizeof(g->Message), "Logical error after %s", fmt);
       return true;
     } // endswitch Type
 
@@ -626,7 +626,7 @@ PBVAL BTUTIL::FindRow(PGLOBAL g)
     } else {
       if (bp || *objpath == '[') {                   // Old style
         if (objpath[strlen(objpath) - 1] != ']') {
-          sprintf(g->Message, "Invalid Table path %s", Tp->Objname);
+          snprintf(g->Message, sizeof(g->Message), "Invalid Table path %s", Tp->Objname);
           return NULL;
         } else if (!bp)
           objpath++;
@@ -706,7 +706,7 @@ PBVAL BTUTIL::MakeTopTree(PGLOBAL g, int type)
           if (bp || *objpath == '[') {
             // Old style
             if (objpath[strlen(objpath) - 1] != ']') {
-              sprintf(g->Message, "Invalid Table path %s", Tp->Objname);
+              snprintf(g->Message, sizeof(g->Message), "Invalid Table path %s", Tp->Objname);
               return NULL;
             } else if (!bp)
               objpath++;
@@ -918,7 +918,7 @@ PBVAL BCUTIL::GetRowValue(PGLOBAL g, PBVAL row, int i)
       bvp = row;
       break;
     default:
-      sprintf(g->Message, "Invalid row JSON type %d", row->Type);
+      snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->Type);
       bvp = NULL;
     } // endswitch Type
 
@@ -1122,7 +1122,7 @@ PBVAL BCUTIL::GetRow(PGLOBAL g)
       val = row;
       break;
     default:
-      sprintf(g->Message, "Invalid row JSON type %d", row->Type);
+      snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->Type);
       val = NULL;
     } // endswitch Type
 
@@ -1222,7 +1222,7 @@ bool BSONDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
       Wrapname = GetStringCatInfo(g, "Wrapper", "Mongo3Interface");
 #endif   // JAVA_SUPPORT
 #else   // !MONGO_SUPPORT
-    sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
     return true;
 #endif  // !MONGO_SUPPORT
   } // endif Uri
@@ -1266,14 +1266,14 @@ PTDB BSONDEF::GetTable(PGLOBAL g, MODE m)
 #if defined(CMGO_SUPPORT)
         txfp = new(g) CMGFAM(this);
 #else
-        sprintf(g->Message, "Mongo %s Driver not available", "C");
+        snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "C");
         return NULL;
 #endif
       } else if (Driver && toupper(*Driver) == 'J') {
 #if defined(JAVA_SUPPORT)
         txfp = new(g) JMGFAM(this);
 #else
-        sprintf(g->Message, "Mongo %s Driver not available", "Java");
+        snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "Java");
         return NULL;
 #endif
       } else {             // Driver not specified
@@ -1282,7 +1282,7 @@ PTDB BSONDEF::GetTable(PGLOBAL g, MODE m)
 #elif defined(JAVA_SUPPORT)
         txfp = new(g) JMGFAM(this);
 #else   // !MONGO_SUPPORT
-        sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
         return NULL;
 #endif  // !MONGO_SUPPORT
       } // endif Driver
@@ -1299,7 +1299,7 @@ PTDB BSONDEF::GetTable(PGLOBAL g, MODE m)
         return NULL;
       } // endif's m
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return NULL;
 #endif  // !ZIP_SUPPORT
     } else if (Compressed) {
@@ -1309,7 +1309,7 @@ PTDB BSONDEF::GetTable(PGLOBAL g, MODE m)
       else
         txfp = new(g) ZLBFAM(this);
 #else   // !GZ_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "GZ");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "GZ");
       return NULL;
 #endif  // !GZ_SUPPORT
     } else if (map) {
@@ -1332,7 +1332,7 @@ PTDB BSONDEF::GetTable(PGLOBAL g, MODE m)
         return NULL;
       } // endif's m
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return NULL;
 #endif  // !ZIP_SUPPORT
     } else
@@ -1554,7 +1554,7 @@ bool TDBBSN::OpenDB(PGLOBAL g)
       case MODE_ARRAY:  type = TYPE_JAR;  break;
       case MODE_VALUE:  type = TYPE_JVAL; break;
       default:
-        sprintf(g->Message, "Invalid Jmode %d", Jmode);
+        snprintf(g->Message, sizeof(g->Message), "Invalid Jmode %d", Jmode);
         return true;
     } // endswitch Jmode
 
@@ -1662,7 +1662,7 @@ bool TDBBSN::PrepareWriting(PGLOBAL g)
 
       if ((signed)strlen(s) > Lrecl) {
         strncpy(To_Line, s, Lrecl);
-        sprintf(g->Message, "Line truncated (lrecl=%d)", Lrecl);
+        snprintf(g->Message, sizeof(g->Message), "Line truncated (lrecl=%d)", Lrecl);
         return PushWarning(g, this);
       } else
         strcpy(To_Line, s);
@@ -1847,7 +1847,7 @@ bool BSONCOL::SetArrayOptions(PGLOBAL g, char* p, int i, PSZ nm)
 
       break;
     default:
-      sprintf(g->Message,
+      snprintf(g->Message, sizeof(g->Message),
         "Invalid function specification %c for %s", *p, Name);
       return true;
     } // endswitch *p
@@ -1863,7 +1863,7 @@ bool BSONCOL::SetArrayOptions(PGLOBAL g, char* p, int i, PSZ nm)
     } // endif n
 
   } else {
-    sprintf(g->Message, "Wrong array specification for %s", Name);
+    snprintf(g->Message, sizeof(g->Message), "Wrong array specification for %s", Name);
     return true;
   } // endif's
 
@@ -1932,7 +1932,7 @@ bool BSONCOL::ParseJpath(PGLOBAL g)
         goto fin;
       } // endif Name
 
-    sprintf(g->Message, "Cannot parse updated column %s", Name);
+    snprintf(g->Message, sizeof(g->Message), "Cannot parse updated column %s", Name);
     return true;
   } // endif To_Orig
 
@@ -2174,7 +2174,7 @@ void BSONCOL::WriteColumn(PGLOBAL g)
 
     break;
   default:                  // ??????????
-    sprintf(g->Message, "Invalid column type %d", Buf_Type);
+    snprintf(g->Message, sizeof(g->Message), "Invalid column type %d", Buf_Type);
   } // endswitch Type
 
 } // end of WriteColumn
@@ -2324,7 +2324,7 @@ int TDBBSON::MakeDocument(PGLOBAL g)
         val = Bp->GetKeyValue(objp, key);
 
         if (!val || !(jsp = Bp->GetBson(val))) {
-          sprintf(g->Message, "Cannot find object key %s", key);
+          snprintf(g->Message, sizeof(g->Message), "Cannot find object key %s", key);
           return RC_FX;
         } // endif val
 
@@ -2332,7 +2332,7 @@ int TDBBSON::MakeDocument(PGLOBAL g)
         if (*p == '[') {
           // Old style
           if (p[strlen(p) - 1] != ']') {
-            sprintf(g->Message, "Invalid Table path near %s", p);
+            snprintf(g->Message, sizeof(g->Message), "Invalid Table path near %s", p);
             return RC_FX;
           } else
             p++;
@@ -2350,7 +2350,7 @@ int TDBBSON::MakeDocument(PGLOBAL g)
         val = Bp->GetArrayValue(arp, i);
 
         if (!val) {
-          sprintf(g->Message, "Cannot find array value %d", i);
+          snprintf(g->Message, sizeof(g->Message), "Cannot find array value %d", i);
           return RC_FX;
         } // endif val
 
@@ -2515,7 +2515,7 @@ bool TDBBSON::OpenDB(PGLOBAL g)
     case MODE_ARRAY:  Row = Bp->NewVal(TYPE_JAR);  break;
     case MODE_VALUE:  Row = Bp->NewVal(TYPE_JVAL); break;
     default:
-      sprintf(g->Message, "Invalid Jmode %d", Jmode);
+      snprintf(g->Message, sizeof(g->Message), "Invalid Jmode %d", Jmode);
       return true;
     } // endswitch Jmode
 

--- a/storage/connect/tabdos.cpp
+++ b/storage/connect/tabdos.cpp
@@ -199,7 +199,7 @@ bool DOSDEF::GetOptFileName(PGLOBAL g, char *filename)
 		case RECFM_CSV: ftype = ".cop"; break;
 		case RECFM_DBF: ftype = ".dbp"; break;
     default:
-      sprintf(g->Message, MSG(INVALID_FTYPE), Recfm);
+      snprintf(g->Message, sizeof(g->Message), MSG(INVALID_FTYPE), Recfm);
       return true;
     } // endswitch Ftype
 
@@ -270,7 +270,7 @@ bool DOSDEF::DeleteIndexFile(PGLOBAL g, PIXDEF pxdf)
 		case RECFM_CSV: ftype = ".cnx"; break;
 		case RECFM_DBF: ftype = ".dbx"; break;
     default:
-      sprintf(g->Message, MSG(BAD_RECFM_VAL), Recfm);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_RECFM_VAL), Recfm);
       return true;
     } // endswitch Ftype
 
@@ -323,7 +323,7 @@ bool DOSDEF::DeleteIndexFile(PGLOBAL g, PIXDEF pxdf)
   } // endif sep
 
   if (rc)
-    sprintf(g->Message, MSG(DEL_FILE_ERR), filename);
+    snprintf(g->Message, sizeof(g->Message), MSG(DEL_FILE_ERR), filename);
 
   return rc;                        // Return true if error
   } // end of DeleteIndexFile
@@ -405,7 +405,7 @@ PTDB DOSDEF::GetTable(PGLOBAL g, MODE mode)
 		} // endif Recfm
 
 #else   // !ZIP_SUPPORT
-		sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+		snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
 		return NULL;
 #endif  // !ZIP_SUPPORT
   } else if (Recfm != RECFM_VAR && Compressed < 2) {
@@ -417,7 +417,7 @@ PTDB DOSDEF::GetTable(PGLOBAL g, MODE mode)
 #if defined(GZ_SUPPORT)
       txfp = new(g) GZXFAM(this);
 #else   // !GZ_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "GZ");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "GZ");
       return NULL;
 #endif  // !GZ_SUPPORT
     } else
@@ -433,7 +433,7 @@ PTDB DOSDEF::GetTable(PGLOBAL g, MODE mode)
         txfp = new(g) ZLBFAM(this);
 
 #else   // !GZ_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "GZ");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "GZ");
       return NULL;
 #endif  // !GZ_SUPPORT
     } else if (map)
@@ -468,7 +468,7 @@ PTDB DOSDEF::GetTable(PGLOBAL g, MODE mode)
             ((PZLBFAM)txfp)->SetOptimized(To_Pos != NULL);
             } // endelse
 #else
-          sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "GZ");
+          snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "GZ");
           return NULL;
 #endif
         } else
@@ -911,7 +911,7 @@ bool TDBDOS::SaveBlockValues(PGLOBAL g)
     return true;
 
   if (!(opfile = fopen(filename, "wb"))) {
-    sprintf(g->Message, MSG(OPEN_MODE_ERROR),
+    snprintf(g->Message, sizeof(g->Message), MSG(OPEN_MODE_ERROR),
             "wb", (int)errno, filename);
     strcat(strcat(g->Message, ": "), strerror(errno));
 
@@ -932,12 +932,12 @@ bool TDBDOS::SaveBlockValues(PGLOBAL g)
     n[0] = Txfp->Last; n[1] = lg; n[2] = Txfp->Nrec; n[3] = Txfp->Block;
 
     if (fwrite(n, sizeof(int), NZ, opfile) != NZ) {
-      sprintf(g->Message, MSG(OPT_HEAD_WR_ERR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(OPT_HEAD_WR_ERR), strerror(errno));
       rc = true;
       } // endif size
 
     if (fwrite(Txfp->BlkPos, lg, block, opfile) != block) {
-      sprintf(g->Message, MSG(OPTBLK_WR_ERR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(OPTBLK_WR_ERR), strerror(errno));
       rc = true;
       } // endif size
 
@@ -960,17 +960,17 @@ bool TDBDOS::SaveBlockValues(PGLOBAL g)
       n[4] = ndv; n[5] = nbm;
 
       if (fwrite(n, sizeof(int), NZ + 2, opfile) != NZ + 2) {
-        sprintf(g->Message, MSG(OPT_HEAD_WR_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(OPT_HEAD_WR_ERR), strerror(errno));
         rc = true;
         } // endif size
 
       if (fwrite(colp->Dval->GetValPointer(), lg, ndv, opfile) != ndv) {
-        sprintf(g->Message, MSG(OPT_DVAL_WR_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(OPT_DVAL_WR_ERR), strerror(errno));
         rc = true;
         } // endif size
 
       if (fwrite(colp->Bmap->GetValPointer(), sizeof(int), nbk, opfile) != nbk) {
-        sprintf(g->Message, MSG(OPT_BMAP_WR_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(OPT_BMAP_WR_ERR), strerror(errno));
         rc = true;
         } // endif size
 
@@ -978,17 +978,17 @@ bool TDBDOS::SaveBlockValues(PGLOBAL g)
       n[0] = colp->Index; n[1] = lg; n[2] = Txfp->Nrec; n[3] = block;
 
       if (fwrite(n, sizeof(int), NZ, opfile) != NZ) {
-        sprintf(g->Message, MSG(OPT_HEAD_WR_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(OPT_HEAD_WR_ERR), strerror(errno));
         rc = true;
         } // endif size
 
       if (fwrite(colp->Min->GetValPointer(), lg, block, opfile) != block) {
-        sprintf(g->Message, MSG(OPT_MIN_WR_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(OPT_MIN_WR_ERR), strerror(errno));
         rc = true;
         } // endif size
 
       if (fwrite(colp->Max->GetValPointer(), lg, block, opfile) != block) {
-        sprintf(g->Message, MSG(OPT_MAX_WR_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(OPT_MAX_WR_ERR), strerror(errno));
         rc = true;
         } // endif size
 
@@ -1096,12 +1096,12 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
     lg = sizeof(int);
 
     if (fread(n, sizeof(int), NZ, opfile) != NZ) {
-      sprintf(g->Message, MSG(OPT_HEAD_RD_ERR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(OPT_HEAD_RD_ERR), strerror(errno));
       goto err;
       } // endif size
 
     if (n[1] != lg || n[2] != nrec) {
-      sprintf(g->Message, MSG(OPT_NOT_MATCH), filename);
+      snprintf(g->Message, sizeof(g->Message), MSG(OPT_NOT_MATCH), filename);
       goto err;
       } // endif
 
@@ -1112,7 +1112,7 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
     defp->To_Pos = (int*)PlugSubAlloc(g, NULL, blk * lg);
 
     if (fread(defp->To_Pos, lg, blk, opfile) != blk) {
-      sprintf(g->Message, MSG(OPTBLK_RD_ERR), strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(OPTBLK_RD_ERR), strerror(errno));
       goto err;
       } // endif size
 
@@ -1128,19 +1128,19 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
 
       //  Now start the reading process.
       if (fread(n, sizeof(int), NZ, opfile) != NZ) {
-        sprintf(g->Message, MSG(OPT_HEAD_RD_ERR), strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), MSG(OPT_HEAD_RD_ERR), strerror(errno));
         goto err;
         } // endif size
 
       if (n[0] == -i) {
         // Read the XDB2 opt values from the opt file
         if (n[1] != lg || n[2] != nrec || n[3] != block) {
-          sprintf(g->Message, MSG(OPT_NOT_MATCH), filename);
+          snprintf(g->Message, sizeof(g->Message), MSG(OPT_NOT_MATCH), filename);
           goto err;
           } // endif
 
         if (fread(n, sizeof(int), 2, opfile) != 2) {
-          sprintf(g->Message, MSG(OPT_HEAD_RD_ERR), strerror(errno));
+          snprintf(g->Message, sizeof(g->Message), MSG(OPT_HEAD_RD_ERR), strerror(errno));
           goto err;
           } // endif fread
 
@@ -1152,7 +1152,7 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
         cdp->SetNdv((int)ndv);
 
         if (fread(cdp->GetDval(), lg, ndv, opfile) != ndv) {
-          sprintf(g->Message, MSG(OPT_DVAL_RD_ERR), strerror(errno));
+          snprintf(g->Message, sizeof(g->Message), MSG(OPT_DVAL_RD_ERR), strerror(errno));
           goto err;
           } // endif size
 
@@ -1162,7 +1162,7 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
         cdp->SetNbm((int)nbm);
 
         if (fread(cdp->GetBmap(), sizeof(int), nbk, opfile) != nbk) {
-          sprintf(g->Message, MSG(OPT_BMAP_RD_ERR), strerror(errno));
+          snprintf(g->Message, sizeof(g->Message), MSG(OPT_BMAP_RD_ERR), strerror(errno));
           goto err;
           } // endif size
 
@@ -1170,7 +1170,7 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
       } else {
         // Read the Min/Max values from the opt file
         if (n[0] != i || n[1] != lg || n[2] != nrec || n[3] != block) {
-          sprintf(g->Message, MSG(OPT_NOT_MATCH), filename);
+          snprintf(g->Message, sizeof(g->Message), MSG(OPT_NOT_MATCH), filename);
           goto err;
           } // endif
 
@@ -1178,7 +1178,7 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
           cdp->SetMin(PlugSubAlloc(g, NULL, blk * lg));
 
         if (fread(cdp->GetMin(), lg, blk, opfile) != blk) {
-          sprintf(g->Message, MSG(OPT_MIN_RD_ERR), strerror(errno));
+          snprintf(g->Message, sizeof(g->Message), MSG(OPT_MIN_RD_ERR), strerror(errno));
           goto err;
           } // endif size
 
@@ -1186,7 +1186,7 @@ bool TDBDOS::GetBlockValues(PGLOBAL g)
           cdp->SetMax(PlugSubAlloc(g, NULL, blk * lg));
 
         if (fread(cdp->GetMax(), lg, blk, opfile) != blk) {
-          sprintf(g->Message, MSG(OPT_MAX_RD_ERR), strerror(errno));
+          snprintf(g->Message, sizeof(g->Message), MSG(OPT_MAX_RD_ERR), strerror(errno));
           goto err;
           } // endif size
 
@@ -1488,7 +1488,7 @@ PBF TDBDOS::CheckBlockFilari(PGLOBAL g, PXOB *arg, int op, bool *cnv)
     if (conv) {
       // The constant has not the good type and will not match
       // the block min/max values. Warn and abort.
-      sprintf(g->Message, "Block opt: %s", MSG(VALTYPE_NOMATCH));
+      snprintf(g->Message, sizeof(g->Message), "Block opt: %s", MSG(VALTYPE_NOMATCH));
       PushWarning(g, this);
       return NULL;
       } // endif Conv
@@ -1693,7 +1693,7 @@ int TDBDOS::MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add)
     if (add && dfp->GetIndx()) {
       for (sxp = dfp->GetIndx(); sxp; sxp = sxp->GetNext())
         if (!stricmp(sxp->GetName(), pxdf->GetName())) {
-          sprintf(g->Message, MSG(INDEX_YET_ON), pxdf->GetName(), Name);
+          snprintf(g->Message, sizeof(g->Message), MSG(INDEX_YET_ON), pxdf->GetName(), Name);
           return RC_FX;
         } else if (!sxp->GetNext())
           break;
@@ -1714,10 +1714,10 @@ int TDBDOS::MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add)
 		for (n = 0, xdp = pxdf; xdp; xdp = xdp->GetNext())
 			for (kdp = xdp->GetToKeyParts(); kdp; kdp = kdp->GetNext()) {
 				if (!(colp = ColDB(g, kdp->GetName(), 0))) {
-					sprintf(g->Message, MSG(INDX_COL_NOTIN), kdp->GetName(), Name);
+					snprintf(g->Message, sizeof(g->Message), MSG(INDX_COL_NOTIN), kdp->GetName(), Name);
 					goto err;
 				} else if (colp->GetResultType() == TYPE_DECIM) {
-					sprintf(g->Message, "Decimal columns are not indexable yet");
+					snprintf(g->Message, sizeof(g->Message), "Decimal columns are not indexable yet");
 					goto err;
 				} // endif Type
 
@@ -1845,14 +1845,14 @@ bool TDBDOS::InitialyzeIndex(PGLOBAL g, volatile PIXDEF xdp, bool sorted)
   // Get the key column description list
   for (k = 0, kdp = xdp->GetToKeyParts(); kdp; kdp = kdp->GetNext())
     if (!(colp = ColDB(g, kdp->GetName(), 0)) || colp->InitValue(g)) {
-      sprintf(g->Message, "Wrong column %s", kdp->GetName());
+      snprintf(g->Message, sizeof(g->Message), "Wrong column %s", kdp->GetName());
       return true;
     } else
       To_Key_Col[k++] = colp;
 
 #if defined(_DEBUG)
   if (k != Knum) {
-    sprintf(g->Message, "Key part number mismatch for %s",
+    snprintf(g->Message, sizeof(g->Message), "Key part number mismatch for %s",
                         xdp->GetName());
     return 0;
     } // endif k
@@ -1953,7 +1953,7 @@ int TDBDOS::RowNumber(PGLOBAL g, bool)
     /*******************************************************************/
     /*  Don't know how to retrieve RowID from file address.            */
     /*******************************************************************/
-    sprintf(g->Message, MSG(NO_ROWID_FOR_AM),
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_ROWID_FOR_AM),
                         GetAmName(g, Txfp->GetAmType()));
     return 0;
   } else
@@ -2479,7 +2479,7 @@ bool DOSCOL::VarSize(void)
 bool DOSCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   {
   if (!(To_Val = value)) {
-    sprintf(g->Message, MSG(VALUE_ERROR), Name);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_ERROR), Name);
     return true;
   } else if (Buf_Type == value->GetType()) {
     // Values are of the (good) column type
@@ -2498,7 +2498,7 @@ bool DOSCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   } else {
     // Values are not of the (good) column type
     if (check) {
-      sprintf(g->Message, MSG(TYPE_VALUE_ERR), Name,
+      snprintf(g->Message, sizeof(g->Message), MSG(TYPE_VALUE_ERR), Name,
               GetTypeName(Buf_Type), GetTypeName(value->GetType()));
       return true;
       } // endif check
@@ -2550,7 +2550,7 @@ void DOSCOL::ReadColumn(PGLOBAL g)
   if (!tdbp->IsRead())
     if ((rc = tdbp->ReadBuffer(g)) != RC_OK) {
       if (rc == RC_EF)
-        sprintf(g->Message, MSG(INV_DEF_READ), rc);
+        snprintf(g->Message, sizeof(g->Message), MSG(INV_DEF_READ), rc);
 
 			throw 11;
 		} // endif
@@ -2615,12 +2615,12 @@ void DOSCOL::ReadColumn(PGLOBAL g)
 
       break;
     default:
-      sprintf(g->Message, MSG(BAD_RECFM), tdbp->Ftype);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_RECFM), tdbp->Ftype);
 			throw 34;
 	} // endswitch Ftype
 
   if (err) {
-    sprintf(g->Message, "Out of range value for column %s at row %d",
+    snprintf(g->Message, sizeof(g->Message), "Out of range value for column %s at row %d",
       Name, tdbp->RowNumber(g));
     PushWarning(g, tdbp);
   } // endif err
@@ -2730,7 +2730,7 @@ void DOSCOL::WriteColumn(PGLOBAL g)
           len = strlen(Buf);
           break;
         default:
-          sprintf(g->Message, "Invalid field format for column %s", Name);
+          snprintf(g->Message, sizeof(g->Message), "Invalid field format for column %s", Name);
 					throw 31;
 			} // endswitch BufType
 
@@ -2744,7 +2744,7 @@ void DOSCOL::WriteColumn(PGLOBAL g)
     if ((len = n) > field) {
 			char *p = Value->GetCharString(Buf);
 
-      sprintf(g->Message, MSG(VALUE_TOO_LONG), p, Name, field);
+      snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_LONG), p, Name, field);
 			throw 31;
 		} else if (Dsp)
       for (i = 0; i < len; i++)
@@ -2772,7 +2772,7 @@ void DOSCOL::WriteColumn(PGLOBAL g)
     /*  Updating to be done only during the second pass (Status=true)  */
     /*******************************************************************/
     if (Value->GetBinValue(p, Long, Status)) {
-      sprintf(g->Message, MSG(BIN_F_TOO_LONG),
+      snprintf(g->Message, sizeof(g->Message), MSG(BIN_F_TOO_LONG),
                           Name, Value->GetSize(), Long);
       throw 31;
     } // endif
@@ -2832,11 +2832,11 @@ bool DOSCOL::SetBitMap(PGLOBAL g)
   if ((i = Dval->Find(Value)) < 0) {
     char buf[32];
 
-    sprintf(g->Message, MSG(DVAL_NOTIN_LIST),
+    snprintf(g->Message, sizeof(g->Message), MSG(DVAL_NOTIN_LIST),
       Value->GetCharString(buf), Name);
     return true;
   } else if (i >= dup->Maxbmp) {
-    sprintf(g->Message, MSG(OPT_LOGIC_ERR), i);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPT_LOGIC_ERR), i);
     return true;
   } else {
     m = i / MAXBMP;
@@ -2860,7 +2860,7 @@ bool DOSCOL::CheckSorted(PGLOBAL g)
       // Verify whether this column is sorted all right
       if (OldVal->CompareValue(Value) > 0) {
         // Column is no more in ascending order
-        sprintf(g->Message, MSG(COL_NOT_SORTED), Name, To_Tdb->GetName());
+        snprintf(g->Message, sizeof(g->Message), MSG(COL_NOT_SORTED), Name, To_Tdb->GetName());
         Sorted = false;
         return true;
       } else
@@ -2901,7 +2901,7 @@ bool DOSCOL::AddDistinctValue(PGLOBAL g)
     // Check whether we have room for an additional value
     if (Ndv == Freq) {
       // Too many values because of wrong Freq setting
-      sprintf(g->Message, MSG(BAD_FREQ_SET), Name);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_FREQ_SET), Name);
       return true;
       } // endif Ndv
 

--- a/storage/connect/tabext.cpp
+++ b/storage/connect/tabext.cpp
@@ -613,7 +613,7 @@ bool TDBEXT::MakeCommand(PGLOBAL g)
 			strcat(stmt, body);
 
 	} else {
-		sprintf(g->Message, "Cannot use this %s command",
+		snprintf(g->Message, sizeof(g->Message), "Cannot use this %s command",
 			(Mode == MODE_UPDATE) ? "UPDATE" : "DELETE");
 		return true;
 	} // endif p
@@ -724,7 +724,7 @@ EXTCOL::EXTCOL(PEXTCOL col1, PTDB tdbp) : COLBLK(col1, tdbp)
 bool EXTCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
 {
 	if (!(To_Val = value)) {
-		sprintf(g->Message, MSG(VALUE_ERROR), Name);
+		snprintf(g->Message, sizeof(g->Message), MSG(VALUE_ERROR), Name);
 		return true;
 	} else if (Buf_Type == value->GetType()) {
 		// Values are of the (good) column type
@@ -743,7 +743,7 @@ bool EXTCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
 	} else {
 		// Values are not of the (good) column type
 		if (check) {
-			sprintf(g->Message, MSG(TYPE_VALUE_ERR), Name,
+			snprintf(g->Message, sizeof(g->Message), MSG(TYPE_VALUE_ERR), Name,
 				GetTypeName(Buf_Type), GetTypeName(value->GetType()));
 			return true;
 		} // endif check

--- a/storage/connect/tabfix.cpp
+++ b/storage/connect/tabfix.cpp
@@ -256,7 +256,7 @@ int TDBFIX::RowNumber(PGLOBAL g, bool b)
       /*  Don't know how to retrieve Rows from DBF file address        */
       /*  because of eventual deleted lines still in the file.         */
       /*****************************************************************/
-      sprintf(g->Message, MSG(NO_ROWID_FOR_AM),
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_ROWID_FOR_AM),
                           GetAmName(g, Txfp->GetAmType()));
       return 0;
       } // endif To_Kindex
@@ -408,7 +408,7 @@ BINCOL::BINCOL(PGLOBAL g, PCOLDEF cdp, PTDB tp, PCOL cp, int i, PCSZ am)
       case 'F': M = sizeof(float);    break;
       case 'D': M = sizeof(double);   break;
       default:
-        sprintf(g->Message, MSG(BAD_BIN_FMT), Fmt, Name);
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_BIN_FMT), Fmt, Name);
 				throw 11;
 		} // endswitch Fmt
 
@@ -482,7 +482,7 @@ void BINCOL::ReadColumn(PGLOBAL g)
   if (!tdbp->IsRead())
     if ((rc = tdbp->ReadBuffer(g)) != RC_OK) {
       if (rc == RC_EF)
-        sprintf(g->Message, MSG(INV_DEF_READ), rc);
+        snprintf(g->Message, sizeof(g->Message), MSG(INV_DEF_READ), rc);
 
 			throw 11;
 		} // endif
@@ -535,14 +535,14 @@ void BINCOL::ReadColumn(PGLOBAL g)
       break;
     case 'C':                 // Text
       if (Value->SetValue_char(p, Long)) {
-        sprintf(g->Message, "Out of range value for column %s at row %d",
+        snprintf(g->Message, sizeof(g->Message), "Out of range value for column %s at row %d",
                 Name, tdbp->RowNumber(g));
         PushWarning(g, tdbp);
         } // endif SetValue_char
 
       break;
     default:
-      sprintf(g->Message, MSG(BAD_BIN_FMT), Fmt, Name);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_BIN_FMT), Fmt, Name);
 			throw 11;
 	} // endswitch Fmt
 
@@ -591,7 +591,7 @@ void BINCOL::WriteColumn(PGLOBAL g)
 				if (Status)
 					Value->GetValueNonAligned<longlong>(p, Value->GetBigintValue());
 			} else if (Value->GetBinValue(p, Long, Status)) {
-        sprintf(g->Message, MSG(BIN_F_TOO_LONG),
+        snprintf(g->Message, sizeof(g->Message), MSG(BIN_F_TOO_LONG),
                             Name, Value->GetSize(), Long);
 				throw 31;
 			} // endif p
@@ -601,7 +601,7 @@ void BINCOL::WriteColumn(PGLOBAL g)
       n = Value->GetBigintValue();
 
       if (n > 32767LL || n < -32768LL) {
-        sprintf(g->Message, MSG(VALUE_TOO_BIG), n, Name);
+        snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_BIG), n, Name);
 				throw 31;
 			} else if (Status)
 				Value->GetValueNonAligned<short>(p, (short)n);
@@ -611,7 +611,7 @@ void BINCOL::WriteColumn(PGLOBAL g)
       n = Value->GetBigintValue();
 
       if (n > 255LL || n < -256LL) {
-        sprintf(g->Message, MSG(VALUE_TOO_BIG), n, Name);
+        snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_BIG), n, Name);
 				throw 31;
 			} else if (Status)
         *p = (char)n;
@@ -621,7 +621,7 @@ void BINCOL::WriteColumn(PGLOBAL g)
       n = Value->GetBigintValue();
 
       if (n > INT_MAX || n < INT_MIN) {
-        sprintf(g->Message, MSG(VALUE_TOO_BIG), n, Name);
+        snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_BIG), n, Name);
 				throw 31;
 			} else if (Status)
 				Value->GetValueNonAligned<int>(p, (int)n);
@@ -645,7 +645,7 @@ void BINCOL::WriteColumn(PGLOBAL g)
       break;
     case 'C':                 // Characters
       if ((n = (signed)strlen(Value->GetCharString(Buf))) > Long) {
-        sprintf(g->Message, MSG(BIN_F_TOO_LONG), Name, (int) n, Long);
+        snprintf(g->Message, sizeof(g->Message), MSG(BIN_F_TOO_LONG), Name, (int) n, Long);
 				throw 31;
 			} // endif n
 
@@ -657,7 +657,7 @@ void BINCOL::WriteColumn(PGLOBAL g)
 
       break;
     default:
-      sprintf(g->Message, MSG(BAD_BIN_FMT), Fmt, Name);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_BIN_FMT), Fmt, Name);
 			throw 31;
 	} // endswitch Fmt
 

--- a/storage/connect/tabfmt.cpp
+++ b/storage/connect/tabfmt.cpp
@@ -230,7 +230,7 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
 
       colname[0] = p;
     } else if (rc == RC_EF) {
-      sprintf(g->Message, MSG(FILE_IS_EMPTY), fn);
+      snprintf(g->Message, sizeof(g->Message), MSG(FILE_IS_EMPTY), fn);
       goto err;
 		} else
 			goto err;
@@ -269,10 +269,10 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
     /*******************************************************************/
 		if ((rc = tdbp->ReadDB(g)) == RC_OK) {
     } else if (rc == RC_EF) {
-      sprintf(g->Message, MSG(EOF_AFTER_LINE), num_read -1);
+      snprintf(g->Message, sizeof(g->Message), MSG(EOF_AFTER_LINE), num_read -1);
       break;
     } else {
-      sprintf(g->Message, MSG(ERR_READING_REC), num_read, fn);
+      snprintf(g->Message, sizeof(g->Message), MSG(ERR_READING_REC), num_read, fn);
       goto err;
     } // endif's
 
@@ -285,7 +285,7 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
       if (*p == sep) {
         if (phase != 1) {
           if (i == MAXCOL - 1) {
-            sprintf(g->Message, MSG(TOO_MANY_FIELDS), num_read, fn);
+            snprintf(g->Message, sizeof(g->Message), MSG(TOO_MANY_FIELDS), num_read, fn);
             goto err;
             } // endif i
 
@@ -313,7 +313,7 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
         if (phase == 0) {
           if (blank) {
             if (++nerr > mxr) {
-              sprintf(g->Message, MSG(MISPLACED_QUOTE), num_read);
+              snprintf(g->Message, sizeof(g->Message), MSG(MISPLACED_QUOTE), num_read);
               goto err;
             } else
               goto skip;
@@ -325,7 +325,7 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
           if (*(p+1) == q) {
             // This is currently not implemented for CSV tables
 //          if (++nerr > mxr) {
-//            sprintf(g->Message, MSG(QUOTE_IN_QUOTE), num_read);
+//            snprintf(g->Message, sizeof(g->Message), MSG(QUOTE_IN_QUOTE), num_read);
 //            goto err;
 //          } else
 //            goto skip;
@@ -336,7 +336,7 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
             phase = 2;
 
         } else if (++nerr > mxr) {      // phase == 2
-          sprintf(g->Message, MSG(MISPLACED_QUOTE), num_read);
+          snprintf(g->Message, sizeof(g->Message), MSG(MISPLACED_QUOTE), num_read);
           goto err;
         } else
           goto skip;
@@ -344,7 +344,7 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
       } else {
         if (phase == 2) {
           if (++nerr > mxr) {
-            sprintf(g->Message, MSG(MISPLACED_QUOTE), num_read);
+            snprintf(g->Message, sizeof(g->Message), MSG(MISPLACED_QUOTE), num_read);
             goto err;
           } else
             goto skip;
@@ -366,7 +366,7 @@ PQRYRES CSVColumns(PGLOBAL g, PCSZ dp, PTOS topt, bool info)
 
     if (phase == 1) {
       if (++nerr > mxr) {
-        sprintf(g->Message, MSG(UNBALANCE_QUOTE), num_read);
+        snprintf(g->Message, sizeof(g->Message), MSG(UNBALANCE_QUOTE), num_read);
         goto err;
       } else
         goto skip;
@@ -583,7 +583,7 @@ PTDB CSVDEF::GetTable(PGLOBAL g, MODE mode)
               ((PZLBFAM)txfp)->SetOptimized(To_Pos != NULL);
               } // endelse
 #else
-            sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "GZ");
+            snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "GZ");
             return NULL;
 #endif
           } else
@@ -864,7 +864,7 @@ bool TDBCSV::SkipHeader(PGLOBAL g)
           } // endfor cdp
 
         if (hlen > Lrecl) {
-          sprintf(g->Message, MSG(LRECL_TOO_SMALL), hlen);
+          snprintf(g->Message, sizeof(g->Message), MSG(LRECL_TOO_SMALL), hlen);
           return true;
           } // endif hlen
 
@@ -948,7 +948,7 @@ int TDBCSV::ReadBuffer(PGLOBAL g)
 
           if (*p != Sep && i != Fields - 1) { // Should be the separator
             if (CheckErr()) {
-              sprintf(g->Message, MSG(MISSING_FIELD),
+              snprintf(g->Message, sizeof(g->Message), MSG(MISSING_FIELD),
                                   i+1, Name, RowNumber(g));
               return RC_FX;
             } else if (Accept)
@@ -975,7 +975,7 @@ int TDBCSV::ReadBuffer(PGLOBAL g)
             } // endif n
 
         } else if (CheckErr()) {
-          sprintf(g->Message, MSG(BAD_QUOTE_FIELD),
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_QUOTE_FIELD),
                               Name, i+1, RowNumber(g));
           return RC_FX;
         } else if (Accept) {
@@ -992,7 +992,7 @@ int TDBCSV::ReadBuffer(PGLOBAL g)
         len = strlen(p2);
         bad = true;
       } else if (CheckErr()) {
-        sprintf(g->Message, MSG(MISSING_FIELD), i+1, Name, RowNumber(g));
+        snprintf(g->Message, sizeof(g->Message), MSG(MISSING_FIELD), i+1, Name, RowNumber(g));
         return RC_FX;
       } else if (Accept) {
         len = strlen(p2);
@@ -1008,7 +1008,7 @@ int TDBCSV::ReadBuffer(PGLOBAL g)
     if (Mode != MODE_UPDATE)
       Fldlen[i] = len;
     else if (len > Fldlen[i]) {
-      sprintf(g->Message, MSG(FIELD_TOO_LONG), i+1, RowNumber(g));
+      snprintf(g->Message, sizeof(g->Message), MSG(FIELD_TOO_LONG), i+1, RowNumber(g));
       return RC_FX;
     } else {
       strncpy(Field[i], p2, len);
@@ -1143,7 +1143,7 @@ int TDBCSV::CheckWrite(PGLOBAL g)
           || Quoted > 1 || (Quoted == 1 && !Fldtyp[i]))
       {
         if (!Qot) {
-          sprintf(g->Message, MSG(SEP_IN_FIELD), i + 1);
+          snprintf(g->Message, sizeof(g->Message), MSG(SEP_IN_FIELD), i + 1);
           return -1;
         } else {
           // Quotes inside a quoted field must be doubled
@@ -1225,7 +1225,7 @@ bool TDBFMT::OpenDB(PGLOBAL g)
   Linenum = 0;
 
   if (Mode == MODE_INSERT || Mode == MODE_UPDATE) {
-    sprintf(g->Message, MSG(FMT_WRITE_NIY), "FMT");
+    snprintf(g->Message, sizeof(g->Message), MSG(FMT_WRITE_NIY), "FMT");
     return true;                    // NIY
     } // endif Mode
 
@@ -1255,13 +1255,13 @@ bool TDBFMT::OpenDB(PGLOBAL g)
       if (!cdp->IsSpecial() && !cdp->IsVirtual() 
                             && (i = cdp->GetOffset() - 1) < Fields) {
         if (!(pfm = cdp->GetFmt())) {
-          sprintf(g->Message, MSG(NO_FLD_FORMAT), i + 1, Name);
+          snprintf(g->Message, sizeof(g->Message), MSG(NO_FLD_FORMAT), i + 1, Name);
           return true;
           } // endif pfm
 
         // Roughly check the Fmt format
         if ((n = strlen(pfm) - 2) < 4) {
-          sprintf(g->Message, MSG(BAD_FLD_FORMAT), i + 1, Name);
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_FLD_FORMAT), i + 1, Name);
           return true;
           } // endif n
 
@@ -1338,7 +1338,7 @@ int TDBFMT::ReadBuffer(PGLOBAL g)
         sscanf("a", "%*c");       // Seems to reset things Ok
 
         if (CheckErr()) {
-          sprintf(g->Message, MSG(BAD_LINEFLD_FMT), Linenum, i + 1, Name);
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_LINEFLD_FMT), Linenum, i + 1, Name);
           return RC_FX;
         } else if (Accept)
           bad = true;
@@ -1361,7 +1361,7 @@ int TDBFMT::ReadBuffer(PGLOBAL g)
 //  if (Mode != MODE_UPDATE)
       Fldlen[i] = len;
 //  else if (len > Fldlen[i]) {
-//    sprintf(g->Message, MSG(FIELD_TOO_LONG), i+1, To_Tdb->RowNumber(g));
+//    snprintf(g->Message, sizeof(g->Message), MSG(FIELD_TOO_LONG), i+1, To_Tdb->RowNumber(g));
 //    return RC_FX;
 //  } else {
 //    strncpy(Field[i], To_Line + pos, len);
@@ -1384,7 +1384,7 @@ int TDBFMT::ReadBuffer(PGLOBAL g)
 /***********************************************************************/
 int TDBFMT::WriteDB(PGLOBAL g)
   {
-  sprintf(g->Message, MSG(FMT_WRITE_NIY), "FMT");
+  snprintf(g->Message, sizeof(g->Message), MSG(FMT_WRITE_NIY), "FMT");
   return RC_FX;                    // NIY
   } // end of WriteDB
 
@@ -1443,7 +1443,7 @@ void CSVCOL::ReadColumn(PGLOBAL g)
   if (!tdbp->IsRead())
     if ((rc = tdbp->ReadBuffer(g)) != RC_OK) {
       if (rc == RC_EF)
-        sprintf(g->Message, MSG(INV_DEF_READ), rc);
+        snprintf(g->Message, sizeof(g->Message), MSG(INV_DEF_READ), rc);
 
 			throw 34;
 		} // endif
@@ -1461,7 +1461,7 @@ void CSVCOL::ReadColumn(PGLOBAL g)
 
     if (Long > colen && tdbp->CheckErr()) {
       Long = colen;                       // Restore column length
-      sprintf(g->Message, MSG(FLD_TOO_LNG_FOR),
+      snprintf(g->Message, sizeof(g->Message), MSG(FLD_TOO_LNG_FOR),
               Fldnum + 1, Name, To_Tdb->RowNumber(g), tdbp->GetFile(g));
 			throw 34;
 		} // endif Long
@@ -1525,7 +1525,7 @@ void CSVCOL::WriteColumn(PGLOBAL g)
     htrc("new length(%p)=%d\n", p, n);
 
   if (n > flen) {
-    sprintf(g->Message, MSG(BAD_FLD_LENGTH), Name, p, n,
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_FLD_LENGTH), Name, p, n,
                         tdbp->RowNumber(g), tdbp->GetFile(g));
 		throw 34;
 	} else if (Dsp)
@@ -1542,7 +1542,7 @@ void CSVCOL::WriteColumn(PGLOBAL g)
   /*********************************************************************/
   if (Fldnum < 0) {
     // This can happen for wrong offset value in XDB files
-    sprintf(g->Message, MSG(BAD_FIELD_RANK), Fldnum + 1, Name);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_FIELD_RANK), Fldnum + 1, Name);
 		throw 34;
 	} else
     strncpy(tdbp->Field[Fldnum], p, flen);

--- a/storage/connect/tabfmt.h
+++ b/storage/connect/tabfmt.h
@@ -163,7 +163,7 @@ class DllExport TDBFMT : public TDBCSV {
 
  protected:
   virtual bool PrepareWriting(PGLOBAL g) 
-       {sprintf(g->Message, MSG(TABLE_READ_ONLY), "FMT"); return true;}
+       {snprintf(g->Message, sizeof(g->Message), MSG(TABLE_READ_ONLY), "FMT"); return true;}
 
   // Members
   PSZ  *FldFormat;                      // Field read format

--- a/storage/connect/tabjdbc.cpp
+++ b/storage/connect/tabjdbc.cpp
@@ -159,7 +159,7 @@ int JDBCDEF::ParseURL(PGLOBAL g, char *url, bool b)
 
 		// get_server_by_name() clones the server if exists
 		if (!(server= get_server_by_name(current_thd->mem_root, url, &server_buffer))) {
-			sprintf(g->Message, "Server %s does not exist!", url);
+			snprintf(g->Message, sizeof(g->Message), "Server %s does not exist!", url);
 			return RC_FX;
 		} // endif server
 
@@ -224,7 +224,7 @@ bool JDBCDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
 		Url = GetStringCatInfo(g, "Url", NULL);
 
 		if (!Url) {
-			sprintf(g->Message, "Missing URL for JDBC table %s", Name);
+			snprintf(g->Message, sizeof(g->Message), "Missing URL for JDBC table %s", Name);
 			return true;
 		} // endif Url
 
@@ -232,7 +232,7 @@ bool JDBCDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
 
 	if (Url)
 		if ((rc = ParseURL(g, Url)) == RC_FX) {
-			sprintf(g->Message, "Wrong JDBC URL %s", Url);
+			snprintf(g->Message, sizeof(g->Message), "Wrong JDBC URL %s", Url);
 			return true;
 		} // endif rc
 
@@ -648,7 +648,7 @@ bool TDBJDBC::OpenDB(PGLOBAL g)
 				if ((n = Jcp->GetResultSize(Query->GetStr(), Cnp)) < 0) {
 					char* msg = PlugDup(g, g->Message);
 
-					sprintf(g->Message, "Get result size: %s (rc=%d)", msg, n);
+					snprintf(g->Message, sizeof(g->Message), "Get result size: %s (rc=%d)", msg, n);
 					return true;
 				} else if (n) {
 					Jcp->m_Rows = n;
@@ -694,7 +694,7 @@ bool TDBJDBC::OpenDB(PGLOBAL g)
 	} else if (Mode == MODE_UPDATE || Mode == MODE_DELETE) {
 		rc = false;  // wait for CheckCond before calling MakeCommand(g);
 	} else
-		sprintf(g->Message, "Invalid mode %d", Mode);
+		snprintf(g->Message, sizeof(g->Message), "Invalid mode %d", Mode);
 
 	if (rc) {
 		Jcp->Close();
@@ -951,7 +951,7 @@ int TDBJDBC::DeleteDB(PGLOBAL g, int irc)
 		// Send the DELETE (all) command to the remote table
 		if (Jcp->ExecuteUpdate(Query->GetStr()) == RC_OK) {
 			AftRows = Jcp->m_Aff;
-			sprintf(g->Message, "%s: %d affected rows", TableName, AftRows);
+			snprintf(g->Message, sizeof(g->Message), "%s: %d affected rows", TableName, AftRows);
 
 			if (trace(1))
 				htrc("%s\n", g->Message);
@@ -979,7 +979,7 @@ void TDBJDBC::CloseDB(PGLOBAL g)
 
 	if (!Werr && 
 		(Mode == MODE_INSERT || Mode == MODE_UPDATE || Mode == MODE_DELETE)) {
-		sprintf(g->Message, "%s: %d affected rows", TableName, AftRows);
+		snprintf(g->Message, sizeof(g->Message), "%s: %d affected rows", TableName, AftRows);
 
 		if (trace(1))
 			htrc("%s\n", g->Message);

--- a/storage/connect/tabjmg.cpp
+++ b/storage/connect/tabjmg.cpp
@@ -96,7 +96,7 @@ bool JMGDISC::ColDesc(PGLOBAL g, jobject obj, char *pcn, char *pfmt,
 		n = Jcp->env->GetIntArrayElements(val, 0);
 
 		if (Jcp->Check(n[0])) {
-			sprintf(g->Message, "ColDesc: %s", Jcp->Msg);
+			snprintf(g->Message, sizeof(g->Message), "ColDesc: %s", Jcp->Msg);
 			goto err;
 		} else if (!n[0])
 			continue;
@@ -526,7 +526,7 @@ char *JMGCOL::Mini(PGLOBAL g, const bson_t *bson, bool b)
 	bson_free(str);
 
 	if (i >= Long) {
-		sprintf(g->Message, "Value too long for column %s", Name);
+		snprintf(g->Message, sizeof(g->Message), "Value too long for column %s", Name);
 		throw (int)TYPE_AM_MGO;
 	}	// endif i
 
@@ -596,7 +596,7 @@ bool JMGCOL::AddValue(PGLOBAL g, bson_t *doc, char *key, bool upd)
 			rc = BSON_APPEND_DATE_TIME(doc, key, Value->GetBigintValue() * 1000);
 			break;
 		default:
-			sprintf(g->Message, "Type %d not supported yet", Buf_Type);
+			snprintf(g->Message, sizeof(g->Message), "Type %d not supported yet", Buf_Type);
 			return true;
 	} // endswitch Buf_Type
 

--- a/storage/connect/tabjson.cpp
+++ b/storage/connect/tabjson.cpp
@@ -239,7 +239,7 @@ int JSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
       (tdp->Version == 2) ? "Mongo2Interface" : "Mongo3Interface");
     tdp->Pretty = 0;
 #else   // !MONGO_SUPPORT
-    sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
     return 0;
 #endif  // !MONGO_SUPPORT
   } // endif Uri
@@ -249,7 +249,7 @@ int JSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #if defined(ZIP_SUPPORT)
       tjsp = new(g) TDBJSON(tdp, new(g) UNZFAM(tdp));
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return 0;
 #endif  // !ZIP_SUPPORT
     } else
@@ -263,7 +263,7 @@ int JSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
     if (!(tdp->Lrecl = GetIntegerTableOption(g, topt, "Lrecl", 0)))
     {
       if (!mgo && !tdp->Uri) {
-        sprintf(g->Message, "LRECL must be specified for pretty=%d", tdp->Pretty);
+        snprintf(g->Message, sizeof(g->Message), "LRECL must be specified for pretty=%d", tdp->Pretty);
         return 0;
       } else
         tdp->Lrecl = 8192;       // Should be enough
@@ -275,7 +275,7 @@ int JSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #if defined(ZIP_SUPPORT)
       tjnp = new(g)TDBJSN(tdp, new(g) UNZFAM(tdp));
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return NULL;
 #endif  // !ZIP_SUPPORT
     } else if (tdp->Uri) {
@@ -283,14 +283,14 @@ int JSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #if defined(CMGO_SUPPORT)
         tjnp = new(g) TDBJSN(tdp, new(g) CMGFAM(tdp));
 #else
-        sprintf(g->Message, "Mongo %s Driver not available", "C");
+        snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "C");
         return 0;
 #endif
       } else if (tdp->Driver && toupper(*tdp->Driver) == 'J') {
 #if defined(JAVA_SUPPORT)
         tjnp = new(g) TDBJSN(tdp, new(g) JMGFAM(tdp));
 #else
-        sprintf(g->Message, "Mongo %s Driver not available", "Java");
+        snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "Java");
         return 0;
 #endif
       } else {             // Driver not specified
@@ -299,7 +299,7 @@ int JSONDISC::GetColumns(PGLOBAL g, PCSZ db, PCSZ dsn, PTOS topt)
 #elif defined(JAVA_SUPPORT)
         tjnp = new(g) TDBJSN(tdp, new(g) JMGFAM(tdp));
 #else
-        sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
         return 0;
 #endif
       } // endif Driver
@@ -513,7 +513,7 @@ bool JSONDISC::Find(PGLOBAL g, PJVAL jvp, PCSZ key, int j)
 
         return false;
       default:
-        sprintf(g->Message, "Logical error after %s", fmt);
+        snprintf(g->Message, sizeof(g->Message), "Logical error after %s", fmt);
         return true;
     } // endswitch Type
 
@@ -671,7 +671,7 @@ bool JSONDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
       Wrapname = GetStringCatInfo(g, "Wrapper", "Mongo3Interface");
 #endif   // JAVA_SUPPORT
 #else   // !MONGO_SUPPORT
-    sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
     return true;
 #endif  // !MONGO_SUPPORT
   } // endif Uri
@@ -706,14 +706,14 @@ PTDB JSONDEF::GetTable(PGLOBAL g, MODE m)
 #if defined(CMGO_SUPPORT)
       txfp = new(g) CMGFAM(this);
 #else
-      sprintf(g->Message, "Mongo %s Driver not available", "C");
+      snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "C");
       return NULL;
 #endif
       } else if (Driver && toupper(*Driver) == 'J') {
 #if defined(JAVA_SUPPORT)
         txfp = new(g) JMGFAM(this);
 #else
-        sprintf(g->Message, "Mongo %s Driver not available", "Java");
+        snprintf(g->Message, sizeof(g->Message), "Mongo %s Driver not available", "Java");
         return NULL;
 #endif
       } else {             // Driver not specified
@@ -722,7 +722,7 @@ PTDB JSONDEF::GetTable(PGLOBAL g, MODE m)
 #elif defined(JAVA_SUPPORT)
         txfp = new(g) JMGFAM(this);
 #else   // !MONGO_SUPPORT
-        sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "MONGO");
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "MONGO");
         return NULL;
 #endif  // !MONGO_SUPPORT
       } // endif Driver
@@ -739,7 +739,7 @@ PTDB JSONDEF::GetTable(PGLOBAL g, MODE m)
         return NULL;
       } // endif's m
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return NULL;
 #endif  // !ZIP_SUPPORT
     } else if (Compressed) {
@@ -749,7 +749,7 @@ PTDB JSONDEF::GetTable(PGLOBAL g, MODE m)
       else
         txfp = new(g) ZLBFAM(this);
 #else   // !GZ_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "GZ");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "GZ");
       return NULL;
 #endif  // !GZ_SUPPORT
     } else if (map)
@@ -792,7 +792,7 @@ PTDB JSONDEF::GetTable(PGLOBAL g, MODE m)
         return NULL;
       } // endif's m
 #else   // !ZIP_SUPPORT
-      sprintf(g->Message, MSG(NO_FEAT_SUPPORT), "ZIP");
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_FEAT_SUPPORT), "ZIP");
       return NULL;
 #endif  // !ZIP_SUPPORT
     } else
@@ -980,7 +980,7 @@ PJSON TDBJSN::FindRow(PGLOBAL g)
     } else {
       if (bp || *objpath == '[') {
         if (objpath[strlen(objpath) - 1] != ']') {
-          sprintf(g->Message, "Invalid Table path %s", Objname);
+          snprintf(g->Message, sizeof(g->Message), "Invalid Table path %s", Objname);
           return NULL;
         } else if (!bp)
           objpath++;
@@ -1031,7 +1031,7 @@ bool TDBJSN::OpenDB(PGLOBAL g)
         case MODE_ARRAY:  Row = new(g) JARRAY;  break;
         case MODE_VALUE:  Row = new(g) JVALUE;  break;
         default:
-          sprintf(g->Message, "Invalid Jmode %d", Jmode);
+          snprintf(g->Message, sizeof(g->Message), "Invalid Jmode %d", Jmode);
           return true;
         } // endswitch Jmode
 
@@ -1209,7 +1209,7 @@ bool TDBJSN::MakeTopTree(PGLOBAL g, PJSON jsp)
           if (bp || *objpath == '[') {
             // Old style
             if (objpath[strlen(objpath) - 1] != ']') {
-              sprintf(g->Message, "Invalid Table path %s", Objname);
+              snprintf(g->Message, sizeof(g->Message), "Invalid Table path %s", Objname);
               return true;
             } else if (!bp)
               objpath++;
@@ -1258,7 +1258,7 @@ bool TDBJSN::PrepareWriting(PGLOBAL g)
 
     if ((signed)strlen(s) > Lrecl) {
       strncpy(To_Line, s, Lrecl);
-      sprintf(g->Message, "Line truncated (lrecl=%d)", Lrecl);
+      snprintf(g->Message, sizeof(g->Message), "Line truncated (lrecl=%d)", Lrecl);
       return PushWarning(g, this);
     } else
       strcpy(To_Line, s);
@@ -1442,7 +1442,7 @@ bool JSONCOL::SetArrayOptions(PGLOBAL g, char *p, int i, PSZ nm)
 
         break;
       default:
-        sprintf(g->Message,
+        snprintf(g->Message, sizeof(g->Message),
           "Invalid function specification %c for %s", *p, Name);
         return true;
     } // endswitch *p
@@ -1458,7 +1458,7 @@ bool JSONCOL::SetArrayOptions(PGLOBAL g, char *p, int i, PSZ nm)
     } // endif n
 
   } else {
-    sprintf(g->Message, "Wrong array specification for %s", Name);
+    snprintf(g->Message, sizeof(g->Message), "Wrong array specification for %s", Name);
     return true;
   } // endif's
 
@@ -1527,7 +1527,7 @@ bool JSONCOL::ParseJpath(PGLOBAL g)
         goto fin;
       } // endif Name
 
-    sprintf(g->Message, "Cannot parse updated column %s", Name);
+    snprintf(g->Message, sizeof(g->Message), "Cannot parse updated column %s", Name);
     return true;
   } // endif To_Orig
 
@@ -1742,7 +1742,7 @@ PJVAL JSONCOL::GetRowValue(PGLOBAL g, PJSON row, int i)
         val = (PJVAL)row;
         break;
       default:
-        sprintf(g->Message, "Invalid row JSON type %d", row->GetType());
+        snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->GetType());
         val = NULL;
     } // endswitch Type
 
@@ -1804,7 +1804,7 @@ void JSONCOL::SetJsonValue(PGLOBAL g, PVAL vp, PJVAL jvp)
 
           break;
         default:
-					sprintf(g->Message, "Unsupported column type %d\n", vp->GetType());
+					snprintf(g->Message, sizeof(g->Message), "Unsupported column type %d\n", vp->GetType());
 					throw 888;
 				} // endswitch Type
 
@@ -1904,7 +1904,7 @@ PVAL JSONCOL::GetColumnValue(PGLOBAL g, PJSON row, int i)
         val = (PJVAL)row;
         break;
       default:
-        sprintf(g->Message, "Invalid row JSON type %d", row->GetType());
+        snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->GetType());
         val = NULL;
       } // endswitch Type
 
@@ -2099,7 +2099,7 @@ PJSON JSONCOL::GetRow(PGLOBAL g)
         val = (PJVAL)row;
         break;
       default:
-        sprintf(g->Message, "Invalid row JSON type %d", row->GetType());
+        snprintf(g->Message, sizeof(g->Message), "Invalid row JSON type %d", row->GetType());
         val = NULL;
       } // endswitch Type
 
@@ -2226,7 +2226,7 @@ void JSONCOL::WriteColumn(PGLOBAL g)
 
       break;
     default:                  // ??????????
-      sprintf(g->Message, "Invalid column type %d", Buf_Type);
+      snprintf(g->Message, sizeof(g->Message), "Invalid column type %d", Buf_Type);
     } // endswitch Type
 
 } // end of WriteColumn
@@ -2372,7 +2372,7 @@ int TDBJSON::MakeDocument(PGLOBAL g)
         val = objp->GetKeyValue(key);
 
         if (!val || !(jsp = val->GetJson())) {
-          sprintf(g->Message, "Cannot find object key %s", key);
+          snprintf(g->Message, sizeof(g->Message), "Cannot find object key %s", key);
           return RC_FX;
         } // endif val
 
@@ -2380,7 +2380,7 @@ int TDBJSON::MakeDocument(PGLOBAL g)
         if (*p == '[') {
           // Old style
           if (p[strlen(p) - 1] != ']') {
-            sprintf(g->Message, "Invalid Table path near %s", p);
+            snprintf(g->Message, sizeof(g->Message), "Invalid Table path near %s", p);
             return RC_FX;
           } else
             p++;
@@ -2398,7 +2398,7 @@ int TDBJSON::MakeDocument(PGLOBAL g)
         val = arp->GetArrayValue(i);
 
         if (!val) {
-          sprintf(g->Message, "Cannot find array value %d", i);
+          snprintf(g->Message, sizeof(g->Message), "Cannot find array value %d", i);
           return RC_FX;
         } // endif val
 
@@ -2562,7 +2562,7 @@ bool TDBJSON::OpenDB(PGLOBAL g)
       case MODE_ARRAY:  Row = new(g) JARRAY;  break;
       case MODE_VALUE:  Row = new(g) JVALUE;  break;
       default:
-        sprintf(g->Message, "Invalid Jmode %d", Jmode);
+        snprintf(g->Message, sizeof(g->Message), "Invalid Jmode %d", Jmode);
         return true;
       } // endswitch Jmode
 
@@ -2646,7 +2646,7 @@ int TDBJSON::DeleteDB(PGLOBAL g, int irc)
   if (irc == RC_OK) {
     // Deleted current row
     if (Doc->DeleteValue(Fpos)) {
-      sprintf(g->Message, "Value %d does not exist", Fpos + 1);
+      snprintf(g->Message, sizeof(g->Message), "Value %d does not exist", Fpos + 1);
       return RC_FX;
       } // endif Delete
 

--- a/storage/connect/table.cpp
+++ b/storage/connect/table.cpp
@@ -207,7 +207,7 @@ PCOL TDB::InsertSpcBlk(PGLOBAL g, PCOLDEF cdp)
 		!stricmp(name, "FPATH") || !stricmp(name, "FNAME") ||
 		!stricmp(name, "FTYPE") || !stricmp(name, "SERVID")) {
 		if (!To_Def || !(To_Def->GetPseudo() & 2)) {
-			sprintf(g->Message, MSG(BAD_SPEC_COLUMN));
+			snprintf(g->Message, sizeof(g->Message), MSG(BAD_SPEC_COLUMN));
 			return NULL;
 		} // endif Pseudo
 
@@ -235,12 +235,12 @@ PCOL TDB::InsertSpcBlk(PGLOBAL g, PCOLDEF cdp)
 	} else if (!stricmp(name, "ROWNUM")) {
 		colp = new(g)RIDBLK(cp, true);
 	} else {
-		sprintf(g->Message, MSG(BAD_SPECIAL_COL), name);
+		snprintf(g->Message, sizeof(g->Message), MSG(BAD_SPECIAL_COL), name);
 		return NULL;
 	} // endif's name
 
 	if (!(colp = InsertSpecialColumn(colp))) {
-		sprintf(g->Message, MSG(BAD_SPECIAL_COL), name);
+		snprintf(g->Message, sizeof(g->Message), MSG(BAD_SPECIAL_COL), name);
 		return NULL;
 	} // endif Insert
 
@@ -266,7 +266,7 @@ void TDB::MarkDB(PGLOBAL, PTDB tdb2)
 /***********************************************************************/
 int TDB::RowNumber(PGLOBAL g, bool)
   {
-  sprintf(g->Message, MSG(ROWID_NOT_IMPL), GetAmName(g, GetAmType()));
+  snprintf(g->Message, sizeof(g->Message), MSG(ROWID_NOT_IMPL), GetAmName(g, GetAmType()));
   return 0;
   } // end of RowNumber
 
@@ -495,7 +495,7 @@ PCOL TDBASE::InsertSpcBlk(PGLOBAL g, PCOLDEF cdp)
       !stricmp(name, "FPATH")  || !stricmp(name, "FNAME") ||
       !stricmp(name, "FTYPE")  || !stricmp(name, "SERVID")) {
     if (!To_Def || !(To_Def->GetPseudo() & 2)) {
-      sprintf(g->Message, MSG(BAD_SPEC_COLUMN));
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_SPEC_COLUMN));
       return NULL;
       } // endif Pseudo
 
@@ -523,12 +523,12 @@ PCOL TDBASE::InsertSpcBlk(PGLOBAL g, PCOLDEF cdp)
   } else if (!stricmp(name, "ROWNUM")) {
       colp = new(g) RIDBLK(cp, true);
   } else {
-    sprintf(g->Message, MSG(BAD_SPECIAL_COL), name);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_SPECIAL_COL), name);
     return NULL;
   } // endif's name
 
   if (!(colp = InsertSpecialColumn(colp))) {
-    sprintf(g->Message, MSG(BAD_SPECIAL_COL), name);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_SPECIAL_COL), name);
     return NULL;
     } // endif Insert
 
@@ -642,12 +642,12 @@ bool TDBCAT::Initialize(PGLOBAL g)
     return true;
 
   if (Qrp->Truncated) {
-    sprintf(g->Message, "Result limited to %d lines", Qrp->Maxres);
+    snprintf(g->Message, sizeof(g->Message), "Result limited to %d lines", Qrp->Maxres);
     PushWarning(g, this);
     } // endif Truncated
 
   if (Qrp->BadLines) {
-    sprintf(g->Message, "%d bad lines in result", Qrp->BadLines);
+    snprintf(g->Message, sizeof(g->Message), "%d bad lines in result", Qrp->BadLines);
     PushWarning(g, this);
     } // endif Badlines
 
@@ -720,7 +720,7 @@ bool TDBCAT::InitCol(PGLOBAL g)
 
 
     if (!colp->Crp /*&& !colp->GetValue()->IsConstant()*/) {
-      sprintf(g->Message, "Invalid flag %d for column %s",
+      snprintf(g->Message, sizeof(g->Message), "Invalid flag %d for column %s",
                           colp->Flag, colp->Name);
       return true;
 		} else if (crp->Fld == FLD_SCALE || crp->Fld == FLD_RADIX)

--- a/storage/connect/tabmac.cpp
+++ b/storage/connect/tabmac.cpp
@@ -100,7 +100,7 @@ PCOL TDBMAC::MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n)
 void TDBMAC::MakeErrorMsg(PGLOBAL g, DWORD drc)
   {
   if (drc == ERROR_BUFFER_OVERFLOW)
-    sprintf(g->Message, 
+    snprintf(g->Message, sizeof(g->Message), 
       "GetAdaptersInfo: Buffer Overflow buflen=%d maxsize=%d",
       Buflen, MaxSize);
   else if (drc == ERROR_INVALID_PARAMETER)
@@ -159,7 +159,7 @@ bool TDBMAC::GetFixedInfo(PGLOBAL g)
     } // endif drc
 
   if (drc != ERROR_SUCCESS) {
-    sprintf(g->Message,  "GetNetworkParams failed. Rc=%08x\n", drc);
+    snprintf(g->Message, sizeof(g->Message),  "GetNetworkParams failed. Rc=%08x\n", drc);
     return true;
     } // endif drc
 

--- a/storage/connect/tabmul.cpp
+++ b/storage/connect/tabmul.cpp
@@ -723,7 +723,7 @@ int TDBDIR::GetMaxSize(PGLOBAL g)
 				FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
 					            FORMAT_MESSAGE_IGNORE_INSERTS,
 					NULL, GetLastError(), 0, (LPTSTR)&buf, sizeof(buf), NULL);
-				sprintf(g->Message, MSG(BAD_FILE_HANDLE), buf);
+				snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILE_HANDLE), buf);
 				return -1;
 			} // endif rc
 
@@ -738,7 +738,7 @@ int TDBDIR::GetMaxSize(PGLOBAL g)
 				rc = GetLastError();
 
 				if (rc != ERROR_NO_MORE_FILES) {
-					sprintf(g->Message, MSG(NEXT_FILE_ERROR), rc);
+					snprintf(g->Message, sizeof(g->Message), MSG(NEXT_FILE_ERROR), rc);
 					FindClose(hSearch);
 					return -1;
 				} // endif rc
@@ -755,7 +755,7 @@ int TDBDIR::GetMaxSize(PGLOBAL g)
 
     // Start searching files in the target directory.
     if (!(Dir = opendir(Direc))) {
-      sprintf(g->Message, MSG(BAD_DIRECTORY), Direc, strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_DIRECTORY), Direc, strerror(errno));
       return -1;
       } // endif dir
 
@@ -763,7 +763,7 @@ int TDBDIR::GetMaxSize(PGLOBAL g)
       strcat(strcpy(Fpath, Direc), Entry->d_name);
 
       if (lstat(Fpath, &Fileinfo) < 0) {
-        sprintf(g->Message, "%s: %s", Fpath, strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), "%s: %s", Fpath, strerror(errno));
         return -1;
       } else if (S_ISREG(Fileinfo.st_mode))
         // Test whether the file name matches the table name filter
@@ -851,7 +851,7 @@ int TDBDIR::ReadDB(PGLOBAL g)
   if (!Dir)
     // Start searching files in the target directory.
     if (!(Dir = opendir(Direc))) {
-      sprintf(g->Message, MSG(BAD_DIRECTORY), Direc, strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_DIRECTORY), Direc, strerror(errno));
       rc = RC_FX;
       } // endif dir
 
@@ -861,7 +861,7 @@ int TDBDIR::ReadDB(PGLOBAL g)
       strcat(strcpy(Fpath, Direc), Entry->d_name);
 
       if (lstat(Fpath, &Fileinfo) < 0) {
-        sprintf(g->Message, "%s: %s", Fpath, strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), "%s: %s", Fpath, strerror(errno));
         rc = RC_FX;
       } else if (S_ISREG(Fileinfo.st_mode))
         // Test whether the file name matches the table name filter
@@ -1015,7 +1015,7 @@ void DIRCOL::ReadColumn(PGLOBAL g)
     case 10: Value->SetValue((int)Tdbp->Fileinfo.st_gid);   break;
 #endif  // !_WIN32
     default:
-      sprintf(g->Message, MSG(INV_DIRCOL_OFST), N);
+      snprintf(g->Message, sizeof(g->Message), MSG(INV_DIRCOL_OFST), N);
 			throw GetAmType();
 	} // endswitch N
 
@@ -1066,7 +1066,7 @@ int TDBSDR::FindInDir(PGLOBAL g)
 			FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
 				FORMAT_MESSAGE_IGNORE_INSERTS,
 				NULL, GetLastError(), 0, (LPTSTR)&buf, sizeof(buf), NULL);
-			sprintf(g->Message, MSG(BAD_FILE_HANDLE), buf);
+			snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILE_HANDLE), buf);
 			return -1;
 		} // endif rc
 
@@ -1087,7 +1087,7 @@ int TDBSDR::FindInDir(PGLOBAL g)
 			rc = GetLastError();
 
 			if (rc != ERROR_NO_MORE_FILES) {
-				sprintf(g->Message, MSG(NEXT_FILE_ERROR), rc);
+				snprintf(g->Message, sizeof(g->Message), MSG(NEXT_FILE_ERROR), rc);
 				FindClose(h);
 				return -1;
 			} // endif rc
@@ -1108,7 +1108,7 @@ int TDBSDR::FindInDir(PGLOBAL g)
 			FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
 				FORMAT_MESSAGE_IGNORE_INSERTS,
 				NULL, GetLastError(), 0, (LPTSTR)&buf, sizeof(buf), NULL);
-			sprintf(g->Message, MSG(BAD_FILE_HANDLE), buf);
+			snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILE_HANDLE), buf);
 			return -1;
 		} // endif rc
 
@@ -1122,7 +1122,7 @@ int TDBSDR::FindInDir(PGLOBAL g)
 			rc = GetLastError();
 
 			if (rc != ERROR_NO_MORE_FILES) {
-				sprintf(g->Message, MSG(NEXT_FILE_ERROR), rc);
+				snprintf(g->Message, sizeof(g->Message), MSG(NEXT_FILE_ERROR), rc);
 				FindClose(h);
 				return -1;
 			} // endif rc
@@ -1161,7 +1161,7 @@ int TDBSDR::FindInDir(PGLOBAL g)
   DIR *dir = opendir(Direc);
 
   if (!dir) {
-    sprintf(g->Message, MSG(BAD_DIRECTORY), Direc, strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_DIRECTORY), Direc, strerror(errno));
     return -1;
     } // endif dir
 
@@ -1169,7 +1169,7 @@ int TDBSDR::FindInDir(PGLOBAL g)
     strcat(strcpy(Fpath, Direc), Entry->d_name);
 
     if (lstat(Fpath, &Fileinfo) < 0) {
-      sprintf(g->Message, "%s: %s", Fpath, strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), "%s: %s", Fpath, strerror(errno));
       return -1;
     } else if (S_ISDIR(Fileinfo.st_mode) && *Entry->d_name != '.') {
       // Look in the name sub-directory
@@ -1288,7 +1288,7 @@ int TDBSDR::ReadDB(PGLOBAL g)
   if (!Sub->D)
     // Start searching files in the target directory.
     if (!(Sub->D = opendir(Direc))) {
-      sprintf(g->Message, MSG(BAD_DIRECTORY), Direc, strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_DIRECTORY), Direc, strerror(errno));
       rc = RC_FX;
       } // endif dir
 
@@ -1298,7 +1298,7 @@ int TDBSDR::ReadDB(PGLOBAL g)
       strcat(strcpy(Fpath, Direc), Entry->d_name);
 
       if (lstat(Fpath, &Fileinfo) < 0) {
-        sprintf(g->Message, "%s: %s", Fpath, strerror(errno));
+        snprintf(g->Message, sizeof(g->Message), "%s: %s", Fpath, strerror(errno));
         rc = RC_FX;
       } else if (S_ISDIR(Fileinfo.st_mode) && strcmp(Entry->d_name, ".")
 			                                     && strcmp(Entry->d_name, "..")) {
@@ -1419,7 +1419,7 @@ int TDBDHR::GetMaxSize(PGLOBAL g)
                         FORMAT_MESSAGE_IGNORE_INSERTS,
                         NULL, rc, 0,
                         (LPTSTR)&filename, sizeof(filename), NULL);
-          sprintf(g->Message, MSG(BAD_FILE_HANDLE), filename);
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILE_HANDLE), filename);
         } // endswitch rc
 
     } else {
@@ -1428,7 +1428,7 @@ int TDBDHR::GetMaxSize(PGLOBAL g)
           rc = GetLastError();
 
           if (rc != ERROR_NO_MORE_FILES) {
-            sprintf(g->Message, MSG(NEXT_FILE_ERROR), rc);
+            snprintf(g->Message, sizeof(g->Message), MSG(NEXT_FILE_ERROR), rc);
             n = -1;
             } // endif rc
 
@@ -1470,7 +1470,7 @@ bool TDBDHR::OpenDB(PGLOBAL g)
   /*********************************************************************/
   if (NeedIndexing(g)) {
     // Direct access of DHR tables is not implemented yet
-    sprintf(g->Message, MSG(NO_DIR_INDX_RD), "DHR");
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_DIR_INDX_RD), "DHR");
     return true;
     } // endif NeedIndexing
 
@@ -1511,7 +1511,7 @@ int TDBDHR::ReadDB(PGLOBAL g)
                       FORMAT_MESSAGE_IGNORE_INSERTS,
                       NULL, erc,  0,
                       (LPTSTR)&filename, sizeof(filename), NULL);
-        sprintf(g->Message, MSG(BAD_FILE_HANDLE), filename);
+        snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILE_HANDLE), filename);
         rc = RC_FX;
       } // endswitch erc
 
@@ -1520,7 +1520,7 @@ int TDBDHR::ReadDB(PGLOBAL g)
       DWORD erc = GetLastError();
 
       if (erc != ERROR_NO_MORE_FILES) {
-        sprintf(g->Message, MSG(NEXT_FILE_ERROR), erc);
+        snprintf(g->Message, sizeof(g->Message), MSG(NEXT_FILE_ERROR), erc);
         FindClose(Hsearch);
         rc = RC_FX;
       } else

--- a/storage/connect/tabmysql.cpp
+++ b/storage/connect/tabmysql.cpp
@@ -712,7 +712,7 @@ bool TDBMYSQL::MakeCommand(PGLOBAL g)
         strlwr(strcpy(qrystr, Query->GetStr()));
 
     } else {
-      sprintf(g->Message, "Cannot use this %s command",
+      snprintf(g->Message, sizeof(g->Message), "Cannot use this %s command",
                    (Mode == MODE_UPDATE) ? "UPDATE" : "DELETE");
       return true;
     } // endif p
@@ -922,7 +922,7 @@ bool TDBMYSQL::OpenDB(PGLOBAL g)
 
 #if 0
     if (!Myc.m_Res || !Myc.m_Fields) {
-      sprintf(g->Message, "%s result", (Myc.m_Res) ? "Void" : "No");
+      snprintf(g->Message, sizeof(g->Message), "%s result", (Myc.m_Res) ? "Void" : "No");
       Myc.Close();
       return true;
       } // endif m_Res
@@ -1011,7 +1011,7 @@ PCOL TDBMYSQL::MakeFieldColumn(PGLOBAL g, char *name)
     } // endfor n
 
   if (!colp)
-    sprintf(g->Message, "Column %s is not in view", name);
+    snprintf(g->Message, sizeof(g->Message), "Column %s is not in view", name);
 
   return colp;
   } // end of MakeFieldColumn
@@ -1048,7 +1048,7 @@ int TDBMYSQL::SendCommand(PGLOBAL g)
 
   if (Myc.ExecSQLcmd(g, Query->GetStr(), &w) == RC_NF) {
     AftRows = Myc.m_Afrw;
-    sprintf(g->Message, "%s: %d affected rows", TableName, AftRows);
+    snprintf(g->Message, sizeof(g->Message), "%s: %d affected rows", TableName, AftRows);
     PushWarning(g, this, 0);    // 0 means a Note
 
     if (trace(1))
@@ -1057,7 +1057,7 @@ int TDBMYSQL::SendCommand(PGLOBAL g)
     if (w && Myc.ExecSQL(g, "SHOW WARNINGS") == RC_OK) {
       // We got warnings from the remote server
       while (Myc.Fetch(g, -1) == RC_OK) {
-        sprintf(g->Message, "%s: (%s) %s", TableName,
+        snprintf(g->Message, sizeof(g->Message), "%s: (%s) %s", TableName,
                 Myc.GetCharField(1), Myc.GetCharField(2));
         PushWarning(g, this);
         } // endwhile Fetch
@@ -1310,7 +1310,7 @@ bool MYSQLCOL::FindRank(PGLOBAL g)
       return false;
       } // endif Name
 
-  sprintf(g->Message, "Column %s not in result set", Name);
+  snprintf(g->Message, sizeof(g->Message), "Column %s not in result set", Name);
   return true;
 } // end of FindRank
 
@@ -1320,7 +1320,7 @@ bool MYSQLCOL::FindRank(PGLOBAL g)
 bool MYSQLCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   {
   if (!(To_Val = value)) {
-    sprintf(g->Message, MSG(VALUE_ERROR), Name);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_ERROR), Name);
     return true;
   } else if (Buf_Type == value->GetType()) {
     // Values are of the (good) column type
@@ -1339,7 +1339,7 @@ bool MYSQLCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   } else {
     // Values are not of the (good) column type
     if (check) {
-      sprintf(g->Message, MSG(TYPE_VALUE_ERR), Name,
+      snprintf(g->Message, sizeof(g->Message), MSG(TYPE_VALUE_ERR), Name,
               GetTypeName(Buf_Type), GetTypeName(value->GetType()));
       return true;
       } // endif check
@@ -1402,7 +1402,7 @@ void MYSQLCOL::ReadColumn(PGLOBAL g)
   {
     if ((rc = tdbp->Myc.Fetch(g, tdbp->N)) != RC_OK) {
       if (rc == RC_EF)
-        sprintf(g->Message, MSG(INV_DEF_READ), rc);
+        snprintf(g->Message, sizeof(g->Message), MSG(INV_DEF_READ), rc);
 
 			throw 11;
 		} else
@@ -1420,7 +1420,7 @@ void MYSQLCOL::ReadColumn(PGLOBAL g)
       p = buf;
 
     if (Value->SetValue_char(p, strlen(p))) {
-      sprintf(g->Message, "Out of range value for column %s at row %d",
+      snprintf(g->Message, sizeof(g->Message), "Out of range value for column %s at row %d",
               Name, tdbp->RowNumber(g));
       PushWarning(g, tdbp);
       } // endif SetValue_char

--- a/storage/connect/taboccur.cpp
+++ b/storage/connect/taboccur.cpp
@@ -361,7 +361,7 @@ bool TDBOCCUR::MakeColumnList(PGLOBAL g)
 	for (i = 0, pn = Colist; i < Mult; i++, pn += (strlen(pn) + 1)) {
 		if (!(Col[i] = Tdbp->ColDB(g, pn, 0))) {
 		  // Column not found in table                                       
-		  sprintf(g->Message, MSG(COL_ISNOT_TABLE), pn, Tabname);
+		  snprintf(g->Message, sizeof(g->Message), MSG(COL_ISNOT_TABLE), pn, Tabname);
 			return true;
 			} // endif Col
 
@@ -409,7 +409,7 @@ bool TDBOCCUR::ViewColumnList(PGLOBAL g)
 	for (i = 0, pn = Colist; i < Mult; i++, pn += (strlen(pn) + 1))
 		if (!(Col[i] = tdbp->MakeFieldColumn(g, pn))) {
 		  // Column not found in table                                       
-		  sprintf(g->Message, MSG(COL_ISNOT_TABLE), pn, Tabname);
+		  snprintf(g->Message, sizeof(g->Message), MSG(COL_ISNOT_TABLE), pn, Tabname);
 			return true;
 			} // endif Col
 

--- a/storage/connect/tabodbc.cpp
+++ b/storage/connect/tabodbc.cpp
@@ -109,7 +109,7 @@ bool ODBCDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
   Desc = Connect = GetStringCatInfo(g, "Connect", NULL);
 
   if (!Connect && !Catfunc) {
-    sprintf(g->Message, "Missing connection for ODBC table %s", Name);
+    snprintf(g->Message, sizeof(g->Message), "Missing connection for ODBC table %s", Name);
     return true;
   } // endif Connect
 
@@ -605,7 +605,7 @@ bool TDBODBC::OpenDB(PGLOBAL g)
         if ((n = Ocp->GetResultSize(Query->GetStr(), Cnp)) < 0) {
 					char* msg = PlugDup(g, g->Message);
 
-					sprintf(g->Message, "Get result size: %s (rc=%d)", msg, n);
+					snprintf(g->Message, sizeof(g->Message), "Get result size: %s (rc=%d)", msg, n);
 					return true;
 				} else if (n) {
 					Ocp->m_Rows = n;
@@ -650,7 +650,7 @@ bool TDBODBC::OpenDB(PGLOBAL g)
   } else if (Mode == MODE_UPDATE || Mode == MODE_DELETE) {
     rc = false;  // wait for CheckCond before calling MakeCommand(g);
   } else
-    sprintf(g->Message, "Invalid mode %d", Mode);
+    snprintf(g->Message, sizeof(g->Message), "Invalid mode %d", Mode);
 
   if (rc) {
     Ocp->Close();
@@ -775,7 +775,7 @@ int TDBODBC::ReadDB(PGLOBAL g)
 
     // Send the UPDATE/DELETE command to the remote table
     if (!Ocp->ExecSQLcommand(Query->GetStr())) {
-      sprintf(g->Message, "%s: %d affected rows", TableName, AftRows);
+      snprintf(g->Message, sizeof(g->Message), "%s: %d affected rows", TableName, AftRows);
 
       if (trace(1))
         htrc("%s\n", g->Message);
@@ -851,7 +851,7 @@ int TDBODBC::DeleteDB(PGLOBAL g, int irc)
 
     // Send the DELETE (all) command to the remote table
     if (!Ocp->ExecSQLcommand(Query->GetStr())) {
-      sprintf(g->Message, "%s: %d affected rows", TableName, AftRows);
+      snprintf(g->Message, sizeof(g->Message), "%s: %d affected rows", TableName, AftRows);
 
       if (trace(1))
         htrc("%s\n", g->Message);

--- a/storage/connect/tabpivot.cpp
+++ b/storage/connect/tabpivot.cpp
@@ -193,7 +193,7 @@ PQRYRES PIVAID::MakePivotColumns(PGLOBAL g)
 				*pcrp = crp->Next;
 			} else if (!stricmp(Picol, crp->Name)) {
 				if (crp->Nulls) {
-					sprintf(g->Message, "Pivot column %s cannot be nullable", Picol);
+					snprintf(g->Message, sizeof(g->Message), "Pivot column %s cannot be nullable", Picol);
 					goto err;
 				} // endif Nulls
 
@@ -549,14 +549,14 @@ bool TDBPIVOT::MakePivotColumns(PGLOBAL g)
     // Now it is time to allocate the pivot and function columns
     if (!(Fcolp = Tdbp->ColDB(g, Fncol, 0))) {
       // Function column not found in table                                       
-      sprintf(g->Message, MSG(COL_ISNOT_TABLE), Fncol, Tabname);
+      snprintf(g->Message, sizeof(g->Message), MSG(COL_ISNOT_TABLE), Fncol, Tabname);
       return true;
     } else if (Fcolp->InitValue(g))
       return true;
 
     if (!(Xcolp = Tdbp->ColDB(g, Picol, 0))) {
       // Pivot column not found in table                                       
-      sprintf(g->Message, MSG(COL_ISNOT_TABLE), Picol, Tabname);
+      snprintf(g->Message, sizeof(g->Message), MSG(COL_ISNOT_TABLE), Picol, Tabname);
       return true;
     } else if (Xcolp->InitValue(g))
       return true;
@@ -670,7 +670,7 @@ bool TDBPIVOT::OpenDB(PGLOBAL g)
     /*******************************************************************/
     /* Currently PIVOT tables cannot be modified.                      */
     /*******************************************************************/
-    sprintf(g->Message, MSG(TABLE_READ_ONLY), "PIVOT");
+    snprintf(g->Message, sizeof(g->Message), MSG(TABLE_READ_ONLY), "PIVOT");
     return TRUE;
     } // endif Mode
 
@@ -799,7 +799,7 @@ int TDBPIVOT::ReadDB(PGLOBAL g)
 /***********************************************************************/
 int TDBPIVOT::WriteDB(PGLOBAL g)
   {
-  sprintf(g->Message, MSG(TABLE_READ_ONLY), "PIVOT");
+  snprintf(g->Message, sizeof(g->Message), MSG(TABLE_READ_ONLY), "PIVOT");
   return RC_FX;
   } // end of WriteDB
 
@@ -808,7 +808,7 @@ int TDBPIVOT::WriteDB(PGLOBAL g)
 /***********************************************************************/
 int TDBPIVOT::DeleteDB(PGLOBAL g, int)
   {
-  sprintf(g->Message, MSG(NO_TABLE_DEL), "PIVOT");
+  snprintf(g->Message, sizeof(g->Message), MSG(NO_TABLE_DEL), "PIVOT");
   return RC_FX;
   } // end of DeleteDB
 

--- a/storage/connect/tabrest.cpp
+++ b/storage/connect/tabrest.cpp
@@ -87,7 +87,7 @@ int Xcurl(PGLOBAL g, PCSZ Http, PCSZ Uri, PCSZ filename)
 		CloseHandle(pi.hProcess);
 		CloseHandle(pi.hThread);
 	} else {
-		sprintf(g->Message, "CreateProcess curl failed (%d)", GetLastError());
+		snprintf(g->Message, sizeof(g->Message), "CreateProcess curl failed (%d)", GetLastError());
 		rc = 1;
 	}	// endif CreateProcess
 #else   // !_WIN32
@@ -159,7 +159,7 @@ XGETREST GetRestFunction(PGLOBAL g)
 		char  buf[256];
 		DWORD rc = GetLastError();
 
-		sprintf(g->Message, MSG(DLL_LOAD_ERROR), rc, soname);
+		snprintf(g->Message, sizeof(g->Message), MSG(DLL_LOAD_ERROR), rc, soname);
 		FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
 			FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
 			(LPTSTR)buf, sizeof(buf), NULL);
@@ -172,7 +172,7 @@ XGETREST GetRestFunction(PGLOBAL g)
 		char  buf[256];
 		DWORD rc = GetLastError();
 
-		sprintf(g->Message, MSG(PROCADD_ERROR), rc, "restGetFile");
+		snprintf(g->Message, sizeof(g->Message), MSG(PROCADD_ERROR), rc, "restGetFile");
 		FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
 			FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
 			(LPTSTR)buf, sizeof(buf), NULL);
@@ -188,14 +188,14 @@ XGETREST GetRestFunction(PGLOBAL g)
 	// Load the desired shared library
 	if (!(Hso = dlopen(soname, RTLD_LAZY))) {
 		error = dlerror();
-		sprintf(g->Message, MSG(SHARED_LIB_ERR), soname, SVP(error));
+		snprintf(g->Message, sizeof(g->Message), MSG(SHARED_LIB_ERR), soname, SVP(error));
 		return NULL;
 	} // endif Hdll
 
 // Get the function returning an instance of the external DEF class
 	if (!(getRestFnc = (XGETREST)dlsym(Hso, "restGetFile"))) {
 		error = dlerror();
-		sprintf(g->Message, MSG(GET_FUNC_ERR), "restGetFile", SVP(error));
+		snprintf(g->Message, sizeof(g->Message), MSG(GET_FUNC_ERR), "restGetFile", SVP(error));
 		dlclose(Hso);
 		return NULL;
 	} // endif getdef
@@ -239,7 +239,7 @@ PQRYRES RESTColumns(PGLOBAL g, PTOS tp, char *tab, char *db, bool info)
 
 		fn = filename;
 		tp->subtype = PlugDup(g, fn);
-		sprintf(g->Message, "No file name. Table will use %s", fn);
+		snprintf(g->Message, sizeof(g->Message), "No file name. Table will use %s", fn);
 		PUSH_WARNING(g->Message);
 	}	// endif fn
 
@@ -265,7 +265,7 @@ PQRYRES RESTColumns(PGLOBAL g, PTOS tp, char *tab, char *db, bool info)
 		qrp = XMLColumns(g, db, tab, tp, info);
 #endif   // XML_SUPPORT
 	else
-    sprintf(g->Message, "Usupported file type %s", ftype);
+    snprintf(g->Message, sizeof(g->Message), "Usupported file type %s", ftype);
 
   return qrp;
 } // end of RESTColumns
@@ -300,7 +300,7 @@ bool RESTDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
 
   if (n == 0) {
     htrc("DefineAM: Unsupported REST table type %s\n", ftype);
-    sprintf(g->Message, "Unsupported REST table type %s", ftype);
+    snprintf(g->Message, sizeof(g->Message), "Unsupported REST table type %s", ftype);
     return true;
   } // endif n
 

--- a/storage/connect/tabsys.cpp
+++ b/storage/connect/tabsys.cpp
@@ -318,7 +318,7 @@ int TDBINI::DeleteDB(PGLOBAL g, int irc)
     case RC_FX:
       while (ReadDB(g) == RC_OK)
         if (!WritePrivateProfileString(Section, NULL, NULL, Ifile)) {
-          sprintf(g->Message, "Error %d accessing %s", 
+          snprintf(g->Message, sizeof(g->Message), "Error %d accessing %s", 
                               GetLastError(), Ifile);
           return RC_FX;
           } // endif
@@ -330,7 +330,7 @@ int TDBINI::DeleteDB(PGLOBAL g, int irc)
         return RC_FX;
       } else
         if (!WritePrivateProfileString(Section, NULL, NULL, Ifile)) {
-          sprintf(g->Message, "Error %d accessing %s", 
+          snprintf(g->Message, sizeof(g->Message), "Error %d accessing %s", 
                               GetLastError(), Ifile);
           return RC_FX;
           } // endif rc
@@ -401,7 +401,7 @@ void INICOL::AllocBuf(PGLOBAL g)
 bool INICOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   {
   if (!(To_Val = value)) {
-    sprintf(g->Message, MSG(VALUE_ERROR), Name);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_ERROR), Name);
     return true;
   } else if (Buf_Type == value->GetType()) {
     // Values are of the (good) column type
@@ -420,7 +420,7 @@ bool INICOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   } else {
     // Values are not of the (good) column type
     if (check) {
-      sprintf(g->Message, MSG(TYPE_VALUE_ERR), Name,
+      snprintf(g->Message, sizeof(g->Message), MSG(TYPE_VALUE_ERR), Name,
               GetTypeName(Buf_Type), GetTypeName(value->GetType()));
       return true;
       } // endif check
@@ -510,7 +510,7 @@ void INICOL::WriteColumn(PGLOBAL g)
   p = Value->GetCharString(Valbuf);
 
   if (strlen(p) > (unsigned)Long) {
-    sprintf(g->Message, MSG(VALUE_TOO_LONG), p, Name, Long);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_LONG), p, Name, Long);
 		throw 31;
 	} else if (Flag == 1) {
     if (tdbp->Mode == MODE_UPDATE) {
@@ -534,7 +534,7 @@ void INICOL::WriteColumn(PGLOBAL g)
     rc = WritePrivateProfileString(tdbp->Section, Name, p, tdbp->Ifile);
     
     if (!rc) {
-      sprintf(g->Message, "Error %d writing to %s", 
+      snprintf(g->Message, sizeof(g->Message), "Error %d writing to %s", 
                           GetLastError(), tdbp->Ifile);
 			throw 31;
 		} // endif rc
@@ -746,7 +746,7 @@ int TDBXIN::DeleteDB(PGLOBAL g, int irc)
   } else if (irc == RC_FX) {
     for (Section = Seclist; *Section; Section += (strlen(Section) + 1))
       if (!WritePrivateProfileString(Section, NULL, NULL, Ifile)) {
-        sprintf(g->Message, "Error %d accessing %s", 
+        snprintf(g->Message, sizeof(g->Message), "Error %d accessing %s", 
                             GetLastError(), Ifile);
         return RC_FX;
         } // endif
@@ -756,7 +756,7 @@ int TDBXIN::DeleteDB(PGLOBAL g, int irc)
     return RC_FX;
   } else
     if (!WritePrivateProfileString(Section, Keycur, NULL, Ifile)) {
-      sprintf(g->Message, "Error %d accessing %s", 
+      snprintf(g->Message, sizeof(g->Message), "Error %d accessing %s", 
                           GetLastError(), Ifile);
       return RC_FX;
       } // endif
@@ -836,7 +836,7 @@ void XINCOL::WriteColumn(PGLOBAL g)
   p = Value->GetCharString(Valbuf);
 
   if (strlen(p) > (unsigned)Long) {
-    sprintf(g->Message, MSG(VALUE_TOO_LONG), p, Name, Long);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_LONG), p, Name, Long);
 		throw 31;
 	} else if (Flag == 1) {
     if (tdbp->Mode == MODE_UPDATE) {
@@ -870,7 +870,7 @@ void XINCOL::WriteColumn(PGLOBAL g)
     rc = WritePrivateProfileString(tdbp->Section, tdbp->Keycur, p, tdbp->Ifile);
     
     if (!rc) {
-      sprintf(g->Message, "Error %d writing to %s", 
+      snprintf(g->Message, sizeof(g->Message), "Error %d writing to %s", 
                           GetLastError(), tdbp->Ifile);
 			throw 31;
 		} // endif rc

--- a/storage/connect/tabtbl.cpp
+++ b/storage/connect/tabtbl.cpp
@@ -691,7 +691,7 @@ bool TDBTBM::OpenTables(PGLOBAL g)
 //    pthread_attr_setdetachstate(&tp->attr, PTHREAD_CREATE_JOINABLE);
 
       if ((k = pthread_create(&tp->Tid, &tp->attr, ThreadOpen, tp))) {
-        sprintf(g->Message, "pthread_create error %d", k);
+        snprintf(g->Message, sizeof(g->Message), "pthread_create error %d", k);
         Nbc++;
         continue;
         } // endif k

--- a/storage/connect/tabutil.cpp
+++ b/storage/connect/tabutil.cpp
@@ -109,7 +109,7 @@ TABLE_SHARE *GetTableShare(PGLOBAL g, THD *thd, const char *db,
     if (thd->is_error())
       thd->clear_error();  // Avoid stopping info commands
 
-    sprintf(g->Message, "Error %d opening share\n", s->error);
+    snprintf(g->Message, sizeof(g->Message), "Error %d opening share\n", s->error);
     free_table_share(s);
     return NULL;
   } // endif open_table_def
@@ -204,19 +204,19 @@ PQRYRES TabColumns(PGLOBAL g, THD *thd, const char *db,
     if ((type = MYSQLtoPLG(fp->type(), &v)) == TYPE_ERROR) {
       if (v == 'K') {
         // Skip this column
-        sprintf(g->Message, "Column %s skipped (unsupported type)", colname);
+        snprintf(g->Message, sizeof(g->Message), "Column %s skipped (unsupported type)", colname);
         push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
         continue;
         } // endif v
 
-      sprintf(g->Message, "Column %s unsupported type", colname);
+      snprintf(g->Message, sizeof(g->Message), "Column %s unsupported type", colname);
       qrp = NULL;
       break;
       } // endif type
 
       if (v == 'X') {
         len = zconv;
-        sprintf(g->Message, "Column %s converted to varchar(%d)",
+        snprintf(g->Message, sizeof(g->Message), "Column %s converted to varchar(%d)",
                 colname, len);
         push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
         } // endif v
@@ -411,7 +411,7 @@ PTDB TDBPRX::GetSubTable(PGLOBAL g, PTABLE tabp, bool b)
     cdb = (tp->Schema) ? tp->Schema : curdb;
 
     if (!stricmp(name, tp->Name) && !stricmp(db, cdb)) {
-      sprintf(g->Message, "Table %s.%s pointing on itself", db, name);
+      snprintf(g->Message, sizeof(g->Message), "Table %s.%s pointing on itself", db, name);
       return NULL;
       } // endif
 
@@ -441,7 +441,7 @@ PTDB TDBPRX::GetSubTable(PGLOBAL g, PTABLE tabp, bool b)
       char buf[MAX_STR];
 
       strcpy(buf, g->Message);
-      snprintf(g->Message, MAX_STR, "Error accessing %s.%s: %s", db, name, buf);
+      snprintf(g->Message, sizeof(g->Message), "Error accessing %s.%s: %s", db, name, buf);
       hc->tshp = NULL;
       goto err;
       } // endif Define
@@ -578,7 +578,7 @@ bool TDBPRX::OpenDB(PGLOBAL g)
     PTDB utp;
 
     if (!(utp= Tdbp->Duplicate(g))) {
-      sprintf(g->Message, MSG(INV_UPDT_TABLE), Tdbp->GetName());
+      snprintf(g->Message, sizeof(g->Message), MSG(INV_UPDT_TABLE), Tdbp->GetName());
       return true;
       } // endif tp
 
@@ -721,7 +721,7 @@ bool PRXCOL::Init(PGLOBAL g, PTDB tp)
     // this may be needed by some tables (which?)
     Colp->SetColUse(ColUse);
   } else {
-    sprintf(g->Message, MSG(NO_MATCHING_COL), Name, tp->GetName());
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_MATCHING_COL), Name, tp->GetName());
     return true;
   } // endif Colp
 

--- a/storage/connect/tabvir.cpp
+++ b/storage/connect/tabvir.cpp
@@ -251,7 +251,7 @@ int TDBVIR::ReadDB(PGLOBAL)
 /***********************************************************************/
 int TDBVIR::WriteDB(PGLOBAL g)
   {
-  sprintf(g->Message, MSG(VIR_READ_ONLY), To_Def->GetType());
+  snprintf(g->Message, sizeof(g->Message), MSG(VIR_READ_ONLY), To_Def->GetType());
   return RC_FX;
   } // end of WriteDB
 
@@ -260,7 +260,7 @@ int TDBVIR::WriteDB(PGLOBAL g)
 /***********************************************************************/
 int TDBVIR::DeleteDB(PGLOBAL g, int)
   {
-  sprintf(g->Message, MSG(VIR_NO_DELETE), To_Def->GetType());
+  snprintf(g->Message, sizeof(g->Message), MSG(VIR_NO_DELETE), To_Def->GetType());
   return RC_FX;
   } // end of DeleteDB
 
@@ -288,7 +288,7 @@ VIRCOL::VIRCOL(PCOLDEF cdp, PTDB tdbp, PCOL cprec, int i, PCSZ)
 void VIRCOL::ReadColumn(PGLOBAL g)
   {
   // This should never be called
-  sprintf(g->Message, "ReadColumn: Column %s is not virtual", Name);
+  snprintf(g->Message, sizeof(g->Message), "ReadColumn: Column %s is not virtual", Name);
 	throw (int)TYPE_COLBLK;
 } // end of ReadColumn
 

--- a/storage/connect/tabwmi.cpp
+++ b/storage/connect/tabwmi.cpp
@@ -62,7 +62,7 @@ PWMIUT InitWMI(PGLOBAL g, PCSZ nsp, PCSZ classname)
   res = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
 
   if (FAILED(res)) {
-    sprintf(g->Message, "Failed to initialize COM library. " 
+    snprintf(g->Message, sizeof(g->Message), "Failed to initialize COM library. " 
             "Error code = %x", res);
     return NULL;
     } // endif res
@@ -74,7 +74,7 @@ PWMIUT InitWMI(PGLOBAL g, PCSZ nsp, PCSZ classname)
                        NULL, EOAC_NONE, NULL);
   
   if (res != RPC_E_TOO_LATE && FAILED(res)) {
-    sprintf(g->Message, "Failed to initialize security. " 
+    snprintf(g->Message, sizeof(g->Message), "Failed to initialize security. " 
             "Error code = %p", res);
     CoUninitialize();
     return NULL;
@@ -85,7 +85,7 @@ PWMIUT InitWMI(PGLOBAL g, PCSZ nsp, PCSZ classname)
                          CLSCTX_INPROC_SERVER, IID_IWbemLocator, 
                          (void**) &loc);
   if (FAILED(res)) {
-    sprintf(g->Message, "Failed to create Locator. " 
+    snprintf(g->Message, sizeof(g->Message), "Failed to create Locator. " 
             "Error code = %x", res);
     CoUninitialize();
     return NULL;
@@ -95,7 +95,7 @@ PWMIUT InitWMI(PGLOBAL g, PCSZ nsp, PCSZ classname)
                     NULL, NULL, NULL, 0, NULL, NULL, &wp->Svc);
 
   if (FAILED(res)) {
-    sprintf(g->Message, "Could not connect. Error code = %x", res); 
+    snprintf(g->Message, sizeof(g->Message), "Could not connect. Error code = %x", res); 
     loc->Release();     
     CoUninitialize();
     return NULL;
@@ -119,7 +119,7 @@ PWMIUT InitWMI(PGLOBAL g, PCSZ nsp, PCSZ classname)
   res = wp->Svc->GetObject(bstr_t(p), 0, 0, &wp->Cobj, 0);
 
   if (FAILED(res)) {
-    sprintf(g->Message, "failed GetObject %s in %s\n", classname, nsp);
+    snprintf(g->Message, sizeof(g->Message), "failed GetObject %s in %s\n", classname, nsp);
     wp->Svc->Release();
     wp->Svc = NULL;    // MUST be set to NULL  (why?)
     return NULL;
@@ -164,12 +164,12 @@ PQRYRES WMIColumns(PGLOBAL g, PCSZ nsp, PCSZ cls, bool info)
     res = wp->Cobj->Get(bstr_t("__Property_Count"), 0, &val, NULL, NULL);
 
     if (FAILED(res)) {
-      sprintf(g->Message, "failed Get(__Property_Count) res=%d\n", res);
+      snprintf(g->Message, sizeof(g->Message), "failed Get(__Property_Count) res=%d\n", res);
       goto err;
       }  // endif res
 
     if (!(n = val.lVal)) {
-      sprintf(g->Message, "Class %s in %s has no properties\n",
+      snprintf(g->Message, sizeof(g->Message), "Class %s in %s has no properties\n",
                           cls, nsp);
       goto err;
       }  // endif res
@@ -182,7 +182,7 @@ PQRYRES WMIColumns(PGLOBAL g, PCSZ nsp, PCSZ cls, bool info)
           NULL, &prnlist);
 
     if (FAILED(res)) {
-      sprintf(g->Message, "failed GetNames res=%d\n", res);
+      snprintf(g->Message, sizeof(g->Message), "failed GetNames res=%d\n", res);
       goto err;
       }  // endif res
 
@@ -194,7 +194,7 @@ PQRYRES WMIColumns(PGLOBAL g, PCSZ nsp, PCSZ cls, bool info)
       res = SafeArrayGetElement(prnlist, &i, &propname);
 
       if (FAILED(res)) {
-        sprintf(g->Message, "failed GetArrayElement res=%d\n", res);
+        snprintf(g->Message, sizeof(g->Message), "failed GetArrayElement res=%d\n", res);
         goto err;
         }  // endif res
 
@@ -221,7 +221,7 @@ PQRYRES WMIColumns(PGLOBAL g, PCSZ nsp, PCSZ cls, bool info)
   res = wp->Cobj->BeginEnumeration(WBEM_FLAG_NONSYSTEM_ONLY);
 
   if (FAILED(res)) {
-    sprintf(g->Message, "failed BeginEnumeration hr=%d\n", res);
+    snprintf(g->Message, sizeof(g->Message), "failed BeginEnumeration hr=%d\n", res);
     qrp = NULL;
     goto err;
     }  // endif hr
@@ -230,7 +230,7 @@ PQRYRES WMIColumns(PGLOBAL g, PCSZ nsp, PCSZ cls, bool info)
     res = wp->Cobj->Next(0, &propname, &val, &type, NULL);
 
     if (FAILED(res)) {
-      sprintf(g->Message, "failed getting Next hr=%d\n", res);
+      snprintf(g->Message, sizeof(g->Message), "failed getting Next hr=%d\n", res);
       qrp = NULL;
       goto err;
     }  else if (res == WBEM_S_NO_MORE_DATA) {
@@ -340,7 +340,7 @@ bool WMIDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
            !stricmp(Nspace, "root\\cli")   ? "Msft_CliAlias" : ""));
 
   if (!*Wclass) {
-    sprintf(g->Message, "Missing class name for %s", Nspace);
+    snprintf(g->Message, sizeof(g->Message), "Missing class name for %s", Nspace);
     return true;
   } else if (!strchr(Wclass, '_')) {
     char *p = (char*)PlugSubAlloc(g, NULL, strlen(Wclass) + 7);
@@ -363,7 +363,7 @@ PTDB WMIDEF::GetTable(PGLOBAL g, MODE m)
   else if (Catfunc == FNC_COL)
     return new(g) TDBWCL(this);
 
-  sprintf(g->Message, "Bad catfunc %ud for WMI", Catfunc);
+  snprintf(g->Message, sizeof(g->Message), "Bad catfunc %ud for WMI", Catfunc);
   return NULL;
   } // end of GetTable
 
@@ -423,7 +423,7 @@ bool TDBWMI::Initialize(PGLOBAL g)
   Res = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
 
   if (FAILED(Res)) {
-    sprintf(g->Message, "Failed to initialize COM library. " 
+    snprintf(g->Message, sizeof(g->Message), "Failed to initialize COM library. " 
             "Error code = %x", Res);
     return true;              // Program has failed.
     } // endif Res
@@ -436,7 +436,7 @@ bool TDBWMI::Initialize(PGLOBAL g)
                          IID_IWbemLocator, (LPVOID*) &loc);
  
   if (FAILED(Res)) {
-    sprintf(g->Message, "Failed to create Locator. " 
+    snprintf(g->Message, sizeof(g->Message), "Failed to create Locator. " 
                         "Error code = %x", Res);
     CoUninitialize();
     return true;       // Program has failed.
@@ -449,7 +449,7 @@ bool TDBWMI::Initialize(PGLOBAL g)
                              NULL, NULL,0, NULL, 0, 0, &Svc);
   
   if (FAILED(Res)) {
-    sprintf(g->Message, "Could not connect. Error code = %x", Res); 
+    snprintf(g->Message, sizeof(g->Message), "Could not connect. Error code = %x", Res); 
     loc->Release();     
     CoUninitialize();
     return true;                // Program has failed.
@@ -464,7 +464,7 @@ bool TDBWMI::Initialize(PGLOBAL g)
                           RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_NONE);
 
   if (FAILED(Res)) {
-    sprintf(g->Message, "Could not set proxy. Error code = %x", Res);
+    snprintf(g->Message, sizeof(g->Message), "Could not set proxy. Error code = %x", Res);
     Svc->Release();
     CoUninitialize();
     return true;               // Program has failed.
@@ -561,7 +561,7 @@ bool TDBWMI::GetWMIInfo(PGLOBAL g)
   char *cmd = MakeWQL(g);
 
   if (cmd == NULL) {
-    sprintf(g->Message, "Error making WQL statement"); 
+    snprintf(g->Message, sizeof(g->Message), "Error making WQL statement"); 
     Svc->Release();
     CoUninitialize();
     return true;               // Program has failed.
@@ -574,7 +574,7 @@ bool TDBWMI::GetWMIInfo(PGLOBAL g)
       NULL, &Enumerator);
   
   if (FAILED(Rc)) {
-    sprintf(g->Message, "Query %s failed. Error code = %x", cmd, Rc); 
+    snprintf(g->Message, sizeof(g->Message), "Query %s failed. Error code = %x", cmd, Rc); 
     Svc->Release();
     CoUninitialize();
     return true;               // Program has failed.

--- a/storage/connect/tabxml.cpp
+++ b/storage/connect/tabxml.cpp
@@ -518,7 +518,7 @@ bool XMLDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
       defcol = "TD";
       break;
     default:
-      sprintf(g->Message, MSG(INV_COL_TYPE), buf);
+      snprintf(g->Message, sizeof(g->Message), MSG(INV_COL_TYPE), buf);
       return true;
     } // endswitch typname
 
@@ -783,7 +783,7 @@ int TDBXML::LoadTableFile(PGLOBAL g, char *filename)
 
     // Initialize the implementation
     if (Docp->Initialize(g, Entry, Zipped)) {
-      sprintf(g->Message, MSG(INIT_FAILED), (Usedom) ? "DOM" : "libxml2");
+      snprintf(g->Message, sizeof(g->Message), MSG(INIT_FAILED), (Usedom) ? "DOM" : "libxml2");
       return RC_FX;
       } // endif init
 
@@ -873,7 +873,7 @@ bool TDBXML::Initialize(PGLOBAL g)
 			// Evaluate table xpath
 			if ((TabNode = Root->SelectSingleNode(g, tabpath))) {
 				if (TabNode->GetType() != XML_ELEMENT_NODE) {
-					sprintf(g->Message, MSG(BAD_NODE_TYPE), TabNode->GetType());
+					snprintf(g->Message, sizeof(g->Message), MSG(BAD_NODE_TYPE), TabNode->GetType());
 					goto error;
 				} // endif Type
 
@@ -890,12 +890,12 @@ bool TDBXML::Initialize(PGLOBAL g)
 				if (!(DBnode = Root->SelectSingleNode(g, tabpath))) {
 					// DB node does not exist yet; we cannot create it
 					// because we don't know where it should be placed
-					sprintf(g->Message, MSG(MISSING_NODE), XmlDB, Xfile);
+					snprintf(g->Message, sizeof(g->Message), MSG(MISSING_NODE), XmlDB, Xfile);
 					goto error;
 				} // endif DBnode
 
 				if (!(TabNode = DBnode->AddChildNode(g, Tabname))) {
-					sprintf(g->Message, MSG(FAIL_ADD_NODE), Tabname);
+					snprintf(g->Message, sizeof(g->Message), MSG(FAIL_ADD_NODE), Tabname);
 					goto error;
 				} // endif TabNode
 
@@ -940,7 +940,7 @@ bool TDBXML::Initialize(PGLOBAL g)
 					goto error;
 
 			} else {
-				sprintf(g->Message, MSG(FILE_UNFOUND), Xfile);
+				snprintf(g->Message, sizeof(g->Message), MSG(FILE_UNFOUND), Xfile);
 
 				if (Mode == MODE_READ) {
 					PushWarning(g, this);
@@ -952,7 +952,7 @@ bool TDBXML::Initialize(PGLOBAL g)
 
 		} else if (rc == RC_INFO) {
 			// Loading failed
-			sprintf(g->Message, MSG(LOADING_FAILED), Xfile);
+			snprintf(g->Message, sizeof(g->Message), MSG(LOADING_FAILED), Xfile);
 			goto error;
 		} else // (rc == RC_FX)
 			goto error;
@@ -985,9 +985,9 @@ bool TDBXML::Initialize(PGLOBAL g)
                              buf, sizeof(buf), NULL, NULL);
 
     if (rc)
-      sprintf(g->Message, "%s: %s", MSG(COM_ERROR), buf);
+      snprintf(g->Message, sizeof(g->Message), "%s: %s", MSG(COM_ERROR), buf);
     else
-      sprintf(g->Message, "%s hr=%x", MSG(COM_ERROR), e.Error());
+      snprintf(g->Message, sizeof(g->Message), "%s hr=%x", MSG(COM_ERROR), e.Error());
 
     goto error;
 #endif   // _WIN32
@@ -1144,7 +1144,7 @@ int TDBXML::RowNumber(PGLOBAL g, bool b)
     /*******************************************************************/
     /*  Don't know how to retrieve RowID for expanded XML tables.      */
     /*******************************************************************/
-    sprintf(g->Message, MSG(NO_ROWID_FOR_AM),
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_ROWID_FOR_AM),
                         GetAmName(g, GetAmType()));
     return 0;          // Means error
   } else
@@ -1266,7 +1266,7 @@ int TDBXML::ReadDB(PGLOBAL g)
     // Get the new row node
 		if (Nlist) {
 			if ((RowNode = Nlist->GetItem(g, Irow, RowNode)) == NULL) {
-				sprintf(g->Message, MSG(MISSING_ROWNODE), Irow);
+				snprintf(g->Message, sizeof(g->Message), MSG(MISSING_ROWNODE), Irow);
 				return RC_FX;
 			} // endif RowNode
 
@@ -1333,7 +1333,7 @@ int TDBXML::DeleteDB(PGLOBAL g, int irc)
     // Delete all rows
     for (Irow = 0; Irow < Nrow; Irow++)
       if ((RowNode = Nlist->GetItem(g, Irow, RowNode)) == NULL) {
-        sprintf(g->Message, MSG(MISSING_ROWNODE), Irow);
+        snprintf(g->Message, sizeof(g->Message), MSG(MISSING_ROWNODE), Irow);
         return RC_FX;
       } else {
         TabNode->DeleteChild(g, RowNode);
@@ -1529,7 +1529,7 @@ bool XMLCOL::ParseXpath(PGLOBAL g, bool mode)
 
   if (Xname) {
     if (Type == 2) {
-      sprintf(g->Message, MSG(BAD_COL_XPATH), Name, Tdbp->Name);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_COL_XPATH), Name, Tdbp->Name);
       return true;
     } else
       strcat(pbuf, Xname);
@@ -1561,7 +1561,7 @@ bool XMLCOL::ParseXpath(PGLOBAL g, bool mode)
       if (mode) {
         // For Update or Insert the Xpath must be explicit
         if (strchr("@/.*", *p)) {
-          sprintf(g->Message, MSG(XPATH_NOT_SUPP), Name);
+          snprintf(g->Message, sizeof(g->Message), MSG(XPATH_NOT_SUPP), Name);
           return true;
         } else
           Nodes[i] = p;
@@ -1572,7 +1572,7 @@ bool XMLCOL::ParseXpath(PGLOBAL g, bool mode)
       } // endfor i, p
 
     if (*p == '/' || *p == '.') {
-      sprintf(g->Message, MSG(XPATH_NOT_SUPP), Name);
+      snprintf(g->Message, sizeof(g->Message), MSG(XPATH_NOT_SUPP), Name);
       return true;
     } else if (*p == '@') {
       p++;                           // Remove the @ if mode
@@ -1633,7 +1633,7 @@ bool XMLCOL::ParseXpath(PGLOBAL g, bool mode)
 bool XMLCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   {
   if (!(To_Val = value)) {
-    sprintf(g->Message, MSG(VALUE_ERROR), Name);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_ERROR), Name);
     return true;
   } else if (Buf_Type == value->GetType()) {
     // Values are of the (good) column type
@@ -1652,7 +1652,7 @@ bool XMLCOL::SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
   } else {
     // Values are not of the (good) column type
     if (check) {
-      sprintf(g->Message, MSG(TYPE_VALUE_ERR), Name,
+      snprintf(g->Message, sizeof(g->Message), MSG(TYPE_VALUE_ERR), Name,
               GetTypeName(Buf_Type), GetTypeName(value->GetType()));
       return true;
       } // endif check
@@ -1705,7 +1705,7 @@ void XMLCOL::ReadColumn(PGLOBAL g)
   if (ValNode) {
     if (ValNode->GetType() != XML_ELEMENT_NODE &&
         ValNode->GetType() != XML_ATTRIBUTE_NODE) {
-      sprintf(g->Message, MSG(BAD_VALNODE), ValNode->GetType(), Name);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_VALNODE), ValNode->GetType(), Name);
 			throw (int)TYPE_AM_XML;
 		} // endif type
 
@@ -1874,7 +1874,7 @@ void XMLCOL::WriteColumn(PGLOBAL g)
   p = Value->GetCharString(buf);
 
   if (strlen(p) > (unsigned)Long) {
-    sprintf(g->Message, MSG(VALUE_TOO_LONG), p, Name, Long);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_LONG), p, Name, Long);
 		throw (int)TYPE_AM_XML;
 	} else
     strcpy(Valbuf, p);
@@ -1915,7 +1915,7 @@ void XMULCOL::ReadColumn(PGLOBAL g)
 
       if (N > Tdbp->Limit) {
         N = Tdbp->Limit;
-        sprintf(g->Message, "Multiple values limited to %d", Tdbp->Limit);
+        snprintf(g->Message, sizeof(g->Message), "Multiple values limited to %d", Tdbp->Limit);
         PushWarning(g, Tdbp);
         } // endif N
 
@@ -1924,7 +1924,7 @@ void XMULCOL::ReadColumn(PGLOBAL g)
 
         if (ValNode->GetType() != XML_ELEMENT_NODE &&
             ValNode->GetType() != XML_ATTRIBUTE_NODE) {
-          sprintf(g->Message, MSG(BAD_VALNODE), ValNode->GetType(), Name);
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_VALNODE), ValNode->GetType(), Name);
 					throw (int)TYPE_AM_XML;
 				} // endif type
 
@@ -2060,7 +2060,7 @@ void XMULCOL::WriteColumn(PGLOBAL g)
         len = Nlx->GetLength();
 
         if (len > 1 && !Tdbp->Xpand) {
-          sprintf(g->Message, MSG(BAD_VAL_UPDATE), Name);
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_VAL_UPDATE), Name);
 					throw (int)TYPE_AM_XML;
 				} else
           ValNode = Nlx->GetItem(g, Tdbp->Nsub, Vxnp);
@@ -2135,7 +2135,7 @@ void XMULCOL::WriteColumn(PGLOBAL g)
   p = Value->GetCharString(buf);
 
   if (strlen(p) > (unsigned)Long) {
-    sprintf(g->Message, MSG(VALUE_TOO_LONG), p, Name, Long);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_LONG), p, Name, Long);
 		throw (int)TYPE_AM_XML;
 	} else
     strcpy(Valbuf, p);
@@ -2262,7 +2262,7 @@ void XPOSCOL::WriteColumn(PGLOBAL g)
   p = Value->GetCharString(buf);
 
   if (strlen(p) > (unsigned)Long) {
-    sprintf(g->Message, MSG(VALUE_TOO_LONG), p, Name, Long);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALUE_TOO_LONG), p, Name, Long);
 		throw (int)TYPE_AM_XML;
 	} else
     strcpy(Valbuf, p);

--- a/storage/connect/tabzip.cpp
+++ b/storage/connect/tabzip.cpp
@@ -85,7 +85,7 @@ bool TDBZIP::open(PGLOBAL g, const char *fn)
 	PlugSetPath(filename, fn, GetPath());
 
 	if (!zipfile && !(zipfile = unzOpen64(filename)))
-		sprintf(g->Message, "Zipfile open error");
+		snprintf(g->Message, sizeof(g->Message), "Zipfile open error");
 
 	return (zipfile == NULL);
 }	// end of open
@@ -155,7 +155,7 @@ int TDBZIP::ReadDB(PGLOBAL g)
 	if (nexterr == UNZ_END_OF_LIST_OF_FILE)
 		return RC_EF;
 	else if (nexterr != UNZ_OK) {
-		sprintf(g->Message, "unzGoToNextFile error %d", nexterr);
+		snprintf(g->Message, sizeof(g->Message), "unzGoToNextFile error %d", nexterr);
 		return RC_FX;
 	}	// endif nexterr
 
@@ -163,7 +163,7 @@ int TDBZIP::ReadDB(PGLOBAL g)
 		sizeof(fn), NULL, 0, NULL, 0);
 
 	if (err != UNZ_OK) {
-		sprintf(g->Message, "unzGetCurrentFileInfo64 error %d", err);
+		snprintf(g->Message, sizeof(g->Message), "unzGetCurrentFileInfo64 error %d", err);
 		return RC_FX;
 	}	// endif err
 

--- a/storage/connect/valblk.cpp
+++ b/storage/connect/valblk.cpp
@@ -105,7 +105,7 @@ PVBLK AllocValBlock(PGLOBAL g, void *mp, int type, int nval, int len,
       blkp = new(g) PTRBLK(g, mp, nval);
       break;
     default:
-      sprintf(g->Message, MSG(BAD_VALBLK_TYPE), type);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_VALBLK_TYPE), type);
       return NULL;
     } // endswitch Type
 
@@ -138,7 +138,7 @@ PSZ VALBLK::GetCharValue(int)
   PGLOBAL& g = Global;
 
   assert(g);
-  sprintf(g->Message, MSG(NO_CHAR_FROM), Type);
+  snprintf(g->Message, sizeof(g->Message), MSG(NO_CHAR_FROM), Type);
 	throw Type;
 	return NULL;
   } // end of GetCharValue
@@ -148,7 +148,7 @@ PSZ VALBLK::GetCharValue(int)
 /***********************************************************************/
 bool VALBLK::SetFormat(PGLOBAL g, PCSZ, int, int)
   {
-  sprintf(g->Message, MSG(NO_DATE_FMT), Type);
+  snprintf(g->Message, sizeof(g->Message), MSG(NO_DATE_FMT), Type);
   return true;
   } // end of SetFormat
 
@@ -191,7 +191,7 @@ bool VALBLK::AllocBuff(PGLOBAL g, size_t size)
   Mblk.Size = size;
 
   if (!(Blkp = PlgDBalloc(g, NULL, Mblk))) {
-    sprintf(g->Message, MSG(MEM_ALLOC_ERR), "Blkp", (int) Mblk.Size);
+    snprintf(g->Message, sizeof(g->Message), MSG(MEM_ALLOC_ERR), "Blkp", (int) Mblk.Size);
     fprintf(stderr, "%s\n", g->Message);
     return true;
     } // endif Blkp
@@ -1380,7 +1380,7 @@ PVBLK MBVALS::Allocate(PGLOBAL g, int type, int len, int prec,
   Mblk.Size = n * GetTypeSize(type, len);
 
   if (!PlgDBalloc(g, NULL, Mblk)) {
-    sprintf(g->Message, MSG(ALLOC_ERROR), "MBVALS::Allocate");
+    snprintf(g->Message, sizeof(g->Message), MSG(ALLOC_ERROR), "MBVALS::Allocate");
     return NULL;
   } else
     Vblk = AllocValBlock(g, Mblk.Memp, type, n, len, prec, 
@@ -1395,7 +1395,7 @@ PVBLK MBVALS::Allocate(PGLOBAL g, int type, int len, int prec,
 bool MBVALS::ReAllocate(PGLOBAL g, int n)
   {
   if (!PlgDBrealloc(g, NULL, Mblk, n * Vblk->GetVlen())) {
-    sprintf(g->Message, MSG(ALLOC_ERROR), "MBVALS::ReAllocate");
+    snprintf(g->Message, sizeof(g->Message), MSG(ALLOC_ERROR), "MBVALS::ReAllocate");
     return TRUE;
   } else
     Vblk->ReAlloc(Mblk.Memp, n);

--- a/storage/connect/value.cpp
+++ b/storage/connect/value.cpp
@@ -360,7 +360,7 @@ PVAL AllocateValue(PGLOBAL g, void *value, short type, short prec)
       valp = new(g) TYPVAL<char>(*(char *)value, TYPE_TINY);
       break;
     default:
-      sprintf(g->Message, MSG(BAD_VALUE_TYPE), type);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_VALUE_TYPE), type);
       return NULL;
   } // endswitch Type
 
@@ -421,7 +421,7 @@ PVAL AllocateValue(PGLOBAL g, int type, int len, int prec,
       valp = new(g) BINVAL(g, (void*)NULL, len, prec);
       break;
     default:
-      sprintf(g->Message, MSG(BAD_VALUE_TYPE), type);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_VALUE_TYPE), type);
       return NULL;
   } // endswitch type
 
@@ -493,7 +493,7 @@ PVAL AllocateValue(PGLOBAL g, PVAL valp, int newtype, int uns)
 
       break;
     default:
-      sprintf(g->Message, MSG(BAD_VALUE_TYPE), newtype);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_VALUE_TYPE), newtype);
       return NULL;
   } // endswitch type
   
@@ -1189,7 +1189,7 @@ bool TYPVAL<TYPE>::Compall(PGLOBAL g, PVAL *vp, int np, OPVAL op)
       Tval = MY_MAX(val[0], val[1]);
       break;
     default:
-//    sprintf(g->Message, MSG(BAD_EXP_OPER), op);
+//    snprintf(g->Message, sizeof(g->Message), MSG(BAD_EXP_OPER), op);
       strcpy(g->Message, "Function not supported");
       return true;
   } // endswitch op
@@ -1435,7 +1435,7 @@ void TYPVAL<PSZ>::SetValue(int n)
   int      k = sprintf(buf, "%d", n);
 
   if (k > Len) {
-    sprintf(g->Message, MSG(VALSTR_TOO_LONG), buf, Len);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALSTR_TOO_LONG), buf, Len);
 		throw 138;
 	} else
     SetValue_psz(buf);
@@ -1453,7 +1453,7 @@ void TYPVAL<PSZ>::SetValue(uint n)
   int      k = sprintf(buf, "%u", n);
 
   if (k > Len) {
-    sprintf(g->Message, MSG(VALSTR_TOO_LONG), buf, Len);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALSTR_TOO_LONG), buf, Len);
     throw 138;
   } else
     SetValue_psz(buf);
@@ -1489,7 +1489,7 @@ void TYPVAL<PSZ>::SetValue(longlong n)
   int      k = sprintf(buf, "%lld", n);
 
   if (k > Len) {
-    sprintf(g->Message, MSG(VALSTR_TOO_LONG), buf, Len);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALSTR_TOO_LONG), buf, Len);
 		throw 138;
 	} else
     SetValue_psz(buf);
@@ -1507,7 +1507,7 @@ void TYPVAL<PSZ>::SetValue(ulonglong n)
   int      k = sprintf(buf, "%llu", n);
 
   if (k > Len) {
-    sprintf(g->Message, MSG(VALSTR_TOO_LONG), buf, Len);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALSTR_TOO_LONG), buf, Len);
     throw 138;
   } else
     SetValue_psz(buf);
@@ -1532,7 +1532,7 @@ void TYPVAL<PSZ>::SetValue(double f)
       break;
 
   if (k > Len) {
-    sprintf(g->Message, MSG(VALSTR_TOO_LONG), buf, Len);
+    snprintf(g->Message, sizeof(g->Message), MSG(VALSTR_TOO_LONG), buf, Len);
 		throw 138;
 	} else
     SetValue_psz(buf);
@@ -1700,7 +1700,7 @@ bool TYPVAL<PSZ>::Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op)
 			SetValue_psz((strcmp(p[0], p[1]) > 0) ? p[0] : p[1]);
 			break;
 		default:
-			//    sprintf(g->Message, MSG(BAD_EXP_OPER), op);
+			//    snprintf(g->Message, sizeof(g->Message), MSG(BAD_EXP_OPER), op);
 			strcpy(g->Message, "Function not supported");
 			return true;
 	} // endswitch op
@@ -2398,7 +2398,7 @@ bool DTVAL::SetFormat(PGLOBAL g, PVAL valp)
   DTVAL *vp;
 
   if (valp->GetType() != TYPE_DATE) {
-    sprintf(g->Message, MSG(NO_FORMAT_TYPE), valp->GetType());
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_FORMAT_TYPE), valp->GetType());
     return true;
   } else
     vp = (DTVAL*)valp;

--- a/storage/connect/xindex.cpp
+++ b/storage/connect/xindex.cpp
@@ -92,7 +92,7 @@ int PlgMakeIndex(PGLOBAL g, PSZ name, PIXDEF pxdf, bool add)
   if (!(tdbp = cat->GetTable(g, tablep)))
     rc = RC_NF;
   else if (!tdbp->GetDef()->Indexable()) {
-    sprintf(g->Message, MSG(TABLE_NO_INDEX), name);
+    snprintf(g->Message, sizeof(g->Message), MSG(TABLE_NO_INDEX), name);
     rc = RC_NF;
   } else if ((rc = ((PTDBASE)tdbp)->MakeIndex(g, pxdf, add)) == RC_INFO)
     rc = RC_OK;            // No or remote index
@@ -351,7 +351,7 @@ bool XINDEX::Make(PGLOBAL g, PIXDEF sxp)
   Record.Size = n * sizeof(int);
 
   if (!PlgDBalloc(g, NULL, Record)) {
-    sprintf(g->Message, MSG(MEM_ALLOC_ERR), "index", n);
+    snprintf(g->Message, sizeof(g->Message), MSG(MEM_ALLOC_ERR), "index", n);
     goto err;    // Error
     } // endif
 
@@ -362,7 +362,7 @@ bool XINDEX::Make(PGLOBAL g, PIXDEF sxp)
     colp = To_Cols[k];
 
     if (!kdfp) {
-      sprintf(g->Message, MSG(INT_COL_ERROR),
+      snprintf(g->Message, sizeof(g->Message), MSG(INT_COL_ERROR),
                           (colp) ? colp->GetName() : "???");
       goto err;    // Error
       } // endif kdfp
@@ -470,7 +470,7 @@ bool XINDEX::Make(PGLOBAL g, PIXDEF sxp)
       case RC_EF:
         goto end_of_file;
       default:
-        sprintf(g->Message, MSG(RC_READING), rc, Tdbp->Name);
+        snprintf(g->Message, sizeof(g->Message), MSG(RC_READING), rc, Tdbp->Name);
         goto err;
       } // endswitch rc
 
@@ -479,7 +479,7 @@ bool XINDEX::Make(PGLOBAL g, PIXDEF sxp)
     /*  future direct access.                                          */
     /*******************************************************************/
     if (nkey == n) {
-      sprintf(g->Message, MSG(TOO_MANY_KEYS), nkey);
+      snprintf(g->Message, sizeof(g->Message), MSG(TOO_MANY_KEYS), nkey);
       return true;
     } else
       To_Rec[nkey] = Tdbp->GetRecpos();
@@ -534,14 +534,14 @@ bool XINDEX::Make(PGLOBAL g, PIXDEF sxp)
   Index.Size = Num_K * sizeof(int);
 
   if (!PlgDBalloc(g, NULL, Index)) {
-    sprintf(g->Message, MSG(MEM_ALLOC_ERR), "index", Num_K);
+    snprintf(g->Message, sizeof(g->Message), MSG(MEM_ALLOC_ERR), "index", Num_K);
     goto err;    // Error
     } // endif alloc
 
   Offset.Size = (Num_K + 1) * sizeof(int);
 
   if (!PlgDBalloc(g, NULL, Offset)) {
-    sprintf(g->Message, MSG(MEM_ALLOC_ERR), "offset", Num_K + 1);
+    snprintf(g->Message, sizeof(g->Message), MSG(MEM_ALLOC_ERR), "offset", Num_K + 1);
     goto err;    // Error
     } // endif alloc
 
@@ -842,7 +842,7 @@ bool XINDEX::SaveIndex(PGLOBAL g, PIXDEF sxp)
 		case RECFM_CSV: ftype = ".cnx"; break;
 		case RECFM_DBF: ftype = ".dbx"; break;
     default:
-      sprintf(g->Message, MSG(INVALID_FTYPE), Tdbp->Ftype);
+      snprintf(g->Message, sizeof(g->Message), MSG(INVALID_FTYPE), Tdbp->Ftype);
       return true;
     } // endswitch Ftype
 
@@ -996,7 +996,7 @@ bool XINDEX::Init(PGLOBAL g)
 		case RECFM_CSV: ftype = ".cnx"; break;
 		case RECFM_DBF: ftype = ".dbx"; break;
     default:
-      sprintf(g->Message, MSG(INVALID_FTYPE), Tdbp->Ftype);
+      snprintf(g->Message, sizeof(g->Message), MSG(INVALID_FTYPE), Tdbp->Ftype);
       return true;
     } // endswitch Ftype
 
@@ -1050,7 +1050,7 @@ bool XINDEX::Init(PGLOBAL g)
   // The test on ID was suppressed because MariaDB can change an index ID
   // when other indexes are added or deleted
   if (/*nv[0] != ID ||*/ nv[1] != Nk) {
-    sprintf(g->Message, MSG(BAD_INDEX_FILE), fn);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_INDEX_FILE), fn);
 
     if (trace(1))
       htrc("nv[0]=%d ID=%d nv[1]=%d Nk=%d\n", nv[0], ID, nv[1], Nk);
@@ -1066,7 +1066,7 @@ bool XINDEX::Init(PGLOBAL g)
     Offset.Size = Ndif * sizeof(int);
 
     if (!PlgDBalloc(g, NULL, Offset)) {
-      sprintf(g->Message, MSG(MEM_ALLOC_ERR), "offset", Ndif);
+      snprintf(g->Message, sizeof(g->Message), MSG(MEM_ALLOC_ERR), "offset", Ndif);
       goto err;
       } // endif
 
@@ -1083,7 +1083,7 @@ bool XINDEX::Init(PGLOBAL g)
     n = nv[3];              // n was just an evaluated max value
 
   if (nv[3] != n) {
-    sprintf(g->Message, MSG(OPT_NOT_MATCH), fn);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPT_NOT_MATCH), fn);
     goto err;
     } // endif
 
@@ -1099,7 +1099,7 @@ bool XINDEX::Init(PGLOBAL g)
     Record.Size = Num_K * sizeof(int);
 
     if (!PlgDBalloc(g, NULL, Record)) {
-      sprintf(g->Message, MSG(MEM_ALLOC_ERR), "index", Num_K);
+      snprintf(g->Message, sizeof(g->Message), MSG(MEM_ALLOC_ERR), "index", Num_K);
       goto err;
       } // endif
 
@@ -1123,7 +1123,7 @@ bool XINDEX::Init(PGLOBAL g)
 
     if (nv[4] != colp->GetResultType() || !colp->GetValue() ||
        (nv[3] != colp->GetValue()->GetClen() && nv[4] != TYPE_STRING)) {
-      sprintf(g->Message, MSG(XCOL_MISMATCH), colp->GetName());
+      snprintf(g->Message, sizeof(g->Message), MSG(XCOL_MISMATCH), colp->GetName());
       goto err;    // Error
       } // endif GetKey
 
@@ -1249,7 +1249,7 @@ bool XINDEX::MapInit(PGLOBAL g)
 		case RECFM_CSV: ftype = ".cnx"; break;
 		case RECFM_DBF: ftype = ".dbx"; break;
     default:
-      sprintf(g->Message, MSG(INVALID_FTYPE), Tdbp->Ftype);
+      snprintf(g->Message, sizeof(g->Message), MSG(INVALID_FTYPE), Tdbp->Ftype);
       return true;
     } // endswitch Ftype
 
@@ -1312,7 +1312,7 @@ bool XINDEX::MapInit(PGLOBAL g)
   // when other indexes are added or deleted
   if (/*nv0 != ID ||*/ nv[1] != Nk) {
     // Not this index
-    sprintf(g->Message, MSG(BAD_INDEX_FILE), fn);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_INDEX_FILE), fn);
 
     if (trace(1))
       htrc("nv0=%d ID=%d nv[1]=%d Nk=%d\n", nv0, ID, nv[1], Nk);
@@ -1337,7 +1337,7 @@ bool XINDEX::MapInit(PGLOBAL g)
     n = nv[3];              // n was just an evaluated max value
 
   if (nv[3] != n) {
-    sprintf(g->Message, MSG(OPT_NOT_MATCH), fn);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPT_NOT_MATCH), fn);
     goto err;
     } // endif
 
@@ -1371,7 +1371,7 @@ bool XINDEX::MapInit(PGLOBAL g)
 
     if (nv[4] != colp->GetResultType() || !colp->GetValue() ||
        (nv[3] != colp->GetValue()->GetClen() && nv[4] != TYPE_STRING)) {
-      sprintf(g->Message, MSG(XCOL_MISMATCH), colp->GetName());
+      snprintf(g->Message, sizeof(g->Message), MSG(XCOL_MISMATCH), colp->GetName());
       goto err;    // Error
       } // endif GetKey
 
@@ -1464,7 +1464,7 @@ bool XINDEX::GetAllSizes(PGLOBAL g,/* int &ndif,*/ int &numk)
 		case RECFM_CSV: ftype = ".cnx"; break;
 		case RECFM_DBF: ftype = ".dbx"; break;
     default:
-      sprintf(g->Message, MSG(INVALID_FTYPE), Tdbp->Ftype);
+      snprintf(g->Message, sizeof(g->Message), MSG(INVALID_FTYPE), Tdbp->Ftype);
       return true;
     } // endswitch Ftype
 
@@ -1511,7 +1511,7 @@ bool XINDEX::GetAllSizes(PGLOBAL g,/* int &ndif,*/ int &numk)
   // The test on ID was suppressed because MariaDB can change an index ID
   // when other indexes are added or deleted
   if (/*nv[0] != ID ||*/ nv[1] != Nk) {
-    sprintf(g->Message, MSG(BAD_INDEX_FILE), fn);
+    snprintf(g->Message, sizeof(g->Message), MSG(BAD_INDEX_FILE), fn);
 
     if (trace(1))
       htrc("nv[0]=%d ID=%d nv[1]=%d Nk=%d\n", nv[0], ID, nv[1], Nk);
@@ -1532,7 +1532,7 @@ bool XINDEX::GetAllSizes(PGLOBAL g,/* int &ndif,*/ int &numk)
     n = nv[3];              // n was just an evaluated max value
 
   if (nv[3] != n) {
-    sprintf(g->Message, MSG(OPT_NOT_MATCH), fn);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPT_NOT_MATCH), fn);
     goto err;
     } // endif
 #endif // 0
@@ -1554,7 +1554,7 @@ bool XINDEX::GetAllSizes(PGLOBAL g,/* int &ndif,*/ int &numk)
 
     if (nv[4] != colp->GetResultType()  ||
        (nv[3] != colp->GetValue()->GetClen() && nv[4] != TYPE_STRING)) {
-      sprintf(g->Message, MSG(XCOL_MISMATCH), colp->GetName());
+      snprintf(g->Message, sizeof(g->Message), MSG(XCOL_MISMATCH), colp->GetName());
       goto err;    // Error
       } // endif GetKey
 
@@ -2338,7 +2338,7 @@ bool XFILE::Open(PGLOBAL g, char *filename, int id, MODE mode)
     case MODE_WRITE:  pmod = "wb"; break;
     case MODE_INSERT: pmod = "ab"; break;
     default:
-      sprintf(g->Message, MSG(BAD_FUNC_MODE), "Xopen", mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_FUNC_MODE), "Xopen", mode);
       return true;
     } // endswitch mode
 
@@ -2354,7 +2354,7 @@ bool XFILE::Open(PGLOBAL g, char *filename, int id, MODE mode)
     /* Position the cursor at end of file so ftell returns file size.  */
     /*******************************************************************/
     if (fseek(Xfile, 0, SEEK_END)) {
-      sprintf(g->Message, MSG(FUNC_ERRNO), errno, "Xseek");
+      snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERRNO), errno, "Xseek");
       return true;
       } // endif
 
@@ -2379,7 +2379,7 @@ bool XFILE::Open(PGLOBAL g, char *filename, int id, MODE mode)
   } else if (mode == MODE_READ && id >= 0) {
     // Get offset from the header
     if (fread(noff, sizeof(IOFF), MAX_INDX, Xfile) != MAX_INDX) {
-      sprintf(g->Message, MSG(XFILE_READERR), errno);
+      snprintf(g->Message, sizeof(g->Message), MSG(XFILE_READERR), errno);
       return true;
       } // endif MAX_INDX
 
@@ -2388,7 +2388,7 @@ bool XFILE::Open(PGLOBAL g, char *filename, int id, MODE mode)
 
     // Position the cursor at the offset of this index
     if (fseek(Xfile, noff[id].v.Low, SEEK_SET)) {
-      sprintf(g->Message, MSG(FUNC_ERRNO), errno, "Xseek");
+      snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERRNO), errno, "Xseek");
       return true;
       } // endif
 
@@ -2408,7 +2408,7 @@ bool XFILE::Seek(PGLOBAL g, int low, int high __attribute__((unused)),
 #endif  // !_DEBUG
 
   if (fseek(Xfile, low, origin)) {
-    sprintf(g->Message, MSG(FUNC_ERRNO), errno, "Xseek");
+    snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERRNO), errno, "Xseek");
     return true;
     } // endif
 
@@ -2421,7 +2421,7 @@ bool XFILE::Seek(PGLOBAL g, int low, int high __attribute__((unused)),
 bool XFILE::Read(PGLOBAL g, void *buf, int n, int size)
   {
   if (fread(buf, size, n, Xfile) != (size_t)n) {
-    sprintf(g->Message, MSG(XFILE_READERR), errno);
+    snprintf(g->Message, sizeof(g->Message), MSG(XFILE_READERR), errno);
     return true;
     } // endif size
 
@@ -2436,7 +2436,7 @@ int XFILE::Write(PGLOBAL g, void *buf, int n, int size, bool& rc)
   int niw = (int)fwrite(buf, size, n, Xfile);
 
   if (niw != n) {
-    sprintf(g->Message, MSG(XFILE_WRITERR), strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(XFILE_WRITERR), strerror(errno));
     rc = true;
     } // endif size
 
@@ -2512,7 +2512,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
   IOFF noff[MAX_INDX];
 
   if (Hfile != INVALID_HANDLE_VALUE) {
-    sprintf(g->Message, MSG(FILE_OPEN_YET), filename);
+    snprintf(g->Message, sizeof(g->Message), MSG(FILE_OPEN_YET), filename);
     return true;
     } // endif
 
@@ -2543,7 +2543,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
       creation = OPEN_EXISTING;
       break;
     default:
-      sprintf(g->Message, MSG(BAD_FUNC_MODE), "Xopen", mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_FUNC_MODE), "Xopen", mode);
       return true;
     } // endswitch
 
@@ -2552,7 +2552,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
 
   if (Hfile == INVALID_HANDLE_VALUE) {
     rc = GetLastError();
-    sprintf(g->Message, MSG(OPEN_ERROR), rc, mode, filename);
+    snprintf(g->Message, sizeof(g->Message), MSG(OPEN_ERROR), rc, mode, filename);
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                   FORMAT_MESSAGE_IGNORE_INSERTS, NULL, rc, 0,
                   (LPTSTR)filename, sizeof(filename), NULL);
@@ -2571,7 +2571,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
     rc = SetFilePointer(Hfile, 0, &high, FILE_END);
 
     if (rc == INVALID_SET_FILE_POINTER && (drc = GetLastError()) != NO_ERROR) {
-      sprintf(g->Message, MSG(ERROR_IN_SFP), drc);
+      snprintf(g->Message, sizeof(g->Message), MSG(ERROR_IN_SFP), drc);
       CloseHandle(Hfile);
       Hfile = INVALID_HANDLE_VALUE;
       return true;
@@ -2592,7 +2592,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
     rc = ReadFile(Hfile, noff, sizeof(noff), &drc, NULL);
 
     if (!rc) {
-      sprintf(g->Message, MSG(XFILE_READERR), GetLastError());
+      snprintf(g->Message, sizeof(g->Message), MSG(XFILE_READERR), GetLastError());
       return true;
       } // endif rc
 
@@ -2601,7 +2601,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
                        (PLONG)&noff[id].v.High, FILE_BEGIN);
 
     if (rc == INVALID_SET_FILE_POINTER) {
-      sprintf(g->Message, MSG(FUNC_ERRNO), GetLastError(), "SetFilePointer");
+      snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERRNO), GetLastError(), "SetFilePointer");
       return true;
       } // endif
 
@@ -2626,7 +2626,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
       oflag |= (O_WRONLY | O_APPEND);
       break;
     default:
-      sprintf(g->Message, MSG(BAD_FUNC_MODE), "Xopen", mode);
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_FUNC_MODE), "Xopen", mode);
       return true;
     } // endswitch
 
@@ -2649,7 +2649,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
     /* Position the cursor at end of file so ftell returns file size.  */
     /*******************************************************************/
     if (!(NewOff.Val = (longlong)lseek64(Hfile, 0LL, SEEK_END))) {
-      sprintf(g->Message, MSG(FUNC_ERRNO), errno, "Seek");
+      snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERRNO), errno, "Seek");
       return true;
       } // endif
 
@@ -2669,7 +2669,7 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
   } else if (mode == MODE_READ && id >= 0) {
     // Get offset from the header
     if (read(Hfile, noff, sizeof(noff)) != sizeof(noff)) {
-      sprintf(g->Message, MSG(READ_ERROR), "Index file", strerror(errno));
+      snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), "Index file", strerror(errno));
       return true;
       } // endif read
       
@@ -2678,9 +2678,9 @@ bool XHUGE::Open(PGLOBAL g, char *filename, int id, MODE mode)
 
     // Position the cursor at the offset of this index
     if (lseek64(Hfile, noff[id].Val, SEEK_SET) < 0) {
-      sprintf(g->Message, "(XHUGE)lseek64: %s (%lld)", strerror(errno), noff[id].Val);
+      snprintf(g->Message, sizeof(g->Message), "(XHUGE)lseek64: %s (%lld)", strerror(errno), noff[id].Val);
       printf("%s\n", g->Message);
-//    sprintf(g->Message, MSG(FUNC_ERRNO), errno, "Hseek");
+//    snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERRNO), errno, "Hseek");
       return true;
       } // endif lseek64
 
@@ -2700,7 +2700,7 @@ bool XHUGE::Seek(PGLOBAL g, int low, int high, int origin)
   DWORD rc = SetFilePointer(Hfile, low, &hi, origin);
 
   if (rc == INVALID_SET_FILE_POINTER && GetLastError() != NO_ERROR) {
-    sprintf(g->Message, MSG(FUNC_ERROR), "Xseek");
+    snprintf(g->Message, sizeof(g->Message), MSG(FUNC_ERROR), "Xseek");
     return true;
     } // endif
 
@@ -2709,7 +2709,7 @@ bool XHUGE::Seek(PGLOBAL g, int low, int high, int origin)
               + (off64_t)high * ((off64_t)0x100 * (off64_t)0x1000000);
 
   if (lseek64(Hfile, pos, origin) < 0) {
-    sprintf(g->Message, MSG(ERROR_IN_LSK), errno);
+    snprintf(g->Message, sizeof(g->Message), MSG(ERROR_IN_LSK), errno);
 
     if (trace(1))
       htrc("lseek64 error %d\n", errno);
@@ -2750,7 +2750,7 @@ bool XHUGE::Read(PGLOBAL g, void *buf, int n, int size)
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                   FORMAT_MESSAGE_IGNORE_INSERTS, NULL, drc, 0,
                   (LPTSTR)buf, sizeof(buf), NULL);
-    sprintf(g->Message, MSG(READ_ERROR), "index file", buf);
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), "index file", buf);
     rc = true;
   } // endif brc
 #else    // UNIX
@@ -2760,7 +2760,7 @@ bool XHUGE::Read(PGLOBAL g, void *buf, int n, int size)
     htrc("Hfile=%d n=%d size=%d count=%d\n", Hfile, n, size, count);
 
   if (read(Hfile, buf, count) != count) {
-    sprintf(g->Message, MSG(READ_ERROR), "Index file", strerror(errno));
+    snprintf(g->Message, sizeof(g->Message), MSG(READ_ERROR), "Index file", strerror(errno));
 
     if (trace(1))
       htrc("read error %d\n", errno);
@@ -2790,7 +2790,7 @@ int XHUGE::Write(PGLOBAL g, void *buf, int n, int size, bool& rc)
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                   FORMAT_MESSAGE_IGNORE_INSERTS, NULL, drc, 0,
                   (LPTSTR)msg, sizeof(msg), NULL);
-    sprintf(g->Message, MSG(WRITING_ERROR), "index file", msg);
+    snprintf(g->Message, sizeof(g->Message), MSG(WRITING_ERROR), "index file", msg);
     rc = true;
     } // endif size
 
@@ -2802,7 +2802,7 @@ int XHUGE::Write(PGLOBAL g, void *buf, int n, int size, bool& rc)
   nbw = write(Hfile, buf, count);
 
   if (nbw != (signed)count) {
-    sprintf(g->Message, MSG(WRITING_ERROR),
+    snprintf(g->Message, sizeof(g->Message), MSG(WRITING_ERROR),
                         "index file", strerror(errno));
     rc = true;
     } // endif nbw
@@ -3019,7 +3019,7 @@ bool KXYCOL::Init(PGLOBAL g, PCOL colp, int n, bool sm, int kln)
 
   // Currently no indexing on NULL columns
   if (colp->IsNullable() && kln) {
-    sprintf(g->Message, "Cannot index nullable column %s", colp->GetName());
+    snprintf(g->Message, sizeof(g->Message), "Cannot index nullable column %s", colp->GetName());
     return true;
     } // endif nullable
 
@@ -3042,7 +3042,7 @@ bool KXYCOL::Init(PGLOBAL g, PCOL colp, int n, bool sm, int kln)
   Keys.Size = (size_t)n * (size_t)Klen;
 
   if (!PlgDBalloc(g, NULL, Keys)) {
-    sprintf(g->Message, MSG(KEY_ALLOC_ERROR), Klen, n);
+    snprintf(g->Message, sizeof(g->Message), MSG(KEY_ALLOC_ERROR), Klen, n);
     return true;    // Error
     } // endif
 
@@ -3160,7 +3160,7 @@ bool KXYCOL::MakeBlockArray(PGLOBAL g, int nb, int size)
 
   // Allocate the required memory
   if (!PlgDBalloc(g, NULL, Bkeys)) {
-    sprintf(g->Message, MSG(KEY_ALLOC_ERROR), Klen, nb);
+    snprintf(g->Message, sizeof(g->Message), MSG(KEY_ALLOC_ERROR), Klen, nb);
     return true;    // Error
     } // endif
 

--- a/storage/connect/xobject.cpp
+++ b/storage/connect/xobject.cpp
@@ -162,7 +162,7 @@ bool CONSTANT::Rephrase(PGLOBAL g, PSZ work)
       sprintf(work + strlen(work), "%d", Value->GetTinyValue());
       break;
     default:
-      sprintf(g->Message, MSG(BAD_CONST_TYPE), Value->GetType());
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_CONST_TYPE), Value->GetType());
       return false;
     } // endswitch
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
This commit replaces sprintf(buf, ...) with snprintf(buf, sizeof(buf), ...), specifically in the "easy" cases where buf is allocated with a size known at compile time. 

The changes make sure we are not write outside array/string bounds which will lead to undefined behaviour. In case the code is trying to write outside bounds - safe version of functions simply cut the string messages so we process this gracefully.


## How can this PR be tested?

All build stages pass for these commits. For the commit without the intentional bug, mysql-test-run is properly passing.
The changes are not change the functionality itself they just replace unsafe C methods with the safe ones.
The changes was validated by FlawFinder.
FlawFinder run without these changes shown:


Hits = 15930

FlawFinder run with these changes shown:

Hits = 15579

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
The changes fully backward compatible.


## Copyright
All new code of the whole pull request, including one or several files that
are either new files or modified ones, are contributed under the BSD-new
license.  I am contributing on behalf of my employer Amazon Web Services,
Inc.