### PR TITLE
JSON_MERGE_PATCH: remove redundant assignments

### DIFF
--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -2645,7 +2645,6 @@ String *Item_func_json_merge_patch::val_str(String *str)
         goto error_return;
       if (je2.value_type == JSON_VALUE_OBJECT)
       {
-        merge_to_null= true;
         goto cont_point;
       }
       merge_to_null= false;


### PR DESCRIPTION
## Description
Hi, guys! I'm a 2022 GSoC Contributor and working on [MCOL-785](https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/2425): **Implementation of JSON functions under Columnstore Select Handler**. I found a redundant assignments in JSON_MERGE_PATCH in MariaDB 10.9. Just a small patch.

## How can this PR be tested?
**This change will not change existing test results.** I applied this change to both MariaDB and [Columnstore](https://github.com/qggcs/mariadb-columnstore-engine/blob/1b58a7a22c55dedb127fd1a522e0c3c846c68848/utils/funcexp/func_json_merge_patch.cpp#L275-L285) and tested them all, the result of JSON_MERGE_PATCH in MariaDB and Columnstore is consistent and the result is correct. Columnstore tests can be found [here](https://github.com/mariadb-corporation/mariadb-columnstore-engine/pull/2425/files#diff-b16c197d83ed890be28835eeb0251c4182031d8dbaf85e4e7a6145c938f465cf).

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
