### PR TITLE
MDEV-29091: Correct event_name in PFS for wait caused by FOR UPDATE

### DIFF
--- a/mysql-test/suite/perfschema/r/events_waits_current_MDEV-29091.result
+++ b/mysql-test/suite/perfschema/r/events_waits_current_MDEV-29091.result
@@ -1,0 +1,41 @@
+SET default_storage_engine=InnoDB;
+SELECT @save_instrument_enabled := ENABLED
+, @save_instrument_timed := TIMED
+FROM performance_schema.setup_instruments
+WHERE NAME = 'wait/lock/table/sql/handler';
+@save_instrument_enabled := ENABLED	@save_instrument_timed := TIMED
+YES	YES
+SELECT @save_consumer_enabled := ENABLED
+FROM performance_schema.setup_consumers
+WHERE NAME = 'events_waits_current';
+@save_consumer_enabled := ENABLED
+YES
+UPDATE performance_schema.setup_instruments 
+SET ENABLED = 'YES', TIMED = 'YES'
+WHERE NAME = 'wait/lock/table/sql/handler';
+UPDATE performance_schema.setup_consumers 
+SET ENABLED = 'YES' 
+WHERE NAME = 'events_waits_current';
+CREATE TABLE t1 (id1 INT(11), col1 VARCHAR (200));
+INSERT INTO t1 VALUES (1, 'aa');
+INSERT INTO t1 VALUES (2, 'bb');
+connect  con1,localhost,root,,test;
+connect  con2,localhost,root,,test;
+connection con1;
+START TRANSACTION;
+connection con2;
+START TRANSACTION;
+SELECT id1 FROM t1 WHERE id1=1 FOR UPDATE;
+connection default;
+SELECT event_name FROM performance_schema.events_waits_current
+WHERE event_name LIKE '%wait/lock/table/sql/handler%';
+event_name
+UPDATE performance_schema.setup_instruments 
+SET ENABLED = @save_instrument_enabled, TIMED = @save_instrument_timed
+WHERE NAME = 'wait/lock/table/sql/handler';
+UPDATE performance_schema.setup_consumers 
+SET ENABLED = @save_consumer_enabled
+WHERE NAME = 'events_waits_current';
+disconnect con1;
+disconnect con2;
+DROP TABLE t1;

--- a/mysql-test/suite/perfschema/r/table_aggregate_hist_2u_2t.result
+++ b/mysql-test/suite/perfschema/r/table_aggregate_hist_2u_2t.result
@@ -215,10 +215,8 @@ wait/io/table/sql/handler	25
 wait/lock/table/sql/handler	24
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -287,10 +285,8 @@ wait/io/table/sql/handler	25
 wait/lock/table/sql/handler	24
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -394,10 +390,8 @@ wait/io/table/sql/handler	25
 wait/lock/table/sql/handler	24
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -471,10 +465,8 @@ wait/io/table/sql/handler	25
 wait/lock/table/sql/handler	24
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -590,10 +582,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	48
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	43	TABLE	test	t1
+wait/lock/table/sql/handler	82	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -672,10 +662,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	48
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	43	TABLE	test	t1
+wait/lock/table/sql/handler	82	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -803,10 +791,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	48
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	43	TABLE	test	t1
+wait/lock/table/sql/handler	82	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -886,10 +872,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -966,10 +950,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1046,10 +1028,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1123,10 +1103,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1199,10 +1177,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1274,10 +1250,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1348,10 +1322,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1424,10 +1396,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1499,10 +1469,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1574,10 +1542,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1649,10 +1615,8 @@ wait/io/table/sql/handler	77
 wait/lock/table/sql/handler	56
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1724,10 +1688,8 @@ wait/io/table/sql/handler	0
 wait/lock/table/sql/handler	0
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	0	0	0	0	0	0	0

--- a/mysql-test/suite/perfschema/r/table_aggregate_hist_2u_3t.result
+++ b/mysql-test/suite/perfschema/r/table_aggregate_hist_2u_3t.result
@@ -214,12 +214,9 @@ wait/io/table/sql/handler	37
 wait/lock/table/sql/handler	36
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	12	TABLE	test	t2
-wait/lock/table/sql/handler	12	TABLE	test	t2
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	24	TABLE	test	t2
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -288,12 +285,9 @@ wait/io/table/sql/handler	37
 wait/lock/table/sql/handler	36
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	12	TABLE	test	t2
-wait/lock/table/sql/handler	12	TABLE	test	t2
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	24	TABLE	test	t2
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -397,12 +391,9 @@ wait/io/table/sql/handler	37
 wait/lock/table/sql/handler	36
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	12	TABLE	test	t2
-wait/lock/table/sql/handler	12	TABLE	test	t2
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	24	TABLE	test	t2
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -476,12 +467,9 @@ wait/io/table/sql/handler	37
 wait/lock/table/sql/handler	36
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	12	TABLE	test	t2
-wait/lock/table/sql/handler	12	TABLE	test	t2
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	24	TABLE	test	t2
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -597,12 +585,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	72
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	24	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	43	TABLE	test	t1
+wait/lock/table/sql/handler	60	TABLE	test	t2
+wait/lock/table/sql/handler	82	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -681,12 +666,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	72
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	24	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	43	TABLE	test	t1
+wait/lock/table/sql/handler	60	TABLE	test	t2
+wait/lock/table/sql/handler	82	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -814,12 +796,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	72
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	24	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	43	TABLE	test	t1
+wait/lock/table/sql/handler	60	TABLE	test	t2
+wait/lock/table/sql/handler	82	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -899,12 +878,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -981,12 +957,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1063,12 +1036,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1142,12 +1112,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1220,12 +1187,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1297,12 +1261,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1373,12 +1334,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1451,12 +1409,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1528,12 +1483,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1605,12 +1557,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1682,12 +1631,9 @@ wait/io/table/sql/handler	113
 wait/lock/table/sql/handler	84
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	18	12	6	12	2	4	0
@@ -1759,12 +1705,9 @@ wait/io/table/sql/handler	0
 wait/lock/table/sql/handler	0
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	23	TABLE	test	t1
-wait/lock/table/sql/handler	24	TABLE	test	t1
-wait/io/table/sql/handler	36	TABLE	test	t2
-wait/lock/table/sql/handler	28	TABLE	test	t2
-wait/io/table/sql/handler	54	TABLE	test	t3
-wait/lock/table/sql/handler	32	TABLE	test	t3
+wait/lock/table/sql/handler	47	TABLE	test	t1
+wait/lock/table/sql/handler	64	TABLE	test	t2
+wait/lock/table/sql/handler	86	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	0	0	0	0	0	0	0

--- a/mysql-test/suite/perfschema/r/table_aggregate_hist_4u_2t.result
+++ b/mysql-test/suite/perfschema/r/table_aggregate_hist_4u_2t.result
@@ -215,10 +215,8 @@ wait/io/table/sql/handler	25
 wait/lock/table/sql/handler	24
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -287,10 +285,8 @@ wait/io/table/sql/handler	25
 wait/lock/table/sql/handler	24
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -394,10 +390,8 @@ wait/io/table/sql/handler	64
 wait/lock/table/sql/handler	48
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	20	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	44	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	40	TABLE	test	t1
+wait/lock/table/sql/handler	72	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	15	10	5	10	2	3	0
@@ -471,10 +465,8 @@ wait/io/table/sql/handler	64
 wait/lock/table/sql/handler	48
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	20	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	44	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	40	TABLE	test	t1
+wait/lock/table/sql/handler	72	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	15	10	5	10	2	3	0
@@ -590,10 +582,8 @@ wait/io/table/sql/handler	116
 wait/lock/table/sql/handler	72
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	35	TABLE	test	t1
-wait/lock/table/sql/handler	30	TABLE	test	t1
-wait/io/table/sql/handler	81	TABLE	test	t3
-wait/lock/table/sql/handler	42	TABLE	test	t3
+wait/lock/table/sql/handler	65	TABLE	test	t1
+wait/lock/table/sql/handler	123	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	27	18	9	18	3	6	0
@@ -672,10 +662,8 @@ wait/io/table/sql/handler	116
 wait/lock/table/sql/handler	72
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	35	TABLE	test	t1
-wait/lock/table/sql/handler	30	TABLE	test	t1
-wait/io/table/sql/handler	81	TABLE	test	t3
-wait/lock/table/sql/handler	42	TABLE	test	t3
+wait/lock/table/sql/handler	65	TABLE	test	t1
+wait/lock/table/sql/handler	123	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	27	18	9	18	3	6	0
@@ -803,10 +791,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	96
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	40	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	56	TABLE	test	t3
+wait/lock/table/sql/handler	93	TABLE	test	t1
+wait/lock/table/sql/handler	184	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -886,10 +872,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -966,10 +950,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1046,10 +1028,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1123,10 +1103,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1199,10 +1177,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1274,10 +1250,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1348,10 +1322,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1424,10 +1396,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1499,10 +1469,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1574,10 +1542,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1649,10 +1615,8 @@ wait/io/table/sql/handler	181
 wait/lock/table/sql/handler	104
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1724,10 +1688,8 @@ wait/io/table/sql/handler	0
 wait/lock/table/sql/handler	0
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	0	0	0	0	0	0	0

--- a/mysql-test/suite/perfschema/r/table_aggregate_hist_4u_3t.result
+++ b/mysql-test/suite/perfschema/r/table_aggregate_hist_4u_3t.result
@@ -214,12 +214,9 @@ wait/io/table/sql/handler	37
 wait/lock/table/sql/handler	36
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	12	TABLE	test	t2
-wait/lock/table/sql/handler	12	TABLE	test	t2
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	24	TABLE	test	t2
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -288,12 +285,9 @@ wait/io/table/sql/handler	37
 wait/lock/table/sql/handler	36
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	8	TABLE	test	t1
-wait/lock/table/sql/handler	10	TABLE	test	t1
-wait/io/table/sql/handler	12	TABLE	test	t2
-wait/lock/table/sql/handler	12	TABLE	test	t2
-wait/io/table/sql/handler	17	TABLE	test	t3
-wait/lock/table/sql/handler	14	TABLE	test	t3
+wait/lock/table/sql/handler	18	TABLE	test	t1
+wait/lock/table/sql/handler	24	TABLE	test	t2
+wait/lock/table/sql/handler	31	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	6	4	2	4	1	1	0
@@ -397,12 +391,9 @@ wait/io/table/sql/handler	94
 wait/lock/table/sql/handler	72
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	20	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	30	TABLE	test	t2
-wait/lock/table/sql/handler	24	TABLE	test	t2
-wait/io/table/sql/handler	44	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	40	TABLE	test	t1
+wait/lock/table/sql/handler	54	TABLE	test	t2
+wait/lock/table/sql/handler	72	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	15	10	5	10	2	3	0
@@ -476,12 +467,9 @@ wait/io/table/sql/handler	94
 wait/lock/table/sql/handler	72
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	20	TABLE	test	t1
-wait/lock/table/sql/handler	20	TABLE	test	t1
-wait/io/table/sql/handler	30	TABLE	test	t2
-wait/lock/table/sql/handler	24	TABLE	test	t2
-wait/io/table/sql/handler	44	TABLE	test	t3
-wait/lock/table/sql/handler	28	TABLE	test	t3
+wait/lock/table/sql/handler	40	TABLE	test	t1
+wait/lock/table/sql/handler	54	TABLE	test	t2
+wait/lock/table/sql/handler	72	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	15	10	5	10	2	3	0
@@ -597,12 +585,9 @@ wait/io/table/sql/handler	170
 wait/lock/table/sql/handler	108
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	35	TABLE	test	t1
-wait/lock/table/sql/handler	30	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t2
-wait/lock/table/sql/handler	36	TABLE	test	t2
-wait/io/table/sql/handler	81	TABLE	test	t3
-wait/lock/table/sql/handler	42	TABLE	test	t3
+wait/lock/table/sql/handler	65	TABLE	test	t1
+wait/lock/table/sql/handler	90	TABLE	test	t2
+wait/lock/table/sql/handler	123	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	27	18	9	18	3	6	0
@@ -681,12 +666,9 @@ wait/io/table/sql/handler	170
 wait/lock/table/sql/handler	108
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	35	TABLE	test	t1
-wait/lock/table/sql/handler	30	TABLE	test	t1
-wait/io/table/sql/handler	54	TABLE	test	t2
-wait/lock/table/sql/handler	36	TABLE	test	t2
-wait/io/table/sql/handler	81	TABLE	test	t3
-wait/lock/table/sql/handler	42	TABLE	test	t3
+wait/lock/table/sql/handler	65	TABLE	test	t1
+wait/lock/table/sql/handler	90	TABLE	test	t2
+wait/lock/table/sql/handler	123	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	27	18	9	18	3	6	0
@@ -814,12 +796,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	144
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	40	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	48	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	56	TABLE	test	t3
+wait/lock/table/sql/handler	93	TABLE	test	t1
+wait/lock/table/sql/handler	132	TABLE	test	t2
+wait/lock/table/sql/handler	184	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -899,12 +878,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -981,12 +957,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1063,12 +1036,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1142,12 +1112,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1220,12 +1187,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1297,12 +1261,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1373,12 +1334,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1451,12 +1409,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1528,12 +1483,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1605,12 +1557,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1682,12 +1631,9 @@ wait/io/table/sql/handler	265
 wait/lock/table/sql/handler	156
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	42	28	14	28	4	10	0
@@ -1759,12 +1705,9 @@ wait/io/table/sql/handler	0
 wait/lock/table/sql/handler	0
 execute dump_waits_history;
 event_name	count(event_name)	object_type	object_schema	object_name
-wait/io/table/sql/handler	53	TABLE	test	t1
-wait/lock/table/sql/handler	44	TABLE	test	t1
-wait/io/table/sql/handler	84	TABLE	test	t2
-wait/lock/table/sql/handler	52	TABLE	test	t2
-wait/io/table/sql/handler	128	TABLE	test	t3
-wait/lock/table/sql/handler	60	TABLE	test	t3
+wait/lock/table/sql/handler	97	TABLE	test	t1
+wait/lock/table/sql/handler	136	TABLE	test	t2
+wait/lock/table/sql/handler	188	TABLE	test	t3
 execute dump_waits_index_io;
 object_type	object_schema	object_name	index_name	count_star	count_read	count_write	count_fetch	count_insert	count_update	count_delete
 TABLE	test	t1	NULL	0	0	0	0	0	0	0

--- a/mysql-test/suite/perfschema/t/events_waits_current_MDEV-29091.test
+++ b/mysql-test/suite/perfschema/t/events_waits_current_MDEV-29091.test
@@ -1,0 +1,62 @@
+#
+# proper event name wait/lock/table/sql/handler recorded in
+# PERFORMANCE_SCHEMA.EVENTS_WAITS_CURRENT. Before this fix, it was
+# labeled as wait/io/table/sql/handler.
+# 
+
+--source include/have_innodb.inc
+--source include/have_perfschema.inc
+--source include/not_embedded.inc
+
+SET default_storage_engine=InnoDB;
+
+SELECT @save_instrument_enabled := ENABLED
+, @save_instrument_timed := TIMED
+FROM performance_schema.setup_instruments
+WHERE NAME = 'wait/lock/table/sql/handler';
+
+SELECT @save_consumer_enabled := ENABLED
+FROM performance_schema.setup_consumers
+WHERE NAME = 'events_waits_current';
+
+UPDATE performance_schema.setup_instruments 
+SET ENABLED = 'YES', TIMED = 'YES'
+WHERE NAME = 'wait/lock/table/sql/handler';
+
+UPDATE performance_schema.setup_consumers 
+SET ENABLED = 'YES' 
+WHERE NAME = 'events_waits_current';
+
+CREATE TABLE t1 (id1 INT(11), col1 VARCHAR (200));
+INSERT INTO t1 VALUES (1, 'aa');
+INSERT INTO t1 VALUES (2, 'bb');
+ 
+connect (con1,localhost,root,,test);
+connect (con2,localhost,root,,test);
+ 
+connection con1;
+START TRANSACTION;
+let $wait_condition=
+  SELECT id1 FROM t1 WHERE id1=1 FOR UPDATE;
+--source include/wait_condition.inc
+ 
+connection con2;
+START TRANSACTION;
+send SELECT id1 FROM t1 WHERE id1=1 FOR UPDATE;
+ 
+connection default;
+SELECT event_name FROM performance_schema.events_waits_current
+WHERE event_name LIKE '%wait/lock/table/sql/handler%';
+ 
+# clean up
+UPDATE performance_schema.setup_instruments 
+SET ENABLED = @save_instrument_enabled, TIMED = @save_instrument_timed
+WHERE NAME = 'wait/lock/table/sql/handler';
+
+UPDATE performance_schema.setup_consumers 
+SET ENABLED = @save_consumer_enabled
+WHERE NAME = 'events_waits_current';
+
+disconnect con1;
+disconnect con2;
+DROP TABLE t1;

--- a/storage/perfschema/pfs.cc
+++ b/storage/perfschema/pfs.cc
@@ -2610,7 +2610,8 @@ start_table_io_wait_v1(PSI_table_locker_state *state,
 
       PFS_table_share *share= pfs_table->m_share;
       wait->m_thread= pfs_thread;
-      wait->m_class= &global_table_io_class;
+      if (wait->m_class == NULL || wait->m_class->m_type != PFS_CLASS_TABLE_LOCK)
+        wait->m_class= &global_table_io_class;
       wait->m_timer_start= timer_start;
       wait->m_timer_end= 0;
       wait->m_object_instance_addr= pfs_table->m_identity;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-29091*
## Description
When one session SELECT rows FOR UPDATE and holds the lock, subsequent
sessions that SELECT ... FOR UPDATE will wait to get the lock.
Currently, that event is labeled as `wait/io/table/sql/handler`, which
is incorrect. Because it is NOT waiting for IO. Instead, it should have
been `wait/lock/table/sql/handler`.

## How can this PR be tested?
All existing test cases should still be passing in Buildbot as well as
GitLab-CI. In addition, new test case added for this PR should also pass.

## Basing the PR against the correct MariaDB version
- [x] This is a big fix and the PR is based against the long-term support release.

## Backward compatibility
This bug fix should be fully backward-compatible

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.