### PR TITLE
MDEV-29187: Deadlock output in InnoDB status always shows transaction…

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -6126,6 +6126,7 @@ namespace Deadlock
       for (trx_t *next= cycle;;)
       {
         next= next->lock.wait_trx;
+        l++;
         const undo_no_t next_weight= TRX_WEIGHT(next) |
           (next->mysql_thd &&
 #ifdef WITH_WSREP


### PR DESCRIPTION
… (0)



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29187*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

per JIRA report, the rollback transaction was listed as 0.
## How can this PR be tested?

Repeated case in jira:
```
MariaDB [test]>  update t1 set f1 = 4 where id = 2;
Query OK, 1 row affected (0.001 sec)
Rows matched: 1  Changed: 1  Warnings: 0

MariaDB [test]>  update t1 set f1 = 5 where id = 1;
ERROR 1213 (40001): Deadlock found when trying to get lock; try restarting transaction
MariaDB [test]> show engine innodb status\G
*************************** 1. row ***************************
  Type: InnoDB
  Name: 
Status: 
=====================================
2022-07-28 15:52:57 0x7f5e4c266640 INNODB MONITOR OUTPUT
=====================================
Per second averages calculated from the last 3 seconds
-----------------
BACKGROUND THREAD
-----------------
srv_master_thread loops: 0 srv_active, 0 srv_shutdown, 64 srv_idle
srv_master_thread log flush and writes: 64
----------
SEMAPHORES
----------
------------------------
LATEST DETECTED DEADLOCK
------------------------
2022-07-28 15:52:48 0x7f5e4c266640
*** (1) TRANSACTION:
TRANSACTION 51, ACTIVE 13 sec starting index read
mysql tables in use 1, locked 1
LOCK WAIT 3 lock struct(s), heap size 1128, 2 row lock(s), undo log entries 1
MariaDB thread id 4, OS thread handle 140042981238336, query id 15 localhost dan Updating
update t1 set f1 = 5 where id = 1
*** WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 6 page no 3 n bits 8 index PRIMARY of table `test`.`t1` trx id 51 lock_mode X locks rec but not gap waiting
Record lock, heap no 2 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000001; asc     ;;
 1: len 6; hex 000000000031; asc      1;;
 2: len 7; hex 090000013b0110; asc     ;  ;;
 3: len 4; hex 80000003; asc     ;;

*** CONFLICTING WITH:
RECORD LOCKS space id 6 page no 3 n bits 8 index PRIMARY of table `test`.`t1` trx id 49 lock_mode X locks rec but not gap
Record lock, heap no 2 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000001; asc     ;;
 1: len 6; hex 000000000031; asc      1;;
 2: len 7; hex 090000013b0110; asc     ;  ;;
 3: len 4; hex 80000003; asc     ;;


*** (2) TRANSACTION:
TRANSACTION 49, ACTIVE 34 sec starting index read
mysql tables in use 1, locked 1
LOCK WAIT 3 lock struct(s), heap size 1128, 2 row lock(s), undo log entries 1
MariaDB thread id 3, OS thread handle 140042981545536, query id 14 localhost dan Updating
update t1 set f1 = 3 where id = 2
*** WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 6 page no 3 n bits 8 index PRIMARY of table `test`.`t1` trx id 49 lock_mode X locks rec but not gap waiting
Record lock, heap no 3 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000002; asc     ;;
 1: len 6; hex 000000000033; asc      3;;
 2: len 7; hex 0a0000013c0110; asc     <  ;;
 3: len 4; hex 80000004; asc     ;;

*** CONFLICTING WITH:
RECORD LOCKS space id 6 page no 3 n bits 8 index PRIMARY of table `test`.`t1` trx id 51 lock_mode X locks rec but not gap
Record lock, heap no 3 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
 0: len 4; hex 80000002; asc     ;;
 1: len 6; hex 000000000033; asc      3;;
 2: len 7; hex 0a0000013c0110; asc     <  ;;
 3: len 4; hex 80000004; asc     ;;

*** WE ROLL BACK TRANSACTION (1)
```
