### PR TITLE
MDEV-12274: Too many connections warning in error log

### DIFF
--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -1263,7 +1263,8 @@ void prepare_new_connection_state(THD* thd)
         and the main Diagnostics Area contains an error condition.
       */
       if (packet_length != packet_error)
-        my_error(ER_NEW_ABORTING_CONNECTION, MYF(0),
+        my_error(ER_NEW_ABORTING_CONNECTION,
+                 (thd->db.str || sctx->user) ? MYF(0) : MYF(ME_JUST_WARNING),
                  thd->thread_id,
                  thd->db.str ? thd->db.str : "unconnected",
                  sctx->user ? sctx->user : "unauthenticated",


### PR DESCRIPTION
## Description

- [x] *The Jira issue number for this PR is: MDEV-12274*

(and linked messages like MDEV-24850, MDEV-21456, MDEV-4160(sort of))

Because of the default warning level, aborted unauthenticated
connections are in the error log. These errors frequently occur
in production environments because cancelled connectiosn occur
all the time when web pages are shutdown.

Rather than flood our user's errors log with these ordinary
messages, lets push them down to the warning level at log-warnings=4
level.

Concept approved by Monty.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->

## How can this PR be tested?

`nc -U /tmp/build-mariadb-server-10.3.sock < /dev/null` no longer outputs error log, unless started with `log_warnings=4` (or more).

## Backward compatibility

Those using fail2ban or something on these non-authentication attempts to reduce error messages get these warnings removed at no CPU cost.