### PR TITLE
MDEV-26447: mysqldump to use Aria for creating views

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -3160,13 +3160,13 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
           }
 
           /*
-            Stand-in tables are always MyISAM tables as the default
+            Stand-in tables are always Aria tables as the default
             engine might have a column-limit that's lower than the
-            number of columns in the view, and MyISAM support is
+            number of columns in the view, and Aria support is
             guaranteed to be in the server anyway.
           */
           fprintf(sql_file,
-                  "\n) ENGINE=MyISAM */;\n"
+                  "\n) ENGINE=Aria */;\n"
                   "SET character_set_client = @saved_cs_client;\n");
 
           check_io(sql_file);

--- a/mysql-test/main/lock_view.result
+++ b/mysql-test/main/lock_view.result
@@ -34,7 +34,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v2` (
   `a` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `mysqltest3` /*!40100 DEFAULT CHARACTER SET latin1 */;
@@ -44,31 +44,31 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v3` (
   `a` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v3i` (
   `a` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v3is` (
   `schema_name` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v3nt` (
   `1` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v3ps` (
   `user` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 USE `mysqltest1`;
@@ -245,7 +245,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v1` (
   `id` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 /*!50001 DROP TABLE IF EXISTS `v1`*/;
 /*!50001 SET @saved_cs_client          = @@character_set_client */;

--- a/mysql-test/main/mysqldump-nl.result
+++ b/mysql-test/main/mysqldump-nl.result
@@ -57,7 +57,7 @@ SET character_set_client = utf8;
 1v` (
   `foobar
 raboof` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 --

--- a/mysql-test/main/mysqldump.result
+++ b/mysql-test/main/mysqldump.result
@@ -2070,7 +2070,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v2` (
   `a` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 /*!50001 DROP TABLE IF EXISTS `v2`*/;
 /*!50001 DROP VIEW IF EXISTS `v2`*/;
@@ -2164,7 +2164,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v1` (
   `a` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 /*!50001 DROP TABLE IF EXISTS `v1`*/;
 /*!50001 DROP VIEW IF EXISTS `v1`*/;
@@ -2238,7 +2238,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v2` (
   `a` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 /*!50001 DROP TABLE IF EXISTS `v2`*/;
 /*!50001 DROP VIEW IF EXISTS `v2`*/;
@@ -2354,7 +2354,7 @@ SET character_set_client = utf8;
   `a` tinyint NOT NULL,
   `b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 DROP TABLE IF EXISTS `v2`;
 /*!50001 DROP VIEW IF EXISTS `v2`*/;
@@ -2362,7 +2362,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v2` (
   `a` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 DROP TABLE IF EXISTS `v3`;
 /*!50001 DROP VIEW IF EXISTS `v3`*/;
@@ -2372,7 +2372,7 @@ SET character_set_client = utf8;
   `a` tinyint NOT NULL,
   `b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 /*!50001 DROP TABLE IF EXISTS `v1`*/;
 /*!50001 DROP VIEW IF EXISTS `v1`*/;
@@ -3113,7 +3113,7 @@ SET character_set_client = utf8;
   `a` tinyint NOT NULL,
   `b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 DROP TABLE IF EXISTS `v1`;
 /*!50001 DROP VIEW IF EXISTS `v1`*/;
@@ -3123,7 +3123,7 @@ SET character_set_client = utf8;
   `a` tinyint NOT NULL,
   `b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 DROP TABLE IF EXISTS `v2`;
 /*!50001 DROP VIEW IF EXISTS `v2`*/;
@@ -3133,7 +3133,7 @@ SET character_set_client = utf8;
   `a` tinyint NOT NULL,
   `b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 USE `test`;
@@ -3513,7 +3513,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v1` (
   `id` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 USE `mysqldump_test_db`;
@@ -3573,7 +3573,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `nasishnasifu` (
   `id` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 USE `mysqldump_tables`;
@@ -3982,7 +3982,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v2` (
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 /*!50001 DROP TABLE IF EXISTS `v2`*/;
 /*!50001 DROP VIEW IF EXISTS `v2`*/;
@@ -4404,7 +4404,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v1` (
   `id` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 USE `mysqldump_test_db`;
@@ -5498,7 +5498,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `nonunique_table_view_name` (
   `1` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `db2` /*!40100 DEFAULT CHARACTER SET utf8 */;
@@ -5599,7 +5599,7 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `nonunique_table_view_name` (
   `1` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 USE `db2`;

--- a/mysql-test/suite/roles/definer.result
+++ b/mysql-test/suite/roles/definer.result
@@ -283,7 +283,7 @@ SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v1` (
   `a+b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
@@ -291,28 +291,28 @@ SET character_set_client = utf8;
   `a+b` tinyint NOT NULL,
   `c` tinyint NOT NULL,
   `current_role()` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v3` (
   `a+b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v4` (
   `a+b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = utf8;
 /*!50001 CREATE TABLE `v5` (
   `a+b` tinyint NOT NULL,
   `c` tinyint NOT NULL
-) ENGINE=MyISAM */;
+) ENGINE=Aria */;
 SET character_set_client = @saved_cs_client;
 
 CREATE DATABASE /*!32312 IF NOT EXISTS*/ `mysqltest1` /*!40100 DEFAULT CHARACTER SET latin1 */;


### PR DESCRIPTION
Instead of MyISAM. This is particular important for Azure
where there is no MyISAM support in their MariaDB cloud product.

Aria was default from 10.4 onwards so lets apply it there rather
than try to make a conditional 10.3 case.