### PR TITLE
MDEV-29222: Fixed mysqld_safe script

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -146,7 +146,7 @@ IF(UNIX)
   # FIND_PROC and CHECK_PID are used by mysqld_safe
 IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
   SET (FIND_PROC
-    "ps wwwp $PID | grep -vE mariadbd-safe -vE mysqld_safe | grep -- $MYSQLD > /dev/null")
+    "ps wwwp $PID | grep -v mariadbd-safe | grep -v mysqld_safe | grep -- $MYSQLD > /dev/null")
 ENDIF()
 IF(NOT FIND_PROC AND CMAKE_SYSTEM_NAME MATCHES "SunOS")
   SET (FIND_PROC


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-29222*

## Description
The mysqld_safe script was using invalid `grep` options, which caused the script to break if it was run while mysqld was already running.

The line that was fixed was likely meant to be 2 separate grep commands, piped into each other, with each one removing any lines that matched. The `-E` option was unneeded, as the command is not using regex.

In summary, the grep command would fail, causing the script to think that the process didn't exist. This meant that the `.pid` file would be cleaned up, even though the process was still running. This caused a lot of problems, as then mysqld would try to run a second process, causing havoc.

## How can this PR be tested?

I managed to reliably reproduce this by simply starting MariaDB using `mysqld_safe start`, and then running the same command again, a few seconds later, on Linux.

For the simplest way to test, just extract out the grep command, and try running it, and see that it works as expected.

For example, you may want to run these commands:

```
# Please set this PID to your mariadb PID
PID="1234"

# This is the OLD, BAD code, which SHOULD FAIL
ps wwwp $PID | grep -vE mariadbd-safe -vE mysqld_safe

# This is the NEW, GOOD code, which SHOULD WORK
ps wwwp $PID | grep -v mariadbd-safe | grep -v mysqld_safe
```

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
This should work with all versions of grep, and should never cause issues.

This bugfix is a strict simplification, that removes complexity, and replies on the most basic `grep` functionality.