### PR TITLE
MDEV-29264: JSON function overflow error based on LONGTEXT field

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -822,7 +822,7 @@ CREATE TABLE t2 SELECT JSON_ARRAY_INSERT(fld, '$.[0]', '0') FROM t1;
 SHOW CREATE TABLE t2;
 Table	Create Table
 t2	CREATE TABLE `t2` (
-  `JSON_ARRAY_INSERT(fld, '$.[0]', '0')` varchar(25) DEFAULT NULL
+  `JSON_ARRAY_INSERT(fld, '$.[0]', '0')` varchar(21) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1
 DROP TABLE t1, t2;
 SET sql_mode=default;
@@ -1435,6 +1435,21 @@ SELECT JSON_ARRAYAGG(a) AS f FROM v;
 f
 ["foo","bar"]
 DROP VIEW v;
+DROP TABLE t;
+#
+# MDEV-29264 JSON functions overflow error based ON LONGTEXT field
+#
+CREATE TABLE t(l1 LONGTEXT, l2 LONGTEXT, l3 LONGTEXT, l4 LONGTEXT);
+INSERT INTO t VALUES('k1', 'v1', 'k2', 'v2');
+SELECT JSON_ARRAY(l1, l2, l3, l4), JSON_OBJECT(l1, l2, l3, l4) from t;
+JSON_ARRAY(l1, l2, l3, l4)	JSON_OBJECT(l1, l2, l3, l4)
+["k1", "v1", "k2", "v2"]	{"k1": "v1", "k2": "v2"}
+SELECT JSON_ARRAY_APPEND(JSON_ARRAY(l1, l2, l3, l4), '$[0]', 'k3'), JSON_ARRAY_INSERT(JSON_ARRAY(l1, l2, l3, l4), '$[0]', 'k3') from t;
+JSON_ARRAY_APPEND(JSON_ARRAY(l1, l2, l3, l4), '$[0]', 'k3')	JSON_ARRAY_INSERT(JSON_ARRAY(l1, l2, l3, l4), '$[0]', 'k3')
+[["k1", "k3"], "v1", "k2", "v2"]	["k3", "k1", "v1", "k2", "v2"]
+SELECT JSON_INSERT(JSON_OBJECT(l1, l2, l3, l4), '$.k3', 'v3'),JSON_SET(JSON_OBJECT(l1, l2, l3, l4), '$.k2', 'new v2'),JSON_REPLACE(JSON_OBJECT(l1, l2, l3, l4), '$.k2', 'new v2') from t;
+JSON_INSERT(JSON_OBJECT(l1, l2, l3, l4), '$.k3', 'v3')	JSON_SET(JSON_OBJECT(l1, l2, l3, l4), '$.k2', 'new v2')	JSON_REPLACE(JSON_OBJECT(l1, l2, l3, l4), '$.k2', 'new v2')
+{"k1": "v1", "k2": "v2", "k3": "v3"}	{"k1": "v1", "k2": "new v2"}	{"k1": "v1", "k2": "new v2"}
 DROP TABLE t;
 #
 # End of 10.5 tests

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -927,6 +927,17 @@ SELECT JSON_ARRAYAGG(a) AS f FROM v;
 DROP VIEW v;
 DROP TABLE t;
 
+
+--echo #
+--echo # MDEV-29264 JSON functions overflow error based ON LONGTEXT field
+--echo #
+CREATE TABLE t(l1 LONGTEXT, l2 LONGTEXT, l3 LONGTEXT, l4 LONGTEXT);
+INSERT INTO t VALUES('k1', 'v1', 'k2', 'v2');
+SELECT JSON_ARRAY(l1, l2, l3, l4), JSON_OBJECT(l1, l2, l3, l4) from t;
+SELECT JSON_ARRAY_APPEND(JSON_ARRAY(l1, l2, l3, l4), '$[0]', 'k3'), JSON_ARRAY_INSERT(JSON_ARRAY(l1, l2, l3, l4), '$[0]', 'k3') from t;
+SELECT JSON_INSERT(JSON_OBJECT(l1, l2, l3, l4), '$.k3', 'v3'),JSON_SET(JSON_OBJECT(l1, l2, l3, l4), '$.k2', 'new v2'),JSON_REPLACE(JSON_OBJECT(l1, l2, l3, l4), '$.k2', 'new v2') from t;
+DROP TABLE t;
+
 --echo #
 --echo # End of 10.5 tests
 --echo #

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -1738,7 +1738,7 @@ bool Item_func_json_array::fix_length_and_dec()
     return TRUE;
 
   for (n_arg=0 ; n_arg < arg_count ; n_arg++)
-    char_length+= args[n_arg]->max_char_length() + 4;
+    char_length+= static_cast<ulonglong>(args[n_arg]->max_char_length()) + 4;
 
   fix_char_length_ulonglong(char_length);
   tmp_val.set_charset(collation.collation);
@@ -1797,7 +1797,8 @@ bool Item_func_json_array_append::fix_length_and_dec()
   for (n_arg= 1; n_arg < arg_count; n_arg+= 2)
   {
     paths[n_arg/2].set_constant_flag(args[n_arg]->const_item());
-    char_length+= args[n_arg/2+1]->max_char_length() + 4;
+    char_length+=
+        static_cast<ulonglong>(args[n_arg+1]->max_char_length()) + 4;
   }
 
   fix_char_length_ulonglong(char_length);
@@ -2959,7 +2960,8 @@ bool Item_func_json_insert::fix_length_and_dec()
   for (n_arg= 1; n_arg < arg_count; n_arg+= 2)
   {
     paths[n_arg/2].set_constant_flag(args[n_arg]->const_item());
-    char_length+= args[n_arg/2+1]->max_char_length() + 4;
+    char_length+=
+        static_cast<ulonglong>(args[n_arg+1]->max_char_length()) + 4;
   }
 
   fix_char_length_ulonglong(char_length);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-29264](https://jira.mariadb.org/plugins/servlet/mobile#issue/MDEV-29264)*

## Description
Avoid `uint32` overflow error for JSON functions on LONGTEXT

## How can this PR be tested?
This patch will not change the result of mariadb server，but make the result of calling the Columnstore JSON function based on LONGTEXT correct.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

