### PR TITLE
Remove redudant defines USE_MB and USE_MB_IDENT

### DIFF
--- a/config.h.cmake
+++ b/config.h.cmake
@@ -261,9 +261,6 @@
 #cmakedefine STRUCT_TIMESPEC_HAS_TV_SEC 1
 #cmakedefine STRUCT_TIMESPEC_HAS_TV_NSEC 1
 
-#define USE_MB 1
-#define USE_MB_IDENT 1
-
 /* this means that valgrind headers and macros are available */
 #cmakedefine HAVE_VALGRIND_MEMCHECK_H 1
 
@@ -462,8 +459,8 @@
 #cmakedefine MYSQL_DEFAULT_CHARSET_NAME "@MYSQL_DEFAULT_CHARSET_NAME@"
 #cmakedefine MYSQL_DEFAULT_COLLATION_NAME "@MYSQL_DEFAULT_COLLATION_NAME@"
 
-#cmakedefine USE_MB 1
-#cmakedefine USE_MB_IDENT 1
+#cmakedefine USE_MB
+#cmakedefine USE_MB_IDENT
 
 /* This should mean case insensitive file system */
 #cmakedefine FN_NO_CASE_SENSE 1


### PR DESCRIPTION
Looking into the build directory:
<details> <summary> Without patch </summary> 
<pre>
$ grep -R "USE_MB" ./include
./include/config.h:#define USE_MB 1
./include/config.h:#define USE_MB_IDENT 1
./include/config.h:#define USE_MB 1
./include/config.h:#define USE_MB_IDENT 1
./include/my_config.h:#define USE_MB 1
./include/my_config.h:#define USE_MB_IDENT 1
./include/my_config.h:#define USE_MB 1
./include/my_config.h:#define USE_MB_IDENT 1
</pre>
</details>

<details> <summary> With patch </summary> 
<pre>
$ grep -R "USE_MB" ./include
./include/config.h:#define USE_MB 1
./include/config.h:#define USE_MB_IDENT 1
./include/my_config.h:#define USE_MB 1
./include/my_config.h:#define USE_MB_IDENT 1
</pre>
</details>

Patch introducing the change: bc76ad8f6be7