### PR TITLE
MDEV-25341: innodb buffer pool soft decommit of memory

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3091,6 +3091,7 @@ void buf_block_t::initialise(const page_id_t page_id, ulint zip_size,
   ut_ad(!page.in_file());
   buf_block_init_low(this);
   page.init(fix, page_id);
+  page.set_os_used();
   page_zip_set_size(&page.zip, zip_size);
 }
 

--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -297,7 +297,7 @@ buf_block_t* buf_LRU_get_free_only()
 			assert_block_ahi_empty(block);
 
 			block->page.set_state(buf_page_t::MEMORY);
-			MEM_MAKE_ADDRESSABLE(block->page.frame, srv_page_size);
+			block->page.set_os_used();
 			break;
 		}
 
@@ -989,13 +989,6 @@ buf_LRU_block_free_non_file_page(
 	block->page.set_state(buf_page_t::NOT_USED);
 
 	MEM_UNDEFINED(block->page.frame, srv_page_size);
-	/* Wipe page_no and space_id */
-	static_assert(FIL_PAGE_OFFSET % 4 == 0, "alignment");
-	memset_aligned<4>(block->page.frame + FIL_PAGE_OFFSET, 0xfe, 4);
-	static_assert(FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID % 4 == 2,
-		      "not perfect alignment");
-	memset_aligned<2>(block->page.frame + FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID,
-			  0xfe, 4);
 	data = block->page.zip.data;
 
 	if (data != NULL) {
@@ -1024,7 +1017,7 @@ buf_LRU_block_free_non_file_page(
 		pthread_cond_signal(&buf_pool.done_free);
 	}
 
-	MEM_NOACCESS(block->page.frame, srv_page_size);
+	block->page.set_os_unused();
 }
 
 /** Release a memory block to the buffer pool. */

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -657,6 +657,20 @@ public:
     access_time= 0;
   }
 
+  void set_os_unused()
+  {
+    MEM_NOACCESS(frame, srv_page_size);
+#ifdef MADV_FREE
+    madvise(frame, srv_page_size, MADV_FREE);
+#elif defined(_WIN32)
+    DiscardVirtualMemory(frame, srv_page_size);
+#endif
+  }
+
+  void set_os_used() const
+  {
+    MEM_MAKE_ADDRESSABLE(frame, srv_page_size);
+  }
 public:
   const page_id_t &id() const { return id_; }
   uint32_t state() const { return zip.fix; }


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25341*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

When InnoDB isn't using memory its polite to other system
processes to allow that memory to be used.

Use madvise(MADV_FREE) to keep virtual mapping but allow kernel
to reclaim memory.

buf_page_t::set_state(buf_page_t::NOT_USED) will call madvise(MADV_FREE)
as will the initialization of the same state.

buf_LRU_block_free_non_file_page is restructured to do this call
after it has overwritten the table space id and page id so that
it is not immediately marked as reused by the kernel.

## How can this PR be tested?

<pre>
sql/mariadbd --no-defaults --skip-networking --datadir=/tmp/${PWD##*/}-datadir --socket=/tmp/${PWD##*/}.sock --plugin-dir=${PWD}/mysql-test/var/plugins/ --verbose  --innodb-buffer-pool-size=10G

$ ps  -C mariadbd -o drs,trs,vsz,rss,pid
  DRS  TRS    VSZ   RSS     PID
12963911 8592 12972504 293792 123320

# reasonably low RSS amount

# load data
$ sysbench --mysql-user=dan --mysql-db=test --mysql-socket=/tmp/build-mariadb-server-10.11.sock --tables=10 --table_size=1000000 oltp_read_write prepare

$ ps  -C mariadbd -o drs,trs,vsz,rss,pid
  DRS  TRS    VSZ   RSS     PID
14868687 8592 14877280 3073736 123320

Innodb_buffer_pool_pages_free           | 491932
# still reasonable amount free

# add some memory presure (26G on a 30G laptop) with memlock
$ sudo ./target/release/eatmemory -m --alloc-definition=1 -s 26000
Killed

# was killed but not before kernel reclaimed lots of RSS innodb memory (without killing MariaDB)

$ ps  -C mariadbd -o drs,trs,vsz,rss,pid
  DRS  TRS    VSZ   RSS     PID
14680179 8592 14688772 2196 123320
</pre>

## Basing the PR against the correct MariaDB version
- [ X ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
