### PR TITLE
Remove redundant variable  in my_strnncollsp_simple function in ctype-simple.c 

### DIFF
--- a/strings/ctype-simple.c
+++ b/strings/ctype-simple.c
@@ -176,7 +176,6 @@ int my_strnncollsp_simple(CHARSET_INFO * cs, const uchar *a, size_t a_length,
 {
   const uchar *map= cs->sort_order, *end;
   size_t length;
-  int res;
 
   end= a + (length= MY_MIN(a_length, b_length));
   while (a < end)
@@ -184,7 +183,6 @@ int my_strnncollsp_simple(CHARSET_INFO * cs, const uchar *a, size_t a_length,
     if (map[*a++] != map[*b++])
       return ((int) map[a[-1]] - (int) map[b[-1]]);
   }
-  res= 0;
   if (a_length != b_length)
   {
     int swap= 1;
@@ -198,15 +196,14 @@ int my_strnncollsp_simple(CHARSET_INFO * cs, const uchar *a, size_t a_length,
       a_length= b_length;
       a= b;
       swap= -1;                                 /* swap sign of result */
-      res= -res;
     }
     for (end= a + a_length-length; a < end ; a++)
     {
       if (map[*a] != map[' '])
-	return (map[*a] < map[' ']) ? -swap : swap;
+        return (map[*a] < map[' ']) ? -swap : swap;
     }
   }
-  return res;
+  return 0;
 }
 
 


### PR DESCRIPTION
### **Description**
****
Hi, guys! I'm a 2022 GSoC Contributor and working on MCS.These days I am trying to optimize the string compared in MCS .Today I find a redundant variable in function my_strnncollsp_simple in ctype-simple.c of MDB
### **How** can this PR be tested?
****
This change will not change existing test results. 
Basing the PR against the correct MariaDB version
 
- [x] This is a new feature and the PR is based against the latest MariaDB development branch
- [ ] This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced