### PR TITLE
Add missing comment and remove unnecessary initialization

### DIFF
--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -3581,6 +3581,7 @@ union Any_pointer {
   @param variable    [in]     Details of the variable.
   @param value_type  [in]     Variable type.
   @param show_type   [in]     Variable show type.
+  @param status_var  [in]     Status variable pointer
   @param charset     [out]    Character set of the value.
   @param buff        [in,out] Buffer to store the value.
                               (Needs to have enough memory

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4985,7 +4985,6 @@ Sys_var_rpl_filter::global_value_ptr(THD *thd,
   }
 
   rpl_filter= mi->rpl_filter;
-  tmp.length(0);
 
   mysql_mutex_lock(&LOCK_active_mi);
   switch (opt_id) {


### PR DESCRIPTION
Add missing comment and remove unnecessary initialization
    - Commit c8948b0d0db4 introduced `get_one_variable()` - updating missing argument.
    - Remove caller setting of empty string in `rpl_filter`, since underlying functions will do the same
      (commit 9584cbe7fcc4 introduced the change).
