### PR TITLE
MDEV-29183: Clarify mysqlbinlog command description

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -1788,7 +1788,7 @@ that may lead to an endless loop.",
    &opt_binlog_rows_event_max_encoded_size, 0,
    GET_ULONG, REQUIRED_ARG, UINT_MAX/4,  256, ULONG_MAX,  0, 256,  0},
 #endif
-  {"verify-binlog-checksum", 'c', "Verify checksum binlog events.",
+  {"verify-binlog-checksum", 'c', "Verify binlog event checksums.",
    (uchar**) &opt_verify_binlog_checksum, (uchar**) &opt_verify_binlog_checksum,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"rewrite-db", OPT_REWRITE_DB,


### PR DESCRIPTION
## Description
The statement 'Verify checksum binlog events.' is confusing. Fix word order to make it clear.

## How can this PR be tested?

This is a word order change for a text description as a part of UI design, so automatic unit testing is not suitable here. It should be tested by being read by human beings.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix for UI and the PR is based against the earliest branch in which the bug can be reproduced*

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.
