### PR TITLE
MDEV-29418 linux uuid implementation returning non-hwaddr based suffix

### DIFF
--- a/mysys/my_gethwaddr.c
+++ b/mysys/my_gethwaddr.c
@@ -111,7 +111,7 @@ my_bool my_gethwaddr(uchar *to)
     for (i= 0; res && i < ifc.ifc_len / sizeof(ifr[0]); i++)
     {
 #if !defined(_AIX) || !defined(__linux__)
-#if defined(__linux___)
+#if defined(__linux__)
 #define HWADDR_DATA ifr[i].ifr_hwaddr.sa_data
 #else
 #define HWADDR_DATA ifr[i].ifr_hwaddr


### PR DESCRIPTION
Because of a define error the wrong value was being returned.

Regression in MDEV-28243

Fixes: 607f9874679c3e4ef7edcd2c9d80120051af73cc
