### PR TITLE
Deb: add kinetic to autobake

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -87,7 +87,7 @@ case "${LSBNAME}" in
     ;&
   focal)
     ;&
-  impish|jammy)
+  impish|jammy|kinetic)
     # mariadb-plugin-rocksdb s390x not supported by us (yet)
     # ubuntu doesn't support mips64el yet, so keep this just
     # in case something changes.


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

To build on kinetic (Ubuntu 22.10) we need to know about it so we can adjust dependencies accordingly.

Needed for https://github.com/MariaDB/buildbot/pull/52

Technically we'll only package 10.6+ for kinetic, but it will build on 10.5 as a minium (due to openssl-3.0).

## How can this PR be tested?

Its manual at the moment, however chicken/egg - its needed for bb to get its kinetic (not yet released) builder.
