### PR TITLE
MDEV-28533: CONNECT engine does not quote columns involved in WHERE clause

### DIFF
--- a/storage/connect/mysql-test/connect/r/mysql.result
+++ b/storage/connect/mysql-test/connect/r/mysql.result
@@ -304,5 +304,27 @@ INSERT INTO t2 VALUES (10),(20),(30),(40);
 DROP TABLE t2;
 DROP TABLE t1;
 #
+# MDEV-28533 CONNECT engine does not quote columns involved in WHERE clause
+#
+CREATE TABLE t1 (id int, `spaced col` varchar(10),`nospace` varchar(10));
+insert into t1 values (1,1,'x1'),(2,'C-003','x2');
+SELECT * from t1;
+id	spaced col	nospace
+1	1	x1
+2	C-003	x2
+CREATE TABLE t2 (id int, `spaced col` varchar(10), `nospace` varchar(10)) ENGINE=CONNECT TABLE_TYPE=MYSQL DBNAME='test' TABNAME='t1' OPTION_LIST='host=localhost,user=root,port=PORT';
+SELECT * from t2;
+id	spaced col	nospace
+1	1	x1
+2	C-003	x2
+SELECT `id` FROM t2 WHERE t2.`nospace` = 'x1';
+id
+1
+SELECT `id` FROM t2 WHERE t2.`spaced col` = 'C-003';
+id
+2
+DROP TABLE t1;
+DROP TABLE t2;
+#
 # End of 10.3 tests
 #

--- a/storage/connect/mysql-test/connect/t/mysql.test
+++ b/storage/connect/mysql-test/connect/t/mysql.test
@@ -484,5 +484,25 @@ DROP TABLE t2;
 DROP TABLE t1;
 
 --echo #
+--echo # MDEV-28533 CONNECT engine does not quote columns involved in WHERE clause
+--echo #
+
+CREATE TABLE t1 (id int, `spaced col` varchar(10),`nospace` varchar(10));
+insert into t1 values (1,1,'x1'),(2,'C-003','x2');
+
+SELECT * from t1;
+
+--replace_result $PORT PORT
+--eval CREATE TABLE t2 (id int, `spaced col` varchar(10), `nospace` varchar(10)) ENGINE=CONNECT TABLE_TYPE=MYSQL DBNAME='test' TABNAME='t1' OPTION_LIST='host=localhost,user=root,port=$PORT'
+
+SELECT * from t2;
+SELECT `id` FROM t2 WHERE t2.`nospace` = 'x1';
+SELECT `id` FROM t2 WHERE t2.`spaced col` = 'C-003';
+
+
+DROP TABLE t1;
+DROP TABLE t2;
+
+--echo #
 --echo # End of 10.3 tests
 --echo #


### PR DESCRIPTION
- Spaced column names are note quoted properly


Reviewer: <>
Note: failing ` connect.misc` is not related to this bug.
- [x] *The Jira issue number for this PR is: MDEV-28533*

