### PR TITLE
MDEV-29540 Incorrect sequence values in INSERT SELECT

### DIFF
--- a/mysql-test/suite/sql_sequence/default.result
+++ b/mysql-test/suite/sql_sequence/default.result
@@ -195,3 +195,105 @@ INSERT INTO t1 () values ();
 EXECUTE stmt;
 DROP TABLE t1;
 DROP SEQUENCE s;
+#
+# MDEV-29540 Incorrect sequence values in INSERT SELECT
+#
+CREATE SEQUENCE s1;
+CREATE TABLE t1 (
+a BIGINT UNSIGNED NOT NULL PRIMARY KEY
+DEFAULT (NEXT VALUE FOR s1),
+b CHAR(1) NOT NULL
+);
+INSERT INTO t1 (b) VALUES ('a');
+INSERT INTO t1 (b) VALUES ('b'), ('c');
+INSERT INTO t1 (b) VALUES ('d');
+INSERT INTO t1 (b) SELECT c FROM (
+SELECT 'e' as c
+UNION
+SELECT 'f'
+  UNION
+SELECT 'g'
+) der;
+SELECT a, b FROM t1;
+a	b
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+7	g
+ALTER SEQUENCE s1 RESTART;
+INSERT INTO t1 (b) SELECT c FROM (
+SELECT 'a' as c
+UNION
+SELECT 'b'
+  UNION
+SELECT 'c'
+  UNION
+SELECT 'd'
+  UNION
+SELECT 'e'
+  UNION
+SELECT 'f'
+  UNION
+SELECT 'g'
+) der;
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+ALTER SEQUENCE s1 RESTART;
+INSERT IGNORE INTO t1 (b) SELECT c FROM (
+SELECT 'a' as c
+UNION
+SELECT 'b'
+  UNION
+SELECT 'c'
+  UNION
+SELECT 'd'
+  UNION
+SELECT 'e'
+  UNION
+SELECT 'f'
+  UNION
+SELECT 'g'
+) der;
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
+Warning	1062	Duplicate entry '5' for key 'PRIMARY'
+Warning	1062	Duplicate entry '6' for key 'PRIMARY'
+Warning	1062	Duplicate entry '7' for key 'PRIMARY'
+SELECT a, b FROM t1;
+a	b
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+7	g
+INSERT IGNORE INTO t1 (b) SELECT c FROM (
+SELECT 'h' as c
+UNION
+SELECT 'i'
+  UNION
+SELECT 'j'
+) der;
+SELECT a, b FROM t1;
+a	b
+1	a
+2	b
+3	c
+4	d
+5	e
+6	f
+7	g
+8	h
+9	i
+10	j
+DROP TABLE t1;
+DROP SEQUENCE s1;
+#
+# End of 10.3 tests
+#

--- a/mysql-test/suite/sql_sequence/default.test
+++ b/mysql-test/suite/sql_sequence/default.test
@@ -135,3 +135,83 @@ EXECUTE stmt;
 # Cleanup
 DROP TABLE t1;
 DROP SEQUENCE s;
+
+--echo #
+--echo # MDEV-29540 Incorrect sequence values in INSERT SELECT
+--echo #
+
+CREATE SEQUENCE s1;
+CREATE TABLE t1 (
+  a BIGINT UNSIGNED NOT NULL PRIMARY KEY
+      DEFAULT (NEXT VALUE FOR s1),
+  b CHAR(1) NOT NULL
+);
+
+INSERT INTO t1 (b) VALUES ('a');
+INSERT INTO t1 (b) VALUES ('b'), ('c');
+INSERT INTO t1 (b) VALUES ('d');
+INSERT INTO t1 (b) SELECT c FROM (
+  SELECT 'e' as c
+  UNION
+  SELECT 'f'
+  UNION
+  SELECT 'g'
+) der;
+
+SELECT a, b FROM t1;
+
+ALTER SEQUENCE s1 RESTART;
+
+--error ER_DUP_ENTRY
+INSERT INTO t1 (b) SELECT c FROM (
+  SELECT 'a' as c
+  UNION
+  SELECT 'b'
+  UNION
+  SELECT 'c'
+  UNION
+  SELECT 'd'
+  UNION
+  SELECT 'e'
+  UNION
+  SELECT 'f'
+  UNION
+  SELECT 'g'
+) der;
+
+ALTER SEQUENCE s1 RESTART;
+
+INSERT IGNORE INTO t1 (b) SELECT c FROM (
+  SELECT 'a' as c
+  UNION
+  SELECT 'b'
+  UNION
+  SELECT 'c'
+  UNION
+  SELECT 'd'
+  UNION
+  SELECT 'e'
+  UNION
+  SELECT 'f'
+  UNION
+  SELECT 'g'
+) der;
+
+SELECT a, b FROM t1;
+
+INSERT IGNORE INTO t1 (b) SELECT c FROM (
+  SELECT 'h' as c
+  UNION
+  SELECT 'i'
+  UNION
+  SELECT 'j'
+) der;
+
+SELECT a, b FROM t1;
+
+DROP TABLE t1;
+DROP SEQUENCE s1;
+
+--echo #
+--echo # End of 10.3 tests
+--echo #

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5455,7 +5455,7 @@ class select_insert :public select_result_interceptor {
   int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
   virtual int prepare2(JOIN *join);
   virtual int send_data(List<Item> &items);
-  virtual void store_values(List<Item> &values);
+  virtual bool store_values(List<Item> &values, bool ignore_errors);
   virtual bool can_rollback_data() { return 0; }
   bool prepare_eof();
   bool send_ok_packet();
@@ -5497,7 +5497,7 @@ public:
   int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
 
   int binlog_show_create_table(TABLE **tables, uint count);
-  void store_values(List<Item> &values);
+  bool store_values(List<Item> &values, bool ignore_errors);
   bool send_eof();
   virtual void abort_result_set();
   virtual bool can_rollback_data() { return 1; }

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -3928,9 +3928,7 @@ int select_insert::send_data(List<Item> &values)
     DBUG_RETURN(0);
 
   thd->count_cuted_fields= CHECK_FIELD_WARN;	// Calculate cuted fields
-  store_values(values);
-  if (table->default_field &&
-      unlikely(table->update_default_fields(info.ignore)))
+  if (store_values(values, info.ignore))
     DBUG_RETURN(1);
   thd->count_cuted_fields= CHECK_FIELD_ERROR_FOR_NULL;
   if (unlikely(thd->is_error()))
@@ -3988,18 +3986,19 @@ int select_insert::send_data(List<Item> &values)
 }
 
 
-void select_insert::store_values(List<Item> &values)
+bool select_insert::store_values(List<Item> &values, bool ignore_errors)
 {
   DBUG_ENTER("select_insert::store_values");
+  bool error;
 
   if (fields->elements)
-    fill_record_n_invoke_before_triggers(thd, table, *fields, values, 1,
-                                         TRG_EVENT_INSERT);
+    error= fill_record_n_invoke_before_triggers(thd, table, *fields, values,
+                                                ignore_errors, TRG_EVENT_INSERT);
   else
-    fill_record_n_invoke_before_triggers(thd, table, table->field_to_fill(),
-                                         values, 1, TRG_EVENT_INSERT);
+    error= fill_record_n_invoke_before_triggers(thd, table, table->field_to_fill(),
+                                                values, ignore_errors, TRG_EVENT_INSERT);
 
-  DBUG_VOID_RETURN;
+  DBUG_RETURN(error);
 }
 
 bool select_insert::prepare_eof()
@@ -4670,10 +4669,10 @@ select_create::binlog_show_create_table(TABLE **tables, uint count)
   return result;
 }
 
-void select_create::store_values(List<Item> &values)
+bool select_create::store_values(List<Item> &values, bool ignore_errors)
 {
-  fill_record_n_invoke_before_triggers(thd, table, field, values, 1,
-                                       TRG_EVENT_INSERT);
+  return fill_record_n_invoke_before_triggers(thd, table, field, values,
+                                              ignore_errors, TRG_EVENT_INSERT);
 }
 
 


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29540*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

The population of default values in INSERT SELECT was being performed twice. With sequences, this resulted in every second sequence value being used.

With SELECT INSERT we remove the second invokation of table->update_default_fields(). This was already performed in store_values() invoking fill_record_n_invoke_before_triggers() which invoked update_default_fields() previously.

We do need to return an error on duplicate values, so the ::store_values is extended to take the ignore option.

## How can this PR be tested?

mtr test included

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

Users won't be hopefully depending on skipped values in sequences in INSERT SELECT.