### PR TITLE
MDEV-28834: Make minimal Lintian changes and some cleanup

### DIFF
--- a/debian/mariadb-test-data.lintian-overrides
+++ b/debian/mariadb-test-data.lintian-overrides
@@ -1,6 +1,8 @@
 # These should be moved, see https://jira.mariadb.org/browse/MDEV-21654
 arch-dependent-file-in-usr-share usr/share/mysql/mysql-test/suite/plugins/pam/pam_mariadb_mtr.so
+arch-dependent-file-in-usr-share [usr/share/mysql/mysql-test/suite/plugins/pam/pam_mariadb_mtr.so]
 arch-independent-package-contains-binary-or-object usr/share/mysql/mysql-test/suite/plugins/pam/pam_mariadb_mtr.so
+arch-independent-package-contains-binary-or-object [usr/share/mysql/mysql-test/suite/plugins/pam/pam_mariadb_mtr.so]
 # Mainly for support for *BSD family. Not right way to do but this is test package and not for production
 incorrect-path-for-interpreter /usr/bin/env perl != /usr/bin/perl [usr/share/mysql/mysql-test/std_data/checkDBI_DBD-MariaDB.pl]
 incorrect-path-for-interpreter /usr/bin/env perl != /usr/bin/perl [usr/share/mysql/mysql-test/suite/engines/rr_trx/run_stress_tx_rr.pl]

--- a/debian/mariadb-test.lintian-overrides
+++ b/debian/mariadb-test.lintian-overrides
@@ -1,6 +1,8 @@
 # These should be moved, see https://jira.mariadb.org/browse/MDEV-21653
 arch-dependent-file-in-usr-share usr/share/mysql/mysql-test/lib/My/SafeProcess/my_safe_process
 arch-dependent-file-in-usr-share usr/share/mysql/mysql-test/lib/My/SafeProcess/wsrep_check_version
+arch-dependent-file-in-usr-share [usr/share/mysql/mysql-test/lib/My/SafeProcess/my_safe_process]
+arch-dependent-file-in-usr-share [usr/share/mysql/mysql-test/lib/My/SafeProcess/wsrep_check_version]
 # Mainly for support for *BSD family. Not right way to do but this is test package and not for production
 incorrect-path-for-interpreter /usr/bin/env perl != /usr/bin/perl [usr/share/mysql/mysql-test/lib/process-purecov-annotations.pl]
 incorrect-path-for-interpreter /usr/bin/env perl != /usr/bin/perl [usr/share/mysql/mysql-test/lib/v1/mysql-test-run.pl]

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -11,12 +11,20 @@ version-substvar-for-external-package mariadb-client-10.5 -> mysql-client-core-8
 version-substvar-for-external-package libmariadbd-dev -> libmariadbclient-dev
 # ColumnStore not used in Debian, safe to ignore. Reported upstream in https://jira.mariadb.org/browse/MDEV-24124
 source-is-missing storage/columnstore/columnstore/utils/jemalloc/libjemalloc.so.2
+source-is-missing [storage/columnstore/columnstore/utils/jemalloc/libjemalloc.so.2]
 # Must be fixed upstream
 source-is-missing storage/mroonga/vendor/groonga/examples/dictionary/html/js/jquery-ui-*.custom.js
+# New Lintian syntax (from version 2.115)
+source-is-missing [sql/share/charsets/languages.html]
+source-is-missing [storage/rocksdb/rocksdb/docs/_includes/footer.html]
 # Intentional control relationships
 version-substvar-for-external-package Replaces * libmariadbd-dev -> libmariadbclient-dev
 version-substvar-for-external-package Replaces * libmariadb-dev -> libmysqlclient-dev
 version-substvar-for-external-package Replaces * libmariadb-dev -> libmysqld-dev
+# New Lintian syntax (from version 2.115)
+version-substvar-for-external-package Replaces * libmariadb-dev -> libmysqlclient-dev [debian/control:*]
+version-substvar-for-external-package Replaces * libmariadb-dev -> libmysqld-dev [debian/control:*]
+version-substvar-for-external-package Replaces * libmariadbd-dev -> libmariadbclient-dev [debian/control:*]
 # We can't change build dependencies on a stable branch (10.5..10.8) so just override this
 missing-build-dependency-for-dh-addon systemd *
 # Data or test files where long lines are justified


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28834*

## Description
This supersedes PR #2257 which is against 10.6

 * Lintian 2.115 introduced new syntax for overrides. Add minimal set of rules to remove errors and have clean tests. Minimal set of rules can be merge up-to 10.8
 * MariaDB 10.2 is not build for Debian Sid so it can't be used for testing anymore. It should be removed upstream `debian/salsa-ci.yml`
 * Make small change to `debian/rules' to remove one external tab
 * Make sure that there is not versions in external dependency `Conflicts` in `debian/control`

## How can this PR be tested?
Most of these changes are beyond manual testing. Building branch and running lintian against it should work as in Salsa-CI:
https://salsa.debian.org/illuusio/mariadb-server/-/jobs/3590792/raw
Current situation with Lintian is:
https://salsa.debian.org/illuusio/mariadb-server/-/jobs/3586829/raw

There should not be any extra errors marked with `E:`. What comes to removing 10.2 there is nothing to-do because it's just not executed.

Whole run is here and it does not pass as it needs more updating Salsa-CI and Debian packaging control file
https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/462772
But they are not mergable up straight so they should be PRed after this one is in.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
Only backward compatibility change is removing test updating from MariaDB version10.2