### PR TITLE
MDEV-28720 add error message if flush log failure

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -6874,7 +6874,12 @@ int main(int argc, char **argv)
     if (flush_logs || opt_delete_master_logs)
     {
       if (mysql_refresh(mysql, REFRESH_LOG))
+      {
+        fprintf(stderr,
+                "Flush logs or delete master logs failure in server \n");
+        first_error= EX_MYSQLERR;
         goto err;
+      }
       verbose_msg("-- main : logs flushed successfully!\n");
     }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-28720*
## Description
If mariadb cnf set log error to some file which mysql user  doesn't has permission to write, mariadb dump will generate an empty file because of executing flush logs  failed at the begin part. 
So I add an error message , and set the exit code to EX_MYSQLERR.

## How can this PR be tested?
CI test is ok.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
No
