### PR TITLE
MDEV-29614 mariadb-upgrade calls mysql and mysql-check

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -935,7 +935,7 @@ static int run_mysqlcheck_upgrade(my_bool mysql_db_only)
     return 0;
   }
   verbose("Phase %d/%d: Checking and upgrading %s", ++phase, phases_total, what);
-  print_conn_args("mysqlcheck");
+  print_conn_args("mariadb-check");
   retch= run_tool(mysqlcheck_path,
                   NULL, /* Send output from mysqlcheck directly to screen */
                   defaults_file,
@@ -1451,7 +1451,7 @@ int main(int argc, char **argv)
   }
 
   /* Find mysql */
-  find_tool(mysql_path, IF_WIN("mysql.exe", "mysql"), self_name);
+  find_tool(mysql_path, IF_WIN("mariadb.exe", "mariadb"), self_name);
 
   open_mysql_upgrade_file();
 
@@ -1459,7 +1459,7 @@ int main(int argc, char **argv)
     exit(upgrade_already_done(0) == 0);
 
   /* Find mysqlcheck */
-  find_tool(mysqlcheck_path, IF_WIN("mysqlcheck.exe", "mysqlcheck"), self_name);
+  find_tool(mysqlcheck_path, IF_WIN("mariadb-check.exe", "mariadb-check"), self_name);
 
   if (opt_systables_only && !opt_silent)
     printf("The --upgrade-system-tables option was used, user tables won't be touched.\n");

--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -778,18 +778,18 @@ FLUSH PRIVILEGES;
 #
 This installation of MariaDB is already upgraded to MariaDB .
 There is no need to run mysql_upgrade again for MariaDB .
-Looking for 'mysql' as: mysql
+Looking for 'mariadb' as: mariadb
 This installation of MariaDB is already upgraded to MariaDB .
 There is no need to run mysql_upgrade again for MariaDB .
 #
 # MDEV-27279: mariadb_upgrade check-if-upgrade absence is do it
 #
-Looking for 'mysql' as: mysql
+Looking for 'mariadb' as: mariadb
 Empty or non existent ...mysql_upgrade_info. Assuming mysql_upgrade has to be run!
 #
 # MDEV-27279: mariadb_upgrade check-if-upgrade with minor version change
 #
-Looking for 'mysql' as: mysql
+Looking for 'mariadb' as: mariadb
 This installation of MariaDB is already upgraded to MariaDB .
 There is no need to run mysql_upgrade again for MariaDB .
 This installation of MariaDB is already upgraded to MariaDB .

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -55,7 +55,7 @@ DROP USER mysqltest1@'%';
 
 --echo Run mysql_upgrade with a non existing server socket
 --replace_result $MYSQLTEST_VARDIR var
---replace_regex /.*mysqlcheck.*: Got/mysqlcheck: Got/ /\([0-9|-]*\)/(errno)/
+--replace_regex /.*mariadb-check.*: Got/mariadb-check: Got/ /\([0-9|-]*\)/(errno)/
 --error 1
 # NC: Added --skip-version-check, as the version check would fail when
 # mysql_upgrade tries to get the server version.
@@ -139,7 +139,7 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 --echo Run mysql_upgrade with unauthorized access
 --error 1
 --exec $MYSQL_UPGRADE --skip-verbose --user=root --password=wrong_password 2>&1
---replace_regex /.*mysqlcheck.*: Got/mysqlcheck: Got/ /\([0-9|-]*\)/(errno)/
+--replace_regex /.*mariadb-check.*: Got/mariadb-check: Got/ /\([0-9|-]*\)/(errno)/
 --error 1
 --exec $MYSQL_UPGRADE --skip-verbose --skip-version-check --user=root --password=wrong_password 2>&1
 
@@ -290,7 +290,7 @@ FLUSH PRIVILEGES;
 --replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB /
 --error 1
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed
---replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB / /'mysql.* as:[^\n]*/'mysql' as: mysql/
+--replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB / /'mariadb.* as:[^\n]*/'mariadb' as: mariadb/
 --error 1
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --verbose
 
@@ -302,7 +302,7 @@ FLUSH PRIVILEGES;
 --replace_regex /[^ ]*mysql_upgrade_info/...mysql_upgrade_info/
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed
 
---replace_regex /'mysql.* as:[^\n]*/'mysql' as: mysql/ /open .* Assuming/open XXX. Assuming/ /[^ ]*mysql_upgrade_info/...mysql_upgrade_info/
+--replace_regex /'mariadb.* as:[^\n]*/'mariadb' as: mariadb/ /open .* Assuming/open XXX. Assuming/ /[^ ]*mysql_upgrade_info/...mysql_upgrade_info/
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --verbose
 
 --echo #
@@ -324,7 +324,7 @@ EOF
 
 --error 1
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --silent
---replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB / /'mysql.* as:[^\n]*/'mysql' as: mysql/
+--replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB / /'mariadb.* as:[^\n]*/'mariadb' as: mariadb/
 --error 1
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --verbose
 --replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB /
@@ -351,7 +351,7 @@ EOF
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --silent
 --replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB /
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed
---replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB / /'mysql.* as:[^\n]*/'mysql' as: mysql/
+--replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB / /'mariadb.* as:[^\n]*/'mysql' as: mysql/
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --verbose
 --remove_file $MYSQLD_DATADIR/mysql_upgrade_info
 drop table mysql.global_priv;


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29614*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

rather than mariadb/mariadb-check. 10.5 was the version when real mariadb names became the default, so use the mariadb names in the mariadb-upgrade.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
