### PR TITLE
MDEV-18200 MariaBackup full backup failed with InnoDB: Failing assert…

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -4503,14 +4503,21 @@ bool Backup_datasinks::backup_low()
 
 		if (recv_find_max_checkpoint(&max_cp_field) == DB_SUCCESS
 		    && log_sys.log.format != 0) {
-			if (max_cp_field == LOG_CHECKPOINT_1) {
-				log_header_read(max_cp_field);
+			switch (max_cp_field) {
+			case LOG_CHECKPOINT_1:
+				if (log_header_read(max_cp_field)) {
+					/* metadata_to_lsn still 0 so error returns below */
+					msg("Error: recv_find_max_checkpoint() failed.");
+					break;
+				}
+				/* fallthrough */
+			default:
+				metadata_to_lsn = mach_read_from_8(
+					log_sys.checkpoint_buf + LOG_CHECKPOINT_LSN);
+				msg("mariabackup: The latest check point"
+				    " (for incremental): '" LSN_PF "'",
+				    metadata_to_lsn);
 			}
-			metadata_to_lsn = mach_read_from_8(
-				log_sys.checkpoint_buf + LOG_CHECKPOINT_LSN);
-			msg("mariabackup: The latest check point"
-			    " (for incremental): '" LSN_PF "'",
-			    metadata_to_lsn);
 		} else {
 			msg("Error: recv_find_max_checkpoint() failed.");
 		}
@@ -4721,7 +4728,11 @@ reread_log_header:
 	checkpoint_lsn_start = log_sys.log.get_lsn();
 	checkpoint_no_start = log_sys.next_checkpoint_no;
 
-	log_header_read(max_cp_field);
+	if (log_header_read(max_cp_field)) {
+		log_mutex_exit();
+		goto fail;
+	}
+
 
 	if (checkpoint_no_start != mach_read_from_8(buf + LOG_CHECKPOINT_NO)
 	    || checkpoint_lsn_start

--- a/mysql-test/suite/mariabackup/data_directory.result
+++ b/mysql-test/suite/mariabackup/data_directory.result
@@ -11,3 +11,9 @@ SELECT * FROM t;
 a
 1
 DROP TABLE t;
+#
+# MDEV-18200 MariaBackup full backup failed with InnoDB: Failing assertion: success
+#
+#
+# End of 10.4 tests
+#

--- a/mysql-test/suite/mariabackup/data_directory.test
+++ b/mysql-test/suite/mariabackup/data_directory.test
@@ -21,4 +21,19 @@ rmdir $table_data_dir;
 SELECT * FROM t;
 DROP TABLE t;
 rmdir $targetdir;
+
+--echo #
+--echo # MDEV-18200 MariaBackup full backup failed with InnoDB: Failing assertion: success
+--echo #
+let $DATADIR= `select @@datadir`;
+chmod 0000 $DATADIR/ibdata1;
+--disable_result_log
+--error 1
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir;
+--enable_result_log
+chmod 0755 $DATADIR/ibdata1;
 rmdir $table_data_dir;
+rmdir $targetdir;
+--echo #
+--echo # End of 10.4 tests
+--echo #

--- a/plugin/cracklib_password_check/CMakeLists.txt
+++ b/plugin/cracklib_password_check/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+IF(PLUGIN_CRACKLIB_PASSWORD_CHECK STREQUAL "NO")
+  ADD_FEATURE_INFO(CRACKLIB_PASSWORD_CHECK "OFF" "CrackLib Password Validation Plugin")
+  RETURN()
+ENDIF()
+
 INCLUDE (CheckIncludeFiles)
 INCLUDE (CheckLibraryExists)
 

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -209,8 +209,9 @@ void
 logs_empty_and_mark_files_at_shutdown(void);
 /*=======================================*/
 /** Read a log group header page to log_sys.checkpoint_buf.
-@param[in]	header	0 or LOG_CHECKPOINT_1 or LOG_CHECKPOINT2 */
-void log_header_read(ulint header);
+@param[in]	header	0 or LOG_CHECKPOINT_1 or LOG_CHECKPOINT2
+@return error code (from fil_io) or DB_SUCCESS */
+dberr_t log_header_read(ulint header);
 /** Write checkpoint info to the log header and invoke log_mutex_exit().
 @param[in]	sync	whether to wait for the write to complete
 @param[in]	end_lsn	start LSN of the MLOG_CHECKPOINT mini-transaction */

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1355,20 +1355,21 @@ log_group_checkpoint(lsn_t end_lsn)
 }
 
 /** Read a log group header page to log_sys.checkpoint_buf.
-@param[in]	header	0 or LOG_CHECKPOINT_1 or LOG_CHECKPOINT2 */
-void log_header_read(ulint header)
+@param[in]	header	0 or LOG_CHECKPOINT_1 or LOG_CHECKPOINT2
+@return         DB_SUCCESS or error. */
+dberr_t log_header_read(ulint header)
 {
-	ut_ad(log_mutex_own());
+  ut_ad(log_mutex_own());
 
-	log_sys.n_log_ios++;
+  log_sys.n_log_ios++;
 
-	MONITOR_INC(MONITOR_LOG_IO);
+  MONITOR_INC(MONITOR_LOG_IO);
 
-	fil_io(IORequestLogRead, true,
-	       page_id_t(SRV_LOG_SPACE_FIRST_ID,
-			 header >> srv_page_size_shift),
-	       0, header & (srv_page_size - 1),
-	       OS_FILE_LOG_BLOCK_SIZE, log_sys.checkpoint_buf, NULL);
+  return fil_io(IORequestLogRead, true,
+                page_id_t(SRV_LOG_SPACE_FIRST_ID,
+                          header >> srv_page_size_shift),
+                0, header & (srv_page_size - 1),
+                OS_FILE_LOG_BLOCK_SIZE, log_sys.checkpoint_buf, NULL);
 }
 
 /** Write checkpoint info to the log header and invoke log_mutex_exit().


### PR DESCRIPTION
…ion: success

There are many filesystem related errors that can occur with MariaBackup. These already outputed to stderr with a good description of the error. Many of these are permission or resource (file descriptor) limits where the assertion and resulting core crash doesn't offer developers anything more than the log message. To the user assertions and corecrashes come across as poor error handling.

There are other case where the operation of MariaBackup and server haven't kept status which are legitimate bugs, but the server state is more useful than the state of MariaBackup which is fairly documented in the log.

Being a change in InnoDB where it isn't the server this also changes the behavior of InnoDB utilities like innochecksum in a similar way to MariaBackup.