### PR TITLE
MDEV-6655: mysqld_multi default log location in wrong directory

### DIFF
--- a/scripts/mysqld_multi.sh
+++ b/scripts/mysqld_multi.sh
@@ -227,7 +227,7 @@ sub defaults_for_group
 
 ####
 #### Init log file. Check for appropriate place for log file, in the following
-#### order:  my_print_defaults mysqld datadir, @datadir@
+#### order:  my_print_defaults mysqld datadir, @localstatedir@
 ####
 
 sub init_log
@@ -241,7 +241,7 @@ sub init_log
   }
   if (!defined($logdir))
   {
-    $logdir= "@datadir@" if (-d "@datadir@" && -w "@datadir@");
+    $logdir= "@localstatedir@" if (-d "@localstatedir@" && -w "@localstatedir@");
   }
   if (!defined($logdir))
   {


### PR DESCRIPTION
The mysqld_multi script template used @datadir@ as default log destination, this is not the MariaDB datadir in this context though but rather the -- typically write-only -- /share dir.

The correct placeholder to use here is @localstatedir@ which gets replaced with the actual MariaDB datadir

- [x] *The Jira issue number for this PR is: MDEV-6655*

This request replaces the earlier https://github.com/MariaDB/server/pull/2109 and includes the requested changes (based on 10.11 now, and also changed the comment above the changed code)