### PR TITLE
MDEV-29684 Fixes for cluster wide write  conflict resolving

### DIFF
--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -349,13 +349,20 @@ extern "C" void wsrep_commit_ordered(THD *thd)
 
 extern "C" bool wsrep_thd_set_wsrep_aborter(THD *bf_thd, THD *victim_thd)
 {
-  WSREP_DEBUG("wsrep_thd_set_wsrep_aborter called");
   mysql_mutex_assert_owner(&victim_thd->LOCK_thd_data);
+  if (!bf_thd)
+  {
+    victim_thd->wsrep_aborter= 0;
+    WSREP_DEBUG("wsrep_thd_set_wsrep_aborter resetting wsrep_aborter");
+    return false;
+  }
   if (victim_thd->wsrep_aborter && victim_thd->wsrep_aborter != bf_thd->thread_id)
   {
     return true;
   }
-  victim_thd->wsrep_aborter = bf_thd->thread_id;
+  victim_thd->wsrep_aborter= bf_thd->thread_id;
+  WSREP_DEBUG("wsrep_thd_set_wsrep_aborter setting wsrep_aborter %u",
+              victim_thd->wsrep_aborter);
   return false;
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18711,6 +18711,13 @@ wsrep_kill_victim(
       victim_trx->lock.was_chosen_as_deadlock_victim= TRUE;
       lock_cancel_waiting_and_release(wait_lock);
     }
+  } else {
+    wsrep_thd_LOCK(thd);
+    victim_trx->lock.was_chosen_as_wsrep_victim= false;
+    wsrep_thd_set_wsrep_aborter(NULL, thd);
+    wsrep_thd_UNLOCK(thd);
+
+    WSREP_DEBUG("wsrep_thd_bf_abort has failed, victim will survive");
   }
 
   DBUG_VOID_RETURN;


### PR DESCRIPTION
Cluster conflict victim's THD is marked with wsrep_aborter. THD::wsrep_aorter holds the thread ID of the hight priority tread, which is currently carrying out BF aborting for this victim.

However, the BF abort operation is not always successful, and in such case the wsrep_aboter mark should be removed. In the old code, this wsrep_aborter resetting did not happen, and this could lead to a situation where the sticky wsrep_aborter mark prevents any further attempt to BF abort this transaction.

This commit fixes this issue, and resets wsrep_aborter after unsuccesful BF abort attempt.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29684*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Cluster conflict victim's THD is marked with wsrep_aborter. THD::wsrep_aborter holds the thread ID of the high priority tread, which is currently carrying out BF aborting for this victim.

However, the BF abort operation is not always successful, and in such case the wsrep_aborter mark should be removed. In the old code, this wsrep_aborter resetting did not happen, and this could lead to a situation where the sticky wsrep_aborter mark prevents any further attempt to BF abort this transaction.

This commit fixes this issue, and resets wsrep_aborter after unsuccessful BF abort attempt.

## How can this PR be tested?
.e.g sysbench conflicting write load against two or more nodes in the cluster, makes to issue surface

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
