### PR TITLE
MDEV-17516: Replication lag issue using parallel replication

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_mdev_17516.test
+++ b/mysql-test/suite/rpl/t/rpl_mdev_17516.test
@@ -1,0 +1,77 @@
+# test for mdev-17516
+#
+# Notes:
+#  1) This test is mainly from the JIRA page, where it has only been slightly
+# modified to be consistent and clear about the problematic report.
+#  2) There is no result file yet, because this just shows the issue for now.
+#
+
+--source include/have_innodb.inc
+--source include/have_binlog_format_mixed.inc
+--source include/master-slave.inc
+--source include/have_debug.inc
+
+# Test various aspects of parallel replication.
+
+--connection master
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+--save_master_pos
+
+--connection slave
+--sync_with_master
+--source include/stop_slave.inc
+SET GLOBAL slave_parallel_threads=4;
+--source include/start_slave.inc
+
+--connection slave
+--sync_with_master
+--source include/stop_slave.inc
+SET GLOBAL slave_parallel_threads=1;
+
+--connection master
+--disable_warnings
+INSERT INTO t1 VALUES (1, SLEEP(4));
+--echo # Sleep 2
+--sleep 2
+INSERT INTO t1 VALUES (2, SLEEP(1));
+--save_master_pos
+
+--connection slave
+set @@global.debug_dbug="+d,delay_next_io_thread_event";
+
+--echo # Lock tables so the MDL cannot commit before we read SBM
+lock tables t1 write;
+--source include/start_slave.inc
+
+--echo # BUG: First report of SBM is 0 because SHOW SLAVE STATUS sees that
+--echo # sql_thread_caught_up is true and parallel workers are not busy, as
+--echo # the relay log is empty because the IO thread is delayed.
+--let $status_items= Seconds_Behind_Master
+--source include/show_slave_status.inc
+
+--echo # Match sleep of IO thread
+sleep 3;
+--echo # SBM should now jump to real value because worker thread has work
+--let $status_items= Seconds_Behind_Master
+--source include/show_slave_status.inc
+unlock tables;
+--sync_with_master
+
+--echo # We are caught up, SBM should be 0
+--let $status_items= Seconds_Behind_Master
+--source include/show_slave_status.inc
+
+--connection master
+drop table t1;
+--save_master_pos
+
+--connection slave
+set @@global.debug_dbug="";
+--sync_with_master
+--source include/stop_slave.inc
+SET GLOBAL slave_parallel_threads=0;
+--source include/start_slave.inc
+
+--source include/rpl_end.inc

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -4807,6 +4807,10 @@ Stopping slave I/O thread due to out-of-memory error from master");
         tokenamount -= network_read_len;
       }
 
+      DBUG_EXECUTE_IF("delay_next_io_thread_event", {
+        sleep(3);
+        DBUG_SET("-d,delay_next_io_thread_event");
+      });
       if (queue_event(mi, event_buf, event_len))
       {
         mi->report(ERROR_LEVEL, ER_SLAVE_RELAY_LOG_WRITE_FAILURE, NULL,


### PR DESCRIPTION
MDEV-17516: Replication lag issue using parallel replication

Note the first commit is the regression, and the second is the
code fix

Problem:
========
If parallelism is enabled on a replica, Seconds_Behind_Master can
spike high in cases of delayed or infrequent transactions (also see
MDEV-29639). This is because a parallel slave updates
last_master_timestamp at the end of an event, rather than the
beginning, to make for a less confusing value of
Seconds_Behind_Master during times of high concurrency. However,
when dealing with delayed or infrequent transactions, then
Seconds_Behind_Master will use the last committed transaction on the
slave in its calculation, leading to potentially very large values.

Solution:
========
Add additional logic to check if an event is the first transaction
after the replica has been idle. If so, update the
last_master_timestamp value when reading the event from the relay
log.
