### PR TITLE
Misc Debian/Salsa-CI fixes

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -58,13 +58,13 @@ replace_uring_with_aio()
 {
   sed 's/liburing-dev/libaio-dev/g' -i debian/control
   sed -e '/-DIGNORE_AIO_CHECK=YES/d' \
-      -e '/-DWITH_URING=yes/d' -i debian/rules
+      -e '/-DWITH_URING=YES/d' -i debian/rules
 }
 
 disable_pmem()
 {
   sed '/libpmem-dev/d' -i debian/control
-  sed '/-DWITH_PMEM=yes/d' -i debian/rules
+  sed '/-DWITH_PMEM=YES/d' -i debian/rules
 }
 
 architecture=$(dpkg-architecture -q DEB_BUILD_ARCH)

--- a/debian/mariadb-server-10.6.mariadb.init
+++ b/debian/mariadb-server-10.6.mariadb.init
@@ -21,9 +21,18 @@ test -x /usr/sbin/mariadbd || exit 0
 
 . /lib/lsb/init-functions
 
-SELF=$(cd $(dirname $0); pwd -P)/$(basename $0)
+SELF=$(cd "$(dirname $0)"; pwd -P)/$(basename $0)
 
-MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
+if [ -f /usr/bin/mariadb-admin ]
+then
+  MYADMIN="/usr/bin/mariadb-admin --defaults-file=/etc/mysql/debian.cnf"
+elif [ -f /usr/bin/mysqladmin ]
+then
+  MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
+else
+  log_failure_msg "Command mariadb-admin/mysqladmin not found! This SysV init script depends on it."
+  exit -1
+fi
 
 # priority can be overridden and "-s" adds output to stderr
 ERR_LOGGER="logger -p daemon.err -t /etc/init.d/mariadb -i"

--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,13 @@ export DEB_BUILD_HARDENING=1
 
 # enable Debian Hardening
 # see: https://wiki.debian.org/Hardening
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all optimize=-lto
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+
+# Disable LTO on Ubuntu, see LP: #1970634 and https://jira.mariadb.org/browse/MDEV-25633
+ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes), yes)
+    export DEB_BUILD_MAINT_OPTIONS += optimize=-lto
+endif
+
 DPKG_EXPORT_BUILDFLAGS = 1
 # Include all defaults, including buildflags.mk
 include /usr/share/dpkg/default.mk

--- a/debian/rules
+++ b/debian/rules
@@ -46,11 +46,6 @@ ifeq (32,$(DEB_HOST_ARCH_BITS))
     CMAKEFLAGS += -DPLUGIN_ROCKSDB=NO
 endif
 
-# ColumnStore can build only on amd64 and arm64
-ifneq (,$(filter $(DEB_HOST_ARCH_CPU),amd64 arm64))
-    CMAKEFLAGS += -DPLUGIN_COLUMNSTORE=NO
-endif
-
 # Cross building requires stack direction instruction
 ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
     ifneq (,$(filter $(DEB_HOST_ARCH_CPU),alpha amd64 arm arm64 i386 ia64 m68k mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sh4 sparc64))

--- a/debian/rules
+++ b/debian/rules
@@ -59,7 +59,7 @@ endif
 # Only attempt to build with PMEM on archs that have package libpmem-dev available
 # See https://packages.debian.org/search?searchon=names&keywords=libpmem-dev
 ifneq (,$(filter $(DEB_HOST_ARCH_CPU),amd64 arm64 ppc64el riscv64))
-		CMAKEFLAGS += -DWITH_PMEM=yes
+    CMAKEFLAGS += -DWITH_PMEM=YES
 endif
 
 # Add support for verbose builds
@@ -100,9 +100,9 @@ endif
 	    -DBUILD_CONFIG=mysql_release \
 	    -DCONC_DEFAULT_CHARSET=utf8mb4 \
 	    -DPLUGIN_AWS_KEY_MANAGEMENT=NO \
-			-DPLUGIN_COLUMNSTORE=NO \
+	    -DPLUGIN_COLUMNSTORE=NO \
 	    -DIGNORE_AIO_CHECK=YES \
-	    -DWITH_URING=yes \
+	    -DWITH_URING=YES \
 	    -DDEB=$(DEB_VENDOR)
 
 # This is needed, otherwise 'make test' will run before binaries have been built
@@ -115,6 +115,7 @@ override_dh_auto_build:
 override_dh_auto_test:
 	@echo "RULES.$@"
 	dh_testdir
+	# Ensure at least an empty file exists
 	touch mysql-test/unstable-tests
 	[ ! -f debian/unstable-tests.$(DEB_HOST_ARCH) ] || cat debian/unstable-tests.$(DEB_HOST_ARCH) >> mysql-test/unstable-tests
 	# Run testsuite
@@ -198,6 +199,7 @@ override_dh_installinit-arch:
 	dh_installinit --name=mariadb --no-start -- defaults 19 21
 	dh_systemd_start --restart-after-upgrade
 
+# Use custom server version string variable
 override_dh_gencontrol:
 	dh_gencontrol -- -Tdebian/substvars
 

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -16,12 +16,17 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   SALSA_CI_GBP_BUILDPACKAGE_ARGS: "--git-submodules" # did not apply to extract-sources
 
+# Extend Salsa-CI build jobs to have longer timeout as the default GitLab
+# timeout (1h) is often not enough
+.build-package:
+  timeout: 3h
+
 stages:
   - provisioning
   - build
   - test
   - upgrade in Sid
-  - upgrade from Bullseye/Buster
+  - upgrade from Bullseye
   - upgrade extras
   - test extras
   - publish # Stage referenced by Salsa-CI template aptly stanza, so must exist even though not used
@@ -134,6 +139,17 @@ blhc:
   apt-get update
   apt-get install -y apt
 
+.test-enable-buster-backports-repos: &test-enable-buster-backports-repos |
+  # Enable buster-backports (assumes environment already Debian Buster)
+  echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/buster-backports.list
+  # Increase default backports priority policy from '100' to '500' so it can actually be used
+  cat << EOF > /etc/apt/preferences.d/enable-backports-to-satisfy-dependencies
+  Package: *
+  Pin: release n=buster-*
+  Pin-Priority: 500
+  EOF
+  apt-get update
+
 .test-install: &test-install |
   # Install MariaDB built in this commit
   apt-get install -y ./*.deb
@@ -213,7 +229,7 @@ fresh install:
   script:
     - *test-prepare-container
     - *test-install
-    - service mariadb status # There is no init.d/mysql in MariaDB 10.6
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -234,7 +250,7 @@ mariadb-10.6 Sid upgrade:
   script:
     - *test-prepare-container
     - *test-install
-    - service mariadb status # There is no init.d/mysql in MariaDB 10.6
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -243,7 +259,7 @@ mariadb-10.6 Sid upgrade:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
 mariadb-10.5 Bullseye to mariadb-10.6 upgrade:
-  stage: upgrade from Bullseye/Buster
+  stage: upgrade from Bullseye
   needs:
     - job: build
   image: debian:bullseye
@@ -268,10 +284,12 @@ mariadb-10.5 Bullseye to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mariadb-10.3 Buster to mariadb-10.6 upgrade:
-  stage: upgrade from Bullseye/Buster
+# Upgrade of libcrypt.so.1 no longer possible from Buster to Sid,
+# so test upgrade only inside Buster (https://bugs.debian.org/993755)
+mariadb-10.3 to mariadb-10.6 upgrade in Buster:
+  stage: upgrade extras
   needs:
-    - job: build
+    - job: build buster-backports
   image: debian:buster
   artifacts:
     when: always
@@ -284,7 +302,7 @@ mariadb-10.3 Buster to mariadb-10.6 upgrade:
     - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
     # Verify installation of MariaDB from Buster
     - *test-verify-initial
-    - *test-enable-sid-repos
+    - *test-enable-buster-backports-repos
     - *test-install
     - service mysql status
     - *test-verify-final
@@ -307,7 +325,7 @@ test basic features:
   script:
     - *test-prepare-container
     - *test-install
-    - service mariadb status # There is no init.d/mysql in MariaDB 10.6
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
     - |
       # Print info about server
@@ -452,7 +470,7 @@ default-libmysqlclient-dev Sid upgrade:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
 default-libmysqlclient-dev Bullseye upgrade:
-  stage: upgrade from Bullseye/Buster
+  stage: upgrade from Bullseye
   needs:
     - job: build
   image: debian:bullseye
@@ -472,10 +490,12 @@ default-libmysqlclient-dev Bullseye upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-default-libmysqlclient-dev Buster upgrade:
-  stage: upgrade from Bullseye/Buster
+# Upgrade of libcrypt.so.1 no longer possible from Buster to Sid,
+# so test upgrade only inside Buster (https://bugs.debian.org/993755)
+default-libmysqlclient-dev upgrade in Buster:
+  stage: upgrade extras
   needs:
-    - job: build
+    - job: build buster-backports
   image: debian:buster
   artifacts:
     when: always
@@ -486,7 +506,7 @@ default-libmysqlclient-dev Buster upgrade:
     - *test-prepare-container
     - apt-get install -y pkg-config default-libmysqlclient-dev
     - pkg-config --list-all
-    - *test-enable-sid-repos
+    - *test-enable-buster-backports-repos
     - *test-install-all-libs
     - *test-verify-libs
   except:
@@ -511,8 +531,20 @@ mysql-8.0 Sid to mariadb-10.6 upgrade:
     - apt-get install -y procps mysql-server 'libmysqlc*'
     - *test-verify-initial
     - *test-install
-    - service mysql status
+    # The Debian version of MariaDB 10.6 still maintains compatibility and there
+    # running 'service mysql status' in Salsa-CI job 'mysql-8.0 Sid to
+    # mariadb-10.6 upgrade' still works.
+    #
+    # However, due to debian/control changes, the upstream MariaDB 10.6 when
+    # installed on a system with a previous installation of MySQL 8.0 will first
+    # fully remove MySQL, including the /etc/init.d/mysql file, so previous
+    # techniques in mariadb-server-10.6.postinst to maintain backwards
+    # compatibility with 'service mysql status' after installing MariaDB on top
+    # MySQL no longer works, and thus the step to test it now intentionally has
+    # a fallback to use the service name 'mariadb' instead, and the fallback is
+    # always used.
     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+    - service mysql status || service mariadb status
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -522,7 +554,7 @@ mysql-8.0 Sid to mariadb-10.6 upgrade:
 
 # Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
 # The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
-mysql-8.0 Focal to mariadb-10.6 upgrade:
+mysql-8.0 Focal to mariadb-10.6 upgrade in Buster:
   stage: upgrade extras
   needs:
     - job: build buster-backports
@@ -582,18 +614,13 @@ mariadb.org-10.6 to mariadb-10.6 upgrade:
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mariadb status # There is no init.d/mysql in MariaDB 10.6
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
   except:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-  allow_failure: true
-  # Installation on Sid fails on missing liburing1 because upstream 10.6
-  # MariaDB.org buildbot has not run 'apt upgrade' for a long time.
-  # Remove this allow_failure once buildbot has built a new 10.6
-  # release using latest liburing-dev in Debian Sid.
 
 mariadb.org-10.5 to mariadb-10.6 upgrade:
   stage: upgrade extras
@@ -617,7 +644,7 @@ mariadb.org-10.5 to mariadb-10.6 upgrade:
     # Verify installation of MariaDB built in this commit
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
     - mariadb --version # Client version
-    - service mariadb status # There is no init.d/mysql in MariaDB 10.5
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -728,7 +755,7 @@ mariadb.org-10.2 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mysql.com-5.7 to mariadb-10.6 upgrade:
+mysql.com-5.7 to mariadb-10.6 upgrade in Buster:
   stage: upgrade extras
   needs:
     - job: build buster-backports
@@ -759,7 +786,7 @@ mysql.com-5.7 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-percona-xtradb-5.7 to mariadb-10.6 upgrade (MDEV-22679):
+percona-xtradb-5.7 to mariadb-10.6 upgrade in Buster (MDEV-22679):
   stage: upgrade extras
   needs:
     - job: build buster-backports

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -48,7 +48,7 @@ very-long-line-length-in-source-file mysql-test/std_data/init_file_longline_3816
 very-long-line-length-in-source-file scripts/fill_help_tables.sql *
 very-long-line-length-in-source-file scripts/mysql_system_tables.sql *
 very-long-line-length-in-source-file scripts/mysql_test_data_timezone.sql *
-# Machine formated HTML
+# Machine formatted HTML
 very-long-line-length-in-source-file sql/share/charsets/languages.html *
 very-long-line-length-in-source-file sql/share/errmsg-utf8.txt *
 # Very long test string

--- a/debian/tests/upstream
+++ b/debian/tests/upstream
@@ -10,6 +10,8 @@ echo "Running test 'testsuite'"
 set -e
 
 SKIP_TEST_LST="/tmp/skip-test.lst"
+ARCH=$(dpkg --print-architecture)
+
 WORKDIR=$(mktemp -d)
 trap 'rm -rf $WORKDIR $SKIP_TEST_LST' 0 INT QUIT ABRT PIPE TERM
 cd "$WORKDIR"
@@ -22,16 +24,15 @@ echo "using tmpdir: $WORKDIR/tmp"
 
 echo "Setting up skip-tests-list"
 
-touch $SKIP_TEST_LST
+# Use unstable-tests list as base to skip all tests  considered unstable
+# or create an empty file if that upstream file does not exists on this branch
+cp /usr/share/mysql/mysql-test/unstable-tests $SKIP_TEST_LST || touch $SKIP_TEST_LST
 
-# Also use arch specific skiplists if such files exist
-for filename in /usr/share/mysql/mysql-test/unstable-tests.*
-do
-  # Check for case that no files matched and glob is returned
-  [ -e "$filename" ] || continue
-  # Append file to the main skip test list file
-  cat "$filename" >> $SKIP_TEST_LST
-done
+# Also use the arch specific skiplists if exist
+if [ -f /usr/share/mysql/mysql-test/unstable-tests.$ARCH ]
+then
+  cat /usr/share/mysql/mysql-test/unstable-tests.$ARCH >> $SKIP_TEST_LST
+fi
 
 # Skip tests that cannot run properly on ci.debian.net / autopkgtests.ubuntu.com
 cat >> $SKIP_TEST_LST << EOF
@@ -48,7 +49,6 @@ main.mysqld--help : For unknown reason table-cache is 4000 instead of default 42
 EOF
 fi
 
-ARCH=$(dpkg --print-architecture)
 if [ "$ARCH" = "s390x" ]
 then
   echo "main.func_regexp_pcre : recursion fails on s390x https://bugs.launchpad.net/ubuntu/+source/mariadb-10.1/+bug/1723947" >> $SKIP_TEST_LST
@@ -56,6 +56,10 @@ elif [ "$ARCH" = "armhf" ] || [ "$ARCH" = "i386" ]
 then
   echo "main.failed_auth_unixsocket : Test returns wrong exit code on armhf and i386 (but only in debci) https://jira.mariadb.org/browse/MDEV-23933" >> $SKIP_TEST_LST
 fi
+
+# Store skipped test list in artifacts so it can be viewed while debugging
+# failed autopkgtest runs
+cp -v $SKIP_TEST_LST $AUTOPKGTEST_ARTIFACTS
 
 cd /usr/share/mysql/mysql-test
 echo "starting mysql-test-tun.pl..."


### PR DESCRIPTION
## Description

See commit messages for details of changes.

## How can this PR be tested?

Anybody can sign up for a free account at salsa.debian.org, the Gitlab instance for Debian development.

The Salsa-CI status for current 10.6 head (ab0190101b0587e0e03b2d75a967050b9a85fd1b) is visible at https://salsa.debian.org/otto/mariadb-server/-/pipelines/443617

![image](https://user-images.githubusercontent.com/668724/197418161-35cfb109-8ba5-4ec7-b651-7f43b923bbab.png)

CI status after these commits is visible at https://salsa.debian.org/otto/mariadb-server/-/pipelines/444495
![image](https://user-images.githubusercontent.com/668724/197423281-7d2d2ddf-f574-42ed-8618-6209f5a4ef98.png)

Once #2294 is merged up from branch 10.5 to 10.6 and once @illuusio completes the Lintian fixes in #2275 the CI status will be even more green as visible in the mockup at https://salsa.debian.org/otto/mariadb-server/-/pipelines/444496
![image](https://user-images.githubusercontent.com/668724/197423333-953ef4ce-e703-4e34-b209-9dfa8a15449e.png)

The last failure will be fixed if/when I finalize #2300. It is a hard one, so I wasn't able to crack it this weekend.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility

These changes only affect building and testing. Thus there are no changes in the installed MariaDB binaries and thus this is safe to do on a stable branch. Actually this improves the safety of the stable branch as it gets back the Salsa-CI test coverage it used to have.
