### PR TITLE
MDEV-16708: mtr ps_missed_cmds_bin_prot allow for updated HELP

### DIFF
--- a/mysql-test/main/ps_missed_cmds_bin_prot.result
+++ b/mysql-test/main/ps_missed_cmds_bin_prot.result
@@ -104,32 +104,11 @@ HANDLER t1 CLOSE;
 DROP TABLE t1;
 # Test case 10: Check that the statements 'HELP'
 # is supported by prepared statements
-HELP `ALTER SERVER`;
+INSERT INTO mysql.help_topic VALUES (0, 'Tamagotchi', 0, 'This digital pet is not a KB article', 'no example', 'https://tamagotchi.com/');
+HELP `Tamagotchi`;
 name	description	example
-ALTER SERVER	Syntax
-------
-
-ALTER SERVER server_name
-  OPTIONS (option [, option] ...)
-
-Description
------------
-
-Alters the server information for server_name, adjusting the specified options
-as per the CREATE SERVER command. The corresponding fields in the
-mysql.servers table are updated accordingly. This statement requires the SUPER
-privilege or, from MariaDB 10.5.2, the FEDERATED ADMIN privilege.
-
-ALTER SERVER is not written to the binary log, irrespective of the binary log
-format being used. From MariaDB 10.1.13, Galera replicates the CREATE SERVER,
-ALTER SERVER and DROP SERVER statements.
-
-Examples
---------
-
-ALTER SERVER s OPTIONS (USER 'sally');
-
-URL: mariadb.com/kb/en/alter-server/	
+Tamagotchi	This digital pet is not a KB article	no example
+DELETE FROM mysql.help_topic WHERE help_topic_id = 0;
 # Test case 11: Check that the statements CREATE/ALTER/DROP PROCEDURE
 # are supported by prepared statements
 CREATE PROCEDURE p1() SET @a=1;

--- a/mysql-test/main/ps_missed_cmds_bin_prot.test
+++ b/mysql-test/main/ps_missed_cmds_bin_prot.test
@@ -128,7 +128,10 @@ DROP TABLE t1;
 
 --echo # Test case 10: Check that the statements 'HELP'
 --echo # is supported by prepared statements
-HELP `ALTER SERVER`;
+# avoid existing articles that may get updated.
+INSERT INTO mysql.help_topic VALUES (0, 'Tamagotchi', 0, 'This digital pet is not a KB article', 'no example', 'https://tamagotchi.com/');
+HELP `Tamagotchi`;
+DELETE FROM mysql.help_topic WHERE help_topic_id = 0;
 
 --echo # Test case 11: Check that the statements CREATE/ALTER/DROP PROCEDURE
 --echo # are supported by prepared statements


### PR DESCRIPTION
We'd like to update our HELP contents independently of the test cases.

Like 5e270ca28d05acb72c6aec9f1d37f9610fc11a0e, the same concept is applied to make the MTR output of a dummy help topic is done to prove the HELP can works as a prepared statement.
