### PR TITLE
Fix building my_gethwaddr() on OpenBSD

### DIFF
--- a/mysys/my_gethwaddr.c
+++ b/mysys/my_gethwaddr.c
@@ -33,8 +33,14 @@ static my_bool memcpy_and_test(uchar *to, uchar *from, uint len)
   return res;
 }
 
-#if defined(__APPLE__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#ifdef __OpenBSD__
+#include <netinet/in.h>
+#include <net/if_arp.h>
+#include <netinet/if_ether.h>
+#else
 #include <net/ethernet.h>
+#endif
 #include <sys/sysctl.h>
 #include <net/route.h>
 #include <net/if.h>


### PR DESCRIPTION
This now builds. But I am not certain how to test this to ensure it matches actual MAC addresses of any HW interfaces. I can see that the suffix changes before and after when using ```select UUID();```.

Also when merging forward to 10.5 and newer OpenBSD needs to be added to the list of OS's for ```memcpy_and_test()```.