### PR TITLE
MDEV-29847: Wrong warning on rlimit capping of max_open_files

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4580,8 +4580,8 @@ static int init_common_variables()
     files= my_set_max_open_files(max_open_files);
     SYSVAR_AUTOSIZE_IF_CHANGED(open_files_limit, files, ulong);
 
-    if (files < wanted_files && global_system_variables.log_warnings)
-      sql_print_warning("Could not increase number of max_open_files to more than %u (request: %u)", files, wanted_files);
+    if (files < max_open_files && global_system_variables.log_warnings)
+      sql_print_warning("Could not increase number of max_open_files to more than %u (request: %u)", files, max_open_files);
 
     /* If we required too much tc_instances than we reduce */
     SYSVAR_AUTOSIZE_IF_CHANGED(tc_instances,


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29847*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Per the code my_set_max_open_files 3 lines earlier, we attempt to set the nofile (number of open files), rlimit to max_open_files.

We should use this in the warning because wanted_files may not be the number.