### PR TITLE
10.4-MDEV-29684 Fixes for cluster wide write conflict resolving

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -5229,7 +5229,8 @@ thd_need_ordering_with(const MYSQL_THD thd, const MYSQL_THD other_thd)
   */
   if (WSREP_ON &&
       wsrep_thd_is_BF(const_cast<THD *>(thd), false) &&
-      wsrep_thd_is_BF(const_cast<THD *>(other_thd), false))
+      wsrep_thd_is_BF(const_cast<THD *>(other_thd), false) &&
+      wsrep_thd_order_before(const_cast<THD *>(thd), const_cast<THD *>(other_thd)))
     return 0;
 #endif /* WITH_WSREP */
   rgi= thd->rgi_slave;


### PR DESCRIPTION
The rather recent thd_need_ordering_with() function does not take high priority transactions' order in consideration. Changed this function to compare also transaction seqnos and favor earlier transaction.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29684*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
The rather recent thd_need_ordering_with() function does not take high priority transactions' order in consideration. Changed this function to compare also transaction seqnos and favor earlier transaction.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
