### PR TITLE
Fix warning with signal typedef for *BSD

### DIFF
--- a/include/my_alarm.h
+++ b/include/my_alarm.h
@@ -31,7 +31,9 @@ extern ulong my_time_to_wait_for_lock;
 #include <signal.h>
 #ifdef HAVE_SIGHANDLER_T
 #define sig_return sighandler_t
-#elif defined(SOLARIS) || defined(__sun) || defined(__APPLE__)
+#elif defined(SOLARIS) || defined(__sun) || defined(__APPLE__) || \
+    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+    defined(__DragonFly__)
 typedef void (*sig_return)(int); /* Returns type from signal */
 #else
 typedef void (*sig_return)(void); /* Returns type from signal */


### PR DESCRIPTION
```
/usr/ports/pobj/mariadb-10.9.3/mariadb-10.9.3/mysys/my_lock.c:183:7: warning: incompatible function pointer types assigning to 'sig_return' (aka 'void (*)(void)') from 'void (*)(int)' [-Wincompatible-function-pointer-types]
      ALARM_INIT;
      ^~~~~~~~~~
/usr/ports/pobj/mariadb-10.9.3/mariadb-10.9.3/include/my_alarm.h:43:16: note: expanded from macro 'ALARM_INIT'
                        alarm_signal=signal(SIGALRM,my_set_alarm_variable);
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/ports/pobj/mariadb-10.9.3/mariadb-10.9.3/mysys/my_lock.c:189:7: warning: incompatible function pointer types passing 'sig_return' (aka 'void (*)(void)') to parameter of type 'void (*)(int)' [-Wincompatible-function-pointer-types]
      ALARM_END;
      ^~~~~~~~~
/usr/ports/pobj/mariadb-10.9.3/mariadb-10.9.3/include/my_alarm.h:44:41: note: expanded from macro 'ALARM_END'
                                              ^~~~~~~~~~~~
/usr/include/sys/signal.h:199:27: note: passing argument to parameter here
void    (*signal(int, void (*)(int)))(int);
                             ^
2 warnings generated.
```

The prototype is the same for all of the *BSD's.

```
void
(*signal(int sigcatch, void (*func)(int sigraised)))(int);
```