### PR TITLE
MDEV-29782 CONNECT YEAR type conversion fix

### DIFF
--- a/storage/connect/mysql-test/connect/r/mysql.result
+++ b/storage/connect/mysql-test/connect/r/mysql.result
@@ -364,5 +364,16 @@ hex(col)
 DROP TABLE t2;
 DROP TABLE t1;
 #
+# MDEV-29782 CONNECT engine converted YEAR to DATETIME, causing INSERT to fail
+#
+CREATE TABLE t1 (id year);
+CREATE TABLE t2 ENGINE=CONNECT TABLE_TYPE=MYSQL DBNAME='test' TABNAME='t1' OPTION_LIST='host=localhost,user=root,port=PORT';
+INSERT INTO t2 VALUES (1999);
+SELECT * FROM t2;
+id
+1999
+DROP TABLE t2;
+DROP TABLE t1;
+#
 # End of 10.3 tests
 #

--- a/storage/connect/mysql-test/connect/t/mysql.test
+++ b/storage/connect/mysql-test/connect/t/mysql.test
@@ -534,5 +534,20 @@ DROP TABLE t1;
 
 
 --echo #
+--echo # MDEV-29782 CONNECT engine converted YEAR to DATETIME, causing INSERT to fail
+--echo #
+
+CREATE TABLE t1 (id year);
+
+--replace_result $PORT PORT
+--eval CREATE TABLE t2 ENGINE=CONNECT TABLE_TYPE=MYSQL DBNAME='test' TABNAME='t1' OPTION_LIST='host=localhost,user=root,port=$PORT'
+
+INSERT INTO t2 VALUES (1999);
+SELECT * FROM t2;
+
+DROP TABLE t2;
+DROP TABLE t1;
+
+--echo #
 --echo # End of 10.3 tests
 --echo #

--- a/storage/connect/myutil.cpp
+++ b/storage/connect/myutil.cpp
@@ -183,6 +183,7 @@ int MYSQLtoPLG(int mytype, char *var)
 
   switch (mytype) {
     case MYSQL_TYPE_SHORT:
+    case MYSQL_TYPE_YEAR:
       type = TYPE_SHORT;
       break;
     case MYSQL_TYPE_LONG:
@@ -209,7 +210,6 @@ int MYSQLtoPLG(int mytype, char *var)
     case MYSQL_TYPE_TIMESTAMP:
     case MYSQL_TYPE_DATE:
     case MYSQL_TYPE_DATETIME:
-    case MYSQL_TYPE_YEAR:
     case MYSQL_TYPE_TIME:
       type = TYPE_DATE;
       break;


### PR DESCRIPTION
When using the MySQL table type the CONNECT engine converted the YEAR datatype to DATETIME for INSERT queries. This is incorrect, causing an error on the INSERT. It should be SHORT instead.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29782*

## How can this PR be tested?

Extra regression suite test added.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
N/A
