### PR TITLE
MDEV-29397 CONNECT engine: Fix note turning into error

### DIFF
--- a/storage/connect/mysql-test/connect/r/odbc_postgresql.result
+++ b/storage/connect/mysql-test/connect/r/odbc_postgresql.result
@@ -320,7 +320,7 @@ my space column
 My value
 DROP TABLE pg_in_maria;
 #
-# MDEV-29397 UPDATE with WHERE on part of two-part parimary key causes
+# MDEV-29397 UPDATE with WHERE on part of two-part primary key causes
 # info to turn into error.
 #
 CREATE TABLE t1 (a VARCHAR(6), b VARCHAR(6), PRIMARY KEY(a, b)) ENGINE=CONNECT TABNAME='schema1.t3' CHARSET=utf8 DATA_CHARSET=utf8 TABLE_TYPE=ODBC CONNECTION='DSN=ConnectEnginePostgresql;UID=mtr;PWD=mtr';

--- a/storage/connect/mysql-test/connect/r/odbc_postgresql.result
+++ b/storage/connect/mysql-test/connect/r/odbc_postgresql.result
@@ -319,3 +319,12 @@ SELECT * from pg_in_maria;
 my space column
 My value
 DROP TABLE pg_in_maria;
+#
+# MDEV-29397 UPDATE with WHERE on part of two-part parimary key causes
+# info to turn into error.
+#
+CREATE TABLE t1 (a VARCHAR(6), b VARCHAR(6), PRIMARY KEY(a, b)) ENGINE=CONNECT TABNAME='schema1.t3' CHARSET=utf8 DATA_CHARSET=utf8 TABLE_TYPE=ODBC CONNECTION='DSN=ConnectEnginePostgresql;UID=mtr;PWD=mtr';
+UPDATE t1 SET a='10' WHERE a='20';
+Warnings:
+Note	1105	schema1.t3: 0 affected rows
+DROP TABLE t1;

--- a/storage/connect/mysql-test/connect/t/odbc_postgresql.test
+++ b/storage/connect/mysql-test/connect/t/odbc_postgresql.test
@@ -223,3 +223,12 @@ DROP TABLE t1;
 CREATE TABLE pg_in_maria ENGINE=CONNECT TABNAME='schema1.space_in_column_name' CHARSET=utf8 DATA_CHARSET=utf8 TABLE_TYPE=ODBC CONNECTION='DSN=ConnectEnginePostgresql;UID=mtr;PWD=mtr' quoted=1;
 SELECT * from pg_in_maria;
 DROP TABLE pg_in_maria;
+
+--echo #
+--echo # MDEV-29397 UPDATE with WHERE on part of two-part parimary key causes
+--echo # info to turn into error.
+--echo #
+CREATE TABLE t1 (a VARCHAR(6), b VARCHAR(6), PRIMARY KEY(a, b)) ENGINE=CONNECT TABNAME='schema1.t3' CHARSET=utf8 DATA_CHARSET=utf8 TABLE_TYPE=ODBC CONNECTION='DSN=ConnectEnginePostgresql;UID=mtr;PWD=mtr';
+UPDATE t1 SET a='10' WHERE a='20';
+DROP TABLE t1;
+

--- a/storage/connect/mysql-test/connect/t/odbc_postgresql.test
+++ b/storage/connect/mysql-test/connect/t/odbc_postgresql.test
@@ -225,7 +225,7 @@ SELECT * from pg_in_maria;
 DROP TABLE pg_in_maria;
 
 --echo #
---echo # MDEV-29397 UPDATE with WHERE on part of two-part parimary key causes
+--echo # MDEV-29397 UPDATE with WHERE on part of two-part primary key causes
 --echo # info to turn into error.
 --echo #
 CREATE TABLE t1 (a VARCHAR(6), b VARCHAR(6), PRIMARY KEY(a, b)) ENGINE=CONNECT TABNAME='schema1.t3' CHARSET=utf8 DATA_CHARSET=utf8 TABLE_TYPE=ODBC CONNECTION='DSN=ConnectEnginePostgresql;UID=mtr;PWD=mtr';

--- a/storage/connect/odbconn.cpp
+++ b/storage/connect/odbconn.cpp
@@ -2582,7 +2582,7 @@ int ODBConn::Rewind(char *sql, ODBCCOL *tocols)
   int rc, rbuf = -1;
 
   if (!m_hstmt)
-    rbuf = -1;
+    rbuf = 0;
   else if (m_Full)
     rbuf = m_Rows;           // No need to "rewind"
   else if (m_Scrollable) {

--- a/storage/connect/tabext.cpp
+++ b/storage/connect/tabext.cpp
@@ -473,7 +473,7 @@ bool TDBEXT::MakeSQL(PGLOBAL g, bool cnt)
 			my_len= res - buf + 1;
 			my_schema_table= (char *) malloc(my_len);
 			memcpy(my_schema_table, buf, my_len - 1);
-			my_schema_table[my_len] = 0;
+			my_schema_table[my_len - 1] = 0;
 			Query->Append(Quote);
 			Query->Append(my_schema_table);
 			Query->Append(Quote);
@@ -481,7 +481,7 @@ bool TDBEXT::MakeSQL(PGLOBAL g, bool cnt)
 			Query->Append(".");
 			// Parse table
 			my_len= strlen(buf) - my_len + 1;
-			my_schema_table= (char *) malloc(my_len);
+			my_schema_table= (char *) malloc(my_len + 1);
 			memcpy(my_schema_table, ++res, my_len);
 			my_schema_table[my_len] = 0;
 			Query->Append(Quote);


### PR DESCRIPTION
ODBC Rewind triggered an error with no SQL, but this is sometimes a valid condition (as can be seen with other classes). Setting this to a 0 return stops errors firing when they shouldn't.

Also fixes ASAN hits from in MDEV-29687 tabext.cpp.

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29397*

## How can this PR be tested?

Additional MTR test added, to test the additional MDEV-29687 fix, run the CONNECT PostgreSQL ODBC test under ASAN.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

