### PR TITLE
service_encryption.h HAVE_ALLOC_H was global

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ import_executables.cmake
 include/*.h.tmp
 include/config.h
 include/my_config.h
+include/mysql/service_encryption.h
 include/mysql_version.h
 include/mysqld_ername.h
 include/mysqld_error.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,6 +490,8 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/include/mysql_version.h.in
                ${CMAKE_BINARY_DIR}/include/mysql_version.h )
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/sql/sql_builtin.cc.in
     ${CMAKE_BINARY_DIR}/sql/sql_builtin.cc)
+CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/include/mysql/service_encryption.h.in
+               ${CMAKE_BINARY_DIR}/include/mysql/service_encryption.h)
 
 IF(GIT_EXECUTABLE AND EXISTS ${PROJECT_SOURCE_DIR}/.git)
   EXECUTE_PROCESS(

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(HEADERS_GEN_CONFIGURE
   mysqld_ername.h
   mysqld_error.h
   sql_state.h
+  mysql/service_encryption.h
 )
 
 SET(HEADERS 

--- a/include/mysql/service_encryption.h.in
+++ b/include/mysql/service_encryption.h.in
@@ -36,6 +36,7 @@ extern "C" {
 #endif
 #else
 #include <stdlib.h>
+#cmakedefine HAVE_ALLOCA_H 1
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #endif


### PR DESCRIPTION
Rather than global include for header files, we use cmake to make service_encryption.h a generated file and populate it with the discovery of ALLOCA_H or not.

Fixes: #2289
Closes: #2321