### PR TITLE
MDEV-29512 deadlock between commit monitor and THD::LOCK_thd_data mutex

### DIFF
--- a/mysql-test/suite/galera/r/galera_MDEV-29512.result
+++ b/mysql-test/suite/galera/r/galera_MDEV-29512.result
@@ -1,0 +1,40 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 int, f3 varchar(2000));
+INSERT INTO t1 VALUES (1, 0, REPEAT('1234567890', 200));
+INSERT INTO t1 VALUES (3, 3, REPEAT('1234567890', 200));
+SET SESSION wsrep_sync_wait=0;
+SET GLOBAL DEBUG_DBUG = "d,sync.wsrep_apply_cb";
+connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connection node_1a;
+SET SESSION wsrep_sync_wait=0;
+connection node_1;
+begin;
+select f1,f2 from t1;
+f1	f2
+1	0
+3	3
+connection node_2;
+UPDATE t1 SET f2=2 WHERE f1=3;
+connection node_1a;
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+connection node_1;
+UPDATE t1 SET f2=1 WHERE f1=3;
+SET GLOBAL wsrep_provider_options = 'dbug=d,commit_monitor_master_enter_sync';
+COMMIT;
+connection node_1a;
+SET SESSION wsrep_on = 0;
+SET SESSION wsrep_on = 1;
+SET GLOBAL wsrep_provider_options = 'dbug=';
+SET GLOBAL wsrep_provider_options = 'signal=commit_monitor_master_enter_sync';
+SET GLOBAL DEBUG_DBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug_dbug = NULL;
+SET debug_sync='RESET';
+connection node_1;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+select f1,f2 from t1;
+f1	f2
+1	0
+3	2
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_MDEV-29512.cnf
+++ b/mysql-test/suite/galera/t/galera_MDEV-29512.cnf
@@ -1,0 +1,15 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+log-bin
+log-slave-updates
+
+[mysqld.1]
+log_bin
+log_slave_updates
+max-binlog-size=4096
+expire-logs-days=1
+
+
+[mysqld.2]
+

--- a/mysql-test/suite/galera/t/galera_MDEV-29512.test
+++ b/mysql-test/suite/galera/t/galera_MDEV-29512.test
@@ -1,0 +1,91 @@
+#
+# This test is for reproducing the issue in:
+# https://jira.mariadb.org/browse/MDEV-29512
+#
+# The hanging in MDEV-29512 happens when binlog purging is attempted, and there is
+# one local BF aborted transaction waiting for commit monitor.
+#
+# The test will launch two node cluster and enable binlogging with expire log days,
+# to force binlog purging to happen.
+# A local transaction is executed so that will become BF abort victim, and has advanced
+# to replication stage waiting for commit monitor for final cleanup (to mark position in innodb)
+# after that, applier is released to complete the BF abort and due to binlog configuration,
+# starting the binlog purging. This is where the hanging would occur, if code is buggy
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+--source include/galera_have_debug_sync.inc
+
+#
+# binlog size is limited to 4096 bytes, we will create enough events to
+# cause binlog rotation
+#
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 int, f3 varchar(2000));
+INSERT INTO t1 VALUES (1, 0, REPEAT('1234567890', 200));
+INSERT INTO t1 VALUES (3, 3, REPEAT('1234567890', 200));
+
+SET SESSION wsrep_sync_wait=0;
+
+# set sync point for replication applier
+SET GLOBAL DEBUG_DBUG = "d,sync.wsrep_apply_cb";
+
+# Control connection to manage sync points for appliers
+--connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connection node_1a
+SET SESSION wsrep_sync_wait=0;
+
+# starting local transaction, only select so far,
+# write will happen later and this will be ordered after the transaction in node_2
+--connection node_1
+begin;
+select f1,f2 from t1;
+
+# send from node 2 an UPDATE transaction,  which will BF abort the transaction in node_1
+--connection node_2
+--let $wait_condition=select count(*)=2 from t1
+--source include/wait_condition.inc
+
+UPDATE t1 SET f2=2 WHERE f1=3;
+
+--connection node_1a
+# wait to see the UPDATE from node_2 in apply_cb sync point
+SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+
+--connection node_1
+# now issuing conflicting update
+UPDATE t1 SET f2=1 WHERE f1=3;
+
+# Block the local commit, send final COMMIT and wait until it gets blocked
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_set_sync_point.inc
+--send COMMIT
+
+--connection node_1a
+# wait for the local commit to enter in commit monitor wait state
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_wait_sync_point.inc
+--source include/galera_clear_sync_point.inc
+
+# release the local transaction to continue with commit
+--let $galera_sync_point = commit_monitor_master_enter_sync
+--source include/galera_signal_sync_point.inc
+
+# and now release the applier, it should force local trx to abort
+SET GLOBAL DEBUG_DBUG = "";
+SET DEBUG_SYNC = "now SIGNAL signal.wsrep_apply_cb";
+SET GLOBAL debug_dbug = NULL;
+SET debug_sync='RESET';
+
+--connection node_1
+--error ER_LOCK_DEADLOCK
+--reap
+
+# wait until applying is complete
+--let $wait_condition = SELECT COUNT(*)=1 FROM t1 WHERE f2=2
+--source include/wait_condition.inc
+
+# final read to verify what we got
+select f1,f2 from t1;
+
+DROP TABLE t1;


### PR DESCRIPTION
This commit contains only a mtr test for reproducing the issue in MDEV-29512 The actual fix will be pushed in wsrep-lib repository

The hanging in MDEV-29512 happens when binlog purging is attempted, and there is one local BF aborted transaction waiting for commit monitor.

The test will launch two node cluster and enable binlogging with expire log days, to force binlog purging to happen.
A local transaction is executed so that will become BF abort victim, and has advanced to replication stage waiting for commit monitor for final cleanup (to mark position in innodb). After that, applier is released to complete the BF abort and due to binlog configuration, starting the binlog purging. This is where the hanging would occur, if code is buggy

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29512*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
The fix, in wsrep-lib, will make sure that any gtid sync wait happens without holding THD::LOCK_thd_data

## How can this PR be tested?
PR contains a mtr test to be used for regression testing

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
As the fix is in wsrep-lib, it will be included in all versions 10.4 and up