### PR TITLE
OS detection logic in my_gethwaddr.c is backwards

### DIFF
--- a/mysys/my_gethwaddr.c
+++ b/mysys/my_gethwaddr.c
@@ -116,7 +116,7 @@ my_bool my_gethwaddr(uchar *to)
     uint i;
     for (i= 0; res && i < ifc.ifc_len / sizeof(ifr[0]); i++)
     {
-#if !defined(_AIX) || !defined(__linux__)
+#if defined(_AIX) || defined(__linux__)
 #if defined(__linux__)
 #define HWADDR_DATA ifr[i].ifr_hwaddr.sa_data
 #else


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
OS detection logic in my_gethwaddr.c is backwards. `#if !defined(_AIX) || !defined(__linux__)` evaluates to true on any platform.

## How can this PR be tested?

Building mariadb on an illumos (OpenSolaris based) operating system works; w/o this patch it fails.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->