### PR TITLE
MDEV-29878 Galera test failure on MDEV-26575

### DIFF
--- a/mysql-test/suite/galera/t/MDEV-25389.test
+++ b/mysql-test/suite/galera/t/MDEV-25389.test
@@ -11,3 +11,8 @@ SELECT @@wsrep_slave_threads;
 SET GLOBAL debug_dbug='';
 SET GLOBAL wsrep_slave_threads=1;
 SELECT @@wsrep_slave_threads;
+
+# MDEV-29878: this test caused a subsequent test to fail
+# during shutdown. Do a restart here, to make sure the
+# issue is fixed.
+--source include/restart_mysqld.inc

--- a/sql/wsrep_thd.cc
+++ b/sql/wsrep_thd.cc
@@ -23,8 +23,7 @@
 #include "rpl_rli.h"
 #include "log_event.h"
 #include "sql_parse.h"
-#include "mysqld.h"   // start_wsrep_THD();
-#include "wsrep_applier.h"   // start_wsrep_THD();
+#include "wsrep_mysqld.h"   // start_wsrep_THD();
 #include "mysql/service_wsrep.h"
 #include "debug_sync.h"
 #include "slave.h"


### PR DESCRIPTION
Test MDEV-26575 fails when it runs after MDEV-25389. This is because the latter simulates a failure while an applier thread is created in `start_wsrep_THD()`. The failure was not handled correctly and would not cleanup the created THD from the global `server_threads`. A subsequent shutdown would hang and eventually fail trying to close this THD.
