### PR TITLE
Restore auto increment offset in test galera_join_with_cc_A

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_join_with_cc_A.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_join_with_cc_A.result
@@ -1,6 +1,9 @@
 connection node_2;
 connection node_1;
 connection node_1;
+connection node_2;
+connection node_3;
+connection node_1;
 CREATE TABLE t1 (pk INT PRIMARY KEY, node INT) ENGINE=innodb;
 INSERT INTO t1 VALUES (1, 1);
 connection node_2;

--- a/mysql-test/suite/galera_3nodes/t/galera_join_with_cc_A.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_join_with_cc_A.test
@@ -15,6 +15,11 @@
 --let $galera_server_number = 3
 --source include/galera_connect.inc
 
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
 --connection node_1
 --let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 --source include/wait_condition.inc
@@ -260,3 +265,5 @@ call mtr.add_suppression("WSREP: Rejecting JOIN message from \(.*\): new State T
 
 --connection node_3
 call mtr.add_suppression("WSREP: Rejecting JOIN message from \(.*\): new State Transfer required.");
+
+--source ../galera/include/auto_increment_offset_restore.inc


### PR DESCRIPTION
Restore auto increment offset at the end of test galera_join_with_cc_A to avoid side effects during check test case phase. 