### PR TITLE
Gitlab-CI: Upgrade Fedora build to always use latest (now 37) version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,9 +28,12 @@ stages:
   - test
   - Salsa-CI
 
-# Base image for builds and tests unless otherwise defined
-# @TODO: Fedora 34 is latest, but fails to start on Gitlab.com with error "shell not found"
-image: fedora:33
+default:
+  # Base image for builds and tests unless otherwise defined
+  image: fedora:latest
+  # Extend build jobs to have longer timeout as the default GitLab
+  # timeout (1h) is often not enough
+  timeout: 3h
 
 # Define common CMAKE_FLAGS for all builds. Skim down build by omitting all
 # submodules (a commit in this repo does not affect their builds anyway) and
@@ -427,14 +430,14 @@ fedora upgrade:
   dependencies:
     - fedora
   script:
-    - yum install -y mariadb-server
+    - dnf install -y mariadb-server
     # Fedora does not support running services in Docker (like Debian packages do) so start it manually
-    - /usr/libexec/mysql-check-socket
-    - /usr/libexec/mysql-prepare-db-dir
-    - sudo -u mysql /usr/libexec/mysqld --basedir=/usr & sleep 10
+    - /usr/libexec/mariadb-check-socket
+    - /usr/libexec/mariadb-prepare-db-dir
+    - sudo -u mysql /usr/libexec/mariadbd --basedir=/usr & sleep 10
     # Dump database contents in installed state
     - mariadb-dump --all-databases --all-tablespaces --triggers --routines --events --skip-extended-insert > old-installed-database.sql
-    - /usr/libexec/mysql-check-upgrade
+    - /usr/libexec/mariadb-check-upgrade
     # Dump database contents in upgraded state
     - mariadb-dump --all-databases --all-tablespaces --triggers --routines --events --skip-extended-insert > old-upgraded-database.sql
     - mariadb --skip-column-names -e "SELECT @@version, @@version_comment"  # Show version


### PR DESCRIPTION
## Description

The version was fixed to be Fedora 36 due to previous issues on Gitlab-CI,
but those seem to be solved now.

Use 'mariadb' name in scripts and server binary as Fedora switched name in
https://src.fedoraproject.org/rpms/mariadb/c/df76620f9e8a9b3f14da8a615050feeac2c62e26

Switch to using the `default:` section supported by newer Gitlab-CI,
see https://docs.gitlab.com/ee/ci/yaml/#default.

Also define an explicit timeout of 3 hours to ensure builds don't time out
if the default timeout is too short.

NOTE TO MERGERS: These changes are version independent and should be
merged up on all MariaDB branches 10.6 -> 10.11.

## How can this PR be tested?

Gitlab-CI passing at:
* https://salsa.debian.org/otto/mariadb-server/-/pipelines/458208
* https://gitlab.com/ottok/mariadb/-/pipelines/700286605

![image](https://user-images.githubusercontent.com/668724/202943438-78bea394-ff22-42f2-a665-ed6a575cf9fb.png)

(test failure on `bad_startup_options` already existed and filed as [MDEV-30002](https://jira.mariadb.org/browse/MDEV-30002))

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility

This only affects CI, so it is safe and appropriate to apply it on the oldest branch that has `.gitlab-ci.yml` and merge it upwards from there.