### PR TITLE
MDEV-30065: mariadb-install-db allow for --enforce-storage-engine=InnoDB

### DIFF
--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -5646,14 +5646,14 @@ dict_table_schema_check(
 		/* no such table */
 
 		if (innobase_strcasecmp(req_schema->table_name, "mysql/innodb_table_stats") == 0) {
-			if (innodb_table_stats_not_found_reported == false) {
+			if (innodb_table_stats_not_found_reported == false && !opt_bootstrap) {
 				innodb_table_stats_not_found = true;
 				innodb_table_stats_not_found_reported = true;
 			} else {
 				should_print = false;
 			}
 		} else if (innobase_strcasecmp(req_schema->table_name, "mysql/innodb_index_stats") == 0 ) {
-			if (innodb_index_stats_not_found_reported == false) {
+			if (innodb_index_stats_not_found_reported == false && !opt_bootstrap) {
 				innodb_index_stats_not_found = true;
 				innodb_index_stats_not_found_reported = true;
 			} else {

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -3293,7 +3293,8 @@ dict_stats_update(
 			or is corrupted, calculate the transient stats */
 
 			if (innodb_table_stats_not_found == false &&
-			    table->stats_error_printed == false) {
+			    table->stats_error_printed == false &&
+			    !opt_bootstrap) {
 				ib::error() << "Fetch of persistent statistics"
 					" requested for table "
 					<< table->name


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30064*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Hide the errors related to missing innodb stats tables in bootstrap mode on the assumption that because we are in bootstrap mode they are going to be created.

## How can this PR be tested?

```
$ mkdir -p /tmp/${PWD##*/}-datadir && scripts/mysql_install_db --no-defaults --srcdir=$OLDPWD --builddir=$PWD --datadir=/tmp/${PWD##*/}-datadir --verbose --enforce-storage-engine=InnoDB
Installing MariaDB/MySQL system tables in '/tmp/build-mariadb-server-10.4-datadir' ...
2022-11-22 13:55:55 0 [Note] /home/dan/repos/build-mariadb-server-10.4/sql/mysqld (mysqld 10.4.28-MariaDB) starting as process 194910 ...
2022-11-22 13:55:55 0 [Note] InnoDB: Using Linux native AIO
2022-11-22 13:55:55 0 [Note] InnoDB: The first innodb_system data file 'ibdata1' did not exist. A new tablespace will be created!
2022-11-22 13:55:55 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2022-11-22 13:55:55 0 [Note] InnoDB: Uses event mutexes
2022-11-22 13:55:55 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
2022-11-22 13:55:55 0 [Note] InnoDB: Number of pools: 1
2022-11-22 13:55:55 0 [Note] InnoDB: Using SSE2 crc32 instructions
2022-11-22 13:55:55 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
2022-11-22 13:55:55 0 [Note] InnoDB: Completed initialization of buffer pool
2022-11-22 13:55:55 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
2022-11-22 13:55:55 0 [Note] InnoDB: Setting file './ibdata1' size to 12 MB. Physically writing the file full; Please wait ...
2022-11-22 13:55:55 0 [Note] InnoDB: File './ibdata1' size is now 12 MB.
2022-11-22 13:55:55 0 [Note] InnoDB: Setting log file ./ib_logfile101 size to 50331648 bytes
2022-11-22 13:55:55 0 [Note] InnoDB: Setting log file ./ib_logfile1 size to 50331648 bytes
2022-11-22 13:55:55 0 [Note] InnoDB: Renaming log file ./ib_logfile101 to ./ib_logfile0
2022-11-22 13:55:55 0 [Note] InnoDB: New log files created, LSN=11451
2022-11-22 13:55:55 0 [Note] InnoDB: Doublewrite buffer not found: creating new
2022-11-22 13:55:55 0 [Note] InnoDB: Doublewrite buffer created
2022-11-22 13:55:55 0 [Note] InnoDB: 128 out of 128 rollback segments are active.
2022-11-22 13:55:55 0 [Note] InnoDB: Creating foreign key constraint system tables.
2022-11-22 13:55:55 0 [Note] InnoDB: Creating tablespace and datafile system tables.
2022-11-22 13:55:55 0 [Note] InnoDB: Creating sys_virtual system tables.
2022-11-22 13:55:55 0 [Note] InnoDB: Creating shared tablespace for temporary tables
2022-11-22 13:55:55 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
2022-11-22 13:55:55 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
2022-11-22 13:55:55 0 [Note] InnoDB: 10.4.28 started; log sequence number 0; transaction id 7
OK
```

No errors displayed.


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

The error code under bootstrap is changed from `DB_TABLE_NOT_FOUND` to `DB_STATS_DO_NOT_EXIST`, but nothing is likely to look at it.