### PR TITLE
MDEV-30065 "mariadb-install-db --enforce-storage-engine=InnoDB" fails with InnoDB errors

### DIFF
--- a/mysql-test/suite/innodb/r/foreign_key.result
+++ b/mysql-test/suite/innodb/r/foreign_key.result
@@ -979,4 +979,27 @@ t2	CREATE TABLE `t2` (
   CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`a`) REFERENCES `t1` (`a`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop tables t2, t1;
+#
+# MDEV-30065 "mariadb-install-db --enforce-storage-engine=InnoDB" fails with InnoDB errors
+#
+use mysql;
+rename table help_topic    to ht;
+rename table help_keyword  to hk;
+rename table help_category to hc;
+rename table help_relation to hr;
+CREATE TABLE help_topic ( help_topic_id int unsigned not null, name char(64) not null, help_category_id smallint unsigned not null, description text not null, example text not null, url text not null, primary key (help_topic_id), unique index (name) ) engine=InnoDB CHARACTER SET utf8 comment='help topics';
+CREATE TABLE help_category ( help_category_id smallint unsigned not null, name  char(64) not null, parent_category_id smallint unsigned null, url text not null, primary key (help_category_id), unique index (name) ) engine=InnoDB CHARACTER SET utf8 comment='help categories';
+CREATE TABLE help_keyword (   help_keyword_id  int unsigned not null, name char(64) not null, primary key (help_keyword_id), unique index (name) ) engine=InnoDB CHARACTER SET utf8 comment='help keywords';
+CREATE TABLE help_relation ( help_topic_id int unsigned not null references help_topic, help_keyword_id  int unsigned not null references help_keyword, primary key (help_keyword_id, help_topic_id) ) engine=InnoDB CHARACTER SET utf8 comment='keyword-topic relation';
+lock table mysql.help_category write, mysql.help_keyword write;
+unlock tables;
+drop table help_relation;
+drop table help_topic;
+drop table help_keyword;
+drop table help_category;
+rename table ht to help_topic;
+rename table hk to help_keyword;
+rename table hc to help_category;
+rename table hr to help_relation;
+use test;
 # End of 10.5 tests

--- a/mysql-test/suite/innodb/t/foreign_key.test
+++ b/mysql-test/suite/innodb/t/foreign_key.test
@@ -1006,6 +1006,36 @@ alter table t2 add foreign key(a) references t1;
 show create table t2;
 drop tables t2, t1;
 
+
+--echo #
+--echo # MDEV-30065 "mariadb-install-db --enforce-storage-engine=InnoDB" fails with InnoDB errors
+--echo #
+
+use mysql;
+
+rename table help_topic    to ht;
+rename table help_keyword  to hk;
+rename table help_category to hc;
+rename table help_relation to hr;
+
+CREATE TABLE help_topic ( help_topic_id int unsigned not null, name char(64) not null, help_category_id smallint unsigned not null, description text not null, example text not null, url text not null, primary key (help_topic_id), unique index (name) ) engine=InnoDB CHARACTER SET utf8 comment='help topics';
+CREATE TABLE help_category ( help_category_id smallint unsigned not null, name  char(64) not null, parent_category_id smallint unsigned null, url text not null, primary key (help_category_id), unique index (name) ) engine=InnoDB CHARACTER SET utf8 comment='help categories';
+CREATE TABLE help_keyword (   help_keyword_id  int unsigned not null, name char(64) not null, primary key (help_keyword_id), unique index (name) ) engine=InnoDB CHARACTER SET utf8 comment='help keywords';
+CREATE TABLE help_relation ( help_topic_id int unsigned not null references help_topic, help_keyword_id  int unsigned not null references help_keyword, primary key (help_keyword_id, help_topic_id) ) engine=InnoDB CHARACTER SET utf8 comment='keyword-topic relation';
+
+lock table mysql.help_category write, mysql.help_keyword write;
+unlock tables;
+
+drop table help_relation;
+drop table help_topic;
+drop table help_keyword;
+drop table help_category;
+rename table ht to help_topic;
+rename table hk to help_keyword;
+rename table hc to help_category;
+rename table hr to help_relation;
+use test;
+
 --echo # End of 10.5 tests
 
 --source include/wait_until_count_sessions.inc

--- a/scripts/mysql_system_tables.sql
+++ b/scripts/mysql_system_tables.sql
@@ -127,10 +127,10 @@ CREATE TABLE IF NOT EXISTS help_topic ( help_topic_id int unsigned not null, nam
 CREATE TABLE IF NOT EXISTS help_category ( help_category_id smallint unsigned not null, name  char(64) not null, parent_category_id smallint unsigned null, url text not null, primary key (help_category_id), unique index (name) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='help categories';
 
 
-CREATE TABLE IF NOT EXISTS help_relation ( help_topic_id int unsigned not null references help_topic, help_keyword_id  int unsigned not null references help_keyword, primary key (help_keyword_id, help_topic_id) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='keyword-topic relation';
-
-
 CREATE TABLE IF NOT EXISTS help_keyword (   help_keyword_id  int unsigned not null, name char(64) not null, primary key (help_keyword_id), unique index (name) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='help keywords';
+
+
+CREATE TABLE IF NOT EXISTS help_relation ( help_topic_id int unsigned not null references help_topic, help_keyword_id  int unsigned not null references help_keyword, primary key (help_keyword_id, help_topic_id) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='keyword-topic relation';
 
 
 CREATE TABLE IF NOT EXISTS time_zone_name (   Name char(64) NOT NULL, Time_zone_id int unsigned NOT NULL, PRIMARY KEY /*Name*/ (Name) ) engine=Aria transactional=1 CHARACTER SET utf8   comment='Time zone names';


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30065*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

These errors derive from the system help tables.

For a very long time mysql.help_relation has been defined with FK references to help_topic and help_keyword. With Aria as the default storage engine these where ignored. With InnoDB as the forced default the help_relation was created before help_keyword resulting in an inability for InnoDB to resolve the resolution of references.

The second problem was in fill_help_tables, the SQL:

  lock tables help_topic write, help_category write, help_keyword write, help_relation write;

Since 10.5, InnoDB reports the FK constraints on help_relation and will add a second READ lock on help_keyword.

The ER_WRONG_LOCK_OF_SYSTEM_TABLE error occurs in lock_tables_check as there are now a list of read and write locks on system tables.

We relax this criteria such that if there are write locks on system tables, provided the all the other tables are both system tables and READ locks that is ok.

## How can this PR be tested?

Adds MTR cases.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
