### PR TITLE
[MDEV-30002] Skip bad_startup_options test when running as root

### DIFF
--- a/mysql-test/main/bad_startup_options.test
+++ b/mysql-test/main/bad_startup_options.test
@@ -1,3 +1,6 @@
+# mysqld refuses to run as root normally.
+--source include/not_as_root.inc
+
 --source include/not_embedded.inc
 --source include/have_ssl_communication.inc
 


### PR DESCRIPTION
## Description
Commit 32158be added a new test `bad_startup_options`. This test fails
if run as root, which is common on many CI systems.

This test should include `not_as_root.inc` so it is skipped, just
like all other similar tests in MariaDB.

## How can this PR be tested?
All existing test cases should still be passing in Buildbot as well as GitLab-CI.
`bad_startup_options` is labelled as `[ skipped ]` in CI but when run locally (as non-root user, e.g., mysql) is marked as `[ pass ]`.

## Basing the PR against the correct MariaDB version
- [x] This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced.

## Backward compatibility
This bug fix should be fully backward-compatible

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.