### PR TITLE
[MDEV-16735] Ensure mysql_upgrade works when changing alter_algorithm

### DIFF
--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -920,4 +920,63 @@ GRANT USAGE ON *.* TO `user3`@`%`
 GRANT ALL PRIVILEGES ON `roelt`.`test2` TO `user3`@`%`
 DROP USER 'user3'@'%';
 update mysql.db set Delete_history_priv='Y' where db like 'test%';
+#
+# MDEV-16735 Upgrades only work if 'alter_algorithm' is 'DEFAULT'
+# or 'COPY'. Test that the session value 'DEFAULT' in mysql_upgrade
+# properly overrides the potentially incompatible global value.
+#
+SET GLOBAL alter_algorithm='INPLACE';
+SHOW GLOBAL VARIABLES LIKE 'alter_algorithm';
+Variable_name	Value
+alter_algorithm	INPLACE
+Phase 1/7: Checking and upgrading mysql database
+Processing databases
+mysql
+mysql.column_stats                                 OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.gtid_slave_pos                               OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.host                                         OK
+mysql.index_stats                                  OK
+mysql.innodb_index_stats                           OK
+mysql.innodb_table_stats                           OK
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.roles_mapping                                OK
+mysql.servers                                      OK
+mysql.table_stats                                  OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.transaction_registry                         OK
+mysql.user                                         OK
+Phase 2/7: Installing used storage engines... Skipped
+Phase 3/7: Fixing views
+Phase 4/7: Running 'mysql_fix_privilege_tables'
+Phase 5/7: Fixing table and database names
+Phase 6/7: Checking and upgrading tables
+Processing databases
+information_schema
+mtr
+mtr.global_suppressions                            OK
+mtr.test_suppressions                              OK
+performance_schema
+test
+Phase 7/7: Running 'FLUSH PRIVILEGES'
+OK
+SET GLOBAL alter_algorithm=DEFAULT;
+SHOW GLOBAL VARIABLES LIKE 'alter_algorithm';
+Variable_name	Value
+alter_algorithm	DEFAULT
 End of 10.3 tests

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -381,4 +381,17 @@ SHOW GRANTS FOR 'user3'@'%';
 DROP USER 'user3'@'%';
 update mysql.db set Delete_history_priv='Y' where db like 'test%';
 
+--echo #
+--echo # MDEV-16735 Upgrades only work if 'alter_algorithm' is 'DEFAULT'
+--echo # or 'COPY'. Test that the session value 'DEFAULT' in mysql_upgrade
+--echo # properly overrides the potentially incompatible global value.
+--echo #
+
+SET GLOBAL alter_algorithm='INPLACE';
+SHOW GLOBAL VARIABLES LIKE 'alter_algorithm';
+--exec $MYSQL_UPGRADE --force 2>&1
+SET GLOBAL alter_algorithm=DEFAULT;
+SHOW GLOBAL VARIABLES LIKE 'alter_algorithm';
+--remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+
 --echo End of 10.3 tests

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -27,7 +27,7 @@
 set sql_mode='';
 set storage_engine=MyISAM;
 set enforce_storage_engine=NULL;
-set alter_algorithm=DEFAULT;
+set alter_algorithm='DEFAULT';
 
 ALTER TABLE user add File_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL;
 


### PR DESCRIPTION
## Description

MDEV-16735 describes how mysql_upgrade fails when alter_algorithm
is set to a value different than DEFAULT/COPY. It was marked as
fixed by 0ee08683, but there was a typo in it. This commit
fix the typo and add MTRs to ensure the fix is working properly.

```
MariaDB [(none)]> set alter_algorithm=DEFAULT;
Query OK, 0 rows affected (0.000 sec)

MariaDB [(none)]> show variables like 'alter_algorithm';
+-----------------+---------+
| Variable_name   | Value   |
+-----------------+---------+
| alter_algorithm | INPLACE |
+-----------------+---------+
1 row in set (0.001 sec)

MariaDB [(none)]> set alter_algorithm='DEFAULT';
Query OK, 0 rows affected (0.000 sec)

MariaDB [(none)]> show variables like 'alter_algorithm';
+-----------------+---------+
| Variable_name   | Value   |
+-----------------+---------+
| alter_algorithm | DEFAULT |
+-----------------+---------+
1 row in set (0.001 sec)
```

**NOTE:** I will work on a follow up PR with the changes for making `set alter_algorithm=DEFAULT;` query fail with the corresponding error message.

## How can this PR be tested?
The corresponding MTR test has been added, so just running the MTR tests as below should be enough (any other test should work as before):

```
./mtr main.mysql_upgrade
```

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.