### PR TITLE
MDEV-29760 query cache - drop db hangs database

### DIFF
--- a/mysql-test/main/query_cache_notembedded.result
+++ b/mysql-test/main/query_cache_notembedded.result
@@ -462,6 +462,27 @@ flush query cache|
 delete from t1|
 drop procedure bug3583|
 drop table t1|
+#
+# MDEV-29760 DROP DATABASE hangs when particular query cache is present
+#
+create table t1 (id int);
+create table t2 like t1;
+create table t3 like t1;
+create database d;
+create table d.t1 like test.t1;
+create table d.t2 like test.t2;
+set LOCAL query_cache_type=ON;
+select id from t3;
+id
+select 'x' a, 'y' b from d.t1;
+a	b
+select 'x' a, 'y' b from d.t1, d.t2;
+a	b
+drop database d;
+drop table t1, t2, t3;
+#
+# End of 10.5 tests
+#
 SET GLOBAL query_cache_size=@query_cache_size_save;
 SET GLOBAL query_cache_type=@query_cache_type_save;
 set GLOBAL sql_mode=@sql_mode_save;

--- a/mysql-test/main/query_cache_notembedded.test
+++ b/mysql-test/main/query_cache_notembedded.test
@@ -325,6 +325,33 @@ drop procedure bug3583|
 drop table t1|
 delimiter ;|
 
+--echo #
+--echo # MDEV-29760 DROP DATABASE hangs when particular query cache is present
+--echo #
+
+create table t1 (id int);
+create table t2 like t1;
+create table t3 like t1;
+
+create database d;
+
+create table d.t1 like test.t1;
+create table d.t2 like test.t2;
+
+set LOCAL query_cache_type=ON;
+
+select id from t3;
+select 'x' a, 'y' b from d.t1;
+select 'x' a, 'y' b from d.t1, d.t2;
+
+drop database d;
+
+drop table t1, t2, t3;
+
+--echo #
+--echo # End of 10.5 tests
+--echo #
+
 # Wait till we reached the initial number of concurrent sessions
 --source include/wait_until_count_sessions.inc
 SET GLOBAL query_cache_size=@query_cache_size_save;

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -2131,8 +2131,7 @@ lookup:
                      ("Handler require invalidation queries of %.*s %llu-%llu",
                       (int)qcache_se_key_len, qcache_se_key_name,
                       engine_data, table->engine_data()));
-          invalidate_table_internal(thd,
-                                    (uchar *) table->db(),
+          invalidate_table_internal((uchar *) table->db(),
                                     table->key_length());
         }
         else
@@ -2381,7 +2380,7 @@ void Query_cache::invalidate(THD *thd, const char *db)
           if (strcmp(table->db(),db) == 0)
           {
             Query_cache_block_table *list_root= table_block->table(0);
-            invalidate_query_block_list(thd,list_root);
+            invalidate_query_block_list(list_root);
           }
 
           table_block= next;
@@ -3320,7 +3319,7 @@ void Query_cache::invalidate_table(THD *thd, uchar * key, size_t key_length)
   DEBUG_SYNC(thd, "wait_in_query_cache_invalidate2");
 
   if (query_cache_size > 0)
-    invalidate_table_internal(thd, key, key_length);
+    invalidate_table_internal(key, key_length);
 
   unlock();
 }
@@ -3335,14 +3334,14 @@ void Query_cache::invalidate_table(THD *thd, uchar * key, size_t key_length)
 */
 
 void
-Query_cache::invalidate_table_internal(THD *thd, uchar *key, size_t key_length)
+Query_cache::invalidate_table_internal(uchar *key, size_t key_length)
 {
   Query_cache_block *table_block=
     (Query_cache_block*)my_hash_search(&tables, key, key_length);
   if (table_block)
   {
     Query_cache_block_table *list_root= table_block->table(0);
-    invalidate_query_block_list(thd, list_root);
+    invalidate_query_block_list(list_root);
   }
 }
 
@@ -3359,8 +3358,7 @@ Query_cache::invalidate_table_internal(THD *thd, uchar *key, size_t key_length)
 */
 
 void
-Query_cache::invalidate_query_block_list(THD *thd,
-                                         Query_cache_block_table *list_root)
+Query_cache::invalidate_query_block_list(Query_cache_block_table *list_root)
 {
   while (list_root->next != list_root)
   {
@@ -3543,7 +3541,7 @@ Query_cache::insert_table(THD *thd, size_t key_len, const char *key,
     */
     {
       Query_cache_block_table *list_root= table_block->table(0);
-      invalidate_query_block_list(thd, list_root);
+      invalidate_query_block_list(list_root);
     }
 
     table_block= 0;

--- a/sql/sql_cache.h
+++ b/sql/sql_cache.h
@@ -319,7 +319,7 @@ private:
   Cache_staus m_cache_status;
 
   void free_query_internal(Query_cache_block *point);
-  void invalidate_table_internal(THD *thd, uchar *key, size_t key_length);
+  void invalidate_table_internal(uchar *key, size_t key_length);
 
 protected:
   /*
@@ -375,8 +375,7 @@ protected:
   void invalidate_table(THD *thd, TABLE *table);
   void invalidate_table(THD *thd, uchar *key, size_t  key_length);
   void invalidate_table(THD *thd, Query_cache_block *table_block);
-  void invalidate_query_block_list(THD *thd, 
-                                   Query_cache_block_table *list_root);
+  void invalidate_query_block_list(Query_cache_block_table *list_root);
 
   TABLE_COUNTER_TYPE
     register_tables_from_list(THD *thd, TABLE_LIST *tables_used,

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -2691,13 +2691,16 @@ err:
   }
   error= thd->is_error();
 
+  if (non_temp_tables_count)
+    query_cache_invalidate3(thd, tables, 0);
+
   /*
     We are always logging drop of temporary tables.
     The reason is to handle the following case:
     - Use statement based replication
     - CREATE TEMPORARY TABLE foo (logged)
     - set row based replication
-    - DROP TEMPORAY TABLE foo    (needs to be logged)
+    - DROP TEMPORARY TABLE foo   (needs to be logged)
     This should be fixed so that we remember if creation of the
     temporary table was logged and only log it if the creation was
     logged.
@@ -2709,7 +2712,6 @@ err:
     if (non_trans_tmp_table_deleted || trans_tmp_table_deleted)
       thd->transaction->stmt.mark_dropped_temp_table();
 
-    query_cache_invalidate3(thd, tables, 0);
     if (!dont_log_query && mysql_bin_log.is_open())
     {
       if (non_trans_tmp_table_deleted)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29760*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Drop database was hanging the server by accessing invalid query cache data. The invalidation of table data dropping the tables wasn't called due to an error in dfb41fddf69ccbca89fd322901f2809bc3bcc0e9.

Also clean up the interface just a little bit.

## How can this PR be tested?

mtr cases included in commit.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*