### PR TITLE
MDEV-28299: Server crashes in XINDXS::Range/CntIndexRange (Connect en…

### DIFF
--- a/storage/connect/mysql-test/connect/r/index.result
+++ b/storage/connect/mysql-test/connect/r/index.result
@@ -139,3 +139,39 @@ DELETE FROM t1;
 DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
+#
+# MDEV-28299: Server crashes in
+#             XINDXS::Range/CntIndexRange (Connect engine)
+#
+CREATE TABLE t1 ( a int not null, KEY (a))engine=CONNECT;
+Warnings:
+Warning	1105	No table_type. Will be set to DOS
+Warning	1105	No file name. Table will use t1.dos
+SELECT * FROM t1 WHERE a=1;
+a
+INSERT INTO t1 values (1),(2),(1);
+SELECT * FROM t1 WHERE a=1;
+a
+1
+1
+DROP TABLE t1;
+CREATE TABLE t1 (a int, b int, pk int, PRIMARY KEY (pk)) engine=CONNECT;
+Warnings:
+Warning	1105	No table_type. Will be set to DOS
+Warning	1105	No file name. Table will use t1.dos
+SELECT x.a
+FROM t1 AS x JOIN t1 AS y ON (x.a = y.b)
+WHERE x.pk > 3;
+a
+INSERT INTO t1 values (1,2,1),(2,1,2),(1,2,3),(3,4,4);
+SELECT x.a
+FROM t1 AS x JOIN t1 AS y ON (x.a = y.b)
+WHERE x.pk > 3;
+a
+INSERT INTO t1 values (1,2,5);
+SELECT x.a
+FROM t1 AS x JOIN t1 AS y ON (x.a = y.b)
+WHERE x.pk > 3;
+a
+1
+DROP TABLE t1;

--- a/storage/connect/mysql-test/connect/t/index.test
+++ b/storage/connect/mysql-test/connect/t/index.test
@@ -84,3 +84,29 @@ DROP TABLE t3;
 --remove_file $MYSQLD_DATADIR/test/emp.txt
 --remove_file $MYSQLD_DATADIR/test/sexe.csv
 --remove_file $MYSQLD_DATADIR/test/sitmat.csv
+
+--echo #
+--echo # MDEV-28299: Server crashes in
+--echo #             XINDXS::Range/CntIndexRange (Connect engine)
+--echo #
+
+CREATE TABLE t1 ( a int not null, KEY (a))engine=CONNECT;
+SELECT * FROM t1 WHERE a=1;
+
+INSERT INTO t1 values (1),(2),(1);
+SELECT * FROM t1 WHERE a=1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (a int, b int, pk int, PRIMARY KEY (pk)) engine=CONNECT;
+SELECT x.a
+FROM t1 AS x JOIN t1 AS y ON (x.a = y.b)
+WHERE x.pk > 3;
+INSERT INTO t1 values (1,2,1),(2,1,2),(1,2,3),(3,4,4);
+SELECT x.a
+FROM t1 AS x JOIN t1 AS y ON (x.a = y.b)
+WHERE x.pk > 3;
+INSERT INTO t1 values (1,2,5);
+SELECT x.a
+FROM t1 AS x JOIN t1 AS y ON (x.a = y.b)
+WHERE x.pk > 3;
+DROP TABLE t1;

--- a/storage/connect/xindex.cpp
+++ b/storage/connect/xindex.cpp
@@ -2028,6 +2028,10 @@ int XINDXS::Range(PGLOBAL g, int limit, bool incl)
   PXCOL kp = To_KeyCol;
   OPVAL op = Op;
 
+// In case single column index doesn't exist return
+  if (!kp)
+    return 0;
+
   switch (limit) {
     case 1: Op = (incl) ? OP_GE : OP_GT; break;
     case 2: Op = (incl) ? OP_GT : OP_GE; break;


### PR DESCRIPTION
…gine)

- Bug happens only in case when the range function on empty key single column index (XINDEXS) is used.
- Solution is to return with empty result in this scenario.

Reviewed by: <>
