### PR TITLE
Fix wsrep_sst_mariabackup with timeout from busybox

### DIFF
--- a/scripts/wsrep_sst_mariabackup.sh
+++ b/scripts/wsrep_sst_mariabackup.sh
@@ -793,7 +793,7 @@ recv_joiner()
     local ltcmd="$tcmd"
     if [ $tmt -gt 0 ]; then
         if [ -n "$(commandex timeout)" ]; then
-            if timeout --help | grep -qw -F -- '-k'; then
+            if timeout --help 2>&1 | grep -qw -F -- '-k'; then
                 ltcmd="timeout -k $(( tmt+10 )) $tmt $tcmd"
             else
                 ltcmd="timeout -s9 $tmt $tcmd"


### PR DESCRIPTION
timeout from busybox outputs to stderr, redirect the output from timeout --help to stdout so our grep
works in all cases.

## Description
The `timeout` utility from busybox outputs to stderr, meaning the -k capability is not detected correctly and we get the --help output in logs.

Redirect stderr to stdout so we can effectively detect -k.

## How can this PR be tested?

Unless we are able to run tests against busybox along with Galera clustering to detect the error case I don't see this patch being amenable to automated testing.

## Basing the PR against the correct MariaDB version

- [ X] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility

Fully backwards compatible.
