### PR TITLE
MDEV-30150 ST_GeomFromGeoJSON, 'geometry' before 'type: feature' error

### DIFF
--- a/mysql-test/main/gis-json.result
+++ b/mysql-test/main/gis-json.result
@@ -58,6 +58,9 @@ Warning	4038	Syntax error in JSON text in argument 1 to function 'st_geomfromgeo
 SELECT st_astext(st_geomfromgeojson('{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [102.0, 0.5] } }'));
 st_astext(st_geomfromgeojson('{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [102.0, 0.5] } }'))
 POINT(102 0.5)
+SELECT st_astext(st_geomfromgeojson('{ "geometry": { "type": "Point", "coordinates": [102.0, 0.5] }, "type": "Feature" }'));
+st_astext(st_geomfromgeojson('{ "geometry": { "type": "Point", "coordinates": [102.0, 0.5] }, "type": "Feature" }'))
+POINT(102 0.5)
 SELECT st_astext(st_geomfromgeojson('{ "type": "FeatureCollection", "features": [{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [102.0, 0.5] }, "properties": { "prop0": "value0" } }]}'));
 st_astext(st_geomfromgeojson('{ "type": "FeatureCollection", "features": [{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [102.0, 0.5] }, "properties": { "prop0": "value0" } }]}'))
 GEOMETRYCOLLECTION(POINT(102 0.5))

--- a/mysql-test/main/gis-json.test
+++ b/mysql-test/main/gis-json.test
@@ -26,6 +26,7 @@ SELECT st_astext(st_geomfromgeojson('{"type""point"}'));
 #enable after fix MDEV-27871
 --disable_view_protocol
 SELECT st_astext(st_geomfromgeojson('{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [102.0, 0.5] } }'));
+SELECT st_astext(st_geomfromgeojson('{ "geometry": { "type": "Point", "coordinates": [102.0, 0.5] }, "type": "Feature" }'));
 SELECT st_astext(st_geomfromgeojson('{ "type": "FeatureCollection", "features": [{ "type": "Feature", "geometry": { "type": "Point", "coordinates": [102.0, 0.5] }, "properties": { "prop0": "value0" } }]}'));
 
 

--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -611,7 +611,8 @@ Geometry *Geometry::create_from_json(Geometry_buffer *buffer,
         if (feature_type_found)
           goto handle_geometry_key;
       }
-      goto err_return;
+      else
+        goto err_return;
     }
     else
     {


### PR DESCRIPTION
The geometry type requires Type:"Feature" but the feature need not be first in the JSON structure.

Adjust code to return an error if geometry isn't a JSON object, but continue parsing searching for Type: "Feature" to trigger the geometry parsing.

Thanks Derick Magnusen for the bug report.