### PR TITLE
MDEV-21187: log_slow_filter="" logs queries not using indexes

### DIFF
--- a/mysql-test/main/log_slow.result
+++ b/mysql-test/main/log_slow.result
@@ -64,7 +64,7 @@ rows_affected	int(11)	NO		NULL
 flush slow logs;
 set long_query_time=0.1;
 set log_slow_filter='';
-set global slow_query_log=1;
+set slow_query_log=1;
 set global log_output='TABLE';
 select sleep(0.5);
 sleep(0.5)
@@ -73,7 +73,7 @@ select count(*) FROM mysql.slow_log;
 count(*)
 1
 set @@long_query_time=default;
-set global slow_query_log= @org_slow_query_log;
+set @@slow_query_log=default;
 set @@log_slow_filter=default;
 set @@log_slow_verbosity=default;
 set global log_output= default;
@@ -115,3 +115,21 @@ Slow_queries_increment
 SET log_slow_filter=DEFAULT;
 SET @@long_query_time=default;
 SET GLOBAL slow_query_log= @org_slow_query_log;
+#
+# MDEV-21187: log_slow_filter="" logs queries not using indexes
+#
+flush status;
+create table t (id int);
+insert into t values (1),(4);
+set log_slow_filter='';
+select * from t;
+id
+1
+4
+show session status like 'Slow_queries';
+Variable_name	Value
+Slow_queries	0
+drop table t;
+#
+# End of 10.3 tests
+#

--- a/mysql-test/main/log_slow.test
+++ b/mysql-test/main/log_slow.test
@@ -50,14 +50,14 @@ flush slow logs;
 # MDEV-4206 (empty filter should be no filter)
 set long_query_time=0.1;
 set log_slow_filter='';
-set global slow_query_log=1;
+set slow_query_log=1;
 set global log_output='TABLE';
 select sleep(0.5);
 select count(*) FROM mysql.slow_log;
 
 # Reset used variables
 set @@long_query_time=default;
-set global slow_query_log= @org_slow_query_log;
+set @@slow_query_log=default;
 set @@log_slow_filter=default;
 set @@log_slow_verbosity=default;
 set global log_output= default;
@@ -102,3 +102,20 @@ SET log_slow_filter=DEFAULT;
 
 SET @@long_query_time=default;
 SET GLOBAL slow_query_log= @org_slow_query_log;
+
+--echo #
+--echo # MDEV-21187: log_slow_filter="" logs queries not using indexes
+--echo #
+
+flush status;
+create table t (id int);
+insert into t values (1),(4);
+set log_slow_filter='';
+select * from t;
+show session status like 'Slow_queries';
+
+drop table t;
+
+--echo #
+--echo # End of 10.3 tests
+--echo #

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2513,7 +2513,7 @@ void log_slow_statement(THD *thd)
   if ((thd->server_status &
        (SERVER_QUERY_NO_INDEX_USED | SERVER_QUERY_NO_GOOD_INDEX_USED)) &&
       !(thd->query_plan_flags & QPLAN_STATUS) &&
-      !slow_filter_masked(thd, QPLAN_NOT_USING_INDEX))
+      (thd->variables.log_slow_filter & QPLAN_NOT_USING_INDEX))
   {
     thd->query_plan_flags|= QPLAN_NOT_USING_INDEX;
     /* We are always logging no index queries if enabled in filter */


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-21187*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Consistent with MDEV-4206 and empty log_slow_filter still means no explict filtering. Since 21518ab2e453 however the log_queries_not_using_indexes became stored in the same variable.

As we need to test for the absense of log_queries_not_using_indexes the SERVER_QUERY_NO_INDEX USED part of log_slow_statement, the empty criteria resulted in an always true to log queries not using indexes if log_slow_filter was set to empty.

Adjusted the log_slow.test for MDEV-4206 as slow_log_query has been global and session for a while and it was relying on the MDEV-21187 buggy behavior to detect a slow query.

## How can this PR be tested?

mtr test included.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*