### PR TITLE
[draft] MDEV-6339 deprecate log_slow_disabled_statements

### DIFF
--- a/mysql-test/suite/sys_vars/r/log_slow_admin_statements_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_admin_statements_func.result
@@ -62,19 +62,29 @@ select @@GLOBAL.log_slow_disabled_statements;
 @@GLOBAL.log_slow_disabled_statements
 admin,sp
 SET @@SESSION.log_slow_disabled_statements="";
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead
 select @@SESSION.log_slow_admin_statements;
 @@SESSION.log_slow_admin_statements
 1
 SET @@SESSION.log_slow_disabled_statements="admin";
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead
 select @@SESSION.log_slow_admin_statements;
 @@SESSION.log_slow_admin_statements
 0
 SET @@GLOBAL.log_slow_disabled_statements="";
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead
 select @@GLOBAL.log_slow_admin_statements;
 @@GLOBAL.log_slow_admin_statements
 1
 SET @@GLOBAL.log_slow_disabled_statements="admin";
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead
 select @@GLOBAL.log_slow_admin_statements;
 @@GLOBAL.log_slow_admin_statements
 0
 SET @@global.log_slow_disabled_statements= @save_log_slow_disabled_statements;
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead

--- a/mysql-test/suite/sys_vars/r/log_slow_disabled_statements_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_disabled_statements_func.result
@@ -58,6 +58,8 @@ CALL slow2()
 SELECT count(if(sleep(1) >= 0,0,NULL)) from t1 where j>'b and part2'
 <--
 SET SESSION log_slow_disabled_statements="call,admin";
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead
 TRUNCATE TABLE mysql.slow_log;
 ALTER TABLE t1 add column extra2 int;
 CALL slow2();
@@ -92,6 +94,8 @@ SELECT j,count(*)+1 from t1 group by j,i
 SELECT count(if(sleep(1) >= 0,0,NULL)) from t1 where j>'b and part3'
 <--
 SET SESSION log_slow_disabled_statements="";
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead
 TRUNCATE TABLE mysql.slow_log;
 ALTER TABLE t1 add column extra3 int;
 CALL slow2();
@@ -130,6 +134,8 @@ CALL slow2()
 SELECT count(if(sleep(1) >= 0,0,NULL)) from t1 where j>'b and part4'
 <--
 SET SESSION log_slow_disabled_statements="call,admin,slave,sp";
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead
 TRUNCATE TABLE mysql.slow_log;
 ALTER TABLE t1 add column extra4 int;
 CALL slow2();
@@ -164,3 +170,5 @@ TRUNCATE TABLE mysql.slow_log;
 SET @@global.log_output=                   @old_log_output;
 SET @@global.slow_query_log=               @old_slow_query_log;
 SET @@global.log_slow_disabled_statements= @old_log_slow_disable_statements;
+Warnings:
+Warning	1287	'@@log_slow_disabled_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter=REPLACE(@@log_slow_filter,"admin","")' instead

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6497,7 +6497,8 @@ static Sys_var_set Sys_log_slow_disabled_statements(
        "Don't log certain types of statements to slow log",
        SESSION_VAR(log_slow_disabled_statements), CMD_LINE(REQUIRED_ARG),
        log_slow_disabled_statements_names,
-       DEFAULT(LOG_SLOW_DISABLE_SP));
+       DEFAULT(LOG_SLOW_DISABLE_SP), 0, NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(0),
+       DEPRECATED("'@@log_slow_filter=REPLACE(@@log_slow_filter,\"admin\",\"\")'")); // since 10.11.2
 
 static Sys_var_set Sys_log_disabled_statements(
        "log_disabled_statements",


### PR DESCRIPTION
log_slow_filter=admin as been available for a long time.

Users can migrate from log_slow_disabled_statements=OFF by removing 'admin' from the default log_slow_filter variable setting.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
