### PR TITLE
MDEV-6339 deprecate log_slow_admin_statements

### DIFF
--- a/mysql-test/main/log_slow_debug.result
+++ b/mysql-test/main/log_slow_debug.result
@@ -6,6 +6,8 @@ SET @@GLOBAL.log_output='TABLE';
 FLUSH SLOW LOGS;
 SET @@GLOBAL.slow_query_log=ON;
 SET @@GLOBAL.log_slow_admin_statements=ON;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 SET @saved_dbug = @@debug_dbug;
 SET SESSION debug_dbug="+d,simulate_slow_query";
 CREATE PROCEDURE show_slow_log()
@@ -19,6 +21,8 @@ $$
 # Expect all admin statements in the slow log (ON,DEFAULT)
 #
 SET @@SESSION.log_slow_admin_statements=ON;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 SET log_slow_filter=DEFAULT;
 TRUNCATE TABLE mysql.slow_log;
 CREATE TABLE t1 (a INT);
@@ -66,6 +70,8 @@ sql_text
 # Expect all admin statements in the slow log (ON,admin)
 #
 SET @@SESSION.log_slow_admin_statements=ON;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 SET log_slow_filter=admin;
 TRUNCATE TABLE mysql.slow_log;
 CREATE TABLE t1 (a INT);
@@ -100,6 +106,8 @@ sql_text
 # Expect none of admin DDL statements in the slow log (ON,filesort)
 #
 SET @@SESSION.log_slow_admin_statements=ON;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 SET log_slow_filter=filesort;
 TRUNCATE TABLE mysql.slow_log;
 CREATE TABLE t1 (a INT);
@@ -127,6 +135,8 @@ sql_text
 # Expect none of admin statements in the slow log (OFF,DEFAULT)
 #
 SET @@SESSION.log_slow_admin_statements=OFF;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 SET log_slow_filter=DEFAULT;
 TRUNCATE TABLE mysql.slow_log;
 CREATE TABLE t1 (a INT);
@@ -171,7 +181,11 @@ sql_text
 # prevent enabling globally suppressed logging by setting the session variable to ON.
 #
 SET @@GLOBAL.log_slow_admin_statements=OFF;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 SET @@SESSION.log_slow_admin_statements=ON;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 SET log_slow_filter=DEFAULT;
 TRUNCATE TABLE mysql.slow_log;
 CREATE TABLE t1 (a INT);
@@ -223,4 +237,6 @@ TRUNCATE mysql.slow_log;
 SET @@global.slow_query_log= @org_slow_query_log;
 SET @@global.log_output= @org_log_output;
 SET @@global.log_slow_admin_statements= @org_log_slow_admin_statements;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 DROP PROCEDURE show_slow_log;

--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -508,8 +508,8 @@ The following specify which files/extra groups are read (specified before remain
  --log-slow-admin-statements 
  Log slow OPTIMIZE, ANALYZE, ALTER and other
  administrative statements to the slow log if it is open. 
- Resets or sets the option 'admin' in
- log_slow_disabled_statements
+ Resets or sets the option 'admin' in log_slow_filter.
+ Deprecated, use log_slow_filter without 'admin'.
  (Defaults to on; use --skip-log-slow-admin-statements to disable.)
  --log-slow-disabled-statements=name 
  Don't log certain types of statements to slow log. Any

--- a/mysql-test/suite/sys_vars/r/log_slow_admin_statements_func.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_admin_statements_func.result
@@ -11,6 +11,8 @@ SET GLOBAL log_output = 'file,table';
 SET GLOBAL slow_query_log = on;
 SET SESSION long_query_time = 0;
 SET SESSION log_slow_admin_statements = on;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 ALTER TABLE log_slow_admin_statements ADD COLUMN k INT DEFAULT 17;
 CREATE PROCEDURE add_rows()
 BEGIN
@@ -42,22 +44,32 @@ SET @@global.log_output=                @old_log_output;
 SET @@global.slow_query_log=            @old_slow_query_log;
 SET @@session.long_query_time=          @old_long_query_time;
 SET @@global.log_slow_admin_statements= @old_log_slow_admin_statements;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 DROP PROCEDURE add_rows;
 TRUNCATE TABLE mysql.slow_log;
 SET @save_log_slow_disabled_statements= @@global.log_slow_disabled_statements;
 SET @@SESSION.log_slow_admin_statements= TRUE;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 select @@SESSION.log_slow_disabled_statements;
 @@SESSION.log_slow_disabled_statements
 sp
 SET @@SESSION.log_slow_admin_statements= FALSE;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 select @@SESSION.log_slow_disabled_statements;
 @@SESSION.log_slow_disabled_statements
 admin,sp
 SET @@GLOBAL.log_slow_admin_statements= TRUE;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 select @@GLOBAL.log_slow_disabled_statements;
 @@GLOBAL.log_slow_disabled_statements
 sp
 SET @@GLOBAL.log_slow_admin_statements= FALSE;
+Warnings:
+Warning	1287	'@@log_slow_admin_statements' is deprecated and will be removed in a future release. Please use '@@log_slow_filter' instead
 select @@GLOBAL.log_slow_disabled_statements;
 @@GLOBAL.log_slow_disabled_statements
 admin,sp

--- a/mysql-test/suite/sys_vars/r/sysvars_server_embedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_embedded.result
@@ -1665,7 +1665,7 @@ COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	LOG_SLOW_ADMIN_STATEMENTS
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Log slow OPTIMIZE, ANALYZE, ALTER and other administrative statements to the slow log if it is open.  Resets or sets the option 'admin' in log_slow_disabled_statements
+VARIABLE_COMMENT	Log slow OPTIMIZE, ANALYZE, ALTER and other administrative statements to the slow log if it is open.  Resets or sets the option 'admin' in log_slow_filter. Deprecated, use log_slow_filter without 'admin'.
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL

--- a/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
@@ -1815,7 +1815,7 @@ COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	LOG_SLOW_ADMIN_STATEMENTS
 VARIABLE_SCOPE	SESSION
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Log slow OPTIMIZE, ANALYZE, ALTER and other administrative statements to the slow log if it is open.  Resets or sets the option 'admin' in log_slow_disabled_statements
+VARIABLE_COMMENT	Log slow OPTIMIZE, ANALYZE, ALTER and other administrative statements to the slow log if it is open.  Resets or sets the option 'admin' in log_slow_filter. Deprecated, use log_slow_filter without 'admin'.
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1511,9 +1511,12 @@ static Sys_var_bit Sys_log_slow_admin_statements(
        "log_slow_admin_statements",
        "Log slow OPTIMIZE, ANALYZE, ALTER and other administrative statements "
        "to the slow log if it is open.  Resets or sets the option 'admin' in "
-       "log_slow_disabled_statements",
+       "log_slow_filter. "
+       "Deprecated, use log_slow_filter without 'admin'.",
        SESSION_VAR(log_slow_disabled_statements),
-       CMD_LINE(OPT_ARG), REVERSE(LOG_SLOW_DISABLE_ADMIN), DEFAULT(TRUE));
+       CMD_LINE(OPT_ARG), REVERSE(LOG_SLOW_DISABLE_ADMIN), DEFAULT(TRUE),
+       0, NOT_IN_BINLOG, ON_CHECK(0), ON_UPDATE(0),
+       DEPRECATED("'@@log_slow_filter'"));
 
 static Sys_var_bit Sys_log_slow_slave_statements(
        "log_slow_slave_statements",


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-6339*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

log_slow_filter=admin as been available for a long time.

Uses can migrate from log_slow_statements_statements=OFF by removing 'admin' from the default log_slow_filter variable setting.

## How can this PR be tested?

Deprecation warning at the moment.

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ X ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

Users will eventually need to change from using log_slow_admin_statements to log_slow_filters.