### PR TITLE
MDEV-30153: remove adhoc version from client programs

### DIFF
--- a/client/mariadb-conv.cc
+++ b/client/mariadb-conv.cc
@@ -25,8 +25,6 @@
 #include "sql_string.h"
 #include "my_dir.h"
 
-#define CONV_VERSION "1.0"
-
 
 class CmdOpt
 {
@@ -415,7 +413,7 @@ public:
   }
   void usage(void)
   {
-    printf("%s Ver %s Distrib %s for %s on %s\n", my_progname, CONV_VERSION,
+    printf("%s Distrib %s for %s on %s\n", my_progname,
       MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
     puts("Character set conversion utility for MariaDB");
     puts("Usage:");

--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -46,8 +46,6 @@
 #include <locale.h>
 #endif
 
-const char *VER= "15.1";
-
 /* Don't try to make a nice table if the data is too big */
 #define MAX_COLUMN_LENGTH	     1024
 
@@ -1850,11 +1848,11 @@ static void usage(int version)
 #else
   const char* readline= "readline";
 #endif
-  printf("%s  Ver %s Distrib %s, for %s (%s) using %s %s\n",
-	 my_progname, VER, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE,
+  printf("%s  Distrib %s, for %s (%s) using %s %s\n",
+	 my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE,
          readline, rl_library_version);
 #else
-  printf("%s  Ver %s Distrib %s, for %s (%s), source revision %s\n", my_progname, VER,
+  printf("%s  Distrib %s, for %s (%s), source revision %s\n", my_progname,
 	MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE,SOURCE_REVISION);
 #endif
 

--- a/client/mysql_plugin.c
+++ b/client/mysql_plugin.c
@@ -22,9 +22,8 @@
 #include <my_dir.h>
 #include <mysql_version.h>
 
-#define SHOW_VERSION "1.0.0"
-#define PRINT_VERSION do { printf("%s  Ver %s Distrib %s\n",    \
-                        my_progname, SHOW_VERSION, MYSQL_SERVER_VERSION);    \
+#define PRINT_VERSION do { printf("%s  Distrib %s\n",    \
+                        my_progname, MYSQL_SERVER_VERSION);    \
                       } while(0)
 
 /* Global variables. */

--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -22,8 +22,6 @@
 
 #include <welcome_copyright_notice.h> /* ORACLE_WELCOME_COPYRIGHT_NOTICE */
 
-#define VER "2.0"
-
 #ifdef HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif
@@ -296,8 +294,8 @@ get_one_option(const struct my_option *opt, const char *argument,
   switch (opt->id) {
 
   case '?':
-    printf("%s  Ver %s Distrib %s, for %s (%s)\n",
-           my_progname, VER, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
+    printf("%s  Distrib %s, for %s (%s)\n",
+           my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
     puts(ORACLE_WELCOME_COPYRIGHT_NOTICE("2000"));
     puts("MariaDB utility for upgrading databases to new MariaDB versions.");
     print_defaults("my", load_default_groups);
@@ -358,8 +356,8 @@ get_one_option(const struct my_option *opt, const char *argument,
     add_option= 0;
     break;
   case 'V':
-    printf("%s  Ver %s Distrib %s, for %s (%s)\n",
-           my_progname, VER, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
+    printf("%s  Distrib %s, for %s (%s)\n",
+           my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
     die(0);
     break;
   case 'f': /* --force     */

--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -28,7 +28,6 @@
 #include <password.h>
 #include <my_sys.h>
 
-#define ADMIN_VERSION "9.1"
 #define MAX_MYSQL_VAR 512
 #define SHUTDOWN_DEF_TIMEOUT 3600		/* Wait for shutdown */
 #define MAX_TRUNC_LENGTH 3
@@ -1391,7 +1390,7 @@ static char **mask_password(int argc, char ***argv)
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s on %s\n",my_progname,ADMIN_VERSION,
+  printf("%s  Distrib %s, for %s on %s\n",my_progname,
 	 MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -2156,7 +2156,7 @@ static void die()
 
 static void print_version()
 {
-  printf("%s Ver 3.5 for %s at %s\n", my_progname, SYSTEM_TYPE, MACHINE_TYPE);
+  printf("%s Distrib %s for %s at %s\n", my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
 }
 
 

--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -18,8 +18,6 @@
 
 /* By Jani Tolonen, 2001-04-20, MySQL Development Team */
 
-#define CHECK_VERSION "2.7.4-MariaDB"
-
 #include "client_priv.h"
 #include <m_ctype.h>
 #include <mysql_version.h>
@@ -250,7 +248,7 @@ int what_to_do = 0;
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n", my_progname, CHECK_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n", my_progname,
    MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
 } /* print_version */
 

--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -39,9 +39,6 @@
 ** 10 Jun 2003: SET NAMES and --no-set-names by Alexander Barkov
 */
 
-/* on merge conflict, bump to a higher version again */
-#define DUMP_VERSION "10.19"
-
 /**
   First mysql version supporting sequences.
 */
@@ -698,7 +695,7 @@ void check_io(FILE *file)
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n",my_progname_short,DUMP_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n",my_progname_short,
          MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 } /* print_version */
 
@@ -775,8 +772,8 @@ static void write_header(FILE *sql_file, const char *db_name)
   else if (!opt_compact)
   {
     print_comment(sql_file, 0,
-                  "-- MariaDB dump %s  Distrib %s, for %s (%s)\n--\n",
-                  DUMP_VERSION, MYSQL_SERVER_VERSION, SYSTEM_TYPE,
+                  "-- MariaDB dump Distrib %s, for %s (%s)\n--\n",
+                  MYSQL_SERVER_VERSION, SYSTEM_TYPE,
                   MACHINE_TYPE);
     print_comment(sql_file, 0, "-- Host: %s    ",
                   fix_for_comment(current_host ? current_host : "localhost"));

--- a/client/mysqlimport.c
+++ b/client/mysqlimport.c
@@ -27,7 +27,6 @@
 **			   *			   *
 **			   *************************
 */
-#define IMPORT_VERSION "3.7"
 
 #include "client_priv.h"
 #include <my_sys.h>
@@ -196,8 +195,8 @@ static const char *load_default_groups[]=
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n" ,my_progname,
-	  IMPORT_VERSION, MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
+  printf("%s  Distrib %s, for %s (%s)\n" ,my_progname,
+	  MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 }
 
 

--- a/client/mysqlshow.c
+++ b/client/mysqlshow.c
@@ -18,8 +18,6 @@
 
 /* Show databases, tables or columns */
 
-#define SHOW_VERSION "9.10"
-
 #include "client_priv.h"
 #include <my_sys.h>
 #include <m_string.h>
@@ -278,7 +276,7 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n",my_progname,SHOW_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n",my_progname,
 	 MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -67,8 +67,6 @@ TODO:
 
 */
 
-#define SLAP_VERSION "1.0"
-
 #define HUGE_STRING_LENGTH 8196
 #define RAND_STRING_SIZE 126
 
@@ -719,7 +717,7 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n",my_progname, SLAP_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n",my_progname,
          MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -33,8 +33,6 @@
   And many others
 */
 
-#define MTEST_VERSION "3.5"
-
 #include "client_priv.h"
 #include <mysql_version.h>
 #include <mysqld_error.h>
@@ -7194,7 +7192,7 @@ static struct my_option my_long_options[] =
 
 void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n",my_progname,MTEST_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n",my_progname,
 	 MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/extra/comp_err.c
+++ b/extra/comp_err.c
@@ -1134,7 +1134,7 @@ static struct languages *parse_charset_string(char *str)
 static void print_version(void)
 {
   DBUG_ENTER("print_version");
-  printf("%s  (Compile errormessage)  Ver %s\n", my_progname, "3.0");
+  printf("%s  (Compile errormessage)  Distrib %s\n", my_progname, MYSQL_SERVER_VERSION);
   DBUG_VOID_RETURN;
 }
 

--- a/extra/innochecksum.cc
+++ b/extra/innochecksum.cc
@@ -1213,12 +1213,12 @@ static struct my_option innochecksum_options[] = {
 static void print_version()
 {
 #ifdef DBUG_OFF
-	printf("%s Ver %s, for %s (%s)\n",
-		my_progname, PACKAGE_VERSION,
+	printf("%s Distrib %s, for %s (%s)\n",
+		my_progname, MYSQL_SERVER_VERSION,
 		SYSTEM_TYPE, MACHINE_TYPE);
 #else
-	printf("%s-debug Ver %s, for %s (%s)\n",
-		my_progname, PACKAGE_VERSION,
+	printf("%s-debug Distrib %s, for %s (%s)\n",
+		my_progname, MYSQL_SERVER_VERSION,
 		SYSTEM_TYPE, MACHINE_TYPE);
 #endif /* DBUG_OFF */
 }

--- a/extra/mariabackup/xbcloud.cc
+++ b/extra/mariabackup/xbcloud.cc
@@ -43,8 +43,6 @@ using std::max;
 using std::map;
 using std::string;
 
-#define XBCLOUD_VERSION "1.0"
-
 #define SWIFT_MAX_URL_SIZE 8192
 #define SWIFT_MAX_HDR_SIZE 8192
 
@@ -343,7 +341,7 @@ static
 void
 print_version()
 {
-	printf("%s  Ver %s for %s (%s)\n", my_progname, XBCLOUD_VERSION,
+	printf("%s  Distrib %s for %s (%s)\n", my_progname, MYSQL_SERVER_VERSION,
 	       SYSTEM_TYPE, MACHINE_TYPE);
 }
 

--- a/extra/mariabackup/xbstream.cc
+++ b/extra/mariabackup/xbstream.cc
@@ -27,7 +27,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1335  USA
 #include "xbstream.h"
 #include "datasink.h"
 
-#define XBSTREAM_VERSION "1.0"
 #define XBSTREAM_BUFFER_SIZE (10 * 1024 * 1024UL)
 
 #define START_FILE_HASH_SIZE 16
@@ -150,7 +149,7 @@ static
 void
 print_version(void)
 {
-	printf("%s  Ver %s for %s (%s)\n", my_progname, XBSTREAM_VERSION,
+	printf("%s  Distrib %s for %s (%s)\n", my_progname, MYSQL_SERVER_VERSION,
 	       SYSTEM_TYPE, MACHINE_TYPE);
 }
 

--- a/extra/my_print_defaults.c
+++ b/extra/my_print_defaults.c
@@ -70,7 +70,7 @@ static void cleanup_and_exit(int exit_code)
 
 static void version()
 {
-  printf("%s  Ver 1.7 for %s at %s\n",my_progname,SYSTEM_TYPE, MACHINE_TYPE);
+  printf("%s  Distrib %s for %s at %s\n",my_progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE, MACHINE_TYPE);
 }
 
 

--- a/extra/perror.c
+++ b/extra/perror.c
@@ -16,8 +16,6 @@
 
 /* Return error-text for system error messages and handler messages */
 
-#define PERROR_VERSION "2.11"
-
 #include <my_global.h>
 #include <my_sys.h>
 #include <m_string.h>
@@ -78,7 +76,7 @@ static HA_ERRORS ha_errlist[]=
 
 static void print_version(void)
 {
-  printf("%s Ver %s, for %s (%s)\n",my_progname,PERROR_VERSION,
+  printf("%s Distrib %s for %s (%s)\n",my_progname, MYSQL_SERVER_VERSION,
 	 SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/extra/replace.c
+++ b/extra/replace.c
@@ -176,7 +176,7 @@ static int static_get_options(int *argc, char***argv)
       case 'I':
       case '?':
 	help=1;					/* Help text written */
-	printf("%s  Ver 1.4 for %s at %s\n",my_progname,SYSTEM_TYPE,
+	printf("%s  Distrib %s for %s at %s\n",my_progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,
 	       MACHINE_TYPE);
 	if (version)
 	  break;

--- a/extra/resolve_stack_dump.c
+++ b/extra/resolve_stack_dump.c
@@ -29,7 +29,6 @@
 #define INIT_SYM_TABLE  4096
 #define INC_SYM_TABLE  4096
 #define MAX_SYM_SIZE   128
-#define DUMP_VERSION "1.4"
 #define HEX_INVALID  (uchar)255
 
 typedef ulong my_long_addr_t ; /* at some point, we need to fix configure
@@ -67,7 +66,7 @@ static void clean_up();
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n",my_progname,DUMP_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n",my_progname,
 	 MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/extra/resolveip.c
+++ b/extra/resolveip.c
@@ -16,8 +16,6 @@
 
 /* Resolves IP's to hostname and hostnames to IP's */
 
-#define RESOLVE_VERSION "2.3"
-
 #include <my_global.h>
 #include <m_ctype.h>
 #include <my_sys.h>
@@ -54,7 +52,7 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s Ver %s, for %s (%s)\n",my_progname,RESOLVE_VERSION,
+  printf("%s Distrib %s, for %s (%s)\n",my_progname,MYSQL_SERVER_VERSION,
 	 SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/man/aria_chk.1
+++ b/man/aria_chk.1
@@ -1,4 +1,4 @@
-.TH ARIA_CHK "1" "May 2014" "aria_chk Ver 1.2" "User Commands"
+.TH ARIA_CHK "1" "May 2014" "aria_chk" "User Commands"
 .SH NAME
 aria_chk \- Aria table\-maintenance utility
 .SH SYNOPSIS

--- a/man/aria_dump_log.1
+++ b/man/aria_dump_log.1
@@ -1,4 +1,4 @@
-.TH ARIA_DUMP_LOG "1" "May 2014" "aria_dump_log Ver 1.0" "User Commands"
+.TH ARIA_DUMP_LOG "1" "May 2014" "aria_dump_log" "User Commands"
 .SH NAME
 aria_dump_log \- Dump content of Aria log pages.
 .SH SYNOPSIS

--- a/man/aria_ftdump.1
+++ b/man/aria_ftdump.1
@@ -1,4 +1,4 @@
-.TH ARIA_FTDUMP "1" "May 2014" "aria_ftdump Ver 1.0" "User Commands"
+.TH ARIA_FTDUMP "1" "May 2014" "aria_ftdump" "User Commands"
 .SH NAME
 aria_ftdump \- display full\-text index information
 .SH DESCRIPTION

--- a/man/aria_pack.1
+++ b/man/aria_pack.1
@@ -1,4 +1,4 @@
-.TH ARIA_PACK "1" "May 2014" "aria_pack Ver 1.0" "User Commands"
+.TH ARIA_PACK "1" "May 2014" "aria_pack" "User Commands"
 .SH NAME
 aria_pack \- generate compressed, read\-only Aria tables
 .SH SYNOPSIS

--- a/man/aria_read_log.1
+++ b/man/aria_read_log.1
@@ -1,4 +1,4 @@
-.TH ARIA_READ_LOG "1" "May 2014" "aria_read_log Ver 1.3" "User Commands"
+.TH ARIA_READ_LOG "1" "May 2014" "aria_read_log" "User Commands"
 .SH NAME
 aria_read_log \- display Aria log file contents
 .SH SYNOPSIS

--- a/man/aria_s3_copy.1
+++ b/man/aria_s3_copy.1
@@ -1,4 +1,4 @@
-.TH ARIA_S3_COPY "1" "June 2020" "aria_s3_copy Ver 1.0" "User Commands"
+.TH ARIA_S3_COPY "1" "June 2020" "aria_s3_copy" "User Commands"
 .SH NAME
 aria_s3_copy \- Copy an Aria table to and from s3
 .SH DESCRIPTION

--- a/mysql-test/main/mysqlbinlog.result
+++ b/mysql-test/main/mysqlbinlog.result
@@ -1269,7 +1269,7 @@ DELIMITER ;
 ROLLBACK /* added by mysqlbinlog */;
 /*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
 /*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
-mariadb-binlog Ver VER for OS at ARCH
+mariadb-binlog Distrib VER for OS at ARCH
 #
 # Test --rewrite-db
 #

--- a/mysql-test/main/mysqlbinlog.test
+++ b/mysql-test/main/mysqlbinlog.test
@@ -608,7 +608,7 @@ eval SET GLOBAL SERVER_ID = $old_server_id;
 #
 # MDEV-12372 mysqlbinlog --version output is the same on 10.x as on 5.5.x, and contains not only version
 #
-replace_regex /.*mariadb-binlog(\.exe)? Ver .* for .* at [-_a-zA-Z0-9]+/mariadb-binlog Ver VER for OS at ARCH/;
+replace_regex /.*mariadb-binlog(\.exe)? Distrib .* for .* at [-_a-zA-Z0-9]+/mariadb-binlog Distrib VER for OS at ARCH/;
 exec $MYSQL_BINLOG --version;
 
 --echo #

--- a/mysql-test/suite/innodb_zip/r/innochecksum_2.result
+++ b/mysql-test/suite/innodb_zip/r/innochecksum_2.result
@@ -37,7 +37,7 @@ merge                             0
 [1]:# check the both short and long options for "help"
 [2]:# Run the innochecksum when file isn't provided.
 # It will print the innochecksum usage similar to --help option.
-innochecksum Ver #.#.#
+innochecksum Distrib
 Copyright (c) YEAR, YEAR , Oracle, MariaDB Corporation Ab and others.
 
 InnoDB offline file checksum utility.
@@ -88,5 +88,5 @@ merge                             0
 Number of pages:#
 Number of pages:#
 [4]:# Print the version of innochecksum and exit
-innochecksum Ver #.#.## Restart the DB server
+innochecksum Distrib# Restart the DB server
 DROP TABLE t1;

--- a/mysql-test/suite/innodb_zip/t/innochecksum_2.test
+++ b/mysql-test/suite/innodb_zip/t/innochecksum_2.test
@@ -62,7 +62,7 @@ open IN_FILE,"<", "$dir/tmp/$file" or die $!;
 open OUT_FILE, ">", "$dir/tmp/tmpfile" or die $!;
 while(<IN_FILE>) {
  unless ($_=~ /^debug.*$/ || $_=~ /\-#, \-\-debug.*$/ || $_=~ /http:.*html/) {
-    $_=~ s/^\S*innochecksum.+Ver.+[0-9]*\.[0-9]*\.[0-9]*.+$/innochecksum Ver #.#.#/g;
+    $_=~ s/^\S*innochecksum(-debug)?\s+Distrib.+$/innochecksum Distrib/g;
     $_=~ s/(Copyright\s\(c\))\s([0-9]*),\s([0-9]*)(.*)/$1 YEAR, YEAR $4/g;
     $_=~ s/Usage:.*\[-c/Usage: innochecksum [-c/g;
     print OUT_FILE $_;
@@ -85,7 +85,7 @@ EOF
 --exec $INNOCHECKSUM -c $MYSQLD_DATADIR/test/t1.ibd
 
 --echo [4]:# Print the version of innochecksum and exit
---replace_regex /.*innochecksum.*Ver.*[0-9]*.[0-9]*.[0-9]*.*/innochecksum Ver #.#.#/
+--replace_regex /.*innochecksum.*Distrib.*[0-9]*.[0-9]*.[0-9]*.*/innochecksum Distrib/
 --exec $INNOCHECKSUM -V $MYSQLD_DATADIR/test/t1.ibd
 
 --echo # Restart the DB server

--- a/mysys/testhash.c
+++ b/mysys/testhash.c
@@ -265,7 +265,7 @@ static int get_options(int argc, char **argv)
     case 'V':
     case 'I':
     case '?':
-      printf("%s  Ver 1.0 for %s at %s\n",progname,SYSTEM_TYPE,MACHINE_TYPE);
+      printf("%s  Distrib %s for %s at %s\n",progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
       printf("MySQL AB, by Monty\n\n");
       printf("Usage: %s [-?ABIKLWv] [-m#] [-t#]\n",progname);
       exit(0);

--- a/sql/mysql_install_db.cc
+++ b/sql/mysql_install_db.cc
@@ -36,7 +36,7 @@ struct IUnknown;
 #include <string>
 
 #define USAGETEXT \
-"mysql_install_db.exe  Ver 1.00 for Windows\n" \
+"mysql_install_db.exe  Distrib " MYSQL_SERVER_VERSION " for Windows\n" \
 "Copyright (C) 2010-2011 Monty Program Ab & Vladislav Vaintroub\n" \
 "This software comes with ABSOLUTELY NO WARRANTY. This is free software,\n" \
 "and you are welcome to modify and redistribute it under the GPL v2 license\n" \

--- a/sql/mysql_upgrade_service.cc
+++ b/sql/mysql_upgrade_service.cc
@@ -37,7 +37,7 @@ extern int upgrade_config_file(const char *myini_path);
 #pragma comment(lib, "version")
 
 #define USAGETEXT \
-"mysql_upgrade_service.exe  Ver 1.00 for Windows\n" \
+"mysql_upgrade_service.exe  Distrib " MYSQL_SERVER_VERSION " for Windows\n" \
 "Copyright (C) 2010-2011 Monty Program Ab & Vladislav Vaintroub" \
 "This software comes with ABSOLUTELY NO WARRANTY. This is free software,\n" \
 "and you are welcome to modify and redistribute it under the GPL v2 license\n" \

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -64,8 +64,6 @@
 #endif /* !defined(DBUG_OFF) */
 #endif /* defined(TZINFO2SQL) || defined(TESTTIME) */
 
-#define PROGRAM_VERSION "1.1"
-
 /* Structure describing local time type (e.g. Moscow summer time (MSD)) */
 typedef struct ttinfo
 {
@@ -2668,7 +2666,7 @@ C_MODE_END
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n",my_progname, PROGRAM_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n",my_progname,
 	 MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
 }
 

--- a/storage/archive/archive_reader.c
+++ b/storage/archive/archive_reader.c
@@ -26,8 +26,6 @@
 #define BUFFER_LEN 1024
 #define ARCHIVE_ROW_HEADER_SIZE 4
 
-#define SHOW_VERSION "0.1"
-
 static void get_options(int *argc,char * * *argv);
 static void print_version(void);
 static void usage(void);
@@ -402,7 +400,7 @@ static void usage(void)
 
 static void print_version(void)
 {
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n", my_progname, SHOW_VERSION,
+  printf("%s  Distrib %s, for %s (%s)\n", my_progname,
          MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
 }
 

--- a/storage/heap/hp_test1.c
+++ b/storage/heap/hp_test1.c
@@ -161,7 +161,7 @@ static int get_options(int argc, char **argv)
       remove_ant=atoi(++pos);
       break;
     case 'V':
-      printf("hp_test1    Ver 3.0 \n");
+      printf("hp_test1    Distrib %s\n", MYSQL_SERVER_VERSION);
       exit(0);
     case '#':
       DBUG_PUSH (++pos);

--- a/storage/heap/hp_test2.c
+++ b/storage/heap/hp_test2.c
@@ -595,7 +595,7 @@ static int get_options(int argc,char *argv[])
     case 'V':
     case 'I':
     case '?':
-      printf("%s  Ver 1.2 for %s at %s\n",progname,SYSTEM_TYPE,MACHINE_TYPE);
+      printf("%s  Distrib %s for %s at %s\n",progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
       puts("TCX Datakonsult AB, by Monty, for your professional use\n");
       printf("Usage: %s [-?ABIKLsWv] [-m#] [-t#]\n",progname);
       exit(0);

--- a/storage/maria/aria_chk.c
+++ b/storage/maria/aria_chk.c
@@ -473,7 +473,7 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s  Ver 1.3 for %s on %s\n", my_progname, SYSTEM_TYPE,
+  printf("%s  Distrib %s for %s on %s\n", my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE,
 	 MACHINE_TYPE);
 }
 

--- a/storage/maria/aria_dump_log.c
+++ b/storage/maria/aria_dump_log.c
@@ -66,8 +66,8 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s Ver 1.1 for %s on %s\n",
-              my_progname_short, SYSTEM_TYPE, MACHINE_TYPE);
+  printf("%s Distrib %s for %s on %s\n",
+              my_progname_short, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
 }
 
 

--- a/storage/maria/aria_pack.c
+++ b/storage/maria/aria_pack.c
@@ -355,7 +355,7 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s Ver 1.0 for %s on %s\n", my_progname, SYSTEM_TYPE, MACHINE_TYPE);
+  printf("%s Distrib %s for %s on %s\n", my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
 }
 
 

--- a/storage/maria/aria_read_log.c
+++ b/storage/maria/aria_read_log.c
@@ -300,8 +300,8 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s Ver 1.5 for %s on %s\n",
-              my_progname_short, SYSTEM_TYPE, MACHINE_TYPE);
+  printf("%s Distrib %s for %s on %s\n",
+              my_progname_short, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
 }
 
 

--- a/storage/maria/aria_s3_copy.cc
+++ b/storage/maria/aria_s3_copy.cc
@@ -111,7 +111,7 @@ static bool get_database_from_path(char *to, size_t to_length, const char *path)
 
 static void print_version(void)
 {
-  printf("%s  Ver 1.0 for %s on %s\n", my_progname, SYSTEM_TYPE,
+  printf("%s  Distrib %s for %s on %s\n", my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE,
 	 MACHINE_TYPE);
 }
 

--- a/storage/maria/ma_test1.c
+++ b/storage/maria/ma_test1.c
@@ -887,7 +887,7 @@ get_one_option(const struct my_option *opt,
     pagecacheing=1;
     break;
   case 'V':
-    printf("test1 Ver 1.2 \n");
+    printf("test1 Distrib %s\n", MYSQL_SERVER_VERSION);
     exit(0);
   case '#':
     DBUG_PUSH(argument);

--- a/storage/maria/ma_test2.c
+++ b/storage/maria/ma_test2.c
@@ -1171,7 +1171,7 @@ static void get_options(int argc, char **argv)
     case '?':
     case 'I':
     case 'V':
-      printf("%s  Ver 1.2 for %s at %s\n",progname,SYSTEM_TYPE,MACHINE_TYPE);
+      printf("%s  Distrib %s for %s at %s\n",progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
       puts("By Monty, for testing Maria\n");
       printf("Usage: %s [-?AbBcCDIKLPRqSsTVWltv] [-k#] [-f#] [-m#] [-e#] [-E#] [-t#]\n",
 	     progname);

--- a/storage/maria/ma_test3.c
+++ b/storage/maria/ma_test3.c
@@ -147,7 +147,7 @@ static void get_options(int argc, char **argv)
    case '?':
     case 'I':
     case 'V':
-      printf("%s  Ver 1.0 for %s at %s\n",progname,SYSTEM_TYPE,MACHINE_TYPE);
+      printf("%s  Distrib %s for %s at %s\n",progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
       puts("By Monty, for your professional use\n");
       puts("Test av locking with threads\n");
       printf("Usage: %s [-?lKA] [-f#] [-t#]\n",progname);

--- a/storage/maria/unittest/ma_control_file-t.c
+++ b/storage/maria/unittest/ma_control_file-t.c
@@ -575,7 +575,7 @@ static struct my_option my_long_options[] =
 static void version(void)
 {
   printf("ma_control_file_test: unit test for the control file "
-         "module of the Aria storage engine. Ver 1.0 \n");
+         "module of the Aria storage engine. Distrib %s\n", MYSQL_SERVER_VERSION);
 }
 
 static my_bool

--- a/storage/myisam/mi_test1.c
+++ b/storage/myisam/mi_test1.c
@@ -652,7 +652,7 @@ get_one_option(const struct my_option *opt,
     key_cacheing=1;
     break;
   case 'V':
-    printf("test1 Ver 1.2 \n");
+    printf("test1 Distrib %s\n", MYSQL_SERVER_VERSION);
     exit(0);
   case '#':
     DBUG_PUSH (argument);

--- a/storage/myisam/mi_test2.c
+++ b/storage/myisam/mi_test2.c
@@ -979,7 +979,7 @@ static void get_options(int argc, char **argv)
     case '?':
     case 'I':
     case 'V':
-      printf("%s  Ver 1.2 for %s at %s\n",progname,SYSTEM_TYPE,MACHINE_TYPE);
+      printf("%s  Distrib %s for %s at %s\n",progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
       puts("By Monty, for your professional use\n");
       printf("Usage: %s [-?AbBcDIKLPRqSsVWltv] [-k#] [-f#] [-m#] [-e#] [-E#] [-t#]\n",
 	     progname);

--- a/storage/myisam/mi_test3.c
+++ b/storage/myisam/mi_test3.c
@@ -145,7 +145,7 @@ static void get_options(int argc, char **argv)
    case '?':
     case 'I':
     case 'V':
-      printf("%s  Ver 1.0 for %s at %s\n",progname,SYSTEM_TYPE,MACHINE_TYPE);
+      printf("%s  Distrib %s for %s at %s\n",progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,MACHINE_TYPE);
       puts("By Monty, for your professional use\n");
       puts("Test av locking with threads\n");
       printf("Usage: %s [-?lKA] [-f#] [-t#]\n",progname);

--- a/storage/myisam/myisamchk.c
+++ b/storage/myisam/myisamchk.c
@@ -333,7 +333,7 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s  Ver 2.7 for %s at %s\n", my_progname, SYSTEM_TYPE,
+  printf("%s  Distrib %s for %s at %s\n", my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE,
 	 MACHINE_TYPE);
 }
 

--- a/storage/myisam/myisamlog.c
+++ b/storage/myisam/myisamlog.c
@@ -249,7 +249,7 @@ static void get_options(register int *argc, register char ***argv)
 	/* Fall through */
       case 'I':
       case '?':
-	printf("%s  Ver 1.4 for %s at %s\n",my_progname,SYSTEM_TYPE,
+	printf("%s  Distrib %s for %s at %s\n",my_progname,MYSQL_SERVER_VERSION,SYSTEM_TYPE,
 	       MACHINE_TYPE);
 	puts("By Monty, for your professional use\n");
 	if (version)

--- a/storage/myisam/myisampack.c
+++ b/storage/myisam/myisampack.c
@@ -291,8 +291,8 @@ static struct my_option my_long_options[] =
 
 static void print_version(void)
 {
-  printf("%s Ver 1.23 for %s on %s\n",
-              my_progname, SYSTEM_TYPE, MACHINE_TYPE);
+  printf("%s Distrib %s for %s on %s\n",
+              my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
 }
 
 

--- a/strings/do_ctype.c
+++ b/strings/do_ctype.c
@@ -97,7 +97,7 @@ register char **argv[];
 	version=1;
       case 'I':
       case '?':
-	printf("%s  Ver 1.0\n",progname);
+	printf("%s  Distrib %s\n",progname,MYSQL_SERVER_VERSION);
 	if (version)
 	  break;
 	puts("Output tabells of to_lower[], to_upper[] and sortorder[]\n");

--- a/tests/mysql_client_fw.c
+++ b/tests/mysql_client_fw.c
@@ -37,7 +37,6 @@ static my_bool non_blocking_api_enabled= 0;
 #include "nonblock-wrappers.h"
 #endif
 
-#define VER "2.1"
 #define MAX_TEST_QUERY_LENGTH 300 /* MAX QUERY BUFFER LENGTH */
 #define MAX_KEY MAX_INDEXES
 #define MAX_SERVER_ARGS 64
@@ -1256,8 +1255,8 @@ static void usage(void)
 {
   /* show the usage string when the user asks for this */
   putc('\n', stdout);
-  printf("%s  Ver %s Distrib %s, for %s (%s)\n",
-	 my_progname, VER, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
+  printf("%s  Distrib %s, for %s (%s)\n",
+	 my_progname, MYSQL_SERVER_VERSION, SYSTEM_TYPE, MACHINE_TYPE);
   puts("By Monty, Venu, Kent and others\n");
   printf("\
 Copyright (C) 2002-2004 MySQL AB\n\


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30153*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

The version number of client numbers are only occasionally increased. Its unclear if the manual pages are kept in sync to contain the same version number.

There are occasions where people report the client version as the server version which makes it hard to help. While the compiled server version isn't always accurate, its usually easier to follow.

Mariadb-backup, aria tools, mariadb-binlog are also highly dependent on being the same as the server version and its important to make this very evident.

## How can this PR be tested?

$tool --version
