### PR TITLE
dgcov: parsing without dot to get specific version

### DIFF
--- a/mysql-test/dgcov.pl
+++ b/mysql-test/dgcov.pl
@@ -71,7 +71,7 @@ if ($opt_purge)
 }
 
 my $gcc_version= `gcc -dumpversion`;
-$gcc_version=~ s/^(\d+)\..*$/$1/ or die "Cannot parse gcc -dumpversion: $gcc_version";
+$gcc_version=~ s/^(\d+).*$/$1/ or die "Cannot parse gcc -dumpversion: $gcc_version";
 
 find(\&gcov_one_file, $root);
 find(\&write_coverage, $root) if $opt_generate;
@@ -191,6 +191,7 @@ sub gcov_one_file {
   } else {
     require IO::Uncompress::Gunzip;
     require JSON::PP;
+    no warnings 'once';
     my $gcov_file_json;
     s/\.gcda$// if $gcc_version >= 11;
     IO::Uncompress::Gunzip::gunzip("$_.gcov.json.gz", \$gcov_file_json)


### PR DESCRIPTION
- Patch introduced 7baf24a0f8e9491a55 for multidigit gcc dump.
    There is no dot in `dumpversion`.
    ```
    $ gcc -dumpversion
    10
    ```
    Otherwise it will fail and not produce the output
    ```
    Running dgcov
    Name "IO::Uncompress::Gunzip::GunzipError" used only once: possible typo at ./dgcov.pl line 197.
    Cannot parse gcc -dumpversion: 9
    ```
    - The warning `once` is always generated:
    ```
    Running dgcov
    Name "IO::Uncompress::Gunzip::GunzipError" used only once: possible typo at ./dgcov.pl line 197.
    <number>
    ```
    Suppresing the line `Name "IO::Uncompress::Gunzip::GunzipError" used only once: possible typo at ./dgcov.pl line 197.`
    with the patch.
    
    - Reviewed by: <>

