### PR TITLE
MDEV-26875: Wrong user in SET DEFAULT ROLE error

### DIFF
--- a/mysql-test/include/delete_anonymous_users.inc
+++ b/mysql-test/include/delete_anonymous_users.inc
@@ -1,7 +1,7 @@
 # Remove anonymous users added by add_anonymous_users.inc
 disable_warnings;
 disable_query_log;
-DELETE FROM mysql.user where host='localhost' and user='';
+DELETE FROM mysql.global_priv where host='localhost' and user='';
 FLUSH PRIVILEGES;
 enable_query_log;
 enable_warnings;

--- a/mysql-test/suite/roles/set_default_role_for.result
+++ b/mysql-test/suite/roles/set_default_role_for.result
@@ -14,7 +14,7 @@ set default role role_a for user_a@localhost;
 set default role invalid_role for user_a@localhost;
 ERROR OP000: Invalid role specification `invalid_role`
 set default role role_b for user_a@localhost;
-ERROR OP000: User `root`@`localhost` has not been granted role `role_b`
+ERROR OP000: User `user_a`@`localhost` has not been granted role `role_b`
 set default role role_b for user_b@localhost;
 show grants;
 Grants for user_a@localhost

--- a/mysql-test/suite/roles/set_default_role_invalid.result
+++ b/mysql-test/suite/roles/set_default_role_invalid.result
@@ -48,7 +48,7 @@ CREATE USER b;
 CREATE ROLE r1;
 CREATE ROLE r2;
 SET DEFAULT ROLE r1 FOR a;
-ERROR OP000: User `root`@`localhost` has not been granted role `r1`
+ERROR OP000: User `a`@`%` has not been granted role `r1`
 GRANT r1 TO b;
 GRANT r2 TO b;
 SET DEFAULT ROLE r1 FOR b;
@@ -100,7 +100,7 @@ GRANT USAGE ON *.* TO `b`@`%`
 GRANT SELECT, UPDATE ON `mysql`.* TO `b`@`%`
 SET DEFAULT ROLE `r2` FOR `b`@`%`
 SET DEFAULT ROLE r1 FOR a;
-ERROR OP000: User `b`@`%` has not been granted role `r1`
+ERROR OP000: User `a`@`%` has not been granted role `r1`
 SET DEFAULT ROLE invalid_role;
 ERROR OP000: Invalid role specification `invalid_role`
 SET DEFAULT ROLE invalid_role FOR a;
@@ -117,7 +117,7 @@ SET DEFAULT ROLE None;
 # Change user b (session 3: role granted to user a)
 SET DEFAULT ROLE r1 FOR a;
 SET DEFAULT ROLE r2 FOR a;
-ERROR OP000: User `b`@`%` has not been granted role `r2`
+ERROR OP000: User `a`@`%` has not been granted role `r2`
 SET DEFAULT ROLE invalid_role;
 ERROR OP000: Invalid role specification `invalid_role`
 SET DEFAULT ROLE invalid_role FOR a;

--- a/mysql-test/suite/roles/set_default_role_invalid.test
+++ b/mysql-test/suite/roles/set_default_role_invalid.test
@@ -70,7 +70,6 @@ CREATE USER a;
 CREATE USER b;
 CREATE ROLE r1;
 CREATE ROLE r2;
-# Role has not been granted to user a, but the role is visible to current_user
 --error ER_INVALID_ROLE
 SET DEFAULT ROLE r1 FOR a;
 # Granting roles to user b

--- a/mysql-test/suite/roles/set_default_role_invalid_skip_name_resolve-master.opt
+++ b/mysql-test/suite/roles/set_default_role_invalid_skip_name_resolve-master.opt
@@ -1,0 +1,1 @@
+--skip-name-resolve

--- a/mysql-test/suite/roles/set_default_role_invalid_skip_name_resolve.result
+++ b/mysql-test/suite/roles/set_default_role_invalid_skip_name_resolve.result
@@ -1,0 +1,85 @@
+#
+# MDEV-26875: Wrong user in SET DEFAULT ROLE error
+#
+create user test_user;
+create role test_role;
+show grants for test_user;
+Grants for test_user@%
+GRANT USAGE ON *.* TO `test_user`@`%`
+set default role test_role for test_user;
+ERROR OP000: User `test_user`@`%` has not been granted role `test_role`
+grant test_role to test_user;
+set default role test_role for test_user;
+show grants for test_user;
+Grants for test_user@%
+GRANT `test_role` TO `test_user`@`%`
+GRANT USAGE ON *.* TO `test_user`@`%`
+SET DEFAULT ROLE `test_role` FOR `test_user`@`%`
+set default role none for test_user;
+#
+# Try to set default role to role(`test_role`).
+--------------------------------------------------------------
+show grants for test_role;
+Grants for test_role
+GRANT USAGE ON *.* TO `test_role`
+create role new_role;
+grant new_role to test_role;
+show grants for test_role;
+Grants for test_role
+GRANT `new_role` TO `test_role`
+GRANT USAGE ON *.* TO `test_role`
+GRANT USAGE ON *.* TO `new_role`
+set default role new_role for test_role;
+ERROR OP000: User `test_role`@`%` has not been granted role `new_role`
+#
+# Test of errors, where hostname cannot be resolved `test_user`
+--------------------------------------------------------------
+grant test_role to test_user@'%';
+set default role test_role for test_user@'%';
+connect con_test_user,127.0.0.1,test_user,,,$MASTER_MYPORT;
+show grants;
+Grants for test_user@%
+GRANT `test_role` TO `test_user`@`%`
+GRANT USAGE ON *.* TO `test_user`@`%`
+GRANT `new_role` TO `test_role`
+GRANT USAGE ON *.* TO `test_role`
+GRANT USAGE ON *.* TO `new_role`
+SET DEFAULT ROLE `test_role` FOR `test_user`@`%`
+select current_role;
+current_role
+test_role
+set role `new_role`;
+ERROR OP000: User `test_user`@`%` has not been granted role `new_role`
+connection default;
+set default role none for test_user;
+disconnect con_test_user;
+connect con_test_user,127.0.0.1,test_user,,,$MASTER_MYPORT;
+select current_role;
+current_role
+NULL
+set role `new_role`;
+ERROR OP000: User `test_user`@`%` has not been granted role `new_role`
+connection default;
+disconnect con_test_user;
+#
+# Test of anonymous user connection
+--------------------------------------------------------------
+grant test_role to ''@localhost;
+connect con1,localhost,'',,,$MASTER_MYPORT;
+SELECT CURRENT_ROLE;
+CURRENT_ROLE
+NULL
+SET role test_role;
+SELECT CURRENT_ROLE;
+CURRENT_ROLE
+test_role
+SET role new_role;
+ERROR OP000: User ``@`localhost` has not been granted role `new_role`
+set default role test_role for ''@localhost;
+ERROR 42000: You are using MariaDB as an anonymous user and anonymous users are not allowed to modify user settings
+connection default;
+disconnect con1;
+REVOKE all privileges, grant option from ''@localhost;
+drop role new_role;
+drop role test_role;
+drop user test_user;

--- a/mysql-test/suite/roles/set_default_role_invalid_skip_name_resolve.test
+++ b/mysql-test/suite/roles/set_default_role_invalid_skip_name_resolve.test
@@ -1,0 +1,78 @@
+source include/not_embedded.inc;
+
+--echo #
+--echo # MDEV-26875: Wrong user in SET DEFAULT ROLE error
+--echo #
+create user test_user;
+create role test_role;
+show grants for test_user;
+--error ER_INVALID_ROLE
+set default role test_role for test_user;
+grant test_role to test_user;
+set default role test_role for test_user;
+show grants for test_user;
+set default role none for test_user;
+
+--echo #
+--echo # Try to set default role to role(`test_role`).
+--echo --------------------------------------------------------------
+show grants for test_role;
+create role new_role;
+grant new_role to test_role;
+show grants for test_role;
+# One can not set role to a role
+--error ER_INVALID_ROLE
+set default role new_role for test_role;
+
+--echo #
+--echo # Test of errors, where hostname cannot be resolved `test_user`
+--echo --------------------------------------------------------------
+# `new_role` is granted to `test_role`
+grant test_role to test_user@'%';
+set default role test_role for test_user@'%';
+
+connect con_test_user,127.0.0.1,test_user,,,$MASTER_MYPORT;
+show grants;
+select current_role;
+# `test_user` indirectly granted `new_role`
+--error ER_INVALID_ROLE
+set role `new_role`;
+
+connection default;
+set default role none for test_user;
+disconnect con_test_user;
+
+connect con_test_user,127.0.0.1,test_user,,,$MASTER_MYPORT;
+select current_role;
+--error ER_INVALID_ROLE
+set role `new_role`;
+
+connection default;
+disconnect con_test_user;
+
+--echo #
+--echo # Test of anonymous user connection
+--echo --------------------------------------------------------------
+--source include/add_anonymous_users.inc
+# Skip windows, since it uses current user `Administrator` in buildbot.
+--source include/not_windows.inc
+grant test_role to ''@localhost;
+
+connect(con1,localhost,'',,,$MASTER_MYPORT);
+SELECT CURRENT_ROLE;
+SET role test_role;
+SELECT CURRENT_ROLE;
+# user cannot set subset role, since it is not granted explicitly
+--error ER_INVALID_ROLE
+SET role new_role;
+--error ER_PASSWORD_ANONYMOUS_USER
+set default role test_role for ''@localhost;
+
+connection default;
+disconnect con1;
+REVOKE all privileges, grant option from ''@localhost;
+--source include/delete_anonymous_users.inc
+
+drop role new_role;
+drop role test_role;
+drop user test_user;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -3339,10 +3339,18 @@ end:
                                                 check_role_is_granted_callback,
                                                 NULL) == -1))
       {
-        /* Role is not granted but current user can see the role */
-        my_printf_error(ER_INVALID_ROLE, "User %`s@%`s has not been granted role %`s",
-                        MYF(0), thd->security_ctx->priv_user,
-                        thd->security_ctx->priv_host, rolename);
+        /* This happens for SET ROLE case and when `--skip-name-resolve` option
+           is used. In that situation host can be NULL and current user is always
+           target user, so printing `priv_user@priv_host` is not incorrect.
+         */
+        if (!host)
+          my_printf_error(ER_INVALID_ROLE, "User %`s@%`s has not been granted role %`s",
+                          MYF(0), thd->security_ctx->priv_user,
+                          thd->security_ctx->priv_host, rolename);
+        else
+          /* Role is not granted but current user can see the role */
+          my_printf_error(ER_INVALID_ROLE, "User %`s@%`s has not been granted role %`s",
+                          MYF(0), user, host, rolename);
       }
       else
       {


### PR DESCRIPTION
- Regression introduced in https://github.com/MariaDB/server/commit/957cb7b7ba355184aebf0f5dc91b7f2aa620c0e0
- Patch https://github.com/MariaDB/server/commit/4abb8216a054e14afbeb81e8529e02bab6fa14ac change `mysql.user` to `mysql.global_priv` for
`add_anonymous.inc`, update `delete_anonymous.inc`.
- Added test case with `--skip-name-resolve`
- Add test case with anonymous user
  - Disable this test for windows, assignes current user to anonymous
  user.

Reviewed by: <serg@mariadb.com>