### PR TITLE
MDEV-18591: mysql_install_db - pass --log-error to mysqld in install

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -148,7 +148,9 @@ parse_arguments()
       --builddir=*) builddir=`parse_arg "$arg"` ;;
       --srcdir=*)  srcdir=`parse_arg "$arg"` ;;
       --ldata=*|--datadir=*|--data=*) ldata=`parse_arg "$arg"` ;;
-      --log-error=*)
+      --log[-_]error=*)
+       # Keep in the arguments passed to the server
+       args="$args $arg"
        log_error=`parse_arg "$arg"` ;;
         # Note that the user will be passed to mysqld so that it runs
         # as 'user' (crucial e.g. if log-bin=/some_other_path/


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-18591*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Previously we parsed it out in mysql_install_db for use in the error message, but failed to pass it to mysqld in the bootstrap.

Thanks Michal Schorm for the test case.

## How can this PR be tested?

Successful case (rather silent)
```
$ mkdir -p /tmp/${PWD##*/}-datadir && scripts/mysql_install_db --no-defaults --srcdir=$OLDPWD --builddir=$PWD --datadir=/tmp/${PWD##*/}-datadir --verbose --log-error=/tmp/mysql.err
Installing MariaDB/MySQL system tables in '/tmp/build-mariadb-server-10.3-datadir' ...
2022-12-08 10:24:40 0 [Note] /home/dan/repos/build-mariadb-server-10.3/sql/mysqld (mysqld 10.3.38-MariaDB) starting as process 306909 ...
OK

~/repos/build-mariadb-server-10.3 
$ cat /tmp/mysql.err
2022-12-08 10:24:40 0 [Note] InnoDB: Using Linux native AIO
2022-12-08 10:24:40 0 [Note] InnoDB: The first innodb_system data file 'ibdata1' did not exist. A new tablespace will be created!
2022-12-08 10:24:40 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2022-12-08 10:24:40 0 [Note] InnoDB: Uses event mutexes
2022-12-08 10:24:40 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
2022-12-08 10:24:40 0 [Note] InnoDB: Number of pools: 1
2022-12-08 10:24:40 0 [Note] InnoDB: Using SSE2 crc32 instructions
2022-12-08 10:24:40 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
2022-12-08 10:24:40 0 [Note] InnoDB: Completed initialization of buffer pool
2022-12-08 10:24:40 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
2022-12-08 10:24:40 0 [Note] InnoDB: Setting file './ibdata1' size to 12 MB. Physically writing the file full; Please wait ...
2022-12-08 10:24:40 0 [Note] InnoDB: File './ibdata1' size is now 12 MB.
2022-12-08 10:24:40 0 [Note] InnoDB: Setting log file ./ib_logfile101 size to 50331648 bytes
2022-12-08 10:24:40 0 [Note] InnoDB: Setting log file ./ib_logfile1 size to 50331648 bytes
2022-12-08 10:24:40 0 [Note] InnoDB: Renaming log file ./ib_logfile101 to ./ib_logfile0
2022-12-08 10:24:40 0 [Note] InnoDB: New log files created, LSN=44897
2022-12-08 10:24:40 0 [Note] InnoDB: Doublewrite buffer not found: creating new
2022-12-08 10:24:40 0 [Note] InnoDB: Doublewrite buffer created
2022-12-08 10:24:40 0 [Note] InnoDB: 128 out of 128 rollback segments are active.
2022-12-08 10:24:40 0 [Note] InnoDB: Creating foreign key constraint system tables.
2022-12-08 10:24:40 0 [Note] InnoDB: Creating tablespace and datafile system tables.
2022-12-08 10:24:40 0 [Note] InnoDB: Creating sys_virtual system tables.
2022-12-08 10:24:40 0 [Note] InnoDB: Creating shared tablespace for temporary tables
2022-12-08 10:24:40 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
2022-12-08 10:24:40 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
2022-12-08 10:24:40 0 [Note] InnoDB: Waiting for purge to start
2022-12-08 10:24:40 0 [Note] InnoDB: 10.3.38 started; log sequence number 0; transaction id 7
```

Config error (enable-large-prefix removed from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=922018):
```
$ mkdir -p /tmp/${PWD##*/}-datadir && scripts/mysql_install_db --no-defaults --srcdir=$OLDPWD --builddir=$PWD --datadir=/tmp/${PWD##*/}-datadir --verbose --log-error=/tmp/mysql.err --enable-large-prefix
Installing MariaDB/MySQL system tables in '/tmp/build-mariadb-server-10.3-datadir' ...
2022-12-08 11:13:45 0 [Note] /home/dan/repos/build-mariadb-server-10.3/sql/mysqld (mysqld 10.3.38-MariaDB) starting as process 308757 ...

Installation of system tables failed!  Examine the logs in
/tmp/mysql.err or /tmp/build-mariadb-server-10.3-datadir for more information.

The problem could be conflicting information in an external
my.cnf files. You can ignore these by doing:

    shell> scripts/mysql_install_db --defaults-file=~/.my.cnf

You can also try to start the mysqld daemon with:

    shell> /home/dan/repos/build-mariadb-server-10.3/sql/mysqld --skip-grant-tables --general-log &

and use the command line tool /home/dan/repos/build-mariadb-server-10.3/client/mysql
to connect to the mysql database and look at the grant tables:

    shell> /home/dan/repos/build-mariadb-server-10.3/client/mysql -u root mysql
    mysql> show tables;

Try 'mysqld --help' if you have problems with paths.  Using
--general-log gives you a log in /tmp/build-mariadb-server-10.3-datadir that may be helpful.

The latest information about mysql_install_db is available at
https://mariadb.com/kb/en/installing-system-tables-mysql_install_db
You can find the latest source at https://downloads.mariadb.org and
the maria-discuss email list at https://launchpad.net/~maria-discuss

Please check all of the above before submitting a bug report
at http://mariadb.org/jira


~/repos/build-mariadb-server-10.3 
$ more /tmp/mysql.err
2022-12-08 11:13:45 0 [Note] InnoDB: Using Linux native AIO
2022-12-08 11:13:45 0 [Note] InnoDB: The first innodb_system data file 'ibdata1' did not exist. A new tablespace will be created!
2022-12-08 11:13:45 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2022-12-08 11:13:45 0 [Note] InnoDB: Uses event mutexes
2022-12-08 11:13:45 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
2022-12-08 11:13:45 0 [Note] InnoDB: Number of pools: 1
2022-12-08 11:13:45 0 [Note] InnoDB: Using SSE2 crc32 instructions
2022-12-08 11:13:45 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
2022-12-08 11:13:45 0 [Note] InnoDB: Completed initialization of buffer pool
2022-12-08 11:13:45 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
2022-12-08 11:13:45 0 [Note] InnoDB: Setting file './ibdata1' size to 12 MB. Physically writing the file full; Please wait ...
2022-12-08 11:13:45 0 [Note] InnoDB: File './ibdata1' size is now 12 MB.
2022-12-08 11:13:45 0 [Note] InnoDB: Setting log file ./ib_logfile101 size to 50331648 bytes
2022-12-08 11:13:45 0 [Note] InnoDB: Setting log file ./ib_logfile1 size to 50331648 bytes
2022-12-08 11:13:45 0 [Note] InnoDB: Renaming log file ./ib_logfile101 to ./ib_logfile0
2022-12-08 11:13:45 0 [Note] InnoDB: New log files created, LSN=44897
2022-12-08 11:13:45 0 [Note] InnoDB: Doublewrite buffer not found: creating new
2022-12-08 11:13:45 0 [Note] InnoDB: Doublewrite buffer created
2022-12-08 11:13:45 0 [Note] InnoDB: 128 out of 128 rollback segments are active.
2022-12-08 11:13:45 0 [Note] InnoDB: Creating foreign key constraint system tables.
2022-12-08 11:13:45 0 [Note] InnoDB: Creating tablespace and datafile system tables.
2022-12-08 11:13:45 0 [Note] InnoDB: Creating sys_virtual system tables.
2022-12-08 11:13:45 0 [Note] InnoDB: Creating shared tablespace for temporary tables
2022-12-08 11:13:45 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
2022-12-08 11:13:45 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
2022-12-08 11:13:45 0 [Note] InnoDB: Waiting for purge to start
2022-12-08 11:13:45 0 [Note] InnoDB: 10.3.38 started; log sequence number 0; transaction id 7
2022-12-08 11:13:45 0 [ERROR] /home/dan/repos/build-mariadb-server-10.3/sql/mysqld: unknown option '--enable-large-prefix'
2022-12-08 11:13:45 0 [ERROR] Aborting
```