### PR TITLE
MDEV-28910 Remove version compatibility hack

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -42,23 +42,13 @@
 #define SAFE_NAME_LEN (NAME_LEN + MYSQL50_TABLE_NAME_PREFIX_LENGTH)
 
 /*
-  MDEV-4088
-
-  MySQL (and MariaDB 5.x before the fix) was using the first character of the
-  server version string (as sent in the first handshake protocol packet) to
-  decide on the replication event formats. And for 10.x the first character
-  is "1", which the slave thought comes from some ancient 1.x version
-  (ignoring the fact that the first ever MySQL version was 3.x).
-
-  To support replication to these old clients, we fake the version in the
-  first handshake protocol packet to start from "5.5.5-" (for example,
-  it might be "5.5.5-10.0.1-MariaDB-debug-log".
-
-  On the client side we remove this fake version prefix to restore the
-  correct server version. The version "5.5.5" did not support
-  pluggable authentication, so any version starting from "5.5.5-" and
-  claiming to support pluggable auth, must be using this fake prefix.
+  MDEV-28910
+  As part the MDEV-4088 hack additional version information was added to
+  MariaDB for replication compatibility. This hack no longer needs to be
+  inserted but we still need older MariaDB versions that use it to be able
+  to connect
 */
+
 /* this version must be the one that *does not* support pluggable auth */
 #define RPL_VERSION_HACK "5.5.5-"
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8050,7 +8050,6 @@ mysqld_get_one_option(const struct my_option *opt, const char *argument,
       strmake(server_version, argument, sizeof(server_version) - 1);
       set_sys_var_value_origin(&server_version_ptr,
                 *filename ? sys_var::CONFIG : sys_var::COMMAND_LINE, filename);
-      using_custom_server_version= true;
     }
 #ifndef EMBEDDED_LIBRARY
     else

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -740,7 +740,6 @@ extern const char *mysql_real_data_home_ptr;
 extern ulong thread_handling;
 extern "C" MYSQL_PLUGIN_IMPORT char server_version[SERVER_VERSION_LENGTH];
 extern char *server_version_ptr;
-extern bool using_custom_server_version;
 extern MYSQL_PLUGIN_IMPORT char mysql_real_data_home[];
 extern char mysql_unpacked_real_data_home[];
 extern MYSQL_PLUGIN_IMPORT struct system_variables global_system_variables;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -13306,12 +13306,7 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio,
     data_len= SCRAMBLE_LENGTH;
   }
 
-  /* When server version is specified in config file, don't include
-     the replication hack prefix. */
-  if (using_custom_server_version)
-    end= strnmov(end, server_version, SERVER_VERSION_LENGTH) + 1;
-  else
-    end= strxnmov(end, SERVER_VERSION_LENGTH, RPL_VERSION_HACK, server_version, NullS) + 1;
+  end= strnmov(end, server_version, SERVER_VERSION_LENGTH) + 1;
 
   int4store((uchar*) end, mpvio->auth_info.thd->thread_id);
   end+= 4;


### PR DESCRIPTION
We had a version compatibility hack to make us compatible with MySQL 5.5. Now MySQL 5.5 is past EoL the hack is no longer needed and in fact can break compatibility with third-party tools.

Note that this is intended to be merged against 11.0 at such a time the branch exists, in the mean time I've made this a draft PR against 10.11.