### PR TITLE
Deb: MariaDB names as default for deb scripts

### DIFF
--- a/debian/additions/debian-start
+++ b/debian/additions/debian-start
@@ -17,12 +17,12 @@ if [ -f /etc/default/mariadb ]; then
   . /etc/default/mariadb
 fi
 
-MYSQL="/usr/bin/mysql --defaults-file=/etc/mysql/debian.cnf"
-MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
-# Don't run full mysql_upgrade on every server restart, use --version-check to do it only once
-MYUPGRADE="/usr/bin/mysql_upgrade --defaults-extra-file=/etc/mysql/debian.cnf --version-check --silent"
-MYCHECK="/usr/bin/mysqlcheck --defaults-file=/etc/mysql/debian.cnf"
-MYCHECK_SUBJECT="WARNING: mysqlcheck has found corrupt tables"
+MARIADB="/usr/bin/mariadb --defaults-file=/etc/mysql/debian.cnf"
+MYADMIN="/usr/bin/mariadb-admin --defaults-file=/etc/mysql/debian.cnf"
+# Don't run full mariadb-upgrade on every server restart, use --version-check to do it only once
+MYUPGRADE="/usr/bin/mariadb-upgrade --defaults-extra-file=/etc/mysql/debian.cnf --version-check --silent"
+MYCHECK="/usr/bin/mariadb-check --defaults-file=/etc/mysql/debian.cnf"
+MYCHECK_SUBJECT="WARNING: mariadb-check has found corrupt tables"
 MYCHECK_PARAMS="--all-databases --fast --silent"
 MYCHECK_RCPT="${MYCHECK_RCPT:-root}"
 

--- a/debian/additions/debian-start.inc.sh
+++ b/debian/additions/debian-start.inc.sh
@@ -11,7 +11,7 @@ function check_for_crashed_tables() {
   set -u
 
   # But do it in the background to not stall the boot process.
-  logger -p daemon.info -i -t$0 "Triggering myisam-recover for all MyISAM tables and aria-recover for all Aria tables"
+  logger -p daemon.info -i -t"$0" "Triggering myisam-recover for all MyISAM tables and aria-recover for all Aria tables"
 
   # Checking for $? is unreliable so the size of the output is checked.
   # Some table handlers like HEAP do not support CHECK TABLE.
@@ -20,15 +20,15 @@ function check_for_crashed_tables() {
   # We have to use xargs in this case, because a for loop barfs on the
   # spaces in the thing to be looped over.
 
-  # If a crashed table is encountered, the "mysql" command will return with a status different from 0
+  # If a crashed table is encountered, the "mariadb" command will return with a status different from 0
   set +e
 
-  LC_ALL=C $MYSQL --skip-column-names --batch -e  '
+  LC_ALL=C $MARIADB --skip-column-names --batch -e  '
       select concat('\''select count(*) into @discard from `'\'',
                     TABLE_SCHEMA, '\''`.`'\'', TABLE_NAME, '\''`'\'')
       from information_schema.TABLES where TABLE_SCHEMA<>'\''INFORMATION_SCHEMA'\'' and TABLE_SCHEMA<>'\''PERFORMANCE_SCHEMA'\'' and ( ENGINE='\''MyISAM'\'' or ENGINE='\''Aria'\'' )' | \
-    xargs -i $MYSQL --skip-column-names --silent --batch \
-                    --force -e "{}" &>$tempfile
+    xargs -i "${MARIADB}" --skip-column-names --silent --batch \
+                    --force -e "{}" &>"${tempfile}"
   set -e
 
   if [ -s "$tempfile" ]; then
@@ -37,14 +37,14 @@ function check_for_crashed_tables() {
         "Improperly closed tables are also reported if clients are accessing\n" \
  	"the tables *now*. A list of current connections is below.\n";
        $MYADMIN processlist status
-    ) >> $tempfile
+    ) >> "${tempfile}"
     # Check for presence as a dependency on mailx would require an MTA.
     if [ -x /usr/bin/mailx ]; then
-      mailx -e -s"$MYCHECK_SUBJECT" $MYCHECK_RCPT < $tempfile
+      mailx -e -s"$MYCHECK_SUBJECT" $MYCHECK_RCPT < "$tempfile"
     fi
-    (echo "$MYCHECK_SUBJECT"; cat $tempfile) | logger -p daemon.warn -i -t$0
+    (echo "$MYCHECK_SUBJECT"; cat "${tempfile}") | logger -p daemon.warn -i -t"$0"
   fi
-  rm $tempfile
+  rm "${tempfile}"
 }
 
 ## Check for tables needing an upgrade.
@@ -54,14 +54,14 @@ function upgrade_system_tables_if_necessary() {
   set -e
   set -u
 
-  logger -p daemon.info -i -t$0 "Upgrading MySQL tables if necessary."
+  logger -p daemon.info -i -t"$0" "Upgrading MySQL tables if necessary."
 
   # Filter all "duplicate column", "duplicate key" and "unknown column"
   # errors as the script is designed to be idempotent.
   LC_ALL=C $MYUPGRADE \
     2>&1 \
     | egrep -v '^(1|@had|ERROR (1051|1054|1060|1061|1146|1347|1348))' \
-    | logger -p daemon.warn -i -t$0
+    | logger -p daemon.warn -i -t"$0"
 }
 
 ## Check for the presence of both, root accounts with and without password.
@@ -70,10 +70,10 @@ function check_root_accounts() {
   set -e
   set -u
 
-  logger -p daemon.info -i -t$0 "Checking for insecure root accounts."
+  logger -p daemon.info -i -t"$0" "Checking for insecure root accounts."
 
-  ret=$( echo "SELECT count(*) FROM mysql.user WHERE user='root' and password='' and plugin in ('', 'mysql_native_password', 'mysql_old_password');" | $MYSQL --skip-column-names )
+  ret=$( echo "SELECT count(*) FROM mysql.user WHERE user='root' and password='' and plugin in ('', 'mysql_native_password', 'mysql_old_password');" | "$MARIADB" --skip-column-names )
   if [ "$ret" -ne "0" ]; then
-    logger -p daemon.warn -i -t$0 "WARNING: mysql.user contains $ret root accounts without password!"
+    logger -p daemon.warn -i -t"$0" "WARNING: mysql.user contains $ret root accounts without password!"
   fi
 }

--- a/debian/mariadb-server-10.5.postinst
+++ b/debian/mariadb-server-10.5.postinst
@@ -20,7 +20,7 @@ set -o pipefail
 
 case "$1" in
   configure)
-    # This is needed because mysql_install_db removes the pid file in /run
+    # This is needed because mariadb-install-db removes the pid file in /run
     # and because changed configuration options should take effect immediately.
     # In case the server wasn't running at all it should be ok if the stop
     # script fails. I can't tell at this point because of the cleaned /run.
@@ -165,12 +165,12 @@ EOF
 
     # initiate databases. Output is not allowed by debconf :-(
     # This will fail if we are upgrading an existing database; in this case
-    # mysql_upgrade, called from the /etc/init.d/mariadb start script, will
+    # mariadb-upgrade, called from the /etc/mysql/debian-start script, will
     # handle things.
     # Debian: beware of the bashisms...
     # Debian: can safely run on upgrades with existing databases
     set +e
-    bash /usr/bin/mysql_install_db --rpm --cross-bootstrap --user=mysql \
+    bash /usr/bin/mariadb-install-db --rpm --cross-bootstrap --user=mysql \
                                    --disable-log-bin  --skip-test-db 2>&1 | \
                                    $ERR_LOGGER
     set -e

--- a/mysql-test/README
+++ b/mysql-test/README
@@ -93,7 +93,7 @@ https://mariadb.org/jira/.
 If the test case is really big or if it contains 'not public' data,
 then put your .test file and .result file(s) into a tar.gz archive,
 add a README that explains the problem, ftp the archive to
-ftp://ftp.askmonty.org/private and submit a report to
+ftp://ftp.mariadb.org/private and submit a report to
 https://mariadb.org/jira about it.
 
 The latest information about mysql-test-run can be found at:

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -593,17 +593,17 @@ else
   echo
   echo "    shell> $0 --defaults-file=~/.my.cnf"
   echo
-  echo "You can also try to start the mysqld daemon with:"
+  echo "You can also try to start the mariadbd daemon with:"
   echo
   echo "    shell> $mysqld --skip-grant-tables --general-log &"
   echo
-  echo "and use the command line tool $bindir/mysql"
+  echo "and use the command line tool $bindir/mariadb"
   echo "to connect to the mysql database and look at the grant tables:"
   echo
-  echo "    shell> $bindir/mysql -u root mysql"
-  echo "    mysql> show tables;"
+  echo "    shell> $bindir/mariadb -u root mysql"
+  echo "    MariaDB> show tables;"
   echo
-  echo "Try 'mysqld --help' if you have problems with paths.  Using"
+  echo "Try '$mysqld --help' if you have problems with paths.  Using"
   echo "--general-log gives you a log in $ldata that may be helpful."
   link_to_help
   echo "You can find the latest source at https://downloads.mariadb.org and"
@@ -621,8 +621,8 @@ fi
 if test "$cross_bootstrap" -eq 0 && test -z "$srcdir"
 then
   s_echo
-  s_echo "To start mysqld at boot time you have to copy"
-  s_echo "support-files/mysql.server to the right place for your system"
+  s_echo "To start mariadbd at boot time you have to copy"
+  s_echo "support-files/mariadb.service to the right place for your system"
 
   if test "$auth_root_authentication_method" = normal
   then
@@ -631,7 +631,7 @@ then
     echo "PLEASE REMEMBER TO SET A PASSWORD FOR THE MariaDB root USER !"
     echo "To do so, start the server, then issue the following command:"
     echo
-    echo "'$bindir/mysql_secure_installation'"
+    echo "'$bindir/mariadb-secure-installation'"
     echo
     echo "which will also give you the option of removing the test"
     echo "databases and anonymous user created by default.  This is"
@@ -655,10 +655,10 @@ then
   then
     echo
     echo "You can start the MariaDB daemon with:"
-    echo "cd '$basedir' ; $bindir/mysqld_safe --datadir='$ldata'"
+    echo "cd '$basedir' ; $bindir/mariadb-safe --datadir='$ldata'"
     echo
     echo "You can test the MariaDB daemon with mysql-test-run.pl"
-    echo "cd '$basedir/mysql-test' ; perl mysql-test-run.pl"
+    echo "cd '$basedir/@INSTALL_MYSQLTESTDIR@' ; perl mariadb-test-run.pl"
   fi
 
   echo

--- a/support-files/rpm/server-postin.sh
+++ b/support-files/rpm/server-postin.sh
@@ -58,7 +58,7 @@ if [ $1 = 1 ] ; then
     mkdir -p $datadir
 
     # Initiate databases
-    %{_bindir}/mysql_install_db --rpm --user=%{mysqld_user}
+    %{_bindir}/mariadb-install-db --rpm --user=%{mysqld_user}
   fi
 
   # Change permissions again to fix any new files.


### PR DESCRIPTION
And a small bit of shell escaping.

Also include the ftp.mariadb.org script rather than old name.