### PR TITLE
MDEV-30222: display errno for popen failures

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -1795,7 +1795,10 @@ static int run_command(char* cmd,
 
   if (!(res_file= my_popen(cmd, "r")))
   {
-    report_or_die("popen(\"%s\", \"r\") failed", cmd);
+#ifdef _WIN32
+    my_osmaperr(GetLastError());
+#endif
+    report_or_die("popen(\"%s\", \"r\") failed (errno %d)", cmd, errno);
     DBUG_RETURN(-1);
   }
 
@@ -1896,7 +1899,12 @@ static int diff_check(const char *diff_name)
   my_snprintf(buf, sizeof(buf), "%s -v", diff_name);
 
   if (!(res_file= my_popen(buf, "r")))
-    die("popen(\"%s\", \"r\") failed", buf);
+  {
+#ifdef _WIN32
+    my_osmaperr(GetLastError());
+#endif
+    die("popen(\"%s\", \"r\") failed (errno %d)", buf, errno);
+  }
 
   /*
     if diff is not present, nothing will be in stdout to increment
@@ -3355,9 +3363,12 @@ void do_exec(struct st_command *command)
 
   if (!(res_file= my_popen(ds_cmd.str, "r")))
   {
+#ifdef _WIN32
+    my_osmaperr(GetLastError());
+#endif
     dynstr_free(&ds_cmd);
     if (command->abort_on_error)
-      report_or_die("popen(\"%s\", \"r\") failed", command->first_argument);
+      report_or_die("popen(\"%s\", \"r\") failed (errno %d)", command->first_argument, errno);
     DBUG_VOID_RETURN;
   }
 
@@ -4575,8 +4586,11 @@ void do_perl(struct st_command *command)
 
     if (!(res_file= my_popen(buf, "r")))
     {
+#ifdef _WIN32
+      my_osmaperr(GetLastError());
+#endif
       if (command->abort_on_error)
-        die("popen(\"%s\", \"r\") failed", buf);
+        die("popen(\"%s\", \"r\") failed (errno %d)", buf, errno);
       dynstr_free(&ds_delimiter);
       DBUG_VOID_RETURN;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30222*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

getting the errno on popen execs is a good first step for this MDEV.

Seems branch pushes don't hit aix.

## How can this PR be tested?

AIX should fail based on the bug report and show the errno.
