### PR TITLE
Fix build failure in sanitizer on GitLab-CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,7 @@ variables:
       echo "$package"
       rpm -qlpv "$package" | awk '{print $1 " " $3 "/" $4 " ." $9 " " $10 " " $11}' | sort -k 3
       echo "------------------------------------------------"
-    done >> ../rpmlist-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
+    done >> "../rpmlist-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log"
   # CPackRPM lists contents in build log, so no need to show the output of this,
   # just store it as a build artifact that can be downloaded and diffed against
   # other builds to detect which files where added/removed/moved
@@ -182,7 +182,7 @@ fedora-sanitizer:
     GIT_SUBMODULE_STRATEGY: normal
   script:
     - yum install -y yum-utils rpm-build openssl-devel clang
-    - yum install -y /usr/lib64/libasan.so.6.0.0 /usr/lib64/libtsan.so.0.0.0 /usr/lib64/libubsan.so.1.0.0
+    - yum install -y libasan libtsan libubsan
     # This repository does not have any .spec files, so install dependencies based on Fedora spec file
     - yum-builddep -y mariadb-server
     - mkdir builddir; cd builddir
@@ -305,6 +305,8 @@ mysql-test-run:
   stage: test
   dependencies:
     - fedora
+  needs:
+    - fedora
   <<: *mysql-test-run-def
   artifacts:
     when: always  # Also show results when tests fail
@@ -326,6 +328,8 @@ mysql-test-run-asan:
     RESTART_POLICY: "--force-restart"
   dependencies:
     - "fedora-sanitizer: [-DWITH_ASAN=YES]"
+  needs:
+    - "fedora-sanitizer: [-DWITH_ASAN=YES]"
   <<: *mysql-test-run-def
   artifacts:
     when: always  # Also show results when tests fail
@@ -338,6 +342,8 @@ mysql-test-run-tsan:
   variables:
     RESTART_POLICY: "--force-restart"
   dependencies:
+    - "fedora-sanitizer: [-DWITH_TSAN=YES]"
+  needs:
     - "fedora-sanitizer: [-DWITH_TSAN=YES]"
   <<: *mysql-test-run-def
   allow_failure: true
@@ -353,6 +359,8 @@ mysql-test-run-ubsan:
     RESTART_POLICY: "--force-restart"
   dependencies:
     - "fedora-sanitizer: [-DWITH_UBSAN=YES]"
+  needs:
+    - "fedora-sanitizer: [-DWITH_UBSAN=YES]"
   <<: *mysql-test-run-def
   allow_failure: true
   artifacts:
@@ -367,6 +375,8 @@ mysql-test-run-msan:
     RESTART_POLICY: "--force-restart"
   dependencies:
     - "fedora-sanitizer: [-DWITH_MSAN=YES]"
+  needs:
+    - "fedora-sanitizer: [-DWITH_MSAN=YES]"
   <<: *mysql-test-run-def
   allow_failure: true
   artifacts:
@@ -378,6 +388,8 @@ mysql-test-run-msan:
 rpmlint:
   stage: test
   dependencies:
+    - fedora
+  needs:
     - fedora
   script:
     - yum install -y rpmlint
@@ -395,6 +407,8 @@ rpmlint:
 fedora install:
   stage: test
   dependencies:
+    - fedora
+  needs:
     - fedora
   script:
     - rm -f rpm/*debuginfo*  # Not relevant in this test
@@ -428,6 +442,8 @@ fedora install:
 fedora upgrade:
   stage: test
   dependencies:
+    - fedora
+  needs:
     - fedora
   script:
     - dnf install -y mariadb-server


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Sanitizer tests were introduced in 617f45b for GitLab CI, but started failing on latest Fedora version with error:

    $ yum install -y /usr/lib64/libasan.so.6.0.0 /usr/lib64/libtsan.so.0.0.0 /usr/lib64/libubsan.so.1.0.0
    Last metadata expiration check: 0:00:51 ago on Fri Dec  9 20:05:01 2022.
    No match for argument: /usr/lib64/libasan.so.6.0.0
    No match for argument: /usr/lib64/libtsan.so.0.0.0
    Error: Unable to find a match: /usr/lib64/libasan.so.6.0.0 /usr/lib64/libtsan.so.0.0.0

The reason for using specific library versions is unknown. Switch to simply using latest package versions, as is works and is likely to work best in the long run.

Also, enclose "../rpmlist-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log" in quotes to avoid `ambiguous redirect` error when $CI_JOB_NAME has spaces.

Additionally use "needs" statements to allow tests to run immediately after dependent jobs passed instead of waiting for the full stage to complete.

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services

## How can this PR be tested?

These changes to not impact the engine code and will not impact any automated tests.

Tests of the GitLab CI can be seen in public mirrors hosted on GitLab instances (e.g., https://salsa.debian.org/robinnewhouse/mariadb-server-mirror/-/pipelines/470329).

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version

- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

