### PR TITLE
header typos

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -33,12 +33,12 @@ extern "C" {
 #include "my_compare.h"
 #include "my_tree.h"
 
-	/* defines used by heap-funktions */
+	/* defines used by heap-functions */
 
 #define HP_MAX_LEVELS	4		/* 128^5 records is enough */
 #define HP_PTRS_IN_NOD	128
 
-	/* struct used with heap_funktions */
+	/* struct used with heap_functions */
 
 typedef struct st_heapinfo		/* Struct from heap_info */
 {
@@ -107,7 +107,7 @@ typedef struct st_heap_block
   ulong last_allocated; /* number of records there is allocated space for */
 } HP_BLOCK;
 
-struct st_heap_info;			/* For referense */
+struct st_heap_info;			/* For reference */
 
 typedef struct st_hp_keydef		/* Key definition with open */
 {

--- a/include/json_lib.h
+++ b/include/json_lib.h
@@ -371,7 +371,7 @@ int json_find_paths_next(json_engine_t *je, json_find_paths_t *state);
 
 
 /*
-  Converst JSON string constant into ordinary string constant
+  Convert JSON string constant into ordinary string constant
   which can involve unpacking json escapes and changing character set.
   Returns negative integer in the case of an error,
   the length of the result otherwise.
@@ -382,7 +382,7 @@ int json_unescape(CHARSET_INFO *json_cs,
                   uchar *res, uchar *res_end);
 
 /*
-  Converst ordinary string constant into JSON string constant.
+  Convert ordinary string constant into JSON string constant.
   which can involve appropriate escaping and changing character set.
   Returns negative integer in the case of an error,
   the length of the result otherwise.

--- a/include/m_ctype.h
+++ b/include/m_ctype.h
@@ -14,7 +14,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
 
 /*
-  A better inplementation of the UNIX ctype(3) library.
+  A better implementation of the UNIX ctype(3) library.
 */
 
 #ifndef _m_ctype_h
@@ -123,7 +123,7 @@ uint16 *my_uca_contraction2_weight(const MY_CONTRACTIONS *c,
                                    my_wc_t wc1, my_wc_t wc2);
 
 
-/* Collation weights on a single level (e.g. primary, secondary, tertiarty) */
+/* Collation weights on a single level (e.g. primary, secondary, tertiary) */
 typedef struct my_uca_level_info_st
 {
   my_wc_t maxchar;
@@ -953,7 +953,7 @@ uint32 my_convert(char *to, uint32 to_length, CHARSET_INFO *to_cs,
   An extended version of my_convert(), to pass non-default mb_wc() and wc_mb().
   For example, String::copy_printable() which is used in
   Protocol::store_warning() uses this to escape control
-  and non-convertable characters.
+  and non-convertible characters.
 */
 uint32 my_convert_using_func(char *to, size_t to_length, CHARSET_INFO *to_cs,
                              my_charset_conv_wc_mb mb_wc,
@@ -1041,7 +1041,7 @@ size_t my_convert_fix(CHARSET_INFO *dstcs, char *dst, size_t dst_length,
   @param str - the beginning of the string
   @param end - the string end (the next byte after the string)
   @return    >0, for a multi-byte character
-  @rerurn    0,  for a single byte character, broken sequence, empty string.
+  @return    0,  for a single byte character, broken sequence, empty string.
 */
 static inline
 uint my_ismbchar(CHARSET_INFO *cs, const char *str, const char *end)

--- a/include/ma_dyncol.h
+++ b/include/ma_dyncol.h
@@ -78,7 +78,7 @@ enum enum_dyncol_func_result
   ER_DYNCOL_YES= 1,                /* For functions returning 0/1 */
   ER_DYNCOL_FORMAT= -1,            /* Wrong format of the encoded string */
   ER_DYNCOL_LIMIT=  -2,            /* Some limit reached */
-  ER_DYNCOL_RESOURCE= -3,          /* Out of resourses */
+  ER_DYNCOL_RESOURCE= -3,          /* Out of resources */
   ER_DYNCOL_DATA= -4,              /* Incorrect input data */
   ER_DYNCOL_UNKNOWN_CHARSET= -5,   /* Unknown character set */
   ER_DYNCOL_TRUNCATED= 2           /* OK, but data was truncated */

--- a/include/my_base.h
+++ b/include/my_base.h
@@ -125,7 +125,7 @@ enum ha_extra_function {
   HA_EXTRA_NO_USER_CHANGE=9,		/* No user is allowed to write */
   HA_EXTRA_KEY_CACHE=10,
   HA_EXTRA_NO_KEY_CACHE=11,
-  HA_EXTRA_WAIT_LOCK=12,		/* Wait until file is avalably (def) */
+  HA_EXTRA_WAIT_LOCK=12,		/* Wait until file is available (def) */
   HA_EXTRA_NO_WAIT_LOCK=13,		/* If file is locked, return quickly */
   HA_EXTRA_WRITE_CACHE=14,		/* Use write cache in ha_write() */
   HA_EXTRA_FLUSH_CACHE=15,		/* flush write_record_cache */
@@ -288,7 +288,7 @@ enum ha_base_keytype {
   This flag can be calculated -- it's based on key lengths comparison.
 */
 #define HA_KEY_HAS_PART_KEY_SEG 65536
-/* Internal Flag Can be calcaluted */
+/* Internal Flag Can be calculated */
 #define HA_INVISIBLE_KEY 2<<18
 	/* Automatic bits in key-flag */
 
@@ -435,9 +435,9 @@ enum ha_base_keytype {
 #define HA_ERR_FIRST            120     /* Copy of first error nr.*/
 
 #define HA_ERR_KEY_NOT_FOUND	120	/* Didn't find key on read or update */
-#define HA_ERR_FOUND_DUPP_KEY	121	/* Dupplicate key on write */
+#define HA_ERR_FOUND_DUPP_KEY	121	/* Duplicate key on write */
 #define HA_ERR_INTERNAL_ERROR   122     /* Internal error */
-#define HA_ERR_RECORD_CHANGED	123	/* Uppdate with is recoverable */
+#define HA_ERR_RECORD_CHANGED	123	/* Update with is recoverable */
 #define HA_ERR_WRONG_INDEX	124	/* Wrong index given to function */
 #define HA_ERR_CRASHED		126	/* Indexfile is crashed */
 #define HA_ERR_WRONG_IN_RECORD	127	/* Record-file is crashed */
@@ -453,7 +453,7 @@ enum ha_base_keytype {
 #define HA_ERR_UNSUPPORTED	138	/* unsupported extension used */
 #define HA_ERR_TO_BIG_ROW	139	/* Too big row */
 #define HA_WRONG_CREATE_OPTION	140	/* Wrong create option */
-#define HA_ERR_FOUND_DUPP_UNIQUE 141	/* Dupplicate unique on write */
+#define HA_ERR_FOUND_DUPP_UNIQUE 141	/* Duplicate unique on write */
 #define HA_ERR_UNKNOWN_CHARSET	 142	/* Can't open charset */
 #define HA_ERR_WRONG_MRG_TABLE_DEF 143  /* conflicting tables in MERGE */
 #define HA_ERR_CRASHED_ON_REPAIR 144	/* Last (automatic?) repair failed */
@@ -497,7 +497,7 @@ enum ha_base_keytype {
                                             illegal data being read */
 #define HA_ERR_NEW_FILE	          172	 /* New file format */
 #define HA_ERR_ROWS_EVENT_APPLY   173    /* The event could not be processed
-                                            no other hanlder error happened */
+                                            no other handler error happened */
 #define HA_ERR_INITIALIZATION     174    /* Error during initialization */
 #define HA_ERR_FILE_TOO_SHORT	  175	 /* File too short */
 #define HA_ERR_WRONG_CRC	  176	 /* Wrong CRC on page */

--- a/include/my_decimal_limits.h
+++ b/include/my_decimal_limits.h
@@ -32,7 +32,7 @@
   digits in one our big digit decreased by 1 (because we always put decimal
   point on the border of our big digits))
 
-  With normal precession we can handle 65 digits. MariaDB can store in
+  With normal precision we can handle 65 digits. MariaDB can store in
   the .frm up to 63 digits.  By default we use DECIMAL_NOT_SPECIFIED digits
   when converting strings to decimal, so we don't want to set this too high.
   To not use up all digits for the scale we limit the number of decimals to

--- a/include/my_dir.h
+++ b/include/my_dir.h
@@ -70,7 +70,7 @@ typedef struct my_stat
   dev_t		st_rdev;	/* more major & minor device numbers (???) */
   off_t		st_size;	/* size of file */
   time_t	st_atime;	/* time for last read */
-  time_t	st_mtime;	/* time for last contens modify */
+  time_t	st_mtime;	/* time for last contents modify */
   time_t	st_ctime;	/* time for last inode or contents modify */
 } MY_STAT;
 

--- a/include/my_global.h
+++ b/include/my_global.h
@@ -675,7 +675,7 @@ typedef SOCKET_SIZE_TYPE size_socket;
   the mismatch of CRT and mysys file IO usage on Windows at runtime.
   CRT file descriptors can be in the range 0-2047, whereas descriptors returned
   by my_open() will start with 2048. If a file descriptor with value less then
-  MY_FILE_MIN is passed to mysys IO function, chances are it stemms from
+  MY_FILE_MIN is passed to mysys IO function, chances are it stems from
   open()/fileno() and not my_open()/my_fileno.
 
   For Posix,  mysys functions are light wrappers around libc, and MY_FILE_MIN
@@ -896,7 +896,7 @@ typedef long long	my_ptrdiff_t;
 #define STDCALL
 #endif
 
-/* Typdefs for easyier portability */
+/* Typdefs for easier portability */
 
 #ifndef HAVE_UCHAR
 typedef unsigned char	uchar;	/* Short for unsigned char */

--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -444,7 +444,7 @@ typedef struct st_io_cache		/* Used when caching files */
   /*
     A caller will use my_b_read() macro to read from the cache
     if the data is already in cache, it will be simply copied with
-    memcpy() and internal variables will be accordinging updated with
+    memcpy() and internal variables will be accordingly updated with
     no functions invoked. However, if the data is not fully in the cache,
     my_b_read() will call read_function to fetch the data. read_function
     must never be invoked directly.
@@ -488,7 +488,7 @@ typedef struct st_io_cache		/* Used when caching files */
   myf	myflags;			/* Flags used to my_read/my_write */
   /*
     alloced_buffer is set to the size of the buffer allocated for the IO_CACHE.
-    Includes the overhead(storing key to ecnrypt and decrypt) for encryption.
+    Includes the overhead(storing key to encrypt and decrypt) for encryption.
     Set to 0 if nothing is allocated.
     Currently READ_NET is the only one that will use a buffer allocated
     somewhere else
@@ -997,7 +997,7 @@ static inline my_hrtime_t make_hr_time(my_time_t time, ulong time_sec_part)
 #define my_munmap(a,b)          munmap((a),(b))
 
 #else
-/* not a complete set of mmap() flags, but only those that nesessary */
+/* not a complete set of mmap() flags, but only those that necessary */
 #define PROT_READ        1
 #define PROT_WRITE       2
 #define MAP_NORESERVE    0

--- a/include/myisam.h
+++ b/include/myisam.h
@@ -15,7 +15,7 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
 
-/* This file should be included when using myisam_funktions */
+/* This file should be included when using myisam_functions */
 
 #ifndef _myisam_h
 #define _myisam_h
@@ -159,7 +159,7 @@ typedef struct st_mi_create_info
   my_bool with_auto_increment;
 } MI_CREATE_INFO;
 
-struct st_myisam_info;			/* For referense */
+struct st_myisam_info;			/* For reference */
 struct st_mi_isam_share;
 typedef struct st_myisam_info MI_INFO;
 struct st_mi_s_param;

--- a/include/myisammrg.h
+++ b/include/myisammrg.h
@@ -14,7 +14,7 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA */
 
-/* This file should be included when using merge_isam_funktions */
+/* This file should be included when using merge_isam_functions */
 
 #ifndef _myisammrg_h
 #define _myisammrg_h
@@ -51,7 +51,7 @@ typedef struct st_mymerge_info		/* Struct from h_info */
   ulonglong data_file_length;
   ulonglong dupp_key_pos;               /* Offset of the Duplicate key in the merge table */
   uint	reclength;			/* Recordlength */
-  int	errkey;				/* With key was dupplicated on err */
+  int	errkey;				/* With key was duplicated on err */
   uint	options;			/* HA_OPTION_... used */
   ulong *rec_per_key;			/* for sql optimizing */
 } MYMERGE_INFO;

--- a/include/mysql.h
+++ b/include/mysql.h
@@ -655,7 +655,7 @@ enum enum_mysql_stmt_state
 
   length         - On input: in case when lengths of input values
                    are different for each execute, you can set this to
-                   point at a variable containining value length. This
+                   point at a variable containing value length. This
                    way the value length can be different in each execute.
                    If length is not NULL, buffer_length is not used.
                    Note, length can even point at buffer_length if

--- a/include/mysql/plugin_ftparser.h
+++ b/include/mysql/plugin_ftparser.h
@@ -101,7 +101,7 @@ enum enum_ft_token_type
     <0 Must not be present
     0  Neither; the word is optional but its presence increases the relevance
   With the default settings of the ft_boolean_syntax system variable,
-  >0 corresponds to the '+' operator, <0 corrresponds to the '-' operator,
+  >0 corresponds to the '+' operator, <0 corresponds to the '-' operator,
   and 0 means neither operator was used.
 
   weight_adjust: A weighting factor that determines how much a match

--- a/include/mysql/psi/mysql_thread.h
+++ b/include/mysql/psi/mysql_thread.h
@@ -588,7 +588,7 @@ typedef struct st_mysql_cond mysql_cond_t;
   This function creates both the thread instrumentation and a thread.
   @c mysql_thread_create is a replacement for @c pthread_create.
   The parameter P4 (or, if it is NULL, P1) will be used as the
-  instrumented thread "indentity".
+  instrumented thread "identity".
   Providing a P1 / P4 parameter with a different value for each call
   will on average improve performances, since this thread identity value
   is used internally to randomize access to data and prevent contention.

--- a/include/mysql/service_base64.h
+++ b/include/mysql/service_base64.h
@@ -29,7 +29,7 @@ extern "C" {
 #include <stdlib.h>
 #endif
 
-/* Allow multuple chunks 'AAA= AA== AA==', binlog uses this */
+/* Allow multiple chunks 'AAA= AA== AA==', binlog uses this */
 #define MY_BASE64_DECODE_ALLOW_MULTIPLE_CHUNKS 1
 
 extern struct base64_service_st {

--- a/include/mysql/service_my_snprintf.h
+++ b/include/mysql/service_my_snprintf.h
@@ -40,7 +40,7 @@
   @post
   The syntax of a format string is generally the same:
   % <flag> <width> <precision> <length modifier> <format>
-  where everithing but the format is optional.
+  where everything but the format is optional.
 
   Three one-character flags are recognized:
     '0' has the standard zero-padding semantics;

--- a/include/mysql/service_thd_timezone.h
+++ b/include/mysql/service_thd_timezone.h
@@ -16,7 +16,7 @@
 
 /**
   @file
-  This service provdes functions to convert between my_time_t and
+  This service provides functions to convert between my_time_t and
   MYSQL_TIME taking into account the current value of the time_zone
   session variable.
 

--- a/include/queues.h
+++ b/include/queues.h
@@ -24,7 +24,7 @@
 */
 
 /*
-  Code for generell handling of priority Queues.
+  Code for general handling of priority Queues.
   Implementation of queues from "Algorithms in C" by Robert Sedgewick.
 */
 

--- a/include/waiting_threads.h
+++ b/include/waiting_threads.h
@@ -81,7 +81,7 @@ typedef struct st_wt_thd {
     1. Latest
         Keep all weights equal.
     2. Random
-        Assight weights at random.
+        Assign weights at random.
         (variant: modify a weight randomly before every lock request)
     3. Youngest
         Set weight to -NOW()


### PR DESCRIPTION
10.3 version

https://github.com/MariaDB/server/pull/2348

<s>sed -i "s/extendible/extendable/g" server/include/lf.h</s>

extendible is an alternate spelling of extendable

some header typos appeared in newer versions than 10.3

include/heap.h
include/json_lib.h
include/m_ctype.h
include/ma_dyncol.h
include/my_base.h
include/my_decimal_limits.h
include/my_dir.h
include/my_global.h
include/my_sys.h
include/myisam.h
include/myisammrg.h
include/mysql.h
include/mysql/plugin_ftparser.h
include/mysql/psi/mysql_thread.h
include/mysql/service_base64.h
include/mysql/service_my_snprintf.h
include/mysql/service_thd_timezone.h
include/queues.h
include/waiting_threads.h