### PR TITLE
MDEV-30275: mariadb names rather than mysql names should be used

### DIFF
--- a/debian/mariadb-server-10.5.mariadb.init
+++ b/debian/mariadb-server-10.5.mariadb.init
@@ -25,6 +25,12 @@ SELF=$(cd $(dirname $0); pwd -P)/$(basename $0)
 
 MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 
+if [ ! -x /usr/bin/mariadbd-safe ]
+then
+  log_failure_msg "/usr/bin/mariadbd-safe not found or executable! This SysV init script depends on it."
+  exit -1
+fi
+
 # priority can be overridden and "-s" adds output to stderr
 ERR_LOGGER="logger -p daemon.err -t /etc/init.d/mariadb -i"
 
@@ -118,7 +124,7 @@ case "${1:-''}" in
     test -e /run/mysqld || install -m 755 -o mysql -g root -d /run/mysqld
 
     # Start MariaDB!
-    /usr/bin/mysqld_safe "${@:2}" 2>&1 >/dev/null | $ERR_LOGGER &
+    /usr/bin/mariadbd-safe "${@:2}" 2>&1 >/dev/null | $ERR_LOGGER &
 
     for i in $(seq 1 "${MYSQLD_STARTUP_TIMEOUT:-30}"); do
       sleep 1

--- a/debian/tests/smoke
+++ b/debian/tests/smoke
@@ -40,28 +40,28 @@ else
   echo "Found systemctl, continuing smoke test.."
 fi
 
-mysql <<EOT
+mariadb <<EOT
 CREATE DATABASE testdatabase;
 CREATE USER 'testuser'@'localhost' identified by 'testpassword';
 GRANT ALL ON testdatabase.* TO 'testuser'@'localhost';
 EOT
 
-mysql testdatabase <<EOT
+mariadb testdatabase <<EOT
 CREATE TABLE foo (bar INTEGER);
 INSERT INTO foo (bar) VALUES (41);
 EOT
 
-result=$(echo 'SELECT bar+1 FROM foo;'|mysql --batch --skip-column-names --user=testuser --password=testpassword testdatabase)
+result=$(echo 'SELECT bar+1 FROM foo;'|mariadb --batch --skip-column-names --user=testuser --password=testpassword testdatabase)
 if [ "$result" != "42" ]; then
        echo "Unexpected result" >&2
        exit 1
 fi
 
-mysql --user=testuser --password=testpassword testdatabase <<EOT
+mariadb --user=testuser --password=testpassword testdatabase <<EOT
 DROP TABLE foo;
 EOT
 
-mysql <<EOT
+mariadb <<EOT
 DROP DATABASE testdatabase;
 DROP USER 'testuser'@'localhost';
 EOT
@@ -89,7 +89,7 @@ if [ "$(dpkg-architecture -qDEB_HOST_ARCH_BITS)" != 32 ] &&
   LOG=/var/lib/mysql/#rocksdb/LOG
   # XXX: The server may only be started during the install of
   #      mariadb-server-10.5, which happens before that of the plugin.
-  [ -e $LOG ] || mysql -e "INSTALL PLUGIN RocksDB SONAME 'ha_rocksdb';"
+  [ -e $LOG ] || mariadb -e "INSTALL PLUGIN RocksDB SONAME 'ha_rocksdb';"
   # XXX: rocksdb_supported_compression_types variable does not report ZSTD.
 
   # Print RocksDB supported items so test log is easier to debug

--- a/mysql-test/suite/wsrep/common.pm
+++ b/mysql-test/suite/wsrep/common.pm
@@ -43,10 +43,10 @@ sub check_wsrep_support() {
   mtr_error("No SST scripts") unless $spath;
   $ENV{PATH}="$spath:$ENV{PATH}";
 
-  # ADD mysql client library path to path so that wsrep_notify_cmd can find mysql
-  # client for loading the tables. (Don't assume each machine has mysql install)
-  my ($cpath) = grep { -f "$_/mysql"; } "$::bindir/scripts", $::path_client_bindir;
-  mtr_error("No scritps") unless $cpath;
+  # ADD mariadb client to path so that wsrep_notify_cmd can find mariadb
+  # client for loading the tables. (Don't assume each machine has mariadb installed)
+  my ($cpath) = grep { -f "$_/mariadb"; } "$::bindir/scripts", $::path_client_bindir;
+  mtr_error("No mariadb client found") unless $cpath;
   $ENV{PATH}="$cpath:$ENV{PATH}" unless $cpath eq $spath;
 
   # ADD my_print_defaults script path to path so that SST scripts can find it

--- a/scripts/galera_recovery.sh
+++ b/scripts/galera_recovery.sh
@@ -68,7 +68,7 @@ parse_arguments() {
 
 wsrep_recover_position() {
   # Redirect server's error log to the log file.
-  eval @sbindir@/mysqld $cmdline_args --user=$user --wsrep_recover \
+  eval @sbindir@/mariadbd $cmdline_args --user=$user --wsrep_recover \
     --disable-log-error 2> "$log_file"
   ret=$?
   if [ $ret -ne 0 ]; then

--- a/scripts/mariadb-service-convert
+++ b/scripts/mariadb-service-convert
@@ -25,7 +25,7 @@
 
 tz_old=$TZ
 
-. /usr/bin/mysqld_safe --dry-run
+. /usr/bin/mariadbd-safe --dry-run
 
 echo "# converted using $0"
 echo "#"


### PR DESCRIPTION
Fix bug in mariadb-service-convert

If mariadb-service-convert is run and the user variable is unset then this sets `User=` in `[Service]`, which then tries to run mariadb as root, which in-turn fails. This only happens when mysqld_safe is missing which is all the time now. So...

1. Don't set `User=` if there is no user variable.
2. User mariadbd-safe instead.

Also
* galera_recovery to use mariadbd
* mtr - wsrep use mariadb executables
* debian/mariadb-server.mariadb.init use mariadbd-safe