### PR TITLE
Mvdev 30321

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-mdev-30321.result
+++ b/mysql-test/suite/innodb/r/innodb-mdev-30321.result
@@ -1,0 +1,16 @@
+#
+# MDEV-30321: blob data corrupted by row_merge_write_blob_to_tmp_file()
+#
+SET UNIQUE_CHECKS=0;
+SET FOREIGN_KEY_CHECKS=0;
+CREATE TABLE t1 (
+data LONGBLOB NOT NULL
+) ENGINE=InnoDB;
+INSERT INTO t1 VALUES 
+(REPEAT('X', @@innodb_sort_buffer_size)),
+(REPEAT('X', @@innodb_sort_buffer_size))
+;
+SELECT COUNT(*) AS nb_corrupted_rows FROM t1 WHERE data != REPEAT('X', @@innodb_sort_buffer_size);
+nb_corrupted_rows
+0
+DROP TABLE IF EXISTS t1;

--- a/mysql-test/suite/innodb/t/innodb-mdev-30321.opt
+++ b/mysql-test/suite/innodb/t/innodb-mdev-30321.opt
@@ -1,0 +1,1 @@
+--innodb_sort_buffer_size=64k

--- a/mysql-test/suite/innodb/t/innodb-mdev-30321.test
+++ b/mysql-test/suite/innodb/t/innodb-mdev-30321.test
@@ -1,0 +1,21 @@
+-- source include/have_innodb.inc
+
+--echo #
+--echo # MDEV-30321: blob data corrupted by row_merge_write_blob_to_tmp_file()
+--echo #
+
+SET UNIQUE_CHECKS=0;
+SET FOREIGN_KEY_CHECKS=0;
+
+CREATE TABLE t1 (
+  data LONGBLOB NOT NULL
+) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES 
+  (REPEAT('X', @@innodb_sort_buffer_size)),
+  (REPEAT('X', @@innodb_sort_buffer_size))
+;
+
+SELECT COUNT(*) AS nb_corrupted_rows FROM t1 WHERE data != REPEAT('X', @@innodb_sort_buffer_size);
+
+DROP TABLE IF EXISTS t1;

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -1066,7 +1066,7 @@ static dberr_t row_merge_write_blob_to_tmp_file(
   uint32_t len= field->len;
   dberr_t err= os_file_write(
     IORequestWrite, "(bulk insert)", blob_file->fd,
-    field->data, blob_file->offset * srv_page_size, len);
+    field->data, blob_file->offset, len);
 
   if (err != DB_SUCCESS)
     return err;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30321*

## Description
Fixes wrong file write offset calculation in row_merge_write_blob_to_tmp_file()

## How can this PR be tested?
Test "innodb-mdev-30321" is included in this PR

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

