### PR TITLE
MDEV-30321: blob data corrupted by row_merge_write_blob_to_tmp_file()

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -387,4 +387,19 @@ Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
 DROP TABLE t1;
 SET GLOBAL INNODB_DEFAULT_ROW_FORMAT= @format;
+#
+#   MDEV-30321 blob data corrupted by row_merge_write_blob_to_tmp_file()
+#
+CREATE TABLE t1 (
+`id` int(11) NOT NULL,
+`data` LONGBLOB NOT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+INSERT INTO t1 VALUES 
+(1, REPEAT('X', @@innodb_sort_buffer_size)),
+(2, REPEAT('X', @@innodb_sort_buffer_size));
+SELECT COUNT(*) AS nb_corrupted_rows FROM t1 WHERE data != REPEAT('X', @@innodb_sort_buffer_size);
+nb_corrupted_rows
+0
+DROP TABLE t1;
 # End of 10.7 tests

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -405,4 +405,21 @@ CHECK TABLE t1;
 DROP TABLE t1;
 SET GLOBAL INNODB_DEFAULT_ROW_FORMAT= @format;
 
+--echo #
+--echo #   MDEV-30321 blob data corrupted by row_merge_write_blob_to_tmp_file()
+--echo #
+
+CREATE TABLE t1 (
+  `id` int(11) NOT NULL,
+  `data` LONGBLOB NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES 
+  (1, REPEAT('X', @@innodb_sort_buffer_size)),
+  (2, REPEAT('X', @@innodb_sort_buffer_size));
+
+SELECT COUNT(*) AS nb_corrupted_rows FROM t1 WHERE data != REPEAT('X', @@innodb_sort_buffer_size);
+DROP TABLE t1;
+
 --echo # End of 10.7 tests

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -1066,7 +1066,7 @@ static dberr_t row_merge_write_blob_to_tmp_file(
   uint32_t len= field->len;
   dberr_t err= os_file_write(
     IORequestWrite, "(bulk insert)", blob_file->fd,
-    field->data, blob_file->offset * srv_page_size, len);
+    field->data, blob_file->offset, len);
 
   if (err != DB_SUCCESS)
     return err;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30321*

## Description
Fixes wrong file write offset calculation in row_merge_write_blob_to_tmp_file()

## How can this PR be tested?
Test "innodb-mdev-30321" is included in this PR

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
