### PR TITLE
Fix a typo in CmakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ IF (WITH_MSAN)
   MY_CHECK_AND_SET_COMPILER_FLAG("-fsanitize=memory -fsanitize-memory-track-origins -U_FORTIFY_SOURCE" DEBUG RELWITHDEBINFO)
 ENDIF()
 
-OPTION(WITH_GPROF "Enable profilingg with gprof" OFF)
+OPTION(WITH_GPROF "Enable profiling with gprof" OFF)
 IF (WITH_GPROF)
   MY_CHECK_AND_SET_COMPILER_FLAG("-pg -g -no-pie -fPIC")
 ENDIF()


### PR DESCRIPTION
There is a small typo in the root cmake file - s/profilingg/profiling.

---

I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.