### PR TITLE
MDEV-30329: mariadb-service-convert resets systemd service to default…

### DIFF
--- a/scripts/mariadb-service-convert
+++ b/scripts/mariadb-service-convert
@@ -36,7 +36,7 @@ echo '[Service]'
 echo
 
 
-if [[ ( "$user" != "root" && "$user" != "mysql" ) || "${SET_USER}" == 1 ]]; then
+if [[ ( ! -z "$user" && "$user" != "root" && "$user" != "mysql" ) || "${SET_USER}" == 1 ]]; then
   echo User=$user
 fi
 


### PR DESCRIPTION
… User=root

If mariadb-service-convert is run and the user variable is unset then this sets `User=` in `[Service]`, which then tries to run mariadb as root, which in-turn fails. This only happens when mysqld_safe is missing which is all the time now. So don't set `User=` if there is no user variable.

Reviewer: @vuvova  (in PR #2382)