### PR TITLE
acl - is_public - avoid embedded warning

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -108,10 +108,6 @@ LEX_CSTRING current_user_and_current_role=
 LEX_CSTRING none= {STRING_WITH_LEN("NONE") };
 LEX_CSTRING public_name= {STRING_WITH_LEN("PUBLIC") };
 
-static inline bool is_public(const char *l) { return l == public_name.str; }
-static inline bool is_public(const LEX_CSTRING *l) { return is_public(l->str); }
-static inline bool is_public(const LEX_USER *l) { return is_public(&l->user); }
-
 static plugin_ref old_password_plugin;
 static plugin_ref native_password_plugin;
 
@@ -135,6 +131,10 @@ struct acl_host_and_ip
 
 #ifndef NO_EMBEDDED_ACCESS_CHECKS
 static bool compare_hostname(const acl_host_and_ip *, const char *, const char *);
+static inline bool is_public(const char *l) { return l == public_name.str; }
+static inline bool is_public(const LEX_CSTRING *l) { return is_public(l->str); }
+static inline bool is_public(const LEX_USER *l) { return is_public(&l->user); }
+
 #else
 #define compare_hostname(X,Y,Z) 0
 #endif


### PR DESCRIPTION
Using clang generates the unused-function warning on embedded like:

```
FAILED: libmysqld/CMakeFiles/sql_embedded.dir/__/sql/sql_acl.cc.o /usr/lib64/ccache/clang++ .... libmysqld/CMakeFiles/sql_embedded.dir/__/sql/sql_acl.cc.o -MF libmysqld/CMakeFiles/sql_embedded.dir/__/sql/sql_acl.cc.o.d -o libmysqld/CMakeFiles/sql_embedded.dir/__/sql/sql_acl.cc.o -c /home/dan/repos/mariadb-server-10.11/sql/sql_acl.cc

sql_acl.cc:113:20: error: unused function 'is_public' [-Werror,-Wunused-function] static inline bool is_public(const LEX_USER *l) { return is_public(&l->user); }
```

```
$ clang++ --version
clang version 15.0.6 (Fedora 15.0.6-2.fc37)
```

fix for 0537ce4e9fab