### PR TITLE
MDEV-30344 MTR tests fail when built without WSREP

### DIFF
--- a/cmake/install_macros.cmake
+++ b/cmake/install_macros.cmake
@@ -266,7 +266,7 @@ SET(DEBUGBUILDDIR "${BINARY_PARENTDIR}/debug" CACHE INTERNAL "Directory of debug
 FUNCTION(INSTALL_MYSQL_TEST from to)
   IF(INSTALL_MYSQLTESTDIR)
     IF(NOT WITH_WSREP)
-      SET(EXCL_GALERA "(suite/(galera|wsrep|sys_vars/[rt]/(sysvars_)?wsrep).*|include/((w.*)?wsrep.*|.*galera.*)\\.inc|std_data/(galera|wsrep).*)")
+      SET(EXCL_GALERA "(suite/(galera|wsrep|sys_vars/[rt]/(sysvars_)?wsrep).*|std_data/(galera|wsrep).*)")
     ELSE()
       SET(EXCL_GALERA "^DOES_NOT_EXIST$")
     ENDIF()


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30344*

## Description
When building with -DWITH_WSREP=OFF, files required for MTR tests are excluded and several tests fail. This is cause by a recent commit 7b44d0ba which attempted to resolve MDEV-23230.

Even when building without WSREP/Galera support some of the MTR include files named *wsrep* are required by other tests.

Removing the following from the CMake install macros will avoid excluding the MTR test .inc files:
`|include/((w.*)?wsrep.*|.*galera.*)\\.inc`

## How can this PR be tested?

The succesful MTR tests can be seen in this [public pipeline](https://salsa.debian.org/robinnewhouse/mariadb-server-mirror/-/jobs/3743831).

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Copyright

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer
Amazon Web Services, Inc.