### PR TITLE
MDEV-21456: TCP health checks to port 3306 quickly exceed max_connect_errors

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -13477,7 +13477,10 @@ bool acl_authenticate(THD *thd, uint com_change_user_pkt_len)
       errors.m_auth_plugin= 1;
       break;
     case CR_AUTH_HANDSHAKE:
-      errors.m_handshake= 1;
+      if (sctx->user)
+        errors.m_handshake= 1;
+      else
+        goto skip_inc_host_errors;
       break;
     case CR_AUTH_USER_CREDENTIALS:
       errors.m_authentication= 1;
@@ -13489,6 +13492,7 @@ bool acl_authenticate(THD *thd, uint com_change_user_pkt_len)
       break;
     }
     inc_host_errors(mpvio.auth_info.thd->security_ctx->ip, &errors);
+skip_inc_host_errors:
     if (!thd->is_error())
       login_failed_error(thd);
     DBUG_RETURN(1);


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-21456*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

The reason for the change is TCP based health checks hit this warning all the time, and as a result, quickly reach the max_connect_errors and the mariadb service becomes unhealthy.

Per text just above the changed lines:

  if sctx->user is unset it's protocol failure, bad packet.

We don't want to set m_handshake as the error when no user is set as:

In Host_errors::sum_connect_errors the m_handshake is copied to the m_connect errors. This value is compared to max_connect_errors to determine the upper limit of failures from a host.

m_handshake in hostname.h its defined as "Number of errors from authentication". While its strickly a response from the plugin, without username set, its not an authentication attempt where we need to be concerned about blocking the user.

## How can this PR be tested?

`nc 192.168.178.73  3306  < /dev/null`

(not IP cannot be IPv4/6 local address).

Then:

```
MariaDB [performance_schema]> select * from host_cache;
Empty set (0.000 sec)
```

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ * ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*


[Alternate implemenation](https://github.com/grooverdan/mariadb-server/tree/bb-10.3-MDEV-21456-no-connection-count-increase_2) that just removes the copying of `m_handshake` errors to `m_connect` errors.