### PR TITLE
MDEV-30081 Select from complex view using where clause gets SIGNAL 11…

### DIFF
--- a/mysql-test/main/derived.result
+++ b/mysql-test/main/derived.result
@@ -1332,3 +1332,103 @@ DROP TABLE t1;
 #
 # End of 10.3 tests
 #
+#
+# MDEV-30081 Select from complex view using where clause gets SIGNAL 11 crash with derived_merge=on
+# Select from complex view using where clause gets SIGNAL 11 crash with derived_merge=on in versions
+# 10.6 - 10.9. The issue does not happen in 10.5 or 10.10. If derived_merge=off then the issue does not happen.
+# If derived_merge=on and there is no where clause used against the view, the issue does not happen. 
+#
+CREATE TABLE t1 ( id int, id1 int, PRIMARY KEY (id), KEY id1 (id1));
+insert into t1 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t2 ( id int PRIMARY KEY);
+insert into t2 values (3),(4),(7);
+CREATE TABLE t3 ( id int, abc int, PRIMARY KEY (id), KEY (abc));
+insert into t3 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t4 ( id int, abc int, PRIMARY KEY (id));
+insert into t4 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t5 ( id int, abc int, PRIMARY KEY (id), KEY abc (abc) );
+insert into t5 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t6 ( id int, abc int, PRIMARY KEY (id), KEY abc (abc) );
+insert into t6 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t7 ( id int, wid int, PRIMARY KEY (id), KEY (wid) );
+insert into t7 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t8 ( id int, wid int, PRIMARY KEY (id), KEY wid (wid));
+insert into t8 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t9 ( id int, abc int, wid int, PRIMARY KEY (id), KEY (wid), KEY id (id));
+insert into t9 values (4,4,6),(7,7,7);
+CREATE TABLE t10 ( id int, abc int, PRIMARY KEY (id), KEY (abc) );
+insert into t10 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t11 ( id int, id1 int, PRIMARY KEY (id), KEY id1 (id1) );
+insert into t11 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t12 ( id int PRIMARY KEY);
+insert into t12 values (3),(4),(7);
+CREATE TABLE t13 ( id int,  id1 int, wid int, PRIMARY KEY (id), KEY (id1), KEY (wid));
+insert into t13 values (4,4,6),(7,7,7);
+CREATE TABLE t14 ( id int PRIMARY KEY );
+insert into t14 values (3),(4),(7);
+CREATE TABLE t15 ( id int, abc int, PRIMARY KEY (id), KEY (abc) );
+insert into t15 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t16 ( id int, id1 int, PRIMARY KEY (id), KEY id1 (id1));
+insert into t16 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+CREATE TABLE t17 ( id int PRIMARY KEY);
+insert into t17 values (3),(4),(7);
+CREATE TABLE t18 ( wtid int);
+insert into t18 values (3),(4),(7);
+CREATE TABLE t19 ( wtid int PRIMARY KEY);
+insert into t19 values (1),(2),(7);
+CREATE TABLE t20 ( wid int, KEY wid (wid));
+insert into t20 values (42),(13),(25),(5);
+CREATE TABLE t21 ( wid int, wtid int, otid int, oid int, PRIMARY KEY (wid), KEY (wtid), KEY (otid), KEY (oid) );
+insert into t21 values (6,30,6,6),(7,17,7,7);
+create view cte as (SELECT id, id1 FROM t16 GROUP BY id1);
+select * from (
+SELECT t21.*
+FROM (((((((((((((((((((((t21 
+JOIN t14 on(t21.oid = t14.id))
+JOIN t15 on(t21.oid = t15.abc))
+JOIN t17  on(t21.oid = t17.id))
+JOIN t19  on(t21.wtid = t19.wtid))
+JOIN t20 on(t21.wid = t20.wid))
+JOIN t6 on(t21.oid = t6.id))
+JOIN t5  on(t21.oid = t5.id))
+JOIN t10  on(t21.oid = t10.id))
+JOIN t8  on(t21.wid = t8.wid))
+JOIN t11  on(t21.oid = t11.id))
+JOIN t1  on(t21.oid = t1.id ))
+JOIN t13  on(t21.oid = t13.id))
+JOIN t9  on(t21.oid = t9.id))
+JOIN t4  on(t21.oid = t4.id))
+LEFT JOIN (SELECT t3.* FROM ((t3 JOIN t14 on(t3.abc = t14.id)) )) dt on(t21.oid = dt.id AND t21.otid = 14))
+JOIN t2  on(t21.oid = t2.id))
+JOIN t12  on(t21.oid = t12.id))
+JOIN t7  on(t7.wid = t21.wid))
+JOIN cte  on(cte.id1 = t14.id))
+LEFT JOIN cte cte_1 on(cte_1.id1 = dt.abc))
+LEFT JOIN cte cte_2 on(cte_2.id1 = t13.id1)) ) dt1
+WHERE dt1.wid = 7;
+wid	wtid	otid	oid
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists t3;
+drop table if exists t4;
+drop table if exists t5;
+drop table if exists t6;
+drop table if exists t7;
+drop table if exists t8;
+drop table if exists t9;
+drop table if exists t10;
+drop table if exists t11;
+drop table if exists t12;
+drop table if exists t13;
+drop table if exists t14;
+drop table if exists t15;
+drop table if exists t16;
+drop table if exists t17;
+drop table if exists t18;
+drop table if exists t19;
+drop table if exists t20;
+drop table if exists t21;
+drop view if exists cte;
+#
+# End of 10.9 tests
+#

--- a/mysql-test/main/derived.test
+++ b/mysql-test/main/derived.test
@@ -1146,3 +1146,128 @@ DROP TABLE t1;
 --echo #
 --echo # End of 10.3 tests
 --echo #
+
+--echo #
+--echo # MDEV-30081 Select from complex view using where clause gets SIGNAL 11 crash with derived_merge=on
+--echo # Select from complex view using where clause gets SIGNAL 11 crash with derived_merge=on in versions
+--echo # 10.6 - 10.9. The issue does not happen in 10.5 or 10.10. If derived_merge=off then the issue does not happen.
+--echo # If derived_merge=on and there is no where clause used against the view, the issue does not happen. 
+--echo #
+
+CREATE TABLE t1 ( id int, id1 int, PRIMARY KEY (id), KEY id1 (id1));
+insert into t1 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t2 ( id int PRIMARY KEY);
+insert into t2 values (3),(4),(7);
+ 
+CREATE TABLE t3 ( id int, abc int, PRIMARY KEY (id), KEY (abc));
+insert into t3 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t4 ( id int, abc int, PRIMARY KEY (id));
+insert into t4 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t5 ( id int, abc int, PRIMARY KEY (id), KEY abc (abc) );
+insert into t5 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t6 ( id int, abc int, PRIMARY KEY (id), KEY abc (abc) );
+insert into t6 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t7 ( id int, wid int, PRIMARY KEY (id), KEY (wid) );
+insert into t7 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t8 ( id int, wid int, PRIMARY KEY (id), KEY wid (wid));
+insert into t8 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t9 ( id int, abc int, wid int, PRIMARY KEY (id), KEY (wid), KEY id (id));
+insert into t9 values (4,4,6),(7,7,7);
+ 
+CREATE TABLE t10 ( id int, abc int, PRIMARY KEY (id), KEY (abc) );
+insert into t10 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t11 ( id int, id1 int, PRIMARY KEY (id), KEY id1 (id1) );
+insert into t11 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t12 ( id int PRIMARY KEY);
+insert into t12 values (3),(4),(7);
+ 
+CREATE TABLE t13 ( id int,  id1 int, wid int, PRIMARY KEY (id), KEY (id1), KEY (wid));
+insert into t13 values (4,4,6),(7,7,7);
+ 
+CREATE TABLE t14 ( id int PRIMARY KEY );
+insert into t14 values (3),(4),(7);
+ 
+CREATE TABLE t15 ( id int, abc int, PRIMARY KEY (id), KEY (abc) );
+insert into t15 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t16 ( id int, id1 int, PRIMARY KEY (id), KEY id1 (id1));
+insert into t16 values (1,17),(2,15),(3,49),(4,3),(5,45),(6,38),(7,17);
+ 
+CREATE TABLE t17 ( id int PRIMARY KEY);
+insert into t17 values (3),(4),(7);
+ 
+CREATE TABLE t18 ( wtid int);
+insert into t18 values (3),(4),(7);
+ 
+CREATE TABLE t19 ( wtid int PRIMARY KEY);
+insert into t19 values (1),(2),(7);
+ 
+CREATE TABLE t20 ( wid int, KEY wid (wid));
+insert into t20 values (42),(13),(25),(5);
+ 
+CREATE TABLE t21 ( wid int, wtid int, otid int, oid int, PRIMARY KEY (wid), KEY (wtid), KEY (otid), KEY (oid) );
+insert into t21 values (6,30,6,6),(7,17,7,7);
+ 
+create view cte as (SELECT id, id1 FROM t16 GROUP BY id1);
+ 
+select * from (
+ SELECT t21.*
+ FROM (((((((((((((((((((((t21 
+                           JOIN t14 on(t21.oid = t14.id))
+                          JOIN t15 on(t21.oid = t15.abc))
+                         JOIN t17  on(t21.oid = t17.id))
+                        JOIN t19  on(t21.wtid = t19.wtid))
+                       JOIN t20 on(t21.wid = t20.wid))
+                      JOIN t6 on(t21.oid = t6.id))
+                     JOIN t5  on(t21.oid = t5.id))
+                    JOIN t10  on(t21.oid = t10.id))
+                   JOIN t8  on(t21.wid = t8.wid))
+                  JOIN t11  on(t21.oid = t11.id))
+                 JOIN t1  on(t21.oid = t1.id ))
+                JOIN t13  on(t21.oid = t13.id))
+               JOIN t9  on(t21.oid = t9.id))
+              JOIN t4  on(t21.oid = t4.id))
+            LEFT JOIN (SELECT t3.* FROM ((t3 JOIN t14 on(t3.abc = t14.id)) )) dt on(t21.oid = dt.id AND t21.otid = 14))
+            JOIN t2  on(t21.oid = t2.id))
+           JOIN t12  on(t21.oid = t12.id))
+          JOIN t7  on(t7.wid = t21.wid))
+         JOIN cte  on(cte.id1 = t14.id))
+       LEFT JOIN cte cte_1 on(cte_1.id1 = dt.abc))
+      LEFT JOIN cte cte_2 on(cte_2.id1 = t13.id1)) ) dt1
+WHERE dt1.wid = 7;
+
+drop table if exists t1;
+drop table if exists t2;
+drop table if exists t3;
+drop table if exists t4;
+drop table if exists t5;
+drop table if exists t6;
+drop table if exists t7;
+drop table if exists t8;
+drop table if exists t9;
+drop table if exists t10;
+drop table if exists t11;
+drop table if exists t12;
+drop table if exists t13;
+drop table if exists t14;
+drop table if exists t15;
+drop table if exists t16;
+drop table if exists t17;
+drop table if exists t18;
+drop table if exists t19;
+drop table if exists t20;
+drop table if exists t21;
+drop view if exists cte;
+
+--echo #
+--echo # End of 10.9 tests
+--echo #

--- a/sql/opt_table_elimination.cc
+++ b/sql/opt_table_elimination.cc
@@ -33,6 +33,7 @@
 #include "sql_select.h"
 #include "opt_trace.h"
 #include "my_json_writer.h"
+#include <set>
 
 /*
   OVERVIEW
@@ -134,6 +135,11 @@
    - Nodes representing unique keys. Unique key has
       = incoming edges from key component value modules
       = outgoing edge to key's table module
+   - Nodes representing unique pseudo-keys for derived tables.
+     Unique pseudo-keys are composed as a result of GROUP BY expressions.
+     Like normal unique keys, they have:
+      = incoming edges from key component value modules
+      = outgoing edge to key's table module
    - Inner side of outer join module. Outer join module has
       = incoming edges from table value modules
       = No outgoing edges. Once we reach it, we know we can eliminate the 
@@ -205,6 +211,7 @@ class Dep_module;
   class Dep_module_expr;
   class Dep_module_goal;
   class Dep_module_key;
+  class Dep_module_pseudo_key;
 
 class Dep_analysis_context;
 
@@ -278,6 +285,8 @@ private:
     Dep_module_key *key_dep;
     /* Otherwise, this and advance */
     uint equality_no;
+    /* Or this one and advance */
+    Dep_module_pseudo_key *pseudo_key_dep;
   };
   friend class Dep_analysis_context;
   friend class Field_dependency_recorder; 
@@ -302,12 +311,20 @@ class Dep_value_table : public Dep_value
 {
 public:
   Dep_value_table(TABLE *table_arg) : 
-    table(table_arg), fields(NULL), keys(NULL)
+    table(table_arg), fields(NULL), keys(NULL), pseudo_key(NULL)
   {}
   TABLE *table;  /* Table this object is representing */
   /* Ordered list of fields that belong to this table */
   Dep_value_field *fields;
-  Dep_module_key *keys; /* Ordered list of Unique keys in this table */
+
+  /* Ordered list of Unique keys in this table */
+  Dep_module_key *keys;
+
+  /*
+    Possible unique pseudo-key applicable for this table
+    (only none or a single one is possible)
+  */
+  Dep_module_pseudo_key *pseudo_key;
 
   /* Iteration over unbound modules that are our dependencies */
   Iterator init_unbound_modules_iter(char *buf);
@@ -443,9 +460,62 @@ private:
 const size_t Dep_module_key::iterator_size= 
   ALIGN_SIZE(sizeof(Dep_module_key::Value_iter));
 
-const size_t Dep_module::iterator_size=
-  MY_MAX(Dep_module_expr::iterator_size, Dep_module_key::iterator_size);
 
+/*
+  A unique pseudo-key module for a derived table.
+  For example, a derived table
+  "SELECT a, count(*) from t1 GROUP BY a"
+  has unique values in its first field "a" due to GROUP BY expression
+  so this can be considered as a unique key for this derived table
+*/
+
+class Dep_module_pseudo_key : public Dep_module
+{
+public:
+  Dep_module_pseudo_key(Dep_value_table *table_arg,
+                        std::set<field_index_t>&& field_indexes)
+      : table(table_arg), derived_table_field_indexes(field_indexes)
+  {
+    unbound_args= static_cast<uint>(field_indexes.size());
+  }
+
+  Dep_value_table *table;
+
+  Iterator init_unbound_values_iter(char *buf) override;
+
+  Dep_value *get_next_unbound_value(Dep_analysis_context *dac,
+                                    Iterator iter) override;
+
+  bool covers_field(int field_index);
+
+  static const size_t iterator_size;
+
+private:
+  /*
+    Set of field numbers (indexes) in the derived table's SELECT list
+    which are included in the GROUP BY expression.
+    For example, unique pseudo-key for SQL
+    "SELECT count(*), b, a FROM t1 GROUP BY a, b"
+    will include two elements: {2} and {1}, since "a" and "b" are on the
+    GROUP BY list and also are present on the SELECT list with indexes 2 and 1
+    (numeration starts from 0).
+  */
+  std::set<field_index_t> derived_table_field_indexes;
+
+  class Value_iter
+  {
+  public:
+    Dep_value_table *table;
+  };
+};
+
+const size_t Dep_module_pseudo_key::iterator_size=
+  ALIGN_SIZE(sizeof(Dep_module_pseudo_key::Value_iter));
+
+const size_t Dep_module::iterator_size=
+  MY_MAX(Dep_module_expr::iterator_size,
+         MY_MAX(Dep_module_key::iterator_size,
+                Dep_module_pseudo_key::iterator_size));
 
 /*
   A module that represents outer join that we're trying to eliminate. If we 
@@ -508,12 +578,17 @@ public:
   */
   MY_BITMAP expr_deps;
   
-  Dep_value_table *create_table_value(TABLE *table);
+  Dep_value_table *create_table_value(TABLE_LIST *table_list);
   Dep_value_field *get_field_value(Field *field);
 
 #ifndef DBUG_OFF
   void dbug_print_deps();
 #endif 
+
+private:
+  void create_unique_pseudo_key_if_needed(TABLE_LIST *table_list,
+                                          Dep_value_table *tbl_dep);
+  int find_field_in_list(List<Item> &fields_list, Item *field);
 };
 
 
@@ -851,7 +926,7 @@ bool check_func_dependency(JOIN *join,
   /* Create Dep_value_table objects for all tables we're trying to eliminate */
   if (oj_tbl)
   {
-    if (!dac.create_table_value(oj_tbl->table))
+    if (!dac.create_table_value(oj_tbl))
       return FALSE; /* purecov: inspected */
   }
   else
@@ -861,7 +936,7 @@ bool check_func_dependency(JOIN *join,
     {
       if (tbl->table && (tbl->table->map & dep_tables))
       {
-        if (!dac.create_table_value(tbl->table))
+        if (!dac.create_table_value(tbl))
           return FALSE; /* purecov: inspected */
       }
     }
@@ -1577,33 +1652,139 @@ void add_module_expr(Dep_analysis_context *ctx, Dep_module_expr **eq_mod,
   DESCRIPTION
     Create a Dep_value_table object for the given table. Also create
     Dep_module_key objects for all unique keys in the table.
+    Create a unique pseudo-key if this table is derived and has
+    a GROUP BY expression.
 
   RETURN
     Created table value object
     NULL if out of memory
 */
 
-Dep_value_table *Dep_analysis_context::create_table_value(TABLE *table)
+Dep_value_table *
+Dep_analysis_context::create_table_value(TABLE_LIST *table_list)
 {
   Dep_value_table *tbl_dep;
-  if (!(tbl_dep= new Dep_value_table(table)))
+  if (!(tbl_dep= new Dep_value_table(table_list->table)))
     return NULL; /* purecov: inspected */
 
   Dep_module_key **key_list= &(tbl_dep->keys);
   /* Add dependencies for unique keys */
-  for (uint i=0; i < table->s->keys; i++)
+  for (uint i= 0; i < table_list->table->s->keys; i++)
   {
-    KEY *key= table->key_info + i; 
+    KEY *key= table_list->table->key_info + i;
     if (key->flags & HA_NOSAME)
     {
       Dep_module_key *key_dep;
-      if (!(key_dep= new Dep_module_key(tbl_dep, i, key->user_defined_key_parts)))
+      if (!(key_dep= new Dep_module_key(tbl_dep, i,
+                                        key->user_defined_key_parts)))
         return NULL;
       *key_list= key_dep;
       key_list= &(key_dep->next_table_key);
     }
   }
-  return table_deps[table->tablenr]= tbl_dep;
+
+  create_unique_pseudo_key_if_needed(table_list, tbl_dep);
+  return table_deps[table_list->table->tablenr]= tbl_dep;
+}
+
+
+/*
+  @brief
+    Check if we can create a unique pseudo-key for the passed table.
+    If we can, create a dependency for it
+
+  @detail
+    Currently, pseudo-key is created for the list of GROUP BY columns.
+
+    TODO: also it can be created if the query uses
+     - SELECT DISTINCT
+     - UNION DISTINCT (not UNION ALL)
+*/
+
+void Dep_analysis_context::create_unique_pseudo_key_if_needed(
+    TABLE_LIST *table_list, Dep_value_table *tbl_dep)
+{
+  auto select_unit= table_list->get_unit();
+  SELECT_LEX *first_select= nullptr;
+  if (select_unit)
+  {
+    first_select= select_unit->first_select();
+
+    /*
+      Exclude UNION (ALL) queries from consideration by checking
+      next_select() == nullptr
+    */
+    if (unlikely(select_unit->first_select()->next_select()))
+      first_select= nullptr;
+  }
+
+  /*
+    GROUP BY expression is considered as a unique pseudo-key
+    for the derived table. Add this pseudo key as a dependency
+  */
+  if (first_select && first_select->group_list.elements > 0)
+  {
+    bool valid= true;
+    std::set<field_index_t> exposed_fields_indexes;
+    for (auto cur_group= first_select->group_list.first;
+         cur_group;
+         cur_group= cur_group->next)
+    {
+      auto elem= *(cur_group->item);
+      /*
+        Make sure GROUP BY elements contain only fields
+        and no functions or other expressions
+      */
+      if (elem->type() != Item::FIELD_ITEM)
+      {
+        valid= false;
+        break;
+      }
+      auto field_idx= find_field_in_list(first_select->join->fields_list, elem);
+      if (field_idx == -1)
+      {
+        /*
+          This GROUP BY element is not present in the select list. This is a
+          case like this:
+             (SELECT a FROM t1 GROUP by a,b) as TBL
+          Here, the combination of (a,b) is unique, but the select doesn't
+          include "b". "a" alone is not unique, so TBL doesn't have a unique
+          pseudo-key.
+        */
+        valid= false;
+        break;
+      }
+      exposed_fields_indexes.insert(field_idx);
+    }
+    if (valid)
+    {
+      Dep_module_pseudo_key *pseudo_key;
+      pseudo_key= new Dep_module_pseudo_key(tbl_dep,
+                                            std::move(exposed_fields_indexes));
+      tbl_dep->pseudo_key= pseudo_key;
+    }
+  }
+}
+
+
+/*
+  Iterate the list of fields and look for the given field.
+  Returns the index of the field if it is found on the list
+  and -1 otherwise
+*/
+
+int Dep_analysis_context::find_field_in_list(List<Item> &fields_list,
+                                             Item *field)
+{
+  List_iterator<Item> it(fields_list);
+  int field_idx= 0;
+  while (auto next_field= it++)
+  {
+    if (next_field->eq(field, false))
+      return field_idx;
+    field_idx++;
+  }
+  return -1; /*not found*/
 }
 
 
@@ -1746,11 +1927,39 @@ Dep_value* Dep_module_key::get_next_unbound_value(Dep_analysis_context *dac,
 }
 
 
+char *Dep_module_pseudo_key::init_unbound_values_iter(char *buf)
+{
+  Value_iter *iter= ALIGN_PTR(my_ptrdiff_t(buf), Value_iter);
+  iter->table= table;
+  return (char *) iter;
+}
+
+Dep_value *
+Dep_module_pseudo_key::get_next_unbound_value(Dep_analysis_context *dac,
+                                                  Dep_module::Iterator iter)
+{
+  Dep_value *res= ((Value_iter *) iter)->table;
+  ((Value_iter *) iter)->table= NULL;
+  return res;
+}
+
+
+/*
+  Check if column number field_index is covered by the pseudo-key.
+*/
+
+bool Dep_module_pseudo_key::covers_field(int field_index)
+{
+  return derived_table_field_indexes.count(field_index) > 0;
+}
+
+
 Dep_value::Iterator Dep_value_field::init_unbound_modules_iter(char *buf)
 {
   Module_iter *iter= ALIGN_PTR(my_ptrdiff_t(buf), Module_iter);
   iter->key_dep= table->keys;
   iter->equality_no= 0;
+  iter->pseudo_key_dep= table->pseudo_key;
   return (char*)iter;
 }
 
@@ -1758,7 +1967,8 @@ Dep_value::Iterator Dep_value_field::init_unbound_modules_iter(char *buf)
 void 
 Dep_value_field::make_unbound_modules_iter_skip_keys(Dep_value::Iterator iter)
 {
-  ((Module_iter*)iter)->key_dep= NULL;
+  ((Module_iter*) iter)->key_dep= NULL;
+  ((Module_iter*) iter)->pseudo_key_dep= NULL;
 }
 
 
@@ -1786,6 +1996,16 @@ Dep_module* Dep_value_field::get_next_unbound_module(Dep_analysis_context *dac,
   }
   else 
     di->key_dep= NULL;
+
+  Dep_module_pseudo_key *pseudo_key_dep= di->pseudo_key_dep;
+  if (pseudo_key_dep && !pseudo_key_dep->is_applicable() &&
+      pseudo_key_dep->covers_field(field->field_index))
+  {
+    di->pseudo_key_dep= NULL;
+    return pseudo_key_dep;
+  }
+  else
+    di->pseudo_key_dep= NULL;
   
   /*
     Then walk through [multi]equalities and find those that
@@ -1819,7 +2039,7 @@ static void mark_as_eliminated(JOIN *join, TABLE_LIST *tbl,
   TABLE *table;
   /*
     NOTE: there are TABLE_LIST object that have
-    tbl->table!= NULL && tbl->nested_join!=NULL and 
+    tbl->table!= NULL && tbl->nested_join!=NULL and
     tbl->table == tbl->nested_join->join_list->element(..)->table
   */
   if (tbl->nested_join)
@@ -1847,7 +2067,6 @@ static void mark_as_eliminated(JOIN *join, TABLE_LIST *tbl,
   if (tbl->on_expr)
     tbl->on_expr->walk(&Item::mark_as_eliminated_processor, FALSE, NULL);
 }
-
 
 #ifndef DBUG_OFF
 /* purecov: begin inspected */

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -971,7 +971,7 @@ public:
   };
 
   void init_query();
-  st_select_lex* outer_select();
+  st_select_lex* outer_select() const;
   const st_select_lex* first_select() const
   {
     return reinterpret_cast<const st_select_lex*>(slave);
@@ -1039,6 +1039,9 @@ public:
   bool set_lock_to_the_last_select(Lex_select_lock l);
 
   friend class st_select_lex;
+
+private:
+  bool is_derived_eliminated() const;
 };
 
 typedef class st_select_lex_unit SELECT_LEX_UNIT;


### PR DESCRIPTION
… crash with derived_merge=on

        Select from complex view using where clause gets SIGNAL 11
        crash with derived_merge=on in versions 10.6 - 10.9. The
        issue does not happen in 10.5 or 10.10. If derived_merge=off
        then the issue does not happen. If derived_merge=on and there
        is no where clause used against the view, the issue does not
        happen.  Issue traced to invalid table_map produced (ultimately)
        by the optimizer table elimination code and fixed in MDEV-26278.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section
