### PR TITLE
MDEV-12274 Too many connections warning in error log

### DIFF
--- a/mysql-test/main/connect.result
+++ b/mysql-test/main/connect.result
@@ -413,7 +413,7 @@ test
 drop procedure p1;
 SET global secure_auth=default;
 #
-# MDEV-19282: Log more specific warning with log_warnings=2 if
+# MDEV-19282/MDEV-12274: Log more specific warning at log_warnings=4 if
 # connection is aborted prior to authentication
 # MDEV-19277: Add status variable that gets incremented if
 # connection is aborted prior to authentication
@@ -423,7 +423,7 @@ SHOW GLOBAL STATUS LIKE 'Aborted_connects%';
 Variable_name	Value
 Aborted_connects	0
 Aborted_connects_preauth	0
-SET GLOBAL log_warnings=2;
+SET GLOBAL log_warnings=4;
 NOT FOUND /This connection closed normally without authentication/ in mysqld.1.err
 # let tcp to detect disconnect
 select sleep(1);

--- a/mysql-test/main/connect.test
+++ b/mysql-test/main/connect.test
@@ -456,7 +456,7 @@ drop procedure p1;
 SET global secure_auth=default;
 
 --echo #
---echo # MDEV-19282: Log more specific warning with log_warnings=2 if
+--echo # MDEV-19282/MDEV-12274: Log more specific warning at log_warnings=4 if
 --echo # connection is aborted prior to authentication
 --echo # MDEV-19277: Add status variable that gets incremented if
 --echo # connection is aborted prior to authentication
@@ -465,7 +465,7 @@ SET global secure_auth=default;
 flush status;
 SHOW GLOBAL STATUS LIKE 'Aborted_connects%';
 
-SET GLOBAL log_warnings=2;
+SET GLOBAL log_warnings=4;
 --let SEARCH_FILE=$MYSQLTEST_VARDIR/log/mysqld.1.err
 --let SEARCH_PATTERN= This connection closed normally without authentication
 --source include/search_pattern_in_file.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2566,7 +2566,7 @@ static void network_init(void)
 
 void close_connection(THD *thd, uint sql_errno)
 {
-  int lvl= (thd->main_security_ctx.user ? 3 : 1);
+  int lvl= 3;
   DBUG_ENTER("close_connection");
 
   if (sql_errno)


### PR DESCRIPTION
This effectively reverts MDEV-19282. There are more requests for less warnings than more.

JIRA users also think this is [excessive at log level 2](https://jira.mariadb.org/browse/MDEV-21456?focusedCommentId=196115&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-196115)

(this is slightly messy to avoid conflicts with #2412 hence draft). Real version would just use 3 as the arg to `print_aborted_warning`).