### PR TITLE
Fix synopses in mysys APIs

### DIFF
--- a/mysys/array.c
+++ b/mysys/array.c
@@ -23,6 +23,7 @@
 
   SYNOPSIS
     init_dynamic_array2()
+      ps_key            Key to register instrumented memory
       array		Pointer to an array
       element_size	Size of element
       init_buffer       Initial buffer pointer

--- a/mysys/hash.c
+++ b/mysys/hash.c
@@ -60,8 +60,9 @@ my_hash_value_type my_hash_sort(CHARSET_INFO *cs, const uchar *key,
   dynamic array that is part of the hash will allocate memory
   as required during insertion.
 
+  @param[in]     psi_key      The key to register instrumented memory
   @param[in,out] hash         The hash that is initialized
-  @param[in[     growth_size  size incrememnt for the underlying dynarray
+  @param[in]     growth_size  size incrememnt for the underlying dynarray
   @param[in]     charset      The character set information
   @param[in]     size         The hash size
   @param[in]     key_offest   The key offset for the hash

--- a/mysys/my_alloc.c
+++ b/mysys/my_alloc.c
@@ -34,8 +34,8 @@
 
   SYNOPSIS
     init_alloc_root()
+      key            - key to register instrumented memory
       mem_root       - memory root to initialize
-      name           - name of memroot (for debugging)
       block_size     - size of chunks (blocks) used for memory allocation
                        (It is external size of chunk i.e. it should include
                         memory required for internal structures, thus it

--- a/mysys/my_malloc.c
+++ b/mysys/my_malloc.c
@@ -59,6 +59,7 @@ void set_malloc_size_cb(MALLOC_SIZE_CB func)
 /**
   Allocate a sized block of memory.
 
+  @param key    Key to register instrumented memory
   @param size   The size of the memory block in bytes.
   @param flags  Failure action modifiers (bitmasks).
 
@@ -120,7 +121,8 @@ void *my_malloc(PSI_memory_key key, size_t size, myf my_flags)
 /**
    @brief wrapper around realloc()
 
-   @param  old_point        pointer to currently allocated area
+   @param  key             key to register instrumented memory
+   @param  old_point       pointer to currently allocated area
    @param  size            new size requested, must be >0
    @param  my_flags        flags
 


### PR DESCRIPTION
Since 7c58e97bf6f80a251046c5b3e7bce826fe058bd6 the PSI_memory_key was added to some routines in the
mysys/. This commit fixes synopses of functions that were updated with
the PSI_memory_key parameter.

---
I am contributing my new code of the whole pull request, including one or several files that are either new files or modified ones, under the BSD-new license.