### PR TITLE
MDEV-19160  json_pretty() alias for json_detailed()

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -2350,3 +2350,16 @@ JSON_OVERLAPS(@json1, @json2)
 #
 # End of 10.9 Test
 #
+#
+# MDEV-19160 json_pretty() alias for json_detailed()
+#
+SELECT JSON_DETAILED('["x"]');
+JSON_DETAILED('["x"]')
+[
+    "x"
+]
+SELECT JSON_PRETTY('["x"]');
+JSON_PRETTY('["x"]')
+[
+    "x"
+]

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -1608,3 +1608,11 @@ SELECT JSON_OVERLAPS(@json1, @json2);
 --echo #
 --echo # End of 10.9 Test
 --echo #
+
+
+--echo #
+--echo # MDEV-19160 json_pretty() alias for json_detailed()
+--echo #
+
+SELECT JSON_DETAILED('["x"]');
+SELECT JSON_PRETTY('["x"]');

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -5762,6 +5762,7 @@ Native_func_registry func_array[] =
   { { STRING_WITH_LEN("JSON_CONTAINS_PATH") }, BUILDER(Create_func_json_contains_path)},
   { { STRING_WITH_LEN("JSON_DEPTH") }, BUILDER(Create_func_json_depth)},
   { { STRING_WITH_LEN("JSON_DETAILED") }, BUILDER(Create_func_json_detailed)},
+  { { STRING_WITH_LEN("JSON_PRETTY") }, BUILDER(Create_func_json_detailed)},
   { { STRING_WITH_LEN("JSON_EQUALS") }, BUILDER(Create_func_json_equals)},
   { { STRING_WITH_LEN("JSON_EXISTS") }, BUILDER(Create_func_json_exists)},
   { { STRING_WITH_LEN("JSON_EXTRACT") }, BUILDER(Create_func_json_extract)},


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-19160*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
In MySQL, the function is called JSON_PRETTY. We should add ability to use this name as an alias of `JSON_DETAILED`.


## How can this PR be tested?
The test files locate at `func_json.test`

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

