### PR TITLE
MDEV-17093: SOURCE_REVISION in log (postfix - not in help)

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5249,8 +5249,9 @@ static int init_server_components()
 ￼    Print source revision hash, as one of the first lines, if not the
 ￼    first in error log, for troubleshooting and debugging purposes
 ￼  */
-  sql_print_information("Starting MariaDB %s source revision %s as process %lu",
-		         server_version, SOURCE_REVISION, (ulong) getpid());
+  if (!opt_help)
+    sql_print_information("Starting MariaDB %s source revision %s as process %lu",
+                          server_version, SOURCE_REVISION, (ulong) getpid());
 
 #ifdef WITH_PERFSCHEMA_STORAGE_ENGINE
   /*


### PR DESCRIPTION
Don't display the source revision in the mysqld --help output.