### PR TITLE
Deb: Sync Salsa-CI from Debian MariaDB 10.6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -305,13 +305,17 @@ Breaks: mariadb-server-10.0,
         mariadb-server-core-10.4,
         mariadb-server-core-10.5,
         mariadb-server-core-10.6 (<< ${source:Version}),
+        mysql-cluster-community-client-plugins,
         mysql-server-core-5.5,
         mysql-server-core-5.6,
         mysql-server-core-5.7,
         mysql-server-core-8.0,
         percona-server-server-5.6,
+        percona-server-server-5.7,
+        percona-server-server-8.0,
         percona-xtradb-cluster-server-5.6,
-        percona-xtradb-cluster-server-5.7
+        percona-xtradb-cluster-server-5.7,
+        percona-xtradb-cluster-server-8.0
 Replaces: mariadb-client-10.0,
           mariadb-client-10.1,
           mariadb-client-10.2,
@@ -351,13 +355,17 @@ Replaces: mariadb-client-10.0,
           mysql-client-core-5.6,
           mysql-client-core-5.7,
           mysql-client-core-8.0,
+          mysql-cluster-community-client-plugins,
           mysql-server-core-5.5,
           mysql-server-core-5.6,
           mysql-server-core-5.7,
           mysql-server-core-8.0,
           percona-server-server-5.6,
+          percona-server-server-5.7,
+          percona-server-server-8.0,
           percona-xtradb-cluster-server-5.6,
           percona-xtradb-cluster-server-5.7,
+          percona-xtradb-cluster-server-8.0,
           virtual-mysql-client-core
 Provides: default-mysql-client-core,
           virtual-mysql-client-core
@@ -540,6 +548,7 @@ Breaks: mariadb-client-10.0,
         mariadb-client-10.6 (<< ${source:Version}),
         mariadb-server-10.0,
         mariadb-server-10.1,
+        mariadb-server-10.2,
         mariadb-server-10.3,
         mariadb-server-10.4,
         mariadb-server-10.5,
@@ -561,6 +570,7 @@ Replaces: mariadb-client-10.0,
           mariadb-client-10.6 (<< ${source:Version}),
           mariadb-server-10.0,
           mariadb-server-10.1,
+          mariadb-server-10.2,
           mariadb-server-10.3,
           mariadb-server-10.4,
           mariadb-server-10.5,
@@ -733,9 +743,11 @@ Package: mariadb-backup
 Architecture: any
 Breaks: mariadb-backup-10.1,
         mariadb-backup-10.2,
+        mariadb-backup-10.3,
         mariadb-client-10.1
 Replaces: mariadb-backup-10.1,
           mariadb-backup-10.2,
+          mariadb-backup-10.3,
           mariadb-client-10.1
 Depends: mariadb-client-core-10.6 (= ${binary:Version}),
          ${misc:Depends},
@@ -758,12 +770,16 @@ Breaks: mariadb-connect-engine-10.0,
         mariadb-connect-engine-10.1,
         mariadb-connect-engine-10.2,
         mariadb-connect-engine-10.3,
-        mariadb-connect-engine-10.4
+        mariadb-connect-engine-10.4,
+        mariadb-server-10.0,
+        mariadb-server-10.1
 Replaces: mariadb-connect-engine-10.0,
           mariadb-connect-engine-10.1,
           mariadb-connect-engine-10.2,
           mariadb-connect-engine-10.3,
-          mariadb-connect-engine-10.4
+          mariadb-connect-engine-10.4,
+          mariadb-server-10.0,
+          mariadb-server-10.1
 Description: Connect storage engine for MariaDB
  Connect engine supports a number of file formats (dbf, xml, txt, bin, etc),
  connections to ODBC tables and remote MySQL tables, as well as a number of
@@ -784,7 +800,7 @@ Description: Amazon S3 archival storage engine for MariaDB
 Package: mariadb-plugin-rocksdb
 Architecture: amd64 arm64 mips64el ppc64el
 Depends: mariadb-server-10.6 (= ${server:Version}),
-         python3,
+         python3:any,
          rocksdb-tools,
          ${misc:Depends},
          ${shlibs:Depends}
@@ -810,12 +826,16 @@ Breaks: mariadb-oqgraph-engine-10.0,
         mariadb-oqgraph-engine-10.1,
         mariadb-oqgraph-engine-10.2,
         mariadb-oqgraph-engine-10.3,
-        mariadb-oqgraph-engine-10.4
+        mariadb-oqgraph-engine-10.4,
+        mariadb-server-10.0,
+        mariadb-server-10.1
 Replaces: mariadb-oqgraph-engine-10.0,
           mariadb-oqgraph-engine-10.1,
           mariadb-oqgraph-engine-10.2,
           mariadb-oqgraph-engine-10.3,
-          mariadb-oqgraph-engine-10.4
+          mariadb-oqgraph-engine-10.4,
+          mariadb-server-10.0,
+          mariadb-server-10.1
 Description: OQGraph storage engine for MariaDB
  The OQGraph engine is a computation engine plugin for handling hierarchies
  (trees) and graphs (friend-of-a-friend, etc) cleanly through standard SQL.
@@ -871,11 +891,15 @@ Depends: libgssapi-krb5-2,
 Breaks: mariadb-gssapi-server-10.1,
         mariadb-gssapi-server-10.2,
         mariadb-gssapi-server-10.3,
-        mariadb-gssapi-server-10.4
+        mariadb-gssapi-server-10.4,
+        mariadb-server-10.0,
+        mariadb-server-10.1
 Replaces: mariadb-gssapi-server-10.1,
           mariadb-gssapi-server-10.2,
           mariadb-gssapi-server-10.3,
-          mariadb-gssapi-server-10.4
+          mariadb-gssapi-server-10.4,
+          mariadb-server-10.0,
+          mariadb-server-10.1
 Description: GSSAPI authentication plugin for MariaDB server
  This plugin includes support for Kerberos on Unix, but can also be used for
  Windows authentication with or without domain environment.
@@ -954,6 +978,8 @@ Replaces: mariadb-test-10.0,
           mariadb-test-5.5,
           mysql-client-5.5,
           mysql-server-5.5,
+          mysql-server-5.7,
+          mysql-server-core-8.0,
           mysql-testsuite,
           mysql-testsuite-5.5,
           mysql-testsuite-5.6,

--- a/debian/libmariadb-dev.install
+++ b/debian/libmariadb-dev.install
@@ -11,10 +11,10 @@ usr/include/mariadb/mariadb_dyncol.h
 usr/include/mariadb/mariadb_rpl.h
 usr/include/mariadb/mariadb_stmt.h
 usr/include/mariadb/mariadb_version.h
+usr/include/mariadb/my_alloca.h
 usr/include/mariadb/my_config.h
 usr/include/mariadb/my_global.h
 usr/include/mariadb/my_sys.h
-usr/include/mariadb/my_alloca.h
 usr/include/mariadb/mysql.h
 usr/include/mariadb/mysql/
 usr/include/mariadb/mysql/client_plugin.h

--- a/debian/libmariadb-dev.lintian-overrides
+++ b/debian/libmariadb-dev.lintian-overrides
@@ -1,1 +1,2 @@
+# This is how upstream does it, wont' fix
 arch-dependent-file-not-in-arch-specific-directory usr/bin/mariadb_config

--- a/debian/mariadb-server-10.6.preinst
+++ b/debian/mariadb-server-10.6.preinst
@@ -119,6 +119,18 @@ then
 
 fi
 
+# If there is no debian-*.flag, and no version was detected, but a file that
+# indicated MySQL 8.0 is found (undo_001 is created by default in MySQL 8.0+
+# installs), then that file is enough of additional indication to trigger the
+# move of the data directory.
+if [ -z "$found_version" ] &&
+   [ -z "$(find $mysql_datadir/debian-*.flag 2> /dev/null)" ] &&
+   [ -f "$mysql_datadir/undo_001" ]
+then
+  echo "$mysql_datadir: no server version flag found, assuming MySQL 8.0 data encountered"
+  downgrade_detected=true
+  found_version="previous" # Just use dummy name as we don't know real version
+fi
 
 # Don't abort dpkg if downgrade is detected (as was done previously).
 # Instead simply move the old datadir and create a new for this_version.
@@ -133,8 +145,8 @@ then
   echo "Please manually export/import your data (e.g. with mysqldump) if needed." 1>&2
   mv -f "$mysql_datadir" "$mysql_datadir-$found_version"
   # Also move away the old debian.cnf file that included credentials that are
-  # no longer valid
-  mv -f /etc/mysql/debian.cnf "/etc/mysql/debian.cnf-$found_version"
+  # no longer valid. If none existed, ignore error and let dpkg continue.
+  mv -f /etc/mysql/debian.cnf "/etc/mysql/debian.cnf-$found_version" || true
 fi
 
 # to be sure

--- a/debian/mariadb-server-core-10.6.install
+++ b/debian/mariadb-server-core-10.6.install
@@ -12,8 +12,8 @@ usr/share/man/man1/resolveip.1
 usr/share/man/man8/mariadbd.8
 usr/share/man/man8/mysqld.8
 usr/share/mysql/bulgarian
-usr/share/mysql/chinese
 usr/share/mysql/charsets
+usr/share/mysql/chinese
 usr/share/mysql/czech
 usr/share/mysql/danish
 usr/share/mysql/dutch

--- a/debian/mariadb-test.install
+++ b/debian/mariadb-test.install
@@ -37,8 +37,8 @@ usr/share/mysql/mysql-test/README.stress
 usr/share/mysql/mysql-test/dgcov.pl
 usr/share/mysql/mysql-test/lib
 usr/share/mysql/mysql-test/mariadb-stress-test.pl
-usr/share/mysql/mysql-test/mysql-test-run.pl
 usr/share/mysql/mysql-test/mariadb-test-run.pl
+usr/share/mysql/mysql-test/mysql-test-run.pl
 usr/share/mysql/mysql-test/purify.supp
 usr/share/mysql/mysql-test/suite.pm
 usr/share/mysql/mysql-test/valgrind.supp

--- a/debian/mariadb-test.links
+++ b/debian/mariadb-test.links
@@ -2,7 +2,7 @@ usr/bin/mariadb-client-test usr/bin/mysql_client_test
 usr/bin/mariadb-client-test-embedded usr/bin/mysql_client_test_embedded
 usr/bin/mariadb-test usr/bin/mysqltest
 usr/bin/mariadb-test-embedded usr/bin/mysqltest_embedded
-usr/share/mysql/mysql-test/mariadb-test-run.pl usr/share/mysql/mysql-test/mysql-test-run.pl
-usr/share/mysql/mysql-test/mariadb-test-run.pl usr/share/mysql/mysql-test/mysql-test-run
-usr/share/mysql/mysql-test/mariadb-test-run.pl usr/share/mysql/mysql-test/mtr
 usr/share/mysql/mysql-test/mariadb-test-run.pl usr/share/mysql/mysql-test/mariadb-test-run
+usr/share/mysql/mysql-test/mariadb-test-run.pl usr/share/mysql/mysql-test/mtr
+usr/share/mysql/mysql-test/mariadb-test-run.pl usr/share/mysql/mysql-test/mysql-test-run
+usr/share/mysql/mysql-test/mariadb-test-run.pl usr/share/mysql/mysql-test/mysql-test-run.pl

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,7 @@
 #!/usr/bin/make -f
 
-export DH_VERBOSE=1
-export DEB_BUILD_HARDENING=1
-
-# enable Debian Hardening
-# see: https://wiki.debian.org/Hardening
+# Enable Debian Hardening
+# https://wiki.debian.org/Hardening
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 # Disable LTO on Ubuntu, see LP: #1970634 and https://jira.mariadb.org/browse/MDEV-25633
@@ -64,8 +61,8 @@ endif
 
 # Only attempt to build with PMEM on archs that have package libpmem-dev available
 # See https://packages.debian.org/search?searchon=names&keywords=libpmem-dev
-ifneq (,$(filter $(DEB_HOST_ARCH_CPU),amd64 arm64 ppc64el riscv64))
-    CMAKEFLAGS += -DWITH_PMEM=YES
+ifneq (,$(filter $(DEB_HOST_ARCH),amd64 arm64 ppc64el riscv64))
+    CMAKEFLAGS += -DWITH_PMEM=ON
 endif
 
 # Add support for verbose builds
@@ -93,6 +90,9 @@ endif
 	# quality standards in Debian. Also building it requires an extra 4 GB of disk
 	# space which makes native Debian builds fail as the total disk space needed
 	# for MariaDB becomes over 10 GB. Only build CS via autobake-deb.sh.
+	#
+	# Note: Don't use '-DWITH_URING=ON' as some Buildbot builders are missing it
+	# and would fail permanently.
 	PATH=$${MYSQL_BUILD_PATH:-"/usr/lib/ccache:/usr/local/bin:/usr/bin:/bin"} \
 	    NO_UPDATE_BUILD_VERSION=1 \
 	    dh_auto_configure --builddirectory=$(BUILDDIR) -- \
@@ -107,8 +107,7 @@ endif
 	    -DCONC_DEFAULT_CHARSET=utf8mb4 \
 	    -DPLUGIN_AWS_KEY_MANAGEMENT=NO \
 	    -DPLUGIN_COLUMNSTORE=NO \
-	    -DIGNORE_AIO_CHECK=YES \
-	    -DWITH_URING=YES \
+	    -DIGNORE_AIO_CHECK=ON \
 	    -DDEB=$(DEB_VENDOR)
 
 # This is needed, otherwise 'make test' will run before binaries have been built
@@ -123,6 +122,7 @@ override_dh_auto_test:
 	dh_testdir
 	# Ensure at least an empty file exists
 	touch mysql-test/unstable-tests
+	# Skip unstable tests if such are defined for arch
 	[ ! -f debian/unstable-tests.$(DEB_HOST_ARCH) ] || cat debian/unstable-tests.$(DEB_HOST_ARCH) >> mysql-test/unstable-tests
 	# Run testsuite
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -7,7 +7,7 @@ include:
 # Override Salsa-CI with MariaDB specific variations
 variables:
   DEB_BUILD_OPTIONS: "nocheck noautodbgsym"
-  RELEASE: sid
+  RELEASE: bullseye
   SALSA_CI_DISABLE_REPROTEST: 1
   SALSA_CI_DISABLE_MISSING_BREAKS: 0
   SALSA_CI_DISABLE_RC_BUGS: 1
@@ -25,8 +25,8 @@ stages:
   - provisioning
   - build
   - test
-  - upgrade in Sid
-  - upgrade from Buster/Bullseye
+  - upgrade in Bullseye
+  - upgrade from Buster
   - upgrade extras
   - test extras
   - publish # Stage referenced by Salsa-CI template aptly stanza, so must exist even though not used
@@ -51,10 +51,17 @@ build:
     - ccache -s # Show ccache stats to validate it worked
     - mv ${CCACHE_TMP_DIR} ${CCACHE_WORK_DIR}
 
-build bullseye-backports:
+build i386:
+  extends: .build-package-i386
+  script:
+    - *autobake-deb-steps
+
+build sid:
   extends: .build-package
+  script:
+    - *autobake-deb-steps
   variables:
-    RELEASE: bullseye-backports
+    RELEASE: sid
 
 build buster-backports:
   extends: .build-package
@@ -70,20 +77,13 @@ build buster-backports:
   variables:
     RELEASE: buster-backports
 
-# base image missing git
-build i386:
-  extends: .build-package
-  script:
-    - apt-get update && apt-get install -y --no-install-recommends git
-    - *autobake-deb-steps
-  image: $SALSA_CI_IMAGES_BASE_I386
-  variables:
-    ARCH: 'i386'
-
 # Build native deb without using autobake-deb.sh. This way we will detect
 # if the debian/control file and other packaging is correct as-is for Debian Sid.
-build native deb:
+build native deb amd64:
   extends: .build-package
+
+build native deb i386:
+  extends: .build-package-i386
 
 autopkgtest:
   extends: .test-autopkgtest
@@ -100,7 +100,7 @@ blhc:
   stage: test extras
   # Build log checker needs a .build file and thus only works on native build
   needs:
-    - job: build native deb
+    - job: build native deb amd64
 
 # In addition to Salsa-CI, also run these fully MariaDB specific build jobs
 
@@ -117,19 +117,6 @@ blhc:
   # Prime the apt cache so later apt commands can run
   apt-get update -qq
 
-# Readline was removed from Debian Sid (and Bullseye) in Feb 2021. To be able to install older
-# versions of MariaDB that depend on it, fetch and install it from Buster.
-.test-install-readline-in-sid-for-backwards-compat: &test-install-readline-in-sid-for-backwards-compat |
-  curl -sS -O http://ftp.de.debian.org/debian/pool/main/r/readline5/libreadline5_5.2+dfsg-3+b13_amd64.deb
-  apt-get -qq install --no-install-recommends --yes ./libreadline5_5.2+dfsg-3+b13_amd64.deb
-
-# OpenSSL 1.1 was Debian Sid in Dec 2022 (as Bookworm will ship with OpenSSL 3.0
-# only). To be able to install versions of MariaDB that depend on OpenSSL 1.1,
-# fetch and install it manually.
-.test-install-openssl1-in-sid-for-backwards-compat: &test-install-openssl1-in-sid-for-backwards-compat |
-  curl -sS -O https://snapshot.debian.org/archive/debian/20220507T034236Z/pool/main/o/openssl/libssl1.1_1.1.1o-1_amd64.deb
-  apt-get -qq install --no-install-recommends --yes ./libssl1.1_1.1.1o-1_amd64.deb
-
 .test-verify-initial: &test-verify-initial |
   dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
   service mysql status || service mariadb status # Early MariaDB 10.5 only had 'mariadb'
@@ -139,25 +126,11 @@ blhc:
   mysql --table -e "SELECT * FROM plugin;" mysql
   mysql --table -e "SHOW PLUGINS;" mysql
 
-.test-enable-sid-repos: &test-enable-sid-repos
+.test-enable-bullseye-repos: &test-enable-bullseye-repos
   # Replace any old repos with just Sid
-  - echo 'deb http://deb.debian.org/debian sid main' > /etc/apt/sources.list
+  - echo 'deb http://deb.debian.org/debian bullseye main' > /etc/apt/sources.list
   # Upgrade minimal stack first
   - apt-get update -qq
-  # Next step will fail on https://bugs.debian.org/993755
-  #   /usr/bin/perl: error while loading shared libraries: libcrypt.so.1: cannot
-  #     open shared object file: No such file or directory
-  #   dpkg: error processing package libc6:amd64 (--configure):
-  - apt-get install -y apt || true
-  # Apply workaround
-  - cd $(mktemp -d) # Use temp dir where apt can download and unpack files
-  - apt-get -y download libcrypt1
-  - dpkg-deb -x libcrypt1_*.deb .
-  - cp -ra lib/* /lib/
-  - cd - # Back to /builds/$USER/mariadb-server/debian/output
-  - find /lib/*/libcrypt.* -ls # Show that new libcrypt is there
-  - apt-get -y --fix-broken install
-  # Complete upgrade of minimal stack
   - apt-get install -y apt
 
 .test-enable-bullseye-backports-repos: &test-enable-bullseye-backports-repos |
@@ -269,8 +242,8 @@ fresh install:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mariadb-10.6 Sid upgrade:
-  stage: upgrade in Sid
+mariadb-10.5 Bullseye upgrade:
+  stage: upgrade in Bullseye
   needs:
     - job: build
   image: debian:${RELEASE}
@@ -281,33 +254,9 @@ mariadb-10.6 Sid upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
+    # Install everything MariaDB 10.5 currently in Debian Bullseye
     - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
-    - *test-install
-    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-mariadb-10.5 with Bullseye backports upgrade:
-  stage: upgrade extras
-  needs:
-    - job: build bullseye-backports
-  image: debian:bullseye
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    # Install everything MariaDB currently in Debian Buster
-    - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
-    # Verify installation of MariaDB from Buster
     - *test-verify-initial
-    - *test-enable-bullseye-backports-repos
     - *test-install
     - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
@@ -329,10 +278,11 @@ mariadb-10.3 with Buster backports upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    # Install everything MariaDB currently in Debian Buster
+    # Install everything MariaDB 10.3 currently in Debian Buster
     - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
     # Verify installation of MariaDB from Buster
     - *test-verify-initial
+    # Buster backports is needed for liburing1 (>= 0.7) and galera-4 (>= 26.4)
     - *test-enable-buster-backports-repos
     - *test-install
     # mariadb-10.3 in Buster ships a /etc/init.d/mysql so it should continue to work
@@ -345,34 +295,8 @@ mariadb-10.3 with Buster backports upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mariadb-10.5 Bullseye to mariadb-10.6 upgrade:
-  stage: upgrade from Buster/Bullseye
-  needs:
-    - job: build
-  image: debian:bullseye
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    # Install everything MariaDB currently in Debian Bullseye
-    - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
-    # Verify installation of MariaDB from Bullseye
-    - *test-verify-initial
-    - *test-enable-sid-repos
-    - *test-install
-    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-mariadb-10.3 Buster to mariadb-10.6 upgrade:
-  stage: upgrade from Buster/Bullseye
+mariadb-10.3 Buster upgrade:
+  stage: upgrade from Buster
   needs:
     - job: build
   image: debian:buster
@@ -383,11 +307,11 @@ mariadb-10.3 Buster to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    # Install everything MariaDB currently in Debian Buster
+    # Install everything MariaDB 10.3 currently in Debian Buster
     - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
     # Verify installation of MariaDB from Buster
     - *test-verify-initial
-    - *test-enable-sid-repos
+    - *test-enable-bullseye-repos
     - *test-install
     # mariadb-10.3 in Buster ships a /etc/init.d/mysql so it should continue to work
     - service mysql status
@@ -503,41 +427,8 @@ build mariadbclient consumer Python-MySQLdb:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-libmysql* to libmariadb* upgrade:
-  stage: upgrade in Sid
-  needs:
-    - job: build
-  image: debian:${RELEASE}
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    # Install all libmysql* available in Debian unstable
-    - apt-get install -y pkg-config libmysqlclient-dev
-    - pkg-config --list-all
-    - pkg-config --cflags mysqlclient # mysqlclient.pc from original package
-    - apt-get install -y ./libmariadb3_*.deb ./mariadb-common_*.deb
-    - pkg-config --list-all
-    - apt-get install -y ./libmariadb-dev_*.deb
-    - pkg-config --list-all
-    - apt-get install -y ./libmariadb-dev-compat_*.deb
-    - pkg-config --cflags mysqlclient # mysqlclient.pc from compat package
-    - pkg-config --list-all
-    - apt-get install -y ./libmariadbd19_*.deb
-    - pkg-config --list-all
-    - apt-get install -y ./libmariadbd-dev_*.deb
-    - pkg-config --list-all
-    - apt-get install -y default-libmysqlclient-dev default-libmysqld-dev
-    - *test-verify-libs
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-default-libmysqlclient-dev Sid upgrade:
-  stage: upgrade in Sid
+default-libmysqlclient-dev Bullseye upgrade:
+  stage: upgrade in Bullseye
   needs:
     - job: build
   image: debian:${RELEASE}
@@ -556,29 +447,8 @@ default-libmysqlclient-dev Sid upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-default-libmysqlclient-dev Bullseye upgrade:
-  stage: upgrade from Buster/Bullseye
-  needs:
-    - job: build
-  image: debian:bullseye
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - apt-get install -y pkg-config default-libmysqlclient-dev
-    - pkg-config --list-all
-    - *test-enable-sid-repos
-    - *test-install-all-libs
-    - *test-verify-libs
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
 default-libmysqlclient-dev Buster upgrade:
-  stage: upgrade from Buster/Bullseye
+  stage: upgrade from Buster
   needs:
     - job: build
   image: debian:buster
@@ -591,28 +461,7 @@ default-libmysqlclient-dev Buster upgrade:
     - *test-prepare-container
     - apt-get install -y pkg-config default-libmysqlclient-dev
     - pkg-config --list-all
-    - *test-enable-sid-repos
-    - *test-install-all-libs
-    - *test-verify-libs
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-default-libmysqlclient-dev with Bullseye backports upgrade:
-  stage: upgrade extras
-  needs:
-    - job: build bullseye-backports
-  image: debian:bullseye
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - apt-get install -y pkg-config default-libmysqlclient-dev
-    - pkg-config --list-all
-    - *test-enable-bullseye-backports-repos
+    - *test-enable-bullseye-repos
     - *test-install-all-libs
     - *test-verify-libs
   except:
@@ -642,49 +491,14 @@ default-libmysqlclient-dev with Buster backports upgrade:
 
 # Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
 # The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
-mysql-8.0 Sid to mariadb-10.6 upgrade:
-  stage: upgrade in Sid
-  needs:
-    - job: build
-  image: debian:sid
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    # The postinst fails often if 'ps' is missing from system, so install procps
-    - apt-get install -y procps mysql-server 'libmysqlc*'
-    - *test-verify-initial
-    - *test-install
-    # Due to some (currently unknown) changes in MySQL 8.0 packaging or apt
-    # behaviour changes, a system with a previous installation of MySQL 8.0 will
-    # on upgrades to MariaDB first fully remove MySQL, including the
-    # /etc/init.d/mysql file, so previous techniques in
-    # mariadb-server-10.6.postinst to maintain backwards compatibility with
-    # 'service mysql status' after installing MariaDB on top MySQL no longer
-    # works. Thus the step to test it now intentionally has a fallback to use
-    # the service name 'mariadb' instead, and the fallback is always used.
-    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
-    - service mysql status || service mariadb status
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-# Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
-# The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
 #
 # Testing on Focal binaries on Buster works. Using Jammy binaries on Bullseye
 # does not work as libc in Jammy is too new.
-mysql-8.0 from Ubuntu 22.04 with Bullseye backports upgrade:
+mysql-8.0 from Ubuntu 22.04 upgrade:
   stage: upgrade extras
   needs:
-    - job: build bullseye-backports
-  image: debian:bullseye
+    - job: build
+  image: debian:${RELEASE}
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -701,8 +515,6 @@ mysql-8.0 from Ubuntu 22.04 with Bullseye backports upgrade:
     - apt-get install -y mysql-server 'libmysqlc*' || true
     - sleep 10 && apt-get install -f
     - *test-verify-initial
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update -qq
     - *test-install
     - service mysql status
     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
@@ -715,11 +527,11 @@ mysql-8.0 from Ubuntu 22.04 with Bullseye backports upgrade:
 
 # Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
 # The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
-mysql-community-cluster-8.0 from MySQL.com with Bullseye backports upgrade:
+mysql-community-cluster-8.0 from MySQL.com upgrade:
   stage: upgrade extras
   needs:
-    - job: build bullseye-backports
-  image: debian:bullseye
+    - job: build
+  image: debian:${RELEASE}
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -737,8 +549,6 @@ mysql-community-cluster-8.0 from MySQL.com with Bullseye backports upgrade:
     - dpkg -l | grep -iE 'maria|mysql|galera'
     - systemctl status mysql; mysql -e 'SELECT VERSION()'
     - systemctl stop mysql # Stop manually as maintainer scripts don't handle this with systemctl shim
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update -qq
     - *test-install
     # Ignore systemctl shim result as MariaDB systemd file is incompatible with it and yields:
     #   ERROR:systemctl:the ExecStartPre control process exited with error code
@@ -787,7 +597,6 @@ mariadb.org-10.6 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-# archive.mariadb.org for Debian Sid latest is 10.5.13
 mariadb.org-10.5 to mariadb-10.6 upgrade:
   stage: upgrade extras
   needs:
@@ -804,7 +613,6 @@ mariadb.org-10.5 to mariadb-10.6 upgrade:
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo "deb https://archive.mariadb.org/mariadb-10.5/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update -qq
-    - *test-install-openssl1-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.5
     - *test-verify-initial
     # Install MariaDB built in this commit
@@ -819,12 +627,11 @@ mariadb.org-10.5 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-# archive.mariadb.org for Debian Sid latest is 10.4.17
-mariadb.org-10.4 to mariadb-10.6 upgrade:
+mariadb.org-10.4 to mariadb-10.6 with Buster backports upgrade:
   stage: upgrade extras
   needs:
-    - job: build
-  image: debian:${RELEASE}
+    - job: build buster-backports
+  image: debian:buster
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -832,17 +639,17 @@ mariadb.org-10.4 to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    - apt-get -qq install --no-install-recommends --yes ca-certificates curl systemctl # systemctl shim needed on platforms that don't have systemd
+    - apt-get -qq install --no-install-recommends --yes ca-certificates curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://archive.mariadb.org/mariadb-10.4/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://archive.mariadb.org/mariadb-10.4/repo/debian buster main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update -qq
-    - *test-install-readline-in-sid-for-backwards-compat
-    - *test-install-openssl1-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.4
     # MariaDB.org version of 10.4 and early 10.5 do not install an init file, so
     # it must be installed here manually
     - cp /usr/share/mysql/mysql.init /etc/init.d/mysql; chmod +x /etc/init.d/mysql; service mysql start; sleep 5
     - *test-verify-initial
+    # Buster backports is needed for liburing1 (>= 0.7) and galera-4 (>= 26.4)
+    - *test-enable-buster-backports-repos
     - *test-install
     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
     - service mysql status
@@ -854,12 +661,11 @@ mariadb.org-10.4 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-# archive.mariadb.org for Debian Sid latest is 10.3.27
-mariadb.org-10.3 to mariadb-10.6 upgrade:
+mariadb.org-10.3 to mariadb-10.6 with Buster backports upgrade:
   stage: upgrade extras
   needs:
-    - job: build
-  image: debian:${RELEASE}
+    - job: build buster-backports
+  image: debian:buster
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -869,12 +675,12 @@ mariadb.org-10.3 to mariadb-10.6 upgrade:
     - *test-prepare-container
     - apt-get -qq install --no-install-recommends --yes ca-certificates curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://archive.mariadb.org/mariadb-10.3/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
+    - echo "deb https://archive.mariadb.org/mariadb-10.3/repo/debian buster main" > /etc/apt/sources.list.d/mariadb.list
     - apt-get update -qq
-    - *test-install-readline-in-sid-for-backwards-compat
-    - *test-install-openssl1-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.3
     - *test-verify-initial
+    # Buster backports is needed for liburing1 (>= 0.7) and galera-4 (>= 26.4)
+    - *test-enable-buster-backports-repos
     - *test-install
     - service mysql status
     # Give the mariadb-upgrade plenty of time to complete, otherwise next commands
@@ -887,52 +693,14 @@ mariadb.org-10.3 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-# archive.mariadb.org for Debian Sid latest is 10.2.21
-mariadb.org-10.2 to mariadb-10.6 upgrade:
+# archive.mariadb.org has for 10.2 only Stretch, so we can't test upgrades to
+# 10.6 with only Buster and Bullseye builds
+
+mysql.com-5.7 upgrade:
   stage: upgrade extras
   needs:
     - job: build
   image: debian:${RELEASE}
-  artifacts:
-    when: always
-    name: "$CI_BUILD_NAME"
-    paths:
-      - ${WORKING_DIR}/debug
-  script:
-    - *test-prepare-container
-    - apt-get -qq install --no-install-recommends --yes ca-certificates curl
-    - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
-    - echo "deb https://archive.mariadb.org/mariadb-10.2/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
-    - apt-get update -qq
-    - *test-install-readline-in-sid-for-backwards-compat
-    - *test-install-openssl1-in-sid-for-backwards-compat
-    - apt-get install -y mariadb-server-10.2
-    # Verify initial state before upgrade
-    - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
-    - service mysql status
-    # prepending with --defaults-file=/etc/mysql/debian.cnf is needed in upstream 5.5–10.3
-    - |
-      mysql --defaults-file=/etc/mysql/debian.cnf --skip-column-names -e "SELECT @@version, @@version_comment"
-      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SHOW DATABASES;"
-      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SELECT * FROM mysql.user; SHOW CREATE USER root@localhost;"
-      mysql --defaults-file=/etc/mysql/debian.cnf --table -e "SELECT * FROM mysql.plugin; SHOW PLUGINS;"
-    - *test-install
-    - service mysql status
-    # Give the mariadb-upgrade plenty of time to complete, otherwise next commands
-    # fail on non-existing mariadb.sys user
-    - sleep 15
-    - *test-verify-final
-  variables:
-    GIT_STRATEGY: none
-  except:
-    variables:
-      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
-
-mysql.com-5.7 with Bullseye backports upgrade:
-  stage: upgrade extras
-  needs:
-    - job: build bullseye-backports
-  image: debian:bullseye
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -947,8 +715,6 @@ mysql.com-5.7 with Bullseye backports upgrade:
       apt-get update -qq
       apt-get install -y 'mysql*' 'libmysqlc*'
     - *test-verify-initial
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update -qq
     - *test-install
     # Due to some (currently unknown) changes in MySQL 5.7 packaging or apt
     # behaviour changes, a system with a previous installation of MySQL will
@@ -968,11 +734,11 @@ mysql.com-5.7 with Bullseye backports upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-percona-xtradb-5.7 with bullseye backports upgrade:
+percona-xtradb-5.7 upgrade:
   stage: upgrade extras
   needs:
-    - job: build bullseye-backports
-  image: debian:bullseye
+    - job: build
+  image: debian:${RELEASE}
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -983,13 +749,11 @@ percona-xtradb-5.7 with bullseye backports upgrade:
     - |
       apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
       apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 9334A25F8507EFA5
-      echo "deb https://repo.percona.com/apt/ bullseye main" > /etc/apt/sources.list.d/mysql.list
+      echo "deb https://repo.percona.com/apt/ ${RELEASE} main" > /etc/apt/sources.list.d/mysql.list
       apt-get update -qq
       apt-get install -y percona-xtradb-cluster-full-57 percona-xtrabackup-24 percona-toolkit pmm2-client
     - service mysql status
     - *test-verify-initial
-    # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update -qq
     - *test-install
     - service mysql status
     - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -155,12 +155,12 @@ blhc:
   EOF
   apt-get update -qq
 
-.test-install: &test-install |
+.test-install: &test-install
   # Install MariaDB built in this commit
-  apt-get install -y ./*.deb
+  - apt-get install -y ./*.deb
   # Verify installation of MariaDB built in this commit
-  dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
-  mariadb --version # Client version
+  - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
+  - mariadb --version # Client version
 
 .test-verify-final: &test-verify-final |
   mkdir -p debug # Ensure dir exists before using it
@@ -615,10 +615,7 @@ mariadb.org-10.5 to mariadb-10.6 upgrade:
     - apt-get update -qq
     - apt-get install -y mariadb-server-10.5
     - *test-verify-initial
-    # Install MariaDB built in this commit
-    # Verify installation of MariaDB built in this commit
-    - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
-    - mariadb --version # Client version
+    - *test-install
     - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
   variables:

--- a/debian/salsa-ci.yml
+++ b/debian/salsa-ci.yml
@@ -26,7 +26,7 @@ stages:
   - build
   - test
   - upgrade in Sid
-  - upgrade from Bullseye
+  - upgrade from Buster/Bullseye
   - upgrade extras
   - test extras
   - publish # Stage referenced by Salsa-CI template aptly stanza, so must exist even though not used
@@ -115,13 +115,20 @@ blhc:
   # Avoid the warnings of "debconf: unable to initialize frontend: Dialog"
   echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
   # Prime the apt cache so later apt commands can run
-  apt-get update
+  apt-get update -qq
 
 # Readline was removed from Debian Sid (and Bullseye) in Feb 2021. To be able to install older
 # versions of MariaDB that depend on it, fetch and install it from Buster.
 .test-install-readline-in-sid-for-backwards-compat: &test-install-readline-in-sid-for-backwards-compat |
-  curl -O http://ftp.de.debian.org/debian/pool/main/r/readline5/libreadline5_5.2+dfsg-3+b13_amd64.deb
-  apt install -y ./libreadline5_5.2+dfsg-3+b13_amd64.deb
+  curl -sS -O http://ftp.de.debian.org/debian/pool/main/r/readline5/libreadline5_5.2+dfsg-3+b13_amd64.deb
+  apt-get -qq install --no-install-recommends --yes ./libreadline5_5.2+dfsg-3+b13_amd64.deb
+
+# OpenSSL 1.1 was Debian Sid in Dec 2022 (as Bookworm will ship with OpenSSL 3.0
+# only). To be able to install versions of MariaDB that depend on OpenSSL 1.1,
+# fetch and install it manually.
+.test-install-openssl1-in-sid-for-backwards-compat: &test-install-openssl1-in-sid-for-backwards-compat |
+  curl -sS -O https://snapshot.debian.org/archive/debian/20220507T034236Z/pool/main/o/openssl/libssl1.1_1.1.1o-1_amd64.deb
+  apt-get -qq install --no-install-recommends --yes ./libssl1.1_1.1.1o-1_amd64.deb
 
 .test-verify-initial: &test-verify-initial |
   dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
@@ -132,12 +139,37 @@ blhc:
   mysql --table -e "SELECT * FROM plugin;" mysql
   mysql --table -e "SHOW PLUGINS;" mysql
 
-.test-enable-sid-repos: &test-enable-sid-repos |
+.test-enable-sid-repos: &test-enable-sid-repos
   # Replace any old repos with just Sid
-  echo 'deb http://deb.debian.org/debian sid main' > /etc/apt/sources.list
+  - echo 'deb http://deb.debian.org/debian sid main' > /etc/apt/sources.list
   # Upgrade minimal stack first
-  apt-get update
-  apt-get install -y apt
+  - apt-get update -qq
+  # Next step will fail on https://bugs.debian.org/993755
+  #   /usr/bin/perl: error while loading shared libraries: libcrypt.so.1: cannot
+  #     open shared object file: No such file or directory
+  #   dpkg: error processing package libc6:amd64 (--configure):
+  - apt-get install -y apt || true
+  # Apply workaround
+  - cd $(mktemp -d) # Use temp dir where apt can download and unpack files
+  - apt-get -y download libcrypt1
+  - dpkg-deb -x libcrypt1_*.deb .
+  - cp -ra lib/* /lib/
+  - cd - # Back to /builds/$USER/mariadb-server/debian/output
+  - find /lib/*/libcrypt.* -ls # Show that new libcrypt is there
+  - apt-get -y --fix-broken install
+  # Complete upgrade of minimal stack
+  - apt-get install -y apt
+
+.test-enable-bullseye-backports-repos: &test-enable-bullseye-backports-repos |
+  # Enable bullseye-backports (assumes environment already Debian Bullseye)
+  echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/bullseye-backports.list
+  # Increase default backports priority policy from '100' to '500' so it can actually be used
+  cat << EOF > /etc/apt/preferences.d/enable-backports-to-satisfy-dependencies
+  Package: *
+  Pin: release n=bullseye-*
+  Pin-Priority: 500
+  EOF
+  apt-get update -qq
 
 .test-enable-buster-backports-repos: &test-enable-buster-backports-repos |
   # Enable buster-backports (assumes environment already Debian Buster)
@@ -148,7 +180,7 @@ blhc:
   Pin: release n=buster-*
   Pin-Priority: 500
   EOF
-  apt-get update
+  apt-get update -qq
 
 .test-install: &test-install |
   # Install MariaDB built in this commit
@@ -249,6 +281,7 @@ mariadb-10.6 Sid upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
+    - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
     - *test-install
     - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
@@ -258,10 +291,10 @@ mariadb-10.6 Sid upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mariadb-10.5 Bullseye to mariadb-10.6 upgrade:
-  stage: upgrade from Bullseye
+mariadb-10.5 with Bullseye backports upgrade:
+  stage: upgrade extras
   needs:
-    - job: build
+    - job: build bullseye-backports
   image: debian:bullseye
   artifacts:
     when: always
@@ -270,13 +303,13 @@ mariadb-10.5 Bullseye to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    # Install everything MariaDB currently in Debian Bullseye
+    # Install everything MariaDB currently in Debian Buster
     - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
-    # Verify installation of MariaDB from Bullseye
+    # Verify installation of MariaDB from Buster
     - *test-verify-initial
-    - *test-enable-sid-repos
+    - *test-enable-bullseye-backports-repos
     - *test-install
-    - service mariadb status
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -284,9 +317,7 @@ mariadb-10.5 Bullseye to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-# Upgrade of libcrypt.so.1 no longer possible from Buster to Sid,
-# so test upgrade only inside Buster (https://bugs.debian.org/993755)
-mariadb-10.3 to mariadb-10.6 upgrade in Buster:
+mariadb-10.3 with Buster backports upgrade:
   stage: upgrade extras
   needs:
     - job: build buster-backports
@@ -304,7 +335,63 @@ mariadb-10.3 to mariadb-10.6 upgrade in Buster:
     - *test-verify-initial
     - *test-enable-buster-backports-repos
     - *test-install
+    # mariadb-10.3 in Buster ships a /etc/init.d/mysql so it should continue to work
     - service mysql status
+    - service mariadb status
+    - *test-verify-final
+  variables:
+    GIT_STRATEGY: none
+  except:
+    variables:
+      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+
+mariadb-10.5 Bullseye to mariadb-10.6 upgrade:
+  stage: upgrade from Buster/Bullseye
+  needs:
+    - job: build
+  image: debian:bullseye
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - ${WORKING_DIR}/debug
+  script:
+    - *test-prepare-container
+    # Install everything MariaDB currently in Debian Bullseye
+    - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
+    # Verify installation of MariaDB from Bullseye
+    - *test-verify-initial
+    - *test-enable-sid-repos
+    - *test-install
+    - service mariadb status # There is no init.d/mysql in MariaDB 10.5+
+    - *test-verify-final
+  variables:
+    GIT_STRATEGY: none
+  except:
+    variables:
+      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+
+mariadb-10.3 Buster to mariadb-10.6 upgrade:
+  stage: upgrade from Buster/Bullseye
+  needs:
+    - job: build
+  image: debian:buster
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - ${WORKING_DIR}/debug
+  script:
+    - *test-prepare-container
+    # Install everything MariaDB currently in Debian Buster
+    - apt-get install -y 'default-mysql*' 'mariadb-*' 'libmariadb*'
+    # Verify installation of MariaDB from Buster
+    - *test-verify-initial
+    - *test-enable-sid-repos
+    - *test-install
+    # mariadb-10.3 in Buster ships a /etc/init.d/mysql so it should continue to work
+    - service mysql status
+    - service mariadb status
     - *test-verify-final
   variables:
     GIT_STRATEGY: none
@@ -470,7 +557,7 @@ default-libmysqlclient-dev Sid upgrade:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
 default-libmysqlclient-dev Bullseye upgrade:
-  stage: upgrade from Bullseye
+  stage: upgrade from Buster/Bullseye
   needs:
     - job: build
   image: debian:bullseye
@@ -490,9 +577,49 @@ default-libmysqlclient-dev Bullseye upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-# Upgrade of libcrypt.so.1 no longer possible from Buster to Sid,
-# so test upgrade only inside Buster (https://bugs.debian.org/993755)
-default-libmysqlclient-dev upgrade in Buster:
+default-libmysqlclient-dev Buster upgrade:
+  stage: upgrade from Buster/Bullseye
+  needs:
+    - job: build
+  image: debian:buster
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - ${WORKING_DIR}/debug
+  script:
+    - *test-prepare-container
+    - apt-get install -y pkg-config default-libmysqlclient-dev
+    - pkg-config --list-all
+    - *test-enable-sid-repos
+    - *test-install-all-libs
+    - *test-verify-libs
+  except:
+    variables:
+      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+
+default-libmysqlclient-dev with Bullseye backports upgrade:
+  stage: upgrade extras
+  needs:
+    - job: build bullseye-backports
+  image: debian:bullseye
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - ${WORKING_DIR}/debug
+  script:
+    - *test-prepare-container
+    - apt-get install -y pkg-config default-libmysqlclient-dev
+    - pkg-config --list-all
+    - *test-enable-bullseye-backports-repos
+    - *test-install-all-libs
+    - *test-verify-libs
+  except:
+    variables:
+      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+
+default-libmysqlclient-dev with Buster backports upgrade:
   stage: upgrade extras
   needs:
     - job: build buster-backports
@@ -531,18 +658,14 @@ mysql-8.0 Sid to mariadb-10.6 upgrade:
     - apt-get install -y procps mysql-server 'libmysqlc*'
     - *test-verify-initial
     - *test-install
-    # The Debian version of MariaDB 10.6 still maintains compatibility and there
-    # running 'service mysql status' in Salsa-CI job 'mysql-8.0 Sid to
-    # mariadb-10.6 upgrade' still works.
-    #
-    # However, due to debian/control changes, the upstream MariaDB 10.6 when
-    # installed on a system with a previous installation of MySQL 8.0 will first
-    # fully remove MySQL, including the /etc/init.d/mysql file, so previous
-    # techniques in mariadb-server-10.6.postinst to maintain backwards
-    # compatibility with 'service mysql status' after installing MariaDB on top
-    # MySQL no longer works, and thus the step to test it now intentionally has
-    # a fallback to use the service name 'mariadb' instead, and the fallback is
-    # always used.
+    # Due to some (currently unknown) changes in MySQL 8.0 packaging or apt
+    # behaviour changes, a system with a previous installation of MySQL 8.0 will
+    # on upgrades to MariaDB first fully remove MySQL, including the
+    # /etc/init.d/mysql file, so previous techniques in
+    # mariadb-server-10.6.postinst to maintain backwards compatibility with
+    # 'service mysql status' after installing MariaDB on top MySQL no longer
+    # works. Thus the step to test it now intentionally has a fallback to use
+    # the service name 'mariadb' instead, and the fallback is always used.
     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
     - service mysql status || service mariadb status
     - *test-verify-final
@@ -554,11 +677,14 @@ mysql-8.0 Sid to mariadb-10.6 upgrade:
 
 # Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
 # The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
-mysql-8.0 Focal to mariadb-10.6 upgrade in Buster:
+#
+# Testing on Focal binaries on Buster works. Using Jammy binaries on Bullseye
+# does not work as libc in Jammy is too new.
+mysql-8.0 from Ubuntu 22.04 with Bullseye backports upgrade:
   stage: upgrade extras
   needs:
-    - job: build buster-backports
-  image: debian:buster
+    - job: build bullseye-backports
+  image: debian:bullseye
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -570,15 +696,54 @@ mysql-8.0 Focal to mariadb-10.6 upgrade in Buster:
     - apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
     - apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 871920D1991BC93C 3B4FE6ACC0B21F32
     - echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" > /etc/apt/sources.list.d/ubuntu.list
-    - apt-get update
+    - apt-get update -qq
     # First install often fail due to bug in mysql-8.0
     - apt-get install -y mysql-server 'libmysqlc*' || true
     - sleep 10 && apt-get install -f
     - *test-verify-initial
     # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update
+    - echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update -qq
     - *test-install
     - service mysql status
+    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+    - *test-verify-final
+  variables:
+    GIT_STRATEGY: none
+  except:
+    variables:
+      - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
+
+# Upgrading from MySQL 8.0 with datadir in place is not possible. Users need to do a data dump.
+# The Debian maintainer scripts detect this situation and simply moves old datadir aside and start fresh.
+mysql-community-cluster-8.0 from MySQL.com with Bullseye backports upgrade:
+  stage: upgrade extras
+  needs:
+    - job: build bullseye-backports
+  image: debian:bullseye
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - ${WORKING_DIR}/debug
+  script:
+    - *test-prepare-container
+    - apt-get install --no-install-recommends --yes ca-certificates curl systemctl
+    - curl -sS "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x859be8d7c586f538430b19c2467b942d3a79bd29" -o /etc/apt/trusted.gpg.d/mysql.asc
+    - echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-cluster-8.0" > /etc/apt/sources.list.d/mysql.list
+    - apt-get update -qq
+    - apt-get install -y mysql-cluster-community-server
+    - sed 's/ExecStartPre=+/ExecStartPre=/' -i /lib/systemd/system/mysql.service # Hack to make file compatible with systemctl shim
+    - systemctl start mysql
+    - dpkg -l | grep -iE 'maria|mysql|galera'
+    - systemctl status mysql; mysql -e 'SELECT VERSION()'
+    - systemctl stop mysql # Stop manually as maintainer scripts don't handle this with systemctl shim
+    # Enable backports to make galera-4 available
+    - echo "deb http://deb.debian.org/debian bullseye-backports main" > /etc/apt/sources.list.d/backports.list && apt-get update -qq
+    - *test-install
+    # Ignore systemctl shim result as MariaDB systemd file is incompatible with it and yields:
+    #   ERROR:systemctl:the ExecStartPre control process exited with error code
+    - systemctl status mysql || true
+    - mysql -e 'SELECT VERSION()' || true
     - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
     - *test-verify-final
   variables:
@@ -599,10 +764,10 @@ mariadb.org-10.6 to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    - apt install -y curl
+    - apt-get -qq install --no-install-recommends --yes ca-certificates curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo "deb https://deb.mariadb.org/10.6/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
-    - apt-get update
+    - apt-get update -qq
     # Package libmariadbclient-dev from mariadb.org conflicts with libmariadb-dev in Sid, so cannot use wildcard that would include it
     # Enable this line when there is a way to install them only from the mariadb.org repo
     # - apt-get install -y 'mariadb*' libmariadb3 'libmariadb-*' 'libmariadbd*'
@@ -622,6 +787,7 @@ mariadb.org-10.6 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
+# archive.mariadb.org for Debian Sid latest is 10.5.13
 mariadb.org-10.5 to mariadb-10.6 upgrade:
   stage: upgrade extras
   needs:
@@ -634,10 +800,11 @@ mariadb.org-10.5 to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    - apt install -y curl
+    - apt-get -qq install --no-install-recommends --yes ca-certificates curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo "deb https://archive.mariadb.org/mariadb-10.5/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
-    - apt-get update
+    - apt-get update -qq
+    - *test-install-openssl1-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.5
     - *test-verify-initial
     # Install MariaDB built in this commit
@@ -652,6 +819,7 @@ mariadb.org-10.5 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
+# archive.mariadb.org for Debian Sid latest is 10.4.17
 mariadb.org-10.4 to mariadb-10.6 upgrade:
   stage: upgrade extras
   needs:
@@ -664,11 +832,12 @@ mariadb.org-10.4 to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    - apt install -y curl systemctl # systemctl shim needed on platforms that don't have systemd
+    - apt-get -qq install --no-install-recommends --yes ca-certificates curl systemctl # systemctl shim needed on platforms that don't have systemd
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo "deb https://archive.mariadb.org/mariadb-10.4/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
-    - apt-get update
+    - apt-get update -qq
     - *test-install-readline-in-sid-for-backwards-compat
+    - *test-install-openssl1-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.4
     # MariaDB.org version of 10.4 and early 10.5 do not install an init file, so
     # it must be installed here manually
@@ -685,6 +854,7 @@ mariadb.org-10.4 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
+# archive.mariadb.org for Debian Sid latest is 10.3.27
 mariadb.org-10.3 to mariadb-10.6 upgrade:
   stage: upgrade extras
   needs:
@@ -697,11 +867,12 @@ mariadb.org-10.3 to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    - apt install -y curl
+    - apt-get -qq install --no-install-recommends --yes ca-certificates curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo "deb https://archive.mariadb.org/mariadb-10.3/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
-    - apt-get update
+    - apt-get update -qq
     - *test-install-readline-in-sid-for-backwards-compat
+    - *test-install-openssl1-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.3
     - *test-verify-initial
     - *test-install
@@ -716,6 +887,7 @@ mariadb.org-10.3 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
+# archive.mariadb.org for Debian Sid latest is 10.2.21
 mariadb.org-10.2 to mariadb-10.6 upgrade:
   stage: upgrade extras
   needs:
@@ -728,11 +900,12 @@ mariadb.org-10.2 to mariadb-10.6 upgrade:
       - ${WORKING_DIR}/debug
   script:
     - *test-prepare-container
-    - apt install -y curl
+    - apt-get -qq install --no-install-recommends --yes ca-certificates curl
     - curl -sS https://mariadb.org/mariadb_release_signing_key.asc -o /etc/apt/trusted.gpg.d/mariadb.asc
     - echo "deb https://archive.mariadb.org/mariadb-10.2/repo/debian ${RELEASE} main" > /etc/apt/sources.list.d/mariadb.list
-    - apt-get update
+    - apt-get update -qq
     - *test-install-readline-in-sid-for-backwards-compat
+    - *test-install-openssl1-in-sid-for-backwards-compat
     - apt-get install -y mariadb-server-10.2
     # Verify initial state before upgrade
     - dpkg -l | grep -iE 'maria|mysql|galera' || true # List installed
@@ -755,11 +928,11 @@ mariadb.org-10.2 to mariadb-10.6 upgrade:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-mysql.com-5.7 to mariadb-10.6 upgrade in Buster:
+mysql.com-5.7 with Bullseye backports upgrade:
   stage: upgrade extras
   needs:
-    - job: build buster-backports
-  image: debian:buster
+    - job: build bullseye-backports
+  image: debian:bullseye
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -770,14 +943,23 @@ mysql.com-5.7 to mariadb-10.6 upgrade in Buster:
     - |
       apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
       apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 467B942D3A79BD29
-      echo "deb https://repo.mysql.com/apt/debian/ buster mysql-5.7" > /etc/apt/sources.list.d/mysql.list
-      apt-get update
+      echo "deb https://repo.mysql.com/apt/debian/ bullseye mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+      apt-get update -qq
       apt-get install -y 'mysql*' 'libmysqlc*'
     - *test-verify-initial
     # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
+    - echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update -qq
     - *test-install
-    - service mysql status
+    # Due to some (currently unknown) changes in MySQL 5.7 packaging or apt
+    # behaviour changes, a system with a previous installation of MySQL will
+    # on upgrades to MariaDB first fully remove MySQL, including the
+    # /etc/init.d/mysql file, so previous techniques in
+    # mariadb-server-10.6.postinst to maintain backwards compatibility with
+    # 'service mysql status' after installing MariaDB on top MySQL no longer
+    # works. Thus the step to test it now intentionally has a fallback to use
+    # the service name 'mariadb' instead, and the fallback is always used.
+    - sleep 5 # Give the mysql_upgrade a bit of time to complete before querying the server
+    - service mysql status || service mariadb status
     - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server
     - *test-verify-final
   variables:
@@ -786,11 +968,11 @@ mysql.com-5.7 to mariadb-10.6 upgrade in Buster:
     variables:
       - $CI_COMMIT_TAG != null && $SALSA_CI_ENABLE_PIPELINE_ON_TAGS !~ /^(1|yes|true)$/
 
-percona-xtradb-5.7 to mariadb-10.6 upgrade in Buster (MDEV-22679):
+percona-xtradb-5.7 with bullseye backports upgrade:
   stage: upgrade extras
   needs:
-    - job: build buster-backports
-  image: debian:buster
+    - job: build bullseye-backports
+  image: debian:bullseye
   artifacts:
     when: always
     name: "$CI_BUILD_NAME"
@@ -801,13 +983,13 @@ percona-xtradb-5.7 to mariadb-10.6 upgrade in Buster (MDEV-22679):
     - |
       apt-get install --no-install-recommends --yes gpg gpg-agent dirmngr ca-certificates # Bare minimal (<4MB) for apt-key to work
       apt-key adv --recv-keys --keyserver hkps://keyserver.ubuntu.com:443 9334A25F8507EFA5
-      echo "deb https://repo.percona.com/apt/ buster main" > /etc/apt/sources.list.d/mysql.list
-      apt-get update
+      echo "deb https://repo.percona.com/apt/ bullseye main" > /etc/apt/sources.list.d/mysql.list
+      apt-get update -qq
       apt-get install -y percona-xtradb-cluster-full-57 percona-xtrabackup-24 percona-toolkit pmm2-client
     - service mysql status
     - *test-verify-initial
     # Enable backports to make galera-4 available
-    - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update
+    - echo "deb http://deb.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list.d/backports.list && apt-get update -qq
     - *test-install
     - service mysql status
     - sleep 15 # Give the mysql_upgrade a bit of extra time to complete with MySQL 5.7 before querying the server


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-MDEV-30322*

## Description

Compare to Debian packaging of MariaDB 1:10.6.11-2 release at commit https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/2934e8a795cbd1eba79e33b8d6c82ed2b0897128 and sync upstream everything that is relevant for upstream and safe to import on a stable 10.6 release.

* Use OpenSSL 1.1 from Debian Snapshots https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/0040c272bf8a9a253fcd393b235b18cd5cdc9289 Related: https://jira.mariadb.org/browse/MDEV-30322

* Prefer using bullseye-backports in mosts tests over buster-bpo https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/daa827ecded9dc1f096ecb05242116173298d602

* Add new upgrade test for MySQL Community Cluster 8.0 https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/3c71bec9b7626d25a55e23b2e570b4e125d5d5df

* Enable automatic datadir move also on upgrades from MySQL.com packages https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/4cbbcb7e56d9604a67230d11a68543d5a83960e3

* Update Breaks/Replaces https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/2cab13d05959fe8f6ea56b866df51f3bfe17dd3f

* Normalize apt-get and curl commands https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/8754ea2578bd214d75a2a9e6a0f7b4b74c062b41

* Standardize on using capitalized 'ON' in CMake build options https://salsa.debian.org/mariadb-team/mariadb-server/-/commit/938757a85aee44c727f3f6996677ef1126c2f5aa

* Apply wrap-and-sort -av and other minor tweaks and inline documentation

NOTE TO MERGERS: This commit is made on 10.6 branch and can be merged to all later branches (10.7, 10.8, ..., 10.11).

## How can this PR be tested?

### Salsa-CI

Before: https://salsa.debian.org/mariadb-team/mariadb-server/-/pipelines/481117

![image](https://user-images.githubusercontent.com/668724/211254658-bc9f85d7-2eff-48ed-8a72-4e56e9a9da3d.png)

After: https://salsa.debian.org/otto/mariadb-server/-/pipelines/481866

![image](https://user-images.githubusercontent.com/668724/212262293-dbe11307-c946-4a3b-85e5-be7f22bc5d93.png)

The MariaDB 10.6 upgrade scenario still fails, but for same reason and not affected by this commit. Fixing that upgrade scenario will continue in #2300.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility

Yes. Changes have been in use in Debian and Ubuntu for some while and are safe to fix on a stable release.
