### PR TITLE
Fix three occurrences of use-of-uninitialized-value

### DIFF
--- a/mysys/mf_format.c
+++ b/mysys/mf_format.c
@@ -36,6 +36,8 @@ char * fn_format(char * to, const char *name, const char *dir,
   DBUG_PRINT("enter",("name: %s  dir: %s  extension: %s  flag: %d",
 		       name,dir,extension,flag));
 
+  memset(buff, 0, FN_REFLEN);
+
   /* Copy and skip directory */
   name+=(length=dirname_part(dev, (startpos=(char *) name), &dev_length));
   if (length == 0 || (flag & MY_REPLACE_DIR))

--- a/mysys/mf_pack.c
+++ b/mysys/mf_pack.c
@@ -337,6 +337,8 @@ size_t unpack_dirname(char * to, const char *from)
   char buff[FN_REFLEN+1+4],*suffix,*tilde_expansion;
   DBUG_ENTER("unpack_dirname");
 
+  memset(buff, 0, FN_REFLEN + 1 +4);
+
   length= normalize_dirname(buff, from);
 
   if (buff[0] == FN_HOMELIB)


### PR DESCRIPTION
GitLab CI backported to version 10.3 in this commit
[24e86b8](https://github.com/MariaDB/server/pull/2418/commits/24e86b862277b853842ebba9e0183312cb28b9c0)
was able to find several problems with similarsignature. Here we are fixing 3
first issues:

```
[ 34%] Built target aes-t
==7597==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55a56cdee49b in my_read_charset_file /CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/mysys/charset.c:507:62
    #1 0x55a56cde5367 in init_available_charsets /CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/mysys/charset.c:641:3
    #2 0x7fb7887e2a67 in __pthread_once_slow (/lib64/libc.so.6+0xa4a67)
    #3 0x55a56cde545f in get_charset_number /CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/mysys/charset.c:705:3
    #4 0x55a56cdddba9 in create_sys_files /CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/extra/comp_err.c:350:18
    #5 0x55a56cdddba9 in main /CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/extra/comp_err.c:200:9
    #6 0x7fb78877deaf in __libc_start_call_main (/lib64/libc.so.6+0x3feaf)
    #7 0x7fb78877df5f in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3ff5f)
    #8 0x55a56cd555d4 in _start (/CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/builddir/extra/comp_err+0x465d4)

  Uninitialized value was created by an allocation of 'stat_info' in the stack frame of function 'my_read_charset_file'
    #0 0x55a56cdedfb0 in my_read_charset_file /CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/mysys/charset.c:500

SUMMARY: MemorySanitizer: use-of-uninitialized-value /CPACK_BUILD_SOURCE_DIRS_LONG_NAME_REQUIREMENT/mysys/charset.c:507:62 in my_read_charset_file
Exiting
```

```
==143==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x56214617f15b  (/usr/bin/my_print_defaults+0x26315b) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
    #1 0x5621460018d2  (/usr/bin/my_print_defaults+0xe58d2) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
    #2 0x562145ffd746  (/usr/bin/my_print_defaults+0xe1746) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
    #3 0x562145ffb550  (/usr/bin/my_print_defaults+0xdf550) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
    #4 0x562145ff9f0d  (/usr/bin/my_print_defaults+0xddf0d) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
    #5 0x562145ff8bf2  (/usr/bin/my_print_defaults+0xdcbf2) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
    #6 0x7ffb39aa950f  (/lib64/libc.so.6+0x2750f) (BuildId: 765237b0355c030ff41d969eedcb87bfccb43595)
    #7 0x7ffb39aa95c8  (/lib64/libc.so.6+0x275c8) (BuildId: 765237b0355c030ff41d969eedcb87bfccb43595)
    #8 0x562145f67534  (/usr/bin/my_print_defaults+0x4b534) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
  Uninitialized value was created by an allocation of 'buff' in the stack frame of function 'fn_format'
    #0 0x562146000ca0  (/usr/bin/my_print_defaults+0xe4ca0) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
SUMMARY: MemorySanitizer: use-of-uninitialized-value (/usr/bin/my_print_defaults+0x26315b) (BuildId: 72ab209e762114adacc5372e572d0ee62e04f5f5)
Exiting
```

and
```
==179==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x55608669c19b  (/usr/bin/my_print_defaults+0x26319b) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
    #1 0x556086521436  (/usr/bin/my_print_defaults+0xe8436) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
    #2 0x55608651e192  (/usr/bin/my_print_defaults+0xe5192) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
    #3 0x55608651a746  (/usr/bin/my_print_defaults+0xe1746) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
    #4 0x556086518550  (/usr/bin/my_print_defaults+0xdf550) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
    #5 0x556086516f0d  (/usr/bin/my_print_defaults+0xddf0d) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
    #6 0x556086515bf2  (/usr/bin/my_print_defaults+0xdcbf2) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
    #7 0x7f213e85550f  (/lib64/libc.so.6+0x2750f) (BuildId: db8b8949801cc5d89afa366440dcc44c9c9ca76a)
    #8 0x7f213e8555c8  (/lib64/libc.so.6+0x275c8) (BuildId: db8b8949801cc5d89afa366440dcc44c9c9ca76a)
    #9 0x556086484534  (/usr/bin/my_print_defaults+0x4b534) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)

  Uninitialized value was created by an allocation of 'buff' in the stack frame of function 'unpack_dirname'
    #0 0x556086520df0  (/usr/bin/my_print_defaults+0xe7df0) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)

SUMMARY: MemorySanitizer: use-of-uninitialized-value (/usr/bin/my_print_defaults+0x26319b) (BuildId: b7fa987d0df881b44c8fa05e46ed1d184fdcf3b5)
Exiting
```

we are expecting that a number of similar problems can appear during further CI
analisys. In this case we continue to fix them in the same manner in new PRs.

All build stages pass for these commits.

- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

The changes are fully backward compatible.

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the BSD-new
license. I am contributing on behalf of my employer Amazon Web Services,
Inc.