### PR TITLE
MDEV-30065: mariadb-install-db --enforce-storage-engine=InnoDB fails …

### DIFF
--- a/mysql-test/include/check-warnings.test
+++ b/mysql-test/include/check-warnings.test
@@ -30,7 +30,7 @@ create temporary table error_log (
   suspicious int default 1,
   file_name varchar(255),
   line varchar(1024) default null
-) engine=myisam;
+);
 
 # Get the name of servers error log
 let $log_error= $MTR_LOG_ERROR;

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -316,7 +316,7 @@ my %mysqld_logs;
 my $opt_debug_sync_timeout= 300; # Default timeout for WAIT_FOR actions.
 my $warn_seconds = 60;
 
-my $rebootstrap_re= '--innodb[-_](?:page[-_]size|checksum[-_]algorithm|undo[-_]tablespaces|log[-_]group[-_]home[-_]dir|data[-_]home[-_]dir)|data[-_]file[-_]path|force_rebootstrap';
+my $rebootstrap_re= '--innodb[-_](?:page[-_]size|checksum[-_]algorithm|undo[-_]tablespaces|log[-_]group[-_]home[-_]dir|data[-_]home[-_]dir)|data[-_]file[-_]path|--enforce[-_]storage[-_]engine|force_rebootstrap';
 
 sub testcase_timeout ($) { return $opt_testcase_timeout * 60; }
 sub check_timeout ($) { return testcase_timeout($_[0]); }

--- a/mysql-test/suite/innodb/r/enforce-innodb.result
+++ b/mysql-test/suite/innodb/r/enforce-innodb.result
@@ -1,0 +1,71 @@
+list of non-innodb system tables:
+SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA='mysql' AND ENGINE!='InnoDB';
+TABLE_NAME
+use mysql;
+show create table help_relation;
+Table	Create Table
+help_relation	CREATE TABLE `help_relation` (
+  `help_topic_id` int(10) unsigned NOT NULL,
+  `help_keyword_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`help_keyword_id`,`help_topic_id`),
+  KEY `help_topic_id` (`help_topic_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci TRANSACTIONAL=0 COMMENT='keyword-topic relation'
+Re-add relation like might have been pre-MDEV-30065 (with a bit of effort).
+alter table help_relation add foreign key (help_topic_id) references help_topic ( help_topic_id), add foreign key (help_keyword_id)  references help_keyword ( help_keyword_id);
+Phase 1/7: Checking and upgrading mysql database
+Processing databases
+mysql
+mysql.column_stats                                 OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.global_priv                                  OK
+mysql.gtid_slave_pos                               OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.index_stats                                  OK
+mysql.innodb_index_stats                           OK
+mysql.innodb_table_stats                           OK
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.roles_mapping                                OK
+mysql.servers                                      OK
+mysql.table_stats                                  OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.transaction_registry                         OK
+Phase 2/7: Installing used storage engines... Skipped
+Phase 3/7: Fixing views
+mysql.user                                         OK
+Phase 4/7: Running 'mysql_fix_privilege_tables'
+Phase 5/7: Fixing table and database names
+Phase 6/7: Checking and upgrading tables
+Processing databases
+information_schema
+mtr
+mtr.global_suppressions                            OK
+mtr.test_suppressions                              OK
+performance_schema
+test
+Phase 7/7: Running 'FLUSH PRIVILEGES'
+OK
+show create table help_relation;
+Table	Create Table
+help_relation	CREATE TABLE `help_relation` (
+  `help_topic_id` int(10) unsigned NOT NULL,
+  `help_keyword_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`help_keyword_id`,`help_topic_id`),
+  KEY `help_topic_id` (`help_topic_id`)
+) ENGINE=Aria DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci PAGE_CHECKSUM=1 TRANSACTIONAL=0 COMMENT='keyword-topic relation'
+#
+# End of 10.5 tests
+#

--- a/mysql-test/suite/innodb/t/enforce-innodb.opt
+++ b/mysql-test/suite/innodb/t/enforce-innodb.opt
@@ -1,0 +1,2 @@
+--enforce-storage-engine=InnoDB
+--default-storage-engine=InnoDB

--- a/mysql-test/suite/innodb/t/enforce-innodb.test
+++ b/mysql-test/suite/innodb/t/enforce-innodb.test
@@ -1,0 +1,22 @@
+--source include/have_innodb.inc
+
+--echo list of non-innodb system tables:
+SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA='mysql' AND ENGINE!='InnoDB';
+
+use mysql;
+
+show create table help_relation;
+
+--echo Re-add relation like might have been pre-MDEV-30065 (with a bit of effort).
+
+alter table help_relation add foreign key (help_topic_id) references help_topic ( help_topic_id), add foreign key (help_keyword_id)  references help_keyword ( help_keyword_id);
+
+--exec $MYSQL_UPGRADE --force 2>&1
+
+show create table help_relation;
+let $MYSQLD_DATADIR= `select @@datadir`;
+--remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+
+--echo #
+--echo # End of 10.5 tests
+--echo #

--- a/scripts/mysql_system_tables.sql
+++ b/scripts/mysql_system_tables.sql
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS help_topic ( help_topic_id int unsigned not null, nam
 CREATE TABLE IF NOT EXISTS help_category ( help_category_id smallint unsigned not null, name  char(64) not null, parent_category_id smallint unsigned null, url text not null, primary key (help_category_id), unique index (name) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='help categories';
 
 
-CREATE TABLE IF NOT EXISTS help_relation ( help_topic_id int unsigned not null references help_topic, help_keyword_id  int unsigned not null references help_keyword, primary key (help_keyword_id, help_topic_id) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='keyword-topic relation';
+CREATE TABLE IF NOT EXISTS help_relation ( help_topic_id int unsigned not null, help_keyword_id  int unsigned not null, primary key (help_keyword_id, help_topic_id), key (help_topic_id) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='keyword-topic relation';
 
 
 CREATE TABLE IF NOT EXISTS help_keyword (   help_keyword_id  int unsigned not null, name char(64) not null, primary key (help_keyword_id), unique index (name) ) engine=Aria transactional=0 CHARACTER SET utf8 comment='help keywords';

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -773,6 +773,9 @@ ALTER TABLE proc ENGINE=Aria transactional=1;
 ALTER TABLE event ENGINE=Aria transactional=1;
 ALTER TABLE proxies_priv ENGINE=Aria transactional=1;
 
+-- system tables shouldn't have FK constraint. If it was forced to innodb, lets remove it.
+ALTER TABLE help_relation drop constraint if exists help_relation_ibfk_1, drop constraint if exists help_relation_ibfk_2, add key if not exists (help_topic_id);
+
 -- The following tables doesn't have to be transactional
 ALTER TABLE help_topic ENGINE=Aria transactional=0;
 ALTER TABLE help_category ENGINE=Aria transactional=0;


### PR DESCRIPTION
…with InnoDB errors

replaces #2342.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30065*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

help_relation table has historically had a FK relationship. Under the normal Aria install, without --enforce-storage-engine=InnoDB, these FK relations would have been ignored.

Azure has been providing InnoDB only system tables for a while so we move to supporting this just a little more.

In this change. we drop the FK relationship rather than manipulate the logic around locking system tables (#2342).

Explictly add the index on help_topic_id that the FK auto-created.

The upgrade path drops these FK relationships. Note mariadb-upgrade unsets the enforce-storage-engine for the upgrade so tables will be forced back to Aria using mariadb-upgrade.

To enable mtr to run a test the check-warnings needed the explict MyISAM table type removed.

The enforce-innodb.opt needed the default-engine=InnoDB to override the mtr default of MyISAM too for the check-warnings.test.

enforce-storage-engine becomes a option that MTR needs to force a re-bootstrap on.

## How can this PR be tested?

mtr test included.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

I tried to split the `$reboostrap_re` according to https://lists.launchpad.net/maria-developers/msg13272.html but my perl skills failed me.