### PR TITLE
MDEV-30389: Update calls to `encryption_crypt` to provide correct destination length

### DIFF
--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -60,6 +60,10 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -57,10 +57,13 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
 {
   void *ctx= alloca(encryption_handler.encryption_ctx_size_func((key_id),(key_version)));
   int res1, res2;
-  unsigned int d1, d2;
+  unsigned int d1, d2= *dlen;
+  assert(*dlen >= slen);
+  assert((dst[*dlen - 1]= 1));
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));
+  d2-= d1;
   res2= encryption_handler.encryption_ctx_finish_func((ctx),(dst + d1),(&d2));
   *dlen= d1 + d2;
   return res1 ? res1 : res2;

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -60,6 +60,10 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -57,10 +57,13 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
 {
   void *ctx= alloca(encryption_handler.encryption_ctx_size_func((key_id),(key_version)));
   int res1, res2;
-  unsigned int d1, d2;
+  unsigned int d1, d2= *dlen;
+  assert(*dlen >= slen);
+  assert((dst[*dlen - 1]= 1));
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));
+  d2-= d1;
   res2= encryption_handler.encryption_ctx_finish_func((ctx),(dst + d1),(&d2));
   *dlen= d1 + d2;
   return res1 ? res1 : res2;

--- a/include/mysql/plugin_data_type.h.pp
+++ b/include/mysql/plugin_data_type.h.pp
@@ -60,6 +60,10 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));

--- a/include/mysql/plugin_data_type.h.pp
+++ b/include/mysql/plugin_data_type.h.pp
@@ -57,10 +57,13 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
 {
   void *ctx= alloca(encryption_handler.encryption_ctx_size_func((key_id),(key_version)));
   int res1, res2;
-  unsigned int d1, d2;
+  unsigned int d1, d2= *dlen;
+  assert(*dlen >= slen);
+  assert((dst[*dlen - 1]= 1));
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));
+  d2-= d1;
   res2= encryption_handler.encryption_ctx_finish_func((ctx),(dst + d1),(&d2));
   *dlen= d1 + d2;
   return res1 ? res1 : res2;

--- a/include/mysql/plugin_encryption.h
+++ b/include/mysql/plugin_encryption.h
@@ -96,8 +96,11 @@ struct st_mariadb_encryption
   /**
     processes (encrypts or decrypts) a chunk of data
 
-    writes the output to th dst buffer. note that it might write
+    writes the output to the dst buffer. note that it might write
     more bytes that were in the input. or less. or none at all.
+
+    dlen points to the starting lenght of the output buffer. Upon return, it
+    should be set to the number of bytes written.
   */
   int (*crypt_ctx_update)(void *ctx, const unsigned char* src, unsigned int slen,
                           unsigned char* dst, unsigned int* dlen);
@@ -123,4 +126,3 @@ struct st_mariadb_encryption
 }
 #endif
 #endif
-

--- a/include/mysql/plugin_encryption.h.pp
+++ b/include/mysql/plugin_encryption.h.pp
@@ -60,6 +60,10 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));

--- a/include/mysql/plugin_encryption.h.pp
+++ b/include/mysql/plugin_encryption.h.pp
@@ -57,10 +57,13 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
 {
   void *ctx= alloca(encryption_handler.encryption_ctx_size_func((key_id),(key_version)));
   int res1, res2;
-  unsigned int d1, d2;
+  unsigned int d1, d2= *dlen;
+  assert(*dlen >= slen);
+  assert((dst[*dlen - 1]= 1));
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));
+  d2-= d1;
   res2= encryption_handler.encryption_ctx_finish_func((ctx),(dst + d1),(&d2));
   *dlen= d1 + d2;
   return res1 ? res1 : res2;

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -60,6 +60,10 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -57,10 +57,13 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
 {
   void *ctx= alloca(encryption_handler.encryption_ctx_size_func((key_id),(key_version)));
   int res1, res2;
-  unsigned int d1, d2;
+  unsigned int d1, d2= *dlen;
+  assert(*dlen >= slen);
+  assert((dst[*dlen - 1]= 1));
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));
+  d2-= d1;
   res2= encryption_handler.encryption_ctx_finish_func((ctx),(dst + d1),(&d2));
   *dlen= d1 + d2;
   return res1 ? res1 : res2;

--- a/include/mysql/plugin_function.h.pp
+++ b/include/mysql/plugin_function.h.pp
@@ -60,6 +60,10 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));

--- a/include/mysql/plugin_function.h.pp
+++ b/include/mysql/plugin_function.h.pp
@@ -57,10 +57,13 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
 {
   void *ctx= alloca(encryption_handler.encryption_ctx_size_func((key_id),(key_version)));
   int res1, res2;
-  unsigned int d1, d2;
+  unsigned int d1, d2= *dlen;
+  assert(*dlen >= slen);
+  assert((dst[*dlen - 1]= 1));
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));
+  d2-= d1;
   res2= encryption_handler.encryption_ctx_finish_func((ctx),(dst + d1),(&d2));
   *dlen= d1 + d2;
   return res1 ? res1 : res2;

--- a/include/mysql/plugin_password_validation.h.pp
+++ b/include/mysql/plugin_password_validation.h.pp
@@ -60,6 +60,10 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   unsigned int d1, d2= *dlen;
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));

--- a/include/mysql/plugin_password_validation.h.pp
+++ b/include/mysql/plugin_password_validation.h.pp
@@ -57,10 +57,13 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
 {
   void *ctx= alloca(encryption_handler.encryption_ctx_size_func((key_id),(key_version)));
   int res1, res2;
-  unsigned int d1, d2;
+  unsigned int d1, d2= *dlen;
+  assert(*dlen >= slen);
+  assert((dst[*dlen - 1]= 1));
   if ((res1= encryption_handler.encryption_ctx_init_func((ctx),(key),(klen),(iv),(ivlen),(flags),(key_id),(key_version))))
     return res1;
   res1= encryption_handler.encryption_ctx_update_func((ctx),(src),(slen),(dst),(&d1));
+  d2-= d1;
   res2= encryption_handler.encryption_ctx_finish_func((ctx),(dst + d1),(&d2));
   *dlen= d1 + d2;
   return res1 ? res1 : res2;

--- a/include/mysql/service_encryption.h
+++ b/include/mysql/service_encryption.h
@@ -104,7 +104,11 @@ static inline unsigned int encryption_key_version_exists(unsigned int id, unsign
   return encryption_key_get(id, version, NULL, &unused) != ENCRYPTION_KEY_VERSION_INVALID;
 }
 
-/* main entrypoint to perform encryption or decryption */
+/** main entrypoint to perform encryption or decryption
+ * @invariant `src` is valid for `slen`
+ * @invariant `dst` is valid for `*dlen`, `*dlen` is initialized
+ * @invariant `src` and `dst` do not overlap
+ */
 static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
                                    unsigned char* dst, unsigned int* dlen,
                                    const unsigned char* key, unsigned int klen,
@@ -118,6 +122,11 @@ static inline int encryption_crypt(const unsigned char* src, unsigned int slen,
   // Verify dlen is initialized properly. See MDEV-30389
   assert(*dlen >= slen);
   assert((dst[*dlen - 1]= 1));
+  // Verify buffers do not overlap
+  if (src < dst)
+    assert(src + slen <= dst);
+  else
+    assert(dst + *dlen <= src);
 
   if ((res1= encryption_ctx_init(ctx, key, klen, iv, ivlen, flags, key_id, key_version)))
     return res1;

--- a/sql/encryption.cc
+++ b/sql/encryption.cc
@@ -189,8 +189,7 @@ ret:
 
 /** Run encryption or decryption on a block.
  * `i32_1`, `i32_2`, and `i64` are used to create the initialization vector
- * @invariant `src` must be valid for `slen`
- * @invariant `dst` is valid for `*dlen`, `*dlen` is initialized
+ * @invariant `src` and `dst` invariants are the same as in `encryption_crypt`
  */
 int do_crypt(const unsigned char* src, unsigned int slen,
              unsigned char* dst, unsigned int* dlen,
@@ -231,8 +230,7 @@ int do_crypt(const unsigned char* src, unsigned int slen,
 
 /** Encrypt a block.
  * `i32_1`, `i32_2`, and `i64` are used to create the initialization vector
- * @invariant `src` is valid for `slen`
- * @invariant `dst` is valid for `*dlen`, `*dlen` is initialized
+ * @invariant `src` and `dst` invariants are the same as in `encryption_crypt`
  */
 int encryption_scheme_encrypt(const unsigned char* src, unsigned int slen,
                               unsigned char* dst, unsigned int* dlen,
@@ -246,8 +244,7 @@ int encryption_scheme_encrypt(const unsigned char* src, unsigned int slen,
 
 /** Decrypt a block.
  * `i32_1`, `i32_2`, and `i64` are used to create the initialization vector
- * @invariant `src` is valid for `slen`
- * @invariant `dst` is valid for `*dlen`, `*dlen` is initialized
+ * @invariant `src` and `dst` invariants are the same as in `encryption_crypt`
  */
 int encryption_scheme_decrypt(const unsigned char* src, unsigned int slen,
                               unsigned char* dst, unsigned int* dlen,

--- a/sql/encryption.cc
+++ b/sql/encryption.cc
@@ -187,6 +187,11 @@ ret:
   return rc;
 }
 
+/** Run encryption or decryption on a block.
+ * `i32_1`, `i32_2`, and `i64` are used to create the initialization vector
+ * @invariant `src` must be valid for `slen`
+ * @invariant `dst` is valid for `*dlen`, `*dlen` is initialized
+ */
 int do_crypt(const unsigned char* src, unsigned int slen,
              unsigned char* dst, unsigned int* dlen,
              struct st_encryption_scheme *scheme,
@@ -224,6 +229,11 @@ int do_crypt(const unsigned char* src, unsigned int slen,
                           iv, sizeof(iv), flag, scheme->key_id, key_version);
 }
 
+/** Encrypt a block.
+ * `i32_1`, `i32_2`, and `i64` are used to create the initialization vector
+ * @invariant `src` is valid for `slen`
+ * @invariant `dst` is valid for `*dlen`, `*dlen` is initialized
+ */
 int encryption_scheme_encrypt(const unsigned char* src, unsigned int slen,
                               unsigned char* dst, unsigned int* dlen,
                               struct st_encryption_scheme *scheme,
@@ -234,7 +244,11 @@ int encryption_scheme_encrypt(const unsigned char* src, unsigned int slen,
                   i32_2, i64, ENCRYPTION_FLAG_NOPAD | ENCRYPTION_FLAG_ENCRYPT);
 }
 
-
+/** Decrypt a block.
+ * `i32_1`, `i32_2`, and `i64` are used to create the initialization vector
+ * @invariant `src` is valid for `slen`
+ * @invariant `dst` is valid for `*dlen`, `*dlen` is initialized
+ */
 int encryption_scheme_decrypt(const unsigned char* src, unsigned int slen,
                               unsigned char* dst, unsigned int* dlen,
                               struct st_encryption_scheme *scheme,

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -5662,7 +5662,7 @@ bool MYSQL_BIN_LOG::write_event_buffer(uchar* buf, uint len)
   {
     DBUG_ASSERT(crypto.scheme == 1);
 
-    uint elen;
+    uint elen= len - 4;
     uchar iv[BINLOG_IV_LENGTH];
 
     ebuf= (uchar*)my_safe_alloca(len);

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -838,7 +838,7 @@ int Log_event::read_log_event(IO_CACHE* file, String* packet,
       DBUG_RETURN(LOG_READ_MEM);
     memcpy(newpkt, packet->ptr(), ev_offset);
 
-    uint dstlen;
+    uint dstlen= (uint) sz - ev_offset - 4;
     uchar *src= (uchar*)packet->ptr() + ev_offset;
     uchar *dst= (uchar*)newpkt + ev_offset;
     memcpy(src + EVENT_LEN_OFFSET, src, 4);

--- a/sql/mf_iocache_encr.cc
+++ b/sql/mf_iocache_encr.cc
@@ -85,7 +85,8 @@ static int my_b_encr_read(IO_CACHE *info, uchar *Buffer, size_t Count)
 
   do
   {
-    uint elength, wlength, length;
+    uint elength, wlength;
+    uint length= static_cast<uint>(info->buffer_length);
     uchar iv[MY_AES_BLOCK_SIZE]= {0};
 
     DBUG_ASSERT(pos_in_file % info->buffer_length == 0);
@@ -102,6 +103,7 @@ static int my_b_encr_read(IO_CACHE *info, uchar *Buffer, size_t Count)
     }
 
     elength= wlength - (uint)(ebuffer - wbuffer);
+    length= elength;
     set_iv(iv, pos_in_file, crypt_data->inbuf_counter);
 
     if (encryption_crypt(ebuffer, elength, info->buffer, &length,
@@ -181,8 +183,9 @@ static int my_b_encr_write(IO_CACHE *info, const uchar *Buffer, size_t Count)
 
   do
   {
+    uint wlength;
     size_t length= MY_MIN(info->buffer_length, Count);
-    uint elength, wlength;
+    uint elength= static_cast<uint>(length);
     uchar iv[MY_AES_BLOCK_SIZE]= {0};
 
     crypt_data->inbuf_counter= crypt_data->counter;
@@ -272,4 +275,3 @@ int init_io_cache_encryption()
   _my_b_encr_write= 0;
   return 0;
 }
-

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -445,11 +445,11 @@ static byte* fil_encrypt_buf_for_non_full_checksum(
 	uint		srclen = size - unencrypted_bytes;
 	const byte*	src = src_frame + header_len;
 	byte*		dst = dst_frame + header_len;
-	uint32		dstlen = 0;
 
 	if (page_compressed) {
 		srclen = mach_read_from_2(src_frame + FIL_PAGE_DATA);
 	}
+	uint dstlen = srclen;
 
 	int rc = encryption_scheme_encrypt(src, srclen, dst, &dstlen,
 					   crypt_data, key_version,
@@ -516,7 +516,7 @@ static byte* fil_encrypt_buf_for_full_crc32(
 			      + FIL_PAGE_FCRC32_CHECKSUM);
 	const byte* src = src_frame + FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION;
 	byte* dst = dst_frame + FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION;
-	uint dstlen = 0;
+	uint dstlen = srclen;
 
 	ut_a(key_version != ENCRYPTION_KEY_VERSION_INVALID);
 
@@ -647,7 +647,6 @@ static dberr_t fil_space_decrypt_full_crc32(
 	/* Calculate the offset where decryption starts */
 	const byte* src = src_frame + FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION;
 	byte* dst = tmp_frame + FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION;
-	uint dstlen = 0;
 	bool corrupted = false;
 	uint size = buf_page_full_crc32_size(src_frame, NULL, &corrupted);
 	if (UNIV_UNLIKELY(corrupted)) {
@@ -656,6 +655,7 @@ static dberr_t fil_space_decrypt_full_crc32(
 
 	uint srclen = size - (FIL_PAGE_FILE_FLUSH_LSN_OR_KEY_VERSION
 			      + FIL_PAGE_FCRC32_CHECKSUM);
+	uint dstlen = srclen;
 
 	int rc = encryption_scheme_decrypt(src, srclen, dst, &dstlen,
 					   crypt_data, key_version,
@@ -711,8 +711,8 @@ static dberr_t fil_space_decrypt_for_non_full_checksum(
 	/* Calculate the offset where decryption starts */
 	const byte* src = src_frame + header_len;
 	byte* dst = tmp_frame + header_len;
-	uint32 dstlen = 0;
 	uint srclen = uint(physical_size) - header_len - FIL_PAGE_DATA_END;
+	uint dstlen = srclen;
 
 	if (page_compressed) {
 		srclen = mach_read_from_2(src_frame + FIL_PAGE_DATA);

--- a/storage/innobase/include/log0crypt.h
+++ b/storage/innobase/include/log0crypt.h
@@ -84,8 +84,8 @@ void log_decrypt_buf(const byte *iv, byte *buf, const byte *const end);
 
 /** Encrypt or decrypt a temporary file block.
 @param[in]	src		block to encrypt or decrypt
-@param[in]	size		size of the block
-@param[out]	dst		destination block, also of length `size`
+@param[in]	size		length of both src and dst in bytes
+@param[out]	dst		destination block
 @param[in]	offs		offset to block
 @param[in]	encrypt		true=encrypt; false=decrypt
 @return whether the operation succeeded */
@@ -99,7 +99,7 @@ bool log_tmp_block_encrypt(
 
 /** Decrypt a temporary file block.
 @param[in]	src		block to decrypt
-@param[in]	size		size of the block
+@param[in]	size		length of both src and dst in bytes
 @param[out]	dst		destination block
 @param[in]	offs		offset to block
 @return whether the operation succeeded */

--- a/storage/innobase/include/log0crypt.h
+++ b/storage/innobase/include/log0crypt.h
@@ -85,7 +85,7 @@ void log_decrypt_buf(const byte *iv, byte *buf, const byte *const end);
 /** Encrypt or decrypt a temporary file block.
 @param[in]	src		block to encrypt or decrypt
 @param[in]	size		size of the block
-@param[out]	dst		destination block
+@param[out]	dst		destination block, also of length `size`
 @param[in]	offs		offset to block
 @param[in]	encrypt		true=encrypt; false=decrypt
 @return whether the operation succeeded */

--- a/storage/innobase/log/log0crypt.cc
+++ b/storage/innobase/log/log0crypt.cc
@@ -429,8 +429,8 @@ ATTRIBUTE_COLD bool log_crypt_read_checkpoint_buf(const byte* buf)
 
 /** Encrypt or decrypt a temporary file block.
 @param[in]	src		block to encrypt or decrypt
-@param[in]	size		size of 'src' block
-@param[out]	dst		destination block, also of length 'size'
+@param[in]	size		length of both src and dst blocks in bytes
+@param[out]	dst		destination block
 @param[in]	offs		offset to block
 @param[in]	encrypt		true=encrypt; false=decrypt
 @return whether the operation succeeded */
@@ -441,7 +441,7 @@ bool log_tmp_block_encrypt(
 	uint64_t	offs,
 	bool		encrypt)
 {
-	uint dst_len = (uint) size;
+	uint dst_len = static_cast<uint>(size);
 	uint64_t iv[MY_AES_BLOCK_SIZE / sizeof(uint64_t)];
 	iv[0] = offs;
 	memcpy(iv + 1, tmp_iv, sizeof iv - sizeof *iv);

--- a/storage/innobase/log/log0crypt.cc
+++ b/storage/innobase/log/log0crypt.cc
@@ -221,9 +221,9 @@ ATTRIBUTE_COLD bool log_decrypt(byte* buf, lsn_t lsn, ulint size)
 		ut_ad(LOG_CRYPT_HDR_SIZE + dst_size
 		      == 512 - LOG_BLOCK_CHECKSUM - LOG_BLOCK_KEY);
 
-		uint dst_len;
+		uint dst_len = static_cast<uint>(dst_size);
 		int rc = encryption_crypt(
-			buf + LOG_CRYPT_HDR_SIZE, static_cast<uint>(dst_size),
+			buf + LOG_CRYPT_HDR_SIZE, dst_len,
 			reinterpret_cast<byte*>(dst), &dst_len,
 			const_cast<byte*>(info.crypt_key),
 			MY_AES_BLOCK_SIZE,
@@ -332,10 +332,10 @@ ATTRIBUTE_COLD bool log_crypt_101_read_block(byte* buf, lsn_t start_lsn)
 	}
 found:
 	byte dst[512];
-	uint dst_len;
 	byte aes_ctr_iv[MY_AES_BLOCK_SIZE];
 
 	const uint src_len = 512 - LOG_BLOCK_HDR_SIZE;
+	uint dst_len = src_len;
 
 	ulint log_block_no = log_block_get_hdr_no(buf);
 
@@ -429,8 +429,8 @@ ATTRIBUTE_COLD bool log_crypt_read_checkpoint_buf(const byte* buf)
 
 /** Encrypt or decrypt a temporary file block.
 @param[in]	src		block to encrypt or decrypt
-@param[in]	size		size of the block
-@param[out]	dst		destination block
+@param[in]	size		size of 'src' block
+@param[out]	dst		destination block, also of length 'size'
 @param[in]	offs		offset to block
 @param[in]	encrypt		true=encrypt; false=decrypt
 @return whether the operation succeeded */
@@ -441,7 +441,7 @@ bool log_tmp_block_encrypt(
 	uint64_t	offs,
 	bool		encrypt)
 {
-	uint dst_len;
+	uint dst_len = (uint) size;
 	uint64_t iv[MY_AES_BLOCK_SIZE / sizeof(uint64_t)];
 	iv[0] = offs;
 	memcpy(iv + 1, tmp_iv, sizeof iv - sizeof *iv);

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -239,6 +239,7 @@ struct fil_iterator_t {
 	byte*		io_buffer;		/*!< Buffer to use for IO */
 	fil_space_crypt_t *crypt_data;		/*!< Crypt data (if encrypted) */
 	byte*           crypt_io_buffer;        /*!< IO buffer when encrypted */
+	byte*           crypt_tmp_buffer;       /*!< Temporary buffer for crypt use */
 };
 
 /** Use the page cursor to iterate over records in a block. */
@@ -2985,17 +2986,25 @@ row_import_read_meta_data(
 /* decrypt and decompress page if needed */
 static dberr_t decrypt_decompress(fil_space_crypt_t *space_crypt,
                                   uint32_t space_flags, span<byte> page,
-                                  uint32_t space_id, byte *page_compress_buf)
+                                  uint32_t space_id, byte *page_compress_buf,
+                                  byte *tmp_frame)
 {
   auto *data= page.data();
 
   if (space_crypt && space_crypt->should_encrypt())
   {
+    uint page_size= static_cast<uint>(page.size());
+
     if (!buf_page_verify_crypt_checksum(data, space_flags))
       return DB_CORRUPTION;
 
-    if (dberr_t err= fil_space_decrypt(space_id, space_flags, space_crypt,
-                                       data, page.size(), data))
+    dberr_t err=
+      fil_space_decrypt(space_id, space_flags, space_crypt,
+                        tmp_frame, page_size, data);
+
+    memcpy(data, tmp_frame, page_size);
+
+    if (err)
       return err;
   }
 
@@ -3115,11 +3124,16 @@ static dberr_t handle_instant_metadata(dict_table_t *table,
     return err;
 
   std::unique_ptr<byte[]> page_compress_buf(new byte[get_buf_size()]);
+  std::unique_ptr<byte[], decltype(&aligned_free)> crypt_tmp_frame(
+      static_cast<byte *>(
+          aligned_malloc(physical_size, CPU_LEVEL1_DCACHE_LINESIZE)),
+      &aligned_free);
 
   if (dberr_t err= decrypt_decompress(space_crypt, space_flags,
                                       {page.get(), static_cast<size_t>
                                        (physical_size)},
-                                      space_id, page_compress_buf.get()))
+                                      space_id, page_compress_buf.get(),
+                                      crypt_tmp_frame.get()))
     return err;
 
   if (table->supports_instant())
@@ -3173,7 +3187,8 @@ static dberr_t handle_instant_metadata(dict_table_t *table,
       if (dberr_t err= decrypt_decompress(space_crypt, space_flags,
                                           {page.get(), static_cast<size_t>
                                            (physical_size)}, space_id,
-                                          page_compress_buf.get()))
+                                          page_compress_buf.get(),
+                                          crypt_tmp_frame.get()))
         return err;
     }
 
@@ -3255,7 +3270,8 @@ static dberr_t handle_instant_metadata(dict_table_t *table,
       if (dberr_t err= decrypt_decompress(space_crypt, space_flags,
                                           {second_page.get(),
                                            static_cast<size_t>(physical_size)},
-                                          space_id, page_compress_buf.get()))
+                                          space_id, page_compress_buf.get(),
+                                          crypt_tmp_frame.get()))
         return err;
 
       if (fil_page_get_type(second_page.get()) != FIL_PAGE_TYPE_BLOB ||
@@ -3697,8 +3713,14 @@ page_corrupted:
     if (!buf_page_verify_crypt_checksum(readptr, m_space_flags))
       goto page_corrupted;
 
-    if ((err= fil_space_decrypt(get_space_id(), m_space_flags, iter.crypt_data,
-                                readptr, size, readptr)))
+    dberr_t err= fil_space_decrypt(get_space_id(), m_space_flags,
+                                   iter.crypt_data, iter.crypt_tmp_buffer,
+                                   size, readptr);
+
+    memcpy_aligned<CPU_LEVEL1_DCACHE_LINESIZE>(readptr, iter.crypt_tmp_buffer,
+                                               size);
+
+    if (err)
       goto func_exit;
   }
 
@@ -4155,17 +4177,21 @@ fil_tablespace_iterate(
 		iter.file_size = file_size;
 		iter.n_io_buffers = n_io_buffers;
 
+		size_t buf_size = (1 + iter.n_io_buffers) * srv_page_size;
+
 		/* Add an extra page for compressed page scratch area. */
 		iter.io_buffer = static_cast<byte*>(
-			aligned_malloc((1 + iter.n_io_buffers)
-				       << srv_page_size_shift, srv_page_size));
+			aligned_malloc(buf_size, srv_page_size));
 
-		iter.crypt_io_buffer = iter.crypt_data
-			? static_cast<byte*>(
-				aligned_malloc((1 + iter.n_io_buffers)
-					       << srv_page_size_shift,
-					       srv_page_size))
-			: NULL;
+		if (iter.crypt_data) {
+			iter.crypt_io_buffer = static_cast<byte *>(
+				aligned_malloc(buf_size, srv_page_size));
+			iter.crypt_tmp_buffer = static_cast<byte *>(
+				aligned_malloc(buf_size, CPU_LEVEL1_DCACHE_LINESIZE));
+		} else {
+			iter.crypt_io_buffer = NULL;
+			iter.crypt_tmp_buffer = NULL;
+		}
 
 		if (block->page.zip.ssize) {
 			ut_ad(iter.n_io_buffers == 1);
@@ -4180,6 +4206,7 @@ fil_tablespace_iterate(
 			fil_space_destroy_crypt_data(&iter.crypt_data);
 		}
 
+		aligned_free(iter.crypt_tmp_buffer);
 		aligned_free(iter.crypt_io_buffer);
 		aligned_free(iter.io_buffer);
 	}

--- a/storage/maria/ma_crypt.c
+++ b/storage/maria/ma_crypt.c
@@ -459,7 +459,7 @@ static int ma_encrypt(MARIA_SHARE *share, MARIA_CRYPT_DATA *crypt_data,
                       uint *key_version)
 {
   int rc;
-  uint32 dstlen= 0;              /* Must be set because of error message */
+  uint32 dstlen= size;
 
   *key_version = encryption_key_get_latest_version(crypt_data->scheme.key_id);
   if (*key_version == ENCRYPTION_KEY_VERSION_INVALID)
@@ -486,6 +486,9 @@ static int ma_encrypt(MARIA_SHARE *share, MARIA_CRYPT_DATA *crypt_data,
   DBUG_ASSERT(!my_assert_on_error || dstlen == size);
   if (! (rc == MY_AES_OK && dstlen == size))
   {
+    if (rc != MY_AES_OK)
+      dstlen= 0; /* reset dstlen if failed, to match expected message */
+
     my_errno= HA_ERR_DECRYPTION_FAILED;
     my_printf_error(HA_ERR_DECRYPTION_FAILED,
                     "failed to encrypt '%s'  rc: %d  dstlen: %u  size: %u\n",
@@ -503,7 +506,7 @@ static int ma_decrypt(MARIA_SHARE *share, MARIA_CRYPT_DATA *crypt_data,
                       uint key_version)
 {
   int rc;
-  uint32 dstlen= 0;              /* Must be set because of error message */
+  uint32 dstlen= size;
 
   rc= encryption_scheme_decrypt(src, size, dst, &dstlen,
                                 &crypt_data->scheme, key_version,
@@ -513,6 +516,8 @@ static int ma_decrypt(MARIA_SHARE *share, MARIA_CRYPT_DATA *crypt_data,
   DBUG_ASSERT(!my_assert_on_error || dstlen == size);
   if (! (rc == MY_AES_OK && dstlen == size))
   {
+    if (rc != MY_AES_OK)
+      dstlen= 0; /* reset dstlen if failed, to match expected message */
     my_errno= HA_ERR_DECRYPTION_FAILED;
     if (!share->silence_encryption_errors)
       my_printf_error(HA_ERR_DECRYPTION_FAILED,


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-30389](https://jira.mariadb.org/browse/MDEV-30389)*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

As described in [MDEV-30389](https://jira.mariadb.org/browse/MDEV-30389), the value of `*dlen` passed to encryption plugins is uninitialized. It is an output variable so this is generally not a programmatic issue. However, there is currently no way to check the destination buffer length from the standpoint of an encryption plugin, so initializing `*dlen` to this value makes sense to allow for debug assertions and checked writes.

This PR seeks to update the passed value of `*dlen` to accurately reflect the available buffer size.

## How can this PR be tested?

This PR adds an `assert` statement to `include/mysql/service_encryption.h` that the destination buffer length is greater than or equal to the source buffer length. This will fail any calls in the existing test suite that do not pass a reasonable buffer length. (not 100% since the initial value is currently random and _may_ contain a value that passes, but so far it has proven "good enough" in practice)

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

(could be either)

## Backward compatibility

`*dlen` is written by any encryption plugin, so it is exposed outside of MariaDB source. However, no plugin can be relying on the initial value of `*dlen` that this PR seeks to change, since it is currently uninitialized.