### PR TITLE
MDEV-22570 Implement wsrep_provider_options as plugin (fix)

### DIFF
--- a/sql/wsrep_plugin.cc
+++ b/sql/wsrep_plugin.cc
@@ -36,11 +36,6 @@
 
 static bool provider_plugin_enabled= false;
 
-/* Prototype for provider system variables */
-static char *dummy_str= 0;
-static MYSQL_SYSVAR_STR(proto_string, dummy_str, 0, 0, 0, 0, "");
-
-
 bool wsrep_provider_plugin_enabled()
 {
   return provider_plugin_enabled;


### PR DESCRIPTION
MYSQL_SYSVAR_STR(proto_string) was never used. So it can be omitted.

Causes compile warnings on clang.

Evidenced by https://buildbot.mariadb.org/#/builders/168/builds/17907/steps/8/logs/stdio