### PR TITLE
MDEV-29774 BF abort no longer wakes up debug_sync waiters

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -11,7 +11,6 @@
 ##############################################################################
 
 galera_as_slave_ctas : MDEV-28378 timeout
-galera_bf_abort_at_after_statement : Timeout in wait_condition.inc for SELECT COUNT(*) = 1 FROM t1 where id = 1 and val = 3
 galera_pc_recovery : MDEV-25199 cluster fails to start up
 galera_sst_encrypted : MDEV-29876 Galera test failure on galera_sst_encrypted
 MW-284 : MDEV-29861 Galera test case hangs

--- a/mysql-test/suite/galera_3nodes/disabled.def
+++ b/mysql-test/suite/galera_3nodes/disabled.def
@@ -13,8 +13,6 @@
 
 galera_2_cluster : MDEV-29877 Galera test failure on galera_2_cluster
 galera_gtid_2_cluster : MDEV-29877 Galera test failure on galera_2_cluster
-galera_parallel_apply_3nodes : MDEV-29368 DEBUG_SYNC timeout
-galera_parallel_apply_3nodes : MDEV-29774 Galera test galera_parallel_apply_3nodes is unstable
 galera_vote_rejoin_mysqldump : MDEV-24481: galera_3nodes.galera_vote_rejoin_mysqldump MTR failed: mysql_shutdown failed
 galera_2_cluster : MDEV-29877 Galera test failure on galera_2_cluster
 galera_gtid_2_cluster : MDEV-29877 Galera test failure on galera_2_cluster

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -257,7 +257,7 @@ extern "C" my_bool wsrep_thd_bf_abort(THD *bf_thd, THD *victim_thd,
     }
 
     victim_thd->wsrep_aborter= bf_thd->thread_id;
-    victim_thd->awake_no_mutex(KILL_QUERY);
+    victim_thd->awake_no_mutex(KILL_QUERY_HARD);
   }
   else
     WSREP_DEBUG("wsrep_thd_bf_abort skipped awake for %llu", thd_get_thread_id(victim_thd));

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -1497,7 +1497,7 @@ sp_head::execute(THD *thd, bool merge_da_on_success)
                                wsrep_current_error_status(thd));
           thd->wsrep_cs().reset_error();
           /* Reset also thd->killed if it has been set during BF abort. */
-          if (thd->killed == KILL_QUERY)
+          if (killed_mask_hard(thd->killed) == KILL_QUERY)
             thd->killed= NOT_KILLED;
           /* if failed transaction was not replayed, must return with error from here */
           if (!must_replay) err_status = 1;


### PR DESCRIPTION
Since commit d7d3ad698abde16978e094b825e17a6ecd8604e, "hard" kill is required to interrupt debug sync waits.
Affected the following tests:
 - galera_var_retry_autocommit,
 - galera_bf_abort_at_after_statement
 - galera_parallel_apply_3nodes
