### PR TITLE
Fix S3 engine Coverity hits

### DIFF
--- a/storage/maria/ha_s3.cc
+++ b/storage/maria/ha_s3.cc
@@ -233,7 +233,7 @@ ha_create_table_option s3_table_option_list[]=
 
 
 ha_s3::ha_s3(handlerton *hton, TABLE_SHARE *table_arg)
-  :ha_maria(hton, table_arg), in_alter_table(S3_NO_ALTER)
+  :ha_maria(hton, table_arg), in_alter_table(S3_NO_ALTER), open_args(NULL)
 {
   /* Remove things that S3 doesn't support */
   int_table_flags&= ~(HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE |

--- a/storage/maria/s3_func.c
+++ b/storage/maria/s3_func.c
@@ -351,7 +351,7 @@ int aria_copy_to_s3(ms3_st *s3_client, const char *aws_bucket,
       if (display)
         printf("Copying frm file %s\n", filename);
 
-      end= strmov(aws_path_end,"/frm");
+      strmov(aws_path_end,"/frm");
       convert_frm_to_s3_format(alloc_block);
 
       /* Note that frm is not compressed! */
@@ -1232,7 +1232,7 @@ static void convert_index_to_s3_format(uchar *header, ulong block_size,
   uchar *base_pos;
   uint  base_offset;
 
-  memcpy(state.header.file_version, header, sizeof(state.header));
+  memcpy(&state.header, header, sizeof(state.header));
   base_offset= mi_uint2korr(state.header.base_pos);
   base_pos= header + base_offset;
 
@@ -1251,7 +1251,7 @@ static void convert_index_to_disk_format(uchar *header)
   uchar *base_pos;
   uint  base_offset;
 
-  memcpy(state.header.file_version, header, sizeof(state.header));
+  memcpy(&state.header, header, sizeof(state.header));
   base_offset= mi_uint2korr(state.header.base_pos);
   base_pos= header + base_offset;
 


### PR DESCRIPTION
Very minor hits found by Coverity for the S3 engine.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*