### PR TITLE
MDEV-30419 Fix unhandled exception thrown from wsrep-lib

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -336,9 +336,14 @@ static bool wsrep_sst_complete (THD*                thd,
   if ((state == Wsrep_server_state::s_joiner ||
        state == Wsrep_server_state::s_initialized))
   {
-    Wsrep_server_state::instance().sst_received(client_service,
-       rcode);
-    WSREP_INFO("SST succeeded for position %s", start_pos_buf);
+    if (Wsrep_server_state::instance().sst_received(client_service, rcode))
+    {
+      failed= true;
+    }
+    else
+    {
+      WSREP_INFO("SST succeeded for position %s", start_pos_buf);
+    }
   }
   else
   {


### PR DESCRIPTION
Updated wsrep-lib to version in which server_state wait_until_state() and sst_received() were changed to report errors via return codes instead of throwing exceptions. Added error handling accordingly.

Tested manually that failure in sst_received() which was caused by server misconfiguration (unknown configuration variable in server configuration) does not cause crash due to uncaught exception.
