### PR TITLE
missing my_afree after my_alloca

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -3598,7 +3598,10 @@ print_table_data(MYSQL_RES *result)
   {
     print_field_types(result);
     if (!mysql_num_rows(result))
+    {
+      my_afree((uchar*) num_flag);
       return;
+    }
     mysql_field_seek(result,0);
   }
   separator.copy("+",1,charset_info);


### PR DESCRIPTION
- [ ] *The Jira issue number for this PR is: MDEV-_____*

## Description

I noticed an early return after a call to `my_alloca` which did not have call to `my_afree`

## How can this PR be tested?

I suppose one could build on a system without alloca, force the early return case, and observe the leak with `valgrind`.
I have not done this.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility

This should not impact compatibility