### PR TITLE
Update the PR template to reflect 10.3 is the earliest maintained

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,10 +40,11 @@ carefully describe how to test manually.
 <!--
 Tick one of the following boxes [x] to help us understand
 if the base branch for the PR is correct
+(Currently the earliest maintained branch is 10.3)
 -->
 ## Basing the PR against the correct MariaDB version
 - [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
-- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*
+- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*
 
 <!--
 You might consider answering some questions like:


### PR DESCRIPTION
We do not want people to try to rebase their patch on anything prior to the earliest *maintained* version.

- [ ] *The Jira issue number for this PR is: MDEV-_____*

## Description

If one finds a bug which has existed since before the earliest maintianed version, the template should make it clear what the earliest version to check is.

## How can this PR be tested?

N/A

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility

N/A