### PR TITLE
Add parameter of key file path for AWS KMS plugin

### DIFF
--- a/plugin/aws_key_management/aws_key_management_plugin.cc
+++ b/plugin/aws_key_management/aws_key_management_plugin.cc
@@ -82,6 +82,7 @@ static unsigned long log_level;
 static int rotate_key;
 static int request_timeout;
 static char* endpoint_url;
+static char* keyfile_dir;
 
 #ifndef DBUG_OFF
 #define WITH_AWS_MOCK 1
@@ -187,13 +188,23 @@ protected:
   }
 };
 
-/*  Get list of files in current directory */
-static vector<string> traverse_current_directory()
+/* Get keyfile directory */
+static const char * get_keyfile_dir()
+{
+  if (keyfile_dir && keyfile_dir[0])
+    return keyfile_dir;
+  return ".";
+}
+
+/*  Get list of files in keyfile directory */
+static vector<string> traverse_keyfile_directory()
 {
   vector<string> v;
 #ifdef _WIN32
   WIN32_FIND_DATA find_data;
-  HANDLE h= FindFirstFile("*.*", &find_data);
+  char path[FN_REFLEN];
+  snprintf(path, sizeof(path), "%s\\*.*", get_keyfile_dir());
+  HANDLE h= FindFirstFile(path, &find_data);
   if (h == INVALID_HANDLE_VALUE)
     return v;
   do
@@ -203,7 +214,7 @@ static vector<string> traverse_current_directory()
   while (FindNextFile(h, &find_data));
   FindClose(h);
 #else
-  DIR *dir = opendir(".");
+  DIR *dir = opendir(get_keyfile_dir());
   if (!dir)
     return v;
   struct dirent *e;
@@ -272,7 +283,7 @@ static int plugin_init(void *p)
   if (init())
     return -1;
 
-  vector<string> files= traverse_current_directory();
+  vector<string> files= traverse_keyfile_directory();
   for (size_t i=0; i < files.size(); i++)
   {
 
@@ -316,7 +327,7 @@ static int plugin_deinit(void *p)
 /*  Generate filename to store the ciphered key */
 static void format_keyfile_name(char *buf, size_t size, uint key_id, uint version)
 {
-  snprintf(buf, size, "aws-kms-key.%u.%u", key_id, version);
+  snprintf(buf, size, "%s%saws-kms-key.%u.%u", get_keyfile_dir(), IF_WIN("\\","/"), key_id, version);
 }
 
 /* Extract key id and version from file name */
@@ -336,7 +347,7 @@ static int extract_id_and_version(const char *name, uint *id, uint *ver)
 static int load_key(KEY_INFO *info)
 {
   int ret;
-  char path[256];
+  char path[FN_REFLEN];
 
   format_keyfile_name(path, sizeof(path), info->key_id, info->key_version);
   ret= read_and_decrypt_key(path, info);
@@ -531,7 +542,7 @@ static int generate_and_save_datakey(uint keyid, uint version)
      return -1;
 
   string out;
-  char filename[20];
+  char filename[FN_REFLEN];
   format_keyfile_name(filename, sizeof(filename), keyid, version);
   int fd= open(filename, O_WRONLY |O_CREAT|O_BINARY, IF_WIN(_S_IREAD, S_IRUSR| S_IRGRP| S_IROTH));
   if (fd < 0)
@@ -652,7 +663,6 @@ static unsigned int get_key(
   return(0);
 }
 
-
 /* Plugin defs */
 struct st_mariadb_encryption aws_key_management_plugin= {
   MariaDB_ENCRYPTION_INTERFACE_VERSION,
@@ -725,6 +735,12 @@ static MYSQL_SYSVAR_STR(endpoint_url, endpoint_url,
   "Used to override the default AWS API endpoint. If not set, the default will be used",
   NULL, NULL, "");
 
+static MYSQL_SYSVAR_STR(keyfile_dir, keyfile_dir,
+  PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+  "Define the directory in which to save key files for the AWS key"
+  "management plugin. If not set, the root datadir will be used",
+  NULL, NULL, "");
+
 #if WITH_AWS_MOCK
 static MYSQL_SYSVAR_BOOL(mock, mock,
   PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
@@ -740,6 +756,7 @@ static struct st_mysql_sys_var* settings[]= {
   MYSQL_SYSVAR(request_timeout),
   MYSQL_SYSVAR(region),
   MYSQL_SYSVAR(endpoint_url),
+  MYSQL_SYSVAR(keyfile_dir),
 #if WITH_AWS_MOCK
   MYSQL_SYSVAR(mock),
 #endif


### PR DESCRIPTION
## Description

AWS KMS plugin saves all key files under the root folder of data
directory. Increasing of the key IDs and key rotations will generate a
lot of key files under the root folder, looks messy and hard to
maintain the folder permission etc.

Now introduce a new plugin parameter `aws_key_management_keyfile_dir` to
define the directory for saving the key files for better maintenance.

Detailed parameter information as following:
```
        VARIABLE_NAME: AWS_KEY_MANAGEMENT_KEYFILE_DIR
        SESSION_VALUE: NULL
         GLOBAL_VALUE: <Directory path>
  GLOBAL_VALUE_ORIGIN: COMMAND-LINE
        DEFAULT_VALUE:
       VARIABLE_SCOPE: GLOBAL
        VARIABLE_TYPE: VARCHAR
     VARIABLE_COMMENT: Define the directory in which to save key files for the AWS key management plugin.
                       If not set, the root datadir will be used
            READ_ONLY: YES
COMMAND_LINE_ARGUMENT: REQUIRED
    GLOBAL_VALUE_PATH: NULL
```

## How can this PR be tested?

There's no MTR for AWS KMS plugin. One needs to build the plugin manually and test it.

The change had been verified manually that:
1. AWS KMS plugin loads the key files in the given directory;
2. new keys and rotated keys are saved successfully in the given
   directory;
3. copying the keys to a new folder and starting MariaDB server with the
   new folder, plugin still loads the existing keys successfully.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility

The changes fully backward compatible.

## Copyright

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.