### PR TITLE
MDEV-30411: main.explain_json_format_partitions fails on Debian armel…

### DIFF
--- a/mysys/my_rdtsc.c
+++ b/mysys/my_rdtsc.c
@@ -368,29 +368,7 @@ void my_timer_init(MY_TIMER_INFO *mti)
 
   /* cycles */
   mti->cycles.frequency= 1000000000;
-#if defined _WIN32 || defined __i386__ || defined __x86_64__
-  mti->cycles.routine= MY_TIMER_ROUTINE_RDTSC;
-#elif defined(__INTEL_COMPILER) && defined(__ia64__) && defined(HAVE_IA64INTRIN_H)
-  mti->cycles.routine= MY_TIMER_ROUTINE_ASM_IA64;
-#elif defined(__GNUC__) && defined(__ia64__)
-  mti->cycles.routine= MY_TIMER_ROUTINE_ASM_IA64;
-#elif defined __GNUC__ && defined __powerpc__
-  mti->cycles.routine= MY_TIMER_ROUTINE_PPC_GET_TIMEBASE;
-#elif defined(__GNUC__) && defined(__sparcv9) && defined(_LP64) && (__GNUC__>2)
-  mti->cycles.routine= MY_TIMER_ROUTINE_ASM_GCC_SPARC64;
-#elif defined(__GNUC__) && defined(__sparc__) && !defined(_LP64) && (__GNUC__>2)
-  mti->cycles.routine= MY_TIMER_ROUTINE_ASM_GCC_SPARC32;
-#elif defined(__GNUC__) && defined(__s390__)
-  mti->cycles.routine= MY_TIMER_ROUTINE_ASM_S390;
-#elif defined(__GNUC__) && defined (__aarch64__)
-  mti->cycles.routine= MY_TIMER_ROUTINE_AARCH64;
-#elif defined(__GNUC__) && defined (__riscv)
-  mti->cycles.routine= MY_TIMER_ROUTINE_RISCV;
-#elif defined(HAVE_SYS_TIMES_H) && defined(HAVE_GETHRTIME)
-  mti->cycles.routine= MY_TIMER_ROUTINE_GETHRTIME;
-#else
-  mti->cycles.routine= 0;
-#endif
+  mti->cycles.routine= MY_TIMER_ROUTINE_CYCLES;
 
   if (!mti->cycles.routine || !my_timer_cycles())
   {


### PR DESCRIPTION
… and armhf builders


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30411*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

The my_timer_cycles is an impressive collection of cycle based timers that isn't comprehensive on all architectures.

MDEV-28926 is such that if there isn't an implementation then the output doesn't include the r_total_time_ms values and therefore test results change.

As an alternative to my_timer_cycles, my_timer_interval returns a clock_gettime based implementation. These on Linux for kernel versions above about 4.0 are VDSO based implementations on arm, arm64, mips, powerpc, ppc64le,riscv, x86, x86_64 and a few others. As these results are returning in nanoseconds, the measure of the time interval is clearer than a static CPU frequency measure at MariaDB startup.

## How can this PR be tested?

Disabled mysql-test/include/analyze-format.inc redaction. Look at similar measurements in test results:
```
CURRENT_TEST: main.analyze_format_json
--- /home/dan/repos/mariadb-server-10.11/mysql-test/main/analyze_format_json.result	2023-01-03 12:36:04.207128489 +1100
+++ /home/dan/repos/mariadb-server-10.11/mysql-test/main/analyze_format_json.reject	2023-01-23 17:43:17.478904449 +1100
@@ -6,12 +6,12 @@
 ANALYZE
 {
   "query_optimization": {
-    "r_total_time_ms": "REPLACED"
+    "r_total_time_ms": 35.199
   },
   "query_block": {
     "select_id": 1,
     "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
+    "r_total_time_ms": 11.037,
     "nested_loop": [
       {
         "table": {
@@ -20,8 +20,8 @@
           "r_loops": 1,
           "rows": 10,
           "r_rows": 10,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
+          "r_table_time_ms": 2.74,
+          "r_other_time_ms": 0.001792758,
           "filtered": 100,
           "r_filtered": 30,
           "attached_condition": "t0.a < 3"
@@ -42,12 +42,12 @@
 ANALYZE
 {
   "query_optimization": {
-    "r_total_time_ms": "REPLACED"
+    "r_total_time_ms": 22.759
   },
   "query_block": {
     "select_id": 1,
     "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
+    "r_total_time_ms": 4.969,
     "nested_loop": [
       {
         "table": {
@@ -56,8 +56,8 @@
           "r_loops": 1,
           "rows": 10,
           "r_rows": 10,
-          "r_table_time_ms": "REPLACED",
-          "r_other_time_ms": "REPLACED",
+          "r_table_time_ms": 1.805,
+          "r_other_time_ms": 7.437997e-4,
           "filtered": 100,
           "r_filtered": 0,
           "attached_condition": "t0.a > 9 and t0.a is not null"
@@ -92,12 +92,12 @@
```

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

Small measurement differenced may results.