### PR TITLE
MDEV-26645: Fix UB in Item_func_plus and Item_func_minus (backport)

### DIFF
--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -1261,6 +1261,9 @@ longlong Item_func_plus::int_op()
         goto err;
     }
   }
+  if (res_unsigned)
+    res= (longlong) ((ulonglong) val0 + (ulonglong) val1);
+
   return check_integer_overflow(res, res_unsigned);
 
 err:
@@ -1420,6 +1423,9 @@ longlong Item_func_minus::int_op()
         goto err;
     }
   }
+  if (res_unsigned)
+    res= (longlong) ((ulonglong) val0 - (ulonglong) val1);
+
   return check_integer_overflow(res, res_unsigned);
 
 err:


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-26645*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Backport of b69191bbb2278fce92b470e8e3abafe048166e39 into 10.3.

Unsigned +/- operations need to be cast to get the correct result.

This shows up in gcc/++ 9.4.0 in Fedora 36.

ref: https://buildbot.mariadb.org/#/builders/386/builds/2923

## How can this PR be tested?

main.func_maths


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X  ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

