### PR TITLE
Automatically check if an upgrade is required in mysqld server

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -71,7 +71,7 @@ static char **defaults_argv;
 
 static my_bool not_used; /* Can't use GET_BOOL without a value pointer */
 
-char upgrade_from_version[1024];
+char upgrade_from_version[64];
 
 static my_bool opt_write_binlog;
 

--- a/mysql-test/main/upgrade-check.result
+++ b/mysql-test/main/upgrade-check.result
@@ -1,0 +1,3 @@
+CALL mtr.add_suppression(".*[/\]mariadb_upgrade_info is empty. Please run mariadb-upgrade.");
+CALL mtr.add_suppression("The content of .*[/\]mariadb_upgrade_info cannot be parsed. Please run mariadb-upgrade.");
+CALL mtr.add_suppression(".*Server version .* is currently running, but the data directory contains mariadb_upgrade_info from older version .*\..*");

--- a/mysql-test/main/upgrade-check.test
+++ b/mysql-test/main/upgrade-check.test
@@ -1,0 +1,74 @@
+#
+# Test upgrade warning appears when mariadb-upgrade tool has not being executed
+#
+
+--source include/not_embedded.inc
+
+# This test uses POSIX-specific shell tools to verify log files' contents, AND
+# the log file check is not implemented for Windows.
+--source include/not_windows.inc
+
+--let $MYSQL_LOG_ERR  = `SELECT @@log_error`
+--let $MYSQL_DATA_DIR = `SELECT @@datadir`
+--let $SERVER_VERSION = `SELECT version()`
+
+#
+# Testing the correct info message is printed in the log when mariadb_upgrade_info
+# file does not exists.
+#
+# NOTE: mariadb_upgrade_info file is not created unless mariadb-upgrade is executed,
+# so when the tests starts it won't exists.
+#
+--replace_regex /[\/\\].*[\/\\]mariadb_upgrade_info/PATH\/mariadb_upgrade_info/
+--exec egrep -q "Cannot open .*[/\\]mariadb_upgrade_info. Please run mariadb-upgrade." "$MYSQL_LOG_ERR"
+
+#
+# Testing the correct warning is printed in the log when mariadb_upgrade_info
+# file is empty.
+#
+CALL mtr.add_suppression(".*[/\]mariadb_upgrade_info is empty. Please run mariadb-upgrade.");
+--write_file $MYSQL_DATA_DIR/mariadb_upgrade_info
+EOF
+--sleep 10
+--replace_regex /[\/\\].*[\/\\]mariadb_upgrade_info/PATH\/mariadb_upgrade_info/
+--exec egrep -q ".*[/\]mariadb_upgrade_info is empty. Please run mariadb-upgrade." "$MYSQL_LOG_ERR"
+--remove_file $MYSQL_DATA_DIR/mariadb_upgrade_info
+
+#
+# Testing the correct warning is printed in the log when mariadb_upgrade_info
+# content cannot be parsed.
+#
+CALL mtr.add_suppression("The content of .*[/\]mariadb_upgrade_info cannot be parsed. Please run mariadb-upgrade.");
+--write_file $MYSQL_DATA_DIR/mariadb_upgrade_info
+wrong_format
+EOF
+--sleep 10
+--replace_regex /[\/\\].*[\/\\]mariadb_upgrade_info/PATH\/mariadb_upgrade_info/
+--exec egrep -q "The content of .*[/\]mariadb_upgrade_info cannot be parsed. Please run mariadb-upgrade." "$MYSQL_LOG_ERR"
+--remove_file $MYSQL_DATA_DIR/mariadb_upgrade_info
+
+#
+# Testing the correct warning is printed in the log when a majore version
+# upgrade is detected.
+#
+CALL mtr.add_suppression(".*Server version .* is currently running, but the data directory contains mariadb_upgrade_info from older version .*\..*");
+--write_file $MYSQL_DATA_DIR/mariadb_upgrade_info
+1.0.0-MariaDB
+EOF
+--sleep 10
+--replace_regex /[0-9]*\.[0-9]*.[0-9]*-MariaDB/VERSION-MariaDB/
+--exec egrep -q "Server version .* is currently running, but the data directory contains mariadb_upgrade_info from older version .*\." "$MYSQL_LOG_ERR"
+--remove_file $MYSQL_DATA_DIR/mariadb_upgrade_info
+
+#
+# Testing that no warnings are printed when mariadb_upgrade_info contains the current version
+#
+--exec echo "$SERVER_VERSION" > "$MYSQL_DATA_DIR/mariadb_upgrade_info"
+--exec egrep -c "\[Warning\]" "$MYSQL_LOG_ERR" > "$MYSQL_TMP_DIR/warnnings_count_before"
+--sleep 10
+--exec egrep -c "\[Warning\]" "$MYSQL_LOG_ERR" > "$MYSQL_TMP_DIR/warnnings_count_after"
+--diff_files $MYSQL_TMP_DIR/warnnings_count_before $MYSQL_TMP_DIR/warnnings_count_after
+
+--remove_file $MYSQL_TMP_DIR/warnnings_count_before
+--remove_file $MYSQL_TMP_DIR/warnnings_count_after
+--remove_file $MYSQL_DATA_DIR/mariadb_upgrade_info


### PR DESCRIPTION
## Description
It would be helpful if MariaDB server is aware if the `mysql_upgrade` tool has been executed after a major upgrade, and provide some kind of warning in the log file if the step was missed or didn't finish successfully during the upgrade process. This PR implements the logic for checking the status of `mysql_upgrade_info` in a similar way than `mysql_upgrade --check-if-upgrade-is-needed` does. The new logic will check the content of `mysql_upgrade_info` and print a warning in the following cases:
   - When the `mysql_upgrade_info` file is empty.
      ```
      2023-01-23 21:34:55 0 [Warning] mysql_upgrade_info file: /home/gondchri/MariaDBupstream/builddir/tmp/mysql_upgrade_info is empty. Please run mariadb-upgrade.
      ```
   - When the `mysql_upgrade_info` content format is unrecognized.
      ```
      2023-01-23 21:33:55 0 [Warning] The content of mysql_upgrade_info file: /home/gondchri/MariaDBupstream/builddir/tmp/mysql_upgrade_info cannot be parsed. Please run mariadb-upgrade.
      ```
   - When an incomplete major version upgrade is detected.
      ```
      2023-01-23 22:11:08 0 [Warning] It appears that your database has begun an upgrade but has not completed it. Server version 10.11.2-MariaDB is currently running, but the data directory contains mysql_upgrade_info from older version 10.10.2-MariaDB. Please run mariadb-upgrade to ensure your database format is up to date.
      ```

Also, an information message will be logged when the `mysql_upgrade_info` file doesn't exists. An information message is printed instead of a warning for this case to avoid printing warnings for fresh installations.

```
2023-01-23 21:33:25 0 [Warning] Can't open mysql_upgrade_info file: /home/gondchri/MariaDBupstream/builddir/tmp/mysql_upgrade_info. Please run mariadb-upgrade.
```

The check will be executed once when the server starts, and every time `CHECK_UPGRADE_TIMEOUT_MS` ms have passed without receiving a new connection to the server. This way we can use the `mysqld` main thread to execute the periodic check without affecting the server when new connections are being accepted.

**NOTE**: As I'm not able to test the changes for Windows based OS, this changes have been added to only take effect when the server is built for Linux based OSs. Yet, the `check_upgrade` function uses the `my_*` functions for interacting with the filesystem, so I expect it to be easy to add the same behaviour for Windows based OS for someone who can properly test it.

## How can this PR be tested?

The corresponding MTR tests have been added within `mysql-test/main/upgrade-check.test` file.

## Basing the PR against the correct MariaDB version
- [X] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.