### PR TITLE
MDEV-30492 Crash when use mariabackup.exe with config 'innodb_flush_m…

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -1896,6 +1896,17 @@ xb_get_one_option(int optid,
     break;
 
   case OPT_INNODB_FLUSH_METHOD:
+#ifdef _WIN32
+    /* From: storage/innobase/handler/ha_innodb.cc:innodb_init_params */
+    switch (srv_file_flush_method) {
+    case SRV_ALL_O_DIRECT_FSYNC + 1 /* "async_unbuffered"="unbuffered" */:
+      srv_file_flush_method= SRV_ALL_O_DIRECT_FSYNC;
+      break;
+    case SRV_ALL_O_DIRECT_FSYNC + 2 /* "normal"="fsync" */:
+      srv_file_flush_method= SRV_FSYNC;
+      break;
+    }
+#endif
     ut_a(srv_file_flush_method
 	 <= IF_WIN(SRV_ALL_O_DIRECT_FSYNC, SRV_O_DIRECT_NO_FSYNC));
     ADD_PRINT_PARAM_OPT(innodb_flush_method_names[srv_file_flush_method]);

--- a/mysql-test/suite/mariabackup/full_backup_win.result
+++ b/mysql-test/suite/mariabackup/full_backup_win.result
@@ -1,0 +1,12 @@
+#
+# MDEV-30492 Crash when use mariabackup.exe with config 'innodb_flush_method=async_unbuffered'
+#
+# xtrabackup backup
+# xtrabackup prepare
+# shutdown server
+# remove datadir
+# xtrabackup move back
+# restart
+#
+# End of 10.4 tests
+#

--- a/mysql-test/suite/mariabackup/full_backup_win.test
+++ b/mysql-test/suite/mariabackup/full_backup_win.test
@@ -1,0 +1,24 @@
+--source include/windows.inc
+
+let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
+
+--echo #
+--echo # MDEV-30492 Crash when use mariabackup.exe with config 'innodb_flush_method=async_unbuffered'
+--echo #
+
+echo # xtrabackup backup;
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --innodb_flush_method=normal --backup --target-dir=$targetdir;
+--enable_result_log
+
+echo # xtrabackup prepare;
+--disable_result_log
+exec $XTRABACKUP  --prepare --innodb-flush-method=async_unbuffered --target-dir=$targetdir;
+-- source include/restart_and_restore.inc
+--enable_result_log
+
+rmdir $targetdir;
+
+--echo #
+--echo # End of 10.4 tests
+--echo #


### PR DESCRIPTION
…ethod=async_unbuffered'

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30492*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description


The srv_file_flush_method has already has its range validated in the parsing of the options.

As such the assertion is unnecessary, and harmful if a user sets a Windows only flush method like async_unbuffered.

Thanks Mitchell Lee for reporting the bug.

## How can this PR be tested?

mariabackup.exe with innodb_flush_method=async_unbuffered

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility

N/A