### PR TITLE
MDEV-30509: mariadb-plugin-connect: introduce curl as recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -525,6 +525,7 @@ Depends: libxml2,
          unixodbc,
          ${misc:Depends},
          ${shlibs:Depends}
+Recommends: curl
 Breaks: mariadb-connect-engine-10.1,
         mariadb-connect-engine-10.2,
         mariadb-connect-engine-10.3


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30509*

## Description
in order to be able to retrieve files using REST queries. Otherwise,
`ERROR 1105 (HY000): Curl not installed.` will be thrown.

This is upstreaming: [Debian Salsa MariaDB team MR 25](https://salsa.debian.org/mariadb-team/mariadb-server/-/merge_requests/25)

## How can this PR be tested?
Use plugin connect without curl and it will fail. Then install curl and it works

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility
Does not provide backward compatibility problems but solves user problem.
