### PR TITLE
MDEV-30498 Rename mysql_upgrade state file to mariadb_upgrade

### DIFF
--- a/debian/additions/mariadb.conf.d/50-mysql-clients.cnf
+++ b/debian/additions/mariadb.conf.d/50-mysql-clients.cnf
@@ -5,7 +5,7 @@
 
 [mysql]
 
-[mysql_upgrade]
+[mariadb-upgrade]
 
 [mysqladmin]
 

--- a/debian/mariadb-server.README.Debian
+++ b/debian/mariadb-server.README.Debian
@@ -102,7 +102,7 @@ The privilege tables are automatically updated so all there is left is read
 the release notes on https://mariadb.com/kb/en/release-notes/ to see if any
 changes affect custom apps.
 
-There should not be any need to run 'mysql_upgrade' manually, as the upgrade
+There should not be any need to run 'mariadb-upgrade' manually, as the upgrade
 scripts do that automatically.
 
 

--- a/mysql-test/include/check-testcase.test
+++ b/mysql-test/include/check-testcase.test
@@ -97,7 +97,7 @@ select count(*) from mysql.proc;
 call mtr.check_testcase();
 
 let $datadir=`select @@datadir`;
-list_files $datadir mysql_upgrade_info;
+list_files $datadir mariadb_upgrade_info;
 list_files $datadir/test #sql*;
 list_files $datadir/mysql #sql*;
 

--- a/mysql-test/include/load_dump_and_upgrade.inc
+++ b/mysql-test/include/load_dump_and_upgrade.inc
@@ -46,4 +46,4 @@ SELECT COUNT(*) > 0 AS `mysql.user has data` FROM mysql.user;
 
 # It will fail if the file doesn't exist, which is good,
 # which is an extra check that it was written
---remove_file $ddir/mysql_upgrade_info
+--remove_file $ddir/mariadb_upgrade_info

--- a/mysql-test/main/ctype_upgrade.test
+++ b/mysql-test/main/ctype_upgrade.test
@@ -197,7 +197,7 @@ SELECT GROUP_CONCAT(a ORDER BY BINARY a) FROM maria100004_xxx_croatian_ci GROUP 
 SHOW CREATE TABLE mysql050614_xxx_croatian_ci;
 SELECT GROUP_CONCAT(a ORDER BY BINARY a) FROM mysql050614_xxx_croatian_ci GROUP BY a;
 
-remove_file $MYSQLD_DATADIR/mysql_upgrade_info;
+remove_file $MYSQLD_DATADIR/mariadb_upgrade_info;
 DROP TABLE maria050313_ucs2_croatian_ci_def;
 DROP TABLE maria050313_utf8_croatian_ci;
 DROP TABLE maria050533_xxx_croatian_ci;

--- a/mysql-test/main/log_tables_upgrade.test
+++ b/mysql-test/main/log_tables_upgrade.test
@@ -24,5 +24,5 @@ RENAME TABLE test.bug49823 TO general_log;
 DROP TABLE general_log;
 RENAME TABLE renamed_general_log TO general_log;
 SET GLOBAL general_log = @saved_general_log;
-remove_file $MYSQLD_DATADIR/mysql_upgrade_info;
+remove_file $MYSQLD_DATADIR/mariadb_upgrade_info;
 USE test;

--- a/mysql-test/main/lowercase_fs_off.test
+++ b/mysql-test/main/lowercase_fs_off.test
@@ -128,7 +128,7 @@ show triggers like '%T1%';
 drop table t1;
 
 let $datadir= `select @@datadir`;
-remove_file $datadir/mysql_upgrade_info;
+remove_file $datadir/mariadb_upgrade_info;
 
 set GLOBAL sql_mode=default;
 

--- a/mysql-test/main/mysql_json_mysql_upgrade.test
+++ b/mysql-test/main/mysql_json_mysql_upgrade.test
@@ -26,7 +26,7 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 show create table mysql_json_test;
 
 --exec $MYSQL_UPGRADE --force 2>&1
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 show create table mysql_json_test;
 select * from mysql_json_test;

--- a/mysql-test/main/mysql_json_mysql_upgrade_with_plugin_loaded.test
+++ b/mysql-test/main/mysql_json_mysql_upgrade_with_plugin_loaded.test
@@ -26,7 +26,7 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 show create table mysql_json_test;
 
 --exec $MYSQL_UPGRADE --force 2>&1
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 show create table mysql_json_test;
 show create table mysql_json_test_big;

--- a/mysql-test/main/mysql_upgrade-20228.test
+++ b/mysql-test/main/mysql_upgrade-20228.test
@@ -40,8 +40,8 @@ WHERE TABLE_SCHEMA='mysql' AND TABLE_NAME='user';
 
 --echo # Running mysql_upgrade
 --exec $MYSQL_UPGRADE --default-character-set=utf8mb4 --force 2>&1
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo #
 --echo # Restoring character_set_client and collation_connection back

--- a/mysql-test/main/mysql_upgrade-6984.test
+++ b/mysql-test/main/mysql_upgrade-6984.test
@@ -14,7 +14,7 @@
 
 update mysql.global_priv set priv=json_set(priv, '$.plugin', 'mysql_native_password', '$.authentication_string', password('foo')) where user='root';
 
---replace_regex /[^ ]*mysql_upgrade_info/...mysql_upgrade_info/
+--replace_regex /[^ ]*mariadb_upgrade_info/...mariadb_upgrade_info/
 --exec $MYSQL_UPGRADE
 
 connect(con1,localhost,root,foo,,,);
@@ -25,7 +25,7 @@ flush privileges;
 set global event_scheduler=OFF;
 
 let MYSQLD_DATADIR= `select @@datadir`;
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 # --skip-grant-tables state may changed during the test. Need to restart the server
 # to restore the --skip-grant-tables state. Otherwise MTR's internal check will fail

--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -150,8 +150,8 @@ test
 Phase 7/7: Running 'FLUSH PRIVILEGES'
 OK
 Run it again - should say already completed
-This installation of MariaDB is already upgraded to VERSION.There is no need to run mysql_upgrade again for VERSION.
-You can use --force if you still want to run mysql_upgrade
+This installation of MariaDB is already upgraded to VERSION.There is no need to run mariadb-upgrade again for VERSION.
+You can use --force if you still want to run mariadb-upgrade
 Force should run it regardless of whether it has been run before
 Phase 1/7: Checking and upgrading mysql database
 Processing databases
@@ -975,7 +975,7 @@ OK
 # Bug#11827359 60223: MYSQL_UPGRADE PROBLEM WITH OPTION
 #                     SKIP-WRITE-BINLOG
 #
-# Droping the previously created mysql_upgrade_info file..
+# Droping the previously created mariadb_upgrade_info file..
 # Running mysql_upgrade with --skip-write-binlog..
 Phase 1/7: Checking and upgrading mysql database
 Processing databases
@@ -1323,7 +1323,7 @@ length(table_name)
 drop table extralongname_extralongname_extralongname_extralongname_ext;
 # End of 10.0 tests
 set sql_mode=default;
-# Droping the previously created mysql_upgrade_info file..
+# Droping the previously created mariadb_upgrade_info file..
 create table test.t1(a int) engine=MyISAM;
 # Trying to enforce InnoDB for all tables
 SET GLOBAL enforce_storage_engine=InnoDB;
@@ -1896,24 +1896,24 @@ FLUSH PRIVILEGES;
 # MDEV-27279: mariadb_upgrade add --check-if-upgrade-is-needed
 #
 This installation of MariaDB is already upgraded to MariaDB .
-There is no need to run mysql_upgrade again for MariaDB .
+There is no need to run mariadb-upgrade again for MariaDB .
 Looking for 'mariadb' as: mariadb
 This installation of MariaDB is already upgraded to MariaDB .
-There is no need to run mysql_upgrade again for MariaDB .
+There is no need to run mariadb-upgrade again for MariaDB .
 #
 # MDEV-27279: mariadb_upgrade check-if-upgrade absence is do it
 #
 Looking for 'mariadb' as: mariadb
-Empty or non existent ...mysql_upgrade_info. Assuming mysql_upgrade has to be run!
+Empty or non existent ...mariadb_upgrade_info. Assuming mysql_upgrade has to be run!
 #
 # MDEV-27279: mariadb_upgrade check-if-upgrade with minor version change
 #
 Looking for 'mariadb' as: mariadb
 This installation of MariaDB is already upgraded to MariaDB .
-There is no need to run mysql_upgrade again for MariaDB .
+There is no need to run mariadb-upgrade again for MariaDB .
 This installation of MariaDB is already upgraded to MariaDB .
-There is no need to run mysql_upgrade again for MariaDB .
-You can use --force if you still want to run mysql_upgrade
+There is no need to run mariadb-upgrade again for MariaDB .
+You can use --force if you still want to run mariadb-upgrade
 #
 # MDEV-27279: mariadb_upgrade check-if-upgrade with major version change
 #

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -7,6 +7,19 @@
 set sql_mode="";
 
 call mtr.add_suppression("Incorrect definition of table mysql.column_stats:.*");
+
+# It should create a file in the MySQL Servers datadir
+let $MYSQLD_DATADIR= `select @@datadir`;
+
+#
+# MDEV-30498 Rename mysql_upgrade state file to mariadb_upgrade.
+#
+# Ensure that old $MYSQLD_DATADIR/mysql_upgrade_info file is deleted.
+#
+
+write_file $MYSQLD_DATADIR/mysql_upgrade_info;
+EOF
+
 #
 # Basic test that we can run mysql_upgrde and that it finds the
 # expected binaries it uses.
@@ -14,22 +27,22 @@ call mtr.add_suppression("Incorrect definition of table mysql.column_stats:.*");
 --echo Run mysql_upgrade once
 --exec $MYSQL_UPGRADE --force 2>&1
 
-# It should have created a file in the MySQL Servers datadir
-let $MYSQLD_DATADIR= `select @@datadir`;
+--error 1
 file_exists $MYSQLD_DATADIR/mysql_upgrade_info;
+file_exists $MYSQLD_DATADIR/mariadb_upgrade_info;
 
 --echo Run it again - should say already completed
 --replace_regex /upgraded to [^\n].*/upgraded to VERSION./ /again for [^\n]*/again for VERSION./
 --exec $MYSQL_UPGRADE 2>&1
 
 # It should have created a file in the MySQL Servers datadir
-file_exists $MYSQLD_DATADIR/mysql_upgrade_info;
+file_exists $MYSQLD_DATADIR/mariadb_upgrade_info;
 
 --echo Force should run it regardless of whether it has been run before
 --exec $MYSQL_UPGRADE --force 2>&1
 
 # It should have created a file in the MySQL Servers datadir
-file_exists $MYSQLD_DATADIR/mysql_upgrade_info;
+file_exists $MYSQLD_DATADIR/mariadb_upgrade_info;
 
 
 #
@@ -123,16 +136,16 @@ DROP USER 'user3'@'%';
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 
---echo # Droping the previously created mysql_upgrade_info file..
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--echo # Droping the previously created mariadb_upgrade_info file..
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo # Running mysql_upgrade with --skip-write-binlog..
---replace_regex /[^ ]*mysql_upgrade_info/...mysql_upgrade_info/
+--replace_regex /[^ ]*mariadb_upgrade_info/...mariadb_upgrade_info/
 --exec $MYSQL_UPGRADE --skip-write-binlog
 
-# mysql_upgrade must have created mysql_upgrade_info file,
+# mysql_upgrade must have created mariadb_upgrade_info file,
 # so the following command should never fail.
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo #
 --echo # Bug #21489398: MYSQL_UPGRADE: FATAL ERROR: UPGRADE FAILED - IMPROVE ERROR
@@ -201,8 +214,8 @@ set sql_mode=default;
 #
 # Enforce storage engine option should not effect mysql_upgrade
 #
---echo # Droping the previously created mysql_upgrade_info file..
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--echo # Droping the previously created mariadb_upgrade_info file..
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 create table test.t1(a int) engine=MyISAM;
 --echo # Trying to enforce InnoDB for all tables
@@ -215,9 +228,9 @@ SET GLOBAL enforce_storage_engine=InnoDB;
 SELECT count(*) FROM information_schema.tables where ENGINE="InnoDB";
 SHOW CREATE TABLE test.t1;
 DROP TABLE test.t1;
-# mysql_upgrade must have created mysql_upgrade_info file,
+# mysql_upgrade must have created mariadb_upgrade_info file,
 # so the following command should never fail.
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 SET GLOBAL enforce_storage_engine=NULL;
 
 --echo # End of 10.1 tests
@@ -300,11 +313,11 @@ FLUSH PRIVILEGES;
 --echo # MDEV-27279: mariadb_upgrade check-if-upgrade absence is do it
 --echo #
 
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
---replace_regex /[^ ]*mysql_upgrade_info/...mysql_upgrade_info/
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
+--replace_regex /[^ ]*mariadb_upgrade_info/...mariadb_upgrade_info/
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed
 
---replace_regex /'mariadb.* as:[^\n]*/'mariadb' as: mariadb/ /open .* Assuming/open XXX. Assuming/ /[^ ]*mysql_upgrade_info/...mysql_upgrade_info/
+--replace_regex /'mariadb.* as:[^\n]*/'mariadb' as: mariadb/ /open .* Assuming/open XXX. Assuming/ /[^ ]*mariadb_upgrade_info/...mariadb_upgrade_info/
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --verbose
 
 --echo #
@@ -319,7 +332,7 @@ perl;
   my $ver= $ENV{'MYSQL_SERVER_VERSION'} or die "MYSQL_SERVER_VERSION not set";
   my $file= $ENV{'DATADIR'} or die "MYSQLD_DATADIR not set";
   $ver =~ s/^(\d*)\.(\d*).(\d*)(.*)/$1.$2.0$4/;
-  open(FILE, ">$file/mysql_upgrade_info") or die "Failed to open $file";
+  open(FILE, ">$file/mariadb_upgrade_info") or die "Failed to open $file";
   print FILE "$ver\n";
   close(FILE);
 EOF
@@ -331,7 +344,7 @@ EOF
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --verbose
 --replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB /
 --exec $MYSQL_UPGRADE
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo #
 --echo # MDEV-27279: mariadb_upgrade check-if-upgrade with major version change
@@ -343,7 +356,7 @@ perl;
   my $ver= $ENV{'MYSQL_SERVER_VERSION'} or die "MYSQL_SERVER_VERSION not set";
   my $file= $ENV{'DATADIR'} or die "MYSQLD_DATADIR not set";
   $ver =~ s/^(\d*)\.(\d*).(\d*)(.*)/10.11.2$4/;
-  open(FILE, ">$file/mysql_upgrade_info") or die "Failed to open $file";
+  open(FILE, ">$file/mariadb_upgrade_info") or die "Failed to open $file";
   print FILE "$ver\n";
   close(FILE);
 EOF
@@ -353,7 +366,7 @@ EOF
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed
 --replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB / /'mariadb.* as:[^\n]*/'mysql' as: mysql/
 --exec $MYSQL_UPGRADE --check-if-upgrade-is-needed --verbose
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 drop table mysql.global_priv;
 rename table mysql.global_priv_bak to mysql.global_priv;
 
@@ -374,7 +387,7 @@ alter table mysql.db drop column Delete_history_priv;
 --source include/restart_mysqld.inc
 --echo Run mysql_upgrade with all privileges on a user
 --exec $MYSQL_UPGRADE --force --silent 2>&1
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 flush privileges;
 SHOW GRANTS FOR 'user3'@'%';
 DROP USER 'user3'@'%';
@@ -393,7 +406,7 @@ SHOW GLOBAL VARIABLES LIKE 'alter_algorithm';
 --exec $MYSQL_UPGRADE --force 2>&1
 SET GLOBAL alter_algorithm=DEFAULT;
 SHOW GLOBAL VARIABLES LIKE 'alter_algorithm';
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo End of 10.3 tests
 
@@ -411,7 +424,7 @@ disconnect con1;
 connection default;
 --echo # mysql_upgrade --force --silent 2>&1
 --exec $MYSQL_UPGRADE --force --silent 2>&1
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 show create user user3@localhost;
 connect con1,localhost,user3,a_password;
 select current_user();
@@ -429,7 +442,7 @@ drop view mysql.user_bak;
 drop table mysql.innodb_index_stats, mysql.innodb_table_stats;
 --echo # mysql_upgrade --force --silent 2>&1
 --exec $MYSQL_UPGRADE --force --silent 2>&1
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 drop table mysql.global_priv;
 rename table mysql.global_priv_bak to mysql.global_priv;
 
@@ -441,7 +454,7 @@ drop view mysql.user_bak;
 alter table mysql.user change authentication_string auth_string text collate utf8_bin not null;
 --echo # mysql_upgrade --force --silent 2>&1
 --exec $MYSQL_UPGRADE --force --silent 2>&1
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 select count(*) from mysql.global_priv;
 drop table mysql.global_priv;
 rename table mysql.global_priv_bak to mysql.global_priv;
@@ -482,7 +495,7 @@ connection default;
 
 drop table mysql.global_priv;
 rename table mysql.global_priv_bak to mysql.global_priv;
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo # End of 10.4 tests
 

--- a/mysql-test/main/mysql_upgrade_mysql_json_datatype.test
+++ b/mysql-test/main/mysql_upgrade_mysql_json_datatype.test
@@ -58,4 +58,4 @@ drop table tempty;
 drop table mysql_json_test;
 drop table mysql_json_test_big;
 
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info

--- a/mysql-test/main/mysql_upgrade_no_innodb.test
+++ b/mysql-test/main/mysql_upgrade_no_innodb.test
@@ -3,4 +3,4 @@
 --exec $MYSQL_UPGRADE --force --upgrade-system-tables 2>&1
 
 let $MYSQLD_DATADIR= `select @@datadir`;
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info

--- a/mysql-test/main/mysql_upgrade_noengine.test
+++ b/mysql-test/main/mysql_upgrade_noengine.test
@@ -46,9 +46,9 @@ drop view mysql.user_bak;
 # pretend it's an upgrade from 10.0
 alter table mysql.user drop column default_role, drop column max_statement_time;
 
-# but mysql_upgrade_info tells otherwise
-remove_file $datadir/mysql_upgrade_info;
-write_file $datadir/mysql_upgrade_info;
+# but mariadb_upgrade_info tells otherwise
+remove_file $datadir/mariadb_upgrade_info;
+write_file $datadir/mariadb_upgrade_info;
 10.1.10-MariaDB
 EOF
 
@@ -64,7 +64,7 @@ source include/switch_to_mysql_user.inc;
 drop view mysql.user_bak;
 
 alter table mysql.user drop column default_role, drop column max_statement_time;
-remove_file $datadir/mysql_upgrade_info;
+remove_file $datadir/mariadb_upgrade_info;
 
 --echo # upgrade from 10.0 - engines are enabled
 --replace_regex /\d\d\.\d*\.\d*[^ .\n]*/MariaDB /
@@ -74,7 +74,7 @@ select table_catalog, table_schema, table_name, table_type, engine, row_format, 
 
 drop table t1, t2;
 
-remove_file $datadir/mysql_upgrade_info;
+remove_file $datadir/mariadb_upgrade_info;
 uninstall plugin blackhole;
 uninstall plugin archive;
 

--- a/mysql-test/main/mysql_upgrade_ssl.test
+++ b/mysql-test/main/mysql_upgrade_ssl.test
@@ -9,4 +9,4 @@
 --echo #
 --exec $MYSQL_UPGRADE --skip-verbose --skip-silent --ssl --force 2>&1
 --let $datadir= `select @@datadir`
---remove_file $datadir/mysql_upgrade_info
+--remove_file $datadir/mariadb_upgrade_info

--- a/mysql-test/main/mysql_upgrade_to_100502.test
+++ b/mysql-test/main/mysql_upgrade_to_100502.test
@@ -55,7 +55,7 @@ SHOW GRANTS FOR user_replslave@localhost;
 
 --echo # mysql_upgrade --force --silent 2>&1
 --exec $MYSQL_UPGRADE --force --silent 2>&1
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 FLUSH PRIVILEGES;
 
 --echo #

--- a/mysql-test/main/mysql_upgrade_view.test
+++ b/mysql-test/main/mysql_upgrade_view.test
@@ -185,6 +185,6 @@ flush tables;
 # back to mariadb default
 drop table mysql.event;
 rename table mysql.ev_bk to mysql.event;
-remove_file $MYSQLD_DATADIR/mysql_upgrade_info;
+remove_file $MYSQLD_DATADIR/mariadb_upgrade_info;
 drop view v1,v2,v3;
 drop table t1;

--- a/mysql-test/main/plugin_auth.test
+++ b/mysql-test/main/plugin_auth.test
@@ -506,7 +506,7 @@ SELECT IS_NULLABLE, COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
     COLUMN_NAME IN ('plugin', 'authentication_string')
   ORDER BY COLUMN_NAME;
 let $datadir= `select @@datadir`;
-remove_file $datadir/mysql_upgrade_info;
+remove_file $datadir/mariadb_upgrade_info;
 drop table mysql.global_priv;
 rename table mysql.global_priv_bak to mysql.global_priv;
 

--- a/mysql-test/main/rpl_mysql_upgrade_slave_repo_check.test
+++ b/mysql-test/main/rpl_mysql_upgrade_slave_repo_check.test
@@ -96,7 +96,7 @@ EOF
 
 --connection master
 let $datadir= `select @@datadir`;
-remove_file $datadir/mysql_upgrade_info;
+remove_file $datadir/mariadb_upgrade_info;
 TRUNCATE TABLE `mysql`.`slave_master_info`;
 TRUNCATE TABLE `mysql`.`slave_relay_log_info`;
 --remove_file $MYSQLTEST_VARDIR/log/mysql_upgrade_master.log
@@ -117,7 +117,7 @@ TRUNCATE TABLE `mysql`.`slave_relay_log_info`;
 --echo "====== Clean up ======"
 --connection master
 let $datadir= `select @@datadir`;
-remove_file $datadir/mysql_upgrade_info;
+remove_file $datadir/mariadb_upgrade_info;
 DROP TABLE `mysql`.`slave_master_info`, `mysql`.`slave_relay_log_info`;
 
 --remove_file $MYSQLTEST_VARDIR/tmp/slave_table_repo_init.sql

--- a/mysql-test/main/statistics_upgrade.test
+++ b/mysql-test/main/statistics_upgrade.test
@@ -44,8 +44,8 @@ alter table t3 rename mysql.column_stats;
 --exec $MYSQL_UPGRADE --upgrade-system-tables  --force --silent 2>&1 
 
 let $MYSQLD_DATADIR= `select @@datadir`;
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo #
 --echo # Table definition after upgrade:

--- a/mysql-test/main/statistics_upgrade_not_done.test
+++ b/mysql-test/main/statistics_upgrade_not_done.test
@@ -50,8 +50,8 @@ select * from mysql.column_stats where table_name='t2' and db_name='test';
 
 --exec $MYSQL_UPGRADE --upgrade-system-tables  --force --silent 2>&1 
 let $MYSQLD_DATADIR= `select @@datadir`;
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 analyze select * from t0 where a<3;
 drop table t0, t1, t2;

--- a/mysql-test/main/upgrade_MDEV-19650.test
+++ b/mysql-test/main/upgrade_MDEV-19650.test
@@ -101,8 +101,8 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 
 --echo # Run mysql_upgrade
 --exec $MYSQL_UPGRADE  2>&1
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo # check new definitions mysql_upgrade
 

--- a/mysql-test/main/upgrade_MDEV-23102-1.test
+++ b/mysql-test/main/upgrade_MDEV-23102-1.test
@@ -115,8 +115,8 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 
 --echo # Run mysql_upgrade
 --exec $MYSQL_UPGRADE  2>&1
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo # check new definitions mysql_upgrade
 
@@ -138,8 +138,8 @@ DROP VIEW mysql.user;
 DROP PROCEDURE AddGeometryColumn;
 DROP PROCEDURE DropGeometryColumn;
 --exec $MYSQL_UPGRADE  2>&1
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 delete from global_priv;
 delete from tables_priv;

--- a/mysql-test/main/upgrade_MDEV-23102-2.test
+++ b/mysql-test/main/upgrade_MDEV-23102-2.test
@@ -96,8 +96,8 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 
 --echo # Run mysql_upgrade
 --exec $MYSQL_UPGRADE  2>&1
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo # check new definitions mysql_upgrade
 
@@ -116,8 +116,8 @@ select count(*) from global_priv where user='mariadb.sys' and host='localhost';
 DROP USER 'superuser'@'localhost';
 DROP VIEW mysql.user;
 --exec $MYSQL_UPGRADE  2>&1
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 delete from global_priv;
 delete from tables_priv;

--- a/mysql-test/main/upgrade_geometrycolumn_procedure_definer.test
+++ b/mysql-test/main/upgrade_geometrycolumn_procedure_definer.test
@@ -43,8 +43,8 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 --echo # Run mysql_upgrade
 --echo #
 --exec $MYSQL_UPGRADE  2>&1
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 --echo #
 --echo # check new definers of Add/DropGeometryColumn

--- a/mysql-test/main/upgrade_mdev_24363.test
+++ b/mysql-test/main/upgrade_mdev_24363.test
@@ -55,8 +55,8 @@ drop user gigi@localhost;
 --echo # Run mysql_upgrade
 --exec $MYSQL_UPGRADE  2>&1
 let $MYSQLD_DATADIR= `select @@datadir`;
---file_exists $MYSQLD_DATADIR/mysql_upgrade_info
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--file_exists $MYSQLD_DATADIR/mariadb_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info
 
 create user gigi@localhost;
 show create user gigi@localhost;

--- a/mysql-test/suite/perfschema/include/upgrade_check.inc
+++ b/mysql-test/suite/perfschema/include/upgrade_check.inc
@@ -12,4 +12,4 @@
 --cat_file $MYSQLTEST_VARDIR/tmp/err_file
 --remove_file $MYSQLTEST_VARDIR/tmp/out_file
 --remove_file $MYSQLTEST_VARDIR/tmp/err_file
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info

--- a/mysql-test/suite/rpl/t/rpl_mysql_upgrade.test
+++ b/mysql-test/suite/rpl/t/rpl_mysql_upgrade.test
@@ -55,7 +55,7 @@ connection master;
 --exec $MYSQL_UPGRADE --skip-verbose --write-binlog --force --user=root > $MYSQLTEST_VARDIR/log/mysql_upgrade.log 2>&1
 
 let $datadir= `select @@datadir`;
-remove_file $datadir/mysql_upgrade_info;
+remove_file $datadir/mariadb_upgrade_info;
 
 connection master;
 let $after_file= query_get_value(SHOW MASTER STATUS, File, 1);

--- a/mysql-test/suite/sysschema/t/mysqldump.test
+++ b/mysql-test/suite/sysschema/t/mysqldump.test
@@ -32,4 +32,4 @@ DROP TEMPORARY TABLE tmp_tables_priv;
 
 FLUSH PRIVILEGES;
 --let $MYSQLD_DATADIR= `select @@datadir`
---remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--remove_file $MYSQLD_DATADIR/mariadb_upgrade_info

--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -597,7 +597,7 @@ cat_sql()
 s_echo "Installing MariaDB/MySQL system tables in '$ldata' ..."
 if cat_sql | eval "$filter_cmd_line" | mysqld_install_cmd_line > /dev/null
 then
-    printf "@VERSION@-MariaDB" > "$ldata/mysql_upgrade_info"
+    printf "@VERSION@-MariaDB" > "$ldata/mariadb_upgrade_info"
   s_echo "OK"
 else
   log_file_place=$ldata

--- a/sql/winservice.c
+++ b/sql/winservice.c
@@ -305,19 +305,19 @@ int get_mysql_service_properties(const wchar_t *bin_path,
   }
 
   /*
-    If version could not be determined so far, try mysql_upgrade_info in
+    If version could not be determined so far, try mariadb_upgrade_info in
     database directory.
   */
   if(props->version_major == 0)
   {
     char buf[MAX_PATH];
-    FILE *mysql_upgrade_info;
+    FILE *mariadb_upgrade_info;
 
-    sprintf_s(buf, MAX_PATH, "%s\\mysql_upgrade_info", props->datadir);
-    mysql_upgrade_info= fopen(buf, "r");
-    if(mysql_upgrade_info)
+    sprintf_s(buf, MAX_PATH, "%s\\mariadb_upgrade_info", props->datadir);
+    mariadb_upgrade_info= fopen(buf, "r");
+    if(mariadb_upgrade_info)
     {
-      if (fgets(buf, MAX_PATH, mysql_upgrade_info))
+      if (fgets(buf, MAX_PATH, mariadb_upgrade_info))
       {
         int major,minor,patch;
         if (sscanf(buf, "%d.%d.%d", &major, &minor, &patch) == 3)


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30498*

## Description
This PR includes the changes for renaming the upgrade state file from `mysql_upgrade_file` to `mariadb_upgrade_file` and ensures that the old file is automatically removed when `mariadb-upgrade` tool is executed.

## How can this PR be tested?

MTR tests referencing old `mysql_upgrade_file` have been updated with the new file name. Also, a new test case have been added on `main.mysql_upgrade` to test that the old file is removed after running `mariadb-upgrade`.

## Basing the PR against the correct MariaDB version
- [X] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility
As the file will be renamed in a major version, there shouldn't be any backward compatibility issue, other than removing the old file and using the new name instead.

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.