### PR TITLE
MDEV-30448 No deprecation message shown for mysql_fix_extensions

### DIFF
--- a/man/mysql_fix_extensions.1
+++ b/man/mysql_fix_extensions.1
@@ -19,6 +19,8 @@ mariadb-fix-extensions \- normalize table file name extensions (mysql_fix_extens
 \fBmysql_fix_extensions \fR\fB\fIdata_dir\fR\fR
 .SH "DESCRIPTION"
 .PP
+This script is deprecated and will be removed in a later release.
+.PP
 \fBmysql_fix_extensions\fR
 converts the extensions for
 MyISAM

--- a/scripts/mysql_fix_extensions.sh
+++ b/scripts/mysql_fix_extensions.sh
@@ -25,6 +25,8 @@
 # makes .frm lowercase and .MYI/MYD/ISM/ISD uppercase
 # useful when datafiles are copied from windows
 
+print STDERR "WARNING: This script is deprecated and will be removed in a future release\n\n";
+
 die "Usage: $0 datadir\n" unless -d $ARGV[0];
 
 for $a (<$ARGV[0]/*/*.*>) { $_=$a;


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30448*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

This is a myisam script and we encourage the use of Aria. So we deprecate it.

Its useful to deprecate it as carrying large amount of low utility scripts makes it hard to determine what is useful and what isn't in the packaging.

## How can this PR be tested?

Run it.