### PR TITLE
MDEV-30573 Server doesn't build with GCOV by GCC 11+

### DIFF
--- a/dbug/dbug.c
+++ b/dbug/dbug.c
@@ -86,7 +86,7 @@
 #include <m_string.h>
 #include <errno.h>
 #ifdef HAVE_gcov
-extern void __gcov_flush();
+#include <gcov.h>
 #endif
 
 #ifndef DBUG_OFF
@@ -2212,7 +2212,7 @@ void _db_suicide_()
   fprintf(stderr, "SIGKILL myself\n");
   fflush(stderr);
 #ifdef HAVE_gcov
-  __gcov_flush();
+  __gcov_dump();
 #endif
 
   retval= kill(getpid(), SIGKILL);
@@ -2262,7 +2262,7 @@ my_bool _db_my_assert(const char *file, int line, const char *msg)
     fprintf(stderr, "%s:%d: assert: %s\n", file, line, msg);
     fflush(stderr);
 #ifdef HAVE_gcov
-    __gcov_flush();
+    __gcov_dump();
 #endif
   }
   return a;

--- a/mysys/stacktrace.c
+++ b/mysys/stacktrace.c
@@ -34,6 +34,9 @@
 #include <execinfo.h>
 #endif
 
+#ifdef HAVE_gcov
+#include <gcov.h>
+#endif
 /**
    Default handler for printing stacktrace
 */
@@ -409,9 +412,6 @@ end:
 /* Produce a core for the thread */
 void my_write_core(int sig)
 {
-#ifdef HAVE_gcov
-  extern void __gcov_flush(void);
-#endif
   signal(sig, SIG_DFL);
 #ifdef HAVE_gcov
   /*
@@ -419,7 +419,7 @@ void my_write_core(int sig)
     information from this process, causing gcov output to be incomplete.
     So we force the writing of coverage information here before terminating.
   */
-  __gcov_flush();
+  __gcov_dump();
 #endif
   pthread_kill(pthread_self(), sig);
 #if defined(P_MYID) && !defined(SCO)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30573*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

__gcov_flush was never an external symbol in the documentation.

It was removed in gcc-11. The correct function to use is __gcov_dump which is defined in the gcov.h header.

## How can this PR be tested?

Compile with ENABLE_GCOV=YES on any version.

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
