### PR TITLE
MDEV-30543 Max_used_connections_time resolved

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -166,6 +166,7 @@ extern "C" {					// Because of SCO 3.2V4.2
 #endif /* _WIN32 */
 
 #include <my_libwrap.h>
+#include <ctime>
 
 #ifdef _WIN32 
 #include <crtdbg.h>
@@ -330,6 +331,8 @@ static my_bool opt_debugging= 0, opt_external_locking= 0, opt_console= 0;
 static my_bool opt_short_log_format= 0, opt_silent_startup= 0;
 
 ulong max_used_connections;
+tm* currtime;
+std::string max_used_connections_time;
 static const char *mysqld_user, *mysqld_chroot;
 static char *default_character_set_name;
 static char *character_set_filesystem_name;
@@ -6147,8 +6150,49 @@ void create_new_thread(CONNECT *connect)
   }
 
   uint sum= connection_count + extra_connection_count;
-  if (sum > max_used_connections)
+  
+  if (sum > max_used_connections){
+    time_t now = time(0);
+    currtime = localtime(&now);
+    std::string year = std::to_string(currtime->tm_year+1900);
+    std::string month;
+    std::string day;
+    std::string hour;
+    std::string min;
+    std::string sec;
+    if(currtime->tm_mon+1 < 10){
+      month = "0" + std::to_string(currtime->tm_mon+1);
+    }
+    else{
+      month = std::to_string(currtime->tm_mon+1);
+    }
+    if(currtime->tm_mday < 10){
+      day = "0" + std::to_string(currtime->tm_mday);
+    }
+    else{
+      day = std::to_string(currtime->tm_mday);
+    }
+    if(currtime->tm_hour < 10){
+      hour = "0" + std::to_string(currtime->tm_hour);
+    }
+    else{
+      hour = std::to_string(currtime->tm_hour);
+    }
+    if(currtime->tm_min < 10){
+      min = "0" + std::to_string(currtime->tm_min);
+    }
+    else{
+      min = std::to_string(currtime->tm_min);
+    }
+    if(currtime->tm_sec < 10){
+      sec = "0" + std::to_string(currtime->tm_sec);
+    }
+    else{
+      sec = std::to_string(currtime->tm_sec);
+    }
+    max_used_connections_time = year + "-" + month + "-" + day + " " + hour + ":" + min + ":" + sec;
     max_used_connections= sum;
+  }
 
   /*
     The initialization of thread_id is done in create_embedded_thd() for


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30543*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here
This PR is trying to add a variable Max_used_connections_time that calculates the current date and time and stores in the prescribed format in the JIRA issue template.
This code doesn't mess with the existing code so, safe to go ;)

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
