### PR TITLE
MDEV-30630: locale: Chinese error messages for ZH_{CN,TW,HK}

### DIFF
--- a/mysql-test/suite/plugins/r/locales.result
+++ b/mysql-test/suite/plugins/r/locales.result
@@ -57,8 +57,8 @@ ID	NAME	DESCRIPTION	MAX_MONTH_NAME_LENGTH	MAX_DAY_NAME_LENGTH	DECIMAL_POINT	THOU
 53	uk_UA	Ukrainian - Ukraine	8	9	,	.	ukrainian
 54	ur_PK	Urdu - Pakistan	6	6	.	,	english
 55	vi_VN	Vietnamese - Vietnam	16	11	,	.	english
-56	zh_CN	Chinese - Peoples Republic of China	3	3	.	,	english
-57	zh_TW	Chinese - Taiwan	3	2	.	,	english
+56	zh_CN	Chinese - Peoples Republic of China	3	3	.	,	chinese
+57	zh_TW	Chinese - Taiwan	3	2	.	,	chinese
 58	ar_DZ	Arabic - Algeria	6	8	.	,	english
 59	ar_EG	Arabic - Egypt	6	8	.	,	english
 60	ar_IN	Arabic - Iran	6	8	.	,	english
@@ -109,7 +109,7 @@ ID	NAME	DESCRIPTION	MAX_MONTH_NAME_LENGTH	MAX_DAY_NAME_LENGTH	DECIMAL_POINT	THOU
 105	nl_BE	Dutch - Belgium	9	9	,	.	dutch
 106	no_NO	Norwegian - Norway	9	7	,	.	norwegian
 107	sv_FI	Swedish - Finland	9	7	,	 	swedish
-108	zh_HK	Chinese - Hong Kong SAR	3	3	.	,	english
+108	zh_HK	Chinese - Hong Kong SAR	3	3	.	,	chinese
 109	el_GR	Greek - Greece	11	9	,	.	greek
 110	rm_CH	Romansh - Switzerland	9	9	,	'	english
 show locales;
@@ -170,8 +170,8 @@ Id	Name	Description	Error_Message_Language
 53	uk_UA	Ukrainian - Ukraine	ukrainian
 54	ur_PK	Urdu - Pakistan	english
 55	vi_VN	Vietnamese - Vietnam	english
-56	zh_CN	Chinese - Peoples Republic of China	english
-57	zh_TW	Chinese - Taiwan	english
+56	zh_CN	Chinese - Peoples Republic of China	chinese
+57	zh_TW	Chinese - Taiwan	chinese
 58	ar_DZ	Arabic - Algeria	english
 59	ar_EG	Arabic - Egypt	english
 60	ar_IN	Arabic - Iran	english
@@ -222,7 +222,7 @@ Id	Name	Description	Error_Message_Language
 105	nl_BE	Dutch - Belgium	dutch
 106	no_NO	Norwegian - Norway	norwegian
 107	sv_FI	Swedish - Finland	swedish
-108	zh_HK	Chinese - Hong Kong SAR	english
+108	zh_HK	Chinese - Hong Kong SAR	chinese
 109	el_GR	Greek - Greece	greek
 110	rm_CH	Romansh - Switzerland	english
 show locales like '%spanish%';

--- a/sql/sql_locale.cc
+++ b/sql/sql_locale.cc
@@ -29,7 +29,7 @@
 
 enum err_msgs_index
 {
-  en_US= 0, cs_CZ, da_DK, nl_NL, et_EE, fr_FR, de_DE, el_GR, hu_HU, it_IT,
+  en_US= 0, zh_CN, cs_CZ, da_DK, nl_NL, et_EE, fr_FR, de_DE, el_GR, hu_HU, it_IT,
   ja_JP, ko_KR, no_NO, nn_NO, pl_PL, pt_PT, ro_RO, ru_RU, sr_RS,  sk_SK,
   es_ES, sv_SE, uk_UA, hi_IN
 } ERR_MSGS_INDEX;
@@ -38,6 +38,7 @@ enum err_msgs_index
 MY_LOCALE_ERRMSGS global_errmsgs[]=
 {
   {"english", NULL},
+  {"chinese", NULL},
   {"czech", NULL},
   {"danish", NULL},
   {"dutch", NULL},
@@ -2095,7 +2096,7 @@ MY_LOCALE my_locale_zh_CN
   '.',        /* decimal point zh_CN */
   ',',        /* thousands_sep zh_CN */
   "\x03",     /* grouping      zh_CN */
-  &global_errmsgs[en_US]
+  &global_errmsgs[zh_CN]
 );
 /***** LOCALE END zh_CN *****/
 
@@ -2131,7 +2132,7 @@ MY_LOCALE my_locale_zh_TW
   '.',        /* decimal point zh_TW */
   ',',        /* thousands_sep zh_TW */
   "\x03",     /* grouping      zh_TW */
-  &global_errmsgs[en_US]
+  &global_errmsgs[zh_CN]
 );
 /***** LOCALE END zh_TW *****/
 
@@ -3171,7 +3172,7 @@ MY_LOCALE my_locale_zh_HK
   '.',        /* decimal point zh_HK */
   ',',        /* thousands_sep zh_HK */
   "\x03",     /* grouping      zh_HK */
-  &global_errmsgs[en_US]
+  &global_errmsgs[zh_CN]
 );
 /***** LOCALE END zh_HK *****/
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

We've got a good compliment of Chinese error messages thanks to #2100.

So do we make it default for those in the ZH_{CH,TW,HK} locale?

## How can this PR be tested?

<pre>
$ mariadblocal --lc-messages=ZH_CN --lc-messages-dir=$PWD/sql/share/chinese
mysql.user table already exists!
Run mysql_upgrade, not mysql_install_db
2023-02-09 18:44:21 0 [Note] Starting MariaDB 10.11.2-MariaDB source revision f91e2226fc60aa8cec42532e6299d879c5d8ad37 as process 330416
2023-02-09 18:44:21 0 [Note] InnoDB: Compressed tables use zlib 1.2.12
2023-02-09 18:44:21 0 [Note] InnoDB: Number of transaction pools: 1
2023-02-09 18:44:21 0 [Note] InnoDB: Using crc32 + pclmulqdq instructions
2023-02-09 18:44:21 0 [Note] InnoDB: Using liburing
2023-02-09 18:44:21 0 [Note] InnoDB: Initializing buffer pool, total size = 128.000MiB, chunk size = 2.000MiB
2023-02-09 18:44:21 0 [Note] InnoDB: Completed initialization of buffer pool
2023-02-09 18:44:21 0 [Note] InnoDB: Setting O_DIRECT on file ./ibdata1 failed
2023-02-09 18:44:21 0 [Note] InnoDB: Buffered log writes (block size=512 bytes)
2023-02-09 18:44:21 0 [Note] InnoDB: 128 rollback segments are active.
2023-02-09 18:44:21 0 [Note] InnoDB: Setting file './ibtmp1' size to 12.000MiB. Physically writing the file full; Please wait ...
2023-02-09 18:44:21 0 [Note] InnoDB: File './ibtmp1' size is now 12.000MiB.
2023-02-09 18:44:21 0 [Note] InnoDB: log sequence number 46966; transaction id 14
2023-02-09 18:44:21 0 [Note] Plugin 'FEEDBACK' is disabled.
2023-02-09 18:44:21 0 [Note] InnoDB: Loading buffer pool(s) from /tmp/build-mariadb-server-10.11-datadir/ib_buffer_pool
2023-02-09 18:44:21 0 [Note] InnoDB: Buffer pool(s) load completed at 230209 18:44:21
2023-02-09 18:44:21 0 [Note] sql/mysqld：已经准备好接受连接
Version：'10.11.2-MariaDB'套接字：'/tmp/build-mariadb-server-10.11.sock'端口：0 Source distribution
</pre>

```
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 3
Server version: 10.11.2-MariaDB Source distribution

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> select no;
ERROR 1054 (42S22): \672A\77E5\5217'no'\5728'field list'
MariaDB [(none)]> set names utf8;
Query OK, 0 rows affected (0.000 sec)

MariaDB [(none)]> select no;
ERROR 1054 (42S22): 未知列'no'在'field list'
```

Bit ugly that `set names utf8` is needed.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*
- [*] pre-GA change.

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

Maybe its unexpected.

## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
