### PR TITLE
MDEV-30613 output_core_info crashes in my_read()

### DIFF
--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -27,6 +27,7 @@
 
 #ifdef __WIN__
 #include <crtdbg.h>
+#include <direct.h>
 #define SIGNAL_FMT "exception 0x%x"
 #else
 #define SIGNAL_FMT "signal %d"
@@ -67,27 +68,27 @@ static inline void output_core_info()
     my_safe_printf_stderr("Writing a core file...\nWorking directory at %.*s\n",
                           (int) len, buff);
   }
-  if ((fd= my_open("/proc/self/limits", O_RDONLY, MYF(0))) >= 0)
+  if ((fd= open("/proc/self/limits", O_RDONLY, MYF(0))) >= 0)
   {
     my_safe_printf_stderr("Resource Limits:\n");
-    while ((len= my_read(fd, (uchar*)buff, sizeof(buff),  MYF(0))) > 0)
+    while ((len= read(fd, (uchar*)buff, sizeof(buff))) > 0)
     {
       my_write_stderr(buff, len);
     }
-    my_close(fd, MYF(0));
+    close(fd);
   }
 #ifdef __linux__
-  if ((fd= my_open("/proc/sys/kernel/core_pattern", O_RDONLY, MYF(0))) >= 0)
+  if ((fd= open("/proc/sys/kernel/core_pattern", O_RDONLY, MYF(0))) >= 0)
   {
-    len= my_read(fd, (uchar*)buff, sizeof(buff),  MYF(0));
+    len= read(fd, (uchar*)buff, sizeof(buff));
     my_safe_printf_stderr("Core pattern: %.*s\n", (int) len, buff);
-    my_close(fd, MYF(0));
+    close(fd);
   }
-  if ((fd= my_open("/proc/version", O_RDONLY, MYF(0))) >= 0)
+  if ((fd= open("/proc/version", O_RDONLY)) >= 0)
   {
-    len= my_read(fd, (uchar*)buff, sizeof(buff),  MYF(0));
+    len= read(fd, (uchar*)buff, sizeof(buff));
     my_safe_printf_stderr("Kernel version: %.*s\n", (int) len, buff);
-    my_close(fd, MYF(0));
+    close(fd);
   }
 #endif
 #elif defined(__APPLE__) || defined(__FreeBSD__)
@@ -101,11 +102,14 @@ static inline void output_core_info()
   {
     my_safe_printf_stderr("Kernel version: %.*s\n", (int) len, buff);
   }
-#else
+#elif defined(HAVE_GETCWD)
   char buff[80];
-  my_getwd(buff, sizeof(buff), 0);
-  my_safe_printf_stderr("Writing a core file at %s\n", buff);
-  fflush(stderr);
+
+  if (getcwd(buff, sizeof(buff)))
+  {
+    my_safe_printf_stderr("Writing a core file at %.*s\n", (int) sizeof(buff), buff);
+    fflush(stderr);
+  }
 #endif
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30613*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

and my_getwd(). The cause is my_errno define which depends on my_thread_var being a not null pointer
otherwise it will be de-referenced and cause
a SEGV already in the signal handler.

Replace uses of these functions in the output_core_info using posix read/getcwd functions instead.

The getwd fallback in my_getcwd isn't needed as
its been obsolute for a very long time.

Thanks Vladislav Vaintroub for diagnosis and posix recommendation.\

## How can this PR be tested?

```
# kill -SEGV $(pidof mariadbd)
information that should help you find out what is causing the crash.
Writing a core file...
Working directory at /tmp/build-mariadb-server-10.4-datadir
Resource Limits:
Limit                     Soft Limit           Hard Limit           Units     
Max cpu time              unlimited            unlimited            seconds   
Max file size             unlimited            unlimited            bytes     
Max data size             unlimited            unlimited            bytes     
Max stack size            8388608              unlimited            bytes     
Max core file size        unlimited            unlimited            bytes     
Max resident set          unlimited            unlimited            bytes     
Max processes             127305               127305               processes 
Max open files            32198                32198                files     
Max locked memory         8388608              8388608              bytes     
Max address space         unlimited            unlimited            bytes     
Max file locks            unlimited            unlimited            locks     
Max pending signals       127305               127305               signals   
Max msgqueue size         819200               819200               bytes     
Max nice priority         0                    0                    
Max realtime priority     0                    0                    
Max realtime timeout      unlimited            unlimited            us        
Core pattern: |/usr/lib/systemd/systemd-coredump %P %u %g %s %t %c %h

Kernel version: Linux version 6.1.7-200.fc37.x86_64 (mockbuild@bkernel01.iad2.fedoraproject.org) (gcc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4), GNU ld version 2.38-25.fc37) #1 SMP PREEMPT_DYNAMIC Wed Jan 18 17:11:49 UTC 2023

Segmentation fault (core dumped)
```

## Backward compatibility

Will miss out on "Writing a core file at ..." on non-readlink capable OS without a getcwd implementation.

Windows still has this https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/getcwd?view=msvc-170. So its unlikely to cause any troubles.

## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
