### PR TITLE
MDEV-30621: Türkiye is the correct current country naming

### DIFF
--- a/mysql-test/suite/plugins/r/locales.result
+++ b/mysql-test/suite/plugins/r/locales.result
@@ -1,3 +1,4 @@
+SET names utf8;
 select * from information_schema.locales;
 ID	NAME	DESCRIPTION	MAX_MONTH_NAME_LENGTH	MAX_DAY_NAME_LENGTH	DECIMAL_POINT	THOUSAND_SEP	ERROR_MESSAGE_LANGUAGE
 0	en_US	English - United States	9	9	.	,	english
@@ -52,7 +53,7 @@ ID	NAME	DESCRIPTION	MAX_MONTH_NAME_LENGTH	MAX_DAY_NAME_LENGTH	DECIMAL_POINT	THOU
 49	ta_IN	Tamil - India	10	8	.	,	english
 50	te_IN	Telugu - India	10	9	.	,	english
 51	th_TH	Thai - Thailand	10	8	.	,	english
-52	tr_TR	Turkish - Turkey	7	9	,	.	english
+52	tr_TR	Turkish - Türkiye	7	9	,	.	english
 53	uk_UA	Ukrainian - Ukraine	8	9	,	.	ukrainian
 54	ur_PK	Urdu - Pakistan	6	6	.	,	english
 55	vi_VN	Vietnamese - Vietnam	16	11	,	.	english
@@ -165,7 +166,7 @@ Id	Name	Description	Error_Message_Language
 49	ta_IN	Tamil - India	english
 50	te_IN	Telugu - India	english
 51	th_TH	Thai - Thailand	english
-52	tr_TR	Turkish - Turkey	english
+52	tr_TR	Turkish - Türkiye	english
 53	uk_UA	Ukrainian - Ukraine	ukrainian
 54	ur_PK	Urdu - Pakistan	english
 55	vi_VN	Vietnamese - Vietnam	english

--- a/mysql-test/suite/plugins/t/locales.test
+++ b/mysql-test/suite/plugins/t/locales.test
@@ -2,6 +2,7 @@ if (`select count(*) = 0 from information_schema.plugins where plugin_name = 'lo
 {
   --skip LOCALES plugin is not active
 }
+SET names utf8;
 
 select * from information_schema.locales;
 show locales;

--- a/sql/sql_locale.cc
+++ b/sql/sql_locale.cc
@@ -1919,7 +1919,7 @@ MY_LOCALE my_locale_th_TH
 );
 /***** LOCALE END th_TH *****/
 
-/***** LOCALE BEGIN tr_TR: Turkish - Turkey *****/
+/***** LOCALE BEGIN tr_TR: Turkish - Türkiye *****/
 static const char *my_locale_month_names_tr_TR[13] = 
  {"Ocak","Şubat","Mart","Nisan","Mayıs","Haziran","Temmuz","Ağustos","Eylül","Ekim","Kasım","Aralık", NullS };
 static const char *my_locale_ab_month_names_tr_TR[13] = 
@@ -1940,7 +1940,7 @@ MY_LOCALE my_locale_tr_TR
 (
   52,
   "tr_TR",
-  "Turkish - Turkey",
+  "Turkish - Türkiye",
   FALSE,
   &my_locale_typelib_month_names_tr_TR,
   &my_locale_typelib_ab_month_names_tr_TR,


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30621*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

As requested to the UN the country formerly known as Turkey is to be refered to as Türkiye.

Reviewer: Alexander Barkov


## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
