### PR TITLE
MDEV-24538: JSON_LENGTH does not return error upon wrong number of parameters

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -1289,5 +1289,12 @@ JSON_LOOSE(JSON_EXTRACT(a, '$**.analyzing_range_alternatives'))
 [{"range_scan_alternatives": [{"index": "a_b", "ranges": ["2 <= a <= 2 AND 4 <= b <= 4", "123"], "rowid_ordered": true, "using_mrr": false, "index_only": true, "rows": 1, "cost": 1.1752, "chosen": true}], "analyzing_roworder_intersect": {"cause": "too few roworder scans"}, "analyzing_index_merge_union": [], "test_one_line_array": ["123"]}]
 drop table t200;
 #
+# MDEV-24538: JSON_LENGTH does not return error upon wrong number of parameters
+#
+SELECT JSON_LENGTH('{"a":"b"}','$','$', 'foo');
+ERROR 42000: Incorrect parameter count in the call to native function 'json_length'
+SELECT JSON_LENGTH();
+ERROR 42000: Incorrect parameter count in the call to native function 'JSON_LENGTH'
+#
 # End of 10.4 tests
 #

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -665,6 +665,7 @@ SELECT 1 + JSON_VALUE('{"nulltest": null}', '$.nulltest');
 SELECT NULL;
 SELECT JSON_EXTRACT('{"a":null, "b":10, "c":"null"}', '$.a');
 
+
 --echo #
 --echo # End of 10.3 tests
 --echo #
@@ -815,6 +816,14 @@ select JSON_DETAILED(JSON_EXTRACT(a, '$**.analyzing_range_alternatives')) from t
 select JSON_PRETTY(JSON_EXTRACT(a, '$**.analyzing_range_alternatives')) from t200;
 select JSON_LOOSE(JSON_EXTRACT(a, '$**.analyzing_range_alternatives')) from t200;
 drop table t200;
+
+--echo #
+--echo # MDEV-24538: JSON_LENGTH does not return error upon wrong number of parameters
+--echo #
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT JSON_LENGTH('{"a":"b"}','$','$', 'foo');
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT JSON_LENGTH();
 
 --echo #
 --echo # End of 10.4 tests

--- a/sql/item_jsonfunc.h
+++ b/sql/item_jsonfunc.h
@@ -310,6 +310,11 @@ class Item_func_json_length: public Item_long_func
 {
   bool check_arguments() const
   {
+    if (arg_count == 0 || arg_count > 2)
+    {
+      my_error(ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT, MYF(0), func_name());
+      return true;
+    }
     return args[0]->check_type_can_return_text(func_name()) ||
            (arg_count > 1 &&
             args[1]->check_type_general_purpose_string(func_name()));


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-24538*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
JSON_LENGTH does not return error upon wrong number of parameters
## How can this PR be tested?
The test is 'json_length.test'.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
