### PR TITLE
Fix mini-benchmark

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -331,6 +331,7 @@ mysql-test-run-asan:
   needs:
     - "fedora-sanitizer: [-DWITH_ASAN=YES]"
   <<: *mysql-test-run-def
+  allow_failure: true
   artifacts:
     when: always  # Also show results when tests fail
     reports:
@@ -489,6 +490,8 @@ mini-benchmark:
   stage: test
   dependencies:
     - fedora
+  needs:
+    - fedora
   script:
     - ls -la rpm; rm -vf rpm/*.el?.*  # Delete artifacts from Centos builds
     # Don't use cracklib, otherwise the Sysbench user password will be rejected
@@ -503,7 +506,7 @@ mini-benchmark:
     - |
       mariadb --skip-column-names -e "SELECT @@version, @@version_comment" | tee /tmp/version
       grep $MARIADB_MAJOR_VERSION /tmp/version || echo "MariaDB didn't install properly"
-    - yum install -y sysbench procps-ng perf || yum install -y https://kojipkgs.fedoraproject.org//packages/luajit/2.0.4/3.el7/x86_64/luajit-2.0.4-3.el7.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/sysbench/1.0.17/2.el7/x86_64/sysbench-1.0.17-2.el7.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/ck/0.5.2/2.el7/x86_64/ck-0.5.2-2.el7.x86_64.rpm
+    - yum install -y sysbench procps-ng perf util-linux || yum install -y https://kojipkgs.fedoraproject.org//packages/luajit/2.0.4/3.el7/x86_64/luajit-2.0.4-3.el7.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/sysbench/1.0.17/2.el7/x86_64/sysbench-1.0.17-2.el7.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/ck/0.5.2/2.el7/x86_64/ck-0.5.2-2.el7.x86_64.rpm
     - /usr/share/mysql/mini-benchmark
     - cp -av */sysbench-run-*.log */metrics.txt ..  # Move files one level down so they can be saved as artifacts
   artifacts:


### PR DESCRIPTION
## Description

The mini-benchmark.sh script failed to run in the latest Fedora
distributions in GitLab CI. It requires `lscpu` resolved by installing
util-linux.

Additionally, executing the benchmark inside a Docker container had
failed because of increased Docker security in recent updates. In
particular the `renice` and `taskset` operations are not permitted.
Neither are the required `perf` operations.
https://docs.docker.com/engine/security/seccomp/

Allow these operations to fail gracefully, and test then skip `perf`,
allowing the remaining benchmark activities to proceed.

Other minor changes to the CI are included such as allowing sanitizer
jobs to fail and using "needs" in the mini-benchmark pipeline.

## How can this PR be tested?
The pipeline for these changes successfully complete and a [public pipeline](https://salsa.debian.org/robinnewhouse/mariadb-server-mirror/-/pipelines/499774) is available.


## Basing the PR against the correct MariaDB version
- [x] *This is a (CI) bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

The mini-benchmark test was introduced in 10.8 (the latest development branch at the time), so this correction targets the earliest branch where there is a CI failure to be fixed.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer
Amazon Web Services, Inc.