### PR TITLE
MDEV-30646: View created via JSON_ARRAYAGG returns incorrect json object

### DIFF
--- a/mysql-test/main/func_json.result
+++ b/mysql-test/main/func_json.result
@@ -1635,5 +1635,18 @@ SELECT JSON_OBJECTAGG('\\', 1);
 JSON_OBJECTAGG('\\', 1)
 {"\\":1}
 #
+# MDEV-30646 View created via JSON_ARRAYAGG returns incorrect json object
+#
+CREATE VIEW v1 AS SELECT JSON_OBJECT(_LATIN1 'plugin', _LATIN1'unix_socket') as v1_json;
+SELECT JSON_ARRAYAGG(v1_json) FROM v1;
+JSON_ARRAYAGG(v1_json)
+["{"plugin": "unix_socket"}"]
+DROP VIEW v1;
+CREATE VIEW v1 AS SELECT JSON_OBJECT('plugin','unix_socket') as v1_json;
+SELECT JSON_ARRAYAGG(v1_json) FROM v1;
+JSON_ARRAYAGG(v1_json)
+["{"plugin": "unix_socket"}"]
+DROP VIEW v1;
+#
 # End of 10.5 tests
 #

--- a/mysql-test/main/func_json.test
+++ b/mysql-test/main/func_json.test
@@ -1076,6 +1076,18 @@ SELECT JSON_OBJECTAGG('\"', 1);
 SELECT JSON_OBJECTAGG('\\', 1);
 
 --echo #
+--echo # MDEV-30646 View created via JSON_ARRAYAGG returns incorrect json object
+--echo #
+
+CREATE VIEW v1 AS SELECT JSON_OBJECT(_LATIN1 'plugin', _LATIN1'unix_socket') as v1_json;
+SELECT JSON_ARRAYAGG(v1_json) FROM v1;
+DROP VIEW v1;
+
+CREATE VIEW v1 AS SELECT JSON_OBJECT('plugin','unix_socket') as v1_json;
+SELECT JSON_ARRAYAGG(v1_json) FROM v1;
+DROP VIEW v1;
+
+--echo #
 --echo # End of 10.5 tests
 --echo #
 

--- a/sql/item_jsonfunc.cc
+++ b/sql/item_jsonfunc.cc
@@ -3911,7 +3911,24 @@ int Arg_comparator::compare_e_json_str_basic(Item *j, Item *s)
 String *Item_func_json_arrayagg::get_str_from_item(Item *i, String *tmp)
 {
   m_tmp_json.length(0);
-  if (append_json_value(&m_tmp_json, i, tmp))
+  if (i->result_type() == STRING_RESULT)
+  {
+    String *sv= i->val_json(tmp);
+    if (i->null_value)
+    {
+      m_tmp_json.append("null", 4);
+      return &m_tmp_json;
+    }
+    if (is_json_type(i))
+      m_tmp_json.append(sv->ptr(), sv->length());
+    else if (m_tmp_json.append("\"", 1) ||
+             m_tmp_json.append(*sv) ||
+             m_tmp_json.append("\"", 1))
+    {
+      return NULL;
+    }
+  }
+  else if (append_json_value(&m_tmp_json, i, tmp))
     return NULL;
   return &m_tmp_json;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30646*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
View created via JSON_ARRAYAGG returns incorrect json object
## How can this PR be tested?
The tests are appended to `func_json.test`
<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
