### PR TITLE
MDEV-30630 locale: Chinese error messages for ZH_CN

### DIFF
--- a/mysql-test/main/locale.result
+++ b/mysql-test/main/locale.result
@@ -306,3 +306,13 @@ date_format('2001-01-06', '%w %a %W', 'de_CH')
 select date_format('2001-09-01', '%c %b %M', 'de_CH');
 date_format('2001-09-01', '%c %b %M', 'de_CH')
 9 Sep September
+#
+#  MDEV-30630 locale: Chinese error message for ZH_CN
+#
+SET lc_messages=ZH_CN;
+SELECT x;
+ERROR 42S22: 未知列'x'在'field list'
+SET lc_messages=DEFAULT;
+#
+# End of 10.4 tests
+#

--- a/mysql-test/main/locale.test
+++ b/mysql-test/main/locale.test
@@ -181,3 +181,17 @@ select date_format('2001-10-01', '%c %b %M', 'rm_CH');
 select date_format('2001-12-01', '%c %b %M', 'rm_CH');
 select date_format('2001-01-06', '%w %a %W', 'de_CH');
 select date_format('2001-09-01', '%c %b %M', 'de_CH');
+
+--echo #
+--echo #  MDEV-30630 locale: Chinese error message for ZH_CN
+--echo #
+
+SET lc_messages=ZH_CN;
+--error ER_BAD_FIELD_ERROR
+SELECT x;
+
+SET lc_messages=DEFAULT;
+
+--echo #
+--echo # End of 10.4 tests
+--echo #

--- a/mysql-test/suite/plugins/r/locales.result
+++ b/mysql-test/suite/plugins/r/locales.result
@@ -57,7 +57,7 @@ ID	NAME	DESCRIPTION	MAX_MONTH_NAME_LENGTH	MAX_DAY_NAME_LENGTH	DECIMAL_POINT	THOU
 53	uk_UA	Ukrainian - Ukraine	8	9	,	.	ukrainian
 54	ur_PK	Urdu - Pakistan	6	6	.	,	english
 55	vi_VN	Vietnamese - Vietnam	16	11	,	.	english
-56	zh_CN	Chinese - Peoples Republic of China	3	3	.	,	english
+56	zh_CN	Chinese - Peoples Republic of China	3	3	.	,	chinese
 57	zh_TW	Chinese - Taiwan	3	2	.	,	english
 58	ar_DZ	Arabic - Algeria	6	8	.	,	english
 59	ar_EG	Arabic - Egypt	6	8	.	,	english
@@ -170,7 +170,7 @@ Id	Name	Description	Error_Message_Language
 53	uk_UA	Ukrainian - Ukraine	ukrainian
 54	ur_PK	Urdu - Pakistan	english
 55	vi_VN	Vietnamese - Vietnam	english
-56	zh_CN	Chinese - Peoples Republic of China	english
+56	zh_CN	Chinese - Peoples Republic of China	chinese
 57	zh_TW	Chinese - Taiwan	english
 58	ar_DZ	Arabic - Algeria	english
 59	ar_EG	Arabic - Egypt	english

--- a/sql/sql_locale.cc
+++ b/sql/sql_locale.cc
@@ -29,7 +29,7 @@
 
 enum err_msgs_index
 {
-  en_US= 0, cs_CZ, da_DK, nl_NL, et_EE, fr_FR, de_DE, el_GR, hu_HU, it_IT,
+  en_US= 0, zh_CN, cs_CZ, da_DK, nl_NL, et_EE, fr_FR, de_DE, el_GR, hu_HU, it_IT,
   ja_JP, ko_KR, no_NO, nn_NO, pl_PL, pt_PT, ro_RO, ru_RU, sr_RS,  sk_SK,
   es_ES, sv_SE, uk_UA, hi_IN
 } ERR_MSGS_INDEX;
@@ -38,6 +38,7 @@ enum err_msgs_index
 MY_LOCALE_ERRMSGS global_errmsgs[]=
 {
   {"english", NULL},
+  {"chinese", NULL},
   {"czech", NULL},
   {"danish", NULL},
   {"dutch", NULL},
@@ -2095,7 +2096,7 @@ MY_LOCALE my_locale_zh_CN
   '.',        /* decimal point zh_CN */
   ',',        /* thousands_sep zh_CN */
   "\x03",     /* grouping      zh_CN */
-  &global_errmsgs[en_US]
+  &global_errmsgs[zh_CN]
 );
 /***** LOCALE END zh_CN *****/
 


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30630*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

MDEV-28227 added the error messages in simplified characters. Lets use these for those running a zh_CN profile.

From Haidong Ji in the MDEV, Taiwan/Hong Kong (zh_TW/zh_HK) would expect traditional characters so this is left for when we have these.

## How can this PR be tested?

plugin.locales tests.

```
mariadbd  --lc-messages=ZH_CN --lc-messages-dir=$PWD/sql/share/chinese
2023-02-15 10:44:32 0 [Note] sql/mysqld：已经准备好接受连接
Version：'10.4.29-MariaDB'套接字：'/tmp/build-mariadb-server-10.4.sock'端口：0 Source distribution
```

```
MariaDB [(none)]> select none;
ERROR 1054 (42S22): 未知列'none'在'field list'
MariaDB [(none)]> is this an error?;
ERROR 1064 (42000): 您的 SQL 语法有错误；请查看相关文档 附近'is this an error?'在第1行
MariaDB [(none)]> select version();
+-----------------+
| version()       |
+-----------------+
| 10.4.29-MariaDB |
+-----------------+
1 row in set (0.000 sec)
```

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility

Chinese error message would result where previously there wasn't. Application should be already relying on codes rather than text for errors.

## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
