### PR TITLE
MDEV-27317 wsrep_checkpoint order violation due to certification failure

### DIFF
--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -472,7 +472,13 @@ int Wsrep_high_priority_service::log_dummy_write_set(const wsrep::ws_handle& ws_
     if (!WSREP_EMULATE_BINLOG(m_thd))
     {
       wsrep_register_for_group_commit(m_thd);
-      ret = ret || cs.provider().commit_order_leave(ws_handle, ws_meta, err);
+      /* wait_for_prior_commit() ensures that all preceding transactions
+         have been committed and seqno has been synced into
+         storage engine. We don't release commit order here yet to
+         avoid following transactions to sync seqno before
+         wsrep_set_SE_checkpoint() below returns. This effectively pauses
+         group commit for the checkpoint operation, but is the only way to
+         ensure proper ordering. */
       m_thd->wait_for_prior_commit();
     }
 
@@ -482,10 +488,7 @@ int Wsrep_high_priority_service::log_dummy_write_set(const wsrep::ws_handle& ws_
     {
       wsrep_unregister_from_group_commit(m_thd);
     }
-    else
-    {
-      ret= ret || cs.provider().commit_order_leave(ws_handle, ws_meta, err);
-    }
+    ret= ret || cs.provider().commit_order_leave(ws_handle, ws_meta, err);
     cs.after_applying();
   }
   DBUG_RETURN(ret);


### PR DESCRIPTION
With binlogs enabled, debug assertion ut_ad(xid_seqno > wsrep_seqno) fired in trx_rseg_update_wsrep_checkpoint() when an applier thread synced the seqno out of order for write set which had failed certification. This was caused by releasing commit order too early when binlogs were on, allowing group commit to run in parallel and commit following transactions too early.

Fixed by extending the commit order critical section to cover call to wsrep_set_SE_checkpoint() also when binlogs are on.

---

Note that even though MDEV-27317 was opened against 10.6, this issue was reproducible with versions 10.4 and above, and therefore opening this PR against 10.4.