### PR TITLE
MDEV-30713 field length handling for CONNECT engine

### DIFF
--- a/storage/connect/catalog.h
+++ b/storage/connect/catalog.h
@@ -39,9 +39,9 @@ typedef struct _colinfo {
   PCSZ   Name;
   int    Type;
   int    Offset;
-  int    Length;
+  unsigned    Length;
   int    Key;
-  int    Precision;
+  unsigned    Precision;
   int    Scale;
   int    Opt;
   int    Freq;

--- a/storage/connect/ha_connect.cc
+++ b/storage/connect/ha_connect.cc
@@ -1618,10 +1618,7 @@ void *ha_connect::GetColumnOption(PGLOBAL g, void *field, PCOLINFO pcf)
   pcf->Scale= 0;
   pcf->Opt= (fop) ? (int)fop->opt : 0;
 
-	if (fp->field_length >= 0)
-		pcf->Length= fp->field_length;
-	else
-		pcf->Length= 256;            // BLOB?
+  pcf->Length= fp->field_length;
 
   pcf->Precision= pcf->Length;
 

--- a/storage/connect/tabext.cpp
+++ b/storage/connect/tabext.cpp
@@ -466,7 +466,7 @@ bool TDBEXT::MakeSQL(PGLOBAL g, bool cnt)
 
 	if (Quote) {
 		// Tabname can have both database and table identifiers, we need to parse
-		if (res= strstr(buf, "."))
+		if ((res= strstr(buf, ".")))
 		{
 			// Parse schema
 			my_len= res - buf + 1;

--- a/storage/connect/value.cpp
+++ b/storage/connect/value.cpp
@@ -163,9 +163,9 @@ PCSZ GetTypeName(int type)
 /***********************************************************************/
 /*  GetTypeSize: returns the PlugDB internal type size.                */
 /***********************************************************************/
-int GetTypeSize(int type, int len)
-  {
-	switch (type) {
+unsigned GetTypeSize(int type, unsigned len)
+{
+  switch (type) {
     case TYPE_DECIM:
     case TYPE_BIN:
     case TYPE_STRING: len = len * sizeof(char); break;
@@ -176,7 +176,7 @@ int GetTypeSize(int type, int len)
     case TYPE_DOUBLE: len = sizeof(double);     break;
     case TYPE_TINY:   len = sizeof(char);       break;
     case TYPE_PCHAR:  len = sizeof(char*);      break;
-    default:          len = -1;
+    default:          len = 0;
   } // endswitch type
 
   return len;

--- a/storage/connect/value.h
+++ b/storage/connect/value.h
@@ -41,7 +41,7 @@ typedef struct _datpar *PDTP;         // For DTVAL
 /***********************************************************************/
 // Exported functions
 DllExport PCSZ  GetTypeName(int);
-DllExport int   GetTypeSize(int, int);
+DllExport unsigned   GetTypeSize(int, unsigned);
 #ifdef ODBC_SUPPORT
 /* This function is exported for use in OEM table type DLLs */
 DllExport int   TranslateSQLType(int stp, int prec, 


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30713*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

fp->field_length was unsigned and therefore the negative condition around it.

Backport of cc182aca9352 fixes it, however to correct the consistent use of types pcf->Length needs to be unsigned too.

At one point pcf->Precision is assigned from pcf->Length so that's also unsigned.

GetTypeSize is assigned to length and has a length argument. A -1 default value seemed dangerious to case, so at least 0 should assert if every hit.

## How can this PR be tested?

Existing test suite. Look at warnings generated.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

Hoping the -1 -> 0 change in GetType doesn't cascade to a meaningful change.

## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
