### PR TITLE
Fix compiler warnings

### DIFF
--- a/storage/connect/libdoc.cpp
+++ b/storage/connect/libdoc.cpp
@@ -600,7 +600,7 @@ xmlNodeSetPtr LIBXMLDOC::GetNodeList(PGLOBAL g, xmlNodePtr np, char *xp)
     if (trace(1))
       htrc("Calling xmlPathInit\n");
 
-    xmlXPathInit();
+    xmlInitParser();
 
     if (trace(1))
       htrc("Calling xmlXPathNewContext Docp=%p\n", Docp);

--- a/storage/connect/tabext.cpp
+++ b/storage/connect/tabext.cpp
@@ -330,7 +330,7 @@ bool TDBEXT::MakeSrcdef(PGLOBAL g)
 	char *catp = strstr(Srcdef, "%s");
 
 	if (catp) {
-		char *fil1 = 0, *fil2;
+		char *fil1 = 0, *fil2 = 0;
 		PCSZ  ph = ((EXTDEF*)To_Def)->Phpos;
 
 		if (!ph)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
gcc-12.2.1 emits following warnings and are fixed:

`-Wdeprecated-declarations`:
- storage/connect/libdoc.cpp

`-Wmaybe-uninitialized`:
- storage/connect/tabext.cpp

This is based on logs building in a Fedora 37 container, and the CMake options being used was:
```
-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DPLUGIN_TOKUDB=NO -DPLUGIN_MROONGA=NO -DPLUGIN_SPIDER=NO -DPLUGIN_OQGRAPH=NO -DPLUGIN_PERFSCHEMA=YES -DPLUGIN_SPHINX=NO
```
which also aligned with builder bot (except ccache).

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.

## How can this PR be tested?

Two tests were executed:
- build the source code and see if there's any warning
- run `./mtr --suite=main --force --parallel=auto` to find any regressions

and both passed.

This PR doesn't introduce any feature or behaviour changes so no new test is needed.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.