### PR TITLE
MDEV-24392 Added support for EXECUTE_IMMEDIATE command when empty str…

### DIFF
--- a/mysql-test/main/ps.result
+++ b/mysql-test/main/ps.result
@@ -5801,5 +5801,10 @@ END;
 $
 ERROR 42000: EXECUTE..USING does not support subqueries or stored functions
 #
+# MDEV-24392: execute immediate '/* do nothing */' not supported 
+# Testing for the 'EXECUTE IMMEDIATE' statement when passing an empty query
+#
+EXECUTE IMMEDIATE '/* nothing */';
+#
 # End of 10.4 tests
 #

--- a/mysql-test/main/ps.test
+++ b/mysql-test/main/ps.test
@@ -5225,5 +5225,11 @@ $
 delimiter ;$
 
 --echo #
+--echo # MDEV-24392: execute immediate '/* do nothing */' not supported 
+--echo # Testing for the 'EXECUTE IMMEDIATE' statement when passing an empty query
+--echo #
+EXECUTE IMMEDIATE '/* nothing */';
+
+--echo #
 --echo # End of 10.4 tests
 --echo #

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -2616,6 +2616,7 @@ static bool check_prepared_statement(Prepared_statement *stmt)
   case SQLCOM_KILL:
   case SQLCOM_COMPOUND:
   case SQLCOM_SHUTDOWN:
+  case SQLCOM_EMPTY_QUERY:
     break;
 
   case SQLCOM_PREPARE:


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-24392*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: Handled the case when passing a comment inside the EXECUTE_IMMEDIATE command  throws an error : 
`ERROR 1243 (HY000): Unknown prepared statement handler (immediate) given to EXECUTE`

Modified the default behaviour of an unknown prepared_statement to throw error message when comments are passed inside the EXECUTE_STATEMENT command. Another workaround could be to handle the passed sql_command in the switch case but 
couldn't find anything suitable for comments in sql/sql_cmd.h file. 

## How can this PR be tested?

Test and Result files are added to the mysql-test dir.
This PR can be tested by running : `./mtr execute_immediate_empty`

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: ------

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
