### PR TITLE
MDEV-24005 Updated the --use-memory option usage message in Mariaback…

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -1088,7 +1088,8 @@ struct my_option xb_client_options[]= {
      (G_PTR *) &xtrabackup_print_param, (G_PTR *) &xtrabackup_print_param, 0,
      GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
     {"use-memory", OPT_XTRA_USE_MEMORY,
-     "The value is used instead of buffer_pool_size",
+     "The value is used in place of innodb_buffer_pool_size. "
+     "This option is only relevant when the --prepare option is specified.",
      (G_PTR *) &xtrabackup_use_memory, (G_PTR *) &xtrabackup_use_memory, 0,
      GET_LL, REQUIRED_ARG, 100 * 1024 * 1024L, 1024 * 1024L, LONGLONG_MAX, 0,
      1024 * 1024L, 0},


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-24005*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

The  --use-memory option is only relevant when performing a --prepare. The usage message is updated accordingly in this PR as it was not descriptive previously.

Previous:
```
debjyoti@d3viL3cho:~/build-mariadb-server-debug$ extra/mariabackup/mariabackup --help | grep use-memory -2
  --print-param       print parameter of mysqld needed for copyback.
  --use-memory=#      The value is used instead of buffer_pool_size
  --throttle=#        limit count of IO operations (pairs of read&write) per
```

Now : 
```
debjyoti@d3viL3cho:~/original-server/build-10.4$ extra/mariabackup/mariabackup --help | grep use-memory -2
  --print-param       print parameter of mysqld needed for copyback.
  --use-memory=#      The value is used in place of innodb_buffer_pool_size.
                      This option is only relevant when the --prepare option is
                      specified.
```


## How can this PR be tested?
NA

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
