### PR TITLE
MDEV-23000: Ensure we get a warning from THD::drop_temporary_table() in case of disk errors 

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5050,7 +5050,7 @@ private:
   bool use_temporary_table(TABLE *table, TABLE **out_table);
   void close_temporary_table(TABLE *table);
   bool log_events_and_free_tmp_shares();
-  void free_tmp_table_share(TMP_TABLE_SHARE *share, bool delete_table);
+  bool free_tmp_table_share(TMP_TABLE_SHARE *share, bool delete_table);
   void free_temporary_table(TABLE *table);
   bool lock_temporary_tables();
   void unlock_temporary_tables();

--- a/sql/temporary_tables.cc
+++ b/sql/temporary_tables.cc
@@ -670,7 +670,7 @@ bool THD::drop_temporary_table(TABLE *table, bool *is_trans, bool delete_table)
   temporary_tables->remove(share);
 
   /* Free the TABLE_SHARE and/or delete the files. */
-  free_tmp_table_share(share, delete_table);
+  result= free_tmp_table_share(share, delete_table);
 
 end:
   if (locked)
@@ -1455,20 +1455,21 @@ bool THD::log_events_and_free_tmp_shares()
   @param share [IN]                   TABLE_SHARE to free
   @param delete_table [IN]            Whether to delete the table files?
 
-  @return void
+  @return false                       Success
+          true                        Error
 */
-void THD::free_tmp_table_share(TMP_TABLE_SHARE *share, bool delete_table)
+bool THD::free_tmp_table_share(TMP_TABLE_SHARE *share, bool delete_table)
 {
+  bool error= false;
   DBUG_ENTER("THD::free_tmp_table_share");
 
   if (delete_table)
   {
-    rm_temporary_table(share->db_type(), share->path.str);
+    error= rm_temporary_table(share->db_type(), share->path.str);
   }
   free_table_share(share);
   my_free(share);
-
-  DBUG_VOID_RETURN;
+  DBUG_RETURN(error);
 }
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-23000*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

## How can this PR be tested?
<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.