### PR TITLE
MDEV-24931: Assertion `prefix_size <= width' failed in Bitmap<width>::is_prefix(uint) & UBSAN: shift exponent 32 is too large for 32-bit type 'int' in generate_derived_keys_for_table

### DIFF
--- a/mysql-test/main/join.result
+++ b/mysql-test/main/join.result
@@ -3406,4 +3406,23 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t3	ref	a	a	5	test.t2.key2	1	
 drop table t1,t2,t3;
 drop table t1000,t10,t03;
+#
+# MDEV-24931: Assertion `prefix_size <= width' failed
+#
+CREATE TABLE t1 (
+f01 int, f02 int, f03 int, f04 int, f05 int, f06 int, f07 int, f08 int,
+f09 int, f10 int, f11 int, f12 int, f13 int, f14 int, f15 int, f16 int,
+f17 int, f18 int, f19 int, f20 int, f21 int, f22 int, f23 int, f24 int,
+f25 int, f26 int, f27 int, f28 int, f29 int, f30 int, f31 int, f32 int,
+f33 int, f34 int, f35 int, f36 int, f37 int, f38 int, f39 int, f40 int,
+f41 int, f42 int, f43 int, f44 int, f45 int, f46 int, f47 int, f48 int,
+f49 int, f50 int, f51 int, f52 int, f53 int, f54 int, f55 int, f56 int,
+f57 int, f58 int, f59 int, f60 int, f61 int, f62 int, f63 int, f64 int,
+f65 int);
+CREATE ALGORITHM=TEMPTABLE VIEW v1 AS SELECT * FROM t1;
+INSERT INTO t1 VALUES (),();
+SELECT * FROM v1 NATURAL JOIN t1;
+f01	f02	f03	f04	f05	f06	f07	f08	f09	f10	f11	f12	f13	f14	f15	f16	f17	f18	f19	f20	f21	f22	f23	f24	f25	f26	f27	f28	f29	f30	f31	f32	f33	f34	f35	f36	f37	f38	f39	f40	f41	f42	f43	f44	f45	f46	f47	f48	f49	f50	f51	f52	f53	f54	f55	f56	f57	f58	f59	f60	f61	f62	f63	f64	f65
+DROP VIEW v1;
+DROP TABLE t1;
 # End of 10.3 tests

--- a/mysql-test/main/join.test
+++ b/mysql-test/main/join.test
@@ -1819,4 +1819,28 @@ WHERE
 drop table t1,t2,t3;
 drop table t1000,t10,t03;
 
+--echo #
+--echo # MDEV-24931: Assertion `prefix_size <= width' failed
+--echo #
+
+CREATE TABLE t1 (
+  f01 int, f02 int, f03 int, f04 int, f05 int, f06 int, f07 int, f08 int,
+  f09 int, f10 int, f11 int, f12 int, f13 int, f14 int, f15 int, f16 int,
+  f17 int, f18 int, f19 int, f20 int, f21 int, f22 int, f23 int, f24 int,
+  f25 int, f26 int, f27 int, f28 int, f29 int, f30 int, f31 int, f32 int,
+  f33 int, f34 int, f35 int, f36 int, f37 int, f38 int, f39 int, f40 int,
+  f41 int, f42 int, f43 int, f44 int, f45 int, f46 int, f47 int, f48 int,
+  f49 int, f50 int, f51 int, f52 int, f53 int, f54 int, f55 int, f56 int,
+  f57 int, f58 int, f59 int, f60 int, f61 int, f62 int, f63 int, f64 int,
+  f65 int);
+
+CREATE ALGORITHM=TEMPTABLE VIEW v1 AS SELECT * FROM t1;
+INSERT INTO t1 VALUES (),();
+
+SELECT * FROM v1 NATURAL JOIN t1;
+
+# Cleanup
+DROP VIEW v1;
+DROP TABLE t1;
+
 --echo # End of 10.3 tests

--- a/sql/sql_bitmap.h
+++ b/sql/sql_bitmap.h
@@ -142,9 +142,9 @@ public:
   }
   bool is_prefix(uint prefix_size) const
   {
-    DBUG_ASSERT(prefix_size <= width);
-
     size_t idx= prefix_size / BITS_PER_ELEMENT;
+
+    DBUG_ASSERT(idx <= ARRAY_ELEMENTS);
 
     for (size_t i= 0; i < idx; i++)
       if (buffer[i] != ALL_BITS_SET)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-24931*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description


## How can this PR be tested?
The test is append to `join.test`

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
