### PR TITLE
 Minimize unsafe C functions usage - replace sprintf() and strcpy()

### DIFF
--- a/libmysqld/libmysql.c
+++ b/libmysqld/libmysql.c
@@ -2914,7 +2914,8 @@ my_bool STDCALL mysql_stmt_bind_param(MYSQL_STMT *stmt, MYSQL_BIND *my_bind)
       break;
     default:
       strmov(stmt->sqlstate, unknown_sqlstate);
-      sprintf(stmt->last_error,
+      snprintf(stmt->last_error,
+        sizeof(stmt->last_error),
 	      ER(stmt->last_errno= CR_UNSUPPORTED_PARAM_TYPE),
 	      param->buffer_type, count);
       DBUG_RETURN(1);
@@ -3001,7 +3002,9 @@ mysql_stmt_send_long_data(MYSQL_STMT *stmt, uint param_number,
   {
     /* Long data handling should be used only for string/binary types */
     strmov(stmt->sqlstate, unknown_sqlstate);
-    sprintf(stmt->last_error, ER(stmt->last_errno= CR_INVALID_BUFFER_USE),
+    snprintf(stmt->last_error,
+      sizeof(stmt->last_error),
+      ER(stmt->last_errno= CR_INVALID_BUFFER_USE),
 	    param->param_number);
     DBUG_RETURN(1);
   }
@@ -4130,7 +4133,8 @@ my_bool STDCALL mysql_stmt_bind_result(MYSQL_STMT *stmt, MYSQL_BIND *my_bind)
     if (setup_one_fetch_function(param, field))
     {
       strmov(stmt->sqlstate, unknown_sqlstate);
-      sprintf(stmt->last_error,
+      snprintf(stmt->last_error,
+              sizeof(stmt->last_error),
               ER(stmt->last_errno= CR_UNSUPPORTED_PARAM_TYPE),
               field->type, param_count);
       DBUG_RETURN(1);

--- a/mysys/my_atomic_writes.c
+++ b/mysys/my_atomic_writes.c
@@ -112,7 +112,7 @@ static my_bool test_if_shannon_card_exists()
     char path[32];
     struct stat stat_buff;
 
-    sprintf(path, "/dev/df%c", dev_part);
+    snprintf(path, sizeof(path), "/dev/df%c", dev_part);
 #ifdef TEST_SHANNON
     if (lstat(path, &stat_buff) < 0)
     {
@@ -121,8 +121,10 @@ static my_bool test_if_shannon_card_exists()
     }
 #endif
     shannon_devices[shannon_found_devices].st_dev= stat_buff.st_rdev;
-    sprintf(shannon_devices[shannon_found_devices].dev_name, "/dev/sct%c",
-            dev_part);
+    snprintf(shannon_devices[shannon_found_devices].dev_name,
+             sizeof(shannon_devices[shannon_found_devices].dev_name),
+             "/dev/sct%c",
+             dev_part);
 
 #ifdef TEST_SHANNON
     printf("%s(): i=%d, stat_buff.st_dev=0x%lx, stat_buff.st_rdev=0x%lx, st_rdev=0x%lx, dev_name=%s\n",
@@ -145,13 +147,15 @@ static my_bool test_if_shannon_card_exists()
 
     for (dev_no= 1 ; dev_no < 9 ; dev_no++)
     {
-      sprintf(path, "/dev/df%c%d", dev_part, dev_no);
+      snprintf(path, sizeof(path), "/dev/df%c%d", dev_part, dev_no);
       if (lstat(path, &stat_buff) < 0)
         break;
 
       shannon_devices[shannon_found_devices].st_dev= stat_buff.st_rdev;
-      sprintf(shannon_devices[shannon_found_devices].dev_name, "/dev/sct%c%d",
-              dev_part, dev_no);
+      snprintf(shannon_devices[shannon_found_devices].dev_name,
+               sizeof(shannon_devices[shannon_found_devices].dev_name),
+               "/dev/sct%c%d",
+               dev_part, dev_no);
 
 #ifdef TEST_SHANNON
       printf("%s(): i=%d, st_dev=0x%lx, st_rdev=0x%lx, dev_name=%s\n",

--- a/mysys/my_conio.c
+++ b/mysys/my_conio.c
@@ -50,7 +50,7 @@ int my_pthread_auto_mutex_lock(HANDLE* ph, const char* name, int id, int time)
   DWORD res;
   char tname[FN_REFLEN];
   
-  sprintf(tname, "%s-%08X", name, id);
+  snprintf(tname, sizeof(tname), "%s-%08X", name, id);
   
   *ph= CreateMutex(NULL, FALSE, tname);
   if (*ph == NULL)

--- a/mysys/my_likely.c
+++ b/mysys/my_likely.c
@@ -77,7 +77,7 @@ void end_my_likely(FILE *out)
   if (!(likely_file= out))
   {
     char name[80];
-    sprintf(name, "/tmp/unlikely-%lu.out", (ulong) getpid());
+    snprintf(name, sizeof(name), "/tmp/unlikely-%lu.out", (ulong) getpid());
     if ((likely_file= my_fopen(name, O_TRUNC | O_WRONLY, MYF(MY_WME))))
       do_close= 1;
     else

--- a/mysys/my_thr_init.c
+++ b/mysys/my_thr_init.c
@@ -426,7 +426,7 @@ const char *my_thread_name(void)
   if (!tmp->name[0])
   {
     my_thread_id id= my_thread_dbug_id();
-    sprintf(name_buff,"T@%lu", (ulong) id);
+    snprintf(name_buff, sizeof(name_buff), "T@%lu", (ulong) id);
     strmake_buf(tmp->name, name_buff);
   }
   return tmp->name;

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -4164,7 +4164,7 @@ int STDCALL mysql_set_character_set(MYSQL *mysql, const char *cs_name)
     /* Skip execution of "SET NAMES" for pre-4.1 servers */
     if (mysql_get_server_version(mysql) < 40100)
       return 0;
-    sprintf(buff, "SET NAMES %s", cs_name);
+    snprintf(buff, sizeof(buff),  "SET NAMES %s", cs_name);
     if (!mysql_real_query(mysql, buff, (uint) strlen(buff)))
     {
       mysql->charset= cs;

--- a/strings/conf_to_src.c
+++ b/strings/conf_to_src.c
@@ -459,7 +459,7 @@ main(int argc, char **argv  __attribute__((unused)))
   bzero((void*)&all_charsets,sizeof(all_charsets));
   bzero((void*) refids, sizeof(refids));
   
-  sprintf(filename,"%s/%s",argv[1],"Index.xml");
+  snprintf(filename,sizeof(filename),"%s/%s",argv[1],"Index.xml");
   my_read_charset_file(filename);
   
   for (cs= all_charsets;
@@ -470,7 +470,7 @@ main(int argc, char **argv  __attribute__((unused)))
     {
       if ( (!simple_cs_is_full(cs)) && (cs->csname))
       {
-        sprintf(filename,"%s/%s.xml",argv[1],cs->csname);
+        snprintf(filename,sizeof(filename),"%s/%s.xml",argv[1],cs->csname);
         my_read_charset_file(filename);
       }
       cs->state|= MY_CS_LOADED;

--- a/strings/uctypedump.c
+++ b/strings/uctypedump.c
@@ -120,7 +120,7 @@ int main(int ac, char ** av)
       }
       else
       {
-        strcpy(tok,s);
+        safe_strcpy(tok, sizeof(tok), s);
       }
       
       end=tok+strlen(tok);
@@ -225,7 +225,7 @@ int main(int ac, char ** av)
   {
     char plane_name[128]="NULL";
     if(uctype[plane].ctype){
-      sprintf(plane_name,"uctype_page%02X",(uint) plane);
+      snprintf(plane_name,sizeof(plane_name),"uctype_page%02X",(uint) plane);
     }
     printf("\t{%d,%s}%s\n",uctype[plane].pctype,plane_name,plane<255?",":"");
   }

--- a/strings/xml.c
+++ b/strings/xml.c
@@ -304,10 +304,10 @@ static int my_xml_leave(MY_XML_PARSER *p, const char *str, size_t slen)
     if (glen)
     {
       mstr(g, tag, sizeof(g)-1, glen);
-      sprintf(p->errstr,"'</%s>' unexpected ('</%s>' wanted)",s,g);
+      snprintf(p->errstr,sizeof(p->errstr),"'</%s>' unexpected ('</%s>' wanted)",s,g);
     }
     else
-      sprintf(p->errstr,"'</%s>' unexpected (END-OF-INPUT wanted)", s);
+      snprintf(p->errstr,sizeof(p->errstr),"'</%s>' unexpected (END-OF-INPUT wanted)", s);
     return MY_XML_ERROR;
   }
   
@@ -362,7 +362,7 @@ int my_xml_parse(MY_XML_PARSER *p,const char *str, size_t len)
       {
         if (MY_XML_IDENT != (lex=my_xml_scan(p,&a)))
         {
-          sprintf(p->errstr,"%s unexpected (ident wanted)",lex2str(lex));
+          snprintf(p->errstr,sizeof(p->errstr),"%s unexpected (ident wanted)",lex2str(lex));
           return MY_XML_ERROR;
         }
         if (MY_XML_OK != my_xml_leave(p,a.beg,(size_t) (a.end-a.beg)))
@@ -390,7 +390,7 @@ int my_xml_parse(MY_XML_PARSER *p,const char *str, size_t len)
       }
       else
       {
-        sprintf(p->errstr,"%s unexpected (ident or '/' wanted)",
+        snprintf(p->errstr,sizeof(p->errstr),"%s unexpected (ident or '/' wanted)",
 		lex2str(lex));
         return MY_XML_ERROR;
       }
@@ -412,7 +412,7 @@ int my_xml_parse(MY_XML_PARSER *p,const char *str, size_t len)
           }
           else
           {
-            sprintf(p->errstr,"%s unexpected (ident or string wanted)",
+            snprintf(p->errstr,sizeof(p->errstr),"%s unexpected (ident or string wanted)",
 		    lex2str(lex));
             return MY_XML_ERROR;
           }
@@ -449,7 +449,7 @@ gt:
       {
         if (lex != MY_XML_QUESTION)
         {
-          sprintf(p->errstr,"%s unexpected ('?' wanted)",lex2str(lex));
+          snprintf(p->errstr,sizeof(p->errstr),"%s unexpected ('?' wanted)",lex2str(lex));
           return MY_XML_ERROR;
         }
         if (MY_XML_OK != my_xml_leave(p,NULL,0))
@@ -465,7 +465,7 @@ gt:
       
       if (lex != MY_XML_GT)
       {
-        sprintf(p->errstr,"%s unexpected ('>' wanted)",lex2str(lex));
+        snprintf(p->errstr,sizeof(p->errstr),"%s unexpected ('>' wanted)",lex2str(lex));
         return MY_XML_ERROR;
       }
     }
@@ -486,7 +486,7 @@ gt:
 
   if (p->attr.start[0])
   {
-    sprintf(p->errstr,"unexpected END-OF-INPUT");
+    snprintf(p->errstr,sizeof(p->errstr),"unexpected END-OF-INPUT");
     return MY_XML_ERROR;
   }
   return MY_XML_OK;


### PR DESCRIPTION
## Description
Replace calls to `sprintf` and `strcpy` by the safer options `snprintf` and `safe_strcpy` in the following directories:

- libmysqld
- mysys
- sql-common
- strings

## How can this PR be tested?

All build stages pass for these commits. For the commit without the intentional bug, mysql-test-run is properly passing. The changes are not change the functionality itself they just replace unsafe C methods with the safe ones.

## Basing the PR against the correct MariaDB version
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility
The changes fully backward compatible.

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.