### PR TITLE
MDEV-27126 my_getopt compares option names case sensitively

### DIFF
--- a/mysys/my_getopt.c
+++ b/mysys/my_getopt.c
@@ -23,6 +23,7 @@
 #include <mysys_err.h>
 #include <my_getopt.h>
 #include <errno.h>
+#include <ctype.h>
 
 typedef void (*init_func_p)(const struct my_option *option, void *variable,
                             longlong value);
@@ -967,8 +968,9 @@ my_bool getopt_compare_strings(register const char *s, register const char *t,
 
   for (;s != end ; s++, t++)
   {
-    if ((*s != '-' ? *s : '_') != (*t != '-' ? *t : '_'))
-      DBUG_RETURN(1);
+    if ((*s != '-' ? tolower((unsigned char)*s) : '_') !=
+        (*t != '-' ? tolower((unsigned char)*t) : '_'))
+        DBUG_RETURN(1);
   }
   DBUG_RETURN(0);
 }

--- a/mysys/my_getopt.c
+++ b/mysys/my_getopt.c
@@ -953,11 +953,11 @@ static int findopt(char *optpat, uint length,
 }
 
 
-/* 
+/*
   function: compare_strings
 
   Works like strncmp, other than 1.) considers '-' and '_' the same.
-  2.) Returns -1 if strings differ, 0 if they are equal
+  2.) Returns 1 if strings differ, 0 if they are equal
 */
 
 my_bool getopt_compare_strings(register const char *s, register const char *t,


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28616*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
make option name lookups and comparisons case insensitive
## How can this PR be tested?
I am not sure how to test this update.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
