### PR TITLE
MDEV-30810 errmsg-utf8.txt no longer uses charsets

### DIFF
--- a/extra/comp_err.c
+++ b/extra/comp_err.c
@@ -37,7 +37,7 @@
 #define ERRORS_PER_RANGE 1000
 #define MAX_SECTIONS 4
 #define HEADER_LENGTH 32                /* Length of header in errmsg.sys */
-#define ERRMSG_VERSION 4                /* Version number of errmsg.sys */
+#define ERRMSG_VERSION 5                /* Version number of errmsg.sys */
 #define DEFAULT_CHARSET_DIR "../sql/share/charsets"
 #define ER_PREFIX "ER_"
 #define ER_PREFIX2 "MARIA_ER_"
@@ -85,7 +85,6 @@ struct languages
 {
   char *lang_long_name;				/* full name of the language */
   char *lang_short_name;			/* abbreviation of the lang. */
-  char *charset;				/* Character set name */
   struct languages *next_lang;			/* Pointer to next language */
 };
 
@@ -329,7 +328,7 @@ static int create_sys_files(struct languages *lang_head,
                             uint error_count)
 {
   FILE *to;
-  uint csnum= 0, i, row_nr;
+  uint i, row_nr;
   ulong length;
   uchar head[HEADER_LENGTH];
   char outfile[FN_REFLEN], *outfile_end;
@@ -345,16 +344,6 @@ static int create_sys_files(struct languages *lang_head,
   */
   for (tmp_lang= lang_head; tmp_lang; tmp_lang= tmp_lang->next_lang)
   {
-
-    /* setting charset name */
-    if (!(csnum= get_charset_number(tmp_lang->charset, MY_CS_PRIMARY,
-                                    MYF(MY_UTF8_IS_UTF8MB3))))
-    {
-      fprintf(stderr, "Unknown charset '%s' in '%s'\n", tmp_lang->charset,
-	      TXTFILE);
-      DBUG_RETURN(1);
-    }
-
     outfile_end= strxmov(outfile, DATADIRECTORY, 
                          tmp_lang->lang_long_name, NullS);
     if (!my_stat(outfile, &stat_info,MYF(0)))
@@ -410,7 +399,6 @@ static int create_sys_files(struct languages *lang_head,
     int2store(head + 10, max_error);            /* Max error */
     int2store(head + 12, row_nr);
     int2store(head + 14, section_count);
-    head[30]= csnum;
 
     my_fseek(to, 0l, MY_SEEK_SET, MYF(0));
     if (my_fwrite(to, (uchar*) head, HEADER_LENGTH, MYF(MY_WME | MY_FNABP)) ||
@@ -450,7 +438,6 @@ static void clean_up(struct languages *lang_head, struct errors *error_head)
     next_language= tmp_lang->next_lang;
     my_free(tmp_lang->lang_short_name);
     my_free(tmp_lang->lang_long_name);
-    my_free(tmp_lang->charset);
     my_free(tmp_lang);
   }
 
@@ -1112,12 +1099,6 @@ static struct languages *parse_charset_string(char *str)
     if (!(new_lang->lang_short_name= get_word(&str)))
       DBUG_RETURN(0);				/* OOM: Fatal error */
     DBUG_PRINT("info", ("short_name: %s", new_lang->lang_short_name));
-
-    /* getting the charset name */
-    str= skip_delimiters(str);
-    if (!(new_lang->charset= get_word(&str)))
-      DBUG_RETURN(0);				/* Fatal error */
-    DBUG_PRINT("info", ("charset: %s", new_lang->charset));
 
     /* skipping space, tab or "," */
     str= skip_delimiters(str);

--- a/sql/derror.cc
+++ b/sql/derror.cc
@@ -258,7 +258,7 @@ static File open_error_msg_file(const char *file_name, const char *language,
     goto err;
   error_pos=2;
   if (head[0] != (uchar) 254 || head[1] != (uchar) 254 ||
-      head[2] != 2 || head[3] != 4)
+      head[2] != 2 || head[3] != 5)
     goto err; /* purecov: inspected */
 
   ret->text_length= uint4korr(head+6);

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -1,4 +1,4 @@
-languages bulgarian=bgn cp1251, chinese=chi gbk, czech=cze latin2, danish=dan latin1, dutch=nla latin1, english=eng latin1, estonian=est latin7, french=fre latin1, georgian=geo utf8mb3, german=ger latin1, greek=greek greek, hindi=hindi utf8mb3, hungarian=hun latin2, italian=ita latin1, japanese=jpn ujis, korean=kor euckr, norwegian-ny=norwegian-ny latin1, norwegian=nor latin1, polish=pol latin2, portuguese=por latin1, romanian=rum latin2, russian=rus koi8r, serbian=serbian cp1250, slovak=slo latin2, spanish=spa latin1, swedish=swe latin1, ukrainian=ukr koi8u;
+languages bulgarian=bgn, chinese=chi, czech=cze, danish=dan, dutch=nla, english=eng, estonian=est, french=fre, georgian=geo, german=ger, greek=greek, hindi=hindi, hungarian=hun, italian=ita, japanese=jpn, korean=kor, norwegian-ny=norwegian-ny, norwegian=nor, polish=pol, portuguese=por, romanian=rum, russian=rus, serbian=serbian, slovak=slo, spanish=spa, swedish=swe, ukrainian=ukr;
 
 default-language eng
 


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30810*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Charset names in the 'languages' line are not used any more.

Removing to avoid confusion.

All messages in errmsg-utf8.txt are in utf8 now.

Charset names should have been removed in MySQL-5.5 during: https://dev.mysql.com/worklog/task/?id=751

Bump version number.

## How can this PR be tested?

Sufficient mtr tests cases around error messages /locales as updated in previous 10.11 commit.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

Its on 10.11 for ease of review (lack of merge conflicts with previous commit). Might need to go to 11.0 / 11.1.

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

Bumping version number means errmsg.sys cannot be used on older versions.

## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
