### PR TITLE
MDEV-30811: fail to compile 11.0 on MacOS

### DIFF
--- a/mysys/my_init.c
+++ b/mysys/my_init.c
@@ -191,8 +191,9 @@ my_bool my_init(void)
       int res= 1;
 #ifdef EXE_LINKPATH
       res= my_readlink(link_name, EXE_LINKPATH, MYF(0));
+#else res = my_readlink(link_name, my_progname, MYF(0));
 #endif
-      if ((res == 0 || my_readlink(link_name, my_progname, MYF(0)) == 0) &&
+      if (res == 0 &&
            strncmp(link_name + dirname_length(link_name), "mariadb", 7) == 0)
       my_error(EE_NAME_DEPRECATED, MYF(MY_WME), link_name);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30811*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Failed to compile 11.0 on MacOS Monterey, 12.5.1, ARM architecture, clang version 15.0.3.


## How can this PR be tested?
This is a specific issue on MacOS, so it is hard to be tested.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
