### PR TITLE
MDEV-13915: STOP SLAVE takes very long time on a busy system

### DIFF
--- a/mysql-test/suite/binlog_encryption/rpl_parallel.result
+++ b/mysql-test/suite/binlog_encryption/rpl_parallel.result
@@ -742,7 +742,6 @@ a	b
 61	61
 62	62
 63	63
-64	64
 68	68
 69	69
 70	70
@@ -827,6 +826,8 @@ SET binlog_format=@old_format;
 connection server_2;
 SET debug_sync='RESET';
 include/start_slave.inc
+SET debug_sync='now WAIT_FOR query_waiting';
+SET debug_sync='now SIGNAL query_cont';
 SELECT * FROM t3 WHERE a >= 80 ORDER BY a;
 a	b
 80	0
@@ -1055,7 +1056,7 @@ SET debug_sync='RESET';
 connection server_1;
 SET debug_sync='RESET';
 connection server_2;
-include/wait_for_slave_sql_error.inc [errno=1317]
+include/wait_for_slave_sql_error.inc [errno=1317,1593]
 STOP SLAVE IO_THREAD;
 SET GLOBAL gtid_slave_pos= 'AFTER_ERROR_GTID_POS';
 include/start_slave.inc
@@ -1215,6 +1216,7 @@ connection server_2;
 include/wait_for_slave_sql_to_stop.inc
 SELECT * FROM t2 WHERE a >= 40 ORDER BY a;
 a
+40
 41
 42
 include/start_slave.inc

--- a/mysql-test/suite/perfschema/r/dml_setup_instruments.result
+++ b/mysql-test/suite/perfschema/r/dml_setup_instruments.result
@@ -44,10 +44,10 @@ wait/synch/cond/sql/COND_flush_thread_cache	YES	YES
 wait/synch/cond/sql/COND_group_commit_orderer	YES	YES
 wait/synch/cond/sql/COND_gtid_ignore_duplicates	YES	YES
 wait/synch/cond/sql/COND_manager	YES	YES
+wait/synch/cond/sql/COND_parallel_abort	YES	YES
 wait/synch/cond/sql/COND_parallel_entry	YES	YES
 wait/synch/cond/sql/COND_prepare_ordered	YES	YES
 wait/synch/cond/sql/COND_queue_state	YES	YES
-wait/synch/cond/sql/COND_rpl_thread	YES	YES
 select * from performance_schema.setup_instruments
 where name='Wait';
 select * from performance_schema.setup_instruments

--- a/mysql-test/suite/rpl/include/rpl_par_stop_slave_quick_common.test
+++ b/mysql-test/suite/rpl/include/rpl_par_stop_slave_quick_common.test
@@ -1,0 +1,150 @@
+#
+# The stop_slave_quick suite of tests aims to validate that stopping a replica
+# with parallelization enabled will stop in a timely manner. That is, a
+# parallel replica should try to immediately stop and roll-back any ongoing
+# transactions. If any threads have a non-transactional workload, then it
+# along with all prior transactions are executed before stopping.
+#
+# This file provides provides test cases that should be binlog format
+# independent. There is, however, behavior that is specific to either
+# statement or row format, which each have their own test files that include
+# this file.
+#
+# Requirements:
+#   1. A table named `ti` has already been created with storage engine InnoDB
+#   2. The test variable ti_ctr has been created, and serves as a dynamic
+#      for values to insert into ti.
+#
+# References:
+#   MDEV-13915: STOP SLAVE takes very long time on a busy system
+#
+
+--echo #
+--echo # Common Test Case 1:
+--echo # Using one parallel replication worker thread on workload {T,T}, ensure
+--echo # the replica immediately rolls back the transaction and stops the
+--echo # SQL thread
+--connection slave
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+--let $row_count_initial=`select count(*) from ti`
+
+--connection master
+--source include/save_master_gtid.inc
+BEGIN;
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+COMMIT;
+
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+
+--connection slave
+LOCK TABLES ti WRITE;
+START SLAVE;
+
+--echo # Wait for replica to begin executing the first transaction
+--connection slave
+--let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state LIKE 'Waiting for table metadata lock' and  command LIKE 'Slave_worker';
+--source include/wait_condition.inc
+
+--connection slave1
+--send STOP SLAVE;
+
+--connection slave
+UNLOCK TABLES;
+--source include/wait_for_slave_sql_to_stop.inc
+
+--connection slave1
+--reap
+--connection slave
+
+--let $row_count_end=`select count(*) from ti`
+--let $row_count_diff=`select ($row_count_end-$row_count_initial)`
+--let $assert_text= No new rows should have been inserted
+--let $assert_cond= $row_count_diff = 0
+--source include/assert.inc
+
+--let $slave_gtid= `select @@global.gtid_slave_pos`
+--let $assert_text= GTID slave state should not change
+--let $assert_cond= $master_pos = $slave_gtid
+--source include/assert.inc
+
+--connection master
+--source include/save_master_gtid.inc
+--connection slave
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+
+
+--echo #
+--echo # Common Test Case 2:
+--echo # Using multiple parallel replication threads (two) on workload {T,T},
+--echo # ensure both transactions are rolled back if stop slave is issued
+--echo # in the middle of the first transaction.
+
+--connection slave
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=2;
+--let $row_count_initial=`select count(*) from ti`
+
+--connection master
+--source include/save_master_gtid.inc
+BEGIN;
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+COMMIT;
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+
+--connection slave
+LOCK TABLES ti WRITE;
+--source include/start_slave.inc
+
+--echo # Wait for replica to begin executing the first transaction
+--connection slave
+--let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state LIKE 'Waiting for table metadata lock' and  command LIKE 'Slave_worker';
+--source include/wait_condition.inc
+
+--echo # Wait for second transaction to begin
+--connection slave
+--let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state LIKE 'Waiting for prior transaction to start%' and  command LIKE 'Slave_worker';
+--source include/wait_condition.inc
+
+--connection slave1
+--send STOP SLAVE;
+
+--connection slave
+UNLOCK TABLES;
+--source include/wait_for_slave_sql_to_stop.inc
+
+--connection slave1
+--reap
+--connection slave
+
+--let $row_count_end=`select count(*) from ti`
+--let $row_count_diff=`select ($row_count_end-$row_count_initial)`
+--let $assert_text= No insertions should have committed
+--let $assert_cond= $row_count_diff = 0
+--source include/assert.inc
+
+--let $slave_gtid= `select @@global.gtid_slave_pos`
+--let $assert_text= GTID slave state should not change
+--let $assert_cond= $master_pos = $slave_gtid
+--source include/assert.inc
+
+--echo # Slave should be error-free
+let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
+--let $assert_text= Slave should be error free
+--let $assert_cond= $last_error = 0
+--source include/assert.inc
+
+--connection master
+--source include/save_master_gtid.inc
+--connection slave
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/r/rpl_parallel.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel.result
@@ -741,7 +741,6 @@ a	b
 61	61
 62	62
 63	63
-64	64
 68	68
 69	69
 70	70
@@ -826,6 +825,8 @@ SET binlog_format=@old_format;
 connection server_2;
 SET debug_sync='RESET';
 include/start_slave.inc
+SET debug_sync='now WAIT_FOR query_waiting';
+SET debug_sync='now SIGNAL query_cont';
 SELECT * FROM t3 WHERE a >= 80 ORDER BY a;
 a	b
 80	0
@@ -1054,7 +1055,7 @@ SET debug_sync='RESET';
 connection server_1;
 SET debug_sync='RESET';
 connection server_2;
-include/wait_for_slave_sql_error.inc [errno=1317]
+include/wait_for_slave_sql_error.inc [errno=1317,1593]
 STOP SLAVE IO_THREAD;
 SET GLOBAL gtid_slave_pos= 'AFTER_ERROR_GTID_POS';
 include/start_slave.inc
@@ -1214,6 +1215,7 @@ connection server_2;
 include/wait_for_slave_sql_to_stop.inc
 SELECT * FROM t2 WHERE a >= 40 ORDER BY a;
 a
+40
 41
 42
 include/start_slave.inc

--- a/mysql-test/suite/rpl/r/rpl_parallel2.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel2.result
@@ -1,6 +1,7 @@
 include/rpl_init.inc [topology=1->2]
 *** MDEV-5509: Incorrect value for Seconds_Behind_Master if parallel replication ***
 connection server_2;
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression("Commit failed due to failure of an earlier commit on which this one depends");
 SET @old_parallel_threads=@@GLOBAL.slave_parallel_threads;
 set @old_parallel_mode= @@GLOBAL.slave_parallel_mode;
 include/stop_slave.inc
@@ -30,7 +31,7 @@ SELECT * FROM t1 WHERE a >= 10 ORDER BY a;
 a	b
 10	0
 connection server_2;
-include/wait_for_slave_sql_error.inc [errno=1062]
+include/wait_for_slave_sql_error.inc [errno=1062,1593]
 SET GLOBAL slave_parallel_threads=8;
 STOP SLAVE;
 SET GLOBAL sql_slave_skip_counter= 1;

--- a/mysql-test/suite/rpl/r/rpl_parallel_mdev6589.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_mdev6589.result
@@ -94,7 +94,7 @@ connection con_temp1;
 COMMIT;
 SET sql_log_bin=1;
 connection server_2;
-include/wait_for_slave_sql_error.inc [errno=1062]
+include/wait_for_slave_sql_error.inc [errno=1062,1593]
 SELECT * FROM t1 ORDER BY a;
 a
 1

--- a/mysql-test/suite/rpl/r/rpl_row_par_stop_slave_quick.result
+++ b/mysql-test/suite/rpl/r/rpl_row_par_stop_slave_quick.result
@@ -1,0 +1,232 @@
+include/master-slave.inc
+[connection master]
+#
+# Setup
+connection slave;
+include/stop_slave.inc
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression("Can't find record");
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+connect slave_lock_extra,127.0.0.1,root,,test,$SLAVE_MYPORT;
+CHANGE MASTER TO MASTER_USE_GTID=SLAVE_POS;
+include/start_slave.inc
+#
+# Initialize test data
+connection master;
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression('Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT.');
+SET @@global.binlog_direct_non_transactional_updates= 0;
+SET @@session.binlog_direct_non_transactional_updates= 0;
+create table ti (a int) engine=innodb;
+create table tm (a int) engine=myisam;
+insert into ti values (100);
+insert into tm values (200);
+connection slave;
+# Run binlog format independent test cases
+#
+# Common Test Case 1:
+# Using one parallel replication worker thread on workload {T,T}, ensure
+# the replica immediately rolls back the transaction and stops the
+# SQL thread
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+connection master;
+include/save_master_gtid.inc
+BEGIN;
+insert into ti values (101);
+insert into ti values (102);
+COMMIT;
+insert into ti values (103);
+connection slave;
+LOCK TABLES ti WRITE;
+START SLAVE;
+# Wait for replica to begin executing the first transaction
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+include/wait_for_slave_sql_to_stop.inc
+connection slave1;
+connection slave;
+include/assert.inc [No new rows should have been inserted]
+include/assert.inc [GTID slave state should not change]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# Common Test Case 2:
+# Using multiple parallel replication threads (two) on workload {T,T},
+# ensure both transactions are rolled back if stop slave is issued
+# in the middle of the first transaction.
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=2;
+connection master;
+include/save_master_gtid.inc
+BEGIN;
+insert into ti values (104);
+insert into ti values (105);
+COMMIT;
+insert into ti values (106);
+connection slave;
+LOCK TABLES ti WRITE;
+include/start_slave.inc
+# Wait for replica to begin executing the first transaction
+connection slave;
+# Wait for second transaction to begin
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+include/wait_for_slave_sql_to_stop.inc
+connection slave1;
+connection slave;
+include/assert.inc [No insertions should have committed]
+include/assert.inc [GTID slave state should not change]
+# Slave should be error-free
+include/assert.inc [Slave should be error free]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# ROW Test Case 1:
+# Using an N multi-statement transaction, ensure if STOP SLAVE is
+# issued in-between row updates, that the transaction is finished.
+connection master;
+truncate table ti;
+truncate table tm;
+# Set up multiple rows to allow a multi-statement update rows event
+insert into tm values (201);
+insert into tm values (202);
+connection slave;
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+connection master;
+# Next-to-commit non-transactional transaction should finish
+update tm set a=a+1;
+include/save_master_gtid.inc
+# This should not be committed because it is after next-to-commit
+insert into ti values (107);
+connection slave;
+set @@global.debug_dbug="+d,pause_after_next_row_exec";
+START SLAVE;
+set debug_sync= "now WAIT_FOR row_executed";
+connection slave1;
+STOP SLAVE;;
+connection slave;
+set @@global.debug_dbug="";
+set debug_sync= "now SIGNAL continue_row_execution";
+connection slave1;
+include/wait_for_slave_sql_to_stop.inc
+# Slave should be error-free
+include/assert.inc [Slave should be error free]
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# ROW Test Case 2:
+# Using a T multi-statement transaction, ensure if STOP SLAVE is
+# issued in-between row updates, that the transaction is rolled back.
+connection master;
+truncate table ti;
+truncate table tm;
+insert into ti values (108);
+insert into ti values (109);
+connection slave;
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+connection master;
+# Next-to-commit transactional multi-row event should be rolled back
+include/save_master_gtid.inc
+update ti set a=a+1;
+insert into ti values (110);
+connection slave;
+set @@global.debug_dbug="+d,pause_after_next_row_exec";
+START SLAVE;
+set debug_sync= "now WAIT_FOR row_executed";
+connection slave1;
+STOP SLAVE;;
+connection slave;
+set @@global.debug_dbug="";
+set debug_sync= "now SIGNAL continue_row_execution";
+connection slave1;
+include/wait_for_slave_sql_to_stop.inc
+include/assert.inc [No new rows should have been inserted]
+# Comparing master gtid 0-1-18 to slaves 0-1-18
+include/assert.inc [No transactions should have committed]
+# Slave should be error-free
+include/assert.inc [Slave should be error free]
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# Row Test Case 3:
+# Using parallel replication on a workload with the next-to-commit
+# transaction as N, such that no other transactions are N, if that
+# transaction takes too long on the slave, it should be killed and an
+# error message displayed to the user mentioning the harmful N changes.
+# Pre-populate data to update
+connection master;
+TRUNCATE TABLE tm;
+insert into tm values (203);
+insert into tm values (204);
+insert into tm values (205);
+connection slave;
+include/start_slave.inc
+Warnings:
+Note	1254	Slave is already running
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+SET @@GLOBAL.debug_dbug="+d,slave_abort_quick_timeout,pause_after_next_row_exec";
+connection master;
+include/save_master_gtid.inc
+update tm set tm.a=tm.a+1;
+insert into ti values (111);
+connection slave;
+include/start_slave.inc
+set debug_sync= "now WAIT_FOR row_executed";
+connection slave1;
+STOP SLAVE;;
+connection slave;
+set debug_sync= "now SIGNAL continue_row_execution WAIT_FOR row_executed";
+# Sleep until slave auto-kill timeout
+SET @@GLOBAL.debug_dbug="-d,pause_after_next_row_exec";
+set debug_sync= "now SIGNAL continue_row_execution";
+include/wait_for_slave_sql_to_stop.inc
+connection slave1;
+connection slave;
+include/assert.inc [GTID slave state should not change]
+include/wait_for_slave_sql_error.inc [errno=1593]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+# Slave shouldn't be able to re-execute the event because last attempt
+# changed the reliant row data
+START SLAVE;
+include/wait_for_slave_sql_error.inc [errno=1032]
+set @@global.slave_exec_mode=IDEMPOTENT;
+SET @@GLOBAL.debug_dbug="-d,slave_abort_quick_timeout";
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+set @@global.slave_exec_mode=STRICT;
+set debug_sync= "RESET";
+#
+# Cleanup
+connection master;
+DROP TABLE ti, tm;
+SET @@global.binlog_direct_non_transactional_updates= 1;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+set @@global.debug_dbug="";
+set @@global.slave_parallel_threads=0;
+include/start_slave.inc
+include/rpl_end.inc
+# End of tests

--- a/mysql-test/suite/rpl/r/rpl_stm_par_stop_slave_quick.result
+++ b/mysql-test/suite/rpl/r/rpl_stm_par_stop_slave_quick.result
@@ -1,0 +1,342 @@
+include/master-slave.inc
+[connection master]
+#
+# Setup
+connection slave;
+include/stop_slave.inc
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression('Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT.');
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression("Commit failed due to failure of an earlier commit on which this one depends");
+# Set slave timeout to force kill worker threads to 4s
+SET @@GLOBAL.debug_dbug="+d,slave_abort_quick_timeout";
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+change master to master_use_gtid=slave_pos;
+include/start_slave.inc
+connect slave_lock_extra,127.0.0.1,root,,test,$SLAVE_MYPORT;
+#
+# Initialize test data
+connection master;
+set statement sql_log_bin=0 for call mtr.add_suppression('Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT.');
+SET @@global.binlog_direct_non_transactional_updates= 0;
+SET @@session.binlog_direct_non_transactional_updates= 0;
+create table ti (a int primary key) engine=innodb;
+create table ti2 (a int) engine=innodb;
+create table ti3 (a int) engine=innodb;
+create table tm (a int) engine=myisam;
+create table tm2 (a int) engine=myisam;
+connection slave;
+# Run binlog format independent test cases
+#
+# Common Test Case 1:
+# Using one parallel replication worker thread on workload {T,T}, ensure
+# the replica immediately rolls back the transaction and stops the
+# SQL thread
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+connection master;
+include/save_master_gtid.inc
+BEGIN;
+insert into ti values (100);
+insert into ti values (101);
+COMMIT;
+insert into ti values (102);
+connection slave;
+LOCK TABLES ti WRITE;
+START SLAVE;
+# Wait for replica to begin executing the first transaction
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+include/wait_for_slave_sql_to_stop.inc
+connection slave1;
+connection slave;
+include/assert.inc [No new rows should have been inserted]
+include/assert.inc [GTID slave state should not change]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# Common Test Case 2:
+# Using multiple parallel replication threads (two) on workload {T,T},
+# ensure both transactions are rolled back if stop slave is issued
+# in the middle of the first transaction.
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=2;
+connection master;
+include/save_master_gtid.inc
+BEGIN;
+insert into ti values (103);
+insert into ti values (104);
+COMMIT;
+insert into ti values (105);
+connection slave;
+LOCK TABLES ti WRITE;
+include/start_slave.inc
+# Wait for replica to begin executing the first transaction
+connection slave;
+# Wait for second transaction to begin
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+include/wait_for_slave_sql_to_stop.inc
+connection slave1;
+connection slave;
+include/assert.inc [No insertions should have committed]
+include/assert.inc [GTID slave state should not change]
+# Slave should be error-free
+include/assert.inc [Slave should be error free]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# Statement Test Case 1:
+# Using one parallel replication worker thread on workload {N,T}, ensure
+# the replica finishes the non-transactional transaction, and does not
+# start the next
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+connection master;
+BEGIN;
+insert into ti values (106);
+insert into tm values (200);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction
+insert into tm2 values (300);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction
+insert into ti values (107);
+COMMIT;
+include/save_master_gtid.inc
+insert into ti values (108);
+connection slave;
+lock tables tm2 write;
+START SLAVE;
+# Wait for replica to get stuck on held lock
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+# Unlock row-level lock holding transaction
+UNLOCK TABLES;
+include/wait_for_slave_sql_to_stop.inc
+connection slave1;
+connection slave;
+include/assert.inc [Transaction should have committed]
+include/assert.inc [N should have been applied]
+# Slave should be error-free
+include/assert.inc [Slave should be error free]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# Statement Test Case 2:
+# If STOP SLAVE is issued on a parallel slave, such that the next to
+# commit transaction is T; even if the next event from the group will
+# commit the transaction (e.g. XID_EVENT), the transaction should be
+# stopped and rolled back.
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+connection master;
+insert into ti values (109);
+insert into ti values (110);
+include/save_master_gtid.inc
+connection slave;
+LOCK TABLES ti WRITE;
+include/start_slave.inc
+# Wait for replica to begin executing the first transaction
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+include/wait_for_slave_sql_to_stop.inc
+connection slave1;
+connection slave;
+include/assert.inc [No insertions should have committed]
+include/assert.inc [GTID slave state should increment to the first transaction]
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+#
+# Statement Test Case 3:
+# Using multiple parallel replication threads on a workload with a
+# non-transactional transaction in-between transactional transactions..
+#  3a: with AGGRESSIVE replication where the N statement has been
+#      executed already, all transactions up to and including N should
+#      be replicated, and all transactions afterwards should be rolled
+#      back.
+#  3b: with MINIMAL replication, the N statement should not execute
+#      concurrently, but should wait along with the other later
+#      transactions, and all future transactions except the first should
+#      be rolled back.
+#  3a: with AGGRESSIVE replication where the slave errors on the first
+#      transaction after having executed the later non-transactional
+#      part, error..
+connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_threads=4;
+connection slave;
+#
+# 3a: slave_parallel_mode=AGGRESSIVE
+set @@global.slave_parallel_mode=AGGRESSIVE;
+connection slave;
+connection master;
+connection master;
+insert into ti values (111);
+BEGIN;
+insert into ti3 values (500);
+insert into tm values (202);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction
+insert into ti3 values (501);
+COMMIT;
+insert into ti2 values (400);
+insert into ti values (112);
+include/save_master_gtid.inc
+connection slave;
+LOCK TABLES ti WRITE;
+connection slave_lock_extra;
+LOCK TABLES ti2 WRITE;
+include/start_slave.inc
+# Wait for replica to halt due to locks and dependency requirements
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+connection slave_lock_extra;
+UNLOCK TABLES;
+connection slave1;
+connection slave;
+include/wait_for_slave_sql_to_stop.inc
+include/assert.inc [The entirety of the first two transactions should have committed with AGGRESSIVE parallelization]
+include/assert.inc [Slave state should be consistent]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+#
+# 3b: slave_parallel_mode=MINIMAL
+set @@global.slave_parallel_mode=MINIMAL;
+connection slave;
+connection master;
+connection master;
+insert into ti values (113);
+BEGIN;
+insert into ti3 values (502);
+insert into tm values (203);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction
+insert into ti3 values (503);
+COMMIT;
+insert into ti2 values (401);
+insert into ti values (114);
+include/save_master_gtid.inc
+connection slave;
+LOCK TABLES ti WRITE;
+connection slave_lock_extra;
+LOCK TABLES ti2 WRITE;
+include/start_slave.inc
+# Wait for replica to halt due to locks and dependency requirements
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+connection slave_lock_extra;
+UNLOCK TABLES;
+connection slave1;
+connection slave;
+include/wait_for_slave_sql_to_stop.inc
+include/assert.inc [All transactions should have rolled back with MINIMAL parallelization]
+include/assert.inc [Slave state should be consistent]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+connection slave;
+#
+# 3c: ERROR slave_parallel_mode=AGGRESSIVE
+set @@global.slave_parallel_mode=AGGRESSIVE;
+connection slave;
+connection master;
+connection master;
+# Create a transaction which takes longer than the allowed SLAVE STOP time
+BEGIN;
+insert into ti values (115+SLEEP(2.5));
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system function that may return a different value on the slave
+insert into ti values (116+SLEEP(2.5));
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system function that may return a different value on the slave
+insert into ti values (117+SLEEP(2.5));
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system function that may return a different value on the slave
+COMMIT;
+BEGIN;
+insert into ti3 values (504);
+insert into tm values (204);
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction
+insert into ti3 values (505);
+COMMIT;
+insert into ti2 values (402);
+insert into ti values (118);
+connection slave;
+LOCK TABLES ti WRITE;
+connection slave_lock_extra;
+LOCK TABLES ti2 WRITE;
+include/start_slave.inc
+# Wait for replica to halt due to locks and dependency requirements
+connection slave;
+connection slave1;
+STOP SLAVE;;
+connection slave;
+UNLOCK TABLES;
+connection slave_lock_extra;
+UNLOCK TABLES;
+connection slave1;
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=1593]
+include/assert.inc [One row should be new from the non-transactional statement of the second transaction]
+include/assert.inc [Slave state should be consistent]
+connection master;
+include/save_master_gtid.inc
+connection slave;
+include/start_slave.inc
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+include/start_slave.inc
+#
+# Cleanup
+connection master;
+DROP TABLE ti, tm, ti2, tm2, ti3;
+SET @@global.binlog_direct_non_transactional_updates= 1;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+set @@global.slave_parallel_threads=0;
+set @@global.slave_domain_parallel_threads=0;
+set @@global.slave_parallel_mode=conservative;
+set @@global.debug_dbug="";
+include/start_slave.inc
+include/rpl_end.inc
+# End of tests

--- a/mysql-test/suite/rpl/t/rpl_parallel.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel.test
@@ -952,6 +952,9 @@ eval KILL $d1_thd_id;
 # Wait until T3 has reacted on the kill.
 SET debug_sync='now WAIT_FOR t3_killed';
 
+--let $wait_condition= select count(*)=1 from information_schema.processlist where state LIKE 'Killing slave' and command='Slave_SQL'
+--source include/wait_condition.inc
+
 # Now we can allow T1 to proceed.
 SET debug_sync='now SIGNAL t1_cont';
 
@@ -959,7 +962,7 @@ SET debug_sync='now SIGNAL t1_cont';
 --source include/wait_for_slave_sql_error.inc
 STOP SLAVE IO_THREAD;
 # Since T2, T3, and T4 run in parallel, we can not be sure if T2 will have time
-# to commit or not before the stop. However, T1 should commit, and T3/T4 may
+# to commit or not before the stop. However, T1 should rollback, and T3/T4 may
 # not have committed. (After slave restart we check that all become committed
 # eventually).
 SELECT * FROM t3 WHERE a >= 60 AND a != 65 ORDER BY a;
@@ -1075,6 +1078,14 @@ SET binlog_format=@old_format;
 --connection server_2
 SET debug_sync='RESET';
 --source include/start_slave.inc
+
+# Test amendment from MDEV-13915:
+# A worker thread's event queue is no longer executed on replica stop.
+# The signal query_cont needs to be re-sent because the transaction was
+# aborted.
+SET debug_sync='now WAIT_FOR query_waiting';
+SET debug_sync='now SIGNAL query_cont';
+
 --sync_with_master
 SELECT * FROM t3 WHERE a >= 80 ORDER BY a;
 
@@ -1407,7 +1418,7 @@ SET debug_sync='RESET';
 
 
 --connection server_2
---let $slave_sql_errno= 1317
+--let $slave_sql_errno= 1317,1593
 --source include/wait_for_slave_sql_error.inc
 STOP SLAVE IO_THREAD;
 --replace_result $after_error_gtid_pos AFTER_ERROR_GTID_POS

--- a/mysql-test/suite/rpl/t/rpl_parallel2.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel2.test
@@ -7,6 +7,7 @@
 --echo *** MDEV-5509: Incorrect value for Seconds_Behind_Master if parallel replication ***
 
 --connection server_2
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression("Commit failed due to failure of an earlier commit on which this one depends");
 SET @old_parallel_threads=@@GLOBAL.slave_parallel_threads;
 set @old_parallel_mode= @@GLOBAL.slave_parallel_mode;
 --source include/stop_slave.inc
@@ -54,7 +55,7 @@ INSERT INTO t1 VALUES (10,0);
 SELECT * FROM t1 WHERE a >= 10 ORDER BY a;
 
 --connection server_2
---let $slave_sql_errno= 1062
+--let $slave_sql_errno= 1062,1593
 --source include/wait_for_slave_sql_error.inc
 
 # At this point, the worker threads should have stopped also.

--- a/mysql-test/suite/rpl/t/rpl_parallel_mdev6589.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_mdev6589.test
@@ -102,7 +102,7 @@ COMMIT;
 SET sql_log_bin=1;
 
 --connection server_2
---let $slave_sql_errno= 1062
+--let $slave_sql_errno= 1062,1593
 --source include/wait_for_slave_sql_error.inc
 
 SELECT * FROM t1 ORDER BY a;

--- a/mysql-test/suite/rpl/t/rpl_row_par_stop_slave_quick.test
+++ b/mysql-test/suite/rpl/t/rpl_row_par_stop_slave_quick.test
@@ -1,0 +1,276 @@
+#
+# Validate that STOP SLAVE works in a timely manner on a parallel replica with
+# ROW binary logging format.
+#
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/master-slave.inc
+--source include/have_innodb.inc
+--source include/have_binlog_format_row.inc
+
+--echo #
+--echo # Setup
+--connection slave
+--source include/stop_slave.inc
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression("Can't find record");
+--let $old_debug= `SELECT @@global.debug_dbug`
+--let $old_threads= `SELECT @@global.slave_parallel_threads`
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+--connect(slave_lock_extra,127.0.0.1,root,,test,$SLAVE_MYPORT)
+CHANGE MASTER TO MASTER_USE_GTID=SLAVE_POS;
+--source include/start_slave.inc
+
+--echo #
+--echo # Initialize test data
+--connection master
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression('Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT.');
+--let $old_binlog_direct= `SELECT @@global.binlog_direct_non_transactional_updates`
+SET @@global.binlog_direct_non_transactional_updates= 0;
+SET @@session.binlog_direct_non_transactional_updates= 0;
+
+
+# Needed by this test and include/rpl_par_stop_slave_quick.inc
+create table ti (a int) engine=innodb;
+create table tm (a int) engine=myisam;
+--let $ti_ctr= 100
+--let $tm_ctr= 200
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--eval insert into tm values ($tm_ctr)
+--inc $tm_ctr
+--sync_slave_with_master
+
+--echo # Run binlog format independent test cases
+--source include/rpl_par_stop_slave_quick_common.test
+
+--echo #
+--echo # ROW Test Case 1:
+--echo # Using an N multi-statement transaction, ensure if STOP SLAVE is
+--echo # issued in-between row updates, that the transaction is finished.
+
+--connection master
+truncate table ti;
+truncate table tm;
+--echo # Set up multiple rows to allow a multi-statement update rows event
+--eval insert into tm values ($tm_ctr)
+--inc $tm_ctr
+--eval insert into tm values ($tm_ctr)
+--inc $tm_ctr
+--sync_slave_with_master
+
+--connection slave
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+--let $row_count_initial=`select count(*) from (select * from ti UNION ALL select * from tm) t`
+
+--connection master
+
+--echo # Next-to-commit non-transactional transaction should finish
+--eval update tm set a=a+1
+--source include/save_master_gtid.inc
+--let $master_gtid_after_update= `select @@global.gtid_binlog_pos`
+
+--echo # This should not be committed because it is after next-to-commit
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+
+--connection slave
+set @@global.debug_dbug="+d,pause_after_next_row_exec";
+
+START SLAVE;
+set debug_sync= "now WAIT_FOR row_executed";
+
+--connection slave1
+--send STOP SLAVE;
+
+--connection slave
+set @@global.debug_dbug="";
+set debug_sync= "now SIGNAL continue_row_execution";
+
+--connection slave1
+--reap
+--source include/wait_for_slave_sql_to_stop.inc
+
+--echo # Slave should be error-free
+let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
+--let $assert_text= Slave should be error free
+--let $assert_cond= $last_error = 0
+--source include/assert.inc
+
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+
+
+--echo #
+--echo # ROW Test Case 2:
+--echo # Using a T multi-statement transaction, ensure if STOP SLAVE is
+--echo # issued in-between row updates, that the transaction is rolled back.
+
+--connection master
+truncate table ti;
+truncate table tm;
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--sync_slave_with_master
+
+--connection slave
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+--let $row_count_initial=`select count(*) from (select * from ti UNION ALL select * from tm) t`
+
+--connection master
+
+--echo # Next-to-commit transactional multi-row event should be rolled back
+--source include/save_master_gtid.inc
+--let $master_gtid_initial= `select @@global.gtid_binlog_pos`
+--eval update ti set a=a+1
+
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+
+--connection slave
+set @@global.debug_dbug="+d,pause_after_next_row_exec";
+START SLAVE;
+set debug_sync= "now WAIT_FOR row_executed";
+
+--connection slave1
+--send STOP SLAVE;
+
+--connection slave
+set @@global.debug_dbug="";
+set debug_sync= "now SIGNAL continue_row_execution";
+
+--connection slave1
+--reap
+--source include/wait_for_slave_sql_to_stop.inc
+
+--let $row_count_end=`select count(*) from (select * from ti UNION ALL select * from tm) t`
+--let $row_count_diff=`select ($row_count_end-$row_count_initial)`
+--let $assert_text= No new rows should have been inserted
+--let $assert_cond= $row_count_diff = 0
+--source include/assert.inc
+
+--let $slave_gtid= `select @@global.gtid_slave_pos`
+--echo # Comparing master gtid $master_pos to slaves $slave_gtid
+--let $assert_text= No transactions should have committed
+--let $assert_cond= $master_pos = $slave_gtid
+--source include/assert.inc
+
+--echo # Slave should be error-free
+let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
+--let $assert_text= Slave should be error free
+--let $assert_cond= $last_error = 0
+--source include/assert.inc
+
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+
+
+--echo #
+--echo # Row Test Case 3:
+--echo # Using parallel replication on a workload with the next-to-commit
+--echo # transaction as N, such that no other transactions are N, if that
+--echo # transaction takes too long on the slave, it should be killed and an
+--echo # error message displayed to the user mentioning the harmful N changes.
+
+--echo # Pre-populate data to update
+--connection master
+TRUNCATE TABLE tm;
+--eval insert into tm values ($tm_ctr)
+--inc $tm_ctr
+--eval insert into tm values ($tm_ctr)
+--inc $tm_ctr
+--eval insert into tm values ($tm_ctr)
+--inc $tm_ctr
+
+--connection slave
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+SET @@GLOBAL.debug_dbug="+d,slave_abort_quick_timeout,pause_after_next_row_exec";
+
+--connection master
+--source include/save_master_gtid.inc
+update tm set tm.a=tm.a+1;
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+
+--connection slave
+--source include/start_slave.inc
+
+set debug_sync= "now WAIT_FOR row_executed";
+
+--connection slave1
+--send STOP SLAVE;
+
+--connection slave
+--let $wait_condition= select count(*)=1 from information_schema.processlist where state LIKE 'Killing slave' and command='Slave_SQL'
+--source include/wait_condition.inc
+
+set debug_sync= "now SIGNAL continue_row_execution WAIT_FOR row_executed";
+
+
+#set debug_sync= "now WAIT_FOR row_executed";
+
+--echo # Sleep until slave auto-kill timeout
+--sleep 5
+
+
+SET @@GLOBAL.debug_dbug="-d,pause_after_next_row_exec";
+set debug_sync= "now SIGNAL continue_row_execution";
+
+--source include/wait_for_slave_sql_to_stop.inc
+
+--connection slave1
+--reap
+--connection slave
+
+--let $slave_gtid= `select @@global.gtid_slave_pos`
+--let $assert_text= GTID slave state should not change
+--let $assert_cond= $master_pos = $slave_gtid
+--source include/assert.inc
+
+--let $slave_sql_errno= 1593
+--source include/wait_for_slave_sql_error.inc
+
+--connection master
+--source include/save_master_gtid.inc
+--connection slave
+--echo # Slave shouldn't be able to re-execute the event because last attempt
+--echo # changed the reliant row data
+START SLAVE;
+
+--let $slave_sql_errno= 1032
+--source include/wait_for_slave_sql_error.inc
+
+--let $old_exec_mode= `SELECT @@global.slave_exec_mode`
+set @@global.slave_exec_mode=IDEMPOTENT;
+
+SET @@GLOBAL.debug_dbug="-d,slave_abort_quick_timeout";
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+
+--eval set @@global.slave_exec_mode=$old_exec_mode
+set debug_sync= "RESET";
+
+
+--echo #
+--echo # Cleanup
+--connection master
+DROP TABLE ti, tm;
+--eval SET @@global.binlog_direct_non_transactional_updates= $old_binlog_direct
+--source include/save_master_gtid.inc
+
+--connection slave
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+--eval set @@global.debug_dbug="$old_debug"
+--eval set @@global.slave_parallel_threads=$old_threads
+--source include/start_slave.inc
+
+--source include/rpl_end.inc
+
+--echo # End of tests

--- a/mysql-test/suite/rpl/t/rpl_stm_par_stop_slave_quick.test
+++ b/mysql-test/suite/rpl/t/rpl_stm_par_stop_slave_quick.test
@@ -1,0 +1,380 @@
+#
+# Validate that STOP SLAVE works in a timely manner on a parallel replica with
+# ROW binary logging format.
+#
+--source include/have_debug.inc
+--source include/master-slave.inc
+--source include/have_innodb.inc
+--source include/have_binlog_format_statement.inc
+
+--echo #
+--echo # Setup
+--connection slave
+--source include/stop_slave.inc
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression('Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT.');
+SET STATEMENT sql_log_bin=0 FOR call mtr.add_suppression("Commit failed due to failure of an earlier commit on which this one depends");
+--let $old_threads= `SELECT @@global.slave_parallel_threads`
+--let $old_domain_threads= `SELECT @@global.slave_domain_parallel_threads`
+--let $old_slave_mode= `SELECT @@global.slave_parallel_mode`
+--let $old_debug_dbug= `SELECT @@global.debug_dbug`
+
+--echo # Set slave timeout to force kill worker threads to 4s
+SET @@GLOBAL.debug_dbug="+d,slave_abort_quick_timeout";
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+change master to master_use_gtid=slave_pos;
+--source include/start_slave.inc
+--connect(slave_lock_extra,127.0.0.1,root,,test,$SLAVE_MYPORT)
+
+--echo #
+--echo # Initialize test data
+--connection master
+set statement sql_log_bin=0 for call mtr.add_suppression('Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT.');
+--let $old_binlog_direct= `SELECT @@global.binlog_direct_non_transactional_updates`
+SET @@global.binlog_direct_non_transactional_updates= 0;
+SET @@session.binlog_direct_non_transactional_updates= 0;
+create table ti (a int primary key) engine=innodb;
+create table ti2 (a int) engine=innodb;
+create table ti3 (a int) engine=innodb;
+create table tm (a int) engine=myisam;
+create table tm2 (a int) engine=myisam;
+--let $ti_ctr= 100
+--let $tm_ctr= 200
+--let $tm2_ctr= 300
+--let $ti2_ctr= 400
+--let $ti3_ctr= 500
+--sync_slave_with_master
+
+--echo # Run binlog format independent test cases
+--source include/rpl_par_stop_slave_quick_common.test
+
+
+--echo #
+--echo # Statement Test Case 1:
+--echo # Using one parallel replication worker thread on workload {N,T}, ensure
+--echo # the replica finishes the non-transactional transaction, and does not
+--echo # start the next
+
+--connection slave
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+--let $row_count_initial=`select count(*) from (select * from ti UNION ALL select * from tm UNION ALL select * from tm2) t`
+
+--connection master
+BEGIN;
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--eval insert into tm values ($tm_ctr)
+--inc $tm_ctr
+--eval insert into tm2 values ($tm2_ctr)
+--inc $tm_ctr
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+COMMIT;
+--source include/save_master_gtid.inc
+
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+
+--connection slave
+lock tables tm2 write;
+START SLAVE;
+
+--echo # Wait for replica to get stuck on held lock
+--connection slave
+--let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state LIKE 'Waiting for table metadata lock' and  command LIKE 'Slave_worker';
+--source include/wait_condition.inc
+
+--connection slave1
+--send STOP SLAVE;
+
+--connection slave
+--echo # Unlock row-level lock holding transaction
+UNLOCK TABLES;
+--source include/wait_for_slave_sql_to_stop.inc
+
+--connection slave1
+--reap
+--connection slave
+
+--let $row_count_end=`select count(*) from (select * from ti UNION ALL select * from tm UNION ALL select * from tm2) t`
+--let $row_count_diff=`select ($row_count_end-$row_count_initial)`
+--let $assert_text= Transaction should have committed
+--let $assert_cond= $row_count_diff = 4
+--source include/assert.inc
+
+--let $slave_gtid= `select @@global.gtid_slave_pos`
+# N is the non-transactional transaction
+--let $assert_text= N should have been applied
+--let $assert_cond= $master_pos = $slave_gtid
+--source include/assert.inc
+
+--echo # Slave should be error-free
+let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
+--let $assert_text= Slave should be error free
+--let $assert_cond= $last_error = 0
+--source include/assert.inc
+
+--connection master
+--source include/save_master_gtid.inc
+
+--connection slave
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+
+
+--echo #
+--echo # Statement Test Case 2:
+--echo # If STOP SLAVE is issued on a parallel slave, such that the next to
+--echo # commit transaction is T; even if the next event from the group will
+--echo # commit the transaction (e.g. XID_EVENT), the transaction should be
+--echo # stopped and rolled back.
+
+--connection slave
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=1;
+--let $row_count_initial=`select count(*) from (select * from ti UNION ALL select * from tm) t`
+
+--connection master
+--let $master_gtid_cmp= `select @@global.gtid_binlog_pos`
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--eval insert into ti values ($ti_ctr)
+--inc $ti_ctr
+--source include/save_master_gtid.inc
+
+--connection slave
+LOCK TABLES ti WRITE;
+--source include/start_slave.inc
+
+--echo # Wait for replica to begin executing the first transaction
+--connection slave
+--let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state LIKE 'Waiting for table metadata lock' and  command LIKE 'Slave_worker';
+--source include/wait_condition.inc
+
+--connection slave1
+--send STOP SLAVE;
+
+--connection slave
+UNLOCK TABLES;
+--source include/wait_for_slave_sql_to_stop.inc
+
+--connection slave1
+--reap
+--connection slave
+
+--let $row_count_end=`select count(*) from (select * from ti UNION ALL select * from tm) t`
+--let $row_count_diff=`select ($row_count_end-$row_count_initial)`
+--let $assert_text= No insertions should have committed
+--let $assert_cond= $row_count_diff = 0
+--source include/assert.inc
+
+--let $slave_gtid= `select @@global.gtid_slave_pos`
+--let $assert_text= GTID slave state should increment to the first transaction
+--let $assert_cond= $master_gtid_cmp = $slave_gtid
+--source include/assert.inc
+
+--source include/start_slave.inc
+--source include/sync_with_master_gtid.inc
+
+
+--echo #
+--echo # Statement Test Case 3:
+--echo # Using multiple parallel replication threads on a workload with a
+--echo # non-transactional transaction in-between transactional transactions..
+--echo #  3a: with AGGRESSIVE replication where the N statement has been
+--echo #      executed already, all transactions up to and including N should
+--echo #      be replicated, and all transactions afterwards should be rolled
+--echo #      back.
+--echo #  3b: with MINIMAL replication, the N statement should not execute
+--echo #      concurrently, but should wait along with the other later
+--echo #      transactions, and all future transactions except the first should
+--echo #      be rolled back.
+--echo #  3a: with AGGRESSIVE replication where the slave errors on the first
+--echo #      transaction after having executed the later non-transactional
+--echo #      part, error..
+
+
+--connection slave
+--source include/stop_slave.inc
+set @@global.slave_parallel_threads=4;
+
+--let $mode_ctr=3
+while ($mode_ctr)
+{
+    --connection slave
+    if ($mode_ctr == 3)
+    {
+        --echo #
+        --echo # 3a: slave_parallel_mode=AGGRESSIVE
+        set @@global.slave_parallel_mode=AGGRESSIVE;
+    }
+    if ($mode_ctr == 2)
+    {
+        --echo #
+        --echo # 3b: slave_parallel_mode=MINIMAL
+        set @@global.slave_parallel_mode=MINIMAL;
+    }
+    if ($mode_ctr == 1)
+    {
+        --echo #
+        --echo # 3c: ERROR slave_parallel_mode=AGGRESSIVE
+        set @@global.slave_parallel_mode=AGGRESSIVE;
+    }
+
+    --connection slave
+    --let $row_count_initial=`select count(*) from (select * from ti UNION ALL select * from tm UNION ALL select * from ti2 UNION ALL select * from tm2 UNION ALL select * from ti3) t`
+
+    --connection master
+    if ($mode_ctr <= 2)
+    {
+        --let $master_gtid_cmp= `select @@global.gtid_binlog_pos`
+    }
+
+    --connection master
+    if ($mode_ctr == 1)
+    {
+        --echo # Create a transaction which takes longer than the allowed SLAVE STOP time
+        BEGIN;
+        --eval insert into ti values ($ti_ctr+SLEEP(2.5))
+        --inc $ti_ctr
+        --eval insert into ti values ($ti_ctr+SLEEP(2.5))
+        --inc $ti_ctr
+        --eval insert into ti values ($ti_ctr+SLEEP(2.5))
+        --inc $ti_ctr
+        COMMIT;
+    }
+    if ($mode_ctr > 1)
+    {
+        --eval insert into ti values ($ti_ctr)
+        --inc $ti_ctr
+    }
+
+    BEGIN;
+    --eval insert into ti3 values ($ti3_ctr)
+    --inc $ti3_ctr
+    --let $reapplied_tm_id= $tm_ctr
+    --eval insert into tm values ($tm_ctr)
+    --inc $tm_ctr
+    --eval insert into ti3 values ($ti3_ctr)
+    --inc $ti3_ctr
+    COMMIT;
+    if ($mode_ctr == 3)
+    {
+        # AGGRESSIVE mode should allow N trx to complete
+        --let $master_gtid_cmp= `select @@global.gtid_binlog_pos`
+    }
+    --eval insert into ti2 values ($ti2_ctr)
+    --inc $ti2_ctr
+    --eval insert into ti values ($ti_ctr)
+    --inc $ti_ctr
+    if ($mode_ctr > 1)
+    {
+        --source include/save_master_gtid.inc
+    }
+
+    --connection slave
+    LOCK TABLES ti WRITE;
+    --connection slave_lock_extra
+    LOCK TABLES ti2 WRITE;
+
+    --source include/start_slave.inc
+
+    --echo # Wait for replica to halt due to locks and dependency requirements
+    --connection slave
+
+    if ($mode_ctr == 3)
+    {
+        # AGGRESSIVE allows for more concurrency that we need to wait for
+        --let $wait_condition= SELECT count(*)=3 FROM information_schema.processlist WHERE state LIKE 'Waiting for table metadata lock' and  command LIKE 'Slave_worker';
+        --source include/wait_condition.inc
+        --let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state LIKE 'Waiting for prior transaction to commit' and  command LIKE 'Slave_worker';
+        --source include/wait_condition.inc
+    }
+    if ($mode_ctr == 2)
+    {
+        # MINIMAL will only have the first transaction begun
+        --let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state LIKE 'Waiting for table metadata lock' and  command LIKE 'Slave_worker';
+        --source include/wait_condition.inc
+        --let $wait_condition= SELECT count(*)=3 FROM information_schema.processlist WHERE state LIKE 'Waiting for prior transaction to start commit%' and  command LIKE 'Slave_worker';
+        --source include/wait_condition.inc
+    }
+
+    --connection slave1
+    --send STOP SLAVE;
+    --connection slave
+    UNLOCK TABLES;
+    --connection slave_lock_extra
+    UNLOCK TABLES;
+
+    --connection slave1
+    --reap
+    --connection slave
+
+    if ($mode_ctr == 1)
+    {
+        --let $slave_sql_errno= 1593
+        --source include/wait_for_slave_sql_error.inc
+    }
+    if ($mode_ctr > 1)
+    {
+        --source include/wait_for_slave_sql_to_stop.inc
+    }
+
+    --let $row_count_end=`select count(*) from (select * from ti UNION ALL select * from tm UNION ALL select * from ti2 UNION ALL select * from tm2 UNION ALL select * from ti3) t`
+    --let $row_count_diff=`select ($row_count_end-$row_count_initial)`
+
+    if ($mode_ctr == 3)
+    {
+        --let $assert_text= The entirety of the first two transactions should have committed with AGGRESSIVE parallelization
+        --let $assert_cond= $row_count_diff = 4
+    }
+    if ($mode_ctr == 2)
+    {
+        --let $assert_text= All transactions should have rolled back with MINIMAL parallelization
+        --let $assert_cond= $row_count_diff = 0
+    }
+
+    if ($mode_ctr == 1)
+    {
+        --let $assert_text= One row should be new from the non-transactional statement of the second transaction
+        --let $assert_cond= $row_count_diff = 1
+    }
+
+    --source include/assert.inc
+
+    --let $slave_gtid= `select @@global.gtid_slave_pos`
+    --let $assert_text= Slave state should be consistent
+    --let $assert_cond= $master_gtid_cmp = $slave_gtid
+    --source include/assert.inc
+
+    --connection master
+    --source include/save_master_gtid.inc
+    --connection slave
+    --source include/start_slave.inc
+    --source include/sync_with_master_gtid.inc
+
+    --source include/stop_slave.inc
+    --dec $mode_ctr
+}
+--source include/start_slave.inc
+
+
+--echo #
+--echo # Cleanup
+--connection master
+DROP TABLE ti, tm, ti2, tm2, ti3;
+--eval SET @@global.binlog_direct_non_transactional_updates= $old_binlog_direct
+--source include/save_master_gtid.inc
+
+--connection slave
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+--eval set @@global.slave_parallel_threads=$old_threads
+--eval set @@global.slave_domain_parallel_threads=$old_domain_threads
+--eval set @@global.slave_parallel_mode=$old_slave_mode
+--eval set @@global.debug_dbug="$old_debug_dbug"
+--source include/start_slave.inc
+
+--source include/rpl_end.inc
+
+--echo # End of tests

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1039,7 +1039,7 @@ PSI_cond_key key_TC_LOG_MMAP_COND_queue_busy;
 PSI_cond_key key_COND_rpl_thread_queue, key_COND_rpl_thread,
   key_COND_rpl_thread_stop, key_COND_rpl_thread_pool,
   key_COND_parallel_entry, key_COND_group_commit_orderer,
-  key_COND_prepare_ordered;
+  key_COND_prepare_ordered, key_COND_parallel_abort;
 PSI_cond_key key_COND_wait_gtid, key_COND_gtid_ignore_duplicates;
 PSI_cond_key key_COND_ack_receiver;
 
@@ -1087,6 +1087,7 @@ static PSI_cond_info all_server_conds[]=
   { &key_COND_parallel_entry, "COND_parallel_entry", 0},
   { &key_COND_group_commit_orderer, "COND_group_commit_orderer", 0},
   { &key_COND_prepare_ordered, "COND_prepare_ordered", 0},
+  { &key_COND_parallel_abort, "COND_parallel_abort", 0},
   { &key_COND_start_thread, "COND_start_thread", PSI_FLAG_GLOBAL},
   { &key_COND_wait_gtid, "COND_wait_gtid", 0},
   { &key_COND_gtid_ignore_duplicates, "COND_gtid_ignore_duplicates", 0},
@@ -9560,6 +9561,7 @@ PSI_stage_info stage_waiting_for_work_from_sql_thread= { 0, "Waiting for work fr
 PSI_stage_info stage_waiting_for_prior_transaction_to_commit= { 0, "Waiting for prior transaction to commit", 0};
 PSI_stage_info stage_waiting_for_prior_transaction_to_start_commit= { 0, "Waiting for prior transaction to start commit before starting next transaction", 0};
 PSI_stage_info stage_waiting_for_room_in_worker_thread= { 0, "Waiting for room in worker thread event queue", 0};
+PSI_stage_info stage_waiting_for_workers_abort= { 0, "Waiting for worker threads to synchronize abort", 0};
 PSI_stage_info stage_waiting_for_workers_idle= { 0, "Waiting for worker threads to be idle", 0};
 PSI_stage_info stage_waiting_for_ftwrl= { 0, "Waiting due to global read lock", 0};
 PSI_stage_info stage_waiting_for_ftwrl_threads_to_pause= { 0, "Waiting for worker threads to pause for global read lock", 0};

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -382,7 +382,8 @@ extern PSI_cond_key key_RELAYLOG_COND_queue_busy;
 extern PSI_cond_key key_TC_LOG_MMAP_COND_queue_busy;
 extern PSI_cond_key key_COND_rpl_thread, key_COND_rpl_thread_queue,
   key_COND_rpl_thread_stop, key_COND_rpl_thread_pool,
-  key_COND_parallel_entry, key_COND_group_commit_orderer;
+  key_COND_parallel_entry, key_COND_group_commit_orderer,
+  key_COND_parallel_abort;
 extern PSI_cond_key key_COND_wait_gtid, key_COND_gtid_ignore_duplicates;
 extern PSI_cond_key key_TABLE_SHARE_COND_rotation;
 
@@ -535,6 +536,7 @@ extern PSI_stage_info stage_waiting_for_work_from_sql_thread;
 extern PSI_stage_info stage_waiting_for_prior_transaction_to_commit;
 extern PSI_stage_info stage_waiting_for_prior_transaction_to_start_commit;
 extern PSI_stage_info stage_waiting_for_room_in_worker_thread;
+extern PSI_stage_info stage_waiting_for_workers_abort;
 extern PSI_stage_info stage_waiting_for_workers_idle;
 extern PSI_stage_info stage_waiting_for_ftwrl;
 extern PSI_stage_info stage_waiting_for_ftwrl_threads_to_pause;

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2155,7 +2155,8 @@ rpl_group_info::reinit(Relay_log_info *rli)
 rpl_group_info::rpl_group_info(Relay_log_info *rli)
   : thd(0), wait_commit_sub_id(0),
     wait_commit_group_info(0), parallel_entry(0),
-    deferred_events(NULL), m_annotate_event(0), is_parallel_exec(false)
+    deferred_events(NULL), m_annotate_event(0), is_parallel_exec(false),
+    modified_non_trans_table(false)
 {
   reinit(rli);
   bzero(&current_gtid, sizeof(current_gtid));

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -797,6 +797,16 @@ struct rpl_group_info
   inuse_relaylog *relay_log;
   uint64 retry_start_offset;
   uint64 retry_event_count;
+
+  /*
+    Our own copy of thd->transaction.all.modified_non_trans_table with a
+    longer lifespan for analysis of slave state. The value stored by the
+    transaction can be reset too early (by commit or rows event error), and
+    in the event of STOP SLAVE, we need to report that a transaction with
+    non-transactional changes had been quit early and rolled-back.
+  */
+  bool modified_non_trans_table;
+
   /*
     If `speculation' is != SPECULATE_NO, then we are optimistically running
     this transaction in parallel, even though it might not be safe (there may

--- a/sql/slave.h
+++ b/sql/slave.h
@@ -42,6 +42,11 @@
 */
 #define SLAVE_MAX_HEARTBEAT_PERIOD 4294967
 
+/*
+  a parameter of sql_slave_killed() to defer the killed status
+*/
+#define SLAVE_WAIT_GROUP_DONE 60
+
 #ifdef HAVE_REPLICATION
 
 #include "log.h"
@@ -278,6 +283,8 @@ void slave_background_kill_request(THD *to_kill);
 void slave_background_gtid_pos_create_request
         (rpl_slave_state::gtid_pos_table *table_entry);
 void slave_background_gtid_pending_delete_request(void);
+int slave_output_incomplete_trx_non_trans_err(THD *thd, rpl_group_info *rgi);
+bool slave_done_waiting_to_force_abort(rpl_group_info *rgi);
 
 extern Master_info *active_mi; /* active_mi for multi-master */
 extern Master_info *default_master_info; /* To replace active_mi */

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3193,6 +3193,9 @@ public:
     Set by a storage engine to request the entire
     transaction (that possibly spans multiple engines) to
     rollback. Reset in ha_rollback.
+
+    This can also be set in parallel replication if a multi-row
+    event is aborted mid-execution, and needs to be rolled back.
   */
   bool       transaction_rollback_request;
   /**
@@ -4726,12 +4729,7 @@ public:
   }
 
   wait_for_commit *wait_for_commit_ptr;
-  int wait_for_prior_commit()
-  {
-    if (wait_for_commit_ptr)
-      return wait_for_commit_ptr->wait_for_prior_commit(this);
-    return 0;
-  }
+  int wait_for_prior_commit();
   void wakeup_subsequent_commits(int wakeup_error)
   {
     if (wait_for_commit_ptr)


### PR DESCRIPTION
The problem is that a parallel replica would not immediately stop
running/queued transactions when issued STOP SLAVE. This would lead
to long periods to wait for all waiting transactions to finish.

This patch updates a parallel replica to try and abort immediately
and roll-back any ongoing transactions. There are two exceptions:
   1. The transaction is next-to-commit and it has already modified
      non-transactional table and cannot be safely rolled back.
   2. We are at the commit step of the transaction.


The first commit on the branch is the MTR tests which show the problem.
The second commit is the code changes.
The third commit is updates to other MTR tests which needed to be fixed.