### PR TITLE
WIP : [MDEV-23962] Removed obsolete code to handle 'arc' directories

### DIFF
--- a/sql/parse_file.cc
+++ b/sql/parse_file.cc
@@ -408,7 +408,7 @@ my_bool rename_in_schema_file(THD *thd,
                               const char *schema, const char *old_name, 
                               const char *new_db, const char *new_name)
 {
-  char old_path[FN_REFLEN + 1], new_path[FN_REFLEN + 1], arc_path[FN_REFLEN + 1];
+  char old_path[FN_REFLEN + 1], new_path[FN_REFLEN + 1];
 
   build_table_filename(old_path, sizeof(old_path) - 1,
                        schema, old_name, reg_ext, 0);
@@ -418,17 +418,6 @@ my_bool rename_in_schema_file(THD *thd,
   if (mysql_file_rename(key_file_frm, old_path, new_path, MYF(MY_WME)))
     return 1;
 
-  /* check if arc_dir exists: disabled unused feature (see bug #17823). */
-  build_table_filename(arc_path, sizeof(arc_path) - 1, schema, "arc", "", 0);
-  
-  { // remove obsolete 'arc' directory and files if any
-    MY_DIR *new_dirp;
-    if ((new_dirp = my_dir(arc_path, MYF(MY_DONT_SORT))))
-    {
-      DBUG_PRINT("my",("Archive subdir found: %s", arc_path));
-      (void) mysql_rm_arc_files(thd, new_dirp, arc_path);
-    }
-  }
   return 0;
 }
 

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -58,7 +58,6 @@ static TYPELIB deletable_extensions=
 static bool find_db_tables_and_rm_known_files(THD *, MY_DIR *, const char *,
                                               const char *, TABLE_LIST **);
 
-long mysql_rm_arc_files(THD *thd, MY_DIR *dirp, const char *org_path);
 my_bool rm_dir_w_symlink(const char *org_path, my_bool send_error);
 static void mysql_change_db_impl(THD *thd,
                                  LEX_CSTRING *new_db_name,
@@ -1371,25 +1370,6 @@ static bool find_db_tables_and_rm_known_files(THD *thd, MY_DIR *dirp,
     char *extension;
     DBUG_PRINT("info",("Examining: %s", file->name));
 
-    if (file->name[0] == 'a' && file->name[1] == 'r' &&
-             file->name[2] == 'c' && file->name[3] == '\0')
-    {
-      /* .frm archive:
-        Those archives are obsolete, but following code should
-        exist to remove existent "arc" directories.
-      */
-      char newpath[FN_REFLEN];
-      MY_DIR *new_dirp;
-      strxmov(newpath, path, "/", "arc", NullS);
-      (void) unpack_filename(newpath, newpath);
-      if ((new_dirp = my_dir(newpath, MYF(MY_DONT_SORT))))
-      {
-	DBUG_PRINT("my",("Archive subdir found: %s", newpath));
-	if ((mysql_rm_arc_files(thd, new_dirp, newpath)) < 0)
-	  DBUG_RETURN(true);
-      }
-      continue;
-    }
     if (!(extension= strrchr(file->name, '.')))
       extension= strend(file->name);
     if (find_type(extension, &deletable_extensions, FIND_TYPE_NO_PREFIX) > 0)
@@ -1460,82 +1440,6 @@ my_bool rm_dir_w_symlink(const char *org_path, my_bool send_error)
     DBUG_RETURN(1);
   }
   DBUG_RETURN(0);
-}
-
-
-/*
-  Remove .frm archives from directory
-
-  SYNOPSIS
-    thd       thread handler
-    dirp      list of files in archive directory
-    db        data base name
-    org_path  path of archive directory
-
-  RETURN
-    > 0 number of removed files
-    -1  error
-
-  NOTE
-    A support of "arc" directories is obsolete, however this
-    function should exist to remove existent "arc" directories.
-*/
-long mysql_rm_arc_files(THD *thd, MY_DIR *dirp, const char *org_path)
-{
-  long deleted= 0;
-  ulong found_other_files= 0;
-  char filePath[FN_REFLEN];
-  DBUG_ENTER("mysql_rm_arc_files");
-  DBUG_PRINT("enter", ("path: %s", org_path));
-
-  for (uint idx=0 ;
-       idx < (uint) dirp->number_of_files && !thd->killed ;
-       idx++)
-  {
-    FILEINFO *file=dirp->dir_entry+idx;
-    char *extension, *revision;
-    DBUG_PRINT("info",("Examining: %s", file->name));
-
-    extension= fn_ext(file->name);
-    if (extension[0] != '.' ||
-        extension[1] != 'f' || extension[2] != 'r' ||
-        extension[3] != 'm' || extension[4] != '-')
-    {
-      found_other_files++;
-      continue;
-    }
-    revision= extension+5;
-    while (*revision && my_isdigit(system_charset_info, *revision))
-      revision++;
-    if (*revision)
-    {
-      found_other_files++;
-      continue;
-    }
-    strxmov(filePath, org_path, "/", file->name, NullS);
-    if (mysql_file_delete_with_symlink(key_file_misc, filePath, "", MYF(MY_WME)))
-    {
-      goto err;
-    }
-    deleted++;
-  }
-  if (thd->killed)
-    goto err;
-
-  my_dirend(dirp);
-
-  /*
-    If the directory is a symbolic link, remove the link first, then
-    remove the directory the symbolic link pointed at
-  */
-  if (!found_other_files &&
-      rm_dir_w_symlink(org_path, 0))
-    DBUG_RETURN(-1);
-  DBUG_RETURN(deleted);
-
-err:
-  my_dirend(dirp);
-  DBUG_RETURN(-1);
 }
 
 


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-23962*

## Description
--**WIP**--
Deleted unused code to handle 'arc' directories in this files : 
sql/sql_db.cc: find_db_tables_and_rm_known_files()
sql/sql_db.cc: mysql_rm_arc_files()
sql/parse_file.cc:rename_in_schema_file()

## How can this PR be tested?
---

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
