### PR TITLE
[MDEV-29827] Clear and specific error when --event-scheduler=ON is combined with skip-grant-tables

### DIFF
--- a/mysql-test/main/events_embedded.test
+++ b/mysql-test/main/events_embedded.test
@@ -1,4 +1,4 @@
 --source include/is_embedded.inc
 
---error 1193
+--error ER_UNKNOWN_SYSTEM_VARIABLE
 set global event_scheduler=ON;

--- a/mysql-test/main/events_skip_grant_tables-master.opt
+++ b/mysql-test/main/events_skip_grant_tables-master.opt
@@ -1,0 +1,1 @@
+--event-scheduler=ON --skip-grant-tables

--- a/mysql-test/main/events_skip_grant_tables.result
+++ b/mysql-test/main/events_skip_grant_tables.result
@@ -1,0 +1,8 @@
+call mtr.add_suppression("Event Scheduler will not function when starting with --skip-grant-tables or --bootstrap.");
+CREATE EVENT test ON SCHEDULE AT CURRENT_TIMESTAMP DO DO NULL;
+ERROR HY000: Event scheduler cannot function with --skip-grant-tables, --bootstrap, or embedded build
+select (@@global.event_scheduler='DISABLED') as expect_1;
+expect_1
+1
+set global event_scheduler=1;
+ERROR HY000: The MariaDB server is running with the --event-scheduler=DISABLED or --skip-grant-tables option so it cannot execute this statement

--- a/mysql-test/main/events_skip_grant_tables.test
+++ b/mysql-test/main/events_skip_grant_tables.test
@@ -1,0 +1,18 @@
+# Can't test with embedded server that doesn't support grants
+-- source include/not_embedded.inc
+call mtr.add_suppression("Event Scheduler will not function when starting with --skip-grant-tables or --bootstrap.");
+
+# [MARIADB-29827] Verify that if server is started with
+# --event-scheduler=ON --skip-grant-tables, we get an error
+# with a distinct explanation that the latter disables the former.
+
+--error ER_EVENTS_NO_ACL
+CREATE EVENT test ON SCHEDULE AT CURRENT_TIMESTAMP DO DO NULL;
+
+# Although --event-scheduler=ON was specified (see -master.opt), it should
+# have been changed to 'DISABLED' at startup.
+select (@@global.event_scheduler='DISABLED') as expect_1;
+
+# Verify that we cannot (re)enable event scheduler
+--error ER_OPTION_PREVENTS_STATEMENT
+set global event_scheduler=1;

--- a/mysql-test/main/mysql_upgrade-6984.result
+++ b/mysql-test/main/mysql_upgrade-6984.result
@@ -167,5 +167,4 @@ OK
 connect con1,localhost,root,foo,,,;
 update mysql.global_priv set priv=json_compact(json_remove(priv, '$.plugin', '$.authentication_string'))  where user='root';
 flush privileges;
-set global event_scheduler=OFF;
 # restart

--- a/mysql-test/main/mysql_upgrade-6984.test
+++ b/mysql-test/main/mysql_upgrade-6984.test
@@ -21,8 +21,6 @@ connect(con1,localhost,root,foo,,,);
 
 update mysql.global_priv set priv=json_compact(json_remove(priv, '$.plugin', '$.authentication_string'))  where user='root';
 flush privileges;
-# Load event table
-set global event_scheduler=OFF;
 
 let MYSQLD_DATADIR= `select @@datadir`;
 --remove_file $MYSQLD_DATADIR/mariadb_upgrade_info

--- a/mysql-test/main/skip_grants.result
+++ b/mysql-test/main/skip_grants.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("Event Scheduler will not function when starting with --skip-grant-tables or --bootstrap.");
 use test;
 CREATE TABLE t1(c INT);
 CREATE TRIGGER t1_bi BEFORE INSERT ON t1
@@ -52,7 +53,7 @@ DROP FUNCTION f3;
 # Bug #26807 "set global event_scheduler=1" and --skip-grant-tables crashes server
 #
 set global event_scheduler=1;
-set global event_scheduler=0;
+ERROR HY000: The MariaDB server is running with the --event-scheduler=DISABLED or --skip-grant-tables option so it cannot execute this statement
 #
 # Bug#26285 Selecting information_schema crahes server
 #

--- a/mysql-test/main/skip_grants.test
+++ b/mysql-test/main/skip_grants.test
@@ -1,5 +1,7 @@
 # This tests not performed with embedded server
 -- source include/not_embedded.inc
+call mtr.add_suppression("Event Scheduler will not function when starting with --skip-grant-tables or --bootstrap.");
+
 -- disable_ps_protocol
 use test;
 
@@ -92,10 +94,8 @@ DROP FUNCTION f3;
 --echo #
 --echo # Bug #26807 "set global event_scheduler=1" and --skip-grant-tables crashes server
 --echo #
---disable_warnings
+--error ER_OPTION_PREVENTS_STATEMENT
 set global event_scheduler=1;
---enable_warnings
-set global event_scheduler=0;
 
 --echo #
 --echo # Bug#26285 Selecting information_schema crahes server

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -10784,3 +10784,5 @@ ER_JSON_INVALID_VALUE_FOR_KEYWORD
         eng "Invalid value for keyword %s"
 ER_JSON_SCHEMA_KEYWORD_UNSUPPORTED
         eng "%s keyword is not supported"
+ER_EVENTS_NO_ACL
+        eng "Event scheduler cannot function with --skip-grant-tables, --bootstrap, or embedded build"


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-29827*

## Description

When the server is started with `--event-scheduler=ON` and with `--skip-grant-tables`, the event scheduler *appears* to be enabled (`SELECT @@global.event_scheduler` returns `'ON'`), but attempting to manipulate it in any way returns a misleading error message:

  "Cannot proceed, because event scheduler is disabled"

Possible solutions:

1. Fast-fail: fail immediately on startup if `EVENT_SCHEDULER` is set to
   any value other than `DISABLED` when starting up without grant
   tables, then prevent `SET GLOBAL event_scheduler` while running.

   Problem: there are existing setup scripts and code which start with
   this combination and assume it will not fail.

2. Warn and change value: if `EVENT_SCHEDULER` is set to any value
   other than `DISABLED` when starting, print a warning and change it
   immediately to `DISABLED`.

   Advantage: The value of the `EVENT_SCHEDULER` system variable after
   startup will be consistent with its functional unavailability.

3. Display a clear error: if `EVENT_SCHEDULER` is enabled, but grant
   tables are not enabled, then ensure error messages clearly explain
   the fact that the combination is not supported.

   Advantage: The error message encountered by the end user when
   attempting to manipulate the event scheduler (such as `CREATE
   EVENT`) is clear and explicit.

This commit implements the combination of solutions (2) and (3): it
will set `EVENT_SCHEDULER=DISABLED` on startup (reflecting the
functional reality) and it will print a startup warning, *and* it will
print a *distinct* error message each time that an end user attempts to
manipulate the event scheduler, so that the end user will clearly understand
the problem even if the startup messages are not visible at that point.

## How can this PR be tested?

It adds an MTR test `main.events_skip_grant_tables` to verify the
expected behavior, and the unmodified `main.events_restart` test
continues to demonstrate no change in the error message when the event
scheduler is non-functional for *different* reasons.

## Basing the PR against the correct MariaDB version

- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility

The change does not affect previous branches

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the BSD-new
license. I am contributing on behalf of my employer Amazon Web Services