### PR TITLE
MDEV-31151: Fix a stack overflow in pinbox allocator

### DIFF
--- a/mysys/lf_alloc-pin.c
+++ b/mysys/lf_alloc-pin.c
@@ -103,12 +103,6 @@
 #include <lf.h>
 #include "my_cpu.h"
 
-/*
-  when using alloca() leave at least that many bytes of the stack -
-  for functions we might be calling from within this stack frame
-*/
-#define ALLOCA_SAFETY_MARGIN 8192
-
 #define LF_PINBOX_MAX_PINS 65536
 
 static void lf_pinbox_real_free(LF_PINS *pins);
@@ -239,25 +233,20 @@ void lf_pinbox_put_pins(LF_PINS *pins)
   } while (!my_atomic_cas32((int32 volatile*) &pinbox->pinstack_top_ver,
                             (int32*) &top_ver,
                             top_ver-pins->link+nr+LF_PINBOX_MAX_PINS));
-  return;
 }
 
-static int ptr_cmp(const void *pa, const void *pb)
+/*
+  Get the next pointer in the purgatory list.
+  Note that next_node is not used to avoid the extra volatile.
+*/
+#define pnext_node(P, X) (*((void **)(((char *)(X)) + (P)->free_ptr_offset)))
+
+static inline void add_to_purgatory(LF_PINS *pins, void *addr)
 {
-  const void *const*a= pa;
-  const void *const*b= pb;
-  return *a < *b ? -1 : *a == *b ? 0 : 1;
+  pnext_node(pins->pinbox, addr)= pins->purgatory;
+  pins->purgatory= addr;
+  pins->purgatory_count++;
 }
-
-#define add_to_purgatory(PINS, ADDR)                                    \
-  do                                                                    \
-  {                                                                     \
-    my_atomic_storeptr_explicit(                                        \
-      (void **)((char *)(ADDR)+(PINS)->pinbox->free_ptr_offset),        \
-      (PINS)->purgatory, MY_MEMORY_ORDER_RELEASE);                      \
-    (PINS)->purgatory= (ADDR);                                          \
-    (PINS)->purgatory_count++;                                          \
-  } while (0)
 
 /*
   Free an object allocated via pinbox allocator
@@ -276,138 +265,86 @@ void lf_pinbox_free(LF_PINS *pins, void *addr)
                       lf_pinbox_real_free(pins););
 }
 
-struct st_harvester {
-  void **granary;
-  int npins;
+struct st_match_and_save_arg {
+  LF_PINS *pins;
+  LF_PINBOX *pinbox;
+  void *old_purgatory;
 };
 
 /*
-  callback forlf_dynarray_iterate:
-  scan all pins of all threads and accumulate all pins
+  Callback for lf_dynarray_iterate:
+  Scan all pins of all threads, for each active (non-null) pin,
+  scan the current thread's purgatory. If present there, move it
+  to a new purgatory. At the end, the old purgatory will contain
+  pointers not pinned by any thread.
 */
-static int harvest_pins(void *e, void *h)
+static int match_and_save(void *e, void *a)
 {
   LF_PINS *el= e;
-  struct st_harvester *hv= h;
+  struct st_match_and_save_arg *arg= a;
+
   int i;
-  LF_PINS *el_end= el+MY_MIN(hv->npins, LF_DYNARRAY_LEVEL_LENGTH);
+  LF_PINS *el_end= el + LF_DYNARRAY_LEVEL_LENGTH;
   for (; el < el_end; el++)
   {
     for (i= 0; i < LF_PINBOX_PINS; i++)
     {
       void *p= my_atomic_loadptr((void **)&el->pin[i]);
       if (p)
-        *hv->granary++= p;
+      {
+        void *cur= arg->old_purgatory;
+        void **list_prev= &arg->old_purgatory;
+        while (cur)
+        {
+          void *next= pnext_node(arg->pinbox, cur);
+
+          if (p == cur)
+          {
+            /* pinned - keeping */
+            add_to_purgatory(arg->pins, cur);
+            /* unlink from old purgatory */
+            *list_prev= next;
+          }
+          else
+            list_prev= (void **)((char *)cur+arg->pinbox->free_ptr_offset);
+          cur= next;
+        }
+        if (!arg->old_purgatory)
+          return 1;
+      }
     }
   }
-  /*
-    hv->npins may become negative below, but it means that
-    we're on the last dynarray page and harvest_pins() won't be
-    called again. We don't bother to make hv->npins() correct
-    (that is 0) in this case.
-  */
-  hv->npins-= LF_DYNARRAY_LEVEL_LENGTH;
   return 0;
 }
-
-/*
-  callback forlf_dynarray_iterate:
-  scan all pins of all threads and see if addr is present there
-*/
-static int match_pins(void *e, void *addr)
-{
-  LF_PINS *el= e;
-  int i;
-  LF_PINS *el_end= el+LF_DYNARRAY_LEVEL_LENGTH;
-  for (; el < el_end; el++)
-    for (i= 0; i < LF_PINBOX_PINS; i++)
-      if (my_atomic_loadptr((void **)&el->pin[i]) == addr)
-        return 1;
-  return 0;
-}
-
-#define next_node(P, X) (*((uchar * volatile *)(((uchar *)(X)) + (P)->free_ptr_offset)))
-#define anext_node(X) next_node(&allocator->pinbox, (X))
 
 /*
   Scan the purgatory and free everything that can be freed
 */
 static void lf_pinbox_real_free(LF_PINS *pins)
 {
-  int npins;
-  void *list;
-  void **addr= NULL;
-  void *first= NULL, *last= NULL;
-  struct st_my_thread_var *var= my_thread_var;
-  void *stack_ends_here= var ? var->stack_ends_here : NULL;
   LF_PINBOX *pinbox= pins->pinbox;
 
-  npins= pinbox->pins_in_array+1;
-
-#ifdef HAVE_ALLOCA
-  if (stack_ends_here != NULL)
-  {
-    int alloca_size= sizeof(void *)*LF_PINBOX_PINS*npins;
-    /* create a sorted list of pinned addresses, to speed up searches */
-    if (available_stack_size(&pinbox, stack_ends_here) >
-        alloca_size + ALLOCA_SAFETY_MARGIN)
-    {
-      struct st_harvester hv;
-      addr= (void **) alloca(alloca_size);
-      hv.granary= addr;
-      hv.npins= npins;
-      /* scan the dynarray and accumulate all pinned addresses */
-     lf_dynarray_iterate(&pinbox->pinarray, harvest_pins, &hv);
-
-      npins= (int)(hv.granary-addr);
-      /* and sort them */
-      if (npins)
-        qsort(addr, npins, sizeof(void *), ptr_cmp);
-    }
-  }
-#endif
-
-  list= pins->purgatory;
-  pins->purgatory= 0;
+  /* Store info about current purgatory. */
+  struct st_match_and_save_arg arg = {pins, pinbox, pins->purgatory};
+  /* Reset purgatory. */
+  pins->purgatory= NULL;
   pins->purgatory_count= 0;
-  while (list)
+
+
+  lf_dynarray_iterate(&pinbox->pinarray, match_and_save, &arg);
+
+  if (arg.old_purgatory)
   {
-    void *cur= list;
-    list= *(void **)((char *)cur+pinbox->free_ptr_offset);
-    if (npins)
-    {
-      if (addr) /* use binary search */
-      {
-        void **a, **b, **c;
-        for (a= addr, b= addr+npins-1, c= a+(b-a)/2; (b-a) > 1; c= a+(b-a)/2)
-          if (cur == *c)
-            a= b= c;
-          else if (cur > *c)
-            a= c;
-          else
-            b= c;
-        if (cur == *a || cur == *b)
-          goto found;
-      }
-      else /* no alloca - no cookie. linear search here */
-      {
-        if (lf_dynarray_iterate(&pinbox->pinarray, match_pins, cur))
-          goto found;
-      }
-    }
-    /* not pinned - freeing */
-    if (last)
-      last= next_node(pinbox, last)= (uchar *)cur;
-    else
-      first= last= (uchar *)cur;
-    continue;
-found:
-    /* pinned - keeping */
-    add_to_purgatory(pins, cur);
+    /* Some objects in the old purgatory were not pinned, free them. */
+    void *last= arg.old_purgatory;
+    while (pnext_node(pinbox, last))
+      last= pnext_node(pinbox, last);
+    pinbox->free_func(arg.old_purgatory, last, pinbox->free_func_arg);
   }
-  if (last)
-    pinbox->free_func(first, last, pinbox->free_func_arg);
 }
+
+#define next_node(P, X) (*((uchar * volatile *)(((uchar *)(X)) + (P)->free_ptr_offset)))
+#define anext_node(X) next_node(&allocator->pinbox, (X))
 
 /* lock-free memory allocator for fixed-size objects */
 


### PR DESCRIPTION
## Description

MariaDB supports a "wait-free concurrent allocator based on pinning addresses".
In `lf_pinbox_real_free()` it tries to sort the pinned addresses for better
performance to use binary search during "real free". `alloca()` was used to
allocate stack memory and copy addresses.

To prevent a stack overflow when allocating the stack memory the function checks
if there's enough stack space. However, the available stack size was calculated
inaccurately which eventually caused database crash due to stack overflow.

The crash was seen on MariaDB 10.6.11 but the same code defect exists on all
MariaDB versions.

Crash stack trace example:

```
#0  msort_with_tmp (p=0x40333f0790a0, b=0x40333f0790d0, n=3) at msort.c:40
#1  0x000040000456c86c in msort_with_tmp (n=3, b=0x40333f0790d0, p=0x40333f079100) at msort.c:45
#2  __GI___qsort_r (b=b@entry=0x40333f0790d0, n=n@entry=3, s=s@entry=8, cmp=cmp@entry=0xaaaac50af0e0 <ptr_cmp>, arg=arg@entry=0x0) at msort.c:297
#3  0x000040000456c968 in __GI_qsort (b=b@entry=0x40333f0790d0, n=n@entry=3, s=s@entry=8, cmp=cmp@entry=0xaaaac50af0e0 <ptr_cmp>) at msort.c:308
#4  0x0000aaaac50af498 in lf_pinbox_real_free (pins=0x4032bb19b610) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/mysys/lf_alloc-pin.c:358
#5  0x0000aaaac50af74c in lf_pinbox_free (pins=pins@entry=0x4032bb19b610, addr=<optimized out>) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/mysys/lf_alloc-pin.c:271
#6  0x0000aaaac50b0fc4 in l_delete (pins=0x4032bb19b610, keylen=<optimized out>, key=0x4033257b3b40 "\002dlrtms_lt", hashnr=4146604099, cs=0xaaaac5aeb5e0 <my_charset_bin>, head=0x400014a82098) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/mysys/lf_hash.cc:258
#7  lf_hash_delete (hash=0xaaaac5b74500 <mdl_locks>, pins=0x4032bb19b610, key=0x4033257b3b40, keylen=<optimized out>) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/mysys/lf_hash.cc:467
#8  0x0000aaaac48577c4 in MDL_context::release_lock (this=<optimized out>, duration=<optimized out>, ticket=0x403289fb0620) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/mdl.cc:2886
#9  0x0000aaaac4857848 in MDL_context::release_locks_stored_before (this=this@entry=0x40332803d370, duration=duration@entry=MDL_TRANSACTION, sentinel=sentinel@entry=0x0) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/mdl.cc:2936
#10 0x0000aaaac4857d24 in MDL_context::release_transactional_locks (this=this@entry=0x40332803d370, thd=thd@entry=0x40332803d218) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/mdl.cc:3122
#11 0x0000aaaac476fa00 in THD::release_transactional_locks (this=<optimized out>) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/sql_class.h:5071
#12 mysql_execute_command (thd=thd@entry=0x40332803d218, is_called_from_prepared_stmt=is_called_from_prepared_stmt@entry=false) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/sql_parse.cc:6150
#13 0x0000aaaac4774f0c in mysql_parse (thd=0x40332803d218, rawbuf=<optimized out>, length=<optimized out>, parser_state=<optimized out>) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/sql_parse.cc:8123
#14 0x0000aaaac476d050 in dispatch_command (command=command@entry=COM_QUERY, thd=thd@entry=0x40332803d218, packet=packet@entry=0x403328054359 "", packet_length=packet_length@entry=2581, blocking=125, blocking@entry=true)
    at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/sql_parse.cc:1907
#15 0x0000aaaac476c244 in do_command (thd=0x40332803d218, blocking=blocking@entry=true) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/sql_parse.cc:1417
#16 0x0000aaaac484eb44 in do_handle_one_connection (connect=<optimized out>, connect@entry=0x40330f279dd8, put_in_cache=put_in_cache@entry=true) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/sql_connect.cc:1459
#17 0x0000aaaac484eec8 in handle_one_connection (arg=arg@entry=0x40330f279dd8) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/sql/sql_connect.cc:1361
#18 0x0000aaaac4dad8f0 in pfs_spawn_thread (arg=0x40330f367018) at /local/p4clients/pkgbuild-QlPbg/workspace/src/MariaDB/storage/perfschema/pfs.cc:2201
#19 0x000040000450a22c in start_thread (arg=0x400004533000) at pthread_create.c:465
#20 0x000040000460ca1c in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:80
```

Why was the available stack size calculation inaccurate?

- MariaDB defines the `thd->thread_stack` to be used as a stack thread
  pointer. However, that's not the accurate value of the stack starting
  address instead it's the address of the `thd` object.
  `thd->thread_stack= (char*) &thd;`
- That inaccurate value is then used to calculate the variable of
  `stack_ends_here` which is eventually used in function
  `lf_pinbox_real_free()` to get the available stack size.

- The end result is inaccurate and could cause stack overflow in the
  qsort() function, especially when there are high connection numbers.
  e.g. 8000-12000 concurrent connections with MariaDB system variable
  `thread_stack`=262144.
  https://mariadb.com/kb/en/server-system-variables/#thread_stack

- Additionally it's easier to be reproduced on ARM instances, it's
  likely related to there are more registers to save/restore on ARM64
  and the structure alignment on ARM tends to have stronger alignment
  requirements.
  Those differences cause slightly different stack frame sizes, and with
  the higher performance of AWS r6g.8xlarge instances, it may cause
  higher number of pinned addresses in the pinbox.

A similar issue happened previously and the fix in fc2c1e43 was to add a
`ALLOCA_SAFETY_MARGIN` which is 8192 bytes. However, that safety margin is not
enough during high connection workloads.

MySQL also had a similar issue and the fix
https://github.com/mysql/mysql-server/commit/b086fda was to remove the use of
`alloca` and replace qsort approach by a linear scan through all pointers (pins)
owned by each thread.

This commit is mostly the same as it is the only way to solve this issue as:
1. Frame sizes in different architecture can be different.
2. Number of active (non-null) pinned addresses varies, so the frame
   size for the recursive sorting function `msort_with_tmp` is also hard
   to predict.
   *Note the number of active pinned addresses usually is very small,
    with 8000 active connections on an AWS r6g.8xlarge instance it's
    about less than 10. But we don't know if there's edge case that the
    value could be bigger.*
3. Allocating big memory blocks in stack doesn't seem to be a very good
   practice.

For further details see the mentioned commit in MySQL and the inline comments.

In addition, `thd->thread_stack` and `stack_ends_here` should not be
used to calculate if we need an accurate value related to the stack
size. However `stack_ends_here` is already used in many places so I
would not deprecate or change it in this commit.

Mini-benchmarking test had been done with script
https://github.com/MariaDB/server/blob/10.11/support-files/mini-benchmark.sh
and no performance regression was seen.


## How can this PR be tested?

MTR and mini-benchmark tests had been done to verify there's no regression.

## Basing the PR against the correct MariaDB version

- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Copyright

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.