### PR TITLE
MDEV-30351 crash in Item_func_left::val_str

### DIFF
--- a/mysql-test/main/func_str.result
+++ b/mysql-test/main/func_str.result
@@ -5240,6 +5240,15 @@ DROP TABLE crash_test_2;
 # Start of 10.4 tests
 #
 #
+# MDEV-30351 crash in Item_func_left::val_str
+#
+SELECT WEIGHT_STRING('aa') IN (LEFT(WEIGHT_STRING('aaa'),4),'bbb') as expect_1;
+expect_1
+1
+SELECT UNHEX('0032') in (LEFT(UNHEX('003200'), 2),'dog') as expect_1;
+expect_1
+1
+#
 # MDEV-21841 CONV() function truncates the result type to 21 symbol.
 #
 CREATE TABLE t1(i BIGINT);

--- a/mysql-test/main/func_str.test
+++ b/mysql-test/main/func_str.test
@@ -2256,15 +2256,21 @@ CREATE TABLE crash_test_2 (
 DROP TABLE t1;
 DROP TABLE crash_test_2;
 
-
 --echo #
 --echo # End of 10.3 tests
 --echo #
 
-
 --echo #
 --echo # Start of 10.4 tests
 --echo #
+
+--echo #
+--echo # MDEV-30351 crash in Item_func_left::val_str
+--echo #
+
+SELECT WEIGHT_STRING('aa') IN (LEFT(WEIGHT_STRING('aaa'),4),'bbb') as expect_1;
+
+SELECT UNHEX('0032') in (LEFT(UNHEX('003200'), 2),'dog') as expect_1;
 
 --echo #
 --echo # MDEV-21841 CONV() function truncates the result type to 21 symbol.

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -3729,6 +3729,7 @@ String *Item_func_weight_string::val_str(String *str)
                                  flags);
   DBUG_ASSERT(frm_length <= tmp_length);
 
+  str->set_charset(&my_charset_bin);
   str->length(frm_length);
   null_value= 0;
   return str;
@@ -3808,6 +3809,7 @@ String *Item_func_unhex::val_str(String *str)
 
   from= res->ptr();
   null_value= 0;
+  str->set_charset(&my_charset_bin);
   str->length(length);
   to= (char*) str->ptr();
   if (res->length() % 2)


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30351

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
crash in `Item_func_left::val_str`
## How can this PR be tested?
The test is appended to `func_str`

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
