### PR TITLE
Make 'move_file' command more reliable in mysqltest

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -3814,9 +3814,21 @@ void do_move_file(struct st_command *command)
                      sizeof(move_file_args)/sizeof(struct command_arg),
                      ' ');
 
-  if (bad_path(ds_to_file.str))
-    DBUG_VOID_RETURN;
+  size_t from_plen = strlen(ds_from_file.str);
+  size_t to_plen = strlen(ds_to_file.str);
+  const char *vardir= getenv("MYSQLTEST_VARDIR");
+  const char *tmpdir= getenv("MYSQL_TMP_DIR");
 
+  if (!((is_sub_path(ds_from_file.str, from_plen, vardir) && 
+        is_sub_path(ds_to_file.str, to_plen, vardir)) || 
+        (is_sub_path(ds_from_file.str, from_plen, tmpdir) && 
+        is_sub_path(ds_to_file.str, to_plen, tmpdir)))) {
+        report_or_die("Paths '%s' and '%s' are not both under MYSQLTEST_VARDIR '%s'"
+                "or both under MYSQL_TMP_DIR '%s'",
+                ds_from_file, ds_to_file, vardir, tmpdir);
+        DBUG_VOID_RETURN;
+  }
+  
   DBUG_PRINT("info", ("Move %s to %s", ds_from_file.str, ds_to_file.str));
   error= (my_rename(ds_from_file.str, ds_to_file.str,
                     MYF(disable_warnings ? 0 : MY_WME)) != 0);

--- a/mysql-test/suite/innodb/r/innodb-wl5522.result
+++ b/mysql-test/suite/innodb/r/innodb-wl5522.result
@@ -63,16 +63,24 @@ a	b	c
 # Done restarting server
 # List before t1 DISCARD
 db.opt
+t1.cfg.sav
 t1.frm
 t1.ibd
+t1.ibd.sav
+t2.cfg.sav
 t2.frm
 t2.ibd
+t2.ibd.sav
 ALTER TABLE t1 DISCARD TABLESPACE;
 # List after t1 DISCARD
 db.opt
+t1.cfg.sav
 t1.frm
+t1.ibd.sav
+t2.cfg.sav
 t2.frm
 t2.ibd
+t2.ibd.sav
 ALTER TABLE t1 IMPORT TABLESPACE;
 ALTER TABLE t1 ENGINE InnoDB;
 SELECT COUNT(*) FROM t1;
@@ -90,10 +98,14 @@ a	b	c
 638	Cavalry	..asdasdfaeraf
 db.opt
 t1.cfg
+t1.cfg.sav
 t1.frm
 t1.ibd
+t1.ibd.sav
+t2.cfg.sav
 t2.frm
 t2.ibd
+t2.ibd.sav
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 640
@@ -112,7 +124,9 @@ ALTER TABLE t2 ROW_FORMAT=DYNAMIC;
 ALTER TABLE t2 DISCARD TABLESPACE;
 # List after t2 DISCARD
 db.opt
+t2.cfg.sav
 t2.frm
+t2.ibd.sav
 ALTER TABLE t2 IMPORT TABLESPACE;
 ERROR HY000: Schema mismatch (Table flags don't match, server table has 0x21 and the meta-data file has 0x1; .cfg file uses ROW_FORMAT=COMPACT)
 ALTER TABLE t2 IMPORT TABLESPACE;

--- a/mysql-test/suite/innodb/t/import_tablespace_race.test
+++ b/mysql-test/suite/innodb/t/import_tablespace_race.test
@@ -36,8 +36,8 @@ ALTER TABLE t NOWAIT ADD INDEX (c);
 
 FLUSH TABLE t FOR EXPORT;
 --let $create= query_get_value(SHOW CREATE TABLE t, Create Table, 1)
---copy_file $datadir/test/t.cfg $MYSQL_TMP_DIR/t.cfg
---copy_file $datadir/test/t.ibd $MYSQL_TMP_DIR/t.ibd
+--copy_file $datadir/test/t.cfg $datadir/test/t.cfg.sav
+--copy_file $datadir/test/t.ibd $datadir/test/t.ibd.sav
 UNLOCK TABLES;
 
 DROP TABLE t;
@@ -46,8 +46,8 @@ eval $create;
 --enable_query_log
 
 ALTER TABLE t DISCARD TABLESPACE;
---move_file $MYSQL_TMP_DIR/t.cfg $datadir/test/t.cfg
---move_file $MYSQL_TMP_DIR/t.ibd $datadir/test/t.ibd
+--move_file $datadir/test/t.cfg.sav $datadir/test/t.cfg
+--move_file $datadir/test/t.ibd.sav $datadir/test/t.ibd
 ALTER TABLE t IMPORT TABLESPACE;
 
 # Cleanup

--- a/mysql-test/suite/innodb/t/innodb-wl5522.test
+++ b/mysql-test/suite/innodb/t/innodb-wl5522.test
@@ -9,7 +9,6 @@ call mtr.add_suppression("InnoDB: Unable to import tablespace .* because it alre
 call mtr.add_suppression("Index for table 't2' is corrupt; try to repair it");
 FLUSH TABLES;
 
-let $MYSQLD_TMPDIR = `SELECT @@tmpdir`;
 let $MYSQLD_DATADIR = `SELECT @@datadir`;
 let $checksum_algorithm = `SELECT @@innodb_checksum_algorithm`;
 
@@ -39,10 +38,10 @@ CREATE TABLE t2(a INT PRIMARY KEY) ENGINE=InnoDB ROW_FORMAT=COMPACT;
 FLUSH TABLE t1, t2 FOR EXPORT;
 --echo # List before copying files
 --list_files $MYSQLD_DATADIR/test
---copy_file $MYSQLD_DATADIR/test/t1.cfg $MYSQLD_TMPDIR/t1.cfg
---copy_file $MYSQLD_DATADIR/test/t1.ibd $MYSQLD_TMPDIR/t1.ibd
---move_file $MYSQLD_DATADIR/test/t2.cfg $MYSQLD_TMPDIR/t2.cfg
---copy_file $MYSQLD_DATADIR/test/t2.ibd $MYSQLD_TMPDIR/t2.ibd
+--copy_file $MYSQLD_DATADIR/test/t1.cfg $MYSQLD_DATADIR/test/t1.cfg.sav
+--copy_file $MYSQLD_DATADIR/test/t1.ibd $MYSQLD_DATADIR/test/t1.ibd.sav
+--move_file $MYSQLD_DATADIR/test/t2.cfg $MYSQLD_DATADIR/test/t2.cfg.sav
+--copy_file $MYSQLD_DATADIR/test/t2.ibd $MYSQLD_DATADIR/test/t2.ibd.sav
 UNLOCK TABLES;
 INSERT INTO t1 (b, c) SELECT b,c FROM t1 ORDER BY a;
 SELECT COUNT(*) FROM t1;
@@ -56,8 +55,8 @@ SELECT * FROM t1 ORDER BY a DESC LIMIT 3;
 ALTER TABLE t1 DISCARD TABLESPACE;
 --echo # List after t1 DISCARD
 --list_files $MYSQLD_DATADIR/test
---copy_file $MYSQLD_TMPDIR/t1.cfg $MYSQLD_DATADIR/test/t1.cfg
---copy_file $MYSQLD_TMPDIR/t1.ibd $MYSQLD_DATADIR/test/t1.ibd
+--copy_file $MYSQLD_DATADIR/test/t1.cfg.sav $MYSQLD_DATADIR/test/t1.cfg
+--copy_file $MYSQLD_DATADIR/test/t1.ibd.sav $MYSQLD_DATADIR/test/t1.ibd
 ALTER TABLE t1 IMPORT TABLESPACE;
 ALTER TABLE t1 ENGINE InnoDB;
 SELECT COUNT(*) FROM t1;
@@ -68,15 +67,15 @@ SELECT COUNT(*) FROM t1;
 SELECT * FROM t1 ORDER BY b,a DESC LIMIT 3;
 SELECT * FROM t1 ORDER BY a DESC LIMIT 3;
 DROP TABLE t1;
---remove_file $MYSQLD_TMPDIR/t1.cfg
---remove_file $MYSQLD_TMPDIR/t1.ibd
+--remove_file $MYSQLD_DATADIR/test/t1.cfg.sav
+--remove_file $MYSQLD_DATADIR/test/t1.ibd.sav
 
 ALTER TABLE t2 ROW_FORMAT=DYNAMIC;
 ALTER TABLE t2 DISCARD TABLESPACE;
 --echo # List after t2 DISCARD
 --list_files $MYSQLD_DATADIR/test
---move_file $MYSQLD_TMPDIR/t2.ibd $MYSQLD_DATADIR/test/t2.ibd
---move_file $MYSQLD_TMPDIR/t2.cfg $MYSQLD_DATADIR/test/t2.cfg
+--move_file $MYSQLD_DATADIR/test/t2.ibd.sav $MYSQLD_DATADIR/test/t2.ibd
+--move_file $MYSQLD_DATADIR/test/t2.cfg.sav $MYSQLD_DATADIR/test/t2.cfg
 --error ER_TABLE_SCHEMA_MISMATCH
 ALTER TABLE t2 IMPORT TABLESPACE;
 --remove_file $MYSQLD_DATADIR/test/t2.cfg

--- a/mysql-test/suite/innodb/t/restart.test
+++ b/mysql-test/suite/innodb/t/restart.test
@@ -4,6 +4,7 @@
 
 let datadir= `select @@datadir`;
 let page_size= `select @@innodb_page_size`;
+let tmp_in_vardir=$MYSQLTEST_VARDIR/tmp;
 
 --echo #
 --echo # MDEV-15333 MariaDB (still) slow start
@@ -28,19 +29,19 @@ call mtr.add_suppression("\\[Warning\\] InnoDB: Ignoring tablespace for `test`\\
 CREATE TABLE tr(a INT)ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
 CREATE TABLE tc(a INT)ENGINE=InnoDB ROW_FORMAT=COMPACT
 PAGE_COMPRESSED=1 PAGE_COMPRESSION_LEVEL=9;
---replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+--replace_result $tmp_in_vardir MYSQL_TMP_DIR
 eval CREATE TABLE td(a INT)ENGINE=InnoDB ROW_FORMAT=DYNAMIC
-STATS_PERSISTENT=0 DATA DIRECTORY='$MYSQL_TMP_DIR';
+STATS_PERSISTENT=0 DATA DIRECTORY='$tmp_in_vardir';
 
 --source include/shutdown_mysqld.inc
 
 --move_file $datadir/test/tr.ibd $datadir/test/tr0.ibd
 --move_file $datadir/test/tc.ibd $datadir/test/tc0.ibd
---move_file $MYSQL_TMP_DIR/test/td.ibd $datadir/test/td0.ibd
+--move_file $tmp_in_vardir/test/td.ibd $datadir/test/td0.ibd
 # TODO: test that MariaDB does not even attempt to open the files
 #--mkdir $datadir/test/tr.ibd
 #--mkdir $datadir/test/tc.ibd
-#--mkdir $MYSQL_TMP_DIR/test/td.ibd
+#--mkdir $tmp_in_vardir/test/td.ibd
 
 perl;
 die unless open OUT, ">", "$ENV{datadir}/test/tr.ibd";
@@ -49,7 +50,7 @@ close OUT or die;
 die unless open OUT, ">", "$ENV{datadir}/test/tc.ibd";
 print OUT "bar " x $ENV{page_size};
 close OUT or die;
-die unless open OUT, ">", "$ENV{MYSQL_TMP_DIR}/test/td.ibd";
+die unless open OUT, ">", "$ENV{tmp_in_vardir}/test/td.ibd";
 print OUT "Xyz " x $ENV{page_size};
 close OUT or die;
 EOF
@@ -67,14 +68,14 @@ AND support IN ('YES', 'DEFAULT', 'ENABLED');
 # TODO: test that MariaDB does not even attempt to open the files
 #--rmdir $datadir/test/tr.ibd
 #--rmdir $datadir/test/tc.ibd
-#--rmdir $MYSQL_TMP_DIR/test/td.ibd
+#--rmdir $tmp_in_vardir/test/td.ibd
 --remove_file $datadir/test/tr.ibd
 --remove_file $datadir/test/tc.ibd
---remove_file $MYSQL_TMP_DIR/test/td.ibd
+--remove_file $tmp_in_vardir/test/td.ibd
 
 --move_file $datadir/test/tr0.ibd $datadir/test/tr.ibd
 --move_file $datadir/test/tc0.ibd $datadir/test/tc.ibd
---move_file $datadir/test/td0.ibd $MYSQL_TMP_DIR/test/td.ibd
+--move_file $datadir/test/td0.ibd $tmp_in_vardir/test/td.ibd
 
 --source include/start_mysqld.inc
 SELECT * FROM tr;
@@ -144,13 +145,13 @@ if ($MTR_COMBINATION_64K)
 }
 
 --error 1
-exec $MYSQLD --no-defaults --skip-networking --innodb_data_file_path=ibdata1:$ibdata_size --innodb-page-size=$page_size --datadir=$MYSQLD_DATADIR --log-error=$MYSQL_TMP_DIR/attempted_start.err;
+exec $MYSQLD --no-defaults --skip-networking --innodb_data_file_path=ibdata1:$ibdata_size --innodb-page-size=$page_size --datadir=$MYSQLD_DATADIR --log-error=$tmp_in_vardir/attempted_start.err;
 
-let SEARCH_FILE= $MYSQL_TMP_DIR/attempted_start.err;
+let SEARCH_FILE= $tmp_in_vardir/attempted_start.err;
 let SEARCH_PATTERN= InnoDB: MySQL-8\.0 tablespace in \./ibdata1;
 source include/search_pattern_in_file.inc;
 
---remove_file $MYSQL_TMP_DIR/attempted_start.err
+--remove_file $tmp_in_vardir/attempted_start.err
 --remove_file $MYSQLD_DATADIR/ibdata1
 --move_file $MYSQLD_DATADIR/ibdata1.bak $MYSQLD_DATADIR/ibdata1
 


### PR DESCRIPTION
## Describe
The tests innodb.import_tablespace_race, innodn.restart, and innodb.innodb-wl5522 move the tablespace file between the data directory and the tmp directory specified by global environment variables. The code looks like: `--move_file $tmpdir/file $datadir/file`

However this is risky because it's not unusual that the set tmp directory (often under /tmp) is mounted on another disk partition or device, and 'move_file' command may fail with "Errcode: 18 'Invalid cross-device link'".

A screenshot of the error:

> CURRENT_TEST: innodb.import_tablespace_race

> /local/.../client//mariadb-test: Error on rename of '/tmp/1TzsNV4ZrR/7/t.cfg' to '/local/.../mysql-test/var/7/mysqld.1/data//test/t.cfg' (Errcode: 18 "Invalid cross-device link")

> mysqltest: At line 50: command "move_file" failed with error: 1  my_errno: 18  errno: 18

> The result from queries just before the failure was:

> < snip >
> ENGINE=InnoDB CHARSET latin1;
> INSERT INTO t SELECT seq, 'x' FROM seq_1_to_100;
> connect  con1,localhost,rdsadmin,,test;
> BEGIN NOT ATOMIC
> DECLARE a INT DEFAULT 0;
> REPEAT
> SET a= a+1;
> UPDATE t SET c = 'xx' WHERE pk = a;
> UNTIL a = 100
> END REPEAT;
> END
> $
> connection default;
> ALTER TABLE t NOWAIT ADD INDEX (c);
> connection con1;
> connection default;
> FLUSH TABLE t FOR EXPORT;
> UNLOCK TABLES;
> DROP TABLE t;
> ALTER TABLE t DISCARD TABLESPACE;

> More results from queries before failure can be found in /local/.../mysql-test/var/7/log/import_tablespace_race.log

To stabilize mysqltest in the described scenario, when move_file errors with error code
EXDEV, attempt copy file followed by remove file. If copy + remove is success, consider
move_file also success; if copy + remove errors, show error message of the original
move_file command and error code EXDEV.

## How to test this PR
Mount /tmp to a different disk partition and set $MYSQL_TMP_DIR to it, and then run the tests to reproduce the error. After the code change, the tests should pass.

Or `./mtr innodb.import_tablespace_race --tmpdir=/dev/shm/tmp`

## Basing the PR against the correct MariaDB version
- [x] This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced and bug fixes are still being accepted.

## Copyright
All new code of the whole pull request, including one or several files that
are either new files or modified ones, are contributed under the BSD-new license.
I am contributing on behalf of my employer Amazon Web Services, Inc.