### PR TITLE
MDEV-30837: Remove awk from Debian scripts

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -201,7 +201,11 @@ then
   for package in *.deb
   do
     echo "$package" | cut -d '_' -f 1
-    dpkg-deb -c "$package" | awk '{print $1 " " $2 " " $6 " " $7 " " $8}' | sort -k 3
+    # shellcheck disable=SC2034
+    dpkg-deb -c "$package" | while IFS=" " read -r col1 col2 col3 col4 col5 col6 col7 col8
+    do
+        echo "$col1 $col2 $col6 $col7 $col8" | sort -k 3
+    done
     echo "------------------------------------------------"
   done
 fi

--- a/debian/mariadb-server.mariadb.init
+++ b/debian/mariadb-server.mariadb.init
@@ -84,7 +84,10 @@ sanity_checks() {
 
   # check for diskspace shortage
   datadir=`mariadbd_get_param datadir`
-  if LC_ALL=C BLOCKSIZE= df --portability $datadir/. | tail -n 1 | awk '{ exit ($4>4096) }'; then
+  # As preset blocksize of GNU df is 1024 then available bytes is $df_available_blocks * 1024
+  # 4096 blocks is then lower than 4 MB
+  df_available_blocks=`LC_ALL=C BLOCKSIZE= df --output=avail "$datadir" | tail -n 1`
+  if [ "$df_available_blocks" -lt "4096" ]; then
     log_failure_msg "$0: ERROR: The partition with $datadir is too full!"
     echo                "ERROR: The partition with $datadir is too full!" | $ERR_LOGGER
     exit 1

--- a/debian/mariadb-server.preinst
+++ b/debian/mariadb-server.preinst
@@ -196,8 +196,10 @@ if [ ! -d $mysql_datadir ] && [ ! -L $mysql_datadir ]; then
   mkdir -Z $mysql_datadir
 fi
 
-# checking disc space
-if LC_ALL=C BLOCKSIZE= df --portability $mysql_datadir/. | tail -n 1 | awk '{ exit ($4>1000) }'; then
+# As preset blocksize of GNU df is 1024 then available bytes is $df_available_blocks * 1024
+# 4096 blocks is then lower than 4 MB
+df_available_blocks=`LC_ALL=C BLOCKSIZE= df --output=avail "$datadir" | tail -n 1`
+if [ "$df_available_blocks" -lt "4096" ]; then
   echo "ERROR: There's not enough space in $mysql_datadir/" 1>&2
   db_stop
   exit 1


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30837*

## Description
Reasoning behind this is that AWK is under used to be hard dependency for building or  installating MariaDB with Debian. This PR removed most part of (G)AWK need.

Debian installation needs/uses AWK for checking for is there enough space for new database. As this is neat and cute way to do it is this reasoning to have AWK installed for example in container image if it's not needed afterwards?

AWK is also used with SysV-init script same purpose with one line which can be rewritten easily (as postint script) to use GNU `coreutils`  and pure BASH which are used and installed.

Same goes with `autobake-debs.sh` where AWK is used just for printing out packages after build. It can be rewritten using Bash only.

## How can this PR be tested?
This can be tested to build packages and install them and have not enough installation space (less than < 4096 blocks) and it should fail.

With `autobake-debs.sh` it can be seen if it's looking same as before

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility
For installaing Debian and SysV-init this should bring no changes. With `autobake-debs.sh` links are correctly printed with this one which was not working with AWK implementation.

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
