### PR TITLE
MDEV-30804 Rollback multi-engine transaction requiring 2PC but commtting in one phase

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-30804.result
+++ b/mysql-test/suite/galera/r/MDEV-30804.result
@@ -1,0 +1,11 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t (a INT) ENGINE=Aria;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+START TRANSACTION;
+INSERT INTO t VALUES ('1');
+INSERT INTO t1 VALUES ('1');
+COMMIT;
+ERROR HY000: Transactional commit not supported by involved engine(s)
+DROP TABLE t;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-30804.cnf
+++ b/mysql-test/suite/galera/t/MDEV-30804.cnf
@@ -1,0 +1,7 @@
+!include ../galera_2nodes.cnf
+
+[mysqld.1]
+log-bin
+
+[mysqld.2]
+log-bin

--- a/mysql-test/suite/galera/t/MDEV-30804.test
+++ b/mysql-test/suite/galera/t/MDEV-30804.test
@@ -1,0 +1,21 @@
+#
+# Test that transaction requiring two-phase commit and involving
+# storage engines not supporting it rolls back with a message.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+--source include/have_aria.inc
+
+CREATE TABLE t (a INT) ENGINE=Aria;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+
+START TRANSACTION;
+INSERT INTO t VALUES ('1');
+INSERT INTO t1 VALUES ('1');
+
+--error ER_ERROR_DURING_COMMIT
+COMMIT;
+
+DROP TABLE t;
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1733,7 +1733,19 @@ int ha_commit_trans(THD *thd, bool all)
       ordering is normally done. Commit ordering must be done here.
     */
     if (run_wsrep_hooks)
-      error= wsrep_before_commit(thd, all);
+    {
+      // This commit involves more than one storage engine and requires
+      // two phases, but some engines don't support it.
+      // Issue a message to the client and roll back the transaction.
+      if (trans->no_2pc && rw_ha_count > 1)
+      {
+        my_message(ER_ERROR_DURING_COMMIT, "Transactional commit not supported "
+                   "by involved engine(s)", MYF(0));
+        error= 1;
+      }
+      else
+        error= wsrep_before_commit(thd, all);
+    }
     if (error)
     {
       ha_rollback_trans(thd, FALSE);


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30804

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

When Galera and binlog are enabled, roll back a transaction that made changes to a number of storage engines, one of which is InnoDB and the other doesn't support two-phase commit. Issue a message to the client as well.

## How can this PR be tested?


MTR test is provided.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
