### PR TITLE
[MDEV-14978] Client programs to use $MARIADB_HOST consistently

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -1738,8 +1738,9 @@ static struct my_option my_long_options[] =
   {"force", 'f',
     "Continue even if we get an SQL error. Sets abort-source-on-error to 0",
     &ignore_errors, &ignore_errors, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host.", &current_host,
-   &current_host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host", 'h', "Connect to host. Defaults in the following order: "
+  "$MARIADB_HOST, $MYSQL_HOST, and then localhost",
+   &current_host, &current_host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"html", 'H', "Produce HTML output.", &opt_html, &opt_html,
    0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-spaces", 'i', "Ignore space after function names.",
@@ -2127,7 +2128,10 @@ static int get_options(int argc, char **argv)
   int ho_error;
   MYSQL_PARAMETERS *mysql_params= mysql_get_parameters();
 
-  tmp= (char *) getenv("MYSQL_HOST");
+  //MARIADB_HOST will be preferred over MYSQL_HOST.
+  tmp= getenv("MARIADB_HOST");
+  if (tmp == NULL)
+    tmp= getenv("MYSQL_HOST");
   if (tmp)
     current_host= my_strdup(PSI_NOT_INSTRUMENTED, tmp, MYF(MY_WME));
 

--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -146,8 +146,9 @@ static struct my_option my_long_options[] =
    &default_charset, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"help", '?', "Display this help and exit.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host.", &host, &host, 0, GET_STR,
-   REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host", 'h', "Connect to host. Defaults in the following order: "
+  "$MARIADB_HOST, and then localhost",
+   &host, &host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"local", 'l', "Local command, don't write to binlog.",
    &opt_local, &opt_local, 0, GET_BOOL, NO_ARG, 0, 0, 0,
    0, 0, 0},
@@ -328,6 +329,9 @@ int main(int argc,char *argv[])
   int error= 0, temp_argc;
   MYSQL mysql;
   char **commands, **save_argv, **temp_argv;
+
+  if (host == NULL)
+    host= getenv("MARIADB_HOST");
 
   MY_INIT(argv[0]);
   sf_leaking_memory=1; /* don't report memory leaks on early exits */

--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -1485,8 +1485,9 @@ static struct my_option my_options[] =
   {"hexdump", 'H', "Augment output with hexadecimal and ASCII event dump.",
    &opt_hexdump, &opt_hexdump, 0, GET_BOOL, NO_ARG,
    0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Get the binlog from server.", &host, &host,
-   0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host", 'h', "Get the binlog from server. Defaults in the following order: "
+  "$MARIADB_HOST, and then localhost",
+   &host, &host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"local-load", 'l', "Prepare local temporary files for LOAD DATA INFILE in the specified directory.",
    &dirname_for_local_load, &dirname_for_local_load, 0,
    GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
@@ -2265,6 +2266,11 @@ get_one_option(const struct my_option *opt, const char *argument,
 static int parse_args(int *argc, char*** argv)
 {
   int ho_error;
+  char *tmp;
+
+  tmp= getenv("MARIADB_HOST");
+  if (tmp && host == NULL)
+    host= my_strdup(PSI_NOT_INSTRUMENTED, tmp, MYF(MY_WME));
 
   if ((ho_error=handle_options(argc, argv, my_options, get_one_option)))
   {

--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -145,8 +145,9 @@ static struct my_option my_long_options[] =
    0, 0 },
   {"help", '?', "Display this help message and exit.", 0, 0, 0, GET_NO_ARG,
    NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host",'h', "Connect to host.", &current_host,
-   &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host",'h', "Connect to host. Defaults in the following order: "
+  "$MARIADB_HOST, and then localhost",
+   &current_host, &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"medium-check", 'm',
    "Faster than extended-check, but only finds 99.99 percent of all errors. Should be good enough for most cases.",
    0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0},
@@ -412,6 +413,9 @@ static int get_options(int *argc, char ***argv)
 {
   int ho_error;
   DBUG_ENTER("get_options");
+
+  if (current_host == NULL)
+    current_host= getenv("MARIADB_HOST");
 
   if (*argc == 1)
   {

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -437,8 +437,9 @@ static struct my_option my_long_options[] =
   {"hex-blob", 0, "Dump binary strings (BINARY, "
     "VARBINARY, BLOB) in hexadecimal format.",
    &opt_hex_blob, &opt_hex_blob, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host.", &current_host,
-   &current_host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host", 'h', "Connect to host. Defaults in the following order: "
+  "$MARIADB_HOST, and then localhost",
+   &current_host, &current_host, 0, GET_STR_ALLOC, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-database", OPT_IGNORE_DATABASE,
    "Do not dump the specified database. To specify more than one database to ignore, "
    "use the directive multiple times, once for each database. Only takes effect "
@@ -1107,8 +1108,13 @@ get_one_option(const struct my_option *opt,
 
 static int get_options(int *argc, char ***argv)
 {
+  char *tmp;
   int ho_error;
   MYSQL_PARAMETERS *mysql_params= mysql_get_parameters();
+
+  tmp= getenv("MARIADB_HOST");
+  if (tmp && current_host == NULL)
+    current_host= my_strdup(PSI_NOT_INSTRUMENTED, tmp, MYF(MY_WME));
 
   opt_max_allowed_packet= *mysql_params->p_max_allowed_packet;
   opt_net_buffer_length= *mysql_params->p_net_buffer_length;

--- a/client/mysqlimport.cc
+++ b/client/mysqlimport.cc
@@ -149,8 +149,9 @@ static struct my_option my_long_options[] =
    0, 0, 0, 0},
   {"help", '?', "Displays this help and exits.", 0, 0, 0, GET_NO_ARG, NO_ARG,
    0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host.", &current_host,
-   &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host", 'h', "Connect to host. Defaults in the following order: "
+  "$MARIADB_HOST, and then localhost",
+   &current_host, &current_host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore", 'i', "If duplicate unique key was found, keep old row.",
    &ignore, &ignore, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"ignore-foreign-keys", 'k',
@@ -366,6 +367,9 @@ get_one_option(const struct my_option *opt, const char *argument,
 static int get_options(int *argc, char ***argv)
 {
   int ho_error;
+
+  if (current_host == NULL)
+    current_host= getenv("MARIADB_HOST");
 
   if ((ho_error=handle_options(argc, argv, my_long_options, get_one_option)))
     exit(ho_error);

--- a/client/mysqlshow.c
+++ b/client/mysqlshow.c
@@ -204,8 +204,9 @@ static struct my_option my_long_options[] =
    GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"help", '?', "Display this help and exit.", 0, 0, 0, GET_NO_ARG, NO_ARG,
    0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host.", &host, &host, 0, GET_STR,
-   REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host", 'h', "Connect to host. Defaults in the following order: "
+  "$MARIADB_HOST, and then localhost",
+   &host, &host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"status", 'i', "Shows a lot of extra information about each table.",
    &opt_status, &opt_status, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0,
    0, 0},
@@ -362,6 +363,9 @@ static void
 get_options(int *argc,char ***argv)
 {
   int ho_error;
+
+  if (host == NULL)
+    host= getenv("MARIADB_HOST");
 
   if ((ho_error=handle_options(argc, argv, my_long_options, get_one_option)))
     exit(ho_error);

--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -611,8 +611,9 @@ static struct my_option my_long_options[] =
    "engine after a `:', like memory:max_row=2300",
    &default_engine, &default_engine, 0,
     GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
-  {"host", 'h', "Connect to host.", &host, &host, 0, GET_STR,
-    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
+  {"host", 'h', "Connect to host. Defaults in the following order: "
+  "$MARIADB_HOST, and then localhost",
+   &host, &host, 0, GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
   {"init-command", 0,
    "SQL Command to execute when connecting to MariaDB server. Will "
    "automatically be re-executed when reconnecting.",
@@ -1185,6 +1186,9 @@ get_options(int *argc,char ***argv)
     my_end_arg= MY_CHECK_ERROR | MY_GIVE_INFO;
   if (debug_check_flag)
     my_end_arg= MY_CHECK_ERROR;
+
+  if (host == NULL)
+    host= getenv("MARIADB_HOST");
 
   /*
     If something is created and --no-drop is not specified, we drop the

--- a/mysql-test/suite/client/client-env-variable.cnf
+++ b/mysql-test/suite/client/client-env-variable.cnf
@@ -1,0 +1,5 @@
+!include include/default_my.cnf
+
+[ENV]
+MARIADB_HOST=localhost
+MYSQL_HOST=some_server

--- a/mysql-test/suite/client/client-env-variable.result
+++ b/mysql-test/suite/client/client-env-variable.result
@@ -1,0 +1,7 @@
+USE test;
+CREATE TABLE pet (name VARCHAR(20));
+localhost
+****************
+nonexistent-server
+Done
+DROP TABLE pet;

--- a/mysql-test/suite/client/client-env-variable.test
+++ b/mysql-test/suite/client/client-env-variable.test
@@ -1,0 +1,87 @@
+-- source include/have_log_bin.inc
+
+# Set up environment varibles for client programs
+# The environment variables for client programs have default options file
+# They interfere with the MTR test so I am creating new variables for them
+
+--let MARIADB = $MYSQL_BINDIR/client//mariadb
+--let MARIADBADMIN = $MYSQL_BINDIR/client//mariadb-admin
+--let MARIADBBINLOG = $MYSQL_BINDIR/client//mariadb-binlog
+--let MARIADBCHECK = $MYSQL_BINDIR/client//mariadb-check
+--let MARIADBDUMP = $MYSQL_BINDIR/client//mariadb-dump
+--let MARIADBIMPORT = $MYSQL_BINDIR/client//mariadb-import
+--let MARIADBSHOW = $MYSQL_BINDIR/client//mariadb-show
+--let MARIADBSLAP = $MYSQL_BINDIR/client//mariadb-slap
+
+# Creating a table for the client programs
+USE test;
+CREATE TABLE pet (name VARCHAR(20));
+
+# Creating a data file for mysqlimport
+write_file $MYSQL_TMP_DIR/pet;
+buster
+bob
+EOF
+
+# Options for client program
+--let $options = --user=root --port=$MASTER_MYPORT --disable-ssl-verify-server-cert
+
+# Check to see if environment variable is defined
+# MARIADB_HOST is defined in client-env-variable.cnf
+--echo $MARIADB_HOST
+
+# Positive test for client program with MARIADB_HOST
+--exec $MARIADB $options -e "SHOW DATABASES;" > /dev/null 2>&1
+--exec $MARIADBADMIN $options processlist > /dev/null 2>&1
+--exec $MARIADBBINLOG $options --read-from-remote-server master-bin.000001 > /dev/null 2>&1
+--exec $MARIADBCHECK $options -c --databases test > /dev/null 2>&1
+--exec $MARIADBDUMP $options test > $MYSQL_TMP_DIR/tmp.sql > /dev/null 2>&1
+--exec $MARIADBIMPORT $options test --local $MYSQL_TMP_DIR/pet > /dev/null 2>&1
+--exec $MARIADBSHOW $options test > /dev/null 2>&1
+--exec $MARIADBSLAP $options > /dev/null 2>&1
+
+#Set up negative test with invalid server
+--echo ****************
+--let MARIADB_HOST=nonexistent-server
+--echo $MARIADB_HOST
+
+# Now run the same command as in the postive test case
+# Client programs are expected to fail since the server does not exist
+# Some client program fails with error 1 and some fails wtih error 2
+
+--error 1
+--exec $MARIADB $options -e "SHOW DATABASES;" > /dev/null 2>&1
+
+--error 1
+--exec $MARIADBADMIN $options processlist > /dev/null 2>&1
+
+--error 1
+--exec $MARIADBBINLOG $options --read-from-remote-server master-bin.000001 > /dev/null 2>&1
+
+--error 2
+--exec $MARIADBCHECK $options -c --databases test > /dev/null 2>&1
+
+--error 2
+--exec $MARIADBDUMP $options test > $MYSQL_TMP_DIR/tmp.sql > /dev/null 2>&1
+
+--error 1
+--exec $MARIADBIMPORT $options test $MYSQL_TMP_DIR/pet > /dev/null 2>&1
+
+--error 1
+--exec $MARIADBSLAP $options > /dev/null 2>&1
+
+# Run the same command but with '--host' to verify command line input overrides env variable
+--exec $MARIADB $options --host localhost -e "SHOW DATABASES;" > /dev/null 2>&1
+--exec $MARIADBADMIN $options --host localhost processlist > /dev/null 2>&1
+--exec $MARIADBBINLOG $options --host localhost --read-from-remote-server master-bin.000001 > /dev/null 2>&1
+--exec $MARIADBCHECK $options --host localhost -c --databases test > /dev/null 2>&1
+--exec $MARIADBDUMP $options --host localhost test > $MYSQL_TMP_DIR/tmp.sql > /dev/null 2>&1
+--exec $MARIADBIMPORT $options --host localhost test --local $MYSQL_TMP_DIR/pet > /dev/null 2>&1
+--exec $MARIADBSHOW $options --host localhost test > /dev/null 2>&1
+--exec $MARIADBSLAP $options --host localhost > /dev/null 2>&1
+
+# Clean up
+--echo Done
+DROP TABLE pet;
+--remove_file $MYSQL_TMP_DIR/tmp.sql
+--remove_file $MYSQL_TMP_DIR/pet


### PR DESCRIPTION
## Description
Note: mysql_upgrade already uses environment variable as default. This feature was not added in for mysql_plugin and mysqltest 

Only `mysql` client program was using $MYSQL_HOST as the default host.
Add the same feature in most other client programs but using $MARIADB_HOST instead.

## How can this PR be tested?

Set up environment variable `export MARIADB_HOST=your_test_server`

Run each client program with the following commands:

`client/mysqlslap -h another_test_server -P 3306 -u admin -p`

`client/mysqlslap  -P 3306 -u admin -p`

Verify that $MARIADB_HOST is used when `-h` is not specified. Also verify $MARIADB_HOST does not override command line argument.

## Basing the PR against the correct MariaDB version
- [X] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.