### PR TITLE
Add SAST scanning to Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ stages:
   - build
   - test
   - Salsa-CI
+  - sast
 
 default:
   # Base image for builds and tests unless otherwise defined
@@ -42,7 +43,7 @@ variables:
   CMAKE_FLAGS: "-DWITH_SSL=system -DPLUGIN_COLUMNSTORE=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_S3=NO -DPLUGIN_MROONGA=NO -DPLUGIN_CONNECT=NO -DPLUGIN_MROONGA=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_PERFSCHEMA=NO -DWITH_WSREP=OFF"
   # Major version dictates which branches share the same ccache. E.g. 10.6-abc
   # and 10.6-xyz will have the same cache.
-  MARIADB_MAJOR_VERSION: "10.8"
+  MARIADB_MAJOR_VERSION: "11.0"
   # NOTE! Currently ccache is only used on the Centos8 build. As each job has
   # sufficiently different environments they are unable to benefit from each
   # other's ccaches. As each build generates about 1 GB of ccache, having
@@ -517,6 +518,70 @@ mini-benchmark:
       metrics:
         - metrics.txt
 
+cppcheck: 
+  stage: sast
+  needs: []
+  variables:
+    GIT_STRATEGY: fetch
+    GIT_SUBMODULE_STRATEGY: normal
+  script:
+    - yum install -y cppcheck diffutils
+    # --template: use a single-line template
+    # --force: check large directories without warning
+    # -i<directory>: ignore this directory when scanning
+    # -j: run multiple cppcheck threads
+    # Use newline to escape colon in yaml
+    - >
+      cppcheck --template="{file}:{line}: {severity}: {message}" --force
+      client dbug extra include libmariadb libmysqld libservices mysql-test mysys mysys_ssl pcre plugin
+      strings tests unittest vio wsrep-lib sql sql-common storage
+      -istorage/mroonga -istorage/tokudb -istorage/spider -istorage/rocksdb -iextra/ -ilibmariadb/ -istorage/columnstore
+      --output-file=cppcheck.txt -j $(nproc)
+    # Parallel jobs may output findings in an nondeterministic order. Sort to match ignorelist.
+    - cat cppcheck.txt | sort > cppcheck_sorted.txt
+    # Remove line numbers for diff
+    - sed 's/:[^:]*:/:/' cppcheck_sorted.txt > cppcheck_sorted_no_line_numbers.txt
+    # Only print new issues not found in ignore list
+    - echo "Problems found in ignore list that were not discovered by cppcheck (may have been fixed)."
+    - diff --changed-group-format='%>' --unchanged-group-format='' cppcheck_sorted_no_line_numbers.txt tests/code_quality/cppcheck_ignorelist.txt || true
+    - echo "Problems found by cppcheck that were not in ignore list."
+    - diff --changed-group-format='%<' --unchanged-group-format='' cppcheck_sorted_no_line_numbers.txt tests/code_quality/cppcheck_ignorelist.txt > lines_not_ignored.txt || true
+    - cat lines_not_ignored.txt && test ! -s lines_not_ignored.txt
+  artifacts:
+    when: always
+    paths:
+      - cppcheck_sorted.txt
+
+flawfinder:
+  stage: sast
+  needs: []
+  variables:
+    GIT_STRATEGY: fetch
+    GIT_SUBMODULE_STRATEGY: normal
+  script:
+    - yum install -y python3 python3-pip jq diffutils git
+    - pip install flawfinder
+    - flawfinder --falsepositive --quiet --html . > flawfinder-all-vulnerabilities.html
+    - cat flawfinder-all-vulnerabilities.html | grep "Hits ="
+    - flawfinder --falsepositive --quiet --minlevel=5 --sarif . > flawfinder-output.json
+    # FlawFinder's --sarif output will display all vulnerabilities despite having --minlevel=5 specified.
+    # Therefore, we postprocess the results with jq and filter out findings where the vulnerability level is less than 5.
+    # Also in the SARIF output format, the vulnerabilities are ranked as 0.2/0.4/0.6/0.8/1.0 which correspond to the --minlevel=1/2/3/4/5 of FlawFinder.
+    # Additionally, we sort the results because individual findings are consistent across different runs, but their ordering may not be.
+    # Vulnerabilities can also be ignored in-line (/* Flawfinder: ignore */), but this option was chosen as to not clutter the codebase.
+    - jq 'del(.runs[] | .tool | .driver | .rules) | del(.runs[] | .results[] | select(.rank < 1)) | del(.runs[] | .results[] | .locations[] | .physicalLocation | .region | .startLine) | .runs[0].results|=sort_by(.fingerprints)' flawfinder-output.json > flawfinder-min-level5.json
+    # Diff against known vulnerabilities, but ignore the line number.
+    - echo "Problems found in ignore list that were not discovered by flawfinder (may have been fixed)."
+    - diff --changed-group-format='%>' --unchanged-group-format='' flawfinder-min-level5.json tests/code_quality/flawfinder_ignorelist.json || true
+    - echo "Problems found by flawfinder that were not in ignore list."
+    - diff --changed-group-format='%<' --unchanged-group-format='' flawfinder-min-level5.json tests/code_quality/flawfinder_ignorelist.json > lines_not_ignored.txt || true
+    - cat lines_not_ignored.txt && test ! -s lines_not_ignored.txt
+  artifacts:
+    when: always
+    paths:
+      - flawfinder-all-vulnerabilities.html
+      - flawfinder-min-level5.json
+      
 # Once all RPM builds and tests have passed, also run the DEB builds and tests
 # @NOTE: This is likely to work well only on salsa.debian.org as the Gitlab.com
 # runners are too small for everything this stage does.

--- a/tests/code_quality/cppcheck_ignorelist.txt
+++ b/tests/code_quality/cppcheck_ignorelist.txt
@@ -1,0 +1,252 @@
+client/mysql.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+client/mysql_plugin.c: error: snprintf format string requires 6 parameters but only 5 are given.
+client/mysql_upgrade.c: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+client/mysqladmin.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+client/mysqlbinlog.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+client/mysqlcheck.c: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+client/mysqlimport.c: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+client/mysqlshow.c: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+client/mysqltest.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+dbug/tests.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+lexyy.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+mysql-test/lib/My/SafeProcess/safe_process_win.cc: error: Uninitialized variable: message_text
+mysys/crc32/crc32_arm64.c: error: Unmatched '('. Configuration: 'HAVE_ARMV8_CRC;__FreeBSD__'.
+mysys/mf_keycache.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+mysys/my_delete.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+mysys/my_fopen.c: error: Return value of allocation function 'freopen' is not stored.
+mysys/my_getsystime.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+mysys/my_largepage.c: error: syntax error: 0 =
+mysys/my_pread.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+mysys/my_rename.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+mysys/my_winfile.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+mysys/my_write.c: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+mysys/thr_lock.c: error: There is an unknown macro here somewhere. Configuration is required. If MYSQL_TABLE_WAIT_VARIABLES is a macro then please configure it.
+mysys/tree.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+plugin/audit_null/audit_null.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_ed25519/server_ed25519.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_examples/auth_0x0100.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_examples/dialog_examples.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_examples/qa_auth_interface.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_examples/qa_auth_server.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_examples/test_plugin.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_gssapi/server_plugin.cc: error: syntax error
+plugin/auth_gssapi/sspi.h: error: #include nested too deeply
+plugin/auth_pam/auth_pam.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_pam/auth_pam_v1.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_pam/testing/pam_mariadb_mtr.c: error: Memory pointed to by 'resp' is freed twice.
+plugin/auth_pipe/auth_pipe.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/auth_socket/auth_socket.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/aws_key_management/aws_key_management_plugin.cc: error: syntax error
+plugin/cracklib_password_check/cracklib_password_check.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/daemon_example/daemon_example.cc: error: syntax error
+plugin/debug_key_management/debug_key_management_plugin.cc: error: syntax error
+plugin/disks/information_schema_disks.cc: error: syntax error
+plugin/example_key_management/example_key_management_plugin.cc: error: syntax error
+plugin/feedback/feedback.cc: error: syntax error
+plugin/file_key_management/file_key_management_plugin.cc: error: syntax error
+plugin/fulltext/plugin_example.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/func_test/plugin.cc: error: syntax error
+plugin/handler_socket/handlersocket/handlersocket.cpp: error: syntax error
+plugin/hashicorp_key_management/hashicorp_key_management_plugin.cc: error: syntax error
+plugin/locale_info/locale_info.cc: error: syntax error
+plugin/metadata_lock_info/metadata_lock_info.cc: error: syntax error
+plugin/password_reuse_check/password_reuse_check.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/provider_bzip2/plugin.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/provider_lz4/plugin.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/provider_lzma/plugin.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/provider_lzo/plugin.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/provider_snappy/plugin.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/qc_info/qc_info.cc: error: syntax error
+plugin/query_response_time/plugin.cc: error: syntax error
+plugin/query_response_time/query_response_time.cc: error: Array 'm_count[41]' accessed at index 43, which is out of bounds.
+plugin/query_response_time/query_response_time.cc: error: Array 'm_total[41]' accessed at index 43, which is out of bounds.
+plugin/server_audit/server_audit.c: error: Uninitialized variable: &tm_time
+plugin/server_audit/server_audit.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/server_audit/server_audit.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/server_audit/server_audit.c: error: Uninitialized variable: &tm_time
+plugin/simple_password_check/simple_password_check.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/sql_errlog/sql_errlog.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/sql_errlog/sql_errlog.c: error: Uninitialized variable: &t
+plugin/test_sql_service/test_sql_service.c: error: Found a exit path from function with non-void return type that has missing return statement
+plugin/type_geom/plugin.cc: error: syntax error
+plugin/type_inet/plugin.cc: error: syntax error
+plugin/type_mysql_json/type.cc: error: syntax error
+plugin/type_test/plugin.cc: error: syntax error
+plugin/type_uuid/plugin.cc: error: syntax error
+plugin/user_variables/user_variables.cc: error: syntax error
+plugin/userstat/userstat.cc: error: syntax error
+plugin/versioning/versioning.cc: error: syntax error
+plugin/wsrep_info/plugin.cc: error: syntax error
+sql-common/client.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+sql-common/client_plugin.c: error: va_list 'unused' used before va_start() was called.
+sql-common/client_plugin.c: error: va_list 'unused' used before va_start() was called.
+sql-common/client_plugin.c: error: va_list 'unused' used before va_start() was called.
+sql-common/client_plugin.c: error: va_list 'unused' used before va_start() was called.
+sql/debug.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+sql/debug_sync.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE is a macro then please configure it.
+sql/gcalc_slicescan.cc: warning: Possible null pointer dereference: first_bottom_point
+sql/gen_lex_hash.cc: error: Common realloc mistake: 'hash_map' nulled but not freed upon failure
+sql/handler.h: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+sql/log.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+sql/log_event.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+sql/net_serv.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+sql/opt_range.cc: error: Unmatched ')'. Configuration: 'OLD_SWEEP_COST'.
+sql/protocol.h: error: syntax error
+sql/rpl_gtid.h: error: va_list 'args' was opened but not closed by va_end().
+sql/rpl_gtid.h: error: va_list 'args' was opened but not closed by va_end().
+sql/rpl_utility.h: error: There is an unknown macro here somewhere. Configuration is required. If CPP_UNNAMED_NS_START is a macro then please configure it.
+sql/semisync_slave.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+sql/sql_base.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+sql/sql_select.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+sql/sql_string.cc: warning: Iterators to containers from different expressions 'to' and 'from' are used together.
+sql/sql_type.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+sql/table.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+sql/threadpool.h: error: syntax error
+sql/winservice.c: error: Resource leak: mariadb_upgrade_info
+sql/wsrep_thd.h: error: failed to expand 'wsrep_create_appliers', Wrong number of parameters for macro 'wsrep_create_appliers'.
+storage/archive/azio.c: error: Syntax Error: AST broken, 'if' doesn't have two operands.
+storage/archive/ha_archive.cc: error: syntax error
+storage/blackhole/ha_blackhole.cc: error: syntax error
+storage/connect/connect.cc: error: Uninitialized variable: lg
+storage/connect/domdoc.cpp: error: syntax error
+storage/connect/ha_connect.cc: error: syntax error
+storage/connect/myconn.cpp: error: Unmatched '{'. Configuration: 'ALPHA;MYSQL_PREPARED_STATEMENTS'.
+storage/connect/myconn.cpp: error: Unmatched '{'. Configuration: 'MYSQL_PREPARED_STATEMENTS'.
+storage/connect/odbconn.cpp: warning: Uninitialized variable: b
+storage/connect/odbconn.cpp: warning: Uninitialized variable: b
+storage/connect/odbconn.cpp: warning: Uninitialized variable: b
+storage/connect/plugutil.cpp: error: Width 255 given in format string (no. 2) is larger than destination buffer 'stmsg[200]', use %199[^\"] to prevent overflowing it.
+storage/connect/plugutil.cpp: error: Width 255 given in format string (no. 1) is larger than destination buffer 'stmsg[200]', use %199[^\"] to prevent overflowing it.
+storage/connect/tabjson.cpp: warning: Possible null pointer dereference: Val
+storage/connect/tabmul.cpp: error: Uninitialized variable: buf
+storage/connect/tabmul.cpp: error: Uninitialized variable: buf
+storage/connect/tabmul.cpp: error: Uninitialized variable: buf
+storage/connect/taboccur.cpp: warning: Uninitialized variable: *pcrp
+storage/connect/unzip.c: warning: Uninitialized variable: *pzlib_filefunc64_32_def.zopen32_file
+storage/connect/value.cpp: error: Signed integer overflow for expression 'n*126230400'.
+storage/connect/zip.c: warning: Uninitialized variable: *pzlib_filefunc64_32_def.zopen32_file
+storage/csv/ha_tina.cc: error: syntax error
+storage/example/ha_example.cc: error: syntax error
+storage/federated/ha_federated.cc: error: syntax error
+storage/heap/ha_heap.cc: error: syntax error
+storage/innobase/btr/btr0btr.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/btr/btr0cur.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/btr/btr0defragment.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/btr/btr0pcur.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/btr/btr0sea.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/buf/buf0buf.cc: error: There is an unknown macro here somewhere. Configuration is required. If ut_d is a macro then please configure it.
+storage/innobase/buf/buf0flu.cc: error: syntax error
+storage/innobase/buf/buf0lru.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/innobase/buf/buf0rea.cc: error: There is an unknown macro here somewhere. Configuration is required. If ut_d is a macro then please configure it.
+storage/innobase/dict/dict0crea.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/dict/dict0load.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/fil/fil0fil.cc: error: There is an unknown macro here somewhere. Configuration is required. If IF_WIN is a macro then please configure it.
+storage/innobase/fsp/fsp0file.cc: error: Resource leak: file
+storage/innobase/fsp/fsp0fsp.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/fts/fts0fts.cc: error: There is an unknown macro here somewhere. Configuration is required. If IF_WIN is a macro then please configure it.
+storage/innobase/fts/fts0opt.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/fts/fts0que.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/gis/gis0rtree.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/innobase/gis/gis0sea.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/handler/ha_innodb.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/innobase/handler/handler0alter.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/innobase/handler/i_s.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/ibuf/ibuf0ibuf.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/lock/lock0lock.cc: error: There is an unknown macro here somewhere. Configuration is required. If IF_WSREP is a macro then please configure it.
+storage/innobase/lock/lock0prdt.cc: error: Syntax Error: AST broken, 'g' doesn't have a parent.
+storage/innobase/log/log0log.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/log/log0log.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/log/log0recv.cc: error: There is an unknown macro here somewhere. Configuration is required. If ut_d is a macro then please configure it.
+storage/innobase/mtr/mtr0mtr.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/os/os0file.cc: error: syntax error
+storage/innobase/page/page0page.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/page/page0zip.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/pars/pars0pars.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/row/row0ftsort.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/row/row0import.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/row/row0ins.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/row/row0log.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/innobase/row/row0merge.cc: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/innobase/row/row0mysql.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/row/row0purge.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/row/row0quiesce.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/row/row0sel.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/row/row0upd.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/row/row0vers.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/srv/srv0srv.cc: error: There is an unknown macro here somewhere. Configuration is required. If ut_d is a macro then please configure it.
+storage/innobase/srv/srv0start.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/trx/trx0i_s.cc: error: Array 'table_cache->chunks[39]' accessed at index 39, which is out of bounds.
+storage/innobase/trx/trx0i_s.cc: error: Array 'table_cache->chunks[39]' accessed at index 39, which is out of bounds.
+storage/innobase/trx/trx0purge.cc: error: There is an unknown macro here somewhere. Configuration is required. If MY_ATTRIBUTE is a macro then please configure it.
+storage/innobase/trx/trx0rec.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/innobase/trx/trx0trx.cc: error: There is an unknown macro here somewhere. Configuration is required. If ut_d is a macro then please configure it.
+storage/innobase/trx/trx0undo.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/aria_pack.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ha_maria.cc: error: syntax error
+storage/maria/ha_maria.cc: error: syntax error
+storage/maria/ha_s3.cc: error: syntax error
+storage/maria/ha_s3.cc: error: Unmatched '{'. Configuration: 'MOVE_FILES_TO_S3_ON_CREATE'.
+storage/maria/ma_bitmap.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_blockrec.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_check.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_checkpoint.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_delete.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_ft_parser.c: error: Address of local auto-variable assigned to a function parameter.
+storage/maria/ma_key.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_loghandler.c: warning: Uninitialized variable: data->current_offset
+storage/maria/ma_open.c: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/maria/ma_pagecache.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_pagecache.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_range.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_recovery_util.c: error: va_start() or va_copy() called subsequently on 'args' without va_end() in between.
+storage/maria/ma_rkey.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_rt_index.c: error: failed to expand 'rt_PAGE_END', Wrong number of parameters for macro 'rt_PAGE_END'.
+storage/maria/ma_search.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_sp_key.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_update.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/maria/ma_write.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/ft_parser.c: error: Address of local auto-variable assigned to a function parameter.
+storage/myisam/ha_myisam.cc: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_check.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_close.c: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/myisam/mi_delete.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_key.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_locking.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_open.c: error: There is an unknown macro here somewhere. Configuration is required. If DBUG_EXECUTE_IF is a macro then please configure it.
+storage/myisam/mi_range.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_rkey.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_search.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_update.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/mi_write.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisam/myisampack.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+storage/myisammrg/ha_myisammrg.cc: error: syntax error
+storage/oqgraph/ha_oqgraph.cc: error: syntax error
+storage/perfschema/ha_perfschema.cc: error: syntax error
+storage/perfschema/table_esgs_by_host_by_event_name.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+storage/perfschema/table_esms_by_host_by_event_name.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+storage/perfschema/table_events_waits.cc: error: Uninitialized struct member: wait.m_wait_class
+storage/perfschema/table_events_waits.cc: error: Uninitialized variable: wait
+storage/perfschema/table_events_waits.cc: error: Uninitialized struct member: wait.m_wait_class
+storage/perfschema/table_events_waits.cc: error: Uninitialized variable: wait->m_wait_class
+storage/perfschema/table_ews_by_host_by_event_name.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+storage/perfschema/table_hosts.cc: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+storage/sequence/sequence.cc: error: syntax error
+storage/test_sql_discovery/test_sql_discovery.cc: error: syntax error
+strings/decimal.c: warning: Possible null pointer dereference: to
+strings/dump_map.c: error: Array 'fromstat[256]' accessed at index 256, which is out of bounds.
+tests/mysql_client_fw.c: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+tests/thread_test.c: error: There is an unknown macro here somewhere. Configuration is required. If STRINGIFY_ARG is a macro then please configure it.
+unittest/mysys/dynstring-t.c: error: syntax error
+unittest/mysys/queues-t.c: error: Uninitialized variable: i
+unittest/mysys/waiting_threads-t.c: error: Uninitialized variable: m
+unittest/mytap/tap.c: error: va_list 'ap' used before va_start() was called.
+unittest/mytap/tap.c: error: va_list 'ap' used before va_start() was called.
+unittest/mytap/tap.c: error: va_list 'ap' used before va_start() was called.
+unittest/mytap/tap.c: error: va_list 'ap' used before va_start() was called.
+vio/viosocket.c: error: There is an unknown macro here somewhere. Configuration is required. If MYSQL_SOCKET_WAIT_VARIABLES is a macro then please configure it.
+vio/viosocket.c: error: There is an unknown macro here somewhere. Configuration is required. If MYSQL_SOCKET_WAIT_VARIABLES is a macro then please configure it.
+vio/viosslfactories.c: error: There is an unknown macro here somewhere. Configuration is required. If ; is a macro then please configure it.
+vio/viotest-sslconnect.cc: error: Memory pointed to by 'vio' is freed twice.
+vio/viotest-sslconnect.cc: error: Memory pointed to by 'ssl_connector' is freed twice.
+wsrep-lib/src/server_state.cpp: error: syntax error: keyword 'try' is not allowed in global scope
+wsrep-lib/src/thread_service_v1.cpp: error: Rethrowing current exception with 'throw;', it seems there is no current exception to rethrow. If there is no current exception this calls std::terminate(). More: https://isocpp.org/wiki/faq/exceptions#throw-without-an-object

--- a/tests/code_quality/flawfinder_ignorelist.json
+++ b/tests/code_quality/flawfinder_ignorelist.json
@@ -1,0 +1,706 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Flawfinder",
+          "version": "2.0.19",
+          "informationUri": "https://dwheeler.com/flawfinder/",
+          "supportedTaxonomies": [
+            {
+              "name": "CWE",
+              "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+            }
+          ]
+        }
+      },
+      "columnKind": "utf16CodeUnits",
+      "results": [
+        {
+          "ruleId": "FF1035",
+          "level": "error",
+          "message": {
+            "text": "race/readlink:This accepts filename arguments; if an attacker can move those files or change the link content, a race condition results.  Also, it does not terminate with ASCII NUL. (CWE-362, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./extra/mariabackup/xtrabackup.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 17,
+                  "endColumn": 57,
+                  "snippet": {
+                    "text": "  ssize_t ret = readlink(\"/proc/self/exe\", buf, size-1);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "11523490c7f8cba115bce125bbce94de5cd5e7f66d4dd07a391aac70fbbdd353"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./client/mysqltest.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 13,
+                  "endColumn": 38,
+                  "snippet": {
+                    "text": "  err_code= chmod(ds_file.str, mode);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "12a7fa6bbd4c81be975838bae2b7b26fe841acaf9804e6d0299188683e230908"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/writeengine/shared/we_typeext.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 12,
+                  "endColumn": 63,
+                  "snippet": {
+                    "text": "    if (fs.chown(fileName.c_str(), uid, gid, funcErrno) == -1)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "16bbd2ed7b8f86182e8f66980ee23b9e0dfe63a9330b7c16a2c2b81a3e8a9377"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/utils/idbdatafile/PosixFileSystem.cpp",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 16,
+                  "endColumn": 49,
+                  "snippet": {
+                    "text": "  if ((ret = ::chown(objectName, p_uid, p_gid)))"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "1882617c363794bedb3e70a4a3be704a3ee928778709b75f971e91ffc7a224b6"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./libmariadb/external/zlib/examples/gun.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 11,
+                  "endColumn": 45,
+                  "snippet": {
+                    "text": "    (void)chown(to, was.st_uid, was.st_gid);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "29cdc74512c56c56c73604ac5fd1c08bf2b38845b3aa91f4129ef9424bdb7f7f"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1014",
+          "level": "error",
+          "message": {
+            "text": "buffer/gets:Does not check for buffer overflows (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./extra/readline/tilde.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 12,
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "      if (!gets (line))"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "34a940ccc6e0248a2cf725e8a0c3f808d1f36d47fc814bd9daadb17f5563d357"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./sql/sql_class.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 10,
+                  "endColumn": 28,
+                  "snippet": {
+                    "text": "  (void) chmod(path, 0644);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "3f97fd0452062ab69db87a04222a17c37c216c4e28e2ae3622730da8dd070d2e"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./mysys/my_chmod.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 7,
+                  "endColumn": 25,
+                  "snippet": {
+                    "text": "  if (chmod(name, mode))"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "46805eec1d288b072d4edb3214822220d394307195be79a33ec3bce455d14750"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1035",
+          "level": "error",
+          "message": {
+            "text": "race/readlink:This accepts filename arguments; if an attacker can move those files or change the link content, a race condition results.  Also, it does not terminate with ASCII NUL. (CWE-362, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./sql/signal_handler.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 13,
+                  "endColumn": 68,
+                  "snippet": {
+                    "text": "  if ((len= readlink(\"/proc/self/cwd\", buff, sizeof(buff)-1)) >= 0)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "4c4d621e451a67f86c3e999e9dd3ceb2639bf4f63b0a946b7836b01d752ca557"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1035",
+          "level": "error",
+          "message": {
+            "text": "race/readlink:This accepts filename arguments; if an attacker can move those files or change the link content, a race condition results.  Also, it does not terminate with ASCII NUL. (CWE-362, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/primitives/blockcache/fsutils.cpp",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 25,
+                  "endColumn": 77,
+                  "snippet": {
+                    "text": "  ssize_t realnamelen = readlink(path.string().c_str(), realname, PATH_MAX);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "52b685022ce9db6c7c332217d74745fc48b65e3e00f2cfdbde8f858d28b8aa9f"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/utils/idbdatafile/IDBFileSystem.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 15,
+                  "endColumn": 104,
+                  "snippet": {
+                    "text": "  virtual int chown(const char* objectName, const uid_t p_uid, const gid_t p_pid, int& funcErrno) const"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "5eb02dbd4395b5c1a30be2665e0db914b8a6fcc6997ae18f8cc8651ec2e788cb"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./libmariadb/external/zlib/examples/gun.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 11,
+                  "endColumn": 42,
+                  "snippet": {
+                    "text": "    (void)chmod(to, was.st_mode & 07777);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "6044966208b061aada8a837a2be969922745fc7d445f7429417ab77f19c40fa5"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/tools/passwd/secrets.cpp",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 9,
+                  "endColumn": 40,
+                  "snippet": {
+                    "text": "    if (chmod(filepathc, S_IRUSR) == 0)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "6f7b5195eb8526770ad61729bd310387d05d0407d1be5dc902f7116e365f4232"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/tools/passwd/secrets.cpp",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 13,
+                  "endColumn": 71,
+                  "snippet": {
+                    "text": "        if (chown(filepathc, userinfo->pw_uid, userinfo->pw_gid) == 0)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "745b105be1b6a7c1e78f52a190edb9aaa848acd9c284c18f40e8a613520ae3df"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/versioning/BRM/oidserver.cpp",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 7,
+                  "endColumn": 86,
+                  "snippet": {
+                    "text": "      chmod(fFilename.c_str(), 0664);  // XXXPAT: override umask at least for testing"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "7ccf3c7811cbce45e635a9fd32003a9477eeee78679105dd973ad921fb72672a"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1035",
+          "level": "error",
+          "message": {
+            "text": "race/readlink:This accepts filename arguments; if an attacker can move those files or change the link content, a race condition results.  Also, it does not terminate with ASCII NUL. (CWE-362, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./mysys/my_symlink.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 15,
+                  "endColumn": 56,
+                  "snippet": {
+                    "text": "  if ((length=readlink(filename, to, FN_REFLEN-1)) < 0)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "7da5207ac0f5baba73c026472a2d3805eed92931852575db64f513702977dd70"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/utils/idbdatafile/PosixFileSystem.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 7,
+                  "endColumn": 106,
+                  "snippet": {
+                    "text": "  int chown(const char* objectName, const uid_t p_uid, const gid_t p_pid, int& funcErrno) const override;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "837ef3ca85cb450e25a7db58e83d60ce5268b46e9130f6e47d781aff97b9a832"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/columnstore/columnstore/utils/idbdatafile/PosixFileSystem.cpp",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 22,
+                  "endColumn": 111,
+                  "snippet": {
+                    "text": "int PosixFileSystem::chown(const char* objectName, const uid_t p_uid, const gid_t p_gid, int& funcErrno) const"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "92873ab0b24cc9dc2ab7ec959968b3d3568e0d9e92b1659c4f823c322397f33a"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./mysys/my_redel.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 7,
+                  "endColumn": 49,
+                  "snippet": {
+                    "text": "  if (chown(to, statbuf.st_uid, statbuf.st_gid))"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "97d2cfe4cb9428e812b796eb39c27f28dc8b198ab9655c2aff8c442de39bdcfe"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1035",
+          "level": "error",
+          "message": {
+            "text": "race/readlink:This accepts filename arguments; if an attacker can move those files or change the link content, a race condition results.  Also, it does not terminate with ASCII NUL. (CWE-362, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./storage/rocksdb/rocksdb/port/stack_trace.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 15,
+                  "endColumn": 54,
+                  "snippet": {
+                    "text": "  auto read = readlink(link, name, sizeof(name) - 1);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "acb399f2a4a15ef8da36c47631bc4ee4bcc1bb0577dfbda141d2eb5d7723af40"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./mysys/my_copy.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 9,
+                  "endColumn": 46,
+                  "snippet": {
+                    "text": "    if (chmod(to, stat_buff.st_mode & 07777))"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "bddb795a7efbd73a4387bbd33fd4f9e505b4f759d784e5d51f60cc43011ee610"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1031",
+          "level": "error",
+          "message": {
+            "text": "race/chown:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./mysys/my_copy.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 9,
+                  "endColumn": 55,
+                  "snippet": {
+                    "text": "    if (chown(to, stat_buff.st_uid, stat_buff.st_gid))"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "c63a81105d753de4762cbcab48d9700f7069da3cd9d57bf4329a6d20fad288aa"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./sql/mysqld.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 12,
+                  "endColumn": 71,
+                  "snippet": {
+                    "text": "    (void) chmod(mysqld_unix_port,S_IFSOCK);\t/* Fix solaris 2.6 bug */"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "d0c4f1302290e2367e246ef7c8d3ea69589cbc4bc148e0efdd4c283fa03cbe01"
+          },
+          "rank": 1.0
+        },
+        {
+          "ruleId": "FF1033",
+          "level": "error",
+          "message": {
+            "text": "race/chmod:This accepts filename arguments; if an attacker can move those files, a race condition results. (CWE-362)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "./mysys/my_redel.c",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startColumn": 7,
+                  "endColumn": 42,
+                  "snippet": {
+                    "text": "  if (chmod(to, statbuf.st_mode & 07777))"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "e11b8df9cbb9e459e4d67a0af5e627b6b1285c78fe23f5a1c823285da96495a8"
+          },
+          "rank": 1.0
+        }
+      ],
+      "externalPropertyFileReferences": {
+        "taxonomies": [
+          {
+            "location": {
+              "uri": "https://raw.githubusercontent.com/sarif-standard/taxonomies/main/CWE_v4.4.sarif"
+            },
+            "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Include cppcheck and FlawFinder for SAST scanning.
Both have ignorelists so only new regressions will 
trigger failures in GitLab CI.

## How can this PR be tested?
The pipeline for these changes successfully complete and a [public pipeline](https://salsa.debian.org/robinnewhouse/mariadb-server-mirror/-/commits/11.0-gitlab-ci) is available.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] This is a new feature and the PR is based against the latest MariaDB development branch

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer
Amazon Web Services, Inc.