### PR TITLE
MDEV-30862 Assertion `mode_ == m_high_priority' failed

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-30862.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-30862.result
@@ -1,0 +1,11 @@
+connection node_2;
+connection node_1;
+SET autocommit=0;
+SET SESSION wsrep_trx_fragment_size=1;
+CREATE TABLE t2 SELECT seq FROM seq_1_to_50;
+ERROR 42000: CREATE TABLE AS SELECT is not supported with streaming replication
+CREATE TABLE t1 (f1 INT NOT NULL AUTO_INCREMENT PRIMARY KEY);
+INSERT INTO t1 VALUES(DEFAULT);
+CREATE TABLE t2 SELECT * FROM t1;
+ERROR 42000: CREATE TABLE AS SELECT is not supported with streaming replication
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/MDEV-30862.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-30862.test
@@ -1,0 +1,24 @@
+#
+# MDEV-30862 Assertion `mode_ == m_high_priority' failed in
+# void wsrep::client_state::after_applying()
+#
+
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+
+SET autocommit=0;
+SET SESSION wsrep_trx_fragment_size=1;
+--error ER_NOT_ALLOWED_COMMAND
+CREATE TABLE t2 SELECT seq FROM seq_1_to_50;
+
+
+#
+# Same test without using seq
+#
+CREATE TABLE t1 (f1 INT NOT NULL AUTO_INCREMENT PRIMARY KEY);
+INSERT INTO t1 VALUES(DEFAULT);
+--error ER_NOT_ALLOWED_COMMAND
+CREATE TABLE t2 SELECT * FROM t1;
+
+
+DROP TABLE t1;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -11569,6 +11569,19 @@ bool Sql_cmd_create_table_like::execute(THD *thd)
   }
 #endif
 
+#ifdef WITH_WSREP
+  if (select_lex->item_list.elements && // With SELECT
+      WSREP(thd) && thd->variables.wsrep_trx_fragment_size > 0)
+  {
+    my_message(
+        ER_NOT_ALLOWED_COMMAND,
+        "CREATE TABLE AS SELECT is not supported with streaming replication",
+        MYF(0));
+    res= 1;
+    goto end_with_restore_list;
+  }
+#endif /* WITH_WSREP */
+
   if (select_lex->item_list.elements || select_lex->tvc) // With select or TVC
   {
     select_result *result;


### PR DESCRIPTION
CREATE TABLE AS SELECT is not supported in combination with streaming replication.