### PR TITLE
MDEV-29630: Remove unneeded code in join_read_always_key()

### DIFF
--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -23786,13 +23786,13 @@ join_const_unlock_row(JOIN_TAB *tab)
 
   DESCRIPTION
     This is "read_fist" function for the "ref" access method.
-   
+
     The functon must leave the index initialized when it returns.
     ref_or_null access implementation depends on that.
 
   RETURN
     0  - Ok
-   -1  - Row not found 
+   -1  - Row not found
     1  - Error
 */
 
@@ -23801,17 +23801,6 @@ join_read_always_key(JOIN_TAB *tab)
 {
   int error;
   TABLE *table= tab->table;
-
-  /* Initialize the index first */
-  if (!table->file->inited)
-  {
-    if (unlikely((error= table->file->ha_index_init(tab->ref.key,
-                                                    tab->sorted))))
-    {
-      (void) report_error(table, error);
-      return 1;
-    }
-  }
 
   if (unlikely(cp_buffer_from_ref(tab->join->thd, table, &tab->ref)))
     return -1;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29630*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Remove unneeded code in join_read_always_key() and merge conditions in one.

## How can this PR be tested?



<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
