### PR TITLE
[WIP] MDEV-13046 : Implement BADFILE syntax with LOAD DATA INFILE

### DIFF
--- a/sql/lex.h
+++ b/sql/lex.h
@@ -85,6 +85,7 @@ SYMBOL symbols[] = {
   { "AVG",		SYM(AVG_SYM)},
   { "AVG_ROW_LENGTH",	SYM(AVG_ROW_LENGTH)},
   { "BACKUP",	        SYM(BACKUP_SYM)},
+  { "BADFILE",	        SYM(BADFILE)},
   { "BEFORE",	        SYM(BEFORE_SYM)},
   { "BEGIN",	        SYM(BEGIN_MARIADB_SYM)},
   { "BETWEEN",		SYM(BETWEEN_SYM)},

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3210,6 +3210,7 @@ public:
   String *wild; /* Wildcard in SHOW {something} LIKE 'wild'*/ 
   sql_exchange *exchange;
   select_result *result;
+  const char *bad_file;
   /**
     @c the two may also hold BINLOG arguments: either comment holds a
     base64-char string or both represent the BINLOG fragment user variables.

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -444,6 +444,7 @@ bool my_yyoverflow(short **a, YYSTYPE **b, size_t *yystacksize);
 %token  <kwd> ASC                           /* SQL-2003-N */
 %token  <kwd> ASENSITIVE_SYM                /* FUTURE-USE */
 %token  <kwd> AS                            /* SQL-2003-R */
+%token  <kwd> BADFILE
 %token  <kwd> BEFORE_SYM                    /* SQL-2003-N */
 %token  <kwd> BETWEEN_SYM                   /* SQL-2003-R */
 %token  <kwd> BIGINT                        /* SQL-2003-R */
@@ -14592,13 +14593,14 @@ load:
                          sql_exchange($7.str, 0, $2))))
               MYSQL_YYABORT;
           }
+          opt_badfile
           opt_duplicate INTO TABLE_SYM table_ident opt_use_partition
           {
             LEX *lex=Lex;
-            if (unlikely(!Select->add_table_to_list(thd, $12, NULL,
+            if (unlikely(!Select->add_table_to_list(thd, $13, NULL,
                                                    TL_OPTION_UPDATING,
                                                    $4, MDL_SHARED_WRITE,
-                                                   NULL, $13)))
+                                                   NULL, $14)))
               MYSQL_YYABORT;
             lex->field_list.empty();
             lex->update_list.empty();
@@ -14606,7 +14608,7 @@ load:
             lex->many_values.empty();
           }
           opt_load_data_charset
-          { Lex->exchange->cs= $15; }
+          { Lex->exchange->cs= $16; }
           opt_xml_rows_identified_by
           opt_field_term opt_line_term opt_ignore_lines opt_field_or_var_spec
           opt_load_data_set_spec
@@ -14637,6 +14639,14 @@ load_data_lock:
             $$= (Lex->sphead ? TL_WRITE_DEFAULT : TL_WRITE_CONCURRENT_INSERT);
           }
         | LOW_PRIORITY { $$= TL_WRITE_LOW_PRIORITY; }
+        ;
+
+opt_badfile:
+          /* empty */
+        | BADFILE TEXT_STRING_filesystem
+          {
+            Lex->bad_file= $2.str;
+          }
         ;
 
 opt_duplicate:
@@ -16085,6 +16095,7 @@ reserved_keyword_udt_not_param_type:
         | AS
         | ASC
         | ASENSITIVE_SYM
+        | BADFILE
         | BEFORE_SYM
         | BETWEEN_SYM
         | BIT_AND


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-13046*


## Description

Added syntax for [BADFILE 'file_name'] with LOAD DATA INFILE statement. For now, it doesn't have any functionality, only the keyword support have been added.

Previously : 
```
MariaDB [anime]> LOAD DATA LOCAL INFILE   '/tmp/loaddata3.dat' BADFILE '/tmp/samp.bad' INTO TABLE lopez FIELDS TERMINATED BY ',' (k,b) SET c=k+b;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'BADFILE '/tmp/samp.bad' INTO TABLE lopez FIELDS TERMINATED BY ',' (k,b) SET c...' at line 1
```

Now :
```
MariaDB [anime]> LOAD DATA LOCAL INFILE   '/tmp/loaddata3.dat' BADFILE '/tmp/samp.bad' INTO TABLE lopez FIELDS TERMINATED BY ',' (k,b) SET c=k+b; `
Query OK, 5 rows affected (0.006 sec)
Records: 5  Deleted: 0  Skipped: 0  Warnings: 0
```


## How can this PR be tested?
Test cases will be added after implementing basic functionality.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*


## Backward compatibility
---


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
