### PR TITLE
MDEV-28641 : Query cache entries not invalidated on slave of a Galera…

### DIFF
--- a/mysql-test/suite/galera/galera_2x2nodes.cnf
+++ b/mysql-test/suite/galera/galera_2x2nodes.cnf
@@ -44,7 +44,7 @@ wsrep-on=1
 #galera_port=@OPT.port
 #ist_port=@OPT.port
 #sst_port=@OPT.port
-wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.1.#galera_port'
+wsrep_cluster_address=gcomm://
 wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
 wsrep_node_address='127.0.0.1:@mysqld.3.#galera_port'
 wsrep_node_incoming_address=127.0.0.1:@mysqld.3.port
@@ -55,33 +55,11 @@ wsrep-on=1
 #galera_port=@OPT.port
 #ist_port=@OPT.port
 #sst_port=@OPT.port
-wsrep_cluster_address=gcomm://
+wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.3.#galera_port'
 wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.4.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
 wsrep_node_address='127.0.0.1:@mysqld.4.#galera_port'
 wsrep_node_incoming_address=127.0.0.1:@mysqld.4.port
 wsrep_sst_receive_address='127.0.0.1:@mysqld.4.#sst_port'
-
-[mysqld.5]
-wsrep-on=1
-#galera_port=@OPT.port
-#ist_port=@OPT.port
-#sst_port=@OPT.port
-wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.4.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.5.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
-wsrep_node_address='127.0.0.1:@mysqld.5.#galera_port'
-wsrep_node_incoming_address=127.0.0.1:@mysqld.5.port
-wsrep_sst_receive_address='127.0.0.1:@mysqld.5.#sst_port'
-
-[mysqld.6]
-wsrep-on=1
-#galera_port=@OPT.port
-#ist_port=@OPT.port
-#sst_port=@OPT.port
-wsrep_cluster_address='gcomm://127.0.0.1:@mysqld.4.#galera_port'
-wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.6.#galera_port;evs.suspect_timeout=PT10S;evs.inactive_timeout=PT30S;evs.install_timeout=PT15S;pc.wait_prim_timeout=PT60S;gcache.size=10M'
-wsrep_node_address='127.0.0.1:@mysqld.6.#galera_port'
-wsrep_node_incoming_address=127.0.0.1:@mysqld.6.port
-wsrep_sst_receive_address='127.0.0.1:@mysqld.6.#sst_port'
 
 [ENV]
 NODE_MYPORT_1= @mysqld.1.port
@@ -96,8 +74,4 @@ NODE_MYSOCK_3= @mysqld.3.socket
 NODE_MYPORT_4= @mysqld.4.port
 NODE_MYSOCK_4= @mysqld.4.socket
 
-NODE_MYPORT_5= @mysqld.5.port
-NODE_MYSOCK_5= @mysqld.5.socket
 
-NODE_MYPORT_6= @mysqld.6.port
-NODE_MYSOCK_6= @mysqld.6.socket

--- a/mysql-test/suite/galera/r/galera_query_cache_invalidate.result
+++ b/mysql-test/suite/galera/r/galera_query_cache_invalidate.result
@@ -1,0 +1,119 @@
+connection node_2;
+connection node_1;
+connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3;
+connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4;
+connection node_2;
+call mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");
+connection node_4;
+call mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");
+connection node_3;
+CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=NODE_MYPORT_1, master_use_gtid=current_pos;;
+START SLAVE;
+include/wait_for_slave_to_start.inc
+connection node_1;
+CREATE TABLE t1 (id bigint primary key, msg varchar(100)) engine=innodb;
+SET AUTOCOMMIT=1;
+INSERT INTO t1 VALUES (4000000, 'foobar');
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+50001
+connection node_3;
+connection node_1;
+# node_1
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+connection node_2;
+# node_2
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+connection node_3;
+# node_3
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+connection node_4;
+# node_4
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+connection node_1;
+# node_1 insert new
+INSERT INTO t1 values (5000000, 'foobar');
+connection node_3;
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+connection node_2;
+# node_2
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+connection node_3;
+# node_3
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+connection node_4;
+# node_4
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+SELECT * FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+connection node_2;
+# node_3 different query same table
+SELECT id, msg FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+connection node_4;
+# node_6 different query same table
+SELECT id, msg FROM t1 WHERE msg='foobar';
+id	msg
+4000000	foobar
+5000000	foobar
+connection node_1;
+drop table t1;
+connection node_3;
+connection node_3;
+STOP SLAVE;
+RESET SLAVE ALL;
+connection node_1;
+SET SESSION WSREP_ON=OFF;
+RESET MASTER;
+SET SESSION WSREP_ON=ON;
+disconnect node_2;
+disconnect node_1;
+# End of test

--- a/mysql-test/suite/galera/t/galera_query_cache_invalidate.cnf
+++ b/mysql-test/suite/galera/t/galera_query_cache_invalidate.cnf
@@ -1,0 +1,25 @@
+!include ../galera_2x2nodes.cnf
+
+[mysqld.1]
+wsrep_gtid_domain_id=1
+server-id=11
+query_cache_type=1
+query_cache_size=15M
+
+[mysqld.2]
+wsrep_gtid_domain_id=1
+server-id=12
+query_cache_type=1
+query_cache_size=15M
+
+[mysqld.3]
+wsrep_gtid_domain_id=2
+server-id=13
+query_cache_type=1
+query_cache_size=15M
+
+[mysqld.4]
+wsrep_gtid_domain_id=2
+server-id=21
+query_cache_type=1
+query_cache_size=15M

--- a/mysql-test/suite/galera/t/galera_query_cache_invalidate.test
+++ b/mysql-test/suite/galera/t/galera_query_cache_invalidate.test
@@ -1,0 +1,120 @@
+--source include/big_test.inc
+--source include/force_restart.inc
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+
+#
+# MDEV-28641 : Query cache entries not invalidated on slave of a Galera cluster
+#
+# We use two 2-node galera clusters as follows
+#
+#       A(1) <-> B(2)              {Galera cluster 1}
+#       |                          {Async replication}
+#       D(3) <-> E(4)              {Galera cluster 2}
+#
+# Normal asyncronous replication is used between nodes 1 and 3
+# so that node_1 is master and node_3 a slave.
+#
+# In this test we can't test is some query fast or slow but we can
+# test does all nodes see all rows (this is not true before fix)
+#
+--connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
+--connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4
+
+--connection node_2
+call mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");
+--connection node_4
+call mtr.add_suppression("WSREP: Ignoring server id for non bootstrap node.");
+
+--connection node_3
+
+--replace_result $NODE_MYPORT_1 NODE_MYPORT_1
+--eval CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=$NODE_MYPORT_1, master_use_gtid=current_pos;
+START SLAVE;
+--source include/wait_for_slave_to_start.inc
+
+--connection node_1
+
+CREATE TABLE t1 (id bigint primary key, msg varchar(100)) engine=innodb;
+--disable_query_log
+INSERT INTO t1 SELECT seq, md5(rand()) from seq_1_to_50000;
+COMMIT;
+--enable_query_log
+SET AUTOCOMMIT=1;
+INSERT INTO t1 VALUES (4000000, 'foobar');
+SELECT COUNT(*) FROM t1;
+--sync_slave_with_master node_3
+
+#
+# All nodes should see one row and first query is slow and second fast
+#
+--connection node_1
+--echo # node_1
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+--connection node_2
+--echo # node_2
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+--connection node_3
+--echo # node_3
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+--connection node_4
+--echo # node_4
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+#
+# Insert a new row in master, this should cause query cache
+# invalidation
+#
+--connection node_1
+--echo # node_1 insert new
+INSERT INTO t1 values (5000000, 'foobar');
+--sync_slave_with_master node_3
+
+#
+# All nodes should see 2 rows
+#
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+
+--connection node_2
+--echo # node_2
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+--connection node_3
+--echo # node_3
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+--connection node_4
+--echo # node_4
+SELECT * FROM t1 WHERE msg='foobar';
+SELECT * FROM t1 WHERE msg='foobar';
+
+--connection node_2
+--echo # node_3 different query same table
+SELECT id, msg FROM t1 WHERE msg='foobar';
+
+--connection node_4
+--echo # node_6 different query same table
+SELECT id, msg FROM t1 WHERE msg='foobar';
+
+#
+# Cleanup
+#
+--connection node_1
+drop table t1;
+--sync_slave_with_master node_3
+
+--connection node_3
+STOP SLAVE;
+RESET SLAVE ALL;
+
+--connection node_1
+SET SESSION WSREP_ON=OFF;
+RESET MASTER;
+SET SESSION WSREP_ON=ON;
+
+--source include/galera_end.inc
+--echo # End of test

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -5586,7 +5586,8 @@ int Rows_log_event::do_apply_event(rpl_group_info *rgi)
       to avoid query cache being polluted with stale entries,
     */
 # ifdef WITH_WSREP
-    if (!WSREP(thd) && !wsrep_thd_is_applying(thd))
+    /* Query cache is not invalidated on wsrep applier here */
+    if (!(WSREP(thd) && wsrep_thd_is_applying(thd)))
 # endif /* WITH_WSREP */
       query_cache.invalidate_locked_for_write(thd, rgi->tables_to_lock);
 #endif /* HAVE_QUERY_CACHE */


### PR DESCRIPTION
… cluster

Query cache should be invalidated if we are not in applier. For some reason this condition was incorrect starting from 10.5 but it is correct in 10.4.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-28641_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Query cache should be invalidated if we are not in applier. For some reason this condition was incorrect starting from 10.5 but it is correct in 10.4.

## How can this PR be tested?

Added a new test case for this.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

## PR quality check
- [X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
