### PR TITLE
MDEV-30413 : run sequence nextval got [Note] WSREP: MDL BF-BF conflic…

### DIFF
--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -462,5 +462,15 @@ void destroy_background_thd(MYSQL_THD thd);
 void
 innobase_reset_background_thd(MYSQL_THD);
 
+#ifdef WITH_WSREP
+/** Append table-level exclusive key.
+@param thd   MySQL thread handle
+@param table table
+@retval false on success
+@retval true on failure */
+struct dict_table_t;
+bool wsrep_append_table_key(MYSQL_THD thd, const dict_table_t &table);
+#endif /* WITH_WSREP */
+
 #endif /* !UNIV_INNOCHECKSUM */
 #endif /* HA_INNODB_PROTOTYPES_H */

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -49,6 +49,7 @@ Created 4/20/1996 Heikki Tuuri
 #ifdef WITH_WSREP
 #include <wsrep.h>
 #include <mysql/service_wsrep.h>
+#include "ha_prototypes.h"
 #endif /* WITH_WSREP */
 
 /*************************************************************************
@@ -2574,42 +2575,6 @@ but GCC 4.8.5 does not support pop_options. */
 # pragma GCC optimize ("O0")
 #endif
 
-#ifdef WITH_WSREP
-/** Start bulk insert operation for Galera by appending
-table-level exclusive key for bulk insert.
-@param trx transaction
-@param index index
-@retval false on success
-@retval true on failure */
-ATTRIBUTE_COLD static bool row_ins_wsrep_start_bulk(trx_t *trx, const dict_index_t &index)
-{
-  char db_buf[NAME_LEN + 1];
-  char tbl_buf[NAME_LEN + 1];
-  ulint	db_buf_len, tbl_buf_len;
-
-  if (!index.table->parse_name(db_buf, tbl_buf, &db_buf_len, &tbl_buf_len))
-  {
-    WSREP_ERROR("Parse_name for bulk insert failed: %s",
-                wsrep_thd_query(trx->mysql_thd));
-    trx->error_state = DB_ROLLBACK;
-    return true;
-  }
-
-  /* Append table-level exclusive key for bulk insert. */
-  const int rcode = wsrep_thd_append_table_key(trx->mysql_thd, db_buf,
-                                               tbl_buf, WSREP_SERVICE_KEY_EXCLUSIVE);
-  if (rcode)
-  {
-    WSREP_ERROR("Appending table key for bulk insert failed: %s, %d",
-                wsrep_thd_query(trx->mysql_thd), rcode);
-    trx->error_state = DB_ROLLBACK;
-    return true;
-  }
-
-  return false;
-}
-#endif
-
 /***************************************************************//**
 Tries to insert an entry into a clustered index, ignoring foreign key
 constraints. If a record with the same unique key is found, the other
@@ -2770,10 +2735,13 @@ err_exit:
 #ifdef WITH_WSREP
 			if (trx->is_wsrep())
 			{
-			    if (!wsrep_thd_is_local_transaction(trx->mysql_thd))
-				    goto skip_bulk_insert;
-			    if (row_ins_wsrep_start_bulk(trx, *index))
-				    goto err_exit;
+				if (!wsrep_thd_is_local_transaction(trx->mysql_thd))
+					goto skip_bulk_insert;
+				if (wsrep_append_table_key(trx->mysql_thd, *index->table))
+				{
+					trx->error_state = DB_ROLLBACK;
+					goto err_exit;
+				}
 			}
 #endif /* WITH_WSREP */
 


### PR DESCRIPTION
…t and [ERROR] Aborting



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30413*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Sequence objects are implemented using special tables. These tables do not have primary key and only one row. NEXTVAL is basically update from existing value to new value. In Galera this could mean that two write-sets from different nodes do not conflict and this could lead situation where write-sets are executed
concurrently and possibly in wrong seqno order.

This is fixed by using table-level exclusive key for SEQUENCE updates. Note that this naturally works
correctly only if InnoDB storage engine is used for sequence.

This fix does not contain a test case because while it is possible to syncronize appliers using dbug_sync it was too hard to syncronize MDL-lock requests to exact objects. Testing done for this fix is documented on MDEV.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
