### PR TITLE
MDEV-29646: sformat('Num [{:20}]', 42) gives incorrect result in view

### DIFF
--- a/mysql-test/main/func_sformat.result
+++ b/mysql-test/main/func_sformat.result
@@ -434,7 +434,7 @@ create table t1 as select sformat(_ucs2 x'003D007B007D003D', _ucs2 x'04420435044
 show create table t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `x` varchar(8) CHARACTER SET ucs2 COLLATE ucs2_general_ci DEFAULT NULL
+  `x` longtext CHARACTER SET ucs2 COLLATE ucs2_general_ci DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop table t1;
 set names latin1;
@@ -468,3 +468,26 @@ set names latin1;
 #
 # End of 10.7 tests
 #
+#
+# Start of 10.8 tests
+#
+#
+# MDEV-29646 sformat('Num [{:20}]', 42) gives incorrect result in view
+#
+create view v1 as select sformat('Num [{:20}]', 42);
+select * from v1;
+sformat('Num [{:20}]', 42)
+Num [                  42]
+drop view v1;
+create view v1 as SELECT sformat('Square root of [{:d}] is [{:.20}]', 2, sqrt(2));
+select * from v1;
+sformat('Square root of [{:d}] is [{:.20}]', 2, sqrt(2))
+Square root of [2] is [1.4142135623730951455]
+drop view v1;
+create table t1 (a text, b int, c text);
+insert t1 values ('[{} -> {}]', 10, '{}'), ('[{:20} <- {}]', 1, '{:30}');
+select sformat(a,b,c) from t1;
+sformat(a,b,c)
+[10 -> {}]
+[                   1 <- {:30}]
+drop table t1;

--- a/mysql-test/main/func_sformat.test
+++ b/mysql-test/main/func_sformat.test
@@ -253,3 +253,24 @@ set names latin1;
 echo #;
 echo # End of 10.7 tests;
 echo #;
+
+echo #;
+echo # Start of 10.8 tests;
+echo #;
+
+echo #;
+echo # MDEV-29646 sformat('Num [{:20}]', 42) gives incorrect result in view;
+echo #;
+
+create view v1 as select sformat('Num [{:20}]', 42);
+select * from v1;
+drop view v1;
+
+create view v1 as SELECT sformat('Square root of [{:d}] is [{:.20}]', 2, sqrt(2));
+select * from v1;
+drop view v1;
+
+create table t1 (a text, b int, c text);
+insert t1 values ('[{} -> {}]', 10, '{}'), ('[{:20} <- {}]', 1, '{:30}');
+select sformat(a,b,c) from t1;
+drop table t1;

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -1348,13 +1348,13 @@ bool Item_func_sformat::fix_length_and_dec()
 
   for (uint i=0 ; i < arg_count ; i++)
   {
-    char_length+= args[i]->max_char_length();
     if (args[i]->result_type() == STRING_RESULT &&
         Type_std_attributes::agg_item_set_converter(c, func_name_cstring(),
                                                     args+i, 1, flags, 1))
       return TRUE;
   }
 
+  char_length= MAX_BLOB_WIDTH;
   fix_char_length_ulonglong(char_length);
   return FALSE;
 }


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29646*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The problem is that sformat does not assign the enough space for the result string. The result string is allocated with the max_length of argument, but the correst max_length should be based on the format string.

The patch fixes the problem by calculating the max_length of the result string based on the format string.


## How can this PR be tested?


If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
