### PR TITLE
Revert "Added mysql-log-rotate to .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,7 +267,6 @@ support-files/mysql.10.0.11.spec
 support-files/mysql.server
 support-files/mysql.service
 support-files/mysql.spec
-support-files/mysql-log-rotate
 support-files/mysqld.service
 support-files/mysqld_multi.server
 support-files/policy/selinux/mysqld-safe.pp


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

This reverts commit 158a58245813b1959d6ee912d77734620c7cf3ba.

In 10.11 the generation of mysql-log-rotate was removed in commit fd0dcad676e7b8665f5363d97849a20cbb712933

There's no need to ignore files that aren't generated.

## How can this PR be tested?

By doing out of tree builds and not leaving build artefact littered in tree builds as some basis of what is generated.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*


## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ X ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.