### PR TITLE
 MDEV-30414 sporadic failures with galera var retry autocommit

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
+++ b/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
@@ -72,6 +72,8 @@ SET SESSION wsrep_retry_autocommit = 64;
 SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
 SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue EXECUTE 64';
 INSERT INTO t1 VALUES (5);
+connection node_2;
+connection node_1;
 connection node_1;
 SELECT COUNT(*) FROM t1;
 COUNT(*)

--- a/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
+++ b/mysql-test/suite/galera/r/galera_var_retry_autocommit.result
@@ -20,17 +20,25 @@ DROP TABLE t1;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 SET SESSION wsrep_retry_autocommit = 1;
+SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
 SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue';
 INSERT INTO t1 (f1) VALUES (3);
 connection node_1a;
 SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 connection node_2;
 TRUNCATE TABLE t1;
-connection node_1;
+connection node_1a;
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_retry_autocommit_reached';
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 0
+SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue';
+connection node_1;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
 SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = NULL;
 DROP TABLE t1;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;

--- a/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
+++ b/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
@@ -25,6 +25,8 @@ SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continu
 SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 
 --connection node_2
+--let $wait_condition = SELECT count(*)=1 FROM information_schema.TABLES WHERE TABLE_SCHEMA='test' AND TABLE_NAME='t1'
+--source include/wait_condition.inc
 TRUNCATE TABLE t1;
 
 --connection node_1
@@ -52,6 +54,8 @@ SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continu
 SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 
 --connection node_2
+--let $wait_condition = SELECT count(*)=1 FROM information_schema.TABLES WHERE TABLE_SCHEMA='test' AND TABLE_NAME='t1'
+--source include/wait_condition.inc
 TRUNCATE TABLE t1;
 
 --connection node_1a
@@ -85,6 +89,8 @@ SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continu
 SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 
 --connection node_2
+--let $wait_condition = SELECT count(*)=1 FROM information_schema.TABLES WHERE TABLE_SCHEMA='test' AND TABLE_NAME='t1'
+--source include/wait_condition.inc
 TRUNCATE TABLE t1;
 
 --connection node_1a
@@ -120,6 +126,11 @@ SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continu
 
 --send INSERT INTO t1 VALUES (5)
 
+--connection node_2
+--let $wait_condition = SELECT count(*)=1 FROM information_schema.TABLES WHERE TABLE_SCHEMA='test' AND TABLE_NAME='t1'
+--source include/wait_condition.inc
+
+--connection node_1
 --disable_query_log
 --disable_result_log
 --let $count = 64
@@ -149,3 +160,4 @@ SELECT COUNT(*) FROM t1;
 SET DEBUG_SYNC = 'RESET';
 SET GLOBAL debug_dbug = NULL;
 DROP TABLE t1;
+

--- a/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
+++ b/mysql-test/suite/galera/t/galera_var_retry_autocommit.test
@@ -44,6 +44,7 @@ DROP TABLE t1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 SET SESSION wsrep_retry_autocommit = 1;
+SET GLOBAL debug_dbug = '+d,sync.wsrep_retry_autocommit';
 SET DEBUG_SYNC = 'wsrep_before_certification SIGNAL before_cert WAIT_FOR continue';
 --send INSERT INTO t1 (f1) VALUES (3)
 
@@ -53,12 +54,17 @@ SET DEBUG_SYNC = 'now WAIT_FOR before_cert';
 --connection node_2
 TRUNCATE TABLE t1;
 
+--connection node_1a
+SET DEBUG_SYNC = 'now WAIT_FOR wsrep_retry_autocommit_reached';
+SELECT COUNT(*) FROM t1;
+SET DEBUG_SYNC = 'now SIGNAL wsrep_retry_autocommit_continue';
+
 --connection node_1
---error 0,ER_LOCK_DEADLOCK
 --reap
 SELECT COUNT(*) FROM t1;
 
 SET DEBUG_SYNC = 'RESET';
+SET GLOBAL debug_dbug = NULL;
 DROP TABLE t1;
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30414*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
the test phase 2, was not deterministic. In problematic scheduling case, the autocommit retry would be too fast and enter once again to block the applier for second time.
The fix, in this PR, is to stop the retrying in sync point, before the actual retrying begins. And let the applier continue first. 
## How can this PR be tested?
PR is about a mtr test fix

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility

## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
