### PR TITLE
Fix insecure use of strcpy, strcat and sprintf in Connect

### DIFF
--- a/storage/connect/bson.cpp
+++ b/storage/connect/bson.cpp
@@ -215,7 +215,7 @@ OFFSET BDOC::ParseArray(size_t& i)
     switch (s[i]) {
     case ',':
       if (level < 2) {
-        sprintf(G->Message, "Unexpected ',' near %.*s", (int) ARGS);
+        snprintf(G->Message, sizeof(G->Message), "Unexpected ',' near %.*s", (int) ARGS);
         throw 1;
       } else
         level = 1;
@@ -223,7 +223,7 @@ OFFSET BDOC::ParseArray(size_t& i)
       break;
     case ']':
       if (level == 1) {
-        sprintf(G->Message, "Unexpected ',]' near %.*s", (int) ARGS);
+        snprintf(G->Message, sizeof(G->Message), "Unexpected ',]' near %.*s", (int) ARGS);
         throw 1;
       } // endif level
 
@@ -237,7 +237,7 @@ OFFSET BDOC::ParseArray(size_t& i)
       break;
     default:
       if (level == 2) {
-        sprintf(G->Message, "Unexpected value near %.*s", (int) ARGS);
+        snprintf(G->Message, sizeof(G->Message), "Unexpected value near %.*s", (int) ARGS);
         throw 1;
       } else if (lastvlp) {
         vlp = ParseValue(i, NewVal());
@@ -284,7 +284,7 @@ OFFSET BDOC::ParseObject(size_t& i)
 
         level = 2;
       } else {
-        sprintf(G->Message, "misplaced string near %.*s", (int) ARGS);
+        snprintf(G->Message, sizeof(G->Message), "misplaced string near %.*s", (int) ARGS);
         throw 2;
       } // endif level
 
@@ -294,14 +294,14 @@ OFFSET BDOC::ParseObject(size_t& i)
         ParseValue(++i, GetVlp(lastbpp));
         level = 3;
       } else {
-        sprintf(G->Message, "Unexpected ':' near %.*s", (int) ARGS);
+        snprintf(G->Message, sizeof(G->Message), "Unexpected ':' near %.*s", (int) ARGS);
         throw 2;
       } // endif level
 
       break;
     case ',':
       if (level < 3) {
-        sprintf(G->Message, "Unexpected ',' near %.*s", (int) ARGS);
+        snprintf(G->Message, sizeof(G->Message), "Unexpected ',' near %.*s", (int) ARGS);
         throw 2;
       } else
         level = 1;
@@ -309,7 +309,7 @@ OFFSET BDOC::ParseObject(size_t& i)
       break;
     case '}':
       if (!(level == 0 || level == 3)) {
-        sprintf(G->Message, "Unexpected '}' near %.*s", (int) ARGS);
+        snprintf(G->Message, sizeof(G->Message), "Unexpected '}' near %.*s", (int) ARGS);
         throw 2;
       } // endif level
 
@@ -321,7 +321,7 @@ OFFSET BDOC::ParseObject(size_t& i)
     case '\t':
       break;
     default:
-      sprintf(G->Message, "Unexpected character '%c' near %.*s",
+      snprintf(G->Message, sizeof(G->Message), "Unexpected character '%c' near %.*s",
         s[i], (int) ARGS);
       throw 2;
     }; // endswitch s[i]
@@ -399,7 +399,7 @@ suite:
   return bvp;
 
 err:
-  sprintf(G->Message, "Unexpected character '%c' near %.*s", s[i], (int) ARGS);
+  snprintf(G->Message, sizeof(G->Message), "Unexpected character '%c' near %.*s", s[i], (int) ARGS);
   throw 3;
 } // end of ParseValue
 
@@ -758,16 +758,16 @@ bool BDOC::SerializeValue(PBVAL jvp, bool b)
       return jp->Escape(MZP(jvp->To_Val));
 
   case TYPE_INTG:
-    sprintf(buf, "%d", jvp->N);
+    snprintf(buf, sizeof(buf), "%d", jvp->N);
     return jp->WriteStr(buf);
   case TYPE_BINT:
-    sprintf(buf, "%lld", *(longlong*)MakePtr(Base, jvp->To_Val));
+    snprintf(buf, sizeof(buf), "%lld", *(longlong*)MakePtr(Base, jvp->To_Val));
     return jp->WriteStr(buf);
   case TYPE_FLOAT:
-    sprintf(buf, "%.*f", jvp->Nd, jvp->F);
+    snprintf(buf, sizeof(buf), "%.*f", jvp->Nd, jvp->F);
     return jp->WriteStr(buf);
   case TYPE_DBL:
-    sprintf(buf, "%.*lf", jvp->Nd, *(double*)MakePtr(Base, jvp->To_Val));
+    snprintf(buf, sizeof(buf), "%.*lf", jvp->Nd, *(double*)MakePtr(Base, jvp->To_Val));
     return jp->WriteStr(buf);
   case TYPE_NULL:
     return jp->WriteStr("null");
@@ -797,7 +797,7 @@ void* BJSON::BsonSubAlloc(size_t size)
     memp, size, pph->To_Free, pph->FreeBlk);
 
   if (size > pph->FreeBlk) {   /* Not enough memory left in pool */
-    sprintf(G->Message,
+    snprintf(G->Message, sizeof(G->Message),
       "Not enough memory for request of %zd (used=%zd free=%zd)",
       size, pph->To_Free, pph->FreeBlk);
     xtrc(1, "BsonSubAlloc: %s\n", G->Message);
@@ -1679,7 +1679,7 @@ PBVAL BJSON::SetValue(PBVAL vlp, PVAL valp)
 
       break;
     default:
-      sprintf(G->Message, "Unsupported typ %d\n", valp->GetType());
+      snprintf(G->Message, sizeof(G->Message), "Unsupported typ %d\n", valp->GetType());
       throw(777);
   } // endswitch Type
 

--- a/storage/connect/bsonudf.cpp
+++ b/storage/connect/bsonudf.cpp
@@ -68,7 +68,7 @@ static PBSON BbinAlloc(PGLOBAL g, ulong len, PBVAL jsp)
 	PBSON bsp = (PBSON)PlgDBSubAlloc(g, NULL, sizeof(BSON));
 
 	if (bsp) {
-		strcpy(bsp->Msg, "Binary Json");
+		snprintf(bsp->Msg, sizeof(bsp->Msg), "Binary Json");
 		bsp->Msg[BMX] = 0;
 		bsp->Filename = NULL;
 		bsp->G = g;
@@ -270,7 +270,7 @@ my_bool BJNX::SetArrayOptions(PGLOBAL g, char* p, int i, PSZ nm)
 		} // endif n
 
 	} else {
-		strcpy(g->Message, "Wrong array specification");
+		snprintf(g->Message, sizeof(g->Message), "Wrong array specification");
 		return true;
 	} // endif's
 
@@ -565,7 +565,7 @@ PBVAL BJNX::GetRowValue(PGLOBAL g, PBVAL row, int i)
 						vlp = row;  // DupVal(g, row) ???
 
 				} else {
-					strcpy(g->Message, "Unexpected object");
+					snprintf(g->Message, sizeof(g->Message), "Unexpected object");
 					vlp = NULL;
 				} //endif Op
 
@@ -610,7 +610,7 @@ PBVAL BJNX::GetRowValue(PGLOBAL g, PBVAL row, int i)
 /*********************************************************************************/
 PVAL BJNX::ExpandArray(PGLOBAL g, PBVAL arp, int n)
 {
-	strcpy(g->Message, "Expand cannot be done by this function");
+	snprintf(g->Message, sizeof(g->Message), "Expand cannot be done by this function");
 	return NULL;
 } // end of ExpandArray
 
@@ -791,7 +791,7 @@ PVAL BJNX::CalculateArray(PGLOBAL g, PBVAL bap, int n)
 		xtrc(1, "Exception %d: %s\n", n, g->Message);
 		PUSH_WARNING(g->Message);
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 	} // end catch
 
 	return vp;
@@ -860,7 +860,7 @@ PBVAL BJNX::GetRow(PGLOBAL g)
 				} else if (row->Type == TYPE_JAR) {
 					AddArrayValue(row, MOF(nwr));
 				} else {
-					strcpy(g->Message, "Wrong type when writing new row");
+					snprintf(g->Message, sizeof(g->Message), "Wrong type when writing new row");
 					nwr = NULL;
 				} // endif's
 
@@ -893,7 +893,7 @@ my_bool BJNX::WriteValue(PGLOBAL g, PBVAL jvalp)
 	case TYPE_JAR:  arp = row;  break;
 	case TYPE_JVAL: jvp = MVP(row->To_Val);  break;
 	default:
-		strcpy(g->Message, "Invalid target type");
+		snprintf(g->Message, sizeof(g->Message), "Invalid target type");
 		return true;
 	} // endswitch Type
 
@@ -1067,7 +1067,7 @@ my_bool BJNX::CheckPath(PGLOBAL g, UDF_ARGS *args, PBVAL jsp, PBVAL& jvp, int n)
 					return false;
 
 			} else {
-				strcpy(g->Message, "Path argument is null");
+				snprintf(g->Message, sizeof(g->Message), "Path argument is null");
 				return true;
 			} // endif path
 
@@ -1088,7 +1088,7 @@ PSZ BJNX::Locate(PGLOBAL g, PBVAL jsp, PBVAL jvp, int k)
 	g->Message[0] = 0;
 
 	if (!jsp) {
-		strcpy(g->Message, "Null json tree");
+		snprintf(g->Message, sizeof(g->Message), "Null json tree");
 		return NULL;
 	} // endif jsp
 
@@ -1115,7 +1115,7 @@ PSZ BJNX::Locate(PGLOBAL g, PBVAL jsp, PBVAL jvp, int k)
 
 		if (err) {
 			if (!g->Message[0])
-				strcpy(g->Message, "Invalid json tree");
+				snprintf(g->Message, sizeof(g->Message), "Invalid json tree");
 
 		} else if (Found) {
 			Jp->WriteChr('\0');
@@ -1127,7 +1127,7 @@ PSZ BJNX::Locate(PGLOBAL g, PBVAL jsp, PBVAL jvp, int k)
 		xtrc(1, "Exception %d: %s\n", n, g->Message);
 		PUSH_WARNING(g->Message);
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 	} // end catch
 
 	return str;
@@ -1208,7 +1208,7 @@ PSZ BJNX::LocateAll(PGLOBAL g, PBVAL jsp, PBVAL bvp, int mx)
 	PJPN    jnp;
 
 	if (!jsp) {
-		strcpy(g->Message, "Null json tree");
+		snprintf(g->Message, sizeof(g->Message), "Null json tree");
 		return NULL;
 	} // endif jsp
 
@@ -1247,13 +1247,13 @@ PSZ BJNX::LocateAll(PGLOBAL g, PBVAL jsp, PBVAL bvp, int mx)
 			PlugSubAlloc(g, NULL, Jp->N);
 			str = Jp->Strp;
 		} else if (!g->Message[0])
-			strcpy(g->Message, "Invalid json tree");
+			snprintf(g->Message, sizeof(g->Message), "Invalid json tree");
 
 	} catch (int n) {
 		xtrc(1, "Exception %d: %s\n", n, g->Message);
 		PUSH_WARNING(g->Message);
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 	} // end catch
 
 	return str;
@@ -1744,7 +1744,7 @@ PBSON BJNX::MakeBinResult(UDF_ARGS *args, PBVAL top, ulong len, int n)
 	if ((bnp = BbinAlloc(G, len, top))) {
 		bnp->Filename = filename;
 		bnp->Pretty = pretty;
-		strcpy(bnp->Msg, "Json Binary item");
+		snprintf(bnp->Msg, sizeof(bnp->Msg), "Json Binary item");
 	} //endif bnp
 
 	return bnp;
@@ -3100,7 +3100,7 @@ char* bson_test(UDF_INIT* initid, UDF_ARGS* args, char* result,
 		*error = 1;
 		str = NULL;
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		*error = 1;
 		str = NULL;
@@ -3221,7 +3221,7 @@ char* bsonlocate(UDF_INIT* initid, UDF_ARGS* args, char* result,
 		*error = 1;
 		path = NULL;
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		*error = 1;
 		path = NULL;
@@ -3339,7 +3339,7 @@ char* bson_locate_all(UDF_INIT* initid, UDF_ARGS* args, char* result,
 		*error = 1;
 		path = NULL;
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		*error = 1;
 		path = NULL;
@@ -3706,7 +3706,7 @@ char *bson_get_item(UDF_INIT *initid, UDF_ARGS *args, char *result,
 		jvp = bnx.GetRowValue(g, jvp, 0);
 
 	if (!bnx.IsJson(jvp)) {
-		strcpy(g->Message, "Not a Json item");
+		snprintf(g->Message, sizeof(g->Message), "Not a Json item");
 	}	else
 		str = bnx.Serialize(g, jvp, NULL, 0);
 
@@ -3838,7 +3838,7 @@ char *bsonget_string(UDF_INIT *initid, UDF_ARGS *args, char *result,
 		PUSH_WARNING(g->Message);
 		str = NULL;
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		str = NULL;
 	} // end catch
@@ -4297,7 +4297,7 @@ static char *bson_handle_item(UDF_INIT *initid, UDF_ARGS *args, char *result,
 		PUSH_WARNING(g->Message);
 		str = NULL;
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		str = NULL;
 	} // end catch
@@ -4739,8 +4739,8 @@ char *bfile_bjson(UDF_INIT *initid, UDF_ARGS *args, char *result,
 	PGLOBAL g = (PGLOBAL)initid->ptr;
 	BDOC    doc(g);
 
-	strcpy(fn, MakePSZ(g, args, 0));
-	strcpy(ofn, MakePSZ(g, args, 1));
+	snprintf(fn, sizeof(fn), "%s",  MakePSZ(g, args, 0));
+	snprintf(ofn, sizeof(ofn), "%s", MakePSZ(g, args, 1));
 
 	if (args->arg_count == 3)
 		lrecl = (size_t)*(longlong*)args->args[2];
@@ -5866,7 +5866,7 @@ static char *bbin_handle_item(UDF_INIT *initid, UDF_ARGS *args, char *result,
 
 		PUSH_WARNING(g->Message);
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 	} // end catch
 
@@ -6198,7 +6198,7 @@ char* bbin_locate_all(UDF_INIT* initid, UDF_ARGS* args, char* result,
 		*error = 1;
 		path = NULL;
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		*error = 1;
 		path = NULL;

--- a/storage/connect/cmgoconn.cpp
+++ b/storage/connect/cmgoconn.cpp
@@ -156,7 +156,7 @@ bool CMgoConn::Connect(PGLOBAL g)
 {
 	if (!Pcg->Db_name || !Pcg->Coll_name) {
 		// This would crash in mongoc_client_get_collection
-		strcpy(g->Message, "Missing DB or collection name");
+		snprintf(g->Message, sizeof(g->Message), "Missing DB or collection name");
 		return true;
 	}	// endif name
 
@@ -165,7 +165,7 @@ bool CMgoConn::Connect(PGLOBAL g)
 		__try {
 		  mongo_init(true);
 	  } __except (EXCEPTION_EXECUTE_HANDLER) {
-		  strcpy(g->Message, "Cannot load MongoDB C driver");
+		  snprintf(g->Message, sizeof(g->Message), "Cannot load MongoDB C driver");
 		  return true;
 	  }	// end try/except
 #else   // !_WIN32
@@ -379,7 +379,7 @@ bool CMgoConn::MakeCursor(PGLOBAL g)
 		p = strrchr(options, ']');
 
 		if (!p) {
-			strcpy(g->Message, "Missing ] in pipeline");
+			snprintf(g->Message, sizeof(g->Message), "Missing ] in pipeline");
 			return true;
 		} else
 			*(char*)p = 0;
@@ -390,7 +390,7 @@ bool CMgoConn::MakeCursor(PGLOBAL g)
 			s->Append(",{\"$match\":");
 
 			if (MakeSelector(g, filp, s)) {
-				strcpy(g->Message, "Failed making selector");
+				snprintf(g->Message, sizeof(g->Message), "Failed making selector");
 				return true;
 			} else
 				s->Append('}');
@@ -454,7 +454,7 @@ bool CMgoConn::MakeCursor(PGLOBAL g)
 					s->Append(',');
 
 				if (MakeSelector(g, filp, s)) {
-					strcpy(g->Message, "Failed making selector");
+					snprintf(g->Message, sizeof(g->Message), "Failed making selector");
 					return true;
 				}	// endif Selector
 
@@ -771,7 +771,7 @@ int CMgoConn::Write(PGLOBAL g)
 			} // endif remove
 
 		} else {
-			strcpy(g->Message, "Mongo update: cannot find _id");
+			snprintf(g->Message, sizeof(g->Message), "Mongo update: cannot find _id");
 			rc = RC_FX;
 		}	// endif b
 
@@ -1066,7 +1066,7 @@ bool CMgoConn::AddValue(PGLOBAL g, PCOL colp, bson_t *doc, char *key, bool upd)
 	} // endswitch Buf_Type
 
 	if (!rc) {
-		strcpy(g->Message, "Adding value failed");
+		snprintf(g->Message, sizeof(g->Message), "Adding value failed");
 		return true;
 	} else
 		return false;

--- a/storage/connect/filamgz.cpp
+++ b/storage/connect/filamgz.cpp
@@ -88,7 +88,7 @@ int GZFAM::Zerror(PGLOBAL g)
   {
   int errnum;
 
-  strcpy(g->Message, gzerror(Zfile, &errnum));
+  snprintf(g->Message, sizeof(g->Message), "%s", gzerror(Zfile, &errnum));
 
   if (errnum == Z_ERRNO)
 #if defined(_WIN32)
@@ -142,7 +142,7 @@ bool GZFAM::OpenTableFile(PGLOBAL g)
       /*****************************************************************/
       /* Updating GZ files not implemented yet.                        */
       /*****************************************************************/
-      strcpy(g->Message, MSG(UPD_ZIP_NOT_IMP));
+      snprintf(g->Message, sizeof(g->Message), MSG(UPD_ZIP_NOT_IMP));
       return true;
     case MODE_DELETE:
       if (!Tdbp->GetNext()) {
@@ -379,7 +379,7 @@ int GZFAM::WriteBuffer(PGLOBAL g)
 /***********************************************************************/
 int GZFAM::DeleteRecords(PGLOBAL g, int)
   {
-  strcpy(g->Message, MSG(NO_ZIP_DELETE));
+  snprintf(g->Message, sizeof(g->Message), MSG(NO_ZIP_DELETE));
   return RC_FX;
   } // end of DeleteRecords
 
@@ -926,7 +926,7 @@ bool ZLBFAM::AllocateBuffer(PGLOBAL g)
 
 #if 0
   if (!Optimized && Tdbp->NeedIndexing(g)) {
-    strcpy(g->Message, MSG(NOP_ZLIB_INDEX));
+    snprintf(g->Message, sizeof(g->Message), MSG(NOP_ZLIB_INDEX));
     return TRUE;
     } // endif indexing
 #endif // 0
@@ -993,7 +993,7 @@ bool ZLBFAM::AllocateBuffer(PGLOBAL g)
       CurBlk = Block - 1;
       CurNum = Last;
 
-      strcpy(g->Message, MSG(NO_PAR_BLK_INS));
+      snprintf(g->Message, sizeof(g->Message), "%s",MSG(NO_PAR_BLK_INS));
       return TRUE;
     } // endif Last
 
@@ -1068,7 +1068,7 @@ bool ZLBFAM::SetPos(PGLOBAL g, int pos __attribute__((unused)))
   return true;
 #if 0 // All this must be checked
   if (pos < 0) {
-    strcpy(g->Message, MSG(INV_REC_POS));
+    snprintf(g->Message, sizeof(g->Message), MSG(INV_REC_POS));
     return true;
     } // endif recpos
 
@@ -1156,7 +1156,7 @@ int ZLBFAM::ReadBuffer(PGLOBAL g)
     rdbuf = Zlenp;
   } else {                     // !Optimized
     if (CurBlk != OldBlk + 1) {
-      strcpy(g->Message, MSG(INV_RAND_ACC));
+      snprintf(g->Message, sizeof(g->Message), MSG(INV_RAND_ACC));
       return RC_FX;
     } else
       Fpos = ftell(Stream);    // Used when optimizing
@@ -1276,7 +1276,7 @@ int ZLBFAM::WriteBuffer(PGLOBAL g)
 #if defined(_DEBUG)
     if (Tdbp->GetFtype() == RECFM_FIX &&
       (signed)strlen(CurLine) != Lrecl + (signed)strlen(CrLf)) {
-      strcpy(g->Message, MSG(BAD_LINE_LEN));
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_LINE_LEN));
       Closing = TRUE;
       return RC_FX;
       } // endif Lrecl

--- a/storage/connect/filamtxt.cpp
+++ b/storage/connect/filamtxt.cpp
@@ -367,13 +367,13 @@ int TXTFAM::UpdateSortedRows(PGLOBAL g)
 //  return RC_INFO;
     return RC_OK;         // Nothing to do
   } else if (!(Sosar = MakeValueArray(g, To_Sos))) {
-    strcpy(g->Message, "Start position array is null");
+    snprintf(g->Message, sizeof(g->Message), "Start position array is null");
     goto err;
   } else if (!(Updar = MakeValueArray(g, To_Upd))) {
-    strcpy(g->Message, "Updated line array is null");
+    snprintf(g->Message, sizeof(g->Message), "Updated line array is null");
     goto err;
   } else if (!(ix = (int*)Posar->GetSortIndex(g))) { 
-    strcpy(g->Message, "Error getting array sort index");
+    snprintf(g->Message, sizeof(g->Message), "Error getting array sort index");
     goto err;
   } // endif's
 
@@ -419,10 +419,10 @@ int TXTFAM::DeleteSortedRows(PGLOBAL g)
 //  return RC_INFO;
     return RC_OK;             // Nothing to do
   } else if (!(Sosar = MakeValueArray(g, To_Sos))) {
-    strcpy(g->Message, "Start position array is null");
+    snprintf(g->Message, sizeof(g->Message), "Start position array is null");
     goto err;
   } else if (!(ix = (int*)Posar->GetSortIndex(g))) { 
-    strcpy(g->Message, "Error getting array sort index");
+    snprintf(g->Message, sizeof(g->Message), "Error getting array sort index");
     goto err;
   } // endif's
 
@@ -454,7 +454,7 @@ err:
 /***********************************************************************/
 int TXTFAM::InitDelete(PGLOBAL g, int, int)
   {
-  strcpy(g->Message, "InitDelete should not be used by this table type");
+  snprintf(g->Message, sizeof(g->Message), "InitDelete should not be used by this table type");
   return RC_FX;
   } // end of InitDelete
 
@@ -556,7 +556,7 @@ bool DOSFAM::OpenTableFile(PGLOBAL g)
 
   switch (mode) {
     case MODE_READ:
-      strcpy(opmode, "r");
+      snprintf(opmode, sizeof(opmode), "r");
       break;
     case MODE_DELETE:
       if (!Tdbp->Next) {
@@ -570,7 +570,7 @@ bool DOSFAM::OpenTableFile(PGLOBAL g)
           } // endif blocked
 
         // This will erase the entire file
-        strcpy(opmode, "w");
+        snprintf(opmode, sizeof(opmode), "w");
         Tdbp->ResetSize();
         break;
         } // endif
@@ -580,14 +580,14 @@ bool DOSFAM::OpenTableFile(PGLOBAL g)
       /* fall through */
     case MODE_UPDATE:
       if ((UseTemp = Tdbp->IsUsingTemp(g))) {
-        strcpy(opmode, "r");
+        snprintf(opmode, sizeof(opmode), "r");
         Bin = true;
       } else
-        strcpy(opmode, "r+");
+        snprintf(opmode, sizeof(opmode), "r+");
 
       break;
     case MODE_INSERT:
-      strcpy(opmode, "a+");
+      snprintf(opmode, sizeof(opmode), "a+");
       break;
     default:
       snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
@@ -1364,7 +1364,7 @@ int BLKFAM::GetNextPos(void)
 /***********************************************************************/
 bool BLKFAM::SetPos(PGLOBAL g, int)
   {
-  strcpy(g->Message, "Blocked variable tables cannot be used indexed");
+  snprintf(g->Message, sizeof(g->Message), "Blocked variable tables cannot be used indexed");
   return true;
   } // end of SetPos
 
@@ -1708,10 +1708,10 @@ bool BINFAM::OpenTableFile(PGLOBAL g) {
 
 	switch (mode) {
 	case MODE_READ:
-		strcpy(opmode, "rb");
+		snprintf(opmode, sizeof(opmode), "rb");
 		break;
 	case MODE_WRITE:
-		strcpy(opmode, "wb");
+		snprintf(opmode, sizeof(opmode), "wb");
 		break;
 	default:
 		snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);
@@ -1859,7 +1859,7 @@ int BINFAM::ReadBuffer(PGLOBAL g)
 	// Read the prefix giving the row length
 	if (!fread(&Recsize, sizeof(size_t), 1, Stream)) {
 		if (!feof(Stream)) {
-			strcpy(g->Message, "Error reading line prefix\n");
+			snprintf(g->Message, sizeof(g->Message), "Error reading line prefix\n");
 			return RC_FX;
 		} else
 			return RC_EF;

--- a/storage/connect/filamvct.cpp
+++ b/storage/connect/filamvct.cpp
@@ -429,7 +429,7 @@ bool VCTFAM::OpenTableFile(PGLOBAL g)
   /*********************************************************************/
   switch (mode) {
     case MODE_READ:
-      strcpy(opmode, "rb");
+      snprintf(opmode, sizeof(opmode), "rb");
       break;
     case MODE_DELETE:
       if (!Tdbp->GetNext()) {
@@ -437,7 +437,7 @@ bool VCTFAM::OpenTableFile(PGLOBAL g)
         DelRows = Cardinality(g);
 
         // This will delete the whole file
-        strcpy(opmode, "wb");
+        snprintf(opmode, sizeof(opmode), "wb");
         break;
         } // endif
 
@@ -445,7 +445,7 @@ bool VCTFAM::OpenTableFile(PGLOBAL g)
       /* fall through */
     case MODE_UPDATE:
       UseTemp = Tdbp->IsUsingTemp(g);
-      strcpy(opmode, (UseTemp) ? "rb" : "r+b");
+      snprintf(opmode, sizeof(opmode), (UseTemp) ? "rb" : "r+b");
       break;
     case MODE_INSERT:
       if (MaxBlk) {
@@ -453,11 +453,11 @@ bool VCTFAM::OpenTableFile(PGLOBAL g)
           if (MakeEmptyFile(g, To_File))
             return true;
 
-        strcpy(opmode, "r+b");   // Required to update empty blocks
+        snprintf(opmode, sizeof(opmode), "r+b");   // Required to update empty blocks
       } else if (!Block || Last == Nrec)
-        strcpy(opmode, "ab");
+        snprintf(opmode, sizeof(opmode), "ab");
       else
-        strcpy(opmode, "r+b");   // Required to update the last block
+        snprintf(opmode, sizeof(opmode), "r+b");   // Required to update the last block
 
       break;
     default:
@@ -1912,7 +1912,7 @@ bool VECFAM::OpenTableFile(PGLOBAL g)
   /*********************************************************************/
   switch (mode) {
     case MODE_READ:
-      strcpy(opmode, "rb");
+      snprintf(opmode, sizeof(opmode), "rb");
       break;
     case MODE_DELETE:
       if (!Tdbp->GetNext()) {
@@ -1920,7 +1920,7 @@ bool VECFAM::OpenTableFile(PGLOBAL g)
         DelRows = Cardinality(g);
 
         // This will delete the whole file
-        strcpy(opmode, "wb");
+        snprintf(opmode, sizeof(opmode), "wb");
 
         // This will stop the process by causing GetProgMax to return 0.
         ResetTableSize(g, 0, Nrec);
@@ -1931,10 +1931,10 @@ bool VECFAM::OpenTableFile(PGLOBAL g)
       /* fall through */
     case MODE_UPDATE:
       UseTemp = Tdbp->IsUsingTemp(g);
-      strcpy(opmode, (UseTemp) ? "rb": "r+b");
+      snprintf(opmode, sizeof(opmode), (UseTemp) ? "rb": "r+b");
       break;
     case MODE_INSERT:
-      strcpy(opmode, "ab");
+      snprintf(opmode, sizeof(opmode), "ab");
       break;
     default:
       snprintf(g->Message, sizeof(g->Message), MSG(BAD_OPEN_MODE), mode);

--- a/storage/connect/filamzip.cpp
+++ b/storage/connect/filamzip.cpp
@@ -152,7 +152,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 	/*********************************************************************/
 	/*  pat is a multiple file name with wildcard characters             */
 	/*********************************************************************/
-	strcpy(filename, pat);
+	snprintf(filename, sizeof(filename), "%s", pat);
 
 #if defined(_WIN32)
 	int  rc;
@@ -174,7 +174,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 			snprintf(g->Message, sizeof(g->Message), MSG(BAD_FILE_HANDLE), filename);
 			return true;
 		} else {
-			strcpy(g->Message, "Cannot find any file to load");
+			snprintf(g->Message, sizeof(g->Message), "Cannot find any file to load");
 			return true;
 		}	// endif rc
 
@@ -208,7 +208,7 @@ static bool ZipFiles(PGLOBAL g, ZIPUTIL *zutp, PCSZ pat, char *buf)
 
 	// Close the search handle.
 	if (!FindClose(hSearch)) {
-		strcpy(g->Message, MSG(SRCH_CLOSE_ERR));
+		snprintf(g->Message, sizeof(g->Message), MSG(SRCH_CLOSE_ERR));
 		return true;
 	} // endif FindClose
 
@@ -402,7 +402,7 @@ bool ZIPUTIL::OpenTable(PGLOBAL g, MODE mode, PCSZ fn, bool append)
 			return true;
 
 	} else {
-		strcpy(g->Message, "Only INSERT mode supported for ZIPPING files");
+		snprintf(g->Message, sizeof(g->Message), "Only INSERT mode supported for ZIPPING files");
 		return true;
 	}	// endif mode
 
@@ -610,7 +610,7 @@ int UNZIPUTL::findEntry(PGLOBAL g, bool next)
 		next = true;
 	} while (true);
 
-	strcpy(g->Message, "FindNext logical error");
+	snprintf(g->Message, sizeof(g->Message), "FindNext logical error");
 	return RC_FX;
 }	// end of FindEntry
 
@@ -703,7 +703,7 @@ bool UNZIPUTL::OpenTable(PGLOBAL g, MODE mode, PCSZ fn)
 			return true;
 
 	} else {
-		strcpy(g->Message, "Only READ mode supported for ZIPPED tables");
+		snprintf(g->Message, sizeof(g->Message), "Only READ mode supported for ZIPPED tables");
 		return true;
 	}	// endif mode
 
@@ -755,7 +755,7 @@ bool UNZIPUTL::openEntry(PGLOBAL g)
 	try {
 		memory = new char[size + 1];
 	} catch (...) {
-		strcpy(g->Message, "Out of memory");
+		snprintf(g->Message, sizeof(g->Message), "Out of memory");
 		return true;
 	} // end try/catch
 
@@ -1130,16 +1130,16 @@ int UZDFAM::dbfhead(PGLOBAL g, void* buf)
 
 	// Check first byte to be sure of .dbf type
 	if ((hdrp->Version & 0x03) != DBFTYPE) {
-		strcpy(g->Message, MSG(NOT_A_DBF_FILE));
+		snprintf(g->Message, sizeof(g->Message), MSG(NOT_A_DBF_FILE));
 		rc = RC_INFO;
 
 		if ((hdrp->Version & 0x30) == 0x30) {
-			strcpy(g->Message, MSG(FOXPRO_FILE));
+			snprintf(g->Message, sizeof(g->Message), MSG(FOXPRO_FILE));
 			dbc = 264;             // FoxPro database container
 		} // endif Version
 
 	} else
-		strcpy(g->Message, MSG(DBASE_FILE));
+		snprintf(g->Message, sizeof(g->Message), MSG(DBASE_FILE));
 
 	// Check last byte(s) of header
 	endmark = (char*)hdrp + hdrp->Headlen() - dbc;
@@ -1304,13 +1304,13 @@ bool ZIPFAM::OpenTableFile(PGLOBAL g)
 	if (len < 0)
 		return true;
 	else if (!append && len > 0) {
-		strcpy(g->Message, "No insert into existing zip file");
+		snprintf(g->Message, sizeof(g->Message), "No insert into existing zip file");
 		return true;
 	} else if (append && len > 0) {
 		UNZIPUTL *zutp = new(g) UNZIPUTL(target, NULL, false);
 
 		if (!zutp->IsInsertOk(g, filename)) {
-			strcpy(g->Message, "No insert into existing entry");
+			snprintf(g->Message, sizeof(g->Message), "No insert into existing entry");
 			return true;
 		}	// endif Ok
 
@@ -1337,7 +1337,7 @@ bool ZIPFAM::OpenTableFile(PGLOBAL g)
 /***********************************************************************/
 int ZIPFAM::ReadBuffer(PGLOBAL g)
 {
-	strcpy(g->Message, "ReadBuffer should not been called when zipping");
+	snprintf(g->Message, sizeof(g->Message), "ReadBuffer should not been called when zipping");
 	return RC_FX;
 } // end of ReadBuffer
 
@@ -1388,13 +1388,13 @@ bool ZPXFAM::OpenTableFile(PGLOBAL g)
 	if (len < 0)
 		return true;
 	else if (!append && len > 0) {
-		strcpy(g->Message, "No insert into existing zip file");
+		snprintf(g->Message, sizeof(g->Message), "No insert into existing zip file");
 		return true;
 	} else if (append && len > 0) {
 		UNZIPUTL *zutp = new(g) UNZIPUTL(target, NULL, false);
 
 		if (!zutp->IsInsertOk(g, filename)) {
-			strcpy(g->Message, "No insert into existing entry");
+			snprintf(g->Message, sizeof(g->Message), "No insert into existing entry");
 			return true;
 		}	// endif Ok
 

--- a/storage/connect/filter.cpp
+++ b/storage/connect/filter.cpp
@@ -386,7 +386,7 @@ int FILTER::CheckColumn(PGLOBAL g, PSQL sqlp, PXOB &p, int &ag)
     } // endfor i
 
   if (*errmsg) {
-    strcpy(g->Message, errmsg);
+    snprintf(g->Message, sizeof(g->Message), errmsg);
     return -1;
   } else
     return n;
@@ -993,7 +993,7 @@ bool FILTER::Convert(PGLOBAL g, bool having)
         break;
       case TYPE_ARRAY:
         if ((Opc != OP_IN && !Opm) || i == 0) {
-          strcpy(g->Message, MSG(BAD_ARRAY_OPER));
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_ARRAY_OPER));
           return TRUE;
           } // endif
 
@@ -1007,7 +1007,7 @@ bool FILTER::Convert(PGLOBAL g, bool having)
           goto TEST;             // Filter has only one argument
           } // endif i
 
-        strcpy(g->Message, MSG(VOID_FIRST_ARG));
+        snprintf(g->Message, sizeof(g->Message), MSG(VOID_FIRST_ARG));
         return TRUE;
       } // endswitch
 
@@ -1052,7 +1052,7 @@ bool FILTER::Convert(PGLOBAL g, bool having)
     } // endif Opc
 
     if (comtype == TYPE_ERROR) {
-      strcpy(g->Message, MSG(ILL_FILTER_CONV));
+      snprintf(g->Message, sizeof(g->Message), MSG(ILL_FILTER_CONV));
       return TRUE;
       } // endif
 
@@ -1101,7 +1101,7 @@ bool FILTER::Convert(PGLOBAL g, bool having)
 
           break;
         case TYPE_FILTER:
-          strcpy(g->Message, MSG(UNMATCH_FIL_ARG));
+          snprintf(g->Message, sizeof(g->Message), MSG(UNMATCH_FIL_ARG));
           return TRUE;
         default:
           // Conversion from Column, Select/Func, Expr, Scalfnc...
@@ -1270,7 +1270,7 @@ bool FILTER::Eval(PGLOBAL g)
           ap = (PARRAY)Arg(1);
           break;
         default:
-          strcpy(g->Message, MSG(IN_WITHOUT_SUB));
+          snprintf(g->Message, sizeof(g->Message), MSG(IN_WITHOUT_SUB));
           goto FilterError;
         } // endswitch Type
 

--- a/storage/connect/fmdlex.c
+++ b/storage/connect/fmdlex.c
@@ -1480,7 +1480,7 @@ void MakeAMPM(int n)
           n, pp->Num, pp->InFmt, pp->OutFmt);
 #endif
   pp->Index[pp->Num++] = -n;
-  sprintf(buf, "%%%ds", m);
+  snprintf(buf, sizeof(buf), "%%%ds", m);
   MakeIn(buf);
 
   if (pp->OutFmt) {

--- a/storage/connect/ha_connect.cc
+++ b/storage/connect/ha_connect.cc
@@ -1868,7 +1868,7 @@ bool ha_connect::CheckVirtualIndex(TABLE_SHARE *s)
       rid= (fp->option_struct) ? fp->option_struct->special : NULL;
 
       if (!rid || (stricmp(rid, "ROWID") && stricmp(rid, "ROWNUM"))) {
-        strcpy(g->Message, "Invalid virtual index");
+        snprintf(g->Message, sizeof(g->Message), "Invalid virtual index");
         return true;
         } // endif rowid
 
@@ -2014,7 +2014,7 @@ int ha_connect::OpenTable(PGLOBAL g, bool del)
       case MODE_INSERT:
       case MODE_UPDATE:
       case MODE_DELETE:
-        strcpy(g->Message, MSG(READ_ONLY));
+        snprintf(g->Message, sizeof(g->Message), MSG(READ_ONLY));
         return HA_ERR_TABLE_READONLY;
       default:
         break;
@@ -2143,7 +2143,7 @@ bool ha_connect::CheckColumnList(PGLOBAL g)
 			htrc("Exception %d: %s\n", n, g->Message);
 		brc= true;
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		brc= true;
 	} // end catch
 
@@ -2512,7 +2512,7 @@ bool ha_connect::MakeKeyWhere(PGLOBAL g, PSTRG qry, OPVAL vop, char q,
 	ranges[1]= (end_range && !eq_range) ? &save_end_range : NULL;
 
 	if (!ranges[0] && !ranges[1]) {
-		strcpy(g->Message, "MakeKeyWhere: No key");
+		snprintf(g->Message, sizeof(g->Message), "MakeKeyWhere: No key");
 	  return true;
 	}	else
 		both= ranges[0] && ranges[1];
@@ -2611,7 +2611,7 @@ bool ha_connect::MakeKeyWhere(PGLOBAL g, PSTRG qry, OPVAL vop, char q,
 	qry->Append(')');
 
   if ((oom= qry->IsTruncated()))
-    strcpy(g->Message, "Out of memory");
+    snprintf(g->Message, sizeof(g->Message), "Out of memory");
 
 	dbug_tmp_restore_column_map(&table->write_set, old_map);
 	return oom;
@@ -3385,7 +3385,7 @@ const COND *ha_connect::cond_push(const COND *cond)
 			if (trace(1))
 				htrc("Exception %d: %s\n", n, g->Message);
 		} catch (const char *msg) {
-			strcpy(g->Message, msg);
+			snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		} // end catch
 
 	fin:;
@@ -3611,7 +3611,7 @@ int ha_connect::optimize(THD* thd, HA_CHECK_OPT*)
 			htrc("Exception %d: %s\n", n, g->Message);
 		rc= HA_ERR_INTERNAL_ERROR;
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		rc= HA_ERR_INTERNAL_ERROR;
 	} // end catch
 
@@ -4711,7 +4711,7 @@ MODE ha_connect::CheckMode(PGLOBAL g, THD *thd,
 				break;
 			default:
         htrc("Unsupported sql_command=%d\n", thd_sql_command(thd));
-        strcpy(g->Message, "CONNECT Unsupported command");
+        snprintf(g->Message, sizeof(g->Message), "CONNECT Unsupported command");
         my_message(ER_NOT_ALLOWED_COMMAND, g->Message, MYF(0));
         newmode= MODE_ERROR;
         break;
@@ -4769,7 +4769,7 @@ MODE ha_connect::CheckMode(PGLOBAL g, THD *thd,
         break;
       default:
         htrc("Unsupported sql_command=%d\n", thd_sql_command(thd));
-        strcpy(g->Message, "CONNECT Unsupported command");
+        snprintf(g->Message, sizeof(g->Message), "CONNECT Unsupported command");
         my_message(ER_NOT_ALLOWED_COMMAND, g->Message, MYF(0));
         newmode= MODE_ERROR;
         break;
@@ -5024,7 +5024,7 @@ int ha_connect::external_lock(THD *thd, int lock_type)
     xmod= MODE_ANY;              // For info commands
     DBUG_RETURN(rc);
 	} else if (check_privileges(thd, options, table->s->db.str)) {
-		strcpy(g->Message, "This operation requires the FILE privilege");
+		snprintf(g->Message, sizeof(g->Message), "This operation requires the FILE privilege");
 		htrc("%s\n", g->Message);
 		DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
 	} // endif check_privileges
@@ -5378,7 +5378,7 @@ bool CheckSelf(PGLOBAL g, TABLE_SHARE *s, PCSZ host,
   else if (port && port != (signed)GetDefaultPort())
     return false;
 
-  strcpy(g->Message, "This MySQL table is defined on itself");
+  snprintf(g->Message, sizeof(g->Message), "This MySQL table is defined on itself");
   return true;
 } // end of CheckSelf
 
@@ -5721,7 +5721,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 		} else if (topt->http) {
       if (ttp == TAB_UNDEF) {
         ttr= TAB_JSON;
-        strcpy(g->Message, "No table_type. Was set to JSON");
+        snprintf(g->Message, sizeof(g->Message), "No table_type. Was set to JSON");
         push_warning(thd, Sql_condition::WARN_LEVEL_NOTE, 0, g->Message);
       } else
         ttr= ttp;
@@ -5754,7 +5754,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
         case TAB_BSON:
 #endif   // BSON_SUPPORT
           if (checkPrivileges(thd, ttp, topt, db)) {
-            strcpy(g->Message, "This operation requires the FILE privilege");
+            snprintf(g->Message, sizeof(g->Message), "This operation requires the FILE privilege");
             rc= HA_ERR_INTERNAL_ERROR;
             goto err;
           } // endif check_privileges
@@ -5770,7 +5770,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 				char *p;
 
 				if (!tbl) {
-					strcpy(g->Message, "Missing table list");
+					snprintf(g->Message, sizeof(g->Message), "Missing table list");
 					rc= HA_ERR_INTERNAL_ERROR;
 					goto err;
 				} // endif tbl
@@ -5828,7 +5828,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 				if (fnc & FNC_DRIVER) {
 					ok= true;
 				} else if (!(url= strz(g, create_info->connect_string))) {
-					strcpy(g->Message, "Missing URL");
+					snprintf(g->Message, sizeof(g->Message), "Missing URL");
 				} else {
 					// Store JDBC additional parameters
 					int      rc;
@@ -5932,7 +5932,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 				if (topt->module && topt->subtype)
 					ok= true;
 				else
-					strcpy(g->Message, "Missing OEM module or subtype");
+					snprintf(g->Message, sizeof(g->Message), "Missing OEM module or subtype");
 
 				break;
 #if defined(LIBXML2_SUPPORT) || defined(DOMDOC_SUPPORT)
@@ -5984,7 +5984,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 		} // endif supfnc
 
 		if (src && fnc != FNC_NO) {
-			strcpy(g->Message, "Cannot make catalog table from srcdef");
+			snprintf(g->Message, sizeof(g->Message), "Cannot make catalog table from srcdef");
 			ok= false;
 		} // endif src
 
@@ -6136,7 +6136,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 					qrp= OEMColumns(g, topt, tab, (char*)db, fnc == FNC_COL);
 					break;
 				default:
-					strcpy(g->Message, "System error during assisted discovery");
+					snprintf(g->Message, sizeof(g->Message), "System error during assisted discovery");
 					break;
 			} // endswitch ttp
 
@@ -6380,7 +6380,7 @@ static int connect_assisted_discovery(handlerton *, THD* thd,
 			htrc("Exception %d: %s\n", n, g->Message);
 		rc= HA_ERR_INTERNAL_ERROR;
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		rc= HA_ERR_INTERNAL_ERROR;
 	} // end catch
 
@@ -6538,7 +6538,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
       case TAB_PIVOT:
       case TAB_OCCUR:
         if (options->srcdef) {
-          strcpy(g->Message, "Cannot check looping reference");
+          snprintf(g->Message, sizeof(g->Message), "Cannot check looping reference");
           push_warning(thd, Sql_condition::WARN_LEVEL_WARN, 0, g->Message);
         } else if (options->tabname) {
           if (!stricmp(options->tabname, create_info->alias.str) &&
@@ -6551,7 +6551,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
             } // endif tab
 
         } else {
-          strcpy(g->Message, "Missing object table name or definition");
+          snprintf(g->Message, sizeof(g->Message), "Missing object table name or definition");
           my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
           DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
         } // endif tabname
@@ -6629,14 +6629,14 @@ int ha_connect::create(const char *name, TABLE *table_arg,
 
 #if !defined(DOMDOC_SUPPORT)
     if (dom) {
-      strcpy(g->Message, "MS-DOM not supported by this version");
+      snprintf(g->Message, sizeof(g->Message), "MS-DOM not supported by this version");
       xsup= NULL;
       } // endif DomDoc
 #endif   // !DOMDOC_SUPPORT
 
 #if !defined(LIBXML2_SUPPORT)
     if (!dom) {
-      strcpy(g->Message, "libxml2 not supported by this version");
+      snprintf(g->Message, sizeof(g->Message), "libxml2 not supported by this version");
       xsup= NULL;
       } // endif Libxml2
 #endif   // !LIBXML2_SUPPORT
@@ -6681,7 +6681,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
       continue;            // This is a virtual column
 
     if (fp->flags & AUTO_INCREMENT_FLAG) {
-      strcpy(g->Message, "Auto_increment is not supported yet");
+      snprintf(g->Message, sizeof(g->Message), "Auto_increment is not supported yet");
       my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
       rc= HA_ERR_INTERNAL_ERROR;
       DBUG_RETURN(rc);
@@ -6697,7 +6697,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
 
     if (type == TAB_VIR)
       if (!fp->option_struct || !fp->option_struct->special) {
-        strcpy(g->Message, "Virtual tables accept only special or virtual columns");
+        snprintf(g->Message, sizeof(g->Message), "Virtual tables accept only special or virtual columns");
         my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
         rc= HA_ERR_INTERNAL_ERROR;
         DBUG_RETURN(rc);
@@ -6915,7 +6915,7 @@ int ha_connect::create(const char *name, TABLE *table_arg,
         // This is an ALTER to CONNECT from another engine.
         // It cannot be accepted because the table data would be modified
         // except when the target file does not exist.
-        strcpy(g->Message, "Operation denied. Table data would be modified.");
+        snprintf(g->Message, sizeof(g->Message), "Operation denied. Table data would be modified.");
         my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
         DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
       } // endif part_info
@@ -6925,11 +6925,11 @@ int ha_connect::create(const char *name, TABLE *table_arg,
     // Get the index definitions
     if ((xdp= GetIndexInfo()) || sqlcom == SQLCOM_DROP_INDEX) {
       if (options->multiple) {
-        strcpy(g->Message, "Multiple tables are not indexable");
+        snprintf(g->Message, sizeof(g->Message), "Multiple tables are not indexable");
         my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
         rc= HA_ERR_UNSUPPORTED;
       } else if (options->compressed) {
-        strcpy(g->Message, "Compressed tables are not indexable");
+        snprintf(g->Message, sizeof(g->Message), "Compressed tables are not indexable");
         my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
         rc= HA_ERR_UNSUPPORTED;
       } else if (GetIndexType(type) == 1) {
@@ -7210,11 +7210,11 @@ ha_connect::check_if_supported_inplace_alter(TABLE *altered_table,
       !SameString(altered_table, "optname") ||
       !SameBool(altered_table, "sepindex")) {
     if (newopt->multiple) {
-      strcpy(g->Message, "Multiple tables are not indexable");
+      snprintf(g->Message, sizeof(g->Message), "Multiple tables are not indexable");
       my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
       DBUG_RETURN(HA_ALTER_ERROR);
     } else if (newopt->compressed) {
-      strcpy(g->Message, "Compressed tables are not indexable");
+      snprintf(g->Message, sizeof(g->Message), "Compressed tables are not indexable");
       my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
       DBUG_RETURN(HA_ALTER_ERROR);
     } else if (GetIndexType(type) == 1) {
@@ -7265,7 +7265,7 @@ ha_connect::check_if_supported_inplace_alter(TABLE *altered_table,
       tshp= NULL;
 
       if (FileExists(fn, false)) {
-        strcpy(g->Message, "Operation denied. Table data would be lost.");
+        snprintf(g->Message, sizeof(g->Message), "Operation denied. Table data would be lost.");
         my_message(ER_UNKNOWN_ERROR, g->Message, MYF(0));
         DBUG_RETURN(HA_ALTER_ERROR);
       } else

--- a/storage/connect/javaconn.cpp
+++ b/storage/connect/javaconn.cpp
@@ -167,7 +167,7 @@ bool JAVAConn::gmID(PGLOBAL g, jmethodID& mid, const char *name, const char *sig
 		mid = env->GetMethodID(jdi, name, sig);
 
 		if (Check()) {
-			strcpy(g->Message, Msg);
+			snprintf(g->Message, sizeof(g->Message), Msg);
 			return true;
 		} else
 			return false;
@@ -372,7 +372,7 @@ bool JAVAConn::Open(PGLOBAL g)
 		rc = jvm->AttachCurrentThread((void**)&env, nullptr);
 
 		if (rc != JNI_OK) {
-			strcpy(g->Message, "Cannot attach jvm to the current thread");
+			snprintf(g->Message, sizeof(g->Message), "Cannot attach jvm to the current thread");
 			return true;
 		} // endif rc
 
@@ -456,26 +456,26 @@ bool JAVAConn::Open(PGLOBAL g)
 
 		switch (rc) {
 			case JNI_OK:
-				strcpy(g->Message, "VM successfully created");
+				snprintf(g->Message, sizeof(g->Message), "VM successfully created");
 				brc = false;
 				break;
 			case JNI_ERR:
-				strcpy(g->Message, "Initialising JVM failed: unknown error");
+				snprintf(g->Message, sizeof(g->Message), "Initialising JVM failed: unknown error");
 				break;
 			case JNI_EDETACHED:
-				strcpy(g->Message, "Thread detached from the VM");
+				snprintf(g->Message, sizeof(g->Message), "Thread detached from the VM");
 				break;
 			case JNI_EVERSION:
-				strcpy(g->Message, "JNI version error");
+				snprintf(g->Message, sizeof(g->Message), "JNI version error");
 				break;
 			case JNI_ENOMEM:
-				strcpy(g->Message, "Not enough memory");
+				snprintf(g->Message, sizeof(g->Message), "Not enough memory");
 				break;
 			case JNI_EEXIST:
-				strcpy(g->Message, "VM already created");
+				snprintf(g->Message, sizeof(g->Message), "VM already created");
 				break;
 			case JNI_EINVAL:
-				strcpy(g->Message, "Invalid arguments");
+				snprintf(g->Message, sizeof(g->Message), "Invalid arguments");
 				break;
 			default:
 				snprintf(g->Message, sizeof(g->Message), "Unknown return code %d", (int)rc);
@@ -516,7 +516,7 @@ bool JAVAConn::Open(PGLOBAL g)
 			rc = env->CallStaticIntMethod(jdi, alp, path);
 
 			if ((msg = Check(rc))) {
-				strcpy(g->Message, msg);
+				snprintf(g->Message, sizeof(g->Message), msg);
 				env->DeleteLocalRef(path);
 				return RC_FX;
 			} else switch (rc) {
@@ -528,7 +528,7 @@ bool JAVAConn::Open(PGLOBAL g)
 					break;
 				case JNI_ERR:
 				default:
-					strcpy(g->Message, "Error adding jpath");
+					snprintf(g->Message, sizeof(g->Message), "Error adding jpath");
 					env->DeleteLocalRef(path);
 					return RC_FX;
 			}	// endswitch rc
@@ -559,7 +559,7 @@ bool JAVAConn::Open(PGLOBAL g)
 	errid = env->GetMethodID(jdi, "GetErrmsg", "()Ljava/lang/String;");
 
 	if (env->ExceptionCheck()) {
-		strcpy(g->Message, "ERROR: method GetErrmsg() not found!");
+		snprintf(g->Message, sizeof(g->Message), "ERROR: method GetErrmsg() not found!");
 		env->ExceptionDescribe();
 		env->ExceptionClear();
 		return true;

--- a/storage/connect/jdbconn.cpp
+++ b/storage/connect/jdbconn.cpp
@@ -879,11 +879,11 @@ int JDBConn::ExecuteCommand(PCSZ sql)
 		snprintf(g->Message, sizeof(g->Message), "GetResult: %s", Msg);
 		rc = RC_FX;
 	} else if (m_Ncol) {
-		strcpy(g->Message, "Result set column number");
+		snprintf(g->Message, sizeof(g->Message), "Result set column number");
 		rc = RC_OK;						// A result set was returned
 	} else {
 		m_Aff = (int)n;			  // Affected rows
-		strcpy(g->Message, "Affected rows");
+		snprintf(g->Message, sizeof(g->Message), "Affected rows");
 		rc = RC_NF;
 	} // endif ncol
 
@@ -903,7 +903,7 @@ int JDBConn::Fetch(int pos)
 
 	if (pos) {
 		if (!m_Scrollable) {
-			strcpy(g->Message, "Cannot fetch(pos) if FORWARD ONLY");
+			snprintf(g->Message, sizeof(g->Message), "Cannot fetch(pos) if FORWARD ONLY");
 		  return rc;
 		} else if (gmID(m_G, fetchid, "Fetch", "(I)Z"))
 			return rc;
@@ -1232,7 +1232,7 @@ int JDBConn::ExecuteSQL(void)
 		jint n = env->CallIntMethod(job, xpid);
 
 		if (n == -3)
-			strcpy(g->Message, "SQL statement is not prepared");
+			snprintf(g->Message, sizeof(g->Message), "SQL statement is not prepared");
 		else if (Check(n))
 			snprintf(g->Message, sizeof(g->Message), "ExecutePrep: %s", Msg);
 		else {
@@ -1315,17 +1315,17 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 			break;
 		case TYPE_DATE:
 			if ((dat = env->FindClass("java/sql/Timestamp")) == nullptr) {
-				strcpy(g->Message, "Cannot find Timestamp class");
+				snprintf(g->Message, sizeof(g->Message), "Cannot find Timestamp class");
 				return true;
 			} else if (!(dtc = env->GetMethodID(dat, "<init>", "(J)V"))) {
-				strcpy(g->Message, "Cannot find Timestamp class constructor");
+				snprintf(g->Message, sizeof(g->Message), "Cannot find Timestamp class constructor");
 				return true;
 			}	// endif's
 
 			lg = (jlong)val->GetBigintValue() * 1000;
 
 			if ((datobj = env->NewObject(dat, dtc, lg)) == nullptr) {
-				strcpy(g->Message, "Cannot make Timestamp object");
+				snprintf(g->Message, sizeof(g->Message), "Cannot make Timestamp object");
 				return true;
 			} else if (gmID(g, setid, "SetTimestampParm", "(ILjava/sql/Timestamp;)V"))
 				return true;
@@ -1416,12 +1416,12 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 		int     rc = ExecuteCommand(src);
 
 		if (rc == RC_NF) {
-			strcpy(g->Message, "Srcdef is not returning a result set");
+			snprintf(g->Message, sizeof(g->Message), "Srcdef is not returning a result set");
 			return NULL;
 		} else if ((rc) == RC_FX) {
 			return NULL;
 		} else if (m_Ncol == 0) {
-			strcpy(g->Message, "Invalid Srcdef");
+			snprintf(g->Message, sizeof(g->Message), "Invalid Srcdef");
 			return NULL;
 		} // endif's
 
@@ -1463,7 +1463,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 				if (Check())
 					snprintf(g->Message, sizeof(g->Message), "ColumnDesc: %s", Msg);
 				else
-					strcpy(g->Message, "No result metadata");
+					snprintf(g->Message, sizeof(g->Message), "No result metadata");
 
 				env->ReleaseIntArrayElements(val, n, 0);
 				return NULL;
@@ -1568,7 +1568,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 
 		// n because we no more ignore the first column
 		if ((n = qrp->Nbcol) > (uint)ncol) {
-			strcpy(g->Message, MSG(COL_NUM_MISM));
+			snprintf(g->Message, sizeof(g->Message), MSG(COL_NUM_MISM));
 			return -1;
 		} // endif n
 
@@ -1638,7 +1638,7 @@ bool JDBConn::SetParam(JDBCCOL *colp)
 		PQRYRES      qrp;
 
 		if (!m_Rows) {
-			strcpy(g->Message, "Void result");
+			snprintf(g->Message, sizeof(g->Message), "Void result");
 			return NULL;
 		} // endif m_Rows
 

--- a/storage/connect/jmgoconn.cpp
+++ b/storage/connect/jmgoconn.cpp
@@ -264,7 +264,7 @@ bool JMgoConn::MakeCursor(PGLOBAL g, PTDB tdbp, PCSZ options,
 		p = strrchr(Options, ']');
 
 		if (!p) {
-			strcpy(g->Message, "Missing ] in pipeline");
+			snprintf(g->Message, sizeof(g->Message), "Missing ] in pipeline");
 			return true;
 		} else
 			*(char*)p = 0;
@@ -275,7 +275,7 @@ bool JMgoConn::MakeCursor(PGLOBAL g, PTDB tdbp, PCSZ options,
 			s->Append(",{\"$match\":");
 
 			if (MakeSelector(g, filp, s)) {
-				strcpy(g->Message, "Failed making selector");
+				snprintf(g->Message, sizeof(g->Message), "Failed making selector");
 				return true;
 			} else
 				s->Append('}');
@@ -343,7 +343,7 @@ bool JMgoConn::MakeCursor(PGLOBAL g, PTDB tdbp, PCSZ options,
 					s->Append(',');
 
 				if (MakeSelector(g, filp, s)) {
-					strcpy(g->Message, "Failed making selector");
+					snprintf(g->Message, sizeof(g->Message), "Failed making selector");
 					return true;
 				}	// endif Selector
 

--- a/storage/connect/json.cpp
+++ b/storage/connect/json.cpp
@@ -164,7 +164,7 @@ PJSON ParseJson(PGLOBAL g, char* s, size_t len, int* ptyp, bool* comma)
     htrc("ParseJson: s=%.10s len=%zd\n", s, len);
 
   if (!s || !len) {
-    strcpy(g->Message, "Void JSON object");
+    snprintf(g->Message, sizeof(g->Message), "Void JSON object");
     return NULL;
   } else if (comma)
     *comma = false;
@@ -247,7 +247,7 @@ PJSON ParseJson(PGLOBAL g, char* s, size_t len, int* ptyp, bool* comma)
       htrc("Exception %d: %s\n", n, g->Message);
     jsp = NULL;
   } catch (const char* msg) {
-    strcpy(g->Message, msg);
+    snprintf(g->Message, sizeof(g->Message), "%s", msg);
     jsp = NULL;
   } // end catch
 
@@ -271,7 +271,7 @@ PSZ Serialize(PGLOBAL g, PJSON jsp, char* fn, int pretty) {
     jdp->dfp = GetDefaultPrec();
 
     if (!jsp) {
-      safe_strcpy(g->Message, sizeof(g->Message), "Null json tree");
+      snprintf(g->Message, sizeof(g->Message), "Null json tree");
       throw 1;
     } else if (!fn) {
       // Serialize to a string
@@ -307,20 +307,25 @@ PSZ Serialize(PGLOBAL g, PJSON jsp, char* fn, int pretty) {
       err = jdp->SerializeValue((PJVAL)jsp);
       break;
     default:
-      strcpy(g->Message, "Invalid json tree");
+      snprintf(g->Message, sizeof(g->Message), "Invalid json tree");
     } // endswitch Type
 
     if (fs) {
       fputs(EL, fs);
       fclose(fs);
-      str = (err) ? NULL : strcpy(g->Message, "Ok");
+      if(err) {
+        str = NULL;
+      } else {
+        snprintf(g->Message, sizeof(g->Message), "Ok");
+        str = g->Message;
+      }
     } else if (!err) {
       str = ((JOUTSTR*)jp)->Strp;
       jp->WriteChr('\0');
       PlugSubAlloc(g, NULL, ((JOUTSTR*)jp)->N);
     } else {
       if (!g->Message[0])
-        strcpy(g->Message, "Error in Serialize");
+        snprintf(g->Message, sizeof(g->Message), "Error in Serialize");
 
     } // endif's
 
@@ -329,7 +334,7 @@ PSZ Serialize(PGLOBAL g, PJSON jsp, char* fn, int pretty) {
       htrc("Exception %d: %s\n", n, g->Message);
     str = NULL;
   } catch (const char* msg) {
-    strcpy(g->Message, msg);
+    snprintf(g->Message, sizeof(g->Message), "%s", msg);
     str = NULL;
   } // end catch
 
@@ -553,7 +558,7 @@ PJAR JDOC::ParseAsArray(PGLOBAL g, int& i, int pretty, int *ptyp)
 
     return jsp;
   } else
-    strcpy(g->Message, "More than one item in file");
+    snprintf(g->Message, sizeof(g->Message), "More than one item in file");
 
   return NULL;
 } // end of ParseAsArray
@@ -672,7 +677,7 @@ PJOB JDOC::ParseObject(PGLOBAL g, int& i)
         throw 2;
     }; // endswitch s[i]
 
-  strcpy(g->Message, "Unexpected EOF in Object");
+  snprintf(g->Message, sizeof(g->Message), "Unexpected EOF in Object");
   throw 2;
 } // end of ParseObject
 
@@ -1179,7 +1184,7 @@ PSZ JOBJECT::GetText(PGLOBAL g, PSTRG text)
 bool JOBJECT::Merge(PGLOBAL g, PJSON jsp)
 {
   if (jsp->GetType() != TYPE_JOB) {
-    strcpy(g->Message, "Second argument is not an object");
+    snprintf(g->Message, sizeof(g->Message), "Second argument is not an object");
     return true;
   } // endif Type
 
@@ -1353,7 +1358,7 @@ PJVAL JARRAY::AddArrayValue(PGLOBAL g, PJVAL jvp, int *x)
 bool JARRAY::Merge(PGLOBAL g, PJSON jsp)
 {
   if (jsp->GetType() != TYPE_JAR) {
-    strcpy(g->Message, "Second argument is not an array");
+    snprintf(g->Message, sizeof(g->Message), "Second argument is not an array");
     return true;
   } // endif Type
 

--- a/storage/connect/jsonudf.cpp
+++ b/storage/connect/jsonudf.cpp
@@ -172,7 +172,7 @@ my_bool JSNX::SetArrayOptions(PGLOBAL g, char *p, int i, PSZ nm)
 		case '!': jnp->Op = OP_SEP;  break; // Average
 		case '#': jnp->Op = OP_NUM;  break;
 		case '*': // Expand this array
-			strcpy(g->Message, "Expand not supported by this function");
+			snprintf(g->Message, sizeof(g->Message), "Expand not supported by this function");
 			return true;
 		default:
 			snprintf(g->Message, sizeof(g->Message), "Invalid function specification %c", *p);
@@ -194,7 +194,7 @@ my_bool JSNX::SetArrayOptions(PGLOBAL g, char *p, int i, PSZ nm)
 		} // endif n
 
 	} else {
-		strcpy(g->Message, "Wrong array specification");
+		snprintf(g->Message, sizeof(g->Message), "Wrong array specification");
 		return true;
 	} // endif's
 
@@ -355,10 +355,10 @@ PJVAL JSNX::MakeJson(PGLOBAL g, PJSON jsp, int n)
 	Jb = false;
 
 	if (Value->IsTypeNum()) {
-		strcpy(g->Message, "Cannot make Json for a numeric value");
+		snprintf(g->Message, sizeof(g->Message), "Cannot make Json for a numeric value");
 		return NULL;
 	} else if (jsp->GetType() != TYPE_JAR && jsp->GetType() != TYPE_JOB) {
-		strcpy(g->Message, "Target is not an array or object");
+		snprintf(g->Message, sizeof(g->Message), "Target is not an array or object");
 		return NULL;
 	}	else 	if (n < Nod -1) {
 		if (jsp->GetType() == TYPE_JAR) {
@@ -447,7 +447,7 @@ PJVAL JSNX::GetRowValue(PGLOBAL g, PJSON row, int i, my_bool b)
 							val = new(g)JVALUE(row);
 
 					} else {
-						strcpy(g->Message, "Unexpected object");
+						snprintf(g->Message, sizeof(g->Message), "Unexpected object");
 						val = NULL;
 					} //endif Op
 
@@ -497,7 +497,7 @@ PJVAL JSNX::GetRowValue(PGLOBAL g, PJSON row, int i, my_bool b)
 /*********************************************************************************/
 PVAL JSNX::ExpandArray(PGLOBAL g, PJAR arp, int n)
 {
-	strcpy(g->Message, "Expand cannot be done by this function");
+	snprintf(g->Message, sizeof(g->Message), "Expand cannot be done by this function");
 	return NULL;
 } // end of ExpandArray
 
@@ -783,7 +783,7 @@ PJSON JSNX::GetRow(PGLOBAL g)
 					((PJAR)row)->AddArrayValue(g, new(g)JVALUE(nwr));
 					((PJAR)row)->InitArray(g);
 				} else {
-					strcpy(g->Message, "Wrong type when writing new row");
+					snprintf(g->Message, sizeof(g->Message), "Wrong type when writing new row");
 					nwr = NULL;
 				} // endif's
 
@@ -816,7 +816,7 @@ my_bool JSNX::WriteValue(PGLOBAL g, PJVAL jvalp)
 	case TYPE_JAR:  arp  = (PJAR)row;  break;
 	case TYPE_JVAL: jvp  = (PJVAL)row; break;
 	default: 
-		strcpy(g->Message, "Invalid target type");
+		snprintf(g->Message, sizeof(g->Message), "Invalid target type");
 		return true;
 	} // endswitch Type
 
@@ -851,7 +851,7 @@ PSZ JSNX::Locate(PGLOBAL g, PJSON jsp, PJVAL jvp, int k)
 	g->Message[0] = 0;
 
 	if (!jsp) {
-		strcpy(g->Message, "Null json tree");
+		snprintf(g->Message, sizeof(g->Message), "Null json tree");
 		return NULL;
 	} // endif jsp
 
@@ -878,7 +878,7 @@ PSZ JSNX::Locate(PGLOBAL g, PJSON jsp, PJVAL jvp, int k)
 
 		if (err) {
 			if (!g->Message[0])
-				strcpy(g->Message, "Invalid json tree");
+				snprintf(g->Message, sizeof(g->Message), "Invalid json tree");
 
 		} else if (Found) {
 			Jp->WriteChr('\0');
@@ -892,7 +892,7 @@ PSZ JSNX::Locate(PGLOBAL g, PJSON jsp, PJVAL jvp, int k)
 
 		PUSH_WARNING(g->Message);
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 	} // end catch
 
 	return str;
@@ -972,7 +972,7 @@ PSZ JSNX::LocateAll(PGLOBAL g, PJSON jsp, PJVAL jvp, int mx)
 	PJPN    jnp;
 	
 	if (!jsp) {
-		strcpy(g->Message, "Null json tree");
+		snprintf(g->Message, sizeof(g->Message), "Null json tree");
 		return NULL;
 	} // endif jsp
 
@@ -1011,7 +1011,7 @@ PSZ JSNX::LocateAll(PGLOBAL g, PJSON jsp, PJVAL jvp, int mx)
 			PlugSubAlloc(g, NULL, Jp->N);
 			str = Jp->Strp;
 		} else if (!g->Message[0])
-			strcpy(g->Message, "Invalid json tree");
+			snprintf(g->Message, sizeof(g->Message), "Invalid json tree");
 
 	} catch (int n) {
 		if (trace(1))
@@ -1019,7 +1019,7 @@ PSZ JSNX::LocateAll(PGLOBAL g, PJSON jsp, PJVAL jvp, int mx)
 
 		PUSH_WARNING(g->Message);
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 	} // end catch
 
 	return str;
@@ -1402,7 +1402,7 @@ static my_bool CheckPath(PGLOBAL g, UDF_ARGS *args, PJSON jsp, PJVAL& jvp, int n
 				} // endif jvp
 
 			} else {
-				strcpy(g->Message, "Path argument is null");
+				snprintf(g->Message, sizeof(g->Message), "Path argument is null");
 				return true;
 			} // endif path
 
@@ -1750,7 +1750,7 @@ my_bool CheckMemory(PGLOBAL g, UDF_INIT *initid, UDF_ARGS *args, uint n,
 					char errmsg[MAX_STR];
 
 					snprintf(errmsg, sizeof(errmsg) - 1, MSG(WORK_AREA), g->Message);
-					strcpy(g->Message, errmsg);
+					snprintf(g->Message, sizeof(g->Message), "%s", errmsg);
 					return true;
 					} // endif SareaAlloc
 
@@ -3620,7 +3620,7 @@ char *jsonget_string(UDF_INIT *initid, UDF_ARGS *args, char *result,
 		PUSH_WARNING(g->Message);
 		str = NULL;
 	} catch (const char *msg) {
-	  strcpy(g->Message, msg);
+	  snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		str = NULL;
   } // end catch
@@ -3980,7 +3980,7 @@ char *jsonlocate(UDF_INIT *initid, UDF_ARGS *args, char *result,
 		*error = 1;
 		path = NULL;
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		*error = 1;
 		path = NULL;
@@ -4106,7 +4106,7 @@ char *json_locate_all(UDF_INIT *initid, UDF_ARGS *args, char *result,
 		*error = 1;
 		path = NULL;
   } catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		*error = 1;
 		path = NULL;
@@ -4379,7 +4379,7 @@ char *handle_item(UDF_INIT *initid, UDF_ARGS *args, char *result,
 		PUSH_WARNING(g->Message);
 		str = NULL;
 	} catch (const char *msg) {
-	  strcpy(g->Message, msg);
+	  snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		PUSH_WARNING(g->Message);
 		str = NULL;
 	} // end catch
@@ -6187,7 +6187,7 @@ bool JUP::unPretty(PGLOBAL g, int lrecl) {
 		htrc("UnPretty: s=%.10s len=%zd lrecl=%d\n", s, len, lrecl);
 
 	if (!s || !len) {
-		strcpy(g->Message, "Void JSON file");
+		snprintf(g->Message, sizeof(g->Message), "Void JSON file");
 		return true;
 	} else if (*s != '[') {
 		// strcpy(g->Message, "JSON file is not an array");
@@ -6250,7 +6250,7 @@ bool JUP::unPretty(PGLOBAL g, int lrecl) {
 			htrc("Exception %d: %s\n", n, g->Message);
 		rc = true;
 	} catch (const char* msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 		rc = true;
 	} // end catch
 

--- a/storage/connect/macutil.cpp
+++ b/storage/connect/macutil.cpp
@@ -57,12 +57,11 @@ void MACINFO::MakeErrorMsg(PGLOBAL g, DWORD drc)
       "GetAdaptersInfo: Buffer Overflow buflen=%d nbofadap=%d",
       Buflen, N);
   else if (drc == ERROR_INVALID_PARAMETER)
-    strcpy(g->Message, "GetAdaptersInfo: Invalid parameters");
+    snprintf(g->Message, sizeof(g->Message), "GetAdaptersInfo: Invalid parameters");
   else if (drc == ERROR_NO_DATA)
-    strcpy(g->Message,
-           "No adapter information exists for the local computer");
+    snprintf(g->Message, sizeof(g->Message), "No adapter information exists for the local computer");
   else if (drc == ERROR_NOT_SUPPORTED)
-    strcpy(g->Message, "GetAdaptersInfo is not supported");
+    snprintf(g->Message, sizeof(g->Message), "GetAdaptersInfo is not supported");
   else
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM |
                   FORMAT_MESSAGE_IGNORE_INSERTS, NULL, GetLastError(),

--- a/storage/connect/odbconn.cpp
+++ b/storage/connect/odbconn.cpp
@@ -1155,7 +1155,7 @@ int ODBConn::Open(PCSZ ConnectString, POPARM sop, DWORD options)
 
     if (!m_UseCnc) {
       if (DriverConnect(options)) {
-        strcpy(g->Message, MSG(CONNECT_CANCEL));
+        snprintf(g->Message, sizeof(g->Message), MSG(CONNECT_CANCEL));
         return 0;
         } // endif
 
@@ -1480,7 +1480,7 @@ int ODBConn::ExecDirectSQL(char *sql, ODBCCOL *tocols)
         ThrowDBX(rc, "SQLNumResultCols", hstmt);
 
       if (ncol == 0) {
-        strcpy(g->Message, "This Srcdef does not return a result set");
+        snprintf(g->Message, sizeof(g->Message), "This Srcdef does not return a result set");
         return -1;
         } // endif ncol
 
@@ -1523,7 +1523,7 @@ int ODBConn::ExecDirectSQL(char *sql, ODBCCOL *tocols)
         tp = GetSQLCType(colp->GetResultType());
 
         if (tp == SQL_TYPE_NULL) {
-          sprintf(m_G->Message, MSG(INV_COLUMN_TYPE),
+          snprintf(m_G->Message, sizeof(m_G->Message), MSG(INV_COLUMN_TYPE),
                   colp->GetResultType(), SVP(colp->GetName()));
           ThrowDBX(m_G->Message);
         } // endif tp
@@ -1549,7 +1549,7 @@ int ODBConn::ExecDirectSQL(char *sql, ODBCCOL *tocols)
       for (int i = 0; i < MAX_NUM_OF_MSG && x->m_ErrMsg[i]; i++)
         htrc(x->m_ErrMsg[i]);
 
-    sprintf(m_G->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(m_G->Message, sizeof(m_G->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
 
     if (b)
       SQLCancel(hstmt);
@@ -1777,7 +1777,7 @@ int ODBConn::ExecuteSQL(void)
 
     if (ncol) {
       // This should never happen while inserting
-      strcpy(g->Message, "Logical error while inserting");
+      snprintf(g->Message, sizeof(g->Message), "Logical error while inserting");
     } else {
       // Insert, Update or Delete statement
       if (!Check(rc = SQLRowCount(m_hstmt, &afrw)))
@@ -1786,7 +1786,7 @@ int ODBConn::ExecuteSQL(void)
     } // endif ncol
 
   } catch(DBX *x) {
-    sprintf(m_G->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(m_G->Message, sizeof(m_G->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     SQLCancel(m_hstmt);
     rc = SQLFreeStmt(m_hstmt, SQL_DROP);
     m_hstmt = NULL;
@@ -1825,7 +1825,7 @@ bool ODBConn::BindParam(ODBCCOL *colp)
       ThrowDBX(rc, "SQLDescribeParam", m_hstmt);
 
   } catch(DBX *x) {
-    sprintf(m_G->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(m_G->Message, sizeof(m_G->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
 #endif // 0
     colsize = colp->GetPrecision();
     sqlt = GetSQLType(buftype);
@@ -1923,10 +1923,10 @@ bool ODBConn::ExecSQLcommand(char *sql)
         ThrowDBX(rc, "SQLRowCount", hstmt);
 
       m_Tdb->AftRows = (int)afrw;
-      strcpy(g->Message, "Affected rows");
+      snprintf(g->Message, sizeof(g->Message), "Affected rows");
     } else {
       m_Tdb->AftRows = (int)ncol;
-      strcpy(g->Message, "Result set column number");
+      snprintf(g->Message, sizeof(g->Message), "Result set column number");
     } // endif ncol
 
   } catch(DBX *x) {
@@ -2024,7 +2024,7 @@ PQRYRES ODBConn::GetMetaData(PGLOBAL g, PCSZ dsn, PCSZ src)
   } // end try/catch
 
   if (!ncol) {
-    strcpy(g->Message, "Invalid Srcdef");
+    snprintf(g->Message, sizeof(g->Message), "Invalid Srcdef");
     goto err;
     } // endif ncol
 
@@ -2122,7 +2122,7 @@ bool ODBConn::GetDataSources(PQRYRES qrp)
       } // endfor i
 
   } catch(DBX *x) {
-    sprintf(m_G->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(m_G->Message, sizeof(m_G->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     rv = true;
   } // end try/catch
 
@@ -2173,7 +2173,7 @@ bool ODBConn::GetDrivers(PQRYRES qrp)
       } // endfor n
 
   } catch(DBX *x) {
-    sprintf(m_G->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+    snprintf(m_G->Message, sizeof(m_G->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
     rv = true;
   } // end try/catch
 
@@ -2517,7 +2517,7 @@ PQRYRES ODBConn::AllocateResult(PGLOBAL g)
   PQRYRES      qrp;
 
   if (!m_Rows) {
-    strcpy(g->Message, "Void result");
+    snprintf(g->Message, sizeof(g->Message), "Void result");
     return NULL;
     } // endif m_Res
 
@@ -2596,7 +2596,7 @@ int ODBConn::Rewind(char *sql, ODBCCOL *tocols)
 
       rbuf = (int)crow;
     } catch(DBX *x) {
-      sprintf(m_G->Message, "%s: %s", x->m_Msg, x->GetErrorMessage(0));
+      snprintf(m_G->Message, sizeof(m_G->Message), "%s: %s", x->m_Msg, x->GetErrorMessage(0));
       rbuf = -1;
     } // end try/catch
 

--- a/storage/connect/osutil.c
+++ b/storage/connect/osutil.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "osutil.h"
+#include "m_string.h"
 
 #ifdef _WIN32
 my_bool CloseFileHandle(HANDLE h) 
@@ -140,25 +141,25 @@ char *_fullpath(char *absPath, const char *relPath, size_t maxLength)
   char *p;
 
   if ( *relPath == '\\' || *relPath == '/' ) {
-    strncpy(absPath, relPath, maxLength);
+    snprintf(absPath, maxLength, "%s", relPath);
   } else if (*relPath == '~') {
     // get the path to the home directory
     struct passwd *pw = getpwuid(getuid());
     const char    *homedir = pw->pw_dir;
 
     if (homedir)
-      strcat(strncpy(absPath, homedir, maxLength), relPath + 1);
+      snprintf(absPath, maxLength, "%s%s", homedir, relPath + 1);
     else
-      strncpy(absPath, relPath, maxLength);
+      snprintf(absPath, maxLength, "%s", relPath);
         
   } else {
     char buff[2*_MAX_PATH];
 
     p= getcwd(buff, _MAX_PATH);
     assert(p);
-    strcat(buff,"/");
-    strcat(buff, relPath);
-    strncpy(absPath, buff, maxLength);
+    safe_strcat(buff, sizeof(buff), "/");
+    safe_strcat(buff, sizeof(buff), relPath);
+    snprintf(absPath, maxLength, "%s", buff);
   }  /* endif's relPath */
 
   p = absPath;

--- a/storage/connect/plgdbutl.cpp
+++ b/storage/connect/plgdbutl.cpp
@@ -381,7 +381,7 @@ char *SetPath(PGLOBAL g, const char *path)
 			return NULL;
 
 		if (PlugIsAbsolutePath(path)) {
-			strcpy(buf, path);
+			snprintf(buf, len, "%s", path);
 			return buf;
 		} // endif path
 
@@ -391,9 +391,9 @@ char *SetPath(PGLOBAL g, const char *path)
 #else   // !_WIN32
 			const char *s = "/";
 #endif  // !_WIN32
-			strcat(strcat(strcat(strcpy(buf, "."), s), path), s);
+			snprintf(buf, len, ".%s%s%s", s, path, s);
 		} else
-			strcpy(buf, path);
+			snprintf(buf, len, "%s", path);
 
 	} // endif path
 

--- a/storage/connect/plugutil.cpp
+++ b/storage/connect/plugutil.cpp
@@ -74,6 +74,7 @@
 /***********************************************************************/
 #define STORAGE                     /* Initialize global variables     */
 
+#include "m_string.h"
 #include "osutil.h"
 #include "global.h"
 #include "plgdbsem.h"
@@ -329,14 +330,15 @@ LPCSTR PlugSetPath(LPSTR pBuff, LPCSTR prefix, LPCSTR FileName, LPCSTR defpath)
 
   switch (*direc) {
     case '\0':
-      strcpy(direc, defdir);
+      snprintf(direc, sizeof(direc), "%s", defdir);
       break;
     case '\\':
     case '/':
       break;
     default:
       // This supposes that defdir ends with a SLASH
-      strcpy(direc, strcat(defdir, direc));
+      safe_strcat(defdir, sizeof(defdir), direc);
+      snprintf(direc, sizeof(direc), "%s", defdir);
     } // endswitch
 
   _makepath(newname, drive, direc, fname, ftype);
@@ -607,7 +609,7 @@ char *PlugDup(PGLOBAL g, const char *str)
   if (str) {
     char *sm = (char*)PlugSubAlloc(g, NULL, strlen(str) + 1);
 
-    strcpy(sm, str);
+    snprintf(sm, strlen(str) + 1, "%s", str);
     return sm;
   } else
     return NULL;

--- a/storage/connect/tabjmg.cpp
+++ b/storage/connect/tabjmg.cpp
@@ -48,7 +48,7 @@ JMGDISC::JMGDISC(PGLOBAL g, int *lg) : MGODISC(g, lg)
 bool JMGDISC::Init(PGLOBAL g)
 {
 	if (!(Jcp = ((TDBJMG*)tmgp)->Jcp)) {
-		strcpy(g->Message, "Init: Jcp is NULL");
+		snprintf(g->Message, sizeof(g->Message), "Init: Jcp is NULL");
 		return true;
 	}	else if (Jcp->gmID(g, columnid, "ColumnDesc",
 		                  "(Ljava/lang/Object;I[II)Ljava/lang/Object;"))
@@ -86,7 +86,7 @@ bool JMGDISC::ColDesc(PGLOBAL g, jobject obj, char *pcn, char *pfmt,
 	jintArray val = Jcp->env->NewIntArray(5);
 
 	if (val == nullptr) {
-		strcpy(g->Message, "Cannot allocate jint array");
+		snprintf(g->Message, sizeof(g->Message), "Cannot allocate jint array");
 		return true;
 	} else if (!ncol)
 		n = Jcp->env->GetIntArrayElements(val, 0);
@@ -113,7 +113,7 @@ bool JMGDISC::ColDesc(PGLOBAL g, jobject obj, char *pcn, char *pfmt,
 			z = 65 - strlen(colname);
 			strncat(strncat(colname, "_", z), key, z - 1);
 		} else
-			strcpy(colname, key);
+			snprintf(colname, sizeof(colname), key);
 
 		if (pfmt) {
 			strncpy(fmt, pfmt, 128);
@@ -121,7 +121,7 @@ bool JMGDISC::ColDesc(PGLOBAL g, jobject obj, char *pcn, char *pfmt,
 			z = 129 - strlen(fmt);
 			strncat(strncat(fmt, ".", z), key, z - 1);
 		} else
-			strcpy(fmt, key);
+			snprintf(fmt, sizeof(fmt), key);
 
 		if (!jres) {
 			bcol.Type = n[0];
@@ -318,7 +318,7 @@ bool TDBJMG::OpenDB(PGLOBAL g)
 	/*  First opening.                                                   */
 	/*********************************************************************/
 	if (Pipe && Mode != MODE_READ) {
-		strcpy(g->Message, "Pipeline tables are read only");
+		snprintf(g->Message, sizeof(g->Message), "Pipeline tables are read only");
 		return true;
 	}	// endif Pipe
 
@@ -353,7 +353,7 @@ bool TDBJMG::OpenDB(PGLOBAL g)
 /***********************************************************************/
 bool TDBJMG::ReadKey(PGLOBAL g, OPVAL op, const key_range *kr)
 {
-	strcpy(g->Message, "MONGO tables are not indexable");
+	snprintf(g->Message, sizeof(g->Message), "MONGO tables are not indexable");
 	return true;
 } // end of ReadKey
 
@@ -601,7 +601,7 @@ bool JMGCOL::AddValue(PGLOBAL g, bson_t *doc, char *key, bool upd)
 	} // endswitch Buf_Type
 
 	if (!rc) {
-		strcpy(g->Message, "Adding value failed");
+		snprintf(g->Message, sizeof(g->Message), "Adding value failed");
 		return true;
 	} else
 		return false;

--- a/storage/connect/tabmysql.cpp
+++ b/storage/connect/tabmysql.cpp
@@ -112,7 +112,7 @@ bool MYSQLDEF::GetServerInfo(PGLOBAL g, const char *server_name)
 
   if (!server_name || !strlen(server_name)) {
     DBUG_PRINT("info", ("server_name not defined!"));
-    strcpy(g->Message, "server_name not defined!");
+    snprintf(g->Message, sizeof(g->Message), "server_name not defined!");
     DBUG_RETURN(true);
     } // endif server_name
 
@@ -121,7 +121,7 @@ bool MYSQLDEF::GetServerInfo(PGLOBAL g, const char *server_name)
   if (!(server= get_server_by_name(mem, server_name, &server_buffer))) {
     DBUG_PRINT("info", ("get_server_by_name returned > 0 error condition!"));
     /* need to come up with error handling */
-    strcpy(g->Message, "get_server_by_name returned > 0 error condition!");
+    snprintf(g->Message, sizeof(g->Message), "get_server_by_name returned > 0 error condition!");
     DBUG_RETURN(true);
     } // endif server
 
@@ -214,21 +214,21 @@ bool MYSQLDEF::ParseURL(PGLOBAL g, char *url, bool b)
     char *sport, *scheme = url;
 
     if (!(Username = strstr(url, "://"))) {
-      strcpy(g->Message, "Connection is not an URL");
+      snprintf(g->Message, sizeof(g->Message), "Connection is not an URL");
       return true;
       } // endif User
 
     scheme[Username - scheme] = 0;
 
     if (stricmp(scheme, "mysql")) {
-      strcpy(g->Message, "scheme must be mysql");
+      snprintf(g->Message, sizeof(g->Message), "scheme must be mysql");
       return true;
       } // endif scheme
 
     Username += 3;
 
     if (!(Hostname = (char*)strchr(Username, '@'))) {
-      strcpy(g->Message, "No host specified in URL");
+      snprintf(g->Message, sizeof(g->Message), "No host specified in URL");
       return true;
     } else {
       *Hostname++ = 0;                   // End Username
@@ -240,7 +240,7 @@ bool MYSQLDEF::ParseURL(PGLOBAL g, char *url, bool b)
 
       // Make sure there isn't an extra /
       if (strchr(pwd, '/')) {
-        strcpy(g->Message, "Syntax error in URL");
+        snprintf(g->Message, sizeof(g->Message), "Syntax error in URL");
         return true;
         } // endif
 
@@ -256,7 +256,7 @@ bool MYSQLDEF::ParseURL(PGLOBAL g, char *url, bool b)
 
     // Make sure there isn't an extra / or @ */
     if ((strchr(Username, '/')) || (strchr(Hostname, '@'))) {
-      strcpy(g->Message, "Syntax error in URL");
+      snprintf(g->Message, sizeof(g->Message), "Syntax error in URL");
       return true;
       } // endif
 
@@ -268,7 +268,7 @@ bool MYSQLDEF::ParseURL(PGLOBAL g, char *url, bool b)
 
         // Make sure there's not an extra /
         if ((strchr(tabn, '/'))) {
-          strcpy(g->Message, "Syntax error in URL");
+          snprintf(g->Message, sizeof(g->Message), "Syntax error in URL");
           return true;
           } // endif /
 
@@ -574,7 +574,7 @@ bool TDBMYSQL::MakeSelect(PGLOBAL g, bool mx)
     len += (mx ? 256 : 1);
 
   if (Query->IsTruncated() || Query->Resize(len)) {
-    strcpy(g->Message, "MakeSelect: Out of memory");
+    snprintf(g->Message, sizeof(g->Message), "MakeSelect: Out of memory");
     return true;
   } // endif Query
 
@@ -599,7 +599,7 @@ bool TDBMYSQL::MakeInsert(PGLOBAL g)
 
   if (Prep) {
 #if !defined(MYSQL_PREPARED_STATEMENTS)
-    strcpy(g->Message, "Prepared statements not used (not supported)");
+    snprintf(g->Message, sizeof(g->Message), "Prepared statements not used (not supported)");
     PushWarning(g, this);
     Prep = false;
 #endif  // !MYSQL_PREPARED_STATEMENTS 
@@ -607,7 +607,7 @@ bool TDBMYSQL::MakeInsert(PGLOBAL g)
 
   for (colp = Columns; colp; colp = colp->GetNext())
     if (colp->IsSpecial()) {
-      strcpy(g->Message, MSG(NO_SPEC_COL));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_SPEC_COL));
       return true;
     } else {
       len += (strlen(colp->GetName()) + 4);
@@ -664,7 +664,7 @@ bool TDBMYSQL::MakeInsert(PGLOBAL g)
 #endif  // MYSQL_PREPARED_STATEMENTS 
 
   if ((oom = Query->IsTruncated()))
-    strcpy(g->Message, "MakeInsert: Out of memory");
+    snprintf(g->Message, sizeof(g->Message), "MakeInsert: Out of memory");
 
   return oom;
   } // end of MakeInsert
@@ -706,7 +706,7 @@ bool TDBMYSQL::MakeCommand(PGLOBAL g)
       Query->Append(Qrystr + (p - qrystr) + strlen(name));
 
       if (Query->IsTruncated()) {
-        strcpy(g->Message, "MakeCommand: Out of memory");
+        snprintf(g->Message, sizeof(g->Message), "MakeCommand: Out of memory");
         return true;
       } else
         strlwr(strcpy(qrystr, Query->GetStr()));
@@ -742,7 +742,7 @@ int TDBMYSQL::MakeUpdate(PGLOBAL g)
                   && !stricmp(tab, Name))
     qc = (Quoted) ? "`" : "";
   else {
-    strcpy(g->Message, "Cannot use this UPDATE command");
+    snprintf(g->Message, sizeof(g->Message), "Cannot use this UPDATE command");
     return RC_FX;
   } // endif sscanf
 
@@ -769,7 +769,7 @@ int TDBMYSQL::MakeDelete(PGLOBAL g)
   else if (sscanf(Qrystr, "%s %s %s%511c", cmd, from, tab, end) > 2)
     qc = (Quoted) ? "`" : "";
   else {
-    strcpy(g->Message, "Cannot use this DELETE command");
+    snprintf(g->Message, sizeof(g->Message), "Cannot use this DELETE command");
     return RC_FX;
   } // endif sscanf
 
@@ -934,7 +934,7 @@ bool TDBMYSQL::OpenDB(PGLOBAL g)
 
   } else if (Mode == MODE_INSERT) {
     if (Srcdef) {
-      strcpy(g->Message, "No insert into anonym views");
+      snprintf(g->Message, sizeof(g->Message), "No insert into anonym views");
       Myc.Close();
       return true;
       } // endif Srcdef
@@ -946,7 +946,7 @@ bool TDBMYSQL::OpenDB(PGLOBAL g)
 
       if (Nparm != n) {
         if (n >= 0)          // Other errors return negative values
-          strcpy(g->Message, MSG(BAD_PARM_COUNT));
+          snprintf(g->Message, sizeof(g->Message), MSG(BAD_PARM_COUNT));
 
       } else
 #endif   // MYSQL_PREPARED_STATEMENTS
@@ -1109,7 +1109,7 @@ bool TDBMYSQL::ReadKey(PGLOBAL g, OPVAL op, const key_range *kr)
 
 			if (To_CondFil)
 				if (Query->Append(" AND ") || Query->Append(To_CondFil->Body)) {
-				  strcpy(g->Message, "Readkey: Out of memory");
+				  snprintf(g->Message, sizeof(g->Message), "Readkey: Out of memory");
 					return true;
 					} // endif Append
 
@@ -1184,7 +1184,7 @@ int TDBMYSQL::WriteDB(PGLOBAL g)
     } // endfor colp
 
   if (unlikely(Query->IsTruncated())) {
-    strcpy(g->Message, "WriteDB: Out of memory");
+    snprintf(g->Message, sizeof(g->Message), "WriteDB: Out of memory");
     rc = RC_FX;
   } else {
     Query->RepLast(')');
@@ -1530,13 +1530,13 @@ PCMD TDBMYEXC::MakeCMD(PGLOBAL g)
           (To_CondFil->Op == OP_EQ || To_CondFil->Op == OP_IN)) {
         xcmd = To_CondFil->Cmds;
       } else
-        strcpy(g->Message, "Invalid command specification filter");
+        snprintf(g->Message, sizeof(g->Message), "Invalid command specification filter");
 
     } else
-      strcpy(g->Message, "No command column in select list");
+      snprintf(g->Message, sizeof(g->Message), "No command column in select list");
 
   } else if (!Srcdef)
-    strcpy(g->Message, "No Srcdef default command");
+    snprintf(g->Message, sizeof(g->Message), "No Srcdef default command");
   else
     xcmd = new(g) CMD(g, Srcdef);
 
@@ -1561,7 +1561,7 @@ int TDBMYEXC::GetMaxSize(PGLOBAL)
 bool TDBMYEXC::OpenDB(PGLOBAL g)
   {
   if (Use == USE_OPEN) {
-    strcpy(g->Message, "Multiple execution is not allowed");
+    snprintf(g->Message, sizeof(g->Message), "Multiple execution is not allowed");
     return true;
     } // endif use
 
@@ -1579,7 +1579,7 @@ bool TDBMYEXC::OpenDB(PGLOBAL g)
   Use = USE_OPEN;       // Do it now in case we are recursively called
 
   if (Mode != MODE_READ && Mode != MODE_READX) {
-    strcpy(g->Message, "No INSERT/DELETE/UPDATE of MYSQL EXEC tables");
+    snprintf(g->Message, sizeof(g->Message), "No INSERT/DELETE/UPDATE of MYSQL EXEC tables");
     return true;
     } // endif Mode
 
@@ -1626,11 +1626,11 @@ int TDBMYEXC::ReadDB(PGLOBAL g)
       switch (rc = Myc.ExecSQLcmd(g, Query->GetStr(), &Warnings)) {
         case RC_NF:
           AftRows = Myc.m_Afrw;
-          strcpy(g->Message, "Affected rows");
+          snprintf(g->Message, sizeof(g->Message), "Affected rows");
           break;
         case RC_OK:
           AftRows = Myc.m_Fields;
-          strcpy(g->Message, "Result set columns");
+          snprintf(g->Message, sizeof(g->Message), "Result set columns");
           break;
         case RC_FX:
           AftRows = Myc.m_Afrw;
@@ -1660,7 +1660,7 @@ int TDBMYEXC::ReadDB(PGLOBAL g)
 /***********************************************************************/
 int TDBMYEXC::WriteDB(PGLOBAL g)
   {
-  strcpy(g->Message, "EXEC MYSQL tables are read only");
+  snprintf(g->Message, sizeof(g->Message), "EXEC MYSQL tables are read only");
   return RC_FX;
   } // end of WriteDB
 

--- a/storage/connect/tabpivot.cpp
+++ b/storage/connect/tabpivot.cpp
@@ -120,7 +120,7 @@ PQRYRES PIVAID::MakePivotColumns(PGLOBAL g)
 			uint n = strlen(Skcol);
 
 			skc = (char*)PlugSubAlloc(g, NULL, n + 2);
-			strcpy(skc, Skcol);
+			snprintf(skc, n + 2, "%s", Skcol);
 			skc[n + 1] = 0;
 
 			// Replace ; by nulls in skc
@@ -133,9 +133,9 @@ PQRYRES PIVAID::MakePivotColumns(PGLOBAL g)
 		if (!Tabsrc && Tabname) {
 			// Locate the  query
 			query = (char*)PlugSubAlloc(g, NULL, strlen(Tabname) + 26);
-			sprintf(query, "SELECT * FROM `%s` LIMIT 1", Tabname);
+			snprintf(query, strlen(Tabname) + 26, "SELECT * FROM `%s` LIMIT 1", Tabname);
 		} else if (!Tabsrc) {
-			strcpy(g->Message, MSG(SRC_TABLE_UNDEF));
+			snprintf(g->Message, sizeof(g->Message), MSG(SRC_TABLE_UNDEF));
 			goto err;
 		} else
 			query = (char*)Tabsrc;
@@ -167,7 +167,7 @@ PQRYRES PIVAID::MakePivotColumns(PGLOBAL g)
 					Fncol = crp->Name;
 
 			if (!Fncol) {
-				strcpy(g->Message, MSG(NO_DEF_FNCCOL));
+				snprintf(g->Message, sizeof(g->Message), MSG(NO_DEF_FNCCOL));
 				goto err;
 			} // endif Fncol
 
@@ -180,7 +180,7 @@ PQRYRES PIVAID::MakePivotColumns(PGLOBAL g)
 					Picol = crp->Name;
 
 			if (!Picol) {
-				strcpy(g->Message, MSG(NO_DEF_PIVOTCOL));
+				snprintf(g->Message, sizeof(g->Message),  MSG(NO_DEF_PIVOTCOL));
 				goto err;
 			} // endif Picol
 
@@ -206,10 +206,10 @@ PQRYRES PIVAID::MakePivotColumns(PGLOBAL g)
 				pcrp = &crp->Next;
 
 		if (!Rblkp) {
-			strcpy(g->Message, MSG(NO_DEF_PIVOTCOL));
+			snprintf(g->Message, sizeof(g->Message), MSG(NO_DEF_PIVOTCOL));
 			goto err;
 		} else if (!fncrp) {
-			strcpy(g->Message, MSG(NO_DEF_FNCCOL));
+			snprintf(g->Message, sizeof(g->Message), MSG(NO_DEF_FNCCOL));
 			goto err;
 		} // endif
 
@@ -302,7 +302,7 @@ PQRYRES PIVAID::MakePivotColumns(PGLOBAL g)
 		if (trace(1))
 			htrc("Exception %d: %s\n", n, g->Message);
 	} catch (const char *msg) {
-		strcpy(g->Message, msg);
+		snprintf(g->Message, sizeof(g->Message), "%s", msg);
 	} // end catch
 
 err:
@@ -443,7 +443,7 @@ bool TDBPIVOT::FindDefaultColumns(PGLOBAL g)
         Fncol = cdp->GetName();
   
     if (!Fncol) {
-      strcpy(g->Message, MSG(NO_DEF_FNCCOL));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_DEF_FNCCOL));
       return true;
       } // endif Fncol
   
@@ -456,7 +456,7 @@ bool TDBPIVOT::FindDefaultColumns(PGLOBAL g)
         Picol = cdp->GetName();
   
     if (!Picol) {
-      strcpy(g->Message, MSG(NO_DEF_PIVOTCOL));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_DEF_PIVOTCOL));
       return true;
       } // endif Picol
   
@@ -519,7 +519,7 @@ bool TDBPIVOT::GetSourceTable(PGLOBAL g)
       } // endif !GBdone
 
   } else if (!Tabsrc) {
-    strcpy(g->Message, MSG(SRC_TABLE_UNDEF));
+    snprintf(g->Message, sizeof(g->Message), MSG(SRC_TABLE_UNDEF));
     return true;
   } // endif
 
@@ -588,18 +588,18 @@ bool TDBPIVOT::MakeViewColumns(PGLOBAL g)
     PTDBMY tdbp;
 
     if (Tdbp->GetAmType() != TYPE_AM_MYSQL) {
-      strcpy(g->Message, "View is not MySQL");
+      snprintf(g->Message, sizeof(g->Message),"View is not MySQL");
       return true;
     } else
       tdbp = (PTDBMY)Tdbp;
 
     if (!Fncol && !(Fncol = tdbp->FindFieldColumn(Picol))) {
-      strcpy(g->Message, MSG(NO_DEF_FNCCOL));
+      snprintf(g->Message, sizeof(g->Message),  MSG(NO_DEF_FNCCOL));
       return true;
       } // endif Fncol
 
     if (!Picol && !(Picol = tdbp->FindFieldColumn(Fncol))) {
-      strcpy(g->Message, MSG(NO_DEF_PIVOTCOL));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_DEF_PIVOTCOL));
       return true;
       } // endif Picol
 
@@ -679,7 +679,7 @@ bool TDBPIVOT::OpenDB(PGLOBAL g)
     /*******************************************************************/
     /* Direct access of PIVOT tables is not implemented yet.           */
     /*******************************************************************/
-    strcpy(g->Message, MSG(NO_PIV_DIR_ACC));
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_PIV_DIR_ACC));
     return TRUE;
     } // endif To_Key_Col
 
@@ -780,7 +780,7 @@ int TDBPIVOT::ReadDB(PGLOBAL g)
 
     if (!colp && !(colp = Dcolp)) {
       if (!Accept) {
-        strcpy(g->Message, MSG(NO_MATCH_COL));
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_MATCH_COL));
         return RC_FX;
       } else
         continue;

--- a/storage/connect/tabsys.cpp
+++ b/storage/connect/tabsys.cpp
@@ -84,7 +84,7 @@ bool INIDEF::DefineAM(PGLOBAL g, LPCSTR, int)
     PlugSetPath(p, Fn, GetPath());
     Fn = p;
   } else {
-    strcpy(g->Message, MSG(MISSING_FNAME));
+    snprintf(g->Message, sizeof(g->Message), MSG(MISSING_FNAME));
     return true;
   } // endif Fn
 
@@ -326,7 +326,7 @@ int TDBINI::DeleteDB(PGLOBAL g, int irc)
       break;
     default:
       if (!Section) {
-        strcpy(g->Message, MSG(NO_SECTION_NAME));
+        snprintf(g->Message, sizeof(g->Message), MSG(NO_SECTION_NAME));
         return RC_FX;
       } else
         if (!WritePrivateProfileString(Section, NULL, NULL, Ifile)) {
@@ -514,7 +514,7 @@ void INICOL::WriteColumn(PGLOBAL g)
 		throw 31;
 	} else if (Flag == 1) {
     if (tdbp->Mode == MODE_UPDATE) {
-      strcpy(g->Message, MSG(NO_SEC_UPDATE));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_SEC_UPDATE));
 			throw 31;
 		} else if (*p) {
       tdbp->Section = p;
@@ -523,7 +523,7 @@ void INICOL::WriteColumn(PGLOBAL g)
 
     return;
   } else if (!tdbp->Section) {
-    strcpy(g->Message, MSG(SEC_NAME_FIRST));
+    snprintf(g->Message, sizeof(g->Message), MSG(SEC_NAME_FIRST));
 		throw 31;
 	} // endif's
 
@@ -752,7 +752,7 @@ int TDBXIN::DeleteDB(PGLOBAL g, int irc)
         } // endif
 
   } else if (!Section) {
-    strcpy(g->Message, MSG(NO_SECTION_NAME));
+    snprintf(g->Message, sizeof(g->Message), MSG(NO_SECTION_NAME));
     return RC_FX;
   } else
     if (!WritePrivateProfileString(Section, Keycur, NULL, Ifile)) {
@@ -840,7 +840,7 @@ void XINCOL::WriteColumn(PGLOBAL g)
 		throw 31;
 	} else if (Flag == 1) {
     if (tdbp->Mode == MODE_UPDATE) {
-      strcpy(g->Message, MSG(NO_SEC_UPDATE));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_SEC_UPDATE));
 			throw 31;
 		} else if (*p) {
       tdbp->Section = p;
@@ -850,7 +850,7 @@ void XINCOL::WriteColumn(PGLOBAL g)
     return;
   } else if (Flag == 2) {
     if (tdbp->Mode == MODE_UPDATE) {
-      strcpy(g->Message, MSG(NO_KEY_UPDATE));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_KEY_UPDATE));
 			throw 31;
 		} else if (*p) {
       tdbp->Keycur = p;
@@ -859,7 +859,7 @@ void XINCOL::WriteColumn(PGLOBAL g)
 
     return;
   } else if (!tdbp->Section || !tdbp->Keycur) {
-    strcpy(g->Message, MSG(SEC_KEY_FIRST));
+    snprintf(g->Message, sizeof(g->Message), MSG(SEC_KEY_FIRST));
 		throw 31;
 	} // endif's
 

--- a/storage/connect/tabxml.cpp
+++ b/storage/connect/tabxml.cpp
@@ -140,7 +140,7 @@ PQRYRES XMLColumns(PGLOBAL g, char *db, char *tab, PTOS topt, bool info)
     } // endif info
 
 	if (GetIntegerTableOption(g, topt, "Multiple", 0)) {
-		strcpy(g->Message, "Cannot find column definition for multiple table");
+		snprintf(g->Message, sizeof(g->Message), "Cannot find column definition for multiple table");
 		return NULL;
 	}	// endif Multiple
 
@@ -152,7 +152,7 @@ PQRYRES XMLColumns(PGLOBAL g, char *db, char *tab, PTOS topt, bool info)
       fn = GetStringTableOption(g, topt, "Subtype", NULL);
     
     if (!fn) {
-      strcpy(g->Message, MSG(MISSING_FNAME));
+      snprintf(g->Message, sizeof(g->Message), MSG(MISSING_FNAME));
       return NULL;
     } else
       topt->subtype = NULL;
@@ -483,12 +483,12 @@ bool XMLDEF::DefineAM(PGLOBAL g, LPCSTR am, int poff)
   Encoding = GetStringCatInfo(g, "Encoding", "UTF-8");
 
   if (*Fn == '?') {
-    strcpy(g->Message, MSG(MISSING_FNAME));
+    snprintf(g->Message, sizeof(g->Message), MSG(MISSING_FNAME));
     return true;
     } // endif fn
 
   if ((signed)GetIntCatInfo("Flag", -1) != -1) {
-    strcpy(g->Message, MSG(DEPREC_FLAG));
+    snprintf(g->Message, sizeof(g->Message), MSG(DEPREC_FLAG));
     return true;
     } // endif flag
 
@@ -567,7 +567,7 @@ PTDB XMLDEF::GetTable(PGLOBAL g, MODE m)
     return new(g) TDBXCT(this);
 
 	if (Zipped && !(m == MODE_READ || m == MODE_ANY)) {
-		strcpy(g->Message, "ZIpped XML tables are read only");
+		snprintf(g->Message, sizeof(g->Message), "ZIpped XML tables are read only");
 		return NULL;
 	}	// endif Zipped
 
@@ -857,16 +857,16 @@ bool TDBXML::Initialize(PGLOBAL g)
 			// Get root node
 			if (!(Root = Docp->GetRoot(g))) {
 				// This should never happen as load should have failed
-				strcpy(g->Message, MSG(EMPTY_DOC));
+				snprintf(g->Message, sizeof(g->Message), MSG(EMPTY_DOC));
 				goto error;
 			} // endif Root
 
 		// If tabname is not an Xpath,
 		// construct one that will find it anywhere
 			if (!strchr(Tabname, '/'))
-				strcat(strcpy(tabpath, "//"), Tabname);
+				snprintf(tabpath, sizeof(tabpath), "//%s", Tabname);
 			else
-				strcpy(tabpath, Tabname);
+				snprintf(tabpath, sizeof(tabpath), "%s", Tabname);
 
 			// Evaluate table xpath
 			if ((TabNode = Root->SelectSingleNode(g, tabpath))) {
@@ -911,7 +911,7 @@ bool TDBXML::Initialize(PGLOBAL g)
 
 				// Create the XML node
 				if (Docp->NewDoc(g, "1.0")) {
-					strcpy(g->Message, MSG(NEW_DOC_FAILED));
+					snprintf(g->Message, sizeof(g->Message), MSG(NEW_DOC_FAILED));
 					goto error;
 				} // endif NewDoc
 
@@ -919,7 +919,7 @@ bool TDBXML::Initialize(PGLOBAL g)
 				To_Xb = Docp->LinkXblock(g, Mode, rc, filename);
 
 				// Add a CONNECT comment node
-				strcpy(buf, " Created by the MariaDB CONNECT Storage Engine");
+				snprintf(buf, sizeof(buf), " Created by the MariaDB CONNECT Storage Engine");
 				Docp->AddComment(g, buf);
 
 				if (XmlDB) {
@@ -932,7 +932,7 @@ bool TDBXML::Initialize(PGLOBAL g)
 					TabNode = Root = Docp->NewRoot(g, Tabname);
 
 				if (TabNode == NULL || Root == NULL) {
-					strcpy(g->Message, MSG(XML_INIT_ERROR));
+					snprintf(g->Message, sizeof(g->Message), MSG(XML_INIT_ERROR));
 					goto error;
 				} else if (SetTabNode(g))
 					goto error;
@@ -992,7 +992,7 @@ bool TDBXML::Initialize(PGLOBAL g)
 #if !defined(UNIX)
   } catch(...) {
     // Other errors
-    strcpy(g->Message, MSG(XMLTAB_INIT_ERR));
+    snprintf(g->Message, sizeof(g->Message), MSG(XMLTAB_INIT_ERR));
     goto error;
 #endif
   } // end of try-catches
@@ -1037,7 +1037,7 @@ bool TDBXML::SetTabNode(PGLOBAL g)
       TabNode->AddText(g, "\n\t");
       rn = TabNode->AddChildNode(g, Rowname, NULL);
     } else {
-      strcpy(g->Message, MSG(NO_ROW_NODE));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_ROW_NODE));
       return true;
     } // endif Rowname
 
@@ -1293,7 +1293,7 @@ bool TDBXML::CheckRow(PGLOBAL g, bool b)
       TabNode->AddText(g, "\n\t");
       RowNode = TabNode->AddChildNode(g, Rowname, RowNode);
     } else {
-      strcpy(g->Message, MSG(NO_ROW_NODE));
+      snprintf(g->Message, sizeof(g->Message), MSG(NO_ROW_NODE));
       return true;
     } // endif Rowname
   }
@@ -1550,7 +1550,7 @@ bool XMLCOL::ParseXpath(PGLOBAL g, bool mode)
       if (Tdbp->Mulnode && !strncmp(p, Tdbp->Mulnode, p2 - p))
       {
         if (!Tdbp->Xpand && mode) {
-          strcpy(g->Message, MSG(CONCAT_SUBNODE));
+          snprintf(g->Message, sizeof(g->Message), MSG(CONCAT_SUBNODE));
           return true;
         } else
           Inod = i;                  // Index of multiple node
@@ -1843,7 +1843,7 @@ void XMLCOL::WriteColumn(PGLOBAL g)
       } // endfor k
 
     if (ColNode == NULL) {
-      strcpy(g->Message, MSG(COL_ALLOC_ERR));
+      snprintf(g->Message, sizeof(g->Message), MSG(COL_ALLOC_ERR));
 			throw (int)TYPE_AM_XML;
 		} // endif ColNode
 
@@ -1862,7 +1862,7 @@ void XMLCOL::WriteColumn(PGLOBAL g)
       AttNode = ColNode->AddProperty(g, Xname, Vxap);
 
   if (ValNode == NULL && AttNode == NULL) {
-    strcpy(g->Message, MSG(VAL_ALLOC_ERR));
+    snprintf(g->Message, sizeof(g->Message), MSG(VAL_ALLOC_ERR));
     throw (int)TYPE_AM_XML;
     } // endif ValNode
 
@@ -2104,7 +2104,7 @@ void XMULCOL::WriteColumn(PGLOBAL g)
       } // endfor k
 
     if (ColNode == NULL) {
-      strcpy(g->Message, MSG(COL_ALLOC_ERR));
+      snprintf(g->Message, sizeof(g->Message), MSG(COL_ALLOC_ERR));
 			throw (int)TYPE_AM_XML;
 		} // endif ColNode
 
@@ -2123,7 +2123,7 @@ void XMULCOL::WriteColumn(PGLOBAL g)
       AttNode = ColNode->AddProperty(g, Xname, Vxap);
 
   if (ValNode == NULL && AttNode == NULL) {
-    strcpy(g->Message, MSG(VAL_ALLOC_ERR));
+    snprintf(g->Message, sizeof(g->Message), MSG(VAL_ALLOC_ERR));
 		throw (int)TYPE_AM_XML;
 	} // endif ValNode
 
@@ -2165,7 +2165,7 @@ void XPOSCOL::ReadColumn(PGLOBAL g)
     return;                         // Same row than the last read
 
   if (Tdbp->Clist == NULL) {
-    strcpy(g->Message, MSG(MIS_TAG_LIST));
+    snprintf(g->Message, sizeof(g->Message), MSG(MIS_TAG_LIST));
 		throw (int)TYPE_AM_XML;
 	} // endif Clist
 
@@ -2235,7 +2235,7 @@ void XPOSCOL::WriteColumn(PGLOBAL g)
   /*  Find the column and value nodes to update or insert.             */
   /*********************************************************************/
   if (Tdbp->Clist == NULL) {
-    strcpy(g->Message, MSG(MIS_TAG_LIST));
+    snprintf(g->Message, sizeof(g->Message), MSG(MIS_TAG_LIST));
 		throw (int)TYPE_AM_XML;
 	} // endif Clist
 

--- a/storage/connect/value.cpp
+++ b/storage/connect/value.cpp
@@ -59,7 +59,7 @@
 #if defined(_DEBUG)
 #define CheckType(V)    if (Type != V->GetType()) { \
     PGLOBAL& g = Global; \
-    strcpy(g->Message, MSG(VALTYPE_NOMATCH)); \
+    snprintf(g->Message, sizeof(g->Message), MSG(VALTYPE_NOMATCH)); \
     throw Type;
 #else
 #define CheckType(V)
@@ -556,7 +556,7 @@ BYTE VALUE::TestValue(PVAL vp)
 /***********************************************************************/
 bool VALUE::Compute(PGLOBAL g, PVAL *, int, OPVAL)
 {
-  strcpy(g->Message, "Compute not implemented for this value type");
+  snprintf(g->Message, sizeof(g->Message), "Compute not implemented for this value type");
   return true;
 } // end of Compute
 
@@ -1051,11 +1051,11 @@ TYPE TYPVAL<TYPE>::SafeAdd(TYPE n1, TYPE n2)
 
   if ((n2 > 0) && (n < n1)) {
     // Overflow
-    strcpy(g->Message, MSG(FIX_OVFLW_ADD));
+    snprintf(g->Message, sizeof(g->Message), MSG(FIX_OVFLW_ADD));
 		throw 138;
 	} else if ((n2 < 0) && (n > n1)) {
     // Underflow
-    strcpy(g->Message, MSG(FIX_UNFLW_ADD));
+    snprintf(g->Message, sizeof(g->Message), MSG(FIX_UNFLW_ADD));
 		throw 138;
 	} // endif's n2
 
@@ -1079,11 +1079,11 @@ TYPE TYPVAL<TYPE>::SafeMult(TYPE n1, TYPE n2)
 
   if (n > MinMaxVal(true)) {
     // Overflow
-    strcpy(g->Message, MSG(FIX_OVFLW_TIMES));
+    snprintf(g->Message, sizeof(g->Message), MSG(FIX_OVFLW_TIMES));
 		throw 138;
 	} else if (n < MinMaxVal(false)) {
     // Underflow
-    strcpy(g->Message, MSG(FIX_UNFLW_TIMES));
+    snprintf(g->Message, sizeof(g->Message), MSG(FIX_UNFLW_TIMES));
 		throw 138;
 	} // endif's n2
 
@@ -1119,7 +1119,7 @@ bool TYPVAL<TYPE>::Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op)
       break;
     case OP_DIV:
       if (!val[1]) {
-        strcpy(g->Message, MSG(ZERO_DIVIDE));
+        snprintf(g->Message, sizeof(g->Message),MSG(ZERO_DIVIDE));
         return true;
         } // endif
 
@@ -1173,7 +1173,7 @@ bool TYPVAL<TYPE>::Compall(PGLOBAL g, PVAL *vp, int np, OPVAL op)
     case OP_DIV:
       if (val[0]) {
         if (!val[1]) {
-          strcpy(g->Message, MSG(ZERO_DIVIDE));
+          snprintf(g->Message, sizeof(g->Message), MSG(ZERO_DIVIDE));
           return true;
           } // endif
     
@@ -1190,7 +1190,7 @@ bool TYPVAL<TYPE>::Compall(PGLOBAL g, PVAL *vp, int np, OPVAL op)
       break;
     default:
 //    snprintf(g->Message, sizeof(g->Message), MSG(BAD_EXP_OPER), op);
-      strcpy(g->Message, "Function not supported");
+      snprintf(g->Message, sizeof(g->Message), "Function not supported");
       return true;
   } // endswitch op
 
@@ -1701,7 +1701,7 @@ bool TYPVAL<PSZ>::Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op)
 			break;
 		default:
 			//    snprintf(g->Message, sizeof(g->Message), MSG(BAD_EXP_OPER), op);
-			strcpy(g->Message, "Function not supported");
+			snprintf(g->Message, sizeof(g->Message), "Function not supported");
 			return true;
 	} // endswitch op
 
@@ -2616,7 +2616,7 @@ bool DTVAL::MakeDate(PGLOBAL g, int *val, int nval)
   if (MakeTime(&datm))
   {
     if (g) {
-      strcpy(g->Message, MSG(BAD_DATETIME));
+      snprintf(g->Message, sizeof(g->Message), MSG(BAD_DATETIME));
       rc = true;
     } else
       Tval = 0;

--- a/storage/connect/xindex.cpp
+++ b/storage/connect/xindex.cpp
@@ -45,6 +45,7 @@
 //nclude "array.h"
 #include "filamtxt.h"
 #include "tabdos.h"
+#include "m_string.h"
 #if defined(VCT_SUPPORT)
 #include "tabvct.h"
 #endif   // VCT_SUPPORT
@@ -857,7 +858,8 @@ bool XINDEX::SaveIndex(PGLOBAL g, PIXDEF sxp)
     char fname[_MAX_FNAME];
 
     _splitpath(defp->GetOfn(), drive, direc, fname, NULL);
-    strcat(strcat(fname, "_"), Xdp->GetName());
+    safe_strcat(fname, sizeof(fname), "_");
+    safe_strcat(fname, sizeof(fname), Xdp->GetName());
     _makepath(fn, drive, direc, fname, ftype);
     sxp = NULL;
   } else {
@@ -1011,7 +1013,8 @@ bool XINDEX::Init(PGLOBAL g)
     char fname[_MAX_FNAME];
 
     _splitpath(defp->GetOfn(), drive, direc, fname, NULL);
-    strcat(strcat(fname, "_"), Xdp->GetName());
+    safe_strcat(fname, sizeof(fname), "_");
+    safe_strcat(fname, sizeof(fname), Xdp->GetName());
     _makepath(fn, drive, direc, fname, ftype);
   } else {
     id = ID;
@@ -1265,7 +1268,8 @@ bool XINDEX::MapInit(PGLOBAL g)
     char fname[_MAX_FNAME];
 
     _splitpath(defp->GetOfn(), drive, direc, fname, NULL);
-    strcat(strcat(fname, "_"), Xdp->GetName());
+    safe_strcat(fname, sizeof(fname), "_");
+    safe_strcat(fname, sizeof(fname), Xdp->GetName());
     _makepath(fn, drive, direc, fname, ftype);
   } else {
     id = ID;
@@ -1480,7 +1484,8 @@ bool XINDEX::GetAllSizes(PGLOBAL g,/* int &ndif,*/ int &numk)
     char fname[_MAX_FNAME];
 
     _splitpath(defp->GetOfn(), drive, direc, fname, NULL);
-    strcat(strcat(fname, "_"), Xdp->GetName());
+    safe_strcat(fname, sizeof(fname), "_");
+    safe_strcat(fname, sizeof(fname), Xdp->GetName());
     _makepath(fn, drive, direc, fname, ftype);
   } else {
     id = ID;


### PR DESCRIPTION
## Description

Old style C functions `strcpy()`, `strcat()` and `sprintf()` are vulnerable to
security issues due to lacking memory boundary checks. Replace these in the
Connect storage engine with safe new and/or custom functions such as
`snprintf()` `safe_strcpy()` and `safe_strcat()`.

With this change FlawFinder and other static security analyzers report 287 fewer
findings.

## How can this PR be tested?

The FlawFinder log before changes:

```
$ cat flawfinder-all-vulnerabilities.html | grep "Hits ="
Hits = 14955
```
After the changes:
```
$ cat flawfinder-all-vulnerabilities.html | grep "Hits ="
Hits = 14668
```

Additionally all CI passes for this change.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility

The changes are fully backward compatible.