### PR TITLE
rocksdb: Define _GNU_SOURCE during fallocate CMake probe

### DIFF
--- a/storage/rocksdb/build_rocksdb.cmake
+++ b/storage/rocksdb/build_rocksdb.cmake
@@ -134,8 +134,8 @@ option(WITH_FALLOCATE "build with fallocate" ON)
 if(WITH_FALLOCATE AND UNIX)
   include(CheckCSourceCompiles)
   CHECK_C_SOURCE_COMPILES("
+#define _GNU_SOURCE
 #include <fcntl.h>
-#include <linux/falloc.h>
 int main() {
  int fd = open(\"/dev/null\", 0);
  fallocate(fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, 0, 1024);


### PR DESCRIPTION
The glibc headers declare fallocate only if _GNU_SOURCE is defined. Without this change, the probe fails with C compilers which do not support implicit function declarations even if the system does in fact support the fallocate function.

Upstream rocksdb does not need this because the probe is run with the C++ compiler, and current g++ versions define _GNU_SOURCE automatically.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
