### PR TITLE
MDEV-31042: Fixing table corruption after incremental backup restore in TSE enabled databases

### DIFF
--- a/mysql-test/suite/mariabackup/MDEV-31042_1.opt
+++ b/mysql-test/suite/mariabackup/MDEV-31042_1.opt
@@ -1,0 +1,7 @@
+--innodb-encryption-rotate-key-age=2
+--innodb_encrypt_tables=ON
+--innodb-encryption-threads=4
+--innodb-tablespaces-encryption
+--plugin-load-add=$FILE_KEY_MANAGEMENT_SO
+--loose-file-key-management
+--loose-file-key-management-filename=$MYSQL_TEST_DIR/std_data/logkey.txt

--- a/mysql-test/suite/mariabackup/MDEV-31042_1.result
+++ b/mysql-test/suite/mariabackup/MDEV-31042_1.result
@@ -1,0 +1,23 @@
+CREATE TABLE t1 (
+`word` int(11) NOT NULL DEFAULT 0,
+`document_number` int(11) NOT NULL DEFAULT 0,
+`total_weight` int(11) DEFAULT NULL,
+`positions` mediumtext DEFAULT NULL,
+PRIMARY KEY (`word`,`document_number`),
+KEY `h685533653_index_ts_c_docume` (`document_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 encrypted=yes;
+# Create full backup , modify table, then create incremental/differential backup
+CREATE TABLE tmp_u1332929658s LIKE t1;
+ALTER TABLE tmp_u1332929658s ADD `u_other_end_port` VARCHAR(40);
+RENAME TABLE t1 TO z_tmp_u1332929658s, tmp_u1332929658s TO t1;
+# shutdown server
+# remove datadir
+# xtrabackup move back
+# restart server
+create database ztest;
+RENAME TABLE test.z_tmp_u1332929658s TO ztest.z_tmp_u1332929658s;
+select count(*) from ztest.z_tmp_u1332929658s;
+count(*)
+0
+drop table t1;
+drop database ztest;

--- a/mysql-test/suite/mariabackup/MDEV-31042_1.test
+++ b/mysql-test/suite/mariabackup/MDEV-31042_1.test
@@ -1,6 +1,7 @@
 # First online alter on an empty table, then optimize table on the same table while incremental backup is going.
 
 --source include/have_file_key_management.inc
+--source include/have_debug.inc
 
 let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
 let $incremental_dir=$MYSQLTEST_VARDIR/tmp/backup_inc1;

--- a/mysql-test/suite/mariabackup/MDEV-31042_1.test
+++ b/mysql-test/suite/mariabackup/MDEV-31042_1.test
@@ -1,0 +1,52 @@
+# First online alter on an empty table, then optimize table on the same table while incremental backup is going.
+
+--source include/have_file_key_management.inc
+
+let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
+let $incremental_dir=$MYSQLTEST_VARDIR/tmp/backup_inc1;
+
+# create an empty table
+CREATE TABLE t1 (
+  `word` int(11) NOT NULL DEFAULT 0,
+  `document_number` int(11) NOT NULL DEFAULT 0,
+  `total_weight` int(11) DEFAULT NULL,
+  `positions` mediumtext DEFAULT NULL,
+  PRIMARY KEY (`word`,`document_number`),
+  KEY `h685533653_index_ts_c_docume` (`document_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 encrypted=yes;
+
+
+echo # Create full backup , modify table, then create incremental/differential backup;
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$basedir;
+--enable_result_log
+
+#online alter ...
+CREATE TABLE tmp_u1332929658s LIKE t1;
+ALTER TABLE tmp_u1332929658s ADD `u_other_end_port` VARCHAR(40);
+RENAME TABLE t1 TO z_tmp_u1332929658s, tmp_u1332929658s TO t1;
+
+# Execute optimize table on t1 while the backup is in-progress, so that it creates a t1.new file
+--let after_copy_test_t1=optimize table test.t1;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$incremental_dir --incremental-basedir=$basedir --dbug=+d,mariabackup_events;
+
+#--disable_result_log
+#echo # Prepare full backup, apply incremental one;
+exec $XTRABACKUP --apply-log-only --prepare --target-dir=$basedir;
+exec $XTRABACKUP --prepare --target-dir=$basedir --incremental-dir=$incremental_dir ;
+
+#echo # Restore and check results;
+let $targetdir=$basedir;
+--source include/restart_and_restore.inc
+--enable_result_log
+
+create database ztest;
+RENAME TABLE test.z_tmp_u1332929658s TO ztest.z_tmp_u1332929658s;
+select count(*) from ztest.z_tmp_u1332929658s;
+
+#Cleanup ...
+drop table t1;
+drop database ztest;
+
+rmdir $basedir;
+rmdir $incremental_dir;

--- a/mysql-test/suite/mariabackup/MDEV-31042_2.opt
+++ b/mysql-test/suite/mariabackup/MDEV-31042_2.opt
@@ -1,0 +1,7 @@
+--innodb-encryption-rotate-key-age=2
+--innodb_encrypt_tables=ON
+--innodb-encryption-threads=4
+--innodb-tablespaces-encryption
+--plugin-load-add=$FILE_KEY_MANAGEMENT_SO
+--loose-file-key-management
+--loose-file-key-management-filename=$MYSQL_TEST_DIR/std_data/logkey.txt

--- a/mysql-test/suite/mariabackup/MDEV-31042_2.result
+++ b/mysql-test/suite/mariabackup/MDEV-31042_2.result
@@ -1,0 +1,24 @@
+CREATE TABLE t1 (
+`word` int(11) NOT NULL DEFAULT 0,
+`document_number` int(11) NOT NULL DEFAULT 0,
+`total_weight` int(11) DEFAULT NULL,
+`positions` mediumtext DEFAULT NULL,
+PRIMARY KEY (`word`,`document_number`),
+KEY `h685533653_index_ts_c_docume` (`document_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 encrypted=yes;
+# Create full backup , modify table, then create incremental/differential backup
+INSERT INTO t1 VALUES (1,24596,4,'hJWXmQdfsdf==');
+CREATE TABLE tmp_u1332929658s LIKE t1;
+ALTER TABLE tmp_u1332929658s ADD `u_other_end_port` VARCHAR(40);
+RENAME TABLE t1 TO z_tmp_u1332929658s, tmp_u1332929658s TO t1;
+# shutdown server
+# remove datadir
+# xtrabackup move back
+# restart server
+create database ztest;
+RENAME TABLE test.z_tmp_u1332929658s TO ztest.z_tmp_u1332929658s;
+select count(*) from ztest.z_tmp_u1332929658s;
+count(*)
+1
+drop table t1;
+drop database ztest;

--- a/mysql-test/suite/mariabackup/MDEV-31042_2.test
+++ b/mysql-test/suite/mariabackup/MDEV-31042_2.test
@@ -1,5 +1,6 @@
 # First online alter on a non-empty table, then optimize table on the same table while incremental backup is going.
 --source include/have_file_key_management.inc
+--source include/have_debug.inc
 
 let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
 let $incremental_dir=$MYSQLTEST_VARDIR/tmp/backup_inc1;

--- a/mysql-test/suite/mariabackup/MDEV-31042_2.test
+++ b/mysql-test/suite/mariabackup/MDEV-31042_2.test
@@ -1,0 +1,52 @@
+# First online alter on a non-empty table, then optimize table on the same table while incremental backup is going.
+--source include/have_file_key_management.inc
+
+let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
+let $incremental_dir=$MYSQLTEST_VARDIR/tmp/backup_inc1;
+
+# create an empty table
+CREATE TABLE t1 (
+  `word` int(11) NOT NULL DEFAULT 0,
+  `document_number` int(11) NOT NULL DEFAULT 0,
+  `total_weight` int(11) DEFAULT NULL,
+  `positions` mediumtext DEFAULT NULL,
+  PRIMARY KEY (`word`,`document_number`),
+  KEY `h685533653_index_ts_c_docume` (`document_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 encrypted=yes;
+
+echo # Create full backup , modify table, then create incremental/differential backup;
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$basedir;
+--enable_result_log
+
+INSERT INTO t1 VALUES (1,24596,4,'hJWXmQdfsdf==');
+
+#online alter ...
+CREATE TABLE tmp_u1332929658s LIKE t1;
+ALTER TABLE tmp_u1332929658s ADD `u_other_end_port` VARCHAR(40);
+RENAME TABLE t1 TO z_tmp_u1332929658s, tmp_u1332929658s TO t1;
+
+# Execute optimize table on t1 while the backup is in-progress, so that it creates a t1.new file
+--let after_copy_test_t1=optimize table test.t1;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$incremental_dir --incremental-basedir=$basedir --dbug=+d,mariabackup_events;
+
+#--disable_result_log
+#echo # Prepare full backup, apply incremental one;
+exec $XTRABACKUP --apply-log-only --prepare --target-dir=$basedir;
+exec $XTRABACKUP --prepare --target-dir=$basedir --incremental-dir=$incremental_dir ;
+
+#echo # Restore and check results;
+let $targetdir=$basedir;
+--source include/restart_and_restore.inc
+--enable_result_log
+
+create database ztest;
+RENAME TABLE test.z_tmp_u1332929658s TO ztest.z_tmp_u1332929658s;
+select count(*) from ztest.z_tmp_u1332929658s;
+
+#Cleanup ...
+drop table t1;
+drop database ztest;
+
+rmdir $basedir;
+rmdir $incremental_dir;

--- a/mysql-test/suite/mariabackup/MDEV-31042_3.opt
+++ b/mysql-test/suite/mariabackup/MDEV-31042_3.opt
@@ -1,0 +1,7 @@
+--innodb-encryption-rotate-key-age=2
+--innodb_encrypt_tables=ON
+--innodb-encryption-threads=4
+--innodb-tablespaces-encryption
+--plugin-load-add=$FILE_KEY_MANAGEMENT_SO
+--loose-file-key-management
+--loose-file-key-management-filename=$MYSQL_TEST_DIR/std_data/logkey.txt

--- a/mysql-test/suite/mariabackup/MDEV-31042_3.result
+++ b/mysql-test/suite/mariabackup/MDEV-31042_3.result
@@ -1,0 +1,18 @@
+CREATE TABLE t1 (
+`word` int(11) NOT NULL DEFAULT 0,
+`document_number` int(11) NOT NULL DEFAULT 0,
+`total_weight` int(11) DEFAULT NULL,
+`positions` mediumtext DEFAULT NULL,
+PRIMARY KEY (`word`,`document_number`),
+KEY `h685533653_index_ts_c_docume` (`document_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 encrypted=yes;
+# Create full backup , modify table, then create incremental/differential backup
+INSERT INTO t1 VALUES (1,24596,4,'hJWXmQdfsdf==');
+# shutdown server
+# remove datadir
+# xtrabackup move back
+# restart server
+db.opt
+t1.frm
+t1.ibd
+drop table t1;

--- a/mysql-test/suite/mariabackup/MDEV-31042_3.test
+++ b/mysql-test/suite/mariabackup/MDEV-31042_3.test
@@ -1,0 +1,47 @@
+# This is to make sure that the xtrabackup_tmp_#<tablespace_id> is removed when not utilized.
+
+--source include/have_file_key_management.inc
+
+let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
+let $incremental_dir=$MYSQLTEST_VARDIR/tmp/backup_inc1;
+
+# create an empty table
+CREATE TABLE t1 (
+  `word` int(11) NOT NULL DEFAULT 0,
+  `document_number` int(11) NOT NULL DEFAULT 0,
+  `total_weight` int(11) DEFAULT NULL,
+  `positions` mediumtext DEFAULT NULL,
+  PRIMARY KEY (`word`,`document_number`),
+  KEY `h685533653_index_ts_c_docume` (`document_number`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 encrypted=yes;
+
+
+echo # Create full backup , modify table, then create incremental/differential backup;
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$basedir;
+--enable_result_log
+
+INSERT INTO t1 VALUES (1,24596,4,'hJWXmQdfsdf==');
+
+# Execute optimize table on t1 while the backup is in-progress, so that it creates a t1.new file
+--let after_copy_test_t1=optimize table test.t1;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$incremental_dir --incremental-basedir=$basedir --dbug=+d,mariabackup_events;
+
+#--disable_result_log
+#echo # Prepare full backup, apply incremental one;
+exec $XTRABACKUP --apply-log-only --prepare --target-dir=$basedir;
+exec $XTRABACKUP --prepare --target-dir=$basedir --incremental-dir=$incremental_dir ;
+
+#echo # Restore and check results;
+let $targetdir=$basedir;
+--source include/restart_and_restore.inc
+--enable_result_log
+
+# should not see xtrabackup_tmp_#* files ...
+list_files $basedir/test/;
+
+#Cleanup ...
+drop table t1;
+
+rmdir $basedir;
+rmdir $incremental_dir;

--- a/mysql-test/suite/mariabackup/MDEV-31042_3.test
+++ b/mysql-test/suite/mariabackup/MDEV-31042_3.test
@@ -1,6 +1,7 @@
 # This is to make sure that the xtrabackup_tmp_#<tablespace_id> is removed when not utilized.
 
 --source include/have_file_key_management.inc
+--source include/have_debug.inc
 
 let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
 let $incremental_dir=$MYSQLTEST_VARDIR/tmp/backup_inc1;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31042*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
The Problem
==========
Consider the following steps:

Suppose there is an encrypted table "t"
Take a base backup of the database
Create a table like t and name it tmp_t
Rename t to z_t and tmp_t to t
Start an increment backup, while the increment backup is ongoing, execute
optimize table on t (make sure this is executed after copying t to the backup)
Restore the incremental backup and start the server.
When we try to rename z_t table to t_prime, we get the following error:
errno: 155 "The table does not exist in the storage engine"

The Cause
========
An incremental backup collect pages modified since a given LSN number.
The modified pages are written to the backup as .delta files.
Further, tables created/optimized while the backup is on-going on are
saved with a suffix such as ".new", ".ren".

The step 5 above creates a t.new file. These files are processed
at the begining of the apply log stage when preparing the incremental
backup. When t.new file is processed, mariabackup deletes the
existing t.ibd file from the base directory and copies t.new as t.ibd.
However, the new t.ibd file carries a tablespace id different from
the old t.ibd file.

To apply the delta, mariabackup finds the proper tablespace file
in "xb_delta_open_matching_space". Mariabackup fails to
find a matching tablespace for z_t (created at step 4 above) inside
"xb_delta_open_matching_space", because there isn't a matching tablespace
in the base backup by the name z_t and also there isn't a matching space
with z_t's tablespace id. At this point, mariabackup creates new tablespace
file. However, this newly created tablespace file does not contain
crypt data and it just have 4 allocated pages. If delta file for
z_t table is empty, the restore operation succeeds but when
we try to access z_t after restore it remains corrupted. If delta file
contains pages (i.e., z_t is not empty), then we will see mariabackup
throwing an error saying that delta file cannot be applied because it cannot
read page 4 from the ibd file.

The Fix
=====
When processing .new files, deleting original t.ibd file and replacing
it with t.new file is the main cause for the issue.

Therefore, in the fix, when processing t.new files we do not
remove original t.ibd file, instead we rename the existing t.ibd
file to xtrabackup_tmp#<space_id>.ibd.

With this, when mariabackup try to find a matching space for z_t.delta.ibd, it will
return the xtrabackup_tmp#<space_id>.ibd and will be renamed to z_t.ibd in the
base backup. Then, afterwards, mariabackup should be able to apply the delta
to the z_t.ibd.

## How can this PR be tested?
I have included 3 MTRs to test this issue.
MDEV-31042_1 -- Verifies the expected behaviour when the table is empty.
MDEV-31042_2 -- Verifies the expected behaviour when the table is not empty.
MDEV-31042_3 -- To make sure we dont leave any temp tables (xtrabackup_tmp<space_id>.ibd) after restore.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB? - No.
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch? - Yes.
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix? - Yes.

## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
