### PR TITLE
MDEV-31045: Fix regression building on Ubuntu 18.04

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -64,7 +64,7 @@ replace_uring_with_aio()
 disable_pmem()
 {
   sed '/libpmem-dev/d' -i debian/control
-  sed '/-DWITH_PMEM=YES/d' -i debian/rules
+  sed '/-DWITH_PMEM=ON/d' -i debian/rules
 }
 
 architecture=$(dpkg-architecture -q DEB_BUILD_ARCH)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31045*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Github PR #2424 regressed Ubuntu 18.04 building other than x86_64 machines. Architecture that are impacted are **PPC64** and **ARM64**. This was because of changes in debian/rules file

which caused removing dependency to package 'libpmem-dev' and CMake which '-DWITH_PMEM' removing not working correctly. Package libpmem-dev was removed but it still required to have PMEM with CMake which. Commit make change that -DWITH_PMEM is correctly removed if it's not wanted.

## How can this PR be tested?
This is easiest to test with MariaDB testsuite on correct architecture PPC64 and ARM64

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility
This should bring back backward compatibility

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
