### PR TITLE
MDEV-30952: Fix and correctly indent Debian scripts

### DIFF
--- a/debian/mariadb-common.postinst
+++ b/debian/mariadb-common.postinst
@@ -35,7 +35,7 @@ case "$1" in
     then
       update-alternatives --install /etc/mysql/my.cnf my.cnf "/etc/mysql/mariadb.cnf" 500 || true
     fi
-  ;;
+    ;;
 esac
 
 #DEBHELPER#

--- a/debian/mariadb-common.postrm
+++ b/debian/mariadb-common.postrm
@@ -10,7 +10,7 @@ case "$1" in
     then
       /usr/share/mysql-common/configure-symlinks remove mariadb "/etc/mysql/mariadb.cnf"
     fi
-  ;;
+    ;;
 esac
 
 #DEBHELPER#

--- a/debian/mariadb-server-10.6.postinst
+++ b/debian/mariadb-server-10.6.postinst
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# shellcheck source=/dev/null
 . /usr/share/debconf/confmodule
 
 # Automatically set version to ease maintenance of this file
@@ -112,8 +113,10 @@ EOF
     # This direct update is needed to enable an authentication mechanism to
     # perform mariadb-upgrade, (MDEV-22678).  To keep the impact minimal, we
     # skip innodb and set key-buffer-size to 0 as it isn't reused.
-    if [ -f "$mysql_datadir"/auto.cnf ] && [ -f "$mysql_datadir"/mysql/user.MYD ] &&
-    [ ! lsof -nt "$mysql_datadir"/mysql/user.MYD > /dev/null ] && [ ! -f "$mysql_datadir"/undo_001 ]; then
+    lsof -nt "$mysql_datadir"/mysql/user.MYD > /dev/null
+    lsof_rtn_code=$?
+    if [ -f "$mysql_datadir/auto.cnf" ] && [ -f "$mysql_datadir/mysql/user.MYD" ] &&
+    [ ! ${lsof_rtn_code} ] && [ ! -f "$mysql_datadir/undo_001" ]; then
       echo "UPDATE mysql.user SET plugin='unix_socket' WHERE plugin='auth_socket';" |
       mariadbd --skip-innodb --key_buffer_size=0  --default-storage-engine=MyISAM --bootstrap 2> /dev/null
     fi
@@ -189,20 +192,22 @@ EOF
     fi
     if [ ! -e "$dc" ]; then
       cat /dev/null > $dc
-      echo "# THIS FILE IS OBSOLETE. STOP USING IT IF POSSIBLE."       >>$dc
-      echo "# This file exists only for backwards compatibility for"   >>$dc
-      echo "# tools that run '--defaults-file=/etc/mysql/debian.cnf'"  >>$dc
-      echo "# and have root level access to the local filesystem."     >>$dc
-      echo "# With those permissions one can run 'mariadb' directly"   >>$dc
-      echo "# anyway thanks to unix socket authentication and hence"   >>$dc
-      echo "# this file is useless. See package README for more info." >>$dc
-      echo "[client]"                                                  >>$dc
-      echo "host     = localhost"                                      >>$dc
-      echo "user     = root"                                           >>$dc
-      echo "[mysql_upgrade]"                                           >>$dc
-      echo "host     = localhost"                                      >>$dc
-      echo "user     = root"                                           >>$dc
-      echo "# THIS FILE WILL BE REMOVED IN A FUTURE DEBIAN RELEASE."   >>$dc
+      {
+        echo "# THIS FILE IS OBSOLETE. STOP USING IT IF POSSIBLE.";
+        echo "# This file exists only for backwards compatibility for";
+        echo "# tools that run '--defaults-file=/etc/mysql/debian.cnf'";
+        echo "# and have root level access to the local filesystem.";
+        echo "# With those permissions one can run 'mariadb' directly";
+        echo "# anyway thanks to unix socket authentication and hence";
+        echo "# this file is useless. See package README for more info.";
+        echo "[client]";
+        echo "host     = localhost";
+        echo "user     = root";
+        echo "[mysql_upgrade]";
+        echo "host     = localhost";
+        echo "user     = root";
+        echo "# THIS FILE WILL BE REMOVED IN A FUTURE DEBIAN RELEASE.";
+      } >> $dc
     fi
     # Keep it only root-readable, as it always was
     chown 0:0 $dc

--- a/debian/mariadb-server-10.6.postinst
+++ b/debian/mariadb-server-10.6.postinst
@@ -7,7 +7,12 @@ set -e
 # Automatically set version to ease maintenance of this file
 MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
-if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
+if [ -n "$DEBIAN_SCRIPT_DEBUG" ]
+then
+  set -v -x
+  DEBIAN_SCRIPT_TRACE=1
+fi
+
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*" 1>&2 }
 
 export PATH=$PATH:/sbin:/usr/sbin:/bin:/usr/bin
@@ -25,7 +30,9 @@ case "$1" in
     # and because changed configuration options should take effect immediately.
     # In case the server wasn't running at all it should be ok if the stop
     # script fails. I can't tell at this point because of the cleaned /run.
-    set +e; invoke-rc.d mariadb stop; set -e
+    set +e
+    invoke-rc.d mariadb stop
+    set -e
 
     # An existing /etc/init.d/mysql might be on the system if there was a
     # previous MySQL or MariaDB installation, since /etc/init.d files are
@@ -65,21 +72,26 @@ case "$1" in
     # If the following symlink exists, it is a preserved copy the old data dir
     # created by the preinst script during a upgrade that would have otherwise
     # been replaced by an empty mysql dir.  This should restore it.
-    for dir in DATADIR LOGDIR; do
+    for dir in DATADIR LOGDIR
+    do
 
-      if [ "$dir" = "DATADIR" ]; then
+      if [ "$dir" = "DATADIR" ]
+      then
         targetdir=$mysql_datadir
       else
         targetdir=$mysql_logdir
       fi
 
       savelink="$mysql_upgradedir/$dir.link"
-      if [ -L "$savelink" ]; then
+      if [ -L "$savelink" ]
+      then
         # If the targetdir was a symlink before we upgraded it is supposed
         # to be either still be present or not existing anymore now.
-        if [ -L "$targetdir" ]; then
+        if [ -L "$targetdir" ]
+        then
           rm "$savelink"
-        elif [ ! -d "$targetdir" ]; then
+        elif [ ! -d "$targetdir" ]
+        then
           mv "$savelink" "$targetdir"
         else
           # this should never even happen, but just in case...
@@ -116,16 +128,26 @@ EOF
     lsof -nt "$mysql_datadir"/mysql/user.MYD > /dev/null
     lsof_rtn_code=$?
     if [ -f "$mysql_datadir/auto.cnf" ] && [ -f "$mysql_datadir/mysql/user.MYD" ] &&
-    [ ! ${lsof_rtn_code} ] && [ ! -f "$mysql_datadir/undo_001" ]; then
+    [ ! ${lsof_rtn_code} ] && [ ! -f "$mysql_datadir/undo_001" ]
+    then
       echo "UPDATE mysql.user SET plugin='unix_socket' WHERE plugin='auth_socket';" |
       mariadbd --skip-innodb --key_buffer_size=0  --default-storage-engine=MyISAM --bootstrap 2> /dev/null
     fi
 
     # Ensure the existence and right permissions for the database and
     # log files. Use mkdir option 'Z' to create with correct SELinux context.
-    if [ ! -d "$mysql_statedir" ] && [ ! -L "$mysql_statedir" ]; then mkdir -Z "$mysql_statedir"; fi
-    if [ ! -d "$mysql_datadir"  ] && [ ! -L "$mysql_datadir" ]; then mkdir -Z "$mysql_datadir" ; fi
-    if [ ! -d "$mysql_logdir"   ] && [ ! -L "$mysql_logdir"  ]; then mkdir -Z "$mysql_logdir"  ; fi
+    if [ ! -d "$mysql_statedir" ] && [ ! -L "$mysql_statedir" ]
+    then
+      mkdir -Z "$mysql_statedir"
+    fi
+    if [ ! -d "$mysql_datadir"  ] && [ ! -L "$mysql_datadir" ]
+    then
+      mkdir -Z "$mysql_datadir"
+    fi
+    if [ ! -d "$mysql_logdir"   ] && [ ! -L "$mysql_logdir"  ]
+    then
+      mkdir -Z "$mysql_logdir"
+    fi
     # When creating an ext3 jounal on an already mounted filesystem like e.g.
     # /var/lib/mysql, you get a .journal file that is not modifiable by chown.
     # The mysql_statedir must not be writable by the mysql user under any
@@ -186,11 +208,13 @@ EOF
     # --defaults-file option for tools (for the sake of upgrades)
     # and thus need /etc/mysql/debian.cnf to exist, even if it's empty.
     # In the long run the goal is to obsolete this file.
-    dc=$mysql_cfgdir/debian.cnf;
-    if [ ! -d "$mysql_cfgdir" ]; then
+    dc="$mysql_cfgdir/debian.cnf"
+    if [ ! -d "$mysql_cfgdir" ]
+    then
       install -o 0 -g 0 -m 0755 -d $mysql_cfgdir
     fi
-    if [ ! -e "$dc" ]; then
+    if [ ! -e "$dc" ]
+    then
       cat /dev/null > $dc
       {
         echo "# THIS FILE IS OBSOLETE. STOP USING IT IF POSSIBLE.";
@@ -220,8 +244,10 @@ EOF
     # on by default) to work both to disable a default profile, and to keep
     # any profile installed and maintained by users themselves.
     profile="/etc/apparmor.d/usr.sbin.mariadbd"
-    if [ -f "$profile" ] && aa-status --enabled 2>/dev/null; then
-      if grep -q /usr/sbin/mariadbd "$profile" 2>/dev/null ; then
+    if [ -f "$profile" ] && aa-status --enabled 2>/dev/null
+    then
+      if grep -q /usr/sbin/mariadbd "$profile" 2>/dev/null
+      then
         apparmor_parser -r "$profile" || true
       else
         echo "/usr/sbin/mariadbd { }" | apparmor_parser --remove 2>/dev/null || true
@@ -233,14 +259,14 @@ EOF
     # Note that file cannot be empty, otherwise systemd version in Ubuntu Bionic
     # will think the service is masked
     echo "# empty placeholder" > /etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf
-
     ;;
 
   abort-upgrade|abort-remove|abort-configure)
     ;;
 
   triggered)
-    if [ -d /run/systemd/system ]; then
+    if [ -d /run/systemd/system ]
+    then
       systemctl --system daemon-reload
     else
       invoke-rc.d mariadb restart
@@ -260,19 +286,23 @@ db_stop # in case invoke fails
 # systemctl. If we upgrade from MySQL mysql.service may be masked, which also
 # means init.d script is disabled. Unmask mysql service explicitly.
 # Check first that the command exists, to avoid emitting any warning messages.
-if [ -x "$(command -v deb-systemd-helper)" ]; then
+if [ -x "$(command -v deb-systemd-helper)" ]
+then
   deb-systemd-helper unmask mysql.service > /dev/null
 fi
 
 #DEBHELPER#
 
 # Modified dh_systemd_start snippet that's not added automatically
-if [ -d /run/systemd/system ]; then
+if [ -d /run/systemd/system ]
+then
   systemctl --system daemon-reload >/dev/null || true
   deb-systemd-invoke start mariadb.service >/dev/null || true
   # Modified dh_installinit snippet to only run with sysvinit
-elif [ -x "/etc/init.d/mariadb" ]; then
-  if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+elif [ -x "/etc/init.d/mariadb" ]
+then
+  if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]
+  then
     invoke-rc.d mariadb start || exit $?
   fi
 fi

--- a/debian/mariadb-server-10.6.postinst
+++ b/debian/mariadb-server-10.6.postinst
@@ -100,7 +100,7 @@ this all away.
 EOF
         fi
       fi
-	    rmdir $mysql_upgradedir 2>/dev/null || true
+      rmdir $mysql_upgradedir 2>/dev/null || true
 
     done
 
@@ -113,9 +113,9 @@ EOF
     # perform mariadb-upgrade, (MDEV-22678).  To keep the impact minimal, we
     # skip innodb and set key-buffer-size to 0 as it isn't reused.
     if [ -f "$mysql_datadir"/auto.cnf ] && [ -f "$mysql_datadir"/mysql/user.MYD ] &&
-       [ ! lsof -nt "$mysql_datadir"/mysql/user.MYD > /dev/null ] && [ ! -f "$mysql_datadir"/undo_001 ]; then
-         echo "UPDATE mysql.user SET plugin='unix_socket' WHERE plugin='auth_socket';" |
-             mariadbd --skip-innodb --key_buffer_size=0  --default-storage-engine=MyISAM --bootstrap 2> /dev/null
+    [ ! lsof -nt "$mysql_datadir"/mysql/user.MYD > /dev/null ] && [ ! -f "$mysql_datadir"/undo_001 ]; then
+      echo "UPDATE mysql.user SET plugin='unix_socket' WHERE plugin='auth_socket';" |
+      mariadbd --skip-innodb --key_buffer_size=0  --default-storage-engine=MyISAM --bootstrap 2> /dev/null
     fi
 
     # Ensure the existence and right permissions for the database and
@@ -171,8 +171,8 @@ EOF
     # Debian: can safely run on upgrades with existing databases
     set +e
     bash /usr/bin/mariadb-install-db --rpm --cross-bootstrap --user=mysql \
-                                   --disable-log-bin  --skip-test-db 2>&1 | \
-                                   $ERR_LOGGER
+      --disable-log-bin  --skip-test-db 2>&1 | \
+      $ERR_LOGGER
     set -e
 
     # On new installations root user can connect via unix_socket.
@@ -188,21 +188,21 @@ EOF
       install -o 0 -g 0 -m 0755 -d $mysql_cfgdir
     fi
     if [ ! -e "$dc" ]; then
-        cat /dev/null > $dc
-        echo "# THIS FILE IS OBSOLETE. STOP USING IT IF POSSIBLE."       >>$dc
-        echo "# This file exists only for backwards compatibility for"   >>$dc
-        echo "# tools that run '--defaults-file=/etc/mysql/debian.cnf'"  >>$dc
-        echo "# and have root level access to the local filesystem."     >>$dc
-        echo "# With those permissions one can run 'mariadb' directly"   >>$dc
-        echo "# anyway thanks to unix socket authentication and hence"   >>$dc
-        echo "# this file is useless. See package README for more info." >>$dc
-        echo "[client]"                                                  >>$dc
-        echo "host     = localhost"                                      >>$dc
-        echo "user     = root"                                           >>$dc
-        echo "[mysql_upgrade]"                                           >>$dc
-        echo "host     = localhost"                                      >>$dc
-        echo "user     = root"                                           >>$dc
-        echo "# THIS FILE WILL BE REMOVED IN A FUTURE DEBIAN RELEASE."   >>$dc
+      cat /dev/null > $dc
+      echo "# THIS FILE IS OBSOLETE. STOP USING IT IF POSSIBLE."       >>$dc
+      echo "# This file exists only for backwards compatibility for"   >>$dc
+      echo "# tools that run '--defaults-file=/etc/mysql/debian.cnf'"  >>$dc
+      echo "# and have root level access to the local filesystem."     >>$dc
+      echo "# With those permissions one can run 'mariadb' directly"   >>$dc
+      echo "# anyway thanks to unix socket authentication and hence"   >>$dc
+      echo "# this file is useless. See package README for more info." >>$dc
+      echo "[client]"                                                  >>$dc
+      echo "host     = localhost"                                      >>$dc
+      echo "user     = root"                                           >>$dc
+      echo "[mysql_upgrade]"                                           >>$dc
+      echo "host     = localhost"                                      >>$dc
+      echo "user     = root"                                           >>$dc
+      echo "# THIS FILE WILL BE REMOVED IN A FUTURE DEBIAN RELEASE."   >>$dc
     fi
     # Keep it only root-readable, as it always was
     chown 0:0 $dc
@@ -229,10 +229,10 @@ EOF
     # will think the service is masked
     echo "# empty placeholder" > /etc/systemd/system/mariadb.service.d/migrated-from-my.cnf-settings.conf
 
-  ;;
+    ;;
 
   abort-upgrade|abort-remove|abort-configure)
-  ;;
+    ;;
 
   triggered)
     if [ -d /run/systemd/system ]; then
@@ -240,12 +240,12 @@ EOF
     else
       invoke-rc.d mariadb restart
     fi
-  ;;
+    ;;
 
   *)
     echo "postinst called with unknown argument '$1'" 1>&2
     exit 1
-  ;;
+    ;;
 esac
 
 db_stop # in case invoke fails
@@ -263,11 +263,11 @@ fi
 
 # Modified dh_systemd_start snippet that's not added automatically
 if [ -d /run/systemd/system ]; then
-	systemctl --system daemon-reload >/dev/null || true
-	deb-systemd-invoke start mariadb.service >/dev/null || true
-# Modified dh_installinit snippet to only run with sysvinit
+  systemctl --system daemon-reload >/dev/null || true
+  deb-systemd-invoke start mariadb.service >/dev/null || true
+  # Modified dh_installinit snippet to only run with sysvinit
 elif [ -x "/etc/init.d/mariadb" ]; then
-	if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
-		invoke-rc.d mariadb start || exit $?
-	fi
+  if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ]; then
+    invoke-rc.d mariadb start || exit $?
+  fi
 fi

--- a/debian/mariadb-server-10.6.postrm
+++ b/debian/mariadb-server-10.6.postrm
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+# shellcheck source=/dev/null
 . /usr/share/debconf/confmodule
 
 # Automatically set version to ease maintenance of this file
@@ -26,7 +27,7 @@ stop_server() {
   set -e
 
   # systemctl could emit exit code 100=no init script (fresh install)
-  if [ "$errno" != 0 -a "$errno" != 100 ]; then
+  if [ "$errno" != 0 ] && [ "$errno" != 100 ]; then
     echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
     echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
     echo "Stop it yourself and try again!" 1>&2
@@ -38,7 +39,7 @@ stop_server() {
 
 case "$1" in
   purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-    if [ -n "`$MYADMIN ping 2>/dev/null`" ]; then
+    if [ -n "$($MYADMIN ping 2>/dev/null)" ]; then
       stop_server
       sleep 2
     fi

--- a/debian/mariadb-server-10.6.postrm
+++ b/debian/mariadb-server-10.6.postrm
@@ -7,7 +7,12 @@ set -e
 # Automatically set version to ease maintenance of this file
 MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
-if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
+if [ -n "$DEBIAN_SCRIPT_DEBUG" ]
+then
+  set -v -x
+  DEBIAN_SCRIPT_TRACE=1
+fi
+
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*" 1>&2 }
 
 MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
@@ -18,7 +23,10 @@ MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 stop_server() {
   # Return immediately if there are no mysqld processes running
   # as there is no point in trying to shutdown in that case.
-  if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
+  if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null
+  then
+    return
+  fi
 
   set +e
   invoke-rc.d mariadb stop
@@ -27,7 +35,8 @@ stop_server() {
   set -e
 
   # systemctl could emit exit code 100=no init script (fresh install)
-  if [ "$errno" != 0 ] && [ "$errno" != 100 ]; then
+  if [ "$errno" != 0 ] && [ "$errno" != 100 ]
+  then
     echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
     echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
     echo "Stop it yourself and try again!" 1>&2
@@ -39,7 +48,8 @@ stop_server() {
 
 case "$1" in
   purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
-    if [ -n "$($MYADMIN ping 2>/dev/null)" ]; then
+    if [ -n "$($MYADMIN ping 2>/dev/null)" ]
+    then
       stop_server
       sleep 2
     fi
@@ -55,7 +65,8 @@ esac
 # - Remove the mysql user only after all his owned files are purged.
 # - Cleanup the initscripts only if this was the last provider of them
 #
-if [ "$1" = "purge" ] && [ -f "/var/lib/mysql/debian-$MAJOR_VER.flag" ]; then
+if [ "$1" = "purge" ] && [ -f "/var/lib/mysql/debian-$MAJOR_VER.flag" ]
+then
   # we remove the mysql user only after all his owned files are purged
   rm -f /var/log/mysql.{log,err}{,.0,.[1234567].gz}
   rm -rf /var/log/mysql
@@ -63,7 +74,8 @@ if [ "$1" = "purge" ] && [ -f "/var/lib/mysql/debian-$MAJOR_VER.flag" ]; then
   db_input high "mariadb-server-$MAJOR_VER/postrm_remove_databases" || true
   db_go || true
   db_get "mariadb-server-$MAJOR_VER/postrm_remove_databases" || true
-  if [ "$RET" = "true" ]; then
+  if [ "$RET" = "true" ]
+  then
     # never remove the debian.cnf when the databases are still existing
     # else we ran into big trouble on the next install!
     rm -f /etc/mysql/debian.cnf
@@ -93,6 +105,7 @@ fi
 #DEBHELPER#
 
 # Modified dh_systemd_start snippet that's not added automatically
-if [ -d /run/systemd/system ]; then
+if [ -d /run/systemd/system ]
+then
   systemctl --system daemon-reload >/dev/null || true
 fi

--- a/debian/mariadb-server-10.6.postrm
+++ b/debian/mariadb-server-10.6.postrm
@@ -15,24 +15,24 @@ MYADMIN="/usr/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 # do it himself. No database directories should be removed while the server
 # is running! Another mariadbd in e.g. a different chroot is fine for us.
 stop_server() {
-    # Return immediately if there are no mysqld processes running
-    # as there is no point in trying to shutdown in that case.
-    if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
+  # Return immediately if there are no mysqld processes running
+  # as there is no point in trying to shutdown in that case.
+  if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
 
-    set +e
-    invoke-rc.d mariadb stop
-    invoke-rc.d mysql stop # Backwards compatibility
-    errno=$?
-    set -e
+  set +e
+  invoke-rc.d mariadb stop
+  invoke-rc.d mysql stop # Backwards compatibility
+  errno=$?
+  set -e
 
-    # systemctl could emit exit code 100=no init script (fresh install)
-    if [ "$errno" != 0 -a "$errno" != 100 ]; then
-      echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
-      echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
-      echo "Stop it yourself and try again!" 1>&2
-      db_stop
-      exit 1
-    fi
+  # systemctl could emit exit code 100=no init script (fresh install)
+  if [ "$errno" != 0 -a "$errno" != 100 ]; then
+    echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
+    echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
+    echo "Stop it yourself and try again!" 1>&2
+    db_stop
+    exit 1
+  fi
 }
 
 
@@ -42,11 +42,11 @@ case "$1" in
       stop_server
       sleep 2
     fi
-  ;;
+    ;;
   *)
     echo "postrm called with unknown argument '$1'" 1>&2
     exit 1
-  ;;
+    ;;
 esac
 
 #
@@ -75,9 +75,9 @@ if [ "$1" = "purge" ] && [ -f "/var/lib/mysql/debian-$MAJOR_VER.flag" ]; then
     if [ -d /var/lib/mysql ]
     then
       find /var/lib/mysql -mindepth 1 \
-           -not -path '*/lost+found/*'     -not -name 'lost+found' \
-           -not -path '*/lost@002bfound/*' -not -name 'lost@002bfound' \
-           -delete
+        -not -path '*/lost+found/*'     -not -name 'lost+found' \
+        -not -path '*/lost@002bfound/*' -not -name 'lost@002bfound' \
+        -delete
 
       # "|| true" still needed as rmdir still exits with non-zero if
       # /var/lib/mysql is a mount point
@@ -93,5 +93,5 @@ fi
 
 # Modified dh_systemd_start snippet that's not added automatically
 if [ -d /run/systemd/system ]; then
-	systemctl --system daemon-reload >/dev/null || true
+  systemctl --system daemon-reload >/dev/null || true
 fi

--- a/debian/mariadb-server-10.6.preinst
+++ b/debian/mariadb-server-10.6.preinst
@@ -14,11 +14,16 @@
 MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
 # Just kill the invalid insserv.conf.d directory without fallback
-if [ -d "/etc/insserv.conf.d/mariadb/" ]; then
+if [ -d "/etc/insserv.conf.d/mariadb/" ]
+then
   rm -rf "/etc/insserv.conf.d/mariadb/"
 fi
 
-if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
+if [ -n "$DEBIAN_SCRIPT_DEBUG" ]
+then
+  set -v -x
+  DEBIAN_SCRIPT_TRACE=1
+fi
 ${DEBIAN_SCRIPT_TRACE:+ echo "#42#DEBUG# RUNNING $0 $*" 1>&2 }
 
 export PATH=$PATH:/sbin:/usr/sbin:/bin:/usr/bin
@@ -32,7 +37,10 @@ stop_server() {
   # Return immediately if there are no mysqld processes running on a host
   # (leave containerized processes with the same name in other namespaces)
   # as there is no point in trying to shutdown in that case.
-  if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
+  if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null
+  then
+    return
+  fi
 
   set +e
   invoke-rc.d mariadb stop
@@ -41,7 +49,8 @@ stop_server() {
   set -e
 
   # systemctl could emit exit code 100=no init script (fresh install)
-  if [ "$errno" != 0 ] && [ "$errno" != 100 ]; then
+  if [ "$errno" != 0 ] && [ "$errno" != 100 ]
+  then
     echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
     echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
     echo "Stop it yourself and try again!" 1>&2
@@ -156,7 +165,8 @@ stop_server
 # If we use NIS then errors should be tolerated. It's up to the
 # user to ensure that the mysql user is correctly setup.
 # Beware that there are two ypwhich one of them needs the 2>/dev/null!
-if test -n "$(which ypwhich 2>/dev/null)"  &&  ypwhich >/dev/null 2>&1; then
+if test -n "$(which ypwhich 2>/dev/null)"  &&  ypwhich >/dev/null 2>&1
+then
   set +e
 fi
 
@@ -171,13 +181,15 @@ fi
 #
 
 # creating mysql group if he isn't already there
-if ! getent group mysql >/dev/null; then
+if ! getent group mysql >/dev/null
+then
   # Adding system group: mysql.
   addgroup --system mysql >/dev/null
 fi
 
 # creating mysql user if he isn't already there
-if ! getent passwd mysql >/dev/null; then
+if ! getent passwd mysql >/dev/null
+then
   # Adding system user: mysql.
   adduser \
     --system \
@@ -195,7 +207,8 @@ set -e
 
 # if there's a symlink, let's store where it's pointing, because otherwise
 # it's going to be lost in some situations
-for dir in DATADIR LOGDIR; do
+for dir in DATADIR LOGDIR
+do
   checkdir=$(eval echo "$"$dir)
   if [ -L "$checkdir" ]; then
     # Use mkdir option 'Z' to create with correct SELinux context.
@@ -205,7 +218,8 @@ for dir in DATADIR LOGDIR; do
 done
 
 # creating mysql home directory
-if [ ! -d $mysql_datadir ] && [ ! -L $mysql_datadir ]; then
+if [ ! -d $mysql_datadir ] && [ ! -L $mysql_datadir ]
+then
   # Use mkdir option 'Z' to create with correct SELinux context.
   mkdir -Z $mysql_datadir
 fi
@@ -213,7 +227,8 @@ fi
 # As preset blocksize of GNU df is 1024 then available bytes is $df_available_blocks * 1024
 # 4096 blocks is then lower than 4 MB
 df_available_blocks=`LC_ALL=C BLOCKSIZE= df --output=avail "$datadir" | tail -n 1`
-if [ "$df_available_blocks" -lt "4096" ]; then
+if [ "$df_available_blocks" -lt "4096" ]
+then
   echo "ERROR: There's not enough space in $mysql_datadir/" 1>&2
   db_stop
   exit 1
@@ -231,7 +246,6 @@ find $mysql_datadir ! -uid "$(id -u mysql)" -print0 | xargs -0 -r chown mysql
 find $mysql_datadir -follow -not -group mysql -print0 2>/dev/null \
   | xargs -0 --no-run-if-empty chgrp mysql
 set -e
-
 
 db_stop
 

--- a/debian/mariadb-server-10.6.preinst
+++ b/debian/mariadb-server-10.6.preinst
@@ -14,7 +14,7 @@ MAJOR_VER="${DPKG_MAINTSCRIPT_PACKAGE#mariadb-server-}"
 
 # Just kill the invalid insserv.conf.d directory without fallback
 if [ -d "/etc/insserv.conf.d/mariadb/" ]; then
-    rm -rf "/etc/insserv.conf.d/mariadb/"
+  rm -rf "/etc/insserv.conf.d/mariadb/"
 fi
 
 if [ -n "$DEBIAN_SCRIPT_DEBUG" ]; then set -v -x; DEBIAN_SCRIPT_TRACE=1; fi
@@ -28,25 +28,25 @@ mysql_upgradedir=/var/lib/mysql-upgrade
 # do it himself. No database directories should be removed while the server
 # is running! Another mariadbd in e.g. a different chroot is fine for us.
 stop_server() {
-    # Return immediately if there are no mysqld processes running on a host
-    # (leave containerized processes with the same name in other namespaces)
-    # as there is no point in trying to shutdown in that case.
-    if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
+  # Return immediately if there are no mysqld processes running on a host
+  # (leave containerized processes with the same name in other namespaces)
+  # as there is no point in trying to shutdown in that case.
+  if ! pgrep -x --nslist pid --ns $$ "mysqld|mariadbd" > /dev/null; then return; fi
 
-    set +e
-    invoke-rc.d mariadb stop
-    invoke-rc.d mysql stop # Backwards compatibility
-    errno=$?
-    set -e
+  set +e
+  invoke-rc.d mariadb stop
+  invoke-rc.d mysql stop # Backwards compatibility
+  errno=$?
+  set -e
 
-    # systemctl could emit exit code 100=no init script (fresh install)
-    if [ "$errno" != 0 -a "$errno" != 100 ]; then
-      echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
-      echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
-      echo "Stop it yourself and try again!" 1>&2
-      db_stop
-      exit 1
-    fi
+  # systemctl could emit exit code 100=no init script (fresh install)
+  if [ "$errno" != 0 -a "$errno" != 100 ]; then
+    echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
+    echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
+    echo "Stop it yourself and try again!" 1>&2
+    db_stop
+    exit 1
+  fi
 }
 
 ################################ main() ##########################
@@ -112,7 +112,7 @@ then
   fi
 
   if dpkg --compare-versions "$found_version" '>>' "$max_upgradeable_version" \
-  && dpkg --compare-versions "$found_version" '<<' "10.0"
+    && dpkg --compare-versions "$found_version" '<<' "10.0"
   then
     downgrade_detected=true
   fi
@@ -171,22 +171,22 @@ fi
 
 # creating mysql group if he isn't already there
 if ! getent group mysql >/dev/null; then
- 	# Adding system group: mysql.
-	addgroup --system mysql >/dev/null
+  # Adding system group: mysql.
+  addgroup --system mysql >/dev/null
 fi
 
 # creating mysql user if he isn't already there
 if ! getent passwd mysql >/dev/null; then
-	# Adding system user: mysql.
-	adduser \
-	  --system \
-          --disabled-login \
-	  --ingroup mysql \
-	  --no-create-home \
-	  --home /nonexistent \
-	  --gecos "MySQL Server" \
-	  --shell /bin/false \
-	  mysql  >/dev/null
+  # Adding system user: mysql.
+  adduser \
+    --system \
+    --disabled-login \
+    --ingroup mysql \
+    --no-create-home \
+    --home /nonexistent \
+    --gecos "MySQL Server" \
+    --shell /bin/false \
+    mysql  >/dev/null
 fi
 
 # end of NIS tolerance zone
@@ -205,7 +205,7 @@ done
 
 # creating mysql home directory
 if [ ! -d $mysql_datadir ] && [ ! -L $mysql_datadir ]; then
-	# Use mkdir option 'Z' to create with correct SELinux context.
+  # Use mkdir option 'Z' to create with correct SELinux context.
   mkdir -Z $mysql_datadir
 fi
 

--- a/debian/mariadb-server-10.6.preinst
+++ b/debian/mariadb-server-10.6.preinst
@@ -7,6 +7,7 @@
 #        * <old-preinst> abort-upgrade <new-version>
 #
 
+# shellcheck source=/dev/null
 . /usr/share/debconf/confmodule
 
 # Automatically set version to ease maintenance of this file
@@ -40,7 +41,7 @@ stop_server() {
   set -e
 
   # systemctl could emit exit code 100=no init script (fresh install)
-  if [ "$errno" != 0 -a "$errno" != 100 ]; then
+  if [ "$errno" != 0 ] && [ "$errno" != 100 ]; then
     echo "Attempt to stop MariaDB/MySQL server returned exitcode $errno" 1>&2
     echo "There is a MariaDB/MySQL server running, but we failed in our attempts to stop it." 1>&2
     echo "Stop it yourself and try again!" 1>&2
@@ -57,7 +58,7 @@ max_upgradeable_version=5.7
 # Check if a flag file is found that indicates a previous MariaDB or MySQL
 # version was installed. If multiple flags are found, check which one was
 # the biggest version number.
-for flag in $mysql_datadir/debian-*.flag
+for flag in "$mysql_datadir"/debian-*.flag
 do
 
   # The for loop leaves $flag as the query string if there are no results,
@@ -92,7 +93,7 @@ done
 # Downgrade is detected if the flag version is bigger than $this_version
 # (e.g. 10.1 > 10.0) or the flag version is smaller than 10.0 but bigger
 # than $max_upgradeable_version.
-if [ ! -z "$found_version" ]
+if [ -n "$found_version" ]
 then
 
   # MySQL 8.0 in Ubuntu has a bug in packaging and the file is name wrongly
@@ -134,7 +135,7 @@ fi
 
 # Don't abort dpkg if downgrade is detected (as was done previously).
 # Instead simply move the old datadir and create a new for this_version.
-if [ ! -z "$downgrade_detected" ]
+if [ -n "$downgrade_detected" ]
 then
   db_input critical "mariadb-server-$MAJOR_VER/old_data_directory_saved" || true
   db_go

--- a/debian/mariadb-server-10.6.prerm
+++ b/debian/mariadb-server-10.6.prerm
@@ -5,8 +5,8 @@ set -e
 
 # Modified dh_systemd_start snippet that's not added automatically
 if [ -d /run/systemd/system ]; then
-	deb-systemd-invoke stop mariadb.service >/dev/null
-# Modified dh_installinit snippet to only run with sysvinit
+  deb-systemd-invoke stop mariadb.service >/dev/null
+  # Modified dh_installinit snippet to only run with sysvinit
 elif [ -x "/etc/init.d/mariadb" ]; then
-	invoke-rc.d mariadb stop || exit $?
+  invoke-rc.d mariadb stop || exit $?
 fi

--- a/debian/mariadb-server-10.6.prerm
+++ b/debian/mariadb-server-10.6.prerm
@@ -4,9 +4,11 @@ set -e
 #DEBHELPER#
 
 # Modified dh_systemd_start snippet that's not added automatically
-if [ -d /run/systemd/system ]; then
+if [ -d /run/systemd/system ]
+then
   deb-systemd-invoke stop mariadb.service >/dev/null
   # Modified dh_installinit snippet to only run with sysvinit
-elif [ -x "/etc/init.d/mariadb" ]; then
+elif [ -x "/etc/init.d/mariadb" ]
+then
   invoke-rc.d mariadb stop || exit $?
 fi


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30952*

## Description
Debian pre- and postinst script have been getting slightly out of `ShellCheck` and they are not indented correctly or same way always. These commits fix most of the issues.  

## How can this PR be tested?
Run `ShellCheck debian/*.pre* debian/*.post*` and check if there is indentation which seems not to be correct.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility
Should not be affected

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
