### PR TITLE
MDEV-31062 : Reduce number of wsrep calls to server code from InnoDB

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -2182,14 +2182,17 @@ btr_cur_ins_lock_and_undo(
 			GAP-locking we mark that this transaction
 			is using unique key scan here. */
 			if ((type & (DICT_CLUSTERED | DICT_UNIQUE)) == DICT_UNIQUE
-			    && trx->is_wsrep()
-			    && wsrep_thd_is_BF(trx->mysql_thd, false)) {
-				trx->wsrep = 3;
+			    && trx->is_wsrep_BF()) {
+				trx->wsrep_begin_UK_scan();
 			}
 #endif /* WITH_WSREP */
-			if (dberr_t err = lock_rec_insert_check_and_lock(
-				    rec, btr_cur_get_block(cursor),
-				    index, thr, mtr, inherit)) {
+			dberr_t err = lock_rec_insert_check_and_lock(
+					rec, btr_cur_get_block(cursor),
+					index, thr, mtr, inherit);
+#ifdef WITH_WSREP
+			trx->wsrep_end_UK_scan();
+#endif /* WITH_WSREP */
+			if (err) {
 				return err;
 			}
 		}

--- a/storage/innobase/dict/dict0stats_bg.cc
+++ b/storage/innobase/dict/dict0stats_bg.cc
@@ -170,9 +170,8 @@ void dict_stats_update_if_needed_func(dict_table_t *table)
 			generated row locks and allow BF thread
 			lock waits to be enqueued at head of waiting
 			queue. */
-			if (trx.is_wsrep()
-			    && !wsrep_thd_is_applying(trx.mysql_thd)
-			    && wsrep_thd_is_BF(trx.mysql_thd, 0)) {
+			if (trx.is_wsrep_BF()
+			    && !wsrep_thd_is_applying(trx.mysql_thd)) {
 				WSREP_DEBUG("Avoiding background statistics"
 					    " calculation for table %s.",
 					table->name.m_name);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2872,7 +2872,13 @@ innobase_trx_init(
 	trx->check_unique_secondary = !thd_test_options(
 		thd, OPTION_RELAXED_UNIQUE_CHECKS);
 #ifdef WITH_WSREP
-	trx->wsrep = wsrep_on(thd);
+	/* Note that we can't lock THD::LOCK_thd_data here because e.g.
+	   in ::trx_group_commit_leader we call run_commit_ordered
+	   holding it and if InnoDB transaction for some reason has not
+	   yet created we arrive here. */
+	trx->wsrep = wsrep_on(thd) ?
+	  (wsrep_thd_is_BF(thd, false) ? (trx_t::TRX_WSREP_BF | trx_t::TRX_WSREP_ON )
+				       : trx_t::TRX_WSREP_ON) : 0;
 #endif
 
 	DBUG_VOID_RETURN;
@@ -4384,7 +4390,7 @@ innobase_commit_low(
 	} else {
 		trx->will_lock = false;
 #ifdef WITH_WSREP
-		trx->wsrep = false;
+		trx->wsrep = 0;
 #endif /* WITH_WSREP */
 	}
 
@@ -18656,7 +18662,7 @@ void lock_wait_wsrep_kill(trx_t *bf_trx, ulong thd_id, trx_id_t trx_id)
           WSREP_DEBUG("Victim %s trx_id: " TRX_ID_FMT " thread: %ld "
                       "seqno: %lld client_state: %s "
                       "client_mode: %s transaction_mode: %s query: %s",
-                      wsrep_thd_is_BF(vthd, false) ? "BF" : "normal",
+                      vtrx->is_wsrep_BF() ? "BF" : "normal",
                       vtrx->id,
                       thd_get_thread_id(vthd),
                       wsrep_thd_trx_seqno(vthd),

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -518,8 +518,8 @@ static void wsrep_assert_no_bf_bf_wait(const lock_t *lock, const trx_t *trx)
 
 	if (!trx->is_wsrep() || !lock_trx->is_wsrep())
 		return;
-	if (UNIV_LIKELY(!wsrep_thd_is_BF(trx->mysql_thd, FALSE))
-	    || UNIV_LIKELY(!wsrep_thd_is_BF(lock_trx->mysql_thd, FALSE)))
+	if (UNIV_LIKELY(!trx->is_wsrep_BF())
+	    || UNIV_LIKELY(!lock_trx->is_wsrep_BF()))
 		return;
 
 	ut_ad(trx->state == TRX_STATE_ACTIVE);
@@ -577,7 +577,7 @@ ATTRIBUTE_NOINLINE static bool wsrep_is_BF_lock_timeout(const trx_t &trx)
   ut_ad(trx.is_wsrep());
 
   if (trx.error_state == DB_DEADLOCK || !srv_monitor_timer ||
-      !wsrep_thd_is_BF(trx.mysql_thd, false))
+      !trx.is_wsrep_BF())
     return false;
 
   ib::info() << "WSREP: BF lock wait long for trx:" << ib::hex(trx.id)
@@ -700,7 +700,7 @@ lock_rec_has_to_wait(
 	ordering of these transactions is already decided and
 	conflicting transaction will be later replayed. */
 	if (trx->is_wsrep_UK_scan()
-	    && wsrep_thd_is_BF(lock2->trx->mysql_thd, false)) {
+	    && lock2->trx->is_wsrep_BF()) {
 		return false;
 	}
 
@@ -934,7 +934,7 @@ ATTRIBUTE_COLD ATTRIBUTE_NOINLINE
 static void lock_wait_wsrep(trx_t *trx)
 {
   DBUG_ASSERT(wsrep_on(trx->mysql_thd));
-  if (!wsrep_thd_is_BF(trx->mysql_thd, false))
+  if (!trx->is_wsrep_BF())
     return;
 
   std::set<trx_t*> victims;
@@ -958,7 +958,7 @@ func_exit:
          lock= UT_LIST_GET_NEXT(un_member.tab_lock.locks, lock))
       /* if victim has also BF status, but has earlier seqno, we have to wait */
       if (lock->trx != trx &&
-          !(wsrep_thd_is_BF(lock->trx->mysql_thd, false) &&
+          !(lock->trx->is_wsrep_BF() &&
             wsrep_thd_order_before(lock->trx->mysql_thd, trx->mysql_thd)))
       {
         victims.emplace(lock->trx);
@@ -978,7 +978,7 @@ func_exit:
       do
         /* if victim has also BF status, but has earlier seqno, we have to wait */
         if (lock->trx != trx &&
-            !(wsrep_thd_is_BF(lock->trx->mysql_thd, false) &&
+            !(lock->trx->is_wsrep_BF() &&
               wsrep_thd_order_before(lock->trx->mysql_thd, trx->mysql_thd)))
         {
           victims.emplace(lock->trx);
@@ -1398,8 +1398,8 @@ static void lock_rec_add_to_queue(unsigned type_mode, hash_cell_t &cell,
 		if (UNIV_LIKELY_NULL(other_lock) && trx->is_wsrep()) {
 			/* Only BF transaction may be granted lock
 			before other conflicting lock request. */
-			if (!wsrep_thd_is_BF(trx->mysql_thd, FALSE)
-			    && !wsrep_thd_is_BF(other_lock->trx->mysql_thd, FALSE)) {
+			if (!trx->is_wsrep_BF()
+			    && !other_lock->trx->is_wsrep_BF()) {
 				/* If it is not BF, this case is a bug. */
 				wsrep_report_bf_lock_wait(trx->mysql_thd, trx->id);
 				wsrep_report_bf_lock_wait(other_lock->trx->mysql_thd, other_lock->trx->id);
@@ -4828,8 +4828,8 @@ func_exit:
 				/* Only BF transaction may be granted
 				lock before other conflicting lock
 				request. */
-				if (!wsrep_thd_is_BF(lock->trx->mysql_thd, FALSE)
-				    && !wsrep_thd_is_BF(other_lock->trx->mysql_thd, FALSE)) {
+				if (!lock->trx->is_wsrep_BF()
+				    && !other_lock->trx->is_wsrep_BF()) {
 					/* If no BF, this case is a bug. */
 					wsrep_report_bf_lock_wait(lock->trx->mysql_thd, lock->trx->id);
 					wsrep_report_bf_lock_wait(other_lock->trx->mysql_thd, other_lock->trx->id);
@@ -5438,8 +5438,8 @@ lock_sec_rec_modify_check_and_lock(
 	there is a probability for lock conflicts between two wsrep
 	high priority threads. To avoid this GAP-locking we mark that
 	this transaction is using unique key scan here. */
-	if (trx->is_wsrep() && wsrep_thd_is_BF(trx->mysql_thd, false))
-		trx->wsrep = 3;
+	if (trx->is_wsrep_BF())
+		trx->wsrep_begin_UK_scan();
 #endif /* WITH_WSREP */
 
 	/* Another transaction cannot have an implicit lock on the record,
@@ -5451,7 +5451,7 @@ lock_sec_rec_modify_check_and_lock(
 			    block, heap_no, index, thr);
 
 #ifdef WITH_WSREP
-	if (trx->wsrep == 3) trx->wsrep = 1;
+	trx->wsrep_end_UK_scan();
 #endif /* WITH_WSREP */
 
 #ifdef UNIV_DEBUG
@@ -5554,15 +5554,15 @@ lock_sec_rec_read_check_and_lock(
 	there is a probability for lock conflicts between two wsrep
 	high priority threads. To avoid this GAP-locking we mark that
 	this transaction is using unique key scan here. */
-	if (trx->is_wsrep() && wsrep_thd_is_BF(trx->mysql_thd, false))
-		trx->wsrep = 3;
+	if (trx->is_wsrep_BF())
+		trx->wsrep_begin_UK_scan();
 #endif /* WITH_WSREP */
 
 	err = lock_rec_lock(false, gap_mode | mode,
 			    block, page_rec_get_heap_no(rec), index, thr);
 
 #ifdef WITH_WSREP
-	if (trx->wsrep == 3) trx->wsrep = 1;
+	trx->wsrep_end_UK_scan();
 #endif /* WITH_WSREP */
 
 	ut_ad(lock_rec_queue_validate(false, block->page.id(),
@@ -6260,7 +6260,7 @@ namespace Deadlock
       (trx->mysql_thd &&
 #ifdef WITH_WSREP
        (thd_has_edited_nontrans_tables(trx->mysql_thd) ||
-        (trx->is_wsrep() && wsrep_thd_is_BF(trx->mysql_thd, false)))
+        (trx->is_wsrep_BF()))
 #else
        thd_has_edited_nontrans_tables(trx->mysql_thd)
 #endif /* WITH_WSREP */
@@ -6295,7 +6295,7 @@ namespace Deadlock
           (next->mysql_thd &&
 #ifdef WITH_WSREP
            (thd_has_edited_nontrans_tables(next->mysql_thd) ||
-            (next->is_wsrep() && wsrep_thd_is_BF(next->mysql_thd, false)))
+            (next->is_wsrep_BF()))
 #else
            thd_has_edited_nontrans_tables(next->mysql_thd)
 #endif /* WITH_WSREP */

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1364,7 +1364,7 @@ TRANSACTIONAL_INLINE inline void trx_t::commit_in_memory(const mtr_t *mtr)
   order critical section. */
   if (wsrep)
   {
-    wsrep= false;
+    wsrep= 0;
     wsrep_commit_ordered(mysql_thd);
   }
 #endif /* WITH_WSREP */


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31062*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Thread executing wsrep transaction can't change during transaction execution. Similarly, thread executing high priority brute force (BF) transaction does not change during transaction execution. Therefore, in both cases there is no need to call server code after transaction has initialized.

InnoDB already stores information is this wsrep transaction to trx_t::wsrep and this is checked using trx->is_wsrep() function. Because, brute force transaction is always a wsrep transaction we can extend trx_t::wsrep variable so that value

0 == not wsrep transaction (and not BF)
1 == normal wsrep transaction
2 == high priority BF wsrep transaction
4 == high priority BF transaction is performing unique secondary index scan

These values can be set by calling server code on innobase_trx_init(). After that we can use trx_t::is_wsrep() and new function introduced in this patch trx_t::is_wsrep_BF(). Unique secondary index scan is determined later but it implies BF. Patch introduces new functions wsrep_begin_UK_scan() and wsrep_end_UK_scan() to handle unique secondary index scan.

This change reduces number of call to server code from InnoDB and reduces code bloat on performance critical stages like acquiring record locks. Furthermore, it simplifies code on several locations.


## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
