### PR TITLE
MDEV-30186 unintialized value where there are no test cases

### DIFF
--- a/mysql-test/mariadb-test-run.pl
+++ b/mysql-test/mariadb-test-run.pl
@@ -401,6 +401,11 @@ sub main {
 
   mtr_report("Collecting tests...");
   my $tests= collect_test_cases($opt_reorder, $opt_suites, \@opt_cases, \@opt_skip_test_list);
+  if (@$tests == 0) {
+    mtr_report("No tests to run...");
+    exit 0;
+  }
+
   mark_time_used('collect');
 
   mysql_install_db(default_mysqld(), "$opt_vardir/install.db") unless using_extern();

--- a/mysql-test/mariadb-test-run.pl
+++ b/mysql-test/mariadb-test-run.pl
@@ -145,7 +145,6 @@ my $opt_start_exit;
 my $start_only;
 my $file_wsrep_provider;
 my $num_saved_cores= 0;  # Number of core files saved in vardir/log/ so far.
-my $test_name_for_report;
 
 our @global_suppressions;
 
@@ -516,13 +515,13 @@ sub main {
   }
 
   if ( not @$completed ) {
-    if ($test_name_for_report)
-    {
-      my $tinfo = My::Test->new(name => $test_name_for_report);
-      $tinfo->{result}= 'MTR_RES_FAILED';
-      $tinfo->{comment}=' ';
-      mtr_report_test($tinfo);
-    }
+    my $test_name= mtr_grab_file($path_testlog);
+    $test_name =~ s/^CURRENT_TEST:\s//;
+    chomp($test_name);
+    my $tinfo = My::Test->new(name => $test_name);
+    $tinfo->{result}= 'MTR_RES_FAILED';
+    $tinfo->{comment}=' ';
+    mtr_report_test($tinfo);
     mtr_error("Test suite aborted");
   }
 
@@ -3741,8 +3740,8 @@ sub resfile_report_test ($) {
 sub run_testcase ($$) {
   my ($tinfo, $server_socket)= @_;
   my $print_freq=20;
-  $test_name_for_report= $tinfo->{name};
-  mtr_verbose("Running test:", $test_name_for_report);
+
+  mtr_verbose("Running test:", $tinfo->{name});
   $ENV{'MTR_TEST_NAME'} = $tinfo->{name};
   resfile_report_test($tinfo) if $opt_resfile;
 
@@ -5131,10 +5130,12 @@ sub mysqld_start ($$) {
   if (!$rc)
   {
     # Report failure about the last test case before exit
-    my $tinfo = My::Test->new(name => $test_name_for_report);
+    my $test_name= mtr_grab_file($path_current_testlog);
+    $test_name =~ s/^CURRENT_TEST:\s//;
+    my $tinfo = My::Test->new(name => $test_name);
     $tinfo->{result}= 'MTR_RES_FAILED';
     $tinfo->{failures}= 1;
-    $tinfo->{logfile}=get_log_from_proc($mysqld->{'proc'}, $test_name_for_report);
+    $tinfo->{logfile}=get_log_from_proc($mysqld->{'proc'}, $tinfo->{name});
     report_option('verbose', 1);
     mtr_report_test($tinfo);
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

As found by @LinuxJedi the use of globals here was subject to race conditions.

Replace previous fix by a solution that just tests if there are not tests and exit quickly.

## How can this PR be tested?

Per original MDEV with `-DPLUGIN_MROONGA=NO`:

```
$ mysql-test/mtr --suite=mroonga
Logging: /home/dan/repos/mariadb-server-10.6/mysql-test/mariadb-test-run.pl  --suite=mroonga
VS config: 
vardir: /home/dan/repos/build-mariadb-server-10.6/mysql-test/var
Checking leftover processes...
Removing old var directory...
Creating var directory '/home/dan/repos/build-mariadb-server-10.6/mysql-test/var'...
Checking supported features...
MariaDB Version 10.6.13-MariaDB
 - SSL connections supported
Using suites: mroonga
Collecting tests...
No tests to run...
```

For reference, 10.5 behaves as such:
```
$ mysql-test/mtr --suite=mroonga
Logging: /home/dan/repos/mariadb-server-10.5/mysql-test/mysql-test-run.pl  --suite=mroonga
VS config: 
vardir: /home/dan/repos/build-mariadb-server-10.5/mysql-test/var
Checking leftover processes...
Removing old var directory...
Creating var directory '/home/dan/repos/build-mariadb-server-10.5/mysql-test/var'...
Checking supported features...
MariaDB Version 10.5.20-MariaDB
 - SSL connections supported
Using suites: mroonga
Collecting tests...
Installing system database...

==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 16000..16019
mysql-test-run: *** ERROR: Test suite aborted

$ echo $?
1
```

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
