### PR TITLE
MDEV-21479 : Galera 4 unable to query cluster state if not primary co…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-21479.result
+++ b/mysql-test/suite/galera/r/MDEV-21479.result
@@ -1,0 +1,95 @@
+connection node_2;
+connection node_1;
+# Lets first see that we can access wsrep schema tables
+# Node1
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 from mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2
+connection node_2;
+# Node2
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2
+connection node_1;
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+SET GLOBAL wsrep_provider_options = 'pc.weight=2';
+connection node_2;
+# Desync and disconnect node_2
+SET @@global.wsrep_desync = 1;
+SET SESSION wsrep_dirty_reads=1;
+SET SESSION wsrep_sync_wait=0;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=1';
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+VARIABLE_VALUE
+non-Primary
+connection node_1;
+# Waiting until node_2 is not part of cluster anymore
+# Verify that we can access wsrep schema tables
+# Node1
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster_members;
+EXPECT_1
+1
+connection node_2;
+# Node2
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2
+connection node_2;
+# Reconnect node_2 back to cluster
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=0';
+SET wsrep_dirty_reads=0;
+SHOW STATUS LIKE 'wsrep_desync_count';
+Variable_name	Value
+wsrep_desync_count	0
+SET @@global.wsrep_desync = 0;
+CALL mtr.add_suppression("WSREP: Protocol violation. JOIN message sender (.*) is not in state transfer \\(SYNCED\\). Message ignored.");
+connection node_1;
+# Wait until both nodes are back to cluster
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+SET GLOBAL wsrep_provider_options = 'pc.weight=1';
+# Verify that we can access wsrep schema tables
+# Node1
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2
+connection node_2;
+# Node2
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2

--- a/mysql-test/suite/galera/t/MDEV-21479.test
+++ b/mysql-test/suite/galera/t/MDEV-21479.test
@@ -1,0 +1,99 @@
+#
+# MDEV-21479 : Galera 4 unable to query cluster state if not primary component
+#
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+
+--echo # Lets first see that we can access wsrep schema tables
+--echo # Node1
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 from mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+
+--connection node_2
+--echo # Node2
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+
+--connection node_1
+# Make node 1 tolerate split-brain
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=true';
+SET GLOBAL wsrep_provider_options = 'pc.weight=2';
+
+# Desync and disconnect node 2 from the PC:
+--connection node_2
+--echo # Desync and disconnect node_2
+SET @@global.wsrep_desync = 1;
+SET SESSION wsrep_dirty_reads=1;
+SET SESSION wsrep_sync_wait=0;
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=1';
+--let $wait_condition = SELECT VARIABLE_VALUE = 'non-Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+
+# Wait until node 2 disappears from the PC:
+--connection node_1
+--echo # Waiting until node_2 is not part of cluster anymore
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+
+--echo # Verify that we can access wsrep schema tables
+--echo # Node1
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster_members;
+
+--connection node_2
+#
+# Here node2 remembers old configuration even when we are non-Primary
+#
+--echo # Node2
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+
+# Reconnect node 2 to the PC:
+--connection node_2
+--echo # Reconnect node_2 back to cluster
+SET GLOBAL wsrep_provider_options = 'gmcast.isolate=0';
+SET wsrep_dirty_reads=0;
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Primary' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_status';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_ready';
+--source include/wait_condition.inc
+
+# Must return 0:
+SHOW STATUS LIKE 'wsrep_desync_count';
+
+# Resync node_2, should pass:
+SET @@global.wsrep_desync = 0;
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--source include/wait_condition.inc
+
+CALL mtr.add_suppression("WSREP: Protocol violation. JOIN message sender (.*) is not in state transfer \\(SYNCED\\). Message ignored.");
+
+--connection node_1
+--echo # Wait until both nodes are back to cluster
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+SET GLOBAL wsrep_provider_options = 'pc.ignore_sb=false';
+SET GLOBAL wsrep_provider_options = 'pc.weight=1';
+
+--echo # Verify that we can access wsrep schema tables
+--echo # Node1
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+
+--connection node_2
+--echo # Node2
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -45,6 +45,9 @@
 #include "ha_sequence.h"
 #include "sql_show.h"
 #include "opt_trace.h"
+#ifdef WITH_WSREP
+#include "wsrep_schema.h"
+#endif
 
 /* For MySQL 5.7 virtual fields */
 #define MYSQL57_GENERATED_FIELD 128
@@ -264,10 +267,14 @@ TABLE_CATEGORY get_table_category(const LEX_CSTRING *db,
   DBUG_ASSERT(name != NULL);
 
 #ifdef WITH_WSREP
-  if (my_strcasecmp(system_charset_info, db->str, "mysql") == 0 &&
-      my_strcasecmp(system_charset_info, name->str, "wsrep_streaming_log") == 0)
+  if (my_strcasecmp(system_charset_info, db->str, WSREP_SCHEMA) == 0)
   {
-    return TABLE_CATEGORY_INFORMATION;
+    if ((my_strcasecmp(system_charset_info, name->str, WSREP_STREAMING_TABLE) == 0 ||
+         my_strcasecmp(system_charset_info, name->str, WSREP_CLUSTER_TABLE) == 0 ||
+         my_strcasecmp(system_charset_info, name->str, WSREP_MEMBERS_TABLE) == 0))
+    {
+      return TABLE_CATEGORY_INFORMATION;
+    }
   }
 #endif /* WITH_WSREP */
   if (is_infoschema_db(db))

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -35,11 +35,6 @@
 #include <string>
 #include <sstream>
 
-#define WSREP_SCHEMA          "mysql"
-#define WSREP_STREAMING_TABLE "wsrep_streaming_log"
-#define WSREP_CLUSTER_TABLE   "wsrep_cluster"
-#define WSREP_MEMBERS_TABLE   "wsrep_cluster_members"
-
 const char* wsrep_sr_table_name_full= WSREP_SCHEMA "/" WSREP_STREAMING_TABLE;
 
 static const std::string wsrep_schema_str= WSREP_SCHEMA;

--- a/sql/wsrep_schema.h
+++ b/sql/wsrep_schema.h
@@ -33,6 +33,11 @@ struct TABLE_LIST;
 struct st_mysql_lex_string;
 typedef struct st_mysql_lex_string LEX_STRING;
 
+#define WSREP_SCHEMA          "mysql"
+#define WSREP_STREAMING_TABLE "wsrep_streaming_log"
+#define WSREP_CLUSTER_TABLE   "wsrep_cluster"
+#define WSREP_MEMBERS_TABLE   "wsrep_cluster_members"
+
 /** Name of the table in `wsrep_schema_str` used for storing streaming
 replication data. In an InnoDB full format, e.g. "database/tablename". */
 extern const char* wsrep_sr_table_name_full;


### PR DESCRIPTION
…mponent



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-21479*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

Set mysql.wsrep_cluster and mysql.wsrep_cluster_members as TABLE_CATEGORY_INFORMATION as mysql.wsrep_streaming_log so that they can be queried even if node is not primary component.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
