### PR TITLE
MDEV-23865 Create malloc function attribute

### DIFF
--- a/include/my_compiler.h
+++ b/include/my_compiler.h
@@ -156,6 +156,7 @@ program.  The paths leading to call of cold functions within code are
 marked as unlikely by the branch prediction mechanism.  optimize a
 rarely invoked function for size instead for speed. */
 # define ATTRIBUTE_COLD __attribute__((cold))
+# define ATTRIBUTE_MALLOC(dealloc, ptr_index) __attribute__((malloc, malloc(dealloc, ptr_index)))
 #elif defined _MSC_VER
 # define ATTRIBUTE_NORETURN __declspec(noreturn)
 # define ATTRIBUTE_NOINLINE __declspec(noinline)
@@ -166,6 +167,10 @@ rarely invoked function for size instead for speed. */
 
 #ifndef ATTRIBUTE_COLD
 # define ATTRIBUTE_COLD /* empty */
+#endif
+
+#ifndef ATTRIBUTE_MALLOC
+#define ATTRIBUTE_MALLOC(dealloc, ptr_index)
 #endif
 
 #include <my_attribute.h>

--- a/mysys/my_malloc.c
+++ b/mysys/my_malloc.c
@@ -65,6 +65,7 @@ void set_malloc_size_cb(MALLOC_SIZE_CB func)
 
   @return A pointer to the allocated memory block, or NULL on failure.
 */
+ATTRIBUTE_MALLOC(my_free, 1)
 void *my_malloc(PSI_memory_key key, size_t size, myf my_flags)
 {
   my_memory_header *mh;


### PR DESCRIPTION
Add  ATTRIBUTE_MALLOC macro.
It's only defined non-empty for gcc (for clang see [bug](https://github.com/llvm/llvm-project/issues/53152)).

For the current implementation, ATTRIBUTE_MALLOC defines both allocator and deallocator, as the only case it's used at is my_malloc/my_free pair