### PR TITLE
MDEV-30197 : Missing DBUG_RETURN or DBUG_VOID_RETURN macro in functio…

### DIFF
--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -55,7 +55,7 @@ static const std::string create_cluster_table_str=
   "view_seqno BIGINT NOT NULL,"
   "protocol_version INT NOT NULL,"
   "capabilities INT NOT NULL"
-  ") ENGINE=InnoDB STATS_PERSISTENT=0";
+  ") ENGINE=InnoDB STATS_PERSISTENT=0 CHARSET=latin1";
 
 static const std::string create_members_table_str=
   "CREATE TABLE IF NOT EXISTS " + wsrep_schema_str + "." + members_table_str +
@@ -64,7 +64,7 @@ static const std::string create_members_table_str=
   "cluster_uuid CHAR(36) NOT NULL,"
   "node_name CHAR(32) NOT NULL,"
   "node_incoming_address VARCHAR(256) NOT NULL"
-  ") ENGINE=InnoDB STATS_PERSISTENT=0";
+  ") ENGINE=InnoDB STATS_PERSISTENT=0 CHARSET=latin1";
 
 #ifdef WSREP_SCHEMA_MEMBERS_HISTORY
 static const std::string cluster_member_history_table_str= "wsrep_cluster_member_history";
@@ -77,7 +77,7 @@ static const std::string create_members_history_table_str=
   "last_view_seqno BIGINT NOT NULL,"
   "node_name CHAR(32) NOT NULL,"
   "node_incoming_address VARCHAR(256) NOT NULL"
-  ") ENGINE=InnoDB STATS_PERSISTENT=0";
+  ") ENGINE=InnoDB STATS_PERSISTENT=0 CHARSET=latin1";
 #endif /* WSREP_SCHEMA_MEMBERS_HISTORY */
 
 static const std::string create_frag_table_str=
@@ -89,7 +89,7 @@ static const std::string create_frag_table_str=
   "flags INT NOT NULL, "
   "frag LONGBLOB NOT NULL, "
   "PRIMARY KEY (node_uuid, trx_id, seqno)"
-  ") ENGINE=InnoDB STATS_PERSISTENT=0";
+  ") ENGINE=InnoDB STATS_PERSISTENT=0 CHARSET=latin1";
 
 static const std::string delete_from_cluster_table=
   "DELETE FROM " + wsrep_schema_str + "." + cluster_table_str;
@@ -101,21 +101,21 @@ static const std::string delete_from_members_table=
 persistent statistics to be collected from these tables. */
 static const std::string alter_cluster_table=
   "ALTER TABLE " + wsrep_schema_str + "." + cluster_table_str +
-  " STATS_PERSISTENT=0";
+  " STATS_PERSISTENT=0 CHARSET=latin1";
 
 static const std::string alter_members_table=
   "ALTER TABLE " + wsrep_schema_str + "." + members_table_str +
-  " STATS_PERSISTENT=0";
+  " STATS_PERSISTENT=0 CHARSET=latin1";
 
 #ifdef WSREP_SCHEMA_MEMBERS_HISTORY
 static const std::string alter_members_history_table=
   "ALTER TABLE " + wsrep_schema_str + "." + members_history_table_str +
-  " STATS_PERSISTENT=0";
+  " STATS_PERSISTENT=0 CHARSET=latin1";
 #endif
 
 static const std::string alter_frag_table=
   "ALTER TABLE " + wsrep_schema_str + "." + sr_table_str +
-  " STATS_PERSISTENT=0";
+  " STATS_PERSISTENT=0 CHARSET=latin1";
 
 namespace Wsrep_schema_impl
 {


### PR DESCRIPTION
…n "Wsrep_schema::restore_view()"

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30197*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Here user is starting server with unsupported client charset. We need to create wsrep_schema tables using explicit latin1 charset to avoid errors in restoring view.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
