### PR TITLE
MDEV-31216: Make sure that lsof does not fail on install

### DIFF
--- a/debian/mariadb-server-10.6.postinst
+++ b/debian/mariadb-server-10.6.postinst
@@ -125,10 +125,10 @@ EOF
     # This direct update is needed to enable an authentication mechanism to
     # perform mariadb-upgrade, (MDEV-22678).  To keep the impact minimal, we
     # skip innodb and set key-buffer-size to 0 as it isn't reused.
-    lsof -nt "$mysql_datadir"/mysql/user.MYD > /dev/null
-    lsof_rtn_code=$?
-    if [ -f "$mysql_datadir/auto.cnf" ] && [ -f "$mysql_datadir/mysql/user.MYD" ] &&
-    [ ! ${lsof_rtn_code} ] && [ ! -f "$mysql_datadir/undo_001" ]
+    if [ -f "$mysql_datadir/auto.cnf" ] &&
+    [ -f "$mysql_datadir/mysql/user.MYD" ] &&
+    ! lsof -nt "$mysql_datadir"/mysql/user.MYD > /dev/null &&
+    [ ! -f "$mysql_datadir/undo_001" ]
     then
       echo "UPDATE mysql.user SET plugin='unix_socket' WHERE plugin='auth_socket';" |
       mariadbd --skip-innodb --key_buffer_size=0  --default-storage-engine=MyISAM --bootstrap 2> /dev/null


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31216*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Command lsof can fail on Debian install. Revert logic more like old one to make sure that there is no failing and still does don't boundce on shellcheck.

Salsa-CI run before indent and this patch: https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/526135
Salsa-CI with indent merge and this fix: https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/526215

## How can this PR be tested?
Build package and try to install package mariadb-server and please check BB builds and Salsa-CI run.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility
This fix makes sure Backward compatibility is ensured

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
