### PR TITLE
server.cnf: adjust major version to 10.11

### DIFF
--- a/support-files/rpm/server.cnf
+++ b/support-files/rpm/server.cnf
@@ -39,8 +39,8 @@
 # you can put MariaDB-only options here
 [mariadb]
 
-# This group is only read by MariaDB-10.8 servers.
+# This group is only read by MariaDB-10.11 servers.
 # If you use the same .cnf file for MariaDB of different versions,
 # use this group for options that older servers don't understand
-[mariadb-10.8]
+[mariadb-10.11]
 


### PR DESCRIPTION
## Description
Update rpm file server.cnf to bump major version to 10.11 group.

## How can this PR be tested?
For example, adding some options for enabling SSL (ssl_key, ssl_cert, ssl_ca, ssl_cipher)

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
