### PR TITLE
MDEV-30013 : Assertion `state() == s_aborting || state() == s_must_re…

### DIFF
--- a/mysql-test/suite/galera/r/mdev-30013.result
+++ b/mysql-test/suite/galera/r/mdev-30013.result
@@ -1,0 +1,17 @@
+connection node_2;
+connection node_1;
+INSTALL PLUGIN ARCHIVE SONAME 'ha_archive.so';
+CREATE TABLE t (a CHAR(1)) ENGINE=ARCHIVE;
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` char(1) DEFAULT NULL
+) ENGINE=ARCHIVE DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+INSERT INTO t VALUES ('A');
+UNINSTALL SONAME 'ha_archive';
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown
+ALTER TABLE t CHANGE COLUMN a a CHAR(2);
+INSERT INTO t (a) VALUES ('AB');
+ERROR 42000: Unknown storage engine 'ARCHIVE'
+DROP TABLE t;

--- a/mysql-test/suite/galera/t/mdev-30013.test
+++ b/mysql-test/suite/galera/t/mdev-30013.test
@@ -1,0 +1,15 @@
+--source include/galera_cluster.inc
+
+if (!$HA_ARCHIVE_SO) {
+  skip Needs Archive loadable plugin;
+}
+
+INSTALL PLUGIN ARCHIVE SONAME 'ha_archive.so';
+CREATE TABLE t (a CHAR(1)) ENGINE=ARCHIVE;
+SHOW CREATE TABLE t;
+INSERT INTO t VALUES ('A');
+UNINSTALL SONAME 'ha_archive';
+ALTER TABLE t CHANGE COLUMN a a CHAR(2);
+--error ER_UNKNOWN_STORAGE_ENGINE
+INSERT INTO t (a) VALUES ('AB');
+DROP TABLE t;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -299,9 +299,6 @@ handlerton *ha_checktype(THD *thd, handlerton *hton, bool no_substitute)
 
   if (no_substitute)
     return NULL;
-#ifdef WITH_WSREP
-  (void)wsrep_after_rollback(thd, false);
-#endif /* WITH_WSREP */
 
   return ha_default_handlerton(thd);
 } /* ha_checktype */


### PR DESCRIPTION
…play' failed in int wsrep::transaction::after_rollback()

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30013*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
This must be some kind of merge error because at ha_check_engine we just find out used engine or default engine. There is no need to roll-back transaction here even if engine is not supported as it will be handled later.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->

## PR quality check
- [ X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
