### PR TITLE
Fix building with modern versions of LibreSSL

### DIFF
--- a/include/ssl_compat.h
+++ b/include/ssl_compat.h
@@ -62,6 +62,13 @@
 #endif /* HAVE_OPENSSL11 */
 #endif
 
+#ifdef LIBRESSL_VERSION_NUMBER
+#define EVP_MD_CTX_SIZE			64
+#define EVP_CIPHER_CTX_SIZE             192
+#define EVP_MD_CTX_init(X) do { memset((X), 0, EVP_MD_CTX_SIZE); EVP_MD_CTX_reset(X); } while(0)
+#define EVP_CIPHER_CTX_init(X) do { memset((X), 0, EVP_CIPHER_CTX_SIZE); EVP_CIPHER_CTX_reset(X); } while(0)
+#else
+
 #ifdef HAVE_WOLFSSL
 #define EVP_MD_CTX_SIZE                 sizeof(wc_Md5)
 #endif
@@ -87,6 +94,7 @@
 #define EVP_CIPHER_CTX_reset(X) EVP_CIPHER_CTX_cleanup(X)
 #define X509_get0_notBefore(X) X509_get_notBefore(X)
 #define X509_get0_notAfter(X) X509_get_notAfter(X)
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
Fix building with LibreSSL with opaque EVP_MD_CTX and EVP_CIPHER_CTX.