### PR TITLE
Fixup warnings for safe_strcpy

### DIFF
--- a/include/m_string.h
+++ b/include/m_string.h
@@ -249,13 +249,31 @@ static inline void lex_string_set3(LEX_CSTRING *lex_str, const char *c_str,
 static inline int safe_strcpy(char *dst, size_t dst_size, const char *src)
 {
   memset(dst, '\0', dst_size);
+  /*
+     Ignoring truncation, we deal with this next.
+  */
+  #if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Wstringop-truncation"
+  #endif
   strncpy(dst, src, dst_size - 1);
+  #if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+  #endif
+
   /*
      If the first condition is true, we are guaranteed to have src length
      >= (dst_size - 1), hence safe to access src[dst_size - 1].
   */
+  #if defined(__GNUC__)
+  #pragma GCC diagnostic push
+  #pragma GCC diagnostic ignored "-Warray-bounds"
+  #endif
   if (dst[dst_size - 2] != '\0' && src[dst_size - 1] != '\0')
     return 1; /* Truncation of src. */
+  #if defined(__GNUC__)
+  #pragma GCC diagnostic pop
+  #endif
   return 0;
 }
 


### PR DESCRIPTION
This fixes warnings in safe_strcpy when compiling with mysql_release build config.

## How can this PR be tested?
Compile with mysql_release config, many of the warnings in CONNECT engine go away. Then normal CI runs.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

