### PR TITLE
Remove CODEOWNERS as obsolete

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-/debian @ottok
-


### PR DESCRIPTION
The CODEOWNERS was added almost 3 years ago but never saw any adoption. Only one person used it (me) to mark what files I maintain and for which I wish to review commits. No other maintainers or code paths were added, so clean it away for clarity.
