### PR TITLE
MDEV-31335 : Create sequence can cause inconsistency

### DIFF
--- a/mysql-test/suite/galera/r/galera_sequences.result
+++ b/mysql-test/suite/galera/r/galera_sequences.result
@@ -79,30 +79,31 @@ SET SESSION autocommit=1;
 DROP SEQUENCE seq1;
 DROP SEQUENCE seq2;
 DROP TABLE t2;
+connection node_2;
 SET SESSION AUTOCOMMIT=0;
 SET SESSION wsrep_OSU_method='RSU';
 CREATE TABLE t1(c1 VARCHAR(10));
-INSERT INTO t1 (c1) VALUES('');
 create temporary sequence sq1 NOCACHE engine=innodb;
 create sequence sq2 NOCACHE engine=innodb;
 COMMIT;
+SET SESSION wsrep_OSU_method='TOI';
 SHOW CREATE SEQUENCE sq1;
 Table	Create Table
 sq1	CREATE SEQUENCE `sq1` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB
 SHOW CREATE SEQUENCE sq2;
 Table	Create Table
 sq2	CREATE SEQUENCE `sq2` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB
-connection node_2;
+connection node_1;
 SHOW CREATE SEQUENCE sq1;
 ERROR 42S02: Table 'test.sq1' doesn't exist
 SHOW CREATE SEQUENCE sq2;
 ERROR 42S02: Table 'test.sq2' doesn't exist
-connection node_1;
+connection node_2;
 SET SESSION AUTOCOMMIT=1;
 DROP TABLE t1;
 DROP SEQUENCE sq1;
 DROP SEQUENCE sq2;
-SET SESSION wsrep_OSU_method='TOI';
+connection node_1;
 CREATE TABLE t (f INT) engine=innodb;
 LOCK TABLE t WRITE;
 CREATE OR REPLACE SEQUENCE t MAXVALUE=13 INCREMENT BY 1 NOCACHE engine=innodb;

--- a/mysql-test/suite/galera/r/galera_temporary_sequences.result
+++ b/mysql-test/suite/galera/r/galera_temporary_sequences.result
@@ -1,0 +1,46 @@
+connection node_2;
+connection node_1;
+connection node_2;
+SET AUTOCOMMIT=0;
+SET SESSION wsrep_OSU_method='RSU';
+CREATE TABLE t (i int primary key, j int);
+CREATE TEMPORARY SEQUENCE seq2 NOCACHE ENGINE=InnoDB;
+COMMIT;
+SET SESSION wsrep_OSU_method='RSU';
+CREATE SEQUENCE seq1 NOCACHE ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method='TOI';
+DROP TABLE t;
+DROP SEQUENCE seq2;
+DROP SEQUENCE seq1;
+connection node_1;
+CREATE TABLE t (i int primary key, j int) ENGINE=InnoDB;
+SET AUTOCOMMIT=0;
+INSERT INTO t VALUES (3,0);
+CREATE TEMPORARY SEQUENCE seq1 NOCACHE ENGINE=InnoDB;
+COMMIT;
+INSERT INTO t VALUES (4,0);
+CREATE SEQUENCE seq2 NOCACHE ENGINE=InnoDB;
+commit;
+connection node_2;
+SELECT * FROM t;
+i	j
+3	0
+4	0
+SHOW CREATE TABLE seq1;
+ERROR 42S02: Table 'test.seq1' doesn't exist
+SHOW CREATE TABLE seq2;
+Table	Create Table
+seq2	CREATE TABLE `seq2` (
+  `next_not_cached_value` bigint(21) NOT NULL,
+  `minimum_value` bigint(21) NOT NULL,
+  `maximum_value` bigint(21) NOT NULL,
+  `start_value` bigint(21) NOT NULL COMMENT 'start value when sequences is created or value if RESTART is used',
+  `increment` bigint(21) NOT NULL COMMENT 'increment value',
+  `cache_size` bigint(21) unsigned NOT NULL,
+  `cycle_option` tinyint(1) unsigned NOT NULL COMMENT '0 if no cycles are allowed, 1 if the sequence should begin a new cycle when maximum_value is passed',
+  `cycle_count` bigint(21) NOT NULL COMMENT 'How many cycles have been done'
+) ENGINE=InnoDB SEQUENCE=1
+connection node_1;
+DROP TABLE t;
+DROP SEQUENCE seq1;
+DROP SEQUENCE seq2;

--- a/mysql-test/suite/galera/t/galera_sequences.test
+++ b/mysql-test/suite/galera/t/galera_sequences.test
@@ -72,33 +72,33 @@ DROP TABLE t2;
 #
 # Case2
 #
+--connection node_2
 SET SESSION AUTOCOMMIT=0;
 SET SESSION wsrep_OSU_method='RSU';
 CREATE TABLE t1(c1 VARCHAR(10));
-INSERT INTO t1 (c1) VALUES('');
 create temporary sequence sq1 NOCACHE engine=innodb;
 create sequence sq2 NOCACHE engine=innodb;
 COMMIT;
+SET SESSION wsrep_OSU_method='TOI';
 SHOW CREATE SEQUENCE sq1;
-SHOW CREATE SEQUENCE sq2;
---connection node_2
---error ER_NO_SUCH_TABLE
-SHOW CREATE SEQUENCE sq1;
---error ER_NO_SUCH_TABLE
 SHOW CREATE SEQUENCE sq2;
 --connection node_1
+--error ER_NO_SUCH_TABLE
+SHOW CREATE SEQUENCE sq1;
+--error ER_NO_SUCH_TABLE
+SHOW CREATE SEQUENCE sq2;
+--connection node_2
 SET SESSION AUTOCOMMIT=1;
 DROP TABLE t1;
 DROP SEQUENCE sq1;
 DROP SEQUENCE sq2;
-SET SESSION wsrep_OSU_method='TOI';
 
 #
 # MDEV-30388 Assertion `!wsrep_has_changes(thd) || (thd->lex->sql_command == SQLCOM_CREATE_TABLE
 # && !thd->is_current_stmt_binlog_format_row()) ||
 # thd->wsrep_cs().transaction().state() == wsrep::transaction::s_aborted' failed
 #
-
+--connection node_1
 CREATE TABLE t (f INT) engine=innodb;
 LOCK TABLE t WRITE;
 CREATE OR REPLACE SEQUENCE t MAXVALUE=13 INCREMENT BY 1 NOCACHE engine=innodb;

--- a/mysql-test/suite/galera/t/galera_temporary_sequences.test
+++ b/mysql-test/suite/galera/t/galera_temporary_sequences.test
@@ -1,0 +1,37 @@
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+
+--connection node_2
+SET AUTOCOMMIT=0;
+SET SESSION wsrep_OSU_method='RSU';
+CREATE TABLE t (i int primary key, j int);
+CREATE TEMPORARY SEQUENCE seq2 NOCACHE ENGINE=InnoDB;
+COMMIT;
+SET SESSION wsrep_OSU_method='RSU';
+CREATE SEQUENCE seq1 NOCACHE ENGINE=InnoDB;
+SET SESSION wsrep_OSU_method='TOI';
+DROP TABLE t;
+DROP SEQUENCE seq2;
+DROP SEQUENCE seq1;
+
+--connection node_1
+CREATE TABLE t (i int primary key, j int) ENGINE=InnoDB;
+SET AUTOCOMMIT=0;
+INSERT INTO t VALUES (3,0);
+CREATE TEMPORARY SEQUENCE seq1 NOCACHE ENGINE=InnoDB;
+COMMIT;
+INSERT INTO t VALUES (4,0);
+CREATE SEQUENCE seq2 NOCACHE ENGINE=InnoDB;
+commit;
+
+--connection node_2
+SELECT * FROM t;
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE seq1;
+SHOW CREATE TABLE seq2;
+
+
+--connection node_1
+DROP TABLE t;
+DROP SEQUENCE seq1;
+DROP SEQUENCE seq2;


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31335*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Do not start TOI for CREATE TEMPORARY SEQUENCE because object is local only and not replicated. Similarly, avoid starting RSU for TEMPORARY SEQUENCEs. Finally, we need to run commit hooks for TEMPORARY SEQUENCEs because CREATE TEMPORARY SEQUENCE does implicit commit for previous changes that need to be replicated and committed.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->


## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
