### PR TITLE
MDEV-31331: Fix cut'n'paste variable name in Debian pre-inst script

### DIFF
--- a/debian/mariadb-server-10.6.preinst
+++ b/debian/mariadb-server-10.6.preinst
@@ -224,14 +224,23 @@ then
   mkdir -Z $mysql_datadir
 fi
 
-# As preset blocksize of GNU df is 1024 then available bytes is $df_available_blocks * 1024
-# 4096 blocks is then lower than 4 MB
-df_available_blocks="$(LC_ALL=C BLOCKSIZE='' df --output=avail "$mysql_datadir" | tail -n 1)"
-if [ "$df_available_blocks" -lt "4096" ]
+# Check if MariaDB datadir is available if not fails.
+# There should be symlink or directory available or something will fail.
+if [ -d "$mysql_datadir" ] || [ -L "$mysql_datadir" ]
 then
-  echo "ERROR: There's not enough space in $mysql_datadir/" 1>&2
-  db_stop
-  exit 1
+    # As preset blocksize of GNU df is 1024 then available bytes is $df_available_blocks * 1024
+    # 4096 blocks is then lower than 4 MB
+    df_available_blocks="$(LC_ALL=C BLOCKSIZE='' df --output=avail "$mysql_datadir" | tail -n 1)"
+    if [ "$df_available_blocks" -lt "4096" ]
+    then
+      echo "ERROR: There's not enough space in $mysql_datadir/" 1>&2
+      db_stop
+      exit 1
+    fi
+else
+    echo "ERROR: There's no directory or symlink available: $mysql_datadir/" 1>&2
+    db_stop
+    exit 1    
 fi
 
 # Since the home directory was created before putting the user into


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31331*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
There is unwanted cut'n'paste variable name in Debian pre-inst script which causes:

df: '': No such file or directory
/var/lib/dpkg/tmp.ci/preinst: line 215: [: : integer expression expected

Rename variable to correct one and make check that that directory or symlink really exists. If it does not then fail with error and message.

## How can this PR be tested?
This is little bit bumpy to test one needs Debian 11 (container or real) and configure it with this one: https://mariadb.org/download/?t=repo-config&d=Debian+11+%22Bullseye%22&v=10.6&r_m=xtom_tal

after that one downloads: https://salsa.debian.org/illuusio/mariadb-server/-/jobs/4260007/artifacts/browse/debian/output/

and installs them over the installed MariaDB 10.6.13 images with
```
w3m  https://salsa.debian.org/illuusio/mariadb-server/-/jobs/4260007/artifacts/download
unzip build_10.6-MDEV-31331-df-preinst-broken.zip
cd debian/output/
dpkg -i *.deb
```
It will fail and one needs to run `sudo apt --fix-broken install` to sort that out. After that one can install mariadb-client-core and mariadb-client also mariadb-server-core and mariadb-server packages

If everything goes well there should not be error anymore.

Debian Salsa-CI run is here: https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/532995

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## Backward compatibility
This will fix cut'n'paste problem so better

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
