### PR TITLE
MDEV-31364: Adding a Github Security Policy file

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ Bug Reports
 Bug and/or error reports regarding MariaDB should be submitted at:
 https://jira.mariadb.org
 
-For reporting security vulnerabilities see:
-https://mariadb.org/about/security-policy/
+For reporting security vulnerabilities, see our [security-policy](https://github.com/diogoteles08/mariadb-server/security/policy).
 
 The code for MariaDB, including all revision history, can be found at:
 https://github.com/MariaDB/server

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Bug Reports
 Bug and/or error reports regarding MariaDB should be submitted at:
 https://jira.mariadb.org
 
-For reporting security vulnerabilities, see our [security-policy](https://github.com/diogoteles08/mariadb-server/security/policy).
+For reporting security vulnerabilities, see our [security-policy](https://mariadb.org/about/security-policy/).
 
 The code for MariaDB, including all revision history, can be found at:
 https://github.com/MariaDB/server

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+Security Policy
+=========================
+
+To report security vulnerabilities, please follow our special [security policy](https://mariadb.org/about/security-policy/). **Do not** report security issues in the public issue tracker.


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-31364*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
Please look at the Jira ticket: https://jira.mariadb.org/browse/MDEV-31364

## How can this PR be tested?

This PR only carries changes on documentation.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
