### PR TITLE
MDEV-30921: Use safe function snprintf

### DIFF
--- a/storage/perfschema/table_events_statements.cc
+++ b/storage/perfschema/table_events_statements.cc
@@ -339,9 +339,8 @@ void table_events_statements_common::make_row_part_2(const sql_digest_storage *d
       safe_byte_count <= pfs_max_digest_length)
   {
     /* Generate the DIGEST string from the MD5 digest  */
-    MD5_HASH_TO_STRING(digest->m_md5,
-                       m_row.m_digest.m_digest);
-    m_row.m_digest.m_digest_length= MD5_HASH_TO_STRING_LENGTH;
+    m_row.m_digest.m_digest_length= md5_hash_to_string(digest->m_md5,
+                                                       m_row.m_digest.m_digest);
 
     /* Generate the DIGEST_TEXT string from the token array */
     compute_digest_text(digest, &m_row.m_digest.m_digest_text);

--- a/storage/perfschema/table_helper.cc
+++ b/storage/perfschema/table_helper.cc
@@ -132,8 +132,7 @@ int PFS_digest_row::make_row(PFS_statements_digest_stat* pfs)
       Calculate digest from MD5 HASH collected to be shown as
       DIGEST in this row.
     */
-    MD5_HASH_TO_STRING(pfs->m_digest_storage.m_md5, m_digest);
-    m_digest_length= MD5_HASH_TO_STRING_LENGTH;
+    m_digest_length= md5_hash_to_string(pfs->m_digest_storage.m_md5, m_digest);
 
     /*
       Calculate digest_text information from the token array collected

--- a/storage/perfschema/table_helper.h
+++ b/storage/perfschema/table_helper.h
@@ -34,15 +34,18 @@
   Write MD5 hash value in a string to be used 
   as DIGEST for the statement.
 */
-#define MD5_HASH_TO_STRING(_hash, _str)                    \
-  sprintf(_str, "%02x%02x%02x%02x%02x%02x%02x%02x"         \
-                "%02x%02x%02x%02x%02x%02x%02x%02x",        \
-          _hash[0], _hash[1], _hash[2], _hash[3],          \
-          _hash[4], _hash[5], _hash[6], _hash[7],          \
-          _hash[8], _hash[9], _hash[10], _hash[11],        \
-          _hash[12], _hash[13], _hash[14], _hash[15])
 
-#define MD5_HASH_TO_STRING_LENGTH 32
+static inline int md5_hash_to_string(const unsigned char *_hash, char *_str)
+{
+  const size_t hash_size = 32; //hash size is always 32, 
+                               //we assume _str passed to the function is >= 33 bytes
+  int res = snprintf(_str, hash_size, 
+  "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x", 
+  _hash[0], _hash[1], _hash[2], _hash[3], _hash[4],
+  _hash[5], _hash[6], _hash[7], _hash[8], _hash[9],
+  _hash[10], _hash[11], _hash[12], _hash[13], _hash[14], _hash[15]);
+  return res;
+}
 
 struct PFS_host;
 struct PFS_user;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30921*

## Description
Replace unsafe usage of sprintf() with snprintf in storage/perfschema/table_helper.h and replace macro with inline function to make code safer and fix MDEV-30921

## How can this PR be tested?
All build stages pass for these commits.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

## Backward compatibility
The changes are fully backward compatible.
