### PR TITLE
MDEV-29894: Calling a function from a different database in a slave side trigger crashes

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_row_trigger_multi_db.result
+++ b/mysql-test/suite/rpl/r/rpl_row_trigger_multi_db.result
@@ -1,0 +1,60 @@
+include/master-slave.inc
+[connection master]
+connection slave;
+set global slave_run_triggers_for_rbr=1;
+connection master;
+CREATE TABLE t1 (a int);
+connection slave;
+connection slave;
+CREATE DATABASE db2;
+CREATE FUNCTION db2.get_value(a INT) RETURNS int(2)  RETURN 0;
+#
+# Test Insert_rows_log_event
+connection slave;
+CREATE TRIGGER tr_ins BEFORE INSERT ON t1 FOR EACH ROW BEGIN
+DECLARE a INT;
+SET a = db2.get_value(1);
+END//
+connection master;
+INSERT INTO t1 VALUES (1);
+connection slave;
+connection slave;
+DROP TRIGGER tr_ins;
+#
+# Test Update_rows_log_event
+connection master;
+INSERT INTO t1 VALUES (5);
+connection slave;
+connection slave;
+CREATE TRIGGER tr_upd BEFORE UPDATE ON t1 FOR EACH ROW BEGIN
+DECLARE a INT;
+SET a = db2.get_value(1);
+END//
+connection master;
+UPDATE t1 SET a=a+1 WHERE a=5;
+connection slave;
+connection slave;
+DROP TRIGGER tr_upd;
+#
+# Test Delete_rows_log_event
+connection master;
+INSERT INTO t1 VALUES (7);
+connection slave;
+connection slave;
+CREATE TRIGGER tr_del BEFORE DELETE ON t1 FOR EACH ROW BEGIN
+DECLARE a INT;
+SET a = db2.get_value(1);
+END//
+connection master;
+DELETE FROM t1 WHERE a=7;
+connection slave;
+connection slave;
+DROP TRIGGER tr_del;
+#
+# Cleanup
+connection slave;
+SET GLOBAL slave_run_triggers_for_rbr=NO;
+DROP DATABASE db2;
+connection master;
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_row_trigger_multi_db.test
+++ b/mysql-test/suite/rpl/t/rpl_row_trigger_multi_db.test
@@ -1,0 +1,98 @@
+#
+#   This test ensures that a table share's database name is not freed when
+# using row based replication with triggers that open different databases
+#
+#
+# References:
+#   MDEV-29894: Calling a function from a different database in a slave side
+#               trigger crashes
+#
+--source include/master-slave.inc
+--source include/have_binlog_format_row.inc
+
+--connection slave
+--let $old_slave_run_triggers= `SELECT @@global.slave_run_triggers_for_rbr`
+set global slave_run_triggers_for_rbr=1;
+
+--connection master
+CREATE TABLE t1 (a int);
+--sync_slave_with_master
+
+--connection slave
+CREATE DATABASE db2;
+CREATE FUNCTION db2.get_value(a INT) RETURNS int(2)  RETURN 0;
+
+--echo #
+--echo # Test Insert_rows_log_event
+
+--connection slave
+DELIMITER //;
+CREATE TRIGGER tr_ins BEFORE INSERT ON t1 FOR EACH ROW BEGIN
+DECLARE a INT;
+SET a = db2.get_value(1);
+END//
+DELIMITER ;//
+
+--connection master
+INSERT INTO t1 VALUES (1);
+--sync_slave_with_master
+
+--connection slave
+DROP TRIGGER tr_ins;
+
+
+--echo #
+--echo # Test Update_rows_log_event
+--connection master
+--let $row_val=5
+--eval INSERT INTO t1 VALUES ($row_val)
+--sync_slave_with_master
+
+--connection slave
+DELIMITER //;
+CREATE TRIGGER tr_upd BEFORE UPDATE ON t1 FOR EACH ROW BEGIN
+DECLARE a INT;
+SET a = db2.get_value(1);
+END//
+DELIMITER ;//
+
+--connection master
+--eval UPDATE t1 SET a=a+1 WHERE a=$row_val
+--sync_slave_with_master
+
+--connection slave
+DROP TRIGGER tr_upd;
+
+
+--echo #
+--echo # Test Delete_rows_log_event
+--connection master
+--let $row_val=7
+--eval INSERT INTO t1 VALUES ($row_val)
+--sync_slave_with_master
+
+--connection slave
+DELIMITER //;
+CREATE TRIGGER tr_del BEFORE DELETE ON t1 FOR EACH ROW BEGIN
+DECLARE a INT;
+SET a = db2.get_value(1);
+END//
+DELIMITER ;//
+
+--connection master
+--eval DELETE FROM t1 WHERE a=$row_val
+--sync_slave_with_master
+
+--connection slave
+DROP TRIGGER tr_del;
+
+
+--echo #
+--echo # Cleanup
+--connection slave
+--eval SET GLOBAL slave_run_triggers_for_rbr=$old_slave_run_triggers
+DROP DATABASE db2;
+--connection master
+DROP TABLE t1;
+
+--source include/rpl_end.inc

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -5188,6 +5188,51 @@ protected:
   uint      m_key_nr;   /* Key number */
   bool master_had_triggers;     /* set after tables opening */
 
+  /*
+    RAII helper class to automatically handle the override/restore of thd->db
+    when applying row events, so it will be visible in SHOW PROCESSLIST.
+
+    If triggers will be invoked, their logic frees the current thread's db,
+    so we use set_db() to use a copy of the table share's database.
+
+    If not using triggers, the db is never freed, and we can reference the
+    same memory owned by the table share.
+  */
+  class Db_restore_ctx
+  {
+  private:
+    THD *thd;
+    LEX_CSTRING restore_db;
+    bool db_copied;
+
+    Db_restore_ctx(Rows_log_event *rev)
+        : thd(rev->thd), restore_db(rev->thd->db)
+    {
+      TABLE *table= rev->m_table;
+
+      if (table->triggers && rev->do_invoke_trigger())
+      {
+        thd->reset_db(&null_clex_str);
+        thd->set_db(&table->s->db);
+        db_copied= true;
+      }
+      else
+      {
+        thd->reset_db(&table->s->db);
+        db_copied= false;
+      }
+    }
+
+    ~Db_restore_ctx()
+    {
+      if (db_copied)
+        thd->set_db(&null_clex_str);
+      thd->reset_db(&restore_db);
+    }
+
+    friend class Rows_log_event;
+  };
+
   int find_key(); // Find a best key to use in find_row()
   int find_row(rpl_group_info *);
   int write_row(rpl_group_info *, const bool);


### PR DESCRIPTION
When opening and locking tables, if triggers will be invoked in a
separate database, thd->set_db() is invoked, thus frees the memory
and headers which thd->db had previously pointed to. In row based
replication, the event execution logic initializes thd->db to point
to the database which the event targets, which is owned by the
corresponding table share. The problem then, is that during the
table opening and locking process for a row event, memory which
belongs to the table share would be freed, which is not valid.

This patch replaces the thd->reset_db() calls to thd->set_db(),
which copies-by-value, rather than by reference. Then when the
memory is freed, our copy of memory is freed, rather than memory
which belongs to a table share.

Additionally, the function backup_current_db_name() from sql_db.cc
is exposed for use in replication.

Note for review: an alternative approach would be to use the
functions already exposed in sql_db.cc: mysql_opt_change_db()
and mysql_change_db(); however, mysql_change_db() has the following
comment:

/*
...
  This function is not the only way to switch the database that is
  currently employed. When the replication slave thread switches the
  database before executing a query, it calls thd->set_db directly.
  However, if the query, in turn, uses a stored routine, the stored routine
  will use this function, even if it's run on the slave.
...
*/

and so I kept the logic as-is for now for consistency.


The first commit in this PR is the MTR regression test which shows
the problem, and the second commit is the code patch.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_____*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to
behave as intended. Consult the documentation on
["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
In many cases, this will be as simple as modifying one `.test` and one `.result`
file in the `mysql-test/` subdirectory. Without _automated_ tests, future regressions
in the expected behavior can't be automatically detected and verified.

If the changes are not amenable to automated testing, please explain why not and
carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
(Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->
## Backward compatibility
TODO: fill details here, if applicable, or remove the section

## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
