### PR TITLE
Fix random InnoDB MSAN failures

### DIFF
--- a/storage/innobase/buf/buf0buddy.cc
+++ b/storage/innobase/buf/buf0buddy.cc
@@ -100,6 +100,9 @@ buf_buddy_mem_invalid(
 Check if a buddy is stamped free.
 @return whether the buddy is free */
 UNIV_INLINE MY_ATTRIBUTE((warn_unused_result))
+#if __has_feature(memory_sanitizer)
+__attribute__((no_sanitize("memory")))
+#endif
 bool
 buf_buddy_stamp_is_free(
 /*====================*/


### PR DESCRIPTION
This is difficult to trigger, but is a false positive that will fire on certain InnoDB tests in MSAN depending on several random factors.

The hit is a false-positive and there is already a code comment indicating this.

Patch was written by Marko and tested by Andrew.

## How can this PR be tested?

Running MSAN buildbot many times over. Appears to be easier to trigger on the older Ubuntu MSAN builder, but I'm able to trigger it locally on using the Debian builder.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
