### PR TITLE
MDEV-31242: Make sure every Debian post/pre script is using bash

### DIFF
--- a/debian/mariadb-common.postinst
+++ b/debian/mariadb-common.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/debian/mariadb-common.postrm
+++ b/debian/mariadb-common.postrm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/debian/mariadb-plugin-mroonga.postinst
+++ b/debian/mariadb-plugin-mroonga.postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/debian/mariadb-plugin-mroonga.prerm
+++ b/debian/mariadb-plugin-mroonga.prerm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/debian/mariadb-server.preinst
+++ b/debian/mariadb-server.preinst
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # summary of how this script can be called:
 #        * <new-preinst> install
@@ -6,6 +6,8 @@
 #        * <new-preinst> upgrade <old-version>
 #        * <old-preinst> abort-upgrade <new-version>
 #
+
+set -e
 
 # shellcheck source=/dev/null
 . /usr/share/debconf/confmodule

--- a/debian/mariadb-server.prerm
+++ b/debian/mariadb-server.prerm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 #DEBHELPER#


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31242*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Make sure that every Debian post and prescript are using bash and have set -e in next to shebang. Commands set -e makes sure that if script fails in one command it will fail whole script.

## How can this PR be tested?
As Salsa-CI on 11.2 in currently broken and this has to be tested by hand:

```
debian/autobake-debs.sh
dpkg -i ../*.deb
```
If everything goes well it should be ok as most of the people had sh either zsh or bash. Now we just want to use Bash as it makes testing easier.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
