### PR TITLE
MDEV-31173 : Server crashes when setting wsrep_cluster_address after …

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_schema_detached.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_schema_detached.result
@@ -1,0 +1,27 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_1;
+call mtr.add_suppression("WSREP: async IST sender failed to serve.*");
+SET @wsrep_provider_options_orig = @@GLOBAL.wsrep_provider_options;
+connection node_2;
+SET @wsrep_cluster_address_orig = @@GLOBAL.wsrep_cluster_address;
+SET GLOBAL WSREP_ON=0;
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2
+connection node_1;
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=true';
+connection node_2;
+Killing server ...
+connection node_1;
+connection node_2;
+connection node_1;
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=false';

--- a/mysql-test/suite/galera/t/galera_wsrep_schema_detached.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_schema_detached.test
@@ -1,0 +1,39 @@
+--source include/galera_cluster.inc
+
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--source include/auto_increment_offset_save.inc
+
+--connection node_1
+call mtr.add_suppression("WSREP: async IST sender failed to serve.*");
+SET @wsrep_provider_options_orig = @@GLOBAL.wsrep_provider_options;
+
+--connection node_2
+SET @wsrep_cluster_address_orig = @@GLOBAL.wsrep_cluster_address;
+SET GLOBAL WSREP_ON=0;
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+
+--connection node_1
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=true';
+
+--connection node_2
+--source include/kill_galera.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+--connection node_2
+--source include/start_mysqld.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=false';
+
+# Cleanup
+--source include/auto_increment_offset_restore.inc

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -266,17 +266,6 @@ TABLE_CATEGORY get_table_category(const LEX_CSTRING *db,
   DBUG_ASSERT(db != NULL);
   DBUG_ASSERT(name != NULL);
 
-#ifdef WITH_WSREP
-  if (my_strcasecmp(system_charset_info, db->str, WSREP_SCHEMA) == 0)
-  {
-    if ((my_strcasecmp(system_charset_info, name->str, WSREP_STREAMING_TABLE) == 0 ||
-         my_strcasecmp(system_charset_info, name->str, WSREP_CLUSTER_TABLE) == 0 ||
-         my_strcasecmp(system_charset_info, name->str, WSREP_MEMBERS_TABLE) == 0))
-    {
-      return TABLE_CATEGORY_INFORMATION;
-    }
-  }
-#endif /* WITH_WSREP */
   if (is_infoschema_db(db))
     return TABLE_CATEGORY_INFORMATION;
 
@@ -297,6 +286,17 @@ TABLE_CATEGORY get_table_category(const LEX_CSTRING *db,
     if (lex_string_eq(&TRANSACTION_REG_NAME, name))
       return TABLE_CATEGORY_LOG;
   }
+#ifdef WITH_WSREP
+  if (lex_string_eq(&WSREP_LEX_SCHEMA, db))
+  {
+    if(lex_string_eq(&WSREP_LEX_STREAMING, name))
+      return TABLE_CATEGORY_INFORMATION;
+    if (lex_string_eq(&WSREP_LEX_CLUSTER, name))
+      return TABLE_CATEGORY_INFORMATION;
+    if (lex_string_eq(&WSREP_LEX_MEMBERS, name))
+      return TABLE_CATEGORY_INFORMATION;
+  }
+#endif /* WITH_WSREP */
 
   return TABLE_CATEGORY_USER;
 }

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2021 Codership Oy <info@codership.com>
+/* Copyright (C) 2015-2023 Codership Oy <info@codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -34,6 +34,16 @@
 
 #include <string>
 #include <sstream>
+
+#define WSREP_SCHEMA          "mysql"
+#define WSREP_STREAMING_TABLE "wsrep_streaming_log"
+#define WSREP_CLUSTER_TABLE   "wsrep_cluster"
+#define WSREP_MEMBERS_TABLE   "wsrep_cluster_members"
+
+LEX_CSTRING WSREP_LEX_SCHEMA= {STRING_WITH_LEN(WSREP_SCHEMA)};
+LEX_CSTRING WSREP_LEX_STREAMING= {STRING_WITH_LEN(WSREP_STREAMING_TABLE)};
+LEX_CSTRING WSREP_LEX_CLUSTER= {STRING_WITH_LEN(WSREP_CLUSTER_TABLE)};
+LEX_CSTRING WSREP_LEX_MEMBERS= {STRING_WITH_LEN(WSREP_MEMBERS_TABLE)};
 
 const char* wsrep_sr_table_name_full= WSREP_SCHEMA "/" WSREP_STREAMING_TABLE;
 

--- a/sql/wsrep_schema.h
+++ b/sql/wsrep_schema.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2015-2019 Codership Oy <info@codership.com>
+/* Copyright (C) 2015-2023 Codership Oy <info@codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -32,11 +32,6 @@ struct TABLE;
 struct TABLE_LIST;
 struct st_mysql_lex_string;
 typedef struct st_mysql_lex_string LEX_STRING;
-
-#define WSREP_SCHEMA          "mysql"
-#define WSREP_STREAMING_TABLE "wsrep_streaming_log"
-#define WSREP_CLUSTER_TABLE   "wsrep_cluster"
-#define WSREP_MEMBERS_TABLE   "wsrep_cluster_members"
 
 /** Name of the table in `wsrep_schema_str` used for storing streaming
 replication data. In an InnoDB full format, e.g. "database/tablename". */
@@ -145,5 +140,10 @@ class Wsrep_schema
 };
 
 extern Wsrep_schema* wsrep_schema;
+
+extern LEX_CSTRING WSREP_LEX_SCHEMA;
+extern LEX_CSTRING WSREP_LEX_STREAMING;
+extern LEX_CSTRING WSREP_LEX_CLUSTER;
+extern LEX_CSTRING WSREP_LEX_MEMBERS;
 
 #endif /* !WSREP_SCHEMA_H */


### PR DESCRIPTION
…adding invalid value to wsrep_allowlist table


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31173*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Problem was that wsrep_schema tables were not marked as category information. Fix allows access to wsrep_schema tables even when node is detached.

This is 10.4-10.9 version of fix.


## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
