### PR TITLE
[MDEV-15935] Connection redirection mechanism

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -248,7 +248,8 @@ static my_bool ignore_errors=0,wait_flag=0,quick=0,
                default_pager_set= 0, opt_sigint_ignore= 0,
                auto_vertical_output= 0, show_query_cost= 0,
                show_warnings= 0, executing_query= 0,
-               ignore_spaces= 0, opt_binhex= 0, opt_progress_reports;
+               ignore_spaces= 0, opt_binhex= 0, opt_progress_reports,
+               opt_follow_server_redirects= 1;
 static my_bool debug_info_flag, debug_check_flag, batch_abort_on_error;
 static my_bool column_types_flag;
 static my_bool preserve_comments= 0;
@@ -1508,6 +1509,8 @@ static bool do_connect(MYSQL *mysql, const char *host, const char *user,
   mysql_options(mysql,MYSQL_OPT_SSL_VERIFY_SERVER_CERT,
                 (char*)&opt_ssl_verify_server_cert);
 #endif
+  mysql_options(mysql,MARIADB_OPT_FOLLOW_SERVER_REDIRECTS,
+                (char*)&opt_follow_server_redirects);
   if (opt_protocol)
     mysql_options(mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
   if (opt_plugin_dir && *opt_plugin_dir)
@@ -1770,6 +1773,11 @@ static struct my_option my_long_options[] =
    &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR_ALLOC,
    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #include "sslopt-longopts.h"
+  {"follow-server-redirects", 0,
+   "Follow server redirects. Disable with "
+   "--disable-follow-server-redirects. This option is enabled by default.",
+   &opt_follow_server_redirects, &opt_follow_server_redirects,
+   0, GET_BOOL, OPT_ARG, 1, 0, 0, 0, 0, 0},
   {"table", 't', "Output in table format.", &output_tables,
    &output_tables, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"tee", OPT_TEE,

--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -288,6 +288,9 @@ enum enum_indicator_type
 /* Do not resend metadata for prepared statements, since 10.6*/
 #define MARIADB_CLIENT_CACHE_METADATA (1ULL << 36)
 
+/* Server doesn't improperly read the pre-TLS dummy packet beyond the initial 2 bytes */
+#define CLIENT_CAN_SEND_DUMMY_HANDSHAKE_PACKET (1ULL << 37)
+
 #ifdef HAVE_COMPRESS
 #define CAN_CLIENT_COMPRESS CLIENT_COMPRESS
 #else

--- a/mysql-test/main/ssl_7937,nossl.result
+++ b/mysql-test/main/ssl_7937,nossl.result
@@ -3,15 +3,13 @@ select if(variable_value > '','yes','no') as 'have_ssl'
   from information_schema.session_status
 where variable_name='ssl_cipher';
 mysql --ssl-ca=cacert.pem -e "call test.have_ssl()"
-have_ssl
-no
+ERROR 2026 (HY000): Client requires TLS/SSL, but the server does not support it
 mysql --ssl -e "call test.have_ssl()"
-have_ssl
-no
+ERROR 2026 (HY000): Client requires TLS/SSL, but the server does not support it
 mysql --ssl-ca=cacert.pem --ssl-verify-server-cert -e "call test.have_ssl()"
-ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it
+ERROR 2026 (HY000): Client requires TLS/SSL, but the server does not support it
 mysql --ssl --ssl-verify-server-cert -e "call test.have_ssl()"
-ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it
+ERROR 2026 (HY000): Client requires TLS/SSL, but the server does not support it
 #
 # MDEV-27105 --ssl option set as default for mariadb CLI
 #

--- a/mysql-test/main/ssl_7937.test
+++ b/mysql-test/main/ssl_7937.test
@@ -20,6 +20,13 @@ create procedure have_ssl()
 --echo mysql --ssl-ca=cacert.pem --ssl-verify-server-cert -e "call test.have_ssl()"
 --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-verify-server-cert -e "call test.have_ssl()" 2>&1
 
+# The replace_regex below replaces
+# "self signed certificate in certificate chain" with "Failed to verify the server certificate"
+#
+# This replacement was added in 6484288cd260cc9ad34d93a35502e66c034f01a7, and it
+# is intended to paper over a difference between various versions of OpenSSL (and its derivatives)
+# in terms of exactly what error message is printed in case of a TLS error caused by a
+# self-signed certificate.
 --echo mysql --ssl --ssl-verify-server-cert -e "call test.have_ssl()"
 --replace_regex /TLS\/SSL error.*certificate[^\n]*/TLS\/SSL error: Failed to verify the server certificate/
 --exec $MYSQL --ssl --ssl-verify-server-cert -e "call test.have_ssl()" 2>&1

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1504,6 +1504,12 @@ static Atomic_counter<uint> extra_connection_count;
 
 my_bool opt_gtid_strict_mode= FALSE;
 
+/**
+ Server redirect
+ */
+
+const char *server_redirect_target = NullS;
+ulong server_redirect_mode= SERVER_REDIRECT_MODE_OFF;
 
 /* Function declarations */
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -995,6 +995,14 @@ extern ulong opt_binlog_dbug_fsync_sleep;
 extern uint volatile global_disable_checkpoint;
 extern my_bool opt_help;
 
+extern const char *server_redirect_target;
+enum enum_server_redirect_mode {
+    SERVER_REDIRECT_MODE_OFF = 0,
+    SERVER_REDIRECT_MODE_ON = 1,
+    SERVER_REDIRECT_MODE_ALL = 2
+};
+extern ulong server_redirect_mode;
+
 extern int mysqld_main(int argc, char **argv);
 
 #ifdef _WIN32

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -10786,3 +10786,7 @@ ER_JSON_SCHEMA_KEYWORD_UNSUPPORTED
         eng "%s keyword is not supported"
 ER_EVENTS_NO_ACL
         eng "Event scheduler cannot function with --skip-grant-tables, --bootstrap, or embedded build"
+ER_SERVER_REDIRECT
+        eng "|Server is redirecting clients to '%1$s'|%1$s"
+        fra "|Ce serveur rédirige ses clients vers '%1$s'|%1$s"
+        spa "|Este servidor redirige sus clientes hacia '%1$s'|%1$s"

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -13248,6 +13248,8 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio,
   char scramble_buf[SCRAMBLE_LENGTH];
   char *end= buff;
   DBUG_ENTER("send_server_handshake_packet");
+  DBUG_PRINT("info", ("send_server_handshake STARTING: vio_type=%s",
+                      safe_vio_type_name(thd->net.vio)));
 
   *end++= protocol_version;
 
@@ -13736,10 +13738,13 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
   THD *thd= mpvio->auth_info.thd;
   NET *net= &thd->net;
   char *end;
+  DBUG_ENTER("parse_client_handshake_packet");
   DBUG_ASSERT(mpvio->status == MPVIO_EXT::FAILURE);
+  DBUG_PRINT("info", ("parse_client_handshake STARTING: vio_type=%s",
+                      safe_vio_type_name(thd->net.vio)));
 
   if (pkt_len < MIN_HANDSHAKE_SIZE)
-    return packet_error;
+    DBUG_RETURN(packet_error);
 
   /*
     Protocol buffer is guaranteed to always end with \0. (see my_net_read())
@@ -13752,7 +13757,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
   if (client_capabilities & CLIENT_PROTOCOL_41)
   {
     if (pkt_len < 32)
-      return packet_error;
+      DBUG_RETURN(packet_error);
     client_capabilities|= ((ulong) uint2korr(net->read_pos+2)) << 16;
     if (!(client_capabilities & CLIENT_MYSQL))
     {
@@ -13774,7 +13779,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
 
     /* Do the SSL layering. */
     if (!ssl_acceptor_fd)
-      return packet_error;
+      DBUG_RETURN(packet_error);
 
     DBUG_PRINT("info", ("IO layer change in progress..."));
     mysql_rwlock_rdlock(&LOCK_ssl_refresh);
@@ -13785,8 +13790,11 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
     if(ssl_ret)
     {
       DBUG_PRINT("error", ("Failed to accept new SSL connection"));
-      return packet_error;
+      DBUG_RETURN(packet_error);
     }
+
+    DBUG_PRINT("info", ("Immediately following IO layer change: vio_type=%s",
+                        safe_vio_type_name(thd->net.vio)));
 
     DBUG_PRINT("info", ("Reading user information over SSL layer"));
     pkt_len= my_net_read(net);
@@ -13794,7 +13802,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
     {
       DBUG_PRINT("error", ("Failed to read user information (pkt_len= %lu)",
 			   pkt_len));
-      return packet_error;
+      DBUG_RETURN(packet_error);
     }
   }
 
@@ -13803,19 +13811,19 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
     thd->max_client_packet_length= uint4korr(net->read_pos+4);
     DBUG_PRINT("info", ("client_character_set: %d", (uint) net->read_pos[8]));
     if (thd_init_client_charset(thd, (uint) net->read_pos[8]))
-      return packet_error;
+      DBUG_RETURN(packet_error);
     end= (char*) net->read_pos+32;
   }
   else
   {
     if (pkt_len < 5)
-      return packet_error;
+      DBUG_RETURN(packet_error);
     thd->max_client_packet_length= uint3korr(net->read_pos+2);
     end= (char*) net->read_pos+5;
   }
 
   if (end >= (char*) net->read_pos+ pkt_len +2)
-    return packet_error;
+    DBUG_RETURN(packet_error);
 
   if (thd->client_capabilities & CLIENT_IGNORE_SPACE)
     thd->variables.sql_mode|= MODE_IGNORE_SPACE;
@@ -13823,7 +13831,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
     thd->variables.net_wait_timeout= thd->variables.net_interactive_timeout;
 
   if (end >= (char*) net->read_pos+ pkt_len +2)
-    return packet_error;
+    DBUG_RETURN(packet_error);
 
   if ((thd->client_capabilities & CLIENT_TRANSACTIONS) &&
       opt_using_transactions)
@@ -13858,7 +13866,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
     len= safe_net_field_length_ll((uchar**)&passwd,
                                       net->read_pos + pkt_len - (uchar*)passwd);
     if (len > pkt_len)
-      return packet_error;
+      DBUG_RETURN(packet_error);
   }
 
   passwd_len= (size_t)len;
@@ -13867,7 +13875,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
 
   if (passwd == NULL ||
       passwd + passwd_len + MY_TEST(db) > (char*) net->read_pos + pkt_len)
-    return packet_error;
+    DBUG_RETURN(packet_error);
 
   /* strlen() can't be easily deleted without changing protocol */
   db_len= safe_strlen(db);
@@ -13882,7 +13890,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
   if (unlikely(thd->copy_with_error(system_charset_info,
                                     (LEX_STRING*) &mpvio->db,
                                     thd->charset(), db, db_len)))
-    return packet_error;
+    DBUG_RETURN(packet_error);
 
   user_len= copy_and_convert(user_buff, sizeof(user_buff) - 1,
                              system_charset_info, user, user_len,
@@ -13909,7 +13917,7 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
 
   my_free(const_cast<char*>(sctx->user));
   if (!(sctx->user= my_strndup(key_memory_MPVIO_EXT_auth_info, user, user_len, MYF(MY_WME))))
-    return packet_error; /* The error is set by my_strdup(). */
+    DBUG_RETURN(packet_error); /* The error is set by my_strdup(). */
 
 
   /*
@@ -13923,12 +13931,12 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
   {
     // if mysqld's been started with --skip-grant-tables option
     mpvio->status= MPVIO_EXT::SUCCESS;
-    return packet_error;
+    DBUG_RETURN(packet_error);
   }
 
   thd->password= passwd_len > 0;
   if (find_mpvio_user(mpvio))
-    return packet_error;
+    DBUG_RETURN(packet_error);
 
   if ((thd->client_capabilities & CLIENT_PLUGIN_AUTH) &&
       (client_plugin < (char *)net->read_pos + pkt_len))
@@ -13993,16 +14001,17 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
     if (send_plugin_request_packet(mpvio,
                                    (uchar*) mpvio->cached_server_packet.pkt,
                                    mpvio->cached_server_packet.pkt_len))
-      return packet_error;
+      DBUG_RETURN(packet_error);
 
     passwd_len= my_net_read(&thd->net);
     passwd= (char*)thd->net.read_pos;
   }
 
   *buff= (uchar*) passwd;
-  return (ulong)passwd_len;
+  DBUG_RETURN((ulong)passwd_len);
 #else
-  return 0;
+  DBUG_ENTER("parse_client_handshake_packet (EMPTY STUB)");
+  DBUG_RETURN(0);
 #endif
 }
 
@@ -14023,6 +14032,8 @@ static int server_mpvio_write_packet(MYSQL_PLUGIN_VIO *param,
   MPVIO_EXT *mpvio= (MPVIO_EXT *) param;
   int res;
   DBUG_ENTER("server_mpvio_write_packet");
+  DBUG_PRINT("info", ("server_mpvio_write_packet STARTING: vio_type=%s",
+                      safe_vio_type_name(mpvio->auth_info.thd->net.vio)));
 
   /* reset cached_client_reply */
   mpvio->cached_client_reply.pkt= 0;
@@ -14069,6 +14080,9 @@ static int server_mpvio_read_packet(MYSQL_PLUGIN_VIO *param, uchar **buf)
   MYSQL_SERVER_AUTH_INFO * const ai= &mpvio->auth_info;
   ulong pkt_len;
   DBUG_ENTER("server_mpvio_read_packet");
+  DBUG_PRINT("info", ("server_mpvio_read_packet STARTING: vio_type=%s",
+                      safe_vio_type_name(mpvio->auth_info.thd->net.vio)));
+
   if (mpvio->status == MPVIO_EXT::RESTART)
   {
     const char *client_auth_plugin=
@@ -14146,6 +14160,8 @@ done:
   ai->auth_string_length= (ulong) mpvio->acl_user->auth[mpvio->curr_auth].salt.length;
   strmake_buf(ai->authenticated_as, mpvio->acl_user->user.str);
 
+  DBUG_PRINT("info", ("server_mpvio_read_packet FINISHING: vio_type=%s",
+                      safe_vio_type_name(mpvio->auth_info.thd->net.vio)));
   DBUG_RETURN((int)pkt_len);
 
 err:
@@ -14154,6 +14170,8 @@ err:
     if (!ai->thd->is_error())
       my_error(ER_HANDSHAKE_ERROR, MYF(0));
   }
+  DBUG_PRINT("info", ("server_mpvio_read_packet FINISHING WITH ERROR: vio_type=%s",
+                      safe_vio_type_name(mpvio->auth_info.thd->net.vio)));
   DBUG_RETURN(-1);
 }
 
@@ -14303,18 +14321,26 @@ static int do_auth_once(THD *thd, const LEX_CSTRING *auth_plugin_name,
   bool unlock_plugin= false;
   plugin_ref plugin= get_auth_plugin(thd, *auth_plugin_name, &unlock_plugin);
 
+  DBUG_ENTER("do_auth_once");
+  DBUG_PRINT("info", ("do_auth_once STARTING: vio_type=%s",
+                      safe_vio_type_name(thd->net.vio)));
   mpvio->plugin= plugin;
   mpvio->auth_info.user_name= NULL;
 
   if (plugin)
   {
     st_mysql_auth *info= (st_mysql_auth *) plugin_decl(plugin)->info;
+
+    DBUG_PRINT("info", ("auth_plugin_name: %s, interface_version: %d",
+                        auth_plugin_name->str, info->interface_version));
+
     switch (info->interface_version >> 8) {
     case 0x02:
       res= info->authenticate_user(mpvio, &mpvio->auth_info);
       break;
     case 0x01:
       {
+        DBUG_PRINT("info", ("Using compat downgrade for authentication"));
         MYSQL_SERVER_AUTH_INFO_0x0100 compat;
         compat.downgrade(&mpvio->auth_info);
         res= info->authenticate_user(mpvio, (MYSQL_SERVER_AUTH_INFO *)&compat);
@@ -14337,7 +14363,9 @@ static int do_auth_once(THD *thd, const LEX_CSTRING *auth_plugin_name,
     res= CR_ERROR;
   }
 
-  return res;
+  DBUG_PRINT("info", ("do_auth_once FINISHING: vio_type=%s",
+                      safe_vio_type_name(thd->net.vio)));
+  DBUG_RETURN(res);
 }
 
 enum PASSWD_ERROR_ACTION

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7173,3 +7173,23 @@ static Sys_var_optimizer_cost Sys_optimizer_scan_cost(
   CMD_LINE(REQUIRED_ARG),
   VALID_RANGE(0, 100000000), DEFAULT(DEFAULT_TABLE_SCAN_SETUP_COST),
   COST_ADJUST(1000));
+
+static Sys_var_charptr_fscs Sys_server_redirect_target(
+	"server_redirect_target",
+        "Server redirection target. This should be a hostname, an IP address, or "
+        "a hostname or IP address followed by ':PORT'. Server redirection will "
+        "not be activated unless SERVER_REDIRECT_MODE is also set.",
+        GLOBAL_VAR(server_redirect_target), CMD_LINE(REQUIRED_ARG),
+        DEFAULT(NULL));
+
+static const char *server_redirect_mode_names[]= {
+        "OFF", "ON", "ALL", 0 };
+
+static Sys_var_enum Sys_server_redirect_mode(
+       "server_redirect_mode",
+       "Server redirection mode. "
+       "Possible modes are: OFF - No redirection, "
+       "ON: Unconditionally redirect new clients attempting to connect over the network (e.g. no redirection of local socket-based connections), "
+       "ALL: Unconditionally redirect new clients attempting to connect (even via local socket-based connections).",
+       GLOBAL_VAR(server_redirect_mode), CMD_LINE(REQUIRED_ARG),
+       server_redirect_mode_names, DEFAULT(0));

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7189,7 +7189,7 @@ static Sys_var_enum Sys_server_redirect_mode(
        "server_redirect_mode",
        "Server redirection mode. "
        "Possible modes are: OFF - No redirection, "
-       "ON: Unconditionally redirect new clients attempting to connect over the network (e.g. no redirection of local socket-based connections), "
+       "ON: Redirect all new clients attempting to connect over the network to the standard server port (no redirection of local socket-based connections, nor of connections to the EXTRA_PORT), "
        "ALL: Unconditionally redirect new clients attempting to connect (even via local socket-based connections).",
        GLOBAL_VAR(server_redirect_mode), CMD_LINE(REQUIRED_ARG),
        server_redirect_mode_names, DEFAULT(0));


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-15935*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

This PR proposes a new feature in [the MariaDB client-server protocol](https://mariadb.com/kb/en/clientserver-protocol): application-layer redirection of client connections.

It also provides an initial server-side implementation of that feature; the corresponding client-side implementation is in https://github.com/mariadb-corporation/mariadb-connector-c/pull/226.

We want the MariaDB server to be able to tell clients connecting to it, “Sorry, this server is unavailable. Connect to an alternate server instead.” This mechanism is inspired by HTTP 302 (“temporary redirect”) mechanism familiar to all developers of web applications, and is intended to have similar semantics and security properties, since these have now been widely deployed and tested for decades.

## How can this PR be tested?

### Automated testing

- [ ] TODO: write new MTR tests to demonstrate and validate the redirection functionality
- [x] Pre-existing MTR tests are updated and passing.

### Manual testing

- Build the server from this PR, along with the updated client from https://github.com/mariadb-corporation/mariadb-connector-c/pull/226 (should be included as a submodule).
- Start the server with `sql/mariadbd --server-redirect-mode=ON --server-redirect-target='some-other-mariadb.server.com:3306' --port=3306 --extra-port=3307 --socket=/tmp/mysql.sock`
- Connect with the updated client and observe the redirection behavior, including the fact that connections to the [`EXTRA_PORT`](https://mariadb.com/kb/en/thread-pool-in-mariadb/#configuring-the-extra-port) and to the Unix socket  are _not_ redirected:
  - `client/mariadb --host 127.0.0.1 --port=3306 -uUSERNAME -pPASSWORD` → redirected
  - `client/mariadb --host 127.0.0.1 --port=3307 -uUSERNAME -pPASSWORD` → _not_ redirected (`EXTRA PORT`)
  - `client/mariadb --socket=/tmp/mysql.sock -uUSERNAME -pPASSWORD` → _not_ redirected (local/non-network-based connection)

<!--
TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
-->
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->
<!--
If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.
-->
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch, **11.2**.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
