### PR TITLE
MDEV-31618: Server crashes in process_i_s_table_temporary_tables/get_all_tables

### DIFF
--- a/mysql-test/main/information_schema_temp_table.result
+++ b/mysql-test/main/information_schema_temp_table.result
@@ -231,3 +231,38 @@ def	test	t1	BASE TABLE	MyISAM	10	Fixed	1	7	X	X	X	X	NULL	X	X	NULL	latin1_swedish_
 def	test	t2	TEMPORARY	MRG_MyISAM	10	Fixed	0	0	X	X	X	X	NULL	X	X	NULL	latin1_swedish_ci	NULL			X	Y
 def	test	t3	BASE TABLE	MRG_MyISAM	10	Fixed	1	5	X	X	X	X	NULL	X	X	NULL	latin1_swedish_ci	NULL			X	N
 DROP TABLE t1,t2,t3;
+#
+# MDEV-31618: Server crashes in
+#             process_i_s_table_temporary_tables/get_all_tables
+#
+CREATE TEMPORARY SEQUENCE seq1;
+SHOW FULL TABLES;
+Tables_in_test	Table_type
+seq1	TEMPORARY SEQUENCE
+SELECT table_schema, table_name FROM  INFORMATION_SCHEMA.TABLES WHERE table_type='temporary sequence';
+table_schema	table_name
+test	seq1
+mysqltest	s2
+mysqltest	s1
+ALTER TABLE `seq1` CHANGE `cache_size` cache_size int;
+ERROR HY000: Sequence 'test.seq1' table structure is invalid (cache_size)
+SHOW FULL TABLES;
+Tables_in_test	Table_type
+seq1	TEMPORARY SEQUENCE
+SELECT table_schema, table_name FROM  INFORMATION_SCHEMA.TABLES WHERE table_type='temporary sequence';
+table_schema	table_name
+test	seq1
+mysqltest	s2
+mysqltest	s1
+CREATE OR REPLACE TEMPORARY SEQUENCE seq1;
+SHOW FULL TABLES;
+Tables_in_test	Table_type
+seq1	TEMPORARY SEQUENCE
+SELECT table_schema, table_name FROM  INFORMATION_SCHEMA.TABLES WHERE table_type='temporary sequence';
+table_schema	table_name
+test	seq1
+mysqltest	s2
+mysqltest	s1
+DROP TABLE seq1;
+DROP TABLE mysqltest.s1;
+DROP TABLE mysqltest.s2;

--- a/mysql-test/main/information_schema_temp_table.test
+++ b/mysql-test/main/information_schema_temp_table.test
@@ -219,3 +219,26 @@ CREATE TABLE t3 (a INT) ENGINE=MERGE UNION=(t1);
 --replace_column 10 X 11 X 12 X 13 X 15 X 16 X 22 X
 SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'test';
 DROP TABLE t1,t2,t3;
+
+--echo #
+--echo # MDEV-31618: Server crashes in
+--echo #             process_i_s_table_temporary_tables/get_all_tables
+--echo #
+
+CREATE TEMPORARY SEQUENCE seq1;
+# Check show temp tables before alter
+SHOW FULL TABLES;
+SELECT table_schema, table_name FROM  INFORMATION_SCHEMA.TABLES WHERE table_type='temporary sequence';
+--error 4086
+ALTER TABLE `seq1` CHANGE `cache_size` cache_size int;
+# Check show temp tables after alter
+SHOW FULL TABLES;
+SELECT table_schema, table_name FROM  INFORMATION_SCHEMA.TABLES WHERE table_type='temporary sequence';
+
+CREATE OR REPLACE TEMPORARY SEQUENCE seq1;
+# Check show temp tables after create/replace alter
+SHOW FULL TABLES;
+SELECT table_schema, table_name FROM  INFORMATION_SCHEMA.TABLES WHERE table_type='temporary sequence';
+DROP TABLE seq1;
+DROP TABLE mysqltest.s1;
+DROP TABLE mysqltest.s2;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -787,6 +787,7 @@ void init_update_queries(void)
     Note that SQLCOM_RENAME_TABLE should not be in this list!
   */
   sql_command_flags[SQLCOM_CREATE_TABLE]|=    CF_PREOPEN_TMP_TABLES;
+  sql_command_flags[SQLCOM_CREATE_SEQUENCE]|= CF_PREOPEN_TMP_TABLES;
   sql_command_flags[SQLCOM_CREATE_INDEX]|=    CF_PREOPEN_TMP_TABLES;
   sql_command_flags[SQLCOM_ALTER_TABLE]|=     CF_PREOPEN_TMP_TABLES;
   sql_command_flags[SQLCOM_TRUNCATE]|=        CF_PREOPEN_TMP_TABLES;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -5326,7 +5326,7 @@ int get_all_tables(THD *thd, TABLE_LIST *tables, COND *cond)
                                  system_charset_info);
         schema_table_store_record(thd, table);
       }
-      else /* SCH_TABLE */
+      else /* SCH_TABLES */
         process_i_s_table_temporary_tables(thd, table, tmp_tbl);
     }
   }
@@ -5372,7 +5372,7 @@ int get_all_tables(THD *thd, TABLE_LIST *tables, COND *cond)
             continue;
         }
 #endif
-	restore_record(table, s->default_values);
+        restore_record(table, s->default_values);
         table->field[schema_table->idx_field1]->
           store(db_name->str, db_name->length, system_charset_info);
         table->field[schema_table->idx_field2]->

--- a/storage/myisammrg/myrg_info.c
+++ b/storage/myisammrg/myrg_info.c
@@ -33,6 +33,8 @@ int myrg_status(MYRG_INFO *info,register MYMERGE_INFO *x,int flag)
   MYRG_TABLE *current_table;
   DBUG_ENTER("myrg_status");
 
+  x->errkey= 0;
+  x->dupp_key_pos= 0;
   if (!(current_table = info->current_table) &&
       info->open_tables != info->end_table)
     current_table = info->open_tables;
@@ -71,11 +73,6 @@ int myrg_status(MYRG_INFO *info,register MYMERGE_INFO *x,int flag)
           the duplicate key is located.
         */
         x->dupp_key_pos= current_table->file_offset + current_table->table->dupp_key_pos;
-      }
-      else
-      {
-        x->errkey= 0;
-        x->dupp_key_pos= 0;
       }
     }
     x->records= info->records;


### PR DESCRIPTION
 [x] *The Jira issue number for this PR is: MDEV-31618*
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
