### PR TITLE
MDEV-31627 innodb large file sizes overflow in logs

### DIFF
--- a/storage/innobase/fsp/fsp0sysspace.cc
+++ b/storage/innobase/fsp/fsp0sysspace.cc
@@ -393,20 +393,19 @@ SysTablespace::set_size(
 	Datafile&	file)
 {
 	ut_ad(!srv_read_only_mode || m_ignore_read_only);
+	os_offset_t sz = static_cast<os_offset_t>(file.m_size)
+		<< srv_page_size_shift;
 
 	/* We created the data file and now write it full of zeros */
 	ib::info() << "Setting file '" << file.filepath() << "' size to "
-		<< ib::bytes_iec{file.m_size << srv_page_size_shift} <<
+		<< ib::bytes_iec{sz} <<
 		". Physically writing the file full; Please wait ...";
 
-	bool	success = os_file_set_size(
-		file.m_filepath, file.m_handle,
-		static_cast<os_offset_t>(file.m_size) << srv_page_size_shift);
+	bool	success = os_file_set_size(file.m_filepath, file.m_handle, sz);
 
 	if (success) {
 		ib::info() << "File '" << file.filepath() << "' size is now "
-			<< ib::bytes_iec{file.m_size << srv_page_size_shift}
-			<< ".";
+			<< ib::bytes_iec{sz} << ".";
 	} else {
 		ib::error() << "Could not set the file size of '"
 			<< file.filepath() << "'. Probably out of disk space";


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31627*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Output results in messages like:

InnoDB: Setting file './ibdata1' size to 0.000B

Cause: Datafile.m_size is a uint32_t and pagesize shifts put this quickl over the uint32_t size limits.

Fixed by casting to os_offset_t for the purposes of display.

## How can this PR be tested?

```
$ scripts/mariadb-install-db    --no-defaults --srcdir=$OLDPWD --builddir=$PWD --datadir=$HOME/xxtmp --innodb-data-file-path=ibdata1:56G --innodb-page-size=4k  --verbose
Installing MariaDB/MySQL system tables in '/home/dan/xxtmp' ...
2023-07-05 18:05:59 0 [Note] Starting MariaDB 10.9.8-MariaDB source revision 35de8326fb6ca2751c83ee7465c33347b9efeb93 as process 2147916
2023-07-05 18:05:59 0 [Note] InnoDB: innodb_page_size=4096
2023-07-05 18:05:59 0 [Note] InnoDB: The first data file './ibdata1' did not exist. A new tablespace will be created!
2023-07-05 18:05:59 0 [Note] InnoDB: Compressed tables use zlib 1.2.13
2023-07-05 18:05:59 0 [Note] InnoDB: Number of transaction pools: 1
2023-07-05 18:05:59 0 [Note] InnoDB: Using crc32 + pclmulqdq instructions
2023-07-05 18:05:59 0 [Note] InnoDB: Using liburing
2023-07-05 18:05:59 0 [Note] InnoDB: Initializing buffer pool, total size = 128.000MiB, chunk size = 2.000MiB
2023-07-05 18:05:59 0 [Note] InnoDB: Completed initialization of buffer pool
2023-07-05 18:05:59 0 [Note] InnoDB: Setting file './ibdata1' size to 56.000GiB. Physically writing the file full; Please wait ...
2023-07-05 18:05:59 0 [Note] InnoDB: File './ibdata1' size is now 56.000GiB.
```

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ X ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
