### PR TITLE
MDEV-31369 Disable TLS v1.0 and 1.1 for MariaDB

### DIFF
--- a/mysql-test/main/ssl_cipher.result
+++ b/mysql-test/main/ssl_cipher.result
@@ -66,3 +66,5 @@ Variable_name	Value
 Ssl_cipher_list	AES128-SHA
 disconnect ssl_con;
 connection default;
+call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
+FOUND 2 /TLSv1.0 and TLSv1.1 are insecure/ in mysqld.1.err

--- a/mysql-test/main/ssl_cipher.test
+++ b/mysql-test/main/ssl_cipher.test
@@ -101,3 +101,9 @@ SHOW STATUS LIKE 'Ssl_cipher';
 SHOW STATUS LIKE 'Ssl_cipher_list';
 disconnect ssl_con;
 connection default;
+
+# MDEV-31369 Disable TLS v1.0 and 1.1 for MariaDB
+call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN= TLSv1.0 and TLSv1.1 are insecure
+--source include/search_pattern_in_file.inc

--- a/mysql-test/main/tls_version.result
+++ b/mysql-test/main/tls_version.result
@@ -12,3 +12,5 @@ Variable_name	Value
 Ssl_version	TLSv1.2
 @@tls_version
 TLSv1.1,TLSv1.2
+call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
+FOUND 1 /TLSv1.0 and TLSv1.1 are insecure/ in mysqld.1.err

--- a/mysql-test/main/tls_version.test
+++ b/mysql-test/main/tls_version.test
@@ -22,3 +22,8 @@
 # finally list available protocols
 --exec $MYSQL --host=localhost --ssl -e "select @@tls_version;"
 
+call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN= TLSv1.0 and TLSv1.1 are insecure
+--source include/search_pattern_in_file.inc
+

--- a/mysql-test/main/tls_version1.result
+++ b/mysql-test/main/tls_version1.result
@@ -4,3 +4,5 @@ Variable_name	Value
 Ssl_version	TLSv1
 @@tls_version
 TLSv1.0
+call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
+FOUND 1 /TLSv1.0 and TLSv1.1 are insecure/ in mysqld.1.err

--- a/mysql-test/main/tls_version1.test
+++ b/mysql-test/main/tls_version1.test
@@ -10,3 +10,8 @@
 --exec $MYSQL --host=localhost --ssl --tls_version=TLSv1.0 -e "show status like 'ssl_version';"
 --exec $MYSQL --host=localhost --ssl -e "select @@tls_version;"
 
+call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN= TLSv1.0 and TLSv1.1 are insecure
+--source include/search_pattern_in_file.inc
+

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4500,6 +4500,8 @@ static int init_common_variables()
     return 1;
   }
 
+  if (tls_version & (VIO_TLSv1_0 + VIO_TLSv1_1))
+      sql_print_warning("TLSv1.0 and TLSv1.1 are insecure and should not be used for tls_version");
 
 #ifdef WITH_WSREP
   /*

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3623,7 +3623,7 @@ static Sys_var_set Sys_tls_version(
        "TLS protocol version for secure connections.",
        READ_ONLY GLOBAL_VAR(tls_version), CMD_LINE(REQUIRED_ARG),
        tls_version_names,
-       DEFAULT(VIO_TLSv1_1 | VIO_TLSv1_2 | VIO_TLSv1_3));
+       DEFAULT(VIO_TLSv1_2 | VIO_TLSv1_3));
 
 static Sys_var_mybool Sys_standard_compliant_cte(
        "standard_compliant_cte",


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31369*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Remove TLSv1.1 from the default tls_version system variable.

Output a warning if TLSv1.0 or TLSv1.1 are selected.

Thanks Tingyao Nian for the feature request.


## How can this PR be tested?

Covered by existing tests.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ X ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ X ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
