### PR TITLE
MDEV-31336: pam_user_map : not supporting username or groupname conta…

### DIFF
--- a/plugin/auth_pam/mapper/pam_user_map.c
+++ b/plugin/auth_pam/mapper/pam_user_map.c
@@ -216,7 +216,7 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags,
     }
     from= s;
     skip(isalnum(*s) || (*s == '_') || (*s == '.') || (*s == '-') ||
-         (*s == '$') || (*s == '\\') || (*s == '/'));
+         (*s == '$') || (*s == '\\') || (*s == '/') || (*s == '@'));
     end_from= s;
     skip(isspace(*s));
     if (end_from == from || *s++ != ':') goto syntax_error;


### PR DESCRIPTION
…ining @ character

Add @ to the allowed characters in a username.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31336*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

User names in the pam_user_map didn't support '@'

## How can this PR be tested?

After the usual amount of system fiddling to get PAM working:

```
$ cat /etc/security/user_map.conf

tom@homecorp: dbuser

$ cat /etc/pam.d/mariadb 
auth required pam_unix.so audit
auth required pam_user_map.so debug
account required pam_unix.so audit

$ (adding users 'tom@homecorp' and 'dbuser')

MariaDB [mysql]> CREATE USER 'dbuser'@'%' IDENTIFIED BY 'strongpassword';
Query OK, 0 rows affected (0.001 sec)

MariaDB [mysql]> GRANT ALL PRIVILEGES ON *.* TO 'dbuser'@'%' ;
Query OK, 0 rows affected (0.001 sec)

MariaDB [mysql]> drop user ''@'%';
Query OK, 0 rows affected (0.000 sec)

MariaDB [mysql]> CREATE USER ''@'%' IDENTIFIED VIA pam USING 'mariadb';
Query OK, 0 rows affected (0.000 sec)

MariaDB [mysql]> drop user ''@localhost;

MariaDB [mysql]> GRANT PROXY ON 'dbuser'@'%' TO ''@'%';
Query OK, 0 rows affected (0.001 sec)
```

success:
```
$ client/mariadb -u tom@homecorp  --plugin-dir=$PWD/libmariadb --protocol tcp 
[mariadb] Password:  
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 13
Server version: 10.4.31-MariaDB Source distribution

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]>  SELECT USER(), CURRENT_USER();
+------------------------+----------------+
| USER()                 | CURRENT_USER() |
+------------------------+----------------+
| tom@homecorp@localhost | dbuser@%       |
+------------------------+----------------+

```

/var/log/secure
```
Jul 10 11:38:25 bark auth_pam_tool[26014]: pam_user_map(mariadb:auth): Opening file '/etc/security/user_map.conf'.
Jul 10 11:38:25 bark auth_pam_tool[26014]: pam_user_map(mariadb:auth): Incoming username 'tom@homecorp'.
Jul 10 11:38:25 bark auth_pam_tool[26014]: pam_user_map(mariadb:auth): Check if username 'tom@homecorp': YES
Jul 10 11:38:25 bark auth_pam_tool[26014]: pam_user_map(mariadb:auth): User mapped as 'dbuser'
```

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ X ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
