### PR TITLE
[MDEV-31369] Change default value of tls_version to disable TLSv1.1

### DIFF
--- a/mysql-test/include/have_tls_1_3.inc
+++ b/mysql-test/include/have_tls_1_3.inc
@@ -1,0 +1,5 @@
+connect (conn1,localhost,root,,,,,SSL);
+if (`SELECT count(*) = 0 FROM information_schema.GLOBAL_STATUS WHERE
+      VARIABLE_NAME = 'ssl_version' AND VARIABLE_VALUE = 'TLSv1.3'`){
+  skip Needs TLSv1.3;
+}

--- a/mysql-test/main/tls_version_default.result
+++ b/mysql-test/main/tls_version_default.result
@@ -1,0 +1,2 @@
+@@tls_version
+TLSv1.2,TLSv1.3

--- a/mysql-test/main/tls_version_default.test
+++ b/mysql-test/main/tls_version_default.test
@@ -1,0 +1,2 @@
+# MDEV-31369 - Test that by default only TLSv1.2 and TLSv.1.3 is enabled
+--exec $MYSQL --host=localhost --ssl -e "SELECT @@tls_version;"

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3611,7 +3611,7 @@ static Sys_var_set Sys_tls_version(
        "TLS protocol version for secure connections.",
        READ_ONLY GLOBAL_VAR(tls_version), CMD_LINE(REQUIRED_ARG),
        tls_version_names,
-       DEFAULT(VIO_TLSv1_1 | VIO_TLSv1_2 | VIO_TLSv1_3));
+       DEFAULT(VIO_TLSv1_2 | VIO_TLSv1_3));
 
 static Sys_var_mybool Sys_standard_compliant_cte(
        "standard_compliant_cte",


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-31369*
## Description
The TLS versions 1.0 (defined in 1999) and 1.1 (defined in 2006) are
insecure and nobody should be using them anymore. Currently all these
TLS versions are still supported by MariaDB, and TLSv1.1,TLSv1.2,TLSv1.3
were enabled by default.

To make the default configuration safer, TLSv1.1 is now disabled by
default. User can still explicitly enable the old TLS versions via
parameter 'tls_version'.

That being said, by default the server only allows TLSv1.2, TLSv1.3
```
    mysql> SHOW GLOBAL VARIABLES LIKE 'tls_version';
    +---------------+-----------------+
    | Variable_name | Value           |
    +---------------+-----------------+
    | tls_version   | TLSv1.2,TLSv1.3 |
    +---------------+-----------------+
```
Before:
```
    mysql> SHOW GLOBAL VARIABLES LIKE 'tls_version';
    +---------------+-------------------------+
    | Variable_name | Value                   |
    +---------------+-------------------------+
    | tls_version   | TLSv1.1,TLSv1.2,TLSv1.3 |
    +---------------+-------------------------+
```
Attempting to connect with disabled protocals will result in error:
```
    ERROR 2026 (HY000): TLS/SSL error: tlsv1 alert protocol version
```

## How can this PR be tested?
Several test cases in main and sys_vars suite are updated top accommodate the change.

All other existing tests are not broken

## Basing the PR against the correct MariaDB version
- [x] *This is a security improvement and the PR is based against the earliest branch in which the fix can be applied*


## Backward compatibility
Some compatibility will be impacted.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.
<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
