### PR TITLE
MDEV-31725 Change visibility of some multi_update members to public.

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -7102,10 +7102,8 @@ class multi_update :public select_result_interceptor
   TABLE_LIST *all_tables; /* query/update command tables */
   List<TABLE_LIST> *leaves;     /* list of leaves of join table tree */
   List<TABLE_LIST> updated_leaves;  /* list of of updated leaves */
-  TABLE_LIST *update_tables;
-  TABLE **tmp_tables, *main_table, *table_to_update;
+  TABLE **tmp_tables, *main_table;
   TMP_TABLE_PARAM *tmp_table_param;
-  ha_rows updated, found;
   List <Item> *fields, *values;
   List <Item> **fields_for_table, **values_for_table;
   uint table_count;
@@ -7135,6 +7133,9 @@ class multi_update :public select_result_interceptor
   bool has_vers_fields;
 
 public:
+  TABLE_LIST *update_tables;
+  TABLE *table_to_update;
+  ha_rows updated, found;
   multi_update(THD *thd_arg, TABLE_LIST *ut, List<TABLE_LIST> *leaves_list,
 	       List<Item> *fields, List<Item> *values,
 	       enum_duplicates handle_duplicates, bool ignore);

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -1679,12 +1679,11 @@ multi_update::multi_update(THD *thd_arg, TABLE_LIST *table_list,
 			   enum enum_duplicates handle_duplicates_arg,
                            bool ignore_arg):
    select_result_interceptor(thd_arg),
-   all_tables(table_list), leaves(leaves_list), update_tables(0),
-   tmp_tables(0), updated(0), found(0), fields(field_list),
-   values(value_list), table_count(0), copy_field(0),
+   all_tables(table_list), leaves(leaves_list), tmp_tables(0),
+   fields(field_list), values(value_list), table_count(0), copy_field(0),
    handle_duplicates(handle_duplicates_arg), do_update(1), trans_safe(1),
    transactional_tables(0), ignore(ignore_arg), error_handled(0), prepared(0),
-   updated_sys_ver(0)
+   updated_sys_ver(0), update_tables(0), updated(0), found(0)
 {
 }
 


### PR DESCRIPTION
Visibility of the following members of class multi_update is changed to public to allow ColumnStore to correctly set the count of the affected rows in a multi-table UPDATE statement:

  multi_update::update_tables
  multi_update::table_to_update
  multi_update::updated
  multi_update::found

To add some context, for single-table UPDATEs, the server call to handler::ha_direct_update_rows(ha_rows *update_rows, ha_rows *found_rows) allows ColumnStore to correctly set the number of updated rows.

However, for UPDATEs involving multi-tables, the server does not call handler::direct_update_rows(). With the following server execution order for multi-table UPDATEs, ColumnStore has the opportunity in handler::rnd_end() to correctly report the number of updated rows to the client (assuming the above four fields of class multi_update are public):

  1. handler::rnd_init()
  2. handler::rnd_end()
  3. multi_update::send_eof()

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31725*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->

## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
