### PR TITLE
MDEV-31332: Galera rsync sst to ignore .snapshot/ files

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -564,6 +564,7 @@ FILTER="-f '- /lost+found'
         -f '- /.Trashes'
         -f '- /.pid'
         -f '- /.conf'
+        -f '- /.snapshot/'
         -f '+ /wsrep_sst_binlog.tar'
         -f '- $ib_home_dir/ib_lru_dump'
         -f '- $ib_home_dir/ibdata*'
@@ -673,7 +674,8 @@ FILTER="-f '- /lost+found'
         cd "$DATA"
 
         find . -maxdepth 1 -mindepth 1 -type d -not -name 'lost+found' \
-             -not -name '.zfs' -print0 | xargs -I{} -0 -P $backup_threads \
+             -not -name '.zfs' -not -name .snapshot -print0 \
+	     | xargs -I{} -0 -P $backup_threads \
              rsync ${STUNNEL:+--rsh="$STUNNEL"} \
              --owner --group --perms --links --specials --ignore-times \
              --inplace --recursive --delete --quiet $WHOLE_FILE_OPT \


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31332*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

.snapshot exists as a directory on NetApp storage and should not be copied during the sst process.

Thanks Daniel Czadek for the bug report.

## How can this PR be tested?

installing docker-compose:
```
virtualenv ~/.py3
source ~/.py3/activate.sh
pip install docker-compose
```

From: https://github.com/grooverdan/mariadb.org-tools/tree/MDEV-31332/daniel/galera-sst-test



```
$ docker-compose up donor
Creating network "galera-sst-test_default" with the default driver
Creating volume "galera-sst-test_joiner" with local driver
Creating volume "galera-sst-test_joiner2" with local driver
Building donor
STEP 1/3: FROM quay.io/mariadb-foundation/mariadb-devel:10.4
STEP 2/3: COPY wsrep_sst_mariabackup /usr/bin/
--> 92e763845b2b
STEP 3/3: COPY wsrep_sst_rsync /usr/bin/
COMMIT mariadb:test
--> 864ea7a68cb0
Successfully tagged localhost/mariadb:test
864ea7a68cb0a51218bf541ab38fa33d0e02a65e037151a5d02f2377235be7b7
WARNING: Image for service donor was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating galera-sst-test_donor_1 ... done
Attaching to galera-sst-test_donor_1
donor_1    | 2023-07-18 07:10:52+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.4.31+maria~ubu2004 started.
donor_1    | 2023-07-18 07:10:52+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
...
```

```
$ podman exec -ti galera-sst-test_donor_1 bash
root@442e0e72a811:/# cd /var/lib/mysql/
root@442e0e72a811:/var/lib/mysql# mkdir .snapshot
root@442e0e72a811:/var/lib/mysql# touch .snapshot/ignorethis
```

```
$ docker-compose up joiner
galera-sst-test_donor_1 is up-to-date
Creating galera-sst-test_joiner_1 ... done
Attaching to galera-sst-test_joiner_1
joiner_1   | 2023-07-18 07:12:54+00:00 [Note] [Entrypoint]: Entrypoint script for MariaDB Server 1:10.4.30+maria~ubu2004 started.
joiner_1   | 2023-07-18 07:12:55+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
...
donor_1    | 2023-07-18  7:13:01 0 [Note] WSREP: Tables flushed.
donor_1    | 2023-07-18  7:13:01 0 [Note] WSREP: Donor state reached
donor_1    | WSREP_SST: [INFO] Tables flushed (20230718 07:13:01.706)
donor_1    | WSREP_SST: [INFO] Transfer of normal directories done (20230718 07:13:01.879)
donor_1    | WSREP_SST: [INFO] Transfer of InnoDB data files done (20230718 07:13:02.064)
donor_1    | WSREP_SST: [INFO] Transfer of InnoDB log files done (20230718 07:13:02.364)
donor_1    | WSREP_SST: [INFO] Transfer of InnoDB undo logs done (20230718 07:13:02.540)
donor_1    | WSREP_SST: [INFO] Transfer of Aria logs done (20230718 07:13:02.710)
donor_1    | WSREP_SST: [INFO] Transfer of data done (20230718 07:13:02.894)
donor_1    | WSREP_SST: [INFO] Sending continue to donor (20230718 07:13:02.898)
donor_1    | 2023-07-18  7:13:02 0 [Note] InnoDB: Resuming purge
donor_1    | 2023-07-18  7:13:02 0 [Note] WSREP: resume
donor_1    | 2023-07-18  7:13:02 0 [Note] WSREP: resuming provider at 5
...
joiner_1   | WSREP_SST: [INFO] Galera co-ords from recovery: 69d3b5cd-253a-11ee-83a0-2a5814fee76b:2 0 (20230718 07:13:03.454)
joiner_1   | WSREP_SST: [INFO] rsync SST completed on joiner (20230718 07:13:03.459)
joiner_1   | WSREP_SST: [INFO] Joiner cleanup: rsync PID=302, stunnel PID=0 (20230718 07:13:03.464)
joiner_1   | WSREP_SST: [INFO] Joiner cleanup done. (20230718 07:13:03.989)
joiner_1   | 2023-07-18  7:13:03 3 [Note] WSREP: SST received
joiner_1   | 2023-07-18  7:13:03 3 [Note] WSREP: Server status change joiner -> initializing
...
```

```
$ podman exec -ti galera-sst-test_joiner_1 ls -la /var/lib/mysql/
total 271332
drwxr-xr-x. 4 mysql mysql      4096 Jul 18 07:13 .
drwxr-xr-x. 1 root  root       4096 Jul  4 18:31 ..
-rw-------. 1 mysql mysql       135 Jul 18 07:13 .my-healthcheck.cnf
-rw-rw----. 1 mysql mysql  17727488 Jul 18 07:13 aria_log.00000001
-rw-rw----. 1 mysql mysql        52 Jul 18 07:13 aria_log_control
-rw-rw----. 1 mysql mysql 134219032 Jul 18 07:13 galera.cache
-rw-rw----. 1 mysql mysql       113 Jul 18 07:13 grastate.dat
-rw-rw----. 1 mysql mysql       217 Jul 18 07:13 gvwstate.dat
-rw-rw----. 1 mysql mysql       930 Jul 18 07:12 ib_buffer_pool
-rw-rw----. 1 mysql mysql  50331648 Jul 18 07:13 ib_logfile0
-rw-rw----. 1 mysql mysql  50331648 Jul 18 07:13 ib_logfile1
-rw-rw----. 1 mysql mysql  12582912 Jul 18 07:13 ibdata1
-rw-rw----. 1 mysql mysql  12582912 Jul 18 07:13 ibtmp1
-rw-rw----. 1 mysql mysql         0 Jul 18 07:12 multi-master.info
drwx------. 2 mysql mysql      4096 Jul 18 07:13 mysql
-rw-r--r--. 1 mysql mysql        15 Jul 18 07:12 mysql_upgrade_info
drwx------. 2 mysql mysql      4096 Jul 18 07:12 performance_schema
-rw-rw----. 1 mysql mysql     24576 Jul 18 07:13 tc.log

```


TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ X ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
