### PR TITLE
MDEV-31746 Problems with tx_isolation after MDEV-21921

### DIFF
--- a/mysql-test/main/mysqltest_tracking_info.result
+++ b/mysql-test/main/mysqltest_tracking_info.result
@@ -61,3 +61,150 @@ ERROR 42000: Variable 'session_track_system_variables' can't be set to the value
 # MDEV-16470 - Session user variables tracker
 #
 # End of 10.5 tests
+# Start of 11.1 tests
+#
+# MDEV-31746 Problems with tx_isolation after MDEV-21921
+#
+# tracking info on
+SET session_track_system_variables='max_insert_delayed_threads';
+SET max_delayed_threads=0;
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- max_insert_delayed_threads
+-- 0
+
+SET @@max_delayed_threads=0;
+SET SESSION max_delayed_threads=0;
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- max_insert_delayed_threads
+-- 0
+
+SET session_track_system_variables='max_delayed_threads';
+SET max_insert_delayed_threads=@@global.max_delayed_threads;
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- max_delayed_threads
+-- 20
+
+SET session_track_system_variables='tx_isolation';
+SET @@session.tx_isolation='READ-COMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-COMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-UNCOMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION transaction_isolation='REPEATABLE-READ';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- REPEATABLE-READ
+
+Track 2, get 2
+SET session_track_system_variables='tx_isolation,transaction_isolation';
+SET @@session.tx_isolation='READ-COMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-COMMITTED
+-- transaction_isolation
+-- READ-COMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-UNCOMMITTED
+-- transaction_isolation
+-- READ-UNCOMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION transaction_isolation='REPEATABLE-READ';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- REPEATABLE-READ
+-- transaction_isolation
+-- REPEATABLE-READ
+
+SET session_track_system_variables='transaction_isolation';
+SET @@session.tx_isolation='READ-COMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- transaction_isolation
+-- READ-COMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- transaction_isolation
+-- READ-UNCOMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION transaction_isolation='REPEATABLE-READ';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- transaction_isolation
+-- REPEATABLE-READ
+
+SET session_track_system_variables='tx_isolation,transaction_isolation,tx_isolation';
+SELECT @@session_track_system_variables;
+@@session_track_system_variables
+transaction_isolation,tx_isolation
+SET @@session.tx_isolation='READ-COMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-COMMITTED
+-- transaction_isolation
+-- READ-COMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-UNCOMMITTED
+-- transaction_isolation
+-- READ-UNCOMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION transaction_isolation='REPEATABLE-READ';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- REPEATABLE-READ
+-- transaction_isolation
+-- REPEATABLE-READ
+
+accumulate as we encounter duplicates
+SET session_track_system_variables='*';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- session_track_system_variables
+-- *
+
+SET @@session.tx_isolation='READ-COMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-COMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- tx_isolation
+-- READ-UNCOMMITTED
+
+Warnings:
+Warning	1287	'@@tx_isolation' is deprecated and will be removed in a future release. Please use '@@transaction_isolation' instead
+SET SESSION transaction_isolation='REPEATABLE-READ';
+-- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
+-- transaction_isolation
+-- REPEATABLE-READ
+-- tx_isolation
+-- REPEATABLE-READ
+
+# End of 11.1 tests

--- a/mysql-test/main/mysqltest_tracking_info.test
+++ b/mysql-test/main/mysqltest_tracking_info.test
@@ -91,3 +91,60 @@ SET SESSION session_track_system_variables=NULL;
 #SET @inserted_value=REPEAT(1,16777180);  # Only crashes when >=16777180 (max = 16777216)
 
 --echo # End of 10.5 tests
+
+--echo # Start of 11.1 tests
+
+--echo #
+--echo # MDEV-31746 Problems with tx_isolation after MDEV-21921
+--echo #
+
+--echo # tracking info on
+
+--enable_session_track_info
+
+SET session_track_system_variables='max_insert_delayed_threads';
+SET max_delayed_threads=0;
+SET @@max_delayed_threads=0;
+SET SESSION max_delayed_threads=0;
+
+SET session_track_system_variables='max_delayed_threads';
+SET max_insert_delayed_threads=@@global.max_delayed_threads;
+
+SET session_track_system_variables='tx_isolation';
+
+SET @@session.tx_isolation='READ-COMMITTED';
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+SET SESSION transaction_isolation='REPEATABLE-READ';
+
+--echo Track 2, get 2
+SET session_track_system_variables='tx_isolation,transaction_isolation';
+
+SET @@session.tx_isolation='READ-COMMITTED';
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+SET SESSION transaction_isolation='REPEATABLE-READ';
+
+SET session_track_system_variables='transaction_isolation';
+
+SET @@session.tx_isolation='READ-COMMITTED';
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+SET SESSION transaction_isolation='REPEATABLE-READ';
+
+SET session_track_system_variables='tx_isolation,transaction_isolation,tx_isolation';
+
+SELECT @@session_track_system_variables;
+
+SET @@session.tx_isolation='READ-COMMITTED';
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+SET SESSION transaction_isolation='REPEATABLE-READ';
+
+--echo accumulate as we encounter duplicates
+SET session_track_system_variables='*';
+
+SET @@session.tx_isolation='READ-COMMITTED';
+SET SESSION tx_isolation='READ-UNCOMMITTED';
+SET SESSION transaction_isolation='REPEATABLE-READ';
+# TEST GAP, there are no aliases of Sys_var_bit variables, implemented but
+# no tests yet.
+--disable_session_track_info
+
+--echo # End of 11.1 tests

--- a/scripts/mariadb_system_tables.sql
+++ b/scripts/mariadb_system_tables.sql
@@ -18,7 +18,7 @@
 -- The system tables of MySQL Server
 --
 
-set sql_mode='';
+set session_track_system_variables='', sql_mode='';
 
 set @orig_storage_engine=@@default_storage_engine;
 set default_storage_engine=Aria;

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -153,7 +153,7 @@ sys_var::sys_var(sys_var_chain *chain, const char *name_arg,
                  const char *substitute) :
   next(0), binlog_status(binlog_status_arg), value_origin(COMPILE_TIME),
   flags(flags_arg), show_val_type(show_val_type_arg),
-  guard(lock), offset(off), on_check(on_check_func), on_update(on_update_func),
+  guard(lock), tracking_id{off, 0}, on_check(on_check_func), on_update(on_update_func),
   deprecation_substitute(substitute)
 {
   /*


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31746*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

With session tracking on the tx_isolation of importance to connector frameworks, its important that tracking of tx_isolation does get informed if a user `set session transaction_isolation=X` as the alias for tx_isolation.

Rather than just implement this for one variable alias, it is implemented for all aliases.

To assist with this the session_tracker has is now made up of the offset types, the sys_var_bit bitmask as well.

This becomes the equivalavant of aliases that change the same memory location.

The impacts of aliases are:
- If track one variable, its alias changes, you get a tracking change on the variable you are monitoring.
- If you track two aliased variables of each other, changing one variable with have two tracking events.
- If you are tracking *, you will get a change on the variable changed. If then you change its alias, you'll get two tracking events for both variable changes.

Other:
* Add const overrides to necessary functions
* Eliminate session tracking in bootstrap.

## How can this PR be tested?

test case updated


If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ X ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
