### PR TITLE
MDEV-15547 - auth_pam: add PAM_RHOST to pam info

### DIFF
--- a/mysql-test/suite/plugins/r/pam.result
+++ b/mysql-test/suite/plugins/r/pam.result
@@ -5,7 +5,7 @@ create user pam_test;
 grant all on test.* to pam_test;
 grant proxy on pam_test to test_pam;
 #
-# athentication is successful, challenge/pin are ok
+# authentication is successful, challenge/pin are ok
 # note that current_user() differs from user()
 #
 Challenge input first.
@@ -16,7 +16,17 @@ select user(), current_user(), database();
 user()	current_user()	database()
 test_pam@localhost	pam_test@%	test
 #
-# athentication is unsuccessful
+# TCP test
+#
+Challenge input first.
+Enter: *************************
+Now, the magic number!
+PIN: 9225
+select user(), current_user(), database();
+user()	current_user()	database()
+test_pam@localhost	pam_test@%	test
+#
+# authentication is unsuccessful
 #
 Challenge input first.
 Enter: *************************

--- a/mysql-test/suite/plugins/r/pam_ipv6.result
+++ b/mysql-test/suite/plugins/r/pam_ipv6.result
@@ -1,0 +1,26 @@
+install plugin pam soname 'auth_pam.so';
+create user test_pam identified via pam using 'mariadb_mtr';
+grant all on test.* to test_pam;
+create user pam_test;
+grant all on test.* to pam_test;
+grant proxy on pam_test to test_pam;
+#
+# Good TCP test
+#
+Challenge input first.
+Enter: *************************
+Now, the magic number!
+PIN: 9225
+select user(), current_user(), database();
+user()	current_user()	database()
+test_pam@::1	pam_test@%	test
+#
+# Bad TCP test
+#
+Challenge input first.
+Enter: *************************
+Now, the magic number!
+PIN: 9224
+drop user test_pam;
+drop user pam_test;
+uninstall plugin pam;

--- a/mysql-test/suite/plugins/t/pam.test
+++ b/mysql-test/suite/plugins/t/pam.test
@@ -25,13 +25,18 @@ select user(), current_user(), database();
 EOF
 
 --echo #
---echo # athentication is successful, challenge/pin are ok
+--echo # authentication is successful, challenge/pin are ok
 --echo # note that current_user() differs from user()
 --echo #
 --exec $MYSQL_TEST -u test_pam < $MYSQLTEST_VARDIR/tmp/pam_good.txt
 
 --echo #
---echo # athentication is unsuccessful
+--echo # TCP test
+--echo #
+--exec $MYSQL_TEST --protocol=tcp --host=127.0.0.1 --port=$MASTER_MYPORT -u test_pam --plugin-dir=$plugindir < $MYSQLTEST_VARDIR/tmp/pam_good.txt
+
+--echo #
+--echo # authentication is unsuccessful
 --echo #
 --error 1
 --exec $MYSQL_TEST -u test_pam < $MYSQLTEST_VARDIR/tmp/pam_bad.txt

--- a/mysql-test/suite/plugins/t/pam_ipv6-master.opt
+++ b/mysql-test/suite/plugins/t/pam_ipv6-master.opt
@@ -1,0 +1,1 @@
+--skip-name-resolve --bind-address=:: 

--- a/mysql-test/suite/plugins/t/pam_ipv6.test
+++ b/mysql-test/suite/plugins/t/pam_ipv6.test
@@ -1,0 +1,34 @@
+let $PAM_PLUGIN_VERSION= $AUTH_PAM_SO;
+--source include/check_ipv6.inc
+--source pam_init.inc
+
+--write_file $MYSQLTEST_VARDIR/tmp/pam_good.txt
+not very secret challenge
+9225
+select user(), current_user(), database();
+EOF
+
+--write_file $MYSQLTEST_VARDIR/tmp/pam_bad.txt
+not very secret challenge
+9224
+select user(), current_user(), database();
+EOF
+
+--echo #
+--echo # Good TCP test
+--echo #
+--exec $MYSQL_TEST --protocol=tcp --host=::1 --port=$MASTER_MYPORT -u test_pam --plugin-dir=$plugindir < $MYSQLTEST_VARDIR/tmp/pam_good.txt
+
+--echo #
+--echo # Bad TCP test
+--echo #
+--error 1
+--exec $MYSQL_TEST --protocol=tcp --host=::1 --port=$MASTER_MYPORT -u test_pam --plugin-dir=$plugindir < $MYSQLTEST_VARDIR/tmp/pam_bad.txt
+
+--remove_file $MYSQLTEST_VARDIR/tmp/pam_good.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/pam_bad.txt
+drop user test_pam;
+drop user pam_test;
+let $count_sessions= 1;
+--source include/wait_until_count_sessions.inc
+uninstall plugin pam;

--- a/plugin/auth_pam/auth_pam_base.c
+++ b/plugin/auth_pam/auth_pam_base.c
@@ -155,6 +155,12 @@ static int pam_auth_base(struct param *param, MYSQL_SERVER_AUTH_INFO *info)
   PAM_DEBUG((stderr, "PAM: pam_start(%s, %s)\n", service, info->user_name));
   DO( pam_start(service, info->user_name, &pam_start_arg, &pamh) );
 
+  if (info->host_or_ip)
+  {
+    PAM_DEBUG((stderr, "PAM: pam_set_item(PAM_RHOST, %s)\n", info->host_or_ip));
+    DO( pam_set_item(pamh, PAM_RHOST, info->host_or_ip) );
+  }
+
   PAM_DEBUG((stderr, "PAM: pam_authenticate(0)\n"));
   DO( pam_authenticate (pamh, 0) );
 

--- a/vio/viosocket.c
+++ b/vio/viosocket.c
@@ -657,7 +657,6 @@ my_socket vio_fd(Vio* vio)
   @param src_length [in] length of the src.
   @param dst        [out] a buffer to store normalized IP address
                           (sockaddr_storage).
-  @param dst_length [out] optional - actual length of the normalized IP address.
 */
 
 void vio_get_normalized_ip(const struct sockaddr *src, size_t src_length,


### PR DESCRIPTION
When an a remote access to MariaDB is made, this sets the PAM_RHOST to the IP address.

## Description

PAM_RHOST provides information useful in diagnosis if there is an authentication failure. Like pam_tally2 (https://www.tecmint.com/use-pam_tally2-to-lock-and-unlock-ssh-failed-login-attempts/) can show you which host has the wrong authentication set.

Modules like pam_ihosts.so an restrict access based on IP.

With host information in the log, tools like fail2ban (https://github.com/fail2ban/fail2ban/blob/master/config/filter.d/pam-generic.conf) can block repeated failure attempts by IP.

This is a rewrite / port of PR #631 

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
