### PR TITLE
Removed CLIENT_SSL_VERIFY_SERVER_CERT flag

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -275,7 +275,7 @@ enum enum_indicator_type
 #define CLIENT_DEPRECATE_EOF (1ULL << 24)
 
 #define CLIENT_PROGRESS_OBSOLETE  (1ULL << 29)
-#define CLIENT_SSL_VERIFY_SERVER_CERT (1ULL << 30)
+#define CLIENT_SSL_VERIFY_SERVER_CERT_OBSOLETE (1ULL << 30)
 /*
   It used to be that if mysql_real_connect() failed, it would delete any
   options set by the client, unless the CLIENT_REMEMBER_OPTIONS flag was
@@ -326,7 +326,6 @@ enum enum_indicator_type
                            CLIENT_MULTI_STATEMENTS | \
                            CLIENT_MULTI_RESULTS | \
                            CLIENT_PS_MULTI_RESULTS | \
-                           CLIENT_SSL_VERIFY_SERVER_CERT | \
                            CLIENT_REMEMBER_OPTIONS | \
                            MARIADB_CLIENT_PROGRESS | \
                            CLIENT_PLUGIN_AUTH | \
@@ -343,9 +342,8 @@ enum enum_indicator_type
   If any of the optional flags is supported by the build it will be switched
   on before sending to the client during the connection handshake.
 */
-#define CLIENT_BASIC_FLAGS (((CLIENT_ALL_FLAGS & ~CLIENT_SSL) \
-                                               & ~CLIENT_COMPRESS) \
-                                               & ~CLIENT_SSL_VERIFY_SERVER_CERT)
+#define CLIENT_BASIC_FLAGS ((CLIENT_ALL_FLAGS & ~CLIENT_SSL) \
+                                               & ~CLIENT_COMPRESS)
 
 /**
   Is raised when a multi-statement transaction

--- a/include/sql_common.h
+++ b/include/sql_common.h
@@ -44,6 +44,7 @@ struct st_mysql_options_extention {
   struct mysql_async_context *async_context;
   HASH connection_attributes;
   size_t connection_attributes_length;
+  my_bool tls_verify_server_cert;
 };
 
 typedef struct st_mysql_methods

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -2093,7 +2093,7 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
      If the server does not support ssl, we abort the connection.
   */
   if (mysql->options.use_ssl &&
-      (mysql->client_flag & CLIENT_SSL_VERIFY_SERVER_CERT) &&
+      (mysql->options.extension && mysql->options.extension->tls_verify_server_cert) &&
       !(mysql->server_capabilities & CLIENT_SSL))
   {
     set_mysql_extended_error(mysql, CR_SSL_CONNECTION_ERROR, unknown_sqlstate,
@@ -2163,7 +2163,7 @@ static int send_client_reply_packet(MCPVIO_EXT *mpvio,
     DBUG_PRINT("info", ("IO layer change done!"));
 
     /* Verify server cert */
-    if ((mysql->client_flag & CLIENT_SSL_VERIFY_SERVER_CERT) &&
+    if ((mysql->options.extension && mysql->options.extension->tls_verify_server_cert) &&
         ssl_verify_server_cert(net->vio, mysql->host, &cert_error))
     {
       set_mysql_extended_error(mysql, CR_SSL_CONNECTION_ERROR, unknown_sqlstate,
@@ -3847,10 +3847,12 @@ mysql_options(MYSQL *mysql,enum mysql_option option, const void *arg)
     mysql->options.use_thread_specific_memory= *(my_bool *) arg;
     break;
   case MYSQL_OPT_SSL_VERIFY_SERVER_CERT:
-    if (*(my_bool*) arg)
-      mysql->options.client_flag|= CLIENT_SSL_VERIFY_SERVER_CERT;
-    else
-      mysql->options.client_flag&= ~CLIENT_SSL_VERIFY_SERVER_CERT;
+    if (!mysql->options.extension)
+      mysql->options.extension= (struct st_mysql_options_extention *)
+        my_malloc(sizeof(struct st_mysql_options_extention),
+                  MYF(MY_WME | MY_ZEROFILL));
+    if (mysql->options.extension)
+      mysql->options.extension->tls_verify_server_cert= *(my_bool*) arg;
     break;
   case MYSQL_PLUGIN_DIR:
     EXTENSION_SET_STRING(&mysql->options, plugin_dir, arg);

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -12759,7 +12759,6 @@ static bool send_server_handshake_packet(MPVIO_EXT *mpvio,
   if (ssl_acceptor_fd)
   {
     thd->client_capabilities |= CLIENT_SSL;
-    thd->client_capabilities |= CLIENT_SSL_VERIFY_SERVER_CERT;
   }
 
   if (data_len)


### PR DESCRIPTION
Because the server certificate verification flag is only used by the client, the flag was removed from the capability flags.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
CLIENT_SSL_VERIFY_SERVER_CERTIFICATE capability was removed in Connector/C 3.1 and needs also to be removed from server capability flags as well.

## How can this PR be tested?
By running the normal test suite (TLS/SSL tests).


TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
