### PR TITLE
MDEV-30520 SELinux/Apparmor incorrectly labeled mariadbd

### DIFF
--- a/support-files/policy/apparmor/usr.sbin.mysqld
+++ b/support-files/policy/apparmor/usr.sbin.mysqld
@@ -136,15 +136,17 @@
     /usr/bin/du rix,
     /usr/bin/find rix,
     /usr/bin/lsof rix,
+    /usr/bin/mariadb rix,
+    /usr/bin/mariadb-backup rix,
     /usr/bin/my_print_defaults rix,
-    /usr/bin/mysqldump rix,
+    /usr/bin/mariadb-dump rix,
     /usr/bin/pv rix,
     /usr/bin/rsync rix,
     /usr/bin/socat rix,
     /usr/bin/tail rix,
     /usr/bin/timeout rix,
     /usr/bin/xargs rix,
-    /usr/bin/xbstream rix,
+    /usr/bin/mbstream rix,
   }
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.sbin.mariadbd>

--- a/support-files/policy/selinux/mariadb-server.fc
+++ b/support-files/policy/selinux/mariadb-server.fc
@@ -6,5 +6,6 @@
 /var/lib/mysql/.*\.err --  gen_context(system_u:object_r:mysqld_log_t,s0)
 /var/lib/mysql/.*\.pid -- gen_context(system_u:object_r:mysqld_var_run_t,s0)
 /var/lib/mysql/.*\.cnf	--  gen_context(system_u:object_r:mysqld_etc_t,s0)
-/usr/bin/mariabackup.* -- gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/sbin/mariadbd -- gen_context(system_u:object_r:mysqld_exec_t,s0)
+/usr/bin/mariadb-backup -- gen_context(system_u:object_r:mysqld_exec_t,s0)
 /usr/bin/wsrep.*  -- gen_context(system_u:object_r:mysqld_safe_exec_t,s0)


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30520*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

From 10.4 -> 10.5 renamed a few MariaDB executables.

The default selinux profile expects mariadb to be installed in /usr/libexec/mariadbd however our packages install in in /usr/sbin.

Change the named executables in the apparmor to use the new names, like mariadb-backup, mariadb, and the selinux takes a changed of the now non-existent executables to use the current names, like /usr/sbin/mariadbd, mbstream.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
