### PR TITLE
MDEV-31743 Server crash in store_length, assertion failure in Type_handler_string_result::sort_length

### DIFF
--- a/mysql-test/main/distinct.result
+++ b/mysql-test/main/distinct.result
@@ -1180,5 +1180,16 @@ a
 1
 drop table t1,t2;
 #
+# MDEV-31743 Server crash in store_length, assertion failure in
+#            Type_handler_string_result::sort_length
+#
+create table t1 (a int, b longtext, c varchar(18));
+insert into t1 values (1, 'Aa123456', 'abc'), (2, 'Bb7897777', 'def'),
+(3, 'Cc01287', 'xyz'), (5, 'd12345', 'efg');
+select distinct if(sum(a), b, 0) from t1 group by value(c) with rollup;
+if(sum(a), b, 0)
+Aa123456
+drop table t1;
+#
 # end of 10.5 tests
 #

--- a/mysql-test/main/distinct.test
+++ b/mysql-test/main/distinct.test
@@ -915,5 +915,17 @@ select distinct a from t1 where t1.a=1 and t1.a in (select a+0 from t2 where t2.
 drop table t1,t2;
 
 --echo #
+--echo # MDEV-31743 Server crash in store_length, assertion failure in
+--echo #            Type_handler_string_result::sort_length
+--echo #
+
+create table t1 (a int, b longtext, c varchar(18));
+insert into t1 values (1, 'Aa123456', 'abc'), (2, 'Bb7897777', 'def'),
+  (3, 'Cc01287', 'xyz'), (5, 'd12345', 'efg');
+
+select distinct if(sum(a), b, 0) from t1 group by value(c) with rollup;
+drop table t1;
+
+--echo #
 --echo # end of 10.5 tests
 --echo #

--- a/sql/filesort.cc
+++ b/sql/filesort.cc
@@ -2275,7 +2275,8 @@ sortlength(THD *thd, Sort_keys *sort_keys, bool *allow_packing_for_sortkeys)
       set_if_smaller(sortorder->length, thd->variables.max_sort_length);
       set_if_smaller(sortorder->original_length, thd->variables.max_sort_length);
     }
-    length+=sortorder->length;
+    DBUG_ASSERT(length < UINT_MAX32 - sortorder->length);
+    length+= sortorder->length;
 
     sort_keys->increment_size_of_packable_fields(sortorder->length_bytes);
     sort_keys->increment_original_sort_length(sortorder->original_length);

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -24629,6 +24629,9 @@ JOIN_TAB::remove_duplicates()
       {
         /* Item is not stored in temporary table, remember it */
         sorder->item= item;
+        sorder->type= sorder->item->type_handler()->is_packable() ?
+                      SORT_FIELD_ATTR::VARIABLE_SIZE :
+                      SORT_FIELD_ATTR::FIXED_SIZE;
         /* Calculate sorder->length */
         item->type_handler()->sort_length(thd, item, sorder);
         sorder++;


### PR DESCRIPTION
…ndler_string_result::sort_length

After MDEV-21580 the truncation of SORT_FIELD::length
  set_if_smaller(sortorder->length, thd->variables.max_sort_length)

became conditional:
  if (is_variable_sized())
    set_if_smaller(length, thd->variables.max_sort_length)

To provide correct functioning of is_variable_sized() SORT_FIELD::type must be set properly. This commit adds the necessary initialization of SORT_FIELD::type to JOIN_TAB::remove_duplicates() as it is done in filesort's sortlength() function.

DBUG_ASSERT is added to sortlength() just in case to prevent a possible uint32 overflow

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31743*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
