### PR TITLE
Revert MDEV-19210

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -190,9 +190,6 @@ ELSE()
   SET(localstatedir ${MYSQL_DATADIR})
 ENDIF()
 
-get_filename_component(MYSQL_UNIX_DIR ${MYSQL_UNIX_ADDR} DIRECTORY)
-SET(mysqlunixdir ${MYSQL_UNIX_DIR})
-
 SET(resolveip_locations "$basedir/${INSTALL_BINDIR} $basedir/bin")
 SET(mysqld_locations "$basedir/${INSTALL_SBINDIR} $basedir/libexec $basedir/sbin $basedir/bin")
 SET(errmsg_locations "$basedir/${INSTALL_MYSQLSHAREDIR}/english $basedir/share/english $basedir/share/mysql/english")
@@ -207,18 +204,6 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/mysql_install_db.sh
 
 INSTALL_SCRIPT(
  "${CMAKE_CURRENT_BINARY_DIR}/mysql_install_db"
-  DESTINATION ${INSTALL_SCRIPTDIR}
-  COMPONENT Server
-  )
-
-CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/galera_new_cluster.sh
-  ${CMAKE_CURRENT_BINARY_DIR}/galera_new_cluster ESCAPE_QUOTES @ONLY)
-  EXECUTE_PROCESS(
-  COMMAND chmod +x ${CMAKE_CURRENT_BINARY_DIR}/galera_new_cluster
-  )
-
-INSTALL_SCRIPT(
- "${CMAKE_CURRENT_BINARY_DIR}/galera_new_cluster"
   DESTINATION ${INSTALL_SCRIPTDIR}
   COMPONENT Server
   )

--- a/scripts/galera_new_cluster.sh
+++ b/scripts/galera_new_cluster.sh
@@ -21,11 +21,11 @@ EOF
     exit 0
 fi
 
-echo _WSREP_NEW_CLUSTER='--wsrep-new-cluster' > @mysqlunixdir@/"wsrep-new-cluster-${1:-mariadb}" && \
+systemctl set-environment _WSREP_NEW_CLUSTER='--wsrep-new-cluster' && \
     systemctl restart ${1:-mariadb}
 
 extcode=$?
 
-rm -f @mysqlunixdir@/"wsrep-new-cluster-${1:-mariadb}"
+systemctl set-environment _WSREP_NEW_CLUSTER=''
 
 exit $extcode

--- a/support-files/CMakeLists.txt
+++ b/support-files/CMakeLists.txt
@@ -32,8 +32,6 @@ ELSE()
   SET(MYSQLD_GROUP "mysql")
   SET(ini_file_extension "cnf")
   SET(HOSTNAME "uname -n")
-  get_filename_component(MYSQL_UNIX_DIR ${MYSQL_UNIX_ADDR} DIRECTORY)
-  SET(mysqlunixdir ${MYSQL_UNIX_DIR})
 ENDIF()
 
 # XXX: shouldn't we just have variables for all this stuff and centralise

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -70,20 +70,20 @@ ProtectSystem=full
 # Prevent accessing /home, /root and /run/user
 ProtectHome=true
 
-# Use an environment file to pass variable _WSREP_START_POSITION
-EnvironmentFile=-@mysqlunixdir@/wsrep-start-position
+# Execute pre and post scripts as root, otherwise it does it as User=
+PermissionsStartOnly=true
 
 @SYSTEMD_EXECSTARTPRE@
 
 # Perform automatic wsrep recovery. When server is started without wsrep,
 # galera_recovery simply returns an empty string. In any case, however,
 # the script is not expected to return with a non-zero status.
-# It is always safe to remove @mysqlunixdir@/wsrep-start-position
-# environment file.
+# It is always safe to unset _WSREP_START_POSITION environment variable.
 # Do not panic if galera_recovery script is not available. (MDEV-10538)
+ExecStartPre=/bin/sh -c "systemctl unset-environment _WSREP_START_POSITION"
 ExecStartPre=/bin/sh -c "[ ! -e @bindir@/galera_recovery ] && VAR= || \
  VAR=`cd @bindir@/..; @bindir@/galera_recovery`; [ $? -eq 0 ] \
- && echo _WSREP_START_POSITION=$VAR > @mysqlunixdir@/wsrep-start-position || exit 1"
+ && systemctl set-environment _WSREP_START_POSITION=$VAR || exit 1"
 
 # Needed to create system tables etc.
 # ExecStartPre=@scriptdir@/mysql_install_db -u mysql
@@ -96,7 +96,7 @@ ExecStartPre=/bin/sh -c "[ ! -e @bindir@/galera_recovery ] && VAR= || \
 ExecStart=@sbindir@/mysqld $MYSQLD_OPTS $_WSREP_NEW_CLUSTER $_WSREP_START_POSITION
 
 # Unset _WSREP_START_POSITION environment variable.
-ExecStartPost=/bin/rm -f @mysqlunixdir@/wsrep-start-position
+ExecStartPost=/bin/sh -c "systemctl unset-environment _WSREP_START_POSITION"
 
 @SYSTEMD_EXECSTARTPOST@
 

--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -70,9 +70,6 @@ ProtectSystem=full
 # Prevent accessing /home, /root and /run/user
 ProtectHome=true
 
-# Use an environment file to pass variable _WSREP_NEW_CLUSTER
-EnvironmentFile=-@mysqlunixdir@/wsrep-new-cluster-%N
-
 # Use an environment file to pass variable _WSREP_START_POSITION
 EnvironmentFile=-@mysqlunixdir@/wsrep-start-position
 


### PR DESCRIPTION
Reverts the fix for MDEV-19210 from PR #1143. This breaks Debian in old BuildBot in a way that cannot be easily resolved.