### PR TITLE
oqgraph: remove clang warnings

### DIFF
--- a/storage/oqgraph/graphcore.cc
+++ b/storage/oqgraph/graphcore.cc
@@ -146,17 +146,6 @@ namespace open_query
       HAVE_EDGE = 4,
     };
 
-    // Force assignment operator, so we can trace through in the debugger
-    inline reference& operator=(const reference& ref) 
-    {    
-      m_flags = ref.m_flags;
-      m_sequence = ref.m_sequence;
-      m_vertex = ref.m_vertex;
-      m_edge = ref.m_edge;
-      m_weight = ref.m_weight;
-      return *this;
-    }
-
     inline reference()
       : m_flags(0), m_sequence(0),
         m_vertex(graph_traits<Graph>::null_vertex()),

--- a/storage/oqgraph/oqgraph_judy.h
+++ b/storage/oqgraph/oqgraph_judy.h
@@ -107,7 +107,6 @@ namespace open_query
       size_type n;
     };
 
-    reference operator[](size_type n) { return reference(*this, n); }
     bool operator[](size_type n) const { return test(n); }
 
     size_type find_first() const;

--- a/storage/oqgraph/oqgraph_shim.h
+++ b/storage/oqgraph/oqgraph_shim.h
@@ -60,9 +60,6 @@ namespace oqgraph3
     edge_iterator(const graph_ptr& graph, size_t offset=0)
       : _graph(graph)
       , _offset(offset) { }
-    edge_iterator(const edge_iterator& pos)
-      : _graph(pos._graph)
-      , _offset(pos._offset) { }
     value_type operator*();
     self& operator+=(size_t n) { _offset+= n; return *this; }
     self& operator++() { ++_offset; return *this; }


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

-Wdeprecated-copy-with-user-provided-copy was causing a few errors on things that where defined in a way that was implicit. By removing code it now compiles without warnings.

tested with fc38 / clang-16

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
