### PR TITLE
MDEV-31963 Fix libfmt usage

### DIFF
--- a/cmake/libfmt.cmake
+++ b/cmake/libfmt.cmake
@@ -33,8 +33,9 @@ MACRO (CHECK_LIBFMT)
      #include <fmt/format-inl.h>
      #include <iostream>
      int main() {
+       int answer= 42;
        fmt::format_args::format_arg arg=
-         fmt::detail::make_arg<fmt::format_context>(42);
+         fmt::detail::make_arg<fmt::format_context>(answer);
          std::cout << fmt::vformat(\"The answer is {}.\",
                                    fmt::format_args(&arg, 1));
      }" HAVE_SYSTEM_LIBFMT)

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -1407,11 +1407,24 @@ namespace fmt {
 */
 String *Item_func_sformat::val_str(String *res)
 {
+  /*
+    A union that stores a numeric format arg value.
+    fmt::detail::make_arg does not accept temporaries, so all of its numeric
+    args are temporarily stored in the fmt_args array.
+    See: https://github.com/fmtlib/fmt/issues/3596
+  */
+  union Format_arg_store {
+    longlong val_int;
+    float    val_float;
+    double   val_double;
+  };
+
   DBUG_ASSERT(fixed());
-  using                         ctx=     fmt::format_context;
-  String                       *fmt_arg= NULL;
-  String                       *parg=    NULL;
-  fmt::format_args::format_arg *vargs=   NULL;
+  using                         ctx=      fmt::format_context;
+  String                       *fmt_arg=  NULL;
+  String                       *parg=     NULL;
+  fmt::format_args::format_arg *vargs=    NULL;
+  Format_arg_store             *fmt_args= NULL;
 
   null_value= true;
   if (!(fmt_arg= args[0]->val_str(res)))
@@ -1420,25 +1433,39 @@ String *Item_func_sformat::val_str(String *res)
   if (!(vargs= new fmt::format_args::format_arg[arg_count - 1]))
     return NULL;
 
+  if (!(fmt_args= new Format_arg_store[arg_count - 1]))
+  {
+    delete [] vargs;
+    return NULL;
+  }
+
   /* Creates the array of arguments for vformat */
   for (uint carg= 1; carg < arg_count; carg++)
   {
     switch (args[carg]->result_type())
     {
     case INT_RESULT:
-      vargs[carg-1]= fmt::detail::make_arg<ctx>(args[carg]->val_int());
+      fmt_args[carg-1].val_int= args[carg]->val_int();
+      vargs[carg-1]= fmt::detail::make_arg<ctx>(fmt_args[carg-1].val_int);
       break;
     case DECIMAL_RESULT: // TODO
     case REAL_RESULT:
       if (args[carg]->field_type() == MYSQL_TYPE_FLOAT)
-        vargs[carg-1]= fmt::detail::make_arg<ctx>((float)args[carg]->val_real());
+      {
+        fmt_args[carg-1].val_float= (float)args[carg]->val_real();
+        vargs[carg-1]= fmt::detail::make_arg<ctx>(fmt_args[carg-1].val_float);
+      }
       else
-        vargs[carg-1]= fmt::detail::make_arg<ctx>(args[carg]->val_real());
+      {
+        fmt_args[carg-1].val_double= args[carg]->val_real();
+        vargs[carg-1]= fmt::detail::make_arg<ctx>(fmt_args[carg-1].val_double);
+      }
       break;
     case STRING_RESULT:
       if (!(parg= args[carg]->val_str(&val_arg[carg-1])))
       {
         delete [] vargs;
+        delete [] fmt_args;
         return NULL;
       }
       vargs[carg-1]= fmt::detail::make_arg<ctx>(*parg);
@@ -1448,6 +1475,7 @@ String *Item_func_sformat::val_str(String *res)
     default:
       DBUG_ASSERT(0);
       delete [] vargs;
+      delete [] fmt_args;
       return NULL;
     }
   }
@@ -1471,6 +1499,7 @@ String *Item_func_sformat::val_str(String *res)
     null_value= true;
   }
   delete [] vargs;
+  delete [] fmt_args;
   return null_value ? NULL : res;
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31963*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

As described in [MDEV-31963](https://jira.mariadb.org/browse/MDEV-31963), MariaDB fails to build with libfmt 10.1.0 because `fmt::detail::make_arg` no longer accepts temporaries. (See also: https://github.com/fmtlib/fmt/issues/3596#issuecomment-1679244746.) This PR fixes the code snippet that checks the system libfmt, and also the `SFORMAT` code that makes use of libfmt.

## How can this PR be tested?

I do not think addition or modification to test cases is necessary; [`func_sformat.test`](https://github.com/MariaDB/server/blob/11.3/mysql-test/main/func_sformat.test) should continue to pass.

To verify the fix, one could install libfmt 10.1.0 locally and build MariaDB 10.7 or later against that. I applied the changes to MariaDB 11.0.3 and 10.9.8 and can confirm that it fixes the build. For the examples in the [`SFORMAT` documentation](https://mariadb.com/kb/en/sformat/), the patched builds continue to provide the same results.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

NB. This fix only applies to 10.7 and later since [`SFORMAT`](https://mariadb.com/kb/en/sformat/) was added in 10.7.0. I based my branch on 10.10 as the final release ([10.9.8](https://mariadb.com/kb/en/mariadb-10-9-8-release-notes/)) in the 10.9 series has been made.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
