### PR TITLE
MDEV-32004: Parse error in mtr tests when using rpl_check_server_ids

### DIFF
--- a/mysql-test/include/rpl_change_topology.inc
+++ b/mysql-test/include/rpl_change_topology.inc
@@ -5,15 +5,15 @@
 # need to change topology after they have sourced include/rpl_init.inc
 #
 # This file sets up variables needed by include/rpl_sync.inc and many
-# other replication scripts in the include/ directory.  It also issues
+# other replication scripts in the include/ directory. It also issues
 # CHANGE MASTER on all servers where the configuration changes from
-# what it was before.  It does not issue START SLAVE (use
+# what it was before. It does not issue START SLAVE (use
 # include/rpl_start_slaves.inc for that).
 #
 # Note: it is not currently possible to change the number of servers
 # after the rpl_init.inc, without first calling rpl_end.inc. So the
 # test has to set $rpl_server_count to the total number of servers
-# that the test uses, before it sources include/rpl_init.inc.  After
+# that the test uses, before it sources include/rpl_init.inc. After
 # that, $rpl_server_count must not change until after next time the
 # test sources include/rpl_end.inc.
 #
@@ -37,7 +37,7 @@
 #     By default, CHANGE MASTER is executed with MASTER_LOG_FILE set
 #     to the name of the last binlog file on the master (retrieved by
 #     executing SHOW MASTER STATUS). This variable can be set to
-#     specify another filename.  This variable should be a
+#     specify another filename. This variable should be a
 #     comma-separated list of the following form:
 #
 #       SERVER_NUMBER_1:FILE_NAME_1,SERVER_NUMBER_2:FILE_NAME_2,...
@@ -45,7 +45,7 @@
 #     Before CHANGE MASTER is executed on server N, this script checks
 #     if $rpl_master_log_file contains the text N:FILE_NAME. If it
 #     does, then MASTER_LOG_FILE is set to FILE_NAME. Otherwise,
-#     MASTER_LOG_FILE is set to the last binlog on the master.  For
+#     MASTER_LOG_FILE is set to the last binlog on the master. For
 #     example, to specify that server_1 should start replicate from
 #     master-bin.000007 and server_5 should start replicate from
 #     master-bin.012345, do:
@@ -53,9 +53,9 @@
 #
 #   $rpl_master_log_pos
 #     By default, CHANGE MASTER is executed without specifying the
-#     MASTER_LOG_POS parameter.  This variable can be set to set a
-#     specific position.  It has the same form as $rpl_master_log_file
-#     (see above).  For example, to specify that server_3 should start
+#     MASTER_LOG_POS parameter. This variable can be set to set a
+#     specific position. It has the same form as $rpl_master_log_file
+#     (see above). For example, to specify that server_3 should start
 #     replicate from position 4711 of its master, do:
 #       --let $rpl_master_log_pos= 3:4711
 #
@@ -72,7 +72,7 @@
 #   include/rpl_stop_slaves.inc
 #   include/rpl_end.inc
 #
-# $rpl_server_count_length:
+# $rpl_server_count_length
 #   Set to LENGTH($rpl_server_count). So if $rpl_server_count < 10,
 #   then $rpl_server_count_length = 1; if 10 <= $rpl_server_count <
 #   100, then $rpl_server_count_length = 2, etc.
@@ -83,12 +83,12 @@
 #   server N is a slave, then the N'th number is the master of server
 #   N. If server N is not a slave, then the N'th number is just spaces
 #   (so in fact it is not a number). For example, if $rpl_topology is
-#   '1->2,2->3,3->1,2->4,5->6', then $rpl_master_list is '3122 6'.
+#   '1->2,2->3,3->1,2->4,5->6', then $rpl_master_list is '3122 5'.
 #
 # $rpl_sync_chain_dirty
-#   This variable is set to 1.  This tells include/rpl_sync.inc to
+#   This variable is set to 1. This tells include/rpl_sync.inc to
 #   compute a new value for $rpl_sync_chain next time that
-#   include/rpl_sync.inc is sourced.  See
+#   include/rpl_sync.inc is sourced. See
 #   include/rpl_generate_sync_chain.inc and include/rpl_sync.inc for
 #   details.
 
@@ -124,7 +124,7 @@ if ($rpl_master_list == '')
 if ($rpl_debug)
 {
   --echo \$rpl_server_count='$rpl_server_count'
-  --echo \$rpl_server_count_length='$rpl_server_count_length'
+  --echo old \$rpl_server_count_length='$rpl_server_count_length'
   --echo new \$rpl_topology='$_rpl_topology'
   --echo old \$rpl_master_list='$rpl_master_list'
   --echo old \$rpl_sync_chain='$rpl_sync_chain'
@@ -210,6 +210,10 @@ if (!$rpl_skip_change_master)
         --let $rpl_connection_name= server_$_rpl_master
         --source include/rpl_connection.inc
         --let $_rpl_master_log_file= query_get_value(SHOW MASTER STATUS, File, 1)
+        if ($rpl_debug)
+        {
+          --echo "\$rpl_master_log_file parameter not set for the master: $_rpl_master, use the latest binlog file by executing SHOW MASTER STATUS."
+        }
       }
       # Change connection.
       --let $rpl_connection_name= server_$_rpl_server
@@ -224,6 +228,10 @@ if (!$rpl_skip_change_master)
       if (!$_rpl_master_log_pos_index)
       {
         --let $_rpl_master_log_pos=
+        if ($rpl_debug)
+        {
+          --echo "\$rpl_master_log_pos parameter not set for the master: $_rpl_master. Set log position to empty."
+        }
       }
       eval CHANGE MASTER TO MASTER_HOST = '127.0.0.1', MASTER_PORT = $_rpl_port, MASTER_USER = 'root', MASTER_LOG_FILE = '$_rpl_master_log_file'$_rpl_master_log_pos, MASTER_CONNECT_RETRY = 1;
     }

--- a/mysql-test/include/rpl_connect.inc
+++ b/mysql-test/include/rpl_connect.inc
@@ -5,7 +5,7 @@
 # This script is normally used internally by rpl_init.inc and
 # master-slave.inc, but it can also be used in test cases that need to
 # create more connections or re-create connections after disconnect.
-#
+# Default ports SERVER_MYPORT_[1,2] are set by rpl_init.inc.
 #
 # ==== Usage ====
 #

--- a/mysql-test/include/rpl_end.inc
+++ b/mysql-test/include/rpl_end.inc
@@ -103,11 +103,9 @@ while ($_rpl_server)
 
 --connection default
 --let $_rpl_server= $rpl_server_count
---let $_rpl_one= _1
 while ($_rpl_server)
 {
   --disconnect server_$_rpl_server
-  --disconnect server_$_rpl_server$_rpl_one
   --dec $_rpl_server
 }
 

--- a/mysql-test/include/rpl_for_each_slave.inc
+++ b/mysql-test/include/rpl_for_each_slave.inc
@@ -1,7 +1,7 @@
 # ==== Purpose ====
 #
 # Execute a .inc file once for each server that was configured as a
-# slave by rpl_init.inc
+# slave by rpl_init.inc, for example start_slave.inc or stop_slave.inc file.
 #
 #
 # ==== Usage ====
@@ -13,6 +13,20 @@
 # Parameters:
 #   $rpl_source_file
 #     The file that will be sourced.
+#
+#   $rpl_server_count
+#     The number of servers to configure. If this is not set, the largest
+#     number in $rpl_topology will be used.
+#     This parameter is obtained from rpl_init.inc.
+#
+#   $rpl_master_list
+#     This parameter is calculated from within rpl_init.inc.
+#
+#   $rpl_server_count_length
+#     Set to LENGTH($rpl_server_count). So if $rpl_server_count < 10,
+#     then $rpl_server_count_length = 1; if 10 <= $rpl_server_count <
+#     100, then $rpl_server_count_length = 2, etc.
+#     This parameter is calculated from within rpl_change_topology.inc.
 #
 #   $rpl_debug
 #     See include/rpl_init.inc

--- a/mysql-test/include/rpl_init.inc
+++ b/mysql-test/include/rpl_init.inc
@@ -32,8 +32,9 @@
 #
 #    (It is allowed, but not required, to configure SERVER_MYPORT_1
 #    and SERVER_MYPORT_2 too. If these variables are not set, the
-#    variables MASTER_MYPORT and SLAVE_MYPORT, configured in the
-#    default my.cnf used by the rpl suite, are used instead.)
+#    variables MASTER_MYPORT and SLAVE_MYPORT are used instead.
+#    These variables are configured in the rpl_1slave_base.cnf,
+#    that is used in the default my.cnf, which is used by the rpl suite.)
 #
 # 2. Execute the following near the top of the test:
 #
@@ -193,18 +194,30 @@ if ($rpl_check_server_ids)
   }
 }
 
-# $rpl_master_list must be set so that include/rpl_change_topology.inc
-# knows which servers are initialized and not.
+if ($rpl_debug)
+{
+  --echo ---- Check the topology and call CHANGE MASTER ----
+}
+
+# $rpl_master_list must be set so that include/rpl_change_topology.inc and later
+# include/rpl_for_each_slave.inc knows which servers are initialized and not.
 --let $rpl_master_list= `SELECT REPEAT('x', $rpl_server_count * LENGTH($rpl_server_count))`
 --source include/rpl_change_topology.inc
 
 
 if (!$rpl_skip_start_slave)
 {
+  if ($rpl_debug)
+  {
+    --echo ---- Start slaves ----
+  }
   --source include/rpl_start_slaves.inc
 }
 
-
+if ($rpl_debug)
+{
+  --echo ---- Set connection to the server_1 ----
+}
 --let $rpl_connection_name= server_1
 --source include/rpl_connection.inc
 

--- a/mysql-test/include/rpl_init.inc
+++ b/mysql-test/include/rpl_init.inc
@@ -3,10 +3,7 @@
 # Set up replication on several servers in a specified topology.
 #
 # By default, this script does the following:
-#  - Creates the connections server_1, server_2, ..., server_N, as
-#    well as extra connections server_1_1, server_2_1, ...,
-#    server_N_1. server_I and server_I_1 are connections to the same
-#    server.
+#  - Creates the connections server_1, server_2, ..., server_N.
 #  - Calls RESET MASTER, RESET SLAVE, USE test, CHANGE MASTER, START SLAVE.
 #  - Sets the connection to server_1 before exiting.
 # With $rpl_check_server_ids parameter, the script does the following:
@@ -143,17 +140,14 @@ if (!$rpl_debug)
 }
 
 
-# Create two connections to each server; reset master/slave, select
+# Create connection to the server; reset master/slave, select
 # database, set autoinc variables.
 --let $_rpl_server= $rpl_server_count
---let $_rpl_one= _1
 while ($_rpl_server)
 {
   # Connect.
   --let $rpl_server_number= $_rpl_server
   --let $rpl_connection_name= server_$_rpl_server
-  --source include/rpl_connect.inc
-  --let $rpl_connection_name= server_$_rpl_server$_rpl_one
   --source include/rpl_connect.inc
 
   # Configure server.

--- a/mysql-test/include/rpl_init.inc
+++ b/mysql-test/include/rpl_init.inc
@@ -7,14 +7,15 @@
 #    well as extra connections server_1_1, server_2_1, ...,
 #    server_N_1. server_I and server_I_1 are connections to the same
 #    server.
-#  - Verifies that @@server_id of all servers are different.
 #  - Calls RESET MASTER, RESET SLAVE, USE test, CHANGE MASTER, START SLAVE.
 #  - Sets the connection to server_1 before exiting.
+# With $rpl_check_server_ids parameter, the script does the following:
+#  - Verifies that @@server_id of all servers are different.
 #
 # ==== Usage ====
 #
 # 1. If you are going to use more than two servers, create
-#    rpl_test.cfg with the following contents:
+#    rpl_test.cnf with the following contents:
 #
 #    !include ../my.cnf
 #    [mysqld.1]
@@ -189,7 +190,7 @@ if ($rpl_check_server_ids)
     while ($_rpl_server2)
     {
       --let $assert_text= Servers $_rpl_server and $_rpl_server2 should have different @@server_id
-      --let $assert_condition= [$_rpl_server:SELECT @@server_id AS i, i, 1] != [$_rpl_server2:SELECT @@server_id AS i, i, 1]
+      --let $assert_cond= [SELECT @@server_id AS i, i, 1] != $_rpl_server
 
       --source include/assert.inc
       --dec $_rpl_server2

--- a/mysql-test/include/rpl_reconnect.inc
+++ b/mysql-test/include/rpl_reconnect.inc
@@ -72,11 +72,6 @@ if (!$_rpl_server_number)
 --source include/rpl_connection.inc
 --enable_reconnect
 
---let $_rpl_one= _1
---let $rpl_connection_name= server_$rpl_server_number$_rpl_one
---source include/rpl_connection.inc
---enable_reconnect
-
 if ($rpl_debug)
 {
   --echo ---- Wait for reconnect and disable reconnect on all connections ----
@@ -121,12 +116,6 @@ if (!$_rpl_server_number)
 --source include/rpl_connection.inc
 --source include/wait_until_connected_again.inc
 --disable_reconnect
-
---let $rpl_connection_name= server_$rpl_server_number$_rpl_one
---source include/rpl_connection.inc
---source include/wait_until_connected_again.inc
---disable_reconnect
-
 
 --let $include_filename= rpl_reconnect.inc
 --source include/end_include_file.inc

--- a/mysql-test/include/rpl_start_slaves.inc
+++ b/mysql-test/include/rpl_start_slaves.inc
@@ -19,7 +19,7 @@
 #
 #   $slave_timeout
 #     Set the timeout when waiting for slave threads to stop and
-#     start, respectively.  See include/wait_for_slave_param.inc
+#     start, respectively. See include/wait_for_slave_param.inc
 
 
 --let $include_filename= rpl_start_slaves.inc

--- a/mysql-test/include/wait_for_slave_io_to_start.inc
+++ b/mysql-test/include/wait_for_slave_io_to_start.inc
@@ -14,13 +14,14 @@
 #
 # Parameters:
 #   $slave_timeout
-#     See include/wait_for_slave_param.inc
+#     Timeout used when waiting for the slave IO thread to start.
+#     See include/wait_for_slave_param.inc.
 #
 #   $rpl_allow_error
 #     By default, this file fails if there is an error in the IO
-#     thread.  However, the IO thread can recover and reconnect after
-#     certain errors.  If such an error is expected, can set
-#     $rpl_allow_error=1.  This will prevent this file from failing if
+#     thread. However, the IO thread can recover and reconnect after
+#     certain errors. If such an error is expected, can set
+#     $rpl_allow_error=1. This will prevent this file from failing if
 #     there is an error in the IO thread.
 #
 #   $rpl_debug

--- a/mysql-test/include/wait_for_slave_sql_to_start.inc
+++ b/mysql-test/include/wait_for_slave_sql_to_start.inc
@@ -11,6 +11,7 @@
 #
 # Parameters:
 #   $slave_timeout
+#     Timeout used when waiting for the slave SQL thread to start.
 #     See include/wait_for_slave_param.inc
 #
 #   $rpl_debug
@@ -25,7 +26,7 @@ let $slave_param= Slave_SQL_Running;
 let $slave_param_value= Yes;
 
 # Unfortunately, the slave sql thread sets Slave_SQL_Running=Yes
-# *before* it clears Last_SQL_Errno.  So we have to allow errors in
+# *before* it clears Last_SQL_Errno. So we have to allow errors in
 # the SQL thread here.
 
 #--let $slave_error_param= Last_SQL_Errno

--- a/mysql-test/include/wait_for_slave_to_start.inc
+++ b/mysql-test/include/wait_for_slave_to_start.inc
@@ -12,6 +12,7 @@
 #
 # Parameters:
 #   $slave_timeout
+#     Timeout used when waiting for the slave threads to start.
 #     See include/wait_for_slave_param.inc
 #
 #   $rpl_debug


### PR DESCRIPTION
* Make `rpl_check_server_ids` argument work again.
* Remove extra connections namely `server_[1,2,..]_1`, that were created during initalization in `rpl_init.inc`, recreated in `rpl_reconnect.inc` and removed in `rpl_end.inc`.
They are dead connections, not used anywhere in `rpl` suite.
* Cosmetic fixes
  * Fix errors in `rpl_init.inc` regarding the comments
    * sed 's/.cfg/.cnf/'
    * Verifying server_id is not by default but with using `rpl_check_server_ids` parameter.
    * Add comment why extra connections `server_[i,..,N]_1` are needed, since there is no usage of env variables `[MASTER,SLAVE]_PORT1` except in `rpl_show_slave_hosts.test`.
* Other cleanup
  * More debug messages,
  * Missing arguments
  * Spaces.

* `rpl_init.inc` flow chart
![image](https://github.com/MariaDB/server/assets/8207668/d09f3d24-49dd-4b83-8de2-9c8474504137)


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
