### PR TITLE
Remove duplicated default client include from replication my.cnf

### DIFF
--- a/mysql-test/suite/rpl/my.cnf
+++ b/mysql-test/suite/rpl/my.cnf
@@ -1,8 +1,8 @@
 # Use settings from rpl_1slave_base.cnf
 # add setting to connect the slave to the master by default
 !include rpl_1slave_base.cnf
-!include include/default_client.cnf
-
-
-[mysqld.2]
-
+# Override specific server settings using [mariadb-x.y] option group
+# from `test.cnf` file right after including this file.
+# E.g. after !include ../my.cnf, in your `test.cnf`, specify your configuration
+# in option group e.g [mysqld.x], so that number `x` corresponds to the number
+# in the rpl server topology.


### PR DESCRIPTION
- `default_client` is included already in `rpl_1slave_base.cnf`, so remove it from `my.cnf`
- Remove option group for `mysqld` server as and add comment how to override specific settings for specific server

- Reviewer: <brandon.nesterenko@mariadb.com>

- Dependency graph (red component in the diagram is related to the PR):

![image](https://github.com/MariaDB/server/assets/8207668/a4405f26-bbb9-49e4-9e23-2b9f336a4a23)





