### PR TITLE
MDEV-29861 : Galera "notify" test cases hang

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -13,10 +13,6 @@
 galera_as_slave_ctas : MDEV-28378 timeout
 galera_pc_recovery : MDEV-25199 cluster fails to start up
 galera_sst_encrypted : MDEV-29876 Galera test failure on galera_sst_encrypted
-galera.MW-284 : MDEV-29861 Galera test case hangs
-galera.galera_binlog_checksum : MDEV-29861 Galera test case hangs
-galera_var_notify_ssl_ipv6 : MDEV-29861 Galera test case hangs
-galera_var_notify_cmd: MDEV-29861 Galera test case hangs
 galera_var_node_address : MDEV-20485 Galera test failure
 MDEV-26575 : MDEV-29878 Galera test failure on MDEV-26575
 galera_bf_abort_group_commit : MDEV-30855 PR to remove the test exists

--- a/sql/wsrep_notify.cc
+++ b/sql/wsrep_notify.cc
@@ -21,6 +21,13 @@
 void wsrep_notify_status(enum wsrep::server_state::state status,
                          const wsrep::view* view)
 {
+  if (!view)
+  {
+    WSREP_DEBUG("wsrep_notify_status server not yet ready : wsrep_ready=%d status %d",
+		wsrep_ready, (int)status);
+    return;
+  }
+
   if (!wsrep_notify_cmd || 0 == strlen(wsrep_notify_cmd))
   {
     WSREP_INFO("wsrep_notify_cmd is not defined, skipping notification.");

--- a/sql/wsrep_utils.h
+++ b/sql/wsrep_utils.h
@@ -189,7 +189,11 @@ public:
 
   void set(enum wsrep::server_state::state status)
   {
-    wsrep_notify_status(status);
+    if (status == wsrep::server_state::s_donor ||
+	status == wsrep::server_state::s_synced)
+      wsrep_notify_status(status, &view_);
+    else
+      wsrep_notify_status(status);
 
     lock();
     status_= status;


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29861*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Problem was that if wsrep_notify_cmd was set it was called with a new status "joined" it tries to connect to the server to update some table, but the server isn't initialized yet, it's not listening for connections. So the server waits for the script to finish, script waits for mariadb client to connect, and the client cannot connect, because the server isn't listening.

Fix is to call script only when Galera has already formed a view or when it is synched or donor.

This fix also enables following test cases:
* galera.MW-284
* galera.galera_binlog_checksum
* galera_var_notify_ssl_ipv6

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
