### PR TITLE
MDEV-32018 Allow the setting of Auto_increment on FK referenced columns

### DIFF
--- a/mysql-test/suite/innodb/r/foreign_key.result
+++ b/mysql-test/suite/innodb/r/foreign_key.result
@@ -892,4 +892,19 @@ DROP INDEX fx ON t1;
 INSERT INTO t1 VALUES (2,11,11);
 DROP TABLE t1;
 SET FOREIGN_KEY_CHECKS=DEFAULT;
+#
+# MDEV-32018 Allow the setting of Auto_increment on FK referenced columns
+#
+CREATE TABLE t1 (
+id int unsigned NOT NULL PRIMARY KEY
+);
+CREATE TABLE t2 (
+id int unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
+t1_id int unsigned DEFAULT NULL,
+CONSTRAINT FK_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id)
+);
+ALTER TABLE t1 MODIFY id INT unsigned AUTO_INCREMENT;
+DROP TABLE t1,t2;
+#
 # End of 10.4 tests
+#

--- a/mysql-test/suite/innodb/t/foreign_key.test
+++ b/mysql-test/suite/innodb/t/foreign_key.test
@@ -935,6 +935,26 @@ INSERT INTO t1 VALUES (2,11,11);
 DROP TABLE t1;
 SET FOREIGN_KEY_CHECKS=DEFAULT;
 
--- echo # End of 10.4 tests
+--echo #
+--echo # MDEV-32018 Allow the setting of Auto_increment on FK referenced columns
+--echo #
+
+CREATE TABLE t1 (
+  id int unsigned NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE t2 (
+  id int unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  t1_id int unsigned DEFAULT NULL,
+  CONSTRAINT FK_t1_id FOREIGN KEY (t1_id) REFERENCES t1 (id)
+);
+
+ALTER TABLE t1 MODIFY id INT unsigned AUTO_INCREMENT;
+
+DROP TABLE t1,t2;
+
+--echo #
+--echo # End of 10.4 tests
+--echo #
 
 --source include/wait_until_count_sessions.inc


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32018*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

In MDEV-31086, SET FOREIGN_KEY_CHECKS=0 cannot bypass checks that make column types of foreign keys incompatible. An unfortunate consequence is that adding an AUTO_INCREMENT is considered incompatible in Field_{num,decimal}::is_equal and for the purpose of FK checks this isn't relevant.

The reason for the auto_increment check in is_equal seems to resolve mysql bug #14573 which still affects Aria and MyISAM storage engines but not InnoDB.

## How can this PR be tested?

mtr test included.

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [*] *This is a feature addition for a limited set of functionality that was removed in a bug fix and hence cased a regression for @horrockss.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [*] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [*] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
