### PR TITLE
MDEV-31177: SHOW SLAVE STATUS Last_SQL_Errno Race Condition on Errored Slave Restart

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
+++ b/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
@@ -6,10 +6,7 @@ change master to master_use_gtid=slave_pos;
 set @@global.slave_parallel_threads= 4;
 set @@global.slave_parallel_mode= optimistic;
 set @@global.gtid_strict_mode=ON;
-set sql_log_bin= 0;
-alter table mysql.gtid_slave_pos engine=innodb;
-call mtr.add_suppression("Deadlock found.*");
-set sql_log_bin= 1;
+set statement sql_log_bin=0 for alter table mysql.gtid_slave_pos engine=innodb;
 include/start_slave.inc
 connection master;
 create table t1 (a int primary key, b int) engine=innodb;
@@ -27,21 +24,21 @@ xa end '1';
 xa prepare '1';
 xa commit '1';
 include/save_master_gtid.inc
-connection slave;
 connection slave1;
 BEGIN;
 SELECT * FROM mysql.gtid_slave_pos WHERE seq_no=100 FOR UPDATE;
 domain_id	sub_id	server_id	seq_no
 connection slave;
 include/start_slave.inc
-include/wait_for_slave_sql_error.inc [errno=1942,1213]
+include/wait_for_slave_sql_error.inc [errno=1942]
+include/stop_slave_io.inc
 connection slave1;
 ROLLBACK;
 # Cleanup
 connection master;
 drop table t1;
 connection slave;
-include/stop_slave.inc
+# TODO: Remove after fixing MDEV-29642
 set @@global.gtid_slave_pos= "0-1-100";
 set @@global.slave_parallel_threads= 0;
 set @@global.gtid_strict_mode= 0;

--- a/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
+++ b/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
@@ -34,15 +34,26 @@ include/wait_for_slave_sql_error.inc [errno=1942]
 include/stop_slave_io.inc
 connection slave1;
 ROLLBACK;
+#
+# MDEV-31177: Ensure that when the slave restarts, the last error code
+# displayed by SHOW SLAVE STATUS does not present along a true value for
+# Slave_SQL_Running
+set @@global.gtid_slave_pos= "0-1-100";
+set @@global.debug_dbug= "+d,delay_sql_thread_after_release_run_lock";
+include/start_slave.inc
+set debug_sync= "now wait_for sql_thread_run_lock_released";
+set debug_sync= "now signal sql_thread_continue";
 # Cleanup
 connection master;
 drop table t1;
 connection slave;
+include/stop_slave.inc
 # TODO: Remove after fixing MDEV-29642
-set @@global.gtid_slave_pos= "0-1-100";
 set @@global.slave_parallel_threads= 0;
 set @@global.gtid_strict_mode= 0;
 set @@global.innodb_lock_wait_timeout= 50;
+set @@global.debug_dbug= "";
+set debug_sync= "RESET";
 include/start_slave.inc
 include/rpl_end.inc
 # End of rpl_xa_prepare_gtid_fail.test

--- a/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
+++ b/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
@@ -2,6 +2,9 @@ include/master-slave.inc
 [connection master]
 connection slave;
 include/stop_slave.inc
+set @save_par_thds= @@global.slave_parallel_threads;
+set @save_strict_mode= @@global.gtid_strict_mode;
+set @save_innodb_lock_wait_timeout= @@global.innodb_lock_wait_timeout;
 change master to master_use_gtid=slave_pos;
 set @@global.slave_parallel_threads= 4;
 set @@global.slave_parallel_mode= optimistic;
@@ -39,11 +42,12 @@ ROLLBACK;
 # displayed by SHOW SLAVE STATUS does not present along a true value for
 # Slave_SQL_Running
 set @@global.gtid_slave_pos= "0-1-100";
+set @save_dbug = @@global.debug_dbug;
 set @@global.debug_dbug= "+d,delay_sql_thread_after_release_run_lock";
 include/start_slave.inc
 set debug_sync= "now wait_for sql_thread_run_lock_released";
 set debug_sync= "now signal sql_thread_continue";
-set @@global.debug_dbug= "";
+set @@global.debug_dbug= @saved_dbug;
 set debug_sync= "RESET";
 # Cleanup
 connection master;
@@ -51,9 +55,9 @@ drop table t1;
 connection slave;
 include/stop_slave.inc
 # TODO: Remove after fixing MDEV-21777
-set @@global.slave_parallel_threads= 0;
-set @@global.gtid_strict_mode= 0;
-set @@global.innodb_lock_wait_timeout= 50;
+set @@global.slave_parallel_threads= @save_par_thds;
+set @@global.gtid_strict_mode= @save_strict_mode;
+set @@global.innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
 include/start_slave.inc
 include/rpl_end.inc
 # End of rpl_xa_prepare_gtid_fail.test

--- a/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
+++ b/mysql-test/suite/rpl/r/rpl_xa_prepare_gtid_fail.result
@@ -43,17 +43,17 @@ set @@global.debug_dbug= "+d,delay_sql_thread_after_release_run_lock";
 include/start_slave.inc
 set debug_sync= "now wait_for sql_thread_run_lock_released";
 set debug_sync= "now signal sql_thread_continue";
+set @@global.debug_dbug= "";
+set debug_sync= "RESET";
 # Cleanup
 connection master;
 drop table t1;
 connection slave;
 include/stop_slave.inc
-# TODO: Remove after fixing MDEV-29642
+# TODO: Remove after fixing MDEV-21777
 set @@global.slave_parallel_threads= 0;
 set @@global.gtid_strict_mode= 0;
 set @@global.innodb_lock_wait_timeout= 50;
-set @@global.debug_dbug= "";
-set debug_sync= "RESET";
 include/start_slave.inc
 include/rpl_end.inc
 # End of rpl_xa_prepare_gtid_fail.test

--- a/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
+++ b/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
@@ -19,6 +19,8 @@
 source include/master-slave.inc;
 source include/have_binlog_format_row.inc;
 source include/have_innodb.inc;
+source include/have_debug.inc;
+source include/have_debug_sync.inc;
 
 --connection slave
 --source include/stop_slave.inc
@@ -26,6 +28,7 @@ source include/have_innodb.inc;
 --let $save_par_thds= `SELECT @@global.slave_parallel_threads`
 --let $save_strict_mode= `SELECT @@global.gtid_strict_mode`
 --let $save_innodb_lock_wait_timeout= `SELECT @@global.innodb_lock_wait_timeout`
+--let $save_debug= `SELECT @@global.debug_dbug`
 
 change master to master_use_gtid=slave_pos;
 set @@global.slave_parallel_threads= 4;
@@ -85,17 +88,38 @@ if ($retried_tx_initial != $retried_tx_test)
 --connection slave1
 ROLLBACK;
 
+--echo #
+--echo # MDEV-31177: Ensure that when the slave restarts, the last error code
+--echo # displayed by SHOW SLAVE STATUS does not present along a true value for
+--echo # Slave_SQL_Running
+--eval set @@global.gtid_slave_pos= "$new_gtid"
+set @@global.debug_dbug= "+d,delay_sql_thread_after_release_run_lock";
+--source include/start_slave.inc
+set debug_sync= "now wait_for sql_thread_run_lock_released";
+--let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1)
+set debug_sync= "now signal sql_thread_continue";
+if ($last_error)
+{
+    --echo # Last_SQL_Errno: $last_error
+    --die SHOW SLAVE STATUS shows the error from the last session on startup
+}
+
+#--echo # witing for mysig
+#set debug_sync="now wait_for mysig";
+
 --echo # Cleanup
 
 --connection master
 drop table t1;
 
 --connection slave
+--source include/stop_slave.inc
 --echo # TODO: Remove after fixing MDEV-29642
---eval set @@global.gtid_slave_pos= "$new_gtid"
 --eval set @@global.slave_parallel_threads= $save_par_thds
 --eval set @@global.gtid_strict_mode= $save_strict_mode
 --eval set @@global.innodb_lock_wait_timeout= $save_innodb_lock_wait_timeout
+--eval set @@global.debug_dbug= "$save_debug"
+set debug_sync= "RESET";
 --source include/start_slave.inc
 
 --source include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
+++ b/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
@@ -28,7 +28,6 @@ source include/have_debug_sync.inc;
 --let $save_par_thds= `SELECT @@global.slave_parallel_threads`
 --let $save_strict_mode= `SELECT @@global.gtid_strict_mode`
 --let $save_innodb_lock_wait_timeout= `SELECT @@global.innodb_lock_wait_timeout`
---let $save_debug= `SELECT @@global.debug_dbug`
 
 change master to master_use_gtid=slave_pos;
 set @@global.slave_parallel_threads= 4;
@@ -73,7 +72,7 @@ BEGIN;
 --let $slave_sql_errno= 1942
 --source include/wait_for_slave_sql_error.inc
 
-# TODO: Remove after fixing MDEV-29642
+# TODO: Remove after fixing MDEV-21777
 # Stop the IO thread too, so the existing relay logs are force purged on slave
 # restart, as to not re-execute the already-prepared transaction
 --source include/stop_slave_io.inc
@@ -93,6 +92,7 @@ ROLLBACK;
 --echo # displayed by SHOW SLAVE STATUS does not present along a true value for
 --echo # Slave_SQL_Running
 --eval set @@global.gtid_slave_pos= "$new_gtid"
+--let $save_debug= `SELECT @@global.debug_dbug`
 set @@global.debug_dbug= "+d,delay_sql_thread_after_release_run_lock";
 --source include/start_slave.inc
 set debug_sync= "now wait_for sql_thread_run_lock_released";
@@ -104,22 +104,19 @@ if ($last_error)
     --die SHOW SLAVE STATUS shows the error from the last session on startup
 }
 
-#--echo # witing for mysig
-#set debug_sync="now wait_for mysig";
+--eval set @@global.debug_dbug= "$save_debug"
+set debug_sync= "RESET";
 
 --echo # Cleanup
-
 --connection master
 drop table t1;
 
 --connection slave
 --source include/stop_slave.inc
---echo # TODO: Remove after fixing MDEV-29642
+--echo # TODO: Remove after fixing MDEV-21777
 --eval set @@global.slave_parallel_threads= $save_par_thds
 --eval set @@global.gtid_strict_mode= $save_strict_mode
 --eval set @@global.innodb_lock_wait_timeout= $save_innodb_lock_wait_timeout
---eval set @@global.debug_dbug= "$save_debug"
-set debug_sync= "RESET";
 --source include/start_slave.inc
 
 --source include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
+++ b/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
@@ -6,8 +6,8 @@
 # GTID slave state, then the slave should immediately quit in error, without
 # retry.
 #
-#   This tests validates the above behavior by simulating a deadlock on the
-# GTID slave state table during the second part of XA PREPARE's commit, to
+#   This tests validates the above behavior by forcing a lock-wait timeout on
+# the GTID slave state table during the second part of XA PREPARE's commit, to
 # ensure that the appropriate error is reported and the transaction was never
 # retried.
 #
@@ -32,14 +32,10 @@ set @@global.slave_parallel_threads= 4;
 set @@global.slave_parallel_mode= optimistic;
 set @@global.gtid_strict_mode=ON;
 
-set sql_log_bin= 0;
-alter table mysql.gtid_slave_pos engine=innodb;
-call mtr.add_suppression("Deadlock found.*");
-set sql_log_bin= 1;
+set statement sql_log_bin=0 for alter table mysql.gtid_slave_pos engine=innodb;
 --source include/start_slave.inc
 
 --connection master
-let $datadir= `select @@datadir`;
 create table t1 (a int primary key, b int) engine=innodb;
 insert t1 values (1,1);
 --source include/save_master_gtid.inc
@@ -64,11 +60,6 @@ xa prepare '1';
 xa commit '1';
 --source include/save_master_gtid.inc
 
-
---connection slave
-
-#--eval set statement sql_log_bin=0 for insert into mysql.gtid_slave_pos values ($gtid_domain_id, 5, $gtid_server_id, $xap_seq_no)
-
 --connection slave1
 BEGIN;
 --eval SELECT * FROM mysql.gtid_slave_pos WHERE seq_no=$xap_seq_no FOR UPDATE
@@ -76,8 +67,13 @@ BEGIN;
 --connection slave
 --source include/start_slave.inc
 
---let $slave_sql_errno= 1942,1213
+--let $slave_sql_errno= 1942
 --source include/wait_for_slave_sql_error.inc
+
+# TODO: Remove after fixing MDEV-29642
+# Stop the IO thread too, so the existing relay logs are force purged on slave
+# restart, as to not re-execute the already-prepared transaction
+--source include/stop_slave_io.inc
 
 --let $retried_tx_test= query_get_value(SHOW ALL SLAVES STATUS, Retried_transactions, 1)
 if ($retried_tx_initial != $retried_tx_test)
@@ -95,7 +91,7 @@ ROLLBACK;
 drop table t1;
 
 --connection slave
---source include/stop_slave.inc
+--echo # TODO: Remove after fixing MDEV-29642
 --eval set @@global.gtid_slave_pos= "$new_gtid"
 --eval set @@global.slave_parallel_threads= $save_par_thds
 --eval set @@global.gtid_strict_mode= $save_strict_mode

--- a/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
+++ b/mysql-test/suite/rpl/t/rpl_xa_prepare_gtid_fail.test
@@ -25,9 +25,9 @@ source include/have_debug_sync.inc;
 --connection slave
 --source include/stop_slave.inc
 
---let $save_par_thds= `SELECT @@global.slave_parallel_threads`
---let $save_strict_mode= `SELECT @@global.gtid_strict_mode`
---let $save_innodb_lock_wait_timeout= `SELECT @@global.innodb_lock_wait_timeout`
+set @save_par_thds= @@global.slave_parallel_threads;
+set @save_strict_mode= @@global.gtid_strict_mode;
+set @save_innodb_lock_wait_timeout= @@global.innodb_lock_wait_timeout;
 
 change master to master_use_gtid=slave_pos;
 set @@global.slave_parallel_threads= 4;
@@ -92,7 +92,7 @@ ROLLBACK;
 --echo # displayed by SHOW SLAVE STATUS does not present along a true value for
 --echo # Slave_SQL_Running
 --eval set @@global.gtid_slave_pos= "$new_gtid"
---let $save_debug= `SELECT @@global.debug_dbug`
+set @save_dbug = @@global.debug_dbug;
 set @@global.debug_dbug= "+d,delay_sql_thread_after_release_run_lock";
 --source include/start_slave.inc
 set debug_sync= "now wait_for sql_thread_run_lock_released";
@@ -104,7 +104,7 @@ if ($last_error)
     --die SHOW SLAVE STATUS shows the error from the last session on startup
 }
 
---eval set @@global.debug_dbug= "$save_debug"
+set @@global.debug_dbug= @saved_dbug;
 set debug_sync= "RESET";
 
 --echo # Cleanup
@@ -114,9 +114,9 @@ drop table t1;
 --connection slave
 --source include/stop_slave.inc
 --echo # TODO: Remove after fixing MDEV-21777
---eval set @@global.slave_parallel_threads= $save_par_thds
---eval set @@global.gtid_strict_mode= $save_strict_mode
---eval set @@global.innodb_lock_wait_timeout= $save_innodb_lock_wait_timeout
+set @@global.slave_parallel_threads= @save_par_thds;
+set @@global.gtid_strict_mode= @save_strict_mode;
+set @@global.innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
 --source include/start_slave.inc
 
 --source include/rpl_end.inc

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -5357,6 +5357,16 @@ pthread_handler_t handle_slave_sql(void *arg)
   mysql_mutex_unlock(&rli->run_lock);
   mysql_cond_broadcast(&rli->start_cond);
 
+#ifdef ENABLED_DEBUG_SYNC
+  DBUG_EXECUTE_IF("delay_sql_thread_after_release_run_lock", {
+    const char act[]= "now "
+                      "signal sql_thread_run_lock_released "
+                      "wait_for sql_thread_continue";
+    DBUG_ASSERT(debug_sync_service);
+    DBUG_ASSERT(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));
+  };);
+#endif
+
   /*
     Reset errors for a clean start (otherwise, if the master is idle, the SQL
     thread may execute no Query_log_event, so the error will remain even


### PR DESCRIPTION
The SQL thread and a user connection executing SHOW SLAVE STATUS
have a race condition on Last_SQL_Errno, such that a slave which
previously errored and stopped, on its next start, SHOW SLAVE STATUS
can show that the SQL Thread is running while the previous error is
also showing.

The fix is to move when the last error is cleared when the SQL
thread starts to occur before setting the status of
Slave_SQL_Running.


The PR commits are as follows:
 1. Cleanup of test rpl_xa_prepare_gtid_fail, unrelated to the bug
 2. Extend rpl_xa_prepare_gtid_fail with a test case which shows the presence of the bug
 3. The patch which fixes the bug

The remainder of the commits are to address reviews.