### PR TITLE
MDEV-25177 Better indication of refusing to start because of ProtectHome

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9299,7 +9299,7 @@ static int test_if_case_insensitive(const char *dir_name)
                                buff, 0666, O_RDWR, MYF(0))) < 0)
   {
     if (!opt_abort)
-      sql_print_warning("Can't create test file %s", buff);
+      sql_print_warning("Can't create test file '%s' (Errcode: %M)", buff, my_errno);
     DBUG_RETURN(-1);
   }
   mysql_file_close(file, MYF(0));


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-25177*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Create test for for case insensitive gives a basic warning on creating a test file and the next thing a user might see is an abort.

ProtectHome and other systemd setting protect system services from accessing user data. Unfortunately some of our users do put things on /home due space or other reasons.

Rather than enumerate the systemd options in a very clunkly fragile way we put an error associated with the "Can't create test file" and hope the user can work it out from there.

## How can this PR be tested?

As RO file systems can't be done in mtr.

ProtectHome in systemd is a read only mount so:

```
mkdir /tmp/d /tmp/e
sudo mount --bind /tmp/d /tmp/e -o ro
$ scripts/mariadb-install-db --no-defaults --srcdir=$OLDPWD --builddir=$PWD --datadir=/tmp/e --verbose  
Installing MariaDB/MySQL system tables in '/tmp/e' ...
2023-08-31  9:06:38 0 [Warning] Can't create test file /tmp/e/bark.lower-test: Read-only file system
2023-08-31  9:06:38 0 [Note] Starting MariaDB 10.4.31-MariaDB source revision 2aea9387497cecb5668ef605b8f80886f9de812c as process 337866
2023-08-31  9:06:38 0 [ERROR] mysqld: Can't create/write to file '/tmp/e/aria_log_control' (Errcode: 30 "Read-only file system")
2023-08-31  9:06:38 0 [ERROR] mysqld: Got error 'Can't create file' when trying to use aria control file '/tmp/e/aria_log_control'
2023-08-31  9:06:38 0 [ERROR] Plugin 'Aria' registration as a STORAGE ENGINE failed.
2023-08-31  9:06:38 0 [Note] InnoDB: Using Linux native AIO
2023-08-31  9:06:38 0 [Note] InnoDB: The first innodb_system data file 'ibdata1' did not exist. A new tablespace will be created!
2023-08-31  9:06:38 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2023-08-31  9:06:38 0 [Note] InnoDB: Uses event mutexes
2023-08-31  9:06:38 0 [Note] InnoDB: Compressed tables use zlib 1.2.13
2023-08-31  9:06:38 0 [Note] InnoDB: Number of pools: 1
2023-08-31  9:06:38 0 [Note] InnoDB: Using SSE2 crc32 instructions
2023-08-31  9:06:38 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
2023-08-31  9:06:38 0 [Note] InnoDB: Completed initialization of buffer pool
2023-08-31  9:06:38 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
2023-08-31  9:06:38 0 [ERROR] InnoDB: Operating system error number 30 in a file operation.
2023-08-31  9:06:38 0 [ERROR] InnoDB: Error number 30 means 'Read-only file system'
2023-08-31  9:06:38 0 [Note] InnoDB: Some operating system error numbers are described at https://mariadb.com/kb/en/library/operating-system-error-codes/
2023-08-31  9:06:38 0 [ERROR] InnoDB: File ./ibdata1: 'create' returned OS error 230. Cannot continue operation
```

# install an existing datadir on /tmp/d
```
$ scripts/mariadb-install-db --no-defaults --srcdir=$OLDPWD --builddir=$PWD --datadir=/tmp/d --verbose  
```

# start on RO fs
```
$ sql/mariadbd --no-defaults --datadir=/tmp/e --socket=/tmp/${PWD##*/}.sock --plugin-dir=${PWD}/mysql-test/var/plugins/ --verbose --skip-networking
2023-08-31  9:07:54 0 [Warning] Can't create test file /tmp/e/bark.lower-test: Read-only file system
2023-08-31  9:07:54 0 [Note] Starting MariaDB 10.4.31-MariaDB source revision 2aea9387497cecb5668ef605b8f80886f9de812c as process 337987
2023-08-31  9:07:54 0 [ERROR] mariadbd: File '/tmp/e/aria_log_control' not found (Errcode: 30 "Read-only file system")
2023-08-31  9:07:54 0 [ERROR] mariadbd: Got error 'Can't open file' when trying to use aria control file '/tmp/e/aria_log_control'
2023-08-31  9:07:54 0 [ERROR] Plugin 'Aria' registration as a STORAGE ENGINE failed.
2023-08-31  9:07:54 0 [Note] InnoDB: Using Linux native AIO
2023-08-31  9:07:54 0 [ERROR] InnoDB: The innodb_system data file 'ibdata1' must be writable
2023-08-31  9:07:54 0 [ERROR] InnoDB: The innodb_system data file 'ibdata1' must be writable
2023-08-31  9:07:54 0 [ERROR] Plugin 'InnoDB' registration as a STORAGE ENGINE failed.
2023-08-31  9:07:54 0 [Note] Plugin 'FEEDBACK' is disabled.
2023-08-31  9:07:54 0 [ERROR] Could not open mysql.plugin table. Some plugins may be not loaded
2023-08-31  9:07:54 0 [ERROR] Failed to initialize plugins.
2023-08-31  9:07:54 0 [ERROR] Aborting
```


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
