### PR TITLE
[MDEV-32102] new capability to ensure having result-set intermediate EOF

### DIFF
--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -288,6 +288,9 @@ enum enum_indicator_type
 /* Do not resend metadata for prepared statements, since 10.6*/
 #define MARIADB_CLIENT_CACHE_METADATA (1ULL << 36)
 
+/* Always send Result-set intermediate EOF whatever CLIENT_DEPRECATE_EOF is set or not*/
+#define MARIADB_CLIENT_SEND_INTERMEDIATE_EOF (1ULL << 37)
+
 #ifdef HAVE_COMPRESS
 #define CAN_CLIENT_COMPRESS CLIENT_COMPRESS
 #else
@@ -329,7 +332,8 @@ enum enum_indicator_type
                            MARIADB_CLIENT_STMT_BULK_OPERATIONS |\
                            MARIADB_CLIENT_EXTENDED_METADATA|\
                            MARIADB_CLIENT_CACHE_METADATA |\
-                           CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS)
+                           CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS |\
+                           MARIADB_CLIENT_SEND_INTERMEDIATE_EOF)
 /*
   Switch off the flags that are optional and depending on build flags
   If any of the optional flags is supported by the build it will be switched

--- a/sql/protocol.h
+++ b/sql/protocol.h
@@ -93,7 +93,7 @@ public:
   virtual ~Protocol() = default;
   void init(THD* thd_arg);
 
-  enum { SEND_NUM_ROWS= 1, SEND_EOF= 2, SEND_FORCE_COLUMN_INFO= 4 };
+  enum { SEND_NUM_ROWS= 1, SEND_EOF= 2, SEND_FORCE_COLUMN_INFO= 4, SEND_PREPARE_EOF= 8 };
   virtual bool send_result_set_metadata(List<Item> *list, uint flags);
   bool send_list_fields(List<Field> *list, const TABLE_LIST *table_list);
   bool send_result_set_row(List<Item> *row_items);

--- a/sql/sql_cache.h
+++ b/sql/sql_cache.h
@@ -549,6 +549,7 @@ struct Query_cache_query_flags
   unsigned int client_long_flag:1;
   unsigned int client_protocol_41:1;
   unsigned int client_extended_metadata:1;
+  unsigned int client_intermediate_eof:1;
   unsigned int client_depr_eof:1;
   unsigned int protocol_type:2;
   unsigned int more_results_exists:1;

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -358,7 +358,7 @@ static bool send_prep_stmt(Prepared_statement *stmt, uint columns)
     */
     error= thd->protocol_text.send_result_set_metadata(
                 (List<Item> *)&stmt->lex->param_list,
-                Protocol::SEND_EOF | Protocol::SEND_FORCE_COLUMN_INFO);
+                Protocol::SEND_PREPARE_EOF | Protocol::SEND_FORCE_COLUMN_INFO);
   }
 
   if (likely(!error))
@@ -1488,7 +1488,7 @@ static int mysql_test_select(Prepared_statement *stmt,
       unit->prepare call above.
     */
     if (send_prep_stmt(stmt, lex->result->field_count(fields)) ||
-        lex->result->send_result_set_metadata(fields, Protocol::SEND_EOF) ||
+        lex->result->send_result_set_metadata(fields, Protocol::SEND_PREPARE_EOF) ||
         thd->protocol->flush())
       goto error;
     DBUG_RETURN(2);
@@ -1755,7 +1755,7 @@ static int send_stmt_metadata(THD *thd, Prepared_statement *stmt, List<Item> *fi
     return 0;
 
   if (send_prep_stmt(stmt, fields->elements) ||
-      thd->protocol->send_result_set_metadata(fields, Protocol::SEND_EOF) ||
+      thd->protocol->send_result_set_metadata(fields, Protocol::SEND_PREPARE_EOF) ||
       thd->protocol->flush())
     return 1;
 
@@ -2102,7 +2102,7 @@ static int mysql_test_handler_read(Prepared_statement *stmt,
       DBUG_RETURN(1);
 
     if (send_prep_stmt(stmt, ha_table->fields.elements) ||
-        lex->result->send_result_set_metadata(ha_table->fields, Protocol::SEND_EOF) ||
+        lex->result->send_result_set_metadata(ha_table->fields, Protocol::SEND_PREPARE_EOF) ||
         thd->protocol->flush())
       DBUG_RETURN(1);
     DBUG_RETURN(2);
@@ -2482,8 +2482,7 @@ static bool check_prepared_statement(Prepared_statement *stmt)
          res= thd->prepare_explain_fields(&result, &field_list,
                                           lex->describe, lex->analyze_stmt) ||
               send_prep_stmt(stmt, result.field_count(field_list)) ||
-              result.send_result_set_metadata(field_list,
-                                                    Protocol::SEND_EOF);
+              result.send_result_set_metadata(field_list, Protocol::SEND_PREPARE_EOF);
        }
        else
          res= send_prep_stmt(stmt, 0);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-32102](https://jira.mariadb.org/browse/MDEV-32102)

## Description
Since MySQL 5.7 and [MDEV-8931](https://jira.mariadb.org/browse/MDEV-8931) for MariaDB, capability CLIENT_DEPRECATE_EOF is present on server, but design has some flows: connectors don't have intermediate EOF anymore on resultset.
This intermediate did have some interesting pieces of information in status_flags like SERVER_MORE_RESULTS_EXIST, SERVER_PS_OUT_PARAMS.

When using binary protocol, calling a stored procedure, output parameters are sent as a resultset. This resultset was identified with intermediate EOF. This piece of information is now present on ending ok_packet only, AFTER having read the rows.

CLIENT_DEPRECATE_EOF capability cannot be set by connector without creating lots of issues.

This task is to add a new specific capability that will indicate to always have the intermediate EOF packet, even with CLIENT_DEPRECATE_EOF activated.

## How can this PR be tested?

MTR updated + java connector tested with and without CLIENT_DEPRECATE_EOF and SEND_INTERMEDIATE_EOF capabilities

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
