### PR TITLE
MDEV-29581: MariaDB-backup prepare lists wrong replication position

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -6255,12 +6255,6 @@ static bool xtrabackup_prepare_func(char** argv)
           my_free(xid_list);
         }
 
-	if (ok) {
-		msg("Last binlog file %s, position %lld",
-		    trx_sys.recovered_binlog_filename,
-		    longlong(trx_sys.recovered_binlog_offset));
-	}
-
 	/* Check whether the log is applied enough or not. */
 	if ((srv_start_lsn || fil_space_get(SRV_LOG_SPACE_FIRST_ID))
 	    && srv_start_lsn < target_lsn) {

--- a/mysql-test/suite/mariabackup/binlog.result
+++ b/mysql-test/suite/mariabackup/binlog.result
@@ -3,6 +3,5 @@ INSERT INTO t VALUES(1);
 SHOW VARIABLES like 'log_bin';
 Variable_name	Value
 log_bin	ON
-FOUND 1 /Last binlog file .*, position .*/ in current_test
-# expect FOUND
+master-bin.000001	XXXX\tPOS
 DROP TABLE t;

--- a/mysql-test/suite/mariabackup/binlog.test
+++ b/mysql-test/suite/mariabackup/binlog.test
@@ -7,6 +7,7 @@ CREATE TABLE t(a varchar(60)) ENGINE INNODB;
 INSERT INTO t VALUES(1);
 
 SHOW VARIABLES like 'log_bin';
+--let $pos=`SELECT @@gtid_current_pos`
 
 --disable_result_log
 exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --target-dir=$basedir;
@@ -14,10 +15,9 @@ exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --target-dir
 
 exec $XTRABACKUP --prepare --binlog-info=1 --target-dir=$basedir ;
 
-let SEARCH_FILE=$MYSQLTEST_VARDIR/log/current_test;
---let SEARCH_PATTERN= Last binlog file .*, position .*
---source include/search_pattern_in_file.inc
---echo # expect FOUND
+--let $_regex=/[0-9]+.$pos/XXXX\tPOS/
+--replace_regex $_regex
+--cat_file $basedir/xtrabackup_binlog_info
 
 DROP TABLE t;
 

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1932,7 +1932,8 @@ files_checked:
 
 			DBUG_PRINT("ib_log", ("apply completed"));
 
-			if (recv_needed_recovery) {
+			if (recv_needed_recovery
+			    && !is_mariabackup_restore_or_export()) {
 				trx_sys_print_mysql_binlog_offset();
 			}
 		}

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4059,23 +4059,10 @@ static int rocksdb_recover(handlerton* hton, XID* xid_list, uint len)
   if (binlog_file && binlog_pos) {
     char file_buf[FN_REFLEN + 1] = {0};
     my_off_t pos;
-    char gtid_buf[FN_REFLEN + 1] = {0};
     if (binlog_manager.read(file_buf, &pos, gtid_buf)) {
       if (is_binlog_advanced(binlog_file, *binlog_pos, file_buf, pos)) {
         memcpy(binlog_file, file_buf, FN_REFLEN + 1);
         *binlog_pos = pos;
-        // NO_LINT_DEBUG
-        fprintf(stderr,
-                "RocksDB: Last binlog file position %llu,"
-                " file name %s\n",
-                pos, file_buf);
-        if (*gtid_buf) {
-          global_sid_lock->rdlock();
-          binlog_max_gtid->parse(global_sid_map, gtid_buf);
-          global_sid_lock->unlock();
-          // NO_LINT_DEBUG
-          fprintf(stderr, "RocksDB: Last MySQL Gtid %s\n", gtid_buf);
-        }
       }
     }
   }


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29581*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The position in the output of the prepare shouldn't be used as a replication position. That is in the xtrabackup_binlog_info file. Listing it in the output could lead to mistake use.

Remove the unfinished RocksDB output even though the code is commented.

Change test mariabackup.binlog to ensure the same binlog position as the file.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
