### PR TITLE
MEV-26312: Record iter methods for JOIN_CACHE_BNL

### DIFF
--- a/sql/sql_join_cache.h
+++ b/sql/sql_join_cache.h
@@ -1124,6 +1124,27 @@ protected:
   void read_next_candidate_for_match(uchar *rec_ptr);
 
 public:
+  /*
+    The following functions are used by a 3rd party storage engine
+    to iterate over the contents of the join buffer for engine condition
+    pushdown during JOINs.
+  */
+
+  bool iterator_init() { return prepare_look_for_matches(false); }
+
+  uchar *iterator_get_next() { return get_next_candidate_for_match(); }
+
+  void iterator_unpack_current(uchar *rec_ptr) {
+    return read_next_candidate_for_match(rec_ptr);
+  }
+
+  uint get_num_fields() { return fields; }
+
+  CACHE_FIELD *get_field_descr() { return field_descr; }
+
+  CACHE_FIELD **get_blob_ptr() { return blob_ptr; }
+
+  /**************************************/
 
   /* 
     This constructor creates an unlinked BNL join cache. The cache is to be


### PR DESCRIPTION
This commit creates new public methods to iterate the join cache. This is useful for engine condition pushdown in remote storage engines. In addition to push the condition, we can also push data to match rows during JOIN.
This avoids full table scan and hence full table read over the network.

Commit copied from #2176 and rebased to 11.3 to eliminate the merge commit.

- [x] *The Jira issue number for this PR is: MDEV-26312*

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
