### PR TITLE
MDEV-29993: myrocks_hotbackup.1 and test suite files installed when e…

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -1,5 +1,10 @@
 # TODO: Copyrights
 
+IF(PLUGIN_ROCKSDB STREQUAL "NO")
+  ADD_FEATURE_INFO(ROCKSDB "OFF" "Storage Engine")
+  RETURN()
+ENDIF()
+
 SET(CPACK_RPM_rocksdb-engine_PACKAGE_SUMMARY "RocksDB storage engine for MariaDB server" PARENT_SCOPE)
 SET(CPACK_RPM_rocksdb-engine_PACKAGE_DESCRIPTION "The RocksDB storage engine is a high performance storage engine, aimed
 at maximising storage efficiency while maintaining InnoDB-like performance." PARENT_SCOPE)


### PR DESCRIPTION
…ngine is disabled

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

No means no, so don't install rocksdb files.

## How can this PR be tested?

```
 1026  cmake -DPLUGIN_ROCKSDB=DYNAMIC . 
 1027  b
 1029  cmake --install . --prefix /tmp/i
 1030  find /tmp/i | grep rocks
 1031  cmake -DPLUGIN_ROCKSDB=NO . 
 1032  b
 1033  cmake --install . --prefix /tmp/j
 1034  find /tmp/j | grep rocks
```

Second install will not contain rocksdb - (except for small number of mariabackup tests)


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
