### PR TITLE
MDEV-31285 : Assertion `state() == s_executing || state() == s_prepar…

### DIFF
--- a/mysql-test/suite/galera/r/mdev-31285.result
+++ b/mysql-test/suite/galera/r/mdev-31285.result
@@ -1,0 +1,23 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_1;
+CREATE TABLE t ENGINE=InnoDB WITH SYSTEM VERSIONING AS SELECT 1 AS i;
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `i` int(1) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci WITH SYSTEM VERSIONING
+SELECT * from t;
+i
+1
+DROP TABLE IF EXISTS t;
+COMMIT;
+connection node_2;
+SET SESSION wsrep_sync_wait=0;
+Killing server ...
+Starting server ...
+connection node_2;
+call mtr.add_suppression("WSREP: Event .*Write_rows_v1 apply failed:.*");
+call mtr.add_suppression("SREP: Failed to apply write set: gtid:.*");

--- a/mysql-test/suite/galera/t/mdev-31285.test
+++ b/mysql-test/suite/galera/t/mdev-31285.test
@@ -1,0 +1,34 @@
+--source include/galera_cluster.inc
+
+--let $node_1 = node_1
+--let $node_2 = node_2
+--source include/auto_increment_offset_save.inc
+
+--connection node_1
+CREATE TABLE t ENGINE=InnoDB WITH SYSTEM VERSIONING AS SELECT 1 AS i;
+SHOW CREATE TABLE t;
+SELECT * from t;
+DROP TABLE IF EXISTS t;
+COMMIT;
+
+#
+# Restart node_2, force SST because database is inconsistent compared to node_1
+#
+--connection node_2
+SET SESSION wsrep_sync_wait=0;
+--source include/kill_galera.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
+--echo Starting server ...
+let $restart_noprint=2;
+--source include/start_mysqld.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_ready';
+--source include/wait_condition.inc
+
+--connection node_2
+call mtr.add_suppression("WSREP: Event .*Write_rows_v1 apply failed:.*");
+call mtr.add_suppression("SREP: Failed to apply write set: gtid:.*");
+
+--source include/auto_increment_offset_restore.inc

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2377,7 +2377,17 @@ void rpl_group_info::slave_close_thread_tables(THD *thd)
 {
   DBUG_ENTER("rpl_group_info::slave_close_thread_tables(THD *thd)");
   thd->get_stmt_da()->set_overwrite_status(true);
-  thd->is_error() ? trans_rollback_stmt(thd) : trans_commit_stmt(thd);
+#ifdef WITH_WSREP
+  // This can happen e.g. when table_def::compatible_with fails and sets a error
+  // but thd->is_error() is false then. However, we do not want to commit
+  // statement on Galera instead we want to rollback it as later in
+  // apply_write_set we rollback transaction and that can't be done
+  // after wsrep transaction state is s_committed.
+  if (WSREP(thd))
+    (thd->is_error() || thd->is_slave_error) ? trans_rollback_stmt(thd) : trans_commit_stmt(thd);
+  else
+#endif
+    thd->is_error() ? trans_rollback_stmt(thd) : trans_commit_stmt(thd);
   thd->get_stmt_da()->set_overwrite_status(false);
 
   close_thread_tables(thd);


### PR DESCRIPTION
…ing || state() == s_prepared || state() == s_must_abort || state() == s_aborting || state() == s_cert_failed || state() == s_must_replay' failed



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31285*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

When applier tries to execute write rows event it find out in table_def::compatible_with that value is not compatible and sets error and thd->is_slave_error but thd->is_error() is false. Later in rpl_group_info::slave_close_thread_tables we commit stmt. This is bad for Galera because later in apply_write_set we notice that event apply was not successful and try to rollback transaction, but wsrep transaction is already in s_committed state.

This is fixed on rpl_group_info::slave_close_thread_tables so that in Galera case we rollback stmt if thd->is_slave_error or thd->is_error() is set. Then later we can rollback wsrep transaction.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
