### PR TITLE
MDEV-21587: disk.disk test result

### DIFF
--- a/plugin/disks/mysql-test/disks/disks.result
+++ b/plugin/disks/mysql-test/disks/disks.result
@@ -7,6 +7,6 @@ DISKS	CREATE TEMPORARY TABLE `DISKS` (
   `Used` bigint(32) NOT NULL,
   `Available` bigint(32) NOT NULL
 ) ENGINE=MEMORY DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci
-select sum(Total) > sum(Available), sum(Total)>sum(Used) from information_schema.disks;
-sum(Total) > sum(Available)	sum(Total)>sum(Used)
+select sum(Total) >= sum(Available), sum(Total)>=sum(Used) from information_schema.disks;
+sum(Total) >= sum(Available)	sum(Total)>=sum(Used)
 1	1

--- a/plugin/disks/mysql-test/disks/disks.test
+++ b/plugin/disks/mysql-test/disks/disks.test
@@ -1,3 +1,3 @@
 --replace_regex /varchar\([0-9]+\)/varchar(pathlen)/
 show create table information_schema.disks;
-select sum(Total) > sum(Available), sum(Total)>sum(Used) from information_schema.disks;
+select sum(Total) >= sum(Available), sum(Total)>=sum(Used) from information_schema.disks;

--- a/plugin/disks/mysql-test/disks/disks_notembedded.result
+++ b/plugin/disks/mysql-test/disks/disks_notembedded.result
@@ -6,16 +6,16 @@ CREATE USER user1@localhost;
 GRANT SELECT ON *.* TO user1@localhost;
 connect  con1,localhost,user1,,;
 connection con1;
-select sum(Total) > sum(Available), sum(Total)>sum(Used) from information_schema.disks;
-sum(Total) > sum(Available)	sum(Total)>sum(Used)
+select sum(Total) >= sum(Available), sum(Total) >= sum(Used) from information_schema.disks;
+sum(Total) >= sum(Available)	sum(Total) >= sum(Used)
 NULL	NULL
 disconnect con1;
 connection default;
 GRANT FILE ON *.* TO user1@localhost;
 connect  con1,localhost,user1,,;
 connection con1;
-select sum(Total) > sum(Available), sum(Total)>sum(Used) from information_schema.disks;
-sum(Total) > sum(Available)	sum(Total)>sum(Used)
+select sum(Total) >= sum(Available), sum(Total) >= sum(Used) from information_schema.disks;
+sum(Total) >= sum(Available)	sum(Total) >= sum(Used)
 1	1
 connection default;
 DROP USER user1@localhost;

--- a/plugin/disks/mysql-test/disks/disks_notembedded.test
+++ b/plugin/disks/mysql-test/disks/disks_notembedded.test
@@ -10,7 +10,7 @@ GRANT SELECT ON *.* TO user1@localhost;
 
 connect (con1,localhost,user1,,);
 connection con1;
-select sum(Total) > sum(Available), sum(Total)>sum(Used) from information_schema.disks;
+select sum(Total) >= sum(Available), sum(Total) >= sum(Used) from information_schema.disks;
 disconnect con1;
 
 connection default;
@@ -18,7 +18,7 @@ GRANT FILE ON *.* TO user1@localhost;
 
 connect (con1,localhost,user1,,);
 connection con1;
-select sum(Total) > sum(Available), sum(Total)>sum(Used) from information_schema.disks;
+select sum(Total) >= sum(Available), sum(Total) >= sum(Used) from information_schema.disks;
 connection default;
 DROP USER user1@localhost;
 


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-21587*

Thanks Otto Kekäläinen for the bug report.
<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description


Allow for a CI system to be almost out of space, or having so little use, that the Total space is the same as available or used.

## How can this PR be tested?

its a mtr test.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.