### PR TITLE
MDEV-32439 INSERT IGNORE on constraints result in ERROR rather than w…

### DIFF
--- a/mysql-test/main/check_constraint.result
+++ b/mysql-test/main/check_constraint.result
@@ -308,5 +308,61 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop table t1;
 #
-# End of 10.4 tests
+# MDEV-32439 INSERT IGNORE VALUES (one row) errors on constraint
+#
+CREATE TABLE t1 (v1 varchar(10), v2 varchar(10), constraint unequal check (v1 != v2));
+INSERT IGNORE INTO t1 VALUES (1,1);
+Warnings:
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SHOW WARNINGS;
+Level	Code	Message
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+INSERT IGNORE INTO t1 VALUES (1,2),(2,2);
+Warnings:
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SHOW WARNINGS;
+Level	Code	Message
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+INSERT IGNORE INTO t1 VALUES (3,3),(4,4);
+Warnings:
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SHOW WARNINGS;
+Level	Code	Message
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SELECT * FROM t1;
+v1	v2
+1	2
+DROP TABLE t1;
+#
+# MDEV-32439 INSERT IGNORE VALUES (one row) errors on constraint
+#
+CREATE TABLE t1 (v1 varchar(10), v2 varchar(10), constraint unequal check (v1 != v2));
+INSERT IGNORE INTO t1 VALUES (1,1);
+Warnings:
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SHOW WARNINGS;
+Level	Code	Message
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+INSERT IGNORE INTO t1 VALUES (1,2),(2,2);
+Warnings:
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SHOW WARNINGS;
+Level	Code	Message
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+INSERT IGNORE INTO t1 VALUES (3,3),(4,4);
+Warnings:
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SHOW WARNINGS;
+Level	Code	Message
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+Warning	4025	CONSTRAINT `unequal` failed for `test`.`t1`
+SELECT * FROM t1;
+v1	v2
+1	2
+DROP TABLE t1;
+#
+# End of 11.4 tests
 #

--- a/mysql-test/main/check_constraint.test
+++ b/mysql-test/main/check_constraint.test
@@ -232,5 +232,33 @@ show create table t1;
 drop table t1;
 
 --echo #
---echo # End of 10.4 tests
+--echo # MDEV-32439 INSERT IGNORE VALUES (one row) errors on constraint
+--echo #
+
+CREATE TABLE t1 (v1 varchar(10), v2 varchar(10), constraint unequal check (v1 != v2));
+INSERT IGNORE INTO t1 VALUES (1,1);
+SHOW WARNINGS;
+INSERT IGNORE INTO t1 VALUES (1,2),(2,2);
+SHOW WARNINGS;
+INSERT IGNORE INTO t1 VALUES (3,3),(4,4);
+SHOW WARNINGS;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # MDEV-32439 INSERT IGNORE VALUES (one row) errors on constraint
+--echo #
+
+CREATE TABLE t1 (v1 varchar(10), v2 varchar(10), constraint unequal check (v1 != v2));
+INSERT IGNORE INTO t1 VALUES (1,1);
+SHOW WARNINGS;
+INSERT IGNORE INTO t1 VALUES (1,2),(2,2);
+SHOW WARNINGS;
+INSERT IGNORE INTO t1 VALUES (3,3),(4,4);
+SHOW WARNINGS;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo #
+--echo # End of 11.4 tests
 --echo #

--- a/mysql-test/main/view.result
+++ b/mysql-test/main/view.result
@@ -1228,9 +1228,16 @@ drop table t1;
 create table t1 (s1 int);
 create view v1 as select * from t1 where s1 < 5 with check option;
 insert ignore into v1 values (6);
-ERROR 44000: CHECK OPTION failed `test`.`v1`
+Warnings:
+Warning	1369	CHECK OPTION failed `test`.`v1`
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1369	CHECK OPTION failed `test`.`v1`
 insert ignore into v1 values (6),(3);
 Warnings:
+Warning	1369	CHECK OPTION failed `test`.`v1`
+SHOW WARNINGS;
+Level	Code	Message
 Warning	1369	CHECK OPTION failed `test`.`v1`
 select * from t1;
 s1

--- a/mysql-test/main/view.test
+++ b/mysql-test/main/view.test
@@ -1126,15 +1126,16 @@ drop view v2, v1;
 drop table t1;
 
 #
-# inserting single value with check option failed always get error
+# inserting single value with check option warns like 2 values
 #
 create table t1 (s1 int);
 create view v1 as select * from t1 where s1 < 5 with check option;
 #single value
--- error ER_VIEW_CHECK_FAILED
 insert ignore into v1 values (6);
+SHOW WARNINGS;
 #several values
 insert ignore into v1 values (6),(3);
+SHOW WARNINGS;
 select * from t1;
 drop view v1;
 drop table t1;

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1129,11 +1129,7 @@ bool mysql_insert(THD *thd, TABLE_LIST *table_list,
         }
       }
 
-      if ((res= table_list->view_check_option(thd,
-                                              (values_list.elements == 1 ?
-                                               0 :
-                                               ignore))) ==
-          VIEW_CHECK_SKIP)
+      if ((res= table_list->view_check_option(thd, ignore)) == VIEW_CHECK_SKIP)
         continue;
       else if (res == VIEW_CHECK_ERROR)
       {


### PR DESCRIPTION
…arning


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32439*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description


INSERT IGNORE had a pecular undocumented case that when one row was inserted, there was an error rather than a warning.

As LOAD DATA IGNORE, UPDATE IGNORE, INSERT IGNORE SELECT, and INSERT IGNORE VALUES (single row, for foreign key violation) all behave the same way with a warning lets keep the behaviour normalized.

In compatibility, previously a error was generated, now a warning is generated.

This behaviour is now consistent with MySQL-8.0 too.

## How can this PR be tested?

test cases included.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
