### PR TITLE
MDEV-29914: Fix maridab-upgrade when sql_safe_updates = on is set in my.cnf

### DIFF
--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -1006,4 +1006,56 @@ disconnect con1;
 connection default;
 drop table mysql.global_priv;
 rename table mysql.global_priv_bak to mysql.global_priv;
+#
+# mariadb-upgrade fails with sql_safe_updates = on
+#
+set @orig_sql_safe_updates = @@GLOBAL.sql_safe_updates;
+set global sql_safe_updates=ON;
+Phase 1/7: Checking and upgrading mysql database
+Processing databases
+mysql
+mysql.column_stats                                 OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.global_priv                                  OK
+mysql.gtid_slave_pos                               OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.index_stats                                  OK
+mysql.innodb_index_stats                           OK
+mysql.innodb_table_stats                           OK
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.roles_mapping                                OK
+mysql.servers                                      OK
+mysql.table_stats                                  OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.transaction_registry                         OK
+Phase 2/7: Installing used storage engines... Skipped
+Phase 3/7: Fixing views
+mysql.user                                         OK
+Phase 4/7: Running 'mysql_fix_privilege_tables'
+Phase 5/7: Fixing table and database names
+Phase 6/7: Checking and upgrading tables
+Processing databases
+information_schema
+mtr
+mtr.global_suppressions                            OK
+mtr.test_suppressions                              OK
+performance_schema
+test
+Phase 7/7: Running 'FLUSH PRIVILEGES'
+OK
+set global sql_safe_updates=@orig_sql_safe_updates;
 # End of 10.4 tests

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -485,4 +485,14 @@ drop table mysql.global_priv;
 rename table mysql.global_priv_bak to mysql.global_priv;
 --remove_file $MYSQLD_DATADIR/mysql_upgrade_info
 
+--echo #
+--echo # mariadb-upgrade fails with sql_safe_updates = on
+--echo #
+
+set @orig_sql_safe_updates = @@GLOBAL.sql_safe_updates;
+set global sql_safe_updates=ON;
+--exec $MYSQL_UPGRADE --force 2>&1
+--remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+set global sql_safe_updates=@orig_sql_safe_updates;
+
 --echo # End of 10.4 tests

--- a/scripts/mysql_system_tables_fix.sql
+++ b/scripts/mysql_system_tables_fix.sql
@@ -25,6 +25,7 @@
 # adding a 'SHOW WARNINGS' after the statement.
 
 set sql_mode='';
+set sql_safe_updates='OFF';
 set storage_engine=Aria;
 set enforce_storage_engine=NULL;
 set alter_algorithm='DEFAULT';


### PR DESCRIPTION
Tested multiple major version upgrades with sql_safe_updates enabled, and confirmed the issue is resolved.

- [x] *The Jira issue number for this PR is: [MDEV-29914](https://jira.mariadb.org/browse/MDEV-29914)

## Description
Some applications run with MariaDB `sql_safe_updates = on`, to ensure updates and deletes always reference keys.

When upgrading major versions however, having this value left in your my.cnf file can lead to a mariadb-upgrade failure with errors:

```
Phase 4/7: Running 'mysql_fix_privilege_tables'
--
ERROR 1175 (HY000) at line 316: You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
ERROR 1175 (HY000) at line 328: You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
ERROR 1175 (HY000) at line 340: You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
ERROR 1175 (HY000) at line 352: You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
ERROR 1175 (HY000) at line 353: You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
ERROR 1175 (HY000) at line 477: You are using safe update mode and you tried to update a table without a WHERE that uses a KEY column
FATAL ERROR: Upgrade failed
```

After this patch, we reset that specific setting to the server default. No adverse effects are expected, because we are replacing an uncommon value to a default value in one script.

While this affects all of the SQL scripts, they're truncated together, so it's reasonable to patch only the first in the set. If they ever get split up to execute individually, each one will need a separate set line.

## How can this PR be tested?

It can be tested by running `mariadb-upgrade` on a server that has `sql_safe_updates  = on` in my.cnf.

I don't think this change is important enough to have unit tests. To do so, we'd need to create database in old versions, and enumerate possible config permutations against mariadb-upgrade.

## Basing the PR against the correct MariaDB version
In my opinion this doesn't need backporting. It might be worth applying to the LTS version (since old LTS will likely upgrade there).

- It only affects people upgrading a major version for the first time.
- There's an easy mitigation to complete the upgrade for older versions

We mostly need to fix this for future major releases.


## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
