### PR TITLE
MDEV-30236 set TaskMax=99% in the MariaDB systemd unit

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -140,6 +140,12 @@ PrivateTmp=false
 TimeoutStartSec=900
 TimeoutStopSec=900
 
+# Set the maximium number of tasks (threads) to 99% of what the system can
+# handle as set by the kernel, reserve the 1% for a remote ssh connection,
+# some monitoring, or that backup cron job. Without the directive this would
+# be 15% (see DefaultTasksMax in systemd man pages).
+TasksMax=99%
+
 ##
 ## Options previously available to be set via [mysqld_safe]
 ## that now needs to be set by systemd config files as mysqld_safe

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -252,6 +252,12 @@ PrivateTmp=false
 TimeoutStartSec=900
 TimeoutStopSec=900
 
+# Set the maximium number of tasks (threads) to 99% of what the system can
+# handle as set by the kernel, reserve the 1% for a remote ssh connection,
+# some monitoring, or that backup cron job. Without the directive this would
+# be 15% (see DefaultTasksMax in systemd man pages).
+TasksMax=99%
+
 # Controlling how multiple instances are separated. See top of this file.
 # Note: This service isn't User=mysql by default so we need to be explicit.
 # It is as an option here as a user may want to use the MYSQLD_MULTI_INSTANCE


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30236*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Originally requested to be infinity, but rolled back to 99% to allow for a remote ssh connection or the odd needed system job. This is up from 15% which is the effective default of DefaultTasksMax.

Thanks Rick Pizzi for the bug report.

## How can this PR be tested?

```
$ systemctl show -all | grep TasksMax
DefaultTasksMax=38170


$ systemctl show mariadb.service | grep TasksMax
TasksMax=38170

$ sudo systemctl edit mariadb.service
(add TasksMax=99%
Successfully installed edited file '/etc/systemd/system/mariadb.service.d/override.conf'.

$ systemctl show mariadb.service | grep TasksMax
TasksMax=251925
```
<!--

Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.