### PR TITLE
MDEV-32549 Cluster inconsistent after SAVEPOINT is rolled back

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-32549.result
+++ b/mysql-test/suite/galera/r/MDEV-32549.result
@@ -1,0 +1,24 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) engine=innodb;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) engine=aria;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+SELECT * FROM t2;
+f1
+SAVEPOINT s1;
+ERROR 42000: The storage engine for the table doesn't support SAVEPOINT
+INSERT INTO t1 VALUES (2);
+COMMIT;
+connection node_1;
+SELECT * FROM t1;
+f1
+1
+2
+connection node_2;
+SELECT * FROM t1;
+f1
+1
+2
+connection node_1;
+DROP TABLE t1,t2;

--- a/mysql-test/suite/galera/t/MDEV-32549.test
+++ b/mysql-test/suite/galera/t/MDEV-32549.test
@@ -1,0 +1,28 @@
+#
+# MDEV-32549: Cluster is inconsitent after savepoint
+# statement is rolled back
+#
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) engine=innodb;
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY) engine=aria;
+
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+SELECT * FROM t2;
+--error ER_CHECK_NOT_IMPLEMENTED
+SAVEPOINT s1;
+INSERT INTO t1 VALUES (2);
+COMMIT;
+
+--connection node_1
+SELECT * FROM t1;
+
+# If bug is present: only the second INSERT
+# is replicated, causing an inconsistent
+# cluster.
+--connection node_2
+SELECT * FROM t1;
+
+--connection node_1
+DROP TABLE t1,t2;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -11200,12 +11200,9 @@ void wsrep_register_binlog_handler(THD *thd, bool trx)
     /*
       Set an implicit savepoint in order to be able to truncate a trx-cache.
     */
-    if (cache_mngr->trx_cache.get_prev_position() == MY_OFF_T_UNDEF)
-    {
-      my_off_t pos= 0;
-      binlog_trans_log_savepos(thd, &pos);
-      cache_mngr->trx_cache.set_prev_position(pos);
-    }
+    my_off_t pos= 0;
+    binlog_trans_log_savepos(thd, &pos);
+    cache_mngr->trx_cache.set_prev_position(pos);
 
     /*
       Set callbacks in order to be able to call commmit or rollback.


### PR DESCRIPTION
Attempting to set a SAVEPOINT when one of the involved storage engines does not support savepoints, raises an error, and results in statement rollback. If Galera is enabled with binlog emulation, the above scenario was not handled correctly, and resulted in cluster wide inconsistency.

The problem was in wsrep_register_binlog_handler(), which is called towards the beginning of SAVEPOINT execution. This function is supposed to mark the beginning of statement position in trx cache through `set_prev_position()`. However, it did so only on condition that `get_prev_position()` returns `MY_OFF_T_UNDEF`. This before statement position is typically reset to undefined at the end of statement in `binlog_commit()` / `binlog_rollback()`. However that's not the case with Galera and binlog emulation, for which binlog commit / rollback hooks are not called due to the optimization that avoids internal 2PC (MDEV-16509).
