### PR TITLE
Disable ps-protocol second execution on test that do not support it

### DIFF
--- a/mysql-test/suite/galera/t/MDEV-27862.test
+++ b/mysql-test/suite/galera/t/MDEV-27862.test
@@ -1,6 +1,8 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
+--disable_ps2_protocol
+
 # NEXTVAL
 
 --connection node_1
@@ -54,3 +56,4 @@ SELECT NEXTVAL(seq_transaction) = 4;
 DROP SEQUENCE seq_transaction;
 DROP TABLE t1;
 
+--enable_ps2_protocol

--- a/mysql-test/suite/galera/t/galera_log_output_csv.test
+++ b/mysql-test/suite/galera/t/galera_log_output_csv.test
@@ -12,13 +12,17 @@ INSERT INTO t1 VALUES (1);
 
 SELECT COUNT(*) > 0 FROM mysql.general_log;
 
+--disable_ps2_protocol
 SELECT 1 = 1 FROM t1;
 SELECT COUNT(*) = 1 FROM mysql.slow_log WHERE sql_text = 'SELECT 1 = 1 FROM t1';
+--enable_ps2_protocol
 
 --connection node_2
 
+--disable_ps2_protocol
 SELECT 2 = 2 FROM t1;
 SELECT COUNT(*) = 1 FROM mysql.slow_log WHERE sql_text = 'SELECT 2 = 2 FROM t1';
+--enable_ps2_protocol
 
 --connection node_1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_query_cache.test
+++ b/mysql-test/suite/galera/t/galera_query_cache.test
@@ -2,6 +2,8 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
+--disable_ps2_protocol
+
 #
 # Ensure that the query cache behaves properly with respect to Galera
 #
@@ -65,3 +67,4 @@ SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_
 
 DROP TABLE t1;
 
+--enable_ps2_protocol

--- a/mysql-test/suite/galera/t/galera_query_cache_sync_wait.test
+++ b/mysql-test/suite/galera/t/galera_query_cache_sync_wait.test
@@ -4,6 +4,8 @@
 --source include/have_query_cache.inc
 --source include/galera_have_debug_sync.inc
 
+--disable_ps2_protocol
+
 CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 
@@ -88,3 +90,5 @@ DROP TABLE t1;
 
 --connection node_2a
 SET DEBUG_SYNC = "RESET";
+
+--enable_ps2_protocol

--- a/mysql-test/suite/galera_3nodes_sr/t/GCF-336.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/GCF-336.test
@@ -1,5 +1,7 @@
 --source include/galera_cluster.inc
 
+--disable_ps2_protocol
+
 --connection node_2
 CREATE TABLE t1 (f1 INTEGER) ENGINE=InnoDB;
 
@@ -45,3 +47,6 @@ CALL mtr.add_suppression("WSREP: failed to send SR rollback for ");
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connection node_3
 --source include/galera_wait_ready.inc
+
+
+--enable_ps2_protocol

--- a/mysql-test/suite/galera_3nodes_sr/t/galera_sr_isolate_master.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/galera_sr_isolate_master.test
@@ -1,6 +1,7 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 
+--disable_ps2_protocol
 #
 # Test the effect of gmcast.isolate on master during an SR transaction
 #
@@ -133,3 +134,4 @@ CALL mtr.add_suppression("failed to send SR rollback for");
 DROP TABLE t1;
 
 --source ../galera/include/auto_increment_offset_restore.inc
+--enable_ps2_protocol

--- a/mysql-test/suite/galera_sr/t/galera_sr_large_fragment.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_large_fragment.test
@@ -6,6 +6,8 @@
 --source include/have_innodb.inc
 --source include/big_test.inc
 
+--disable_ps2_protocol
+
 CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO ten VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 
@@ -56,3 +58,4 @@ CALL mtr.add_suppression('InnoDB: Resizing redo log from');
 CALL mtr.add_suppression('InnoDB: Starting to delete and rewrite log files');
 CALL mtr.add_suppression('InnoDB: New log files created, LSN=');
 
+--enable_ps2_protocol

--- a/mysql-test/suite/galera_sr/t/galera_sr_many_fragments.test
+++ b/mysql-test/suite/galera_sr/t/galera_sr_many_fragments.test
@@ -6,6 +6,8 @@
 --source include/have_innodb.inc
 --source include/big_test.inc
 
+--disable_ps2_protocol
+
 CREATE TABLE ten (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO ten VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 
@@ -51,3 +53,5 @@ SELECT COUNT(*) = 0 FROM t1;
 
 DROP TABLE ten;
 DROP TABLE t1;
+
+--enable_ps2_protocol


### PR DESCRIPTION
MDEV-31003 has introduced second execution for SELECTs that execute under ps-protocol. The following tests in galera suites do not support this mode of execution, disable it:

  galera.MDEV-27862
  galera.galera_log_output_csv
  galera.galera_query_cache
  galera.galera_query_cache_sync_wait
  galera_3nodes_sr.GCF-336
  galera_3nodes_sr.galera_sr_isolate_master
  galera_sr.galera_sr_large_fragment
  galera_sr.galera_sr_many_fragments

