### PR TITLE
MDEV-31953 madvise(..., MADV_FREE) is causing a performance regression / MDEV-24670 avoid OOM by linux kernel co-operative memory management

### DIFF
--- a/mysql-test/suite/innodb/r/mem_pressure.result
+++ b/mysql-test/suite/innodb/r/mem_pressure.result
@@ -1,0 +1,27 @@
+#
+# MDEV-24670 avoid OOM by linux kernel co-operative memory management
+#
+set @save_dbug=@@debug_dbug;
+set @save_limit=@@GLOBAL.innodb_limit_optimistic_insert_debug;
+set @save_lag_wait=@@GLOBAL.innodb_max_purge_lag_wait;
+set GLOBAL innodb_max_purge_lag_wait=0;
+CREATE TABLE t1 (t TEXT) ENGINE=InnoDB;
+SET GLOBAL innodb_limit_optimistic_insert_debug=2;
+SET unique_checks=0, foreign_key_checks=0;
+INSERT INTO t1 SELECT CONCAT(REPEAT('junk text', 500), CAST(seq AS CHAR)) FROM seq_1_to_1000;
+SET GLOBAL innodb_limit_optimistic_insert_debug=@save_limit;
+SET GLOBAL innodb_max_purge_lag_wait=@save_lag_wait;
+DROP TABLE t1;
+SELECT CAST(VARIABLE_VALUE AS INTEGER) INTO @dirty_prev
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';
+set debug_dbug="d,trigger_garbage_collection";
+SET GLOBAL innodb_buffer_pool_size=@@innodb_buffer_pool_size;
+SELECT CAST(VARIABLE_VALUE AS INTEGER) < @dirty_prev AS LESS_DIRTY_IS_GOOD
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';
+LESS_DIRTY_IS_GOOD
+1
+FOUND 1 /InnoDB: Memory pressure event freed/ in mysqld.1.err
+set debug_dbug=@save_dbug;
+# End of 10.11 tests

--- a/mysql-test/suite/innodb/t/mem_pressure.test
+++ b/mysql-test/suite/innodb/t/mem_pressure.test
@@ -1,0 +1,44 @@
+--source include/have_debug.inc
+--source include/linux.inc
+--source include/not_embedded.inc
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+
+--echo #
+--echo # MDEV-24670 avoid OOM by linux kernel co-operative memory management
+--echo #
+
+set @save_dbug=@@debug_dbug;
+
+set @save_limit=@@GLOBAL.innodb_limit_optimistic_insert_debug;
+set @save_lag_wait=@@GLOBAL.innodb_max_purge_lag_wait;
+set GLOBAL innodb_max_purge_lag_wait=0;
+
+CREATE TABLE t1 (t TEXT) ENGINE=InnoDB;
+SET GLOBAL innodb_limit_optimistic_insert_debug=2;
+SET unique_checks=0, foreign_key_checks=0;
+INSERT INTO t1 SELECT CONCAT(REPEAT('junk text', 500), CAST(seq AS CHAR)) FROM seq_1_to_1000;
+
+SET GLOBAL innodb_limit_optimistic_insert_debug=@save_limit;
+SET GLOBAL innodb_max_purge_lag_wait=@save_lag_wait;
+
+DROP TABLE t1;
+
+SELECT CAST(VARIABLE_VALUE AS INTEGER) INTO @dirty_prev
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';
+
+set debug_dbug="d,trigger_garbage_collection";
+SET GLOBAL innodb_buffer_pool_size=@@innodb_buffer_pool_size;
+
+SELECT CAST(VARIABLE_VALUE AS INTEGER) < @dirty_prev AS LESS_DIRTY_IS_GOOD
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';
+
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+let SEARCH_PATTERN= InnoDB: Memory pressure event freed;
+--source include/search_pattern_in_file.inc
+
+set debug_dbug=@save_dbug;
+
+--echo # End of 10.11 tests

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -656,12 +656,9 @@ public:
     access_time= 0;
   }
 
-  void set_os_unused()
+  void set_os_unused() const
   {
     MEM_NOACCESS(frame, srv_page_size);
-#ifdef MADV_FREE
-    madvise(frame, srv_page_size, MADV_FREE);
-#endif
   }
 
   void set_os_used() const
@@ -1300,6 +1297,11 @@ public:
 
   /** Resize from srv_buf_pool_old_size to srv_buf_pool_size. */
   inline void resize();
+
+#ifdef __linux__
+  /** Collect garbage (release pages from the LRU list) */
+  inline void garbage_collect();
+#endif
 
   /** @return whether resize() is in progress */
   bool resize_in_progress() const


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31953 / MDEV-24670*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The madvice(FREE) added in 10.11 cased performance regressions. To trigger it less often the memory pressure mechanism of Linux was used.

## How can this PR be tested?

Manually like in MDEV-25341.

```
2023-10-27 19:37:44 0 [Note] InnoDB: Loading buffer pool(s) from /tmp/build-mariadb-server-10.11-datadir/ib_buffer_pool
2023-10-27 19:37:44 0 [Note] Plugin 'FEEDBACK' is disabled.
2023-10-27 19:37:44 0 [Note] sql/mariadbd: ready for connections.
Version: '10.11.6-MariaDB'  socket: '/tmp/build-mariadb-server-10.11.sock'  port: 0  Source distribution
2023-10-27 19:37:45 0 [Note] InnoDB: Buffer pool(s) load completed at 231027 19:37:45
2023-10-27 19:37:54 0 [Note] Memory pressure event freed 5314 pages
```

+ mtr case

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
