### PR TITLE
MDEV-22232: Fix CTAS replay & retry in case it gets BF-aborted

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-22232.result
+++ b/mysql-test/suite/galera/r/MDEV-22232.result
@@ -1,0 +1,27 @@
+connection node_2;
+connection node_1;
+connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1;
+--- CTAS with empty result set ---
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+SET DEBUG_SYNC = 'create_table_select_before_create SIGNAL may_alter WAIT_FOR bf_abort';
+CREATE TABLE t2 SELECT * FROM t1;
+connection node_1;
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+ALTER TABLE t1 DROP FOREIGN KEY b, ALGORITHM=COPY;
+connection con1;
+ERROR 70100: Query execution was interrupted
+SET DEBUG_SYNC = 'RESET';
+--- CTAS with non-empty result set ---
+INSERT INTO t1 VALUES (10), (20), (30);
+SET DEBUG_SYNC = 'create_table_select_before_create SIGNAL may_alter WAIT_FOR bf_abort';
+CREATE TABLE t2 SELECT * FROM t1;
+connection node_1;
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+ALTER TABLE t1 DROP FOREIGN KEY b, ALGORITHM=COPY;
+connection con1;
+ERROR 70100: Query execution was interrupted
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+disconnect con1;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/MDEV-22232.test
+++ b/mysql-test/suite/galera/t/MDEV-22232.test
@@ -1,0 +1,72 @@
+#
+# MDEV-22232: CTAS execution crashes during replay.
+#
+# There were multiple problems and two failing scenarios with empty result set
+# and with non-empty result set:
+# - CTAS didn't add shared keys for selected tables
+# - Security context wasn't set on the replayer thread
+# - CTAS was retried after failure - now retry disabled
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+
+--connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1
+
+# Scenario 1
+--echo --- CTAS with empty result set ---
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+
+# Run CTAS until the resulting table gets created,
+# then it gets BF aborted by ALTER.
+SET DEBUG_SYNC = 'create_table_select_before_create SIGNAL may_alter WAIT_FOR bf_abort';
+--send
+  CREATE TABLE t2 SELECT * FROM t1;
+
+# Wait for CTAS to reach the table create point,
+# start executing ALTER and BF abort CTAS.
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+--disable_result_log
+--error ER_ERROR_ON_RENAME
+ALTER TABLE t1 DROP FOREIGN KEY b, ALGORITHM=COPY;
+--enable_result_log
+
+--connection con1
+# CTAS gets BF aborted.
+--error ER_QUERY_INTERRUPTED
+--reap
+
+# Cleanup
+SET DEBUG_SYNC = 'RESET';
+
+
+# Scenario 2
+--echo --- CTAS with non-empty result set ---
+INSERT INTO t1 VALUES (10), (20), (30);
+
+# Run CTAS until the resulting table gets created,
+# then it gets BF aborted by ALTER.
+SET DEBUG_SYNC = 'create_table_select_before_create SIGNAL may_alter WAIT_FOR bf_abort';
+--send
+  CREATE TABLE t2 SELECT * FROM t1;
+
+# Wait for CTAS to reach the table create point,
+# start executing ALTER and BF abort CTAS.
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+--disable_result_log
+--error ER_ERROR_ON_RENAME
+ALTER TABLE t1 DROP FOREIGN KEY b, ALGORITHM=COPY;
+--enable_result_log
+
+--connection con1
+# CTAS gets BF aborted.
+--error ER_QUERY_INTERRUPTED
+--reap
+
+# Cleanup
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+--disconnect con1
+--source include/galera_end.inc

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -84,6 +84,7 @@
 #include "debug_sync.h"
 
 #ifdef WITH_WSREP
+#include "wsrep_mysqld.h" /* wsrep_append_table_keys() */
 #include "wsrep_trans_observer.h" /* wsrep_start_transction() */
 #endif /* WITH_WSREP */
 
@@ -4799,17 +4800,13 @@ bool select_create::send_eof()
                   thd->wsrep_trx_id(), thd->thread_id, thd->query_id);
 
       /*
-        append table level exclusive key for CTAS
+        For CTAS, append table level exclusive key for created table
+        and table level shared key for selected table.
       */
-      wsrep_key_arr_t key_arr= {0, 0};
-      wsrep_prepare_keys_for_isolation(thd,
-                                       create_table->db.str,
-                                       create_table->table_name.str,
-                                       table_list,
-                                       &key_arr);
-      int rcode= wsrep_thd_append_key(thd, key_arr.keys, key_arr.keys_len,
-                                      WSREP_SERVICE_KEY_EXCLUSIVE);
-      wsrep_keys_free(&key_arr);
+      int rcode= wsrep_append_table_keys(thd, create_table, table_list,
+              WSREP_SERVICE_KEY_EXCLUSIVE);
+      rcode= rcode || wsrep_append_table_keys(thd, nullptr, select_tables,
+              WSREP_SERVICE_KEY_SHARED);
       if (rcode)
       {
         DBUG_PRINT("wsrep", ("row key failed: %d", rcode));

--- a/sql/wsrep_client_service.cc
+++ b/sql/wsrep_client_service.cc
@@ -283,6 +283,13 @@ enum wsrep::provider::status Wsrep_client_service::replay()
     original THD state during replication event applying.
    */
   THD *replayer_thd= new THD(true, true);
+  // Replace the security context of the replayer with the security context
+  // of the original THD. Since security context class doesn't have proper
+  // copy constructors, we need to store the original one and set it back
+  // before destruction so that THD desctruction doesn't cause double-free
+  // on the replaced security context.
+  Security_context old_ctx = replayer_thd->main_security_ctx;
+  replayer_thd->main_security_ctx = m_thd->main_security_ctx;
   replayer_thd->thread_stack= m_thd->thread_stack;
   replayer_thd->real_id= pthread_self();
   replayer_thd->prior_thr_create_utime=
@@ -299,6 +306,7 @@ enum wsrep::provider::status Wsrep_client_service::replay()
     replayer_service.replay_status(ret);
   }
 
+  replayer_thd->main_security_ctx = old_ctx;
   delete replayer_thd;
   DBUG_RETURN(ret);
 }

--- a/sql/wsrep_mysqld.h
+++ b/sql/wsrep_mysqld.h
@@ -347,17 +347,10 @@ int wsrep_must_ignore_error(THD* thd);
 
 bool wsrep_replicate_GTID(THD* thd);
 
-typedef struct wsrep_key_arr
-{
-    wsrep_key_t* keys;
-    size_t       keys_len;
-} wsrep_key_arr_t;
-bool wsrep_prepare_keys_for_isolation(THD*              thd,
-                                      const char*       db,
-                                      const char*       table,
-                                      const TABLE_LIST* table_list,
-                                      wsrep_key_arr_t*  ka);
-void wsrep_keys_free(wsrep_key_arr_t* key_arr);
+int wsrep_append_table_keys(THD* thd,
+                            TABLE_LIST* first_table,
+                            TABLE_LIST* table_list,
+                            Wsrep_service_key_type key_type);
 
 extern void
 wsrep_handle_mdl_conflict(MDL_context *requestor_ctx,


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-22232*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
When CTAS got BF aborted, it crashed during replay. The fix is as following:
- Add selected tables as shared keys for CTAS certification
- Set proper security context on the replayer thread
- Disallow CTAS command retry

## How can this PR be tested?

MTR test is provided.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
