### PR TITLE
MDEV-31116 SIGSEGV in test_if_skip_sort_order|JOIN::optimize_stage2

### DIFF
--- a/mysql-test/main/order_by_innodb.result
+++ b/mysql-test/main/order_by_innodb.result
@@ -296,3 +296,13 @@ a	b	c
 6	2	26
 6	3	36
 drop table t1;
+#
+#  MDEV-31116: SIGSEGV in test_if_skip_sort_order|JOIN::optimize_stage2
+#
+CREATE TABLE t1 (a BINARY (2),b BINARY (1),KEY(a)) ENGINE=innodb;
+INSERT INTO t1 select 'ab', NULL from seq_1_to_14;
+SELECT * FROM t1 WHERE a IN (SELECT a FROM t1 WHERE a >'') ORDER BY a LIMIT 1;
+a	b
+ab	NULL
+DROP TABLE t1;
+# End of 11.0 tests

--- a/mysql-test/main/order_by_innodb.test
+++ b/mysql-test/main/order_by_innodb.test
@@ -250,3 +250,12 @@ explain select * from t1 force index(r) order by a,b limit 20;
 explain select * from t1 force index(r) order by a desc,b limit 20;
         select * from t1 force index(r) order by a desc,b limit 20;
 drop table t1;
+
+--echo #
+--echo #  MDEV-31116: SIGSEGV in test_if_skip_sort_order|JOIN::optimize_stage2
+--echo #
+CREATE TABLE t1 (a BINARY (2),b BINARY (1),KEY(a)) ENGINE=innodb;
+INSERT INTO t1 select 'ab', NULL from seq_1_to_14;
+SELECT * FROM t1 WHERE a IN (SELECT a FROM t1 WHERE a >'') ORDER BY a LIMIT 1;
+DROP TABLE t1;
+--echo # End of 11.0 tests

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -26478,7 +26478,7 @@ test_if_skip_sort_order(JOIN_TAB *tab,ORDER *order,ha_rows select_limit,
          !table->is_clustering_key(best_key)))
       goto use_filesort;
 
-    if (table->opt_range_keys.is_set(best_key) && best_key != ref_key)
+    if (select && table->opt_range_keys.is_set(best_key) && best_key != ref_key)
     {
       key_map tmp_map;
       tmp_map.clear_all();       // Force the creation of quick select


### PR DESCRIPTION
Verify that a pointer is set before dereferencing it.  Adds automated test that will crash without this fix.
