### PR TITLE
MDEV-14448: Ctrl-C should not exit the client

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -89,6 +89,7 @@ extern "C" {
 #undef bcmp				// Fix problem with new readline
 #if defined(__WIN__)
 #include <conio.h>
+#include <windows.h>
 #else
 # ifdef __APPLE__
 #  include <editline/readline.h>
@@ -169,7 +170,7 @@ static char * opt_mysql_unix_port=0;
 static int connect_flag=CLIENT_INTERACTIVE;
 static my_bool opt_binary_mode= FALSE;
 static my_bool opt_connect_expired_password= FALSE;
-static int interrupted_query= 0;
+static int interrupted_query= 0,killed_connection_sigint= 0;
 static char *current_host,*current_db,*current_user=0,*opt_password=0,
             *current_prompt=0, *delimiter_str= 0,
             *default_charset= (char*) MYSQL_AUTODETECT_CHARSET_NAME,
@@ -1072,7 +1073,21 @@ extern "C" sig_handler handle_sigint(int sig);
 static sig_handler window_resize(int sig);
 #endif
 
-
+#ifdef _WIN32
+static BOOL WINAPI ctrl_handler_windows(DWORD fdwCtrlType)
+{
+  switch (fdwCtrlType)
+  {
+    case CTRL_C_EVENT:
+    // Handle the CTRL-C signal.
+    case CTRL_BREAK_EVENT:
+      handle_sigint(SIGINT);
+      return TRUE; // this means that the signal is handled
+  }
+  // This means to pass the signal to the next handler
+  return FALSE;
+}
+#endif
 const char DELIMITER_NAME[]= "delimiter";
 const uint DELIMITER_NAME_LEN= sizeof(DELIMITER_NAME) - 1;
 inline bool is_delimiter_command(char *name, ulong len)
@@ -1205,11 +1220,12 @@ int main(int argc,char *argv[])
   if (!status.batch)
     ignore_errors=1;				// Don't abort monitor
 
-  if (opt_sigint_ignore)
-    signal(SIGINT, SIG_IGN);
-  else
-    signal(SIGINT, handle_sigint);              // Catch SIGINT to clean up
-  signal(SIGQUIT, mysql_end);			// Catch SIGQUIT to clean up
+#ifndef _WIN32
+  signal(SIGINT, handle_sigint);   // Catch SIGINT to clean up
+  signal(SIGQUIT, mysql_end);      // Catch SIGQUIT to clean up
+#else
+  SetConsoleCtrlHandler(ctrl_handler_windows, TRUE);
+#endif
 
 #if defined(HAVE_TERMIOS_H) && defined(GWINSZ_IN_SYS_IOCTL)
   /* Readline will call this if it installs a handler */
@@ -1385,14 +1401,21 @@ static bool do_connect(MYSQL *mysql, const char *host, const char *user,
 
 sig_handler handle_sigint(int sig)
 {
+  if (opt_sigint_ignore) return;
+
   char kill_buffer[40];
   MYSQL *kill_mysql= NULL;
 
-  /* terminate if no query being executed, or we already tried interrupting */
-  if (!executing_query || (interrupted_query == 2))
+  /* If no query being executed, don't exit. */
+  if (!executing_query)
   {
-    tee_fprintf(stdout, "Ctrl-C -- exit!\n");
-    goto err;
+#ifndef _WIN32
+      tee_fprintf(stdout, "^C\n");
+      rl_on_new_line();           // Regenerate the prompt on a newline
+      rl_replace_line("", 0);     // Clear the previous text
+      rl_redisplay();
+#endif
+    return;
   }
 
   kill_mysql= mysql_init(kill_mysql);
@@ -1418,7 +1441,13 @@ sig_handler handle_sigint(int sig)
                 kill_buffer);
   mysql_real_query(kill_mysql, kill_buffer, (uint) strlen(kill_buffer));
   mysql_close(kill_mysql);
-  tee_fprintf(stdout, "Ctrl-C -- query killed. Continuing normally.\n");
+  if (interrupted_query == 1)
+    tee_fprintf(stdout, "Ctrl-C -- query killed. Continuing normally.\n");
+  else
+  {
+    tee_fprintf(stdout, "Ctrl-C -- connection killed. Abort. \n");
+    killed_connection_sigint= 1;
+  }
   if (in_com_source)
     aborted= 1;                                 // Abort source command
   return;
@@ -2063,7 +2092,7 @@ static int read_and_execute(bool interactive)
       size_t clen;
       do
       {
-	line= my_cgets((char*)tmpbuf.ptr(), tmpbuf.alloced_length()-1, &clen);
+        line= my_cgets((char*)tmpbuf.ptr(), tmpbuf.alloced_length()-1, &clen);
         buffer.append(line, clen);
         /* 
            if we got buffer fully filled than there is a chance that
@@ -2074,8 +2103,18 @@ static int read_and_execute(bool interactive)
         An empty line is returned from my_cgets when there's error reading :
         Ctrl-c for example
       */
-      if (line)
-        line= buffer.c_ptr();
+     if (line)
+     {
+       line= buffer.c_ptr();
+     }
+     else
+     {
+      tee_puts("^C", stdout);
+      glob_buffer.length(0);
+      ml_comment = false;
+      in_string = 0;
+      continue;
+     }
 #else
       if (opt_outfile)
 	fputs(prompt, OUTFILE);
@@ -2085,8 +2124,13 @@ static int read_and_execute(bool interactive)
         the readline/libedit library.
       */
       if (line)
+      {
         free(line);
-      line= readline(prompt);
+        line= (char *)NULL;
+        glob_buffer.length(0);
+      }
+      if (!killed_connection_sigint)
+        line= readline(prompt);
 #endif /* defined(__WIN__) */
 
       /*
@@ -3227,6 +3271,7 @@ com_go(String *buffer,char *line __attribute__((unused)))
   int           err= 0;
 
   interrupted_query= 0;
+  killed_connection_sigint= 0;
   if (!status.batch)
   {
     old_buffer= *buffer;			// Save for edit command


### PR DESCRIPTION
`SIGINT` will abort the connection if `CTRL-C` is pressed x 2 (or more) and the query is long running, what is inline with behavior before without the patch - see below (2.). It is checked on Windows too (see jira).
Otherwise it will abort the query (if there is long running query), otherwise it will not exit the client.

##  1. Without the PR
### a) Default: pressing `CTRL-C` aborts the connection
```sql
MariaDB [(none)]> Ctrl-C -- exit!
Aborted
```
### b) For long running query
  - see below (3.) how to simulate
  - same output for killing the query/connection
  - reconnected
##### b.1) Kill query (same with patch)
```sql
MariaDB [(none)]> show databases;
^CCtrl-C -- query killed. Continuing normally.
+--------------------+
| Database           |
+--------------------+
+--------------------+
4 rows in set (4.379 sec)
```

##### b.2) Kill connection
```sql
# 1. query (note that time is 8s)
MariaDB [(none)]> show databases;
^C^CCtrl-C -- query killed. Continuing normally.
Ctrl-C -- query killed. Continuing normally.
+--------------------+
| Database           |
+--------------------+
+--------------------+
4 rows in set (8.716 sec)

# 2. query
MariaDB [(none)]> show databases;
ERROR 2013 (HY000): Lost connection to server during query

# 3. query (note that time is 4s to reconnect, any other query is 1s)
MariaDB [(none)]> show databases;
ERROR 2006 (HY000): Server has gone away
No connection. Trying to reconnect...
Connection id:    15
Current database: *** NONE ***
```

## 2. With the patch
### a) Default:
```sql
MariaDB [(none)]> ^C
MariaDB [(none)]> ^C
MariaDB [(none)]> ^C
```

### b) For long running query 
##### b.1)  Kill query (same as without the patch)
```sql
MariaDB [(none)]> show databases;
^CCtrl-C -- query killed. Continuing normally.
+--------------------+
| Database           |
+--------------------+
+--------------------+
4 rows in set (4.372 sec)

MariaDB [(none)]> ^C
MariaDB [(none)]> exit
Bye
```

##### b.2) Kill connection 
  - 2 or more times `CTRL-C` , connection is aborted
```sql
MariaDB [(none)]> show databases;
^C^C^C^CCtrl-C -- query killed. Continuing normally.
Ctrl-C -- connection killed. Abort. 
+--------------------+
| Database           |
+--------------------+
+--------------------+
4 rows in set (8.479 sec)

Bye
```

## 3. Simulate long running query
#### 1. Add `1 [s]` delay to `docker` network using `tc`: 
```bash
$ tc qdisc show|grep docker
qdisc noqueue 0: dev docker0 root refcnt 2 
$ sudo tc qdisc add dev docker0 root netem delay 1000ms
$ tc qdisc show|grep docker
qdisc netem 8001: dev docker0 root refcnt 2 limit 1000 delay 1.0s
```
#### 2. Start `docker` container and expose port
```bash
$ docker container run --rm -p=3307:3306 --name mariadb-server -e MYSQL_ROOT_PASSWORD=secret -d mariadb:latest
```
#### 3. Start host client with exposed port
```bash
$ ./client/mysql -uroot -psecret -hlocalhost -P3307 --protocol=tcp
```
#### 4. Check queries (takes about `1 [s]`)
```sql
MariaDB [(none)]> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| sys                |
+--------------------+
4 rows in set (1.001 sec)
```


## 4. Problem: `ASAN` bug with patch
   - When using characters after `SIGINT` for slow running queries we hit the bug.
   - Suggestions from reviewer are welcome.
  
```sql
MariaDB [(none)]> show databases;
^CafsdasCtrl-C -- query killed. Continuing normally.
+--------------------+
| Database           |
+--------------------+
+--------------------+
4 rows in set (4.381 sec)

MariaDB [(none)]> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| sys                |
+--------------------+
4 rows in set (1.001 sec)

MariaDB [(none)]> ^C
MariaDB [(none)]> exit
Bye

=================================================================
==144227==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f8debe1f808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x7f8debcfbeac in xmalloc (/lib/x86_64-linux-gnu/libreadline.so.5+0x29eac)
    #2 0x7f8debcf6902 in rl_add_undo (/lib/x86_64-linux-gnu/libreadline.so.5+0x24902)
    #3 0x7f8debcf90ec in rl_insert_text (/lib/x86_64-linux-gnu/libreadline.so.5+0x270ec)
    #4 0x7f8debcfa079 in _rl_insert_char (/lib/x86_64-linux-gnu/libreadline.so.5+0x28079)
    #5 0x7f8debce4455 in _rl_dispatch_subseq (/lib/x86_64-linux-gnu/libreadline.so.5+0x12455)
    #6 0x7f8debce47c0 in readline_internal_char (/lib/x86_64-linux-gnu/libreadline.so.5+0x127c0)
    #7 0x7f8debce4dc4 in readline (/lib/x86_64-linux-gnu/libreadline.so.5+0x12dc4)
    #8 0x55d5f7ea7166 in read_and_execute /home/anel/GitHub/mariadb/server/src/10.4/client/mysql.cc:2133
    #9 0x55d5f7ea4fda in main /home/anel/GitHub/mariadb/server/src/10.4/client/mysql.cc:1297
    #10 0x7f8deb3ad082 in __libc_start_main ../csu/libc-start.c:308
    #11 0x55d5f7ea31ad in _start (/home/anel/GitHub/mariadb/server/build/10.4/client/mysql+0xd51ad)

SUMMARY: AddressSanitizer: 32 byte(s) leaked in 1 allocation(s).
Aborted (core dumped)
```

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*


## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
