### PR TITLE
MDEV-29913  Assertion `thd->stmt_arena != thd->progress.arena' failed in thd_progress_init upon bulk load

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -467,3 +467,13 @@ DROP TABLE t1;
 CREATE TABLE t (a CHAR CHARACTER SET utf8) ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
 INSERT t SELECT left(seq,1) FROM seq_1_to_43691;
 DROP TABLE t;
+#
+#  MDEV-29913  Assertion `thd->stmt_arena != thd->progress.arena'
+#		failed in thd_progress_init upon bulk load
+#
+SELECT * INTO OUTFILE 'numbers' FROM seq_1_to_20165;
+CREATE TABLE t1(
+pk int, f1 varchar(4) DEFAULT 'foo', KEY(pk)) ENGINE=InnoDB;
+SET AUTOCOMMIT=0;
+LOAD DATA INFILE 'numbers' INTO TABLE t1(pk);
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -495,3 +495,17 @@ DROP TABLE t1;
 CREATE TABLE t (a CHAR CHARACTER SET utf8) ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
 INSERT t SELECT left(seq,1) FROM seq_1_to_43691;
 DROP TABLE t;
+
+--echo #
+--echo #  MDEV-29913  Assertion `thd->stmt_arena != thd->progress.arena'
+--echo #		failed in thd_progress_init upon bulk load
+--echo #
+SELECT * INTO OUTFILE 'numbers' FROM seq_1_to_20165;
+CREATE TABLE t1(
+	pk int, f1 varchar(4) DEFAULT 'foo', KEY(pk)) ENGINE=InnoDB;
+SET AUTOCOMMIT=0;
+LOAD DATA INFILE 'numbers' INTO TABLE t1(pk);
+# Cleanup
+--let $datadir= `select @@datadir`
+--remove_file $datadir/test/numbers
+DROP TABLE t1;

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -3551,7 +3551,7 @@ row_merge_sort(
 	*/
 #ifndef __sun__
 	/* Progress report only for "normal" indexes. */
-	if (dup && !(dup->index->type & DICT_FTS)) {
+	if (update_progress) {
 		thd_progress_init(trx->mysql_thd, 1);
 	}
 #endif /* __sun__ */
@@ -3568,7 +3568,7 @@ row_merge_sort(
 		show processlist progress field */
 		/* Progress report only for "normal" indexes. */
 #ifndef __sun__
-		if (dup && !(dup->index->type & DICT_FTS)) {
+		if (update_progress) {
 			thd_progress_report(trx->mysql_thd, file->offset - num_runs, file->offset);
 		}
 #endif /* __sun__ */
@@ -3598,7 +3598,7 @@ row_merge_sort(
 
 	/* Progress report only for "normal" indexes. */
 #ifndef __sun__
-	if (dup && !(dup->index->type & DICT_FTS)) {
+	if (update_progress) {
 		thd_progress_end(trx->mysql_thd);
 	}
 #endif /* __sun__ */
@@ -5330,7 +5330,7 @@ dberr_t row_merge_bulk_t::write_to_index(ulint index_no, trx_t *trx)
   }
 
   err= row_merge_sort(trx, &dup, file,
-                      m_block, &m_tmpfd, true, 0, 0,
+                      m_block, &m_tmpfd, false, 0, 0,
                       m_crypt_block, table->space_id, nullptr);
   if (err != DB_SUCCESS)
     goto func_exit;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29913*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

row_merge_bulk_t::write_to_index(): Don't report the progress for bulk load operation
## How can this PR be tested?
Added the test case in mtr

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
