### PR TITLE
MDEV-29913  Assertion `thd->stmt_arena != thd->progress.arena' failed in thd_progress_init upon bulk load

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -467,3 +467,13 @@ DROP TABLE t1;
 CREATE TABLE t (a CHAR CHARACTER SET utf8) ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
 INSERT t SELECT left(seq,1) FROM seq_1_to_43691;
 DROP TABLE t;
+#
+#  MDEV-29913  Assertion `thd->stmt_arena != thd->progress.arena'
+#		failed in thd_progress_init upon bulk load
+#
+CREATE TABLE t1(
+pk int, f1 varchar(4) DEFAULT 'foo', KEY(pk)) ENGINE=InnoDB;
+SET AUTOCOMMIT=0;
+SELECT * INTO OUTFILE 'load.data' FROM seq_1_to_200;
+LOAD DATA INFILE 'load.data' INTO TABLE t1(pk);
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -495,3 +495,18 @@ DROP TABLE t1;
 CREATE TABLE t (a CHAR CHARACTER SET utf8) ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
 INSERT t SELECT left(seq,1) FROM seq_1_to_43691;
 DROP TABLE t;
+
+--echo #
+--echo #  MDEV-29913  Assertion `thd->stmt_arena != thd->progress.arena'
+--echo #		failed in thd_progress_init upon bulk load
+--echo #
+CREATE TABLE t1(
+	pk int, f1 varchar(4) DEFAULT 'foo', KEY(pk)) ENGINE=InnoDB;
+SET AUTOCOMMIT=0;
+--disable_ps2_protocol
+SELECT * INTO OUTFILE 'load.data' FROM seq_1_to_200;
+--enable_ps2_protocol
+LOAD DATA INFILE 'load.data' INTO TABLE t1(pk);
+DROP TABLE t1;
+let $datadir= `select @@datadir`;
+remove_file $datadir/test/load.data;

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -3545,17 +3545,6 @@ row_merge_sort(
 	of file marker).  Thus, it must be at least one block. */
 	ut_ad(file->offset > 0);
 
-	/* These thd_progress* calls will crash on sol10-64 when innodb_plugin
-	is used. MDEV-9356: innodb.innodb_bug53290 fails (crashes) on
-	sol10-64 in buildbot.
-	*/
-#ifndef __sun__
-	/* Progress report only for "normal" indexes. */
-	if (dup && !(dup->index->type & DICT_FTS)) {
-		thd_progress_init(trx->mysql_thd, 1);
-	}
-#endif /* __sun__ */
-
 	if (global_system_variables.log_warnings > 2) {
 		sql_print_information("InnoDB: Online DDL : merge-sorting"
 				      " has estimated " ULINTPF " runs",
@@ -3564,15 +3553,6 @@ row_merge_sort(
 
 	/* Merge the runs until we have one big run */
 	do {
-		/* Report progress of merge sort to MySQL for
-		show processlist progress field */
-		/* Progress report only for "normal" indexes. */
-#ifndef __sun__
-		if (dup && !(dup->index->type & DICT_FTS)) {
-			thd_progress_report(trx->mysql_thd, file->offset - num_runs, file->offset);
-		}
-#endif /* __sun__ */
-
 		error = row_merge(trx, dup, file, block, tmpfd,
 				  &num_runs, run_offset, stage,
 				  crypt_block, space);
@@ -3595,13 +3575,6 @@ row_merge_sort(
 	} while (num_runs > 1);
 
 	ut_free(run_offset);
-
-	/* Progress report only for "normal" indexes. */
-#ifndef __sun__
-	if (dup && !(dup->index->type & DICT_FTS)) {
-		thd_progress_end(trx->mysql_thd);
-	}
-#endif /* __sun__ */
 
 	DBUG_RETURN(error);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-29913*

## Description
row_merge_bulk_t::write_to_index(): Don't report the progress for bulk load operation

## How can this PR be tested?
Wrote test case to test scenario. Running ./mtr innodb.insert_into_empty test case

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
