### PR TITLE
MDEV-32790: Output result in show create table for mysql_json type should be longtext

### DIFF
--- a/mysql-test/main/mysql_json_table_recreate.result
+++ b/mysql-test/main/mysql_json_table_recreate.result
@@ -169,3 +169,47 @@ Total_Number_of_Tests	Succesful_Tests	String_is_valid_JSON
 drop table tempty;
 drop table mysql_json_test;
 drop table mysql_json_test_big;
+#
+# MDEV-32790: Output result in show create table
+#             for mysql_json type should be longtext
+#
+create table t1(j json);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `j` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`j`))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+drop table t1;
+create table t1(j mysql_json);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `j` mysql_json /* JSON from MySQL 5.7 */ CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+drop table t1;
+create table `testjson` (
+`t` json /* JSON from MySQL 5.7*/ CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
+) ENGINE=InnoDB DEFAULT CH...' at line 2
+create table `testjson` (
+`t` json /* JSON from MySQL 5.7*/ COLLATE utf8mb4_bin NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+show create table testjson;
+Table	Create Table
+testjson	CREATE TABLE `testjson` (
+  `t` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL CHECK (json_valid(`t`))
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+drop table testjson;
+create table `testjson` (
+`t` longtext /* JSON from MySQL 5.7 */ CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+show create table testjson;
+Table	Create Table
+testjson	CREATE TABLE `testjson` (
+  `t` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+drop table testjson;
+#
+# End of 10.5 tests
+#

--- a/mysql-test/main/mysql_json_table_recreate.test
+++ b/mysql-test/main/mysql_json_table_recreate.test
@@ -88,3 +88,39 @@ from mysql_json_test_big;
 drop table tempty;
 drop table mysql_json_test;
 drop table mysql_json_test_big;
+
+--echo #
+--echo # MDEV-32790: Output result in show create table
+--echo #             for mysql_json type should be longtext
+--echo #
+
+create table t1(j json);
+show create table t1;
+drop table t1;
+create table t1(j mysql_json);
+show create table t1;
+drop table t1;
+# `json` type should not have character set and collation other than utf8mb4_bin
+--error ER_PARSE_ERROR
+create table `testjson` (
+  `t` json /* JSON from MySQL 5.7*/ CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+# By removing character set from `json` field query should work and
+# expand to `longtext` with characterset
+create table `testjson` (
+  `t` json /* JSON from MySQL 5.7*/ COLLATE utf8mb4_bin NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+show create table testjson;
+drop table testjson;
+
+# `longtext` that is alias can have character set
+create table `testjson` (
+  `t` longtext /* JSON from MySQL 5.7 */ CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+show create table testjson;
+drop table testjson;
+
+--echo #
+--echo # End of 10.5 tests
+--echo #

--- a/plugin/type_mysql_json/type.cc
+++ b/plugin/type_mysql_json/type.cc
@@ -62,7 +62,7 @@ public:
   bool parse_mysql(String *dest, const char *data, size_t length) const;
   bool send(Protocol *protocol) { return Field::send(protocol); }
   void sql_type(String &s) const
-  { s.set_ascii(STRING_WITH_LEN("json /* MySQL 5.7 */")); }
+  { s.set_ascii(STRING_WITH_LEN("mysql_json /* JSON from MySQL 5.7 */")); }
   /* this will make ALTER TABLE to consider it different from built-in field */
   Compression_method *compression_method() const { return (Compression_method*)1; }
 };


### PR DESCRIPTION
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
