### PR TITLE
MDEV-32235: mysql_json cannot be used on newly created table

### DIFF
--- a/mysql-test/main/mysql_json_table_recreate.result
+++ b/mysql-test/main/mysql_json_table_recreate.result
@@ -181,12 +181,7 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop table t1;
 create table t1(j mysql_json);
-show create table t1;
-Table	Create Table
-t1	CREATE TABLE `t1` (
-  `j` mysql_json /* JSON from MySQL 5.7 */ CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL
-) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
-drop table t1;
+ERROR HY000: Cannot create table `test`.`t1`: Run mariadb-upgrade, to upgrade table with mysql_json type.
 create table `testjson` (
 `t` json /* JSON from MySQL 5.7*/ CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
@@ -210,6 +205,17 @@ testjson	CREATE TABLE `testjson` (
   `t` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop table testjson;
+#
+# MDEV-32235: mysql_json cannot be used on newly created table
+#
+CREATE TABLE t(j mysql_json);
+ERROR HY000: Cannot create table `test`.`t`: Run mariadb-upgrade, to upgrade table with mysql_json type.
+CREATE TABLE IF NOT EXISTS t(j mysql_json);
+ERROR HY000: Cannot create table `test`.`t`: Run mariadb-upgrade, to upgrade table with mysql_json type.
+CREATE OR REPLACE TABLE t(j mysql_json);
+ERROR HY000: Cannot create table `test`.`t`: Run mariadb-upgrade, to upgrade table with mysql_json type.
+CREATE TEMPORARY TABLE t(j mysql_json);
+ERROR HY000: Cannot create table `test`.`t`: Run mariadb-upgrade, to upgrade table with mysql_json type.
 #
 # End of 10.5 tests
 #

--- a/mysql-test/main/mysql_json_table_recreate.test
+++ b/mysql-test/main/mysql_json_table_recreate.test
@@ -97,9 +97,8 @@ drop table mysql_json_test_big;
 create table t1(j json);
 show create table t1;
 drop table t1;
+--error ER_CANT_CREATE_TABLE
 create table t1(j mysql_json);
-show create table t1;
-drop table t1;
 # `json` type should not have character set and collation other than utf8mb4_bin
 --error ER_PARSE_ERROR
 create table `testjson` (
@@ -120,6 +119,20 @@ create table `testjson` (
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 show create table testjson;
 drop table testjson;
+
+
+--echo #
+--echo # MDEV-32235: mysql_json cannot be used on newly created table
+--echo #
+
+--error ER_CANT_CREATE_TABLE
+CREATE TABLE t(j mysql_json);
+--error ER_CANT_CREATE_TABLE
+CREATE TABLE IF NOT EXISTS t(j mysql_json);
+--error ER_CANT_CREATE_TABLE
+CREATE OR REPLACE TABLE t(j mysql_json);
+--error ER_CANT_CREATE_TABLE
+CREATE TEMPORARY TABLE t(j mysql_json);
 
 --echo #
 --echo # End of 10.5 tests

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -3657,6 +3657,19 @@ mysql_prepare_create_table(THD *thd, HA_CREATE_INFO *create_info,
     if (sql_field->vcol_info)
       sql_field->flags&= ~NOT_NULL_FLAG;
 
+    if (sql_field->real_field_type() == MYSQL_TYPE_BLOB &&
+        thd->lex->sql_command == SQLCOM_CREATE_TABLE)
+    {
+      if (!strcmp(sql_field->type_handler()->name().ptr(), "MYSQL_JSON"))
+      {
+        my_printf_error(ER_CANT_CREATE_TABLE,
+                        "Cannot create table %`s.%`s: "
+                        "Run mariadb-upgrade, "
+                        "to upgrade table with mysql_json type.", MYF(0),
+                        alter_info->db.str, alter_info->table_name.str);
+        DBUG_RETURN(TRUE);
+      }
+    }
     /*
       Initialize length from its original value (number of characters),
       which was set in the parser. This is necessary if we're


### PR DESCRIPTION
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
