### PR TITLE
MDEV-32168: slave_error_param condition is never checked from the wait_for_slave_param.inc

### DIFF
--- a/mysql-test/include/wait_for_slave_io_error.inc
+++ b/mysql-test/include/wait_for_slave_io_error.inc
@@ -59,7 +59,7 @@ let $_wfsie_errno= query_get_value(SHOW SLAVE STATUS, Last_IO_Errno, 1);
 
 if ($slave_io_errno == '') {
   --echo !!!ERROR IN TEST: you must set \$slave_io_errno before you source
-  --echo !!!wait_for_slave_sql_error.inc. The error we got this time was '$_wfsie_errno',
+  --echo !!!wait_for_slave_io_error.inc. The error we got this time was '$_wfsie_errno',
   --echo !!!so you probably want to add the following line to your test case:
   --echo !!!  --let \$slave_io_errno= $_wfsie_errno
   --die !!!ERROR IN TEST: you must set \$slave_io_errno before sourcing wait_for_slave_io_error.inc

--- a/mysql-test/include/wait_for_slave_param.inc
+++ b/mysql-test/include/wait_for_slave_param.inc
@@ -56,11 +56,6 @@ if (!$_slave_timeout)
   }
 }
 
-if ($slave_error_param == '')
-{
-  --let $slave_error_param= 1
-}
-
 let $_slave_param_comparison= $slave_param_comparison;
 if (!$_slave_param_comparison)
 {
@@ -90,7 +85,7 @@ while ($_slave_continue)
   --let $_show_slave_status_value= query_get_value("SHOW SLAVE STATUS", $slave_param, 1)
 
   # Check if an error condition is reached.
-  if (!$slave_error_param)
+  if ($slave_error_param)
   {
     --let $_show_slave_status_error_value= query_get_value("SHOW SLAVE STATUS", $slave_error_param, 1)
     if ($_show_slave_status_error_value)

--- a/mysql-test/suite/binlog_encryption/encrypted_master_switch_to_unencrypted_coords.test
+++ b/mysql-test/suite/binlog_encryption/encrypted_master_switch_to_unencrypted_coords.test
@@ -136,6 +136,8 @@ start slave;
 SHOW TABLES;
 
 --disable_connect_log
+# IO thread is stopped, stop SQL thread only
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 --enable_connect_log
 reset slave;

--- a/mysql-test/suite/binlog_encryption/encrypted_master_switch_to_unencrypted_gtid.test
+++ b/mysql-test/suite/binlog_encryption/encrypted_master_switch_to_unencrypted_gtid.test
@@ -132,6 +132,8 @@ if (`SELECT strcmp("$gsp","")`)
 SHOW TABLES;
 
 --disable_connect_log
+# IO thread is stopped, wait for SQL thread to be stopped
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 --enable_connect_log
 reset slave;

--- a/mysql-test/suite/binlog_encryption/rpl_parallel.result
+++ b/mysql-test/suite/binlog_encryption/rpl_parallel.result
@@ -897,7 +897,6 @@ connection con2;
 SET debug_sync='RESET';
 connection server_2;
 include/wait_for_slave_sql_error.inc [errno=1062]
-include/wait_for_slave_sql_to_stop.inc
 SELECT * FROM t3 WHERE a >= 110 ORDER BY a;
 a	b
 110	1

--- a/mysql-test/suite/binlog_encryption/rpl_parallel_ignored_errors.result
+++ b/mysql-test/suite/binlog_encryption/rpl_parallel_ignored_errors.result
@@ -35,6 +35,7 @@ connection server_2;
 connection con_temp2;
 COMMIT;
 connection server_2;
+include/wait_for_slave_sql_error.inc [errno=1062]
 include/stop_slave.inc
 include/assert.inc [table t1 should have zero rows where a>32]
 SELECT * FROM t1 WHERE a>32;

--- a/mysql-test/suite/multi_source/gtid_slave_pos.result
+++ b/mysql-test/suite/multi_source/gtid_slave_pos.result
@@ -97,8 +97,9 @@ set default_master_connection = 'slave1';
 STOP SLAVE;
 include/wait_for_slave_to_stop.inc
 set default_master_connection = 'slave2';
+include/wait_for_slave_sql_error.inc [errno=1942]
 STOP SLAVE;
-include/wait_for_slave_to_stop.inc
+include/stop_slave.inc
 set default_master_connection = 'slave1';
 START SLAVE;
 include/wait_for_slave_to_start.inc

--- a/mysql-test/suite/multi_source/gtid_slave_pos.test
+++ b/mysql-test/suite/multi_source/gtid_slave_pos.test
@@ -118,8 +118,11 @@ set default_master_connection = 'slave1';
 STOP SLAVE;
 --source include/wait_for_slave_to_stop.inc
 set default_master_connection = 'slave2';
+--let $slave_sql_errno= 1942
+--source include/wait_for_slave_sql_error.inc
 STOP SLAVE;
---source include/wait_for_slave_to_stop.inc
+--let $rpl_only_running_threads= 1
+--source include/stop_slave.inc
 set default_master_connection = 'slave1';
 START SLAVE;
 --source include/wait_for_slave_to_start.inc

--- a/mysql-test/suite/rpl/include/mdev-31448_conservative.inc
+++ b/mysql-test/suite/rpl/include/mdev-31448_conservative.inc
@@ -50,8 +50,8 @@ insert into t1 values (3);
 commit;
 
 --connection slave
---let $slave_timeout=1032
---source include/wait_for_slave_sql_to_stop.inc
+--let $slave_sql_errno=1032
+--source include/wait_for_slave_sql_error.inc
 
 update t1 set a=1 where a=2;
 set @@global.slave_parallel_threads = @save.slave_parallel_threads;

--- a/mysql-test/suite/rpl/include/mdev-31448_optimistic.inc
+++ b/mysql-test/suite/rpl/include/mdev-31448_optimistic.inc
@@ -75,8 +75,8 @@ drop table t2;
 commit;
 
 --connection slave
---let $slave_timeout=1032
---source include/wait_for_slave_sql_to_stop.inc
+--let $slave_sql_errno=1032
+--source include/wait_for_slave_sql_error.inc
 
 update t1 set a=1 where a=2;
 set @@global.slave_parallel_threads = @save.slave_parallel_threads;

--- a/mysql-test/suite/rpl/include/rpl_binlog_max_cache_size.test
+++ b/mysql-test/suite/rpl/include/rpl_binlog_max_cache_size.test
@@ -411,6 +411,8 @@ while ($n)
 COMMIT;
 
 --connection slave
+# Multi-statement transaction raised ER_TRANS_CACHE_FULL (4096=128x32)
+# that will stop SQL slave thread
 --let $slave_sql_errno= 1197
 if (`SELECT @@binlog_format = 'ROW'`)
 {
@@ -430,6 +432,8 @@ source include/show_binlog_events.inc;
 --replace_result $old_binlog_stmt_cache_size ORIGINAL_VALUE
 --eval SET GLOBAL binlog_stmt_cache_size= $old_binlog_stmt_cache_size
 
+# SQL slave is stopped, stop only IO thread
+--let $rpl_only_running_threads= 1
 source include/stop_slave.inc;
 source include/start_slave.inc;
 

--- a/mysql-test/suite/rpl/include/rpl_shutdown_wait_slaves.inc
+++ b/mysql-test/suite/rpl/include/rpl_shutdown_wait_slaves.inc
@@ -75,17 +75,26 @@ EOF
 --connection server_1
 DROP TABLE t1;
 
+# Slaves IO thread will receive the disconnect error when master was shutdown
+# so we are allowing error on start.
 --connection server_2
 --disable_warnings
+--let rpl_allow_error=1
+--source include/wait_for_slave_io_to_start.inc
+
 --source include/start_slave.inc
 --enable_warnings
 
 --connection server_3
 --disable_warnings
+--let rpl_allow_error=1
+--source include/wait_for_slave_io_to_start.inc
 --source include/start_slave.inc
 --enable_warnings
 
 --connection server_4
 --disable_warnings
+--let rpl_allow_error=1
+--source include/wait_for_slave_io_to_start.inc
 --source include/start_slave.inc
 --enable_warnings

--- a/mysql-test/suite/rpl/include/rpl_start_stop_slave.test
+++ b/mysql-test/suite/rpl/include/rpl_start_stop_slave.test
@@ -207,6 +207,7 @@ START SLAVE;
 --let $status_items= Last_IO_Errno, Last_IO_Error
 --source include/show_slave_status.inc
 
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 RESET SLAVE;
 

--- a/mysql-test/suite/rpl/include/rpl_stop_middle_group.test
+++ b/mysql-test/suite/rpl/include/rpl_stop_middle_group.test
@@ -82,7 +82,9 @@ connection slave;
 # slave will catch the killed status, won't shut down immediately
 # but does it eventually having the whole group unfinished (not committed)
 
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_SLAVE_FATAL_ERROR
+--let slave_sql_errno= 1593
+source include/wait_for_slave_sql_error.inc;
 
 # checking: the error and group unfinished
 
@@ -120,7 +122,8 @@ connection slave;
 # but does it eventually having the whole group unfinished (not committed)
 # 
 
-source include/wait_for_slave_sql_to_stop.inc;
+--let slave_sql_errno= 1593
+source include/wait_for_slave_sql_error.inc;
 
 # checking: the error and group unfinished 
 

--- a/mysql-test/suite/rpl/r/rpl_domain_id_filter_master_crash.result
+++ b/mysql-test/suite/rpl/r/rpl_domain_id_filter_master_crash.result
@@ -38,8 +38,8 @@ connection master;
 include/rpl_start_server.inc [server_number=1]
 # Master has restarted successfully
 connection slave;
-include/stop_slave.inc
-include/start_slave.inc
+include/wait_for_slave_io_to_start.inc
+include/wait_for_slave_sql_to_start.inc
 select * from ti;
 a
 1

--- a/mysql-test/suite/rpl/r/rpl_fail_register.result
+++ b/mysql-test/suite/rpl/r/rpl_fail_register.result
@@ -1,14 +1,15 @@
 include/master-slave.inc
 [connection master]
 connection slave;
+CALL mtr.add_suppression("Slave I/O: Master command COM_REGISTER_SLAVE failed: Debug Induced Error");
 set @old_dbug=@@global.debug_dbug;
 set global debug_dbug='d,fail_com_register_slave';
 stop slave;
 reset slave;
 include/wait_for_slave_to_stop.inc
 start slave;
-stop slave;
-include/wait_for_slave_to_stop.inc
+include/wait_for_slave_io_error.inc [errno=1597]
+include/stop_slave_sql.inc
 set global debug_dbug=@old_dbug;
 connection master;
 kill DUMP_THREAD;

--- a/mysql-test/suite/rpl/r/rpl_gtid_delete_domain.result
+++ b/mysql-test/suite/rpl/r/rpl_gtid_delete_domain.result
@@ -52,7 +52,7 @@ Waiting until 'Slave_IO_Running' = 'Yes' [$slave_error_param='Last_IO_Errno']
 .. con='slave' warn='1' qlog='1' rlog='1' aborterr='1'
 ...==== BEGIN include/wait_for_slave_param.inc [Slave_SQL_Running] ====
 ... con='slave' warn='1' qlog='1' rlog='1' aborterr='1'
-Waiting until 'Slave_SQL_Running' = 'Yes' [$slave_error_param='1']
+Waiting until 'Slave_SQL_Running' = 'Yes' [$slave_error_param='']
 [connection slave]
 ...==== END include/wait_for_slave_param.inc [Slave_SQL_Running] ====
 ... con='slave' warn='1' qlog='1' rlog='1' aborterr='1'

--- a/mysql-test/suite/rpl/r/rpl_mdev_17614.result
+++ b/mysql-test/suite/rpl/r/rpl_mdev_17614.result
@@ -30,7 +30,7 @@ a	b	c
 1	1	1
 2	2	3
 stop slave;
-include/wait_for_slave_to_stop.inc
+include/stop_slave.inc
 reset slave;
 connection master;
 reset master;
@@ -190,7 +190,7 @@ a	b	c
 1	1	1
 2	2	3
 stop slave;
-include/wait_for_slave_to_stop.inc
+include/stop_slave.inc
 reset slave;
 connection master;
 reset master;

--- a/mysql-test/suite/rpl/r/rpl_parallel.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel.result
@@ -896,7 +896,6 @@ connection con2;
 SET debug_sync='RESET';
 connection server_2;
 include/wait_for_slave_sql_error.inc [errno=1062]
-include/wait_for_slave_sql_to_stop.inc
 SELECT * FROM t3 WHERE a >= 110 ORDER BY a;
 a	b
 110	1

--- a/mysql-test/suite/rpl/r/rpl_parallel_ignored_errors.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_ignored_errors.result
@@ -35,6 +35,7 @@ connection server_2;
 connection con_temp2;
 COMMIT;
 connection server_2;
+include/wait_for_slave_sql_error.inc [errno=1062]
 include/stop_slave.inc
 include/assert.inc [table t1 should have zero rows where a>32]
 SELECT * FROM t1 WHERE a>32;

--- a/mysql-test/suite/rpl/r/rpl_parallel_kill.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_kill.result
@@ -30,7 +30,7 @@ kill $t3_tid;
 connection slave1;
 commit;
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1032]
 update t1 set a=1 where a=2;
 set @@global.slave_parallel_threads = @save.slave_parallel_threads;
 set @@global.slave_parallel_mode = @save.slave_parallel_mode;
@@ -78,7 +78,7 @@ include/wait_for_slave_param.inc [Last_Errno]
 connection slave1;
 commit;
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1032]
 update t1 set a=1 where a=2;
 set @@global.slave_parallel_threads = @save.slave_parallel_threads;
 set @@global.slave_parallel_mode = @save.slave_parallel_mode;
@@ -127,7 +127,7 @@ include/wait_for_slave_param.inc [Last_Errno]
 connection slave1;
 commit;
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1032]
 update t1 set a=1 where a=2;
 set @@global.slave_parallel_threads = @save.slave_parallel_threads;
 set @@global.slave_parallel_mode = @save.slave_parallel_mode;

--- a/mysql-test/suite/rpl/r/rpl_row_idempotency.result
+++ b/mysql-test/suite/rpl/r/rpl_row_idempotency.result
@@ -89,7 +89,7 @@ b
 3
 *** slave must stop (Trying to delete a referenced foreing key)
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1451]
 Last_SQL_Error
 1451
 select * from ti1 order by b /* must be (1),(2),(3) - not deleted */;
@@ -114,7 +114,7 @@ connection master;
 insert into ti2 set a=3, b=3 /* offending write event */;
 *** slave must stop (Trying to insert an invalid foreign key)
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1452]
 Last_SQL_Error
 1452
 select * from ti2 order by b /* must be (2,2) */;
@@ -139,9 +139,9 @@ a	b
 insert into ti1 set b=1;
 connection master;
 insert into ti1 set b=1 /* offending write event */;
-*** slave must stop (Trying to insert a dupliacte key)
+*** slave must stop (Trying to insert a duplicate key)
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1062]
 Last_SQL_Error
 1062
 set foreign_key_checks= 0;
@@ -164,7 +164,7 @@ connection master;
 DELETE FROM t1 WHERE a = -2;
 *** slave must stop (Key was not found)
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1032]
 Last_SQL_Error
 1032
 set global slave_exec_mode='IDEMPOTENT';
@@ -176,7 +176,7 @@ connection master;
 DELETE FROM t2 WHERE a = -2;
 *** slave must stop (Key was not found)
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1032]
 Last_SQL_Error
 1032
 set global slave_exec_mode='IDEMPOTENT';
@@ -190,7 +190,7 @@ connection master;
 UPDATE t1 SET a = 1 WHERE a = -1;
 *** slave must stop (Key was not found)
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1032]
 Last_SQL_Error
 1032
 set global slave_exec_mode='IDEMPOTENT';
@@ -202,7 +202,7 @@ connection master;
 UPDATE t2 SET a = 1 WHERE a = -1;
 *** slave must stop (Key was not found)
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1032]
 Last_SQL_Error
 1032
 set global slave_exec_mode='IDEMPOTENT';

--- a/mysql-test/suite/rpl/r/rpl_semi_sync_master_shutdown.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_master_shutdown.result
@@ -14,14 +14,12 @@ connection master;
 # Shutdown master
 include/rpl_stop_server.inc [server_number=1]
 connection slave;
-include/stop_slave.inc
+include/wait_for_slave_io_error.inc [errno=2003]
 # Restart master
 include/rpl_start_server.inc [server_number=1]
 connection slave;
-include/stop_slave.inc
-Warnings:
-Note	1255	Slave already has been stopped
-include/start_slave.inc
+include/wait_for_slave_sql_to_start.inc
+include/wait_for_slave_io_to_start.inc
 connection master;
 SET @@GLOBAL.debug_dbug="";
 SET @@GLOBAL. rpl_semi_sync_master_enabled = 0;

--- a/mysql-test/suite/rpl/r/rpl_shutdown_wait_semisync_slaves.result
+++ b/mysql-test/suite/rpl/r/rpl_shutdown_wait_semisync_slaves.result
@@ -34,10 +34,13 @@ connection server_1;
 connection server_1;
 DROP TABLE t1;
 connection server_2;
+include/wait_for_slave_io_to_start.inc
 include/start_slave.inc
 connection server_3;
+include/wait_for_slave_io_to_start.inc
 include/start_slave.inc
 connection server_4;
+include/wait_for_slave_io_to_start.inc
 include/start_slave.inc
 connection server_2;
 include/stop_slave.inc

--- a/mysql-test/suite/rpl/r/rpl_shutdown_wait_slaves.result
+++ b/mysql-test/suite/rpl/r/rpl_shutdown_wait_slaves.result
@@ -21,9 +21,12 @@ connection server_1;
 connection server_1;
 DROP TABLE t1;
 connection server_2;
+include/wait_for_slave_io_to_start.inc
 include/start_slave.inc
 connection server_3;
+include/wait_for_slave_io_to_start.inc
 include/start_slave.inc
 connection server_4;
+include/wait_for_slave_io_to_start.inc
 include/start_slave.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_slave_status.result
+++ b/mysql-test/suite/rpl/r/rpl_slave_status.result
@@ -36,7 +36,6 @@ connection slave;
 include/stop_slave.inc
 START SLAVE;
 include/wait_for_slave_sql_to_start.inc
-include/wait_for_slave_io_to_stop.inc
 ==== Verify that Slave IO thread stopped with error ====
 include/wait_for_slave_io_error.inc [errno=1045]
 ==== Cleanup (Note that slave IO thread is not running) ====

--- a/mysql-test/suite/rpl/r/rpl_ssl1.result
+++ b/mysql-test/suite/rpl/r/rpl_ssl1.result
@@ -15,7 +15,7 @@ connection slave;
 select * from t1;
 t
 stop slave;
-include/wait_for_slave_to_stop.inc
+include/wait_for_slave_io_error.inc [errno=1045]
 change master to master_ssl=1 , master_ssl_ca ='MYSQL_TEST_DIR/std_data/cacert.pem', master_ssl_cert='MYSQL_TEST_DIR/std_data/client-cert.pem', master_ssl_key='MYSQL_TEST_DIR/std_data/client-key.pem';
 start slave;
 include/wait_for_slave_to_start.inc

--- a/mysql-test/suite/rpl/r/rpl_stm_stop_middle_group.result
+++ b/mysql-test/suite/rpl/r/rpl_stm_stop_middle_group.result
@@ -43,7 +43,7 @@ Warnings:
 Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it accesses a non-transactional table after accessing a transactional table within the same transaction
 commit;
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1593]
 SELECT "Fatal error: ... Slave SQL Thread stopped with incomplete event group having non-transactional changes. If the group consists solely of row-based events, you can try to restart the slave with --slave-exec-mode=IDEMPOTENT, which ignores duplicate key, key not found, and similar errors (see documentation for details)." AS Last_SQL_Error, @check as `true`;
 Last_SQL_Error	true
 Fatal error: ... Slave SQL Thread stopped with incomplete event group having non-transactional changes. If the group consists solely of row-based events, you can try to restart the slave with --slave-exec-mode=IDEMPOTENT, which ignores duplicate key, key not found, and similar errors (see documentation for details).	1
@@ -63,7 +63,7 @@ set @@global.debug_dbug="d,stop_slave_middle_group,incomplete_group_in_relay_log
 connection master;
 update tm as t1, ti as t2 set t1.a=t1.a * 2, t2.a=t2.a * 2;
 connection slave;
-include/wait_for_slave_sql_to_stop.inc
+include/wait_for_slave_sql_error.inc [errno=1593]
 SELECT "Fatal error: ... Slave SQL Thread stopped with incomplete event group having non-transactional changes. If the group consists solely of row-based events, you can try to restart the slave with --slave-exec-mode=IDEMPOTENT, which ignores duplicate key, key not found, and similar errors (see documentation for details)." AS Last_SQL_Error, @check as `true`;
 Last_SQL_Error	true
 Fatal error: ... Slave SQL Thread stopped with incomplete event group having non-transactional changes. If the group consists solely of row-based events, you can try to restart the slave with --slave-exec-mode=IDEMPOTENT, which ignores duplicate key, key not found, and similar errors (see documentation for details).	1

--- a/mysql-test/suite/rpl/t/mdev-31448_kill_ooo_finish_optimistic.test
+++ b/mysql-test/suite/rpl/t/mdev-31448_kill_ooo_finish_optimistic.test
@@ -81,6 +81,7 @@ DROP TABLE t1;
 --connection slave
 --echo #
 --echo # Cleanup
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 eval set @@global.slave_parallel_threads= $save_slave_parallel_threads;
 eval set @@global.slave_parallel_mode= $save_slave_parallel_mode;

--- a/mysql-test/suite/rpl/t/rpl_connection.test
+++ b/mysql-test/suite/rpl/t/rpl_connection.test
@@ -16,6 +16,7 @@ CHANGE MASTER TO MASTER_USER= '', MASTER_PASSWORD= '';
 START SLAVE;
 --let $slave_io_errno= 1045, 1593
 --source include/wait_for_slave_io_error.inc
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 
 CHANGE MASTER TO MASTER_USER= 'root', MASTER_PASSWORD= '';

--- a/mysql-test/suite/rpl/t/rpl_domain_id_filter_io_crash.test
+++ b/mysql-test/suite/rpl/t/rpl_domain_id_filter_io_crash.test
@@ -149,7 +149,7 @@ connection slave;
 SELECT * FROM t1;
 
 SET @@global.debug_dbug=@saved_dbug;
-
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 let $do_domain_ids_before= query_get_value(SHOW SLAVE STATUS, Replicate_Do_Domain_Ids, 1);
 let $ignore_domain_ids_before= query_get_value(SHOW SLAVE STATUS, Replicate_Ignore_Domain_Ids, 1);

--- a/mysql-test/suite/rpl/t/rpl_domain_id_filter_master_crash.test
+++ b/mysql-test/suite/rpl/t/rpl_domain_id_filter_master_crash.test
@@ -67,8 +67,10 @@ connection master;
 save_master_pos;
 
 --connection slave
---source include/stop_slave.inc
---source include/start_slave.inc
+--let rpl_allow_error=1
+--source include/wait_for_slave_io_to_start.inc
+--let rpl_allow_error=
+--source include/wait_for_slave_sql_to_start.inc
 sync_with_master;
 select * from ti;
 select * from tm;

--- a/mysql-test/suite/rpl/t/rpl_fail_register.test
+++ b/mysql-test/suite/rpl/t/rpl_fail_register.test
@@ -3,7 +3,7 @@ source include/have_binlog_format_mixed.inc;
 source include/master-slave.inc;
 
 connection slave;
-
+CALL mtr.add_suppression("Slave I/O: Master command COM_REGISTER_SLAVE failed: Debug Induced Error");
 set @old_dbug=@@global.debug_dbug;
 set global debug_dbug='d,fail_com_register_slave';
 
@@ -11,8 +11,11 @@ stop slave;
 reset slave;
 source include/wait_for_slave_to_stop.inc;
 start slave;
-stop slave;
-source include/wait_for_slave_to_stop.inc;
+# Debug point will raise IO thread error ER_SLAVE_MASTER_COM_FAILURE
+# so we will wait for that and manually stop the SQL thread
+--let $slave_io_errno= 1597
+--source include/wait_for_slave_io_error.inc
+--source include/stop_slave_sql.inc
 set global debug_dbug=@old_dbug;
 
 connection master;

--- a/mysql-test/suite/rpl/t/rpl_gtid_errorhandling.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_errorhandling.test
@@ -19,7 +19,7 @@ INSERT INTO t1 VALUES (1);
 CALL mtr.add_suppression("Slave: Failed to open mysql.gtid_slave_pos");
 --let $slave_sql_errno=1944
 --source include/wait_for_slave_sql_error.inc
-
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 ALTER TABLE mysql.gtid_slave_pos CHANGE seq_no seq_no BIGINT UNSIGNED NOT NULL;
 ALTER TABLE mysql.gtid_slave_pos DROP PRIMARY KEY;

--- a/mysql-test/suite/rpl/t/rpl_gtid_errorlog.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_errorlog.test
@@ -31,7 +31,7 @@ SET sql_log_bin=1;
 START SLAVE;
 --let $slave_sql_errno=1062
 --source include/wait_for_slave_sql_error.inc
-
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 # Skip the problem event from the master.
 SET GLOBAL gtid_slave_pos= "0-1-100";

--- a/mysql-test/suite/rpl/t/rpl_gtid_startpos.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_startpos.test
@@ -50,6 +50,7 @@ eval CHANGE MASTER TO master_host = '127.0.0.1', master_port = $MASTER_MYPORT,
 START SLAVE;
 --let $slave_io_errno= 1236
 --source include/wait_for_slave_io_error.inc
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 
 --replace_result $MASTER_MYPORT MASTER_PORT

--- a/mysql-test/suite/rpl/t/rpl_gtid_stop_start.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_stop_start.test
@@ -207,7 +207,7 @@ SET sql_log_bin=0;
 call mtr.add_suppression("Failed to load slave replication state from table");
 call mtr.add_suppression("Unable to load replication GTID slave state");
 SET sql_log_bin=1;
-
+--let rpl_allow_error= 1
 --source include/start_slave.inc
 --connection server_1
 INSERT INTO t1 VALUES (9);

--- a/mysql-test/suite/rpl/t/rpl_heartbeat_basic.test
+++ b/mysql-test/suite/rpl/t/rpl_heartbeat_basic.test
@@ -327,6 +327,7 @@ sleep 4;
 let $rcvd_heartbeats_after= query_get_value(SHOW STATUS LIKE 'slave_received_heartbeats', Value, 1);
 let $result= query_get_value(SELECT ($rcvd_heartbeats_after - $rcvd_heartbeats_before) > 0 AS Result, Result, 1);
 --echo Heartbeat events are received while sql thread stopped (1 means 'yes'): $result
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 DROP TABLE t1;
 --echo

--- a/mysql-test/suite/rpl/t/rpl_mdev_17614.test
+++ b/mysql-test/suite/rpl/t/rpl_mdev_17614.test
@@ -41,7 +41,8 @@ SELECT * FROM t1;
 
 # restart replication for the next testcase
 stop slave;
---source include/wait_for_slave_to_stop.inc
+--let $rpl_only_running_threads= 1
+--source include/stop_slave.inc
 reset slave;
 connection master;
 reset master;
@@ -160,7 +161,8 @@ SELECT * FROM t1;
 
 # restart replication for the next testcase
 stop slave;
---source include/wait_for_slave_to_stop.inc
+--let $rpl_only_running_threads= 1
+--source include/stop_slave.inc
 reset slave;
 connection master;
 reset master;

--- a/mysql-test/suite/rpl/t/rpl_parallel.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel.test
@@ -1175,9 +1175,9 @@ SET debug_sync='RESET';
 --save_master_pos
 
 --connection server_2
+# SQL thread stopped
 --let $slave_sql_errno= 1062
 --source include/wait_for_slave_sql_error.inc
---source include/wait_for_slave_sql_to_stop.inc
 # We should not see the row (112,3) here, it should be rolled back due to
 # error signal from the prior transaction.
 SELECT * FROM t3 WHERE a >= 110 ORDER BY a;

--- a/mysql-test/suite/rpl/t/rpl_parallel_ignored_errors.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_ignored_errors.test
@@ -93,6 +93,9 @@ COMMIT;
 
 # Clean up.
 --connection server_2
+--let $slave_sql_errno= 1062
+--source include/wait_for_slave_sql_error.inc
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 --let $assert_cond= COUNT(*) = 0 FROM t1 WHERE a>32
 --let $assert_text= table t1 should have zero rows where a>32

--- a/mysql-test/suite/rpl/t/rpl_parallel_retry.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_retry.test
@@ -469,6 +469,7 @@ if (`SELECT count(*) = 1 FROM t1 WHERE a = 2`)
 # Clean up
 #
 --connection server_2
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 SET @@GLOBAL.slave_parallel_threads=@old_parallel_threads;
 SET @@GLOBAL.slave_parallel_mode=@old_parallel_mode;

--- a/mysql-test/suite/rpl/t/rpl_row_corruption.test
+++ b/mysql-test/suite/rpl/t/rpl_row_corruption.test
@@ -39,6 +39,7 @@ SET @@global.debug_dbug="d,inject_tblmap_same_id_maps_diff_table";
 # wait for error 1593 (ER_SLAVE_FATAL_ERROR)
 --let $slave_sql_errno=1593 
 --source include/wait_for_slave_sql_error.inc
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 
 # clean up

--- a/mysql-test/suite/rpl/t/rpl_row_idempotency.test
+++ b/mysql-test/suite/rpl/t/rpl_row_idempotency.test
@@ -139,7 +139,9 @@ select * from ti1 order by b /* must be (2),(3) */;
 
 --echo *** slave must stop (Trying to delete a referenced foreing key)
 connection slave;
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_ROW_IS_REFERENCED_2 # Cannot add or update a child row: a foreign key constraint fails 
+--let slave_sql_errno= 1451
+source include/wait_for_slave_sql_error.inc;
 
 let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
 disable_query_log;
@@ -173,7 +175,9 @@ insert into ti2 set a=3, b=3 /* offending write event */;
 
 --echo *** slave must stop (Trying to insert an invalid foreign key)
 connection slave;
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_NO_REFERENCED_ROW_2 # Cannot add or update a parent row: a foreign key constraint fails
+--let slave_sql_errno= 1452
+source include/wait_for_slave_sql_error.inc;
 
 let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
 disable_query_log;
@@ -210,9 +214,11 @@ insert into ti1 set b=1;
 connection master;
 insert into ti1 set b=1 /* offending write event */;
 
---echo *** slave must stop (Trying to insert a dupliacte key)
+--echo *** slave must stop (Trying to insert a duplicate key)
 connection slave;
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_DUP_ENTRY # Duplicate entry for key
+--let slave_sql_errno= 1062
+source include/wait_for_slave_sql_error.inc;
 
 let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
 disable_query_log;
@@ -247,7 +253,10 @@ DELETE FROM t1 WHERE a = -2;
 
 --echo *** slave must stop (Key was not found)
 connection slave;
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_KEY_NOT_FOUND # Can't find record
+--let slave_sql_errno= 1032
+source include/wait_for_slave_sql_error.inc;
+
 
 let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
 disable_query_log;
@@ -265,7 +274,9 @@ connection master;
 DELETE FROM t2 WHERE a = -2; 
 --echo *** slave must stop (Key was not found)
 connection slave;
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_KEY_NOT_FOUND # Can't find record
+--let slave_sql_errno= 1032
+source include/wait_for_slave_sql_error.inc;
 
 let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
 disable_query_log;
@@ -287,7 +298,9 @@ UPDATE t1 SET a = 1 WHERE a = -1;
 
 --echo *** slave must stop (Key was not found)
 connection slave;
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_KEY_NOT_FOUND # Can't find record
+--let slave_sql_errno= 1032
+source include/wait_for_slave_sql_error.inc;
 
 let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
 disable_query_log;
@@ -307,7 +320,9 @@ UPDATE t2 SET a = 1 WHERE a = -1;
 
 --echo *** slave must stop (Key was not found)
 connection slave;
-source include/wait_for_slave_sql_to_stop.inc;
+# ER_KEY_NOT_FOUND # Can't find record
+--let slave_sql_errno= 1032
+source include/wait_for_slave_sql_error.inc;
 
 let $last_error = query_get_value("SHOW SLAVE STATUS", Last_SQL_Errno, 1);
 disable_query_log;

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_master_shutdown.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_master_shutdown.test
@@ -30,8 +30,12 @@ connection master;
 --let $rpl_server_number=1
 source include/rpl_stop_server.inc;
 
+# After stoping the master, slave receives the disconnect error (2003)
 --connection slave
---source include/stop_slave.inc
+--let $slave_io_errno=2003
+--let $slave_io_error_is_nonfatal=1
+--source include/wait_for_slave_io_error.inc
+--let $slave_io_error_is_nonfatal=0
 
 #connection master;
 --echo # Restart master
@@ -42,8 +46,10 @@ source include/rpl_start_server.inc;
 # Clean up
 #
 --connection slave
---source include/stop_slave.inc
---source include/start_slave.inc
+--source include/wait_for_slave_sql_to_start.inc
+--let rpl_allow_error=1
+--source include/wait_for_slave_io_to_start.inc
+#--source include/start_slave.inc
 
 --connection master
 SET @@GLOBAL.debug_dbug="";

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
@@ -116,11 +116,13 @@ show status like 'Rpl_semi_sync_master_no_tx';
 --connection server_2
 --eval SET @@GLOBAL.debug_dbug= "$sav_server_2_dbug"
 --eval SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0
+--let $rpl_only_running_threads= 1
 source include/stop_slave.inc;
 
 --connection server_3
 --eval SET @@GLOBAL.debug_dbug= "$sav_server_3_dbug"
 --eval SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0
+--let $rpl_only_running_threads= 1
 source include/stop_slave.inc;
 
 --echo #-- Bring the master back up

--- a/mysql-test/suite/rpl/t/rpl_slave_status.test
+++ b/mysql-test/suite/rpl/t/rpl_slave_status.test
@@ -59,7 +59,6 @@ sync_slave_with_master;
 source include/stop_slave.inc;
 START SLAVE;
 source include/wait_for_slave_sql_to_start.inc;
-source include/wait_for_slave_io_to_stop.inc;
 
 --echo ==== Verify that Slave IO thread stopped with error ====
 # 1045 = ER_ACCESS_DENIED_ERROR
@@ -68,7 +67,7 @@ source include/wait_for_slave_io_to_stop.inc;
 
 --echo ==== Cleanup (Note that slave IO thread is not running) ====
 
-# cleanup: slave io thread has is stopped so we reset replication
+# cleanup: slave io thread is stopped so we reset replication
 --source include/stop_slave_sql.inc
 CHANGE MASTER TO MASTER_USER = 'root', MASTER_PASSWORD = '';
 # clear Slave_IO_Errno

--- a/mysql-test/suite/rpl/t/rpl_ssl1.test
+++ b/mysql-test/suite/rpl/t/rpl_ssl1.test
@@ -30,7 +30,9 @@ select * from t1;
 
 #showing that replication could work with ssl params
 stop slave;
---source include/wait_for_slave_to_stop.inc
+--let $slave_io_errno=1045
+--source include/wait_for_slave_io_error.inc
+
 --replace_result $MYSQL_TEST_DIR MYSQL_TEST_DIR
 eval change master to master_ssl=1 , master_ssl_ca ='$MYSQL_TEST_DIR/std_data/cacert.pem', master_ssl_cert='$MYSQL_TEST_DIR/std_data/client-cert.pem', master_ssl_key='$MYSQL_TEST_DIR/std_data/client-key.pem';
 start slave;

--- a/mysql-test/suite/rpl/t/semisync_future-7591.test
+++ b/mysql-test/suite/rpl/t/semisync_future-7591.test
@@ -19,6 +19,7 @@ insert into t1 values (1);
 reset master;
 
 --connection slave
+--let $rpl_only_running_threads= 1
 --source include/stop_slave.inc
 reset slave;
 --source include/start_slave.inc

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -4775,7 +4775,13 @@ connected:
         goto err;
       goto connected;
     }
-    DBUG_EXECUTE_IF("fail_com_register_slave", goto err;);
+    DBUG_EXECUTE_IF("fail_com_register_slave",
+                    {
+                      mi->report(ERROR_LEVEL, ER_SLAVE_MASTER_COM_FAILURE, NULL,
+                      ER(ER_SLAVE_MASTER_COM_FAILURE), "COM_REGISTER_SLAVE",
+                      "Debug Induced Error");
+                      goto err;
+                    });
   }
 
   DBUG_PRINT("info",("Starting reading binary log from master"));


### PR DESCRIPTION
By overriding the local branch accidentally, PR #2762  was closed and couldn't be reopened.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
