### PR TITLE
MDEV-35991 - Add `RUN_ABI_CHECK` to CMake cache

### DIFF
--- a/cmake/abi_check.cmake
+++ b/cmake/abi_check.cmake
@@ -23,10 +23,13 @@
 # (Solaris) sed or diff might act differently from GNU, so we run only 
 # on systems we can trust.
 IF(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Linux")
- SET(RUN_ABI_CHECK 1)
+ SET(RUN_ABI_CHECK_DEFAULT 1)
 ELSE()
- SET(RUN_ABI_CHECK 0)
+ SET(RUN_ABI_CHECK_DEFAULT 0)
 ENDIF()
+
+SET(RUN_ABI_CHECK ${RUN_ABI_CHECK_DEFAULT} CACHE
+    BOOL "Verify the exported ABI has not changed")
 
 IF(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang" AND RUN_ABI_CHECK)
   IF(CMAKE_C_COMPILER MATCHES "ccache$")


### PR DESCRIPTION
## Description

Allow disabling the ABI check at build time by setting a new CMake flag:

    -DRUN_ABI_CHECK=NO

This option will default to the current default setting

---

This is nice for debugging when you don't want to regenerate `.pp` files for every rebuild. There may already be a way to do this that I am not aware of.

## How can this PR be tested?

Make a change to a `.pp` file (e.g. `plugin_encryption.h.pp`) and try building with and without this option.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
