### PR TITLE
MDEV-32689: Remove Ubuntu Bionic from 10.5

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -76,9 +76,6 @@ case "${LSBNAME}" in
     # need to match here to avoid the default Error however
     ;;
   # UBUNTU
-  bionic)
-    remove_rocksdb_tools
-    ;&
   focal)
     ;&
   impish|jammy|kinetic)


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-32689*

## Description
Commit Removed Ubuntu Bionic from debian/autobake-debs.sh as it's not used anymore to build official MariaDB images.
Please see #2828 for 10.6 and up version

**REMINDER TO MERGER: This commit should not be merged up to 10.6 or forward**

## How can this PR be tested?
This is just downgraded #2828 which is merged

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
