### PR TITLE
MDEV-32820 Race condition between trx_purge_free_segment() and trx_undo_create()

### DIFF
--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -365,8 +365,10 @@ void trx_purge_free_segment(mtr_t &mtr, trx_rseg_t* rseg, fil_addr_t hdr_addr)
   while (!fseg_free_step_not_header(TRX_UNDO_SEG_HDR + TRX_UNDO_FSEG_HEADER +
                                     block->frame, &mtr))
   {
-    block->fix();
-    const page_id_t id{block->page.id()};
+    buf_block_buf_fix_inc(rseg_hdr, __FILE__, __LINE__);
+    buf_block_buf_fix_inc(block, __FILE__, __LINE__);
+    ut_d(const page_id_t rseg_hdr_id{rseg_hdr->page.id()});
+    ut_d(const page_id_t id{block->page.id()});
     mtr.commit();
     /* NOTE: If the server is killed after the log that was produced
     up to this point was written, and before the log from the mtr.commit()
@@ -376,19 +378,12 @@ void trx_purge_free_segment(mtr_t &mtr, trx_rseg_t* rseg, fil_addr_t hdr_addr)
     This does not matter when using multiple innodb_undo_tablespaces;
     innodb_undo_log_truncate=ON will be able to reclaim the space. */
     mtr.start();
-    ut_ad(rw_lock_s_lock_nowait(block->debug_latch, __FILE__, __LINE__));
+    rw_lock_x_lock(&rseg_hdr->lock);
     rw_lock_x_lock(&block->lock);
-    if (UNIV_UNLIKELY(block->page.id() != id))
-    {
-      block->unfix();
-      rw_lock_x_unlock(&block->lock);
-      ut_d(rw_lock_s_unlock(block->debug_latch));
-      block= buf_page_get(id, 0, RW_X_LATCH, &mtr);
-      if (!block)
-        return;
-    }
-    else
-      mtr_memo_push(&mtr, block, MTR_MEMO_PAGE_X_FIX);
+    ut_ad(rseg_hdr->page.id() == rseg_hdr_id);
+    ut_ad(block->page.id() == id);
+    mtr_memo_push(&mtr, rseg_hdr, MTR_MEMO_PAGE_X_FIX);
+    mtr_memo_push(&mtr, block, MTR_MEMO_PAGE_X_FIX);
   }
 
   while (!fseg_free_step(TRX_UNDO_SEG_HDR + TRX_UNDO_FSEG_HEADER +


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-32820*

## Description
`trx_purge_free_segment()`: If `fseg_free_step_not_header()` needs to be called multiple times, acquire an exclusive latch on the rollback segment header page after restarting the mini-transaction so that the rest of this function cannot execute concurrently with `trx_undo_create()` on the same rollback segment.

This fixes a regression that was introduced in commit c14a39431b211017e6809bb79c4079b38ffc3dff (MDEV-30753).

## How can this PR be tested?
The normal regression test suite should exercise this. The bug was found via a one-time failure of the test `encryption.create_or_replace` in 23651e27c672aa57d0dfba1251a4fc0abc6c95d6 (which uses `innodb_undo_tablespaces=3` by default). I think that the bug should be repeatable with any setting of `innodb_undo_tablespaces=0`, but it is a very rare finding (only one occurrence in our CI system, not reproduced elsewhere). The assertion `f >= FREED` that failed was introduced in 10.6 aaef2e1d8c843d1e40b1ce0c5199c3abb3c5da28; I did not check if an equivalent assertion is present in 10.5 at all.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.