### PR TITLE
MDEV-32820 Race condition between trx_purge_free_segment() and trx_undo_create()

### DIFF
--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -349,14 +349,21 @@ trx_purge_add_undo_to_history(const trx_t* trx, trx_undo_t*& undo, mtr_t* mtr)
 }
 
 /** Free an undo log segment.
-@param block     rollback segment header page
+@param rseg_hdr  rollback segment header page
+@param block     undo segment header page
 @param mtr       mini-transaction */
-static void trx_purge_free_segment(buf_block_t *block, mtr_t &mtr)
+static void trx_purge_free_segment(buf_block_t *rseg_hdr, buf_block_t *block,
+                                   mtr_t &mtr)
 {
+  ut_ad(mtr.memo_contains_flagged(rseg_hdr, MTR_MEMO_PAGE_X_FIX));
+  ut_ad(mtr.memo_contains_flagged(block, MTR_MEMO_PAGE_X_FIX));
+
   while (!fseg_free_step_not_header(TRX_UNDO_SEG_HDR + TRX_UNDO_FSEG_HEADER +
                                     block->page.frame, &mtr))
   {
+    rseg_hdr->fix();
     block->fix();
+    ut_d(const page_id_t rseg_hdr_id{rseg_hdr->page.id()});
     ut_d(const page_id_t id{block->page.id()});
     mtr.commit();
     /* NOTE: If the server is killed after the log that was produced
@@ -367,8 +374,11 @@ static void trx_purge_free_segment(buf_block_t *block, mtr_t &mtr)
     This does not matter when using multiple innodb_undo_tablespaces;
     innodb_undo_log_truncate=ON will be able to reclaim the space. */
     mtr.start();
+    rseg_hdr->page.lock.x_lock();
+    ut_ad(rseg_hdr->page.id() == rseg_hdr_id);
     block->page.lock.x_lock();
     ut_ad(block->page.id() == id);
+    mtr.memo_push(rseg_hdr, MTR_MEMO_PAGE_X_MODIFY);
     mtr.memo_push(block, MTR_MEMO_PAGE_X_MODIFY);
   }
 
@@ -458,7 +468,7 @@ loop:
     free_segment:
       ut_ad(rseg.curr_size >= seg_size);
       rseg.curr_size-= seg_size;
-      trx_purge_free_segment(b, mtr);
+      trx_purge_free_segment(rseg_hdr, b, mtr);
       break;
     case TRX_UNDO_CACHED:
       /* rseg.undo_cached must point to this page */


### PR DESCRIPTION
This is the 10.6 version of #2847.

- [x] *The Jira issue number for this PR is: MDEV-32820*

## Description
`trx_purge_free_segment()`: If `fseg_free_step_not_header()` needs to be called multiple times, acquire an exclusive latch on the rollback segment header page after restarting the mini-transaction so that the rest of this function cannot execute concurrently with `trx_undo_create()` on the same rollback segment.

This fixes a regression that was introduced in commit c14a39431b211017e6809bb79c4079b38ffc3dff (MDEV-30753).

## How can this PR be tested?
The normal regression test suite should exercise this. The bug was found via a one-time failure of the test `encryption.create_or_replace` in 23651e27c672aa57d0dfba1251a4fc0abc6c95d6 (which uses `innodb_undo_tablespaces=3` by default). I think that the bug should be repeatable with any setting of `innodb_undo_tablespaces=0`, but it is a very rare finding (only one occurrence in our CI system, not reproduced elsewhere).

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.