### PR TITLE
MDEV-31995 Fix2 allocate memory in mem_root properly.

### DIFF
--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -10697,8 +10697,9 @@ bool st_select_lex::save_item_list_names(THD *thd)
 
   while ((item= li++))
   {
-    if (unlikely(orig_names_of_item_list_elems->push_back(
-          new Lex_ident_sys(item->name.str, item->name.length), thd->mem_root)))
+    Lex_ident_sys *name= new (thd->mem_root) Lex_ident_sys(thd, &item->name);
+    if (unlikely(!name ||
+          orig_names_of_item_list_elems->push_back(name,  thd->mem_root)))
     {
       if (arena)
         thd->restore_active_arena(arena, &backup);

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -143,6 +143,11 @@ public:
 struct Lex_ident_sys_st: public LEX_CSTRING
 {
 public:
+  static void *operator new(size_t size, MEM_ROOT *mem_root) throw ()
+  { return alloc_root(mem_root, size); }
+  static void operator delete(void *ptr,size_t size) { TRASH_FREE(ptr, size); }
+  static void operator delete(void *ptr, MEM_ROOT *mem_root) {}
+
   bool copy_ident_cli(THD *thd, const Lex_ident_cli_st *str);
   bool copy_keyword(THD *thd, const Lex_ident_cli_st *str);
   bool copy_sys(THD *thd, const LEX_CSTRING *str);
@@ -175,6 +180,10 @@ public:
   {
     LEX_CSTRING tmp= {name, length};
     set_valid_utf8(&tmp);
+  }
+  Lex_ident_sys(THD *thd, const LEX_CSTRING *str)
+  {
+    set_valid_utf8(str);
   }
   Lex_ident_sys & operator=(const Lex_ident_sys_st &name)
   {


### PR DESCRIPTION
Lex_ident_sys had no new operator and was used incorrectly in save_item_list_names(), so leaked memory.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31995*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
