### PR TITLE
MDEV-23401  main suite test case prints extra row for metadata_lock_info query

### DIFF
--- a/mysql-test/main/backup_interaction.result
+++ b/mysql-test/main/backup_interaction.result
@@ -95,7 +95,7 @@ drop table t1;
 #
 # BACKUP STAGE performs implicit commits
 #
-create table t1(a int) engine=InnoDB;
+create table t1(a int) stats_persistent=0, engine=InnoDB;
 begin;
 insert into t1 values(1);
 select lock_mode from information_schema.metadata_lock_info;
@@ -197,8 +197,9 @@ drop table t1;
 # CHECK: RO transaction under BACKUP STAGE is a potential deadlock
 # OTOH we most probably allow them under FTWRL as well
 #
-CREATE TABLE t1 (col1 INT) ENGINE = InnoDB;
+CREATE TABLE t1 (col1 INT)stats_persistent=0, ENGINE = InnoDB;
 insert into t1 values (1);
+InnoDB		0 transactions not purged
 backup stage start;
 backup stage block_commit;
 begin;

--- a/mysql-test/main/backup_interaction.test
+++ b/mysql-test/main/backup_interaction.test
@@ -120,7 +120,7 @@ drop table t1;
 --echo # BACKUP STAGE performs implicit commits
 --echo #
 --disable_view_protocol
-create table t1(a int) engine=InnoDB;
+create table t1(a int) stats_persistent=0, engine=InnoDB;
 begin;
 insert into t1 values(1);
 select lock_mode from information_schema.metadata_lock_info;
@@ -221,8 +221,9 @@ drop table t1;
 --echo # OTOH we most probably allow them under FTWRL as well
 --echo #
 --disable_view_protocol
-CREATE TABLE t1 (col1 INT) ENGINE = InnoDB;
+CREATE TABLE t1 (col1 INT)stats_persistent=0, ENGINE = InnoDB;
 insert into t1 values (1);
+--source ../suite/innodb/include/wait_all_purged.inc
 backup stage start;
 backup stage block_commit;
 begin;

--- a/mysql-test/main/backup_lock.result
+++ b/mysql-test/main/backup_lock.result
@@ -1,6 +1,7 @@
 #
 # Testing which locks we get from all stages
 #
+InnoDB		0 transactions not purged
 BACKUP STAGE START;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
@@ -29,7 +30,8 @@ connection default;
 #
 # testing if BACKUP STAGE FLUSH causes deadlocks with ALTER TABLE
 #
-create table t1 (a int) engine=innodb;
+create table t1 (a int) stats_persistent= 0, engine=innodb;
+InnoDB		0 transactions not purged
 start transaction;
 insert into t1 values (1);
 connection con1;
@@ -95,7 +97,8 @@ drop table t1;
 #
 # testing if BACKUP STAGE FLUSH causes deadlocks with DROP TABLE
 #
-create table t1 (a int) engine=innodb;
+create table t1 (a int)stats_persistent=0, engine=innodb;
+InnoDB		0 transactions not purged
 start transaction;
 insert into t1 values (1);
 connection con1;
@@ -122,6 +125,7 @@ connection default;
 # Check if backup stage block_dll + concurrent drop table blocks select
 #
 create table t1 (a int) engine=innodb;
+InnoDB		0 transactions not purged
 backup stage start;
 backup stage block_ddl;
 connection con1;

--- a/mysql-test/main/backup_lock.test
+++ b/mysql-test/main/backup_lock.test
@@ -12,6 +12,7 @@
 --echo # Testing which locks we get from all stages
 --echo #
 
+--source ../suite/innodb/include/wait_all_purged.inc
 BACKUP STAGE START;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 BACKUP STAGE FLUSH;
@@ -36,8 +37,8 @@ connection default;
 --echo # testing if BACKUP STAGE FLUSH causes deadlocks with ALTER TABLE
 --echo #
 
-create table t1 (a int) engine=innodb;
-
+create table t1 (a int) stats_persistent= 0, engine=innodb;
+--source ../suite/innodb/include/wait_all_purged.inc
 start transaction;
 # Acquires MDL lock
 insert into t1 values (1);
@@ -123,7 +124,8 @@ drop table t1;
 --echo # testing if BACKUP STAGE FLUSH causes deadlocks with DROP TABLE
 --echo #
 
-create table t1 (a int) engine=innodb;
+create table t1 (a int)stats_persistent=0, engine=innodb;
+--source ../suite/innodb/include/wait_all_purged.inc
 start transaction;
 # Acquires MDL lock
 insert into t1 values (1);
@@ -159,6 +161,7 @@ connection default;
 --echo #
 
 create table t1 (a int) engine=innodb;
+--source ../suite/innodb/include/wait_all_purged.inc
 backup stage start;
 backup stage block_ddl;
 connection con1;

--- a/mysql-test/main/backup_locks.result
+++ b/mysql-test/main/backup_locks.result
@@ -1,6 +1,7 @@
 #
 # Test lock taken
 #
+InnoDB		0 transactions not purged
 BACKUP LOCK test.t1;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
@@ -23,7 +24,7 @@ BACKUP UNLOCK;
 #
 connect  con1,localhost,root,,;
 connection default;
-create table t1 (a int) engine=innodb;
+create table t1 (a int) stats_persistent=0,engine=innodb;
 insert into t1 values (1);
 backup lock t1;
 select * from t1;
@@ -32,6 +33,7 @@ a
 connection con1;
 drop table t1;
 connection default;
+InnoDB		0 transactions not purged
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_SHARED_HIGH_PRIO	Table metadata lock	test	t1

--- a/mysql-test/main/backup_locks.test
+++ b/mysql-test/main/backup_locks.test
@@ -11,6 +11,7 @@
 --echo # Test lock taken
 --echo #
 
+--source ../suite/innodb/include/wait_all_purged.inc
 BACKUP LOCK test.t1;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 BACKUP UNLOCK;
@@ -29,7 +30,7 @@ BACKUP UNLOCK;
 connect (con1,localhost,root,,);
 
 connection default;
-create table t1 (a int) engine=innodb;
+create table t1 (a int) stats_persistent=0,engine=innodb;
 insert into t1 values (1);
 backup lock t1;
 select * from t1;
@@ -40,6 +41,7 @@ let $wait_condition=
     select count(*) = 1 from information_schema.processlist
     where state = "Waiting for table metadata lock";
 --source include/wait_condition.inc
+--source ../suite/innodb/include/wait_all_purged.inc
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 --error ER_LOCK_DEADLOCK
 select * from t1;

--- a/mysql-test/main/backup_stages.result
+++ b/mysql-test/main/backup_stages.result
@@ -17,6 +17,7 @@ FROM information_schema.processlist WHERE id = @con1_id;
 ID	USER	COMMAND	STATE	INFO	STAGE	MAX_STAGE	INFO_BINARY
 <con1_id>	root	Query	Waiting for backup lock	BACKUP STAGE START	0	0	BACKUP STAGE START
 BACKUP STAGE END;
+InnoDB		0 transactions not purged
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_START	Backup lock		

--- a/mysql-test/main/backup_stages.test
+++ b/mysql-test/main/backup_stages.test
@@ -50,6 +50,7 @@ FROM information_schema.processlist WHERE id = @con1_id;
 # con1 uses @@global.lock_wait_timeout
 
 BACKUP STAGE END;
+--source ../suite/innodb/include/wait_all_purged.inc
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 
 --connection con1

--- a/mysql-test/main/create_or_replace.result
+++ b/mysql-test/main/create_or_replace.result
@@ -260,6 +260,7 @@ Note	1051	Unknown table 'mysqltest2.t2'
 create table test.t1 (i int) engine=myisam;
 create table mysqltest2.t2 like test.t1;
 lock table test.t1 write, mysqltest2.t2 write;
+InnoDB		0 transactions not purged
 select * from information_schema.metadata_lock_info;
 THREAD_ID	LOCK_MODE	LOCK_DURATION	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 #	MDL_BACKUP_DDL	NULL	Backup lock		

--- a/mysql-test/main/create_or_replace.test
+++ b/mysql-test/main/create_or_replace.test
@@ -216,6 +216,7 @@ drop table if exists test.t1,mysqltest2.t2;
 create table test.t1 (i int) engine=myisam;
 create table mysqltest2.t2 like test.t1;
 lock table test.t1 write, mysqltest2.t2 write;
+--source ../suite/innodb/include/wait_all_purged.inc
 --replace_column 1 #
 --sorted_result
 select * from information_schema.metadata_lock_info;

--- a/mysql-test/main/mdl.result
+++ b/mysql-test/main/mdl.result
@@ -7,6 +7,7 @@
 #
 CREATE TABLE t1(a INT) ENGINE=InnoDB;
 CREATE TABLE t3(a INT) ENGINE=myisam;
+InnoDB		0 transactions not purged
 LOCK TABLES t1 WRITE CONCURRENT, t1 AS t2 READ;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
@@ -56,7 +57,7 @@ DROP TABLE t1,t3;
 #
 # Check MDL locks taken for different kind of tables by open
 #
-CREATE TABLE t1(a INT) ENGINE=InnoDB;
+CREATE TABLE t1(a INT) stats_persistent=0, ENGINE=InnoDB;
 CREATE TABLE t3(a INT) ENGINE=myisam;
 connect  locker,localhost,root,,;
 connection default;
@@ -64,6 +65,7 @@ FLUSH TABLES WITH READ LOCK;
 connection locker;
 insert into t1 values (1);
 connection default;
+InnoDB		0 transactions not purged
 connection default;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
@@ -77,6 +79,7 @@ FLUSH TABLES WITH READ LOCK;
 connection locker;
 insert into t3 values (2);
 connection default;
+InnoDB		0 transactions not purged
 connection default;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME

--- a/mysql-test/main/mdl.test
+++ b/mysql-test/main/mdl.test
@@ -11,6 +11,7 @@
 --disable_service_connection
 CREATE TABLE t1(a INT) ENGINE=InnoDB;
 CREATE TABLE t3(a INT) ENGINE=myisam;
+--source ../suite/innodb/include/wait_all_purged.inc
 LOCK TABLES t1 WRITE CONCURRENT, t1 AS t2 READ;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 UNLOCK TABLES;
@@ -38,7 +39,7 @@ DROP TABLE t1,t3;
 --echo # Check MDL locks taken for different kind of tables by open
 --echo #
 
-CREATE TABLE t1(a INT) ENGINE=InnoDB;
+CREATE TABLE t1(a INT) stats_persistent=0, ENGINE=InnoDB;
 CREATE TABLE t3(a INT) ENGINE=myisam;
 connect (locker,localhost,root,,);
 connection default;
@@ -52,6 +53,7 @@ let $wait_condition=
   select count(*) > 0 from information_schema.processlist
   where state = "Waiting for backup lock";
 --source include/wait_condition.inc
+--source ../suite/innodb/include/wait_all_purged.inc
 connection default;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 unlock tables;
@@ -69,6 +71,7 @@ let $wait_condition=
   select count(*) > 0 from information_schema.processlist
   where state = "Waiting for backup lock";
 --source include/wait_condition.inc
+--source ../suite/innodb/include/wait_all_purged.inc
 connection default;
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 unlock tables;

--- a/mysql-test/main/mdl_sync.result
+++ b/mysql-test/main/mdl_sync.result
@@ -2514,6 +2514,7 @@ connection con2;
 SET DEBUG_SYNC= 'now WAIT_FOR table_opened';
 # Check that FLUSH must wait to get the GRL
 # and let DROP PROCEDURE continue
+InnoDB		0 transactions not purged
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_DDL	Backup lock		
@@ -2538,7 +2539,7 @@ SET DEBUG_SYNC= 'RESET';
 # UPDATE should wait for FTWRL with non transactional table second
 #
 create table t1 (a int) engine=myisam;
-create table t2 (a int) engine=innodb;
+create table t2 (a int) stats_persistent=0, engine=innodb;
 insert into t1 values (1);
 insert into t2 values (1);
 SET DEBUG_SYNC= 'after_open_table_mdl_shared SIGNAL table_opened WAIT_FOR grlwait execute 2';

--- a/mysql-test/main/mdl_sync.test
+++ b/mysql-test/main/mdl_sync.test
@@ -3249,6 +3249,7 @@ connection con2;
 SET DEBUG_SYNC= 'now WAIT_FOR table_opened';
 --echo # Check that FLUSH must wait to get the GRL
 --echo # and let DROP PROCEDURE continue
+--source ../suite/innodb/include/wait_all_purged.inc
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 SET DEBUG_SYNC= 'mdl_acquire_lock_wait SIGNAL grlwait';
 --send FLUSH TABLES WITH READ LOCK
@@ -3274,7 +3275,7 @@ SET DEBUG_SYNC= 'RESET';
 --echo #
 
 create table t1 (a int) engine=myisam;
-create table t2 (a int) engine=innodb;
+create table t2 (a int) stats_persistent=0, engine=innodb;
 insert into t1 values (1);
 insert into t2 values (1);
 


### PR DESCRIPTION

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-23401*

## Description
- Added the parameter stats_persistent=0 for InnoDB engine.
- Before printing metadata_lock_info query, make sure that InnoDB does complete purging.

## How can this PR be tested?
mysql-test-run.pl --suite=main should be sufficient for testing the test case changes

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
