### PR TITLE
MDEV-32611: Test suite is missing dump option `delete-master-logs`

### DIFF
--- a/mysql-test/main/rpl_mysqldump_slave.result
+++ b/mysql-test/main/rpl_mysqldump_slave.result
@@ -65,4 +65,13 @@ SET GLOBAL gtid_slave_pos='0-2-1003';
 -- CHANGE MASTER TO MASTER_LOG_FILE='slave-bin.000001', MASTER_LOG_POS=BINLOG_START;
 CHANGE MASTER TO MASTER_USE_GTID=slave_pos;
 SET GLOBAL gtid_slave_pos='0-2-1003';
+connection master;
+CREATE TABLE t (
+id int
+);
+insert into t values (1);
+insert into t values (2);
+drop table t;
+-- CHANGE MASTER TO MASTER_LOG_FILE='master-bin.000002', MASTER_LOG_POS=BINLOG_START;
+-- SET GLOBAL gtid_slave_pos='0-1-1005';
 include/rpl_end.inc

--- a/mysql-test/main/rpl_mysqldump_slave.test
+++ b/mysql-test/main/rpl_mysqldump_slave.test
@@ -83,6 +83,46 @@ DROP TABLE t2;
 --replace_regex /MASTER_LOG_POS=[0-9]+/MASTER_LOG_POS=BINLOG_START/
 --exec $MYSQL_DUMP_SLAVE --compact --master-data --single-transaction --gtid test
 
+#
+# MDEV-32611 Added test for mysqldump --delete-master-logs option.
+# This options is alias of 
+# get binlogs: show master status -> flush logs -> purge binary logs to <new_binlog>
+# sequence and this test is derived using the same pattern.
+#
 
+connection master;
+
+CREATE TABLE t (
+    id int
+);
+
+insert into t values (1);
+insert into t values (2);
+
+drop table t;
+
+--let $predump_binlog_filename= query_get_value(SHOW MASTER STATUS, File, 1)
+
+# Execute mysqldump with delete-master-logs option
+--replace_regex /MASTER_LOG_POS=[0-9]+/MASTER_LOG_POS=BINLOG_START/
+--exec $MYSQL_DUMP --compact --no-create-info --no-data --delete-master-logs test
+
+--let $postdump_binlog_filename= query_get_value(SHOW MASTER STATUS, File, 1)
+
+--let $postdump_first_binary_log_filename= query_get_value(SHOW BINARY LOGS, Log_name, 1)
+
+if ($predump_binlog_filename == $postdump_binlog_filename)
+{
+  --echo # predump_binlog_filename: $predump_binlog_filename
+  --echo # postdump_binlog_filename: $postdump_binlog_filename
+  --die Master state didn't change after mariadb-dump with --delete-master-logs.
+}
+
+if ($postdump_first_binary_log_filename != $postdump_binlog_filename)
+{
+  --echo # postdump_first_binary_log_filename: $postdump_first_binary_log_filename
+  --echo # postdump_binlog_filename: $postdump_binlog_filename
+  --die Master binlog wasn't deleted after mariadb-dump with --delete-master-logs.
+}
 
 --source include/rpl_end.inc


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32611*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This patch is for updating the testcase in `rpl_myslqdump_slave.test` for missing mysqldump `delete-master-logs` option

## How can this PR be tested?

by executing `mysql-test-run.pl rpl_mysqldump_slave.test` desire output can be obtained.
an additional note: I added this test at the very end, because adding it in the middle at it's correct place. it changes pre existing result, so i didn't. on suggestion i can do it. 
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
