### PR TITLE
MDEV-28971 SEQUENCEs do not work with streaming replication

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-28971.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-28971.result
@@ -1,0 +1,17 @@
+connection node_2;
+connection node_1;
+CREATE SEQUENCE SEQ NOCACHE ENGINE=InnoDB;
+SET SESSION wsrep_trx_fragment_size=1;
+SET collation_connection=utf16_thai_520_w2;
+SET autocommit=0;
+CREATE TABLE t1 (a BLOB UNIQUE);
+INSERT INTO t1 VALUES ('AAF');
+SELECT SETVAL (SEQ, 100);
+ERROR 42000: This version of MariaDB doesn't yet support 'SEQUENCEs with streaming replication in Galera cluster'
+ALTER TABLE t1 ADD CONSTRAINT constraint_1 UNIQUE (a);
+Warnings:
+Note	1831	Duplicate index `constraint_1`. This is deprecated and will be disallowed in a future release
+INSERT INTO t1 VALUES();
+ALTER TABLE t1 ADD KEY(b (50));
+ERROR 42000: Key column 'b' doesn't exist in table
+DROP TABLE t1,SEQ;

--- a/mysql-test/suite/galera_sr/t/MDEV-28971.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-28971.test
@@ -1,0 +1,20 @@
+#
+# MDEV-28971 - Assertion `total_length + thd->wsrep_sr().log_position() == saved_pos'
+# failed in int wsrep_write_cache_inc(THD*, IO_CACHE*, size_t*)
+#
+
+--source include/galera_cluster.inc
+
+CREATE SEQUENCE SEQ NOCACHE ENGINE=InnoDB;
+SET SESSION wsrep_trx_fragment_size=1;
+SET collation_connection=utf16_thai_520_w2;
+SET autocommit=0;
+CREATE TABLE t1 (a BLOB UNIQUE);
+INSERT INTO t1 VALUES ('AAF');
+--error ER_NOT_SUPPORTED_YET
+SELECT SETVAL (SEQ, 100);
+ALTER TABLE t1 ADD CONSTRAINT constraint_1 UNIQUE (a);
+INSERT INTO t1 VALUES();
+--error ER_KEY_COLUMN_DOES_NOT_EXITS
+ALTER TABLE t1 ADD KEY(b (50));
+DROP TABLE t1,SEQ;

--- a/sql/ha_sequence.cc
+++ b/sql/ha_sequence.cc
@@ -261,13 +261,26 @@ int ha_sequence::write_row(const uchar *buf)
   }
 
 #ifdef WITH_WSREP
-  /* We need to start Galera transaction for select NEXT VALUE FOR
-  sequence if it is not yet started. Note that ALTER is handled
-  as TOI. */
-  if (WSREP_ON && WSREP(thd) &&
-      !thd->wsrep_trx().active() &&
-      wsrep_thd_is_local(thd))
-    wsrep_start_transaction(thd, thd->wsrep_next_trx_id());
+  if (WSREP_ON && WSREP(thd) && wsrep_thd_is_local(thd))
+  {
+    if (sequence_locked &&
+        (wsrep_thd_is_SR(thd) || wsrep_streaming_enabled(thd)))
+    {
+      my_error(ER_NOT_SUPPORTED_YET, MYF(0),
+               "SEQUENCEs with streaming replication in Galera cluster");
+      DBUG_RETURN(HA_ERR_UNSUPPORTED);
+    }
+
+    /*
+       We need to start Galera transaction for select NEXT VALUE FOR
+       sequence if it is not yet started. Note that ALTER is handled
+       as TOI.
+    */
+    if (!thd->wsrep_trx().active())
+    {
+      wsrep_start_transaction(thd, thd->wsrep_next_trx_id());
+    }
+  }
 #endif
 
   if (likely(!(error= file->update_first_row(buf))))


### PR DESCRIPTION
Return an error if user attempts to use SEQUENCEs in combination with streaming replication in a Galera cluster. This is currently not supported.
