### PR TITLE
MDEV-32374 log_sys.lsn_lock is a performance hog

### DIFF
--- a/storage/innobase/btr/btr0bulk.cc
+++ b/storage/innobase/btr/btr0bulk.cc
@@ -969,10 +969,10 @@ BtrBulk::pageCommit(
 /** Log free check */
 inline void BtrBulk::logFreeCheck()
 {
-	if (log_sys.check_flush_or_checkpoint()) {
+	if (log_sys.check_for_checkpoint()) {
 		release();
 
-		log_check_margins();
+		log_free_check();
 
 		latch();
 	}

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2124,6 +2124,8 @@ ATTRIBUTE_COLD void buf_flush_ahead(lsn_t lsn, bool furious)
       limit= lsn;
       buf_pool.page_cleaner_set_idle(false);
       pthread_cond_signal(&buf_pool.do_flush_list);
+      if (furious)
+        log_sys.set_check_for_checkpoint();
     }
     mysql_mutex_unlock(&buf_pool.flush_list_mutex);
   }

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -3078,7 +3078,7 @@ ATTRIBUTE_NOINLINE ATTRIBUTE_COLD void mtr_t::name_write()
 and write out FILE_MODIFY if needed, and write FILE_CHECKPOINT.
 @param lsn  checkpoint LSN
 @return current LSN */
-lsn_t fil_names_clear(lsn_t lsn)
+ATTRIBUTE_COLD lsn_t fil_names_clear(lsn_t lsn)
 {
 	mtr_t	mtr;
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1575,7 +1575,8 @@ static void innodb_drop_database(handlerton*, char *path)
       ibuf_delete_for_discarded_space(id);
 
     /* Any changes must be persisted before we return. */
-    log_write_up_to(mtr.commit_lsn(), true);
+    if (mtr.commit_lsn())
+      log_write_up_to(mtr.commit_lsn(), true);
   }
 
   my_free(namebuf);

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4338,7 +4338,8 @@ static void unlock_and_close_files(const std::vector<pfs_os_file_t> &deleted,
   row_mysql_unlock_data_dictionary(trx);
   for (pfs_os_file_t d : deleted)
     os_file_close(d);
-  log_write_up_to(trx->commit_lsn, true);
+  if (trx->commit_lsn)
+    log_write_up_to(trx->commit_lsn, true);
 }
 
 /** Commit a DDL transaction and unlink any deleted files. */
@@ -11666,7 +11667,6 @@ foreign_fail:
 		}
 
 		unlock_and_close_files(deleted, trx);
-		log_write_up_to(trx->commit_lsn, true);
 		DBUG_EXECUTE_IF("innodb_alter_commit_crash_after_commit",
 				DBUG_SUICIDE(););
 		trx->free();
@@ -11723,7 +11723,6 @@ foreign_fail:
 	}
 
 	unlock_and_close_files(deleted, trx);
-	log_write_up_to(trx->commit_lsn, true);
 	DBUG_EXECUTE_IF("innodb_alter_commit_crash_after_commit",
 			DBUG_SUICIDE(););
 	trx->free();

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1802,7 +1802,7 @@ bool fil_comp_algo_loaded(ulint comp_algo);
 and write out FILE_MODIFY if needed, and write FILE_CHECKPOINT.
 @param lsn  checkpoint LSN
 @return current LSN */
-lsn_t fil_names_clear(lsn_t lsn);
+ATTRIBUTE_COLD lsn_t fil_names_clear(lsn_t lsn);
 
 #ifdef UNIV_ENABLE_UNIT_TEST_MAKE_FILEPATH
 void test_make_filepath();

--- a/storage/innobase/include/mtr0mtr.h
+++ b/storage/innobase/include/mtr0mtr.h
@@ -105,7 +105,7 @@ struct mtr_t {
   This is to be used at log_checkpoint().
   @param checkpoint_lsn   the log sequence number of a checkpoint, or 0
   @return current LSN */
-  lsn_t commit_files(lsn_t checkpoint_lsn= 0);
+  ATTRIBUTE_COLD lsn_t commit_files(lsn_t checkpoint_lsn= 0);
 
   /** @return mini-transaction savepoint (current size of m_memo) */
   ulint get_savepoint() const

--- a/storage/innobase/include/srw_lock.h
+++ b/storage/innobase/include/srw_lock.h
@@ -34,7 +34,6 @@ this program; if not, write to the Free Software Foundation, Inc.,
 # define SUX_LOCK_GENERIC /* Use dummy implementation for debugging purposes */
 #endif
 
-#ifdef SUX_LOCK_GENERIC
 /** An exclusive-only variant of srw_lock */
 template<bool spinloop>
 class pthread_mutex_wrapper final
@@ -70,7 +69,6 @@ template<>
 inline void pthread_mutex_wrapper<true>::wr_lock()
 { if (!wr_lock_try()) wr_wait(); }
 # endif
-#endif
 
 /** Futex-based mutex */
 template<bool spinloop>
@@ -541,7 +539,7 @@ public:
   /** @return whether any lock may be held by any thread */
   bool is_locked_or_waiting() const noexcept
   { return lock.is_locked_or_waiting(); }
-  /** @return whether an exclusive lock may be held by any thread */
+  /** @return whether a shared or exclusive lock may be held by any thread */
   bool is_locked() const noexcept { return lock.is_locked(); }
   /** @return whether an exclusive lock may be held by any thread */
   bool is_write_locked() const noexcept { return lock.is_write_locked(); }

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -120,7 +120,7 @@ public:
 		ut_ad(mtr_started == scan_mtr->is_active());
 
 		DBUG_EXECUTE_IF("row_merge_instrument_log_check_flush",
-				log_sys.set_check_flush_or_checkpoint(););
+				log_sys.set_check_for_checkpoint(););
 
 		for (idx_tuple_vec::iterator it = m_dtuple_vec.begin();
 		     it != m_dtuple_vec.end();
@@ -128,7 +128,7 @@ public:
 			dtuple = *it;
 			ut_ad(dtuple);
 
-			if (log_sys.check_flush_or_checkpoint()) {
+			if (log_sys.check_for_checkpoint()) {
 				if (mtr_started) {
 					if (!btr_pcur_move_to_prev_on_page(pcur)) {
 						error = DB_CORRUPTION;

--- a/storage/innobase/sync/srw_lock.cc
+++ b/storage/innobase/sync/srw_lock.cc
@@ -143,8 +143,7 @@ static inline void srw_pause(unsigned delay)
   HMT_medium();
 }
 
-#ifdef SUX_LOCK_GENERIC
-# ifndef PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
+#ifndef PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP
 template<> void pthread_mutex_wrapper<true>::wr_wait()
 {
   const unsigned delay= srw_pause_delay();
@@ -158,8 +157,9 @@ template<> void pthread_mutex_wrapper<true>::wr_wait()
 
   pthread_mutex_lock(&lock);
 }
-# endif
+#endif
 
+#ifdef SUX_LOCK_GENERIC
 template void ssux_lock_impl<false>::init();
 template void ssux_lock_impl<true>::init();
 template void ssux_lock_impl<false>::destroy();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-32374*

## Description
The `log_sys.lsn_lock` that was introduced in commit a635c40648519fd6c3729c9657872a16a0a20821 had better be located in the same cache line with `log_sys.latch` so that `log_t::append_prepare()` needs to modify only two first cache lines where `log_sys` is stored.

`log_t::lsn_lock`: On Linux, change the type from `pthread_mutex_t` to something that may be as small as 32 bits, to pack more data members in the same cache line. On Microsoft Windows, `CRITICAL_SECTION` works better.

`log_t::check_flush_or_checkpoint_`: Renamed to `need_checkpoint`. There is no need to pause all writer threads in `log_free_check()` when we only need to write `log_sys.buf` to `ib_logfile0`. That will be done in `mtr_t::commit()`.

`log_t::append_prepare_wait()`: Make the member function non-static to simplify the call interface, and add a parameter for the LSN.

`log_t::append_prepare()`: Invoke append_prepare_wait() at most once. Only `set_check_for_checkpoint()` if a log checkpoint needs to be written. If the log buffer needs to be written, we will take care of it ourselves later in our caller. This will reduce interference with `log_free_check()` in other threads.

`mtr_t::commit()`: Call `log_write_up_to()` if needed.

`log_t::get_write_target()`: Return a `log_write_up_to()` target to `mtr_t::commit()`.

`buf_flush_ahead()`: If we are in furious flushing, call `log_sys.set_check_for_checkpoint()` so that all writers will wait in `log_free_check()` until the checkpoint is done. Otherwise, the test `innodb.insert_into_empty` could occasionally report an error "Crash recovery is broken".

`log_check_margins()`: Replaced by `log_free_check()`.

`log_flush_margin()`: Removed. This is part of `mtr_t::commit()` and other operations that write log.

`log_t::create()`, `log_t::attach()`: Guarantee that `buf_free < max_buf_free` will always hold on PMEM, to satisfy an assumption of `log_t::get_write_target()`.

`log_write_up_to()`: Assert `lsn!=0`. Such calls are not incorrect, but it is cheaper to test that single unlikely condition in `mtr_t::commit()` rather than test several conditions in `log_write_up_to()`.

`innodb_drop_database()`, `unlock_and_close_files()`: Check the LSN before calling `log_write_up_to()`.

`ha_innobase::commit_inplace_alter_table()`: Remove redundant calls to `log_write_up_to()` after calling `unlock_and_close_files()`.

## How can this PR be tested?
This is a low-level change that is rather well exercised by the existing tests in the regression test suite, except that our CI systems mostly use the "fake PMEM" by default. @mleich1 tested this with RQG, specifically disabling the use of PMEM.

This is a performance fix. I tested it with a very skewed microbenchmark: Sysbench `oltp_update_non_index` on 256 tables, 10 rows per table, 256 threads, 10 GiB buffer pool (large enough for the workload), 4 GiB log file, and the minimum `--innodb-log-buffer-size=2m`, running on Linux `/dev/shm` but with `cmake -DCMAKE_DISABLE_FIND_PACKAGE_PMEM=1`. I also tested a more reasonable `--innodb-log-buffer-size=128m`. In either configuration, the modified code did not perform worse than the original.

Steve Shaw tested b58e1cef7f2f5294c393a3709819091213d3a0d5 with HammerDB and reported a 5% improvement in throughput at lower virtual user counts (up to the number of hardware threads). In that version, the `log_write_up_to()` call in `mtr_t::commit()` was unconditional; @vaintroub suggested to add the condition.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.