### PR TITLE
MDEV-32781 galera_bf_lock_wait test failed

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_lock_wait.result
+++ b/mysql-test/suite/galera/r/galera_bf_lock_wait.result
@@ -33,6 +33,26 @@ SET SESSION wsrep_sync_wait=0;
 call p1(1000);
 connection node_1;
 checking error log for 'BF lock wait long' message for 10 times every 10 seconds ...
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
+include/assert_grep.inc [BF lock wait long]
 connection node_1_p1;
 connection node_1_p2;
 connection node_2_p1;

--- a/mysql-test/suite/galera/t/galera_bf_lock_wait.test
+++ b/mysql-test/suite/galera/t/galera_bf_lock_wait.test
@@ -52,6 +52,12 @@ let $counter=10;
 let $sleep_period=10;
  
 echo checking error log for 'BF lock wait long' message for $counter times every $sleep_period seconds ...;
+
+--let assert_text= BF lock wait long
+--let assert_select= BF lock wait long
+--let assert_count= 0
+--let assert_only_after= CURRENT_TEST: galera.galera_bf_lock_wait
+
 while($counter > 0)
 {
 --disable_query_log
@@ -60,9 +66,11 @@ while($counter > 0)
 --enable_query_log
 --enable_result_log
 
-# use error 0,1 instead if want test to continue
-  --error 1
-  exec grep 'BF lock wait long' $MYSQLTEST_VARDIR/log/mysqld.*.err;
+--let assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--source include/assert_grep.inc
+
+--let assert_file= $MYSQLTEST_VARDIR/log/mysqld.2.err
+--source include/assert_grep.inc
   dec $counter;
 }
 


### PR DESCRIPTION
This test happens to fail if it runs after test
galera_inject_bf_long_wait.
And the reason is that galera_bf_lock_wait greps for message "BF lock wait long" in the error log, and expects that grep matches no lines. Whereas galera_inject_bf_long_wait intentionally causes the message to appear in the log. The fix consists in using assert_grep.inc with option assert_only_after, such that galera_bf_lock_wait is limited to grep only those lines that appeared in the log after it started to execute.