### PR TITLE
MDEV-31611: mariadb-setpermission - Can't use string as an ARRAY ref while strict refs in use

### DIFF
--- a/scripts/mysql_setpermission.sh
+++ b/scripts/mysql_setpermission.sh
@@ -68,7 +68,7 @@ usage() if ($opt_help); # the help function
 
 if ($opt_host =~ s/:(\d+)$//)
 {
-    $opt_port = $1;
+  $opt_port = $1;
 }
 
 if ($opt_host eq '')
@@ -98,7 +98,7 @@ my $prefix= 'mysql';
 if (eval {DBI->install_driver("MariaDB")}) {
   $dsn ="DBI:MariaDB:;";
   $prefix= 'mariadb';
-} 
+}
 else {
   $dsn = "DBI:mysql:;";
 }
@@ -226,11 +226,11 @@ sub setpwd
   {
     $pass = "PASSWORD(". $dbh->quote($pass) . ")";
   }
-  my $uh= "$user@$host";
+  my $uh= $user."@".$host;
   my $sth = $dbh->prepare("set password for $uh =$pass") || die $dbh->errstr;
   $sth->execute || die $dbh->errstr;
   $sth->finish;
-  print "The password is set for user $user.\n\n";
+  print "The password is set for user $uh.\n\n";
 
 }
 


### PR DESCRIPTION
## Create user and grant privileges
```sql
MariaDB [(none)]> create user test@localhost identified by 'pass1';

MariaDB [(none)]> grant select,update on mysql.* to test@localhost;
Query OK, 0 rows affected (0.001 sec)

MariaDB [(none)]> show grants for test@localhost;
+-------------------------------------------------------------------------------------------------------------+
| Grants for test@localhost                                                                                   |
+-------------------------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO `test`@`localhost` IDENTIFIED BY PASSWORD '*FB6E1F205D675BC29B052DB14CCEFE7759C5FF7E' |
| GRANT SELECT, UPDATE ON `mysql`.* TO `test`@`localhost`                                                     |
+-------------------------------------------------------------------------------------------------------------+
2 rows in set (0.000 sec)
```
## Change password via script
```bash
$ ./scripts/mysql_setpermission --user=test --password=pass1 --host=localhost

WARNING: MYSQL_OPT_RECONNECT is deprecated and will be removed in a future version.
######################################################################
## Welcome to the permission setter 1.4 for MariaDB.
## made by Luuk de Boer
######################################################################
What would you like to do:
  1. Set password for an existing user.
  2. Create a database + user privilege for that database
     and host combination (user can only do SELECT)
  3. Create/append user privilege for an existing database
     and host combination (user can only do SELECT)
  4. Create/append broader user privileges for an existing
     database and host combination
     (user can do SELECT,INSERT,UPDATE,DELETE)
  5. Create/append quite extended user privileges for an
     existing database and host combination (user can do
     SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,
     LOCK TABLES,CREATE TEMPORARY TABLES)
  6. Create/append full privileges for an existing database
     and host combination (user has FULL privilege)
  7. Remove all privileges for for an existing database and
     host combination.
     (user will have all permission fields set to N)
  0. exit this program

Make your choice [1,2,3,4,5,6,7,0]: 1


Setting a (new) password for a user.

For which user do you want to specify a password: test
Username = test
Would you like to set a password for test [y/n]: y
What password do you want to specify for test: 
Type the password again: 
We now need to know which host for test we have to change.
Choose from the following hosts: 
  - localhost 
The host please (case sensitive): localhost
The following host will be used: localhost.
######################################################################

That was it ... here is an overview of what you gave to me:
The username 		: test
The host		: localhost
######################################################################

Are you pretty sure you would like to implement this [yes/no]: yes
Okay ... let's go then ...

The password is set for user 'test'@'localhost'.

```
## Verify
```sql
$ mariadb -utest -ppass123
Welcome to the MariaDB monitor.  Commands end with ; or \g.
Your MariaDB connection id is 50
Server version: 10.6.16-MariaDB-1:10.6.16+maria~ubu2004 mariadb.org binary distribution

Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

MariaDB [(none)]> 
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
