### PR TITLE
MDEV-32371 Deadlock between buf_page_get_zip() and buf_pool_t::corrupted_evict()

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2235,14 +2235,21 @@ lookup:
 
       if (discard_attempted || !bpage->frame)
       {
-        /* Even when we are holding a hash_lock, it should be
-        acceptable to wait for a page S-latch here, because
-        buf_page_t::read_complete() will not wait for buf_pool.mutex,
-        and because S-latch would not conflict with a U-latch
-        that would be protecting buf_page_t::write_complete(). */
-        bpage->lock.s_lock();
+        const bool got_s_latch= bpage->lock.s_lock_try();
         hash_lock.unlock_shared();
-        break;
+        if (UNIV_LIKELY(got_s_latch))
+          break;
+        /* We may fail to acquire bpage->lock because
+        buf_page_t::read_complete() may be invoking
+        buf_pool_t::corrupted_evict() on this block, which it would
+        hold an exclusive latch on.
+
+        Let us aqcuire and release buf_pool.mutex to ensure that any
+        buf_pool_t::corrupted_evict() will proceed before we reacquire
+        the hash_lock that it could be waiting for. */
+        mysql_mutex_lock(&buf_pool.mutex);
+        mysql_mutex_unlock(&buf_pool.mutex);
+        goto lookup;
       }
 
       hash_lock.unlock_shared();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-32371*

## Description
`buf_page_get_zip()`: Do not wait for the page latch while holding `hash_lock`. If the latch is not available, ensure that any concurrent `buf_pool_t::corrupted_evict()` will be able to acquire the `hash_lock`, and then retry the lookup. If the page was corrupted and evicted, we will finally `goto must_read_page`, retry the read once more, and then report an error.

## How can this PR be tested?
I think that this is best tested together with [MDEV-31817](https://jira.mariadb.org/browse/MDEV-31817) #2865, which is included for the purpose of testing. The workload must use `ROW_FORMAT=COMPRESSED` tables, and we might want to use `CMAKE_BUILD_TYPE=RelWithDebInfo`.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.