### PR TITLE
mallinfo2: include malloc header even if mallinfo undetected

### DIFF
--- a/sql/sql_test.cc
+++ b/sql/sql_test.cc
@@ -27,10 +27,12 @@
 #include "my_json_writer.h"
 #include <hash.h>
 #include <thr_alarm.h>
-#if defined(HAVE_MALLINFO) && defined(HAVE_MALLOC_H)
+#if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
+#if defined(HAVE_MALLOC_H)
 #include <malloc.h>
-#elif defined(HAVE_MALLINFO) && defined(HAVE_SYS_MALLOC_H)
+#elif defined(HAVE_SYS_MALLOC_H)
 #include <sys/malloc.h>
+#endif
 #endif
 
 #ifdef HAVE_EVENT_SCHEDULER


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

It may be the case that for some reason, -Werror deprecated for instance, that mallinfo isn't detected. In this case the malloc.h headers won't be included which defines the mallinfo2 function and its structure.

Re-organise so that either function pulls in the header.

## How can this PR be tested?

remove from generated files

```
include/config.h:#define HAVE_MALLINFO 1
include/my_config.h:#define HAVE_MALLINFO 1
```

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
