### PR TITLE
main.subselect* often fails on CI with ER_SUBQUERY_NO_1_ROW

### DIFF
--- a/mysql-test/main/subselect.result
+++ b/mysql-test/main/subselect.result
@@ -7163,24 +7163,26 @@ drop table t1;
 #
 # MDEV-7565: Server crash with Signal 6 (part 2)
 #
-truncate table mysql.slow_log;
+create table t1 (id int not null primary key);
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
 From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
 Group By  TestCase.Revenue, TestCase.TemplateID;
 ControlRev
 NULL
+drop table t1;
 #
 # MDEV-7445:Server crash with Signal 6
 #
+create table t1 (id int not null primary key);
 CREATE PROCEDURE procedure2()
 BEGIN
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E           
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
   From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
@@ -7193,6 +7195,7 @@ call procedure2();
 ControlRev
 NULL
 drop procedure procedure2;
+drop table t1;
 #
 # MDEV-7846:Server crashes in Item_subselect::fix
 #_fields or fails with Thread stack overrun

--- a/mysql-test/main/subselect.test
+++ b/mysql-test/main/subselect.test
@@ -5995,25 +5995,27 @@ drop table t1;
 --echo # MDEV-7565: Server crash with Signal 6 (part 2)
 --echo #
 
-truncate table mysql.slow_log;
+create table t1 (id int not null primary key);
 Select 
-  (Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-    Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+  (Select Sum(`TestCase`.Revenue) From t1 E
+    Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
   ) As `ControlRev`
 From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
 Group By  TestCase.Revenue, TestCase.TemplateID;
+drop table t1;
 
 --echo #
 --echo # MDEV-7445:Server crash with Signal 6
 --echo #
 
+create table t1 (id int not null primary key);
 --delimiter |
 CREATE PROCEDURE procedure2()
 BEGIN
   Select 
-    (Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-      Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+    (Select Sum(`TestCase`.Revenue) From t1 E           
+      Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
      ) As `ControlRev`
   From 
   (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
@@ -6025,6 +6027,7 @@ call procedure2();
 call procedure2();
 
 drop procedure procedure2;
+drop table t1;
 
 
 --echo #

--- a/mysql-test/main/subselect_no_exists_to_in.result
+++ b/mysql-test/main/subselect_no_exists_to_in.result
@@ -7163,24 +7163,26 @@ drop table t1;
 #
 # MDEV-7565: Server crash with Signal 6 (part 2)
 #
-truncate table mysql.slow_log;
+create table t1 (id int not null primary key);
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
 From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
 Group By  TestCase.Revenue, TestCase.TemplateID;
 ControlRev
 NULL
+drop table t1;
 #
 # MDEV-7445:Server crash with Signal 6
 #
+create table t1 (id int not null primary key);
 CREATE PROCEDURE procedure2()
 BEGIN
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E           
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
   From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
@@ -7193,6 +7195,7 @@ call procedure2();
 ControlRev
 NULL
 drop procedure procedure2;
+drop table t1;
 #
 # MDEV-7846:Server crashes in Item_subselect::fix
 #_fields or fails with Thread stack overrun

--- a/mysql-test/main/subselect_no_mat.result
+++ b/mysql-test/main/subselect_no_mat.result
@@ -7156,24 +7156,26 @@ drop table t1;
 #
 # MDEV-7565: Server crash with Signal 6 (part 2)
 #
-truncate table mysql.slow_log;
+create table t1 (id int not null primary key);
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
 From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
 Group By  TestCase.Revenue, TestCase.TemplateID;
 ControlRev
 NULL
+drop table t1;
 #
 # MDEV-7445:Server crash with Signal 6
 #
+create table t1 (id int not null primary key);
 CREATE PROCEDURE procedure2()
 BEGIN
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E           
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
   From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
@@ -7186,6 +7188,7 @@ call procedure2();
 ControlRev
 NULL
 drop procedure procedure2;
+drop table t1;
 #
 # MDEV-7846:Server crashes in Item_subselect::fix
 #_fields or fails with Thread stack overrun

--- a/mysql-test/main/subselect_no_opts.result
+++ b/mysql-test/main/subselect_no_opts.result
@@ -7154,24 +7154,26 @@ drop table t1;
 #
 # MDEV-7565: Server crash with Signal 6 (part 2)
 #
-truncate table mysql.slow_log;
+create table t1 (id int not null primary key);
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
 From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
 Group By  TestCase.Revenue, TestCase.TemplateID;
 ControlRev
 NULL
+drop table t1;
 #
 # MDEV-7445:Server crash with Signal 6
 #
+create table t1 (id int not null primary key);
 CREATE PROCEDURE procedure2()
 BEGIN
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E           
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
   From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
@@ -7184,6 +7186,7 @@ call procedure2();
 ControlRev
 NULL
 drop procedure procedure2;
+drop table t1;
 #
 # MDEV-7846:Server crashes in Item_subselect::fix
 #_fields or fails with Thread stack overrun

--- a/mysql-test/main/subselect_no_scache.result
+++ b/mysql-test/main/subselect_no_scache.result
@@ -7169,24 +7169,26 @@ drop table t1;
 #
 # MDEV-7565: Server crash with Signal 6 (part 2)
 #
-truncate table mysql.slow_log;
+create table t1 (id int not null primary key);
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
 From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
 Group By  TestCase.Revenue, TestCase.TemplateID;
 ControlRev
 NULL
+drop table t1;
 #
 # MDEV-7445:Server crash with Signal 6
 #
+create table t1 (id int not null primary key);
 CREATE PROCEDURE procedure2()
 BEGIN
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E           
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
   From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
@@ -7199,6 +7201,7 @@ call procedure2();
 ControlRev
 NULL
 drop procedure procedure2;
+drop table t1;
 #
 # MDEV-7846:Server crashes in Item_subselect::fix
 #_fields or fails with Thread stack overrun

--- a/mysql-test/main/subselect_no_semijoin.result
+++ b/mysql-test/main/subselect_no_semijoin.result
@@ -7154,24 +7154,26 @@ drop table t1;
 #
 # MDEV-7565: Server crash with Signal 6 (part 2)
 #
-truncate table mysql.slow_log;
+create table t1 (id int not null primary key);
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
 From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
 Group By  TestCase.Revenue, TestCase.TemplateID;
 ControlRev
 NULL
+drop table t1;
 #
 # MDEV-7445:Server crash with Signal 6
 #
+create table t1 (id int not null primary key);
 CREATE PROCEDURE procedure2()
 BEGIN
 Select 
-(Select Sum(`TestCase`.Revenue) From mysql.slow_log E           
-Where TestCase.TemplateID not in (Select 1 from mysql.slow_log where 2=2)
+(Select Sum(`TestCase`.Revenue) From t1 E           
+Where TestCase.TemplateID not in (Select 1 from t1 where 2=2)
 ) As `ControlRev`
   From 
 (Select  3 as Revenue, 4 as TemplateID) As `TestCase` 
@@ -7184,6 +7186,7 @@ call procedure2();
 ControlRev
 NULL
 drop procedure procedure2;
+drop table t1;
 #
 # MDEV-7846:Server crashes in Item_subselect::fix
 #_fields or fails with Thread stack overrun


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Using mysql.slow_log was a test table would generate more than one row if there was more than one row in the table.

Some by implicitly enforcing an aggregation in the subquery.

## How can this PR be tested?

its a test.
If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
