### PR TITLE
MDEV-32936: Detect do ARM processor have NEON intrinsics or not

### DIFF
--- a/mysys/CMakeLists.txt
+++ b/mysys/CMakeLists.txt
@@ -89,6 +89,11 @@ ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
   IF(CMAKE_COMPILER_IS_GNUCC)
     include(CheckCXXSourceCompiles)
 
+    # Check if NEON intrinsics are available and does not
+    # print error 'NEON intrinsics not available with the soft-float ABI.
+    # Please use -mfloat-abi=softfp or -mfloat-abi=hard'
+    CHECK_INCLUDE_FILES(arm_neon.h HAVE_ARMV8_NEON)
+
     CHECK_CXX_SOURCE_COMPILES("
     #define CRC32CX(crc, value) __asm__(\"crc32cx %w[c], %w[c], %x[v]\":[c]\"+r\"(crc):[v]\"r\"(value))
     asm(\".arch_extension crc\");
@@ -135,9 +140,21 @@ ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
       IF(HAVE_ARMV8_CRYPTO)
         ADD_DEFINITIONS(-DHAVE_ARMV8_CRYPTO)
       ENDIF()
+      IF(NOT HAVE_ARMV8_NEON)
+        set(CMAKE_REQUIRED_FLAGS "-mfpu=neon -mfloat-abi=softfp")
+        CHECK_INCLUDE_FILES(arm_neon.h HAVE_ARMV8_NEON_SOFTFP)
+        set(CMAKE_REQUIRED_FLAGS "")
+      ENDIF()
       SET(MYSYS_SOURCES ${MYSYS_SOURCES} crc32/crc32_arm64.c)
+
+      IF(HAVE_ARMV8_NEON_SOFTFP)
+        SET(CRC32_ARM64_FLAGS "-mfpu=neon -mfloat-abi=softfp -march=armv8-a+crc+crypto")
+      ELSE()
+        SET(CRC32_ARM64_FLAGS "-march=armv8-a+crc+crypto")
+      ENDIF()
+
       SET_SOURCE_FILES_PROPERTIES(crc32/crc32_arm64.c PROPERTIES
-        COMPILE_FLAGS "-march=armv8-a+crc+crypto")
+        COMPILE_FLAGS ${CRC32_ARM64_FLAGS})
     ENDIF()
   ENDIF()
 ENDIF()


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32936*

## Description
This is mainly to have support for [Debian armel toolchain](https://wiki.debian.org/ArmEabiPort). This toolchain is for mainly for ARMv5/6 with no had float support. It does not have NEON support neither but it can be emulated with `-mfpu=neon -mfloat-abi=softfp'.

This PR overcomes problem:
```
/usr/lib/gcc/arm-linux-gnueabi/13/include/arm_neon.h:31:2: error: #error "NEON intrinsics not available with the soft-float ABI.  Please use -mfloat-abi=softfp or -mfloat-abi=hard"
```
by adding those flags that are needed to emulate NEON and hardware floating point. They are only applied to specific file which is compiled with emulation on. All the rest does not have new flags.

This PR is not needed if MariaDB is build as 32-bits version on ARM (which most of the CPU:s should be)

As I know this is little bit niche group of users whom wants to use MariaDB for example in Raspberry Pi 1 or Raspberry pi Zero (W) but having MariaDB client in those systems won't hurt anyone.

## How can this PR be tested?
PR is only tested with ARM Linux distros on ARM 64-bit machine (docker image is the same that is used in Salsa CI and has correct armel:

```
docker run -it --rm registry.salsa.debian.org/salsa-ci-team/pipeline/arm32v5/base:sid bash
apt update
apt install git-buildpackage
... fetch git repo and get correct branch ...
cd server
mk-build-deps -r -i debian/control -t "apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends"
mkdir build
cd build
cmake ..
cd mysys
make
```
Afterwards everything else could be build also but if one just wants to check if this is working then `mysys` dir is enough.


## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
