### PR TITLE
MDEV-31939 Adaptive flush recommendation ignores dirty ratio and checkpoint age

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2379,10 +2379,11 @@ static os_thread_ret_t DECLARE_THREAD(buf_flush_page_cleaner)(void*)
       else
       {
       maybe_unemployed:
-        const bool below{dirty_pct < pct_lwm};
-        pct_lwm= 0.0;
-        if (below)
+        if (dirty_pct < pct_lwm)
+        {
+          pct_lwm= 0.0;
           goto possibly_unemployed;
+        }
       }
     }
     else if (dirty_pct < srv_max_buf_pool_modified_pct)


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-31939*

## Description
`buf_flush_page_cleaner()`: Pass `pct_lwm=srv_max_dirty_pages_pct_lwm` (`innodb_max_dirty_pages_pct_lwm`) to
`page_cleaner_flush_pages_recommendation()` unless the dirty page ratio of the buffer pool is below that. Starting with
commit d4265fbde587bd79b6fe3793225d3f4798ee955e we used to always pass `pct_lwm=0.0`, which was not intended.

## How can this PR be tested?
I tested this with a Sysbench `oltp_update_index` workload and some diagnostic that would emit additional output once per second:
```diff
diff --git a/storage/innobase/buf/buf0flu.cc b/storage/innobase/buf/buf0flu.cc
index c0c743ede57..91b7b04819c 100644
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2433,6 +2433,10 @@ static os_thread_ret_t DECLARE_THREAD(buf_flush_page_cleaner)(void*)
       mysql_mutex_lock(&buf_pool.mutex);
       last_pages= n_flushed= buf_flush_list_holding_mutex(n);
       page_cleaner.flush_time+= ut_time_ms() - tm;
+      sql_print_information("InnoDB: flush %zu, %zu, %zu, %g, %zu/%zu",
+                            n, n_flushed, page_cleaner.flush_time, pct_lwm,
+                            buf_pool.flush_list.count,
+                            buf_pool.LRU.count);
       MONITOR_INC_VALUE_CUMULATIVE(MONITOR_FLUSH_ADAPTIVE_TOTAL_PAGE,
                                    MONITOR_FLUSH_ADAPTIVE_COUNT,
                                    MONITOR_FLUSH_ADAPTIVE_PAGES,
```
Without the fix, we would see smaller values of `n` and `n_flushed` as well as `pct_lwm=0.0`, even though I specified `innodb_max_dirty_pages_pct_lwm=10` when starting up the server.

It is not practical to write a regression test case for this.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.