### PR TITLE
MDEV-32919: Cannot select particular field from IS.tables in case table needs upgrade from MySQL 5.7

### DIFF
--- a/mysql-test/main/mysql_json_table_recreate.result
+++ b/mysql-test/main/mysql_json_table_recreate.result
@@ -239,3 +239,51 @@ ERROR HY000: 'MYSQL_JSON' is not allowed in this context
 #
 # End of 10.5 tests
 #
+# MDEV-32919: Cannot select particular field from IS.tables
+#             in case table needs upgrade from MySQL 5.7
+#
+explain select table_type from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	tables	ALL	NULL	NULL	NULL	NULL	NULL	Using where; Open_frm_only; Scanned all databases
+select table_type from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+table_type
+BASE TABLE
+Warnings:
+Warning	1707	Table rebuild required. Please do "ALTER TABLE `test.mysql_json_test` FORCE" or dump/reload to fix it!
+select table_comment from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+table_comment
+Table rebuild required. Please do "ALTER TABLE `test.mysql_json_test` FORCE" or dump/reload to fix it!
+Warnings:
+Warning	1707	Table rebuild required. Please do "ALTER TABLE `test.mysql_json_test` FORCE" or dump/reload to fix it!
+explain select * from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	tables	ALL	NULL	NULL	NULL	NULL	NULL	Using where; Open_full_table; Scanned all databases
+select * from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+TABLE_CATALOG	def
+TABLE_SCHEMA	test
+TABLE_NAME	mysql_json_test
+TABLE_TYPE	BASE TABLE
+ENGINE	NULL
+VERSION	NULL
+ROW_FORMAT	NULL
+TABLE_ROWS	NULL
+AVG_ROW_LENGTH	NULL
+DATA_LENGTH	NULL
+MAX_DATA_LENGTH	NULL
+INDEX_LENGTH	NULL
+DATA_FREE	NULL
+AUTO_INCREMENT	NULL
+CREATE_TIME	NULL
+UPDATE_TIME	NULL
+CHECK_TIME	NULL
+TABLE_COLLATION	NULL
+CHECKSUM	NULL
+CREATE_OPTIONS	NULL
+TABLE_COMMENT	Table rebuild required. Please do "ALTER TABLE `test.mysql_json_test` FORCE" or dump/reload to fix it!
+MAX_INDEX_LENGTH	NULL
+TEMPORARY	NULL
+Warnings:
+Level	Warning
+Code	1707
+Message	Table rebuild required. Please do "ALTER TABLE `test.mysql_json_test` FORCE" or dump/reload to fix it!
+drop table mysql_json_test;

--- a/mysql-test/main/mysql_json_table_recreate.test
+++ b/mysql-test/main/mysql_json_table_recreate.test
@@ -161,3 +161,20 @@ DELIMITER ;$$
 --echo #
 --echo # End of 10.5 tests
 --echo #
+--echo # MDEV-32919: Cannot select particular field from IS.tables
+--echo #             in case table needs upgrade from MySQL 5.7
+--echo #
+--source include/have_innodb.inc
+
+--copy_file std_data/mysql_json/mysql_json_test.frm $MYSQLD_DATADIR/test/mysql_json_test.frm
+--copy_file std_data/mysql_json/mysql_json_test.MYI $MYSQLD_DATADIR/test/mysql_json_test.MYI
+--copy_file std_data/mysql_json/mysql_json_test.MYD $MYSQLD_DATADIR/test/mysql_json_test.MYD
+explain select table_type from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+select table_type from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+select table_comment from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+
+explain select * from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+--vertical_results
+select * from information_schema.tables where table_comment LIKE 'Table rebuild required. Please do "ALTER TABLE %';
+--horizontal_results
+drop table mysql_json_test;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -5056,6 +5056,14 @@ static int fill_schema_table_from_frm(THD *thd, MEM_ROOT *mem_root,
     closefrm(&tbl);
   }
 
+  // Handle MYSQL_JSON data type with table that needs upgrade
+  if (share->incompatible_version & HA_CREATE_USED_ENGINE)
+  {
+    table_list.table= &tbl;
+    res= schema_table->process_table(thd, &table_list, table,
+                                     TRUE, db_name, table_name);
+  }
+
 
 end_share:
   tdc_release_share(share);


### PR DESCRIPTION
- When selecting * fields from IS.tables, open method using full table scan is called `fill_schema_table_by_open()`.
- When select specific field from IS.tables, open method from frm is used `fill_schema_table_from_frm()`.
- Call `get_schema_tables_record` for `MYSQL_JSON` data type in case plugin is installed and table needs upgrade.

## Basing the PR against the correct MariaDB version
- [] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
