### PR TITLE
Update Amazon S3 test for URL endpoints

### DIFF
--- a/mysql-test/suite/s3/amazon.test
+++ b/mysql-test/suite/s3/amazon.test
@@ -1,6 +1,6 @@
 --source include/have_s3.inc
 
-if (`SELECT @@s3_host_name <> "s3.amazonaws.com"`)
+if (`SELECT @@s3_host_name NOT LIKE "%.amazonaws.com"`)
 {
   skip Not connected to AWS;
 }


### PR DESCRIPTION
If you are using a region other than us-east-1, the region needs to be part of the domain when accessing S3. This pathc updates the Amazon test so that any Amazon S3 domain is detected as connecting to Amazon S3.

## How can this PR be tested?

This can be tested by running the Aria S3 engine against Amazon using the region as part of the domain. For example `s3-us-east-2.amazonaws.com` or `s3.us-east-2.amazonaws.com`.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
