### PR TITLE
MDEV-32920  innodb_buffer_pool_read_requests always 0

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_force_recovery.result
+++ b/mysql-test/suite/innodb/r/innodb_force_recovery.result
@@ -4,9 +4,18 @@ insert into t1 values(1, 2);
 insert into t2 values(1, 2);
 SET GLOBAL innodb_fast_shutdown = 0;
 # restart: --innodb-force-recovery=4
+SELECT CAST(variable_value AS INTEGER) INTO @read1
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='innodb_buffer_pool_read_requests';
 select * from t1;
 f1	f2
 1	2
+SELECT CAST(variable_value AS INTEGER) INTO @read2
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='innodb_buffer_pool_read_requests';
+SELECT @read1>0, @read2>@read1;
+@read1>0	@read2>@read1
+1	1
 begin;
 insert into t1 values(2, 3);
 rollback;

--- a/mysql-test/suite/innodb/t/innodb_force_recovery.test
+++ b/mysql-test/suite/innodb/t/innodb_force_recovery.test
@@ -21,7 +21,17 @@ SET GLOBAL innodb_fast_shutdown = 0;
 --source include/restart_mysqld.inc
 let $status=`SHOW ENGINE INNODB STATUS`;
 
+SELECT CAST(variable_value AS INTEGER) INTO @read1
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='innodb_buffer_pool_read_requests';
+
 select * from t1;
+
+SELECT CAST(variable_value AS INTEGER) INTO @read2
+FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='innodb_buffer_pool_read_requests';
+
+SELECT @read1>0, @read2>@read1;
 
 begin;
 insert into t1 values(2, 3);

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -901,6 +901,9 @@ srv_export_innodb_status(void)
 	export_vars.innodb_data_written = srv_stats.data_written
 		+ (dblwr << srv_page_size_shift);
 
+	export_vars.innodb_buffer_pool_read_requests
+		= buf_pool.stat.n_page_gets;
+
 	export_vars.innodb_buffer_pool_bytes_data =
 		buf_pool.stat.LRU_bytes
 		+ (UT_LIST_GET_LEN(buf_pool.unzip_LRU)


### PR DESCRIPTION


<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32920*

## Description

srv_export_innodb_status(): Update
export_vars.innodb_buffer_pool_read_requests
with buf_pool.stat.n_page_gets.

## How can this PR be tested?
Attached the innodb.buf_pool_read_requests in innodb suite.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
