### PR TITLE
MDEV-28619 Server crash in Window_funcs_sort::setup

### DIFF
--- a/mysql-test/main/win.result
+++ b/mysql-test/main/win.result
@@ -4390,3 +4390,23 @@ row_number() OVER (order by a)
 2
 3
 drop table t1;
+#
+# MDEV-28619: Server crash in Window_funcs_sort::setup
+#
+SELECT 1 IN (SELECT 1 a UNION SELECT 5 ORDER BY LAST_VALUE (a) OVER XXX);
+ERROR HY000: Window specification with name 'XXX' is not defined
+SELECT 1 IN (SELECT 2 AS two UNION (SELECT 5 AS five) ORDER BY LAST_VALUE (0) OVER x);
+ERROR HY000: Window specification with name 'x' is not defined
+WITH col AS (SELECT 1 AS t1)
+SELECT t1 IN (
+SELECT t1 FROM col UNION SELECT 50 FROM col ORDER BY LAST_VALUE (1) OVER x DESC
+) FROM col;
+ERROR HY000: Window specification with name 'x' is not defined
+use test;
+CREATE TABLE t1 ( col FLOAT NOT NULL ) ;
+INSERT INTO t1 ( col ) VALUES ( 52 ) ;
+SELECT col IN (
+SELECT col FROM t1 UNION (SELECT 0) ORDER BY LAST_VALUE (0) OVER x DESC
+) FROM t1;
+ERROR HY000: Window specification with name 'x' is not defined
+DROP TABLE t1;

--- a/mysql-test/main/win.test
+++ b/mysql-test/main/win.test
@@ -2874,3 +2874,26 @@ create table t1 (a int);
 insert into t1 values (1),(2),(3);
 SELECT  row_number() OVER (order by a) FROM t1  order by NAME_CONST('myname',NULL);
 drop table t1;
+
+--echo #
+--echo # MDEV-28619: Server crash in Window_funcs_sort::setup
+--echo #
+
+--error ER_WRONG_WINDOW_SPEC_NAME
+SELECT 1 IN (SELECT 1 a UNION SELECT 5 ORDER BY LAST_VALUE (a) OVER XXX);
+--error ER_WRONG_WINDOW_SPEC_NAME
+SELECT 1 IN (SELECT 2 AS two UNION (SELECT 5 AS five) ORDER BY LAST_VALUE (0) OVER x);
+--error ER_WRONG_WINDOW_SPEC_NAME
+WITH col AS (SELECT 1 AS t1)
+SELECT t1 IN (
+  SELECT t1 FROM col UNION SELECT 50 FROM col ORDER BY LAST_VALUE (1) OVER x DESC
+) FROM col;
+
+use test;
+CREATE TABLE t1 ( col FLOAT NOT NULL ) ;
+INSERT INTO t1 ( col ) VALUES ( 52 ) ;
+--error ER_WRONG_WINDOW_SPEC_NAME
+SELECT col IN (
+  SELECT col FROM t1 UNION (SELECT 0) ORDER BY LAST_VALUE (0) OVER x DESC
+) FROM t1;
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/r/tempfiles_encrypted.result
+++ b/mysql-test/suite/encryption/r/tempfiles_encrypted.result
@@ -4397,6 +4397,26 @@ row_number() OVER (order by a)
 3
 drop table t1;
 #
+# MDEV-28619: Server crash in Window_funcs_sort::setup
+#
+SELECT 1 IN (SELECT 1 a UNION SELECT 5 ORDER BY LAST_VALUE (a) OVER XXX);
+ERROR HY000: Window specification with name 'XXX' is not defined
+SELECT 1 IN (SELECT 2 AS two UNION (SELECT 5 AS five) ORDER BY LAST_VALUE (0) OVER x);
+ERROR HY000: Window specification with name 'x' is not defined
+WITH col AS (SELECT 1 AS t1)
+SELECT t1 IN (
+SELECT t1 FROM col UNION SELECT 50 FROM col ORDER BY LAST_VALUE (1) OVER x DESC
+) FROM col;
+ERROR HY000: Window specification with name 'x' is not defined
+use test;
+CREATE TABLE t1 ( col FLOAT NOT NULL ) ;
+INSERT INTO t1 ( col ) VALUES ( 52 ) ;
+SELECT col IN (
+SELECT col FROM t1 UNION (SELECT 0) ORDER BY LAST_VALUE (0) OVER x DESC
+) FROM t1;
+ERROR HY000: Window specification with name 'x' is not defined
+DROP TABLE t1;
+#
 # MDEV-23867: select crash in compute_window_func
 #
 set @save_sort_buffer_size=@@sort_buffer_size;

--- a/sql/sql_window.cc
+++ b/sql/sql_window.cc
@@ -336,7 +336,8 @@ setup_windows(THD *thd, Ref_ptr_array ref_pointer_array, TABLE_LIST *tables,
   List_iterator_fast<Item_window_func> li(win_funcs);
   while (Item_window_func * win_func_item= li++)
   {
-    if (win_func_item->check_result_type_of_order_item())
+    if (win_func_item->resolve_window_name(thd) ||
+        win_func_item->check_result_type_of_order_item())
       DBUG_RETURN(1);
   }
   DBUG_RETURN(0);


### PR DESCRIPTION
Fixes a crash where a query referencing an undefined WINDOW is nested within the IN clause of another query.  Such queries may have the form:
  SELECT ... IN (SELECT ... UNION SELECT ... ORDER BY LAST_VALUE (...) OVER w);
Further examples are in the tests associated with this commit.  The error seen now with this fix is consistent with MySQL 8.2 though not identically worded; MariaDB renders the error as "Window specification with name 'X' is not defined" while MySQL 8.2 renders it as "Window name 'x' is not defined").

Item_window_func::resolve_window_name is idempotent with respect to resolving a window name to a window specification: if the name has been resolved to the specification, then it does not attempt to re-resolve; otherwise, it attempts to resolve the name and if it doesn't resolve it, then it will return a failure.

setup_windows now leverages resolve_window_name to ensure that a window function has a corresponding window spec.  Typically that check would've been completed before this point in execution by setup_order (which eventually invokes fix_fields), but in this case we have an instance of Item_in_subselect which relies on running the nested query back through the execution engine. That nested executor doesn't reparse the query and instead expects that all references have been resolved.
