### PR TITLE
MDEV-32738: Don't roll back high-prio txn waiting on a lock in InnoDB

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-32738.result
+++ b/mysql-test/suite/galera/r/MDEV-32738.result
@@ -1,0 +1,32 @@
+connection node_2;
+connection node_1;
+connect con1_1,127.0.0.1,root,,test,$NODE_MYPORT_1;
+connect con1_2,127.0.0.1,root,,test,$NODE_MYPORT_1;
+CREATE TABLE t1(c1 INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t1_fk(c1 INT PRIMARY KEY, c2 INT, INDEX (c2), FOREIGN KEY (c2) REFERENCES t1(c1)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+connection con1_1;
+SET DEBUG_SYNC = 'ib_after_row_insert WAIT_FOR bf_abort';
+INSERT INTO t1_fk VALUES (1, 1);
+connection con1_2;
+SET DEBUG_SYNC = 'ha_write_row_start SIGNAL may_alter WAIT_FOR may_insert';
+INSERT INTO t1_fk VALUES (2, 2);
+connection node_1;
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+SET DEBUG_SYNC = 'after_lock_table_for_trx SIGNAL may_insert WAIT_FOR alter_continue';
+ALTER TABLE t1 ADD COLUMN c2 INT;
+connection con1_1;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection con1_2;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET DEBUG_SYNC = 'now SIGNAL alter_continue';
+connection node_1;
+connection node_2;
+INSERT INTO t1 (c1, c2) VALUES (2, 2);
+connection node_1;
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1_fk, t1;
+disconnect con1_1;
+disconnect con1_2;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/MDEV-32738.cnf
+++ b/mysql-test/suite/galera/t/MDEV-32738.cnf
@@ -1,0 +1,5 @@
+!include ../galera_2nodes.cnf
+
+# Disable retry for autocommit statements.
+[mysqld]
+wsrep-retry-autocommit=0

--- a/mysql-test/suite/galera/t/MDEV-32738.test
+++ b/mysql-test/suite/galera/t/MDEV-32738.test
@@ -1,0 +1,74 @@
+#
+# MDEV-32738: Don't roll back high-priority transaction waiting on a lock in InnoDB.
+#
+# DML transactions on FK-child tables also get table locks on FK-parent tables.
+# If there is a DML transaction holding such a lock, and a TOI transaction starts,
+# the latter BF-aborts the former and puts itself into a waiting state.
+# If at this moment another DML transaction on FK-child table starts, it doesn't
+# check that the transaction waiting on a parent table lock is TOI, and it
+# erroneously BF-aborts the waiting TOI transaction.
+#
+# The fix: check that the waiting transaction is TOI and in this case roll back
+# the incoming DML transaction in InnoDB.
+#
+# The test runs with autocommit statement retry disabled.
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+
+--connect con1_1,127.0.0.1,root,,test,$NODE_MYPORT_1
+--connect con1_2,127.0.0.1,root,,test,$NODE_MYPORT_1
+
+CREATE TABLE t1(c1 INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t1_fk(c1 INT PRIMARY KEY, c2 INT, INDEX (c2), FOREIGN KEY (c2) REFERENCES t1(c1)) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES (1);
+
+--connection con1_1
+SET DEBUG_SYNC = 'ib_after_row_insert WAIT_FOR bf_abort';
+# INSERT also grabs FK-referenced table lock.
+--send
+  INSERT INTO t1_fk VALUES (1, 1);
+
+--connection con1_2
+SET DEBUG_SYNC = 'ha_write_row_start SIGNAL may_alter WAIT_FOR may_insert';
+# Stop before doing anything, but pass wsrep_sync_wait().
+# This should be done before ALTER enters TOI.
+--send
+  INSERT INTO t1_fk VALUES (2, 2);
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR may_alter';
+SET DEBUG_SYNC = 'after_lock_table_for_trx SIGNAL may_insert WAIT_FOR alter_continue';
+# ALTER BF-aborts the first INSERT and lets the second INSERT continue.
+--send
+  ALTER TABLE t1 ADD COLUMN c2 INT;
+
+--connection con1_1
+# First INSERT gets BF-aborted.
+--error ER_LOCK_DEADLOCK
+--reap
+
+--connection con1_2
+# Second INSERT rolls back as ALTER is waiting on the lock.
+--error ER_LOCK_DEADLOCK
+--reap
+SET DEBUG_SYNC = 'now SIGNAL alter_continue';
+
+--connection node_1
+# ALTER succeeds.
+--reap
+
+--connection node_2
+# Sanity check that ALTER has been replicated.
+INSERT INTO t1 (c1, c2) VALUES (2, 2);
+
+# Cleanup.
+--connection node_1
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1_fk, t1;
+--disconnect con1_1
+--disconnect con1_2
+--source include/galera_end.inc


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32738*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
DML transactions on FK-child tables also get table locks on FK-parent tables.
If there is a DML transaction holding such a lock, and a TOI transaction starts, the latter BF-aborts the former and puts itself into a waiting state.
If at this moment another DML transaction on FK-child table starts, it doesn't check that the transaction waiting on a parent table lock is TOI, and it erroneously BF-aborts the waiting TOI transaction.

The fix: don't roll back high-priority transaction waiting on a lock in InnoDB, instead roll back an incoming DML transaction.

## How can this PR be tested?

MTR test is provided.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
