### PR TITLE
MDEV-32964: Expect DB_INTERRUPTED from wsrep_row_upd_check_foreign_constraints

### DIFF
--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -2486,18 +2486,18 @@ row_upd_sec_index_entry(
 				case DB_NO_REFERENCED_ROW:
 					err = DB_SUCCESS;
 					break;
-				case DB_LOCK_WAIT:
+				case DB_INTERRUPTED:
 				case DB_DEADLOCK:
 				case DB_LOCK_WAIT_TIMEOUT:
 					WSREP_DEBUG("Foreign key check fail: "
 						"%s on table %s index %s query %s",
-						ut_strerr(err), index->name(), index->table->name.m_name,
+						ut_strerr(err), index->table->name.m_name, index->name(),
 						wsrep_thd_query(trx->mysql_thd));
 					break;
 				default:
 					WSREP_ERROR("Foreign key check fail: "
 						"%s on table %s index %s query %s",
-						ut_strerr(err), index->name(), index->table->name.m_name,
+						ut_strerr(err), index->table->name.m_name, index->name(),
 						wsrep_thd_query(trx->mysql_thd));
 					break;
 				}
@@ -2506,7 +2506,7 @@ row_upd_sec_index_entry(
 		}
 
 #ifdef WITH_WSREP
-		ut_ad(err == DB_SUCCESS || err == DB_LOCK_WAIT
+		ut_ad(err == DB_SUCCESS || err == DB_INTERRUPTED
 		      || err == DB_DEADLOCK || err == DB_LOCK_WAIT_TIMEOUT);
 #else
 		ut_ad(err == DB_SUCCESS);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32964*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
DB_INTERRUPTED should be a valid return code expected from wsrep_row_upd_check_foreign_constraints call.

## How can this PR be tested?

Manually tested with pstress to ensure the issue doesn't reproduce anymore.
No MTR is provided as it's pretty hard to build such a combination of load that would make the issue surface with the given return code.
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
