### PR TITLE
MDEV-32973: SHOW TABLES LIKE shows temporary tables with non-matching names

### DIFF
--- a/mysql-test/main/information_schema_temp_table.result
+++ b/mysql-test/main/information_schema_temp_table.result
@@ -319,3 +319,56 @@ seq3	TEMPORARY SEQUENCE
 drop table seq3;
 show  full tables;
 Tables_in_test	Table_type
+#
+# MDEV-32973: SHOW TABLES LIKE shows temporary tables with
+#             non-matching names
+#
+CREATE DATABASE db;
+USE db;
+CREATE TABLE realtable (a INT);
+CREATE TEMPORARY TABLE temptable (a INT);
+SHOW TABLES LIKE 'faketable';
+Tables_in_db (faketable)
+SHOW TABLES LIKE 'temptable';
+Tables_in_db (temptable)
+temptable
+SHOW TABLES LIKE '%pt%';
+Tables_in_db (%pt%)
+temptable
+SHOW TABLES LIKE '%lt%';
+Tables_in_db (%lt%)
+realtable
+select table_name from information_schema.tables where
+table_schema='db' and table_name='temptable';
+table_name
+temptable
+select table_name from information_schema.tables where
+table_schema='db' and table_name='faketable';
+table_name
+drop database db;
+create database `t\_p`;
+create temporary table `t\_p`.tmp (a int);
+select table_schema, table_name from information_schema.tables where table_schema='t\\_p';
+table_schema	table_name
+t\_p	tmp
+drop database `t\_p`;
+create database db;
+use db;
+create temporary table `t\_p` (a int);
+select table_schema, table_name from information_schema.tables where table_schema='db' and table_name='t\\_p';
+table_schema	table_name
+db	t\_p
+select table_schema, table_name from information_schema.tables where table_name='t\\_p';
+table_schema	table_name
+db	t\_p
+drop table `t\_p`;
+CREATE TEMPORARY TABLE t2 (a INT);
+select table_name from information_schema.tables where
+table_schema='db' and table_name='T2';
+table_name
+SHOW TABLES LIKE 'T%';
+Tables_in_db (T%)
+drop database db;
+#
+# End of 11.2 tests
+#

--- a/mysql-test/main/information_schema_temp_table.test
+++ b/mysql-test/main/information_schema_temp_table.test
@@ -278,3 +278,45 @@ drop table seq2;
 show  full tables;
 drop table seq3;
 show  full tables;
+
+--echo #
+--echo # MDEV-32973: SHOW TABLES LIKE shows temporary tables with
+--echo #             non-matching names
+--echo #
+
+CREATE DATABASE db;
+USE db;
+CREATE TABLE realtable (a INT);
+CREATE TEMPORARY TABLE temptable (a INT);
+SHOW TABLES LIKE 'faketable';
+SHOW TABLES LIKE 'temptable';
+SHOW TABLES LIKE '%pt%';
+SHOW TABLES LIKE '%lt%';
+select table_name from information_schema.tables where
+  table_schema='db' and table_name='temptable';
+select table_name from information_schema.tables where
+  table_schema='db' and table_name='faketable';
+drop database db;
+
+create database `t\_p`;
+create temporary table `t\_p`.tmp (a int);
+select table_schema, table_name from information_schema.tables where table_schema='t\\_p';
+drop database `t\_p`;
+
+create database db;
+use db;
+create temporary table `t\_p` (a int);
+select table_schema, table_name from information_schema.tables where table_schema='db' and table_name='t\\_p';
+select table_schema, table_name from information_schema.tables where table_name='t\\_p';
+drop table `t\_p`;
+
+-- source include/not_windows.inc
+CREATE TEMPORARY TABLE t2 (a INT);
+select table_name from information_schema.tables where
+  table_schema='db' and table_name='T2';
+SHOW TABLES LIKE 'T%';
+drop database db;
+
+--echo #
+--echo # End of 11.2 tests
+--echo #

--- a/mysql-test/main/information_schema_temp_table_lowercase.opt
+++ b/mysql-test/main/information_schema_temp_table_lowercase.opt
@@ -1,0 +1,1 @@
+--lower-case-table-names=1

--- a/mysql-test/main/information_schema_temp_table_lowercase.result
+++ b/mysql-test/main/information_schema_temp_table_lowercase.result
@@ -1,0 +1,34 @@
+#
+# MDEV-32973: SHOW TABLES LIKE shows temporary tables with
+#             non-matching names
+#
+create temporary table t1 (a int);
+select table_name from information_schema.tables where
+table_schema='test' and table_name='T1';
+table_name
+t1
+SHOW TABLES LIKE 'T%';
+Tables_in_test (T%)
+t1
+create database db;
+use db;
+create temporary table `t\_p` (a int);
+select table_schema, table_name from information_schema.tables where table_schema='db' and table_name='t\\_p';
+table_schema	table_name
+db	t\_p
+select table_schema, table_name from information_schema.tables where table_name='t\\_p';
+table_schema	table_name
+db	t\_p
+select table_schema, table_name from information_schema.tables where table_schema='db' and table_name='T\\_p';
+table_schema	table_name
+db	t\_p
+drop database db;
+create database `t\_p`;
+create temporary table `t\_p`.tmp (a int);
+select table_schema, table_name from information_schema.tables where table_schema='T\\_P';
+table_schema	table_name
+t\_p	tmp
+drop database `t\_p`;
+#
+# End of 11.2 tests
+#

--- a/mysql-test/main/information_schema_temp_table_lowercase.test
+++ b/mysql-test/main/information_schema_temp_table_lowercase.test
@@ -1,0 +1,27 @@
+--echo #
+--echo # MDEV-32973: SHOW TABLES LIKE shows temporary tables with
+--echo #             non-matching names
+--echo #
+
+# Compare table names in a case-insensitive manner
+create temporary table t1 (a int);
+select table_name from information_schema.tables where
+  table_schema='test' and table_name='T1';
+SHOW TABLES LIKE 'T%';
+
+create database db;
+use db;
+create temporary table `t\_p` (a int);
+select table_schema, table_name from information_schema.tables where table_schema='db' and table_name='t\\_p';
+select table_schema, table_name from information_schema.tables where table_name='t\\_p';
+select table_schema, table_name from information_schema.tables where table_schema='db' and table_name='T\\_p';
+drop database db;
+
+create database `t\_p`;
+create temporary table `t\_p`.tmp (a int);
+select table_schema, table_name from information_schema.tables where table_schema='T\\_P';
+drop database `t\_p`;
+
+--echo #
+--echo # End of 11.2 tests
+--echo #

--- a/mysql-test/suite/rpl/r/rpl_ddl.result
+++ b/mysql-test/suite/rpl/r/rpl_ddl.result
@@ -343,7 +343,6 @@ TEST-INFO: SLAVE:  The INSERT is committed (Succeeded)
 connection master;
 SHOW TABLES LIKE 't2';
 Tables_in_mysqltest1 (t2)
-t23
 connection slave;
 SHOW TABLES LIKE 't2';
 Tables_in_mysqltest1 (t2)


### PR DESCRIPTION
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
