### PR TITLE
MDEV-31000 Assertion failed on ALTER TABLE...page_compressed=1

### DIFF
--- a/mysql-test/suite/innodb/r/alter_table.result
+++ b/mysql-test/suite/innodb/r/alter_table.result
@@ -117,5 +117,16 @@ ERROR 42000: Incorrect column specifier for column 'c'
 CREATE TABLE t1 (c DATETIME AUTO_INCREMENT UNIQUE) ENGINE=InnoDB;
 ERROR 42000: Incorrect column specifier for column 'c'
 #
-# End of 10.4 tests
+# MDEV-31000 Assertion failed on ALTER TABLE...page_compressed=1
 #
+SET @save_file_per_table=@@GLOBAL.innodb_file_per_table;
+SET GLOBAL innodb_file_per_table=0;
+CREATE TABLE t (c INT PRIMARY KEY) ENGINE=INNODB;
+SET GLOBAL innodb_file_per_table=1;
+ALTER TABLE t page_compressed=1;
+SET GLOBAL innodb_file_per_table=@save_file_per_table;
+SELECT space>0 FROM information_schema.innodb_sys_tables WHERE name='test/t';
+space>0
+1
+DROP TABLE t;
+# End of 10.4 tests

--- a/mysql-test/suite/innodb/t/alter_table.test
+++ b/mysql-test/suite/innodb/t/alter_table.test
@@ -121,6 +121,16 @@ CREATE TABLE t1 (c TIMESTAMP AUTO_INCREMENT UNIQUE) ENGINE=InnoDB;
 CREATE TABLE t1 (c DATETIME AUTO_INCREMENT UNIQUE) ENGINE=InnoDB;
 
 --echo #
---echo # End of 10.4 tests
+--echo # MDEV-31000 Assertion failed on ALTER TABLE...page_compressed=1
 --echo #
 
+SET @save_file_per_table=@@GLOBAL.innodb_file_per_table;
+SET GLOBAL innodb_file_per_table=0;
+CREATE TABLE t (c INT PRIMARY KEY) ENGINE=INNODB;
+SET GLOBAL innodb_file_per_table=1;
+ALTER TABLE t page_compressed=1;
+SET GLOBAL innodb_file_per_table=@save_file_per_table;
+SELECT space>0 FROM information_schema.innodb_sys_tables WHERE name='test/t';
+DROP TABLE t;
+
+--echo # End of 10.4 tests


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-31000*
## Description
`ha_innobase::check_if_supported_inplace_alter()`: On `ALTER_OPTIONS`, if `innodb_file_per_table=1` and the table resides in the system tablespace, require that the table be rebuilt (and moved to an `.ibd` file).
## How can this PR be tested?
The regression test suite was extended with a test case.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.