### PR TITLE
MDEV-18322 Assertion "wrong page type" on instant ALTER TABLE

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_bugs.result
+++ b/mysql-test/suite/innodb/r/instant_alter_bugs.result
@@ -495,4 +495,28 @@ SET GLOBAL innodb_purge_rseg_truncate_frequency=@save_frequency;
 CREATE TABLE t1 (i int AS (0) STORED, j INT) ENGINE=InnoDB;
 ALTER TABLE t1 ADD COLUMN i INT GENERATED ALWAYS AS (1), DROP COLUMN i;
 DROP TABLE t1;
+#
+# MDEV-18322 Assertion "wrong_page_type" on instant ALTER
+#
+BEGIN NOT ATOMIC
+DECLARE c TEXT
+DEFAULT(SELECT CONCAT('CREATE TABLE t1 (c',
+GROUP_CONCAT(seq SEPARATOR ' CHAR(200), c'),
+' CHAR(211)) ENGINE=InnoDB ROW_FORMAT=REDUNDANT')
+FROM seq_1_to_40);
+EXECUTE IMMEDIATE c;
+END;
+$$
+INSERT INTO t1 SET c1=NULL;
+ALTER TABLE t1 ADD c41 INT FIRST;
+ERROR 42000: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 8123. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
+ALTER TABLE t1 ADD c41 INT FIRST;
+ERROR 42000: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 8123. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
+DROP TABLE t1;
 # End of 10.4 tests

--- a/mysql-test/suite/innodb/t/instant_alter_bugs.test
+++ b/mysql-test/suite/innodb/t/instant_alter_bugs.test
@@ -1,4 +1,5 @@
 --source include/have_innodb.inc
+--source include/have_sequence.inc
 
 SET @save_frequency= @@GLOBAL.innodb_purge_rseg_truncate_frequency;
 SET GLOBAL innodb_purge_rseg_truncate_frequency=1;
@@ -524,6 +525,30 @@ SET GLOBAL innodb_purge_rseg_truncate_frequency=@save_frequency;
 --echo #
 CREATE TABLE t1 (i int AS (0) STORED, j INT) ENGINE=InnoDB;
 ALTER TABLE t1 ADD COLUMN i INT GENERATED ALWAYS AS (1), DROP COLUMN i;
+DROP TABLE t1;
+
+--echo #
+--echo # MDEV-18322 Assertion "wrong_page_type" on instant ALTER
+--echo #
+
+DELIMITER $$;
+BEGIN NOT ATOMIC
+  DECLARE c TEXT
+  DEFAULT(SELECT CONCAT('CREATE TABLE t1 (c',
+                        GROUP_CONCAT(seq SEPARATOR ' CHAR(200), c'),
+                        ' CHAR(211)) ENGINE=InnoDB ROW_FORMAT=REDUNDANT')
+          FROM seq_1_to_40);
+  EXECUTE IMMEDIATE c;
+END;
+$$
+DELIMITER ;$$
+INSERT INTO t1 SET c1=NULL;
+--error ER_TOO_BIG_ROWSIZE
+ALTER TABLE t1 ADD c41 INT FIRST;
+--error ER_TOO_BIG_ROWSIZE
+ALTER TABLE t1 ADD c41 INT FIRST;
+CHECK TABLE t1;
+SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
 
 --echo # End of 10.4 tests

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -6130,10 +6130,6 @@ empty_table:
 			goto err_exit;
 		}
 
-		btr_set_instant(root, *index, &mtr);
-		mtr.commit();
-		mtr.start();
-		index->set_modified(mtr);
 		err = row_ins_clust_index_entry_low(
 			BTR_NO_LOCKING_FLAG, BTR_MODIFY_TREE, index,
 			index->n_uniq, entry, 0, thr);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-18322*

## Description
`innobase_instant_try()`: Invoke `btr_set_instant()` in the same mini-transaction that has successfully inserted the metadata record. In this way, if inserting the metadata record fails before any undo log record was written for it, the index root page will remain consistent.
## How can this PR be tested?
The regression test was extended with a test case for reproducing this bug.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.