### PR TITLE
MDEV-32968  InnoDB fails to restore tablespace first page from doublewrite buffer when page is empty

### DIFF
--- a/mysql-test/suite/innodb/r/doublewrite.result
+++ b/mysql-test/suite/innodb/r/doublewrite.result
@@ -1,7 +1,7 @@
 #
 # MDEV-32242 innodb.doublewrite test case always is skipped
 #
-create table t1 (f1 int primary key, f2 blob) engine=innodb;
+create table t1 (f1 int primary key, f2 blob) stats_persistent=0, engine=innodb;
 start transaction;
 insert into t1 values(1, repeat('#',12));
 insert into t1 values(2, repeat('+',12));
@@ -19,9 +19,32 @@ XA PREPARE 'x';
 disconnect dml;
 connection default;
 flush table t1 for export;
+# Kill the server
 # restart
 FOUND 1 /InnoDB: Restoring page \[page id: space=[1-9][0-9]*, page number=0\] of datafile/ in mysqld.1.err
 FOUND 1 /InnoDB: Recovered page \[page id: space=[1-9][0-9]*, page number=3\]/ in mysqld.1.err
+XA ROLLBACK 'x';
+check table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+select f1, f2 from t1;
+f1	f2
+1	############
+2	++++++++++++
+3	////////////
+4	------------
+5	............
+connect  dml,localhost,root,,;
+XA START 'x';
+insert into t1 values (6, repeat('%', @@innodb_page_size/2));
+XA END 'x';
+XA PREPARE 'x';
+disconnect dml;
+connection default;
+flush table t1 for export;
+# Kill the server
+# restart
+FOUND 2 /InnoDB: Restoring page \[page id: space=[1-9][0-9]*, page number=0\] of datafile/ in mysqld.1.err
 XA ROLLBACK 'x';
 check table t1;
 Table	Op	Msg_type	Msg_text

--- a/mysql-test/suite/innodb/r/log_file_name.result
+++ b/mysql-test/suite/innodb/r/log_file_name.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("InnoDB: Header page consists of zero bytes in datafile:");
 SET GLOBAL innodb_file_per_table=ON;
 FLUSH TABLES;
 CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
@@ -89,7 +90,7 @@ SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 ENGINE	SUPPORT	COMMENT	TRANSACTIONS	XA	SAVEPOINTS
-FOUND 1 /\[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
+FOUND 1 /\[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
 FOUND 1 /\[ERROR\] InnoDB: Datafile .*u1.*\. Cannot determine the space ID from the first 64 pages/ in mysqld.1.err
 NOT FOUND /\[Note\] InnoDB: Cannot read first page of .*u2.ibd/ in mysqld.1.err
 # Fault 7: Missing or wrong data file and innodb_force_recovery
@@ -98,11 +99,11 @@ SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 ENGINE	SUPPORT	COMMENT	TRANSACTIONS	XA	SAVEPOINTS
-FOUND 1 /\[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
+FOUND 1 /\[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
 FOUND 1 /InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace/ in mysqld.1.err
 FOUND 1 /\[ERROR\] InnoDB: Cannot replay rename of tablespace \d+ from '.*u4.ibd' to '.*u6.ibd' because the target file exists/ in mysqld.1.err
 # restart: --innodb-force-recovery=1
-FOUND 1 /\[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
+FOUND 1 /\[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
 FOUND 1 /InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace/ in mysqld.1.err
 FOUND 1 /\[Warning\] InnoDB: Tablespace \d+ was not found at .*u[1-5].ibd, and innodb_force_recovery was set. All redo log for this tablespace will be ignored!/ in mysqld.1.err
 # restart

--- a/mysql-test/suite/innodb/t/doublewrite.test
+++ b/mysql-test/suite/innodb/t/doublewrite.test
@@ -17,6 +17,7 @@ call mtr.add_suppression("InnoDB: A bad Space ID was found in datafile");
 call mtr.add_suppression("InnoDB: Checksum mismatch in datafile: ");
 call mtr.add_suppression("InnoDB: Inconsistent tablespace ID in .*t1\\.ibd");
 call mtr.add_suppression("\\[Warning\\] Found 1 prepared XA transactions");
+call mtr.add_suppression("InnoDB: Header page consists of zero bytes in datafile:");
 --enable_query_log
 
 let INNODB_PAGE_SIZE=`select @@innodb_page_size`;
@@ -24,7 +25,7 @@ let MYSQLD_DATADIR=`select @@datadir`;
 let ALGO=`select @@innodb_checksum_algorithm`;
 let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
 
-create table t1 (f1 int primary key, f2 blob) engine=innodb;
+create table t1 (f1 int primary key, f2 blob) stats_persistent=0, engine=innodb;
 
 start transaction;
 insert into t1 values(1, repeat('#',12));
@@ -38,7 +39,7 @@ commit work;
 SET GLOBAL innodb_fast_shutdown = 0;
 let $shutdown_timeout=;
 --source include/restart_mysqld.inc
-
+--source ../include/no_checkpoint_start.inc
 connect (dml,localhost,root,,);
 XA START 'x';
 insert into t1 values (6, repeat('%', @@innodb_page_size/2));
@@ -50,8 +51,8 @@ connection default;
 flush table t1 for export;
 
 let $restart_parameters=;
-let $shutdown_timeout=0;
---source include/shutdown_mysqld.inc
+--let CLEANUP_IF_CHECKPOINT=drop table t1, unexpected_checkpoint;
+--source ../include/no_checkpoint_end.inc
 
 perl;
 use IO::Handle;
@@ -115,6 +116,35 @@ EOF
 let SEARCH_PATTERN=InnoDB: Restoring page \[page id: space=[1-9][0-9]*, page number=0\] of datafile;
 --source include/search_pattern_in_file.inc
 let SEARCH_PATTERN=InnoDB: Recovered page \[page id: space=[1-9][0-9]*, page number=3\];
+--source include/search_pattern_in_file.inc
+XA ROLLBACK 'x';
+check table t1;
+select f1, f2 from t1;
+
+--source ../include/no_checkpoint_start.inc
+connect (dml,localhost,root,,);
+XA START 'x';
+insert into t1 values (6, repeat('%', @@innodb_page_size/2));
+XA END 'x';
+XA PREPARE 'x';
+disconnect dml;
+connection default;
+
+flush table t1 for export;
+
+let $restart_parameters=;
+--source ../include/no_checkpoint_end.inc
+
+# Zero out the first page in file and try to recover from dblwr
+perl;
+use IO::Handle;
+open(FILE, "+<", "$ENV{'MYSQLD_DATADIR'}test/t1.ibd") or die;
+syswrite(FILE, chr(0) x $ENV{INNODB_PAGE_SIZE});
+close FILE;
+EOF
+
+--source include/start_mysqld.inc
+let SEARCH_PATTERN=InnoDB: Restoring page \[page id: space=[1-9][0-9]*, page number=0\] of datafile;
 --source include/search_pattern_in_file.inc
 XA ROLLBACK 'x';
 check table t1;

--- a/mysql-test/suite/innodb/t/doublewrite_debug.test
+++ b/mysql-test/suite/innodb/t/doublewrite_debug.test
@@ -17,6 +17,7 @@ call mtr.add_suppression("Plugin 'InnoDB' (init function returned error|registra
 call mtr.add_suppression("InnoDB: A bad Space ID was found in datafile");
 call mtr.add_suppression("InnoDB: Checksum mismatch in datafile: ");
 call mtr.add_suppression("InnoDB: Inconsistent tablespace ID in .*t1\\.ibd");
+call mtr.add_suppression("InnoDB: Header page consists of zero bytes in datafile:");
 --enable_query_log
 
 let INNODB_PAGE_SIZE=`select @@innodb_page_size`;

--- a/mysql-test/suite/innodb/t/log_file_name.test
+++ b/mysql-test/suite/innodb/t/log_file_name.test
@@ -7,6 +7,8 @@
 # Embedded server does not support crashing
 --source include/not_embedded.inc
 
+call mtr.add_suppression("InnoDB: Header page consists of zero bytes in datafile:");
+
 SET GLOBAL innodb_file_per_table=ON;
 FLUSH TABLES;
 
@@ -172,6 +174,7 @@ call mtr.add_suppression("InnoDB: Table test/u[123] in the InnoDB data dictionar
 call mtr.add_suppression("InnoDB: Cannot replay rename of tablespace.*");
 call mtr.add_suppression("InnoDB: Attempted to open a previously opened tablespace");
 call mtr.add_suppression("InnoDB: Recovery cannot access file");
+call mtr.add_suppression("InnoDB: Cannot read first page in datafile:");
 FLUSH TABLES;
 --enable_query_log
 
@@ -215,7 +218,7 @@ EOF
 --source include/start_mysqld.inc
 eval $check_no_innodb;
 
-let SEARCH_PATTERN= \[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
+let SEARCH_PATTERN= \[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
 --source include/search_pattern_in_file.inc
 
 let SEARCH_PATTERN= \[ERROR\] InnoDB: Datafile .*u1.*\. Cannot determine the space ID from the first 64 pages;
@@ -240,7 +243,7 @@ let SEARCH_PATTERN= \[Note\] InnoDB: Cannot read first page of .*u2.ibd;
 --source include/start_mysqld.inc
 eval $check_no_innodb;
 
-let SEARCH_PATTERN= \[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
+let SEARCH_PATTERN= \[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
 --source include/search_pattern_in_file.inc
 
 let SEARCH_PATTERN= InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace;
@@ -253,7 +256,7 @@ let SEARCH_PATTERN= \[ERROR\] InnoDB: Cannot replay rename of tablespace \d+ fro
 
 --source include/restart_mysqld.inc
 
-let SEARCH_PATTERN= \[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
+let SEARCH_PATTERN= \[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
 --source include/search_pattern_in_file.inc
 
 let SEARCH_PATTERN= InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace;

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -475,9 +475,16 @@ Datafile::validate_for_recovery()
 
 		err = find_space_id();
 		if (err != DB_SUCCESS || m_space_id == 0) {
-			ib::error() << "Datafile '" << m_filepath << "' is"
-				" corrupted. Cannot determine the space ID from"
-				" the first 64 pages.";
+
+			m_space_id = recv_sys.dblwr.find_first_page(
+				m_filepath, m_handle);
+
+			if (m_space_id) goto free_first_page;
+
+			sql_print_error(
+				"InnoDB: Datafile '%s' is corrupted."
+				" Cannot determine the space ID from"
+				" the first 64 pages.", m_filepath);
 			return(err);
 		}
 
@@ -485,7 +492,7 @@ Datafile::validate_for_recovery()
 			m_space_id, m_filepath, m_handle)) {
 			return(DB_CORRUPTION);
 		}
-
+free_first_page:
 		/* Free the previously read first page and then re-validate. */
 		free_first_page();
 		err = validate_first_page(0);
@@ -531,9 +538,9 @@ Datafile::validate_first_page(lsn_t* flush_lsn)
 
 	if (error_txt != NULL) {
 err_exit:
-		ib::info() << error_txt << " in datafile: " << m_filepath
-			<< ", Space ID:" << m_space_id  << ", Flags: "
-			<< m_flags;
+		sql_print_error("InnoDB: %s in datafile: %s, Space ID: %zu, "
+				"Flags: %zu", error_txt, m_filepath,
+				m_space_id, m_flags);
 		m_is_valid = false;
 		free_first_page();
 		return(DB_CORRUPTION);

--- a/storage/innobase/include/buf0dblwr.h
+++ b/storage/innobase/include/buf0dblwr.h
@@ -103,7 +103,8 @@ public:
   If we are upgrading from a version before MySQL 4.1, then this
   function performs the necessary update operations to support
   innodb_file_per_table. If we are in a crash recovery, this function
-  loads the pages from double write buffer into memory.
+  loads the pages from double write buffer which are not older than
+  the checkpoint into memory.
   @param file File handle
   @param path Path name of file
   @return DB_SUCCESS or error code */

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -49,6 +49,11 @@ recv_find_max_checkpoint(ulint* max_field)
 ATTRIBUTE_COLD void recv_recover_page(fil_space_t* space, buf_page_t* bpage)
 	MY_ATTRIBUTE((nonnull));
 
+/** Read the latest checkpoint information from log file
+and store it in log_sys.next_checkpoint and recv_sys.mlog_checkpoint_lsn
+@return error code or DB_SUCCESS */
+dberr_t recv_recovery_read_max_checkpoint();
+
 /** Start recovering from a redo log checkpoint.
 @param[in]	flush_lsn	FIL_PAGE_FILE_FLUSH_LSN
 of first system tablespace page
@@ -141,7 +146,18 @@ struct recv_dblwr_t
   @param file      tablespace file handle
   @return whether the operation failed */
   bool restore_first_page(
-         ulint space_id, const char *name, os_file_t file);
+         ulint space_id, const char *name, pfs_os_file_t file);
+
+  /** Restore the first page of the given tablespace from
+  doublewrite buffer.
+  1) Find the page which has page_no as 0
+  2) Read first 3 pages from tablespace file
+  3) Compare the space_ids from the pages with page0 which
+  was retrieved from doublewrite buffer
+  @param name tablespace filepath
+  @param file tablespace file handle
+  @return space_id or 0 in case of error */
+  uint32_t find_first_page(const char *name, pfs_os_file_t file);
 
   typedef std::deque<byte*, ut_allocator<byte*> > list;
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3415,6 +3415,46 @@ recv_init_crash_recovery_spaces(bool rescan, bool& missing_tablespace)
 	return DB_SUCCESS;
 }
 
+dberr_t recv_recovery_read_max_checkpoint()
+{
+  ut_ad(srv_operation <= SRV_OPERATION_EXPORT_RESTORED ||
+        srv_operation == SRV_OPERATION_RESTORE ||
+        srv_operation == SRV_OPERATION_RESTORE_EXPORT);
+  ut_d(mysql_mutex_lock(&buf_pool.mutex));
+  ut_ad(UT_LIST_GET_LEN(buf_pool.LRU) == 0);
+  ut_ad(UT_LIST_GET_LEN(buf_pool.unzip_LRU) == 0);
+  ut_d(mysql_mutex_unlock(&buf_pool.mutex));
+
+  if (srv_force_recovery >= SRV_FORCE_NO_LOG_REDO)
+  {
+    sql_print_information("InnoDB: innodb_force_recovery=6 skips redo log apply");
+    return DB_SUCCESS;
+  }
+
+  mysql_mutex_lock(&log_sys.mutex);
+  ulint max_cp;
+  dberr_t err= recv_find_max_checkpoint(&max_cp);
+
+  if (err != DB_SUCCESS)
+    recv_sys.recovered_lsn= log_sys.get_lsn();
+  else
+  {
+    byte* buf= log_sys.checkpoint_buf;
+    err= log_sys.log.read(max_cp, {buf, OS_FILE_LOG_BLOCK_SIZE});
+    if (err == DB_SUCCESS)
+    {
+      log_sys.next_checkpoint_no=
+        mach_read_from_8(buf + LOG_CHECKPOINT_NO);
+      log_sys.next_checkpoint_lsn=
+        mach_read_from_8(buf + LOG_CHECKPOINT_LSN);
+      recv_sys.mlog_checkpoint_lsn=
+        mach_read_from_8(buf + LOG_CHECKPOINT_END_LSN);
+    }
+  }
+  mysql_mutex_unlock(&log_sys.mutex);
+  return err;
+}
+
 /** Start recovering from a redo log checkpoint.
 @param[in]	flush_lsn	FIL_PAGE_FILE_FLUSH_LSN
 of first system tablespace page
@@ -3422,12 +3462,8 @@ of first system tablespace page
 dberr_t
 recv_recovery_from_checkpoint_start(lsn_t flush_lsn)
 {
-	ulint		max_cp_field;
-	lsn_t		checkpoint_lsn;
 	bool		rescan = false;
-	ib_uint64_t	checkpoint_no;
 	lsn_t		contiguous_lsn;
-	byte*		buf;
 	dberr_t		err = DB_SUCCESS;
 
 	ut_ad(srv_operation <= SRV_OPERATION_EXPORT_RESTORED
@@ -3445,27 +3481,11 @@ recv_recovery_from_checkpoint_start(lsn_t flush_lsn)
 		return(DB_SUCCESS);
 	}
 
-	recv_sys.recovery_on = true;
-
 	mysql_mutex_lock(&log_sys.mutex);
-
-	err = recv_find_max_checkpoint(&max_cp_field);
-
-	if (err != DB_SUCCESS) {
-
-		recv_sys.recovered_lsn = log_sys.get_lsn();
-		mysql_mutex_unlock(&log_sys.mutex);
-		return(err);
-	}
-
-	buf = log_sys.checkpoint_buf;
-	if ((err= log_sys.log.read(max_cp_field, {buf, OS_FILE_LOG_BLOCK_SIZE}))) {
-		mysql_mutex_unlock(&log_sys.mutex);
-		return(err);
-	}
-
-	checkpoint_lsn = mach_read_from_8(buf + LOG_CHECKPOINT_LSN);
-	checkpoint_no = mach_read_from_8(buf + LOG_CHECKPOINT_NO);
+	uint64_t checkpoint_no= log_sys.next_checkpoint_no;
+	lsn_t checkpoint_lsn= log_sys.next_checkpoint_lsn;
+	const lsn_t end_lsn= recv_sys.mlog_checkpoint_lsn;
+	recv_sys.recovery_on = true;
 
 	/* Start reading the log from the checkpoint lsn. The variable
 	contiguous_lsn contains an lsn up to which the log is known to
@@ -3474,8 +3494,6 @@ recv_recovery_from_checkpoint_start(lsn_t flush_lsn)
 
 	ut_ad(RECV_SCAN_SIZE <= srv_log_buffer_size);
 
-	const lsn_t	end_lsn = mach_read_from_8(
-		buf + LOG_CHECKPOINT_END_LSN);
 
 	ut_ad(recv_sys.pages.empty());
 	contiguous_lsn = checkpoint_lsn;
@@ -3845,8 +3863,52 @@ byte *recv_dblwr_t::find_page(const page_id_t page_id,
   return result;
 }
 
+uint32_t recv_dblwr_t::find_first_page(const char *name, pfs_os_file_t file)
+{
+  os_offset_t file_size= os_file_get_size(file);
+  if (file_size != (os_offset_t) -1)
+  {
+    for (const page_t *page : pages)
+    {
+      uint32_t space_id= page_get_space_id(page);
+      if (page_get_page_no(page) > 0 || space_id == 0)
+next_page:
+        continue;
+      uint32_t flags= mach_read_from_4(
+        FSP_HEADER_OFFSET + FSP_SPACE_FLAGS + page);
+      page_id_t page_id(space_id, 0);
+      size_t page_size= fil_space_t::physical_size(flags);
+      if (file_size < 4 * page_size)
+        goto next_page;
+      byte *read_page=
+        static_cast<byte*>(aligned_malloc(3 * page_size, page_size));
+      /* Read 3 pages from the file and match the space id
+      with the space id which is stored in
+      doublewrite buffer page. */
+      if (os_file_read(IORequestRead, file, read_page, page_size,
+                       3 * page_size) != DB_SUCCESS)
+        goto next_page;
+      for (ulint j= 0; j <= 2; j++)
+      {
+        byte *cur_page= read_page + j * page_size;
+        if (buf_is_zeroes(span<const byte>(cur_page, page_size)))
+          return 0;
+        if (mach_read_from_4(cur_page + FIL_PAGE_OFFSET) != j + 1 ||
+            memcmp(cur_page + FIL_PAGE_SPACE_ID,
+                   page + FIL_PAGE_SPACE_ID, 4) ||
+            buf_page_is_corrupted(false, cur_page, flags))
+          goto next_page;
+      }
+      if (!restore_first_page(space_id, name, file))
+        return space_id;
+      break;
+    }
+  }
+  return 0;
+}
+
 bool recv_dblwr_t::restore_first_page(ulint space_id, const char *name,
-                                      os_file_t file)
+                                      pfs_os_file_t file)
 {
   const page_id_t page_id(space_id, 0);
   const byte* page= find_page(page_id);
@@ -3854,10 +3916,11 @@ bool recv_dblwr_t::restore_first_page(ulint space_id, const char *name,
   {
     /* If the first page of the given user tablespace is not there
     in the doublewrite buffer, then the recovery is going to fail
-    now. Hence this is treated as error. */
-    ib::error()
-            << "Corrupted page " << page_id << " of datafile '"
-            << name <<"' could not be found in the doublewrite buffer.";
+    now. Report error only when doublewrite buffer is not empty */
+    if (pages.size())
+      ib::error() << "Corrupted page " << page_id << " of datafile '"
+                  << name <<"' could not be found in the "
+                  <<"doublewrite buffer.";
     return true;
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32968*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
InnoDB fails to find the space id from the page0 of
the tablespace. In that case, InnoDB can use
doublewrite buffer to recover the page0 and write
into the file.    
buf_dblwr_t::init_or_load_pages(): Loads only the pages
which are valid.(page lsn >= checkpoint). To do that,
InnoDB has to open the redo log before system
tablespace, read the latest checkpoint information.
    
 recv_dblwr_t::find_first_page():
    1) Iterate the doublewrite buffer pages and find the 0th page
    2) Read the tablespace flags, space id from the 0th page.
    3) Read the 1st, 2nd and 3rd page from tablespace file and
    compare the space id with the space id which is stored
    in doublewrite buffer.
    4) If it matches then we can write into the file.
    5) Return space which matches the pages from the file.
    
 SysTablespace::read_lsn_and_check_flags(): Remove the
  retry logic for validating the first page. After
  restoring the first page from doublewrite buffer,
  assign tablespace flags by reading the first page.
    
  recv_recovery_read_max_checkpoint(): Reads the maximum
  checkpoint information from log file
    
  recv_recovery_from_checkpoint_start(): Avoid reading
  the checkpoint header information from log file
   
  Datafile::validate_first_page(): Throw error in case
  of first page validation fails.
## How can this PR be tested?

./mtr innodb.doublewrite should test the added function
If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
