### PR TITLE
MDEV-32725 innodb.import_update_stats accesses uninitialized ib_table->stat_n_rows

### DIFF
--- a/mysql-test/suite/innodb/t/import_update_stats.test
+++ b/mysql-test/suite/innodb/t/import_update_stats.test
@@ -4,7 +4,6 @@
 
 --source include/not_embedded.inc
 --source include/have_innodb.inc
---source include/not_valgrind.inc # MDEV-32725 FIXME
 
 let MYSQLD_DATADIR =`SELECT @@datadir`;
 SET @old_innodb_file_per_table = @@innodb_file_per_table;

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -530,16 +530,9 @@ dict_stats_empty_index(
 	}
 }
 
-/*********************************************************************//**
-Write all zeros (or 1 where it makes sense) into a table and its indexes'
-statistics members. The resulting stats correspond to an empty table. */
-static
-void
-dict_stats_empty_table(
-/*===================*/
-	dict_table_t*	table,	/*!< in/out: table */
+void dict_stats_empty_table(
+	dict_table_t*	table,
 	bool		empty_defrag_stats)
-				/*!< in: whether to empty defrag stats */
 {
 	mutex_enter(&dict_sys.mutex);
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14316,7 +14316,7 @@ ha_innobase::info_low(
 	DBUG_ASSERT(ib_table->get_ref_count() > 0);
 
 	if (!ib_table->is_readable()) {
-		ib_table->stat_initialized = true;
+		dict_stats_empty_table(ib_table, true);
 	}
 
 	if (flag & HA_STATUS_TIME) {

--- a/storage/innobase/include/dict0stats.h
+++ b/storage/innobase/include/dict0stats.h
@@ -240,4 +240,13 @@ dict_stats_report_error(dict_table_t* table, bool defragment = false)
 void test_dict_stats_all();
 #endif /* UNIV_ENABLE_UNIT_TEST_DICT_STATS */
 
+/** Write all zeros (or 1 where it makes sense) into a table
+and its indexes'statistics members. The resulting stats
+correspond to an empty table.
+@param	table			table stats to be emptied
+@param  empty_defrag_stats	empty the defrag stats */
+void
+dict_stats_empty_table(
+	dict_table_t*	table,
+	bool		empty_defrag_stats);
 #endif /* dict0stats_h */


### PR DESCRIPTION

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32725*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
- InnoDB should write all zeros into a table and its indexes statistics members when table is unreadable.

## How can this PR be tested?
./mtr innodb.import_update_stats

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
