### PR TITLE
Explicitly recommend target branches in CODING_STANDARDS

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,8 @@ Without automated tests, future regressions in the expected behavior can't be au
 If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.
 
 <!--
-Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.4)
+Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
+see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
 -->
 ## Basing the PR against the correct MariaDB version
 - [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
@@ -43,5 +44,5 @@ Tick one of the following boxes [x] to help us understand if the base branch for
   Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
 -->
 ## PR quality check
-- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
+- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
 - [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -37,13 +37,20 @@ The commit messages are typically rendered in [Markdown format](https://docs.git
 When updating your code, please make sure you perform a rebase, not a merge with the latest branch.
 Pull requests should be a simple fast-forward of the branch they are intended to land on.
 
-The correct way to rebase (if working on top of 10.3 branch):
+The correct way to rebase (if working on top of 10.11 branch):
 
 ```sh
-git fetch upstream/10.3  # This assumes upstream is github.com/MariaDB/server
-git rebase upstream/10.3
+git fetch upstream/10.11  # This assumes upstream is github.com/MariaDB/server
+git rebase upstream/10.11
 git push --force my_branch
 ```
+
+### Target branch
+
+Pull requests should be based against the correct MariaDB version.
+New features should be based against the latest MariaDB development branch, which is the current GitHub default branch: https://github.com/MariaDB/server/blob/-/VERSION
+Bug fixes should be based against the earliest maintained branch in which the bug can be reproduced.
+The earliest maintained branch is found at https://mariadb.org/about/#maintenance-policy.
 
 ## Coding Style (C / C++ files)
 


### PR DESCRIPTION
<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
When making commits, the branches to target are not clearly defined in
public documentation, and frequently change. As the development branch
and the earliest maintained branches progress, it should be reflected in
CODING_STANDARDS.md.

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services.

## How can this PR be tested?
Documentation change, no testing necessary.


## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the 
BSD-new license. I am contributing on behalf of my employer Amazon Web 
Services.