### PR TITLE
MDEV-33006 Missing required privilege CONNECTION ADMIN

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -6403,7 +6403,7 @@ static bool check_all_privileges()
 	}
 
 	/* KILL ... */
-	if (!opt_no_lock && (opt_kill_long_queries_timeout || opt_kill_long_query_type)) {
+	if (!opt_no_lock && opt_kill_long_queries_timeout) {
 		check_result |= check_privilege(
 			granted_privileges,
 			"CONNECTION ADMIN", "*", "*",
@@ -6424,7 +6424,7 @@ static bool check_all_privileges()
 	if (opt_galera_info || opt_slave_info
 		|| opt_safe_slave_backup) {
 		check_result |= check_privilege(granted_privileges,
-			"SLAVE MONITOR", "*", "*",
+			"REPLICA MONITOR", "*", "*",
 			PRIVILEGE_WARNING);
 	}
 

--- a/mysql-test/suite/mariabackup/backup_grants.result
+++ b/mysql-test/suite/mariabackup/backup_grants.result
@@ -3,12 +3,13 @@ FOUND 1 /missing required privilege RELOAD/ in backup.log
 FOUND 1 /missing required privilege PROCESS/ in backup.log
 FOUND 1 /GRANT USAGE ON/ in backup.log
 GRANT RELOAD, PROCESS on *.* to backup@localhost;
-NOT FOUND /missing required privilege REPLICA MONITOR/ in backup.log
+FOUND 1 /missing required privilege REPLICA MONITOR/ in backup.log
 GRANT REPLICA MONITOR ON *.* TO backup@localhost;
 REVOKE REPLICA MONITOR ON *.* FROM backup@localhost;
+FOUND 1 /missing required privilege CONNECTION ADMIN/ in backup.log
 GRANT CONNECTION ADMIN ON *.* TO backup@localhost;
 FOUND 1 /missing required privilege REPLICATION SLAVE ADMIN/ in backup.log
-NOT FOUND /missing required privilege REPLICA MONITOR/ in backup.log
+FOUND 1 /missing required privilege REPLICA MONITOR/ in backup.log
 GRANT REPLICATION SLAVE ADMIN ON *.* TO backup@localhost;
 GRANT REPLICA MONITOR ON *.* TO backup@localhost;
 DROP USER backup@localhost;

--- a/mysql-test/suite/mariabackup/backup_grants.test
+++ b/mysql-test/suite/mariabackup/backup_grants.test
@@ -10,7 +10,7 @@ rmdir $targetdir;
 # backup fails without --no-lock, because of FTWRL
 --disable_result_log
 error 1;
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
 
 let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/backup.log;
@@ -31,7 +31,7 @@ rmdir $targetdir;
 # --slave-info and galera info require REPLICA MONITOR
 --disable_result_log
 error 1;
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup --slave-info  --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup --slave-info  --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
 rmdir $targetdir;
 
@@ -47,16 +47,15 @@ REVOKE REPLICA MONITOR ON *.* FROM backup@localhost;
 
 # TODO need a query that would delay a BACKUP STAGE START/ BACKUP STAGE BLOCK_COMMIT longer than the kill-long-queries-timeout
 #--send SELECT SLEEP(9) kill_me
-## kill-long-query-type=(not empty) requires CONNECTION ADMIN
-#--disable_result_log
-#error 1;
-#--exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup  --kill-long-query-type=all --kill-long-queries-timeout=4 --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log;
-#--reap
-#--enable_result_log
-#rmdir $targetdir;
-#
-#--let SEARCH_PATTERN=  missing required privilege CONNECTION ADMIN
-#--source include/search_pattern_in_file.inc
+
+# kill-long-query-type=(not empty) requires CONNECTION ADMIN
+--disable_result_log
+--exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup --kill-long-query-type=ALL --kill-long-queries-timeout=4 --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
+--enable_result_log
+rmdir $targetdir;
+
+--let SEARCH_PATTERN= missing required privilege CONNECTION ADMIN
+--source include/search_pattern_in_file.inc
 
 GRANT CONNECTION ADMIN ON *.* TO backup@localhost;
 --disable_result_log


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33006*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description


opt_kill_long_query_type being an enum could be 0 corresponding to ALL. When ALL is specified, the CONNECTION ADMIN is still required.

fixed test cases associated with REPLICA MONITOR.

Noticed thanks to bug report by Tim van Dijen.

Fixes: 79b58f1ca893b8affc5075d0a548563d376cd481

## How can this PR be tested?

mtr included

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.