### PR TITLE
MDEV-33009 Server hangs for a long time with innodb_undo_log_truncate=ON

### DIFF
--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -681,6 +681,13 @@ void trx_purge_truncate_history()
 
         if (prev != buf_pool.flush_hp.get())
         {
+          /* The functions buf_pool_t::release_freed_page() or
+          buf_do_flush_list_batch() may be right now holding
+          buf_pool.mutex and waiting to acquire
+          buf_pool.flush_list_mutex. Ensure that they can proceed,
+          to avoid extreme waits. */
+          mysql_mutex_unlock(&buf_pool.flush_list_mutex);
+          mysql_mutex_lock(&buf_pool.flush_list_mutex);
           /* Rescan, because we may have lost the position. */
           bpage= UT_LIST_GET_LAST(buf_pool.flush_list);
           continue;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33009*
## Description
`trx_purge_truncate_history()`: When we need to wait for a page latch, acquire and release `buf_pool.mutex` to ensure that any thread that may be holding `buf_pool.mutex` and waiting for `buf_pool.flush_list_mutex` will be able to proceed.

This fixes up commit a0f02f743848fb6ef6d2a51960f77e1e38da1682 (MDEV-32757).
## How can this PR be tested?
This is best tested by @hgxl64 in the Ubuntu 18.04 environment where the original anomaly was observed. The existing regression tests `innodb.undo_truncate` and `innodb.undo_truncate_recover` does cover this code.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.