### PR TITLE
MDEV-33009 Server hangs for a long time with innodb_undo_log_truncate=ON

### DIFF
--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -687,8 +687,8 @@ not_free:
     mini-transaction commit and the server was killed, then
     discarding the to-be-trimmed pages without flushing would
     break crash recovery. */
-    mysql_mutex_lock(&buf_pool.flush_list_mutex);
   rescan:
+    mysql_mutex_lock(&buf_pool.flush_list_mutex);
     for (buf_page_t *bpage= UT_LIST_GET_LAST(buf_pool.flush_list); bpage; )
     {
       ut_ad(bpage->oldest_modification());
@@ -730,7 +730,17 @@ not_free:
         mysql_mutex_lock(&buf_pool.flush_list_mutex);
 
         if (prev != buf_pool.flush_hp.get())
+        {
+          /* The functions buf_pool_t::release_freed_page() or
+          buf_do_flush_list_batch() may be right now holding
+          buf_pool.mutex and waiting to acquire
+          buf_pool.flush_list_mutex. Ensure that they can proceed,
+          to avoid extreme waits. */
+          mysql_mutex_unlock(&buf_pool.flush_list_mutex);
+          mysql_mutex_lock(&buf_pool.mutex);
+          mysql_mutex_unlock(&buf_pool.mutex);
           goto rescan;
+        }
       }
 
       bpage= prev;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33009*

## Description
`trx_purge_truncate_history()`: When we need to wait for a page latch, acquire and release `buf_pool.mutex` to ensure that any thread that may be holding `buf_pool.mutex` and waiting for `buf_pool.flush_list_mutex` will be able to proceed.

This fixes up commit 5dbe7a8c9aa88b7ed17311c2f1df651c9da7783b (MDEV-32757).
## How can this PR be tested?
This is best tested by @hgxl64 in the Ubuntu 18.04 environment where the original anomaly was observed. The existing regression tests `innodb.undo_truncate` and `innodb.undo_truncate_recover` do cover this code.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [x] This is a 10.6 version of #2930.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.