### PR TITLE
MDEV-26923 Check all invalid config options

### DIFF
--- a/mysql-test/main/mysqld_option_err.result
+++ b/mysql-test/main/mysqld_option_err.result
@@ -3,6 +3,14 @@ Test bad binlog format.
 Test bad default storage engine.
 Test non-numeric value passed to number option.
 Test that bad value for plugin enum option is rejected correctly.
+Test to see if multiple unknown options will be displayed in the error output
+unknown option '--nonexistentoption'
+unknown option '--alsononexistent'
+unknown variable 'nonexistentvariable=1'
+Test to see if multiple ambiguous options and invalid arguments will be displayed in the error output
+Error while setting value 'invalid_value' to 'sql_mode'
+ambiguous option '--character' (character-set-client-handshake, character_sets_dir)
+option '--bootstrap' cannot take an argument
 Test that --help --verbose works
 Test that --not-known-option --help --verbose gives error
 Done.

--- a/mysql-test/main/mysqld_option_err.test
+++ b/mysql-test/main/mysqld_option_err.test
@@ -46,6 +46,18 @@ mkdir $MYSQLTEST_VARDIR/tmp/mysqld_option_err;
 --error 7
 --exec $MYSQLD_BOOTSTRAP_CMD --skip-networking --datadir=$MYSQLTEST_VARDIR/tmp/mysqld_option_err --skip-grant-tables --plugin-dir=$MYSQLTEST_VARDIR/plugins --plugin-load=example=ha_example.so --plugin-example-enum-var=noexist >>$MYSQLTEST_VARDIR/tmp/mysqld_option_err/mysqltest.log 2>&1
 
+--echo Test to see if multiple unknown options will be displayed in the error output
+# Remove the noise to make the test robust
+--replace_regex /^((?!nonexistent).)*$// /.*unknown/unknown/
+--error 7
+--exec $MYSQLD_BOOTSTRAP_CMD --skip-networking --datadir=$MYSQLTEST_VARDIR/tmp/mysqld_option_err --skip-grant-tables --nonexistentoption --alsononexistent --nonexistentvariable=1 2>&1
+
+--echo Test to see if multiple ambiguous options and invalid arguments will be displayed in the error output
+# Remove the noise to make the test robust
+--replace_regex /^((?!('sql_mode'|'--character'|'--bootstrap')).)*$// /.*Error while setting value/Error while setting value/ /.*ambiguous option/ambiguous option/ /.*option '--bootstrap'/option '--bootstrap'/
+--error 1
+--exec $MYSQLD_BOOTSTRAP_CMD --skip-networking --datadir=$MYSQLTEST_VARDIR/tmp/mysqld_option_err --skip-grant-tables --getopt-prefix-matching --sql-mode=invalid_value --character --bootstrap=partstoob 2>&1
+
 #
 # Test that an wrong option with --help --verbose gives an error
 #


### PR DESCRIPTION
* [x] _The Jira issue number for this PR is: MDEV-26923_

## Description

This change makes the effort to reduce the number of server restarts required due to passing invalid options.

Previously, the behavior was to error out on the first invalid option encountered. With this change, a best effort approach is made so that all invalid options processed will be printed before exiting.

There is a caveat. The options are processed many times at varying stages of server startup because the server is not aware of all valid options immediately (e.g. plugins have to be loaded first before the server knows what are the available plugin options). So, there are some options that the server can determine are invalid "early" on, and there are some options that the server cannot determine are invalid until "later" on. For example, the server can determine an option such as `--a` is an ambiguous option very early on but an option such as `--this-does-not-match-any-option` cannot be labelled as invalid until the server is aware of all available options.

Thus, it is possible that the server will still fail before printing out all "invalid" options. You can see this by passing `--a --obvious-invalid-option`.

## How can this PR be tested?

MTR test main.mysqld_option_err has been updated with a new test which passes

## Basing the PR against the correct MariaDB version

* [ ] _This is a new feature and the PR is based against the latest MariaDB development branch._
* [x] _This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced._

## PR quality check

* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

# Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.