### PR TITLE
sql/sql_test.cc include header correction

### DIFF
--- a/sql/sql_test.cc
+++ b/sql/sql_test.cc
@@ -27,12 +27,12 @@
 #include "my_json_writer.h"
 #include <hash.h>
 #include <thr_alarm.h>
-#if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
-#if defined(HAVE_MALLOC_H)
+#if (defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)) && defined(HAVE_MALLOC_H)
 #include <malloc.h>
-#elif defined(HAVE_SYS_MALLOC_H)
-#include <sys/malloc.h>
 #endif
+
+#if defined(HAVE_SYS_MALLOC_H)
+#include <sys/malloc.h>
 #endif
 
 #ifdef HAVE_EVENT_SCHEDULER


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

While 1fec50120fb4b08ea76cc79cf65905a0d5027e84 (#2880 was right, when merged to 10.5, the MacOS include header
(9a3cbc05415dd862852dffbd368527319107f460)
was included under the #ifdef HAVE_MALLINFO{,2} which isn't the case on MacOS.

sys/malloc.h possibly has use under OpenBSD from MDEV-4190 patch so keep it separate. C89 doesn't mention the need however and malloc only needs stdlib.h.

## How can this PR be tested?

Debug builds cover this.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
