### PR TITLE
Fix unaligned access in my_dir

### DIFF
--- a/mysys/my_lib.c
+++ b/mysys/my_lib.c
@@ -115,7 +115,10 @@ MY_DIR	*my_dir(const char *path, myf MyFlags)
   DIR		*dirp;
   struct dirent *dp;
   char		tmp_path[FN_REFLEN + 2], *tmp_file;
-  char	dirent_tmp[sizeof(struct dirent)+_POSIX_PATH_MAX+1];
+  union {
+    char storage[sizeof(struct dirent)+_POSIX_PATH_MAX+1];
+    struct dirent d;
+  } dirent_tmp;
 
   DBUG_ENTER("my_dir");
   DBUG_PRINT("my",("path: '%s' MyFlags: %lu",path,MyFlags));
@@ -139,9 +142,9 @@ MY_DIR	*my_dir(const char *path, myf MyFlags)
   init_alloc_root(&dirh->root, "dir", NAMES_START_SIZE, NAMES_START_SIZE,
                   MYF(MyFlags));
 
-  dp= (struct dirent*) dirent_tmp;
+  dp= &dirent_tmp.d;
   
-  while (!(READDIR(dirp,(struct dirent*) dirent_tmp,dp)))
+  while (!(READDIR(dirp,&dirent_tmp.d,dp)))
   {
     MY_STAT statbuf, *mystat= 0;
     


### PR DESCRIPTION
Accessing data through an unaligned pointer is undefined behavior and can cause crashes certain architectures (e.g. arm). Use a union to force the compiler to allocate storage suitably aligned for a `struct dirent`.

1. What problem is the patch trying to solve?
unaligned access

2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
No functional change (apart from not crashing when accessing an unaligned pointer)

3. Do you think this patch might introduce side-effects in other parts of the server?
No side effects.

## How can this PR be tested?

> If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

Compile with undefined behavior sanitizer, check that it does not crash. Automated testing is difficult, since it's not even guaranteed that variable will be actually unaligned.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
