### PR TITLE
MDEV-31925 mysqld_upgrade --check-if-upgrade-is-needed leaks files

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -1374,7 +1374,12 @@ int main(int argc, char **argv)
   open_mysql_upgrade_file();
 
   if (opt_check_upgrade)
-    exit(upgrade_already_done(0) == 0);
+  {
+    int upgrade_needed = upgrade_already_done(0);
+    free_used_memory();
+    my_end(my_end_arg);
+    exit(upgrade_needed == 0);
+  }
 
   /* Find mysqlcheck */
   find_tool(mysqlcheck_path, IF_WIN("mysqlcheck.exe", "mysqlcheck"), self_name);

--- a/mysql-test/main/mysql_upgrade_file_leak.result
+++ b/mysql-test/main/mysql_upgrade_file_leak.result
@@ -1,0 +1,4 @@
+Running mysql_upgrade with --check-if-upgrade-is-needed
+Checking for absence of temporary files by mysql_upgrade
+No temporary files found
+End of 10.4 tests

--- a/mysql-test/main/mysql_upgrade_file_leak.test
+++ b/mysql-test/main/mysql_upgrade_file_leak.test
@@ -1,0 +1,24 @@
+-- source include/mysql_upgrade_preparation.inc
+
+#
+# MDEV-31925 mysqld_upgrade --check-if-upgrade-is-needed leaks files
+#
+
+# Run mysql_upgrade with --check-if-upgrade-is-needed
+--echo Running mysql_upgrade with --check-if-upgrade-is-needed
+--exec $MYSQL_UPGRADE --check-if-upgrade-is-needed 2>&1
+
+# Check if temporary files related to mysql_upgrade are cleared
+--echo Checking for absence of temporary files by mysql_upgrade
+--perl
+
+# Use the temporary directory path from the MySQL configuration
+my $tmpdir = "$ENV{MYSQL_TMP_DIR}";
+
+die "Test failed: Found temporary file left by mysql_upgrade\n" if (glob("$tmpdir/mysql_upgrade-*"));
+print "No temporary files found\n";
+EOF
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+--remove_file $MYSQLD_DATADIR/mysql_upgrade_info
+--echo End of 10.4 tests


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: [MDEV-31925*](https://jira.mariadb.org/browse/MDEV-31925)

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This patch addresses a file leak issue identified in `mysql_upgrade` with the `--check-if-upgrade-is-needed` option. Previously, the execution of `mysql_upgrade` with this flag would leave temporary files in the system's temp directory. This patch ensures that any temporary files created during the `mysql_upgrade `process are properly cleaned up, thus maintaining a cleaner system environment.

## How can this PR be tested?

The patch includes an updated test case that verifies the absence of temporary files after running `mysql_upgrade` with the `--check-if-upgrade-is-needed` option. This test should pass without any temporary files being left behind in the temp directory.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
