### PR TITLE
MDEV-33052 MSAN use-of-uninitialized-value in buf_read_ahead_linear()

### DIFF
--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -643,6 +643,12 @@ hard_fail:
 
       uint32_t prev= mach_read_from_4(my_assume_aligned<4>(f + FIL_PAGE_PREV));
       uint32_t next= mach_read_from_4(my_assume_aligned<4>(f + FIL_PAGE_NEXT));
+      /* The underlying file page of this buffer pool page could actually
+      be marked as freed, or a read of the page into the buffer pool might
+      be in progress. We may read uninitialized data here.
+      Suppress warnings of comparing uninitialized values. */
+      MEM_MAKE_DEFINED(&prev, sizeof prev);
+      MEM_MAKE_DEFINED(&next, sizeof next);
       if (prev == FIL_NULL || next == FIL_NULL)
         goto hard_fail;
       page_id_t id= page_id;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33052*

## Description
A MemorySanitizer error use-of-uninitialized-value may be issued for `buf_read_ahead_linear()`, which indeed is performing unsafe reads of the page header fields `FIL_PAGE_PREV` and `FIL_PAGE_NEXT`. The impact of comparing invalid data is minor; we might trigger a read-ahead when we should not, or skip it when we should perform it.

## How can this PR be tested?
The error is very rare and nondeterministic. On buildbot, it was observed only once in a 10.6 based branch when running the test `innodb_fts.bug_32831765`.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

MemorySanitizer is only usable (and enabled in our CI systems) starting with 10.5. A corresponding error could theoretically occur also in Valgrind builds on 10.4, but I do not remember any occurrence there, and the code in 10.5 has been heavily refactored over earlier versions.

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.