### PR TITLE
MDEV-32808 encrypt sql crash

### DIFF
--- a/mysql-test/suite/plugins/r/keymgt_sql_service.result
+++ b/mysql-test/suite/plugins/r/keymgt_sql_service.result
@@ -1,0 +1,13 @@
+install soname 'example_keymgt_sql_service.so';
+SET @saved_encrypt_tables = @@global.innodb_encrypt_tables;
+SET @saved_encryption_threads = @@global.innodb_encryption_threads;
+SET SESSION innodb_default_encryption_key_id=1;
+SET GLOBAL innodb_encrypt_tables=ON;
+SET GLOBAL innodb_encryption_threads=1;
+We didn't crash
+SET GLOBAL innodb_encrypt_tables = @saved_encrypt_tables;
+SET GLOBAL innodb_encryption_threads = @saved_encryption_threads;
+uninstall soname 'example_keymgt_sql_service.so';
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown
+# End of 10.4 tests

--- a/mysql-test/suite/plugins/t/keymgt_sql_service.test
+++ b/mysql-test/suite/plugins/t/keymgt_sql_service.test
@@ -1,0 +1,28 @@
+-- source include/have_innodb.inc
+-- source include/not_embedded.inc
+
+if (!$EXAMPLE_KEYMGT_SQL_SERVICE_SO) {
+  skip No example_keymgt_sql_service plugin;
+}
+eval install soname '$EXAMPLE_KEYMGT_SQL_SERVICE_SO';
+
+SET @saved_encrypt_tables = @@global.innodb_encrypt_tables;
+SET @saved_encryption_threads = @@global.innodb_encryption_threads;
+
+SET SESSION innodb_default_encryption_key_id=1;
+
+SET GLOBAL innodb_encrypt_tables=ON;
+SET GLOBAL innodb_encryption_threads=1;
+
+--echo We didn't crash
+
+--let $wait_condition= SELECT COUNT(*)=1 FROM information_schema.TABLES WHERE TABLE_SCHEMA='test' AND TABLE_NAME='t1';
+--source include/wait_condition.inc
+
+SET GLOBAL innodb_encrypt_tables = @saved_encrypt_tables;
+SET GLOBAL innodb_encryption_threads = @saved_encryption_threads;
+
+# warning expected, crypt thread holds reference until it shuts down.
+eval uninstall soname '$EXAMPLE_KEYMGT_SQL_SERVICE_SO';
+
+-- echo # End of 10.4 tests

--- a/plugin/example_keymgt_sql_service/CMakeLists.txt
+++ b/plugin/example_keymgt_sql_service/CMakeLists.txt
@@ -1,0 +1,2 @@
+MYSQL_ADD_PLUGIN(EXAMPLE_KEYMGT_SQL_SERVICE example_keymgt_sql_service.cc
+                 MODULE_ONLY COMPONENT Test)

--- a/plugin/example_keymgt_sql_service/example_keymgt_sql_service.cc
+++ b/plugin/example_keymgt_sql_service/example_keymgt_sql_service.cc
@@ -11,6 +11,7 @@
 
 static int run_sql(const char *query, size_t query_len)
 {
+  MYSQL_RES *res;
 
   MYSQL *mysql= mysql_init(NULL);
   if (!mysql)
@@ -21,6 +22,12 @@ static int run_sql(const char *query, size_t query_len)
 
   if (mysql_real_query(mysql, query, query_len))
     return 1;
+
+  if (!(res= mysql_store_result(mysql)))
+      return 1;
+
+  mysql_free_result(res);
+
 
   mysql_close(mysql);
   return 0;
@@ -51,7 +58,8 @@ get_key(unsigned int key_id, unsigned int version,
 
 static int example_keymgt_sql_service_init(void *p)
 {
-  return run_sql(STRING_WITH_LEN("CREATE TABLE test.t1 (id int)")) ? HA_ERR_RETRY_INIT : 0;
+  run_sql(STRING_WITH_LEN("CREATE TABLE test.t1 (id int)")); // ? HA_ERR_RETRY_INIT : 0;
+  return 0;
 }
 
 static int example_keymgt_sql_service_deinit(void *p)

--- a/plugin/example_keymgt_sql_service/example_keymgt_sql_service.cc
+++ b/plugin/example_keymgt_sql_service/example_keymgt_sql_service.cc
@@ -1,0 +1,95 @@
+#include <mysql/plugin_encryption.h>
+#include <cstring>
+
+#define STRING_WITH_LEN(X) (X ""), ((size_t) (sizeof(X) - 1))
+
+/* my_base.h without compile errors */
+#define HA_ERR_RETRY_INIT 129
+
+// AES128-GCM 128-bit key
+#define KEY_LEN 16
+
+static int run_sql(const char *query, size_t query_len)
+{
+
+  MYSQL *mysql= mysql_init(NULL);
+  if (!mysql)
+    return 1;
+
+  if (mysql_real_connect_local(mysql) == NULL)
+    return 1;
+
+  if (mysql_real_query(mysql, query, query_len))
+    return 1;
+
+  mysql_close(mysql);
+  return 0;
+}
+
+static unsigned int
+get_latest_key_version(unsigned int key_id)
+{
+  return run_sql(STRING_WITH_LEN("SELECT * FROM test.t1"));
+}
+
+static unsigned int
+get_key(unsigned int key_id, unsigned int version,
+        unsigned char* dstbuf, unsigned *buflen)
+{
+
+  if (run_sql(STRING_WITH_LEN("SELECT * FROM test.t1")))
+    return 1;
+
+  if (dstbuf == NULL) {
+    *buflen = KEY_LEN;
+  } else {
+    memset(dstbuf, 9, *buflen);
+  }
+
+  return 0;
+}
+
+static int example_keymgt_sql_service_init(void *p)
+{
+  return run_sql(STRING_WITH_LEN("CREATE TABLE test.t1 (id int)")) ? HA_ERR_RETRY_INIT : 0;
+}
+
+static int example_keymgt_sql_service_deinit(void *p)
+{
+  /* MDEV-33047 using sql_service within deinit of plugin segfaults on shutdown
+  return run_sql(STRING_WITH_LEN("DROP TABLE test.t1"));
+  */
+  return 0;
+}
+
+struct st_mariadb_encryption example_keymgt_sql_service= {
+  MariaDB_ENCRYPTION_INTERFACE_VERSION,
+  get_latest_key_version,
+  get_key,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+};
+
+/*
+  Plugin library descriptor
+*/
+maria_declare_plugin(example_keymgt_sql_service)
+{
+  MariaDB_ENCRYPTION_PLUGIN,
+  &example_keymgt_sql_service,
+  "example_keymgt_sql_service",
+  "Trevor, Daniel",
+  "Example keymgt plugin that uses sql service",
+  PLUGIN_LICENSE_GPL,
+  example_keymgt_sql_service_init,
+  example_keymgt_sql_service_deinit,
+  0x0100 /* 1.0 */,
+  NULL,	/* status variables */
+  NULL,	/* system variables */
+  "1.0",
+  MariaDB_PLUGIN_MATURITY_STABLE
+}
+maria_declare_plugin_end;

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -2412,6 +2412,9 @@ DECLARE_THREAD(fil_crypt_thread)(void*)
 	/* if we find a space that is starting, skip over it and recheck it later */
 	bool recheck = false;
 
+	/* so key management plugins can call the sql service */
+	my_thread_init();
+
 	while (!thr.should_shutdown()) {
 
 		key_state_t new_state;
@@ -2492,6 +2495,8 @@ DECLARE_THREAD(fil_crypt_thread)(void*)
 			fil_crypt_return_iops(&thr);
 		}
 	}
+
+	my_thread_end();
 
 	/* return iops if shutting down */
 	fil_crypt_return_iops(&thr);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32808*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Using a SQL service from within an encryption plugin fails as there's no THD valid.

## How can this PR be tested?

MTR included. Second commit attempting to eliminate memory leak:
```
Version: '10.4.33-MariaDB-log'  socket: '/home/dan/repos/build-mariadb-server-10.4-debug/mysql-test/var/tmp/mysqld.1.sock'  port: 16000  Source distribution
2023-12-19 18:16:45 9 [Note] InnoDB: Creating #1 encryption thread id 139867329214144 total threads 1.
2023-12-19 18:16:45 0 [Note] /home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld (initiated by: root[root] @ localhost [127.0.0.1]): Normal shutdown
2023-12-19 18:16:45 0 [Note] Event Scheduler: Purging the queue. 0 events
2023-12-19 18:16:45 0 [Note] InnoDB: FTS optimize thread exiting.
2023-12-19 18:16:46 0 [Note] InnoDB: Starting shutdown...
2023-12-19 18:16:46 0 [Note] InnoDB: Dumping buffer pool(s) to /home/dan/repos/build-mariadb-server-10.4-debug/mysql-test/var/mysqld.1/data/ib_buffer_pool
2023-12-19 18:16:46 0 [Note] InnoDB: Instance 0, restricted to 125 pages due to innodb_buf_pool_dump_pct=25
2023-12-19 18:16:46 0 [Note] InnoDB: Buffer pool(s) dump completed at 231219 18:16:46
2023-12-19 18:16:47 0 [Note] InnoDB: Removed temporary tablespace data file: "ibtmp1"
2023-12-19 18:16:47 0 [Note] InnoDB: Shutdown completed; log sequence number 68197; transaction id 33
2023-12-19 18:16:47 0 [Note] /home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld: Shutdown complete

Warning: Memory not freed: 28352

=================================================================
==3247871==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1280 byte(s) in 1 object(s) allocated from:
    #0 0x75f022 in malloc (/home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld+0x75f022) (BuildId: 33dbf266cfd6a1942a1a044db6d53b4abfba362e)
    #1 0x20aa238 in my_malloc /home/dan/repos/mariadb-server-10.4/mysys/my_malloc.c:101:10
    #2 0xa5ceed in plugin_initialize(st_mem_root*, st_plugin_int*, int*, char**, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_plugin.cc:1482:10
    #3 0xa63e34 in finalize_install(THD*, TABLE*, st_mysql_const_lex_string const*, int*, char**) /home/dan/repos/mariadb-server-10.4/sql/sql_plugin.cc:2186:9

Direct leak of 616 byte(s) in 1 object(s) allocated from:
    #0 0x75f022 in malloc (/home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld+0x75f022) (BuildId: 33dbf266cfd6a1942a1a044db6d53b4abfba362e)
    #1 0x20aa238 in my_malloc /home/dan/repos/mariadb-server-10.4/mysys/my_malloc.c:101:10
    #2 0xd8a49d in MDL_map::find_or_insert(LF_PINS*, MDL_key const*) /home/dan/repos/mariadb-server-10.4/sql/mdl.cc:863:9
    #3 0xd900af in MDL_context::try_acquire_lock_impl(MDL_request*, MDL_ticket**) /home/dan/repos/mariadb-server-10.4/sql/mdl.cc:2138:25
    #4 0xd90b0f in MDL_context::acquire_lock(MDL_request*, double) /home/dan/repos/mariadb-server-10.4/sql/mdl.cc:2296:7
    #5 0xbbc6cc in try_acquire_high_prio_shared_mdl_lock(THD*, TABLE_LIST*, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:4927:29
    #6 0xbbc6cc in fill_schema_table_from_frm(THD*, st_mem_root*, TABLE*, st_schema_table*, st_mysql_const_lex_string*, st_mysql_const_lex_string*, Open_tables_backup*, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:5006:7
    #7 0xbbc6cc in get_all_tables(THD*, TABLE_LIST*, Item*) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:5372:20
    #8 0xbd8ae4 in get_schema_tables_result(JOIN*, enum_schema_table_state) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:9224:11
    #9 0xb17c2e in JOIN::exec_inner() /home/dan/repos/mariadb-server-10.4/sql/sql_select.cc:4582:7
    #10 0xab759a in JOIN::exec() /home/dan/repos/mariadb-server-10.4/sql/sql_select.cc:4407:3
    #11 0xab759a in mysql_select(THD*, TABLE_LIST*, unsigned int, List<Item>&, Item*, unsigned int, st_order*, st_order*, Item*, st_order*, unsigned long long, select_result*, st_select_lex_unit*, st_select_lex*) /home/dan/repos/mariadb-server-10.4/sql/sql_select.cc:4846:9

Indirect leak of 25992 byte(s) in 2 object(s) allocated from:
    #0 0x75f022 in malloc (/home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld+0x75f022) (BuildId: 33dbf266cfd6a1942a1a044db6d53b4abfba362e)
    #1 0x20aa238 in my_malloc /home/dan/repos/mariadb-server-10.4/mysys/my_malloc.c:101:10
    #2 0x7f358e002a15  (<unknown module>)
    #3 0xa5ceed in plugin_initialize(st_mem_root*, st_plugin_int*, int*, char**, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_plugin.cc:1482:10
    #4 0xa63e34 in finalize_install(THD*, TABLE*, st_mysql_const_lex_string const*, int*, char**) /home/dan/repos/mariadb-server-10.4/sql/sql_plugin.cc:2186:9

Indirect leak of 8280 byte(s) in 28 object(s) allocated from:
    #0 0x75f022 in malloc (/home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld+0x75f022) (BuildId: 33dbf266cfd6a1942a1a044db6d53b4abfba362e)
    #1 0x20aa238 in my_malloc /home/dan/repos/mariadb-server-10.4/mysys/my_malloc.c:101:10

Indirect leak of 1456 byte(s) in 1 object(s) allocated from:
    #0 0x79ccc1 in operator new(unsigned long) (/home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld+0x79ccc1) (BuildId: 33dbf266cfd6a1942a1a044db6d53b4abfba362e)
    #1 0xa8fac0 in mysql_real_connect_local /home/dan/repos/mariadb-server-10.4/sql/sql_prepare.cc:6230:6
    #2 0x7f358e002a15  (<unknown module>)
    #3 0xa5ceed in plugin_initialize(st_mem_root*, st_plugin_int*, int*, char**, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_plugin.cc:1482:10
    #4 0xa63e34 in finalize_install(THD*, TABLE*, st_mysql_const_lex_string const*, int*, char**) /home/dan/repos/mariadb-server-10.4/sql/sql_plugin.cc:2186:9

Indirect leak of 616 byte(s) in 1 object(s) allocated from:
    #0 0x75f022 in malloc (/home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld+0x75f022) (BuildId: 33dbf266cfd6a1942a1a044db6d53b4abfba362e)
    #1 0x20aa238 in my_malloc /home/dan/repos/mariadb-server-10.4/mysys/my_malloc.c:101:10
    #2 0xd8a49d in MDL_map::find_or_insert(LF_PINS*, MDL_key const*) /home/dan/repos/mariadb-server-10.4/sql/mdl.cc:863:9
    #3 0xd900af in MDL_context::try_acquire_lock_impl(MDL_request*, MDL_ticket**) /home/dan/repos/mariadb-server-10.4/sql/mdl.cc:2138:25
    #4 0xd90b0f in MDL_context::acquire_lock(MDL_request*, double) /home/dan/repos/mariadb-server-10.4/sql/mdl.cc:2296:7
    #5 0xbbc6cc in try_acquire_high_prio_shared_mdl_lock(THD*, TABLE_LIST*, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:4927:29
    #6 0xbbc6cc in fill_schema_table_from_frm(THD*, st_mem_root*, TABLE*, st_schema_table*, st_mysql_const_lex_string*, st_mysql_const_lex_string*, Open_tables_backup*, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:5006:7
    #7 0xbbc6cc in get_all_tables(THD*, TABLE_LIST*, Item*) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:5372:20
    #8 0xbd8ae4 in get_schema_tables_result(JOIN*, enum_schema_table_state) /home/dan/repos/mariadb-server-10.4/sql/sql_show.cc:9224:11
    #9 0xb17c2e in JOIN::exec_inner() /home/dan/repos/mariadb-server-10.4/sql/sql_select.cc:4582:7
    #10 0xab759a in JOIN::exec() /home/dan/repos/mariadb-server-10.4/sql/sql_select.cc:4407:3
    #11 0xab759a in mysql_select(THD*, TABLE_LIST*, unsigned int, List<Item>&, Item*, unsigned int, st_order*, st_order*, Item*, st_order*, unsigned long long, select_result*, st_select_lex_unit*, st_select_lex*) /home/dan/repos/mariadb-server-10.4/sql/sql_select.cc:4846:9

Indirect leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x75f022 in malloc (/home/dan/repos/build-mariadb-server-10.4-debug/sql/mysqld+0x75f022) (BuildId: 33dbf266cfd6a1942a1a044db6d53b4abfba362e)
    #1 0x20aa238 in my_malloc /home/dan/repos/mariadb-server-10.4/mysys/my_malloc.c:101:10
    #2 0x926965 in THD::init() /home/dan/repos/mariadb-server-10.4/sql/sql_class.cc:1214:3
    #3 0x9251ba in THD::THD(unsigned long long, bool) /home/dan/repos/mariadb-server-10.4/sql/sql_class.cc:809:3

SUMMARY: AddressSanitizer: 38344 byte(s) leaked in 35 allocation(s).
```


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
