### PR TITLE
MDEV-26740  Inplace alter rebuild increases file size

### DIFF
--- a/mysql-test/suite/innodb_zip/r/innochecksum_3.result
+++ b/mysql-test/suite/innodb_zip/r/innochecksum_3.result
@@ -120,7 +120,6 @@ Filename::tab#.ibd
 #::#		|		Index page			|	index id=#, page level=#, No. of records=#, garbage=#, -
 #::#		|		Index page			|	index id=#, page level=#, No. of records=#, garbage=#, -
 #::#		|		Freshly allocated page		|	-
-#::#		|		Freshly allocated page		|	-
 # Variables used by page type dump for ibdata1
 
 Variables (--variable-name=value)
@@ -153,7 +152,6 @@ Filename::tab#.ibd
 #::#		|		Index page			|	index id=#, page level=#, No. of records=#, garbage=#, -
 #::#		|		Index page			|	index id=#, page level=#, No. of records=#, garbage=#, -
 #::#		|		Index page			|	index id=#, page level=#, No. of records=#, garbage=#, -
-#::#		|		Freshly allocated page		|	-
 #::#		|		Freshly allocated page		|	-
 [6]: check the valid lower bound values for option
 # allow-mismatches,page,start-page,end-page


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-26740*
## Description
PageBulk::init(): Unnecessary reserves the extent before allocating a page for bulk insert. btr_page_alloc() capable of handing the extending of tablespace.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
