### PR TITLE
sql_test.cc compile fix for Debug macos

### DIFF
--- a/sql/sql_test.cc
+++ b/sql/sql_test.cc
@@ -29,14 +29,14 @@
 #include <thr_alarm.h>
 #include "sql_connect.h"
 #include "thread_cache.h"
-#if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
-#if defined(HAVE_MALLOC_H)
+#if (defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)) && defined(HAVE_MALLOC_H)
 #include <malloc.h>
-#elif defined(HAVE_SYS_MALLOC_H)
-#include <sys/malloc.h>
-#elif defined(HAVE_MALLOC_ZONE)
-#include <malloc/malloc.h>
 #endif
+#if defined(HAVE_SYS_MALLOC_H)
+#include <sys/malloc.h>
+#endif
+#if defined(HAVE_MALLOC_ZONE)
+#include <malloc/malloc.h>
 #endif
 
 #ifdef HAVE_EVENT_SCHEDULER


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The merge up of 1fec50120fb4b08ea76cc79cf65905a0d5027e84 incorrectly included the HAVE_MALLOC_ZONE into the condition of the HAVE_MALLINFO{,} headers. This was incorrect and needed to be separate.

Closes #2937


## How can this PR be tested?

compile test debug on macos
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.