### PR TITLE
plugin cracklib password check - selinux

### DIFF
--- a/plugin/cracklib_password_check/CMakeLists.txt
+++ b/plugin/cracklib_password_check/CMakeLists.txt
@@ -32,7 +32,7 @@ IF (HAVE_ALLOCA_H AND HAVE_CRACK_H AND HAVE_LIBCRACK AND HAVE_MEMCPY)
     IF(CHECKMODULE AND SEMODULE_PACKAGE)
       FOREACH(pol mariadb-plugin-cracklib-password-check)
         SET(src ${CMAKE_CURRENT_SOURCE_DIR}/policy/selinux/${pol}.te)
-        SET(tmp ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pol}-pp.dir/${pol}.mod)
+        SET(tmp ${CMAKE_CURRENT_BINARY_DIR}/${pol}.mod)
         SET(out ${CMAKE_CURRENT_BINARY_DIR}/${pol}.pp)
         ADD_CUSTOM_COMMAND(OUTPUT ${out}
           COMMAND ${CHECKMODULE} -M -m ${src} -o ${tmp}


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Out of tree builds of -DRPM, with selinux can fail as follows:

[627/2102] Generating mariadb-plugin-cracklib-password-check.pp FAILED: plugin/cracklib_password_check/mariadb-plugin-cracklib-password-check.pp build-mariadb-server-11.4/plugin/cracklib_password_check/mariadb-plugin-cracklib-password-check.pp cd build-mariadb-server-11.4/plugin/cracklib_password_check && /usr/bin/checkmodule -M -m gmariadb-server-11.4/plugin/cracklib_password_check/policy/selinux/mariadb-plugin-cracklib-password-check.te -o build-mariadb-server-11.4/plugin/cracklib_password_check/CMakeFiles/mariadb-plugin-cracklib-password-check-pp.dir/mariadb-plugin-cracklib-password-check.mod && /usr/bin/semodule_package -m build-mariadb-server-11.4/plugin/cracklib_password_check/CMakeFiles/mariadb-plugin-cracklib-password-check-pp.dir/mariadb-plugin-cracklib-password-check.mod -o build-mariadb-server-11.4/plugin/cracklib_password_check/mariadb-plugin-cracklib-password-check.pp /usr/bin/checkmodule:  error opening build-mariadb-server-11.4/plugin/cracklib_password_check/CMakeFiles/mariadb-plugin-cracklib-password-check-pp.dir/mariadb-plugin-cracklib-password-check.mod:  No such file or directory [642/2102] Building CXX object storage/rocksdb/CMakeFiles/rocksdb_tools.dir/rocksdb/tools/ldb_cmd.cc.o ninja: build stopped: subcommand failed.

There isn't a directory to put the temporary artifact in.

There's no need for the temporary artifact to be outside the CMAKE_CURRENT_BINARY_DIR so we just use that path.


## How can this PR be tested?

build with cracklib, -DRPM=, out of tree, with ninja.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
