### PR TITLE
MDEV-33098 The test innodb.doublewrite_debug occasionally fails to start up InnoDB

### DIFF
--- a/mysql-test/suite/innodb/r/doublewrite_debug.result
+++ b/mysql-test/suite/innodb/r/doublewrite_debug.result
@@ -23,7 +23,7 @@ commit work;
 # Test Begin: Test if recovery works if 1st page and 2nd page
 # of system tablespace is full of zeroes.
 SET GLOBAL innodb_fast_shutdown = 0;
-# restart
+# restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
 begin;
 insert into t1 values (6, repeat('%', 400));
 # Make the first page dirty for system tablespace
@@ -33,6 +33,7 @@ set global innodb_fil_make_page_dirty_debug = 0;
 set global innodb_saved_page_number_debug = 1;
 set global innodb_fil_make_page_dirty_debug = 0;
 set global innodb_buf_flush_list_now = 1;
+# Kill the server
 # Make the 1st page (page_no=0) and 2nd page (page_no=1)
 # of the system tablespace all zeroes.
 # restart
@@ -52,7 +53,7 @@ f1	f2
 # ---------------------------------------------------------------
 # Test Begin: Test if recovery works if 1st page of
 # system tablespace is corrupted and 2nd page as corrupted.
-set global innodb_log_checkpoint_now = 1;
+# restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
 begin;
 insert into t1 values (6, repeat('%', 400));
 # Make the first page dirty for system tablespace
@@ -62,6 +63,7 @@ set global innodb_fil_make_page_dirty_debug = 0;
 set global innodb_saved_page_number_debug = 1;
 set global innodb_fil_make_page_dirty_debug = 0;
 set global innodb_buf_flush_list_now = 1;
+# Kill the server
 # Corrupt the 1st page (page_no=0) and 2nd page of the system tablespace.
 # restart
 FOUND 2 /InnoDB: Restoring page \[page id: space=0, page number=0\] of datafile/ in mysqld.1.err
@@ -83,7 +85,7 @@ drop table t1;
 # MDEV-12600 crash during install_db with innodb_page_size=32K
 # and ibdata1=3M
 #
-# restart: --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/doublewrite --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/doublewrite --innodb-data-file-path=ibdata1:1M;ibdata2:1M:autoextend
+# restart: --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/doublewrite --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/doublewrite --innodb-undo-tablespaces=0 --innodb-data-file-path=ibdata1:1M;ibdata2:1M:autoextend
 SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');

--- a/mysql-test/suite/innodb/t/doublewrite_debug.test
+++ b/mysql-test/suite/innodb/t/doublewrite_debug.test
@@ -44,7 +44,9 @@ commit work;
 # Slow shutdown and restart to make sure ibuf merge is finished
 SET GLOBAL innodb_fast_shutdown = 0;
 let $shutdown_timeout=;
+let $restart_parameters="--debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0";
 --source include/restart_mysqld.inc
+--source ../include/no_checkpoint_start.inc
 begin;
 insert into t1 values (6, repeat('%', 400));
 
@@ -57,8 +59,20 @@ set global innodb_saved_page_number_debug = 1;
 set global innodb_fil_make_page_dirty_debug = 0;
 
 set global innodb_buf_flush_list_now = 1;
-let $shutdown_timeout=0;
---source include/shutdown_mysqld.inc
+
+--let CLEANUP_IF_CHECKPOINT=drop table t1, unexpected_checkpoint;
+# Occasionally, a checkpoint would occur on the MSAN builder.
+# We do not know the reason, because the failure can only be reproduced if there is
+# enough load in that environment.
+# Therefore, we allow the test to be skipped when run on MSAN.
+# In other environments, we want the test to fail if a checkpoint occurs,
+# so that we would catch it if it starts to happen regularly.
+if (`select count(*) from information_schema.system_variables where variable_name='have_sanitizer' and global_value like "MSAN%"`)
+{
+--let CLEANUP_IF_CHECKPOINT=drop table t1;
+}
+
+--source ../include/no_checkpoint_end.inc
 
 --echo # Make the 1st page (page_no=0) and 2nd page (page_no=1)
 --echo # of the system tablespace all zeroes.
@@ -74,6 +88,7 @@ print FILE chr(0) x ($ENV{'INNODB_PAGE_SIZE'});
 close FILE;
 EOF
 
+let $restart_parameters=;
 --source include/start_mysqld.inc
 
 let SEARCH_PATTERN=InnoDB: Restoring page \[page id: space=0, page number=0\] of datafile;
@@ -90,7 +105,9 @@ select f1, f2 from t1;
 --echo # Test Begin: Test if recovery works if 1st page of
 --echo # system tablespace is corrupted and 2nd page as corrupted.
 
-set global innodb_log_checkpoint_now = 1;
+let $restart_parameters="--debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0";
+--source include/restart_mysqld.inc
+--source ../include/no_checkpoint_start.inc
 begin;
 insert into t1 values (6, repeat('%', 400));
 
@@ -103,8 +120,8 @@ set global innodb_saved_page_number_debug = 1;
 set global innodb_fil_make_page_dirty_debug = 0;
 
 set global innodb_buf_flush_list_now = 1;
-let $shutdown_timeout=0;
---source include/shutdown_mysqld.inc
+
+--source ../include/no_checkpoint_end.inc
 
 --echo # Corrupt the 1st page (page_no=0) and 2nd page of the system tablespace.
 perl;
@@ -119,6 +136,7 @@ print FILE chr(0) x ($ENV{'INNODB_PAGE_SIZE'}/2);
 close FILE;
 EOF
 
+let $restart_parameters=;
 --source include/start_mysqld.inc
 
 let SEARCH_PATTERN=InnoDB: Restoring page \[page id: space=0, page number=0\] of datafile;
@@ -145,7 +163,7 @@ WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 
 --let $ibp=--innodb-log-group-home-dir=$bugdir --innodb-data-home-dir=$bugdir
---let $ibd=$ibp --innodb-undo-tablespaces=0
+--let $ibp=$ibp --innodb-undo-tablespaces=0
 --let $ibp=$ibp --innodb-data-file-path=ibdata1:1M;ibdata2:1M:autoextend
 
 --let $restart_parameters= $ibp


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33098*

## Description
- innodb.doublewrite_debug should avoid the checkpoint before killing the server. So used debug sync and innodb_flush_sync to avoid the checkpoint completely.

## How can this PR be tested?
./mtr innodb.doublewrite_debug
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
