### PR TITLE
MDEV-32892 IO Thread Reports False Error When Stopped During Connecting to Primary

### DIFF
--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -7390,7 +7390,7 @@ static int connect_to_master(THD* thd, MYSQL* mysql, Master_info* mi,
                              mi->port, 0, client_flag) == 0))
   {
     /* Don't repeat last error */
-    if ((int)mysql_errno(mysql) != last_errno)
+    if ((int)mysql_errno(mysql) != last_errno && !mi->abort_slave)
     {
       last_errno=mysql_errno(mysql);
       suppress_warnings= 0;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32892*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This PR addresses an issue where the replication system incorrectly logs a connection error (Errno: 2013) when the slave IO thread is manually stopped by the user during the connection handshake process. The problem arises because the system treats a user-initiated stop as a connection error.

The fix involves modifying the `connect_to_master `function to check the `mi->abort_slave` flag, which is set true when a user issues a stop command for the slave IO thread. The function now bypasses error logging if `mi->abort_slave` is true, thereby avoiding misleading error messages for user-initiated actions. 

## How can this PR be tested?

This PR can be tested by starting and then quickly stopping the slave IO thread, and then verifying that no connection error is logged in this case. 
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct. (Currently the earliest maintained branch is 10.3)
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
