### PR TITLE
MDEV-33160 show_status_array() calls various functions via incompatible pointer

### DIFF
--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11869,8 +11869,8 @@ static my_bool count_column_grants(void *grant_table,
   This must be performed under the mutex in order to make sure the
   iteration does not fail.
 */
-static int show_column_grants(THD *thd, SHOW_VAR *var, char *buff,
-                              enum enum_var_type scope)
+static int show_column_grants(THD *thd, SHOW_VAR *var, void *buff,
+                              system_status_var *, enum enum_var_type scope)
 {
   var->type= SHOW_ULONG;
   var->value= buff;
@@ -11886,8 +11886,8 @@ static int show_column_grants(THD *thd, SHOW_VAR *var, char *buff,
   return 0;
 }
 
-static int show_database_grants(THD *thd, SHOW_VAR *var, char *buff,
-                                enum enum_var_type scope)
+static int show_database_grants(THD *thd, SHOW_VAR *var, void *buff,
+                                system_status_var *, enum enum_var_type scope)
 {
   var->type= SHOW_UINT;
   var->value= buff;

--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -1345,8 +1345,8 @@ int tdc_iterate(THD *thd, my_hash_walk_action action, void *argument,
 }
 
 
-int show_tc_active_instances(THD *thd, SHOW_VAR *var, char *buff,
-                             enum enum_var_type scope)
+int show_tc_active_instances(THD *thd, SHOW_VAR *var, void *buff,
+                             system_status_var *, enum enum_var_type scope)
 {
   var->type= SHOW_UINT;
   var->value= buff;

--- a/sql/table_cache.h
+++ b/sql/table_cache.h
@@ -97,8 +97,8 @@ extern int tdc_iterate(THD *thd, my_hash_walk_action action, void *argument,
                        bool no_dups= false);
 
 extern uint tc_records(void);
-int show_tc_active_instances(THD *thd, SHOW_VAR *var, char *buff,
-                             enum enum_var_type scope);
+int show_tc_active_instances(THD *thd, SHOW_VAR *var, void *buff,
+                             system_status_var *, enum enum_var_type scope);
 extern void tc_purge(bool mark_flushed= false);
 extern void tc_add_table(THD *thd, TABLE *table);
 extern void tc_release_table(TABLE *table);

--- a/sql/threadpool.h
+++ b/sql/threadpool.h
@@ -64,9 +64,6 @@ extern int tp_get_thread_count();
 /* Activate threadpool scheduler */
 extern void tp_scheduler(void);
 
-extern int show_threadpool_idle_threads(THD *thd, SHOW_VAR *var, char *buff,
-                                        enum enum_var_type scope);
-
 enum  TP_PRIORITY {
   TP_PRIORITY_HIGH,
   TP_PRIORITY_LOW,

--- a/storage/sphinx/ha_sphinx.cc
+++ b/storage/sphinx/ha_sphinx.cc
@@ -3548,7 +3548,8 @@ CSphSEStats * sphinx_get_stats ( THD * thd, SHOW_VAR * out )
 	return 0;
 }
 
-int sphinx_showfunc_total ( THD * thd, SHOW_VAR * out, char * )
+static int sphinx_showfunc_total ( THD * thd, SHOW_VAR * out, void *,
+                                   system_status_var *, enum_var_type )
 {
 	CSphSEStats * pStats = sphinx_get_stats ( thd, out );
 	if ( pStats )
@@ -3559,7 +3560,8 @@ int sphinx_showfunc_total ( THD * thd, SHOW_VAR * out, char * )
 	return 0;
 }
 
-int sphinx_showfunc_total_found ( THD * thd, SHOW_VAR * out, char * )
+static int sphinx_showfunc_total_found ( THD * thd, SHOW_VAR * out, void *,
+                                         system_status_var *, enum_var_type )
 {
 	CSphSEStats * pStats = sphinx_get_stats ( thd, out );
 	if ( pStats )
@@ -3570,7 +3572,8 @@ int sphinx_showfunc_total_found ( THD * thd, SHOW_VAR * out, char * )
 	return 0;
 }
 
-int sphinx_showfunc_time ( THD * thd, SHOW_VAR * out, char * )
+static int sphinx_showfunc_time ( THD * thd, SHOW_VAR * out, void *,
+                                  system_status_var *, enum_var_type )
 {
 	CSphSEStats * pStats = sphinx_get_stats ( thd, out );
 	if ( pStats )
@@ -3581,7 +3584,8 @@ int sphinx_showfunc_time ( THD * thd, SHOW_VAR * out, char * )
 	return 0;
 }
 
-int sphinx_showfunc_word_count ( THD * thd, SHOW_VAR * out, char * )
+static int sphinx_showfunc_word_count ( THD * thd, SHOW_VAR * out, void *,
+                                        system_status_var *, enum_var_type )
 {
 	CSphSEStats * pStats = sphinx_get_stats ( thd, out );
 	if ( pStats )
@@ -3592,9 +3596,11 @@ int sphinx_showfunc_word_count ( THD * thd, SHOW_VAR * out, char * )
 	return 0;
 }
 
-int sphinx_showfunc_words ( THD * thd, SHOW_VAR * out, char * sBuffer )
+static int sphinx_showfunc_words ( THD * thd, SHOW_VAR * out, void * buf,
+                                   system_status_var *, enum_var_type )
 {
 #if MYSQL_VERSION_ID>50100
+	char *sBuffer = static_cast<char*>(buf);
 	if ( sphinx_hton_ptr )
 	{
 		CSphTLS * pTls = (CSphTLS *) *thd_ha_data ( thd, sphinx_hton_ptr );
@@ -3649,7 +3655,8 @@ int sphinx_showfunc_words ( THD * thd, SHOW_VAR * out, char * sBuffer )
 	return 0;
 }
 
-int sphinx_showfunc_error ( THD * thd, SHOW_VAR * out, char * )
+static int sphinx_showfunc_error ( THD * thd, SHOW_VAR * out, void *,
+                                   system_status_var *, enum_var_type )
 {
 	CSphSEStats * pStats = sphinx_get_stats ( thd, out );
 	out->type = SHOW_CHAR;

--- a/storage/sphinx/ha_sphinx.h
+++ b/storage/sphinx/ha_sphinx.h
@@ -164,12 +164,6 @@ private:
 bool sphinx_show_status ( THD * thd );
 #endif
 
-int sphinx_showfunc_total_found ( THD *, SHOW_VAR *, char * );
-int sphinx_showfunc_total ( THD *, SHOW_VAR *, char * );
-int sphinx_showfunc_time ( THD *, SHOW_VAR *, char * );
-int sphinx_showfunc_word_count ( THD *, SHOW_VAR *, char * );
-int sphinx_showfunc_words ( THD *, SHOW_VAR *, char * );
-
 //
 // $Id: ha_sphinx.h 4818 2014-09-24 08:53:38Z tomat $
 //

--- a/storage/spider/spd_param.cc
+++ b/storage/spider/spd_param.cc
@@ -115,7 +115,8 @@ extern volatile ulonglong spider_mon_table_cache_version_req;
   }
 
 #ifdef HANDLER_HAS_DIRECT_UPDATE_ROWS
-static int spider_direct_update(THD *thd, SHOW_VAR *var, char *buff)
+static int spider_direct_update(THD *thd, SHOW_VAR *var, void *,
+                                system_status_var *, enum_var_type)
 {
   int error_num = 0;
   SPIDER_TRX *trx;
@@ -126,7 +127,8 @@ static int spider_direct_update(THD *thd, SHOW_VAR *var, char *buff)
   DBUG_RETURN(error_num);
 }
 
-static int spider_direct_delete(THD *thd, SHOW_VAR *var, char *buff)
+static int spider_direct_delete(THD *thd, SHOW_VAR *var, void *,
+                                system_status_var *, enum_var_type)
 {
   int error_num = 0;
   SPIDER_TRX *trx;
@@ -138,7 +140,8 @@ static int spider_direct_delete(THD *thd, SHOW_VAR *var, char *buff)
 }
 #endif
 
-static int spider_direct_order_limit(THD *thd, SHOW_VAR *var, char *buff)
+static int spider_direct_order_limit(THD *thd, SHOW_VAR *var, void *,
+                                     system_status_var *, enum_var_type)
 {
   int error_num = 0;
   SPIDER_TRX *trx;
@@ -149,7 +152,8 @@ static int spider_direct_order_limit(THD *thd, SHOW_VAR *var, char *buff)
   DBUG_RETURN(error_num);
 }
 
-static int spider_direct_aggregate(THD *thd, SHOW_VAR *var, char *buff)
+static int spider_direct_aggregate(THD *thd, SHOW_VAR *var, void *,
+                                   system_status_var *, enum_var_type)
 {
   int error_num = 0;
   SPIDER_TRX *trx;
@@ -160,7 +164,8 @@ static int spider_direct_aggregate(THD *thd, SHOW_VAR *var, char *buff)
   DBUG_RETURN(error_num);
 }
 
-static int spider_parallel_search(THD *thd, SHOW_VAR *var, char *buff)
+static int spider_parallel_search(THD *thd, SHOW_VAR *var, void *,
+                                  system_status_var *, enum_var_type)
 {
   int error_num = 0;
   SPIDER_TRX *trx;
@@ -172,7 +177,8 @@ static int spider_parallel_search(THD *thd, SHOW_VAR *var, char *buff)
 }
 
 #if defined(HS_HAS_SQLCOM) && defined(HAVE_HANDLERSOCKET)
-static int spider_hs_result_free(THD *thd, SHOW_VAR *var, char *buff)
+static int spider_hs_result_free(THD *thd, SHOW_VAR *var, void *,
+                                 system_status_var *, enum_var_type)
 {
   int error_num = 0;
   SPIDER_TRX *trx;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33160*

## Description
In commit b4ff64568c88ab3ce559e7bd39853d9cbf86704a the signature of mysql_show_var_func was changed, but not all functions of that type were adjusted.

When the server is configured with `cmake -DWITH_ASAN=ON` and compiled with clang, runtime errors would be flagged for invoking functions through an incompatible function pointer.

## How can this PR be tested?
This is covered by the regression test suite. I noticed the problem by running `./mtr --suite=perfschema` and searching the logs. I had applied the following patch in order to ignore all other errors that `clang -fsanitize=undefined` would catch:
```diff
diff --git a/mysql-test/mysql-test-run.pl b/mysql-test/mysql-test-run.pl
index cdd8f0bf6cd..2ad0651afb6 100755
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4370,8 +4370,7 @@ sub extract_warning_lines ($$) {
      qr/missing DBUG_RETURN/,
      qr/Attempting backtrace/,
      qr/Assertion .* failed/,
-     qr/Sanitizer/,
-     qr/runtime error:/,
+     qr/(Address|Leak)Sanitizer/,
     );
   # These are taken from the include/mtr_warnings.sql global suppression
   # list. They occur delayed, so they can be parsed during shutdown rather
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.