### PR TITLE
Server crashes with innodb-force-recovery=6 and enabling the innodb_truncate_temporary_tablespace_now variable

### DIFF
--- a/mysql-test/suite/innodb/r/temp_truncate.result
+++ b/mysql-test/suite/innodb/r/temp_truncate.result
@@ -36,3 +36,17 @@ SELECT COUNT(*) FROM t1;
 COUNT(*)
 65536
 DROP TABLE t1;
+# MDEV-33101 Server crashes when starting the server with
+# innodb-force-recovery=6 and enabling the
+# innodb_truncate_temporary_tablespace_now variable
+# restart: --innodb-force-recovery=6
+SHOW VARIABLES LIKE "innodb_read_only";
+Variable_name	Value
+innodb_read_only	ON
+SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
+# restart: --innodb-read-only
+SHOW VARIABLES LIKE "innodb_read_only";
+Variable_name	Value
+innodb_read_only	ON
+SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
+# restart

--- a/mysql-test/suite/innodb/t/temp_truncate.test
+++ b/mysql-test/suite/innodb/t/temp_truncate.test
@@ -32,3 +32,20 @@ connection default;
 COMMIT;
 SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
+
+--echo # MDEV-33101 Server crashes when starting the server with
+--echo # innodb-force-recovery=6 and enabling the
+--echo # innodb_truncate_temporary_tablespace_now variable
+
+--let $restart_parameters=--innodb-force-recovery=6
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE "innodb_read_only";
+SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
+
+--let $restart_parameters=--innodb-read-only
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE "innodb_read_only";
+SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18482,7 +18482,8 @@ static
 void
 innodb_trunc_temp_space_update(THD*, st_mysql_sys_var*, void*, const void* save)
 {
-  if (!*static_cast<const my_bool*>(save))
+  /* Temp tablespace is not initialized in read only mode. */
+  if (!*static_cast<const my_bool*>(save) || srv_read_only_mode)
     return;
   mysql_mutex_unlock(&LOCK_global_system_variables);
   fsp_shrink_temp_space();


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33101*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
4. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The issue is introduced by "MDEV-28699: Shrink temporary
tablespaces without restart". SRV_FORCE_NO_LOG_REDO forces
server to read only mode and we don't initialize temporary
tablespace in read only mode.

solution: innodb_truncate_temporary_tablespace_now should 
be no-op in read only mode.

## How can this PR be tested?
./mtr innodb.temp_truncate

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.