### PR TITLE
[MDEV-33435] RISC-V: use RDTIME instead of RDCYCLE

### DIFF
--- a/include/my_rdtsc.h
+++ b/include/my_rdtsc.h
@@ -111,7 +111,7 @@ C_MODE_START
   On AARCH64, we use the generic timer base register. We override clang
   implementation for aarch64 as it access a PMU register which is not
   guaranteed to be active.
-  On RISC-V, we use the rdcycle instruction to read from mcycle register.
+  On RISC-V, we use the rdtime instruction to read from mtime register.
 
   Sadly, we have nothing for the Digital Alpha, MIPS, Motorola m68k,
   HP PA-RISC or other non-mainstream (or obsolete) processors.
@@ -211,15 +211,15 @@ static inline ulonglong my_timer_cycles(void)
   }
 #elif defined(__riscv)
   #define MY_TIMER_ROUTINE_CYCLES MY_TIMER_ROUTINE_RISCV
-  /* Use RDCYCLE (and RDCYCLEH on riscv32) */
+  /* Use RDTIME (and RDTIMEH on riscv32) */
   {
 # if __riscv_xlen == 32
     ulong result_lo, result_hi0, result_hi1;
     /* Implemented in assembly because Clang insisted on branching. */
     __asm __volatile__(
-        "rdcycleh %0\n"
-        "rdcycle %1\n"
-        "rdcycleh %2\n"
+        "rdtimeh %0\n"
+        "rdtime %1\n"
+        "rdtimeh %2\n"
         "sub %0, %0, %2\n"
         "seqz %0, %0\n"
         "sub %0, zero, %0\n"
@@ -228,7 +228,7 @@ static inline ulonglong my_timer_cycles(void)
     return (static_cast<ulonglong>(result_hi1) << 32) | result_lo;
 # else
     ulonglong result;
-    __asm __volatile__("rdcycle %0" : "=r"(result));
+    __asm __volatile__("rdtime %0" : "=r"(result));
     return result;
   }
 # endif


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-33435*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Starting with Linux 6.6 [1], RDCYCLE is a privileged instruction on RISC-V and can't be used directly from userland. There is a sysctl option to change that as a transition period, but it will eventually disappear.

Use RDTIME instead, which while less accurate has the advantage of being synchronized between CPU (and thus monotonic) and of constant frequency.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=cc4c07c89aada16229084eeb93895c95b7eabaa3

## How can this PR be tested?

Running MariaDB on a riscv64 host running Linux 6.6+ without this change (or even just the testsuite) fails with a SIGILL. After applying this patch, the testsuite passes fully.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
