### PR TITLE
MDEV-33137: Assertion end_lsn == page_lsn failed in recv_recover_page

### DIFF
--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -378,8 +378,8 @@ static void trx_purge_free_segment(buf_block_t *rseg_hdr, buf_block_t *block,
     ut_ad(rseg_hdr->page.id() == rseg_hdr_id);
     block->page.lock.x_lock();
     ut_ad(block->page.id() == id);
-    mtr.memo_push(rseg_hdr, MTR_MEMO_PAGE_X_MODIFY);
-    mtr.memo_push(block, MTR_MEMO_PAGE_X_MODIFY);
+    mtr.memo_push(rseg_hdr, MTR_MEMO_PAGE_X_FIX);
+    mtr.memo_push(block, MTR_MEMO_PAGE_X_FIX);
   }
 
   while (!fseg_free_step(TRX_UNDO_SEG_HDR + TRX_UNDO_FSEG_HEADER +
@@ -502,7 +502,7 @@ loop:
   mtr.start();
   rseg_hdr->page.lock.x_lock();
   ut_ad(rseg_hdr->page.id() == rseg.page_id());
-  mtr.memo_push(rseg_hdr, MTR_MEMO_PAGE_X_MODIFY);
+  mtr.memo_push(rseg_hdr, MTR_MEMO_PAGE_X_FIX);
 
   goto loop;
 }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33137*
## Description
`trx_purge_free_segment()`, `trx_purge_truncate_rseg_history()`: Do not claim that the blocks will be modified in the mini-transaction, because that will not always be the case. Whenever there is a modification, `mtr_t::set_modified()` will flag it.

The debug assertion that failed in recovery is checking that all changes to data pages are covered by log records. Due to these incorrect calls, we would unnecessarily write unmodified data pages, which is something that commit 05fa4558e0e82302ece981deabce764491464eb2 aims to avoid.

The incorrect calls had originally been added in commit de31ca6a212118bd29876f964497050e446bda02 (MDEV-32820) and commit 86767bcc0f121db3ad83a74647a642754a0ce57f (MDEV-29593).
## How can this PR be tested?
This was tested by @elenst on the 10.11 and 11.2 branches by repeatedly killing and restarting the server during a DML write workload. This bug has also occasionally been caught by recovery tests in the regression test suite, like this:
```
innodb_zip.bug56680 '4k,innodb'          w9 [ fail ]  Found warnings/errors in server log file!
        Test ended at 2023-12-17 11:57:59
line
2023-12-17 11:57:58 0 [Warning] InnoDB: The last skipped log record LSN 1315593 is not equal to page LSN 1315626
2023-12-17 11:57:58 0 [Warning] InnoDB: The last skipped log record LSN 1315984 is not equal to page LSN 1316017
2023-12-17 11:57:58 0 [Warning] InnoDB: The last skipped log record LSN 1329658 is not equal to page LSN 1329707
^ Found warnings in /home/buildbot/amd64-ubuntu-2204/build/mysql-test/var/9/log/mysqld.1.err
ok
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
```