### PR TITLE
MDEV-30259 & MDEV-33187: mariadb-hotcopy fails for performance_schema/sys

### DIFF
--- a/scripts/mysqlhotcopy.sh
+++ b/scripts/mysqlhotcopy.sh
@@ -189,21 +189,38 @@ $opt{quiet} = 0 if $opt{debug};
 $opt{allowold} = 1 if $opt{keepold};
 
 # --- connect to the database ---
+## Socket takes precedence.
 my $dsn;
-$dsn  = ";host=" . (defined($opt{host}) ? $opt{host} : "localhost");
-$dsn .= ";port=$opt{port}" if $opt{port};
-$dsn .= ";mariadb_socket=$opt{socket}" if $opt{socket};
+my $prefix= 'mysql';
+
+if (eval {DBI->install_driver("MariaDB")}) {
+  $dsn ="DBI:MariaDB:;";
+  $prefix= 'mariadb';
+}
+else {
+  $dsn = "DBI:mysql:;";
+}
+
+if ($opt{socket} and -S $opt{socket})
+{
+  $dsn .= "${prefix}_socket=$opt{socket}";
+}
+else
+{
+  $dsn .= "host=" . $opt{host};
+  if ($opt{host} ne "localhost")
+  {
+    $dsn .= ";port=". $opt{port};
+  }
+}
+
+$dsn .= ";mariadb_read_default_group=mysqlhotcopy";
 
 # use mariadb_read_default_group=mysqlhotcopy so that [client] and
 # [mysqlhotcopy] groups will be read from standard options files.
-
-my $dbh = DBI->connect("DBI:MariaDB:$dsn;mariadb_read_default_group=mysqlhotcopy",
-                        $opt{user}, $opt{password},
-{
-    RaiseError => 1,
-    PrintError => 0,
-    AutoCommit => 1,
-});
+# make the connection to MariaDB
+my $dbh= DBI->connect($dsn, $opt{user}, $opt{password}, { RaiseError => 1, PrintError => 0}) ||
+                      die("Can't make a connection to the MariaDB server.\n The error: $DBI::errstr");
 
 # --- check that checkpoint table exists if specified ---
 if ( $opt{checkpoint} ) {

--- a/scripts/mysqlhotcopy.sh
+++ b/scripts/mysqlhotcopy.sh
@@ -288,6 +288,7 @@ if ( defined $opt{regexp} ) {
     $sth_dbs->execute;
     while ( my ($db_name) = $sth_dbs->fetchrow_array ) {
 	next if $db_name =~ m/^information_schema$/i;
+	next if $db_name =~ m/^performance_schema$/i;
 	push @db_desc, { 'src' => $db_name, 't_regex' => $t_regex } if ( $db_name =~ m/$opt{regexp}/o );
     }
 }

--- a/scripts/mysqlhotcopy.sh
+++ b/scripts/mysqlhotcopy.sh
@@ -289,6 +289,7 @@ if ( defined $opt{regexp} ) {
     while ( my ($db_name) = $sth_dbs->fetchrow_array ) {
 	next if $db_name =~ m/^information_schema$/i;
 	next if $db_name =~ m/^performance_schema$/i;
+	next if $db_name =~ m/^sys$/i;
 	push @db_desc, { 'src' => $db_name, 't_regex' => $t_regex } if ( $db_name =~ m/$opt{regexp}/o );
     }
 }


### PR DESCRIPTION
This PR consists of 3 PR:
## 1. Make mariadb-hotcopy compatible with DBI:MariaDB
- I tried to allow DBI for mariadb-hotcopy the same as for other scripts.
<details closed>
<summary>Check driver compatibility</summary>
<br>
Install DB and run server locally :heavy_check_mark: 
<pre>
$ ./scripts/mysql_install_db --srcdir=../../src/10.11 --defaults-file=~/.my1011-hs.cnf
Installing MariaDB/MySQL system tables in '/tmp/10.11' ...
OK
$ ./sql/mysqld --defaults-file=~/.my1011-hs.cnf
</pre>

1. User not allowed to connect through socket :heavy_check_mark: 
<pre>
$ ./scripts/mysqlhotcopy  "--regex=.*" ./tmp 
DBI connect(';host=;port=;mariadb_read_default_group=mysqlhotcopy','',...) failed: Access denied for user 'anel'@'localhost' (using password: NO) at ./scripts/mysqlhotcopy line 222.
</pre>

2. User cannot connect through socket :heavy_check_mark: 
<pre>
$ ./scripts/mysqlhotcopy  "--regex=.*" ./tmp 
DBI connect(';host=;port=;mariadb_read_default_group=mysqlhotcopy','',...) failed: Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2) at ./scripts/mysqlhotcopy line 22
</pre>

3. Create new user `test@localhost` and connect through host and port :heavy_check_mark: 
<pre>
# There is no table
$ ./scripts/mysqlhotcopy  "--regex=.*" -h 127.0.0.1 -P 3306 -u test -p mypassword ./tmp 
No tables to hot-copy at ./scripts/mysqlhotcopy line 60.

# Create table for that user in test table
$ ./scripts/mysqlhotcopy  "--regex=.*" -h 127.0.0.1 -P 3306 -u test -p mypassword ./tmp 
No tables to hot-copy at ./scripts/mysqlhotcopy line 60.

# Give user test@localhost privilege
MariaDB [(none)]> grant RELOAD on test.* to test@localhost;
ERROR 1221 (HY000): Incorrect usage of DB GRANT and GLOBAL PRIVILEGES
MariaDB [(none)]> grant RELOAD on *.* to test@localhost;
Query OK, 0 rows affected (0.015 sec)
MariaDB [(none)]> show grants for test@localhost;
+--------------------------------------------------------------------------------------------------------------+
| Grants for test@localhost                                                                                    |
+--------------------------------------------------------------------------------------------------------------+
| GRANT RELOAD ON *.* TO `test`@`localhost` IDENTIFIED BY PASSWORD '*FABE5482D5AADF36D028AC443D117BE1180B9725' |
+--------------------------------------------------------------------------------------------------------------+
1 row in set (0.000 sec)

# Apply patches 2. and 3. and it will work
$ ./scripts/mysqlhotcopy  "--regex=.*" -h 127.0.0.1 -P 3306 -u test -p mypassword --allowold ./tmp 
Deleting previous 'old' hotcopy directory ('./tmp/test_old')
...
mysqlhotcopy copied 1 tables (3 files) in 0 seconds (0 seconds overall).
</pre>
</details>
- Still there is the problem :x: 
<details open>
<summary>performance schema missing</summary>
<br>
<pre>
$ ./scripts/mysqlhotcopy  "--regex=.*" -S /tmp/mysql.sock  --allowold ./tmp
DBD::mysql::db do failed:  command denied to user 'anel'@'localhost' for table `performance_schema`.`accounts` at ./scripts/mysqlhotcopy line 540.
</pre>
</details>

## 2. MDEV-30259: mariadb-hotcopy fails for performance_schema
- Contributed by Paul Szabo <psz@maths.usyd.edu.au>
- Solves the problem from 1. ( :heavy_check_mark: )  but there is another problem :x: 
<details open>
<summary>sys schema missing</summary>
<br>
<pre>
$ ./scripts/mysqlhotcopy  "--regex=.*" -S /tmp/mysql.sock  --allowold ./tmp
Deleting previous 'old' hotcopy directory ('./tmp/mysql_old')
...
DBD::mysql::db do failed: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ' `sys`.`host_summary` READ, `sys`.`host_summary_by_file_io` READ, `sys`.`host...' at line 1 at ./scripts/mysqlhotcopy line 547.
....
</pre>
</details>

## 3.  MDEV-33187: mariadb-hotcopy fails for sys
- Contributed by Paul Szabo <psz@maths.usyd.edu.au>
- Solves problem from 2. :heavy_check_mark: 
```bash
$ ./scripts/mysqlhotcopy  "--regex=.*" -S /tmp/mysql.sock  --allowold ./tmp
Deleting previous 'old' hotcopy directory ('./tmp/mysql_old')
Existing hotcopy directory renamed to './tmp/mysql_old'
Deleting previous 'old' hotcopy directory ('./tmp/test_old')
Existing hotcopy directory renamed to './tmp/test_old'
2024-01-11 13:01:47 9 [Note] InnoDB: Sync to disk of `mysql`.`gtid_slave_pos` started.
2024-01-11 13:01:47 9 [Note] InnoDB: Stopping purge
2024-01-11 13:01:47 9 [Note] InnoDB: Writing table metadata to './mysql/gtid_slave_pos.cfg'
2024-01-11 13:01:47 9 [Note] InnoDB: Table `mysql`.`gtid_slave_pos` flushed to disk
2024-01-11 13:01:47 9 [Note] InnoDB: Sync to disk of `mysql`.`innodb_index_stats` started.
2024-01-11 13:01:47 9 [Note] InnoDB: Writing table metadata to './mysql/innodb_index_stats.cfg'
2024-01-11 13:01:47 9 [Note] InnoDB: Table `mysql`.`innodb_index_stats` flushed to disk
2024-01-11 13:01:47 9 [Note] InnoDB: Sync to disk of `mysql`.`innodb_table_stats` started.
2024-01-11 13:01:47 9 [Note] InnoDB: Writing table metadata to './mysql/innodb_table_stats.cfg'
2024-01-11 13:01:47 9 [Note] InnoDB: Table `mysql`.`innodb_table_stats` flushed to disk
Flushed 27 tables with read lock (`mysql`.`column_stats`, `mysql`.`columns_priv`, `mysql`.`db`, `mysql`.`event`, `mysql`.`func`, `mysql`.`global_priv`, `mysql`.`gtid_slave_pos`, `mysql`.`help_category`, `mysql`.`help_keyword`, `mysql`.`help_relation`, `mysql`.`help_topic`, `mysql`.`index_stats`, `mysql`.`innodb_index_stats`, `mysql`.`innodb_table_stats`, `mysql`.`plugin`, `mysql`.`proc`, `mysql`.`procs_priv`, `mysql`.`proxies_priv`, `mysql`.`roles_mapping`, `mysql`.`servers`, `mysql`.`table_stats`, `mysql`.`tables_priv`, `mysql`.`time_zone`, `mysql`.`time_zone_leap_second`, `mysql`.`time_zone_name`, `mysql`.`time_zone_transition`, `mysql`.`time_zone_transition_type`) in 0 seconds.
2024-01-11 13:01:47 9 [Note] InnoDB: Deleting the meta-data file './mysql/gtid_slave_pos.cfg'
2024-01-11 13:01:47 9 [Note] InnoDB: Deleting the meta-data file './mysql/innodb_index_stats.cfg'
2024-01-11 13:01:47 9 [Note] InnoDB: Deleting the meta-data file './mysql/innodb_table_stats.cfg'
2024-01-11 13:01:47 9 [Note] InnoDB: Resuming purge
Locked 1 views (`mysql`.`user`) in 0 seconds.
Copying 88 files...
Copying indices for 0 files...
Copying 1 files...
Copying indices for 0 files...
Unlocked tables.
mysqlhotcopy copied 56 tables (89 files) in 0 seconds (0 seconds overall).
```
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
