### PR TITLE
MDEV-29369: rpl.rpl_semi_sync_shutdown_await_ack fails regularly with…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_shutdown_await_ack.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_shutdown_await_ack.result
@@ -111,14 +111,12 @@ count(*)=1
 #-- Re-synchronize slaves with master and disable semi-sync
 #-- Stop slaves
 connection server_2;
-#-- Waiting for IO thread to realize master shutdown and stop
-include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-#-- Waiting for IO thread to realize master shutdown and stop
-include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
@@ -235,13 +233,12 @@ set debug_sync= "now signal continue_semisync_kill_connection";
 set debug_sync= "reset";
 #-- Stop slaves
 connection server_2;
-include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-#-- Waiting for IO thread to stop from corrupt_queue_event injection
-include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
@@ -354,13 +351,12 @@ set debug_sync= "now signal continue_semisync_kill_connection";
 set debug_sync= "reset";
 #-- Stop slaves
 connection server_2;
-include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-#-- Waiting for IO thread to realize master shutdown and stop
-include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
@@ -479,13 +475,12 @@ set debug_sync= "now signal continue_semisync_kill_connection";
 set debug_sync= "reset";
 #-- Stop slaves
 connection server_2;
-include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-#-- Waiting for IO thread to realize master shutdown and stop
-include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_io.inc
 include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;

--- a/mysql-test/suite/rpl/r/rpl_semi_sync_shutdown_await_ack.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_shutdown_await_ack.result
@@ -9,9 +9,6 @@ connection server_1;
 call mtr.add_suppression("Timeout waiting");
 call mtr.add_suppression("did not exit");
 call mtr.add_suppression("Got an error reading communication packets");
-set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
-set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
-set @sav_master_dbug= @@GLOBAL.debug_dbug;
 # Suppress slave errors related to the simulated error
 connection server_2;
 call mtr.add_suppression("reply failed");
@@ -129,9 +126,6 @@ SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 connection server_1_con2;
 connection default;
 connection server_1;
-set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
-set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
-set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -255,9 +249,6 @@ SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 connection server_1_con2;
 connection default;
 connection server_1;
-set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
-set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
-set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -377,9 +368,6 @@ SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 connection server_1_con2;
 connection default;
 connection server_1;
-set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
-set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
-set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -505,9 +493,6 @@ SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 connection server_1_con2;
 connection default;
 connection server_1;
-set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
-set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
-set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -540,8 +525,5 @@ SET @@GLOBAL.rpl_semi_sync_slave_enabled = @sav_enabled_server_3;
 SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 include/start_slave.inc
 connection server_1;
-SET @@GLOBAL.rpl_semi_sync_master_timeout= @sav_master_timeout;
-SET @@GLOBAL.rpl_semi_sync_master_enabled= @sav_enabled_master;
-SET @@GLOBAL.debug_dbug= @sav_master_dbug;
 drop table t1;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_semi_sync_shutdown_await_ack.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_shutdown_await_ack.result
@@ -9,17 +9,24 @@ connection server_1;
 call mtr.add_suppression("Timeout waiting");
 call mtr.add_suppression("did not exit");
 call mtr.add_suppression("Got an error reading communication packets");
+set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
+set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
+set @sav_master_dbug= @@GLOBAL.debug_dbug;
 # Suppress slave errors related to the simulated error
 connection server_2;
 call mtr.add_suppression("reply failed");
 call mtr.add_suppression("Replication event checksum verification");
 call mtr.add_suppression("Relay log write failure");
 call mtr.add_suppression("Failed to kill the active semi-sync connection");
+set @sav_enabled_server_2= @@GLOBAL.rpl_semi_sync_slave_enabled;
+set @sav_server_2_dbug= @@GLOBAL.debug_dbug;
 connection server_3;
 call mtr.add_suppression("reply failed");
 call mtr.add_suppression("Replication event checksum verification");
 call mtr.add_suppression("Relay log write failure");
 call mtr.add_suppression("Failed to kill the active semi-sync connection");
+set @sav_enabled_server_3= @@GLOBAL.rpl_semi_sync_slave_enabled;
+set @sav_server_3_dbug= @@GLOBAL.debug_dbug;
 connection server_1;
 CREATE TABLE t1 (a int);
 connection server_2;
@@ -40,15 +47,15 @@ connection server_1;
 #-- Enable semi-sync on slaves
 let slave_last= 3
 connection server_2;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
 Rpl_semi_sync_slave_status	ON
 connection server_3;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
@@ -67,24 +74,20 @@ show status like 'Rpl_semi_sync_master_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	2
 #-- Prepare servers to simulate delay or error
-connection server_1;
-SET @@GLOBAL.debug_dbug= "";
 connection server_2;
 SET @@GLOBAL.debug_dbug= "+d,simulate_delay_semisync_slave_reply";
 connection server_3;
 SET @@GLOBAL.debug_dbug= "+d,simulate_delay_semisync_slave_reply";
 #--
 #-- Test begins
+connection server_1_con2;
+#-- Give enough time after timeout/ack received to query yes_tx/no_tx
+SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 connection server_1;
 #-- Begin semi-sync transaction
 INSERT INTO t1 VALUES (1);
 connection server_1_con2;
 #-- Wait until master recognizes a connection is awaiting semi-sync ACK
-show status like 'Rpl_semi_sync_master_wait_sessions';
-Variable_name	Value
-Rpl_semi_sync_master_wait_sessions	1
-#-- Give enough time after timeout/ack received to query yes_tx/no_tx
-SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 #-- Begin master shutdown
 SHUTDOWN WAIT FOR ALL SLAVES;
 connection server_1;
@@ -111,22 +114,24 @@ count(*)=1
 #-- Re-synchronize slaves with master and disable semi-sync
 #-- Stop slaves
 connection server_2;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+#-- Waiting for IO thread to realize master shutdown and stop
+include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+#-- Waiting for IO thread to realize master shutdown and stop
+include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 #-- Bring the master back up
 connection server_1_con2;
 connection default;
 connection server_1;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
-show status like 'Rpl_semi_sync_master_status';
-Variable_name	Value
-Rpl_semi_sync_master_status	OFF
+set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
+set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
+set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -157,15 +162,15 @@ connection server_1;
 #-- Enable semi-sync on slaves
 let slave_last= 3
 connection server_2;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
 Rpl_semi_sync_slave_status	ON
 connection server_3;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
@@ -184,24 +189,20 @@ show status like 'Rpl_semi_sync_master_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	2
 #-- Prepare servers to simulate delay or error
-connection server_1;
-SET @@GLOBAL.debug_dbug= "+d,mysqld_delay_kill_threads_phase_1";
 connection server_2;
-SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event";
+SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141";
 connection server_3;
-SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event";
+SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141";
 #--
 #-- Test begins
+connection server_1_con2;
+#-- Give enough time after timeout/ack received to query yes_tx/no_tx
+SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 connection server_1;
 #-- Begin semi-sync transaction
 INSERT INTO t1 VALUES (1);
 connection server_1_con2;
 #-- Wait until master recognizes a connection is awaiting semi-sync ACK
-show status like 'Rpl_semi_sync_master_wait_sessions';
-Variable_name	Value
-Rpl_semi_sync_master_wait_sessions	1
-#-- Give enough time after timeout/ack received to query yes_tx/no_tx
-SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 #-- Begin master shutdown
 SHUTDOWN WAIT FOR ALL SLAVES;
 connection server_1;
@@ -226,24 +227,37 @@ count(*)=0
 1
 #
 #-- Re-synchronize slaves with master and disable semi-sync
+#-- FIXME: workaround for MDEV-28141, preventing errored replicas from
+# killing their semi-sync connections
+connection server_2;
+set debug_sync= "now wait_for at_semisync_kill_connection";
+set debug_sync= "now signal continue_semisync_kill_connection";
+# Wait for debug_sync signal to have been received before issuing RESET
+set debug_sync= "reset";
+connection server_3;
+set debug_sync= "now wait_for at_semisync_kill_connection";
+set debug_sync= "now signal continue_semisync_kill_connection";
+# Wait for debug_sync signal to have been received before issuing RESET
+set debug_sync= "reset";
 #-- Stop slaves
 connection server_2;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+#-- Waiting for IO thread to stop from corrupt_queue_event injection
+include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 #-- Bring the master back up
 connection server_1_con2;
 connection default;
 connection server_1;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
-show status like 'Rpl_semi_sync_master_status';
-Variable_name	Value
-Rpl_semi_sync_master_status	OFF
+set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
+set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
+set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -275,15 +289,15 @@ connection server_1;
 #-- Enable semi-sync on slaves
 let slave_last= 3
 connection server_2;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
 Rpl_semi_sync_slave_status	ON
 connection server_3;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
@@ -302,24 +316,20 @@ show status like 'Rpl_semi_sync_master_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	2
 #-- Prepare servers to simulate delay or error
-connection server_1;
-SET @@GLOBAL.debug_dbug= "+d,mysqld_delay_kill_threads_phase_1";
 connection server_2;
-SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event";
+SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141";
 connection server_3;
 SET @@GLOBAL.debug_dbug= "+d,simulate_delay_semisync_slave_reply";
 #--
 #-- Test begins
+connection server_1_con2;
+#-- Give enough time after timeout/ack received to query yes_tx/no_tx
+SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 connection server_1;
 #-- Begin semi-sync transaction
 INSERT INTO t1 VALUES (1);
 connection server_1_con2;
 #-- Wait until master recognizes a connection is awaiting semi-sync ACK
-show status like 'Rpl_semi_sync_master_wait_sessions';
-Variable_name	Value
-Rpl_semi_sync_master_wait_sessions	1
-#-- Give enough time after timeout/ack received to query yes_tx/no_tx
-SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 #-- Begin master shutdown
 SHUTDOWN WAIT FOR ALL SLAVES;
 connection server_1;
@@ -344,24 +354,32 @@ count(*)=1
 1
 #
 #-- Re-synchronize slaves with master and disable semi-sync
+#-- FIXME: workaround for MDEV-28141, preventing errored replicas from
+# killing their semi-sync connections
+connection server_2;
+set debug_sync= "now wait_for at_semisync_kill_connection";
+set debug_sync= "now signal continue_semisync_kill_connection";
+# Wait for debug_sync signal to have been received before issuing RESET
+set debug_sync= "reset";
 #-- Stop slaves
 connection server_2;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+#-- Waiting for IO thread to realize master shutdown and stop
+include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 #-- Bring the master back up
 connection server_1_con2;
 connection default;
 connection server_1;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
-show status like 'Rpl_semi_sync_master_status';
-Variable_name	Value
-Rpl_semi_sync_master_status	OFF
+set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
+set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
+set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -399,15 +417,15 @@ connection server_1;
 #-- Enable semi-sync on slaves
 let slave_last= 3
 connection server_2;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
 Rpl_semi_sync_slave_status	ON
 connection server_3;
-set global rpl_semi_sync_slave_enabled = 1;
 include/stop_slave.inc
+set global rpl_semi_sync_slave_enabled = 1;
 include/start_slave.inc
 show status like 'Rpl_semi_sync_slave_status';
 Variable_name	Value
@@ -426,24 +444,20 @@ show status like 'Rpl_semi_sync_master_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	2
 #-- Prepare servers to simulate delay or error
-connection server_1;
-SET @@GLOBAL.debug_dbug= "+d,mysqld_delay_kill_threads_phase_1";
 connection server_2;
-SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event,slave_delay_killing_semisync_connection";
+SET @@GLOBAL.debug_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141";
 connection server_3;
 SET @@GLOBAL.debug_dbug= "+d,simulate_delay_semisync_slave_reply";
 #--
 #-- Test begins
+connection server_1_con2;
+#-- Give enough time after timeout/ack received to query yes_tx/no_tx
+SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 connection server_1;
 #-- Begin semi-sync transaction
 INSERT INTO t1 VALUES (1);
 connection server_1_con2;
 #-- Wait until master recognizes a connection is awaiting semi-sync ACK
-show status like 'Rpl_semi_sync_master_wait_sessions';
-Variable_name	Value
-Rpl_semi_sync_master_wait_sessions	1
-#-- Give enough time after timeout/ack received to query yes_tx/no_tx
-SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 #-- Begin master shutdown
 SHUTDOWN WAIT FOR ALL SLAVES;
 connection server_1;
@@ -468,24 +482,32 @@ count(*)=1
 1
 #
 #-- Re-synchronize slaves with master and disable semi-sync
+#-- FIXME: workaround for MDEV-28141, preventing errored replicas from
+# killing their semi-sync connections
+connection server_2;
+set debug_sync= "now wait_for at_semisync_kill_connection";
+set debug_sync= "now signal continue_semisync_kill_connection";
+# Wait for debug_sync signal to have been received before issuing RESET
+set debug_sync= "reset";
 #-- Stop slaves
 connection server_2;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+include/wait_for_slave_io_error.inc [errno=1595]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 connection server_3;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
-include/stop_slave.inc
+#-- Waiting for IO thread to realize master shutdown and stop
+include/wait_for_slave_io_error.inc [errno=2003]
+include/stop_slave_sql.inc
+SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 #-- Bring the master back up
 connection server_1_con2;
 connection default;
 connection server_1;
-SET @@GLOBAL.debug_dbug= "";
-SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
-show status like 'Rpl_semi_sync_master_status';
-Variable_name	Value
-Rpl_semi_sync_master_status	OFF
+set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
+set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
+set @sav_master_dbug= @@GLOBAL.debug_dbug;
 TRUNCATE TABLE t1;
 #-- Bring slaves back up
 connection server_2;
@@ -509,10 +531,17 @@ COUNT(*)=0
 #############################
 connection server_2;
 include/stop_slave.inc
+SET @@GLOBAL.rpl_semi_sync_slave_enabled = @sav_enabled_server_2;
+SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 include/start_slave.inc
 connection server_3;
 include/stop_slave.inc
+SET @@GLOBAL.rpl_semi_sync_slave_enabled = @sav_enabled_server_3;
+SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 include/start_slave.inc
 connection server_1;
+SET @@GLOBAL.rpl_semi_sync_master_timeout= @sav_master_timeout;
+SET @@GLOBAL.rpl_semi_sync_master_enabled= @sav_enabled_master;
+SET @@GLOBAL.debug_dbug= @sav_master_dbug;
 drop table t1;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.cnf
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.cnf
@@ -5,11 +5,9 @@ log_warnings=9
 
 [mysqld.2]
 log_warnings=9
-master_retry_count=2
 
 [mysqld.3]
 log_warnings=9
-master_retry_count=2
 
 [ENV]
 SERVER_MYPORT_3=		@mysqld.3.port

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.cnf
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.cnf
@@ -5,9 +5,11 @@ log_warnings=9
 
 [mysqld.2]
 log_warnings=9
+master_retry_count=2
 
 [mysqld.3]
 log_warnings=9
+master_retry_count=2
 
 [ENV]
 SERVER_MYPORT_3=		@mysqld.3.port

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
@@ -3,7 +3,6 @@
 # replicas before shutting down.
 #
 # Parameters:
-#   server_1_dbug (string)          Debug setting for primary (server 1)
 #   server_2_dbug (string)          Debug setting to simulate delay or error on
 #                                   the first replica (server 2)
 #   server_3_dbug (string)          Debug setting to simulate delay or error on
@@ -32,8 +31,8 @@ while (`SELECT $i <= $slave_last`)
   --connection server_$i
   --sync_with_master
 
-  set global rpl_semi_sync_slave_enabled = 1;
   source include/stop_slave.inc;
+  set global rpl_semi_sync_slave_enabled = 1;
   source include/start_slave.inc;
   show status like 'Rpl_semi_sync_slave_status';
 
@@ -56,8 +55,6 @@ show status like 'Rpl_semi_sync_master_status';
 show status like 'Rpl_semi_sync_master_clients';
 
 --echo #-- Prepare servers to simulate delay or error
---connection server_1
---eval SET @@GLOBAL.debug_dbug= $server_1_dbug
 --connection server_2
 --eval SET @@GLOBAL.debug_dbug= $server_2_dbug
 --connection server_3
@@ -65,6 +62,14 @@ show status like 'Rpl_semi_sync_master_clients';
 
 --echo #--
 --echo #-- Test begins
+
+--connection server_1_con2
+--echo #-- Give enough time after timeout/ack received to query yes_tx/no_tx
+SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
+
+--write_file $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+wait
+EOF
 
 --connection server_1
 --echo #-- Begin semi-sync transaction
@@ -75,14 +80,6 @@ show status like 'Rpl_semi_sync_master_clients';
 let $status_var= Rpl_semi_sync_master_wait_sessions;
 let $status_var_value= 1;
 source include/wait_for_status_var.inc;
-show status like 'Rpl_semi_sync_master_wait_sessions';
-
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-wait
-EOF
-
---echo #-- Give enough time after timeout/ack received to query yes_tx/no_tx
-SET @@GLOBAL.debug_dbug= "+d,delay_shutdown_phase_2_after_semisync_wait";
 
 --echo #-- Begin master shutdown
 --send SHUTDOWN WAIT FOR ALL SLAVES
@@ -111,19 +108,80 @@ show status like 'Rpl_semi_sync_master_no_tx';
 --echo #
 --echo #-- Re-synchronize slaves with master and disable semi-sync
 
+if (`SELECT ($server_2_expect_row_count + $server_3_expect_row_count) < 2`)
+{
+--echo #-- FIXME: workaround for MDEV-28141, preventing errored replicas from
+--echo # killing their semi-sync connections
+# I.e. we can't create a new kill connection to the primary if we know that the
+# primary is shutting down for risk of Packets out of order error. So we wait
+# to hit a debug_sync point before the creation of the new kill_connection, and
+# don't progress until the primary has been shutdown, so no new connection can
+# be formed.
+# Note this is only needed in the error case (using corrupt_queue_event), as
+# the running io_thread will otherwise automatically detect that the primary
+# has shutdown before progressing to the cleanup of the io thread.
+}
+
+if (!$server_2_expect_row_count)
+{
+  --connection server_2
+  set debug_sync= "now wait_for at_semisync_kill_connection";
+  set debug_sync= "now signal continue_semisync_kill_connection";
+  --echo # Wait for debug_sync signal to have been received before issuing RESET
+  let $wait_condition= select count(*)=0 from information_schema.processlist where state like "debug sync point%";
+  source include/wait_condition.inc;
+  set debug_sync= "reset";
+}
+if (!$server_3_expect_row_count)
+{
+  --connection server_3
+  set debug_sync= "now wait_for at_semisync_kill_connection";
+  set debug_sync= "now signal continue_semisync_kill_connection";
+  --echo # Wait for debug_sync signal to have been received before issuing RESET
+  let $wait_condition= select count(*)=0 from information_schema.processlist where state like "debug sync point%";
+  source include/wait_condition.inc;
+  set debug_sync= "reset";
+}
+
 --echo #-- Stop slaves
 
 --connection server_2
---eval SET @@GLOBAL.debug_dbug= "$sav_server_2_dbug"
---eval SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0
---let $rpl_only_running_threads= 1
-source include/stop_slave.inc;
+if (!$server_2_expect_row_count)
+{
+  # ER_SLAVE_RELAY_LOG_WRITE_FAILURE
+  --let $slave_io_errno=1595
+  --source include/wait_for_slave_io_error.inc
+  --source include/stop_slave_sql.inc
+}
+if ($server_2_expect_row_count)
+{
+  --echo #-- Waiting for IO thread to realize master shutdown and stop
+  --let $slave_io_errno=2003
+  --source include/wait_for_slave_io_error.inc
+  --source include/stop_slave_sql.inc
+  #--source include/stop_slave.inc
+}
+SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 
 --connection server_3
---eval SET @@GLOBAL.debug_dbug= "$sav_server_3_dbug"
---eval SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0
---let $rpl_only_running_threads= 1
-source include/stop_slave.inc;
+if (!$server_3_expect_row_count)
+{
+  --echo #-- Waiting for IO thread to stop from corrupt_queue_event injection
+  # ER_SLAVE_RELAY_LOG_WRITE_FAILURE (1595) if corrupt_queue failure
+  --let $slave_io_errno=1595
+  --source include/wait_for_slave_io_error.inc
+  --source include/stop_slave_sql.inc
+}
+if ($server_3_expect_row_count)
+{
+  --echo #-- Waiting for IO thread to realize master shutdown and stop
+  --let $slave_io_errno=2003
+  --source include/wait_for_slave_io_error.inc
+  --source include/stop_slave_sql.inc
+}
+SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 
 --echo #-- Bring the master back up
 --connection server_1_con2
@@ -142,12 +200,11 @@ EOF
 --enable_reconnect
 --source include/wait_until_connected_again.inc
 
---eval SET @@GLOBAL.debug_dbug= "$sav_master_dbug"
-let $status_var= Rpl_semi_sync_master_clients;
-let $status_var_value= 0;
-source include/wait_for_status_var.inc;
---eval SET @@GLOBAL.rpl_semi_sync_master_enabled = 0
-show status like 'Rpl_semi_sync_master_status';
+# Because we restarted, we have to store the default values again for later
+# restoration at cleanup
+set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
+set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
+set @sav_master_dbug= @@GLOBAL.debug_dbug;
 
 TRUNCATE TABLE t1;
 --save_master_pos

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
@@ -146,46 +146,32 @@ if (!$server_3_expect_row_count)
 --echo #-- Stop slaves
 
 --connection server_2
-if (!$server_2_expect_row_count)
-{
-  # ER_SLAVE_RELAY_LOG_WRITE_FAILURE
-  --let $slave_io_errno=1595
-  --source include/wait_for_slave_io_error.inc
-  --source include/stop_slave_sql.inc
-}
-if ($server_2_expect_row_count)
-{
-  # At this point, because the master has shutdown, the IO thread may or may
-  # not have realized the shutdown, and started to try to automatically
-  # reconnect. Rather than issue `stop_slave.inc` now, which may or may not
-  # result in an error state, we force the error for consistency by waiting
-  # for the IO thread to fail to reconnect to the shutdown master.
-  --echo #-- Waiting for IO thread to realize master shutdown and stop
-  --let $slave_io_errno=2003
-  --source include/wait_for_slave_io_error.inc
-  --source include/stop_slave_sql.inc
-}
+# If server_2_expect_row_count is 0, we are simulating an error on the replica
+# and the IO thread will end with errno 1595.
+# Otherwise, we still expect error, because the master has shutdown at this
+# point, and the IO thread may or may not have realized the shutdown, and
+# started to try to automatically reconnect. This may result in the IO thread
+# giving a 2003 error if the slave tries to reconnect to a shutdown master.
+# Additionally disable warnings because the slave may have stopped in err
+# automatically, and we don't want a sporadic "Slave is already stopped"
+# warning.
+--disable_warnings
+--let $rpl_allow_error= 1
+--source include/stop_slave_io.inc
+--enable_warnings
+--let $rpl_allow_error=
+--source include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
 
 --connection server_3
-if (!$server_3_expect_row_count)
-{
-  --echo #-- Waiting for IO thread to stop from corrupt_queue_event injection
-  # ER_SLAVE_RELAY_LOG_WRITE_FAILURE (1595) if corrupt_queue failure
-  --let $slave_io_errno=1595
-  --source include/wait_for_slave_io_error.inc
-  --source include/stop_slave_sql.inc
-}
-if ($server_3_expect_row_count)
-{
-  # Wait for error to be detected naturally, rather than issue `stop_slave` for
-  # the IO thread, see the comment above for $server_2_expect_row_count.
-  --echo #-- Waiting for IO thread to realize master shutdown and stop
-  --let $slave_io_errno=2003
-  --source include/wait_for_slave_io_error.inc
-  --source include/stop_slave_sql.inc
-}
+# Expect error for IO thread, see above comment for stopping server_2
+--disable_warnings
+--let $rpl_allow_error= 1
+--source include/stop_slave_io.inc
+--enable_warnings
+--let $rpl_allow_error=
+--source include/stop_slave_sql.inc
 SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_3;
 

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.inc
@@ -155,11 +155,15 @@ if (!$server_2_expect_row_count)
 }
 if ($server_2_expect_row_count)
 {
+  # At this point, because the master has shutdown, the IO thread may or may
+  # not have realized the shutdown, and started to try to automatically
+  # reconnect. Rather than issue `stop_slave.inc` now, which may or may not
+  # result in an error state, we force the error for consistency by waiting
+  # for the IO thread to fail to reconnect to the shutdown master.
   --echo #-- Waiting for IO thread to realize master shutdown and stop
   --let $slave_io_errno=2003
   --source include/wait_for_slave_io_error.inc
   --source include/stop_slave_sql.inc
-  #--source include/stop_slave.inc
 }
 SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 SET @@GLOBAL.rpl_semi_sync_slave_enabled= @sav_enabled_server_2;
@@ -175,6 +179,8 @@ if (!$server_3_expect_row_count)
 }
 if ($server_3_expect_row_count)
 {
+  # Wait for error to be detected naturally, rather than issue `stop_slave` for
+  # the IO thread, see the comment above for $server_2_expect_row_count.
   --echo #-- Waiting for IO thread to realize master shutdown and stop
   --let $slave_io_errno=2003
   --source include/wait_for_slave_io_error.inc
@@ -199,12 +205,6 @@ EOF
 --connection server_1
 --enable_reconnect
 --source include/wait_until_connected_again.inc
-
-# Because we restarted, we have to store the default values again for later
-# restoration at cleanup
-set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
-set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
-set @sav_master_dbug= @@GLOBAL.debug_dbug;
 
 TRUNCATE TABLE t1;
 --save_master_pos

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.test
@@ -69,9 +69,9 @@ call mtr.add_suppression("Timeout waiting");
 call mtr.add_suppression("did not exit");
 call mtr.add_suppression("Got an error reading communication packets");
 
---let $sav_master_timeout= `SELECT @@global.rpl_semi_sync_master_timeout`
---let $sav_enabled_master= `SELECT @@GLOBAL.rpl_semi_sync_master_enabled`
---let $sav_master_dbug= `SELECT @@GLOBAL.debug_dbug`
+set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
+set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
+set @sav_master_dbug= @@GLOBAL.debug_dbug;
 
 --echo # Suppress slave errors related to the simulated error
 --connection server_2
@@ -79,16 +79,16 @@ call mtr.add_suppression("reply failed");
 call mtr.add_suppression("Replication event checksum verification");
 call mtr.add_suppression("Relay log write failure");
 call mtr.add_suppression("Failed to kill the active semi-sync connection");
---let $sav_enabled_server_2=`SELECT @@GLOBAL.rpl_semi_sync_slave_enabled`
---let $sav_server_2_dbug= `SELECT @@GLOBAL.debug_dbug`
+set @sav_enabled_server_2= @@GLOBAL.rpl_semi_sync_slave_enabled;
+set @sav_server_2_dbug= @@GLOBAL.debug_dbug;
 
 --connection server_3
 call mtr.add_suppression("reply failed");
 call mtr.add_suppression("Replication event checksum verification");
 call mtr.add_suppression("Relay log write failure");
 call mtr.add_suppression("Failed to kill the active semi-sync connection");
---let $sav_enabled_server_3=`SELECT @@GLOBAL.rpl_semi_sync_slave_enabled`
---let $sav_server_3_dbug= `SELECT @@GLOBAL.debug_dbug`
+set @sav_enabled_server_3= @@GLOBAL.rpl_semi_sync_slave_enabled;
+set @sav_server_3_dbug= @@GLOBAL.debug_dbug;
 
 --connection server_1
 CREATE TABLE t1 (a int);
@@ -116,7 +116,6 @@ while (`SELECT $i <= $slave_last`)
 --echo # allowed timeout, the primary should delay killing the suspended thread
 --echo # until an ACK is received (Rpl_semi_sync_master_yes_tx should be 1).
 --echo #
---let server_1_dbug= ""
 --let server_2_dbug= "+d,simulate_delay_semisync_slave_reply"
 --let server_3_dbug= "+d,simulate_delay_semisync_slave_reply"
 --let semisync_timeout= 1600
@@ -129,9 +128,8 @@ while (`SELECT $i <= $slave_last`)
 --echo # the primary should delay killing the suspended thread until the
 --echo # timeout is reached (Rpl_semi_sync_master_no_tx should be 1).
 --echo #
---let server_1_dbug= "+d,mysqld_delay_kill_threads_phase_1"
---let server_2_dbug= "+d,corrupt_queue_event"
---let server_3_dbug= "+d,corrupt_queue_event"
+--let server_2_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141"
+--let server_3_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141"
 --let semisync_timeout= 500
 --let server_2_expect_row_count= 0
 --let server_3_expect_row_count= 0
@@ -143,8 +141,7 @@ while (`SELECT $i <= $slave_last`)
 --echo # primary should delay killing the suspended thread until it receives an
 --echo # ACK from the delayed slave (Rpl_semi_sync_master_yes_tx should be 1).
 --echo #
---let server_1_dbug= "+d,mysqld_delay_kill_threads_phase_1"
---let server_2_dbug= "+d,corrupt_queue_event"
+--let server_2_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141"
 --let server_3_dbug= "+d,simulate_delay_semisync_slave_reply"
 --let semisync_timeout= 1600
 --let server_2_expect_row_count= 0
@@ -167,11 +164,10 @@ while (`SELECT $i <= $slave_last`)
 # mysqld_delay_kill_threads_phase1 ensures that server_2 will have enough time
 # to start a new connection that has the intent to kill the active semi-sync
 # connection
---let server_1_dbug= "+d,mysqld_delay_kill_threads_phase_1"
 
 # slave_delay_killing_semisync_connection ensures that the primary has force
 # killed its current connection before it is able to issue `KILL`
---let server_2_dbug= "+d,corrupt_queue_event,slave_delay_killing_semisync_connection"
+--let server_2_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141"
 --let server_3_dbug= "+d,simulate_delay_semisync_slave_reply"
 --let semisync_timeout= 1600
 --let server_2_expect_row_count= 0
@@ -184,33 +180,24 @@ while (`SELECT $i <= $slave_last`)
 
 --connection server_2
 source include/stop_slave.inc;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled = @sav_enabled_server_2;
+SET @@GLOBAL.debug_dbug= @sav_server_2_dbug;
 source include/start_slave.inc;
-
---disable_query_log
---eval SET @@GLOBAL.rpl_semi_sync_slave_enabled = $sav_enabled_server_2
---eval SET @@GLOBAL.debug_dbug= "$sav_server_2_dbug"
---enable_query_log
 
 --connection server_3
 source include/stop_slave.inc;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled = @sav_enabled_server_3;
+SET @@GLOBAL.debug_dbug= @sav_server_3_dbug;
 source include/start_slave.inc;
-
---disable_query_log
---eval SET @@GLOBAL.rpl_semi_sync_slave_enabled = $sav_enabled_server_3
---eval SET @@GLOBAL.debug_dbug= "$sav_server_3_dbug"
---enable_query_log
-
 
 --connection server_1
 let $status_var= Rpl_semi_sync_master_clients;
 let $status_var_value= 0;
 source include/wait_for_status_var.inc;
 
---disable_query_log
---eval SET @@GLOBAL.rpl_semi_sync_master_timeout= $sav_master_timeout
---eval SET @@GLOBAL.rpl_semi_sync_master_enabled= $sav_enabled_master
---eval SET @@GLOBAL.debug_dbug= "$sav_master_dbug"
---enable_query_log
+SET @@GLOBAL.rpl_semi_sync_master_timeout= @sav_master_timeout;
+SET @@GLOBAL.rpl_semi_sync_master_enabled= @sav_enabled_master;
+SET @@GLOBAL.debug_dbug= @sav_master_dbug;
 
 drop table t1;
 

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_await_ack.test
@@ -69,9 +69,8 @@ call mtr.add_suppression("Timeout waiting");
 call mtr.add_suppression("did not exit");
 call mtr.add_suppression("Got an error reading communication packets");
 
-set @sav_master_timeout= @@global.rpl_semi_sync_master_timeout;
-set @sav_enabled_master= @@GLOBAL.rpl_semi_sync_master_enabled;
-set @sav_master_dbug= @@GLOBAL.debug_dbug;
+--let $sav_master_timeout= `SELECT @@GLOBAL.rpl_semi_sync_master_timeout`
+--let $sav_enabled_master= `SELECT @@GLOBAL.rpl_semi_sync_master_enabled`
 
 --echo # Suppress slave errors related to the simulated error
 --connection server_2
@@ -160,13 +159,6 @@ while (`SELECT $i <= $slave_last`)
 --echo # slave does not send a `QUIT` in this case (Rpl_semi_sync_master_yes_tx
 --echo # should be 1 because server_3 will send the ACK within a valid timeout).
 --echo #
-
-# mysqld_delay_kill_threads_phase1 ensures that server_2 will have enough time
-# to start a new connection that has the intent to kill the active semi-sync
-# connection
-
-# slave_delay_killing_semisync_connection ensures that the primary has force
-# killed its current connection before it is able to issue `KILL`
 --let server_2_dbug= "+d,corrupt_queue_event,delay_semisync_kill_connection_for_mdev_28141"
 --let server_3_dbug= "+d,simulate_delay_semisync_slave_reply"
 --let semisync_timeout= 1600
@@ -195,9 +187,10 @@ let $status_var= Rpl_semi_sync_master_clients;
 let $status_var_value= 0;
 source include/wait_for_status_var.inc;
 
-SET @@GLOBAL.rpl_semi_sync_master_timeout= @sav_master_timeout;
-SET @@GLOBAL.rpl_semi_sync_master_enabled= @sav_enabled_master;
-SET @@GLOBAL.debug_dbug= @sav_master_dbug;
+--disable_query_log
+--eval SET @@GLOBAL.rpl_semi_sync_master_timeout= $sav_master_timeout;
+--eval SET @@GLOBAL.rpl_semi_sync_master_enabled= $sav_enabled_master;
+--enable_query_log
 
 drop table t1;
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1745,7 +1745,6 @@ static void close_connections(void)
     This will give the threads some time to gracefully abort their
     statements and inform their clients that the server is about to die.
   */
-  DBUG_EXECUTE_IF("mysqld_delay_kill_threads_phase_1", my_sleep(200000););
   int n_threads_awaiting_ack= 0;
   server_threads.iterate(kill_thread_phase_1, &n_threads_awaiting_ack);
 

--- a/sql/semisync_slave.cc
+++ b/sql/semisync_slave.cc
@@ -17,6 +17,7 @@
 
 #include <my_global.h>
 #include "semisync_slave.h"
+#include "debug_sync.h"
 
 Repl_semi_sync_slave repl_semisync_slave;
 
@@ -115,7 +116,21 @@ int Repl_semi_sync_slave::slave_start(Master_info *mi)
 int Repl_semi_sync_slave::slave_stop(Master_info *mi)
 {
   if (get_slave_enabled())
+  {
+#ifdef ENABLED_DEBUG_SYNC
+  /*
+    TODO: Remove after MDEV-28141
+  */
+  DBUG_EXECUTE_IF("delay_semisync_kill_connection_for_mdev_28141", {
+    const char act[]= "now "
+                      "signal at_semisync_kill_connection "
+                      "wait_for continue_semisync_kill_connection";
+    DBUG_ASSERT(debug_sync_service);
+    DBUG_ASSERT(!debug_sync_set_action(mi->io_thd, STRING_WITH_LEN(act)));
+  };);
+#endif
     kill_connection(mi->mysql);
+  }
 
   if (rpl_semi_sync_slave_status)
     rpl_semi_sync_slave_status= 0;
@@ -150,8 +165,6 @@ void Repl_semi_sync_slave::kill_connection(MYSQL *mysql)
                           "connection");
     goto failed_graceful_kill;
   }
-
-  DBUG_EXECUTE_IF("slave_delay_killing_semisync_connection", my_sleep(400000););
 
   kill_buffer_length= my_snprintf(kill_buffer, 30, "KILL %lu",
                                 mysql->thread_id);


### PR DESCRIPTION
… Result content mismatch

This test was prone to failures for a few reasons, summarized below:

 1) MDEV-32168 introduced “only_running_threads=1” to
slave_stop.inc, which allowed the stop logic to bypass an attempting-to-reconnect IO thread. That is, the IO thread could realize the master shutdown in `read_event()`, and thereby call into `try_to_reconnect()`. This would leave the IO thread up when the test expected it to be stopped. The fix for this is two-part. First, rather than stop the io thread, wait for it to realize the master shutdown so it can turn itself off automatically. Second, change the test configuration `master_retry_count` to 2 (default 10000) so it waits a reasonable amount of time.

 2) On slow systems (or those running profiling tools, e.g. MSAN),
the waiting-for-ack transaction can complete before the system processes the `SHUTDOWN WAIT FOR ALL SLAVES`. There was shutdown preparation logic in-between the transaction and shutdown itself, which contributes to this problem. This patch also moves this preparation logic before the transaction, so there is less to do in-between the calls.

 3) Changed work-around for MDEV-28141 to use debug_sync instead
of sleep delay, as it was still possible to hit the bug on very slow systems.

Also adjusted for MDEV-32031 fix to change MTR restoration variables to user variables
