### PR TITLE
MDEV-33251 Redundant check on prebuilt::n_rows_fetched overflow

### DIFF
--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -4406,12 +4406,10 @@ row_search_mvcc(
 			goto func_exit;
 		}
 
+#if SIZEOF_SIZE_T < 8
+		if (UNIV_LIKELY(~prebuilt->n_rows_fetched))
+#endif
 		prebuilt->n_rows_fetched++;
-
-		if (prebuilt->n_rows_fetched > 1000000000) {
-			/* Prevent wrap-over */
-			prebuilt->n_rows_fetched = 500000000;
-		}
 
 		mode = pcur->search_mode;
 	}


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33251*
## Description
`row_search_mvcc()`: Revise an overflow check, disabling it on 64-bit systems. The maximum number of consecutive record reads in a key range scan should be limited by the maximum number of records per page (less than 2¹³) and the maximum number of pages per tablespace (2³²) to less than 2⁴⁵. On 32-bit systems we can simplify the overflow check.
TODO: fill description here
## How can this PR be tested?
This code path is covered by the regression test suite, but the overflow condition (before and after this change) should be unreachable during any practical tests, even on 32-bit systems.

This has been previously tested as part of #2959.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.