### PR TITLE
MDEV-33133: MDL conflict handling code should skip BF-aborted trxs

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-33133.result
+++ b/mysql-test/suite/galera/r/MDEV-33133.result
@@ -1,0 +1,34 @@
+connection node_2;
+connection node_1;
+connect node_1a,127.0.0.1,root,,test,$NODE_MYPORT_1;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_rollback_mdl_release';
+connection node_2;
+SET SESSION wsrep_trx_fragment_size = 1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+connection node_1a;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+0
+SET SESSION wsrep_retry_autocommit = 0;
+SET DEBUG_SYNC = 'ha_write_row_start SIGNAL may_toi WAIT_FOR bf_abort';
+INSERT INTO t1 VALUES (2);
+connection node_1;
+SET DEBUG_SYNC = 'now WAIT_FOR may_toi';
+SET DEBUG_SYNC = 'after_wsrep_thd_abort WAIT_FOR sync.wsrep_rollback_mdl_release_reached';
+TRUNCATE TABLE t1;
+connection node_1a;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET DEBUG_SYNC = 'now SIGNAL signal.wsrep_rollback_mdl_release';
+connection node_2;
+INSERT INTO t1 VALUES (3);
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+connection node_1;
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+disconnect node_1a;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/MDEV-33133.test
+++ b/mysql-test/suite/galera/t/MDEV-33133.test
@@ -1,0 +1,80 @@
+#
+# MDEV-33133: MDL conflict handling code should skip transactions
+# BF-aborted before.
+#
+# It's possible that MDL conflict handling code is called more
+# than once for a transaction when:
+# - it holds more than one conflicting MDL lock
+# - reschedule_waiters() is executed,
+# which results in repeated attempts to BF-abort already aborted
+# transaction.
+# In such situations, it might be that BF-aborting logic sees
+# a partially rolled back transaction and erroneously decides
+# on future actions for such a transaction.
+#
+# The specific situation tested and fixed is when a SR transaction
+# applied in the node gets BF-aborted by a started TOI operation.
+# It's then caught with the server transaction already rolled back,
+# but with no MDL locks yet released. This caused wrong state
+# detection for such a transaction during repeated MDL conflict
+# handling code execution.
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+
+--connect node_1a,127.0.0.1,root,,test,$NODE_MYPORT_1
+
+--connection node_1
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_rollback_mdl_release';
+
+--connection node_2
+SET SESSION wsrep_trx_fragment_size = 1;
+START TRANSACTION;
+INSERT INTO t1 VALUES (1);
+
+--connection node_1a
+# Sync wait for SR transaction to replicate and apply fragment.
+SELECT COUNT(*) FROM t1;
+SET SESSION wsrep_retry_autocommit = 0;
+SET DEBUG_SYNC = 'ha_write_row_start SIGNAL may_toi WAIT_FOR bf_abort';
+--send
+  INSERT INTO t1 VALUES (2);
+
+--connection node_1
+SET DEBUG_SYNC = 'now WAIT_FOR may_toi';
+# BF-abort SR transaction and wait until it reaches the point
+# prior to release MDL locks.
+# Then abort local INSERT, which will go through rescedule_waiters()
+# and see SR transaction holding MDL locks but already rolled back.
+# In this case SR transaction should be skipped in MDL conflict
+# handling code.
+SET DEBUG_SYNC = 'after_wsrep_thd_abort WAIT_FOR sync.wsrep_rollback_mdl_release_reached';
+--send
+  TRUNCATE TABLE t1;
+
+--connection node_1a
+# Local INSERT gets aborted.
+--error ER_LOCK_DEADLOCK
+--reap
+# Let the aborted SR transaction continue and finally release MDL locks,
+# which in turn allows TRUNCATE to complete.
+SET DEBUG_SYNC = 'now SIGNAL signal.wsrep_rollback_mdl_release';
+
+--connection node_2
+# SR transaction has been BF-aborted.
+--error ER_LOCK_DEADLOCK
+INSERT INTO t1 VALUES (3);
+
+--connection node_1
+# TRUNCATE completes.
+--reap
+
+# Cleanup
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+--disconnect node_1a
+--source include/galera_end.inc


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33133*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This is a backport from 10.6 branch, the issue doesn't reproduce on 10.4, but the fix is good to have along with the MTR test.

It's possible that MDL conflict handling code is called more than once for a transaction when:
- it holds more than one conflicting MDL lock
- reschedule_waiters() is executed, which results in repeated attempts to BF-abort already aborted transaction.
In such situations, it might be that BF-aborting logic sees a partially rolled back transaction and erroneously decides on future actions for such a transaction.

The specific situation tested and fixed is when a SR transaction applied in the node gets BF-aborted by a started TOI operation. It's then caught with the server transaction already rolled back, but with no MDL locks yet released. This caused wrong state detection for such a transaction during repeated MDL conflict handling code execution.


## How can this PR be tested?

MTR test is provided.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
