### PR TITLE
MDEV-30660 COUNT DISTINCT seems unnecessarily slow when run on a PK

### DIFF
--- a/mysql-test/main/distinct.result
+++ b/mysql-test/main/distinct.result
@@ -1192,4 +1192,3 @@ Aa123456
 drop table t1;
 #
 # end of 10.5 tests
-#

--- a/mysql-test/main/distinct.test
+++ b/mysql-test/main/distinct.test
@@ -928,4 +928,4 @@ drop table t1;
 
 --echo #
 --echo # end of 10.5 tests
---echo #
+

--- a/mysql-test/main/distinct_notembedded.result
+++ b/mysql-test/main/distinct_notembedded.result
@@ -289,6 +289,31 @@ JS
         "aggregator_type": "simple"
     }
 ]
+# GROUP_CONCAT implements non-standard distinct aggregator
+SELECT GROUP_CONCAT(b) FROM t1;
+GROUP_CONCAT(b)
+1,1,1
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "group_concat(t1.b separator ',')",
+        "aggregator_type": "simple"
+    }
+]
+SELECT GROUP_CONCAT(DISTINCT b) FROM t1;
+GROUP_CONCAT(DISTINCT b)
+1
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "group_concat(distinct t1.b separator ',')",
+        "aggregator_type": "distinct"
+    }
+]
 DROP TABLE t1, t2, t3;
 DROP VIEW v1;
 SET optimizer_trace = @save_optimizer_trace;

--- a/mysql-test/main/distinct_notembedded.result
+++ b/mysql-test/main/distinct_notembedded.result
@@ -1,0 +1,280 @@
+#
+# MDEV-30660 COUNT DISTINCT seems unnecessarily slow when run on a PK
+#
+set @save_optimizer_trace = @@optimizer_trace;
+SET optimizer_trace='enabled=on';
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY, b INT NOT NULL);
+INSERT INTO t1 VALUES (1,1), (2,1), (3,1);
+# Optimization is applied (aggregator=simple):
+SELECT COUNT(DISTINCT a) FROM t1;
+COUNT(DISTINCT a)
+3
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.a)",
+        "type of aggregator": "simple"
+    }
+]
+SELECT AVG(DISTINCT a), SUM(DISTINCT b) FROM t1;
+AVG(DISTINCT a)	SUM(DISTINCT b)
+2.0000	1
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "avg(distinct t1.a)",
+        "type of aggregator": "simple"
+    },
+    {
+        "function": "sum(distinct t1.b)",
+        "type of aggregator": "distinct"
+    }
+]
+# Only `a` is unique but it's enough to eliminate DISTINCT:
+SELECT COUNT(DISTINCT b, a) FROM t1;
+COUNT(DISTINCT b, a)
+3
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.b,t1.a)",
+        "type of aggregator": "simple"
+    }
+]
+SELECT COUNT(DISTINCT a, a + b) FROM t1;
+COUNT(DISTINCT a, a + b)
+3
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.a,t1.a + t1.b)",
+        "type of aggregator": "simple"
+    }
+]
+SELECT SUM(DISTINCT a), AVG(DISTINCT a), COUNT(DISTINCT a) FROM t1 WHERE a > 1;
+SUM(DISTINCT a)	AVG(DISTINCT a)	COUNT(DISTINCT a)
+5	2.5000	2
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "sum(distinct t1.a)",
+        "type of aggregator": "simple"
+    },
+    {
+        "function": "avg(distinct t1.a)",
+        "type of aggregator": "simple"
+    },
+    {
+        "function": "count(distinct t1.a)",
+        "type of aggregator": "simple"
+    }
+]
+# Optimization is not applied 'cause function argument is not a field
+# (aggregator=distinct):
+SELECT SUM(DISTINCT a + b) FROM t1;
+SUM(DISTINCT a + b)
+9
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "sum(distinct t1.a + t1.b)",
+        "type of aggregator": "distinct"
+    }
+]
+SELECT COUNT(DISTINCT b) FROM t1;
+COUNT(DISTINCT b)
+1
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.b)",
+        "type of aggregator": "distinct"
+    }
+]
+SELECT AVG(DISTINCT b / a) FROM t1;
+AVG(DISTINCT b / a)
+0.61110000
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "avg(distinct t1.b / t1.a)",
+        "type of aggregator": "distinct"
+    }
+]
+EXPLAIN SELECT COUNT(DISTINCT (SELECT a)) FROM t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t1	index	NULL	PRIMARY	4	NULL	3	Using index
+2	DEPENDENT SUBQUERY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	No tables used
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct (/* select#2 */ select t1.a))",
+        "type of aggregator": "distinct"
+    }
+]
+CREATE TABLE t2 (a INT);
+INSERT INTO t2 VALUES (1), (2);
+# Optimization is not applied 'cause there is more than one table
+SELECT COUNT(DISTINCT t1.a) FROM t1, t2;
+COUNT(DISTINCT t1.a)
+3
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.a)",
+        "type of aggregator": "distinct"
+    }
+]
+SELECT AVG(DISTINCT t1.a) FROM t1, t2;
+AVG(DISTINCT t1.a)
+2.0000
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "avg(distinct t1.a)",
+        "type of aggregator": "distinct"
+    }
+]
+# Const tables, optimization is applied
+SELECT COUNT(DISTINCT a) FROM t1, (SELECT 1) AS t2;
+COUNT(DISTINCT a)
+3
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.a)",
+        "type of aggregator": "simple"
+    }
+]
+SELECT AVG(DISTINCT t1.a) FROM (SELECT 1 AS a) AS t2, t1, (SELECT 2 AS a) AS t3;
+AVG(DISTINCT t1.a)
+2.0000
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "avg(distinct t1.a)",
+        "type of aggregator": "simple"
+    }
+]
+SELECT COUNT(DISTINCT a) FROM t1, (SELECT 1 UNION SELECT 2) AS t2;
+COUNT(DISTINCT a)
+3
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.a)",
+        "type of aggregator": "distinct"
+    }
+]
+# Unique index on two columns
+CREATE TABLE t3 (a INT NOT NULL, b INT NOT NULL);
+INSERT INTO t3 VALUES (1,1), (1,2), (1,3), (2,1), (2,2), (3,1), (3,2);
+CREATE UNIQUE INDEX t3_a_b ON t3 (a, b);
+# Optimization is applied:
+SELECT COUNT(DISTINCT a, b) FROM t3;
+COUNT(DISTINCT a, b)
+7
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t3.a,t3.b)",
+        "type of aggregator": "simple"
+    }
+]
+SELECT COUNT(DISTINCT b, a) FROM t3;
+COUNT(DISTINCT b, a)
+7
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t3.b,t3.a)",
+        "type of aggregator": "simple"
+    }
+]
+SELECT COUNT(DISTINCT b, a) FROM t3 WHERE a < 3;
+COUNT(DISTINCT b, a)
+5
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t3.b,t3.a)",
+        "type of aggregator": "simple"
+    }
+]
+# Optimization is applied to one of the functions:
+SELECT COUNT(DISTINCT b), SUM(DISTINCT a), SUM(DISTINCT a + b) FROM t3 GROUP BY a;
+COUNT(DISTINCT b)	SUM(DISTINCT a)	SUM(DISTINCT a + b)
+3	1	9
+2	2	7
+2	3	9
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t3.b)",
+        "type of aggregator": "simple"
+    },
+    {
+        "function": "sum(distinct t3.a)",
+        "type of aggregator": "distinct"
+    },
+    {
+        "function": "sum(distinct t3.a + t3.b)",
+        "type of aggregator": "distinct"
+    }
+]
+# Can't apply optimization 'cause GROUP BY argument is not a field:
+SELECT COUNT(DISTINCT b) FROM t3 GROUP BY a+b;
+COUNT(DISTINCT b)
+1
+2
+3
+1
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t3.b)",
+        "type of aggregator": "distinct"
+    }
+]
+DROP TABLE t1, t2, t3;
+SET optimizer_trace = @save_optimizer_trace;
+#
+# end of 10.6 tests

--- a/mysql-test/main/distinct_notembedded.result
+++ b/mysql-test/main/distinct_notembedded.result
@@ -15,7 +15,7 @@ JS
 [
     {
         "function": "count(distinct t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 SELECT AVG(DISTINCT a), SUM(DISTINCT b) FROM t1;
@@ -27,11 +27,11 @@ JS
 [
     {
         "function": "avg(distinct t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     },
     {
         "function": "sum(distinct t1.b)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 # Only `a` is unique but it's enough to eliminate DISTINCT:
@@ -44,7 +44,7 @@ JS
 [
     {
         "function": "count(distinct t1.b,t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 SELECT COUNT(DISTINCT a, a + b) FROM t1;
@@ -56,7 +56,7 @@ JS
 [
     {
         "function": "count(distinct t1.a,t1.a + t1.b)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 SELECT SUM(DISTINCT a), AVG(DISTINCT a), COUNT(DISTINCT a) FROM t1 WHERE a > 1;
@@ -68,15 +68,15 @@ JS
 [
     {
         "function": "sum(distinct t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     },
     {
         "function": "avg(distinct t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     },
     {
         "function": "count(distinct t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 # Optimization is not applied 'cause function argument is not a field
@@ -90,7 +90,7 @@ JS
 [
     {
         "function": "sum(distinct t1.a + t1.b)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 SELECT COUNT(DISTINCT b) FROM t1;
@@ -102,7 +102,7 @@ JS
 [
     {
         "function": "count(distinct t1.b)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 SELECT AVG(DISTINCT b / a) FROM t1;
@@ -114,7 +114,7 @@ JS
 [
     {
         "function": "avg(distinct t1.b / t1.a)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 EXPLAIN SELECT COUNT(DISTINCT (SELECT a)) FROM t1;
@@ -127,7 +127,7 @@ JS
 [
     {
         "function": "count(distinct (/* select#2 */ select t1.a))",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 CREATE TABLE t2 (a INT);
@@ -142,7 +142,7 @@ JS
 [
     {
         "function": "count(distinct t1.a)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 SELECT AVG(DISTINCT t1.a) FROM t1, t2;
@@ -154,7 +154,7 @@ JS
 [
     {
         "function": "avg(distinct t1.a)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 # Const tables, optimization is applied
@@ -167,7 +167,7 @@ JS
 [
     {
         "function": "count(distinct t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 SELECT AVG(DISTINCT t1.a) FROM (SELECT 1 AS a) AS t2, t1, (SELECT 2 AS a) AS t3;
@@ -179,7 +179,7 @@ JS
 [
     {
         "function": "avg(distinct t1.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 SELECT COUNT(DISTINCT a) FROM t1, (SELECT 1 UNION SELECT 2) AS t2;
@@ -191,7 +191,7 @@ JS
 [
     {
         "function": "count(distinct t1.a)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 # Unique index on two columns
@@ -208,7 +208,7 @@ JS
 [
     {
         "function": "count(distinct t3.a,t3.b)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 SELECT COUNT(DISTINCT b, a) FROM t3;
@@ -220,7 +220,7 @@ JS
 [
     {
         "function": "count(distinct t3.b,t3.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 SELECT COUNT(DISTINCT b, a) FROM t3 WHERE a < 3;
@@ -232,7 +232,7 @@ JS
 [
     {
         "function": "count(distinct t3.b,t3.a)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     }
 ]
 # Optimization is applied to one of the functions:
@@ -247,15 +247,15 @@ JS
 [
     {
         "function": "count(distinct t3.b)",
-        "type of aggregator": "simple"
+        "aggregator_type": "simple"
     },
     {
         "function": "sum(distinct t3.a)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     },
     {
         "function": "sum(distinct t3.a + t3.b)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
     }
 ]
 # Can't apply optimization 'cause GROUP BY argument is not a field:
@@ -271,10 +271,26 @@ JS
 [
     {
         "function": "count(distinct t3.b)",
-        "type of aggregator": "distinct"
+        "aggregator_type": "distinct"
+    }
+]
+# Test merged view
+CREATE VIEW v1 AS SELECT * FROM t1;
+# Optimization is applied
+SELECT COUNT(DISTINCT a, b) FROM v1;
+COUNT(DISTINCT a, b)
+3
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '$**.prepare_sum_aggregators')) AS JS
+FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+JS
+[
+    {
+        "function": "count(distinct t1.a,t1.b)",
+        "aggregator_type": "simple"
     }
 ]
 DROP TABLE t1, t2, t3;
+DROP VIEW v1;
 SET optimizer_trace = @save_optimizer_trace;
 #
 # end of 10.6 tests

--- a/mysql-test/main/distinct_notembedded.test
+++ b/mysql-test/main/distinct_notembedded.test
@@ -89,7 +89,14 @@ eval $trace;
 SELECT COUNT(DISTINCT b) FROM t3 GROUP BY a+b;
 eval $trace;
 
+--echo # Test merged view
+CREATE VIEW v1 AS SELECT * FROM t1;
+--echo # Optimization is applied
+SELECT COUNT(DISTINCT a, b) FROM v1;
+eval $trace;
+
 DROP TABLE t1, t2, t3;
+DROP VIEW v1;
 SET optimizer_trace = @save_optimizer_trace;
 --echo #
 --echo # end of 10.6 tests

--- a/mysql-test/main/distinct_notembedded.test
+++ b/mysql-test/main/distinct_notembedded.test
@@ -1,0 +1,95 @@
+# Embedded doesn't have optimizer trace:
+--source include/not_embedded.inc
+
+--source include/have_sequence.inc
+
+--echo #
+--echo # MDEV-30660 COUNT DISTINCT seems unnecessarily slow when run on a PK
+--echo #
+
+set @save_optimizer_trace = @@optimizer_trace;
+SET optimizer_trace='enabled=on';
+let $trace=
+SELECT JSON_DETAILED(JSON_EXTRACT(trace, '\$**.prepare_sum_aggregators')) AS JS
+  FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY, b INT NOT NULL);
+INSERT INTO t1 VALUES (1,1), (2,1), (3,1);
+
+--echo # Optimization is applied (aggregator=simple):
+SELECT COUNT(DISTINCT a) FROM t1;
+eval $trace;
+
+SELECT AVG(DISTINCT a), SUM(DISTINCT b) FROM t1;
+eval $trace;
+
+--echo # Only `a` is unique but it's enough to eliminate DISTINCT:
+SELECT COUNT(DISTINCT b, a) FROM t1;
+eval $trace;
+
+SELECT COUNT(DISTINCT a, a + b) FROM t1;
+eval $trace;
+
+SELECT SUM(DISTINCT a), AVG(DISTINCT a), COUNT(DISTINCT a) FROM t1 WHERE a > 1;
+eval $trace;
+
+--echo # Optimization is not applied 'cause function argument is not a field
+--echo # (aggregator=distinct):
+SELECT SUM(DISTINCT a + b) FROM t1;
+eval $trace;
+
+SELECT COUNT(DISTINCT b) FROM t1;
+eval $trace;
+
+SELECT AVG(DISTINCT b / a) FROM t1;
+eval $trace;
+
+EXPLAIN SELECT COUNT(DISTINCT (SELECT a)) FROM t1;
+eval $trace;
+
+CREATE TABLE t2 (a INT);
+INSERT INTO t2 VALUES (1), (2);
+
+--echo # Optimization is not applied 'cause there is more than one table
+SELECT COUNT(DISTINCT t1.a) FROM t1, t2;
+eval $trace;
+
+SELECT AVG(DISTINCT t1.a) FROM t1, t2;
+eval $trace;
+
+--echo # Const tables, optimization is applied
+SELECT COUNT(DISTINCT a) FROM t1, (SELECT 1) AS t2;
+eval $trace;
+
+SELECT AVG(DISTINCT t1.a) FROM (SELECT 1 AS a) AS t2, t1, (SELECT 2 AS a) AS t3;
+eval $trace;
+
+SELECT COUNT(DISTINCT a) FROM t1, (SELECT 1 UNION SELECT 2) AS t2;
+eval $trace;
+
+--echo # Unique index on two columns
+CREATE TABLE t3 (a INT NOT NULL, b INT NOT NULL);
+INSERT INTO t3 VALUES (1,1), (1,2), (1,3), (2,1), (2,2), (3,1), (3,2);
+CREATE UNIQUE INDEX t3_a_b ON t3 (a, b);
+--echo # Optimization is applied:
+SELECT COUNT(DISTINCT a, b) FROM t3;
+eval $trace;
+
+SELECT COUNT(DISTINCT b, a) FROM t3;
+eval $trace;
+
+SELECT COUNT(DISTINCT b, a) FROM t3 WHERE a < 3;
+eval $trace;
+
+--echo # Optimization is applied to one of the functions:
+SELECT COUNT(DISTINCT b), SUM(DISTINCT a), SUM(DISTINCT a + b) FROM t3 GROUP BY a;
+eval $trace;
+
+--echo # Can't apply optimization 'cause GROUP BY argument is not a field:
+SELECT COUNT(DISTINCT b) FROM t3 GROUP BY a+b;
+eval $trace;
+
+DROP TABLE t1, t2, t3;
+SET optimizer_trace = @save_optimizer_trace;
+--echo #
+--echo # end of 10.6 tests

--- a/mysql-test/main/distinct_notembedded.test
+++ b/mysql-test/main/distinct_notembedded.test
@@ -95,6 +95,13 @@ CREATE VIEW v1 AS SELECT * FROM t1;
 SELECT COUNT(DISTINCT a, b) FROM v1;
 eval $trace;
 
+--echo # GROUP_CONCAT implements non-standard distinct aggregator
+SELECT GROUP_CONCAT(b) FROM t1;
+eval $trace;
+
+SELECT GROUP_CONCAT(DISTINCT b) FROM t1;
+eval $trace;
+
 DROP TABLE t1, t2, t3;
 DROP VIEW v1;
 SET optimizer_trace = @save_optimizer_trace;

--- a/mysql-test/main/opt_trace.result
+++ b/mysql-test/main/opt_trace.result
@@ -1507,6 +1507,12 @@ EXPLAIN SELECT MIN(d) FROM t1 where b=2 and c=3  group by a	{
           },
           {
             "test_if_skip_sort_order": []
+          },
+          {
+            "prepare_sum_aggregators": {
+              "function": "min(t1.d)",
+              "type of aggregator": "simple"
+            }
           }
         ]
       }
@@ -1708,6 +1714,18 @@ EXPLAIN SELECT id,MIN(a),MAX(a) FROM t1 WHERE a>=20010104e0 GROUP BY id	{
           },
           {
             "test_if_skip_sort_order": []
+          },
+          {
+            "prepare_sum_aggregators": {
+              "function": "min(t1.a)",
+              "type of aggregator": "simple"
+            }
+          },
+          {
+            "prepare_sum_aggregators": {
+              "function": "max(t1.a)",
+              "type of aggregator": "simple"
+            }
           }
         ]
       }

--- a/mysql-test/main/opt_trace.result
+++ b/mysql-test/main/opt_trace.result
@@ -1511,7 +1511,7 @@ EXPLAIN SELECT MIN(d) FROM t1 where b=2 and c=3  group by a	{
           {
             "prepare_sum_aggregators": {
               "function": "min(t1.d)",
-              "type of aggregator": "simple"
+              "aggregator_type": "simple"
             }
           }
         ]
@@ -1718,13 +1718,13 @@ EXPLAIN SELECT id,MIN(a),MAX(a) FROM t1 WHERE a>=20010104e0 GROUP BY id	{
           {
             "prepare_sum_aggregators": {
               "function": "min(t1.a)",
-              "type of aggregator": "simple"
+              "aggregator_type": "simple"
             }
           },
           {
             "prepare_sum_aggregators": {
               "function": "max(t1.a)",
-              "type of aggregator": "simple"
+              "aggregator_type": "simple"
             }
           }
         ]

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -2026,7 +2026,9 @@ protected:
     { return f->val_str(tmp, key + offset); }
   virtual void cut_max_length(String *result,
                               uint old_length, uint max_length) const;
-  bool uses_non_standard_aggregator_for_distinct() const { return distinct; }
+  bool uses_non_standard_aggregator_for_distinct() const override
+    { return distinct; }
+
 public:
   // Methods used by ColumnStore
   bool get_distinct() const { return distinct; }

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -599,6 +599,17 @@ public:
   bool is_window_func_sum_expr() { return window_func_sum_expr_flag; }
   virtual void setup_caches(THD *thd) {};
   virtual void set_partition_row_count(ulonglong count) { DBUG_ASSERT(0); }
+
+  /*
+    While most Item_sum descendants employ standard aggregators configured
+    through Item_sum::set_aggregator() call, there are exceptions like
+    Item_func_group_concat, which implements its own custom aggregators for
+    deduplication values.
+    This function distinguishes between the use of standard and custom
+    aggregators by the object
+  */
+  virtual bool uses_non_standard_aggregator_for_distinct() const
+  { return false; }
 };
 
 
@@ -2015,6 +2026,7 @@ protected:
     { return f->val_str(tmp, key + offset); }
   virtual void cut_max_length(String *result,
                               uint old_length, uint max_length) const;
+  bool uses_non_standard_aggregator_for_distinct() const { return distinct; }
 public:
   // Methods used by ColumnStore
   bool get_distinct() const { return distinct; }

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -27220,7 +27220,9 @@ bool JOIN::prepare_sum_aggregators(THD *thd,Item_sum **func_ptr,
     Json_writer_object trace_aggr(thd, "prepare_sum_aggregators");
     trace_aggr.add("function", func);
     trace_aggr.add("aggregator_type",
-                   need_distinct_aggregator ? "distinct" : "simple");
+                   (need_distinct_aggregator ||
+                    func->uses_non_standard_aggregator_for_distinct()) ?
+                      "distinct" : "simple");
     if (func->set_aggregator(thd,
                              need_distinct_aggregator ?
                              Aggregator::DISTINCT_AGGREGATOR :

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -27190,7 +27190,7 @@ bool JOIN::prepare_sum_aggregators(THD *thd,Item_sum **func_ptr,
       List<Item> arg_fields;
       for (uint i= 0; i < func->argument_count(); i++)
       {
-        if (func->arguments()[i]->type() == Item::FIELD_ITEM)
+        if (func->arguments()[i]->real_item()->type() == Item::FIELD_ITEM)
           arg_fields.push_back(func->arguments()[i]);
       }
 
@@ -27207,7 +27207,7 @@ bool JOIN::prepare_sum_aggregators(THD *thd,Item_sum **func_ptr,
       */
       for (ORDER *group= group_list; group ; group= group->next)
       {
-        if ((*group->item)->type() == Item::FIELD_ITEM)
+        if ((*group->item)->real_item()->type() == Item::FIELD_ITEM)
           arg_fields.push_back(*group->item);
       }
 
@@ -27219,7 +27219,7 @@ bool JOIN::prepare_sum_aggregators(THD *thd,Item_sum **func_ptr,
     Json_writer_object trace_wrapper(thd);
     Json_writer_object trace_aggr(thd, "prepare_sum_aggregators");
     trace_aggr.add("function", func);
-    trace_aggr.add("type of aggregator",
+    trace_aggr.add("aggregator_type",
                    need_distinct_aggregator ? "distinct" : "simple");
     if (func->set_aggregator(thd,
                              need_distinct_aggregator ?

--- a/sql/sql_select.h
+++ b/sql/sql_select.h
@@ -1849,6 +1849,8 @@ private:
   bool transform_all_conds_and_on_exprs_in_join_list(THD *thd,
                                                  List<TABLE_LIST> *join_list,
                                                  Item_transformer transformer);
+  bool prepare_sum_aggregators(THD *thd,Item_sum **func_ptr,
+                               bool need_distinct);
 };
 
 enum enum_with_bush_roots { WITH_BUSH_ROOTS, WITHOUT_BUSH_ROOTS};


### PR DESCRIPTION
If we have a statement like SELECT AGGFN(DISTINCT c1, c2,..,cn) FROM t1, where AGGFN is an aggregate function like COUNT(), AVG(), SUM(), and there is a unique index on table t1 including all columns (c1, c2,..,cn), the values retrieved from the table are guaranteed to be unique. So we can optimize aggregation and avoid de-duplicating of values, in other words - ignore the DISTINCT clause.
The restrictions are:
  - only one table involved in the join
  - all arguments of the aggregate function are fields (not functions/subqueries)

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_30660_*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
