### PR TITLE
MDEV-33283: Binlog Checksum is Zeroed by Zlib if Part of Event Data is Empty

### DIFF
--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -916,6 +916,10 @@ int Log_event_writer::write_header(uchar *pos, size_t len)
 int Log_event_writer::write_data(const uchar *pos, size_t len)
 {
   DBUG_ENTER("Log_event_writer::write_data");
+
+  if (!len)
+    DBUG_RETURN(0);
+
   if (checksum_len)
     crc= my_checksum(crc, pos, len);
 


### PR DESCRIPTION
An existing binlog checksum can be overridden to 0 if writing a NULL payload when using Zlib for the computation. That is, calling into Zlib's crc32 with empty data initializes an incremental CRC computation to 0.

This patch changes the Log_event_writer::write_data() to exit immediately if there is nothing to write, thereby bypassing the checksum computation. This follows the pattern of
Log_event_writer::encrypt_and_write(), which also exits immediately if there is no data to write.


See that this fixes the failing `rpl.rpl_sp_effects` test on [s390x](https://buildbot.mariadb.org/#/builders/476/builds/16004)
