### PR TITLE
MDEV-33301 memlock with systemd still not working

### DIFF
--- a/cmake/cpack_rpm.cmake
+++ b/cmake/cpack_rpm.cmake
@@ -163,6 +163,7 @@ SET(CPACK_RPM_server_USER_FILELIST
     ${ignored}
     "%config(noreplace) ${INSTALL_SYSCONF2DIR}/*"
     "%config(noreplace) ${INSTALL_SYSCONFDIR}/logrotate.d/mysql"
+    "%caps(cap_ipc_lock=pe) %{_sbindir}/mysqld"
     )
 SET(CPACK_RPM_common_USER_FILELIST ${ignored} "%config(noreplace) ${INSTALL_SYSCONFDIR}/my.cnf")
 SET(CPACK_RPM_shared_USER_FILELIST ${ignored} "%config(noreplace) ${INSTALL_SYSCONF2DIR}/*")

--- a/debian/mariadb-server-core-10.5.postinst
+++ b/debian/mariadb-server-core-10.5.postinst
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+# inspired by iputils-ping
+#
+# cap_ipc_lock is required if a user wants to use --memlock
+# and has insufficient RLIMIT_MEMLOCK (MDEV-33301)
+
+PROGRAM=$(dpkg-divert --truename /usr/sbin/mysqld)
+
+if [ "$1" = configure ]; then
+  # If we have setcap installed, try setting
+  # which allows us to install our binaries without the setuid
+  # bit.
+  if command -v setcap > /dev/null; then
+    if ! setcap cap_ipc_lock+ep "$PROGRAM"; then
+      echo "Setcap failed on $PROGRAM, required with --memlock if insufficent RLIMIT_MEMLOCK" >&2
+    fi
+  fi
+fi
+
+
+#DEBHELPER#
+
+exit 0

--- a/support-files/policy/apparmor/usr.sbin.mysqld
+++ b/support-files/policy/apparmor/usr.sbin.mysqld
@@ -14,6 +14,7 @@
 
   capability chown,
   capability dac_override,
+  capability ipc_lock,
   capability setgid,
   capability setuid,
   capability sys_rawio,

--- a/support-files/policy/selinux/mariadb-server.te
+++ b/support-files/policy/selinux/mariadb-server.te
@@ -25,7 +25,7 @@ require {
 	class lnk_file read;
 	class process { getattr signull };
 	class unix_stream_socket connectto;
-	class capability { sys_resource sys_nice };
+	class capability { ipc_lock sys_resource sys_nice };
 	class tcp_socket { name_bind name_connect };
 	class file { execute setattr read create getattr execute_no_trans write ioctl open append unlink };
 	class sock_file { create unlink getattr };
@@ -87,6 +87,8 @@ allow mysqld_t bin_t:file { getattr read execute open execute_no_trans ioctl };
 
 # MariaDB additions
 allow mysqld_t self:process setpgid;
+allow mysqld_t self:capability { ipc_lock };
+
 # This rule allows port tcp/4444
 allow mysqld_t kerberos_port_t:tcp_socket { name_bind name_connect };
 # This rule allows port tcp/4567 (tram_port_t may not be available on


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33301*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

CapabilityBoundingSet included CAP_IPC_LOCK in MDEV-9095, however it requires that the executable has the capability marked in extended attributes also.

The alternate to this is raising the RLIMIT_MEMLOCK for the service/ process to be able to complete the mlockall system call. This needs to be adjusted to whatever the MariaDB server was going to allocate. Rather than leave the non-obvious mapping of settings and tuning, add the capability so its easier for the user.

We set the capability, if possible, but may never be used depending on user settings. As such in the Debian postinst script, don't complain if this fails.

The CAP_IPC_LOCK also facilitates the mmaping of huge memory pages. (see man mmap).

## How can this PR be tested?

enable --memlock and a innodb_buffer_pool or similar larger than the default memlock limit (8M on my system). Start service. See if `@@locked_in_memory` is ON after the start.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.