### PR TITLE
Fix ninja build for cracklib_password_check

### DIFF
--- a/plugin/cracklib_password_check/CMakeLists.txt
+++ b/plugin/cracklib_password_check/CMakeLists.txt
@@ -32,11 +32,12 @@ IF (HAVE_ALLOCA_H AND HAVE_CRACK_H AND HAVE_LIBCRACK AND HAVE_MEMCPY)
     IF(CHECKMODULE AND SEMODULE_PACKAGE)
       FOREACH(pol mariadb-plugin-cracklib-password-check)
         SET(src ${CMAKE_CURRENT_SOURCE_DIR}/policy/selinux/${pol}.te)
-        SET(tmp ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${pol}-pp.dir/${pol}.mod)
+        SET(tmp ${CMAKE_CURRENT_BINARY_DIR}/${pol}.mod)
         SET(out ${CMAKE_CURRENT_BINARY_DIR}/${pol}.pp)
         ADD_CUSTOM_COMMAND(OUTPUT ${out}
           COMMAND ${CHECKMODULE} -M -m ${src} -o ${tmp}
           COMMAND ${SEMODULE_PACKAGE} -m ${tmp} -o ${out}
+          COMMAND ${CMAKE_COMMAND} -E remove ${tmp}
         DEPENDS ${src})
         ADD_CUSTOM_TARGET(${pol}-pp ALL DEPENDS ${out})
         INSTALL(FILES ${out} DESTINATION ${inst_location}/policy/selinux COMPONENT cracklib-password-check)


### PR DESCRIPTION
## Description

As was done in dc77111 for `support-files/CMakeLists.txt`
Do not rely on existence of `CMakeFiles/${target}.dir` directory existence
It is not there for custom targets in Ninja build.

This regression was introduced in #1131 which likely copied the pattern from e79e840 before that regression was addressed in dc77111.

## How can this PR be tested?

A passing build can be seen at https://salsa.debian.org/robinnewhouse/mariadb-server-mirror/-/pipelines/630860.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services.