### PR TITLE
MDEV-33274 The test encryption.innodb-redo-nokeys often fails

### DIFF
--- a/mysql-test/suite/encryption/r/innodb-redo-nokeys.result
+++ b/mysql-test/suite/encryption/r/innodb-redo-nokeys.result
@@ -8,8 +8,6 @@ call mtr.add_suppression("InnoDB: (Unable to apply log to|Discarding log for) co
 call mtr.add_suppression("InnoDB: Cannot apply log to \\[page id: space=[1-9][0-9]*, page number=0\\] of corrupted file '.*test.t[1-5]\\.ibd'");
 call mtr.add_suppression("InnoDB: Failed to read page .* from file '.*'");
 call mtr.add_suppression("InnoDB: OPT_PAGE_CHECKSUM mismatch");
-call mtr.add_suppression("InnoDB: Missing FILE_CHECKPOINT");
-call mtr.add_suppression("InnoDB: Log scan aborted at LSN");
 call mtr.add_suppression("InnoDB: Set innodb_force_recovery=1 to ignore corruption");
 call mtr.add_suppression("InnoDB: Encryption key is not found for");
 # restart: --file-key-management-filename=MYSQL_TEST_DIR/std_data/keys2.txt
@@ -23,6 +21,15 @@ insert into t2 select * from t1;
 insert into t3 select * from t1;
 insert into t4 select * from t1;
 commit;
+
+# Flush all dirty pages from buffer pool
+SET @no_checkpoint_save_pct= @@GLOBAL.innodb_max_dirty_pages_pct;
+SET @no_checkpoint_save_pct_lwm= @@GLOBAL.innodb_max_dirty_pages_pct_lwm;
+SET GLOBAL innodb_max_dirty_pages_pct_lwm=0.0;
+SET GLOBAL innodb_max_dirty_pages_pct=0.0;
+SET GLOBAL innodb_max_dirty_pages_pct= @no_checkpoint_save_pct;
+SET GLOBAL innodb_max_dirty_pages_pct_lwm= @no_checkpoint_save_pct_lwm;
+
 CREATE TABLE t5 (a VARCHAR(8)) ENGINE=InnoDB ENCRYPTED=YES;
 SET GLOBAL innodb_flush_log_at_trx_commit=1;
 begin;
@@ -42,6 +49,6 @@ SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 ENGINE	SUPPORT	COMMENT	TRANSACTIONS	XA	SAVEPOINTS
-FOUND 1 /\[ERROR\] InnoDB: Encryption key is not found for .*test.t1.ibd/ in mysqld.1.err
+FOUND 1 /\[ERROR\] InnoDB: Encryption key is not found for .*test.t[1-5].ibd/ in mysqld.1.err
 # restart: --file-key-management-filename=MYSQL_TEST_DIR/std_data/keys2.txt
 drop table t1,t2,t3,t4,t5;

--- a/mysql-test/suite/encryption/t/innodb-redo-nokeys.test
+++ b/mysql-test/suite/encryption/t/innodb-redo-nokeys.test
@@ -13,8 +13,6 @@ call mtr.add_suppression("InnoDB: (Unable to apply log to|Discarding log for) co
 call mtr.add_suppression("InnoDB: Cannot apply log to \\[page id: space=[1-9][0-9]*, page number=0\\] of corrupted file '.*test.t[1-5]\\.ibd'");
 call mtr.add_suppression("InnoDB: Failed to read page .* from file '.*'");
 call mtr.add_suppression("InnoDB: OPT_PAGE_CHECKSUM mismatch");
-call mtr.add_suppression("InnoDB: Missing FILE_CHECKPOINT");
-call mtr.add_suppression("InnoDB: Log scan aborted at LSN");
 call mtr.add_suppression("InnoDB: Set innodb_force_recovery=1 to ignore corruption");
 call mtr.add_suppression("InnoDB: Encryption key is not found for");
 
@@ -44,7 +42,9 @@ insert into t3 select * from t1;
 insert into t4 select * from t1;
 commit;
 
+let $no_checkpoint_flush= 1;
 --source ../../suite/innodb/include/no_checkpoint_start.inc
+
 #
 # We test redo log page read at recv_read_page using
 # keys that are not in std_data/keys.txt. If checkpoint
@@ -77,7 +77,7 @@ WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 
 let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err;
-let SEARCH_PATTERN = \[ERROR\] InnoDB: Encryption key is not found for .*test.t1.ibd;
+let SEARCH_PATTERN = \[ERROR\] InnoDB: Encryption key is not found for .*test.t[1-5].ibd;
 --source include/search_pattern_in_file.inc
 
 #

--- a/mysql-test/suite/innodb/include/no_checkpoint_start.inc
+++ b/mysql-test/suite/innodb/include/no_checkpoint_start.inc
@@ -1,5 +1,28 @@
 # Preparation for using no_checkpoint_end.inc
 
+# no_checkpoint_flush: Set to trigger flushing the dirty pages from buffer pool
+# and checkpoint before the "no checkpoint" block.
+
+if ($no_checkpoint_flush) {
+  --echo
+  --echo # Flush all dirty pages from buffer pool
+  SET @no_checkpoint_save_pct= @@GLOBAL.innodb_max_dirty_pages_pct;
+  SET @no_checkpoint_save_pct_lwm= @@GLOBAL.innodb_max_dirty_pages_pct_lwm;
+
+  SET GLOBAL innodb_max_dirty_pages_pct_lwm=0.0;
+  SET GLOBAL innodb_max_dirty_pages_pct=0.0;
+
+  let $wait_condition =
+  SELECT variable_value = 0
+  FROM information_schema.global_status
+  WHERE variable_name = 'INNODB_BUFFER_POOL_PAGES_DIRTY';
+  --source include/wait_condition.inc
+
+  SET GLOBAL innodb_max_dirty_pages_pct= @no_checkpoint_save_pct;
+  SET GLOBAL innodb_max_dirty_pages_pct_lwm= @no_checkpoint_save_pct_lwm;
+  --echo
+}
+
 let MYSQLD_DATADIR= `select @@datadir`;
 --replace_regex /.*Last checkpoint at[ 	]*([0-9]+).*/\1/
 let CHECKPOINT_LSN=`SHOW ENGINE INNODB STATUS`;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33274*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
1. If we fail to open a tablespace while looking for FILE_CHECKPOINT, we set the corruption flag. Specifically, if encryption key is missing, we would not be able to open an encrypted tablespace and the flag could be set. We miss checking for this flag and report "Missing FILE_CHECKPOINT"
  [ERROR] InnoDB: Missing FILE_CHECKPOINT(xxx) at xxx
  [ERROR] InnoDB: Log scan aborted at LSN xxx

2. Based on the dynamic flushes and checkpoint we could return error for any one of t1-t5 encrypted table. The test needs to be corrected.
  NOT FOUND[ERROR] InnoDB: Encryption key is not found for .*test.t1.ibd

## How can this PR be tested?

./mtr encryption.innodb-redo-nokeys
Please check the MDEV for temporary changes suggested in test to for faster reproduction.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
