### PR TITLE
MDEV-30528 CREATE FULLTEXT INDEX assertion failure WITH SYSTEM VERSIONING

### DIFF
--- a/mysql-test/suite/innodb_fts/r/innodb-fts-ddl,vers.rdiff
+++ b/mysql-test/suite/innodb_fts/r/innodb-fts-ddl,vers.rdiff
@@ -1,0 +1,57 @@
+--- innodb-fts-ddl.result
++++ innodb-fts-ddl.reject
+@@ -11,8 +11,10 @@
+ ('MySQL vs. YourSQL','In the following database comparison ...'),
+ ('MySQL Security','When configured properly, MySQL ...');
+ ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
+-ERROR 0A000: ALGORITHM=NOCOPY is not supported for this operation. Try ALGORITHM=INPLACE
+-ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=INPLACE;
++ERROR 0A000: ALGORITHM=NOCOPY is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
++ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
++affected rows: 6
++info: Records: 6  Duplicates: 0  Warnings: 0
+ SELECT * FROM fts_test WHERE MATCH (title, body)
+ AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+ id	title	body
+@@ -26,7 +28,9 @@
+ ('1001 MySQL Tricks','1. Never run mysqld as root. 2. ...'),
+ ('MySQL vs. YourSQL','In the following database comparison ...'),
+ ('MySQL Security','When configured properly, MySQL ...');
+-ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
++ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
++affected rows: 12
++info: Records: 12  Duplicates: 0  Warnings: 0
+ SELECT * FROM fts_test WHERE MATCH (title, body)
+ AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+ id	title	body
+@@ -76,8 +80,10 @@
+ ('MySQL vs. YourSQL','In the following database comparison ...'),
+ ('MySQL Security','When configured properly, MySQL ...');
+ CREATE FULLTEXT INDEX idx on fts_test (title, body) LOCK=NONE;
+-ERROR 0A000: LOCK=NONE is not supported. Reason: Fulltext index creation requires a lock. Try LOCK=SHARED
+-ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
++ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned operations. Try LOCK=SHARED
++ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
++affected rows: 6
++info: Records: 6  Duplicates: 0  Warnings: 0
+ ALTER TABLE fts_test ROW_FORMAT=REDUNDANT, LOCK=NONE;
+ ERROR 0A000: LOCK=NONE is not supported. Reason: Fulltext index creation requires a lock. Try LOCK=SHARED
+ ALTER TABLE fts_test ROW_FORMAT=REDUNDANT;
+@@ -162,7 +168,7 @@
+ (20, 'MySQL Security','When configured properly, MySQL ...');
+ ALTER TABLE articles ADD FULLTEXT INDEX idx (title),
+ ADD FULLTEXT INDEX idx3 (title), ALGORITHM=INPLACE;
+-ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: InnoDB presently supports one FULLTEXT index creation at a time. Try ALGORITHM=COPY
++ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
+ ALTER TABLE articles ADD FULLTEXT INDEX idx (title),
+ ADD FULLTEXT INDEX idx3 (title);
+ affected rows: 6
+@@ -274,7 +280,7 @@
+ call mtr.add_suppression("InnoDB: Failed to create");
+ CREATE TABLE t1(a TEXT, FTS_DOC_ID BIGINT UNSIGNED NOT NULL UNIQUE) ENGINE=InnoDB;
+ ALTER TABLE t1 ADD FULLTEXT(a), ALGORITHM=INPLACE;
+-ERROR HY000: Got error 11 "Resource temporarily unavailable" from storage engine InnoDB
++ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
+ DROP TABLE t1;
+ CREATE TABLE t1 (a VARCHAR(3)) ENGINE=InnoDB;
+ ALTER TABLE t1 ADD FULLTEXT KEY(a), ADD COLUMN b VARCHAR(3), ADD FULLTEXT KEY(b);

--- a/mysql-test/suite/innodb_fts/r/innodb-fts-ddl,vers_trx.rdiff
+++ b/mysql-test/suite/innodb_fts/r/innodb-fts-ddl,vers_trx.rdiff
@@ -1,0 +1,57 @@
+--- innodb-fts-ddl.result
++++ innodb-fts-ddl.reject
+@@ -11,8 +11,10 @@
+ ('MySQL vs. YourSQL','In the following database comparison ...'),
+ ('MySQL Security','When configured properly, MySQL ...');
+ ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
+-ERROR 0A000: ALGORITHM=NOCOPY is not supported for this operation. Try ALGORITHM=INPLACE
+-ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=INPLACE;
++ERROR 0A000: ALGORITHM=NOCOPY is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
++ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
++affected rows: 6
++info: Records: 6  Duplicates: 0  Warnings: 0
+ SELECT * FROM fts_test WHERE MATCH (title, body)
+ AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+ id	title	body
+@@ -26,7 +28,9 @@
+ ('1001 MySQL Tricks','1. Never run mysqld as root. 2. ...'),
+ ('MySQL vs. YourSQL','In the following database comparison ...'),
+ ('MySQL Security','When configured properly, MySQL ...');
+-ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
++ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
++affected rows: 12
++info: Records: 12  Duplicates: 0  Warnings: 0
+ SELECT * FROM fts_test WHERE MATCH (title, body)
+ AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+ id	title	body
+@@ -76,8 +80,10 @@
+ ('MySQL vs. YourSQL','In the following database comparison ...'),
+ ('MySQL Security','When configured properly, MySQL ...');
+ CREATE FULLTEXT INDEX idx on fts_test (title, body) LOCK=NONE;
+-ERROR 0A000: LOCK=NONE is not supported. Reason: Fulltext index creation requires a lock. Try LOCK=SHARED
+-ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
++ERROR 0A000: LOCK=NONE is not supported. Reason: Not implemented for system-versioned operations. Try LOCK=SHARED
++ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
++affected rows: 6
++info: Records: 6  Duplicates: 0  Warnings: 0
+ ALTER TABLE fts_test ROW_FORMAT=REDUNDANT, LOCK=NONE;
+ ERROR 0A000: LOCK=NONE is not supported. Reason: Fulltext index creation requires a lock. Try LOCK=SHARED
+ ALTER TABLE fts_test ROW_FORMAT=REDUNDANT;
+@@ -162,7 +168,7 @@
+ (20, 'MySQL Security','When configured properly, MySQL ...');
+ ALTER TABLE articles ADD FULLTEXT INDEX idx (title),
+ ADD FULLTEXT INDEX idx3 (title), ALGORITHM=INPLACE;
+-ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: InnoDB presently supports one FULLTEXT index creation at a time. Try ALGORITHM=COPY
++ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
+ ALTER TABLE articles ADD FULLTEXT INDEX idx (title),
+ ADD FULLTEXT INDEX idx3 (title);
+ affected rows: 6
+@@ -274,7 +280,7 @@
+ call mtr.add_suppression("InnoDB: Failed to create");
+ CREATE TABLE t1(a TEXT, FTS_DOC_ID BIGINT UNSIGNED NOT NULL UNIQUE) ENGINE=InnoDB;
+ ALTER TABLE t1 ADD FULLTEXT(a), ALGORITHM=INPLACE;
+-ERROR HY000: Got error 11 "Resource temporarily unavailable" from storage engine InnoDB
++ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
+ DROP TABLE t1;
+ CREATE TABLE t1 (a VARCHAR(3)) ENGINE=InnoDB;
+ ALTER TABLE t1 ADD FULLTEXT KEY(a), ADD COLUMN b VARCHAR(3), ADD FULLTEXT KEY(b);

--- a/mysql-test/suite/innodb_fts/r/innodb-fts-fic,vers.rdiff
+++ b/mysql-test/suite/innodb_fts/r/innodb-fts-fic,vers.rdiff
@@ -1,0 +1,10 @@
+--- innodb-fts-fic.result
++++ innodb-fts-fic.reject
+@@ -172,7 +172,6 @@
+ (1, 'MySQL Tutorial','DBMS stands for DataBase ...'),
+ (2, 'How To Use MySQL Well','After you went through a ...');
+ CREATE FULLTEXT INDEX idx ON wp(title, text);
+-ERROR HY000: Column 'FTS_DOC_ID' is of wrong type for an InnoDB FULLTEXT index
+ DROP TABLE wp;
+ CREATE TABLE wp(
+ FTS_DOC_ID bigint unsigned PRIMARY KEY,

--- a/mysql-test/suite/innodb_fts/r/innodb-fts-fic,vers_trx.rdiff
+++ b/mysql-test/suite/innodb_fts/r/innodb-fts-fic,vers_trx.rdiff
@@ -1,0 +1,10 @@
+--- innodb-fts-fic.result
++++ innodb-fts-fic.reject
+@@ -172,7 +172,6 @@
+ (1, 'MySQL Tutorial','DBMS stands for DataBase ...'),
+ (2, 'How To Use MySQL Well','After you went through a ...');
+ CREATE FULLTEXT INDEX idx ON wp(title, text);
+-ERROR HY000: Column 'FTS_DOC_ID' is of wrong type for an InnoDB FULLTEXT index
+ DROP TABLE wp;
+ CREATE TABLE wp(
+ FTS_DOC_ID bigint unsigned PRIMARY KEY,

--- a/mysql-test/suite/innodb_fts/r/misc_debug,vers.rdiff
+++ b/mysql-test/suite/innodb_fts/r/misc_debug,vers.rdiff
@@ -1,0 +1,53 @@
+--- misc_debug.result
++++ misc_debug.reject
+@@ -7,14 +7,14 @@
+ SET @saved_debug_dbug = @@SESSION.debug_dbug;
+ SET SESSION debug_dbug="+d,ib_dict_create_index_tree_fail";
+ CREATE FULLTEXT INDEX idx ON articles(body);
+-ERROR HY000: Out of memory.
++ERROR HY000: Can't create table `test`.`articles` (errno: 128 "Out of memory in engine")
+ SET SESSION debug_dbug=@saved_debug_dbug;
+ ALTER TABLE articles STATS_PERSISTENT=DEFAULT;
+ DROP TABLE articles;
+ CREATE TABLE t (a INT, b TEXT) engine=innodb;
+ SET debug_dbug='+d,alter_table_rollback_new_index';
+-ALTER TABLE t ADD FULLTEXT INDEX (b(64));
+-ERROR HY000: Unknown error
++ALTER TABLE t ADD FULLTEXT INDEX (b(64)), ALGORITHM=INPLACE;
++ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
+ SET SESSION debug_dbug=@saved_debug_dbug;
+ DROP TABLE t;
+ CREATE TABLE t1 (pk INT, a VARCHAR(8), PRIMARY KEY(pk),
+@@ -27,32 +27,6 @@
+ ALTER TABLE t1 FORCE;
+ DROP TABLE t2, t1;
+ #
+-# MDEV-25200 Index count mismatch due to aborted FULLTEXT INDEX
+-#
+-CREATE TABLE t1(a INT, b TEXT, c TEXT, FULLTEXT INDEX(b)) ENGINE=InnoDB;
+-INSERT INTO t1 VALUES(1, "test", "test_1");
+-connect con1,localhost,root,,test;
+-SET DEBUG_DBUG="+d,innodb_OOM_inplace_alter";
+-SET DEBUG_SYNC='innodb_commit_inplace_alter_table_enter SIGNAL s2 WAIT_FOR g2';
+-ALTER TABLE t1 ADD FULLTEXT(c);
+-connection default;
+-SET DEBUG_SYNC='now WAIT_FOR s2';
+-START TRANSACTION;
+-SELECT * FROM t1;
+-a	b	c
+-1	test	test_1
+-SET DEBUG_SYNC='now SIGNAL g2';
+-connection con1;
+-ERROR HY000: Out of memory.
+-disconnect con1;
+-connection default;
+-SET DEBUG_SYNC=RESET;
+-ALTER TABLE t1 ADD bl INT AS (LENGTH(b)) VIRTUAL;
+-CHECK TABLE t1;
+-Table	Op	Msg_type	Msg_text
+-test.t1	check	status	OK
+-DROP TABLE t1;
+-#
+ # MDEV-25663 Double free of transaction during TRUNCATE
+ #
+ call mtr.add_suppression("InnoDB: \\(Too many concurrent transactions\\)");

--- a/mysql-test/suite/innodb_fts/r/misc_debug,vers_trx.rdiff
+++ b/mysql-test/suite/innodb_fts/r/misc_debug,vers_trx.rdiff
@@ -1,0 +1,53 @@
+--- misc_debug.result
++++ misc_debug.reject
+@@ -7,14 +7,14 @@
+ SET @saved_debug_dbug = @@SESSION.debug_dbug;
+ SET SESSION debug_dbug="+d,ib_dict_create_index_tree_fail";
+ CREATE FULLTEXT INDEX idx ON articles(body);
+-ERROR HY000: Out of memory.
++ERROR HY000: Can't create table `test`.`articles` (errno: 128 "Out of memory in engine")
+ SET SESSION debug_dbug=@saved_debug_dbug;
+ ALTER TABLE articles STATS_PERSISTENT=DEFAULT;
+ DROP TABLE articles;
+ CREATE TABLE t (a INT, b TEXT) engine=innodb;
+ SET debug_dbug='+d,alter_table_rollback_new_index';
+-ALTER TABLE t ADD FULLTEXT INDEX (b(64));
+-ERROR HY000: Unknown error
++ALTER TABLE t ADD FULLTEXT INDEX (b(64)), ALGORITHM=INPLACE;
++ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Not implemented for system-versioned operations. Try ALGORITHM=COPY
+ SET SESSION debug_dbug=@saved_debug_dbug;
+ DROP TABLE t;
+ CREATE TABLE t1 (pk INT, a VARCHAR(8), PRIMARY KEY(pk),
+@@ -27,32 +27,6 @@
+ ALTER TABLE t1 FORCE;
+ DROP TABLE t2, t1;
+ #
+-# MDEV-25200 Index count mismatch due to aborted FULLTEXT INDEX
+-#
+-CREATE TABLE t1(a INT, b TEXT, c TEXT, FULLTEXT INDEX(b)) ENGINE=InnoDB;
+-INSERT INTO t1 VALUES(1, "test", "test_1");
+-connect con1,localhost,root,,test;
+-SET DEBUG_DBUG="+d,innodb_OOM_inplace_alter";
+-SET DEBUG_SYNC='innodb_commit_inplace_alter_table_enter SIGNAL s2 WAIT_FOR g2';
+-ALTER TABLE t1 ADD FULLTEXT(c);
+-connection default;
+-SET DEBUG_SYNC='now WAIT_FOR s2';
+-START TRANSACTION;
+-SELECT * FROM t1;
+-a	b	c
+-1	test	test_1
+-SET DEBUG_SYNC='now SIGNAL g2';
+-connection con1;
+-ERROR HY000: Out of memory.
+-disconnect con1;
+-connection default;
+-SET DEBUG_SYNC=RESET;
+-ALTER TABLE t1 ADD bl INT AS (LENGTH(b)) VIRTUAL;
+-CHECK TABLE t1;
+-Table	Op	Msg_type	Msg_text
+-test.t1	check	status	OK
+-DROP TABLE t1;
+-#
+ # MDEV-25663 Double free of transaction during TRUNCATE
+ #
+ call mtr.add_suppression("InnoDB: \\(Too many concurrent transactions\\)");

--- a/mysql-test/suite/innodb_fts/r/sync_ddl,vers.rdiff
+++ b/mysql-test/suite/innodb_fts/r/sync_ddl,vers.rdiff
@@ -1,0 +1,12 @@
+--- sync_ddl.result
++++ sync_ddl.reject
+@@ -100,7 +100,7 @@
+ ADD COLUMN id2 INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+ DROP INDEX idx1,
+ ADD FULLTEXT INDEX idx2(value);
+-affected rows: 0
+-info: Records: 0  Duplicates: 0  Warnings: 0
++affected rows: 2
++info: Records: 2  Duplicates: 0  Warnings: 0
+ DROP TABLE t1;
+ SET GLOBAL debug_dbug = @save_debug;

--- a/mysql-test/suite/innodb_fts/r/sync_ddl,vers_trx.rdiff
+++ b/mysql-test/suite/innodb_fts/r/sync_ddl,vers_trx.rdiff
@@ -1,0 +1,12 @@
+--- sync_ddl.result
++++ sync_ddl.reject
+@@ -100,7 +100,7 @@
+ ADD COLUMN id2 INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+ DROP INDEX idx1,
+ ADD FULLTEXT INDEX idx2(value);
+-affected rows: 0
+-info: Records: 0  Duplicates: 0  Warnings: 0
++affected rows: 2
++info: Records: 2  Duplicates: 0  Warnings: 0
+ DROP TABLE t1;
+ SET GLOBAL debug_dbug = @save_debug;

--- a/mysql-test/suite/innodb_fts/r/sync_ddl.result
+++ b/mysql-test/suite/innodb_fts/r/sync_ddl.result
@@ -99,7 +99,8 @@ ALTER TABLE t1
 DROP COLUMN id1,
 ADD COLUMN id2 INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
 DROP INDEX idx1,
-ADD FULLTEXT INDEX idx2(value),
-ALGORITHM=INPLACE;
+ADD FULLTEXT INDEX idx2(value);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
 DROP TABLE t1;
 SET GLOBAL debug_dbug = @save_debug;

--- a/mysql-test/suite/innodb_fts/t/innodb-fts-ddl.test
+++ b/mysql-test/suite/innodb_fts/t/innodb-fts-ddl.test
@@ -20,11 +20,20 @@ INSERT INTO fts_test (title,body) VALUES
 	('MySQL Security','When configured properly, MySQL ...');
 
 # Table does rebuild when fts index builds for the first time
+# Create the FTS index
+
+if ($MTR_COMBINATION_ORIG) {
 --error ER_ALTER_OPERATION_NOT_SUPPORTED
 ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
-
-# Create the FTS index
 ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=INPLACE;
+}
+if (!$MTR_COMBINATION_ORIG) {
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
+--enable_info
+ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
+--disable_info
+}
 
 # Select word "tutorial" in the table
 SELECT * FROM fts_test WHERE MATCH (title, body)
@@ -43,7 +52,14 @@ INSERT INTO fts_test (title,body) VALUES
 	('MySQL Security','When configured properly, MySQL ...');
 
 # FTS_DOC_ID hidden column and FTS_DOC_ID index exist
+if ($MTR_COMBINATION_ORIG) {
 ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
+}
+if (!$MTR_COMBINATION_ORIG) {
+--enable_info
+ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
+--disable_info
+}
 
 # Select word "tutorial" in the table
 SELECT * FROM fts_test WHERE MATCH (title, body)
@@ -112,7 +128,14 @@ INSERT INTO fts_test (title,body) VALUES
 # column already exists. This has not been implemented yet.
 --error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
 CREATE FULLTEXT INDEX idx on fts_test (title, body) LOCK=NONE;
+if ($MTR_COMBINATION_ORIG) {
 ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body), ALGORITHM=NOCOPY;
+}
+if (!$MTR_COMBINATION_ORIG) {
+--enable_info
+ALTER TABLE fts_test ADD FULLTEXT `idx` (title, body);
+--disable_info
+}
 
 --error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
 ALTER TABLE fts_test ROW_FORMAT=REDUNDANT, LOCK=NONE;
@@ -349,8 +372,14 @@ let $fts_aux_file= `select concat('FTS_',right(concat(repeat('0',16), lower(hex(
 write_file $MYSQLD_DATADIR/test/$fts_aux_file;
 EOF
 --replace_regex /".*" from/"Resource temporarily unavailable" from/
+if ($MTR_COMBINATION_ORIG) {
 --error ER_GET_ERRNO
 ALTER TABLE t1 ADD FULLTEXT(a), ALGORITHM=INPLACE;
+}
+if (!$MTR_COMBINATION_ORIG) {
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t1 ADD FULLTEXT(a), ALGORITHM=INPLACE;
+}
 DROP TABLE t1;
 remove_file $MYSQLD_DATADIR/test/$fts_aux_file;
 

--- a/mysql-test/suite/innodb_fts/t/innodb-fts-fic.test
+++ b/mysql-test/suite/innodb_fts/t/innodb-fts-fic.test
@@ -211,8 +211,13 @@ INSERT INTO wp (FTS_DOC_ID, title, text) VALUES
    (1, 'MySQL Tutorial','DBMS stands for DataBase ...'),
    (2, 'How To Use MySQL Well','After you went through a ...');
 
+if ($MTR_COMBINATION_ORIG) {
 --error ER_INNODB_FT_WRONG_DOCID_COLUMN
 CREATE FULLTEXT INDEX idx ON wp(title, text);
+}
+if (!$MTR_COMBINATION_ORIG) {
+CREATE FULLTEXT INDEX idx ON wp(title, text);
+}
 
 DROP TABLE wp;
 CREATE TABLE wp(

--- a/mysql-test/suite/innodb_fts/t/misc_debug.test
+++ b/mysql-test/suite/innodb_fts/t/misc_debug.test
@@ -23,8 +23,14 @@ CREATE TABLE articles (
 # The newly create dict_index_t should be removed from fts cache
 SET @saved_debug_dbug = @@SESSION.debug_dbug;
 SET SESSION debug_dbug="+d,ib_dict_create_index_tree_fail";
+if ($MTR_COMBINATION_ORIG) {
 --error ER_OUT_OF_RESOURCES
 CREATE FULLTEXT INDEX idx ON articles(body);
+}
+if (!$MTR_COMBINATION_ORIG) {
+--error ER_CANT_CREATE_TABLE
+CREATE FULLTEXT INDEX idx ON articles(body);
+}
 SET SESSION debug_dbug=@saved_debug_dbug;
 
 # This simply go through ha_innobase::commit_inplace_alter_table
@@ -37,8 +43,14 @@ DROP TABLE articles;
 
 CREATE TABLE t (a INT, b TEXT) engine=innodb;
 SET debug_dbug='+d,alter_table_rollback_new_index';
+if ($MTR_COMBINATION_ORIG) {
 -- error ER_UNKNOWN_ERROR
 ALTER TABLE t ADD FULLTEXT INDEX (b(64));
+}
+if (!$MTR_COMBINATION_ORIG) {
+-- error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+ALTER TABLE t ADD FULLTEXT INDEX (b(64)), ALGORITHM=INPLACE;
+}
 SET SESSION debug_dbug=@saved_debug_dbug;
 
 DROP TABLE t;
@@ -56,6 +68,7 @@ ALTER TABLE t1 FORCE;
 # Cleanup
 DROP TABLE t2, t1;
 
+if ($MTR_COMBINATION_ORIG) {
 --echo #
 --echo # MDEV-25200 Index count mismatch due to aborted FULLTEXT INDEX
 --echo #
@@ -81,6 +94,7 @@ ALTER TABLE t1 ADD bl INT AS (LENGTH(b)) VIRTUAL;
 CHECK TABLE t1;
 DROP TABLE t1;
 --source include/wait_until_count_sessions.inc
+}
 
 --echo #
 --echo # MDEV-25663 Double free of transaction during TRUNCATE

--- a/mysql-test/suite/innodb_fts/t/sync_ddl.test
+++ b/mysql-test/suite/innodb_fts/t/sync_ddl.test
@@ -182,12 +182,13 @@ INSERT INTO t1 (value) VALUES
     ('collation of latin1_bin to make it case sensitive')
     ;
 
+--enable_info
 ALTER TABLE t1
     DROP COLUMN id1,
     ADD COLUMN id2 INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     DROP INDEX idx1,
-    ADD FULLTEXT INDEX idx2(value),
-    ALGORITHM=INPLACE;
+    ADD FULLTEXT INDEX idx2(value);
+--disable_info
 
 DROP TABLE t1;
 

--- a/mysql-test/suite/versioning/r/alter.result
+++ b/mysql-test/suite/versioning/r/alter.result
@@ -845,3 +845,15 @@ Warnings:
 Note	1060	Duplicate column name 'v'
 alter table `b` add column if not exists ( p bit );
 drop table `b`;
+#
+# MDEV-30528 Assertion !mbmaxlen || ... failed
+# in dtype_get_at_most_n_mbchars()
+#
+CREATE TABLE t(f TEXT) WITH SYSTEM VERSIONING CHARACTER SET utf8 ENGINE=InnoDB;
+INSERT INTO t VALUES ('foo');
+DELETE FROM t;
+ALTER TABLE t ADD FULLTEXT (f);
+affected rows: 1
+info: Records: 1  Duplicates: 0  Warnings: 0
+DROP TABLE t;
+# End of 10.4 tests

--- a/mysql-test/suite/versioning/t/alter.test
+++ b/mysql-test/suite/versioning/t/alter.test
@@ -739,3 +739,18 @@ alter table `b` add system versioning;
 alter table `b` add column if not exists ( w bit, v serial );
 alter table `b` add column if not exists ( p bit );
 drop table `b`;
+
+--echo #
+--echo # MDEV-30528 Assertion !mbmaxlen || ... failed
+--echo # in dtype_get_at_most_n_mbchars()
+--echo #
+
+CREATE TABLE t(f TEXT) WITH SYSTEM VERSIONING CHARACTER SET utf8 ENGINE=InnoDB;
+INSERT INTO t VALUES ('foo');
+DELETE FROM t;
+--enable_info
+ALTER TABLE t ADD FULLTEXT (f);
+--disable_info
+DROP TABLE t;
+
+--echo # End of 10.4 tests

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -457,8 +457,6 @@ row_merge_buf_redundant_convert(
 @param[in,out]	row		table row
 @param[in]	ext		cache of externally stored
 				column prefixes, or NULL
-@param[in]	history_fts	row is historical in a system-versioned table
-				on which a FTS_DOC_ID_INDEX(FTS_DOC_ID) exists
 @param[in,out]	doc_id		Doc ID if we are creating
 				FTS index
 @param[in,out]	conv_heap	memory heap where to allocate data when
@@ -480,7 +478,6 @@ row_merge_buf_add(
 	fts_psort_t*		psort_info,
 	dtuple_t*		row,
 	const row_ext_t*	ext,
-	const bool		history_fts,
 	doc_id_t*		doc_id,
 	mem_heap_t*		conv_heap,
 	dberr_t*		err,
@@ -543,7 +540,7 @@ error:
 			: NULL;
 
 		/* Process the Doc ID column */
-		if (!v_col && (history_fts || *doc_id)
+		if (!v_col && *doc_id
 		    && col->ind == index->table->fts->doc_col) {
 			fts_write_doc_id((byte*) &write_doc_id, *doc_id);
 
@@ -595,7 +592,7 @@ error:
 
 
 			/* Tokenize and process data for FTS */
-			if (!history_fts && (index->type & DICT_FTS)) {
+			if (index->type & DICT_FTS) {
 				fts_doc_item_t*	doc_item;
 				byte*		value;
 				void*		ptr;
@@ -1707,6 +1704,7 @@ row_merge_read_clustered_index(
 	DBUG_ENTER("row_merge_read_clustered_index");
 
 	ut_ad((old_table == new_table) == !col_map);
+	ut_ad(old_table->fts || !new_table->fts || !new_table->versioned());
 	ut_ad(!defaults || col_map);
 	ut_ad(trx_state_eq(trx, TRX_STATE_ACTIVE));
 	ut_ad(trx->id);
@@ -1892,7 +1890,6 @@ row_merge_read_clustered_index(
 		dtuple_t*	row;
 		row_ext_t*	ext;
 		page_cur_t*	cur	= btr_pcur_get_page_cur(&pcur);
-		bool history_row, history_fts = false;
 
 		page_cur_move_to_next(cur);
 
@@ -2130,11 +2127,6 @@ end_of_index:
 					   row_heap);
 		ut_ad(row);
 
-		history_row = new_table->versioned()
-		       && dtuple_get_nth_field(row, new_table->vers_end)
-		       ->vers_history_row();
-		history_fts = history_row && new_table->fts;
-
 		for (ulint i = 0; i < n_nonnull; i++) {
 			dfield_t*	field	= &row->fields[nonnull[i]];
 
@@ -2164,7 +2156,7 @@ end_of_index:
 		}
 
 		/* Get the next Doc ID */
-		if (add_doc_id && !history_fts) {
+		if (add_doc_id) {
 			doc_id++;
 		} else {
 			doc_id = 0;
@@ -2204,7 +2196,9 @@ end_of_index:
 								add_autoinc);
 
 			if (new_table->versioned()) {
-				if (history_row) {
+				if (dtuple_get_nth_field(row,
+							 new_table->vers_end)
+				    ->vers_history_row()) {
 					if (dfield_get_type(dfield)->prtype & DATA_NOT_NULL) {
 						err = DB_UNSUPPORTED;
 						my_error(ER_UNSUPPORTED_EXTENSION, MYF(0),
@@ -2323,7 +2317,7 @@ write_buffers:
 			if (UNIV_LIKELY
 			    (row && (rows_added = row_merge_buf_add(
 					buf, fts_index, old_table, new_table,
-					psort_info, row, ext, history_fts,
+					psort_info, row, ext,
 					&doc_id, conv_heap, &err,
 					&v_heap, eval_table, trx)))) {
 
@@ -2657,7 +2651,7 @@ write_buffers:
 				    (!(rows_added = row_merge_buf_add(
 						buf, fts_index, old_table,
 						new_table, psort_info,
-						row, ext, history_fts, &doc_id,
+						row, ext, &doc_id,
 						conv_heap, &err, &v_heap,
 						eval_table, trx)))) {
                                         /* An empty buffer should have enough


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-30528*
## Description
`ha_innobase::check_if_supported_inplace_alter()`: Require `ALGORITHM=COPY` when creating a `FULLTEXT INDEX` on a versioned table.

`row_merge_buf_add()`, `row_merge_read_clustered_index()`: Remove the parameter or local variable `history_fts` that had been added in the attempt to fix MDEV-25004.

## How can this PR be tested?
This is covered by changes to existing tests, including an addition to the test `versioning.alter`.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.