### PR TITLE
MDEV-7850: GTID Thread_id Post-Push Fixes

### DIFF
--- a/mysql-test/suite/galera_sr/r/MDEV-18585.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-18585.result
@@ -12,7 +12,7 @@ SET SESSION wsrep_trx_fragment_size=1;
 INSERT INTO t1 VALUES (5), (6);
 SET SESSION wsrep_trx_fragment_unit=default;
 SET SESSION wsrep_trx_fragment_size=default;
-SHOW BINLOG EVENTS IN 'mysqld-bin.000002' FROM 527;
+SHOW BINLOG EVENTS IN 'mysqld-bin.000002' FROM 530;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 mysqld-bin.000002	#	Gtid	1	#	BEGIN GTID 0-1-2
 mysqld-bin.000002	#	Annotate_rows	1	#	INSERT INTO t1 VALUES (1), (2)

--- a/mysql-test/suite/rpl/r/rpl_gtid_thread_id.result
+++ b/mysql-test/suite/rpl/r/rpl_gtid_thread_id.result
@@ -12,18 +12,19 @@ connection master;
 include/assert_grep.inc [Ensure only 3 GTID events exist (Primary)]
 include/assert_grep.inc [Ensure each GTID event has the thread id (Primary)]
 #
-# GTID event's thread_id should not use psuedo_thread_id
+# GTID event's thread_id should use psuedo_thread_id
 connection master;
 set @@pseudo_thread_id=99999;
 insert into t1 values(2);
 # MYSQL_BINLOG local > primary_outfile
-include/assert_grep.inc [GTID event's thread_id does not use pseudo_thread_id]
+include/assert_grep.inc [GTID event's thread_id should use pseudo_thread_id]
 #
 # Test the serial replica
 connection slave;
 # MYSQL_BINLOG local > replica_outfile
 include/assert_grep.inc [Ensure the same number of GTID events on the replica as the primary]
-include/assert_grep.inc [Ensure each GTID event has the thread id of the SQL Thread]
+include/assert_grep.inc [Ensure GTID events logged with primary's thread id maintain that value]
+include/assert_grep.inc [Ensure GTID event logged with pseudo_thread_id on primary maintains that value]
 #
 # Test the parallel replica
 connection slave;
@@ -37,7 +38,7 @@ connection slave;
 connection slave;
 # MYSQL_BINLOG local > replica_outfile
 include/assert_grep.inc [Ensure the same number of GTID events on the replica as the primary]
-include/assert_grep.inc [Ensure only the new GTID events have the thread id of the worker thread]
+include/assert_grep.inc [Ensure GTID the new events are logged on the replica with the thread_id of the master primary thread id]
 include/stop_slave.inc
 SET @@GLOBAL.slave_parallel_threads=0;
 include/start_slave.inc

--- a/mysql-test/suite/rpl/t/rpl_gtid_thread_id.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_thread_id.test
@@ -1,9 +1,8 @@
 #
 #   Verify that GTID log events are written into the binary log along with the
-# id of the thread which executed the transaction. On the primary, this is the
-# id of the user connection. On a replica, this is either the id of the SQL
-# Thread id, if serial, or the id of the corresponding worker thread, if
-# parallel. Psuedo_thread_id is disregarded and only used for Query log events.
+# id of the thread which originally executed the transaction. On the primary,
+# this is the id of the user connection (or the pseudo_thread_id). The replica
+# should maintain this value when binlogging.
 #
 # References:
 #   MDEV-7850:  MariaDB doesn't show thread_id for ROW-based events in binlog
@@ -38,7 +37,7 @@ optimize table t1;
 --source include/assert_grep.inc
 
 --echo #
---echo # GTID event's thread_id should not use psuedo_thread_id
+--echo # GTID event's thread_id should use psuedo_thread_id
 --connection master
 --let $old_pseudo_id= `SELECT @@SESSION.pseudo_thread_id`
 set @@pseudo_thread_id=99999;
@@ -46,8 +45,8 @@ insert into t1 values(2);
 --echo # MYSQL_BINLOG local > primary_outfile
 --exec $MYSQL_BINLOG $local > $primary_outfile
 
---let $assert_count= 0
---let $assert_text= GTID event's thread_id does not use pseudo_thread_id
+--let $assert_count= 1
+--let $assert_text= GTID event's thread_id should use pseudo_thread_id
 --let $assert_select=GTID [0-9]-[0-9]-[0-9].*thread_id=99999\$
 --source include/assert_grep.inc
 
@@ -59,8 +58,6 @@ insert into t1 values(2);
 --echo #
 --echo # Test the serial replica
 --connection slave
---let $sql_thread_id= `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE COMMAND LIKE 'Slave_SQL'`
-
 --let replica_thread_id=`select connection_id()`
 --let datadir= `select @@datadir`
 --let filename= query_get_value(SHOW MASTER STATUS, File, 1)
@@ -75,8 +72,14 @@ insert into t1 values(2);
 --let $assert_file= $replica_outfile
 --source include/assert_grep.inc
 
---let $assert_text= Ensure each GTID event has the thread id of the SQL Thread
---let $assert_select=GTID [0-9]-[0-9]-[0-9].*thread_id=$sql_thread_id\$
+--let $assert_count= 3
+--let $assert_text= Ensure GTID events logged with primary's thread id maintain that value
+--let $assert_select=GTID [0-9]-[0-9]-[0-9].*thread_id=$primary_thread_id\$
+--source include/assert_grep.inc
+
+--let $assert_count= 1
+--let $assert_text= Ensure GTID event logged with pseudo_thread_id on primary maintains that value
+--let $assert_select=GTID [0-9]-[0-9]-[0-9].*thread_id=99999\$
 --source include/assert_grep.inc
 
 
@@ -94,7 +97,6 @@ insert into t1 values(4);
 --sync_slave_with_master
 
 --connection slave
---let $worker_thread_id= `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE COMMAND LIKE 'Slave_worker'`
 --echo # MYSQL_BINLOG local > replica_outfile
 --exec $MYSQL_BINLOG $local > $replica_outfile
 
@@ -104,9 +106,9 @@ insert into t1 values(4);
 #--let $assert_file= $replica_outfile
 --source include/assert_grep.inc
 
---let $assert_count= 2
---let $assert_text= Ensure only the new GTID events have the thread id of the worker thread
---let $assert_select=GTID [0-9]-[0-9]-[0-9].*thread_id=$worker_thread_id\$
+--let $assert_count= 5
+--let $assert_text= Ensure GTID the new events are logged on the replica with the thread_id of the master primary thread id
+--let $assert_select=GTID [0-9]-[0-9]-[0-9].*thread_id=$primary_thread_id\$
 --source include/assert_grep.inc
 
 --source include/stop_slave.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1587,6 +1587,13 @@ Query_log_event::Query_log_event(const uchar *buf, uint event_len,
     }
     case Q_DUMMY:
     {
+      /*
+        At some point, this query event was translated from a GTID event, with
+        these Q_DUMMY bytes added to pad the end of the header. We can skip the
+        rest of processing these vars. Note this is a separate case from the
+        default to avoid the DBUG_PRINT of an unknown status var.
+      */
+      pos= (const uchar*) end;
       break;
     }
     default:
@@ -1893,6 +1900,7 @@ Query_log_event::begin_event(String *packet, ulong ev_offset,
   uchar *p= (uchar *)packet->ptr() + ev_offset;
   uchar *q= p + LOG_EVENT_HEADER_LEN;
   size_t data_len= packet->length() - ev_offset;
+  size_t dummy_bytes;
   uint16 flags;
 
   if (checksum_alg == BINLOG_CHECKSUM_ALG_CRC32)
@@ -1901,16 +1909,6 @@ Query_log_event::begin_event(String *packet, ulong ev_offset,
     DBUG_ASSERT(checksum_alg == BINLOG_CHECKSUM_ALG_UNDEF ||
                 checksum_alg == BINLOG_CHECKSUM_ALG_OFF);
 
-  /*
-    Currently we only need to replace GTID event.
-    The length of GTID differs depending on whether it contains commit id.
-    And/or thread id.
-  */
-  DBUG_ASSERT(data_len >= LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN &&
-              data_len <= LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN + 2 + 9);
-  if (data_len < LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN ||
-      data_len > LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN + 2 + 9)
-    return 1;
 
   flags= uint2korr(p + FLAGS_OFFSET);
   flags&= ~LOG_EVENT_THREAD_SPECIFIC_F;
@@ -1922,32 +1920,22 @@ Query_log_event::begin_event(String *packet, ulong ev_offset,
   int4store(q + Q_EXEC_TIME_OFFSET, 0);
   q[Q_DB_LEN_OFFSET]= 0;
   int2store(q + Q_ERR_CODE_OFFSET, 0);
-  if (data_len == LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN)
-  {
-    int2store(q + Q_STATUS_VARS_LEN_OFFSET, 0);
-    q[Q_DATA_OFFSET]= 0;                    /* Zero terminator for empty db */
-    q+= Q_DATA_OFFSET + 1;
-  }
-  else
-  {
-    DBUG_ASSERT(data_len <= LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN + 11);
-    DBUG_ASSERT(data_len >= LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN + 2);
 
-    /* Put in an empty time_zone_str to take up the extra 2 plus the number of
-       dummy_bytes. */
-    size_t dummy_bytes=
-        data_len - (LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN + 2);
+  /*
+    If the allocated GTID event packet header is longer than the size of the
+    standard BEGIN query event's, then we need to fill in everything else with
+    "dummy" values. That is, old replicas won't recognize the meaning for the DUMMY
+    value, and will skip the rest of the status vars section.
+  */
+  DBUG_ASSERT(data_len >= LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN);
+  dummy_bytes= data_len - (LOG_EVENT_HEADER_LEN + GTID_HEADER_LEN);
+  int2store(q + Q_STATUS_VARS_LEN_OFFSET, dummy_bytes);
+  for (size_t i= 0; i < dummy_bytes; i++)
+    q[Q_DATA_OFFSET + i]= Q_DUMMY;
+  q+= dummy_bytes;
+  q[Q_DATA_OFFSET]= 0;                    /* Zero terminator for empty db */
+  q+= Q_DATA_OFFSET + 1;
 
-    int2store(q + Q_STATUS_VARS_LEN_OFFSET, dummy_bytes + 2);
-    for (size_t i= 0; i < dummy_bytes; i++)
-      q[Q_DATA_OFFSET + i]= Q_DUMMY;
-    q+= dummy_bytes;
-
-    q[Q_DATA_OFFSET]= Q_TIME_ZONE_CODE;
-    q[Q_DATA_OFFSET+1]= 0;           /* Zero length for empty time_zone_str */
-    q[Q_DATA_OFFSET+2]= 0;                  /* Zero terminator for empty db */
-    q+= Q_DATA_OFFSET + 3;
-  }
   memcpy(q, "BEGIN", 5);
 
   if (checksum_alg == BINLOG_CHECKSUM_ALG_CRC32)
@@ -2469,10 +2457,9 @@ Gtid_log_event::Gtid_log_event(const uchar *buf, uint event_len,
       buf+= 8;
     }
 
-    if (flags_extra & FL_EXTRA_THREAD_ID)
+    if (flags_extra & FL_EXTRA_THREAD_ID &&
+        static_cast<uint>(buf - buf_0) <= event_len + 8)
     {
-      DBUG_ASSERT(static_cast<uint>(buf - buf_0) <= event_len + 8);
-
       thread_id= uint8korr(buf);
       buf+= 8;
 

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -324,6 +324,16 @@ class String;
 
 #define Q_HRNOW 128
 #define Q_XID   129
+
+/*
+  When sending transactions to old slaves that don't support GTID events, the
+  GTID event is over-written (in-place, i.e. within the same allocated memory)
+  to be a BEGIN query event. If the header length of the original GTID event
+  exceeds the standard length of the Query event header, Q_DUMMY bytes pad the
+  status var section of the Query header so the structure of the Query event
+  is valid. Old slaves will see the first Q_DUMMY byte, not recognize it, and
+  skip reading the rest of the status var section.
+*/
 #define Q_DUMMY 255
 
 #define Q_GTID_FLAGS3 130

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -2812,7 +2812,8 @@ Gtid_log_event::Gtid_log_event(THD *thd_arg, uint64 seq_no_arg,
     seq_no(seq_no_arg), commit_id(commit_id_arg), domain_id(domain_id_arg),
     flags2((standalone ? FL_STANDALONE : 0) |
            (commit_id_arg ? FL_GROUP_COMMIT_ID : 0)),
-    flags_extra(0), extra_engines(0), thread_id(thd_arg->thread_id)
+    flags_extra(0), extra_engines(0),
+    thread_id(thd_arg->variables.pseudo_thread_id)
 {
   cache_type= Log_event::EVENT_NO_CACHE;
   bool is_tmp_table= thd_arg->lex->stmt_accessed_temp_table();
@@ -3068,6 +3069,7 @@ Gtid_log_event::do_apply_event(rpl_group_info *rgi)
   thd->variables.server_id= this->server_id;
   thd->variables.gtid_domain_id= this->domain_id;
   thd->variables.gtid_seq_no= this->seq_no;
+  thd->variables.pseudo_thread_id= this->thread_id;
   rgi->gtid_ev_flags2= flags2;
 
   rgi->gtid_ev_flags_extra= flags_extra;


### PR DESCRIPTION
Note this is currently a work-in-progress, pushed for potential
early feedback.

It addresses:
 1) The original thread_id of the master is propagated into
    the thread_id of the slave-binlogged GTID thread_id,
    rather than the thread_id of the applier thread.
 2) When seeing Q_DUMMY, rather than loop through each
    status var byte, skip to the end of the status var
    section.
 3) Added comments to explain the purpose of Q_DUMMY
 4) Simplified Query_log_event::begin_event to always use
    Q_DUMMY, rather than keeping the time zone str as well
 5) Fixed DBUG_ASSERT to be part of the conditoin to read in
    the event thread id, as to not read unowned memory
 6) Removed invalid ASSERTIONS for begin_event()
