### PR TITLE
MDEV-33341 innodb.undo_space_dblwr test case fails with Unknown Storage Engine InnoDB

### DIFF
--- a/mysql-test/suite/innodb/r/undo_space_dblwr.result
+++ b/mysql-test/suite/innodb/r/undo_space_dblwr.result
@@ -4,16 +4,14 @@ Variable_name	Value
 innodb_doublewrite	ON
 create table t1(f1 int not null, f2 int not null)engine=innodb;
 insert into t1 values (1, 1);
-SET GLOBAL innodb_purge_rseg_truncate_frequency=1;
-InnoDB		0 transactions not purged
-set GLOBAL innodb_log_checkpoint_now=1;
+SET GLOBAL innodb_fast_shutdown = 0;
+# restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
 # Make the first page dirty for undo tablespace
 set global innodb_saved_page_number_debug = 0;
 set global innodb_fil_make_page_dirty_debug = 1;
-SET GLOBAL innodb_max_dirty_pages_pct_lwm=0.0;
-SET GLOBAL innodb_max_dirty_pages_pct=0.0;
+SET GLOBAL innodb_buf_flush_list_now = 1;
 # Kill the server
-# restart
+# restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
 FOUND 1 /Checksum mismatch in the first page of file/ in mysqld.1.err
 check table t1;
 Table	Op	Msg_type	Msg_text

--- a/mysql-test/suite/innodb/t/undo_space_dblwr.test
+++ b/mysql-test/suite/innodb/t/undo_space_dblwr.test
@@ -9,20 +9,19 @@ show variables like 'innodb_doublewrite';
 create table t1(f1 int not null, f2 int not null)engine=innodb;
 insert into t1 values (1, 1);
 
-SET GLOBAL innodb_purge_rseg_truncate_frequency=1;
---source include/wait_all_purged.inc
+# Slow shutdown and restart to make sure ibuf merge is finished
+SET GLOBAL innodb_fast_shutdown = 0;
+let $shutdown_timeout=;
+let $restart_parameters="--debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0";
+--source include/restart_mysqld.inc
 
-set GLOBAL innodb_log_checkpoint_now=1;
 --source ../include/no_checkpoint_start.inc
-
 --echo # Make the first page dirty for undo tablespace
 set global innodb_saved_page_number_debug = 0;
 set global innodb_fil_make_page_dirty_debug = 1;
 
-SET GLOBAL innodb_max_dirty_pages_pct_lwm=0.0;
-SET GLOBAL innodb_max_dirty_pages_pct=0.0;
+SET GLOBAL innodb_buf_flush_list_now = 1;
 
-sleep 1;
 --let CLEANUP_IF_CHECKPOINT=drop table t1;
 --source ../include/no_checkpoint_end.inc
 

--- a/mysql-test/suite/sys_vars/r/innodb_fil_make_page_dirty_debug_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_fil_make_page_dirty_debug_basic.result
@@ -22,7 +22,4 @@ Warning	1287	'<select expression> INTO <destination>;' is deprecated and will be
 set global innodb_saved_page_number_debug = 0;
 set global innodb_fil_make_page_dirty_debug = @space_id;
 drop table t1;
-# Must always be 0.
-SELECT @@global.innodb_fil_make_page_dirty_debug;
-@@global.innodb_fil_make_page_dirty_debug
-0
+set global innodb_fil_make_page_dirty_debug = 0;

--- a/mysql-test/suite/sys_vars/t/innodb_fil_make_page_dirty_debug_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_fil_make_page_dirty_debug_basic.test
@@ -29,6 +29,4 @@ set global innodb_saved_page_number_debug = 0;
 set global innodb_fil_make_page_dirty_debug = @space_id;
 drop table t1;
 
---echo # Must always be 0.
-SELECT @@global.innodb_fil_make_page_dirty_debug;
-
+set global innodb_fil_make_page_dirty_debug = 0;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17553,6 +17553,7 @@ innodb_make_page_dirty(THD*, st_mysql_sys_var*, void*, const void* save)
 {
 	mtr_t		mtr;
 	uint		space_id = *static_cast<const uint*>(save);
+	srv_fil_make_page_dirty_debug= space_id;
 	mysql_mutex_unlock(&LOCK_global_system_variables);
 	fil_space_t*	space = fil_space_t::get(space_id);
 
@@ -18310,13 +18311,15 @@ buf_flush_list_now_set(THD*, st_mysql_sys_var*, void*, const void* save)
     return;
   const uint s= srv_fil_make_page_dirty_debug;
   mysql_mutex_unlock(&LOCK_global_system_variables);
-  if (s)
-    buf_flush_sync();
-  else
+  if (s == 0 || srv_is_undo_tablespace(s))
   {
-    while (buf_flush_list_space(fil_system.sys_space, nullptr));
+    fil_space_t *space= fil_system.sys_space;
+    if (s) { space= fil_space_get(s); }
+    while (buf_flush_list_space(space, nullptr));
     os_aio_wait_until_no_pending_writes();
   }
+  else
+    buf_flush_sync();
   mysql_mutex_lock(&LOCK_global_system_variables);
 }
 


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-33341*

## Description

Reason:
======
undo_space_dblwr test case fails if the first page of undo tablespace is not flushed before restart the server. While restarting the server, InnoDB fails to detect the first page of undo tablespace from doublewrite buffer.

Fix:
===
Use "ib_log_checkpoint_avoid_hard" debug sync point to avoid checkpoint and make sure to flush the
dirtied page before killing the server.

innodb_make_page_dirty(): Fails to set srv_fil_make_page_dirty_debug variable.

## How can this PR be tested?
./mtr innodb.undo_space_dblwr
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
