### PR TITLE
MDEV-35992 - Use aligned memory allocator in pfs-t tests

### DIFF
--- a/storage/perfschema/unittest/stub_print_error.h
+++ b/storage/perfschema/unittest/stub_print_error.h
@@ -23,21 +23,24 @@
 #include <my_global.h>
 #include <my_sys.h>
 #include <pfs_global.h>
+#include "aligned.h"
+#include "assume_aligned.h"
 
 bool pfs_initialized= false;
 
 void *pfs_malloc(PFS_builtin_memory_class *klass, size_t size, myf flags)
 {
-  void *ptr= malloc(size);
+  size= MY_ALIGN(size, CPU_LEVEL1_DCACHE_LINESIZE);
+  void *ptr= aligned_malloc(size, CPU_LEVEL1_DCACHE_LINESIZE);
   if (ptr && (flags & MY_ZEROFILL))
-    memset(ptr, 0, size);
+    memset_aligned<CPU_LEVEL1_DCACHE_LINESIZE>(ptr, 0, size);
   return ptr;
 }
 
 void pfs_free(PFS_builtin_memory_class *, size_t, void *ptr)
 {
   if (ptr != NULL)
-    free(ptr);
+    aligned_free(ptr);
 }
 
 void *pfs_malloc_array(PFS_builtin_memory_class *klass, size_t n, size_t size, myf flags)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

(copy from commit message)

The pfs-t tests can segfault when compiled with the `-mavx` compiler flag. The segfault is caused by unaligned memory accesses incompatible with AVX instructions.

This patch corrects the alignment issue by adopting aligned memory allocation and deallocation mechanisms, inspired by the approach already in use within `stub_pfs_global.`h. By ensuring that all dynamically allocated memory in the Performance Schema tests is properly aligned to `CPU_LEVEL1_DCACHE_LINESIZE`, the patch eliminates the segmentation faults previously observed under compilation with the -mavx flag.

The bug was reported here: https://bugs.gentoo.org/895112
The fix is somewhat related to https://jira.mariadb.org/browse/MDEV-28091

## How can this PR be tested?


<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

Compile with `-mavx` flag and run pfs unittests.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

Actually, the bug is in all maintained versions. I have chosen 10.6 because the patch applies cleanly to all more recent versions. But some modification might be needed for 10.4 and 10.5.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
