### PR TITLE
MDEV-32424 Crash in subselect engine

### DIFF
--- a/mysql-test/main/in_subq_cond_pushdown.result
+++ b/mysql-test/main/in_subq_cond_pushdown.result
@@ -3887,3 +3887,14 @@ i1
 2
 1
 DROP TABLE t1,t2,t3;
+#
+# MDEV-32424 Crash in query GROUP BY...HAVING
+#
+CREATE TABLE t1 (col VARCHAR(1));
+INSERT INTO t1 (col) VALUES ('x'), (NULL), ('x'), (NULL);
+SELECT * FROM t1 GROUP BY col HAVING col = (SELECT * FROM t1) AND col IN (1 , col);
+ERROR 21000: Subquery returns more than 1 row
+DROP TABLE t1;
+#
+# End of 10.4 tests
+#

--- a/mysql-test/main/in_subq_cond_pushdown.test
+++ b/mysql-test/main/in_subq_cond_pushdown.test
@@ -860,3 +860,17 @@ SELECT t3.i1 FROM t3
                                     GROUP BY i1 HAVING t.i1 < 3));
 
 DROP TABLE t1,t2,t3;
+
+--echo #
+--echo # MDEV-32424 Crash in query GROUP BY...HAVING
+--echo #
+
+CREATE TABLE t1 (col VARCHAR(1));
+INSERT INTO t1 (col) VALUES ('x'), (NULL), ('x'), (NULL);
+--error 1242
+SELECT * FROM t1 GROUP BY col HAVING col = (SELECT * FROM t1) AND col IN (1 , col);
+DROP TABLE t1;
+
+--echo #
+--echo # End of 10.4 tests
+--echo #

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -8886,6 +8886,11 @@ st_select_lex::check_cond_extraction_for_grouping_fields(THD *thd, Item *cond)
   {
     int fl= cond->excl_dep_on_grouping_fields(this) && !cond->is_expensive() ?
       FULL_EXTRACTION_FL : NO_EXTRACTION_FL;
+    if (fl == FULL_EXTRACTION_FL)
+    {
+      if (cond->walk(&Item::is_subquery_processor, 0, 0))
+        fl= NO_EXTRACTION_FL;
+    }
     cond->set_extraction_flag(fl);
   }
 }


### PR DESCRIPTION
According to MDEV-29363, recompute the with_subquery() attribute in the pushdown code to avoid writing to freed memory.
