### PR TITLE
MDEV-33383 fts query calculate ranking crashes

### DIFF
--- a/storage/innobase/include/fts0types.inl
+++ b/storage/innobase/include/fts0types.inl
@@ -59,7 +59,7 @@ fts_trx_row_doc_id_cmp(
 	const fts_trx_row_t*	tr1 = (const fts_trx_row_t*) p1;
 	const fts_trx_row_t*	tr2 = (const fts_trx_row_t*) p2;
 
-	return((int)(tr1->doc_id - tr2->doc_id));
+	return(fts_doc_id_cmp(&tr1->doc_id, &tr2->doc_id));
 }
 
 /******************************************************************//**
@@ -75,7 +75,7 @@ fts_ranking_doc_id_cmp(
 	const fts_ranking_t*	rk1 = (const fts_ranking_t*) p1;
 	const fts_ranking_t*	rk2 = (const fts_ranking_t*) p2;
 
-	return((int)(rk1->doc_id - rk2->doc_id));
+	return(fts_doc_id_cmp(&rk1->doc_id, &rk2->doc_id));
 }
 
 /******************************************************************//**
@@ -83,14 +83,20 @@ Compare two doc_ids.
 @return < 0 if n1 < n2, 0 if n1 == n2, > 0 if n1 > n2 */
 UNIV_INLINE
 int fts_doc_id_cmp(
-/*==================*/
+/*===============*/
 	const void*	p1,			/*!< in: id1 */
 	const void*	p2)			/*!< in: id2 */
 {
 	const doc_id_t*	up1 = static_cast<const doc_id_t*>(p1);
 	const doc_id_t*	up2 = static_cast<const doc_id_t*>(p2);
 
-	return static_cast<int>(*up1 - *up2);
+	if (*up1 < *up2) {
+		return (-1);
+	} else if (*up1 > *up2) {
+		return (1);
+	} else {
+		return (0);
+	}
 }
 
 /******************************************************************//**


### PR DESCRIPTION
Problem:
========
Run query in customer's instance:
SELECT `tid` FROM `thread_search` WHERE MATCH (`title`,`sub_content`) AGAINST ('****' IN BOOLEAN MODE);

It crashes in fts_query_calculate_ranking():
  ret = rbt_search(word_freq->doc_freqs, &parent, &ranking->doc_id);

  /* It must exist. */
  ut_a(ret == 0);

It means that the doc id should exist in doc_freqs, which contains all doc ids having the same word.

Analysis:
=========
The doc id 1675241735 has been inserted into the rbtree(rbt_node_add()), but after some following inserts(3839877411), it could not be searched by rbt_search(). But It does exist in the rbtree(iterated by rbt_next()). Obviously the rbtree is corrupted

The root cause is that the compare funciton fts_ranking_doc_id_cmp() returns the wrong result. So the rbtree is not working as a sorted binary tree.

It's totally wrong to compare two integers as below, no matter signed or unsigned.
return((int)(rk1->doc_id - rk2->doc_id));

Solution:
=========
The solution is pretty simple: just use > < == to compare two doc ids

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
