### PR TITLE
MDEV-33464 Crash when innodb_max_undo_log_size is set to innodb_page_size*4294967296

### DIFF
--- a/mysql-test/suite/innodb/r/undo_truncate.result
+++ b/mysql-test/suite/innodb/r/undo_truncate.result
@@ -25,6 +25,7 @@ delete from t1;
 connection con2;
 delete from t2;
 connection con1;
+SET GLOBAL innodb_max_undo_log_size = @@GLOBAL.innodb_page_size * 4294967296;
 SET GLOBAL innodb_undo_log_truncate = 1;
 commit;
 disconnect con1;
@@ -32,6 +33,8 @@ connection con2;
 commit;
 disconnect con2;
 connection default;
+SET GLOBAL innodb_max_purge_lag_wait=0;
+SET GLOBAL innodb_max_undo_log_size=DEFAULT;
 SET GLOBAL innodb_max_purge_lag_wait=0;
 set global innodb_fast_shutdown=0;
 # restart

--- a/mysql-test/suite/innodb/t/undo_truncate.test
+++ b/mysql-test/suite/innodb/t/undo_truncate.test
@@ -42,6 +42,7 @@ connection con1; reap; send delete from t1;
 connection con2; reap; delete from t2;
 connection con1; reap;
 
+SET GLOBAL innodb_max_undo_log_size = @@GLOBAL.innodb_page_size * 4294967296;
 SET GLOBAL innodb_undo_log_truncate = 1;
 commit; disconnect con1;
 connection con2; commit; disconnect con2;
@@ -52,6 +53,8 @@ connection default;
 let $trx_before= `SHOW ENGINE INNODB STATUS`;
 let $trx_before= `select substr('$trx_before',9)+2`;
 
+SET GLOBAL innodb_max_purge_lag_wait=0;
+SET GLOBAL innodb_max_undo_log_size=DEFAULT;
 SET GLOBAL innodb_max_purge_lag_wait=0;
 set global innodb_fast_shutdown=0;
 --source include/restart_mysqld.inc

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -669,7 +669,9 @@ fil_space_t *purge_sys_t::truncating_tablespace()
   if (space || srv_undo_tablespaces_active < 2 || !srv_undo_log_truncate)
     return space;
 
-  const ulint size= ulint(srv_max_undo_log_size >> srv_page_size_shift);
+  const uint32_t size=
+    uint32_t(std::min(ulonglong{std::numeric_limits<uint32_t>::max()},
+                      srv_max_undo_log_size >> srv_page_size_shift));
   for (ulint i= truncate_undo_space.last, j= i;; )
   {
     if (fil_space_t *s= undo_truncate_try(srv_undo_space_id_start + i, size))


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33464*
## Description
`purge_sys_t::truncating_tablespace()`: Clamp the
`innodb_max_undo_log_size` to the maximum number of pages before converting the result into a 32-bit unsigned integer.

This fixes up commit f8c88d905b44bffe161158309e9acc25ad3691aa (MDEV-33213).

In later major versions, we would use 32-bit unsigned integer here due to commit ca501ffb04246dcaa1f1d433d916d8436e30602e and the code would crash also on 64-bit processors.

## Release Notes
https://mariadb.com/kb/en/innodb-purge/ seems to be covering this area. I am not sure if this bug deserves to be mentioned there.

For 10.11 and later: Setting innodb_max_undo_log_size to something larger than innodb_page_size*4294967295 would 
cause unexpected behavior or crashes when setting innodb_undo_log_truncate=ON and using innodb_undo_tablespaces>1.

For 10.6: The description needs to be qualified with "On 32-bit systems."

## How can this PR be tested?
This case is covered by the test `innodb.undo_truncate`. The modified test would crash on 32-bit systems when the fix is not present.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.