### PR TITLE
MDEV-33420: HASHICORP_KEY_MANAGEMENT fails on Windows with libcurl installed

### DIFF
--- a/plugin/hashicorp_key_management/CMakeLists.txt
+++ b/plugin/hashicorp_key_management/CMakeLists.txt
@@ -1,10 +1,8 @@
-INCLUDE(FindCURL)
+FIND_PACKAGE(CURL)
 IF(NOT CURL_FOUND)
   # Can't build plugin
   RETURN()
 ENDIF()
-
-INCLUDE_DIRECTORIES(${CURL_INCLUDE_DIR})
 
 set(CPACK_RPM_hashicorp-key-management_PACKAGE_SUMMARY "Hashicorp Key Management plugin for MariaDB" PARENT_SCOPE)
 set(CPACK_RPM_hashicorp-key-management_PACKAGE_DESCRIPTION "This encryption plugin uses Hashicorp Vault for storing encryption
@@ -12,7 +10,7 @@ set(CPACK_RPM_hashicorp-key-management_PACKAGE_DESCRIPTION "This encryption plug
 
 MYSQL_ADD_PLUGIN(HASHICORP_KEY_MANAGEMENT
   hashicorp_key_management_plugin.cc
-  LINK_LIBRARIES ${CURL_LIBRARIES}
+  LINK_LIBRARIES CURL::libcurl
   CONFIG hashicorp_key_management.cnf
   COMPONENT hashicorp-key-management
   MODULE_ONLY)

--- a/win/packaging/CPackWixConfig.cmake
+++ b/win/packaging/CPackWixConfig.cmake
@@ -53,7 +53,7 @@ add_component(Backup
   DESCRIPTION "Installs backup utilities(mariabackup and mbstream)")
  
 #Miscellaneous hidden components, part of server / or client programs
-foreach(comp connect-engine connect-engine-jdbc ClientPlugins aws-key-management rocksdb-engine)
+foreach(comp connect-engine connect-engine-jdbc ClientPlugins aws-key-management rocksdb-engine plugin-hashicorp-key-management)
   add_component(${comp} GROUP MySQLServer HIDDEN)
 endforeach()
 


### PR DESCRIPTION
- When `libcurl` is installed in path out of default path, like on
  Windows, `include_directories` failed to find `curl/curl.h`.
- Fix `cmake` by using modern syntax with imported target and
  `find_package`
- Fix warnings treated as the errors
- Remove `HASHICORP_HAVE_EXCEPTIONS` macro and related code
- Add package to `Server` component in Windows
- Tested with `$ ./mysql-test/mtr --suite=vault`
- Closes PR #3068
- Reviewer: <wlad@mariadb.com>
                   <julius.goryavsky@mariadb.com>

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
