### PR TITLE
MDEV-33325 Crash in flst_read_addr on corrupted data

### DIFF
--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -562,7 +562,8 @@ btr_page_alloc_for_ibuf(
   {
     buf_page_make_young_if_needed(&new_block->page);
     *err= flst_remove(root, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST, new_block,
-                PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST_NODE, mtr);
+                      PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST_NODE,
+                      fil_system.sys_space->free_limit, mtr);
   }
   ut_d(if (*err == DB_SUCCESS)
          flst_validate(root, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST, mtr));
@@ -666,7 +667,8 @@ btr_page_free_for_ibuf(
   buf_block_t *root= btr_get_latched_root(*index, mtr);
   dberr_t err=
     flst_add_first(root, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST,
-                   block, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST_NODE, mtr);
+                   block, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST_NODE,
+                   fil_system.sys_space->free_limit, mtr);
   ut_d(if (err == DB_SUCCESS)
          flst_validate(root, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST, mtr));
   return err;

--- a/storage/innobase/fut/fut0lst.cc
+++ b/storage/innobase/fut/fut0lst.cc
@@ -113,17 +113,18 @@ static void flst_add_to_empty(buf_block_t *base, uint16_t boffset,
 }
 
 /** Insert a node after another one.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  cur     insert position block
-@param[in]      coffset byte offset of the insert position
-@param[in,out]  add     block to be added
-@param[in]      aoffset byte offset of the block to be added
-@param[in,out]  mtr     mini-transaction */
+@param base    base node block
+@param boffset byte offset of the base node
+@param cur     insert position block
+@param coffset byte offset of the insert position
+@param add     block to be added
+@param aoffset byte offset of the block to be added
+@param limit   fil_space_t::free_limit
+@param mtr     mini-transaction */
 static dberr_t flst_insert_after(buf_block_t *base, uint16_t boffset,
                                  buf_block_t *cur, uint16_t coffset,
                                  buf_block_t *add, uint16_t aoffset,
-                                 mtr_t *mtr)
+                                 uint32_t limit, mtr_t *mtr)
 {
   ut_ad(base != cur || boffset != coffset);
   ut_ad(base != add || boffset != aoffset);
@@ -139,6 +140,15 @@ static dberr_t flst_insert_after(buf_block_t *base, uint16_t boffset,
                                    MTR_MEMO_PAGE_SX_FIX));
 
   fil_addr_t next_addr= flst_get_next_addr(cur->page.frame + coffset);
+  if (next_addr.page >= limit)
+  {
+    if (UNIV_UNLIKELY(next_addr.page != FIL_NULL))
+      return DB_CORRUPTION;
+  }
+  else if (UNIV_UNLIKELY(next_addr.boffset < FIL_PAGE_DATA ||
+                         next_addr.boffset >= base->physical_size() -
+                         FIL_PAGE_DATA_END))
+    return DB_CORRUPTION;
 
   flst_write_addr(*add, add->page.frame + aoffset + FLST_PREV,
                   cur->page.id().page_no(), coffset, mtr);
@@ -167,18 +177,19 @@ static dberr_t flst_insert_after(buf_block_t *base, uint16_t boffset,
 }
 
 /** Insert a node before another one.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  cur     insert position block
-@param[in]      coffset byte offset of the insert position
-@param[in,out]  add     block to be added
-@param[in]      aoffset byte offset of the block to be added
-@param[in,out]  mtr     mini-transaction
+@param base    base node block
+@param boffset byte offset of the base node
+@param cur     insert position block
+@param coffset byte offset of the insert position
+@param add     block to be added
+@param aoffset byte offset of the block to be added
+@param limit   fil_space_t::free_limit
+@param mtr     mini-transaction
 @return error code */
 static dberr_t flst_insert_before(buf_block_t *base, uint16_t boffset,
                                   buf_block_t *cur, uint16_t coffset,
                                   buf_block_t *add, uint16_t aoffset,
-                                  mtr_t *mtr)
+                                  uint32_t limit, mtr_t *mtr)
 {
   ut_ad(base != cur || boffset != coffset);
   ut_ad(base != add || boffset != aoffset);
@@ -194,6 +205,15 @@ static dberr_t flst_insert_before(buf_block_t *base, uint16_t boffset,
                                    MTR_MEMO_PAGE_SX_FIX));
 
   fil_addr_t prev_addr= flst_get_prev_addr(cur->page.frame + coffset);
+  if (prev_addr.page >= limit)
+  {
+    if (UNIV_UNLIKELY(prev_addr.page != FIL_NULL))
+      return DB_CORRUPTION;
+  }
+  else if (UNIV_UNLIKELY(prev_addr.boffset < FIL_PAGE_DATA ||
+                         prev_addr.boffset >= base->physical_size() -
+                         FIL_PAGE_DATA_END))
+    return DB_CORRUPTION;
 
   flst_write_addr(*add, add->page.frame + aoffset + FLST_PREV,
                   prev_addr.page, prev_addr.boffset, mtr);
@@ -234,14 +254,9 @@ void flst_init(const buf_block_t& block, byte *base, mtr_t *mtr)
   flst_zero_both(block, base + FLST_FIRST, mtr);
 }
 
-/** Append a file list node to a list.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  add     block to be added
-@param[in]      aoffset byte offset of the node to be added
-@param[in,outr] mtr     mini-transaction */
 dberr_t flst_add_last(buf_block_t *base, uint16_t boffset,
-                      buf_block_t *add, uint16_t aoffset, mtr_t *mtr)
+                      buf_block_t *add, uint16_t aoffset,
+                      uint32_t limit, mtr_t *mtr)
 {
   ut_ad(base != add || boffset != aoffset);
   ut_ad(boffset < base->physical_size());
@@ -258,6 +273,13 @@ dberr_t flst_add_last(buf_block_t *base, uint16_t boffset,
   else
   {
     fil_addr_t addr= flst_get_last(base->page.frame + boffset);
+    if (UNIV_UNLIKELY(addr.page >= limit))
+      return DB_CORRUPTION;
+    else if (UNIV_UNLIKELY(addr.boffset < FIL_PAGE_DATA ||
+                           addr.boffset >= base->physical_size() -
+                           FIL_PAGE_DATA_END))
+      return DB_CORRUPTION;
+
     buf_block_t *cur= add;
     dberr_t err;
     if (addr.page != add->page.id().page_no() &&
@@ -266,19 +288,13 @@ dberr_t flst_add_last(buf_block_t *base, uint16_t boffset,
                                 BUF_GET_POSSIBLY_FREED, mtr, &err)))
       return err;
     return flst_insert_after(base, boffset, cur, addr.boffset,
-                             add, aoffset, mtr);
+                             add, aoffset, limit, mtr);
   }
 }
 
-/** Prepend a file list node to a list.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  add     block to be added
-@param[in]      aoffset byte offset of the node to be added
-@param[in,out]  mtr     mini-transaction
-@return error code */
 dberr_t flst_add_first(buf_block_t *base, uint16_t boffset,
-                       buf_block_t *add, uint16_t aoffset, mtr_t *mtr)
+                       buf_block_t *add, uint16_t aoffset,
+                       uint32_t limit, mtr_t *mtr)
 {
   ut_ad(base != add || boffset != aoffset);
   ut_ad(boffset < base->physical_size());
@@ -296,6 +312,12 @@ dberr_t flst_add_first(buf_block_t *base, uint16_t boffset,
   else
   {
     fil_addr_t addr= flst_get_first(base->page.frame + boffset);
+    if (UNIV_UNLIKELY(addr.page >= limit))
+      return DB_CORRUPTION;
+    else if (UNIV_UNLIKELY(addr.boffset < FIL_PAGE_DATA ||
+                           addr.boffset >= base->physical_size() -
+                           FIL_PAGE_DATA_END))
+      return DB_CORRUPTION;
     buf_block_t *cur= add;
     dberr_t err;
     if (addr.page != add->page.id().page_no() &&
@@ -304,19 +326,13 @@ dberr_t flst_add_first(buf_block_t *base, uint16_t boffset,
                                 BUF_GET_POSSIBLY_FREED, mtr, &err)))
       return err;
     return flst_insert_before(base, boffset, cur, addr.boffset,
-                              add, aoffset, mtr);
+                              add, aoffset, limit, mtr);
   }
 }
 
-/** Remove a file list node.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  cur     block to be removed
-@param[in]      coffset byte offset of the current record to be removed
-@param[in,out]  mtr     mini-transaction
-@return error code */
 dberr_t flst_remove(buf_block_t *base, uint16_t boffset,
-                    buf_block_t *cur, uint16_t coffset, mtr_t *mtr)
+                    buf_block_t *cur, uint16_t coffset,
+                    uint32_t limit, mtr_t *mtr)
 {
   ut_ad(boffset < base->physical_size());
   ut_ad(coffset < cur->physical_size());
@@ -329,9 +345,27 @@ dberr_t flst_remove(buf_block_t *base, uint16_t boffset,
   const fil_addr_t next_addr= flst_get_next_addr(cur->page.frame + coffset);
   dberr_t err= DB_SUCCESS;
 
-  if (prev_addr.page == FIL_NULL)
+  if (next_addr.page >= limit)
+  {
+    if (next_addr.page != FIL_NULL)
+      return DB_CORRUPTION;
+  }
+  else if (UNIV_UNLIKELY(next_addr.boffset < FIL_PAGE_DATA ||
+                         next_addr.boffset >= base->physical_size() -
+                         FIL_PAGE_DATA_END))
+    return DB_CORRUPTION;
+
+  if (prev_addr.page >= limit)
+  {
+    if (prev_addr.page != FIL_NULL)
+      return DB_CORRUPTION;
     flst_write_addr(*base, base->page.frame + boffset + FLST_FIRST,
                     next_addr.page, next_addr.boffset, mtr);
+  }
+  else if (UNIV_UNLIKELY(prev_addr.boffset < FIL_PAGE_DATA ||
+                         prev_addr.boffset >= base->physical_size() -
+                         FIL_PAGE_DATA_END))
+    return DB_CORRUPTION;
   else
   {
     buf_block_t *b= cur;
@@ -375,25 +409,19 @@ void flst_validate(const buf_block_t *base, uint16_t boffset, mtr_t *mtr)
   ut_ad(mtr->memo_contains_flagged(base, MTR_MEMO_PAGE_X_FIX |
                                    MTR_MEMO_PAGE_SX_FIX));
 
-  /* We use two mini-transaction handles: the first is used to lock
-  the base node, and prevent other threads from modifying the list.
-  The second is used to traverse the list. We cannot run the second
-  mtr without committing it at times, because if the list is long,
-  the x-locked pages could fill the buffer, resulting in a deadlock. */
-  mtr_t mtr2;
-
   const uint32_t len= flst_get_len(base->page.frame + boffset);
   fil_addr_t addr= flst_get_first(base->page.frame + boffset);
 
   for (uint32_t i= len; i--; )
   {
-    mtr2.start();
+    ut_ad(addr.boffset >= FIL_PAGE_DATA);
+    ut_ad(addr.boffset < base->physical_size() - FIL_PAGE_DATA_END);
     const buf_block_t *b=
       buf_page_get_gen(page_id_t(base->page.id().space(), addr.page),
                        base->zip_size(), RW_SX_LATCH, nullptr, BUF_GET, mtr);
     ut_ad(b);
     addr= flst_get_next_addr(b->page.frame + addr.boffset);
-    mtr2.commit();
+    mtr->release_last_page();
   }
 
   ut_ad(addr.page == FIL_NULL);
@@ -402,13 +430,14 @@ void flst_validate(const buf_block_t *base, uint16_t boffset, mtr_t *mtr)
 
   for (uint32_t i= len; i--; )
   {
-    mtr2.start();
+    ut_ad(addr.boffset >= FIL_PAGE_DATA);
+    ut_ad(addr.boffset < base->physical_size() - FIL_PAGE_DATA_END);
     const buf_block_t *b=
       buf_page_get_gen(page_id_t(base->page.id().space(), addr.page),
                        base->zip_size(), RW_SX_LATCH, nullptr, BUF_GET, mtr);
     ut_ad(b);
     addr= flst_get_prev_addr(b->page.frame + addr.boffset);
-    mtr2.commit();
+    mtr->release_last_page();
   }
 
   ut_ad(addr.page == FIL_NULL);

--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -1831,7 +1831,7 @@ corrupted:
 
 	err = flst_add_last(ibuf_root, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST,
 			    block, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST_NODE,
-			    &mtr);
+			    fil_system.sys_space->free_limit, &mtr);
 	if (UNIV_UNLIKELY(err != DB_SUCCESS)) {
 		goto corrupted;
 	}
@@ -1862,7 +1862,6 @@ Removes a page from the free list and frees it to the fsp system. */
 static void ibuf_remove_free_page()
 {
 	mtr_t	mtr;
-	mtr_t	mtr2;
 	page_t*	header_page;
 
 	log_free_check();
@@ -1889,26 +1888,28 @@ early_exit:
 		return;
 	}
 
-	ibuf_mtr_start(&mtr2);
-
-	buf_block_t* root = ibuf_tree_root_get(&mtr2);
+	const auto root_savepoint = mtr.get_savepoint();
+	buf_block_t* root = ibuf_tree_root_get(&mtr);
 
 	if (UNIV_UNLIKELY(!root)) {
-		ibuf_mtr_commit(&mtr2);
 		goto early_exit;
 	}
-
-	mysql_mutex_unlock(&ibuf_mutex);
 
 	const uint32_t page_no = flst_get_last(PAGE_HEADER
 					       + PAGE_BTR_IBUF_FREE_LIST
 					       + root->page.frame).page;
 
+	if (page_no >= fil_system.sys_space->free_limit) {
+		goto early_exit;
+	}
+
+	mysql_mutex_unlock(&ibuf_mutex);
+
 	/* NOTE that we must release the latch on the ibuf tree root
 	because in fseg_free_page we access level 1 pages, and the root
 	is a level 2 page. */
-
-	ibuf_mtr_commit(&mtr2);
+	root->page.lock.u_unlock();
+	mtr.lock_register(root_savepoint, MTR_MEMO_BUF_FIX);
 	ibuf_exit(&mtr);
 
 	/* Since pessimistic inserts were prevented, we know that the
@@ -1931,15 +1932,7 @@ early_exit:
 	ibuf_enter(&mtr);
 
 	mysql_mutex_lock(&ibuf_mutex);
-
-	root = ibuf_tree_root_get(&mtr, &err);
-	if (UNIV_UNLIKELY(!root)) {
-		mysql_mutex_unlock(&ibuf_pessimistic_insert_mutex);
-		goto func_exit;
-	}
-
-	ut_ad(page_no == flst_get_last(PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST
-				       + root->page.frame).page);
+	mtr.upgrade_buffer_fix(root_savepoint, RW_X_LATCH);
 
 	/* Remove the page from the free list and update the ibuf size data */
 	if (buf_block_t* block =
@@ -1948,7 +1941,7 @@ early_exit:
 		err = flst_remove(root, PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST,
 				  block,
 				  PAGE_HEADER + PAGE_BTR_IBUF_FREE_LIST_NODE,
-				  &mtr);
+				  fil_system.sys_space->free_limit, &mtr);
 	}
 
 	mysql_mutex_unlock(&ibuf_pessimistic_insert_mutex);

--- a/storage/innobase/include/fut0lst.h
+++ b/storage/innobase/include/fut0lst.h
@@ -78,34 +78,40 @@ void flst_init(const buf_block_t &block, byte *base, mtr_t *mtr)
   MY_ATTRIBUTE((nonnull));
 
 /** Append a file list node to a list.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  add     block to be added
-@param[in]      aoffset byte offset of the node to be added
-@param[in,out]  mtr     mini-transaction
+@param base    base node block
+@param boffset byte offset of the base node
+@param add     block to be added
+@param aoffset byte offset of the node to be added
+@param limit   fil_space_t::free_limit
+@param mtr     mini-transaction
 @return error code */
 dberr_t flst_add_last(buf_block_t *base, uint16_t boffset,
-                      buf_block_t *add, uint16_t aoffset, mtr_t *mtr)
+                      buf_block_t *add, uint16_t aoffset,
+                      uint32_t limit, mtr_t *mtr)
   MY_ATTRIBUTE((nonnull, warn_unused_result));
 /** Prepend a file list node to a list.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  add     block to be added
-@param[in]      aoffset byte offset of the node to be added
-@param[in,out]  mtr     mini-transaction
+@param base    base node block
+@param boffset byte offset of the base node
+@param add     block to be added
+@param aoffset byte offset of the node to be added
+@param limit   fil_space_t::free_limit
+@param mtr     mini-transaction
 @return error code */
 dberr_t flst_add_first(buf_block_t *base, uint16_t boffset,
-                    buf_block_t *add, uint16_t aoffset, mtr_t *mtr)
+                       buf_block_t *add, uint16_t aoffset,
+                       uint32_t limit, mtr_t *mtr)
   MY_ATTRIBUTE((nonnull, warn_unused_result));
 /** Remove a file list node.
-@param[in,out]  base    base node block
-@param[in]      boffset byte offset of the base node
-@param[in,out]  cur     block to be removed
-@param[in]      coffset byte offset of the current record to be removed
-@param[in,out]  mtr     mini-transaction
+@param base    base node block
+@param boffset byte offset of the base node
+@param cur     block to be removed
+@param coffset byte offset of the current record to be removed
+@param limit   fil_space_t::free_limit
+@param mtr     mini-transaction
 @return error code */
 dberr_t flst_remove(buf_block_t *base, uint16_t boffset,
-                    buf_block_t *cur, uint16_t coffset, mtr_t *mtr)
+                    buf_block_t *cur, uint16_t coffset,
+                    uint32_t limit, mtr_t *mtr)
   MY_ATTRIBUTE((nonnull, warn_unused_result));
 
 /** @return the length of a list */
@@ -117,11 +123,9 @@ inline uint32_t flst_get_len(const flst_base_node_t *base)
 /** @return a file address */
 inline fil_addr_t flst_read_addr(const byte *faddr)
 {
-  fil_addr_t addr= { mach_read_from_4(faddr + FIL_ADDR_PAGE),
-		     mach_read_from_2(faddr + FIL_ADDR_BYTE) };
-  ut_a(addr.page == FIL_NULL || addr.boffset >= FIL_PAGE_DATA);
-  ut_a(ut_align_offset(faddr, srv_page_size) >= FIL_PAGE_DATA);
-  return addr;
+  ut_ad(ut_align_offset(faddr, srv_page_size) >= FIL_PAGE_DATA);
+  return fil_addr_t{mach_read_from_4(faddr + FIL_ADDR_PAGE),
+                    mach_read_from_2(faddr + FIL_ADDR_BYTE)};
 }
 
 /** @return list first node address */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33325*
## Description
`flst_read_addr()`: Remove assertions. Instead, we will check these conditions in the callers and avoid a crash in case of corruption. We will check the conditions more carefully, because the callers know more exact bounds for the page numbers and the byte offsets withing pages.

In the following functions, the assertions will be removed without replacement: `flst_insert_after()`, `flst_insert_before()`, `flst_add_last()`, `flst_add_first()`, `flst_remove()`. These functions insert or delete items in the doubly linked list of pages. There are debug assertions for validating the input. We may copy corrupted pointers from existing list nodes. Corruption will be noticed when the lists are being read.

## How can this PR be tested?
This code is covered basically by all InnoDB regression tests. Some additional stress testing would be helpful to ensure that this is not wrongly flagging more corruption than usual.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

This is follow-up to 0b47c126e31cddda1e94588799599e138400bcf8 (MDEV-13542). Older major versions would crash on more types of corruption.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.