### PR TITLE
MDEV-31154 Fatal InnoDB error or assertion `!is_v' failure upon multi…

### DIFF
--- a/mysql-test/main/rowid_filter_innodb.result
+++ b/mysql-test/main/rowid_filter_innodb.result
@@ -3573,3 +3573,98 @@ pk	c1
 DROP TABLE t1,t2;
 set global innodb_stats_persistent= @stats.save;
 # End of 10.4 tests
+#
+# MDEV-31154: Fatal InnoDB error or assertion `!is_v' failure upon multi-update with indexed virtual column
+#
+# Test with auto generated Primary Key
+#
+create table t1 (a int, b int as (a/2) virtual, key (b), key (a)) engine=innodb;
+insert into t1(a)
+select (rand(1)*1000)/10 from seq_1_to_1000;
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+set @save_optimizer_switch= @@optimizer_switch;
+set optimizer_switch='rowid_filter=off';
+explain extended select count(*) from t1 where a between 21 and 30 and b=12;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref	b,a	b	5	const	27	9.60	Using where
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30
+select count(*) from t1 where a between 21 and 30 and b=12;
+count(*)
+27
+explain extended select count(*) from t1 where a between 21 and 30 and b=12 for update;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref	b,a	b	5	const	27	9.60	Using where
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30 for update
+select count(*) from t1 where a between 21 and 30 and b=12 for update;
+count(*)
+27
+set optimizer_switch='rowid_filter=on';
+explain extended select count(*) from t1 where a between 21 and 30 and b=12;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref|filter	b,a	b|a	5|5	const	27 (10%)	9.60	Using where; Using rowid filter
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30
+select count(*) from t1 where a between 21 and 30 and b=12;
+count(*)
+27
+explain extended select count(*) from t1 where a between 21 and 30 and b=12 for update;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref|filter	b,a	b|a	5|5	const	27 (10%)	9.60	Using where; Using rowid filter
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30 for update
+select count(*) from t1 where a between 21 and 30 and b=12 for update;
+count(*)
+27
+drop table t1;
+set optimizer_switch=@save_optimizer_switch;
+# Test with Primary Key
+#
+create table t1 (p int primary key auto_increment, a int, b int as (a/2) virtual, key (b), key (a)) engine=innodb;
+insert into t1(a)
+select (rand(1)*1000)/10 from seq_1_to_1000;
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+set @save_optimizer_switch= @@optimizer_switch;
+set optimizer_switch='rowid_filter=off';
+explain extended select count(*) from t1 where a between 21 and 30 and b=12;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref	b,a	b	5	const	27	9.60	Using where
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30
+select count(*) from t1 where a between 21 and 30 and b=12;
+count(*)
+27
+explain extended select count(*) from t1 where a between 21 and 30 and b=12 for update;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref	b,a	b	5	const	27	9.60	Using where
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30 for update
+select count(*) from t1 where a between 21 and 30 and b=12 for update;
+count(*)
+27
+set optimizer_switch='rowid_filter=on';
+explain extended select count(*) from t1 where a between 21 and 30 and b=12;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref|filter	b,a	b|a	5|5	const	27 (10%)	9.60	Using where; Using rowid filter
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30
+select count(*) from t1 where a between 21 and 30 and b=12;
+count(*)
+27
+explain extended select count(*) from t1 where a between 21 and 30 and b=12 for update;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	ref|filter	b,a	b|a	5|5	const	27 (10%)	9.60	Using where; Using rowid filter
+Warnings:
+Note	1003	select count(0) AS `count(*)` from `test`.`t1` where `test`.`t1`.`b` = 12 and `test`.`t1`.`a` between 21 and 30 for update
+select count(*) from t1 where a between 21 and 30 and b=12 for update;
+count(*)
+27
+drop table t1;
+set optimizer_switch=@save_optimizer_switch;

--- a/mysql-test/main/rowid_filter_innodb.test
+++ b/mysql-test/main/rowid_filter_innodb.test
@@ -699,3 +699,61 @@ DROP TABLE t1,t2;
 set global innodb_stats_persistent= @stats.save;
 
 --echo # End of 10.4 tests
+
+--echo #
+--echo # MDEV-31154: Fatal InnoDB error or assertion `!is_v' failure upon multi-update with indexed virtual column
+--echo #
+
+--echo # Test with auto generated Primary Key
+--echo #
+create table t1 (a int, b int as (a/2) virtual, key (b), key (a)) engine=innodb;
+insert into t1(a)
+select (rand(1)*1000)/10 from seq_1_to_1000;
+analyze table t1;
+
+let $q1= select count(*) from t1 where a between 21 and 30 and b=12;
+let $q2= select count(*) from t1 where a between 21 and 30 and b=12 for update;
+
+set @save_optimizer_switch= @@optimizer_switch;
+
+set optimizer_switch='rowid_filter=off';
+eval explain extended $q1;
+eval $q1;
+eval explain extended $q2;
+eval $q2;
+
+set optimizer_switch='rowid_filter=on';
+eval explain extended $q1;
+eval $q1;
+eval explain extended $q2;
+eval $q2;
+
+drop table t1;
+set optimizer_switch=@save_optimizer_switch;
+
+--echo # Test with Primary Key
+--echo #
+create table t1 (p int primary key auto_increment, a int, b int as (a/2) virtual, key (b), key (a)) engine=innodb;
+insert into t1(a)
+select (rand(1)*1000)/10 from seq_1_to_1000;
+analyze table t1;
+
+let $q1= select count(*) from t1 where a between 21 and 30 and b=12;
+let $q2= select count(*) from t1 where a between 21 and 30 and b=12 for update;
+
+set @save_optimizer_switch= @@optimizer_switch;
+
+set optimizer_switch='rowid_filter=off';
+eval explain extended $q1;
+eval $q1;
+eval explain extended $q2;
+eval $q2;
+
+set optimizer_switch='rowid_filter=on';
+eval explain extended $q1;
+eval $q1;
+eval explain extended $q2;
+eval $q2;
+
+drop table t1;
+set optimizer_switch=@save_optimizer_switch;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7350,26 +7350,58 @@ ha_innobase::build_template(
 
 	ulint num_v = 0;
 
-	if (active_index != MAX_KEY
-	     && active_index == pushed_idx_cond_keyno) {
-		m_prebuilt->idx_cond = this;
-		goto icp;
-	} else if (pushed_rowid_filter && rowid_filter_is_active) {
-icp:
-		/* Push down an index condition or an end_range check. */
+	/* MDEV-31154: For pushed down index condition we don't support virtual
+	column and idx_cond_push() does check for it. For row ID filtering we
+	don't need such restrictions but we get into trouble trying to use the
+	ICP path.
+
+	1. It should be fine to follow no_icp path if primary key is generated.
+	However, with user specified primary key(PK), the row is identified by
+	the PK and those columns need to be converted to mysql format in
+	row_search_idx_cond_check before doing the comparison. Since secondary
+	indexes always have PK appended in innodb, it works with current ICP
+	handling code when fetch_primary_key_cols is set to TRUE.
+
+	2. Although ICP comparison and Row ID comparison works on different
+	columns the current ICP code can be shared by both.
+
+	3. In most cases, it works today by jumping to goto no_icp when we
+	encounter a virtual column. This is hackish and already have some
+	issues as it cannot handle PK and all states are not reset properly,
+	for example, idx_cond_n_cols is not reset.
+
+	4. We already encountered MDEV-28747 m_prebuilt->idx_cond was being set.
+
+	Neither ICP nor row ID comparison needs virtual columns and the code is
+	simplified to handle both. It should handle the issues. */
+
+	const bool pushed_down = active_index != MAX_KEY
+				 && active_index == pushed_idx_cond_keyno;
+	const bool rowid_filter = pushed_rowid_filter && rowid_filter_is_active;
+
+	m_prebuilt->idx_cond = pushed_down ? this : nullptr;
+
+	if (pushed_down || rowid_filter) {
+		/* Push down an index condition, end_range check or row ID
+		filter */
 		for (ulint i = 0; i < n_fields; i++) {
 			const Field* field = table->field[i];
 			const bool is_v = !field->stored_in_db();
-			if (is_v && skip_virtual) {
-				num_v++;
-				continue;
-			}
+
 			bool index_contains = index->contains_col_or_prefix(
 				is_v ? num_v : i - num_v, is_v);
-			if (is_v && index_contains) {
-				m_prebuilt->n_template = 0;
-				num_v = 0;
-				goto no_icp;
+
+			if (is_v) {
+				if (index_contains) {
+					/* We want to ensure that ICP is not
+					used with virtual columns. Ideally we
+					should assert here ut_ad(!pushed_down)
+					but we are taking forward the legacy to
+					possibly handle unexpected cases. */
+					m_prebuilt->idx_cond = nullptr;
+				}
+				num_v++;
+				continue;
 			}
 
 			/* Test if an end_range or an index condition
@@ -7389,7 +7421,7 @@ icp:
 			which would be acceptable if end_range==NULL. */
 			if (build_template_needs_field_in_icp(
 				    index, m_prebuilt, index_contains,
-				    is_v ? num_v : i - num_v, is_v)) {
+				    i - num_v, false)) {
 				if (!whole_row) {
 					field = build_template_needs_field(
 						index_contains,
@@ -7398,9 +7430,6 @@ icp:
 						fetch_primary_key_cols,
 						index, table, i, num_v);
 					if (!field) {
-						if (is_v) {
-							num_v++;
-						}
 						continue;
 					}
 				}
@@ -7483,15 +7512,16 @@ icp:
 				*/
 			}
 
-			if (is_v) {
-				num_v++;
-			}
 		}
 
-		ut_ad(m_prebuilt->idx_cond_n_cols > 0);
-		ut_ad(m_prebuilt->idx_cond_n_cols == m_prebuilt->n_template);
-
 		num_v = 0;
+		ut_ad(m_prebuilt->idx_cond_n_cols == m_prebuilt->n_template);
+		if (m_prebuilt->idx_cond_n_cols == 0) {
+			/* No columns to push down. It is safe to jump to np ICP
+			path. */
+			m_prebuilt->idx_cond = nullptr;
+			goto no_icp;
+		}
 
 		/* Include the fields that are not needed in index condition
 		pushdown. */
@@ -7506,7 +7536,7 @@ icp:
 			bool index_contains = index->contains_col_or_prefix(
 				is_v ? num_v : i - num_v, is_v);
 
-			if (!build_template_needs_field_in_icp(
+			if (is_v || !build_template_needs_field_in_icp(
 				    index, m_prebuilt, index_contains,
 				    is_v ? num_v : i - num_v, is_v)) {
 				/* Not needed in ICP */
@@ -7539,7 +7569,7 @@ icp:
 	} else {
 no_icp:
 		/* No index condition pushdown */
-		m_prebuilt->idx_cond = NULL;
+		ut_ad(m_prebuilt->idx_cond == nullptr);
 		ut_ad(num_v == 0);
 
 		for (ulint i = 0; i < n_fields; i++) {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-31154*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This is issue is about row ID filtering used with index on virtual
column(s). We hit debug assert and crash while building the record
template in Innodb. The primary reason is that we try to force the code
path to use the ICP path. With ICP, we don't support index with virtual
column and we validate it while index condition is pushed.

Simplify the code for building template to handle both ICP and Row ID
filtering by skipping virtual columns.

## Release Notes
None

## How can this PR be tested?
./mtr main.rowid_filter_innodb

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
