### PR TITLE
MDEV-33508 Performance regression due to frequent scan of buf_pool.flush_list

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2433,16 +2433,6 @@ static void buf_flush_page_cleaner()
     {
       buf_pool.page_cleaner_set_idle(false);
       buf_pool.n_flush_inc();
-      /* Remove clean blocks from buf_pool.flush_list before the LRU scan. */
-      for (buf_page_t *p= UT_LIST_GET_FIRST(buf_pool.flush_list); p; )
-      {
-        const lsn_t lsn{p->oldest_modification()};
-        ut_ad(lsn > 2 || lsn == 1);
-        buf_page_t *n= UT_LIST_GET_NEXT(list, p);
-        if (lsn <= 1)
-          buf_pool.delete_from_flush_list(p);
-        p= n;
-      }
       mysql_mutex_unlock(&buf_pool.flush_list_mutex);
       n= srv_max_io_capacity;
       mysql_mutex_lock(&buf_pool.mutex);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33508*
## Description
`buf_flush_page_cleaner()`: Remove a loop that had originally been added in commit 9d1466522ea92963ac6ca16b597392714280c9f1 (MDEV-32029) and made redundant by commit 5b53342a6a59ae1141b2a46467954fc3836f8e80 (MDEV-32588).

Starting with commit d34479dc664d4cbd4e9dad6b0f92d7c8e55595d1 (MDEV-33053) this loop would cause a significant performance regression in workloads where `buf_pool.need_LRU_eviction()` constantly holds in `buf_flush_page_cleaner()`.

Thanks to @sm-shaw for noticing this. (Actually, also @mariadb-DebarunBanerjee had pointed out this code in the #2949 review.)
## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?
Some stress tests of the server with a minimal `innodb_buffer_pool_size` would be useful, to ensure that there will be no hangs.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.