### PR TITLE
MDEV-33011 mariabackup --backup: FATAL ERROR: ... Can't open datafile…

### DIFF
--- a/mysql-test/suite/innodb/r/rename_table.result
+++ b/mysql-test/suite/innodb/r/rename_table.result
@@ -20,9 +20,15 @@ path
 DROP DATABASE abc_def;
 # restart
 DROP DATABASE abc_def2;
-call mtr.add_suppression("InnoDB: (Operating system error|The error means|Cannot rename file)");
+call mtr.add_suppression("InnoDB: Cannot rename '.*t1.ibd' to '.*non_existing_db.*' because the target schema directory doesn't exist");
 CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(100);
 RENAME TABLE t1 TO non_existing_db.t1;
 ERROR HY000: Error on rename of './test/t1' to './non_existing_db/t1' (errno: 168 "Unknown (generic) error from engine")
-FOUND 1 /\[ERROR\] InnoDB: Cannot rename file '.*t1\.ibd' to '.*non_existing_db/ in mysqld.1.err
+FOUND 1 /\[ERROR\] InnoDB: Cannot rename '.*t1\.ibd' to '.*non_existing_db/ in mysqld.1.err
+SET GLOBAL innodb_fast_shutdown=2;
+# restart
+SELECT * FROM t1;
+a
+100
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/rename_table.test
+++ b/mysql-test/suite/innodb/t/rename_table.test
@@ -30,16 +30,21 @@ DROP DATABASE abc_def;
 
 DROP DATABASE abc_def2;
 
-call mtr.add_suppression("InnoDB: (Operating system error|The error means|Cannot rename file)");
+call mtr.add_suppression("InnoDB: Cannot rename '.*t1.ibd' to '.*non_existing_db.*' because the target schema directory doesn't exist");
 
 CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(100);
 --replace_result "\\" "/"
 --error ER_ERROR_ON_RENAME
 RENAME TABLE t1 TO non_existing_db.t1;
 
---let SEARCH_PATTERN= \[ERROR\] InnoDB: Cannot rename file '.*t1\.ibd' to '.*non_existing_db
+--let SEARCH_PATTERN= \[ERROR\] InnoDB: Cannot rename '.*t1\.ibd' to '.*non_existing_db
 let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
 --source include/search_pattern_in_file.inc
 
+SET GLOBAL innodb_fast_shutdown=2;
+--source include/restart_mysqld.inc
+
+SELECT * FROM t1;
 # Cleanup
 DROP TABLE t1;

--- a/mysql-test/suite/mariabackup/rename_during_backup.result
+++ b/mysql-test/suite/mariabackup/rename_during_backup.result
@@ -60,3 +60,15 @@ SELECT * from t6;
 i
 5
 DROP TABLE t6;
+#
+# MDEV-33011 mariabackup --backup: FATAL ERROR: ... Can't open datafile cool_down/t3
+#
+# Simulate zero initialized page to defer tablespace load after rename log is found
+SET @save_dbug = @@SESSION.debug_dbug;
+SET DEBUG_DBUG="+d,checkpoint_after_file_create";
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+# RENAME that fails after redo log entry is written and flushed
+RENAME TABLE t1 TO non_existing_db.t1;
+ERROR HY000: Error on rename of './test/t1' to './non_existing_db/t1' (errno: 168 "Unknown (generic) error from engine")
+DROP TABLE t1;

--- a/mysql-test/suite/mariabackup/rename_during_backup.test
+++ b/mysql-test/suite/mariabackup/rename_during_backup.test
@@ -90,4 +90,31 @@ SELECT * from t6;
 DROP TABLE t6;
 rmdir $targetdir;
 
+--echo #
+--echo # MDEV-33011 mariabackup --backup: FATAL ERROR: ... Can't open datafile cool_down/t3
+--echo #
 
+--disable_query_log
+call mtr.add_suppression("InnoDB: Cannot rename '.*t1.ibd' to '.*non_existing_db.*' because the target schema directory doesn't exist");
+--enable_query_log
+
+mkdir $targetdir;
+
+--echo # Simulate zero initialized page to defer tablespace load after rename log is found
+SET @save_dbug = @@SESSION.debug_dbug;
+SET DEBUG_DBUG="+d,checkpoint_after_file_create";
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1);
+
+--echo # RENAME that fails after redo log entry is written and flushed
+--replace_result "\\" "/"
+--error ER_ERROR_ON_RENAME
+RENAME TABLE t1 TO non_existing_db.t1;
+
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --target-dir=$targetdir;
+exec $XTRABACKUP --prepare --target-dir=$targetdir;
+--enable_result_log
+
+DROP TABLE t1;
+rmdir $targetdir;

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1618,14 +1618,44 @@ Allocates and builds a file name from a path, a table or tablespace name
 and a suffix. The string must be freed by caller with ut_free().
 @param[in] path NULL or the directory path or the full path and filename.
 @param[in] name NULL if path is full, or Table/Tablespace name
-@param[in] suffix NULL or the file extention to use.
+@param[in] extension NULL or the file extension to use.
+@param[in] trim_name true if the last name on the path should be trimmed.
 @return own: file name */
 char*
-fil_make_filepath(
+fil_make_filepath_low(
 	const char*	path,
 	const char*	name,
-	ib_extention	suffix,
-	bool		strip_name);
+	ib_extention	extension,
+	bool		trim_name);
+
+/** Wrapper function over fil_make_filepath_low to build file name.
+@param path NULL or the directory path or the full path and filename.
+@param name NULL if path is full, or Table/Tablespace name
+@param extension NULL or the file extension to use.
+@param trim_name true if the last name on the path should be trimmed.
+@return own: file name */
+static inline char*
+fil_make_filepath(const char* path, const char* name, ib_extention extension,
+                  bool trim_name)
+{
+  /* If we are going to strip a name off the path, there better be a
+  path and a new name to put back on. */
+  ut_ad(!trim_name || (path && name));
+  return fil_make_filepath_low(path, name, extension, trim_name);
+}
+
+/** Wrapper function over fil_make_filepath_low to build directory name.
+@param path NULL or the directory path or the full path and filename.
+@param name NULL if path is full, or Table/Tablespace name
+@param extension NULL or the file extension to use.
+@param trim_name true if the last name on the path should be trimmed.
+@return own: directory name */
+static inline char*
+fil_make_dirpath(const char* path, const char* name, ib_extention extension,
+                 bool trim_name)
+{
+  return fil_make_filepath_low(path, name, extension, trim_name);
+}
 
 /** Create a tablespace file.
 @param[in]	space_id	Tablespace ID


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33011*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

    The root cause is the WAL logging of file operation when the actual
    operation fails afterwards. It creates a situation with a log entry for
    a operation that would always fail. I could simulate both the backup
    scenario error and Innodb recovery failure exploiting the weakness.
    
    We are following WAL for file rename operation and once logged the
    operation must eventually complete successfully, or it is a major
    catastrophe. Right now, we fail for rename and handle it as normal error
    and it is the problem.
    
    I created a patch to address RENAME operation to a non existing schema
    where the destination schema directory is missing. The patch checks for
    the missing schema before logging in an attempt to avoid the failure
    after WAL log is written/flushed. I also checked that the schema cannot
    be dropped or there cannot be any race with other rename to the same
    file. This is protected by the MDL lock in SQL today.
    
    The patch should be a good improvement over the current situation
    and solves the issue at hand.

## Release Notes
None

## How can this PR be tested?
./mtr innodb.rename_recovery
./mtr mariabackup.rename_during_backup
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
