### PR TITLE
MDEV-19044  Alter table corrupts while applying the modification log

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_crash.result
+++ b/mysql-test/suite/innodb/r/instant_alter_crash.result
@@ -199,6 +199,33 @@ INSERT IGNORE INTO t1 (f3) VALUES ( 'b' );
 INSERT IGNORE INTO t1 (f3) VALUES ( 'l' );
 SET DEBUG_SYNC="now SIGNAL con1_finish";
 connection default;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;
+#
+# MDEV-19044 Alter table corrupts while applying the
+#             modification log
+#
+CREATE TABLE t1 (
+f1 INT,
+f2 INT,
+f3 char(19) CHARACTER SET utf8mb3,
+f4 VARCHAR(500),
+f5 TEXT)ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
+INSERT INTO t1 VALUES(3, 1, REPEAT('a', 2), REPEAT("b", 20),'a');
+ALTER TABLE t1 ADD COLUMN f6 INT NOT NULL, ALGORITHM=INSTANT;
+INSERT INTO t1 VALUES(1, 2, REPEAT('InnoDB', 2),
+REPEAT("MariaDB", 20), REPEAT('a', 8000), 12);
+INSERT INTO t1 VALUES(1, 2, REPEAT('MYSQL', 2),
+REPEAT("MariaDB", 20), REPEAT('a', 8000), 12);
+SET DEBUG_SYNC='innodb_inplace_alter_table_enter SIGNAL con1_begin WAIT_FOR con1_update';
+ALTER TABLE t1 MODIFY COLUMN f2 INT NOT NULL, LOCK=Default;
+connection con1;
+SET DEBUG_SYNC='now WAIT_FOR con1_begin';
+UPDATE t1 SET f2=204 order by f1 limit 2;
+SET DEBUG_SYNC='now SIGNAL con1_update';
+connection default;
 disconnect con1;
 SET DEBUG_SYNC=RESET;
 CHECK TABLE t1;

--- a/mysql-test/suite/innodb/t/instant_alter_crash.test
+++ b/mysql-test/suite/innodb/t/instant_alter_crash.test
@@ -227,6 +227,33 @@ SET DEBUG_SYNC="now SIGNAL con1_finish";
 
 connection default;
 reap;
+CHECK TABLE t1;
+DROP TABLE t1;
+
+--echo #
+--echo # MDEV-19044 Alter table corrupts while applying the
+--echo #             modification log
+--echo #
+CREATE TABLE t1 (
+	f1 INT,
+	f2 INT,
+	f3 char(19) CHARACTER SET utf8mb3,
+        f4 VARCHAR(500),
+	f5 TEXT)ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
+INSERT INTO t1 VALUES(3, 1, REPEAT('a', 2), REPEAT("b", 20),'a');
+ALTER TABLE t1 ADD COLUMN f6 INT NOT NULL, ALGORITHM=INSTANT;
+INSERT INTO t1 VALUES(1, 2, REPEAT('InnoDB', 2),
+		      REPEAT("MariaDB", 20), REPEAT('a', 8000), 12);
+INSERT INTO t1 VALUES(1, 2, REPEAT('MYSQL', 2),
+                      REPEAT("MariaDB", 20), REPEAT('a', 8000), 12);
+SET DEBUG_SYNC='innodb_inplace_alter_table_enter SIGNAL con1_begin WAIT_FOR con1_update';
+send ALTER TABLE t1 MODIFY COLUMN f2 INT NOT NULL, LOCK=Default;
+connection con1;
+SET DEBUG_SYNC='now WAIT_FOR con1_begin';
+UPDATE t1 SET f2=204 order by f1 limit 2;
+SET DEBUG_SYNC='now SIGNAL con1_update';
+connection default;
+reap;
 disconnect con1;
 SET DEBUG_SYNC=RESET;
 CHECK TABLE t1;

--- a/storage/innobase/rem/rem0rec.cc
+++ b/storage/innobase/rem/rem0rec.cc
@@ -427,7 +427,7 @@ start:
 		}
 
 		if (!field->fixed_len
-		    || (format == REC_LEAF_TEMP
+		    || (format <= REC_LEAF_TEMP_INSTANT
 			&& !dict_col_get_fixed_size(col, true))) {
 			/* Variable-length field: read the length */
 			len = *lens--;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-19044*

## Description
Problem:
========
- InnoDB reads the length of the variable length field wrongly while applying the modification log of instant table.

Solution:
========
rec_init_offsets_comp_ordinary(): For the temporary instant file record, InnoDB should read the length of the variable length field from the record itself.

## How can this PR be tested?
./mtr innodb.instant_alter_crash test case
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
