### PR TITLE
MDEV-14193 innodb.log_file_name failed in buildbot with exception

### DIFF
--- a/mysql-test/suite/innodb/r/lock_insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/lock_insert_into_empty.result
@@ -47,6 +47,9 @@ CREATE TABLE t1 (k INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 SET k=1;
 START TRANSACTION;
 INSERT INTO t1 SET k=2;
+SELECT count(*) > 0 FROM mysql.innodb_index_stats lock in share mode;
+count(*) > 0
+1
 connect  con1,localhost,root,,test;
 SET innodb_lock_wait_timeout=0;
 CREATE TABLE t2 (pk INT AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB
@@ -54,4 +57,6 @@ AS SELECT k FROM t1;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 disconnect con1;
 connection default;
+SET innodb_lock_wait_timeout=default;
 DROP TABLE t1;
+DROP TABLE IF EXISTS t2;

--- a/mysql-test/suite/innodb/t/lock_insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/lock_insert_into_empty.test
@@ -51,6 +51,7 @@ CREATE TABLE t1 (k INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 SET k=1;
 START TRANSACTION;
 INSERT INTO t1 SET k=2;
+SELECT count(*) > 0 FROM mysql.innodb_index_stats lock in share mode;
 
 --connect (con1,localhost,root,,test)
 SET innodb_lock_wait_timeout=0;
@@ -59,5 +60,6 @@ CREATE TABLE t2 (pk INT AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB
 AS SELECT k FROM t1;
 --disconnect con1
 --connection default
-
+SET innodb_lock_wait_timeout=default;
 DROP TABLE t1;
+DROP TABLE IF EXISTS t2;


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-14193*

## Description
Problem:
=======
- innodb.log_file_name fails if it executes after innodb.lock_insert_into_empty in few cases.
innodb.lock_insert_into_empty test case failed to
cleanup the table t2. Rollback of create..select fails to remove the table when it fails to acquire the
innodb statistics table. This leads to rename table in log_file_name test case fails.

Solution:
========
- Cleanup the table t2 explictly after resetting innodb_lock_wait_timeout variable in
innodb.lock_insert_into_empty test case.

## How can this PR be tested?
./mtr innodb.log_insert_into_empty innodb.log_file_name
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
