### PR TITLE
MDEV-33546: Rpl_semi_sync_slave_status is ON When Replication Is Not Configured

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_fail_over.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_fail_over.result
@@ -50,6 +50,8 @@ SELECT @@GLOBAL.gtid_current_pos;
 0-1-4
 # restart: --skip-slave-start=1 --rpl-semi-sync-slave-enabled=1
 connection server_1;
+# Ensuring variable rpl_semi_sync_slave_enabled is ON..
+# Ensuring status rpl_semi_sync_slave_status is OFF..
 include/assert.inc [Table t1 should have 1 rows.]
 FOUND 1 /truncated binlog file:.*master.*000001/ in mysqld.1.err
 disconnect conn_client;
@@ -128,6 +130,8 @@ SELECT @@GLOBAL.gtid_current_pos;
 0-2-7
 # restart: --skip-slave-start=1 --rpl-semi-sync-slave-enabled=1
 connection server_2;
+# Ensuring variable rpl_semi_sync_slave_enabled is ON..
+# Ensuring status rpl_semi_sync_slave_status is OFF..
 include/assert.inc [Table t1 should have 3 rows.]
 FOUND 1 /truncated binlog file:.*slave.*000002.* to remove transactions starting from GTID 0-1-6/ in mysqld.2.err
 disconnect conn_client;
@@ -207,6 +211,8 @@ SELECT @@GLOBAL.gtid_current_pos;
 0-1-9
 # restart: --skip-slave-start=1 --rpl-semi-sync-slave-enabled=1
 connection server_1;
+# Ensuring variable rpl_semi_sync_slave_enabled is ON..
+# Ensuring status rpl_semi_sync_slave_status is OFF..
 include/assert.inc [Table t1 should have 6 rows.]
 FOUND 1 /truncated binlog file:.*master.*000002.* to remove transactions starting from GTID 0-1-9/ in mysqld.1.err
 disconnect conn_client;

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_crash.inc
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_crash.inc
@@ -81,6 +81,20 @@ SELECT @@GLOBAL.gtid_current_pos;
 --enable_reconnect
 --source include/wait_until_connected_again.inc
 
+--let $slave_semi_sync_enabled= query_get_value(SHOW VARIABLES LIKE 'Rpl_semi_sync_slave_enabled', Value, 1)
+--echo # Ensuring variable rpl_semi_sync_slave_enabled is ON..
+if (`SELECT strcmp("ON", "$slave_semi_sync_enabled") != 0`)
+{
+  --die Slave started with rpl_semi_sync_slave_enabled=1 yet it is OFF in the variable output
+}
+
+--let $slave_semi_sync_status= query_get_value(SHOW STATUS LIKE 'Rpl_semi_sync_slave_status', Value, 1)
+--echo # Ensuring status rpl_semi_sync_slave_status is OFF..
+if (`SELECT strcmp("OFF", "$slave_semi_sync_status") != 0`)
+{
+  --die Slave started with skip-slave-start yet started with rpl_semi_sync_slave_status=ON
+}
+
 --let $assert_cond= COUNT(*) = $expected_rows_on_master FROM t1
 --let $assert_text= Table t1 should have $expected_rows_on_master rows.
 --source include/assert.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -11007,7 +11007,7 @@ Recovery_context::Recovery_context() :
   prev_event_pos(0),
   last_gtid_standalone(false), last_gtid_valid(false), last_gtid_no2pc(false),
   last_gtid_engines(0),
-  do_truncate(repl_semisync_slave.get_slave_enabled()),
+  do_truncate(global_rpl_semi_sync_slave_enabled),
   truncate_validated(false), truncate_reset_done(false),
   truncate_set_in_1st(false), id_binlog(MAX_binlog_id),
   checksum_alg(BINLOG_CHECKSUM_ALG_UNDEF), gtid_maybe_to_truncate(NULL)

--- a/sql/semisync_slave.cc
+++ b/sql/semisync_slave.cc
@@ -34,7 +34,6 @@ int Repl_semi_sync_slave::init_object()
   m_init_done = true;
 
   /* References to the parameter works after set_options(). */
-  set_slave_enabled(global_rpl_semi_sync_slave_enabled);
   set_trace_level(rpl_semi_sync_slave_trace_level);
   set_delay_master(rpl_semi_sync_slave_delay_master);
   set_kill_conn_timeout(rpl_semi_sync_slave_kill_conn_timeout);


### PR DESCRIPTION
If a server has a default configuration (e.g. in a my.cnf file) with
rpl_semi_sync_slave_enabled set, on server start, the corresponding
rpl_semi_sync_slave_status variable will also be ON initially, even
if the slave was never configured/started. This is because the
Repl_semi_sync_slave initialization logic (function init_object())
sets the running status to the enabled value during
init_server_components().

This patch fixes this by removing the statement which sets the
semi-sync slave running status from the initialization logic. An
additional change needed from this is to semi-sync recovery: this
status variable was used as a condition to determine binlog
truncation during server recovery. This patch also switches this
condition to reference the global rpl_semi_sync_slave_enabled
variable. Though note, the semi-sync recovery condition is to be
changed entirely with the MDEV-33424 agenda.

This PR is organized as follows:
1. The first commit is the regression which shows the bug
2. The second commit contains the code patch and fix for the regression failing test