### PR TITLE
MDEV-35997 - Support vector ANN search benchmarking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -497,6 +497,9 @@ csx/
 # Windows Store app package directory
 AppPackages/
 
+# Ccache data directory
+.ccache
+
 # Others
 # sql/
 *.Cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -519,6 +519,39 @@ mini-benchmark:
       metrics:
         - metrics.txt
 
+ann-benchmark:
+  stage: test
+  needs: []
+  image: ubuntu:22.04
+  variables:
+    GIT_STRATEGY: fetch
+    GIT_SUBMODULE_STRATEGY: normal
+  script:
+    # Install dependencies for MariaDB build
+    - apt-get update
+    - apt-get install -y --no-install-recommends devscripts equivs ccache ninja-build
+    - mk-build-deps -r -i debian/control -t 'apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends'
+    # Build MariaDB for vector support with ccache
+    - mkdir -p builddir
+    - export CCACHE_DIR="$(pwd)/.ccache"; update-ccache-symlinks; ccache --zero-stats  # Zero out ccache counters
+    - ./support-files/ann-benchmark/server-vector-build.sh 2>&1 | tee -a ../build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
+    - ccache -s  # Show ccache stats to validate it worked
+    # Prepare and run ann-benchmarks
+    - apt-get install -y --no-install-recommends python3-numpy python3-scipy python3-pip build-essential git libmariadb-dev
+    - mkdir -p ann-workspace
+    - ./support-files/ann-benchmark/run-local.sh
+  artifacts:
+    when: always
+    name: "$CI_BUILD_NAME"
+    paths:
+      - build-$CI_JOB_NAME-$CI_COMMIT_REF_SLUG.log
+      - ${WORKING_DIR}/debug
+      - ann-workspace/ann-benchmarks/results
+  cache:
+    key: $MARIADB_MAJOR_VERSION
+    paths:
+      - .ccache
+
 cppcheck: 
   stage: sast
   needs: []

--- a/support-files/ann-benchmark/Dockerfile
+++ b/support-files/ann-benchmark/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+WORKDIR /build
+
+# Install dependencies for MariaDB build
+RUN apt-get update
+RUN apt-get install -yq --no-install-recommends libmariadb-dev devscripts equivs ccache ninja-build curl
+COPY debian/control /tmp/control
+RUN mk-build-deps -r -i /tmp/control -t 'apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends'
+
+# Install the required python lib for ann-benchmarks in advance. 
+# We do NOT install the whole ann-benchmarks in docker but instead keep it in mounted volume to allow local customization to benchmark configuration.
+RUN apt-get install -yq python3-numpy python3-scipy python3-pip build-essential git
+# Ann-benchmarks requires python 3.10, but higher version should also work
+RUN python3 -c 'import sys; exit(sys.version_info < (3,10))'
+RUN curl -LO https://github.com/HugoWenTD/ann-benchmarks/raw/mariadb/requirements.txt
+RUN pip3 install -r requirements.txt mariadb
+
+WORKDIR /build/server

--- a/support-files/ann-benchmark/run-docker.sh
+++ b/support-files/ann-benchmark/run-docker.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+# Description:
+#   This script automates the execution of the ANN benchmarking test with the ann-benchmarks tool within a Docker container.
+#   It builds the required Docker image if it doesn't exist or if forced, and then runs the benchmark in the specified workspace.
+#   Additionally, it offers support for overriding default behavior through environment variables.
+#
+# Dependencies:
+#   - Docker
+#
+# Usage:
+#   [MARIADB_SOURCE_DIR=.] [ANN_WORKSPACE=./ann-workspace] [DOCKER_REBUILD=yes] [MARIADB_REBUILD=yes] [DATASET=random-xs-20-euclidean] ./support-files/ann-benchmark/run-docker.sh
+#
+# Environment Variables:
+#   - ANN_WORKSPACE: Path to the workspace directory. Default: '<MariaDB source dir>/ann-workspace'
+#   - DOCKER_REBUILD: Flag to force the rebuild of the Docker image. Default: no
+#   - MARIADB_REBUILD: Flag to determine if MariaDB needs to be rebuilt. Default: yes
+#   - DATASET: Dataset to be used for benchmarking. Default: 'random-xs-20-euclidean'
+
+# Default paths
+SCRIPT_DIR=$(dirname "$(readlink -m "$0")")
+MARIADB_SOURCE_DIR="$SCRIPT_DIR/../.."
+ANN_WORKSPACE=$(realpath "${ANN_WORKSPACE:-$MARIADB_SOURCE_DIR/ann-workspace}")
+
+# Check if ANN_WORKSPACE exists, and create it if it doesn't
+if [ ! -d "$ANN_WORKSPACE" ]; then
+  mkdir -p "$ANN_WORKSPACE" || { echo -e "Error: Failed to create directory '$ANN_WORKSPACE'.\n"; exit 1; }
+fi
+
+IMAGE_NAME="mariadb-ann-benchmark"
+# Check if the Docker image exists and whether to force rebuild
+if [[ "$(docker images -q $IMAGE_NAME:latest 2> /dev/null)" == "" || "$DOCKER_REBUILD" == "yes" ]]; then
+  echo "Rebuilding docker image $IMAGE_NAME ..."
+  docker build -t $IMAGE_NAME -f $SCRIPT_DIR/Dockerfile $MARIADB_SOURCE_DIR
+else
+  echo "Docker image found."
+fi
+
+# Default value for MARIADB_REBUILD
+MARIADB_REBUILD=${MARIADB_REBUILD:-yes}
+
+cmd="./support-files/ann-benchmark/run-local.sh"
+# Run Ann-benchmark in docker container
+if [ "$MARIADB_REBUILD" == yes ]; then
+  cmd="./support-files/ann-benchmark/server-vector-build.sh && $cmd"
+fi
+
+vol_options="-v $MARIADB_SOURCE_DIR:/build/server -v $ANN_WORKSPACE:/build/ann-workspace"
+env_options="-e ANN_WORKSPACE=/build/ann-workspace -e MARIADB_BUILD_DIR=/build/ann-workspace/builddir -e CCACHE_DIR=/build/server/.ccache -e DATASET=$DATASET"
+
+docker run -it --rm --user $(id -u):$(id -g) $env_options $vol_options $IMAGE_NAME /bin/bash -c "$cmd"

--- a/support-files/ann-benchmark/run-local.sh
+++ b/support-files/ann-benchmark/run-local.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -e
+
+# Description:
+#   This script facilitates the execution of the ANN (Approximate Nearest Neighbors) benchmarking test using the ann-benchmarks tool.
+#   It runs the benchmark either against local builds or a specified folder where the MariaDB server is installed.
+#   Additionally, it offers support for overriding default behavior through environment variables.
+#
+# Dependencies:
+#   - Python 3.10+
+#   - Python library dependencies required by ann-benchmarks tool.
+#
+# Usage:
+#   [MARIADB_ROOT_DIR=./builddir] [ANN_WORKSPACE=./ann-workspace] [DATASET=random-xs-20-euclidean] [FLAMEGRAPH=yes] ./support-files/ann-benchmark/run-local.sh
+#
+# Environment Variables:
+#   - MARIADB_BUILD_DIR: Path to the directory where MariaDB is built. Default: '<MariaDB source dir>/builddir'
+#   - ANN_WORKSPACE:     Path to the workspace directory. Default: '<MariaDB source dir>/ann-workspace'
+#   - DATASET:           Dataset to be used for benchmarking. Default: 'random-xs-20-euclidean'
+#   - FLAMEGRAPH:        Generate flame graph using perf. <yes/no>. Default: no
+
+# Ensure that subprocesses are terminated upon an unexpected exit.
+trap 'pkill -P $$' EXIT INT
+
+# Default paths
+SCRIPT_DIR=$(dirname "$(readlink -m "$0")")
+MARIADB_SOURCE_DIR="$SCRIPT_DIR/../.."
+MARIADB_BUILD_DIR=$(realpath "${MARIADB_BUILD_DIR:-$MARIADB_SOURCE_DIR/builddir}")
+ANN_WORKSPACE=$(realpath "${ANN_WORKSPACE:-$MARIADB_SOURCE_DIR/ann-workspace}")
+
+# Default dataset
+DATASET="${DATASET:-random-xs-20-euclidean}"
+
+# Sub-workdirs
+ANN_SOURCE_DIR=$ANN_WORKSPACE/ann-benchmarks
+MARIADB_DB_WORKSPACE=$ANN_WORKSPACE/mariadb-workspace
+
+# Ensure the build artifacts exist
+if [ ! -d $MARIADB_BUILD_DIR ] || [ ! -f $MARIADB_BUILD_DIR/*/mariadbd ]; then
+  echo "Error: '$MARIADB_BUILD_DIR' does not exist or 'mariadbd' file does not found."
+  exit 1
+fi
+
+mkdir -p $ANN_WORKSPACE
+cd $ANN_WORKSPACE
+
+# Download ann-benchmarks in the target folder and install dependencies
+function install_ann_benchmarks() {
+  target_dir=$1
+  
+  # Check if Python 3.10 or newer is available, required by ann-benchmarks
+  if ! python3 -c 'import sys; exit(sys.version_info < (3,10))'; then
+      echo -e "Python is required but not found. Please install Python 3.10 or higher to proceed.\n"
+      exit 1
+  fi
+  
+  ann_git_repo="https://github.com/HugoWenTD/ann-benchmarks.git"
+  ann_git_branch="mariadb"
+  
+  echo -e "Downloading ann-benchmark...\n"
+  if [ ! -d "$target_dir" ]; then
+      # Only clone ann-benchmarks repository if it doesn't exist
+      git clone --branch "$ann_git_branch" "$ann_git_repo" --depth 1 "$target_dir" || {
+          echo -e "Failed to clone ann-benchmarks repository. Please check your internet connection and try again.\n"
+          exit 1
+      }
+      # Existing benchmark results for various algorithms in the repository may cause confusion:
+      # https://github.com/erikbern/ann-benchmarks/tree/main/results
+      # Deleting these irrelevant images to prevent confusion.
+      rm -rf $target_dir/results/*
+  else
+      # Do not overwrite the script to allow user customization
+      echo -e "[WARN] ann-benchmarks repository already exists. Skipping cloning. Remove $target_dir if you want it to be re-initialized.\n"
+  fi
+  
+  echo -e "Installing ann-benchmark dependencies...\n"
+  if ! pip3 install -q -r $target_dir/requirements.txt mariadb; then
+      echo -e "Failed to install dependencies. Please make sure pip is installed and try again.\n"
+      exit 1
+  fi
+}
+
+# Prepare ann-benchmarks
+install_ann_benchmarks $ANN_SOURCE_DIR
+cd $ANN_SOURCE_DIR
+
+# Env variables as arguments for ann-benchmarks run
+export DO_INIT_MARIADB=yes
+export MARIADB_ROOT_DIR="$MARIADB_BUILD_DIR"
+export MARIADB_DB_WORKSPACE
+export MARIADB_SOURCE_DIR
+export FLAMEGRAPH
+
+# Remove previous results if there's any
+rm -rf results/$DATASET
+
+echo -e "Starting ann-benchmark...\n"
+# One known issue of ann-benchmars tool is that it returns 0 even test failed:
+python3 -u run.py  --algorithm mariadb --dataset $DATASET --local
+
+echo -e "\nAnn-benchmark exporting data...\n"
+python3 -u data_export.py --out results/res.csv
+
+echo -e "\nAnn-benchmark plotting...\n"
+python3 -u plot.py --dataset $DATASET
+# For this version we use the recall rate and QPS provided by the tool for eveluation of the performance.
+# Note that QPS number could be different on different instance type.
+echo -e "\nAnn-benchmark plot done, the last two colunms in above output for 'recall rate' and 'QPS'. ^^^ \n"
+echo -e "\n[COMPLETED]\n"

--- a/support-files/ann-benchmark/server-vector-build.sh
+++ b/support-files/ann-benchmark/server-vector-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Default paths
+SCRIPT_DIR=$(dirname "$(readlink -m "$0")")
+MARIADB_SOURCE_DIR="$SCRIPT_DIR/../.."
+MARIADB_BUILD_DIR=$(realpath "${MARIADB_BUILD_DIR:-$MARIADB_SOURCE_DIR/builddir}")
+
+# Skip building some of the engine/plugins as not necessary or does not build with current vector branch
+cmake -S $MARIADB_SOURCE_DIR -B $MARIADB_BUILD_DIR -G Ninja -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DWITH_SSL=system -DPLUGIN_COLUMNSTORE=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_S3=NO -DPLUGIN_MROONGA=NO -DPLUGIN_CONNECT=NO -DPLUGIN_MROONGA=NO -DPLUGIN_TOKUDB=NO -DPLUGIN_PERFSCHEMA=NO -DWITH_WSREP=OFF -DPLUGIN_SPIDER=NO
+
+cmake --build $MARIADB_BUILD_DIR


### PR DESCRIPTION
## Description

Introduce scripts and Docker file for running the `ann-benchmarks` tool, dedicated to vector search performance testing.

- Offer developers support to run the benchmark in their development environment via existing MariaDB builds or by deploying the source code and executing the benchmark within Docker.

- Also, integrate these builds into GitLab CI for Ubuntu 22.04 and include ANN benchmarking tests.

For detailed usage instructions, refer to the commit message and script help command.


## How can this PR be tested?

Manual test was done for the scripts. The script is also integrated in Git-Lab CI pipeline.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*

## Backward compatibility

The changes fully backward compatible.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.