### PR TITLE
MDEV-32445  InnoDB may corrupt its log before upgrading it on startup

### DIFF
--- a/mysql-test/suite/innodb/r/log_upgrade_101_flags.result
+++ b/mysql-test/suite/innodb/r/log_upgrade_101_flags.result
@@ -1,0 +1,12 @@
+call mtr.add_suppression("InnoDB: The change buffer is corrupted");
+call mtr.add_suppression("InnoDB: Tablespace size stored in header is 768 pages, but the sum of data file sizes is 384 pages");
+call mtr.add_suppression("InnoDB: adjusting FSP_SPACE_FLAGS of file");
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/log_upgrade --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/log_upgrade --innodb-force-recovery=5 --innodb-log-file-size=4m --innodb_page_size=32k --innodb_buffer_pool_size=10M
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.ENGINES
+WHERE engine = 'innodb'
+AND support IN ('YES', 'DEFAULT', 'ENABLED');
+COUNT(*)
+1
+FOUND 1 /InnoDB: Upgrading redo log:/ in mysqld.1.err
+# restart
+# End of 10.5 tests

--- a/mysql-test/suite/innodb/t/log_upgrade_101_flags.test
+++ b/mysql-test/suite/innodb/t/log_upgrade_101_flags.test
@@ -1,0 +1,91 @@
+--source include/have_innodb.inc
+--source include/big_test.inc
+--source include/not_embedded.inc
+call mtr.add_suppression("InnoDB: The change buffer is corrupted");
+call mtr.add_suppression("InnoDB: Tablespace size stored in header is 768 pages, but the sum of data file sizes is 384 pages");
+call mtr.add_suppression("InnoDB: adjusting FSP_SPACE_FLAGS of file");
+--source include/shutdown_mysqld.inc
+let bugdir= $MYSQLTEST_VARDIR/tmp/log_upgrade;
+--mkdir $bugdir
+--let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $dirs= --innodb-data-home-dir=$bugdir --innodb-log-group-home-dir=$bugdir
+
+# Test case similar to log_upgrade.test
+perl;
+do "$ENV{MTR_SUITE_DIR}/../innodb/include/crc32.pl";
+my $polynomial = 0x82f63b78; # CRC-32C
+
+die unless open OUT, ">", "$ENV{bugdir}/ibdata1";
+binmode OUT;
+
+my $head = pack("Nx[18]", 0);
+# Add FSP_SPACE_FLAGS as 49152 (10.1.0...10.1.20), page_size = 32k
+my $body = pack("x[8]Nx[4]Nx[2]Nx[32696]", 768, 49152, 97937874);
+my $ck = mycrc32($head, 0, $polynomial) ^ mycrc32($body, 0, $polynomial);
+print OUT pack("N",$ck).$head.pack("x[12]").$body.pack("Nx[4]",$ck);
+# Dummy pages 1..6.
+print OUT chr(0) x (6 * 32768);
+# Dictionary header page (page 7).
+$head = pack("Nx[18]", 7);
+$body = pack("x[32]Nx[8]Nx[32674]", 8, 9);
+$ck = mycrc32($head, 0, $polynomial) ^ mycrc32($body, 0, $polynomial);
+print OUT pack("N",$ck).$head.pack("x[12]").$body.pack("Nx[4]",$ck);
+
+# Empty SYS_TABLES page (page 8).
+$head = pack("NNNx[8]n", 8, ~0, ~0, 17855);
+$body = pack("nnx[31]Cx[20]", 2, 124, 1);
+$body .= pack("nxnn", 0x801, 3, 116) . "infimum";
+$body .= pack("xnxnxx", 0x901, 0x803) . "supremum";
+$body .= pack("x[32632]nn", 116, 101);
+$ck = mycrc32($head, 0, $polynomial) ^ mycrc32($body, 0, $polynomial);
+print OUT pack("N",$ck).$head.pack("x[12]").$body.pack("Nx[4]",$ck);
+
+# Empty SYS_INDEXES page (page 9).
+$head = pack("NNNx[8]n", 9, ~0, ~0, 17855);
+$body = pack("nnx[31]Cx[20]", 2, 124, 3);
+$body .= pack("nxnn", 0x801, 3, 116) . "infimum";
+$body .= pack("xnxnxx", 0x901, 0x803) . "supremum";
+$body .= pack("x[32632]nn", 116, 101);
+$ck = mycrc32($head, 0, $polynomial) ^ mycrc32($body, 0, $polynomial);
+print OUT pack("N",$ck).$head.pack("x[12]").$body.pack("Nx[4]",$ck);
+
+die unless seek(OUT, 768 * 16384 - 1, 0);
+print OUT chr(0);
+close OUT or die;
+
+die unless open OUT, ">", "$ENV{bugdir}/ib_logfile0";
+binmode OUT;
+$_= pack("Nx[5]nx[5]", 1, 0x1286) . "BogoDB 4.3.2.1" . chr(0) x 478;
+print OUT $_, pack("N", mycrc32($_, 0, $polynomial));
+# checkpoint page 1 and all-zero checkpoint 2
+$_= pack("x[13]nCNNx[484]", 0x1286, 12, 2, 0x80c);
+print OUT $_, pack("N", mycrc32($_, 0, $polynomial));
+die unless seek(OUT, 0x1FFFFFFFF, 0);
+print OUT chr(0);
+close OUT or die;
+die unless open OUT, ">", "$ENV{bugdir}/ib_logfile1";
+binmode OUT;
+die unless seek(OUT, 0x800, 0); # the first 2048 bytes are unused!
+$_= pack("Nnnx[500]", 0x80000944, 12, 12);
+print OUT $_, pack("N", mycrc32($_, 0, $polynomial));
+die unless seek(OUT, 0x1FFFFFFFF, 0);
+print OUT chr(0);
+close OUT or die;
+EOF
+
+--let $restart_parameters= $dirs --innodb-force-recovery=5 --innodb-log-file-size=4m --innodb_page_size=32k --innodb_buffer_pool_size=10M
+--source include/start_mysqld.inc
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.ENGINES
+WHERE engine = 'innodb'
+AND support IN ('YES', 'DEFAULT', 'ENABLED');
+--source include/shutdown_mysqld.inc
+--let SEARCH_PATTERN= InnoDB: Upgrading redo log:
+--source include/search_pattern_in_file.inc
+--let $restart_parameters= $dirs
+
+--remove_files_wildcard $bugdir
+--rmdir $bugdir
+--let $restart_parameters=
+--source include/start_mysqld.inc
+
+--echo # End of 10.5 tests

--- a/storage/innobase/include/log0log.inl
+++ b/storage/innobase/include/log0log.inl
@@ -270,6 +270,7 @@ log_reserve_and_write_fast(
 	}
 
 	lsn_t lsn = log_sys.get_lsn();
+	ut_ad(log_sys.is_physical());
 	*start_lsn = lsn;
 
 	memcpy(log_sys.buf + log_sys.buf_free, str, len);

--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -850,6 +850,8 @@ static void log_write_low(const void *str, size_t size)
       len= trailer_offset - log_sys.buf_free % OS_FILE_LOG_BLOCK_SIZE;
     }
 
+    ut_ad(log_sys.is_physical());
+
     memcpy(log_sys.buf + log_sys.buf_free, str, len);
 
     size-= len;

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1555,6 +1555,102 @@ dberr_t srv_start(bool create_new_db)
 
 		fil_system.space_id_reuse_warned = false;
 
+		if (srv_operation == SRV_OPERATION_RESTORE
+		    || srv_operation == SRV_OPERATION_RESTORE_EXPORT) {
+			buf_flush_sync();
+			recv_sys.debug_free();
+			/* After applying the redo log from
+			SRV_OPERATION_BACKUP, flush the changes
+			to the data files and truncate or delete the log.
+			Unless --export is specified, no further change to
+			InnoDB files is needed. */
+			ut_ad(srv_force_recovery <= SRV_FORCE_IGNORE_CORRUPT);
+			ut_ad(recv_no_log_write);
+			err = fil_write_flushed_lsn(log_sys.get_lsn());
+			DBUG_ASSERT(!buf_pool.any_io_pending());
+			log_sys.log.close_file();
+			if (err == DB_SUCCESS) {
+				bool trunc = srv_operation
+					== SRV_OPERATION_RESTORE;
+				if (!trunc) {
+					delete_log_file("0");
+				} else {
+					auto logfile0 = get_log_file_path();
+					/* Truncate the first log file. */
+					fclose(fopen(logfile0.c_str(), "w"));
+				}
+			}
+			return(err);
+		}
+		/* Upgrade or resize or rebuild the redo logs before
+		generating any dirty pages, so that the old redo log
+		file will not be written to. */
+
+		if (srv_force_recovery == SRV_FORCE_NO_LOG_REDO) {
+			/* Completely ignore the redo log. */
+		} else if (srv_read_only_mode) {
+			/* Leave the redo log alone. */
+		} else if (srv_log_file_size_requested == srv_log_file_size
+			   && srv_log_file_found
+			   && log_sys.log.format
+			   == (srv_encrypt_log
+			       ? log_t::FORMAT_ENC_10_5
+			       : log_t::FORMAT_10_5)
+			   && log_sys.log.subformat == 2) {
+			/* No need to add or remove encryption,
+			upgrade, downgrade, or resize. */
+		} else {
+			/* Prepare to delete the old redo log file */
+			flushed_lsn = srv_prepare_to_delete_redo_log_file(
+				srv_log_file_found);
+
+			DBUG_EXECUTE_IF("innodb_log_abort_1",
+					return(srv_init_abort(DB_ERROR)););
+			/* Prohibit redo log writes from any other
+			threads until creating a log checkpoint at the
+			end of create_log_file(). */
+			ut_d(recv_no_log_write = true);
+			DBUG_ASSERT(!buf_pool.any_io_pending());
+
+			DBUG_EXECUTE_IF("innodb_log_abort_3",
+					return(srv_init_abort(DB_ERROR)););
+			DBUG_PRINT("ib_log", ("After innodb_log_abort_3"));
+
+			/* Stamp the LSN to the data files. */
+			err = fil_write_flushed_lsn(flushed_lsn);
+
+			DBUG_EXECUTE_IF("innodb_log_abort_4", err = DB_ERROR;);
+			DBUG_PRINT("ib_log", ("After innodb_log_abort_4"));
+
+			if (err != DB_SUCCESS) {
+				return(srv_init_abort(err));
+			}
+
+			/* Close the redo log file, so that we can replace it */
+			log_sys.log.close_file();
+
+			DBUG_EXECUTE_IF("innodb_log_abort_5",
+					return(srv_init_abort(DB_ERROR)););
+			DBUG_PRINT("ib_log", ("After innodb_log_abort_5"));
+
+			ib::info()
+				<< "Starting to delete and rewrite log file.";
+
+			srv_log_file_size = srv_log_file_size_requested;
+
+			err = create_log_file(false, flushed_lsn, logfile0);
+
+			if (err == DB_SUCCESS) {
+				err = create_log_file_rename(flushed_lsn,
+							     logfile0);
+			}
+
+			if (err != DB_SUCCESS) {
+				return(srv_init_abort(err));
+			}
+		}
+		recv_sys.debug_free();
+
 		if (!srv_read_only_mode) {
 			const ulint flags = FSP_FLAGS_PAGE_SSIZE();
 			for (ulint id = 0; id <= srv_undo_tablespaces; id++) {
@@ -1639,104 +1735,6 @@ dberr_t srv_start(bool create_new_db)
 				return(srv_init_abort(DB_ERROR));
 			}
 		}
-
-		if (srv_operation == SRV_OPERATION_RESTORE
-		    || srv_operation == SRV_OPERATION_RESTORE_EXPORT) {
-			buf_flush_sync();
-			recv_sys.debug_free();
-			/* After applying the redo log from
-			SRV_OPERATION_BACKUP, flush the changes
-			to the data files and truncate or delete the log.
-			Unless --export is specified, no further change to
-			InnoDB files is needed. */
-			ut_ad(srv_force_recovery <= SRV_FORCE_IGNORE_CORRUPT);
-			ut_ad(recv_no_log_write);
-			err = fil_write_flushed_lsn(log_sys.get_lsn());
-			DBUG_ASSERT(!buf_pool.any_io_pending());
-			log_sys.log.close_file();
-			if (err == DB_SUCCESS) {
-				bool trunc = srv_operation
-					== SRV_OPERATION_RESTORE;
-				if (!trunc) {
-					delete_log_file("0");
-				} else {
-					auto logfile0 = get_log_file_path();
-					/* Truncate the first log file. */
-					fclose(fopen(logfile0.c_str(), "w"));
-				}
-			}
-			return(err);
-		}
-
-		/* Upgrade or resize or rebuild the redo logs before
-		generating any dirty pages, so that the old redo log
-		file will not be written to. */
-
-		if (srv_force_recovery == SRV_FORCE_NO_LOG_REDO) {
-			/* Completely ignore the redo log. */
-		} else if (srv_read_only_mode) {
-			/* Leave the redo log alone. */
-		} else if (srv_log_file_size_requested == srv_log_file_size
-			   && srv_log_file_found
-			   && log_sys.log.format
-			   == (srv_encrypt_log
-			       ? log_t::FORMAT_ENC_10_5
-			       : log_t::FORMAT_10_5)
-			   && log_sys.log.subformat == 2) {
-			/* No need to add or remove encryption,
-			upgrade, downgrade, or resize. */
-		} else {
-			/* Prepare to delete the old redo log file */
-			flushed_lsn = srv_prepare_to_delete_redo_log_file(
-				srv_log_file_found);
-
-			DBUG_EXECUTE_IF("innodb_log_abort_1",
-					return(srv_init_abort(DB_ERROR)););
-			/* Prohibit redo log writes from any other
-			threads until creating a log checkpoint at the
-			end of create_log_file(). */
-			ut_d(recv_no_log_write = true);
-			DBUG_ASSERT(!buf_pool.any_io_pending());
-
-			DBUG_EXECUTE_IF("innodb_log_abort_3",
-					return(srv_init_abort(DB_ERROR)););
-			DBUG_PRINT("ib_log", ("After innodb_log_abort_3"));
-
-			/* Stamp the LSN to the data files. */
-			err = fil_write_flushed_lsn(flushed_lsn);
-
-			DBUG_EXECUTE_IF("innodb_log_abort_4", err = DB_ERROR;);
-			DBUG_PRINT("ib_log", ("After innodb_log_abort_4"));
-
-			if (err != DB_SUCCESS) {
-				return(srv_init_abort(err));
-			}
-
-			/* Close the redo log file, so that we can replace it */
-			log_sys.log.close_file();
-
-			DBUG_EXECUTE_IF("innodb_log_abort_5",
-					return(srv_init_abort(DB_ERROR)););
-			DBUG_PRINT("ib_log", ("After innodb_log_abort_5"));
-
-			ib::info()
-				<< "Starting to delete and rewrite log file.";
-
-			srv_log_file_size = srv_log_file_size_requested;
-
-			err = create_log_file(false, flushed_lsn, logfile0);
-
-			if (err == DB_SUCCESS) {
-				err = create_log_file_rename(flushed_lsn,
-							     logfile0);
-			}
-
-			if (err != DB_SUCCESS) {
-				return(srv_init_abort(err));
-			}
-		}
-
-		recv_sys.debug_free();
 	}
 
 	ut_ad(err == DB_SUCCESS);


### PR DESCRIPTION

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32445*

## Description
Problem:
========
 During upgrade, InnoDB does write the redo log for adjusting
the tablespace size or tablespace flags even before the log has upgraded to configured format. This could lead to data inconsistent if any crash happened during upgrade process.

Fix:
===
srv_start(): Write the tablespace flags adjustment, increased tablespace size redo log only after redo log upgradation.

log_write_low(), log_reserve_and_write_fast(): Check whether the redo log is in physical format.

## How can this PR be tested?
./mtr innodb.log_upgrade_101_flags
If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
