### PR TITLE
Update URLs in test_upgrade script

### DIFF
--- a/tests/upgrade_from/test_upgrade.sh
+++ b/tests/upgrade_from/test_upgrade.sh
@@ -132,7 +132,7 @@ install_mariadb_from_archive() {
 [mariadb]
 name=MariaDB
 baseurl=$rpm_repository
-gpgkey=https://ftp.osuosl.org/pub/mariadb/yum/RPM-GPG-KEY-MariaDB
+gpgkey=https://archive.mariadb.org/PublicKey
 gpgcheck=1
 EOF
 
@@ -153,7 +153,7 @@ EOF
     [[ $latest_distro == 33 ]] && dnf install -y http://springdale.princeton.edu/data/springdale/7/x86_64/os/Computational/boost173-program-options-1.73.0-7.sdl7.x86_64.rpm
     [[ $latest_distro == 34 ]] && dnf install -y https://repo.almalinux.org/almalinux/9/AppStream/x86_64/os/Packages/boost-program-options-1.75.0-8.el9.x86_64.rpm \
         https://vault.centos.org/centos/8/AppStream/x86_64/os/Packages/liburing-1.0.7-3.el8.x86_64.rpm
-    [[ $latest_distro == 35 ]] && dnf install -y https://download-ib01.fedoraproject.org/pub/fedora/linux/updates/36/Everything/x86_64/Packages/b/boost-program-options-1.76.0-12.fc36.x86_64.rpm
+    [[ $latest_distro == 35 ]] && dnf install -y https://archives.fedoraproject.org/pub/archive/fedora/linux/updates/36/Everything/x86_64/Packages/b/boost-program-options-1.76.0-12.fc36.x86_64.rpm
     if [[ $major_version == "10.4" ]] && [[ $minor_version -ge 24 ]]; then
         log RPMs not available for version 10.4.24+ from this repository. You may try testing by installing from the .tar.gz binaries.
         exit 1


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->


<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Update the URLs in two places in the tests/upgrade_from/test_upgrade.sh script.
* boost-program-options dependency points to
    archives.fedoraproject.org
* gpgkey for the MariaDB rpm repository points to
    archive.mariadb.org/PublicKey

This ensures that the upgrade testing run in .gitlab-ci.yml continues to
function and refers to the correct GPG key.

## Release Notes
None, minor fix, no change in functionality

## How can this PR be tested?

Start a Docker image
```
docker run --rm -w /mariadb/ -v $(pwd):/mariadb/ -it fedora:latest bash
```
Inside docker
```
[root@fb7e29abd0ac mariadb]# ./tests/upgrade_from/test_upgrade.sh 10.5 10.6
```
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.