### PR TITLE
MDEV-33600 galera.MDEV-25731 failure wsrep_replicate_myisam removed in 10.7

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-25731.result
+++ b/mysql-test/suite/galera/r/MDEV-25731.result
@@ -4,9 +4,8 @@ connection node_1;
 SET GLOBAL wsrep_load_data_splitting=ON;
 Warnings:
 Warning	1287	'@@wsrep_load_data_splitting' is deprecated and will be removed in a future release
-SET GLOBAL wsrep_replicate_myisam=ON;
-Warnings:
-Warning	1287	'@@wsrep_replicate_myisam' is deprecated and will be removed in a future release. Please use '@@wsrep_mode=REPLICATE_MYISAM' instead
+SET @save_wsrep_mode=@@GLOBAL.wsrep_mode;
+SET GLOBAL wsrep_mode=REPLICATE_MYISAM;
 CREATE TABLE t1 (c1 int) ENGINE=MYISAM;
 LOAD DATA INFILE '../../std_data/mdev-25731.dat' IGNORE INTO TABLE t1 LINES TERMINATED BY '\n';
 Warnings:
@@ -33,6 +32,4 @@ DROP TABLE t1;
 SET GLOBAL wsrep_load_data_splitting=OFF;
 Warnings:
 Warning	1287	'@@wsrep_load_data_splitting' is deprecated and will be removed in a future release
-SET GLOBAL wsrep_replicate_myisam=OFF;
-Warnings:
-Warning	1287	'@@wsrep_replicate_myisam' is deprecated and will be removed in a future release. Please use '@@wsrep_mode=REPLICATE_MYISAM' instead
+SET GLOBAL wsrep_mode=@save_wsrep_mode;

--- a/mysql-test/suite/galera/t/MDEV-25731.test
+++ b/mysql-test/suite/galera/t/MDEV-25731.test
@@ -3,7 +3,8 @@
 
 --connection node_1
 SET GLOBAL wsrep_load_data_splitting=ON;
-SET GLOBAL wsrep_replicate_myisam=ON;
+SET @save_wsrep_mode=@@GLOBAL.wsrep_mode;
+SET GLOBAL wsrep_mode=REPLICATE_MYISAM;
 CREATE TABLE t1 (c1 int) ENGINE=MYISAM;
 LOAD DATA INFILE '../../std_data/mdev-25731.dat' IGNORE INTO TABLE t1 LINES TERMINATED BY '\n';
 SELECT COUNT(*) AS EXPECT_6 FROM t1;
@@ -22,6 +23,6 @@ SELECT COUNT(*) AS EXPECT_12 FROM t1;
 --connection node_1
 DROP TABLE t1;
 SET GLOBAL wsrep_load_data_splitting=OFF;
-SET GLOBAL wsrep_replicate_myisam=OFF;
+SET GLOBAL wsrep_mode=@save_wsrep_mode;
 
 


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33600*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Replace with wsrep_mode.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
