### PR TITLE
MDEV-33603 connect.part_table test failure - ppc64le only

### DIFF
--- a/storage/connect/mysql-test/connect/r/part_table.result
+++ b/storage/connect/mysql-test/connect/r/part_table.result
@@ -151,7 +151,7 @@ Note	1105	xt3: 0 affected rows
 UPDATE t1 SET msg = 'soixante' WHERE id = 60;
 Warnings:
 Note	1105	xt3: 1 affected rows
-SELECT * FROM t1 WHERE id > 50;
+SELECT * FROM t1 WHERE id > 50 ORDER BY id;
 id	msg
 60	soixante
 72	number

--- a/storage/connect/mysql-test/connect/t/part_table.test
+++ b/storage/connect/mysql-test/connect/t/part_table.test
@@ -75,7 +75,7 @@ SELECT * FROM t1 WHERE id = 7;
 SELECT * FROM t1 WHERE id = 35;
 UPDATE t1 SET msg = 'number' WHERE id in (60,72);
 UPDATE t1 SET msg = 'soixante' WHERE id = 60;
-SELECT * FROM t1 WHERE id > 50;
+SELECT * FROM t1 WHERE id > 50 ORDER BY id;
 UPDATE t1 SET msg = 'big' WHERE id > 50;
 UPDATE t1 SET msg = 'sept' WHERE id = 7;
 SELECT * FROM t1;


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33603*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Corrected by fixing test case order to the id column.

## Release Notes

not noteworty.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
