### PR TITLE
MDEV-32346  Assertion failure sym_node->table != NULL in pars_retrieve_table_def on UPDATE

### DIFF
--- a/mysql-test/suite/innodb_fts/r/foreign_key_update.result
+++ b/mysql-test/suite/innodb_fts/r/foreign_key_update.result
@@ -32,3 +32,15 @@ database
 database
 DROP TABLE t1_fk;
 DROP TABLE t1;
+#
+# MDEV-32346  Assertion failure sym_node->table != NULL
+#	in pars_retrieve_table_def on UPDATE
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT, b TEXT, FOREIGN KEY(a) REFERENCES t1(a),
+FULLTEXT (b))ENGINE=InnoDB;
+INSERT INTO t1 SET a=1;
+ALTER TABLE t2 DISCARD TABLESPACE;
+UPDATE t1 SET a=2;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`a`) REFERENCES `t1` (`a`))
+DROP TABLE t2,t1;

--- a/mysql-test/suite/innodb_fts/t/foreign_key_update.test
+++ b/mysql-test/suite/innodb_fts/t/foreign_key_update.test
@@ -32,3 +32,16 @@ SELECT * FROM t1_fk WHERE MATCH(a) AGAINST('database');
 
 DROP TABLE t1_fk;
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-32346  Assertion failure sym_node->table != NULL
+--echo #	in pars_retrieve_table_def on UPDATE
+--echo #
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT, b TEXT, FOREIGN KEY(a) REFERENCES t1(a),
+		 FULLTEXT (b))ENGINE=InnoDB;
+INSERT INTO t1 SET a=1;
+ALTER TABLE t2 DISCARD TABLESPACE;
+--error ER_ROW_IS_REFERENCED_2
+UPDATE t1 SET a=2;
+DROP TABLE t2,t1;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1689,7 +1689,8 @@ init_fts_doc_id_for_ref(
 
 		ut_ad(foreign->foreign_table != NULL);
 
-		if (foreign->foreign_table->fts != NULL) {
+		if (foreign->foreign_table->space
+		    && foreign->foreign_table->fts) {
 			fts_init_doc_id(foreign->foreign_table);
 		}
 


### PR DESCRIPTION
## Description
- During update operation, InnoDB should avoid the initializing the FTS_DOC_ID of foreign table if the foreign table is discarded

## How can this PR be tested?
./mtr innodb_fts.foreign_key_update
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
