### PR TITLE
MDEV-32633: Fix Galera cluster <-> native replication interaction

### DIFF
--- a/mysql-test/suite/galera_3nodes/disabled.def
+++ b/mysql-test/suite/galera_3nodes/disabled.def
@@ -11,7 +11,6 @@
 ##############################################################################
 
 galera_2_cluster : MDEV-32631 galera_2_cluster: before_rollback(): Assertion `0' failed
-galera_gtid_2_cluster : MDEV-32633 galera_gtid_2_cluster: Assertion `thd->wsrep_next_trx_id() != (0x7fffffffffffffffLL * 2ULL + 1)'
 galera_ssl_reload : MDEV-32778 galera_ssl_reload failed with warning message
 galera_ipv6_mariabackup : temporarily disabled at the request of Codership
 galera_pc_bootstrap : temporarily disabled at the request of Codership

--- a/mysql-test/suite/galera_3nodes/r/galera_gtid_2_cluster.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_gtid_2_cluster.result
@@ -75,15 +75,15 @@ insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
 @@gtid_binlog_state
 1-11-2,2-21-1
-select * from t1;
-cluster_domain_id	node_server_id	seq_no
-1	11	2
-2	21	1
 #wait for sync  cluster 1 and 2
 connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+2	21	1
 cluster 1 node 2
 connection node_2;
 select @@gtid_binlog_state;
@@ -98,6 +98,11 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+2	21	1
 cluster 1 node 3
 connection node_3;
 select @@gtid_binlog_state;
@@ -112,6 +117,12 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
 cluster 2 node 2
 connection node_5;
 select @@gtid_binlog_state;
@@ -126,6 +137,13 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
 cluster 2 node 3
 connection node_6;
 select @@gtid_binlog_state;
@@ -140,6 +158,14 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
 cluster 1 node 1
 connection node_1;
 select @@gtid_binlog_state;
@@ -220,15 +246,15 @@ insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
 @@gtid_binlog_state
 1-11-2,2-21-1
-select * from t1;
-cluster_domain_id	node_server_id	seq_no
-1	11	2
-2	21	1
 #wait for sync  cluster 1 and 2
 connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+2	21	1
 cluster 1 node 2
 connection node_2;
 select @@gtid_binlog_state;
@@ -243,6 +269,11 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+2	21	1
 cluster 1 node 3
 connection node_3;
 select @@gtid_binlog_state;
@@ -257,6 +288,12 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
 cluster 2 node 2
 connection node_5;
 select @@gtid_binlog_state;
@@ -271,6 +308,13 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
 cluster 2 node 3
 connection node_6;
 select @@gtid_binlog_state;
@@ -285,6 +329,14 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
 cluster 1 node 1
 connection node_1;
 select @@gtid_binlog_state;

--- a/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
@@ -75,12 +75,12 @@ select @@gtid_binlog_state;
 select @@gtid_binlog_state;
 insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
-select * from t1;
 --echo #wait for sync  cluster 1 and 2
 --connection node_1
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 2
@@ -94,6 +94,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 3
 --connection node_3
@@ -106,6 +107,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 2
 --connection node_5
@@ -118,6 +120,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 3
 --connection node_6
@@ -130,6 +133,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 1
@@ -226,13 +230,13 @@ select @@gtid_binlog_state;
 --connection node_4
 insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
-select * from t1;
 
 --echo #wait for sync  cluster 1 and 2
 --connection node_1
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 2
@@ -246,6 +250,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 3
 --connection node_3
@@ -258,6 +263,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 2
 --connection node_5
@@ -270,6 +276,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 3
 --connection node_6
@@ -282,6 +289,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 1

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -5057,54 +5057,14 @@ MYSQL_BIN_LOG::is_xidlist_idle_nolock()
 }
 
 #ifdef WITH_WSREP
-inline bool
-is_gtid_cached_internal(IO_CACHE *file)
+static bool is_gtid_written_on_trans_start(const THD *thd)
 {
-  uchar data[EVENT_TYPE_OFFSET+1];
-  bool result= false;
-  my_off_t write_pos= my_b_tell(file);
-  if (reinit_io_cache(file, READ_CACHE, 0, 0, 0))
-    return false;
-  /*
-   In the cache we have gtid event if , below condition is true,
-  */
-  my_b_read(file, data, sizeof(data));
-  uint event_type= (uchar)data[EVENT_TYPE_OFFSET];
-  if (event_type == GTID_LOG_EVENT)
-    result= true;
-  /*
-    Cleanup , Why because we have not read the full buffer
-    and this will cause next to next reinit_io_cache(called in write_cache)
-    to make cache empty.
-   */
-  file->read_pos= file->read_end;
-  if (reinit_io_cache(file, WRITE_CACHE, write_pos, 0, 0))
-    return false;
-  return result;
+  return wsrep_gtid_mode && thd->variables.gtid_seq_no && WSREP(thd) &&
+      ((thd->slave_thread && wsrep_thd_is_local(thd)) ||
+       (!thd->slave_thread && (wsrep_thd_is_applying(thd))));
 }
 #endif
 
-#ifdef WITH_WSREP
-inline bool
-MYSQL_BIN_LOG::is_gtid_cached(THD *thd)
-{
-  binlog_cache_mngr *mngr= (binlog_cache_mngr *) thd_get_ha_data(
-          thd, binlog_hton);
-  if (!mngr)
-    return false;
-  binlog_cache_data *cache_trans= mngr->get_binlog_cache_data(
-          use_trans_cache(thd, true));
-  binlog_cache_data *cache_stmt= mngr->get_binlog_cache_data(
-          use_trans_cache(thd, false));
-  if (cache_trans && !cache_trans->empty() &&
-          is_gtid_cached_internal(&cache_trans->cache_log))
-    return true;
-  if (cache_stmt && !cache_stmt->empty() &&
-          is_gtid_cached_internal(&cache_stmt->cache_log))
-    return true;
-  return false;
-}
-#endif
 /**
   Create a new log file name.
 
@@ -5731,27 +5691,36 @@ THD::binlog_start_trans_and_stmt()
     }
     /* Write Gtid
          Get domain id only when gtid mode is set
-         If this event is replicate through a master then ,
-         we will forward the same gtid another nodes
-         We have to do this only one time in mysql transaction.
-         Since this function is called multiple times , We will check for
-         ha_info->is_started()
+         If this event is replicated through the native replication, then
+         we will forward the same gtid to all other nodes in Wsrep cluster.
+         If the event is applied through Wsrep and has gtid set, then
+         store given gtid value as it's forwarded from another cluster
+         connected through the native replication.
+         We have to store gtid event only once per transaction.
+         Since this function is called multiple times, we will check for
+         ha_info->is_started().
+         TOI mode transaction will have been started by this time, so its
+         gtid event is written on transaction commit as usual.
        */
     Ha_trx_info *ha_info;
     ha_info= this->ha_data[binlog_hton->slot].ha_info + (mstmt_mode ? 1 : 0);
 
-    if (!ha_info->is_started() && wsrep_gtid_mode
-            && this->variables.gtid_seq_no)
+    if (!ha_info->is_started() && is_gtid_written_on_trans_start(this))
     {
       binlog_cache_mngr *const cache_mngr=
         (binlog_cache_mngr*) thd_get_ha_data(this, binlog_hton);
       binlog_cache_data *cache_data= cache_mngr->get_binlog_cache_data(1);
       IO_CACHE *file= &cache_data->cache_log;
       Log_event_writer writer(file, cache_data);
-        Gtid_log_event gtid_event(this, this->variables.gtid_seq_no,
-                            this->variables.gtid_domain_id,
-                            true, LOG_EVENT_SUPPRESS_USE_F,
-                            true, 0);
+      rpl_group_info* rgi = this->slave_thread ? this->rgi_slave : this->wsrep_rgi;
+      const bool standalone =
+          rgi->gtid_ev_flags2 & Gtid_log_event::FL_STANDALONE;
+      const bool is_transactional =
+          rgi->gtid_ev_flags2 & Gtid_log_event::FL_TRANSACTIONAL;
+      Gtid_log_event gtid_event(this, this->variables.gtid_seq_no,
+                                this->variables.gtid_domain_id,
+                                standalone, LOG_EVENT_SUPPRESS_USE_F,
+                                is_transactional, 0);
       // Replicated events in writeset doesn't have checksum
       gtid_event.checksum_alg= BINLOG_CHECKSUM_ALG_OFF;
       gtid_event.server_id= this->variables.server_id;
@@ -6078,6 +6047,8 @@ MYSQL_BIN_LOG::write_gtid_event(THD *thd, bool standalone,
   DBUG_PRINT("enter", ("standalone: %d", standalone));
 
 #ifdef WITH_WSREP
+  /* Checked before thd->variables.gtid_seq_no is reset. */
+  const bool gtid_written= is_gtid_written_on_trans_start(thd);
   if (WSREP(thd)                               && 
       (wsrep_thd_trx_seqno(thd) > 0)           &&
       wsrep_gtid_mode && !thd->variables.gtid_seq_no)
@@ -6137,7 +6108,7 @@ MYSQL_BIN_LOG::write_gtid_event(THD *thd, bool standalone,
   DBUG_ASSERT(this == &mysql_bin_log);
 
 #ifdef WITH_WSREP
-  if (wsrep_gtid_mode && is_gtid_cached(thd))
+  if (gtid_written)
     DBUG_RETURN(false);
 #endif
 

--- a/sql/rpl_gtid.cc
+++ b/sql/rpl_gtid.cc
@@ -700,6 +700,8 @@ rpl_slave_state::record_gtid(THD *thd, const rpl_gtid *gtid, uint64 sub_id,
   if (WSREP_ON_ && wsrep_thd_is_local(thd))
   {
     thd->wsrep_ignore_table= false;
+    if (thd->wsrep_next_trx_id() == WSREP_UNDEFINED_TRX_ID)
+      thd->set_query_id(next_query_id());
     wsrep_start_trx_if_not_started(thd);
   }
   else

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1723,10 +1723,15 @@ int wsrep_to_buf_helper(
 #endif /* GTID_SUPPORT */
   if (wsrep_gtid_mode && thd->variables.gtid_seq_no)
   {
+    rpl_group_info* rgi = thd->slave_thread ? thd->rgi_slave : thd->wsrep_rgi;
+    const bool standalone =
+        rgi->gtid_ev_flags2 & Gtid_log_event::FL_STANDALONE;
+    const bool is_transactional =
+        rgi->gtid_ev_flags2 & Gtid_log_event::FL_TRANSACTIONAL;
     Gtid_log_event gtid_event(thd, thd->variables.gtid_seq_no,
                           thd->variables.gtid_domain_id,
-                          true, LOG_EVENT_SUPPRESS_USE_F,
-                          true, 0);
+                          standalone, LOG_EVENT_SUPPRESS_USE_F,
+                          is_transactional, 0);
     gtid_event.server_id= thd->variables.server_id;
     if (!gtid_event.is_valid()) ret= 0;
     ret= writer.write(&gtid_event);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32633*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
It's possible to establish Galera multi-cluster setups connected through the native replication when every Galera cluster is configured to have a separate domain ID.
For this setup to work, we need to replace domain ID values in generated GTID events when they are written at transaction commit to the values configured by Wsrep replication.

At the same time, it's possible that the GTID event already contains a correct domain ID if it comes through the native replication from another Galera cluster.
In this case, when such an event is applied either through a native replication slave thread or through Wsrep applier, we write GTID event on transaction start and avoid writing it during transaction commit.

The code contained multiple problems that were fixed:
- applying GTID events didn't work because it's applied without a running server transaction and Wsrep transaction was not started
- GTID event generation on transaction start didn't contain proper "standalone" and "is_transactional" flags that the original applied GTID event contained
- condition determining that GTID event is written on transaction start to avoid writing it on commit relied on the fact that the GTID event is the first found in transaction/statement caches, which wasn't the case and resulted in duplicate GTID events written
- instead of relying on the caches to find a GTID event, a simple check is introduced that follows the exact rules for checking if event is written at transaction start as described above
- the test case is improved to check that exact GTID events are applied after two Galera clusters have synced.

## Release Notes
This fix is 10.4 version-only.

## How can this PR be tested?

Re-enabled previously failing MTR test.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
