### PR TITLE
MDEV-5228 Fix incorrect message on a failed attempt to revoke grants from a role

### DIFF
--- a/mysql-test/suite/roles/drop_routines.result
+++ b/mysql-test/suite/roles/drop_routines.result
@@ -30,7 +30,7 @@ end|
 grant execute on function mysql.test_func to r2;
 grant execute on procedure mysql.test_proc to r3;
 revoke execute on procedure mysql.test_proc from r2;
-ERROR 42000: There is no such grant defined for user 'r2' on host '' on routine 'test_proc'
+ERROR 42000: There is no such grant defined for role 'r2' on routine 'test_proc'
 show grants for r1;
 Grants for r1
 GRANT DELETE ON `mysql`.`roles_mapping` TO `r2`

--- a/mysql-test/suite/roles/drop_routines.test
+++ b/mysql-test/suite/roles/drop_routines.test
@@ -34,7 +34,7 @@ delimiter ;|
 grant execute on function mysql.test_func to r2;
 grant execute on procedure mysql.test_proc to r3;
 
---error ER_NONEXISTING_PROC_GRANT
+--error ER_NONEXISTING_PROC_GRANT_ROLE
 revoke execute on procedure mysql.test_proc from r2;
 
 --sorted_result

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -4457,10 +4457,8 @@ ER_NEW_ABORTING_CONNECTION 08S01
         spa "Abortada conexión %lld a la base de datos: '%-.192s' usuario: '%-.48s' equipo: '%-.64s'%-.64s (%-.64s)"
         swe "Avbröt länken för tråd %lld till db '%-.192s', användare '%-.48s', host '%-.64s'%-.64s (%-.64s)"
         ukr "Перервано з'єднання %lld до бази данних: '%-.192s' користувач: '%-.48s' хост: '%-.64s'%-.64s (%-.64s)"
-ER_UNUSED_10
-        eng "You should never see it"
-        geo "ეს ვერასდროს უნდა დაინახოთ"
-        spa "Nunca lo debería vd de ver"
+ER_NONEXISTING_GRANT_ROLE 42000
+        eng "There is no such grant defined for role '%s'"
 ER_FLUSH_MASTER_BINLOG_CLOSED  
         chi "Binlog 已关闭, 不能 RESET MASTER"
         eng "Binlog closed, cannot RESET MASTER"
@@ -7391,14 +7389,10 @@ ER_EVENT_NEITHER_M_EXPR_NOR_M_AT
         ger "Kein DATETIME-Ausdruck angegeben"
         geo "დრო/თარიღის გამოსახულება მითითებული არაა"
         spa "No se ha suministrado expresión datetime"
-ER_UNUSED_2
-        eng "You should never see it"
-        geo "ამას წესით ვერ უნდა ხედავდეთ"
-        spa "No lo debería vd de ver nunca"
-ER_UNUSED_3
-        eng "You should never see it"
-        geo "ამას წესით ვერასდროს უნდა ხედავდეთ"
-        spa "No lo debería vd  de ver nunca"
+ER_NONEXISTING_TABLE_GRANT_ROLE 42000
+        eng "There is no such grant defined for role '%s' on table '%-.192s'"
+ER_NONEXISTING_PROC_GRANT_ROLE 42000
+        eng "There is no such grant defined for role '%s' on routine '%-.192s'"
 ER_EVENT_CANNOT_DELETE
         chi "无法从mysql.event删除该事件"
         eng "Failed to delete the event from mysql.event"

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -353,6 +353,30 @@ inline privilege_t public_access()
   return (acl_public ? acl_public->access : NO_ACL);
 }
 
+static void missing_global_grant_error(bool is_role, const char* user_or_role, const char* host)
+{
+  if (is_role)
+    my_error(ER_NONEXISTING_GRANT_ROLE, MYF(0), user_or_role);
+  else
+    my_error(ER_NONEXISTING_GRANT, MYF(0), user_or_role, host);
+}
+
+static void missing_table_grant_error(bool is_role, const char* user_or_role, const char* host, const char* table)
+{
+  if (is_role)
+    my_error(ER_NONEXISTING_TABLE_GRANT_ROLE, MYF(0), user_or_role, table);
+  else
+    my_error(ER_NONEXISTING_TABLE_GRANT, MYF(0), user_or_role, host, table);
+}
+
+static void missing_proc_grant_error(bool is_role, const char* user_or_role, const char* host, const char* routine)
+{
+  if (is_role)
+    my_error(ER_NONEXISTING_PROC_GRANT_ROLE, MYF(0), user_or_role, routine);
+  else
+    my_error(ER_NONEXISTING_PROC_GRANT, MYF(0), user_or_role, host, routine);
+}
+
 class Grant_tables;
 class User_table;
 class Proxies_priv_table;
@@ -1757,7 +1781,7 @@ class User_table_json: public User_table
                                  USERNAME_CHAR_LENGTH);
     return 0;
   }
-  bool get_value(const char *key, 
+  bool get_value(const char *key,
                  enum json_types vt, const char **v, size_t *vl) const
   {
     enum json_types value_type;
@@ -5108,7 +5132,7 @@ static int replace_db_table(TABLE *table, const char *db,
   {
     if (revoke_grant)
     { // no row, no revoke
-      my_error(ER_NONEXISTING_GRANT, MYF(0), combo.user.str, combo.host.str);
+      missing_global_grant_error(combo.is_role(), combo.user.str, combo.host.str);
       goto abort;
     }
     old_row_exists = 0;
@@ -5406,7 +5430,7 @@ replace_proxies_priv_table(THD *thd, TABLE *table, const LEX_USER *user,
     DBUG_PRINT ("info", ("Row not found"));
     if (revoke_grant)
     { // no row, no revoke
-      my_error(ER_NONEXISTING_GRANT, MYF(0), user->user.str, user->host.str);
+      missing_global_grant_error(user->is_role(), user->user.str, user->host.str);
       goto abort;
     }
     old_row_exists= 0;
@@ -5889,9 +5913,9 @@ static int replace_column_table(GRANT_TABLE *g_t,
     {
       if (revoke_grant)
       {
-	my_error(ER_NONEXISTING_TABLE_GRANT, MYF(0),
+        missing_table_grant_error(combo.is_role(),
                  combo.user.str, combo.host.str,
-                 table_name);                   /* purecov: inspected */
+                 table_name);
 	result= -1;                             /* purecov: inspected */
 	continue;                               /* purecov: inspected */
       }
@@ -6114,9 +6138,9 @@ static int replace_table_table(THD *thd, GRANT_TABLE *grant_table,
     */
     if (revoke_grant)
     { // no row, no revoke
-      my_error(ER_NONEXISTING_TABLE_GRANT, MYF(0),
-               combo.user.str, combo.host.str,
-               table_name);		        /* purecov: deadcode */
+      missing_table_grant_error(combo.is_role(),
+                 combo.user.str, combo.host.str,
+                 table_name); /* purecov: deadcode */
       DBUG_RETURN(1);				/* purecov: deadcode */
     }
     old_row_exists = 0;
@@ -6252,7 +6276,7 @@ static int replace_routine_table(THD *thd, GRANT_NAME *grant_name,
     */
     if (revoke_grant)
     { // no row, no revoke
-      my_error(ER_NONEXISTING_PROC_GRANT, MYF(0),
+      missing_proc_grant_error(combo.is_role(),
                combo.user.str, combo.host.str, routine_name);
       DBUG_RETURN(-1);
     }
@@ -7423,7 +7447,7 @@ int mysql_table_grant(THD *thd, TABLE_LIST *table_list,
     {
       if (revoke_grant)
       {
-        my_error(ER_NONEXISTING_TABLE_GRANT, MYF(0),
+        missing_table_grant_error(Str->is_role(),
                  Str->user.str, Str->host.str, table_list->table_name.str);
         result= TRUE;
         continue;
@@ -7603,7 +7627,7 @@ bool mysql_routine_grant(THD *thd, TABLE_LIST *table_list,
                                     Str->user.str, table_name, sph, 1);
     if (revoke_grant && (!grant_name || !grant_name->init_privs))
     {
-      my_error(ER_NONEXISTING_PROC_GRANT, MYF(0),
+      missing_proc_grant_error(Str->is_role(),
                Str->user.str, Str->host.str, table_name);
       result= TRUE;
       continue;
@@ -9654,8 +9678,7 @@ bool mysql_show_grants(THD *thd, LEX_USER *lex_user)
       mysql_mutex_unlock(&acl_cache->lock);
       mysql_rwlock_unlock(&LOCK_grant);
 
-      my_error(ER_NONEXISTING_GRANT, MYF(0),
-               username, hostname);
+      missing_global_grant_error(false, username, hostname);
       DBUG_RETURN(TRUE);
     }
 
@@ -9709,9 +9732,9 @@ bool mysql_show_grants(THD *thd, LEX_USER *lex_user)
       {
         mysql_mutex_unlock(&acl_cache->lock);
         mysql_rwlock_unlock(&LOCK_grant);
-        my_error(ER_NONEXISTING_GRANT, MYF(0),
-                 thd->security_ctx->priv_user,
-                 thd->security_ctx->priv_host);
+        missing_global_grant_error(false,
+                thd->security_ctx->priv_user,
+                thd->security_ctx->priv_host);
         DBUG_RETURN(TRUE);
       }
     }
@@ -11891,6 +11914,7 @@ Silence_routine_definer_errors::handle_condition(
     switch (sql_errno)
     {
       case ER_NONEXISTING_PROC_GRANT:
+      case ER_NONEXISTING_PROC_GRANT_ROLE:
         /* Convert the error into a warning. */
         push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
                      sql_errno, msg);


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-5228*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Ensure that when there is a failed attempt to revoke a grant for a role, the error message indicates that the failure was
on a role instead of a user.

## Release Notes
Ensure that when there is a failed attempt to revoke a grant for a role, the error message indicates that the failure was on a role instead of a user.

## How can this PR be tested?

Existing MTR tests that reference grant error messages were run and failing tests were modified accordingly. To this end, the following test suites were run:
- funcs_1
- roles
- rpl

Additionally manual testing was performed as in the manner described in https://jira.mariadb.org/browse/MDEV-5228. See results for before and after below.

### Before
```
MariaDB [mysql]> create role role1;
 
MariaDB [mysql]> grant select on mysql.user to role1;
 
MariaDB [mysql]> create role role2;
 
MariaDB [mysql]> grant role1 to role2;
 
MariaDB [mysql]> revoke all, grant option from role2;
ERROR 1147 (42000): There is no such grant defined for user 'role2' on host '' on table 'user' <--- Wrong error msg. role2 is a role not user
Error (Code 1147): There is no such grant defined for user 'role2' on host '' on table 'user'
```

### After
```
MariaDB [(none)]> create role foo;

MariaDB [(none)]> revoke all on bar.* from foo;
ERROR 1141 (42000): There is no such grant defined for role 'foo'   <------- Correct error message
MariaDB [(none)]> create role role1;

MariaDB [(none)]> grant select on mysql.user to role1;

MariaDB [(none)]> create role role2;

MariaDB [(none)]> grant role1 to role2;

MariaDB [(none)]> revoke all, grant option from role2;
ERROR 1148 (42000): There is no such grant defined for role 'role2' on table 'user'   <------ Correct error message

```
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.


## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.