### PR TITLE
 MDEV-34604 mytop - fix specifying filters in .mytop

### DIFF
--- a/scripts/mytop.sh
+++ b/scripts/mytop.sh
@@ -147,7 +147,12 @@ if (-e $config)
 
             if (/(\S+)\s*=\s*(.*\S)/)
             {
-                $config{lc $1} = $2 if exists $config{lc $1};
+                my ($k, $v) = ($1, $2);
+                if ($k =~ /^filter_/i) {
+                  $config{lc $k} = StringOrRegex($v) if exists $config{lc $k};
+                } else {
+                  $config{lc $k} = $v if exists $config{lc $k};
+                }
             }
         }
         close CFG;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The mytop utility supports defining filters in .mytop, but this functionality is currently broken.

Specifying filters (filter_status, filter_user, etc) in the mytop config won't work, because any filter specified here is added to the config hash as a literal string.  This change fixes that - if filter_* is defined in the config and matches an existing filter_* key, then run the value through StringOrRegex() and assign the result to the config hash.

## Release Notes
Update mytop utility to fix parsing of filter_* entries in .mytop config.

## How can this PR be tested?

I don't know that the test suite will actually test this script.

That being said, a manual test will work as follows:
- Add a filter_ entry to the .mytop config, eg: filter_state=/data/
- Run mytop, and see if any queries with state 'Sending data' appear.
- Alternatively, hit capital D in mytop to dump %config hash to screen and look for the filter you added.
   - If it appears as 'filter_state' => qr/data/, the change worked.
   - If it appears as 'filter_state' => '/data/', the config entry is being interpreted as a string, and will never match as a regex.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [x] *This is a bug fix for a util which was originally from a third party and predates MariaDB, and as such all MariaDB branches contain this bug.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
