### PR TITLE
MDEV-33599  innodb.innodb-64k-crash - frequent timeout after 900 seconds

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4509,7 +4509,7 @@ sub extract_warning_lines ($$) {
      qr/Detected table cache mutex contention at instance .* waits. Additional table cache instance cannot be activated: consider raising table_open_cache_instances. Number of active instances/,
      qr/WSREP: Failed to guess base node address/,
      qr/WSREP: Guessing address for incoming client/,
-
+     qr/InnoDB: Difficult to find free blocks in the buffer pool*/,
      # for UBSAN
      qr/decimal\.c.*: runtime error: signed integer overflow/,
      # Disable test for UBSAN on dynamically loaded objects

--- a/mysql-test/suite/innodb/r/innodb-lru-force-no-free-page.result
+++ b/mysql-test/suite/innodb/r/innodb-lru-force-no-free-page.result
@@ -1,4 +1,3 @@
-call mtr.add_suppression("InnoDB: Difficult to find free blocks in the buffer pool");
 SET @saved_debug = @@SESSION.debug_dbug;
 SET SESSION debug_dbug="+d,ib_lru_force_no_free_page";
 CREATE TABLE t1 (j LONGBLOB) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/log_file_name.result
+++ b/mysql-test/suite/innodb/r/log_file_name.result
@@ -90,7 +90,7 @@ SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 ENGINE	SUPPORT	COMMENT	TRANSACTIONS	XA	SAVEPOINTS
-FOUND 1 /\[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
+FOUND 1 /\[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
 FOUND 1 /\[ERROR\] InnoDB: Datafile .*u1.*\. Cannot determine the space ID from the first 64 pages/ in mysqld.1.err
 NOT FOUND /\[Note\] InnoDB: Cannot read first page of .*u2.ibd/ in mysqld.1.err
 # Fault 7: Missing or wrong data file and innodb_force_recovery
@@ -99,11 +99,11 @@ SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');
 ENGINE	SUPPORT	COMMENT	TRANSACTIONS	XA	SAVEPOINTS
-FOUND 1 /\[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
+FOUND 1 /\[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
 FOUND 1 /InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace/ in mysqld.1.err
 FOUND 1 /\[ERROR\] InnoDB: Cannot replay rename of tablespace \d+ from '.*u4.ibd' to '.*u6.ibd' because the target file exists/ in mysqld.1.err
 # restart: --innodb-force-recovery=1
-FOUND 1 /\[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
+FOUND 1 /\[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd/ in mysqld.1.err
 FOUND 1 /InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace/ in mysqld.1.err
 FOUND 1 /\[Warning\] InnoDB: Tablespace \d+ was not found at .*u[1-5].ibd, and innodb_force_recovery was set. All redo log for this tablespace will be ignored!/ in mysqld.1.err
 # restart

--- a/mysql-test/suite/innodb/t/innodb-lru-force-no-free-page.test
+++ b/mysql-test/suite/innodb/t/innodb-lru-force-no-free-page.test
@@ -2,8 +2,6 @@
 --source include/have_debug.inc
 --source include/not_embedded.inc
 
-call mtr.add_suppression("InnoDB: Difficult to find free blocks in the buffer pool");
-
 SET @saved_debug = @@SESSION.debug_dbug;
 SET SESSION debug_dbug="+d,ib_lru_force_no_free_page";
 

--- a/mysql-test/suite/innodb/t/log_file_name.test
+++ b/mysql-test/suite/innodb/t/log_file_name.test
@@ -218,7 +218,7 @@ EOF
 --source include/start_mysqld.inc
 eval $check_no_innodb;
 
-let SEARCH_PATTERN= \[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
+let SEARCH_PATTERN= \[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
 --source include/search_pattern_in_file.inc
 
 let SEARCH_PATTERN= \[ERROR\] InnoDB: Datafile .*u1.*\. Cannot determine the space ID from the first 64 pages;
@@ -243,7 +243,7 @@ let SEARCH_PATTERN= \[Note\] InnoDB: Cannot read first page of .*u2.ibd;
 --source include/start_mysqld.inc
 eval $check_no_innodb;
 
-let SEARCH_PATTERN= \[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
+let SEARCH_PATTERN= \[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
 --source include/search_pattern_in_file.inc
 
 let SEARCH_PATTERN= InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace;
@@ -256,7 +256,7 @@ let SEARCH_PATTERN= \[ERROR\] InnoDB: Cannot replay rename of tablespace \d+ fro
 
 --source include/restart_mysqld.inc
 
-let SEARCH_PATTERN= \[ERROR\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
+let SEARCH_PATTERN= \[Note\] InnoDB: Header page consists of zero bytes in datafile: .*u1.ibd;
 --source include/search_pattern_in_file.inc
 
 let SEARCH_PATTERN= InnoDB: At LSN: \d+: unable to open file .*u[1-5].ibd for tablespace;

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -538,9 +538,10 @@ Datafile::validate_first_page(lsn_t* flush_lsn)
 
 	if (error_txt != NULL) {
 err_exit:
-		sql_print_error("InnoDB: %s in datafile: %s, Space ID: %zu, "
-				"Flags: %zu", error_txt, m_filepath,
-				m_space_id, m_flags);
+		sql_print_information(
+			"InnoDB: %s in datafile: %s, Space ID: %zu, "
+			"Flags: %zu", error_txt, m_filepath,
+			m_space_id, m_flags);
 		m_is_valid = false;
 		free_first_page();
 		return(DB_CORRUPTION);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33599*
## Description
1) Suppress the warning "Difficult to find the block in buffer pool" globally
2) Demote the error to note in validate_first_page()

## How can this PR be tested?
./mtr innodb.log_file_name innodb.innodb-lru-force-no-free-page
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
