### PR TITLE
Add #if defines around usage of OS_DATA_FILE_NO_O_DIRECT

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -1409,11 +1409,12 @@ ATTRIBUTE_COLD void fil_space_t::reopen_all()
         continue;
 
       ulint type= OS_DATA_FILE;
-
+#if defined _WIN32 || defined HAVE_FCNTL_DIRECT
       switch (FSP_FLAGS_GET_ZIP_SSIZE(space.flags)) {
       case 1: case 2:
         type= OS_DATA_FILE_NO_O_DIRECT;
       }
+#endif
 
       for (ulint count= 10000; count--;)
       {


### PR DESCRIPTION
<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

There is a compile error on 11.5 branch in the server.git repo when building mariadbd on a m1 mac.

This has to do with the unguarded usage of `OS_DATA_FILE_NO_O_DIRECT`. Its only defined when `WIN32 || HAVE_FCNTL_DIRECT` which fails on macos (atleast current code paths don't define it and afaik macos doesn't have `O_DIRECT`).

https://github.com/mariadb/server/blob/11.5/storage/innobase/fil/fil0fil.cc#L1415

Am using the default cmake flags in gitlab yml

`-DWITH_SSL=system -DPLUGIN_COLUMNSTORE=NO -DPLUGIN_ROCKSDB=NO -DPLUGIN_S3=NO -DPLUGIN_MROONGA=NO -DPLUGIN_CONNECT=NO -DPLUGIN_TOKUDB=NO -DWITH_WSREP=OFF`

This patch makes it compile.  

```
diff --git a/storage/innobase/fil/fil0fil.cc b/storage/innobase/fil/fil0fil.cc
index 0ce54df6574..75ac2bfb53a 100644
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -1409,11 +1409,12 @@ ATTRIBUTE_COLD void fil_space_t::reopen_all()
         continue;

       ulint type= OS_DATA_FILE;
-
+#if defined _WIN32 || defined HAVE_FCNTL_DIRECT
       switch (FSP_FLAGS_GET_ZIP_SSIZE(space.flags)) {
       case 1: case 2:
         type= OS_DATA_FILE_NO_O_DIRECT;
       }
+#endif
```

## Release Notes
- Fixes build for Macos/M1

## How can this PR be tested?
- Checkout repository on macOS/m1 and run cmake with default flags


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
