### PR TITLE
MDEV-33618: add mariadbd_safe to option groups

### DIFF
--- a/man/mariadbd-safe.1
+++ b/man/mariadbd-safe.1
@@ -51,14 +51,14 @@ Options unknown to
 are passed to
 \fBmysqld\fR
 if they are specified on the command line, but ignored if they are specified in the
-[mysqld_safe] or [mariadb_safe]
+[mysqld_safe], [mariadbd-safe] or [mariadbd_safe]
 groups of an option file\&.
 .PP
 \fBmysqld_safe\fR
 reads all options from the
 [mysqld],
 [server],
-[mysqld_safe], and [mariadb_safe]
+[mysqld_safe], [mariadbd-safe] and [mariadbd_safe]
 sections in option files\&. For example, if you specify a
 [mysqld]
 section like this,

--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -595,7 +595,7 @@ fi
 # If arguments come from [mysqld_safe] section of my.cnf
 # we complain about unrecognized options
 unrecognized_handling=complain
-parse_arguments `$print_defaults $defaults --loose-verbose mysqld_safe safe_mysqld mariadb_safe mariadbd-safe`
+parse_arguments `$print_defaults $defaults --loose-verbose mysqld_safe safe_mysqld mariadb_safe mariadbd_safe mariadbd-safe`
 
 # We only need to pass arguments through to the server if we don't
 # handle them here.  So, we collect unrecognized options (passed on


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33618*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
- Add `mariadbd_safe` to be used as an option group in my.cnf
- Update man page.
