### PR TITLE
MDEV-33660: Warns the user if they try to set auto_increment <= max_v…

### DIFF
--- a/mysql-test/main/alter_table_autoinc-5574.result
+++ b/mysql-test/main/alter_table_autoinc-5574.result
@@ -2,6 +2,8 @@ create table t1(a int(10)unsigned not null auto_increment primary key,
 b varchar(255) not null) engine=innodb default charset=utf8;
 insert into t1 values(1,'aaa'),(2,'bbb');
 alter table t1 auto_increment=1;
+Warnings:
+Warning	167	Can not set AUTO_INCREMENT to 1 which is lower than or equal to the current max value in the table: 2
 insert into t1 values(NULL, 'ccc');
 select * from t1;
 a	b

--- a/mysql-test/suite/innodb/r/autoinc_persist.result
+++ b/mysql-test/suite/innodb/r/autoinc_persist.result
@@ -562,6 +562,8 @@ Expect 200
 # This will not change the counter to 150, but to 201, which is the next
 # of current max counter in the table
 ALTER TABLE t3 AUTO_INCREMENT = 150;
+Warnings:
+Warning	167	Can not set AUTO_INCREMENT to 150 which is lower than or equal to the current max value in the table: 200
 SHOW CREATE TABLE t3;
 Table	Create Table
 t3	CREATE TABLE `t3` (
@@ -603,6 +605,8 @@ UPDATE t3 SET a = 200 WHERE a = 150;
 INSERT INTO t3 VALUES(220);
 # This still fails to set to 120, but just 221
 ALTER TABLE t3 AUTO_INCREMENT = 120;
+Warnings:
+Warning	167	Can not set AUTO_INCREMENT to 120 which is lower than or equal to the current max value in the table: 220
 SHOW CREATE TABLE t3;
 Table	Create Table
 t3	CREATE TABLE `t3` (
@@ -725,6 +729,8 @@ t_inplace	CREATE TABLE `t_inplace` (
 # current max counter in the table, since the specified value
 # is smaller than the existing biggest value(50 < 123)
 ALTER TABLE t_inplace DROP COLUMN b, AUTO_INCREMENT = 50, ALGORITHM = INPLACE;
+Warnings:
+Warning	167	Can not set AUTO_INCREMENT to 50 which is lower than or equal to the current max value in the table: 122
 # We expect the counter to be 123
 SHOW CREATE TABLE t_inplace;
 Table	Create Table

--- a/mysql-test/suite/innodb/r/innodb-autoinc-44030.result
+++ b/mysql-test/suite/innodb/r/innodb-autoinc-44030.result
@@ -24,7 +24,9 @@ d1
 3
 ALTER TABLE t1 AUTO_INCREMENT = 3;
 affected rows: 0
-info: Records: 0  Duplicates: 0  Warnings: 0
+info: Records: 0  Duplicates: 0  Warnings: 1
+Warnings:
+Warning	167	Can not set AUTO_INCREMENT to 3 which is lower than or equal to the current max value in the table: 3
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/vcol/r/innodb_autoinc_vcol.result
+++ b/mysql-test/suite/vcol/r/innodb_autoinc_vcol.result
@@ -6,6 +6,8 @@ c2	c1
 2	2
 2	3
 alter table t1 auto_increment = 3;
+Warnings:
+Warning	167	Can not set AUTO_INCREMENT to 3 which is lower than or equal to the current max value in the table: 3
 show create table t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -9877,11 +9877,21 @@ commit_set_autoinc(
 				: 0;
 
 			if (autoinc <= max_in_table) {
+				push_warning_printf(
+					ctx->trx->mysql_thd,
+					Sql_condition::WARN_LEVEL_WARN,
+					HA_ERR_AUTOINC_ERANGE,
+					"Can not set AUTO_INCREMENT to %d which is lower than"
+          " or equal to the current max value in the table: %d",
+					autoinc,
+					max_in_table);
+
 				ctx->new_table->autoinc = innobase_next_autoinc(
 					max_in_table, 1,
 					ctx->prebuilt->autoinc_increment,
 					ctx->prebuilt->autoinc_offset,
 					innobase_get_int_col_max_value(ai));
+
 				/* Persist the maximum value as the
 				last used one. */
 				autoinc = max_in_table;


### PR DESCRIPTION
…alue

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33660*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This PR adds a warning for the cases where `ALTER TABLE .. AUTO_INCREMENT = X` is set to a value lower than or equal to the current `max_value` in the table.



```
MariaDB [test]> alter table t1 auto_increment=3;
Query OK, 0 rows affected, 1 warning (0.012 sec)
Records: 0  Duplicates: 0  Warnings: 1

MariaDB [test]> show warnings\G
*************************** 1. row ***************************
  Level: Warning
   Code: 167
Message: Can not set AUTO_INCREMENT to 3 which is lower than or equal to the current max value in the table: 5
1 row in set (0.000 sec)

```

Points to review:
Is the error code `HA_ERR_AUTOINC_ERANGE` ok or should I use/create another one?

## Release Notes
Warns the user if they try to set auto_increment to a value lower than or equal max_value.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
