### PR TITLE
MDEV-33636: RPM caps is on mariadbd exe

### DIFF
--- a/cmake/cpack_rpm.cmake
+++ b/cmake/cpack_rpm.cmake
@@ -183,7 +183,7 @@ ENDMACRO(SETA)
 IF (CMAKE_VERSION VERSION_GREATER 3.10.0)
   # cmake bug #14362
   SET(CPACK_RPM_server_USER_FILELIST ${CPACK_RPM_server_USER_FILELIST}
-      "%caps(cap_ipc_lock=pe) %{_sbindir}/mysqld"
+      "%caps(cap_ipc_lock=pe) %{_sbindir}/mariadbd"
       )
 ENDIF()
 


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->

## Description

Postfix on 51e3f1daf54309d14fe8db438024d88aa110e86a that mariadbd should be the executable name rather than capabilities on a symlink.

## Release Notes

not significant

## How can this PR be tested?

Check RPM builds and that capabilities are added on install.


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.