### PR TITLE
MDEV-33652 compat/oracle.sp-inout fails on macOS

### DIFF
--- a/mysql-test/suite/compat/oracle/r/sp-inout.result
+++ b/mysql-test/suite/compat/oracle/r/sp-inout.result
@@ -6,13 +6,13 @@ SET sql_mode=ORACLE;
 # CREATE PACKAGE with procedure and function with IN, OUT, INOUT qualifiers
 # And SHOW CREATE PACKAGE
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT);
 FUNCTION func_sub(d OUT INT, a IN INT, b IN INT, c INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT)
 AS
@@ -30,15 +30,15 @@ RETURN a - b;
 END;
 END;
 $$
-SHOW CREATE PACKAGE pkg2;
+SHOW CREATE PACKAGE Pkg2;
 Package	sql_mode	Create Package	character_set_client	collation_connection	Database Collation
-pkg2	PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ORACLE,NO_KEY_OPTIONS,NO_TABLE_OPTIONS,NO_FIELD_OPTIONS,NO_AUTO_CREATE_USER,SIMULTANEOUS_ASSIGNMENT	CREATE DEFINER="root"@"localhost" PACKAGE "pkg2" AS
+Pkg2	PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ORACLE,NO_KEY_OPTIONS,NO_TABLE_OPTIONS,NO_FIELD_OPTIONS,NO_AUTO_CREATE_USER,SIMULTANEOUS_ASSIGNMENT	CREATE DEFINER="root"@"localhost" PACKAGE "Pkg2" AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT);
 FUNCTION func_sub(d OUT INT, a IN INT, b IN INT, c INOUT INT) RETURN INT;
 END	latin1	latin1_swedish_ci	latin1_swedish_ci
-SHOW CREATE PACKAGE BODY pkg2;
+SHOW CREATE PACKAGE BODY Pkg2;
 Package body	sql_mode	Create Package Body	character_set_client	collation_connection	Database Collation
-pkg2	PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ORACLE,NO_KEY_OPTIONS,NO_TABLE_OPTIONS,NO_FIELD_OPTIONS,NO_AUTO_CREATE_USER,SIMULTANEOUS_ASSIGNMENT	CREATE DEFINER="root"@"localhost" PACKAGE BODY "pkg2" AS
+Pkg2	PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ORACLE,NO_KEY_OPTIONS,NO_TABLE_OPTIONS,NO_FIELD_OPTIONS,NO_AUTO_CREATE_USER,SIMULTANEOUS_ASSIGNMENT	CREATE DEFINER="root"@"localhost" PACKAGE BODY "Pkg2" AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT)
 AS
 res INT;
@@ -54,7 +54,7 @@ d := 10;
 RETURN a - b;
 END;
 END	latin1	latin1_swedish_ci	latin1_swedish_ci
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # CREATE FUNCTION with IN, OUT, INOUT qualifiers
 # SHOW CREATE FUNCTION
@@ -99,12 +99,12 @@ DROP PROCEDURE add_proc;
 # Call function from SELECT query
 # SELECT > FUNCTION(IN)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION add_func2 (a IN INT, b IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION add_func2(a IN INT, b IN INT) RETURN INT
 AS
@@ -115,20 +115,20 @@ END;
 $$
 set @a = 2;
 set @b = 3;
-select pkg2.add_func2(@a, @b);
-pkg2.add_func2(@a, @b)
+select Pkg2.add_func2(@a, @b);
+Pkg2.add_func2(@a, @b)
 5
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call function from SELECT query
 # SELECT > FUNCTION(OUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION add_func3 (a IN INT, b IN INT, c OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION add_func3(a IN INT, b IN INT, c OUT INT) RETURN INT
 AS
@@ -141,19 +141,19 @@ $$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-select pkg2.add_func3(@a, @b, @c);
-ERROR HY000: OUT or INOUT argument 3 for function pkg2.add_func3 is not allowed here
-DROP PACKAGE pkg2;
+select Pkg2.add_func3(@a, @b, @c);
+ERROR HY000: OUT or INOUT argument 3 for function Pkg2.add_func3 is not allowed here
+DROP PACKAGE Pkg2;
 # 
 # Call function from SELECT query
 # SELECT > FUNCTION(INOUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION add_func4 (a IN INT, b IN INT, c OUT INT, d INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION add_func4(a IN INT, b IN INT, c OUT INT, d INOUT INT) RETURN INT
 AS
@@ -168,20 +168,20 @@ set @a = 2;
 set @b = 3;
 set @c = 0;
 set @d = 9;
-select pkg2.add_func4(@a, @b, @c, @d);
-ERROR HY000: OUT or INOUT argument 3 for function pkg2.add_func4 is not allowed here
-DROP PACKAGE pkg2;
+select Pkg2.add_func4(@a, @b, @c, @d);
+ERROR HY000: OUT or INOUT argument 3 for function Pkg2.add_func4 is not allowed here
+DROP PACKAGE Pkg2;
 # 
 # Call from procedure
 # PROCEDURE(OUT) > FUNCTION(IN)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE add_proc2 (a IN INT, b IN INT, c OUT INT);
 FUNCTION add_func2 (a IN INT, b IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE add_proc2(a IN INT, b IN INT, c OUT INT)
 AS
@@ -198,22 +198,22 @@ $$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.add_proc2(@a, @b, @c);
+call Pkg2.add_proc2(@a, @b, @c);
 select @c;
 @c
 5
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call from procedure
 # PROCEDURE(OUT) > FUNCTION(OUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE add_proc3 (a IN INT, b IN INT, c OUT INT);
 FUNCTION add_func3 (a IN INT, b IN INT, c OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE add_proc3(a IN INT, b IN INT, c OUT INT)
 AS
@@ -232,22 +232,22 @@ $$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.add_proc3(@a, @b, @c);
+call Pkg2.add_proc3(@a, @b, @c);
 select @c;
 @c
 100
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call from procedure
 # PROCEDURE(OUT) > FUNCTION(INOUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE add_proc4 (a IN INT, b IN INT, c OUT INT);
 FUNCTION add_func4 (a IN INT, b IN INT, c OUT INT, d INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE add_proc4(a IN INT, b IN INT, res OUT INT)
 AS
@@ -270,27 +270,27 @@ $$
 set @a = 2;
 set @b = 3;
 set @res = 0;
-call pkg2.add_proc4(@a, @b, @res);
+call Pkg2.add_proc4(@a, @b, @res);
 select @res;
 @res
 131
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call from procedure
 # PROCEDURE(OUT) > PROCEDURE(OUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE test_proc1 (a IN INT, b IN INT, c OUT INT);
 PROCEDURE add_proc (a IN INT, b IN INT, c OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE test_proc1(a IN INT, b IN INT, c OUT INT)
 AS
 BEGIN
-call pkg2.add_proc(a, b, c);
+call Pkg2.add_proc(a, b, c);
 END;
 PROCEDURE add_proc(a IN INT, b IN INT, c OUT INT)
 AS
@@ -302,22 +302,22 @@ $$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.test_proc1(@a, @b, @c);
+call Pkg2.test_proc1(@a, @b, @c);
 select @c;
 @c
 5
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Argument's order change
 # PROCEDURE(a IN, b IN, c OUT) > FUNCTION(b IN, a IN, c OUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT);
 FUNCTION func_sub(b IN INT, a IN INT, c OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT)
 AS
@@ -338,22 +338,22 @@ $$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.proc_main(@a, @b, @c);
+call Pkg2.proc_main(@a, @b, @c);
 select @c;
 @c
 -1
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Argument's order change
 # PROCEDURE(a IN, b IN, c OUT) > FUNCTION(c OUT, b IN, a IN)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT);
 FUNCTION func_sub(c OUT INT, b IN INT, a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT)
 AS
@@ -374,22 +374,22 @@ $$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.proc_main(@a, @b, @c);
+call Pkg2.proc_main(@a, @b, @c);
 select @c;
 @c
 -1
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Argument's order change
 # PROCEDURE(a IN, b IN, c INOUT, d OUT) > FUNCTION(d OUT, a IN, b IN, c INOUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT);
 FUNCTION func_sub(d OUT INT, a IN INT, b IN INT, c INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT)
 AS
@@ -411,23 +411,23 @@ set @a = 15;
 set @b = 5;
 set @c = 4;
 set @d= 0;
-call pkg2.proc_main(@a, @b, @c, @d);
+call Pkg2.proc_main(@a, @b, @c, @d);
 select @d;
 @d
 30
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Argument's order change
 # PROCEDURE(a IN INT, b IN INT, c INOUT INT, d OUT INT) > FUNCTION1(c INOUT INT, b IN INT) > FUNCTION2(d OUT INT, a IN INT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT);
 FUNCTION func_sub1(c INOUT INT, b IN INT) RETURN INT;
 FUNCTION func_sub2(d OUT INT, a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT)
 AS
@@ -456,22 +456,22 @@ set @a = 15;
 set @b = 6;
 set @c = 4;
 set @d= 0;
-call pkg2.proc_main(@a, @b, @c, @d);
+call Pkg2.proc_main(@a, @b, @c, @d);
 select @d;
 @d
 30
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Argument's order change
 # FUNCTION1(a IN, b IN) > FUNCTION2(b IN, c OUT, a IN)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT, b IN INT) RETURN INT;
 FUNCTION func_sub(b IN INT, c OUT INT, a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT, b IN INT) RETURN INT
 AS
@@ -491,21 +491,21 @@ END;
 $$
 set @a = 2;
 set @b = 3;
-select pkg2.func_main(@a, @b);
-pkg2.func_main(@a, @b)
+select Pkg2.func_main(@a, @b);
+Pkg2.func_main(@a, @b)
 105
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call procedure inside function
 # FUNCTION1(a IN, b IN) > PROCEDURE(a IN, b IN, c OUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(b IN INT, a IN INT) RETURN INT;
 PROCEDURE proc_sub(a IN INT, b IN INT, c OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(b IN INT, a IN INT) RETURN INT
 AS
@@ -523,21 +523,21 @@ END;
 $$
 set @a = 2;
 set @b = 3;
-select pkg2.func_main(@a, @b);
-pkg2.func_main(@a, @b)
+select Pkg2.func_main(@a, @b);
+Pkg2.func_main(@a, @b)
 5
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call procedure inside function
 # FUNCTION1(a IN, b IN) > PROCEDURE(a IN, b INOUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(b IN INT, a IN INT) RETURN INT;
 PROCEDURE proc_sub(a IN INT, b INOUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(b IN INT, a IN INT) RETURN INT
 AS
@@ -554,21 +554,21 @@ END;
 $$
 set @a = 2;
 set @b = 3;
-select pkg2.func_main(@a, @b);
-pkg2.func_main(@a, @b)
+select Pkg2.func_main(@a, @b);
+Pkg2.func_main(@a, @b)
 5
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call procedure inside function
 # FUNCTION1(a IN, b IN, c OUT) > PROCEDURE(a IN, b IN, c OUT)
 # 
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(b IN INT, a IN INT, c OUT INT) RETURN INT;
 PROCEDURE proc_sub(a IN INT, b IN INT, c OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(b IN INT, a IN INT, c OUT INT) RETURN INT
 AS
@@ -587,9 +587,9 @@ $$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-select pkg2.func_main(@a, @b, @c);
-ERROR HY000: OUT or INOUT argument 3 for function pkg2.func_main is not allowed here
-DROP PACKAGE pkg2;
+select Pkg2.func_main(@a, @b, @c);
+ERROR HY000: OUT or INOUT argument 3 for function Pkg2.func_main is not allowed here
+DROP PACKAGE Pkg2;
 # 
 # Call function from UPDATE query
 # UPDATE <table> SET <column> = FUNCTION(a IN)
@@ -602,12 +602,12 @@ Age int
 INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT
 AS
@@ -617,14 +617,14 @@ END;
 END;
 $$
 set @a = 5;
-UPDATE Persons SET Age = pkg2.func(@a) WHERE ID = 1;
+UPDATE Persons SET Age = Pkg2.func(@a) WHERE ID = 1;
 SELECT * FROM Persons;
 ID	Name	Age
 1	AAA	50
 2	BBB	20
 3	CCC	30
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call function from UPDATE query
 # UPDATE <table> SET <column> = FUNCTION(a OUT)
@@ -637,12 +637,12 @@ Age int
 INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT
 AS
@@ -653,10 +653,10 @@ END;
 END;
 $$
 set @a = 0;
-UPDATE Persons SET Age = pkg2.func(@a) WHERE ID = 1;
-ERROR HY000: OUT or INOUT argument 1 for function pkg2.func is not allowed here
+UPDATE Persons SET Age = Pkg2.func(@a) WHERE ID = 1;
+ERROR HY000: OUT or INOUT argument 1 for function Pkg2.func is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call function from INSERT query
 # INSERT INTO <table> SELECT <val1>, <val2>, FUNCTION(a IN)
@@ -669,12 +669,12 @@ Age int
 INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT
 AS
@@ -692,7 +692,7 @@ ID	Name	Age
 3	CCC	30
 4	DDD	40
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call function from INSERT query
 # INSERT INTO <table> SELECT <val1>, <val2>, FUNCTION(a OUT)
@@ -705,12 +705,12 @@ Age int
 INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT
 AS
@@ -729,7 +729,7 @@ set @a = 0;
 INSERT INTO Persons SELECT 5, 'EEE', PKG2.func(@a);
 ERROR HY000: OUT or INOUT argument 1 for function PKG2.func is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call function from DELETE query
 # DELETE FROM <table> WHERE <column> = FUNCTION(a IN)
@@ -743,12 +743,12 @@ INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT
 AS
@@ -771,7 +771,7 @@ ID	Name	Age
 2	BBB	20
 3	CCC	30
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Call function from DELETE query
 # DELETE FROM <table> WHERE <column> = FUNCTION(a OUT)
@@ -785,12 +785,12 @@ INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT
 AS
@@ -810,7 +810,7 @@ set @a = 0;
 DELETE FROM Persons WHERE ID = PKG2.func(@a);
 ERROR HY000: OUT or INOUT argument 1 for function PKG2.func is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # SELECT query inside function
 # FUNCTION(a IN) > SELECT … FROM <table>
@@ -824,12 +824,12 @@ INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT
 AS
@@ -841,8 +841,8 @@ END;
 END;
 $$
 set @a = 3;
-select pkg2.func_main(@a);
-pkg2.func_main(@a)
+select Pkg2.func_main(@a);
+Pkg2.func_main(@a)
 30
 select * from Persons;
 ID	Name	Age
@@ -851,7 +851,7 @@ ID	Name	Age
 3	CCC	30
 4	DDD	40
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # SELECT query inside function
 # FUNCTION(a OUT) > SELECT … FROM <table>
@@ -865,12 +865,12 @@ INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a OUT INT) RETURN INT
 AS
@@ -881,10 +881,10 @@ END;
 END;
 $$
 set @a = 0;
-select pkg2.func_main(@a);
-ERROR HY000: OUT or INOUT argument 1 for function pkg2.func_main is not allowed here
+select Pkg2.func_main(@a);
+ERROR HY000: OUT or INOUT argument 1 for function Pkg2.func_main is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # SELECT query inside function
 # FUNCTION(a INOUT) > SELECT … FROM <table>
@@ -898,12 +898,12 @@ INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a INOUT INT) RETURN INT
 AS
@@ -914,10 +914,10 @@ END;
 END;
 $$
 set @a = 1;
-select pkg2.func_main(@a);
-ERROR HY000: OUT or INOUT argument 1 for function pkg2.func_main is not allowed here
+select Pkg2.func_main(@a);
+ERROR HY000: OUT or INOUT argument 1 for function Pkg2.func_main is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # SELECT query inside function
 # FUNCTION(a IN) > FUNCTION(a IN, b OUT) > SELECT … FROM <table>
@@ -931,13 +931,13 @@ INSERT INTO Persons VALUES (1, 'AAA', 10);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT;
 FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;  
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT
 AS
@@ -956,8 +956,8 @@ END;
 END;
 $$
 set @a = 2;
-select pkg2.func_main(@a);
-pkg2.func_main(@a)
+select Pkg2.func_main(@a);
+Pkg2.func_main(@a)
 20
 select * from Persons;
 ID	Name	Age
@@ -966,7 +966,7 @@ ID	Name	Age
 3	CCC	30
 4	DDD	40
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # UPDATE query inside function
 # FUNCTION(a IN) > UPDATE <table> SET …
@@ -981,12 +981,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT
 AS
@@ -1006,8 +1006,8 @@ ID	Name	Age
 4	DDD	40
 5	EEE	40
 set @a = 5;
-select pkg2.func_main(@a);
-pkg2.func_main(@a)
+select Pkg2.func_main(@a);
+Pkg2.func_main(@a)
 50
 select * from Persons;
 ID	Name	Age
@@ -1017,7 +1017,7 @@ ID	Name	Age
 4	DDD	40
 5	EEE	50
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # UPDATE query inside function
 # FUNCTION(a IN, b OUT) > UPDATE <table> SET …
@@ -1032,12 +1032,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT, b OUT INT) RETURN INT
 AS
@@ -1050,10 +1050,10 @@ END;
 $$
 set @a = 5;
 set @b = 0;
-select pkg2.func_main(@a, @b);
-ERROR HY000: OUT or INOUT argument 2 for function pkg2.func_main is not allowed here
+select Pkg2.func_main(@a, @b);
+ERROR HY000: OUT or INOUT argument 2 for function Pkg2.func_main is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # UPDATE query inside function
 # FUNCTION(a IN, b INOUT) > UPDATE <table> SET …
@@ -1068,12 +1068,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT
 AS
@@ -1086,10 +1086,10 @@ END;
 $$
 set @a = 5;
 set @b = 0;
-select pkg2.func_main(@a, @b);
-ERROR HY000: OUT or INOUT argument 2 for function pkg2.func_main is not allowed here
+select Pkg2.func_main(@a, @b);
+ERROR HY000: OUT or INOUT argument 2 for function Pkg2.func_main is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # UPDATE query inside function
 # FUNCTION(a IN) > FUNCTION(a IN, b OUT) > UPDATE <table> SET …
@@ -1104,13 +1104,13 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT;
 FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;  
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT
 AS
@@ -1137,8 +1137,8 @@ ID	Name	Age
 4	DDD	40
 5	EEE	40
 set @a = 1;
-select pkg2.func_main(@a);
-pkg2.func_main(@a)
+select Pkg2.func_main(@a);
+Pkg2.func_main(@a)
 10
 select * from Persons;
 ID	Name	Age
@@ -1148,7 +1148,7 @@ ID	Name	Age
 4	DDD	40
 5	EEE	40
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # INSERT query inside function
 # FUNCTION(a IN) > INSERT INTO <table> VALUES …
@@ -1163,12 +1163,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 50);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT
 AS
@@ -1188,8 +1188,8 @@ ID	Name	Age
 4	DDD	40
 5	EEE	50
 set @a = 6;
-select pkg2.func_main(@a);
-pkg2.func_main(@a)
+select Pkg2.func_main(@a);
+Pkg2.func_main(@a)
 60
 select * from Persons;
 ID	Name	Age
@@ -1200,7 +1200,7 @@ ID	Name	Age
 5	EEE	50
 6	FFF	60
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # INSERT query inside function
 # FUNCTION(a IN, b OUT) > INSERT INTO <table> VALUES …
@@ -1215,12 +1215,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 50);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT, b OUT INT) RETURN INT
 AS
@@ -1240,10 +1240,10 @@ ID	Name	Age
 5	EEE	50
 set @a = 6;
 set @b = 0;
-select pkg2.func_main(@a, @b);
-ERROR HY000: OUT or INOUT argument 2 for function pkg2.func_main is not allowed here
+select Pkg2.func_main(@a, @b);
+ERROR HY000: OUT or INOUT argument 2 for function Pkg2.func_main is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # INSERT query inside function
 # FUNCTION(a IN, b INOUT) > INSERT INTO <table> VALUES …
@@ -1258,12 +1258,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT
 AS
@@ -1283,10 +1283,10 @@ ID	Name	Age
 5	EEE	40
 set @a = 6;
 set @b = 0;
-select pkg2.func_main(@a, @b);
-ERROR HY000: OUT or INOUT argument 2 for function pkg2.func_main is not allowed here
+select Pkg2.func_main(@a, @b);
+ERROR HY000: OUT or INOUT argument 2 for function Pkg2.func_main is not allowed here
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # INSERT query inside function
 # FUNCTION(a IN) > FUNCTION(a IN, b OUT) > INSERT INTO <table> VALUES …
@@ -1301,13 +1301,13 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT;
 FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func_main(a IN INT) RETURN INT
 AS
@@ -1334,8 +1334,8 @@ ID	Name	Age
 4	DDD	40
 5	EEE	40
 set @a = 6;
-select pkg2.func_main(@a);
-pkg2.func_main(@a)
+select Pkg2.func_main(@a);
+Pkg2.func_main(@a)
 60
 select * from Persons;
 ID	Name	Age
@@ -1346,7 +1346,7 @@ ID	Name	Age
 5	EEE	40
 6	FFF	60
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(IN) > SELECT FROM <table> …
@@ -1360,13 +1360,13 @@ INSERT INTO Persons VALUES (1, 'AAA', 50);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1390,12 +1390,12 @@ ID	Name	Age
 4	DDD	40
 set @a = 2;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select @b;
 @b
 20
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(OUT) > SELECT FROM <table> …
@@ -1409,13 +1409,13 @@ INSERT INTO Persons VALUES (1, 'AAA', 50);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1439,12 +1439,12 @@ ID	Name	Age
 4	DDD	40
 set @a = 1;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select @b;
 @b
 50
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(INOUT) > SELECT FROM <table> …
@@ -1458,13 +1458,13 @@ INSERT INTO Persons VALUES (1, 'AAA', 50);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1493,12 +1493,12 @@ ID	Name	Age
 4	DDD	40
 set @a = 2;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select @b;
 @b
 500
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(IN) > INSESRT INTO <table> …
@@ -1512,13 +1512,13 @@ INSERT INTO Persons VALUES (1, 'AAA', 50);
 INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1541,7 +1541,7 @@ ID	Name	Age
 4	DDD	40
 set @a = 5;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 ID	Name	Age
 1	AAA	50
@@ -1550,7 +1550,7 @@ ID	Name	Age
 4	DDD	40
 5	FFF	50
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(OUT) > INSESRT INTO <table> …
@@ -1565,13 +1565,13 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'FFF', 50);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1596,7 +1596,7 @@ ID	Name	Age
 5	FFF	50
 set @a = 6;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 ID	Name	Age
 1	AAA	50
@@ -1606,7 +1606,7 @@ ID	Name	Age
 5	FFF	50
 6	GGG	60
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(INOUT) > INSESRT INTO <table> …
@@ -1622,13 +1622,13 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'FFF', 50);
 INSERT INTO Persons VALUES (6, 'GGG', 60);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1659,7 +1659,7 @@ ID	Name	Age
 6	GGG	60
 set @a = 7;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 ID	Name	Age
 1	AAA	50
@@ -1670,7 +1670,7 @@ ID	Name	Age
 6	GGG	60
 7	HHH	70
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(IN) > UPDATE <table> SET …
@@ -1687,13 +1687,13 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'FFF', 50);
 INSERT INTO Persons VALUES (6, 'GGG', 60);
 INSERT INTO Persons VALUES (7, 'HHH', 70);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1719,7 +1719,7 @@ ID	Name	Age
 7	HHH	70
 set @a = 5;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 ID	Name	Age
 1	AAA	50
@@ -1730,7 +1730,7 @@ ID	Name	Age
 6	GGG	60
 7	HHH	70
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(OUT) > UPDATE <table> SET …
@@ -1747,13 +1747,13 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'FFF', 100);
 INSERT INTO Persons VALUES (6, 'GGG', 60);
 INSERT INTO Persons VALUES (7, 'HHH', 70);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1781,7 +1781,7 @@ ID	Name	Age
 7	HHH	70
 set @a = 6;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 ID	Name	Age
 1	AAA	50
@@ -1792,7 +1792,7 @@ ID	Name	Age
 6	GGG	100
 7	HHH	70
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # PROCEDURE > FUNCTION > SQL query
 # PROCEDURE(OUT) > FUNCTION(INOUT) > UPDATE <table> SET …
@@ -1809,13 +1809,13 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'FFF', 100);
 INSERT INTO Persons VALUES (6, 'GGG', 100);
 INSERT INTO Persons VALUES (7, 'HHH', 70);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT);
 FUNCTION func_sub(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc_main(a IN INT, b OUT INT)
 AS
@@ -1847,7 +1847,7 @@ ID	Name	Age
 7	HHH	70
 set @a = 7;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 ID	Name	Age
 1	AAA	50
@@ -1858,7 +1858,7 @@ ID	Name	Age
 6	GGG	100
 7	HHH	100
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 # 
 # Trigger
 # TRIGGER AFTER UPDATE ON TABLE1 > UPDATE TABLE2
@@ -1916,12 +1916,12 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a IN INT) RETURN INT
 AS
@@ -1940,7 +1940,7 @@ res INT;
 BEGIN
 a := 10;
 res := 0;
-res := pkg2.func(a);
+res := Pkg2.func(a);
 END;
 $$
 SELECT * FROM Persons;
@@ -1961,7 +1961,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -1980,12 +1980,12 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a OUT INT) RETURN INT
 AS
@@ -2005,7 +2005,7 @@ res INT;
 BEGIN
 a := 10;
 res := 0;
-res := pkg2.func(a);
+res := Pkg2.func(a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2026,7 +2026,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2045,12 +2045,12 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 FUNCTION func(a INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 FUNCTION func(a INOUT INT) RETURN INT
 AS
@@ -2070,7 +2070,7 @@ res INT;
 BEGIN
 a := 10;
 res := 0;
-res := pkg2.func(a);
+res := Pkg2.func(a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2091,7 +2091,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2110,12 +2110,12 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc(a IN INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc(a IN INT)
 AS
@@ -2128,7 +2128,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW 
 BEGIN
-call pkg2.proc(@a);
+call Pkg2.proc(@a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2149,7 +2149,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2168,12 +2168,12 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc(a OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc(a OUT INT)
 AS
@@ -2186,7 +2186,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-call pkg2.proc(@a);
+call Pkg2.proc(@a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2207,7 +2207,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2226,12 +2226,12 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc(a INOUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc(a INOUT INT)
 AS
@@ -2246,7 +2246,7 @@ AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
 set @a = 2;
-call pkg2.proc(@a);
+call Pkg2.proc(@a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2267,7 +2267,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2286,13 +2286,13 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc(a OUT INT);
 FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc(a OUT INT)
 AS
@@ -2313,7 +2313,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-call pkg2.proc(@a);
+call Pkg2.proc(@a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2334,7 +2334,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2353,13 +2353,13 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc(a OUT INT);
 FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc(a OUT INT)
 AS
@@ -2381,7 +2381,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-call pkg2.proc(@a);
+call Pkg2.proc(@a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2402,7 +2402,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2421,13 +2421,13 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc(a OUT INT);
 FUNCTION func(a INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc(a OUT INT)
 AS
@@ -2449,7 +2449,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-call pkg2.proc(@a);
+call Pkg2.proc(@a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2470,7 +2470,7 @@ SELECT * FROM PersonsLog;
 UpdateCount
 1
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 # 
@@ -2489,13 +2489,13 @@ CREATE TABLE PersonsLog (
 UpdateCount int
 );
 INSERT INTO PersonsLog VALUES (0);
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
 PROCEDURE proc(a OUT INT);
 FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
 PROCEDURE proc(a OUT INT)
 AS
@@ -2517,7 +2517,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-call pkg2.proc(@a);
+call Pkg2.proc(@a);
 END;
 $$
 SELECT * FROM Persons;
@@ -2538,18 +2538,18 @@ SELECT * FROM PersonsLog;
 UpdateCount
 111
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 #
 # Package BODY variables as OUT parameters
 #
-CREATE PACKAGE pkg1 AS
+CREATE PACKAGE pKg1 AS
 FUNCTION f1(b IN OUT INT) RETURN INT;
 FUNCTION show_private_variables() RETURN TEXT;
 END;
 $$
-CREATE PACKAGE BODY pkg1 AS
+CREATE PACKAGE BODY pKg1 AS
 pa INT:= 0;
 pb INT:= 10;
 FUNCTION f1(b IN OUT INT) RETURN INT AS
@@ -2565,7 +2565,7 @@ BEGIN
 SET pa=f1(pb);
 END;
 $$
-SELECT pkg1.show_private_variables();
-pkg1.show_private_variables()
+SELECT pKg1.show_private_variables();
+pKg1.show_private_variables()
 Private variables: pa=510  pb=110
-DROP PACKAGE pkg1;
+DROP PACKAGE pKg1;

--- a/mysql-test/suite/compat/oracle/t/sp-inout.test
+++ b/mysql-test/suite/compat/oracle/t/sp-inout.test
@@ -10,13 +10,13 @@ SET sql_mode=ORACLE;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT);
   FUNCTION func_sub(d OUT INT, a IN INT, b IN INT, c INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT)
   AS
@@ -36,9 +36,9 @@ END;
 $$
 DELIMITER ;$$
 
-SHOW CREATE PACKAGE pkg2;
-SHOW CREATE PACKAGE BODY pkg2;
-DROP PACKAGE pkg2;
+SHOW CREATE PACKAGE Pkg2;
+SHOW CREATE PACKAGE BODY Pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # CREATE FUNCTION with IN, OUT, INOUT qualifiers
@@ -82,12 +82,12 @@ DROP PROCEDURE add_proc;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION add_func2 (a IN INT, b IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION add_func2(a IN INT, b IN INT) RETURN INT
   AS
@@ -100,8 +100,8 @@ DELIMITER ;$$
 
 set @a = 2;
 set @b = 3;
-select pkg2.add_func2(@a, @b);
-DROP PACKAGE pkg2;
+select Pkg2.add_func2(@a, @b);
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from SELECT query
@@ -109,12 +109,12 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION add_func3 (a IN INT, b IN INT, c OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION add_func3(a IN INT, b IN INT, c OUT INT) RETURN INT
   AS
@@ -130,8 +130,8 @@ set @a = 2;
 set @b = 3;
 set @c = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.add_func3(@a, @b, @c);
-DROP PACKAGE pkg2;
+select Pkg2.add_func3(@a, @b, @c);
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from SELECT query
@@ -139,12 +139,12 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION add_func4 (a IN INT, b IN INT, c OUT INT, d INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION add_func4(a IN INT, b IN INT, c OUT INT, d INOUT INT) RETURN INT
   AS
@@ -162,8 +162,8 @@ set @b = 3;
 set @c = 0;
 set @d = 9;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.add_func4(@a, @b, @c, @d);
-DROP PACKAGE pkg2;
+select Pkg2.add_func4(@a, @b, @c, @d);
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call from procedure
@@ -171,13 +171,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE add_proc2 (a IN INT, b IN INT, c OUT INT);
   FUNCTION add_func2 (a IN INT, b IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE add_proc2(a IN INT, b IN INT, c OUT INT)
   AS
@@ -197,9 +197,9 @@ DELIMITER ;$$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.add_proc2(@a, @b, @c);
+call Pkg2.add_proc2(@a, @b, @c);
 select @c;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call from procedure
@@ -207,13 +207,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE add_proc3 (a IN INT, b IN INT, c OUT INT);
   FUNCTION add_func3 (a IN INT, b IN INT, c OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE add_proc3(a IN INT, b IN INT, c OUT INT)
   AS
@@ -234,9 +234,9 @@ DELIMITER ;$$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.add_proc3(@a, @b, @c);
+call Pkg2.add_proc3(@a, @b, @c);
 select @c;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call from procedure
@@ -244,13 +244,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE add_proc4 (a IN INT, b IN INT, c OUT INT);
   FUNCTION add_func4 (a IN INT, b IN INT, c OUT INT, d INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE add_proc4(a IN INT, b IN INT, res OUT INT)
   AS
@@ -275,9 +275,9 @@ DELIMITER ;$$
 set @a = 2;
 set @b = 3;
 set @res = 0;
-call pkg2.add_proc4(@a, @b, @res);
+call Pkg2.add_proc4(@a, @b, @res);
 select @res;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call from procedure
@@ -285,18 +285,18 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE test_proc1 (a IN INT, b IN INT, c OUT INT);
   PROCEDURE add_proc (a IN INT, b IN INT, c OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE test_proc1(a IN INT, b IN INT, c OUT INT)
   AS
   BEGIN
-	call pkg2.add_proc(a, b, c);
+	call Pkg2.add_proc(a, b, c);
   END;
   PROCEDURE add_proc(a IN INT, b IN INT, c OUT INT)
   AS
@@ -310,9 +310,9 @@ DELIMITER ;$$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.test_proc1(@a, @b, @c);
+call Pkg2.test_proc1(@a, @b, @c);
 select @c;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Argument's order change
@@ -320,13 +320,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT);
   FUNCTION func_sub(b IN INT, a IN INT, c OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT)
   AS
@@ -349,9 +349,9 @@ DELIMITER ;$$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.proc_main(@a, @b, @c);
+call Pkg2.proc_main(@a, @b, @c);
 select @c;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Argument's order change
@@ -359,13 +359,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT);
   FUNCTION func_sub(c OUT INT, b IN INT, a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c OUT INT)
   AS
@@ -388,9 +388,9 @@ DELIMITER ;$$
 set @a = 2;
 set @b = 3;
 set @c = 0;
-call pkg2.proc_main(@a, @b, @c);
+call Pkg2.proc_main(@a, @b, @c);
 select @c;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Argument's order change
@@ -398,13 +398,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT);
   FUNCTION func_sub(d OUT INT, a IN INT, b IN INT, c INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT)
   AS
@@ -428,9 +428,9 @@ set @a = 15;
 set @b = 5;
 set @c = 4;
 set @d= 0;
-call pkg2.proc_main(@a, @b, @c, @d);
+call Pkg2.proc_main(@a, @b, @c, @d);
 select @d;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Argument's order change
@@ -438,14 +438,14 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT);
   FUNCTION func_sub1(c INOUT INT, b IN INT) RETURN INT;
   FUNCTION func_sub2(d OUT INT, a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b IN INT, c INOUT INT, d OUT INT)
   AS
@@ -476,9 +476,9 @@ set @a = 15;
 set @b = 6;
 set @c = 4;
 set @d= 0;
-call pkg2.proc_main(@a, @b, @c, @d);
+call Pkg2.proc_main(@a, @b, @c, @d);
 select @d;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Argument's order change
@@ -486,13 +486,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT, b IN INT) RETURN INT;
   FUNCTION func_sub(b IN INT, c OUT INT, a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT, b IN INT) RETURN INT
   AS
@@ -514,8 +514,8 @@ DELIMITER ;$$
 
 set @a = 2;
 set @b = 3;
-select pkg2.func_main(@a, @b);
-DROP PACKAGE pkg2;
+select Pkg2.func_main(@a, @b);
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call procedure inside function
@@ -523,13 +523,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(b IN INT, a IN INT) RETURN INT;
   PROCEDURE proc_sub(a IN INT, b IN INT, c OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(b IN INT, a IN INT) RETURN INT
   AS
@@ -549,8 +549,8 @@ DELIMITER ;$$
 
 set @a = 2;
 set @b = 3;
-select pkg2.func_main(@a, @b);
-DROP PACKAGE pkg2;
+select Pkg2.func_main(@a, @b);
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call procedure inside function
@@ -558,13 +558,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(b IN INT, a IN INT) RETURN INT;
   PROCEDURE proc_sub(a IN INT, b INOUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(b IN INT, a IN INT) RETURN INT
   AS
@@ -583,8 +583,8 @@ DELIMITER ;$$
 
 set @a = 2;
 set @b = 3;
-select pkg2.func_main(@a, @b);
-DROP PACKAGE pkg2;
+select Pkg2.func_main(@a, @b);
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call procedure inside function
@@ -592,13 +592,13 @@ DROP PACKAGE pkg2;
 --echo # 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(b IN INT, a IN INT, c OUT INT) RETURN INT;
   PROCEDURE proc_sub(a IN INT, b IN INT, c OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(b IN INT, a IN INT, c OUT INT) RETURN INT
   AS
@@ -620,8 +620,8 @@ set @a = 2;
 set @b = 3;
 set @c = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.func_main(@a, @b, @c);
-DROP PACKAGE pkg2;
+select Pkg2.func_main(@a, @b, @c);
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from UPDATE query
@@ -638,12 +638,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT
   AS
@@ -655,10 +655,10 @@ $$
 DELIMITER ;$$
 
 set @a = 5;
-UPDATE Persons SET Age = pkg2.func(@a) WHERE ID = 1;
+UPDATE Persons SET Age = Pkg2.func(@a) WHERE ID = 1;
 SELECT * FROM Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from UPDATE query
@@ -675,12 +675,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT
   AS
@@ -694,9 +694,9 @@ DELIMITER ;$$
 
 set @a = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-UPDATE Persons SET Age = pkg2.func(@a) WHERE ID = 1;
+UPDATE Persons SET Age = Pkg2.func(@a) WHERE ID = 1;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from INSERT query
@@ -713,12 +713,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT
   AS
@@ -733,7 +733,7 @@ set @a = 4;
 INSERT INTO Persons SELECT 4, 'DDD', PKG2.func(@a);
 SELECT * FROM Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from INSERT query
@@ -750,12 +750,12 @@ INSERT INTO Persons VALUES (2, 'BBB', 20);
 INSERT INTO Persons VALUES (3, 'CCC', 30);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT
   AS
@@ -772,7 +772,7 @@ set @a = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
 INSERT INTO Persons SELECT 5, 'EEE', PKG2.func(@a);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from DELETE query
@@ -790,12 +790,12 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT
   AS
@@ -811,7 +811,7 @@ set @a = 4;
 DELETE FROM Persons WHERE ID = PKG2.func(@a);
 SELECT * FROM Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Call function from DELETE query
@@ -829,12 +829,12 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT
   AS
@@ -851,7 +851,7 @@ set @a = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
 DELETE FROM Persons WHERE ID = PKG2.func(@a);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # SELECT query inside function
@@ -869,12 +869,12 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT
   AS
@@ -888,10 +888,10 @@ $$
 DELIMITER ;$$
 
 set @a = 3;
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # SELECT query inside function
@@ -909,12 +909,12 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a OUT INT) RETURN INT
   AS
@@ -928,9 +928,9 @@ DELIMITER ;$$
 
 set @a = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # SELECT query inside function
@@ -948,12 +948,12 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a INOUT INT) RETURN INT
   AS
@@ -967,9 +967,9 @@ DELIMITER ;$$
 
 set @a = 1;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # SELECT query inside function
@@ -987,13 +987,13 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT;
   FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;  
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT
   AS
@@ -1014,10 +1014,10 @@ $$
 DELIMITER ;$$
 
 set @a = 2;
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # UPDATE query inside function
@@ -1036,12 +1036,12 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT
   AS
@@ -1058,10 +1058,10 @@ DELIMITER ;$$
 
 select * from Persons;
 set @a = 5;
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # UPDATE query inside function
@@ -1080,12 +1080,12 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT, b OUT INT) RETURN INT
   AS
@@ -1101,9 +1101,9 @@ DELIMITER ;$$
 set @a = 5;
 set @b = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.func_main(@a, @b);
+select Pkg2.func_main(@a, @b);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # UPDATE query inside function
@@ -1122,12 +1122,12 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT
   AS
@@ -1143,9 +1143,9 @@ DELIMITER ;$$
 set @a = 5;
 set @b = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.func_main(@a, @b);
+select Pkg2.func_main(@a, @b);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # UPDATE query inside function
@@ -1164,13 +1164,13 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT;
   FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;  
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT
   AS
@@ -1193,10 +1193,10 @@ DELIMITER ;$$
 
 select * from Persons;
 set @a = 1;
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # INSERT query inside function
@@ -1215,12 +1215,12 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 50);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT
   AS
@@ -1237,11 +1237,11 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 6;
 --disable_ps2_protocol
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 --enable_ps2_protocol
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # INSERT query inside function
@@ -1260,12 +1260,12 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 50);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT, b OUT INT) RETURN INT
   AS
@@ -1282,9 +1282,9 @@ select * from Persons;
 set @a = 6;
 set @b = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.func_main(@a, @b);
+select Pkg2.func_main(@a, @b);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # INSERT query inside function
@@ -1303,12 +1303,12 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'EEE', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT, b INOUT INT) RETURN INT
   AS
@@ -1325,9 +1325,9 @@ select * from Persons;
 set @a = 6;
 set @b = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-select pkg2.func_main(@a, @b);
+select Pkg2.func_main(@a, @b);
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # INSERT query inside function
@@ -1347,13 +1347,13 @@ INSERT INTO Persons VALUES (5, 'EEE', 40);
 
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT;
   FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func_main(a IN INT) RETURN INT
   AS
@@ -1377,11 +1377,11 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 6;
 --disable_ps2_protocol
-select pkg2.func_main(@a);
+select Pkg2.func_main(@a);
 --enable_ps2_protocol
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1399,13 +1399,13 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1426,10 +1426,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 2;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select @b;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1447,13 +1447,13 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1474,10 +1474,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 1;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select @b;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1495,13 +1495,13 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1527,10 +1527,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 2;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select @b;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1548,13 +1548,13 @@ INSERT INTO Persons VALUES (3, 'CCC', 30);
 INSERT INTO Persons VALUES (4, 'DDD', 40);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1574,10 +1574,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 5;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1596,13 +1596,13 @@ INSERT INTO Persons VALUES (4, 'DDD', 40);
 INSERT INTO Persons VALUES (5, 'FFF', 50);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1623,10 +1623,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 6;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1646,13 +1646,13 @@ INSERT INTO Persons VALUES (5, 'FFF', 50);
 INSERT INTO Persons VALUES (6, 'GGG', 60);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1678,10 +1678,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 7;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1702,13 +1702,13 @@ INSERT INTO Persons VALUES (6, 'GGG', 60);
 INSERT INTO Persons VALUES (7, 'HHH', 70);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1728,10 +1728,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 5;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1752,13 +1752,13 @@ INSERT INTO Persons VALUES (6, 'GGG', 60);
 INSERT INTO Persons VALUES (7, 'HHH', 70);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT, b OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1780,10 +1780,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 6;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # PROCEDURE > FUNCTION > SQL query
@@ -1804,13 +1804,13 @@ INSERT INTO Persons VALUES (6, 'GGG', 100);
 INSERT INTO Persons VALUES (7, 'HHH', 70);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT);
   FUNCTION func_sub(a IN INT, b INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc_main(a IN INT, b OUT INT)
   AS
@@ -1836,10 +1836,10 @@ DELIMITER ;$$
 select * from Persons;
 set @a = 7;
 set @b = 0;
-call pkg2.proc_main(@a, @b);
+call Pkg2.proc_main(@a, @b);
 select * from Persons;
 DROP TABLE Persons;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 
 --echo # 
 --echo # Trigger
@@ -1897,12 +1897,12 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a IN INT) RETURN INT
   AS
@@ -1921,7 +1921,7 @@ DECLARE
 BEGIN
 	a := 10;
 	res := 0;
-	res := pkg2.func(a);
+	res := Pkg2.func(a);
 END;
 $$
 DELIMITER ;$$
@@ -1932,7 +1932,7 @@ UPDATE Persons SET Age = 30 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -1956,12 +1956,12 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a OUT INT) RETURN INT
   AS
@@ -1981,7 +1981,7 @@ DECLARE
 BEGIN
 	a := 10;
 	res := 0;
-	res := pkg2.func(a);
+	res := Pkg2.func(a);
 END;
 $$
 DELIMITER ;$$
@@ -1992,7 +1992,7 @@ UPDATE Persons SET Age = 50 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2016,12 +2016,12 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   FUNCTION func(a INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   FUNCTION func(a INOUT INT) RETURN INT
   AS
@@ -2041,7 +2041,7 @@ DECLARE
 BEGIN
 	a := 10;
 	res := 0;
-	res := pkg2.func(a);
+	res := Pkg2.func(a);
 END;
 $$
 DELIMITER ;$$
@@ -2052,7 +2052,7 @@ UPDATE Persons SET Age = 60 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2076,12 +2076,12 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc(a IN INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc(a IN INT)
   AS
@@ -2094,7 +2094,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW 
 BEGIN
-	call pkg2.proc(@a);
+	call Pkg2.proc(@a);
 END;
 $$
 DELIMITER ;$$
@@ -2105,7 +2105,7 @@ UPDATE Persons SET Age = 30 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2129,12 +2129,12 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc(a OUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc(a OUT INT)
   AS
@@ -2147,7 +2147,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-	call pkg2.proc(@a);
+	call Pkg2.proc(@a);
 END;
 $$
 DELIMITER ;$$
@@ -2158,7 +2158,7 @@ UPDATE Persons SET Age = 50 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2182,12 +2182,12 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc(a INOUT INT);
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc(a INOUT INT)
   AS
@@ -2202,7 +2202,7 @@ AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
 	set @a = 2;
-	call pkg2.proc(@a);
+	call Pkg2.proc(@a);
 END;
 $$
 DELIMITER ;$$
@@ -2213,7 +2213,7 @@ UPDATE Persons SET Age = 50 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2237,13 +2237,13 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc(a OUT INT);
   FUNCTION func(a IN INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc(a OUT INT)
   AS
@@ -2264,7 +2264,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-	call pkg2.proc(@a);
+	call Pkg2.proc(@a);
 END;
 $$
 DELIMITER ;$$
@@ -2275,7 +2275,7 @@ UPDATE Persons SET Age = 60 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2299,13 +2299,13 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc(a OUT INT);
   FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc(a OUT INT)
   AS
@@ -2327,7 +2327,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-	call pkg2.proc(@a);
+	call Pkg2.proc(@a);
 END;
 $$
 DELIMITER ;$$
@@ -2338,7 +2338,7 @@ UPDATE Persons SET Age = 80 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2362,13 +2362,13 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc(a OUT INT);
   FUNCTION func(a INOUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc(a OUT INT)
   AS
@@ -2390,7 +2390,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-	call pkg2.proc(@a);
+	call Pkg2.proc(@a);
 END;
 $$
 DELIMITER ;$$
@@ -2401,7 +2401,7 @@ UPDATE Persons SET Age = 90 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2425,13 +2425,13 @@ CREATE TABLE PersonsLog (
 INSERT INTO PersonsLog VALUES (0);
 
 DELIMITER $$;
-CREATE OR REPLACE PACKAGE pkg2
+CREATE OR REPLACE PACKAGE Pkg2
 AS
   PROCEDURE proc(a OUT INT);
   FUNCTION func(a OUT INT) RETURN INT;
 END;
 $$
-CREATE OR REPLACE PACKAGE BODY pkg2
+CREATE OR REPLACE PACKAGE BODY Pkg2
 AS
   PROCEDURE proc(a OUT INT)
   AS
@@ -2453,7 +2453,7 @@ CREATE OR REPLACE TRIGGER my_trigger
 AFTER UPDATE ON Persons
 FOR EACH ROW
 BEGIN
-	call pkg2.proc(@a);
+	call Pkg2.proc(@a);
 END;
 $$
 DELIMITER ;$$
@@ -2464,7 +2464,7 @@ UPDATE Persons SET Age = 80 WHERE ID = 1;
 SELECT * FROM Persons;
 SELECT * FROM PersonsLog;
 DROP TRIGGER my_trigger;
-DROP PACKAGE pkg2;
+DROP PACKAGE Pkg2;
 DROP TABLE Persons;
 DROP TABLE PersonsLog;
 
@@ -2474,12 +2474,12 @@ DROP TABLE PersonsLog;
 --echo #
 
 DELIMITER $$;
-CREATE PACKAGE pkg1 AS
+CREATE PACKAGE pKg1 AS
   FUNCTION f1(b IN OUT INT) RETURN INT;
   FUNCTION show_private_variables() RETURN TEXT;
 END;
 $$
-CREATE PACKAGE BODY pkg1 AS
+CREATE PACKAGE BODY pKg1 AS
   pa INT:= 0;
   pb INT:= 10;
   FUNCTION f1(b IN OUT INT) RETURN INT AS
@@ -2497,5 +2497,5 @@ BEGIN
 END;
 $$
 DELIMITER ;$$
-SELECT pkg1.show_private_variables();
-DROP PACKAGE pkg1;
+SELECT pKg1.show_private_variables();
+DROP PACKAGE pKg1;

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -2775,11 +2775,11 @@ LEX_CSTRING
 Item_sp::func_name_cstring(THD *thd, bool is_package_function) const
 {
   /* Calculate length to avoid reallocation of string for sure */
-  size_t len= (((m_name->m_explicit_name ? m_name->m_db.length : 0) +
+  size_t len= (((m_name->use_explicit_name() ? m_name->m_db.length : 0) +
               m_name->m_name.length)*2 + //characters*quoting
              2 +                         // quotes for the function name
              2 +                         // quotes for the package name
-             (m_name->m_explicit_name ?
+             (m_name->use_explicit_name() ?
               3 : 0) +                   // '`', '`' and '.' for the db
              1 +                         // '.' between package and function
              1 +                         // end of string
@@ -2788,7 +2788,7 @@ Item_sp::func_name_cstring(THD *thd, bool is_package_function) const
                system_charset_info);
 
   qname.length(0);
-  if (m_name->m_explicit_name)
+  if (m_name->use_explicit_name())
   {
     append_identifier(thd, &qname, &m_name->m_db);
     qname.append('.');

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -3000,7 +3000,7 @@ Create_sp_func::create_with_db(THD *thd,
   if (item_list != NULL)
     arg_count= item_list->elements;
 
-  qname= new (thd->mem_root) sp_name(db, name, use_explicit_name);
+  qname= new (thd->mem_root) sp_name(thd, db, name, use_explicit_name);
   if (unlikely(sph->sp_resolve_package_routine(thd, thd->lex->sphead,
                                                qname, &sph, &pkgname)))
     return NULL;

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -6750,7 +6750,7 @@ Item_func_sp::fix_fields(THD *thd, Item **ref)
   DBUG_ASSERT(m_sp == NULL);
   if (!(m_sp= sp))
   {
-    my_missing_function_error(m_name->m_name, ErrConvDQName(m_name).ptr());
+    my_missing_function_error(*m_name->get_case_preserved_name(), ErrConvDQName(m_name).ptr());
     process_error(thd);
     DBUG_RETURN(TRUE);
   }

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -8104,6 +8104,7 @@ public:
     m_name.str= name;
     m_name.length= name_length;
   }
+  virtual ~Database_qualified_name() = default;
 
   bool eq(const Database_qualified_name *other) const
   {
@@ -8123,8 +8124,8 @@ public:
     - Lower-case "db" if lower-case-table-names==1.
     - Preserve "name" as is.
   */
-  bool copy_sp_name_internal(MEM_ROOT *mem_root, const LEX_CSTRING &db,
-                             const LEX_CSTRING &name);
+  virtual bool copy_sp_name_internal(MEM_ROOT *mem_root, const LEX_CSTRING &db,
+                                     const LEX_CSTRING &name);
 
   // Export db and name as a qualified name string: 'db.name'
   size_t make_qname(char *dst, size_t dstlen, bool casedn_name) const
@@ -8148,6 +8149,7 @@ public:
     m_name.length= Identifier_chain2(package, routine).make_qname(tmp, length,
                                                                   false);
     m_name.str= tmp;
+    on_update_name(mem_root, m_db, m_name);
     return false;
   }
 
@@ -8161,7 +8163,16 @@ public:
     if (unlikely(!(m_db.str= strmake_root(mem_root, db.str, db.length))))
       return true;
     m_db.length= db.length;
+    on_update_name(mem_root, m_db, m_name);
     return false;
+  }
+
+  /** Event hook to do work whenever the m_name or m_db fields are updated. */
+  virtual void on_update_name(MEM_ROOT *mem_root,
+                             const LEX_CSTRING &db,
+                             const LEX_CSTRING &name)
+  {
+      // Intentionally do nothing here by default.
   }
 };
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6355,7 +6355,7 @@ drop_routine(THD *thd, LEX *lex)
   int sp_result;
 #ifdef HAVE_DLOPEN
   if (lex->sql_command == SQLCOM_DROP_FUNCTION &&
-      ! lex->spname->m_explicit_name)
+      ! lex->spname->use_explicit_name())
   {
     /* DROP FUNCTION <non qualified name> */
     enum drop_udf_result rc= mysql_drop_function(thd, &lex->spname->m_name);

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2665,8 +2665,8 @@ static int wsrep_create_sp(THD *thd, uchar** buf, size_t* buf_len)
   }
   if (sp->m_handler->
       show_create_sp(thd, &log_query,
-                     sp->m_explicit_name ? sp->m_db : null_clex_str,
-                     sp->m_name, sp->m_params, returns,
+                     sp->m_explicit_name ? *sp->get_case_preserved_db() : null_clex_str,
+                     *sp->get_case_preserved_name(), sp->m_params, returns,
                      sp->m_body, sp->chistics(),
                      thd->lex->definer[0],
                      thd->lex->create_info,


### PR DESCRIPTION
On systems where the database is running from a case-insensitive filesystem (like APFS which is case-insensitive by default), we discard the SP name case information.  Later, if we print or otherwise display this name to the user, it’s shown as all lowercase, in contradiction to our documentation.

When specifying the name of a SP, we remember that name both in its original case and in a lowercase form.  We show the original case to the user whenever it may appear in an error message or show output. We retain the all-lowercase value for internal processing as we do today, so internal SP lookup procedures are unaffected.