### PR TITLE
MDEV-32777 DDL operations very slow under macOS

### DIFF
--- a/mysys/my_sync.c
+++ b/mysys/my_sync.c
@@ -70,17 +70,7 @@ int my_sync(File fd, myf my_flags)
 
   do
   {
-#if defined(F_FULLFSYNC)
-    /*
-      In Mac OS X >= 10.3 this call is safer than fsync() (it forces the
-      disk's cache and guarantees ordered writes).
-    */
-    if (!(res= fcntl(fd, F_FULLFSYNC, 0)))
-      break; /* ok */
-    /* Some file systems don't support F_FULLFSYNC and fail above: */
-    DBUG_PRINT("info",("fcntl(F_FULLFSYNC) failed, falling back"));
-#endif
-#if defined(HAVE_FDATASYNC) && HAVE_DECL_FDATASYNC
+#if defined(HAVE_FDATASYNC) && defined(HAVE_DECL_FDATASYNC)
     res= fdatasync(fd);
 #elif defined(HAVE_FSYNC)
     res= fsync(fd);


### PR DESCRIPTION
macOS is a development platform for our product but calls to fcntl(F_FULLFSYNC) are too slow for developer needs.  macOS offers at least three different disk flush calls, making tradeoffs between reliability and performance (see analysis notes on this MDEV). On macOS only and as a compromise, we will back out the change to call fcntl(F_FULLFSYNC), sacrificing a full flush in favor of more performant writes.