### PR TITLE
MDEV-249034 fix assersion (prefix_size <= width)

### DIFF
--- a/mysql-test/suite/join/join_natural.result
+++ b/mysql-test/suite/join/join_natural.result
@@ -1,0 +1,30 @@
+#
+# Bug #XXXXXX: INET_ATON() returns signed, not unsigned
+#
+DROP TABLE IF EXISTS ttt1;
+Warnings:
+Note	1051	Unknown table 'test.ttt1'
+DROP VIEW IF EXISTS vvv1;
+Warnings:
+Note	4092	Unknown VIEW: 'test.vvv1'
+CREATE TABLE ttt1 (
+f01 int, f02 int, f03 int, f04 int, f05 int, f06 int, f07 int, f08 int,
+f09 int, f10 int, f11 int, f12 int, f13 int, f14 int, f15 int, f16 int,
+f17 int, f18 int, f19 int, f20 int, f21 int, f22 int, f23 int, f24 int,
+f25 int, f26 int, f27 int, f28 int, f29 int, f30 int, f31 int, f32 int,
+f33 int, f34 int, f35 int, f36 int, f37 int, f38 int, f39 int, f40 int,
+f41 int, f42 int, f43 int, f44 int, f45 int, f46 int, f47 int, f48 int,
+f49 int, f50 int, f51 int, f52 int, f53 int, f54 int, f55 int, f56 int,
+f57 int, f58 int, f59 int, f60 int, f61 int, f62 int, f63 int, f64 int,
+f65 int);
+CREATE ALGORITHM=TEMPTABLE VIEW vvv1 AS SELECT * FROM ttt1;
+INSERT INTO ttt1 VALUES (),();
+INSERT INTO ttt1 VALUES (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1);
+SELECT * FROM vvv1 NATURAL JOIN ttt1;
+f01	f02	f03	f04	f05	f06	f07	f08	f09	f10	f11	f12	f13	f14	f15	f16	f17	f18	f19	f20	f21	f22	f23	f24	f25	f26	f27	f28	f29	f30	f31	f32	f33	f34	f35	f36	f37	f38	f39	f40	f41	f42	f43	f44	f45	f46	f47	f48	f49	f50	f51	f52	f53	f54	f55	f56	f57	f58	f59	f60	f61	f62	f63	f64	f65
+1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1	1
+DROP VIEW vvv1;
+DROP TABLE ttt1;

--- a/mysql-test/suite/join/join_natural.test
+++ b/mysql-test/suite/join/join_natural.test
@@ -1,0 +1,46 @@
+--echo #
+--echo # Bug #XXXXXX: INET_ATON() returns signed, not unsigned
+--echo #
+DROP TABLE IF EXISTS ttt1;
+DROP VIEW IF EXISTS vvv1;
+
+
+
+CREATE TABLE ttt1 (
+
+  f01 int, f02 int, f03 int, f04 int, f05 int, f06 int, f07 int, f08 int,
+
+  f09 int, f10 int, f11 int, f12 int, f13 int, f14 int, f15 int, f16 int,
+
+  f17 int, f18 int, f19 int, f20 int, f21 int, f22 int, f23 int, f24 int,
+
+  f25 int, f26 int, f27 int, f28 int, f29 int, f30 int, f31 int, f32 int,
+
+  f33 int, f34 int, f35 int, f36 int, f37 int, f38 int, f39 int, f40 int,
+
+  f41 int, f42 int, f43 int, f44 int, f45 int, f46 int, f47 int, f48 int,
+
+  f49 int, f50 int, f51 int, f52 int, f53 int, f54 int, f55 int, f56 int,
+
+  f57 int, f58 int, f59 int, f60 int, f61 int, f62 int, f63 int, f64 int,
+
+  f65 int);
+
+
+
+CREATE ALGORITHM=TEMPTABLE VIEW vvv1 AS SELECT * FROM ttt1;
+
+INSERT INTO ttt1 VALUES (),();
+
+INSERT INTO ttt1 VALUES (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+1,1,1,1,1);
+
+
+SELECT * FROM vvv1 NATURAL JOIN ttt1;
+
+DROP VIEW vvv1;
+
+DROP TABLE ttt1;
+

--- a/sql/sql_bitmap.h
+++ b/sql/sql_bitmap.h
@@ -133,8 +133,12 @@ public:
   }
   bool is_prefix(uint prefix_size) const
   {
-    DBUG_ASSERT(prefix_size <= width);
-
+    // if prefix_size is larger than width, the function would return false
+    // to indicate that the prefix is not fully set,
+    // as it exceeds the total number of bits in the bitmap.
+    if(prefix_size > width)
+      return false;
+  
     size_t idx= prefix_size / BITS_PER_ELEMENT;
 
     for (size_t i= 0; i < idx; i++)


### PR DESCRIPTION
the prefix_size might be larger than the  width , in this case the function should return false because it is impossible for the first [prefix_size] bits to be set to 1 , because prefix_size > number of bits available

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-24931

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
1-when apply this query : SELECT * FROM v1 NATURAL JOIN t1; where v1 is view from t1 , and t1 is any table with number of columns > 64 , then the server will  crash.
2- i have added test suit/join/join_natural.test , before the patch it fail , after this patch it pass correctly 
3-no i don't think so , i have read the dependencies and i found that there is only one function depend  on this patch  witch is make_join_statistics in file sql/sql_select.cc , and after following the logic it is clearly that this function need to this patch , it is need to return false from is_prefix in case prefix_size > width

## Release Notes
there is nothing need to be changed , the patch is only inside the logic of single function with take about the dependencies 

## How can this PR be tested?
run the following from the build directory :
mysql-test/mtr --suite=join --mem --parallel=5

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
