### PR TITLE
MDEV-21102: Server crashes in JOIN_CACHE::write_record_data upon EXPL…

### DIFF
--- a/mysql-test/main/join_cache.result
+++ b/mysql-test/main/join_cache.result
@@ -6396,5 +6396,27 @@ b	b	d	c	c
 10	NULL	NULL	NULL	NULL
 DROP TABLE t1,t2,t3,t4;
 #
+# MDEV-21102: Server crashes in JOIN_CACHE::write_record_data upon EXPLAIN with subqueries and constant tables
+#
+CREATE TABLE t1 (a int, b int) ENGINE=MyISAM;
+CREATE TABLE t2 (c int, d int) ENGINE=MyISAM;
+INSERT INTO t2 VALUES (1,10);
+CREATE TABLE t3 (e int, key (e)) ENGINE=MyISAM;
+INSERT INTO t3 VALUES (2),(3);
+# Must not crash, must use join buffer in subquery
+EXPLAIN
+SELECT * FROM t1
+WHERE a > b OR a IN (
+SELECT c FROM t2 WHERE EXISTS (
+SELECT * FROM t3 t3a JOIN t3 t3b WHERE t3a.e < d
+)
+);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE noticed after reading const tables
+2	DEPENDENT SUBQUERY	t2	system	NULL	NULL	NULL	NULL	1	
+3	SUBQUERY	t3a	index	e	e	5	NULL	2	Using where; Using index
+3	SUBQUERY	t3b	index	NULL	e	5	NULL	2	Using index; Using join buffer (flat, BNL join)
+DROP TABLE t1,t2,t3;
+#
 # End of 10.4 tests
 #

--- a/mysql-test/main/join_cache.test
+++ b/mysql-test/main/join_cache.test
@@ -4306,5 +4306,26 @@ eval $q2;
 DROP TABLE t1,t2,t3,t4;
 
 --echo #
+--echo # MDEV-21102: Server crashes in JOIN_CACHE::write_record_data upon EXPLAIN with subqueries and constant tables
+--echo #
+CREATE TABLE t1 (a int, b int) ENGINE=MyISAM;
+
+CREATE TABLE t2 (c int, d int) ENGINE=MyISAM;
+INSERT INTO t2 VALUES (1,10);
+
+CREATE TABLE t3 (e int, key (e)) ENGINE=MyISAM;
+INSERT INTO t3 VALUES (2),(3);
+
+--echo # Must not crash, must use join buffer in subquery
+EXPLAIN
+SELECT * FROM t1
+WHERE a > b OR a IN (
+    SELECT c FROM t2 WHERE EXISTS (
+        SELECT * FROM t3 t3a JOIN t3 t3b WHERE t3a.e < d
+    )
+);
+DROP TABLE t1,t2,t3;
+
+--echo #
 --echo # End of 10.4 tests
 --echo #

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -562,6 +562,8 @@ void Item_subselect::recalc_used_tables(st_select_lex *new_parent,
   This measure is used instead of JOIN::read_time, because it is considered
   to be much more reliable than the cost estimate.
 
+  Note: the logic in this function must agree with JOIN::init_join_caches().
+
   @return true if the subquery is expensive
   @return false otherwise
 */

--- a/sql/sql_join_cache.cc
+++ b/sql/sql_join_cache.cc
@@ -1589,6 +1589,7 @@ bool JOIN_CACHE::put_record()
 {
   bool is_full;
   uchar *link= 0;
+  DBUG_ASSERT(!for_explain_only);
   if (prev_cache)
     link= prev_cache->get_curr_rec_link();
   write_record_data(link, &is_full);


### PR DESCRIPTION
…AIN with subqueries

JOIN_CACHE has a light-weight initialization mode that's targeted at EXPLAINs. In that mode, JOIN_CACHE objects are not able to execute.

Light-weight mode was used whenever the statement was an EXPLAIN. However the EXPLAIN can execute subqueries, provided they enumerate less than @@expensive_subquery_limit rows.

Make sure we use light-weight initialization mode only when the select is more expensive @@expensive_subquery_limit.

Also add an assert into JOIN_CACHE::put_record() which prevents its use if it was initialized for EXPLAIN only.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
