### PR TITLE
MDEV-33574 Improve mysqlbinlog error message

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -2997,7 +2997,8 @@ int main(int argc, char** argv)
   {
     if (!opt_version)
     {
-      usage();
+      error("Please provide the log file(s). Run with '--help' for usage "
+            "instructions.");
       retval= ERROR_STOP;
     }
     goto err;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: [MDEV-33574](https://jira.mariadb.org/browse/MDEV-33574)*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Previously, when running mysqlbinlog without providing a binlog file, it would print the entire help text, which was very verbose and made it difficult to identify the actual issue.

Now change the behavior to print a more concise error message instead:

    "ERROR: Please provide the log file(s). Run with '--help' for usage instructions."

This makes the error output more user-friendly and easier to understand, especially when running the tool in scripts or automated processes.

## Release Notes
What should the release notes say about this change?
- I think this minor change does not need to be included in the release notes. Or simply say "Concise error message when no binlog file is provided. (MDEV-33574)"

## How can this PR be tested?
The change includes error message change only, no MTR needed.

Instead of displaying the previous 200+ line help message, the following example shows concise message will be output when executing mysqlbinlog/mariadb-binlog without specifying a log file:

```
$ ./mariadb-binlog -R  --socket=/var/lib/mysql/mysql.sock --stop-never
ERROR: Please provide the log file(s). Run with '--help' for usage instructions.
```

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is an improvement of the error message but the fix versions are marked as 10.4+ in Jira [MDEV-33574](https://jira.mariadb.org/browse/MDEV-33574).*
Please let me know if we should fix it only for 10.5+ and I'll rebase.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.