### PR TITLE
MDEV-33757 Get rid of TrxUndoRsegs code

### DIFF
--- a/storage/innobase/include/trx0rseg.h
+++ b/storage/innobase/include/trx0rseg.h
@@ -170,19 +170,21 @@ public:
   /** Last not yet purged undo log header; FIL_NULL if all purged */
   uint32_t last_page_no;
 
-  /** trx_t::no | last_offset << 48 */
+  /** trx_t::no << 16 | last_offset */
   uint64_t last_commit_and_offset;
 
   /** @return the commit ID of the last committed transaction */
   trx_id_t last_trx_no() const
-  { return last_commit_and_offset & ((1ULL << 48) - 1); }
+  { return last_commit_and_offset >> 16; }
   /** @return header offset of the last committed transaction */
   uint16_t last_offset() const
-  { return static_cast<uint16_t>(last_commit_and_offset >> 48); }
+  {
+    return static_cast<uint16_t>(last_commit_and_offset & ((1ULL << 16) - 1));
+  }
 
   void set_last_commit(uint16_t last_offset, trx_id_t trx_no)
   {
-    last_commit_and_offset= static_cast<uint64_t>(last_offset) << 48 | trx_no;
+    last_commit_and_offset= trx_no << 16 | static_cast<uint64_t>(last_offset);
   }
 
   /** @return the page identifier */

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -56,84 +56,6 @@ purge_sys_t	purge_sys;
 my_bool		srv_purge_view_update_only_debug;
 #endif /* UNIV_DEBUG */
 
-/** Sentinel value */
-static const TrxUndoRsegs NullElement;
-
-/** Default constructor */
-TrxUndoRsegsIterator::TrxUndoRsegsIterator()
-	: m_rsegs(NullElement), m_iter(m_rsegs.begin())
-{
-}
-
-/** Sets the next rseg to purge in purge_sys.
-Executed in the purge coordinator thread.
-@retval false when nothing is to be purged
-@retval true  when purge_sys.rseg->latch was locked */
-inline bool TrxUndoRsegsIterator::set_next()
-{
-	ut_ad(!purge_sys.next_stored);
-	mysql_mutex_lock(&purge_sys.pq_mutex);
-
-	/* Only purge consumes events from the priority queue, user
-	threads only produce the events. */
-
-	/* Check if there are more rsegs to process in the
-	current element. */
-	if (m_iter != m_rsegs.end()) {
-		/* We are still processing rollback segment from
-		the same transaction and so expected transaction
-		number shouldn't increase. Undo the increment of
-		expected commit done by caller assuming rollback
-		segments from given transaction are done. */
-		purge_sys.tail.trx_no = (*m_iter)->last_trx_no();
-	} else if (!purge_sys.purge_queue.empty()) {
-		m_rsegs = purge_sys.purge_queue.top();
-		purge_sys.purge_queue.pop();
-		ut_ad(purge_sys.purge_queue.empty()
-		      || purge_sys.purge_queue.top() != m_rsegs);
-		m_iter = m_rsegs.begin();
-	} else {
-		/* Queue is empty, reset iterator. */
-		purge_sys.rseg = NULL;
-		mysql_mutex_unlock(&purge_sys.pq_mutex);
-		m_rsegs = NullElement;
-		m_iter = m_rsegs.begin();
-		return false;
-	}
-
-	purge_sys.rseg = *m_iter++;
-	mysql_mutex_unlock(&purge_sys.pq_mutex);
-
-	/* We assume in purge of externally stored fields that space
-	id is in the range of UNDO tablespace space ids */
-	ut_ad(purge_sys.rseg->space->id == TRX_SYS_SPACE
-	      || srv_is_undo_tablespace(purge_sys.rseg->space->id));
-
-	purge_sys.rseg->latch.wr_lock(SRW_LOCK_CALL);
-	trx_id_t last_trx_no = purge_sys.rseg->last_trx_no();
-	purge_sys.hdr_offset = purge_sys.rseg->last_offset();
-	purge_sys.hdr_page_no = purge_sys.rseg->last_page_no;
-
-	/* Only the purge_coordinator_task will access this object
-	purge_sys.rseg_iter, or any of purge_sys.hdr_page_no,
-	purge_sys.tail.
-	The field purge_sys.head and purge_sys.view are modified by
-	purge_sys_t::clone_end_view()
-	in the purge_coordinator_task
-	while holding exclusive purge_sys.latch.
-	The purge_sys.view may also be modified by
-	purge_sys_t::wake_if_not_active() while holding exclusive
-	purge_sys.latch.
-	The purge_sys.head may be read by
-	purge_truncation_callback(). */
-	ut_ad(last_trx_no == m_rsegs.trx_no);
-	ut_a(purge_sys.hdr_page_no != FIL_NULL);
-	ut_a(purge_sys.tail.trx_no <= last_trx_no);
-	purge_sys.tail.trx_no = last_trx_no;
-
-	return(true);
-}
-
 /** Build a purge 'query' graph. The actual purge is performed by executing
 this query graph.
 @return own: the query graph */
@@ -571,42 +493,17 @@ loop:
   goto loop;
 }
 
-/** Cleanse purge queue to remove the rseg that reside in undo-tablespace
-marked for truncate.
-@param[in]	space	undo tablespace being truncated */
-static void trx_purge_cleanse_purge_queue(const fil_space_t& space)
+void purge_sys_t::cleanse_purge_queue(const fil_space_t &space)
 {
-	typedef	std::vector<TrxUndoRsegs>	purge_elem_list_t;
-	purge_elem_list_t			purge_elem_list;
-
-	mysql_mutex_lock(&purge_sys.pq_mutex);
-
-	/* Remove rseg instances that are in the purge queue before we start
-	truncate of corresponding UNDO truncate. */
-	while (!purge_sys.purge_queue.empty()) {
-		purge_elem_list.push_back(purge_sys.purge_queue.top());
-		purge_sys.purge_queue.pop();
-	}
-
-	for (purge_elem_list_t::iterator it = purge_elem_list.begin();
-	     it != purge_elem_list.end();
-	     ++it) {
-
-		for (TrxUndoRsegs::iterator it2 = it->begin();
-		     it2 != it->end();
-		     ++it2) {
-			if ((*it2)->space == &space) {
-				it->erase(it2);
-				break;
-			}
-		}
-
-		if (!it->empty()) {
-			purge_sys.purge_queue.push(*it);
-		}
-	}
-
-	mysql_mutex_unlock(&purge_sys.pq_mutex);
+  byte purge_elem_list[TRX_SYS_N_RSEGS];
+  mysql_mutex_lock(&pq_mutex);
+  std::copy(purge_queue.c_begin(), purge_queue.c_end(), purge_elem_list);
+  byte *purge_list_end = purge_elem_list + purge_queue.size();
+  purge_queue.clear();
+  for (byte *elem = purge_elem_list; elem < purge_list_end; ++elem)
+    if (trx_sys.rseg_array[*elem].space != &space)
+      purge_queue.push_rseg_index(*elem);
+  mysql_mutex_unlock(&pq_mutex);
 }
 
 dberr_t purge_sys_t::iterator::free_history() const
@@ -750,7 +647,7 @@ not_free:
 
     const char *file_name= UT_LIST_GET_FIRST(space->chain)->name;
     sql_print_information("InnoDB: Truncating %s", file_name);
-    trx_purge_cleanse_purge_queue(*space);
+    purge_sys.cleanse_purge_queue(*space);
 
     /* Lock all modified pages of the tablespace.
 
@@ -869,7 +766,7 @@ buf_block_t *purge_sys_t::get_page(page_id_t id)
   return nullptr;
 }
 
-void purge_sys_t::rseg_get_next_history_log()
+bool purge_sys_t::rseg_get_next_history_log()
 {
   fil_addr_t prev_log_addr;
 
@@ -917,12 +814,13 @@ void purge_sys_t::rseg_get_next_history_log()
       can never produce events from an empty rollback segment. */
 
       mysql_mutex_lock(&pq_mutex);
-      purge_queue.push(*rseg);
+      purge_queue.push(rseg);
       mysql_mutex_unlock(&pq_mutex);
     }
   }
 
   rseg->latch.wr_unlock();
+  return choose_next_log();
 }
 
 /** Position the purge sys "iterator" on the undo record to use for purging.
@@ -930,11 +828,37 @@ void purge_sys_t::rseg_get_next_history_log()
 @retval true  when purge_sys.rseg->latch was locked */
 bool purge_sys_t::choose_next_log()
 {
-  if (!rseg_iter.set_next())
-    return false;
+  ut_ad(!next_stored);
 
-  hdr_offset= rseg->last_offset();
-  hdr_page_no= rseg->last_page_no;
+  mysql_mutex_lock(&pq_mutex);
+  if (purge_queue.empty()) {
+    rseg = nullptr;
+    mysql_mutex_unlock(&purge_sys.pq_mutex);
+    return false;
+  }
+  rseg= purge_queue.pop();
+  mysql_mutex_unlock(&purge_sys.pq_mutex);
+
+  /* We assume in purge of externally stored fields that space
+  id is in the range of UNDO tablespace space ids */
+  ut_ad(rseg->space == fil_system.sys_space ||
+        srv_is_undo_tablespace(rseg->space->id));
+
+  rseg->latch.wr_lock(SRW_LOCK_CALL);
+  trx_id_t last_trx_no = rseg->last_trx_no();
+  hdr_offset = rseg->last_offset();
+  hdr_page_no = rseg->last_page_no;
+
+  /* Only the purge_coordinator_task will access this any of
+  purge_sys.hdr_page_no, purge_sys.tail. The field purge_sys.head and
+  purge_sys.view are modified by clone_end_view() in the
+  purge_coordinator_task while holding exclusive purge_sys.latch. The
+  purge_sys.view may also be modified by wake_if_not_active() while holding
+  exclusive purge_sys.latch. The purge_sys.head may be read by
+  purge_truncation_callback(). */
+  ut_a(hdr_page_no != FIL_NULL);
+  ut_a(tail.trx_no <= last_trx_no);
+  tail.trx_no = last_trx_no;
 
   if (!rseg->needs_purge)
   {
@@ -993,12 +917,9 @@ inline trx_purge_rec_t purge_sys_t::get_next_rec(roll_ptr_t roll_ptr)
 
   if (!offset)
   {
-    /* It is the dummy undo log record, which means that there is no
-    need to purge this undo log */
-    rseg_get_next_history_log();
-
-    /* Look for the next undo log and record to purge */
-    if (choose_next_log())
+    /* It is the dummy undo log record, which means that there is no need to
+    purge this undo log. Look for the next undo log and record to purge */
+    if (rseg_get_next_history_log())
       rseg->latch.wr_unlock();
     return {nullptr, 1};
   }
@@ -1046,9 +967,8 @@ inline trx_purge_rec_t purge_sys_t::get_next_rec(roll_ptr_t roll_ptr)
   else
   {
   got_no_rec:
-    rseg_get_next_history_log();
     /* Look for the next undo log and record to purge */
-    locked= choose_next_log();
+    locked= rseg_get_next_history_log();
   }
 
   if (locked)

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1138,15 +1138,23 @@ inline void trx_t::write_serialisation_history(mtr_t *mtr)
     }
     else if (rseg->last_page_no == FIL_NULL)
     {
-      mysql_mutex_lock(&purge_sys.pq_mutex);
+      /* trx_sys.assign_new_trx_no() and
+      purge_sys.enqueue() must be invoked in the same
+      critical section protected with purge queue mutex to avoid rseg with
+      greater last commit number to be pushed to purge queue prior to rseg with
+      lesser last commit number. In other words pushing to purge queue must be
+      serialized along with assigning trx_no. Otherwise purge coordinator
+      thread can also fetch redo log records from rseg with greater last commit
+      number before rseg with lesser one. */
+      purge_sys.queue_lock();
       trx_sys.assign_new_trx_no(this);
       const trx_id_t end{rw_trx_hash_element->no};
+      rseg->last_page_no= undo->hdr_page_no;
       /* end cannot be less than anything in rseg. User threads only
       produce events when a rollback segment is empty. */
-      purge_sys.purge_queue.push(TrxUndoRsegs{end, *rseg});
-      mysql_mutex_unlock(&purge_sys.pq_mutex);
-      rseg->last_page_no= undo->hdr_page_no;
       rseg->set_last_commit(undo->hdr_offset, end);
+      purge_sys.enqueue(*rseg);
+      purge_sys.queue_unlock();
     }
     else
       trx_sys.assign_new_trx_no(this);


### PR DESCRIPTION
TrxUndoRsegs is wrapper for vector of trx_rseg_t*. It has two constructors, both initialize the vector with only one element. And they are used to push transactions rseg(the singular) to purge queue. There is no function to add elements to the vector. The default constructor is used only for declaration of NullElement.

The TrxUndoRsegs was introduced in WL#6915 in MySQL 5.7 and. MySQL 5.7 would unnecessarily let the purge of history parse the temporary undo records, and then look up the table (via a global hash table), and only at the point of processing the parsed undo log record determine that the table is a temporary table and the undo record must be thrown away.

In MariaDB 10.2 we have two disjoint sets of rollback segments (128 for persistent, 128 for temporary), and purge does not even see the temporary tables. The only reason why temporary tables are visible to other threads is a SQL layer bug (MDEV-17805).

purge_sys_t::choose_next_log(): merge the relevant part of TrxUndoRsegsIterator::set_next() to the start of purge_sys_t::choose_next_log().

purge_sys_t::rseg_get_next_history_log(): add a tail call of purge_sys_t::choose_next_log() and adjust the callers, to simplify the control flow further.

purge_sys.pq_mutex and purge_sys.purge_queue: make it private by adding some simple accessor function.

trx_purge_cleanse_purge_queue(): make it a member of purge_sys_t to have have access to private purge_sys.pq_mutex and purge_sys.purge_queue.

Thanks Marko Mäkelä for historical overview of TrxUndoRsegs development.

Reviewed by: Marko Mäkelä

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
