### PR TITLE
MDEV-33659 Fix crash in kdf() without parameters

### DIFF
--- a/mysql-test/main/func_kdf.result
+++ b/mysql-test/main/func_kdf.result
@@ -154,5 +154,10 @@ NULL
 Warnings:
 Warning	3047	Invalid argument error: 65537 in function kdf.
 #
+# MDEV-33659 Test kdf() without parameters
+#
+select kdf();
+ERROR 42000: Incorrect parameter count in the call to native function 'kdf'
+#
 # End of 11.3 tests
 #

--- a/mysql-test/main/func_kdf.test
+++ b/mysql-test/main/func_kdf.test
@@ -52,6 +52,13 @@ select length(kdf('foo', 'bar', 100, 'pbkdf2_hmac', 65536));
 select length(kdf('foo', 'bar', 100, 'pbkdf2_hmac', 65537));
 
 --echo #
+--echo # MDEV-33659 Test kdf() without parameters
+--echo #
+
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+select kdf();
+
+--echo #
 --echo # End of 11.3 tests
 --echo #
 

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -3229,8 +3229,12 @@ Item*
 Create_func_kdf::create_native(THD *thd, const LEX_CSTRING *name,
                                List<Item> *item_list)
 {
-  uint arg_count= item_list->elements;
   Item *a[5];
+  uint arg_count= 0;
+
+  if (item_list != NULL)
+    arg_count= item_list->elements;
+
   for (uint i=0; i < MY_MIN(array_elements(a), arg_count); i++)
     a[i]= item_list->pop();
   switch (arg_count)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33659*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
 
- When there is no parameter item_list is NULL.
- This code checks if item_list is NULL before setting arg_count to item_list->elements.


## Release Notes
Fix system crash when KDF() was called without parameters.

This function was added to MariaDB in 11.3 (see https://github.com/MariaDB/server/commit/4f9396b9f80031120f325d54f06d346dea7f1bfb and https://mariadb.com/kb/en/kdf) and did not exist in earlier major versions.

## How can this PR be tested?

```sh
./mtr main.func_kdf
```
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
