### PR TITLE
MDEV-33770  Alter operation hangs when encryption thread works on the same tablespace

### DIFF
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -2755,7 +2755,7 @@ fil_space_crypt_close_tablespace(
 				   << " seconds to drop space: "
 				   << space->name << " ("
 				   << space->id << ") active threads "
-				   << cnt << "flushing="
+				   << cnt << " flushing="
 				   << flushing << ".";
 			last = now;
 		}

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2288,13 +2288,13 @@ fil_check_pending_operations(
 	fil_space_t* sp = fil_space_get_by_id(id);
 
 	if (sp) {
+		sp->set_stopping(true);
 		if (sp->crypt_data && sp->acquire()) {
 			mutex_exit(&fil_system.mutex);
 			fil_space_crypt_close_tablespace(sp);
 			mutex_enter(&fil_system.mutex);
 			sp->release();
 		}
-		sp->set_stopping(true);
 	}
 
 	/* Check for pending operations. */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33770*

## Description

- Background encryption threads wait for stop flag to exit early from the tablespace. Alter operation fails to set the stop flag before waiting for the encryption thread to stop using the tablespace.

## How can this PR be tested?
```
--source include/have_innodb.inc
--source include/have_sequence.inc
--source include/have_file_key_management_plugin.inc
--source include/count_sessions.inc
 
SET @save_threads = @@GLOBAL.innodb_encryption_threads;
 
SET default_storage_engine = InnoDB;
 
SET GLOBAL innodb_encryption_threads = 1;
 
create table t1(f1 int not null, f2 int not null)engine=innodb;
insert into t1 select seq, seq from seq_1_to_65536;
insert into t1 select seq, seq from seq_1_to_65536;
insert into t1 select seq, seq from seq_1_to_65536;
SET GLOBAL innodb_encrypt_tables=1;
sleep 20;
alter table t1 force, algorithm=inplace;
drop table t1;
```
Sleep in above test case is for InnoDB to complete the encryption on all other tablespace. Added the below patch inside `fil_crypt_thread()` to make the background thread wait for stop signal to come out.

```
diff --git a/storage/innobase/fil/fil0crypt.cc b/storage/innobase/fil
/fil0crypt.cc
index ad02f1c3393..91e287fef35 100644
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -2458,6 +2458,11 @@ DECLARE_THREAD(fil_crypt_thread)(void*)
                        /* we found a space to rotate */
                        fil_crypt_start_rotate_space(&new_state, &thr);
 
+                       if (!strcmp(thr.space->name, "test/t1")) {
+                               while (!thr.space->is_stopping()) {
+                                       os_thread_sleep(20000);
+                               }
+                       }
                        /* iterate all pages (cooperativly with other threads) */
                        while (!thr.should_shutdown() &&
                               fil_crypt_find_page_to_rotate(&new_state, &thr)) {
```
With out this pull request patch, innodb hangs for alter operation by throwing the warning in log file:
```
2024-03-26 14:42:18 9 [Warning] InnoDB: Waited 60 seconds to drop space: test/#sql-ib21 (5) active threads 1flushing=0.
 2024-03-26 14:42:48 9 [Warning] InnoDB: Waited 90 seconds to drop space: test/#sql-ib21 (5) active threads 1flushing=0.
```

Difficult to use debug execute if on background thread. That's why i had to come up with above test case.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
