### PR TITLE
MDEV-33290: Disable ColumnStore based on boost version (postfix)

### DIFF
--- a/storage/columnstore/CMakeLists.txt
+++ b/storage/columnstore/CMakeLists.txt
@@ -13,14 +13,16 @@ endmacro()
 
 IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
 CMAKE_SYSTEM_PROCESSOR STREQUAL "amd64")
-    add_subdirectory(columnstore)
+    cmake_policy(SET CMP0093 NEW)
 
     # https://jira.mariadb.org/browse/MCOL-5611
-    FIND_PACKAGE(Boost 1.80.0 COMPONENTS system filesystem thread regex date_time chrono atomic)
-    IF (Boost_FOUND)
+    FIND_PACKAGE(Boost COMPONENTS system filesystem thread regex date_time chrono atomic)
+    IF (Boost_VERSION VERSION_GREATER "1.79.0")
         MESSAGE_ONCE(CS_NO_BOOST "Boost Libraries >= 1.80.0 not supported!")
         return()
     ENDIF()
+
+    add_subdirectory(columnstore)
 
     IF(TARGET columnstore)
         # Needed to bump the component changes up to the main scope


### PR DESCRIPTION
Its important to fail early and only contine with the include after the boost version check succeeds.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33290*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Correct previous mistake in determining the boost version - check, then include columnstore.

## Release Notes

Nothing required.

## How can this PR be tested?

See if it builds correctly on fedora autobake builders
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.