### PR TITLE
MDEV-32633: Fix Galera cluster <-> native replication interaction

### DIFF
--- a/mysql-test/suite/galera_3nodes/disabled.def
+++ b/mysql-test/suite/galera_3nodes/disabled.def
@@ -11,7 +11,6 @@
 ##############################################################################
 
 galera_2_cluster : MDEV-32631 galera_2_cluster: before_rollback(): Assertion `0' failed
-galera_gtid_2_cluster : MDEV-32633 galera_gtid_2_cluster: Assertion `thd->wsrep_next_trx_id() != (0x7fffffffffffffffLL * 2ULL + 1)'
 galera_ssl_reload : MDEV-32778 galera_ssl_reload failed with warning message
 galera_ipv6_mariabackup : temporarily disabled at the request of Codership
 galera_pc_bootstrap : temporarily disabled at the request of Codership

--- a/mysql-test/suite/galera_3nodes/r/galera_gtid_2_cluster.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_gtid_2_cluster.result
@@ -75,15 +75,15 @@ insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
 @@gtid_binlog_state
 1-11-2,2-21-1
-select * from t1;
-cluster_domain_id	node_server_id	seq_no
-1	11	2
-2	21	1
 #wait for sync  cluster 1 and 2
 connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+2	21	1
 cluster 1 node 2
 connection node_2;
 select @@gtid_binlog_state;
@@ -98,6 +98,11 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+2	21	1
 cluster 1 node 3
 connection node_3;
 select @@gtid_binlog_state;
@@ -112,6 +117,12 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
 cluster 2 node 2
 connection node_5;
 select @@gtid_binlog_state;
@@ -126,6 +137,13 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
 cluster 2 node 3
 connection node_6;
 select @@gtid_binlog_state;
@@ -140,6 +158,63 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+# check other nodes are consistent
+connection node_2;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-4,2-21-3
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+connection node_3;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-4,2-21-3
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+connection node_5;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-4,2-21-3
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+connection node_6;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-4,2-21-3
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
 cluster 1 node 1
 connection node_1;
 select @@gtid_binlog_state;
@@ -220,15 +295,15 @@ insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
 @@gtid_binlog_state
 1-11-7,2-21-4
-select * from t1;
-cluster_domain_id	node_server_id	seq_no
-1	11	2
-2	21	1
 #wait for sync  cluster 1 and 2
 connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+2	21	1
 cluster 1 node 2
 connection node_2;
 select @@gtid_binlog_state;
@@ -243,6 +318,11 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+2	21	1
 cluster 1 node 3
 connection node_3;
 select @@gtid_binlog_state;
@@ -257,6 +337,12 @@ connection node_1;
 include/save_master_gtid.inc
 connection node_4;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
 cluster 2 node 2
 connection node_5;
 select @@gtid_binlog_state;
@@ -271,6 +357,13 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
 cluster 2 node 3
 connection node_6;
 select @@gtid_binlog_state;
@@ -285,6 +378,63 @@ connection node_4;
 include/save_master_gtid.inc
 connection node_1;
 include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+# check other nodes are consistent
+connection node_2;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-9,2-21-6
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+connection node_3;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-9,2-21-6
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+connection node_5;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-9,2-21-6
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
+connection node_6;
+select @@gtid_binlog_state;
+@@gtid_binlog_state
+1-11-9,2-21-6
+select * from t1 order by 1, 2, 3;
+cluster_domain_id	node_server_id	seq_no
+1	11	2
+1	12	3
+1	13	4
+2	21	1
+2	22	2
+2	23	3
 cluster 1 node 1
 connection node_1;
 select @@gtid_binlog_state;

--- a/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.cnf
@@ -9,11 +9,11 @@ server-id=11
 
 [mysqld.2]
 wsrep_gtid_domain_id=1
-server-id=12
+server-id=11
 
 [mysqld.3]
 wsrep_gtid_domain_id=1
-server-id=13
+server-id=11
 
 [mysqld.4]
 wsrep_gtid_domain_id=2
@@ -21,8 +21,8 @@ server-id=21
 
 [mysqld.5]
 wsrep_gtid_domain_id=2
-server-id=22
+server-id=21
 
 [mysqld.6]
 wsrep_gtid_domain_id=2
-server-id=23
+server-id=21

--- a/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
@@ -11,6 +11,7 @@
 --source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 --connection node_1
 --echo cluster 1 node 1
@@ -75,12 +76,12 @@ select @@gtid_binlog_state;
 select @@gtid_binlog_state;
 insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
-select * from t1;
 --echo #wait for sync  cluster 1 and 2
 --connection node_1
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 2
@@ -94,6 +95,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 3
 --connection node_3
@@ -106,6 +108,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 2
 --connection node_5
@@ -118,6 +121,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 3
 --connection node_6
@@ -130,7 +134,21 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
+--echo # check other nodes are consistent
+--connection node_2
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
+--connection node_3
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
+--connection node_5
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
+--connection node_6
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 1
 --connection node_1
@@ -226,13 +244,13 @@ select @@gtid_binlog_state;
 --connection node_4
 insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
-select * from t1;
 
 --echo #wait for sync  cluster 1 and 2
 --connection node_1
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 2
@@ -246,6 +264,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 3
 --connection node_3
@@ -258,6 +277,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 2
 --connection node_5
@@ -270,6 +290,7 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 3
 --connection node_6
@@ -282,7 +303,21 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+select * from t1 order by 1, 2, 3;
 
+--echo # check other nodes are consistent
+--connection node_2
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
+--connection node_3
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
+--connection node_5
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
+--connection node_6
+select @@gtid_binlog_state;
+select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 1
 --connection node_1

--- a/sql/rpl_gtid.cc
+++ b/sql/rpl_gtid.cc
@@ -704,6 +704,8 @@ rpl_slave_state::record_gtid(THD *thd, const rpl_gtid *gtid, uint64 sub_id,
   {
     thd->wsrep_ignore_table= false;
     table->file->row_logging= 1; // replication requires binary logging
+    if (thd->wsrep_next_trx_id() == WSREP_UNDEFINED_TRX_ID)
+      thd->set_query_id(next_query_id());
     wsrep_start_trx_if_not_started(thd);
   }
   else


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32633*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->

GTID events are applied without a running server transaction, we need to set next transaction ID for Wsrep transaction.

The whole Galera cluster now has a single GTID value (including the server ID throughout the cluster), fix the config accordingly.

Add force restart so that repeated MTR test execution prints consistent GTID values, otherwise they would have been recovered from the previous run.

## Release Notes

The fix is for versions 10.5 upwards.

## How can this PR be tested?

Re-enabled previously failing MTR test.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
