### PR TITLE
MDEV-33787 : Fix Galera test failures on 10.11

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-25731.result
+++ b/mysql-test/suite/galera/r/MDEV-25731.result
@@ -4,9 +4,7 @@ connection node_1;
 SET GLOBAL wsrep_load_data_splitting=ON;
 Warnings:
 Warning	1287	'@@wsrep_load_data_splitting' is deprecated and will be removed in a future release
-SET GLOBAL wsrep_replicate_myisam=ON;
-Warnings:
-Warning	1287	'@@wsrep_replicate_myisam' is deprecated and will be removed in a future release. Please use '@@wsrep_mode=REPLICATE_MYISAM' instead
+SET GLOBAL wsrep_mode=REPLICATE_MYISAM;
 CREATE TABLE t1 (c1 int) ENGINE=MYISAM;
 LOAD DATA INFILE '../../std_data/mdev-25731.dat' IGNORE INTO TABLE t1 LINES TERMINATED BY '\n';
 Warnings:
@@ -33,6 +31,4 @@ DROP TABLE t1;
 SET GLOBAL wsrep_load_data_splitting=OFF;
 Warnings:
 Warning	1287	'@@wsrep_load_data_splitting' is deprecated and will be removed in a future release
-SET GLOBAL wsrep_replicate_myisam=OFF;
-Warnings:
-Warning	1287	'@@wsrep_replicate_myisam' is deprecated and will be removed in a future release. Please use '@@wsrep_mode=REPLICATE_MYISAM' instead
+SET GLOBAL wsrep_mode=DEFAULT;

--- a/mysql-test/suite/galera/r/galera_wan_restart_sst.result
+++ b/mysql-test/suite/galera/r/galera_wan_restart_sst.result
@@ -10,7 +10,7 @@ SELECT VARIABLE_VALUE AS EXPECT_4 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VA
 EXPECT_4
 4
 connection node_1;
-CREATE TABLE t1 (f1 INTEGER);
+CREATE TABLE t1 (f1 INTEGER NOT NULL PRIMARY KEY) ENGINE=INNODB;
 INSERT INTO t1 VALUES (1);
 connection node_2;
 INSERT INTO t1 VALUES (2);
@@ -20,6 +20,8 @@ connection node_4;
 INSERT INTO t1 VALUES (4);
 connection node_3;
 INSERT INTO t1 VALUES (13);
+connection node_1;
+connection node_3;
 Killing server ...
 connection node_1;
 INSERT INTO t1 VALUES (11);
@@ -29,8 +31,11 @@ connection node_4;
 INSERT INTO t1 VALUES (14);
 connection node_3;
 INSERT INTO t1 VALUES (131);
+connection node_1;
 connection node_2;
 INSERT INTO t1 VALUES (22);
+connection node_1;
+connection node_2;
 Killing server ...
 connection node_1;
 INSERT INTO t1 VALUES (21);
@@ -42,6 +47,8 @@ connection node_2;
 INSERT INTO t1 VALUES (221);
 connection node_4;
 INSERT INTO t1 VALUES (34);
+connection node_1;
+connection node_4;
 Killing server ...
 connection node_1;
 INSERT INTO t1 VALUES (31);

--- a/mysql-test/suite/galera/t/MDEV-25731.test
+++ b/mysql-test/suite/galera/t/MDEV-25731.test
@@ -3,7 +3,7 @@
 
 --connection node_1
 SET GLOBAL wsrep_load_data_splitting=ON;
-SET GLOBAL wsrep_replicate_myisam=ON;
+SET GLOBAL wsrep_mode=REPLICATE_MYISAM;
 CREATE TABLE t1 (c1 int) ENGINE=MYISAM;
 LOAD DATA INFILE '../../std_data/mdev-25731.dat' IGNORE INTO TABLE t1 LINES TERMINATED BY '\n';
 SELECT COUNT(*) AS EXPECT_6 FROM t1;
@@ -22,6 +22,6 @@ SELECT COUNT(*) AS EXPECT_12 FROM t1;
 --connection node_1
 DROP TABLE t1;
 SET GLOBAL wsrep_load_data_splitting=OFF;
-SET GLOBAL wsrep_replicate_myisam=OFF;
+SET GLOBAL wsrep_mode=DEFAULT;
 
 

--- a/mysql-test/suite/galera/t/galera_ist_mariabackup_verify_ca.cnf
+++ b/mysql-test/suite/galera/t/galera_ist_mariabackup_verify_ca.cnf
@@ -10,9 +10,11 @@ ssl-ca=@ENV.MYSQL_TEST_DIR/std_data/cacert.pem
 
 [mysqld.1]
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;pc.ignore_sb=true'
+innodb-log-file-buffering
 
 [mysqld.2]
 wsrep_provider_options='base_port=@mysqld.2.#galera_port;pc.ignore_sb=true'
+innodb-log-file-buffering
 
 [sst]
 ssl-mode=VERIFY_CA

--- a/mysql-test/suite/galera/t/galera_wan_restart_sst.test
+++ b/mysql-test/suite/galera/t/galera_wan_restart_sst.test
@@ -11,6 +11,7 @@
 --source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 --connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4
@@ -27,7 +28,7 @@
 SELECT VARIABLE_VALUE AS EXPECT_4 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
 
 --connection node_1
-CREATE TABLE t1 (f1 INTEGER);
+CREATE TABLE t1 (f1 INTEGER NOT NULL PRIMARY KEY) ENGINE=INNODB;
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
@@ -45,10 +46,20 @@ INSERT INTO t1 VALUES (4);
 
 --connection node_3
 INSERT INTO t1 VALUES (13);
-
---source include/kill_galera.inc
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1;
+--source include/wait_condition.inc
 
 --connection node_1
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_3
+--source include/kill_galera.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.3/data/grastate.dat
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
 INSERT INTO t1 VALUES (11);
 
 --connection node_2
@@ -62,6 +73,10 @@ INSERT INTO t1 VALUES (14);
 
 INSERT INTO t1 VALUES (131);
 
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 4 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
 #
 # Restart node #2
 #
@@ -69,9 +84,17 @@ INSERT INTO t1 VALUES (131);
 --connection node_2
 INSERT INTO t1 VALUES (22);
 
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_2
 --source include/kill_galera.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.2/data/grastate.dat
 
 --connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
 INSERT INTO t1 VALUES (21);
 
 --connection node_3
@@ -90,11 +113,21 @@ INSERT INTO t1 VALUES (221);
 #
 
 --connection node_4
+--let $wait_condition = SELECT VARIABLE_VALUE = 4 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
 INSERT INTO t1 VALUES (34);
 
+--connection node_1
+--let $wait_condition = SELECT COUNT(*) = 15 FROM t1;
+--source include/wait_condition.inc
+
+--connection node_4
 --source include/kill_galera.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.4/data/grastate.dat
 
 --connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
 INSERT INTO t1 VALUES (31);
 
 --connection node_2
@@ -105,6 +138,7 @@ INSERT INTO t1 VALUES (33);
 
 --connection node_4
 --source include/start_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.4/data/grastate.dat
 
 INSERT INTO t1 VALUES (341);
 

--- a/mysql-test/suite/galera/t/rpl_galera_to_mariadb_clone_slave_using_mariadb-backup.cnf
+++ b/mysql-test/suite/galera/t/rpl_galera_to_mariadb_clone_slave_using_mariadb-backup.cnf
@@ -1,1 +1,10 @@
 !include ../galera_2nodes_as_master.cnf
+
+[mysqld.1]
+innodb-log-file-buffering
+
+[mysqld.2]
+innodb-log-file-buffering
+
+[mysqld.3]
+innodb-log-file-buffering

--- a/mysql-test/suite/galera_3nodes/r/galera_allowlist.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_allowlist.result
@@ -7,6 +7,9 @@ connection node_2;
 SELECT COUNT(*) = 3 FROM mysql.wsrep_allowlist;
 COUNT(*) = 3
 1
+connection node_1;
+connection node_2;
+connection node_3;
 connection node_3;
 SET @@global.wsrep_desync = 1;
 SET SESSION wsrep_sync_wait = 0;

--- a/mysql-test/suite/galera_3nodes/t/galera_allowlist.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_allowlist.test
@@ -12,6 +12,12 @@ SELECT COUNT(*) = 3 FROM mysql.wsrep_allowlist;
 --let $galera_server_number = 3
 --source include/galera_connect.inc
 
+# Save original auto_increment_offset values.
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source ../galera/include/auto_increment_offset_save.inc
+
 --connection node_3
 # Desync and disconnect node 3 from the PC:
 SET @@global.wsrep_desync = 1;
@@ -64,3 +70,6 @@ CALL mtr.add_suppression('WSREP: Connection not allowed');
 
 --connection node_3
 CALL mtr.add_suppression('WSREP: Ignoring lack of quorum');
+
+# Restore original auto_increment_offset values.
+--source ../galera/include/auto_increment_offset_restore.inc

--- a/mysql-test/suite/galera_3nodes_sr/r/GCF-832.result
+++ b/mysql-test/suite/galera_3nodes_sr/r/GCF-832.result
@@ -6,20 +6,26 @@ connection node_2;
 connection node_3;
 connection node_2;
 SET GLOBAL debug_dbug="d,crash_last_fragment_commit_after_fragment_removal";
-CREATE TABLE t1 (f1 VARCHAR(30)) ENGINE=InnoDB;
+CREATE TABLE t1 (f1 VARCHAR(30) not null primary key) ENGINE=InnoDB;
 SET AUTOCOMMIT=OFF;
 SET SESSION wsrep_trx_fragment_size=1;
 START TRANSACTION;
-INSERT INTO t1 VALUES ('primary'),('primary'),('primary'),('primary'),('primary');
+INSERT INTO t1 VALUES ('primary1'),('primary2'),('primary3'),('primary4'),('primary5');
 COMMIT;
 Got one of the listed errors
+connection node_1;
+connection node_2;
 # restart
 connection node_1;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) = 0
 1
+SELECT * FROM t1;
+f1
 connection node_2;
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
 COUNT(*) = 0
 1
+SELECT * FROM t1;
+f1
 DROP TABLE t1;

--- a/mysql-test/suite/galera_3nodes_sr/r/galera_sr_kill_slave_before_apply.result
+++ b/mysql-test/suite/galera_3nodes_sr/r/galera_sr_kill_slave_before_apply.result
@@ -44,6 +44,7 @@ connection node_2;
 SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
 EXPECT_0
 0
+call mtr.add_suppression("WSREP: node uuid:.*");
 connection node_1;
 DROP TABLE t1;
 DROP TABLE t2;

--- a/mysql-test/suite/galera_3nodes_sr/t/GCF-832.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/GCF-832.test
@@ -4,6 +4,7 @@
 #
 --source include/galera_cluster.inc
 --source include/have_debug_sync.inc
+--source include/force_restart.inc
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 # Save original auto_increment_offset values.
@@ -13,30 +14,42 @@
 --source ../galera/include/auto_increment_offset_save.inc
 
 --connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
 SET GLOBAL debug_dbug="d,crash_last_fragment_commit_after_fragment_removal";
 
 --let $_expect_file_name= `select regexp_replace(@@tmpdir, '^.*/','')`
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/$_expect_file_name.expect
 --exec echo "wait" > $_expect_file_name
 
-CREATE TABLE t1 (f1 VARCHAR(30)) ENGINE=InnoDB;
+CREATE TABLE t1 (f1 VARCHAR(30) not null primary key) ENGINE=InnoDB;
 
 SET AUTOCOMMIT=OFF;
 SET SESSION wsrep_trx_fragment_size=1;
 START TRANSACTION;
 
-INSERT INTO t1 VALUES ('primary'),('primary'),('primary'),('primary'),('primary');
+INSERT INTO t1 VALUES ('primary1'),('primary2'),('primary3'),('primary4'),('primary5');
 --error 2013,2026
 COMMIT;
 
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
+
+--connection node_2
 --source include/start_mysqld.inc
 
 --connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--source include/wait_condition.inc
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
+SELECT * FROM t1;
 
 --connection node_2
 --enable_reconnect
 SELECT COUNT(*) = 0 FROM mysql.wsrep_streaming_log;
+SELECT * FROM t1;
 
 DROP TABLE t1;
 

--- a/mysql-test/suite/galera_3nodes_sr/t/galera_sr_kill_slave_before_apply.test
+++ b/mysql-test/suite/galera_3nodes_sr/t/galera_sr_kill_slave_before_apply.test
@@ -6,6 +6,7 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 --connect node_3, 127.0.0.1, root, , test, $NODE_MYPORT_3
 # Save original auto_increment_offset values.
@@ -86,6 +87,8 @@ SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
 
 --connection node_2
 SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+# As noted above sometimes node delivers the same view twice
+call mtr.add_suppression("WSREP: node uuid:.*");
 
 --connection node_1
 DROP TABLE t1;


### PR DESCRIPTION
Changes to be committed:
	modified:   mysql-test/suite/galera/r/MDEV-25731.result
	modified:   mysql-test/suite/galera/t/MDEV-25731.test
	modified:   mysql-test/suite/galera/t/galera_ist_mariabackup_verify_ca.test
	modified:   mysql-test/suite/galera_3nodes/r/galera_allowlist.result
	modified:   mysql-test/suite/galera_3nodes/t/galera_allowlist.test

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
