### PR TITLE
Check if OS_DATA_FILE_NO_O_DIRECT is defined before using it

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -2418,7 +2418,12 @@ static bool innodb_init()
   os_file_delete_if_exists_func(ib_logfile0.c_str(), nullptr);
   os_file_t file= os_file_create_func(ib_logfile0.c_str(),
                                       OS_FILE_CREATE, OS_FILE_NORMAL,
-                                      OS_DATA_FILE_NO_O_DIRECT, false, &ret);
+#if defined _WIN32 || defined HAVE_FCNTL_DIRECT
+                                      OS_DATA_FILE_NO_O_DIRECT,
+#else
+                                      OS_DATA_FILE,
+#endif
+                                      false, &ret);
   if (!ret)
   {
   invalid_log:

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -1408,12 +1408,19 @@ ATTRIBUTE_COLD void fil_space_t::reopen_all()
       if (!node->is_open())
         continue;
 
-      ulint type= OS_DATA_FILE;
-
-      switch (FSP_FLAGS_GET_ZIP_SSIZE(space.flags)) {
-      case 1: case 2:
+#if defined _WIN32 || defined HAVE_FCNTL_DIRECT
+      ulint type;
+      switch (FSP_FLAGS_GET_ZIP_SSIZE(node->space->flags)) {
+      case 1:
+      case 2:
         type= OS_DATA_FILE_NO_O_DIRECT;
+        break;
+      default:
+        type= OS_DATA_FILE;
       }
+#else
+      constexpr auto type= OS_DATA_FILE;
+#endif
 
       for (ulint count= 10000; count--;)
       {


### PR DESCRIPTION
## Description
When building on MacOS (clang 15) `OS_DATA_FILE_NO_O_DIRECT` isn't defined:

```
  >> 4543    /mariadb/extra/mariabackup/xtrabackup.cc:2421:39: error: use of undeclared identifier 'OS_DATA_FILE_NO_O_DIRECT'
     4544                                          OS_DATA_FILE_NO_O_DIRECT, false, &ret);
```

This PR changes two files to allow compilation on MacOS. In both cases I just made a similar check to those already being done in `fil0fil.cc`.

## Release Notes
- Check if OS_DATA_FILE_NO_O_DIRECT is defined before using it, fixing compilation on MacOS

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.