### PR TITLE
MDEV-33010 Condition with CHARSET()/COERCIBILITY() erroneously pushed…

### DIFF
--- a/mysql-test/main/derived_cond_pushdown_innodb.result
+++ b/mysql-test/main/derived_cond_pushdown_innodb.result
@@ -1,0 +1,39 @@
+#
+# MDEV-33010: Crash when pushing condition with CHARSET()/COERCIBILITY()
+#             into derived table
+#
+CREATE TABLE t1 (c1 BIGINT, KEY (c1)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+CREATE TABLE t2 (c2 DOUBLE UNSIGNED);
+INSERT INTO t2 VALUES (1);
+SET optimizer_switch='derived_merge=off';
+EXPLAIN EXTENDED
+SELECT dt1_c1 FROM
+(SELECT c1 AS dt1_c1 FROM t1) AS dt1
+JOIN
+(SELECT 1 AS dt2_c2 FROM t2) AS dt2
+ON CHARSET(dt2_c2) BETWEEN dt1_c1 AND dt1_c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived3>	system	NULL	NULL	NULL	NULL	1	100.00	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+3	DERIVED	t2	system	NULL	NULL	NULL	NULL	1	100.00	
+2	DERIVED	t1	ref	c1	c1	9	const	1	100.00	Using where; Using index
+Warnings:
+Warning	1292	Truncated incorrect DECIMAL value: 'binary'
+Note	1003	/* select#1 */ select `dt1`.`dt1_c1` AS `dt1_c1` from (/* select#2 */ select `test`.`t1`.`c1` AS `dt1_c1` from `test`.`t1` where <cache>(charset(1)) between `test`.`t1`.`c1` and `test`.`t1`.`c1`) `dt1` where <cache>(charset(1)) between `dt1`.`dt1_c1` and `dt1`.`dt1_c1`
+EXPLAIN EXTENDED
+SELECT dt1_c1 FROM
+(SELECT c1 AS dt1_c1 FROM t1) AS dt1
+JOIN
+(SELECT 1 AS dt2_c2 FROM t2) AS dt2
+ON COERCIBILITY(dt2_c2) BETWEEN dt1_c1 AND dt1_c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	<derived3>	system	NULL	NULL	NULL	NULL	1	100.00	
+1	PRIMARY	<derived2>	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where
+3	DERIVED	t2	system	NULL	NULL	NULL	NULL	1	100.00	
+2	DERIVED	t1	ref	c1	c1	9	const	1	100.00	Using where; Using index
+Warnings:
+Note	1003	/* select#1 */ select `dt1`.`dt1_c1` AS `dt1_c1` from (/* select#2 */ select `test`.`t1`.`c1` AS `dt1_c1` from `test`.`t1` where <cache>(coercibility(1)) between `test`.`t1`.`c1` and `test`.`t1`.`c1`) `dt1` where <cache>(coercibility(1)) between `dt1`.`dt1_c1` and `dt1`.`dt1_c1`
+SET optimizer_switch=DEFAULT;
+DROP TABLE t1, t2;
+# End of 10.4 tests

--- a/mysql-test/main/derived_cond_pushdown_innodb.test
+++ b/mysql-test/main/derived_cond_pushdown_innodb.test
@@ -1,0 +1,31 @@
+--source include/have_innodb.inc
+
+--echo #
+--echo # MDEV-33010: Crash when pushing condition with CHARSET()/COERCIBILITY()
+--echo #             into derived table
+--echo #
+CREATE TABLE t1 (c1 BIGINT, KEY (c1)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+CREATE TABLE t2 (c2 DOUBLE UNSIGNED);
+INSERT INTO t2 VALUES (1);
+
+SET optimizer_switch='derived_merge=off';
+
+EXPLAIN EXTENDED
+  SELECT dt1_c1 FROM
+    (SELECT c1 AS dt1_c1 FROM t1) AS dt1
+    JOIN
+    (SELECT 1 AS dt2_c2 FROM t2) AS dt2
+      ON CHARSET(dt2_c2) BETWEEN dt1_c1 AND dt1_c1;
+
+EXPLAIN EXTENDED
+     SELECT dt1_c1 FROM
+       (SELECT c1 AS dt1_c1 FROM t1) AS dt1
+       JOIN
+       (SELECT 1 AS dt2_c2 FROM t2) AS dt2
+          ON COERCIBILITY(dt2_c2) BETWEEN dt1_c1 AND dt1_c1;
+
+SET optimizer_switch=DEFAULT;
+DROP TABLE t1, t2;
+
+--echo # End of 10.4 tests

--- a/mysql-test/main/olap.result
+++ b/mysql-test/main/olap.result
@@ -787,18 +787,12 @@ DROP TABLE t1;
 #
 # MDEV-17830 Server crashes in Item_null_result::field_type upon SELECT with CHARSET(date) and ROLLUP
 #
-# Note, different MariaDB versions can return different results
-# in the two rows (such as "latin1" vs "binary"). This is wrong.
-# Both lines should return equal values.
-# The point in this test is to make sure it does not crash.
-# As this is a minor issue, bad result will be fixed
-# in a later version, presumably in 10.4.
 CREATE TABLE t (d DATE) ENGINE=MyISAM;
 INSERT INTO t VALUES ('2018-12-12');
 SELECT CHARSET(d) AS f FROM t GROUP BY d WITH ROLLUP;
 f
 binary
-latin1
+binary
 DROP TABLE t;
 #
 # MDEV-14041 Server crashes in String::length on queries with functions and ROLLUP

--- a/mysql-test/main/olap.test
+++ b/mysql-test/main/olap.test
@@ -433,13 +433,6 @@ DROP TABLE t1;
 --echo # MDEV-17830 Server crashes in Item_null_result::field_type upon SELECT with CHARSET(date) and ROLLUP
 --echo #
 
---echo # Note, different MariaDB versions can return different results
---echo # in the two rows (such as "latin1" vs "binary"). This is wrong.
---echo # Both lines should return equal values.
---echo # The point in this test is to make sure it does not crash.
---echo # As this is a minor issue, bad result will be fixed
---echo # in a later version, presumably in 10.4.
-
 CREATE TABLE t (d DATE) ENGINE=MyISAM;
 INSERT INTO t VALUES ('2018-12-12');
 SELECT CHARSET(d) AS f FROM t GROUP BY d WITH ROLLUP;

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -3143,11 +3143,27 @@ longlong Item_func_char_length::val_int()
 }
 
 
+bool Item_func_coercibility::fix_length_and_dec()
+{
+  max_length=10;
+  maybe_null= 0;
+  /*
+    Since this is a const item which doesn't use tables (see used_tables()),
+    we don't want to access the function arguments during execution.
+    That's why we store the derivation here during the preparation phase
+    and only return it later at the execution phase
+  */
+  DBUG_ASSERT(args[0]->is_fixed());
+  m_cached_collation_derivation= (longlong) args[0]->collation.derivation;
+  return false;
+}
+
+
 longlong Item_func_coercibility::val_int()
 {
   DBUG_ASSERT(fixed == 1);
   null_value= 0;
-  return (longlong) args[0]->collation.derivation;
+  return m_cached_collation_derivation;
 }
 
 

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -2285,13 +2285,15 @@ public:
 
 class Item_func_coercibility :public Item_long_func
 {
+  longlong m_cached_collation_derivation;
+
   bool check_arguments() const override
   { return args[0]->check_type_can_return_str(func_name()); }
 public:
   Item_func_coercibility(THD *thd, Item *a): Item_long_func(thd, a) {}
   longlong val_int() override;
   const char *func_name() const override { return "coercibility"; }
-  bool fix_length_and_dec() override { max_length=10; maybe_null= 0; return FALSE; }
+  bool fix_length_and_dec() override;
   bool eval_not_null_tables(void *) override
   {
     not_null_tables_cache= 0;
@@ -2306,6 +2308,7 @@ public:
   bool const_item() const override { return true; }
   Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_coercibility>(thd, this); }
+  table_map used_tables() const override { return 0; }
 };
 
 

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -3625,9 +3625,8 @@ String *Item_func_charset::val_str(String *str)
   DBUG_ASSERT(fixed == 1);
   uint dummy_errors;
 
-  CHARSET_INFO *cs= args[0]->charset_for_protocol(); 
   null_value= 0;
-  str->copy(cs->csname, (uint) strlen(cs->csname),
+  str->copy(m_cached_charset_info.str, m_cached_charset_info.length,
 	    &my_charset_latin1, collation.collation, &dummy_errors);
   return str;
 }


### PR DESCRIPTION
… into derived table

Based on the current logic, objects of classes Item_func_charset and Item_func_coercibility (responsible for CHARSET() and COERCIBILITY() functions) are always considered const.
However, SQL syntax allows their use in a non-constant manner, such as CHARSET(t1.a), COERCIBILITY(t1.a), and similar.

This "const-forcing" was introduced with
commit aa1002a35cefcc1851cbfb6b6b60463bda6f9aa3.

When those objects are erroneously deemed const, it could lead to unwanted consequences like pushing down conditions to materialized derived tables illegitimately.

This commits removes the "const-forcing" for Item_func_charset and Item_func_coercibility, making them determine their constness in the general way

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_33010*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
