### PR TITLE
MDEV-33803 Error 4162 "Operator does not exists" is incorrectly-worded

### DIFF
--- a/mysql-test/main/gis.result
+++ b/mysql-test/main/gis.result
@@ -5072,37 +5072,37 @@ ERROR 42000: Incorrect parameter count in the call to native function 'WITHIN(PO
 # MDEV-20009 Add CAST(expr AS pluggable_type)
 #
 SELECT CAST(1 AS GEOMETRY);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometry)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometry)'
 SELECT CAST(1 AS GEOMETRYCOLLECTION);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometrycollection)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometrycollection)'
 SELECT CAST(1 AS POINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS point)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS point)'
 SELECT CAST(1 AS LINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS linestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS linestring)'
 SELECT CAST(1 AS POLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS polygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS polygon)'
 SELECT CAST(1 AS MULTIPOINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipoint)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipoint)'
 SELECT CAST(1 AS MULTILINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multilinestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multilinestring)'
 SELECT CAST(1 AS MULTIPOLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipolygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipolygon)'
 SELECT CONVERT(1, GEOMETRY);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometry)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometry)'
 SELECT CONVERT(1, GEOMETRYCOLLECTION);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometrycollection)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometrycollection)'
 SELECT CONVERT(1, POINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS point)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS point)'
 SELECT CONVERT(1, LINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS linestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS linestring)'
 SELECT CONVERT(1, POLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS polygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS polygon)'
 SELECT CONVERT(1, MULTIPOINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipoint)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipoint)'
 SELECT CONVERT(1, MULTILINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multilinestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multilinestring)'
 SELECT CONVERT(1, MULTIPOLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipolygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipolygon)'
 #
 # MDEV-17832 Protocol: extensions for Pluggable types and JSON, GEOMETRY
 #

--- a/mysql-test/suite/compat/oracle/r/gis.result
+++ b/mysql-test/suite/compat/oracle/r/gis.result
@@ -33,37 +33,37 @@ ERROR 42000: Incorrect parameter count in the call to native function 'WITHIN(PO
 # MDEV-20009 Add CAST(expr AS pluggable_type)
 #
 SELECT CAST(1 AS GEOMETRY);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometry)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometry)'
 SELECT CAST(1 AS GEOMETRYCOLLECTION);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometrycollection)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometrycollection)'
 SELECT CAST(1 AS POINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS point)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS point)'
 SELECT CAST(1 AS LINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS linestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS linestring)'
 SELECT CAST(1 AS POLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS polygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS polygon)'
 SELECT CAST(1 AS MULTIPOINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipoint)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipoint)'
 SELECT CAST(1 AS MULTILINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multilinestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multilinestring)'
 SELECT CAST(1 AS MULTIPOLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipolygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipolygon)'
 SELECT CONVERT(1, GEOMETRY);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometry)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometry)'
 SELECT CONVERT(1, GEOMETRYCOLLECTION);
-ERROR HY000: Operator does not exists: 'CAST(expr AS geometrycollection)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS geometrycollection)'
 SELECT CONVERT(1, POINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS point)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS point)'
 SELECT CONVERT(1, LINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS linestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS linestring)'
 SELECT CONVERT(1, POLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS polygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS polygon)'
 SELECT CONVERT(1, MULTIPOINT);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipoint)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipoint)'
 SELECT CONVERT(1, MULTILINESTRING);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multilinestring)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multilinestring)'
 SELECT CONVERT(1, MULTIPOLYGON);
-ERROR HY000: Operator does not exists: 'CAST(expr AS multipolygon)'
+ERROR HY000: Operator does not exist: 'CAST(expr AS multipolygon)'
 #
 # End of 10.5 tests
 #

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -9082,7 +9082,7 @@ ER_TOO_LONG_DATABASE_COMMENT
 ER_UNKNOWN_DATA_TYPE
         eng "Unknown data type: '%-.64s'"
 ER_UNKNOWN_OPERATOR
-        eng "Operator does not exists: '%-.128s'"
+        eng "Operator does not exist: '%-.128s'"
 ER_WARN_HISTORY_ROW_START_TIME
         eng "Table `%s.%s` history row start '%s' is later than row end '%s'"
 ER_PART_STARTS_BEYOND_INTERVAL


### PR DESCRIPTION
"Operator does not exists" should rather read "Operator does not exist".

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33803*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This PR fixes the error message. "Operator does not exists" should rather read "Operator does not exist".

## Release Notes
n/a

## How can this PR be tested?
Use the existing test suite
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
