### PR TITLE
Add cpu-limit option for mini-benchmark

### DIFF
--- a/support-files/mini-benchmark.sh
+++ b/support-files/mini-benchmark.sh
@@ -310,4 +310,4 @@ case $RESULT in
 esac
 # Record the output into the log file, if requested
 ) 2>&1 | ($LOG && tee "$BENCHMARK_NAME"-"$TIMESTAMP".log)
-
+exit ${PIPESTATUS[0]} # Propagate errors in the sub-shell

--- a/support-files/mini-benchmark.sh
+++ b/support-files/mini-benchmark.sh
@@ -26,6 +26,8 @@ display_help() {
   echo "                     sysbench runs"
   echo "  --perf-flamegraph  record performance counters in perf.data.* and"
   echo "                     generate flamegraphs automatically"
+  echo "  --cpu-limit        upper limit on the number of CPU cycles (in billions) used for the benchmark"
+  echo "                     default: 750"
   echo "  -h, --help         display this help and exit"
 }
 
@@ -77,6 +79,11 @@ do
       ;;
     --perf-flamegraph)
       PERF_RECORD=true
+      shift
+      ;;
+    --cpu-limit)
+      shift
+      CPU_CYCLE_LIMIT=$1
       shift
       ;;
     -*)
@@ -247,12 +254,21 @@ then
   echo "Total: $(grep -h -e instructions sysbench-run-*.log | sort -k 1 | awk '{s+=$1}END{print s}')"
   echo # Newline improves readability
 
+  if [ -z "$CPU_CYCLE_LIMIT" ]
+  then 
+     # 04-04-2024: We found this to be an appropriate default limit after running a few benchmarks
+     # Configure the limit with --cpu-limit if needed
+    CPU_CYCLE_LIMIT=750
+  fi
+  CPU_CYCLE_LIMIT_LONG="${CPU_CYCLE_LIMIT}000000000"
+
   # Final verdict based on cpu cycle count
   RESULT="$(grep -h -e cycles sysbench-run-*.log | sort -k 1 | awk '{s+=$1}END{print s}')"
-  if [ "$RESULT" -gt 850 ]
+  if [ "$RESULT" -gt "$CPU_CYCLE_LIMIT_LONG" ]
   then
     echo # Newline improves readability
-    echo "Benchmark exceeded 850 billion cpu cycles, performance most likely regressed!"
+    echo "Benchmark exceeded the allowed limit of ${CPU_CYCLE_LIMIT} billion CPU cycles"
+    echo "Performance most likely regressed!"
     exit 1
   fi
 fi


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Enable configuration of CPU cycle limit for mini-benchmark

As performance improves, the permitted number of CPU cycles to be used
during the benchmark should be lowered to catch performance regressions. An
option `--cpu-limit` is added to better support this.

Additionally, there is a minor fix to the exit behavior of mini-benchmark when an error is encountered.

## Release Notes

None

## How can this PR be tested?
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

This can be tested by installing MariaDB in a docker container and executing `./support-files/mini-benchmark.sh`

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
