### PR TITLE
MDEV-14231  MATCH() AGAINST( IN BOOLEAN MODE), results mismatch

### DIFF
--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -543,6 +543,7 @@ typedef struct st_mysql_ftparser_boolean_info
   int weight_adjust;
   char wasign;
   char trunc;
+  int position;
   char prev;
   char *quot;
 } MYSQL_FTPARSER_BOOLEAN_INFO;

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -543,6 +543,7 @@ typedef struct st_mysql_ftparser_boolean_info
   int weight_adjust;
   char wasign;
   char trunc;
+  int position;
   char prev;
   char *quot;
 } MYSQL_FTPARSER_BOOLEAN_INFO;

--- a/include/mysql/plugin_encryption.h.pp
+++ b/include/mysql/plugin_encryption.h.pp
@@ -543,6 +543,7 @@ typedef struct st_mysql_ftparser_boolean_info
   int weight_adjust;
   char wasign;
   char trunc;
+  int position;
   char prev;
   char *quot;
 } MYSQL_FTPARSER_BOOLEAN_INFO;

--- a/include/mysql/plugin_ftparser.h
+++ b/include/mysql/plugin_ftparser.h
@@ -124,6 +124,7 @@ typedef struct st_mysql_ftparser_boolean_info
   int weight_adjust;
   char wasign;
   char trunc;
+  int position;
   /* These are parser state and must be removed. */
   char prev;
   char *quot;

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -585,6 +585,7 @@ typedef struct st_mysql_ftparser_boolean_info
   int weight_adjust;
   char wasign;
   char trunc;
+  int position;
   char prev;
   char *quot;
 } MYSQL_FTPARSER_BOOLEAN_INFO;

--- a/include/mysql/plugin_password_validation.h.pp
+++ b/include/mysql/plugin_password_validation.h.pp
@@ -543,6 +543,7 @@ typedef struct st_mysql_ftparser_boolean_info
   int weight_adjust;
   char wasign;
   char trunc;
+  int position;
   char prev;
   char *quot;
 } MYSQL_FTPARSER_BOOLEAN_INFO;

--- a/mysql-test/suite/innodb_fts/r/multiple_index.result
+++ b/mysql-test/suite/innodb_fts/r/multiple_index.result
@@ -1,0 +1,211 @@
+drop table if exists t1;
+CREATE TABLE t1 (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+a VARCHAR(200),
+b TEXT
+) ENGINE = InnoDB STATS_PERSISTENT=0;
+INSERT INTO t1 (a,b) VALUES
+('MySQL Tutorial','DBMS stands for DataBase ...')  ,
+('How To Use MySQL Well','After you went through a ...'),
+('Optimizing MySQL','In this tutorial we will show ...');
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_1 (a);
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_2 (b);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `a` varchar(200) DEFAULT NULL,
+  `b` text DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  FULLTEXT KEY `idx_1` (`a`),
+  FULLTEXT KEY `idx_2` (`b`)
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci STATS_PERSISTENT=0
+START TRANSACTION;
+INSERT INTO t1 (a,b) VALUES
+('1001 MySQL Tricks','1. Never run mysqld as root. 2. ...'),
+('MySQL vs. YourSQL','In the following database comparison ...'),
+('MySQL Security','When configured properly, MySQL ...');
+ROLLBACK;
+SELECT * FROM t1 WHERE MATCH (a)
+AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(a) AGAINST("+mysql +Tutorial" IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(b) AGAINST("+Tutorial" IN BOOLEAN MODE);
+id	a	b
+3	Optimizing MySQL	In this tutorial we will show ...
+select * from t1 where MATCH(b) AGAINST("+stands +(DataBase)" IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(b) AGAINST("+DataBase -(comparison)" IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select *, MATCH(a) AGAINST("Optimizing MySQL" IN BOOLEAN MODE) as x from t1;
+id	a	b	x
+1	MySQL Tutorial	DBMS stands for DataBase ...	0.000000001885928302414186
+2	How To Use MySQL Well	After you went through a ...	0.000000001885928302414186
+3	Optimizing MySQL	In this tutorial we will show ...	0.22764469683170319
+select *, MATCH(b) AGAINST("collections support" IN BOOLEAN MODE) as x from t1;
+id	a	b	x
+1	MySQL Tutorial	DBMS stands for DataBase ...	0
+2	How To Use MySQL Well	After you went through a ...	0
+3	Optimizing MySQL	In this tutorial we will show ...	0
+select * from t1 where MATCH a AGAINST ("+Optimiz* +Optimiz*" IN BOOLEAN MODE);
+id	a	b
+3	Optimizing MySQL	In this tutorial we will show ...
+select * from t1 where MATCH b AGAINST ('"DBMS stands"' IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH b AGAINST ('"DBMS STANDS"' IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(b) AGAINST ("DataBase" WITH QUERY EXPANSION);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(a) AGAINST ("Security" WITH QUERY EXPANSION);
+id	a	b
+ALTER TABLE t1 DROP INDEX idx_1;
+ALTER TABLE t1 DROP INDEX idx_2;
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_1 (a);
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_2 (b);
+SELECT * FROM t1 WHERE MATCH (a)
+AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(a) AGAINST("+mysql +Tutorial" IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(b) AGAINST("+Tutorial" IN BOOLEAN MODE);
+id	a	b
+3	Optimizing MySQL	In this tutorial we will show ...
+select * from t1 where MATCH(b) AGAINST("+stands +(DataBase)" IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(b) AGAINST("+DataBase -(comparison)" IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select *, MATCH(a) AGAINST("Optimizing MySQL" IN BOOLEAN MODE) as x from t1;
+id	a	b	x
+1	MySQL Tutorial	DBMS stands for DataBase ...	0.000000001885928302414186
+2	How To Use MySQL Well	After you went through a ...	0.000000001885928302414186
+3	Optimizing MySQL	In this tutorial we will show ...	0.22764469683170319
+select *, MATCH(b) AGAINST("collections support" IN BOOLEAN MODE) as x from t1;
+id	a	b	x
+1	MySQL Tutorial	DBMS stands for DataBase ...	0
+2	How To Use MySQL Well	After you went through a ...	0
+3	Optimizing MySQL	In this tutorial we will show ...	0
+select * from t1 where MATCH a AGAINST ("+Optimiz* +Optimiz*" IN BOOLEAN MODE);
+id	a	b
+3	Optimizing MySQL	In this tutorial we will show ...
+select * from t1 where MATCH b AGAINST ('"DBMS stands"' IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH b AGAINST ('"DBMS STANDS"' IN BOOLEAN MODE);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(b) AGAINST ("DataBase" WITH QUERY EXPANSION);
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+select * from t1 where MATCH(a) AGAINST ("Security" WITH QUERY EXPANSION);
+id	a	b
+INSERT INTO t1 (a,b) VALUES ('test query expansion','for database ...');
+INSERT INTO t1 (a,b) VALUES
+('test proximity search, test, proximity and phrase',
+'search, with proximity innodb');
+INSERT INTO t1 (a,b) VALUES
+('test proximity fts search, test, proximity and phrase',
+'search, with proximity innodb');
+INSERT INTO t1 (a,b) VALUES
+('test more of proximity for fts search, test, more proximity and phrase',
+'search, with proximity innodb');
+SELECT * FROM t1
+WHERE MATCH (a)
+AGAINST ('"proximity search"@3' IN BOOLEAN MODE);
+id	a	b
+8	test proximity search, test, proximity and phrase	search, with proximity innodb
+9	test proximity fts search, test, proximity and phrase	search, with proximity innodb
+SELECT * FROM t1
+WHERE MATCH (a)
+AGAINST ('"proximity search"@2' IN BOOLEAN MODE);
+id	a	b
+8	test proximity search, test, proximity and phrase	search, with proximity innodb
+SELECT * FROM t1
+WHERE MATCH (b)
+AGAINST ('"proximity innodb"@4' IN BOOLEAN MODE);
+id	a	b
+8	test proximity search, test, proximity and phrase	search, with proximity innodb
+9	test proximity fts search, test, proximity and phrase	search, with proximity innodb
+10	test more of proximity for fts search, test, more proximity and phrase	search, with proximity innodb
+SELECT * FROM t1
+WHERE MATCH (a)
+AGAINST ('"test proximity"@3' IN BOOLEAN MODE);
+id	a	b
+8	test proximity search, test, proximity and phrase	search, with proximity innodb
+9	test proximity fts search, test, proximity and phrase	search, with proximity innodb
+10	test more of proximity for fts search, test, more proximity and phrase	search, with proximity innodb
+SELECT * FROM t1
+WHERE MATCH (a)
+AGAINST ('"more test proximity"@3' IN BOOLEAN MODE);
+id	a	b
+10	test more of proximity for fts search, test, more proximity and phrase	search, with proximity innodb
+SELECT * FROM t1
+WHERE MATCH (a)
+AGAINST ('"more test proximity"@2' IN BOOLEAN MODE);
+id	a	b
+SELECT * FROM t1
+WHERE MATCH (a)
+AGAINST ('"more fts proximity"@02' IN BOOLEAN MODE);
+id	a	b
+SELECT * FROM t1 WHERE CONCAT(t1.a,t1.b) IN (
+SELECT CONCAT(a,b) FROM t1 AS t2 WHERE
+MATCH (t2.a) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+) OR t1.id = 3 ;
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+3	Optimizing MySQL	In this tutorial we will show ...
+SELECT * FROM t1 WHERE CONCAT(t1.a,t1.b) IN (
+SELECT CONCAT(a,b) FROM t1 AS t2
+WHERE MATCH (t2.a) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+AND t2.id != 3) ;
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+SELECT * FROM t1 WHERE id IN (SELECT MIN(id) FROM t1 WHERE
+MATCH (b) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)) OR id = 3 ;
+id	a	b
+3	Optimizing MySQL	In this tutorial we will show ...
+SELECT * FROM t1 WHERE id NOT IN (SELECT MIN(id) FROM t1
+WHERE MATCH (b) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)) ;
+id	a	b
+1	MySQL Tutorial	DBMS stands for DataBase ...
+2	How To Use MySQL Well	After you went through a ...
+7	test query expansion	for database ...
+8	test proximity search, test, proximity and phrase	search, with proximity innodb
+9	test proximity fts search, test, proximity and phrase	search, with proximity innodb
+10	test more of proximity for fts search, test, more proximity and phrase	search, with proximity innodb
+SELECT * FROM t1 WHERE EXISTS (SELECT t2.id FROM t1 AS t2 WHERE
+MATCH (t2.b) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+AND t1.id = t2.id) ;
+id	a	b
+3	Optimizing MySQL	In this tutorial we will show ...
+SELECT * FROM t1 WHERE NOT EXISTS (SELECT t2.id FROM t1 AS t2 WHERE
+MATCH (t2.a) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+AND t1.id = t2.id) ;
+id	a	b
+2	How To Use MySQL Well	After you went through a ...
+3	Optimizing MySQL	In this tutorial we will show ...
+7	test query expansion	for database ...
+8	test proximity search, test, proximity and phrase	search, with proximity innodb
+9	test proximity fts search, test, proximity and phrase	search, with proximity innodb
+10	test more of proximity for fts search, test, more proximity and phrase	search, with proximity innodb
+SELECT * FROM t1 WHERE t1.id = (SELECT MAX(t2.id) FROM t1 AS t2 WHERE
+MATCH(t2.a) AGAINST ('"proximity search"@3' IN BOOLEAN MODE));
+id	a	b
+9	test proximity fts search, test, proximity and phrase	search, with proximity innodb
+SELECT * FROM t1 WHERE t1.id > (SELECT MIN(t2.id) FROM t1 AS t2 WHERE
+MATCH(t2.b) AGAINST ('"proximity innodb"@3' IN BOOLEAN MODE));
+id	a	b
+9	test proximity fts search, test, proximity and phrase	search, with proximity innodb
+10	test more of proximity for fts search, test, more proximity and phrase	search, with proximity innodb
+DROP TABLE t1;

--- a/mysql-test/suite/innodb_fts/r/plugin_debug.result
+++ b/mysql-test/suite/innodb_fts/r/plugin_debug.result
@@ -1,0 +1,320 @@
+INSTALL PLUGIN simple_parser SONAME 'mypluglib';
+# Test Part 2: Create Index Test(CREATE TABLE WITH FULLTEXT INDEX)
+CREATE TABLE articles (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200),
+body TEXT,
+FULLTEXT (title, body) WITH PARSER simple_parser
+) ENGINE=InnoDB;
+INSERT INTO articles (title, body) VALUES
+('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+('How To Use MySQL Well','After you went through a ...'),
+('Optimizing MySQL','In this tutorial we will show ...'),
+('1001 MySQL Tricks','How to use full-text search engine'),
+('Go MySQL Tricks','How to use full text search engine');
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('mysql');
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	How To Use MySQL Well	After you went through a ...
+3	Optimizing MySQL	In this tutorial we will show ...
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('will go');
+id	title	body
+# Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full-text');
+id	title	body
+4	1001 MySQL Tricks	How to use full-text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full text');
+id	title	body
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+id	title	body
+DROP TABLE articles;
+# Test Part 3: Row Merge Create Index Test(ALTER TABLE ADD FULLTEXT INDEX)
+CREATE TABLE articles (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200),
+body TEXT
+) ENGINE=InnoDB;
+INSERT INTO articles (title, body) VALUES
+('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+('How To Use MySQL Well','After you went through a ...'),
+('Optimizing MySQL','In this tutorial we will show ...'),
+('1001 MySQL Tricks','How to use full-text search engine'),
+('Go MySQL Tricks','How to use full text search engine');
+ALTER TABLE articles ADD FULLTEXT INDEX (title, body) WITH PARSER simple_parser;
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('mysql');
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	How To Use MySQL Well	After you went through a ...
+3	Optimizing MySQL	In this tutorial we will show ...
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('will go');
+id	title	body
+# Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full-text');
+id	title	body
+4	1001 MySQL Tricks	How to use full-text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full text');
+id	title	body
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full-text' WITH QUERY EXPANSION);
+id	title	body
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+2	How To Use MySQL Well	After you went through a ...
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+3	Optimizing MySQL	In this tutorial we will show ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full text' WITH QUERY EXPANSION);
+id	title	body
+5	Go MySQL Tricks	How to use full text search engine
+4	1001 MySQL Tricks	How to use full-text search engine
+2	How To Use MySQL Well	After you went through a ...
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+3	Optimizing MySQL	In this tutorial we will show ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+id	title	body
+DROP TABLE articles;
+# Test Part 3 END
+SET SESSION debug="+d,fts_instrument_use_default_parser";
+Warnings:
+Warning	1287	'@@debug' is deprecated and will be removed in a future release. Please use '@@debug_dbug' instead
+# Test Part 4: Create Index Test with Default/Internal Parser
+CREATE TABLE articles (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200),
+body TEXT,
+FULLTEXT (title, body) WITH PARSER simple_parser
+) ENGINE=InnoDB;
+INSERT INTO articles (title, body) VALUES
+('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+('How To Use MySQL Well','After you went through a ...'),
+('Optimizing MySQL','In this tutorial we will show ...'),
+('1001 MySQL Tricks','How to use full-text search engine'),
+('Go MySQL Tricks','How to use full text search engine');
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('mysql');
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	How To Use MySQL Well	After you went through a ...
+3	Optimizing MySQL	In this tutorial we will show ...
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('will go');
+id	title	body
+# Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full-text');
+id	title	body
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full text');
+id	title	body
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+DROP TABLE articles;
+# Test Part 5: Row Merge Create Index Test with Default/Internal Parser
+CREATE TABLE articles (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200),
+body TEXT
+) ENGINE=InnoDB;
+INSERT INTO articles (title, body) VALUES
+('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+('How To Use MySQL Well','After you went through a ...'),
+('Optimizing MySQL','In this tutorial we will show ...'),
+('1001 MySQL Tricks','How to use full-text search engine'),
+('Go MySQL Tricks','How to use full text search engine');
+ALTER TABLE articles ADD FULLTEXT INDEX (title, body) WITH PARSER simple_parser;
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('mysql');
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	How To Use MySQL Well	After you went through a ...
+3	Optimizing MySQL	In this tutorial we will show ...
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('will go');
+id	title	body
+# Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full-text');
+id	title	body
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('full text');
+id	title	body
+4	1001 MySQL Tricks	How to use full-text search engine
+5	Go MySQL Tricks	How to use full text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+id	title	body
+DROP TABLE articles;
+# Test Part 6: Test Query Parser with Default/Internal Parser
+SET GLOBAL innodb_ft_enable_diag_print = 1;
+CREATE TABLE articles (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200),
+body TEXT,
+FULLTEXT (title, body) WITH PARSER simple_parser
+) ENGINE=InnoDB;
+INSERT INTO articles (title, body) VALUES
+('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+('MySQL Tutorial','DBMS stands for MySQL good one DataBase ...'),
+('How To Use MySQL Well','After you went through a ...'),
+('Optimizing MySQL','In this tutorial we will show ...'),
+('1001 MySQL Tricks','How to use full-text search engine');
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+mysql -database' IN BOOLEAN MODE);
+id	title	body
+3	How To Use MySQL Well	After you went through a ...
+4	Optimizing MySQL	In this tutorial we will show ...
+5	1001 MySQL Tricks	How to use full-text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('>mysql <database ~search' IN BOOLEAN MODE);
+id	title	body
+3	How To Use MySQL Well	After you went through a ...
+4	Optimizing MySQL	In this tutorial we will show ...
+5	1001 MySQL Tricks	How to use full-text search engine
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	MySQL Tutorial	DBMS stands for MySQL good one DataBase ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+(mysql database) -engine' IN BOOLEAN MODE);
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	MySQL Tutorial	DBMS stands for MySQL good one DataBase ...
+3	How To Use MySQL Well	After you went through a ...
+4	Optimizing MySQL	In this tutorial we will show ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+(mysql database -engine' IN BOOLEAN MODE);
+id	title	body
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"mysql"' IN BOOLEAN MODE);
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	MySQL Tutorial	DBMS stands for MySQL good one DataBase ...
+3	How To Use MySQL Well	After you went through a ...
+4	Optimizing MySQL	In this tutorial we will show ...
+5	1001 MySQL Tricks	How to use full-text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"for mysql"' IN BOOLEAN MODE);
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+2	MySQL Tutorial	DBMS stands for MySQL good one DataBase ...
+3	How To Use MySQL Well	After you went through a ...
+4	Optimizing MySQL	In this tutorial we will show ...
+5	1001 MySQL Tricks	How to use full-text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"full text search"' IN BOOLEAN MODE);
+id	title	body
+5	1001 MySQL Tricks	How to use full-text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"full text search engine"' IN BOOLEAN MODE);
+id	title	body
+5	1001 MySQL Tricks	How to use full-text search engine
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+"dbms stands" -good' IN BOOLEAN MODE);
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+("dbms stands") -good' IN BOOLEAN MODE);
+id	title	body
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+("dbms stands" search) -good' IN BOOLEAN MODE);
+id	title	body
+5	1001 MySQL Tricks	How to use full-text search engine
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+("dbms stands" "full text") -good' IN BOOLEAN MODE);
+id	title	body
+5	1001 MySQL Tricks	How to use full-text search engine
+1	MySQL Tutorial	DBMS stands for MySQL DataBase ...
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('("msyql database")@3' IN BOOLEAN MODE);
+id	title	body
+DROP TABLE articles;
+SET NAMES utf8;
+# Test Part 7: Test Different Charset
+CREATE TABLE articles (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200),
+body TEXT,
+FULLTEXT (title, body) WITH PARSER simple_parser
+) ENGINE=InnoDB DEFAULT CHARACTER SET gb2312 COLLATE gb2312_chinese_ci;
+INSERT INTO articles (title, body) VALUES
+('数据库 是 数据 的 结构化 集合','它 可以 是 任何 东西'),
+('从 简单 的 购物清单 到 画展','或 企业网络 中 的 海量信息'),
+('要 想 将 数据 添加 到 数据库','或 访问、处理 计算机 数据库 中 保存 的 数据'),
+('需要 使用 数据库 管理系统','计算机 是 处理 大量 数据 的 理想 工具');
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('数据库');
+id	title	body
+3	要 想 将 数据 添加 到 数据库	或 访问、处理 计算机 数据库 中 保存 的 数据
+1	数据库 是 数据 的 结构化 集合	它 可以 是 任何 东西
+4	需要 使用 数据库 管理系统	计算机 是 处理 大量 数据 的 理想 工具
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('数据');
+id	title	body
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('数据*');
+id	title	body
+3	要 想 将 数据 添加 到 数据库	或 访问、处理 计算机 数据库 中 保存 的 数据
+1	数据库 是 数据 的 结构化 集合	它 可以 是 任何 东西
+4	需要 使用 数据库 管理系统	计算机 是 处理 大量 数据 的 理想 工具
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('+数据库 -计算机');
+id	title	body
+1	数据库 是 数据 的 结构化 集合	它 可以 是 任何 东西
+SELECT * FROM articles WHERE
+MATCH(title, body) AGAINST('"计算机 数据库"' IN BOOLEAN MODE);
+id	title	body
+3	要 想 将 数据 添加 到 数据库	或 访问、处理 计算机 数据库 中 保存 的 数据
+DROP TABLE articles;
+SET GLOBAL innodb_ft_enable_diag_print = 0;
+SET SESSION debug="-d,fts_instrument_use_default_parser";
+Warnings:
+Warning	1287	'@@debug' is deprecated and will be removed in a future release. Please use '@@debug_dbug' instead
+# Test Part 9:# Abort the operation in dict_create_index_step
+CREATE TABLE articles (
+id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200),
+body TEXT,
+FULLTEXT (title, body) WITH PARSER simple_parser
+) ENGINE=InnoDB;
+SET SESSION debug="+d,ib_dict_create_index_tree_fail";
+Warnings:
+Warning	1287	'@@debug' is deprecated and will be removed in a future release. Please use '@@debug_dbug' instead
+CREATE FULLTEXT INDEX idx ON articles(body);
+ERROR HY000: Out of memory.
+SET SESSION debug="-d,ib_dict_create_index_tree_fail";
+Warnings:
+Warning	1287	'@@debug' is deprecated and will be removed in a future release. Please use '@@debug_dbug' instead
+DROP TABLE articles;
+UNINSTALL PLUGIN simple_parser;

--- a/mysql-test/suite/innodb_fts/t/multiple_index.test
+++ b/mysql-test/suite/innodb_fts/t/multiple_index.test
@@ -1,0 +1,173 @@
+--source include/have_innodb.inc
+
+#------------------------------------------------------------------------------
+# Test With two FTS index on same table + alter/create/drop index + tnx
+#------------------------------------------------------------------------------
+--disable_warnings
+drop table if exists t1;
+--enable_warnings
+
+# Create FTS table
+CREATE TABLE t1 (
+        id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+        a VARCHAR(200),
+        b TEXT
+        ) ENGINE = InnoDB STATS_PERSISTENT=0;
+
+# Insert rows
+INSERT INTO t1 (a,b) VALUES
+        ('MySQL Tutorial','DBMS stands for DataBase ...')  ,
+        ('How To Use MySQL Well','After you went through a ...'),
+        ('Optimizing MySQL','In this tutorial we will show ...');
+
+# Create the 2 FTS index Using Alter on same table
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_1 (a);
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_2 (b);
+EVAL SHOW CREATE TABLE t1;
+
+# check mutiple index with transaction
+START TRANSACTION;
+# Insert rows
+INSERT INTO t1 (a,b) VALUES
+        ('1001 MySQL Tricks','1. Never run mysqld as root. 2. ...'),
+        ('MySQL vs. YourSQL','In the following database comparison ...'),
+        ('MySQL Security','When configured properly, MySQL ...');
+ROLLBACK;
+
+# Select word "tutorial" in the table
+SELECT * FROM t1 WHERE MATCH (a)
+        AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+
+# boolean mode
+select * from t1 where MATCH(a) AGAINST("+mysql +Tutorial" IN BOOLEAN MODE);
+select * from t1 where MATCH(b) AGAINST("+Tutorial" IN BOOLEAN MODE);
+select * from t1 where MATCH(b) AGAINST("+stands +(DataBase)" IN BOOLEAN MODE);
+select * from t1 where MATCH(b) AGAINST("+DataBase -(comparison)" IN BOOLEAN MODE);
+select *, MATCH(a) AGAINST("Optimizing MySQL" IN BOOLEAN MODE) as x from t1;
+select *, MATCH(b) AGAINST("collections support" IN BOOLEAN MODE) as x from t1;
+select * from t1 where MATCH a AGAINST ("+Optimiz* +Optimiz*" IN BOOLEAN MODE);
+select * from t1 where MATCH b AGAINST ('"DBMS stands"' IN BOOLEAN MODE);
+select * from t1 where MATCH b AGAINST ('"DBMS STANDS"' IN BOOLEAN MODE);
+
+# query expansion
+select * from t1 where MATCH(b) AGAINST ("DataBase" WITH QUERY EXPANSION);
+select * from t1 where MATCH(a) AGAINST ("Security" WITH QUERY EXPANSION);
+
+# Drop index 
+ALTER TABLE t1 DROP INDEX idx_1;
+ALTER TABLE t1 DROP INDEX idx_2;
+
+# Create the FTS index again
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_1 (a);
+ALTER TABLE t1 ADD FULLTEXT INDEX idx_2 (b);
+
+# Select word "tutorial" in the table
+SELECT * FROM t1 WHERE MATCH (a)
+        AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE);
+
+# boolean mode
+select * from t1 where MATCH(a) AGAINST("+mysql +Tutorial" IN BOOLEAN MODE);
+select * from t1 where MATCH(b) AGAINST("+Tutorial" IN BOOLEAN MODE);
+select * from t1 where MATCH(b) AGAINST("+stands +(DataBase)" IN BOOLEAN MODE);
+select * from t1 where MATCH(b) AGAINST("+DataBase -(comparison)" IN BOOLEAN MODE);
+select *, MATCH(a) AGAINST("Optimizing MySQL" IN BOOLEAN MODE) as x from t1;
+select *, MATCH(b) AGAINST("collections support" IN BOOLEAN MODE) as x from t1;
+select * from t1 where MATCH a AGAINST ("+Optimiz* +Optimiz*" IN BOOLEAN MODE);
+select * from t1 where MATCH b AGAINST ('"DBMS stands"' IN BOOLEAN MODE);
+select * from t1 where MATCH b AGAINST ('"DBMS STANDS"' IN BOOLEAN MODE);
+
+# query expansion
+select * from t1 where MATCH(b) AGAINST ("DataBase" WITH QUERY EXPANSION);
+select * from t1 where MATCH(a) AGAINST ("Security" WITH QUERY EXPANSION);
+
+# insert for proximity search 
+INSERT INTO t1 (a,b) VALUES ('test query expansion','for database ...');
+# Insert into table with similar word of different distances
+INSERT INTO t1 (a,b) VALUES
+        ('test proximity search, test, proximity and phrase',
+         'search, with proximity innodb');
+
+INSERT INTO t1 (a,b) VALUES
+        ('test proximity fts search, test, proximity and phrase',
+         'search, with proximity innodb');
+
+INSERT INTO t1 (a,b) VALUES
+        ('test more of proximity for fts search, test, more proximity and phrase',
+         'search, with proximity innodb');
+
+# This should only return the first document
+SELECT * FROM t1
+        WHERE MATCH (a)
+        AGAINST ('"proximity search"@3' IN BOOLEAN MODE);
+
+# This would return no document
+SELECT * FROM t1
+        WHERE MATCH (a)
+        AGAINST ('"proximity search"@2' IN BOOLEAN MODE);
+
+# This give you all three documents
+SELECT * FROM t1
+        WHERE MATCH (b)
+        AGAINST ('"proximity innodb"@4' IN BOOLEAN MODE);
+
+# Similar boundary testing for the words
+SELECT * FROM t1
+        WHERE MATCH (a)
+        AGAINST ('"test proximity"@3' IN BOOLEAN MODE);
+
+# Test with more word The last document will return, please notice there
+# is no ordering requirement for proximity search.
+SELECT * FROM t1
+        WHERE MATCH (a)
+        AGAINST ('"more test proximity"@3' IN BOOLEAN MODE);
+
+SELECT * FROM t1
+        WHERE MATCH (a)
+        AGAINST ('"more test proximity"@2' IN BOOLEAN MODE);
+
+# The phrase search will not require exact word ordering
+SELECT * FROM t1
+        WHERE MATCH (a)
+        AGAINST ('"more fts proximity"@02' IN BOOLEAN MODE);
+
+
+# Select word "tutorial" in the table - innodb crash
+SELECT * FROM t1 WHERE CONCAT(t1.a,t1.b) IN (
+SELECT CONCAT(a,b) FROM t1 AS t2 WHERE
+MATCH (t2.a) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+) OR t1.id = 3 ;
+
+
+# Select word "tutorial" in the table  - innodb crash
+SELECT * FROM t1 WHERE CONCAT(t1.a,t1.b) IN (
+SELECT CONCAT(a,b) FROM t1 AS t2
+WHERE MATCH (t2.a) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+AND t2.id != 3) ;
+
+# Select word "tutorial" in the table
+SELECT * FROM t1 WHERE id IN (SELECT MIN(id) FROM t1 WHERE
+MATCH (b) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)) OR id = 3 ;
+
+# Select word except  "tutorial" in the table
+SELECT * FROM t1 WHERE id NOT IN (SELECT MIN(id) FROM t1
+WHERE MATCH (b) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)) ;
+
+
+# Select word "tutorial" in the table
+SELECT * FROM t1 WHERE EXISTS (SELECT t2.id FROM t1 AS t2 WHERE
+MATCH (t2.b) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+AND t1.id = t2.id) ;
+
+
+# Select not word like "tutorial" using subquery
+SELECT * FROM t1 WHERE NOT EXISTS (SELECT t2.id FROM t1 AS t2 WHERE
+MATCH (t2.a) AGAINST ('Tutorial' IN NATURAL LANGUAGE MODE)
+AND t1.id = t2.id) ;
+
+
+SELECT * FROM t1 WHERE t1.id = (SELECT MAX(t2.id) FROM t1 AS t2 WHERE
+MATCH(t2.a) AGAINST ('"proximity search"@3' IN BOOLEAN MODE));
+SELECT * FROM t1 WHERE t1.id > (SELECT MIN(t2.id) FROM t1 AS t2 WHERE
+MATCH(t2.b) AGAINST ('"proximity innodb"@3' IN BOOLEAN MODE));
+
+DROP TABLE t1;

--- a/mysql-test/suite/innodb_fts/t/plugin_debug.test
+++ b/mysql-test/suite/innodb_fts/t/plugin_debug.test
@@ -1,0 +1,295 @@
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_simple_parser.inc
+
+INSTALL PLUGIN simple_parser SONAME 'mypluglib';
+
+-- echo # Test Part 2: Create Index Test(CREATE TABLE WITH FULLTEXT INDEX)
+CREATE TABLE articles (
+	id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+	title VARCHAR(200),
+	body TEXT,
+	FULLTEXT (title, body) WITH PARSER simple_parser
+	) ENGINE=InnoDB;
+
+INSERT INTO articles (title, body) VALUES
+  ('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+  ('How To Use MySQL Well','After you went through a ...'),
+  ('Optimizing MySQL','In this tutorial we will show ...'),
+  ('1001 MySQL Tricks','How to use full-text search engine'),
+  ('Go MySQL Tricks','How to use full text search engine');
+
+# Simple term search
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('mysql');
+
+# Test stopword and word len less than fts_min_token_size
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('will go');
+
+-- echo # Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full-text');
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full text');
+
+# No result here, we get '"mysql' 'database"' by simple parser
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+
+DROP TABLE articles;
+
+-- echo # Test Part 3: Row Merge Create Index Test(ALTER TABLE ADD FULLTEXT INDEX)
+CREATE TABLE articles (
+	id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+	title VARCHAR(200),
+	body TEXT
+	) ENGINE=InnoDB;
+
+INSERT INTO articles (title, body) VALUES
+  ('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+  ('How To Use MySQL Well','After you went through a ...'),
+  ('Optimizing MySQL','In this tutorial we will show ...'),
+  ('1001 MySQL Tricks','How to use full-text search engine'),
+  ('Go MySQL Tricks','How to use full text search engine');
+
+# Create fulltext index
+ALTER TABLE articles ADD FULLTEXT INDEX (title, body) WITH PARSER simple_parser;
+
+# Simple term search
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('mysql');
+
+# Test stopword and word len less than fts_min_token_size
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('will go');
+
+-- echo # Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full-text');
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full text');
+
+# Test query expansion
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full-text' WITH QUERY EXPANSION);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full text' WITH QUERY EXPANSION);
+
+# No result here, we get '"mysql' 'database"' by simple parser
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+
+DROP TABLE articles;
+-- echo # Test Part 3 END
+
+# Use default parser
+SET SESSION debug="+d,fts_instrument_use_default_parser";
+
+-- echo # Test Part 4: Create Index Test with Default/Internal Parser
+CREATE TABLE articles (
+	id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+	title VARCHAR(200),
+	body TEXT,
+	FULLTEXT (title, body) WITH PARSER simple_parser
+	) ENGINE=InnoDB;
+
+INSERT INTO articles (title, body) VALUES
+  ('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+  ('How To Use MySQL Well','After you went through a ...'),
+  ('Optimizing MySQL','In this tutorial we will show ...'),
+  ('1001 MySQL Tricks','How to use full-text search engine'),
+  ('Go MySQL Tricks','How to use full text search engine');
+
+# Simple term search
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('mysql');
+
+# Test stopword and word len less than fts_min_token_size
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('will go');
+
+-- echo # Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full-text');
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full text');
+
+# Phrase search
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+
+DROP TABLE articles;
+
+# Disable query parse using plugin parser
+-- echo # Test Part 5: Row Merge Create Index Test with Default/Internal Parser
+CREATE TABLE articles (
+	id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+	title VARCHAR(200),
+	body TEXT
+	) ENGINE=InnoDB;
+
+INSERT INTO articles (title, body) VALUES
+  ('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+  ('How To Use MySQL Well','After you went through a ...'),
+  ('Optimizing MySQL','In this tutorial we will show ...'),
+  ('1001 MySQL Tricks','How to use full-text search engine'),
+  ('Go MySQL Tricks','How to use full text search engine');
+
+# Create fulltext index
+ALTER TABLE articles ADD FULLTEXT INDEX (title, body) WITH PARSER simple_parser;
+
+# Simple term search
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('mysql');
+
+# Test stopword and word len less than fts_min_token_size
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('will go');
+
+-- echo # Test plugin parser tokenizer difference
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full-text');
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('full text');
+
+# Phrase search
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+
+DROP TABLE articles;
+
+-- echo # Test Part 6: Test Query Parser with Default/Internal Parser
+let $innodb_ft_enable_diag_print_orig = `SELECT @@innodb_ft_enable_diag_print`;
+# Enable diag print to print query parse tree
+SET GLOBAL innodb_ft_enable_diag_print = 1;
+
+CREATE TABLE articles (
+	id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+	title VARCHAR(200),
+	body TEXT,
+	FULLTEXT (title, body) WITH PARSER simple_parser
+	) ENGINE=InnoDB;
+
+INSERT INTO articles (title, body) VALUES
+  ('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),
+  ('MySQL Tutorial','DBMS stands for MySQL good one DataBase ...'),
+  ('How To Use MySQL Well','After you went through a ...'),
+  ('Optimizing MySQL','In this tutorial we will show ...'),
+  ('1001 MySQL Tricks','How to use full-text search engine');
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+mysql -database' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('>mysql <database ~search' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+(mysql database) -engine' IN BOOLEAN MODE);
+
+# The will be no result because of parsing error.
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+(mysql database -engine' IN BOOLEAN MODE);
+
+# Test phrase match
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"mysql"' IN BOOLEAN MODE);
+
+# Test stopword or word less than fts_min_token_size
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"for mysql"' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"mysql database"' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"full text search"' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"full text search engine"' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+"dbms stands" -good' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+("dbms stands") -good' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+("dbms stands" search) -good' IN BOOLEAN MODE);
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+("dbms stands" "full text") -good' IN BOOLEAN MODE);
+
+# Test proximity match
+# It will be treated as phrase match
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('("msyql database")@3' IN BOOLEAN MODE);
+
+DROP TABLE articles;
+
+SET NAMES utf8;
+
+-- echo # Test Part 7: Test Different Charset
+CREATE TABLE articles (
+	id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+	title VARCHAR(200),
+	body TEXT,
+	FULLTEXT (title, body) WITH PARSER simple_parser
+	) ENGINE=InnoDB DEFAULT CHARACTER SET gb2312 COLLATE gb2312_chinese_ci;
+
+INSERT INTO articles (title, body) VALUES
+  ('数据库 是 数据 的 结构化 集合','它 可以 是 任何 东西'),
+  ('从 简单 的 购物清单 到 画展','或 企业网络 中 的 海量信息'),
+  ('要 想 将 数据 添加 到 数据库','或 访问、处理 计算机 数据库 中 保存 的 数据'),
+  ('需要 使用 数据库 管理系统','计算机 是 处理 大量 数据 的 理想 工具');
+
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('数据库');
+
+# Test word len less than fts_min_token_size
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('数据');
+
+# Test wildcard
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('数据*');
+
+# Test operator
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('+数据库 -计算机');
+
+# Test phrase search
+SELECT * FROM articles WHERE
+	MATCH(title, body) AGAINST('"计算机 数据库"' IN BOOLEAN MODE);
+
+DROP TABLE articles;
+
+eval SET GLOBAL innodb_ft_enable_diag_print = $innodb_ft_enable_diag_print_orig;
+
+# Disable use default parser
+SET SESSION debug="-d,fts_instrument_use_default_parser";
+
+-- echo # Test Part 9:# Abort the operation in dict_create_index_step
+# by setting return status of dict_create_index_tree_step() to DB_OUT_OF_MEMORY
+# # The newly create dict_index_t should be removed from fts cache
+
+CREATE TABLE articles (
+       id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+       title VARCHAR(200),
+       body TEXT,
+       FULLTEXT (title, body) WITH PARSER simple_parser
+) ENGINE=InnoDB;
+#
+SET SESSION debug="+d,ib_dict_create_index_tree_fail";
+--error ER_OUT_OF_RESOURCES
+CREATE FULLTEXT INDEX idx ON articles(body);
+SET SESSION debug="-d,ib_dict_create_index_tree_fail";
+#
+DROP TABLE articles;
+
+UNINSTALL PLUGIN simple_parser;

--- a/plugin/fulltext/plugin_example.c
+++ b/plugin/fulltext/plugin_example.c
@@ -148,7 +148,7 @@ static int simple_parser_deinit(MYSQL_FTPARSER_PARAM *param
 static void add_word(MYSQL_FTPARSER_PARAM *param, const char *word, size_t len)
 {
   MYSQL_FTPARSER_BOOLEAN_INFO bool_info=
-    { FT_TOKEN_WORD, 0, 0, 0, 0, ' ', 0 };
+    { FT_TOKEN_WORD, 0, 0, 0, 0, 0, ' ', 0 };
 
   param->mysql_add_word(param, word, (int)len, &bool_info);
 }

--- a/storage/innobase/fts/fts0fts.cc
+++ b/storage/innobase/fts/fts0fts.cc
@@ -4628,12 +4628,8 @@ fts_tokenize_document_internal(
 {
 	fts_string_t	str;
 	byte		buf[FTS_MAX_WORD_LEN + 1];
-	/* JAN: TODO: MySQL 5.7
 	MYSQL_FTPARSER_BOOLEAN_INFO bool_info =
 		{ FT_TOKEN_WORD, 0, 0, 0, 0, 0, ' ', 0 };
-	*/
-	MYSQL_FTPARSER_BOOLEAN_INFO bool_info =
-		{ FT_TOKEN_WORD, 0, 0, 0, 0, ' ', 0};
 
 	ut_ad(len >= 0);
 
@@ -4647,11 +4643,9 @@ fts_tokenize_document_internal(
 			&str);
 
 		if (str.f_len > 0) {
-			/* JAN: TODO: MySQL 5.7
 			bool_info.position =
 				static_cast<int>(i + inc - str.f_len);
 			ut_ad(bool_info.position >= 0);
-			*/
 
 			/* Stop when add word fails */
 			if (param->mysql_add_word(
@@ -4678,7 +4672,7 @@ fts_tokenize_add_word_for_parser(
 	MYSQL_FTPARSER_PARAM*	param,		/* in: parser paramter */
 	const char*			word,		/* in: token word */
 	int			word_len,	/* in: word len */
-	MYSQL_FTPARSER_BOOLEAN_INFO*)
+	MYSQL_FTPARSER_BOOLEAN_INFO* boolean_info)
 {
 	fts_string_t	str;
 	fts_tokenize_param_t*	fts_param;
@@ -4694,11 +4688,8 @@ fts_tokenize_add_word_for_parser(
 	str.f_n_char = fts_get_token_size(
 		const_cast<CHARSET_INFO*>(param->cs), word, str.f_len);
 
-	/* JAN: TODO: MySQL 5.7 FTS
 	ut_ad(boolean_info->position >= 0);
 	position = boolean_info->position + fts_param->add_pos;
-	*/
-	position = fts_param->add_pos++;
 
 	fts_add_token(result_doc, str, position);
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-14231*

## Description
This patch is taken mysql-5.7.
st_mysql_ftparser_boolean_info(): Add variable position to store the correct offset for the default fts parser.
Added plugin_debug.test, multiple_index.test from mysql-5.7

## How can this PR be tested?
./mtr innodb_fts.plugin_debug innodb_fts.multiple_index

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
