### PR TITLE
MDEV-32489 Change buffer index fails to delete the records

### DIFF
--- a/storage/innobase/btr/btr0pcur.cc
+++ b/storage/innobase/btr/btr0pcur.cc
@@ -657,8 +657,9 @@ user record satisfying the search condition, in the case PAGE_CUR_L or
 PAGE_CUR_LE, on the last user record. If no such user record exists, then
 in the first case sets the cursor after last in tree, and in the latter case
 before first in tree. The latching mode must be BTR_SEARCH_LEAF or
-BTR_MODIFY_LEAF. */
-void
+BTR_MODIFY_LEAF.
+@return DB_SUCCESS or error code */
+dberr_t
 btr_pcur_open_on_user_rec_func(
 /*===========================*/
 	dict_index_t*	index,		/*!< in: index */
@@ -672,8 +673,12 @@ btr_pcur_open_on_user_rec_func(
 	unsigned	line,		/*!< in: line where called */
 	mtr_t*		mtr)		/*!< in: mtr */
 {
-	btr_pcur_open_low(index, 0, tuple, mode, latch_mode, cursor,
-			  file, line, 0, mtr);
+	auto err = btr_pcur_open_low(index, 0, tuple, mode, latch_mode, cursor,
+				     file, line, 0, mtr);
+
+	if (UNIV_UNLIKELY(err != DB_SUCCESS)) {
+		return err;
+	}
 
 	if ((mode == PAGE_CUR_GE) || (mode == PAGE_CUR_G)) {
 
@@ -688,4 +693,5 @@ btr_pcur_open_on_user_rec_func(
 
 		ut_error;
 	}
+	return DB_SUCCESS;
 }

--- a/storage/innobase/include/btr0pcur.h
+++ b/storage/innobase/include/btr0pcur.h
@@ -181,8 +181,9 @@ user record satisfying the search condition, in the case PAGE_CUR_L or
 PAGE_CUR_LE, on the last user record. If no such user record exists, then
 in the first case sets the cursor after last in tree, and in the latter case
 before first in tree. The latching mode must be BTR_SEARCH_LEAF or
-BTR_MODIFY_LEAF. */
-void
+BTR_MODIFY_LEAF.
+@return DB_SUCCESS or error code */
+dberr_t
 btr_pcur_open_on_user_rec_func(
 /*===========================*/
 	dict_index_t*	index,		/*!< in: index */

--- a/storage/innobase/include/ibuf0ibuf.h
+++ b/storage/innobase/include/ibuf0ibuf.h
@@ -370,10 +370,11 @@ in DISCARD TABLESPACE, IMPORT TABLESPACE, or read-ahead.
 void ibuf_delete_for_discarded_space(ulint space);
 
 /** Contract the change buffer by reading pages to the buffer pool.
+@param slow_shutdown true, if called during slow shutdown
 @return a lower limit for the combined size in bytes of entries which
 will be merged from ibuf trees to the pages read
 @retval 0 if ibuf.empty */
-ulint ibuf_contract();
+ulint ibuf_contract(bool slow_shutdown);
 
 /** Contracts insert buffer trees by reading pages referring to space_id
 to the buffer pool.

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1665,7 +1665,7 @@ void srv_shutdown(bool ibuf_merge)
 			ibuf_read_merge_pages() */
 			ibuf_max_size_update(0);
 			log_free_check();
-			n_read = ibuf_contract();
+			n_read = ibuf_contract(true);
 		}
 
 		if (n_tables_to_drop || ibuf_merge) {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32489*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
When the change buffer records for a page span across multiple change buffer leaf pages or the starting record is at the beginning of a page with a left sibling, ibuf_delete_recs deletes only the records in first page and fails to move to subsequent pages.

Subsequently a slow shutdown hangs trying to delete those left over records.

Fix-A: Position the cursor to an user record in B-tree and exit only when all records are exhausted.

Fix-B: Make sure we call ibuf_delete_recs during slow shutdown for pages with IBUF entries to cleanup any previously left over records.

## Release Notes
None

## How can this PR be tested?
RQG test as done by the filer.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->
It is possible to repeat the issue with good predictability with somewhat complex mtr test, 4k page size and some code modification to force certain path. Otherwise we need multiple large tablespaces of size more than extent size. The test is updated in the MDEV. While the test can be used to validate the patch it is hard to maintain such test in repository and I am not adding it to our mtr test suite,

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
