### PR TITLE
MDEV-33855 MSAN use-of-uninitialized-value in rtr_pcur_getnext_from_path()

### DIFF
--- a/storage/innobase/gis/gis0sea.cc
+++ b/storage/innobase/gis/gis0sea.cc
@@ -289,10 +289,6 @@ rtr_pcur_getnext_from_path(
 			mtr->rollback_to_savepoint(1);
 		}
 
-		ut_ad((my_latch_mode | 4) == BTR_CONT_MODIFY_TREE
-		      || !page_is_leaf(btr_cur_get_page(btr_cur))
-		      || !btr_cur->page_cur.block->page.lock.have_any());
-
 		const auto block_savepoint = mtr->get_savepoint();
 		block = buf_page_get_gen(
 			page_id_t(index->table->space_id,


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33855*
## Description
`rtr_pcur_getnext_from_path()`: Remove a debug assertion that suffers from a data race with `buf_LRU_block_free_non_file_page()`.

## Release Notes
No mention is needed, because this is only removing a bogus debug assertion.

## How can this PR be tested?
Repeatedly run `./mtr innodb_gis.rtree_compress` in a MemorySanitizer instrumented build.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.