### PR TITLE
MDEV-33408 Alter HNSW graph storage and fix memory leak

### DIFF
--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -9842,7 +9842,7 @@ int TABLE::hlindex_open(uint nr)
     }
     TABLE *table= (TABLE*)alloc_root(&mem_root, sizeof(*table));
     if (!table ||
-        open_table_from_share(in_use, s->hlindex, &empty_clex_str, db_stat, 0,
+        open_table_from_share(in_use, s->hlindex, &empty_clex_str, db_stat, EXTRA_RECORD,
                               in_use->open_options, table, 0))
       return 1;
     hlindex= table;


### PR DESCRIPTION
## Description
This commit changes the way HNSW graph information is stored in the second table. Instead of storing connections as separate records, it now stores neighbors for each node, leading to significant performance improvements and storage savings.

**Comparing with the previous approach, the insert speed is 5 times faster, search speed improves by 23%, and storage usage is reduced by 73%, based on ann-benchmark tests with random-xs-20-euclidean and random-s-100-euclidean datasets.**

Additionally, in previous code, vector objects were not released after use, resulting in excessive memory consumption (over 20GB for building the index with 90,000 records), preventing tests with large datasets.
Now ensure that vectors are released appropriately during the insert and search functions. Note there are still some vectors that need to be cleaned up after search query completion. Needs to be addressed in a future commit.



## How can this PR be tested?

#### Comparing the performance with previous method of saving connections, using ann-benchmark tool, significant improvement on insert/search/storage size can be seen:
*To isolate the impact of the storage structure on performance, I basically kept the HNSW parameters consistent in the commit. Only different parameter is a EF_SEARCH=10 which could help improve the recall. 
"new" version is based on commit in this pull request and "old" version is of commit [00b613a2](https://github.com/MariaDB/server/pull/3156/commits/00b613a2bf359a89ec5fd06445e8f91fe07fa4a4) which includes my fix in a previous [pending PR](https://github.com/MariaDB/server/pull/3156).* )

- **With dataset of random-xs-20-euclidean:**

  | Metric                             |       old       |       new       |       change        |
  |-----------------------------------|-----------------|-----------------|----------------------|
  | Insert time for 9000 records      | 109.41 sec      | 22.17 sec       | **(5 times faster)**     |
  | K-ANN search recall                | 0.737           | 0.782           | (+6%)                |
  | K-ANN search QPS                   | 687.526         | 843.368         | **(+22%)**               |
  | Second table size (data + index)   | 8.1M            | 2.16M           | **(-73%)**               |

  - New second table data and index sizes `t1#i#01.*`:
    ```
    -rw-rw---- 1 wenhug amazon 1.9M Apr 12 20:59 t1#i#01.MYD
    -rw-rw---- 1 wenhug amazon 272K Apr 12 20:59 t1#i#01.MYI
    -rw-rw---- 1 wenhug amazon 1.5K Apr 12 20:58 t1.frm
    -rw-rw---- 1 wenhug amazon 809K Apr 12 20:59 t1.MYD
    -rw-rw---- 1 wenhug amazon  93K Apr 12 20:59 t1.MYI
    ```
  - Old second table data and index sizes `t1#i#01.*`:
    ```
    -rw-rw---- 1 wenhug amazon 5.0M Apr 12 17:16 t1#i#01.MYD
    -rw-rw---- 1 wenhug amazon 3.1M Apr 12 17:17 t1#i#01.MYI
    -rw-rw---- 1 wenhug amazon 1.5K Apr 12 17:15 t1.frm
    -rw-rw---- 1 wenhug amazon 809K Apr 12 17:16 t1.MYD
    -rw-rw---- 1 wenhug amazon  93K Apr 12 17:17 t1.MYI
    ```

- **With dataset of random-s-100-euclidean:**

  | Metric                             |       old       |       new       |       change        |
  |-----------------------------------|-----------------|-----------------|----------------------|
  | Insert time for 90000 records     | 1328.48 sec     | 259.15 sec      | **(5 times faster)**     |
  | K-ANN search recall                | 0.221           | 0.335           | (+50%)               |
  | K-ANN search QPS                   | 539.019         | 668.827         | **(+24%)**               |
  | Second table size (data + index)   | 79M             | 20.8M           | **(-73%)**               |

  - New second table data and index sizes `t1#i#01.*`:
    ```
    -rw-rw---- 1 wenhug amazon  18M Apr 12 17:30 t1#i#01.MYD
    -rw-rw---- 1 wenhug amazon 2.8M Apr 12 17:33 t1#i#01.MYI
    -rw-rw---- 1 wenhug amazon 1.5K Apr 12 17:26 t1.frm
    -rw-rw---- 1 wenhug amazon  36M Apr 12 17:30 t1.MYD
    -rw-rw---- 1 wenhug amazon 905K Apr 12 17:33 t1.MYI
    ```

  - Old second table data and index sizes `t1#i#01.*`:
    ```
    -rw-rw---- 1 wenhug amazon  46M Apr 12 17:56 t1#i#01.MYD
    -rw-rw---- 1 wenhug amazon  33M Apr 12 17:59 t1#i#01.MYI
    -rw-rw---- 1 wenhug amazon 1.5K Apr 12 17:34 t1.frm
    -rw-rw---- 1 wenhug amazon  36M Apr 12 17:56 t1.MYD
    -rw-rw---- 1 wenhug amazon 905K Apr 12 17:59 t1.MYI
    ```
