### PR TITLE
Fix(wsrep_sst_rsync.sh): get CN 

### DIFF
--- a/scripts/wsrep_sst_rsync.sh
+++ b/scripts/wsrep_sst_rsync.sh
@@ -862,7 +862,7 @@ EOF
                 exit 42
             fi
             CN=$("$OPENSSL_BINARY" x509 -noout -subject -in "$SSTCERT" | \
-                 tr ',' '\n' | grep -F 'CN =' | cut -d '=' -f2 | sed s/^\ // | \
+                 sed s/subject=// | tr ',' '\n' | grep -F 'CN =' | cut -d '=' -f2 | sed s/^\ // | \
                  sed s/\ %//)
         fi
         MY_SECRET="$(wsrep_gen_secret)"


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The script retrieves the subject of the certificate using the command ``openssl x509 -noout -subject -in "$SSTCERT"`` and then pipes it to extract the CN. However, the current method for extracting the CN encounters issues when the CN is the first field of the subject. This pull request aims to address this issue and ensure the successful extraction of the CN from the subject of the certificate, regardless of its position within the subject field.

Here are the lines (864-866) that extracts the CN:

``CN=$("$OPENSSL_BINARY" x509 -noout -subject -in "$SSTCERT" | 
                 tr ',' '\n' | grep -F 'CN =' | cut -d '=' -f2 | sed s/^\ // | 
                 sed s/\ %//)``


This method of extracting the CN works when the CN is not the first field of the subject (e.g., subject=OU = Example, CN = www.example.com, C = EX), but it fails when the CN is the first field (e.g., subject=CN = www.exemple.com).

As the ACME challenge can only validate the CN of the certificate, this is the only field in the subject of the certificates produced by certbot.

A simple fix is to remove "subject=" from this return, and the pipe works again.


## Release Notes
Fix the command to get CN in wsrep_sst_rsync when the CN field is the first field of the subject of the certificate

## How can this PR be tested?
Using a certificate which only contain the CN field in it's subject.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
