### PR TITLE
MDEV-33616 Tests failing on macOS

### DIFF
--- a/mysql-test/suite/compat/oracle/r/sp-inout.result
+++ b/mysql-test/suite/compat/oracle/r/sp-inout.result
@@ -684,7 +684,7 @@ END;
 END;
 $$
 set @a = 4;
-INSERT INTO Persons SELECT 4, 'DDD', PKG2.func(@a);
+INSERT INTO Persons SELECT 4, 'DDD', pkg2.func(@a);
 SELECT * FROM Persons;
 ID	Name	Age
 1	AAA	10
@@ -726,8 +726,8 @@ ID	Name	Age
 2	BBB	20
 3	CCC	30
 set @a = 0;
-INSERT INTO Persons SELECT 5, 'EEE', PKG2.func(@a);
-ERROR HY000: OUT or INOUT argument 1 for function PKG2.func is not allowed here
+INSERT INTO Persons SELECT 5, 'EEE', pkg2.func(@a);
+ERROR HY000: OUT or INOUT argument 1 for function pkg2.func is not allowed here
 DROP TABLE Persons;
 DROP PACKAGE pkg2;
 # 
@@ -764,7 +764,7 @@ ID	Name	Age
 3	CCC	30
 4	DDD	40
 set @a = 4;
-DELETE FROM Persons WHERE ID = PKG2.func(@a);
+DELETE FROM Persons WHERE ID = pkg2.func(@a);
 SELECT * FROM Persons;
 ID	Name	Age
 1	AAA	10
@@ -807,8 +807,8 @@ ID	Name	Age
 3	CCC	30
 4	DDD	40
 set @a = 0;
-DELETE FROM Persons WHERE ID = PKG2.func(@a);
-ERROR HY000: OUT or INOUT argument 1 for function PKG2.func is not allowed here
+DELETE FROM Persons WHERE ID = pkg2.func(@a);
+ERROR HY000: OUT or INOUT argument 1 for function pkg2.func is not allowed here
 DROP TABLE Persons;
 DROP PACKAGE pkg2;
 # 

--- a/mysql-test/suite/compat/oracle/t/sp-inout.test
+++ b/mysql-test/suite/compat/oracle/t/sp-inout.test
@@ -730,7 +730,7 @@ $$
 DELIMITER ;$$
 
 set @a = 4;
-INSERT INTO Persons SELECT 4, 'DDD', PKG2.func(@a);
+INSERT INTO Persons SELECT 4, 'DDD', pkg2.func(@a);
 SELECT * FROM Persons;
 DROP TABLE Persons;
 DROP PACKAGE pkg2;
@@ -770,7 +770,7 @@ DELIMITER ;$$
 SELECT * FROM Persons;
 set @a = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-INSERT INTO Persons SELECT 5, 'EEE', PKG2.func(@a);
+INSERT INTO Persons SELECT 5, 'EEE', pkg2.func(@a);
 DROP TABLE Persons;
 DROP PACKAGE pkg2;
 
@@ -808,7 +808,7 @@ DELIMITER ;$$
 
 SELECT * FROM Persons;
 set @a = 4;
-DELETE FROM Persons WHERE ID = PKG2.func(@a);
+DELETE FROM Persons WHERE ID = pkg2.func(@a);
 SELECT * FROM Persons;
 DROP TABLE Persons;
 DROP PACKAGE pkg2;
@@ -849,7 +849,7 @@ DELIMITER ;$$
 SELECT * FROM Persons;
 set @a = 0;
 --error ER_SF_OUT_INOUT_ARG_NOT_ALLOWED
-DELETE FROM Persons WHERE ID = PKG2.func(@a);
+DELETE FROM Persons WHERE ID = pkg2.func(@a);
 DROP TABLE Persons;
 DROP PACKAGE pkg2;
 


### PR DESCRIPTION
compat/oracle.sp-inout now uses lowercase object names for test compatibility with both case-insensitive and case-sensitive filesystems.
