### PR TITLE
MDEV-35998 - Refine OpenSSL test names and allow more complete OpenSSL version coverage

### DIFF
--- a/mysql-test/main/openssl,sslv3.result
+++ b/mysql-test/main/openssl,sslv3.result
@@ -3,14 +3,14 @@ grant select on test.* to ssl_sslv3@localhost require cipher "AES128-SHA";
 create user ssl_tls12@localhost;
 grant select on test.* to ssl_tls12@localhost require cipher "AES128-SHA256";
 TLS1.2 ciphers: user is ok with any cipher
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
 TLS1.2 ciphers: user requires SSLv3 cipher AES128-SHA
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
 TLS1.2 ciphers: user requires TLSv1.2 cipher AES128-SHA256
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
 SSLv3 ciphers: user is ok with any cipher
 Variable_name	Value
 Ssl_cipher	AES256-SHA

--- a/mysql-test/main/openssl,tlsv12.result
+++ b/mysql-test/main/openssl,tlsv12.result
@@ -15,13 +15,13 @@ Variable_name	Value
 Ssl_cipher	AES128-SHA256
 ERROR 1045 (28000): Access denied for user 'ssl_tls12'@'localhost' (using password: NO)
 SSLv3 ciphers: user is ok with any cipher
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
 SSLv3 ciphers: user requires SSLv3 cipher AES128-SHA
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
 SSLv3 ciphers: user requires TLSv1.2 cipher AES128-SHA256
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
-ERROR 2026 (HY000): TLS/SSL error: sslv3 alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
 drop user ssl_sslv3@localhost;
 drop user ssl_tls12@localhost;

--- a/mysql-test/main/openssl.combinations
+++ b/mysql-test/main/openssl.combinations
@@ -1,6 +1,6 @@
 [tlsv12]
 loose-ssl-cipher=TLSv1.2
 
-[tlsv10]
+[sslv3]
 loose-ssl-cipher=SSLv3
 

--- a/mysql-test/main/openssl.test
+++ b/mysql-test/main/openssl.test
@@ -1,15 +1,13 @@
+# This is OpenSSL test.
 #
-# MDEV-6975 Implement TLS protocol
-#
-# test SSLv3 and TLSv1.2 ciphers when OpenSSL is restricted to SSLv3 or TLSv1.2
+# Test SSLv3 and TLSv1.2 ciphers when OpenSSL is restricted to SSLv3 or TLSv1.2
+# 
+# Related: MDEV-6975 Implement TLS protocol
 #
 source include/have_ssl_communication.inc;
 source include/require_openssl_client.inc;
 
-# this is OpenSSL test.
-
 create user ssl_sslv3@localhost;
-# grant select on test.* to ssl_sslv3@localhost require cipher "AES128-SHA";
 grant select on test.* to ssl_sslv3@localhost require cipher "AES128-SHA";
 create user ssl_tls12@localhost;
 grant select on test.* to ssl_tls12@localhost require cipher "AES128-SHA256";
@@ -18,24 +16,36 @@ let $mysql=$MYSQL --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$
 
 disable_abort_on_error;
 echo TLS1.2 ciphers: user is ok with any cipher;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --tls-version=TLSv1.2 --ssl-cipher=AES128-SHA256;
 --replace_result DHE-RSA-CHACHA20-POLY1305 DHE-RSA-AES256-GCM-SHA384 ECDHE-RSA-AES256-GCM-SHA384 DHE-RSA-AES256-GCM-SHA384
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --tls-version=TLSv1.2 --ssl-cipher=TLSv1.2;
 echo TLS1.2 ciphers: user requires SSLv3 cipher AES128-SHA;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_sslv3 --tls-version=TLSv1.2 --ssl-cipher=AES128-SHA256;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_sslv3 --tls-version=TLSv1.2 --ssl-cipher=TLSv1.2;
 echo TLS1.2 ciphers: user requires TLSv1.2 cipher AES128-SHA256;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_tls12 --tls-version=TLSv1.2 --ssl-cipher=AES128-SHA256;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_tls12 --tls-version=TLSv1.2 --ssl-cipher=TLSv1.2;
 
 echo SSLv3 ciphers: user is ok with any cipher;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --tls-version=TLSv1.0,TLSv1.1,TLSv1.2 --ssl-cipher=AES256-SHA;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --tls-version=TLSv1.0,TLSv1.1,TLSv1.2 --ssl-cipher=SSLv3;
 echo SSLv3 ciphers: user requires SSLv3 cipher AES128-SHA;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_sslv3 --tls-version=TLSv1.0,TLSv1.1,TLSv1.2 --ssl-cipher=AES128-SHA;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_sslv3 --tls-version=TLSv1.0,TLSv1.1,TLSv1.2 --ssl-cipher=SSLv3;
 echo SSLv3 ciphers: user requires TLSv1.2 cipher AES128-SHA256;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_tls12 --tls-version=TLSv1.0,TLSv1.1,TLSv1.2 --ssl-cipher=AES128-SHA;
+--replace_result "sslv3 alert" "ssl/tls alert"
 exec $mysql --user ssl_tls12 --tls-version=TLSv1.0,TLSv1.1,TLSv1.2 --ssl-cipher=SSLv3;
 
 drop user ssl_sslv3@localhost;

--- a/mysql-test/suite.pm
+++ b/mysql-test/suite.pm
@@ -65,8 +65,8 @@ sub skip_combinations {
   $skip{'include/have_ssl_communication.inc'} =
   $skip{'include/have_ssl_crypto_functs.inc'} = 'Requires SSL' unless $ssl_lib;
 
-  $skip{'main/openssl_6975.test'} = 'no or wrong openssl version'
-    unless $openssl_ver ge "1.0.1d" and $openssl_ver lt "1.1.1";
+  $skip{'main/openssl.test'} = 'openssl version greater than or equal to 1.0.1d required'
+    unless $openssl_ver ge "1.0.1d";
 
   $skip{'main/ssl_7937.combinations'} = [ 'x509v3' ]
     unless $ssl_lib =~ /WolfSSL/ or $openssl_ver ge "1.0.2";


### PR DESCRIPTION
## Description
- Remove "6975" from the OpenSSL test and result file names. "6975" refers to https://jira.mariadb.org/browse/MDEV-6975 about implementing TLS support in general, which is not a bug report. In this case, this is a generic OpenSSL test set, so update the test file names for better clarification.
- Remove the upper bound of the OpenSSL version check to allow the tests to also run with latest OpenSSL versions given that this is a generic set of OpenSSL tests.
- Update the tests and result files such that they are compatible with new error messages for OpenSSL 3.2.0 and later versions ("https://github.com/openssl/openssl/commit/81b741f68984").
- Update the configuration name from "tlsv10" to "sslv3" when SSL cipher used is "SSLv3".


## How can this PR be tested?

by running the updated OpenSSL tests.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.
