### PR TITLE
MDEV-33934   Assertion `!check_foreigns' failed in bulk_insert_apply_for_table(dict_table_t*)

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -488,4 +488,16 @@ BEGIN;
 LOAD DATA INFILE 'VARDIR/tmp/t.outfile' INTO TABLE t;
 COMMIT;
 DROP TABLE t;
+#
+#  MDEV-33934 Assertion `!check_foreigns' failed in
+#    trx_t::bulk_insert_apply_for_table(dict_table_t*)
+#
+CREATE TABLE t1(f1 INT,f2 INT,KEY(f1))engine=innodb;
+BEGIN;
+INSERT INTO t1 VALUES();
+SET STATEMENT FOREIGN_KEY_CHECKS=1 FOR SELECT * FROM t1;
+f1	f2
+NULL	NULL
+COMMIT;
+DROP TABLE t1;
 # End of 10.11 tests

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -523,4 +523,15 @@ eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/t.outfile' INTO TABLE t;
 COMMIT;
 DROP TABLE t;
 --remove_file $MYSQLTEST_VARDIR/tmp/t.outfile
+
+--echo #
+--echo #  MDEV-33934 Assertion `!check_foreigns' failed in
+--echo #    trx_t::bulk_insert_apply_for_table(dict_table_t*)
+--echo #
+CREATE TABLE t1(f1 INT,f2 INT,KEY(f1))engine=innodb;
+BEGIN;
+INSERT INTO t1 VALUES();
+SET STATEMENT FOREIGN_KEY_CHECKS=1 FOR SELECT * FROM t1;
+COMMIT;
+DROP TABLE t1;
 --echo # End of 10.11 tests

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -5373,8 +5373,6 @@ dberr_t trx_t::bulk_insert_apply_for_table(dict_table_t *table)
 {
   if (UNIV_UNLIKELY(!bulk_insert))
     return DB_SUCCESS;
-  ut_ad(!check_unique_secondary);
-  ut_ad(!check_foreigns);
   auto it= mod_tables.find(table);
   if (it != mod_tables.end() && it->second.bulk_store)
     if (dberr_t err= it->second.write_bulk(table, this))


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33934*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

This issue is caused by commit 188c5da72a0057e4572b1d7e4efcd0c39332a839 (MDEV-32453).
trx_t::bulk_insert_apply_for_table(): Remove the assert check_unique_secondary and check_foreigns. InnoDB can apply the bulk insert operation even after disabling the check_foreigns and check_unique_secondary variable.

## Release Notes
This change avoids debug assert failure during bulk insert operation.

## How can this PR be tested?
./mtr innodb.insert_into_empty

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
