### PR TITLE
MDEV-33928 : Assertion failure on wsrep_thd_is_aborting

### DIFF
--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -1,4 +1,4 @@
-/* Copyright 2018-2023 Codership Oy <info@codership.com>
+/* Copyright 2018-2024 Codership Oy <info@codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -263,12 +263,28 @@ extern "C" my_bool wsrep_thd_order_before(const THD *left, const THD *right)
   return FALSE;
 }
 
+/** Check if wsrep transaction is aborting state.
+
+Calling function should make sure that wsrep transaction state
+can't change during this function.
+
+This function is called from
+wsrep_abort_thd where we hold THD::LOCK_thd_data
+wsrep_handle_mdl_conflict we hold THD::LOCK_thd_data
+wsrep_assert_no_bf_bf_wait we hold lock_sys.latch
+innobase_kill_query we hold THD::LOCK_thd_data (THD::awake_no_mutex)
+
+@param thd         thread handle
+
+@return true       if wsrep transaction is aborting
+@return false      if not
+
+*/
 extern "C" my_bool wsrep_thd_is_aborting(const MYSQL_THD thd)
 {
-  mysql_mutex_assert_owner(&thd->LOCK_thd_data);
-
   const wsrep::client_state& cs(thd->wsrep_cs());
   const enum wsrep::transaction::state tx_state(cs.transaction().state());
+
   switch (tx_state)
   {
     case wsrep::transaction::s_must_abort:
@@ -277,7 +293,7 @@ extern "C" my_bool wsrep_thd_is_aborting(const MYSQL_THD thd)
     case wsrep::transaction::s_aborting:
       return true;
     default:
-      return false;
+      break;
   }
 
   return false;


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33928*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Problem was assertion assuming we always hold
THD::LOCK_thd_data mutex that is not true.
In most cases this is true but function is
also used from InnoDB lock manager and
there we can't take THD::LOCK_thd_data to
obey mutex ordering. Removed assertion as
wsrep transaction state can't change even
that case.
## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
