### PR TITLE
fix build with WITH_EXTRA_CHARSETS=none in cmake

### DIFF
--- a/strings/ctype-uca.c
+++ b/strings/ctype-uca.c
@@ -39437,18 +39437,24 @@ my_uca1400_collation_definition_init(MY_CHARSET_LOADER *loader,
     *dst= nopad ? my_charset_utf8mb4_unicode_520_nopad_ci :
                   my_charset_utf8mb4_unicode_520_ci;
     break;
+#ifdef HAVE_CHARSET_ucs2
   case MY_CS_ENCODING_UCS2:
     *dst= nopad ? my_charset_ucs2_unicode_520_nopad_ci :
                   my_charset_ucs2_unicode_520_ci;
     break;
+#endif
+#ifdef HAVE_CHARSET_utf16
   case MY_CS_ENCODING_UTF16:
     *dst= nopad ? my_charset_utf16_unicode_520_nopad_ci :
                   my_charset_utf16_unicode_520_ci;
     break;
+#endif
+#ifdef HAVE_CHARSET_utf32
   case MY_CS_ENCODING_UTF32:
     *dst= nopad ? my_charset_utf32_unicode_520_nopad_ci :
                   my_charset_utf32_unicode_520_ci;
     break;
+#endif
   }
 
   dst->number= id;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

This fixes cmake-based builds with -DWITH_EXTRA_CHARSETS=none, which results in a CHARSETS list that does _not_ include ucs2, utf16, or utf32.

## Release Notes
"Building with CMake and -DWITH_EXTRA_CHARSETS=none now works"

## How can this PR be tested?

Compiling with cmake with -DWITH_EXTRA_CHARSETS=none.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

Erm well... the contributing info says to target the "master branch" but no such thing exists, so I targeted the current default branch (11.5 as of this writing). However, the problem exists in all previous version branches as well (I was trying to compile 10.11).

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
