### PR TITLE
MDEV-33334  mariabackup does not always write encrypted files to backup location

### DIFF
--- a/mysql-test/suite/mariabackup/encrypted_export.opt
+++ b/mysql-test/suite/mariabackup/encrypted_export.opt
@@ -1,0 +1,6 @@
+--innodb_encrypt_tables=1
+--plugin-load-add=$FILE_KEY_MANAGEMENT_SO
+--loose-file-key-management
+--loose-file-key-management-filekey=FILE:$MTR_SUITE_DIR/filekeys-data.key
+--loose-file-key-management-filename=$MTR_SUITE_DIR/filekeys-data.enc
+--loose-file-key-management-encryption-algorithm=aes_cbc

--- a/mysql-test/suite/mariabackup/encrypted_export.result
+++ b/mysql-test/suite/mariabackup/encrypted_export.result
@@ -1,0 +1,14 @@
+CREATE TABLE t1(c VARCHAR(128)) ENGINE INNODB;
+insert into t1 values(repeat('a',100));
+select @@innodb_encrypt_tables;
+@@innodb_encrypt_tables
+ON
+# xtrabackup backup
+# xtrabackup prepare export
+# restart
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;

--- a/mysql-test/suite/mariabackup/encrypted_export.test
+++ b/mysql-test/suite/mariabackup/encrypted_export.test
@@ -1,0 +1,29 @@
+--source include/have_file_key_management.inc
+--source include/have_innodb.inc
+
+CREATE TABLE t1(c VARCHAR(128)) ENGINE INNODB;
+insert into t1 values(repeat('a',100));
+
+select @@innodb_encrypt_tables;
+echo # xtrabackup backup;
+let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
+
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --parallel=10 --target-dir=$targetdir;
+--enable_result_log
+--source include/shutdown_mysqld.inc
+
+echo # xtrabackup prepare export;
+--disable_result_log
+exec $XTRABACKUP --prepare --export --target-dir=$targetdir;
+--enable_result_log
+
+--source include/start_mysqld.inc
+let MYSQLD_DATADIR=`select @@datadir`;
+ALTER TABLE t1 DISCARD TABLESPACE;
+copy_file $targetdir/test/t1.ibd $MYSQLD_DATADIR/test/t1.ibd;
+copy_file $targetdir/test/t1.cfg $MYSQLD_DATADIR/test/t1.cfg;
+ALTER TABLE t1 IMPORT TABLESPACE;
+CHECK TABLE t1;
+DROP TABLE t1;
+rmdir $targetdir;


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-33334*

## Description
Problem:
========
mariabackup --prepare fails to write the pages in encrypted format. This issue happens only for default encrypted table when innodb_encrypt_tables variable is enabled.

Fix:
====
backup process should write the value of innodb_encrypt_tables variable in configuration file. prepare should enable the variable based on configuration file.


## How can this PR be tested?
./mtr mariabackup.encrypted_export

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
