### PR TITLE
MDEV-33970  Assertion `!m.first->second.is_bulk_insert()' failed in trx_undo_report_row_operation()

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -500,4 +500,14 @@ f1	f2
 NULL	NULL
 COMMIT;
 DROP TABLE t1;
+#
+#  MDEV-33970  Assertion `!m.first->second.is_bulk_insert()'
+#         failed in trx_undo_report_row_operation()
+#
+CREATE TABLE t1(c1 INT,c2 CHAR) ENGINE=INNODB PARTITION BY KEY(c1) PARTITIONS 2;
+begin;
+INSERT INTO t1 VALUES(2,0);
+DELETE FROM t1;
+commit;
+DROP TABLE t1;
 # End of 10.11 tests

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -534,4 +534,15 @@ INSERT INTO t1 VALUES();
 SET STATEMENT FOREIGN_KEY_CHECKS=1 FOR SELECT * FROM t1;
 COMMIT;
 DROP TABLE t1;
+
+--echo #
+--echo #  MDEV-33970  Assertion `!m.first->second.is_bulk_insert()'
+--echo #         failed in trx_undo_report_row_operation()
+--echo #
+CREATE TABLE t1(c1 INT,c2 CHAR) ENGINE=INNODB PARTITION BY KEY(c1) PARTITIONS 2;
+begin;
+INSERT INTO t1 VALUES(2,0);
+DELETE FROM t1;
+commit;
+DROP TABLE t1;
 --echo # End of 10.11 tests

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -5371,8 +5371,6 @@ void trx_t::bulk_rollback_low()
 
 dberr_t trx_t::bulk_insert_apply_for_table(dict_table_t *table)
 {
-  if (UNIV_UNLIKELY(!bulk_insert))
-    return DB_SUCCESS;
   auto it= mod_tables.find(table);
   if (it != mod_tables.end())
   {


### PR DESCRIPTION

## Description

In case of partition insert, InnoDB fails to end the bulk insert for one of the partition. It leads to bulk insert operation for the consecutive delete statement.

trx_t::bulk_insert_apply_for_table(): Irrespective of bulk insert value, InnoDB should end the bulk insert for the table.

## How can this PR be tested?
./mtr innodb.insert_into_empty
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
