### PR TITLE
MDEV-33979 Disallow bulk insert operation during partition update statement

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -251,4 +251,13 @@ c1
 1984
 3331
 DROP TABLE t1;
+#
+#  MDEV-33979 Disallow bulk insert operation during
+#      partition update statement
+#
+CREATE TABLE t1(a INT KEY)ENGINE=InnoDB
+PARTITION BY KEY(a) PARTITIONS 16;
+INSERT INTO t1 VALUES(1);
+UPDATE t1 SET a = 2 WHERE a = 1;
+DROP TABLE t1;
 # End of 10.6 tests

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -269,4 +269,14 @@ connection default;
 disconnect con1;
 SELECT * FROM t1;
 DROP TABLE t1;
+
+--echo #
+--echo #  MDEV-33979 Disallow bulk insert operation during
+--echo #      partition update statement
+--echo #
+CREATE TABLE t1(a INT KEY)ENGINE=InnoDB
+		PARTITION BY KEY(a) PARTITIONS 16;
+INSERT INTO t1 VALUES(1);
+UPDATE t1 SET a = 2 WHERE a = 1;
+DROP TABLE t1;
 --echo # End of 10.6 tests

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8776,6 +8776,7 @@ ha_innobase::delete_row(
 		: PLAIN_DELETE;
 	trx->fts_next_doc_id = 0;
 
+	ut_ad(!trx->is_bulk_insert());
 	error = row_update_for_mysql(m_prebuilt);
 
 #ifdef WITH_WSREP

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2708,7 +2708,9 @@ err_exit:
 	    && !index->table->skip_alter_undo
 	    && !index->table->n_rec_locks
 	    && !index->table->is_active_ddl()
-	    && !index->table->versioned()) {
+	    && !index->table->versioned()
+            && (!dict_table_is_partition(index->table)
+	        || thd_sql_command(trx->mysql_thd) == SQLCOM_INSERT)) {
 		DEBUG_SYNC_C("empty_root_page_insert");
 
 		if (!index->table->is_temporary()) {


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33979*

## Description
Problem:
========
- Partition update operation enables the bulk insert for the transaction while moving the row between partitions. This leads to debug assert failure while removing the row from one of the partition.

Solution:
========
- Disallow the bulk insert operation for non-insert operation of partition table.



## How can this PR be tested?
./mtr innodb.insert_into_empty

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
