### PR TITLE
MDEV-22855 Assertion `!field->prefix_len || field->fixed_len == field->prefix_len` failed in btr_node_ptr_max_size

### DIFF
--- a/mysql-test/suite/innodb/r/index_length.result
+++ b/mysql-test/suite/innodb/r/index_length.result
@@ -20,4 +20,12 @@ FLOOR(index_length/@@innodb_page_size)
 2
 disconnect stop_purge;
 DROP TABLE t1;
+#
+# MDEV-22855  Assertion (!field->prefix_len ||
+#        field->fixed_len == field->prefix_len)
+#        failed in btr_node_ptr_max_size
+#
+CREATE TABLE t1(c CHAR(194) CHARACTER SET UTF32, KEY k1(c(193)))ENGINE=InnoDB;
+INSERT INTO t1 SET c='';
+DROP TABLE t1;
 # End of 10.4 tests

--- a/mysql-test/suite/innodb/t/index_length.test
+++ b/mysql-test/suite/innodb/t/index_length.test
@@ -20,4 +20,12 @@ WHERE table_schema = 'test' AND table_name = 't1';
 disconnect stop_purge;
 DROP TABLE t1;
 
+--echo #
+--echo # MDEV-22855  Assertion (!field->prefix_len ||
+--echo #        field->fixed_len == field->prefix_len)
+--echo #        failed in btr_node_ptr_max_size
+--echo #
+CREATE TABLE t1(c CHAR(194) CHARACTER SET UTF32, KEY k1(c(193)))ENGINE=InnoDB;
+INSERT INTO t1 SET c='';
+DROP TABLE t1;
 --echo # End of 10.4 tests

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1126,7 +1126,7 @@ static ulint btr_node_ptr_max_size(const dict_index_t* index)
 		/* Determine the maximum length of the index field. */
 
 		field_max_size = dict_col_get_fixed_size(col, comp);
-		if (field_max_size) {
+		if (field_max_size && field->fixed_len) {
 			/* dict_index_add_col() should guarantee this */
 			ut_ad(!field->prefix_len
 			      || field->fixed_len == field->prefix_len);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-22855*

## Description
Problem:
========
- InnoDB wrongly calulates the record size in btr_node_ptr_max_size() when prefix index of
the column has to be stored externally.

Fix:
====
- InnoDB should add the maximum field size to record size when the field is a fixed length one.

## How can this PR be tested?
./mtr innodb.innodb-index

# Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
