### PR TITLE
Allow MariaDB server to startup past 2038 and continue to verify compatibility with testing in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,23 +283,20 @@ centos7:
       - rpm
       - builddir/_CPack_Packages/Linux/RPM/SPECS/
 
-.mysql-test-run: &mysql-test-run-def
-  stage: test
-  script:
+.mysql-test-run: &mysql-test-run-def |
     # Install packages so tests and the dependencies install
     # @TODO: RPM missing 'patch' and 'diff' as dependency, so installing it manually for now
-    - yum install -y rpm/*.rpm patch diffutils
+    yum install -y rpm/*.rpm patch diffutils
     # mtr expects to be launched in-place and with write access to it's own directories
-    - cd /usr/share/mariadb-test
+    cd /usr/share/mariadb-test
     # Skip failing tests
-    - |
-      echo "
+    echo "
       main.mysqldump : Field separator argument is not what is expected; check the manual when executing 'SELECT INTO OUTFILE'
       main.flush_logs_not_windows : query 'flush logs' succeeded - should have failed with error ER_CANT_CREATE_FILE (1004)
       main.mysql_upgrade_noengine : upgrade output order does not match the expected
       main.func_math              : MDEV-20966 - Wrong error code
-      " > skiplist
-    - ./mtr --suite=main --force --parallel=auto --xml-report=$CI_PROJECT_DIR/junit.xml --skip-test-list=skiplist $RESTART_POLICY
+    " > skiplist
+    $SIMULATE_TIME ./mtr --suite=main --force --parallel=auto --xml-report=$CI_PROJECT_DIR/junit.xml --skip-test-list=skiplist $MTR_FLAGS
 
 mysql-test-run:
   stage: test
@@ -307,7 +304,8 @@ mysql-test-run:
     - fedora
   needs:
     - fedora
-  <<: *mysql-test-run-def
+  script:
+    - *mysql-test-run-def
   artifacts:
     when: always  # Also show results when tests fail
     reports:
@@ -325,12 +323,13 @@ mysql-test-run:
 mysql-test-run-asan:
   stage: test
   variables:
-    RESTART_POLICY: "--force-restart"
+    MTR_FLAGS: "--force-restart"
   dependencies:
     - "fedora-sanitizer: [-DWITH_ASAN=YES]"
   needs:
     - "fedora-sanitizer: [-DWITH_ASAN=YES]"
-  <<: *mysql-test-run-def
+  script:
+    - *mysql-test-run-def
   allow_failure: true
   artifacts:
     when: always  # Also show results when tests fail
@@ -341,12 +340,13 @@ mysql-test-run-asan:
 mysql-test-run-tsan:
   stage: test
   variables:
-    RESTART_POLICY: "--force-restart"
+    MTR_FLAGS: "--force-restart"
   dependencies:
     - "fedora-sanitizer: [-DWITH_TSAN=YES]"
   needs:
     - "fedora-sanitizer: [-DWITH_TSAN=YES]"
-  <<: *mysql-test-run-def
+  script:
+    - *mysql-test-run-def
   allow_failure: true
   artifacts:
     when: always  # Also show results when tests fail
@@ -357,18 +357,41 @@ mysql-test-run-tsan:
 mysql-test-run-ubsan:
   stage: test
   variables:
-    RESTART_POLICY: "--force-restart"
+    MTR_FLAGS: "--force-restart"
   dependencies:
     - "fedora-sanitizer: [-DWITH_UBSAN=YES]"
   needs:
     - "fedora-sanitizer: [-DWITH_UBSAN=YES]"
-  <<: *mysql-test-run-def
+  script:
+    - *mysql-test-run-def
   allow_failure: true
   artifacts:
     when: always  # Also show results when tests fail
     reports:
       junit:
         - junit.xml
+
+mysql-test-run-future:
+  stage: test
+  variables:
+    MTR_FLAGS: "--max-test-fail=0"
+  dependencies:
+    - fedora
+  needs:
+    - fedora
+  script:
+    - yum install -y faketime
+    - *mysql-test-run-def
+  artifacts:
+    when: always  # Also show results when tests fail
+    reports:
+      junit:
+        - junit.xml
+  parallel:
+    matrix:
+    # The reason we test in two different future times is for the ability to separate between 
+    # failures pertaining to general time expiry issues and failures specific to the 32-bit time/Y2038 problem
+      - SIMULATE_TIME: ["faketime 2038-01-20",  "faketime 2038-01-18"]
 
 rpmlint:
   stage: test

--- a/mysql-test/main/long_unique_bugs.result
+++ b/mysql-test/main/long_unique_bugs.result
@@ -59,8 +59,8 @@ update t1 set f = 'foo';
 select * from t1;
 pk	f
 1	foo
-select pk, f, row_end > DATE'2030-01-01' from t1 for system_time all;
-pk	f	row_end > DATE'2030-01-01'
+select pk, f, row_end > DATE'2106-01-01' from t1 for system_time all;
+pk	f	row_end > DATE'2106-01-01'
 1	foo	1
 1	foo	0
 1	bar	0

--- a/mysql-test/main/long_unique_bugs.test
+++ b/mysql-test/main/long_unique_bugs.test
@@ -59,7 +59,7 @@ update t1 set f = 'bar';
 select * from t1;
 update t1 set f = 'foo';
 select * from t1;
-select pk, f, row_end > DATE'2030-01-01' from t1 for system_time all;
+select pk, f, row_end > DATE'2106-01-01' from t1 for system_time all;
 drop table t1;
 
 --echo #

--- a/mysql-test/main/sp.result
+++ b/mysql-test/main/sp.result
@@ -2734,7 +2734,7 @@ drop table t3|
 drop procedure if exists bug6857|
 create procedure bug6857()
 begin
-declare t0, t1 int;
+declare t0, t1 bigint;
 declare plus bool default 0;
 set t0 = unix_timestamp();
 select sleep(1.1);

--- a/mysql-test/main/sp.test
+++ b/mysql-test/main/sp.test
@@ -3365,7 +3365,7 @@ drop procedure if exists bug6857|
 --enable_warnings
 create procedure bug6857()
 begin
-  declare t0, t1 int;
+  declare t0, t1 bigint;
   declare plus bool default 0;
   set t0 = unix_timestamp();
   select sleep(1.1);

--- a/mysys/thr_timer.c
+++ b/mysys/thr_timer.c
@@ -35,9 +35,15 @@ static mysql_cond_t  COND_timer;
 static QUEUE timer_queue;
 pthread_t timer_thread;
 
+#if SIZEOF_VOIDP == 4
+/* 32 bit system, using old timestamp */
 #define set_max_time(abs_time) \
   { (abs_time)->MY_tv_sec= INT_MAX32; (abs_time)->MY_tv_nsec= 0; }
-
+#else
+/* 64 bit system. Use 4 byte unsigned timestamp */
+#define set_max_time(abs_time) \
+  { (abs_time)->MY_tv_sec= UINT_MAX32; (abs_time)->MY_tv_nsec= 0; }
+#endif
 
 static void *timer_handler(void *arg __attribute__((unused)));
 


### PR DESCRIPTION
#### Note: This PR is intended to only be merged AFTER the changes in branch `bb-11.5-MDEV-32188-timestamps` are finalized and merged into mainline 11.5

- [x] *The Jira issue number for this PR is: MDEV-32188*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Commits in branch: `bb-11.5-MDEV-32188-timestamps` made changes to use the entire 32 bit unsigned range in order to support timestamps past 2038-01-20 on 64 bit systems. 

**Without changing set_max_time on thr_timer to also match this new range, the server will crash when attempting to startup past 2038-01-19.** Like the commits in `bb-11.5-MDEV-32188-timestamps`, the changes only apply to 64 bit systems.

Furthermore, in order to ensure that all future changes preserve the ability for the engine to start and function past the year 2038, a new GitLab MTR run is added which uses libfaketime to simulate starting the server and running the test suite in the future. The job simulates running in two times in the year 2038, once before the signed 32 bit UNIX limit and once after.

## Release Notes

- MariaDB now supports running past the signed 32 bit UNIX timestamp limit 2038-01-19. 

## How can this PR be tested?

- `./mtr --suite=main` successfully completes both locally and in GitLab CI when running at the present time, in simulated 2038-01-18 and simulated 2038-01-20 while running on branch `bb-11.5-MDEV-32188-timestamps`

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

-------

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.