### PR TITLE
[MDEV-34009] Introduce server-initiated instant failover mechanism

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -248,7 +248,8 @@ static my_bool ignore_errors=0,wait_flag=0,quick=0,
                default_pager_set= 0, opt_sigint_ignore= 0,
                auto_vertical_output= 0, show_query_cost= 0,
                show_warnings= 0, executing_query= 0,
-               ignore_spaces= 0, opt_binhex= 0, opt_progress_reports;
+               ignore_spaces= 0, opt_binhex= 0, opt_progress_reports,
+               opt_follow_instant_failovers= 1;
 static my_bool debug_info_flag, debug_check_flag, batch_abort_on_error;
 static my_bool column_types_flag;
 static my_bool preserve_comments= 0;
@@ -1503,6 +1504,8 @@ static bool do_connect(MYSQL *mysql, const char *host, const char *user,
   if (opt_secure_auth)
     mysql_options(mysql, MYSQL_SECURE_AUTH, (char *) &opt_secure_auth);
   SET_SSL_OPTS_WITH_CHECK(mysql);
+  mysql_options(mysql,MARIADB_OPT_FOLLOW_INSTANT_FAILOVERS,
+                (char*)&opt_follow_instant_failovers);
   if (opt_protocol)
     mysql_options(mysql,MYSQL_OPT_PROTOCOL,(char*)&opt_protocol);
   if (opt_plugin_dir && *opt_plugin_dir)
@@ -1805,6 +1808,11 @@ static struct my_option my_long_options[] =
    &opt_mysql_unix_port, &opt_mysql_unix_port, 0, GET_STR_ALLOC,
    REQUIRED_ARG, 0, 0, 0, 0, 0, 0},
 #include "sslopt-longopts.h"
+  {"follow-instant-failovers", 0,
+   "Follow instant failovers. Disable with "
+   "--disable-follow-instant-failovers. This option is enabled by default.",
+   &opt_follow_instant_failovers, &opt_follow_instant_failovers,
+   0, GET_BOOL, OPT_ARG, 1, 0, 0, 0, 0, 0},
   {"table", 't', "Output in table format.", &output_tables,
    &output_tables, 0, GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0},
   {"tee", OPT_TEE,

--- a/mysql-test/main/instant_failover.cnf
+++ b/mysql-test/main/instant_failover.cnf
@@ -1,0 +1,7 @@
+!include include/default_my.cnf
+
+[mysqld.1]
+extra-port=@ENV.MASTER_EXTRA_PORT
+
+[ENV]
+MASTER_EXTRA_PORT= @OPT.port

--- a/mysql-test/main/instant_failover.result
+++ b/mysql-test/main/instant_failover.result
@@ -1,0 +1,40 @@
+call mtr.add_suppression("\\[Warning\\] Redirecting connection \\d+ via \\S+ to INSTANT_FAILOVER_TARGET=\\S+ \\(INSTANT_FAILOVER_MODE=\\w+\\)");
+Verify that a TCP connection works with --disable-follow-instant-failovers (before enabling instant failover)
+default_port_tcp_works
+1
+Verify that connections via local socket and extra port SUCCEED
+connection default;
+connect local_sock,localhost,root,,test;
+disconnect local_sock;
+connect tcp_sock,127.0.0.1,root,,test,$MASTER_EXTRA_PORT;
+disconnect tcp_sock;
+Enable instant failover in its default mode (ON)
+connection default;
+set global instant_failover_mode=ON;
+set global instant_failover_target="127.0.0.1:$MASTER_EXTRA_PORT"
+With --disable-follow-instant-failovers, connecting to the default port should now fail
+With --follow-instant-failovers (the client library default), this should redirect to the extra port
+connect OKAY,127.0.0.1,root,,test,$MASTER_MYPORT;
+disconnect OKAY;
+Setup a redirect loop, and verify that connections fail due to the loop
+connection default;
+set global instant_failover_target="127.0.0.1:$MASTER_MYPORT"
+connect(127.0.0.1,root,,test,MASTER_MYPORT,MASTER_MYSOCK);
+connect fail_con,127.0.0.1,root,,test,$MASTER_MYPORT;
+ERROR HY000: Too many instant failovers (>= 8)
+Change instant failover mode to ALL, and verify that even connections via local socket and extra port now FAIL due to the loop
+connection default;
+set global instant_failover_mode=ALL;
+connect(localhost,root,,test,MASTER_MYPORT,MASTER_MYSOCK);
+connect fail_con,localhost,root,,test;
+ERROR HY000: Too many instant failovers (>= 8)
+connect(127.0.0.1,root,,test,MASTER_EXTRA_PORT,MASTER_MYSOCK);
+connect fail_con,127.0.0.1,root,,test,$MASTER_EXTRA_PORT;
+ERROR HY000: Too many instant failovers (>= 8)
+Turn instant failover back off
+connection default;
+set global instant_failover_mode=OFF;
+set global instant_failover_target=DEFAULT;
+Connections should now succeed again, even with --disable-follow-instant-failovers
+default_port_tcp_works
+1

--- a/mysql-test/main/instant_failover.test
+++ b/mysql-test/main/instant_failover.test
@@ -1,0 +1,64 @@
+# We need to ignore the redirection warnings in the server logs, e.g.
+# "Redirecting connection N via SSL/TLS to INSTANT_FAILOVER_TARGET=127.0.0.1:$MASTER_EXTRA_PORT (INSTANT_FAILOVER_MODE=ON)"
+call mtr.add_suppression("\\[Warning\\] Redirecting connection \\d+ via \\S+ to INSTANT_FAILOVER_TARGET=\\S+ \\(INSTANT_FAILOVER_MODE=\\w+\\)");
+
+##########
+--echo Verify that a TCP connection works with --disable-follow-instant-failovers (before enabling instant failover)
+--exec $MYSQL --disable-follow-instant-failovers --host=127.0.0.1 --port=$MASTER_MYPORT test -e "select 1 as default_port_tcp_works"
+
+--echo Verify that connections via local socket and extra port SUCCEED
+--connection default
+--connect local_sock,localhost,root,,test
+--disconnect local_sock
+--connect tcp_sock,127.0.0.1,root,,test,$MASTER_EXTRA_PORT
+--disconnect tcp_sock
+
+##########
+--echo Enable instant failover in its default mode (ON)
+--connection default
+set global instant_failover_mode=ON;
+--echo set global instant_failover_target="127.0.0.1:\$MASTER_EXTRA_PORT"
+--disable_query_log
+--eval set global instant_failover_target="127.0.0.1:$MASTER_EXTRA_PORT"
+--enable_query_log
+
+##########
+--echo With --disable-follow-instant-failovers, connecting to the default port should now fail
+--error 1
+--exec $MYSQL --disable-follow-instant-failovers --host=127.0.0.1 --port=$MASTER_MYPORT test -e "select 1"
+
+--echo With --follow-instant-failovers (the client library default), this should redirect to the extra port
+--connect OKAY,127.0.0.1,root,,test,$MASTER_MYPORT
+--disconnect OKAY
+
+##########
+--echo Setup a redirect loop, and verify that connections fail due to the loop
+--connection default
+--echo set global instant_failover_target="127.0.0.1:\$MASTER_MYPORT"
+--disable_query_log
+--eval set global instant_failover_target="127.0.0.1:$MASTER_MYPORT"
+--enable_query_log
+--replace_result $MASTER_MYSOCK MASTER_MYSOCK $MASTER_MYPORT MASTER_MYPORT
+--error ER_INSTANT_FAILOVER
+--connect fail_con,127.0.0.1,root,,test,$MASTER_MYPORT
+
+##########
+--echo Change instant failover mode to ALL, and verify that even connections via local socket and extra port now FAIL due to the loop
+--connection default
+set global instant_failover_mode=ALL;
+--replace_result $MASTER_MYSOCK MASTER_MYSOCK $MASTER_MYPORT MASTER_MYPORT
+--error ER_INSTANT_FAILOVER
+--connect fail_con,localhost,root,,test
+--replace_result $MASTER_MYSOCK MASTER_MYSOCK $MASTER_EXTRA_PORT MASTER_EXTRA_PORT
+--error ER_INSTANT_FAILOVER
+--connect fail_con,127.0.0.1,root,,test,$MASTER_EXTRA_PORT
+
+##########
+--echo Turn instant failover back off
+--connection default
+set global instant_failover_mode=OFF;
+set global instant_failover_target=DEFAULT;
+
+--echo Connections should now succeed again, even with --disable-follow-instant-failovers
+--error 0
+--exec $MYSQL --disable-follow-instant-failovers --host=127.0.0.1 --port=$MASTER_MYPORT test -e "select 1 as default_port_tcp_works"

--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -433,6 +433,20 @@ The following specify which files/extra groups are read (specified before remain
  Set the replication role. One of: MASTER, SLAVE
  --init-slave=name   Command(s) that are executed by a slave server each time
  the SQL thread starts
+ --instant-failover-mode=name 
+ Instant failover mode. Possible modes are: OFF - No
+ instant failover, ON: Unconditionally redirect new
+ clients connecting over the network via the standard
+ server port to INSTANT_FAILOVER_TARGET (no redirection of
+ local socket-based connections, nor of connections to the
+ EXTRA_PORT), ALL: Unconditionally redirect all new
+ clients to INSTANT_FAILOVER_TARGET (even via local
+ socket-based connections and the EXTRA_PORT).
+ --instant-failover-target=name 
+ Instant failover target. This should be a hostname, an IP
+ address, or a hostname or IP address followed by ':PORT'.
+ Instant failover will not be activated unless
+ INSTANT_FAILOVER_MODE is also set.
  --interactive-timeout=# 
  The number of seconds the server waits for activity on an
  interactive connection before closing it
@@ -1706,6 +1720,8 @@ init-connect
 init-file (No default value)
 init-rpl-role MASTER
 init-slave 
+instant-failover-mode OFF
+instant-failover-target (No default value)
 interactive-timeout 28800
 join-buffer-size 262144
 join-buffer-space-limit 2097152

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1526,6 +1526,12 @@ static Atomic_counter<uint> extra_connection_count;
 
 my_bool opt_gtid_strict_mode= FALSE;
 
+/**
+ Instant failover
+ */
+
+const char *instant_failover_target = NullS;
+ulong instant_failover_mode= INSTANT_FAILOVER_MODE_OFF;
 
 /* Function declarations */
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -1002,6 +1002,14 @@ extern ulong opt_binlog_dbug_fsync_sleep;
 extern uint volatile global_disable_checkpoint;
 extern my_bool opt_help;
 
+extern const char *instant_failover_target;
+enum enum_instant_failover_mode {
+    INSTANT_FAILOVER_MODE_OFF = 0,
+    INSTANT_FAILOVER_MODE_ON = 1,
+    INSTANT_FAILOVER_MODE_ALL = 2
+};
+extern ulong instant_failover_mode;
+
 extern int mysqld_main(int argc, char **argv);
 
 #ifdef _WIN32

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12280,3 +12280,7 @@ ER_SEQUENCE_TABLE_CANNOT_HAVE_ANY_CONSTRAINTS
         eng "Sequence tables cannot have any constraints"
 ER_SEQUENCE_TABLE_ORDER_BY
         eng "ORDER BY"
+ER_INSTANT_FAILOVER
+        eng "|Server is directing clients to the alternative server '%1$s'|%1$s"
+        fra "|Ce serveur dirige ses clients vers le serveur alternatif '%1$s'|%1$s"
+        spa "|Este servidor está dirigiendo sus clientes al servidor alternativo '%1$s'|%1$s"

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -13904,6 +13904,84 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
   char *end;
   DBUG_ASSERT(mpvio->status == MPVIO_EXT::FAILURE);
 
+  enum enum_vio_type type= vio_type(thd->net.vio);
+  bool local_connection= (type == VIO_TYPE_SOCKET) || (type == VIO_TYPE_NAMEDPIPE);
+  uint16_t server_port = 0;
+  bool is_extra_port= FALSE;
+
+  if (!local_connection) {
+    /* We want to determine if the client is connecting to the TCP
+     * port optionally configured via the system variable
+     * EXTRA_PORT. This is intended for emergency/administrative
+     * use. (See
+     * https://mariadb.com/kb/en/thread-pool-in-mariadb/#configuring-the-extra-port)
+     *
+     * Based on its name and usage elsewhere in the server codebase,
+     * I expected that the net->vio->mysql_socket data structure
+     * would be populated at this point, including the member
+     * .is_extra_port whose name suggests it is precisely intended
+     * to convey this information.
+     *
+     * However, debugging with GDB demonstrates that
+     * net->vio->mysql_socket is NOT reliably populated, and in
+     * particular .is_extra_port appears to have the value 127
+     * regardless of whether client has connected via the extra
+     * port, or not.
+     *
+     * This means that we need to compare the local socket
+     * address to mysqld_extra_port (which holds the value of the
+     * EXTRA_PORT system vairable).
+     *
+     * That leads to another data structure which is inexplicably
+     * unpopulated at this point: net->vio->local. Since we cannot
+     * rely on that data structure either, we have to populate it
+     * ourselves here.
+     *
+     * FIXME: If net->vio->mysql_socket were sanely and reliably
+     * populated here, this entire 'if'-block could be replaced
+     * with:
+     *
+     *   is_extra_port= net->vio->mysql_socket->is_extra_port.
+     */
+
+    union _sockaddr_ipv46 {
+      struct sockaddr_storage _nvl; /* This is the actual type of net->vio->local */
+      struct sockaddr_in inaddr;
+      struct sockaddr_in6 in6addr;
+      struct sockaddr addr;
+    } *a = (union _sockaddr_ipv46 *)&net->vio->local;
+
+    if (a->_nvl.ss_family == AF_UNSPEC)
+    {
+      /* FIXME: If we could rely on net->vio->local having already
+       * been populated, we could remove this entire 'if' block.
+       */
+      socklen_t addrlen = sizeof(a->_nvl);
+      memset(a, 0, addrlen);
+      if (mysql_socket_getsockname(net->vio->mysql_socket, &a->addr, &addrlen) == -1)
+        DBUG_PRINT("error", ("mysql_socket_getsockname(net->vio->mysql_socket.fd = %d) failed: errno = %d",
+                             net->vio->mysql_socket.fd, errno));
+      else if (a->addr.sa_family != AF_INET && a->addr.sa_family != AF_INET6)
+        DBUG_PRINT("error", ("mysql_socket_getsockname(net->vio->mysql_socket.fd = %d) unexpectedly returned non-IP address family: %d",
+                             net->vio->mysql_socket.fd, a->addr.sa_family));
+    }
+
+    if (a->_nvl.ss_family == AF_INET || a->_nvl.ss_family == AF_INET6) {
+      server_port= ntohs(a->addr.sa_family == AF_INET
+                         ? a->inaddr.sin_port
+                         : a->in6addr.sin6_port);
+      DBUG_PRINT("info", ("Client has connected via TCP/IP port %d (EXTRA_PORT is %d)",
+                          server_port, mysqld_extra_port));
+
+      /* FIXME: Should we set net->vio->mysql_socket.is_extra_port directly,
+       * or will that have unintended side effects?
+       *
+       * Err on the side of caution and simply set a local variable.
+       */
+      is_extra_port= (server_port == mysqld_extra_port);
+    }
+  }
+
   if (pkt_len < MIN_HANDSHAKE_SIZE)
     return packet_error;
 
@@ -14002,11 +14080,9 @@ static ulong parse_client_handshake_packet(MPVIO_EXT *mpvio,
    *   a security vulnerability that needs a separate fix (see more details at
    *   https://jira.mariadb.org/browse/CONC-648).
    */
-  enum enum_vio_type type= vio_type(thd->net.vio);
-  bool local_connection= (type == VIO_TYPE_SOCKET) || (type == VIO_TYPE_NAMEDPIPE);
 
   if (instant_failover_mode == INSTANT_FAILOVER_MODE_ALL ||
-      (instant_failover_mode == INSTANT_FAILOVER_MODE_ON && !local_connection))
+      (instant_failover_mode == INSTANT_FAILOVER_MODE_ON && !local_connection && !is_extra_port))
   {
     sql_print_warning("Redirecting connection %lld via %s to INSTANT_FAILOVER_TARGET=%s (INSTANT_FAILOVER_MODE=%s)",
                       thd->thread_id, safe_vio_type_name(thd->net.vio), instant_failover_target,

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7344,7 +7344,7 @@ static Sys_var_enum Sys_instant_failover_mode(
        "instant_failover_mode",
        "Instant failover mode. "
        "Possible modes are: OFF - No instant failover, "
-       "ON: Unconditionally redirect new clients connecting over the network to INSTANT_FAILOVER_TARGET (no redirection of local socket-based connections), "
-       "ALL: Unconditionally redirect all new clients to INSTANT_FAILOVER_TARGET (even via local socket-based connections).",
+       "ON: Unconditionally redirect new clients connecting over the network via the standard server port to INSTANT_FAILOVER_TARGET (no redirection of local socket-based connections, nor of connections to the EXTRA_PORT), "
+       "ALL: Unconditionally redirect all new clients to INSTANT_FAILOVER_TARGET (even via local socket-based connections and the EXTRA_PORT).",
        GLOBAL_VAR(instant_failover_mode), CMD_LINE(REQUIRED_ARG),
        instant_failover_mode_names, DEFAULT(0));

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7328,3 +7328,23 @@ static Sys_var_enum Sys_block_encryption_mode(
   "AES_ENCRYPT() and AES_DECRYPT() functions",
   SESSION_VAR(block_encryption_mode), CMD_LINE(REQUIRED_ARG),
   block_encryption_mode_values, DEFAULT(0));
+
+static Sys_var_charptr_fscs Sys_instant_failover_target(
+	"instant_failover_target",
+        "Instant failover target. This should be a hostname, an IP address, or "
+        "a hostname or IP address followed by ':PORT'. Instant failover will "
+        "not be activated unless INSTANT_FAILOVER_MODE is also set.",
+        GLOBAL_VAR(instant_failover_target), CMD_LINE(REQUIRED_ARG),
+        DEFAULT(NULL));
+
+static const char *instant_failover_mode_names[]= {
+        "OFF", "ON", "ALL", 0 };
+
+static Sys_var_enum Sys_instant_failover_mode(
+       "instant_failover_mode",
+       "Instant failover mode. "
+       "Possible modes are: OFF - No instant failover, "
+       "ON: Unconditionally redirect new clients connecting over the network to INSTANT_FAILOVER_TARGET (no redirection of local socket-based connections), "
+       "ALL: Unconditionally redirect all new clients to INSTANT_FAILOVER_TARGET (even via local socket-based connections).",
+       GLOBAL_VAR(instant_failover_mode), CMD_LINE(REQUIRED_ARG),
+       instant_failover_mode_names, DEFAULT(0));


### PR DESCRIPTION
This PR is a pared-down version of https://github.com/MariaDB/server/pull/3224, which _only_ introduces the server-initiated instant failover mechanism and _does not address_ any of the pre-existing TLS issues which were discovered or highlighted during its development.

Upstream developers chose a different approach (see https://github.com/MariaDB/server/pull/1472 and https://github.com/mariadb-corporation/mariadb-connector-c/pull/137) for [MDEV-15935](https://jira.mariadb.org/browse/MDEV-15935) ("connection redirection").

I maintain that a **simple and obligatory** server-directed failover mechanism will be a very useful feature for many users, so I'm reintroducing it here under the alternative name of "instant failover."

## Description

This PR proposes a new feature in [the MariaDB client-server protocol](https://mariadb.com/kb/en/clientserver-protocol): a server-initiated failover which can redirect new client connections to an alternate endpoint at the application layer.

It also provides an initial server-side implementation of that feature; the corresponding client-side implementation is in https://github.com/mariadb-corporation/mariadb-connector-c/pull/246.

We want the MariaDB server to be able to tell clients connecting to it, “Sorry, this server is unavailable. Connect to an alternate server instead.” This mechanism is inspired by HTTP 302 (“temporary redirect”) mechanism familiar to all developers of web applications, and is intended to have similar semantics and security properties, since these have now been widely deployed and tested for decades.

## How can this PR be tested?

### Automated testing

- [X] The newly-added `main.instant_failover` MTR test functionally verifies the instant failover mechanism.
- [x] Pre-existing MTR tests are updated and passing.

### Manual testing

- Build the server from this PR, along with the updated client from https://github.com/mariadb-corporation/mariadb-connector-c/pull/246 (included in this PR as a submodule change).
- Start the server with `sql/mariadbd --instant-failover-mode=ON --instant-failover-target='some-other-mariadb.server.com:3306' --port=3306 --extra-port=3307 --socket=/tmp/mysql.sock`
- Connect with the updated client and observe the failover/redirection behavior, including the fact that connections to the [`EXTRA_PORT`](https://mariadb.com/kb/en/thread-pool-in-mariadb/#configuring-the-extra-port) and to the Unix socket  are _not_ redirected:
  - `client/mariadb --host 127.0.0.1 --port=3306 -uUSERNAME -pPASSWORD` → redirected to `INSTANT_FAILOVER_TARGET`  - `client/mariadb --host 127.0.0.1 --port=3307 -uUSERNAME -pPASSWORD` → _not_ redirected (`EXTRA PORT`)
  - `client/mariadb --socket=/tmp/mysql.sock -uUSERNAME -pPASSWORD` → _not_ redirected (local/non-network-based connection)

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch, **11.5**.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/11.0/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
