### PR TITLE
MDEV-33997 : Assertion `((WSREP_PROVIDER_EXISTS_ && this->variables.w…

### DIFF
--- a/mysql-test/suite/wsrep/r/MDEV-33997.result
+++ b/mysql-test/suite/wsrep/r/MDEV-33997.result
@@ -1,0 +1,38 @@
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+INSERT INTO t SELECT 1 ;
+COMMIT;
+SELECT * FROM t;
+c
+1
+1
+DROP TABLE t;
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t SELECT 1 ;
+SELECT * FROM t;
+c
+1
+DROP TABLE t;
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t SELECT 1 ;
+ERROR 42000: This version of MariaDB doesn't yet support 'RSU on this table engine'
+SELECT * FROM t;
+c
+DROP TABLE t;
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+INSERT INTO t SELECT 1 ;
+ERROR 42000: This version of MariaDB doesn't yet support 'RSU on this table engine'
+COMMIT;
+SELECT * FROM t;
+c
+1
+DROP TABLE t;

--- a/mysql-test/suite/wsrep/t/MDEV-33997.cnf
+++ b/mysql-test/suite/wsrep/t/MDEV-33997.cnf
@@ -1,0 +1,9 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+binlog-format=ROW
+innodb-flush-log-at-trx-commit=1
+wsrep-cluster-address=gcomm://
+wsrep-provider=@ENV.WSREP_PROVIDER
+innodb-autoinc-lock-mode=2

--- a/mysql-test/suite/wsrep/t/MDEV-33997.combinations
+++ b/mysql-test/suite/wsrep/t/MDEV-33997.combinations
@@ -1,0 +1,4 @@
+[binlogon]
+log-bin
+
+[binlogoff]

--- a/mysql-test/suite/wsrep/t/MDEV-33997.test
+++ b/mysql-test/suite/wsrep/t/MDEV-33997.test
@@ -1,0 +1,49 @@
+--source include/have_wsrep.inc
+--source include/have_innodb.inc
+--source include/have_wsrep_provider.inc
+--source include/have_partition.inc
+#
+# MDEV-33997: Assertion `((WSREP_PROVIDER_EXISTS_ && this->variables.wsrep_on) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()' failed in int THD::binlog_write_row(TABLE*, bool, const uchar*)
+#
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+INSERT INTO t SELECT 1 ;
+COMMIT;
+SELECT * FROM t;
+DROP TABLE t;
+
+#
+# MDEV-27296 : Assertion `((thd && (WSREP_PROVIDER_EXISTS_ && thd->variables.wsrep_on)) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()' failed
+# Second test case
+#
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=INNODB PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t SELECT 1 ;
+SELECT * FROM t;
+DROP TABLE t;
+
+#
+# We should not allow RSU for MyISAM
+#
+SET autocommit=1;
+SET SESSION wsrep_osu_method=RSU;
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t SELECT 1 ;
+SELECT * FROM t;
+DROP TABLE t;
+
+SET SESSION wsrep_osu_method=RSU;
+SET autocommit=0;
+
+CREATE TABLE t (c INT) ENGINE=MYISAM PARTITION BY KEY(c) PARTITIONS 2;
+INSERT INTO t VALUES (1);
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t SELECT 1 ;
+COMMIT;
+SELECT * FROM t;
+DROP TABLE t;

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -5495,13 +5495,15 @@ int Rows_log_event::do_apply_event(rpl_group_info *rgi)
 #ifdef WITH_WSREP
       if (WSREP(thd))
       {
-        WSREP_WARN("BF applier failed to open_and_lock_tables: %u, fatal: %d "
+        WSREP_WARN("BF applier thread=%lu failed to open_and_lock_tables for "
+                   "%s, fatal: %d "
                    "wsrep = (exec_mode: %d conflict_state: %d seqno: %lld)",
-                    thd->get_stmt_da()->sql_errno(),
-                    thd->is_fatal_error,
-                    thd->wsrep_cs().mode(),
-                    thd->wsrep_trx().state(),
-                    (long long) wsrep_thd_trx_seqno(thd));
+                   thd_get_thread_id(thd),
+                   thd->get_stmt_da()->message(),
+                   thd->is_fatal_error,
+                   thd->wsrep_cs().mode(),
+                   thd->wsrep_trx().state(),
+                   wsrep_thd_trx_seqno(thd));
       }
 #endif /* WITH_WSREP */
       if (thd->is_error() &&


### PR DESCRIPTION
…srep_on) && wsrep_emulate_bin_log) || mysql_bin_log.is_open()' failed in int THD::binlog_write_row(TABLE*, bool, const uchar*)

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33997*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Problem was that we did not found that table was partitioned and then we should find what is actual underlaying storage engine.

We should not use RSU for !InnoDB tables.


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
