### PR TITLE
MDEV-33980  mariadb-backup --backup is missing retry logic for undo tablespaces

### DIFF
--- a/mysql-test/suite/mariabackup/undo_space_id.result
+++ b/mysql-test/suite/mariabackup/undo_space_id.result
@@ -11,3 +11,10 @@ undo004
 undo003
 undo004
 DROP TABLE t1;
+#
+#  MDEV-33980  mariadb-backup --backup is missing
+#       retry logic for undo tablespaces
+#
+# xtrabackup backup
+# Display undo log files from target directory
+FOUND 5 /Retrying to read undo tablespace*/ in backup.log

--- a/mysql-test/suite/mariabackup/undo_space_id.test
+++ b/mysql-test/suite/mariabackup/undo_space_id.test
@@ -23,3 +23,22 @@ list_files $basedir undo*;
 
 DROP TABLE t1;
 rmdir $basedir;
+
+--echo #
+--echo #  MDEV-33980  mariadb-backup --backup is missing
+--echo #       retry logic for undo tablespaces
+--echo #
+let $backuplog= $MYSQLTEST_VARDIR/tmp/backup.log;
+--echo # xtrabackup backup
+--disable_result_log
+--error 1
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --target-dir=$basedir --dbug=+d,undo_space_read_fail > $backuplog;
+--enable_result_log
+--echo # Display undo log files from target directory
+list_files $basedir undo*;
+
+--let SEARCH_PATTERN=Retrying to read undo tablespace*
+--let SEARCH_FILE=$backuplog
+--source include/search_pattern_in_file.inc
+rmdir $basedir;
+remove_file $backuplog;

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -7560,7 +7560,15 @@ invalid:
 	}
 	ut_free(buf2);
 
+	DBUG_EXECUTE_IF("undo_space_read_fail",
+			if (space_id == srv_undo_space_id_start) {
+				goto wrong_space_id;
+			});
+
 	if (UNIV_UNLIKELY(space_id != space->id)) {
+#ifndef DBUG_OFF
+wrong_space_id:
+#endif
 		ib::error() << "Expected tablespace id " << space->id
 			<< " but found " << space_id
 			<< " in the file " << name;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33980*

## Description
Problem:
========
- Currently mariabackup have to reread the pages in case they are modified by server concurrently. But while reading the undo tablespace, mariabackup failed to do reread the page in case of error.

Fix:
===
Mariabackup --backup functionality should have retry logic while reading the undo tablespaces.


## How can this PR be tested?
./mtr mariabackup.undo_space_id

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
