### PR TITLE
MDEV-31161 Assertion failures upon adding a too long key to table with COMPRESSED row

### DIFF
--- a/mysql-test/suite/innodb/r/row_size_error_log_warnings_3,4k.rdiff
+++ b/mysql-test/suite/innodb/r/row_size_error_log_warnings_3,4k.rdiff
@@ -1,0 +1,2 @@
+91a92
+> ERROR 42000: Row size too large. The maximum row size for the used table type, not counting BLOBs, is 1982. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs

--- a/mysql-test/suite/innodb/r/row_size_error_log_warnings_3.result
+++ b/mysql-test/suite/innodb/r/row_size_error_log_warnings_3.result
@@ -82,3 +82,11 @@ f29(10), f30(10), f31(10), f32(10),
 f33(10)))
 ENGINE=InnoDB;
 ERROR 42000: Too many key parts specified; max 32 parts allowed
+#
+# MDEV-31161 Assertion failures upon adding a too long key
+#             to table with COMPRESSED row format
+#
+CREATE TABLE t1(pk INT PRIMARY KEY, f1 INT, f2 TEXT)ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+INSERT INTO t1 (pk) VALUES (1);
+ALTER TABLE t1 ADD KEY (f1), ADD KEY (f2(1000));
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/row_size_error_log_warnings_3.test
+++ b/mysql-test/suite/innodb/t/row_size_error_log_warnings_3.test
@@ -85,3 +85,19 @@ CREATE TABLE t1(f1 char(200), f2 char(200), f3 char(200),
                             f29(10), f30(10), f31(10), f32(10),
                             f33(10)))
                 ENGINE=InnoDB;
+
+--echo #
+--echo # MDEV-31161 Assertion failures upon adding a too long key
+--echo #             to table with COMPRESSED row format
+--echo #
+--let $page_size= `SELECT @@GLOBAL.innodb_page_size`
+CREATE TABLE t1(pk INT PRIMARY KEY, f1 INT, f2 TEXT)ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+INSERT INTO t1 (pk) VALUES (1);
+let $error_code = 0;
+if ($page_size == 4096) {
+let $error_code = ER_TOO_BIG_ROWSIZE;
+}
+
+--error $error_code
+ALTER TABLE t1 ADD KEY (f1), ADD KEY (f2(1000));
+DROP TABLE t1;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -7436,6 +7436,7 @@ error_handled:
 		row_mysql_lock_data_dictionary(ctx->trx);
 	} else {
 		row_merge_drop_indexes(ctx->trx, user_table, true);
+		user_table->indexes.start->online_log = nullptr;
 		ctx->trx->commit();
 	}
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-31161*

## Description
Problem:
=======
During InnoDB non-rebuild online alter operation, InnoDB set the dummy log to clustered index online log. This can be used by concurrent DML to identify whether the table undergoes online DDL. InnoDB fails to reset the dummy log of clustered index in case of error happened during prepare phase.

Solution:
========
Reset the InnoDB clustered index online log in case of error during prepare phase.


## How can this PR be tested?
./mtr innodb.row_size_error_log_warnings_3
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
