### PR TITLE
MDEV-34053 mariadbbackup privilege REPLICA MONITOR issue

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -6413,7 +6413,7 @@ static bool check_all_privileges()
 	if (opt_galera_info || opt_slave_info
 		|| opt_safe_slave_backup) {
 		check_result |= check_privilege(granted_privileges,
-			"REPLICA MONITOR", "*", "*",
+			"SLAVE MONITOR", "*", "*",
 			PRIVILEGE_WARNING);
 	}
 

--- a/mysql-test/suite/mariabackup/backup_grants.result
+++ b/mysql-test/suite/mariabackup/backup_grants.result
@@ -1,15 +1,20 @@
 CREATE user backup@localhost IDENTIFIED BY 'xyz';
+NOT FOUND /missing required privilege/ in backup.log
 FOUND 1 /missing required privilege RELOAD/ in backup.log
 FOUND 1 /missing required privilege PROCESS/ in backup.log
 FOUND 1 /GRANT USAGE ON/ in backup.log
 GRANT RELOAD, PROCESS on *.* to backup@localhost;
-FOUND 1 /missing required privilege REPLICA MONITOR/ in backup.log
+NOT FOUND /missing required privilege/ in backup.log
+FOUND 1 /missing required privilege SLAVE MONITOR/ in backup.log
 GRANT REPLICA MONITOR ON *.* TO backup@localhost;
+NOT FOUND /missing required privilege/ in backup.log
 REVOKE REPLICA MONITOR ON *.* FROM backup@localhost;
 FOUND 1 /missing required privilege CONNECTION ADMIN/ in backup.log
 GRANT CONNECTION ADMIN ON *.* TO backup@localhost;
+NOT FOUND /missing required privilege/ in backup.log
 FOUND 1 /missing required privilege REPLICATION SLAVE ADMIN/ in backup.log
-FOUND 1 /missing required privilege REPLICA MONITOR/ in backup.log
+FOUND 1 /missing required privilege SLAVE MONITOR/ in backup.log
 GRANT REPLICATION SLAVE ADMIN ON *.* TO backup@localhost;
 GRANT REPLICA MONITOR ON *.* TO backup@localhost;
+NOT FOUND /missing required privilege/ in backup.log
 DROP USER backup@localhost;

--- a/mysql-test/suite/mariabackup/backup_grants.test
+++ b/mysql-test/suite/mariabackup/backup_grants.test
@@ -1,10 +1,14 @@
 let $targetdir=$MYSQLTEST_VARDIR/tmp/backup;
 CREATE user backup@localhost IDENTIFIED BY 'xyz';
 
+let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/backup.log;
 # backup possible for unprivileges user, with --no-lock
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup -pxyz --no-lock  --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup -pxyz --no-lock  --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
+
+--let SEARCH_PATTERN=  missing required privilege
+--source include/search_pattern_in_file.inc
 rmdir $targetdir;
 
 # backup fails without --no-lock, because of FTWRL
@@ -13,7 +17,6 @@ error 1;
 exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup -pxyz --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
 
-let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/backup.log;
 --let SEARCH_PATTERN=  missing required privilege RELOAD
 --source include/search_pattern_in_file.inc
 --let SEARCH_PATTERN=  missing required privilege PROCESS
@@ -23,25 +26,29 @@ let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/backup.log;
 # backup succeeds with RELOAD privilege
 GRANT RELOAD, PROCESS on *.* to backup@localhost;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --user=backup --password=xyz --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --user=backup --password=xyz --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
+--let SEARCH_PATTERN=  missing required privilege
+--source include/search_pattern_in_file.inc
 rmdir $targetdir;
 
 # MDEV-23607 Warning: missing required privilege REPLICATION CLIENT
-# --slave-info and galera info require REPLICA MONITOR
+# --slave-info and --galera-info require REPLICA MONITOR
 --disable_result_log
 error 1;
 exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --user backup --password xyz --slave-info  --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
 rmdir $targetdir;
 
---let SEARCH_PATTERN=  missing required privilege REPLICA MONITOR
+--let SEARCH_PATTERN=  missing required privilege SLAVE MONITOR
 --source include/search_pattern_in_file.inc
 
 GRANT REPLICA MONITOR ON *.* TO backup@localhost;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup -pxyz --slave-info --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup -pxyz --slave-info --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
+--let SEARCH_PATTERN=  missing required privilege
+--source include/search_pattern_in_file.inc
 rmdir $targetdir;
 REVOKE REPLICA MONITOR ON *.* FROM backup@localhost;
 
@@ -59,8 +66,10 @@ rmdir $targetdir;
 
 GRANT CONNECTION ADMIN ON *.* TO backup@localhost;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup --user=backup --password=xyz --kill-long-query-type=all --kill-long-queries-timeout=1 --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup --password=xyz  --kill-long-query-type=all --kill-long-queries-timeout=1 --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
+--let SEARCH_PATTERN=  missing required privilege
+--source include/search_pattern_in_file.inc
 rmdir $targetdir;
 
 # --safe-slave-backup requires REPLICATION SLAVE ADMIN, and REPLICA MONITOR
@@ -72,14 +81,16 @@ rmdir $targetdir;
 
 --let SEARCH_PATTERN=  missing required privilege REPLICATION SLAVE ADMIN
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN=  missing required privilege REPLICA MONITOR
+--let SEARCH_PATTERN=  missing required privilege SLAVE MONITOR
 --source include/search_pattern_in_file.inc
 
 GRANT REPLICATION SLAVE ADMIN ON *.* TO backup@localhost;
 GRANT REPLICA MONITOR ON *.* TO backup@localhost;
 --disable_result_log
-exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup -pxyz --safe-slave-backup --target-dir=$targetdir;
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf --backup -ubackup -pxyz --safe-slave-backup --target-dir=$targetdir > $MYSQLTEST_VARDIR/tmp/backup.log 2>&1;
 --enable_result_log
+--let SEARCH_PATTERN=  missing required privilege
+--source include/search_pattern_in_file.inc
 rmdir $targetdir;
 
 DROP USER backup@localhost;


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34053*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

MariaDB-backup needs to check for SLAVE MONITOR as that is what is returned by SHOW GRANTS.

Update test to ensure that warnings about missing privileges do not occur when the backup is successful.

Thanks Eugene for reporting the issue.

## Release Notes

Remove erroneous MariaDB-Backup warnings about required privileges

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
