### PR TITLE
MDEV-34112 Replace one operator name keyword

### DIFF
--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -11125,7 +11125,7 @@ double table_after_join_selectivity(JOIN *join, uint idx, JOIN_TAB *s,
   else
   {
     sel= records_out / pos->records_read;
-    DBUG_ASSERT(sel >= 0.0 and sel <= 1.00001);
+    DBUG_ASSERT(sel >= 0.0 && sel <= 1.00001);
     if (sel > 1.0)
       sel= 1.0;
   }


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34112*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Alternative operator name keywords like `and`, `or`, `xor`, etc., are uncommon in MariaDB and can cause obscure build errors when the GCC flag `-fno-operator-names` is applied.

Description of `-fno-operator-names`:
https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html
> Do not treat the operator name keywords `and`, `bitand`, `bitor`, `compl`, `not`, `or` and `xor` as synonyms as keywords.

Part of the build errors:

    /local/p4clients/pkgbuild-LdLa_/workspace/src/RDSMariaDB/sql/sql_select.cc:11171:28: error: expected ‘)’ before ‘and’
    11171 |     DBUG_ASSERT(sel >= 0.0 and sel <= 1.00001);
          |                            ^~~
    /local/p4clients/pkgbuild-LdLa_/workspace/src/RDSMariaDB/include/my_global.h:372:44: note: in definition of macro ‘unlikely’
      372 | #define unlikely(x)     __builtin_expect(((x) != 0),0)
          |                                            ^
    ...

The build failure is caused by using alternative operator name keywords `and` introduced in commit b66cdbd1e.
Replace the `and` keyword with `&&` and target on MariaDB 11.0+ branches which include the commit.



## Release Notes
N/A

## How can this PR be tested?
This is the only occurrence I found using the operator names. With this change, build succeeds with GCC flag `-fno-operator-names`.
Existing MTR tests and builds will verify there's no regression.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Copyright
All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.