### PR TITLE
MDEV-33952: Fix flaky galera_create_table_as_select test with debug sync

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -22,4 +22,3 @@ galera_var_ignore_apply_errors : MENT-1997 galera_var_ignore_apply_errors test f
 MDEV-22232 : temporarily disabled at the request of Codership
 MW-402 : temporarily disabled at the request of Codership
 galera_desync_overlapped : MDEV-21538 galera_desync_overlapped MTR failed: Result content mismatch
-galera_create_table_as_select : MDEV-33952 fails sporadically

--- a/mysql-test/suite/galera/r/galera_create_table_as_select.result
+++ b/mysql-test/suite/galera/r/galera_create_table_as_select.result
@@ -76,22 +76,21 @@ EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
 DROP TABLE t1, t2;
 connection node_1;
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_apply_cb';
 CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
-connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
-LOCK TABLE t2 WRITE;
-connection node_1;
+SET DEBUG_SYNC = 'create_table_select_before_create WAIT_FOR sync.wsrep_apply_cb_reached';
+SET DEBUG_SYNC = 'create_table_select_before_lock SIGNAL signal.wsrep_apply_cb WAIT_FOR bf_abort';
 CREATE TABLE t1 AS SELECT * FROM t2;;
-connection node_1a;
 connection node_2;
 SELECT COUNT(*) = 5 FROM t2;
 COUNT(*) = 5
 1
 CREATE TABLE t1 AS SELECT * FROM t2;
-connection node_1a;
-UNLOCK TABLES;
 connection node_1;
-Got one of the listed errors
+ERROR 70100: Query execution was interrupted
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1, t2;
 CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);

--- a/mysql-test/suite/galera/t/galera_create_table_as_select.test
+++ b/mysql-test/suite/galera/t/galera_create_table_as_select.test
@@ -3,6 +3,8 @@
 #
 
 --source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
 
 --connection node_1
 SET SESSION default_storage_engine=InnoDB;
@@ -103,31 +105,27 @@ DROP TABLE t1, t2;
 #
 
 --connection node_1
+# Pause applying CTAS command from the other node
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_apply_cb';
 
 CREATE TABLE t2 (f1 INTEGER) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
 
---connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
-LOCK TABLE t2 WRITE;
-
---connection node_1
+# Wait until local CTAS grabs MDL lock and let applied CTAS BF-abort it
+SET DEBUG_SYNC = 'create_table_select_before_create WAIT_FOR sync.wsrep_apply_cb_reached';
+SET DEBUG_SYNC = 'create_table_select_before_lock SIGNAL signal.wsrep_apply_cb WAIT_FOR bf_abort';
 --send CREATE TABLE t1 AS SELECT * FROM t2;
-
---connection node_1a
---let $wait_condition = SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE STATE LIKE 'Waiting for table metadata lock%'
---source include/wait_condition.inc
 
 --connection node_2
 SELECT COUNT(*) = 5 FROM t2;
 CREATE TABLE t1 AS SELECT * FROM t2;
 
---connection node_1a
-UNLOCK TABLES;
-
 --connection node_1
---error ER_TABLE_EXISTS_ERROR,ER_QUERY_INTERRUPTED
+--error ER_QUERY_INTERRUPTED
 --reap
 
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1, t2;
 
 #


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33952*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The test that triggers multi-master conflict between two CTAS commands uses LOCK/UNLOCK TABLES to block local CTAS from progress. It could result in a race when UNLOCK TABLES command is issued a bit earlier then needed, causing local CTAS to run further and change wsrep transaction state, so that a different code path is taken later and the original error gets overridden, causing the test to fail. The solution is to replace LOCK/UNLOCK TABLES with debug sync points.


## Release Notes

The fix is for 10.5+ versions.

## How can this PR be tested?

MTR test is fixed an re-enabled.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
