### PR TITLE
MDEV-34118 fsp_alloc_free_extent() fails to flag DB_OUT_OF_FILE_SPACE

### DIFF
--- a/mysql-test/suite/innodb/r/temporary_table.result
+++ b/mysql-test/suite/innodb/r/temporary_table.result
@@ -801,4 +801,14 @@ CHECK TABLE t EXTENDED;
 Table	Op	Msg_type	Msg_text
 test.t	check	status	OK
 DROP TEMPORARY TABLE t;
+#
+# MDEV-34118 fsp_alloc_free_extent() fails to flag DB_OUT_OF_FILE_SPACE
+#
+SET @save_increment = @@GLOBAL.innodb_autoextend_increment;
+SET GLOBAL innodb_autoextend_increment=1;
+CREATE TEMPORARY TABLE t (c LONGTEXT) ENGINE=INNODB;
+INSERT INTO t VALUES (REPEAT ('1',16777216));
+ERROR HY000: The table 't' is full
+DROP TEMPORARY TABLE t;
+SET GLOBAL innodb_autoextend_increment=@save_increment;
 # End of 10.6 tests

--- a/mysql-test/suite/innodb/t/temporary_table.test
+++ b/mysql-test/suite/innodb/t/temporary_table.test
@@ -635,4 +635,23 @@ CHECK TABLE t;
 CHECK TABLE t EXTENDED;
 DROP TEMPORARY TABLE t;
 
+--echo #
+--echo # MDEV-34118 fsp_alloc_free_extent() fails to flag DB_OUT_OF_FILE_SPACE
+--echo #
+SET @save_increment = @@GLOBAL.innodb_autoextend_increment;
+SET GLOBAL innodb_autoextend_increment=1;
+CREATE TEMPORARY TABLE t (c LONGTEXT) ENGINE=INNODB;
+if ($MTR_COMBINATION_4K)
+{
+--error ER_RECORD_FILE_FULL
+INSERT INTO t VALUES (REPEAT ('1',16777216));
+}
+if (!$MTR_COMBINATION_4K)
+{
+INSERT INTO t VALUES (REPEAT ('1',16777216));
+--echo ERROR HY000: The table 't' is full
+}
+DROP TEMPORARY TABLE t;
+SET GLOBAL innodb_autoextend_increment=@save_increment;
+
 --echo # End of 10.6 tests

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -967,6 +967,7 @@ corrupted:
 			first = flst_get_first(FSP_HEADER_OFFSET + FSP_FREE
 					       + header->page.frame);
 			if (first.page == FIL_NULL) {
+				*err = DB_OUT_OF_FILE_SPACE;
 				return nullptr;	/* No free extents left */
 			}
 			if (first.page >= space->free_limit) {


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34118*
## Description
`fsp_alloc_free_extent()` failed to set `*err = DB_OUT_OF_FILE_SPACE` when the tablespace is full.

## Release Notes
InnoDB could fail to report `ER_RECORD_FILE_FULL` when running out of space.
## How can this PR be tested?
```sh
./mtr innodb.temporary_table,4k
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

This is a bug fix that depends on earlier refactoring in MariaDB Server 10.6.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.