### PR TITLE
don't require resolveip if it won't be used

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -38,6 +38,7 @@ force=0
 in_rpm=0
 ip_only=0
 cross_bootstrap=0
+do_resolve=0
 auth_root_authentication_method=socket
 auth_root_socket_user=""
 skip_test_db=0
@@ -330,6 +331,11 @@ parse_arguments PICK-ARGS-FROM-ARGV "$@"
 
 rel_mysqld="$dirname0/@INSTALL_SBINDIR@/mariadbd"
 
+if test "$cross_bootstrap" -eq 0 -a "$in_rpm" -eq 0 -a "$force" -eq 0
+  do_resolve=1
+then
+fi
+
 # Configure paths to support files
 if test -n "$srcdir"
 then
@@ -422,7 +428,7 @@ fi
 hostname=`@HOSTNAME@`
 
 # Check if hostname is valid
-if test "$cross_bootstrap" -eq 0 -a "$in_rpm" -eq 0 -a "$force" -eq 0
+if test "$do_resolve" -eq 1
 then
   resolved=`"$resolveip" $hostname 2>&1`
   if test $? -ne 0
@@ -448,7 +454,7 @@ then
   fi
 fi
 
-if test "$ip_only" -eq 1
+if test "$do_resolve" -eq 1 -a "$ip_only" -eq 1
 then
   hostname=`echo "$resolved" | awk '/ /{print $6}'`
 fi


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This avoids checking for resolveip if it won't be used by using the same conditional used before deciding to execute resolveip. I ran into this while reducing mariadb's installation footprint.

## Release Notes

## How can this PR be tested?

Install without resolveip?

## Basing the PR against the correct MariaDB version

Eh I'm not really sure which one this falls under.

- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
