### PR TITLE
MDEV-34156 InnoDB fails to apply the redo log for compressed tablespace

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3385,8 +3385,10 @@ recv_init_crash_recovery_spaces(bool rescan, bool& missing_tablespace)
 			fil_names_dirty(rs.second.space);
 
 			/* Add the freed page ranges in the respective
-			tablespace */
-			if (!rs.second.freed_ranges.empty()
+			tablespace only if InnoDB doesn't need to
+			rescan the redo logs */
+			if (!rescan
+			    && !rs.second.freed_ranges.empty()
 			    && (srv_immediate_scrub_data_uncompressed
 				|| rs.second.space->is_compressed())) {
 


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-34156*

## Description
Problem:
=======
- During recovery, InnoDB fails to apply the redo log for compressed tablespace. The reason is that
InnoDB assumes that pages has been freed while applying the redo log for it. InnoDB does multiple scan due to small buffer pool size. Problematic page has been freed and reinitialize multiple times. InnoDB stores the freed page information before it ran out of memory.
But InnoDB assigns the freed page ranges to tablespace in recv_init_crash_recovery_spaces() even though
InnoDB doesn't have complete freed range information.

Solution:
=========
rec_init_crash_recovery_spaces(): Don't add the freed ranges to tablespace if InnoDB has to read the redo log again.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
