### PR TITLE
MDEV-34169 Don't allow innodb_open_files to be lesser than number of non-user tablespace

### DIFF
--- a/mysql-test/suite/innodb/r/open_files_limit.result
+++ b/mysql-test/suite/innodb/r/open_files_limit.result
@@ -1,0 +1,4 @@
+call mtr.add_suppression("\\[Warning\\] InnoDB: innodb_open_files=.* is not greater than the number of system tablespace files, temporary tablespace files, innodb_undo_tablespaces=.*");
+FOUND 1 /\[Warning\] InnoDB: innodb_open_files=.* is not greater than the number of system tablespace files, temporary tablespace files, innodb_undo_tablespaces=.*/ in mysqld.1.err
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/open_files_limit.opt
+++ b/mysql-test/suite/innodb/t/open_files_limit.opt
@@ -1,0 +1,3 @@
+--innodb_undo_tablespaces=8
+--innodb_open_files=10
+--innodb_temp_data_file_path=ibtmp1:32M;ibtmp2:32M:autoextend

--- a/mysql-test/suite/innodb/t/open_files_limit.test
+++ b/mysql-test/suite/innodb/t/open_files_limit.test
@@ -1,0 +1,9 @@
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+call mtr.add_suppression("\\[Warning\\] InnoDB: innodb_open_files=.* is not greater than the number of system tablespace files, temporary tablespace files, innodb_undo_tablespaces=.*");
+let SEARCH_PATTERN= \[Warning\] InnoDB: innodb_open_files=.* is not greater than the number of system tablespace files, temporary tablespace files, innodb_undo_tablespaces=.*;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+DROP TABLE t1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3860,6 +3860,21 @@ static int innodb_init_params()
 		}
 	}
 
+	ulint min_open_files_limit = srv_undo_tablespaces
+				+ srv_sys_space.m_files.size()
+				+ srv_tmp_space.m_files.size() + 1;
+	if (min_open_files_limit > innobase_open_files) {
+		sql_print_warning(
+			"InnoDB: innodb_open_files=%lu is not greater "
+			"than the number of system tablespace files, "
+			"temporary tablespace files, "
+			"innodb_undo_tablespaces=%lu; adjusting "
+			"to innodb_open_files=%zu",
+			innobase_open_files, srv_undo_tablespaces,
+			min_open_files_limit);
+		innobase_open_files = (ulong) min_open_files_limit;
+	}
+
 	srv_max_n_open_files = innobase_open_files;
 	srv_innodb_status = (ibool) innobase_create_status_file;
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34169*

## Description
- InnoDB only closes the user tablespace when the number of open files exceeds innodb_open_files limit. In that case, InnoDB should make sure that innodb_open_files value should be greater than number of undo tablespace, system and temporary tablespace.


## How can this PR be tested?
./mtr innodb.open_files_limit 

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
