### PR TITLE
MDEV-34166 Server could hang with BP < 80M under stress

### DIFF
--- a/mysql-test/suite/innodb/r/lock_memory_debug.result
+++ b/mysql-test/suite/innodb/r/lock_memory_debug.result
@@ -1,0 +1,13 @@
+#
+# MDEV-34166 Server could hang with BP < 80M under stress
+#
+call mtr.add_suppression("\\[Warning\\] InnoDB: Over 67 percent of the buffer pool");
+CREATE TABLE t1 (col1 INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+SET STATEMENT debug_dbug='+d,innodb_skip_lock_bitmap' FOR
+INSERT INTO t1 SELECT a.* FROM t1 a, t1 b, t1 c, t1 d, t1 e, t1 f, t1 g LIMIT 45000;
+ERROR HY000: The total number of locks exceeds the lock table size
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+5
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/lock_memory_debug.opt
+++ b/mysql-test/suite/innodb/t/lock_memory_debug.opt
@@ -1,0 +1,1 @@
+--innodb_buffer_pool_size=5M

--- a/mysql-test/suite/innodb/t/lock_memory_debug.test
+++ b/mysql-test/suite/innodb/t/lock_memory_debug.test
@@ -1,0 +1,19 @@
+--source include/have_innodb.inc
+--source include/have_debug.inc
+
+--echo #
+--echo # MDEV-34166 Server could hang with BP < 80M under stress
+--echo #
+
+call mtr.add_suppression("\\[Warning\\] InnoDB: Over 67 percent of the buffer pool");
+
+CREATE TABLE t1 (col1 INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+
+--error ER_LOCK_TABLE_FULL
+SET STATEMENT debug_dbug='+d,innodb_skip_lock_bitmap' FOR
+INSERT INTO t1 SELECT a.* FROM t1 a, t1 b, t1 c, t1 d, t1 e, t1 f, t1 g LIMIT 45000;
+
+SELECT COUNT(*) FROM t1;
+
+DROP TABLE t1;

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -1739,6 +1739,11 @@ lock_rec_find_similar_on_page(
 	const trx_t*    trx)            /*!< in: transaction */
 {
 	ut_ad(lock_mutex_own());
+	DBUG_EXECUTE_IF("innodb_skip_lock_bitmap", {
+		if (!trx->in_rollback) {
+			return nullptr;
+		}
+	});
 
 	for (/* No op */;
 	     lock != NULL;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34166*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
BUF_LRU_MIN_LEN (256) is too high value for low buffer pool(BP) size. For example, for BP size lower than 80M and 16 K page size, the limit is more than 5% of total BP and for lowest BP 5M, it is 80% of the BP. Non-data objects like explicit locks could occupy part of the BP pool reducing the pages available for LRU. If LRU reaches minimum limit and if no free pages are available, server would hang with page cleaner not able to free any more pages.

Fix: To avoid such hang, we adjust the LRU limit lower than the limit for data objects as checked in buf_LRU_check_size_of_non_data_objects() i.e. one page less than 5% of BP.

## Release Notes
This could happen in rare case with BP size < 80M. Too many lock objects created with UPDATE, DELETE, INSERT INTO SELECT from same TABLE with queries over large range in RR or Serializable isolation could leads to the issue.

## How can this PR be tested?

./mtr innodb.lock_memory_debug
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
