### PR TITLE
MDEV-34175 mtr_t::log_close() warning should change the shutdown condition

### DIFF
--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -925,7 +925,7 @@ static mtr_t::page_flush_ahead log_close(lsn_t lsn)
                       " last checkpoint LSN=" LSN_PF ", current LSN=" LSN_PF
                       "%s.",
                       lsn_t{log_sys.last_checkpoint_lsn}, lsn,
-                      srv_shutdown_state != SRV_SHUTDOWN_INITIATED
+                      srv_shutdown_state > SRV_SHUTDOWN_INITIATED
                       ? ". Shutdown is in progress" : "");
     }
   }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
- InnoDB can print the wrong warning message  like "shutdown is in progress" even though InnoDB is in normal
condition. InnoDB should print the warning message saying "Shutdown is in progress" only when shutdown state is greater than SRV_SHUTDOWN_INITIATED.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
