### PR TITLE
MDEV-34167 We fail to terminate transaction early with ER_LOCK_TABLE_…

### DIFF
--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -451,7 +451,10 @@ got_block:
     mysql_mutex_unlock(&buf_pool.flush_list_mutex);
     if (my_cond_timedwait(&buf_pool.done_free, &buf_pool.mutex.m_mutex,
                           &abstime))
+    {
       buf_pool.LRU_warn();
+      buf_LRU_check_size_of_non_data_objects();
+    }
   }
 
   goto got_block;

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1486,7 +1486,7 @@ public:
   {
     return !recv_recovery_is_on() &&
       UT_LIST_GET_LEN(free) + UT_LIST_GET_LEN(LRU) <
-        n_chunks_new / 4 * chunks->size;
+        (n_chunks_new * chunks->size) / 4;
   }
 
   /** @return whether the buffer pool is running low */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34167*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This regression is introduced in 10.6 by following commit. commit b6a2472489accf0ae9ac3655ffe9b2997ab267ba
MDEV-27891: SIGSEGV in InnoDB buffer pool resize

During DML, we check if buffer pool is running out of data pages in buf_pool_t::running_out. Here, if 75% of the buffer pool is occupied by non-data pages, we rollback the current transaction and exit with ER_LOCK_TABLE_FULL.

The integer division (n_chunks_new / 4) becomes zero whenever the total number of chunks are < 4 making the check completely ineffective for such cases. Also the check is inaccurate for larger chunks.

Fix-1: Correct the check in buf_pool_t::running_out.

Fix-2: While waiting for free page, check for
buf_LRU_check_size_of_non_data_objects.

## Release Notes
When system is reaching out of memory in BP due to too many locks, it allows DMLs to exit before reaching the critical stage of server exit. 

## How can this PR be tested?
The test case from MDEV-34166 which is being fixed in 10.5 would also test this patch once merged. So. we would have the automated test running soon. Till that time it is difficult to add an automated test as it requires large BP and records in the order of millions to validate it.

In MDEV, I have updated the way it can be tested manually.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
