### PR TITLE
MDEV-34204 Assertion `!*detailed_error' failed on shutdown after XA PREPARE

### DIFF
--- a/mysql-test/suite/innodb/r/xa_recovery.result
+++ b/mysql-test/suite/innodb/r/xa_recovery.result
@@ -1,4 +1,4 @@
-CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 connect  con1,localhost,root;
 XA START 'x';
@@ -6,7 +6,7 @@ UPDATE t1 set a=2;
 XA END 'x';
 XA PREPARE 'x';
 connect  con2,localhost,root;
-CREATE TABLE t2 (a INT) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT PRIMARY KEY) ENGINE=InnoDB;
 XA START 'y';
 INSERT INTO t2 VALUES (1);
 XA END 'y';
@@ -29,7 +29,18 @@ XA ROLLBACK 'x';
 SELECT * FROM t1;
 a
 1
-DROP TABLE t1;
+CREATE TABLE t3(a INT PRIMARY KEY REFERENCES t1(a)) ENGINE=InnoDB;
+XA START 'a';
+INSERT INTO t3 SET a=1;
+INSERT INTO t3 SET a=42;
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`t3`, CONSTRAINT `t3_ibfk_1` FOREIGN KEY (`a`) REFERENCES `t1` (`a`))
+XA END 'a';
+XA PREPARE 'a';
 SET GLOBAL innodb_fast_shutdown=0;
 # restart
+XA COMMIT 'a';
+SELECT * FROM t3;
+a
+1
+DROP TABLE t3,t1;
 XA ROLLBACK 'y';

--- a/mysql-test/suite/innodb/t/xa_recovery.test
+++ b/mysql-test/suite/innodb/t/xa_recovery.test
@@ -10,12 +10,12 @@ call mtr.add_suppression("Found [12] prepared XA transactions");
 FLUSH TABLES;
 --enable_query_log
 
-CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 connect (con1,localhost,root);
 XA START 'x'; UPDATE t1 set a=2; XA END 'x'; XA PREPARE 'x';
 connect (con2,localhost,root);
-CREATE TABLE t2 (a INT) ENGINE=InnoDB;
+CREATE TABLE t2 (a INT PRIMARY KEY) ENGINE=InnoDB;
 XA START 'y'; INSERT INTO t2 VALUES (1); XA END 'y'; XA PREPARE 'y';
 connection default;
 
@@ -53,9 +53,18 @@ SELECT * FROM t1;
 XA ROLLBACK 'x';
 SELECT * FROM t1;
 
-DROP TABLE t1;
+CREATE TABLE t3(a INT PRIMARY KEY REFERENCES t1(a)) ENGINE=InnoDB;
+XA START 'a';
+INSERT INTO t3 SET a=1;
+--error ER_NO_REFERENCED_ROW_2
+INSERT INTO t3 SET a=42;
+XA END 'a';
+XA PREPARE 'a';
 
 SET GLOBAL innodb_fast_shutdown=0;
 --source include/restart_mysqld.inc
 
+XA COMMIT 'a';
+SELECT * FROM t3;
+DROP TABLE t3,t1;
 XA ROLLBACK 'y';

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -554,6 +554,7 @@ trx_free_at_shutdown(trx_t *trx)
 	trx->state = TRX_STATE_NOT_STARTED;
 	ut_ad(!UT_LIST_GET_LEN(trx->lock.trx_locks));
 	trx->id = 0;
+	ut_d(*trx->detailed_error = '\0');
 	trx->free();
 }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34204*

## Description
`trx_free_at_shutdown()`: Similar to `trx_t::commit_in_memory()`, clear the detailed_error (`FOREIGN KEY` constraint error) before invoking `trx_t::free()`. We only do this on debug instrumented builds in order to avoid a debug assertion failure on shutdown.
## Release Notes
Nothing. This was a bogus debug assertion failure.
## How can this PR be tested?
```sh
./mtr innodb.xa_recovery
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.