### PR TITLE
MDEV-33817 fixup: Disable for macOS

### DIFF
--- a/mysys/crc32/crc32c_x86.cc
+++ b/mysys/crc32/crc32c_x86.cc
@@ -24,7 +24,11 @@
 # endif
 #else
 # include <cpuid.h>
-# if __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 8)
+# ifdef __APPLE__ /* AVX512 states are not enabled in XCR0 */
+# elif __GNUC__ >= 14 || (defined __clang_major__ && __clang_major__ >= 18)
+#  define TARGET "pclmul,evex512,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"
+#  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
+# elif __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 8)
 #  define TARGET "pclmul,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"
 #  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
 # endif


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33817*
## Description
According to https://discussions.apple.com/thread/8256853 an attempt to use AVX512 registers on macOS will result in `#UD` (crash at runtime).

The AVX512 intrinsic functions may also be unavailable on Apple Xcode, at least in a version that is based on clang 10.

Furthermore, starting with clang-18 and GCC 14, we must add `evex512` to the target flags. We might also write avx10.1-512, but it could enable some AVX512 flags that we do not have any CPUID check for.
## Release Notes
Nothing; macOS on x86 is not an officially supported platform, and GCC 14 and clang-18 probably are not in any stable operating system distribution yet.

## How can this PR be tested?
See #3195.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.