### PR TITLE
MDEV-33523 Spurious deadlock error when wsrep_on=OFF

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-33523.result
+++ b/mysql-test/suite/galera/r/MDEV-33523.result
@@ -1,0 +1,6 @@
+connection node_2;
+connection node_1;
+SET SESSION wsrep_on=OFF;
+BEGIN;
+ROLLBACK;
+SET SESSION wsrep_on=OFF;

--- a/mysql-test/suite/galera/r/galera_bf_kill.result
+++ b/mysql-test/suite/galera/r/galera_bf_kill.result
@@ -49,16 +49,23 @@ a	b
 disconnect node_2a;
 disconnect node_2b;
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2a;
 SET SESSION wsrep_on=OFF;
 begin;
 update t1 set a =5, b=2;
 connection node_2;
 ALTER TABLE t1 ADD UNIQUE KEY b3(b);
+connection node_2b;
+SET SESSION wsrep_sync_wait=0;
+connection node_2a;
 select * from t1;
 a	b
-2	1
+5	2
+commit;
+connection node_2;
 disconnect node_2a;
+disconnect node_2b;
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2a;
 SET SESSION wsrep_on=OFF;
@@ -67,7 +74,7 @@ update t1 set a =5, b=2;
 connection node_2;
 select * from t1;
 a	b
-2	1
+5	2
 disconnect node_2a;
 connection node_1;
 drop table t1;

--- a/mysql-test/suite/galera/t/MDEV-33523.test
+++ b/mysql-test/suite/galera/t/MDEV-33523.test
@@ -1,0 +1,11 @@
+#
+# MDEV-33523: Spurious deadlock error when wsrep_on=OFF
+#
+--source include/galera_cluster.inc
+
+SET SESSION wsrep_on=OFF;
+BEGIN;
+# If bug is present, the following rollback
+# results in ER_LOCK_DEADLOCK error.
+ROLLBACK;
+SET SESSION wsrep_on=OFF;

--- a/mysql-test/suite/galera/t/galera_bf_kill.test
+++ b/mysql-test/suite/galera/t/galera_bf_kill.test
@@ -94,23 +94,39 @@ select * from t1;
 --disconnect node_2b
 
 #
-# Test case 5: Start a transaction on node_2a with wsrep disabled 
-# and start a DDL on other transaction that will then abort node_2a
-# transactions
+# Test case 5: Start a transaction on node_2a with wsrep disabled. 
+# A conflicting DDL on other transaction can't BF abort
+# transaction from node_2a (wsrep disabled).
 #
 
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2
 --connection node_2a
 SET SESSION wsrep_on=OFF;
 begin;
 update t1 set a =5, b=2;
 
 --connection node_2
-ALTER TABLE t1 ADD UNIQUE KEY b3(b);
+--send ALTER TABLE t1 ADD UNIQUE KEY b3(b)
 
+--connection node_2b
+SET SESSION wsrep_sync_wait=0;
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for table metadata lock';
+--source include/wait_condition.inc
+
+--connection node_2a
 select * from t1;
 
+# We expect that ALTER should not be able to BF abort
+# this transaction, it must wait for it to finish.
+# Expect commit to succeed.
+commit;
+
+--connection node_2
+--reap
+
 --disconnect node_2a
+--disconnect node_2b
 
 #
 # Test case 6: Start a transaction on node_2a with wsrep disabled 

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -179,7 +179,7 @@ bool trans_begin(THD *thd, uint flags)
   }
 
 #ifdef WITH_WSREP
-  if (wsrep_thd_is_local(thd))
+  if (WSREP(thd) && wsrep_thd_is_local(thd))
   {
     if (wsrep_sync_wait(thd))
       DBUG_RETURN(TRUE);


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33523*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

A spurious deadlock error is raised on transaction cleanup, when wsrep_on = OFF.



## Release Notes
Not needed 

## How can this PR be tested?
A MTR test is included in the patch.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
