### PR TITLE
MDEV-34200 InnoDB tries to write to read-only system tablespace in buf_dblwr_t::init_or_load_pages()

### DIFF
--- a/mysql-test/suite/innodb/r/row_format_redundant.result
+++ b/mysql-test/suite/innodb/r/row_format_redundant.result
@@ -1,5 +1,5 @@
 SET GLOBAL innodb_fast_shutdown=0;
-# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb-undo-tablespaces=0 --innodb-stats-persistent=0
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/undo_dir --innodb-undo-tablespaces=0 --innodb-stats-persistent=0
 SET GLOBAL innodb_file_per_table=1;
 #
 # Bug#21644827 - FTS, ASSERT !SRV_READ_ONLY_MODE || M_IMPL.M_LOG_MODE ==
@@ -26,7 +26,7 @@ row_format=redundant;
 insert into t3 values(444, 'dddd', 'bbbbb', 'aaaaa');
 insert into t3 values(555, 'eeee', 'ccccc', 'aaaaa');
 SET GLOBAL innodb_fast_shutdown=0;
-# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb-undo-tablespaces=0 --innodb-stats-persistent=0 --innodb-read-only
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/undo_dir --innodb-undo-tablespaces=0 --innodb-stats-persistent=0 --innodb-read-only
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 4096
@@ -42,14 +42,14 @@ TRUNCATE TABLE t2;
 ERROR HY000: Table 't2' is read only
 TRUNCATE TABLE t3;
 ERROR HY000: Table 't3' is read only
-# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb-undo-tablespaces=0 --innodb-stats-persistent=0 --skip-innodb-fast-shutdown
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/undo_dir --innodb-undo-tablespaces=0 --innodb-stats-persistent=0 --skip-innodb-fast-shutdown
 TRUNCATE TABLE t1;
 TRUNCATE TABLE t2;
 TRUNCATE TABLE t3;
 corrupted SYS_TABLES.MIX_LEN for test/t1
 corrupted SYS_TABLES.MIX_LEN for test/t2
 corrupted SYS_TABLES.MIX_LEN for test/t3
-# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb-undo-tablespaces=0 --innodb-stats-persistent=0 --skip-innodb-fast-shutdown
+# restart: --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/row_format_redundant --innodb-data-file-path=ibdata1:1M:autoextend --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/undo_dir --innodb-undo-tablespaces=0 --innodb-stats-persistent=0 --skip-innodb-fast-shutdown
 TRUNCATE TABLE t1;
 ERROR 42S02: Table 'test.t1' doesn't exist in engine
 TRUNCATE TABLE t2;

--- a/mysql-test/suite/innodb/r/undo_upgrade.result
+++ b/mysql-test/suite/innodb/r/undo_upgrade.result
@@ -62,3 +62,27 @@ SELECT @@global.innodb_undo_tablespaces;
 # Should list 2 undo log tablespaces, not 4
 undo001
 undo002
+#
+# MDEV-34200 InnoDB tries to write to read-only
+#    system tablespace in buf_dblwr_t::init_or_load_pages()
+#
+SET GLOBAL innodb_fast_shutdown=0;
+# restart: --innodb_undo_tablespaces=4
+# Should list 4 undo log tablespaces
+undo001
+undo002
+undo003
+undo004
+set global innodb_fast_shutdown=0;
+# restart: --innodb_read_only=1
+set global innodb_fast_shutdown=0;
+# restart: --innodb-data-file-path=ibdata1:1M:autoextend --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/undo_dir --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/bugdir --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/bugdir --innodb_undo_tablespaces=3
+# Should list 3 undo log tablespaces
+undo001
+undo002
+undo003
+set global innodb_fast_shutdown=0;
+# restart: --innodb-data-file-path=ibdata1:1M:autoextend --innodb_undo_directory=MYSQLTEST_VARDIR/tmp/undo_dir --innodb-data-home-dir=MYSQLTEST_VARDIR/tmp/bugdir_1 --innodb-log-group-home-dir=MYSQLTEST_VARDIR/tmp/bugdir_1 --innodb_undo_tablespaces=0
+# Shouldn't list 0 undo log tablespaces
+set global innodb_fast_shutdown=0;
+# restart

--- a/mysql-test/suite/innodb/t/row_format_redundant.test
+++ b/mysql-test/suite/innodb/t/row_format_redundant.test
@@ -16,11 +16,14 @@ let INNODB_PAGE_SIZE=`select @@innodb_page_size`;
 
 let bugdir= $MYSQLTEST_VARDIR/tmp/row_format_redundant;
 --mkdir $bugdir
+let undodir= $MYSQLTEST_VARDIR/tmp/undo_dir;
+--mkdir $undodir
+
 --let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
 
 --let $d=--innodb-data-home-dir=$bugdir --innodb-log-group-home-dir=$bugdir
 --let $d=$d --innodb-data-file-path=ibdata1:1M:autoextend
---let $d=$d --innodb-undo-tablespaces=0 --innodb-stats-persistent=0
+--let $d=$d --innodb_undo_directory=$undodir --innodb-undo-tablespaces=0 --innodb-stats-persistent=0
 --let $restart_parameters= $d
 # Ensure that any DDL records from previous tests have been purged.
 SET GLOBAL innodb_fast_shutdown=0;
@@ -159,6 +162,7 @@ DROP TABLE t2,t3;
 --list_files $bugdir
 --remove_files_wildcard $bugdir
 --rmdir $bugdir
+--rmdir $undodir
 
 # Remove the data file, because DROP TABLE skipped it for the "corrupted" table
 --let MYSQLD_DATADIR=`select @@datadir`

--- a/mysql-test/suite/innodb/t/table_flags.test
+++ b/mysql-test/suite/innodb/t/table_flags.test
@@ -29,12 +29,15 @@ let MYSQLD_DATADIR=`select @@datadir`;
 
 let bugdir= $MYSQLTEST_VARDIR/tmp/table_flags;
 --mkdir $bugdir
+let undodir= $MYSQLTEST_VARDIR/tmp/undo_dir;
+--mkdir $undodir
+
 --let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err
 
 --let $d=--innodb-data-home-dir=$bugdir --innodb-log-group-home-dir=$bugdir
 --let $d=$d --innodb-data-file-path=ibdata1:1M:autoextend
 --let $d=$d --innodb-undo-tablespaces=0
---let $d=$d --skip-innodb-fast-shutdown
+--let $d=$d --skip-innodb-fast-shutdown --innodb_undo_directory=$undodir
 --let $restart_noprint=1
 --let $restart_parameters=$d --innodb-stats-persistent=0
 --source include/restart_mysqld.inc
@@ -234,6 +237,7 @@ DROP TABLE tr,tc,td,tz,tp;
 --list_files $bugdir
 --remove_files_wildcard $bugdir
 --rmdir $bugdir
+--rmdir $undodir
 
 call mtr.add_suppression("ERROR HY000: Can't create table `test`.`t1`");
 --error ER_CANT_CREATE_TABLE

--- a/mysql-test/suite/innodb/t/undo_upgrade.test
+++ b/mysql-test/suite/innodb/t/undo_upgrade.test
@@ -76,3 +76,46 @@ SELECT @@global.innodb_undo_tablespaces;
 
 --echo # Should list 2 undo log tablespaces, not 4
 list_files $MYSQLD_DATADIR undo*;
+
+--echo #
+--echo # MDEV-34200 InnoDB tries to write to read-only
+--echo #    system tablespace in buf_dblwr_t::init_or_load_pages()
+--echo #
+
+SET GLOBAL innodb_fast_shutdown=0;
+let $restart_parameters=--innodb_undo_tablespaces=4;
+--source include/restart_mysqld.inc
+--echo # Should list 4 undo log tablespaces
+list_files $MYSQLD_DATADIR undo*;
+
+set global innodb_fast_shutdown=0;
+let $restart_parameters=--innodb_read_only=1;
+--source include/restart_mysqld.inc
+
+set global innodb_fast_shutdown=0;
+let bugdir= $MYSQLTEST_VARDIR/tmp/bugdir;
+mkdir $bugdir;
+let undodir= $MYSQLTEST_VARDIR/tmp/undo_dir;
+mkdir $undodir;
+let $d= --innodb-data-file-path=ibdata1:1M:autoextend;
+let $d=$d --innodb_undo_directory=$undodir;
+let $restart_parameters= $d --innodb-data-home-dir=$bugdir --innodb-log-group-home-dir=$bugdir --innodb_undo_tablespaces=3;
+--source include/restart_mysqld.inc
+--echo # Should list 3 undo log tablespaces
+list_files $undodir undo*;
+
+let bugdir_1= $MYSQLTEST_VARDIR/tmp/bugdir_1;
+mkdir $bugdir_1;
+
+set global innodb_fast_shutdown=0;
+let $restart_parameters= $d --innodb-data-home-dir=$bugdir_1 --innodb-log-group-home-dir=$bugdir_1 --innodb_undo_tablespaces=0;
+--source include/restart_mysqld.inc
+--echo # Shouldn't list 0 undo log tablespaces
+list_files $undodir undo*;
+
+set global innodb_fast_shutdown=0;
+let $restart_parameters=;
+--source include/restart_mysqld.inc
+rmdir $bugdir;
+rmdir $bugdir_1;
+rmdir $undodir;

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -283,6 +283,7 @@ func_exit:
   init(TRX_SYS_DOUBLEWRITE + read_buf);
 
   const bool upgrade_to_innodb_file_per_table=
+    !srv_read_only_mode &&
     mach_read_from_4(TRX_SYS_DOUBLEWRITE_SPACE_ID_STORED +
                      TRX_SYS_DOUBLEWRITE + read_buf) !=
     TRX_SYS_DOUBLEWRITE_SPACE_ID_STORED_N;

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -370,6 +370,11 @@ inline dberr_t trx_sys_t::reset_page(mtr_t *mtr)
       sys_header->page.frame + TRX_SYS_DOUBLEWRITE
       + FSEG_HEADER_SIZE + TRX_SYS_DOUBLEWRITE_REPEAT,
       sys_header->page.frame + TRX_SYS_DOUBLEWRITE + FSEG_HEADER_SIZE, 12);
+    mtr->write<4>(
+      *sys_header,
+      TRX_SYS_DOUBLEWRITE + TRX_SYS_DOUBLEWRITE_SPACE_ID_STORED +
+      sys_header->page.frame,
+      TRX_SYS_DOUBLEWRITE_SPACE_ID_STORED_N);
   }
 
   return DB_SUCCESS;
@@ -822,7 +827,7 @@ unused_undo:
   {
      char name[OS_FILE_MAX_PATH];
      snprintf(name, sizeof name, "%s/undo%03u", srv_undo_dir, i);
-     uint32_t space_id= srv_undo_tablespace_open(create_new_undo, name, i);
+     uint32_t space_id= srv_undo_tablespace_open(false, name, i);
      if (!space_id || space_id == ~0U)
        break;
      if (0 == srv_undo_tablespaces_open++)


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-34200*

## Description

- InnoDB fails to set the TRX_SYS_DOUBLEWRITE_SPACE_ID_STORED flag in transaction system header page while recreating the undo log tablespaces

buf_dblwr_t::init_or_load_pages(): Tries to reset the space id and try to write into doublewrite buffer even when read_only mode is enabled.

In srv_all_undo_tablespaces_open(), InnoDB should try to open the extra unused undo tablespaces instead of trying to creating it.


## How can this PR be tested?
./mtr innodb.undo_upgrade --mem
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
