### PR TITLE
MDEV-33816 FORCE INDEX(IDX) can build a non-index-only full-index scan

### DIFF
--- a/mysql-test/main/key.result
+++ b/mysql-test/main/key.result
@@ -641,7 +641,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t1	index	NULL	a	5	NULL	6	
 SHOW STATUS LIKE 'Last_query_cost';
 Variable_name	Value
-Last_query_cost	14.199000
+Last_query_cost	9.212184
 DROP TABLE t1;
 #
 # MDEV-21480: Unique key using ref access though eq_ref access can be used
@@ -685,3 +685,42 @@ c	c
 9	10
 10	11
 drop table t1,t2;
+# Check some issues with FORCE INDEX and full index scans
+# (Does FORCE INDEX force an index scan)
+#
+create table t1 (a int primary key, b int, c int, d int,
+key k1 (b) using BTREE, key k2 (c,d) using btree) engine=heap;
+insert into t1 select seq as a, seq as b, seq as c, seq as d
+from seq_1_to_100;
+explain select sum(a+b) from t1 force index (k1) where b>0 and a=99;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	k1	k1	5	NULL	100	Using where
+explain select sum(a+b) from t1 force index (k1) where a>0;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index	NULL	k1	5	NULL	100	Using where
+explain select sum(a+b) from t1 force index (k1);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index	NULL	k1	5	NULL	100	
+explain select sum(a+b) from t1 force index for join (k1);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index	NULL	k1	5	NULL	100	
+explain select sum(a+b) from t1 force index for order by (k1);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	
+explain select sum(a+b) from t1 force index (k1,k2);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index	NULL	k1	5	NULL	100	
+select sum(a+b) from t1 force index (k1);
+sum(a+b)
+10100
+explain select sum(a+b) from t1 force index (primary);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	100	
+select sum(a+b) from t1 force index (primary);
+sum(a+b)
+10100
+explain select straight_join sum(a+b) from seq_1_to_10 as s, t1 force index (k2) where t1.a=s.seq;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	s	index	PRIMARY	PRIMARY	8	NULL	10	Using index
+1	SIMPLE	t1	index	NULL	k2	10	NULL	100	Using where; Using join buffer (flat, BNL join)
+drop table t1;

--- a/mysql-test/main/key.test
+++ b/mysql-test/main/key.test
@@ -605,3 +605,23 @@ EXPLAIN SELECT t1.c, t2.c FROM t1, t2 WHERE t1.b=t2.a and t1.c=t2.b;
 SELECT t1.c, t2.c FROM t1, t2 WHERE t1.b=t2.a and t1.c=t2.b;
 
 drop table t1,t2;
+
+--echo # Check some issues with FORCE INDEX and full index scans
+--echo # (Does FORCE INDEX force an index scan)
+--echo #
+
+create table t1 (a int primary key, b int, c int, d int,
+key k1 (b) using BTREE, key k2 (c,d) using btree) engine=heap;
+insert into t1 select seq as a, seq as b, seq as c, seq as d
+from seq_1_to_100;
+explain select sum(a+b) from t1 force index (k1) where b>0 and a=99;
+explain select sum(a+b) from t1 force index (k1) where a>0;
+explain select sum(a+b) from t1 force index (k1);
+explain select sum(a+b) from t1 force index for join (k1);
+explain select sum(a+b) from t1 force index for order by (k1);
+explain select sum(a+b) from t1 force index (k1,k2);
+select sum(a+b) from t1 force index (k1);
+explain select sum(a+b) from t1 force index (primary);
+select sum(a+b) from t1 force index (primary);
+explain select straight_join sum(a+b) from seq_1_to_10 as s, t1 force index (k2) where t1.a=s.seq;
+drop table t1;

--- a/mysql-test/main/range_vs_index_merge_innodb.result
+++ b/mysql-test/main/range_vs_index_merge_innodb.result
@@ -1693,7 +1693,7 @@ SELECT * FROM t1 FORCE KEY (PRIMARY,f3,f4)
 WHERE ( f3 = 1 OR f1 = 7 ) AND f1 < 10
 OR f3 BETWEEN 2 AND 2 AND ( f3 = 1 OR f4 < 7 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	PRIMARY,f3,f4	NULL	NULL	NULL	306	Using where
+1	SIMPLE	t1	index	PRIMARY,f3,f4	f3	5	NULL	306	Using where
 SELECT * FROM t1 FORCE KEY (PRIMARY,f3,f4)
 WHERE ( f3 = 1 OR f1 = 7 ) AND f1 < 10
 OR f3 BETWEEN 2 AND 2 AND ( f3 = 1 OR f4 < 7 );
@@ -1726,7 +1726,7 @@ SELECT * FROM t1 FORCE KEY (PRIMARY,f3,f4)
 WHERE ( f3 = 1 OR f1 = 7 ) AND f1 < 10
 OR f3 BETWEEN 2 AND 2 AND ( f3 = 1 OR f4 < 7 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ALL	PRIMARY,f3,f4	NULL	NULL	NULL	320	Using where
+1	SIMPLE	t1	index	PRIMARY,f3,f4	f3	5	NULL	320	Using where
 SELECT * FROM t1 FORCE KEY (PRIMARY,f3,f4)
 WHERE ( f3 = 1 OR f1 = 7 ) AND f1 < 10
 OR f3 BETWEEN 2 AND 2 AND ( f3 = 1 OR f4 < 7 );

--- a/mysql-test/suite/gcol/r/innodb_virtual_index.result
+++ b/mysql-test/suite/gcol/r/innodb_virtual_index.result
@@ -334,8 +334,8 @@ NULL
 100
 SELECT fld2 FROM t FORCE INDEX(fld1);
 fld2
-100
 NULL
+100
 Warnings:
 Warning	1365	Division by 0
 disconnect stop_purge;

--- a/sql/sql_base.h
+++ b/sql/sql_base.h
@@ -360,7 +360,7 @@ inline void setup_table_map(TABLE *table, TABLE_LIST *table_list, uint tablenr)
   }
   table->tablenr= tablenr;
   table->map= (table_map) 1 << tablenr;
-  table->force_index= table_list->force_index;
+  table->force_index= table->force_index_join= 0;
   table->force_index_order= table->force_index_group= 0;
   table->covering_keys= table->s->keys_for_keyread;
 }

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -390,6 +390,7 @@ POSITION::POSITION()
   records_read= cond_selectivity= read_time= 0.0;
   prefix_record_count= 0.0;
   key= 0;
+  forced_index= 0;
   use_join_buffer= 0;
   sj_strategy= SJ_OPT_NONE;
   n_sj_tables= 0;
@@ -1973,8 +1974,6 @@ bool JOIN::make_range_rowid_filters()
     filter_map.clear_all();
     filter_map.set_bit(tab->range_rowid_filter_info->key_no);
     filter_map.merge(tab->table->with_impossible_ranges);
-    bool force_index_save= tab->table->force_index;
-    tab->table->force_index= true;
     quick_select_return rc;
     /*
       EQ_FUNC and EQUAL_FUNC already sent unusable key notes (if any)
@@ -1984,7 +1983,6 @@ bool JOIN::make_range_rowid_filters()
     rc= sel->test_quick_select(thd, filter_map, (table_map) 0,
                                (ha_rows) HA_POS_ERROR, true, false, true,
                                true, Item_func::BITMAP_EXCEPT_ANY_EQUALITY);
-    tab->table->force_index= force_index_save;
     if (rc == SQL_SELECT::ERROR || thd->is_error())
     {
       DBUG_RETURN(true); /* Fatal error */
@@ -3255,6 +3253,7 @@ int JOIN::optimize_stage2()
     */
     if ((order || group_list) &&
         tab->type != JT_ALL &&
+        tab->type != JT_NEXT &&
         tab->type != JT_FT &&
         tab->type != JT_REF_OR_NULL &&
         ((order && simple_order) || (group_list && simple_group)))
@@ -8025,6 +8024,7 @@ best_access_path(JOIN      *join,
   uint use_cond_selectivity= thd->variables.optimizer_use_condition_selectivity;
   KEYUSE *best_key=         0;
   uint best_max_key_part=   0;
+  uint best_forced_index= MAX_KEY, forced_index= MAX_KEY;
   my_bool found_constraint= 0;
   double best=              DBL_MAX;
   double best_time=         DBL_MAX;
@@ -8824,7 +8824,7 @@ best_access_path(JOIN      *join,
         best_max_key_part >= s->table->opt_range[best_key->key].key_parts) &&// (2)
       !((s->table->file->ha_table_flags() & HA_TABLE_SCAN_ON_INDEX) &&   // (3)
         ! s->table->covering_keys.is_clear_all() && best_key && !s->quick) &&// (3)
-      !(s->table->force_index && best_key && !s->quick) &&               // (4)
+      !(s->table->force_index_join && best_key && !s->quick) &&          // (4)
       !(best_key && s->table->pos_in_table_list->jtbm_subselect))        // (5)
   {                                             // Check full join
     bool force_estimate= 0;
@@ -8889,15 +8889,52 @@ best_access_path(JOIN      *join,
     else
     {
       /* Estimate cost of reading table. */
-      if (s->table->force_index && !best_key) // index scan
+      if (s->cached_forced_index_type)
       {
-        type= JT_NEXT;
-        tmp= s->table->file->read_time(s->ref.key, 1, s->records);
+        type=         s->cached_forced_index_type;
+        tmp=          s->cached_forced_index_cost;
+        forced_index= s->cached_forced_index;
       }
-      else // table scan
+      else
       {
-        tmp= s->scan_time();
-        type= JT_ALL;
+        TABLE* table= s->table;
+        if (table->force_index_join && !best_key)
+        {
+          /*
+            The query is using 'forced_index' and we did not find a complete
+            key.  Determine if we can do a non-index-only full index scan
+            if query specifies FORCE INDEX on a covering index.
+          */
+          type= JT_NEXT;
+
+          /* No cached key, use shortest allowed key */
+          key_map keys= *table->file->keys_to_use_for_scanning();
+          keys.intersect(table->keys_in_use_for_query);
+          if ((forced_index= find_shortest_key(table, &keys)) < MAX_KEY)
+          {
+            tmp= cost_for_index_read(thd, table,
+                                     forced_index,
+                                     s->records,
+                                     s->worst_seeks);
+            /* Calculate cost of checking the attached WHERE */
+            const double where_cost= ((double) 3.2e-05);
+            tmp+= s->records * where_cost;
+          }
+          else
+          {
+            /* No usable key, use table scan */
+            tmp= s->scan_time();
+            type= JT_ALL;
+          }
+        }
+        else // table scan
+        {
+          tmp= s->scan_time();
+          type= JT_ALL;
+        }
+        s->cached_forced_index_type= type;
+        s->cached_forced_index_cost= tmp;
+        s->cached_forced_index= forced_index;
       }
 
       if ((s->table->map & join->outer_join) || disable_jbuf)     // Can't use join cache
@@ -8962,6 +8999,7 @@ best_access_path(JOIN      *join,
       best= tmp;
       records= rnd_records;
       best_key= 0;
+      best_forced_index= forced_index;
       best_filter= 0;
       if (s->quick && s->quick->get_type() == QUICK_SELECT_I::QS_TYPE_RANGE)
         best_filter= filter;
@@ -8986,6 +9024,7 @@ best_access_path(JOIN      *join,
   pos->records_read= records;
   pos->read_time=    best;
   pos->key=          best_key;
+  pos->forced_index= best_forced_index;
   pos->type=         best_type;
   pos->table=        s;
   pos->ref_depend_map= best_ref_depends_map;
@@ -11470,7 +11509,13 @@ bool JOIN::get_best_combination()
       goto loop_end;
     if ( !(keyuse= best_positions[tablenr].key))
     {
-      j->type=JT_ALL;
+      if (cur_pos->type == JT_NEXT)             // Forced index
+      {
+        j->type= JT_NEXT;
+        j->index= cur_pos->forced_index;
+      }
+      else
+       j->type=JT_ALL;
       if (best_positions[tablenr].use_join_buffer &&
           tablenr != const_tables)
 	full_join= 1;
@@ -12727,7 +12772,8 @@ make_join_select(JOIN *join,SQL_SELECT *select,COND *cond)
               tab->table->reginfo.impossible_range)
 	    DBUG_RETURN(1);
 	}
-	else if (tab->type == JT_ALL && ! use_quick_range)
+	else if ((tab->type == JT_ALL || tab->type == JT_NEXT) &&
+                 ! use_quick_range)
 	{
 	  if (!tab->const_keys.is_clear_all() &&
 	      tab->table->reginfo.impossible_range)
@@ -13849,6 +13895,7 @@ uint check_join_cache_usage(JOIN_TAB *tab,
   prev_cache= prev_tab->cache;
 
   switch (tab->type) {
+  case JT_NEXT:
   case JT_ALL:
     if (cache_level == 1)
       prev_cache= 0;
@@ -14010,6 +14057,7 @@ restart:
     case JT_EQ_REF:
     case JT_REF:
     case JT_REF_OR_NULL:
+    case JT_NEXT:
     case JT_ALL:
       tab->used_join_cache_level= check_join_cache_usage(tab, options,
                                                          no_jbuf_after,
@@ -14264,6 +14312,25 @@ make_join_readinfo(JOIN *join, ulonglong options, uint no_jbuf_after)
           (!jcl || jcl > 4) && !tab->ref.is_access_triggered())
         push_index_cond(tab, tab->ref.key);
       break;
+    case JT_NEXT:                               // Index scan
+      DBUG_ASSERT(!(tab->select && tab->select->quick));
+      if (tab->use_quick == 2)
+      {
+        join->thd->set_status_no_good_index_used();
+	tab->read_first_record= join_init_quick_read_record;
+	if (statistics)
+	  join->thd->inc_status_select_range_check();
+      }
+      else
+      {
+        tab->read_first_record= join_read_first;
+        if (statistics)
+        {
+          join->thd->inc_status_select_scan();
+          join->thd->query_plan_flags|= QPLAN_FULL_SCAN;
+        }
+      }
+      break;
     case JT_ALL:
     case JT_HASH:
       /*
@@ -14456,7 +14523,8 @@ bool error_if_full_join(JOIN *join)
   for (JOIN_TAB *tab=first_top_level_tab(join, WITH_CONST_TABLES); tab;
        tab= next_top_level_tab(join, tab))
   {
-    if (tab->type == JT_ALL && (!tab->select || !tab->select->quick))
+      if ((tab->type == JT_ALL || tab->type == JT_NEXT) &&
+          (!tab->select || !tab->select->quick))
     {
       my_message(ER_UPDATE_WITHOUT_KEY_IN_SAFE_MODE,
                  ER_THD(join->thd,
@@ -22920,9 +22988,29 @@ int join_init_read_record(JOIN_TAB *tab)
   save_copy=     tab->read_record.copy_field;
   save_copy_end= tab->read_record.copy_field_end;
   
-  if (init_read_record(&tab->read_record, tab->join->thd, tab->table,
-                       tab->select, tab->filesort_result, 1, 1, FALSE))
-    return 1;
+  /*
+    JT_NEXT means that we should use an index scan on index 'tab->index'
+    However if filesort is set, the table was already sorted above
+    and now have to retrive the rows from the tmp file or by rnd_pos()
+    If !(tab->select && tab->select->quick)) it means that we are
+    in "Range checked for each record" and we better let the normal
+    init_read_record() handle this case
+  */
+
+  if (tab->type == JT_NEXT && ! tab->filesort &&
+      !(tab->select && tab->select->quick))
+  {
+    /* Used with covered_index scan or force index */
+    if (init_read_record_idx(&tab->read_record, tab->join->thd, tab->table,
+                             1, tab->index, 0))
+      return 1;
+  }
+  else
+  {
+    if (init_read_record(&tab->read_record, tab->join->thd, tab->table,
+                         tab->select, tab->filesort_result, 1, 1, FALSE))
+      return 1;
+  }
 
   tab->read_record.copy_field=     save_copy;
   tab->read_record.copy_field_end= save_copy_end;

--- a/sql/sql_select.h
+++ b/sql/sql_select.h
@@ -361,6 +361,9 @@ typedef struct st_join_table {
     
   double        partial_join_cardinality;
 
+  /* Used with force_index_join */
+  double        cached_forced_index_cost{0};
+
   table_map	dependent,key_dependent;
   /*
      1 - use quick select
@@ -379,7 +382,8 @@ typedef struct st_join_table {
   uint          used_blobs;
   uint          used_null_fields;
   uint          used_uneven_bit_fields;
-  enum join_type type;
+  uint          cached_forced_index;
+  enum join_type type, cached_forced_index_type;
   /* If first key part is used for any key in 'key_dependent' */
   bool          key_start_dependent;
   bool          cached_eq_ref_table,eq_ref_table;
@@ -1035,6 +1039,8 @@ public:
     are covered by the specified semi-join strategy
   */
   uint n_sj_tables;
+    
+  uint forced_index;                    // If force_index() is used
 
   /*
     TRUE <=> join buffering will be used. At the moment this is based on

--- a/sql/table.h
+++ b/sql/table.h
@@ -1455,6 +1455,9 @@ public:
   */
   bool force_index;
 
+  /* Flag set when the statement contains FORCE INDEX FOR JOIN */
+  bool force_index_join;
+
   /**
     Flag set when the statement contains FORCE INDEX FOR ORDER BY
     See TABLE_LIST::process_index_hints().


### PR DESCRIPTION
When there is no range nor ref condition that we may leverage for an index lookup, thne we may do a full index scan instead of a table scan.

Mostly a port of 33fc8037e0a5c54c69732b3ee0eb7aea41392aed
