### PR TITLE
MDEV-34209 InnoDB is disregarding read-only mode on slow shutdown

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4262,7 +4262,7 @@ innobase_end(handlerton*, ha_panic_function)
 		}
 
 		/* Do system tablespace truncation during slow shutdown */
-		if (!srv_fast_shutdown
+		if (!srv_fast_shutdown && !high_level_read_only
 		    && srv_operation == SRV_OPERATION_NORMAL) {
 			fsp_system_tablespace_truncate();
 		}


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34209*
## Description
`innobase_end()`: Do not attempt to shrink the system tablespace if `innodb_read_only=ON` or `innodb_force_recovery>4`. This fixes a regression due to commit 2d6c2f22a4f9844db45d66e063fbf9314889eb1b (MDEV-32452).
## Release Notes
On shutdown with `innodb_fast_shutdown=0`, InnoDB would attempt to write to the system tablespace even though it is supposed to be read-only due to the `innodb_read_only` or `innodb_force_recovery` settings.
## How can this PR be tested?
This bug was caught when testing #3272, which adds `SET GLOBAL innodb_fast_shutdown=0` to the test `innodb.undo_upgrade`. The failure is sporadic; I repeated it for `innodb.undo_upgrade,64k` on a MemorySanitizer instrumented build.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.