### PR TITLE
MDEV-34206 compile failure: fmt use incompatible with libfmt-10.2.[2]+

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -1382,7 +1382,7 @@ bool Item_func_sformat::fix_length_and_dec(THD *thd)
 namespace fmt {
   template <> struct formatter<String>: formatter<string_view> {
     template <typename FormatContext>
-    auto format(String c, FormatContext& ctx) -> decltype(ctx.out()) {
+    auto format(String c, FormatContext& ctx) const -> decltype(ctx.out()) {
       string_view name = { c.ptr(), c.length() };
       return formatter<string_view>::format(name, ctx);
     };

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -1386,6 +1386,12 @@ namespace fmt {
       string_view name = { c.ptr(), c.length() };
       return formatter<string_view>::format(name, ctx);
     };
+    /* needed below function for libfmt-7.1.3 compatibility, (not 9.1.0+) */
+    template <typename FormatContext>
+    auto format(String c, FormatContext& ctx) -> decltype(ctx.out()) {
+      string_view name = { c.ptr(), c.length() };
+      return formatter<string_view>::format(name, ctx);
+    };
   };
 };
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34206*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Upstream libfmt commit https://github.com/fmtlib/fmt/commit/d70729215fba1d54862e407b626abf86ddf409bf now requires the format function to be const.

Adjust the function prototype so it is const and can compile.

## Release Notes

Not important

## How can this PR be tested?

Compile with master version of libfmt

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.