### PR TITLE
MDEV-34212 InnoDB transaction recovery is incorrect

### DIFF
--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -45,6 +45,7 @@ Created 11/5/1995 Heikki Tuuri
 /** @name Modes for buf_page_get_gen */
 /* @{ */
 #define BUF_GET			10	/*!< get always */
+#define BUF_GET_RECOVER		9	/*!< like BUF_GET, but in recv_sys.recover() */
 #define	BUF_GET_IF_IN_POOL	11	/*!< get if in pool */
 #define BUF_PEEK_IF_IN_POOL	12	/*!< get if in pool, do not make
 					the block young in the LRU list */

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3672,8 +3672,8 @@ recv_sys_t::recover(const page_id_t page_id, mtr_t *mtr, dberr_t *err)
 {
   if (!recovery_on)
   must_read:
-    return buf_page_get_gen(page_id, 0, RW_S_LATCH, nullptr, BUF_GET, mtr,
-                            err);
+    return buf_page_get_gen(page_id, 0, RW_NO_LATCH, nullptr, BUF_GET_RECOVER,
+                            mtr, err);
 
   mysql_mutex_lock(&mutex);
   map::iterator p= pages.find(page_id);
@@ -3722,7 +3722,7 @@ recv_sys_t::recover(const page_id_t page_id, mtr_t *mtr, dberr_t *err)
     goto corrupted;
   }
 
-  mtr->page_lock(block, RW_S_LATCH);
+  mtr->page_lock(block, RW_NO_LATCH);
   return block;
 }
 

--- a/storage/innobase/trx/trx0undo.cc
+++ b/storage/innobase/trx/trx0undo.cc
@@ -980,7 +980,7 @@ trx_undo_mem_create_at_db_start(trx_rseg_t *rseg, ulint id, uint32_t page_no)
 
 	mtr.start();
 	const page_id_t page_id{rseg->space->id, page_no};
-	const buf_block_t* block = buf_page_get(page_id, 0, RW_X_LATCH, &mtr);
+	const buf_block_t* block = recv_sys.recover(page_id, &mtr, nullptr);
 	if (UNIV_UNLIKELY(!block)) {
 corrupted:
 		mtr.commit();
@@ -1094,9 +1094,8 @@ corrupted_type:
 	undo->last_page_no = last_addr.page;
 	undo->top_page_no = last_addr.page;
 
-	const buf_block_t* last = buf_page_get(
-		page_id_t(rseg->space->id, undo->last_page_no), 0,
-		RW_X_LATCH, &mtr);
+	const buf_block_t* last = recv_sys.recover(
+		page_id_t(rseg->space->id, undo->last_page_no), &mtr, nullptr);
 
 	if (UNIV_UNLIKELY(!last)) {
 		goto corrupted_undo;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34212*
## Description
Starting with [MDEV-32042](https://jira.mariadb.org/browse/MDEV-32042), we assume that the function `buf_page_get_gen()` is not being invoked while log is being applied during crash recovery. The idea is that any access to buffer pool pages during crash recovery must look up pages via `recv_sys_t::recover()`. This was being violated by the function `trx_undo_mem_create_at_db_start()` during startup.

`trx_undo_mem_create_at_db_start()`: Invoke `recv_sys_t::recover()` instead of `buf_page_get_gen()`, so that all undo log pages will be recovered correctly. Failure to do this could prevent InnoDB from starting up due to `Data structure corruption`, or it could potentially lead to a situation where InnoDB starts up but some transactions were recovered incorrectly.

`recv_sys_t::recover()`: Only acquire a buffer-fix on the pages, not a shared latch. This is adequate protection, because this function is only being invoked during early startup when no "users" are modifying buffer pool pages. The only writes are due to server bootstrap (the data files being created) or crash recovery (changes from `ib_logfile0` being applied).

`buf_page_get_gen()`: Assert that the function is not invoked while crash recovery is in progress, and that the special mode `BUF_GET_RECOVER` is only invoked during crash recovery or server bootstrap.

All this should really have been part of commit 850d61736deba354377634cf344256ee850b93b7 (MDEV-32042).
## Release Notes
InnoDB crash recovery could fail with an error `Data structure corruption`.
## How can this PR be tested?
The failure is very hard to reproduce. I managed it on a MemorySanitizer instrumented build with
```bash
./mtr --parallel=60 innodb.table_flags,64k,strict_full_crc32{,,,,,}{,,,,}{,}
```
If the change to `trx_undo_mem_create_at_db_start()` is omitted, the added assertion in `buf_page_get_gen()` will fail easily.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.