### PR TITLE
MDEV-34216 Possible corruption when shrinking the system tablespace on innodb_fast_shutdown=0

### DIFF
--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -583,8 +583,9 @@ void mtr_t::commit_shrink(fil_space_t &space, uint32_t size)
 
   if (space.id == TRX_SYS_SPACE)
     srv_sys_space.set_last_file_size(file->size);
+  else
+    space.set_create_lsn(m_commit_lsn);
 
-  space.set_create_lsn(m_commit_lsn);
   mysql_mutex_unlock(&fil_system.mutex);
 
   space.clear_freed_ranges();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34216*
## Description
This bug was found related to MDEV-34212 and #3277.

Some InnoDB tests, most notably `innodb.table_flags,64k` would occasionally fail. I am able to reproduce this locally on a MemorySanitizer build, sporadically.

This bug was revealed due to the recent commit 466ae1cf81f54b729058357bb19c4cf3982e1367 which set `innodb_fast_shutdown=0` during server bootstrap in our regression test driver.

Due to the bug, a write of undo page 50 in the system tablespace was discarded in `buf_page_t::flush()`. A subsequent InnoDB startup failed because an old version of that page would point to a freed undo log page 300.

`mtr_t::commit_shrink()`: Only invoke `fil_space_t::set_create_lsn()` on undo tablespaces, which will be fully reinitialized or created from the scratch. On the system tablespace, we must only adjust the file size, to avoid writing pages that are beyond the end of the tablespace. Thanks to Thirunarayanan Balathandayuthapani for providing this fix.
## Release Notes
The InnoDB system tablespace could become corrupted if it is shrunk during a shutdown with `innodb_fast_shutdown=0`.
## How can this PR be tested?
The following is a minimal `.test` file for reproducing this. I was only able to reproduce this in a MemorySanitizer instrumented build:
```sql
--source include/have_innodb.inc
SELECT @@innodb_page_size;
```
and the .opt file:
```
--innodb-undo-tablespaces=0 --innodb-page-size=64k --innodb-buffer-pool-size=20m
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.