### PR TITLE
MDEV-34214: allow intermediate certs in wsrep

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -1338,6 +1338,7 @@ verify_ca_matches_cert()
     errmsg=$("$OPENSSL_BINARY" verify -verbose \
                  ${ca:+ -CAfile} ${ca:+ "$ca"} \
                  ${cap:+ -CApath} ${cap:+ "$cap"} \
+                 -untrusted "$cert" \
                  "$cert" 2>&1) || not_match=1
 
     if [ $not_match -eq 1 ]; then


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-34214](https://jira.mariadb.org/browse/MDEV-34214)*

## Description
* Pass the sst.tcert / ssl_cert (leaf certificate) to openssl verify as parameter for the "-untrusted" flag, aligning the script behavior with MariaDB's [CONC-500](https://jira.mariadb.org/browse/CONC-500), Galera's [Issue 571](https://github.com/codership/galera/issues/571)

## Release Notes
* wsrep_sst_common now validates certificate chains using every certificate present in tcert/ssl_cert

## How can this PR be tested?
Testing can be done by ensuring the file used in ssl_cert includes more than one certificate (e.g. Let's Encrypt fullchain.pem)

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
