### PR TITLE
MDEV-34221  Errors about checksum mismatch on crash recovery are confusing

### DIFF
--- a/mysql-test/suite/innodb/r/undo_space_dblwr.result
+++ b/mysql-test/suite/innodb/r/undo_space_dblwr.result
@@ -12,7 +12,7 @@ set global innodb_fil_make_page_dirty_debug = 1;
 SET GLOBAL innodb_buf_flush_list_now = 1;
 # Kill the server
 # restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
-FOUND 1 /Checksum mismatch in the first page of file/ in mysqld.1.err
+FOUND 1 /Restoring page \[page id: space=1, page number=0\] of datafile '.*undo001' from the doublewrite buffer./ in mysqld.1.err
 check table t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK

--- a/mysql-test/suite/innodb/t/undo_space_dblwr.test
+++ b/mysql-test/suite/innodb/t/undo_space_dblwr.test
@@ -39,7 +39,7 @@ EOF
 
 --source include/start_mysqld.inc
 let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
-let SEARCH_PATTERN= Checksum mismatch in the first page of file;
+let SEARCH_PATTERN= Restoring page \[page id: space=1, page number=0\] of datafile '.*undo001' from the doublewrite buffer.;
 --source include/search_pattern_in_file.inc
 
 check table t1;

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -554,7 +554,6 @@ err_exit:
     fsp_flags= mach_read_from_4(FSP_HEADER_OFFSET + FSP_SPACE_FLAGS + page);
     if (buf_page_is_corrupted(false, page, fsp_flags))
     {
-      ib::error() << "Checksum mismatch in the first page of file " << name;
       if (recv_sys.dblwr.restore_first_page(space_id, name, fh))
         goto err_exit;
     }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34221*

## Description
- InnoDB should avoid printing the error message before restoring the first page from doublewrite buffer.


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
