### PR TITLE
MDEV-34234: make lsof optional on RPM

### DIFF
--- a/cmake/cpack_rpm.cmake
+++ b/cmake/cpack_rpm.cmake
@@ -220,8 +220,9 @@ SETA(CPACK_RPM_server_PACKAGE_REQUIRES
 
 IF(WITH_WSREP)
   SETA(CPACK_RPM_server_PACKAGE_REQUIRES
-    "galera-4" "rsync" "lsof" "grep" "gawk" "iproute"
+    "galera-4" "rsync" "grep" "gawk" "iproute"
     "coreutils" "findutils" "tar")
+  SETA(CPACK_RPM_server_PACKAGE_RECOMMENDS "lsof")
 ENDIF()
 
 SET(CPACK_RPM_server_PRE_INSTALL_SCRIPT_FILE ${CMAKE_SOURCE_DIR}/support-files/rpm/server-prein.sh)


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-34234](https://jira.mariadb.org/browse/MDEV-34234)*

## Description
Make lsof an optional dependency on RPM based builds. This should allow users to select if they prefer to use ss, lsof or sockstat when using WSREP.

## Release Notes
Remove hard dependency on LSOF on RPM based installs.

## How can this PR be tested?

Manually inspect RPM dependencies and note lsof is marked as a weak dependency

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
