### PR TITLE
MDEV-34256 InnoDB throws out of bound write due to temporary tablespace truncation

### DIFF
--- a/mysql-test/suite/innodb/r/temp_truncate_freed.result
+++ b/mysql-test/suite/innodb/r/temp_truncate_freed.result
@@ -1,0 +1,11 @@
+set @old_innodb_buffer_pool_size = @@innodb_buffer_pool_size;
+set @old_immediate_scrub_data_val= @@innodb_immediate_scrub_data_uncompressed;
+SET GLOBAL innodb_immediate_scrub_data_uncompressed=1;
+SET GLOBAL innodb_buffer_pool_size= 16777216;
+CREATE TEMPORARY TABLE t1(c1 MEDIUMTEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (repeat(1,16777215));
+DROP TEMPORARY TABLE t1;
+SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
+SET GLOBAL innodb_buffer_pool_size=10485760;
+set global innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
+set global innodb_immediate_scrub_data_uncompressed = @old_immediate_scrub_data_val;

--- a/mysql-test/suite/innodb/t/temp_truncate_freed.test
+++ b/mysql-test/suite/innodb/t/temp_truncate_freed.test
@@ -1,0 +1,25 @@
+--source include/have_innodb.inc
+
+set @old_innodb_buffer_pool_size = @@innodb_buffer_pool_size;
+set @old_immediate_scrub_data_val= @@innodb_immediate_scrub_data_uncompressed;
+
+SET GLOBAL innodb_immediate_scrub_data_uncompressed=1;
+SET GLOBAL innodb_buffer_pool_size= 16777216;
+
+CREATE TEMPORARY TABLE t1(c1 MEDIUMTEXT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (repeat(1,16777215));
+DROP TEMPORARY TABLE t1;
+SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
+
+let $wait_timeout = 180;
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
+  FROM information_schema.global_status
+  WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
+
+SET GLOBAL innodb_buffer_pool_size=10485760;
+--source include/wait_condition.inc
+
+set global innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
+set global innodb_immediate_scrub_data_uncompressed = @old_immediate_scrub_data_val;
+--source include/wait_condition.inc

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -3714,7 +3714,7 @@ inline void fil_space_t::clear_freed_ranges(uint32_t threshold)
   {
     if (range.first >= threshold)
       continue;
-    else if (range.last > threshold)
+    else if (range.last >= threshold)
     {
       range_t new_range{range.first, threshold - 1};
       current_ranges.add_range(new_range);


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-34256*

## Description
 InnoDB fails with out of bound write error after temporary
tablespace truncation. InnoDB fail to clear freed ranges
if shrinking size is the last offset of the freed range.

## How can this PR be tested?
./mtr innodb.temp_truncate_freed
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
