### PR TITLE
Revert "MDEV-32935: Remove unneeded CMAKE_SYSTEM_PROCESSOR parameter …

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -89,6 +89,7 @@ endif
 	    -DCOMPILATION_COMMENT="mariadb.org binary distribution" \
 	    -DMYSQL_SERVER_SUFFIX="-$(DEB_VERSION_REVISION)" \
 	    -DSYSTEM_TYPE="debian-$(DEB_HOST_GNU_SYSTEM)" \
+	    -DCMAKE_SYSTEM_PROCESSOR=$(DEB_HOST_ARCH) \
 	    -DBUILD_CONFIG=mysql_release \
 	    -DPLUGIN_TOKUDB=NO \
 	    -DPLUGIN_CASSANDRA=NO \


### PR DESCRIPTION
…from Debian"

This reverts commit 6914b7804dd29b71f9a85a120f6352d8cd855e38.

With the MDEV-32935 change, building on 32bit Linux with a 64bit CPU causes CMAKE_SYSTEM_PROCESSOR to detect 64bit. This then triggers things such as ColumnStore to build, which definitely should not build on a 32bit platform.
