### PR TITLE
MDEV-34283 A misplaced btr_cur_need_opposite_intention() check may fail to prevent hangs

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -756,6 +756,7 @@ static bool btr_cur_need_opposite_intention(const buf_page_t &bpage,
                                             ulint compress_limit,
                                             const rec_t *rec)
 {
+  ut_ad(bpage.frame == page_align(rec));
   if (UNIV_LIKELY_NULL(bpage.zip.data) &&
       !page_zip_available(&bpage.zip, is_clust, node_ptr_max_size, 1))
     return true;
@@ -1437,11 +1438,6 @@ release_tree:
           !btr_block_get(*index(), btr_page_get_next(block->page.frame),
                          RW_X_LATCH, false, mtr, &err))
         goto func_exit;
-      if (btr_cur_need_opposite_intention(block->page, index()->is_clust(),
-                                          lock_intention,
-                                          node_ptr_max_size, compress_limit,
-                                          page_cur.rec))
-        goto need_opposite_intention;
     }
 
   reached_latched_leaf:
@@ -1462,6 +1458,13 @@ release_tree:
     ut_ad(up_match != ULINT_UNDEFINED || mode != PAGE_CUR_GE);
     ut_ad(up_match != ULINT_UNDEFINED || mode != PAGE_CUR_LE);
     ut_ad(low_match != ULINT_UNDEFINED || mode != PAGE_CUR_LE);
+
+    if (latch_mode == BTR_MODIFY_TREE &&
+        btr_cur_need_opposite_intention(block->page, index()->is_clust(),
+                                        lock_intention,
+                                        node_ptr_max_size, compress_limit,
+                                        page_cur.rec))
+        goto need_opposite_intention;
 
 #ifdef BTR_CUR_HASH_ADAPT
     /* We do a dirty read of btr_search_enabled here.  We will


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34283*
## Description
`btr_cur_t::search_leaf()`: Invoke `btr_cur_need_opposite_intention()` after positioning `page_cur.rec` so that the record will be in the intended page. This is something that was broken in f2096478d5750b983f9a9cc4691d20e152dafd4a or de4030e4d49805a7ded5c0bfee01cc3fd7623522 or related changes.
## Release Notes
In extremely rare cases, InnoDB could hang due to a mispredicted page split or merge.
## How can this PR be tested?
`./mtr innodb.temp_table_savepoint` and many other tests cover this.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.