### PR TITLE
GitLab CI Upgrade CentOS 8 to CentOS 9 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ variables:
   # Major version dictates which branches share the same ccache. E.g. 10.6-abc
   # and 10.6-xyz will have the same cache.
   MARIADB_MAJOR_VERSION: "10.5"
-  # NOTE! Currently ccache is only used on the Centos8 build. As each job has
+  # NOTE! Currently ccache is only used on the Centos 9 build. As each job has
   # sufficiently different environments they are unable to benefit from each
   # other's ccaches. As each build generates about 1 GB of ccache, having
   # multiple caches would quickly consume all free storage on Gitlab-CI and
@@ -53,7 +53,7 @@ variables:
   # cache:policy are not flexible enough to have a system where the cache is
   # uploaded only once a week and not on every build. Having ccache on at least
   # one build still helps ensure that ccache compatibility is at least tested
-  # and if the Centos 8 build is always significantly faster than all other
+  # and if the Centos 9 build is always significantly faster than all other
   # builds (e.g. on self-hosted Gitlab instances) then users would at least be
   # able to discover it.
   #
@@ -209,26 +209,20 @@ fedora-sanitizer:
     matrix:
       - SANITIZER: [-DWITH_ASAN=YES, -DWITH_TSAN=YES, -DWITH_UBSAN=YES]
 
-centos8:
+centos9:
   stage: build
-  image: quay.io/centos/centos:stream8 # CentOS 8 is deprecated, use this Stream8 instead
+  image: quay.io/centos/centos:stream9 # CentOS 9 is deprecated, use this Stream9 instead
   variables:
     GIT_STRATEGY: fetch
     GIT_SUBMODULE_STRATEGY: normal
   script:
-    - yum install -y yum-utils rpm-build openssl-devel pcre2-devel
-    - yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-    # dnf --enablerepo=powertools install Judy-devel  #--> not found
-    - dnf config-manager --set-enabled powertools
-    # Error:
-    # Problem: conflicting requests
-    # - package Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.i686 is filtered out by modular filtering
-    # - package Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64 is filtered out by modular filtering
-    # Solution: install Judy-devel directly from downloaded rpm file:
-    - yum install -y http://vault.centos.org/centos/8/PowerTools/x86_64/os/Packages/Judy-devel-1.0.5-18.module_el8.3.0+757+d382997d.x86_64.rpm
-    # Use eatmydata to speed up build
-    - yum install -y https://github.com/stewartsmith/libeatmydata/releases/download/v129/libeatmydata-129-1.fc33.x86_64.rpm
-    - yum install -y ccache  # From EPEL
+    - yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    - yum install -y yum-utils rpm-build openssl-devel libeatmydata ccache
+    # Install missing dependencies
+    - yum install -y https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/Judy-devel-1.0.5-28.el9.x86_64.rpm
+    - yum install -y https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/bison-devel-3.7.4-5.el9.x86_64.rpm
+    - yum install -y https://mirror.stream.centos.org/9-stream/CRB/x86_64/os/Packages/multilib-rpm-config-1-19.el9.noarch.rpm
+    # Configure ccache
     - source /etc/profile.d/ccache.sh
     - export CCACHE_DIR="$(pwd)/.ccache"; ccache --zero-stats
     # This repository does not have any .spec files, so install dependencies based on CentOS spec file


### PR DESCRIPTION
## Description
    
> After May 31, 2024, CentOS Stream 8 will be archived and no further
updates will be provided. [1]
    
CentOS Stream 8 is now EOL and should be updated to using CentOS Stream 9 for compatibility testing in GitLab CI.
    
[1] https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/
https://www.centos.org/centos-linux-eol/


## Release Notes
None

## How can this PR be tested?
Start CentOS 9 container with 
docker run --rm  -it quay.io/centos/centos:stream9 bash

Follow the build code in .gitlab-ci.yml

A working pipeline can be seen on the public mirror https://salsa.debian.org/robinnewhouse/mariadb-server-mirror/-/pipelines

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.