### PR TITLE
MDEV-34261: Detect if build is running under 32-bit container

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -62,6 +62,7 @@ replace_uring_with_aio()
 }
 
 architecture=$(dpkg-architecture -q DEB_BUILD_ARCH)
+uname_machine=$(uname -m)
 
 # Parse release name and number from Linux standard base release
 # Example:
@@ -159,6 +160,14 @@ fi
 if which eatmydata > /dev/null
 then
   BUILDPACKAGE_DPKGCMD+=("eatmydata")
+fi
+
+# If running autobake-debs.sh inside docker/podman host machine which
+# has 64 bits cpu but container image is 32 bit make sure that we set
+# correct arch with linux32 for 32 bit enviroment
+if [ "$architecture" = "i386" ] && [ "$uname_machine" = "x86_64" ]
+then
+  BUILDPACKAGE_DPKGCMD+=("linux32")
 fi
 
 BUILDPACKAGE_DPKGCMD+=("dpkg-buildpackage")


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34261*

## Description
When building on 64-bit kernel machine in 32-bit docker container CMake falsely (but it works as expected) detects that  container runtime in also 64-bits. Use linux32 command to change runtime environment to 32-bit and then CMake will  correctly disable for example ColumnStore and not try to build it

This commit only works with debian/autobake-debs.sh

## Release Notes
Should add nothing as this brings back i386 building in 11.5 and above

## How can this PR be tested?
This is bit difficult to test as problem start to rise after 11.5. They have `__int128` which is not supported and probably won't be supported in i386 environment. But basics is that have i386 container and launch it with `docker run -it quay.io/mariadb-foundation/bb-worker:debian12-386 bash`. Then try to compile with `debian/autobake-debs.sh`

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
