### PR TITLE
MDEV-34296 extern thread_local is a CPU waste

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2165,6 +2165,12 @@ void buf_page_free(fil_space_t *space, uint32_t page, mtr_t *mtr)
   mtr->memo_push(block, MTR_MEMO_PAGE_X_MODIFY);
 }
 
+static void buf_inc_get(ha_handler_stats *stats)
+{
+  mariadb_increment_pages_accessed(stats);
+  ++buf_pool.stat.n_page_gets;
+}
+
 /** Get read access to a compressed page (usually of type
 FIL_PAGE_TYPE_ZBLOB or FIL_PAGE_TYPE_ZBLOB2).
 The page must be released with unfix().
@@ -2180,8 +2186,8 @@ buf_page_t* buf_page_get_zip(const page_id_t page_id, ulint zip_size)
 {
   ut_ad(zip_size);
   ut_ad(ut_is_2pow(zip_size));
-  ++buf_pool.stat.n_page_gets;
-  mariadb_increment_pages_accessed();
+  ha_handler_stats *const stats= mariadb_stats;
+  buf_inc_get(stats);
 
   buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(page_id.fold());
   page_hash_latch &hash_lock= buf_pool.page_hash.lock_get(chain);
@@ -2283,7 +2289,7 @@ must_read_page:
   switch (dberr_t err= buf_read_page(page_id, zip_size)) {
   case DB_SUCCESS:
   case DB_SUCCESS_LOCKED_REC:
-    mariadb_increment_pages_read();
+    mariadb_increment_pages_read(stats);
     goto lookup;
   default:
     ib::error() << "Reading compressed page " << page_id
@@ -2460,9 +2466,8 @@ buf_page_get_low(
 	ut_ad(!mtr || !ibuf_inside(mtr)
 	      || ibuf_page_low(page_id, zip_size, FALSE, NULL));
 
-	++buf_pool.stat.n_page_gets;
-        mariadb_increment_pages_accessed();
-
+	ha_handler_stats* const stats = mariadb_stats;
+	buf_inc_get(stats);
 	auto& chain= buf_pool.page_hash.cell_get(page_id.fold());
 	page_hash_latch& hash_lock = buf_pool.page_hash.lock_get(chain);
 loop:
@@ -2533,7 +2538,7 @@ loop:
 	switch (dberr_t local_err = buf_read_page(page_id, zip_size)) {
 	case DB_SUCCESS:
 	case DB_SUCCESS_LOCKED_REC:
-                mariadb_increment_pages_read();
+		mariadb_increment_pages_read(stats);
 		buf_read_ahead_random(page_id, zip_size, ibuf_inside(mtr));
 		break;
 	default:
@@ -3127,8 +3132,7 @@ buf_block_t *buf_page_try_get(const page_id_t page_id, mtr_t *mtr)
   ut_ad(block->page.buf_fix_count());
   ut_ad(block->page.id() == page_id);
 
-  ++buf_pool.stat.n_page_gets;
-  mariadb_increment_pages_accessed();
+  buf_inc_get(mariadb_stats);
   return block;
 }
 

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -300,12 +300,15 @@ buf_read_page_low(
 	}
 
 	ut_ad(bpage->in_file());
-	ulonglong mariadb_timer= 0;
+	ulonglong mariadb_timer = 0;
 
 	if (sync) {
 		thd_wait_begin(nullptr, THD_WAIT_DISKIO);
-		if (mariadb_stats_active())
-		  mariadb_timer= mariadb_measure();
+		if (const ha_handler_stats *stats = mariadb_stats) {
+			if (stats->active) {
+				mariadb_timer = mariadb_measure();
+			}
+		}
 	}
 
 	DBUG_LOG("ib_buf",
@@ -324,15 +327,16 @@ buf_read_page_low(
 	if (UNIV_UNLIKELY(fio.err != DB_SUCCESS)) {
 		buf_pool.corrupted_evict(bpage, buf_page_t::READ_FIX);
 	} else if (sync) {
-		thd_wait_end(NULL);
+		thd_wait_end(nullptr);
 		/* The i/o was already completed in space->io() */
 		fio.err = bpage->read_complete(*fio.node);
 		space->release();
 		if (fio.err == DB_FAIL) {
 			fio.err = DB_PAGE_CORRUPTED;
 		}
-		if (mariadb_timer)
-		  mariadb_increment_pages_read_time(mariadb_timer);
+		if (mariadb_timer) {
+			mariadb_increment_pages_read_time(mariadb_timer);
+		}
 	}
 
 	return fio.err;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -110,8 +110,7 @@ extern my_bool opt_readonly;
 #include "ut0mem.h"
 #include "row0ext.h"
 #include "mariadb_stats.h"
-thread_local ha_handler_stats mariadb_dummy_stats;
-thread_local ha_handler_stats *mariadb_stats= &mariadb_dummy_stats;
+simple_thread_local ha_handler_stats *mariadb_stats;
 
 #include <limits>
 #include <myisamchk.h>                          // TT_FOR_UPGRADE


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34296*
## Description
In commit 99bd22605938c42d876194f2ec75b32e658f00f5 (MDEV-31558) we wrongly thought that there would be minimal overhead for accessing a thread-local variable `mariadb_stats`.

It turns out that in C++11, each access to an `extern thread_local` variable requires conditionally invoking an initialization function. In fact, we do have a custom initializer of this very variable, and that call is actually unavoidable.

In C++20, one could declare `constinit thread_local` variables, but the address of a `thread_local` variable (`&mariadb_dummy_stats`) is not a compile-time constant. We did not want to declare `mariadb_dummy_stats` without `thread_local`, because then the dummy accesses could lead to cache line contention between threads.

`mariadb_stats`: Declare as `__thread` or `__declspec(thread)` so that there will be no dynamic initialization, but zero-initialization.

`mariadb_dummy_stats`: Remove. It is lesser evil to let the environment perform zero-initialization and check if `!mariadb_stats`.
## Release Notes
This is a relatively minor performance improvement, maybe not worth mentioning specially.
## How can this PR be tested?
```sh
./mtr main.analyze_engine_stats2 main.analyze_engine_stats main.rowid_filter_innodb
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.