### PR TITLE
mtr: run check-testcase client process under debugger

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -5526,6 +5526,8 @@ sub start_check_testcase ($$$) {
     mtr_add_arg($args, "--record");
   }
   my $errfile= "$opt_vardir/tmp/$name.err";
+
+  My::Debugger::setup_client_args(\$args, \$exe_mysqltest);
   my $proc= My::SafeProcess->new
     (
      name          => $name,


### PR DESCRIPTION

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
mtr launches mariadb-test (mysqltest) a few times during the single test run: one known extra run happens before the test, this stage is known as check-testcase. 

This client run is not debug-ready, though. The failure happens very early, then one may need to debug the first client run.
The submitted approach invokes check-testcase client, if `--client-{debugger}` is specified.


## How can this PR be tested?

The best way to test it is to add abort() to mysqltest.cc:main().

## Basing the PR against the correct MariaDB version
This is a test framework improvement, it should be pushed to the earliest maintained version. 
## PR quality check

- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves. 
