### PR TITLE
MDEV-34307 On startup, [FATAL] InnoDB: Page ... still fixed or dirty

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3700,15 +3700,13 @@ void buf_refresh_io_stats()
 All pages must be in a replaceable state (not modified or latched). */
 void buf_pool_invalidate()
 {
-	mysql_mutex_lock(&buf_pool.mutex);
-
 	/* It is possible that a write batch that has been posted
 	earlier is still not complete. For buffer pool invalidation to
 	proceed we must ensure there is NO write activity happening. */
 
-	ut_d(mysql_mutex_unlock(&buf_pool.mutex));
+	os_aio_wait_until_no_pending_writes(false);
 	ut_d(buf_pool.assert_all_freed());
-	ut_d(mysql_mutex_lock(&buf_pool.mutex));
+	mysql_mutex_lock(&buf_pool.mutex);
 
 	while (UT_LIST_GET_LEN(buf_pool.LRU)) {
 		buf_LRU_scan_and_free_block();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34307*
## Description
`buf_pool_invalidate()`: Properly wait for `os_aio_wait_until_no_pending_writes()` to ensure so that there are no pending `buf_page_t::write_complete()` or `buf_page_write_complete()` operations. This will avoid a failure of `buf_pool.assert_all_freed()`.

This bug should affect debug builds only. At this point, the `buf_pool.flush_list` should be clear and all changes should have been written out. The loop around `buf_LRU_scan_and_free_block()` should have eventually completed and freed all pages as soon as `buf_page_t::write_complete()` had a chance to release the page latches.

This regression was introduced in a55b951e6082a4ce9a1f2ed5ee176ea7dbbaf1f2.
## Release Notes
This only fixes a debug check and should have no impact on actual operations.
## How can this PR be tested?
This was found while testing #3282, running `mariadb-backup --prepare` on HDD. This code should be covered by killing the server and restarting with a smaller `innodb_buffer_pool_size`, but it should be hard to hit the race condition that we are fixing here. See [MDEV-34307](https://jira.mariadb.org/browse/MDEV-34307) for an analysis of an `rr replay` trace of a failure.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.