### PR TITLE
MDEV-34321: UBSAN runtime error: call to function crc32c_3way through…

### DIFF
--- a/mysys/crc32/crc32c.cc
+++ b/mysys/crc32/crc32c.cc
@@ -526,7 +526,7 @@ extern "C" const char *my_crc32c_implementation()
 }  // namespace crc32c
 }  // namespace mysys_namespace
 
-extern "C" unsigned my_crc32c(unsigned int crc, const char *buf, size_t size)
+extern "C" uint32 my_crc32c(uint32 crc, const void *buf, size_t size)
 {
   return mysys_namespace::crc32c::ChosenExtend(crc,buf, size);
 }

--- a/mysys/crc32/crc32c_amd64.cc
+++ b/mysys/crc32/crc32c_amd64.cc
@@ -184,9 +184,9 @@ static inline uint64_t CombineCRC(
 // Compute CRC-32C using the Intel hardware instruction.
 extern "C"
 USE_PCLMUL
-uint32_t crc32c_3way(uint32_t crc, const char *buf, size_t len)
+uint32_t crc32c_3way(uint32_t crc, const void *buf, size_t len)
 {
-  const unsigned char* next = (const unsigned char*)buf;
+  const unsigned char* next = static_cast<const unsigned char*>(buf);
   uint64_t count;
   uint64_t crc0, crc1, crc2;
   crc0 = crc ^ 0xffffffffu;

--- a/mysys/crc32/crc32c_x86.cc
+++ b/mysys/crc32/crc32c_x86.cc
@@ -54,9 +54,9 @@ static uint32_t cpuid_ecx()
 #endif
 }
 
-typedef unsigned (*my_crc32_t)(unsigned, const void *, size_t);
-extern "C" unsigned int crc32_pclmul(unsigned int, const void *, size_t);
-extern "C" unsigned int crc32c_3way(unsigned int, const void *, size_t);
+typedef uint32_t (*my_crc32_t)(uint32_t, const void *, size_t);
+extern "C" uint32_t crc32_pclmul(uint32_t, const void *, size_t);
+extern "C" uint32_t crc32c_3way(uint32_t, const void *, size_t);
 
 #ifdef USE_VPCLMULQDQ
 # include <immintrin.h>


### PR DESCRIPTION
MDEV-34321: UBSAN runtime error: call to function crc32c_3way through pointer to incorrect function type

my_crc32_t takes function signature:

```
unsigned int (*)(unsigned int, const void *, unsigned long)
```

yet the crc32c_3way derivation has a definition with a second parameter of a different type:

```
uint32_t crc32c_3way(uint32_t crc, const char *buf, size_t len)
```

which leads to UBSAN errors. This patch creates a type-safe wrapper to call crc32c_3way.

Assigning to @dr-m because you authored the original MDEV-24745. 

I also considered changing the definition of crc32c_3way() in crc32c_amd64.c, yet that feels more fragile (it seems to be pulled in from a third party). 