### PR TITLE
MDEV-34178 Performance regression with IO-bound insert benchmark

### DIFF
--- a/storage/innobase/include/srw_lock.h
+++ b/storage/innobase/include/srw_lock.h
@@ -402,7 +402,7 @@ typedef srw_spin_lock_low srw_spin_lock;
 class ssux_lock
 {
   PSI_rwlock *pfs_psi;
-  ssux_lock_impl<false> lock;
+  ssux_lock_impl<true> lock;
 
   ATTRIBUTE_NOINLINE void psi_rd_lock(const char *file, unsigned line);
   ATTRIBUTE_NOINLINE void psi_wr_lock(const char *file, unsigned line);

--- a/storage/innobase/include/sux_lock.h
+++ b/storage/innobase/include/sux_lock.h
@@ -285,7 +285,7 @@ public:
 typedef sux_lock<ssux_lock_impl<true>> block_lock;
 
 #ifndef UNIV_PFS_RWLOCK
-typedef sux_lock<ssux_lock_impl<false>> index_lock;
+typedef sux_lock<ssux_lock_impl<true>> index_lock;
 #else
 typedef sux_lock<ssux_lock> index_lock;
 

--- a/storage/innobase/sync/srw_lock.cc
+++ b/storage/innobase/sync/srw_lock.cc
@@ -525,7 +525,7 @@ void ssux_lock::psi_u_wr_upgrade(const char *file, unsigned line)
 {
   PSI_rwlock_locker_state state;
   DBUG_ASSERT(lock.writer.is_locked());
-  uint32_t lk= 1;
+  uint32_t lk= 0;
   const bool nowait=
     lock.readers.compare_exchange_strong(lk, ssux_lock_impl<false>::WRITER,
                                          std::memory_order_acquire,


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34178*
## Description
Performance testing conducted by @mdcallag identified multiple scalability bottlenecks around the spin loop logic for `buf_page_t::lock`. It also suggests that we might better enable spin loops also for `dict_index_t::lock`.
## Release Notes
Performance of I/O bound workloads was improved.
## How can this PR be tested?
I think that this is best tested by @mdcallag. Enabling the spin loops for `index_lock` (79039bdc6f028c86355f0045c70dc3b7c97e05aa) may be turn out to be unnecessary in the advent of the other changes.

This is low-level code, and it is in part covered by by the `innodb_sync-t` unit test. I ran it (as well as the entire regression test suite) for both `PLUGIN_PERFSCHEMA=NO`  and `PLUGIN_PERFSCHEMA=STATIC`.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.