### PR TITLE
MDEV-12008 : Change error code for Galera unkillable threads

### DIFF
--- a/mysql-test/suite/galera/r/galera_kill_applier.result
+++ b/mysql-test/suite/galera/r/galera_kill_applier.result
@@ -6,13 +6,13 @@ SELECT @@wsrep_slave_threads;
 1
 SET GLOBAL wsrep_slave_threads=2;
 KILL ID;
-Got one of the listed errors
+ERROR HY000: This is an high priority thread/query and cannot be killed without compromising consistency of the cluster
 KILL QUERY ID;
-Got one of the listed errors
+ERROR HY000: This is an high priority thread/query and cannot be killed without compromising consistency of the cluster
 KILL ID;
-Got one of the listed errors
+ERROR HY000: This is an high priority thread/query and cannot be killed without compromising consistency of the cluster
 KILL QUERY ID;
-Got one of the listed errors
+ERROR HY000: This is an high priority thread/query and cannot be killed without compromising consistency of the cluster
 SET GLOBAL wsrep_slave_threads=DEFAULT;
 connection node_1;
 create table t1(a int not null primary key) engine=innodb;

--- a/mysql-test/suite/galera/r/galera_kill_bf.result
+++ b/mysql-test/suite/galera/r/galera_kill_bf.result
@@ -1,0 +1,25 @@
+connection node_2;
+connection node_1;
+connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1;
+call mtr.add_suppression("WSREP: ALTER TABLE isolation failure");
+CREATE TABLE t1(c1 INT PRIMARY KEY, c2 INT) ENGINE=InnoDB;
+INSERT into t1 values (1,1);
+SET DEBUG_SYNC = 'alter_table_after_open_tables SIGNAL bf_started WAIT_FOR bf_continue';
+ALTER TABLE t1 DROP COLUMN c2;;
+connection node_1;
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = 'now WAIT_FOR bf_started';
+KILL ID;
+ERROR HY000: This is an high priority thread/query and cannot be killed without compromising consistency of the cluster
+KILL QUERY ID;
+ERROR HY000: This is an high priority thread/query and cannot be killed without compromising consistency of the cluster
+connection node_1;
+SET DEBUG_SYNC = 'now SIGNAL bf_continue';
+connection con1;
+SET DEBUG_SYNC = 'RESET';
+SELECT * FROM t1;
+c1
+1
+connection node_1;
+DROP TABLE t1;
+disconnect con1;

--- a/mysql-test/suite/galera/t/galera_kill_applier.test
+++ b/mysql-test/suite/galera/t/galera_kill_applier.test
@@ -17,21 +17,21 @@ SET GLOBAL wsrep_slave_threads=2;
 --let $applier_thread = `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'wsrep applier idle' LIMIT 1`
 
 --replace_result $applier_thread ID
---error ER_KILL_DENIED_ERROR,ER_KILL_DENIED_ERROR
+--error ER_KILL_DENIED_HIGH_PRIORITY
 --eval KILL $applier_thread
 
 --replace_result $applier_thread ID
---error ER_KILL_DENIED_ERROR,ER_KILL_DENIED_ERROR
+--error ER_KILL_DENIED_HIGH_PRIORITY
 --eval KILL QUERY $applier_thread
 
 --let $aborter_thread = `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'wsrep aborter idle' LIMIT 1`
 
 --replace_result $aborter_thread ID
---error ER_KILL_DENIED_ERROR,ER_KILL_DENIED_ERROR
+--error ER_KILL_DENIED_HIGH_PRIORITY
 --eval KILL $aborter_thread
 
 --replace_result $aborter_thread ID
---error ER_KILL_DENIED_ERROR,ER_KILL_DENIED_ERROR
+--error ER_KILL_DENIED_HIGH_PRIORITY
 --eval KILL QUERY $aborter_thread
 
 SET GLOBAL wsrep_slave_threads=DEFAULT;

--- a/mysql-test/suite/galera/t/galera_kill_bf.test
+++ b/mysql-test/suite/galera/t/galera_kill_bf.test
@@ -1,0 +1,41 @@
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+
+--connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1
+
+call mtr.add_suppression("WSREP: ALTER TABLE isolation failure");
+
+CREATE TABLE t1(c1 INT PRIMARY KEY, c2 INT) ENGINE=InnoDB;
+INSERT into t1 values (1,1);
+
+SET DEBUG_SYNC = 'alter_table_after_open_tables SIGNAL bf_started WAIT_FOR bf_continue';
+--send ALTER TABLE t1 DROP COLUMN c2;
+
+--connection node_1
+SET SESSION wsrep_sync_wait = 0;
+SET DEBUG_SYNC = 'now WAIT_FOR bf_started';
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'debug sync point: alter_table_after_open_tables'
+--source include/wait_condition.inc
+
+--let $applier_thread = `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'debug sync point:%' LIMIT 1`
+
+--replace_result $applier_thread ID
+--error ER_KILL_DENIED_HIGH_PRIORITY
+--eval KILL $applier_thread
+
+--replace_result $applier_thread ID
+--error ER_KILL_DENIED_HIGH_PRIORITY
+--eval KILL QUERY $applier_thread
+
+--connection node_1
+SET DEBUG_SYNC = 'now SIGNAL bf_continue';
+
+--connection con1
+--reap
+SET DEBUG_SYNC = 'RESET';
+SELECT * FROM t1;
+
+--connection node_1
+DROP TABLE t1;
+--disconnect con1

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -9111,3 +9111,6 @@ ER_NOT_ALLOWED_IN_THIS_CONTEXT
         eng "'%-.128s' is not allowed in this context"
 ER_DATA_WAS_COMMITED_UNDER_ROLLBACK
         eng "Engine %s does not support rollback. Changes were committed during rollback call"
+ER_KILL_DENIED_HIGH_PRIORITY
+        eng "This is an high priority thread/query and cannot be killed without compromising consistency of the cluster"
+

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -9398,17 +9398,21 @@ kill_one_thread(THD *thd, my_thread_id id, killed_state kill_signal, killed_type
 
     mysql_mutex_lock(&tmp->LOCK_thd_data); // Lock from concurrent usage
 
-#ifdef WITH_WSREP
-    if (((thd->security_ctx->master_access & PRIV_KILL_OTHER_USER_PROCESS) ||
-        thd->security_ctx->user_matches(tmp->security_ctx)) &&
-        !wsrep_thd_is_BF(tmp, false) && !tmp->wsrep_applier)
-#else
     if ((thd->security_ctx->master_access & PRIV_KILL_OTHER_USER_PROCESS) ||
         thd->security_ctx->user_matches(tmp->security_ctx))
-#endif /* WITH_WSREP */
     {
-      {
 #ifdef WITH_WSREP
+      if (wsrep_thd_is_BF(tmp, false) || tmp->wsrep_applier)
+      {
+        error= ER_KILL_DENIED_HIGH_PRIORITY;
+	push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
+                            ER_KILL_DENIED_HIGH_PRIORITY,
+                            "Thread %lld is %s and cannot be killed",
+                            tmp->thread_id,
+                           (tmp->wsrep_applier ? "wsrep applier" : "high priority"));
+      }
+      else
+      {
         if (WSREP(tmp))
         {
           /* Object tmp is not guaranteed to exist after wsrep_kill_thd()
@@ -9418,7 +9422,9 @@ kill_one_thread(THD *thd, my_thread_id id, killed_state kill_signal, killed_type
 #endif /* WITH_WSREP */
         tmp->awake_no_mutex(kill_signal);
         error= 0;
+#ifdef WITH_WSREP
       }
+#endif /* WITH_WSREP */
     }
     else
       error= (type == KILL_TYPE_QUERY ? ER_KILL_QUERY_DENIED_ERROR :
@@ -9548,7 +9554,9 @@ void sql_kill(THD *thd, my_thread_id id, killed_state state, killed_type type)
       thd->send_kill_message();
   }
   else
+  {
     my_error(error, MYF(0), id);
+  }
 }
 
 


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-12008*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Changed error code for Galera unkillable threads to be ER_KILL_DENIED_HIGH_PRIORITY giving message

This is an high priority thread/query and cannot be killed without compromising consistency of the cluster

also a warning is produced
  Thread %lld is [wsrep applier|high priority] and cannot be killed


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
