### PR TITLE
MDEV-34269 : 10.11.8 cluster becomes inconsistent when using composit…

### DIFF
--- a/mysql-test/include/log_bin.combinations
+++ b/mysql-test/include/log_bin.combinations
@@ -1,0 +1,4 @@
+[binlogoff]
+
+[binlogon]
+log-bin

--- a/mysql-test/include/log_bin.inc
+++ b/mysql-test/include/log_bin.inc
@@ -1,0 +1,3 @@
+# include file for test files that can be run with and without log-bin
+# (see include/log_bin.combinations)
+

--- a/mysql-test/suite/galera/r/galera_partition_key.result
+++ b/mysql-test/suite/galera/r/galera_partition_key.result
@@ -1,0 +1,46 @@
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE TABLE `t1` (
+`id` int(10) unsigned NOT NULL,
+`other_id` int(10) unsigned NOT NULL,
+PRIMARY KEY (`id`,`other_id`)
+) ENGINE=InnoDB
+PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+INSERT INTO t1 VALUES (1, 0);
+CREATE TABLE t2 LIKE t1;
+START TRANSACTION;
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+COMMIT;
+connection node_2;
+SELECT * from t1;
+id	other_id
+SELECT * from t2;
+id	other_id
+1	0
+DROP TABLE t1, t2;
+connection node_1;
+CREATE TABLE `t1` (
+`id` int(10) unsigned NOT NULL,
+`other_id` int(10) unsigned NOT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+INSERT INTO t1 VALUES (1, 0);
+CREATE TABLE t2 LIKE t1;
+START TRANSACTION;
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+COMMIT;
+connection node_2;
+SELECT * from t1;
+id	other_id
+SELECT * from t2;
+id	other_id
+1	0
+DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/galera_myisam_autocommit.test
+++ b/mysql-test/suite/galera/t/galera_myisam_autocommit.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/log_bin.inc
 
 #
 # This tests simple autocommit replication of MyISAM tables.

--- a/mysql-test/suite/galera/t/galera_partition.test
+++ b/mysql-test/suite/galera/t/galera_partition.test
@@ -2,6 +2,7 @@
 --source include/have_partition.inc
 --source include/big_test.inc
 --source include/force_restart.inc
+--source include/log_bin.inc
 
 --connection node_1
 

--- a/mysql-test/suite/galera/t/galera_partition_key.test
+++ b/mysql-test/suite/galera/t/galera_partition_key.test
@@ -1,0 +1,55 @@
+--source include/galera_cluster.inc
+--source include/have_partition.inc
+--source include/log_bin.inc
+
+--connection node_1
+CREATE TABLE `t1` (
+  `id` int(10) unsigned NOT NULL,
+  `other_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`,`other_id`)
+) ENGINE=InnoDB
+ PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+ PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+
+INSERT INTO t1 VALUES (1, 0);
+
+CREATE TABLE t2 LIKE t1;
+
+START TRANSACTION;
+
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+
+COMMIT;
+
+--connection node_2
+SELECT * from t1;
+SELECT * from t2;
+DROP TABLE t1, t2;
+
+--connection node_1
+CREATE TABLE `t1` (
+  `id` int(10) unsigned NOT NULL,
+  `other_id` int(10) unsigned NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB
+ PARTITION BY LIST (`id` MOD 2)
+(PARTITION `p0` VALUES IN (0) ENGINE = InnoDB,
+ PARTITION `p1` VALUES IN (1) ENGINE = InnoDB);
+
+INSERT INTO t1 VALUES (1, 0);
+
+CREATE TABLE t2 LIKE t1;
+
+START TRANSACTION;
+
+INSERT INTO t2(SELECT * FROM t1 WHERE id = 1);
+DELETE FROM t1 WHERE id = 1;
+
+COMMIT;
+
+--connection node_2
+SELECT * from t1;
+SELECT * from t2;
+DROP TABLE t1, t2;

--- a/mysql-test/suite/galera/t/mdev-22063.test
+++ b/mysql-test/suite/galera/t/mdev-22063.test
@@ -1,6 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
---source include/have_log_bin.inc
+--source include/log_bin.inc
 --source include/have_sequence.inc
 --source include/have_aria.inc
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4747,7 +4747,9 @@ mysql_execute_command(THD *thd)
 #ifdef WITH_WSREP
       if (wsrep && !first_table->view)
       {
-        bool is_innodb= (first_table->table->file->ht->db_type == DB_TYPE_INNODB);
+        const handlerton *hton = first_table->table->file->partition_ht() ?
+          first_table->table->file->partition_ht() : first_table->table->file->ht;
+        bool is_innodb= (hton->db_type == DB_TYPE_INNODB);
 
         // For consistency check inserted table needs to be InnoDB
         if (!is_innodb && thd->wsrep_consistency_check != NO_CONSISTENCY_CHECK)


### PR DESCRIPTION
…e primary key and partitioning



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34269*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This is regression from commit 3228c08fa8. Problem is that when table storage engine is determined there should be check is table partitioned and if it is then determine partition implementing storage engine.

Reported bug is reproducible only with --log-bin so make sure tests changed by 3228c08fa8 and new test are run with --log-bin and binlog disabled.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
