### PR TITLE
MDEV-32892: IO Thread Reports False Error When Stopped During Connect…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_stop_slave_error.result
+++ b/mysql-test/suite/rpl/r/rpl_stop_slave_error.result
@@ -2,7 +2,9 @@ include/master-slave.inc
 [connection master]
 connection master;
 connection slave;
+# MDEV-32892: Repeatedly starting/stopping io_thread..
 include/stop_slave.inc
 NOT FOUND /Error reading packet from server: Lost connection/ in slave_log.err
+NOT FOUND /error code: 2013/ in slave_log.err
 include/start_slave.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_stop_slave_error.test
+++ b/mysql-test/suite/rpl/t/rpl_stop_slave_error.test
@@ -6,9 +6,24 @@ source include/master-slave.inc;
 
 connection master;
 sync_slave_with_master;
+
+--let $iter=100
+--echo # MDEV-32892: Repeatedly starting/stopping io_thread..
+--disable_query_log
+while ($iter)
+{
+  stop slave io_thread;
+  start slave io_thread;
+  --dec $iter
+}
+--enable_query_log
 source include/stop_slave.inc;
+
 let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/slave_log.err;
 let SEARCH_PATTERN=Error reading packet from server: Lost connection;
+source include/search_pattern_in_file.inc;
+
+let SEARCH_PATTERN=error code: 2013;
 source include/search_pattern_in_file.inc;
 
 source include/start_slave.inc;

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -2292,6 +2292,9 @@ past_checksum:
     if (unlikely(mysql_real_query(mysql,
                                   STRING_WITH_LEN("SET skip_replication=1"))))
     {
+      if (check_io_slave_killed(mi, NULL))
+        goto slave_killed_err;
+
       err_code= mysql_errno(mysql);
       if (is_network_error(err_code))
       {
@@ -2336,6 +2339,9 @@ past_checksum:
                          STRINGIFY_ARG(MARIA_SLAVE_CAPABILITY_MINE))));
     if (unlikely(rc))
     {
+      if (check_io_slave_killed(mi, NULL))
+        goto slave_killed_err;
+
       err_code= mysql_errno(mysql);
       if (is_network_error(err_code))
       {
@@ -2377,6 +2383,9 @@ after_set_capability:
         !(master_res= mysql_store_result(mysql)) ||
         !(master_row= mysql_fetch_row(master_res)))
     {
+      if (check_io_slave_killed(mi, NULL))
+        goto slave_killed_err;
+
       err_code= mysql_errno(mysql);
       if (is_network_error(err_code))
       {
@@ -2412,6 +2421,9 @@ after_set_capability:
     rc= mysql_real_query(mysql, query_str.ptr(), query_str.length());
     if (unlikely(rc))
     {
+      if (check_io_slave_killed(mi, NULL))
+        goto slave_killed_err;
+
       err_code= mysql_errno(mysql);
       if (is_network_error(err_code))
       {
@@ -2445,6 +2457,9 @@ after_set_capability:
     rc= mysql_real_query(mysql, query_str.ptr(), query_str.length());
     if (unlikely(rc))
     {
+      if (check_io_slave_killed(mi, NULL))
+        goto slave_killed_err;
+
       err_code= mysql_errno(mysql);
       if (is_network_error(err_code))
       {
@@ -2478,6 +2493,9 @@ after_set_capability:
     rc= mysql_real_query(mysql, query_str.ptr(), query_str.length());
     if (unlikely(rc))
     {
+      if (check_io_slave_killed(mi, NULL))
+        goto slave_killed_err;
+
       err_code= mysql_errno(mysql);
       if (is_network_error(err_code))
       {
@@ -2514,6 +2532,9 @@ after_set_capability:
       rc= mysql_real_query(mysql, query_str.ptr(), query_str.length());
       if (unlikely(rc))
       {
+        if (check_io_slave_killed(mi, NULL))
+          goto slave_killed_err;
+
         err_code= mysql_errno(mysql);
         if (is_network_error(err_code))
         {
@@ -3658,7 +3679,7 @@ static ulong read_event(MYSQL* mysql, Master_info *mi, bool* suppress_warnings,
     }
     else
     {
-      if (!mi->rli.abort_slave)
+      if (!(mi->rli.abort_slave || io_slave_killed(mi)))
       {
         sql_print_error("Error reading packet from server: %s (server_errno=%d)",
                         mysql_error(mysql), mysql_errno(mysql));
@@ -7432,7 +7453,7 @@ static int connect_to_master(THD* thd, MYSQL* mysql, Master_info* mi,
                              mi->port, 0, client_flag) == 0))
   {
     /* Don't repeat last error */
-    if ((int)mysql_errno(mysql) != last_errno)
+    if ((int)mysql_errno(mysql) != last_errno && !io_slave_killed(mi))
     {
       last_errno=mysql_errno(mysql);
       suppress_warnings= 0;


### PR DESCRIPTION
MDEV-32892: IO Thread Reports False Error When Stopped During Connecting to Primary

The IO thread can report error code 2013 into the error log when it is stopped during the initial connection process to the primary, as well as when trying to read an event. However, because the IO thread is being stopped, its connection to the primary is force-killed by the signaling thread (see THD::awake_no_mutex()), and thereby these connection errors should be ignored.
