### PR TITLE
MDEV-34365: UBSAN runtime error: call to function io_callback(tpool::…

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3560,8 +3560,9 @@ os_file_get_status(
 
 extern void fil_aio_callback(const IORequest &request);
 
-static void io_callback(tpool::aiocb* cb)
+static void io_callback(void *_cb)
 {
+  tpool::aiocb* cb= static_cast<tpool::aiocb*>(_cb);
   const IORequest request(*static_cast<const IORequest*>
                           (static_cast<const void*>(cb->m_userdata)));
   if (cb->m_err != DB_SUCCESS)


### PR DESCRIPTION
MDEV-34365: UBSAN runtime error: call to function io_callback(tpool::aiocb*)

On an UBSAN clang-15 build, if running with UBSAN option halt_on_error=1 (the issue doesn't show up without it), MTR fails during mysqld --bootstrap with UBSAN error:

call to function io_callback(tpool::aiocb*) through pointer to incorrect function type 'void (*)(void *)'

This patch corrects the parameter type of io_callback to match its expected type defined by callback_func, i.e. (void*).