### PR TITLE
MDEV-34168: Extend perror utility to print link to knowledge page

### DIFF
--- a/extra/perror.c
+++ b/extra/perror.c
@@ -359,7 +359,8 @@ int main(int argc,char *argv[])
       {
         found= 1;
         if (verbose)
-          printf("MariaDB error code %3d (%s): %s\n", code, name, msg);
+          printf("MariaDB error code %3d (%s): %s\n"
+                 "Learn more: https://mariadb.com/kb/en/e%3d/\n", code, name, msg, code);
         else
           puts(msg);
       }

--- a/mysql-test/main/perror-win.result
+++ b/mysql-test/main/perror-win.result
@@ -3,5 +3,6 @@ Win32 error code 150: System trace information was not specified in your CONFIG.
 OS error code  23:  Too many open files in system
 Win32 error code 23: Data error (cyclic redundancy check).
 MariaDB error code 1062 (ER_DUP_ENTRY): Duplicate entry '%-.192T' for key %d
+Learn more: https://mariadb.com/kb/en/e1062/
 Win32 error code 1062: The service has not been started.
 Illegal error code: 30000

--- a/mysql-test/main/perror.result
+++ b/mysql-test/main/perror.result
@@ -1,6 +1,10 @@
 Illegal error code: 10000
 MariaDB error code 1062 (ER_DUP_ENTRY): Duplicate entry '%-.192T' for key %d
+Learn more: https://mariadb.com/kb/en/e1062/
 MariaDB error code 1408 (ER_STARTUP): %s: ready for connections.
 Version: '%s'  socket: '%s'  port: %d  %s
+Learn more: https://mariadb.com/kb/en/e1408/
 MariaDB error code 1459 (ER_TABLE_NEEDS_UPGRADE): Upgrade required. Please do "REPAIR %s %`s" or dump/reload to fix it!
+Learn more: https://mariadb.com/kb/en/e1459/
 MariaDB error code 1461 (ER_MAX_PREPARED_STMT_COUNT_REACHED): Can't create more than max_prepared_stmt_count statements (current value: %u)
+Learn more: https://mariadb.com/kb/en/e1461/


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34168*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
As all server errors have a dedicated webpage, the perror utility is extended to print a link to the KB page of the corresponding error.

## Release Notes
N/A

## How can this PR be tested?
The test `main.perror` was updated to include the links printed by the sample tests. All tests are confirmed to pass by running the command `./mtr --suite=main`.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.