### PR TITLE
MDEV-34374 Shrinking tablespace logic fails to handle error condition

### DIFF
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -3465,10 +3465,10 @@ dberr_t fsp_traverse_extents(
   else
   {
     err= old_xdes_entry->insert(0, mtr);
-    if (err) return err;
-    if (threshold & (srv_page_size - 1))
+    if (err == DB_SUCCESS && threshold & (srv_page_size - 1))
       err= old_xdes_entry->insert(
         xdes_calc_descriptor_page(0, threshold), mtr);
+    if (err) return err;
   }
 
   buf_block_t *block= nullptr;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34374*

## Description
- InnoDB ignores the error while traversing the used extents during shrinking process. This could
to corrupt the tablespace.  
## Release Notes
InnoDB shrinking process handles the error condition while traversing the extents.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
