### PR TITLE
MDEV-33746 Supply missing override markings

### DIFF
--- a/cmake/maintainer.cmake
+++ b/cmake/maintainer.cmake
@@ -27,14 +27,16 @@ SET(MY_WARNING_FLAGS
   -Wenum-conversion
   -Wextra
   -Wformat-security
+  -Winconsistent-missing-override
   -Wno-format-truncation
   -Wno-init-self
   -Wno-nonnull-compare
   -Wno-null-conversion
   -Wno-unused-parameter
   -Wno-unused-private-field
-  -Woverloaded-virtual
   -Wnon-virtual-dtor
+  -Woverloaded-virtual
+  -Wsuggest-override
   -Wvla
   -Wwrite-strings
   )

--- a/mysys_ssl/my_crypt.cc
+++ b/mysys_ssl/my_crypt.cc
@@ -101,10 +101,10 @@ public:
   uchar source_tail[MY_AES_BLOCK_SIZE];
 
   MyCTX_nopad() : MyCTX() { }
-  ~MyCTX_nopad() = default;
+  ~MyCTX_nopad() override = default;
 
   int init(const EVP_CIPHER *cipher, int encrypt, const uchar *key, uint klen,
-           const uchar *iv, uint ivlen)
+           const uchar *iv, uint ivlen) override
   {
     compile_time_assert(MY_AES_CTX_SIZE >= sizeof(MyCTX_nopad));
     this->key= key;
@@ -141,13 +141,13 @@ public:
     source_tail_len= new_tail_len;
   }
 
-  int update(const uchar *src, uint slen, uchar *dst, uint *dlen)
+  int update(const uchar *src, uint slen, uchar *dst, uint *dlen) override
   {
     update_source_tail(src, slen);
     return MyCTX::update(src, slen, dst, dlen);
   }
 
-  int finish(uchar *dst, uint *dlen)
+  int finish(uchar *dst, uint *dlen) override
   {
     if (source_tail_len)
     {
@@ -206,10 +206,10 @@ public:
   const uchar *aad;
   int aadlen;
   MyCTX_gcm() : MyCTX() { }
-  ~MyCTX_gcm() { }
+  ~MyCTX_gcm() override { }
 
   int init(const EVP_CIPHER *cipher, int encrypt, const uchar *key, uint klen,
-           const uchar *iv, uint ivlen)
+           const uchar *iv, uint ivlen) override
   {
     compile_time_assert(MY_AES_CTX_SIZE >= sizeof(MyCTX_gcm));
     int res= MyCTX::init(cipher, encrypt, key, klen, iv, ivlen);
@@ -219,7 +219,7 @@ public:
     return res;
   }
 
-  int update(const uchar *src, uint slen, uchar *dst, uint *dlen)
+  int update(const uchar *src, uint slen, uchar *dst, uint *dlen) override
   {
     /*
       note that this GCM class cannot do streaming decryption, because
@@ -244,7 +244,7 @@ public:
     return MyCTX::update(src, slen, dst, dlen);
   }
 
-  int finish(uchar *dst, uint *dlen)
+  int finish(uchar *dst, uint *dlen) override
   {
     int fin;
     if (!EVP_CipherFinal_ex(ctx, dst, &fin))

--- a/plugin/aws_key_management/aws_key_management_plugin.cc
+++ b/plugin/aws_key_management/aws_key_management_plugin.cc
@@ -154,7 +154,7 @@ public:
     Base(logLevel) 
   {
   }
-  virtual LogLevel GetLogLevel(void) const override
+  LogLevel GetLogLevel(void) const override
   {
     return (LogLevel)log_level;
   }
@@ -162,12 +162,12 @@ public:
   {
   }
 
-  virtual void Flush(void) override
+  void Flush(void) override
   {
   }
 
 protected:
-  virtual void ProcessFormattedStatement(Aws::String&& statement) override
+  void ProcessFormattedStatement(Aws::String&& statement) override
   {
 #ifdef _WIN32
     /*

--- a/plugin/feedback/url_http.cc
+++ b/plugin/feedback/url_http.cc
@@ -53,7 +53,7 @@ class Url_http: public Url {
     {
       proxy_host.length= 0;
     }
-  ~Url_http()
+  ~Url_http() override
   {
     my_free(host.str);
     my_free(port.str);
@@ -62,9 +62,9 @@ class Url_http: public Url {
   }
 
   public:
-  void abort();
-  int send(const char* data, size_t data_length);
-  int set_proxy(const char *proxy, size_t proxy_len)
+  void abort() override;
+  int send(const char* data, size_t data_length) override;
+  int set_proxy(const char *proxy, size_t proxy_len) override
   {
     if (use_proxy())
     {

--- a/plugin/func_test/plugin.cc
+++ b/plugin/func_test/plugin.cc
@@ -24,20 +24,20 @@ class Item_func_sysconst_test :public Item_func_sysconst
 {
 public:
   Item_func_sysconst_test(THD *thd): Item_func_sysconst(thd) {}
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     null_value= str->copy(STRING_WITH_LEN("sysconst_test"), system_charset_info);
     return null_value ? NULL : str;
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     max_length= MAX_FIELD_NAME * system_charset_info->mbmaxlen;
     maybe_null= true;
     return false;
   }
-  const char *func_name() const { return "sysconst_test"; }
-  const char *fully_qualified_func_name() const { return "sysconst_test()"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "sysconst_test"; }
+  const char *fully_qualified_func_name() const override { return "sysconst_test()"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sysconst_test>(thd, this); }
 };
 

--- a/plugin/handler_socket/handlersocket/database.cpp
+++ b/plugin/handler_socket/handlersocket/database.cpp
@@ -84,10 +84,10 @@ prep_stmt::operator =(const prep_stmt& x)
 
 struct database : public database_i, private noncopyable {
   database(const config& c);
-  virtual ~database();
-  virtual dbcontext_ptr create_context(bool for_write) volatile;
-  virtual void stop() volatile;
-  virtual const config& get_conf() const volatile;
+  ~database() override;
+  dbcontext_ptr create_context(bool for_write) volatile override;
+  void stop() volatile override;
+  const config& get_conf() const volatile override;
  public:
   int child_running;
  private:
@@ -128,21 +128,21 @@ struct expr_user_lock : private noncopyable {
 
 struct dbcontext : public dbcontext_i, private noncopyable {
   dbcontext(volatile database *d, bool for_write);
-  virtual ~dbcontext();
-  virtual void init_thread(const void *stack_botton,
-    volatile int& shutdown_flag);
-  virtual void term_thread();
-  virtual bool check_alive();
-  virtual void lock_tables_if();
-  virtual void unlock_tables_if();
-  virtual bool get_commit_error();
-  virtual void clear_error();
-  virtual void close_tables_if();
-  virtual void table_addref(size_t tbl_id);
-  virtual void table_release(size_t tbl_id);
-  virtual void cmd_open(dbcallback_i& cb, const cmd_open_args& args);
-  virtual void cmd_exec(dbcallback_i& cb, const cmd_exec_args& args);
-  virtual void set_statistics(size_t num_conns, size_t num_active);
+  ~dbcontext() override;
+  void init_thread(const void *stack_botton,
+    volatile int& shutdown_flag) override;
+  void term_thread() override;
+  bool check_alive() override;
+  void lock_tables_if() override;
+  void unlock_tables_if() override;
+  bool get_commit_error() override;
+  void clear_error() override;
+  void close_tables_if() override;
+  void table_addref(size_t tbl_id) override;
+  void table_release(size_t tbl_id) override;
+  void cmd_open(dbcallback_i& cb, const cmd_open_args& args) override;
+  void cmd_exec(dbcallback_i& cb, const cmd_exec_args& args) override;
+  void set_statistics(size_t num_conns, size_t num_active) override;
  private:
   int set_thread_message(const char *fmt, ...)
     __attribute__((format (printf, 2, 3)));

--- a/plugin/handler_socket/handlersocket/hstcpsvr.cpp
+++ b/plugin/handler_socket/handlersocket/hstcpsvr.cpp
@@ -34,8 +34,8 @@ struct worker_throbj {
 
 struct hstcpsvr : public hstcpsvr_i, private noncopyable {
   hstcpsvr(const config& c);
-  ~hstcpsvr();
-  virtual std::string start_listen();
+  ~hstcpsvr() override;
+  std::string start_listen() override;
  private:
   hstcpsvr_shared_c cshared;
   volatile hstcpsvr_shared_v vshared;

--- a/plugin/handler_socket/handlersocket/hstcpsvr_worker.cpp
+++ b/plugin/handler_socket/handlersocket/hstcpsvr_worker.cpp
@@ -77,15 +77,15 @@ struct hstcpsvr_conn : public dbcallback_i {
   bool write_more(bool *more_r = 0);
   bool read_more(bool *more_r = 0);
  public:
-  virtual void dbcb_set_prep_stmt(size_t pst_id, const prep_stmt& v);
-  virtual const prep_stmt *dbcb_get_prep_stmt(size_t pst_id) const;
-  virtual void dbcb_resp_short(uint32_t code, const char *msg);
-  virtual void dbcb_resp_short_num(uint32_t code, uint32_t value);
-  virtual void dbcb_resp_short_num64(uint32_t code, uint64_t value);
-  virtual void dbcb_resp_begin(size_t num_flds);
-  virtual void dbcb_resp_entry(const char *fld, size_t fldlen);
-  virtual void dbcb_resp_end();
-  virtual void dbcb_resp_cancel();
+  void dbcb_set_prep_stmt(size_t pst_id, const prep_stmt& v) override;
+  const prep_stmt *dbcb_get_prep_stmt(size_t pst_id) const override;
+  void dbcb_resp_short(uint32_t code, const char *msg) override;
+  void dbcb_resp_short_num(uint32_t code, uint32_t value) override;
+  void dbcb_resp_short_num64(uint32_t code, uint64_t value) override;
+  void dbcb_resp_begin(size_t num_flds) override;
+  void dbcb_resp_entry(const char *fld, size_t fldlen) override;
+  void dbcb_resp_end() override;
+  void dbcb_resp_cancel() override;
  public:
   hstcpsvr_conn() : addr_len(sizeof(addr)), readsize(4096),
     nonblocking(false), read_finished(false), write_finished(false),
@@ -254,7 +254,7 @@ hstcpsvr_conn::dbcb_resp_cancel()
 
 struct hstcpsvr_worker : public hstcpsvr_worker_i, private noncopyable {
   hstcpsvr_worker(const hstcpsvr_worker_arg& arg);
-  virtual void run();
+  void run() override;
  private:
   const hstcpsvr_shared_c& cshared;
   volatile hstcpsvr_shared_v& vshared;

--- a/plugin/handler_socket/libhsclient/hstcpcli.cpp
+++ b/plugin/handler_socket/libhsclient/hstcpcli.cpp
@@ -27,23 +27,23 @@ namespace dena {
 
 struct hstcpcli : public hstcpcli_i, private noncopyable {
   hstcpcli(const socket_args& args);
-  virtual void close();
-  virtual int reconnect();
-  virtual bool stable_point();
-  virtual void request_buf_open_index(size_t pst_id, const char *dbn,
-    const char *tbl, const char *idx, const char *retflds, const char *filflds);
-  virtual void request_buf_auth(const char *secret, const char *typ);
-  virtual void request_buf_exec_generic(size_t pst_id, const string_ref& op,
+  void close() override;
+  int reconnect() override;
+  bool stable_point() override;
+  void request_buf_open_index(size_t pst_id, const char *dbn,
+    const char *tbl, const char *idx, const char *retflds, const char *filflds) override;
+  void request_buf_auth(const char *secret, const char *typ) override;
+  void request_buf_exec_generic(size_t pst_id, const string_ref& op,
     const string_ref *kvs, size_t kvslen, uint32_t limit, uint32_t skip,
     const string_ref& mod_op, const string_ref *mvs, size_t mvslen,
     const hstcpcli_filter *fils, size_t filslen, int invalues_keypart,
-    const string_ref *invalues, size_t invalueslen);
-  virtual int request_send();
-  virtual int response_recv(size_t& num_flds_r);
-  virtual const string_ref *get_next_row();
-  virtual void response_buf_remove();
-  virtual int get_error_code();
-  virtual std::string get_error();
+    const string_ref *invalues, size_t invalueslen) override;
+  int request_send() override;
+  int response_recv(size_t& num_flds_r) override;
+  const string_ref *get_next_row() override;
+  void response_buf_remove() override;
+  int get_error_code() override;
+  std::string get_error() override;
  private:
   int read_more();
   void clear_error();

--- a/plugin/type_inet/item_inetfunc.h
+++ b/plugin/type_inet/item_inetfunc.h
@@ -27,13 +27,13 @@
 
 class Item_func_inet_aton : public Item_longlong_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_text(0, arg_count); }
 public:
   Item_func_inet_aton(THD *thd, Item *a): Item_longlong_func(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "inet_aton"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "inet_aton"; }
+  bool fix_length_and_dec() override
   {
     decimals= 0;
     max_length= 21;
@@ -41,7 +41,7 @@ public:
     unsigned_flag= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_inet_aton>(thd, this); }
 };
 
@@ -55,16 +55,16 @@ class Item_func_inet_ntoa : public Item_str_func
 public:
   Item_func_inet_ntoa(THD *thd, Item *a): Item_str_func(thd, a)
   { }
-  String* val_str(String* str);
-  const char *func_name() const { return "inet_ntoa"; }
-  bool fix_length_and_dec()
+  String* val_str(String* str) override;
+  const char *func_name() const override { return "inet_ntoa"; }
+  bool fix_length_and_dec() override
   {
     decimals= 0;
     fix_length_and_charset(3 * 8 + 7, default_charset());
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_inet_ntoa>(thd, this); }
 };
 
@@ -82,7 +82,7 @@ public:
   {
     null_value= false;
   }
-  bool need_parentheses_in_default() { return false; }
+  bool need_parentheses_in_default() override { return false; }
 };
 
 
@@ -98,20 +98,20 @@ public:
   { }
 
 public:
-  virtual const char *func_name() const
+  const char *func_name() const override
   { return "inet6_aton"; }
 
-  virtual bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals= 0;
     fix_length_and_charset(16, &my_charset_bin);
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_inet6_aton>(thd, this); }
 
-  String *val_str(String *to);
+  String *val_str(String *to) override;
 };
 
 
@@ -127,10 +127,10 @@ public:
   { }
 
 public:
-  virtual const char *func_name() const
+  const char *func_name() const override
   { return "inet6_ntoa"; }
 
-  virtual bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals= 0;
 
@@ -142,8 +142,8 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  String *val_str_ascii(String *to);
-  Item *get_copy(THD *thd)
+  String *val_str_ascii(String *to) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_inet6_ntoa>(thd, this); }
 };
 
@@ -160,12 +160,12 @@ public:
   { }
 
 public:
-  virtual const char *func_name() const
+  const char *func_name() const override
   { return "is_ipv4"; }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_is_ipv4>(thd, this); }
 
-  longlong val_int();
+  longlong val_int() override;
 };
 
 
@@ -180,12 +180,12 @@ public:
     Item_func_inet_bool_base(thd, ip_addr)
   { }
 
-  virtual const char *func_name() const
+  const char *func_name() const override
   { return "is_ipv6"; }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_is_ipv6>(thd, this); }
 
-  longlong val_int();
+  longlong val_int() override;
 };
 
 
@@ -199,11 +199,11 @@ public:
   inline Item_func_is_ipv4_compat(THD *thd, Item *ip_addr):
     Item_func_inet_bool_base(thd, ip_addr)
   { }
-  virtual const char *func_name() const
+  const char *func_name() const override
   { return "is_ipv4_compat"; }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_is_ipv4_compat>(thd, this); }
-  longlong val_int();
+  longlong val_int() override;
 };
 
 
@@ -217,11 +217,11 @@ public:
   inline Item_func_is_ipv4_mapped(THD *thd, Item *ip_addr):
     Item_func_inet_bool_base(thd, ip_addr)
   { }
-  virtual const char *func_name() const
+  const char *func_name() const override
   { return "is_ipv4_mapped"; }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_is_ipv4_mapped>(thd, this); }
-  longlong val_int();
+  longlong val_int() override;
 };
 
 #endif // ITEM_INETFUNC_INCLUDED

--- a/plugin/type_inet/plugin.cc
+++ b/plugin/type_inet/plugin.cc
@@ -44,7 +44,7 @@ public:
   static Create_func_inet_ntoa s_singleton;
 protected:
   Create_func_inet_ntoa() {}
-  virtual ~Create_func_inet_ntoa() {}
+  ~Create_func_inet_ntoa() override {}
 };
 
 
@@ -58,7 +58,7 @@ public:
   static Create_func_inet_aton s_singleton;
 protected:
   Create_func_inet_aton() {}
-  virtual ~Create_func_inet_aton() {}
+  ~Create_func_inet_aton() override {}
 };
 
 
@@ -72,7 +72,7 @@ public:
   static Create_func_inet6_aton s_singleton;
 protected:
   Create_func_inet6_aton() {}
-  virtual ~Create_func_inet6_aton() {}
+  ~Create_func_inet6_aton() override {}
 };
 
 
@@ -86,7 +86,7 @@ public:
   static Create_func_inet6_ntoa s_singleton;
 protected:
   Create_func_inet6_ntoa() {}
-  virtual ~Create_func_inet6_ntoa() {}
+  ~Create_func_inet6_ntoa() override {}
 };
 
 
@@ -100,7 +100,7 @@ public:
   static Create_func_is_ipv4 s_singleton;
 protected:
   Create_func_is_ipv4() {}
-  virtual ~Create_func_is_ipv4() {}
+  ~Create_func_is_ipv4() override {}
 };
 
 
@@ -114,7 +114,7 @@ public:
   static Create_func_is_ipv6 s_singleton;
 protected:
   Create_func_is_ipv6() {}
-  virtual ~Create_func_is_ipv6() {}
+  ~Create_func_is_ipv6() override {}
 };
 
 
@@ -128,7 +128,7 @@ public:
   static Create_func_is_ipv4_compat s_singleton;
 protected:
   Create_func_is_ipv4_compat() {}
-  virtual ~Create_func_is_ipv4_compat() {}
+  ~Create_func_is_ipv4_compat() override {}
 };
 
 
@@ -142,7 +142,7 @@ public:
   static Create_func_is_ipv4_mapped s_singleton;
 protected:
   Create_func_is_ipv4_mapped() {}
-  virtual ~Create_func_is_ipv4_mapped() {}
+  ~Create_func_is_ipv4_mapped() override {}
 };
 
 

--- a/plugin/type_inet/sql_type_inet.cc
+++ b/plugin/type_inet/sql_type_inet.cc
@@ -1102,9 +1102,9 @@ public:
   Item_cache_inet6(THD *thd)
    :Item_cache(thd, &type_handler_inet6)
   { }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_cache_inet6>(thd, this); }
-  bool cache_value()
+  bool cache_value() override
   {
     if (!example)
       return false;
@@ -1119,54 +1119,54 @@ public:
                                                  type_handler());
     return true;
   }
-  String* val_str(String *to)
+  String* val_str(String *to) override
   {
     if (!has_value())
       return NULL;
     Inet6_null tmp(m_value.ptr(), m_value.length());
     return tmp.is_null() || tmp.to_string(to) ? NULL : to;
   }
-  my_decimal *val_decimal(my_decimal *to)
+  my_decimal *val_decimal(my_decimal *to) override
   {
     if (!has_value())
       return NULL;
     my_decimal_set_zero(to);
     return to;
   }
-  longlong val_int()
+  longlong val_int() override
   {
     if (!has_value())
       return 0;
     return 0;
   }
-  double val_real()
+  double val_real() override
   {
     if (!has_value())
       return 0;
     return 0;
   }
-  longlong val_datetime_packed(THD *thd)
-  {
-    DBUG_ASSERT(0);
-    if (!has_value())
-      return 0;
-    return 0;
-  }
-  longlong val_time_packed(THD *thd)
+  longlong val_datetime_packed(THD *thd) override
   {
     DBUG_ASSERT(0);
     if (!has_value())
       return 0;
     return 0;
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  longlong val_time_packed(THD *thd) override
+  {
+    DBUG_ASSERT(0);
+    if (!has_value())
+      return 0;
+    return 0;
+  }
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     if (!has_value())
       return true;
     set_zero_time(ltime, MYSQL_TIMESTAMP_TIME);
     return false;
   }
-  bool val_native(THD *thd, Native *to)
+  bool val_native(THD *thd, Native *to) override
   {
     if (!has_value())
       return true;

--- a/plugin/type_mysql_json/type.cc
+++ b/plugin/type_mysql_json/type.cc
@@ -62,14 +62,14 @@ public:
                  &my_charset_utf8mb4_bin)
   {}
 
-  String *val_str(String *val_buffer, String *val_str);
-  const Type_handler *type_handler() const { return &type_handler_mysql_json; }
+  String *val_str(String *val_buffer, String *val_str) override;
+  const Type_handler *type_handler() const override { return &type_handler_mysql_json; }
   bool parse_mysql(String *dest, const char *data, size_t length) const;
-  bool send(Protocol *protocol) { return Field::send(protocol); }
-  void sql_type(String &s) const
+  bool send(Protocol *protocol) override { return Field::send(protocol); }
+  void sql_type(String &s) const override
   { s.set_ascii(STRING_WITH_LEN("mysql_json /* JSON from MySQL 5.7 */")); }
   /* this will make ALTER TABLE to consider it different from built-in field */
-  Compression_method *compression_method() const { return (Compression_method*)1; }
+  Compression_method *compression_method() const override { return (Compression_method*)1; }
 };
 
 Field *Type_handler_mysql_json::make_conversion_table_field(MEM_ROOT *root,

--- a/plugin/versioning/versioning.cc
+++ b/plugin/versioning/versioning.cc
@@ -30,14 +30,14 @@ template <TR_table::field_id_t TRT_FIELD>
 class Create_func_trt : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_trt<TRT_FIELD> s_singleton;
 
 protected:
   Create_func_trt() = default;
-  virtual ~Create_func_trt() = default;
+  ~Create_func_trt() override = default;
 };
 
 template<TR_table::field_id_t TRT_FIELD>
@@ -104,8 +104,8 @@ template <class Item_func_trt_trx_seesX>
 class Create_func_trt_trx_sees : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list)
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override
   {
     Item *func= NULL;
     int arg_count= 0;
@@ -133,7 +133,7 @@ public:
 
 protected:
   Create_func_trt_trx_sees() = default;
-  virtual ~Create_func_trt_trx_sees() = default;
+  ~Create_func_trt_trx_sees() override = default;
 };
 
 template<class X>

--- a/sql/event_data_objects.cc
+++ b/sql/event_data_objects.cc
@@ -71,14 +71,14 @@ public:
                            Stored_program_creation_ctx **ctx);
 
 public:
-  virtual Stored_program_creation_ctx *clone(MEM_ROOT *mem_root)
+  Stored_program_creation_ctx *clone(MEM_ROOT *mem_root) override
   {
     return new (mem_root)
                Event_creation_ctx(m_client_cs, m_connection_cl, m_db_cl);
   }
 
 protected:
-  virtual Object_creation_ctx *create_backup_ctx(THD *thd) const
+  Object_creation_ctx *create_backup_ctx(THD *thd) const override
   {
     /*
       We can avoid usual backup/restore employed in stored programs since we

--- a/sql/event_data_objects.h
+++ b/sql/event_data_objects.h
@@ -117,7 +117,7 @@ public:
   virtual ~Event_queue_element();
 
   virtual bool
-  load_from_row(THD *thd, TABLE *table);
+  load_from_row(THD *thd, TABLE *table) override;
 
   bool
   compute_next_execution_time();
@@ -155,7 +155,7 @@ public:
   init();
 
   virtual bool
-  load_from_row(THD *thd, TABLE *table);
+  load_from_row(THD *thd, TABLE *table) override;
 
   int
   get_create_event(THD *thd, String *buf);
@@ -176,7 +176,7 @@ public:
   Event_job_data();
 
   virtual bool
-  load_from_row(THD *thd, TABLE *table);
+  load_from_row(THD *thd, TABLE *table) override;
 
   bool
   execute(THD *thd, bool drop);

--- a/sql/field.h
+++ b/sql/field.h
@@ -3156,7 +3156,7 @@ public:
     :Field_temporal(ptr_arg, len_arg, null_ptr_arg, null_bit_arg,
                     unireg_check_arg, field_name_arg)
     {}
-  bool validate_value_in_record(THD *thd, const uchar *record) const;
+  bool validate_value_in_record(THD *thd, const uchar *record) const override;
 };
 
 
@@ -4161,7 +4161,7 @@ public:
   {
     return (uint32) field_length + sort_suffix_length();
   }
-  virtual uint32 sort_suffix_length() const override
+  uint32 sort_suffix_length() const override
   {
     return (field_charset() == &my_charset_bin ? length_bytes : 0);
   }
@@ -4507,7 +4507,7 @@ public:
   uint32 sort_length() const override;
   uint32 sort_suffix_length() const override;
   uint32 value_length() override { return get_length(); }
-  virtual uint32 max_data_length() const override
+  uint32 max_data_length() const override
   {
     return (uint32) (((ulonglong) 1 << (packlength*8)) -1);
   }
@@ -5119,20 +5119,20 @@ public:
      m_table(NULL)
     {}
   ~Field_row();
-  en_fieldtype tmp_engine_column_type(bool use_packed_rows) const
+  en_fieldtype tmp_engine_column_type(bool use_packed_rows) const override
   {
     DBUG_ASSERT(0);
     return Field::tmp_engine_column_type(use_packed_rows);
   }
   enum_conv_type rpl_conv_type_from(const Conv_source &source,
                                     const Relay_log_info *rli,
-                                    const Conv_param &param) const
+                                    const Conv_param &param) const override
   {
     DBUG_ASSERT(0);
     return CONV_TYPE_IMPOSSIBLE;
   }
-  Virtual_tmp_table **virtual_tmp_table_addr() { return &m_table; }
-  bool sp_prepare_and_store_item(THD *thd, Item **value);
+  Virtual_tmp_table **virtual_tmp_table_addr() override { return &m_table; }
+  bool sp_prepare_and_store_item(THD *thd, Item **value) override;
 };
 
 

--- a/sql/gcalc_tools.h
+++ b/sql/gcalc_tools.h
@@ -146,16 +146,16 @@ public:
   Gcalc_operation_transporter(Gcalc_function *fn, Gcalc_heap *heap) :
     Gcalc_shape_transporter(heap), m_fn(fn) {}
 
-  int single_point(double x, double y);
-  int start_line();
-  int complete_line();
-  int start_poly();
-  int complete_poly();
-  int start_ring();
-  int complete_ring();
-  int add_point(double x, double y);
-  int start_collection(int n_objects);
-  int empty_shape();
+  int single_point(double x, double y) override;
+  int start_line() override;
+  int complete_line() override;
+  int start_poly() override;
+  int complete_poly() override;
+  int start_ring() override;
+  int complete_ring() override;
+  int add_point(double x, double y) override;
+  int start_collection(int n_objects) override;
+  int empty_shape() override;
 };
 
 

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -10344,7 +10344,7 @@ public:
       m_tot_parts(tot_parts)
   {}
 
-  ~ha_partition_inplace_ctx()
+  ~ha_partition_inplace_ctx() override
   {
     if (handler_ctx_array)
     {

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -478,7 +478,7 @@ public:
   }
   Partition_share *get_part_share() { return part_share; }
   handler *clone(const char *name, MEM_ROOT *mem_root) override;
-  virtual void set_part_info(partition_info *part_info) override
+  void set_part_info(partition_info *part_info) override
   {
      m_part_info= part_info;
      m_is_sub_partitioned= part_info->is_sub_partitioned();

--- a/sql/ha_sequence.h
+++ b/sql/ha_sequence.h
@@ -67,44 +67,44 @@ public:
   ~ha_sequence();
 
   /* virtual function that are re-implemented for sequence */
-  int open(const char *name, int mode, uint test_if_locked);
+  int open(const char *name, int mode, uint test_if_locked) override;
   int create(const char *name, TABLE *form,
-             HA_CREATE_INFO *create_info);
-  handler *clone(const char *name, MEM_ROOT *mem_root);
-  int write_row(const uchar *buf);
-  Table_flags table_flags() const;
+             HA_CREATE_INFO *create_info) override;
+  handler *clone(const char *name, MEM_ROOT *mem_root) override;
+  int write_row(const uchar *buf) override;
+  Table_flags table_flags() const override;
   /* One can't update or delete from sequence engine */
-  int update_row(const uchar *old_data, const uchar *new_data)
+  int update_row(const uchar *old_data, const uchar *new_data) override
   { return HA_ERR_WRONG_COMMAND; }
-  int delete_row(const uchar *buf)
+  int delete_row(const uchar *buf) override
   { return HA_ERR_WRONG_COMMAND; }
   /* One can't delete from sequence engine */
-  int truncate()
+  int truncate() override
   { return HA_ERR_WRONG_COMMAND; }
   /* Can't use query cache */
-  uint8 table_cache_type()
+  uint8 table_cache_type() override
   { return HA_CACHE_TBL_NOCACHE; }
-  void print_error(int error, myf errflag);
-  int info(uint);
-  LEX_CSTRING *engine_name() { return hton_name(file->ht); }
-  int external_lock(THD *thd, int lock_type);
-  int extra(enum ha_extra_function operation);
+  void print_error(int error, myf errflag) override;
+  int info(uint) override;
+  LEX_CSTRING *engine_name() override { return hton_name(file->ht); }
+  int external_lock(THD *thd, int lock_type) override;
+  int extra(enum ha_extra_function operation) override;
   /* For ALTER ONLINE TABLE */
   bool check_if_incompatible_data(HA_CREATE_INFO *create_info,
-                                  uint table_changes);
+                                  uint table_changes) override;
   void write_lock() { write_locked= 1;}
   void unlock() { write_locked= 0; }
   bool is_locked() { return write_locked; }
 
   /* Functions that are directly mapped to the underlying handler */
-  int rnd_init(bool scan)
+  int rnd_init(bool scan) override
   { return file->rnd_init(scan); }
   /*
     We need to have a lock here to protect engines like MyISAM from
     simultaneous read and write. For sequence's this is not critical
     as this function is used extremely seldom.
   */
-  int rnd_next(uchar *buf)
+  int rnd_next(uchar *buf) override
   {
     int error;
     table->s->sequence->read_lock(table);
@@ -112,9 +112,9 @@ public:
     table->s->sequence->read_unlock(table);
     return error;
   }
-  int rnd_end()
+  int rnd_end() override
   { return file->rnd_end(); }
-  int rnd_pos(uchar *buf, uchar *pos)
+  int rnd_pos(uchar *buf, uchar *pos) override
   {
     int error;
     table->s->sequence->read_lock(table);
@@ -122,37 +122,37 @@ public:
     table->s->sequence->read_unlock(table);
     return error;
   }
-  void position(const uchar *record)
+  void position(const uchar *record) override
   { return file->position(record); }
   const char *table_type() const
   { return file->table_type(); }
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   { return file->index_flags(inx, part, all_parts); }
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type)
+                             enum thr_lock_type lock_type) override
   { return file->store_lock(thd, to, lock_type); }
-  int close(void)
+  int close(void) override
   { return file->close(); }
   const char **bas_ext() const
   { return file->bas_ext(); }
-  int delete_table(const char*name)
+  int delete_table(const char*name) override
   { return file->delete_table(name); }
-  int rename_table(const char *from, const char *to)
+  int rename_table(const char *from, const char *to) override
   { return file->rename_table(from, to); }
-  void unbind_psi()
+  void unbind_psi() override
   { file->unbind_psi(); }
-  void rebind_psi()
+  void rebind_psi() override
   { file->rebind_psi(); }
 
-  bool auto_repair(int error) const
+  bool auto_repair(int error) const override
   { return file->auto_repair(error); }
-  int repair(THD* thd, HA_CHECK_OPT* check_opt)
+  int repair(THD* thd, HA_CHECK_OPT* check_opt) override
   { return file->repair(thd, check_opt); }
-  bool check_and_repair(THD *thd)
+  bool check_and_repair(THD *thd) override
   { return file->check_and_repair(thd); }
-  bool is_crashed() const
+  bool is_crashed() const override
   { return file->is_crashed(); }
-  void column_bitmaps_signal()
+  void column_bitmaps_signal() override
   { return file->column_bitmaps_signal(); }
 
   /* New methods */

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -162,7 +162,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl)
+                        Sql_condition ** cond_hdl) override
   {
     *cond_hdl= NULL;
     if (non_existing_table_error(sql_errno))

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -5141,8 +5141,8 @@ public:
     : thd(thd_arg), wild(NULL), with_temps(true), tables(tables_arg) {}
   ~Discovered_table_list() = default;
 
-  bool add_table(const char *tname, size_t tlen);
-  bool add_file(const char *fname);
+  bool add_table(const char *tname, size_t tlen) override;
+  bool add_file(const char *fname) override;
 
   void sort();
   void remove_duplicates(); // assumes that the list is sorted

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -7992,7 +7992,7 @@ class Dependency_marker: public Field_enumerator
 public:
   THD *thd;
   st_select_lex *current_select;
-  virtual void visit_field(Item_field *item)
+  void visit_field(Item_field *item) override
   {
     // Find which select the field is in. This is achieved by walking up 
     // the select tree and looking for the table of interest.

--- a/sql/item.h
+++ b/sql/item.h
@@ -417,16 +417,16 @@ public:
 class Sp_rcontext_handler_local: public Sp_rcontext_handler
 {
 public:
-  const LEX_CSTRING *get_name_prefix() const;
-  sp_rcontext *get_rcontext(sp_rcontext *ctx) const;
+  const LEX_CSTRING *get_name_prefix() const override;
+  sp_rcontext *get_rcontext(sp_rcontext *ctx) const override;
 };
 
 
 class Sp_rcontext_handler_package_body: public Sp_rcontext_handler
 {
 public:
-  const LEX_CSTRING *get_name_prefix() const;
-  sp_rcontext *get_rcontext(sp_rcontext *ctx) const;
+  const LEX_CSTRING *get_name_prefix() const override;
+  sp_rcontext *get_rcontext(sp_rcontext *ctx) const override;
 };
 
 
@@ -1156,9 +1156,9 @@ public:
   {
     return type_handler()->max_display_length(this);
   }
-  const TYPELIB *get_typelib() const { return NULL; }
-  void set_maybe_null(bool maybe_null_arg) { maybe_null= maybe_null_arg; }
-  void set_typelib(const TYPELIB *typelib)
+  const TYPELIB *get_typelib() const override { return NULL; }
+  void set_maybe_null(bool maybe_null_arg) override { maybe_null= maybe_null_arg; }
+  void set_typelib(const TYPELIB *typelib) override
   {
     // Non-field Items (e.g. hybrid functions) never have ENUM/SET types yet.
     DBUG_ASSERT(0);
@@ -1666,7 +1666,7 @@ public:
   inline uint float_length(uint decimals_par) const
   { return decimals < FLOATING_POINT_DECIMALS ? (DBL_DIG+2+decimals_par) : DBL_DIG+8;}
   /* Returns total number of decimal digits */
-  virtual uint decimal_precision() const
+  uint decimal_precision() const override
   {
     return type_handler()->Item_decimal_precision(this);
   }
@@ -2798,20 +2798,20 @@ public:
   Item_fixed_hybrid(THD *thd, Item_fixed_hybrid *item)
    :Item(thd, item), fixed(item->fixed)
   { }
-  bool fix_fields(THD *thd, Item **ref)
+  bool fix_fields(THD *thd, Item **ref) override
   {
     DBUG_ASSERT(!fixed);
     fixed= true;
     return false;
   }
-  void cleanup()
+  void cleanup() override
   {
     Item::cleanup();
     fixed= false;
   }
-  void quick_fix_field() { fixed= true; }
-  void unfix_fields() { fixed= false; }
-  bool is_fixed() const { return fixed; }
+  void quick_fix_field() override { fixed= true; }
+  void unfix_fields() override { fixed= false; }
+  bool is_fixed() const override { return fixed; }
 };
 
 
@@ -2889,8 +2889,8 @@ class Item_basic_constant :public Item_basic_value
 {
 public:
   Item_basic_constant(THD *thd): Item_basic_value(thd) {};
-  bool check_vcol_func_processor(void *arg) { return false; }
-  const Item_const *get_item_const() const { return this; }
+  bool check_vcol_func_processor(void *arg) override { return false; }
+  const Item_const *get_item_const() const override { return this; }
   virtual Item_basic_constant *make_string_literal_concat(THD *thd,
                                                           const LEX_CSTRING *)
   {
@@ -4330,11 +4330,11 @@ public:
   Item_uint(THD *thd, const char *str_arg, size_t length);
   Item_uint(THD *thd, ulonglong i): Item_int(thd, i, 10) {}
   Item_uint(THD *thd, const char *str_arg, longlong i, uint length);
-  double val_real() { return ulonglong2double((ulonglong)value); }
-  Item *clone_item(THD *thd);
-  Item *neg(THD *thd);
-  uint decimal_precision() const { return max_length; }
-  Item *get_copy(THD *thd)
+  double val_real() override { return ulonglong2double((ulonglong)value); }
+  Item *clone_item(THD *thd) override;
+  Item *neg(THD *thd) override;
+  uint decimal_precision() const override { return max_length; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_uint>(thd, this); }
 };
 
@@ -4617,7 +4617,7 @@ public:
                               const LEX_CSTRING &str, CHARSET_INFO *tocs):
     Item_string(thd, name_arg, str, tocs)
   { }
-  virtual bool is_cs_specified() const
+  bool is_cs_specified() const override
   {
     return true;
   }
@@ -4696,7 +4696,7 @@ public:
   {
     max_length= length;
   }
-  bool check_vcol_func_processor(void *arg) 
+  bool check_vcol_func_processor(void *arg) override 
   {
     return mark_unsupported_function("safe_string", arg, VCOL_IMPOSSIBLE);
   }
@@ -4721,7 +4721,7 @@ public:
    :Item_partition_func_safe_string(thd, LEX_CSTRING({header, strlen(header)}),
                                     length * cs->mbmaxlen, cs)
   { }
-  void make_send_field(THD *thd, Send_field *field);
+  void make_send_field(THD *thd, Send_field *field) override;
 };
 
 
@@ -4735,7 +4735,7 @@ public:
   {
     unsigned_flag=1;
   }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     const Type_handler *h=
       Type_handler::get_handler_by_field_type(int_field_type);
@@ -4761,14 +4761,14 @@ public:
   {
     hex_string_init(thd, str, str_length);
   }
-  const Type_handler *type_handler() const { return &type_handler_varchar; }
-  virtual Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs)
+  const Type_handler *type_handler() const override { return &type_handler_varchar; }
+  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override
   {
     return const_charset_converter(thd, tocs, true);
   }
-  const String *const_ptr_string() const { return &str_value; }
-  String *val_str(String*) { return &str_value; }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  const String *const_ptr_string() const override { return &str_value; }
+  String *val_str(String*) override { return &str_value; }
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
@@ -5132,7 +5132,7 @@ public:
   {
     maybe_null= false;
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     cached_time.copy_to_mysql_time(ltime);
     return (null_value= false);
@@ -5153,7 +5153,7 @@ public:
   {
     maybe_null= false;
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     cached_time.copy_to_mysql_time(ltime);
     return (null_value= false);
@@ -7074,7 +7074,7 @@ class Item_cache_year: public Item_cache_int
 public:
   Item_cache_year(THD *thd, const Type_handler *handler)
    :Item_cache_int(thd, handler) { }
-  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t mode)
+  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t mode) override
   {
     return type_handler_year.Item_get_date_with_warn(thd, this, to, mode);
   }
@@ -7281,8 +7281,8 @@ public:
   Item_cache_double(THD *thd)
    :Item_cache_real(thd, &type_handler_double)
   { }
-  String* val_str(String *str);
-  Item *get_copy(THD *thd)
+  String* val_str(String *str) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_cache_double>(thd, this); }
 };
 
@@ -7293,8 +7293,8 @@ public:
   Item_cache_float(THD *thd)
    :Item_cache_real(thd, &type_handler_float)
   { }
-  String* val_str(String *str);
-  Item *get_copy(THD *thd)
+  String* val_str(String *str) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_cache_float>(thd, this); }
 };
 
@@ -7358,7 +7358,7 @@ public:
   Item_cache_str_for_nullif(THD *thd, const Item *item)
    :Item_cache_str(thd, item)
   { }
-  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs)
+  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override
   {
     /**
       Item_cache_str::safe_charset_converter() returns a new Item_cache
@@ -7372,7 +7372,7 @@ public:
     */
     return Item::safe_charset_converter(thd, tocs);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_cache_str_for_nullif>(thd, this); }
 };
 
@@ -7594,9 +7594,9 @@ class Item_iterator_ref_list: public Item_iterator
 public:
   Item_iterator_ref_list(List_iterator<Item*> &arg_list):
     list(arg_list) {}
-  void open() { list.rewind(); }
-  Item *next() { return *(list++); }
-  void close() {}
+  void open() override { list.rewind(); }
+  Item *next() override { return *(list++); }
+  void close() override {}
 };
 
 
@@ -7610,9 +7610,9 @@ class Item_iterator_list: public Item_iterator
 public:
   Item_iterator_list(List_iterator<Item> &arg_list):
     list(arg_list) {}
-  void open() { list.rewind(); }
-  Item *next() { return (list++); }
-  void close() {}
+  void open() override { list.rewind(); }
+  Item *next() override { return (list++); }
+  void close() override {}
 };
 
 
@@ -7626,14 +7626,14 @@ class Item_iterator_row: public Item_iterator
   uint current;
 public:
   Item_iterator_row(Item *base) : base_item(base), current(0) {}
-  void open() { current= 0; }
-  Item *next()
+  void open() override { current= 0; }
+  Item *next() override
   {
     if (current >= base_item->cols())
       return NULL;
     return base_item->element_index(current++);
   }
-  void close() {}
+  void close() override {}
 };
 
 
@@ -7679,84 +7679,84 @@ public:
 
   void change_item(THD *thd, Item *);
 
-  bool fix_fields(THD *thd, Item **it);
+  bool fix_fields(THD *thd, Item **it) override;
 
-  void print(String *str, enum_query_type query_type);
+  void print(String *str, enum_query_type query_type) override;
 
-  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs);
-  Item *get_tmp_table_item(THD *thd)
+  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override;
+  Item *get_tmp_table_item(THD *thd) override
   { return m_item->get_tmp_table_item(thd); }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_direct_ref_to_item>(thd, this); }
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
-                          COND_EQUAL **cond_equal_ref)
+                          COND_EQUAL **cond_equal_ref) override
   {
     return m_item->build_equal_items(thd, inherited, link_item_fields,
                                      cond_equal_ref);
   }
-  const char *full_name() const { return m_item->full_name(); }
-  void make_send_field(THD *thd, Send_field *field)
+  const char *full_name() const override { return m_item->full_name(); }
+  void make_send_field(THD *thd, Send_field *field) override
   { m_item->make_send_field(thd, field); }
-  bool eq(const Item *item, bool binary_cmp) const
+  bool eq(const Item *item, bool binary_cmp) const override
   {
     const Item *it= item->real_item();
     return m_item->eq(it, binary_cmp);
   }
-  void fix_after_pullout(st_select_lex *new_parent, Item **refptr, bool merge)
+  void fix_after_pullout(st_select_lex *new_parent, Item **refptr, bool merge) override
   { m_item->fix_after_pullout(new_parent, &m_item, merge); }
-  void save_val(Field *to)
+  void save_val(Field *to) override
   { return m_item->save_val(to); }
-  void save_result(Field *to)
+  void save_result(Field *to) override
   { return m_item->save_result(to); }
-  int save_in_field(Field *to, bool no_conversions)
+  int save_in_field(Field *to, bool no_conversions) override
   { return m_item->save_in_field(to, no_conversions); }
-  const Type_handler *type_handler() const { return m_item->type_handler(); }
-  table_map used_tables() const { return m_item->used_tables(); }
-  void update_used_tables()
+  const Type_handler *type_handler() const override { return m_item->type_handler(); }
+  table_map used_tables() const override { return m_item->used_tables(); }
+  void update_used_tables() override
   { m_item->update_used_tables(); }
-  bool const_item() const { return m_item->const_item(); }
-  table_map not_null_tables() const { return m_item->not_null_tables(); }
-  bool walk(Item_processor processor, bool walk_subquery, void *arg)
+  bool const_item() const override { return m_item->const_item(); }
+  table_map not_null_tables() const override { return m_item->not_null_tables(); }
+  bool walk(Item_processor processor, bool walk_subquery, void *arg) override
   {
     return m_item->walk(processor, walk_subquery, arg) ||
       (this->*processor)(arg);
   }
-  bool enumerate_field_refs_processor(void *arg)
+  bool enumerate_field_refs_processor(void *arg) override
   { return m_item->enumerate_field_refs_processor(arg); }
-  Item_field *field_for_view_update()
+  Item_field *field_for_view_update() override
   { return m_item->field_for_view_update(); }
 
   /* Row emulation: forwarding of ROW-related calls to orig_item */
-  uint cols() const
+  uint cols() const override
   { return m_item->cols(); }
-  Item* element_index(uint i)
+  Item* element_index(uint i) override
   { return this; }
-  Item** addr(uint i)
+  Item** addr(uint i) override
   { return  &m_item; }
-  bool check_cols(uint c)
+  bool check_cols(uint c) override
   { return Item::check_cols(c); }
-  bool null_inside()
+  bool null_inside() override
   { return m_item->null_inside(); }
-  void bring_value()
+  void bring_value() override
   {}
 
-  Item_equal *get_item_equal() { return m_item->get_item_equal(); }
-  void set_item_equal(Item_equal *item_eq) { m_item->set_item_equal(item_eq); }
-  Item_equal *find_item_equal(COND_EQUAL *cond_equal)
+  Item_equal *get_item_equal() override { return m_item->get_item_equal(); }
+  void set_item_equal(Item_equal *item_eq) override { m_item->set_item_equal(item_eq); }
+  Item_equal *find_item_equal(COND_EQUAL *cond_equal) override
   { return m_item->find_item_equal(cond_equal); }
-  Item *propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  Item *propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   { return m_item->propagate_equal_fields(thd, ctx, cond); }
-  Item *replace_equal_field(THD *thd, uchar *arg)
+  Item *replace_equal_field(THD *thd, uchar *arg) override
   { return m_item->replace_equal_field(thd, arg); }
 
-  bool excl_dep_on_table(table_map tab_map)
+  bool excl_dep_on_table(table_map tab_map) override
   { return m_item->excl_dep_on_table(tab_map); }
-  bool excl_dep_on_grouping_fields(st_select_lex *sel)
+  bool excl_dep_on_grouping_fields(st_select_lex *sel) override
   { return m_item->excl_dep_on_grouping_fields(sel); }
-  bool is_expensive() { return m_item->is_expensive(); }
+  bool is_expensive() override { return m_item->is_expensive(); }
   void set_item(Item *item) { m_item= item; }
-  Item *build_clone(THD *thd)
+  Item *build_clone(THD *thd) override
   {
     Item *clone_item= m_item->build_clone(thd);
     if (clone_item)
@@ -7771,7 +7771,7 @@ public:
   }
 
   void split_sum_func(THD *thd, Ref_ptr_array ref_pointer_array,
-                      List<Item> &fields, uint flags)
+                      List<Item> &fields, uint flags) override
   {
     m_item->split_sum_func(thd, ref_pointer_array, fields, flags);
   }
@@ -7779,7 +7779,7 @@ public:
     This processor states that this is safe for virtual columns
     (because this Item transparency)
   */
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
 };
 
 inline bool TABLE::mark_column_with_deps(Field *field)

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -4823,7 +4823,7 @@ class Func_handler_bit_or_int_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     Longlong_null a= item->arguments()[0]->to_longlong_null();
@@ -4836,7 +4836,7 @@ class Func_handler_bit_or_dec_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     VDec a(item->arguments()[0]);
@@ -4858,7 +4858,7 @@ class Func_handler_bit_and_int_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     Longlong_null a= item->arguments()[0]->to_longlong_null();
@@ -4871,7 +4871,7 @@ class Func_handler_bit_and_dec_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     VDec a(item->arguments()[0]);

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -236,12 +236,12 @@ public:
   Item_bool_func(THD *thd, Item *a, Item *b, Item *c): Item_int_func(thd, a, b, c) {}
   Item_bool_func(THD *thd, List<Item> &list): Item_int_func(thd, list) { }
   Item_bool_func(THD *thd, Item_bool_func *item) :Item_int_func(thd, item) {}
-  const Type_handler *type_handler() const { return &type_handler_bool; }
-  const Type_handler *fixed_type_handler() const { return &type_handler_bool; }
-  CHARSET_INFO *compare_collation() const { return NULL; }
-  bool fix_length_and_dec() { decimals=0; max_length=1; return FALSE; }
-  uint decimal_precision() const { return 1; }
-  bool need_parentheses_in_default() { return true; }
+  const Type_handler *type_handler() const override { return &type_handler_bool; }
+  const Type_handler *fixed_type_handler() const override { return &type_handler_bool; }
+  CHARSET_INFO *compare_collation() const override { return NULL; }
+  bool fix_length_and_dec() override { decimals=0; max_length=1; return FALSE; }
+  uint decimal_precision() const override { return 1; }
+  bool need_parentheses_in_default() override { return true; }
 };
 
 
@@ -253,11 +253,11 @@ public:
 class Item_func_truth : public Item_bool_func
 {
 public:
-  virtual bool val_bool();
-  virtual longlong val_int();
-  virtual bool fix_length_and_dec();
-  virtual void print(String *str, enum_query_type query_type);
-  enum precedence precedence() const { return CMP_PRECEDENCE; }
+  bool val_bool() override;
+  longlong val_int() override;
+  bool fix_length_and_dec() override;
+  void print(String *str, enum_query_type query_type) override;
+  enum precedence precedence() const override { return CMP_PRECEDENCE; }
 
 protected:
   Item_func_truth(THD *thd, Item *a, bool a_value, bool a_affirmative):
@@ -287,8 +287,8 @@ class Item_func_istrue : public Item_func_truth
 public:
   Item_func_istrue(THD *thd, Item *a): Item_func_truth(thd, a, true, true) {}
   ~Item_func_istrue() = default;
-  virtual const char* func_name() const { return "istrue"; }
-  Item *get_copy(THD *thd)
+  const char* func_name() const override { return "istrue"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_istrue>(thd, this); }
 };
 
@@ -303,11 +303,11 @@ public:
   Item_func_isnottrue(THD *thd, Item *a):
     Item_func_truth(thd, a, true, false) {}
   ~Item_func_isnottrue() = default;
-  virtual const char* func_name() const { return "isnottrue"; }
-  bool find_not_null_fields(table_map allowed) { return false; }
-  Item *get_copy(THD *thd)
+  const char* func_name() const override { return "isnottrue"; }
+  bool find_not_null_fields(table_map allowed) override { return false; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isnottrue>(thd, this); }
-  bool eval_not_null_tables(void *) { not_null_tables_cache= 0; return false; }
+  bool eval_not_null_tables(void *) override { not_null_tables_cache= 0; return false; }
 };
 
 
@@ -320,8 +320,8 @@ class Item_func_isfalse : public Item_func_truth
 public:
   Item_func_isfalse(THD *thd, Item *a): Item_func_truth(thd, a, false, true) {}
   ~Item_func_isfalse() = default;
-  virtual const char* func_name() const { return "isfalse"; }
-  Item *get_copy(THD *thd)
+  const char* func_name() const override { return "isfalse"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isfalse>(thd, this); }
 };
 
@@ -336,11 +336,11 @@ public:
   Item_func_isnotfalse(THD *thd, Item *a):
     Item_func_truth(thd, a, false, false) {}
   ~Item_func_isnotfalse() = default;
-  virtual const char* func_name() const { return "isnotfalse"; }
-  bool find_not_null_fields(table_map allowed) { return false; }
-  Item *get_copy(THD *thd)
+  const char* func_name() const override { return "isnotfalse"; }
+  bool find_not_null_fields(table_map allowed) override { return false; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isnotfalse>(thd, this); }
-  bool eval_not_null_tables(void *) { not_null_tables_cache= 0; return false; }
+  bool eval_not_null_tables(void *) override { not_null_tables_cache= 0; return false; }
 };
 
 
@@ -427,10 +427,10 @@ public:
   Item_bool_func2(THD *thd, Item *a, Item *b):
     Item_bool_func(thd, a, b) { }
 
-  bool is_null() { return MY_TEST(args[0]->is_null() || args[1]->is_null()); }
+  bool is_null() override { return MY_TEST(args[0]->is_null() || args[1]->is_null()); }
   COND *remove_eq_conds(THD *thd, Item::cond_result *cond_value,
-                        bool top_level);
-  bool count_sargable_conds(void *arg);
+                        bool top_level) override;
+  bool count_sargable_conds(void *arg) override;
   /*
     Specifies which result type the function uses to compare its arguments.
     This method is used in equal field propagation.
@@ -445,7 +445,7 @@ public:
     */
     return &type_handler_varchar;
   }
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr)
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override
   {
     DBUG_ENTER("Item_bool_func2::get_mm_tree");
     DBUG_ASSERT(arg_count == 2);
@@ -478,7 +478,7 @@ class Item_bool_func2_with_rev :public Item_bool_func2
 {
 protected:
   SEL_TREE *get_func_mm_tree(RANGE_OPT_PARAM *param,
-                             Field *field, Item *value)
+                             Field *field, Item *value) override
   {
     DBUG_ENTER("Item_bool_func2_with_rev::get_func_mm_tree");
     Item_func::Functype func_type=
@@ -489,7 +489,7 @@ public:
   Item_bool_func2_with_rev(THD *thd, Item *a, Item *b):
     Item_bool_func2(thd, a, b) { }
   virtual enum Functype rev_functype() const= 0;
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr)
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override
   {
     DBUG_ENTER("Item_bool_func2_with_rev::get_mm_tree");
     DBUG_ASSERT(arg_count == 2);
@@ -523,7 +523,7 @@ class Item_bool_rowready_func2 :public Item_bool_func2_with_rev
 {
 protected:
   Arg_comparator cmp;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return check_argument_types_like_args0();
   }
@@ -531,15 +531,15 @@ public:
   Item_bool_rowready_func2(THD *thd, Item *a, Item *b):
     Item_bool_func2_with_rev(thd, a, b), cmp(tmp_arg, tmp_arg + 1)
   { }
-  Sql_mode_dependency value_depends_on_sql_mode() const;
-  void print(String *str, enum_query_type query_type)
+  Sql_mode_dependency value_depends_on_sql_mode() const override;
+  void print(String *str, enum_query_type query_type) override
   {
     Item_func::print_op(str, query_type);
   }
-  enum precedence precedence() const { return CMP_PRECEDENCE; }
-  Item *neg_transformer(THD *thd);
+  enum precedence precedence() const override { return CMP_PRECEDENCE; }
+  Item *neg_transformer(THD *thd) override;
   virtual Item *negated_item(THD *thd);
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     Item_args::propagate_equal_fields(thd,
                                       Context(ANY_SUBST,
@@ -548,7 +548,7 @@ public:
                                       cond);
     return this;
   }
-  bool fix_length_and_dec();
+  bool fix_length_and_dec() override;
   bool fix_length_and_dec_generic(THD *thd,
                                   const Type_handler *compare_handler)
   {
@@ -561,25 +561,25 @@ public:
     DBUG_ASSERT(args == tmp_arg);
     return cmp.set_cmp_func(thd, this, tmp_arg, tmp_arg + 1, true/*set_null*/);
   }
-  CHARSET_INFO *compare_collation() const { return cmp.compare_collation(); }
-  const Type_handler *compare_type_handler() const
+  CHARSET_INFO *compare_collation() const override { return cmp.compare_collation(); }
+  const Type_handler *compare_type_handler() const override
   {
     return cmp.compare_type_handler();
   }
   Arg_comparator *get_comparator() { return &cmp; }
-  void cleanup()
+  void cleanup() override
   {
     Item_bool_func2::cleanup();
     cmp.cleanup();
   }
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables)
+                      SARGABLE_PARAM **sargables) override
   {
     return add_key_fields_optimize_op(join, key_fields, and_level,
                                       usable_tables, sargables, false);
   }
-  Item *build_clone(THD *thd)
+  Item *build_clone(THD *thd) override
   {
     Item_bool_rowready_func2 *clone=
       (Item_bool_rowready_func2 *) Item_func::build_clone(thd);
@@ -600,20 +600,20 @@ class Item_func_xor :public Item_bool_func
 {
 public:
   Item_func_xor(THD *thd, Item *i1, Item *i2): Item_bool_func(thd, i1, i2) {}
-  enum Functype functype() const { return XOR_FUNC; }
-  const char *func_name() const { return "xor"; }
-  enum precedence precedence() const { return XOR_PRECEDENCE; }
-  void print(String *str, enum_query_type query_type)
+  enum Functype functype() const override { return XOR_FUNC; }
+  const char *func_name() const override { return "xor"; }
+  enum precedence precedence() const override { return XOR_PRECEDENCE; }
+  void print(String *str, enum_query_type query_type) override
   { Item_func::print_op(str, query_type); }
-  longlong val_int();
-  bool find_not_null_fields(table_map allowed) { return false; }
-  Item *neg_transformer(THD *thd);
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  longlong val_int() override;
+  bool find_not_null_fields(table_map allowed) override { return false; }
+  Item *neg_transformer(THD *thd) override;
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     Item_args::propagate_equal_fields(thd, Context_boolean(), cond);
     return this;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_xor>(thd, this); }
 };
 
@@ -674,15 +674,15 @@ class Item_func_trig_cond: public Item_bool_func
 public:
   Item_func_trig_cond(THD *thd, Item *a, bool *f): Item_bool_func(thd, a)
   { trig_var= f; }
-  longlong val_int() { return *trig_var ? args[0]->val_int() : 1; }
-  enum Functype functype() const { return TRIG_COND_FUNC; };
-  const char *func_name() const { return "trigcond"; };
-  bool const_item() const { return FALSE; }
+  longlong val_int() override { return *trig_var ? args[0]->val_int() : 1; }
+  enum Functype functype() const override { return TRIG_COND_FUNC; };
+  const char *func_name() const override { return "trigcond"; };
+  bool const_item() const override { return FALSE; }
   bool *get_trig_var() { return trig_var; }
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables);
-  Item *get_copy(THD *thd)
+                      SARGABLE_PARAM **sargables) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_trig_cond>(thd, this); }
 };
 
@@ -698,19 +698,19 @@ public:
   Item_func_not_all(THD *thd, Item *a):
     Item_func_not(thd, a), test_sum_item(0), test_sub_item(0), show(0)
     {}
-  table_map not_null_tables() const { return 0; }
-  longlong val_int();
-  enum Functype functype() const { return NOT_ALL_FUNC; }
-  const char *func_name() const { return "<not>"; }
-  enum precedence precedence() const
+  table_map not_null_tables() const override { return 0; }
+  longlong val_int() override;
+  enum Functype functype() const override { return NOT_ALL_FUNC; }
+  const char *func_name() const override { return "<not>"; }
+  enum precedence precedence() const override
   { return show ? Item_func::precedence() : args[0]->precedence(); }
-  bool fix_fields(THD *thd, Item **ref)
+  bool fix_fields(THD *thd, Item **ref) override
     {return Item_func::fix_fields(thd, ref);}
-  virtual void print(String *str, enum_query_type query_type);
+  void print(String *str, enum_query_type query_type) override;
   void set_sum_test(Item_sum_min_max *item) { test_sum_item= item; test_sub_item= 0; };
   void set_sub_test(Item_maxmin_subselect *item) { test_sub_item= item; test_sum_item= 0;};
   bool empty_underlying_subquery();
-  Item *neg_transformer(THD *thd);
+  Item *neg_transformer(THD *thd) override;
 };
 
 
@@ -719,10 +719,10 @@ class Item_func_nop_all :public Item_func_not_all
 public:
 
   Item_func_nop_all(THD *thd, Item *a): Item_func_not_all(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "<nop>"; }
-  Item *neg_transformer(THD *thd);
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "<nop>"; }
+  Item *neg_transformer(THD *thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_nop_all>(thd, this); }
 };
 
@@ -735,24 +735,24 @@ public:
     Item_bool_rowready_func2(thd, a, b),
     abort_on_null(false), in_equality_no(UINT_MAX)
   {}
-  longlong val_int();
-  enum Functype functype() const { return EQ_FUNC; }
-  enum Functype rev_functype() const { return EQ_FUNC; }
-  cond_result eq_cmp_result() const { return COND_TRUE; }
-  const char *func_name() const { return "="; }
-  void top_level_item() { abort_on_null= true; }
-  Item *negated_item(THD *thd);
+  longlong val_int() override;
+  enum Functype functype() const override { return EQ_FUNC; }
+  enum Functype rev_functype() const override { return EQ_FUNC; }
+  cond_result eq_cmp_result() const override { return COND_TRUE; }
+  const char *func_name() const override { return "="; }
+  void top_level_item() override { abort_on_null= true; }
+  Item *negated_item(THD *thd) override;
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
-                          COND_EQUAL **cond_equal_ref);
+                          COND_EQUAL **cond_equal_ref) override;
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables)
+                      SARGABLE_PARAM **sargables) override
   {
     return add_key_fields_optimize_op(join, key_fields, and_level,
                                       usable_tables, sargables, true);
   }
-  bool check_equality(THD *thd, COND_EQUAL *cond, List<Item> *eq_list);
+  bool check_equality(THD *thd, COND_EQUAL *cond, List<Item> *eq_list) override;
   /* 
     - If this equality is created from the subquery's IN-equality:
       number of the item it was created from, e.g. for
@@ -761,9 +761,9 @@ public:
     - Otherwise, UINT_MAX
   */
   uint in_equality_no;
-  virtual uint exists2in_reserved_items() { return 1; };
+  uint exists2in_reserved_items() override { return 1; };
   friend class  Arg_comparator;
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_eq>(thd, this); }
 };
 
@@ -772,23 +772,23 @@ class Item_func_equal final :public Item_bool_rowready_func2
 public:
   Item_func_equal(THD *thd, Item *a, Item *b):
     Item_bool_rowready_func2(thd, a, b) {}
-  longlong val_int();
-  bool fix_length_and_dec();
-  table_map not_null_tables() const { return 0; }
-  bool find_not_null_fields(table_map allowed) { return false; }
-  enum Functype functype() const { return EQUAL_FUNC; }
-  enum Functype rev_functype() const { return EQUAL_FUNC; }
-  cond_result eq_cmp_result() const { return COND_TRUE; }
-  const char *func_name() const { return "<=>"; }
-  Item *neg_transformer(THD *thd) { return 0; }
+  longlong val_int() override;
+  bool fix_length_and_dec() override;
+  table_map not_null_tables() const override { return 0; }
+  bool find_not_null_fields(table_map allowed) override { return false; }
+  enum Functype functype() const override { return EQUAL_FUNC; }
+  enum Functype rev_functype() const override { return EQUAL_FUNC; }
+  cond_result eq_cmp_result() const override { return COND_TRUE; }
+  const char *func_name() const override { return "<=>"; }
+  Item *neg_transformer(THD *thd) override { return 0; }
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables)
+                      SARGABLE_PARAM **sargables) override
   {
     return add_key_fields_optimize_op(join, key_fields, and_level,
                                       usable_tables, sargables, true);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_equal>(thd, this); }
 };
 
@@ -798,13 +798,13 @@ class Item_func_ge :public Item_bool_rowready_func2
 public:
   Item_func_ge(THD *thd, Item *a, Item *b):
     Item_bool_rowready_func2(thd, a, b) {};
-  longlong val_int();
-  enum Functype functype() const { return GE_FUNC; }
-  enum Functype rev_functype() const { return LE_FUNC; }
-  cond_result eq_cmp_result() const { return COND_TRUE; }
-  const char *func_name() const { return ">="; }
-  Item *negated_item(THD *thd);
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  enum Functype functype() const override { return GE_FUNC; }
+  enum Functype rev_functype() const override { return LE_FUNC; }
+  cond_result eq_cmp_result() const override { return COND_TRUE; }
+  const char *func_name() const override { return ">="; }
+  Item *negated_item(THD *thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ge>(thd, this); }
 };
 
@@ -814,13 +814,13 @@ class Item_func_gt :public Item_bool_rowready_func2
 public:
   Item_func_gt(THD *thd, Item *a, Item *b):
     Item_bool_rowready_func2(thd, a, b) {};
-  longlong val_int();
-  enum Functype functype() const { return GT_FUNC; }
-  enum Functype rev_functype() const { return LT_FUNC; }
-  cond_result eq_cmp_result() const { return COND_FALSE; }
-  const char *func_name() const { return ">"; }
-  Item *negated_item(THD *thd);
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  enum Functype functype() const override { return GT_FUNC; }
+  enum Functype rev_functype() const override { return LT_FUNC; }
+  cond_result eq_cmp_result() const override { return COND_FALSE; }
+  const char *func_name() const override { return ">"; }
+  Item *negated_item(THD *thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_gt>(thd, this); }
 };
 
@@ -830,13 +830,13 @@ class Item_func_le :public Item_bool_rowready_func2
 public:
   Item_func_le(THD *thd, Item *a, Item *b):
     Item_bool_rowready_func2(thd, a, b) {};
-  longlong val_int();
-  enum Functype functype() const { return LE_FUNC; }
-  enum Functype rev_functype() const { return GE_FUNC; }
-  cond_result eq_cmp_result() const { return COND_TRUE; }
-  const char *func_name() const { return "<="; }
-  Item *negated_item(THD *thd);
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  enum Functype functype() const override { return LE_FUNC; }
+  enum Functype rev_functype() const override { return GE_FUNC; }
+  cond_result eq_cmp_result() const override { return COND_TRUE; }
+  const char *func_name() const override { return "<="; }
+  Item *negated_item(THD *thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_le>(thd, this); }
 };
 
@@ -846,13 +846,13 @@ class Item_func_lt :public Item_bool_rowready_func2
 public:
   Item_func_lt(THD *thd, Item *a, Item *b):
     Item_bool_rowready_func2(thd, a, b) {}
-  longlong val_int();
-  enum Functype functype() const { return LT_FUNC; }
-  enum Functype rev_functype() const { return GT_FUNC; }
-  cond_result eq_cmp_result() const { return COND_FALSE; }
-  const char *func_name() const { return "<"; }
-  Item *negated_item(THD *thd);
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  enum Functype functype() const override { return LT_FUNC; }
+  enum Functype rev_functype() const override { return GT_FUNC; }
+  cond_result eq_cmp_result() const override { return COND_FALSE; }
+  const char *func_name() const override { return "<"; }
+  Item *negated_item(THD *thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_lt>(thd, this); }
 };
 
@@ -861,19 +861,19 @@ class Item_func_ne :public Item_bool_rowready_func2
 {
 protected:
   SEL_TREE *get_func_mm_tree(RANGE_OPT_PARAM *param,
-                             Field *field, Item *value);
+                             Field *field, Item *value) override;
 public:
   Item_func_ne(THD *thd, Item *a, Item *b):
     Item_bool_rowready_func2(thd, a, b) {}
-  longlong val_int();
-  enum Functype functype() const { return NE_FUNC; }
-  enum Functype rev_functype() const { return NE_FUNC; }
-  cond_result eq_cmp_result() const { return COND_FALSE; }
-  const char *func_name() const { return "<>"; }
-  Item *negated_item(THD *thd);
+  longlong val_int() override;
+  enum Functype functype() const override { return NE_FUNC; }
+  enum Functype rev_functype() const override { return NE_FUNC; }
+  cond_result eq_cmp_result() const override { return COND_FALSE; }
+  const char *func_name() const override { return "<>"; }
+  Item *negated_item(THD *thd) override;
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields, uint *and_level,
-                      table_map usable_tables, SARGABLE_PARAM **sargables);
-  Item *get_copy(THD *thd)
+                      table_map usable_tables, SARGABLE_PARAM **sargables) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ne>(thd, this); }
 };
 
@@ -929,37 +929,37 @@ class Item_func_between :public Item_func_opt_neg
 {
 protected:
   SEL_TREE *get_func_mm_tree(RANGE_OPT_PARAM *param,
-                             Field *field, Item *value);
+                             Field *field, Item *value) override;
   bool val_int_cmp_int_finalize(longlong value, longlong a, longlong b);
 public:
   String value0,value1,value2;
   Item_func_between(THD *thd, Item *a, Item *b, Item *c):
     Item_func_opt_neg(thd, a, b, c) { }
-  longlong val_int()
+  longlong val_int() override
   {
     DBUG_ASSERT(fixed);
     return m_comparator.type_handler()->Item_func_between_val_int(this);
   }
-  enum Functype functype() const   { return BETWEEN; }
-  const char *func_name() const { return "between"; }
-  enum precedence precedence() const { return BETWEEN_PRECEDENCE; }
-  bool fix_length_and_dec();
+  enum Functype functype() const override   { return BETWEEN; }
+  const char *func_name() const override { return "between"; }
+  enum precedence precedence() const override { return BETWEEN_PRECEDENCE; }
+  bool fix_length_and_dec() override;
   bool fix_length_and_dec_string(THD *)
   {
     return agg_arg_charsets_for_comparison(cmp_collation, args, 3);
   }
   bool fix_length_and_dec_temporal(THD *);
   bool fix_length_and_dec_numeric(THD *);
-  virtual void print(String *str, enum_query_type query_type);
-  bool eval_not_null_tables(void *opt_arg);
-  bool find_not_null_fields(table_map allowed);
-  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge);
-  bool count_sargable_conds(void *arg);
+  void print(String *str, enum_query_type query_type) override;
+  bool eval_not_null_tables(void *opt_arg) override;
+  bool find_not_null_fields(table_map allowed) override;
+  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
+  bool count_sargable_conds(void *arg) override;
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr);
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+                      SARGABLE_PARAM **sargables) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     Item_args::propagate_equal_fields(thd,
                                       Context(ANY_SUBST,
@@ -968,7 +968,7 @@ public:
                                       cond);
     return this;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_between>(thd, this); }
 
   longlong val_int_cmp_string();
@@ -983,24 +983,24 @@ public:
 
 class Item_func_strcmp :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_str(0, 2); }
   String value1, value2;
   DTCollation cmp_collation;
 public:
   Item_func_strcmp(THD *thd, Item *a, Item *b):
     Item_long_func(thd, a, b) {}
-  longlong val_int();
-  uint decimal_precision() const { return 1; }
-  const char *func_name() const { return "strcmp"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  uint decimal_precision() const override { return 1; }
+  const char *func_name() const override { return "strcmp"; }
+  bool fix_length_and_dec() override
   {
     if (agg_arg_charsets_for_comparison(cmp_collation, args, 2))
       return TRUE;
     fix_char_length(2); // returns "1" or "0" or "-1"
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_strcmp>(thd, this); }
 };
 
@@ -1017,7 +1017,7 @@ class Item_func_interval :public Item_long_func
   Item_row *row;
   bool use_decimal_comparison;
   interval_range *intervals;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return check_argument_types_like_args0();
   }
@@ -1025,17 +1025,17 @@ public:
   Item_func_interval(THD *thd, Item_row *a):
     Item_long_func(thd, a), row(a), intervals(0)
   { }
-  bool fix_fields(THD *, Item **);
-  longlong val_int();
-  bool fix_length_and_dec();
-  const char *func_name() const { return "interval"; }
-  uint decimal_precision() const { return 2; }
-  void print(String *str, enum_query_type query_type)
+  bool fix_fields(THD *, Item **) override;
+  longlong val_int() override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "interval"; }
+  uint decimal_precision() const override { return 2; }
+  void print(String *str, enum_query_type query_type) override
   {
     str->append(func_name());
     print_args(str, 0, query_type);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_interval>(thd, this); }
 };
 
@@ -1047,23 +1047,23 @@ public:
     Item_func_case_expression(thd, a, b) {}
   Item_func_coalesce(THD *thd, List<Item> &list):
     Item_func_case_expression(thd, list) {}
-  double real_op();
-  longlong int_op();
-  String *str_op(String *);
-  my_decimal *decimal_op(my_decimal *);
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool time_op(THD *thd, MYSQL_TIME *ltime);
-  bool native_op(THD *thd, Native *to);
-  bool fix_length_and_dec()
+  double real_op() override;
+  longlong int_op() override;
+  String *str_op(String *) override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override;
+  bool native_op(THD *thd, Native *to) override;
+  bool fix_length_and_dec() override
   {
     if (aggregate_for_result(func_name(), args, arg_count, true))
       return TRUE;
     fix_attributes(args, arg_count);
     return FALSE;
   }
-  const char *func_name() const { return "coalesce"; }
-  table_map not_null_tables() const { return 0; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "coalesce"; }
+  table_map not_null_tables() const override { return 0; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_coalesce>(thd, this); }
 };
 
@@ -1127,14 +1127,14 @@ class Item_func_ifnull :public Item_func_case_abbreviation2
 public:
   Item_func_ifnull(THD *thd, Item *a, Item *b):
     Item_func_case_abbreviation2(thd, a, b) {}
-  double real_op();
-  longlong int_op();
-  String *str_op(String *str);
-  my_decimal *decimal_op(my_decimal *);
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool time_op(THD *thd, MYSQL_TIME *ltime);
-  bool native_op(THD *thd, Native *to);
-  bool fix_length_and_dec()
+  double real_op() override;
+  longlong int_op() override;
+  String *str_op(String *str) override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override;
+  bool native_op(THD *thd, Native *to) override;
+  bool fix_length_and_dec() override
   {
     /*
       Set nullability from args[1] by default.
@@ -1151,10 +1151,10 @@ public:
       return TRUE;
     return FALSE;
   }
-  const char *func_name() const { return "ifnull"; }
+  const char *func_name() const override { return "ifnull"; }
 
-  table_map not_null_tables() const { return 0; }
-  Item *get_copy(THD *thd)
+  table_map not_null_tables() const override { return 0; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ifnull>(thd, this); }
 };
 
@@ -1177,32 +1177,32 @@ public:
     :Item_func_case_abbreviation2(thd, a, b, c)
   { }
 
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     Datetime_truncation_not_needed dt(thd, find_item(), fuzzydate);
     return (null_value= dt.copy_to_mysql_time(ltime, mysql_timestamp_type()));
   }
-  bool time_op(THD *thd, MYSQL_TIME *ltime)
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override
   {
     return (null_value= Time(find_item()).copy_to_mysql_time(ltime));
   }
-  longlong int_op()
+  longlong int_op() override
   {
     return val_int_from_item(find_item());
   }
-  double real_op()
+  double real_op() override
   {
     return val_real_from_item(find_item());
   }
-  my_decimal *decimal_op(my_decimal *decimal_value)
+  my_decimal *decimal_op(my_decimal *decimal_value) override
   {
     return val_decimal_from_item(find_item(), decimal_value);
   }
-  String *str_op(String *str)
+  String *str_op(String *str) override
   {
     return val_str_from_item(find_item(), str);
   }
-  bool native_op(THD *thd, Native *to)
+  bool native_op(THD *thd, Native *to) override
   {
     return val_native_with_conversion_from_item(thd, find_item(), to,
                                                 type_handler());
@@ -1213,21 +1213,21 @@ public:
 class Item_func_if :public Item_func_case_abbreviation2_switch
 {
 protected:
-  Item *find_item() const { return args[0]->val_bool() ? args[1] : args[2]; }
+  Item *find_item() const override { return args[0]->val_bool() ? args[1] : args[2]; }
 
 public:
   Item_func_if(THD *thd, Item *a, Item *b, Item *c):
     Item_func_case_abbreviation2_switch(thd, a, b, c)
   {}
-  bool fix_fields(THD *, Item **);
-  bool fix_length_and_dec()
+  bool fix_fields(THD *, Item **) override;
+  bool fix_length_and_dec() override
   {
     return fix_length_and_dec2_eliminate_null(args + 1);
   }
-  const char *func_name() const { return "if"; }
-  bool eval_not_null_tables(void *opt_arg);
-  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "if"; }
+  bool eval_not_null_tables(void *opt_arg) override;
+  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_if>(thd, this); }
 private:
   void cache_type_info(Item *source);
@@ -1237,18 +1237,18 @@ private:
 class Item_func_nvl2 :public Item_func_case_abbreviation2_switch
 {
 protected:
-  Item *find_item() const { return args[0]->is_null() ? args[2] : args[1]; }
+  Item *find_item() const override { return args[0]->is_null() ? args[2] : args[1]; }
 
 public:
   Item_func_nvl2(THD *thd, Item *a, Item *b, Item *c):
     Item_func_case_abbreviation2_switch(thd, a, b, c)
   {}
-  const char *func_name() const { return "nvl2"; }
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "nvl2"; }
+  bool fix_length_and_dec() override
   {
     return fix_length_and_dec2_eliminate_null(args + 1);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_nvl2>(thd, this); }
 };
 
@@ -1295,28 +1295,28 @@ public:
     m_cache(NULL),
     m_arg0(NULL)
   { arg_count--; }
-  void cleanup()
+  void cleanup() override
   {
     Item_func_hybrid_field_type::cleanup();
     arg_count= 2; // See the comment to the constructor
   }
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool time_op(THD *thd, MYSQL_TIME *ltime);
-  double real_op();
-  longlong int_op();
-  String *str_op(String *str);
-  my_decimal *decimal_op(my_decimal *);
-  bool native_op(THD *thd, Native *to);
-  bool fix_length_and_dec();
-  bool walk(Item_processor processor, bool walk_subquery, void *arg);
-  const char *func_name() const { return "nullif"; }
-  void print(String *str, enum_query_type query_type);
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override;
+  double real_op() override;
+  longlong int_op() override;
+  String *str_op(String *str) override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool native_op(THD *thd, Native *to) override;
+  bool fix_length_and_dec() override;
+  bool walk(Item_processor processor, bool walk_subquery, void *arg) override;
+  const char *func_name() const override { return "nullif"; }
+  void print(String *str, enum_query_type query_type) override;
   void split_sum_func(THD *thd, Ref_ptr_array ref_pointer_array, 
-                      List<Item> &fields, uint flags);
-  void update_used_tables();
-  table_map not_null_tables() const { return 0; }
-  bool is_null();
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+                      List<Item> &fields, uint flags) override;
+  void update_used_tables() override;
+  table_map not_null_tables() const override { return 0; }
+  bool is_null() override;
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     Context cmpctx(ANY_SUBST, cmp.compare_type_handler(),
                               cmp.compare_collation());
@@ -1337,17 +1337,17 @@ public:
                                                            cond, &args[2]);
     return this;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_nullif>(thd, this); }
-  Item *derived_field_transformer_for_having(THD *thd, uchar *arg)
+  Item *derived_field_transformer_for_having(THD *thd, uchar *arg) override
   { reset_first_arg_if_needed(); return this; }
-  Item *derived_field_transformer_for_where(THD *thd, uchar *arg)
+  Item *derived_field_transformer_for_where(THD *thd, uchar *arg) override
   { reset_first_arg_if_needed(); return this; }
-  Item *grouping_field_transformer_for_where(THD *thd, uchar *arg)
+  Item *grouping_field_transformer_for_where(THD *thd, uchar *arg) override
   { reset_first_arg_if_needed(); return this; }
-  Item *in_subq_field_transformer_for_where(THD *thd, uchar *arg)
+  Item *in_subq_field_transformer_for_where(THD *thd, uchar *arg) override
   { reset_first_arg_if_needed(); return this; }
-  Item *in_subq_field_transformer_for_having(THD *thd, uchar *arg)
+  Item *in_subq_field_transformer_for_having(THD *thd, uchar *arg) override
   { reset_first_arg_if_needed(); return this; }
 };
 
@@ -1435,16 +1435,16 @@ class in_string :public in_vector
 public:
   in_string(THD *thd, uint elements, qsort2_cmp cmp_func, CHARSET_INFO *cs);
   ~in_string();
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
-  Item* create_item(THD *thd);
-  void value_to_item(uint pos, Item *item)
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
+  Item* create_item(THD *thd) override;
+  void value_to_item(uint pos, Item *item) override
   {    
     String *str=((String*) base)+pos;
     Item_string_for_in_vector *to= (Item_string_for_in_vector*) item;
     to->set_value(str);
   }
-  const Type_handler *type_handler() const { return &type_handler_varchar; }
+  const Type_handler *type_handler() const override { return &type_handler_varchar; }
 };
 
 class in_longlong :public in_vector
@@ -1462,16 +1462,16 @@ protected:
   } tmp;
 public:
   in_longlong(THD *thd, uint elements);
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
-  Item* create_item(THD *thd);
-  void value_to_item(uint pos, Item *item)
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
+  Item* create_item(THD *thd) override;
+  void value_to_item(uint pos, Item *item) override
   {
     ((Item_int*) item)->value= ((packed_longlong*) base)[pos].val;
     ((Item_int*) item)->unsigned_flag= (bool)
       ((packed_longlong*) base)[pos].unsigned_flag;
   }
-  const Type_handler *type_handler() const { return &type_handler_slonglong; }
+  const Type_handler *type_handler() const override { return &type_handler_slonglong; }
 
   friend int cmp_longlong(void *cmp_arg, packed_longlong *a,packed_longlong *b);
 };
@@ -1482,11 +1482,11 @@ class in_timestamp :public in_vector
   Timestamp_or_zero_datetime tmp;
 public:
   in_timestamp(THD *thd, uint elements);
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
-  Item* create_item(THD *thd);
-  void value_to_item(uint pos, Item *item);
-  const Type_handler *type_handler() const { return &type_handler_timestamp2; }
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
+  Item* create_item(THD *thd) override;
+  void value_to_item(uint pos, Item *item) override;
+  const Type_handler *type_handler() const override { return &type_handler_timestamp2; }
 };
 
 
@@ -1500,8 +1500,8 @@ public:
 
   in_temporal(THD *thd, uint elements)
     :in_longlong(thd, elements) {};
-  Item *create_item(THD *thd);
-  void value_to_item(uint pos, Item *item)
+  Item *create_item(THD *thd) override;
+  void value_to_item(uint pos, Item *item) override
   {
     packed_longlong *val= reinterpret_cast<packed_longlong*>(base)+pos;
     Item_datetime *dt= static_cast<Item_datetime*>(item);
@@ -1517,9 +1517,9 @@ public:
   in_datetime(THD *thd, uint elements)
    :in_temporal(thd, elements)
   {}
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
-  const Type_handler *type_handler() const { return &type_handler_datetime2; }
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
+  const Type_handler *type_handler() const override { return &type_handler_datetime2; }
 };
 
 
@@ -1529,9 +1529,9 @@ public:
   in_time(THD *thd, uint elements)
    :in_temporal(thd, elements)
   {}
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
-  const Type_handler *type_handler() const { return &type_handler_time2; }
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
+  const Type_handler *type_handler() const override { return &type_handler_time2; }
 };
 
 
@@ -1540,14 +1540,14 @@ class in_double :public in_vector
   double tmp;
 public:
   in_double(THD *thd, uint elements);
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
-  Item *create_item(THD *thd);
-  void value_to_item(uint pos, Item *item)
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
+  Item *create_item(THD *thd) override;
+  void value_to_item(uint pos, Item *item) override
   {
     ((Item_float*)item)->value= ((double*) base)[pos];
   }
-  const Type_handler *type_handler() const { return &type_handler_double; }
+  const Type_handler *type_handler() const override { return &type_handler_double; }
 };
 
 
@@ -1556,16 +1556,16 @@ class in_decimal :public in_vector
   my_decimal val;
 public:
   in_decimal(THD *thd, uint elements);
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
-  Item *create_item(THD *thd);
-  void value_to_item(uint pos, Item *item)
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
+  Item *create_item(THD *thd) override;
+  void value_to_item(uint pos, Item *item) override
   {
     my_decimal *dec= ((my_decimal *)base) + pos;
     Item_decimal *item_dec= (Item_decimal*)item;
     item_dec->set_decimal_value(dec);
   }
-  const Type_handler *type_handler() const { return &type_handler_newdecimal; }
+  const Type_handler *type_handler() const override { return &type_handler_newdecimal; }
 };
 
 
@@ -1634,7 +1634,7 @@ public:
   cmp_item_sort_string(CHARSET_INFO *cs):
     cmp_item_string(cs),
     value(value_buff, sizeof(value_buff), cs) {}
-  void store_value(Item *item)
+  void store_value(Item *item) override
   {
     value_res= item->val_str(&value);
     m_null_value= item->null_value;
@@ -1646,13 +1646,13 @@ public:
       value_res= &value;
     }
   }
-  int cmp_not_null(const Value *val)
+  int cmp_not_null(const Value *val) override
   {
     DBUG_ASSERT(!val->is_null());
     DBUG_ASSERT(val->is_string());
     return sortcmp(value_res, &val->m_string, cmp_charset) != 0;
   }
-  int cmp(Item *arg)
+  int cmp(Item *arg) override
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String tmp(buff, sizeof(buff), cmp_charset), *res= arg->val_str(&tmp);
@@ -1665,12 +1665,12 @@ public:
     else
       return TRUE;
   }
-  int compare(cmp_item *ci)
+  int compare(cmp_item *ci) override
   {
     cmp_item_string *l_cmp= (cmp_item_string *) ci;
     return sortcmp(value_res, l_cmp->value_res, cmp_charset);
   } 
-  cmp_item *make_same();
+  cmp_item *make_same() override;
   void set_charset(CHARSET_INFO *cs)
   {
     cmp_charset= cs;
@@ -1683,28 +1683,28 @@ class cmp_item_int : public cmp_item_scalar
   longlong value;
 public:
   cmp_item_int() = default;                           /* Remove gcc warning */
-  void store_value(Item *item)
+  void store_value(Item *item) override
   {
     value= item->val_int();
     m_null_value= item->null_value;
   }
-  int cmp_not_null(const Value *val)
+  int cmp_not_null(const Value *val) override
   {
     DBUG_ASSERT(!val->is_null());
     DBUG_ASSERT(val->is_longlong());
     return value != val->value.m_longlong;
   }
-  int cmp(Item *arg)
+  int cmp(Item *arg) override
   {
     const bool rc= value != arg->val_int();
     return (m_null_value || arg->null_value) ? UNKNOWN : rc;
   }
-  int compare(cmp_item *ci)
+  int compare(cmp_item *ci) override
   {
     cmp_item_int *l_cmp= (cmp_item_int *)ci;
     return (value < l_cmp->value) ? -1 : ((value == l_cmp->value) ? 0 : 1);
   }
-  cmp_item *make_same();
+  cmp_item *make_same() override;
 };
 
 /*
@@ -1716,7 +1716,7 @@ protected:
   longlong value;
 public:
   cmp_item_temporal() = default;
-  int compare(cmp_item *ci);
+  int compare(cmp_item *ci) override;
 };
 
 
@@ -1726,14 +1726,14 @@ public:
   cmp_item_datetime()
    :cmp_item_temporal()
   { }
-  void store_value(Item *item)
+  void store_value(Item *item) override
   {
     value= item->val_datetime_packed(current_thd);
     m_null_value= item->null_value;
   }
-  int cmp_not_null(const Value *val);
-  int cmp(Item *arg);
-  cmp_item *make_same();
+  int cmp_not_null(const Value *val) override;
+  int cmp(Item *arg) override;
+  cmp_item *make_same() override;
 };
 
 
@@ -1743,14 +1743,14 @@ public:
   cmp_item_time()
    :cmp_item_temporal()
   { }
-  void store_value(Item *item)
+  void store_value(Item *item) override
   {
     value= item->val_time_packed(current_thd);
     m_null_value= item->null_value;
   }
-  int cmp_not_null(const Value *val);
-  int cmp(Item *arg);
-  cmp_item *make_same();
+  int cmp_not_null(const Value *val) override;
+  int cmp(Item *arg) override;
+  cmp_item *make_same() override;
 };
 
 
@@ -1759,11 +1759,11 @@ class cmp_item_timestamp: public cmp_item_scalar
   Timestamp_or_zero_datetime_native m_native;
 public:
   cmp_item_timestamp() :cmp_item_scalar() { }
-  void store_value(Item *item);
-  int cmp_not_null(const Value *val);
-  int cmp(Item *arg);
-  int compare(cmp_item *ci);
-  cmp_item *make_same();
+  void store_value(Item *item) override;
+  int cmp_not_null(const Value *val) override;
+  int cmp(Item *arg) override;
+  int compare(cmp_item *ci) override;
+  cmp_item *make_same() override;
 };
 
 
@@ -1772,28 +1772,28 @@ class cmp_item_real : public cmp_item_scalar
   double value;
 public:
   cmp_item_real() = default;                          /* Remove gcc warning */
-  void store_value(Item *item)
+  void store_value(Item *item) override
   {
     value= item->val_real();
     m_null_value= item->null_value;
   }
-  int cmp_not_null(const Value *val)
+  int cmp_not_null(const Value *val) override
   {
     DBUG_ASSERT(!val->is_null());
     DBUG_ASSERT(val->is_double());
     return value != val->value.m_double;
   }
-  int cmp(Item *arg)
+  int cmp(Item *arg) override
   {
     const bool rc= value != arg->val_real();
     return (m_null_value || arg->null_value) ? UNKNOWN : rc;
   }
-  int compare(cmp_item *ci)
+  int compare(cmp_item *ci) override
   {
     cmp_item_real *l_cmp= (cmp_item_real *) ci;
     return (value < l_cmp->value)? -1 : ((value == l_cmp->value) ? 0 : 1);
   }
-  cmp_item *make_same();
+  cmp_item *make_same() override;
 };
 
 
@@ -1802,11 +1802,11 @@ class cmp_item_decimal : public cmp_item_scalar
   my_decimal value;
 public:
   cmp_item_decimal() = default;                       /* Remove gcc warning */
-  void store_value(Item *item);
-  int cmp(Item *arg);
-  int cmp_not_null(const Value *val);
-  int compare(cmp_item *c);
-  cmp_item *make_same();
+  void store_value(Item *item) override;
+  int cmp(Item *arg) override;
+  int cmp_not_null(const Value *val) override;
+  int compare(cmp_item *c) override;
+  cmp_item *make_same() override;
 };
 
 
@@ -1822,28 +1822,28 @@ class cmp_item_sort_string_in_static :public cmp_item_string
 public:
   cmp_item_sort_string_in_static(CHARSET_INFO *cs):
     cmp_item_string(cs) {}
-  void store_value(Item *item)
+  void store_value(Item *item) override
   {
     value_res= item->val_str(&value);
     m_null_value= item->null_value;
   }
-  int cmp_not_null(const Value *val)
+  int cmp_not_null(const Value *val) override
   {
     DBUG_ASSERT(false);
     return TRUE;
   }
-  int cmp(Item *item)
+  int cmp(Item *item) override
   {
     // Should never be called
     DBUG_ASSERT(false);
     return TRUE;
   }
-  int compare(cmp_item *ci)
+  int compare(cmp_item *ci) override
   {
     cmp_item_string *l_cmp= (cmp_item_string *) ci;
     return sortcmp(value_res, l_cmp->value_res, cmp_charset);
   }
-  cmp_item *make_same()
+  cmp_item *make_same() override
   {
     return new cmp_item_sort_string_in_static(cmp_charset);
   }
@@ -2229,18 +2229,18 @@ public:
   Item_func_case(THD *thd, List<Item> &list)
    :Item_func_case_expression(thd, list)
   { }
-  double real_op();
-  longlong int_op();
-  String *str_op(String *);
-  my_decimal *decimal_op(my_decimal *);
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool time_op(THD *thd, MYSQL_TIME *ltime);
-  bool native_op(THD *thd, Native *to);
-  bool fix_fields(THD *thd, Item **ref);
-  table_map not_null_tables() const { return 0; }
-  const char *func_name() const { return "case"; }
+  double real_op() override;
+  longlong int_op() override;
+  String *str_op(String *) override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override;
+  bool native_op(THD *thd, Native *to) override;
+  bool fix_fields(THD *thd, Item **ref) override;
+  table_map not_null_tables() const override { return 0; }
+  const char *func_name() const override { return "case"; }
   CHARSET_INFO *compare_collation() const { return cmp_collation.collation; }
-  bool need_parentheses_in_default() { return true; }
+  bool need_parentheses_in_default() override { return true; }
 };
 
 
@@ -2255,7 +2255,7 @@ class Item_func_case_searched: public Item_func_case
 {
   uint when_count() const { return arg_count / 2; }
   bool with_else() const { return arg_count % 2; }
-  Item **else_expr_addr() const { return with_else() ? &args[arg_count - 1] : 0; }
+  Item **else_expr_addr() const override { return with_else() ? &args[arg_count - 1] : 0; }
 public:
   Item_func_case_searched(THD *thd, List<Item> &list)
    :Item_func_case(thd, list)
@@ -2263,17 +2263,17 @@ public:
     DBUG_ASSERT(arg_count >= 2);
     reorder_args(0);
   }
-  enum Functype functype() const   { return CASE_SEARCHED_FUNC; }
-  void print(String *str, enum_query_type query_type);
-  bool fix_length_and_dec();
-  Item *propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  enum Functype functype() const override   { return CASE_SEARCHED_FUNC; }
+  void print(String *str, enum_query_type query_type) override;
+  bool fix_length_and_dec() override;
+  Item *propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     // None of the arguments are in a comparison context
     Item_args::propagate_equal_fields(thd, Context_identity(), cond);
     return this;
   }
-  Item *find_item();
-  Item *get_copy(THD *thd)
+  Item *find_item() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_case_searched>(thd, this); }
 };
 
@@ -2296,7 +2296,7 @@ protected:
   uint m_found_types;
   uint when_count() const { return (arg_count - 1) / 2; }
   bool with_else() const { return arg_count % 2 == 0; }
-  Item **else_expr_addr() const { return with_else() ? &args[arg_count - 1] : 0; }
+  Item **else_expr_addr() const override { return with_else() ? &args[arg_count - 1] : 0; }
   bool aggregate_switch_and_when_arguments(THD *thd, bool nulls_equal);
   bool prepare_predicant_and_values(THD *thd, uint *found_types,
                                               bool nulls_equal);
@@ -2309,19 +2309,19 @@ public:
     DBUG_ASSERT(arg_count >= 3);
     reorder_args(1);
   }
-  void cleanup()
+  void cleanup() override
   {
     DBUG_ENTER("Item_func_case_simple::cleanup");
     Item_func::cleanup();
     Predicant_to_list_comparator::cleanup();
     DBUG_VOID_RETURN;
   }
-  enum Functype functype() const   { return CASE_SIMPLE_FUNC; }
-  void print(String *str, enum_query_type query_type);
-  bool fix_length_and_dec();
-  Item *propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond);
-  Item *find_item();
-  Item *build_clone(THD *thd)
+  enum Functype functype() const override   { return CASE_SIMPLE_FUNC; }
+  void print(String *str, enum_query_type query_type) override;
+  bool fix_length_and_dec() override;
+  Item *propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override;
+  Item *find_item() override;
+  Item *build_clone(THD *thd) override
   {
     Item_func_case_simple *clone= (Item_func_case_simple *)
                                   Item_func_case::build_clone(thd);
@@ -2330,7 +2330,7 @@ public:
       return NULL;
     return clone;
   } 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_case_simple>(thd, this); }
 };
 
@@ -2341,12 +2341,12 @@ public:
   Item_func_decode_oracle(THD *thd, List<Item> &list)
    :Item_func_case_simple(thd, list)
   { }
-  const Schema *schema() const { return &oracle_schema_ref; }
-  const char *func_name() const { return "decode"; }
-  void print(String *str, enum_query_type query_type);
-  bool fix_length_and_dec();
-  Item *find_item();
-  Item *get_copy(THD *thd)
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  const char *func_name() const override { return "decode"; }
+  void print(String *str, enum_query_type query_type) override;
+  bool fix_length_and_dec() override;
+  Item *find_item() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_decode_oracle>(thd, this); }
 };
 
@@ -2397,13 +2397,13 @@ class Item_func_in :public Item_func_opt_neg,
     return true;
   }
   bool prepare_predicant_and_values(THD *thd, uint *found_types);
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return check_argument_types_like_args0();
   }
 protected:
   SEL_TREE *get_func_mm_tree(RANGE_OPT_PARAM *param,
-                             Field *field, Item *value);
+                             Field *field, Item *value) override;
   bool transform_into_subq;
   bool transform_into_subq_checked;
 public:
@@ -2432,9 +2432,9 @@ public:
     array(0), have_null(0),
     arg_types_compatible(FALSE), emb_on_expr_nest(0)
   { }
-  longlong val_int();
-  bool fix_fields(THD *, Item **);
-  bool fix_length_and_dec();
+  longlong val_int() override;
+  bool fix_fields(THD *, Item **) override;
+  bool fix_length_and_dec() override;
   bool compatible_types_scalar_bisection_possible()
   {
     DBUG_ASSERT(m_comparator.cmp_type() != ROW_RESULT);
@@ -2466,7 +2466,7 @@ public:
   bool fix_for_row_comparison_using_cmp_items(THD *thd);
   bool fix_for_row_comparison_using_bisection(THD *thd);
 
-  void cleanup()
+  void cleanup() override
   {
     DBUG_ENTER("Item_func_in::cleanup");
     Item_int_func::cleanup();
@@ -2476,10 +2476,10 @@ public:
     DBUG_VOID_RETURN;
   }
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields, uint *and_level,
-                      table_map usable_tables, SARGABLE_PARAM **sargables);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr);
+                      table_map usable_tables, SARGABLE_PARAM **sargables) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
   SEL_TREE *get_func_row_mm_tree(RANGE_OPT_PARAM *param, Item_row *key_row); 
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     /*
       Note, we pass ANY_SUBST, this makes sure that non of the args
@@ -2503,17 +2503,17 @@ public:
     }
     return this;
   }
-  virtual void print(String *str, enum_query_type query_type);
-  enum Functype functype() const { return IN_FUNC; }
-  const char *func_name() const { return "in"; }
-  enum precedence precedence() const { return IN_PRECEDENCE; }
-  bool eval_not_null_tables(void *opt_arg);
-  bool find_not_null_fields(table_map allowed);
-  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge);
-  bool count_sargable_conds(void *arg);
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  enum Functype functype() const override { return IN_FUNC; }
+  const char *func_name() const override { return "in"; }
+  enum precedence precedence() const override { return IN_PRECEDENCE; }
+  bool eval_not_null_tables(void *opt_arg) override;
+  bool find_not_null_fields(table_map allowed) override;
+  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
+  bool count_sargable_conds(void *arg) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_in>(thd, this); }
-  Item *build_clone(THD *thd)
+  Item *build_clone(THD *thd) override
   {
     Item_func_in *clone= (Item_func_in *) Item_func::build_clone(thd);
     if (clone)
@@ -2524,10 +2524,10 @@ public:
     }
     return clone;
   }
-  void mark_as_condition_AND_part(TABLE_LIST *embedding);
+  void mark_as_condition_AND_part(TABLE_LIST *embedding) override;
   bool to_be_transformed_into_in_subq(THD *thd);
   bool create_value_list_for_tvc(THD *thd, List< List<Item> > *values);
-  Item *in_predicate_to_in_subs_transformer(THD *thd, uchar *arg);
+  Item *in_predicate_to_in_subs_transformer(THD *thd, uchar *arg) override;
   uint32 max_length_of_left_expr();
 };
 
@@ -2568,10 +2568,10 @@ class in_row :public in_vector
 public:
   in_row(THD *thd, uint elements, Item *);
   ~in_row();
-  bool set(uint pos, Item *item);
-  uchar *get_value(Item *item);
+  bool set(uint pos, Item *item) override;
+  uchar *get_value(Item *item) override;
   friend class Item_func_in;
-  const Type_handler *type_handler() const { return &type_handler_row; }
+  const Type_handler *type_handler() const override { return &type_handler_row; }
   cmp_item *get_cmp_item() { return &tmp; }
 };
 
@@ -2580,19 +2580,19 @@ class Item_func_null_predicate :public Item_bool_func
 {
 protected:
   SEL_TREE *get_func_mm_tree(RANGE_OPT_PARAM *param,
-                             Field *field, Item *value)
+                             Field *field, Item *value) override
   {
     DBUG_ENTER("Item_func_null_predicate::get_func_mm_tree");
     DBUG_RETURN(get_mm_parts(param, field, functype(), value));
   }
   SEL_ARG *get_mm_leaf(RANGE_OPT_PARAM *param, Field *field,
                        KEY_PART *key_part,
-                       Item_func::Functype type, Item *value);
+                       Item_func::Functype type, Item *value) override;
 public:
   Item_func_null_predicate(THD *thd, Item *a): Item_bool_func(thd, a) { }
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields, uint *and_level,
-                      table_map usable_tables, SARGABLE_PARAM **sargables);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr)
+                      table_map usable_tables, SARGABLE_PARAM **sargables) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override
   {
     DBUG_ENTER("Item_func_null_predicate::get_mm_tree");
     SEL_TREE *ftree= get_full_func_mm_tree_for_args(param, args[0], NULL);
@@ -2600,14 +2600,14 @@ public:
       ftree= Item_func::get_mm_tree(param, cond_ptr);
     DBUG_RETURN(ftree);
   }
-  CHARSET_INFO *compare_collation() const
+  CHARSET_INFO *compare_collation() const override
   { return args[0]->collation.collation; }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals=0; max_length=1; maybe_null=0;
     return FALSE;
   }
-  bool count_sargable_conds(void *arg);
+  bool count_sargable_conds(void *arg) override;
 };
 
 
@@ -2615,11 +2615,11 @@ class Item_func_isnull :public Item_func_null_predicate
 {
 public:
   Item_func_isnull(THD *thd, Item *a): Item_func_null_predicate(thd, a) {}
-  longlong val_int();
-  enum Functype functype() const { return ISNULL_FUNC; }
-  const char *func_name() const { return "isnull"; }
-  void print(String *str, enum_query_type query_type);
-  enum precedence precedence() const { return CMP_PRECEDENCE; }
+  longlong val_int() override;
+  enum Functype functype() const override { return ISNULL_FUNC; }
+  const char *func_name() const override { return "isnull"; }
+  void print(String *str, enum_query_type query_type) override;
+  enum precedence precedence() const override { return CMP_PRECEDENCE; }
 
   bool arg_is_datetime_notnull_field()
   {
@@ -2636,7 +2636,7 @@ public:
   }
 
   /* Optimize case of not_null_column IS NULL */
-  virtual void update_used_tables()
+  void update_used_tables() override
   {
     if (!args[0]->maybe_null && !arg_is_datetime_notnull_field())
     {
@@ -2651,11 +2651,11 @@ public:
     }
   }
   COND *remove_eq_conds(THD *thd, Item::cond_result *cond_value,
-                        bool top_level);
-  table_map not_null_tables() const { return 0; }
-  bool find_not_null_fields(table_map allowed);
-  Item *neg_transformer(THD *thd);
-  Item *get_copy(THD *thd)
+                        bool top_level) override;
+  table_map not_null_tables() const override { return 0; }
+  bool find_not_null_fields(table_map allowed) override;
+  Item *neg_transformer(THD *thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isnull>(thd, this); }
 };
 
@@ -2674,16 +2674,16 @@ public:
   Item_is_not_null_test(THD *thd, Item_in_subselect* ow, Item *a):
     Item_func_isnull(thd, a), owner(ow)
   {}
-  enum Functype functype() const { return ISNOTNULLTEST_FUNC; }
-  longlong val_int();
-  const char *func_name() const { return "<is_not_null_test>"; }
-  void update_used_tables();
+  enum Functype functype() const override { return ISNOTNULLTEST_FUNC; }
+  longlong val_int() override;
+  const char *func_name() const override { return "<is_not_null_test>"; }
+  void update_used_tables() override;
   /*
     we add RAND_TABLE_BIT to prevent moving this item from HAVING to WHERE
   */
-  table_map used_tables() const
+  table_map used_tables() const override
     { return used_tables_cache | RAND_TABLE_BIT; }
-  bool const_item() const { return FALSE; }
+  bool const_item() const override { return FALSE; }
 };
 
 
@@ -2694,16 +2694,16 @@ public:
   Item_func_isnotnull(THD *thd, Item *a):
     Item_func_null_predicate(thd, a), abort_on_null(0)
   { }
-  longlong val_int();
-  enum Functype functype() const { return ISNOTNULL_FUNC; }
-  const char *func_name() const { return "isnotnull"; }
-  enum precedence precedence() const { return CMP_PRECEDENCE; }
-  table_map not_null_tables() const
+  longlong val_int() override;
+  enum Functype functype() const override { return ISNOTNULL_FUNC; }
+  const char *func_name() const override { return "isnotnull"; }
+  enum precedence precedence() const override { return CMP_PRECEDENCE; }
+  table_map not_null_tables() const override
   { return abort_on_null ? not_null_tables_cache : 0; }
-  Item *neg_transformer(THD *thd);
-  void print(String *str, enum_query_type query_type);
-  void top_level_item() { abort_on_null=1; }
-  Item *get_copy(THD *thd)
+  Item *neg_transformer(THD *thd) override;
+  void print(String *str, enum_query_type query_type) override;
+  void top_level_item() override { abort_on_null=1; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isnotnull>(thd, this); }
 };
 
@@ -2735,14 +2735,14 @@ class Item_func_like :public Item_bool_func2
   bool with_sargable_pattern() const;
 protected:
   SEL_TREE *get_func_mm_tree(RANGE_OPT_PARAM *param,
-                             Field *field, Item *value)
+                             Field *field, Item *value) override
   {
     DBUG_ENTER("Item_func_like::get_func_mm_tree");
     DBUG_RETURN(get_mm_parts(param, field, LIKE_FUNC, value));
   }
   SEL_ARG *get_mm_leaf(RANGE_OPT_PARAM *param, Field *field,
                        KEY_PART *key_part,
-                       Item_func::Functype type, Item *value);
+                       Item_func::Functype type, Item *value) override;
 public:
   int escape;
   bool negated;
@@ -2754,13 +2754,13 @@ public:
 
   bool get_negated() const { return negated; } // Used by ColumnStore
 
-  Sql_mode_dependency value_depends_on_sql_mode() const;
-  longlong val_int();
-  enum Functype functype() const { return LIKE_FUNC; }
-  void print(String *str, enum_query_type query_type);
-  CHARSET_INFO *compare_collation() const
+  Sql_mode_dependency value_depends_on_sql_mode() const override;
+  longlong val_int() override;
+  enum Functype functype() const override { return LIKE_FUNC; }
+  void print(String *str, enum_query_type query_type) override;
+  CHARSET_INFO *compare_collation() const override
   { return cmp_collation.collation; }
-  cond_result eq_cmp_result() const
+  cond_result eq_cmp_result() const override
   {
     /**
       We cannot always rewrite conditions as follows:
@@ -2796,9 +2796,9 @@ public:
     return compare_collation() == &my_charset_bin ? COND_TRUE : COND_OK;
   }
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields, uint *and_level,
-                      table_map usable_tables, SARGABLE_PARAM **sargables);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr);
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+                      table_map usable_tables, SARGABLE_PARAM **sargables) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     /*
       LIKE differs from the regular comparison operator ('=') in the following:
@@ -2831,32 +2831,32 @@ public:
                                         cond);
     return this;
   }
-  const char *func_name() const { return "like"; }
-  enum precedence precedence() const { return IN_PRECEDENCE; }
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "like"; }
+  enum precedence precedence() const override { return IN_PRECEDENCE; }
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override
   {
     max_length= 1;
     return agg_arg_charsets_for_comparison(cmp_collation, args, 2);
   }
-  void cleanup();
+  void cleanup() override;
 
-  Item *neg_transformer(THD *thd)
+  Item *neg_transformer(THD *thd) override
   {
     negated= !negated;
     return this;
   }
 
-  bool walk(Item_processor processor, bool walk_subquery, void *arg)
+  bool walk(Item_processor processor, bool walk_subquery, void *arg) override
   {
     return walk_args(processor, walk_subquery, arg)
       ||   escape_item->walk(processor, walk_subquery, arg)
       ||  (this->*processor)(arg);
   }
 
-  bool find_selective_predicates_list_processor(void *arg);
+  bool find_selective_predicates_list_processor(void *arg) override;
   
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_like>(thd, this); }
 };
 
@@ -2938,24 +2938,24 @@ class Item_func_regex :public Item_bool_func
 public:
   Item_func_regex(THD *thd, Item *a, Item *b): Item_bool_func(thd, a, b)
   {}
-  void cleanup()
+  void cleanup() override
   {
     DBUG_ENTER("Item_func_regex::cleanup");
     Item_bool_func::cleanup();
     re.cleanup();
     DBUG_VOID_RETURN;
   }
-  longlong val_int();
-  bool fix_length_and_dec();
-  const char *func_name() const { return "regexp"; }
-  enum precedence precedence() const { return IN_PRECEDENCE; }
-  Item *get_copy(THD *) { return 0; }
-  void print(String *str, enum_query_type query_type)
+  longlong val_int() override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "regexp"; }
+  enum precedence precedence() const override { return IN_PRECEDENCE; }
+  Item *get_copy(THD *) override { return 0; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_op(str, query_type);
   }
 
-  CHARSET_INFO *compare_collation() const { return cmp_collation.collation; }
+  CHARSET_INFO *compare_collation() const override { return cmp_collation.collation; }
 };
 
 
@@ -2967,7 +2967,7 @@ public:
 */
 class Item_func_regexp_instr :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_can_return_str(func_name()) ||
            args[1]->check_type_can_return_text(func_name());
@@ -2978,17 +2978,17 @@ public:
   Item_func_regexp_instr(THD *thd, Item *a, Item *b)
    :Item_long_func(thd, a, b)
   {}
-  void cleanup()
+  void cleanup() override
   {
     DBUG_ENTER("Item_func_regexp_instr::cleanup");
     Item_int_func::cleanup();
     re.cleanup();
     DBUG_VOID_RETURN;
   }
-  longlong val_int();
-  bool fix_length_and_dec();
-  const char *func_name() const { return "regexp_instr"; }
-  Item *get_copy(THD *thd) { return 0; }
+  longlong val_int() override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "regexp_instr"; }
+  Item *get_copy(THD *thd) override { return 0; }
 };
 
 
@@ -3029,64 +3029,64 @@ public:
     DBUG_ASSERT(nlist->elements);
     list.append(nlist);
   }
-  bool fix_fields(THD *, Item **ref);
-  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge);
+  bool fix_fields(THD *, Item **ref) override;
+  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
 
-  enum Type type() const { return COND_ITEM; }
+  enum Type type() const override { return COND_ITEM; }
   List<Item>* argument_list() { return &list; }
-  table_map used_tables() const;
-  void update_used_tables()
+  table_map used_tables() const override;
+  void update_used_tables() override
   {
     used_tables_and_const_cache_init();
     used_tables_and_const_cache_update_and_join(list);
   }
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
-                          COND_EQUAL **cond_equal_ref);
+                          COND_EQUAL **cond_equal_ref) override;
   COND *remove_eq_conds(THD *thd, Item::cond_result *cond_value,
-                        bool top_level);
+                        bool top_level) override;
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr);
-  virtual void print(String *str, enum_query_type query_type);
+                      SARGABLE_PARAM **sargables) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
+  void print(String *str, enum_query_type query_type) override;
   void split_sum_func(THD *thd, Ref_ptr_array ref_pointer_array,
-                      List<Item> &fields, uint flags);
+                      List<Item> &fields, uint flags) override;
   friend int setup_conds(THD *thd, TABLE_LIST *tables, TABLE_LIST *leaves,
                          COND **conds);
-  void top_level_item() { abort_on_null=1; }
+  void top_level_item() override { abort_on_null=1; }
   bool top_level() { return abort_on_null; }
   void copy_andor_arguments(THD *thd, Item_cond *item);
-  bool walk(Item_processor processor, bool walk_subquery, void *arg);
+  bool walk(Item_processor processor, bool walk_subquery, void *arg) override;
   Item *do_transform(THD *thd, Item_transformer transformer, uchar *arg, bool toplevel);
-  Item *transform(THD *thd, Item_transformer transformer, uchar *arg)
+  Item *transform(THD *thd, Item_transformer transformer, uchar *arg) override
   {
     return do_transform(thd, transformer, arg, 0);
   }
-  Item *top_level_transform(THD *thd, Item_transformer transformer, uchar *arg)
+  Item *top_level_transform(THD *thd, Item_transformer transformer, uchar *arg) override
   {
     return do_transform(thd, transformer, arg, 1);
   }
-  void traverse_cond(Cond_traverser, void *arg, traverse_order order);
+  void traverse_cond(Cond_traverser, void *arg, traverse_order order) override;
   void neg_arguments(THD *thd);
-  Item* propagate_equal_fields(THD *, const Context &, COND_EQUAL *);
+  Item* propagate_equal_fields(THD *, const Context &, COND_EQUAL *) override;
   Item *do_compile(THD *thd, Item_analyzer analyzer, uchar **arg_p,
                    Item_transformer transformer, uchar *arg_t, bool toplevel);
   Item *compile(THD *thd, Item_analyzer analyzer, uchar **arg_p,
-                Item_transformer transformer, uchar *arg_t)
+                Item_transformer transformer, uchar *arg_t) override
   {
     return do_compile(thd, analyzer, arg_p, transformer, arg_t, 0);
   }
   Item* top_level_compile(THD *thd, Item_analyzer analyzer, uchar **arg_p,
-                          Item_transformer transformer, uchar *arg_t)
+                          Item_transformer transformer, uchar *arg_t) override
   {
     return do_compile(thd, analyzer, arg_p, transformer, arg_t, 1);
   }
-  bool eval_not_null_tables(void *opt_arg);
-  bool find_not_null_fields(table_map allowed);
-  Item *build_clone(THD *thd);
-  bool excl_dep_on_table(table_map tab_map);
-  bool excl_dep_on_grouping_fields(st_select_lex *sel);
+  bool eval_not_null_tables(void *opt_arg) override;
+  bool find_not_null_fields(table_map allowed) override;
+  Item *build_clone(THD *thd) override;
+  bool excl_dep_on_table(table_map tab_map) override;
+  bool excl_dep_on_grouping_fields(st_select_lex *sel) override;
 
 private:
   void merge_sub_condition(List_iterator<Item>& li);
@@ -3240,53 +3240,53 @@ public:
   void merge_into_list(THD *thd, List<Item_equal> *list, bool save_merged,
                       bool only_intersected);
   void update_const(THD *thd);
-  enum Functype functype() const { return MULT_EQUAL_FUNC; }
-  longlong val_int(); 
-  const char *func_name() const { return "multiple equal"; }
+  enum Functype functype() const override { return MULT_EQUAL_FUNC; }
+  longlong val_int() override; 
+  const char *func_name() const override { return "multiple equal"; }
   void sort(Item_field_cmpfunc compare, void *arg);
-  bool fix_length_and_dec();
-  bool fix_fields(THD *thd, Item **ref);
-  void cleanup()
+  bool fix_length_and_dec() override;
+  bool fix_fields(THD *thd, Item **ref) override;
+  void cleanup() override
   {
     delete eval_item;
     eval_item= NULL;
   }
-  void update_used_tables();
-  bool find_not_null_fields(table_map allowed);
+  void update_used_tables() override;
+  bool find_not_null_fields(table_map allowed) override;
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
-                          COND_EQUAL **cond_equal_ref);
+                          COND_EQUAL **cond_equal_ref) override;
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr);
-  bool walk(Item_processor processor, bool walk_subquery, void *arg);
-  Item *transform(THD *thd, Item_transformer transformer, uchar *arg);
-  virtual void print(String *str, enum_query_type query_type);
+                      SARGABLE_PARAM **sargables) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
+  bool walk(Item_processor processor, bool walk_subquery, void *arg) override;
+  Item *transform(THD *thd, Item_transformer transformer, uchar *arg) override;
+  void print(String *str, enum_query_type query_type) override;
   const Type_handler *compare_type_handler() const { return m_compare_handler; }
-  CHARSET_INFO *compare_collation() const { return m_compare_collation; }
+  CHARSET_INFO *compare_collation() const override { return m_compare_collation; }
 
   void set_context_field(Item_field *ctx_field) { context_field= ctx_field; }
   void set_link_equal_fields(bool flag) { link_equal_fields= flag; }
-  Item* get_copy(THD *thd) { return 0; }
+  Item* get_copy(THD *thd) override { return 0; }
   /*
     This does not comply with the specification of the virtual method,
     but Item_equal items are processed distinguishly anyway
   */
-  bool excl_dep_on_table(table_map tab_map)
+  bool excl_dep_on_table(table_map tab_map) override
   {
     return used_tables() & tab_map;
   }
-  bool excl_dep_on_in_subq_left_part(Item_in_subselect *subq_pred);
-  bool excl_dep_on_grouping_fields(st_select_lex *sel);
+  bool excl_dep_on_in_subq_left_part(Item_in_subselect *subq_pred) override;
+  bool excl_dep_on_grouping_fields(st_select_lex *sel) override;
   bool create_pushable_equalities(THD *thd, List<Item> *equalities,
                                   Pushdown_checker checker, uchar *arg,
                                   bool clone_const);
   /* Return the number of elements in this multiple equality */
   uint elements_count() { return equal_items.elements; }
   friend class Item_equal_fields_iterator;
-  bool count_sargable_conds(void *arg);
-  Item *multiple_equality_transformer(THD *thd, uchar *arg);
+  bool count_sargable_conds(void *arg) override;
+  Item *multiple_equality_transformer(THD *thd, uchar *arg) override;
   friend class Item_equal_iterator<List_iterator_fast,Item>;
   friend class Item_equal_iterator<List_iterator,Item>;
   friend Item *eliminate_item_equal(THD *thd, COND *cond,
@@ -3416,24 +3416,24 @@ public:
   Item_cond_and(THD *thd, Item *i1,Item *i2): Item_cond(thd, i1, i2) {}
   Item_cond_and(THD *thd, Item_cond_and *item): Item_cond(thd, item) {}
   Item_cond_and(THD *thd, List<Item> &list_arg): Item_cond(thd, list_arg) {}
-  enum Functype functype() const { return COND_AND_FUNC; }
-  longlong val_int();
-  const char *func_name() const { return "and"; }
-  enum precedence precedence() const { return AND_PRECEDENCE; }
-  table_map not_null_tables() const
+  enum Functype functype() const override { return COND_AND_FUNC; }
+  longlong val_int() override;
+  const char *func_name() const override { return "and"; }
+  enum precedence precedence() const override { return AND_PRECEDENCE; }
+  table_map not_null_tables() const override
   { return abort_on_null ? not_null_tables_cache: and_tables_cache; }
-  Item *copy_andor_structure(THD *thd);
-  Item *neg_transformer(THD *thd);
-  void mark_as_condition_AND_part(TABLE_LIST *embedding);
-  virtual uint exists2in_reserved_items() { return list.elements; };
+  Item *copy_andor_structure(THD *thd) override;
+  Item *neg_transformer(THD *thd) override;
+  void mark_as_condition_AND_part(TABLE_LIST *embedding) override;
+  uint exists2in_reserved_items() override { return list.elements; };
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
-                          COND_EQUAL **cond_equal_ref);
-  bool set_format_by_check_constraint(Send_field_extended_metadata *to) const;
+                          COND_EQUAL **cond_equal_ref) override;
+  bool set_format_by_check_constraint(Send_field_extended_metadata *to) const override;
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields, uint *and_level,
-                      table_map usable_tables, SARGABLE_PARAM **sargables);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr);
-  Item *get_copy(THD *thd)
+                      table_map usable_tables, SARGABLE_PARAM **sargables) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_cond_and>(thd, this); }
 };
 
@@ -3450,14 +3450,14 @@ public:
   Item_cond_or(THD *thd, Item *i1,Item *i2): Item_cond(thd, i1, i2) {}
   Item_cond_or(THD *thd, Item_cond_or *item): Item_cond(thd, item) {}
   Item_cond_or(THD *thd, List<Item> &list_arg): Item_cond(thd, list_arg) {}
-  enum Functype functype() const { return COND_OR_FUNC; }
-  longlong val_int();
-  const char *func_name() const { return "or"; }
-  enum precedence precedence() const { return OR_PRECEDENCE; }
-  table_map not_null_tables() const { return and_tables_cache; }
-  Item *copy_andor_structure(THD *thd);
-  Item *neg_transformer(THD *thd);
-  Item *get_copy(THD *thd)
+  enum Functype functype() const override { return COND_OR_FUNC; }
+  longlong val_int() override;
+  const char *func_name() const override { return "or"; }
+  enum precedence precedence() const override { return OR_PRECEDENCE; }
+  table_map not_null_tables() const override { return and_tables_cache; }
+  Item *copy_andor_structure(THD *thd) override;
+  Item *neg_transformer(THD *thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_cond_or>(thd, this); }
 };
 
@@ -3465,10 +3465,10 @@ class Item_func_dyncol_check :public Item_bool_func
 {
 public:
   Item_func_dyncol_check(THD *thd, Item *str): Item_bool_func(thd, str) {}
-  longlong val_int();
-  const char *func_name() const { return "column_check"; }
-  bool need_parentheses_in_default() { return false; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "column_check"; }
+  bool need_parentheses_in_default() override { return false; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dyncol_check>(thd, this); }
 };
 
@@ -3477,10 +3477,10 @@ class Item_func_dyncol_exists :public Item_bool_func
 public:
   Item_func_dyncol_exists(THD *thd, Item *str, Item *num):
     Item_bool_func(thd, str, num) {}
-  longlong val_int();
-  const char *func_name() const { return "column_exists"; }
-  bool need_parentheses_in_default() { return false; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "column_exists"; }
+  bool need_parentheses_in_default() override { return false; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dyncol_exists>(thd, this); }
 };
 
@@ -3491,11 +3491,11 @@ public:
   Item_func_cursor_bool_attr(THD *thd, const LEX_CSTRING *name, uint offset)
    :Item_bool_func(thd), Cursor_ref(name, offset)
   { }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), arg, VCOL_SESSION_FUNC);
   }
-  void print(String *str, enum_query_type query_type)
+  void print(String *str, enum_query_type query_type) override
   {
     Cursor_ref::print_func(str, func_name());
   }
@@ -3507,9 +3507,9 @@ class Item_func_cursor_isopen: public Item_func_cursor_bool_attr
 public:
   Item_func_cursor_isopen(THD *thd, const LEX_CSTRING *name, uint offset)
    :Item_func_cursor_bool_attr(thd, name, offset) { }
-  const char *func_name() const { return "%ISOPEN"; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "%ISOPEN"; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_cursor_isopen>(thd, this); }
 };
 
@@ -3519,9 +3519,9 @@ class Item_func_cursor_found: public Item_func_cursor_bool_attr
 public:
   Item_func_cursor_found(THD *thd, const LEX_CSTRING *name, uint offset)
    :Item_func_cursor_bool_attr(thd, name, offset) { maybe_null= true; }
-  const char *func_name() const { return "%FOUND"; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "%FOUND"; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_cursor_found>(thd, this); }
 };
 
@@ -3531,9 +3531,9 @@ class Item_func_cursor_notfound: public Item_func_cursor_bool_attr
 public:
   Item_func_cursor_notfound(THD *thd, const LEX_CSTRING *name, uint offset)
    :Item_func_cursor_bool_attr(thd, name, offset) { maybe_null= true; }
-  const char *func_name() const { return "%NOTFOUND"; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "%NOTFOUND"; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_cursor_notfound>(thd, this); }
 };
 
@@ -3572,11 +3572,11 @@ class Eq_creator :public Comp_creator
 public:
   Eq_creator() = default;                             /* Remove gcc warning */
   virtual ~Eq_creator() = default;                    /* Remove gcc warning */
-  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const;
-  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const;
-  const char* symbol(bool invert) const { return invert? "<>" : "="; }
-  bool eqne_op() const { return 1; }
-  bool l_op() const { return 0; }
+  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const override;
+  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const override;
+  const char* symbol(bool invert) const override { return invert? "<>" : "="; }
+  bool eqne_op() const override { return 1; }
+  bool l_op() const override { return 0; }
 };
 
 class Ne_creator :public Comp_creator
@@ -3584,11 +3584,11 @@ class Ne_creator :public Comp_creator
 public:
   Ne_creator() = default;                             /* Remove gcc warning */
   virtual ~Ne_creator() = default;                    /* Remove gcc warning */
-  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const;
-  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const;
-  const char* symbol(bool invert) const { return invert? "=" : "<>"; }
-  bool eqne_op() const { return 1; }
-  bool l_op() const { return 0; }
+  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const override;
+  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const override;
+  const char* symbol(bool invert) const override { return invert? "=" : "<>"; }
+  bool eqne_op() const override { return 1; }
+  bool l_op() const override { return 0; }
 };
 
 class Gt_creator :public Comp_creator
@@ -3596,11 +3596,11 @@ class Gt_creator :public Comp_creator
 public:
   Gt_creator() = default;                             /* Remove gcc warning */
   virtual ~Gt_creator() = default;                    /* Remove gcc warning */
-  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const;
-  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const;
-  const char* symbol(bool invert) const { return invert? "<=" : ">"; }
-  bool eqne_op() const { return 0; }
-  bool l_op() const { return 0; }
+  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const override;
+  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const override;
+  const char* symbol(bool invert) const override { return invert? "<=" : ">"; }
+  bool eqne_op() const override { return 0; }
+  bool l_op() const override { return 0; }
 };
 
 class Lt_creator :public Comp_creator
@@ -3608,11 +3608,11 @@ class Lt_creator :public Comp_creator
 public:
   Lt_creator() = default;                             /* Remove gcc warning */
   virtual ~Lt_creator() = default;                    /* Remove gcc warning */
-  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const;
-  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const;
-  const char* symbol(bool invert) const { return invert? ">=" : "<"; }
-  bool eqne_op() const { return 0; }
-  bool l_op() const { return 1; }
+  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const override;
+  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const override;
+  const char* symbol(bool invert) const override { return invert? ">=" : "<"; }
+  bool eqne_op() const override { return 0; }
+  bool l_op() const override { return 1; }
 };
 
 class Ge_creator :public Comp_creator
@@ -3620,11 +3620,11 @@ class Ge_creator :public Comp_creator
 public:
   Ge_creator() = default;                             /* Remove gcc warning */
   virtual ~Ge_creator() = default;                    /* Remove gcc warning */
-  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const;
-  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const;
-  const char* symbol(bool invert) const { return invert? "<" : ">="; }
-  bool eqne_op() const { return 0; }
-  bool l_op() const { return 0; }
+  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const override;
+  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const override;
+  const char* symbol(bool invert) const override { return invert? "<" : ">="; }
+  bool eqne_op() const override { return 0; }
+  bool l_op() const override { return 0; }
 };
 
 class Le_creator :public Comp_creator
@@ -3632,11 +3632,11 @@ class Le_creator :public Comp_creator
 public:
   Le_creator() = default;                             /* Remove gcc warning */
   virtual ~Le_creator() = default;                    /* Remove gcc warning */
-  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const;
-  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const;
-  const char* symbol(bool invert) const { return invert? ">" : "<="; }
-  bool eqne_op() const { return 0; }
-  bool l_op() const { return 1; }
+  Item_bool_rowready_func2* create(THD *thd, Item *a, Item *b) const override;
+  Item_bool_rowready_func2* create_swap(THD *thd, Item *a, Item *b) const override;
+  const char* symbol(bool invert) const override { return invert? ">" : "<="; }
+  bool eqne_op() const override { return 0; }
+  bool l_op() const override { return 1; }
 };
 
 /*

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -66,10 +66,10 @@ extern Native_func_registry_array native_func_registry_array_geom;
 class Create_sp_func : public Create_qfunc
 {
 public:
-  virtual Item *create_with_db(THD *thd,
+  Item *create_with_db(THD *thd,
                                const LEX_CSTRING *db,
                                const LEX_CSTRING *name,
-                               bool use_explicit_name, List<Item> *item_list);
+                               bool use_explicit_name, List<Item> *item_list) override;
 
   static Create_sp_func s_singleton;
 
@@ -77,7 +77,7 @@ protected:
   /** Constructor. */
   Create_sp_func() = default;
   /** Destructor. */
-  virtual ~Create_sp_func() = default;
+  ~Create_sp_func() override = default;
 };
 
 
@@ -90,319 +90,319 @@ protected:
 class Create_func_abs : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_abs s_singleton;
 
 protected:
   Create_func_abs() = default;
-  virtual ~Create_func_abs() = default;
+  ~Create_func_abs() override = default;
 };
 
 
 class Create_func_acos : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_acos s_singleton;
 
 protected:
   Create_func_acos() = default;
-  virtual ~Create_func_acos() = default;
+  ~Create_func_acos() override = default;
 };
 
 
 class Create_func_addtime : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_addtime s_singleton;
 
 protected:
   Create_func_addtime() = default;
-  virtual ~Create_func_addtime() = default;
+  ~Create_func_addtime() override = default;
 };
 
 
 class Create_func_aes_encrypt : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_aes_encrypt s_singleton;
 
 protected:
   Create_func_aes_encrypt() = default;
-  virtual ~Create_func_aes_encrypt() = default;
+  ~Create_func_aes_encrypt() override = default;
 };
 
 
 class Create_func_aes_decrypt : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_aes_decrypt s_singleton;
 
 protected:
   Create_func_aes_decrypt() = default;
-  virtual ~Create_func_aes_decrypt() = default;
+  ~Create_func_aes_decrypt() override = default;
 };
 
 
 class Create_func_asin : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_asin s_singleton;
 
 protected:
   Create_func_asin() = default;
-  virtual ~Create_func_asin() = default;
+  ~Create_func_asin() override = default;
 };
 
 
 class Create_func_atan : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_atan s_singleton;
 
 protected:
   Create_func_atan() = default;
-  virtual ~Create_func_atan() = default;
+  ~Create_func_atan() override = default;
 };
 
 
 class Create_func_benchmark : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_benchmark s_singleton;
 
 protected:
   Create_func_benchmark() = default;
-  virtual ~Create_func_benchmark() = default;
+  ~Create_func_benchmark() override = default;
 };
 
 
 class Create_func_bin : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_bin s_singleton;
 
 protected:
   Create_func_bin() = default;
-  virtual ~Create_func_bin() = default;
+  ~Create_func_bin() override = default;
 };
 
 
 class Create_func_binlog_gtid_pos : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_binlog_gtid_pos s_singleton;
 
 protected:
   Create_func_binlog_gtid_pos() = default;
-  virtual ~Create_func_binlog_gtid_pos() = default;
+  ~Create_func_binlog_gtid_pos() override = default;
 };
 
 
 class Create_func_bit_count : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_bit_count s_singleton;
 
 protected:
   Create_func_bit_count() = default;
-  virtual ~Create_func_bit_count() = default;
+  ~Create_func_bit_count() override = default;
 };
 
 
 class Create_func_bit_length : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_bit_length s_singleton;
 
 protected:
   Create_func_bit_length() = default;
-  virtual ~Create_func_bit_length() = default;
+  ~Create_func_bit_length() override = default;
 };
 
 
 class Create_func_ceiling : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_ceiling s_singleton;
 
 protected:
   Create_func_ceiling() = default;
-  virtual ~Create_func_ceiling() = default;
+  ~Create_func_ceiling() override = default;
 };
 
 
 class Create_func_chr : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_chr s_singleton;
 
 protected:
   Create_func_chr() = default;
-  virtual ~Create_func_chr() = default;
+  ~Create_func_chr() override = default;
 };
 
 
 class Create_func_char_length : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_char_length s_singleton;
 
 protected:
   Create_func_char_length() = default;
-  virtual ~Create_func_char_length() = default;
+  ~Create_func_char_length() override = default;
 };
 
 
 class Create_func_coercibility : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_coercibility s_singleton;
 
 protected:
   Create_func_coercibility() = default;
-  virtual ~Create_func_coercibility() = default;
+  ~Create_func_coercibility() override = default;
 };
 
 class Create_func_dyncol_check : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_dyncol_check s_singleton;
 
 protected:
   Create_func_dyncol_check() = default;
-  virtual ~Create_func_dyncol_check() = default;
+  ~Create_func_dyncol_check() override = default;
 };
 
 class Create_func_dyncol_exists : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_dyncol_exists s_singleton;
 
 protected:
   Create_func_dyncol_exists() = default;
-  virtual ~Create_func_dyncol_exists() = default;
+  ~Create_func_dyncol_exists() override = default;
 };
 
 class Create_func_dyncol_list : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_dyncol_list s_singleton;
 
 protected:
   Create_func_dyncol_list() = default;
-  virtual ~Create_func_dyncol_list() = default;
+  ~Create_func_dyncol_list() override = default;
 };
 
 class Create_func_dyncol_json : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_dyncol_json s_singleton;
 
 protected:
   Create_func_dyncol_json() = default;
-  virtual ~Create_func_dyncol_json() = default;
+  ~Create_func_dyncol_json() override = default;
 };
 
 
 class Create_func_compress : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_compress s_singleton;
 
 protected:
   Create_func_compress() = default;
-  virtual ~Create_func_compress() = default;
+  ~Create_func_compress() override = default;
 };
 
 
 class Create_func_concat : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_concat s_singleton;
 
 protected:
   Create_func_concat() = default;
-  virtual ~Create_func_concat() = default;
+  ~Create_func_concat() override = default;
 };
 
 
 class Create_func_concat_operator_oracle : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_concat_operator_oracle s_singleton;
 
 protected:
   Create_func_concat_operator_oracle() = default;
-  virtual ~Create_func_concat_operator_oracle() = default;
+  ~Create_func_concat_operator_oracle() override = default;
 };
 
 
 class Create_func_decode_histogram : public Create_func_arg2
 {
 public:
-  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_decode_histogram s_singleton;
 
 protected:
   Create_func_decode_histogram() = default;
-  virtual ~Create_func_decode_histogram() = default;
+  ~Create_func_decode_histogram() override = default;
 };
 
 
 class Create_func_decode_oracle : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list)
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override
   {
     if (unlikely(!item_list || item_list->elements < 3))
     {
@@ -416,15 +416,15 @@ public:
 
 protected:
   Create_func_decode_oracle() = default;
-  virtual ~Create_func_decode_oracle() = default;
+  ~Create_func_decode_oracle() override = default;
 };
 
 
 class Create_func_decode : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list)
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override
   {
     if (unlikely(!item_list || item_list->elements != 2))
     {
@@ -440,945 +440,945 @@ public:
 
 protected:
   Create_func_decode() {}
-  virtual ~Create_func_decode() {}
+  ~Create_func_decode() override {}
 };
 
 
 class Create_func_concat_ws : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_concat_ws s_singleton;
 
 protected:
   Create_func_concat_ws() = default;
-  virtual ~Create_func_concat_ws() = default;
+  ~Create_func_concat_ws() override = default;
 };
 
 
 class Create_func_connection_id : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_connection_id s_singleton;
 
 protected:
   Create_func_connection_id() = default;
-  virtual ~Create_func_connection_id() = default;
+  ~Create_func_connection_id() override = default;
 };
 
 
 class Create_func_nvl2 : public Create_func_arg3
 {
 public:
-  virtual Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3);
+  Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3) override;
 
   static Create_func_nvl2 s_singleton;
 
 protected:
   Create_func_nvl2() = default;
-  virtual ~Create_func_nvl2() = default;
+  ~Create_func_nvl2() override = default;
 };
 
 
 class Create_func_conv : public Create_func_arg3
 {
 public:
-  virtual Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3);
+  Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3) override;
 
   static Create_func_conv s_singleton;
 
 protected:
   Create_func_conv() = default;
-  virtual ~Create_func_conv() = default;
+  ~Create_func_conv() override = default;
 };
 
 
 class Create_func_convert_tz : public Create_func_arg3
 {
 public:
-  virtual Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3);
+  Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3) override;
 
   static Create_func_convert_tz s_singleton;
 
 protected:
   Create_func_convert_tz() = default;
-  virtual ~Create_func_convert_tz() = default;
+  ~Create_func_convert_tz() override = default;
 };
 
 
 class Create_func_cos : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_cos s_singleton;
 
 protected:
   Create_func_cos() = default;
-  virtual ~Create_func_cos() = default;
+  ~Create_func_cos() override = default;
 };
 
 
 class Create_func_cot : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_cot s_singleton;
 
 protected:
   Create_func_cot() = default;
-  virtual ~Create_func_cot() = default;
+  ~Create_func_cot() override = default;
 };
 
 
 class Create_func_crc32 : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_crc32 s_singleton;
 
 protected:
   Create_func_crc32() = default;
-  virtual ~Create_func_crc32() = default;
+  ~Create_func_crc32() override = default;
 };
 
 
 class Create_func_datediff : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_datediff s_singleton;
 
 protected:
   Create_func_datediff() = default;
-  virtual ~Create_func_datediff() = default;
+  ~Create_func_datediff() override = default;
 };
 
 
 class Create_func_dayname : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_dayname s_singleton;
 
 protected:
   Create_func_dayname() = default;
-  virtual ~Create_func_dayname() = default;
+  ~Create_func_dayname() override = default;
 };
 
 
 class Create_func_dayofmonth : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_dayofmonth s_singleton;
 
 protected:
   Create_func_dayofmonth() = default;
-  virtual ~Create_func_dayofmonth() = default;
+  ~Create_func_dayofmonth() override = default;
 };
 
 
 class Create_func_dayofweek : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_dayofweek s_singleton;
 
 protected:
   Create_func_dayofweek() = default;
-  virtual ~Create_func_dayofweek() = default;
+  ~Create_func_dayofweek() override = default;
 };
 
 
 class Create_func_dayofyear : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_dayofyear s_singleton;
 
 protected:
   Create_func_dayofyear() = default;
-  virtual ~Create_func_dayofyear() = default;
+  ~Create_func_dayofyear() override = default;
 };
 
 
 class Create_func_degrees : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_degrees s_singleton;
 
 protected:
   Create_func_degrees() = default;
-  virtual ~Create_func_degrees() = default;
+  ~Create_func_degrees() override = default;
 };
 
 
 class Create_func_des_decrypt : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_des_decrypt s_singleton;
 
 protected:
   Create_func_des_decrypt() = default;
-  virtual ~Create_func_des_decrypt() = default;
+  ~Create_func_des_decrypt() override = default;
 };
 
 
 class Create_func_des_encrypt : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_des_encrypt s_singleton;
 
 protected:
   Create_func_des_encrypt() = default;
-  virtual ~Create_func_des_encrypt() = default;
+  ~Create_func_des_encrypt() override = default;
 };
 
 
 class Create_func_elt : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_elt s_singleton;
 
 protected:
   Create_func_elt() = default;
-  virtual ~Create_func_elt() = default;
+  ~Create_func_elt() override = default;
 };
 
 
 class Create_func_encode : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_encode s_singleton;
 
 protected:
   Create_func_encode() = default;
-  virtual ~Create_func_encode() = default;
+  ~Create_func_encode() override = default;
 };
 
 
 class Create_func_encrypt : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_encrypt s_singleton;
 
 protected:
   Create_func_encrypt() = default;
-  virtual ~Create_func_encrypt() = default;
+  ~Create_func_encrypt() override = default;
 };
 
 
 class Create_func_exp : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_exp s_singleton;
 
 protected:
   Create_func_exp() = default;
-  virtual ~Create_func_exp() = default;
+  ~Create_func_exp() override = default;
 };
 
 
 class Create_func_export_set : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_export_set s_singleton;
 
 protected:
   Create_func_export_set() = default;
-  virtual ~Create_func_export_set() = default;
+  ~Create_func_export_set() override = default;
 };
 
 
 class Create_func_field : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_field s_singleton;
 
 protected:
   Create_func_field() = default;
-  virtual ~Create_func_field() = default;
+  ~Create_func_field() override = default;
 };
 
 
 class Create_func_find_in_set : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_find_in_set s_singleton;
 
 protected:
   Create_func_find_in_set() = default;
-  virtual ~Create_func_find_in_set() = default;
+  ~Create_func_find_in_set() override = default;
 };
 
 
 class Create_func_floor : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_floor s_singleton;
 
 protected:
   Create_func_floor() = default;
-  virtual ~Create_func_floor() = default;
+  ~Create_func_floor() override = default;
 };
 
 
 class Create_func_format : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_format s_singleton;
 
 protected:
   Create_func_format() = default;
-  virtual ~Create_func_format() = default;
+  ~Create_func_format() override = default;
 };
 
 
 class Create_func_found_rows : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_found_rows s_singleton;
 
 protected:
   Create_func_found_rows() = default;
-  virtual ~Create_func_found_rows() = default;
+  ~Create_func_found_rows() override = default;
 };
 
 
 class Create_func_from_base64 : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_from_base64 s_singleton;
 
 protected:
   Create_func_from_base64() = default;
-  virtual ~Create_func_from_base64() = default;
+  ~Create_func_from_base64() override = default;
 };
 
 
 class Create_func_from_days : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_from_days s_singleton;
 
 protected:
   Create_func_from_days() = default;
-  virtual ~Create_func_from_days() = default;
+  ~Create_func_from_days() override = default;
 };
 
 
 class Create_func_from_unixtime : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_from_unixtime s_singleton;
 
 protected:
   Create_func_from_unixtime() = default;
-  virtual ~Create_func_from_unixtime() = default;
+  ~Create_func_from_unixtime() override = default;
 };
 
 
 class Create_func_get_lock : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_get_lock s_singleton;
 
 protected:
   Create_func_get_lock() = default;
-  virtual ~Create_func_get_lock() = default;
+  ~Create_func_get_lock() override = default;
 };
 
 
 class Create_func_greatest : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_greatest s_singleton;
 
 protected:
   Create_func_greatest() = default;
-  virtual ~Create_func_greatest() = default;
+  ~Create_func_greatest() override = default;
 };
 
 
 class Create_func_hex : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_hex s_singleton;
 
 protected:
   Create_func_hex() = default;
-  virtual ~Create_func_hex() = default;
+  ~Create_func_hex() override = default;
 };
 
 
 class Create_func_ifnull : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_ifnull s_singleton;
 
 protected:
   Create_func_ifnull() = default;
-  virtual ~Create_func_ifnull() = default;
+  ~Create_func_ifnull() override = default;
 };
 
 
 class Create_func_instr : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_instr s_singleton;
 
 protected:
   Create_func_instr() = default;
-  virtual ~Create_func_instr() = default;
+  ~Create_func_instr() override = default;
 };
 
 
 class Create_func_is_free_lock : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_is_free_lock s_singleton;
 
 protected:
   Create_func_is_free_lock() = default;
-  virtual ~Create_func_is_free_lock() = default;
+  ~Create_func_is_free_lock() override = default;
 };
 
 
 class Create_func_is_used_lock : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_is_used_lock s_singleton;
 
 protected:
   Create_func_is_used_lock() = default;
-  virtual ~Create_func_is_used_lock() = default;
+  ~Create_func_is_used_lock() override = default;
 };
 
 
 class Create_func_isnull : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_isnull s_singleton;
 
 protected:
   Create_func_isnull() = default;
-  virtual ~Create_func_isnull() = default;
+  ~Create_func_isnull() override = default;
 };
 
 
 class Create_func_json_exists : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_json_exists s_singleton;
 
 protected:
   Create_func_json_exists() = default;
-  virtual ~Create_func_json_exists() = default;
+  ~Create_func_json_exists() override = default;
 };
 
 
 class Create_func_json_valid : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_json_valid s_singleton;
 
 protected:
   Create_func_json_valid() = default;
-  virtual ~Create_func_json_valid() = default;
+  ~Create_func_json_valid() override = default;
 };
 
 
 class Create_func_json_compact : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_json_compact s_singleton;
 
 protected:
   Create_func_json_compact() = default;
-  virtual ~Create_func_json_compact() = default;
+  ~Create_func_json_compact() override = default;
 };
 
 
 class Create_func_json_loose : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_json_loose s_singleton;
 
 protected:
   Create_func_json_loose() = default;
-  virtual ~Create_func_json_loose() = default;
+  ~Create_func_json_loose() override = default;
 };
 
 
 class Create_func_json_detailed: public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_detailed s_singleton;
 
 protected:
   Create_func_json_detailed() = default;
-  virtual ~Create_func_json_detailed() = default;
+  ~Create_func_json_detailed() override = default;
 };
 
 
 class Create_func_json_type : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_json_type s_singleton;
 
 protected:
   Create_func_json_type() = default;
-  virtual ~Create_func_json_type() = default;
+  ~Create_func_json_type() override = default;
 };
 
 
 class Create_func_json_depth : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_json_depth s_singleton;
 
 protected:
   Create_func_json_depth() = default;
-  virtual ~Create_func_json_depth() = default;
+  ~Create_func_json_depth() override = default;
 };
 
 
 class Create_func_json_value : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_json_value s_singleton;
 
 protected:
   Create_func_json_value() = default;
-  virtual ~Create_func_json_value() = default;
+  ~Create_func_json_value() override = default;
 };
 
 
 class Create_func_json_query : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_json_query s_singleton;
 
 protected:
   Create_func_json_query() = default;
-  virtual ~Create_func_json_query() = default;
+  ~Create_func_json_query() override = default;
 };
 
 
 class Create_func_json_keys: public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_keys s_singleton;
 
 protected:
   Create_func_json_keys() = default;
-  virtual ~Create_func_json_keys() = default;
+  ~Create_func_json_keys() override = default;
 };
 
 
 class Create_func_json_contains: public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_contains s_singleton;
 
 protected:
   Create_func_json_contains() = default;
-  virtual ~Create_func_json_contains() = default;
+  ~Create_func_json_contains() override = default;
 };
 
 
 class Create_func_json_contains_path : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_contains_path s_singleton;
 
 protected:
   Create_func_json_contains_path() = default;
-  virtual ~Create_func_json_contains_path() = default;
+  ~Create_func_json_contains_path() override = default;
 };
 
 
 class Create_func_json_extract : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_extract s_singleton;
 
 protected:
   Create_func_json_extract() = default;
-  virtual ~Create_func_json_extract() = default;
+  ~Create_func_json_extract() override = default;
 };
 
 
 class Create_func_json_search : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_search s_singleton;
 
 protected:
   Create_func_json_search() = default;
-  virtual ~Create_func_json_search() = default;
+  ~Create_func_json_search() override = default;
 };
 
 
 class Create_func_json_array : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_array s_singleton;
 
 protected:
   Create_func_json_array() = default;
-  virtual ~Create_func_json_array() = default;
+  ~Create_func_json_array() override = default;
 };
 
 
 class Create_func_json_array_append : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_array_append s_singleton;
 
 protected:
   Create_func_json_array_append() = default;
-  virtual ~Create_func_json_array_append() = default;
+  ~Create_func_json_array_append() override = default;
 };
 
 
 class Create_func_json_array_insert : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_array_insert s_singleton;
 
 protected:
   Create_func_json_array_insert() = default;
-  virtual ~Create_func_json_array_insert() = default;
+  ~Create_func_json_array_insert() override = default;
 };
 
 
 class Create_func_json_insert : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_insert s_singleton;
 
 protected:
   Create_func_json_insert() = default;
-  virtual ~Create_func_json_insert() = default;
+  ~Create_func_json_insert() override = default;
 };
 
 
 class Create_func_json_set : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_set s_singleton;
 
 protected:
   Create_func_json_set() = default;
-  virtual ~Create_func_json_set() = default;
+  ~Create_func_json_set() override = default;
 };
 
 
 class Create_func_json_replace : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_replace s_singleton;
 
 protected:
   Create_func_json_replace() = default;
-  virtual ~Create_func_json_replace() = default;
+  ~Create_func_json_replace() override = default;
 };
 
 
 class Create_func_json_remove : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_remove s_singleton;
 
 protected:
   Create_func_json_remove() = default;
-  virtual ~Create_func_json_remove() = default;
+  ~Create_func_json_remove() override = default;
 };
 
 
 class Create_func_json_object : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_object s_singleton;
 
 protected:
   Create_func_json_object() = default;
-  virtual ~Create_func_json_object() = default;
+  ~Create_func_json_object() override = default;
 };
 
 
 class Create_func_json_length : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_length s_singleton;
 
 protected:
   Create_func_json_length() = default;
-  virtual ~Create_func_json_length() = default;
+  ~Create_func_json_length() override = default;
 };
 
 
 class Create_func_json_merge : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_merge s_singleton;
 
 protected:
   Create_func_json_merge() = default;
-  virtual ~Create_func_json_merge() = default;
+  ~Create_func_json_merge() override = default;
 };
 
 
 class Create_func_json_merge_patch : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_json_merge_patch s_singleton;
 
 protected:
   Create_func_json_merge_patch() = default;
-  virtual ~Create_func_json_merge_patch() = default;
+  ~Create_func_json_merge_patch() override = default;
 };
 
 
 class Create_func_json_quote : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_json_quote s_singleton;
 
 protected:
   Create_func_json_quote() = default;
-  virtual ~Create_func_json_quote() = default;
+  ~Create_func_json_quote() override = default;
 };
 
 
 class Create_func_json_unquote : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_json_unquote s_singleton;
 
 protected:
   Create_func_json_unquote() = default;
-  virtual ~Create_func_json_unquote() = default;
+  ~Create_func_json_unquote() override = default;
 };
 
 
 class Create_func_last_day : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_last_day s_singleton;
 
 protected:
   Create_func_last_day() = default;
-  virtual ~Create_func_last_day() = default;
+  ~Create_func_last_day() override = default;
 };
 
 
 class Create_func_last_insert_id : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_last_insert_id s_singleton;
 
 protected:
   Create_func_last_insert_id() = default;
-  virtual ~Create_func_last_insert_id() = default;
+  ~Create_func_last_insert_id() override = default;
 };
 
 
 class Create_func_lcase : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_lcase s_singleton;
 
 protected:
   Create_func_lcase() = default;
-  virtual ~Create_func_lcase() = default;
+  ~Create_func_lcase() override = default;
 };
 
 
 class Create_func_least : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_least s_singleton;
 
 protected:
   Create_func_least() = default;
-  virtual ~Create_func_least() = default;
+  ~Create_func_least() override = default;
 };
 
 
 class Create_func_length : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_length s_singleton;
 
 protected:
   Create_func_length() = default;
-  virtual ~Create_func_length() = default;
+  ~Create_func_length() override = default;
 };
 
 class Create_func_octet_length : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_octet_length s_singleton;
 
 protected:
   Create_func_octet_length() = default;
-  virtual ~Create_func_octet_length() = default;
+  ~Create_func_octet_length() override = default;
 };
 
 
@@ -1386,26 +1386,26 @@ protected:
 class Create_func_like_range_min : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_like_range_min s_singleton;
 
 protected:
   Create_func_like_range_min() = default;
-  virtual ~Create_func_like_range_min() = default;
+  ~Create_func_like_range_min() override = default;
 };
 
 
 class Create_func_like_range_max : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_like_range_max s_singleton;
 
 protected:
   Create_func_like_range_max() = default;
-  virtual ~Create_func_like_range_max() = default;
+  ~Create_func_like_range_max() override = default;
 };
 #endif
 
@@ -1413,88 +1413,88 @@ protected:
 class Create_func_ln : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_ln s_singleton;
 
 protected:
   Create_func_ln() = default;
-  virtual ~Create_func_ln() = default;
+  ~Create_func_ln() override = default;
 };
 
 
 class Create_func_load_file : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_load_file s_singleton;
 
 protected:
   Create_func_load_file() = default;
-  virtual ~Create_func_load_file() = default;
+  ~Create_func_load_file() override = default;
 };
 
 
 class Create_func_locate : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_locate s_singleton;
 
 protected:
   Create_func_locate() = default;
-  virtual ~Create_func_locate() = default;
+  ~Create_func_locate() override = default;
 };
 
 
 class Create_func_log : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_log s_singleton;
 
 protected:
   Create_func_log() = default;
-  virtual ~Create_func_log() = default;
+  ~Create_func_log() override = default;
 };
 
 
 class Create_func_log10 : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_log10 s_singleton;
 
 protected:
   Create_func_log10() = default;
-  virtual ~Create_func_log10() = default;
+  ~Create_func_log10() override = default;
 };
 
 
 class Create_func_log2 : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_log2 s_singleton;
 
 protected:
   Create_func_log2() = default;
-  virtual ~Create_func_log2() = default;
+  ~Create_func_log2() override = default;
 };
 
 
 class Create_func_lpad : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list)
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override
   {
     return create_native_std(thd, name, item_list);
   }
@@ -1502,7 +1502,7 @@ public:
 
 protected:
   Create_func_lpad() = default;
-  virtual ~Create_func_lpad() = default;
+  ~Create_func_lpad() override = default;
   Item *create_native_std(THD *thd, const LEX_CSTRING *name,
                           List<Item> *items);
   Item *create_native_oracle(THD *thd, const LEX_CSTRING *name,
@@ -1514,7 +1514,7 @@ class Create_func_lpad_oracle : public Create_func_lpad
 {
 public:
   Item *create_native(THD *thd, const LEX_CSTRING *name,
-                      List<Item> *item_list)
+                      List<Item> *item_list) override
   {
     return create_native_oracle(thd, name, item_list);
   }
@@ -1525,250 +1525,250 @@ public:
 class Create_func_ltrim : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_ltrim s_singleton;
 
 protected:
   Create_func_ltrim() = default;
-  virtual ~Create_func_ltrim() = default;
+  ~Create_func_ltrim() override = default;
 };
 
 
 class Create_func_ltrim_oracle : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_ltrim_oracle s_singleton;
 
 protected:
   Create_func_ltrim_oracle() = default;
-  virtual ~Create_func_ltrim_oracle() = default;
+  ~Create_func_ltrim_oracle() override = default;
 };
 
 
 class Create_func_makedate : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_makedate s_singleton;
 
 protected:
   Create_func_makedate() = default;
-  virtual ~Create_func_makedate() = default;
+  ~Create_func_makedate() override = default;
 };
 
 
 class Create_func_maketime : public Create_func_arg3
 {
 public:
-  virtual Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3);
+  Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3) override;
 
   static Create_func_maketime s_singleton;
 
 protected:
   Create_func_maketime() = default;
-  virtual ~Create_func_maketime() = default;
+  ~Create_func_maketime() override = default;
 };
 
 
 class Create_func_make_set : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_make_set s_singleton;
 
 protected:
   Create_func_make_set() = default;
-  virtual ~Create_func_make_set() = default;
+  ~Create_func_make_set() override = default;
 };
 
 
 class Create_func_master_pos_wait : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_master_pos_wait s_singleton;
 
 protected:
   Create_func_master_pos_wait() = default;
-  virtual ~Create_func_master_pos_wait() = default;
+  ~Create_func_master_pos_wait() override = default;
 };
 
 
 class Create_func_master_gtid_wait : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_master_gtid_wait s_singleton;
 
 protected:
   Create_func_master_gtid_wait() = default;
-  virtual ~Create_func_master_gtid_wait() = default;
+  ~Create_func_master_gtid_wait() override = default;
 };
 
 
 class Create_func_md5 : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_md5 s_singleton;
 
 protected:
   Create_func_md5() = default;
-  virtual ~Create_func_md5() = default;
+  ~Create_func_md5() override = default;
 };
 
 
 class Create_func_monthname : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_monthname s_singleton;
 
 protected:
   Create_func_monthname() = default;
-  virtual ~Create_func_monthname() = default;
+  ~Create_func_monthname() override = default;
 };
 
 
 class Create_func_name_const : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_name_const s_singleton;
 
 protected:
   Create_func_name_const() = default;
-  virtual ~Create_func_name_const() = default;
+  ~Create_func_name_const() override = default;
 };
 
 
 class Create_func_nullif : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_nullif s_singleton;
 
 protected:
   Create_func_nullif() = default;
-  virtual ~Create_func_nullif() = default;
+  ~Create_func_nullif() override = default;
 };
 
 
 class Create_func_oct : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_oct s_singleton;
 
 protected:
   Create_func_oct() = default;
-  virtual ~Create_func_oct() = default;
+  ~Create_func_oct() override = default;
 };
 
 
 class Create_func_ord : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_ord s_singleton;
 
 protected:
   Create_func_ord() = default;
-  virtual ~Create_func_ord() = default;
+  ~Create_func_ord() override = default;
 };
 
 
 class Create_func_period_add : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_period_add s_singleton;
 
 protected:
   Create_func_period_add() = default;
-  virtual ~Create_func_period_add() = default;
+  ~Create_func_period_add() override = default;
 };
 
 
 class Create_func_period_diff : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_period_diff s_singleton;
 
 protected:
   Create_func_period_diff() = default;
-  virtual ~Create_func_period_diff() = default;
+  ~Create_func_period_diff() override = default;
 };
 
 
 class Create_func_pi : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_pi s_singleton;
 
 protected:
   Create_func_pi() = default;
-  virtual ~Create_func_pi() = default;
+  ~Create_func_pi() override = default;
 };
 
 
 class Create_func_pow : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_pow s_singleton;
 
 protected:
   Create_func_pow() = default;
-  virtual ~Create_func_pow() = default;
+  ~Create_func_pow() override = default;
 };
 
 
 class Create_func_quote : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_quote s_singleton;
 
 protected:
   Create_func_quote() = default;
-  virtual ~Create_func_quote() = default;
+  ~Create_func_quote() override = default;
 };
 
 
 class Create_func_regexp_instr : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_regexp_instr s_singleton;
 
 protected:
   Create_func_regexp_instr() = default;
-  virtual ~Create_func_regexp_instr() = default;
+  ~Create_func_regexp_instr() override = default;
 };
 
 
@@ -1784,7 +1784,7 @@ public:
 
 protected:
   Create_func_regexp_replace() = default;
-  virtual ~Create_func_regexp_replace() = default;
+  ~Create_func_regexp_replace() override = default;
 };
 
 Create_func_regexp_replace Create_func_regexp_replace::s_singleton;
@@ -1803,7 +1803,7 @@ public:
 
 protected:
   Create_func_regexp_replace_oracle() = default;
-  virtual ~Create_func_regexp_replace_oracle() = default;
+  ~Create_func_regexp_replace_oracle() override = default;
 };
 
 Create_func_regexp_replace_oracle
@@ -1813,47 +1813,47 @@ Create_func_regexp_replace_oracle
 class Create_func_regexp_substr : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_regexp_substr s_singleton;
 
 protected:
   Create_func_regexp_substr() = default;
-  virtual ~Create_func_regexp_substr() = default;
+  ~Create_func_regexp_substr() override = default;
 };
 
 
 class Create_func_radians : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_radians s_singleton;
 
 protected:
   Create_func_radians() = default;
-  virtual ~Create_func_radians() = default;
+  ~Create_func_radians() override = default;
 };
 
 
 class Create_func_rand : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_rand s_singleton;
 
 protected:
   Create_func_rand() = default;
-  virtual ~Create_func_rand() = default;
+  ~Create_func_rand() override = default;
 };
 
 
 class Create_func_release_all_locks : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_release_all_locks s_singleton;
 };
@@ -1862,61 +1862,61 @@ public:
 class Create_func_release_lock : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_release_lock s_singleton;
 
 protected:
   Create_func_release_lock() = default;
-  virtual ~Create_func_release_lock() = default;
+  ~Create_func_release_lock() override = default;
 };
 
 
 class Create_func_replace_oracle : public Create_func_arg3
 {
 public:
-  virtual Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3);
+  Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3) override;
 
   static Create_func_replace_oracle s_singleton;
 
 protected:
   Create_func_replace_oracle() = default;
-  virtual ~Create_func_replace_oracle() = default;
+  ~Create_func_replace_oracle() override = default;
 };
 
 
 class Create_func_reverse : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_reverse s_singleton;
 
 protected:
   Create_func_reverse() = default;
-  virtual ~Create_func_reverse() = default;
+  ~Create_func_reverse() override = default;
 };
 
 
 class Create_func_round : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_round s_singleton;
 
 protected:
   Create_func_round() = default;
-  virtual ~Create_func_round() = default;
+  ~Create_func_round() override = default;
 };
 
 
 class Create_func_rpad : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list)
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override
   {
     return create_native_std(thd, name, item_list);
   }
@@ -1924,7 +1924,7 @@ public:
 
 protected:
   Create_func_rpad() = default;
-  virtual ~Create_func_rpad() = default;
+  ~Create_func_rpad() override = default;
   Item *create_native_std(THD *thd, const LEX_CSTRING *name,
                           List<Item> *items);
   Item *create_native_oracle(THD *thd, const LEX_CSTRING *name,
@@ -1936,7 +1936,7 @@ class Create_func_rpad_oracle : public Create_func_rpad
 {
 public:
   Item *create_native(THD *thd, const LEX_CSTRING *name,
-                      List<Item> *item_list)
+                      List<Item> *item_list) override
   {
     return create_native_oracle(thd, name, item_list);
   }
@@ -1947,430 +1947,430 @@ public:
 class Create_func_rtrim : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_rtrim s_singleton;
 
 protected:
   Create_func_rtrim() = default;
-  virtual ~Create_func_rtrim() = default;
+  ~Create_func_rtrim() override = default;
 };
 
 
 class Create_func_rtrim_oracle : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_rtrim_oracle s_singleton;
 
 protected:
   Create_func_rtrim_oracle() = default;
-  virtual ~Create_func_rtrim_oracle() = default;
+  ~Create_func_rtrim_oracle() override = default;
 };
 
 
 class Create_func_sec_to_time : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_sec_to_time s_singleton;
 
 protected:
   Create_func_sec_to_time() = default;
-  virtual ~Create_func_sec_to_time() = default;
+  ~Create_func_sec_to_time() override = default;
 };
 
 
 class Create_func_sha : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_sha s_singleton;
 
 protected:
   Create_func_sha() = default;
-  virtual ~Create_func_sha() = default;
+  ~Create_func_sha() override = default;
 };
 
 
 class Create_func_sha2 : public Create_func_arg2
 {
 public:
-  virtual Item* create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item* create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_sha2 s_singleton;
 
 protected:
   Create_func_sha2() = default;
-  virtual ~Create_func_sha2() = default;
+  ~Create_func_sha2() override = default;
 };
 
 
 class Create_func_sign : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_sign s_singleton;
 
 protected:
   Create_func_sign() = default;
-  virtual ~Create_func_sign() = default;
+  ~Create_func_sign() override = default;
 };
 
 
 class Create_func_sin : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_sin s_singleton;
 
 protected:
   Create_func_sin() = default;
-  virtual ~Create_func_sin() = default;
+  ~Create_func_sin() override = default;
 };
 
 
 class Create_func_sleep : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_sleep s_singleton;
 
 protected:
   Create_func_sleep() = default;
-  virtual ~Create_func_sleep() = default;
+  ~Create_func_sleep() override = default;
 };
 
 
 class Create_func_soundex : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_soundex s_singleton;
 
 protected:
   Create_func_soundex() = default;
-  virtual ~Create_func_soundex() = default;
+  ~Create_func_soundex() override = default;
 };
 
 
 class Create_func_space : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_space s_singleton;
 
 protected:
   Create_func_space() = default;
-  virtual ~Create_func_space() = default;
+  ~Create_func_space() override = default;
 };
 
 
 class Create_func_sqrt : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_sqrt s_singleton;
 
 protected:
   Create_func_sqrt() = default;
-  virtual ~Create_func_sqrt() = default;
+  ~Create_func_sqrt() override = default;
 };
 
 
 class Create_func_str_to_date : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_str_to_date s_singleton;
 
 protected:
   Create_func_str_to_date() = default;
-  virtual ~Create_func_str_to_date() = default;
+  ~Create_func_str_to_date() override = default;
 };
 
 
 class Create_func_strcmp : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_strcmp s_singleton;
 
 protected:
   Create_func_strcmp() = default;
-  virtual ~Create_func_strcmp() = default;
+  ~Create_func_strcmp() override = default;
 };
 
 
 class Create_func_substr_index : public Create_func_arg3
 {
 public:
-  virtual Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3);
+  Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3) override;
 
   static Create_func_substr_index s_singleton;
 
 protected:
   Create_func_substr_index() = default;
-  virtual ~Create_func_substr_index() = default;
+  ~Create_func_substr_index() override = default;
 };
 
 
 class Create_func_substr_oracle : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_substr_oracle s_singleton;
 
 protected:
   Create_func_substr_oracle() = default;
-  virtual ~Create_func_substr_oracle() = default;
+  ~Create_func_substr_oracle() override = default;
 };
 
 
 class Create_func_subtime : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_subtime s_singleton;
 
 protected:
   Create_func_subtime() = default;
-  virtual ~Create_func_subtime() = default;
+  ~Create_func_subtime() override = default;
 };
 
 
 class Create_func_tan : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_tan s_singleton;
 
 protected:
   Create_func_tan() = default;
-  virtual ~Create_func_tan() = default;
+  ~Create_func_tan() override = default;
 };
 
 
 class Create_func_time_format : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_time_format s_singleton;
 
 protected:
   Create_func_time_format() = default;
-  virtual ~Create_func_time_format() = default;
+  ~Create_func_time_format() override = default;
 };
 
 
 class Create_func_time_to_sec : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_time_to_sec s_singleton;
 
 protected:
   Create_func_time_to_sec() = default;
-  virtual ~Create_func_time_to_sec() = default;
+  ~Create_func_time_to_sec() override = default;
 };
 
 
 class Create_func_timediff : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_timediff s_singleton;
 
 protected:
   Create_func_timediff() = default;
-  virtual ~Create_func_timediff() = default;
+  ~Create_func_timediff() override = default;
 };
 
 
 class Create_func_to_base64 : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_to_base64 s_singleton;
 
 protected:
   Create_func_to_base64() = default;
-  virtual ~Create_func_to_base64() = default;
+  ~Create_func_to_base64() override = default;
 };
 
 
 class Create_func_to_days : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_to_days s_singleton;
 
 protected:
   Create_func_to_days() = default;
-  virtual ~Create_func_to_days() = default;
+  ~Create_func_to_days() override = default;
 };
 
 class Create_func_to_seconds : public Create_func_arg1
 {
 public:
-  virtual Item* create_1_arg(THD *thd, Item *arg1);
+  Item* create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_to_seconds s_singleton;
 
 protected:
   Create_func_to_seconds() = default;
-  virtual ~Create_func_to_seconds() = default;
+  ~Create_func_to_seconds() override = default;
 };
 
 
 class Create_func_ucase : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_ucase s_singleton;
 
 protected:
   Create_func_ucase() = default;
-  virtual ~Create_func_ucase() = default;
+  ~Create_func_ucase() override = default;
 };
 
 
 class Create_func_uncompress : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_uncompress s_singleton;
 
 protected:
   Create_func_uncompress() = default;
-  virtual ~Create_func_uncompress() = default;
+  ~Create_func_uncompress() override = default;
 };
 
 
 class Create_func_uncompressed_length : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_uncompressed_length s_singleton;
 
 protected:
   Create_func_uncompressed_length() = default;
-  virtual ~Create_func_uncompressed_length() = default;
+  ~Create_func_uncompressed_length() override = default;
 };
 
 
 class Create_func_unhex : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_unhex s_singleton;
 
 protected:
   Create_func_unhex() = default;
-  virtual ~Create_func_unhex() = default;
+  ~Create_func_unhex() override = default;
 };
 
 
 class Create_func_unix_timestamp : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_unix_timestamp s_singleton;
 
 protected:
   Create_func_unix_timestamp() = default;
-  virtual ~Create_func_unix_timestamp() = default;
+  ~Create_func_unix_timestamp() override = default;
 };
 
 
 class Create_func_uuid : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_uuid s_singleton;
 
 protected:
   Create_func_uuid() = default;
-  virtual ~Create_func_uuid() = default;
+  ~Create_func_uuid() override = default;
 };
 
 
 class Create_func_uuid_short : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_uuid_short s_singleton;
 
 protected:
   Create_func_uuid_short() = default;
-  virtual ~Create_func_uuid_short() = default;
+  ~Create_func_uuid_short() override = default;
 };
 
 
 class Create_func_version : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_version s_singleton;
 
 protected:
   Create_func_version() = default;
-  virtual ~Create_func_version() = default;
+  ~Create_func_version() override = default;
 };
 
 
 class Create_func_weekday : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_weekday s_singleton;
 
 protected:
   Create_func_weekday() = default;
-  virtual ~Create_func_weekday() = default;
+  ~Create_func_weekday() override = default;
 };
 
 
 class Create_func_weekofyear : public Create_func_arg1
 {
 public:
-  virtual Item *create_1_arg(THD *thd, Item *arg1);
+  Item *create_1_arg(THD *thd, Item *arg1) override;
 
   static Create_func_weekofyear s_singleton;
 
 protected:
   Create_func_weekofyear() = default;
-  virtual ~Create_func_weekofyear() = default;
+  ~Create_func_weekofyear() override = default;
 };
 
 
@@ -2378,26 +2378,26 @@ protected:
 class Create_func_wsrep_last_written_gtid : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_wsrep_last_written_gtid s_singleton;
 
 protected:
   Create_func_wsrep_last_written_gtid() = default;
-  virtual ~Create_func_wsrep_last_written_gtid() = default;
+  ~Create_func_wsrep_last_written_gtid() override = default;
 };
 
 
 class Create_func_wsrep_last_seen_gtid : public Create_func_arg0
 {
 public:
-  virtual Item *create_builder(THD *thd);
+  Item *create_builder(THD *thd) override;
 
   static Create_func_wsrep_last_seen_gtid s_singleton;
 
 protected:
   Create_func_wsrep_last_seen_gtid() = default;
-  virtual ~Create_func_wsrep_last_seen_gtid() = default;
+  ~Create_func_wsrep_last_seen_gtid() override = default;
 };
 
 
@@ -2411,7 +2411,7 @@ public:
 
 protected:
   Create_func_wsrep_sync_wait_upto() = default;
-  virtual ~Create_func_wsrep_sync_wait_upto() = default;
+  ~Create_func_wsrep_sync_wait_upto() override = default;
 };
 #endif /* WITH_WSREP */
 
@@ -2419,40 +2419,40 @@ protected:
 class Create_func_xml_extractvalue : public Create_func_arg2
 {
 public:
-  virtual Item *create_2_arg(THD *thd, Item *arg1, Item *arg2);
+  Item *create_2_arg(THD *thd, Item *arg1, Item *arg2) override;
 
   static Create_func_xml_extractvalue s_singleton;
 
 protected:
   Create_func_xml_extractvalue() = default;
-  virtual ~Create_func_xml_extractvalue() = default;
+  ~Create_func_xml_extractvalue() override = default;
 };
 
 
 class Create_func_xml_update : public Create_func_arg3
 {
 public:
-  virtual Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3);
+  Item *create_3_arg(THD *thd, Item *arg1, Item *arg2, Item *arg3) override;
 
   static Create_func_xml_update s_singleton;
 
 protected:
   Create_func_xml_update() = default;
-  virtual ~Create_func_xml_update() = default;
+  ~Create_func_xml_update() override = default;
 };
 
 
 class Create_func_year_week : public Create_native_func
 {
 public:
-  virtual Item *create_native(THD *thd, const LEX_CSTRING *name,
-                              List<Item> *item_list);
+  Item *create_native(THD *thd, const LEX_CSTRING *name,
+                              List<Item> *item_list) override;
 
   static Create_func_year_week s_singleton;
 
 protected:
   Create_func_year_week() = default;
-  virtual ~Create_func_year_week() = default;
+  ~Create_func_year_week() override = default;
 };
 
 

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -2150,7 +2150,7 @@ class Func_handler_shift_left_int_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return item->arguments()[0]->to_longlong_null() <<
@@ -2163,7 +2163,7 @@ class Func_handler_shift_left_decimal_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return VDec(item->arguments()[0]).to_xlonglong_null() <<
@@ -2184,7 +2184,7 @@ class Func_handler_shift_right_int_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->fixed == 1);
     return item->arguments()[0]->to_longlong_null() >>
@@ -2197,7 +2197,7 @@ class Func_handler_shift_right_decimal_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return VDec(item->arguments()[0]).to_xlonglong_null() >>
@@ -2218,7 +2218,7 @@ class Func_handler_bit_neg_int_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return ~ item->arguments()[0]->to_longlong_null();
@@ -2230,7 +2230,7 @@ class Func_handler_bit_neg_decimal_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return ~ VDec(item->arguments()[0]).to_xlonglong_null();
@@ -3428,7 +3428,7 @@ class Func_handler_bit_count_int_to_slong:
         public Item_handled_func::Handler_slong2
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return item->arguments()[0]->to_longlong_null().bit_count();
@@ -3440,7 +3440,7 @@ class Func_handler_bit_count_decimal_to_slong:
         public Item_handled_func::Handler_slong2
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return VDec(item->arguments()[0]).to_xlonglong_null().bit_count();
@@ -4182,7 +4182,7 @@ public:
                         const char * /* sqlstate */,
                         Sql_condition::enum_warning_level* /* level */,
                         const char *message,
-                        Sql_condition ** /* cond_hdl */);
+                        Sql_condition ** /* cond_hdl */) override;
 };
 
 bool
@@ -6500,7 +6500,7 @@ class Func_handler_bit_xor_int_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return item->arguments()[0]->to_longlong_null() ^
@@ -6513,7 +6513,7 @@ class Func_handler_bit_xor_dec_to_ulonglong:
         public Item_handled_func::Handler_ulonglong
 {
 public:
-  Longlong_null to_longlong_null(Item_handled_func *item) const
+  Longlong_null to_longlong_null(Item_handled_func *item) const override
   {
     DBUG_ASSERT(item->is_fixed());
     return VDec(item->arguments()[0]).to_xlonglong_null() ^

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -126,7 +126,7 @@ public:
     DBUG_ASSERT(0);
     return SCALAR_CMP_EQ;
   }
-  enum Type type() const { return FUNC_ITEM; }
+  enum Type type() const override { return FUNC_ITEM; }
   virtual enum Functype functype() const   { return UNKNOWN_FUNC; }
   Item_func(THD *thd): Item_func_or_sum(thd)
   {
@@ -177,29 +177,29 @@ public:
    :Item_func_or_sum(thd, item), With_sum_func_cache(item),
     not_null_tables_cache(item->not_null_tables_cache)
   { }
-  bool fix_fields(THD *, Item **ref);
-  void cleanup()
+  bool fix_fields(THD *, Item **ref) override;
+  void cleanup() override
   {
     Item_func_or_sum::cleanup();
     used_tables_and_const_cache_init();
   }
-  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge);
-  void quick_fix_field();
-  table_map not_null_tables() const;
-  void update_used_tables()
+  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
+  void quick_fix_field() override;
+  table_map not_null_tables() const override;
+  void update_used_tables() override
   {
     used_tables_and_const_cache_init();
     used_tables_and_const_cache_update_and_join(arg_count, args);
   }
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
-                          COND_EQUAL **cond_equal_ref);
-  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr)
+                          COND_EQUAL **cond_equal_ref) override;
+  SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override
   {
     DBUG_ENTER("Item_func::get_mm_tree");
     DBUG_RETURN(const_item() ? get_mm_tree_for_const(param) : NULL);
   }
-  bool eq(const Item *item, bool binary_cmp) const;
+  bool eq(const Item *item, bool binary_cmp) const override;
   virtual Item *key_item() const { return args[0]; }
   void set_arguments(THD *thd, List<Item> &list)
   {
@@ -208,8 +208,8 @@ public:
     list.empty();                                     // Fields are used
   }
   void split_sum_func(THD *thd, Ref_ptr_array ref_pointer_array,
-                      List<Item> &fields, uint flags);
-  virtual void print(String *str, enum_query_type query_type);
+                      List<Item> &fields, uint flags) override;
+  void print(String *str, enum_query_type query_type) override;
   void print_op(String *str, enum_query_type query_type);
   void print_args(String *str, uint from, enum_query_type query_type) const;
   void print_args_parenthesized(String *str, enum_query_type query_type) const
@@ -218,7 +218,7 @@ public:
     print_args(str, 0, query_type);
     str->append(')');
   }
-  bool is_null() { 
+  bool is_null() override { 
     update_null_value();
     return null_value; 
   }
@@ -226,9 +226,9 @@ public:
 
   void signal_divide_by_null();
   friend class udf_handler;
-  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table)
+  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table) override
   { return tmp_table_field_from_field_type(root, table); }
-  Item *get_tmp_table_item(THD *thd);
+  Item *get_tmp_table_item(THD *thd) override;
 
   void fix_char_length_ulonglong(ulonglong max_char_length_arg)
   {
@@ -242,13 +242,13 @@ public:
     else
       max_length= (uint32) max_result_length;
   }
-  Item *transform(THD *thd, Item_transformer transformer, uchar *arg);
+  Item *transform(THD *thd, Item_transformer transformer, uchar *arg) override;
   Item* compile(THD *thd, Item_analyzer analyzer, uchar **arg_p,
-                Item_transformer transformer, uchar *arg_t);
+                Item_transformer transformer, uchar *arg_t) override;
   void traverse_cond(Cond_traverser traverser,
-                     void * arg, traverse_order order);
-  bool eval_not_null_tables(void *opt_arg);
-  bool find_not_null_fields(table_map allowed);
+                     void * arg, traverse_order order) override;
+  bool eval_not_null_tables(void *opt_arg) override;
+  bool find_not_null_fields(table_map allowed) override;
  // bool is_expensive_processor(void *arg);
  // virtual bool is_expensive() { return 0; }
   inline void raise_numeric_overflow(const char *type_name)
@@ -364,7 +364,7 @@ public:
     return FALSE;
   }
 
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     /*
       By default only substitution for a field whose two different values
@@ -380,7 +380,7 @@ public:
     return used_tables() & RAND_TABLE_BIT;
   }
 
-  bool excl_dep_on_table(table_map tab_map)
+  bool excl_dep_on_table(table_map tab_map) override
   {
     if (used_tables() & OUTER_REF_TABLE_BIT)
       return false; 
@@ -388,14 +388,14 @@ public:
            Item_args::excl_dep_on_table(tab_map);
   }
 
-  bool excl_dep_on_grouping_fields(st_select_lex *sel)
+  bool excl_dep_on_grouping_fields(st_select_lex *sel) override
   {
     if (has_rand_bit() || with_subquery())
       return false;
     return Item_args::excl_dep_on_grouping_fields(sel);
   }
 
-  bool excl_dep_on_in_subq_left_part(Item_in_subselect *subq_pred)
+  bool excl_dep_on_in_subq_left_part(Item_in_subselect *subq_pred) override
   {
     return Item_args::excl_dep_on_in_subq_left_part(subq_pred);
   }
@@ -408,24 +408,24 @@ public:
     representation of a TIMESTAMP argument verbatim, and thus does not depend on
     the timezone.
    */
-  virtual bool check_valid_arguments_processor(void *bool_arg)
+  bool check_valid_arguments_processor(void *bool_arg) override
   {
     return has_timestamp_args();
   }
 
-  virtual bool find_function_processor (void *arg)
+  bool find_function_processor (void *arg) override
   {
     return functype() == *(Functype *) arg;
   }
 
-  void no_rows_in_result()
+  void no_rows_in_result() override
   {
     for (uint i= 0; i < arg_count; i++)
     {
       args[i]->no_rows_in_result();
     }
   }
-  void restore_to_before_no_rows_in_result()
+  void restore_to_before_no_rows_in_result() override
   {
     for (uint i= 0; i < arg_count; i++)
     {
@@ -433,10 +433,10 @@ public:
     }
   }
   void convert_const_compared_to_int_field(THD *thd);
-  bool with_sum_func() const { return m_with_sum_func; }
-  With_sum_func_cache* get_with_sum_func_cache() { return this; }
-  Item_func *get_item_func() { return this; }
-  bool is_simplified_cond_processor(void *arg)
+  bool with_sum_func() const override { return m_with_sum_func; }
+  With_sum_func_cache* get_with_sum_func_cache() override { return this; }
+  Item_func *get_item_func() override { return this; }
+  bool is_simplified_cond_processor(void *arg) override
   { return const_item() && !val_int(); }
 };
 
@@ -451,17 +451,17 @@ public:
   { collation= DTCollation_numeric(); }
   Item_real_func(THD *thd, List<Item> &list): Item_func(thd, list)
   { collation= DTCollation_numeric(); }
-  String *val_str(String*str);
-  my_decimal *val_decimal(my_decimal *decimal_value);
-  longlong val_int()
+  String *val_str(String*str) override;
+  my_decimal *val_decimal(my_decimal *decimal_value) override;
+  longlong val_int() override
   {
     DBUG_ASSERT(fixed == 1);
     return Converter_double_to_longlong(val_real(), unsigned_flag).result();
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   { return get_date_from_real(thd, ltime, fuzzydate); }
-  const Type_handler *type_handler() const { return &type_handler_double; }
-  bool fix_length_and_dec()
+  const Type_handler *type_handler() const override { return &type_handler_double; }
+  bool fix_length_and_dec() override
   {
     decimals= NOT_FIXED_DEC;
     max_length= float_length(decimals);
@@ -487,7 +487,7 @@ public:
   Item_hybrid_func(THD *thd, List<Item> &list): Item_func(thd, list) { }
   Item_hybrid_func(THD *thd, Item_hybrid_func *item)
     :Item_func(thd, item), Type_handler_hybrid_field_type(item) { }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   { return Type_handler_hybrid_field_type::type_handler(); }
   void fix_length_and_dec_long_or_longlong(uint char_length, bool unsigned_arg)
   {
@@ -543,30 +543,30 @@ public:
   class Handler_str: public Handler
   {
   public:
-    String *val_str_ascii(Item_handled_func *item, String *str) const
+    String *val_str_ascii(Item_handled_func *item, String *str) const override
     {
       return item->Item::val_str_ascii(str);
     }
-    double val_real(Item_handled_func *item) const
+    double val_real(Item_handled_func *item) const override
     {
       DBUG_ASSERT(item->is_fixed());
       StringBuffer<64> tmp;
       String *res= item->val_str(&tmp);
       return res ? item->double_from_string_with_check(res) : 0.0;
     }
-    longlong val_int(Item_handled_func *item) const
+    longlong val_int(Item_handled_func *item) const override
     {
       DBUG_ASSERT(item->is_fixed());
       StringBuffer<22> tmp;
       String *res= item->val_str(&tmp);
       return res ? item->longlong_from_string_with_check(res) : 0;
     }
-    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const
+    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const override
     {
       return item->val_decimal_from_string(to);
     }
     bool get_date(THD *thd, Item_handled_func *item, MYSQL_TIME *to,
-                  date_mode_t fuzzydate) const
+                  date_mode_t fuzzydate) const override
     {
       return item->get_date_from_string(thd, to, fuzzydate);
     }
@@ -579,7 +579,7 @@ public:
   class Handler_temporal: public Handler
   {
   public:
-    String *val_str(Item_handled_func *item, String *to) const
+    String *val_str(Item_handled_func *item, String *to) const override
     {
       StringBuffer<MAX_FIELD_WIDTH> ascii_buf;
       return item->val_str_from_val_str_ascii(to, &ascii_buf);
@@ -594,28 +594,28 @@ public:
   class Handler_temporal_string: public Handler_temporal
   {
   public:
-    const Type_handler *return_type_handler(const Item_handled_func *) const
+    const Type_handler *return_type_handler(const Item_handled_func *) const override
     {
       return &type_handler_string;
     }
     const Type_handler *
-      type_handler_for_create_select(const Item_handled_func *item) const
+      type_handler_for_create_select(const Item_handled_func *item) const override
     {
       return return_type_handler(item)->type_handler_for_tmp_table(item);
     }
-    double val_real(Item_handled_func *item) const
+    double val_real(Item_handled_func *item) const override
     {
       return Temporal_hybrid(item).to_double();
     }
-    longlong val_int(Item_handled_func *item) const
+    longlong val_int(Item_handled_func *item) const override
     {
       return Temporal_hybrid(item).to_longlong();
     }
-    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const
+    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const override
     {
       return Temporal_hybrid(item).to_decimal(to);
     }
-    String *val_str_ascii(Item_handled_func *item, String *to) const
+    String *val_str_ascii(Item_handled_func *item, String *to) const override
     {
       return Temporal_hybrid(item).to_string(to, item->decimals);
     }
@@ -625,28 +625,28 @@ public:
   class Handler_date: public Handler_temporal
   {
   public:
-    const Type_handler *return_type_handler(const Item_handled_func *) const
+    const Type_handler *return_type_handler(const Item_handled_func *) const override
     {
       return &type_handler_newdate;
     }
-    bool fix_length_and_dec(Item_handled_func *item) const
+    bool fix_length_and_dec(Item_handled_func *item) const override
     {
       item->fix_attributes_date();
       return false;
     }
-    double val_real(Item_handled_func *item) const
+    double val_real(Item_handled_func *item) const override
     {
       return Date(item).to_double();
     }
-    longlong val_int(Item_handled_func *item) const
+    longlong val_int(Item_handled_func *item) const override
     {
       return Date(item).to_longlong();
     }
-    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const
+    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const override
     {
       return Date(item).to_decimal(to);
     }
-    String *val_str_ascii(Item_handled_func *item, String *to) const
+    String *val_str_ascii(Item_handled_func *item, String *to) const override
     {
       return Date(item).to_string(to);
     }
@@ -656,27 +656,27 @@ public:
   class Handler_time: public Handler_temporal
   {
   public:
-    const Type_handler *return_type_handler(const Item_handled_func *) const
+    const Type_handler *return_type_handler(const Item_handled_func *) const override
     {
       return &type_handler_time2;
     }
-    double val_real(Item_handled_func *item) const
+    double val_real(Item_handled_func *item) const override
     {
       return Time(item).to_double();
     }
-    longlong val_int(Item_handled_func *item) const
+    longlong val_int(Item_handled_func *item) const override
     {
       return Time(item).to_longlong();
     }
-    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const
+    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const override
     {
       return Time(item).to_decimal(to);
     }
-    String *val_str_ascii(Item_handled_func *item, String *to) const
+    String *val_str_ascii(Item_handled_func *item, String *to) const override
     {
       return Time(item).to_string(to, item->decimals);
     }
-    bool val_native(THD *thd, Item_handled_func *item, Native *to) const
+    bool val_native(THD *thd, Item_handled_func *item, Native *to) const override
     {
       return Time(thd, item).to_native(to, item->decimals);
     }
@@ -686,23 +686,23 @@ public:
   class Handler_datetime: public Handler_temporal
   {
   public:
-    const Type_handler *return_type_handler(const Item_handled_func *) const
+    const Type_handler *return_type_handler(const Item_handled_func *) const override
     {
       return &type_handler_datetime2;
     }
-    double val_real(Item_handled_func *item) const
+    double val_real(Item_handled_func *item) const override
     {
       return Datetime(item).to_double();
     }
-    longlong val_int(Item_handled_func *item) const
+    longlong val_int(Item_handled_func *item) const override
     {
       return Datetime(item).to_longlong();
     }
-    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const
+    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const override
     {
       return Datetime(item).to_decimal(to);
     }
-    String *val_str_ascii(Item_handled_func *item, String *to) const
+    String *val_str_ascii(Item_handled_func *item, String *to) const override
     {
       return Datetime(item).to_string(to, item->decimals);
     }
@@ -712,7 +712,7 @@ public:
   class Handler_int: public Handler
   {
   public:
-    String *val_str(Item_handled_func *item, String *to) const
+    String *val_str(Item_handled_func *item, String *to) const override
     {
       longlong nr= val_int(item);
       if (item->null_value)
@@ -720,25 +720,25 @@ public:
       to->set_int(nr, item->unsigned_flag, item->collation.collation);
       return to;
     }
-    String *val_str_ascii(Item_handled_func *item, String *to) const
+    String *val_str_ascii(Item_handled_func *item, String *to) const override
     {
       return item->Item::val_str_ascii(to);
     }
-    double val_real(Item_handled_func *item) const
+    double val_real(Item_handled_func *item) const override
     {
       return item->unsigned_flag ? (double) ((ulonglong) val_int(item)) :
                                    (double) val_int(item);
     }
-    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const
+    my_decimal *val_decimal(Item_handled_func *item, my_decimal *to) const override
     {
       return item->val_decimal_from_int(to);
     }
     bool get_date(THD *thd, Item_handled_func *item,
-                  MYSQL_TIME *to, date_mode_t fuzzydate) const
+                  MYSQL_TIME *to, date_mode_t fuzzydate) const override
     {
       return item->get_date_from_int(thd, to, fuzzydate);
     }
-    longlong val_int(Item_handled_func *item) const
+    longlong val_int(Item_handled_func *item) const override
     {
       Longlong_null tmp= to_longlong_null(item);
       item->null_value= tmp.is_null();
@@ -750,11 +750,11 @@ public:
   class Handler_slong: public Handler_int
   {
   public:
-    const Type_handler *return_type_handler(const Item_handled_func *item) const
+    const Type_handler *return_type_handler(const Item_handled_func *item) const override
     {
       return &type_handler_slong;
     }
-    bool fix_length_and_dec(Item_handled_func *item) const
+    bool fix_length_and_dec(Item_handled_func *item) const override
     {
       item->unsigned_flag= false;
       item->collation= DTCollation_numeric();
@@ -766,7 +766,7 @@ public:
   class Handler_slong2: public Handler_slong
   {
   public:
-    bool fix_length_and_dec(Item_handled_func *func) const
+    bool fix_length_and_dec(Item_handled_func *func) const override
     {
       bool rc= Handler_slong::fix_length_and_dec(func);
       func->max_length= 2;
@@ -777,11 +777,11 @@ public:
   class Handler_ulonglong: public Handler_int
   {
   public:
-    const Type_handler *return_type_handler(const Item_handled_func *item) const
+    const Type_handler *return_type_handler(const Item_handled_func *item) const override
     {
       return &type_handler_ulonglong;
     }
-    bool fix_length_and_dec(Item_handled_func *item) const
+    bool fix_length_and_dec(Item_handled_func *item) const override
     {
       item->unsigned_flag= true;
       item->collation= DTCollation_numeric();
@@ -801,11 +801,11 @@ public:
   {
     m_func_handler= handler;
   }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return m_func_handler->return_type_handler(this);
   }
-  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table)
+  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table) override
   {
     DBUG_ASSERT(fixed);
     const Type_handler *h= m_func_handler->type_handler_for_create_select(this);
@@ -813,31 +813,31 @@ public:
                                         Record_addr(maybe_null),
                                         *this, table);
   }
-  String *val_str(String *to)
+  String *val_str(String *to) override
   {
     return m_func_handler->val_str(this, to);
   }
-  String *val_str_ascii(String *to)
+  String *val_str_ascii(String *to) override
   {
     return m_func_handler->val_str_ascii(this, to);
   }
-  double val_real()
+  double val_real() override
   {
     return m_func_handler->val_real(this);
   }
-  longlong val_int()
+  longlong val_int() override
   {
     return m_func_handler->val_int(this);
   }
-  my_decimal *val_decimal(my_decimal *to)
+  my_decimal *val_decimal(my_decimal *to) override
   {
     return m_func_handler->val_decimal(this, to);
   }
-  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t fuzzydate) override
   {
     return m_func_handler->get_date(thd, this, to, fuzzydate);
   }
-  bool val_native(THD *thd, Native *to)
+  bool val_native(THD *thd, Native *to) override
   {
     return m_func_handler->val_native(thd, this, to);
   }
@@ -940,25 +940,25 @@ public:
     Item_hybrid_func(thd, list)
   { collation= DTCollation_numeric(); }
 
-  double val_real()
+  double val_real() override
   {
     DBUG_ASSERT(fixed);
     return Item_func_hybrid_field_type::type_handler()->
            Item_func_hybrid_field_type_val_real(this);
   }
-  longlong val_int()
+  longlong val_int() override
   {
     DBUG_ASSERT(fixed);
     return Item_func_hybrid_field_type::type_handler()->
            Item_func_hybrid_field_type_val_int(this);
   }
-  my_decimal *val_decimal(my_decimal *dec)
+  my_decimal *val_decimal(my_decimal *dec) override
   {
     DBUG_ASSERT(fixed);
     return Item_func_hybrid_field_type::type_handler()->
            Item_func_hybrid_field_type_val_decimal(this, dec);
   }
-  String *val_str(String*str)
+  String *val_str(String*str) override
   {
     DBUG_ASSERT(fixed);
     String *res= Item_func_hybrid_field_type::type_handler()->
@@ -966,14 +966,14 @@ public:
     DBUG_ASSERT(null_value == (res == NULL));
     return res;
   }
-  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t mode)
+  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t mode) override
   {
     DBUG_ASSERT(fixed);
     return Item_func_hybrid_field_type::type_handler()->
            Item_func_hybrid_field_type_get_date_with_warn(thd, this, to, mode);
   }
 
-  bool val_native(THD *thd, Native *to)
+  bool val_native(THD *thd, Native *to) override
   {
     DBUG_ASSERT(fixed);
     return native_op(thd, to);
@@ -1078,7 +1078,7 @@ public:
   Item_func_case_expression(THD *thd, List<Item> &list):
     Item_func_hybrid_field_type(thd, list)
   { }
-  bool find_not_null_fields(table_map allowed) { return false; }
+  bool find_not_null_fields(table_map allowed) override { return false; }
 };
 
 
@@ -1107,18 +1107,18 @@ public:
   Item_func_numhybrid(THD *thd, List<Item> &list):
     Item_func_hybrid_field_type(thd, list)
   { }
-  String *str_op(String *str) { DBUG_ASSERT(0); return 0; }
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  String *str_op(String *str) override { DBUG_ASSERT(0); return 0; }
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     DBUG_ASSERT(0);
     return true;
   }
-  bool time_op(THD *thd, MYSQL_TIME *ltime)
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override
   {
     DBUG_ASSERT(0);
     return true;
   }
-  bool native_op(THD *thd, Native *to)
+  bool native_op(THD *thd, Native *to) override
   {
     DBUG_ASSERT(0);
     return true;
@@ -1132,8 +1132,8 @@ class Item_func_num1: public Item_func_numhybrid
 public:
   Item_func_num1(THD *thd, Item *a): Item_func_numhybrid(thd, a) {}
   Item_func_num1(THD *thd, Item *a, Item *b): Item_func_numhybrid(thd, a, b) {}
-  bool check_partition_func_processor(void *int_arg) { return FALSE; }
-  bool check_vcol_func_processor(void *arg) { return FALSE; }
+  bool check_partition_func_processor(void *int_arg) override { return FALSE; }
+  bool check_vcol_func_processor(void *arg) override { return FALSE; }
 };
 
 
@@ -1141,7 +1141,7 @@ public:
 class Item_num_op :public Item_func_numhybrid
 {
 protected:
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return false; // Checked by aggregate_for_num_op()
   }
@@ -1149,7 +1149,7 @@ public:
   Item_num_op(THD *thd, Item *a, Item *b): Item_func_numhybrid(thd, a, b) {}
   virtual void result_precision()= 0;
 
-  virtual inline void print(String *str, enum_query_type query_type)
+  inline void print(String *str, enum_query_type query_type) override
   {
     print_op(str, query_type);
   }
@@ -1179,7 +1179,7 @@ public:
     if (decimals == 0 && downcast_decimal_to_int)
       set_handler(type_handler_long_or_longlong());
   }
-  bool need_parentheses_in_default() { return true; }
+  bool need_parentheses_in_default() override { return true; }
 };
 
 
@@ -1207,16 +1207,16 @@ public:
   { collation= DTCollation_numeric(); fix_char_length(21); }
   Item_int_func(THD *thd, Item_int_func *item) :Item_func(thd, item)
   { collation= DTCollation_numeric(); }
-  double val_real();
-  String *val_str(String*str);
-  my_decimal *val_decimal(my_decimal *decimal_value)
+  double val_real() override;
+  String *val_str(String*str) override;
+  my_decimal *val_decimal(my_decimal *decimal_value) override
   {
     return val_decimal_from_int(decimal_value);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   { return get_date_from_int(thd, ltime, fuzzydate); }
-  const Type_handler *type_handler() const= 0;
-  bool fix_length_and_dec() { return FALSE; }
+  const Type_handler *type_handler() const override= 0;
+  bool fix_length_and_dec() override { return FALSE; }
 };
 
 
@@ -1229,13 +1229,13 @@ public:
   Item_long_func(THD *thd, Item *a, Item *b, Item *c): Item_int_func(thd, a, b, c) {}
   Item_long_func(THD *thd, List<Item> &list): Item_int_func(thd, list) { }
   Item_long_func(THD *thd, Item_long_func *item) :Item_int_func(thd, item) {}
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     if (unsigned_flag)
       return &type_handler_ulong;
     return &type_handler_slong;
   }
-  bool fix_length_and_dec() { max_length= 11; return FALSE; }
+  bool fix_length_and_dec() override { max_length= 11; return FALSE; }
 };
 
 
@@ -1248,12 +1248,12 @@ public:
   Item_long_ge0_func(THD *thd, Item *a, Item *b, Item *c): Item_int_func(thd, a, b, c) {}
   Item_long_ge0_func(THD *thd, List<Item> &list): Item_int_func(thd, list) { }
   Item_long_ge0_func(THD *thd, Item_long_ge0_func *item) :Item_int_func(thd, item) {}
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     DBUG_ASSERT(!unsigned_flag);
     return &type_handler_slong_ge0;
   }
-  bool fix_length_and_dec() { max_length= 10; return FALSE; }
+  bool fix_length_and_dec() override { max_length= 10; return FALSE; }
 };
 
 
@@ -1262,12 +1262,12 @@ class Item_func_hash: public Item_int_func
 public:
   Item_func_hash(THD *thd, List<Item> &item): Item_int_func(thd, item)
   {}
-  longlong val_int();
-  bool fix_length_and_dec();
-  const Type_handler *type_handler() const { return &type_handler_slong; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  bool fix_length_and_dec() override;
+  const Type_handler *type_handler() const override { return &type_handler_slong; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_hash>(thd, this); }
-  const char *func_name() const { return "<hash>"; }
+  const char *func_name() const override { return "<hash>"; }
 };
 
 class Item_func_hash_mariadb_100403: public Item_func_hash
@@ -1276,10 +1276,10 @@ public:
   Item_func_hash_mariadb_100403(THD *thd, List<Item> &item)
    :Item_func_hash(thd, item)
   {}
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_hash_mariadb_100403>(thd, this); }
-  const char *func_name() const { return "<hash_mariadb_100403>"; }
+  const char *func_name() const override { return "<hash_mariadb_100403>"; }
 };
 
 class Item_longlong_func: public Item_int_func
@@ -1293,7 +1293,7 @@ public:
     Item_int_func(thd, a, b, c, d) {}
   Item_longlong_func(THD *thd, List<Item> &list): Item_int_func(thd, list) { }
   Item_longlong_func(THD *thd, Item_longlong_func *item) :Item_int_func(thd, item) {}
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     if (unsigned_flag)
       return &type_handler_ulonglong;
@@ -1322,17 +1322,17 @@ class Item_func_cursor_rowcount: public Item_longlong_func,
 public:
   Item_func_cursor_rowcount(THD *thd, const LEX_CSTRING *name, uint offset)
    :Item_longlong_func(thd), Cursor_ref(name, offset) { maybe_null= true; }
-  const char *func_name() const { return "%ROWCOUNT"; }
-  longlong val_int();
-  bool check_vcol_func_processor(void *arg)
+  const char *func_name() const override { return "%ROWCOUNT"; }
+  longlong val_int() override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), arg, VCOL_SESSION_FUNC);
   }
-  void print(String *str, enum_query_type query_type)
+  void print(String *str, enum_query_type query_type) override
   {
     return Cursor_ref::print_func(str, func_name());
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_cursor_rowcount>(thd, this); }
 };
 
@@ -1344,15 +1344,15 @@ class Item_func_connection_id :public Item_long_func
 
 public:
   Item_func_connection_id(THD *thd): Item_long_func(thd) { unsigned_flag=1; }
-  const char *func_name() const { return "connection_id"; }
-  bool fix_length_and_dec();
-  bool fix_fields(THD *thd, Item **ref);
-  longlong val_int() { DBUG_ASSERT(fixed == 1); return value; }
-  bool check_vcol_func_processor(void *arg)
+  const char *func_name() const override { return "connection_id"; }
+  bool fix_length_and_dec() override;
+  bool fix_fields(THD *thd, Item **ref) override;
+  longlong val_int() override { DBUG_ASSERT(fixed == 1); return value; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_connection_id>(thd, this); }
 };
 
@@ -1364,13 +1364,13 @@ public:
   {
     unsigned_flag= 0;
   }
-  const char *func_name() const { return "cast_as_signed"; }
-  const Type_handler *type_handler() const
+  const char *func_name() const override { return "cast_as_signed"; }
+  const Type_handler *type_handler() const override
   {
     return Type_handler::type_handler_long_or_longlong(max_char_length(),
                                                        false);
   }
-  longlong val_int()
+  longlong val_int() override
   {
     longlong value= args[0]->val_int_signed_typecast();
     null_value= args[0]->null_value;
@@ -1412,14 +1412,14 @@ public:
     set_if_bigger(char_length, 1U + (unsigned_flag ? 0 : 1));
     fix_char_length(char_length);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     return args[0]->type_handler()->Item_func_signed_fix_length_and_dec(this);
   }
-  virtual void print(String *str, enum_query_type query_type);
-  uint decimal_precision() const { return args[0]->decimal_precision(); }
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  uint decimal_precision() const override { return args[0]->decimal_precision(); }
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_signed>(thd, this); }
 };
 
@@ -1431,26 +1431,26 @@ public:
   {
     unsigned_flag= 1;
   }
-  const char *func_name() const { return "cast_as_unsigned"; }
-  const Type_handler *type_handler() const
+  const char *func_name() const override { return "cast_as_unsigned"; }
+  const Type_handler *type_handler() const override
   {
     if (max_char_length() <= MY_INT32_NUM_DECIMAL_DIGITS - 1)
       return &type_handler_ulong;
     return &type_handler_ulonglong;
   }
-  longlong val_int()
+  longlong val_int() override
   {
     longlong value= args[0]->val_int_unsigned_typecast();
     null_value= args[0]->null_value;
     return value;
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     return args[0]->type_handler()->Item_func_unsigned_fix_length_and_dec(this);
   }
-  uint decimal_precision() const { return max_length; }
-  virtual void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  uint decimal_precision() const override { return max_length; }
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_unsigned>(thd, this); }
 };
 
@@ -1467,26 +1467,26 @@ public:
     fix_char_length(my_decimal_precision_to_length_no_truncation(len, dec,
                                                                  unsigned_flag));
   }
-  String *val_str(String *str) { return VDec(this).to_string(str); }
-  double val_real() { return VDec(this).to_double(); }
-  longlong val_int() { return VDec(this).to_longlong(unsigned_flag); }
-  my_decimal *val_decimal(my_decimal*);
-  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t mode)
+  String *val_str(String *str) override { return VDec(this).to_string(str); }
+  double val_real() override { return VDec(this).to_double(); }
+  longlong val_int() override { return VDec(this).to_longlong(unsigned_flag); }
+  my_decimal *val_decimal(my_decimal*) override;
+  bool get_date(THD *thd, MYSQL_TIME *to, date_mode_t mode) override
   {
     return decimal_to_datetime_with_warn(thd, VDec(this).ptr(), to, mode,
                                          NULL, NULL);
   }
-  const Type_handler *type_handler() const { return &type_handler_newdecimal; }
+  const Type_handler *type_handler() const override { return &type_handler_newdecimal; }
   void fix_length_and_dec_generic() {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     return
       args[0]->type_handler()->Item_decimal_typecast_fix_length_and_dec(this);
   }
-  const char *func_name() const { return "decimal_typecast"; }
-  virtual void print(String *str, enum_query_type query_type);
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "decimal_typecast"; }
+  void print(String *str, enum_query_type query_type) override;
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_decimal_typecast>(thd, this); }
 };
 
@@ -1502,8 +1502,8 @@ public:
     decimals=   (uint8)  dec;
     max_length= (uint32) len;
   }
-  bool need_parentheses_in_default() { return true; }
-  void print(String *str, enum_query_type query_type);
+  bool need_parentheses_in_default() override { return true; }
+  void print(String *str, enum_query_type query_type) override;
   void fix_length_and_dec_generic() { maybe_null= 1; }
 };
 
@@ -1514,18 +1514,18 @@ public:
   Item_float_typecast(THD *thd, Item *a)
    :Item_real_typecast(thd, a, MAX_FLOAT_STR_LENGTH, NOT_FIXED_DEC)
   { }
-  const Type_handler *type_handler() const { return &type_handler_float; }
-  bool fix_length_and_dec()
+  const Type_handler *type_handler() const override { return &type_handler_float; }
+  bool fix_length_and_dec() override
   {
     return
       args[0]->type_handler()->Item_float_typecast_fix_length_and_dec(this);
   }
-  const char *func_name() const { return "float_typecast"; }
-  double val_real()
+  const char *func_name() const override { return "float_typecast"; }
+  double val_real() override
   {
     return (double) (float) val_real_with_truncate(FLT_MAX);
   }
-  String *val_str(String*str)
+  String *val_str(String*str) override
   {
     Float nr(Item_float_typecast::val_real());
     if (null_value)
@@ -1533,7 +1533,7 @@ public:
     nr.to_string(str, decimals);
     return str;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_float_typecast>(thd, this); }
 };
 
@@ -1544,14 +1544,14 @@ public:
   Item_double_typecast(THD *thd, Item *a, uint len, uint dec):
     Item_real_typecast(thd, a, len, dec)
   { }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     return
       args[0]->type_handler()->Item_double_typecast_fix_length_and_dec(this);
   }
-  const char *func_name() const { return "double_typecast"; }
-  double val_real() { return val_real_with_truncate(DBL_MAX); }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "double_typecast"; }
+  double val_real() override { return val_real_with_truncate(DBL_MAX); }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_double_typecast>(thd, this); }
 };
 
@@ -1560,9 +1560,9 @@ class Item_func_additive_op :public Item_num_op
 {
 public:
   Item_func_additive_op(THD *thd, Item *a, Item *b): Item_num_op(thd, a, b) {}
-  void result_precision();
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
+  void result_precision() override;
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
 };
 
 
@@ -1571,13 +1571,13 @@ class Item_func_plus :public Item_func_additive_op
 public:
   Item_func_plus(THD *thd, Item *a, Item *b):
     Item_func_additive_op(thd, a, b) {}
-  const char *func_name() const { return "+"; }
-  enum precedence precedence() const { return ADD_PRECEDENCE; }
-  bool fix_length_and_dec();
-  longlong int_op();
-  double real_op();
-  my_decimal *decimal_op(my_decimal *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "+"; }
+  enum precedence precedence() const override { return ADD_PRECEDENCE; }
+  bool fix_length_and_dec() override;
+  longlong int_op() override;
+  double real_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_plus>(thd, this); }
 };
 
@@ -1589,13 +1589,13 @@ public:
     Item_func_additive_op(thd, a, b),
     m_depends_on_sql_mode_no_unsigned_subtraction(false)
   { }
-  const char *func_name() const { return "-"; }
-  enum precedence precedence() const { return ADD_PRECEDENCE; }
-  Sql_mode_dependency value_depends_on_sql_mode() const;
-  longlong int_op();
-  double real_op();
-  my_decimal *decimal_op(my_decimal *);
-  bool fix_length_and_dec();
+  const char *func_name() const override { return "-"; }
+  enum precedence precedence() const override { return ADD_PRECEDENCE; }
+  Sql_mode_dependency value_depends_on_sql_mode() const override;
+  longlong int_op() override;
+  double real_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool fix_length_and_dec() override;
   void fix_unsigned_flag();
   void fix_length_and_dec_double()
   {
@@ -1612,7 +1612,7 @@ public:
     Item_func_additive_op::fix_length_and_dec_int();
     fix_unsigned_flag();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_minus>(thd, this); }
 };
 
@@ -1622,16 +1622,16 @@ class Item_func_mul :public Item_num_op
 public:
   Item_func_mul(THD *thd, Item *a, Item *b):
     Item_num_op(thd, a, b) {}
-  const char *func_name() const { return "*"; }
-  enum precedence precedence() const { return MUL_PRECEDENCE; }
-  longlong int_op();
-  double real_op();
-  my_decimal *decimal_op(my_decimal *);
-  void result_precision();
-  bool fix_length_and_dec();
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "*"; }
+  enum precedence precedence() const override { return MUL_PRECEDENCE; }
+  longlong int_op() override;
+  double real_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  void result_precision() override;
+  bool fix_length_and_dec() override;
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_mul>(thd, this); }
 };
 
@@ -1641,16 +1641,16 @@ class Item_func_div :public Item_num_op
 public:
   uint prec_increment;
   Item_func_div(THD *thd, Item *a, Item *b): Item_num_op(thd, a, b) {}
-  longlong int_op() { DBUG_ASSERT(0); return 0; }
-  double real_op();
-  my_decimal *decimal_op(my_decimal *);
-  const char *func_name() const { return "/"; }
-  enum precedence precedence() const { return MUL_PRECEDENCE; }
-  bool fix_length_and_dec();
+  longlong int_op() override { DBUG_ASSERT(0); return 0; }
+  double real_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  const char *func_name() const override { return "/"; }
+  enum precedence precedence() const override { return MUL_PRECEDENCE; }
+  bool fix_length_and_dec() override;
   void fix_length_and_dec_double();
   void fix_length_and_dec_int();
-  void result_precision();
-  Item *get_copy(THD *thd)
+  void result_precision() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_div>(thd, this); }
 };
 
@@ -1660,21 +1660,21 @@ class Item_func_int_div :public Item_int_func
 public:
   Item_func_int_div(THD *thd, Item *a, Item *b): Item_int_func(thd, a, b)
   {}
-  longlong val_int();
-  const char *func_name() const { return "DIV"; }
-  enum precedence precedence() const { return MUL_PRECEDENCE; }
-  const Type_handler *type_handler() const
+  longlong val_int() override;
+  const char *func_name() const override { return "DIV"; }
+  enum precedence precedence() const override { return MUL_PRECEDENCE; }
+  const Type_handler *type_handler() const override
   { return type_handler_long_or_longlong(); }
-  bool fix_length_and_dec();
-  void print(String *str, enum_query_type query_type)
+  bool fix_length_and_dec() override;
+  void print(String *str, enum_query_type query_type) override
   {
     print_op(str, query_type);
   }
 
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_int_div>(thd, this); }
 };
 
@@ -1683,13 +1683,13 @@ class Item_func_mod :public Item_num_op
 {
 public:
   Item_func_mod(THD *thd, Item *a, Item *b): Item_num_op(thd, a, b) {}
-  longlong int_op();
-  double real_op();
-  my_decimal *decimal_op(my_decimal *);
-  const char *func_name() const { return "MOD"; }
-  enum precedence precedence() const { return MUL_PRECEDENCE; }
-  void result_precision();
-  bool fix_length_and_dec();
+  longlong int_op() override;
+  double real_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  const char *func_name() const override { return "MOD"; }
+  enum precedence precedence() const override { return MUL_PRECEDENCE; }
+  void result_precision() override;
+  bool fix_length_and_dec() override;
   void fix_length_and_dec_double()
   {
     Item_num_op::fix_length_and_dec_double();
@@ -1706,9 +1706,9 @@ public:
     DBUG_ASSERT(decimals == 0);
     set_handler(type_handler_long_or_longlong());
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  Item *get_copy(THD *thd)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_mod>(thd, this); }
 };
 
@@ -1717,13 +1717,13 @@ class Item_func_neg :public Item_func_num1
 {
 public:
   Item_func_neg(THD *thd, Item *a): Item_func_num1(thd, a) {}
-  double real_op();
-  longlong int_op();
-  my_decimal *decimal_op(my_decimal *);
-  const char *func_name() const { return "-"; }
-  enum Functype functype() const   { return NEG_FUNC; }
-  enum precedence precedence() const { return NEG_PRECEDENCE; }
-  void print(String *str, enum_query_type query_type)
+  double real_op() override;
+  longlong int_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  const char *func_name() const override { return "-"; }
+  enum Functype functype() const override   { return NEG_FUNC; }
+  enum precedence precedence() const override { return NEG_PRECEDENCE; }
+  void print(String *str, enum_query_type query_type) override
   {
     str->append(func_name());
     args[0]->print_parenthesised(str, query_type, precedence());
@@ -1731,10 +1731,10 @@ public:
   void fix_length_and_dec_int();
   void fix_length_and_dec_double();
   void fix_length_and_dec_decimal();
-  bool fix_length_and_dec();
-  uint decimal_precision() const { return args[0]->decimal_precision(); }
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  uint decimal_precision() const override { return args[0]->decimal_precision(); }
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_neg>(thd, this); }
 };
 
@@ -1743,16 +1743,16 @@ class Item_func_abs :public Item_func_num1
 {
 public:
   Item_func_abs(THD *thd, Item *a): Item_func_num1(thd, a) {}
-  double real_op();
-  longlong int_op();
-  my_decimal *decimal_op(my_decimal *);
-  const char *func_name() const { return "abs"; }
+  double real_op() override;
+  longlong int_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  const char *func_name() const override { return "abs"; }
   void fix_length_and_dec_int();
   void fix_length_and_dec_sint_ge0();
   void fix_length_and_dec_double();
   void fix_length_and_dec_decimal();
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_abs>(thd, this); }
 };
 
@@ -1760,12 +1760,12 @@ public:
 
 class Item_dec_func :public Item_real_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_real(0, arg_count); }
  public:
   Item_dec_func(THD *thd, Item *a): Item_real_func(thd, a) {}
   Item_dec_func(THD *thd, Item *a, Item *b): Item_real_func(thd, a, b) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals=NOT_FIXED_DEC; max_length=float_length(decimals);
     maybe_null=1;
@@ -1777,9 +1777,9 @@ class Item_func_exp :public Item_dec_func
 {
 public:
   Item_func_exp(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "exp"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "exp"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_exp>(thd, this); }
 };
 
@@ -1788,9 +1788,9 @@ class Item_func_ln :public Item_dec_func
 {
 public:
   Item_func_ln(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "ln"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "ln"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ln>(thd, this); }
 };
 
@@ -1800,9 +1800,9 @@ class Item_func_log :public Item_dec_func
 public:
   Item_func_log(THD *thd, Item *a): Item_dec_func(thd, a) {}
   Item_func_log(THD *thd, Item *a, Item *b): Item_dec_func(thd, a, b) {}
-  double val_real();
-  const char *func_name() const { return "log"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "log"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_log>(thd, this); }
 };
 
@@ -1811,9 +1811,9 @@ class Item_func_log2 :public Item_dec_func
 {
 public:
   Item_func_log2(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "log2"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "log2"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_log2>(thd, this); }
 };
 
@@ -1822,9 +1822,9 @@ class Item_func_log10 :public Item_dec_func
 {
 public:
   Item_func_log10(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "log10"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "log10"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_log10>(thd, this); }
 };
 
@@ -1833,9 +1833,9 @@ class Item_func_sqrt :public Item_dec_func
 {
 public:
   Item_func_sqrt(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "sqrt"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "sqrt"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sqrt>(thd, this); }
 };
 
@@ -1844,9 +1844,9 @@ class Item_func_pow :public Item_dec_func
 {
 public:
   Item_func_pow(THD *thd, Item *a, Item *b): Item_dec_func(thd, a, b) {}
-  double val_real();
-  const char *func_name() const { return "pow"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "pow"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_pow>(thd, this); }
 };
 
@@ -1855,9 +1855,9 @@ class Item_func_acos :public Item_dec_func
 {
 public:
   Item_func_acos(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "acos"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "acos"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_acos>(thd, this); }
 };
 
@@ -1865,9 +1865,9 @@ class Item_func_asin :public Item_dec_func
 {
 public:
   Item_func_asin(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "asin"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "asin"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_asin>(thd, this); }
 };
 
@@ -1876,9 +1876,9 @@ class Item_func_atan :public Item_dec_func
 public:
   Item_func_atan(THD *thd, Item *a): Item_dec_func(thd, a) {}
   Item_func_atan(THD *thd, Item *a, Item *b): Item_dec_func(thd, a, b) {}
-  double val_real();
-  const char *func_name() const { return "atan"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "atan"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_atan>(thd, this); }
 };
 
@@ -1886,9 +1886,9 @@ class Item_func_cos :public Item_dec_func
 {
 public:
   Item_func_cos(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "cos"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "cos"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_cos>(thd, this); }
 };
 
@@ -1896,9 +1896,9 @@ class Item_func_sin :public Item_dec_func
 {
 public:
   Item_func_sin(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "sin"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "sin"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sin>(thd, this); }
 };
 
@@ -1906,9 +1906,9 @@ class Item_func_tan :public Item_dec_func
 {
 public:
   Item_func_tan(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "tan"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "tan"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_tan>(thd, this); }
 };
 
@@ -1916,9 +1916,9 @@ class Item_func_cot :public Item_dec_func
 {
 public:
   Item_func_cot(THD *thd, Item *a): Item_dec_func(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "cot"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "cot"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_cot>(thd, this); }
 };
 
@@ -1927,8 +1927,8 @@ class Item_func_int_val :public Item_func_hybrid_field_type
 {
 public:
   Item_func_int_val(THD *thd, Item *a): Item_func_hybrid_field_type(thd, a) {}
-  bool check_partition_func_processor(void *int_arg) { return FALSE; }
-  bool check_vcol_func_processor(void *arg) { return FALSE; }
+  bool check_partition_func_processor(void *int_arg) override { return FALSE; }
+  bool check_vcol_func_processor(void *arg) override { return FALSE; }
   virtual decimal_round_mode round_mode() const= 0;
   void fix_length_and_dec_double();
   void fix_length_and_dec_int_or_decimal();
@@ -1943,9 +1943,9 @@ public:
     set_handler(&type_handler_datetime2);
     maybe_null= true; // E.g. CEILING(TIMESTAMP'0000-01-01 23:59:59.9')
   }
-  bool fix_length_and_dec();
-  String *str_op(String *str) { DBUG_ASSERT(0); return 0; }
-  bool native_op(THD *thd, Native *to);
+  bool fix_length_and_dec() override;
+  String *str_op(String *str) override { DBUG_ASSERT(0); return 0; }
+  bool native_op(THD *thd, Native *to) override;
 };
 
 
@@ -1953,14 +1953,14 @@ class Item_func_ceiling :public Item_func_int_val
 {
 public:
   Item_func_ceiling(THD *thd, Item *a): Item_func_int_val(thd, a) {}
-  const char *func_name() const { return "ceiling"; }
-  decimal_round_mode round_mode() const { return CEILING; }
-  longlong int_op();
-  double real_op();
-  my_decimal *decimal_op(my_decimal *);
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool time_op(THD *thd, MYSQL_TIME *ltime);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "ceiling"; }
+  decimal_round_mode round_mode() const override { return CEILING; }
+  longlong int_op() override;
+  double real_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ceiling>(thd, this); }
 };
 
@@ -1969,14 +1969,14 @@ class Item_func_floor :public Item_func_int_val
 {
 public:
   Item_func_floor(THD *thd, Item *a): Item_func_int_val(thd, a) {}
-  const char *func_name() const { return "floor"; }
-  decimal_round_mode round_mode() const { return FLOOR; }
-  longlong int_op();
-  double real_op();
-  my_decimal *decimal_op(my_decimal *);
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool time_op(THD *thd, MYSQL_TIME *ltime);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "floor"; }
+  decimal_round_mode round_mode() const override { return FLOOR; }
+  longlong int_op() override;
+  double real_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_floor>(thd, this); }
 };
 
@@ -1991,14 +1991,14 @@ class Item_func_round :public Item_func_hybrid_field_type
 public:
   Item_func_round(THD *thd, Item *a, Item *b, bool trunc_arg)
     :Item_func_hybrid_field_type(thd, a, b), truncate(trunc_arg) {}
-  const char *func_name() const { return truncate ? "truncate" : "round"; }
-  double real_op();
-  longlong int_op();
-  my_decimal *decimal_op(my_decimal *);
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool time_op(THD *thd, MYSQL_TIME *ltime);
-  bool native_op(THD *thd, Native *to);
-  String *str_op(String *str)
+  const char *func_name() const override { return truncate ? "truncate" : "round"; }
+  double real_op() override;
+  longlong int_op() override;
+  my_decimal *decimal_op(my_decimal *) override;
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool time_op(THD *thd, MYSQL_TIME *ltime) override;
+  bool native_op(THD *thd, Native *to) override;
+  String *str_op(String *str) override
   {
     DBUG_ASSERT(0);
     return NULL;
@@ -2013,7 +2013,7 @@ public:
   void fix_arg_time();
   void fix_arg_datetime();
   void fix_arg_temporal(const Type_handler *h, uint int_part_length);
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     /*
       We don't want to translate ENUM/SET to CHAR here.
@@ -2021,7 +2021,7 @@ public:
     */
     return args[0]->real_type_handler()->Item_func_round_fix_length_and_dec(this);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_round>(thd, this); }
 };
 
@@ -2030,39 +2030,39 @@ class Item_func_rand :public Item_real_func
 {
   struct my_rnd_struct *rand;
   bool first_eval; // TRUE if val_real() is called 1st time
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_int(0, arg_count); }
   void seed_random (Item * val);
 public:
   Item_func_rand(THD *thd, Item *a):
     Item_real_func(thd, a), rand(0), first_eval(TRUE) {}
   Item_func_rand(THD *thd): Item_real_func(thd) {}
-  double val_real();
-  const char *func_name() const { return "rand"; }
-  bool const_item() const { return 0; }
-  void update_used_tables();
-  bool fix_fields(THD *thd, Item **ref);
-  void cleanup() { first_eval= TRUE; Item_real_func::cleanup(); }
-  bool check_vcol_func_processor(void *arg)
+  double val_real() override;
+  const char *func_name() const override { return "rand"; }
+  bool const_item() const override { return 0; }
+  void update_used_tables() override;
+  bool fix_fields(THD *thd, Item **ref) override;
+  void cleanup() override { first_eval= TRUE; Item_real_func::cleanup(); }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_rand>(thd, this); }
 };
 
 
 class Item_func_sign :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_real(func_name()); }
 public:
   Item_func_sign(THD *thd, Item *a): Item_long_func(thd, a) {}
-  const char *func_name() const { return "sign"; }
-  uint decimal_precision() const { return 1; }
-  bool fix_length_and_dec() { fix_char_length(2); return FALSE; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "sign"; }
+  uint decimal_precision() const override { return 1; }
+  bool fix_length_and_dec() override { fix_char_length(2); return FALSE; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sign>(thd, this); }
 };
 
@@ -2071,21 +2071,21 @@ class Item_func_units :public Item_real_func
 {
   char *name;
   double mul,add;
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_real(0, arg_count); }
 public:
   Item_func_units(THD *thd, char *name_arg, Item *a, double mul_arg,
                   double add_arg):
     Item_real_func(thd, a), name(name_arg), mul(mul_arg), add(add_arg) {}
-  double val_real();
-  const char *func_name() const { return name; }
-  bool fix_length_and_dec()
+  double val_real() override;
+  const char *func_name() const override { return name; }
+  bool fix_length_and_dec() override
   {
     decimals= NOT_FIXED_DEC;
     max_length= float_length(decimals);
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_units>(thd, this); }
 };
 
@@ -2106,7 +2106,7 @@ class Item_func_min_max :public Item_hybrid_func
   String tmp_value;
   int cmp_sign;
 protected:
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return false; // Checked by aggregate_for_min_max()
   }
@@ -2122,37 +2122,37 @@ public:
   bool get_date_native(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
   bool get_time_native(THD *thd, MYSQL_TIME *res);
 
-  double val_real()
+  double val_real() override
   {
     DBUG_ASSERT(fixed);
     return Item_func_min_max::type_handler()->
              Item_func_min_max_val_real(this);
   }
-  longlong val_int()
+  longlong val_int() override
   {
     DBUG_ASSERT(fixed);
     return Item_func_min_max::type_handler()->
              Item_func_min_max_val_int(this);
   }
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     DBUG_ASSERT(fixed);
     return Item_func_min_max::type_handler()->
              Item_func_min_max_val_str(this, str);
   }
-  my_decimal *val_decimal(my_decimal *dec)
+  my_decimal *val_decimal(my_decimal *dec) override
   {
     DBUG_ASSERT(fixed);
     return Item_func_min_max::type_handler()->
              Item_func_min_max_val_decimal(this, dec);
   }
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override
   {
     DBUG_ASSERT(fixed);
     return Item_func_min_max::type_handler()->
              Item_func_min_max_get_date(thd, this, res, fuzzydate);
   }
-  bool val_native(THD *thd, Native *to);
+  bool val_native(THD *thd, Native *to) override;
   void aggregate_attributes_real(Item **items, uint nitems)
   {
     /*
@@ -2173,7 +2173,7 @@ public:
     Item_func::aggregate_attributes_real(items, nitems);
     max_length= float_length(decimals);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     if (aggregate_for_min_max(func_name(), args, arg_count))
       return true;
@@ -2186,8 +2186,8 @@ class Item_func_min :public Item_func_min_max
 {
 public:
   Item_func_min(THD *thd, List<Item> &list): Item_func_min_max(thd, list, 1) {}
-  const char *func_name() const { return "least"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "least"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_min>(thd, this); }
 };
 
@@ -2195,8 +2195,8 @@ class Item_func_max :public Item_func_min_max
 {
 public:
   Item_func_max(THD *thd, List<Item> &list): Item_func_min_max(thd, list, -1) {}
-  const char *func_name() const { return "greatest"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "greatest"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_max>(thd, this); }
 };
 
@@ -2213,35 +2213,35 @@ public:
   {
     name= a->name;
   }
-  double val_real() { return val_real_from_item(args[0]); }
-  longlong val_int() { return val_int_from_item(args[0]); }
-  String *val_str(String *str) { return val_str_from_item(args[0], str); }
-  bool val_native(THD *thd, Native *to)
+  double val_real() override { return val_real_from_item(args[0]); }
+  longlong val_int() override { return val_int_from_item(args[0]); }
+  String *val_str(String *str) override { return val_str_from_item(args[0], str); }
+  bool val_native(THD *thd, Native *to) override
     { return val_native_from_item(thd, args[0], to); }
-  my_decimal *val_decimal(my_decimal *dec)
+  my_decimal *val_decimal(my_decimal *dec) override
     { return val_decimal_from_item(args[0], dec); }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
     { return get_date_from_item(thd, args[0], ltime, fuzzydate); }
-  const char *func_name() const { return "rollup_const"; }
-  bool const_item() const { return 0; }
-  const Type_handler *type_handler() const { return args[0]->type_handler(); }
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "rollup_const"; }
+  bool const_item() const override { return 0; }
+  const Type_handler *type_handler() const override { return args[0]->type_handler(); }
+  bool fix_length_and_dec() override
   {
     Type_std_attributes::set(*args[0]);
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_rollup_const>(thd, this); }
 };
 
 
 class Item_long_func_length: public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_str(func_name()); }
 public:
   Item_long_func_length(THD *thd, Item *a): Item_long_func(thd, a) {}
-  bool fix_length_and_dec() { max_length=10; return FALSE; }
+  bool fix_length_and_dec() override { max_length=10; return FALSE; }
 };
 
 
@@ -2250,9 +2250,9 @@ class Item_func_octet_length :public Item_long_func_length
   String value;
 public:
   Item_func_octet_length(THD *thd, Item *a): Item_long_func_length(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "octet_length"; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "octet_length"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_octet_length>(thd, this); }
 };
 
@@ -2261,14 +2261,14 @@ class Item_func_bit_length :public Item_longlong_func
   String value;
 public:
   Item_func_bit_length(THD *thd, Item *a): Item_longlong_func(thd, a) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     max_length= 11; // 0x100000000*8 = 34,359,738,368
     return FALSE;
   }
-  longlong val_int();
-  const char *func_name() const { return "bit_length"; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "bit_length"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_bit_length>(thd, this); }
 };
 
@@ -2277,34 +2277,34 @@ class Item_func_char_length :public Item_long_func_length
   String value;
 public:
   Item_func_char_length(THD *thd, Item *a): Item_long_func_length(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "char_length"; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "char_length"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_char_length>(thd, this); }
 };
 
 class Item_func_coercibility :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_str(func_name()); }
 public:
   Item_func_coercibility(THD *thd, Item *a): Item_long_func(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "coercibility"; }
-  bool fix_length_and_dec() { max_length=10; maybe_null= 0; return FALSE; }
-  bool eval_not_null_tables(void *)
+  longlong val_int() override;
+  const char *func_name() const override { return "coercibility"; }
+  bool fix_length_and_dec() override { max_length=10; maybe_null= 0; return FALSE; }
+  bool eval_not_null_tables(void *) override
   {
     not_null_tables_cache= 0;
     return false;
   }
-  bool find_not_null_fields(table_map allowed)
+  bool find_not_null_fields(table_map allowed) override
   {
     return false;
   }
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   { return this; }
-  bool const_item() const { return true; }
-  Item *get_copy(THD *thd)
+  bool const_item() const override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_coercibility>(thd, this); }
 };
 
@@ -2317,7 +2317,7 @@ public:
 */
 class Item_func_locate :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return check_argument_types_can_return_str(0, 2) ||
            (arg_count > 2 && args[2]->check_type_can_return_int(func_name()));
@@ -2329,15 +2329,15 @@ public:
    :Item_long_func(thd, a, b) {}
   Item_func_locate(THD *thd, Item *a, Item *b, Item *c)
    :Item_long_func(thd, a, b, c) {}
-  const char *func_name() const { return "locate"; }
-  longlong val_int();
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "locate"; }
+  longlong val_int() override;
+  bool fix_length_and_dec() override
   {
     max_length= MY_INT32_NUM_DECIMAL_DIGITS;
     return agg_arg_charsets_for_comparison(cmp_collation, args, 2);
   }
-  virtual void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_locate>(thd, this); }
 };
 
@@ -2349,45 +2349,45 @@ class Item_func_field :public Item_long_func
   DTCollation cmp_collation;
 public:
   Item_func_field(THD *thd, List<Item> &list): Item_long_func(thd, list) {}
-  longlong val_int();
-  const char *func_name() const { return "field"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "field"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_field>(thd, this); }
 };
 
 
 class Item_func_ascii :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_str(0, arg_count); }
   String value;
 public:
   Item_func_ascii(THD *thd, Item *a): Item_long_func(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "ascii"; }
-  bool fix_length_and_dec() { max_length=3; return FALSE; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "ascii"; }
+  bool fix_length_and_dec() override { max_length=3; return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ascii>(thd, this); }
 };
 
 class Item_func_ord :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_str(func_name()); }
   String value;
 public:
   Item_func_ord(THD *thd, Item *a): Item_long_func(thd, a) {}
-  bool fix_length_and_dec() { fix_char_length(7); return FALSE; }
-  longlong val_int();
-  const char *func_name() const { return "ord"; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override { fix_char_length(7); return FALSE; }
+  longlong val_int() override;
+  const char *func_name() const override { return "ord"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ord>(thd, this); }
 };
 
 class Item_func_find_in_set :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_str(0, 2); }
   String value,value2;
   uint enum_value;
@@ -2396,10 +2396,10 @@ class Item_func_find_in_set :public Item_long_func
 public:
   Item_func_find_in_set(THD *thd, Item *a, Item *b):
     Item_long_func(thd, a, b), enum_value(0) {}
-  longlong val_int();
-  const char *func_name() const { return "find_in_set"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "find_in_set"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_find_in_set>(thd, this); }
 };
 
@@ -2407,7 +2407,7 @@ public:
 
 class Item_func_bit_operator: public Item_handled_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_int(0, arg_count); }
 protected:
   bool fix_length_and_dec_op1_std(const Handler *ha_int, const Handler *ha_dec)
@@ -2426,11 +2426,11 @@ public:
    :Item_handled_func(thd, a) {}
   Item_func_bit_operator(THD *thd, Item *a, Item *b)
    :Item_handled_func(thd, a, b) {}
-  void print(String *str, enum_query_type query_type)
+  void print(String *str, enum_query_type query_type) override
   {
     print_op(str, query_type);
   }
-  bool need_parentheses_in_default() { return true; }
+  bool need_parentheses_in_default() override { return true; }
 };
 
 class Item_func_bit_or :public Item_func_bit_operator
@@ -2438,10 +2438,10 @@ class Item_func_bit_or :public Item_func_bit_operator
 public:
   Item_func_bit_or(THD *thd, Item *a, Item *b)
    :Item_func_bit_operator(thd, a, b) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return "|"; }
-  enum precedence precedence() const { return BITOR_PRECEDENCE; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "|"; }
+  enum precedence precedence() const override { return BITOR_PRECEDENCE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_bit_or>(thd, this); }
 };
 
@@ -2450,22 +2450,22 @@ class Item_func_bit_and :public Item_func_bit_operator
 public:
   Item_func_bit_and(THD *thd, Item *a, Item *b)
    :Item_func_bit_operator(thd, a, b) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return "&"; }
-  enum precedence precedence() const { return BITAND_PRECEDENCE; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "&"; }
+  enum precedence precedence() const override { return BITAND_PRECEDENCE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_bit_and>(thd, this); }
 };
 
 class Item_func_bit_count :public Item_handled_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_int(func_name()); }
 public:
   Item_func_bit_count(THD *thd, Item *a): Item_handled_func(thd, a) {}
-  const char *func_name() const { return "bit_count"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "bit_count"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_bit_count>(thd, this); }
 };
 
@@ -2474,10 +2474,10 @@ class Item_func_shift_left :public Item_func_bit_operator
 public:
   Item_func_shift_left(THD *thd, Item *a, Item *b)
    :Item_func_bit_operator(thd, a, b) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return "<<"; }
-  enum precedence precedence() const { return SHIFT_PRECEDENCE; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "<<"; }
+  enum precedence precedence() const override { return SHIFT_PRECEDENCE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_shift_left>(thd, this); }
 };
 
@@ -2486,10 +2486,10 @@ class Item_func_shift_right :public Item_func_bit_operator
 public:
   Item_func_shift_right(THD *thd, Item *a, Item *b)
    :Item_func_bit_operator(thd, a, b) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return ">>"; }
-  enum precedence precedence() const { return SHIFT_PRECEDENCE; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return ">>"; }
+  enum precedence precedence() const override { return SHIFT_PRECEDENCE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_shift_right>(thd, this); }
 };
 
@@ -2497,48 +2497,48 @@ class Item_func_bit_neg :public Item_func_bit_operator
 {
 public:
   Item_func_bit_neg(THD *thd, Item *a): Item_func_bit_operator(thd, a) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return "~"; }
-  enum precedence precedence() const { return NEG_PRECEDENCE; }
-  void print(String *str, enum_query_type query_type)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "~"; }
+  enum precedence precedence() const override { return NEG_PRECEDENCE; }
+  void print(String *str, enum_query_type query_type) override
   {
     str->append(func_name());
     args[0]->print_parenthesised(str, query_type, precedence());
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_bit_neg>(thd, this); }
 };
 
 
 class Item_func_last_insert_id :public Item_longlong_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_int(0, arg_count); }
 public:
   Item_func_last_insert_id(THD *thd): Item_longlong_func(thd) {}
   Item_func_last_insert_id(THD *thd, Item *a): Item_longlong_func(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "last_insert_id"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "last_insert_id"; }
+  bool fix_length_and_dec() override
   {
     unsigned_flag= true;
     if (arg_count)
       max_length= args[0]->max_length;
     return FALSE;
   }
-  bool fix_fields(THD *thd, Item **ref);
-  bool check_vcol_func_processor(void *arg)
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_last_insert_id>(thd, this); }
 };
 
 
 class Item_func_benchmark :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_can_return_int(func_name()) ||
            args[1]->check_type_scalar(func_name());
@@ -2547,15 +2547,15 @@ public:
   Item_func_benchmark(THD *thd, Item *count_expr, Item *expr):
     Item_long_func(thd, count_expr, expr)
   {}
-  longlong val_int();
-  const char *func_name() const { return "benchmark"; }
-  bool fix_length_and_dec() { max_length=1; maybe_null=0; return FALSE; }
-  virtual void print(String *str, enum_query_type query_type);
-  bool check_vcol_func_processor(void *arg)
+  longlong val_int() override;
+  const char *func_name() const override { return "benchmark"; }
+  bool fix_length_and_dec() override { max_length=1; maybe_null=0; return FALSE; }
+  void print(String *str, enum_query_type query_type) override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_benchmark>(thd, this); }
 };
 
@@ -2565,24 +2565,24 @@ void item_func_sleep_free(void);
 
 class Item_func_sleep :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_real(func_name()); }
 public:
   Item_func_sleep(THD *thd, Item *a): Item_long_func(thd, a) {}
-  bool fix_length_and_dec() { fix_char_length(1); return FALSE; }
-  bool const_item() const { return 0; }
-  const char *func_name() const { return "sleep"; }
-  table_map used_tables() const
+  bool fix_length_and_dec() override { fix_char_length(1); return FALSE; }
+  bool const_item() const override { return 0; }
+  const char *func_name() const override { return "sleep"; }
+  table_map used_tables() const override
   {
     return used_tables_cache | RAND_TABLE_BIT;
   }
-  bool is_expensive() { return 1; }
-  longlong val_int();
-  bool check_vcol_func_processor(void *arg)
+  bool is_expensive() override { return 1; }
+  longlong val_int() override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sleep>(thd, this); }
 };
 
@@ -2603,7 +2603,7 @@ class Item_udf_func :public Item_func
   }
 protected:
   udf_handler udf;
-  bool is_expensive_processor(void *arg) { return TRUE; }
+  bool is_expensive_processor(void *arg) override { return TRUE; }
 
   class VDec_udf: public Dec_ptr_and_buffer
   {
@@ -2622,9 +2622,9 @@ public:
     Item_func(thd), udf(udf_arg) {}
   Item_udf_func(THD *thd, udf_func *udf_arg, List<Item> &list):
     Item_func(thd, list), udf(udf_arg) {}
-  const char *func_name() const { return udf.name(); }
-  enum Functype functype() const   { return UDF_FUNC; }
-  bool fix_fields(THD *thd, Item **ref)
+  const char *func_name() const override { return udf.name(); }
+  enum Functype functype() const override   { return UDF_FUNC; }
+  bool fix_fields(THD *thd, Item **ref) override
   {
     DBUG_ASSERT(fixed == 0);
     bool res= udf.fix_fields(thd, this, arg_count, args);
@@ -2633,7 +2633,7 @@ public:
     return res;
   }
   void fix_num_length_and_dec();
-  void update_used_tables()
+  void update_used_tables() override
   {
     /*
       TODO: Make a member in UDF_INIT and return if a UDF is deterministic or
@@ -2682,27 +2682,27 @@ public:
       set_non_deterministic_if_needed();
     }
   }
-  void cleanup();
-  bool eval_not_null_tables(void *opt_arg)
+  void cleanup() override;
+  bool eval_not_null_tables(void *opt_arg) override
   {
     not_null_tables_cache= 0;
     return 0;
   }
-  bool find_not_null_fields(table_map allowed)
+  bool find_not_null_fields(table_map allowed) override
   {
     return false;
   }
-  bool is_expensive() { return 1; }
-  virtual void print(String *str, enum_query_type query_type);
-  bool check_vcol_func_processor(void *arg)
+  bool is_expensive() override { return 1; }
+  void print(String *str, enum_query_type query_type) override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_NON_DETERMINISTIC);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
-  bool excl_dep_on_grouping_fields(st_select_lex *sel)
+  bool excl_dep_on_grouping_fields(st_select_lex *sel) override
   { return false; }
 };
 
@@ -2715,13 +2715,13 @@ class Item_func_udf_float :public Item_udf_func
   Item_func_udf_float(THD *thd, udf_func *udf_arg,
                       List<Item> &list):
     Item_udf_func(thd, udf_arg, list) {}
-  longlong val_int()
+  longlong val_int() override
   {
     DBUG_ASSERT(fixed == 1);
     return Converter_double_to_longlong(Item_func_udf_float::val_real(),
                                         unsigned_flag).result();
   }
-  my_decimal *val_decimal(my_decimal *dec_buf)
+  my_decimal *val_decimal(my_decimal *dec_buf) override
   {
     double res=val_real();
     if (null_value)
@@ -2729,11 +2729,11 @@ class Item_func_udf_float :public Item_udf_func
     double2my_decimal(E_DEC_FATAL_ERROR, res, dec_buf);
     return dec_buf;
   }
-  double val_real();
-  String *val_str(String *str);
-  const Type_handler *type_handler() const { return &type_handler_double; }
-  bool fix_length_and_dec() { fix_num_length_and_dec(); return FALSE; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  String *val_str(String *str) override;
+  const Type_handler *type_handler() const override { return &type_handler_double; }
+  bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_udf_float>(thd, this); }
 };
 
@@ -2746,21 +2746,21 @@ public:
   Item_func_udf_int(THD *thd, udf_func *udf_arg,
                     List<Item> &list):
     Item_udf_func(thd, udf_arg, list) {}
-  longlong val_int();
-  double val_real() { return (double) Item_func_udf_int::val_int(); }
-  my_decimal *val_decimal(my_decimal *decimal_value)
+  longlong val_int() override;
+  double val_real() override { return (double) Item_func_udf_int::val_int(); }
+  my_decimal *val_decimal(my_decimal *decimal_value) override
   {
     return val_decimal_from_int(decimal_value);
   }
-  String *val_str(String *str);
-  const Type_handler *type_handler() const
+  String *val_str(String *str) override;
+  const Type_handler *type_handler() const override
   {
     if (unsigned_flag)
       return &type_handler_ulonglong;
     return &type_handler_slonglong;
   }
-  bool fix_length_and_dec() { decimals= 0; max_length= 21; return FALSE; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override { decimals= 0; max_length= 21; return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_udf_int>(thd, this); }
 };
 
@@ -2772,22 +2772,22 @@ public:
     Item_udf_func(thd, udf_arg) {}
   Item_func_udf_decimal(THD *thd, udf_func *udf_arg, List<Item> &list):
     Item_udf_func(thd, udf_arg, list) {}
-  longlong val_int()
+  longlong val_int() override
   {
     return VDec_udf(this, &udf).to_longlong(unsigned_flag);
   }
-  double val_real()
+  double val_real() override
   {
     return VDec_udf(this, &udf).to_double();
   }
-  my_decimal *val_decimal(my_decimal *);
-  String *val_str(String *str)
+  my_decimal *val_decimal(my_decimal *) override;
+  String *val_str(String *str) override
   {
     return VDec_udf(this, &udf).to_string_round(str, decimals);
   }
-  const Type_handler *type_handler() const { return &type_handler_newdecimal; }
-  bool fix_length_and_dec() { fix_num_length_and_dec(); return FALSE; }
-  Item *get_copy(THD *thd)
+  const Type_handler *type_handler() const override { return &type_handler_newdecimal; }
+  bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_udf_decimal>(thd, this); }
 };
 
@@ -2799,8 +2799,8 @@ public:
     Item_udf_func(thd, udf_arg) {}
   Item_func_udf_str(THD *thd, udf_func *udf_arg, List<Item> &list):
     Item_udf_func(thd, udf_arg, list) {}
-  String *val_str(String *);
-  double val_real()
+  String *val_str(String *) override;
+  double val_real() override
   {
     int err_not_used;
     char *end_not_used;
@@ -2809,14 +2809,14 @@ public:
     return res ? res->charset()->strntod((char*) res->ptr(), res->length(),
                                          &end_not_used, &err_not_used) : 0.0;
   }
-  longlong val_int()
+  longlong val_int() override
   {
     int err_not_used;
     String *res;  res=val_str(&str_value);
     return res ? res->charset()->strntoll(res->ptr(),res->length(),10,
                                           (char**) 0, &err_not_used) : (longlong) 0;
   }
-  my_decimal *val_decimal(my_decimal *dec_buf)
+  my_decimal *val_decimal(my_decimal *dec_buf) override
   {
     String *res=val_str(&str_value);
     if (!res)
@@ -2824,9 +2824,9 @@ public:
     string2my_decimal(E_DEC_FATAL_ERROR, res, dec_buf);
     return dec_buf;
   }
-  const Type_handler *type_handler() const { return string_type_handler(); }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  const Type_handler *type_handler() const override { return string_type_handler(); }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_udf_str>(thd, this); }
 };
 
@@ -2893,13 +2893,13 @@ class Item_func_lock :public Item_long_func
   Item_func_lock(THD *thd): Item_long_func(thd) { }
   Item_func_lock(THD *thd, Item *a): Item_long_func(thd, a) {}
   Item_func_lock(THD *thd, Item *a, Item *b): Item_long_func(thd, a, b) {}
-  table_map used_tables() const
+  table_map used_tables() const override
   {
     return used_tables_cache | RAND_TABLE_BIT;
   }
-  bool const_item() const { return 0; }
-  bool is_expensive() { return 1; }
-  bool check_vcol_func_processor(void *arg)
+  bool const_item() const override { return 0; }
+  bool is_expensive() override { return 1; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
@@ -2908,7 +2908,7 @@ class Item_func_lock :public Item_long_func
 
 class Item_func_get_lock final :public Item_func_lock
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_general_purpose_string(func_name()) ||
            args[1]->check_type_can_return_real(func_name());
@@ -2916,10 +2916,10 @@ class Item_func_get_lock final :public Item_func_lock
   String value;
  public:
   Item_func_get_lock(THD *thd, Item *a, Item *b) :Item_func_lock(thd, a, b) {}
-  longlong val_int() final;
-  const char *func_name() const final { return "get_lock"; }
-  bool fix_length_and_dec() { max_length= 1; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) final
+  longlong val_int() override final;
+  const char *func_name() const override final { return "get_lock"; }
+  bool fix_length_and_dec() override { max_length= 1; maybe_null= 1; return FALSE; }
+  Item *get_copy(THD *thd) override final
   { return get_item_copy<Item_func_get_lock>(thd, this); }
 };
 
@@ -2929,24 +2929,24 @@ class Item_func_release_all_locks final :public Item_func_lock
 public:
   Item_func_release_all_locks(THD *thd): Item_func_lock(thd)
   { unsigned_flag= 1; }
-  longlong val_int() final;
-  const char *func_name() const final { return "release_all_locks"; }
-  Item *get_copy(THD *thd) final
+  longlong val_int() override final;
+  const char *func_name() const override final { return "release_all_locks"; }
+  Item *get_copy(THD *thd) override final
   { return get_item_copy<Item_func_release_all_locks>(thd, this); }
 };
 
 
 class Item_func_release_lock final :public Item_func_lock
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_general_purpose_string(func_name()); }
   String value;
 public:
   Item_func_release_lock(THD *thd, Item *a): Item_func_lock(thd, a) {}
-  longlong val_int() final;
-  const char *func_name() const { return "release_lock"; }
-  bool fix_length_and_dec() { max_length= 1; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) final
+  longlong val_int() override final;
+  const char *func_name() const override { return "release_lock"; }
+  bool fix_length_and_dec() override { max_length= 1; maybe_null= 1; return FALSE; }
+  Item *get_copy(THD *thd) override final
   { return get_item_copy<Item_func_release_lock>(thd, this); }
 };
 
@@ -2955,7 +2955,7 @@ public:
 
 class Item_master_pos_wait :public Item_longlong_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return
       args[0]->check_type_general_purpose_string(func_name()) ||
@@ -2971,21 +2971,21 @@ public:
     Item_longlong_func(thd, a, b, c) {}
   Item_master_pos_wait(THD *thd, Item *a, Item *b, Item *c, Item *d):
     Item_longlong_func(thd, a, b, c, d) {}
-  longlong val_int();
-  const char *func_name() const { return "master_pos_wait"; }
-  bool fix_length_and_dec() { max_length=21; maybe_null=1; return FALSE; }
-  bool check_vcol_func_processor(void *arg)
+  longlong val_int() override;
+  const char *func_name() const override { return "master_pos_wait"; }
+  bool fix_length_and_dec() override { max_length=21; maybe_null=1; return FALSE; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_master_pos_wait>(thd, this); }
 };
 
 
 class Item_master_gtid_wait :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_general_purpose_string(func_name()) ||
            (arg_count > 1 && args[1]->check_type_can_return_real(func_name()));
@@ -2996,14 +2996,14 @@ public:
    :Item_long_func(thd, a) {}
   Item_master_gtid_wait(THD *thd, Item *a, Item *b)
    :Item_long_func(thd, a, b) {}
-  longlong val_int();
-  const char *func_name() const { return "master_gtid_wait"; }
-  bool fix_length_and_dec() { max_length=2; return FALSE; }
-  bool check_vcol_func_processor(void *arg)
+  longlong val_int() override;
+  const char *func_name() const override { return "master_gtid_wait"; }
+  bool fix_length_and_dec() override { max_length=2; return FALSE; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_master_gtid_wait>(thd, this); }
 };
 
@@ -3030,16 +3030,16 @@ public:
     :Item_hybrid_func(thd, item),
     m_var_entry(item->m_var_entry), name(item->name) { }
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     DBUG_ASSERT(fixed);
     return create_tmp_field_ex_from_handler(root, table, src, param,
                                             type_handler());
   }
-  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table)
+  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table) override
   { return create_table_field_from_handler(root, table); }
-  bool check_vcol_func_processor(void *arg);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool check_vcol_func_processor(void *arg) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
@@ -3082,46 +3082,46 @@ public:
     null_item(item->null_item), save_result(item->save_result)
   {}
 
-  enum Functype functype() const { return SUSERVAR_FUNC; }
-  double val_real();
-  longlong val_int();
-  String *val_str(String *str);
-  my_decimal *val_decimal(my_decimal *);
-  double val_result();
-  longlong val_int_result();
-  bool val_bool_result();
-  String *str_result(String *str);
-  my_decimal *val_decimal_result(my_decimal *);
-  bool is_null_result();
+  enum Functype functype() const override { return SUSERVAR_FUNC; }
+  double val_real() override;
+  longlong val_int() override;
+  String *val_str(String *str) override;
+  my_decimal *val_decimal(my_decimal *) override;
+  double val_result() override;
+  longlong val_int_result() override;
+  bool val_bool_result() override;
+  String *str_result(String *str) override;
+  my_decimal *val_decimal_result(my_decimal *) override;
+  bool is_null_result() override;
   bool update_hash(void *ptr, size_t length, const Type_handler *th,
                    CHARSET_INFO *cs);
-  bool send(Protocol *protocol, st_value *buffer);
-  void make_send_field(THD *thd, Send_field *tmp_field);
+  bool send(Protocol *protocol, st_value *buffer) override;
+  void make_send_field(THD *thd, Send_field *tmp_field) override;
   bool check(bool use_result_field);
   void save_item_result(Item *item);
   bool update();
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec();
-  void print(String *str, enum_query_type query_type);
-  enum precedence precedence() const { return ASSIGN_PRECEDENCE; }
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override;
+  void print(String *str, enum_query_type query_type) override;
+  enum precedence precedence() const override { return ASSIGN_PRECEDENCE; }
   void print_as_stmt(String *str, enum_query_type query_type);
-  const char *func_name() const { return "set_user_var"; }
+  const char *func_name() const override { return "set_user_var"; }
   int save_in_field(Field *field, bool no_conversions,
                     bool can_use_result_field);
-  int save_in_field(Field *field, bool no_conversions)
+  int save_in_field(Field *field, bool no_conversions) override
   {
     return save_in_field(field, no_conversions, 1);
   }
   void save_org_in_field(Field *field,
-                         fast_field_copier data __attribute__ ((__unused__)))
+                         fast_field_copier data __attribute__ ((__unused__))) override
     { (void)save_in_field(field, 1, 0); }
-  bool register_field_in_read_map(void *arg);
-  bool register_field_in_bitmap(void *arg);
+  bool register_field_in_read_map(void *arg) override;
+  bool register_field_in_bitmap(void *arg) override;
   bool set_entry(THD *thd, bool create_if_not_exists);
-  void cleanup();
-  Item *get_copy(THD *thd)
+  void cleanup() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_set_user_var>(thd, this); }
-  bool excl_dep_on_table(table_map tab_map) { return false; }
+  bool excl_dep_on_table(table_map tab_map) override { return false; }
 };
 
 
@@ -3131,30 +3131,30 @@ class Item_func_get_user_var :public Item_func_user_var,
 public:
   Item_func_get_user_var(THD *thd, const LEX_CSTRING *a):
     Item_func_user_var(thd, a) {}
-  enum Functype functype() const { return GUSERVAR_FUNC; }
+  enum Functype functype() const override { return GUSERVAR_FUNC; }
   LEX_CSTRING get_name() { return name; }
-  double val_real();
-  longlong val_int();
-  my_decimal *val_decimal(my_decimal*);
-  String *val_str(String* str);
-  bool fix_length_and_dec();
-  virtual void print(String *str, enum_query_type query_type);
+  double val_real() override;
+  longlong val_int() override;
+  my_decimal *val_decimal(my_decimal*) override;
+  String *val_str(String* str) override;
+  bool fix_length_and_dec() override;
+  void print(String *str, enum_query_type query_type) override;
   /*
     We must always return variables as strings to guard against selects of type
     select @t1:=1,@t1,@t:="hello",@t from foo where (@t1:= t2.b)
   */
-  const char *func_name() const { return "get_user_var"; }
-  bool const_item() const;
-  table_map used_tables() const
+  const char *func_name() const override { return "get_user_var"; }
+  bool const_item() const override;
+  table_map used_tables() const override
   { return const_item() ? 0 : RAND_TABLE_BIT; }
-  bool eq(const Item *item, bool binary_cmp) const;
-  Item *get_copy(THD *thd)
+  bool eq(const Item *item, bool binary_cmp) const override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_get_user_var>(thd, this); }
 private:
-  bool set_value(THD *thd, sp_rcontext *ctx, Item **it);
+  bool set_value(THD *thd, sp_rcontext *ctx, Item **it) override;
 
 public:
-  Settable_routine_parameter *get_settable_routine_parameter()
+  Settable_routine_parameter *get_settable_routine_parameter() override
   {
     return this;
   }
@@ -3183,54 +3183,54 @@ public:
     org_name= *a;
     set_name(thd, a->str, a->length, system_charset_info);
   }
-  Load_data_outvar *get_load_data_outvar()
+  Load_data_outvar *get_load_data_outvar() override
   {
     return this;
   }
-  bool load_data_set_null(THD *thd, const Load_data_param *param)
+  bool load_data_set_null(THD *thd, const Load_data_param *param) override
   {
     set_null_value(param->charset());
     return false;
   }
-  bool load_data_set_no_data(THD *thd, const Load_data_param *param)
+  bool load_data_set_no_data(THD *thd, const Load_data_param *param) override
   {
     set_null_value(param->charset());
     return false;
   }
   bool load_data_set_value(THD *thd, const char *pos, uint length,
-                           const Load_data_param *param)
+                           const Load_data_param *param) override
   {
     set_value(pos, length, param->charset());
     return false;
   }
-  void load_data_print_for_log_event(THD *thd, String *to) const;
-  bool load_data_add_outvar(THD *thd, Load_data_param *param) const
+  void load_data_print_for_log_event(THD *thd, String *to) const override;
+  bool load_data_add_outvar(THD *thd, Load_data_param *param) const override
   {
     return param->add_outvar_user_var(thd);
   }
-  uint load_data_fixed_length() const
+  uint load_data_fixed_length() const override
   {
     return 0;
   }
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     DBUG_ASSERT(0);
     return NULL;
   }
   /* We should return something different from FIELD_ITEM here */
-  enum Type type() const { return CONST_ITEM;}
-  double val_real();
-  longlong val_int();
-  String *val_str(String *str);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  my_decimal *val_decimal(my_decimal *decimal_buffer);
+  enum Type type() const override { return CONST_ITEM;}
+  double val_real() override;
+  longlong val_int() override;
+  String *val_str(String *str) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  my_decimal *val_decimal(my_decimal *decimal_buffer) override;
   /* fix_fields() binds variable name with its entry structure */
-  bool fix_fields(THD *thd, Item **ref);
+  bool fix_fields(THD *thd, Item **ref) override;
   void set_null_value(CHARSET_INFO* cs);
   void set_value(const char *str, uint length, CHARSET_INFO* cs);
-  const Type_handler *type_handler() const { return &type_handler_double; }
-  Item *get_copy(THD *thd)
+  const Type_handler *type_handler() const override { return &type_handler_double; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_user_var_as_out_param>(thd, this); }
 };
 
@@ -3258,24 +3258,24 @@ public:
                            enum_var_type var_type_arg,
                            LEX_CSTRING *component_arg, const char *name_arg,
                            size_t name_len_arg);
-  enum Functype functype() const { return GSYSVAR_FUNC; }
-  void update_null_value();
-  bool fix_length_and_dec();
-  void print(String *str, enum_query_type query_type);
-  bool const_item() const { return true; }
-  table_map used_tables() const { return 0; }
-  const Type_handler *type_handler() const;
-  double val_real();
-  longlong val_int();
-  String* val_str(String*);
-  my_decimal *val_decimal(my_decimal *dec_buf)
+  enum Functype functype() const override { return GSYSVAR_FUNC; }
+  void update_null_value() override;
+  bool fix_length_and_dec() override;
+  void print(String *str, enum_query_type query_type) override;
+  bool const_item() const override { return true; }
+  table_map used_tables() const override { return 0; }
+  const Type_handler *type_handler() const override;
+  double val_real() override;
+  longlong val_int() override;
+  String* val_str(String*) override;
+  my_decimal *val_decimal(my_decimal *dec_buf) override
   { return val_decimal_from_real(dec_buf); }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
   /* TODO: fix to support views */
-  const char *func_name() const { return "get_system_var"; }
+  const char *func_name() const override { return "get_system_var"; }
   /**
     Indicates whether this system variable is written to the binlog or not.
 
@@ -3285,11 +3285,11 @@ public:
     @return true if the variable is written to the binlog, false otherwise.
   */
   bool is_written_to_binlog();
-  bool eq(const Item *item, bool binary_cmp) const;
+  bool eq(const Item *item, bool binary_cmp) const override;
 
-  void cleanup();
-  bool check_vcol_func_processor(void *arg);
-  Item *get_copy(THD *thd)
+  void cleanup() override;
+  bool check_vcol_func_processor(void *arg) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_get_system_var>(thd, this); }
 };
 
@@ -3312,7 +3312,7 @@ public:
   Item_func_match(THD *thd, List<Item> &a, uint b):
     Item_real_func(thd, a), key(0), flags(b), join_key(0), ft_handler(0),
     table(0), master(0), concat_ws(0) { }
-  void cleanup()
+  void cleanup() override
   {
     DBUG_ENTER("Item_func_match::cleanup");
     Item_real_func::cleanup();
@@ -3323,34 +3323,34 @@ public:
     table= 0;           // required by Item_func_match::eq()
     DBUG_VOID_RETURN;
   }
-  bool is_expensive_processor(void *arg) { return TRUE; }
-  enum Functype functype() const { return FT_FUNC; }
-  const char *func_name() const { return "match"; }
-  bool eval_not_null_tables(void *opt_arg)
+  bool is_expensive_processor(void *arg) override { return TRUE; }
+  enum Functype functype() const override { return FT_FUNC; }
+  const char *func_name() const override { return "match"; }
+  bool eval_not_null_tables(void *opt_arg) override
   {
     not_null_tables_cache= 0;
     return 0;
   }
-  bool find_not_null_fields(table_map allowed)
+  bool find_not_null_fields(table_map allowed) override
   {
     return false;
   }
-  bool fix_fields(THD *thd, Item **ref);
-  bool eq(const Item *, bool binary_cmp) const;
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool eq(const Item *, bool binary_cmp) const override;
   /* The following should be safe, even if we compare doubles */
-  longlong val_int() { DBUG_ASSERT(fixed == 1); return val_real() != 0.0; }
-  double val_real();
-  virtual void print(String *str, enum_query_type query_type);
+  longlong val_int() override { DBUG_ASSERT(fixed == 1); return val_real() != 0.0; }
+  double val_real() override;
+  void print(String *str, enum_query_type query_type) override;
 
   bool fix_index();
   bool init_search(THD *thd, bool no_order);
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function("match ... against()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_match>(thd, this); }
-  Item *build_clone(THD *thd) { return 0; }
+  Item *build_clone(THD *thd) override { return 0; }
 private:
   /**
      Check whether storage engine for given table, 
@@ -3393,54 +3393,54 @@ class Item_func_bit_xor : public Item_func_bit_operator
 public:
   Item_func_bit_xor(THD *thd, Item *a, Item *b)
    :Item_func_bit_operator(thd, a, b) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return "^"; }
-  enum precedence precedence() const { return BITXOR_PRECEDENCE; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "^"; }
+  enum precedence precedence() const override { return BITXOR_PRECEDENCE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_bit_xor>(thd, this); }
 };
 
 class Item_func_is_free_lock :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_general_purpose_string(func_name()); }
   String value;
 public:
   Item_func_is_free_lock(THD *thd, Item *a): Item_long_func(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "is_free_lock"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "is_free_lock"; }
+  bool fix_length_and_dec() override
   {
     decimals=0; max_length=1; maybe_null=1;
     return FALSE;
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_is_free_lock>(thd, this); }
 };
 
 class Item_func_is_used_lock :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_general_purpose_string(func_name()); }
   String value;
 public:
   Item_func_is_used_lock(THD *thd, Item *a): Item_long_func(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "is_used_lock"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "is_used_lock"; }
+  bool fix_length_and_dec() override
   {
     decimals=0; max_length=10; maybe_null=1;
     return FALSE;
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_is_used_lock>(thd, this); }
 };
 
@@ -3485,14 +3485,14 @@ class Item_func_row_count :public Item_longlong_func
 {
 public:
   Item_func_row_count(THD *thd): Item_longlong_func(thd) {}
-  longlong val_int();
-  const char *func_name() const { return "row_count"; }
-  bool fix_length_and_dec() { decimals= 0; maybe_null=0; return FALSE; }
-  bool check_vcol_func_processor(void *arg)
+  longlong val_int() override;
+  const char *func_name() const override { return "row_count"; }
+  bool fix_length_and_dec() override { decimals= 0; maybe_null=0; return FALSE; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_row_count>(thd, this); }
 };
 
@@ -3512,10 +3512,10 @@ private:
   bool execute();
 
 protected:
-  bool is_expensive_processor(void *arg)
+  bool is_expensive_processor(void *arg) override
   { return is_expensive(); }
 
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     // sp_prepare_func_item() checks that the number of columns is correct
     return false;
@@ -3530,53 +3530,53 @@ public:
 
   virtual ~Item_func_sp() = default;
 
-  void update_used_tables();
+  void update_used_tables() override;
 
-  void cleanup();
+  void cleanup() override;
 
-  const char *func_name() const;
+  const char *func_name() const override;
 
-  const Type_handler *type_handler() const;
+  const Type_handler *type_handler() const override;
 
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param);
-  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table)
+                             const Tmp_field_param *param) override;
+  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table) override
   {
     return result_type() != STRING_RESULT ?
            sp_result_field :
            create_table_field_from_handler(root, table);
   }
-  void make_send_field(THD *thd, Send_field *tmp_field);
+  void make_send_field(THD *thd, Send_field *tmp_field) override;
 
-  longlong val_int()
+  longlong val_int() override
   {
     if (execute())
       return (longlong) 0;
     return sp_result_field->val_int();
   }
 
-  double val_real()
+  double val_real() override
   {
     if (execute())
       return 0.0;
     return sp_result_field->val_real();
   }
 
-  my_decimal *val_decimal(my_decimal *dec_buf)
+  my_decimal *val_decimal(my_decimal *dec_buf) override
   {
     if (execute())
       return NULL;
     return sp_result_field->val_decimal(dec_buf);
   }
 
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     if (execute())
       return true;
     return sp_result_field->get_date(ltime, fuzzydate);
   }
 
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     String buf;
     char buff[20];
@@ -3595,26 +3595,26 @@ public:
     return str;
   }
 
-  bool val_native(THD *thd, Native *to)
+  bool val_native(THD *thd, Native *to) override
   {
     if (execute())
       return true;
     return null_value= sp_result_field->val_native(to);
   }
 
-  void update_null_value()
+  void update_null_value() override
   { 
     execute();
   }
 
-  virtual bool change_context_processor(void *cntx)
+  bool change_context_processor(void *cntx) override
     { context= (Name_resolution_context *)cntx; return FALSE; }
 
-  virtual enum Functype functype() const { return FUNC_SP; }
+  enum Functype functype() const override { return FUNC_SP; }
 
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec(void);
-  bool is_expensive();
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec(void) override;
+  bool is_expensive() override;
 
   inline Field *get_sp_result_field()
   {
@@ -3625,20 +3625,20 @@ public:
     return m_name;
   }
 
-  bool check_vcol_func_processor(void *arg);
-  bool limit_index_condition_pushdown_processor(void *opt_arg)
+  bool check_vcol_func_processor(void *arg) override;
+  bool limit_index_condition_pushdown_processor(void *opt_arg) override
   {
     return TRUE;
   }
-  Item *get_copy(THD *) { return 0; }
-  bool eval_not_null_tables(void *opt_arg)
+  Item *get_copy(THD *) override { return 0; }
+  bool eval_not_null_tables(void *opt_arg) override
   {
     not_null_tables_cache= 0;
     return 0;
   }
-  bool excl_dep_on_grouping_fields(st_select_lex *sel)
+  bool excl_dep_on_grouping_fields(st_select_lex *sel) override
   { return false; }
-  bool find_not_null_fields(table_map allowed)
+  bool find_not_null_fields(table_map allowed) override
   {
     return false;
   }
@@ -3649,14 +3649,14 @@ class Item_func_found_rows :public Item_longlong_func
 {
 public:
   Item_func_found_rows(THD *thd): Item_longlong_func(thd) {}
-  longlong val_int();
-  const char *func_name() const { return "found_rows"; }
-  bool fix_length_and_dec() { decimals= 0; maybe_null=0; return FALSE; }
-  bool check_vcol_func_processor(void *arg)
+  longlong val_int() override;
+  const char *func_name() const override { return "found_rows"; }
+  bool fix_length_and_dec() override { decimals= 0; maybe_null=0; return FALSE; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_found_rows>(thd, this); }
 };
 
@@ -3665,17 +3665,17 @@ class Item_func_oracle_sql_rowcount :public Item_longlong_func
 {
 public:
   Item_func_oracle_sql_rowcount(THD *thd): Item_longlong_func(thd) {}
-  longlong val_int();
-  const char *func_name() const { return "SQL%ROWCOUNT"; }
-  void print(String *str, enum_query_type query_type)
+  longlong val_int() override;
+  const char *func_name() const override { return "SQL%ROWCOUNT"; }
+  void print(String *str, enum_query_type query_type) override
   {
     str->append(func_name());
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_oracle_sql_rowcount>(thd, this); }
 };
 
@@ -3684,23 +3684,23 @@ class Item_func_sqlcode: public Item_long_func
 {
 public:
   Item_func_sqlcode(THD *thd): Item_long_func(thd) { }
-  longlong val_int();
-  const char *func_name() const { return "SQLCODE"; }
-  void print(String *str, enum_query_type query_type)
+  longlong val_int() override;
+  const char *func_name() const override { return "SQLCODE"; }
+  void print(String *str, enum_query_type query_type) override
   {
     str->append(func_name());
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     maybe_null= null_value= false;
     max_length= 11;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sqlcode>(thd, this); }
 };
 
@@ -3711,17 +3711,17 @@ class Item_func_uuid_short :public Item_longlong_func
 {
 public:
   Item_func_uuid_short(THD *thd): Item_longlong_func(thd) {}
-  const char *func_name() const { return "uuid_short"; }
-  longlong val_int();
-  bool const_item() const { return false; }
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "uuid_short"; }
+  longlong val_int() override;
+  bool const_item() const override { return false; }
+  bool fix_length_and_dec() override
   { max_length= 21; unsigned_flag=1; return FALSE; }
-  table_map used_tables() const { return RAND_TABLE_BIT; }
-  bool check_vcol_func_processor(void *arg)
+  table_map used_tables() const override { return RAND_TABLE_BIT; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_NON_DETERMINISTIC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_uuid_short>(thd, this); }
 };
 
@@ -3732,32 +3732,32 @@ protected:
   Item *last_value;
 public:
   Item_func_last_value(THD *thd, List<Item> &list): Item_func(thd, list) {}
-  double val_real();
-  longlong val_int();
-  String *val_str(String *);
-  my_decimal *val_decimal(my_decimal *);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool val_native(THD *thd, Native *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "last_value"; }
-  const Type_handler *type_handler() const { return last_value->type_handler(); }
-  bool eval_not_null_tables(void *)
+  double val_real() override;
+  longlong val_int() override;
+  String *val_str(String *) override;
+  my_decimal *val_decimal(my_decimal *) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool val_native(THD *thd, Native *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "last_value"; }
+  const Type_handler *type_handler() const override { return last_value->type_handler(); }
+  bool eval_not_null_tables(void *) override
   {
     not_null_tables_cache= 0;
     return 0;
   }
-  bool find_not_null_fields(table_map allowed)
+  bool find_not_null_fields(table_map allowed) override
   {
     return false;
   }
-  bool const_item() const { return 0; }
+  bool const_item() const override { return 0; }
   void evaluate_sideeffects();
-  void update_used_tables()
+  void update_used_tables() override
   {
     Item_func::update_used_tables();
     maybe_null= last_value->maybe_null;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_last_value>(thd, this); }
 };
 
@@ -3772,9 +3772,9 @@ protected:
 public:
   Item_func_nextval(THD *thd, TABLE_LIST *table_list_arg):
   Item_longlong_func(thd), table_list(table_list_arg) {}
-  longlong val_int();
-  const char *func_name() const { return "nextval"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "nextval"; }
+  bool fix_length_and_dec() override
   {
     unsigned_flag= 0;
     max_length= MAX_BIGINT_WIDTH;
@@ -3797,11 +3797,11 @@ public:
       table= table_list->next_local->table;
     }
   }
-  bool const_item() const { return 0; }
-  Item *get_copy(THD *thd)
+  bool const_item() const override { return 0; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_nextval>(thd, this); }
-  void print(String *str, enum_query_type query_type);
-  bool check_vcol_func_processor(void *arg)
+  void print(String *str, enum_query_type query_type) override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_NEXTVAL);
   }
@@ -3815,9 +3815,9 @@ class Item_func_lastval :public Item_func_nextval
 public:
   Item_func_lastval(THD *thd, TABLE_LIST *table_list_arg):
   Item_func_nextval(thd, table_list_arg) {}
-  longlong val_int();
-  const char *func_name() const { return "lastval"; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "lastval"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_lastval>(thd, this); }
 };
 
@@ -3835,10 +3835,10 @@ public:
     : Item_func_nextval(thd, table_list_arg),
     nextval(nextval_arg), round(round_arg), is_used(is_used_arg)
   {}
-  longlong val_int();
-  const char *func_name() const { return "setval"; }
-  void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "setval"; }
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_setval>(thd, this); }
 };
 

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -2790,7 +2790,7 @@ public:
 
 protected:
   Create_func_area() = default;
-  virtual ~Create_func_area() = default;
+  ~Create_func_area() override = default;
 };
 
 
@@ -2806,7 +2806,7 @@ public:
 
 protected:
   Create_func_as_wkb() = default;
-  virtual ~Create_func_as_wkb() = default;
+  ~Create_func_as_wkb() override = default;
 };
 
 
@@ -2822,7 +2822,7 @@ public:
 
 protected:
   Create_func_as_wkt() = default;
-  virtual ~Create_func_as_wkt() = default;
+  ~Create_func_as_wkt() override = default;
 };
 
 
@@ -2839,7 +2839,7 @@ public:
 
 protected:
   Create_func_centroid() = default;
-  virtual ~Create_func_centroid() = default;
+  ~Create_func_centroid() override = default;
 };
 
 
@@ -2855,7 +2855,7 @@ public:
 
 protected:
   Create_func_convexhull() = default;
-  virtual ~Create_func_convexhull() = default;
+  ~Create_func_convexhull() override = default;
 };
 
 
@@ -2871,7 +2871,7 @@ public:
 
 protected:
   Create_func_pointonsurface() = default;
-  virtual ~Create_func_pointonsurface() = default;
+  ~Create_func_pointonsurface() override = default;
 };
 
 
@@ -2888,7 +2888,7 @@ public:
 
 protected:
   Create_func_mbr_contains() = default;
-  virtual ~Create_func_mbr_contains() = default;
+  ~Create_func_mbr_contains() override = default;
 };
 
 
@@ -2904,7 +2904,7 @@ public:
 
 protected:
   Create_func_contains() = default;
-  virtual ~Create_func_contains() = default;
+  ~Create_func_contains() override = default;
 };
 
 
@@ -2920,7 +2920,7 @@ public:
 
 protected:
   Create_func_crosses() = default;
-  virtual ~Create_func_crosses() = default;
+  ~Create_func_crosses() override = default;
 };
 
 
@@ -2936,7 +2936,7 @@ public:
 
 protected:
   Create_func_dimension() = default;
-  virtual ~Create_func_dimension() = default;
+  ~Create_func_dimension() override = default;
 };
 
 
@@ -2953,7 +2953,7 @@ public:
 
 protected:
   Create_func_mbr_disjoint() = default;
-  virtual ~Create_func_mbr_disjoint() = default;
+  ~Create_func_mbr_disjoint() override = default;
 };
 
 
@@ -2969,7 +2969,7 @@ public:
 
 protected:
   Create_func_disjoint() = default;
-  virtual ~Create_func_disjoint() = default;
+  ~Create_func_disjoint() override = default;
 };
 
 
@@ -2985,7 +2985,7 @@ public:
 
 protected:
   Create_func_distance() = default;
-  virtual ~Create_func_distance() = default;
+  ~Create_func_distance() override = default;
 };
 
 
@@ -2998,7 +2998,7 @@ public:
 
 protected:
   Create_func_distance_sphere() = default;
-  virtual ~Create_func_distance_sphere() = default;
+  ~Create_func_distance_sphere() override = default;
 };
 
 
@@ -3033,7 +3033,7 @@ public:
 
 protected:
   Create_func_endpoint() = default;
-  virtual ~Create_func_endpoint() = default;
+  ~Create_func_endpoint() override = default;
 };
 
 
@@ -3049,7 +3049,7 @@ public:
 
 protected:
   Create_func_envelope() = default;
-  virtual ~Create_func_envelope() = default;
+  ~Create_func_envelope() override = default;
 };
 
 class Create_func_boundary : public Create_func_arg1
@@ -3064,7 +3064,7 @@ public:
 
 protected:
   Create_func_boundary() = default;
-  virtual ~Create_func_boundary() = default;
+  ~Create_func_boundary() override = default;
 };
 
 
@@ -3081,7 +3081,7 @@ public:
 
 protected:
   Create_func_mbr_equals() = default;
-  virtual ~Create_func_mbr_equals() = default;
+  ~Create_func_mbr_equals() override = default;
 };
 
 
@@ -3098,7 +3098,7 @@ public:
 
 protected:
   Create_func_equals() = default;
-  virtual ~Create_func_equals() = default;
+  ~Create_func_equals() override = default;
 };
 
 
@@ -3115,7 +3115,7 @@ public:
 
 protected:
   Create_func_exteriorring() = default;
-  virtual ~Create_func_exteriorring() = default;
+  ~Create_func_exteriorring() override = default;
 };
 
 
@@ -3130,7 +3130,7 @@ public:
 
 protected:
   Create_func_geometry_from_text() = default;
-  virtual ~Create_func_geometry_from_text() = default;
+  ~Create_func_geometry_from_text() override = default;
 };
 
 
@@ -3181,7 +3181,7 @@ public:
 
 protected:
   Create_func_geometry_from_wkb() = default;
-  virtual ~Create_func_geometry_from_wkb() = default;
+  ~Create_func_geometry_from_wkb() override = default;
 };
 
 
@@ -3231,7 +3231,7 @@ public:
 
 protected:
   Create_func_geometry_from_json() = default;
-  virtual ~Create_func_geometry_from_json() = default;
+  ~Create_func_geometry_from_json() override = default;
 };
 
 
@@ -3291,7 +3291,7 @@ public:
 
 protected:
   Create_func_as_geojson() = default;
-  virtual ~Create_func_as_geojson() = default;
+  ~Create_func_as_geojson() override = default;
 };
 
 
@@ -3351,7 +3351,7 @@ public:
 
 protected:
   Create_func_geometry_type() = default;
-  virtual ~Create_func_geometry_type() = default;
+  ~Create_func_geometry_type() override = default;
 };
 
 
@@ -3368,7 +3368,7 @@ public:
 
 protected:
   Create_func_geometryn() = default;
-  virtual ~Create_func_geometryn() = default;
+  ~Create_func_geometryn() override = default;
 };
 
 
@@ -3385,7 +3385,7 @@ public:
 
 protected:
   Create_func_gis_debug() = default;
-  virtual ~Create_func_gis_debug() = default;
+  ~Create_func_gis_debug() override = default;
 };
 #endif
 
@@ -3402,7 +3402,7 @@ public:
 
 protected:
   Create_func_glength() = default;
-  virtual ~Create_func_glength() = default;
+  ~Create_func_glength() override = default;
 };
 
 
@@ -3419,7 +3419,7 @@ public:
 
 protected:
   Create_func_interiorringn() = default;
-  virtual ~Create_func_interiorringn() = default;
+  ~Create_func_interiorringn() override = default;
 };
 
 
@@ -3435,7 +3435,7 @@ public:
 
 protected:
   Create_func_relate() = default;
-  virtual ~Create_func_relate() = default;
+  ~Create_func_relate() override = default;
 };
 
 
@@ -3452,7 +3452,7 @@ public:
 
 protected:
   Create_func_mbr_intersects() = default;
-  virtual ~Create_func_mbr_intersects() = default;
+  ~Create_func_mbr_intersects() override = default;
 };
 
 
@@ -3469,7 +3469,7 @@ public:
 
 protected:
   Create_func_intersects() = default;
-  virtual ~Create_func_intersects() = default;
+  ~Create_func_intersects() override = default;
 };
 
 
@@ -3486,7 +3486,7 @@ public:
 
 protected:
   Create_func_intersection() = default;
-  virtual ~Create_func_intersection() = default;
+  ~Create_func_intersection() override = default;
 };
 
 
@@ -3503,7 +3503,7 @@ public:
 
 protected:
   Create_func_difference() = default;
-  virtual ~Create_func_difference() = default;
+  ~Create_func_difference() override = default;
 };
 
 
@@ -3520,7 +3520,7 @@ public:
 
 protected:
   Create_func_union() = default;
-  virtual ~Create_func_union() = default;
+  ~Create_func_union() override = default;
 };
 
 
@@ -3537,7 +3537,7 @@ public:
 
 protected:
   Create_func_symdifference() = default;
-  virtual ~Create_func_symdifference() = default;
+  ~Create_func_symdifference() override = default;
 };
 
 
@@ -3553,7 +3553,7 @@ public:
 
 protected:
   Create_func_buffer() = default;
-  virtual ~Create_func_buffer() = default;
+  ~Create_func_buffer() override = default;
 };
 
 
@@ -3569,7 +3569,7 @@ public:
 
 protected:
   Create_func_isclosed() = default;
-  virtual ~Create_func_isclosed() = default;
+  ~Create_func_isclosed() override = default;
 };
 
 
@@ -3585,7 +3585,7 @@ public:
 
 protected:
   Create_func_isring() = default;
-  virtual ~Create_func_isring() = default;
+  ~Create_func_isring() override = default;
 };
 
 
@@ -3601,7 +3601,7 @@ public:
 
 protected:
   Create_func_isempty() = default;
-  virtual ~Create_func_isempty() = default;
+  ~Create_func_isempty() override = default;
 };
 
 
@@ -3617,7 +3617,7 @@ public:
 
 protected:
   Create_func_issimple() = default;
-  virtual ~Create_func_issimple() = default;
+  ~Create_func_issimple() override = default;
 };
 
 
@@ -3634,7 +3634,7 @@ public:
 
 protected:
   Create_func_numgeometries() = default;
-  virtual ~Create_func_numgeometries() = default;
+  ~Create_func_numgeometries() override = default;
 };
 
 
@@ -3650,7 +3650,7 @@ public:
 
 protected:
   Create_func_numinteriorring() = default;
-  virtual ~Create_func_numinteriorring() = default;
+  ~Create_func_numinteriorring() override = default;
 };
 
 
@@ -3666,7 +3666,7 @@ public:
 
 protected:
   Create_func_numpoints() = default;
-  virtual ~Create_func_numpoints() = default;
+  ~Create_func_numpoints() override = default;
 };
 
 
@@ -3683,7 +3683,7 @@ public:
 
 protected:
   Create_func_mbr_overlaps() = default;
-  virtual ~Create_func_mbr_overlaps() = default;
+  ~Create_func_mbr_overlaps() override = default;
 };
 
 
@@ -3700,7 +3700,7 @@ public:
 
 protected:
   Create_func_overlaps() = default;
-  virtual ~Create_func_overlaps() = default;
+  ~Create_func_overlaps() override = default;
 };
 
 
@@ -3719,7 +3719,7 @@ public:
 
 protected:
   Create_func_pointn() = default;
-  virtual ~Create_func_pointn() = default;
+  ~Create_func_pointn() override = default;
 };
 
 
@@ -3737,7 +3737,7 @@ public:
 
 protected:
   Create_func_srid() = default;
-  virtual ~Create_func_srid() = default;
+  ~Create_func_srid() override = default;
 };
 
 
@@ -3754,7 +3754,7 @@ public:
 
 protected:
   Create_func_startpoint() = default;
-  virtual ~Create_func_startpoint() = default;
+  ~Create_func_startpoint() override = default;
 };
 
 
@@ -3772,7 +3772,7 @@ public:
 
 protected:
   Create_func_touches() = default;
-  virtual ~Create_func_touches() = default;
+  ~Create_func_touches() override = default;
 };
 
 
@@ -3789,7 +3789,7 @@ public:
 
 protected:
   Create_func_mbr_within() = default;
-  virtual ~Create_func_mbr_within() = default;
+  ~Create_func_mbr_within() override = default;
 };
 
 
@@ -3806,7 +3806,7 @@ public:
 
 protected:
   Create_func_within() = default;
-  virtual ~Create_func_within() = default;
+  ~Create_func_within() override = default;
 };
 
 
@@ -3822,7 +3822,7 @@ public:
 
 protected:
   Create_func_x() = default;
-  virtual ~Create_func_x() = default;
+  ~Create_func_x() override = default;
 };
 
 
@@ -3838,7 +3838,7 @@ public:
 
 protected:
   Create_func_y() = default;
-  virtual ~Create_func_y() = default;
+  ~Create_func_y() override = default;
 };
 
 

--- a/sql/item_geofunc.h
+++ b/sql/item_geofunc.h
@@ -42,8 +42,8 @@ public:
   Item_geometry_func(THD *thd, Item *a, Item *b, Item *c):
     Item_str_func(thd, a, b, c) {}
   Item_geometry_func(THD *thd, List<Item> &list): Item_str_func(thd, list) {}
-  bool fix_length_and_dec();
-  const Type_handler *type_handler() const { return &type_handler_geometry; }
+  bool fix_length_and_dec() override;
+  const Type_handler *type_handler() const override { return &type_handler_geometry; }
 };
 
 
@@ -54,7 +54,7 @@ class Item_real_func_args_geometry: public Item_real_func
 {
 protected:
   String value;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count == 1);
     return Type_handler_geometry::check_type_geom_or_binary(func_name(),
@@ -71,7 +71,7 @@ public:
 */
 class Item_long_func_args_geometry: public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count == 1);
     return Type_handler_geometry::check_type_geom_or_binary(func_name(),
@@ -92,7 +92,7 @@ class Item_bool_func_args_geometry: public Item_bool_func
 {
 protected:
   String value;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count == 1);
     return Type_handler_geometry::check_type_geom_or_binary(func_name(),
@@ -110,7 +110,7 @@ public:
 class Item_str_ascii_func_args_geometry: public Item_str_ascii_func
 {
 protected:
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count >= 1);
     return Type_handler_geometry::check_type_geom_or_binary(func_name(),
@@ -132,7 +132,7 @@ public:
 class Item_binary_func_args_geometry: public Item_str_func
 {
 protected:
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count >= 1);
     return Type_handler_geometry::check_type_geom_or_binary(func_name(),
@@ -150,7 +150,7 @@ public:
 class Item_geometry_func_args_geometry: public Item_geometry_func
 {
 protected:
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count >= 1);
     return Type_handler_geometry::check_type_geom_or_binary(func_name(),
@@ -170,7 +170,7 @@ public:
 class Item_real_func_args_geometry_geometry: public Item_real_func
 {
 protected:
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count >= 2);
     return Type_handler_geometry::check_types_geom_or_binary(func_name(),
@@ -189,7 +189,7 @@ class Item_bool_func_args_geometry_geometry: public Item_bool_func
 {
 protected:
   String value;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count >= 2);
     return Type_handler_geometry::check_types_geom_or_binary(func_name(),
@@ -203,7 +203,7 @@ public:
 
 class Item_func_geometry_from_text: public Item_geometry_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_general_purpose_string(func_name()) ||
            check_argument_types_can_return_int(1, MY_MIN(2, arg_count));
@@ -212,15 +212,15 @@ public:
   Item_func_geometry_from_text(THD *thd, Item *a): Item_geometry_func(thd, a) {}
   Item_func_geometry_from_text(THD *thd, Item *a, Item *srid):
     Item_geometry_func(thd, a, srid) {}
-  const char *func_name() const { return "st_geometryfromtext"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_geometryfromtext"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_geometry_from_text>(thd, this); }
 };
 
 class Item_func_geometry_from_wkb: public Item_geometry_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return
       Type_handler_geometry::check_type_geom_or_binary(func_name(), args[0]) ||
@@ -230,9 +230,9 @@ public:
   Item_func_geometry_from_wkb(THD *thd, Item *a): Item_geometry_func(thd, a) {}
   Item_func_geometry_from_wkb(THD *thd, Item *a, Item *srid):
     Item_geometry_func(thd, a, srid) {}
-  const char *func_name() const { return "st_geometryfromwkb"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_geometryfromwkb"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_geometry_from_wkb>(thd, this); }
 };
 
@@ -240,7 +240,7 @@ public:
 class Item_func_geometry_from_json: public Item_geometry_func
 {
   String tmp_js;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     // TODO: check with Alexey, for better args[1] and args[2] type control
     return args[0]->check_type_general_purpose_string(func_name()) ||
@@ -252,9 +252,9 @@ public:
     Item_geometry_func(thd, js, opt) {}
   Item_func_geometry_from_json(THD *thd, Item *js, Item *opt, Item *srid):
     Item_geometry_func(thd, js, opt, srid) {}
-  const char *func_name() const { return "st_geomfromgeojson"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_geomfromgeojson"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_geometry_from_json>(thd, this); }
 };
 
@@ -264,10 +264,10 @@ class Item_func_as_wkt: public Item_str_ascii_func_args_geometry
 public:
   Item_func_as_wkt(THD *thd, Item *a)
    :Item_str_ascii_func_args_geometry(thd, a) {}
-  const char *func_name() const { return "st_astext"; }
-  String *val_str_ascii(String *);
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_astext"; }
+  String *val_str_ascii(String *) override;
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_as_wkt>(thd, this); }
 };
 
@@ -276,10 +276,10 @@ class Item_func_as_wkb: public Item_binary_func_args_geometry
 public:
   Item_func_as_wkb(THD *thd, Item *a)
    :Item_binary_func_args_geometry(thd, a) {}
-  const char *func_name() const { return "st_aswkb"; }
-  String *val_str(String *);
-  const Type_handler *type_handler() const { return &type_handler_long_blob; }
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "st_aswkb"; }
+  String *val_str(String *) override;
+  const Type_handler *type_handler() const override { return &type_handler_long_blob; }
+  bool fix_length_and_dec() override
   {
     collation.set(&my_charset_bin);
     decimals=0;
@@ -287,14 +287,14 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_as_wkb>(thd, this); }
 };
 
 
 class Item_func_as_geojson: public Item_str_ascii_func_args_geometry
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     // TODO: check with Alexey, for better args[1] and args[2] type control
     return Item_str_ascii_func_args_geometry::check_arguments() ||
@@ -307,10 +307,10 @@ public:
    :Item_str_ascii_func_args_geometry(thd, js, max_dec_digits) {}
   Item_func_as_geojson(THD *thd, Item *js, Item *max_dec_digits, Item *opt)
    :Item_str_ascii_func_args_geometry(thd, js, max_dec_digits, opt) {}
-  const char *func_name() const { return "st_asgeojson"; }
-  bool fix_length_and_dec();
-  String *val_str_ascii(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_asgeojson"; }
+  bool fix_length_and_dec() override;
+  String *val_str_ascii(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_as_geojson>(thd, this); }
 };
 
@@ -320,16 +320,16 @@ class Item_func_geometry_type: public Item_str_ascii_func_args_geometry
 public:
   Item_func_geometry_type(THD *thd, Item *a)
    :Item_str_ascii_func_args_geometry(thd, a) {}
-  String *val_str_ascii(String *);
-  const char *func_name() const { return "st_geometrytype"; }
-  bool fix_length_and_dec()
+  String *val_str_ascii(String *) override;
+  const char *func_name() const override { return "st_geometrytype"; }
+  bool fix_length_and_dec() override
   {
     // "GeometryCollection" is the longest
     fix_length_and_charset(20, default_charset());
     maybe_null= 1;
     return FALSE;
   };
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_geometry_type>(thd, this); }
 };
 
@@ -362,9 +362,9 @@ public:
    :Item_geometry_func_args_geometry(thd, a),
     res_heap(8192, sizeof(ch_node))
     {}
-  const char *func_name() const { return "st_convexhull"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_convexhull"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_convexhull>(thd, this); }
 };
 
@@ -374,13 +374,13 @@ class Item_func_centroid: public Item_geometry_func_args_geometry
 public:
   Item_func_centroid(THD *thd, Item *a)
    :Item_geometry_func_args_geometry(thd, a) {}
-  const char *func_name() const { return "st_centroid"; }
-  String *val_str(String *);
-  const Type_handler *type_handler() const
+  const char *func_name() const override { return "st_centroid"; }
+  String *val_str(String *) override;
+  const Type_handler *type_handler() const override
   {
     return &type_handler_point;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_centroid>(thd, this); }
 };
 
@@ -389,13 +389,13 @@ class Item_func_envelope: public Item_geometry_func_args_geometry
 public:
   Item_func_envelope(THD *thd, Item *a)
    :Item_geometry_func_args_geometry(thd, a) {}
-  const char *func_name() const { return "st_envelope"; }
-  String *val_str(String *);
-  const Type_handler *type_handler() const
+  const char *func_name() const override { return "st_envelope"; }
+  String *val_str(String *) override;
+  const Type_handler *type_handler() const override
   {
     return &type_handler_polygon;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_envelope>(thd, this); }
 };
 
@@ -412,43 +412,43 @@ class Item_func_boundary: public Item_geometry_func_args_geometry
     Transporter(Gcalc_result_receiver *receiver) :
       Gcalc_shape_transporter(NULL), m_receiver(receiver)
     {}
-    int single_point(double x, double y);
-    int start_line();
-    int complete_line();
-    int start_poly();
-    int complete_poly();
-    int start_ring();
-    int complete_ring();
-    int add_point(double x, double y);
+    int single_point(double x, double y) override;
+    int start_line() override;
+    int complete_line() override;
+    int start_poly() override;
+    int complete_poly() override;
+    int start_ring() override;
+    int complete_ring() override;
+    int add_point(double x, double y) override;
 
-    int start_collection(int n_objects);
+    int start_collection(int n_objects) override;
   };
   Gcalc_result_receiver res_receiver;
 public:
   Item_func_boundary(THD *thd, Item *a)
    :Item_geometry_func_args_geometry(thd, a) {}
-  const char *func_name() const { return "st_boundary"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_boundary"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_boundary>(thd, this); }
 };
 
 
 class Item_func_point: public Item_geometry_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_real(0, 2); }
 public:
   Item_func_point(THD *thd, Item *a, Item *b): Item_geometry_func(thd, a, b) {}
   Item_func_point(THD *thd, Item *a, Item *b, Item *srid):
     Item_geometry_func(thd, a, b, srid) {}
-  const char *func_name() const { return "point"; }
-  String *val_str(String *);
-  const Type_handler *type_handler() const
+  const char *func_name() const override { return "point"; }
+  String *val_str(String *) override;
+  const Type_handler *type_handler() const override
   {
     return &type_handler_point;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_point>(thd, this); }
 };
 
@@ -458,7 +458,7 @@ class Item_func_spatial_decomp: public Item_geometry_func_args_geometry
 public:
   Item_func_spatial_decomp(THD *thd, Item *a, Item_func::Functype ft):
     Item_geometry_func_args_geometry(thd, a) { decomp_func = ft; }
-  const char *func_name() const 
+  const char *func_name() const override 
   { 
     switch (decomp_func)
     {
@@ -473,15 +473,15 @@ public:
         return "spatial_decomp_unknown"; 
     }
   }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_spatial_decomp>(thd, this); }
 };
 
 class Item_func_spatial_decomp_n: public Item_geometry_func_args_geometry
 {
   enum Functype decomp_func_n;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return Item_geometry_func_args_geometry::check_arguments() ||
            args[1]->check_type_can_return_int(func_name());
@@ -491,7 +491,7 @@ public:
    :Item_geometry_func_args_geometry(thd, a, b),
     decomp_func_n(ft)
   { }
-  const char *func_name() const 
+  const char *func_name() const override 
   { 
     switch (decomp_func_n)
     {
@@ -506,14 +506,14 @@ public:
         return "spatial_decomp_n_unknown"; 
     }
   }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_spatial_decomp_n>(thd, this); }
 };
 
 class Item_func_spatial_collection: public Item_geometry_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return Type_handler_geometry::check_types_geom_or_binary(func_name(), args,
                                                              0, arg_count);
@@ -528,8 +528,8 @@ public:
     coll_type=ct;
     item_type=it;
   }
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     if (Item_geometry_func::fix_length_and_dec())
       return TRUE;
@@ -558,12 +558,12 @@ public:
                                  Geometry::wkb_geometrycollection,
                                  Geometry::wkb_point)
   { }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return &type_handler_geometrycollection;
   }
-  const char *func_name() const { return "geometrycollection"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "geometrycollection"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_geometrycollection>(thd, this); }
 };
 
@@ -576,9 +576,9 @@ public:
                                  Geometry::wkb_linestring,
                                  Geometry::wkb_point)
   { }
-  const Type_handler *type_handler() const { return &type_handler_linestring; }
-  const char *func_name() const { return "linestring"; }
-  Item *get_copy(THD *thd)
+  const Type_handler *type_handler() const override { return &type_handler_linestring; }
+  const char *func_name() const override { return "linestring"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_linestring>(thd, this); }
 };
 
@@ -591,9 +591,9 @@ public:
                                  Geometry::wkb_polygon,
                                  Geometry::wkb_linestring)
   { }
-  const Type_handler *type_handler() const { return &type_handler_polygon; }
-  const char *func_name() const { return "polygon"; }
-  Item *get_copy(THD *thd)
+  const Type_handler *type_handler() const override { return &type_handler_polygon; }
+  const char *func_name() const override { return "polygon"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_polygon>(thd, this); }
 };
 
@@ -606,12 +606,12 @@ public:
                                  Geometry::wkb_multilinestring,
                                  Geometry::wkb_linestring)
   { }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return &type_handler_multilinestring;
   }
-  const char *func_name() const { return "multilinestring"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "multilinestring"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_multilinestring>(thd, this); }
 };
 
@@ -624,12 +624,12 @@ public:
                                  Geometry::wkb_multipoint,
                                  Geometry::wkb_point)
   { }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return &type_handler_multipoint;
   }
-  const char *func_name() const { return "multipoint"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "multipoint"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_multipoint>(thd, this); }
 };
 
@@ -642,12 +642,12 @@ public:
                                  Geometry::wkb_multipolygon,
                                  Geometry::wkb_polygon)
   { }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return &type_handler_multipolygon;
   }
-  const char *func_name() const { return "multipolygon"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "multipolygon"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_multipolygon>(thd, this); }
 };
 
@@ -664,8 +664,8 @@ protected:
   String tmp_value1, tmp_value2;
   SEL_ARG *get_mm_leaf(RANGE_OPT_PARAM *param, Field *field,
                        KEY_PART *key_part,
-                       Item_func::Functype type, Item *value);
-  bool check_arguments() const
+                       Item_func::Functype type, Item *value) override;
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count >= 2);
     return Type_handler_geometry::check_types_geom_or_binary(func_name(),
@@ -677,8 +677,8 @@ public:
   {
     maybe_null= true;
   }
-  enum Functype functype() const { return spatial_rel; }
-  enum Functype rev_functype() const
+  enum Functype functype() const override { return spatial_rel; }
+  enum Functype rev_functype() const override
   {
     switch (spatial_rel)
     {
@@ -690,16 +690,16 @@ public:
         return spatial_rel;
     }
   }
-  bool is_null() { (void) val_int(); return null_value; }
+  bool is_null() override { (void) val_int(); return null_value; }
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
-                      SARGABLE_PARAM **sargables)
+                      SARGABLE_PARAM **sargables) override
   {
     return add_key_fields_optimize_op(join, key_fields, and_level,
                                       usable_tables, sargables, false);
   }
-  bool need_parentheses_in_default() { return false; }
-  Item *build_clone(THD *thd) { return 0; }
+  bool need_parentheses_in_default() override { return false; }
+  Item *build_clone(THD *thd) override { return 0; }
 };
 
 
@@ -709,9 +709,9 @@ public:
   Item_func_spatial_mbr_rel(THD *thd, Item *a, Item *b, enum Functype sp_rel):
     Item_func_spatial_rel(thd, a, b, sp_rel)
   { }
-  longlong val_int();
-  const char *func_name() const;
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_spatial_mbr_rel>(thd, this); }
 };
 
@@ -725,9 +725,9 @@ public:
   Item_func_spatial_precise_rel(THD *thd, Item *a, Item *b, enum Functype sp_rel):
     Item_func_spatial_rel(thd, a, b, sp_rel), collector()
   { }
-  longlong val_int();
-  const char *func_name() const;
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_spatial_precise_rel>(thd, this); }
 };
 
@@ -738,7 +738,7 @@ class Item_func_spatial_relate: public Item_bool_func_args_geometry_geometry
   Gcalc_scan_iterator scan_it;
   Gcalc_function func;
   String tmp_value1, tmp_value2, tmp_matrix;
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return Item_bool_func_args_geometry_geometry::check_arguments() ||
            args[2]->check_type_general_purpose_string(func_name());
@@ -747,10 +747,10 @@ public:
   Item_func_spatial_relate(THD *thd, Item *a, Item *b, Item *matrix):
     Item_bool_func_args_geometry_geometry(thd, a, b, matrix)
   { }
-  longlong val_int();
-  const char *func_name() const { return "st_relate"; }
-  bool need_parentheses_in_default() { return false; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_relate"; }
+  bool need_parentheses_in_default() override { return false; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_spatial_relate>(thd, this); }
 };
 
@@ -761,7 +761,7 @@ public:
 
 class Item_func_spatial_operation: public Item_geometry_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     DBUG_ASSERT(arg_count >= 2);
     return Type_handler_geometry::check_types_geom_or_binary(func_name(),
@@ -781,20 +781,20 @@ public:
     Item_geometry_func(thd, a, b), spatial_op(sp_op)
   {}
   virtual ~Item_func_spatial_operation();
-  String *val_str(String *);
-  const char *func_name() const;
-  virtual inline void print(String *str, enum_query_type query_type)
+  String *val_str(String *) override;
+  const char *func_name() const override;
+  void print(String *str, enum_query_type query_type) override
   {
     Item_func::print(str, query_type);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_spatial_operation>(thd, this); }
 };
 
 
 class Item_func_buffer: public Item_geometry_func_args_geometry
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return Item_geometry_func_args_geometry::check_arguments() ||
            args[1]->check_type_can_return_real(func_name());
@@ -822,16 +822,16 @@ protected:
                                           Gcalc_function::op_difference),
       skip_line(FALSE)
     {}
-    int single_point(double x, double y);
-    int start_line();
-    int complete_line();
-    int start_poly();
-    int complete_poly();
-    int start_ring();
-    int complete_ring();
-    int add_point(double x, double y);
+    int single_point(double x, double y) override;
+    int start_line() override;
+    int complete_line() override;
+    int start_poly() override;
+    int complete_poly() override;
+    int start_ring() override;
+    int complete_ring() override;
+    int add_point(double x, double y) override;
 
-    int start_collection(int n_objects);
+    int start_collection(int n_objects) override;
   };
   Gcalc_heap collector;
   Gcalc_function func;
@@ -842,9 +842,9 @@ protected:
 public:
   Item_func_buffer(THD *thd, Item *obj, Item *distance)
    :Item_geometry_func_args_geometry(thd, obj, distance) {}
-  const char *func_name() const { return "st_buffer"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "st_buffer"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_buffer>(thd, this); }
 };
 
@@ -854,11 +854,11 @@ class Item_func_isempty: public Item_bool_func_args_geometry
 public:
   Item_func_isempty(THD *thd, Item *a)
    :Item_bool_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_isempty"; }
-  bool fix_length_and_dec() { maybe_null= 1; return FALSE; }
-  bool need_parentheses_in_default() { return false; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_isempty"; }
+  bool fix_length_and_dec() override { maybe_null= 1; return FALSE; }
+  bool need_parentheses_in_default() override { return false; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isempty>(thd, this); }
 };
 
@@ -871,11 +871,11 @@ class Item_func_issimple: public Item_long_func_args_geometry
 public:
   Item_func_issimple(THD *thd, Item *a)
    :Item_long_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_issimple"; }
-  bool fix_length_and_dec() { decimals=0; max_length=2; return FALSE; }
-  uint decimal_precision() const { return 1; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_issimple"; }
+  bool fix_length_and_dec() override { decimals=0; max_length=2; return FALSE; }
+  uint decimal_precision() const override { return 1; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_issimple>(thd, this); }
 };
 
@@ -884,11 +884,11 @@ class Item_func_isclosed: public Item_long_func_args_geometry
 public:
   Item_func_isclosed(THD *thd, Item *a)
    :Item_long_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_isclosed"; }
-  bool fix_length_and_dec() { decimals=0; max_length=2; return FALSE; }
-  uint decimal_precision() const { return 1; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_isclosed"; }
+  bool fix_length_and_dec() override { decimals=0; max_length=2; return FALSE; }
+  uint decimal_precision() const override { return 1; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isclosed>(thd, this); }
 };
 
@@ -896,9 +896,9 @@ class Item_func_isring: public Item_func_issimple
 {
 public:
   Item_func_isring(THD *thd, Item *a): Item_func_issimple(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_isring"; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_isring"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_isring>(thd, this); }
 };
 
@@ -907,10 +907,10 @@ class Item_func_dimension: public Item_long_func_args_geometry
 public:
   Item_func_dimension(THD *thd, Item *a)
    :Item_long_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_dimension"; }
-  bool fix_length_and_dec() { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_dimension"; }
+  bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dimension>(thd, this); }
 };
 
@@ -919,16 +919,16 @@ class Item_func_x: public Item_real_func_args_geometry
 {
 public:
   Item_func_x(THD *thd, Item *a): Item_real_func_args_geometry(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "st_x"; }
-  bool fix_length_and_dec()
+  double val_real() override;
+  const char *func_name() const override { return "st_x"; }
+  bool fix_length_and_dec() override
   {
     if (Item_real_func::fix_length_and_dec())
       return TRUE;
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_x>(thd, this); }
 };
 
@@ -937,16 +937,16 @@ class Item_func_y: public Item_real_func_args_geometry
 {
 public:
   Item_func_y(THD *thd, Item *a): Item_real_func_args_geometry(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "st_y"; }
-  bool fix_length_and_dec()
+  double val_real() override;
+  const char *func_name() const override { return "st_y"; }
+  bool fix_length_and_dec() override
   {
     if (Item_real_func::fix_length_and_dec())
       return TRUE;
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_y>(thd, this); }
 };
 
@@ -956,10 +956,10 @@ class Item_func_numgeometries: public Item_long_func_args_geometry
 public:
   Item_func_numgeometries(THD *thd, Item *a)
    :Item_long_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_numgeometries"; }
-  bool fix_length_and_dec() { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_numgeometries"; }
+  bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_numgeometries>(thd, this); }
 };
 
@@ -969,10 +969,10 @@ class Item_func_numinteriorring: public Item_long_func_args_geometry
 public:
   Item_func_numinteriorring(THD *thd, Item *a)
    :Item_long_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_numinteriorrings"; }
-  bool fix_length_and_dec() { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_numinteriorrings"; }
+  bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_numinteriorring>(thd, this); }
 };
 
@@ -982,10 +982,10 @@ class Item_func_numpoints: public Item_long_func_args_geometry
 public:
   Item_func_numpoints(THD *thd, Item *a)
    :Item_long_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "st_numpoints"; }
-  bool fix_length_and_dec() { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "st_numpoints"; }
+  bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_numpoints>(thd, this); }
 };
 
@@ -994,16 +994,16 @@ class Item_func_area: public Item_real_func_args_geometry
 {
 public:
   Item_func_area(THD *thd, Item *a): Item_real_func_args_geometry(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "st_area"; }
-  bool fix_length_and_dec()
+  double val_real() override;
+  const char *func_name() const override { return "st_area"; }
+  bool fix_length_and_dec() override
   {
     if (Item_real_func::fix_length_and_dec())
       return TRUE;
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_area>(thd, this); }
 };
 
@@ -1014,16 +1014,16 @@ class Item_func_glength: public Item_real_func_args_geometry
 public:
   Item_func_glength(THD *thd, Item *a)
    :Item_real_func_args_geometry(thd, a) {}
-  double val_real();
-  const char *func_name() const { return "st_length"; }
-  bool fix_length_and_dec()
+  double val_real() override;
+  const char *func_name() const override { return "st_length"; }
+  bool fix_length_and_dec() override
   {
     if (Item_real_func::fix_length_and_dec())
       return TRUE;
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_glength>(thd, this); }
 };
 
@@ -1033,10 +1033,10 @@ class Item_func_srid: public Item_long_func_args_geometry
 public:
   Item_func_srid(THD *thd, Item *a)
    :Item_long_func_args_geometry(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "srid"; }
-  bool fix_length_and_dec() { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  const char *func_name() const override { return "srid"; }
+  bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_srid>(thd, this); }
 };
 
@@ -1051,9 +1051,9 @@ class Item_func_distance: public Item_real_func_args_geometry_geometry
 public:
   Item_func_distance(THD *thd, Item *a, Item *b)
    :Item_real_func_args_geometry_geometry(thd, a, b) {}
-  double val_real();
-  const char *func_name() const { return "st_distance"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "st_distance"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_distance>(thd, this); }
 };
 
@@ -1065,9 +1065,9 @@ class Item_func_sphere_distance: public Item_real_func
 public:
   Item_func_sphere_distance(THD *thd, List<Item> &list):
     Item_real_func(thd, list) {}
-  double val_real();
-  const char *func_name() const { return "st_distance_sphere"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  const char *func_name() const override { return "st_distance_sphere"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sphere_distance>(thd, this); }
 };
 
@@ -1081,13 +1081,13 @@ class Item_func_pointonsurface: public Item_geometry_func_args_geometry
 public:
   Item_func_pointonsurface(THD *thd, Item *a)
    :Item_geometry_func_args_geometry(thd, a) {}
-  const char *func_name() const { return "st_pointonsurface"; }
-  String *val_str(String *);
-  const Type_handler *type_handler() const
+  const char *func_name() const override { return "st_pointonsurface"; }
+  String *val_str(String *) override;
+  const Type_handler *type_handler() const override
   {
     return &type_handler_point;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_pointonsurface>(thd, this); }
 };
 
@@ -1098,14 +1098,14 @@ class Item_func_gis_debug: public Item_long_func
   public:
     Item_func_gis_debug(THD *thd, Item *a): Item_long_func(thd, a)
     { null_value= false; }
-    bool fix_length_and_dec() { fix_char_length(10); return FALSE; }
-    const char *func_name() const  { return "st_gis_debug"; }
-    longlong val_int();
-    bool check_vcol_func_processor(void *arg)
+    bool fix_length_and_dec() override { fix_char_length(10); return FALSE; }
+    const char *func_name() const override  { return "st_gis_debug"; }
+    longlong val_int() override;
+    bool check_vcol_func_processor(void *arg) override
     {
       return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
     }
-    Item *get_copy(THD *thd)
+    Item *get_copy(THD *thd) override
     { return get_item_copy<Item_func_gis_debug>(thd, this); }
 };
 #endif

--- a/sql/item_jsonfunc.h
+++ b/sql/item_jsonfunc.h
@@ -75,23 +75,23 @@ protected:
 
 public:
   Item_func_json_valid(THD *thd, Item *json) : Item_bool_func(thd, json) {}
-  longlong val_int();
-  const char *func_name() const { return "json_valid"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "json_valid"; }
+  bool fix_length_and_dec() override
   {
     if (Item_bool_func::fix_length_and_dec())
       return TRUE;
     maybe_null= 1;
     return FALSE;
   }
-  bool set_format_by_check_constraint(Send_field_extended_metadata *to) const
+  bool set_format_by_check_constraint(Send_field_extended_metadata *to) const override
   {
     static const Lex_cstring fmt(STRING_WITH_LEN("json"));
     return to->set_format_name(fmt);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_valid>(thd, this); }
-  enum Functype functype() const   { return JSON_VALID_FUNC; }
+  enum Functype functype() const override   { return JSON_VALID_FUNC; }
 };
 
 
@@ -104,11 +104,11 @@ protected:
 public:
   Item_func_json_exists(THD *thd, Item *js, Item *i_path):
     Item_bool_func(thd, js, i_path) {}
-  const char *func_name() const { return "json_exists"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_exists"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_exists>(thd, this); }
-  longlong val_int();
+  longlong val_int() override;
 };
 
 
@@ -186,10 +186,10 @@ protected:
 
 public:
   Item_func_json_quote(THD *thd, Item *s): Item_str_func(thd, s) {}
-  const char *func_name() const { return "json_quote"; }
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_quote"; }
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_quote>(thd, this); }
 };
 
@@ -201,10 +201,10 @@ protected:
   String *read_json(json_engine_t *je);
 public:
   Item_func_json_unquote(THD *thd, Item *s): Item_str_func(thd, s) {}
-  const char *func_name() const { return "json_unquote"; }
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_unquote"; }
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_unquote>(thd, this); }
 };
 
@@ -233,7 +233,7 @@ public:
     Item_json_func(thd, list), paths(NULL), tmp_paths(0), n_paths(0) {}
   virtual ~Item_json_str_multipath();
 
-  bool fix_fields(THD *thd, Item **ref);
+  bool fix_fields(THD *thd, Item **ref) override;
   virtual uint get_n_paths() const = 0;
 };
 
@@ -247,15 +247,15 @@ public:
                     char **out_val, int *value_len);
   Item_func_json_extract(THD *thd, List<Item> &list):
     Item_json_str_multipath(thd, list) {}
-  const char *func_name() const { return "json_extract"; }
-  enum Functype functype() const   { return JSON_EXTRACT_FUNC; }
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  longlong val_int();
-  double val_real();
-  my_decimal *val_decimal(my_decimal *);
-  uint get_n_paths() const { return arg_count - 1; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_extract"; }
+  enum Functype functype() const override   { return JSON_EXTRACT_FUNC; }
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  longlong val_int() override;
+  double val_real() override;
+  my_decimal *val_decimal(my_decimal *) override;
+  uint get_n_paths() const override { return arg_count - 1; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_extract>(thd, this); }
 };
 
@@ -271,10 +271,10 @@ protected:
 public:
   Item_func_json_contains(THD *thd, List<Item> &list):
     Item_bool_func(thd, list) {}
-  const char *func_name() const { return "json_contains"; }
-  bool fix_length_and_dec();
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_contains"; }
+  bool fix_length_and_dec() override;
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_contains>(thd, this); }
 };
 
@@ -293,11 +293,11 @@ public:
   Item_func_json_contains_path(THD *thd, List<Item> &list):
     Item_bool_func(thd, list), tmp_paths(0) {}
   virtual ~Item_func_json_contains_path();
-  const char *func_name() const { return "json_contains_path"; }
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec();
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_contains_path"; }
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override;
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_contains_path>(thd, this); }
 };
 
@@ -312,10 +312,10 @@ public:
     Item_json_func(thd) {}
   Item_func_json_array(THD *thd, List<Item> &list):
     Item_json_func(thd, list) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "json_array"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "json_array"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_array>(thd, this); }
 };
 
@@ -328,11 +328,11 @@ protected:
 public:
   Item_func_json_array_append(THD *thd, List<Item> &list):
     Item_json_str_multipath(thd, list) {}
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  uint get_n_paths() const { return arg_count/2; }
-  const char *func_name() const { return "json_array_append"; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  uint get_n_paths() const override { return arg_count/2; }
+  const char *func_name() const override { return "json_array_append"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_array_append>(thd, this); }
 };
 
@@ -342,9 +342,9 @@ class Item_func_json_array_insert: public Item_func_json_array_append
 public:
   Item_func_json_array_insert(THD *thd, List<Item> &list):
     Item_func_json_array_append(thd, list) {}
-  String *val_str(String *);
-  const char *func_name() const { return "json_array_insert"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  const char *func_name() const override { return "json_array_insert"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_array_insert>(thd, this); }
 };
 
@@ -356,9 +356,9 @@ public:
     Item_func_json_array(thd) {}
   Item_func_json_object(THD *thd, List<Item> &list):
     Item_func_json_array(thd, list) {}
-  String *val_str(String *);
-  const char *func_name() const { return "json_object"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  const char *func_name() const override { return "json_object"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_object>(thd, this); }
 };
 
@@ -370,9 +370,9 @@ protected:
 public:
   Item_func_json_merge(THD *thd, List<Item> &list):
     Item_func_json_array(thd, list) {}
-  String *val_str(String *);
-  const char *func_name() const { return "json_merge_preserve"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  const char *func_name() const override { return "json_merge_preserve"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_merge>(thd, this); }
 };
 
@@ -381,15 +381,15 @@ class Item_func_json_merge_patch: public Item_func_json_merge
 public:
   Item_func_json_merge_patch(THD *thd, List<Item> &list):
     Item_func_json_merge(thd, list) {}
-  const char *func_name() const { return "json_merge_patch"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_merge_patch"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_merge_patch>(thd, this); }
 };
 
 class Item_func_json_length: public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     if (arg_count == 0 || arg_count > 2)
     {
@@ -407,26 +407,26 @@ protected:
 public:
   Item_func_json_length(THD *thd, List<Item> &list):
     Item_long_func(thd, list) {}
-  const char *func_name() const { return "json_length"; }
-  bool fix_length_and_dec();
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_length"; }
+  bool fix_length_and_dec() override;
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_length>(thd, this); }
 };
 
 
 class Item_func_json_depth: public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_text(func_name()); }
 protected:
   String tmp_js;
 public:
   Item_func_json_depth(THD *thd, Item *js): Item_long_func(thd, js) {}
-  const char *func_name() const { return "json_depth"; }
-  bool fix_length_and_dec() { max_length= 10; return FALSE; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_depth"; }
+  bool fix_length_and_dec() override { max_length= 10; return FALSE; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_depth>(thd, this); }
 };
 
@@ -437,10 +437,10 @@ protected:
   String tmp_js;
 public:
   Item_func_json_type(THD *thd, Item *js): Item_str_func(thd, js) {}
-  const char *func_name() const { return "json_type"; }
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_type"; }
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_type>(thd, this); }
 };
 
@@ -455,15 +455,15 @@ public:
   Item_func_json_insert(bool i_mode, bool r_mode, THD *thd, List<Item> &list):
     Item_json_str_multipath(thd, list),
       mode_insert(i_mode), mode_replace(r_mode) {}
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  uint get_n_paths() const { return arg_count/2; }
-  const char *func_name() const
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  uint get_n_paths() const override { return arg_count/2; }
+  const char *func_name() const override
   {
     return mode_insert ?
              (mode_replace ? "json_set" : "json_insert") : "json_replace";
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_insert>(thd, this); }
 };
 
@@ -475,11 +475,11 @@ protected:
 public:
   Item_func_json_remove(THD *thd, List<Item> &list):
     Item_json_str_multipath(thd, list) {}
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  uint get_n_paths() const { return arg_count - 1; }
-  const char *func_name() const { return "json_remove"; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  uint get_n_paths() const override { return arg_count - 1; }
+  const char *func_name() const override { return "json_remove"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_remove>(thd, this); }
 };
 
@@ -493,10 +493,10 @@ protected:
 public:
   Item_func_json_keys(THD *thd, List<Item> &list):
     Item_str_func(thd, list) {}
-  const char *func_name() const { return "json_keys"; }
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_keys"; }
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_keys>(thd, this); }
 };
 
@@ -516,12 +516,12 @@ protected:
 public:
   Item_func_json_search(THD *thd, List<Item> &list):
     Item_json_str_multipath(thd, list) {}
-  const char *func_name() const { return "json_search"; }
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec();
-  String *val_str(String *);
-  uint get_n_paths() const { return arg_count > 4 ? arg_count - 4 : 0; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "json_search"; }
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override;
+  String *val_str(String *) override;
+  uint get_n_paths() const override { return arg_count > 4 ? arg_count - 4 : 0; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_search>(thd, this); }
 };
 
@@ -545,11 +545,11 @@ public:
   Item_func_json_format(THD *thd, List<Item> &list):
     Item_json_func(thd, list), fmt(DETAILED) {}
 
-  const char *func_name() const;
-  bool fix_length_and_dec();
-  String *val_str(String *str);
-  String *val_json(String *str);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override;
+  bool fix_length_and_dec() override;
+  String *val_str(String *str) override;
+  String *val_json(String *str) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_json_format>(thd, this); }
 };
 

--- a/sql/item_row.h
+++ b/sql/item_row.h
@@ -57,104 +57,104 @@ public:
     not_null_tables_cache(0), with_null(0)
   { }
 
-  bool with_subquery() const { DBUG_ASSERT(fixed); return m_with_subquery; }
-  enum Type type() const { return ROW_ITEM; };
-  const Type_handler *type_handler() const { return &type_handler_row; }
+  bool with_subquery() const override { DBUG_ASSERT(fixed); return m_with_subquery; }
+  enum Type type() const override { return ROW_ITEM; };
+  const Type_handler *type_handler() const override { return &type_handler_row; }
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     return NULL; // Check with Vicentiu why it's called for Item_row
   }
   void illegal_method_call(const char *);
-  bool is_null() { return null_value; }
-  void make_send_field(THD *thd, Send_field *)
+  bool is_null() override { return null_value; }
+  void make_send_field(THD *thd, Send_field *) override
   {
     illegal_method_call((const char*)"make_send_field");
   };
-  double val_real()
+  double val_real() override
   {
     illegal_method_call((const char*)"val");
     return 0;
   };
-  longlong val_int()
+  longlong val_int() override
   {
     illegal_method_call((const char*)"val_int");
     return 0;
   };
-  String *val_str(String *)
+  String *val_str(String *) override
   {
     illegal_method_call((const char*)"val_str");
     return 0;
   };
-  my_decimal *val_decimal(my_decimal *)
+  my_decimal *val_decimal(my_decimal *) override
   {
     illegal_method_call((const char*)"val_decimal");
     return 0;
   };
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     illegal_method_call((const char*)"get_date");
     return true;
   }
-  bool fix_fields(THD *thd, Item **ref);
-  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge);
-  void cleanup();
+  bool fix_fields(THD *thd, Item **ref) override;
+  void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
+  void cleanup() override;
   void split_sum_func(THD *thd, Ref_ptr_array ref_pointer_array,
-                      List<Item> &fields, uint flags);
-  bool with_sum_func() const { return m_with_sum_func; }
-  With_sum_func_cache* get_with_sum_func_cache() { return this; }
-  table_map used_tables() const { return used_tables_cache; };
-  bool const_item() const { return const_item_cache; };
-  void update_used_tables()
+                      List<Item> &fields, uint flags) override;
+  bool with_sum_func() const override { return m_with_sum_func; }
+  With_sum_func_cache* get_with_sum_func_cache() override { return this; }
+  table_map used_tables() const override { return used_tables_cache; };
+  bool const_item() const override { return const_item_cache; };
+  void update_used_tables() override
   {
     used_tables_and_const_cache_init();
     used_tables_and_const_cache_update_and_join(arg_count, args);
   }
-  table_map not_null_tables() const { return not_null_tables_cache; }
-  virtual void print(String *str, enum_query_type query_type);
+  table_map not_null_tables() const override { return not_null_tables_cache; }
+  void print(String *str, enum_query_type query_type) override;
 
-  bool walk(Item_processor processor, bool walk_subquery, void *arg)
+  bool walk(Item_processor processor, bool walk_subquery, void *arg) override
   {
     if (walk_args(processor, walk_subquery, arg))
       return true;
     return (this->*processor)(arg);
   }
-  Item *transform(THD *thd, Item_transformer transformer, uchar *arg);
-  bool eval_not_null_tables(void *opt_arg);
-  bool find_not_null_fields(table_map allowed);
+  Item *transform(THD *thd, Item_transformer transformer, uchar *arg) override;
+  bool eval_not_null_tables(void *opt_arg) override;
+  bool find_not_null_fields(table_map allowed) override;
 
-  uint cols() const { return arg_count; }
-  Item* element_index(uint i) { return args[i]; }
-  Item** addr(uint i) { return args + i; }
-  bool check_cols(uint c);
-  bool null_inside() { return with_null; };
-  void bring_value();
+  uint cols() const override { return arg_count; }
+  Item* element_index(uint i) override { return args[i]; }
+  Item** addr(uint i) override { return args + i; }
+  bool check_cols(uint c) override;
+  bool null_inside() override { return with_null; };
+  void bring_value() override;
 
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   {
     Item_args::propagate_equal_fields(thd, Context_identity(), cond);
     return this;
   }
 
-  bool excl_dep_on_table(table_map tab_map)
+  bool excl_dep_on_table(table_map tab_map) override
   {
     return Item_args::excl_dep_on_table(tab_map);
   }
 
-  bool excl_dep_on_grouping_fields(st_select_lex *sel)
+  bool excl_dep_on_grouping_fields(st_select_lex *sel) override
   {
     return Item_args::excl_dep_on_grouping_fields(sel);
   }
 
-  bool excl_dep_on_in_subq_left_part(Item_in_subselect *subq_pred)
+  bool excl_dep_on_in_subq_left_part(Item_in_subselect *subq_pred) override
   {
     return Item_args::excl_dep_on_in_subq_left_part(subq_pred);
   }
 
-  bool check_vcol_func_processor(void *arg) {return FALSE; }
-  Item *get_copy(THD *thd)
+  bool check_vcol_func_processor(void *arg) override {return FALSE; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_row>(thd, this); }
-  Item *build_clone(THD *thd);
+  Item *build_clone(THD *thd) override;
 };
 
 #endif /* ITEM_ROW_INCLUDED */

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -64,14 +64,14 @@ public:
     Item_func(thd, a, b, c, d, e) { decimals=NOT_FIXED_DEC; }
   Item_str_func(THD *thd, List<Item> &list):
     Item_func(thd, list) { decimals=NOT_FIXED_DEC; }
-  longlong val_int();
-  double val_real();
-  my_decimal *val_decimal(my_decimal *);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  longlong val_int() override;
+  double val_real() override;
+  my_decimal *val_decimal(my_decimal *) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   { return get_date_from_string(thd, ltime, fuzzydate); }
-  const Type_handler *type_handler() const { return string_type_handler(); }
+  const Type_handler *type_handler() const override { return string_type_handler(); }
   void left_right_max_length();
-  bool fix_fields(THD *thd, Item **ref);
+  bool fix_fields(THD *thd, Item **ref) override;
 };
 
 
@@ -88,11 +88,11 @@ public:
   Item_str_ascii_func(THD *thd, Item *a, Item *b): Item_str_func(thd, a, b) {}
   Item_str_ascii_func(THD *thd, Item *a, Item *b, Item *c):
     Item_str_func(thd, a, b, c) {}
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     return val_str_from_val_str_ascii(str, &ascii_buf);
   }
-  String *val_str_ascii(String *)= 0;
+  String *val_str_ascii(String *) override= 0;
 };
 
 
@@ -108,7 +108,7 @@ public:
    :Item_str_ascii_func(thd, a) { }
   Item_str_ascii_checksum_func(THD *thd, Item *a, Item *b)
    :Item_str_ascii_func(thd, a, b) { }
-  bool eq(const Item *item, bool binary_cmp) const
+  bool eq(const Item *item, bool binary_cmp) const override
   {
     // Always use binary argument comparison: MD5('x') != MD5('X')
     return Item_func::eq(item, true);
@@ -128,7 +128,7 @@ public:
    :Item_str_func(thd, a) { }
   Item_str_binary_checksum_func(THD *thd, Item *a, Item *b)
    :Item_str_func(thd, a, b) { }
-  bool eq(const Item *item, bool binary_cmp) const
+  bool eq(const Item *item, bool binary_cmp) const override
   {
     /*
       Always use binary argument comparison:
@@ -143,14 +143,14 @@ class Item_func_md5 :public Item_str_ascii_checksum_func
 {
 public:
   Item_func_md5(THD *thd, Item *a): Item_str_ascii_checksum_func(thd, a) {}
-  String *val_str_ascii(String *);
-  bool fix_length_and_dec()
+  String *val_str_ascii(String *) override;
+  bool fix_length_and_dec() override
   {
     fix_length_and_charset(32, default_charset());
     return FALSE;
   }
-  const char *func_name() const { return "md5"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "md5"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_md5>(thd, this); }
 };
 
@@ -159,10 +159,10 @@ class Item_func_sha :public Item_str_ascii_checksum_func
 {
 public:
   Item_func_sha(THD *thd, Item *a): Item_str_ascii_checksum_func(thd, a) {}
-  String *val_str_ascii(String *);    
-  bool fix_length_and_dec();
-  const char *func_name() const { return "sha"; }
-  Item *get_copy(THD *thd)
+  String *val_str_ascii(String *) override;    
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "sha"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sha>(thd, this); }
 };
 
@@ -171,10 +171,10 @@ class Item_func_sha2 :public Item_str_ascii_checksum_func
 public:
   Item_func_sha2(THD *thd, Item *a, Item *b)
    :Item_str_ascii_checksum_func(thd, a, b) {}
-  String *val_str_ascii(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "sha2"; }
-  Item *get_copy(THD *thd)
+  String *val_str_ascii(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "sha2"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sha2>(thd, this); }
 };
 
@@ -184,10 +184,10 @@ class Item_func_to_base64 :public Item_str_ascii_checksum_func
 public:
   Item_func_to_base64(THD *thd, Item *a)
    :Item_str_ascii_checksum_func(thd, a) {}
-  String *val_str_ascii(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "to_base64"; }
-  Item *get_copy(THD *thd)
+  String *val_str_ascii(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "to_base64"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_to_base64>(thd, this); }
 };
 
@@ -197,10 +197,10 @@ class Item_func_from_base64 :public Item_str_binary_checksum_func
 public:
   Item_func_from_base64(THD *thd, Item *a)
    :Item_str_binary_checksum_func(thd, a) { }
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "from_base64"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "from_base64"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_from_base64>(thd, this); }
 };
 
@@ -217,7 +217,7 @@ protected:
 public:
   Item_aes_crypt(THD *thd, Item *a, Item *b)
    :Item_str_binary_checksum_func(thd, a, b) {}
-  String *val_str(String *);
+  String *val_str(String *) override;
 };
 
 class Item_func_aes_encrypt :public Item_aes_crypt
@@ -225,9 +225,9 @@ class Item_func_aes_encrypt :public Item_aes_crypt
 public:
   Item_func_aes_encrypt(THD *thd, Item *a, Item *b)
    :Item_aes_crypt(thd, a, b) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return "aes_encrypt"; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "aes_encrypt"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_aes_encrypt>(thd, this); }
 };
 
@@ -236,9 +236,9 @@ class Item_func_aes_decrypt :public Item_aes_crypt
 public:
   Item_func_aes_decrypt(THD *thd, Item *a, Item *b):
     Item_aes_crypt(thd, a, b) {}
-  bool fix_length_and_dec();
-  const char *func_name() const { return "aes_decrypt"; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "aes_decrypt"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_aes_decrypt>(thd, this); }
 };
 
@@ -259,16 +259,16 @@ protected:
 public:
   Item_func_concat(THD *thd, List<Item> &list): Item_str_func(thd, list) {}
   Item_func_concat(THD *thd, Item *a, Item *b): Item_str_func(thd, a, b) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const Schema *schema() const { return &mariadb_schema; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  const char *func_name() const { return "concat"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "concat"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_concat>(thd, this); }
 };
 
@@ -286,9 +286,9 @@ public:
   Item_func_concat_operator_oracle(THD *thd, Item *a, Item *b)
    :Item_func_concat(thd, a, b)
   { }
-  String *val_str(String *);
-  const Schema *schema() const { return &oracle_schema_ref; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *) override;
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  void print(String *str, enum_query_type query_type) override
   {
     if (query_type & QT_FOR_FRM)
     {
@@ -299,7 +299,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   {
     return get_item_copy<Item_func_concat_operator_oracle>(thd, this);
   }
@@ -311,16 +311,16 @@ class Item_func_decode_histogram :public Item_str_func
 public:
   Item_func_decode_histogram(THD *thd, Item *a, Item *b):
     Item_str_func(thd, a, b) {}
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     collation.set(system_charset_info);
     max_length= MAX_BLOB_WIDTH;
     maybe_null= 1;
     return FALSE;
   }
-  const char *func_name() const { return "decode_histogram"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "decode_histogram"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_decode_histogram>(thd, this); }
 };
 
@@ -329,11 +329,11 @@ class Item_func_concat_ws :public Item_str_func
   String tmp_value;
 public:
   Item_func_concat_ws(THD *thd, List<Item> &list): Item_str_func(thd, list) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "concat_ws"; }
-  table_map not_null_tables() const { return 0; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "concat_ws"; }
+  table_map not_null_tables() const override { return 0; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_concat_ws>(thd, this); }
 };
 
@@ -342,10 +342,10 @@ class Item_func_reverse :public Item_str_func
   String tmp_value;
 public:
   Item_func_reverse(THD *thd, Item *a): Item_str_func(thd, a) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "reverse"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "reverse"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_reverse>(thd, this); }
 };
 
@@ -358,16 +358,16 @@ protected:
 public:
   Item_func_replace(THD *thd, Item *org, Item *find, Item *replace):
     Item_str_func(thd, org, find, replace) {}
-  String *val_str(String *to) { return val_str_internal(to, false); };
-  bool fix_length_and_dec();
-  const Schema *schema() const { return &mariadb_schema; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *to) override { return val_str_internal(to, false); };
+  bool fix_length_and_dec() override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  const char *func_name() const { return "replace"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "replace"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_replace>(thd, this); }
 };
 
@@ -378,9 +378,9 @@ class Item_func_replace_oracle :public Item_func_replace
 public:
   Item_func_replace_oracle(THD *thd, Item *org, Item *find, Item *replace):
     Item_func_replace(thd, org, find, replace) {}
-  String *val_str(String *to) { return val_str_internal(to, true); };
-  const Schema *schema() const { return &oracle_schema_ref; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *to) override { return val_str_internal(to, true); };
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  void print(String *str, enum_query_type query_type) override
   {
     if (query_type & QT_FOR_FRM)
     {
@@ -391,7 +391,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_replace_oracle>(thd, this); }
 };
 
@@ -408,26 +408,26 @@ public:
   Item_func_regexp_replace(THD *thd, Item *a, Item *b, Item *c):
     Item_str_func(thd, a, b, c)
     {}
-  const Schema *schema() const { return &mariadb_schema; }
-  void print(String *str, enum_query_type query_type)
+  const Schema *schema() const override { return &mariadb_schema; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  void cleanup()
+  void cleanup() override
   {
     DBUG_ENTER("Item_func_regexp_replace::cleanup");
     Item_str_func::cleanup();
     re.cleanup();
     DBUG_VOID_RETURN;
   }
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     return val_str_internal(str, false);
   }
-  bool fix_length_and_dec();
-  const char *func_name() const { return "regexp_replace"; }
-  Item *get_copy(THD *thd) { return 0;}
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "regexp_replace"; }
+  Item *get_copy(THD *thd) override { return 0;}
 };
 
 
@@ -437,14 +437,14 @@ public:
   Item_func_regexp_replace_oracle(THD *thd, Item *a, Item *b, Item *c)
    :Item_func_regexp_replace(thd, a, b, c)
   {}
-  const Schema *schema() const { return &oracle_schema_ref; }
-  bool fix_length_and_dec()
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  bool fix_length_and_dec() override
   {
     bool rc= Item_func_regexp_replace::fix_length_and_dec();
     maybe_null= true; // Empty result is converted to NULL
     return rc;
   }
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     return val_str_internal(str, true);
   }
@@ -458,17 +458,17 @@ public:
   Item_func_regexp_substr(THD *thd, Item *a, Item *b):
     Item_str_func(thd, a, b)
     {}
-  void cleanup()
+  void cleanup() override
   {
     DBUG_ENTER("Item_func_regexp_substr::cleanup");
     Item_str_func::cleanup();
     re.cleanup();
     DBUG_VOID_RETURN;
   }
-  String *val_str(String *str);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "regexp_substr"; }
-  Item *get_copy(THD *thd) { return 0; }
+  String *val_str(String *str) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "regexp_substr"; }
+  Item *get_copy(THD *thd) override { return 0; }
 };
 
 
@@ -479,10 +479,10 @@ public:
   Item_func_insert(THD *thd, Item *org, Item *start, Item *length,
                    Item *new_str):
     Item_str_func(thd, org, start, length, new_str) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "insert"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "insert"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_insert>(thd, this); }
 };
 
@@ -495,7 +495,7 @@ protected:
   String tmp_value;
 public:
   Item_str_conv(THD *thd, Item *item): Item_str_func(thd, item) {}
-  String *val_str(String *);
+  String *val_str(String *) override;
 };
 
 
@@ -503,9 +503,9 @@ class Item_func_lcase :public Item_str_conv
 {
 public:
   Item_func_lcase(THD *thd, Item *item): Item_str_conv(thd, item) {}
-  const char *func_name() const { return "lcase"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "lcase"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_lcase>(thd, this); }
 };
 
@@ -513,9 +513,9 @@ class Item_func_ucase :public Item_str_conv
 {
 public:
   Item_func_ucase(THD *thd, Item *item): Item_str_conv(thd, item) {}
-  const char *func_name() const { return "ucase"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "ucase"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ucase>(thd, this); }
 };
 
@@ -525,11 +525,11 @@ class Item_func_left :public Item_str_func
   String tmp_value;
 public:
   Item_func_left(THD *thd, Item *a, Item *b): Item_str_func(thd, a, b) {}
-  bool hash_not_null(Hasher *hasher);
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "left"; }
-  Item *get_copy(THD *thd)
+  bool hash_not_null(Hasher *hasher) override;
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "left"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_left>(thd, this); }
 };
 
@@ -539,10 +539,10 @@ class Item_func_right :public Item_str_func
   String tmp_value;
 public:
   Item_func_right(THD *thd, Item *a, Item *b): Item_str_func(thd, a, b) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "right"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "right"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_right>(thd, this); }
 };
 
@@ -558,25 +558,25 @@ public:
     Item_str_func(thd, a, b, c) {}
   Item_func_substr(THD *thd, List<Item> &list)
     :Item_str_func(thd, list) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const Schema *schema() const { return &mariadb_schema; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  const char *func_name() const { return "substr"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "substr"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_substr>(thd, this); }
 };
 
 class Item_func_substr_oracle :public Item_func_substr
 {
 protected:
-  longlong get_position()
+  longlong get_position() override
   { longlong pos= args[1]->val_int(); return pos == 0 ? 1 : pos; }
-  String *make_empty_result(String *str)
+  String *make_empty_result(String *str) override
   { null_value= 1; return NULL; }
 public:
   Item_func_substr_oracle(THD *thd, Item *a, Item *b):
@@ -585,14 +585,14 @@ public:
     Item_func_substr(thd, a, b, c) {}
   Item_func_substr_oracle(THD *thd, List<Item> &list)
     :Item_func_substr(thd, list) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     bool res= Item_func_substr::fix_length_and_dec();
     maybe_null= true;
     return res;
   }
-  const Schema *schema() const { return &oracle_schema_ref; }
-  void print(String *str, enum_query_type query_type)
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  void print(String *str, enum_query_type query_type) override
   {
     if (query_type & QT_FOR_FRM)
     {
@@ -603,7 +603,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_substr_oracle>(thd, this); }
 };
 
@@ -613,10 +613,10 @@ class Item_func_substr_index :public Item_str_func
 public:
   Item_func_substr_index(THD *thd, Item *a,Item *b,Item *c):
     Item_str_func(thd, a, b, c) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "substring_index"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "substring_index"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_substr_index>(thd, this); }
 
 };
@@ -648,14 +648,14 @@ protected:
 public:
   Item_func_trim(THD *thd, Item *a, Item *b): Item_str_func(thd, a, b) {}
   Item_func_trim(THD *thd, Item *a): Item_str_func(thd, a) {}
-  Sql_mode_dependency value_depends_on_sql_mode() const;
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const Schema *schema() const { return &mariadb_schema; }
-  const char *func_name() const { return "trim"; }
-  void print(String *str, enum_query_type query_type);
+  Sql_mode_dependency value_depends_on_sql_mode() const override;
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  const char *func_name() const override { return "trim"; }
+  void print(String *str, enum_query_type query_type) override;
   virtual const char *mode_name() const { return "both"; }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_trim>(thd, this); }
 };
 
@@ -663,20 +663,20 @@ public:
 class Item_func_trim_oracle :public Item_func_trim
 {
 protected:
-  String *make_empty_result(String *str)
+  String *make_empty_result(String *str) override
   { null_value= 1; return NULL; }
 public:
   Item_func_trim_oracle(THD *thd, Item *a, Item *b):
     Item_func_trim(thd, a, b) {}
   Item_func_trim_oracle(THD *thd, Item *a): Item_func_trim(thd, a) {}
-  const Schema *schema() const { return &oracle_schema_ref; }
-  bool fix_length_and_dec()
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  bool fix_length_and_dec() override
   {
     bool res= Item_func_trim::fix_length_and_dec();
     maybe_null= true;
     return res;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_trim_oracle>(thd, this); }
 };
 
@@ -686,15 +686,15 @@ class Item_func_ltrim :public Item_func_trim
 public:
   Item_func_ltrim(THD *thd, Item *a, Item *b): Item_func_trim(thd, a, b) {}
   Item_func_ltrim(THD *thd, Item *a): Item_func_trim(thd, a) {}
-  Sql_mode_dependency value_depends_on_sql_mode() const
+  Sql_mode_dependency value_depends_on_sql_mode() const override
   {
     return Item_func::value_depends_on_sql_mode();
   }
-  String *val_str(String *);
-  const Schema *schema() const { return &mariadb_schema; }
-  const char *func_name() const { return "ltrim"; }
-  const char *mode_name() const { return "leading"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  const char *func_name() const override { return "ltrim"; }
+  const char *mode_name() const override { return "leading"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ltrim>(thd, this); }
 };
 
@@ -702,20 +702,20 @@ public:
 class Item_func_ltrim_oracle :public Item_func_ltrim
 {
 protected:
-  String *make_empty_result(String *str)
+  String *make_empty_result(String *str) override
   { null_value= 1; return NULL; }
 public:
   Item_func_ltrim_oracle(THD *thd, Item *a, Item *b):
     Item_func_ltrim(thd, a, b) {}
   Item_func_ltrim_oracle(THD *thd, Item *a): Item_func_ltrim(thd, a) {}
-  const Schema *schema() const { return &oracle_schema_ref; }
-  bool fix_length_and_dec()
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  bool fix_length_and_dec() override
   {
     bool res= Item_func_ltrim::fix_length_and_dec();
     maybe_null= true;
     return res;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_ltrim_oracle>(thd, this); }
 };
 
@@ -725,11 +725,11 @@ class Item_func_rtrim :public Item_func_trim
 public:
   Item_func_rtrim(THD *thd, Item *a, Item *b): Item_func_trim(thd, a, b) {}
   Item_func_rtrim(THD *thd, Item *a): Item_func_trim(thd, a) {}
-  String *val_str(String *);
-  const Schema *schema() const { return &mariadb_schema; }
-  const char *func_name() const { return "rtrim"; }
-  const char *mode_name() const { return "trailing"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  const char *func_name() const override { return "rtrim"; }
+  const char *mode_name() const override { return "trailing"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_rtrim>(thd, this); }
 };
 
@@ -737,20 +737,20 @@ public:
 class Item_func_rtrim_oracle :public Item_func_rtrim
 {
 protected:
-  String *make_empty_result(String *str)
+  String *make_empty_result(String *str) override
   { null_value= 1; return NULL; }
 public:
   Item_func_rtrim_oracle(THD *thd, Item *a, Item *b):
     Item_func_rtrim(thd, a, b) {}
   Item_func_rtrim_oracle(THD *thd, Item *a): Item_func_rtrim(thd, a) {}
-  const Schema *schema() const { return &oracle_schema_ref; }
-  bool fix_length_and_dec()
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  bool fix_length_and_dec() override
   {
     bool res= Item_func_rtrim::fix_length_and_dec();
     maybe_null= true;
     return res;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_rtrim_oracle>(thd, this); }
 };
 
@@ -775,9 +775,9 @@ public:
     Item_str_ascii_checksum_func(thd, a), alg(NEW), deflt(1) {}
   Item_func_password(THD *thd, Item *a, PW_Alg al):
     Item_str_ascii_checksum_func(thd, a), alg(al), deflt(0) {}
-  String *val_str_ascii(String *str);
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec()
+  String *val_str_ascii(String *str) override;
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override
   {
     fix_length_and_charset((alg == 1 ?
                             SCRAMBLED_PASSWORD_CHAR_LENGTH :
@@ -785,11 +785,11 @@ public:
                            default_charset());
     return FALSE;
   }
-  const char *func_name() const { return ((deflt || alg == 1) ?
+  const char *func_name() const override { return ((deflt || alg == 1) ?
                                           "password" : "old_password"); }
   static char *alloc(THD *thd, const char *password, size_t pass_len,
                      enum PW_Alg al);
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_password>(thd, this); }
 };
 
@@ -803,16 +803,16 @@ public:
    :Item_str_binary_checksum_func(thd, a) {}
   Item_func_des_encrypt(THD *thd, Item *a, Item *b)
    :Item_str_binary_checksum_func(thd, a, b) {}
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     maybe_null=1;
     /* 9 = MAX ((8- (arg_len % 8)) + 1) */
     max_length = args[0]->max_length + 9;
     return FALSE;
   }
-  const char *func_name() const { return "des_encrypt"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "des_encrypt"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_des_encrypt>(thd, this); }
 };
 
@@ -824,8 +824,8 @@ public:
    :Item_str_binary_checksum_func(thd, a) {}
   Item_func_des_decrypt(THD *thd, Item *a, Item *b)
    :Item_str_binary_checksum_func(thd, a, b) {}
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     maybe_null=1;
     /* 9 = MAX ((8- (arg_len % 8)) + 1) */
@@ -834,8 +834,8 @@ public:
       max_length-= 9U;
     return FALSE;
   }
-  const char *func_name() const { return "des_decrypt"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "des_decrypt"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_des_decrypt>(thd, this); }
 };
 
@@ -864,14 +864,14 @@ public:
   {
     constructor_helper();
   }
-  String *val_str(String *);
-  bool fix_length_and_dec() { maybe_null=1; max_length = 13; return FALSE; }
-  const char *func_name() const { return "encrypt"; }
-  bool check_vcol_func_processor(void *arg)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override { maybe_null=1; max_length = 13; return FALSE; }
+  const char *func_name() const override { return "encrypt"; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_encrypt>(thd, this); }
 };
 
@@ -888,10 +888,10 @@ protected:
 public:
   Item_func_encode(THD *thd, Item *a, Item *seed_arg):
     Item_str_binary_checksum_func(thd, a, seed_arg) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "encode"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "encode"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_encode>(thd, this); }
 protected:
   virtual void crypto_transform(String *);
@@ -905,17 +905,17 @@ class Item_func_decode :public Item_func_encode
 {
 public:
   Item_func_decode(THD *thd, Item *a, Item *seed_arg): Item_func_encode(thd, a, seed_arg) {}
-  const Schema *schema() const { return &mariadb_schema; }
-  void print(String *str, enum_query_type query_type)
+  const Schema *schema() const override { return &mariadb_schema; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  const char *func_name() const { return "decode"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "decode"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_decode>(thd, this); }
 protected:
-  void crypto_transform(String *);
+  void crypto_transform(String *) override;
 };
 
 
@@ -924,19 +924,19 @@ class Item_func_sysconst :public Item_str_func
 public:
   Item_func_sysconst(THD *thd): Item_str_func(thd)
   { collation.set(system_charset_info,DERIVATION_SYSCONST); }
-  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs);
+  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override;
   /*
     Used to create correct Item name in new converted item in
     safe_charset_converter, return string representation of this function
     call
   */
   virtual const char *fully_qualified_func_name() const = 0;
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(fully_qualified_func_name(), arg,
                                      VCOL_SESSION_FUNC);
   }
-  bool const_item() const;
+  bool const_item() const override;
 };
 
 
@@ -944,16 +944,16 @@ class Item_func_database :public Item_func_sysconst
 {
 public:
   Item_func_database(THD *thd): Item_func_sysconst(thd) {}
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     max_length= NAME_CHAR_LEN * system_charset_info->mbmaxlen;
     maybe_null=1;
     return FALSE;
   }
-  const char *func_name() const { return "database"; }
-  const char *fully_qualified_func_name() const { return "database()"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "database"; }
+  const char *fully_qualified_func_name() const override { return "database()"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_database>(thd, this); }
 };
 
@@ -962,20 +962,20 @@ class Item_func_sqlerrm :public Item_func_sysconst
 {
 public:
   Item_func_sqlerrm(THD *thd): Item_func_sysconst(thd) {}
-  String *val_str(String *);
-  const char *func_name() const { return "SQLERRM"; }
-  const char *fully_qualified_func_name() const { return "SQLERRM"; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *) override;
+  const char *func_name() const override { return "SQLERRM"; }
+  const char *fully_qualified_func_name() const override { return "SQLERRM"; }
+  void print(String *str, enum_query_type query_type) override
   {
     str->append(func_name());
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     max_length= 512 * system_charset_info->mbmaxlen;
     null_value= maybe_null= false;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sqlerrm>(thd, this); }
 };
 
@@ -990,25 +990,25 @@ public:
   {
     str_value.set("", 0, system_charset_info);
   }
-  String *val_str(String *)
+  String *val_str(String *) override
   {
     DBUG_ASSERT(fixed == 1);
     return (null_value ? 0 : &str_value);
   }
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec()
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override
   {
     max_length= (uint32) (username_char_length +
                  HOSTNAME_LENGTH + 1) * SYSTEM_CHARSET_MBMAXLEN;
     return FALSE;
   }
-  const char *func_name() const { return "user"; }
-  const char *fully_qualified_func_name() const { return "user()"; }
-  int save_in_field(Field *field, bool no_conversions)
+  const char *func_name() const override { return "user"; }
+  const char *fully_qualified_func_name() const override { return "user()"; }
+  int save_in_field(Field *field, bool no_conversions) override
   {
     return save_str_value_in_field(field, &str_value);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_user>(thd, this); }
 };
 
@@ -1020,10 +1020,10 @@ class Item_func_current_user :public Item_func_user
 public:
   Item_func_current_user(THD *thd, Name_resolution_context *context_arg):
     Item_func_user(thd), context(context_arg) {}
-  bool fix_fields(THD *thd, Item **ref);
-  const char *func_name() const { return "current_user"; }
-  const char *fully_qualified_func_name() const { return "current_user()"; }
-  bool check_vcol_func_processor(void *arg)
+  bool fix_fields(THD *thd, Item **ref) override;
+  const char *func_name() const override { return "current_user"; }
+  const char *fully_qualified_func_name() const override { return "current_user()"; }
+  bool check_vcol_func_processor(void *arg) override
   {
     context= 0;
     return mark_unsupported_function(fully_qualified_func_name(), arg,
@@ -1039,29 +1039,29 @@ class Item_func_current_role :public Item_func_sysconst
 public:
   Item_func_current_role(THD *thd, Name_resolution_context *context_arg):
     Item_func_sysconst(thd), context(context_arg) {}
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec()
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override
   {
     max_length= (uint32) username_char_length * SYSTEM_CHARSET_MBMAXLEN;
     return FALSE;
   }
-  int save_in_field(Field *field, bool no_conversions)
+  int save_in_field(Field *field, bool no_conversions) override
   { return save_str_value_in_field(field, &str_value); }
-  const char *func_name() const { return "current_role"; }
-  const char *fully_qualified_func_name() const { return "current_role()"; }
-  String *val_str(String *)
+  const char *func_name() const override { return "current_role"; }
+  const char *fully_qualified_func_name() const override { return "current_role()"; }
+  String *val_str(String *) override
   {
     DBUG_ASSERT(fixed == 1);
     return null_value ? NULL : &str_value;
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
 
     context= 0;
     return mark_unsupported_function(fully_qualified_func_name(), arg,
                                      VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_current_role>(thd, this); }
 };
 
@@ -1071,10 +1071,10 @@ class Item_func_soundex :public Item_str_func
   String tmp_value;
 public:
   Item_func_soundex(THD *thd, Item *a): Item_str_func(thd, a) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "soundex"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "soundex"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_soundex>(thd, this); }
 };
 
@@ -1083,12 +1083,12 @@ class Item_func_elt :public Item_str_func
 {
 public:
   Item_func_elt(THD *thd, List<Item> &list): Item_str_func(thd, list) {}
-  double val_real();
-  longlong val_int();
-  String *val_str(String *str);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "elt"; }
-  Item *get_copy(THD *thd)
+  double val_real() override;
+  longlong val_int() override;
+  String *val_str(String *str) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "elt"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_elt>(thd, this); }
 };
 
@@ -1099,10 +1099,10 @@ class Item_func_make_set :public Item_str_func
 
 public:
   Item_func_make_set(THD *thd, List<Item> &list): Item_str_func(thd, list) {}
-  String *val_str(String *str);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "make_set"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *str) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "make_set"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_make_set>(thd, this); }
 };
 
@@ -1116,10 +1116,10 @@ public:
   Item_func_format(THD *thd, Item *org, Item *dec, Item *lang):
     Item_str_ascii_func(thd, org, dec, lang) {}
 
-  String *val_str_ascii(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "format"; }
-  Item *get_copy(THD *thd)
+  String *val_str_ascii(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "format"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_format>(thd, this); }
 };
 
@@ -1135,16 +1135,16 @@ public:
   Item_func_char(THD *thd, Item *arg1, CHARSET_INFO *cs):
     Item_str_func(thd, arg1)
   { collation.set(cs); }
-  String *val_str(String *);
+  String *val_str(String *) override;
   void append_char(String * str, int32 num);
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     max_length= arg_count * 4;
     return FALSE;
   }
-  const char *func_name() const { return "char"; }
-  void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "char"; }
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_char>(thd, this); }
 };
 
@@ -1153,14 +1153,14 @@ class Item_func_chr :public Item_func_char
 public:
   Item_func_chr(THD *thd, Item *arg1, CHARSET_INFO *cs):
     Item_func_char(thd, arg1, cs) {}
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     max_length= 4;
     return FALSE;
   }
-  const char *func_name() const { return "chr"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "chr"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_chr>(thd, this); }
 };
 
@@ -1170,10 +1170,10 @@ class Item_func_repeat :public Item_str_func
 public:
   Item_func_repeat(THD *thd, Item *arg1, Item *arg2):
     Item_str_func(thd, arg1, arg2) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "repeat"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "repeat"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_repeat>(thd, this); }
 };
 
@@ -1182,10 +1182,10 @@ class Item_func_space :public Item_str_func
 {
 public:
   Item_func_space(THD *thd, Item *arg1): Item_str_func(thd, arg1) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "space"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "space"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_space>(thd, this); }
 };
 
@@ -1195,14 +1195,14 @@ class Item_func_binlog_gtid_pos :public Item_str_func
 public:
   Item_func_binlog_gtid_pos(THD *thd, Item *arg1, Item *arg2):
     Item_str_func(thd, arg1, arg2) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "binlog_gtid_pos"; }
-  bool check_vcol_func_processor(void *arg)
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "binlog_gtid_pos"; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_binlog_gtid_pos>(thd, this); }
 };
 
@@ -1218,7 +1218,7 @@ public:
     Item_str_func(thd, arg1, arg2) {}
   Item_func_pad(THD *thd, List<Item> &list):
     Item_str_func(thd,list) {}
-  bool fix_length_and_dec();
+  bool fix_length_and_dec() override;
 };
 
 
@@ -1231,23 +1231,23 @@ public:
     Item_func_pad(thd, arg1, arg2) {}
   Item_func_rpad(THD *thd, List<Item> &list):
     Item_func_pad(thd,list) {}
-  String *val_str(String *);
-  const Schema *schema() const { return &mariadb_schema; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *) override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  const char *func_name() const { return "rpad"; }
-  Sql_mode_dependency value_depends_on_sql_mode() const;
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "rpad"; }
+  Sql_mode_dependency value_depends_on_sql_mode() const override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_rpad>(thd, this); }
 };
 
 
 class Item_func_rpad_oracle :public Item_func_rpad
 {
-  String *make_empty_result(String *str)
+  String *make_empty_result(String *str) override
   { null_value= 1; return NULL; }
 public:
   Item_func_rpad_oracle(THD *thd, Item *arg1, Item *arg2, Item *arg3):
@@ -1256,14 +1256,14 @@ public:
     Item_func_rpad(thd, arg1, arg2) {}
   Item_func_rpad_oracle(THD *thd, List<Item> &list):
     Item_func_rpad(thd,list) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     bool res= Item_func_rpad::fix_length_and_dec();
     maybe_null= true;
     return res;
   }
-  const Schema *schema() const { return &oracle_schema_ref; }
-  void print(String *str, enum_query_type query_type)
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  void print(String *str, enum_query_type query_type) override
   {
     if (query_type & QT_FOR_FRM)
     {
@@ -1274,7 +1274,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_rpad_oracle>(thd, this); }
 };
 
@@ -1288,22 +1288,22 @@ public:
     Item_func_pad(thd, arg1, arg2) {}
   Item_func_lpad(THD *thd, List<Item> &list):
     Item_func_pad(thd,list) {}
-  String *val_str(String *);
-  const Schema *schema() const { return &mariadb_schema; }
-  void print(String *str, enum_query_type query_type)
+  String *val_str(String *) override;
+  const Schema *schema() const override { return &mariadb_schema; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  const char *func_name() const { return "lpad"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "lpad"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_lpad>(thd, this); }
 };
 
 
 class Item_func_lpad_oracle :public Item_func_lpad
 {
-  String *make_empty_result(String *str)
+  String *make_empty_result(String *str) override
   { null_value= 1; return NULL; }
 public:
   Item_func_lpad_oracle(THD *thd, Item *arg1, Item *arg2, Item *arg3):
@@ -1312,14 +1312,14 @@ public:
     Item_func_lpad(thd, arg1, arg2) {}
   Item_func_lpad_oracle(THD *thd, List<Item> &list):
     Item_func_lpad(thd,list) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     bool res= Item_func_lpad::fix_length_and_dec();
     maybe_null= true;
     return res;
   }
-  const Schema *schema() const { return &oracle_schema_ref; }
-  void print(String *str, enum_query_type query_type)
+  const Schema *schema() const override { return &oracle_schema_ref; }
+  void print(String *str, enum_query_type query_type) override
   {
     if (query_type & QT_FOR_FRM)
     {
@@ -1330,7 +1330,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_lpad_oracle>(thd, this); }
 };
 
@@ -1340,16 +1340,16 @@ class Item_func_conv :public Item_str_func
 public:
   Item_func_conv(THD *thd, Item *a, Item *b, Item *c):
     Item_str_func(thd, a, b, c) {}
-  const char *func_name() const { return "conv"; }
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "conv"; }
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     collation.set(default_charset());
     fix_char_length(64);
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_conv>(thd, this); }
 };
 
@@ -1368,16 +1368,16 @@ protected:
 public:
   Item_func_hex(THD *thd, Item *a):
     Item_str_ascii_checksum_func(thd, a), m_arg0_type_handler(NULL) {}
-  const char *func_name() const { return "hex"; }
+  const char *func_name() const override { return "hex"; }
   String *val_str_ascii_from_val_int(String *str);
   String *val_str_ascii_from_val_real(String *str);
   String *val_str_ascii_from_val_str(String *str);
-  String *val_str_ascii(String *str)
+  String *val_str_ascii(String *str) override
   {
     DBUG_ASSERT(fixed);
     return m_arg0_type_handler->Item_func_hex_val_str_ascii(this, str);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     collation.set(default_charset(), DERIVATION_COERCIBLE, MY_REPERTOIRE_ASCII);
     decimals=0;
@@ -1385,7 +1385,7 @@ public:
     m_arg0_type_handler= args[0]->type_handler();
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_hex>(thd, this); }
 };
 
@@ -1398,16 +1398,16 @@ public:
     /* there can be bad hex strings */
     maybe_null= 1;
   }
-  const char *func_name() const { return "unhex"; }
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "unhex"; }
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     collation.set(&my_charset_bin);
     decimals=0;
     max_length=(1+args[0]->max_length)/2;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_unhex>(thd, this); }
 };
 
@@ -1423,8 +1423,8 @@ public:
   Item_func_like_range(THD *thd, Item *a, Item *b, bool is_min_arg):
     Item_str_func(thd, a, b), is_min(is_min_arg)
   { maybe_null= 1; }
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     collation.set(args[0]->collation);
     decimals=0;
@@ -1439,8 +1439,8 @@ class Item_func_like_range_min :public Item_func_like_range
 public:
   Item_func_like_range_min(THD *thd, Item *a, Item *b):
     Item_func_like_range(thd, a, b, true) { }
-  const char *func_name() const { return "like_range_min"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "like_range_min"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_like_range_min>(thd, this); }
 };
 
@@ -1450,8 +1450,8 @@ class Item_func_like_range_max :public Item_func_like_range
 public:
   Item_func_like_range_max(THD *thd, Item *a, Item *b):
     Item_func_like_range(thd, a, b, false) { }
-  const char *func_name() const { return "like_range_max"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "like_range_max"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_like_range_max>(thd, this); }
 };
 #endif
@@ -1461,7 +1461,7 @@ class Item_func_binary :public Item_str_func
 {
 public:
   Item_func_binary(THD *thd, Item *a): Item_str_func(thd, a) {}
-  String *val_str(String *a)
+  String *val_str(String *a) override
   {
     DBUG_ASSERT(fixed == 1);
     String *tmp=args[0]->val_str(a);
@@ -1470,16 +1470,16 @@ public:
       tmp->set_charset(&my_charset_bin);
     return tmp;
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     collation.set(&my_charset_bin);
     max_length=args[0]->max_length;
     return FALSE;
   }
-  void print(String *str, enum_query_type query_type);
-  const char *func_name() const { return "cast_as_binary"; }
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  const char *func_name() const override { return "cast_as_binary"; }
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_binary>(thd, this); }
 };
 
@@ -1489,20 +1489,20 @@ class Item_load_file :public Item_str_func
   String tmp_value;
 public:
   Item_load_file(THD *thd, Item *a): Item_str_func(thd, a) {}
-  String *val_str(String *);
-  const char *func_name() const { return "load_file"; }
-  bool fix_length_and_dec()
+  String *val_str(String *) override;
+  const char *func_name() const override { return "load_file"; }
+  bool fix_length_and_dec() override
   {
     collation.set(&my_charset_bin, DERIVATION_COERCIBLE);
     maybe_null=1;
     max_length=MAX_BLOB_WIDTH;
     return FALSE;
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_load_file>(thd, this); }
 };
 
@@ -1516,10 +1516,10 @@ class Item_func_export_set: public Item_str_func
     Item_str_func(thd, a, b, c, d) {}
   Item_func_export_set(THD *thd, Item *a, Item *b, Item* c, Item* d, Item* e):
     Item_str_func(thd, a, b, c, d, e) {}
-  String  *val_str(String *str);
-  bool fix_length_and_dec();
-  const char *func_name() const { return "export_set"; }
-  Item *get_copy(THD *thd)
+  String  *val_str(String *str) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "export_set"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_export_set>(thd, this); }
 };
 
@@ -1529,9 +1529,9 @@ class Item_func_quote :public Item_str_func
   String tmp_value;
 public:
   Item_func_quote(THD *thd, Item *a): Item_str_func(thd, a) {}
-  const char *func_name() const { return "quote"; }
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "quote"; }
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     collation.set(args[0]->collation);
     ulonglong max_result_length= (ulonglong) args[0]->max_length * 2 +
@@ -1542,7 +1542,7 @@ public:
     max_length= (uint32) MY_MIN(max_result_length, MAX_BLOB_WIDTH);
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_quote>(thd, this); }
 };
 
@@ -1594,8 +1594,8 @@ public:
               (cs->mbmaxlen > 1 || !(cs->state & MY_CS_NONASCII))));
     }
   }
-  String *val_str(String *);
-  longlong val_int()
+  String *val_str(String *) override;
+  longlong val_int() override
   {
     if (args[0]->result_type() == STRING_RESULT)
       return Item_str_func::val_int();
@@ -1604,7 +1604,7 @@ public:
       return 0;
     return res;
   }
-  double val_real()
+  double val_real() override
   {
     if (args[0]->result_type() == STRING_RESULT)
       return Item_str_func::val_real();
@@ -1613,7 +1613,7 @@ public:
       return 0;
     return res;
   }
-  my_decimal *val_decimal(my_decimal *d)
+  my_decimal *val_decimal(my_decimal *d) override
   {
     if (args[0]->result_type() == STRING_RESULT)
       return Item_str_func::val_decimal(d);
@@ -1622,7 +1622,7 @@ public:
       return NULL;
     return res;
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     if (args[0]->result_type() == STRING_RESULT)
       return Item_str_func::get_date(thd, ltime, fuzzydate);
@@ -1631,10 +1631,10 @@ public:
       return 1;
     return res;
   }
-  bool fix_length_and_dec();
-  const char *func_name() const { return "convert"; }
-  void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return "convert"; }
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_conv_charset>(thd, this); }
 };
 
@@ -1644,20 +1644,20 @@ class Item_func_set_collation :public Item_str_func
 public:
   Item_func_set_collation(THD *thd, Item *a, CHARSET_INFO *set_collation):
     Item_str_func(thd, a), m_set_collation(set_collation) {}
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  bool eq(const Item *item, bool binary_cmp) const;
-  const char *func_name() const { return "collate"; }
-  enum precedence precedence() const { return COLLATE_PRECEDENCE; }
-  enum Functype functype() const { return COLLATE_FUNC; }
-  void print(String *str, enum_query_type query_type);
-  Item_field *field_for_view_update()
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  bool eq(const Item *item, bool binary_cmp) const override;
+  const char *func_name() const override { return "collate"; }
+  enum precedence precedence() const override { return COLLATE_PRECEDENCE; }
+  enum Functype functype() const override { return COLLATE_FUNC; }
+  void print(String *str, enum_query_type query_type) override;
+  Item_field *field_for_view_update() override
   {
     /* this function is transparent for view updating */
     return args[0]->field_for_view_update();
   }
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_set_collation>(thd, this); }
 };
 
@@ -1666,17 +1666,17 @@ class Item_func_expr_str_metadata :public Item_str_func
 {
 public:
   Item_func_expr_str_metadata(THD *thd, Item *a): Item_str_func(thd, a) { }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
      collation.set(system_charset_info);
      max_length= 64 * collation.collation->mbmaxlen; // should be enough
      maybe_null= 0;
      return FALSE;
   };
-  table_map not_null_tables() const { return 0; }
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  table_map not_null_tables() const override { return 0; }
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   { return this; }
-  bool const_item() const { return true; }
+  bool const_item() const override { return true; }
 };
 
 
@@ -1685,9 +1685,9 @@ class Item_func_charset :public Item_func_expr_str_metadata
 public:
   Item_func_charset(THD *thd, Item *a)
     :Item_func_expr_str_metadata(thd, a) { }
-  String *val_str(String *);
-  const char *func_name() const { return "charset"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  const char *func_name() const override { return "charset"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_charset>(thd, this); }
 };
 
@@ -1697,9 +1697,9 @@ class Item_func_collation :public Item_func_expr_str_metadata
 public:
   Item_func_collation(THD *thd, Item *a)
     :Item_func_expr_str_metadata(thd, a) {}
-  String *val_str(String *);
-  const char *func_name() const { return "collation"; }
-  Item *get_copy(THD *thd)
+  String *val_str(String *) override;
+  const char *func_name() const override { return "collation"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_collation>(thd, this); }
 };
 
@@ -1719,10 +1719,10 @@ public:
     flags= flags_arg;
     result_length= result_length_arg;
   }
-  const char *func_name() const { return "weight_string"; }
-  String *val_str(String *);
-  bool fix_length_and_dec();
-  bool eq(const Item *item, bool binary_cmp) const
+  const char *func_name() const override { return "weight_string"; }
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override;
+  bool eq(const Item *item, bool binary_cmp) const override
   {
     if (!Item_str_func::eq(item, binary_cmp))
       return false;
@@ -1731,25 +1731,25 @@ public:
            this->nweights == that->nweights &&
            this->result_length == that->result_length;
   }
-  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond)
+  Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   { return this; }
-  void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_weight_string>(thd, this); }
 };
 
 class Item_func_crc32 :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_str(func_name()); }
   String value;
 public:
   Item_func_crc32(THD *thd, Item *a): Item_long_func(thd, a)
   { unsigned_flag= 1; }
-  const char *func_name() const { return "crc32"; }
-  bool fix_length_and_dec() { max_length=10; return FALSE; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "crc32"; }
+  bool fix_length_and_dec() override { max_length=10; return FALSE; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_crc32>(thd, this); }
 };
 
@@ -1759,10 +1759,10 @@ class Item_func_uncompressed_length : public Item_long_func_length
 public:
   Item_func_uncompressed_length(THD *thd, Item *a)
    :Item_long_func_length(thd, a) {}
-  const char *func_name() const{return "uncompressed_length";}
-  bool fix_length_and_dec() { max_length=10; maybe_null= true; return FALSE; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override{return "uncompressed_length";}
+  bool fix_length_and_dec() override { max_length=10; maybe_null= true; return FALSE; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_uncompressed_length>(thd, this); }
 };
 
@@ -1778,14 +1778,14 @@ class Item_func_compress: public Item_str_binary_checksum_func
 public:
   Item_func_compress(THD *thd, Item *a)
    :Item_str_binary_checksum_func(thd, a) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     max_length= (args[0]->max_length * 120) / 100 + 12;
     return FALSE;
   }
-  const char *func_name() const{return "compress";}
-  String *val_str(String *) ZLIB_DEPENDED_FUNCTION
-  Item *get_copy(THD *thd)
+  const char *func_name() const override{return "compress";}
+  String *val_str(String *) override ZLIB_DEPENDED_FUNCTION
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_compress>(thd, this); }
 };
 
@@ -1795,14 +1795,14 @@ class Item_func_uncompress: public Item_str_binary_checksum_func
 public:
   Item_func_uncompress(THD *thd, Item *a)
    :Item_str_binary_checksum_func(thd, a) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     maybe_null= 1; max_length= MAX_BLOB_WIDTH;
     return FALSE;
   }
-  const char *func_name() const{return "uncompress";}
-  String *val_str(String *) ZLIB_DEPENDED_FUNCTION
-  Item *get_copy(THD *thd)
+  const char *func_name() const override{return "uncompress";}
+  String *val_str(String *) override ZLIB_DEPENDED_FUNCTION
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_uncompress>(thd, this); }
 };
 
@@ -1811,21 +1811,21 @@ class Item_func_uuid: public Item_str_func
 {
 public:
   Item_func_uuid(THD *thd): Item_str_func(thd) {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     collation.set(DTCollation_numeric());
     fix_char_length(MY_UUID_STRING_LENGTH);
     return FALSE;
   }
-  bool const_item() const { return false; }
-  table_map used_tables() const { return RAND_TABLE_BIT; }
-  const char *func_name() const{ return "uuid"; }
-  String *val_str(String *);
-  bool check_vcol_func_processor(void *arg)
+  bool const_item() const override { return false; }
+  table_map used_tables() const override { return RAND_TABLE_BIT; }
+  const char *func_name() const override{ return "uuid"; }
+  String *val_str(String *) override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_NON_DETERMINISTIC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_uuid>(thd, this); }
 };
 
@@ -1842,13 +1842,13 @@ protected:
   void print_arguments(String *str, enum_query_type query_type);
 public:
   Item_func_dyncol_create(THD *thd, List<Item> &args, DYNCALL_CREATE_DEF *dfs);
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec();
-  const char *func_name() const{ return "column_create"; }
-  String *val_str(String *);
-  void print(String *str, enum_query_type query_type);
-  enum Functype functype() const   { return DYNCOL_FUNC; }
-  Item *get_copy(THD *thd)
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override;
+  const char *func_name() const override{ return "column_create"; }
+  String *val_str(String *) override;
+  void print(String *str, enum_query_type query_type) override;
+  enum Functype functype() const override   { return DYNCOL_FUNC; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dyncol_create>(thd, this); }
 };
 
@@ -1859,10 +1859,10 @@ public:
   Item_func_dyncol_add(THD *thd, List<Item> &args_arg, DYNCALL_CREATE_DEF *dfs):
     Item_func_dyncol_create(thd, args_arg, dfs)
   {}
-  const char *func_name() const{ return "column_add"; }
-  String *val_str(String *);
-  void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override{ return "column_add"; }
+  String *val_str(String *) override;
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dyncol_add>(thd, this); }
 };
 
@@ -1871,16 +1871,16 @@ class Item_func_dyncol_json: public Item_str_func
 public:
   Item_func_dyncol_json(THD *thd, Item *str): Item_str_func(thd, str)
     {collation.set(DYNCOL_UTF);}
-  const char *func_name() const{ return "column_json"; }
-  String *val_str(String *);
-  bool fix_length_and_dec()
+  const char *func_name() const override{ return "column_json"; }
+  String *val_str(String *) override;
+  bool fix_length_and_dec() override
   {
     max_length= MAX_BLOB_WIDTH;
     maybe_null= 1;
     decimals= 0;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dyncol_json>(thd, this); }
 };
 
@@ -1893,15 +1893,15 @@ class Item_dyncol_get: public Item_str_func
 public:
   Item_dyncol_get(THD *thd, Item *str, Item *num): Item_str_func(thd, str, num)
   {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   { maybe_null= 1;; max_length= MAX_BLOB_WIDTH; return FALSE; }
   /* Mark that collation can change between calls */
-  bool dynamic_result() { return 1; }
+  bool dynamic_result() override { return 1; }
 
-  const char *func_name() const { return "column_get"; }
-  String *val_str(String *);
-  longlong val_int();
-  longlong val_int_signed_typecast()
+  const char *func_name() const override { return "column_get"; }
+  String *val_str(String *) override;
+  longlong val_int() override;
+  longlong val_int_signed_typecast() override
   {
     unsigned_flag= false;   // Mark that we want to have a signed value
     longlong value= val_int(); // val_int() can change unsigned_flag
@@ -1909,7 +1909,7 @@ public:
       push_note_converted_to_negative_complement(current_thd);
     return value;
   }
-  longlong val_int_unsigned_typecast()
+  longlong val_int_unsigned_typecast() override
   {
     unsigned_flag= true; // Mark that we want to have an unsigned value
     longlong value= val_int(); // val_int() can change unsigned_flag
@@ -1917,12 +1917,12 @@ public:
       push_note_converted_to_positive_complement(current_thd);
     return value;
   }
-  double val_real();
-  my_decimal *val_decimal(my_decimal *);
+  double val_real() override;
+  my_decimal *val_decimal(my_decimal *) override;
   bool get_dyn_value(THD *thd, DYNAMIC_COLUMN_VALUE *val, String *tmp);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_dyncol_get>(thd, this); }
 };
 
@@ -1932,11 +1932,11 @@ class Item_func_dyncol_list: public Item_str_func
 public:
   Item_func_dyncol_list(THD *thd, Item *str): Item_str_func(thd, str)
     {collation.set(DYNCOL_UTF);}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   { maybe_null= 1; max_length= MAX_BLOB_WIDTH; return FALSE; };
-  const char *func_name() const{ return "column_list"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override{ return "column_list"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dyncol_list>(thd, this); }
 };
 
@@ -1950,14 +1950,14 @@ class Item_temptable_rowid :public Item_str_func
 public:
   TABLE *table;
   Item_temptable_rowid(TABLE *table_arg);
-  const Type_handler *type_handler() const { return &type_handler_string; }
+  const Type_handler *type_handler() const override { return &type_handler_string; }
   Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table)
   { return create_table_field_from_handler(root, table); }
-  String *val_str(String *str);
-  enum Functype functype() const { return  TEMPTABLE_ROWID; }
-  const char *func_name() const { return "<rowid>"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  String *val_str(String *str) override;
+  enum Functype functype() const override { return  TEMPTABLE_ROWID; }
+  const char *func_name() const override { return "<rowid>"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_temptable_rowid>(thd, this); }
 };
 #ifdef WITH_WSREP
@@ -1969,15 +1969,15 @@ class Item_func_wsrep_last_written_gtid: public Item_str_ascii_func
   String gtid_str;
 public:
   Item_func_wsrep_last_written_gtid(THD *thd): Item_str_ascii_func(thd) {}
-  const char *func_name() const { return "wsrep_last_written_gtid"; }
-  String *val_str_ascii(String *);
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "wsrep_last_written_gtid"; }
+  String *val_str_ascii(String *) override;
+  bool fix_length_and_dec() override
   {
     max_length= WSREP_GTID_STR_LEN;
     maybe_null= true;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_wsrep_last_written_gtid>(thd, this); }
 };
 
@@ -1986,15 +1986,15 @@ class Item_func_wsrep_last_seen_gtid: public Item_str_ascii_func
   String gtid_str;
 public:
   Item_func_wsrep_last_seen_gtid(THD *thd): Item_str_ascii_func(thd) {}
-  const char *func_name() const { return "wsrep_last_seen_gtid"; }
-  String *val_str_ascii(String *);
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "wsrep_last_seen_gtid"; }
+  String *val_str_ascii(String *) override;
+  bool fix_length_and_dec() override
   {
     max_length= WSREP_GTID_STR_LEN;
     maybe_null= true;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_wsrep_last_seen_gtid>(thd, this); }
 };
 
@@ -2004,10 +2004,10 @@ class Item_func_wsrep_sync_wait_upto: public Item_int_func
 public:
  Item_func_wsrep_sync_wait_upto(THD *thd, Item *a): Item_int_func(thd, a) {}
  Item_func_wsrep_sync_wait_upto(THD *thd, Item *a, Item* b): Item_int_func(thd, a, b) {}
-  const Type_handler *type_handler() const { return &type_handler_string; }
-  const char *func_name() const { return "wsrep_sync_wait_upto_gtid"; }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  const Type_handler *type_handler() const override { return &type_handler_string; }
+  const char *func_name() const override { return "wsrep_sync_wait_upto_gtid"; }
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_wsrep_sync_wait_upto>(thd, this); }
 };
 #endif /* WITH_WSREP */

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -468,7 +468,7 @@ class Field_fixer: public Field_enumerator
 public:
   table_map used_tables; /* Collect used_tables here */
   st_select_lex *new_parent; /* Select we're in */
-  virtual void visit_field(Item_field *item)
+  void visit_field(Item_field *item) override
   {
     //for (TABLE_LIST *tbl= new_parent->leaf_tables; tbl; tbl= tbl->next_local)
     //{

--- a/sql/item_subselect.h
+++ b/sql/item_subselect.h
@@ -307,29 +307,29 @@ public:
   Item_singlerow_subselect(THD *thd_arg): Item_subselect(thd_arg), value(0), row (0)
   {}
 
-  void cleanup();
-  subs_type substype() { return SINGLEROW_SUBS; }
+  void cleanup() override;
+  subs_type substype() override { return SINGLEROW_SUBS; }
 
-  void reset();
-  void no_rows_in_result();
-  bool select_transformer(JOIN *join);
+  void reset() override;
+  void no_rows_in_result() override;
+  bool select_transformer(JOIN *join) override;
   void store(uint i, Item* item);
-  double val_real();
-  longlong val_int ();
-  String *val_str (String *);
-  bool val_native(THD *thd, Native *);
-  my_decimal *val_decimal(my_decimal *);
-  bool val_bool();
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  const Type_handler *type_handler() const;
-  bool fix_length_and_dec();
+  double val_real() override;
+  longlong val_int () override;
+  String *val_str (String *) override;
+  bool val_native(THD *thd, Native *) override;
+  my_decimal *val_decimal(my_decimal *) override;
+  bool val_bool() override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  const Type_handler *type_handler() const override;
+  bool fix_length_and_dec() override;
 
-  uint cols() const;
-  Item* element_index(uint i) { return reinterpret_cast<Item*>(row[i]); }
-  Item** addr(uint i) { return (Item**)row + i; }
-  bool check_cols(uint c);
-  bool null_inside();
-  void bring_value();
+  uint cols() const override;
+  Item* element_index(uint i) override { return reinterpret_cast<Item*>(row[i]); }
+  Item** addr(uint i) override { return (Item**)row + i; }
+  bool check_cols(uint c) override;
+  bool null_inside() override;
+  void bring_value() override;
 
   /**
     This method is used to implement a special case of semantic tree
@@ -345,7 +345,7 @@ public:
   */
   st_select_lex* invalidate_and_restore_select_lex();
 
-  Item* expr_cache_insert_transformer(THD *thd, uchar *unused);
+  Item* expr_cache_insert_transformer(THD *thd, uchar *unused) override;
 
   friend class select_singlerow_subselect;
 };
@@ -360,12 +360,12 @@ protected:
 public:
   Item_maxmin_subselect(THD *thd, Item_subselect *parent,
 			st_select_lex *select_lex, bool max);
-  virtual void print(String *str, enum_query_type query_type);
-  void cleanup();
+  void print(String *str, enum_query_type query_type) override;
+  void cleanup() override;
   bool any_value() { return was_values; }
   void register_value() { was_values= TRUE; }
-  void reset_value_registration() { was_values= FALSE; }
-  void no_rows_in_result();
+  void reset_value_registration() override { was_values= FALSE; }
+  void no_rows_in_result() override;
 };
 
 /* exists subselect */
@@ -800,16 +800,16 @@ public:
                         chooser_compare_func_creator fc,
                         st_select_lex *select_lex, bool all);
 
-  void cleanup();
+  void cleanup() override;
   // only ALL subquery has upper not
-  subs_type substype() { return all?ALL_SUBS:ANY_SUBS; }
-  bool select_transformer(JOIN *join);
+  subs_type substype() override { return all?ALL_SUBS:ANY_SUBS; }
+  bool select_transformer(JOIN *join) override;
   void create_comp_func(bool invert) { func= func_creator(invert); }
-  void print(String *str, enum_query_type query_type);
-  enum precedence precedence() const { return CMP_PRECEDENCE; }
+  void print(String *str, enum_query_type query_type) override;
+  enum precedence precedence() const override { return CMP_PRECEDENCE; }
   bool is_maxmin_applicable(JOIN *join);
   bool transform_into_max_min(JOIN *join);
-  void no_rows_in_result();
+  void no_rows_in_result() override;
 };
 
 
@@ -1066,9 +1066,9 @@ public:
      check_null(chk_null),
      having(having_arg)
   { DBUG_ASSERT(subs); }
-  int exec();
-  void print (String *str, enum_query_type query_type);
-  virtual enum_engine_type engine_type() { return INDEXSUBQUERY_ENGINE; }
+  int exec() override;
+  void print (String *str, enum_query_type query_type) override;
+  enum_engine_type engine_type() override { return INDEXSUBQUERY_ENGINE; }
 };
 
 /*
@@ -1509,7 +1509,7 @@ protected:
 
   bool test_null_row(rownum_t row_num);
   bool exists_complementing_null_row(MY_BITMAP *keys_to_complement);
-  bool partial_match();
+  bool partial_match() override;
 public:
   subselect_rowid_merge_engine(subselect_uniquesubquery_engine *engine_arg,
                                TABLE *tmp_table_arg, uint merge_keys_count_arg,
@@ -1528,15 +1528,15 @@ public:
   {}
   ~subselect_rowid_merge_engine();
   bool init(MY_BITMAP *non_null_key_parts, MY_BITMAP *partial_match_key_parts);
-  void cleanup();
-  virtual enum_engine_type engine_type() { return ROWID_MERGE_ENGINE; }
+  void cleanup() override;
+  enum_engine_type engine_type() override { return ROWID_MERGE_ENGINE; }
 };
 
 
 class subselect_table_scan_engine: public subselect_partial_match_engine
 {
 protected:
-  bool partial_match();
+  bool partial_match() override;
 public:
   subselect_table_scan_engine(subselect_uniquesubquery_engine *engine_arg,
                               TABLE *tmp_table_arg, Item_subselect *item_arg,
@@ -1545,7 +1545,7 @@ public:
                               bool has_covering_null_row_arg,
                               bool has_covering_null_columns_arg,
                               uint count_columns_with_nulls_arg);
-  void cleanup();
-  virtual enum_engine_type engine_type() { return TABLE_SCAN_ENGINE; }
+  void cleanup() override;
+  enum_engine_type engine_type() override { return TABLE_SCAN_ENGINE; }
 };
 #endif /* ITEM_SUBSELECT_INCLUDED */

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -418,7 +418,7 @@ public:
   Item_sum(THD *thd, List<Item> &list);
   //Copy constructor, need to perform subselects with temporary tables
   Item_sum(THD *thd, Item_sum *item);
-  enum Type type() const { return SUM_FUNC_ITEM; }
+  enum Type type() const override { return SUM_FUNC_ITEM; }
   virtual enum Sumfunctype sum_func () const=0;
   bool is_aggr_sum_func()
   {
@@ -468,14 +468,14 @@ public:
     Updated value is then saved in the field.
   */
   virtual void update_field()=0;
-  virtual bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   { maybe_null=1; null_value=1; return FALSE; }
   virtual Item *result_item(THD *thd, Field *field);
 
-  void update_used_tables ();
+  void update_used_tables () override;
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
-                          COND_EQUAL **cond_equal_ref)
+                          COND_EQUAL **cond_equal_ref) override
   {
     /*
       Item_sum (and derivants) of the original WHERE/HAVING clauses
@@ -486,7 +486,7 @@ public:
     return Item::build_equal_items(thd, inherited, link_item_fields,
                                    cond_equal_ref);
   }
-  bool is_null() { return null_value; }
+  bool is_null() override { return null_value; }
   /**
     make_const()
     Called if we've managed to calculate the value of this Item in
@@ -499,8 +499,8 @@ public:
     const_item_cache= true;
   }
   void reset_forced_const() { const_item_cache= false; }
-  virtual bool const_during_execution() const { return false; }
-  virtual void print(String *str, enum_query_type query_type);
+  bool const_during_execution() const override { return false; }
+  void print(String *str, enum_query_type query_type) override;
   void fix_num_length_and_dec();
 
   /**
@@ -513,7 +513,7 @@ public:
     may be initialized to 0 by clear() and to NULL by
     no_rows_in_result().
   */
-  virtual void no_rows_in_result()
+  void no_rows_in_result() override
   {
     set_aggregator(with_distinct ?
                    Aggregator::DISTINCT_AGGREGATOR :
@@ -521,14 +521,14 @@ public:
     aggregator_clear();
   }
   virtual void make_unique() { force_copy_fields= TRUE; }
-  Item *get_tmp_table_item(THD *thd);
+  Item *get_tmp_table_item(THD *thd) override;
   virtual Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table);
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     return create_tmp_field(root, param->group(), table);
   }
-  virtual bool collect_outer_ref_processor(void *param);
+  bool collect_outer_ref_processor(void *param) override;
   bool init_sum_func_check(THD *thd);
   bool check_sum_func(THD *thd, Item **ref);
   bool register_sum_func(THD *thd, Item **ref);
@@ -588,14 +588,14 @@ public:
   virtual bool supports_removal() const { return false; }
   virtual void remove() { DBUG_ASSERT(0); }
 
-  virtual void cleanup();
-  bool check_vcol_func_processor(void *arg);
+  void cleanup() override;
+  bool check_vcol_func_processor(void *arg) override;
   virtual void setup_window_func(THD *thd, Window_spec *window_spec) {}
   void mark_as_window_func_sum_expr() { window_func_sum_expr_flag= true; }
   bool is_window_func_sum_expr() { return window_func_sum_expr_flag; }
   virtual void setup_caches(THD *thd) {};
 
-  bool with_sum_func() const { return true; }
+  bool with_sum_func() const override { return true; }
   virtual void set_partition_row_count(ulonglong count) { DBUG_ASSERT(0); }
 
   /*
@@ -702,15 +702,15 @@ public:
     Aggregator(sum), table(NULL), tmp_table_param(NULL), tree(NULL),
     always_null(false), use_distinct_values(false) {}
   virtual ~Aggregator_distinct ();
-  Aggregator_type Aggrtype() { return DISTINCT_AGGREGATOR; }
+  Aggregator_type Aggrtype() override { return DISTINCT_AGGREGATOR; }
 
-  bool setup(THD *);
-  void clear(); 
-  bool add();
-  void endup();
-  virtual my_decimal *arg_val_decimal(my_decimal * value);
-  virtual double arg_val_real();
-  virtual bool arg_is_null(bool use_null_value);
+  bool setup(THD *) override;
+  void clear() override; 
+  bool add() override;
+  void endup() override;
+  my_decimal *arg_val_decimal(my_decimal * value) override;
+  double arg_val_real() override;
+  bool arg_is_null(bool use_null_value) override;
 
   bool unique_walk_function(void *element);
   bool unique_walk_function_for_count(void *element);
@@ -729,15 +729,15 @@ public:
 
   Aggregator_simple (Item_sum *sum) :
     Aggregator(sum) {}
-  Aggregator_type Aggrtype() { return Aggregator::SIMPLE_AGGREGATOR; }
+  Aggregator_type Aggrtype() override { return Aggregator::SIMPLE_AGGREGATOR; }
 
-  bool setup(THD * thd) { return item_sum->setup(thd); }
-  void clear() { item_sum->clear(); }
-  bool add() { return item_sum->add(); }
-  void endup() {};
-  virtual my_decimal *arg_val_decimal(my_decimal * value);
-  virtual double arg_val_real();
-  virtual bool arg_is_null(bool use_null_value);
+  bool setup(THD * thd) override { return item_sum->setup(thd); }
+  void clear() override { item_sum->clear(); }
+  bool add() override { return item_sum->add(); }
+  void endup() override {};
+  my_decimal *arg_val_decimal(my_decimal * value) override;
+  double arg_val_real() override;
+  bool arg_is_null(bool use_null_value) override;
 };
 
 
@@ -753,7 +753,7 @@ public:
     Item_sum(thd, list) {}
   Item_sum_num(THD *thd, Item_sum_num *item):
     Item_sum(thd, item) {}
-  bool fix_fields(THD *, Item **);
+  bool fix_fields(THD *, Item **) override;
 };
 
 
@@ -764,23 +764,23 @@ public:
   Item_sum_double(THD *thd, Item *item_par): Item_sum_num(thd, item_par) {}
   Item_sum_double(THD *thd, List<Item> &list): Item_sum_num(thd, list) {}
   Item_sum_double(THD *thd, Item_sum_double *item) :Item_sum_num(thd, item) {}
-  longlong val_int()
+  longlong val_int() override
   {
     return val_int_from_real();
   }
-  String *val_str(String*str)
+  String *val_str(String*str) override
   {
     return val_string_from_real(str);
   }
-  my_decimal *val_decimal(my_decimal *to)
+  my_decimal *val_decimal(my_decimal *to) override
   {
     return val_decimal_from_real(to);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return get_date_from_real(thd, ltime, fuzzydate);
   }
-  const Type_handler *type_handler() const { return &type_handler_double; }
+  const Type_handler *type_handler() const override { return &type_handler_double; }
 };
 
 
@@ -791,14 +791,14 @@ public:
   Item_sum_int(THD *thd, Item *item_par): Item_sum_num(thd, item_par) {}
   Item_sum_int(THD *thd, List<Item> &list): Item_sum_num(thd, list) {}
   Item_sum_int(THD *thd, Item_sum_int *item) :Item_sum_num(thd, item) {}
-  double val_real() { DBUG_ASSERT(fixed == 1); return (double) val_int(); }
-  String *val_str(String*str);
-  my_decimal *val_decimal(my_decimal *);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  double val_real() override { DBUG_ASSERT(fixed == 1); return (double) val_int(); }
+  String *val_str(String*str) override;
+  my_decimal *val_decimal(my_decimal *) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return get_date_from_int(thd, ltime, fuzzydate);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   { decimals=0; max_length=21; maybe_null=null_value=0; return FALSE; }
 };
 
@@ -815,7 +815,7 @@ protected:
   my_decimal direct_sum_decimal;
   my_decimal dec_buffs[2];
   uint curr_dec_buff;
-  bool fix_length_and_dec();
+  bool fix_length_and_dec() override;
 
 public:
   Item_sum_sum(THD *thd, Item *item_par, bool distinct):
@@ -825,40 +825,40 @@ public:
     set_distinct(distinct);
   }
   Item_sum_sum(THD *thd, Item_sum_sum *item);
-  enum Sumfunctype sum_func () const 
+  enum Sumfunctype sum_func () const override 
   { 
     return has_with_distinct() ? SUM_DISTINCT_FUNC : SUM_FUNC; 
   }
-  void cleanup();
+  void cleanup() override;
   void direct_add(my_decimal *add_sum_decimal);
   void direct_add(double add_sum_real, bool add_sum_is_null);
-  void clear();
-  bool add();
-  double val_real();
-  longlong val_int();
-  String *val_str(String*str);
-  my_decimal *val_decimal(my_decimal *);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  void clear() override;
+  bool add() override;
+  double val_real() override;
+  longlong val_int() override;
+  String *val_str(String*str) override;
+  my_decimal *val_decimal(my_decimal *) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   { return Type_handler_hybrid_field_type::type_handler(); }
   void fix_length_and_dec_double();
   void fix_length_and_dec_decimal();
-  void reset_field();
-  void update_field();
-  void no_rows_in_result() {}
-  const char *func_name() const 
+  void reset_field() override;
+  void update_field() override;
+  void no_rows_in_result() override {}
+  const char *func_name() const override 
   { 
     return has_with_distinct() ? "sum(distinct " : "sum("; 
   }
-  Item *copy_or_same(THD* thd);
-  void remove();
-  Item *get_copy(THD *thd)
+  Item *copy_or_same(THD* thd) override;
+  void remove() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_sum>(thd, this); }
 
-  bool supports_removal() const
+  bool supports_removal() const override
   {
     return true;
   }
@@ -878,10 +878,10 @@ class Item_sum_count :public Item_sum_int
 
   friend class Aggregator_distinct;
 
-  void clear();
-  bool add();
-  void cleanup();
-  void remove();
+  void clear() override;
+  bool add() override;
+  void cleanup() override;
+  void remove() override;
 
 public:
   Item_sum_count(THD *thd, Item *item_par):
@@ -907,30 +907,30 @@ public:
     Item_sum_int(thd, item), direct_counted(FALSE),
     direct_reseted_field(FALSE), count(item->count)
   {}
-  enum Sumfunctype sum_func () const 
+  enum Sumfunctype sum_func () const override 
   { 
     return has_with_distinct() ? COUNT_DISTINCT_FUNC : COUNT_FUNC; 
   }
-  void no_rows_in_result() { count=0; }
+  void no_rows_in_result() override { count=0; }
   void make_const(longlong count_arg) 
   { 
     count=count_arg;
     Item_sum::make_const();
   }
-  const Type_handler *type_handler() const { return &type_handler_slonglong; }
-  longlong val_int();
-  void reset_field();
-  void update_field();
+  const Type_handler *type_handler() const override { return &type_handler_slonglong; }
+  longlong val_int() override;
+  void reset_field() override;
+  void update_field() override;
   void direct_add(longlong add_count);
-  const char *func_name() const 
+  const char *func_name() const override 
   { 
     return has_with_distinct() ? "count(distinct " : "count(";
   }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_count>(thd, this); }
 
-  bool supports_removal() const
+  bool supports_removal() const override
   {
     return true;
   }
@@ -955,38 +955,38 @@ public:
 
   void fix_length_and_dec_double();
   void fix_length_and_dec_decimal();
-  bool fix_length_and_dec();
-  enum Sumfunctype sum_func () const 
+  bool fix_length_and_dec() override;
+  enum Sumfunctype sum_func () const override 
   {
     return has_with_distinct() ? AVG_DISTINCT_FUNC : AVG_FUNC;
   }
-  void clear();
-  bool add();
-  void remove();
-  double val_real();
+  void clear() override;
+  bool add() override;
+  void remove() override;
+  double val_real() override;
   // In SPs we might force the "wrong" type with select into a declare variable
-  longlong val_int() { return val_int_from_real(); }
-  my_decimal *val_decimal(my_decimal *);
-  String *val_str(String *str);
-  void reset_field();
-  void update_field();
-  Item *result_item(THD *thd, Field *field);
-  void no_rows_in_result() {}
-  const char *func_name() const 
+  longlong val_int() override { return val_int_from_real(); }
+  my_decimal *val_decimal(my_decimal *) override;
+  String *val_str(String *str) override;
+  void reset_field() override;
+  void update_field() override;
+  Item *result_item(THD *thd, Field *field) override;
+  void no_rows_in_result() override {}
+  const char *func_name() const override 
   { 
     return has_with_distinct() ? "avg(distinct " : "avg("; 
   }
-  Item *copy_or_same(THD* thd);
-  Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table);
-  void cleanup()
+  Item *copy_or_same(THD* thd) override;
+  Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table) override;
+  void cleanup() override
   {
     count= 0;
     Item_sum_sum::cleanup();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_avg>(thd, this); }
 
-  bool supports_removal() const
+  bool supports_removal() const override
   {
     return true;
   }
@@ -1111,7 +1111,7 @@ public:
     :Item_sum(thd, item),
     Type_handler_hybrid_field_type(item)
   { }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   { return Type_handler_hybrid_field_type::type_handler(); }
   bool fix_length_and_dec_generic();
   bool fix_length_and_dec_numeric(const Type_handler *h);
@@ -1145,35 +1145,35 @@ public:
     direct_added(FALSE), value(item->value), arg_cache(0),
     cmp_sign(item->cmp_sign), was_values(item->was_values)
   { }
-  bool fix_fields(THD *, Item **);
-  bool fix_length_and_dec();
+  bool fix_fields(THD *, Item **) override;
+  bool fix_length_and_dec() override;
   void setup_hybrid(THD *thd, Item *item, Item *value_arg);
-  void clear();
+  void clear() override;
   void direct_add(Item *item);
-  double val_real();
-  longlong val_int();
-  my_decimal *val_decimal(my_decimal *);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  void reset_field();
-  String *val_str(String *);
-  bool val_native(THD *thd, Native *);
-  const Type_handler *real_type_handler() const
+  double val_real() override;
+  longlong val_int() override;
+  my_decimal *val_decimal(my_decimal *) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  void reset_field() override;
+  String *val_str(String *) override;
+  bool val_native(THD *thd, Native *) override;
+  const Type_handler *real_type_handler() const override
   {
     return get_arg(0)->real_type_handler();
   }
-  const TYPELIB *get_typelib() const { return args[0]->get_typelib(); }
-  void update_field();
+  const TYPELIB *get_typelib() const override { return args[0]->get_typelib(); }
+  void update_field() override;
   void min_max_update_str_field();
   void min_max_update_real_field();
   void min_max_update_int_field();
   void min_max_update_decimal_field();
   void min_max_update_native_field();
-  void cleanup();
+  void cleanup() override;
   bool any_value() { return was_values; }
-  void no_rows_in_result();
-  void restore_to_before_no_rows_in_result();
-  Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table);
-  void setup_caches(THD *thd) { setup_hybrid(thd, arguments()[0], NULL); }
+  void no_rows_in_result() override;
+  void restore_to_before_no_rows_in_result() override;
+  Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table) override;
+  void setup_caches(THD *thd) override { setup_hybrid(thd, arguments()[0], NULL); }
 };
 
 
@@ -1182,12 +1182,12 @@ class Item_sum_min final :public Item_sum_min_max
 public:
   Item_sum_min(THD *thd, Item *item_par): Item_sum_min_max(thd, item_par, 1) {}
   Item_sum_min(THD *thd, Item_sum_min *item) :Item_sum_min_max(thd, item) {}
-  enum Sumfunctype sum_func () const {return MIN_FUNC;}
+  enum Sumfunctype sum_func () const override {return MIN_FUNC;}
 
-  bool add();
-  const char *func_name() const { return "min("; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  bool add() override;
+  const char *func_name() const override { return "min("; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_min>(thd, this); }
 };
 
@@ -1197,12 +1197,12 @@ class Item_sum_max final :public Item_sum_min_max
 public:
   Item_sum_max(THD *thd, Item *item_par): Item_sum_min_max(thd, item_par, -1) {}
   Item_sum_max(THD *thd, Item_sum_max *item) :Item_sum_min_max(thd, item) {}
-  enum Sumfunctype sum_func () const {return MAX_FUNC;}
+  enum Sumfunctype sum_func () const override {return MAX_FUNC;}
 
-  bool add();
-  const char *func_name() const { return "max("; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  bool add() override;
+  const char *func_name() const override { return "max("; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_max>(thd, this); }
 };
 
@@ -1221,20 +1221,20 @@ public:
     if (as_window_function)
       memcpy(bit_counters, item->bit_counters, sizeof(bit_counters));
   }
-  enum Sumfunctype sum_func () const {return SUM_BIT_FUNC;}
-  void clear();
-  longlong val_int();
-  void reset_field();
-  void update_field();
-  const Type_handler *type_handler() const { return &type_handler_ulonglong; }
-  bool fix_length_and_dec()
+  enum Sumfunctype sum_func () const override {return SUM_BIT_FUNC;}
+  void clear() override;
+  longlong val_int() override;
+  void reset_field() override;
+  void update_field() override;
+  const Type_handler *type_handler() const override { return &type_handler_ulonglong; }
+  bool fix_length_and_dec() override
   {
     if (args[0]->check_type_can_return_int(func_name()))
       return true;
     decimals= 0; max_length=21; unsigned_flag= 1; maybe_null= null_value= 0;
     return FALSE;
   }
-  void cleanup()
+  void cleanup() override
   {
     bits= reset_bits;
     if (as_window_function)
@@ -1242,12 +1242,12 @@ public:
     Item_sum_int::cleanup();
   }
   void setup_window_func(THD *thd __attribute__((unused)),
-                         Window_spec *window_spec __attribute__((unused)))
+                         Window_spec *window_spec __attribute__((unused))) override
   {
     as_window_function= TRUE;
     clear_as_window();
   }
-  void remove()
+  void remove() override
   {
     if (as_window_function)
     {
@@ -1258,7 +1258,7 @@ public:
     DBUG_ASSERT(0);
   }
 
-  bool supports_removal() const
+  bool supports_removal() const override
   {
     return true;
   }
@@ -1286,14 +1286,14 @@ class Item_sum_or final :public Item_sum_bit
 public:
   Item_sum_or(THD *thd, Item *item_par): Item_sum_bit(thd, item_par, 0) {}
   Item_sum_or(THD *thd, Item_sum_or *item) :Item_sum_bit(thd, item) {}
-  bool add();
-  const char *func_name() const { return "bit_or("; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  bool add() override;
+  const char *func_name() const override { return "bit_or("; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_or>(thd, this); }
 
 private:
-  void set_bits_from_counters();
+  void set_bits_from_counters() override;
 };
 
 
@@ -1303,14 +1303,14 @@ public:
   Item_sum_and(THD *thd, Item *item_par):
     Item_sum_bit(thd, item_par, ULONGLONG_MAX) {}
   Item_sum_and(THD *thd, Item_sum_and *item) :Item_sum_bit(thd, item) {}
-  bool add();
-  const char *func_name() const { return "bit_and("; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  bool add() override;
+  const char *func_name() const override { return "bit_and("; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_and>(thd, this); }
 
 private:
-  void set_bits_from_counters();
+  void set_bits_from_counters() override;
 };
 
 class Item_sum_xor final :public Item_sum_bit
@@ -1318,14 +1318,14 @@ class Item_sum_xor final :public Item_sum_bit
 public:
   Item_sum_xor(THD *thd, Item *item_par): Item_sum_bit(thd, item_par, 0) {}
   Item_sum_xor(THD *thd, Item_sum_xor *item) :Item_sum_bit(thd, item) {}
-  bool add();
-  const char *func_name() const { return "bit_xor("; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  bool add() override;
+  const char *func_name() const override { return "bit_xor("; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_xor>(thd, this); }
 
 private:
-  void set_bits_from_counters();
+  void set_bits_from_counters() override;
 };
 
 class sp_head;
@@ -1394,48 +1394,48 @@ public:
               sp_head *sp, List<Item> &list);
   Item_sum_sp(THD *thd, Item_sum_sp *item);
 
-  enum Sumfunctype sum_func () const
+  enum Sumfunctype sum_func () const override
   {
     return SP_AGGREGATE_FUNC;
   }
-  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table)
+  Field *create_field_for_create_select(MEM_ROOT *root, TABLE *table) override
   {
     return create_table_field_from_handler(root, table);
   }
-  bool fix_length_and_dec();
-  bool fix_fields(THD *thd, Item **ref);
-  const char *func_name() const;
-  const Type_handler *type_handler() const;
-  bool add();
+  bool fix_length_and_dec() override;
+  bool fix_fields(THD *thd, Item **ref) override;
+  const char *func_name() const override;
+  const Type_handler *type_handler() const override;
+  bool add() override;
 
   /* val_xx functions */
-  longlong val_int()
+  longlong val_int() override
   {
     if(execute())
       return 0;
     return sp_result_field->val_int();
   }
 
-  double val_real()
+  double val_real() override
   {
     if(execute())
       return 0.0;
     return sp_result_field->val_real();
   }
 
-  my_decimal *val_decimal(my_decimal *dec_buf)
+  my_decimal *val_decimal(my_decimal *dec_buf) override
   {
     if(execute())
       return NULL;
     return sp_result_field->val_decimal(dec_buf);
   }
 
-  bool val_native(THD *thd, Native *to)
+  bool val_native(THD *thd, Native *to) override
   {
     return null_value= execute() || sp_result_field->val_native(to);
   }
 
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     String buf;
     char buff[20];
@@ -1453,11 +1453,11 @@ public:
     str->copy(buf);
     return str;
   }
-  void reset_field(){DBUG_ASSERT(0);}
-  void update_field(){DBUG_ASSERT(0);}
-  void clear();
-  void cleanup();
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  void reset_field() override{DBUG_ASSERT(0);}
+  void update_field() override{DBUG_ASSERT(0);}
+  void clear() override;
+  void cleanup() override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return execute() || sp_result_field->get_date(ltime, fuzzydate);
   }
@@ -1465,9 +1465,9 @@ public:
   {
     return sp_result_field;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_sp>(thd, this); }
-  Item *copy_or_same(THD *thd);
+  Item *copy_or_same(THD *thd) override;
 };
 
 /* Items to get the value of a stored sum function */
@@ -1486,18 +1486,18 @@ public:
     max_length= item->max_length;
     unsigned_flag= item->unsigned_flag;
   }
-  table_map used_tables() const { return (table_map) 1L; }
+  table_map used_tables() const override { return (table_map) 1L; }
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     return create_tmp_field_ex_simple(root, table, src, param);
   }
-  void save_in_result_field(bool no_conversions) { DBUG_ASSERT(0); }
-  bool check_vcol_func_processor(void *arg)
+  void save_in_result_field(bool no_conversions) override { DBUG_ASSERT(0); }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(name.str, arg, VCOL_IMPOSSIBLE);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
@@ -1512,8 +1512,8 @@ public:
   Item_avg_field(THD *thd, Item_sum_avg *item)
    :Item_sum_field(thd, item), prec_increment(item->prec_increment)
   { }
-  enum Type type() const { return FIELD_AVG_ITEM; }
-  bool is_null() { update_null_value(); return null_value; }
+  enum Type type() const override { return FIELD_AVG_ITEM; }
+  bool is_null() override { update_null_value(); return null_value; }
 };
 
 
@@ -1523,12 +1523,12 @@ public:
   Item_avg_field_double(THD *thd, Item_sum_avg *item)
    :Item_avg_field(thd, item)
   { }
-  const Type_handler *type_handler() const { return &type_handler_double; }
-  longlong val_int() { return val_int_from_real(); }
-  my_decimal *val_decimal(my_decimal *dec) { return val_decimal_from_real(dec); }
-  String *val_str(String *str) { return val_string_from_real(str); }
-  double val_real();
-  Item *get_copy(THD *thd)
+  const Type_handler *type_handler() const override { return &type_handler_double; }
+  longlong val_int() override { return val_int_from_real(); }
+  my_decimal *val_decimal(my_decimal *dec) override { return val_decimal_from_real(dec); }
+  String *val_str(String *str) override { return val_string_from_real(str); }
+  double val_real() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_avg_field_double>(thd, this); }
 };
 
@@ -1543,21 +1543,21 @@ public:
     f_scale(item->f_scale),
     dec_bin_size(item->dec_bin_size)
   { }
-  const Type_handler *type_handler() const { return &type_handler_newdecimal; }
-  double val_real()
+  const Type_handler *type_handler() const override { return &type_handler_newdecimal; }
+  double val_real() override
   {
     return VDec(this).to_double();
   }
-  longlong val_int()
+  longlong val_int() override
   {
     return VDec(this).to_longlong(unsigned_flag);
   }
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     return VDec(this).to_string_round(str, decimals);
   }
-  my_decimal *val_decimal(my_decimal *);
-  Item *get_copy(THD *thd)
+  my_decimal *val_decimal(my_decimal *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_avg_field_decimal>(thd, this); }
 };
 
@@ -1569,16 +1569,16 @@ public:
   Item_variance_field(THD *thd, Item_sum_variance *item)
    :Item_sum_field(thd, item), sample(item->sample)
   { }
-  enum Type type() const {return FIELD_VARIANCE_ITEM; }
-  double val_real();
-  longlong val_int() { return val_int_from_real(); }
-  String *val_str(String *str)
+  enum Type type() const override {return FIELD_VARIANCE_ITEM; }
+  double val_real() override;
+  longlong val_int() override { return val_int_from_real(); }
+  String *val_str(String *str) override
   { return val_string_from_real(str); }
-  my_decimal *val_decimal(my_decimal *dec_buf)
+  my_decimal *val_decimal(my_decimal *dec_buf) override
   { return val_decimal_from_real(dec_buf); }
-  bool is_null() { update_null_value(); return null_value; }
-  const Type_handler *type_handler() const { return &type_handler_double; }
-  Item *get_copy(THD *thd)
+  bool is_null() override { update_null_value(); return null_value; }
+  const Type_handler *type_handler() const override { return &type_handler_double; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_variance_field>(thd, this); }
 };
 
@@ -1589,9 +1589,9 @@ public:
   Item_std_field(THD *thd, Item_sum_std *item)
    :Item_variance_field(thd, item)
   { }
-  enum Type type() const { return FIELD_STD_ITEM; }
-  double val_real();
-  Item *get_copy(THD *thd)
+  enum Type type() const override { return FIELD_STD_ITEM; }
+  double val_real() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_std_field>(thd, this); }
 };
 
@@ -1617,8 +1617,8 @@ public:
   Item_udf_sum(THD *thd, Item_udf_sum *item)
     :Item_sum(thd, item), udf(item->udf)
   { udf.not_original= TRUE; }
-  const char *func_name() const { return udf.name(); }
-  bool fix_fields(THD *thd, Item **ref)
+  const char *func_name() const override { return udf.name(); }
+  bool fix_fields(THD *thd, Item **ref) override
   {
     DBUG_ASSERT(fixed == 0);
 
@@ -1650,18 +1650,18 @@ public:
     memcpy (orig_args, args, sizeof (Item *) * arg_count);
     return check_sum_func(thd, ref);
   }
-  enum Sumfunctype sum_func () const { return UDF_SUM_FUNC; }
+  enum Sumfunctype sum_func () const override { return UDF_SUM_FUNC; }
   virtual bool have_field_update(void) const { return 0; }
 
-  void clear();
-  bool add();
-  bool supports_removal() const;
-  void remove();
-  void reset_field() {};
-  void update_field() {};
-  void cleanup();
-  virtual void print(String *str, enum_query_type query_type);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  void clear() override;
+  bool add() override;
+  bool supports_removal() const override;
+  void remove() override;
+  void reset_field() override {};
+  void update_field() override {};
+  void cleanup() override;
+  void print(String *str, enum_query_type query_type) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
@@ -1677,14 +1677,14 @@ class Item_sum_udf_float :public Item_udf_sum
     Item_udf_sum(thd, udf_arg, list) {}
   Item_sum_udf_float(THD *thd, Item_sum_udf_float *item)
     :Item_udf_sum(thd, item) {}
-  longlong val_int() { return val_int_from_real(); }
-  double val_real();
-  String *val_str(String*str);
-  my_decimal *val_decimal(my_decimal *);
-  const Type_handler *type_handler() const { return &type_handler_double; }
-  bool fix_length_and_dec() { fix_num_length_and_dec(); return FALSE; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  longlong val_int() override { return val_int_from_real(); }
+  double val_real() override;
+  String *val_str(String*str) override;
+  my_decimal *val_decimal(my_decimal *) override;
+  const Type_handler *type_handler() const override { return &type_handler_double; }
+  bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_udf_float>(thd, this); }
 };
 
@@ -1698,20 +1698,20 @@ public:
     Item_udf_sum(thd, udf_arg, list) {}
   Item_sum_udf_int(THD *thd, Item_sum_udf_int *item)
     :Item_udf_sum(thd, item) {}
-  longlong val_int();
-  double val_real()
+  longlong val_int() override;
+  double val_real() override
     { DBUG_ASSERT(fixed == 1); return (double) Item_sum_udf_int::val_int(); }
-  String *val_str(String*str);
-  my_decimal *val_decimal(my_decimal *);
-  const Type_handler *type_handler() const
+  String *val_str(String*str) override;
+  my_decimal *val_decimal(my_decimal *) override;
+  const Type_handler *type_handler() const override
   {
     if (unsigned_flag)
       return &type_handler_ulonglong;
     return &type_handler_slonglong;
   }
-  bool fix_length_and_dec() { decimals=0; max_length=21; return FALSE; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override { decimals=0; max_length=21; return FALSE; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_udf_int>(thd, this); }
 };
 
@@ -1725,8 +1725,8 @@ public:
     Item_udf_sum(thd, udf_arg, list) {}
   Item_sum_udf_str(THD *thd, Item_sum_udf_str *item)
     :Item_udf_sum(thd, item) {}
-  String *val_str(String *);
-  double val_real()
+  String *val_str(String *) override;
+  double val_real() override
   {
     int err_not_used;
     char *end_not_used;
@@ -1735,7 +1735,7 @@ public:
     return res ? res->charset()->strntod((char*) res->ptr(),res->length(),
 			                 &end_not_used, &err_not_used) : 0.0;
   }
-  longlong val_int()
+  longlong val_int() override
   {
     int err_not_used;
     char *end;
@@ -1748,11 +1748,11 @@ public:
     end= (char*) res->ptr()+res->length();
     return cs->strtoll10(res->ptr(), &end, &err_not_used);
   }
-  my_decimal *val_decimal(my_decimal *dec);
-  const Type_handler *type_handler() const { return string_type_handler(); }
-  bool fix_length_and_dec();
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  my_decimal *val_decimal(my_decimal *dec) override;
+  const Type_handler *type_handler() const override { return string_type_handler(); }
+  bool fix_length_and_dec() override;
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_udf_str>(thd, this); }
 };
 
@@ -1766,23 +1766,23 @@ public:
     Item_udf_sum(thd, udf_arg, list) {}
   Item_sum_udf_decimal(THD *thd, Item_sum_udf_decimal *item)
     :Item_udf_sum(thd, item) {}
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     return VDec(this).to_string_round(str, decimals);
   }
-  double val_real()
+  double val_real() override
   {
     return VDec(this).to_double();
   }
-  longlong val_int()
+  longlong val_int() override
   {
     return VDec(this).to_longlong(unsigned_flag);
   }
-  my_decimal *val_decimal(my_decimal *);
-  const Type_handler *type_handler() const { return &type_handler_newdecimal; }
-  bool fix_length_and_dec() { fix_num_length_and_dec(); return FALSE; }
-  Item *copy_or_same(THD* thd);
-  Item *get_copy(THD *thd)
+  my_decimal *val_decimal(my_decimal *) override;
+  const Type_handler *type_handler() const override { return &type_handler_newdecimal; }
+  bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
+  Item *copy_or_same(THD* thd) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_udf_decimal>(thd, this); }
 };
 

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -2462,21 +2462,21 @@ String *Item_char_typecast::val_str_binary_from_native(String *str)
 class Item_char_typecast_func_handler: public Item_handled_func::Handler_str
 {
 public:
-  const Type_handler *return_type_handler(const Item_handled_func *item) const
+  const Type_handler *return_type_handler(const Item_handled_func *item) const override
   {
     return Type_handler::string_type_handler(item->max_length);
   }
   const Type_handler *
-    type_handler_for_create_select(const Item_handled_func *item) const
+    type_handler_for_create_select(const Item_handled_func *item) const override
   {
     return return_type_handler(item)->type_handler_for_tmp_table(item);
   }
 
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     return false;
   }
-  String *val_str(Item_handled_func *item, String *to) const
+  String *val_str(Item_handled_func *item, String *to) const override
   {
     DBUG_ASSERT(dynamic_cast<const Item_char_typecast*>(item));
     return static_cast<Item_char_typecast*>(item)->val_str_generic(to);

--- a/sql/item_timefunc.h
+++ b/sql/item_timefunc.h
@@ -32,7 +32,7 @@ bool get_interval_value(THD *thd, Item *args,
 
 class Item_long_func_date_field: public Item_long_ge0_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_date(func_name()); }
 public:
   Item_long_func_date_field(THD *thd, Item *a)
@@ -42,7 +42,7 @@ public:
 
 class Item_long_func_time_field: public Item_long_ge0_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_time(func_name()); }
 public:
   Item_long_func_time_field(THD *thd, Item *a)
@@ -52,37 +52,37 @@ public:
 
 class Item_func_period_add :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_int(0, 2); }
 public:
   Item_func_period_add(THD *thd, Item *a, Item *b): Item_long_func(thd, a, b) {}
-  longlong val_int();
-  const char *func_name() const { return "period_add"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "period_add"; }
+  bool fix_length_and_dec() override
   {
     max_length=6*MY_CHARSET_BIN_MB_MAXLEN;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_period_add>(thd, this); }
 };
 
 
 class Item_func_period_diff :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_int(0, 2); }
 public:
   Item_func_period_diff(THD *thd, Item *a, Item *b): Item_long_func(thd, a, b) {}
-  longlong val_int();
-  const char *func_name() const { return "period_diff"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "period_diff"; }
+  bool fix_length_and_dec() override
   {
     decimals=0;
     max_length=6*MY_CHARSET_BIN_MB_MAXLEN;
     return FALSE;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_period_diff>(thd, this); }
 };
 
@@ -91,53 +91,53 @@ class Item_func_to_days :public Item_long_func_date_field
 {
 public:
   Item_func_to_days(THD *thd, Item *a): Item_long_func_date_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "to_days"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "to_days"; }
+  bool fix_length_and_dec() override
   {
     decimals=0; 
     max_length=6*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  enum_monotonicity_info get_monotonicity_info() const;
-  longlong val_int_endpoint(bool left_endp, bool *incl_endp);
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  enum_monotonicity_info get_monotonicity_info() const override;
+  longlong val_int_endpoint(bool left_endp, bool *incl_endp) override;
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_to_days>(thd, this); }
 };
 
 
 class Item_func_to_seconds :public Item_longlong_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_date(0, arg_count); }
 public:
   Item_func_to_seconds(THD *thd, Item *a): Item_longlong_func(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "to_seconds"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "to_seconds"; }
+  bool fix_length_and_dec() override
   {
     decimals=0; 
     fix_char_length(12);
     maybe_null= 1;
     return FALSE;
   }
-  enum_monotonicity_info get_monotonicity_info() const;
-  longlong val_int_endpoint(bool left_endp, bool *incl_endp);
-  bool check_partition_func_processor(void *bool_arg) { return FALSE;}
+  enum_monotonicity_info get_monotonicity_info() const override;
+  longlong val_int_endpoint(bool left_endp, bool *incl_endp) override;
+  bool check_partition_func_processor(void *bool_arg) override { return FALSE;}
 
   /* Only meaningful with date part and optional time part */
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_to_seconds>(thd, this); }
 };
 
@@ -146,22 +146,22 @@ class Item_func_dayofmonth :public Item_long_func_date_field
 {
 public:
   Item_func_dayofmonth(THD *thd, Item *a): Item_long_func_date_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "dayofmonth"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "dayofmonth"; }
+  bool fix_length_and_dec() override
   {
     decimals=0; 
     max_length=2*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dayofmonth>(thd, this); }
 };
 
@@ -171,22 +171,22 @@ class Item_func_month :public Item_long_ge0_func
 public:
   Item_func_month(THD *thd, Item *a): Item_long_ge0_func(thd, a)
   { }
-  longlong val_int();
-  const char *func_name() const { return "month"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "month"; }
+  bool fix_length_and_dec() override
   {
     decimals= 0;
     fix_char_length(2);
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_month>(thd, this); }
 };
 
@@ -196,19 +196,19 @@ class Item_func_monthname :public Item_str_func
   MY_LOCALE *locale;
 public:
   Item_func_monthname(THD *thd, Item *a): Item_str_func(thd, a) {}
-  const char *func_name() const { return "monthname"; }
-  String *val_str(String *str);
-  bool fix_length_and_dec();
-  bool check_partition_func_processor(void *int_arg) {return TRUE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  const char *func_name() const override { return "monthname"; }
+  String *val_str(String *str) override;
+  bool fix_length_and_dec() override;
+  bool check_partition_func_processor(void *int_arg) override {return TRUE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_monthname>(thd, this); }
 };
 
@@ -217,22 +217,22 @@ class Item_func_dayofyear :public Item_long_func_date_field
 {
 public:
   Item_func_dayofyear(THD *thd, Item *a): Item_long_func_date_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "dayofyear"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "dayofyear"; }
+  bool fix_length_and_dec() override
   {
     decimals= 0;
     fix_char_length(3);
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dayofyear>(thd, this); }
 };
 
@@ -241,22 +241,22 @@ class Item_func_hour :public Item_long_func_time_field
 {
 public:
   Item_func_hour(THD *thd, Item *a): Item_long_func_time_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "hour"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "hour"; }
+  bool fix_length_and_dec() override
   {
     decimals=0;
     max_length=2*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_hour>(thd, this); }
 };
 
@@ -265,22 +265,22 @@ class Item_func_minute :public Item_long_func_time_field
 {
 public:
   Item_func_minute(THD *thd, Item *a): Item_long_func_time_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "minute"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "minute"; }
+  bool fix_length_and_dec() override
   {
     decimals=0;
     max_length=2*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_minute>(thd, this); }
 };
 
@@ -289,22 +289,22 @@ class Item_func_quarter :public Item_long_func_date_field
 {
 public:
   Item_func_quarter(THD *thd, Item *a): Item_long_func_date_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "quarter"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "quarter"; }
+  bool fix_length_and_dec() override
   {
      decimals=0;
      max_length=1*MY_CHARSET_BIN_MB_MAXLEN;
      maybe_null=1;
      return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_quarter>(thd, this); }
 };
 
@@ -313,29 +313,29 @@ class Item_func_second :public Item_long_func_time_field
 {
 public:
   Item_func_second(THD *thd, Item *a): Item_long_func_time_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "second"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "second"; }
+  bool fix_length_and_dec() override
   {
     decimals=0;
     max_length=2*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_second>(thd, this); }
 };
 
 
 class Item_func_week :public Item_long_ge0_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_can_return_date(func_name()) ||
            (arg_count > 1 && args[1]->check_type_can_return_int(func_name()));
@@ -343,32 +343,32 @@ class Item_func_week :public Item_long_ge0_func
 public:
   Item_func_week(THD *thd, Item *a): Item_long_ge0_func(thd, a) {}
   Item_func_week(THD *thd, Item *a, Item *b): Item_long_ge0_func(thd, a, b) {}
-  longlong val_int();
-  const char *func_name() const { return "week"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "week"; }
+  bool fix_length_and_dec() override
   {
     decimals=0;
     max_length=2*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     if (arg_count == 2)
       return FALSE;
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return arg_count == 2;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_week>(thd, this); }
 };
 
 class Item_func_yearweek :public Item_long_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_can_return_date(func_name()) ||
            args[1]->check_type_can_return_int(func_name());
@@ -376,22 +376,22 @@ class Item_func_yearweek :public Item_long_func
 public:
   Item_func_yearweek(THD *thd, Item *a, Item *b)
    :Item_long_func(thd, a, b) {}
-  longlong val_int();
-  const char *func_name() const { return "yearweek"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "yearweek"; }
+  bool fix_length_and_dec() override
   {
     decimals=0;
     max_length=6*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_yearweek>(thd, this); }
 };
 
@@ -400,24 +400,24 @@ class Item_func_year :public Item_long_func_date_field
 {
 public:
   Item_func_year(THD *thd, Item *a): Item_long_func_date_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "year"; }
-  enum_monotonicity_info get_monotonicity_info() const;
-  longlong val_int_endpoint(bool left_endp, bool *incl_endp);
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "year"; }
+  enum_monotonicity_info get_monotonicity_info() const override;
+  longlong val_int_endpoint(bool left_endp, bool *incl_endp) override;
+  bool fix_length_and_dec() override
   {
     decimals=0;
     max_length=4*MY_CHARSET_BIN_MB_MAXLEN;
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_year>(thd, this); }
 };
 
@@ -428,29 +428,29 @@ class Item_func_weekday :public Item_long_func
 public:
   Item_func_weekday(THD *thd, Item *a, bool type_arg):
     Item_long_func(thd, a), odbc_type(type_arg) { }
-  longlong val_int();
-  const char *func_name() const
+  longlong val_int() override;
+  const char *func_name() const override
   {
      return (odbc_type ? "dayofweek" : "weekday");
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals= 0;
     fix_char_length(1);
     maybe_null=1;
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_weekday>(thd, this); }
 };
 
@@ -459,20 +459,20 @@ class Item_func_dayname :public Item_str_func
   MY_LOCALE *locale;
  public:
   Item_func_dayname(THD *thd, Item *a): Item_str_func(thd, a) {}
-  const char *func_name() const { return "dayname"; }
-  String *val_str(String *str);
-  const Type_handler *type_handler() const { return &type_handler_varchar; }
-  bool fix_length_and_dec();
-  bool check_partition_func_processor(void *int_arg) {return TRUE;}
-  bool check_vcol_func_processor(void *arg)
+  const char *func_name() const override { return "dayname"; }
+  String *val_str(String *str) override;
+  const Type_handler *type_handler() const override { return &type_handler_varchar; }
+  bool fix_length_and_dec() override;
+  bool check_partition_func_processor(void *int_arg) override {return TRUE;}
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_dayname>(thd, this); }
 };
 
@@ -493,9 +493,9 @@ public:
     else
       set_handler(type_handler_long_or_longlong());
   }
-  double real_op() { DBUG_ASSERT(0); return 0; }
-  String *str_op(String *str) { DBUG_ASSERT(0); return 0; }
-  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  double real_op() override { DBUG_ASSERT(0); return 0; }
+  String *str_op(String *str) override { DBUG_ASSERT(0); return 0; }
+  bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     DBUG_ASSERT(0);
     return true;
@@ -510,34 +510,34 @@ public:
   Item_func_unix_timestamp(THD *thd): Item_func_seconds_hybrid(thd) {}
   Item_func_unix_timestamp(THD *thd, Item *a):
     Item_func_seconds_hybrid(thd, a) {}
-  const char *func_name() const { return "unix_timestamp"; }
-  enum_monotonicity_info get_monotonicity_info() const;
-  longlong val_int_endpoint(bool left_endp, bool *incl_endp);
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
+  const char *func_name() const override { return "unix_timestamp"; }
+  enum_monotonicity_info get_monotonicity_info() const override;
+  longlong val_int_endpoint(bool left_endp, bool *incl_endp) override;
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
   /*
     UNIX_TIMESTAMP() depends on the current timezone
     (and thus may not be used as a partitioning function)
     when its argument is NOT of the TIMESTAMP type.
   */
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_timestamp_args();
   }
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     if (arg_count)
       return FALSE;
     return mark_unsupported_function(func_name(), "()", arg, VCOL_TIME_FUNC);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     fix_length_and_dec_generic(arg_count ?
                                args[0]->datetime_precision(current_thd) : 0);
     return FALSE;
   }
-  longlong int_op();
-  my_decimal *decimal_op(my_decimal* buf);
-  Item *get_copy(THD *thd)
+  longlong int_op() override;
+  my_decimal *decimal_op(my_decimal* buf) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_unix_timestamp>(thd, this); }
 };
 
@@ -547,21 +547,21 @@ class Item_func_time_to_sec :public Item_func_seconds_hybrid
 public:
   Item_func_time_to_sec(THD *thd, Item *item):
     Item_func_seconds_hybrid(thd, item) {}
-  const char *func_name() const { return "time_to_sec"; }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  const char *func_name() const override { return "time_to_sec"; }
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_time_args();
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     fix_length_and_dec_generic(args[0]->time_precision(current_thd));
     return FALSE;
   }
-  longlong int_op();
-  my_decimal *decimal_op(my_decimal* buf);
-  Item *get_copy(THD *thd)
+  longlong int_op() override;
+  my_decimal *decimal_op(my_decimal* buf) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_time_to_sec>(thd, this); }
 };
 
@@ -572,12 +572,12 @@ public:
   Item_datefunc(THD *thd): Item_func(thd) { }
   Item_datefunc(THD *thd, Item *a): Item_func(thd, a) { }
   Item_datefunc(THD *thd, Item *a, Item *b): Item_func(thd, a, b) { }
-  const Type_handler *type_handler() const { return &type_handler_newdate; }
-  longlong val_int() { return Date(this).to_longlong(); }
-  double val_real() { return Date(this).to_double(); }
-  String *val_str(String *to) { return Date(this).to_string(to); }
-  my_decimal *val_decimal(my_decimal *to) { return Date(this).to_decimal(to); }
-  bool fix_length_and_dec()
+  const Type_handler *type_handler() const override { return &type_handler_newdate; }
+  longlong val_int() override { return Date(this).to_longlong(); }
+  double val_real() override { return Date(this).to_double(); }
+  String *val_str(String *to) override { return Date(this).to_string(to); }
+  my_decimal *val_decimal(my_decimal *to) override { return Date(this).to_decimal(to); }
+  bool fix_length_and_dec() override
   {
     fix_attributes_date();
     maybe_null= (arg_count > 0);
@@ -593,12 +593,12 @@ public:
   Item_timefunc(THD *thd, Item *a): Item_func(thd, a) {}
   Item_timefunc(THD *thd, Item *a, Item *b): Item_func(thd, a, b) {}
   Item_timefunc(THD *thd, Item *a, Item *b, Item *c): Item_func(thd, a, b ,c) {}
-  const Type_handler *type_handler() const { return &type_handler_time2; }
-  longlong val_int() { return Time(this).to_longlong(); }
-  double val_real() { return Time(this).to_double(); }
-  String *val_str(String *to) { return Time(this).to_string(to, decimals); }
-  my_decimal *val_decimal(my_decimal *to) { return Time(this).to_decimal(to); }
-  bool val_native(THD *thd, Native *to)
+  const Type_handler *type_handler() const override { return &type_handler_time2; }
+  longlong val_int() override { return Time(this).to_longlong(); }
+  double val_real() override { return Time(this).to_double(); }
+  String *val_str(String *to) override { return Time(this).to_string(to, decimals); }
+  my_decimal *val_decimal(my_decimal *to) override { return Time(this).to_decimal(to); }
+  bool val_native(THD *thd, Native *to) override
   {
     return Time(thd, this).to_native(to, decimals);
   }
@@ -613,11 +613,11 @@ public:
   Item_datetimefunc(THD *thd, Item *a, Item *b): Item_func(thd, a, b) {}
   Item_datetimefunc(THD *thd, Item *a, Item *b, Item *c):
     Item_func(thd, a, b ,c) {}
-  const Type_handler *type_handler() const { return &type_handler_datetime2; }
-  longlong val_int() { return Datetime(this).to_longlong(); }
-  double val_real() { return Datetime(this).to_double(); }
-  String *val_str(String *to) { return Datetime(this).to_string(to, decimals); }
-  my_decimal *val_decimal(my_decimal *to) { return Datetime(this).to_decimal(to); }
+  const Type_handler *type_handler() const override { return &type_handler_datetime2; }
+  longlong val_int() override { return Datetime(this).to_longlong(); }
+  double val_real() override { return Datetime(this).to_double(); }
+  String *val_str(String *to) override { return Datetime(this).to_string(to, decimals); }
+  my_decimal *val_decimal(my_decimal *to) override { return Datetime(this).to_decimal(to); }
 };
 
 
@@ -630,20 +630,20 @@ class Item_func_curtime :public Item_timefunc
 public:
   Item_func_curtime(THD *thd, uint dec): Item_timefunc(thd), last_query_id(0)
   { decimals= dec; }
-  bool fix_fields(THD *, Item **);
-  bool fix_length_and_dec() { fix_attributes_time(decimals); return FALSE; }
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
+  bool fix_fields(THD *, Item **) override;
+  bool fix_length_and_dec() override { fix_attributes_time(decimals); return FALSE; }
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
   /* 
     Abstract method that defines which time zone is used for conversion.
     Converts time current time in my_time_t representation to broken-down
     MYSQL_TIME representation using UTC-SYSTEM or per-thread time zone.
   */
   virtual void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time)=0;
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_TIME_FUNC);
   }
-  void print(String *str, enum_query_type query_type);
+  void print(String *str, enum_query_type query_type) override;
 };
 
 
@@ -651,9 +651,9 @@ class Item_func_curtime_local :public Item_func_curtime
 {
 public:
   Item_func_curtime_local(THD *thd, uint dec): Item_func_curtime(thd, dec) {}
-  const char *func_name() const { return "curtime"; }
-  virtual void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "curtime"; }
+  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_curtime_local>(thd, this); }
 };
 
@@ -662,9 +662,9 @@ class Item_func_curtime_utc :public Item_func_curtime
 {
 public:
   Item_func_curtime_utc(THD *thd, uint dec): Item_func_curtime(thd, dec) {}
-  const char *func_name() const { return "utc_time"; }
-  virtual void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "utc_time"; }
+  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_curtime_utc>(thd, this); }
 };
 
@@ -677,9 +677,9 @@ class Item_func_curdate :public Item_datefunc
   MYSQL_TIME ltime;
 public:
   Item_func_curdate(THD *thd): Item_datefunc(thd), last_query_id(0) {}
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
   virtual void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time)=0;
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_TIME_FUNC);
   }
@@ -690,9 +690,9 @@ class Item_func_curdate_local :public Item_func_curdate
 {
 public:
   Item_func_curdate_local(THD *thd): Item_func_curdate(thd) {}
-  const char *func_name() const { return "curdate"; }
-  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "curdate"; }
+  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_curdate_local>(thd, this); }
 };
 
@@ -701,9 +701,9 @@ class Item_func_curdate_utc :public Item_func_curdate
 {
 public:
   Item_func_curdate_utc(THD *thd): Item_func_curdate(thd) {}
-  const char *func_name() const { return "utc_date"; }
-  void store_now_in_TIME(THD* thd, MYSQL_TIME *now_time);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "utc_date"; }
+  void store_now_in_TIME(THD* thd, MYSQL_TIME *now_time) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_curdate_utc>(thd, this); }
 };
 
@@ -717,12 +717,12 @@ class Item_func_now :public Item_datetimefunc
 public:
   Item_func_now(THD *thd, uint dec): Item_datetimefunc(thd), last_query_id(0)
   { decimals= dec; }
-  bool fix_fields(THD *, Item **);
-  bool fix_length_and_dec()
+  bool fix_fields(THD *, Item **) override;
+  bool fix_length_and_dec() override
   { fix_attributes_datetime(decimals); return FALSE;}
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
   virtual void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time)=0;
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     /*
       NOW is safe for replication as slaves will run with same time as
@@ -730,7 +730,7 @@ public:
     */
     return mark_unsupported_function(func_name(), "()", arg, VCOL_TIME_FUNC);
   }
-  void print(String *str, enum_query_type query_type);
+  void print(String *str, enum_query_type query_type) override;
 };
 
 
@@ -738,11 +738,11 @@ class Item_func_now_local :public Item_func_now
 {
 public:
   Item_func_now_local(THD *thd, uint dec): Item_func_now(thd, dec) {}
-  const char *func_name() const { return "current_timestamp"; }
-  int save_in_field(Field *field, bool no_conversions);
-  virtual void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time);
-  virtual enum Functype functype() const { return NOW_FUNC; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "current_timestamp"; }
+  int save_in_field(Field *field, bool no_conversions) override;
+  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
+  enum Functype functype() const override { return NOW_FUNC; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_now_local>(thd, this); }
 };
 
@@ -751,15 +751,15 @@ class Item_func_now_utc :public Item_func_now
 {
 public:
   Item_func_now_utc(THD *thd, uint dec): Item_func_now(thd, dec) {}
-  const char *func_name() const { return "utc_timestamp"; }
-  virtual void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time);
-  virtual enum Functype functype() const { return NOW_UTC_FUNC; }
-  virtual bool check_vcol_func_processor(void *arg)
+  const char *func_name() const override { return "utc_timestamp"; }
+  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
+  enum Functype functype() const override { return NOW_UTC_FUNC; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg,
                                      VCOL_TIME_FUNC | VCOL_NON_DETERMINISTIC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_now_utc>(thd, this); }
 };
 
@@ -772,44 +772,44 @@ class Item_func_sysdate_local :public Item_func_now
 {
 public:
   Item_func_sysdate_local(THD *thd, uint dec): Item_func_now(thd, dec) {}
-  bool const_item() const { return 0; }
-  const char *func_name() const { return "sysdate"; }
-  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time);
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
-  table_map used_tables() const { return RAND_TABLE_BIT; }
-  bool check_vcol_func_processor(void *arg)
+  bool const_item() const override { return 0; }
+  const char *func_name() const override { return "sysdate"; }
+  void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
+  table_map used_tables() const override { return RAND_TABLE_BIT; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg,
                                      VCOL_TIME_FUNC | VCOL_NON_DETERMINISTIC);
   }
-  virtual enum Functype functype() const { return SYSDATE_FUNC; }
-  Item *get_copy(THD *thd)
+  enum Functype functype() const override { return SYSDATE_FUNC; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sysdate_local>(thd, this); }
 };
 
 
 class Item_func_from_days :public Item_datefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_int(func_name()); }
 public:
   Item_func_from_days(THD *thd, Item *a): Item_datefunc(thd, a) {}
-  const char *func_name() const { return "from_days"; }
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  const char *func_name() const override { return "from_days"; }
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return has_date_args() || has_time_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_from_days>(thd, this); }
 };
 
 
 class Item_func_date_format :public Item_str_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_can_return_date(func_name()) ||
            check_argument_types_can_return_text(1, arg_count);
@@ -824,18 +824,18 @@ public:
     Item_str_func(thd, a, b), locale(0), is_time_format(false) {}
   Item_func_date_format(THD *thd, Item *a, Item *b, Item *c):
     Item_str_func(thd, a, b, c), locale(0), is_time_format(false) {}
-  String *val_str(String *str);
-  const char *func_name() const { return "date_format"; }
-  bool fix_length_and_dec();
+  String *val_str(String *str) override;
+  const char *func_name() const override { return "date_format"; }
+  bool fix_length_and_dec() override;
   uint format_length(const String *format);
-  bool eq(const Item *item, bool binary_cmp) const;
-  bool check_vcol_func_processor(void *arg)
+  bool eq(const Item *item, bool binary_cmp) const override;
+  bool check_vcol_func_processor(void *arg) override
   {
     if (arg_count > 2)
       return false;
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_date_format>(thd, this); }
 };
 
@@ -844,28 +844,28 @@ class Item_func_time_format: public Item_func_date_format
 public:
   Item_func_time_format(THD *thd, Item *a, Item *b):
     Item_func_date_format(thd, a, b) { is_time_format= true; }
-  const char *func_name() const { return "time_format"; }
-  bool check_vcol_func_processor(void *arg) { return false; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "time_format"; }
+  bool check_vcol_func_processor(void *arg) override { return false; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_time_format>(thd, this); }
 };
 
 
 class Item_func_from_unixtime :public Item_datetimefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_decimal(func_name()); }
   Time_zone *tz;
  public:
   Item_func_from_unixtime(THD *thd, Item *a): Item_datetimefunc(thd, a) {}
-  const char *func_name() const { return "from_unixtime"; }
-  bool fix_length_and_dec();
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
-  bool check_vcol_func_processor(void *arg)
+  const char *func_name() const override { return "from_unixtime"; }
+  bool fix_length_and_dec() override;
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_from_unixtime>(thd, this); }
 };
 
@@ -886,7 +886,7 @@ class Time_zone;
 */
 class Item_func_convert_tz :public Item_datetimefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_can_return_date(func_name()) ||
            check_argument_types_can_return_text(1, arg_count);
@@ -902,35 +902,35 @@ class Item_func_convert_tz :public Item_datetimefunc
  public:
   Item_func_convert_tz(THD *thd, Item *a, Item *b, Item *c):
     Item_datetimefunc(thd, a, b, c), from_tz_cached(0), to_tz_cached(0) {}
-  const char *func_name() const { return "convert_tz"; }
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "convert_tz"; }
+  bool fix_length_and_dec() override
   {
     fix_attributes_datetime(args[0]->datetime_precision(current_thd));
     maybe_null= true;
     return FALSE;
   }
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
-  void cleanup();
-  Item *get_copy(THD *thd)
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
+  void cleanup() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_convert_tz>(thd, this); }
 };
 
 
 class Item_func_sec_to_time :public Item_timefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_decimal(func_name()); }
 public:
   Item_func_sec_to_time(THD *thd, Item *item): Item_timefunc(thd, item) {}
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
-  bool fix_length_and_dec()
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
+  bool fix_length_and_dec() override
   {
     fix_attributes_time(args[0]->decimals);
     maybe_null= true;
     return FALSE;
   }
-  const char *func_name() const { return "sec_to_time"; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "sec_to_time"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_sec_to_time>(thd, this); }
 };
 
@@ -944,13 +944,13 @@ public:
                          bool neg_arg):
     Item_handled_func(thd, a, b), int_type(type_arg),
     date_sub_interval(neg_arg) {}
-  const char *func_name() const { return "date_add_interval"; }
-  bool fix_length_and_dec();
-  bool eq(const Item *item, bool binary_cmp) const;
-  void print(String *str, enum_query_type query_type);
-  enum precedence precedence() const { return INTERVAL_PRECEDENCE; }
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "date_add_interval"; }
+  bool fix_length_and_dec() override;
+  bool eq(const Item *item, bool binary_cmp) const override;
+  void print(String *str, enum_query_type query_type) override;
+  enum precedence precedence() const override { return INTERVAL_PRECEDENCE; }
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_date_add_interval>(thd, this); }
 };
 
@@ -1004,25 +1004,25 @@ class Item_extract :public Item_int_func,
     m_date_mode(date_mode_t(0)),
     int_type(type_arg)
   { }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return Type_handler_hybrid_field_type::type_handler();
   }
-  longlong val_int();
-  enum Functype functype() const { return EXTRACT_FUNC; }
-  const char *func_name() const { return "extract"; }
-  bool check_arguments() const;
-  bool fix_length_and_dec();
-  bool eq(const Item *item, bool binary_cmp) const;
-  void print(String *str, enum_query_type query_type);
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg)
+  longlong val_int() override;
+  enum Functype functype() const override { return EXTRACT_FUNC; }
+  const char *func_name() const override { return "extract"; }
+  bool check_arguments() const override;
+  bool fix_length_and_dec() override;
+  bool eq(const Item *item, bool binary_cmp) const override;
+  void print(String *str, enum_query_type query_type) override;
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override
   {
     if (int_type != INTERVAL_WEEK)
       return FALSE;
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     switch (int_type) {
     case INTERVAL_YEAR:
@@ -1058,7 +1058,7 @@ class Item_extract :public Item_int_func,
     }
     return true;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_extract>(thd, this); }
 };
 
@@ -1085,9 +1085,9 @@ public:
   Item_char_typecast(THD *thd, Item *a, uint length_arg, CHARSET_INFO *cs_arg):
     Item_handled_func(thd, a), cast_length(length_arg), cast_cs(cs_arg),
     m_suppress_warning_to_error_escalation(false) {}
-  enum Functype functype() const { return CHAR_TYPECAST_FUNC; }
-  bool eq(const Item *item, bool binary_cmp) const;
-  const char *func_name() const { return "cast_as_char"; }
+  enum Functype functype() const override { return CHAR_TYPECAST_FUNC; }
+  bool eq(const Item *item, bool binary_cmp) const override;
+  const char *func_name() const override { return "cast_as_char"; }
   CHARSET_INFO *cast_charset() const { return cast_cs; }
   String *val_str_generic(String *a);
   String *val_str_binary_from_native(String *a);
@@ -1095,13 +1095,13 @@ public:
   void fix_length_and_dec_numeric();
   void fix_length_and_dec_str();
   void fix_length_and_dec_native_to_binary(uint32 octet_length);
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     return args[0]->type_handler()->Item_char_typecast_fix_length_and_dec(this);
   }
-  void print(String *str, enum_query_type query_type);
-  bool need_parentheses_in_default() { return true; }
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  bool need_parentheses_in_default() override { return true; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_char_typecast>(thd, this); }
 };
 
@@ -1115,7 +1115,7 @@ public:
                        &my_charset_latin1),
     m_fsp(fsp)
   { }
-  String *val_str(String *to)
+  String *val_str(String *to) override
   {
     Interval_DDhhmmssff it(current_thd, args[0], m_fsp);
     null_value= !it.is_valid_interval_DDhhmmssff();
@@ -1128,17 +1128,17 @@ class Item_date_typecast :public Item_datefunc
 {
 public:
   Item_date_typecast(THD *thd, Item *a): Item_datefunc(thd, a) {}
-  const char *func_name() const { return "cast_as_date"; }
-  void print(String *str, enum_query_type query_type)
+  const char *func_name() const override { return "cast_as_date"; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_cast_temporal(str, query_type);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool fix_length_and_dec()
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool fix_length_and_dec() override
   {
     return args[0]->type_handler()->Item_date_typecast_fix_length_and_dec(this);
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_date_typecast>(thd, this); }
 };
 
@@ -1148,19 +1148,19 @@ class Item_time_typecast :public Item_timefunc
 public:
   Item_time_typecast(THD *thd, Item *a, uint dec_arg):
     Item_timefunc(thd, a) { decimals= dec_arg; }
-  const char *func_name() const { return "cast_as_time"; }
-  void print(String *str, enum_query_type query_type)
+  const char *func_name() const override { return "cast_as_time"; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_cast_temporal(str, query_type);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool fix_length_and_dec()
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool fix_length_and_dec() override
   {
     return args[0]->type_handler()->
            Item_time_typecast_fix_length_and_dec(this);
   }
-  Sql_mode_dependency value_depends_on_sql_mode() const;
-  Item *get_copy(THD *thd)
+  Sql_mode_dependency value_depends_on_sql_mode() const override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_time_typecast>(thd, this); }
 };
 
@@ -1170,40 +1170,40 @@ class Item_datetime_typecast :public Item_datetimefunc
 public:
   Item_datetime_typecast(THD *thd, Item *a, uint dec_arg):
     Item_datetimefunc(thd, a) { decimals= dec_arg; }
-  const char *func_name() const { return "cast_as_datetime"; }
-  void print(String *str, enum_query_type query_type)
+  const char *func_name() const override { return "cast_as_datetime"; }
+  void print(String *str, enum_query_type query_type) override
   {
     print_cast_temporal(str, query_type);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  bool fix_length_and_dec()
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  bool fix_length_and_dec() override
   {
     return args[0]->type_handler()->
            Item_datetime_typecast_fix_length_and_dec(this);
   }
-  Sql_mode_dependency value_depends_on_sql_mode() const;
-  Item *get_copy(THD *thd)
+  Sql_mode_dependency value_depends_on_sql_mode() const override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_datetime_typecast>(thd, this); }
 };
 
 
 class Item_func_makedate :public Item_datefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_int(0, arg_count); }
 public:
   Item_func_makedate(THD *thd, Item *a, Item *b):
     Item_datefunc(thd, a, b) {}
-  const char *func_name() const { return "makedate"; }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "makedate"; }
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_makedate>(thd, this); }
 };
 
 
 class Item_func_timestamp :public Item_datetimefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return args[0]->check_type_can_return_date(func_name()) ||
            args[1]->check_type_can_return_time(func_name());
@@ -1212,8 +1212,8 @@ public:
   Item_func_timestamp(THD *thd, Item *a, Item *b)
    :Item_datetimefunc(thd, a, b)
   { }
-  const char *func_name() const { return "timestamp"; }
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "timestamp"; }
+  bool fix_length_and_dec() override
   {
     THD *thd= current_thd;
     uint dec0= args[0]->datetime_precision(thd);
@@ -1222,7 +1222,7 @@ public:
     maybe_null= true;
     return false;
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     Datetime dt(thd, args[0], Datetime::Options(TIME_CONV_NONE, thd));
     if (!dt.is_valid_datetime())
@@ -1233,7 +1233,7 @@ public:
     return (null_value= Sec6_add(dt.get_mysql_time(), it.get_mysql_time(), 1).
                            to_datetime(ltime));
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_timestamp>(thd, this); }
 };
 
@@ -1258,21 +1258,21 @@ public:
   Item_func_add_time(THD *thd, Item *a, Item *b, bool neg_arg)
    :Item_handled_func(thd, a, b), sign(neg_arg ? -1 : 1)
   { }
-  bool fix_length_and_dec();
-  const char *func_name() const { return sign > 0 ? "addtime" : "subtime"; }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override;
+  const char *func_name() const override { return sign > 0 ? "addtime" : "subtime"; }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_add_time>(thd, this); }
 };
 
 
 class Item_func_timediff :public Item_timefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_time(0, arg_count); }
 public:
   Item_func_timediff(THD *thd, Item *a, Item *b): Item_timefunc(thd, a, b) {}
-  const char *func_name() const { return "timediff"; }
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "timediff"; }
+  bool fix_length_and_dec() override
   {
     THD *thd= current_thd;
     uint dec= MY_MAX(args[0]->time_precision(thd),
@@ -1281,14 +1281,14 @@ public:
     maybe_null= true;
     return FALSE;
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  Item *get_copy(THD *thd)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_timediff>(thd, this); }
 };
 
 class Item_func_maketime :public Item_timefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   {
     return check_argument_types_can_return_int(0, 2) ||
            args[2]->check_type_can_return_decimal(func_name());
@@ -1297,15 +1297,15 @@ public:
   Item_func_maketime(THD *thd, Item *a, Item *b, Item *c):
     Item_timefunc(thd, a, b, c)
   {}
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     fix_attributes_time(args[2]->decimals);
     maybe_null= true;
     return FALSE;
   }
-  const char *func_name() const { return "maketime"; }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "maketime"; }
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_maketime>(thd, this); }
 };
 
@@ -1314,29 +1314,29 @@ class Item_func_microsecond :public Item_long_func_time_field
 {
 public:
   Item_func_microsecond(THD *thd, Item *a): Item_long_func_time_field(thd, a) {}
-  longlong val_int();
-  const char *func_name() const { return "microsecond"; }
-  bool fix_length_and_dec()
+  longlong val_int() override;
+  const char *func_name() const override { return "microsecond"; }
+  bool fix_length_and_dec() override
   {
     decimals=0;
     maybe_null=1;
     fix_char_length(6);
     return FALSE;
   }
-  bool check_partition_func_processor(void *int_arg) {return FALSE;}
-  bool check_vcol_func_processor(void *arg) { return FALSE;}
-  bool check_valid_arguments_processor(void *int_arg)
+  bool check_partition_func_processor(void *int_arg) override {return FALSE;}
+  bool check_vcol_func_processor(void *arg) override { return FALSE;}
+  bool check_valid_arguments_processor(void *int_arg) override
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_microsecond>(thd, this); }
 };
 
 
 class Item_func_timestamp_diff :public Item_longlong_func
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return check_argument_types_can_return_date(0, arg_count); }
   const interval_type int_type;
 public:
@@ -1345,16 +1345,16 @@ public:
 public:
   Item_func_timestamp_diff(THD *thd, Item *a, Item *b, interval_type type_arg):
     Item_longlong_func(thd, a, b), int_type(type_arg) {}
-  const char *func_name() const { return "timestampdiff"; }
-  longlong val_int();
-  bool fix_length_and_dec()
+  const char *func_name() const override { return "timestampdiff"; }
+  longlong val_int() override;
+  bool fix_length_and_dec() override
   {
     decimals=0;
     maybe_null=1;
     return FALSE;
   }
-  virtual void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_timestamp_diff>(thd, this); }
 };
 
@@ -1371,17 +1371,17 @@ public:
   Item_func_get_format(THD *thd, timestamp_type type_arg, Item *a):
     Item_str_ascii_func(thd, a), type(type_arg)
   {}
-  String *val_str_ascii(String *str);
-  const char *func_name() const { return "get_format"; }
-  bool fix_length_and_dec()
+  String *val_str_ascii(String *str) override;
+  const char *func_name() const override { return "get_format"; }
+  bool fix_length_and_dec() override
   {
     maybe_null= 1;
     decimals=0;
     fix_length_and_charset(17, default_charset());
     return FALSE;
   }
-  virtual void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_get_format>(thd, this); }
 };
 
@@ -1399,22 +1399,22 @@ public:
   {}
   bool get_date_common(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate,
                        timestamp_type);
-  const char *func_name() const { return "str_to_date"; }
-  bool fix_length_and_dec();
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "str_to_date"; }
+  bool fix_length_and_dec() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_str_to_date>(thd, this); }
 };
 
 
 class Item_func_last_day :public Item_datefunc
 {
-  bool check_arguments() const
+  bool check_arguments() const override
   { return args[0]->check_type_can_return_date(func_name()); }
 public:
   Item_func_last_day(THD *thd, Item *a): Item_datefunc(thd, a) {}
-  const char *func_name() const { return "last_day"; }
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "last_day"; }
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_last_day>(thd, this); }
 };
 
@@ -1459,7 +1459,7 @@ class Func_handler_date_add_interval_datetime:
         public Func_handler_date_add_interval
 {
 public:
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     uint dec= MY_MAX(item->arguments()[0]->datetime_precision(current_thd),
                      interval_dec(item->arguments()[1], int_type(item)));
@@ -1467,7 +1467,7 @@ public:
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     Datetime::Options opt(TIME_CONV_NONE, thd);
     Datetime dt(thd, item->arguments()[0], opt);
@@ -1486,7 +1486,7 @@ class Func_handler_date_add_interval_datetime_arg0_time:
 {
 public:
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const;
+                MYSQL_TIME *to, date_mode_t fuzzy) const override;
 };
 
 
@@ -1496,7 +1496,7 @@ class Func_handler_date_add_interval_date:
 {
 public:
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     /*
       The first argument is known to be of the DATE data type (not DATETIME).
@@ -1518,7 +1518,7 @@ class Func_handler_date_add_interval_time:
         public Func_handler_date_add_interval
 {
 public:
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     uint dec= MY_MAX(item->arguments()[0]->time_precision(current_thd),
                      interval_dec(item->arguments()[1], int_type(item)));
@@ -1526,7 +1526,7 @@ public:
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     Time t(thd, item->arguments()[0]);
     if (!t.is_valid_time())
@@ -1543,7 +1543,7 @@ class Func_handler_date_add_interval_string:
         public Func_handler_date_add_interval
 {
 public:
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     uint dec= MY_MAX(item->arguments()[0]->datetime_precision(current_thd),
                      interval_dec(item->arguments()[1], int_type(item)));
@@ -1555,7 +1555,7 @@ public:
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     if (item->arguments()[0]->
           get_date(thd, to, Datetime::Options(TIME_CONV_NONE, thd)) ||
@@ -1584,7 +1584,7 @@ public:
   Func_handler_add_time_datetime(int sign)
    :Func_handler_sign(sign)
   { }
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     THD *thd= current_thd;
     uint dec0= item->arguments()[0]->datetime_precision(thd);
@@ -1593,7 +1593,7 @@ public:
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     DBUG_ASSERT(item->is_fixed());
     Datetime::Options opt(TIME_CONV_NONE, thd);
@@ -1618,7 +1618,7 @@ public:
   Func_handler_add_time_time(int sign)
    :Func_handler_sign(sign)
   { }
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     THD *thd= current_thd;
     uint dec0= item->arguments()[0]->time_precision(thd);
@@ -1627,7 +1627,7 @@ public:
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     DBUG_ASSERT(item->is_fixed());
     Time t(thd, item->arguments()[0]);
@@ -1651,7 +1651,7 @@ public:
   Func_handler_add_time_string(int sign)
    :Func_handler_sign(sign)
   { }
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     uint dec0= item->arguments()[0]->decimals;
     uint dec1= Interval_DDhhmmssff::fsp(current_thd, item->arguments()[1]);
@@ -1664,7 +1664,7 @@ public:
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     DBUG_ASSERT(item->is_fixed());
     // Detect a proper timestamp type based on the argument values
@@ -1688,13 +1688,13 @@ class Func_handler_str_to_date_datetime_sec:
         public Item_handled_func::Handler_datetime
 {
 public:
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     item->fix_attributes_datetime(0);
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     return static_cast<Item_func_str_to_date*>(item)->
              get_date_common(thd, to, fuzzy, MYSQL_TIMESTAMP_DATETIME);
@@ -1706,13 +1706,13 @@ class Func_handler_str_to_date_datetime_usec:
         public Item_handled_func::Handler_datetime
 {
 public:
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     item->fix_attributes_datetime(TIME_SECOND_PART_DIGITS);
     return false;
   }
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     return static_cast<Item_func_str_to_date*>(item)->
              get_date_common(thd, to, fuzzy, MYSQL_TIMESTAMP_DATETIME);
@@ -1724,7 +1724,7 @@ class Func_handler_str_to_date_date: public Item_handled_func::Handler_date
 {
 public:
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     return static_cast<Item_func_str_to_date*>(item)->
              get_date_common(thd, to, fuzzy, MYSQL_TIMESTAMP_DATE);
@@ -1736,7 +1736,7 @@ class Func_handler_str_to_date_time: public Item_handled_func::Handler_time
 {
 public:
   bool get_date(THD *thd, Item_handled_func *item,
-                MYSQL_TIME *to, date_mode_t fuzzy) const
+                MYSQL_TIME *to, date_mode_t fuzzy) const override
   {
     if (static_cast<Item_func_str_to_date*>(item)->
          get_date_common(thd, to, fuzzy, MYSQL_TIMESTAMP_TIME))
@@ -1759,7 +1759,7 @@ public:
 class Func_handler_str_to_date_time_sec: public Func_handler_str_to_date_time
 {
 public:
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     item->fix_attributes_time(0);
     return false;
@@ -1770,7 +1770,7 @@ public:
 class Func_handler_str_to_date_time_usec: public Func_handler_str_to_date_time
 {
 public:
-  bool fix_length_and_dec(Item_handled_func *item) const
+  bool fix_length_and_dec(Item_handled_func *item) const override
   {
     item->fix_attributes_time(TIME_SECOND_PART_DIGITS);
     return false;

--- a/sql/item_vers.h
+++ b/sql/item_vers.h
@@ -33,12 +33,12 @@ public:
     DBUG_ASSERT(a->type() == Item::FIELD_ITEM);
   }
 
-  virtual bool val_bool();
-  virtual longlong val_int()
+  bool val_bool() override;
+  longlong val_int() override
   {
     return (val_bool() ? 1 : 0);
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     maybe_null= 0;
     null_value= 0;
@@ -46,9 +46,9 @@ public:
     max_length= 1;
     return FALSE;
   }
-  virtual const char* func_name() const { return "is_history"; }
-  virtual void print(String *str, enum_query_type query_type);
-  Item *get_copy(THD *thd)
+  const char* func_name() const override { return "is_history"; }
+  void print(String *str, enum_query_type query_type) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_history>(thd, this); }
 };
 
@@ -57,7 +57,7 @@ class Item_func_trt_ts: public Item_datetimefunc
   TR_table::field_id_t trt_field;
 public:
   Item_func_trt_ts(THD *thd, Item* a, TR_table::field_id_t _trt_field);
-  const char *func_name() const
+  const char *func_name() const override
   {
     if (trt_field == TR_table::FLD_BEGIN_TS)
     {
@@ -65,10 +65,10 @@ public:
     }
     return "trt_commit_ts";
   }
-  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate);
-  Item *get_copy(THD *thd)
+  bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_trt_ts>(thd, this); }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   { fix_attributes_datetime(decimals); return FALSE; }
 };
 
@@ -84,7 +84,7 @@ public:
   Item_func_trt_id(THD *thd, Item* a, TR_table::field_id_t _trt_field, bool _backwards= false);
   Item_func_trt_id(THD *thd, Item* a, Item* b, TR_table::field_id_t _trt_field);
 
-  const char *func_name() const
+  const char *func_name() const override
   {
     switch (trt_field)
     {
@@ -100,15 +100,15 @@ public:
     return NULL;
   }
 
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     bool res= Item_int_func::fix_length_and_dec();
     max_length= 20;
     return res;
   }
 
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_trt_id>(thd, this); }
 };
 
@@ -119,12 +119,12 @@ protected:
 
 public:
   Item_func_trt_trx_sees(THD *thd, Item* a, Item* b);
-  const char *func_name() const
+  const char *func_name() const override
   {
     return "trt_trx_sees";
   }
-  longlong val_int();
-  Item *get_copy(THD *thd)
+  longlong val_int() override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_trt_trx_sees>(thd, this); }
 };
 
@@ -137,7 +137,7 @@ public:
   {
     accept_eq= true;
   }
-  const char *func_name() const
+  const char *func_name() const override
   {
     return "trt_trx_sees_eq";
   }

--- a/sql/item_windowfunc.h
+++ b/sql/item_windowfunc.h
@@ -118,37 +118,37 @@ public:
   Item_sum_row_number(THD *thd)
     : Item_sum_int(thd),  count(0) {}
 
-  const Type_handler *type_handler() const { return &type_handler_slonglong; }
+  const Type_handler *type_handler() const override { return &type_handler_slonglong; }
 
-  void clear()
+  void clear() override
   {
     count= 0;
   }
 
-  bool add()
+  bool add() override
   {
     count++;
     return false;
   }
 
-  void reset_field() { DBUG_ASSERT(0); }
-  void update_field() {}
+  void reset_field() override { DBUG_ASSERT(0); }
+  void update_field() override {}
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return ROW_NUMBER_FUNC;
   }
 
-  longlong val_int()
+  longlong val_int() override
   {
     return count;
   }
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "row_number";
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_row_number>(thd, this); }
 };
 
@@ -181,38 +181,38 @@ public:
 
   Item_sum_rank(THD *thd) : Item_sum_int(thd), peer_tracker(NULL) {}
 
-  const Type_handler *type_handler() const { return &type_handler_slonglong; }
+  const Type_handler *type_handler() const override { return &type_handler_slonglong; }
 
-  void clear()
+  void clear() override
   {
     /* This is called on partition start */
     cur_rank= 1;
     row_number= 0;
   }
 
-  bool add();
+  bool add() override;
 
-  longlong val_int()
+  longlong val_int() override
   {
     return cur_rank;
   }
 
-  void reset_field() { DBUG_ASSERT(0); }
-  void update_field() {}
+  void reset_field() override { DBUG_ASSERT(0); }
+  void update_field() override {}
 
-  enum Sumfunctype sum_func () const
+  enum Sumfunctype sum_func () const override
   {
     return RANK_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "rank";
   }
 
-  void setup_window_func(THD *thd, Window_spec *window_spec);
+  void setup_window_func(THD *thd, Window_spec *window_spec) override;
 
-  void cleanup()
+  void cleanup() override
   {
     if (peer_tracker)
     {
@@ -221,7 +221,7 @@ public:
     }
     Item_sum_int::cleanup();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_rank>(thd, this); }
 };
 
@@ -255,35 +255,35 @@ class Item_sum_dense_rank: public Item_sum_int
      XXX(cvicentiu) This class could potentially be implemented in the rank
      class, with a switch for the DENSE case.
   */
-  void clear()
+  void clear() override
   {
     dense_rank= 0;
     first_add= true;
   }
-  bool add();
-  void reset_field() { DBUG_ASSERT(0); }
-  void update_field() {}
-  longlong val_int()
+  bool add() override;
+  void reset_field() override { DBUG_ASSERT(0); }
+  void update_field() override {}
+  longlong val_int() override
   {
     return dense_rank;
   }
 
   Item_sum_dense_rank(THD *thd)
     : Item_sum_int(thd), dense_rank(0), first_add(true), peer_tracker(NULL) {}
-  const Type_handler *type_handler() const { return &type_handler_slonglong; }
-  enum Sumfunctype sum_func () const
+  const Type_handler *type_handler() const override { return &type_handler_slonglong; }
+  enum Sumfunctype sum_func () const override
   {
     return DENSE_RANK_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "dense_rank";
   }
 
-  void setup_window_func(THD *thd, Window_spec *window_spec);
+  void setup_window_func(THD *thd, Window_spec *window_spec) override;
 
-  void cleanup()
+  void cleanup() override
   {
     if (peer_tracker)
     {
@@ -292,7 +292,7 @@ class Item_sum_dense_rank: public Item_sum_int
     }
     Item_sum_int::cleanup();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_dense_rank>(thd, this); }
 };
 
@@ -309,22 +309,22 @@ class Item_sum_hybrid_simple : public Item_sum_hybrid
    value(NULL)
   { }
 
-  bool add();
-  bool fix_fields(THD *, Item **);
-  bool fix_length_and_dec();
+  bool add() override;
+  bool fix_fields(THD *, Item **) override;
+  bool fix_length_and_dec() override;
   void setup_hybrid(THD *thd, Item *item);
-  double val_real();
-  longlong val_int();
-  my_decimal *val_decimal(my_decimal *);
-  void reset_field();
-  String *val_str(String *);
-  bool val_native(THD *thd, Native *to);
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate);
-  const Type_handler *type_handler() const
+  double val_real() override;
+  longlong val_int() override;
+  my_decimal *val_decimal(my_decimal *) override;
+  void reset_field() override;
+  String *val_str(String *) override;
+  bool val_native(THD *thd, Native *to) override;
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
+  const Type_handler *type_handler() const override
   { return Type_handler_hybrid_field_type::type_handler(); }
-  void update_field();
-  Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table);
-  void clear()
+  void update_field() override;
+  Field *create_tmp_field(MEM_ROOT *root, bool group, TABLE *table) override;
+  void clear() override
   {
     value->clear();
     null_value= 1;
@@ -345,17 +345,17 @@ class Item_sum_first_value : public Item_sum_hybrid_simple
     Item_sum_hybrid_simple(thd, arg_expr) {}
 
 
-  enum Sumfunctype sum_func () const
+  enum Sumfunctype sum_func () const override
   {
     return FIRST_VALUE_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "first_value";
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_first_value>(thd, this); }
 };
 
@@ -371,17 +371,17 @@ class Item_sum_last_value : public Item_sum_hybrid_simple
   Item_sum_last_value(THD* thd, Item* arg_expr) :
     Item_sum_hybrid_simple(thd, arg_expr) {}
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return LAST_VALUE_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "last_value";
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_last_value>(thd, this); }
 };
 
@@ -391,17 +391,17 @@ class Item_sum_nth_value : public Item_sum_hybrid_simple
   Item_sum_nth_value(THD *thd, Item *arg_expr, Item* offset_expr) :
     Item_sum_hybrid_simple(thd, arg_expr, offset_expr) {}
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return NTH_VALUE_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "nth_value";
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_nth_value>(thd, this); }
 };
 
@@ -411,17 +411,17 @@ class Item_sum_lead : public Item_sum_hybrid_simple
   Item_sum_lead(THD *thd, Item *arg_expr, Item* offset_expr) :
     Item_sum_hybrid_simple(thd, arg_expr, offset_expr) {}
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return LEAD_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "lead";
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_lead>(thd, this); }
 };
 
@@ -431,17 +431,17 @@ class Item_sum_lag : public Item_sum_hybrid_simple
   Item_sum_lag(THD *thd, Item *arg_expr, Item* offset_expr) :
     Item_sum_hybrid_simple(thd, arg_expr, offset_expr) {}
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return LAG_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "lag";
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_lag>(thd, this); }
 };
 
@@ -495,7 +495,7 @@ class Item_sum_percent_rank: public Item_sum_double,
   Item_sum_percent_rank(THD *thd)
     : Item_sum_double(thd), cur_rank(1), peer_tracker(NULL) {}
 
-  longlong val_int()
+  longlong val_int() override
   {
    /*
       Percent rank is a real value so calling the integer value should never
@@ -505,7 +505,7 @@ class Item_sum_percent_rank: public Item_sum_double,
     return 0;
   }
 
-  double val_real()
+  double val_real() override
   {
    /*
      We can not get the real value without knowing the number of rows
@@ -518,43 +518,43 @@ class Item_sum_percent_rank: public Item_sum_double,
              static_cast<double>(cur_rank - 1) / (partition_rows - 1) : 0;
   }
 
-  enum Sumfunctype sum_func () const
+  enum Sumfunctype sum_func () const override
   {
     return PERCENT_RANK_FUNC;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "percent_rank";
   }
 
-  void update_field() {}
+  void update_field() override {}
 
-  void clear()
+  void clear() override
   {
     cur_rank= 1;
     row_number= 0;
   }
-  bool add();
-  const Type_handler *type_handler() const { return &type_handler_double; }
+  bool add() override;
+  const Type_handler *type_handler() const override { return &type_handler_double; }
 
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals = 10;  // TODO-cvicentiu find out how many decimals the standard
                     // requires.
     return FALSE;
   }
 
-  void setup_window_func(THD *thd, Window_spec *window_spec);
+  void setup_window_func(THD *thd, Window_spec *window_spec) override;
 
-  void reset_field() { DBUG_ASSERT(0); }
+  void reset_field() override { DBUG_ASSERT(0); }
 
-  void set_partition_row_count(ulonglong count)
+  void set_partition_row_count(ulonglong count) override
   {
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_percent_rank>(thd, this); }
 
  private:
@@ -563,7 +563,7 @@ class Item_sum_percent_rank: public Item_sum_double,
 
   Group_bound_tracker *peer_tracker;
 
-  void cleanup()
+  void cleanup() override
   {
     if (peer_tracker)
     {
@@ -596,51 +596,51 @@ class Item_sum_cume_dist: public Item_sum_double,
   Item_sum_cume_dist(THD *thd) :Item_sum_double(thd) { }
   Item_sum_cume_dist(THD *thd, Item *arg) :Item_sum_double(thd, arg) { }
 
-  double val_real()
+  double val_real() override
   {
     return calc_val_real(&null_value, current_row_count_);
   }
 
-  bool add()
+  bool add() override
   {
     current_row_count_++;
     return false;
   }
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return CUME_DIST_FUNC;
   }
 
-  void clear()
+  void clear() override
   {
     current_row_count_= 0;
     partition_row_count_= 0;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "cume_dist";
   }
 
-  void update_field() {}
-  const Type_handler *type_handler() const { return &type_handler_double; }
+  void update_field() override {}
+  const Type_handler *type_handler() const override { return &type_handler_double; }
 
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals = 10;  // TODO-cvicentiu find out how many decimals the standard
                     // requires.
     return FALSE;
   }
   
-  void reset_field() { DBUG_ASSERT(0); }
+  void reset_field() override { DBUG_ASSERT(0); }
 
-  void set_partition_row_count(ulonglong count)
+  void set_partition_row_count(ulonglong count) override
   {
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_cume_dist>(thd, this); }
 
 };
@@ -654,7 +654,7 @@ class Item_sum_ntile : public Item_sum_int,
     Item_sum_int(thd, num_quantiles_expr), n_old_val_(0)
   { }
 
-  longlong val_int()
+  longlong val_int() override
   {
     if (get_row_count() == 0)
     {
@@ -681,41 +681,41 @@ class Item_sum_ntile : public Item_sum_int,
     return (current_row_count_ - 1 - extra_rows) / quantile_size + 1;
   }
 
-  bool add()
+  bool add() override
   {
     current_row_count_++;
     return false;
   }
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return NTILE_FUNC;
   }
 
-  void clear()
+  void clear() override
   {
     current_row_count_= 0;
     partition_row_count_= 0;
     n_old_val_= 0;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "ntile";
   }
 
-  void update_field() {}
+  void update_field() override {}
 
-  const Type_handler *type_handler() const { return &type_handler_slonglong; }
+  const Type_handler *type_handler() const override { return &type_handler_slonglong; }
 
-  void reset_field() { DBUG_ASSERT(0); }
+  void reset_field() override { DBUG_ASSERT(0); }
 
-  void set_partition_row_count(ulonglong count)
+  void set_partition_row_count(ulonglong count) override
   {
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_ntile>(thd, this); }
 
  private:
@@ -734,7 +734,7 @@ public:
                            value(NULL), val_calculated(FALSE), first_call(TRUE),
                            prev_value(0), order_item(NULL){}
 
-  double val_real()
+  double val_real() override
   {
     if (get_row_count() == 0 || get_arg(0)->is_null())
     {
@@ -745,7 +745,7 @@ public:
     return value->val_real();
   }
 
-  longlong val_int()
+  longlong val_int() override
   {
     if (get_row_count() == 0 || get_arg(0)->is_null())
     {
@@ -756,7 +756,7 @@ public:
     return value->val_int();
   }
 
-  my_decimal* val_decimal(my_decimal* dec)
+  my_decimal* val_decimal(my_decimal* dec) override
   {
     if (get_row_count() == 0 || get_arg(0)->is_null())
     {
@@ -767,7 +767,7 @@ public:
     return value->val_decimal(dec);
   }
 
-  String* val_str(String *str)
+  String* val_str(String *str) override
   {
     if (get_row_count() == 0 || get_arg(0)->is_null())
     {
@@ -778,7 +778,7 @@ public:
     return value->val_str(str);
   }
 
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     if (get_row_count() == 0 || get_arg(0)->is_null())
     {
@@ -789,7 +789,7 @@ public:
     return value->get_date(thd, ltime, fuzzydate);
   }
 
-  bool val_native(THD *thd, Native *to)
+  bool val_native(THD *thd, Native *to) override
   {
     if (get_row_count() == 0 || get_arg(0)->is_null())
     {
@@ -800,7 +800,7 @@ public:
     return value->val_native(thd, to);
   }
 
-  bool add()
+  bool add() override
   {
     Item *arg= get_arg(0);
     if (arg->is_null())
@@ -841,12 +841,12 @@ public:
     return false;
   }
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return PERCENTILE_DISC_FUNC;
   }
 
-  void clear()
+  void clear() override
   {
     val_calculated= false;
     first_call= true;
@@ -855,34 +855,34 @@ public:
     current_row_count_= 0;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "percentile_disc";
   }
 
-  void update_field() {}
-  const Type_handler *type_handler() const
+  void update_field() override {}
+  const Type_handler *type_handler() const override
   {return Type_handler_hybrid_field_type::type_handler();}
 
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals = 10;  // TODO-cvicentiu find out how many decimals the standard
                     // requires.
     return FALSE;
   }
 
-  void reset_field() { DBUG_ASSERT(0); }
+  void reset_field() override { DBUG_ASSERT(0); }
 
-  void set_partition_row_count(ulonglong count)
+  void set_partition_row_count(ulonglong count) override
   {
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_percentile_disc>(thd, this); }
-  void setup_window_func(THD *thd, Window_spec *window_spec);
+  void setup_window_func(THD *thd, Window_spec *window_spec) override;
   void setup_hybrid(THD *thd, Item *item);
-  bool fix_fields(THD *thd, Item **ref);
+  bool fix_fields(THD *thd, Item **ref) override;
 
 private:
   Item_cache *value;
@@ -901,7 +901,7 @@ public:
                            floor_value(NULL), ceil_value(NULL), first_call(TRUE),prev_value(0),
                            ceil_val_calculated(FALSE), floor_val_calculated(FALSE), order_item(NULL){}
 
-  double val_real()
+  double val_real() override
   {
     if (get_row_count() == 0 || get_arg(0)->is_null())
     {
@@ -928,7 +928,7 @@ public:
     return ret_val;
   }
 
-  bool add()
+  bool add() override
   {
     Item *arg= get_arg(0);
     if (arg->is_null())
@@ -978,12 +978,12 @@ public:
     return false;
   }
 
-  enum Sumfunctype sum_func() const
+  enum Sumfunctype sum_func() const override
   {
     return PERCENTILE_CONT_FUNC;
   }
 
-  void clear()
+  void clear() override
   {
     first_call= true;
     floor_value->clear();
@@ -994,31 +994,31 @@ public:
     current_row_count_= 0;
   }
 
-  const char*func_name() const
+  const char*func_name() const override
   {
     return "percentile_cont";
   }
-  void update_field() {}
+  void update_field() override {}
 
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     decimals = 10;  // TODO-cvicentiu find out how many decimals the standard
                     // requires.
     return FALSE;
   }
 
-  void reset_field() { DBUG_ASSERT(0); }
+  void reset_field() override { DBUG_ASSERT(0); }
 
-  void set_partition_row_count(ulonglong count)
+  void set_partition_row_count(ulonglong count) override
   {
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_sum_percentile_cont>(thd, this); }
-  void setup_window_func(THD *thd, Window_spec *window_spec);
+  void setup_window_func(THD *thd, Window_spec *window_spec) override;
   void setup_hybrid(THD *thd, Item *item);
-  bool fix_fields(THD *thd, Item **ref);
+  bool fix_fields(THD *thd, Item **ref) override;
 
 private:
   Item_cache *floor_value;
@@ -1056,7 +1056,7 @@ public:
 
   Item_sum *window_func() const { return (Item_sum *) args[0]; }
 
-  void update_used_tables();
+  void update_used_tables() override;
 
   /*
     This is used by filesort to mark the columns it needs to read (because they
@@ -1067,7 +1067,7 @@ public:
     have been computed. In that case, window function will need to read its
     temp.table field. In order to allow that, mark that field in the read_set.
   */
-  bool register_field_in_read_map(void *arg)
+  bool register_field_in_read_map(void *arg) override
   {
     TABLE *table= (TABLE*) arg;
     if (result_field && (result_field->table == table || !table))
@@ -1170,11 +1170,11 @@ public:
   */
   void setup_partition_border_check(THD *thd);
 
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return ((Item_sum *) args[0])->type_handler();
   }
-  enum Item::Type type() const { return Item::WINDOW_FUNC_ITEM; }
+  enum Item::Type type() const override { return Item::WINDOW_FUNC_ITEM; }
 
 private:
   /* 
@@ -1217,7 +1217,7 @@ public:
     read_value_from_result_field= true;
   }
 
-  bool is_null()
+  bool is_null() override
   {
     if (force_return_blank)
       return true;
@@ -1228,7 +1228,7 @@ public:
     return window_func()->is_null();
   }
 
-  double val_real() 
+  double val_real() override 
   {
     double res;
     if (force_return_blank)
@@ -1249,7 +1249,7 @@ public:
     return res;
   }
 
-  longlong val_int()
+  longlong val_int() override
   {
     longlong res;
     if (force_return_blank)
@@ -1270,7 +1270,7 @@ public:
     return res;
   }
 
-  String* val_str(String* str)
+  String* val_str(String* str) override
   {
     String *res;
     if (force_return_blank)
@@ -1293,7 +1293,7 @@ public:
     return res;
   }
 
-  bool val_native(THD *thd, Native *to)
+  bool val_native(THD *thd, Native *to) override
   {
     if (force_return_blank)
       return null_value= true;
@@ -1302,7 +1302,7 @@ public:
     return val_native_from_item(thd, window_func(), to);
   }
 
-  my_decimal* val_decimal(my_decimal* dec)
+  my_decimal* val_decimal(my_decimal* dec) override
   {
     my_decimal *res;
     if (force_return_blank)
@@ -1325,7 +1325,7 @@ public:
     return res;
   }
 
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     bool res;
     if (force_return_blank)
@@ -1349,23 +1349,23 @@ public:
   }
 
   void split_sum_func(THD *thd, Ref_ptr_array ref_pointer_array,
-                              List<Item> &fields, uint flags);
+                              List<Item> &fields, uint flags) override;
 
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     Type_std_attributes::set(window_func());
     return FALSE;
   }
 
-  const char* func_name() const { return "WF"; }
+  const char* func_name() const override { return "WF"; }
 
-  bool fix_fields(THD *thd, Item **ref);
+  bool fix_fields(THD *thd, Item **ref) override;
 
   bool resolve_window_name(THD *thd);
   
-  void print(String *str, enum_query_type query_type);
+  void print(String *str, enum_query_type query_type) override;
 
- Item *get_copy(THD *thd) { return 0; }
+ Item *get_copy(THD *thd) override { return 0; }
 
 };
 

--- a/sql/item_xmlfunc.cc
+++ b/sql/item_xmlfunc.cc
@@ -141,21 +141,21 @@ public:
     fltend= (MY_XPATH_FLT*) tmp_native_value.end();
     nodeset->length(0);
   }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     return &type_handler_xpath_nodeset;
   }
-  const Type_handler *fixed_type_handler() const
+  const Type_handler *fixed_type_handler() const override
   {
     return &type_handler_xpath_nodeset;
   }
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     DBUG_ASSERT(0);
     return NULL;
   }
-  String *val_str(String *str)
+  String *val_str(String *str) override
   {
     prepare_nodes();
     val_native(current_thd, &tmp2_native_value);
@@ -189,7 +189,7 @@ public:
     }
     return str;
   }
-  bool fix_length_and_dec()
+  bool fix_length_and_dec() override
   {
     max_length= MAX_BLOB_WIDTH;
     collation.collation= pxml->charset();
@@ -198,8 +198,8 @@ public:
     const_item_cache= false;
     return FALSE;
   }
-  const char *func_name() const { return "nodeset"; }
-  bool check_vcol_func_processor(void *arg)
+  const char *func_name() const override { return "nodeset"; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), arg, VCOL_IMPOSSIBLE);
   }
@@ -213,9 +213,9 @@ class Item_nodeset_func_rootelement :public Item_nodeset_func
 public:
   Item_nodeset_func_rootelement(THD *thd, String *pxml):
     Item_nodeset_func(thd, pxml) {}
-  const char *func_name() const { return "xpath_rootelement"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_rootelement"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_rootelement>(thd, this); }
 };
 
@@ -226,9 +226,9 @@ class Item_nodeset_func_union :public Item_nodeset_func
 public:
   Item_nodeset_func_union(THD *thd, Item *a, Item *b, String *pxml):
     Item_nodeset_func(thd, a, b, pxml) {}
-  const char *func_name() const { return "xpath_union"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_union"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_union>(thd, this); }
 };
 
@@ -242,7 +242,7 @@ public:
   Item_nodeset_func_axisbyname(THD *thd, Item *a, const char *n_arg, uint l_arg,
                                String *pxml):
     Item_nodeset_func(thd, a, pxml), node_name(n_arg), node_namelen(l_arg) { }
-  const char *func_name() const { return "xpath_axisbyname"; }
+  const char *func_name() const override { return "xpath_axisbyname"; }
   bool validname(MY_XML_NODE *n)
   {
     if (node_name[0] == '*')
@@ -260,9 +260,9 @@ public:
   Item_nodeset_func_selfbyname(THD *thd, Item *a, const char *n_arg, uint l_arg,
                                String *pxml):
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
-  const char *func_name() const { return "xpath_selfbyname"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_selfbyname"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_selfbyname>(thd, this); }
 };
 
@@ -274,9 +274,9 @@ public:
   Item_nodeset_func_childbyname(THD *thd, Item *a, const char *n_arg, uint l_arg,
                                 String *pxml): 
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
-  const char *func_name() const { return "xpath_childbyname"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_childbyname"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_childbyname>(thd, this); }
 };
 
@@ -290,9 +290,9 @@ public:
                                      String *pxml, bool need_self_arg):
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml),
       need_self(need_self_arg) {}
-  const char *func_name() const { return "xpath_descendantbyname"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_descendantbyname"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_descendantbyname>(thd, this); }
 };
 
@@ -306,9 +306,9 @@ public:
                                    String *pxml, bool need_self_arg):
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml),
       need_self(need_self_arg) {}
-  const char *func_name() const { return "xpath_ancestorbyname"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_ancestorbyname"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_ancestorbyname>(thd, this); }
 };
 
@@ -320,9 +320,9 @@ public:
   Item_nodeset_func_parentbyname(THD *thd, Item *a, const char *n_arg, uint l_arg,
                                  String *pxml):
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
-  const char *func_name() const { return "xpath_parentbyname"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_parentbyname"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_parentbyname>(thd, this); }
 };
 
@@ -334,9 +334,9 @@ public:
   Item_nodeset_func_attributebyname(THD *thd, Item *a, const char *n_arg,
                                     uint l_arg, String *pxml):
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
-  const char *func_name() const { return "xpath_attributebyname"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_attributebyname"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_attributebyname>(thd, this); }
 };
 
@@ -351,9 +351,9 @@ class Item_nodeset_func_predicate :public Item_nodeset_func
 public:
   Item_nodeset_func_predicate(THD *thd, Item *a, Item *b, String *pxml):
     Item_nodeset_func(thd, a, b, pxml) {}
-  const char *func_name() const { return "xpath_predicate"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_predicate"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_predicate>(thd, this); }
 };
 
@@ -364,9 +364,9 @@ class Item_nodeset_func_elementbyindex :public Item_nodeset_func
 public:
   Item_nodeset_func_elementbyindex(THD *thd, Item *a, Item *b, String *pxml):
     Item_nodeset_func(thd, a, b, pxml) { }
-  const char *func_name() const { return "xpath_elementbyindex"; }
-  bool val_native(THD *thd, Native *nodeset);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_elementbyindex"; }
+  bool val_native(THD *thd, Native *nodeset) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_func_elementbyindex>(thd, this); }
 };
 
@@ -384,8 +384,8 @@ class Item_xpath_cast_bool :public Item_bool_func
 public:
   Item_xpath_cast_bool(THD *thd, Item *a, String *pxml_arg):
     Item_bool_func(thd, a), pxml(pxml_arg) {}
-  const char *func_name() const { return "xpath_cast_bool"; }
-  longlong val_int()
+  const char *func_name() const override { return "xpath_cast_bool"; }
+  longlong val_int() override
   {
     if (args[0]->fixed_type_handler() == &type_handler_xpath_nodeset)
     {
@@ -394,7 +394,7 @@ public:
     }
     return args[0]->val_real() ? 1 : 0;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_xpath_cast_bool>(thd, this); }
 };
 
@@ -406,9 +406,9 @@ class Item_xpath_cast_number :public Item_real_func
 {
 public:
   Item_xpath_cast_number(THD *thd, Item *a): Item_real_func(thd, a) {}
-  const char *func_name() const { return "xpath_cast_number"; }
-  virtual double val_real() { return args[0]->val_real(); }
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "xpath_cast_number"; }
+  double val_real() override { return args[0]->val_real(); }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_xpath_cast_number>(thd, this); }
 };
 
@@ -422,12 +422,12 @@ public:
   Native *native_cache;
   Item_nodeset_context_cache(THD *thd, Native *native_arg, String *pxml):
     Item_nodeset_func(thd, pxml), native_cache(native_arg) { }
-  bool val_native(THD *thd, Native *nodeset)
+  bool val_native(THD *thd, Native *nodeset) override
   {
     return nodeset->copy(*native_cache);
   }
-  bool fix_length_and_dec() { max_length= MAX_BLOB_WIDTH;; return FALSE;  }
-  Item *get_copy(THD *thd)
+  bool fix_length_and_dec() override { max_length= MAX_BLOB_WIDTH;; return FALSE;  }
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_context_cache>(thd, this); }
 };
 
@@ -439,16 +439,16 @@ class Item_func_xpath_position :public Item_long_func
 public:
   Item_func_xpath_position(THD *thd, Item *a, String *p):
     Item_long_func(thd, a), pxml(p) {}
-  const char *func_name() const { return "xpath_position"; }
-  bool fix_length_and_dec() { max_length=10; return FALSE; }
-  longlong val_int()
+  const char *func_name() const override { return "xpath_position"; }
+  bool fix_length_and_dec() override { max_length=10; return FALSE; }
+  longlong val_int() override
   {
     args[0]->val_native(current_thd, &tmp_native_value);
     if (tmp_native_value.elements() == 1)
       return tmp_native_value.element(0).pos + 1;
     return 0;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_xpath_position>(thd, this); }
 };
 
@@ -460,9 +460,9 @@ class Item_func_xpath_count :public Item_long_func
 public:
   Item_func_xpath_count(THD *thd, Item *a, String *p):
     Item_long_func(thd, a), pxml(p) {}
-  const char *func_name() const { return "xpath_count"; }
-  bool fix_length_and_dec() { max_length=10; return FALSE; }
-  longlong val_int()
+  const char *func_name() const override { return "xpath_count"; }
+  bool fix_length_and_dec() override { max_length=10; return FALSE; }
+  longlong val_int() override
   {
     uint predicate_supplied_context_size;
     args[0]->val_native(current_thd, &tmp_native_value);
@@ -471,7 +471,7 @@ public:
       return predicate_supplied_context_size;
     return tmp_native_value.elements();
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_xpath_count>(thd, this); }
 };
 
@@ -484,8 +484,8 @@ public:
   Item_func_xpath_sum(THD *thd, Item *a, String *p):
     Item_real_func(thd, a), pxml(p) {}
 
-  const char *func_name() const { return "xpath_sum"; }
-  double val_real()
+  const char *func_name() const override { return "xpath_sum"; }
+  double val_real() override
   {
     double sum= 0;
     args[0]->val_native(current_thd, &tmp_native_value);
@@ -516,7 +516,7 @@ public:
     }
     return sum;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_xpath_sum>(thd, this); }
 };
 
@@ -531,13 +531,13 @@ public:
                             CHARSET_INFO *cs):
     Item_string(thd, str, length, cs)
   { }
-  bool const_item() const { return false ; }
-  bool basic_const_item() const { return false; }
+  bool const_item() const override { return false ; }
+  bool basic_const_item() const override { return false; }
   void set_value(const char *str, uint length, CHARSET_INFO *cs)
   {
     str_value.set(str, length, cs);
   }
-  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs)
+  Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override
   {
     /*
       Item_string::safe_charset_converter() does not accept non-constants.
@@ -556,18 +556,18 @@ public:
   Item_nodeset_to_const_comparator(THD *thd, Item *nodeset, Item *cmpfunc,
                                    String *p):
     Item_bool_func(thd, nodeset, cmpfunc), pxml(p) {}
-  const char *func_name() const { return "xpath_nodeset_to_const_comparator"; }
-  bool check_vcol_func_processor(void *arg)
+  const char *func_name() const override { return "xpath_nodeset_to_const_comparator"; }
+  bool check_vcol_func_processor(void *arg) override
   {
     return mark_unsupported_function(func_name(), arg, VCOL_IMPOSSIBLE);
   }
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     DBUG_ASSERT(0);
     return NULL;
   }
-  longlong val_int()
+  longlong val_int() override
   {
     Item_func *comp= (Item_func*)args[1];
     Item_string_xml_non_const *fake=
@@ -598,7 +598,7 @@ public:
     }
     return 0;
   }
-  Item *get_copy(THD *thd)
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_nodeset_to_const_comparator>(thd, this); }
 };
 

--- a/sql/item_xmlfunc.h
+++ b/sql/item_xmlfunc.h
@@ -117,9 +117,9 @@ public:
   {
     maybe_null= TRUE;
   }
-  bool fix_fields(THD *thd, Item **ref);
-  bool fix_length_and_dec();
-  bool const_item() const
+  bool fix_fields(THD *thd, Item **ref) override;
+  bool fix_length_and_dec() override;
+  bool const_item() const override
   {
     return const_item_cache && (!nodeset_func || nodeset_func->const_item());
   }
@@ -131,9 +131,9 @@ class Item_func_xml_extractvalue: public Item_xml_str_func
 public:
   Item_func_xml_extractvalue(THD *thd, Item *a, Item *b):
     Item_xml_str_func(thd, a, b) {}
-  const char *func_name() const { return "extractvalue"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "extractvalue"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_xml_extractvalue>(thd, this); }
 };
 
@@ -148,9 +148,9 @@ class Item_func_xml_update: public Item_xml_str_func
 public:
   Item_func_xml_update(THD *thd, Item *a, Item *b, Item *c):
     Item_xml_str_func(thd, a, b, c) {}
-  const char *func_name() const { return "updatexml"; }
-  String *val_str(String *);
-  Item *get_copy(THD *thd)
+  const char *func_name() const override { return "updatexml"; }
+  String *val_str(String *) override;
+  Item *get_copy(THD *thd) override
   { return get_item_copy<Item_func_xml_update>(thd, this); }
 };
 

--- a/sql/keycaches.cc
+++ b/sql/keycaches.cc
@@ -48,7 +48,7 @@ public:
   {
     return length == name_length && !memcmp(name, name_cmp, length);
   }
-  ~NAMED_ILINK()
+  ~NAMED_ILINK() override
   {
     my_free((void *) name);
   }

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -210,14 +210,14 @@ public:
     m_message[0]= '\0';
   }
 
-  virtual ~Silence_log_table_errors() = default;
+  ~Silence_log_table_errors() override = default;
 
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                 uint sql_errno,
                                 const char* sql_state,
                                 Sql_condition::enum_warning_level *level,
                                 const char* msg,
-                                Sql_condition ** cond_hdl);
+                                Sql_condition ** cond_hdl) override;
   const char *message() const { return m_message; }
 };
 

--- a/sql/log.h
+++ b/sql/log.h
@@ -101,25 +101,25 @@ class TC_LOG_DUMMY: public TC_LOG // use it to disable the logging
 {
 public:
   TC_LOG_DUMMY() = default;
-  int open(const char *opt_name)        { return 0; }
-  void close()                          { }
+  int open(const char *opt_name) override        { return 0; }
+  void close() override                          { }
   /*
     TC_LOG_DUMMY is only used when there are <= 1 XA-capable engines, and we
     only use internal XA during commit when >= 2 XA-capable engines
     participate.
   */
   int log_and_order(THD *thd, my_xid xid, bool all,
-                    bool need_prepare_ordered, bool need_commit_ordered)
+                    bool need_prepare_ordered, bool need_commit_ordered) override
   {
     DBUG_ASSERT(0);
     return 1;
   }
-  int unlog(ulong cookie, my_xid xid)  { return 0; }
-  int unlog_xa_prepare(THD *thd, bool all)
+  int unlog(ulong cookie, my_xid xid) override  { return 0; }
+  int unlog_xa_prepare(THD *thd, bool all) override
   {
     return 0;
   }
-  void commit_checkpoint_notify(void *cookie) { DBUG_ASSERT(0); };
+  void commit_checkpoint_notify(void *cookie) override { DBUG_ASSERT(0); };
 };
 
 #define TC_LOG_PAGE_SIZE   8192
@@ -197,16 +197,16 @@ class TC_LOG_MMAP: public TC_LOG
 
   public:
   TC_LOG_MMAP(): inited(0), pending_checkpoint(0) {}
-  int open(const char *opt_name);
-  void close();
+  int open(const char *opt_name) override;
+  void close() override;
   int log_and_order(THD *thd, my_xid xid, bool all,
-                    bool need_prepare_ordered, bool need_commit_ordered);
-  int unlog(ulong cookie, my_xid xid);
-  int unlog_xa_prepare(THD *thd, bool all)
+                    bool need_prepare_ordered, bool need_commit_ordered) override;
+  int unlog(ulong cookie, my_xid xid) override;
+  int unlog_xa_prepare(THD *thd, bool all) override
   {
     return 0;
   }
-  void commit_checkpoint_notify(void *cookie);
+  void commit_checkpoint_notify(void *cookie) override;
   int recover();
 
   private:
@@ -720,15 +720,15 @@ public:
   }
 #endif
 
-  int open(const char *opt_name);
-  void close();
-  virtual int generate_new_name(char *new_name, const char *log_name,
-                                ulong next_log_number);
+  int open(const char *opt_name) override;
+  void close() override;
+  int generate_new_name(char *new_name, const char *log_name,
+                        ulong next_log_number) override;
   int log_and_order(THD *thd, my_xid xid, bool all,
-                    bool need_prepare_ordered, bool need_commit_ordered);
-  int unlog(ulong cookie, my_xid xid);
-  int unlog_xa_prepare(THD *thd, bool all);
-  void commit_checkpoint_notify(void *cookie);
+                    bool need_prepare_ordered, bool need_commit_ordered) override;
+  int unlog(ulong cookie, my_xid xid) override;
+  int unlog_xa_prepare(THD *thd, bool all) override;
+  void commit_checkpoint_notify(void *cookie) override;
   int recover(LOG_INFO *linfo, const char *last_log_name, IO_CACHE *first_log,
               Format_description_log_event *fdle, bool do_xa);
   int do_binlog_recovery(const char *opt_name, bool do_xa_recovery);
@@ -1017,19 +1017,19 @@ class Log_to_csv_event_handler: public Log_event_handler
 public:
   Log_to_csv_event_handler();
   ~Log_to_csv_event_handler();
-  virtual bool init();
-  virtual void cleanup();
+  bool init() override;
+  void cleanup() override;
 
-  virtual bool log_slow(THD *thd, my_hrtime_t current_time,
+  bool log_slow(THD *thd, my_hrtime_t current_time,
                         const char *user_host, size_t user_host_len, ulonglong query_utime,
                         ulonglong lock_utime, bool is_command,
-                        const char *sql_text, size_t sql_text_len);
-  virtual bool log_error(enum loglevel level, const char *format,
-                         va_list args);
-  virtual bool log_general(THD *thd, my_hrtime_t event_time, const char *user_host, size_t user_host_len, my_thread_id thread_id,
+                        const char *sql_text, size_t sql_text_len) override;
+  bool log_error(enum loglevel level, const char *format,
+                         va_list args) override;
+  bool log_general(THD *thd, my_hrtime_t event_time, const char *user_host, size_t user_host_len, my_thread_id thread_id,
                            const char *command_type, size_t command_type_len,
                            const char *sql_text, size_t sql_text_len,
-                           CHARSET_INFO *client_cs);
+                           CHARSET_INFO *client_cs) override;
 
   int activate_log(THD *thd, uint log_type);
 };
@@ -1047,19 +1047,19 @@ class Log_to_file_event_handler: public Log_event_handler
 public:
   Log_to_file_event_handler(): is_initialized(FALSE)
   {}
-  virtual bool init();
-  virtual void cleanup();
+  bool init() override;
+  void cleanup() override;
 
-  virtual bool log_slow(THD *thd, my_hrtime_t current_time,
+  bool log_slow(THD *thd, my_hrtime_t current_time,
                         const char *user_host, size_t user_host_len, ulonglong query_utime,
                         ulonglong lock_utime, bool is_command,
-                        const char *sql_text, size_t sql_text_len);
-  virtual bool log_error(enum loglevel level, const char *format,
-                         va_list args);
-  virtual bool log_general(THD *thd, my_hrtime_t event_time, const char *user_host, size_t user_host_len, my_thread_id thread_id,
+                        const char *sql_text, size_t sql_text_len) override;
+  bool log_error(enum loglevel level, const char *format,
+                         va_list args) override;
+  bool log_general(THD *thd, my_hrtime_t event_time, const char *user_host, size_t user_host_len, my_thread_id thread_id,
                            const char *command_type, size_t command_type_len,
                            const char *sql_text, size_t sql_text_len,
-                           CHARSET_INFO *client_cs);
+                           CHARSET_INFO *client_cs) override;
   void flush();
   void init_pthread_objects();
   MYSQL_QUERY_LOG *get_mysql_slow_log() { return &mysql_slow_log; }

--- a/sql/log_event_old.h
+++ b/sql/log_event_old.h
@@ -111,12 +111,12 @@ public:
   flag_set get_flags(flag_set flags_arg) const { return m_flags & flags_arg; }
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
-  virtual void pack_info(Protocol *protocol);
+  void pack_info(Protocol *protocol) override;
 #endif
 
 #ifdef MYSQL_CLIENT
   /* not for direct call, each derived has its own ::print() */
-  virtual bool print(FILE *file, PRINT_EVENT_INFO *print_event_info)= 0;
+  bool print(FILE *file, PRINT_EVENT_INFO *print_event_info) override= 0;
 #endif
 
 #ifndef MYSQL_CLIENT
@@ -127,16 +127,19 @@ public:
 #endif
 
   /* Member functions to implement superclass interface */
-  virtual int get_data_size();
+  int get_data_size() override;
 
   MY_BITMAP const *get_cols() const { return &m_cols; }
   size_t get_width() const          { return m_width; }
   ulong get_table_id() const        { return m_table_id; }
 
 #ifndef MYSQL_CLIENT
-  virtual bool write_data_header();
-  virtual bool write_data_body();
-  virtual const char *get_db() { return m_table->s->db.str; }
+  bool write_data_header() override;
+  bool write_data_body() override;
+  const char *get_db() override { return m_table->s->db.str; }
+#ifdef HAVE_REPLICATION
+  bool is_part_of_group() override { return 1; }
+#endif
 #endif
   /*
     Check that malloc() succeeded in allocating memory for the rows
@@ -144,11 +147,10 @@ public:
     is valid is done in the Update_rows_log_event_old::is_valid()
     function.
   */
-  virtual bool is_valid() const
+  bool is_valid() const override
   {
     return m_rows_buf && m_cols.bitmap;
   }
-  bool is_part_of_group() { return 1; }
 
   uint     m_row_count;         /* The number of rows added to the event */
 
@@ -215,9 +217,9 @@ protected:
 private:
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
-  virtual int do_apply_event(rpl_group_info *rgi);
-  virtual int do_update_pos(rpl_group_info *rgi);
-  virtual enum_skip_reason do_shall_skip(rpl_group_info *rgi);
+  int do_apply_event(rpl_group_info *rgi) override;
+  int do_update_pos(rpl_group_info *rgi) override;
+  enum_skip_reason do_shall_skip(rpl_group_info *rgi) override;
 
   /*
     Primitive to prepare for a sequence of row executions.
@@ -379,13 +381,13 @@ public:
 
 private:
 #ifdef MYSQL_CLIENT
-  bool print(FILE *file, PRINT_EVENT_INFO *print_event_info);
+  bool print(FILE *file, PRINT_EVENT_INFO *print_event_info) override;
 #endif
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
-  virtual int do_before_row_operations(const Slave_reporting_capability *const);
-  virtual int do_after_row_operations(const Slave_reporting_capability *const,int);
-  virtual int do_exec_row(rpl_group_info *);
+  int do_before_row_operations(const Slave_reporting_capability *const) override;
+  int do_after_row_operations(const Slave_reporting_capability *const,int) override;
+  int do_exec_row(rpl_group_info *) override;
 #endif
   /********** END OF CUT & PASTE FROM Write_rows_log_event **********/
 
@@ -397,19 +399,19 @@ public:
   };
 
 private:
-  virtual Log_event_type get_type_code() { return (Log_event_type)TYPE_CODE; }
+  Log_event_type get_type_code() override { return (Log_event_type)TYPE_CODE; }
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
   // use old definition of do_apply_event()
-  virtual int do_apply_event(rpl_group_info *rgi)
+  int do_apply_event(rpl_group_info *rgi) override
   { return Old_rows_log_event::do_apply_event(this, rgi); }
 
   // primitives for old version of do_apply_event()
-  virtual int do_before_row_operations(TABLE *table);
-  virtual int do_after_row_operations(TABLE *table, int error);
+  int do_before_row_operations(TABLE *table) override;
+  int do_after_row_operations(TABLE *table, int error) override;
   virtual int do_prepare_row(THD*, rpl_group_info*, TABLE*,
-                             uchar const *row_start, uchar const **row_end);
-  virtual int do_exec_row(TABLE *table);
+                             uchar const *row_start, uchar const **row_end) override;
+  int do_exec_row(TABLE *table) override;
 
 #endif
 };
@@ -455,13 +457,13 @@ public:
 
 protected:
 #ifdef MYSQL_CLIENT
-  bool print(FILE *file, PRINT_EVENT_INFO *print_event_info);
+  bool print(FILE *file, PRINT_EVENT_INFO *print_event_info) override;
 #endif
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
-  virtual int do_before_row_operations(const Slave_reporting_capability *const);
-  virtual int do_after_row_operations(const Slave_reporting_capability *const,int);
-  virtual int do_exec_row(rpl_group_info *);
+  int do_before_row_operations(const Slave_reporting_capability *const) override;
+  int do_after_row_operations(const Slave_reporting_capability *const,int) override;
+  int do_exec_row(rpl_group_info *) override;
 #endif /* !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION) */
   /********** END OF CUT & PASTE FROM Update_rows_log_event **********/
 
@@ -475,19 +477,19 @@ public:
   };
 
 private:
-  virtual Log_event_type get_type_code() { return (Log_event_type)TYPE_CODE; }
+  Log_event_type get_type_code() override { return (Log_event_type)TYPE_CODE; }
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
   // use old definition of do_apply_event()
-  virtual int do_apply_event(rpl_group_info *rgi)
+  int do_apply_event(rpl_group_info *rgi) override
   { return Old_rows_log_event::do_apply_event(this, rgi); }
 
   // primitives for old version of do_apply_event()
-  virtual int do_before_row_operations(TABLE *table);
-  virtual int do_after_row_operations(TABLE *table, int error);
+  int do_before_row_operations(TABLE *table) override;
+  int do_after_row_operations(TABLE *table, int error) override;
   virtual int do_prepare_row(THD*, rpl_group_info*, TABLE*,
-                             uchar const *row_start, uchar const **row_end);
-  virtual int do_exec_row(TABLE *table);
+                             uchar const *row_start, uchar const **row_end) override;
+  int do_exec_row(TABLE *table) override;
 #endif /* !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION) */
 };
 
@@ -529,13 +531,13 @@ public:
   
 protected:
 #ifdef MYSQL_CLIENT
-  bool print(FILE *file, PRINT_EVENT_INFO *print_event_info);
+  bool print(FILE *file, PRINT_EVENT_INFO *print_event_info) override;
 #endif
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
-  virtual int do_before_row_operations(const Slave_reporting_capability *const);
-  virtual int do_after_row_operations(const Slave_reporting_capability *const,int);
-  virtual int do_exec_row(rpl_group_info *);
+  int do_before_row_operations(const Slave_reporting_capability *const) override;
+  int do_after_row_operations(const Slave_reporting_capability *const,int) override;
+  int do_exec_row(rpl_group_info *) override;
 #endif
   /********** END CUT & PASTE FROM Delete_rows_log_event **********/
 
@@ -549,19 +551,19 @@ public:
   };
 
 private:
-  virtual Log_event_type get_type_code() { return (Log_event_type)TYPE_CODE; }
+  Log_event_type get_type_code() override { return (Log_event_type)TYPE_CODE; }
 
 #if !defined(MYSQL_CLIENT) && defined(HAVE_REPLICATION)
   // use old definition of do_apply_event()
-  virtual int do_apply_event(rpl_group_info *rgi)
+  int do_apply_event(rpl_group_info *rgi) override
   { return Old_rows_log_event::do_apply_event(this, rgi); }
 
   // primitives for old version of do_apply_event()
-  virtual int do_before_row_operations(TABLE *table);
-  virtual int do_after_row_operations(TABLE *table, int error);
+  int do_before_row_operations(TABLE *table) override;
+  int do_after_row_operations(TABLE *table, int error) override;
   virtual int do_prepare_row(THD*, rpl_group_info*, TABLE*,
-                             uchar const *row_start, uchar const **row_end);
-  virtual int do_exec_row(TABLE *table);
+                             uchar const *row_start, uchar const **row_end) override;
+  int do_exec_row(TABLE *table) override;
 #endif
 };
 

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -8523,6 +8523,7 @@ uint8 Update_rows_log_event::get_trg_event_map()
 #endif
 
 
+#if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)
 void Incident_log_event::pack_info(Protocol *protocol)
 {
   char buf[256];
@@ -8535,7 +8536,7 @@ void Incident_log_event::pack_info(Protocol *protocol)
                        m_incident, description(), m_message.str);
   protocol->store(buf, bytes, &my_charset_bin);
 }
-
+#endif
 
 #if defined(WITH_WSREP)
 /*
@@ -8622,6 +8623,7 @@ Incident_log_event::write_data_body()
 }
 
 
+#if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)
 /* Pack info for its unrecognized ignorable event */
 void Ignorable_log_event::pack_info(Protocol *protocol)
 {
@@ -8631,7 +8633,7 @@ void Ignorable_log_event::pack_info(Protocol *protocol)
                      number, description);
   protocol->store(buf, bytes, &my_charset_bin);
 }
-
+#endif
 
 #if defined(HAVE_REPLICATION)
 Heartbeat_log_event::Heartbeat_log_event(const char* buf, ulong event_len,

--- a/sql/mdl.cc
+++ b/sql/mdl.cc
@@ -199,10 +199,10 @@ public:
       m_current_search_depth(0),
       m_found_deadlock(FALSE)
   {}
-  virtual bool enter_node(MDL_context *node);
-  virtual void leave_node(MDL_context *node);
+  bool enter_node(MDL_context *node) override;
+  void leave_node(MDL_context *node) override;
 
-  virtual bool inspect_edge(MDL_context *dest);
+  bool inspect_edge(MDL_context *dest) override;
 
   MDL_context *get_victim() const { return m_victim; }
 private:
@@ -434,11 +434,11 @@ public:
   struct MDL_scoped_lock : public MDL_lock_strategy
   {
     MDL_scoped_lock() = default;
-    virtual const bitmap_t *incompatible_granted_types_bitmap() const
+    const bitmap_t *incompatible_granted_types_bitmap() const override
     { return m_granted_incompatible; }
-    virtual const bitmap_t *incompatible_waiting_types_bitmap() const
+    const bitmap_t *incompatible_waiting_types_bitmap() const override
     { return m_waiting_incompatible; }
-    virtual bool needs_notification(const MDL_ticket *ticket) const
+    bool needs_notification(const MDL_ticket *ticket) const override
     { return (ticket->get_type() == MDL_SHARED); }
 
     /**
@@ -449,14 +449,14 @@ public:
       insert delayed. We need to kill such threads in order to get
       global shared lock. We do this my calling code outside of MDL.
     */
-    virtual bool conflicting_locks(const MDL_ticket *ticket) const
+    bool conflicting_locks(const MDL_ticket *ticket) const override
     { return ticket->get_type() == MDL_INTENTION_EXCLUSIVE; }
 
     /*
       In scoped locks, only IX lock request would starve because of X/S. But that
       is practically very rare case. So just return 0 from this function.
     */
-    virtual bitmap_t hog_lock_types_bitmap() const
+    bitmap_t hog_lock_types_bitmap() const override
     { return 0; }
   private:
     static const bitmap_t m_granted_incompatible[MDL_TYPE_END];
@@ -471,11 +471,11 @@ public:
   struct MDL_object_lock : public MDL_lock_strategy
   {
     MDL_object_lock() = default;
-    virtual const bitmap_t *incompatible_granted_types_bitmap() const
+    const bitmap_t *incompatible_granted_types_bitmap() const override
     { return m_granted_incompatible; }
-    virtual const bitmap_t *incompatible_waiting_types_bitmap() const
+    const bitmap_t *incompatible_waiting_types_bitmap() const override
     { return m_waiting_incompatible; }
-    virtual bool needs_notification(const MDL_ticket *ticket) const
+    bool needs_notification(const MDL_ticket *ticket) const override
     {
       return (MDL_BIT(ticket->get_type()) &
               (MDL_BIT(MDL_SHARED_NO_WRITE) |
@@ -491,7 +491,7 @@ public:
       lock or some other non-MDL resource we might need to wake it up
       by calling code outside of MDL.
     */
-    virtual bool conflicting_locks(const MDL_ticket *ticket) const
+    bool conflicting_locks(const MDL_ticket *ticket) const override
     { return ticket->get_type() < MDL_SHARED_UPGRADABLE; }
 
     /*
@@ -499,7 +499,7 @@ public:
       max_write_lock_count times in a row while other lock types are
       waiting.
     */
-    virtual bitmap_t hog_lock_types_bitmap() const
+    bitmap_t hog_lock_types_bitmap() const override
     {
       return (MDL_BIT(MDL_SHARED_NO_WRITE) |
               MDL_BIT(MDL_SHARED_NO_READ_WRITE) |
@@ -515,11 +515,11 @@ public:
   struct MDL_backup_lock: public MDL_lock_strategy
   {
     MDL_backup_lock() = default;
-    virtual const bitmap_t *incompatible_granted_types_bitmap() const
+    const bitmap_t *incompatible_granted_types_bitmap() const override
     { return m_granted_incompatible; }
-    virtual const bitmap_t *incompatible_waiting_types_bitmap() const
+    const bitmap_t *incompatible_waiting_types_bitmap() const override
     { return m_waiting_incompatible; }
-    virtual bool needs_notification(const MDL_ticket *ticket) const
+    bool needs_notification(const MDL_ticket *ticket) const override
     {
       return (MDL_BIT(ticket->get_type()) & MDL_BIT(MDL_BACKUP_FTWRL1));
     }
@@ -529,7 +529,7 @@ public:
        We need to kill such threads in order to get lock for FTWRL statements.
        We do this by calling code outside of MDL.
     */
-    virtual bool conflicting_locks(const MDL_ticket *ticket) const
+    bool conflicting_locks(const MDL_ticket *ticket) const override
     {
       return (MDL_BIT(ticket->get_type()) &
               (MDL_BIT(MDL_BACKUP_DML) |
@@ -541,7 +541,7 @@ public:
       BACKUP statements. This scenario is partically useless in real world,
       so we just return 0 here.
     */
-    virtual bitmap_t hog_lock_types_bitmap() const
+    bitmap_t hog_lock_types_bitmap() const override
     { return 0; }
   private:
     static const bitmap_t m_granted_incompatible[MDL_BACKUP_END];

--- a/sql/mdl.h
+++ b/sql/mdl.h
@@ -726,8 +726,8 @@ public:
   bool is_incompatible_when_waiting(enum_mdl_type type) const;
 
   /** Implement MDL_wait_for_subgraph interface. */
-  virtual bool accept_visitor(MDL_wait_for_graph_visitor *dvisitor);
-  virtual uint get_deadlock_weight() const;
+  bool accept_visitor(MDL_wait_for_graph_visitor *dvisitor) override;
+  uint get_deadlock_weight() const override;
   /**
     Status of lock request represented by the ticket as reflected in P_S.
   */

--- a/sql/multi_range_read.h
+++ b/sql/multi_range_read.h
@@ -247,11 +247,11 @@ public:
            void *seq_init_param, uint n_ranges,
            uint mode, Key_parameters *key_par,
            Lifo_buffer *key_buffer,
-           Buffer_manager *buf_manager_arg);
-  int get_next(range_id_t *range_info);
-  int refill_buffer(bool initial) { return initial? 0: HA_ERR_END_OF_FILE; }
-  uchar *get_rowid_ptr() { return file->ref; }
-  bool skip_record(range_id_t range_id, uchar *rowid)
+           Buffer_manager *buf_manager_arg) override;
+  int get_next(range_id_t *range_info) override;
+  int refill_buffer(bool initial) override { return initial? 0: HA_ERR_END_OF_FILE; }
+  uchar *get_rowid_ptr() override { return file->ref; }
+  bool skip_record(range_id_t range_id, uchar *rowid) override
   {
     return (file->mrr_funcs.skip_record &&
             file->mrr_funcs.skip_record(file->mrr_iter, range_id, rowid));
@@ -270,12 +270,12 @@ public:
            void *seq_init_param, uint n_ranges,
            uint mode, Key_parameters *key_par,
            Lifo_buffer *key_buffer,
-           Buffer_manager *buf_manager_arg);
-  int get_next(range_id_t *range_info);
-  int refill_buffer(bool initial);
-  uchar *get_rowid_ptr() { return file->ref; }
+           Buffer_manager *buf_manager_arg) override;
+  int get_next(range_id_t *range_info) override;
+  int refill_buffer(bool initial) override;
+  uchar *get_rowid_ptr() override { return file->ref; }
   
-  bool skip_record(range_id_t range_info, uchar *rowid)
+  bool skip_record(range_id_t range_info, uchar *rowid) override
   {
     return (mrr_funcs.skip_record &&
             mrr_funcs.skip_record(mrr_iter, range_info, rowid));
@@ -292,9 +292,9 @@ public:
                                     uchar **space_start, uchar *space_end);
   void set_no_interruption_temp_buffer();
 
-  void interrupt_read();
-  void resume_read();
-  void position();
+  void interrupt_read() override;
+  void resume_read() override;
+  void position() override;
 private:
   Key_value_records_iterator kv_it;
 
@@ -365,8 +365,8 @@ class Mrr_ordered_rndpos_reader : public Mrr_reader
 public:
   int init(handler *file, Mrr_index_reader *index_reader, uint mode,
            Lifo_buffer *buf, Rowid_filter *filter);
-  int get_next(range_id_t *range_info);
-  int refill_buffer(bool initial);
+  int get_next(range_id_t *range_info) override;
+  int refill_buffer(bool initial) override;
 private:
   handler *file; /* Handler to use */
   

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -2269,10 +2269,10 @@ public:
   TRP_RANGE(SEL_ARG *key_arg, uint idx_arg, uint mrr_flags_arg)
    : key(key_arg), key_idx(idx_arg), mrr_flags(mrr_flags_arg)
   {}
-  virtual ~TRP_RANGE() = default;                     /* Remove gcc warning */
+  ~TRP_RANGE() override = default;                     /* Remove gcc warning */
 
   QUICK_SELECT_I *make_quick(PARAM *param, bool retrieve_full_rows,
-                             MEM_ROOT *parent_alloc)
+                             MEM_ROOT *parent_alloc) override
   {
     DBUG_ENTER("TRP_RANGE::make_quick");
     QUICK_RANGE_SELECT *quick;
@@ -2285,7 +2285,7 @@ public:
     DBUG_RETURN(quick);
   }
   void trace_basic_info(PARAM *param,
-                        Json_writer_object *trace_object) const;
+                        Json_writer_object *trace_object) const override;
 };
 
 void TRP_RANGE::trace_basic_info(PARAM *param,
@@ -2317,9 +2317,9 @@ class TRP_ROR_INTERSECT : public TABLE_READ_PLAN
 {
 public:
   TRP_ROR_INTERSECT() = default;                      /* Remove gcc warning */
-  virtual ~TRP_ROR_INTERSECT() = default;             /* Remove gcc warning */
+  ~TRP_ROR_INTERSECT() override = default;             /* Remove gcc warning */
   QUICK_SELECT_I *make_quick(PARAM *param, bool retrieve_full_rows,
-                             MEM_ROOT *parent_alloc);
+                             MEM_ROOT *parent_alloc) override;
 
   /* Array of pointers to ROR range scans used in this intersection */
   struct st_ror_scan_info **first_scan;
@@ -2328,7 +2328,7 @@ public:
   bool is_covering; /* TRUE if no row retrieval phase is necessary */
   double index_scan_costs; /* SUM(cost(index_scan)) */
   void trace_basic_info(PARAM *param,
-                        Json_writer_object *trace_object) const;
+                        Json_writer_object *trace_object) const override;
 };
 
 
@@ -2343,13 +2343,13 @@ class TRP_ROR_UNION : public TABLE_READ_PLAN
 {
 public:
   TRP_ROR_UNION() = default;                          /* Remove gcc warning */
-  virtual ~TRP_ROR_UNION() = default;                 /* Remove gcc warning */
+  ~TRP_ROR_UNION() override = default;                 /* Remove gcc warning */
   QUICK_SELECT_I *make_quick(PARAM *param, bool retrieve_full_rows,
-                             MEM_ROOT *parent_alloc);
+                             MEM_ROOT *parent_alloc) override;
   TABLE_READ_PLAN **first_ror; /* array of ptrs to plans for merged scans */
   TABLE_READ_PLAN **last_ror;  /* end of the above array */
   void trace_basic_info(PARAM *param,
-                        Json_writer_object *trace_object) const;
+                        Json_writer_object *trace_object) const override;
 };
 
 void TRP_ROR_UNION::trace_basic_info(PARAM *param,
@@ -2376,15 +2376,15 @@ class TRP_INDEX_INTERSECT : public TABLE_READ_PLAN
 {
 public:
   TRP_INDEX_INTERSECT() = default;                     /* Remove gcc warning */
-  virtual ~TRP_INDEX_INTERSECT() = default;            /* Remove gcc warning */
+  ~TRP_INDEX_INTERSECT() override = default;            /* Remove gcc warning */
   QUICK_SELECT_I *make_quick(PARAM *param, bool retrieve_full_rows,
-                             MEM_ROOT *parent_alloc);
+                             MEM_ROOT *parent_alloc) override;
   TRP_RANGE **range_scans; /* array of ptrs to plans of intersected scans */
   TRP_RANGE **range_scans_end; /* end of the array */
   /* keys whose scans are to be filtered by cpk conditions */
   key_map filtered_scans;
   void trace_basic_info(PARAM *param,
-                        Json_writer_object *trace_object) const;
+                        Json_writer_object *trace_object) const override;
 
 };
 
@@ -2413,13 +2413,13 @@ class TRP_INDEX_MERGE : public TABLE_READ_PLAN
 {
 public:
   TRP_INDEX_MERGE() = default;                        /* Remove gcc warning */
-  virtual ~TRP_INDEX_MERGE() = default;               /* Remove gcc warning */
+  ~TRP_INDEX_MERGE() override = default;               /* Remove gcc warning */
   QUICK_SELECT_I *make_quick(PARAM *param, bool retrieve_full_rows,
-                             MEM_ROOT *parent_alloc);
+                             MEM_ROOT *parent_alloc) override;
   TRP_RANGE **range_scans; /* array of ptrs to plans of merged scans */
   TRP_RANGE **range_scans_end; /* end of the array */
   void trace_basic_info(PARAM *param,
-                        Json_writer_object *trace_object) const;
+                        Json_writer_object *trace_object) const override;
 };
 
 void TRP_INDEX_MERGE::trace_basic_info(PARAM *param,
@@ -2481,13 +2481,13 @@ public:
       if (key_infix_len)
         memcpy(this->key_infix, key_infix_arg, key_infix_len);
     }
-  virtual ~TRP_GROUP_MIN_MAX() = default;             /* Remove gcc warning */
+  ~TRP_GROUP_MIN_MAX() override = default;             /* Remove gcc warning */
 
   QUICK_SELECT_I *make_quick(PARAM *param, bool retrieve_full_rows,
-                             MEM_ROOT *parent_alloc);
+                             MEM_ROOT *parent_alloc) override;
   void use_index_scan() { is_index_scan= TRUE; }
   void trace_basic_info(PARAM *param,
-                        Json_writer_object *trace_object) const;
+                        Json_writer_object *trace_object) const override;
 };
 
 

--- a/sql/opt_range.h
+++ b/sql/opt_range.h
@@ -1161,28 +1161,28 @@ public:
     { return new QUICK_RANGE_SELECT(thd, head, index, no_alloc, parent_alloc,
                                     create_error); }
   
-  void need_sorted_output();
-  int init();
-  int reset(void);
-  int get_next();
-  void range_end();
+  void need_sorted_output() override;
+  int init() override;
+  int reset(void) override;
+  int get_next() override;
+  void range_end() override;
   int get_next_prefix(uint prefix_length, uint group_key_parts, 
                       uchar *cur_prefix);
-  bool reverse_sorted() { return 0; }
-  bool unique_key_range();
-  int init_ror_merged_scan(bool reuse_handler, MEM_ROOT *alloc);
-  void save_last_pos()
+  bool reverse_sorted() override { return 0; }
+  bool unique_key_range() override;
+  int init_ror_merged_scan(bool reuse_handler, MEM_ROOT *alloc) override;
+  void save_last_pos() override
   { file->position(record); }
-  int get_type() { return QS_TYPE_RANGE; }
-  void add_keys_and_lengths(String *key_names, String *used_lengths);
-  Explain_quick_select *get_explain(MEM_ROOT *alloc);
+  int get_type() override { return QS_TYPE_RANGE; }
+  void add_keys_and_lengths(String *key_names, String *used_lengths) override;
+  Explain_quick_select *get_explain(MEM_ROOT *alloc) override;
 #ifndef DBUG_OFF
-  void dbug_dump(int indent, bool verbose);
+  void dbug_dump(int indent, bool verbose) override;
 #endif
-  virtual void replace_handler(handler *new_file) { file= new_file; }
-  QUICK_SELECT_I *make_reverse(uint used_key_parts_arg);
+  void replace_handler(handler *new_file) override { file= new_file; }
+  QUICK_SELECT_I *make_reverse(uint used_key_parts_arg) override;
 
-  virtual void add_used_key_part_to_set();
+  void add_used_key_part_to_set() override;
 
 private:
   /* Default copy ctor used by QUICK_SELECT_DESC */
@@ -1230,13 +1230,13 @@ public:
     :QUICK_RANGE_SELECT(thd, table, index_arg, no_alloc, parent_alloc,
     create_err)
     {};
-  virtual QUICK_RANGE_SELECT *clone(bool *create_error)
+  QUICK_RANGE_SELECT *clone(bool *create_error) override
     {
       DBUG_ASSERT(0);
       return new QUICK_RANGE_SELECT_GEOM(thd, head, index, no_alloc,
                                          parent_alloc, create_error);
     }
-  virtual int get_next();
+  int get_next() override;
 };
 
 
@@ -1312,16 +1312,16 @@ public:
   QUICK_INDEX_SORT_SELECT(THD *thd, TABLE *table);
   ~QUICK_INDEX_SORT_SELECT();
 
-  int  init();
-  void need_sorted_output() { DBUG_ASSERT(0); /* Can't do it */ }
-  int  reset(void);
-  bool reverse_sorted() { return false; }
-  bool unique_key_range() { return false; }
-  bool is_keys_used(const MY_BITMAP *fields);
+  int  init() override;
+  void need_sorted_output() override { DBUG_ASSERT(0); /* Can't do it */ }
+  int  reset(void) override;
+  bool reverse_sorted() override { return false; }
+  bool unique_key_range() override { return false; }
+  bool is_keys_used(const MY_BITMAP *fields) override;
 #ifndef DBUG_OFF
-  void dbug_dump(int indent, bool verbose);
+  void dbug_dump(int indent, bool verbose) override;
 #endif
-  Explain_quick_select *get_explain(MEM_ROOT *alloc);
+  Explain_quick_select *get_explain(MEM_ROOT *alloc) override;
 
   bool push_quick_back(QUICK_RANGE_SELECT *quick_sel_range);
 
@@ -1333,7 +1333,7 @@ public:
 
   MEM_ROOT alloc;
   THD *thd;
-  virtual bool is_valid()
+  bool is_valid() override
   {
     List_iterator_fast<QUICK_RANGE_SELECT> it(quick_selects);
     QUICK_RANGE_SELECT *quick;
@@ -1352,7 +1352,7 @@ public:
   /* used to get rows collected in Unique */
   READ_RECORD read_record;
 
-  virtual void add_used_key_part_to_set();
+  void add_used_key_part_to_set() override;
 };
 
 
@@ -1363,31 +1363,31 @@ private:
   /* true if this select is currently doing a clustered PK scan */
   bool  doing_pk_scan;
 protected:
-  int read_keys_and_merge();
+  int read_keys_and_merge() override;
 
 public:
   QUICK_INDEX_MERGE_SELECT(THD *thd_arg, TABLE *table)
     :QUICK_INDEX_SORT_SELECT(thd_arg, table) {}
 
-  int get_next();
-  int get_type() { return QS_TYPE_INDEX_MERGE; }
-  void add_keys_and_lengths(String *key_names, String *used_lengths);
+  int get_next() override;
+  int get_type() override { return QS_TYPE_INDEX_MERGE; }
+  void add_keys_and_lengths(String *key_names, String *used_lengths) override;
 };
 
 class QUICK_INDEX_INTERSECT_SELECT : public QUICK_INDEX_SORT_SELECT
 {
 protected:
-  int read_keys_and_merge();
+  int read_keys_and_merge() override;
 
 public:
   QUICK_INDEX_INTERSECT_SELECT(THD *thd_arg, TABLE *table)
     :QUICK_INDEX_SORT_SELECT(thd_arg, table) {}
 
   key_map filtered_scans;
-  int get_next();
-  int get_type() { return QS_TYPE_INDEX_INTERSECT; }
-  void add_keys_and_lengths(String *key_names, String *used_lengths);
-  Explain_quick_select *get_explain(MEM_ROOT *alloc);
+  int get_next() override;
+  int get_type() override { return QS_TYPE_INDEX_INTERSECT; }
+  void add_keys_and_lengths(String *key_names, String *used_lengths) override;
+  Explain_quick_select *get_explain(MEM_ROOT *alloc) override;
 };
 
 
@@ -1417,21 +1417,21 @@ public:
                              MEM_ROOT *parent_alloc);
   ~QUICK_ROR_INTERSECT_SELECT();
 
-  int  init();
-  void need_sorted_output() { DBUG_ASSERT(0); /* Can't do it */ }
-  int  reset(void);
-  int  get_next();
-  bool reverse_sorted() { return false; }
-  bool unique_key_range() { return false; }
-  int get_type() { return QS_TYPE_ROR_INTERSECT; }
-  void add_keys_and_lengths(String *key_names, String *used_lengths);
-  Explain_quick_select *get_explain(MEM_ROOT *alloc);
-  bool is_keys_used(const MY_BITMAP *fields);
-  void add_used_key_part_to_set();
+  int  init() override;
+  void need_sorted_output() override { DBUG_ASSERT(0); /* Can't do it */ }
+  int  reset(void) override;
+  int  get_next() override;
+  bool reverse_sorted() override { return false; }
+  bool unique_key_range() override { return false; }
+  int get_type() override { return QS_TYPE_ROR_INTERSECT; }
+  void add_keys_and_lengths(String *key_names, String *used_lengths) override;
+  Explain_quick_select *get_explain(MEM_ROOT *alloc) override;
+  bool is_keys_used(const MY_BITMAP *fields) override;
+  void add_used_key_part_to_set() override;
 #ifndef DBUG_OFF
-  void dbug_dump(int indent, bool verbose);
+  void dbug_dump(int indent, bool verbose) override;
 #endif
-  int init_ror_merged_scan(bool reuse_handler, MEM_ROOT *alloc);
+  int init_ror_merged_scan(bool reuse_handler, MEM_ROOT *alloc) override;
   bool push_quick_back(MEM_ROOT *alloc, QUICK_RANGE_SELECT *quick_sel_range);
 
   class QUICK_SELECT_WITH_RECORD : public Sql_alloc
@@ -1448,7 +1448,7 @@ public:
   */
   List<QUICK_SELECT_WITH_RECORD> quick_selects;
 
-  virtual bool is_valid()
+  bool is_valid() override
   {
     List_iterator_fast<QUICK_SELECT_WITH_RECORD> it(quick_selects);
     QUICK_SELECT_WITH_RECORD *quick;
@@ -1497,26 +1497,26 @@ public:
   QUICK_ROR_UNION_SELECT(THD *thd, TABLE *table);
   ~QUICK_ROR_UNION_SELECT();
 
-  int  init();
-  void need_sorted_output() { DBUG_ASSERT(0); /* Can't do it */ }
-  int  reset(void);
-  int  get_next();
-  bool reverse_sorted() { return false; }
-  bool unique_key_range() { return false; }
-  int get_type() { return QS_TYPE_ROR_UNION; }
-  void add_keys_and_lengths(String *key_names, String *used_lengths);
-  Explain_quick_select *get_explain(MEM_ROOT *alloc);
-  bool is_keys_used(const MY_BITMAP *fields);
-  void add_used_key_part_to_set();
+  int  init() override;
+  void need_sorted_output() override { DBUG_ASSERT(0); /* Can't do it */ }
+  int  reset(void) override;
+  int  get_next() override;
+  bool reverse_sorted() override { return false; }
+  bool unique_key_range() override { return false; }
+  int get_type() override { return QS_TYPE_ROR_UNION; }
+  void add_keys_and_lengths(String *key_names, String *used_lengths) override;
+  Explain_quick_select *get_explain(MEM_ROOT *alloc) override;
+  bool is_keys_used(const MY_BITMAP *fields) override;
+  void add_used_key_part_to_set() override;
 #ifndef DBUG_OFF
-  void dbug_dump(int indent, bool verbose);
+  void dbug_dump(int indent, bool verbose) override;
 #endif
 
   bool push_quick_back(QUICK_SELECT_I *quick_sel_range);
 
   List<QUICK_SELECT_I> quick_selects; /* Merged quick selects */
 
-  virtual bool is_valid()
+  bool is_valid() override
   {
     List_iterator_fast<QUICK_SELECT_I> it(quick_selects);
     QUICK_SELECT_I *quick;
@@ -1642,21 +1642,21 @@ public:
   void update_key_stat();
   void adjust_prefix_ranges();
   bool alloc_buffers();
-  int init();
-  void need_sorted_output() { /* always do it */ }
-  int reset();
-  int get_next();
-  bool reverse_sorted() { return false; }
-  bool unique_key_range() { return false; }
-  int get_type() { return QS_TYPE_GROUP_MIN_MAX; }
-  void add_keys_and_lengths(String *key_names, String *used_lengths);
-  void add_used_key_part_to_set();
+  int init() override;
+  void need_sorted_output() override { /* always do it */ }
+  int reset() override;
+  int get_next() override;
+  bool reverse_sorted() override { return false; }
+  bool unique_key_range() override { return false; }
+  int get_type() override { return QS_TYPE_GROUP_MIN_MAX; }
+  void add_keys_and_lengths(String *key_names, String *used_lengths) override;
+  void add_used_key_part_to_set() override;
 #ifndef DBUG_OFF
-  void dbug_dump(int indent, bool verbose);
+  void dbug_dump(int indent, bool verbose) override;
 #endif
   bool is_agg_distinct() { return have_agg_distinct; }
   bool loose_scan_is_scanning() { return is_index_scan; }
-  Explain_quick_select *get_explain(MEM_ROOT *alloc);
+  Explain_quick_select *get_explain(MEM_ROOT *alloc) override;
 };
 
 
@@ -1664,18 +1664,18 @@ class QUICK_SELECT_DESC: public QUICK_RANGE_SELECT
 {
 public:
   QUICK_SELECT_DESC(QUICK_RANGE_SELECT *q, uint used_key_parts);
-  virtual QUICK_RANGE_SELECT *clone(bool *create_error)
+  QUICK_RANGE_SELECT *clone(bool *create_error) override
     { DBUG_ASSERT(0); return new QUICK_SELECT_DESC(this, used_key_parts); }
-  int get_next();
-  bool reverse_sorted() { return 1; }
-  int get_type() { return QS_TYPE_RANGE_DESC; }
-  QUICK_SELECT_I *make_reverse(uint used_key_parts_arg)
+  int get_next() override;
+  bool reverse_sorted() override { return 1; }
+  int get_type() override { return QS_TYPE_RANGE_DESC; }
+  QUICK_SELECT_I *make_reverse(uint used_key_parts_arg) override
   {
     return this; // is already reverse sorted
   }
 private:
   bool range_reads_after_key(QUICK_RANGE *range);
-  int reset(void) { rev_it.rewind(); return QUICK_RANGE_SELECT::reset(); }
+  int reset(void) override { rev_it.rewind(); return QUICK_RANGE_SELECT::reset(); }
   List<QUICK_RANGE> rev_ranges;
   List_iterator<QUICK_RANGE> rev_it;
   uint used_key_parts;
@@ -1774,12 +1774,12 @@ public:
       QUICK_RANGE_SELECT (thd, table, key, 1, NULL, create_err) 
   { (void) init(); }
   ~FT_SELECT() { file->ft_end(); }
-  virtual QUICK_RANGE_SELECT *clone(bool *create_error)
+  QUICK_RANGE_SELECT *clone(bool *create_error) override
     { DBUG_ASSERT(0); return new FT_SELECT(thd, head, index, create_error); }
-  int init() { return file->ft_init(); }
-  int reset() { return 0; }
-  int get_next() { return file->ha_ft_read(record); }
-  int get_type() { return QS_TYPE_FULLTEXT; }
+  int init() override { return file->ft_init(); }
+  int reset() override { return 0; }
+  int get_next() override { return file->ha_ft_read(record); }
+  int get_type() override { return QS_TYPE_FULLTEXT; }
 };
 
 FT_SELECT *get_ft_select(THD *thd, TABLE *table, uint key);

--- a/sql/opt_subselect.cc
+++ b/sql/opt_subselect.cc
@@ -5837,7 +5837,7 @@ public:
   select_value_catcher(THD *thd_arg, Item_subselect *item_arg):
     select_subselect(thd_arg, item_arg)
   {}
-  int send_data(List<Item> &items);
+  int send_data(List<Item> &items) override;
   int setup(List<Item> *items);
   bool assigned;  /* TRUE <=> we've caught a value */
   uint n_elements; /* How many elements we get */

--- a/sql/opt_table_elimination.cc
+++ b/sql/opt_table_elimination.cc
@@ -251,9 +251,9 @@ public:
   Field *field; /* Field this object is representing */
   
   /* Iteration over unbound modules that are our dependencies */
-  Iterator init_unbound_modules_iter(char *buf);
+  Iterator init_unbound_modules_iter(char *buf) override;
   Dep_module* get_next_unbound_module(Dep_analysis_context *dac, 
-                                      Iterator iter);
+                                      Iterator iter) override;
   
   void make_unbound_modules_iter_skip_keys(Iterator iter);
   
@@ -310,9 +310,9 @@ public:
   Dep_module_key *keys; /* Ordered list of Unique keys in this table */
 
   /* Iteration over unbound modules that are our dependencies */
-  Iterator init_unbound_modules_iter(char *buf);
+  Iterator init_unbound_modules_iter(char *buf) override;
   Dep_module* get_next_unbound_module(Dep_analysis_context *dac, 
-                                      Iterator iter);
+                                      Iterator iter) override;
   static const size_t iterator_size;
 private:
   class Module_iter
@@ -394,8 +394,8 @@ public:
   /* Used during condition analysis only, similar to KEYUSE::level */
   uint level;
 
-  Iterator init_unbound_values_iter(char *buf);
-  Dep_value* get_next_unbound_value(Dep_analysis_context *dac, Iterator iter);
+  Iterator init_unbound_values_iter(char *buf) override;
+  Dep_value* get_next_unbound_value(Dep_analysis_context *dac, Iterator iter) override;
   static const size_t iterator_size;
 private:
   class Value_iter
@@ -429,8 +429,8 @@ public:
   /* Unique keys form a linked list, ordered by keyno */
   Dep_module_key *next_table_key;
   
-  Iterator init_unbound_values_iter(char *buf);
-  Dep_value* get_next_unbound_value(Dep_analysis_context *dac, Iterator iter);
+  Iterator init_unbound_values_iter(char *buf) override;
+  Dep_value* get_next_unbound_value(Dep_analysis_context *dac, Iterator iter) override;
   static const size_t iterator_size;
 private:
   class Value_iter
@@ -459,18 +459,18 @@ public:
   {
     unbound_args= n_children;
   }
-  bool is_final() { return TRUE; }
+  bool is_final() override { return TRUE; }
   /* 
     This is the goal module, so the running wave algorithm should terminate
     once it sees that this module is applicable and should never try to apply
     it, hence no use for unbound value iterator implementation.
   */
-  Iterator init_unbound_values_iter(char *buf)
+  Iterator init_unbound_values_iter(char *buf) override
   { 
     DBUG_ASSERT(0); 
     return NULL;
   }
-  Dep_value* get_next_unbound_value(Dep_analysis_context *dac, Iterator iter)
+  Dep_value* get_next_unbound_value(Dep_analysis_context *dac, Iterator iter) override
   {
     DBUG_ASSERT(0); 
     return NULL;
@@ -966,7 +966,7 @@ public:
   Field_dependency_recorder(Dep_analysis_context *ctx_arg): ctx(ctx_arg)
   {}
   
-  void visit_field(Item_field *item)
+  void visit_field(Item_field *item) override
   {
     Field *field= item->field;
     Dep_value_table *tbl_dep;

--- a/sql/parse_file.h
+++ b/sql/parse_file.h
@@ -68,8 +68,8 @@ class File_parser_dummy_hook: public Unknown_key_hook
 {
 public:
   File_parser_dummy_hook() = default;                 /* Remove gcc warning */
-  virtual bool process_unknown_string(const char *&unknown_key, uchar* base,
-                                      MEM_ROOT *mem_root, const char *end);
+  bool process_unknown_string(const char *&unknown_key, uchar* base,
+                              MEM_ROOT *mem_root, const char *end) override;
 };
 
 extern File_parser_dummy_hook file_parser_dummy_hook;

--- a/sql/procedure.h
+++ b/sql/procedure.h
@@ -44,9 +44,9 @@ public:
      this->name.str=    name_par;
      this->name.length= strlen(name_par);
   }
-  enum Type type() const { return Item::PROC_ITEM; }
+  enum Type type() const override { return Item::PROC_ITEM; }
   Field *create_tmp_field_ex(MEM_ROOT *root, TABLE *table, Tmp_field_src *src,
-                             const Tmp_field_param *param)
+                             const Tmp_field_param *param) override
   {
     /*
       We can get to here when using a CURSOR for a query with PROCEDURE:
@@ -58,19 +58,19 @@ public:
   virtual void set(double nr)=0;
   virtual void set(const char *str,uint length,CHARSET_INFO *cs)=0;
   virtual void set(longlong nr)=0;
-  const Type_handler *type_handler() const=0;
+  const Type_handler *type_handler() const override=0;
   void set(const char *str) { set(str,(uint) strlen(str), default_charset()); }
   unsigned int size_of() { return sizeof(*this);}
-  bool check_vcol_func_processor(void *arg)
+  bool check_vcol_func_processor(void *arg) override
   {
     DBUG_ASSERT(0); // impossible
     return mark_unsupported_function("proc", arg, VCOL_IMPOSSIBLE);
   }
-  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate)
+  bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
-  Item* get_copy(THD *thd) { return 0; }
+  Item* get_copy(THD *thd) override { return 0; }
 };
 
 class Item_proc_real :public Item_proc
@@ -82,23 +82,23 @@ public:
   {
      decimals=dec; max_length=float_length(dec);
   }
-  const Type_handler *type_handler() const { return &type_handler_double; }
-  void set(double nr) { value=nr; }
-  void set(longlong nr) { value=(double) nr; }
-  void set(const char *str,uint length,CHARSET_INFO *cs)
+  const Type_handler *type_handler() const override { return &type_handler_double; }
+  void set(double nr) override { value=nr; }
+  void set(longlong nr) override { value=(double) nr; }
+  void set(const char *str,uint length,CHARSET_INFO *cs) override
   {
     int err_not_used;
     char *end_not_used;
     value= cs->strntod((char*) str,length, &end_not_used, &err_not_used);
   }
-  double val_real() { return value; }
-  longlong val_int() { return (longlong) value; }
-  String *val_str(String *s)
+  double val_real() override { return value; }
+  longlong val_int() override { return (longlong) value; }
+  String *val_str(String *s) override
   {
     s->set_real(value,decimals,default_charset());
     return s;
   }
-  my_decimal *val_decimal(my_decimal *);
+  my_decimal *val_decimal(my_decimal *) override;
   unsigned int size_of() { return sizeof(*this);}
 };
 
@@ -108,20 +108,20 @@ class Item_proc_int :public Item_proc
 public:
   Item_proc_int(THD *thd, const char *name_par): Item_proc(thd, name_par)
   { max_length=11; }
-  const Type_handler *type_handler() const
+  const Type_handler *type_handler() const override
   {
     if (unsigned_flag)
       return &type_handler_ulonglong;
     return &type_handler_slonglong;
   }
-  void set(double nr) { value=(longlong) nr; }
-  void set(longlong nr) { value=nr; }
-  void set(const char *str,uint length, CHARSET_INFO *cs)
+  void set(double nr) override { value=(longlong) nr; }
+  void set(longlong nr) override { value=nr; }
+  void set(const char *str,uint length, CHARSET_INFO *cs) override
   { int err; value= cs->strntoll(str,length,10,NULL,&err); }
-  double val_real() { return (double) value; }
-  longlong val_int() { return value; }
-  String *val_str(String *s) { s->set(value, default_charset()); return s; }
-  my_decimal *val_decimal(my_decimal *);
+  double val_real() override { return (double) value; }
+  longlong val_int() override { return value; }
+  String *val_str(String *s) override { s->set(value, default_charset()); return s; }
+  my_decimal *val_decimal(my_decimal *) override;
   unsigned int size_of() { return sizeof(*this);}
 };
 
@@ -131,12 +131,12 @@ class Item_proc_string :public Item_proc
 public:
   Item_proc_string(THD *thd, const char *name_par, uint length):
     Item_proc(thd, name_par) { this->max_length=length; }
-  const Type_handler *type_handler() const { return &type_handler_varchar; }
-  void set(double nr) { str_value.set_real(nr, 2, default_charset()); }
-  void set(longlong nr) { str_value.set(nr, default_charset()); }
-  void set(const char *str, uint length, CHARSET_INFO *cs)
+  const Type_handler *type_handler() const override { return &type_handler_varchar; }
+  void set(double nr) override { str_value.set_real(nr, 2, default_charset()); }
+  void set(longlong nr) override { str_value.set(nr, default_charset()); }
+  void set(const char *str, uint length, CHARSET_INFO *cs) override
   { str_value.copy(str,length,cs); }
-  double val_real()
+  double val_real() override
   {
     int err_not_used;
     char *end_not_used;
@@ -144,17 +144,17 @@ public:
     return cs->strntod((char*) str_value.ptr(), str_value.length(),
 		       &end_not_used, &err_not_used);
   }
-  longlong val_int()
+  longlong val_int() override
   { 
     int err;
     CHARSET_INFO *cs=str_value.charset();
     return cs->strntoll(str_value.ptr(),str_value.length(),10,NULL,&err);
   }
-  String *val_str(String*)
+  String *val_str(String*) override
   {
     return null_value ? (String*) 0 : (String*) &str_value;
   }
-  my_decimal *val_decimal(my_decimal *);
+  my_decimal *val_decimal(my_decimal *) override;
   unsigned int size_of() { return sizeof(*this);}  
 };
 

--- a/sql/rowid_filter.h
+++ b/sql/rowid_filter.h
@@ -274,9 +274,9 @@ public:
 
   ~Range_rowid_filter();
 
-  build_return_code build();
+  build_return_code build() override;
 
-  bool check(char *elem)
+  bool check(char *elem) override
   {
     if (container->is_empty())
       return false;
@@ -372,16 +372,16 @@ public:
   Rowid_filter_sorted_array(uint elems, uint elem_size)
     : refpos_container(elems, elem_size), is_checked(false) {}
 
-  Rowid_filter_container_type get_type()
+  Rowid_filter_container_type get_type() override
   { return SORTED_ARRAY_CONTAINER; }
 
-  bool alloc() { return refpos_container.alloc(); }
+  bool alloc() override { return refpos_container.alloc(); }
 
-  bool add(void *ctxt, char *elem) { return refpos_container.add(elem); }
+  bool add(void *ctxt, char *elem) override { return refpos_container.add(elem); }
 
-  bool check(void *ctxt, char *elem);
+  bool check(void *ctxt, char *elem) override;
 
-  bool is_empty() { return refpos_container.is_empty(); }
+  bool is_empty() override { return refpos_container.is_empty(); }
 };
 
 /**

--- a/sql/session_tracker.h
+++ b/sql/session_tracker.h
@@ -210,9 +210,9 @@ class Session_sysvars_tracker: public State_tracker
 public:
   void init(THD *thd);
   void deinit(THD *thd);
-  bool enable(THD *thd);
-  bool update(THD *thd, set_var *var);
-  bool store(THD *thd, String *buf);
+  bool enable(THD *thd) override;
+  bool update(THD *thd, set_var *var) override;
+  bool store(THD *thd, String *buf) override;
   void mark_as_changed(THD *thd, const sys_var *var);
   void deinit() { orig_list.deinit(); }
   /* callback */
@@ -237,8 +237,8 @@ bool sysvartrack_global_update(THD *thd, char *str, size_t len);
 class Current_schema_tracker: public State_tracker
 {
 public:
-  bool update(THD *thd, set_var *var);
-  bool store(THD *thd, String *buf);
+  bool update(THD *thd, set_var *var) override;
+  bool store(THD *thd, String *buf) override;
 };
 
 
@@ -259,8 +259,8 @@ public:
 class Session_state_change_tracker: public State_tracker
 {
 public:
-  bool update(THD *thd, set_var *var);
-  bool store(THD *thd, String *buf);
+  bool update(THD *thd, set_var *var) override;
+  bool store(THD *thd, String *buf) override;
 };
 
 
@@ -329,7 +329,7 @@ class Transaction_state_tracker : public State_tracker
   enum_tx_state calc_trx_state(THD *thd, thr_lock_type l, bool has_trx);
 public:
 
-  bool enable(THD *thd)
+  bool enable(THD *thd) override
   {
     m_enabled= false;
     tx_changed= TX_CHG_NONE;
@@ -340,8 +340,8 @@ public:
     return State_tracker::enable(thd);
   }
 
-  bool update(THD *thd, set_var *var);
-  bool store(THD *thd, String *buf);
+  bool update(THD *thd, set_var *var) override;
+  bool store(THD *thd, String *buf) override;
 
   /** Change transaction characteristics */
   void set_read_flags(THD *thd, enum enum_tx_read_flags flags);

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -326,11 +326,11 @@ public:
 
   set_var(THD *thd, enum_var_type type_arg, sys_var *var_arg,
           const LEX_CSTRING *base_name_arg, Item *value_arg);
-  virtual bool is_system() { return 1; }
-  int check(THD *thd);
-  int update(THD *thd);
-  int light_check(THD *thd);
-  virtual bool is_var_optimizer_trace() const
+  bool is_system() override { return 1; }
+  int check(THD *thd) override;
+  int update(THD *thd) override;
+  int light_check(THD *thd) override;
+  bool is_var_optimizer_trace() const override
   {
     extern sys_var *Sys_optimizer_trace_ptr;
     return var == Sys_optimizer_trace_ptr;
@@ -346,9 +346,9 @@ public:
   set_var_user(Item_func_set_user_var *item)
     :user_var_item(item)
   {}
-  int check(THD *thd);
-  int update(THD *thd);
-  int light_check(THD *thd);
+  int check(THD *thd) override;
+  int update(THD *thd) override;
+  int light_check(THD *thd) override;
 };
 
 /* For SET PASSWORD */
@@ -359,8 +359,8 @@ class set_var_password: public set_var_base
 public:
   set_var_password(LEX_USER *user_arg) :user(user_arg)
   {}
-  int check(THD *thd);
-  int update(THD *thd);
+  int check(THD *thd) override;
+  int update(THD *thd) override;
 };
 
 /* For SET ROLE */
@@ -371,8 +371,8 @@ class set_var_role: public set_var_base
   privilege_t access;
 public:
   set_var_role(LEX_CSTRING role_arg) : role(role_arg), access(NO_ACL) {}
-  int check(THD *thd);
-  int update(THD *thd);
+  int check(THD *thd) override;
+  int update(THD *thd) override;
 };
 
 /* For SET DEFAULT ROLE */
@@ -385,8 +385,8 @@ class set_var_default_role: public set_var_base
 public:
   set_var_default_role(LEX_USER *user_arg, LEX_CSTRING role_arg) :
     user(user_arg), role(role_arg) {}
-  int check(THD *thd);
-  int update(THD *thd);
+  int check(THD *thd) override;
+  int update(THD *thd) override;
 };
 
 /* For SET NAMES and SET CHARACTER SET */
@@ -404,8 +404,8 @@ public:
      character_set_results(result_coll_arg),
      collation_connection(connection_coll_arg)
   {}
-  int check(THD *thd);
-  int update(THD *thd);
+  int check(THD *thd) override;
+  int update(THD *thd) override;
 };
 
 

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -255,7 +255,7 @@ public:
   load_from_db(THD *thd, const Database_qualified_name *name, TABLE *proc_tbl);
 
 public:
-  virtual Stored_program_creation_ctx *clone(MEM_ROOT *mem_root)
+  Stored_program_creation_ctx *clone(MEM_ROOT *mem_root) override
   {
     return new (mem_root) Stored_routine_creation_ctx(m_client_cs,
                                                       m_connection_cl,
@@ -263,7 +263,7 @@ public:
   }
 
 protected:
-  virtual Object_creation_ctx *create_backup_ctx(THD *thd) const
+  Object_creation_ctx *create_backup_ctx(THD *thd) const override
   {
     DBUG_ENTER("Stored_routine_creation_ctx::create_backup_ctx");
     DBUG_RETURN(new Stored_routine_creation_ctx(thd));
@@ -428,7 +428,7 @@ public:
   Proc_table_intact() : m_print_once(TRUE) { has_keys= TRUE; }
 
 protected:
-  void report_error(uint code, const char *fmt, ...);
+  void report_error(uint code, const char *fmt, ...) override;
 };
 
 
@@ -804,12 +804,12 @@ Sp_handler::db_find_and_cache_routine(THD *thd,
 struct Silence_deprecated_warning : public Internal_error_handler
 {
 public:
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                 uint sql_errno,
                                 const char* sqlstate,
                                 Sql_condition::enum_warning_level *level,
                                 const char* msg,
-                                Sql_condition ** cond_hdl);
+                                Sql_condition ** cond_hdl) override;
 };
 
 bool
@@ -899,12 +899,12 @@ public:
     :m_error_caught(false)
   {}
 
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                 uint sql_errno,
                                 const char* sqlstate,
                                 Sql_condition::enum_warning_level *level,
                                 const char* message,
-                                Sql_condition ** cond_hdl);
+                                Sql_condition ** cond_hdl) override;
 
   bool error_caught() const { return m_error_caught; }
 
@@ -1717,7 +1717,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl)
+                        Sql_condition ** cond_hdl) override
   {
     if (sql_errno == ER_NO_SUCH_TABLE ||
         sql_errno == ER_NO_SUCH_TABLE_IN_ENGINE ||

--- a/sql/sp.h
+++ b/sql/sp.h
@@ -249,33 +249,33 @@ public:
 class Sp_handler_procedure: public Sp_handler
 {
 public:
-  enum_sp_type type() const { return SP_TYPE_PROCEDURE; }
-  LEX_CSTRING type_lex_cstring() const
+  enum_sp_type type() const override { return SP_TYPE_PROCEDURE; }
+  LEX_CSTRING type_lex_cstring() const override
   {
     static LEX_CSTRING m_type_str= { STRING_WITH_LEN("PROCEDURE")};
     return m_type_str;
   }
-  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const;
-  const char *show_create_routine_col1_caption() const
+  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const override;
+  const char *show_create_routine_col1_caption() const override
   {
     return "Procedure";
   }
-  const char *show_create_routine_col3_caption() const
+  const char *show_create_routine_col3_caption() const override
   {
     return "Create Procedure";
   }
-  MDL_key::enum_mdl_namespace get_mdl_type() const
+  MDL_key::enum_mdl_namespace get_mdl_type() const override
   {
     return MDL_key::PROCEDURE;
   }
-  const Sp_handler *package_routine_handler() const;
-  sp_cache **get_cache(THD *) const;
+  const Sp_handler *package_routine_handler() const override;
+  sp_cache **get_cache(THD *) const override;
 #ifndef NO_EMBEDDED_ACCESS_CHECKS
-  HASH *get_priv_hash() const;
+  HASH *get_priv_hash() const override;
 #endif
-  ulong recursion_depth(THD *thd) const;
-  void recursion_level_error(THD *thd, const sp_head *sp) const;
-  bool add_instr_preturn(THD *thd, sp_head *sp, sp_pcontext *spcont) const;
+  ulong recursion_depth(THD *thd) const override;
+  void recursion_level_error(THD *thd, const sp_head *sp) const override;
+  bool add_instr_preturn(THD *thd, sp_head *sp, sp_pcontext *spcont) const override;
 };
 
 
@@ -283,13 +283,13 @@ class Sp_handler_package_procedure: public Sp_handler_procedure
 {
 public:
   int sp_cache_routine(THD *thd, const Database_qualified_name *name,
-                       sp_head **sp) const
+                       sp_head **sp) const override
   {
     return sp_cache_package_routine(thd, name, sp);
   }
   sp_head *sp_find_routine(THD *thd,
                            const Database_qualified_name *name,
-                           bool cache_only) const
+                           bool cache_only) const override
   {
     return sp_find_package_routine(thd, name, cache_only);
   }
@@ -299,32 +299,32 @@ public:
 class Sp_handler_function: public Sp_handler
 {
 public:
-  enum_sp_type type() const { return SP_TYPE_FUNCTION; }
-  LEX_CSTRING type_lex_cstring() const
+  enum_sp_type type() const override { return SP_TYPE_FUNCTION; }
+  LEX_CSTRING type_lex_cstring() const override
   {
     static LEX_CSTRING m_type_str= { STRING_WITH_LEN("FUNCTION")};
     return m_type_str;
   }
-  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const;
-  const char *show_create_routine_col1_caption() const
+  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const override;
+  const char *show_create_routine_col1_caption() const override
   {
     return "Function";
   }
-  const char *show_create_routine_col3_caption() const
+  const char *show_create_routine_col3_caption() const override
   {
     return "Create Function";
   }
-  MDL_key::enum_mdl_namespace get_mdl_type() const
+  MDL_key::enum_mdl_namespace get_mdl_type() const override
   {
     return MDL_key::FUNCTION;
   }
-  const Sp_handler *package_routine_handler() const;
-  sp_cache **get_cache(THD *) const;
+  const Sp_handler *package_routine_handler() const override;
+  sp_cache **get_cache(THD *) const override;
 #ifndef NO_EMBEDDED_ACCESS_CHECKS
-  HASH *get_priv_hash() const;
+  HASH *get_priv_hash() const override;
 #endif
   bool add_instr_freturn(THD *thd, sp_head *sp, sp_pcontext *spcont,
-                         Item *item, LEX *lex) const;
+                         Item *item, LEX *lex) const override;
 };
 
 
@@ -332,13 +332,13 @@ class Sp_handler_package_function: public Sp_handler_function
 {
 public:
   int sp_cache_routine(THD *thd, const Database_qualified_name *name,
-                       sp_head **sp) const
+                       sp_head **sp) const override
   {
     return sp_cache_package_routine(thd, name, sp);
   }
   sp_head *sp_find_routine(THD *thd,
                            const Database_qualified_name *name,
-                           bool cache_only) const
+                           bool cache_only) const override
   {
     return sp_find_package_routine(thd, name, cache_only);
   }
@@ -357,7 +357,7 @@ public:
                       const st_sp_chistics &chistics,
                       const AUTHID &definer,
                       const DDL_options_st ddl_options,
-                      sql_mode_t sql_mode) const;
+                      sql_mode_t sql_mode) const override;
 };
 
 
@@ -366,34 +366,34 @@ class Sp_handler_package_spec: public Sp_handler_package
 public: // TODO: make it private or protected
   int sp_find_and_drop_routine(THD *thd, TABLE *table,
                                const Database_qualified_name *name)
-                               const;
+                               const override;
 public:
-  enum_sp_type type() const { return SP_TYPE_PACKAGE; }
-  LEX_CSTRING type_lex_cstring() const
+  enum_sp_type type() const override { return SP_TYPE_PACKAGE; }
+  LEX_CSTRING type_lex_cstring() const override
   {
     static LEX_CSTRING m_type_str= {STRING_WITH_LEN("PACKAGE")};
     return m_type_str;
   }
-  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const
+  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const override
   {
     static LEX_CSTRING m_empty_body= {STRING_WITH_LEN("BEGIN END")};
     return m_empty_body;
   }
-  const char *show_create_routine_col1_caption() const
+  const char *show_create_routine_col1_caption() const override
   {
     return "Package";
   }
-  const char *show_create_routine_col3_caption() const
+  const char *show_create_routine_col3_caption() const override
   {
     return "Create Package";
   }
-  MDL_key::enum_mdl_namespace get_mdl_type() const
+  MDL_key::enum_mdl_namespace get_mdl_type() const override
   {
     return MDL_key::PACKAGE_BODY;
   }
-  sp_cache **get_cache(THD *) const;
+  sp_cache **get_cache(THD *) const override;
 #ifndef NO_EMBEDDED_ACCESS_CHECKS
-  HASH *get_priv_hash() const;
+  HASH *get_priv_hash() const override;
 #endif
 };
 
@@ -401,32 +401,32 @@ public:
 class Sp_handler_package_body: public Sp_handler_package
 {
 public:
-  enum_sp_type type() const { return SP_TYPE_PACKAGE_BODY; }
-  LEX_CSTRING type_lex_cstring() const
+  enum_sp_type type() const override { return SP_TYPE_PACKAGE_BODY; }
+  LEX_CSTRING type_lex_cstring() const override
   {
     static LEX_CSTRING m_type_str= {STRING_WITH_LEN("PACKAGE BODY")};
     return m_type_str;
   }
-  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const
+  LEX_CSTRING empty_body_lex_cstring(sql_mode_t mode) const override
   {
     static LEX_CSTRING m_empty_body= {STRING_WITH_LEN("BEGIN END")};
     return m_empty_body;
   }
-  const char *show_create_routine_col1_caption() const
+  const char *show_create_routine_col1_caption() const override
   {
     return "Package body";
   }
-  const char *show_create_routine_col3_caption() const
+  const char *show_create_routine_col3_caption() const override
   {
     return "Create Package Body";
   }
-  MDL_key::enum_mdl_namespace get_mdl_type() const
+  MDL_key::enum_mdl_namespace get_mdl_type() const override
   {
     return MDL_key::PACKAGE_BODY;
   }
-  sp_cache **get_cache(THD *) const;
+  sp_cache **get_cache(THD *) const override;
 #ifndef NO_EMBEDDED_ACCESS_CHECKS
-  HASH *get_priv_hash() const;
+  HASH *get_priv_hash() const override;
 #endif
 };
 
@@ -434,18 +434,18 @@ public:
 class Sp_handler_trigger: public Sp_handler
 {
 public:
-  enum_sp_type type() const { return SP_TYPE_TRIGGER; }
-  LEX_CSTRING type_lex_cstring() const
+  enum_sp_type type() const override { return SP_TYPE_TRIGGER; }
+  LEX_CSTRING type_lex_cstring() const override
   {
     static LEX_CSTRING m_type_str= { STRING_WITH_LEN("TRIGGER")};
     return m_type_str;
   }
-  MDL_key::enum_mdl_namespace get_mdl_type() const
+  MDL_key::enum_mdl_namespace get_mdl_type() const override
   {
     DBUG_ASSERT(0);
     return MDL_key::TRIGGER;
   }
-  const Sp_handler *sp_handler_mysql_proc() const { return NULL; }
+  const Sp_handler *sp_handler_mysql_proc() const override { return NULL; }
 };
 
 

--- a/sql/sp_head.h
+++ b/sql/sp_head.h
@@ -87,7 +87,7 @@ protected:
   { }
 
 protected:
-  virtual void change_env(THD *thd) const
+  void change_env(THD *thd) const override
   {
     thd->variables.collation_database= m_db_cl;
 
@@ -1044,9 +1044,9 @@ public:
     return m_routine_implementations.check_dup_qualified(lex->sphead) ||
            m_routine_implementations.push_back(lex, &main_mem_root);
   }
-  sp_package *get_package() { return this; }
-  void init_psi_share();
-  bool is_invoked() const
+  sp_package *get_package() override { return this; }
+  void init_psi_share() override;
+  bool is_invoked() const override
   {
     /*
       Cannot flush a package out of the SP cache when:
@@ -1081,8 +1081,8 @@ public:
     Query_arena(thd->lex->sphead->get_main_mem_root(), STMT_INITIALIZED_FOR_SP)
   { }
   ~sp_lex_cursor() { free_items(); }
-  void cleanup_stmt() { }
-  Query_arena *query_arena() { return this; }
+  void cleanup_stmt() override { }
+  Query_arena *query_arena() override { return this; }
   bool validate()
   {
     DBUG_ASSERT(sql_command == SQLCOM_SELECT);
@@ -1358,18 +1358,18 @@ public:
 
   virtual ~sp_instr_stmt() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 private:
 
   sp_lex_keeper m_lex_keeper;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 
 }; // class sp_instr_stmt : public sp_instr
@@ -1393,11 +1393,11 @@ public:
 
   virtual ~sp_instr_set() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 protected:
   sp_rcontext *get_rcontext(THD *thd) const;
@@ -1407,7 +1407,7 @@ protected:
   sp_lex_keeper m_lex_keeper;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_set : public sp_instr
 
@@ -1436,9 +1436,9 @@ public:
 
   virtual ~sp_instr_set_row_field() = default;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 }; // class sp_instr_set_field : public sp_instr_set
 
 
@@ -1478,9 +1478,9 @@ public:
 
   virtual ~sp_instr_set_row_field_by_name() = default;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 }; // class sp_instr_set_field_by_name : public sp_instr_set
 
 
@@ -1504,11 +1504,11 @@ public:
 
   virtual ~sp_instr_set_trigger_field() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 private:
   Item_trigger_field *trigger_field;
@@ -1516,7 +1516,7 @@ private:
   sp_lex_keeper m_lex_keeper;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_trigger_field : public sp_instr
 
@@ -1550,7 +1550,7 @@ public:
   virtual void set_destination(uint old_dest, uint new_dest)
     = 0;
 
-  virtual uint get_cont_dest() const;
+  uint get_cont_dest() const override;
 
 protected:
 
@@ -1576,17 +1576,17 @@ public:
 
   virtual ~sp_instr_jump() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads);
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override;
 
-  virtual uint opt_shortcut_jump(sp_head *sp, sp_instr *start);
+  uint opt_shortcut_jump(sp_head *sp, sp_instr *start) override;
 
-  virtual void opt_move(uint dst, List<sp_instr> *ibp);
+  void opt_move(uint dst, List<sp_instr> *ibp) override;
 
-  virtual void backpatch(uint dest, sp_pcontext *dst_ctx)
+  void backpatch(uint dest, sp_pcontext *dst_ctx) override
   {
     /* Calling backpatch twice is a logic flaw in jump resolution. */
     DBUG_ASSERT(m_dest == 0);
@@ -1596,14 +1596,14 @@ public:
   /**
     Update the destination; used by the optimizer.
   */
-  virtual void set_destination(uint old_dest, uint new_dest)
+  void set_destination(uint old_dest, uint new_dest) override
   {
     if (m_dest == old_dest)
       m_dest= new_dest;
   }
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_jump : public sp_instr_opt_meta
 
@@ -1627,23 +1627,23 @@ public:
 
   virtual ~sp_instr_jump_if_not() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads);
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override;
 
   /** Override sp_instr_jump's shortcut; we stop here */
-  virtual uint opt_shortcut_jump(sp_head *sp, sp_instr *start)
+  uint opt_shortcut_jump(sp_head *sp, sp_instr *start) override
   {
     return m_ip;
   }
 
-  virtual void opt_move(uint dst, List<sp_instr> *ibp);
+  void opt_move(uint dst, List<sp_instr> *ibp) override;
 
-  virtual void set_destination(uint old_dest, uint new_dest)
+  void set_destination(uint old_dest, uint new_dest) override
   {
     sp_instr_jump::set_destination(old_dest, new_dest);
     if (m_cont_dest == old_dest)
@@ -1656,7 +1656,7 @@ private:
   sp_lex_keeper m_lex_keeper;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_jump_if_not : public sp_instr_jump
 
@@ -1674,18 +1674,18 @@ public:
 
   virtual ~sp_instr_preturn() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads)
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override
   {
     marked= 1;
     return UINT_MAX;
   }
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_preturn : public sp_instr
 
@@ -1705,13 +1705,13 @@ public:
 
   virtual ~sp_instr_freturn() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads)
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override
   {
     marked= 1;
     return UINT_MAX;
@@ -1724,7 +1724,7 @@ protected:
   sp_lex_keeper m_lex_keeper;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_freturn : public sp_instr
 
@@ -1753,19 +1753,19 @@ public:
     m_handler= NULL;
   }
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads);
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override;
 
   /** Override sp_instr_jump's shortcut; we stop here. */
-  virtual uint opt_shortcut_jump(sp_head *sp, sp_instr *start)
+  uint opt_shortcut_jump(sp_head *sp, sp_instr *start) override
   {
     return m_ip;
   }
 
-  virtual void backpatch(uint dest, sp_pcontext *dst_ctx)
+  void backpatch(uint dest, sp_pcontext *dst_ctx) override
   {
     DBUG_ASSERT(!m_dest || !m_opt_hpop);
     if (!m_dest)
@@ -1792,7 +1792,7 @@ private:
   uint m_frame;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_hpush_jump : public sp_instr_jump
 
@@ -1815,16 +1815,16 @@ public:
     m_count= count;
   }
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 private:
 
   uint m_count;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_hpop : public sp_instr
 
@@ -1843,24 +1843,24 @@ public:
 
   virtual ~sp_instr_hreturn() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
   /* This instruction will not be short cut optimized. */
-  virtual uint opt_shortcut_jump(sp_head *sp, sp_instr *start)
+  uint opt_shortcut_jump(sp_head *sp, sp_instr *start) override
   {
     return m_ip;
   }
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads);
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override;
 
 private:
 
   uint m_frame;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_hreturn : public sp_instr_jump
 
@@ -1879,23 +1879,23 @@ public:
 
   virtual ~sp_instr_cpush() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
   /**
     This call is used to cleanup the instruction when a sensitive
     cursor is closed. For now stored procedures always use materialized
     cursors and the call is not used.
   */
-  virtual void cleanup_stmt() { /* no op */ }
+  void cleanup_stmt() override { /* no op */ }
 private:
 
   sp_lex_keeper m_lex_keeper;
   uint m_cursor;                /**< Frame offset (for debugging) */
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_cpush : public sp_instr
 
@@ -1918,16 +1918,16 @@ public:
     m_count= count;
   }
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 private:
 
   uint m_count;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_cpop : public sp_instr
 
@@ -1945,18 +1945,18 @@ public:
 
   virtual ~sp_instr_copen() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 private:
 
   uint m_cursor;		///< Stack index
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_copen : public sp_instr_stmt
 
@@ -1981,12 +1981,12 @@ public:
       m_var(voffs)
   {}
   virtual ~sp_instr_cursor_copy_struct() = default;
-  virtual int execute(THD *thd, uint *nextp);
-  virtual int exec_core(THD *thd, uint *nextp);
-  virtual void print(String *str);
+  int execute(THD *thd, uint *nextp) override;
+  int exec_core(THD *thd, uint *nextp) override;
+  void print(String *str) override;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 };
 
@@ -2004,16 +2004,16 @@ public:
 
   virtual ~sp_instr_cclose() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 private:
 
   uint m_cursor;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_cclose : public sp_instr
 
@@ -2033,9 +2033,9 @@ public:
 
   virtual ~sp_instr_cfetch() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
   void add_to_varlist(sp_variable *var)
   {
@@ -2049,7 +2049,7 @@ private:
   bool m_error_on_no_data;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_cfetch : public sp_instr
 
@@ -2071,12 +2071,12 @@ public:
 
   virtual ~sp_instr_agg_cfetch() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_agg_cfetch : public sp_instr
 
@@ -2096,11 +2096,11 @@ public:
 
   virtual ~sp_instr_error() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads)
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override
   {
     marked= 1;
     return UINT_MAX;
@@ -2111,7 +2111,7 @@ private:
   int m_errcode;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_error : public sp_instr
 
@@ -2129,17 +2129,17 @@ public:
 
   virtual ~sp_instr_set_case_expr() = default;
 
-  virtual int execute(THD *thd, uint *nextp);
+  int execute(THD *thd, uint *nextp) override;
 
-  virtual int exec_core(THD *thd, uint *nextp);
+  int exec_core(THD *thd, uint *nextp) override;
 
-  virtual void print(String *str);
+  void print(String *str) override;
 
-  virtual uint opt_mark(sp_head *sp, List<sp_instr> *leads);
+  uint opt_mark(sp_head *sp, List<sp_instr> *leads) override;
 
-  virtual void opt_move(uint dst, List<sp_instr> *ibp);
+  void opt_move(uint dst, List<sp_instr> *ibp) override;
 
-  virtual void set_destination(uint old_dest, uint new_dest)
+  void set_destination(uint old_dest, uint new_dest) override
   {
     if (m_cont_dest == old_dest)
       m_cont_dest= new_dest;
@@ -2152,7 +2152,7 @@ private:
   sp_lex_keeper m_lex_keeper;
 
 public:
-  virtual PSI_statement_info* get_psi_info() { return & psi_info; }
+  PSI_statement_info* get_psi_info() override { return & psi_info; }
   static PSI_statement_info psi_info;
 }; // class sp_instr_set_case_expr : public sp_instr_opt_meta
 

--- a/sql/spatial.h
+++ b/sql/spatial.h
@@ -399,14 +399,14 @@ class Gis_point: public Geometry
 public:
   Gis_point() = default;                              /* Remove gcc warning */
   virtual ~Gis_point() = default;                     /* Remove gcc warning */
-  uint32 get_data_size() const;
-  bool init_from_wkt(Gis_read_stream *trs, String *wkb);
-  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res);
-  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb);
-  bool get_data_as_wkt(String *txt, const char **end) const;
+  uint32 get_data_size() const override;
+  bool init_from_wkt(Gis_read_stream *trs, String *wkb) override;
+  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res) override;
+  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb) override;
+  bool get_data_as_wkt(String *txt, const char **end) const override;
   bool get_data_as_json(String *txt, uint max_dec_digits,
-                        const char **end) const;
-  bool get_mbr(MBR *mbr, const char **end) const;
+                        const char **end) const override;
+  bool get_mbr(MBR *mbr, const char **end) const override;
   
   int get_xy(double *x, double *y) const
   {
@@ -429,7 +429,7 @@ public:
     return 1;
   }
 
-  int get_x(double *x) const
+  int get_x(double *x) const override
   {
     if (no_data(m_data, SIZEOF_STORED_DOUBLE))
       return 1;
@@ -437,7 +437,7 @@ public:
     return 0;
   }
 
-  int get_y(double *y) const
+  int get_y(double *y) const override
   {
     const char *data= m_data;
     if (no_data(data, SIZEOF_STORED_DOUBLE * 2)) return 1;
@@ -445,16 +445,16 @@ public:
     return 0;
   }
 
-  int geom_length(double *len, const char **end) const;
-  int area(double *ar, const char **end) const;
-  bool dimension(uint32 *dim, const char **end) const
+  int geom_length(double *len, const char **end) const override;
+  int area(double *ar, const char **end) const override;
+  bool dimension(uint32 *dim, const char **end) const override
   {
     *dim= 0;
     *end= 0;					/* No default end */
     return 0;
   }
-  int store_shapes(Gcalc_shape_transporter *trn) const;
-  const Class_info *get_class_info() const;
+  int store_shapes(Gcalc_shape_transporter *trn) const override;
+  const Class_info *get_class_info() const override;
   double calculate_haversine(const Geometry *g, const double sphere_radius,
                              int *error);
   int spherical_distance_multipoints(Geometry *g, const double r, double *result,
@@ -469,29 +469,29 @@ class Gis_line_string: public Geometry
 public:
   Gis_line_string() = default;                        /* Remove gcc warning */
   virtual ~Gis_line_string() = default;               /* Remove gcc warning */
-  uint32 get_data_size() const;
-  bool init_from_wkt(Gis_read_stream *trs, String *wkb);
-  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res);
-  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb);
-  bool get_data_as_wkt(String *txt, const char **end) const;
+  uint32 get_data_size() const override;
+  bool init_from_wkt(Gis_read_stream *trs, String *wkb) override;
+  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res) override;
+  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb) override;
+  bool get_data_as_wkt(String *txt, const char **end) const override;
   bool get_data_as_json(String *txt, uint max_dec_digits,
-                        const char **end) const;
-  bool get_mbr(MBR *mbr, const char **end) const;
-  int geom_length(double *len, const char **end) const;
-  int area(double *ar, const char **end) const;
-  int is_closed(int *closed) const;
-  int num_points(uint32 *n_points) const;
-  int start_point(String *point) const;
-  int end_point(String *point) const;
-  int point_n(uint32 n, String *result) const;
-  bool dimension(uint32 *dim, const char **end) const
+                        const char **end) const override;
+  bool get_mbr(MBR *mbr, const char **end) const override;
+  int geom_length(double *len, const char **end) const override;
+  int area(double *ar, const char **end) const override;
+  int is_closed(int *closed) const override;
+  int num_points(uint32 *n_points) const override;
+  int start_point(String *point) const override;
+  int end_point(String *point) const override;
+  int point_n(uint32 n, String *result) const override;
+  bool dimension(uint32 *dim, const char **end) const override
   {
     *dim= 1;
     *end= 0;					/* No default end */
     return 0;
   }
-  int store_shapes(Gcalc_shape_transporter *trn) const;
-  const Class_info *get_class_info() const;
+  int store_shapes(Gcalc_shape_transporter *trn) const override;
+  const Class_info *get_class_info() const override;
 };
 
 
@@ -502,29 +502,29 @@ class Gis_polygon: public Geometry
 public:
   Gis_polygon() = default;                            /* Remove gcc warning */
   virtual ~Gis_polygon() = default;                   /* Remove gcc warning */
-  uint32 get_data_size() const;
-  bool init_from_wkt(Gis_read_stream *trs, String *wkb);
-  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res);
-  uint init_from_opresult(String *bin, const char *opres, uint res_len);
-  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb);
-  bool get_data_as_wkt(String *txt, const char **end) const;
+  uint32 get_data_size() const override;
+  bool init_from_wkt(Gis_read_stream *trs, String *wkb) override;
+  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res) override;
+  uint init_from_opresult(String *bin, const char *opres, uint res_len) override;
+  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb) override;
+  bool get_data_as_wkt(String *txt, const char **end) const override;
   bool get_data_as_json(String *txt, uint max_dec_digits,
-                        const char **end) const;
-  bool get_mbr(MBR *mbr, const char **end) const;
-  int area(double *ar, const char **end) const;
-  int exterior_ring(String *result) const;
-  int num_interior_ring(uint32 *n_int_rings) const;
-  int interior_ring_n(uint32 num, String *result) const;
+                        const char **end) const override;
+  bool get_mbr(MBR *mbr, const char **end) const override;
+  int area(double *ar, const char **end) const override;
+  int exterior_ring(String *result) const override;
+  int num_interior_ring(uint32 *n_int_rings) const override;
+  int interior_ring_n(uint32 num, String *result) const override;
   int centroid_xy(double *x, double *y) const;
-  int centroid(String *result) const;
-  bool dimension(uint32 *dim, const char **end) const
+  int centroid(String *result) const override;
+  bool dimension(uint32 *dim, const char **end) const override
   {
     *dim= 2;
     *end= 0;					/* No default end */
     return 0;
   }
-  int store_shapes(Gcalc_shape_transporter *trn) const;
-  const Class_info *get_class_info() const;
+  int store_shapes(Gcalc_shape_transporter *trn) const override;
+  const Class_info *get_class_info() const override;
 };
 
 
@@ -539,25 +539,25 @@ class Gis_multi_point: public Geometry
 public:
   Gis_multi_point() = default;                        /* Remove gcc warning */
   virtual ~Gis_multi_point() = default;               /* Remove gcc warning */
-  uint32 get_data_size() const;
-  bool init_from_wkt(Gis_read_stream *trs, String *wkb);
-  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res);
-  uint init_from_opresult(String *bin, const char *opres, uint res_len);
-  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb);
-  bool get_data_as_wkt(String *txt, const char **end) const;
+  uint32 get_data_size() const override;
+  bool init_from_wkt(Gis_read_stream *trs, String *wkb) override;
+  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res) override;
+  uint init_from_opresult(String *bin, const char *opres, uint res_len) override;
+  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb) override;
+  bool get_data_as_wkt(String *txt, const char **end) const override;
   bool get_data_as_json(String *txt, uint max_dec_digits,
-                        const char **end) const;
-  bool get_mbr(MBR *mbr, const char **end) const;
-  int num_geometries(uint32 *num) const;
-  int geometry_n(uint32 num, String *result) const;
-  bool dimension(uint32 *dim, const char **end) const
+                        const char **end) const override;
+  bool get_mbr(MBR *mbr, const char **end) const override;
+  int num_geometries(uint32 *num) const override;
+  int geometry_n(uint32 num, String *result) const override;
+  bool dimension(uint32 *dim, const char **end) const override
   {
     *dim= 0;
     *end= 0;					/* No default end */
     return 0;
   }
-  int store_shapes(Gcalc_shape_transporter *trn) const;
-  const Class_info *get_class_info() const;
+  int store_shapes(Gcalc_shape_transporter *trn) const override;
+  const Class_info *get_class_info() const override;
   int spherical_distance_multipoints(Geometry *g, const double r, double *res,
                                      int *error);
 };
@@ -570,27 +570,27 @@ class Gis_multi_line_string: public Geometry
 public:
   Gis_multi_line_string() = default;                  /* Remove gcc warning */
   virtual ~Gis_multi_line_string() = default;         /* Remove gcc warning */
-  uint32 get_data_size() const;
-  bool init_from_wkt(Gis_read_stream *trs, String *wkb);
-  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res);
-  uint init_from_opresult(String *bin, const char *opres, uint res_len);
-  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb);
-  bool get_data_as_wkt(String *txt, const char **end) const;
+  uint32 get_data_size() const override;
+  bool init_from_wkt(Gis_read_stream *trs, String *wkb) override;
+  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res) override;
+  uint init_from_opresult(String *bin, const char *opres, uint res_len) override;
+  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb) override;
+  bool get_data_as_wkt(String *txt, const char **end) const override;
   bool get_data_as_json(String *txt, uint max_dec_digits,
-                        const char **end) const;
-  bool get_mbr(MBR *mbr, const char **end) const;
-  int num_geometries(uint32 *num) const;
-  int geometry_n(uint32 num, String *result) const;
-  int geom_length(double *len, const char **end) const;
-  int is_closed(int *closed) const;
-  bool dimension(uint32 *dim, const char **end) const
+                        const char **end) const override;
+  bool get_mbr(MBR *mbr, const char **end) const override;
+  int num_geometries(uint32 *num) const override;
+  int geometry_n(uint32 num, String *result) const override;
+  int geom_length(double *len, const char **end) const override;
+  int is_closed(int *closed) const override;
+  bool dimension(uint32 *dim, const char **end) const override
   {
     *dim= 1;
     *end= 0;					/* No default end */
     return 0;
   }
-  int store_shapes(Gcalc_shape_transporter *trn) const;
-  const Class_info *get_class_info() const;
+  int store_shapes(Gcalc_shape_transporter *trn) const override;
+  const Class_info *get_class_info() const override;
 };
 
 
@@ -601,27 +601,27 @@ class Gis_multi_polygon: public Geometry
 public:
   Gis_multi_polygon() = default;                      /* Remove gcc warning */
   virtual ~Gis_multi_polygon() = default;             /* Remove gcc warning */
-  uint32 get_data_size() const;
-  bool init_from_wkt(Gis_read_stream *trs, String *wkb);
-  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res);
-  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb);
-  bool get_data_as_wkt(String *txt, const char **end) const;
+  uint32 get_data_size() const override;
+  bool init_from_wkt(Gis_read_stream *trs, String *wkb) override;
+  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res) override;
+  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb) override;
+  bool get_data_as_wkt(String *txt, const char **end) const override;
   bool get_data_as_json(String *txt, uint max_dec_digits,
-                        const char **end) const;
-  bool get_mbr(MBR *mbr, const char **end) const;
-  int num_geometries(uint32 *num) const;
-  int geometry_n(uint32 num, String *result) const;
-  int area(double *ar, const char **end) const;
-  int centroid(String *result) const;
-  bool dimension(uint32 *dim, const char **end) const
+                        const char **end) const override;
+  bool get_mbr(MBR *mbr, const char **end) const override;
+  int num_geometries(uint32 *num) const override;
+  int geometry_n(uint32 num, String *result) const override;
+  int area(double *ar, const char **end) const override;
+  int centroid(String *result) const override;
+  bool dimension(uint32 *dim, const char **end) const override
   {
     *dim= 2;
     *end= 0;					/* No default end */
     return 0;
   }
-  int store_shapes(Gcalc_shape_transporter *trn) const;
-  const Class_info *get_class_info() const;
-  uint init_from_opresult(String *bin, const char *opres, uint res_len);
+  int store_shapes(Gcalc_shape_transporter *trn) const override;
+  const Class_info *get_class_info() const override;
+  uint init_from_opresult(String *bin, const char *opres, uint res_len) override;
 };
 
 
@@ -632,22 +632,22 @@ class Gis_geometry_collection: public Geometry
 public:
   Gis_geometry_collection() = default;                /* Remove gcc warning */
   virtual ~Gis_geometry_collection() = default;       /* Remove gcc warning */
-  uint32 get_data_size() const;
-  bool init_from_wkt(Gis_read_stream *trs, String *wkb);
-  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res);
-  uint init_from_opresult(String *bin, const char *opres, uint res_len);
-  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb);
-  bool get_data_as_wkt(String *txt, const char **end) const;
+  uint32 get_data_size() const override;
+  bool init_from_wkt(Gis_read_stream *trs, String *wkb) override;
+  uint init_from_wkb(const char *wkb, uint len, wkbByteOrder bo, String *res) override;
+  uint init_from_opresult(String *bin, const char *opres, uint res_len) override;
+  bool init_from_json(json_engine_t *je, bool er_on_3D, String *wkb) override;
+  bool get_data_as_wkt(String *txt, const char **end) const override;
   bool get_data_as_json(String *txt, uint max_dec_digits,
-                        const char **end) const;
-  bool get_mbr(MBR *mbr, const char **end) const;
-  int area(double *ar, const char **end) const;
-  int geom_length(double *len, const char **end) const;
-  int num_geometries(uint32 *num) const;
-  int geometry_n(uint32 num, String *result) const;
-  bool dimension(uint32 *dim, const char **end) const;
-  int store_shapes(Gcalc_shape_transporter *trn) const;
-  const Class_info *get_class_info() const;
+                        const char **end) const override;
+  bool get_mbr(MBR *mbr, const char **end) const override;
+  int area(double *ar, const char **end) const override;
+  int geom_length(double *len, const char **end) const override;
+  int num_geometries(uint32 *num) const override;
+  int geometry_n(uint32 num, String *result) const override;
+  bool dimension(uint32 *dim, const char **end) const override;
+  int store_shapes(Gcalc_shape_transporter *trn) const override;
+  const Class_info *get_class_info() const override;
 };
 
 struct Geometry_buffer : public

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -940,9 +940,9 @@ class User_table_tabular: public User_table
 {
  public:
 
-  LEX_CSTRING& name() const { return MYSQL_TABLE_NAME_USER; }
+  LEX_CSTRING& name() const override { return MYSQL_TABLE_NAME_USER; }
 
-  int get_auth(THD *thd, MEM_ROOT *root, ACL_USER *u) const
+  int get_auth(THD *thd, MEM_ROOT *root, ACL_USER *u) const override
   {
     mysql_mutex_assert_owner(&acl_cache->lock);
     u->alloc_auth(root, 1);
@@ -985,7 +985,7 @@ class User_table_tabular: public User_table
     return 0;
   }
 
-  bool set_auth(const ACL_USER &u) const
+  bool set_auth(const ACL_USER &u) const override
   {
     if (u.nauth != 1)
       return 1;
@@ -1006,7 +1006,7 @@ class User_table_tabular: public User_table
     return 0;
   }
 
-  privilege_t get_access() const
+  privilege_t get_access() const override
   {
     privilege_t access(Grant_table_base::get_access());
     if ((num_fields() <= 13) && (access & CREATE_ACL))
@@ -1065,7 +1065,7 @@ class User_table_tabular: public User_table
     return access & GLOBAL_ACLS;
   }
 
-  void set_access(const privilege_t rights, bool revoke) const
+  void set_access(const privilege_t rights, bool revoke) const override
   {
     ulonglong priv(SELECT_ACL);
     for (uint i= start_priv_columns; i < end_priv_columns; i++, priv <<= 1)
@@ -1075,132 +1075,132 @@ class User_table_tabular: public User_table
     }
   }
 
-  SSL_type get_ssl_type () const
+  SSL_type get_ssl_type () const override
   {
     Field *f= get_field(end_priv_columns, MYSQL_TYPE_ENUM);
     return (SSL_type)(f ? f->val_int()-1 : 0);
   }
-  int set_ssl_type (SSL_type x) const
+  int set_ssl_type (SSL_type x) const override
   {
     if (Field *f= get_field(end_priv_columns, MYSQL_TYPE_ENUM))
       return f->store(x+1, 0);
     else
       return 1;
   }
-  const char* get_ssl_cipher (MEM_ROOT *root) const
+  const char* get_ssl_cipher (MEM_ROOT *root) const override
   {
     Field *f= get_field(end_priv_columns + 1, MYSQL_TYPE_BLOB);
     return f ? ::get_field(root,f) : 0;
   }
-  int set_ssl_cipher (const char *s, size_t l) const
+  int set_ssl_cipher (const char *s, size_t l) const override
   {
     if (Field *f= get_field(end_priv_columns + 1, MYSQL_TYPE_BLOB))
       return f->store(s, l, &my_charset_latin1);
     else
       return 1;
   }
-  const char* get_x509_issuer (MEM_ROOT *root) const
+  const char* get_x509_issuer (MEM_ROOT *root) const override
   {
     Field *f= get_field(end_priv_columns + 2, MYSQL_TYPE_BLOB);
     return f ? ::get_field(root,f) : 0;
   }
-  int set_x509_issuer (const char *s, size_t l) const
+  int set_x509_issuer (const char *s, size_t l) const override
   {
     if (Field *f= get_field(end_priv_columns + 2, MYSQL_TYPE_BLOB))
       return f->store(s, l, &my_charset_latin1);
     else
       return 1;
   }
-  const char* get_x509_subject (MEM_ROOT *root) const
+  const char* get_x509_subject (MEM_ROOT *root) const override
   {
     Field *f= get_field(end_priv_columns + 3, MYSQL_TYPE_BLOB);
     return f ? ::get_field(root,f) : 0;
   }
-  int set_x509_subject (const char *s, size_t l) const
+  int set_x509_subject (const char *s, size_t l) const override
   {
     if (Field *f= get_field(end_priv_columns + 3, MYSQL_TYPE_BLOB))
       return f->store(s, l, &my_charset_latin1);
     else
       return 1;
   }
-  longlong get_max_questions () const
+  longlong get_max_questions () const override
   {
     Field *f= get_field(end_priv_columns + 4, MYSQL_TYPE_LONG);
     return f ? f->val_int() : 0;
   }
-  int set_max_questions (longlong x) const
+  int set_max_questions (longlong x) const override
   {
     if (Field *f= get_field(end_priv_columns + 4, MYSQL_TYPE_LONG))
       return f->store(x, 0);
     else
       return 1;
   }
-  longlong get_max_updates () const
+  longlong get_max_updates () const override
   {
     Field *f= get_field(end_priv_columns + 5, MYSQL_TYPE_LONG);
     return f ? f->val_int() : 0;
   }
-  int set_max_updates (longlong x) const
+  int set_max_updates (longlong x) const override
   {
     if (Field *f= get_field(end_priv_columns + 5, MYSQL_TYPE_LONG))
       return f->store(x, 0);
     else
       return 1;
   }
-  longlong get_max_connections () const
+  longlong get_max_connections () const override
   {
     Field *f= get_field(end_priv_columns + 6, MYSQL_TYPE_LONG);
     return f ? f->val_int() : 0;
   }
-  int set_max_connections (longlong x) const
+  int set_max_connections (longlong x) const override
   {
     if (Field *f= get_field(end_priv_columns + 6, MYSQL_TYPE_LONG))
       return f->store(x, 0);
     else
       return 1;
   }
-  longlong get_max_user_connections () const
+  longlong get_max_user_connections () const override
   {
     Field *f= get_field(end_priv_columns + 7, MYSQL_TYPE_LONG);
     return f ? f->val_int() : 0;
   }
-  int set_max_user_connections (longlong x) const
+  int set_max_user_connections (longlong x) const override
   {
     if (Field *f= get_field(end_priv_columns + 7, MYSQL_TYPE_LONG))
       return f->store(x, 0);
     else
       return 1;
   }
-  double get_max_statement_time () const
+  double get_max_statement_time () const override
   {
     Field *f= get_field(end_priv_columns + 13, MYSQL_TYPE_NEWDECIMAL);
     return f ? f->val_real() : 0;
   }
-  int set_max_statement_time (double x) const
+  int set_max_statement_time (double x) const override
   {
     if (Field *f= get_field(end_priv_columns + 13, MYSQL_TYPE_NEWDECIMAL))
       return f->store(x);
     else
       return 1;
   }
-  bool get_is_role () const
+  bool get_is_role () const override
   {
     Field *f= get_field(end_priv_columns + 11, MYSQL_TYPE_ENUM);
     return f ? f->val_int()-1 : 0;
   }
-  int set_is_role (bool x) const
+  int set_is_role (bool x) const override
   {
     if (Field *f= get_field(end_priv_columns + 11, MYSQL_TYPE_ENUM))
       return f->store(x+1, 0);
     else
       return 1;
   }
-  const char* get_default_role (MEM_ROOT *root) const
+  const char* get_default_role (MEM_ROOT *root) const override
   {
     Field *f= get_field(end_priv_columns + 12, MYSQL_TYPE_STRING);
     return f ? ::get_field(root,f) : 0;
   }
-  int set_default_role (const char *s, size_t l) const
+  int set_default_role (const char *s, size_t l) const override
   {
     if (Field *f= get_field(end_priv_columns + 12, MYSQL_TYPE_STRING))
       return f->store(s, l, system_charset_info);
@@ -1210,12 +1210,12 @@ class User_table_tabular: public User_table
   /* On a MariaDB 10.3 user table, the account locking accessors will try to
      get the content of the max_statement_time column, but they will fail due
      to the typecheck in get_field. */
-  bool get_account_locked () const
+  bool get_account_locked () const override
   {
     Field *f= get_field(end_priv_columns + 13, MYSQL_TYPE_ENUM);
     return f ? f->val_int()-1 : 0;
   }
-  int set_account_locked (bool x) const
+  int set_account_locked (bool x) const override
   {
     if (Field *f= get_field(end_priv_columns + 13, MYSQL_TYPE_ENUM))
       return f->store(x+1, 0);
@@ -1223,14 +1223,14 @@ class User_table_tabular: public User_table
     return 1;
   }
 
-  bool get_password_expired () const
+  bool get_password_expired () const override
   {
     uint field_num= end_priv_columns + 10;
 
     Field *f= get_field(field_num, MYSQL_TYPE_ENUM);
     return f ? f->val_int()-1 : 0;
   }
-  int set_password_expired (bool x) const
+  int set_password_expired (bool x) const override
   {
     uint field_num= end_priv_columns + 10;
 
@@ -1238,14 +1238,14 @@ class User_table_tabular: public User_table
       return f->store(x+1, 0);
     return 1;
   }
-  my_time_t get_password_last_changed () const
+  my_time_t get_password_last_changed () const override
   {
     ulong unused_dec;
     if (Field *f= get_field(end_priv_columns + 11, MYSQL_TYPE_TIMESTAMP2))
       return f->get_timestamp(&unused_dec);
     return 0;
   }
-  int set_password_last_changed (my_time_t x) const
+  int set_password_last_changed (my_time_t x) const override
   {
     if (Field *f= get_field(end_priv_columns + 11, MYSQL_TYPE_TIMESTAMP2))
     {
@@ -1254,7 +1254,7 @@ class User_table_tabular: public User_table
     }
     return 1;
   }
-  longlong get_password_lifetime () const
+  longlong get_password_lifetime () const override
   {
     if (Field *f= get_field(end_priv_columns + 12, MYSQL_TYPE_SHORT))
     {
@@ -1264,7 +1264,7 @@ class User_table_tabular: public User_table
     }
     return 0;
   }
-  int set_password_lifetime (longlong x) const
+  int set_password_lifetime (longlong x) const override
   {
     if (Field *f= get_field(end_priv_columns + 12, MYSQL_TYPE_SHORT))
     {
@@ -1279,7 +1279,7 @@ class User_table_tabular: public User_table
     return 1;
   }
 
-  virtual ~User_table_tabular() = default;
+  ~User_table_tabular() override = default;
  private:
   friend class Grant_tables;
 
@@ -1304,7 +1304,7 @@ class User_table_tabular: public User_table
     return f->real_type() == type ? f : NULL;
   }
 
-  int setup_sysvars() const
+  int setup_sysvars() const override
   {
     username_char_length= MY_MIN(m_table->field[1]->char_length(),
                                  USERNAME_CHAR_LENGTH);
@@ -1378,9 +1378,9 @@ class User_table_tabular: public User_table
 */
 class User_table_json: public User_table
 {
-  LEX_CSTRING& name() const { return MYSQL_TABLE_NAME[USER_TABLE]; }
+  LEX_CSTRING& name() const override { return MYSQL_TABLE_NAME[USER_TABLE]; }
 
-  int get_auth(THD *thd, MEM_ROOT *root, ACL_USER *u) const
+  int get_auth(THD *thd, MEM_ROOT *root, ACL_USER *u) const override
   {
     size_t array_len;
     const char *array;
@@ -1459,7 +1459,7 @@ class User_table_json: public User_table
     return 0;
   }
 
-  bool set_auth(const ACL_USER &u) const
+  bool set_auth(const ACL_USER &u) const override
   {
     size_t array_len;
     const char *array;
@@ -1584,7 +1584,7 @@ class User_table_json: public User_table
     return access & ALL_KNOWN_ACL;
   }
 
-  privilege_t get_access() const
+  privilege_t get_access() const override
   {
     ulonglong version_id= (ulonglong) get_int_value("version_id");
     ulonglong access= (ulonglong) get_int_value("access");
@@ -1611,7 +1611,7 @@ class User_table_json: public User_table
     return adjust_access(version_id, access) & GLOBAL_ACLS;
   }
 
-  void set_access(const privilege_t rights, bool revoke) const
+  void set_access(const privilege_t rights, bool revoke) const override
   {
     privilege_t access= get_access();
     if (revoke)
@@ -1624,77 +1624,77 @@ class User_table_json: public User_table
   const char *unsafe_str(const char *s) const
   { return s[0] ? s : NULL; }
 
-  SSL_type get_ssl_type () const
+  SSL_type get_ssl_type () const override
   { return (SSL_type)get_int_value("ssl_type"); }
-  int set_ssl_type (SSL_type x) const
+  int set_ssl_type (SSL_type x) const override
   { return set_int_value("ssl_type", x); }
-  const char* get_ssl_cipher (MEM_ROOT *root) const
+  const char* get_ssl_cipher (MEM_ROOT *root) const override
   { return unsafe_str(get_str_value(root, "ssl_cipher")); }
-  int set_ssl_cipher (const char *s, size_t l) const
+  int set_ssl_cipher (const char *s, size_t l) const override
   { return set_str_value("ssl_cipher", s, l); }
-  const char* get_x509_issuer (MEM_ROOT *root) const
+  const char* get_x509_issuer (MEM_ROOT *root) const override
   { return unsafe_str(get_str_value(root, "x509_issuer")); }
-  int set_x509_issuer (const char *s, size_t l) const
+  int set_x509_issuer (const char *s, size_t l) const override
   { return set_str_value("x509_issuer", s, l); }
-  const char* get_x509_subject (MEM_ROOT *root) const
+  const char* get_x509_subject (MEM_ROOT *root) const override
   { return unsafe_str(get_str_value(root, "x509_subject")); }
-  int set_x509_subject (const char *s, size_t l) const
+  int set_x509_subject (const char *s, size_t l) const override
   { return set_str_value("x509_subject", s, l); }
-  longlong get_max_questions () const
+  longlong get_max_questions () const override
   { return get_int_value("max_questions"); }
-  int set_max_questions (longlong x) const
+  int set_max_questions (longlong x) const override
   { return set_int_value("max_questions", x); }
-  longlong get_max_updates () const
+  longlong get_max_updates () const override
   { return get_int_value("max_updates"); }
-  int set_max_updates (longlong x) const
+  int set_max_updates (longlong x) const override
   { return set_int_value("max_updates", x); }
-  longlong get_max_connections () const
+  longlong get_max_connections () const override
   { return get_int_value("max_connections"); }
-  int set_max_connections (longlong x) const
+  int set_max_connections (longlong x) const override
   { return set_int_value("max_connections", x); }
-  longlong get_max_user_connections () const
+  longlong get_max_user_connections () const override
   { return get_int_value("max_user_connections"); }
-  int set_max_user_connections (longlong x) const
+  int set_max_user_connections (longlong x) const override
   { return set_int_value("max_user_connections", x); }
-  double get_max_statement_time () const
+  double get_max_statement_time () const override
   { return get_double_value("max_statement_time"); }
-  int set_max_statement_time (double x) const
+  int set_max_statement_time (double x) const override
   { return set_double_value("max_statement_time", x); }
-  bool get_is_role () const
+  bool get_is_role () const override
   { return get_bool_value("is_role"); }
-  int set_is_role (bool x) const
+  int set_is_role (bool x) const override
   { return set_bool_value("is_role", x); }
-  const char* get_default_role (MEM_ROOT *root) const
+  const char* get_default_role (MEM_ROOT *root) const override
   { return get_str_value(root, "default_role"); }
-  int set_default_role (const char *s, size_t l) const
+  int set_default_role (const char *s, size_t l) const override
   { return set_str_value("default_role", s, l); }
-  bool get_account_locked () const
+  bool get_account_locked () const override
   { return get_bool_value("account_locked"); }
-  int set_account_locked (bool x) const
+  int set_account_locked (bool x) const override
   { return set_bool_value("account_locked", x); }
-  my_time_t get_password_last_changed () const
+  my_time_t get_password_last_changed () const override
   { return static_cast<my_time_t>(get_int_value("password_last_changed")); }
-  int set_password_last_changed (my_time_t x) const
+  int set_password_last_changed (my_time_t x) const override
   { return set_int_value("password_last_changed", static_cast<longlong>(x)); }
-  int set_password_lifetime (longlong x) const
+  int set_password_lifetime (longlong x) const override
   { return set_int_value("password_lifetime", x); }
-  longlong get_password_lifetime () const
+  longlong get_password_lifetime () const override
   { return get_int_value("password_lifetime", -1); }
   /*
      password_last_changed=0 means the password is manually expired.
      In MySQL 5.7+ this state is described using the password_expired column
      in mysql.user
   */
-  bool get_password_expired () const
+  bool get_password_expired () const override
   { return get_int_value("password_last_changed", -1) == 0; }
-  int set_password_expired (bool x) const
+  int set_password_expired (bool x) const override
   { return x ? set_password_last_changed(0) : 0; }
 
-  ~User_table_json() = default;
+  ~User_table_json() override = default;
  private:
   friend class Grant_tables;
   static const uint JSON_SIZE=1024;
-  int setup_sysvars() const
+  int setup_sysvars() const override
   {
     using_global_priv_table= true;
     username_char_length= MY_MIN(m_table->field[1]->char_length(),
@@ -5366,8 +5366,8 @@ public:
   GRANT_TABLE(const char *h, const char *d,const char *u,
               const char *t, privilege_t p, privilege_t c);
   GRANT_TABLE (TABLE *form, TABLE *col_privs);
-  ~GRANT_TABLE();
-  bool ok() { return privs != NO_ACL || cols != NO_ACL; }
+  ~GRANT_TABLE() override;
+  bool ok() override { return privs != NO_ACL || cols != NO_ACL; }
   void init_hash()
   {
     my_hash_init2(key_memory_acl_memex, &hash_columns, 4, system_charset_info,
@@ -11628,14 +11628,14 @@ public:
     : is_grave(FALSE)
   {}
 
-  virtual ~Silence_routine_definer_errors() = default;
+  ~Silence_routine_definer_errors() override = default;
 
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                 uint sql_errno,
                                 const char* sqlstate,
                                 Sql_condition::enum_warning_level *level,
                                 const char* msg,
-                                Sql_condition ** cond_hdl);
+                                Sql_condition ** cond_hdl) override;
 
   bool has_errors() { return is_grave; }
 

--- a/sql/sql_acl.h
+++ b/sql/sql_acl.h
@@ -311,7 +311,7 @@ public:
    :m_command(command)
   { }
   bool is_revoke() const { return m_command == SQLCOM_REVOKE; }
-  enum_sql_command sql_command_code() const { return m_command; }
+  enum_sql_command sql_command_code() const override { return m_command; }
 };
 
 
@@ -325,7 +325,7 @@ public:
   Sql_cmd_grant_proxy(enum_sql_command command, privilege_t grant_option)
    :Sql_cmd_grant(command), m_grant_option(grant_option)
   { }
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 };
 
 
@@ -352,7 +352,7 @@ public:
   Sql_cmd_grant_table(enum_sql_command command, const Grant_privilege &grant)
    :Sql_cmd_grant_object(command, grant)
   { }
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 };
 
 
@@ -366,7 +366,7 @@ public:
    :Sql_cmd_grant_object(command, grant),
     m_sph(sph)
   { }
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 };
 
 #endif /* SQL_ACL_INCLUDED */

--- a/sql/sql_admin.h
+++ b/sql/sql_admin.h
@@ -38,9 +38,9 @@ public:
 
   ~Sql_cmd_analyze_table() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ANALYZE;
   }
@@ -61,9 +61,9 @@ public:
 
   ~Sql_cmd_check_table() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_CHECK;
   }
@@ -83,9 +83,9 @@ public:
 
   ~Sql_cmd_optimize_table() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_OPTIMIZE;
   }
@@ -106,9 +106,9 @@ public:
 
   ~Sql_cmd_repair_table() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_REPAIR;
   }

--- a/sql/sql_alter.h
+++ b/sql/sql_alter.h
@@ -362,7 +362,7 @@ protected:
 
   virtual ~Sql_cmd_common_alter_table() = default;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ALTER_TABLE;
   }
@@ -383,9 +383,9 @@ public:
 
   ~Sql_cmd_alter_table() = default;
 
-  Storage_engine_name *option_storage_engine_name() { return this; }
+  Storage_engine_name *option_storage_engine_name() override { return this; }
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 };
 
 
@@ -405,11 +405,11 @@ public:
 
   ~Sql_cmd_alter_sequence() = default;
 
-  enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ALTER_SEQUENCE;
   }
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 };
 
 
@@ -429,7 +429,7 @@ public:
     : m_tablespace_op(tablespace_op_arg)
   {}
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
 private:
   const enum_tablespace_op_type m_tablespace_op;

--- a/sql/sql_analyse.h
+++ b/sql/sql_analyse.h
@@ -123,13 +123,13 @@ public:
     { init_tree(&tree, 0, 0, sizeof(String), (qsort_cmp2) sortcmp2,
 		free_string, NULL, MYF(MY_THREAD_SPECIFIC)); };
 
-  void	 add();
-  void	 get_opt_type(String*, ha_rows);
-  String *get_min_arg(String *not_used __attribute__((unused)))
+  void	 add() override;
+  void	 get_opt_type(String*, ha_rows) override;
+  String *get_min_arg(String *not_used __attribute__((unused))) override
   { return &min_arg; }
-  String *get_max_arg(String *not_used __attribute__((unused)))
+  String *get_max_arg(String *not_used __attribute__((unused))) override
   { return &max_arg; }
-  String *avg(String *s, ha_rows rows)
+  String *avg(String *s, ha_rows rows) override
   {
     if (!(rows - nulls))
       s->set_real((double) 0.0, 1,my_thd_charset);
@@ -140,10 +140,10 @@ public:
   }
   friend int collect_string(String *element, element_count count,
 			    TREE_INFO *info);
-  tree_walk_action collect_enum()
+  tree_walk_action collect_enum() override
   { return (tree_walk_action) collect_string; }
   String *std(String *s __attribute__((unused)),
-	      ha_rows rows __attribute__((unused)))
+	      ha_rows rows __attribute__((unused))) override
   { return (String*) 0; }
 };
 
@@ -165,16 +165,16 @@ public:
               0, (void *)&bin_size, MYF(MY_THREAD_SPECIFIC));
   };
 
-  void	 add();
-  void	 get_opt_type(String*, ha_rows);
-  String *get_min_arg(String *);
-  String *get_max_arg(String *);
-  String *avg(String *s, ha_rows rows);
+  void	 add() override;
+  void	 get_opt_type(String*, ha_rows) override;
+  String *get_min_arg(String *) override;
+  String *get_max_arg(String *) override;
+  String *avg(String *s, ha_rows rows) override;
   friend int collect_decimal(uchar *element, element_count count,
                              TREE_INFO *info);
-  tree_walk_action collect_enum()
+  tree_walk_action collect_enum() override
   { return (tree_walk_action) collect_decimal; }
-  String *std(String *s, ha_rows rows);
+  String *std(String *s, ha_rows rows) override;
 };
 
 
@@ -193,19 +193,19 @@ public:
 		(qsort_cmp2) compare_double2, NULL, NULL,
                 MYF(MY_THREAD_SPECIFIC)); }
 
-  void	 add();
-  void	 get_opt_type(String*, ha_rows);
-  String *get_min_arg(String *s)
+  void	 add() override;
+  void	 get_opt_type(String*, ha_rows) override;
+  String *get_min_arg(String *s) override
   {
     s->set_real(min_arg, item->decimals, my_thd_charset);
     return s;
   }
-  String *get_max_arg(String *s)
+  String *get_max_arg(String *s) override
   {
     s->set_real(max_arg, item->decimals, my_thd_charset);
     return s;
   }
-  String *avg(String *s, ha_rows rows)
+  String *avg(String *s, ha_rows rows) override
   {
     if (!(rows - nulls))
       s->set_real((double) 0.0, 1,my_thd_charset);
@@ -213,7 +213,7 @@ public:
       s->set_real(((double)sum / (double) (rows - nulls)), item->decimals,my_thd_charset);
     return s;
   }
-  String *std(String *s, ha_rows rows)
+  String *std(String *s, ha_rows rows) override
   {
     double tmp = ulonglong2double(rows);
     if (!(tmp - nulls))
@@ -226,10 +226,10 @@ public:
     }
     return s;
   }
-  uint	 decimals() { return item->decimals; }
+  uint	 decimals() override { return item->decimals; }
   friend int collect_real(double *element, element_count count,
 			  TREE_INFO *info);
-  tree_walk_action collect_enum()
+  tree_walk_action collect_enum() override
   { return (tree_walk_action) collect_real;}
 };
 
@@ -248,11 +248,11 @@ public:
 		(qsort_cmp2) compare_longlong2, NULL, NULL,
                 MYF(MY_THREAD_SPECIFIC)); }
 
-  void	 add();
-  void	 get_opt_type(String*, ha_rows);
-  String *get_min_arg(String *s) { s->set(min_arg,my_thd_charset); return s; }
-  String *get_max_arg(String *s) { s->set(max_arg,my_thd_charset); return s; }
-  String *avg(String *s, ha_rows rows)
+  void	 add() override;
+  void	 get_opt_type(String*, ha_rows) override;
+  String *get_min_arg(String *s) override { s->set(min_arg,my_thd_charset); return s; }
+  String *get_max_arg(String *s) override { s->set(max_arg,my_thd_charset); return s; }
+  String *avg(String *s, ha_rows rows) override
   {
     if (!(rows - nulls))
       s->set_real((double) 0.0, 1,my_thd_charset);
@@ -260,7 +260,7 @@ public:
       s->set_real(((double) sum / (double) (rows - nulls)), DEC_IN_AVG,my_thd_charset);
     return s;
   }
-  String *std(String *s, ha_rows rows)
+  String *std(String *s, ha_rows rows) override
   {
     double tmp = ulonglong2double(rows);
     if (!(tmp - nulls))
@@ -275,7 +275,7 @@ public:
   }
   friend int collect_longlong(longlong *element, element_count count,
 			      TREE_INFO *info);
-  tree_walk_action collect_enum()
+  tree_walk_action collect_enum() override
   { return (tree_walk_action) collect_longlong;}
 };
 
@@ -293,11 +293,11 @@ public:
     { init_tree(&tree, 0, 0, sizeof(ulonglong),
 		(qsort_cmp2) compare_ulonglong2, NULL, NULL,
                 MYF(MY_THREAD_SPECIFIC)); }
-  void	 add();
-  void	 get_opt_type(String*, ha_rows);
-  String *get_min_arg(String *s) { s->set(min_arg,my_thd_charset); return s; }
-  String *get_max_arg(String *s) { s->set(max_arg,my_thd_charset); return s; }
-  String *avg(String *s, ha_rows rows)
+  void	 add() override;
+  void	 get_opt_type(String*, ha_rows) override;
+  String *get_min_arg(String *s) override { s->set(min_arg,my_thd_charset); return s; }
+  String *get_max_arg(String *s) override { s->set(max_arg,my_thd_charset); return s; }
+  String *avg(String *s, ha_rows rows) override
   {
     if (!(rows - nulls))
       s->set_real((double) 0.0, 1,my_thd_charset);
@@ -306,7 +306,7 @@ public:
 	     DEC_IN_AVG,my_thd_charset);
     return s;
   }
-  String *std(String *s, ha_rows rows)
+  String *std(String *s, ha_rows rows) override
   {
     double tmp = ulonglong2double(rows);
     if (!(tmp - nulls))
@@ -322,7 +322,7 @@ public:
   }
   friend int collect_ulonglong(ulonglong *element, element_count count,
 			       TREE_INFO *info);
-  tree_walk_action collect_enum()
+  tree_walk_action collect_enum() override
   { return (tree_walk_action) collect_ulonglong; }
 };
 
@@ -354,11 +354,11 @@ public:
 	delete (*f);
     }
   }
-  virtual void add() {}
-  virtual bool change_columns(THD *thd, List<Item> &fields);
-  virtual int  send_row(List<Item> &field_list);
-  virtual void end_group(void) {}
-  virtual int end_of_records(void);
+  void add() override {}
+  bool change_columns(THD *thd, List<Item> &fields) override;
+  int  send_row(List<Item> &field_list) override;
+  void end_group(void) override {}
+  int end_of_records(void) override;
   friend Procedure *proc_analyse_init(THD *thd, ORDER *param,
 				      select_result *result,
 				      List<Item> &field_list);

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -116,7 +116,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl);
+                        Sql_condition ** cond_hdl) override;
 
   /**
     Returns TRUE if there were ER_NO_SUCH_/WRONG_MRG_TABLE and there
@@ -517,7 +517,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl)
+                        Sql_condition ** cond_hdl) override
   {
     *cond_hdl= NULL;
     if (sql_errno == ER_OPEN_AS_READONLY)
@@ -1400,14 +1400,14 @@ public:
     : m_ot_ctx(ot_ctx_arg), m_is_active(FALSE)
   {}
 
-  virtual ~MDL_deadlock_handler() = default;
+  ~MDL_deadlock_handler() override = default;
 
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                 uint sql_errno,
                                 const char* sqlstate,
                                 Sql_condition::enum_warning_level *level,
                                 const char* msg,
-                                Sql_condition ** cond_hdl);
+                                Sql_condition ** cond_hdl) override;
 
 private:
   /** Open table context to be used for back-off request. */
@@ -3167,12 +3167,12 @@ request_backoff_action(enum_open_table_action action_arg,
 class MDL_deadlock_discovery_repair_handler : public Internal_error_handler
 {
 public:
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                   uint sql_errno,
                                   const char* sqlstate,
                                   Sql_condition::enum_warning_level *level,
                                   const char* msg,
-                                  Sql_condition ** cond_hdl)
+                                  Sql_condition ** cond_hdl) override
   {
     if (sql_errno == ER_LOCK_DEADLOCK)
     {

--- a/sql/sql_base.h
+++ b/sql/sql_base.h
@@ -419,13 +419,13 @@ public:
 class DML_prelocking_strategy : public Prelocking_strategy
 {
 public:
-  virtual bool handle_routine(THD *thd, Query_tables_list *prelocking_ctx,
-                              Sroutine_hash_entry *rt, sp_head *sp,
-                              bool *need_prelocking);
-  virtual bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
-                            TABLE_LIST *table_list, bool *need_prelocking);
-  virtual bool handle_view(THD *thd, Query_tables_list *prelocking_ctx,
-                           TABLE_LIST *table_list, bool *need_prelocking);
+  bool handle_routine(THD *thd, Query_tables_list *prelocking_ctx,
+                      Sroutine_hash_entry *rt, sp_head *sp,
+                      bool *need_prelocking) override;
+  bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
+                    TABLE_LIST *table_list, bool *need_prelocking) override;
+  bool handle_view(THD *thd, Query_tables_list *prelocking_ctx,
+                   TABLE_LIST *table_list, bool *need_prelocking) override;
 };
 
 
@@ -436,8 +436,8 @@ public:
 
 class Lock_tables_prelocking_strategy : public DML_prelocking_strategy
 {
-  virtual bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
-                            TABLE_LIST *table_list, bool *need_prelocking);
+  bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
+                    TABLE_LIST *table_list, bool *need_prelocking) override;
 };
 
 
@@ -452,13 +452,13 @@ class Lock_tables_prelocking_strategy : public DML_prelocking_strategy
 class Alter_table_prelocking_strategy : public Prelocking_strategy
 {
 public:
-  virtual bool handle_routine(THD *thd, Query_tables_list *prelocking_ctx,
-                              Sroutine_hash_entry *rt, sp_head *sp,
-                              bool *need_prelocking);
-  virtual bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
-                            TABLE_LIST *table_list, bool *need_prelocking);
-  virtual bool handle_view(THD *thd, Query_tables_list *prelocking_ctx,
-                           TABLE_LIST *table_list, bool *need_prelocking);
+  bool handle_routine(THD *thd, Query_tables_list *prelocking_ctx,
+                      Sroutine_hash_entry *rt, sp_head *sp,
+                      bool *need_prelocking) override;
+  bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
+                    TABLE_LIST *table_list, bool *need_prelocking) override;
+  bool handle_view(THD *thd, Query_tables_list *prelocking_ctx,
+                   TABLE_LIST *table_list, bool *need_prelocking) override;
 };
 
 
@@ -650,7 +650,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl);
+                        Sql_condition ** cond_hdl) override;
 
   /**
     Returns TRUE if one or more ER_NO_SUCH_TABLE errors have been

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -486,7 +486,7 @@ public:
     Used to make a clone of this object for ALTER/CREATE TABLE
     @sa comment for Key_part_spec::clone
   */
-  virtual Key *clone(MEM_ROOT *mem_root) const
+  Key *clone(MEM_ROOT *mem_root) const override
   { return new (mem_root) Foreign_key(*this, mem_root); }
   /* Used to validate foreign key options */
   bool validate(List<Create_field> &table_fields);
@@ -1372,7 +1372,7 @@ public:
   void set_n_backup_statement(Statement *stmt, Statement *backup);
   void restore_backup_statement(Statement *stmt, Statement *backup);
   /* return class type */
-  virtual Type type() const;
+  Type type() const override;
 };
 
 
@@ -1924,7 +1924,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl)
+                        Sql_condition ** cond_hdl) override
   {
     /* Ignore error */
     return TRUE;
@@ -1946,7 +1946,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl)
+                        Sql_condition ** cond_hdl) override
   {
     if (*level == Sql_condition::WARN_LEVEL_ERROR)
       errors++;
@@ -1974,7 +1974,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl);
+                        Sql_condition ** cond_hdl) override;
 
 private:
 };
@@ -1995,7 +1995,7 @@ public:
                         const char *sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition **cond_hdl);
+                        Sql_condition **cond_hdl) override;
 
   bool need_reopen() const { return m_need_reopen; };
   void init() { m_need_reopen= FALSE; };
@@ -2011,7 +2011,7 @@ struct Suppress_warnings_error_handler : public Internal_error_handler
                         const char *sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char *msg,
-                        Sql_condition **cond_hdl)
+                        Sql_condition **cond_hdl) override
   {
     return *level == Sql_condition::WARN_LEVEL_WARN;
   }
@@ -3659,7 +3659,7 @@ public:
   enter_cond(mysql_cond_t *cond, mysql_mutex_t* mutex,
              const PSI_stage_info *stage, PSI_stage_info *old_stage,
              const char *src_function, const char *src_file,
-             int src_line)
+             int src_line) override
   {
     mysql_mutex_assert_owner(mutex);
     mysys_var->current_mutex = mutex;
@@ -3671,7 +3671,7 @@ public:
   }
   inline void exit_cond(const PSI_stage_info *stage,
                         const char *src_function, const char *src_file,
-                        int src_line)
+                        int src_line) override
   {
     /*
       Putting the mutex unlock in thd->exit_cond() ensures that
@@ -3688,8 +3688,8 @@ public:
     mysql_mutex_unlock(&mysys_var->mutex);
     return;
   }
-  virtual int is_killed() { return killed; }
-  virtual THD* get_thd() { return this; }
+  int is_killed() override { return killed; }
+  THD* get_thd() override { return this; }
 
   /**
     A callback to the server internals that is used to address
@@ -3714,8 +3714,8 @@ public:
     @retval  TRUE  if the thread was woken up
     @retval  FALSE otherwise.
    */
-  virtual bool notify_shared_lock(MDL_context_owner *ctx_in_use,
-                                  bool needs_thr_lock_abort);
+  bool notify_shared_lock(MDL_context_owner *ctx_in_use,
+                          bool needs_thr_lock_abort) override;
 
   // End implementation of MDL_context_owner interface.
 
@@ -4825,7 +4825,7 @@ public:
 
 public:
   /** Overloaded to guard query/query_length fields */
-  virtual void set_statement(Statement *stmt);
+  void set_statement(Statement *stmt) override;
   inline void set_command(enum enum_server_command command)
   {
     DBUG_ASSERT(command != COM_SLEEP);
@@ -5707,7 +5707,7 @@ public:
   TABLE *dst_table; /* table to write into */
 
   /* The following is called in the child thread: */
-  int send_data(List<Item> &items);
+  int send_data(List<Item> &items) override;
 };
 
 
@@ -5721,7 +5721,7 @@ class select_result_text_buffer : public select_result_sink
 {
 public:
   select_result_text_buffer(THD *thd_arg): select_result_sink(thd_arg) {}
-  int send_data(List<Item> &items);
+  int send_data(List<Item> &items) override;
   bool send_result_set_metadata(List<Item> &fields, uint flag);
 
   void save_to(String *res);
@@ -5749,9 +5749,9 @@ public:
     DBUG_PRINT("enter", ("this %p", this));
     DBUG_VOID_RETURN;
   }              /* Remove gcc warning */
-  uint field_count(List<Item> &fields) const { return 0; }
-  bool send_result_set_metadata(List<Item> &fields, uint flag) { return FALSE; }
-  select_result_interceptor *result_interceptor() { return this; }
+  uint field_count(List<Item> &fields) const override { return 0; }
+  bool send_result_set_metadata(List<Item> &fields, uint flag) override { return FALSE; }
+  select_result_interceptor *result_interceptor() override { return this; }
 
   /*
     Instruct the object to not call my_ok(). Client output will be handled
@@ -5819,10 +5819,10 @@ private:
     uint get_field_count() { return field_count; }
     void set_spvar_list(List<sp_variable> *vars) { spvar_list= vars; }
 
-    virtual bool send_eof() { return FALSE; }
-    virtual int send_data(List<Item> &items);
-    virtual int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
-    virtual bool view_structure_only() const { return m_view_structure_only; }
+    bool send_eof() override { return FALSE; }
+    int send_data(List<Item> &items) override;
+    int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+    bool view_structure_only() const override { return m_view_structure_only; }
 };
 
 public:
@@ -5879,13 +5879,13 @@ class select_send :public select_result {
 public:
   select_send(THD *thd_arg):
     select_result(thd_arg), is_result_set_started(FALSE) {}
-  bool send_result_set_metadata(List<Item> &list, uint flags);
-  int send_data(List<Item> &items);
-  bool send_eof();
-  virtual bool check_simple_select() const { return FALSE; }
-  void abort_result_set();
-  virtual void cleanup();
-  select_result_interceptor *result_interceptor() { return NULL; }
+  bool send_result_set_metadata(List<Item> &list, uint flags) override;
+  int send_data(List<Item> &items) override;
+  bool send_eof() override;
+  bool check_simple_select() const override { return FALSE; }
+  void abort_result_set() override;
+  void cleanup() override;
+  select_result_interceptor *result_interceptor() override { return NULL; }
 };
 
 
@@ -5897,9 +5897,9 @@ public:
 
 class select_send_analyze : public select_send
 {
-  bool send_result_set_metadata(List<Item> &list, uint flags) { return 0; }
-  bool send_eof() { return 0; }
-  void abort_result_set() {}
+  bool send_result_set_metadata(List<Item> &list, uint flags) override { return 0; }
+  bool send_eof() override { return 0; }
+  void abort_result_set() override {}
 public:
   select_send_analyze(THD *thd_arg): select_send(thd_arg) {}
 };
@@ -5918,8 +5918,8 @@ public:
     select_result_interceptor(thd_arg), exchange(ex), file(-1),row_count(0L)
   { path[0]=0; }
   ~select_to_file();
-  bool send_eof();
-  void cleanup();
+  bool send_eof() override;
+  void cleanup() override;
 };
 
 
@@ -5959,16 +5959,16 @@ class select_export :public select_to_file {
 public:
   select_export(THD *thd_arg, sql_exchange *ex): select_to_file(thd_arg, ex) {}
   ~select_export();
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
-  int send_data(List<Item> &items);
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+  int send_data(List<Item> &items) override;
 };
 
 
 class select_dump :public select_to_file {
 public:
   select_dump(THD *thd_arg, sql_exchange *ex): select_to_file(thd_arg, ex) {}
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
-  int send_data(List<Item> &items);
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+  int send_data(List<Item> &items) override;
 };
 
 
@@ -5986,17 +5986,17 @@ class select_insert :public select_result_interceptor {
                 List<Item> *update_values, enum_duplicates duplic,
                 bool ignore, select_result *sel_ret_list);
   ~select_insert();
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
-  virtual int prepare2(JOIN *join);
-  virtual int send_data(List<Item> &items);
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+  int prepare2(JOIN *join) override;
+  int send_data(List<Item> &items) override;
   virtual bool store_values(List<Item> &values);
   virtual bool can_rollback_data() { return 0; }
   bool prepare_eof();
   bool send_ok_packet();
-  bool send_eof();
-  virtual void abort_result_set();
+  bool send_eof() override;
+  void abort_result_set() override;
   /* not implemented: select_insert is never re-used in prepared statements */
-  void cleanup();
+  void cleanup() override;
 };
 
 
@@ -6028,18 +6028,18 @@ public:
     m_plock(NULL), exit_done(0),
     saved_tmp_table_share(0)
     {}
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
 
   int binlog_show_create_table(TABLE **tables, uint count);
-  bool store_values(List<Item> &values);
-  bool send_eof();
-  virtual void abort_result_set();
-  virtual bool can_rollback_data() { return 1; }
+  bool store_values(List<Item> &values) override;
+  bool send_eof() override;
+  void abort_result_set() override;
+  bool can_rollback_data() override { return 1; }
 
   // Needed for access from local class MY_HOOKS in prepare(), since thd is proteted.
   const THD *get_thd(void) { return thd; }
   const HA_CREATE_INFO *get_create_info() { return create_info; };
-  int prepare2(JOIN *join) { return 0; }
+  int prepare2(JOIN *join) override { return 0; }
 
 private:
   TABLE *create_table_from_items(THD *thd,
@@ -6198,7 +6198,7 @@ public:
     init();
     tmp_table_param.init();
   }
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
   /**
     Do prepare() and prepare2() if they have been postponed until
     column type information is computed (used by select_union_direct).
@@ -6209,13 +6209,13 @@ public:
   */
   virtual bool postponed_prepare(List<Item> &types)
   { return false; }
-  int send_data(List<Item> &items);
+  int send_data(List<Item> &items) override;
   int write_record();
   int update_counter(Field *counter, longlong value);
   int delete_record();
-  bool send_eof();
+  bool send_eof() override;
   virtual bool flush();
-  void cleanup();
+  void cleanup() override;
   virtual bool create_result_table(THD *thd, List<Item> *column_types,
                                    bool is_distinct, ulonglong options,
                                    const LEX_CSTRING *alias,
@@ -6342,11 +6342,11 @@ public:
     curr_op_type(UNSPECIFIED)
   {
   };
-  int send_data(List<Item> &items);
-  void change_select();
+  int send_data(List<Item> &items) override;
+  void change_select() override;
   int unfold_record(ha_rows cnt);
-  bool send_eof();
-  bool force_enable_index_if_needed()
+  bool send_eof() override;
+  bool force_enable_index_if_needed() override
   {
     is_index_enabled= true;
     return true;
@@ -6403,15 +6403,15 @@ class select_union_recursive :public select_unit
       row_counter(0)
   { incr_table_param.init(); };
 
-  int send_data(List<Item> &items);
+  int send_data(List<Item> &items) override;
   bool create_result_table(THD *thd, List<Item> *column_types,
                            bool is_distinct, ulonglong options,
                            const LEX_CSTRING *alias,
                            bool bit_fields_as_long,
                            bool create_table,
                            bool keep_row_order,
-                           uint hidden);
-  void cleanup();
+                           uint hidden) override;
+  void cleanup() override;
 };
 
 /**
@@ -6458,30 +6458,30 @@ public:
     done_send_result_set_metadata(false), done_initialize_tables(false),
     limit_found_rows(0)
     { send_records= 0; }
-  bool change_result(select_result *new_result);
-  uint field_count(List<Item> &fields) const
+  bool change_result(select_result *new_result) override;
+  uint field_count(List<Item> &fields) const override
   {
     // Only called for top-level select_results, usually select_send
     DBUG_ASSERT(false); /* purecov: inspected */
     return 0; /* purecov: inspected */
   }
-  bool postponed_prepare(List<Item> &types);
-  bool send_result_set_metadata(List<Item> &list, uint flags);
-  int send_data(List<Item> &items);
-  bool initialize_tables (JOIN *join);
-  bool send_eof();
-  bool flush() { return false; }
-  bool check_simple_select() const
+  bool postponed_prepare(List<Item> &types) override;
+  bool send_result_set_metadata(List<Item> &list, uint flags) override;
+  int send_data(List<Item> &items) override;
+  bool initialize_tables (JOIN *join) override;
+  bool send_eof() override;
+  bool flush() override { return false; }
+  bool check_simple_select() const override
   {
     /* Only called for top-level select_results, usually select_send */
     DBUG_ASSERT(false); /* purecov: inspected */
     return false; /* purecov: inspected */
   }
-  void abort_result_set()
+  void abort_result_set() override
   {
     result->abort_result_set(); /* purecov: inspected */
   }
-  void cleanup()
+  void cleanup() override
   {
     send_records= 0;
   }
@@ -6499,7 +6499,11 @@ public:
     // EXPLAIN should never output to a select_union_direct
     DBUG_ASSERT(false); /* purecov: inspected */
   }
+#ifdef EMBEDDED_LIBRARY
+  void begin_dataset() override
+#else
   void begin_dataset()
+#endif
   {
     // Only called for sp_cursor::Select_fetch_into_spvars
     DBUG_ASSERT(false); /* purecov: inspected */
@@ -6515,8 +6519,8 @@ protected:
 public:
   select_subselect(THD *thd_arg, Item_subselect *item_arg):
     select_result_interceptor(thd_arg), item(item_arg) {}
-  int send_data(List<Item> &items)=0;
-  bool send_eof() { return 0; };
+  int send_data(List<Item> &items) override=0;
+  bool send_eof() override { return 0; };
 };
 
 /* Single value subselect interface class */
@@ -6526,7 +6530,7 @@ public:
   select_singlerow_subselect(THD *thd_arg, Item_subselect *item_arg):
     select_subselect(thd_arg, item_arg)
   {}
-  int send_data(List<Item> &items);
+  int send_data(List<Item> &items) override;
 };
 
 
@@ -6577,10 +6581,10 @@ public:
                            bool bit_fields_as_long,
                            bool create_table,
                            bool keep_row_order,
-                           uint hidden);
+                           uint hidden) override;
   bool init_result_table(ulonglong select_options);
-  int send_data(List<Item> &items);
-  void cleanup();
+  int send_data(List<Item> &items) override;
+  void cleanup() override;
   ha_rows get_null_count_of_col(uint idx)
   {
     DBUG_ASSERT(idx < table->s->fields);
@@ -6613,8 +6617,8 @@ public:
                                   bool mx, bool all):
     select_subselect(thd_arg, item_arg), cache(0), fmax(mx), is_all(all)
   {}
-  void cleanup();
-  int send_data(List<Item> &items);
+  void cleanup() override;
+  int send_data(List<Item> &items) override;
   bool cmp_real();
   bool cmp_int();
   bool cmp_decimal();
@@ -6629,7 +6633,7 @@ class select_exists_subselect :public select_subselect
 public:
   select_exists_subselect(THD *thd_arg, Item_subselect *item_arg):
     select_subselect(thd_arg, item_arg) {}
-  int send_data(List<Item> &items);
+  int send_data(List<Item> &items) override;
 };
 
 
@@ -6886,15 +6890,15 @@ public:
 public:
   multi_delete(THD *thd_arg, TABLE_LIST *dt, uint num_of_tables);
   ~multi_delete();
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
-  int send_data(List<Item> &items);
-  bool initialize_tables (JOIN *join);
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+  int send_data(List<Item> &items) override;
+  bool initialize_tables (JOIN *join) override;
   int do_deletes();
   int do_table_deletes(TABLE *table, SORT_INFO *sort_info, bool ignore);
-  bool send_eof();
+  bool send_eof() override;
   inline ha_rows num_deleted() const { return deleted; }
-  virtual void abort_result_set();
-  void prepare_to_read_rows();
+  void abort_result_set() override;
+  void prepare_to_read_rows() override;
 };
 
 
@@ -6941,17 +6945,17 @@ public:
 	       enum_duplicates handle_duplicates, bool ignore);
   ~multi_update();
   bool init(THD *thd);
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
-  int send_data(List<Item> &items);
-  bool initialize_tables (JOIN *join);
-  int prepare2(JOIN *join);
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+  int send_data(List<Item> &items) override;
+  bool initialize_tables (JOIN *join) override;
+  int prepare2(JOIN *join) override;
   int  do_updates();
-  bool send_eof();
+  bool send_eof() override;
   inline ha_rows num_found() const { return found; }
   inline ha_rows num_updated() const { return updated; }
-  virtual void abort_result_set();
-  void update_used_tables();
-  void prepare_to_read_rows();
+  void abort_result_set() override;
+  void update_used_tables() override;
+  void prepare_to_read_rows() override;
 };
 
 class my_var_sp;
@@ -6983,8 +6987,8 @@ public:
       m_rcontext_handler(rcontext_handler),
       m_type_handler(type_handler), offset(o), sp(s) { }
   ~my_var_sp() = default;
-  bool set(THD *thd, Item *val);
-  my_var_sp *get_my_var_sp() { return this; }
+  bool set(THD *thd, Item *val) override;
+  my_var_sp *get_my_var_sp() override { return this; }
   const Type_handler *type_handler() const { return m_type_handler; }
   sp_rcontext *get_rcontext(sp_rcontext *local_ctx) const;
 };
@@ -7004,7 +7008,7 @@ public:
               &type_handler_double/*Not really used*/, s),
     m_field_offset(field_idx)
   { }
-  bool set(THD *thd, Item *val);
+  bool set(THD *thd, Item *val) override;
 };
 
 class my_var_user: public my_var {
@@ -7012,7 +7016,7 @@ public:
   my_var_user(const LEX_CSTRING *j)
     : my_var(j, SESSION_VAR) { }
   ~my_var_user() = default;
-  bool set(THD *thd, Item *val);
+  bool set(THD *thd, Item *val) override;
 };
 
 class select_dumpvar :public select_result_interceptor {
@@ -7025,11 +7029,11 @@ public:
    :select_result_interceptor(thd_arg), row_count(0), m_var_sp_row(NULL)
   { var_list.empty(); }
   ~select_dumpvar() = default;
-  int prepare(List<Item> &list, SELECT_LEX_UNIT *u);
-  int send_data(List<Item> &items);
-  bool send_eof();
-  virtual bool check_simple_select() const;
-  void cleanup();
+  int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+  int send_data(List<Item> &items) override;
+  bool send_eof() override;
+  bool check_simple_select() const override;
+  void cleanup() override;
 };
 
 /* Bits in sql_command_flags */
@@ -7676,7 +7680,7 @@ public:
   ErrConvDQName(const Database_qualified_name *name)
    :m_name(name)
   { }
-  const char *ptr() const
+  const char *ptr() const override
   {
     m_name->make_qname(err_buffer, sizeof(err_buffer), false);
     return err_buffer;
@@ -7696,10 +7700,10 @@ public:
     m_maybe_null(false)
   { }
 
-  void set_maybe_null(bool maybe_null_arg) { m_maybe_null= maybe_null_arg; }
+  void set_maybe_null(bool maybe_null_arg) override { m_maybe_null= maybe_null_arg; }
   bool get_maybe_null() const { return m_maybe_null; }
 
-  uint decimal_precision() const
+  uint decimal_precision() const override
   {
     /*
       Type_holder is not used directly to create fields, so
@@ -7711,11 +7715,11 @@ public:
     DBUG_ASSERT(0);
     return 0;
   }
-  void set_typelib(const TYPELIB *typelib)
+  void set_typelib(const TYPELIB *typelib) override
   {
     m_typelib= typelib;
   }
-  const TYPELIB *get_typelib() const
+  const TYPELIB *get_typelib() const override
   {
     return m_typelib;
   }

--- a/sql/sql_cmd.h
+++ b/sql/sql_cmd.h
@@ -220,9 +220,9 @@ public:
     :show_all_slaves_status(status_all)
   {}
 
-  enum_sql_command sql_command_code() const { return SQLCOM_SHOW_SLAVE_STAT; }
+  enum_sql_command sql_command_code() const override { return SQLCOM_SHOW_SLAVE_STAT; }
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
   bool is_show_all_slaves_stat() { return show_all_slaves_status; }
 };
 
@@ -231,20 +231,20 @@ class Sql_cmd_create_table_like: public Sql_cmd,
                                  public Storage_engine_name
 {
 public:
-  Storage_engine_name *option_storage_engine_name() { return this; }
-  bool execute(THD *thd);
+  Storage_engine_name *option_storage_engine_name() override { return this; }
+  bool execute(THD *thd) override;
 };
 
 class Sql_cmd_create_table: public Sql_cmd_create_table_like
 {
 public:
-  enum_sql_command sql_command_code() const { return SQLCOM_CREATE_TABLE; }
+  enum_sql_command sql_command_code() const override { return SQLCOM_CREATE_TABLE; }
 };
 
 class Sql_cmd_create_sequence: public Sql_cmd_create_table_like
 {
 public:
-  enum_sql_command sql_command_code() const { return SQLCOM_CREATE_SEQUENCE; }
+  enum_sql_command sql_command_code() const override { return SQLCOM_CREATE_SEQUENCE; }
 };
 
 
@@ -268,9 +268,9 @@ public:
     @param thd the current thread.
     @return false on success.
   */
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_CALL;
   }

--- a/sql/sql_cursor.cc
+++ b/sql/sql_cursor.cc
@@ -49,15 +49,15 @@ public:
   Materialized_cursor(select_result *result, TABLE *table);
 
   int send_result_set_metadata(THD *thd, List<Item> &send_result_set_metadata);
-  virtual bool is_open() const { return table != 0; }
-  virtual int open(JOIN *join __attribute__((unused)));
-  virtual void fetch(ulong num_rows);
-  virtual void close();
-  bool export_structure(THD *thd, Row_definition_list *defs)
+  bool is_open() const override { return table != 0; }
+  int open(JOIN *join __attribute__((unused))) override;
+  void fetch(ulong num_rows) override;
+  void close() override;
+  bool export_structure(THD *thd, Row_definition_list *defs) override
   {
     return table->export_structure(thd, defs);
   }
-  virtual ~Materialized_cursor();
+  ~Materialized_cursor() override;
 
   void on_table_fill_finished();
 };
@@ -79,9 +79,9 @@ public:
   Materialized_cursor *materialized_cursor;
   Select_materialize(THD *thd_arg, select_result *result_arg):
     select_unit(thd_arg), result(result_arg), materialized_cursor(0) {}
-  virtual bool send_result_set_metadata(List<Item> &list, uint flags);
-  bool send_eof() { return false; }
-  bool view_structure_only() const
+  bool send_result_set_metadata(List<Item> &list, uint flags) override;
+  bool send_eof() override { return false; }
+  bool view_structure_only() const override
   {
     return result->view_structure_only();
   }

--- a/sql/sql_error.h
+++ b/sql/sql_error.h
@@ -888,7 +888,7 @@ public:
     : ErrConv(), str(str_arg), len(strlen(str_arg)), cs(cs_arg) {}
   ErrConvString(const String *s)
     : ErrConv(), str(s->ptr()), len(s->length()), cs(s->charset()) {}
-  const char *ptr() const
+  const char *ptr() const override
   {
     return set_str(str, len, cs);
   }
@@ -899,7 +899,7 @@ class ErrConvInteger : public ErrConv, public Longlong_hybrid
 public:
   ErrConvInteger(const Longlong_hybrid &nr)
    : ErrConv(), Longlong_hybrid(nr) { }
-  const char *ptr() const
+  const char *ptr() const override
   {
     return set_longlong(static_cast<Longlong_hybrid>(*this));
   }
@@ -910,7 +910,7 @@ class ErrConvDouble: public ErrConv
   double num;
 public:
   ErrConvDouble(double num_arg) : ErrConv(), num(num_arg) {}
-  const char *ptr() const
+  const char *ptr() const override
   {
     return set_double(num);
   }
@@ -921,7 +921,7 @@ class ErrConvTime : public ErrConv
   const MYSQL_TIME *ltime;
 public:
   ErrConvTime(const MYSQL_TIME *ltime_arg) : ErrConv(), ltime(ltime_arg) {}
-  const char *ptr() const
+  const char *ptr() const override
   {
     return set_mysql_time(ltime);
   }
@@ -932,7 +932,7 @@ class ErrConvDecimal : public ErrConv
   const decimal_t *d;
 public:
   ErrConvDecimal(const decimal_t *d_arg) : ErrConv(), d(d_arg) {}
-  const char *ptr() const
+  const char *ptr() const override
   {
     return set_decimal(d);
   }

--- a/sql/sql_explain.h
+++ b/sql/sql_explain.h
@@ -161,21 +161,21 @@ class Explain_table_access;
 class Explain_basic_join : public Explain_node
 {
 public:
-  enum explain_node_type get_type() { return EXPLAIN_BASIC_JOIN; }
+  enum explain_node_type get_type() override { return EXPLAIN_BASIC_JOIN; }
   
   Explain_basic_join(MEM_ROOT *root) : Explain_node(root), join_tabs(NULL) {}
   ~Explain_basic_join();
 
   bool add_table(Explain_table_access *tab, Explain_query *query);
 
-  int get_select_id() { return select_id; }
+  int get_select_id() override { return select_id; }
 
   int select_id;
 
   int print_explain(Explain_query *query, select_result_sink *output,
-                    uint8 explain_flags, bool is_analyze);
+                    uint8 explain_flags, bool is_analyze) override;
   void print_explain_json(Explain_query *query, Json_writer *writer, 
-                          bool is_analyze);
+                          bool is_analyze) override;
 
   void print_explain_json_interns(Explain_query *query, Json_writer *writer,
                                   bool is_analyze);
@@ -205,7 +205,7 @@ class Explain_aggr_node;
 class Explain_select : public Explain_basic_join
 {
 public:
-  enum explain_node_type get_type() { return EXPLAIN_SELECT; }
+  enum explain_node_type get_type() override { return EXPLAIN_SELECT; }
 
   Explain_select(MEM_ROOT *root, bool is_analyze) : 
   Explain_basic_join(root),
@@ -260,9 +260,9 @@ public:
   Explain_aggr_node* aggr_tree;
 
   int print_explain(Explain_query *query, select_result_sink *output, 
-                    uint8 explain_flags, bool is_analyze);
+                    uint8 explain_flags, bool is_analyze) override;
   void print_explain_json(Explain_query *query, Json_writer *writer, 
-                          bool is_analyze);
+                          bool is_analyze) override;
   
   Table_access_tracker *get_using_temporary_read_tracker()
   {
@@ -299,7 +299,7 @@ class Explain_aggr_filesort : public Explain_aggr_node
   List<Item> sort_items;
   List<ORDER::enum_order> sort_directions;
 public:
-  enum_explain_aggr_node_type get_type() { return AGGR_OP_FILESORT; }
+  enum_explain_aggr_node_type get_type() override { return AGGR_OP_FILESORT; }
   Filesort_tracker tracker;
 
   Explain_aggr_filesort(MEM_ROOT *mem_root, bool is_analyze, 
@@ -311,20 +311,20 @@ public:
 class Explain_aggr_tmp_table : public Explain_aggr_node
 {
 public:
-  enum_explain_aggr_node_type get_type() { return AGGR_OP_TEMP_TABLE; }
+  enum_explain_aggr_node_type get_type() override { return AGGR_OP_TEMP_TABLE; }
 };
 
 class Explain_aggr_remove_dups : public Explain_aggr_node
 {
 public:
-  enum_explain_aggr_node_type get_type() { return AGGR_OP_REMOVE_DUPLICATES; }
+  enum_explain_aggr_node_type get_type() override { return AGGR_OP_REMOVE_DUPLICATES; }
 };
 
 class Explain_aggr_window_funcs : public Explain_aggr_node
 {
   List<Explain_aggr_filesort> sorts;
 public:
-  enum_explain_aggr_node_type get_type() { return AGGR_OP_WINDOW_FUNCS; }
+  enum_explain_aggr_node_type get_type() override { return AGGR_OP_WINDOW_FUNCS; }
 
   void print_json_members(Json_writer *writer, bool is_analyze);
   friend class Window_funcs_computation;
@@ -351,10 +351,10 @@ public:
     fake_select_lex_explain(root, is_analyze)
   {}
 
-  enum explain_node_type get_type() { return EXPLAIN_UNION; }
+  enum explain_node_type get_type() override { return EXPLAIN_UNION; }
   unit_common_op operation;
 
-  int get_select_id()
+  int get_select_id() override
   {
     DBUG_ASSERT(union_members.elements() > 0);
     return union_members.at(0);
@@ -377,9 +377,9 @@ public:
     union_members.append(select_no);
   }
   int print_explain(Explain_query *query, select_result_sink *output, 
-                    uint8 explain_flags, bool is_analyze);
+                    uint8 explain_flags, bool is_analyze) override;
   void print_explain_json(Explain_query *query, Json_writer *writer, 
-                          bool is_analyze);
+                          bool is_analyze) override;
 
   const char *fake_select_type;
   bool using_filesort;
@@ -886,8 +886,8 @@ public:
     command_tracker(is_analyze)
   {}
 
-  virtual enum explain_node_type get_type() { return EXPLAIN_UPDATE; }
-  virtual int get_select_id() { return 1; /* always root */ }
+  enum explain_node_type get_type() override { return EXPLAIN_UPDATE; }
+  int get_select_id() override { return 1; /* always root */ }
 
   const char *select_type;
 
@@ -943,10 +943,10 @@ public:
   /* TODO: This tracks time to read rows from the table */
   Exec_time_tracker table_tracker;
 
-  virtual int print_explain(Explain_query *query, select_result_sink *output, 
-                            uint8 explain_flags, bool is_analyze);
-  virtual void print_explain_json(Explain_query *query, Json_writer *writer,
-                                  bool is_analyze);
+  int print_explain(Explain_query *query, select_result_sink *output, 
+                    uint8 explain_flags, bool is_analyze) override;
+  void print_explain_json(Explain_query *query, Json_writer *writer,
+                          bool is_analyze) override;
 };
 
 
@@ -966,13 +966,13 @@ public:
 
   StringBuffer<64> table_name;
 
-  enum explain_node_type get_type() { return EXPLAIN_INSERT; }
-  int get_select_id() { return 1; /* always root */ }
+  enum explain_node_type get_type() override { return EXPLAIN_INSERT; }
+  int get_select_id() override { return 1; /* always root */ }
 
   int print_explain(Explain_query *query, select_result_sink *output, 
-                    uint8 explain_flags, bool is_analyze);
+                    uint8 explain_flags, bool is_analyze) override;
   void print_explain_json(Explain_query *query, Json_writer *writer, 
-                          bool is_analyze);
+                          bool is_analyze) override;
 };
 
 
@@ -993,13 +993,13 @@ public:
   */
   bool deleting_all_rows;
 
-  virtual enum explain_node_type get_type() { return EXPLAIN_DELETE; }
-  virtual int get_select_id() { return 1; /* always root */ }
+  enum explain_node_type get_type() override { return EXPLAIN_DELETE; }
+  int get_select_id() override { return 1; /* always root */ }
 
-  virtual int print_explain(Explain_query *query, select_result_sink *output, 
-                            uint8 explain_flags, bool is_analyze);
-  virtual void print_explain_json(Explain_query *query, Json_writer *writer,
-                                  bool is_analyze);
+  int print_explain(Explain_query *query, select_result_sink *output, 
+                    uint8 explain_flags, bool is_analyze) override;
+  void print_explain_json(Explain_query *query, Json_writer *writer,
+                          bool is_analyze) override;
 };
 
 

--- a/sql/sql_expression_cache.h
+++ b/sql/sql_expression_cache.h
@@ -113,19 +113,19 @@ class Expression_cache_tmptable :public Expression_cache
 public:
   Expression_cache_tmptable(THD *thd, List<Item> &dependants, Item *value);
   virtual ~Expression_cache_tmptable();
-  virtual result check_value(Item **value);
-  virtual my_bool put_value(Item *value);
+  result check_value(Item **value) override;
+  my_bool put_value(Item *value) override;
 
-  void print(String *str, enum_query_type query_type);
-  bool is_inited() { return inited; };
-  void init();
+  void print(String *str, enum_query_type query_type) override;
+  bool is_inited() override { return inited; };
+  void init() override;
 
   void set_tracker(Expression_cache_tracker *st)
   {
     tracker= st;
     update_tracker();
   }
-  virtual void update_tracker()
+  void update_tracker() override
   {
     if (tracker)
     {

--- a/sql/sql_get_diagnostics.h
+++ b/sql/sql_get_diagnostics.h
@@ -39,12 +39,12 @@ public:
     : m_info(info)
   {}
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_GET_DIAGNOSTICS;
   }
 
-  virtual bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
 private:
   /** The information to be obtained. */
@@ -223,7 +223,7 @@ public:
   {}
 
   /** Obtain statement information in the context of a diagnostics area. */
-  bool aggregate(THD *thd, const Diagnostics_area *da);
+  bool aggregate(THD *thd, const Diagnostics_area *da) override;
 
 private:
   /* List of statement information items. */
@@ -301,7 +301,7 @@ public:
   {}
 
   /** Obtain condition information in the context of a diagnostics area. */
-  bool aggregate(THD *thd, const Diagnostics_area *da);
+  bool aggregate(THD *thd, const Diagnostics_area *da) override;
 
 private:
   /**

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2298,7 +2298,7 @@ public:
       forced_insert_id(0), query(query_arg), time_zone(0),
       user(0), host(0), ip(0)
     {}
-  ~delayed_row()
+  ~delayed_row() override
   {
     my_free(query.str);
     my_free(record);
@@ -2381,7 +2381,7 @@ public:
                                           TL_WRITE_LOW_PRIORITY : TL_WRITE;
     DBUG_VOID_RETURN;
   }
-  ~Delayed_insert()
+  ~Delayed_insert() override
   {
     /* The following is not really needed, but just for safety */
     delayed_row *row;
@@ -3057,13 +3057,13 @@ void kill_delayed_threads(void)
 class Delayed_prelocking_strategy : public Prelocking_strategy
 {
 public:
-  virtual bool handle_routine(THD *thd, Query_tables_list *prelocking_ctx,
+  bool handle_routine(THD *thd, Query_tables_list *prelocking_ctx,
                               Sroutine_hash_entry *rt, sp_head *sp,
-                              bool *need_prelocking);
-  virtual bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
-                            TABLE_LIST *table_list, bool *need_prelocking);
-  virtual bool handle_view(THD *thd, Query_tables_list *prelocking_ctx,
-                           TABLE_LIST *table_list, bool *need_prelocking);
+                              bool *need_prelocking) override;
+  bool handle_table(THD *thd, Query_tables_list *prelocking_ctx,
+                            TABLE_LIST *table_list, bool *need_prelocking) override;
+  bool handle_view(THD *thd, Query_tables_list *prelocking_ctx,
+                           TABLE_LIST *table_list, bool *need_prelocking) override;
 };
 
 
@@ -4729,7 +4729,7 @@ select_create::prepare(List<Item> &_values, SELECT_LEX_UNIT *u)
       }
 
   private:
-    virtual int do_postlock(TABLE **tables, uint count)
+    int do_postlock(TABLE **tables, uint count) override
     {
       int error;
       THD *thd= const_cast<THD*>(ptr->get_thd());

--- a/sql/sql_join_cache.h
+++ b/sql/sql_join_cache.h
@@ -940,7 +940,7 @@ protected:
   }
   
   /* Get the total length of all prefixes of a record in hashed join buffer */ 
-  uint get_prefix_length() 
+  uint get_prefix_length() override 
   { 
     return base_prefix_length + get_size_of_rec_offset();
   }
@@ -949,13 +949,13 @@ protected:
     Get maximum size of the additional space per record used for
     the hash table with record keys
   */
-  uint get_max_key_addon_space_per_record();
+  uint get_max_key_addon_space_per_record() override;
 
   /* 
     Calculate how much space in the buffer would not be occupied by
     records, key entries and additional memory for the MMR buffer.
   */ 
-  size_t rem_space() 
+  size_t rem_space() override 
   { 
     return MY_MAX(last_key_entry-end_pos-aux_buff_size,0);
   }
@@ -964,25 +964,25 @@ protected:
     Calculate how much space is taken by allocation of the key
     entry for a record in the join buffer
   */
-  uint extra_key_length() { return key_entry_length; }
+  uint extra_key_length() override { return key_entry_length; }
 
   /* 
     Skip record from a hashed join buffer if its match flag
     is set to MATCH_FOUND
   */
-  bool skip_if_matched();
+  bool skip_if_matched() override;
 
   /*
     Skip record from a hashed join buffer if its match flag setting 
     commands to do so
   */
-  bool skip_if_not_needed_match();
+  bool skip_if_not_needed_match() override;
 
   /* Search for a key in the hash table of the join buffer */
   bool key_search(uchar *key, uint key_len, uchar **key_ref_ptr);
 
   /* Reallocate the join buffer of a hashed join cache */
-  int realloc_buffer();
+  int realloc_buffer() override;
 
   /* 
     This constructor creates an unlinked hashed join cache. The cache is to be
@@ -1003,16 +1003,16 @@ protected:
 public:
 
   /* Initialize a hashed join cache */       
-  int init(bool for_explain);
+  int init(bool for_explain) override;
 
   /* Reset the buffer of a hashed join cache for reading/writing */
-  void reset(bool for_writing);
+  void reset(bool for_writing) override;
 
   /* Add a record into the buffer of a hashed join cache */
-  bool put_record();
+  bool put_record() override;
 
   /* Read the next record from the buffer of a hashed join cache */
-  bool get_record();
+  bool get_record() override;
 
   /*
     Shall check whether all records in a key chain have 
@@ -1112,13 +1112,13 @@ private:
 
 protected:
 
-  bool prepare_look_for_matches(bool skip_last);
+  bool prepare_look_for_matches(bool skip_last) override;
 
-  uchar *get_next_candidate_for_match();
+  uchar *get_next_candidate_for_match() override;
 
-  bool skip_next_candidate_for_match(uchar *rec_ptr);
+  bool skip_next_candidate_for_match(uchar *rec_ptr) override;
 
-  void read_next_candidate_for_match(uchar *rec_ptr);
+  void read_next_candidate_for_match(uchar *rec_ptr) override;
 
 public:
 
@@ -1139,11 +1139,11 @@ public:
     :JOIN_CACHE(j, tab, prev) {}
 
   /* Initialize the BNL cache */       
-  int init(bool for_explain);
+  int init(bool for_explain) override;
 
-  enum Join_algorithm get_join_alg() { return BNL_JOIN_ALG; }
+  enum Join_algorithm get_join_alg() override { return BNL_JOIN_ALG; }
 
-  bool is_key_access() { return FALSE; }
+  bool is_key_access() override { return FALSE; }
 
 };
 
@@ -1179,13 +1179,13 @@ protected:
   */
   uchar *get_matching_chain_by_join_key();
 
-  bool prepare_look_for_matches(bool skip_last);
+  bool prepare_look_for_matches(bool skip_last) override;
 
-  uchar *get_next_candidate_for_match();
+  uchar *get_next_candidate_for_match() override;
 
-  bool skip_next_candidate_for_match(uchar *rec_ptr);
+  bool skip_next_candidate_for_match(uchar *rec_ptr) override;
 
-  void read_next_candidate_for_match(uchar *rec_ptr);
+  void read_next_candidate_for_match(uchar *rec_ptr) override;
 
 public:
 
@@ -1206,11 +1206,11 @@ public:
     : JOIN_CACHE_HASHED(j, tab, prev) {}
 
   /* Initialize the BNLH cache */       
-  int init(bool for_explain);
+  int init(bool for_explain) override;
 
-  enum Join_algorithm get_join_alg() { return BNLH_JOIN_ALG; }
+  enum Join_algorithm get_join_alg() override { return BNLH_JOIN_ALG; }
 
-  bool is_key_access() { return TRUE; }
+  bool is_key_access() override { return TRUE; }
 
 };
 
@@ -1253,11 +1253,11 @@ public:
   JOIN_TAB_SCAN_MRR(JOIN *j, JOIN_TAB *tab, uint flags, RANGE_SEQ_IF rs_funcs)
     :JOIN_TAB_SCAN(j, tab), range_seq_funcs(rs_funcs), mrr_mode(flags) {}
 
-  uint aux_buffer_incr(size_t recno);
+  uint aux_buffer_incr(size_t recno) override;
 
-  int open();
+  int open() override;
  
-  int next();
+  int next() override;
 
   friend class JOIN_CACHE_BKA; /* it needs to add an mrr_mode flag after JOIN_CACHE::init() call */
 };
@@ -1293,26 +1293,26 @@ protected:
     Get the number of ranges in the cache buffer passed to the MRR
     interface. For each record its own range is passed.
   */
-  uint get_number_of_ranges_for_mrr() { return (uint)records; }
+  uint get_number_of_ranges_for_mrr() override { return (uint)records; }
 
  /*
    Setup the MRR buffer as the space between the last record put
    into the join buffer and the very end of the join buffer 
  */
-  int setup_aux_buffer(HANDLER_BUFFER &aux_buff)
+  int setup_aux_buffer(HANDLER_BUFFER &aux_buff) override
   {
     aux_buff.buffer= end_pos;
     aux_buff.buffer_end= buff+buff_size;
     return 0;
   }
 
-  bool prepare_look_for_matches(bool skip_last);
+  bool prepare_look_for_matches(bool skip_last) override;
 
-  uchar *get_next_candidate_for_match();
+  uchar *get_next_candidate_for_match() override;
 
-  bool skip_next_candidate_for_match(uchar *rec_ptr);
+  bool skip_next_candidate_for_match(uchar *rec_ptr) override;
 
-  void read_next_candidate_for_match(uchar *rec_ptr);
+  void read_next_candidate_for_match(uchar *rec_ptr) override;
 
 public:
 
@@ -1338,14 +1338,14 @@ public:
     :JOIN_CACHE(bka->join, bka->join_tab, bka->prev_cache),
       mrr_mode(bka->mrr_mode)  {}
 
-  uchar **get_curr_association_ptr() { return &curr_association; }
+  uchar **get_curr_association_ptr() override { return &curr_association; }
 
   /* Initialize the BKA cache */       
-  int init(bool for_explain);
+  int init(bool for_explain) override;
 
-  enum Join_algorithm get_join_alg() { return BKA_JOIN_ALG; }
+  enum Join_algorithm get_join_alg() override { return BKA_JOIN_ALG; }
 
-  bool is_key_access() { return TRUE; }
+  bool is_key_access() override { return TRUE; }
 
   /* Get the key built over the next record from the join buffer */
   uint get_next_key(uchar **key);
@@ -1353,7 +1353,7 @@ public:
   /* Check index condition of the joined table for a record from BKA cache */
   bool skip_index_tuple(range_id_t range_info);
 
-  bool save_explain_data(EXPLAIN_BKA_TYPE *explain);
+  bool save_explain_data(EXPLAIN_BKA_TYPE *explain) override;
 };
 
 
@@ -1389,21 +1389,21 @@ private:
 
 protected:
 
-  uint get_number_of_ranges_for_mrr() { return key_entries; }
+  uint get_number_of_ranges_for_mrr() override { return key_entries; }
 
   /* 
     Initialize the MRR buffer allocating some space within the join buffer.
     The entire space between the last record put into the join buffer and the
     last key entry added to the hash table is used for the MRR buffer.
   */
-  int setup_aux_buffer(HANDLER_BUFFER &aux_buff)
+  int setup_aux_buffer(HANDLER_BUFFER &aux_buff) override
   {
     aux_buff.buffer= end_pos;
     aux_buff.buffer_end= last_key_entry;
     return 0;
   }
 
-  bool prepare_look_for_matches(bool skip_last);
+  bool prepare_look_for_matches(bool skip_last) override;
 
   /*
     The implementations of the methods
@@ -1438,15 +1438,15 @@ public:
     :JOIN_CACHE_BNLH(bkah->join, bkah->join_tab, bkah->prev_cache),
       mrr_mode(bkah->mrr_mode)  {}
 
-  uchar **get_curr_association_ptr() { return &curr_matching_chain; }
+  uchar **get_curr_association_ptr() override { return &curr_matching_chain; }
 
   /* Initialize the BKAH cache */       
-  int init(bool for_explain);
+  int init(bool for_explain) override;
 
-  enum Join_algorithm get_join_alg() { return BKAH_JOIN_ALG; }
+  enum Join_algorithm get_join_alg() override { return BKAH_JOIN_ALG; }
 
   /* Check index condition of the joined table for a record from BKAH cache */
   bool skip_index_tuple(range_id_t range_info);
 
-  bool save_explain_data(EXPLAIN_BKA_TYPE *explain);
+  bool save_explain_data(EXPLAIN_BKA_TYPE *explain) override;
 };

--- a/sql/sql_lifo_buffer.h
+++ b/sql/sql_lifo_buffer.h
@@ -162,22 +162,22 @@ class Forward_lifo_buffer: public Lifo_buffer
 {
   uchar *pos;
 public:
-  enum_direction type() { return FORWARD; }
-  size_t used_size()
+  enum_direction type() override { return FORWARD; }
+  size_t used_size() override
   {
     return (size_t)(pos - start);
   }
-  void reset()
+  void reset() override
   {
     pos= start;
   }
-  uchar *end_of_space() { return pos; }
-  bool have_space_for(size_t bytes)
+  uchar *end_of_space() override { return pos; }
+  bool have_space_for(size_t bytes) override
   {
     return (pos + bytes < end);
   }
 
-  void write()
+  void write() override
   {
     write_bytes(write_ptr1, size1);
     if (size2)
@@ -199,8 +199,8 @@ public:
     *position= (*position) - bytes;
     return *position;
   }
-  bool read() { return read(&pos, &read_ptr1, &read_ptr2); }
-  bool read(uchar **position, uchar **ptr1, uchar **ptr2)
+  bool read() override { return read(&pos, &read_ptr1, &read_ptr2); }
+  bool read(uchar **position, uchar **ptr1, uchar **ptr2) override
   {
     if (!have_data(*position, size1 + size2))
       return TRUE;
@@ -209,7 +209,7 @@ public:
     *ptr1= read_bytes(position, size1);
     return FALSE;
   }
-  void remove_unused_space(uchar **unused_start, uchar **unused_end)
+  void remove_unused_space(uchar **unused_start, uchar **unused_end) override
   {
     DBUG_ASSERT(0); /* Don't need this yet */
   }
@@ -228,9 +228,9 @@ public:
     end= unused_end;
   }
   /* Return pointer to start of the memory area that is occupied by the data */
-  uchar *used_area() { return start; }
+  uchar *used_area() override { return start; }
   friend class Lifo_buffer_iterator;
-  uchar *get_pos() { return pos; }
+  uchar *get_pos() override { return pos; }
 };
 
 
@@ -254,22 +254,22 @@ class Backward_lifo_buffer: public Lifo_buffer
 {
   uchar *pos;
 public:
-  enum_direction type() { return BACKWARD; }
+  enum_direction type() override { return BACKWARD; }
  
-  size_t used_size()
+  size_t used_size() override
   {
     return (size_t)(end - pos);
   }
-  void reset()
+  void reset() override
   {
     pos= end;
   }
-  uchar *end_of_space() { return end; }
-  bool have_space_for(size_t bytes)
+  uchar *end_of_space() override { return end; }
+  bool have_space_for(size_t bytes) override
   {
     return (pos - bytes >= start);
   }
-  void write()
+  void write() override
   {
     if (write_ptr2)
       write_bytes(write_ptr2, size2);
@@ -281,11 +281,11 @@ public:
     pos -= bytes;
     memcpy(pos, data, bytes);
   }
-  bool read()
+  bool read() override
   {
     return read(&pos, &read_ptr1, &read_ptr2);
   }
-  bool read(uchar **position, uchar **ptr1, uchar **ptr2)
+  bool read(uchar **position, uchar **ptr1, uchar **ptr2) override
   {
     if (!have_data(*position, size1 + size2))
       return TRUE;
@@ -310,7 +310,7 @@ public:
     @param unused_start  OUT Start of the unused space
     @param unused_end    OUT End of the unused space
   */
-  void remove_unused_space(uchar **unused_start, uchar **unused_end)
+  void remove_unused_space(uchar **unused_start, uchar **unused_end) override
   {
     *unused_start= start;
     *unused_end= pos;
@@ -321,9 +321,9 @@ public:
     DBUG_ASSERT(0); /* Not used for backward buffers */
   }
   /* Return pointer to start of the memory area that is occupied by the data */
-  uchar *used_area() { return pos; }
+  uchar *used_area() override { return pos; }
   friend class Lifo_buffer_iterator;
-  uchar *get_pos() { return pos; }
+  uchar *get_pos() override { return pos; }
 };
 
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1528,14 +1528,14 @@ class Silence_all_errors : public Internal_error_handler
   int error;
 public:
   Silence_all_errors():error(0) {}
-  virtual ~Silence_all_errors() {}
+  ~Silence_all_errors() override {}
 
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                 uint sql_errno,
                                 const char* sql_state,
                                 Sql_condition::enum_warning_level *level,
                                 const char* msg,
-                                Sql_condition ** cond_hdl)
+                                Sql_condition ** cond_hdl) override
   {
     error= sql_errno;
     *cond_hdl= NULL;

--- a/sql/sql_partition_admin.h
+++ b/sql/sql_partition_admin.h
@@ -129,7 +129,7 @@ public:
 
   ~Sql_cmd_alter_table_exchange_partition() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
 private:
   bool exchange_partition(THD *thd, TABLE_LIST *, Alter_info *);
@@ -151,10 +151,10 @@ public:
 
   ~Sql_cmd_alter_table_analyze_partition() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
   /* Override SQLCOM_ANALYZE, since it is an ALTER command */
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ALTER_TABLE;
   }
@@ -176,10 +176,10 @@ public:
 
   ~Sql_cmd_alter_table_check_partition() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
   /* Override SQLCOM_CHECK, since it is an ALTER command */
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ALTER_TABLE;
   }
@@ -201,10 +201,10 @@ public:
 
   ~Sql_cmd_alter_table_optimize_partition() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
   /* Override SQLCOM_OPTIMIZE, since it is an ALTER command */
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ALTER_TABLE;
   }
@@ -226,10 +226,10 @@ public:
 
   ~Sql_cmd_alter_table_repair_partition() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
   /* Override SQLCOM_REPAIR, since it is an ALTER command */
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ALTER_TABLE;
   }
@@ -249,10 +249,10 @@ public:
 
   virtual ~Sql_cmd_alter_table_truncate_partition() = default;
 
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
   /* Override SQLCOM_TRUNCATE, since it is an ALTER command */
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_ALTER_TABLE;
   }

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -314,22 +314,22 @@ public:
   sys_var_pluginvar(sys_var_chain *chain, const char *name_arg,
                     st_plugin_int *p, st_mysql_sys_var *plugin_var_arg,
                     const char *substitute);
-  sys_var_pluginvar *cast_pluginvar() { return this; }
+  sys_var_pluginvar *cast_pluginvar() override { return this; }
   uchar* real_value_ptr(THD *thd, enum_var_type type) const;
   TYPELIB* plugin_var_typelib(void) const;
   const uchar* do_value_ptr(THD *thd, enum_var_type type, const LEX_CSTRING *base) const;
-  const uchar* session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar* session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return do_value_ptr(thd, OPT_SESSION, base); }
-  const uchar* global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar* global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return do_value_ptr(thd, OPT_GLOBAL, base); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return do_value_ptr(thd, OPT_DEFAULT, 0); }
-  bool do_check(THD *thd, set_var *var);
-  virtual void session_save_default(THD *thd, set_var *var) {}
-  virtual void global_save_default(THD *thd, set_var *var) {}
-  bool session_update(THD *thd, set_var *var);
-  bool global_update(THD *thd, set_var *var);
-  bool session_is_default(THD *thd);
+  bool do_check(THD *thd, set_var *var) override;
+  void session_save_default(THD *thd, set_var *var) override {}
+  void global_save_default(THD *thd, set_var *var) override {}
+  bool session_update(THD *thd, set_var *var) override;
+  bool global_update(THD *thd, set_var *var) override;
+  bool session_is_default(THD *thd) override;
 };
 
 

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -140,11 +140,11 @@ class Select_fetch_protocol_binary: public select_send
   Protocol_binary protocol;
 public:
   Select_fetch_protocol_binary(THD *thd);
-  virtual bool send_result_set_metadata(List<Item> &list, uint flags);
-  virtual int send_data(List<Item> &items);
-  virtual bool send_eof();
+  bool send_result_set_metadata(List<Item> &list, uint flags) override;
+  int send_data(List<Item> &items) override;
+  bool send_eof() override;
 #ifdef EMBEDDED_LIBRARY
-  void begin_dataset()
+  void begin_dataset() override
   {
     protocol.begin_dataset();
   }
@@ -204,10 +204,10 @@ public:
                                         String *expanded_query);
 public:
   Prepared_statement(THD *thd_arg);
-  virtual ~Prepared_statement();
+  ~Prepared_statement() override;
   void setup_set_params();
-  virtual Query_arena::Type type() const;
-  virtual void cleanup_stmt();
+  Query_arena::Type type() const override;
+  void cleanup_stmt() override;
   bool set_name(const LEX_CSTRING *name);
   inline void close_cursor() { delete cursor; cursor= 0; }
   inline bool is_in_use() { return flags & (uint) IS_IN_USE; }
@@ -252,7 +252,7 @@ class Execute_sql_statement: public Server_runnable
 {
 public:
   Execute_sql_statement(LEX_STRING sql_text);
-  virtual bool execute_server_code(THD *thd);
+  bool execute_server_code(THD *thd) override;
 private:
   LEX_STRING m_sql_text;
 };
@@ -5535,29 +5535,33 @@ public:
     thd->set_binlog_bit();
   }
 protected:
-  bool net_store_data(const uchar *from, size_t length);
+  bool net_store_data(const uchar *from, size_t length) override;
   bool net_store_data_cs(const uchar *from, size_t length,
-                         CHARSET_INFO *fromcs, CHARSET_INFO *tocs);
-  bool net_send_eof(THD *thd, uint server_status, uint statement_warn_count);
+                         CHARSET_INFO *fromcs, CHARSET_INFO *tocs) override;
+  bool net_send_eof(THD *thd, uint server_status, uint statement_warn_count) override;
   bool net_send_ok(THD *, uint, uint, ulonglong, ulonglong, const char *,
-                   bool, bool);
-  bool net_send_error_packet(THD *, uint, const char *, const char *);
+                   bool, bool) override;
+  bool net_send_error_packet(THD *, uint, const char *, const char *) override;
   bool begin_dataset();
   bool begin_dataset(THD *thd, uint numfields);
 
-  bool write();
-  bool flush();
+  bool write() override;
+  bool flush() override;
 
   bool store_field_metadata(const THD *thd, const Send_field &field,
                             CHARSET_INFO *charset_for_protocol,
                             uint pos);
-  bool send_result_set_metadata(List<Item> *list, uint flags);
+  bool send_result_set_metadata(List<Item> *list, uint flags) override;
+#ifdef EMBEDDED_LIBRARY
+  void remove_last_row() override;
+#else
   void remove_last_row();
-  bool store_null();
-  void prepare_for_resend();
+#endif
+  bool store_null() override;
+  void prepare_for_resend() override;
   bool send_list_fields(List<Field> *list, const TABLE_LIST *table_list);
  
-  enum enum_protocol_type type() { return PROTOCOL_LOCAL; };
+  enum enum_protocol_type type() override { return PROTOCOL_LOCAL; };
 };
 
 static

--- a/sql/sql_schema.cc
+++ b/sql/sql_schema.cc
@@ -26,7 +26,7 @@ public:
    :Schema(name)
   { }
   const Type_handler *map_data_type(THD *thd, const Type_handler *src)
-                                    const
+                                    const override
   {
     if (src == &type_handler_newdate)
       return thd->type_handler_for_datetime();
@@ -34,7 +34,7 @@ public:
   }
 
   Create_func *find_native_function_builder(THD *thd, const LEX_CSTRING &name)
-                                                                         const
+                                                                         const override
   {
     return native_functions_hash_oracle.find(thd, name);
   }
@@ -42,10 +42,10 @@ public:
   Item *make_item_func_replace(THD *thd,
                                Item *subj,
                                Item *find,
-                               Item *replace) const;
+                               Item *replace) const override;
   Item *make_item_func_substr(THD *thd,
-                              const Lex_substring_spec_st &spec) const;
-  Item *make_item_func_trim(THD *thd, const Lex_trim_st &spec) const;
+                              const Lex_substring_spec_st &spec) const override;
+  Item *make_item_func_trim(THD *thd, const Lex_trim_st &spec) const override;
 };
 
 
@@ -56,7 +56,7 @@ public:
    :Schema(name)
   { }
   const Type_handler *map_data_type(THD *thd, const Type_handler *src)
-                                    const
+                                    const override
   {
     if (src == &type_handler_timestamp ||
         src == &type_handler_timestamp2)

--- a/sql/sql_select.h
+++ b/sql/sql_select.h
@@ -770,13 +770,13 @@ class Duplicate_weedout_picker : public Semi_join_strategy_picker
   
   bool is_used;
 public:
-  void set_empty()
+  void set_empty() override
   {
     dupsweedout_tables= 0;
     first_dupsweedout_table= MAX_TABLES;
     is_used= FALSE;
   }
-  void set_from_prev(POSITION *prev);
+  void set_from_prev(POSITION *prev) override;
   
   bool check_qep(JOIN *join,
                  uint idx,
@@ -786,9 +786,9 @@ public:
                  double *read_time,
                  table_map *handled_fanout,
                  sj_strategy_enum *stratey,
-                 POSITION *loose_scan_pos);
+                 POSITION *loose_scan_pos) override;
 
-  void mark_used() { is_used= TRUE; }
+  void mark_used() override { is_used= TRUE; }
   friend void fix_semijoin_strategies_for_picked_join_order(JOIN *join);
 };
 
@@ -816,13 +816,13 @@ class Firstmatch_picker : public Semi_join_strategy_picker
   bool in_firstmatch_prefix() { return (first_firstmatch_table != MAX_TABLES); }
   void invalidate_firstmatch_prefix() { first_firstmatch_table= MAX_TABLES; }
 public:
-  void set_empty()
+  void set_empty() override
   {
     invalidate_firstmatch_prefix();
     is_used= FALSE;
   }
 
-  void set_from_prev(POSITION *prev);
+  void set_from_prev(POSITION *prev) override;
   bool check_qep(JOIN *join,
                  uint idx,
                  table_map remaining_tables, 
@@ -831,9 +831,9 @@ public:
                  double *read_time,
                  table_map *handled_fanout,
                  sj_strategy_enum *strategy,
-                 POSITION *loose_scan_pos);
+                 POSITION *loose_scan_pos) override;
 
-  void mark_used() { is_used= TRUE; }
+  void mark_used() override { is_used= TRUE; }
   friend void fix_semijoin_strategies_for_picked_join_order(JOIN *join);
 };
 
@@ -859,13 +859,13 @@ public:
   uint loosescan_parts; /* Number of keyparts to be kept distinct */
   
   bool is_used;
-  void set_empty()
+  void set_empty() override
   {
     first_loosescan_table= MAX_TABLES; 
     is_used= FALSE;
   }
 
-  void set_from_prev(POSITION *prev);
+  void set_from_prev(POSITION *prev) override;
   bool check_qep(JOIN *join,
                  uint idx,
                  table_map remaining_tables, 
@@ -874,8 +874,8 @@ public:
                  double *read_time,
                  table_map *handled_fanout,
                  sj_strategy_enum *strategy,
-                 POSITION *loose_scan_pos);
-  void mark_used() { is_used= TRUE; }
+                 POSITION *loose_scan_pos) override;
+  void mark_used() override { is_used= TRUE; }
 
   friend class Loose_scan_opt;
   friend void best_access_path(JOIN      *join,
@@ -907,13 +907,13 @@ class Sj_materialization_picker : public Semi_join_strategy_picker
   table_map sjm_scan_need_tables;
 
 public:
-  void set_empty()
+  void set_empty() override
   {
     sjm_scan_need_tables= 0;
     sjm_scan_last_inner= 0;
     is_used= FALSE;
   }
-  void set_from_prev(POSITION *prev);
+  void set_from_prev(POSITION *prev) override;
   bool check_qep(JOIN *join,
                  uint idx,
                  table_map remaining_tables, 
@@ -922,8 +922,8 @@ public:
                  double *read_time,
                  table_map *handled_fanout,
                  sj_strategy_enum *strategy,
-                 POSITION *loose_scan_pos);
-  void mark_used() { is_used= TRUE; }
+                 POSITION *loose_scan_pos) override;
+  void mark_used() override { is_used= TRUE; }
 
   friend void fix_semijoin_strategies_for_picked_join_order(JOIN *join);
 };
@@ -2012,8 +2012,8 @@ class store_key_field: public store_key
     }
   }  
 
-  enum Type type() const { return FIELD_STORE_KEY; }
-  const char *name() const { return field_name; }
+  enum Type type() const override { return FIELD_STORE_KEY; }
+  const char *name() const override { return field_name; }
 
   void change_source_field(Item_field *fld_item)
   {
@@ -2022,7 +2022,7 @@ class store_key_field: public store_key
   }
 
  protected: 
-  enum store_key_result copy_inner()
+  enum store_key_result copy_inner() override
   {
     TABLE *table= copy_field.to_field->table;
     MY_BITMAP *old_map= dbug_tmp_use_all_columns(table,
@@ -2065,11 +2065,11 @@ public:
   {}
 
 
-  enum Type type() const { return ITEM_STORE_KEY; }
-  const char *name() const { return "func"; }
+  enum Type type() const override { return ITEM_STORE_KEY; }
+  const char *name() const override { return "func"; }
 
  protected:  
-  enum store_key_result copy_inner()
+  enum store_key_result copy_inner() override
   {
     TABLE *table= to_field->table;
     MY_BITMAP *old_map= dbug_tmp_use_all_columns(table,
@@ -2118,12 +2118,12 @@ public:
     :store_key_item(arg, new_item, FALSE), inited(0)
   {}
 
-  enum Type type() const { return CONST_ITEM_STORE_KEY; }
-  const char *name() const { return "const"; }
-  bool store_key_is_const() { return true; }
+  enum Type type() const override { return CONST_ITEM_STORE_KEY; }
+  const char *name() const override { return "const"; }
+  bool store_key_is_const() override { return true; }
 
 protected:  
-  enum store_key_result copy_inner()
+  enum store_key_result copy_inner() override
   {
     int res;
     if (!inited)

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1061,7 +1061,7 @@ public:
 
   bool handle_condition(THD *thd, uint sql_errno, const char * /* sqlstate */,
                         Sql_condition::enum_warning_level *level,
-                        const char *message, Sql_condition ** /* cond_hdl */)
+                        const char *message, Sql_condition ** /* cond_hdl */) override
   {
     /*
        The handler does not handle the errors raised by itself.
@@ -5101,7 +5101,7 @@ class Warnings_only_error_handler : public Internal_error_handler
 public:
   bool handle_condition(THD *thd, uint sql_errno, const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
-                        const char* msg, Sql_condition ** cond_hdl)
+                        const char* msg, Sql_condition ** cond_hdl) override
   {
     if (sql_errno == ER_TRG_NO_DEFINER || sql_errno == ER_TRG_NO_CREATION_CTX
         || sql_errno == ER_PARSE_ERROR)
@@ -10304,12 +10304,12 @@ class IS_internal_schema_access : public ACL_internal_schema_access
 public:
   IS_internal_schema_access() = default;
 
-  ~IS_internal_schema_access() = default;
+  ~IS_internal_schema_access() override = default;
 
   ACL_internal_access_result check(privilege_t want_access,
-                                   privilege_t *save_priv) const;
+                                   privilege_t *save_priv) const override;
 
-  const ACL_internal_table_access *lookup(const char *name) const;
+  const ACL_internal_table_access *lookup(const char *name) const override;
 };
 
 ACL_internal_access_result

--- a/sql/sql_show.h
+++ b/sql/sql_show.h
@@ -174,7 +174,7 @@ public:
   String query_str;
   
   /* Overloaded virtual function */
-  void call_in_target_thread();
+  void call_in_target_thread() override;
 };
 
 /**

--- a/sql/sql_signal.h
+++ b/sql/sql_signal.h
@@ -85,12 +85,12 @@ public:
 
   virtual ~Sql_cmd_signal() = default;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_SIGNAL;
   }
 
-  virtual bool execute(THD *thd);
+  bool execute(THD *thd) override;
 };
 
 /**
@@ -111,12 +111,12 @@ public:
 
   virtual ~Sql_cmd_resignal() = default;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_RESIGNAL;
   }
 
-  virtual bool execute(THD *thd);
+  bool execute(THD *thd) override;
 };
 
 #endif

--- a/sql/sql_statistics.cc
+++ b/sql/sql_statistics.cc
@@ -746,7 +746,7 @@ private:
     table_name_field= stat_table->field[TABLE_STAT_TABLE_NAME];
   }
 
-  void change_full_table_name(const LEX_CSTRING *db, const LEX_CSTRING *tab)
+  void change_full_table_name(const LEX_CSTRING *db, const LEX_CSTRING *tab) override
   {
     db_name_field->store(db->str, db->length, system_charset_info);
     table_name_field->store(tab->str, tab->length, system_charset_info);
@@ -816,7 +816,7 @@ public:
     the field write_stat.cardinality' from the TABLE structure for 'table'.
   */    
 
-  void store_stat_fields()
+  void store_stat_fields() override
   {
     Field *stat_field= stat_table->field[TABLE_STAT_CARDINALITY];
     if (table->collected_stats->cardinality_is_null)
@@ -843,7 +843,7 @@ public:
     for 'table' accordingly.
   */    
 
-  void get_stat_values()
+  void get_stat_values() override
   {
     Table_statistics *read_stats= table_share->stats_cb.table_stats;
     read_stats->cardinality_is_null= TRUE;
@@ -890,7 +890,7 @@ private:
     column_name_field= stat_table->field[COLUMN_STAT_COLUMN_NAME];
   } 
 
-  void change_full_table_name(const LEX_CSTRING *db, const LEX_CSTRING *tab)
+  void change_full_table_name(const LEX_CSTRING *db, const LEX_CSTRING *tab) override
   {
      db_name_field->store(db->str, db->length, system_charset_info);
      table_name_field->store(tab->str, tab->length, system_charset_info);
@@ -1019,7 +1019,7 @@ public:
     length of the column. 
   */    
 
-  void store_stat_fields()
+  void store_stat_fields() override
   {
     StringBuffer<MAX_FIELD_WIDTH> val;
 
@@ -1097,7 +1097,7 @@ public:
     'table_field'.
   */    
 
-  void get_stat_values()
+  void get_stat_values() override
   {
     table_field->read_stats->set_all_nulls();
 
@@ -1233,7 +1233,7 @@ private:
     prefix_arity_field= stat_table->field[INDEX_STAT_PREFIX_ARITY];
   } 
 
-  void change_full_table_name(const LEX_CSTRING *db, const LEX_CSTRING *tab)
+  void change_full_table_name(const LEX_CSTRING *db, const LEX_CSTRING *tab) override
   {
      db_name_field->store(db->str, db->length, system_charset_info);
      table_name_field->store(tab->str, tab->length, system_charset_info);
@@ -1355,7 +1355,7 @@ public:
     equal  to 0, the value of the column is set to NULL.
   */    
 
-  void store_stat_fields()
+  void store_stat_fields() override
   {
     Field *stat_field= stat_table->field[INDEX_STAT_AVG_FREQUENCY];
     double avg_frequency=
@@ -1386,7 +1386,7 @@ public:
     set to the value of the column.
   */    
 
-  void get_stat_values()
+  void get_stat_values() override
   {
     double avg_frequency= 0;
     if(find_stat())
@@ -1760,7 +1760,7 @@ public:
                      tree_key_length, max_heap_table_size, 1);
   }
 
-  bool add()
+  bool add() override
   {
     longlong val= table_field->val_int();   
     return tree->unique_add(&val);

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -62,7 +62,7 @@ public:
     :Stored_program_creation_ctx(client_cs, connection_cl, db_cl)
   { }
 
-  virtual Stored_program_creation_ctx *clone(MEM_ROOT *mem_root)
+  Stored_program_creation_ctx *clone(MEM_ROOT *mem_root) override
   {
     return new (mem_root) Trigger_creation_ctx(m_client_cs,
                                                m_connection_cl,
@@ -70,7 +70,7 @@ public:
   }
 
 protected:
-  virtual Object_creation_ctx *create_backup_ctx(THD *thd) const
+  Object_creation_ctx *create_backup_ctx(THD *thd) const override
   {
     return new Trigger_creation_ctx(thd);
   }
@@ -261,8 +261,8 @@ public:
   Handle_old_incorrect_sql_modes_hook(const char *file_path)
     :path(file_path)
   {};
-  virtual bool process_unknown_string(const char *&unknown_key, uchar* base,
-                                      MEM_ROOT *mem_root, const char *end);
+  bool process_unknown_string(const char *&unknown_key, uchar* base,
+                                      MEM_ROOT *mem_root, const char *end) override;
 };
 
 
@@ -273,8 +273,8 @@ public:
                                           LEX_CSTRING *trigger_table_arg)
     :path(file_path), trigger_table_value(trigger_table_arg)
   {};
-  virtual bool process_unknown_string(const char *&unknown_key, uchar* base,
-                                      MEM_ROOT *mem_root, const char *end);
+  bool process_unknown_string(const char *&unknown_key, uchar* base,
+                                      MEM_ROOT *mem_root, const char *end) override;
 private:
   const char *path;
   LEX_CSTRING *trigger_table_value;
@@ -301,12 +301,12 @@ public:
 
   Deprecated_trigger_syntax_handler() : m_trigger_name(NULL) {}
 
-  virtual bool handle_condition(THD *thd,
+  bool handle_condition(THD *thd,
                                 uint sql_errno,
                                 const char* sqlstate,
                                 Sql_condition::enum_warning_level *level,
                                 const char* message,
-                                Sql_condition ** cond_hdl)
+                                Sql_condition ** cond_hdl) override
   {
     if (sql_errno != EE_OUTOFMEMORY &&
         sql_errno != ER_OUT_OF_RESOURCES)

--- a/sql/sql_truncate.h
+++ b/sql/sql_truncate.h
@@ -40,9 +40,9 @@ public:
     @param thd the current thread.
     @return false on success.
   */
-  bool execute(THD *thd);
+  bool execute(THD *thd) override;
 
-  virtual enum_sql_command sql_command_code() const
+  enum_sql_command sql_command_code() const override
   {
     return SQLCOM_TRUNCATE;
   }

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -3583,13 +3583,13 @@ public:
 class Vers_type_timestamp: public Vers_type_handler
 {
 public:
-  virtual vers_kind_t kind() const
+  vers_kind_t kind() const override
   {
     return VERS_TIMESTAMP;
   }
   bool check_sys_fields(const LEX_CSTRING &table_name,
                         const Column_definition *row_start,
-                        const Column_definition *row_end) const;
+                        const Column_definition *row_end) const override;
 };
 extern Vers_type_timestamp vers_type_timestamp;
 
@@ -3597,13 +3597,13 @@ extern Vers_type_timestamp vers_type_timestamp;
 class Vers_type_trx: public Vers_type_handler
 {
 public:
-  virtual vers_kind_t kind() const
+  vers_kind_t kind() const override
   {
     return VERS_TRX_ID;
   }
   bool check_sys_fields(const LEX_CSTRING &table_name,
                         const Column_definition *row_start,
-                        const Column_definition *row_end) const;
+                        const Column_definition *row_end) const override;
 };
 extern MYSQL_PLUGIN_IMPORT Vers_type_trx vers_type_trx;
 

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -1689,8 +1689,8 @@ class Multiupdate_prelocking_strategy : public DML_prelocking_strategy
   bool done;
   bool has_prelocking_list;
 public:
-  void reset(THD *thd);
-  bool handle_end(THD *thd);
+  void reset(THD *thd) override;
+  bool handle_end(THD *thd) override;
 };
 
 void Multiupdate_prelocking_strategy::reset(THD *thd)

--- a/sql/sql_window.cc
+++ b/sql/sql_window.cc
@@ -954,7 +954,7 @@ protected:
 class Table_read_cursor : public Rowid_seq_cursor
 {
 public:
-  virtual ~Table_read_cursor() = default;
+  ~Table_read_cursor() override = default;
 
   void init(READ_RECORD *info)
   {
@@ -1022,7 +1022,7 @@ public:
   /*
     This returns -1 when end of partition was reached.
   */
-  int next()
+  int next() override
   {
     int res;
     if (end_of_partition)
@@ -1312,12 +1312,12 @@ public:
     item_add->fix_fields(thd, &item_add);
   }
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     // Save the value of FUNC(current_row)
     range_expr->fetch_value_from(item_add);
@@ -1326,19 +1326,19 @@ public:
     end_of_partition= false;
   }
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     walk_till_non_peer();
   }
 
-  void pre_next_row()
+  void pre_next_row() override
   {
     if (end_of_partition)
       return;
     range_expr->fetch_value_from(item_add);
   }
 
-  void next_row()
+  void next_row() override
   {
     if (end_of_partition)
       return;
@@ -1350,12 +1350,12 @@ public:
     walk_till_non_peer();
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
 
-  bool is_outside_computation_bounds() const
+  bool is_outside_computation_bounds() const override
   {
     if (end_of_partition)
       return true;
@@ -1452,12 +1452,12 @@ public:
     item_add->fix_fields(thd, &item_add);
   }
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     // Save the value of FUNC(current_row)
     range_expr->fetch_value_from(item_add);
@@ -1467,20 +1467,20 @@ public:
     added_values= false;
   }
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     cursor.move_to(rownum);
     walk_till_non_peer();
   }
 
-  void pre_next_row()
+  void pre_next_row() override
   {
     if (end_of_partition)
       return;
     range_expr->fetch_value_from(item_add);
   }
 
-  void next_row()
+  void next_row() override
   {
     if (end_of_partition)
       return;
@@ -1492,14 +1492,14 @@ public:
     walk_till_non_peer();
   }
 
-  bool is_outside_computation_bounds() const
+  bool is_outside_computation_bounds() const override
   {
     if (!added_values)
       return true;
     return false;
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     if (end_of_partition)
       return cursor.get_rownum(); // Cursor does not pass over partition bound.
@@ -1561,13 +1561,13 @@ public:
   {
   }
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
     peer_tracker.init();
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     // Save the value of the current_row
     peer_tracker.check_if_next_group();
@@ -1576,17 +1576,17 @@ public:
     add_value_to_items();
   }
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     walk_till_non_peer();
   }
 
-  void pre_next_row()
+  void pre_next_row() override
   {
     dont_move= !peer_tracker.check_if_next_group();
   }
 
-  void next_row()
+  void next_row() override
   {
     // Check if our cursor is pointing at a peer of the current row.
     // If not, move forward until that becomes true
@@ -1601,7 +1601,7 @@ public:
     walk_till_non_peer();
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
@@ -1658,7 +1658,7 @@ public:
     move(false)
   {}
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     bound_tracker.init();
 
@@ -1666,23 +1666,23 @@ public:
     peer_tracker.init();
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     // Fetch the value from the first row
     peer_tracker.check_if_next_group();
     cursor.move_to(rownum);
   }
 
-  void next_partition(ha_rows rownum) {}
+  void next_partition(ha_rows rownum) override {}
 
-  void pre_next_row()
+  void pre_next_row() override
   {
     // Check if the new current_row is a peer of the row that our cursor is
     // pointing to.
     move= peer_tracker.check_if_next_group();
   }
 
-  void next_row()
+  void next_row() override
   {
     if (move)
     {
@@ -1710,7 +1710,7 @@ public:
     }
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
@@ -1732,9 +1732,9 @@ public:
                             SQL_I_List<ORDER> *order_list)
   {}
 
-  void init(READ_RECORD *info) {}
+  void init(READ_RECORD *info) override {}
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     /*
       UNBOUNDED PRECEDING frame end just stays on the first row of the
@@ -1744,12 +1744,12 @@ public:
     curr_rownum= rownum;
   }
 
-  void next_row()
+  void next_row() override
   {
     /* Do nothing, UNBOUNDED PRECEDING frame end doesn't move. */
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return curr_rownum;
   }
@@ -1774,17 +1774,17 @@ public:
       SQL_I_List<ORDER> *order_list) :
     cursor(thd, partition_list) {}
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     cursor.on_next_partition(rownum);
   }
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     /* Activate the first row */
     cursor.fetch();
@@ -1797,12 +1797,12 @@ public:
     }
   }
 
-  void next_row()
+  void next_row() override
   {
     /* Do nothing, UNBOUNDED FOLLOWING frame end doesn't move */
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
@@ -1817,7 +1817,7 @@ public:
       SQL_I_List<ORDER> *partition_list, SQL_I_List<ORDER> *order_list) :
     Frame_unbounded_following(thd, partition_list, order_list) {}
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     ha_rows num_rows_in_partition= 0;
     if (cursor.fetch())
@@ -1830,7 +1830,7 @@ public:
     set_win_funcs_row_count(num_rows_in_partition);
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
@@ -1857,7 +1857,7 @@ public:
   {
     order_item= order_list->first->item[0];
   }
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     ha_rows num_rows_in_partition= 0;
     if (cursor.fetch())
@@ -1873,7 +1873,7 @@ public:
     set_win_funcs_row_count(num_rows_in_partition);
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
@@ -1904,12 +1904,12 @@ public:
     is_top_bound(is_top_bound_arg), n_rows(n_rows_arg), n_rows_behind(0)
   {}
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
   }
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     /*
       Position our cursor to point at the first row in the new partition
@@ -1935,13 +1935,13 @@ public:
 
   }
 
-  void next_row()
+  void next_row() override
   {
     n_rows_behind++;
     move_cursor_if_possible();
   }
 
-  bool is_outside_computation_bounds() const
+  bool is_outside_computation_bounds() const override
   {
     /* As a bottom boundary, rows have not yet been added. */
     if (!is_top_bound && n_rows - n_rows_behind)
@@ -1949,7 +1949,7 @@ public:
     return false;
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
@@ -2007,26 +2007,26 @@ public:
 
   Frame_rows_current_row_bottom() : curr_rownum(0) {}
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     add_value_to_items();
     curr_rownum= rownum;
   }
 
-  void next_partition(ha_rows rownum) {}
+  void next_partition(ha_rows rownum) override {}
 
-  void pre_next_row()
+  void pre_next_row() override
   {
     /* Temp table's current row is current_row. Add it to the window func */
     add_value_to_items();
   }
 
-  void next_row()
+  void next_row() override
   {
     curr_rownum++;
   };
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return curr_rownum;
   }
@@ -2083,13 +2083,13 @@ public:
   {
   }
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
     at_partition_end= false;
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     at_partition_end= false;
 
@@ -2097,7 +2097,7 @@ public:
   }
 
   /* Move our cursor to be n_rows ahead.  */
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     if (is_top_bound)
       next_part_top(rownum);
@@ -2105,7 +2105,7 @@ public:
       next_part_bottom(rownum);
   }
 
-  void next_row()
+  void next_row() override
   {
     if (is_top_bound)
       next_row_top();
@@ -2113,7 +2113,7 @@ public:
       next_row_bottom();
   }
 
-  bool is_outside_computation_bounds() const
+  bool is_outside_computation_bounds() const override
   {
     /*
        The top bound can go over the current partition. In this case,
@@ -2124,7 +2124,7 @@ public:
     return false;
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return cursor.get_rownum();
   }
@@ -2210,12 +2210,12 @@ public:
                     const Frame_cursor &bottom_bound) :
     top_bound(top_bound), bottom_bound(bottom_bound) {}
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     /* TODO(cvicentiu) Sum functions get cleared on next partition anyway during
        the window function computation algorithm. Either perform this only in
@@ -2225,23 +2225,23 @@ public:
     clear_sum_functions();
   }
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     compute_values_for_current_row();
   }
 
-  void pre_next_row()
+  void pre_next_row() override
   {
     clear_sum_functions();
   }
 
-  void next_row()
+  void next_row() override
   {
     curr_rownum++;
     compute_values_for_current_row();
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return curr_rownum;
   }
@@ -2301,36 +2301,36 @@ class Frame_positional_cursor : public Frame_cursor
     bottom_bound(&bottom_bound), offset(&offset),
     negative_offset(negative_offset) {}
 
-  void init(READ_RECORD *info)
+  void init(READ_RECORD *info) override
   {
     cursor.init(info);
   }
 
-  void pre_next_partition(ha_rows rownum)
+  void pre_next_partition(ha_rows rownum) override
   {
     /* The offset is dependant on the current row values. We can only get
      * it here accurately. When fetching other rows, it changes. */
     save_offset_value();
   }
 
-  void next_partition(ha_rows rownum)
+  void next_partition(ha_rows rownum) override
   {
     save_positional_value();
   }
 
-  void pre_next_row()
+  void pre_next_row() override
   {
     /* The offset is dependant on the current row values. We can only get
      * it here accurately. When fetching other rows, it changes. */
     save_offset_value();
   }
 
-  void next_row()
+  void next_row() override
   {
     save_positional_value();
   }
 
-  ha_rows get_curr_rownum() const
+  ha_rows get_curr_rownum() const override
   {
     return position_cursor.get_curr_rownum();
   }

--- a/sql/sql_window.h
+++ b/sql/sql_window.h
@@ -173,7 +173,7 @@ class Window_def : public Window_spec
     : Window_spec(win_ref, part_list, ord_list, win_frame),
       window_name(win_name) {}
  
-  const char *name() { return window_name->str; }
+  const char *name() override { return window_name->str; }
 
 };
 

--- a/sql/sys_vars.inl
+++ b/sql/sys_vars.inl
@@ -198,7 +198,7 @@ public:
     SYSVAR_ASSERT(block_size > 0);
     SYSVAR_ASSERT(def_val % block_size == 0);
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     my_bool fixed= FALSE, unused;
     longlong v= var->value->val_int();
@@ -245,23 +245,23 @@ public:
     return throw_bounds_warning(thd, name.str, fixed,
                                 var->value->unsigned_flag, v);
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, T)= static_cast<T>(var->save_result.ulonglong_value);
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(T)= static_cast<T>(var->save_result.ulonglong_value);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= (ulonglong)*(T*)global_value_ptr(thd, 0); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= option.def_value; }
   private:
   T get_max_var() { return *((T*) max_var_ptr()); }
-  const uchar *default_value_ptr(THD *thd) const { return (uchar*) &option.def_value; }
+  const uchar *default_value_ptr(THD *thd) const override { return (uchar*) &option.def_value; }
 };
 
 typedef Sys_var_integer<int, GET_INT, SHOW_SINT> Sys_var_int;
@@ -327,7 +327,7 @@ public:
     typelib.type_lengths= 0;    // only used by Fields_enum and Field_set
     option.typelib= &typelib;
   }
-  bool do_check(THD *thd, set_var *var) // works for enums and my_bool
+  bool do_check(THD *thd, set_var *var) override // works for enums and my_bool
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String str(buff, sizeof(buff), system_charset_info), *res;
@@ -395,7 +395,7 @@ public:
     SYSVAR_ASSERT(size == sizeof(ulong));
   }
   bool check_maximum(THD *thd, set_var *var,
-                     const char *c_val, longlong i_val)
+                     const char *c_val, longlong i_val) override
   {
     if (!max_var_ptr() ||
         var->save_result.ulonglong_value <= get_max_var())
@@ -406,27 +406,27 @@ public:
                    throw_bounds_warning(thd, name.str, TRUE,
                                         var->value->unsigned_flag, i_val);
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, ulong)= static_cast<ulong>(var->save_result.ulonglong_value);
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(ulong)= static_cast<ulong>(var->save_result.ulonglong_value);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= global_var(ulong); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= option.def_value; }
   const uchar *valptr(THD *thd, ulong val) const
   { return reinterpret_cast<const uchar*>(typelib.type_names[val]); }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, session_var(thd, ulong)); }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(ulong)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return valptr(thd, (ulong)option.def_value); }
 
   ulong get_max_var() { return *((ulong *) max_var_ptr()); }
@@ -460,21 +460,21 @@ public:
     SYSVAR_ASSERT(getopt.arg_type == OPT_ARG || getopt.id < 0);
     SYSVAR_ASSERT(size == sizeof(my_bool));
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, my_bool)= var->save_result.ulonglong_value != 0;
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(my_bool)= var->save_result.ulonglong_value != 0;
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= (ulonglong)*(my_bool *)global_value_ptr(thd, 0); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= option.def_value; }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   {
     thd->sys_var_tmp.my_bool_value=(my_bool) option.def_value;
     return (uchar*) &thd->sys_var_tmp.my_bool_value;
@@ -518,7 +518,7 @@ public:
     option.var_type|= (flags & ALLOCATED) ? GET_STR_ALLOC : GET_STR;
     global_var(const char*)= def_val;
   }
-  void cleanup()
+  void cleanup() override
   {
     if (flags & ALLOCATED)
     {
@@ -556,9 +556,9 @@ public:
 
     return false;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   { return do_string_check(thd, var, charset(thd)); }
-  bool session_update(THD *thd, set_var *var)= 0;
+  bool session_update(THD *thd, set_var *var) override= 0;
   char *global_update_prepare(THD *thd, set_var *var)
   {
     char *new_val, *ptr= var->save_result.string_value.str;
@@ -581,14 +581,14 @@ public:
     flags|= ALLOCATED;
     global_var(char*)= new_val;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     char *new_val= global_update_prepare(thd, var);
     global_update_finish(new_val);
     return (new_val == 0 && var->save_result.string_value.str != 0);
   }
-  void session_save_default(THD *thd, set_var *var)= 0;
-  void global_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override= 0;
+  void global_save_default(THD *thd, set_var *var) override
   {
     char *ptr= (char*)(intptr)option.def_value;
     var->save_result.string_value.str= ptr;
@@ -615,12 +615,12 @@ public:
     SYSVAR_ASSERT(size == sizeof(char *));
   }
 
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { DBUG_ASSERT(FALSE); }
 };
 
@@ -649,7 +649,7 @@ public:
                          getopt, def_val, lock,
                          VARIABLE_NOT_IN_BINLOG, 0, 0, 0)
     {}
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
      if (Sys_var_charptr_base::do_check(thd, var) ||
          sysvartrack_validate_value(thd, var->save_result.string_value.str,
@@ -657,7 +657,7 @@ public:
        return TRUE;
      return FALSE;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     char *new_val= global_update_prepare(thd, var);
     if (new_val)
@@ -673,9 +673,9 @@ public:
     global_update_finish(new_val);
     return (new_val == 0 && var->save_result.string_value.str != 0);
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   { return thd->session_tracker.sysvars.update(thd, var); }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
      var->save_result.string_value.str= global_var(char*);
      var->save_result.string_value.length=
@@ -707,27 +707,27 @@ public:
   {
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { DBUG_ASSERT(FALSE); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { DBUG_ASSERT(FALSE); }
 protected:
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     return thd->security_ctx->proxy_user[0] ?
       (uchar *) &(thd->security_ctx->proxy_user[0]) : NULL;
@@ -742,7 +742,7 @@ public:
   {}
 
 protected:
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     return (uchar*)thd->security_ctx->external_user;
   }
@@ -827,7 +827,7 @@ public:
     SYSVAR_ASSERT(size == sizeof(LEX_CSTRING));
     *const_cast<SHOW_TYPE*>(&show_val_type)= SHOW_LEX_STRING;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     if (Sys_var_charptr::global_update(thd, var))
       return true;
@@ -861,7 +861,7 @@ public:
     SYSVAR_ASSERT(scope() == ONLY_SESSION)
     *const_cast<SHOW_TYPE*>(&show_val_type)= SHOW_LEX_STRING;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String str(buff, sizeof(buff), system_charset_info), *res;
@@ -885,7 +885,7 @@ public:
     }
     return false;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     LEX_CSTRING *tmp= &session_var(thd, LEX_CSTRING);
     tmp->length= var->save_result.string_value.length;
@@ -893,22 +893,22 @@ public:
     strmake((char*) tmp->str, var->save_result.string_value.str, tmp->length);
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     char *ptr= (char*)(intptr)option.def_value;
     var->save_result.string_value.str= ptr;
     var->save_result.string_value.length= strlen(ptr);
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(FALSE);
     return NULL;
@@ -945,14 +945,14 @@ public:
               lock, binlog_status_arg, on_check_func, on_update_func,
               substitute)
   { option.var_type|= GET_STR; }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     bool rc= Sys_var_charptr::do_string_check(thd, var, charset(thd));
     if (var->save_result.string_value.str == nullptr)
       var->save_result.string_value.str= const_cast<char*>("");
     return rc;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     const char *val= var->save_result.string_value.str;
     if (!var->value)
@@ -961,33 +961,33 @@ public:
       DBUG_SET(val);
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     const char *val= var->save_result.string_value.str;
     DBUG_SET_INITIAL(val);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     char *ptr= (char*)(intptr)option.def_value;
     var->save_result.string_value.str= ptr;
     var->save_result.string_value.length= safe_strlen(ptr);
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     char buf[256];
     DBUG_EXPLAIN(buf, sizeof(buf));
     return (uchar*) thd->strdup(buf);
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     char buf[256];
     DBUG_EXPLAIN_INITIAL(buf, sizeof(buf));
     return (uchar*) thd->strdup(buf);
   }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return (uchar*)""; }
 };
 #endif
@@ -1033,7 +1033,7 @@ public:
     offset= global_var_ptr() - (uchar*)dflt_key_cache;
     SYSVAR_ASSERT(scope() == GLOBAL);
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     ulonglong new_value= var->save_result.ulonglong_value;
     LEX_CSTRING *base_name= &var->base;
@@ -1063,7 +1063,7 @@ public:
 
     return keycache_update(thd, key_cache, offset, new_value);
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     KEY_CACHE *key_cache= get_key_cache(base);
     if (!key_cache)
@@ -1197,7 +1197,7 @@ public:
     SYSVAR_ASSERT(max_val >= def_val);
     SYSVAR_ASSERT(size == sizeof(double));
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     my_bool fixed;
     double v= var->value->val_real();
@@ -1205,19 +1205,19 @@ public:
 
     return throw_bounds_warning(thd, name.str, fixed, v);
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, double)= var->save_result.double_value;
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(double)= var->save_result.double_value;
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->save_result.double_value= global_var(double); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { var->save_result.double_value= getopt_ulonglong2double(option.def_value); }
 };
 
@@ -1248,7 +1248,7 @@ public:
               lock, binlog_status_arg, on_check_func, on_update_func,
               substitute)
   { }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     if (thd->user_connect && thd->user_connect->user_resources.user_conn)
       return (uchar*) &(thd->user_connect->user_resources.user_conn);
@@ -1294,7 +1294,7 @@ public:
     SYSVAR_ASSERT(strcmp(values[typelib.count-1], "default") == 0);
     SYSVAR_ASSERT(size == sizeof(ulonglong));
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String str(buff, sizeof(buff), system_charset_info), *res;
@@ -1346,27 +1346,27 @@ public:
 
     return false;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, ulonglong)= var->save_result.ulonglong_value;
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(ulonglong)= var->save_result.ulonglong_value;
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= global_var(ulonglong); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= option.def_value; }
   const uchar *valptr(THD *thd, ulonglong val) const
   { return (uchar*)flagset_to_string(thd, 0, val, typelib.type_names); }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, session_var(thd, ulonglong)); }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(ulonglong)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return valptr(thd, option.def_value); }
 };
 
@@ -1409,7 +1409,7 @@ public:
     SYSVAR_ASSERT(size == sizeof(ulonglong));
   }
   bool check_maximum(THD *thd, set_var *var,
-                     const char *c_val, longlong i_val)
+                     const char *c_val, longlong i_val) override
   {
     if (!max_var_ptr() ||
         (var->save_result.ulonglong_value & ~(get_max_var())) == 0)
@@ -1420,7 +1420,7 @@ public:
                    throw_bounds_warning(thd, name.str, TRUE,
                                         var->value->unsigned_flag, i_val);
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String str(buff, sizeof(buff), system_charset_info), *res;
@@ -1460,27 +1460,27 @@ public:
     var->save_result.ulonglong_value= tmp;
     return check_maximum(thd, var, 0, tmp);
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, ulonglong)= var->save_result.ulonglong_value;
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(ulonglong)= var->save_result.ulonglong_value;
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= global_var(ulonglong); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= option.def_value; }
   const uchar *valptr(THD *thd, ulonglong val) const
   { return reinterpret_cast<const uchar*>(set_to_string(thd, 0, val, typelib.type_names)); }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, session_var(thd, ulonglong)); }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(ulonglong)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return valptr(thd, option.def_value); }
 
   ulonglong get_max_var() { return *((ulonglong*) max_var_ptr()); }
@@ -1521,7 +1521,7 @@ public:
     SYSVAR_ASSERT(size == sizeof(plugin_ref));
     SYSVAR_ASSERT(getopt.id < 0); // force NO_CMD_LINE
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String str(buff,sizeof(buff), system_charset_info), *res;
@@ -1560,19 +1560,19 @@ public:
       plugin_unlock(NULL, oldval);
     }
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     do_update((plugin_ref*)session_var_ptr(thd),
               var->save_result.plugin);
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     do_update((plugin_ref*)global_var_ptr(),
               var->save_result.plugin);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     plugin_ref plugin= global_var(plugin_ref);
     var->save_result.plugin= plugin ? my_plugin_lock(thd, plugin) : 0;
@@ -1594,7 +1594,7 @@ public:
     return my_plugin_lock(thd, plugin);
   }
 
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     var->save_result.plugin= get_default(thd);
   }
@@ -1604,11 +1604,11 @@ public:
     return (uchar*)(plugin ? thd->strmake(plugin_name(plugin)->str,
                                           plugin_name(plugin)->length) : 0);
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, session_var(thd, plugin_ref)); }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(plugin_ref)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return valptr(thd, get_default(thd)); }
 };
 
@@ -1657,7 +1657,7 @@ public:
     SYSVAR_ASSERT(size == sizeof(plugin_ref));
     SYSVAR_ASSERT(getopt.id < 0); // force NO_CMD_LINE
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String str(buff,sizeof(buff), system_charset_info), *res;
@@ -1678,19 +1678,19 @@ public:
     *valptr= copy_engine_list(newval);
     free_engine_list(oldval);
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     do_update((plugin_ref**)session_var_ptr(thd),
               var->save_result.plugins);
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     do_update((plugin_ref**)global_var_ptr(),
               var->save_result.plugins);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     plugin_ref* plugins= global_var(plugin_ref *);
     var->save_result.plugins= plugins ? temp_copy_engine_list(thd, plugins) : 0;
@@ -1704,7 +1704,7 @@ public:
                                false, true);
   }
 
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     var->save_result.plugins= get_default(thd);
   }
@@ -1713,11 +1713,11 @@ public:
   {
     return reinterpret_cast<uchar*>(pretty_print_engine_list(thd, plugins));
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, session_var(thd, plugin_ref*)); }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(plugin_ref*)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return valptr(thd, get_default(thd)); }
 };
 
@@ -1747,7 +1747,7 @@ public:
     SYSVAR_ASSERT(scope() == ONLY_SESSION);
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     char buff[STRING_BUFFER_USUAL_SIZE];
     String str(buff, sizeof(buff), system_charset_info), *res;
@@ -1762,35 +1762,35 @@ public:
     }
     return false;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     return debug_sync_update(thd, var->save_result.string_value.str,
                                   var->save_result.string_value.length);
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     var->save_result.string_value.str= const_cast<char*>("");
     var->save_result.string_value.length= 0;
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     return debug_sync_value_ptr(thd);
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return (uchar*)""; }
 };
 #endif /* defined(ENABLED_DEBUG_SYNC) */
@@ -1848,22 +1848,22 @@ public:
     SYSVAR_ASSERT(def_val < 2);
     SYSVAR_ASSERT(size == sizeof(ulonglong));
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     set(session_var_ptr(thd), var->save_result.ulonglong_value);
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     set(global_var_ptr(), var->save_result.ulonglong_value);
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     var->save_result.ulonglong_value=
       (reverse_semantics == !(global_var(ulonglong) & bitmask));
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { var->save_result.ulonglong_value= option.def_value; }
 
   uchar *valptr(THD *thd, ulonglong val) const
@@ -1871,11 +1871,11 @@ public:
     thd->sys_var_tmp.my_bool_value= (reverse_semantics == !(val & bitmask));
     return (uchar*) &thd->sys_var_tmp.my_bool_value;
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, session_var(thd, ulonglong)); }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(ulonglong)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   {
     thd->sys_var_tmp.my_bool_value= option.def_value != 0;
     return (uchar*) &thd->sys_var_tmp.my_bool_value;
@@ -1923,28 +1923,28 @@ public:
     SYSVAR_ASSERT(scope() == ONLY_SESSION);
     SYSVAR_ASSERT(getopt.id < 0); // NO_CMD_LINE, because the offset is fake
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   { return update_func(thd, var); }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->value= 0; }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { DBUG_ASSERT(FALSE); }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     thd->sys_var_tmp.ulonglong_value= read_func(thd);
     return (uchar*) &thd->sys_var_tmp.ulonglong_value;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   {
     thd->sys_var_tmp.ulonglong_value= 0;
     return (uchar*) &thd->sys_var_tmp.ulonglong_value;
@@ -1976,7 +1976,7 @@ public:
     SYSVAR_ASSERT(scope() == ONLY_SESSION);
     SYSVAR_ASSERT(getopt.id < 0); // NO_CMD_LINE, because the offset is fake
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     if (var->value)
     {
@@ -1987,36 +1987,36 @@ public:
       thd->user_time.val= 0;
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  bool session_is_default(THD *thd)
+  bool session_is_default(THD *thd) override
   {
     return thd->user_time.val == 0;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->value= 0; }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   { DBUG_ASSERT(FALSE); }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     thd->sys_var_tmp.double_value= thd->start_time +
           thd->start_time_sec_part/(double)TIME_SECOND_PART_FACTOR;
     return (uchar*) &thd->sys_var_tmp.double_value;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   {
     thd->sys_var_tmp.double_value= 0;
     return (uchar*) &thd->sys_var_tmp.double_value;
   }
-  bool on_check_access_session(THD *thd) const;
+  bool on_check_access_session(THD *thd) const override;
 };
 
 
@@ -2055,28 +2055,28 @@ public:
     SYSVAR_ASSERT(size == sizeof(enum SHOW_COMP_OPTION));
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var) {
+  bool do_check(THD *thd, set_var *var) override {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(FALSE);
     return true;
   }
-  void session_save_default(THD *thd, set_var *var) { }
-  void global_save_default(THD *thd, set_var *var) { }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  void session_save_default(THD *thd, set_var *var) override { }
+  void global_save_default(THD *thd, set_var *var) override { }
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(FALSE);
     return 0;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     return (uchar*)show_comp_option_name[global_var(enum SHOW_COMP_OPTION)];
   }
@@ -2127,32 +2127,32 @@ public:
     SYSVAR_ASSERT(getopt.id < 0);
     SYSVAR_ASSERT(size == sizeof(void *));
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   { return false; }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, const void*)= var->save_result.ptr;
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(const void*)= var->save_result.ptr;
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   { var->save_result.ptr= global_var(void*); }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     void **default_value= reinterpret_cast<void**>(option.def_value);
     var->save_result.ptr= *default_value;
   }
   uchar *valptr(THD *thd, uchar *val) const
   { return val ? *(uchar**)(val+name_offset) : 0; }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, session_var(thd, uchar*)); }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(uchar*)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return valptr(thd, *(uchar**)option.def_value); }
 };
 
@@ -2186,7 +2186,7 @@ public:
     SYSVAR_ASSERT(size == sizeof(Time_zone *));
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     char buff[MAX_TIME_ZONE_NAME_LENGTH];
     String str(buff, sizeof(buff), &my_charset_latin1);
@@ -2203,28 +2203,28 @@ public:
     }
     return false;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     session_var(thd, Time_zone*)= var->save_result.time_zone;
     return false;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     global_var(Time_zone*)= var->save_result.time_zone;
     return false;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     var->save_result.time_zone= global_var(Time_zone*);
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     var->save_result.time_zone=
       *(Time_zone**)(intptr)option.def_value;
   }
   const uchar *valptr(THD *thd, Time_zone *val) const
   { return reinterpret_cast<const uchar*>(val->get_name()->ptr()); }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     /*
       This is an ugly fix for replication: we don't replicate properly queries
@@ -2237,9 +2237,9 @@ public:
     thd->time_zone_used= 1;
     return valptr(thd, session_var(thd, Time_zone *));
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return valptr(thd, global_var(Time_zone*)); }
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *default_value_ptr(THD *thd) const override
   { return valptr(thd, *(Time_zone**)option.def_value); }
 };
 
@@ -2265,7 +2265,7 @@ public:
     :Sys_var_enum(name_arg, comment, flag_args, off, size, getopt,
                   values, def_val, lock, binlog_status_arg, on_check_func)
   {}
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     if (var->type == OPT_SESSION && Sys_var_enum::session_update(thd, var))
       return TRUE;
@@ -2326,7 +2326,7 @@ public:
     :Sys_var_mybool(name_arg, comment, flag_args, off, size, getopt,
                     def_val, lock, binlog_status_arg, on_check_func)
   {}
-  virtual bool session_update(THD *thd, set_var *var);
+  bool session_update(THD *thd, set_var *var) override;
 };
 
 /*
@@ -2345,7 +2345,7 @@ public:
     :Sys_var_enum(name_arg, comment, flag_args, off, size, getopt,
                   values, def_val, lock, binlog_status_arg)
   {}
-  bool global_update(THD *thd, set_var *var);
+  bool global_update(THD *thd, set_var *var) override;
 };
 
 /*
@@ -2386,16 +2386,16 @@ public:
     mi_accessor_func(mi_accessor_arg),
     update_multi_source_variable_func(on_update_func)
   { }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     return session_update(thd, var);
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     /* Use value given in variable declaration */
     global_save_default(thd, var);
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     ulonglong *tmp, res;
     tmp= (ulonglong*) (((uchar*)&(thd->variables)) + offset);
@@ -2403,7 +2403,7 @@ public:
     *tmp= res;
     return (uchar*) tmp;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     return session_value_ptr(thd, base);
   }
@@ -2432,35 +2432,35 @@ public:
     SYSVAR_ASSERT(is_readonly());
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override;
 };
 
 
@@ -2481,35 +2481,35 @@ public:
     SYSVAR_ASSERT(is_readonly());
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override;
 };
 
 
@@ -2528,31 +2528,31 @@ public:
   {
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var);
-  bool session_update(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override;
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool global_update(THD *thd, set_var *var);
-  void session_save_default(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override;
+  void session_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     /* Record the attempt to use default so we can error. */
     var->value= 0;
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override;
+  const uchar *default_value_ptr(THD *thd) const override
   { return 0; }
-  bool on_check_access_global(THD *thd) const
+  bool on_check_access_global(THD *thd) const override
   {
     return check_global_access(thd, PRIV_SET_SYSTEM_GLOBAL_VAR_GTID_SLAVE_POS);
   }
@@ -2574,31 +2574,31 @@ public:
   {
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var);
-  bool session_update(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override;
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool global_update(THD *thd, set_var *var);
-  void session_save_default(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override;
+  void session_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     /* Record the attempt to use default so we can error. */
     var->value= 0;
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(false);
     return NULL;
   }
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
-  const uchar *default_value_ptr(THD *thd) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override;
+  const uchar *default_value_ptr(THD *thd) const override
   { return 0; }
-  bool on_check_access_global(THD *thd) const
+  bool on_check_access_global(THD *thd) const override
   {
     return
       check_global_access(thd, PRIV_SET_SYSTEM_GLOBAL_VAR_GTID_BINLOG_STATE);
@@ -2622,31 +2622,31 @@ public:
     SYSVAR_ASSERT(is_readonly());
     option.var_type|= GET_STR;
   }
-  bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
     return true;
   }
-  void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     DBUG_ASSERT(false);
   }
-  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const;
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override;
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   {
     DBUG_ASSERT(false);
     return NULL;
@@ -2671,8 +2671,8 @@ public:
     option.value= (uchar**)1; // crash me, please
     SYSVAR_ASSERT(scope() == GLOBAL);
   }
-  bool global_update(THD *thd, set_var *var);
-  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const;
+  bool global_update(THD *thd, set_var *var) override;
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override;
 };
 
 
@@ -2693,7 +2693,7 @@ public:
   {
     option.var_type= GET_STR;
   }
-  virtual bool do_check(THD *thd, set_var *var)
+  bool do_check(THD *thd, set_var *var) override
   {
     if (!var->value)
       return false;
@@ -2732,26 +2732,26 @@ private:
   }
 
 public:
-  virtual bool global_update(THD *thd, set_var *var)
+  bool global_update(THD *thd, set_var *var) override
   {
     return update(thd, var, &global_var(vers_asof_timestamp_t));
   }
-  virtual bool session_update(THD *thd, set_var *var)
+  bool session_update(THD *thd, set_var *var) override
   {
     return update(thd, var, &session_var(thd, vers_asof_timestamp_t));
   }
 
-  virtual bool session_is_default(THD *thd)
+  bool session_is_default(THD *thd) override
   {
     const vers_asof_timestamp_t &var= session_var(thd, vers_asof_timestamp_t);
     return var.type == SYSTEM_TIME_UNSPECIFIED;
   }
 
-  virtual void session_save_default(THD *thd, set_var *var)
+  void session_save_default(THD *thd, set_var *var) override
   {
     save_default(var, &session_var(thd, vers_asof_timestamp_t));
   }
-  virtual void global_save_default(THD *thd, set_var *var)
+  void global_save_default(THD *thd, set_var *var) override
   {
     save_default(var, &global_var(vers_asof_timestamp_t));
   }
@@ -2789,8 +2789,8 @@ private:
   }
 
 public:
-  virtual const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *session_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return value_ptr(thd, session_var(thd, vers_asof_timestamp_t)); }
-  virtual const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const
+  const uchar *global_value_ptr(THD *thd, const LEX_CSTRING *base) const override
   { return value_ptr(thd, global_var(vers_asof_timestamp_t)); }
 };

--- a/sql/sys_vars_shared.h
+++ b/sql/sys_vars_shared.h
@@ -52,9 +52,9 @@ class PolyLock_mutex: public PolyLock
   mysql_mutex_t *mutex;
 public:
   PolyLock_mutex(mysql_mutex_t *arg): mutex(arg) {}
-  void rdlock() { mysql_mutex_lock(mutex); }
-  void wrlock() { mysql_mutex_lock(mutex); }
-  void unlock() { mysql_mutex_unlock(mutex); }
+  void rdlock() override { mysql_mutex_lock(mutex); }
+  void wrlock() override { mysql_mutex_lock(mutex); }
+  void unlock() override { mysql_mutex_unlock(mutex); }
 };
 
 class PolyLock_rwlock: public PolyLock
@@ -62,9 +62,9 @@ class PolyLock_rwlock: public PolyLock
   mysql_rwlock_t *rwlock;
 public:
   PolyLock_rwlock(mysql_rwlock_t *arg): rwlock(arg) {}
-  void rdlock() { mysql_rwlock_rdlock(rwlock); }
-  void wrlock() { mysql_rwlock_wrlock(rwlock); }
-  void unlock() { mysql_rwlock_unlock(rwlock); }
+  void rdlock() override { mysql_rwlock_rdlock(rwlock); }
+  void wrlock() override { mysql_rwlock_wrlock(rwlock); }
+  void unlock() override { mysql_rwlock_unlock(rwlock); }
 };
 
 class AutoWLock

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -8618,7 +8618,7 @@ public:
                         const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
                         const char* msg,
-                        Sql_condition ** cond_hdl)
+                        Sql_condition ** cond_hdl) override
   {
     *cond_hdl= NULL;
     if (*level == Sql_condition::WARN_LEVEL_ERROR)

--- a/sql/table.h
+++ b/sql/table.h
@@ -172,9 +172,9 @@ protected:
                               CHARSET_INFO *connection_cl);
 
 protected:
-  virtual Object_creation_ctx *create_backup_ctx(THD *thd) const;
+  Object_creation_ctx *create_backup_ctx(THD *thd) const override;
 
-  virtual void change_env(THD *thd) const;
+  void change_env(THD *thd) const override;
 
 protected:
   /**
@@ -565,7 +565,7 @@ public:
 class Table_check_intact_log_error : public Table_check_intact
 {
 protected:
-  void report_error(uint, const char *fmt, ...);
+  void report_error(uint, const char *fmt, ...) override;
 public:
   Table_check_intact_log_error() : Table_check_intact(true) {}
 };
@@ -591,9 +591,9 @@ public:
 
   MDL_context *get_ctx() const { return m_ctx; }
 
-  virtual bool accept_visitor(MDL_wait_for_graph_visitor *dvisitor);
+  bool accept_visitor(MDL_wait_for_graph_visitor *dvisitor) override;
 
-  virtual uint get_deadlock_weight() const;
+  uint get_deadlock_weight() const override;
 
   /**
     Pointers for participating in the list of waiters for table share.
@@ -2982,13 +2982,13 @@ class Field_iterator_table: public Field_iterator
   Field **ptr;
 public:
   Field_iterator_table() :ptr(0) {}
-  void set(TABLE_LIST *table) { ptr= table->table->field; }
+  void set(TABLE_LIST *table) override { ptr= table->table->field; }
   void set_table(TABLE *table) { ptr= table->field; }
-  void next() { ptr++; }
-  bool end_of_fields() { return *ptr == 0; }
-  LEX_CSTRING *name();
-  Item *create_item(THD *thd);
-  Field *field() { return *ptr; }
+  void next() override { ptr++; }
+  bool end_of_fields() override { return *ptr == 0; }
+  LEX_CSTRING *name() override;
+  Item *create_item(THD *thd) override;
+  Field *field() override { return *ptr; }
 };
 
 
@@ -3000,13 +3000,13 @@ class Field_iterator_view: public Field_iterator
   TABLE_LIST *view;
 public:
   Field_iterator_view() :ptr(0), array_end(0) {}
-  void set(TABLE_LIST *table);
-  void next() { ptr++; }
-  bool end_of_fields() { return ptr == array_end; }
-  LEX_CSTRING *name();
-  Item *create_item(THD *thd);
+  void set(TABLE_LIST *table) override;
+  void next() override { ptr++; }
+  bool end_of_fields() override { return ptr == array_end; }
+  LEX_CSTRING *name() override;
+  Item *create_item(THD *thd) override;
   Item **item_ptr() {return &ptr->item; }
-  Field *field() { return 0; }
+  Field *field() override { return 0; }
   inline Item *item() { return ptr->item; }
   Field_translator *field_translator() { return ptr; }
 };
@@ -3024,12 +3024,12 @@ class Field_iterator_natural_join: public Field_iterator
 public:
   Field_iterator_natural_join() :cur_column_ref(NULL) {}
   ~Field_iterator_natural_join() = default;
-  void set(TABLE_LIST *table);
-  void next();
-  bool end_of_fields() { return !cur_column_ref; }
-  LEX_CSTRING *name() { return cur_column_ref->name(); }
-  Item *create_item(THD *thd) { return cur_column_ref->create_item(thd); }
-  Field *field() { return cur_column_ref->field(); }
+  void set(TABLE_LIST *table) override;
+  void next() override;
+  bool end_of_fields() override { return !cur_column_ref; }
+  LEX_CSTRING *name() override { return cur_column_ref->name(); }
+  Item *create_item(THD *thd) override { return cur_column_ref->create_item(thd); }
+  Field *field() override { return cur_column_ref->field(); }
   Natural_join_column *column_ref() { return cur_column_ref; }
 };
 
@@ -3060,16 +3060,16 @@ class Field_iterator_table_ref: public Field_iterator
   void set_field_iterator();
 public:
   Field_iterator_table_ref() :field_it(NULL) {}
-  void set(TABLE_LIST *table);
-  void next();
-  bool end_of_fields()
+  void set(TABLE_LIST *table) override;
+  void next() override;
+  bool end_of_fields() override
   { return (table_ref == last_leaf && field_it->end_of_fields()); }
-  LEX_CSTRING *name() { return field_it->name(); }
+  LEX_CSTRING *name() override { return field_it->name(); }
   const char *get_table_name();
   const char *get_db_name();
   GRANT_INFO *grant();
-  Item *create_item(THD *thd) { return field_it->create_item(thd); }
-  Field *field() { return field_it->field(); }
+  Item *create_item(THD *thd) override { return field_it->create_item(thd); }
+  Field *field() override { return field_it->field(); }
   Natural_join_column *get_or_create_column_ref(THD *thd, TABLE_LIST *parent_table_ref);
   Natural_join_column *get_natural_column_ref();
 };

--- a/sql/threadpool.h
+++ b/sql/threadpool.h
@@ -136,12 +136,12 @@ struct TP_pool
 struct TP_pool_win:TP_pool
 {
   TP_pool_win();
-  virtual int init();
-  virtual ~TP_pool_win();
-  virtual TP_connection *new_connection(CONNECT *c);
-  virtual void add(TP_connection *);
-  virtual int set_max_threads(uint);
-  virtual int set_min_threads(uint);
+  int init() override;
+  ~TP_pool_win() override;
+  TP_connection *new_connection(CONNECT *c) override;
+  void add(TP_connection *) override;
+  int set_max_threads(uint) override;
+  int set_min_threads(uint) override;
 };
 #endif
 
@@ -149,12 +149,12 @@ struct TP_pool_generic :TP_pool
 {
   TP_pool_generic();
   ~TP_pool_generic();
-  virtual int init();
-  virtual TP_connection *new_connection(CONNECT *c);
-  virtual void add(TP_connection *);
-  virtual int set_pool_size(uint);
-  virtual int set_stall_limit(uint);
-  virtual int get_idle_thread_count();
+  int init() override;
+  TP_connection *new_connection(CONNECT *c) override;
+  void add(TP_connection *) override;
+  int set_pool_size(uint) override;
+  int set_stall_limit(uint) override;
+  int get_idle_thread_count() override;
 };
 
 #endif /* HAVE_POOL_OF_THREADS */

--- a/sql/threadpool_generic.h
+++ b/sql/threadpool_generic.h
@@ -75,11 +75,11 @@ struct TP_connection_generic :public TP_connection
   TP_connection_generic(CONNECT* c);
   ~TP_connection_generic();
 
-  virtual int init() { return 0; };
-  virtual void set_io_timeout(int sec);
-  virtual int  start_io();
-  virtual void wait_begin(int type);
-  virtual void wait_end();
+  int init() override { return 0; };
+  void set_io_timeout(int sec) override;
+  int  start_io() override;
+  void wait_begin(int type) override;
+  void wait_end() override;
 
   thread_group_t* thread_group;
   TP_connection_generic* next_in_queue;

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -1028,9 +1028,9 @@ class Time_zone_system : public Time_zone
 {
 public:
   Time_zone_system() = default;                       /* Remove gcc warning */
-  virtual my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t, uint *error_code) const;
-  virtual void gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const;
-  virtual const String * get_name() const;
+  my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t, uint *error_code) const override;
+  void gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const override;
+  const String * get_name() const override;
 };
 
 
@@ -1124,10 +1124,10 @@ class Time_zone_utc : public Time_zone
 {
 public:
   Time_zone_utc() = default;                          /* Remove gcc warning */
-  virtual my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t,
-                                    uint *error_code) const;
-  virtual void gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const;
-  virtual const String * get_name() const;
+  my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t,
+                                    uint *error_code) const override;
+  void gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const override;
+  const String * get_name() const override;
 };
 
 
@@ -1207,9 +1207,9 @@ class Time_zone_db : public Time_zone
 {
 public:
   Time_zone_db(TIME_ZONE_INFO *tz_info_arg, const String * tz_name_arg);
-  virtual my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t, uint *error_code) const;
-  virtual void gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const;
-  virtual const String * get_name() const;
+  my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t, uint *error_code) const override;
+  void gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const override;
+  const String * get_name() const override;
 private:
   TIME_ZONE_INFO *tz_info;
   const String *tz_name;
@@ -1305,10 +1305,10 @@ class Time_zone_offset : public Time_zone
 {
 public:
   Time_zone_offset(long tz_offset_arg);
-  virtual my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t,
-                                    uint *error_code) const;
-  virtual void   gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const;
-  virtual const String * get_name() const;
+  my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t,
+                                    uint *error_code) const override;
+  void   gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const override;
+  const String * get_name() const override;
   /*
     This have to be public because we want to be able to access it from
     my_offset_tzs_get_key() function

--- a/sql/wsrep_client_service.h
+++ b/sql/wsrep_client_service.h
@@ -36,38 +36,38 @@ class Wsrep_client_service : public wsrep::client_service
 public:
   Wsrep_client_service(THD*, Wsrep_client_state&);
 
-  bool interrupted(wsrep::unique_lock<wsrep::mutex>&) const;
-  void reset_globals();
-  void store_globals();
-  int prepare_data_for_replication();
-  void cleanup_transaction();
-  bool statement_allowed_for_streaming() const;
-  size_t bytes_generated() const;
-  int prepare_fragment_for_replication(wsrep::mutable_buffer&, size_t&);
-  int remove_fragments();
-  void emergency_shutdown()
+  bool interrupted(wsrep::unique_lock<wsrep::mutex>&) const override;
+  void reset_globals() override;
+  void store_globals() override;
+  int prepare_data_for_replication() override;
+  void cleanup_transaction() override;
+  bool statement_allowed_for_streaming() const override;
+  size_t bytes_generated() const override;
+  int prepare_fragment_for_replication(wsrep::mutable_buffer&, size_t&) override;
+  int remove_fragments() override;
+  void emergency_shutdown() override
   { throw wsrep::not_implemented_error(); }
-  void will_replay();
-  void signal_replayed();
-  enum wsrep::provider::status replay();
-  enum wsrep::provider::status replay_unordered();
-  void wait_for_replayers(wsrep::unique_lock<wsrep::mutex>&);
-  enum wsrep::provider::status commit_by_xid();
-  bool is_explicit_xa()
+  void will_replay() override;
+  void signal_replayed() override;
+  enum wsrep::provider::status replay() override;
+  enum wsrep::provider::status replay_unordered() override;
+  void wait_for_replayers(wsrep::unique_lock<wsrep::mutex>&) override;
+  enum wsrep::provider::status commit_by_xid() override;
+  bool is_explicit_xa() override
   {
     return false;
   }
-  bool is_prepared_xa()
+  bool is_prepared_xa() override
   {
     return false;
   }
-  bool is_xa_rollback()
+  bool is_xa_rollback() override
   {
     return false;
   }
-  void debug_sync(const char*);
-  void debug_crash(const char*);
-  int bf_rollback();
+  void debug_sync(const char*) override;
+  void debug_crash(const char*) override;
+  int bf_rollback() override;
 private:
   friend class Wsrep_server_service;
   THD* m_thd;

--- a/sql/wsrep_condition_variable.h
+++ b/sql/wsrep_condition_variable.h
@@ -31,17 +31,17 @@ public:
   { }
   ~Wsrep_condition_variable() = default;
 
-  void notify_one()
+  void notify_one() override
   {
     mysql_cond_signal(m_cond);
   }
 
-  void notify_all()
+  void notify_all() override
   {
     mysql_cond_broadcast(m_cond);
   }
 
-  void wait(wsrep::unique_lock<wsrep::mutex>& lock)
+  void wait(wsrep::unique_lock<wsrep::mutex>& lock) override
   {
     mysql_mutex_t* mutex= static_cast<mysql_mutex_t*>(lock.mutex()->native());
     mysql_cond_wait(m_cond, mutex);

--- a/sql/wsrep_high_priority_service.h
+++ b/sql/wsrep_high_priority_service.h
@@ -33,31 +33,31 @@ public:
   Wsrep_high_priority_service(THD*);
   ~Wsrep_high_priority_service();
   int start_transaction(const wsrep::ws_handle&,
-                        const wsrep::ws_meta&);
-  int next_fragment(const wsrep::ws_meta&);
-  const wsrep::transaction& transaction() const;
-  int adopt_transaction(const wsrep::transaction&);
+                        const wsrep::ws_meta&) override;
+  int next_fragment(const wsrep::ws_meta&) override;
+  const wsrep::transaction& transaction() const override;
+  int adopt_transaction(const wsrep::transaction&) override;
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&,
-                      wsrep::mutable_buffer&) = 0;
+                      wsrep::mutable_buffer&) override = 0;
   int append_fragment_and_commit(const wsrep::ws_handle&,
                                  const wsrep::ws_meta&,
                                  const wsrep::const_buffer&,
-                                 const wsrep::xid&);
-  int remove_fragments(const wsrep::ws_meta&);
-  int commit(const wsrep::ws_handle&, const wsrep::ws_meta&);
-  int rollback(const wsrep::ws_handle&, const wsrep::ws_meta&);
+                                 const wsrep::xid&) override;
+  int remove_fragments(const wsrep::ws_meta&) override;
+  int commit(const wsrep::ws_handle&, const wsrep::ws_meta&) override;
+  int rollback(const wsrep::ws_handle&, const wsrep::ws_meta&) override;
   int apply_toi(const wsrep::ws_meta&, const wsrep::const_buffer&,
-                wsrep::mutable_buffer&);
-  void store_globals();
-  void reset_globals();
-  void switch_execution_context(wsrep::high_priority_service&);
+                wsrep::mutable_buffer&) override;
+  void store_globals() override;
+  void reset_globals() override;
+  void switch_execution_context(wsrep::high_priority_service&) override;
   int log_dummy_write_set(const wsrep::ws_handle&,
                           const wsrep::ws_meta&,
-                          wsrep::mutable_buffer&);
-  void adopt_apply_error(wsrep::mutable_buffer&);
+                          wsrep::mutable_buffer&) override;
+  void adopt_apply_error(wsrep::mutable_buffer&) override;
 
   virtual bool check_exit_status() const = 0;
-  void debug_crash(const char*);
+  void debug_crash(const char*) override;
 protected:
   friend Wsrep_server_service;
   THD* m_thd;
@@ -84,12 +84,12 @@ public:
   Wsrep_applier_service(THD*);
   ~Wsrep_applier_service();
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&,
-                      wsrep::mutable_buffer&);
+                      wsrep::mutable_buffer&) override;
   int apply_nbo_begin(const wsrep::ws_meta&, const wsrep::const_buffer& data,
-                      wsrep::mutable_buffer& err);
-  void after_apply();
-  bool is_replaying() const { return false; }
-  bool check_exit_status() const;
+                      wsrep::mutable_buffer& err) override;
+  void after_apply() override;
+  bool is_replaying() const override { return false; }
+  bool check_exit_status() const override;
 };
 
 class Wsrep_replayer_service : public Wsrep_high_priority_service
@@ -98,21 +98,21 @@ public:
   Wsrep_replayer_service(THD* replayer_thd, THD* orig_thd);
   ~Wsrep_replayer_service();
   int apply_write_set(const wsrep::ws_meta&, const wsrep::const_buffer&,
-                      wsrep::mutable_buffer&);
+                      wsrep::mutable_buffer&) override;
   int apply_nbo_begin(const wsrep::ws_meta&, const wsrep::const_buffer& data,
-                      wsrep::mutable_buffer& err)
+                      wsrep::mutable_buffer& err) override
   {
     DBUG_ASSERT(0); /* DDL should never cause replaying */
     return 0;
   }
-  void after_apply() { }
-  bool is_replaying() const { return true; }
+  void after_apply() override { }
+  bool is_replaying() const override { return true; }
   void replay_status(enum wsrep::provider::status status)
   { m_replay_status = status; }
   enum wsrep::provider::status replay_status() const
   { return m_replay_status; }
   /* Replayer should never be forced to exit */
-  bool check_exit_status() const { return false; }
+  bool check_exit_status() const override { return false; }
 private:
   THD* m_orig_thd;
   struct da_shadow

--- a/sql/wsrep_mutex.h
+++ b/sql/wsrep_mutex.h
@@ -29,17 +29,17 @@ public:
     : m_mutex(mutex)
   { }
 
-  void lock()
+  void lock() override
   {
     mysql_mutex_lock(m_mutex);
   }
 
-  void unlock()
+  void unlock() override
   {
     mysql_mutex_unlock(m_mutex);
   }
 
-  void* native()
+  void* native() override
   {
     return m_mutex;
   }

--- a/sql/wsrep_server_service.h
+++ b/sql/wsrep_server_service.h
@@ -32,49 +32,49 @@ public:
     : m_server_state(server_state)
   { }
 
-  wsrep::storage_service* storage_service(wsrep::client_service&);
+  wsrep::storage_service* storage_service(wsrep::client_service&) override;
 
-  wsrep::storage_service* storage_service(wsrep::high_priority_service&);
+  wsrep::storage_service* storage_service(wsrep::high_priority_service&) override;
 
-  void release_storage_service(wsrep::storage_service*);
-
-  wsrep::high_priority_service*
-  streaming_applier_service(wsrep::client_service&);
+  void release_storage_service(wsrep::storage_service*) override;
 
   wsrep::high_priority_service*
-  streaming_applier_service(wsrep::high_priority_service&);
+  streaming_applier_service(wsrep::client_service&) override;
 
-  void release_high_priority_service(wsrep::high_priority_service*);
+  wsrep::high_priority_service*
+  streaming_applier_service(wsrep::high_priority_service&) override;
+
+  void release_high_priority_service(wsrep::high_priority_service*) override;
 
   void background_rollback(wsrep::unique_lock<wsrep::mutex> &,
-                           wsrep::client_state &);
+                           wsrep::client_state &) override;
 
-  void bootstrap();
-  void log_message(enum wsrep::log::level, const char*);
+  void bootstrap() override;
+  void log_message(enum wsrep::log::level, const char*) override;
 
-  void log_dummy_write_set(wsrep::client_state&, const wsrep::ws_meta&)
+  void log_dummy_write_set(wsrep::client_state&, const wsrep::ws_meta&) override
   { throw wsrep::not_implemented_error(); }
 
-  void log_view(wsrep::high_priority_service*, const wsrep::view&);
+  void log_view(wsrep::high_priority_service*, const wsrep::view&) override;
 
-  void recover_streaming_appliers(wsrep::client_service&);
-  void recover_streaming_appliers(wsrep::high_priority_service&);
-  wsrep::view get_view(wsrep::client_service&, const wsrep::id& own_id);
+  void recover_streaming_appliers(wsrep::client_service&) override;
+  void recover_streaming_appliers(wsrep::high_priority_service&) override;
+  wsrep::view get_view(wsrep::client_service&, const wsrep::id& own_id) override;
 
-  wsrep::gtid get_position(wsrep::client_service&);
-  void set_position(wsrep::client_service&, const wsrep::gtid&);
+  wsrep::gtid get_position(wsrep::client_service&) override;
+  void set_position(wsrep::client_service&, const wsrep::gtid&) override;
 
   void log_state_change(enum wsrep::server_state::state,
-                        enum wsrep::server_state::state);
+                        enum wsrep::server_state::state) override;
 
-  bool sst_before_init() const;
+  bool sst_before_init() const override;
 
-  std::string sst_request();
-  int start_sst(const std::string&, const wsrep::gtid&, bool);
+  std::string sst_request() override;
+  int start_sst(const std::string&, const wsrep::gtid&, bool) override;
 
-  int wait_committing_transactions(int);
+  int wait_committing_transactions(int) override;
 
-  void debug_sync(const char*);
+  void debug_sync(const char*) override;
 private:
   Wsrep_server_state& m_server_state;
 };

--- a/sql/wsrep_storage_service.h
+++ b/sql/wsrep_storage_service.h
@@ -28,19 +28,19 @@ class Wsrep_storage_service :
 public:
   Wsrep_storage_service(THD*);
   ~Wsrep_storage_service();
-  int start_transaction(const wsrep::ws_handle&);
-  void adopt_transaction(const wsrep::transaction&);
+  int start_transaction(const wsrep::ws_handle&) override;
+  void adopt_transaction(const wsrep::transaction&) override;
   int append_fragment(const wsrep::id&,
                       wsrep::transaction_id,
                       int flags,
                       const wsrep::const_buffer&,
-                      const wsrep::xid&);
-  int update_fragment_meta(const wsrep::ws_meta&);
-  int remove_fragments();
-  int commit(const wsrep::ws_handle&, const wsrep::ws_meta&);
-  int rollback(const wsrep::ws_handle&, const wsrep::ws_meta&);
-  void store_globals();
-  void reset_globals();
+                      const wsrep::xid&) override;
+  int update_fragment_meta(const wsrep::ws_meta&) override;
+  int remove_fragments() override;
+  int commit(const wsrep::ws_handle&, const wsrep::ws_meta&) override;
+  int rollback(const wsrep::ws_handle&, const wsrep::ws_meta&) override;
+  void store_globals() override;
+  void reset_globals() override;
 private:
   friend class Wsrep_server_service;
   THD* m_thd;

--- a/storage/archive/ha_archive.h
+++ b/storage/archive/ha_archive.h
@@ -88,8 +88,8 @@ class ha_archive final : public handler
 public:
   ha_archive(handlerton *hton, TABLE_SHARE *table_arg);
   ~ha_archive() = default;
-  const char *index_type(uint inx) { return "NONE"; }
-  ulonglong table_flags() const
+  const char *index_type(uint inx) override { return "NONE"; }
+  ulonglong table_flags() const override
   {
     return (HA_NO_TRANSACTIONS | HA_REC_NOT_IN_SEQ | HA_CAN_BIT_FIELD |
             HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE |
@@ -97,66 +97,66 @@ public:
             HA_HAS_RECORDS | HA_CAN_REPAIR | HA_SLOW_RND_POS |
             HA_FILE_BASED | HA_CAN_INSERT_DELAYED | HA_CAN_GEOMETRY);
   }
-  ulong index_flags(uint idx, uint part, bool all_parts) const
+  ulong index_flags(uint idx, uint part, bool all_parts) const override
   {
     return HA_ONLY_WHOLE_INDEX;
   }
-  virtual void get_auto_increment(ulonglong offset, ulonglong increment,
-                                  ulonglong nb_desired_values,
-                                  ulonglong *first_value,
-                                  ulonglong *nb_reserved_values);
-  uint max_supported_keys()          const { return 1; }
-  uint max_supported_key_length()    const { return sizeof(ulonglong); }
-  uint max_supported_key_part_length() const { return sizeof(ulonglong); }
-  ha_rows records() { return share->rows_recorded; }
-  int index_init(uint keynr, bool sorted);
-  virtual int index_read(uchar * buf, const uchar * key,
-			 uint key_len, enum ha_rkey_function find_flag);
-  virtual int index_read_idx(uchar * buf, uint index, const uchar * key,
-			     uint key_len, enum ha_rkey_function find_flag);
-  int index_next(uchar * buf);
-  int open(const char *name, int mode, uint test_if_locked);
-  int close(void);
-  int write_row(const uchar * buf);
+  void get_auto_increment(ulonglong offset, ulonglong increment,
+                          ulonglong nb_desired_values,
+                          ulonglong *first_value,
+                          ulonglong *nb_reserved_values) override;
+  uint max_supported_keys() const       override { return 1; }
+  uint max_supported_key_length() const override { return sizeof(ulonglong); }
+  uint max_supported_key_part_length() const override { return sizeof(ulonglong); }
+  ha_rows records() override { return share->rows_recorded; }
+  int index_init(uint keynr, bool sorted) override;
+  int index_read(uchar * buf, const uchar * key,
+                 uint key_len, enum ha_rkey_function find_flag) override;
+  int index_read_idx(uchar * buf, uint index, const uchar * key,
+                     uint key_len, enum ha_rkey_function find_flag);
+  int index_next(uchar * buf) override;
+  int open(const char *name, int mode, uint test_if_locked) override;
+  int close(void) override;
+  int write_row(const uchar * buf) override;
   int real_write_row(const uchar *buf, azio_stream *writer);
-  int truncate();
-  int rnd_init(bool scan=1);
-  int rnd_next(uchar *buf);
-  int rnd_pos(uchar * buf, uchar *pos);
+  int truncate() override;
+  int rnd_init(bool scan=1) override;
+  int rnd_next(uchar *buf) override;
+  int rnd_pos(uchar * buf, uchar *pos) override;
   int get_row(azio_stream *file_to_read, uchar *buf);
   int get_row_version2(azio_stream *file_to_read, uchar *buf);
   int get_row_version3(azio_stream *file_to_read, uchar *buf);
   Archive_share *get_share(const char *table_name, int *rc);
   int init_archive_reader();
   // Always try auto_repair in case of HA_ERR_CRASHED_ON_USAGE
-  bool auto_repair(int error) const
+  bool auto_repair(int error) const override
   { return error == HA_ERR_CRASHED_ON_USAGE; }
   int read_data_header(azio_stream *file_to_read);
-  void position(const uchar *record);
-  int info(uint);
-  int extra(enum ha_extra_function operation);
-  void update_create_info(HA_CREATE_INFO *create_info);
-  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info);
-  int optimize(THD* thd, HA_CHECK_OPT* check_opt);
-  int repair(THD* thd, HA_CHECK_OPT* check_opt);
-  int check_for_upgrade(HA_CHECK_OPT *check_opt);
-  void start_bulk_insert(ha_rows rows, uint flags);
-  int end_bulk_insert();
-  enum row_type get_row_type() const 
+  void position(const uchar *record) override;
+  int info(uint) override;
+  int extra(enum ha_extra_function operation) override;
+  void update_create_info(HA_CREATE_INFO *create_info) override;
+  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info) override;
+  int optimize(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int repair(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int check_for_upgrade(HA_CHECK_OPT *check_opt) override;
+  void start_bulk_insert(ha_rows rows, uint flags) override;
+  int end_bulk_insert() override;
+  enum row_type get_row_type() const override 
   { 
     return ROW_TYPE_COMPRESSED;
   }
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type);
-  bool is_crashed() const;
-  int check(THD* thd, HA_CHECK_OPT* check_opt);
-  bool check_and_repair(THD *thd);
+                             enum thr_lock_type lock_type) override;
+  bool is_crashed() const override;
+  int check(THD* thd, HA_CHECK_OPT* check_opt) override;
+  bool check_and_repair(THD *thd) override;
   uint32 max_row_length(const uchar *buf);
   bool fix_rec_buff(unsigned int length);
   int unpack_row(azio_stream *file_to_read, uchar *record);
   unsigned int pack_row(const uchar *record, azio_stream *writer);
-  bool check_if_incompatible_data(HA_CREATE_INFO *info, uint table_changes);
-  int external_lock(THD *thd, int lock_type);
+  bool check_if_incompatible_data(HA_CREATE_INFO *info, uint table_changes) override;
+  int external_lock(THD *thd, int lock_type) override;
 private:
   void flush_and_clear_pending_writes();
 };

--- a/storage/blackhole/ha_blackhole.h
+++ b/storage/blackhole/ha_blackhole.h
@@ -49,15 +49,15 @@ public:
     The name of the index type that will be used for display
     don't implement this method unless you really have indexes
   */
-  const char *index_type(uint key_number);
-  ulonglong table_flags() const
+  const char *index_type(uint key_number) override;
+  ulonglong table_flags() const override
   {
     return(HA_NULL_IN_KEY | HA_CAN_FULLTEXT | HA_CAN_SQL_HANDLER |
            HA_BINLOG_STMT_CAPABLE | HA_BINLOG_ROW_CAPABLE |
            HA_CAN_INDEX_BLOBS | HA_AUTO_PART_KEY | HA_CAN_ONLINE_BACKUPS |
            HA_FILE_BASED | HA_CAN_GEOMETRY | HA_CAN_INSERT_DELAYED);
   }
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   {
     return ((table_share->key_info[inx].algorithm == HA_KEY_ALG_FULLTEXT) ?
             0 : HA_READ_NEXT | HA_READ_PREV | HA_READ_RANGE |
@@ -67,39 +67,39 @@ public:
 #define BLACKHOLE_MAX_KEY	MAX_KEY		/* Max allowed keys */
 #define BLACKHOLE_MAX_KEY_SEG	16		/* Max segments for key */
 #define BLACKHOLE_MAX_KEY_LENGTH	3500		/* Like in InnoDB */
-  uint max_supported_keys()          const { return BLACKHOLE_MAX_KEY; }
-  uint max_supported_key_length()    const { return BLACKHOLE_MAX_KEY_LENGTH; }
-  uint max_supported_key_part_length() const { return BLACKHOLE_MAX_KEY_LENGTH; }
-  int open(const char *name, int mode, uint test_if_locked);
-  int close(void);
-  int truncate();
-  int rnd_init(bool scan);
-  int rnd_next(uchar *buf);
-  int rnd_pos(uchar * buf, uchar *pos);
+  uint max_supported_keys() const       override { return BLACKHOLE_MAX_KEY; }
+  uint max_supported_key_length() const override { return BLACKHOLE_MAX_KEY_LENGTH; }
+  uint max_supported_key_part_length() const override { return BLACKHOLE_MAX_KEY_LENGTH; }
+  int open(const char *name, int mode, uint test_if_locked) override;
+  int close(void) override;
+  int truncate() override;
+  int rnd_init(bool scan) override;
+  int rnd_next(uchar *buf) override;
+  int rnd_pos(uchar * buf, uchar *pos) override;
   int index_read_map(uchar * buf, const uchar * key, key_part_map keypart_map,
-                     enum ha_rkey_function find_flag);
+                     enum ha_rkey_function find_flag) override;
   int index_read_idx_map(uchar * buf, uint idx, const uchar * key,
                          key_part_map keypart_map,
-                         enum ha_rkey_function find_flag);
-  int index_read_last_map(uchar * buf, const uchar * key, key_part_map keypart_map);
-  int index_next(uchar * buf);
-  int index_prev(uchar * buf);
-  int index_first(uchar * buf);
-  int index_last(uchar * buf);
-  void position(const uchar *record);
-  int info(uint flag);
-  int external_lock(THD *thd, int lock_type);
+                         enum ha_rkey_function find_flag) override;
+  int index_read_last_map(uchar * buf, const uchar * key, key_part_map keypart_map) override;
+  int index_next(uchar * buf) override;
+  int index_prev(uchar * buf) override;
+  int index_first(uchar * buf) override;
+  int index_last(uchar * buf) override;
+  void position(const uchar *record) override;
+  int info(uint flag) override;
+  int external_lock(THD *thd, int lock_type) override;
   int create(const char *name, TABLE *table_arg,
-             HA_CREATE_INFO *create_info);
+             HA_CREATE_INFO *create_info) override;
   THR_LOCK_DATA **store_lock(THD *thd,
                              THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type);
-  int delete_table(const char *name)
+                             enum thr_lock_type lock_type) override;
+  int delete_table(const char *name) override
   {
     return 0;
   }
 private:
-  virtual int write_row(const uchar *buf);
-  virtual int update_row(const uchar *old_data, const uchar *new_data);
-  virtual int delete_row(const uchar *buf);
+  int write_row(const uchar *buf) override;
+  int update_row(const uchar *old_data, const uchar *new_data) override;
+  int delete_row(const uchar *buf) override;
 };

--- a/storage/connect/array.h
+++ b/storage/connect/array.h
@@ -38,11 +38,11 @@ class DllExport ARRAY : public XOBJECT, public CSORT { // Array descblock
 //ARRAY(PGLOBAL g, PARRAY par, int k);
 
   // Implementation
-  virtual int   GetType(void) {return TYPE_ARRAY;}
-  virtual int   GetResultType(void) {return Type;}
-  virtual int   GetLength(void) {return Len;}
-  virtual int   GetLengthEx(void) {return Len;}
-  virtual int   GetScale() {return 0;}
+  int   GetType(void) override {return TYPE_ARRAY;}
+  int   GetResultType(void) override {return Type;}
+  int   GetLength(void) override {return Len;}
+  int   GetLengthEx(void) override {return Len;}
+  int   GetScale() override {return 0;}
           int   GetNval(void) {return Nval;}
           int   GetSize(void) {return Size;}
 //        PVAL  GetValp(void) {return Valp;}
@@ -51,13 +51,13 @@ class DllExport ARRAY : public XOBJECT, public CSORT { // Array descblock
 
   // Methods
   using XOBJECT::GetIntValue;
-  virtual void  Reset(void) {Bot = -1;}
-  virtual int   Qcompare(int *, int *);
-  virtual bool  Compare(PXOB) {assert(false); return false;}
-  virtual bool  SetFormat(PGLOBAL, FORMAT&) {assert(false); return false;}
+  void  Reset(void) override {Bot = -1;}
+  int   Qcompare(int *, int *) override;
+  bool  Compare(PXOB) override {assert(false); return false;}
+  bool  SetFormat(PGLOBAL, FORMAT&) override {assert(false); return false;}
 //virtual int   CheckSpcCol(PTDB, int) {return 0;}
-  virtual void  Printf(PGLOBAL g, FILE *f, uint n);
-  virtual void  Prints(PGLOBAL g, char *ps, uint z);
+  void  Printf(PGLOBAL g, FILE *f, uint n) override;
+  void  Prints(PGLOBAL g, char *ps, uint z) override;
 //        void  Empty(void);
           void  SetPrecision(PGLOBAL g, int p);
           bool  AddValue(PGLOBAL g, PSZ sp);
@@ -119,7 +119,7 @@ class MULAR : public CSORT, public BLOCK {   // No need to be an XOBJECT
   void SetPars(PARRAY par, int i) {Pars[i] = par;}
 
   // Methods
-  virtual int Qcompare(int *i1, int *i2);   // Sort compare routine
+  int Qcompare(int *i1, int *i2) override;   // Sort compare routine
           bool Sort(PGLOBAL g);
 
  protected:

--- a/storage/connect/blkfil.h
+++ b/storage/connect/blkfil.h
@@ -27,8 +27,8 @@ class DllExport BLOCKFILTER : public BLOCK {           /* Block Filter */
   // Methods
   virtual void Reset(PGLOBAL) = 0;
   virtual int  BlockEval(PGLOBAL) = 0;
-  virtual void Printf(PGLOBAL g, FILE *f, uint n);
-  virtual void Prints(PGLOBAL g, char *ps, uint z);
+  void Printf(PGLOBAL g, FILE *f, uint n) override;
+  void Prints(PGLOBAL g, char *ps, uint z) override;
 
  protected:
   BLOCKFILTER(void) = default;       // Standard constructor not to be used
@@ -50,8 +50,8 @@ class DllExport BLKFILLOG : public BLOCKFILTER { /* Logical Op Block Filter */
   BLKFILLOG(PTDBDOS tdbp, int op, PBF *bfp, int n);
 
   // Methods
-  virtual void Reset(PGLOBAL g);
-  virtual int  BlockEval(PGLOBAL g);
+  void Reset(PGLOBAL g) override;
+  int  BlockEval(PGLOBAL g) override;
 
  protected:
   BLKFILLOG(void) = default;       // Standard constructor not to be used
@@ -70,8 +70,8 @@ class DllExport BLKFILARI : public BLOCKFILTER { /* Arithm. Op Block Filter */
   BLKFILARI(PGLOBAL g, PTDBDOS tdbp, int op, PXOB *xp);
 
   // Methods
-  virtual void Reset(PGLOBAL g);
-  virtual int  BlockEval(PGLOBAL g);
+  void Reset(PGLOBAL g) override;
+  int  BlockEval(PGLOBAL g) override;
   virtual void MakeValueBitmap(void) {}
 
  protected:
@@ -93,8 +93,8 @@ class DllExport BLKFILAR2 : public BLKFILARI { /* Arithm. Op Block Filter */
   BLKFILAR2(PGLOBAL g, PTDBDOS tdbp, int op, PXOB *xp);
 
   // Methods
-  virtual int  BlockEval(PGLOBAL g);
-  virtual void MakeValueBitmap(void);
+  int  BlockEval(PGLOBAL g) override;
+  void MakeValueBitmap(void) override;
 
  protected:
   BLKFILAR2(void) = default;       // Standard constructor not to be used
@@ -114,8 +114,8 @@ class DllExport BLKFILMR2 : public BLKFILARI { /* Arithm. Op Block Filter */
   BLKFILMR2(PGLOBAL g, PTDBDOS tdbp, int op, PXOB *xp);
 
   // Methods
-  virtual int  BlockEval(PGLOBAL g);
-  virtual void MakeValueBitmap(void);
+  int  BlockEval(PGLOBAL g) override;
+  void MakeValueBitmap(void) override;
 
  protected:
   BLKFILMR2(void) = default;       // Standard constructor not to be used
@@ -137,8 +137,8 @@ class DllExport BLKSPCARI : public BLOCKFILTER { /* Arithm. Op Block Filter */
   BLKSPCARI(PTDBDOS tdbp, int op, PXOB *xp, int bsize);
 
   // Methods
-  virtual void Reset(PGLOBAL g);
-  virtual int  BlockEval(PGLOBAL g);
+  void Reset(PGLOBAL g) override;
+  int  BlockEval(PGLOBAL g) override;
 
  protected:
   BLKSPCARI(void) = default;       // Standard constructor not to be used
@@ -159,8 +159,8 @@ class DllExport BLKFILIN : public BLOCKFILTER {  // With array arguments.
   BLKFILIN(PGLOBAL g, PTDBDOS tdbp, int op, int opm, PXOB *xp);
 
   // Methods
-  virtual void Reset(PGLOBAL g);
-  virtual int  BlockEval(PGLOBAL g);
+  void Reset(PGLOBAL g) override;
+  int  BlockEval(PGLOBAL g) override;
   virtual void MakeValueBitmap(void) {}
 
  protected:
@@ -181,8 +181,8 @@ class DllExport BLKFILIN2 : public BLKFILIN {  // With array arguments.
 
   // Methods
 //virtual void Reset(PGLOBAL g);
-  virtual int  BlockEval(PGLOBAL g);
-  virtual void MakeValueBitmap(void);
+  int  BlockEval(PGLOBAL g) override;
+  void MakeValueBitmap(void) override;
 
  protected:
   // Member
@@ -205,8 +205,8 @@ class DllExport BLKSPCIN : public BLOCKFILTER {  // With array arguments.
   BLKSPCIN(PGLOBAL g, PTDBDOS tdbp, int op, int opm, PXOB *xp, int bsize);
 
   // Methods
-  virtual void Reset(PGLOBAL g);
-  virtual int  BlockEval(PGLOBAL g);
+  void Reset(PGLOBAL g) override;
+  int  BlockEval(PGLOBAL g) override;
 
  protected:
   // Member

--- a/storage/connect/cmgfam.h
+++ b/storage/connect/cmgfam.h
@@ -26,18 +26,18 @@ public:
 	CMGFAM(PCMGFAM txfp);
 
 	// Implementation
-	virtual AMT   GetAmType(void) { return TYPE_AM_MGO; }
+	AMT   GetAmType(void) override { return TYPE_AM_MGO; }
 	virtual bool  GetUseTemp(void) { return false; }
 	virtual int   GetPos(void);
 	virtual int   GetNextPos(void);
 	void  SetTdbp(PTDBDOS tdbp) { Tdbp = tdbp; }
-	virtual PTXF  Duplicate(PGLOBAL g) { return (PTXF)new(g) CMGFAM(this); }
+	PTXF  Duplicate(PGLOBAL g) { return (PTXF)new(g) CMGFAM(this); }
 	void  SetLrecl(int lrecl) { Lrecl = lrecl; }
 
 	// Methods
 	virtual void  Reset(void);
 	virtual int   GetFileLength(PGLOBAL g);
-	virtual int   Cardinality(PGLOBAL g);
+	int   Cardinality(PGLOBAL g) override;
 	virtual int   MaxBlkSize(PGLOBAL g, int s);
 	virtual bool  AllocateBuffer(PGLOBAL g) { return false; }
 	virtual int   GetRowID(void);

--- a/storage/connect/colblk.h
+++ b/storage/connect/colblk.h
@@ -27,12 +27,12 @@ class DllExport COLBLK : public XOBJECT {
 
  public:
   // Implementation
-  virtual int     GetType(void) {return TYPE_COLBLK;}
-  virtual int     GetResultType(void) {return Buf_Type;}
-  virtual int     GetScale(void) {return Format.Prec;}
+  int     GetType(void) override {return TYPE_COLBLK;}
+  int     GetResultType(void) override {return Buf_Type;}
+  int     GetScale(void) override {return Format.Prec;}
   virtual int     GetPrecision(void) {return Precision;}
-  virtual int     GetLength(void) {return Long;}
-  virtual int     GetLengthEx(void);
+  int     GetLength(void) override {return Long;}
+  int     GetLengthEx(void) override;
   virtual int     GetAmType() {return TYPE_AM_ERROR;}
   virtual void    SetOk(void) {Status |= BUF_EMPTY;}
   virtual PTDB    GetTo_Tdb(void) {return To_Tdb;}
@@ -65,17 +65,17 @@ class DllExport COLBLK : public XOBJECT {
           void    SetNullable(bool b) {Nullable = b;}
           void    SetName(PSZ name_var) { Name= name_var; }
   // Methods
-  virtual void    Reset(void);
-  virtual bool    Compare(PXOB xp);
-  virtual bool    SetFormat(PGLOBAL, FORMAT&);
+  void    Reset(void) override;
+  bool    Compare(PXOB xp) override;
+  bool    SetFormat(PGLOBAL, FORMAT&) override;
   virtual bool    IsSpecial(void) {return false;}
-  virtual bool    Eval(PGLOBAL g);
+  bool    Eval(PGLOBAL g) override;
   virtual bool    SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
   virtual void    SetTo_Val(PVAL) {}
   virtual void    ReadColumn(PGLOBAL g);
   virtual void    WriteColumn(PGLOBAL g);
-  virtual void    Printf(PGLOBAL g, FILE *, uint);
-  virtual void    Prints(PGLOBAL g, char *, uint);
+  void    Printf(PGLOBAL g, FILE *, uint) override;
+  void    Prints(PGLOBAL g, char *, uint) override;
   virtual bool    VarSize(void) {return false;}
           bool    InitValue(PGLOBAL g);
 
@@ -108,13 +108,12 @@ class DllExport SPCBLK : public COLBLK {
   SPCBLK(PCOLUMN cp);
 
   // Implementation
-  virtual int  GetAmType(void) = 0;
   virtual bool GetRnm(void) {return false;}
 
   // Methods
-  virtual bool IsSpecial(void) {return true;}
-  virtual void ReadColumn(PGLOBAL g) = 0;
-  virtual void WriteColumn(PGLOBAL g);
+  bool IsSpecial(void) override {return true;}
+  void ReadColumn(PGLOBAL g) override = 0;
+  void WriteColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used
@@ -130,11 +129,11 @@ class DllExport RIDBLK : public SPCBLK {
   RIDBLK(PCOLUMN cp, bool rnm);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_ROWID;}
-  virtual bool GetRnm(void) {return Rnm;}
+  int  GetAmType(void) override {return TYPE_AM_ROWID;}
+  bool GetRnm(void) override {return Rnm;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   bool Rnm;                         // False for RowID, True for RowNum
@@ -149,11 +148,11 @@ class DllExport FIDBLK : public SPCBLK {
   FIDBLK(PCOLUMN cp, OPVAL op);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_FILID;}
+  int  GetAmType(void) override {return TYPE_AM_FILID;}
 
   // Methods
-  virtual void Reset(void) {}       // This is a pseudo constant column
-  virtual void ReadColumn(PGLOBAL g);
+  void Reset(void) override {}       // This is a pseudo constant column
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   PCSZ  Fn;                         // The current To_File of the table
@@ -169,11 +168,11 @@ class DllExport TIDBLK : public SPCBLK {
   TIDBLK(PCOLUMN cp);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_TABID;}
+  int  GetAmType(void) override {return TYPE_AM_TABID;}
 
   // Methods
-  virtual void Reset(void) {}       // This is a pseudo constant column
-  virtual void ReadColumn(PGLOBAL g);
+  void Reset(void) override {}       // This is a pseudo constant column
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used
@@ -192,11 +191,11 @@ class DllExport PRTBLK : public SPCBLK {
   PRTBLK(PCOLUMN cp);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_PRTID;}
+  int  GetAmType(void) override {return TYPE_AM_PRTID;}
 
   // Methods
-  virtual void Reset(void) {}       // This is a pseudo constant column
-  virtual void ReadColumn(PGLOBAL g);
+  void Reset(void) override {}       // This is a pseudo constant column
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used
@@ -215,11 +214,11 @@ class DllExport SIDBLK : public SPCBLK {
   SIDBLK(PCOLUMN cp);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_SRVID;}
+  int  GetAmType(void) override {return TYPE_AM_SRVID;}
 
   // Methods
-  virtual void Reset(void) {}       // This is a pseudo constant column
-  virtual void ReadColumn(PGLOBAL g);
+  void Reset(void) override {}       // This is a pseudo constant column
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used

--- a/storage/connect/domdoc.h
+++ b/storage/connect/domdoc.h
@@ -73,7 +73,7 @@ class DOMNODE : public XMLNODE {
   // Methods
   virtual RCODE  GetContent(PGLOBAL g, char *buf, int len);
   virtual bool   SetContent(PGLOBAL g, char *txtp, int len);
-  virtual PXNODE Clone(PGLOBAL g, PXNODE np);
+  PXNODE Clone(PGLOBAL g, PXNODE np) override;
   virtual PXLIST GetChildElements(PGLOBAL g, char *xp, PXLIST lp);
   virtual PXLIST SelectNodes(PGLOBAL g, char *xp, PXLIST lp);
   virtual PXNODE SelectSingleNode(PGLOBAL g, char *xp, PXNODE np);

--- a/storage/connect/filamap.h
+++ b/storage/connect/filamap.h
@@ -24,32 +24,32 @@ class DllExport MAPFAM : public TXTFAM {
   MAPFAM(PMAPFAM tmfp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_MAP;}
-  virtual int   GetPos(void);
-  virtual int   GetNextPos(void);
-  virtual PTXF  Duplicate(PGLOBAL g)
+  AMT   GetAmType(void) override {return TYPE_AM_MAP;}
+  int   GetPos(void) override;
+  int   GetNextPos(void) override;
+  PTXF  Duplicate(PGLOBAL g) override
                   {return (PTXF)new(g) MAPFAM(this);}
 
   // Methods
-  virtual void  Reset(void);
-  virtual int   GetFileLength(PGLOBAL g);
-  virtual int   Cardinality(PGLOBAL g) {return (g) ? -1 : 0;}
-  virtual int   MaxBlkSize(PGLOBAL g, int s) {return s;}
-  virtual int   GetRowID(void);
-  virtual bool  RecordPos(PGLOBAL g);
-  virtual bool  SetPos(PGLOBAL g, int recpos);
-  virtual int   SkipRecord(PGLOBAL g, bool header);
-  virtual bool  OpenTableFile(PGLOBAL g);
-  virtual bool  DeferReading(void) {return false;}
+  void  Reset(void) override;
+  int   GetFileLength(PGLOBAL g) override;
+  int   Cardinality(PGLOBAL g) override {return (g) ? -1 : 0;}
+  int   MaxBlkSize(PGLOBAL g, int s) override {return s;}
+  int   GetRowID(void) override;
+  bool  RecordPos(PGLOBAL g) override;
+  bool  SetPos(PGLOBAL g, int recpos) override;
+  int   SkipRecord(PGLOBAL g, bool header) override;
+  bool  OpenTableFile(PGLOBAL g) override;
+  bool  DeferReading(void) override {return false;}
 	virtual int   GetNext(PGLOBAL g) {return RC_EF;}
-	virtual int   ReadBuffer(PGLOBAL g);
-  virtual int   WriteBuffer(PGLOBAL g);
-  virtual int   DeleteRecords(PGLOBAL g, int irc);
-  virtual void  CloseTableFile(PGLOBAL g, bool abort);
-  virtual void  Rewind(void);
+	int   ReadBuffer(PGLOBAL g) override;
+  int   WriteBuffer(PGLOBAL g) override;
+  int   DeleteRecords(PGLOBAL g, int irc) override;
+  void  CloseTableFile(PGLOBAL g, bool abort) override;
+  void  Rewind(void) override;
 
  protected:
-  virtual int   InitDelete(PGLOBAL g, int fpos, int spos);
+  int   InitDelete(PGLOBAL g, int fpos, int spos) override;
 
   // Members
   char *Memory;               // Pointer on file mapping view.
@@ -70,18 +70,18 @@ class DllExport MBKFAM : public MAPFAM {
   MBKFAM(PMAPFAM tmfp) : MAPFAM(tmfp) {}
 
   // Implementation
-  virtual PTXF Duplicate(PGLOBAL g)
+  PTXF Duplicate(PGLOBAL g) override
                   {return (PTXF)new(g) MBKFAM(this);}
 
   // Methods
-  virtual void Reset(void);
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  MaxBlkSize(PGLOBAL g, int s)
+  void Reset(void) override;
+  int  Cardinality(PGLOBAL g) override;
+  int  MaxBlkSize(PGLOBAL g, int s) override
                 {return TXTFAM::MaxBlkSize(g, s);}
-  virtual int  GetRowID(void);
-  virtual int  SkipRecord(PGLOBAL g, bool header);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual void Rewind(void);
+  int  GetRowID(void) override;
+  int  SkipRecord(PGLOBAL g, bool header) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  void Rewind(void) override;
 
  protected:
   // No additional members
@@ -97,22 +97,22 @@ class DllExport MPXFAM : public MBKFAM {
   MPXFAM(PMAPFAM tmfp) : MBKFAM(tmfp) {}
 
   // Implementation
-  virtual int   GetPos(void);
-  virtual PTXF  Duplicate(PGLOBAL g)
+  int   GetPos(void) override;
+  PTXF  Duplicate(PGLOBAL g) override
                   {return (PTXF)new(g) MPXFAM(this);}
 
   // Methods
-  virtual int   Cardinality(PGLOBAL g) {return TXTFAM::Cardinality(g);}
-  virtual int   MaxBlkSize(PGLOBAL g, int s)
+  int   Cardinality(PGLOBAL g) override {return TXTFAM::Cardinality(g);}
+  int   MaxBlkSize(PGLOBAL g, int s) override
                 {return TXTFAM::MaxBlkSize(g, s);}
-  virtual bool  SetPos(PGLOBAL g, int recpos);
-  virtual int   GetNextPos(void) {return GetPos() + 1;}
-  virtual bool  DeferReading(void) {return false;}
-  virtual int   ReadBuffer(PGLOBAL g);
-  virtual int   WriteBuffer(PGLOBAL g);
+  bool  SetPos(PGLOBAL g, int recpos) override;
+  int   GetNextPos(void) override {return GetPos() + 1;}
+  bool  DeferReading(void) override {return false;}
+  int   ReadBuffer(PGLOBAL g) override;
+  int   WriteBuffer(PGLOBAL g) override;
 
  protected:
-  virtual int   InitDelete(PGLOBAL g, int fpos, int spos);
+  int   InitDelete(PGLOBAL g, int fpos, int spos) override;
 
   // No additional members
   }; // end of class MPXFAM

--- a/storage/connect/filamdbf.h
+++ b/storage/connect/filamdbf.h
@@ -55,23 +55,23 @@ class DllExport DBFFAM : public FIXFAM, public DBFBASE {
   DBFFAM(PDBFFAM txfp) : FIXFAM(txfp), DBFBASE((PDBF)txfp) {}
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_DBF;}
-  virtual PTXF Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_DBF;}
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) DBFFAM(this);}
 
   // Methods
-  virtual int  GetNerr(void) {return Nerr;}
-  virtual int  Cardinality(PGLOBAL g);
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual void ResetBuffer(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
-  virtual void Rewind(void);
+  int  GetNerr(void) override {return Nerr;}
+  int  Cardinality(PGLOBAL g) override;
+  bool OpenTableFile(PGLOBAL g) override;
+  bool AllocateBuffer(PGLOBAL g) override;
+  void ResetBuffer(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
+  void Rewind(void) override;
 
  protected:
-  virtual bool CopyHeader(PGLOBAL g);
+  bool CopyHeader(PGLOBAL g) override;
 //virtual int  InitDelete(PGLOBAL g, int fpos, int spos);
 
   // Members
@@ -88,18 +88,18 @@ class DllExport DBMFAM : public MPXFAM, public DBFBASE {
   DBMFAM(PDBMFAM txfp) : MPXFAM(txfp), DBFBASE((PDBF)txfp) {}
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_DBF;}
-  virtual PTXF Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_DBF;}
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) DBMFAM(this);}
-  virtual  int  GetDelRows(void);
+   int  GetDelRows(void) override;
 
   // Methods
-  virtual int  GetNerr(void) {return Nerr;}
-  virtual int  Cardinality(PGLOBAL g);
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void Rewind(void);
+  int  GetNerr(void) override {return Nerr;}
+  int  Cardinality(PGLOBAL g) override;
+  bool AllocateBuffer(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void Rewind(void) override;
 
  protected:
   // Members

--- a/storage/connect/filamfix.h
+++ b/storage/connect/filamfix.h
@@ -25,28 +25,28 @@ class DllExport FIXFAM : public BLKFAM {
   FIXFAM(PFIXFAM txfp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_FIX;}
-  virtual PTXF Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_FIX;}
+  PTXF Duplicate(PGLOBAL g) override
                  {return (PTXF)new(g) FIXFAM(this);}
 
   // Methods
-  virtual int  Cardinality(PGLOBAL g) {return TXTFAM::Cardinality(g);}
-  virtual int  MaxBlkSize(PGLOBAL g, int s)
+  int  Cardinality(PGLOBAL g) override {return TXTFAM::Cardinality(g);}
+  int  MaxBlkSize(PGLOBAL g, int s) override
                 {return TXTFAM::MaxBlkSize(g, s);}
-  virtual bool SetPos(PGLOBAL g, int recpos);
-  virtual int  GetNextPos(void) {return Fpos + 1;}
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual void ResetBuffer(PGLOBAL g);
+  bool SetPos(PGLOBAL g, int recpos) override;
+  int  GetNextPos(void) override {return Fpos + 1;}
+  bool AllocateBuffer(PGLOBAL g) override;
+  void ResetBuffer(PGLOBAL g) override;
   virtual int  WriteModifiedBlock(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
+  int  ReadBuffer(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
 
  protected:
   virtual bool CopyHeader(PGLOBAL g) {return false;}
-  virtual bool MoveIntermediateLines(PGLOBAL g, bool *b);
-  virtual int  InitDelete(PGLOBAL g, int fpos, int spos);
+  bool MoveIntermediateLines(PGLOBAL g, bool *b) override;
+  int  InitDelete(PGLOBAL g, int fpos, int spos) override;
 
   // No additional members
   }; // end of class FIXFAM
@@ -64,22 +64,22 @@ class BGXFAM : public FIXFAM {
   BGXFAM(PBGXFAM txfp);
 
   // Implementation
-  virtual PTXF Duplicate(PGLOBAL g)
+  PTXF Duplicate(PGLOBAL g) override
                  {return (PTXF)new(g) BGXFAM(this);}
 
   // Methods
-  virtual int  Cardinality(PGLOBAL g);
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual int  WriteModifiedBlock(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
-  virtual void Rewind(void);
+  int  Cardinality(PGLOBAL g) override;
+  bool OpenTableFile(PGLOBAL g) override;
+  int  WriteModifiedBlock(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
+  void Rewind(void) override;
 
  protected:
-  virtual bool OpenTempFile(PGLOBAL g);
-  virtual bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL);
+  bool OpenTempFile(PGLOBAL g) override;
+  bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL) override;
           int  BigRead(PGLOBAL g, HANDLE h, void *inbuf, int req);
           bool BigWrite(PGLOBAL g, HANDLE h, void *inbuf, int req);
           bool BigSeek(PGLOBAL g, HANDLE h, BIGINT pos

--- a/storage/connect/filamgz.h
+++ b/storage/connect/filamgz.h
@@ -28,28 +28,28 @@ class DllExport GZFAM : public TXTFAM {
   GZFAM(PGZFAM txfp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_GZ;}
-  virtual int  GetPos(void);
-  virtual int  GetNextPos(void);
-  virtual PTXF Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_GZ;}
+  int  GetPos(void) override;
+  int  GetNextPos(void) override;
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) GZFAM(this);}
 
   // Methods
-  virtual void Reset(void);
-  virtual int  GetFileLength(PGLOBAL g);
-  virtual int  Cardinality(PGLOBAL g) {return (g) ? -1 : 0;}
-  virtual int  MaxBlkSize(PGLOBAL g, int s) {return s;}
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual int  GetRowID(void);
-  virtual bool RecordPos(PGLOBAL g);
-  virtual bool SetPos(PGLOBAL g, int recpos);
-  virtual int  SkipRecord(PGLOBAL g, bool header);
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
-  virtual void Rewind(void);
+  void Reset(void) override;
+  int  GetFileLength(PGLOBAL g) override;
+  int  Cardinality(PGLOBAL g) override {return (g) ? -1 : 0;}
+  int  MaxBlkSize(PGLOBAL g, int s) override {return s;}
+  bool AllocateBuffer(PGLOBAL g) override;
+  int  GetRowID(void) override;
+  bool RecordPos(PGLOBAL g) override;
+  bool SetPos(PGLOBAL g, int recpos) override;
+  int  SkipRecord(PGLOBAL g, bool header) override;
+  bool OpenTableFile(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
+  void Rewind(void) override;
 
  protected:
           int  Zerror(PGLOBAL g);    // GZ error function
@@ -71,23 +71,23 @@ class DllExport ZBKFAM : public GZFAM {
   ZBKFAM(PZBKFAM txfp);
 
   // Implementation
-  virtual int  GetPos(void);
-  virtual int  GetNextPos(void) {return 0;}
-  virtual PTXF Duplicate(PGLOBAL g)
+  int  GetPos(void) override;
+  int  GetNextPos(void) override {return 0;}
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) ZBKFAM(this);}
 
   // Methods
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  MaxBlkSize(PGLOBAL g, int s);
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual int  GetRowID(void);
-  virtual bool RecordPos(PGLOBAL g);
-  virtual int  SkipRecord(PGLOBAL g, bool header);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
-  virtual void Rewind(void);
+  int  Cardinality(PGLOBAL g) override;
+  int  MaxBlkSize(PGLOBAL g, int s) override;
+  bool AllocateBuffer(PGLOBAL g) override;
+  int  GetRowID(void) override;
+  bool RecordPos(PGLOBAL g) override;
+  int  SkipRecord(PGLOBAL g, bool header) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
+  void Rewind(void) override;
 
  protected:
   // Members
@@ -108,15 +108,15 @@ class DllExport GZXFAM : public ZBKFAM {
   GZXFAM(PZIXFAM txfp) : ZBKFAM(txfp) {}
 
   // Implementation
-  virtual int  GetNextPos(void) {return 0;}
-  virtual PTXF Duplicate(PGLOBAL g)
+  int  GetNextPos(void) override {return 0;}
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) GZXFAM(this);}
 
   // Methods
-  virtual int  Cardinality(PGLOBAL g);
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
+  int  Cardinality(PGLOBAL g) override;
+  bool AllocateBuffer(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
 
  protected:
   // No additional Members
@@ -140,21 +140,21 @@ class DllExport ZLBFAM : public BLKFAM {
   ZLBFAM(PZLBFAM txfp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_ZLIB;}
-  virtual int  GetPos(void);
-  virtual int  GetNextPos(void);
-  virtual PTXF Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_ZLIB;}
+  int  GetPos(void) override;
+  int  GetNextPos(void) override;
+  PTXF Duplicate(PGLOBAL g) override
                   {return (PTXF)new(g) ZLBFAM(this);}
   inline  void SetOptimized(bool b) {Optimized = b;}
 
   // Methods
-  virtual int  GetFileLength(PGLOBAL g);
-  virtual bool SetPos(PGLOBAL g, int recpos);
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
-  virtual void Rewind(void);
+  int  GetFileLength(PGLOBAL g) override;
+  bool SetPos(PGLOBAL g, int recpos) override;
+  bool AllocateBuffer(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
+  void Rewind(void) override;
 
  protected:
           bool WriteCompressedBuffer(PGLOBAL g);

--- a/storage/connect/filamtxt.h
+++ b/storage/connect/filamtxt.h
@@ -134,35 +134,35 @@ class DllExport DOSFAM : public TXTFAM {
   DOSFAM(PBLKFAM tdfp, PDOSDEF tdp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_DOS;}
-  virtual bool  GetUseTemp(void) {return UseTemp;}
-  virtual int   GetPos(void);
-  virtual int   GetNextPos(void);
-  virtual PTXF  Duplicate(PGLOBAL g)
+  AMT   GetAmType(void) override {return TYPE_AM_DOS;}
+  bool  GetUseTemp(void) override {return UseTemp;}
+  int   GetPos(void) override;
+  int   GetNextPos(void) override;
+  PTXF  Duplicate(PGLOBAL g) override
                   {return (PTXF)new(g) DOSFAM(this);}
 
   // Methods
-  virtual void  Reset(void);
-  virtual int   GetFileLength(PGLOBAL g);
-  virtual int   Cardinality(PGLOBAL g);
-  virtual int   MaxBlkSize(PGLOBAL g, int s);
-  virtual bool  AllocateBuffer(PGLOBAL g);
-  virtual int   GetRowID(void);
-  virtual bool  RecordPos(PGLOBAL g);
-  virtual bool  SetPos(PGLOBAL g, int recpos);
-  virtual int   SkipRecord(PGLOBAL g, bool header);
-  virtual bool  OpenTableFile(PGLOBAL g);
-  virtual int   ReadBuffer(PGLOBAL g);
-  virtual int   WriteBuffer(PGLOBAL g);
-  virtual int   DeleteRecords(PGLOBAL g, int irc);
-  virtual void  CloseTableFile(PGLOBAL g, bool abort);
-  virtual void  Rewind(void);
+  void  Reset(void) override;
+  int   GetFileLength(PGLOBAL g) override;
+  int   Cardinality(PGLOBAL g) override;
+  int   MaxBlkSize(PGLOBAL g, int s) override;
+  bool  AllocateBuffer(PGLOBAL g) override;
+  int   GetRowID(void) override;
+  bool  RecordPos(PGLOBAL g) override;
+  bool  SetPos(PGLOBAL g, int recpos) override;
+  int   SkipRecord(PGLOBAL g, bool header) override;
+  bool  OpenTableFile(PGLOBAL g) override;
+  int   ReadBuffer(PGLOBAL g) override;
+  int   WriteBuffer(PGLOBAL g) override;
+  int   DeleteRecords(PGLOBAL g, int irc) override;
+  void  CloseTableFile(PGLOBAL g, bool abort) override;
+  void  Rewind(void) override;
 
  protected:
   virtual bool  OpenTempFile(PGLOBAL g);
   virtual bool  MoveIntermediateLines(PGLOBAL g, bool *b);
   virtual int   RenameTempFile(PGLOBAL g);
-  virtual int   InitDelete(PGLOBAL g, int fpos, int spos);
+  int   InitDelete(PGLOBAL g, int fpos, int spos) override;
 
   // Members
   FILE   *Stream;             // Points to Dos file structure
@@ -183,25 +183,25 @@ class DllExport BLKFAM : public DOSFAM {
   BLKFAM(PBLKFAM txfp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_BLK;}
-  virtual int   GetPos(void);
-  virtual int   GetNextPos(void);
-  virtual PTXF  Duplicate(PGLOBAL g)
+  AMT   GetAmType(void) override {return TYPE_AM_BLK;}
+  int   GetPos(void) override;
+  int   GetNextPos(void) override;
+  PTXF  Duplicate(PGLOBAL g) override
                   {return (PTXF)new(g) BLKFAM(this);}
 
   // Methods
-  virtual void  Reset(void);
-  virtual int   Cardinality(PGLOBAL g);
-  virtual int   MaxBlkSize(PGLOBAL g, int s);
-  virtual bool  AllocateBuffer(PGLOBAL g);
-  virtual int   GetRowID(void);
-  virtual bool  RecordPos(PGLOBAL g);
-  virtual bool  SetPos(PGLOBAL g, int recpos);
-  virtual int   SkipRecord(PGLOBAL g, bool header);
-  virtual int   ReadBuffer(PGLOBAL g);
-  virtual int   WriteBuffer(PGLOBAL g);
-  virtual void  CloseTableFile(PGLOBAL g, bool abort);
-  virtual void  Rewind(void);
+  void  Reset(void) override;
+  int   Cardinality(PGLOBAL g) override;
+  int   MaxBlkSize(PGLOBAL g, int s) override;
+  bool  AllocateBuffer(PGLOBAL g) override;
+  int   GetRowID(void) override;
+  bool  RecordPos(PGLOBAL g) override;
+  bool  SetPos(PGLOBAL g, int recpos) override;
+  int   SkipRecord(PGLOBAL g, bool header) override;
+  int   ReadBuffer(PGLOBAL g) override;
+  int   WriteBuffer(PGLOBAL g) override;
+  void  CloseTableFile(PGLOBAL g, bool abort) override;
+  void  Rewind(void) override;
 
  protected:
   // Members
@@ -222,24 +222,24 @@ public:
 	BINFAM(PBINFAM txfp) : DOSFAM(txfp) {Recsize = txfp->Recsize;}
 
 	// Implementation
-	virtual AMT   GetAmType(void) {return TYPE_AM_BIN;}
+	AMT   GetAmType(void) override {return TYPE_AM_BIN;}
 //virtual int   GetPos(void);
 //virtual int   GetNextPos(void);
-	virtual PTXF  Duplicate(PGLOBAL g) { return (PTXF)new(g) BINFAM(this); }
+	PTXF  Duplicate(PGLOBAL g) override { return (PTXF)new(g) BINFAM(this); }
 
 	// Methods
 //virtual void  Reset(void) {TXTFAM::Reset();}
 //virtual int   GetFileLength(PGLOBAL g);
 //virtual int   Cardinality(PGLOBAL g);
-	virtual int   MaxBlkSize(PGLOBAL g, int s) {return s;}
-	virtual bool  AllocateBuffer(PGLOBAL g);
+	int   MaxBlkSize(PGLOBAL g, int s) override {return s;}
+	bool  AllocateBuffer(PGLOBAL g) override;
 //virtual int   GetRowID(void);
 //virtual bool  RecordPos(PGLOBAL g);
 //virtual bool  SetPos(PGLOBAL g, int recpos);
-	virtual int   SkipRecord(PGLOBAL g, bool header) {return RC_OK;}
+	int   SkipRecord(PGLOBAL g, bool header) override {return RC_OK;}
 //virtual bool  OpenTableFile(PGLOBAL g);
-	virtual int   ReadBuffer(PGLOBAL g);
-	virtual int   WriteBuffer(PGLOBAL g);
+	int   ReadBuffer(PGLOBAL g) override;
+	int   WriteBuffer(PGLOBAL g) override;
 //virtual int   DeleteRecords(PGLOBAL g, int irc);
 //virtual void  CloseTableFile(PGLOBAL g, bool abort);
 //virtual void  Rewind(void);

--- a/storage/connect/filamvct.h
+++ b/storage/connect/filamvct.h
@@ -34,27 +34,27 @@ class DllExport VCTFAM : public FIXFAM {
   VCTFAM(PVCTFAM txfp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_VCT;}
-  virtual PTXF Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_VCT;}
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) VCTFAM(this);}
-  virtual int  GetFileLength(PGLOBAL g);
+  int  GetFileLength(PGLOBAL g) override;
 
   // Methods
-  virtual void Reset(void);
-  virtual int  MaxBlkSize(PGLOBAL g, int s);
-  virtual bool AllocateBuffer(PGLOBAL g);
+  void Reset(void) override;
+  int  MaxBlkSize(PGLOBAL g, int s) override;
+  bool AllocateBuffer(PGLOBAL g) override;
   virtual bool InitInsert(PGLOBAL g);
-  virtual void ResetBuffer(PGLOBAL g) {}
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  GetRowID(void);
+  void ResetBuffer(PGLOBAL g) override {}
+  int  Cardinality(PGLOBAL g) override;
+  int  GetRowID(void) override;
 
   // Database routines
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
-  virtual void Rewind(void);
+  bool OpenTableFile(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
+  void Rewind(void) override;
 
   // Specific functions
   virtual bool ReadBlock(PGLOBAL g, PVCTCOL colp);
@@ -62,9 +62,9 @@ class DllExport VCTFAM : public FIXFAM {
 
  protected:
   virtual bool MakeEmptyFile(PGLOBAL g, PCSZ fn);
-  virtual bool OpenTempFile(PGLOBAL g);
+  bool OpenTempFile(PGLOBAL g) override;
   virtual bool MoveLines(PGLOBAL g) {return false;}
-  virtual bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL);
+  bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL) override;
   virtual bool CleanUnusedSpace(PGLOBAL g);
   virtual int  GetBlockInfo(PGLOBAL g);
   virtual bool SetBlockInfo(PGLOBAL g);
@@ -98,25 +98,25 @@ class DllExport VCMFAM : public VCTFAM {
   VCMFAM(PVCMFAM txfp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_VMP;}
-  virtual PTXF Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_VMP;}
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) VCMFAM(this);}
 
   // Methods
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual bool InitInsert(PGLOBAL g);
+  bool AllocateBuffer(PGLOBAL g) override;
+  bool InitInsert(PGLOBAL g) override;
 
   // Database routines
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
+  bool OpenTableFile(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
 
  protected:
   // Specific functions
-  virtual bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL);
-  virtual bool ReadBlock(PGLOBAL g, PVCTCOL colp);
-  virtual bool WriteBlock(PGLOBAL g, PVCTCOL colp);
+  bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL) override;
+  bool ReadBlock(PGLOBAL g, PVCTCOL colp) override;
+  bool WriteBlock(PGLOBAL g, PVCTCOL colp) override;
 
   // Members
   char*   Memory;               // Pointer on file mapping view.
@@ -137,29 +137,29 @@ class DllExport VECFAM : public VCTFAM {
   VECFAM(PVECFAM txfp);
 
   // Implementation
-  virtual PTXF Duplicate(PGLOBAL g)
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) VECFAM(this);}
 
   // Methods
-  virtual bool AllocateBuffer(PGLOBAL g);
-  virtual bool InitInsert(PGLOBAL g);
-  virtual void ResetBuffer(PGLOBAL g);
+  bool AllocateBuffer(PGLOBAL g) override;
+  bool InitInsert(PGLOBAL g) override;
+  void ResetBuffer(PGLOBAL g) override;
 
   // Database routines
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
+  bool OpenTableFile(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
 
   // Specific functions
-  virtual bool ReadBlock(PGLOBAL g, PVCTCOL colp);
-  virtual bool WriteBlock(PGLOBAL g, PVCTCOL colp);
+  bool ReadBlock(PGLOBAL g, PVCTCOL colp) override;
+  bool WriteBlock(PGLOBAL g, PVCTCOL colp) override;
 
  protected:
-  virtual bool OpenTempFile(PGLOBAL g);
-  virtual bool MoveLines(PGLOBAL g);
-  virtual bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL);
-  virtual int  RenameTempFile(PGLOBAL g);
+  bool OpenTempFile(PGLOBAL g) override;
+  bool MoveLines(PGLOBAL g) override;
+  bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL) override;
+  int  RenameTempFile(PGLOBAL g) override;
           bool OpenColumnFile(PGLOBAL g, PCSZ opmode, int i);
 
   // Members
@@ -184,16 +184,16 @@ class DllExport VMPFAM : public VCMFAM {
   VMPFAM(PVMPFAM txfp);
 
   // Implementation
-  virtual PTXF Duplicate(PGLOBAL g)
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) VMPFAM(this);}
 
   // Methods
-  virtual bool AllocateBuffer(PGLOBAL g);
+  bool AllocateBuffer(PGLOBAL g) override;
 
   // Database routines
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
+  bool OpenTableFile(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
 
  protected:
           bool MapColumnFile(PGLOBAL g, MODE mode, int i);
@@ -214,33 +214,33 @@ class BGVFAM : public VCTFAM {
   BGVFAM(PBGVFAM txfp);
 
   // Implementation
-  virtual PTXF Duplicate(PGLOBAL g)
+  PTXF Duplicate(PGLOBAL g) override
                 {return (PTXF)new(g) BGVFAM(this);}
 
   // Methods
-  virtual bool AllocateBuffer(PGLOBAL g);
+  bool AllocateBuffer(PGLOBAL g) override;
 
   // Database routines
-  virtual bool OpenTableFile(PGLOBAL g);
-  virtual int  WriteBuffer(PGLOBAL g);
-  virtual int  DeleteRecords(PGLOBAL g, int irc);
-  virtual void CloseTableFile(PGLOBAL g, bool abort);
-  virtual void Rewind(void);
+  bool OpenTableFile(PGLOBAL g) override;
+  int  WriteBuffer(PGLOBAL g) override;
+  int  DeleteRecords(PGLOBAL g, int irc) override;
+  void CloseTableFile(PGLOBAL g, bool abort) override;
+  void Rewind(void) override;
 
   // Specific functions
-  virtual bool ReadBlock(PGLOBAL g, PVCTCOL colp);
-  virtual bool WriteBlock(PGLOBAL g, PVCTCOL colp);
+  bool ReadBlock(PGLOBAL g, PVCTCOL colp) override;
+  bool WriteBlock(PGLOBAL g, PVCTCOL colp) override;
 
  protected:
           bool BigSeek(PGLOBAL g, HANDLE h, BIGINT pos, bool b = false);
           bool BigRead(PGLOBAL g, HANDLE h, void *inbuf, int req);
           bool BigWrite(PGLOBAL g, HANDLE h, void *inbuf, int req);
-  virtual bool MakeEmptyFile(PGLOBAL g, PCSZ fn);
-  virtual bool OpenTempFile(PGLOBAL g);
-  virtual bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL);
-  virtual bool CleanUnusedSpace(PGLOBAL g);
-  virtual bool SetBlockInfo(PGLOBAL g);
-  virtual int  GetBlockInfo(PGLOBAL g);
+  bool MakeEmptyFile(PGLOBAL g, PCSZ fn) override;
+  bool OpenTempFile(PGLOBAL g) override;
+  bool MoveIntermediateLines(PGLOBAL g, bool *b = NULL) override;
+  bool CleanUnusedSpace(PGLOBAL g) override;
+  bool SetBlockInfo(PGLOBAL g) override;
+  int  GetBlockInfo(PGLOBAL g) override;
 
   // Members
   HANDLE  Hfile;                // Handle to big file

--- a/storage/connect/filamzip.h
+++ b/storage/connect/filamzip.h
@@ -97,16 +97,16 @@ class DllExport UNZFAM : public MAPFAM {
 	UNZFAM(PUNZFAM txfp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) {return TYPE_AM_ZIP;}
-	virtual PTXF Duplicate(PGLOBAL g) {return (PTXF) new(g) UNZFAM(this);}
+	AMT  GetAmType(void) override {return TYPE_AM_ZIP;}
+	PTXF Duplicate(PGLOBAL g) override {return (PTXF) new(g) UNZFAM(this);}
 
 	// Methods
-	virtual int  Cardinality(PGLOBAL g);
-	virtual int  GetFileLength(PGLOBAL g);
+	int  Cardinality(PGLOBAL g) override;
+	int  GetFileLength(PGLOBAL g) override;
 	//virtual int  MaxBlkSize(PGLOBAL g, int s) {return s;}
-	virtual bool OpenTableFile(PGLOBAL g);
-	virtual bool DeferReading(void) { return false; }
-	virtual int  GetNext(PGLOBAL g);
+	bool OpenTableFile(PGLOBAL g) override;
+	bool DeferReading(void) override { return false; }
+	int  GetNext(PGLOBAL g) override;
 	//virtual int  ReadBuffer(PGLOBAL g);
 	//virtual int  WriteBuffer(PGLOBAL g);
 	//virtual int  DeleteRecords(PGLOBAL g, int irc);
@@ -129,14 +129,14 @@ class DllExport UZXFAM : public MPXFAM {
 	UZXFAM(PUZXFAM txfp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) { return TYPE_AM_ZIP; }
-	virtual PTXF Duplicate(PGLOBAL g) { return (PTXF) new(g)UZXFAM(this); }
+	AMT  GetAmType(void) override { return TYPE_AM_ZIP; }
+	PTXF Duplicate(PGLOBAL g) override { return (PTXF) new(g)UZXFAM(this); }
 
 	// Methods
-	virtual int  GetFileLength(PGLOBAL g);
-	virtual int  Cardinality(PGLOBAL g);
-	virtual bool OpenTableFile(PGLOBAL g);
-	virtual int  GetNext(PGLOBAL g);
+	int  GetFileLength(PGLOBAL g) override;
+	int  Cardinality(PGLOBAL g) override;
+	bool OpenTableFile(PGLOBAL g) override;
+	int  GetNext(PGLOBAL g) override;
 	//virtual int  ReadBuffer(PGLOBAL g);
 
  protected:
@@ -156,14 +156,14 @@ public:
 	UZDFAM(PUZDFAM txfp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) { return TYPE_AM_ZIP; }
-	virtual PTXF Duplicate(PGLOBAL g) { return (PTXF) new(g)UZDFAM(this); }
+	AMT  GetAmType(void) override { return TYPE_AM_ZIP; }
+	PTXF Duplicate(PGLOBAL g) override { return (PTXF) new(g)UZDFAM(this); }
 
 	// Methods
-	virtual int  GetFileLength(PGLOBAL g);
-	virtual int  Cardinality(PGLOBAL g);
-	virtual bool OpenTableFile(PGLOBAL g);
-	virtual int  GetNext(PGLOBAL g);
+	int  GetFileLength(PGLOBAL g) override;
+	int  Cardinality(PGLOBAL g) override;
+	bool OpenTableFile(PGLOBAL g) override;
+	int  GetNext(PGLOBAL g) override;
 	//virtual int  ReadBuffer(PGLOBAL g);
 
 protected:
@@ -184,17 +184,17 @@ class DllExport ZIPFAM : public DOSFAM {
 	ZIPFAM(PDOSDEF tdp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) {return TYPE_AM_ZIP;}
+	AMT  GetAmType(void) override {return TYPE_AM_ZIP;}
 
 	// Methods
-	virtual int  Cardinality(PGLOBAL g) {return 0;}
-	virtual int  GetFileLength(PGLOBAL g) {return g ? 0 : 1;}
+	int  Cardinality(PGLOBAL g) override {return 0;}
+	int  GetFileLength(PGLOBAL g) override {return g ? 0 : 1;}
 	//virtual int  MaxBlkSize(PGLOBAL g, int s) {return s;}
-	virtual bool OpenTableFile(PGLOBAL g);
-	virtual int  ReadBuffer(PGLOBAL g);
-	virtual int  WriteBuffer(PGLOBAL g);
+	bool OpenTableFile(PGLOBAL g) override;
+	int  ReadBuffer(PGLOBAL g) override;
+	int  WriteBuffer(PGLOBAL g) override;
 	//virtual int  DeleteRecords(PGLOBAL g, int irc);
-	virtual void CloseTableFile(PGLOBAL g, bool abort);
+	void CloseTableFile(PGLOBAL g, bool abort) override;
 
  protected:
 	// Members
@@ -213,14 +213,14 @@ class DllExport ZPXFAM : public FIXFAM {
 	ZPXFAM(PDOSDEF tdp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) {return TYPE_AM_ZIP;}
+	AMT  GetAmType(void) override {return TYPE_AM_ZIP;}
 
 	// Methods
-	virtual int  Cardinality(PGLOBAL g) {return 0;}
-	virtual int  GetFileLength(PGLOBAL g) {return g ? 0 : 1;}
-	virtual bool OpenTableFile(PGLOBAL g);
-	virtual int  WriteBuffer(PGLOBAL g);
-	virtual void CloseTableFile(PGLOBAL g, bool abort);
+	int  Cardinality(PGLOBAL g) override {return 0;}
+	int  GetFileLength(PGLOBAL g) override {return g ? 0 : 1;}
+	bool OpenTableFile(PGLOBAL g) override;
+	int  WriteBuffer(PGLOBAL g) override;
+	void CloseTableFile(PGLOBAL g, bool abort) override;
 
  protected:
 	// Members

--- a/storage/connect/filter.h
+++ b/storage/connect/filter.h
@@ -34,11 +34,11 @@ class DllExport FILTER : public XOBJECT { /* Filter description block  */
   FILTER(PFIL fil1);
 
   // Implementation
-  virtual int    GetType(void) {return TYPE_FILTER;}
-  virtual int    GetResultType(void) {return TYPE_INT;}
-  virtual int    GetLength(void) {return 1;}
-  virtual int    GetLengthEx(void) {assert(FALSE); return 0;}
-  virtual int    GetScale() {return 0;};
+  int    GetType(void) override {return TYPE_FILTER;}
+  int    GetResultType(void) override {return TYPE_INT;}
+  int    GetLength(void) override {return 1;}
+  int    GetLengthEx(void) override {assert(FALSE); return 0;}
+  int    GetScale() override {return 0;};
           PFIL   GetNext(void) {return Next;}
           OPVAL  GetOpc(void) {return Opc;}
           int    GetOpm(void) {return Opm;}
@@ -50,19 +50,19 @@ class DllExport FILTER : public XOBJECT { /* Filter description block  */
           void   SetNext(PFIL filp) {Next = filp;}
 
   // Methods
-  virtual void   Reset(void);
-  virtual bool   Compare(PXOB) {return FALSE;}          // Not used yet
-  virtual bool   Init(PGLOBAL);
-  virtual bool   Eval(PGLOBAL);
-  virtual bool   SetFormat(PGLOBAL, FORMAT&) {return TRUE;}      // NUY
+  void   Reset(void) override;
+  bool   Compare(PXOB) override {return FALSE;}          // Not used yet
+  bool   Init(PGLOBAL) override;
+  bool   Eval(PGLOBAL) override;
+  bool   SetFormat(PGLOBAL, FORMAT&) override {return TRUE;}      // NUY
 //virtual int    CheckColumn(PGLOBAL g, PSQL sqlp, PXOB &xp, int &ag);
 //virtual int    RefNum(PSQL);
 //virtual PXOB   SetSelect(PGLOBAL, PSQL, bool) {return NULL;}   // NUY
 //virtual PXOB   CheckSubQuery(PGLOBAL, PSQL);
 //virtual bool   CheckLocal(PTDB);
 //virtual int    CheckSpcCol(PTDB tdbp, int n);
-	virtual void   Printf(PGLOBAL g, FILE *f, uint n);
-  virtual void   Prints(PGLOBAL g, char *ps, uint z);
+	void   Printf(PGLOBAL g, FILE *f, uint n) override;
+  void   Prints(PGLOBAL g, char *ps, uint z) override;
 //        PFIL   Linearize(bool nosep);
 //        PFIL   Link(PGLOBAL g, PFIL fil2);
 //        PFIL   RemoveLastSep(void);
@@ -102,7 +102,7 @@ class DllExport FILTER : public XOBJECT { /* Filter description block  */
 class FILTERX : public FILTER {
  public:
   // Methods
-  virtual bool Eval(PGLOBAL) = 0; // just to prevent direct FILTERX use
+  bool Eval(PGLOBAL) override = 0; // just to prevent direct FILTERX use
 
   // Fake operator new used to change a filter into a derived filter
   void * operator new(size_t, PFIL filp) {return filp;}
@@ -123,7 +123,7 @@ class FILTERCMP : public FILTERX {
   FILTERCMP(PGLOBAL g);
 
   // Methods
-  virtual bool Eval(PGLOBAL);
+  bool Eval(PGLOBAL) override;
   }; // end of class FILTEREQ
 
 /***********************************************************************/
@@ -132,7 +132,7 @@ class FILTERCMP : public FILTERX {
 class FILTERAND : public FILTERX {
  public:
   // Methods
-  virtual bool Eval(PGLOBAL);
+  bool Eval(PGLOBAL) override;
   }; // end of class FILTERAND
 
 /***********************************************************************/
@@ -141,7 +141,7 @@ class FILTERAND : public FILTERX {
 class FILTEROR : public FILTERX {
  public:
   // Methods
-  virtual bool Eval(PGLOBAL);
+  bool Eval(PGLOBAL) override;
   }; // end of class FILTEROR
 
 /***********************************************************************/
@@ -150,7 +150,7 @@ class FILTEROR : public FILTERX {
 class FILTERNOT : public FILTERX {
  public:
   // Methods
-  virtual bool Eval(PGLOBAL);
+  bool Eval(PGLOBAL) override;
   }; // end of class FILTERNOT
 
 /***********************************************************************/
@@ -159,7 +159,7 @@ class FILTERNOT : public FILTERX {
 class FILTERIN : public FILTERX {
  public:
   // Methods
-  virtual bool Eval(PGLOBAL);
+  bool Eval(PGLOBAL) override;
   }; // end of class FILTERIN
 
 /***********************************************************************/
@@ -171,8 +171,8 @@ class FILTERTRUE : public FILTERX {
   FILTERTRUE(PVAL valp) {Value = valp; Value->SetValue_bool(TRUE);}
 
   // Methods
-  virtual void Reset(void);
-  virtual bool Eval(PGLOBAL);
+  void Reset(void) override;
+  bool Eval(PGLOBAL) override;
   }; // end of class FILTERTRUE
 
 #endif // __FILTER__

--- a/storage/connect/ha_connect.h
+++ b/storage/connect/ha_connect.h
@@ -230,7 +230,7 @@ public:
     The name of the index type that will be used for display.
     Don't implement this method unless you really have indexes.
    */
-  const char *index_type(uint inx);
+  const char *index_type(uint inx) override;
 
   /** @brief
     The file extensions.
@@ -241,15 +241,15 @@ public:
     Check if a storage engine supports a particular alter table in-place
     @note Called without holding thr_lock.c lock.
  */
- virtual enum_alter_inplace_result
+ enum_alter_inplace_result
  check_if_supported_inplace_alter(TABLE *altered_table,
-                                  Alter_inplace_info *ha_alter_info);
+                                  Alter_inplace_info *ha_alter_info) override;
 
   /** @brief
     This is a list of flags that indicate what functionality the storage engine
     implements. The current table flags are documented in handler.h
   */
-  ulonglong table_flags() const;
+  ulonglong table_flags() const override;
 
   /** @brief
     This is a bitmap of flags that indicates how the storage engine
@@ -261,7 +261,7 @@ public:
     If all_parts is set, MySQL wants to know the flags for the combined
     index, up to and including 'part'.
   */
-  ulong index_flags(uint inx, uint part, bool all_parts) const;
+  ulong index_flags(uint inx, uint part, bool all_parts) const override;
 
   /** @brief
     unireg.cc will call max_supported_record_length(), max_supported_keys(),
@@ -270,7 +270,7 @@ public:
     send. Return *real* limits of your storage engine here; MySQL will do
     min(your_limits, MySQL_limits) automatically.
    */
-  uint max_supported_record_length() const { return HA_MAX_REC_LENGTH; }
+  uint max_supported_record_length() const override { return HA_MAX_REC_LENGTH; }
 
   /** @brief
     unireg.cc will call this to make sure that the storage engine can handle
@@ -281,7 +281,7 @@ public:
     There is no need to implement ..._key_... methods if your engine doesn't
     support indexes.
    */
-  uint max_supported_keys()          const { return 10; }
+  uint max_supported_keys() const override { return 10; }
 
   /** @brief
     unireg.cc will call this to make sure that the storage engine can handle
@@ -292,7 +292,7 @@ public:
     There is no need to implement ..._key_... methods if your engine doesn't
     support indexes.
    */
-  uint max_supported_key_parts()     const { return 10; }
+  uint max_supported_key_parts() const override { return 10; }
 
   /** @brief
     unireg.cc will call this to make sure that the storage engine can handle
@@ -303,17 +303,17 @@ public:
     There is no need to implement ..._key_... methods if your engine doesn't
     support indexes.
    */
-  uint max_supported_key_length()    const { return 255; }
+  uint max_supported_key_length() const override { return 255; }
 
   /** @brief
     Called in test_quick_select to determine if indexes should be used.
   */
-  virtual double scan_time() { return (double) (stats.records+stats.deleted) / 20.0+10; }
+  double scan_time() override { return (double) (stats.records+stats.deleted) / 20.0+10; }
 
   /** @brief
     This method will never be called if you do not implement indexes.
   */
-  virtual double read_time(uint, uint, ha_rows rows)
+  double read_time(uint, uint, ha_rows rows) override
     { return (double) rows /  20.0+1; }
 
   /*
@@ -322,7 +322,7 @@ public:
     Most of these methods are not obligatory, skip them and
     MySQL will treat them as not implemented
   */
-  virtual bool get_error_message(int error, String *buf);
+  bool get_error_message(int error, String *buf) override;
 
  /**
    Push condition down to the table handler.
@@ -346,27 +346,27 @@ public:
    Calls to rnd_init/rnd_end, index_init/index_end etc do not affect the
    condition stack.
  */
-virtual const COND *cond_push(const COND *cond);
+const COND *cond_push(const COND *cond) override;
 PCFIL CheckCond(PGLOBAL g, PCFIL filp, const Item *cond);
 const char *GetValStr(OPVAL vop, bool neg);
 PFIL  CondFilter(PGLOBAL g, Item *cond);
 //PFIL  CheckFilter(PGLOBAL g);
 
 /** admin commands - called from mysql_admin_table */
-virtual int check(THD* thd, HA_CHECK_OPT* check_opt);
+int check(THD* thd, HA_CHECK_OPT* check_opt) override;
 
  /**
    Number of rows in table. It will only be called if
    (table_flags() & (HA_HAS_RECORDS | HA_STATS_RECORDS_IS_EXACT)) != 0
  */
- virtual ha_rows records();
+ ha_rows records() override;
 
  /**
    Type of table for caching query
    CONNECT should not use caching because its tables are external
    data prone to me modified out of MariaDB
  */
- virtual uint8 table_cache_type(void)
+ uint8 table_cache_type(void) override
  {
 #if defined(MEMORY_TRACE)
    // Temporary until bug MDEV-4771 is fixed
@@ -379,37 +379,37 @@ virtual int check(THD* thd, HA_CHECK_OPT* check_opt);
  /** @brief
     We implement this in ha_connect.cc; it's a required method.
   */
-  int open(const char *name, int mode, uint test_if_locked);    // required
+  int open(const char *name, int mode, uint test_if_locked) override;    // required
 
   /** @brief
     We implement this in ha_connect.cc; it's a required method.
   */
-  int close(void);                                              // required
+  int close(void) override;                                              // required
 
   /** @brief
     We implement this in ha_connect.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int write_row(const uchar *buf);
+  int write_row(const uchar *buf) override;
 
   /** @brief
     We implement this in ha_connect.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int update_row(const uchar *old_data, const uchar *new_data);
+  int update_row(const uchar *old_data, const uchar *new_data) override;
 
   /** @brief
     We implement this in ha_connect.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int delete_row(const uchar *buf);
+  int delete_row(const uchar *buf) override;
 
   // Added to the connect handler
-  int index_init(uint idx, bool sorted);
-  int index_end();
+  int index_init(uint idx, bool sorted) override;
+  int index_end() override;
   int index_read(uchar * buf, const uchar * key, uint key_len,
-                              enum ha_rkey_function find_flag);
-  int index_next_same(uchar *buf, const uchar *key, uint keylen);
+                              enum ha_rkey_function find_flag) override;
+  int index_next_same(uchar *buf, const uchar *key, uint keylen) override;
 
   /** @brief
     We implement this in ha_connect.cc. It's not an obligatory method;
@@ -422,25 +422,25 @@ virtual int check(THD* thd, HA_CHECK_OPT* check_opt);
     We implement this in ha_connect.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int index_next(uchar *buf);
+  int index_next(uchar *buf) override;
 
   /** @brief
     We implement this in ha_connect.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-int index_prev(uchar *buf);
+int index_prev(uchar *buf) override;
 
   /** @brief
     We implement this in ha_connect.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int index_first(uchar *buf);
+  int index_first(uchar *buf) override;
 
   /** @brief
     We implement this in ha_connect.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int index_last(uchar *buf);
+  int index_last(uchar *buf) override;
 
   /* Index condition pushdown implementation */
 //Item *idx_cond_push(uint keyno, Item* idx_cond);
@@ -453,57 +453,57 @@ int index_prev(uchar *buf);
     cursor to the start of the table; no need to deallocate and allocate
     it again. This is a required method.
   */
-  int rnd_init(bool scan);                                      //required
-  int rnd_end();
-  int rnd_next(uchar *buf);                                     ///< required
-  int rnd_pos(uchar *buf, uchar *pos);                          ///< required
-  void position(const uchar *record);                           ///< required
-  int info(uint);                                               ///< required
-  int extra(enum ha_extra_function operation);
-  int start_stmt(THD *thd, thr_lock_type lock_type);
-  int external_lock(THD *thd, int lock_type);                   ///< required
-  int delete_all_rows(void);
+  int rnd_init(bool scan) override;                                      //required
+  int rnd_end() override;
+  int rnd_next(uchar *buf) override;                                     ///< required
+  int rnd_pos(uchar *buf, uchar *pos) override;                          ///< required
+  void position(const uchar *record) override;                           ///< required
+  int info(uint) override;                                               ///< required
+  int extra(enum ha_extra_function operation) override;
+  int start_stmt(THD *thd, thr_lock_type lock_type) override;
+  int external_lock(THD *thd, int lock_type) override;                   ///< required
+  int delete_all_rows(void) override;
   ha_rows records_in_range(uint inx, const key_range *start_key,
-                           const key_range *end_key, page_range *pages);
+                           const key_range *end_key, page_range *pages) override;
   /**
     These methods can be overridden, but their default implementation
     provide useful functionality.
   */
-  int rename_table(const char *from, const char *to);
+  int rename_table(const char *from, const char *to) override;
   /**
     Delete a table in the engine. Called for base as well as temporary
     tables.
   */
-  int delete_table(const char *name);
+  int delete_table(const char *name) override;
   /**
     Called by delete_table and rename_table
   */
   int delete_or_rename_table(const char *from, const char *to);
   int create(const char *name, TABLE *form,
-             HA_CREATE_INFO *create_info);                      ///< required
+             HA_CREATE_INFO *create_info) override;                  ///< required
   bool check_if_incompatible_data(HA_CREATE_INFO *info,
-                                  uint table_changes);
+                                  uint table_changes) override;
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type);     ///< required
-  int optimize(THD* thd, HA_CHECK_OPT* check_opt);
+                             enum thr_lock_type lock_type) override; ///< required
+  int optimize(THD* thd, HA_CHECK_OPT* check_opt) override;
 
   /**
    * Multi Range Read interface
    */
   int multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
-                            uint n_ranges, uint mode, HANDLER_BUFFER *buf);
-  int multi_range_read_next(range_id_t *range_info);
+                            uint n_ranges, uint mode, HANDLER_BUFFER *buf) override;
+  int multi_range_read_next(range_id_t *range_info) override;
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param,
                                       uint n_ranges, uint *bufsz,
-                                      uint *flags, Cost_estimate *cost);
+                                      uint *flags, Cost_estimate *cost) override;
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
                                 uint key_parts, uint *bufsz,
-                                uint *flags, Cost_estimate *cost);
-  int multi_range_read_explain_info(uint mrr_mode, char *str, size_t size);
+                                uint *flags, Cost_estimate *cost) override;
+  int multi_range_read_explain_info(uint mrr_mode, char *str, size_t size) override;
 
-  int reset(void) {ds_mrr.dsmrr_close(); return 0;}
+  int reset(void) override {ds_mrr.dsmrr_close(); return 0;}
 
   /* Index condition pushdown implementation */
 //  Item *idx_cond_push(uint keyno, Item* idx_cond);

--- a/storage/connect/jdbconn.h
+++ b/storage/connect/jdbconn.h
@@ -23,7 +23,7 @@ public:
 	// Constructor
 	JDBConn(PGLOBAL g, PCSZ wrapper);
 
-	virtual void AddJars(PSTRG jpop, char sep);
+	void AddJars(PSTRG jpop, char sep) override;
 	PQRYRES AllocateResult(PGLOBAL g, PTDB tdbp);
 
 	// Attributes
@@ -34,9 +34,9 @@ public:
 
 public:
 	// Operations
-	virtual bool Connect(PJPARM sop);
-	virtual bool MakeCursor(PGLOBAL g, PTDB tdbp, PCSZ options,
-		PCSZ filter, bool pipe) {return true;}
+	bool Connect(PJPARM sop) override;
+	bool MakeCursor(PGLOBAL g, PTDB tdbp, PCSZ options,
+                        PCSZ filter, bool pipe) override {return true;}
 	virtual int  GetResultSize(PCSZ sql, PCOL colp);
 	virtual int  ExecuteCommand(PCSZ sql);
 	virtual int  ExecuteQuery(PCSZ sql);

--- a/storage/connect/jmgfam.h
+++ b/storage/connect/jmgfam.h
@@ -31,35 +31,35 @@ public:
 	JMGFAM(PJMGFAM txfp);
 
 	// Implementation
-	virtual AMT   GetAmType(void) { return TYPE_AM_MGO; }
-	virtual bool  GetUseTemp(void) { return false; }
-	virtual int   GetPos(void);
-	virtual int   GetNextPos(void);
-	virtual PTXF  Duplicate(PGLOBAL g) { return (PTXF)new(g) JMGFAM(this); }
+	AMT   GetAmType(void) override { return TYPE_AM_MGO; }
+	bool  GetUseTemp(void) override { return false; }
+	int   GetPos(void) override;
+	int   GetNextPos(void) override;
+	PTXF  Duplicate(PGLOBAL g) override { return (PTXF)new(g) JMGFAM(this); }
 	void  SetLrecl(int lrecl) { Lrecl = lrecl; }
 
 	// Methods
-	virtual void  Reset(void);
-	virtual int   GetFileLength(PGLOBAL g);
-	virtual int   Cardinality(PGLOBAL g);
-	virtual int   MaxBlkSize(PGLOBAL g, int s);
-	virtual bool  AllocateBuffer(PGLOBAL g) { return false; }
-	virtual int   GetRowID(void);
-	virtual bool  RecordPos(PGLOBAL g);
-	virtual bool  SetPos(PGLOBAL g, int recpos);
-	virtual int   SkipRecord(PGLOBAL g, bool header);
-	virtual bool  OpenTableFile(PGLOBAL g);
-	virtual int   ReadBuffer(PGLOBAL g);
-	virtual int   WriteBuffer(PGLOBAL g);
-	virtual int   DeleteRecords(PGLOBAL g, int irc);
-	virtual void  CloseTableFile(PGLOBAL g, bool abort);
-	virtual void  Rewind(void);
+	void  Reset(void) override;
+	int   GetFileLength(PGLOBAL g) override;
+	int   Cardinality(PGLOBAL g) override;
+	int   MaxBlkSize(PGLOBAL g, int s) override;
+	bool  AllocateBuffer(PGLOBAL g) override { return false; }
+	int   GetRowID(void) override;
+	bool  RecordPos(PGLOBAL g) override;
+	bool  SetPos(PGLOBAL g, int recpos) override;
+	int   SkipRecord(PGLOBAL g, bool header) override;
+	bool  OpenTableFile(PGLOBAL g) override;
+	int   ReadBuffer(PGLOBAL g) override;
+	int   WriteBuffer(PGLOBAL g) override;
+	int   DeleteRecords(PGLOBAL g, int irc) override;
+	void  CloseTableFile(PGLOBAL g, bool abort) override;
+	void  Rewind(void) override;
 
 protected:
-	virtual bool  OpenTempFile(PGLOBAL g) { return false; }
-	virtual bool  MoveIntermediateLines(PGLOBAL g, bool *b) { return false; }
-	virtual int   RenameTempFile(PGLOBAL g) { return RC_OK; }
-	virtual int   InitDelete(PGLOBAL g, int fpos, int spos);
+	bool  OpenTempFile(PGLOBAL g) override { return false; }
+	bool  MoveIntermediateLines(PGLOBAL g, bool *b) override { return false; }
+	int   RenameTempFile(PGLOBAL g) override { return RC_OK; }
+	int   InitDelete(PGLOBAL g, int fpos, int spos) override;
 	bool  Init(PGLOBAL g);
 //bool  MakeCursor(PGLOBAL g);
 

--- a/storage/connect/jmgoconn.h
+++ b/storage/connect/jmgoconn.h
@@ -61,9 +61,9 @@ public:
 
 	// Implementation
 public:
-	virtual void AddJars(PSTRG jpop, char sep);
-	virtual bool Connect(PJPARM sop);
-	virtual bool MakeCursor(PGLOBAL g, PTDB tdbp, PCSZ options, PCSZ filter, bool pipe);
+	void AddJars(PSTRG jpop, char sep) override;
+	bool Connect(PJPARM sop) override;
+	bool MakeCursor(PGLOBAL g, PTDB tdbp, PCSZ options, PCSZ filter, bool pipe) override;
 //	PQRYRES AllocateResult(PGLOBAL g, TDBEXT *tdbp, int n);
 
 	// Attributes

--- a/storage/connect/json.h
+++ b/storage/connect/json.h
@@ -142,14 +142,14 @@ public:
 	JOBJECT(int i) : JSON(i) {}
 
 	// Methods
-	virtual void  Clear(void) {First = Last = NULL;}
+	void  Clear(void) override {First = Last = NULL;}
 //virtual JTYP  GetValType(void) {return TYPE_JOB;}
-  virtual PJPR  GetFirst(void) {return First;}
-	virtual int   GetSize(bool b);
-  virtual PJOB  GetObject(void) {return this;}
-	virtual PSZ   GetText(PGLOBAL g, PSTRG text);
-	virtual bool  Merge(PGLOBAL g, PJSON jsp);
-	virtual bool  IsNull(void);
+  PJPR  GetFirst(void) override {return First;}
+	int   GetSize(bool b) override;
+  PJOB  GetObject(void) override {return this;}
+	PSZ   GetText(PGLOBAL g, PSTRG text) override;
+	bool  Merge(PGLOBAL g, PJSON jsp) override;
+	bool  IsNull(void) override;
 
 	// Specific
 	PJPR  AddPair(PGLOBAL g, PCSZ key);
@@ -174,15 +174,15 @@ class JARRAY : public JSON {
 	JARRAY(int i) : JSON(i) {}
 
 	// Methods
-  virtual void  Clear(void) {First = Last = NULL; Size = 0;}
-	virtual int   size(void) { return Size; }
-  virtual PJAR  GetArray(void) {return this;}
-	virtual int   GetSize(bool b);
-  virtual PJVAL GetArrayValue(int i);
-	virtual PSZ   GetText(PGLOBAL g, PSTRG text);
-	virtual bool  Merge(PGLOBAL g, PJSON jsp);
-  virtual bool  DeleteValue(int n);
-  virtual bool  IsNull(void);
+  void  Clear(void) override {First = Last = NULL; Size = 0;}
+	int   size(void) override { return Size; }
+  PJAR  GetArray(void) override {return this;}
+	int   GetSize(bool b) override;
+  PJVAL GetArrayValue(int i) override;
+	PSZ   GetText(PGLOBAL g, PSTRG text) override;
+	bool  Merge(PGLOBAL g, PJSON jsp) override;
+  bool  DeleteValue(int n) override;
+  bool  IsNull(void) override;
 
 	// Specific
 	PJVAL AddArrayValue(PGLOBAL g, PJVAL jvp = NULL, int* x = NULL);
@@ -221,14 +221,14 @@ public:
   //using JSON::SetVal;
 
 	// Methods
-	virtual void   Clear(void);
+	void   Clear(void) override;
 //virtual JTYP   GetType(void) {return TYPE_JVAL;}
   virtual JTYP   GetValType(void);
-  virtual PJOB   GetObject(void);
-  virtual PJAR   GetArray(void);
-  virtual PJSON  GetJsp(void) {return (DataType == TYPE_JSON ? Jsp : NULL);}
-  virtual PSZ    GetText(PGLOBAL g, PSTRG text);
-	virtual bool   IsNull(void);
+  PJOB   GetObject(void) override;
+  PJAR   GetArray(void) override;
+  PJSON  GetJsp(void) override {return (DataType == TYPE_JSON ? Jsp : NULL);}
+  PSZ    GetText(PGLOBAL g, PSTRG text) override;
+	bool   IsNull(void) override;
 
 	// Specific
 	//inline PVL  GetVal(void) { return Val; }
@@ -239,7 +239,7 @@ public:
 	long long GetBigint(void);
 	double GetFloat(void);
 	PVAL   GetValue(PGLOBAL g);
-	void   SetValue(PJSON jsp);
+	void   SetValue(PJSON jsp) override;
 	void   SetValue(PGLOBAL g, PVAL valp);
 	void   SetString(PGLOBAL g, PSZ s, int ci = 0);
 	void   SetInteger(PGLOBAL g, int n);
@@ -288,9 +288,9 @@ class JOUTSTR : public JOUT {
 public:
 	JOUTSTR(PGLOBAL g);
 
-	virtual bool WriteStr(const char* s);
-	virtual bool WriteChr(const char c);
-	virtual bool Escape(const char* s);
+	bool WriteStr(const char* s) override;
+	bool WriteChr(const char c) override;
+	bool Escape(const char* s) override;
 
 	// Member
 	char* Strp;                         // The serialized string
@@ -305,9 +305,9 @@ class JOUTFILE : public JOUT {
 public:
 	JOUTFILE(PGLOBAL g, FILE* str, int pty) : JOUT(g) { Stream = str; Pretty = pty; }
 
-	virtual bool WriteStr(const char* s);
-	virtual bool WriteChr(const char c);
-	virtual bool Escape(const char* s);
+	bool WriteStr(const char* s) override;
+	bool WriteChr(const char c) override;
+	bool Escape(const char* s) override;
 
 	// Member
 	FILE* Stream;
@@ -320,8 +320,8 @@ class JOUTPRT : public JOUTFILE {
 public:
 	JOUTPRT(PGLOBAL g, FILE* str) : JOUTFILE(g, str, 2) { M = 0; B = false; }
 
-	virtual bool WriteStr(const char* s);
-	virtual bool WriteChr(const char c);
+	bool WriteStr(const char* s) override;
+	bool WriteChr(const char c) override;
 
 	// Member
 	int  M;

--- a/storage/connect/libdoc.cpp
+++ b/storage/connect/libdoc.cpp
@@ -63,23 +63,23 @@ class LIBXMLDOC : public XMLDOCUMENT {
   LIBXMLDOC(char *nsl, char *nsdf, char *enc, PFBLOCK fp);
 
   // Properties
-  virtual short  GetDocType(void) {return TYPE_FB_XML2;}
-  virtual void  *GetDocPtr(void) {return Docp;}
-  virtual void   SetNofree(bool b) {Nofreelist = b;}
+  short  GetDocType(void) override {return TYPE_FB_XML2;}
+  void  *GetDocPtr(void) override {return Docp;}
+  void   SetNofree(bool b) override {Nofreelist = b;}
 
   // Methods
-	virtual bool    Initialize(PGLOBAL g, PCSZ entry, bool zipped);
-  virtual bool    ParseFile(PGLOBAL g, char *fn);
-  virtual bool    NewDoc(PGLOBAL g, PCSZ ver);
-  virtual void    AddComment(PGLOBAL g, char *com);
-  virtual PXNODE  GetRoot(PGLOBAL g);
-  virtual PXNODE  NewRoot(PGLOBAL g, char *name);
-  virtual PXNODE  NewPnode(PGLOBAL g, char *name);
-  virtual PXATTR  NewPattr(PGLOBAL g);
-  virtual PXLIST  NewPlist(PGLOBAL g);
-  virtual int     DumpDoc(PGLOBAL g, char *ofn);
-  virtual void    CloseDoc(PGLOBAL g, PFBLOCK xp);
-  virtual PFBLOCK LinkXblock(PGLOBAL g, MODE m, int rc, char *fn);
+	bool    Initialize(PGLOBAL g, PCSZ entry, bool zipped) override;
+  bool    ParseFile(PGLOBAL g, char *fn) override;
+  bool    NewDoc(PGLOBAL g, PCSZ ver) override;
+  void    AddComment(PGLOBAL g, char *com) override;
+  PXNODE  GetRoot(PGLOBAL g) override;
+  PXNODE  NewRoot(PGLOBAL g, char *name) override;
+  PXNODE  NewPnode(PGLOBAL g, char *name) override;
+  PXATTR  NewPattr(PGLOBAL g) override;
+  PXLIST  NewPlist(PGLOBAL g) override;
+  int     DumpDoc(PGLOBAL g, char *ofn) override;
+  void    CloseDoc(PGLOBAL g, PFBLOCK xp) override;
+  PFBLOCK LinkXblock(PGLOBAL g, MODE m, int rc, char *fn) override;
 
  protected:
 //        bool     CheckDocument(FILE *of, xmlNodePtr np);
@@ -105,23 +105,23 @@ class XML2NODE : public XMLNODE {
   friend class XML2NODELIST;
  public:
   // Properties
-  virtual char  *GetName(PGLOBAL g) {return (char*)Nodep->name;}
-  virtual int    GetType(void);
-  virtual PXNODE GetNext(PGLOBAL g);
-  virtual PXNODE GetChild(PGLOBAL g);
+  char  *GetName(PGLOBAL g) override {return (char*)Nodep->name;}
+  int    GetType(void) override;
+  PXNODE GetNext(PGLOBAL g) override;
+  PXNODE GetChild(PGLOBAL g) override;
 
   // Methods
-  virtual RCODE  GetContent(PGLOBAL g, char *buf, int len);
-  virtual bool   SetContent(PGLOBAL g, char *txtp, int len);
-  virtual PXNODE Clone(PGLOBAL g, PXNODE np);
-  virtual PXLIST GetChildElements(PGLOBAL g, char *xp, PXLIST lp);
-  virtual PXLIST SelectNodes(PGLOBAL g, char *xp, PXLIST lp);
-  virtual PXNODE SelectSingleNode(PGLOBAL g, char *xp, PXNODE np);
-  virtual PXATTR GetAttribute(PGLOBAL g, char *name, PXATTR ap);
-  virtual PXNODE AddChildNode(PGLOBAL g, PCSZ name, PXNODE np);
-  virtual PXATTR AddProperty(PGLOBAL g, char *name, PXATTR ap);
-  virtual void   AddText(PGLOBAL g, PCSZ txtp);
-  virtual void   DeleteChild(PGLOBAL g, PXNODE dnp);
+  RCODE  GetContent(PGLOBAL g, char *buf, int len) override;
+  bool   SetContent(PGLOBAL g, char *txtp, int len) override;
+  PXNODE Clone(PGLOBAL g, PXNODE np) override;
+  PXLIST GetChildElements(PGLOBAL g, char *xp, PXLIST lp) override;
+  PXLIST SelectNodes(PGLOBAL g, char *xp, PXLIST lp) override;
+  PXNODE SelectSingleNode(PGLOBAL g, char *xp, PXNODE np) override;
+  PXATTR GetAttribute(PGLOBAL g, char *name, PXATTR ap) override;
+  PXNODE AddChildNode(PGLOBAL g, PCSZ name, PXNODE np) override;
+  PXATTR AddProperty(PGLOBAL g, char *name, PXATTR ap) override;
+  void   AddText(PGLOBAL g, PCSZ txtp) override;
+  void   DeleteChild(PGLOBAL g, PXNODE dnp) override;
 
  protected:
   // Constructor
@@ -141,9 +141,9 @@ class XML2NODELIST : public XMLNODELIST {
   friend class XML2NODE;
  public:
   // Methods
-  virtual int    GetLength(void);
-  virtual PXNODE GetItem(PGLOBAL g, int n, PXNODE np);
-  virtual bool   DropItem(PGLOBAL g, int n);
+  int    GetLength(void) override;
+  PXNODE GetItem(PGLOBAL g, int n, PXNODE np) override;
+  bool   DropItem(PGLOBAL g, int n) override;
 
  protected:
   // Constructor
@@ -161,12 +161,12 @@ class XML2ATTR : public XMLATTRIBUTE {
   friend class XML2NODE;
  public:
   // Properties
-  virtual char  *GetName(PGLOBAL g) {return (char*)Atrp->name;}
-  virtual PXATTR GetNext(PGLOBAL g);
+  char  *GetName(PGLOBAL g) override {return (char*)Atrp->name;}
+  PXATTR GetNext(PGLOBAL g) override;
 
   // Methods
-  virtual RCODE  GetText(PGLOBAL g, char *bufp, int len);
-  virtual bool   SetText(PGLOBAL g, char *txtp, int len);
+  RCODE  GetText(PGLOBAL g, char *bufp, int len) override;
+  bool   SetText(PGLOBAL g, char *txtp, int len) override;
 
  protected:
   // Constructor

--- a/storage/connect/mongo.h
+++ b/storage/connect/mongo.h
@@ -69,11 +69,11 @@ public:
 	MGODEF(void);
 
 	// Implementation
-	virtual const char *GetType(void) { return "MONGO"; }
+	const char *GetType(void) override { return "MONGO"; }
 
 	// Methods
-	virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-	virtual PTDB GetTable(PGLOBAL g, MODE m);
+	bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+	PTDB GetTable(PGLOBAL g, MODE m) override;
 
 protected:
 	// Members

--- a/storage/connect/mycat.h
+++ b/storage/connect/mycat.h
@@ -101,13 +101,13 @@ class MYCAT : public CATALOG {
   void    SetHandler(PHC hc) {Hc= hc;}
 
   // Methods
-  void    Reset(void);
+  void    Reset(void) override;
   bool    StoreIndex(PGLOBAL, PTABDEF) {return false;}  // Temporary
 	PTABDEF GetTableDesc(PGLOBAL g, PTABLE tablep,
 		                   LPCSTR type, PRELDEF *prp = NULL);
   PTDB    GetTable(PGLOBAL g, PTABLE tablep, 
-                              MODE mode = MODE_READ, LPCSTR type = NULL);
-  void    ClearDB(PGLOBAL g);
+                   MODE mode = MODE_READ, LPCSTR type = NULL) override;
+  void    ClearDB(PGLOBAL g) override;
 
  protected:
 	PTABDEF MakeTableDesc(PGLOBAL g, PTABLE tablep, LPCSTR am);

--- a/storage/connect/reldef.h
+++ b/storage/connect/reldef.h
@@ -91,20 +91,20 @@ public:
 	RECFM   GetTableFormat(const char* type);
 	bool    SepIndex(void) {return GetBoolCatInfo("SepIndex", false);}
   bool    IsReadOnly(void) {return Read_Only;}
-  virtual AMT    GetDefType(void) {return TYPE_AM_TAB;}
+  AMT    GetDefType(void) override {return TYPE_AM_TAB;}
   virtual PIXDEF GetIndx(void) {return NULL;}
   virtual void   SetIndx(PIXDEF) {}
   virtual bool   IsHuge(void) {return false;}
   const CHARSET_INFO *data_charset() {return m_data_charset;}
-	const   char  *GetCsName(void) {return csname;}
+  const   char  *GetCsName(void) {return csname;}
 
   // Methods
-          int  GetColCatInfo(PGLOBAL g);
-          void SetIndexInfo(void);
-          bool DropTable(PGLOBAL g, PSZ name);
-	virtual bool Define(PGLOBAL g, PCATLG cat,
-						          LPCSTR name, LPCSTR schema, LPCSTR am);
-	virtual bool DefineAM(PGLOBAL, LPCSTR, int) = 0;
+  int  GetColCatInfo(PGLOBAL g);
+  void SetIndexInfo(void);
+  bool DropTable(PGLOBAL g, PSZ name);
+  bool Define(PGLOBAL g, PCATLG cat,
+              LPCSTR name, LPCSTR schema, LPCSTR am) override;
+  virtual bool DefineAM(PGLOBAL, LPCSTR, int) = 0;
 
  protected:
   // Members
@@ -135,12 +135,12 @@ class DllExport OEMDEF : public TABDEF {                  /* OEM table */
   OEMDEF(void) {Hdll = NULL; Pxdef = NULL; Module = Subtype = NULL;}
 
   // Implementation
-  virtual const char *GetType(void) {return "OEM";}
-  virtual AMT  GetDefType(void) {return TYPE_AM_OEM;}
+  const char *GetType(void) override {return "OEM";}
+  AMT  GetDefType(void) override {return TYPE_AM_OEM;}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE mode);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE mode) override;
 
  protected:
   PTABDEF GetXdef(PGLOBAL g);

--- a/storage/connect/tabbson.h
+++ b/storage/connect/tabbson.h
@@ -71,11 +71,11 @@ public:
   BSONDEF(void);
 
   // Implementation
-  virtual const char* GetType(void) { return "BSON"; }
+  const char* GetType(void) override { return "BSON"; }
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
 protected:
   // Members
@@ -170,30 +170,30 @@ public:
   TDBBSN(TDBBSN* tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) { return TYPE_AM_JSN; }
-  virtual bool SkipHeader(PGLOBAL g);
-  virtual PTDB Duplicate(PGLOBAL g) { return (PTDB)new(g) TDBBSN(this); }
+  AMT  GetAmType(void) override { return TYPE_AM_JSN; }
+  bool SkipHeader(PGLOBAL g) override;
+  PTDB Duplicate(PGLOBAL g) override { return (PTDB)new(g) TDBBSN(this); }
   PBVAL GetRow(void) { return Row; }
 
   // Methods
-  virtual PTDB Clone(PTABS t);
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual PCOL InsertSpecialColumn(PCOL colp);
-  virtual int  RowNumber(PGLOBAL g, bool b = FALSE) {return (b) ? M : N;}
-  virtual bool CanBeFiltered(void) 
+  PTDB Clone(PTABS t) override;
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  PCOL InsertSpecialColumn(PCOL colp) override;
+  int  RowNumber(PGLOBAL g, bool b = FALSE) override {return (b) ? M : N;}
+  bool CanBeFiltered(void) override 
                {return Txfp->GetAmType() == TYPE_AM_MGO || !Xcol;}
 
   // Database routines
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual bool PrepareWriting(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual void CloseDB(PGLOBAL g);
+  int  Cardinality(PGLOBAL g) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  bool PrepareWriting(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  void CloseDB(PGLOBAL g) override;
 
   // Specific routine
-  virtual int  EstimatedLength(void);
+  int  EstimatedLength(void) override;
 
 protected:
   PBVAL FindRow(PGLOBAL g);
@@ -242,15 +242,15 @@ public:
   BSONCOL(BSONCOL* colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int   GetAmType(void) { return Tbp->GetAmType(); }
-  virtual bool  Stringify(void) { return Sgfy; }
+  int   GetAmType(void) override { return Tbp->GetAmType(); }
+  bool  Stringify(void) override { return Sgfy; }
 
   // Methods
-  virtual bool  SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
+  bool  SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
           bool  ParseJpath(PGLOBAL g);
-  virtual PSZ   GetJpath(PGLOBAL g, bool proj);
-  virtual void  ReadColumn(PGLOBAL g);
-  virtual void  WriteColumn(PGLOBAL g);
+  PSZ   GetJpath(PGLOBAL g, bool proj) override;
+  void  ReadColumn(PGLOBAL g) override;
+  void  WriteColumn(PGLOBAL g) override;
 
 protected:
   bool  CheckExpand(PGLOBAL g, int i, PSZ nm, bool b);
@@ -288,30 +288,30 @@ public:
   TDBBSON(PBTDB tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) { return TYPE_AM_JSON; }
-  virtual PTDB Duplicate(PGLOBAL g) { return (PTDB)new(g) TDBBSON(this); }
+  AMT  GetAmType(void) override { return TYPE_AM_JSON; }
+  PTDB Duplicate(PGLOBAL g) override { return (PTDB)new(g) TDBBSON(this); }
   PBVAL GetDoc(void) { return Docp; }
 
   // Methods
-  virtual PTDB Clone(PTABS t);
+  PTDB Clone(PTABS t) override;
 
   // Database routines
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual void ResetSize(void);
-  virtual int  GetProgCur(void) { return N; }
-  virtual int  GetRecpos(void);
-  virtual bool SetRecpos(PGLOBAL g, int recpos);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual bool PrepareWriting(PGLOBAL g) { return false; }
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
+  int  Cardinality(PGLOBAL g) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  void ResetSize(void) override;
+  int  GetProgCur(void) override { return N; }
+  int  GetRecpos(void) override;
+  bool SetRecpos(PGLOBAL g, int recpos) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  bool PrepareWriting(PGLOBAL g) override { return false; }
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
   int  MakeDocument(PGLOBAL g);
 
   // Optimization routines
-  virtual int  MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add);
+  int  MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add) override;
 
 protected:
   int  MakeNewDoc(PGLOBAL g);
@@ -335,7 +335,7 @@ public:
 
 protected:
   // Specific routines
-  virtual PQRYRES GetResult(PGLOBAL g);
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   PTOS Topt;

--- a/storage/connect/tabcmg.h
+++ b/storage/connect/tabcmg.h
@@ -17,9 +17,9 @@ public:
 	CMGDISC(PGLOBAL g, int *lg) : MGODISC(g, lg) { drv = "C"; }
 
 	// Methods
-	virtual void GetDoc(void);
-//virtual bool Find(PGLOBAL g, int i, int k, bool b);
-	virtual bool Find(PGLOBAL g);
+	void GetDoc(void) override;
+//bool Find(PGLOBAL g, int i, int k, bool b) override;
+	bool Find(PGLOBAL g) override;
 
 	// BSON Function
 //bool FindInDoc(PGLOBAL g, bson_iter_t *iter, const bson_t *doc,
@@ -49,24 +49,24 @@ public:
 	TDBCMG(TDBCMG *tdbp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) {return TYPE_AM_MGO;}
-	virtual PTDB Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBCMG(this);}
+	AMT  GetAmType(void) override {return TYPE_AM_MGO;}
+	PTDB Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBCMG(this);}
 
 	// Methods
-	virtual PTDB Clone(PTABS t);
-	virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-	virtual PCOL InsertSpecialColumn(PCOL colp);
-	virtual int  RowNumber(PGLOBAL g, bool b = FALSE) {return N;}
+	PTDB Clone(PTABS t) override;
+	PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+	PCOL InsertSpecialColumn(PCOL colp) override;
+	int  RowNumber(PGLOBAL g, bool b = FALSE) override {return N;}
 
 	// Database routines
-	virtual int  Cardinality(PGLOBAL g);
-	virtual int  GetMaxSize(PGLOBAL g);
-	virtual bool OpenDB(PGLOBAL g);
-	virtual int  ReadDB(PGLOBAL g);
-	virtual int  WriteDB(PGLOBAL g);
-	virtual int  DeleteDB(PGLOBAL g, int irc);
-	virtual void CloseDB(PGLOBAL g);
-	virtual bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr);
+	int  Cardinality(PGLOBAL g) override;
+	int  GetMaxSize(PGLOBAL g) override;
+	bool OpenDB(PGLOBAL g) override;
+	int  ReadDB(PGLOBAL g) override;
+	int  WriteDB(PGLOBAL g) override;
+	int  DeleteDB(PGLOBAL g, int irc) override;
+	void CloseDB(PGLOBAL g) override;
+	bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr) override;
 
 protected:
 	bool Init(PGLOBAL g);
@@ -96,13 +96,13 @@ public:
 	MGOCOL(MGOCOL *colp, PTDB tdbp); // Constructor used in copy process
 
 	// Implementation
-	virtual int   GetAmType(void) { return Tmgp->GetAmType(); }
-	virtual bool  Stringify(void) { return Sgfy; }
+	int   GetAmType(void) override { return Tmgp->GetAmType(); }
+	bool  Stringify(void) override { return Sgfy; }
 
 	// Methods
-	virtual PSZ   GetJpath(PGLOBAL g, bool proj);
-	virtual void  ReadColumn(PGLOBAL g);
-	virtual void  WriteColumn(PGLOBAL g);
+	PSZ   GetJpath(PGLOBAL g, bool proj) override;
+	void  ReadColumn(PGLOBAL g) override;
+	void  WriteColumn(PGLOBAL g) override;
 
 protected:
 	// Default constructor not to be used
@@ -124,7 +124,7 @@ public:
 
 protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	virtual PQRYRES GetResult(PGLOBAL g) override;
 
 	// Members
 	PTOS Topt;

--- a/storage/connect/tabcol.h
+++ b/storage/connect/tabcol.h
@@ -38,8 +38,8 @@ class DllExport XTAB: public BLOCK {  // Table Name-Schema-Srcdef block.
 
   // Methods
   PTABLE Link(PTABLE);
-  void   Printf(PGLOBAL g, FILE *f, uint n);
-  void   Prints(PGLOBAL g, char *ps, uint z);
+  void   Printf(PGLOBAL g, FILE *f, uint n) override;
+  void   Prints(PGLOBAL g, char *ps, uint z) override;
 
  protected:
   // Members
@@ -64,11 +64,11 @@ class DllExport COLUMN: public XOBJECT {  // Column Name/Qualifier block.
   COLUMN(LPCSTR name);
 
   // Implementation
-  virtual int    GetType(void) {return TYPE_COLUMN;}
-  virtual int    GetResultType(void) {assert(false); return TYPE_VOID;}
-  virtual int    GetLength(void) {assert(false); return 0;}
-  virtual int    GetLengthEx(void) {assert(false); return 0;}
-  virtual int    GetScale() {assert(false); return 0;};
+  int    GetType(void) override {return TYPE_COLUMN;}
+  int    GetResultType(void) override {assert(false); return TYPE_VOID;}
+  int    GetLength(void) override {assert(false); return 0;}
+  int    GetLengthEx(void) override {assert(false); return 0;}
+  int    GetScale() override {assert(false); return 0;};
           LPCSTR GetName(void) {return Name;}
           LPCSTR GetQualifier(void) {return Qualifier;}
           PTABLE GetTo_Table(void) {return To_Table;}
@@ -78,13 +78,13 @@ class DllExport COLUMN: public XOBJECT {  // Column Name/Qualifier block.
           void   SetTo_Col(PCOL colp) {To_Col = colp;}
 
   // Methods
-  virtual void   Printf(PGLOBAL g, FILE *f, uint n);
-  virtual void   Prints(PGLOBAL g, char *ps, uint z);
+  void   Printf(PGLOBAL g, FILE *f, uint n) override;
+  void   Prints(PGLOBAL g, char *ps, uint z) override;
   // All methods below should never be used for COLUMN's
-  virtual void   Reset(void) {assert(false);}
-  virtual bool   Compare(PXOB) {assert(false); return false;}
-  virtual bool   SetFormat(PGLOBAL, FORMAT&);
-  virtual bool   Eval(PGLOBAL) {assert(false); return true;}
+  void   Reset(void) override {assert(false);}
+  bool   Compare(PXOB) override {assert(false); return false;}
+  bool   SetFormat(PGLOBAL, FORMAT&) override;
+  bool   Eval(PGLOBAL) override {assert(false); return true;}
 
  private:
   // Members

--- a/storage/connect/tabdos.h
+++ b/storage/connect/tabdos.h
@@ -36,11 +36,11 @@ class DllExport DOSDEF : public TABDEF {  /* Logical table description */
   DOSDEF(void);
 
   // Implementation
-  virtual AMT         GetDefType(void) {return TYPE_AM_DOS;}
-  virtual const char *GetType(void) {return "DOS";}
-  virtual PIXDEF      GetIndx(void) {return To_Indx;}
-  virtual void        SetIndx(PIXDEF xdp) {To_Indx = xdp;}
-  virtual bool        IsHuge(void) {return Huge;}
+  AMT         GetDefType(void) override {return TYPE_AM_DOS;}
+  const char *GetType(void) override {return "DOS";}
+  PIXDEF      GetIndx(void) override {return To_Indx;}
+  void        SetIndx(PIXDEF xdp) override {To_Indx = xdp;}
+  bool        IsHuge(void) override {return Huge;}
   PCSZ    GetFn(void) {return Fn;}
   PCSZ    GetOfn(void) {return Ofn;}
 	PCSZ    GetEntry(void) {return Entry;}
@@ -63,11 +63,11 @@ class DllExport DOSDEF : public TABDEF {  /* Logical table description */
   int    *GetTo_Pos(void) {return To_Pos;}
 
   // Methods
-	virtual int  Indexable(void)
+	int  Indexable(void) override
   	{return (!Multiple && !Mulentries && Compressed != 1) ? 1 : 0;}
 	virtual bool DeleteIndexFile(PGLOBAL g, PIXDEF pxdf);
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE mode);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE mode) override;
           bool InvalidateIndex(PGLOBAL g);
           bool GetOptFileName(PGLOBAL g, char *filename);
           void RemoveOptValues(PGLOBAL g);
@@ -133,62 +133,62 @@ class DllExport TDBDOS : public TDBASE {
   inline  PXOB *GetLink(void) {return To_Link;}
 
   // Implementation
-  virtual AMT   GetAmType(void) {return Txfp->GetAmType();}
-  virtual PCSZ  GetFile(PGLOBAL) {return Txfp->To_File;}
-  virtual void  SetFile(PGLOBAL, PCSZ fn) {Txfp->To_File = fn;}
-  virtual void  SetAbort(bool b) {Abort = b;}
-  virtual RECFM GetFtype(void) {return Ftype;}
+  AMT   GetAmType(void) override {return Txfp->GetAmType();}
+  PCSZ  GetFile(PGLOBAL) override {return Txfp->To_File;}
+  void  SetFile(PGLOBAL, PCSZ fn) override {Txfp->To_File = fn;}
+  void  SetAbort(bool b) override {Abort = b;}
+  RECFM GetFtype(void) override {return Ftype;}
   virtual bool  SkipHeader(PGLOBAL) {return false;}
-  virtual void  RestoreNrec(void) {Txfp->SetNrec(1);}
-  virtual PTDB  Duplicate(PGLOBAL g)
+  void  RestoreNrec(void) override {Txfp->SetNrec(1);}
+  PTDB  Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBDOS(g, this);}
 
   // Methods
-  virtual PTDB  Clone(PTABS t);
-  virtual void  ResetDB(void) {Txfp->Reset();}
-  virtual bool  IsUsingTemp(PGLOBAL g);
-  virtual bool  IsIndexed(void) {return Indxd;}
-  virtual void  ResetSize(void) {MaxSize = Cardinal = -1;}
-  virtual int   ResetTableOpt(PGLOBAL g, bool dop, bool dox);
+  PTDB  Clone(PTABS t) override;
+  void  ResetDB(void) override {Txfp->Reset();}
+  bool  IsUsingTemp(PGLOBAL g) override;
+  bool  IsIndexed(void) override {return Indxd;}
+  void  ResetSize(void) override {MaxSize = Cardinal = -1;}
+  int   ResetTableOpt(PGLOBAL g, bool dop, bool dox) override;
   virtual int   MakeBlockValues(PGLOBAL g);
   virtual bool  SaveBlockValues(PGLOBAL g);
-  virtual bool  GetBlockValues(PGLOBAL g);
+  bool  GetBlockValues(PGLOBAL g) override;
   virtual PBF   InitBlockFilter(PGLOBAL g, PFIL filp);
 //virtual PBX   InitBlockIndex(PGLOBAL g);
   virtual int   TestBlock(PGLOBAL g);
-  virtual void  PrintAM(FILE *f, char *m);
+  void  PrintAM(FILE *f, char *m) override;
 
   // Database routines
-  virtual PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
+  PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
   virtual char *GetOpenMode(PGLOBAL, char*) {return NULL;}
   virtual int   GetFileLength(PGLOBAL g) {return Txfp->GetFileLength(g);}
-  virtual int   GetProgMax(PGLOBAL g);
-  virtual int   GetProgCur(void);
+  int   GetProgMax(PGLOBAL g) override;
+  int   GetProgCur(void) override;
 //virtual int   GetAffectedRows(void) {return Txfp->GetDelRows();}
-  virtual int   GetRecpos(void) {return Txfp->GetPos();}
-  virtual bool  SetRecpos(PGLOBAL g, int recpos)
+  int   GetRecpos(void) override {return Txfp->GetPos();}
+  bool  SetRecpos(PGLOBAL g, int recpos) override
                 {return Txfp->SetPos(g, recpos);}
-  virtual int   RowNumber(PGLOBAL g, bool b = false);
-  virtual int   Cardinality(PGLOBAL g);
-  virtual int   GetMaxSize(PGLOBAL g);
-  virtual bool  OpenDB(PGLOBAL g);
-  virtual int   ReadDB(PGLOBAL g);
-  virtual int   WriteDB(PGLOBAL g);
-  virtual int   DeleteDB(PGLOBAL g, int irc);
-  virtual void  CloseDB(PGLOBAL g);
+  int   RowNumber(PGLOBAL g, bool b = false) override;
+  int   Cardinality(PGLOBAL g) override;
+  int   GetMaxSize(PGLOBAL g) override;
+  bool  OpenDB(PGLOBAL g) override;
+  int   ReadDB(PGLOBAL g) override;
+  int   WriteDB(PGLOBAL g) override;
+  int   DeleteDB(PGLOBAL g, int irc) override;
+  void  CloseDB(PGLOBAL g) override;
   virtual int   ReadBuffer(PGLOBAL g) {return Txfp->ReadBuffer(g);}
 
   // Specific routine
   virtual int   EstimatedLength(void);
 
   // Optimization routines
-  virtual int   MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add);
+  int   MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add) override;
           bool  InitialyzeIndex(PGLOBAL g, PIXDEF xdp, bool sorted);
           void  ResetBlockFilter(PGLOBAL g);
           bool  GetDistinctColumnValues(PGLOBAL g, int nrec);
 
  protected:
-  virtual bool  PrepareWriting(PGLOBAL g);
+  bool  PrepareWriting(PGLOBAL g) override;
           PBF   CheckBlockFilari(PGLOBAL g, PXOB *arg, int op, bool *cnv);
 
   // Members
@@ -219,10 +219,10 @@ class DllExport DOSCOL : public COLBLK {
   DOSCOL(DOSCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int    GetAmType(void) {return TYPE_AM_DOS;}
-  virtual void   SetTo_Val(PVAL valp) {To_Val = valp;}
-  virtual int    GetClustered(void) {return Clustered;}
-  virtual int    IsClustered(void) {return (Clustered &&
+  int    GetAmType(void) override {return TYPE_AM_DOS;}
+  void   SetTo_Val(PVAL valp) override {To_Val = valp;}
+  int    GetClustered(void) override {return Clustered;}
+  int    IsClustered(void) override {return (Clustered &&
                  ((PDOSDEF)(((PTDBDOS)To_Tdb)->To_Def))->IsOptimized());}
   virtual int    IsSorted(void) {return Sorted;}
   virtual PVBLK  GetMin(void) {return Min;}
@@ -233,10 +233,10 @@ class DllExport DOSCOL : public COLBLK {
   virtual PVBLK  GetDval(void) {return Dval;}
 
   // Methods
-  virtual bool   VarSize(void);
-  virtual bool   SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-  virtual void   ReadColumn(PGLOBAL g);
-  virtual void   WriteColumn(PGLOBAL g);
+  bool   VarSize(void) override;
+  bool   SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
+  void   ReadColumn(PGLOBAL g) override;
+  void   WriteColumn(PGLOBAL g) override;
 
  protected:
   virtual bool   SetMinMax(PGLOBAL g);

--- a/storage/connect/tabext.h
+++ b/storage/connect/tabext.h
@@ -59,7 +59,7 @@ public:
 	EXTDEF(void);                  // Constructor
 
 	// Implementation
-	virtual const char *GetType(void) { return "EXT"; }
+	const char *GetType(void) override { return "EXT"; }
 	inline PCSZ GetTabname(void) { return Tabname; }
 	inline PCSZ GetTabschema(void) { return Tabschema; }
 	inline PCSZ GetUsername(void) { return Username; };
@@ -72,8 +72,8 @@ public:
 	inline int  GetOptions(void) { return Options; }
 
 	// Methods
-	virtual int  Indexable(void) { return 2; }
-	virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
+	int  Indexable(void) override { return 2; }
+	bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
 
 protected:
 	// Members
@@ -115,15 +115,15 @@ public:
 	// Implementation
 
 	// Properties
-	virtual bool IsRemote(void) { return true; }
+	bool IsRemote(void) override { return true; }
 
 	// Methods
-	virtual PCSZ GetServer(void) { return "Remote"; }
-	virtual int  GetRecpos(void);
+	PCSZ GetServer(void) override { return "Remote"; }
+	int  GetRecpos(void) override;
 
 	// Database routines
-	virtual int  GetMaxSize(PGLOBAL g);
-	virtual int  GetProgMax(PGLOBAL g);
+	int  GetMaxSize(PGLOBAL g) override;
+	int  GetProgMax(PGLOBAL g) override;
 
 protected:
 	// Internal functions
@@ -185,9 +185,9 @@ public:
 	inline void  SetCrp(PCOLRES crp) { Crp = crp; }
 
 	// Methods
-	virtual bool   SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-	virtual void   ReadColumn(PGLOBAL) = 0;
-	virtual void   WriteColumn(PGLOBAL) = 0;
+	bool   SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
+	void   ReadColumn(PGLOBAL) override = 0;
+	void   WriteColumn(PGLOBAL) override = 0;
 
 protected:
 	// Constructor for count(*) column

--- a/storage/connect/tabfix.h
+++ b/storage/connect/tabfix.h
@@ -28,30 +28,30 @@ class DllExport TDBFIX : public TDBDOS {
   TDBFIX(PGLOBAL g, PTDBFIX tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_FIX;}
-  virtual void RestoreNrec(void);
-  virtual PTDB Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_FIX;}
+  void RestoreNrec(void) override;
+  PTDB Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBFIX(g, this);}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
-  virtual void ResetDB(void);
-  virtual bool IsUsingTemp(PGLOBAL g);
-  virtual int  RowNumber(PGLOBAL g, bool b = false);
-  virtual int  ResetTableOpt(PGLOBAL g, bool dop, bool dox);
-  virtual void ResetSize(void);
-  virtual int  GetBadLines(void) {return Txfp->GetNerr();}
+  PTDB Clone(PTABS t) override;
+  void ResetDB(void) override;
+  bool IsUsingTemp(PGLOBAL g) override;
+  int  RowNumber(PGLOBAL g, bool b = false) override;
+  int  ResetTableOpt(PGLOBAL g, bool dop, bool dox) override;
+  void ResetSize(void) override;
+  int  GetBadLines(void) override {return Txfp->GetNerr();}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  GetProgMax(PGLOBAL g);
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  GetProgMax(PGLOBAL g) override;
+  int  Cardinality(PGLOBAL g) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
 
  protected:
-  virtual bool PrepareWriting(PGLOBAL g) {return false;}
+  bool PrepareWriting(PGLOBAL g) override {return false;}
 
   // Members
   char Teds;                  /* Binary table default endian setting   */
@@ -69,14 +69,14 @@ class DllExport BINCOL : public DOSCOL {
   BINCOL(BINCOL *colp, PTDB tdbp);  // Constructor used in copy process
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_BIN;}
+  int  GetAmType(void) override {return TYPE_AM_BIN;}
           int  GetDeplac(void) {return Deplac;}
           int  GetFileSize(void) 
                {return N ? N : GetTypeSize(Buf_Type, Long);}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
 
   // Static
   static  void SetEndian(void); 
@@ -105,7 +105,7 @@ public:
 
 protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g)
+	PQRYRES GetResult(PGLOBAL g) override
 	  {return DBFColumns(g, ((PTABDEF)To_Def)->GetPath(), Fn, Topt, false);}
 
 	// Members

--- a/storage/connect/tabfmt.h
+++ b/storage/connect/tabfmt.h
@@ -27,13 +27,13 @@ public:
   CSVDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "CSV";}
+  const char *GetType(void) override {return "CSV";}
   char    GetSep(void) {return Sep;}
   char    GetQot(void) {return Qot;}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE mode);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE mode) override;
 
  protected:
   // Members
@@ -60,29 +60,29 @@ public:
   TDBCSV(PGLOBAL g, PTDBCSV tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_CSV;}
-  virtual PTDB Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_CSV;}
+  PTDB Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBCSV(g, this);}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
+  PTDB Clone(PTABS t) override;
 //virtual bool IsUsingTemp(PGLOBAL g);
-  virtual int  GetBadLines(void) {return (int)Nerr;}
+  int  GetBadLines(void) override {return (int)Nerr;}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  CheckWrite(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);        // Physical file read
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  CheckWrite(PGLOBAL g) override;
+  int  ReadBuffer(PGLOBAL g) override;        // Physical file read
 
   // Specific routines
-  virtual int  EstimatedLength(void);
-  virtual bool SkipHeader(PGLOBAL g);
+  int  EstimatedLength(void) override;
+  bool SkipHeader(PGLOBAL g) override;
   virtual bool CheckErr(void);
 
  protected:
-  virtual bool PrepareWriting(PGLOBAL g);
+  bool PrepareWriting(PGLOBAL g) override;
 
   // Members
   PSZ  *Field;             // Field to write to current line
@@ -112,12 +112,12 @@ class DllExport CSVCOL : public DOSCOL {
   CSVCOL(CSVCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int    GetAmType() {return TYPE_AM_CSV;}
+  int    GetAmType() override {return TYPE_AM_CSV;}
 
   // Methods
-  virtual bool   VarSize(void);
-  virtual void   ReadColumn(PGLOBAL g);
-  virtual void   WriteColumn(PGLOBAL g);
+  bool   VarSize(void) override;
+  void   ReadColumn(PGLOBAL g) override;
+  void   WriteColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used
@@ -143,26 +143,26 @@ class DllExport TDBFMT : public TDBCSV {
   TDBFMT(PGLOBAL g, PTDBFMT tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_FMT;}
-  virtual PTDB Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_FMT;}
+  PTDB Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBFMT(g, this);}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
+  PTDB Clone(PTABS t) override;
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-//virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+//int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
 //virtual int  CheckWrite(PGLOBAL g);
-  virtual int  ReadBuffer(PGLOBAL g);        // Physical file read
+  int  ReadBuffer(PGLOBAL g) override;        // Physical file read
 
   // Specific routines
-  virtual int  EstimatedLength(void);
+  int  EstimatedLength(void) override;
 
  protected:
-  virtual bool PrepareWriting(PGLOBAL g) 
+  bool PrepareWriting(PGLOBAL g) override 
        {snprintf(g->Message, sizeof(g->Message), MSG(TABLE_READ_ONLY), "FMT"); return true;}
 
   // Members
@@ -182,7 +182,7 @@ class DllExport TDBCCL : public TDBCAT {
 
  protected:
   // Specific routines
-  virtual PQRYRES GetResult(PGLOBAL g);
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
 	PTOS  Topt;

--- a/storage/connect/tabjdbc.h
+++ b/storage/connect/tabjdbc.h
@@ -29,11 +29,11 @@ public:
 	JDBCDEF(void);
 
 	// Implementation
-	virtual const char *GetType(void) { return "JDBC"; }
+	const char *GetType(void) override { return "JDBC"; }
 
 	// Methods
-	virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-	virtual PTDB GetTable(PGLOBAL g, MODE m);
+	bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+	PTDB GetTable(PGLOBAL g, MODE m) override;
 	int  ParseURL(PGLOBAL g, char *url, bool b = true);
 	bool SetParms(PJPARM sjp);
 
@@ -60,25 +60,25 @@ public:
   TDBJDBC(PTDBJDBC tdbp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) {return TYPE_AM_JDBC;}
-  virtual PTDB Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBJDBC(this);}
+	AMT  GetAmType(void) override {return TYPE_AM_JDBC;}
+  PTDB Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBJDBC(this);}
 
 	// Methods
-  virtual PTDB Clone(PTABS t);
-	virtual bool SetRecpos(PGLOBAL g, int recpos);
-	virtual void ResetSize(void);
-	virtual PCSZ GetServer(void) { return "JDBC"; }
+  PTDB Clone(PTABS t) override;
+	bool SetRecpos(PGLOBAL g, int recpos) override;
+	void ResetSize(void) override;
+	PCSZ GetServer(void) override { return "JDBC"; }
 	virtual int  Indexable(void) { return 2; }
 
 	// Database routines
-	virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-	virtual int  Cardinality(PGLOBAL g);
-	virtual bool OpenDB(PGLOBAL g);
-	virtual int  ReadDB(PGLOBAL g);
-	virtual int  WriteDB(PGLOBAL g);
-	virtual int  DeleteDB(PGLOBAL g, int irc);
-	virtual void CloseDB(PGLOBAL g);
-	virtual bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr);
+	PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+	int  Cardinality(PGLOBAL g) override;
+	bool OpenDB(PGLOBAL g) override;
+	int  ReadDB(PGLOBAL g) override;
+	int  WriteDB(PGLOBAL g) override;
+	int  DeleteDB(PGLOBAL g, int irc) override;
+	void CloseDB(PGLOBAL g) override;
+	bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr) override;
 
 protected:
 	// Internal functions
@@ -108,12 +108,12 @@ public:
   JDBCCOL(JDBCCOL *colp, PTDB tdbp); // Constructor used in copy process
 
 	// Implementation
-	virtual int  GetAmType(void) { return TYPE_AM_JDBC; }
+	int  GetAmType(void) override { return TYPE_AM_JDBC; }
 
 	// Methods
 //virtual bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-	virtual void ReadColumn(PGLOBAL g);
-	virtual void WriteColumn(PGLOBAL g);
+	void ReadColumn(PGLOBAL g) override;
+	void WriteColumn(PGLOBAL g) override;
 
 protected:
 	// Constructor for count(*) column
@@ -135,19 +135,19 @@ public:
 	TDBXJDC(PJDBCDEF tdp = NULL);
 
 	// Implementation
-	virtual AMT  GetAmType(void) {return TYPE_AM_XDBC;}
+	AMT  GetAmType(void) override {return TYPE_AM_XDBC;}
 
 	// Methods
 
 	// Database routines
-	virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
+	PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
 	//virtual int  GetProgMax(PGLOBAL g);
-	virtual int  GetMaxSize(PGLOBAL g);
-	virtual bool OpenDB(PGLOBAL g);
-	virtual int  ReadDB(PGLOBAL g);
-	virtual int  WriteDB(PGLOBAL g);
-	virtual int  DeleteDB(PGLOBAL g, int irc);
-	//virtual void CloseDB(PGLOBAL g);
+	int  GetMaxSize(PGLOBAL g) override;
+	bool OpenDB(PGLOBAL g) override;
+	int  ReadDB(PGLOBAL g) override;
+	int  WriteDB(PGLOBAL g) override;
+	int  DeleteDB(PGLOBAL g, int irc) override;
+	//void CloseDB(PGLOBAL g) override;
 
 protected:
 	// Internal functions
@@ -170,11 +170,11 @@ public:
 	JSRCCOL(PCOLDEF cdp, PTDB tdbp, PCOL cprec, int i, PCSZ am = "JDBC");
 
 	// Implementation
-	virtual int  GetAmType(void) {return TYPE_AM_JDBC;}
+	int  GetAmType(void) override {return TYPE_AM_JDBC;}
 
 	// Methods
-	virtual void ReadColumn(PGLOBAL g);
-	virtual void WriteColumn(PGLOBAL g);
+	void ReadColumn(PGLOBAL g) override;
+	void WriteColumn(PGLOBAL g) override;
 
 protected:
 	// Members
@@ -192,7 +192,7 @@ public:
 
 protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	virtual PQRYRES GetResult(PGLOBAL g) override;
 
 	// Members
 	int      Maxres;            // Returned lines limit
@@ -208,7 +208,7 @@ public:
 
 protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	virtual PQRYRES GetResult(PGLOBAL g) override;
 
 	// Members
 	PCSZ     Schema;            // Points to schema name or NULL
@@ -227,7 +227,7 @@ public:
 
 protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	virtual PQRYRES GetResult(PGLOBAL g) override;
 
 	// Members
 	PCSZ Colpat;            // Points to catalog column pattern

--- a/storage/connect/tabjmg.h
+++ b/storage/connect/tabjmg.h
@@ -18,9 +18,9 @@ public:
 	JMGDISC(PGLOBAL g, int *lg);
 
 	// Methods
-	virtual bool Init(PGLOBAL g);
-	virtual void GetDoc(void) {}
-	virtual bool Find(PGLOBAL g);
+	bool Init(PGLOBAL g) override;
+	void GetDoc(void) override {}
+	bool Find(PGLOBAL g) override;
 
 protected:
 	// Function
@@ -51,25 +51,25 @@ public:
 	TDBJMG(TDBJMG *tdbp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) { return TYPE_AM_MGO; }
-	virtual PTDB Duplicate(PGLOBAL g) { return (PTDB)new(g) TDBJMG(this); }
+	AMT  GetAmType(void) override { return TYPE_AM_MGO; }
+	PTDB Duplicate(PGLOBAL g) override { return (PTDB)new(g) TDBJMG(this); }
 
 	// Methods
-	virtual PTDB Clone(PTABS t);
-	virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-	virtual PCOL InsertSpecialColumn(PCOL colp);
+	PTDB Clone(PTABS t) override;
+	PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+	PCOL InsertSpecialColumn(PCOL colp) override;
 //virtual void SetFilter(PFIL fp);
-	virtual int  RowNumber(PGLOBAL g, bool b = FALSE) { return N; }
+	int  RowNumber(PGLOBAL g, bool b = FALSE) override { return N; }
 
 	// Database routines
-	virtual int  Cardinality(PGLOBAL g);
-	virtual int  GetMaxSize(PGLOBAL g);
-	virtual bool OpenDB(PGLOBAL g);
-	virtual int  ReadDB(PGLOBAL g);
-	virtual int  WriteDB(PGLOBAL g);
-	virtual int  DeleteDB(PGLOBAL g, int irc);
-	virtual void CloseDB(PGLOBAL g);
-	virtual bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr);
+	int  Cardinality(PGLOBAL g) override;
+	int  GetMaxSize(PGLOBAL g) override;
+	bool OpenDB(PGLOBAL g) override;
+	int  ReadDB(PGLOBAL g) override;
+	int  WriteDB(PGLOBAL g) override;
+	int  DeleteDB(PGLOBAL g, int irc) override;
+	void CloseDB(PGLOBAL g) override;
+	bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr) override;
 
 protected:
 	bool Init(PGLOBAL g);
@@ -106,14 +106,14 @@ public:
 	JMGCOL(JMGCOL *colp, PTDB tdbp); // Constructor used in copy process
 
 	// Implementation
-	virtual int   GetAmType(void) {return Tmgp->GetAmType();}
-	virtual bool  Stringify(void) { return Sgfy; }
+	int   GetAmType(void) override {return Tmgp->GetAmType();}
+	bool  Stringify(void) override { return Sgfy; }
 
 	// Methods
 	//virtual bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-	virtual PSZ   GetJpath(PGLOBAL g, bool proj);
-	virtual void  ReadColumn(PGLOBAL g);
-	virtual void  WriteColumn(PGLOBAL g);
+	PSZ   GetJpath(PGLOBAL g, bool proj) override;
+	void  ReadColumn(PGLOBAL g) override;
+	void  WriteColumn(PGLOBAL g) override;
 //bool AddValue(PGLOBAL g, bson_t *doc, char *key, bool upd);
 
 protected:
@@ -138,7 +138,7 @@ public:
 
 protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	virtual PQRYRES GetResult(PGLOBAL g) override;
 
 	// Members
 	PTOS Topt;

--- a/storage/connect/tabjson.h
+++ b/storage/connect/tabjson.h
@@ -93,11 +93,11 @@ public:
   JSONDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "JSON";}
+  const char *GetType(void) override {return "JSON";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -141,32 +141,32 @@ public:
    TDBJSN(TDBJSN *tdbp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_JSN;}
-  virtual bool  SkipHeader(PGLOBAL g);
-  virtual PTDB  Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBJSN(this);}
+  AMT   GetAmType(void) override {return TYPE_AM_JSN;}
+  bool  SkipHeader(PGLOBAL g) override;
+  PTDB  Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBJSN(this);}
           PJSON GetRow(void) {return Row;}
 					void  SetG(PGLOBAL g) {G = g;}
 
   // Methods
-  virtual PTDB  Clone(PTABS t);
-  virtual PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual PCOL  InsertSpecialColumn(PCOL colp);
-  virtual int   RowNumber(PGLOBAL g, bool b = FALSE)
+  PTDB  Clone(PTABS t) override;
+  PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  PCOL  InsertSpecialColumn(PCOL colp) override;
+  int   RowNumber(PGLOBAL g, bool b = FALSE) override
                  {return (b) ? M : N;}
-	virtual bool  CanBeFiltered(void) 
+	bool  CanBeFiltered(void) override 
 	              {return Txfp->GetAmType() == TYPE_AM_MGO || !Xcol;}
 
   // Database routines
-  //virtual int   Cardinality(PGLOBAL g);
-  //virtual int   GetMaxSize(PGLOBAL g);
-  virtual bool  OpenDB(PGLOBAL g);
-  virtual int   ReadDB(PGLOBAL g);
-	virtual bool  PrepareWriting(PGLOBAL g);
-	virtual int   WriteDB(PGLOBAL g);
-  virtual void  CloseDB(PGLOBAL g);
+  //int   Cardinality(PGLOBAL g) override;
+  //int   GetMaxSize(PGLOBAL g) override;
+  bool  OpenDB(PGLOBAL g) override;
+  int   ReadDB(PGLOBAL g) override;
+	bool  PrepareWriting(PGLOBAL g) override;
+	int   WriteDB(PGLOBAL g) override;
+  void  CloseDB(PGLOBAL g) override;
 
 	// Specific routine
-	virtual int   EstimatedLength(void);
+	int   EstimatedLength(void) override;
 
 protected:
           PJSON FindRow(PGLOBAL g);
@@ -216,15 +216,15 @@ public:
   JSONCOL(JSONCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int   GetAmType(void) {return Tjp->GetAmType();}
-  virtual bool  Stringify(void) { return Sgfy; }
+  int   GetAmType(void) override {return Tjp->GetAmType();}
+  bool  Stringify(void) override { return Sgfy; }
 
   // Methods
-  virtual bool  SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
+  bool  SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
           bool  ParseJpath(PGLOBAL g);
-	virtual PSZ   GetJpath(PGLOBAL g, bool proj);
-	virtual void  ReadColumn(PGLOBAL g);
-  virtual void  WriteColumn(PGLOBAL g);
+	PSZ   GetJpath(PGLOBAL g, bool proj) override;
+	void  ReadColumn(PGLOBAL g) override;
+  void  WriteColumn(PGLOBAL g) override;
 
  protected:
   bool  CheckExpand(PGLOBAL g, int i, PSZ nm, bool b);
@@ -269,30 +269,30 @@ class DllExport TDBJSON : public TDBJSN {
    TDBJSON(PJTDB tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_JSON;}
-  virtual PTDB Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBJSON(this);}
+  AMT  GetAmType(void) override {return TYPE_AM_JSON;}
+  PTDB Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBJSON(this);}
           PJAR GetDoc(void) {return Doc;} 
 
   // Methods
-  virtual PTDB Clone(PTABS t);
+  PTDB Clone(PTABS t) override;
 
   // Database routines
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual void ResetSize(void);
-  virtual int  GetProgCur(void) {return N;}
-	virtual int  GetRecpos(void);
-  virtual bool SetRecpos(PGLOBAL g, int recpos);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual bool PrepareWriting(PGLOBAL g) {return false;}
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
+  int  Cardinality(PGLOBAL g) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  void ResetSize(void) override;
+  int  GetProgCur(void) override {return N;}
+	int  GetRecpos(void) override;
+  bool SetRecpos(PGLOBAL g, int recpos) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  bool PrepareWriting(PGLOBAL g) override {return false;}
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
           int  MakeDocument(PGLOBAL g);
 
   // Optimization routines
-  virtual int  MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add);
+  int  MakeIndex(PGLOBAL g, PIXDEF pxdf, bool add) override;
 
  protected:
           int  MakeNewDoc(PGLOBAL g);
@@ -314,7 +314,7 @@ class DllExport TDBJCL : public TDBCAT {
 
  protected:
   // Specific routines
-  virtual PQRYRES GetResult(PGLOBAL g);
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   PTOS Topt;

--- a/storage/connect/tabmac.h
+++ b/storage/connect/tabmac.h
@@ -48,23 +48,23 @@ class TDBMAC : public TDBASE {
 //TDBMAC(PGLOBAL g, PTDBMAC tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_MAC;}
-//virtual PTDB Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBMAC(g, this);}
+  AMT  GetAmType(void) override {return TYPE_AM_MAC;}
+// PTDB Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBMAC(g, this);}
 
   // Methods
-//virtual PTDB Clone(PTABS t);
+//PTDB Clone(PTABS t) override;
   virtual int GetRecpos(void) {return N;}
-  virtual int RowNumber(PGLOBAL g, bool b = false) {return N;}
+  int RowNumber(PGLOBAL g, bool b = false) override {return N;}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  Cardinality(PGLOBAL g) {return GetMaxSize(g);}
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g) {}
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  Cardinality(PGLOBAL g) override {return GetMaxSize(g);}
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override {}
 
  protected:
   // Specific routines
@@ -94,10 +94,10 @@ class MACCOL : public COLBLK {
 //MACCOL(MACCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_MAC;}
+  int  GetAmType(void) override {return TYPE_AM_MAC;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   MACCOL(void) {}              // Default constructor not to be used

--- a/storage/connect/tabmul.h
+++ b/storage/connect/tabmul.h
@@ -32,31 +32,31 @@ class DllExport TDBMUL : public TDBASE {
   TDBMUL(PTDBMUL tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return Tdbp->GetAmType();}
-  virtual PTDB Duplicate(PGLOBAL g);
+  AMT  GetAmType(void) override {return Tdbp->GetAmType();}
+  PTDB Duplicate(PGLOBAL g) override;
 
   // Methods
-  virtual void ResetDB(void);
-  virtual PTDB Clone(PTABS t);
-  virtual bool IsSame(PTDB tp) {return tp == (PTDB)Tdbp;}
-  virtual PCSZ GetFile(PGLOBAL g) {return Tdbp->GetFile(g);}
-  virtual int  GetRecpos(void) {return 0;}
-  virtual PCOL ColDB(PGLOBAL g, PSZ name, int num);
+  void ResetDB(void) override;
+  PTDB Clone(PTABS t) override;
+  bool IsSame(PTDB tp) override {return tp == (PTDB)Tdbp;}
+  PCSZ GetFile(PGLOBAL g) override {return Tdbp->GetFile(g);}
+  int  GetRecpos(void) override {return 0;}
+  PCOL ColDB(PGLOBAL g, PSZ name, int num) override;
           bool InitFileNames(PGLOBAL g);
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n)
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override
                 {strcpy(g->Message, MSG(MUL_MAKECOL_ERR)); return NULL;}
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual int  GetProgMax(PGLOBAL g);
-  virtual int  GetProgCur(void);
-  virtual int  RowNumber(PGLOBAL g, bool b = false);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
+  int  Cardinality(PGLOBAL g) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  int  GetProgMax(PGLOBAL g) override;
+  int  GetProgCur(void) override;
+  int  RowNumber(PGLOBAL g, bool b = false) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
 
  protected:
 
@@ -83,10 +83,10 @@ public:
 	TDBMSD(PTDBMSD tdbp) : TDBMUL(tdbp) {}
 
 	// Implementation
-	virtual PTDB Duplicate(PGLOBAL g);
+	PTDB Duplicate(PGLOBAL g);
 
 	// Methods
-	virtual PTDB Clone(PTABS t);
+	PTDB Clone(PTABS t) override;
 	bool InitFileNames(PGLOBAL g);
 
 	// Database routines
@@ -108,11 +108,11 @@ class DllExport DIRDEF : public TABDEF {    /* Directory listing table */
   DIRDEF(void) {Fn = NULL; Incl = false; Huge = false;}
 
   // Implementation
-  virtual const char *GetType(void) {return "DIR";}
+  const char *GetType(void) override {return "DIR";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -137,21 +137,21 @@ public:
 	TDBDIR(PSZ fpat);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_DIR;}
+  AMT  GetAmType(void) override {return TYPE_AM_DIR;}
 
   // Methods
-  virtual int GetRecpos(void) {return iFile;}
+  int GetRecpos(void) override {return iFile;}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual int  GetProgMax(PGLOBAL g) {return GetMaxSize(g);}
-  virtual int  GetProgCur(void) {return iFile;}
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  int  GetProgMax(PGLOBAL g) override {return GetMaxSize(g);}
+  int  GetProgCur(void) override {return iFile;}
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
 
  protected:
 	void Init(void);
@@ -195,11 +195,11 @@ class TDBSDR : public TDBDIR {
 	TDBSDR(PSZ fpat) : TDBDIR(fpat) {Sub = NULL;}
 
   // Database routines
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual int  GetProgMax(PGLOBAL g) {return GetMaxSize(g);}
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-//virtual void CloseDB(PGLOBAL g);
+  int  GetMaxSize(PGLOBAL g) override;
+  int  GetProgMax(PGLOBAL g) override {return GetMaxSize(g);}
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+//void CloseDB(PGLOBAL g) override;
 
  protected:
           int  FindInDir(PGLOBAL g);
@@ -230,10 +230,10 @@ class DIRCOL : public COLBLK {
   DIRCOL(DIRCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int    GetAmType(void) {return TYPE_AM_DIR;}
+  int    GetAmType(void) override {return TYPE_AM_DIR;}
 
   // Methods
-  virtual void   ReadColumn(PGLOBAL g);
+  void   ReadColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used

--- a/storage/connect/tabmysql.h
+++ b/storage/connect/tabmysql.h
@@ -28,7 +28,7 @@ class MYSQLDEF : public EXTDEF           {/* Logical table description */
   MYSQLDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "MYSQL";}
+  const char *GetType(void) override {return "MYSQL";}
   inline  PSZ  GetHostname(void) {return Hostname;};
 //inline  PSZ  GetDatabase(void) {return Tabschema;};
 //inline  PSZ  GetTabname(void) {return Tabname;}
@@ -39,8 +39,8 @@ class MYSQLDEF : public EXTDEF           {/* Logical table description */
 
   // Methods
 //virtual int  Indexable(void) {return 2;}
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
           bool ParseURL(PGLOBAL g, char *url, bool b = true);
           bool GetServerInfo(PGLOBAL g, const char *server_name);
 
@@ -77,30 +77,30 @@ class TDBMYSQL : public TDBEXT {
   TDBMYSQL(PTDBMY tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_MYSQL;}
-  virtual PTDB Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBMYSQL(this);}
+  AMT  GetAmType(void) override {return TYPE_AM_MYSQL;}
+  PTDB Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBMYSQL(this);}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
+  PTDB Clone(PTABS t) override;
 //virtual int  GetAffectedRows(void) {return AftRows;}
-  virtual int  GetRecpos(void) {return N;}
-  virtual int  GetProgMax(PGLOBAL g);
-  virtual void ResetDB(void) {N = 0;}
-  virtual int  RowNumber(PGLOBAL g, bool b = false);
-  virtual bool IsView(void) {return Isview;}
-  virtual PCSZ GetServer(void) {return Server;}
+  int  GetRecpos(void) override {return N;}
+  int  GetProgMax(PGLOBAL g) override;
+  void ResetDB(void) override {N = 0;}
+  int  RowNumber(PGLOBAL g, bool b = false) override;
+  bool IsView(void) override {return Isview;}
+  PCSZ GetServer(void) override {return Server;}
           void SetDatabase(LPCSTR db) {Schema = (char*)db;}
 
   // Schema routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  Cardinality(PGLOBAL g);
-//virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
-  virtual bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  Cardinality(PGLOBAL g) override;
+//int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
+  bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr) override;
 
   // Specific routines
           bool SetColumnRanks(PGLOBAL g);
@@ -112,7 +112,7 @@ class TDBMYSQL : public TDBEXT {
   bool MakeSelect(PGLOBAL g, bool mx);
   bool MakeInsert(PGLOBAL g);
   int  BindColumns(PGLOBAL g __attribute__((unused)));
-  virtual bool MakeCommand(PGLOBAL g);
+  bool MakeCommand(PGLOBAL g) override;
 //int  MakeUpdate(PGLOBAL g);  
 //int  MakeDelete(PGLOBAL g);
   int  SendCommand(PGLOBAL g);
@@ -154,13 +154,13 @@ class MYSQLCOL : public COLBLK {
   MYSQLCOL(MYSQLCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_MYSQL;}
+  int  GetAmType(void) override {return TYPE_AM_MYSQL;}
           void InitBind(PGLOBAL g);
 
   // Methods
-  virtual bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
           bool FindRank(PGLOBAL g);
 
  protected:
@@ -182,19 +182,19 @@ class TDBMYEXC : public TDBMYSQL {
   TDBMYEXC(PTDBMYX tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_MYX;}
-  virtual PTDB Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBMYEXC(this);}
+  AMT  GetAmType(void) override {return TYPE_AM_MYX;}
+  PTDB Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBMYEXC(this);}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
-  virtual bool IsView(void) {return Isview;}
+  PTDB Clone(PTABS t) override;
+  bool IsView(void) override {return Isview;}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
 
  protected:
   // Internal functions
@@ -223,8 +223,8 @@ class MYXCOL : public MYSQLCOL {
   MYXCOL(MYXCOL *colp, PTDB tdbp);   // Constructor used in copy process
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
 
  protected:
   // Members
@@ -242,7 +242,7 @@ class TDBMCL : public TDBCAT {
 
  protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   PCSZ Host;                      // Host machine to use            

--- a/storage/connect/taboccur.h
+++ b/storage/connect/taboccur.h
@@ -26,11 +26,11 @@ class OCCURDEF : public PRXDEF {          /* Logical table description */
 	OCCURDEF(void) {Pseudo = 3; Colist = Xcol = NULL;}
 
   // Implementation
-  virtual const char *GetType(void) {return "OCCUR";}
+  const char *GetType(void) override {return "OCCUR";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -50,21 +50,21 @@ class TDBOCCUR : public TDBPRX {
   TDBOCCUR(POCCURDEF tdp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_OCCUR;}
+  AMT  GetAmType(void) override {return TYPE_AM_OCCUR;}
   				void SetTdbp(PTDBASE tdbp) {Tdbp = tdbp;}
 
   // Methods
-	virtual void ResetDB(void) {N = 0; Tdbp->ResetDB();}
-	virtual int  RowNumber(PGLOBAL g, bool b = FALSE);
+	void ResetDB(void) override {N = 0; Tdbp->ResetDB();}
+	int  RowNumber(PGLOBAL g, bool b = FALSE) override;
 					bool MakeColumnList(PGLOBAL g);
           bool ViewColumnList(PGLOBAL g);
 
   // Database routines
-	virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual bool InitTable(PGLOBAL g);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
+	PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  bool InitTable(PGLOBAL g) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
 
  protected:
   // Members
@@ -89,12 +89,12 @@ class OCCURCOL : public COLBLK {
   OCCURCOL(PCOLDEF cdp, PTDBOCCUR tdbp, int n);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_OCCUR;}
+  int  GetAmType(void) override {return TYPE_AM_OCCUR;}
 					int  GetI(void) {return I;}
 
   // Methods
-  virtual void Reset(void) {}		// Evaluated only by TDBOCCUR
-  virtual void ReadColumn(PGLOBAL g);
+  void Reset(void) override {}		// Evaluated only by TDBOCCUR
+  void ReadColumn(PGLOBAL g) override;
 					void Xreset(void) {I = 0;};
 
  protected:
@@ -114,10 +114,10 @@ class RANKCOL : public COLBLK {
 	RANKCOL(PCOLDEF cdp, PTDBOCCUR tdbp, int n) : COLBLK(cdp, tdbp, n) {}
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_OCCUR;}
+  int  GetAmType(void) override {return TYPE_AM_OCCUR;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used

--- a/storage/connect/tabodbc.h
+++ b/storage/connect/tabodbc.h
@@ -31,14 +31,14 @@ public:
   ODBCDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "ODBC";}
+  const char *GetType(void) override {return "ODBC";}
   PSZ  GetConnect(void) {return Connect;}
   int  GetCatver(void) {return Catver;}
 
   // Methods
-	virtual int  Indexable(void) {return 2;}
-	virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  int  Indexable(void) override {return 2;}
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -63,28 +63,28 @@ class TDBODBC : public TDBEXT {
   TDBODBC(PTDBODBC tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_ODBC;}
-  virtual PTDB Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_ODBC;}
+  PTDB Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBODBC(this);}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
-  virtual bool SetRecpos(PGLOBAL g, int recpos);
-  virtual PCSZ GetFile(PGLOBAL g);
-  virtual void SetFile(PGLOBAL g, PCSZ fn);
-  virtual void ResetSize(void);
-  virtual PCSZ GetServer(void) {return "ODBC";}
+  PTDB Clone(PTABS t) override;
+  bool SetRecpos(PGLOBAL g, int recpos) override;
+  PCSZ GetFile(PGLOBAL g) override;
+  void SetFile(PGLOBAL g, PCSZ fn) override;
+  void ResetSize(void) override;
+  PCSZ GetServer(void) override {return "ODBC";}
   virtual int  Indexable(void) {return 2;}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  Cardinality(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
-	virtual bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  Cardinality(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
+  bool ReadKey(PGLOBAL g, OPVAL op, const key_range *kr) override;
 
  protected:
   // Internal functions
@@ -109,16 +109,16 @@ class ODBCCOL : public EXTCOL {
  public:
   // Constructors
   ODBCCOL(PCOLDEF cdp, PTDB tdbp, PCOL cprec, int i, PCSZ am = "ODBC");
-  ODBCCOL(ODBCCOL *colp, PTDB tdbp); // Constructor used in copy process
+  ODBCCOL(ODBCCOL *colp, PTDB tdbp); // Constructor used in opy process
 
   // Implementation
-  virtual int     GetAmType(void) {return TYPE_AM_ODBC;}
-          SQLLEN *GetStrLen(void) {return StrLen;}
+  int     GetAmType(void) override {return TYPE_AM_ODBC;}
+  SQLLEN *GetStrLen(void) {return StrLen;}
 
   // Methods
 //virtual bool   SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-  virtual void   ReadColumn(PGLOBAL g);
-  virtual void   WriteColumn(PGLOBAL g);
+  void   ReadColumn(PGLOBAL g) override;
+  void   WriteColumn(PGLOBAL g) override;
           void   AllocateBuffers(PGLOBAL g, int rows);
           void  *GetBuffer(DWORD rows);
           SWORD  GetBuflen(void);
@@ -146,20 +146,20 @@ class TDBXDBC : public TDBODBC {
   TDBXDBC(PTDBXDBC tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_XDBC;}
-  virtual PTDB Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_XDBC;}
+  PTDB Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBXDBC(this);}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
+  PTDB Clone(PTABS t) override;
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
 
  protected:
   // Internal functions
@@ -185,8 +185,8 @@ class XSRCCOL : public ODBCCOL {
   // Implementation
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
 
  protected:
   // Members
@@ -203,8 +203,8 @@ class TDBDRV : public TDBCAT {
   TDBDRV(PODEF tdp) : TDBCAT(tdp) {Maxres = tdp->Maxres;}
 
  protected:
-	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+  // Specific routines
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   int      Maxres;            // Returned lines limit
@@ -219,8 +219,8 @@ class TDBSRC : public TDBDRV {
   TDBSRC(PODEF tdp) : TDBDRV(tdp) {}
 
  protected:
-	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+  // Specific routines
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // No additional Members
   }; // end of class TDBSRC
@@ -234,8 +234,8 @@ class TDBOTB : public TDBDRV {
   TDBOTB(PODEF tdp);
 
  protected:
-	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+  // Specific routines
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
 	PCSZ     Dsn;               // Points to connection string
@@ -254,8 +254,8 @@ class TDBOCL : public TDBOTB {
 	 TDBOCL(PODEF tdp);
 
  protected:
-	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+  // Specific routines
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
 	char    *Colpat;						// Points to column pattern

--- a/storage/connect/tabpivot.h
+++ b/storage/connect/tabpivot.h
@@ -27,7 +27,7 @@ class PIVAID : public CSORT {
   bool    SkipColumn(PCOLRES crp, char *skc);
 
   // The sorting function
-  virtual int  Qcompare(int *, int *);
+  int  Qcompare(int *, int *) override;
 
  protected:
   // Members
@@ -64,11 +64,11 @@ class PIVOTDEF : public PRXDEF {          /* Logical table description */
   PIVOTDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "PIVOT";}
+  const char *GetType(void) override {return "PIVOT";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -96,22 +96,22 @@ class TDBPIVOT : public TDBPRX {
   TDBPIVOT(PPIVOTDEF tdp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_PIVOT;}
+  AMT  GetAmType(void) override {return TYPE_AM_PIVOT;}
 
   // Methods
-  virtual int  GetRecpos(void) {return N;}
-  virtual void ResetDB(void) {N = 0;}
-  virtual int  RowNumber(PGLOBAL g, bool b = FALSE);
+  int  GetRecpos(void) override {return N;}
+  void ResetDB(void) override {N = 0;}
+  int  RowNumber(PGLOBAL g, bool b = FALSE) override;
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  Cardinality(PGLOBAL g) {return (g) ? 10 : 0;}
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  Cardinality(PGLOBAL g) override {return (g) ? 10 : 0;}
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
 
  protected:
   // Internal routines
@@ -154,10 +154,10 @@ class FNCCOL : public COLBLK {
   FNCCOL(PCOLDEF cdp, PTDB tdbp, PCOL cprec, int i);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_FNC;}
+  int  GetAmType(void) override {return TYPE_AM_FNC;}
 
   // Methods
-  virtual void Reset(void) {}
+  void Reset(void) override {}
           bool InitColumn(PGLOBAL g);
           bool CompareColumn(void);
 
@@ -177,13 +177,13 @@ class SRCCOL : public PRXCOL {
   SRCCOL(PCOLDEF cdp, PTDB tdbp, PCOL cprec, int n);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_SRC;}
+  int  GetAmType(void) override {return TYPE_AM_SRC;}
 
   // Methods
   using PRXCOL::Init;
-  virtual void Reset(void) {}
+  void Reset(void) override {}
           void SetColumn(void);
-  virtual bool Init(PGLOBAL g, PTDB tp);
+  bool Init(PGLOBAL g, PTDB tp) override;
           bool CompareLast(void);
 
  protected:

--- a/storage/connect/tabrest.h
+++ b/storage/connect/tabrest.h
@@ -33,11 +33,11 @@ public:
 	RESTDEF(void) { Tdp = NULL; Http = Uri = Fn = NULL; }
 
 	// Implementation
-	virtual const char *GetType(void) { return "REST"; }
+	const char *GetType(void) override { return "REST"; }
 
 	// Methods
-	virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-	virtual PTDB GetTable(PGLOBAL g, MODE m);
+	bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+	PTDB GetTable(PGLOBAL g, MODE m) override;
 
 protected:
 	// Members

--- a/storage/connect/tabsys.h
+++ b/storage/connect/tabsys.h
@@ -27,11 +27,11 @@ class DllExport INIDEF : public TABDEF {      /* INI table description */
   INIDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "INI";}
+  const char *GetType(void) override {return "INI";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -53,30 +53,30 @@ class TDBINI : public TDBASE {
   TDBINI(PTDBINI tdbp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_INI;}
-  virtual PTDB  Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBINI(this);}
+  AMT   GetAmType(void) override {return TYPE_AM_INI;}
+  PTDB  Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBINI(this);}
 
   // Methods
-  virtual PTDB  Clone(PTABS t);
-  virtual int   GetRecpos(void) {return N;}
-  virtual int   GetProgCur(void) {return N;}
+  PTDB  Clone(PTABS t) override;
+  int   GetRecpos(void) override {return N;}
+  int   GetProgCur(void) override {return N;}
 //virtual int   GetAffectedRows(void) {return 0;}
-  virtual PCSZ  GetFile(PGLOBAL g) {return Ifile;}
-  virtual void  SetFile(PGLOBAL g, PCSZ fn) {Ifile = fn;}
-  virtual void  ResetDB(void) {Seclist = Section = NULL; N = 0;}
-  virtual void  ResetSize(void) {MaxSize = -1; Seclist = NULL;}
-  virtual int   RowNumber(PGLOBAL g, bool b = false) {return N;}
+  PCSZ  GetFile(PGLOBAL g) override {return Ifile;}
+  void  SetFile(PGLOBAL g, PCSZ fn) override {Ifile = fn;}
+  void  ResetDB(void) override {Seclist = Section = NULL; N = 0;}
+  void  ResetSize(void) override {MaxSize = -1; Seclist = NULL;}
+  int   RowNumber(PGLOBAL g, bool b = false) override {return N;}
           char *GetSeclist(PGLOBAL g);
 
   // Database routines
-  virtual PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int   Cardinality(PGLOBAL g);
-  virtual int   GetMaxSize(PGLOBAL g);
-  virtual bool  OpenDB(PGLOBAL g);
-  virtual int   ReadDB(PGLOBAL g);
-  virtual int   WriteDB(PGLOBAL g);
-  virtual int   DeleteDB(PGLOBAL g, int irc);
-  virtual void  CloseDB(PGLOBAL g);
+  PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int   Cardinality(PGLOBAL g) override;
+  int   GetMaxSize(PGLOBAL g) override;
+  bool  OpenDB(PGLOBAL g) override;
+  int   ReadDB(PGLOBAL g) override;
+  int   WriteDB(PGLOBAL g) override;
+  int   DeleteDB(PGLOBAL g, int irc) override;
+  void  CloseDB(PGLOBAL g) override;
 
  protected:
   // Members
@@ -97,13 +97,13 @@ class INICOL : public COLBLK {
   INICOL(INICOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_INI;}
-  virtual void SetTo_Val(PVAL valp) {To_Val = valp;}
+  int  GetAmType(void) override {return TYPE_AM_INI;}
+  void SetTo_Val(PVAL valp) override {To_Val = valp;}
 
   // Methods
-  virtual bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
   virtual void AllocBuf(PGLOBAL g);
 
  protected:
@@ -132,24 +132,24 @@ class TDBXIN : public TDBINI {
   TDBXIN(PTDBXIN tdbp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_INI;}
-  virtual PTDB  Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBXIN(this);}
+  AMT   GetAmType(void) override {return TYPE_AM_INI;}
+  PTDB  Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBXIN(this);}
 
   // Methods
-  virtual PTDB  Clone(PTABS t);
-  virtual int   GetRecpos(void);
-  virtual bool  SetRecpos(PGLOBAL g, int recpos);
-  virtual void  ResetDB(void)
+  PTDB  Clone(PTABS t) override;
+  int   GetRecpos(void) override;
+  bool  SetRecpos(PGLOBAL g, int recpos) override;
+  void  ResetDB(void) override
                 {Seclist = Section = Keycur = NULL; N = 0; Oldsec = -1;}
           char *GetKeylist(PGLOBAL g, char *sec);
 
   // Database routines
-  virtual PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int   Cardinality(PGLOBAL g);
-  virtual bool  OpenDB(PGLOBAL g);
-  virtual int   ReadDB(PGLOBAL g);
-  virtual int   WriteDB(PGLOBAL g);
-  virtual int   DeleteDB(PGLOBAL g, int irc);
+  PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int   Cardinality(PGLOBAL g) override;
+  bool  OpenDB(PGLOBAL g) override;
+  int   ReadDB(PGLOBAL g) override;
+  int   WriteDB(PGLOBAL g) override;
+  int   DeleteDB(PGLOBAL g, int irc) override;
 
  protected:
   // Members
@@ -171,8 +171,8 @@ class XINCOL : public INICOL {
   // Implementation
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used

--- a/storage/connect/tabtbl.h
+++ b/storage/connect/tabtbl.h
@@ -24,11 +24,11 @@ class DllExport TBLDEF : public PRXDEF {  /* Logical table description */
   TBLDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "TBL";}
+  const char *GetType(void) override {return "TBL";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -48,21 +48,21 @@ class DllExport TDBTBL : public TDBPRX {
   TDBTBL(PTBLDEF tdp = NULL);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_TBL;}
+  AMT  GetAmType(void) override {return TYPE_AM_TBL;}
 
   // Methods
-  virtual void ResetDB(void);
-  virtual int  GetRecpos(void) {return Rows;}
-  virtual int  GetBadLines(void) {return (int)Nbc;}
+  void ResetDB(void) override;
+  int  GetRecpos(void) override {return Rows;}
+  int  GetBadLines(void) override {return (int)Nbc;}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  Cardinality(PGLOBAL g);
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual int  RowNumber(PGLOBAL g, bool b = FALSE);
-  virtual PCOL InsertSpecialColumn(PCOL scp);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  Cardinality(PGLOBAL g) override;
+  int  GetMaxSize(PGLOBAL g) override;
+  int  RowNumber(PGLOBAL g, bool b = FALSE) override;
+  PCOL InsertSpecialColumn(PCOL scp) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
 
  protected:
   // Internal functions
@@ -89,7 +89,7 @@ class TBTBLK : public TIDBLK {
   TBTBLK(PVAL valp) {Value = valp;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
 
   // Fake operator new used to change TIDBLK into SDTBLK
   void * operator new(size_t size, TIDBLK *sp) {return sp;}
@@ -143,11 +143,11 @@ class DllExport TDBTBM : public TDBTBL {
   virtual void ResetDB(void);
 
   // Database routines
-	virtual int  Cardinality(PGLOBAL g) { return 10; }
-	virtual int  GetMaxSize(PGLOBAL g) { return 10; } // Temporary
-  virtual int  RowNumber(PGLOBAL g, bool b = FALSE);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
+	int  Cardinality(PGLOBAL g) override { return 10; }
+	int  GetMaxSize(PGLOBAL g) override { return 10; } // Temporary
+  int  RowNumber(PGLOBAL g, bool b = FALSE) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
 
  protected:
   // Internal functions

--- a/storage/connect/tabutil.h
+++ b/storage/connect/tabutil.h
@@ -40,11 +40,11 @@ class DllExport PRXDEF : public TABDEF {  /* Logical table description */
 	 PRXDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "PRX";}
+  const char *GetType(void) override {return "PRX";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE mode);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE mode) override;
 
  protected:
   // Members
@@ -63,27 +63,27 @@ class DllExport TDBPRX : public TDBASE {
   TDBPRX(PTDBPRX tdbp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_PRX;}
-  virtual PTDB  Duplicate(PGLOBAL g)
+  AMT   GetAmType(void) override {return TYPE_AM_PRX;}
+  PTDB  Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBPRX(this);}
 
   // Methods
-  virtual PTDB  Clone(PTABS t);
-  virtual int   GetRecpos(void) {return Tdbp->GetRecpos();}
-	virtual void  ResetDB(void) {Tdbp->ResetDB();}
-	virtual int   RowNumber(PGLOBAL g, bool b = FALSE);
-  virtual PCSZ  GetServer(void) {return (Tdbp) ? Tdbp->GetServer() : (PSZ)"?";}
+  PTDB  Clone(PTABS t) override;
+  int   GetRecpos(void) override {return Tdbp->GetRecpos();}
+	void  ResetDB(void) override {Tdbp->ResetDB();}
+	int   RowNumber(PGLOBAL g, bool b = FALSE) override;
+  PCSZ  GetServer(void) override {return (Tdbp) ? Tdbp->GetServer() : (PSZ)"?";}
 
   // Database routines
-	virtual PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
+	PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
   virtual bool  InitTable(PGLOBAL g);
-  virtual int   Cardinality(PGLOBAL g);
-  virtual int   GetMaxSize(PGLOBAL g);
-  virtual bool  OpenDB(PGLOBAL g);
-  virtual int   ReadDB(PGLOBAL g);
-  virtual int   WriteDB(PGLOBAL g);
-  virtual int   DeleteDB(PGLOBAL g, int irc);
-  virtual void  CloseDB(PGLOBAL g) {if (Tdbp) Tdbp->CloseDB(g);}
+  int   Cardinality(PGLOBAL g) override;
+  int   GetMaxSize(PGLOBAL g) override;
+  bool  OpenDB(PGLOBAL g) override;
+  int   ReadDB(PGLOBAL g) override;
+  int   WriteDB(PGLOBAL g) override;
+  int   DeleteDB(PGLOBAL g, int irc) override;
+  void  CloseDB(PGLOBAL g) override {if (Tdbp) Tdbp->CloseDB(g);}
           PTDB  GetSubTable(PGLOBAL g, PTABLE tabp, bool b = false);
           void  RemoveNext(PTABLE tp);
 
@@ -106,16 +106,16 @@ class DllExport PRXCOL : public COLBLK {
   PRXCOL(PRXCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_PRX;}
+  int  GetAmType(void) override {return TYPE_AM_PRX;}
 
   // Methods
   using COLBLK::Init;
-  virtual void Reset(void);
-  virtual bool IsSpecial(void) {return Pseudo;}
-  virtual bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check)
+  void Reset(void) override;
+  bool IsSpecial(void) override {return Pseudo;}
+  bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override
                 {return false;}
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
   virtual bool Init(PGLOBAL g, PTDB tp);
 
  protected:
@@ -141,7 +141,7 @@ class TDBTBC : public TDBCAT {
 
  protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   PSZ     Db;                    // Database of the table  

--- a/storage/connect/tabvct.h
+++ b/storage/connect/tabvct.h
@@ -29,12 +29,12 @@ class DllExport VCTDEF : public DOSDEF {  /* Logical table description */
   VCTDEF(void) {Split = false; Estimate = Header = 0;}
 
   // Implementation
-  virtual const char *GetType(void) {return "VCT";}
+  const char *GetType(void) override {return "VCT";}
   int  GetEstimate(void) {return Estimate;}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE mode);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE mode) override;
 
  protected:
           int  MakeFnPattern(char *fpat);
@@ -62,20 +62,20 @@ class DllExport TDBVCT : public TDBFIX {
   TDBVCT(PGLOBAL g, PTDBVCT tdbp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_VCT;}
-  virtual PTDB Duplicate(PGLOBAL g)
+  AMT  GetAmType(void) override {return TYPE_AM_VCT;}
+  PTDB Duplicate(PGLOBAL g) override
                 {return (PTDB)new(g) TDBVCT(g, this);}
           bool IsSplit(void) {return ((VCTDEF*)To_Def)->Split;}
 
   // Methods
-  virtual PTDB Clone(PTABS t);
-  virtual bool IsUsingTemp(PGLOBAL g);
+  PTDB Clone(PTABS t) override;
+  bool IsUsingTemp(PGLOBAL g) override;
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual void CloseDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  void CloseDB(PGLOBAL g) override;
 
  protected:
   // Members
@@ -98,13 +98,13 @@ class DllExport VCTCOL : public DOSCOL {
   VCTCOL(VCTCOL *colp, PTDB tdbp); // Constructor used in copy process
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_VCT;}
+  int  GetAmType(void) override {return TYPE_AM_VCT;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
-  virtual bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-  virtual void SetOk(void);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
+  bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
+  void SetOk(void) override;
 
  protected:
   virtual void ReadBlock(PGLOBAL g);

--- a/storage/connect/tabvir.h
+++ b/storage/connect/tabvir.h
@@ -24,12 +24,12 @@ class DllExport VIRDEF : public TABDEF {  /* Logical table description */
 	VIRDEF(void) = default;
 
   // Implementation
-  virtual const char *GetType(void) {return "VIRTUAL";}
+  const char *GetType(void) override {return "VIRTUAL";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL, LPCSTR, int) {Pseudo = 3; return false;}
-  virtual int  Indexable(void) {return 3;}
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL, LPCSTR, int) override {Pseudo = 3; return false;}
+  int  Indexable(void) override {return 3;}
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -44,24 +44,24 @@ class DllExport TDBVIR : public TDBASE {
 	TDBVIR(PVIRDEF tdp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_VIR;}
+  AMT  GetAmType(void) override {return TYPE_AM_VIR;}
 
   // Methods
-  virtual int  GetRecpos(void) {return N;}
-  virtual bool SetRecpos(PGLOBAL g, int recpos)
+  int  GetRecpos(void) override {return N;}
+  bool SetRecpos(PGLOBAL g, int recpos) override
                {N = recpos - 2; return false;}
-	virtual int  RowNumber(PGLOBAL g, bool b = false) {return N + 1;}
+	int  RowNumber(PGLOBAL g, bool b = false) override {return N + 1;}
           int  TestFilter(PFIL filp, bool nop);
 
   // Database routines
-	virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  Cardinality(PGLOBAL g) {return (g) ? Size : 1;}
-  virtual int  GetMaxSize(PGLOBAL g) {return Size;}
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-	virtual void CloseDB(PGLOBAL g) {}
+	PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  Cardinality(PGLOBAL g) override {return (g) ? Size : 1;}
+  int  GetMaxSize(PGLOBAL g) override {return Size;}
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+	void CloseDB(PGLOBAL g) override {}
 
  protected:
   // Members
@@ -79,10 +79,10 @@ class VIRCOL : public COLBLK {
   VIRCOL(PCOLDEF cdp, PTDB tdbp, PCOL cprec, int i, PCSZ am = "VIRTUAL");
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_VIR;}
+  int  GetAmType(void) override {return TYPE_AM_VIR;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   // Default constructor not to be used
@@ -100,11 +100,11 @@ class TDBVICL : public TDBCAT {
   TDBVICL(PVIRDEF tdp) : TDBCAT(tdp) {}
 
   // Methods
-  virtual int  Cardinality(PGLOBAL g) {return 2;} // Avoid DBUG_ASSERT
+  int  Cardinality(PGLOBAL g) override {return 2;} // Avoid DBUG_ASSERT
 
  protected:
 	// Specific routines
-	virtual PQRYRES GetResult(PGLOBAL g);
+	PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   }; // end of class TDBVICL

--- a/storage/connect/tabwmi.h
+++ b/storage/connect/tabwmi.h
@@ -66,22 +66,22 @@ class TDBWMI : public TDBASE {
   TDBWMI(PWMIDEF tdp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_WMI;}
+  AMT  GetAmType(void) override {return TYPE_AM_WMI;}
 
   // Methods
   virtual int GetRecpos(void);
   virtual int GetProgCur(void) {return N;}
-  virtual int RowNumber(PGLOBAL g, bool b = false) {return N + 1;}
+  int RowNumber(PGLOBAL g, bool b = false) override {return N + 1;}
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int  Cardinality(PGLOBAL g) {return GetMaxSize(g);}
-  virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int  Cardinality(PGLOBAL g) override {return GetMaxSize(g);}
+  int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
 
  protected:
   // Specific routines
@@ -118,10 +118,10 @@ class WMICOL : public COLBLK {
   WMICOL(PCOLDEF cdp, PTDB tdbp, int n);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_WMI;}
+  int  GetAmType(void) override {return TYPE_AM_WMI;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
 
  protected:
   WMICOL(void) {}              // Default constructor not to be used
@@ -143,7 +143,7 @@ class TDBWCL : public TDBCAT {
 
  protected:
   // Specific routines
-  virtual PQRYRES GetResult(PGLOBAL g);
+  virtual PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   char   *Nsp;                         // Name space

--- a/storage/connect/tabxcl.h
+++ b/storage/connect/tabxcl.h
@@ -29,11 +29,11 @@ class XCLDEF : public PRXDEF {            /* Logical table description */
 	 XCLDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "XCL";}
+  const char *GetType(void) override {return "XCL";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE mode);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE mode) override;
 
  protected:
   // Members
@@ -54,17 +54,17 @@ class TDBXCL : public TDBPRX {
   TDBXCL(PXCLDEF tdp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_XCOL;}
+  AMT   GetAmType(void) override {return TYPE_AM_XCOL;}
 
   // Methods
-	virtual void  ResetDB(void) {N = 0; Tdbp->ResetDB();}
-	virtual int   RowNumber(PGLOBAL g, bool b = FALSE);
+	void  ResetDB(void) override {N = 0; Tdbp->ResetDB();}
+	int   RowNumber(PGLOBAL g, bool b = FALSE) override;
 
   // Database routines
-	virtual PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual int   GetMaxSize(PGLOBAL g);
-  virtual bool  OpenDB(PGLOBAL g);
-  virtual int   ReadDB(PGLOBAL g);
+	PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  int   GetMaxSize(PGLOBAL g) override;
+  bool  OpenDB(PGLOBAL g) override;
+  int   ReadDB(PGLOBAL g) override;
 
  protected:
   // Members
@@ -89,9 +89,9 @@ class XCLCOL : public PRXCOL {
 
   // Methods
   using PRXCOL::Init;
-  virtual void Reset(void) {}	  // Evaluated only by TDBXCL
-  virtual void ReadColumn(PGLOBAL g);
-  virtual bool Init(PGLOBAL g, PTDB tp = NULL);
+  void Reset(void) override {}	  // Evaluated only by TDBXCL
+  void ReadColumn(PGLOBAL g) override;
+  bool Init(PGLOBAL g, PTDB tp = NULL) override;
 
  protected:
   // Default constructor not to be used

--- a/storage/connect/tabxml.h
+++ b/storage/connect/tabxml.h
@@ -25,11 +25,11 @@ class DllExport XMLDEF : public TABDEF {  /* Logical table description */
    XMLDEF(void);
 
   // Implementation
-  virtual const char *GetType(void) {return "XML";}
+  const char *GetType(void) override {return "XML";}
 
   // Methods
-  virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-  virtual PTDB GetTable(PGLOBAL g, MODE m);
+  bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+  PTDB GetTable(PGLOBAL g, MODE m) override;
 
  protected:
   // Members
@@ -72,18 +72,18 @@ class DllExport TDBXML : public TDBASE {
   TDBXML(PTDBXML tdbp);
 
   // Implementation
-  virtual AMT   GetAmType(void) {return TYPE_AM_XML;}
-  virtual PTDB  Duplicate(PGLOBAL g) {return (PTDB)new(g) TDBXML(this);}
+  AMT   GetAmType(void) override {return TYPE_AM_XML;}
+  PTDB  Duplicate(PGLOBAL g) override {return (PTDB)new(g) TDBXML(this);}
 
   // Methods
-  virtual PTDB  Clone(PTABS t);
-  virtual int   GetRecpos(void);
-  virtual int   GetProgCur(void) {return N;}
-  virtual PCSZ  GetFile(PGLOBAL g) {return Xfile;}
-  virtual void  SetFile(PGLOBAL g, PCSZ fn) {Xfile = fn;}
-  virtual void  ResetDB(void) {N = 0;}
-  virtual void  ResetSize(void) {MaxSize = -1;}
-  virtual int   RowNumber(PGLOBAL g, bool b = false);
+  PTDB  Clone(PTABS t) override;
+  int   GetRecpos(void) override;
+  int   GetProgCur(void) override {return N;}
+  PCSZ  GetFile(PGLOBAL g) override {return Xfile;}
+  void  SetFile(PGLOBAL g, PCSZ fn) override {Xfile = fn;}
+  void  ResetDB(void) override {N = 0;}
+  void  ResetSize(void) override {MaxSize = -1;}
+  int   RowNumber(PGLOBAL g, bool b = false) override;
           int   LoadTableFile(PGLOBAL g, char *filename);
           bool  Initialize(PGLOBAL g);
           bool  SetTabNode(PGLOBAL g);
@@ -91,19 +91,19 @@ class DllExport TDBXML : public TDBASE {
           bool  CheckRow(PGLOBAL g, bool b);
 
   // Database routines
-  virtual PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-  virtual PCOL  InsertSpecialColumn(PCOL colp);
+  PCOL  MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+  PCOL  InsertSpecialColumn(PCOL colp) override;
 //virtual int   GetMaxSame(PGLOBAL g) {return (Xpand) ? Limit : 1;}
-  virtual int   Cardinality(PGLOBAL g);
-  virtual int   GetMaxSize(PGLOBAL g);
+  int   Cardinality(PGLOBAL g) override;
+  int   GetMaxSize(PGLOBAL g) override;
 //virtual bool  NeedIndexing(PGLOBAL g);
-  virtual bool  OpenDB(PGLOBAL g);
-  virtual int   ReadDB(PGLOBAL g);
-  virtual int   WriteDB(PGLOBAL g);
-  virtual int   DeleteDB(PGLOBAL g, int irc);
-  virtual void  CloseDB(PGLOBAL g);
-  virtual int   CheckWrite(PGLOBAL g) {Checked = true; return 0;}
-	virtual const CHARSET_INFO *data_charset();
+  bool  OpenDB(PGLOBAL g) override;
+  int   ReadDB(PGLOBAL g) override;
+  int   WriteDB(PGLOBAL g) override;
+  int   DeleteDB(PGLOBAL g, int irc) override;
+  void  CloseDB(PGLOBAL g) override;
+  int   CheckWrite(PGLOBAL g) override {Checked = true; return 0;}
+	const CHARSET_INFO *data_charset() override;
 
  protected:
   // Members
@@ -164,14 +164,14 @@ class XMLCOL : public COLBLK {
   XMLCOL(XMLCOL *colp, PTDB tdbp);   // Constructor used in copy process
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_XML;}
-  virtual void SetTo_Val(PVAL valp) {To_Val = valp;}
+  int  GetAmType(void) override {return TYPE_AM_XML;}
+  void SetTo_Val(PVAL valp) override {To_Val = valp;}
           bool ParseXpath(PGLOBAL g, bool mode);
 
   // Methods
-  virtual bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check);
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  bool SetBuffer(PGLOBAL g, PVAL value, bool ok, bool check) override;
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
           bool AllocBuf(PGLOBAL g, bool mode);
           void AllocNodes(PGLOBAL g, PXDOC dp);
 
@@ -234,8 +234,8 @@ class XMULCOL : public XMLCOLX {
   XMULCOL(PVAL valp) {Value = valp; Mul = true;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
   }; // end of class XMULCOL
 
 /***********************************************************************/
@@ -248,8 +248,8 @@ class XPOSCOL : public XMLCOLX {
   XPOSCOL(PVAL valp) {Value = valp;}
 
   // Methods
-  virtual void ReadColumn(PGLOBAL g);
-  virtual void WriteColumn(PGLOBAL g);
+  void ReadColumn(PGLOBAL g) override;
+  void WriteColumn(PGLOBAL g) override;
   }; // end of class XPOSCOL
 
 /***********************************************************************/
@@ -262,7 +262,7 @@ class TDBXCT : public TDBCAT {
 
  protected:
   // Specific routines
-  virtual PQRYRES GetResult(PGLOBAL g);
+  PQRYRES GetResult(PGLOBAL g) override;
 
   // Members
   PTOS  Topt;

--- a/storage/connect/tabzip.h
+++ b/storage/connect/tabzip.h
@@ -26,11 +26,11 @@ public:
 	ZIPDEF(void) = default;
 
 	// Implementation
-	virtual const char *GetType(void) {return "ZIP";}
+	const char *GetType(void) override {return "ZIP";}
 
 	// Methods
-	virtual bool DefineAM(PGLOBAL g, LPCSTR am, int poff);
-	virtual PTDB GetTable(PGLOBAL g, MODE m);
+	bool DefineAM(PGLOBAL g, LPCSTR am, int poff) override;
+	PTDB GetTable(PGLOBAL g, MODE m) override;
 
 protected:
 	// Members
@@ -47,22 +47,22 @@ public:
 	TDBZIP(PZIPDEF tdp);
 
 	// Implementation
-	virtual AMT  GetAmType(void) {return TYPE_AM_ZIP;}
-	virtual PCSZ GetFile(PGLOBAL) {return zfn;}
-	virtual void SetFile(PGLOBAL, PCSZ fn) {zfn = fn;}
+	AMT  GetAmType(void) override {return TYPE_AM_ZIP;}
+	PCSZ GetFile(PGLOBAL) override {return zfn;}
+	void SetFile(PGLOBAL, PCSZ fn) override {zfn = fn;}
 
 	// Methods
-	virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-	virtual int  Cardinality(PGLOBAL g);
-	virtual int  GetMaxSize(PGLOBAL g);
-	virtual int  GetRecpos(void) {return 0;}
+	PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+	int  Cardinality(PGLOBAL g) override;
+	int  GetMaxSize(PGLOBAL g) override;
+	int  GetRecpos(void) override {return 0;}
 
 	// Database routines
-	virtual bool OpenDB(PGLOBAL g);
-	virtual int  ReadDB(PGLOBAL g);
-	virtual int  WriteDB(PGLOBAL g);
-	virtual int  DeleteDB(PGLOBAL g, int irc);
-	virtual void CloseDB(PGLOBAL g);
+	bool OpenDB(PGLOBAL g) override;
+	int  ReadDB(PGLOBAL g) override;
+	int  WriteDB(PGLOBAL g) override;
+	int  DeleteDB(PGLOBAL g, int irc) override;
+	void CloseDB(PGLOBAL g) override;
 
 protected:
 	bool open(PGLOBAL g, const char *filename);
@@ -87,10 +87,10 @@ public:
 	ZIPCOL(PCOLDEF cdp, PTDB tdbp, PCOL cprec, int i, PCSZ am = "ZIP");
 
 	// Implementation
-	virtual int  GetAmType(void) { return TYPE_AM_ZIP; }
+	int  GetAmType(void) override { return TYPE_AM_ZIP; }
 
 	// Methods
-	virtual void ReadColumn(PGLOBAL g);
+	void ReadColumn(PGLOBAL g) override;
 
 protected:
 	// Default constructor not to be used

--- a/storage/connect/valblk.h
+++ b/storage/connect/valblk.h
@@ -149,54 +149,54 @@ class TYPBLK : public VALBLK {
   TYPBLK(void *mp, int size, int type, int prec = 0, bool un = false);
 
   // Implementation
-  virtual bool   Init(PGLOBAL g, bool check);
-  virtual int    GetVlen(void) {return sizeof(TYPE);}
+  bool   Init(PGLOBAL g, bool check) override;
+  int    GetVlen(void) override {return sizeof(TYPE);}
 
-  virtual char   GetTinyValue(int n) {return (char)UnalignedRead(n);}
-  virtual uchar  GetUTinyValue(int n) {return (uchar)UnalignedRead(n);}
-  virtual short  GetShortValue(int n) {return (short)UnalignedRead(n);}
-  virtual ushort GetUShortValue(int n) {return (ushort)UnalignedRead(n);}
-  virtual int    GetIntValue(int n) {return (int)UnalignedRead(n);}
-  virtual uint   GetUIntValue(int n) {return (uint)UnalignedRead(n);}
-  virtual longlong GetBigintValue(int n) {return (longlong)UnalignedRead(n);}
-  virtual ulonglong GetUBigintValue(int n) {return (ulonglong)UnalignedRead(n);}
-  virtual double GetFloatValue(int n) {return (double)UnalignedRead(n);}
-  virtual char  *GetCharString(char *p, int n);
-  virtual void   Reset(int n) {UnalignedWrite(n, 0);}
+  char   GetTinyValue(int n) override {return (char)UnalignedRead(n);}
+  uchar  GetUTinyValue(int n) override {return (uchar)UnalignedRead(n);}
+  short  GetShortValue(int n) override {return (short)UnalignedRead(n);}
+  ushort GetUShortValue(int n) override {return (ushort)UnalignedRead(n);}
+  int    GetIntValue(int n) override {return (int)UnalignedRead(n);}
+  uint   GetUIntValue(int n) override {return (uint)UnalignedRead(n);}
+  longlong GetBigintValue(int n) override {return (longlong)UnalignedRead(n);}
+  ulonglong GetUBigintValue(int n) override {return (ulonglong)UnalignedRead(n);}
+  double GetFloatValue(int n) override {return (double)UnalignedRead(n);}
+  char  *GetCharString(char *p, int n) override;
+  void   Reset(int n) override {UnalignedWrite(n, 0);}
 
   // Methods
   using VALBLK::SetValue;
-  virtual void   SetValue(PCSZ sp, int n);
-  virtual void   SetValue(const char *sp, uint len, int n);
-  virtual void   SetValue(short sval, int n)
+  void   SetValue(PCSZ sp, int n) override;
+  void   SetValue(const char *sp, uint len, int n) override;
+  void   SetValue(short sval, int n) override
                   {UnalignedWrite(n, (TYPE)sval); SetNull(n, false);}
-  virtual void   SetValue(ushort sval, int n)
+  void   SetValue(ushort sval, int n) override
                   {UnalignedWrite(n, (TYPE)sval); SetNull(n, false);}
-  virtual void   SetValue(int lval, int n)
+  void   SetValue(int lval, int n) override
                   {UnalignedWrite(n, (TYPE)lval); SetNull(n, false);}
-  virtual void   SetValue(uint lval, int n)
+  void   SetValue(uint lval, int n) override
                   {UnalignedWrite(n, (TYPE)lval); SetNull(n, false);}
-  virtual void   SetValue(longlong lval, int n)
+  void   SetValue(longlong lval, int n) override
                   {UnalignedWrite(n, (TYPE)lval); SetNull(n, false);}
-  virtual void   SetValue(ulonglong lval, int n)
+  void   SetValue(ulonglong lval, int n) override
                   {UnalignedWrite(n, (TYPE)lval); SetNull(n, false);}
-  virtual void   SetValue(double fval, int n)
+  void   SetValue(double fval, int n) override
                   {UnalignedWrite(n, (TYPE)fval); SetNull(n, false);}
-  virtual void   SetValue(char cval, int n)
+  void   SetValue(char cval, int n) override
                   {UnalignedWrite(n, (TYPE)cval); SetNull(n, false);}
-  virtual void   SetValue(uchar cval, int n)
+  void   SetValue(uchar cval, int n) override
                   {UnalignedWrite(n, (TYPE)cval); SetNull(n, false);}
-  virtual void   SetValue(PVAL valp, int n);
-  virtual void   SetValue(PVBLK pv, int n1, int n2);
-  virtual void   SetMin(PVAL valp, int n);
-  virtual void   SetMax(PVAL valp, int n);
-  virtual void   Move(int i, int j);
-  virtual int    CompVal(PVAL vp, int n);
-  virtual int    CompVal(int i1, int i2);
-  virtual void  *GetValPtr(int n);
-  virtual void  *GetValPtrEx(int n);
-  virtual int    Find(PVAL vp);
-  virtual int    GetMaxLength(void);
+  void   SetValue(PVAL valp, int n) override;
+  void   SetValue(PVBLK pv, int n1, int n2) override;
+  void   SetMin(PVAL valp, int n) override;
+  void   SetMax(PVAL valp, int n) override;
+  void   Move(int i, int j) override;
+  int    CompVal(PVAL vp, int n) override;
+  int    CompVal(int i1, int i2) override;
+  void  *GetValPtr(int n) override;
+  void  *GetValPtrEx(int n) override;
+  int    Find(PVAL vp) override;
+  int    GetMaxLength(void) override;
 
  protected:
   // Specialized functions
@@ -229,38 +229,38 @@ class CHRBLK : public VALBLK {
   CHRBLK(void *mp, int size, int type, int len, int prec, bool b);
 
   // Implementation
-  virtual bool   Init(PGLOBAL g, bool check);
-  virtual int    GetVlen(void) {return Long;}
-  virtual PSZ    GetCharValue(int n);
-  virtual char   GetTinyValue(int n);
-  virtual uchar  GetUTinyValue(int n);
-  virtual short  GetShortValue(int n);
-  virtual ushort GetUShortValue(int n);
-  virtual int    GetIntValue(int n);
-  virtual uint   GetUIntValue(int n);
-  virtual longlong GetBigintValue(int n);
-  virtual ulonglong GetUBigintValue(int n);
-  virtual double GetFloatValue(int n);
-  virtual char  *GetCharString(char *p, int n);
-  virtual void   Reset(int n);
-  virtual void   SetPrec(int p) {Ci = (p != 0);}
-  virtual bool   IsCi(void) {return Ci;}
+  bool   Init(PGLOBAL g, bool check) override;
+  int    GetVlen(void) override {return Long;}
+  PSZ    GetCharValue(int n) override;
+  char   GetTinyValue(int n) override;
+  uchar  GetUTinyValue(int n) override;
+  short  GetShortValue(int n) override;
+  ushort GetUShortValue(int n) override;
+  int    GetIntValue(int n) override;
+  uint   GetUIntValue(int n) override;
+  longlong GetBigintValue(int n) override;
+  ulonglong GetUBigintValue(int n) override;
+  double GetFloatValue(int n) override;
+  char  *GetCharString(char *p, int n) override;
+  void   Reset(int n) override;
+  void   SetPrec(int p) override {Ci = (p != 0);}
+  bool   IsCi(void) override {return Ci;}
 
   // Methods
   using VALBLK::SetValue;
-  virtual void   SetValue(PCSZ sp, int n);
-  virtual void   SetValue(const char *sp, uint len, int n);
-  virtual void   SetValue(PVAL valp, int n);
-  virtual void   SetValue(PVBLK pv, int n1, int n2);
-  virtual void   SetMin(PVAL valp, int n);
-  virtual void   SetMax(PVAL valp, int n);
-  virtual void   Move(int i, int j);
-  virtual int    CompVal(PVAL vp, int n);
-  virtual int    CompVal(int i1, int i2);
-  virtual void  *GetValPtr(int n);
-  virtual void  *GetValPtrEx(int n);
-  virtual int    Find(PVAL vp);
-  virtual int    GetMaxLength(void);
+  void   SetValue(PCSZ sp, int n) override;
+  void   SetValue(const char *sp, uint len, int n) override;
+  void   SetValue(PVAL valp, int n) override;
+  void   SetValue(PVBLK pv, int n1, int n2) override;
+  void   SetMin(PVAL valp, int n) override;
+  void   SetMax(PVAL valp, int n) override;
+  void   Move(int i, int j) override;
+  int    CompVal(PVAL vp, int n) override;
+  int    CompVal(int i1, int i2) override;
+  void  *GetValPtr(int n) override;
+  void  *GetValPtrEx(int n) override;
+  int    Find(PVAL vp) override;
+  int    GetMaxLength(void) override;
 
  protected:
   // Members
@@ -282,39 +282,39 @@ class STRBLK : public VALBLK {
   STRBLK(PGLOBAL g, void *mp, int size, int type);
 
   // Implementation
-  virtual void   SetNull(int n, bool b) {if (b) {Strp[n] = NULL;}}
-  virtual bool   IsNull(int n) {return Strp[n] == NULL;}
-  virtual void   SetNullable(bool) {}      // Always nullable
-  virtual bool   Init(PGLOBAL g, bool check);
-  virtual int    GetVlen(void) {return sizeof(PSZ);}
-  virtual PSZ    GetCharValue(int n) {return Strp[n];}
-  virtual char   GetTinyValue(int n);
-  virtual uchar  GetUTinyValue(int n);
-  virtual short  GetShortValue(int n);
-  virtual ushort GetUShortValue(int n);
-  virtual int    GetIntValue(int n);
-  virtual uint   GetUIntValue(int n);
-  virtual longlong GetBigintValue(int n);
-  virtual ulonglong GetUBigintValue(int n);
-  virtual double GetFloatValue(int n) {return atof(Strp[n]);}
-  virtual char  *GetCharString(char *, int n) {return Strp[n];}
-  virtual void   Reset(int n) {Strp[n] = NULL;}
+  void   SetNull(int n, bool b) override {if (b) {Strp[n] = NULL;}}
+  bool   IsNull(int n) override {return Strp[n] == NULL;}
+  void   SetNullable(bool) override {}      // Always nullable
+  bool   Init(PGLOBAL g, bool check) override;
+  int    GetVlen(void) override {return sizeof(PSZ);}
+  PSZ    GetCharValue(int n) override {return Strp[n];}
+  char   GetTinyValue(int n) override;
+  uchar  GetUTinyValue(int n) override;
+  short  GetShortValue(int n) override;
+  ushort GetUShortValue(int n) override;
+  int    GetIntValue(int n) override;
+  uint   GetUIntValue(int n) override;
+  longlong GetBigintValue(int n) override;
+  ulonglong GetUBigintValue(int n) override;
+  double GetFloatValue(int n) override {return atof(Strp[n]);}
+  char  *GetCharString(char *, int n) override {return Strp[n];}
+  void   Reset(int n) override {Strp[n] = NULL;}
 
   // Methods
   using VALBLK::SetValue;
-  virtual void   SetValue(PCSZ sp, int n);
-  virtual void   SetValue(const char *sp, uint len, int n);
-  virtual void   SetValue(PVAL valp, int n);
-  virtual void   SetValue(PVBLK pv, int n1, int n2);
-  virtual void   SetMin(PVAL valp, int n);
-  virtual void   SetMax(PVAL valp, int n);
-  virtual void   Move(int i, int j);
-  virtual int    CompVal(PVAL vp, int n);
-  virtual int    CompVal(int i1, int i2);
-  virtual void  *GetValPtr(int n);
-  virtual void  *GetValPtrEx(int n);
-  virtual int    Find(PVAL vp);
-  virtual int    GetMaxLength(void);
+  void   SetValue(PCSZ sp, int n) override;
+  void   SetValue(const char *sp, uint len, int n) override;
+  void   SetValue(PVAL valp, int n) override;
+  void   SetValue(PVBLK pv, int n1, int n2) override;
+  void   SetMin(PVAL valp, int n) override;
+  void   SetMax(PVAL valp, int n) override;
+  void   Move(int i, int j) override;
+  int    CompVal(PVAL vp, int n) override;
+  int    CompVal(int i1, int i2) override;
+  void  *GetValPtr(int n) override;
+  void  *GetValPtrEx(int n) override;
+  int    Find(PVAL vp) override;
+  int    GetMaxLength(void) override;
 
   // Specific
           void   SetSorted(bool b) {Sorted = b;}
@@ -334,12 +334,12 @@ class DATBLK : public TYPBLK<int> {
   DATBLK(void *mp, int size);
 
   // Implementation
-  virtual bool  SetFormat(PGLOBAL g, PCSZ fmt, int len, int year = 0);
-  virtual char *GetCharString(char *p, int n);
+  bool  SetFormat(PGLOBAL g, PCSZ fmt, int len, int year = 0) override;
+  char *GetCharString(char *p, int n) override;
 
   // Methods
   using TYPBLK<int>::SetValue;
-  virtual void  SetValue(PCSZ sp, int n);
+  void  SetValue(PCSZ sp, int n) override;
 
  protected:
   // Members
@@ -364,8 +364,8 @@ class PTRBLK : public STRBLK {
   // Methods
   using STRBLK::SetValue;
   using STRBLK::CompVal;
-  virtual void   SetValue(PCSZ p, int n) {Strp[n] = (char*)p;}
-  virtual int    CompVal(int i1, int i2);
+  void   SetValue(PCSZ p, int n) override {Strp[n] = (char*)p;}
+  int    CompVal(int i1, int i2) override;
 
  protected:
   // Members

--- a/storage/connect/value.h
+++ b/storage/connect/value.h
@@ -123,8 +123,8 @@ public:
   virtual bool   IsEqual(PVAL vp, bool chktype) = 0;
   virtual bool   Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op);
   virtual bool   FormatValue(PVAL vp, PCSZ fmt) = 0;
-	virtual void   Printf(PGLOBAL g, FILE *, uint);
-	virtual void   Prints(PGLOBAL g, char *ps, uint z);
+	void   Printf(PGLOBAL g, FILE *, uint) override;
+	void   Prints(PGLOBAL g, char *ps, uint z) override;
 
 	/**
 	Set value from a non-aligned in-memory value in the machine byte order.
@@ -194,48 +194,48 @@ class DllExport TYPVAL : public VALUE {
   TYPVAL(TYPE n, int type, int prec = 0, bool un = false);
 
   // Implementation
-  virtual bool   IsTypeNum(void) {return true;}
-  virtual bool   IsZero(void) {return Tval == 0;}
-  virtual void   Reset(void) {Tval = 0;}
-  virtual int    GetValLen(void);
-  virtual int    GetValPrec() {return Prec;}
-  virtual int    GetSize(void) {return sizeof(TYPE);}
+  bool   IsTypeNum(void) override {return true;}
+  bool   IsZero(void) override {return Tval == 0;}
+  void   Reset(void) override {Tval = 0;}
+  int    GetValLen(void) override;
+  int    GetValPrec() override {return Prec;}
+  int    GetSize(void) override {return sizeof(TYPE);}
 //virtual PSZ    GetCharValue(void) {return VALUE::GetCharValue();}
-  virtual char   GetTinyValue(void) {return (char)Tval;}
-  virtual uchar  GetUTinyValue(void) {return (uchar)Tval;}
-  virtual short  GetShortValue(void) {return (short)Tval;}
-  virtual ushort GetUShortValue(void) {return (ushort)Tval;}
-  virtual int    GetIntValue(void) {return (int)Tval;}
-  virtual uint   GetUIntValue(void) {return (uint)Tval;}
-  virtual longlong GetBigintValue(void) {return (longlong)Tval;}
-  virtual ulonglong GetUBigintValue(void) {return (ulonglong)Tval;}
-  virtual double GetFloatValue(void) {return (double)Tval;}
-  virtual void  *GetTo_Val(void) {return &Tval;}
+  char   GetTinyValue(void) override {return (char)Tval;}
+  uchar  GetUTinyValue(void) override {return (uchar)Tval;}
+  short  GetShortValue(void) override {return (short)Tval;}
+  ushort GetUShortValue(void) override {return (ushort)Tval;}
+  int    GetIntValue(void) override {return (int)Tval;}
+  uint   GetUIntValue(void) override {return (uint)Tval;}
+  longlong GetBigintValue(void) override {return (longlong)Tval;}
+  ulonglong GetUBigintValue(void) override {return (ulonglong)Tval;}
+  double GetFloatValue(void) override {return (double)Tval;}
+  void  *GetTo_Val(void) override {return &Tval;}
 
   // Methods
-  virtual bool   SetValue_pval(PVAL valp, bool chktype);
-  virtual bool   SetValue_char(const char *p, int n);
-  virtual void   SetValue_psz(PCSZ s);
-  virtual void   SetValue_bool(bool b) {Tval = (b) ? 1 : 0;}
-  virtual int    CompareValue(PVAL vp);
-  virtual void   SetValue(char c) {Tval = (TYPE)c; Null = false;}
-  virtual void   SetValue(uchar c) {Tval = (TYPE)c; Null = false;}
-  virtual void   SetValue(short i) {Tval = (TYPE)i; Null = false;}
-  virtual void   SetValue(ushort i) {Tval = (TYPE)i; Null = false;}
-  virtual void   SetValue(int n) {Tval = (TYPE)n; Null = false;}
-  virtual void   SetValue(uint n) {Tval = (TYPE)n; Null = false;}
-  virtual void   SetValue(longlong n) {Tval = (TYPE)n; Null = false;}
-  virtual void   SetValue(ulonglong n) {Tval = (TYPE)n; Null = false;}
-  virtual void   SetValue(double f) {Tval = (TYPE)f; Null = false;}
-  virtual void   SetValue_pvblk(PVBLK blk, int n);
-  virtual void   SetBinValue(void *p);
-  virtual bool   GetBinValue(void *buf, int buflen, bool go);
-  virtual int    ShowValue(char *buf, int len);
-  virtual char  *GetCharString(char *p);
-  virtual bool   IsEqual(PVAL vp, bool chktype);
-  virtual bool   Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op);
-  virtual bool   SetConstFormat(PGLOBAL, FORMAT&);
-  virtual bool   FormatValue(PVAL vp, PCSZ fmt);
+  bool   SetValue_pval(PVAL valp, bool chktype) override;
+  bool   SetValue_char(const char *p, int n) override;
+  void   SetValue_psz(PCSZ s) override;
+  void   SetValue_bool(bool b) override {Tval = (b) ? 1 : 0;}
+  int    CompareValue(PVAL vp) override;
+  void   SetValue(char c) override {Tval = (TYPE)c; Null = false;}
+  void   SetValue(uchar c) override {Tval = (TYPE)c; Null = false;}
+  void   SetValue(short i) override {Tval = (TYPE)i; Null = false;}
+  void   SetValue(ushort i) override {Tval = (TYPE)i; Null = false;}
+  void   SetValue(int n) override {Tval = (TYPE)n; Null = false;}
+  void   SetValue(uint n) override {Tval = (TYPE)n; Null = false;}
+  void   SetValue(longlong n) override {Tval = (TYPE)n; Null = false;}
+  void   SetValue(ulonglong n) override {Tval = (TYPE)n; Null = false;}
+  void   SetValue(double f) override {Tval = (TYPE)f; Null = false;}
+  void   SetValue_pvblk(PVBLK blk, int n) override;
+  void   SetBinValue(void *p) override;
+  bool   GetBinValue(void *buf, int buflen, bool go) override;
+  int    ShowValue(char *buf, int len) override;
+  char  *GetCharString(char *p) override;
+  bool   IsEqual(PVAL vp, bool chktype) override;
+  bool   Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op) override;
+  bool   SetConstFormat(PGLOBAL, FORMAT&) override;
+  bool   FormatValue(PVAL vp, PCSZ fmt) override;
 
  protected:
   static  TYPE   MinMaxVal(bool b);
@@ -268,49 +268,49 @@ public:
   TYPVAL(PGLOBAL g, PSZ s, int n, int c);
 
   // Implementation
-  virtual bool   IsTypeNum(void) {return false;}
-  virtual bool   IsZero(void) {return *Strp == 0;}
-  virtual void   Reset(void) {*Strp = 0;}
-  virtual int    GetValLen(void) {return Len;};
-  virtual int    GetValPrec() {return (Ci) ? 1 : 0;}
-  virtual int    GetSize(void) {return (Strp) ? (int)strlen(Strp) : 0;}
-  virtual PSZ    GetCharValue(void) {return Strp;}
-  virtual char   GetTinyValue(void);
-  virtual uchar  GetUTinyValue(void);
-  virtual short  GetShortValue(void);
-  virtual ushort GetUShortValue(void);
-  virtual int    GetIntValue(void);
-  virtual uint   GetUIntValue(void);
-  virtual longlong GetBigintValue(void);
-  virtual ulonglong GetUBigintValue(void);
-  virtual double GetFloatValue(void) {return atof(Strp);}
-  virtual void  *GetTo_Val(void) {return Strp;}
-  virtual void   SetPrec(int prec) {Ci = prec != 0;}
+  bool   IsTypeNum(void) override {return false;}
+  bool   IsZero(void) override {return *Strp == 0;}
+  void   Reset(void) override {*Strp = 0;}
+  int    GetValLen(void) override {return Len;};
+  int    GetValPrec() override {return (Ci) ? 1 : 0;}
+  int    GetSize(void) override {return (Strp) ? (int)strlen(Strp) : 0;}
+  PSZ    GetCharValue(void) override {return Strp;}
+  char   GetTinyValue(void) override;
+  uchar  GetUTinyValue(void) override;
+  short  GetShortValue(void) override;
+  ushort GetUShortValue(void) override;
+  int    GetIntValue(void) override;
+  uint   GetUIntValue(void) override;
+  longlong GetBigintValue(void) override;
+  ulonglong GetUBigintValue(void) override;
+  double GetFloatValue(void) override {return atof(Strp);}
+  void  *GetTo_Val(void) override {return Strp;}
+  void   SetPrec(int prec) override {Ci = prec != 0;}
 
   // Methods
-  virtual bool   SetValue_pval(PVAL valp, bool chktype);
-  virtual bool   SetValue_char(const char *p, int n);
-  virtual void   SetValue_psz(PCSZ s);
-  virtual void   SetValue_pvblk(PVBLK blk, int n);
-  virtual void   SetValue(char c);
-  virtual void   SetValue(uchar c);
-  virtual void   SetValue(short i);
-  virtual void   SetValue(ushort i);
-  virtual void   SetValue(int n);
-  virtual void   SetValue(uint n);
-  virtual void   SetValue(longlong n);
-  virtual void   SetValue(ulonglong n);
-  virtual void   SetValue(double f);
-  virtual void   SetBinValue(void *p);
-  virtual int    CompareValue(PVAL vp);
-  virtual bool   GetBinValue(void *buf, int buflen, bool go);
-  virtual int    ShowValue(char *buf, int len);
-  virtual char  *GetCharString(char *p);
-  virtual bool   IsEqual(PVAL vp, bool chktype);
-  virtual bool   Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op);
-  virtual bool   FormatValue(PVAL vp, PCSZ fmt);
-  virtual bool   SetConstFormat(PGLOBAL, FORMAT&);
-	virtual void   Prints(PGLOBAL g, char *ps, uint z);
+  bool   SetValue_pval(PVAL valp, bool chktype) override;
+  bool   SetValue_char(const char *p, int n) override;
+  void   SetValue_psz(PCSZ s) override;
+  void   SetValue_pvblk(PVBLK blk, int n) override;
+  void   SetValue(char c) override;
+  void   SetValue(uchar c) override;
+  void   SetValue(short i) override;
+  void   SetValue(ushort i) override;
+  void   SetValue(int n) override;
+  void   SetValue(uint n) override;
+  void   SetValue(longlong n) override;
+  void   SetValue(ulonglong n) override;
+  void   SetValue(double f) override;
+  void   SetBinValue(void *p) override;
+  int    CompareValue(PVAL vp) override;
+  bool   GetBinValue(void *buf, int buflen, bool go) override;
+  int    ShowValue(char *buf, int len) override;
+  char  *GetCharString(char *p) override;
+  bool   IsEqual(PVAL vp, bool chktype) override;
+  bool   Compute(PGLOBAL g, PVAL *vp, int np, OPVAL op) override;
+  bool   FormatValue(PVAL vp, PCSZ fmt) override;
+  bool   SetConstFormat(PGLOBAL, FORMAT&) override;
+	void   Prints(PGLOBAL g, char *ps, uint z) override;
 
  protected:
   // Members
@@ -329,16 +329,16 @@ class DllExport DECVAL: public TYPVAL<PSZ> {
   DECVAL(PGLOBAL g, PSZ s, int n, int prec, bool uns);
 
   // Implementation
-  virtual bool   IsTypeNum(void) {return true;}
-  virtual bool   IsZero(void);
-  virtual void   Reset(void);
-  virtual int    GetValPrec() {return Prec;}
+  bool   IsTypeNum(void) override {return true;}
+  bool   IsZero(void) override;
+  void   Reset(void) override;
+  int    GetValPrec() override {return Prec;}
 
   // Methods
-  virtual bool   GetBinValue(void *buf, int buflen, bool go);
-  virtual int    ShowValue(char *buf, int len);
-  virtual bool   IsEqual(PVAL vp, bool chktype);
-  virtual int    CompareValue(PVAL vp);
+  bool   GetBinValue(void *buf, int buflen, bool go) override;
+  int    ShowValue(char *buf, int len) override;
+  bool   IsEqual(PVAL vp, bool chktype) override;
+  int    CompareValue(PVAL vp) override;
 
  protected:
   // Members
@@ -355,47 +355,47 @@ public:
   BINVAL(PGLOBAL g, void *p, int cl, int n);
 
   // Implementation
-  virtual bool   IsTypeNum(void) {return false;}
-  virtual bool   IsZero(void);
-  virtual void   Reset(void);
-  virtual int    GetValLen(void) {return Clen;};
-  virtual int    GetValPrec() {return 0;}
-  virtual int    GetSize(void) {return Len;}
-  virtual PSZ    GetCharValue(void) {return (PSZ)Binp;}
-  virtual char   GetTinyValue(void);
-  virtual uchar  GetUTinyValue(void);
-  virtual short  GetShortValue(void);
-  virtual ushort GetUShortValue(void);
-  virtual int    GetIntValue(void);
-  virtual uint   GetUIntValue(void);
-  virtual longlong GetBigintValue(void);
-  virtual ulonglong GetUBigintValue(void);
-  virtual double GetFloatValue(void);
-  virtual void  *GetTo_Val(void) {return Binp;}
+  bool   IsTypeNum(void) override {return false;}
+  bool   IsZero(void) override;
+  void   Reset(void) override;
+  int    GetValLen(void) override {return Clen;};
+  int    GetValPrec() override {return 0;}
+  int    GetSize(void) override {return Len;}
+  PSZ    GetCharValue(void) override {return (PSZ)Binp;}
+  char   GetTinyValue(void) override;
+  uchar  GetUTinyValue(void) override;
+  short  GetShortValue(void) override;
+  ushort GetUShortValue(void) override;
+  int    GetIntValue(void) override;
+  uint   GetUIntValue(void) override;
+  longlong GetBigintValue(void) override;
+  ulonglong GetUBigintValue(void) override;
+  double GetFloatValue(void) override;
+  void  *GetTo_Val(void) override {return Binp;}
 
   // Methods
-  virtual bool   SetValue_pval(PVAL valp, bool chktype);
-  virtual bool   SetValue_char(const char *p, int n);
-  virtual void   SetValue_psz(PCSZ s);
-  virtual void   SetValue_pvblk(PVBLK blk, int n);
-  virtual void   SetValue(char c);
-  virtual void   SetValue(uchar c);
-  virtual void   SetValue(short i);
-  virtual void   SetValue(ushort i);
-  virtual void   SetValue(int n);
-  virtual void   SetValue(uint n);
-  virtual void   SetValue(longlong n);
-  virtual void   SetValue(ulonglong n);
-  virtual void   SetValue(double f);
-  virtual void   SetBinValue(void *p);
+  bool   SetValue_pval(PVAL valp, bool chktype) override;
+  bool   SetValue_char(const char *p, int n) override;
+  void   SetValue_psz(PCSZ s) override;
+  void   SetValue_pvblk(PVBLK blk, int n) override;
+  void   SetValue(char c) override;
+  void   SetValue(uchar c) override;
+  void   SetValue(short i) override;
+  void   SetValue(ushort i) override;
+  void   SetValue(int n) override;
+  void   SetValue(uint n) override;
+  void   SetValue(longlong n) override;
+  void   SetValue(ulonglong n) override;
+  void   SetValue(double f) override;
+  void   SetBinValue(void *p) override;
 	virtual void   SetBinValue(void* p, ulong len);
-	virtual bool   GetBinValue(void *buf, int buflen, bool go);
-  virtual int    CompareValue(PVAL) {assert(false); return 0;}
-  virtual int    ShowValue(char *buf, int len);
-  virtual char  *GetCharString(char *p);
-  virtual bool   IsEqual(PVAL vp, bool chktype);
-  virtual bool   FormatValue(PVAL vp, PCSZ fmt);
-  virtual bool   SetConstFormat(PGLOBAL, FORMAT&);
+	bool   GetBinValue(void *buf, int buflen, bool go) override;
+  int    CompareValue(PVAL) override {assert(false); return 0;}
+  int    ShowValue(char *buf, int len) override;
+  char  *GetCharString(char *p) override;
+  bool   IsEqual(PVAL vp, bool chktype) override;
+  bool   FormatValue(PVAL vp, PCSZ fmt) override;
+  bool   SetConstFormat(PGLOBAL, FORMAT&) override;
 
  protected:
   // Members
@@ -415,15 +415,15 @@ class DllExport DTVAL : public TYPVAL<int> {
   using TYPVAL<int>::SetValue;
 
   // Implementation
-  virtual bool   SetValue_pval(PVAL valp, bool chktype);
-  virtual bool   SetValue_char(const char *p, int n);
-  virtual void   SetValue_psz(PCSZ s);
-  virtual void   SetValue_pvblk(PVBLK blk, int n);
-  virtual void   SetValue(int n);
-  virtual PSZ    GetCharValue(void) { return Sdate; }
-	virtual char  *GetCharString(char *p);
-  virtual int    ShowValue(char *buf, int len);
-  virtual bool   FormatValue(PVAL vp, PCSZ fmt);
+  bool   SetValue_pval(PVAL valp, bool chktype) override;
+  bool   SetValue_char(const char *p, int n) override;
+  void   SetValue_psz(PCSZ s) override;
+  void   SetValue_pvblk(PVBLK blk, int n) override;
+  void   SetValue(int n) override;
+  PSZ    GetCharValue(void) override { return Sdate; }
+	char  *GetCharString(char *p) override;
+  int    ShowValue(char *buf, int len) override;
+  bool   FormatValue(PVAL vp, PCSZ fmt) override;
           bool   SetFormat(PGLOBAL g, PCSZ fmt, int len, int year = 0);
           bool   SetFormat(PGLOBAL g, PVAL valp);
           bool   IsFormatted(void) {return Pdtp != NULL;}

--- a/storage/connect/xindex.h
+++ b/storage/connect/xindex.h
@@ -200,8 +200,8 @@ class DllExport XXBASE : public CSORT, public BLOCK {
           void FreeIndex(void) {PlgDBfree(Index);}
 
   // Methods
-  virtual void Printf(PGLOBAL g, FILE *f, uint n);
-  virtual void Prints(PGLOBAL g, char *ps, uint z);
+  void Printf(PGLOBAL g, FILE *f, uint n) override;
+  void Prints(PGLOBAL g, char *ps, uint z) override;
   virtual bool Init(PGLOBAL g) = 0;
   virtual bool Make(PGLOBAL g, PIXDEF sxp) = 0;
 #if defined(XMAP)
@@ -214,7 +214,7 @@ class DllExport XXBASE : public CSORT, public BLOCK {
   virtual int  FastFind(void) = 0;
   virtual bool Reorder(PGLOBAL) {return true;}
   virtual int  Range(PGLOBAL, int = 0, bool = true) {return -1;} // Means error
-  virtual int  Qcompare(int *, int *) = 0;
+  int  Qcompare(int *, int *) override = 0;
   virtual int  GroupSize(void) {return 1;}
   virtual void Close(void) = 0;
 
@@ -254,32 +254,32 @@ class DllExport XINDEX : public XXBASE {
                        PCOL *cp, PXOB *xp = NULL, int k = 0);
 
   // Implementation
-  virtual IDT  GetType(void) {return TYPE_IDX_INDX;}
-  virtual bool IsMul(void) {return (Nval < Nk) ? true : Mul;}
+  IDT  GetType(void) override {return TYPE_IDX_INDX;}
+  bool IsMul(void) override {return (Nval < Nk) ? true : Mul;}
 //virtual bool HaveSame(void) {return Op == OP_SAME;}
-  virtual int  GetCurPos(void) {return (Pex) ? Pex[Cur_K] : Cur_K;}
-  virtual void SetNval(int n) {Nval = n;}
+  int  GetCurPos(void) override {return (Pex) ? Pex[Cur_K] : Cur_K;}
+  void SetNval(int n) override {Nval = n;}
           int  GetMaxSame(void) {return MaxSame;}
 
   // Methods
-  virtual void Reset(void);
-  virtual bool Init(PGLOBAL g);
+  void Reset(void) override;
+  bool Init(PGLOBAL g) override;
 #if defined(XMAP)
-  virtual bool MapInit(PGLOBAL g);
+  bool MapInit(PGLOBAL g) override;
 #endif   // XMAP
-  virtual int  Qcompare(int *, int *);
-  virtual int  Fetch(PGLOBAL g);
-  virtual int  FastFind(void);
-  virtual int  GroupSize(void);
-  virtual int  Range(PGLOBAL g, int limit = 0, bool incl = true);
-  virtual int  MaxRange(void) {return MaxSame;}
+  int  Qcompare(int *, int *) override;
+  int  Fetch(PGLOBAL g) override;
+  int  FastFind(void) override;
+  int  GroupSize(void) override;
+  int  Range(PGLOBAL g, int limit = 0, bool incl = true) override;
+  int  MaxRange(void) override {return MaxSame;}
   virtual int  ColMaxSame(PXCOL kp);
-  virtual void Close(void);
-  virtual bool NextVal(bool eq);
-  virtual bool PrevVal(void);
-  virtual bool Make(PGLOBAL g, PIXDEF sxp);
+  void Close(void) override;
+  bool NextVal(bool eq) override;
+  bool PrevVal(void) override;
+  bool Make(PGLOBAL g, PIXDEF sxp) override;
   virtual bool SaveIndex(PGLOBAL g, PIXDEF sxp);
-  virtual bool Reorder(PGLOBAL g);
+  bool Reorder(PGLOBAL g) override;
           bool GetAllSizes(PGLOBAL g,/* int &ndif,*/ int &numk);
 
  protected:
@@ -310,16 +310,16 @@ class DllExport XINDXS : public XINDEX {
   XINDXS(PTDBDOS tdbp, PIXDEF xdp, PXLOAD pxp, PCOL *cp, PXOB *xp = NULL);
 
   // Implementation
-  virtual void SetNval(int n) {assert(n == 1);}
+  void SetNval(int n) override {assert(n == 1);}
 
   // Methods
-  virtual int  Qcompare(int *, int *);
-  virtual int  Fetch(PGLOBAL g);
-  virtual int  FastFind(void);
-  virtual bool NextVal(bool eq);
-  virtual bool PrevVal(void);
-  virtual int  Range(PGLOBAL g, int limit = 0, bool incl = true);
-  virtual int  GroupSize(void);
+  int  Qcompare(int *, int *) override;
+  int  Fetch(PGLOBAL g) override;
+  int  FastFind(void) override;
+  bool NextVal(bool eq) override;
+  bool PrevVal(void) override;
+  int  Range(PGLOBAL g, int limit = 0, bool incl = true) override;
+  int  GroupSize(void) override;
 
  protected:
   // Members
@@ -367,14 +367,14 @@ class DllExport XFILE : public XLOAD {
   XFILE(void);
 
   // Methods
-  virtual bool  Open(PGLOBAL g, char *filename, int id, MODE mode);
-  virtual bool  Seek(PGLOBAL g, int low, int high, int origin);
-  virtual bool  Read(PGLOBAL g, void *buf, int n, int size);
-  virtual int   Write(PGLOBAL g, void *buf, int n, int size, bool& rc);
-  virtual void  Close(char *fn, int id);
-  virtual void  Close(void);
+  bool  Open(PGLOBAL g, char *filename, int id, MODE mode) override;
+  bool  Seek(PGLOBAL g, int low, int high, int origin) override;
+  bool  Read(PGLOBAL g, void *buf, int n, int size) override;
+  int   Write(PGLOBAL g, void *buf, int n, int size, bool& rc) override;
+  void  Close(char *fn, int id) override;
+  void  Close(void) override;
 #if defined(XMAP)
-  virtual void *FileView(PGLOBAL g, char *fn);
+  void *FileView(PGLOBAL g, char *fn) override;
 #endif   // XMAP
 
  protected:
@@ -395,13 +395,13 @@ class DllExport XHUGE : public XLOAD {
 
   // Methods
   using XLOAD::Close;
-  virtual bool  Open(PGLOBAL g, char *filename, int id, MODE mode);
-  virtual bool  Seek(PGLOBAL g, int low, int high, int origin);
-  virtual bool  Read(PGLOBAL g, void *buf, int n, int size);
-  virtual int   Write(PGLOBAL g, void *buf, int n, int size, bool& rc);
-  virtual void  Close(char *fn, int id);
+  bool  Open(PGLOBAL g, char *filename, int id, MODE mode) override;
+  bool  Seek(PGLOBAL g, int low, int high, int origin) override;
+  bool  Read(PGLOBAL g, void *buf, int n, int size) override;
+  int   Write(PGLOBAL g, void *buf, int n, int size, bool& rc) override;
+  void  Close(char *fn, int id) override;
 #if defined(XMAP)
-  virtual void *FileView(PGLOBAL g, char *fn);
+  void *FileView(PGLOBAL g, char *fn) override;
 #endif   // XMAP
 
  protected:
@@ -418,21 +418,21 @@ class DllExport XXROW : public XXBASE {
   XXROW(PTDBDOS tbxp);
 
   // Implementation
-  virtual IDT  GetType(void) {return TYPE_IDX_XROW;}
-  virtual void Reset(void);
+  IDT  GetType(void) override {return TYPE_IDX_XROW;}
+  void Reset(void) override;
 
   // Methods
-  virtual bool Init(PGLOBAL g);
+  bool Init(PGLOBAL g) override;
 #if defined(XMAP)
-  virtual bool MapInit(PGLOBAL) {return true;}
+  bool MapInit(PGLOBAL) override {return true;}
 #endif   // XMAP
-  virtual int  Fetch(PGLOBAL g);
-  virtual int  FastFind(void);
-  virtual int  MaxRange(void) {return 1;}
-  virtual int  Range(PGLOBAL g, int limit = 0, bool incl = true);
-  virtual int  Qcompare(int *, int *) {assert(false); return 0;}
-  virtual bool Make(PGLOBAL, PIXDEF) {return false;}
-  virtual void Close(void) {}
+  int  Fetch(PGLOBAL g) override;
+  int  FastFind(void) override;
+  int  MaxRange(void) override {return 1;}
+  int  Range(PGLOBAL g, int limit = 0, bool incl = true) override;
+  int  Qcompare(int *, int *) override {assert(false); return 0;}
+  bool Make(PGLOBAL, PIXDEF) override {return false;}
+  void Close(void) override {}
 
  protected:
   // Members

--- a/storage/connect/xobject.h
+++ b/storage/connect/xobject.h
@@ -75,17 +75,17 @@ class DllExport XVOID : public XOBJECT {
   XVOID(void) {Constant = true;}
 
   // Implementation
-  virtual int    GetType(void) {return TYPE_VOID;}
-  virtual int    GetLength(void) {return 0;}
-  virtual int    GetLengthEx(void) {return 0;}
-  virtual PSZ    GetCharValue(void) {return NULL;}
-  virtual int    GetIntValue(void) {return 0;}
-  virtual double GetFloatValue(void) {return 0.0;}
-  virtual int    GetScale() {return 0;}
+  int    GetType(void) override {return TYPE_VOID;}
+  int    GetLength(void) override {return 0;}
+  int    GetLengthEx(void) override {return 0;}
+  PSZ    GetCharValue(void) override {return NULL;}
+  int    GetIntValue(void) override {return 0;}
+  double GetFloatValue(void) override {return 0.0;}
+  int    GetScale() override {return 0;}
 
   // Methods
-  virtual bool   Compare(PXOB xp) {return xp->GetType() == TYPE_VOID;}
-  virtual bool   SetFormat(PGLOBAL, FORMAT&) {return true;}
+  bool   Compare(PXOB xp) override {return xp->GetType() == TYPE_VOID;}
+  bool   SetFormat(PGLOBAL, FORMAT&) override {return true;}
   }; // end of class XVOID
 
 
@@ -100,20 +100,20 @@ class DllExport CONSTANT : public XOBJECT {
   CONSTANT(PVAL valp) {Value = valp; Constant = true;}
 
   // Implementation
-  virtual int    GetType(void) {return TYPE_CONST;}
-  virtual int    GetResultType(void) {return Value->Type;}
-  virtual int    GetLength(void) {return Value->GetValLen();}
-  virtual int    GetScale() {return Value->GetValPrec();}
-  virtual int    GetLengthEx(void);
+  int    GetType(void) override {return TYPE_CONST;}
+  int    GetResultType(void) override {return Value->Type;}
+  int    GetLength(void) override {return Value->GetValLen();}
+  int    GetScale() override {return Value->GetValPrec();}
+  int    GetLengthEx(void) override;
 
   // Methods
-  virtual bool   Compare(PXOB xp);
-  virtual bool   SetFormat(PGLOBAL g, FORMAT& fmt)
+  bool   Compare(PXOB xp) override;
+  bool   SetFormat(PGLOBAL g, FORMAT& fmt) override
                  {return Value->SetConstFormat(g, fmt);}
           void   Convert(PGLOBAL g, int newtype);
           void   SetValue(PVAL vp) {Value = vp;}
-  virtual void   Printf(PGLOBAL g, FILE *, uint);
-  virtual void   Prints(PGLOBAL g, char *, uint);
+  void   Printf(PGLOBAL g, FILE *, uint) override;
+  void   Prints(PGLOBAL g, char *, uint) override;
   }; // end of class CONSTANT
 
 /***********************************************************************/

--- a/storage/connect/xtable.h
+++ b/storage/connect/xtable.h
@@ -109,8 +109,8 @@ class DllExport TDB: public BLOCK {     // Table Descriptor Block.
   virtual PTDB   Copy(PTABS t);
   virtual void   PrintAM(FILE *f, char *m)
                   {fprintf(f, "%s AM(%d)\n",  m, GetAmType());}
-  virtual void   Printf(PGLOBAL g, FILE *f, uint n);
-  virtual void   Prints(PGLOBAL g, char *ps, uint z);
+  void   Printf(PGLOBAL g, FILE *f, uint n) override;
+  void   Prints(PGLOBAL g, char *ps, uint z) override;
   virtual PCSZ   GetServer(void) = 0;
   virtual int    GetBadLines(void) {return 0;}
 	virtual CHARSET_INFO *data_charset(void);
@@ -173,7 +173,7 @@ class DllExport TDBASE : public TDB {
   inline  void    SetKindex(PKXBASE kxp) {To_Kindex = kxp;}
 
   // Properties
-	PKXBASE GetKindex(void) {return To_Kindex;}
+	PKXBASE GetKindex(void) override {return To_Kindex;}
 	PXOB   *GetLink(void) {return To_Link;}
 	PIXDEF  GetXdp(void) {return To_Xdp;}
 	void    ResetKindex(PGLOBAL g, PKXBASE kxp);
@@ -182,17 +182,17 @@ class DllExport TDBASE : public TDB {
 
   // Methods
   virtual bool   IsUsingTemp(PGLOBAL) {return false;}
-  virtual PCATLG GetCat(void);
-  virtual void   PrintAM(FILE *f, char *m);
-  virtual int    GetProgMax(PGLOBAL g) {return GetMaxSize(g);}
+  PCATLG GetCat(void) override;
+  void   PrintAM(FILE *f, char *m) override;
+  int    GetProgMax(PGLOBAL g) override {return GetMaxSize(g);}
   virtual void   RestoreNrec(void) {}
   virtual int    ResetTableOpt(PGLOBAL g, bool dop, bool dox);
-  virtual PCSZ   GetServer(void) {return "Current";}
+  PCSZ   GetServer(void) override {return "Current";}
 
   // Database routines
   virtual int  MakeIndex(PGLOBAL g, PIXDEF, bool)
                 {strcpy(g->Message, "Remote index"); return RC_INFO;}
-  virtual bool ReadKey(PGLOBAL, OPVAL, const key_range *)
+  bool ReadKey(PGLOBAL, OPVAL, const key_range *) override
                       {assert(false); return true;}
 
  protected:
@@ -218,23 +218,23 @@ class DllExport TDBCAT : public TDBASE {
   TDBCAT(PTABDEF tdp);
 
   // Implementation
-  virtual AMT  GetAmType(void) {return TYPE_AM_CAT;}
+  AMT  GetAmType(void) override {return TYPE_AM_CAT;}
 
   // Methods
-  virtual int  GetRecpos(void) {return N;}
-  virtual int  GetProgCur(void) {return N;}
-  virtual int  RowNumber(PGLOBAL, bool = false) {return N + 1;}
-  virtual bool SetRecpos(PGLOBAL g, int recpos);
+  int  GetRecpos(void) override {return N;}
+  int  GetProgCur(void) override {return N;}
+  int  RowNumber(PGLOBAL, bool = false) override {return N + 1;}
+  bool SetRecpos(PGLOBAL g, int recpos) override;
 
   // Database routines
-  virtual PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n);
-	virtual int  Cardinality(PGLOBAL) {return 10;}	 // To avoid assert
-	virtual int  GetMaxSize(PGLOBAL g);
-  virtual bool OpenDB(PGLOBAL g);
-  virtual int  ReadDB(PGLOBAL g);
-  virtual int  WriteDB(PGLOBAL g);
-  virtual int  DeleteDB(PGLOBAL g, int irc);
-  virtual void CloseDB(PGLOBAL g);
+  PCOL MakeCol(PGLOBAL g, PCOLDEF cdp, PCOL cprec, int n) override;
+	int  Cardinality(PGLOBAL) override {return 10;}	 // To avoid assert
+	int  GetMaxSize(PGLOBAL g) override;
+  bool OpenDB(PGLOBAL g) override;
+  int  ReadDB(PGLOBAL g) override;
+  int  WriteDB(PGLOBAL g) override;
+  int  DeleteDB(PGLOBAL g, int irc) override;
+  void CloseDB(PGLOBAL g) override;
 
  protected:
   // Specific routines
@@ -258,10 +258,10 @@ class DllExport CATCOL : public COLBLK {
   CATCOL(PCOLDEF cdp, PTDB tdbp, int n);
 
   // Implementation
-  virtual int  GetAmType(void) {return TYPE_AM_ODBC;}
+  int  GetAmType(void) override {return TYPE_AM_ODBC;}
 
   // Methods
-	virtual void ReadColumn(PGLOBAL g);
+	void ReadColumn(PGLOBAL g) override;
 
  protected:
   CATCOL(void) = default;              // Default constructor not to be used

--- a/storage/csv/ha_tina.h
+++ b/storage/csv/ha_tina.h
@@ -102,14 +102,14 @@ public:
       delete file_buff;
     free_root(&blobroot, MYF(0));
   }
-  const char *index_type(uint inx) { return "NONE"; }
-  ulonglong table_flags() const
+  const char *index_type(uint inx) override { return "NONE"; }
+  ulonglong table_flags() const override
   {
     return (HA_NO_TRANSACTIONS | HA_REC_NOT_IN_SEQ | HA_NO_AUTO_INCREMENT |
             HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE | HA_CAN_EXPORT |
             HA_CAN_REPAIR | HA_SLOW_RND_POS);
   }
-  ulong index_flags(uint idx, uint part, bool all_parts) const
+  ulong index_flags(uint idx, uint part, bool all_parts) const override
   {
     /*
       We will never have indexes so this will never be called(AKA we return
@@ -124,7 +124,7 @@ public:
   /*
      Called in test_quick_select to determine if indexes should be used.
    */
-  virtual double scan_time() { return (double) (stats.records+stats.deleted) / 20.0+10; }
+  double scan_time() override { return (double) (stats.records+stats.deleted) / 20.0+10; }
   /* The next method will never be called */
   virtual bool fast_key_read() { return 1;}
   /* 
@@ -132,38 +132,38 @@ public:
     (e.g. save number of records seen on full table scan and/or use file size
     as upper bound)
   */
-  ha_rows estimate_rows_upper_bound() { return HA_POS_ERROR; }
+  ha_rows estimate_rows_upper_bound() override { return HA_POS_ERROR; }
 
-  int open(const char *name, int mode, uint open_options);
-  int close(void);
-  int write_row(const uchar * buf);
-  int update_row(const uchar * old_data, const uchar * new_data);
-  int delete_row(const uchar * buf);
-  int rnd_init(bool scan=1);
-  int rnd_next(uchar *buf);
-  int rnd_pos(uchar * buf, uchar *pos);
-  bool check_and_repair(THD *thd);
-  int check(THD* thd, HA_CHECK_OPT* check_opt);
-  bool is_crashed() const;
-  int rnd_end();
-  int repair(THD* thd, HA_CHECK_OPT* check_opt);
+  int open(const char *name, int mode, uint open_options) override;
+  int close(void) override;
+  int write_row(const uchar * buf) override;
+  int update_row(const uchar * old_data, const uchar * new_data) override;
+  int delete_row(const uchar * buf) override;
+  int rnd_init(bool scan=1) override;
+  int rnd_next(uchar *buf) override;
+  int rnd_pos(uchar * buf, uchar *pos) override;
+  bool check_and_repair(THD *thd) override;
+  int check(THD* thd, HA_CHECK_OPT* check_opt) override;
+  bool is_crashed() const override;
+  int rnd_end() override;
+  int repair(THD* thd, HA_CHECK_OPT* check_opt) override;
   /* This is required for SQL layer to know that we support autorepair */
-  bool auto_repair(int error) const
+  bool auto_repair(int error) const override
   { return error == HA_ERR_CRASHED_ON_USAGE; }
   bool auto_repair() const { return 1; }
-  void position(const uchar *record);
-  int info(uint);
-  int reset();
-  int extra(enum ha_extra_function operation);
-  int delete_all_rows(void);
-  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info);
+  void position(const uchar *record) override;
+  int info(uint) override;
+  int reset() override;
+  int extra(enum ha_extra_function operation) override;
+  int delete_all_rows(void) override;
+  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info) override;
   bool check_if_incompatible_data(HA_CREATE_INFO *info,
-                                  uint table_changes);
+                                  uint table_changes) override;
 
-  int external_lock(THD *thd, int lock_type);
+  int external_lock(THD *thd, int lock_type) override;
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-      enum thr_lock_type lock_type);
+      enum thr_lock_type lock_type) override;
 
   /*
     These functions used to get/update status of the handler.

--- a/storage/example/ha_example.h
+++ b/storage/example/ha_example.h
@@ -74,13 +74,13 @@ public:
     The name of the index type that will be used for display.
     Don't implement this method unless you really have indexes.
    */
-  const char *index_type(uint inx) { return "HASH"; }
+  const char *index_type(uint inx) override { return "HASH"; }
 
   /** @brief
     This is a list of flags that indicate what functionality the storage engine
     implements. The current table flags are documented in handler.h
   */
-  ulonglong table_flags() const
+  ulonglong table_flags() const override
   {
     /*
       We are saying that this engine is just statement capable to have
@@ -100,7 +100,7 @@ public:
     If all_parts is set, MySQL wants to know the flags for the combined
     index, up to and including 'part'.
   */
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   {
     return 0;
   }
@@ -112,7 +112,7 @@ public:
     send. Return *real* limits of your storage engine here; MySQL will do
     min(your_limits, MySQL_limits) automatically.
    */
-  uint max_supported_record_length() const { return HA_MAX_REC_LENGTH; }
+  uint max_supported_record_length() const override { return HA_MAX_REC_LENGTH; }
 
   /** @brief
     unireg.cc will call this to make sure that the storage engine can handle
@@ -123,7 +123,7 @@ public:
     There is no need to implement ..._key_... methods if your engine doesn't
     support indexes.
    */
-  uint max_supported_keys()          const { return 0; }
+  uint max_supported_keys() const override { return 0; }
 
   /** @brief
     unireg.cc will call this to make sure that the storage engine can handle
@@ -134,7 +134,7 @@ public:
     There is no need to implement ..._key_... methods if your engine doesn't
     support indexes.
    */
-  uint max_supported_key_parts()     const { return 0; }
+  uint max_supported_key_parts() const override { return 0; }
 
   /** @brief
     unireg.cc will call this to make sure that the storage engine can handle
@@ -145,17 +145,17 @@ public:
     There is no need to implement ..._key_... methods if your engine doesn't
     support indexes.
    */
-  uint max_supported_key_length()    const { return 0; }
+  uint max_supported_key_length() const override { return 0; }
 
   /** @brief
     Called in test_quick_select to determine if indexes should be used.
   */
-  virtual double scan_time() { return (double) (stats.records+stats.deleted) / 20.0+10; }
+  double scan_time() override { return (double) (stats.records+stats.deleted) / 20.0+10; }
 
   /** @brief
     This method will never be called if you do not implement indexes.
   */
-  virtual double read_time(uint, uint, ha_rows rows)
+  double read_time(uint, uint, ha_rows rows) override
   { return (double) rows /  20.0+1; }
 
   /*
@@ -167,61 +167,61 @@ public:
   /** @brief
     We implement this in ha_example.cc; it's a required method.
   */
-  int open(const char *name, int mode, uint test_if_locked);    // required
+  int open(const char *name, int mode, uint test_if_locked) override;    // required
 
   /** @brief
     We implement this in ha_example.cc; it's a required method.
   */
-  int close(void);                                              // required
+  int close(void) override;                                              // required
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int write_row(const uchar *buf);
+  int write_row(const uchar *buf) override;
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int update_row(const uchar *old_data, const uchar *new_data);
+  int update_row(const uchar *old_data, const uchar *new_data) override;
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int delete_row(const uchar *buf);
+  int delete_row(const uchar *buf) override;
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
   int index_read_map(uchar *buf, const uchar *key,
-                     key_part_map keypart_map, enum ha_rkey_function find_flag);
+                     key_part_map keypart_map, enum ha_rkey_function find_flag) override;
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int index_next(uchar *buf);
+  int index_next(uchar *buf) override;
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int index_prev(uchar *buf);
+  int index_prev(uchar *buf) override;
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int index_first(uchar *buf);
+  int index_first(uchar *buf) override;
 
   /** @brief
     We implement this in ha_example.cc. It's not an obligatory method;
     skip it and and MySQL will treat it as not implemented.
   */
-  int index_last(uchar *buf);
+  int index_last(uchar *buf) override;
 
   /** @brief
     Unlike index_init(), rnd_init() can be called two consecutive times
@@ -231,24 +231,24 @@ public:
     cursor to the start of the table; no need to deallocate and allocate
     it again. This is a required method.
   */
-  int rnd_init(bool scan);                                      //required
-  int rnd_end();
-  int rnd_next(uchar *buf);                                     ///< required
-  int rnd_pos(uchar *buf, uchar *pos);                          ///< required
-  void position(const uchar *record);                           ///< required
-  int info(uint);                                               ///< required
-  int extra(enum ha_extra_function operation);
-  int external_lock(THD *thd, int lock_type);                   ///< required
-  int delete_all_rows(void);
+  int rnd_init(bool scan) override;                                      //required
+  int rnd_end() override;
+  int rnd_next(uchar *buf) override;                                     ///< required
+  int rnd_pos(uchar *buf, uchar *pos) override;                          ///< required
+  void position(const uchar *record) override;                           ///< required
+  int info(uint) override;                                               ///< required
+  int extra(enum ha_extra_function operation) override;
+  int external_lock(THD *thd, int lock_type) override;                   ///< required
+  int delete_all_rows(void) override;
   ha_rows records_in_range(uint inx, const key_range *min_key,
-                           const key_range *max_key, page_range *pages);
-  int delete_table(const char *from);
+                           const key_range *max_key, page_range *pages) override;
+  int delete_table(const char *from) override;
   int create(const char *name, TABLE *form,
-             HA_CREATE_INFO *create_info);                      ///< required
+             HA_CREATE_INFO *create_info) override;                      ///< required
   enum_alter_inplace_result
   check_if_supported_inplace_alter(TABLE* altered_table,
-                                   Alter_inplace_info* ha_alter_info);
+                                   Alter_inplace_info* ha_alter_info) override;
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type);     ///< required
+                             enum thr_lock_type lock_type) override;     ///< required
 };

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -1658,7 +1658,7 @@ public:
 public:
   bool handle_condition(THD *thd, uint sql_errno, const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
-                        const char* msg, Sql_condition ** cond_hdl)
+                        const char* msg, Sql_condition ** cond_hdl) override
   {
     return sql_errno >= ER_ABORTING_CONNECTION &&
            sql_errno <= ER_NET_WRITE_INTERRUPTED;

--- a/storage/federated/ha_federated.h
+++ b/storage/federated/ha_federated.h
@@ -131,13 +131,13 @@ public:
     don't implement this method unless you really have indexes
    */
   // perhaps get index type
-  const char *index_type(uint inx) { return "REMOTE"; }
+  const char *index_type(uint inx) override { return "REMOTE"; }
   /*
     This is a list of flags that says what the storage engine
     implements. The current table flags are documented in
     handler.h
   */
-  ulonglong table_flags() const
+  ulonglong table_flags() const override
   {
     /* fix server to be able to get remote server table flags */
     return (HA_PRIMARY_KEY_IN_READ_INDEX | HA_FILE_BASED
@@ -160,15 +160,15 @@ public:
     index up to and including 'part'.
   */
     /* fix server to be able to get remote server index flags */
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   {
     return (HA_READ_NEXT | HA_READ_RANGE | HA_READ_AFTER_KEY);
   }
-  uint max_supported_record_length() const { return HA_MAX_REC_LENGTH; }
-  uint max_supported_keys()          const { return MAX_KEY; }
-  uint max_supported_key_parts()     const { return MAX_REF_PARTS; }
-  uint max_supported_key_length()    const { return FEDERATED_MAX_KEY_LENGTH; }
-  uint max_supported_key_part_length() const { return FEDERATED_MAX_KEY_LENGTH; }
+  uint max_supported_record_length() const override { return HA_MAX_REC_LENGTH; }
+  uint max_supported_keys() const       override { return MAX_KEY; }
+  uint max_supported_key_parts() const  override { return MAX_REF_PARTS; }
+  uint max_supported_key_length() const override { return FEDERATED_MAX_KEY_LENGTH; }
+  uint max_supported_key_part_length() const override { return FEDERATED_MAX_KEY_LENGTH; }
   /*
     Called in test_quick_select to determine if indexes should be used.
     Normally, we need to know number of blocks . For federated we need to
@@ -180,7 +180,7 @@ public:
     The reason for "records * 1000" is that such a large number forces 
     this to use indexes "
   */
-  double scan_time()
+  double scan_time() override
   {
     DBUG_PRINT("info", ("records %lu", (ulong) stats.records));
     return (double)(stats.records*1000); 
@@ -188,7 +188,7 @@ public:
   /*
     The next method will never be called if you do not implement indexes.
   */
-  double read_time(uint index, uint ranges, ha_rows rows) 
+  double read_time(uint index, uint ranges, ha_rows rows) override 
   {
     /*
       Per Brian, this number is bugus, but this method must be implemented,
@@ -197,33 +197,33 @@ public:
     return (double) rows /  20.0+1;
   }
 
-  const key_map *keys_to_use_for_scanning() { return &key_map_full; }
+  const key_map *keys_to_use_for_scanning() override { return &key_map_full; }
   /*
     Everything below are methods that we implment in ha_federated.cc.
 
     Most of these methods are not obligatory, skip them and
     MySQL will treat them as not implemented
   */
-  int open(const char *name, int mode, uint test_if_locked);    // required
-  int close(void);                                              // required
+  int open(const char *name, int mode, uint test_if_locked) override;    // required
+  int close(void) override;                                              // required
 
-  void start_bulk_insert(ha_rows rows, uint flags);
-  int end_bulk_insert();
-  int write_row(const uchar *buf);
-  int update_row(const uchar *old_data, const uchar *new_data);
-  int delete_row(const uchar *buf);
-  int index_init(uint keynr, bool sorted);
-  ha_rows estimate_rows_upper_bound();
+  void start_bulk_insert(ha_rows rows, uint flags) override;
+  int end_bulk_insert() override;
+  int write_row(const uchar *buf) override;
+  int update_row(const uchar *old_data, const uchar *new_data) override;
+  int delete_row(const uchar *buf) override;
+  int index_init(uint keynr, bool sorted) override;
+  ha_rows estimate_rows_upper_bound() override;
   int index_read(uchar *buf, const uchar *key,
-                 uint key_len, enum ha_rkey_function find_flag);
+                 uint key_len, enum ha_rkey_function find_flag) override;
   int index_read_idx(uchar *buf, uint idx, const uchar *key,
                      uint key_len, enum ha_rkey_function find_flag);
-  int index_next(uchar *buf);
-  int index_end();
+  int index_next(uchar *buf) override;
+  int index_end() override;
   int read_range_first(const key_range *start_key,
                                const key_range *end_key,
-                               bool eq_range, bool sorted);
-  int read_range_next();
+                               bool eq_range, bool sorted) override;
+  int read_range_next() override;
   /*
     unlike index_init(), rnd_init() can be called two times
     without rnd_end() in between (it only makes sense if scan=1).
@@ -232,17 +232,17 @@ public:
     position it to the start of the table, no need to deallocate
     and allocate it again
   */
-  int rnd_init(bool scan);                                      //required
-  int rnd_end();
-  int rnd_next(uchar *buf);                                      //required
+  int rnd_init(bool scan) override;                                      //required
+  int rnd_end() override;
+  int rnd_next(uchar *buf) override;                                      //required
   int rnd_next_int(uchar *buf);
-  int rnd_pos(uchar *buf, uchar *pos);                            //required
-  void position(const uchar *record);                            //required
+  int rnd_pos(uchar *buf, uchar *pos) override;                            //required
+  void position(const uchar *record) override;                            //required
   /*
     A ref is a pointer inside a local buffer. It is not comparable to
     other ref's. This is never called as HA_NON_COMPARABLE_ROWID is set.
   */
-  int cmp_ref(const uchar *ref1, const uchar *ref2)
+  int cmp_ref(const uchar *ref1, const uchar *ref2) override
   {
 #ifdef NOT_YET
     DBUG_ASSERT(0);
@@ -251,38 +251,38 @@ public:
     return handler::cmp_ref(ref1,ref2);         /* Works if table scan is used */
 #endif
   }
-  int info(uint);                                              //required
-  int extra(ha_extra_function operation);
+  int info(uint) override;                                              //required
+  int extra(ha_extra_function operation) override;
 
   void update_auto_increment(void);
-  int repair(THD* thd, HA_CHECK_OPT* check_opt);
-  int optimize(THD* thd, HA_CHECK_OPT* check_opt);
-  int delete_table(const char *name)
+  int repair(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int optimize(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int delete_table(const char *name) override
   {
     return 0;
   }
-  int delete_all_rows(void);
-  int truncate();
+  int delete_all_rows(void) override;
+  int truncate() override;
   int create(const char *name, TABLE *form,
-             HA_CREATE_INFO *create_info);                      //required
+             HA_CREATE_INFO *create_info) override;                      //required
   ha_rows records_in_range(uint inx,
                            const key_range *start_key,
                            const key_range *end_key,
-                           page_range *pages);
-  uint8 table_cache_type() { return HA_CACHE_TBL_NOCACHE; }
+                           page_range *pages) override;
+  uint8 table_cache_type() override { return HA_CACHE_TBL_NOCACHE; }
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type);     //required
-  bool get_error_message(int error, String *buf);
+                             enum thr_lock_type lock_type) override;     //required
+  bool get_error_message(int error, String *buf) override;
   
   MYSQL_RES *store_result(MYSQL *mysql);
   void free_result();
   
-  int external_lock(THD *thd, int lock_type);
+  int external_lock(THD *thd, int lock_type) override;
   int connection_commit();
   int connection_rollback();
   int connection_autocommit(bool state);
   int execute_simple_query(const char *query, int len);
-  int reset(void);
+  int reset(void) override;
 };
 

--- a/storage/federatedx/federatedx_io_mysql.cc
+++ b/storage/federatedx/federatedx_io_mysql.cc
@@ -73,55 +73,55 @@ class federatedx_io_mysql :public federatedx_io
   bool test_all_restrict() const;
 public:
   federatedx_io_mysql(FEDERATEDX_SERVER *);
-  ~federatedx_io_mysql();
+  ~federatedx_io_mysql() override;
 
   int simple_query(const char *fmt, ...);
-  int query(const char *buffer, size_t length);
-  virtual FEDERATEDX_IO_RESULT *store_result();
+  int query(const char *buffer, size_t length) override;
+  FEDERATEDX_IO_RESULT *store_result() override;
 
-  virtual size_t max_query_size() const;
+  size_t max_query_size() const override;
 
-  virtual my_ulonglong affected_rows() const;
-  virtual my_ulonglong last_insert_id() const;
+  my_ulonglong affected_rows() const override;
+  my_ulonglong last_insert_id() const override;
 
-  virtual int error_code();
-  virtual const char *error_str();
+  int error_code() override;
+  const char *error_str() override;
 
-  void reset();
-  int commit();
-  int rollback();
+  void reset() override;
+  int commit() override;
+  int rollback() override;
 
-  int savepoint_set(ulong sp);
-  ulong savepoint_release(ulong sp);
-  ulong savepoint_rollback(ulong sp);
-  void savepoint_restrict(ulong sp);
+  int savepoint_set(ulong sp) override;
+  ulong savepoint_release(ulong sp) override;
+  ulong savepoint_rollback(ulong sp) override;
+  void savepoint_restrict(ulong sp) override;
 
-  ulong last_savepoint() const;
-  ulong actual_savepoint() const;
-  bool is_autocommit() const;
+  ulong last_savepoint() const override;
+  ulong actual_savepoint() const override;
+  bool is_autocommit() const override;
 
   bool table_metadata(ha_statistics *stats, const char *table_name,
-                      uint table_name_length, uint flag);
+                      uint table_name_length, uint flag) override;
 
   /* resultset operations */
 
-  virtual void free_result(FEDERATEDX_IO_RESULT *io_result);
-  virtual unsigned int get_num_fields(FEDERATEDX_IO_RESULT *io_result);
-  virtual my_ulonglong get_num_rows(FEDERATEDX_IO_RESULT *io_result);
-  virtual FEDERATEDX_IO_ROW *fetch_row(FEDERATEDX_IO_RESULT *io_result,
-                                       FEDERATEDX_IO_ROWS **current= NULL);
-  virtual ulong *fetch_lengths(FEDERATEDX_IO_RESULT *io_result);
-  virtual const char *get_column_data(FEDERATEDX_IO_ROW *row,
-                                      unsigned int column);
-  virtual bool is_column_null(const FEDERATEDX_IO_ROW *row,
-                              unsigned int column) const;
+  void free_result(FEDERATEDX_IO_RESULT *io_result) override;
+  unsigned int get_num_fields(FEDERATEDX_IO_RESULT *io_result) override;
+  my_ulonglong get_num_rows(FEDERATEDX_IO_RESULT *io_result) override;
+  FEDERATEDX_IO_ROW *fetch_row(FEDERATEDX_IO_RESULT *io_result,
+                                       FEDERATEDX_IO_ROWS **current= NULL) override;
+  ulong *fetch_lengths(FEDERATEDX_IO_RESULT *io_result) override;
+  const char *get_column_data(FEDERATEDX_IO_ROW *row,
+                                      unsigned int column) override;
+  bool is_column_null(const FEDERATEDX_IO_ROW *row,
+                              unsigned int column) const override;
 
-  virtual size_t get_ref_length() const;
-  virtual void mark_position(FEDERATEDX_IO_RESULT *io_result,
-                             void *ref, FEDERATEDX_IO_ROWS *current);
-  virtual int seek_position(FEDERATEDX_IO_RESULT **io_result,
-                            const void *ref);
-  virtual void set_thd(void *thd);
+  size_t get_ref_length() const override;
+  void mark_position(FEDERATEDX_IO_RESULT *io_result,
+                             void *ref, FEDERATEDX_IO_ROWS *current) override;
+  int seek_position(FEDERATEDX_IO_RESULT **io_result,
+                            const void *ref) override;
+  void set_thd(void *thd) override;
 };
 
 

--- a/storage/federatedx/federatedx_io_null.cc
+++ b/storage/federatedx/federatedx_io_null.cc
@@ -56,52 +56,52 @@ class federatedx_io_null :public federatedx_io
 {
 public:
   federatedx_io_null(FEDERATEDX_SERVER *);
-  ~federatedx_io_null();
+  ~federatedx_io_null() override;
 
-  int query(const char *buffer, size_t length);
-  virtual FEDERATEDX_IO_RESULT *store_result();
+  int query(const char *buffer, size_t length) override;
+  FEDERATEDX_IO_RESULT *store_result() override;
 
-  virtual size_t max_query_size() const;
+  size_t max_query_size() const override;
 
-  virtual my_ulonglong affected_rows() const;
-  virtual my_ulonglong last_insert_id() const;
+  my_ulonglong affected_rows() const override;
+  my_ulonglong last_insert_id() const override;
 
-  virtual int error_code();
-  virtual const char *error_str();
+  int error_code() override;
+  const char *error_str() override;
   
-  void reset();
-  int commit();
-  int rollback();
+  void reset() override;
+  int commit() override;
+  int rollback() override;
   
-  int savepoint_set(ulong sp);
-  ulong savepoint_release(ulong sp);
-  ulong savepoint_rollback(ulong sp);
-  void savepoint_restrict(ulong sp);
+  int savepoint_set(ulong sp) override;
+  ulong savepoint_release(ulong sp) override;
+  ulong savepoint_rollback(ulong sp) override;
+  void savepoint_restrict(ulong sp) override;
   
-  ulong last_savepoint() const;
-  ulong actual_savepoint() const;
-  bool is_autocommit() const;
+  ulong last_savepoint() const override;
+  ulong actual_savepoint() const override;
+  bool is_autocommit() const override;
 
   bool table_metadata(ha_statistics *stats, const char *table_name,
-                      uint table_name_length, uint flag);
+                      uint table_name_length, uint flag) override;
   
   /* resultset operations */
   
-  virtual void free_result(FEDERATEDX_IO_RESULT *io_result);
-  virtual unsigned int get_num_fields(FEDERATEDX_IO_RESULT *io_result);
-  virtual my_ulonglong get_num_rows(FEDERATEDX_IO_RESULT *io_result);
-  virtual FEDERATEDX_IO_ROW *fetch_row(FEDERATEDX_IO_RESULT *io_result,
-                                       FEDERATEDX_IO_ROWS **current= NULL);
-  virtual ulong *fetch_lengths(FEDERATEDX_IO_RESULT *io_result);
-  virtual const char *get_column_data(FEDERATEDX_IO_ROW *row,
-                                      unsigned int column);
-  virtual bool is_column_null(const FEDERATEDX_IO_ROW *row,
-                              unsigned int column) const;
-  virtual size_t get_ref_length() const;
-  virtual void mark_position(FEDERATEDX_IO_RESULT *io_result,
-                             void *ref, FEDERATEDX_IO_ROWS *current);
-  virtual int seek_position(FEDERATEDX_IO_RESULT **io_result,
-                            const void *ref);
+  void free_result(FEDERATEDX_IO_RESULT *io_result) override;
+  unsigned int get_num_fields(FEDERATEDX_IO_RESULT *io_result) override;
+  my_ulonglong get_num_rows(FEDERATEDX_IO_RESULT *io_result) override;
+  FEDERATEDX_IO_ROW *fetch_row(FEDERATEDX_IO_RESULT *io_result,
+                                       FEDERATEDX_IO_ROWS **current= NULL) override;
+  ulong *fetch_lengths(FEDERATEDX_IO_RESULT *io_result) override;
+  const char *get_column_data(FEDERATEDX_IO_ROW *row,
+                                      unsigned int column) override;
+  bool is_column_null(const FEDERATEDX_IO_ROW *row,
+                              unsigned int column) const override;
+  size_t get_ref_length() const override;
+  void mark_position(FEDERATEDX_IO_RESULT *io_result,
+                             void *ref, FEDERATEDX_IO_ROWS *current) override;
+  int seek_position(FEDERATEDX_IO_RESULT **io_result,
+                            const void *ref) override;
 };
 
 

--- a/storage/federatedx/federatedx_pushdown.h
+++ b/storage/federatedx/federatedx_pushdown.h
@@ -33,10 +33,10 @@ private:
 public:
   ha_federatedx_derived_handler(THD* thd_arg, TABLE_LIST *tbl);
   ~ha_federatedx_derived_handler();
-  int init_scan();
-  int next_row();
-  int end_scan();
-  void print_error(int, unsigned long);
+  int init_scan() override;
+  int next_row() override;
+  int end_scan() override;
+  void print_error(int, unsigned long) override;
 };
 
 
@@ -56,8 +56,8 @@ private:
 public:
   ha_federatedx_select_handler(THD* thd_arg, SELECT_LEX *sel);
   ~ha_federatedx_select_handler();
-  int init_scan();
-  int next_row();
-  int end_scan();
-  void print_error(int, unsigned long);
+  int init_scan() override;
+  int next_row() override;
+  int end_scan() override;
+  void print_error(int, unsigned long) override;
 };

--- a/storage/federatedx/ha_federatedx.cc
+++ b/storage/federatedx/ha_federatedx.cc
@@ -1820,7 +1820,7 @@ public:
 public:
   bool handle_condition(THD *thd, uint sql_errno, const char* sqlstate,
                         Sql_condition::enum_warning_level *level,
-                        const char* msg, Sql_condition ** cond_hdl)
+                        const char* msg, Sql_condition ** cond_hdl) override
   {
     return sql_errno >= ER_ABORTING_CONNECTION &&
            sql_errno <= ER_NET_WRITE_INTERRUPTED;

--- a/storage/federatedx/ha_federatedx.h
+++ b/storage/federatedx/ha_federatedx.h
@@ -325,13 +325,13 @@ public:
     don't implement this method unless you really have indexes
    */
   // perhaps get index type
-  const char *index_type(uint inx) { return "REMOTE"; }
+  const char *index_type(uint inx) override { return "REMOTE"; }
   /*
     This is a list of flags that says what the storage engine
     implements. The current table flags are documented in
     handler.h
   */
-  ulonglong table_flags() const
+  ulonglong table_flags() const override
   {
     /* fix server to be able to get remote server table flags */
     return (HA_PRIMARY_KEY_IN_READ_INDEX | HA_FILE_BASED
@@ -351,15 +351,15 @@ public:
     index up to and including 'part'.
   */
     /* fix server to be able to get remote server index flags */
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   {
     return (HA_READ_NEXT | HA_READ_RANGE);
   }
-  uint max_supported_record_length() const { return HA_MAX_REC_LENGTH; }
-  uint max_supported_keys()          const { return MAX_KEY; }
-  uint max_supported_key_parts()     const { return MAX_REF_PARTS; }
-  uint max_supported_key_length()    const { return FEDERATEDX_MAX_KEY_LENGTH; }
-  uint max_supported_key_part_length() const { return FEDERATEDX_MAX_KEY_LENGTH; }
+  uint max_supported_record_length() const override { return HA_MAX_REC_LENGTH; }
+  uint max_supported_keys() const       override { return MAX_KEY; }
+  uint max_supported_key_parts() const  override { return MAX_REF_PARTS; }
+  uint max_supported_key_length() const override { return FEDERATEDX_MAX_KEY_LENGTH; }
+  uint max_supported_key_part_length() const override { return FEDERATEDX_MAX_KEY_LENGTH; }
   /*
     Called in test_quick_select to determine if indexes should be used.
     Normally, we need to know number of blocks . For federatedx we need to
@@ -371,7 +371,7 @@ public:
     The reason for "records * 1000" is that such a large number forces
     this to use indexes "
   */
-  double scan_time()
+  double scan_time() override
   {
     DBUG_PRINT("info", ("records %lu", (ulong) stats.records));
     return (double)(stats.records*1000);
@@ -379,7 +379,7 @@ public:
   /*
     The next method will never be called if you do not implement indexes.
   */
-  double read_time(uint index, uint ranges, ha_rows rows)
+  double read_time(uint index, uint ranges, ha_rows rows) override
   {
     /*
       Per Brian, this number is bugus, but this method must be implemented,
@@ -388,33 +388,33 @@ public:
     return (double) rows /  20.0+1;
   }
 
-  const key_map *keys_to_use_for_scanning() { return &key_map_full; }
+  const key_map *keys_to_use_for_scanning() override { return &key_map_full; }
   /*
     Everything below are methods that we implment in ha_federatedx.cc.
 
     Most of these methods are not obligatory, skip them and
     MySQL will treat them as not implemented
   */
-  int open(const char *name, int mode, uint test_if_locked);    // required
-  int close(void);                                              // required
+  int open(const char *name, int mode, uint test_if_locked) override;    // required
+  int close(void) override;                                              // required
 
-  void start_bulk_insert(ha_rows rows, uint flags);
-  int end_bulk_insert();
-  int write_row(const uchar *buf);
-  int update_row(const uchar *old_data, const uchar *new_data);
-  int delete_row(const uchar *buf);
-  int index_init(uint keynr, bool sorted);
-  ha_rows estimate_rows_upper_bound();
+  void start_bulk_insert(ha_rows rows, uint flags) override;
+  int end_bulk_insert() override;
+  int write_row(const uchar *buf) override;
+  int update_row(const uchar *old_data, const uchar *new_data) override;
+  int delete_row(const uchar *buf) override;
+  int index_init(uint keynr, bool sorted) override;
+  ha_rows estimate_rows_upper_bound() override;
   int index_read(uchar *buf, const uchar *key,
-                 uint key_len, enum ha_rkey_function find_flag);
+                 uint key_len, enum ha_rkey_function find_flag) override;
   int index_read_idx(uchar *buf, uint idx, const uchar *key,
                      uint key_len, enum ha_rkey_function find_flag);
-  int index_next(uchar *buf);
-  int index_end();
+  int index_next(uchar *buf) override;
+  int index_end() override;
   int read_range_first(const key_range *start_key,
                                const key_range *end_key,
-                               bool eq_range, bool sorted);
-  int read_range_next();
+                               bool eq_range, bool sorted) override;
+  int read_range_next() override;
   /*
     unlike index_init(), rnd_init() can be called two times
     without rnd_end() in between (it only makes sense if scan=1).
@@ -423,16 +423,16 @@ public:
     position it to the start of the table, no need to deallocate
     and allocate it again
   */
-  int rnd_init(bool scan);                                      //required
-  int rnd_end();
-  int rnd_next(uchar *buf);                                      //required
-  int rnd_pos(uchar *buf, uchar *pos);                            //required
-  void position(const uchar *record);                            //required
+  int rnd_init(bool scan) override;                                      //required
+  int rnd_end() override;
+  int rnd_next(uchar *buf) override;                                      //required
+  int rnd_pos(uchar *buf, uchar *pos) override;                            //required
+  void position(const uchar *record) override;                            //required
   /*
     A ref is a pointer inside a local buffer. It is not comparable to
     other ref's. This is never called as HA_NON_COMPARABLE_ROWID is set.
   */
-  int cmp_ref(const uchar *ref1, const uchar *ref2)
+  int cmp_ref(const uchar *ref1, const uchar *ref2) override
   {
 #ifdef NOT_YET
     DBUG_ASSERT(0);
@@ -441,29 +441,29 @@ public:
     return handler::cmp_ref(ref1,ref2);         /* Works if table scan is used */
 #endif
   }
-  int info(uint);                                              //required
-  int extra(ha_extra_function operation);
+  int info(uint) override;                                              //required
+  int extra(ha_extra_function operation) override;
 
   void update_auto_increment(void);
-  int repair(THD* thd, HA_CHECK_OPT* check_opt);
-  int optimize(THD* thd, HA_CHECK_OPT* check_opt);
-  int delete_table(const char *name)
+  int repair(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int optimize(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int delete_table(const char *name) override
   {
     return 0;
   }
-  int delete_all_rows(void);
+  int delete_all_rows(void) override;
   int create(const char *name, TABLE *form,
-             HA_CREATE_INFO *create_info);                      //required
+             HA_CREATE_INFO *create_info) override;                      //required
   ha_rows records_in_range(uint inx, const key_range *start_key,
-                           const key_range *end_key, page_range *pages);
-  uint8 table_cache_type() { return HA_CACHE_TBL_NOCACHE; }
+                           const key_range *end_key, page_range *pages) override;
+  uint8 table_cache_type() override { return HA_CACHE_TBL_NOCACHE; }
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type);     //required
-  bool get_error_message(int error, String *buf);
-  int start_stmt(THD *thd, thr_lock_type lock_type);
-  int external_lock(THD *thd, int lock_type);
-  int reset(void);
+                             enum thr_lock_type lock_type) override;     //required
+  bool get_error_message(int error, String *buf) override;
+  int start_stmt(THD *thd, thr_lock_type lock_type) override;
+  int external_lock(THD *thd, int lock_type) override;
+  int reset(void) override;
   int free_result(void);
 
   const FEDERATEDX_SHARE *get_federatedx_share() const { return share; }

--- a/storage/heap/ha_heap.h
+++ b/storage/heap/ha_heap.h
@@ -37,15 +37,15 @@ class ha_heap final : public handler
 public:
   ha_heap(handlerton *hton, TABLE_SHARE *table);
   ~ha_heap() = default;
-  handler *clone(const char *name, MEM_ROOT *mem_root);
-  const char *index_type(uint inx)
+  handler *clone(const char *name, MEM_ROOT *mem_root) override;
+  const char *index_type(uint inx) override
   {
     return ((table_share->key_info[inx].algorithm == HA_KEY_ALG_BTREE) ?
             "BTREE" : "HASH");
   }
   /* Rows also use a fixed-size format */
-  enum row_type get_row_type() const { return ROW_TYPE_FIXED; }
-  ulonglong table_flags() const
+  enum row_type get_row_type() const override { return ROW_TYPE_FIXED; }
+  ulonglong table_flags() const override
   {
     return (HA_FAST_KEY_READ | HA_NO_BLOBS | HA_NULL_IN_KEY |
             HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE |
@@ -53,73 +53,73 @@ public:
             HA_REC_NOT_IN_SEQ | HA_CAN_INSERT_DELAYED | HA_NO_TRANSACTIONS |
             HA_HAS_RECORDS | HA_STATS_RECORDS_IS_EXACT | HA_CAN_HASH_KEYS);
   }
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   {
     return ((table_share->key_info[inx].algorithm == HA_KEY_ALG_BTREE) ?
             HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER | HA_READ_RANGE :
             HA_ONLY_WHOLE_INDEX | HA_KEY_SCAN_NOT_ROR);
   }
-  const key_map *keys_to_use_for_scanning() { return &btree_keys; }
-  uint max_supported_keys()          const { return MAX_KEY; }
-  uint max_supported_key_part_length() const { return MAX_KEY_LENGTH; }
-  double scan_time()
+  const key_map *keys_to_use_for_scanning() override { return &btree_keys; }
+  uint max_supported_keys() const override { return MAX_KEY; }
+  uint max_supported_key_part_length() const override { return MAX_KEY_LENGTH; }
+  double scan_time() override
   { return (double) (stats.records+stats.deleted) / 20.0+10; }
-  double read_time(uint index, uint ranges, ha_rows rows)
+  double read_time(uint index, uint ranges, ha_rows rows) override
   { return (double) (rows +1)/ 20.0; }
-  double keyread_time(uint index, uint ranges, ha_rows rows)
+  double keyread_time(uint index, uint ranges, ha_rows rows) override
   { return (double) (rows + ranges) / 20.0 ; }
-  double avg_io_cost()
+  double avg_io_cost() override
   { return 0.05; }                              /* 1/20 */
-  int open(const char *name, int mode, uint test_if_locked);
-  int close(void);
+  int open(const char *name, int mode, uint test_if_locked) override;
+  int close(void) override;
   void set_keys_for_scanning(void);
-  int write_row(const uchar * buf);
-  int update_row(const uchar * old_data, const uchar * new_data);
-  int delete_row(const uchar * buf);
-  virtual void get_auto_increment(ulonglong offset, ulonglong increment,
-                                  ulonglong nb_desired_values,
-                                  ulonglong *first_value,
-                                  ulonglong *nb_reserved_values);
+  int write_row(const uchar * buf) override;
+  int update_row(const uchar * old_data, const uchar * new_data) override;
+  int delete_row(const uchar * buf) override;
+  void get_auto_increment(ulonglong offset, ulonglong increment,
+                          ulonglong nb_desired_values,
+                          ulonglong *first_value,
+                          ulonglong *nb_reserved_values) override;
   int index_read_map(uchar * buf, const uchar * key, key_part_map keypart_map,
-                     enum ha_rkey_function find_flag);
-  int index_read_last_map(uchar *buf, const uchar *key, key_part_map keypart_map);
+                     enum ha_rkey_function find_flag) override;
+  int index_read_last_map(uchar *buf, const uchar *key, key_part_map keypart_map) override;
   int index_read_idx_map(uchar * buf, uint index, const uchar * key,
                          key_part_map keypart_map,
-                         enum ha_rkey_function find_flag);
-  int index_next(uchar * buf);
-  int index_prev(uchar * buf);
-  int index_first(uchar * buf);
-  int index_last(uchar * buf);
-  int rnd_init(bool scan);
-  int rnd_next(uchar *buf);
-  int rnd_pos(uchar * buf, uchar *pos);
-  void position(const uchar *record);
-  int can_continue_handler_scan();
-  int info(uint);
-  int extra(enum ha_extra_function operation);
-  int reset();
-  int external_lock(THD *thd, int lock_type);
-  int delete_all_rows(void);
-  int reset_auto_increment(ulonglong value);
-  int disable_indexes(key_map map, bool persist);
-  int enable_indexes(key_map map, bool persist);
-  int indexes_are_disabled(void);
+                         enum ha_rkey_function find_flag) override;
+  int index_next(uchar * buf) override;
+  int index_prev(uchar * buf) override;
+  int index_first(uchar * buf) override;
+  int index_last(uchar * buf) override;
+  int rnd_init(bool scan) override;
+  int rnd_next(uchar *buf) override;
+  int rnd_pos(uchar * buf, uchar *pos) override;
+  void position(const uchar *record) override;
+  int can_continue_handler_scan() override;
+  int info(uint) override;
+  int extra(enum ha_extra_function operation) override;
+  int reset() override;
+  int external_lock(THD *thd, int lock_type) override;
+  int delete_all_rows(void) override;
+  int reset_auto_increment(ulonglong value) override;
+  int disable_indexes(key_map map, bool persist) override;
+  int enable_indexes(key_map map, bool persist) override;
+  int indexes_are_disabled(void) override;
   ha_rows records_in_range(uint inx, const key_range *start_key,
-                           const key_range *end_key, page_range *pages);
-  int delete_table(const char *from);
-  void drop_table(const char *name);
-  int rename_table(const char * from, const char * to);
-  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info);
-  void update_create_info(HA_CREATE_INFO *create_info);
+                           const key_range *end_key, page_range *pages) override;
+  int delete_table(const char *from) override;
+  void drop_table(const char *name) override;
+  int rename_table(const char * from, const char * to) override;
+  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info) override;
+  void update_create_info(HA_CREATE_INFO *create_info) override;
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-			     enum thr_lock_type lock_type);
-  int cmp_ref(const uchar *ref1, const uchar *ref2)
+			     enum thr_lock_type lock_type) override;
+  int cmp_ref(const uchar *ref1, const uchar *ref2) override
   {
     return memcmp(ref1, ref2, sizeof(HEAP_PTR));
   }
-  bool check_if_incompatible_data(HA_CREATE_INFO *info, uint table_changes);
-  int find_unique_row(uchar *record, uint unique_idx);
+  bool check_if_incompatible_data(HA_CREATE_INFO *info, uint table_changes) override;
+  int find_unique_row(uchar *record, uint unique_idx) override;
 private:
   void update_key_stats();
 };

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1013,7 +1013,7 @@ struct ha_innobase_inplace_ctx : public inplace_alter_handler_ctx
 			prebuilt);
 	}
 
-	~ha_innobase_inplace_ctx()
+	~ha_innobase_inplace_ctx() override
 	{
 		UT_DELETE(m_stage);
 		if (instant_table) {
@@ -1122,7 +1122,7 @@ struct ha_innobase_inplace_ctx : public inplace_alter_handler_ctx
 
 	/** Share context between partitions.
 	@param[in] ctx	context from another partition of the table */
-	void set_shared_data(const inplace_alter_handler_ctx& ctx)
+	void set_shared_data(const inplace_alter_handler_ctx& ctx) override
 	{
 		if (add_autoinc != ULINT_UNDEFINED) {
 			const ha_innobase_inplace_ctx& ha_ctx =

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -378,14 +378,14 @@ public:
   file_os_io &operator=(file_os_io &&rhs);
   ~file_os_io() noexcept;
 
-  dberr_t open(const char *path, bool read_only) noexcept final;
+  dberr_t open(const char *path, bool read_only) noexcept override final;
   bool is_opened() const noexcept { return m_fd != OS_FILE_CLOSED; }
-  dberr_t rename(const char *old_path, const char *new_path) noexcept final;
-  dberr_t close() noexcept final;
-  dberr_t read(os_offset_t offset, span<byte> buf) noexcept final;
+  dberr_t rename(const char *old_path, const char *new_path) noexcept override final;
+  dberr_t close() noexcept override final;
+  dberr_t read(os_offset_t offset, span<byte> buf) noexcept override final;
   dberr_t write(const char *path, os_offset_t offset,
-                span<const byte> buf) noexcept final;
-  dberr_t flush() noexcept final;
+                span<const byte> buf) noexcept override final;
+  dberr_t flush() noexcept override final;
 
 private:
   pfs_os_file_t m_fd{OS_FILE_CLOSED};

--- a/storage/innobase/include/sync0policy.h
+++ b/storage/innobase/include/sync0policy.h
@@ -177,7 +177,7 @@ public:
     Print information about the latch
     @return the string representation
   */
-  virtual std::string to_string() const
+  std::string to_string() const override
   {
     std::ostringstream msg;
     const MutexDebug ctx= get();

--- a/storage/maria/ha_maria.h
+++ b/storage/maria/ha_maria.h
@@ -77,7 +77,7 @@ public:
   { return max_supported_key_length(); }
   enum row_type get_row_type() const override final;
   void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share) override final;
-  virtual double scan_time() override final;
+  double scan_time() override final;
 
   int open(const char *name, int mode, uint test_if_locked) override;
   int close(void) override final;

--- a/storage/mroonga/ha_mroonga.hpp
+++ b/storage/mroonga/ha_mroonga.hpp
@@ -35,11 +35,8 @@ extern "C" {
 #include <mrn_operations.hpp>
 #include <mrn_database.hpp>
 
-#if __cplusplus >= 201402
-#  define mrn_override override
-#else
-#  define mrn_override
-#endif
+#define mrn_override override
+
 
 #if (MYSQL_VERSION_ID >= 50514 && MYSQL_VERSION_ID < 50600)
 #  define MRN_HANDLER_HAVE_FINAL_ADD_INDEX 1
@@ -455,10 +452,10 @@ public:
   int update_row(const uchar *old_data, const uchar *new_data) mrn_override;
   int delete_row(const uchar *buf) mrn_override;
 
-  uint max_supported_record_length()   const mrn_override;
-  uint max_supported_keys()            const mrn_override;
-  uint max_supported_key_parts()       const mrn_override;
-  uint max_supported_key_length()      const mrn_override;
+  uint max_supported_record_length() const   mrn_override;
+  uint max_supported_keys() const            mrn_override;
+  uint max_supported_key_parts() const       mrn_override;
+  uint max_supported_key_length() const      mrn_override;
   uint max_supported_key_part_length() const mrn_override;
 
   ha_rows records_in_range(uint inx, const key_range *min_key,

--- a/storage/mroonga/vendor/groonga/lib/dat/dat.hpp
+++ b/storage/mroonga/vendor/groonga/lib/dat/dat.hpp
@@ -185,7 +185,7 @@ class Exception : public std::exception {
   virtual int line() const throw() {
     return line_;
   }
-  virtual const char *what() const throw() {
+  const char *what() const throw() override {
     return what_;
   }
 
@@ -206,7 +206,7 @@ class Error : public Exception {
       : Exception(ex) {}
   virtual ~Error() throw() = default;
 
-  virtual ErrorCode code() const throw() {
+  ErrorCode code() const throw() override {
     return T;
   }
 };

--- a/storage/mroonga/vendor/groonga/lib/dat/id-cursor.hpp
+++ b/storage/mroonga/vendor/groonga/lib/dat/id-cursor.hpp
@@ -44,17 +44,17 @@ class GRN_DAT_API IdCursor : public Cursor {
             UInt32 limit = MAX_UINT32,
             UInt32 flags = 0);
 
-  void close();
+  void close() override;
 
-  const Key &next();
+  const Key &next() override;
 
-  UInt32 offset() const {
+  UInt32 offset() const override {
     return offset_;
   }
-  UInt32 limit() const {
+  UInt32 limit() const override {
     return limit_;
   }
-  UInt32 flags() const {
+  UInt32 flags() const override {
     return flags_;
   }
 

--- a/storage/mroonga/vendor/groonga/lib/dat/key-cursor.hpp
+++ b/storage/mroonga/vendor/groonga/lib/dat/key-cursor.hpp
@@ -38,17 +38,17 @@ class GRN_DAT_API KeyCursor : public Cursor {
             UInt32 limit = MAX_UINT32,
             UInt32 flags = 0);
 
-  void close();
+  void close() override;
 
-  const Key &next();
+  const Key &next() override;
 
-  UInt32 offset() const {
+  UInt32 offset() const override {
     return offset_;
   }
-  UInt32 limit() const {
+  UInt32 limit() const override {
     return limit_;
   }
-  UInt32 flags() const {
+  UInt32 flags() const override {
     return flags_;
   }
 

--- a/storage/mroonga/vendor/groonga/lib/dat/predictive-cursor.hpp
+++ b/storage/mroonga/vendor/groonga/lib/dat/predictive-cursor.hpp
@@ -37,17 +37,17 @@ class GRN_DAT_API PredictiveCursor : public Cursor {
             UInt32 limit = MAX_UINT32,
             UInt32 flags = 0);
 
-  void close();
+  void close() override;
 
-  const Key &next();
+  const Key &next() override;
 
-  UInt32 offset() const {
+  UInt32 offset() const override {
     return offset_;
   }
-  UInt32 limit() const {
+  UInt32 limit() const override {
     return limit_;
   }
-  UInt32 flags() const {
+  UInt32 flags() const override {
     return flags_;
   }
 

--- a/storage/mroonga/vendor/groonga/lib/dat/prefix-cursor.hpp
+++ b/storage/mroonga/vendor/groonga/lib/dat/prefix-cursor.hpp
@@ -38,17 +38,17 @@ class GRN_DAT_API PrefixCursor : public Cursor {
             UInt32 limit = MAX_UINT32,
             UInt32 flags = 0);
 
-  void close();
+  void close() override;
 
-  const Key &next();
+  const Key &next() override;
 
-  UInt32 offset() const {
+  UInt32 offset() const override {
     return offset_;
   }
-  UInt32 limit() const {
+  UInt32 limit() const override {
     return limit_;
   }
-  UInt32 flags() const {
+  UInt32 flags() const override {
     return flags_;
   }
 

--- a/storage/myisam/ha_myisam.h
+++ b/storage/myisam/ha_myisam.h
@@ -54,101 +54,101 @@ class ha_myisam final : public handler
  public:
   ha_myisam(handlerton *hton, TABLE_SHARE *table_arg);
   ~ha_myisam() = default;
-  handler *clone(const char *name, MEM_ROOT *mem_root);
-  const char *index_type(uint key_number);
-  ulonglong table_flags() const { return int_table_flags; }
-  int index_init(uint idx, bool sorted);
-  int index_end();
-  int rnd_end();
+  handler *clone(const char *name, MEM_ROOT *mem_root) override;
+  const char *index_type(uint key_number) override;
+  ulonglong table_flags() const override { return int_table_flags; }
+  int index_init(uint idx, bool sorted) override;
+  int index_end() override;
+  int rnd_end() override;
 
-  ulong index_flags(uint inx, uint part, bool all_parts) const;
-  uint max_supported_keys()          const { return MI_MAX_KEY; }
-  uint max_supported_key_parts()     const { return HA_MAX_KEY_SEG; }
-  uint max_supported_key_length()    const { return HA_MAX_KEY_LENGTH; }
-  uint max_supported_key_part_length() const { return HA_MAX_KEY_LENGTH; }
-  void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share);
-  int open(const char *name, int mode, uint test_if_locked);
-  int close(void);
-  int write_row(const uchar * buf);
-  int update_row(const uchar * old_data, const uchar * new_data);
-  int delete_row(const uchar * buf);
+  ulong index_flags(uint inx, uint part, bool all_parts) const override;
+  uint max_supported_keys() const          override { return MI_MAX_KEY; }
+  uint max_supported_key_parts() const     override { return HA_MAX_KEY_SEG; }
+  uint max_supported_key_length() const    override { return HA_MAX_KEY_LENGTH; }
+  uint max_supported_key_part_length() const override { return HA_MAX_KEY_LENGTH; }
+  void change_table_ptr(TABLE *table_arg, TABLE_SHARE *share) override;
+  int open(const char *name, int mode, uint test_if_locked) override;
+  int close(void) override;
+  int write_row(const uchar * buf) override;
+  int update_row(const uchar * old_data, const uchar * new_data) override;
+  int delete_row(const uchar * buf) override;
   int index_read_map(uchar *buf, const uchar *key, key_part_map keypart_map,
-                     enum ha_rkey_function find_flag);
+                     enum ha_rkey_function find_flag) override;
   int index_read_idx_map(uchar *buf, uint index, const uchar *key,
                          key_part_map keypart_map,
-                         enum ha_rkey_function find_flag);
-  int index_next(uchar * buf);
-  int index_prev(uchar * buf);
-  int index_first(uchar * buf);
-  int index_last(uchar * buf);
-  int index_next_same(uchar *buf, const uchar *key, uint keylen);
-  int ft_init()
+                         enum ha_rkey_function find_flag) override;
+  int index_next(uchar * buf) override;
+  int index_prev(uchar * buf) override;
+  int index_first(uchar * buf) override;
+  int index_last(uchar * buf) override;
+  int index_next_same(uchar *buf, const uchar *key, uint keylen) override;
+  int ft_init() override
   {
     if (!ft_handler)
       return 1;
     ft_handler->please->reinit_search(ft_handler);
     return 0;
   }
-  FT_INFO *ft_init_ext(uint flags, uint inx,String *key)
+  FT_INFO *ft_init_ext(uint flags, uint inx,String *key) override
   {
     return ft_init_search(flags,file,inx,
                           (uchar *)key->ptr(), key->length(), key->charset(),
                           table->record[0]);
   }
-  int ft_read(uchar *buf);
-  int rnd_init(bool scan);
-  int rnd_next(uchar *buf);
-  int rnd_pos(uchar * buf, uchar *pos);
-  int remember_rnd_pos();
-  int restart_rnd_next(uchar *buf);
-  void position(const uchar *record);
-  int info(uint);
-  int extra(enum ha_extra_function operation);
-  int extra_opt(enum ha_extra_function operation, ulong cache_size);
-  int reset(void);
-  int external_lock(THD *thd, int lock_type);
-  int delete_all_rows(void);
-  int reset_auto_increment(ulonglong value);
-  int disable_indexes(key_map map, bool persist);
-  int enable_indexes(key_map map, bool persist);
-  int indexes_are_disabled(void);
-  void start_bulk_insert(ha_rows rows, uint flags);
-  int end_bulk_insert();
+  int ft_read(uchar *buf) override;
+  int rnd_init(bool scan) override;
+  int rnd_next(uchar *buf) override;
+  int rnd_pos(uchar * buf, uchar *pos) override;
+  int remember_rnd_pos() override;
+  int restart_rnd_next(uchar *buf) override;
+  void position(const uchar *record) override;
+  int info(uint) override;
+  int extra(enum ha_extra_function operation) override;
+  int extra_opt(enum ha_extra_function operation, ulong cache_size) override;
+  int reset(void) override;
+  int external_lock(THD *thd, int lock_type) override;
+  int delete_all_rows(void) override;
+  int reset_auto_increment(ulonglong value) override;
+  int disable_indexes(key_map map, bool persist) override;
+  int enable_indexes(key_map map, bool persist) override;
+  int indexes_are_disabled(void) override;
+  void start_bulk_insert(ha_rows rows, uint flags) override;
+  int end_bulk_insert() override;
   ha_rows records_in_range(uint inx, const key_range *min_key,
-                           const key_range *max_key, page_range *pages);
-  void update_create_info(HA_CREATE_INFO *create_info);
-  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info);
+                           const key_range *max_key, page_range *pages) override;
+  void update_create_info(HA_CREATE_INFO *create_info) override;
+  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info) override;
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-			     enum thr_lock_type lock_type);
-  virtual void get_auto_increment(ulonglong offset, ulonglong increment,
-                                  ulonglong nb_desired_values,
-                                  ulonglong *first_value,
-                                  ulonglong *nb_reserved_values);
-  int rename_table(const char * from, const char * to);
-  int delete_table(const char *name);
-  int check_for_upgrade(HA_CHECK_OPT *check_opt);
-  int check(THD* thd, HA_CHECK_OPT* check_opt);
-  int analyze(THD* thd,HA_CHECK_OPT* check_opt);
-  int repair(THD* thd, HA_CHECK_OPT* check_opt);
-  bool check_and_repair(THD *thd);
-  bool is_crashed() const;
-  bool auto_repair(int error) const
+			     enum thr_lock_type lock_type) override;
+  void get_auto_increment(ulonglong offset, ulonglong increment,
+                          ulonglong nb_desired_values,
+                          ulonglong *first_value,
+                          ulonglong *nb_reserved_values) override;
+  int rename_table(const char * from, const char * to) override;
+  int delete_table(const char *name) override;
+  int check_for_upgrade(HA_CHECK_OPT *check_opt) override;
+  int check(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int analyze(THD* thd,HA_CHECK_OPT* check_opt) override;
+  int repair(THD* thd, HA_CHECK_OPT* check_opt) override;
+  bool check_and_repair(THD *thd) override;
+  bool is_crashed() const override;
+  bool auto_repair(int error) const override
   {
     return (myisam_recover_options != HA_RECOVER_OFF &&
             error == HA_ERR_CRASHED_ON_USAGE);
   }
-  int optimize(THD* thd, HA_CHECK_OPT* check_opt);
-  int assign_to_keycache(THD* thd, HA_CHECK_OPT* check_opt);
-  int preload_keys(THD* thd, HA_CHECK_OPT* check_opt);
+  int optimize(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int assign_to_keycache(THD* thd, HA_CHECK_OPT* check_opt) override;
+  int preload_keys(THD* thd, HA_CHECK_OPT* check_opt) override;
   enum_alter_inplace_result check_if_supported_inplace_alter(TABLE *new_table,
-                                            Alter_inplace_info *alter_info);
-  bool check_if_incompatible_data(HA_CREATE_INFO *info, uint table_changes);
+                                            Alter_inplace_info *alter_info) override;
+  bool check_if_incompatible_data(HA_CREATE_INFO *info, uint table_changes) override;
 #ifdef HAVE_QUERY_CACHE
   my_bool register_query_cache_table(THD *thd, const char *table_key,
                                      uint key_length,
                                      qc_engine_callback
                                      *engine_callback,
-                                     ulonglong *engine_data);
+                                     ulonglong *engine_data) override;
 #endif
   MI_INFO *file_ptr(void)
   {
@@ -159,20 +159,20 @@ public:
    * Multi Range Read interface
    */
   int multi_range_read_init(RANGE_SEQ_IF *seq, void *seq_init_param,
-                            uint n_ranges, uint mode, HANDLER_BUFFER *buf);
-  int multi_range_read_next(range_id_t *range_info);
+                            uint n_ranges, uint mode, HANDLER_BUFFER *buf) override;
+  int multi_range_read_next(range_id_t *range_info) override;
   ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                       void *seq_init_param, 
                                       uint n_ranges, uint *bufsz,
-                                      uint *flags, Cost_estimate *cost);
+                                      uint *flags, Cost_estimate *cost) override;
   ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
                                 uint key_parts, uint *bufsz, 
-                                uint *flags, Cost_estimate *cost);
-  int multi_range_read_explain_info(uint mrr_mode, char *str, size_t size);
+                                uint *flags, Cost_estimate *cost) override;
+  int multi_range_read_explain_info(uint mrr_mode, char *str, size_t size) override;
 
   /* Index condition pushdown implementation */
-  Item *idx_cond_push(uint keyno, Item* idx_cond);
-  bool rowid_filter_push(Rowid_filter* rowid_filter);
+  Item *idx_cond_push(uint keyno, Item* idx_cond) override;
+  bool rowid_filter_push(Rowid_filter* rowid_filter) override;
 
 private:
   DsMrr_impl ds_mrr;

--- a/storage/myisammrg/ha_myisammrg.h
+++ b/storage/myisammrg/ha_myisammrg.h
@@ -82,8 +82,8 @@ public:
 
   ha_myisammrg(handlerton *hton, TABLE_SHARE *table_arg);
   ~ha_myisammrg();
-  const char *index_type(uint key_number);
-  ulonglong table_flags() const
+  const char *index_type(uint key_number) override;
+  ulonglong table_flags() const override
   {
     return (HA_REC_NOT_IN_SEQ | HA_AUTO_PART_KEY | HA_NO_TRANSACTIONS |
             HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE |
@@ -93,70 +93,70 @@ public:
             HA_NO_COPY_ON_ALTER |
             HA_DUPLICATE_POS | HA_CAN_MULTISTEP_MERGE);
   }
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   {
     return ((table_share->key_info[inx].algorithm == HA_KEY_ALG_FULLTEXT) ?
             0 : HA_READ_NEXT | HA_READ_PREV | HA_READ_RANGE |
             HA_READ_ORDER | HA_KEYREAD_ONLY);
   }
-  uint max_supported_keys()          const { return MI_MAX_KEY; }
-  uint max_supported_key_length()    const { return HA_MAX_KEY_LENGTH; }
-  uint max_supported_key_part_length() const { return HA_MAX_KEY_LENGTH; }
-  double scan_time()
+  uint max_supported_keys()          const override { return MI_MAX_KEY; }
+  uint max_supported_key_length()    const override{ return HA_MAX_KEY_LENGTH; }
+  uint max_supported_key_part_length() const override { return HA_MAX_KEY_LENGTH; }
+  double scan_time() override
   { return ulonglong2double(stats.data_file_length) / IO_SIZE + file->tables; }
 
-  int open(const char *name, int mode, uint test_if_locked);
+  int open(const char *name, int mode, uint test_if_locked) override;
   int add_children_list(void);
   int attach_children(void);
   int detach_children(void);
-  virtual handler *clone(const char *name, MEM_ROOT *mem_root);
-  int close(void);
-  int write_row(const uchar * buf);
-  int update_row(const uchar * old_data, const uchar * new_data);
-  int delete_row(const uchar * buf);
+  handler *clone(const char *name, MEM_ROOT *mem_root) override;
+  int close(void) override;
+  int write_row(const uchar * buf) override;
+  int update_row(const uchar * old_data, const uchar * new_data) override;
+  int delete_row(const uchar * buf) override;
   int index_read_map(uchar *buf, const uchar *key, key_part_map keypart_map,
-                     enum ha_rkey_function find_flag);
+                     enum ha_rkey_function find_flag) override;
   int index_read_idx_map(uchar *buf, uint index, const uchar *key,
                          key_part_map keypart_map,
-                         enum ha_rkey_function find_flag);
-  int index_read_last_map(uchar *buf, const uchar *key, key_part_map keypart_map);
-  int index_next(uchar * buf);
-  int index_prev(uchar * buf);
-  int index_first(uchar * buf);
-  int index_last(uchar * buf);
-  int index_next_same(uchar *buf, const uchar *key, uint keylen);
-  int rnd_init(bool scan);
-  int rnd_next(uchar *buf);
-  int rnd_pos(uchar * buf, uchar *pos);
-  void position(const uchar *record);
+                         enum ha_rkey_function find_flag) override;
+  int index_read_last_map(uchar *buf, const uchar *key, key_part_map keypart_map) override;
+  int index_next(uchar * buf) override;
+  int index_prev(uchar * buf) override;
+  int index_first(uchar * buf) override;
+  int index_last(uchar * buf) override;
+  int index_next_same(uchar *buf, const uchar *key, uint keylen) override;
+  int rnd_init(bool scan) override;
+  int rnd_next(uchar *buf) override;
+  int rnd_pos(uchar * buf, uchar *pos) override;
+  void position(const uchar *record) override;
   ha_rows records_in_range(uint inx, const key_range *start_key,
-                           const key_range *end_key, page_range *pages);
-  int delete_all_rows();
-  int info(uint);
-  int reset(void);
-  int extra(enum ha_extra_function operation);
-  int extra_opt(enum ha_extra_function operation, ulong cache_size);
-  int external_lock(THD *thd, int lock_type);
-  uint lock_count(void) const;
+                           const key_range *end_key, page_range *pages) override;
+  int delete_all_rows() override;
+  int info(uint) override;
+  int reset(void) override;
+  int extra(enum ha_extra_function operation) override;
+  int extra_opt(enum ha_extra_function operation, ulong cache_size) override;
+  int external_lock(THD *thd, int lock_type) override;
+  uint lock_count(void) const override;
   int create_mrg(const char *name, HA_CREATE_INFO *create_info);
-  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info);
+  int create(const char *name, TABLE *form, HA_CREATE_INFO *create_info) override;
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-			     enum thr_lock_type lock_type);
-  void update_create_info(HA_CREATE_INFO *create_info);
-  void append_create_info(String *packet);
+			     enum thr_lock_type lock_type) override;
+  void update_create_info(HA_CREATE_INFO *create_info) override;
+  void append_create_info(String *packet) override;
   MYRG_INFO *myrg_info() { return file; }
   TABLE *table_ptr() { return table; }
   enum_alter_inplace_result check_if_supported_inplace_alter(TABLE *,
-                                                Alter_inplace_info *);
+                                                Alter_inplace_info *) override;
   bool inplace_alter_table(TABLE *altered_table,
-                           Alter_inplace_info *ha_alter_info);
-  int check(THD* thd, HA_CHECK_OPT* check_opt);
-  ha_rows records();
-  virtual uint count_query_cache_dependant_tables(uint8 *tables_type);
-  virtual my_bool
+                           Alter_inplace_info *ha_alter_info) override;
+  int check(THD* thd, HA_CHECK_OPT* check_opt) override;
+  ha_rows records() override;
+  uint count_query_cache_dependant_tables(uint8 *tables_type) override;
+  my_bool
     register_query_cache_dependant_tables(THD *thd,
                                           Query_cache *cache,
                                           Query_cache_block_table **block,
-                                          uint *n);
-  virtual void set_lock_type(enum thr_lock_type lock);
+                                          uint *n) override;
+  void set_lock_type(enum thr_lock_type lock) override;
 };

--- a/storage/perfschema/cursor_by_account.h
+++ b/storage/perfschema/cursor_by_account.h
@@ -43,9 +43,9 @@ class cursor_by_account : public PFS_engine_table
 public:
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   cursor_by_account(const PFS_engine_table_share *share);

--- a/storage/perfschema/cursor_by_host.h
+++ b/storage/perfschema/cursor_by_host.h
@@ -43,9 +43,9 @@ class cursor_by_host : public PFS_engine_table
 public:
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   cursor_by_host(const PFS_engine_table_share *share);

--- a/storage/perfschema/cursor_by_thread.h
+++ b/storage/perfschema/cursor_by_thread.h
@@ -43,9 +43,9 @@ class cursor_by_thread : public PFS_engine_table
 public:
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   cursor_by_thread(const PFS_engine_table_share *share);

--- a/storage/perfschema/cursor_by_thread_connect_attr.h
+++ b/storage/perfschema/cursor_by_thread_connect_attr.h
@@ -62,9 +62,9 @@ class cursor_by_thread_connect_attr : public PFS_engine_table
 public:
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   cursor_by_thread_connect_attr(const PFS_engine_table_share *share);

--- a/storage/perfschema/cursor_by_user.h
+++ b/storage/perfschema/cursor_by_user.h
@@ -43,9 +43,9 @@ class cursor_by_user : public PFS_engine_table
 public:
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   cursor_by_user(const PFS_engine_table_share *share);

--- a/storage/perfschema/ha_perfschema.h
+++ b/storage/perfschema/ha_perfschema.h
@@ -53,10 +53,10 @@ public:
 
   ~ha_perfschema();
 
-  const char *index_type(uint) { return ""; }
+  const char *index_type(uint) override { return ""; }
 
   /** Capabilities of the performance schema tables. */
-  ulonglong table_flags(void) const
+  ulonglong table_flags(void) const override
   {
     /*
       About HA_FAST_KEY_READ:
@@ -86,25 +86,25 @@ public:
     Operations supported by indexes.
     None, there are no indexes.
   */
-  ulong index_flags(uint , uint , bool ) const
+  ulong index_flags(uint , uint , bool ) const override
   { return 0; }
 
-  uint max_supported_record_length(void) const
+  uint max_supported_record_length(void) const override
   { return HA_MAX_REC_LENGTH; }
 
-  uint max_supported_keys(void) const
+  uint max_supported_keys(void) const override
   { return 0; }
 
-  uint max_supported_key_parts(void) const
+  uint max_supported_key_parts(void) const override
   { return 0; }
 
-  uint max_supported_key_length(void) const
+  uint max_supported_key_length(void) const override
   { return 0; }
 
-  ha_rows estimate_rows_upper_bound(void)
+  ha_rows estimate_rows_upper_bound(void) override
   { return HA_POS_ERROR; }
 
-  double scan_time(void)
+  double scan_time(void) override
   { return 1.0; }
 
   /**
@@ -114,22 +114,22 @@ public:
     @param test_if_locked unused
     @return 0 on success
   */
-  int open(const char *name, int mode, uint test_if_locked);
+  int open(const char *name, int mode, uint test_if_locked) override;
 
   /**
     Close a table handle.
     @sa open.
   */
-  int close(void);
+  int close(void) override;
 
   /**
     Write a row.
     @param buf the row to write
     @return 0 on success
   */
-  int write_row(const uchar *buf);
+  int write_row(const uchar *buf) override;
 
-  void use_hidden_primary_key();
+  void use_hidden_primary_key() override;
 
   /**
     Update a row.
@@ -137,29 +137,29 @@ public:
     @param new_data the row new values
     @return 0 on success
   */
-  int update_row(const uchar *old_data, const uchar *new_data);
+  int update_row(const uchar *old_data, const uchar *new_data) override;
 
   /**
     Delete a row.
     @param buf the row to delete
     @return 0 on success
   */
-  int delete_row(const uchar *buf);
+  int delete_row(const uchar *buf) override;
 
-  int rnd_init(bool scan);
+  int rnd_init(bool scan) override;
 
   /**
     Scan end.
     @sa rnd_init.
   */
-  int rnd_end(void);
+  int rnd_end(void) override;
 
   /**
     Iterator, fetch the next row.
     @param[out] buf the row fetched.
     @return 0 on success
   */
-  int rnd_next(uchar *buf);
+  int rnd_next(uchar *buf) override;
 
   /**
     Iterator, fetch the row at a given position.
@@ -167,42 +167,42 @@ public:
     @param pos the row position
     @return 0 on success
   */
-  int rnd_pos(uchar *buf, uchar *pos);
+  int rnd_pos(uchar *buf, uchar *pos) override;
 
   /**
     Read the row current position.
     @param record the current row
   */
-  void position(const uchar *record);
+  void position(const uchar *record) override;
 
-  int info(uint);
+  int info(uint) override;
 
-  int delete_all_rows(void);
+  int delete_all_rows(void) override;
 
-  int truncate();
+  int truncate() override;
 
-  int delete_table(const char *from);
+  int delete_table(const char *from) override;
 
-  int rename_table(const char * from, const char * to);
+  int rename_table(const char * from, const char * to) override;
 
   int create(const char *name, TABLE *form,
-             HA_CREATE_INFO *create_info);
+             HA_CREATE_INFO *create_info) override;
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type);
+                             enum thr_lock_type lock_type) override;
 
-  virtual uint8 table_cache_type(void)
+  uint8 table_cache_type(void) override
   { return HA_CACHE_TBL_NOCACHE; }
 
-  virtual my_bool register_query_cache_table
+  my_bool register_query_cache_table
     (THD *, const char *, uint , qc_engine_callback *engine_callback,
-     ulonglong *)
+     ulonglong *) override
   {
     *engine_callback= 0;
     return FALSE;
   }
 
-  virtual void print_error(int error, myf errflags);
+  void print_error(int error, myf errflags) override;
 
 private:
   /**

--- a/storage/perfschema/pfs_account.cc
+++ b/storage/perfschema/pfs_account.cc
@@ -666,7 +666,7 @@ public:
     : m_thread(thread)
   {}
 
-  virtual void operator()(PFS_account *pfs)
+  void operator()(PFS_account *pfs) override
   {
     PFS_user *user= sanitize_user(pfs->m_user);
     PFS_host *host= sanitize_host(pfs->m_host);
@@ -699,7 +699,7 @@ public:
     : m_thread(thread)
   {}
 
-  virtual void operator()(PFS_account *pfs)
+  void operator()(PFS_account *pfs) override
   {
     if (pfs->m_username_length > 0 && pfs->m_hostname_length > 0)
     {

--- a/storage/perfschema/pfs_engine_table.cc
+++ b/storage/perfschema/pfs_engine_table.cc
@@ -343,13 +343,13 @@ static PFS_engine_table_share *all_shares[]=
 class PFS_silent_check_intact : public Table_check_intact
 {
 protected:
-  virtual void report_error(uint code, const char *fmt, ...) {}
+  void report_error(uint code, const char *fmt, ...) override {}
 
 public:
   PFS_silent_check_intact()
   {}
 
-  ~PFS_silent_check_intact()
+  ~PFS_silent_check_intact() override
   {}
 };
 
@@ -672,12 +672,12 @@ class PFS_internal_schema_access : public ACL_internal_schema_access
 public:
   PFS_internal_schema_access() = default;
 
-  ~PFS_internal_schema_access() = default;
+  ~PFS_internal_schema_access() override = default;
 
   ACL_internal_access_result check(privilege_t want_access,
-                                   privilege_t *save_priv) const;
+                                   privilege_t *save_priv) const override;
 
-  const ACL_internal_table_access *lookup(const char *name) const;
+  const ACL_internal_table_access *lookup(const char *name) const override;
 };
 
 ACL_internal_access_result

--- a/storage/perfschema/pfs_engine_table.h
+++ b/storage/perfschema/pfs_engine_table.h
@@ -340,8 +340,8 @@ public:
 
   ~PFS_readonly_acl() = default;
 
-  virtual ACL_internal_access_result check(privilege_t want_access,
-                                           privilege_t *save_priv) const;
+    ACL_internal_access_result check(privilege_t want_access,
+                                     privilege_t *save_priv) const override;
 };
 
 /** Singleton instance of PFS_readonly_acl. */
@@ -358,8 +358,8 @@ public:
 
   ~PFS_truncatable_acl() = default;
 
-  virtual ACL_internal_access_result check(privilege_t want_access,
-                                   privilege_t *save_priv) const;
+  ACL_internal_access_result check(privilege_t want_access,
+                                   privilege_t *save_priv) const override;
 };
 
 /** Singleton instance of PFS_truncatable_acl. */
@@ -377,7 +377,7 @@ public:
   ~PFS_updatable_acl() = default;
 
   ACL_internal_access_result check(privilege_t want_access,
-                                   privilege_t *save_priv) const;
+                                   privilege_t *save_priv) const override;
 };
 
 /** Singleton instance of PFS_updatable_acl. */
@@ -395,7 +395,7 @@ public:
   ~PFS_editable_acl() = default;
 
   ACL_internal_access_result check(privilege_t want_access,
-                                   privilege_t *save_priv) const;
+                                   privilege_t *save_priv) const override;
 };
 
 /** Singleton instance of PFS_editable_acl. */
@@ -412,7 +412,7 @@ public:
   ~PFS_unknown_acl() = default;
 
   ACL_internal_access_result check(privilege_t want_access,
-                                   privilege_t *save_priv) const;
+                                   privilege_t *save_priv) const override;
 };
 
 /** Singleton instance of PFS_unknown_acl. */
@@ -430,7 +430,7 @@ public:
 
   ~PFS_readonly_world_acl()
   {}
-  virtual ACL_internal_access_result check(privilege_t want_access, privilege_t *save_priv) const;
+  ACL_internal_access_result check(privilege_t want_access, privilege_t *save_priv) const override;
 };
 
 
@@ -449,7 +449,7 @@ public:
 
   ~PFS_truncatable_world_acl()
   {}
-  virtual ACL_internal_access_result check(privilege_t want_access, privilege_t *save_priv) const;
+  ACL_internal_access_result check(privilege_t want_access, privilege_t *save_priv) const override;
 };
 
 
@@ -468,8 +468,8 @@ class PFS_readonly_processlist_acl : public PFS_readonly_acl {
   ~PFS_readonly_processlist_acl()
   {}
 
-  virtual ACL_internal_access_result check(privilege_t want_access,
-                                           privilege_t *save_priv) const;
+  ACL_internal_access_result check(privilege_t want_access,
+                                   privilege_t *save_priv) const override;
 };
 
 /** Singleton instance of PFS_readonly_processlist_acl */

--- a/storage/perfschema/pfs_host.cc
+++ b/storage/perfschema/pfs_host.cc
@@ -349,7 +349,7 @@ public:
     : m_thread(thread)
   {}
 
-  virtual void operator()(PFS_host *pfs)
+  void operator()(PFS_host *pfs) override
   {
     pfs->aggregate(true);
     if (pfs->get_refcount() == 0)

--- a/storage/perfschema/pfs_instr_class.cc
+++ b/storage/perfschema/pfs_instr_class.cc
@@ -2022,7 +2022,7 @@ public:
     : m_thread(thread)
   {}
 
-  virtual void operator()(PFS_table_share *pfs)
+  void operator()(PFS_table_share *pfs) override
   {
     pfs->refresh_setup_object_flags(m_thread);
   }
@@ -2045,7 +2045,7 @@ public:
     : m_thread(thread)
   {}
 
-  virtual void operator()(PFS_program *pfs)
+  void operator()(PFS_program *pfs) override
   {
     pfs->refresh_setup_object_flags(m_thread);
   }

--- a/storage/perfschema/pfs_setup_actor.cc
+++ b/storage/perfschema/pfs_setup_actor.cc
@@ -231,7 +231,7 @@ public:
     : m_pins(pins)
   {}
 
-  virtual void operator()(PFS_setup_actor *pfs)
+  void operator()(PFS_setup_actor *pfs) override
   {
     lf_hash_delete(&setup_actor_hash, m_pins,
                    pfs->m_key.m_hash_key, pfs->m_key.m_key_length);

--- a/storage/perfschema/pfs_setup_object.cc
+++ b/storage/perfschema/pfs_setup_object.cc
@@ -231,7 +231,7 @@ public:
     : m_pins(pins)
   {}
 
-  virtual void operator()(PFS_setup_object *pfs)
+  void operator()(PFS_setup_object *pfs) override
   {
     lf_hash_delete(&setup_object_hash, m_pins,
                    pfs->m_key.m_hash_key, pfs->m_key.m_key_length);

--- a/storage/perfschema/pfs_user.cc
+++ b/storage/perfschema/pfs_user.cc
@@ -314,7 +314,7 @@ public:
     : m_thread(thread)
   {}
 
-  virtual void operator()(PFS_user *pfs)
+  void operator()(PFS_user *pfs) override
   {
     pfs->aggregate(true);
     if (pfs->get_refcount() == 0)

--- a/storage/perfschema/pfs_variable.h
+++ b/storage/perfschema/pfs_variable.h
@@ -205,7 +205,7 @@ public:
   Find_THD_variable() : m_unsafe_thd(NULL) {}
   Find_THD_variable(THD *unsafe_thd) : m_unsafe_thd(unsafe_thd) {}
 
-  virtual bool operator()(THD *thd)
+  bool operator()(THD *thd) override
   {
     //TODO: filter bg threads?
     if (thd != m_unsafe_thd)
@@ -608,18 +608,18 @@ public:
 private:
   /* Build SHOW_var array. */
   bool init_show_var_array(enum_var_type scope, bool strict);
-  bool do_initialize_session(void);
+  bool do_initialize_session(void) override;
 
   /* Global */
-  int do_materialize_global(void);
+  int do_materialize_global(void) override;
   /* Global and Session - THD */
-  int do_materialize_all(THD* thd);
+  int do_materialize_all(THD* thd) override;
   /* Session - THD */
-  int do_materialize_session(THD* thd);
+  int do_materialize_session(THD* thd) override;
   /* Session -  PFS_thread */
-  int do_materialize_session(PFS_thread *thread);
+  int do_materialize_session(PFS_thread *thread) override;
   /* Single variable -  PFS_thread */
-  int do_materialize_session(PFS_thread *pfs_thread, uint index);
+  int do_materialize_session(PFS_thread *pfs_thread, uint index) override;
 
   /* Temporary mem_root to use for materialization. */
   MEM_ROOT m_mem_sysvar;
@@ -660,14 +660,14 @@ protected:
   bool m_show_command;
 
 private:
-  bool do_initialize_session(void);
+  bool do_initialize_session(void) override;
 
-  int do_materialize_global(void);
+  int do_materialize_global(void) override;
   /* Global and Session - THD */
-  int do_materialize_all(THD* thd);
-  int do_materialize_session(THD *thd);
-  int do_materialize_session(PFS_thread *thread);
-  int do_materialize_session(PFS_thread *thread, uint index) { return 0; }
+  int do_materialize_all(THD* thd) override;
+  int do_materialize_session(THD *thd) override;
+  int do_materialize_session(PFS_thread *thread) override;
+  int do_materialize_session(PFS_thread *thread, uint index) override { return 0; }
   int do_materialize_client(PFS_client *pfs_client);
 
   /* Callback to sum user, host or account status variables. */

--- a/storage/perfschema/pfs_visitor.cc
+++ b/storage/perfschema/pfs_visitor.cc
@@ -49,7 +49,7 @@ public:
     : m_visitor(visitor)
   {}
 
-  virtual void operator()(THD *thd)
+  void operator()(THD *thd) override
   {
     m_visitor->visit_THD(thd);
   }
@@ -132,7 +132,7 @@ public:
     : m_visitor(visitor), m_host(host)
   {}
 
-  virtual void operator()(THD *thd)
+  void operator()(THD *thd) override
   {
     PSI_thread *psi= thd->get_psi();
     PFS_thread *pfs= reinterpret_cast<PFS_thread*>(psi);
@@ -221,7 +221,7 @@ public:
     : m_visitor(visitor), m_user(user)
   {}
 
-  virtual void operator()(THD *thd)
+  void operator()(THD *thd) override
   {
     PSI_thread *psi= thd->get_psi();
     PFS_thread *pfs= reinterpret_cast<PFS_thread*>(psi);
@@ -310,7 +310,7 @@ public:
     : m_visitor(visitor), m_account(account)
   {}
 
-  virtual void operator()(THD *thd)
+  void operator()(THD *thd) override
   {
     PSI_thread *psi= thd->get_psi();
     PFS_thread *pfs= reinterpret_cast<PFS_thread*>(psi);
@@ -752,7 +752,7 @@ public:
     : m_visitor(visitor)
   {}
 
-  virtual void operator()(PFS_table_share *pfs)
+  void operator()(PFS_table_share *pfs) override
   {
     if (pfs->m_enabled)
     {
@@ -772,7 +772,7 @@ public:
     : m_visitor(visitor)
   {}
 
-  virtual void operator()(PFS_table *pfs)
+  void operator()(PFS_table *pfs) override
   {
     PFS_table_share *safe_share= sanitize_table_share(pfs->m_share);
     if (safe_share != NULL)
@@ -811,7 +811,7 @@ public:
     : m_visitor(visitor), m_share(share)
   {}
 
-  virtual void operator()(PFS_table *pfs)
+  void operator()(PFS_table *pfs) override
   {
     if (pfs->m_share == m_share)
     {
@@ -852,7 +852,7 @@ public:
     : m_visitor(visitor), m_share(share), m_index(index)
   {}
 
-  virtual void operator()(PFS_table *pfs)
+  void operator()(PFS_table *pfs) override
   {
     if (pfs->m_share == m_share)
     {

--- a/storage/perfschema/pfs_visitor.h
+++ b/storage/perfschema/pfs_visitor.h
@@ -314,11 +314,11 @@ public:
   /** Constructor. */
   PFS_connection_wait_visitor(PFS_instr_class *klass);
   virtual ~PFS_connection_wait_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** EVENT_NAME instrument index. */
   uint m_index;
@@ -336,11 +336,11 @@ public:
   /** Constructor. */
   PFS_connection_all_wait_visitor();
   virtual ~PFS_connection_all_wait_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** Wait statistic collected. */
   PFS_single_stat m_stat;
@@ -359,11 +359,11 @@ public:
   /** Constructor. */
   PFS_connection_stage_visitor(PFS_stage_class *klass);
   virtual ~PFS_connection_stage_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** EVENT_NAME instrument index. */
   uint m_index;
@@ -381,11 +381,11 @@ public:
   /** Constructor. */
   PFS_connection_statement_visitor(PFS_statement_class *klass);
   virtual ~PFS_connection_statement_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** EVENT_NAME instrument index. */
   uint m_index;
@@ -403,11 +403,11 @@ public:
   /** Constructor. */
   PFS_connection_all_statement_visitor();
   virtual ~PFS_connection_all_statement_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** Statement statistic collected. */
   PFS_statement_stat m_stat;
@@ -426,11 +426,11 @@ public:
   /** Constructor. */
   PFS_connection_transaction_visitor(PFS_transaction_class *klass);
   virtual ~PFS_connection_transaction_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** EVENT_NAME instrument index. */
   uint m_index;
@@ -450,11 +450,11 @@ public:
   /** Constructor. */
   PFS_connection_all_transaction_visitor();
   virtual ~PFS_connection_all_transaction_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** Statement statistic collected. */
   PFS_transaction_stat m_stat;
@@ -474,11 +474,11 @@ public:
   /** Constructor. */
   PFS_connection_stat_visitor();
   virtual ~PFS_connection_stat_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** Connection statistic collected. */
   PFS_connection_stat m_stat;
@@ -494,11 +494,11 @@ public:
   /** Constructor. */
   PFS_connection_memory_visitor(PFS_memory_class *klass);
   virtual ~PFS_connection_memory_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
 
   /** EVENT_NAME instrument index. */
   uint m_index;
@@ -516,12 +516,12 @@ public:
   /** Constructor. */
   PFS_connection_status_visitor(STATUS_VAR *status_vars);
   virtual ~PFS_connection_status_visitor();
-  virtual void visit_global();
-  virtual void visit_host(PFS_host *pfs);
-  virtual void visit_account(PFS_account *pfs);
-  virtual void visit_user(PFS_user *pfs);
-  virtual void visit_thread(PFS_thread *pfs);
-  virtual void visit_THD(THD *thd);
+  void visit_global() override;
+  void visit_host(PFS_host *pfs) override;
+  void visit_account(PFS_account *pfs) override;
+  void visit_user(PFS_user *pfs) override;
+  void visit_thread(PFS_thread *pfs) override;
+  void visit_THD(THD *thd) override;
 
 private:
   STATUS_VAR *m_status_vars;
@@ -536,16 +536,16 @@ class PFS_instance_wait_visitor : public PFS_instance_visitor
 public:
   PFS_instance_wait_visitor();
   virtual ~PFS_instance_wait_visitor();
-  virtual void visit_mutex_class(PFS_mutex_class *pfs);
-  virtual void visit_rwlock_class(PFS_rwlock_class *pfs);
-  virtual void visit_cond_class(PFS_cond_class *pfs);
-  virtual void visit_file_class(PFS_file_class *pfs);
-  virtual void visit_socket_class(PFS_socket_class *pfs);
-  virtual void visit_mutex(PFS_mutex *pfs);
-  virtual void visit_rwlock(PFS_rwlock *pfs);
-  virtual void visit_cond(PFS_cond *pfs);
-  virtual void visit_file(PFS_file *pfs);
-  virtual void visit_socket(PFS_socket *pfs);
+  void visit_mutex_class(PFS_mutex_class *pfs) override;
+  void visit_rwlock_class(PFS_rwlock_class *pfs) override;
+  void visit_cond_class(PFS_cond_class *pfs) override;
+  void visit_file_class(PFS_file_class *pfs) override;
+  void visit_socket_class(PFS_socket_class *pfs) override;
+  void visit_mutex(PFS_mutex *pfs) override;
+  void visit_rwlock(PFS_rwlock *pfs) override;
+  void visit_cond(PFS_cond *pfs) override;
+  void visit_file(PFS_file *pfs) override;
+  void visit_socket(PFS_socket *pfs) override;
 
   /** Wait statistic collected. */
   PFS_single_stat m_stat;
@@ -560,9 +560,9 @@ class PFS_object_wait_visitor : public PFS_object_visitor
 public:
   PFS_object_wait_visitor();
   virtual ~PFS_object_wait_visitor();
-  virtual void visit_global();
-  virtual void visit_table_share(PFS_table_share *pfs);
-  virtual void visit_table(PFS_table *pfs);
+  void visit_global() override;
+  void visit_table_share(PFS_table_share *pfs) override;
+  void visit_table(PFS_table *pfs) override;
 
   /** Object wait statistic collected. */
   PFS_single_stat m_stat;
@@ -577,9 +577,9 @@ class PFS_table_io_wait_visitor : public PFS_object_visitor
 public:
   PFS_table_io_wait_visitor();
   virtual ~PFS_table_io_wait_visitor();
-  virtual void visit_global();
-  virtual void visit_table_share(PFS_table_share *pfs);
-  virtual void visit_table(PFS_table *pfs);
+  void visit_global() override;
+  void visit_table_share(PFS_table_share *pfs) override;
+  void visit_table(PFS_table *pfs) override;
 
   /** Table io wait statistic collected. */
   PFS_single_stat m_stat;
@@ -594,8 +594,8 @@ class PFS_table_io_stat_visitor : public PFS_object_visitor
 public:
   PFS_table_io_stat_visitor();
   virtual ~PFS_table_io_stat_visitor();
-  virtual void visit_table_share(PFS_table_share *pfs);
-  virtual void visit_table(PFS_table *pfs);
+  void visit_table_share(PFS_table_share *pfs) override;
+  void visit_table(PFS_table *pfs) override;
 
   /** Table io statistic collected. */
   PFS_table_io_stat m_stat;
@@ -610,8 +610,8 @@ class PFS_index_io_stat_visitor : public PFS_object_visitor
 public:
   PFS_index_io_stat_visitor();
   virtual ~PFS_index_io_stat_visitor();
-  virtual void visit_table_share_index(PFS_table_share *pfs, uint index);
-  virtual void visit_table_index(PFS_table *pfs, uint index);
+  void visit_table_share_index(PFS_table_share *pfs, uint index) override;
+  void visit_table_index(PFS_table *pfs, uint index) override;
 
   /** Index io statistic collected. */
   PFS_table_io_stat m_stat;
@@ -626,9 +626,9 @@ class PFS_table_lock_wait_visitor : public PFS_object_visitor
 public:
   PFS_table_lock_wait_visitor();
   virtual ~PFS_table_lock_wait_visitor();
-  virtual void visit_global();
-  virtual void visit_table_share(PFS_table_share *pfs);
-  virtual void visit_table(PFS_table *pfs);
+  void visit_global() override;
+  void visit_table_share(PFS_table_share *pfs) override;
+  void visit_table(PFS_table *pfs) override;
 
   /** Table lock wait statistic collected. */
   PFS_single_stat m_stat;
@@ -643,8 +643,8 @@ class PFS_table_lock_stat_visitor : public PFS_object_visitor
 public:
   PFS_table_lock_stat_visitor();
   virtual ~PFS_table_lock_stat_visitor();
-  virtual void visit_table_share(PFS_table_share *pfs);
-  virtual void visit_table(PFS_table *pfs);
+  void visit_table_share(PFS_table_share *pfs) override;
+  void visit_table(PFS_table *pfs) override;
 
   /** Table lock statistic collected. */
   PFS_table_lock_stat m_stat;
@@ -659,8 +659,8 @@ class PFS_instance_socket_io_stat_visitor : public PFS_instance_visitor
 public:
   PFS_instance_socket_io_stat_visitor();
   virtual ~PFS_instance_socket_io_stat_visitor();
-  virtual void visit_socket_class(PFS_socket_class *pfs);
-  virtual void visit_socket(PFS_socket *pfs);
+  void visit_socket_class(PFS_socket_class *pfs) override;
+  void visit_socket(PFS_socket *pfs) override;
 
   /** Wait and byte count statistics collected. */
   PFS_socket_io_stat m_socket_io_stat;
@@ -675,8 +675,8 @@ class PFS_instance_file_io_stat_visitor : public PFS_instance_visitor
 public:
   PFS_instance_file_io_stat_visitor();
   virtual ~PFS_instance_file_io_stat_visitor();
-  virtual void visit_file_class(PFS_file_class *pfs);
-  virtual void visit_file(PFS_file *pfs);
+  void visit_file_class(PFS_file_class *pfs) override;
+  void visit_file(PFS_file *pfs) override;
 
   /** Wait and byte count statistics collected. */
   PFS_file_io_stat m_file_io_stat;

--- a/storage/perfschema/table_accounts.h
+++ b/storage/perfschema/table_accounts.h
@@ -57,10 +57,10 @@ public:
   static int delete_all_rows();
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
 
 protected:
@@ -70,7 +70,7 @@ public:
   ~table_accounts() = default;
 
 private:
-  virtual void make_row(PFS_account *pfs);
+  void make_row(PFS_account *pfs) override;
 
   /** Table share lock. */
   static THR_LOCK m_table_lock;

--- a/storage/perfschema/table_all_instr.h
+++ b/storage/perfschema/table_all_instr.h
@@ -76,9 +76,9 @@ class table_all_instr : public PFS_engine_table
 public:
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override; 
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_all_instr(const PFS_engine_table_share *share);

--- a/storage/perfschema/table_esgs_by_account_by_event_name.h
+++ b/storage/perfschema/table_esgs_by_account_by_event_name.h
@@ -91,16 +91,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esgs_by_account_by_event_name();
 

--- a/storage/perfschema/table_esgs_by_host_by_event_name.h
+++ b/storage/perfschema/table_esgs_by_host_by_event_name.h
@@ -91,16 +91,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esgs_by_host_by_event_name();
 

--- a/storage/perfschema/table_esgs_by_thread_by_event_name.h
+++ b/storage/perfschema/table_esgs_by_thread_by_event_name.h
@@ -95,16 +95,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esgs_by_thread_by_event_name();
 

--- a/storage/perfschema/table_esgs_by_user_by_event_name.h
+++ b/storage/perfschema/table_esgs_by_user_by_event_name.h
@@ -96,16 +96,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esgs_by_user_by_event_name();
 

--- a/storage/perfschema/table_esgs_global_by_event_name.h
+++ b/storage/perfschema/table_esgs_global_by_event_name.h
@@ -62,16 +62,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esgs_global_by_event_name();
 

--- a/storage/perfschema/table_esms_by_account_by_event_name.h
+++ b/storage/perfschema/table_esms_by_account_by_event_name.h
@@ -91,16 +91,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esms_by_account_by_event_name();
 

--- a/storage/perfschema/table_esms_by_digest.h
+++ b/storage/perfschema/table_esms_by_digest.h
@@ -65,15 +65,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esms_by_digest();
 

--- a/storage/perfschema/table_esms_by_host_by_event_name.h
+++ b/storage/perfschema/table_esms_by_host_by_event_name.h
@@ -91,16 +91,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esms_by_host_by_event_name();
 

--- a/storage/perfschema/table_esms_by_program.h
+++ b/storage/perfschema/table_esms_by_program.h
@@ -75,15 +75,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esms_by_program();
 

--- a/storage/perfschema/table_esms_by_thread_by_event_name.h
+++ b/storage/perfschema/table_esms_by_thread_by_event_name.h
@@ -95,16 +95,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esms_by_thread_by_event_name();
 

--- a/storage/perfschema/table_esms_by_user_by_event_name.h
+++ b/storage/perfschema/table_esms_by_user_by_event_name.h
@@ -91,16 +91,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esms_by_user_by_event_name();
 

--- a/storage/perfschema/table_esms_global_by_event_name.h
+++ b/storage/perfschema/table_esms_global_by_event_name.h
@@ -62,16 +62,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_esms_global_by_event_name();
 

--- a/storage/perfschema/table_ets_by_account_by_event_name.h
+++ b/storage/perfschema/table_ets_by_account_by_event_name.h
@@ -95,16 +95,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ets_by_account_by_event_name();
 

--- a/storage/perfschema/table_ets_by_host_by_event_name.h
+++ b/storage/perfschema/table_ets_by_host_by_event_name.h
@@ -95,16 +95,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ets_by_host_by_event_name();
 

--- a/storage/perfschema/table_ets_by_thread_by_event_name.h
+++ b/storage/perfschema/table_ets_by_thread_by_event_name.h
@@ -99,16 +99,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ets_by_thread_by_event_name();
 

--- a/storage/perfschema/table_ets_by_user_by_event_name.h
+++ b/storage/perfschema/table_ets_by_user_by_event_name.h
@@ -95,16 +95,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ets_by_user_by_event_name();
 

--- a/storage/perfschema/table_ets_global_by_event_name.h
+++ b/storage/perfschema/table_ets_global_by_event_name.h
@@ -66,16 +66,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ets_global_by_event_name();
 

--- a/storage/perfschema/table_events_stages.h
+++ b/storage/perfschema/table_events_stages.h
@@ -100,10 +100,10 @@ struct pos_events_stages_history : public PFS_double_index
 class table_events_stages_common : public PFS_engine_table
 {
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_events_stages_common(const PFS_engine_table_share *share, void *pos);
 
@@ -128,10 +128,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_stages_current();
@@ -163,10 +163,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_stages_history();
@@ -195,10 +195,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_stages_history_long();

--- a/storage/perfschema/table_events_statements.h
+++ b/storage/perfschema/table_events_statements.h
@@ -183,10 +183,10 @@ struct pos_events_statements_history : public PFS_double_index
 class table_events_statements_common : public PFS_engine_table
 {
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_events_statements_common(const PFS_engine_table_share *share, void *pos);
 
@@ -215,10 +215,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_statements_current();
@@ -252,10 +252,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_statements_history();
@@ -286,10 +286,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_statements_history_long();

--- a/storage/perfschema/table_events_transactions.h
+++ b/storage/perfschema/table_events_transactions.h
@@ -127,10 +127,10 @@ struct pos_events_transactions_history : public PFS_double_index
 class table_events_transactions_common : public PFS_engine_table
 {
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_events_transactions_common(const PFS_engine_table_share *share, void *pos);
 
@@ -156,10 +156,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_transactions_current();
@@ -198,10 +198,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_transactions_history();
@@ -231,10 +231,10 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_transactions_history_long();

--- a/storage/perfschema/table_events_waits.h
+++ b/storage/perfschema/table_events_waits.h
@@ -139,10 +139,10 @@ struct pos_events_waits_history : public PFS_double_index
 class table_events_waits_common : public PFS_engine_table
 {
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_events_waits_common(const PFS_engine_table_share *share, void *pos);
 
@@ -173,9 +173,9 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_waits_current();
@@ -209,9 +209,9 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
   table_events_waits_history();
@@ -242,9 +242,9 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+    int rnd_pos(const void *pos) override;
+    void reset_position(void) override;;
 
 protected:
   table_events_waits_history_long();

--- a/storage/perfschema/table_events_waits_summary.h
+++ b/storage/perfschema/table_events_waits_summary.h
@@ -67,16 +67,16 @@ protected:
   void make_instr_row(PFS_instr *pfs, PFS_instr_class *klass,
                       const void *object_instance_begin,
                       PFS_single_stat *pfs_stat);
-  virtual void make_mutex_row(PFS_mutex *pfs);
-  virtual void make_rwlock_row(PFS_rwlock *pfs);
-  virtual void make_cond_row(PFS_cond *pfs);
-  virtual void make_file_row(PFS_file *pfs);
-  virtual void make_socket_row(PFS_socket *pfs);
+  void make_mutex_row(PFS_mutex *pfs) override;
+  void make_rwlock_row(PFS_rwlock *pfs) override;
+  void make_cond_row(PFS_cond *pfs) override;
+  void make_file_row(PFS_file *pfs) override;
+  void make_socket_row(PFS_socket *pfs) override;
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_events_waits_summary_by_instance();
 

--- a/storage/perfschema/table_ews_by_account_by_event_name.h
+++ b/storage/perfschema/table_ews_by_account_by_event_name.h
@@ -103,15 +103,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ews_by_account_by_event_name();
 

--- a/storage/perfschema/table_ews_by_host_by_event_name.h
+++ b/storage/perfschema/table_ews_by_host_by_event_name.h
@@ -103,15 +103,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ews_by_host_by_event_name();
 

--- a/storage/perfschema/table_ews_by_thread_by_event_name.h
+++ b/storage/perfschema/table_ews_by_thread_by_event_name.h
@@ -102,15 +102,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ews_by_thread_by_event_name();
 

--- a/storage/perfschema/table_ews_by_user_by_event_name.h
+++ b/storage/perfschema/table_ews_by_user_by_event_name.h
@@ -103,15 +103,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ews_by_user_by_event_name();
 

--- a/storage/perfschema/table_ews_global_by_event_name.h
+++ b/storage/perfschema/table_ews_global_by_event_name.h
@@ -91,15 +91,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_ews_global_by_event_name();
 

--- a/storage/perfschema/table_file_instances.h
+++ b/storage/perfschema/table_file_instances.h
@@ -61,15 +61,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_file_instances();
 

--- a/storage/perfschema/table_file_summary_by_event_name.h
+++ b/storage/perfschema/table_file_summary_by_event_name.h
@@ -62,15 +62,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_file_summary_by_event_name();
 

--- a/storage/perfschema/table_file_summary_by_instance.h
+++ b/storage/perfschema/table_file_summary_by_instance.h
@@ -70,15 +70,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_file_summary_by_instance();
 

--- a/storage/perfschema/table_global_status.h
+++ b/storage/perfschema/table_global_status.h
@@ -75,16 +75,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_global_status();
 
 public:

--- a/storage/perfschema/table_global_variables.h
+++ b/storage/perfschema/table_global_variables.h
@@ -74,16 +74,16 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_global_variables();
 
 public:

--- a/storage/perfschema/table_host_cache.h
+++ b/storage/perfschema/table_host_cache.h
@@ -114,15 +114,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_host_cache();
 

--- a/storage/perfschema/table_hosts.h
+++ b/storage/perfschema/table_hosts.h
@@ -57,11 +57,11 @@ public:
   static int delete_all_rows();
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
-
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
+    
 
 protected:
   table_hosts();
@@ -70,7 +70,7 @@ public:
   ~table_hosts() = default;
 
 private:
-  virtual void make_row(PFS_host *pfs);
+  void make_row(PFS_host *pfs) override;
 
   /** Table share lock. */
   static THR_LOCK m_table_lock;

--- a/storage/perfschema/table_md_locks.h
+++ b/storage/perfschema/table_md_locks.h
@@ -69,15 +69,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_metadata_locks();
 

--- a/storage/perfschema/table_mems_by_account_by_event_name.h
+++ b/storage/perfschema/table_mems_by_account_by_event_name.h
@@ -92,15 +92,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_mems_by_account_by_event_name();
 

--- a/storage/perfschema/table_mems_by_host_by_event_name.h
+++ b/storage/perfschema/table_mems_by_host_by_event_name.h
@@ -92,15 +92,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_mems_by_host_by_event_name();
 

--- a/storage/perfschema/table_mems_by_thread_by_event_name.h
+++ b/storage/perfschema/table_mems_by_thread_by_event_name.h
@@ -92,15 +92,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_mems_by_thread_by_event_name();
 

--- a/storage/perfschema/table_mems_by_user_by_event_name.h
+++ b/storage/perfschema/table_mems_by_user_by_event_name.h
@@ -92,15 +92,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_mems_by_user_by_event_name();
 

--- a/storage/perfschema/table_mems_global_by_event_name.h
+++ b/storage/perfschema/table_mems_global_by_event_name.h
@@ -94,15 +94,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_mems_global_by_event_name();
 

--- a/storage/perfschema/table_os_global_by_type.h
+++ b/storage/perfschema/table_os_global_by_type.h
@@ -93,15 +93,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_os_global_by_type();
 

--- a/storage/perfschema/table_performance_timers.h
+++ b/storage/perfschema/table_performance_timers.h
@@ -59,15 +59,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
 protected:
   table_performance_timers();

--- a/storage/perfschema/table_prepared_stmt_instances.h
+++ b/storage/perfschema/table_prepared_stmt_instances.h
@@ -94,15 +94,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_prepared_stmt_instances();
 

--- a/storage/perfschema/table_replication_applier_configuration.h
+++ b/storage/perfschema/table_replication_applier_configuration.h
@@ -83,10 +83,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_applier_configuration();
 
@@ -98,9 +98,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_replication_applier_status.h
+++ b/storage/perfschema/table_replication_applier_status.h
@@ -94,10 +94,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_applier_status();
 
@@ -109,9 +109,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_replication_applier_status_by_coordinator.h
+++ b/storage/perfschema/table_replication_applier_status_by_coordinator.h
@@ -100,10 +100,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_applier_status_by_coordinator();
 
@@ -115,9 +115,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_replication_applier_status_by_worker.h
+++ b/storage/perfschema/table_replication_applier_status_by_worker.h
@@ -158,10 +158,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_applier_status_by_worker();
 
@@ -173,9 +173,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_replication_connection_configuration.h
+++ b/storage/perfschema/table_replication_connection_configuration.h
@@ -128,10 +128,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_connection_configuration();
 
@@ -143,9 +143,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_replication_connection_status.h
+++ b/storage/perfschema/table_replication_connection_status.h
@@ -126,10 +126,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_connection_status();
 
@@ -141,9 +141,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_replication_group_member_stats.h
+++ b/storage/perfschema/table_replication_group_member_stats.h
@@ -91,10 +91,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_group_member_stats();
 
@@ -106,9 +106,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_replication_group_members.h
+++ b/storage/perfschema/table_replication_group_members.h
@@ -84,10 +84,10 @@ protected:
     @param read_all         true if all columns are read.
   */
 
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_replication_group_members();
 
@@ -99,9 +99,9 @@ public:
   static PFS_engine_table_share m_share;
   static PFS_engine_table* create();
   static ha_rows get_row_count();
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 };
 

--- a/storage/perfschema/table_session_account_connect_attrs.h
+++ b/storage/perfschema/table_session_account_connect_attrs.h
@@ -46,7 +46,7 @@ public:
   ~table_session_account_connect_attrs() = default;
 
 protected:
-  virtual bool thread_fits(PFS_thread *thread);
+  bool thread_fits(PFS_thread *thread) override;
 
 private:
   /** Table share lock. */

--- a/storage/perfschema/table_session_connect.h
+++ b/storage/perfschema/table_session_connect.h
@@ -69,10 +69,10 @@ public:
   ~table_session_connect();
 
 protected:
-  virtual void make_row(PFS_thread *pfs, uint ordinal);
+  void make_row(PFS_thread *pfs, uint ordinal) override;
   virtual bool thread_fits(PFS_thread *thread);
-  virtual int read_row_values(TABLE *table, unsigned char *buf,
-                              Field **fields, bool read_all);
+  int read_row_values(TABLE *table, unsigned char *buf,
+                      Field **fields, bool read_all) override;
 protected:
   /** Current row. */
   row_session_connect_attrs m_row;

--- a/storage/perfschema/table_session_status.h
+++ b/storage/perfschema/table_session_status.h
@@ -76,16 +76,16 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_session_status();
 
 public:

--- a/storage/perfschema/table_session_variables.h
+++ b/storage/perfschema/table_session_variables.h
@@ -74,16 +74,16 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_session_variables();
 
 public:

--- a/storage/perfschema/table_setup_actors.h
+++ b/storage/perfschema/table_setup_actors.h
@@ -71,24 +71,24 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
-  virtual int update_row_values(TABLE *table,
-                                const unsigned char *old_buf,
-                                const unsigned char *new_buf,
-                                Field **fields);
+  int update_row_values(TABLE *table,
+                        const unsigned char *old_buf,
+                        const unsigned char *new_buf,
+                        Field **fields) override;
 
-  virtual int delete_row_values(TABLE *table,
-                                const unsigned char *buf,
-                                Field **fields);
+  int delete_row_values(TABLE *table,
+                        const unsigned char *buf,
+                        Field **fields) override;
 
   table_setup_actors();
 

--- a/storage/perfschema/table_setup_consumers.h
+++ b/storage/perfschema/table_setup_consumers.h
@@ -59,20 +59,20 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
-  virtual int update_row_values(TABLE *table,
-                                const unsigned char *old_buf,
-                                const unsigned char *new_buf,
-                                Field **fields);
+  int update_row_values(TABLE *table,
+                        const unsigned char *old_buf,
+                        const unsigned char *new_buf,
+                        Field **fields) override;
 
   table_setup_consumers();
 

--- a/storage/perfschema/table_setup_instruments.h
+++ b/storage/perfschema/table_setup_instruments.h
@@ -97,21 +97,21 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
-
-  virtual int update_row_values(TABLE *table,
-                                const unsigned char *old_buf,
-                                const unsigned char *new_buf,
-                                Field **fields);
-
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
+    
+  int update_row_values(TABLE *table,
+                        const unsigned char *old_buf,
+                        const unsigned char *new_buf,
+                        Field **fields) override;
+    
   table_setup_instruments();
 
 public:

--- a/storage/perfschema/table_setup_objects.h
+++ b/storage/perfschema/table_setup_objects.h
@@ -70,24 +70,24 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
-  virtual int update_row_values(TABLE *table,
-                                const unsigned char *old_buf,
-                                const unsigned char *new_buf,
-                                Field **fields);
-
-  virtual int delete_row_values(TABLE *table,
-                                const unsigned char *buf,
-                                Field **fields);
+  int update_row_values(TABLE *table,
+                        const unsigned char *old_buf,
+                        const unsigned char *new_buf,
+                        Field **fields) override;
+    
+  int delete_row_values(TABLE *table,
+                        const unsigned char *buf,
+                        Field **fields) override;
 
   table_setup_objects();
 

--- a/storage/perfschema/table_setup_timers.h
+++ b/storage/perfschema/table_setup_timers.h
@@ -55,20 +55,20 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
-  virtual int update_row_values(TABLE *table,
-                                const unsigned char *old_buf,
-                                const unsigned char *new_buf,
-                                Field **fields);
+  int update_row_values(TABLE *table,
+                        const unsigned char *old_buf,
+                        const unsigned char *new_buf,
+                        Field **fields) override;
 
   table_setup_timers();
 

--- a/storage/perfschema/table_socket_instances.h
+++ b/storage/perfschema/table_socket_instances.h
@@ -73,15 +73,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_socket_instances();
 

--- a/storage/perfschema/table_socket_summary_by_event_name.h
+++ b/storage/perfschema/table_socket_summary_by_event_name.h
@@ -63,15 +63,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_socket_summary_by_event_name();
 

--- a/storage/perfschema/table_socket_summary_by_instance.h
+++ b/storage/perfschema/table_socket_summary_by_instance.h
@@ -66,15 +66,15 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_socket_summary_by_instance();
 

--- a/storage/perfschema/table_status_by_account.h
+++ b/storage/perfschema/table_status_by_account.h
@@ -111,16 +111,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_status_by_account();
 
 public:

--- a/storage/perfschema/table_status_by_host.h
+++ b/storage/perfschema/table_status_by_host.h
@@ -109,16 +109,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_status_by_host();
 
 public:

--- a/storage/perfschema/table_status_by_thread.h
+++ b/storage/perfschema/table_status_by_thread.h
@@ -107,16 +107,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_status_by_thread();
 
 public:

--- a/storage/perfschema/table_status_by_user.h
+++ b/storage/perfschema/table_status_by_user.h
@@ -109,16 +109,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_status_by_user();
 
 public:

--- a/storage/perfschema/table_sync_instances.h
+++ b/storage/perfschema/table_sync_instances.h
@@ -65,15 +65,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_mutex_instances();
 
@@ -123,15 +123,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_rwlock_instances();
 
@@ -175,15 +175,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 private:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_cond_instances();
 

--- a/storage/perfschema/table_table_handles.h
+++ b/storage/perfschema/table_table_handles.h
@@ -69,16 +69,16 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_table_handles();
 

--- a/storage/perfschema/table_threads.h
+++ b/storage/perfschema/table_threads.h
@@ -95,16 +95,16 @@ public:
   static PFS_engine_table* create();
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
+    
 
-
-  virtual int update_row_values(TABLE *table,
-                                const unsigned char *old_buf,
-                                const unsigned char *new_buf,
-                                Field **fields);
+  int update_row_values(TABLE *table,
+                        const unsigned char *old_buf,
+                        const unsigned char *new_buf,
+                        Field **fields) override;
 
 protected:
   table_threads();
@@ -113,7 +113,7 @@ public:
   ~table_threads() = default;
 
 private:
-  virtual void make_row(PFS_thread *pfs);
+  void make_row(PFS_thread *pfs) override;
 
   /** Table share lock. */
   static THR_LOCK m_table_lock;

--- a/storage/perfschema/table_tiws_by_index_usage.h
+++ b/storage/perfschema/table_tiws_by_index_usage.h
@@ -87,16 +87,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_tiws_by_index_usage();
 

--- a/storage/perfschema/table_tiws_by_table.h
+++ b/storage/perfschema/table_tiws_by_table.h
@@ -62,16 +62,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_tiws_by_table();
 

--- a/storage/perfschema/table_tlws_by_table.h
+++ b/storage/perfschema/table_tlws_by_table.h
@@ -62,16 +62,16 @@ public:
   static int delete_all_rows();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_tlws_by_table();
 

--- a/storage/perfschema/table_users.h
+++ b/storage/perfschema/table_users.h
@@ -57,10 +57,10 @@ public:
   static int delete_all_rows();
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
 
 protected:
@@ -70,7 +70,7 @@ public:
   ~table_users() = default;
 
 private:
-  virtual void make_row(PFS_user *pfs);
+  void make_row(PFS_user *pfs) override;
 
   /** Table share lock. */
   static THR_LOCK m_table_lock;

--- a/storage/perfschema/table_uvar_by_thread.cc
+++ b/storage/perfschema/table_uvar_by_thread.cc
@@ -46,7 +46,7 @@ public:
     : m_unsafe_thd(unsafe_thd)
   {}
 
-  virtual bool operator()(THD *thd)
+  bool operator()(THD *thd) override
   {
     if (thd != m_unsafe_thd)
       return false;

--- a/storage/perfschema/table_uvar_by_thread.h
+++ b/storage/perfschema/table_uvar_by_thread.h
@@ -154,15 +154,15 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
 
   table_uvar_by_thread();
 

--- a/storage/perfschema/table_variables_by_thread.h
+++ b/storage/perfschema/table_variables_by_thread.h
@@ -107,16 +107,16 @@ public:
   static PFS_engine_table* create();
   static ha_rows get_row_count();
 
-  virtual int rnd_init(bool scan);
-  virtual int rnd_next();
-  virtual int rnd_pos(const void *pos);
-  virtual void reset_position(void);
+  int rnd_init(bool scan) override;
+  int rnd_next() override;
+  int rnd_pos(const void *pos) override;
+  void reset_position(void) override;
 
 protected:
-  virtual int read_row_values(TABLE *table,
-                              unsigned char *buf,
-                              Field **fields,
-                              bool read_all);
+  int read_row_values(TABLE *table,
+                      unsigned char *buf,
+                      Field **fields,
+                      bool read_all) override;
   table_variables_by_thread();
 
 public:

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3169,7 +3169,7 @@ class Rdb_transaction_impl : public Rdb_transaction {
     }
   }
 
-  virtual bool is_writebatch_trx() const override { return false; }
+  bool is_writebatch_trx() const override { return false; }
 
   bool is_prepared() override {
     return m_rocksdb_tx && rocksdb::Transaction::PREPARED == m_rocksdb_tx->GetState();
@@ -3514,7 +3514,7 @@ private:
     m_notifier = std::make_shared<Rdb_snapshot_notifier>(this);
   }
 
-  virtual ~Rdb_transaction_impl() override {
+  ~Rdb_transaction_impl() override {
     rollback();
 
     // Theoretically the notifier could outlive the Rdb_transaction_impl
@@ -3720,7 +3720,7 @@ class Rdb_writebatch_impl : public Rdb_transaction {
                                                true);
   }
 
-  virtual ~Rdb_writebatch_impl() override {
+  ~Rdb_writebatch_impl() override {
     rollback();
     delete m_batch;
   }

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -441,7 +441,7 @@ class ha_rocksdb : public my_core::handler {
 
   ha_rocksdb(my_core::handlerton *const hton,
              my_core::TABLE_SHARE *const table_arg);
-  virtual ~ha_rocksdb() override {
+  ~ha_rocksdb() override {
     int err MY_ATTRIBUTE((__unused__));
     err = finalize_bulk_load(false);
     if (err != 0) {
@@ -458,7 +458,7 @@ class ha_rocksdb : public my_core::handler {
 
     const char *table_type() const
 
-    is non-virtual in class handler, so there's no point to override it.
+    is non-in class handler, so there's no point to override it.
   */
 
   /* The following is only used by SHOW KEYS: */
@@ -623,15 +623,15 @@ public:
                        bool sorted) override
       MY_ATTRIBUTE((__warn_unused_result__));
 
-  virtual double scan_time() override {
+  double scan_time() override {
     DBUG_ENTER_FUNC();
 
     DBUG_RETURN(
         static_cast<double>((stats.records + stats.deleted) / 20.0 + 10));
   }
 
-  virtual double read_time(uint, uint, ha_rows rows) override;
-  virtual void print_error(int error, myf errflag) override;
+  double read_time(uint, uint, ha_rows rows) override;
+  void print_error(int error, myf errflag) override;
 
   int open(const char *const name, int mode, uint test_if_locked) override
       MY_ATTRIBUTE((__warn_unused_result__));
@@ -977,11 +977,11 @@ public:
 
 #ifdef MARIAROCKS_NOT_YET // MDEV-10976
  public:
-  virtual void rpl_before_delete_rows() override;
-  virtual void rpl_after_delete_rows() override;
-  virtual void rpl_before_update_rows() override;
-  virtual void rpl_after_update_rows() override;
-  virtual bool use_read_free_rpl() const override;
+  void rpl_before_delete_rows() override;
+  void rpl_after_delete_rows() override;
+  void rpl_before_update_rows() override;
+  void rpl_after_update_rows() override;
+  bool use_read_free_rpl() const override;
 #endif // MARIAROCKS_NOT_YET
 
  private:

--- a/storage/rocksdb/properties_collector.h
+++ b/storage/rocksdb/properties_collector.h
@@ -128,7 +128,7 @@ class Rdb_tbl_prop_coll : public rocksdb::TablePropertiesCollector {
   virtual rocksdb::Status Finish(
       rocksdb::UserCollectedProperties *properties) override;
 
-  virtual const char *Name() const override { return "Rdb_tbl_prop_coll"; }
+  const char *Name() const override { return "Rdb_tbl_prop_coll"; }
 
   rocksdb::UserCollectedProperties GetReadableProperties() const override;
 
@@ -193,7 +193,7 @@ class Rdb_tbl_prop_coll_factory
                                  m_table_stats_sampling_pct);
   }
 
-  virtual const char *Name() const override {
+  const char *Name() const override {
     return "Rdb_tbl_prop_coll_factory";
   }
 

--- a/storage/rocksdb/rdb_compact_filter.h
+++ b/storage/rocksdb/rdb_compact_filter.h
@@ -105,9 +105,9 @@ class Rdb_compact_filter : public rocksdb::CompactionFilter {
     return false;
   }
 
-  virtual bool IgnoreSnapshots() const override { return true; }
+  bool IgnoreSnapshots() const override { return true; }
 
-  virtual const char *Name() const override { return "Rdb_compact_filter"; }
+  const char *Name() const override { return "Rdb_compact_filter"; }
 
   void get_ttl_duration_and_offset(const GL_INDEX_ID &gl_index_id,
                                    uint64 *ttl_duration,

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1582,7 +1582,7 @@ class Rdb_system_merge_op : public rocksdb::AssociativeMergeOperator {
     return true;
   }
 
-  virtual const char *Name() const override { return "Rdb_system_merge_op"; }
+  const char *Name() const override { return "Rdb_system_merge_op"; }
 
  private:
   /*

--- a/storage/rocksdb/rdb_mutex_wrapper.h
+++ b/storage/rocksdb/rdb_mutex_wrapper.h
@@ -39,7 +39,7 @@ class Rdb_mutex : public rocksdb::TransactionDBMutex {
 
  public:
   Rdb_mutex();
-  virtual ~Rdb_mutex() override;
+  ~Rdb_mutex() override;
 
   /*
     Override parent class's virtual methods of interrest.
@@ -47,7 +47,7 @@ class Rdb_mutex : public rocksdb::TransactionDBMutex {
 
   // Attempt to acquire lock.  Return OK on success, or other Status on failure.
   // If returned status is OK, TransactionDB will eventually call UnLock().
-  virtual rocksdb::Status Lock() override;
+  rocksdb::Status Lock() override;
 
   // Attempt to acquire lock.  If timeout is non-negative, operation should be
   // failed after this many microseconds.
@@ -59,7 +59,7 @@ class Rdb_mutex : public rocksdb::TransactionDBMutex {
       int64_t timeout_time MY_ATTRIBUTE((__unused__))) override;
 
   // Unlock Mutex that was successfully locked by Lock() or TryLockUntil()
-  virtual void UnLock() override;
+  void UnLock() override;
 
  private:
   mysql_mutex_t m_mutex;
@@ -77,7 +77,7 @@ class Rdb_cond_var : public rocksdb::TransactionDBCondVar {
 
  public:
   Rdb_cond_var();
-  virtual ~Rdb_cond_var() override;
+  ~Rdb_cond_var() override;
 
   /*
     Override parent class's virtual methods of interrest.
@@ -109,10 +109,10 @@ class Rdb_cond_var : public rocksdb::TransactionDBCondVar {
 
   // If any threads are waiting on *this, unblock at least one of the
   // waiting threads.
-  virtual void Notify() override;
+  void Notify() override;
 
   // Unblocks all threads waiting on *this.
-  virtual void NotifyAll() override;
+  void NotifyAll() override;
 
  private:
   mysql_cond_t m_cond;
@@ -137,7 +137,7 @@ class Rdb_mutex_factory : public rocksdb::TransactionDBMutexFactory {
     return std::make_shared<Rdb_cond_var>();
   }
 
-  virtual ~Rdb_mutex_factory() override = default;
+  ~Rdb_mutex_factory() override = default;
 };
 
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -148,7 +148,7 @@ class Rdb_background_thread : public Rdb_thread {
   }
 
  public:
-  virtual void run() override;
+  void run() override;
 
   void request_save_stats() {
     RDB_MUTEX_LOCK_CHECK(m_signal_mutex);
@@ -175,7 +175,7 @@ class Rdb_manual_compaction_thread : public Rdb_thread {
   std::map<int, Manual_compaction_request> m_requests;
 
  public:
-  virtual void run() override;
+  void run() override;
   int request_manual_compaction(rocksdb::ColumnFamilyHandle *cf,
                                 rocksdb::Slice *start, rocksdb::Slice *limit,
                                 int concurrency = 0);
@@ -189,7 +189,7 @@ class Rdb_manual_compaction_thread : public Rdb_thread {
 */
 
 struct Rdb_drop_index_thread : public Rdb_thread {
-  virtual void run() override;
+  void run() override;
 };
 
 }  // namespace myrocks

--- a/storage/sequence/sequence.cc
+++ b/storage/sequence/sequence.cc
@@ -47,7 +47,7 @@ public:
   {
     thr_lock_init(&lock);
   }
-  ~Sequence_share()
+  ~Sequence_share() override
   {
     thr_lock_delete(&lock);
   }
@@ -64,45 +64,45 @@ public:
   Sequence_share *seqs;
   ha_seq(handlerton *hton, TABLE_SHARE *table_arg)
     : handler(hton, table_arg), seqs(0) { }
-  ulonglong table_flags() const
+  ulonglong table_flags() const override
   { return HA_BINLOG_ROW_CAPABLE | HA_BINLOG_STMT_CAPABLE; }
 
   /* open/close/locking */
   int create(const char *name, TABLE *table_arg,
-             HA_CREATE_INFO *create_info)
+             HA_CREATE_INFO *create_info) override
   { return HA_ERR_WRONG_COMMAND; }
 
-  int open(const char *name, int mode, uint test_if_locked);
-  int close(void);
-  int delete_table(const char *name)
+  int open(const char *name, int mode, uint test_if_locked) override;
+  int close(void) override;
+  int delete_table(const char *name) override
   {
     return 0;
   }
-  THR_LOCK_DATA **store_lock(THD *, THR_LOCK_DATA **, enum thr_lock_type);
+  THR_LOCK_DATA **store_lock(THD *, THR_LOCK_DATA **, enum thr_lock_type) override;
 
   /* table scan */
-  int rnd_init(bool scan);
-  int rnd_next(unsigned char *buf);
-  void position(const uchar *record);
-  int rnd_pos(uchar *buf, uchar *pos);
-  int info(uint flag);
+  int rnd_init(bool scan) override;
+  int rnd_next(unsigned char *buf) override;
+  void position(const uchar *record) override;
+  int rnd_pos(uchar *buf, uchar *pos) override;
+  int info(uint flag) override;
 
   /* indexes */
-  ulong index_flags(uint inx, uint part, bool all_parts) const
+  ulong index_flags(uint inx, uint part, bool all_parts) const override
   { return HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER |
            HA_READ_RANGE | HA_KEYREAD_ONLY; }
-  uint max_supported_keys() const { return 1; }
+  uint max_supported_keys() const override { return 1; }
   int index_read_map(uchar *buf, const uchar *key, key_part_map keypart_map,
-                     enum ha_rkey_function find_flag);
-  int index_next(uchar *buf);
-  int index_prev(uchar *buf);
-  int index_first(uchar *buf);
-  int index_last(uchar *buf);
+                     enum ha_rkey_function find_flag) override;
+  int index_next(uchar *buf) override;
+  int index_prev(uchar *buf) override;
+  int index_first(uchar *buf) override;
+  int index_last(uchar *buf) override;
   ha_rows records_in_range(uint inx, const key_range *start_key,
-                           const key_range *end_key, page_range *pages);
-  double scan_time() { return (double)nvalues(); }
-  double read_time(uint index, uint ranges, ha_rows rows) { return (double)rows; }
-  double keyread_time(uint index, uint ranges, ha_rows rows) { return (double)rows; }
+                           const key_range *end_key, page_range *pages) override;
+  double scan_time() override { return (double)nvalues(); }
+  double read_time(uint index, uint ranges, ha_rows rows) override { return (double)rows; }
+  double keyread_time(uint index, uint ranges, ha_rows rows) override { return (double)rows; }
 
 private:
   void set(uchar *buf);
@@ -382,10 +382,10 @@ public:
       // Reset limit because we are handling it now
       orig_lim->set_unlimited();
     }
-  ~ha_seq_group_by_handler() = default;
-  int init_scan() { first_row= 1 ; return 0; }
-  int next_row();
-  int end_scan()  { return 0; }
+  ~ha_seq_group_by_handler() override = default;
+  int init_scan() override { first_row= 1 ; return 0; }
+  int next_row() override;
+  int end_scan() override  { return 0; }
 };
 
 static group_by_handler *

--- a/storage/sphinx/ha_sphinx.h
+++ b/storage/sphinx/ha_sphinx.h
@@ -56,84 +56,84 @@ public:
 					~ha_sphinx ();
 
 	const char *	table_type () const		{ return "SPHINX"; }	///< SE name for display purposes
-	const char *	index_type ( uint )		{ return "HASH"; }		///< index type name for display purposes
+	const char *	index_type ( uint ) override		{ return "HASH"; }		///< index type name for display purposes
 
 	#if MYSQL_VERSION_ID>50100
-	ulonglong		table_flags () const	{ return HA_CAN_INDEX_BLOBS | 
+	ulonglong		table_flags () const override	{ return HA_CAN_INDEX_BLOBS | 
                                                                  HA_CAN_TABLE_CONDITION_PUSHDOWN; } ///< bitmap of implemented flags (see handler.h for more info)
 	#else
 	ulong			table_flags () const	{ return HA_CAN_INDEX_BLOBS; }			///< bitmap of implemented flags (see handler.h for more info)
 	#endif
 
-	ulong			index_flags ( uint, uint, bool ) const	{ return 0; }	///< bitmap of flags that says how SE implements indexes
-	uint			max_supported_record_length () const	{ return HA_MAX_REC_LENGTH; }
-	uint			max_supported_keys () const				{ return 1; }
-	uint			max_supported_key_parts () const		{ return 1; }
-	uint			max_supported_key_length () const		{ return MAX_KEY_LENGTH; }
-	uint			max_supported_key_part_length () const	{ return MAX_KEY_LENGTH; }
+	ulong			index_flags ( uint, uint, bool ) const override	{ return 0; }	///< bitmap of flags that says how SE implements indexes
+	uint			max_supported_record_length () const override	{ return HA_MAX_REC_LENGTH; }
+	uint			max_supported_keys () const override				{ return 1; }
+	uint			max_supported_key_parts () const override		{ return 1; }
+	uint			max_supported_key_length () const override		{ return MAX_KEY_LENGTH; }
+	uint			max_supported_key_part_length () const override	{ return MAX_KEY_LENGTH; }
 
 	#if MYSQL_VERSION_ID>50100
-	virtual double	scan_time ()	{ return (double)( stats.records+stats.deleted )/20.0 + 10; }	///< called in test_quick_select to determine if indexes should be used
+	double	scan_time () override	{ return (double)( stats.records+stats.deleted )/20.0 + 10; }	///< called in test_quick_select to determine if indexes should be used
 	#else
 	virtual double	scan_time ()	{ return (double)( records+deleted )/20.0 + 10; }				///< called in test_quick_select to determine if indexes should be used
 	#endif
 
-        virtual double read_time(uint index, uint ranges, ha_rows rows)
+        double read_time(uint index, uint ranges, ha_rows rows) override
 	{ return ranges + (double)rows/20.0 + 1; }					///< index read time estimate
 
 public:
-	int				open ( const char * name, int mode, uint test_if_locked );
-	int				close ();
+	int				open ( const char * name, int mode, uint test_if_locked ) override;
+	int				close () override;
 
-	int				write_row ( const byte * buf );
-	int				update_row ( const byte * old_data, const byte * new_data );
-	int				delete_row ( const byte * buf );
-	int				extra ( enum ha_extra_function op );
+	int				write_row ( const byte * buf ) override;
+	int				update_row ( const byte * old_data, const byte * new_data ) override;
+	int				delete_row ( const byte * buf ) override;
+	int				extra ( enum ha_extra_function op ) override;
 
-	int				index_init ( uint keynr, bool sorted ); // 5.1.x
+	int				index_init ( uint keynr, bool sorted ) override; // 5.1.x
 	int				index_init ( uint keynr ) { return index_init ( keynr, false ); } // 5.0.x
 
-	int				index_end ();
-	int				index_read ( byte * buf, const byte * key, uint key_len, enum ha_rkey_function find_flag );
+	int				index_end () override;
+	int				index_read ( byte * buf, const byte * key, uint key_len, enum ha_rkey_function find_flag ) override;
 	int				index_read_idx ( byte * buf, uint idx, const byte * key, uint key_len, enum ha_rkey_function find_flag );
-	int				index_next ( byte * buf );
-	int				index_next_same ( byte * buf, const byte * key, uint keylen );
-	int				index_prev ( byte * buf );
-	int				index_first ( byte * buf );
-	int				index_last ( byte * buf );
+	int				index_next ( byte * buf ) override;
+	int				index_next_same ( byte * buf, const byte * key, uint keylen ) override;
+	int				index_prev ( byte * buf ) override;
+	int				index_first ( byte * buf ) override;
+	int				index_last ( byte * buf ) override;
 
 	int				get_rec ( byte * buf, const byte * key, uint keylen );
 
-	int				rnd_init ( bool scan );
-	int				rnd_end ();
-	int				rnd_next ( byte * buf );
-	int				rnd_pos ( byte * buf, byte * pos );
-	void			position ( const byte * record );
+	int				rnd_init ( bool scan ) override;
+	int				rnd_end () override;
+	int				rnd_next ( byte * buf ) override;
+	int				rnd_pos ( byte * buf, byte * pos ) override;
+	void			position ( const byte * record ) override;
 
 #if MYSQL_VERSION_ID>=50030
-	int				info ( uint );
+	int				info ( uint ) override;
 #else
 	void			info ( uint );
 #endif
 
-	int				reset();
-	int				external_lock ( THD * thd, int lock_type );
-	int				delete_all_rows ();
-	ha_rows			        records_in_range ( uint inx, const key_range * min_key, const key_range * max_key,  page_range *pages);
+	int				reset() override;
+	int				external_lock ( THD * thd, int lock_type ) override;
+	int				delete_all_rows () override;
+	ha_rows			        records_in_range ( uint inx, const key_range * min_key, const key_range * max_key,  page_range *pages) override;
 
-	int				delete_table ( const char * from );
-	int				rename_table ( const char * from, const char * to );
-	int				create ( const char * name, TABLE * form, HA_CREATE_INFO * create_info );
+	int				delete_table ( const char * from ) override;
+	int				rename_table ( const char * from, const char * to ) override;
+	int				create ( const char * name, TABLE * form, HA_CREATE_INFO * create_info ) override;
 
-	THR_LOCK_DATA **		store_lock ( THD * thd, THR_LOCK_DATA ** to, enum thr_lock_type lock_type );
+	THR_LOCK_DATA **		store_lock ( THD * thd, THR_LOCK_DATA ** to, enum thr_lock_type lock_type ) override;
 
 public:
 #if MYSQL_VERSION_ID<50610
 	virtual const COND *	cond_push ( const COND *cond );
 #else
-	virtual const Item *		cond_push ( const Item *cond );
+	const Item *		cond_push ( const Item *cond ) override;
 #endif	
-	virtual void			cond_pop ();
+	void			cond_pop () override;
 
 private:
 	uint32			m_iFields;

--- a/storage/spider/ha_spider.h
+++ b/storage/spider/ha_spider.h
@@ -208,14 +208,14 @@ public:
   handler *clone(
     const char *name,
     MEM_ROOT *mem_root
-  );
+  ) override;
   const char **bas_ext() const;
   int open(
     const char* name,
     int mode,
     uint test_if_locked
-  );
-  int close();
+  ) override;
+  int close() override;
   int check_access_kind_for_connection(
     THD *thd,
     bool write_request
@@ -233,30 +233,30 @@ public:
     THD *thd,
     THR_LOCK_DATA **to,
     enum thr_lock_type lock_type
-  );
+  ) override;
   int external_lock(
     THD *thd,
     int lock_type
-  );
+  ) override;
   int start_stmt(
     THD *thd,
     thr_lock_type lock_type
-  );
-  int reset();
+  ) override;
+  int reset() override;
   int extra(
     enum ha_extra_function operation
-  );
+  ) override;
   int index_init(
     uint idx,
     bool sorted
-  );
+  ) override;
 #ifdef HA_CAN_BULK_ACCESS
   int pre_index_init(
     uint idx,
     bool sorted
   );
 #endif
-  int index_end();
+  int index_end() override;
 #ifdef HA_CAN_BULK_ACCESS
   int pre_index_end();
 #endif
@@ -265,36 +265,36 @@ public:
     const uchar *key,
     key_part_map keypart_map,
     enum ha_rkey_function find_flag
-  );
+  ) override;
   int index_read_last_map(
     uchar *buf,
     const uchar *key,
     key_part_map keypart_map
-  );
+  ) override;
   int index_next(
     uchar *buf
-  );
+  ) override;
   int index_prev(
     uchar *buf
-  );
+  ) override;
   int index_first(
     uchar *buf
-  );
+  ) override;
   int index_last(
     uchar *buf
-  );
+  ) override;
   int index_next_same(
     uchar *buf,
     const uchar *key,
     uint keylen
-  );
+  ) override;
   int read_range_first(
     const key_range *start_key,
     const key_range *end_key,
     bool eq_range,
     bool sorted
-  );
-  int read_range_next();
+  ) override;
+  int read_range_next() override;
   void reset_no_where_cond();
   bool check_no_where_cond();
 #ifdef HA_MRR_USE_DEFAULT_IMPL
@@ -306,7 +306,7 @@ public:
     uint *bufsz,
     uint *flags,
     Cost_estimate *cost
-  );
+  ) override;
   ha_rows multi_range_read_info(
     uint keyno,
     uint n_ranges,
@@ -315,17 +315,17 @@ public:
     uint *bufsz,
     uint *flags,
     Cost_estimate *cost
-  );
+  ) override;
   int multi_range_read_init(
     RANGE_SEQ_IF *seq,
     void *seq_init_param,
     uint n_ranges,
     uint mode,
     HANDLER_BUFFER *buf
-  );
+  ) override;
   int multi_range_read_next(
     range_id_t *range_info
-  );
+  ) override;
   int multi_range_read_next_first(
     range_id_t *range_info
   );
@@ -346,57 +346,57 @@ public:
 #endif
   int rnd_init(
     bool scan
-  );
+  ) override;
 #ifdef HA_CAN_BULK_ACCESS
   int pre_rnd_init(
     bool scan
   );
 #endif
-  int rnd_end();
+  int rnd_end() override;
 #ifdef HA_CAN_BULK_ACCESS
   int pre_rnd_end();
 #endif
   int rnd_next(
     uchar *buf
-  );
+  ) override;
   void position(
     const uchar *record
-  );
+  ) override;
   int rnd_pos(
     uchar *buf,
     uchar *pos
-  );
+  ) override;
   int cmp_ref(
     const uchar *ref1,
     const uchar *ref2
-  );
-  int ft_init();
-  void ft_end();
+  ) override;
+  int ft_init() override;
+  void ft_end() override;
   FT_INFO *ft_init_ext(
     uint flags,
     uint inx,
     String *key
-  );
+  ) override;
   int ft_read(
     uchar *buf
-  );
+  ) override;
   int pre_index_read_map(
     const uchar *key,
     key_part_map keypart_map,
     enum ha_rkey_function find_flag,
     bool use_parallel
-  );
-  int pre_index_first(bool use_parallel);
-  int pre_index_last(bool use_parallel);
+  ) override;
+  int pre_index_first(bool use_parallel) override;
+  int pre_index_last(bool use_parallel) override;
   int pre_index_read_last_map(
     const uchar *key,
     key_part_map keypart_map,
     bool use_parallel
-  );
+  ) override;
 #ifdef HA_MRR_USE_DEFAULT_IMPL
   int pre_multi_range_read_next(
     bool use_parallel
-  );
+  ) override;
 #else
   int pre_read_multi_range_first(
     KEY_MULTI_RANGE **found_range_p,
@@ -413,47 +413,47 @@ public:
     bool eq_range,
     bool sorted,
     bool use_parallel
-  );
-  int pre_ft_read(bool use_parallel);
-  int pre_rnd_next(bool use_parallel);
+  ) override;
+  int pre_ft_read(bool use_parallel) override;
+  int pre_rnd_next(bool use_parallel) override;
   int info(
     uint flag
-  );
+  ) override;
   ha_rows records_in_range(
     uint inx,
     const key_range *start_key,
     const key_range *end_key,
     page_range *pages
-  );
+  ) override;
   int check_crd();
-  int pre_records();
-  ha_rows records();
+  int pre_records() override;
+  ha_rows records() override;
 #ifdef HA_HAS_CHECKSUM_EXTENDED
-  int pre_calculate_checksum();
-  int calculate_checksum();
+  int pre_calculate_checksum() override;
+  int calculate_checksum() override;
 #endif
   const char *table_type() const;
-  ulonglong table_flags() const;
+  ulonglong table_flags() const override;
   ulong table_flags_for_partition();
   const char *index_type(
     uint key_number
-  );
+  ) override;
   ulong index_flags(
     uint idx,
     uint part,
     bool all_parts
-  ) const;
-  uint max_supported_record_length() const;
-  uint max_supported_keys() const;
-  uint max_supported_key_parts() const;
-  uint max_supported_key_length() const;
-  uint max_supported_key_part_length() const;
-  uint8 table_cache_type();
+  ) const override;
+  uint max_supported_record_length() const override;
+  uint max_supported_keys() const override;
+  uint max_supported_key_parts() const override;
+  uint max_supported_key_length() const override;
+  uint max_supported_key_part_length() const override;
+  uint8 table_cache_type() override;
 #ifdef HANDLER_HAS_NEED_INFO_FOR_AUTO_INC
-  bool need_info_for_auto_inc();
+  bool need_info_for_auto_inc() override;
 #endif
 #ifdef HANDLER_HAS_CAN_USE_FOR_AUTO_INC_INIT
-  bool can_use_for_auto_inc_init();
+  bool can_use_for_auto_inc_init() override;
 #endif
   int update_auto_increment();
   void get_auto_increment(
@@ -462,25 +462,25 @@ public:
     ulonglong nb_desired_values,
     ulonglong *first_value,
     ulonglong *nb_reserved_values
-  );
+  ) override;
   int reset_auto_increment(
     ulonglong value
-  );
-  void release_auto_increment();
+  ) override;
+  void release_auto_increment() override;
 #ifdef SPIDER_HANDLER_START_BULK_INSERT_HAS_FLAGS
   void start_bulk_insert(
     ha_rows rows,
     uint flags
-  );
+  ) override;
 #else
   void start_bulk_insert(
     ha_rows rows
   );
 #endif
-  int end_bulk_insert();
+  int end_bulk_insert() override;
   int write_row(
     const uchar *buf
-  );
+  ) override;
 #ifdef HA_CAN_BULK_ACCESS
   int pre_write_row(
     uchar *buf
@@ -492,21 +492,21 @@ public:
     bool hs_request
   );
 #endif
-  bool start_bulk_update();
+  bool start_bulk_update() override;
   int exec_bulk_update(
     ha_rows *dup_key_found
-  );
-  int end_bulk_update();
+  ) override;
+  int end_bulk_update() override;
 #ifdef SPIDER_UPDATE_ROW_HAS_CONST_NEW_DATA
   int bulk_update_row(
     const uchar *old_data,
     const uchar *new_data,
     ha_rows *dup_key_found
-  );
+  ) override;
   int update_row(
     const uchar *old_data,
     const uchar *new_data
-  );
+  ) override;
 #else
   int bulk_update_row(
     const uchar *old_data,
@@ -556,7 +556,7 @@ public:
 #ifdef SPIDER_MDEV_16246
   int direct_update_rows_init(
     List<Item> *update_fields
-  );
+  ) override;
 #else
   int direct_update_rows_init();
 #endif
@@ -617,7 +617,7 @@ public:
   int direct_update_rows(
     ha_rows *update_rows,
     ha_rows *found_row
-  );
+  ) override;
 #endif
 #ifdef HA_CAN_BULK_ACCESS
 #ifdef HANDLER_HAS_DIRECT_UPDATE_ROWS_WITH_HS
@@ -642,11 +642,11 @@ public:
 #endif
 #endif
 #endif
-  bool start_bulk_delete();
-  int end_bulk_delete();
+  bool start_bulk_delete() override;
+  int end_bulk_delete() override;
   int delete_row(
     const uchar *buf
-  );
+  ) override;
 #ifdef HANDLER_HAS_DIRECT_UPDATE_ROWS
   bool check_direct_delete_sql_part(
     st_select_lex *select_lex,
@@ -665,7 +665,7 @@ public:
     bool sorted
   );
 #else
-  int direct_delete_rows_init();
+  int direct_delete_rows_init() override;
 #endif
 #ifdef HA_CAN_BULK_ACCESS
 #ifdef HANDLER_HAS_DIRECT_UPDATE_ROWS_WITH_HS
@@ -697,7 +697,7 @@ public:
 #else
   int direct_delete_rows(
     ha_rows *delete_rows
-  );
+  ) override;
 #endif
 #ifdef HA_CAN_BULK_ACCESS
 #ifdef HANDLER_HAS_DIRECT_UPDATE_ROWS_WITH_HS
@@ -718,90 +718,90 @@ public:
 #endif
 #endif
 #endif
-  int delete_all_rows();
-  int truncate();
-  double scan_time();
+  int delete_all_rows() override;
+  int truncate() override;
+  double scan_time() override;
   double read_time(
     uint index,
     uint ranges,
     ha_rows rows
-  );
+  ) override;
 #ifdef HA_CAN_BULK_ACCESS
   void bulk_req_exec();
 #endif
-  const key_map *keys_to_use_for_scanning();
-  ha_rows estimate_rows_upper_bound();
+  const key_map *keys_to_use_for_scanning() override;
+  ha_rows estimate_rows_upper_bound() override;
   void print_error(
     int error,
     myf errflag
-  );
+  ) override;
   bool get_error_message(
     int error,
     String *buf
-  );
+  ) override;
   int create(
     const char *name,
     TABLE *form,
     HA_CREATE_INFO *info
-  );
+  ) override;
   void update_create_info(
     HA_CREATE_INFO* create_info
-  );
+  ) override;
   int rename_table(
     const char *from,
     const char *to
-  );
+  ) override;
   int delete_table(
     const char *name
-  );
-  bool is_crashed() const;
+  ) override;
+  bool is_crashed() const override;
 #ifdef SPIDER_HANDLER_AUTO_REPAIR_HAS_ERROR
-  bool auto_repair(int error) const;
+  bool auto_repair(int error) const override;
 #else
   bool auto_repair() const;
 #endif
   int disable_indexes(
     key_map map, bool persist
-  );
+  ) override;
   int enable_indexes(
     key_map map, bool persist
-  );
+  ) override;
   int check(
     THD* thd,
     HA_CHECK_OPT* check_opt
-  );
+  ) override;
   int repair(
     THD* thd,
     HA_CHECK_OPT* check_opt
-  );
+  ) override;
   bool check_and_repair(
     THD *thd
-  );
+  ) override;
   int analyze(
     THD* thd,
     HA_CHECK_OPT* check_opt
-  );
+  ) override;
   int optimize(
     THD* thd,
     HA_CHECK_OPT* check_opt
-  );
+  ) override;
   bool is_fatal_error(
     int error_num,
     uint flags
-  );
+  ) override;
   Field *field_exchange(
     Field *field
   );
   const COND *cond_push(
     const COND* cond
-  );
-  void cond_pop();
+  ) override;
+  void cond_pop() override;
   int info_push(
     uint info_type,
     void *info
-  );
+  ) override;
 #ifdef HANDLER_HAS_DIRECT_AGGREGATE
-  void return_record_by_parent();
+  void return_record_by_parent() override;
 #endif
   TABLE *get_table();
   void set_ft_discard_bitmap();

--- a/storage/spider/spd_db_mysql.h
+++ b/storage/spider/spd_db_mysql.h
@@ -245,29 +245,29 @@ public:
   int store_to_field(
     Field *field,
     CHARSET_INFO *access_charset
-  );
+  ) override;
   int append_to_str(
     spider_string *str
-  );
+  ) override;
   int append_escaped_to_str(
     spider_string *str,
     uint dbton_id
-  );
-  void first();
-  void next();
-  bool is_null();
-  int val_int();
-  double val_real();
+  ) override;
+  void first() override;
+  void next() override;
+  bool is_null() override;
+  int val_int() override;
+  double val_real() override;
   my_decimal *val_decimal(
     my_decimal *decimal_value,
     CHARSET_INFO *access_charset
-  );
-  SPIDER_DB_ROW *clone();
+  ) override;
+  SPIDER_DB_ROW *clone() override;
   int store_to_tmp_table(
     TABLE *tmp_table,
     spider_string *str
-  );
-  uint get_byte_size();
+  ) override;
+  uint get_byte_size() override;
 };
 
 class spider_db_mysql_row: public spider_db_mbase_row
@@ -295,20 +295,20 @@ public:
     SPIDER_DB_CONN *in_db_conn
   );
   virtual ~spider_db_mbase_result();
-  bool has_result();
-  void free_result();
-  SPIDER_DB_ROW *current_row();
-  SPIDER_DB_ROW *fetch_row();
+  bool has_result() override;
+  void free_result() override;
+  SPIDER_DB_ROW *current_row() override;
+  SPIDER_DB_ROW *fetch_row() override;
   SPIDER_DB_ROW *fetch_row_from_result_buffer(
     spider_db_result_buffer *spider_res_buf
-  );
+  ) override;
   SPIDER_DB_ROW *fetch_row_from_tmp_table(
     TABLE *tmp_table
-  );
+  ) override;
   int fetch_table_status(
     int mode,
     ha_statistics &stat
-  );
+  ) override;
   int fetch_simple_action(
     uint simple_action,
     uint position,
@@ -317,11 +317,11 @@ public:
   int fetch_table_records(
     int mode,
     ha_rows &records
-  );
+  ) override;
 #ifdef HA_HAS_CHECKSUM_EXTENDED
   int fetch_table_checksum(
     ha_spider *spider
-  );
+  ) override;
 #endif
   int fetch_table_cardinality(
     int mode,
@@ -329,10 +329,10 @@ public:
     longlong *cardinality,
     uchar *cardinality_upd,
     int bitmap_size
-  );
+  ) override;
   int fetch_table_mon_status(
     int &status
-  );
+  ) override;
   int fetch_show_master_status(
     const char **binlog_file_name,
     const char **binlog_pos
@@ -340,26 +340,26 @@ public:
   int fetch_select_binlog_gtid_pos(
     const char **gtid_pos
   );
-  longlong num_rows();
-  uint num_fields();
+  longlong num_rows() override;
+  uint num_fields() override;
   void move_to_pos(
     longlong pos
-  );
-  int get_errno();
+  ) override;
+  int get_errno() override;
 #ifdef SPIDER_HAS_DISCOVER_TABLE_STRUCTURE
   int fetch_columns_for_discover_table_structure(
     spider_string *str,
     CHARSET_INFO *access_charset
-  );
+  ) override;
   int fetch_index_for_discover_table_structure(
     spider_string *str,
     CHARSET_INFO *access_charset
-  );
+  ) override;
   int fetch_table_for_discover_table_structure(
     spider_string *str,
     SPIDER_SHARE *spider_share,
     CHARSET_INFO *access_charset
-  );
+  ) override;
 #endif
 };
 
@@ -405,9 +405,9 @@ public:
     spider_db_mbase_util *spider_db_mbase_utility
   );
   virtual ~spider_db_mbase();
-  int init();
-  bool is_connected();
-  void bg_connect();
+  int init() override;
+  bool is_connected() override;
+  void bg_connect() override;
   int connect(
     char *tgt_host,
     char *tgt_username,
@@ -417,116 +417,116 @@ public:
     char *server_name,
     int connect_retry_count,
     longlong connect_retry_interval
-  );
-  int ping();
-  void bg_disconnect();
-  void disconnect();
-  int set_net_timeout();
+  ) override;
+  int ping() override;
+  void bg_disconnect() override;
+  void disconnect() override;
+  int set_net_timeout() override;
   int exec_query(
     const char *query,
     uint length,
     int quick_mode
-  );
-  int get_errno();
-  const char *get_error();
+  ) override;
+  int get_errno() override;
+  const char *get_error() override;
   bool is_server_gone_error(
     int error_num
-  );
+  ) override;
   bool is_dup_entry_error(
     int error_num
-  );
+  ) override;
   bool is_xa_nota_error(
     int error_num
-  );
+  ) override;
   int fetch_and_print_warnings(struct tm *l_time);
   spider_db_result *store_result(
     spider_db_result_buffer **spider_res_buf,
     st_spider_db_request_key *request_key,
     int *error_num
-  );
+  ) override;
   spider_db_result *use_result(
     ha_spider *spider,
     st_spider_db_request_key *request_key,
     int *error_num
-  );
-  int next_result();
-  uint affected_rows();
-  uint matched_rows();
+  ) override;
+  int next_result() override;
+  uint affected_rows() override;
+  uint matched_rows() override;
   bool inserted_info(
     spider_db_handler *handler,
     ha_copy_info *copy_info
-  );
-  ulonglong last_insert_id();
+  ) override;
+  ulonglong last_insert_id() override;
   int set_character_set(
     const char *csname
-  );
+  ) override;
   int select_db(
     const char *dbname
-  );
+  ) override;
   int consistent_snapshot(
     int *need_mon
-  );
-  bool trx_start_in_bulk_sql();
+  ) override;
+  bool trx_start_in_bulk_sql() override;
   int start_transaction(
     int *need_mon
-  );
+  ) override;
   int commit(
     int *need_mon
-  );
+  ) override;
   int rollback(
     int *need_mon
-  );
-  bool xa_start_in_bulk_sql();
+  ) override;
+  bool xa_start_in_bulk_sql() override;
   int xa_start(
     XID *xid,
     int *need_mon
-  );
+  ) override;
   int xa_end(
     XID *xid,
     int *need_mon
-  );
+  ) override;
   int xa_prepare(
     XID *xid,
     int *need_mon
-  );
+  ) override;
   int xa_commit(
     XID *xid,
     int *need_mon
-  );
+  ) override;
   int xa_rollback(
     XID *xid,
     int *need_mon
-  );
-  bool set_trx_isolation_in_bulk_sql();
+  ) override;
+  bool set_trx_isolation_in_bulk_sql() override;
   int set_trx_isolation(
     int trx_isolation,
     int *need_mon
-  );
-  bool set_autocommit_in_bulk_sql();
+  ) override;
+  bool set_autocommit_in_bulk_sql() override;
   int set_autocommit(
     bool autocommit,
     int *need_mon
-  );
-  bool set_sql_log_off_in_bulk_sql();
+  ) override;
+  bool set_sql_log_off_in_bulk_sql() override;
   int set_sql_log_off(
     bool sql_log_off,
     int *need_mon
-  );
-  bool set_wait_timeout_in_bulk_sql();
+  ) override;
+  bool set_wait_timeout_in_bulk_sql() override;
   int set_wait_timeout(
     int wait_timeout,
     int *need_mon
-  );
-  bool set_sql_mode_in_bulk_sql();
+  ) override;
+  bool set_sql_mode_in_bulk_sql() override;
   int set_sql_mode(
     sql_mode_t sql_mode,
     int *need_mon
-  );
-  bool set_time_zone_in_bulk_sql();
+  ) override;
+  bool set_time_zone_in_bulk_sql() override;
   int set_time_zone(
     Time_zone *time_zone,
     int *need_mon
-  );
+  ) override;
   int exec_simple_sql_with_result(
     SPIDER_TRX *trx,
     SPIDER_SHARE *share,
@@ -546,7 +546,7 @@ public:
     int mode,
     SPIDER_DB_RESULT **res1,
     SPIDER_DB_RESULT **res2
-  );
+  ) override;
   int select_binlog_gtid_pos(
     SPIDER_TRX *trx,
     SPIDER_SHARE *share,
@@ -564,25 +564,25 @@ public:
     char *to,
     const char *from,
     size_t from_length
-  );
-  bool have_lock_table_list();
+  ) override;
+  bool have_lock_table_list() override;
   int append_lock_tables(
     spider_string *str
-  );
+  ) override;
   int append_unlock_tables(
     spider_string *str
-  );
-  uint get_lock_table_hash_count();
-  void reset_lock_table_hash();
-  uint get_opened_handler_count();
-  void reset_opened_handler();
+  ) override;
+  uint get_lock_table_hash_count() override;
+  void reset_lock_table_hash() override;
+  uint get_opened_handler_count() override;
+  void reset_opened_handler() override;
   void set_dup_key_idx(
     ha_spider *spider,
     int link_idx
-  );
+  ) override;
   bool cmp_request_key_to_snd(
     st_spider_db_request_key *request_key
-  );
+  ) override;
 };
 
 class spider_db_mysql: public spider_db_mbase
@@ -637,20 +637,20 @@ public:
     spider_db_mbase_util *spider_db_mbase_utility
   );
   virtual ~spider_mbase_share();
-  int init();
+  int init() override;
   uint get_column_name_length(
     uint field_index
-  );
+  ) override;
   int append_column_name(
     spider_string *str,
     uint field_index
-  );
+  ) override;
   int append_column_name_with_alias(
     spider_string *str,
     uint field_index,
     const char *alias,
     uint alias_length
-  );
+  ) override;
   int append_table_name(
     spider_string *str,
     int all_link_idx
@@ -663,16 +663,16 @@ public:
     spider_string *str,
     int *table_name_pos
   );
-  bool need_change_db_table_name();
+  bool need_change_db_table_name() override;
 #ifdef SPIDER_HAS_DISCOVER_TABLE_STRUCTURE
   int discover_table_structure(
     SPIDER_TRX *trx,
     SPIDER_SHARE *spider_share,
     spider_string *str
-  );
+  ) override;
 #endif
 #ifdef HA_HAS_CHECKSUM_EXTENDED
-  bool checksum_support();
+  bool checksum_support() override;
 #endif
 protected:
   int create_table_names_str();
@@ -763,17 +763,17 @@ public:
     spider_db_mbase_util *spider_db_mbase_utility
   );
   virtual ~spider_mbase_handler();
-  int init();
+  int init() override;
   int append_index_hint(
     spider_string *str,
     int link_idx,
     ulong sql_type
-    );
+  ) override;
   int append_table_name_with_adjusting(
     spider_string *str,
     int link_idx,
     ulong sql_type
-  );
+  ) override;
   int append_key_column_types(
     const key_range *start_key,
     spider_string *str
@@ -786,8 +786,8 @@ public:
   );
   int append_tmp_table_and_sql_for_bka(
     const key_range *start_key
-  );
-  int reuse_tmp_table_and_sql_for_bka();
+  ) override;
+  int reuse_tmp_table_and_sql_for_bka() override;
   void create_tmp_bka_table_name(
     char *tmp_table_name,
     int *tmp_table_name_length,
@@ -818,62 +818,62 @@ public:
   );
   int append_union_table_and_sql_for_bka(
     const key_range *start_key
-  );
-  int reuse_union_table_and_sql_for_bka();
+  ) override;
+  int reuse_union_table_and_sql_for_bka() override;
   int append_insert_for_recovery(
     ulong sql_type,
     int link_idx
-  );
+  ) override;
   int append_update(
     const TABLE *table,
     my_ptrdiff_t ptr_diff
-  );
+  ) override;
   int append_update(
     const TABLE *table,
     my_ptrdiff_t ptr_diff,
     int link_idx
-  );
+  ) override;
   int append_delete(
     const TABLE *table,
     my_ptrdiff_t ptr_diff
-  );
+  ) override;
   int append_delete(
     const TABLE *table,
     my_ptrdiff_t ptr_diff,
     int link_idx
-  );
-  int append_insert_part();
+  ) override;
+  int append_insert_part() override;
   int append_insert(
     spider_string *str,
     int link_idx
   );
-  int append_update_part();
+  int append_update_part() override;
   int append_update(
     spider_string *str,
     int link_idx
   );
-  int append_delete_part();
+  int append_delete_part() override;
   int append_delete(
     spider_string *str
   );
-  int append_update_set_part();
+  int append_update_set_part() override;
   int append_update_set(
     spider_string *str
   );
   #ifdef HANDLER_HAS_DIRECT_UPDATE_ROWS
-  int append_direct_update_set_part();
+  int append_direct_update_set_part() override;
   int append_direct_update_set(
     spider_string *str
   );
   int append_dup_update_pushdown_part(
     const char *alias,
     uint alias_length
-  );
+  ) override;
   int append_update_columns_part(
     const char *alias,
     uint alias_length
-  );
-  int check_update_columns_part();
+  ) override;
+  int check_update_columns_part() override;
   int append_update_columns(
     spider_string *str,
     const char *alias,
@@ -882,28 +882,28 @@ public:
   #endif
   int append_select_part(
     ulong sql_type
-  );
+  ) override;
   int append_select(
     spider_string *str,
     ulong sql_type
-  );
+  ) override;
   int append_table_select_part(
     ulong sql_type
-  );
+  ) override;
   int append_table_select(
     spider_string *str
   );
   int append_key_select_part(
     ulong sql_type,
     uint idx
-  );
+  ) override;
   int append_key_select(
     spider_string *str,
     uint idx
   );
   int append_minimum_select_part(
     ulong sql_type
-  );
+  ) override;
   int append_minimum_select(
     spider_string *str,
     ulong sql_type
@@ -931,47 +931,47 @@ public:
   );
   int append_hint_after_table_part(
     ulong sql_type
-  );
+  ) override;
   int append_hint_after_table(
     spider_string *str
   );
   void set_where_pos(
     ulong sql_type
-  );
+  ) override;
   void set_where_to_pos(
     ulong sql_type
-  );
+  ) override;
   int check_item_type(
     Item *item
-  );
+  ) override;
   int append_values_connector_part(
     ulong sql_type
-  );
+  ) override;
   int append_values_connector(
     spider_string *str
   );
   int append_values_terminator_part(
     ulong sql_type
-  );
+  ) override;
   int append_values_terminator(
     spider_string *str
   );
   int append_union_table_connector_part(
     ulong sql_type
-  );
+  ) override;
   int append_union_table_connector(
     spider_string *str
   );
   int append_union_table_terminator_part(
     ulong sql_type
-  );
+  ) override;
   int append_union_table_terminator(
     spider_string *str
   );
   int append_key_column_values_part(
     const key_range *start_key,
     ulong sql_type
-  );
+  ) override;
   int append_key_column_values(
     spider_string *str,
     const key_range *start_key
@@ -979,7 +979,7 @@ public:
   int append_key_column_values_with_name_part(
     const key_range *start_key,
     ulong sql_type
-  );
+  ) override;
   int append_key_column_values_with_name(
     spider_string *str,
     const key_range *start_key
@@ -988,7 +988,7 @@ public:
     const key_range *start_key,
     const key_range *end_key,
     ulong sql_type
-  );
+  ) override;
   int append_key_where(
     spider_string *str,
     spider_string *str_part,
@@ -1005,7 +1005,7 @@ public:
     const uchar **ptr,
     bool key_eq,
     bool tgt_final
-  );
+  ) override;
   int append_is_null(
     ulong sql_type,
     spider_string *str,
@@ -1021,7 +1021,7 @@ public:
     ulong sql_type,
     bool set_order,
     int key_count
-  );
+  ) override;
   int append_where_terminator(
     ulong sql_type,
     spider_string *str,
@@ -1032,7 +1032,7 @@ public:
   );
   int append_match_where_part(
     ulong sql_type
-  );
+  ) override;
   int append_match_where(
     spider_string *str
   );
@@ -1046,7 +1046,7 @@ public:
     uint alias_length,
     ulong sql_type,
     bool test_flg
-  );
+  ) override;
   int append_condition(
     spider_string *str,
     const char *alias,
@@ -1070,7 +1070,7 @@ public:
     ulong sql_type,
     const char *alias,
     uint alias_length
-  );
+  ) override;
   int append_match_select(
     spider_string *str,
     const char *alias,
@@ -1081,7 +1081,7 @@ public:
     ulong sql_type,
     const char *alias,
     uint alias_length
-  );
+  ) override;
   int append_sum_select(
     spider_string *str,
     const char *alias,
@@ -1090,16 +1090,16 @@ public:
 #endif
   void set_order_pos(
     ulong sql_type
-  );
+  ) override;
   void set_order_to_pos(
     ulong sql_type
-  );
+  ) override;
 #ifdef HANDLER_HAS_DIRECT_AGGREGATE
   int append_group_by_part(
     const char *alias,
     uint alias_length,
     ulong sql_type
-  );
+  ) override;
   int append_group_by(
     spider_string *str,
     const char *alias,
@@ -1110,7 +1110,7 @@ public:
     const char *alias,
     uint alias_length,
     ulong sql_type
-  );
+  ) override;
   int append_key_order_for_merge_with_alias(
     spider_string *str,
     const char *alias,
@@ -1120,7 +1120,7 @@ public:
     const char *alias,
     uint alias_length,
     ulong sql_type
-  );
+  ) override;
   int append_key_order_for_direct_order_limit_with_alias(
     spider_string *str,
     const char *alias,
@@ -1130,7 +1130,7 @@ public:
     const char *alias,
     uint alias_length,
     ulong sql_type
-  );
+  ) override;
   int append_key_order_for_handler(
     spider_string *str,
     const char *alias,
@@ -1145,12 +1145,12 @@ public:
     longlong offset,
     longlong limit,
     ulong sql_type
-  );
+  ) override;
   int reappend_limit_part(
     longlong offset,
     longlong limit,
     ulong sql_type
-  );
+  ) override;
   int append_limit(
     spider_string *str,
     longlong offset,
@@ -1158,25 +1158,25 @@ public:
   );
   int append_select_lock_part(
     ulong sql_type
-  );
+  ) override;
   int append_select_lock(
     spider_string *str
   );
   int append_union_all_start_part(
     ulong sql_type
-  );
+  ) override;
   int append_union_all_start(
     spider_string *str
   );
   int append_union_all_part(
     ulong sql_type
-  );
+  ) override;
   int append_union_all(
     spider_string *str
   );
   int append_union_all_end_part(
     ulong sql_type
-  );
+  ) override;
   int append_union_all_end(
     spider_string *str
   );
@@ -1184,7 +1184,7 @@ public:
     ulong sql_type,
     uint multi_range_cnt,
     bool with_comma
-  );
+  ) override;
   int append_multi_range_cnt(
     spider_string *str,
     uint multi_range_cnt,
@@ -1193,7 +1193,7 @@ public:
   int append_multi_range_cnt_with_name_part(
     ulong sql_type,
     uint multi_range_cnt
-  );
+  ) override;
   int append_multi_range_cnt_with_name(
     spider_string *str,
     uint multi_range_cnt
@@ -1203,7 +1203,7 @@ public:
     uint handler_id,
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int append_open_handler(
     spider_string *str,
     uint handler_id,
@@ -1213,36 +1213,36 @@ public:
   int append_close_handler_part(
     ulong sql_type,
     int link_idx
-  );
+  ) override;
   int append_close_handler(
     spider_string *str,
     int link_idx
   );
   int append_insert_terminator_part(
     ulong sql_type
-  );
+  ) override;
   int append_insert_terminator(
     spider_string *str
   );
   int append_insert_values_part(
     ulong sql_type
-  );
+  ) override;
   int append_insert_values(
     spider_string *str
   );
   int append_into_part(
     ulong sql_type
-  );
+  ) override;
   int append_into(
     spider_string *str
   );
   void set_insert_to_pos(
     ulong sql_type
-  );
+  ) override;
   int append_from_part(
     ulong sql_type,
     int link_idx
-  );
+  ) override;
   int append_from(
     spider_string *str,
     ulong sql_type,
@@ -1288,7 +1288,7 @@ public:
   );
   int append_delete_all_rows_part(
     ulong sql_type
-  );
+  ) override;
   int append_delete_all_rows(
     spider_string *str,
     ulong sql_type
@@ -1303,7 +1303,7 @@ public:
     const key_range *end_key,
     ulong sql_type,
     int link_idx
-  );
+  ) override;
   int append_explain_select(
     spider_string *str,
     const key_range *start_key,
@@ -1313,32 +1313,32 @@ public:
   );
   bool is_sole_projection_field(
     uint16 field_index
-  );
+  ) override;
   bool is_bulk_insert_exec_period(
     bool bulk_end
-  );
+  ) override;
   bool sql_is_filled_up(
     ulong sql_type
-  );
+  ) override;
   bool sql_is_empty(
     ulong sql_type
-  );
-  bool support_multi_split_read();
-  bool support_bulk_update();
-  int bulk_tmp_table_insert();
+  ) override;
+  bool support_multi_split_read() override;
+  bool support_bulk_update() override;
+  int bulk_tmp_table_insert() override;
   int bulk_tmp_table_insert(
     int link_idx
-  );
-  int bulk_tmp_table_end_bulk_insert();
-  int bulk_tmp_table_rnd_init();
-  int bulk_tmp_table_rnd_next();
-  int bulk_tmp_table_rnd_end();
+  ) override;
+  int bulk_tmp_table_end_bulk_insert() override;
+  int bulk_tmp_table_rnd_init() override;
+  int bulk_tmp_table_rnd_next() override;
+  int bulk_tmp_table_rnd_end() override;
   bool need_copy_for_update(
     int link_idx
-  );
-  bool bulk_tmp_table_created();
-  int mk_bulk_tmp_table_and_bulk_start();
-  void rm_bulk_tmp_table();
+  ) override;
+  bool bulk_tmp_table_created() override;
+  int mk_bulk_tmp_table_and_bulk_start() override;
+  void rm_bulk_tmp_table() override;
   int store_sql_to_bulk_tmp_table(
     spider_string *str,
     TABLE *tmp_table
@@ -1350,156 +1350,156 @@ public:
   int insert_lock_tables_list(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int append_lock_tables_list(
     SPIDER_CONN *conn,
     int link_idx,
     int *appended
-  );
+  ) override;
   int realloc_sql(
     ulong *realloced
-  );
+  ) override;
   int reset_sql(
     ulong sql_type
-  );
+  ) override;
 #ifdef SPIDER_HAS_GROUP_BY_HANDLER
   int set_sql_for_exec(
     ulong sql_type,
     int link_idx,
     SPIDER_LINK_IDX_CHAIN *link_idx_chain
-  );
+  ) override;
 #endif
   int set_sql_for_exec(
     ulong sql_type,
     int link_idx
-  );
+  ) override;
   int set_sql_for_exec(
     spider_db_copy_table *tgt_ct,
     ulong sql_type
-  );
+  ) override;
   int execute_sql(
     ulong sql_type,
     SPIDER_CONN *conn,
     int quick_mode,
     int *need_mon
-  );
-  int reset();
+  ) override;
+  int reset() override;
   int sts_mode_exchange(
     int sts_mode
-  );
+  ) override;
   int show_table_status(
     int link_idx,
     int sts_mode,
     uint flag
-  );
+  ) override;
   int crd_mode_exchange(
     int crd_mode
-  );
+  ) override;
   int show_index(
     int link_idx,
     int crd_mode
-  );
+  ) override;
   int simple_action(
     uint simple_action,
     int link_idx
   );
   int show_records(
     int link_idx
-  );
+  ) override;
 #ifdef HA_HAS_CHECKSUM_EXTENDED
   int checksum_table(
     int link_idx
-  );
+  ) override;
 #endif
   int show_last_insert_id(
     int link_idx,
     ulonglong &last_insert_id
-  );
+  ) override;
   ha_rows explain_select(
     const key_range *start_key,
     const key_range *end_key,
     int link_idx
-  );
+  ) override;
   int lock_tables(
     int link_idx
-  );
+  ) override;
   int unlock_tables(
     int link_idx
-  );
+  ) override;
   int disable_keys(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int enable_keys(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int check_table(
     SPIDER_CONN *conn,
     int link_idx,
     HA_CHECK_OPT* check_opt
-  );
+  ) override;
   int repair_table(
     SPIDER_CONN *conn,
     int link_idx,
     HA_CHECK_OPT* check_opt
-  );
+  ) override;
   int analyze_table(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int optimize_table(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int flush_tables(
     SPIDER_CONN *conn,
     int link_idx,
     bool lock
-  );
+  ) override;
   int flush_logs(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int insert_opened_handler(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int delete_opened_handler(
     SPIDER_CONN *conn,
     int link_idx
-  );
+  ) override;
   int sync_from_clone_source(
     spider_db_handler *dbton_hdl
-  );
+  ) override;
   bool support_use_handler(
     int use_handler
-  );
+  ) override;
   void minimum_select_bitmap_create();
   bool minimum_select_bit_is_set(
     uint field_index
-  );
+  ) override;
   void copy_minimum_select_bitmap(
     uchar *bitmap
-  );
-  int init_union_table_name_pos();
-  int set_union_table_name_pos();
+  ) override;
+  int init_union_table_name_pos() override;
+  int set_union_table_name_pos() override;
   int reset_union_table_name(
     spider_string *str,
     int link_idx,
     ulong sql_type
-  );
+  ) override;
 #ifdef SPIDER_HAS_GROUP_BY_HANDLER
   int append_from_and_tables_part(
     spider_fields *fields,
     ulong sql_type
-  );
+  ) override;
   int append_where_part(
     ulong sql_type
-  );
+  ) override;
   int append_having_part(
     ulong sql_type
-  );
+  ) override;
   int append_item_type_part(
     Item *item,
     const char *alias,
@@ -1507,7 +1507,7 @@ public:
     bool use_fields,
     spider_fields *fields,
     ulong sql_type
-  );
+  ) override;
   int append_list_item_select_part(
     List<Item> *select,
     const char *alias,
@@ -1515,7 +1515,7 @@ public:
     bool use_fields,
     spider_fields *fields,
     ulong sql_type
-  );
+  ) override;
   int append_list_item_select(
     List<Item> *select,
     spider_string *str,
@@ -1531,7 +1531,7 @@ public:
     bool use_fields,
     spider_fields *fields,
     ulong sql_type
-  );
+  ) override;
   int append_group_by(
     ORDER *order,
     spider_string *str,
@@ -1547,7 +1547,7 @@ public:
     bool use_fields,
     spider_fields *fields,
     ulong sql_type
-  );
+  ) override;
   int append_order_by(
     ORDER *order,
     spider_string *str,
@@ -1562,12 +1562,12 @@ public:
     st_select_lex *select_lex,
     longlong select_limit,
     longlong offset_limit
-  );
+  ) override;
   bool check_direct_delete(
     st_select_lex *select_lex,
     longlong select_limit,
     longlong offset_limit
-  );
+  ) override;
 #endif
 };
 
@@ -1601,49 +1601,49 @@ public:
     spider_mbase_share *db_share
   );
   virtual ~spider_mbase_copy_table();
-  int init();
+  int init() override;
   void set_sql_charset(
     CHARSET_INFO *cs
-  );
-  int append_select_str();
+  ) override;
+  int append_select_str() override;
   int append_insert_str(
     int insert_flg
-  );
+  ) override;
   int append_table_columns(
     TABLE_SHARE *table_share
-  );
-  int append_from_str();
+  ) override;
+  int append_from_str() override;
   int append_table_name(
     int link_idx
-  );
-  void set_sql_pos();
-  void set_sql_to_pos();
+  ) override;
+  void set_sql_pos() override;
+  void set_sql_to_pos() override;
   int append_copy_where(
     spider_db_copy_table *source_ct,
     KEY *key_info,
     ulong *last_row_pos,
     ulong *last_lengths
-  );
+  ) override;
   int append_key_order_str(
     KEY *key_info,
     int start_pos,
     bool desc_flg
-  );
+  ) override;
   int append_limit(
     longlong offset,
     longlong limit
-  );
-  int append_into_str();
-  int append_open_paren_str();
-  int append_values_str();
+  ) override;
+  int append_into_str() override;
+  int append_open_paren_str() override;
+  int append_values_str() override;
   int append_select_lock_str(
     int lock_mode
-  );
+  ) override;
   int exec_query(
     SPIDER_CONN *conn,
     int quick_mode,
     int *need_mon
-  );
+  ) override;
   int copy_key_row(
     spider_db_copy_table *source_ct,
     Field *field,
@@ -1661,15 +1661,15 @@ public:
     SPIDER_DB_ROW *row,
     ulong **last_row_pos,
     ulong **last_lengths
-  );
+  ) override;
   int copy_rows(
     TABLE *table,
     SPIDER_DB_ROW *row
-  );
-  int append_insert_terminator();
+  ) override;
+  int append_insert_terminator() override;
   int copy_insert_values(
     spider_db_copy_table *source_ct
-  );
+  ) override;
 };
 
 class spider_mysql_copy_table: public spider_mbase_copy_table

--- a/storage/spider/spd_group_by_handler.h
+++ b/storage/spider/spd_group_by_handler.h
@@ -32,9 +32,9 @@ public:
     spider_fields *fields_arg
   );
   ~spider_group_by_handler();
-  int init_scan();
-  int next_row();
-  int end_scan();
+  int init_scan() override;
+  int next_row() override;
+  int end_scan() override;
 };
 
 group_by_handler *spider_create_group_by_handler(

--- a/storage/test_sql_discovery/test_sql_discovery.cc
+++ b/storage/test_sql_discovery/test_sql_discovery.cc
@@ -48,7 +48,7 @@ public:
   {
     thr_lock_init(&lock);
   }
-  ~TSD_share()
+  ~TSD_share() override
   {
     thr_lock_delete(&lock);
   }
@@ -64,17 +64,17 @@ private:
 public:
   ha_tsd(handlerton *hton, TABLE_SHARE *table_arg)
     : handler(hton, table_arg) { }
-  ulonglong table_flags() const
+  ulonglong table_flags() const override
   { // NO_TRANSACTIONS and everything that affects CREATE TABLE
     return HA_NO_TRANSACTIONS | HA_CAN_GEOMETRY | HA_NULL_IN_KEY |
            HA_CAN_INDEX_BLOBS | HA_AUTO_PART_KEY | HA_CAN_RTREEKEYS |
            HA_CAN_FULLTEXT;
   }
 
-  ulong index_flags(uint inx, uint part, bool all_parts) const { return 0; }
+  ulong index_flags(uint inx, uint part, bool all_parts) const override { return 0; }
 
   THR_LOCK_DATA **store_lock(THD *thd, THR_LOCK_DATA **to,
-                             enum thr_lock_type lock_type)
+                             enum thr_lock_type lock_type) override
   {
     if (lock_type != TL_IGNORE && lock.type == TL_UNLOCK)
       lock.type = lock_type;
@@ -82,17 +82,17 @@ public:
     return to;
   }
 
-  int rnd_init(bool scan) { return 0; }
-  int rnd_next(unsigned char *buf) { return HA_ERR_END_OF_FILE; }
-  void position(const uchar *record) { }
-  int rnd_pos(uchar *buf, uchar *pos) { return HA_ERR_END_OF_FILE; }
-  int info(uint flag) { return 0; }
-  uint max_supported_keys() const { return 16; }
+  int rnd_init(bool scan) override { return 0; }
+  int rnd_next(unsigned char *buf) override { return HA_ERR_END_OF_FILE; }
+  void position(const uchar *record) override { }
+  int rnd_pos(uchar *buf, uchar *pos) override { return HA_ERR_END_OF_FILE; }
+  int info(uint flag) override { return 0; }
+  uint max_supported_keys() const override { return 16; }
   int create(const char *name, TABLE *table_arg,
-             HA_CREATE_INFO *create_info) { return HA_ERR_WRONG_COMMAND; }
+             HA_CREATE_INFO *create_info) override { return HA_ERR_WRONG_COMMAND; }
 
-  int open(const char *name, int mode, uint test_if_locked);
-  int close(void);
+  int open(const char *name, int mode, uint test_if_locked) override;
+  int close(void) override;
 };
 
 TSD_share *ha_tsd::get_share()

--- a/storage/tokudb/PerconaFT/ftcxx/exceptions.hpp
+++ b/storage/tokudb/PerconaFT/ftcxx/exceptions.hpp
@@ -117,7 +117,7 @@ namespace ftcxx {
             return _code;
         }
 
-        virtual const char *what() const noexcept {
+        const char *what() const noexcept override {
             return ft_strerror(_code);
         }
     };
@@ -132,7 +132,7 @@ namespace ftcxx {
             return _code;
         }
 
-        virtual const char *what() const noexcept {
+        const char *what() const noexcept override {
             return strerror(_code);
         }
     };

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -728,21 +728,21 @@ public:
     ~ha_tokudb();
 
     const char *table_type() const;
-    const char *index_type(uint inx);
+    const char *index_type(uint inx) override;
     const char **bas_ext() const;
 
     //
     // Returns a bit mask of capabilities of storage engine. Capabilities 
     // defined in sql/handler.h
     //
-    ulonglong table_flags() const;
+    ulonglong table_flags() const override;
     
-    ulong index_flags(uint inx, uint part, bool all_parts) const;
+    ulong index_flags(uint inx, uint part, bool all_parts) const override;
 
     //
     // Returns limit on the number of keys imposed by tokudb.
     //
-    uint max_supported_keys() const {
+    uint max_supported_keys() const override {
         return MAX_KEY;
     } 
 
@@ -754,43 +754,43 @@ public:
     //
     // Returns the limit on the key length imposed by tokudb.
     //
-    uint max_supported_key_length() const {
+    uint max_supported_key_length() const override {
         return UINT_MAX32;
     } 
 
     //
     // Returns limit on key part length imposed by tokudb.
     //
-    uint max_supported_key_part_length() const {
+    uint max_supported_key_part_length() const override {
         return UINT_MAX32;
     } 
-    const key_map *keys_to_use_for_scanning() {
+    const key_map *keys_to_use_for_scanning() override {
         return &key_map_full;
     }
 
-    double scan_time();
+    double scan_time() override;
 
-    double read_time(uint index, uint ranges, ha_rows rows);
+    double read_time(uint index, uint ranges, ha_rows rows) override;
     
     // Defined in mariadb
-    double keyread_time(uint index, uint ranges, ha_rows rows);
+    double keyread_time(uint index, uint ranges, ha_rows rows) override;
 
     // Defined in mysql 5.6
     double index_only_read_time(uint keynr, double records);
 
-    int open(const char *name, int mode, uint test_if_locked);
-    int close();
-    void update_create_info(HA_CREATE_INFO* create_info);
-    int create(const char *name, TABLE * form, HA_CREATE_INFO * create_info);
-    int delete_table(const char *name);
-    int rename_table(const char *from, const char *to);
-    int optimize(THD * thd, HA_CHECK_OPT * check_opt);
-    int analyze(THD * thd, HA_CHECK_OPT * check_opt);
-    int write_row(const uchar * buf);
-    int update_row(const uchar * old_data, const uchar * new_data);
-    int delete_row(const uchar * buf);
+    int open(const char *name, int mode, uint test_if_locked) override;
+    int close() override;
+    void update_create_info(HA_CREATE_INFO* create_info) override;
+    int create(const char *name, TABLE * form, HA_CREATE_INFO * create_info) override;
+    int delete_table(const char *name) override;
+    int rename_table(const char *from, const char *to) override;
+    int optimize(THD * thd, HA_CHECK_OPT * check_opt) override;
+    int analyze(THD * thd, HA_CHECK_OPT * check_opt) override;
+    int write_row(const uchar * buf) override;
+    int update_row(const uchar * old_data, const uchar * new_data) override;
+    int delete_row(const uchar * buf) override;
 #if MYSQL_VERSION_ID >= 100000
-    void start_bulk_insert(ha_rows rows, uint flags);
+    void start_bulk_insert(ha_rows rows, uint flags) override;
 #else
     void start_bulk_insert(ha_rows rows);
 #endif
@@ -807,49 +807,49 @@ public:
                            DBT* key,
                            DBT* val,
                            void* error_extra);
-    int end_bulk_insert();
+    int end_bulk_insert() override;
     int end_bulk_insert(bool abort);
 
-    int prepare_index_scan();
-    int prepare_index_key_scan( const uchar * key, uint key_len );
-    int prepare_range_scan( const key_range *start_key, const key_range *end_key);
-    void column_bitmaps_signal();
-    int index_init(uint index, bool sorted);
-    int index_end();
-    int index_next_same(uchar * buf, const uchar * key, uint keylen); 
-    int index_read(uchar * buf, const uchar * key, uint key_len, enum ha_rkey_function find_flag);
-    int index_read_last(uchar * buf, const uchar * key, uint key_len);
-    int index_next(uchar * buf);
-    int index_prev(uchar * buf);
-    int index_first(uchar * buf);
-    int index_last(uchar * buf);
+    int prepare_index_scan() override;
+    int prepare_index_key_scan( const uchar * key, uint key_len ) override;
+    int prepare_range_scan( const key_range *start_key, const key_range *end_key) override;
+    void column_bitmaps_signal() override;
+    int index_init(uint index, bool sorted) override;
+    int index_end() override;
+    int index_next_same(uchar * buf, const uchar * key, uint keylen) override;
+    int index_read(uchar * buf, const uchar * key, uint key_len, enum ha_rkey_function find_flag) override;
+    int index_read_last(uchar * buf, const uchar * key, uint key_len) override;
+    int index_next(uchar * buf) override;
+    int index_prev(uchar * buf) override;
+    int index_first(uchar * buf) override;
+    int index_last(uchar * buf) override;
 
     bool has_gap_locks() const { return true; }
 
-    int rnd_init(bool scan);
-    int rnd_end();
-    int rnd_next(uchar * buf);
-    int rnd_pos(uchar * buf, uchar * pos);
+    int rnd_init(bool scan) override;
+    int rnd_end() override;
+    int rnd_next(uchar * buf) override;
+    int rnd_pos(uchar * buf, uchar * pos) override;
 
     int read_range_first(const key_range *start_key,
                                  const key_range *end_key,
-                                 bool eq_range, bool sorted);
-    int read_range_next();
+                                 bool eq_range, bool sorted) override;
+    int read_range_next() override;
 
 
-    void position(const uchar * record);
-    int info(uint);
-    int extra(enum ha_extra_function operation);
-    int reset();
-    int external_lock(THD * thd, int lock_type);
-    int start_stmt(THD * thd, thr_lock_type lock_type);
+    void position(const uchar * record) override;
+    int info(uint) override;
+    int extra(enum ha_extra_function operation) override;
+    int reset() override;
+    int external_lock(THD * thd, int lock_type) override;
+    int start_stmt(THD * thd, thr_lock_type lock_type) override;
 
     ha_rows records_in_range(uint inx, const key_range * min_key,
                              const key_range * max_key,
-                             page_range *pages);
+                             page_range *pages) override;
 
     uint32_t get_cursor_isolation_flags(enum thr_lock_type lock_type, THD* thd);
-    THR_LOCK_DATA **store_lock(THD * thd, THR_LOCK_DATA ** to, enum thr_lock_type lock_type);
+    THR_LOCK_DATA **store_lock(THD * thd, THR_LOCK_DATA ** to, enum thr_lock_type lock_type) override;
 
     int get_status(DB_TXN* trans);
     void init_hidden_prim_key_info(DB_TXN *txn);
@@ -859,20 +859,20 @@ public:
         hpk_num_to_char(to, share->auto_ident);
         share->unlock();
     }
-    virtual void get_auto_increment(
+    void get_auto_increment(
         ulonglong offset,
         ulonglong increment,
         ulonglong nb_desired_values,
         ulonglong* first_value,
-        ulonglong* nb_reserved_values);
+        ulonglong* nb_reserved_values) override;
     bool is_optimize_blocking();
     bool is_auto_inc_singleton();
-    void print_error(int error, myf errflag);
-    uint8 table_cache_type() {
+    void print_error(int error, myf errflag) override;
+    uint8 table_cache_type() override {
         return HA_CACHE_TBL_TRANSACT;
     }
-    int cmp_ref(const uchar * ref1, const uchar * ref2);
-    bool check_if_incompatible_data(HA_CREATE_INFO * info, uint table_changes);
+    int cmp_ref(const uchar * ref1, const uchar * ref2) override;
+    bool check_if_incompatible_data(HA_CREATE_INFO * info, uint table_changes) override;
 
 #ifdef MARIADB_BASE_VERSION
 
@@ -884,16 +884,16 @@ public:
     int multi_range_read_init(RANGE_SEQ_IF* seq,
                               void* seq_init_param,
                               uint n_ranges, uint mode,
-                              HANDLER_BUFFER *buf);
-    int multi_range_read_next(range_id_t *range_info);
+                              HANDLER_BUFFER *buf) override;
+    int multi_range_read_next(range_id_t *range_info) override;
     ha_rows multi_range_read_info_const(uint keyno, RANGE_SEQ_IF *seq,
                                         void *seq_init_param, 
                                         uint n_ranges, uint *bufsz,
-                                        uint *flags, COST_VECT *cost);
+                                        uint *flags, COST_VECT *cost) override;
     ha_rows multi_range_read_info(uint keyno, uint n_ranges, uint keys,
                                   uint key_parts, uint *bufsz, 
-                                  uint *flags, COST_VECT *cost);
-    int multi_range_read_explain_info(uint mrr_mode, char *str, size_t size);
+                                  uint *flags, COST_VECT *cost) override;
+    int multi_range_read_explain_info(uint mrr_mode, char *str, size_t size) override;
 
 #else
 
@@ -912,18 +912,18 @@ public:
 
 #endif
 
-    Item* idx_cond_push(uint keyno, class Item* idx_cond);
-    void cancel_pushed_idx_cond();
+    Item* idx_cond_push(uint keyno, class Item* idx_cond) override;
+    void cancel_pushed_idx_cond() override;
 
     bool can_convert_varstring(const Field_varstring* field,
                                const Column_definition&new_type) const;
 
 #if defined(TOKU_INCLUDE_ALTER_56) && TOKU_INCLUDE_ALTER_56
  public:
-    enum_alter_inplace_result check_if_supported_inplace_alter(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
-    bool prepare_inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
-    bool inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
-    bool commit_inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info, bool commit);
+    enum_alter_inplace_result check_if_supported_inplace_alter(TABLE *altered_table, Alter_inplace_info *ha_alter_info) override;
+    bool prepare_inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info) override;
+    bool inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info) override;
+    bool commit_inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info, bool commit) override;
  private:
     int alter_table_add_index(Alter_inplace_info* ha_alter_info);
     int alter_table_drop_index(Alter_inplace_info* ha_alter_info);
@@ -968,9 +968,9 @@ public:
  public:
     // delete all rows from the table
     // effect: all dictionaries, including the main and indexes, should be empty
-    int discard_or_import_tablespace(my_bool discard);
-    int truncate();
-    int delete_all_rows();
+    int discard_or_import_tablespace(my_bool discard) override;
+    int truncate() override;
+    int delete_all_rows() override;
     void extract_hidden_primary_key(uint keynr, DBT const *found_key);
     void read_key_only(uchar * buf, uint keynr, DBT const *found_key);
     int read_row_callback (uchar * buf, uint keynr, DBT const *row, DBT const *found_key);
@@ -1003,7 +1003,7 @@ public:
     //
     uint primary_key;
 
-    int check(THD *thd, HA_CHECK_OPT *check_opt);
+    int check(THD *thd, HA_CHECK_OPT *check_opt) override;
 
     int fill_range_query_buf(
         bool need_val, 

--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -42,17 +42,17 @@ public:
 
     virtual ~recount_rows_t();
 
-    virtual const char* key();
-    virtual const char* database();
-    virtual const char* table();
-    virtual const char* type();
-    virtual const char* parameters();
-    virtual const char* status();
+    const char* key() override;
+    const char* database() override;
+    const char* table() override;
+    const char* type() override;
+    const char* parameters() override;
+    const char* status() override;
 
 protected:
-    virtual void on_run();
+    void on_run() override;
 
-    virtual void on_destroy();
+    void on_destroy() override;
 
 private:
     // to be provided by the initiator of recount rows
@@ -281,17 +281,17 @@ public:
 
     virtual ~standard_t();
 
-    virtual const char* key(void);
-    virtual const char* database();
-    virtual const char* table();
-    virtual const char* type();
-    virtual const char* parameters();
-    virtual const char* status();
+    const char* key(void) override;
+    const char* database() override;
+    const char* table() override;
+    const char* type() override;
+    const char* parameters() override;
+    const char* status() override;
 
 protected:
-    virtual void on_run();
+    void on_run() override;
 
-    virtual void on_destroy();
+    void on_destroy() override;
 
 private:
     // to be provided by initiator of analyze

--- a/tpool/aio_simulated.cc
+++ b/tpool/aio_simulated.cc
@@ -142,7 +142,7 @@ public:
     pool->submit_task(&cb->m_internal_task);
   }
 
-  virtual int submit_io(aiocb *aiocb) override
+  int submit_io(aiocb *aiocb) override
   {
     aiocb->m_internal_task.m_func = simulated_aio_callback;
     aiocb->m_internal_task.m_arg = aiocb;
@@ -152,8 +152,8 @@ public:
     return 0;
   }
 
-  virtual int bind(native_file_handle &fd) override { return 0; }
-  virtual int unbind(const native_file_handle &fd) override { return 0; }
+  int bind(native_file_handle &fd) override { return 0; }
+  int unbind(const native_file_handle &fd) override { return 0; }
 };
 
 aio *create_simulated_aio(thread_pool *tp)

--- a/tpool/aio_win.cc
+++ b/tpool/aio_win.cc
@@ -102,7 +102,7 @@ public:
     m_thread.join();
   }
 
-  virtual int submit_io(aiocb* cb) override
+  int submit_io(aiocb* cb) override
   {
     memset((OVERLAPPED *)cb, 0, sizeof(OVERLAPPED));
     cb->m_internal = this;
@@ -123,12 +123,12 @@ public:
   }
 
   // Inherited via aio
-  virtual int bind(native_file_handle& fd) override
+  int bind(native_file_handle& fd) override
   {
     return CreateIoCompletionPort(fd, m_completion_port, 0, 0) ? 0
       : GetLastError();
   }
-  virtual int unbind(const native_file_handle& fd) override { return 0; }
+  int unbind(const native_file_handle& fd) override { return 0; }
 };
 
 aio* create_win_aio(thread_pool* pool, int max_io)

--- a/tpool/tpool_generic.cc
+++ b/tpool/tpool_generic.cc
@@ -321,11 +321,11 @@ class thread_pool_generic : public thread_pool
   }
 public:
   thread_pool_generic(int min_threads, int max_threads);
-  ~thread_pool_generic();
+  ~thread_pool_generic() override;
   void wait_begin() override;
   void wait_end() override;
   void submit_task(task *task) override;
-  virtual aio *create_native_aio(int max_io) override
+  aio *create_native_aio(int max_io) override
   {
 #ifdef _WIN32
     return create_win_aio(this, max_io);
@@ -454,13 +454,13 @@ public:
       m_task.wait();
     }
 
-    virtual ~timer_generic()
+    ~timer_generic() override
     {
       disarm();
     }
   };
   timer_generic m_maintenance_timer;
-  virtual timer* create_timer(callback_func func, void *data) override
+  timer* create_timer(callback_func func, void *data) override
   {
     return new timer_generic(func, data, this);
   }

--- a/tpool/tpool_win.cc
+++ b/tpool/tpool_win.cc
@@ -144,7 +144,7 @@ class thread_pool_win : public thread_pool
     /**
      Submit async IO.
     */
-    virtual int submit_io(aiocb* cb) override
+    int submit_io(aiocb* cb) override
     {
       memset((OVERLAPPED *)cb, 0, sizeof(OVERLAPPED));
 
@@ -192,7 +192,7 @@ class thread_pool_win : public thread_pool
     /**
       Binds the file handle via CreateThreadpoolIo().
     */
-    virtual int bind(native_file_handle& fd) override
+    int bind(native_file_handle& fd) override
     {
       fd.m_ptp_io =
         CreateThreadpoolIo(fd.m_handle, io_completion_callback, 0, &(m_pool.m_env));
@@ -204,7 +204,7 @@ class thread_pool_win : public thread_pool
     /**
       Unbind the file handle via CloseThreadpoolIo.
     */
-    virtual int unbind(const native_file_handle& fd) override
+    int unbind(const native_file_handle& fd) override
     {
       if (fd.m_ptp_io)
         CloseThreadpoolIo(fd.m_ptp_io);
@@ -262,7 +262,7 @@ public:
 
     task->execute();
   }
-  virtual void submit_task(task *task) override
+  void submit_task(task *task) override
   {
     auto entry= m_task_cache.get();
     task->add_ref();

--- a/unittest/sql/my_apc-t.cc
+++ b/unittest/sql/my_apc-t.cc
@@ -123,7 +123,7 @@ public:
   int *where_to;  // Where to write it
   Apc_order(int a, int *b) : value(a), where_to(b) {}
 
-  void call_in_target_thread()
+  void call_in_target_thread() override
   {
     my_sleep(int_rand(1000));
     *where_to = value;


### PR DESCRIPTION
Find and fix missing virtual override markings.  Updates CMAKE_CXX_FLAGS to include -Wsuggest-override and -Winconsistent-missing-override.  In a few places, redundant virtual markings were removed.
