### PR TITLE
MDEV-33837: wsrep_sst_common.sh does not have shebang

### DIFF
--- a/scripts/wsrep_sst_common.sh
+++ b/scripts/wsrep_sst_common.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright (C) 2017-2022 MariaDB
 # Copyright (C) 2012-2015 Codership Oy
 #


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33837*

## Description
As script scripts/wsrep_sst_common.sh is mainly meant to be sourced in bash/zsh script but there is also possiblity to run to independent also. It does not hurt to have shebang on script file.

Fixes lintian warning:
 * W: mariadb-server: executable-not-elf-or-script [usr/bin/wsrep_sst_common]

## Release Notes
Should not appear in Release notes

## How can this PR be tested?
Test is `usr/bin/wsrep_sst_common` work the same with or without `/bin/sh` shebang

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
