### PR TITLE
MDEV-34389  Don't write FILE_CHECKPOINT during recovery when log file is insufficient

### DIFF
--- a/mysql-test/suite/innodb/r/log_file_overwrite.result
+++ b/mysql-test/suite/innodb/r/log_file_overwrite.result
@@ -1,0 +1,8 @@
+call mtr.add_suppression("InnoDB: Plugin initialization aborted");
+call mtr.add_suppression("plugin 'InnoDB' registration as a STORAGE ENGINE failed.");
+CREATE TABLE t1(f1 INT NOT NULL, f2 TEXT)ENGINE=InnoDB;
+# restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
+INSERT INTO t1 SELECT seq, repeat('a', 4000) FROM seq_1_to_1800;
+# restart: --debug_dbug=+d,before_final_redo_apply --innodb_log_file_size=8M
+# restart: --innodb_log_file_size=10M
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/log_file_overwrite.test
+++ b/mysql-test/suite/innodb/t/log_file_overwrite.test
@@ -1,0 +1,17 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/have_debug.inc
+
+call mtr.add_suppression("InnoDB: Plugin initialization aborted");
+call mtr.add_suppression("plugin 'InnoDB' registration as a STORAGE ENGINE failed.");
+CREATE TABLE t1(f1 INT NOT NULL, f2 TEXT)ENGINE=InnoDB;
+let $restart_parameters=--debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0;
+--source include/restart_mysqld.inc
+INSERT INTO t1 SELECT seq, repeat('a', 4000) FROM seq_1_to_1800;
+let $restart_parameters=--debug_dbug=+d,before_final_redo_apply --innodb_log_file_size=8M;
+let $shutdown_timeout=0;
+--source include/restart_mysqld.inc
+let $restart_parameters=--innodb_log_file_size=10M;
+let $shutdown_timeout=;
+--source include/restart_mysqld.inc
+DROP TABLE t1;

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3738,7 +3738,9 @@ completed:
 	if (!srv_read_only_mode
             && srv_operation <= SRV_OPERATION_EXPORT_RESTORED
 	    && (~log_t::FORMAT_ENCRYPTED & log_sys.log.format)
-	    == log_t::FORMAT_10_5) {
+	    == log_t::FORMAT_10_5
+	    && recv_sys.recovered_lsn - log_sys.last_checkpoint_lsn
+	    < log_sys.log_capacity) {
 		/* Write a FILE_CHECKPOINT marker as the first thing,
 		before generating any other redo log. This ensures
 		that subsequent crash recovery will be possible even
@@ -3748,6 +3750,9 @@ completed:
 
 	log_sys.next_checkpoint_no = ++checkpoint_no;
 
+	DBUG_EXECUTE_IF("before_final_redo_apply",
+			mysql_mutex_unlock(&log_sys.mutex);
+			return DB_ERROR;);
 	mutex_enter(&recv_sys.mutex);
 
 	recv_sys.apply_log_recs = true;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34389*

## Description
- InnoDB tries to write FILE_CHECKPOINT marker when log file size is insufficient. This could corrupt the
log file and make it unrecoverable.

recv_recovery_From_checkpoint_start(): Before writing FILE_CHECKPOINT marker, check whether
we have sufficient log file capacity

## How can this PR be tested?
Pasted the test case in MDEV page.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
