### PR TITLE
Chore: syntax error for `if` statement in mysql_install_db

### DIFF
--- a/scripts/mysql_install_db.sh
+++ b/scripts/mysql_install_db.sh
@@ -338,8 +338,8 @@ parse_arguments PICK-ARGS-FROM-ARGV "$@"
 rel_mysqld="$dirname0/@INSTALL_SBINDIR@/mariadbd"
 
 if test "$cross_bootstrap" -eq 0 -a "$in_rpm" -eq 0 -a "$force" -eq 0
-  do_resolve=1
 then
+  do_resolve=1
 fi
 
 # Configure paths to support files


### PR DESCRIPTION
## Description

The `mysql_install_db` script fails due to a syntax error in an `if` statement. Specifically, the `then` keyword is incorrectly placed, causing the script to terminate unexpectedly with the error: `/usr/bin/mysql_install_db: 343: Syntax error: "fi" unexpected`.

This PR corrects the placement of the `then` keyword in the `if` statement, ensuring that the script runs successfully. The error can be reproduced by executing the following command:
```sh
sudo -u mysql mysql_install_db --rpm --user=mysql
```

## Release Notes

Fixed a syntax error in the `mysql_install_db` script that caused it to fail with a "Syntax error: 'fi' unexpected" message. This error was due to the incorrect placement of the `then` keyword in an `if` statement.

## How can this PR be tested?

To verify the fix, ensure that the `mysql_install_db` script runs without syntax errors. Specifically, run the script with the `--rpm` and `--user=mysql` options and checks for successful completion.

## Basing the PR against the correct MariaDB version
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.