### PR TITLE
MDEV-34397: "delete si" rather than "my_free(si)" in THD::register_sl…

### DIFF
--- a/sql/repl_failsafe.cc
+++ b/sql/repl_failsafe.cc
@@ -159,7 +159,7 @@ int THD::register_slave(uchar *packet, size_t packet_length)
   return 0;
 
 err:
-  delete si;
+  my_free(si);
   my_message(ER_UNKNOWN_ERROR, errmsg, MYF(0)); /* purecov: inspected */
   return 1;
 }


### PR DESCRIPTION
MDEV-34397: "delete si" rather than "my_free(si)" in THD::register_slave()

In the error case of THD::register_slave(), there is undefined behavior of Slave_info si because it is allocated via malloc() (my_malloc), and cleaned up via delete().

This patch makes these consistent by switching si's cleanup to use my_free.

A simple way to reproduce the undefined behavior is to apply the following patch and run any test in the `rpl` MTR suite.
```
diff --git a/sql/repl_failsafe.cc b/sql/repl_failsafe.cc
index f3d76df31ed..9f9b96c6ac0 100644
--- a/sql/repl_failsafe.cc
+++ b/sql/repl_failsafe.cc
@@ -133,7 +133,7 @@ int THD::register_slave(uchar *packet, size_t packet_length)
   get_object(p,si->host, "Failed to register slave: too long 'report-host'");
   get_object(p,si->user, "Failed to register slave: too long 'report-user'");
   get_object(p,si->password, "Failed to register slave; too long 'report-password'");
-  if (p+10 > p_end)
+  //if (p+10 > p_end)
     goto err;
   si->port= uint2korr(p);
   p += 2;
```