### PR TITLE
MDEV-34108 Inappropriate semi-consistent read in RC if innodb_snapsho…

### DIFF
--- a/mysql-test/suite/innodb/r/lock_isolation.result
+++ b/mysql-test/suite/innodb/r/lock_isolation.result
@@ -103,6 +103,27 @@ SELECT * FROM t;
 a	b
 10	1
 10	20
+TRUNCATE TABLE t;
+#
+# MDEV-34108 Inappropriate semi-consistent read in snapshot isolation
+#
+INSERT INTO t VALUES(NULL, 1), (1, 1);
+BEGIN;
+UPDATE t SET b = 3;
+connection consistent;
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+BEGIN;
+UPDATE t SET b = 2 WHERE a;
+connection default;
+UPDATE t SET a = 1;
+COMMIT;
+connection consistent;
+COMMIT;
+connection default;
+SELECT * FROM t;
+a	b
+1	2
+1	2
 DROP TABLE t;
 #
 # MDEV-33802 Weird read view after ROLLBACK of other transactions

--- a/mysql-test/suite/innodb/t/lock_isolation.test
+++ b/mysql-test/suite/innodb/t/lock_isolation.test
@@ -105,6 +105,40 @@ COMMIT;
 
 --connection default
 SELECT * FROM t;
+TRUNCATE TABLE t;
+
+--echo #
+--echo # MDEV-34108 Inappropriate semi-consistent read in snapshot isolation
+--echo #
+INSERT INTO t VALUES(NULL, 1), (1, 1);
+BEGIN;
+UPDATE t SET b = 3;
+
+--connection consistent
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+BEGIN;
+# As semi-consistent read is disabled for innodb_snapshot_isolation=ON, the
+# following UPDATE must be blocked on the first record.
+--send UPDATE t SET b = 2 WHERE a
+
+--connection default
+let $wait_condition=
+  select count(*) = 1 from information_schema.processlist
+  where state = 'Updating' and info = 'UPDATE t SET b = 2 WHERE a';
+--source include/wait_condition.inc
+
+UPDATE t SET a = 1;
+COMMIT;
+--connection consistent
+# If the bug wouldn't be fixed, the result would be (1,3),(1,2), because
+# "UPDATE t SET b = 2 WHERE a" would be blocked on the second (1,3) record,
+# as semi-consistent read would filter out the first (null,3) record without
+# blocking.
+--reap
+COMMIT;
+
+--connection default
+SELECT * FROM t;
 DROP TABLE t;
 
 --echo #

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -866,6 +866,8 @@ row_sel_build_committed_vers_for_mysql(
 	mtr_t*		mtr)		/*!< in: mtr */
 {
 	if (prebuilt->trx->snapshot_isolation) {
+		ut_ad(prebuilt->trx->isolation_level
+		    == TRX_ISO_READ_UNCOMMITTED);
 		*old_vers = rec;
 		return;
 	}
@@ -5261,7 +5263,20 @@ no_gap_lock:
 			if (UNIV_LIKELY(prebuilt->row_read_type
 					!= ROW_READ_TRY_SEMI_CONSISTENT)
 			    || unique_search
-			    || index != clust_index) {
+			    || index != clust_index
+			    /* If read view was opened, sel_set_rec_lock()
+			    would return DB_RECORD_CHANGED, and we would not be
+			    here. As read view wasn't opened, do locking read
+			    instead of semi-consistent one for READ COMMITTED.
+			    For READ UNCOMMITTED
+			    row_sel_build_committed_vers_for_mysql() must read
+			    uncommitted version of the record. For REPEATABLE
+			    READ and SERIALIZABLE prebuilt->row_read_type
+			    must be not equal to ROW_READ_TRY_SEMI_CONSISTENT,
+			    so there will be locking read for those isolation
+			    levels. */
+			    || (trx->snapshot_isolation && trx->isolation_level
+			      == TRX_ISO_READ_COMMITTED )) {
 				if (!prebuilt->skip_locked) {
 					goto lock_wait_or_error;
 				}


### PR DESCRIPTION
…t_isolation=ON

The fixes in b8a671988954870b7db22e20d1a1409fd40f8e3d have not disabled semi-consistent read for innodb_snapshot_isolation=ON mode, they just allowed read uncommitted version of a record, that's why the test for MDEV-26643 worked well.

The semi-consistent read should be disabled on upper level in row_search_mvcc().

Reviewed by Marko Mäkelä.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
