### PR TITLE
MDEV-34435 Increase code coverage for debug_dbug test case during startup

### DIFF
--- a/mysql-test/suite/binlog/t/binlog_recover_checksum_error.test
+++ b/mysql-test/suite/binlog/t/binlog_recover_checksum_error.test
@@ -16,7 +16,7 @@ call mtr.add_suppression("Error in Log_event::read_log_event");
 
 # Proof of no crash follows.
 # There's no need for actual bin-loggable queries to the server
---let $restart_parameters=  --master_verify_checksum=ON --debug_dbug="+d,corrupt_read_log_event_char"
+--let $restart_parameters=  --master_verify_checksum=ON --debug_dbug=+d,corrupt_read_log_event_char
 --let $shutdown_timeout=0
 --source include/restart_mysqld.inc
 --let $restart_parameters=

--- a/mysql-test/suite/galera_3nodes/t/MDEV-29171.test
+++ b/mysql-test/suite/galera_3nodes/t/MDEV-29171.test
@@ -90,7 +90,7 @@ show variables like 'wsrep_gtid_domain_id';
 # If bug is present, node_3 remains on domain id 100
 #
 --connection node_3
---let $restart_parameters = --wsrep_sst_donor="node2"
+--let $restart_parameters = --wsrep_sst_donor=node2
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.3.expect
 --source include/start_mysqld.inc
 

--- a/mysql-test/suite/innodb/r/innodb_buffer_pool_fail.result
+++ b/mysql-test/suite/innodb/r/innodb_buffer_pool_fail.result
@@ -6,3 +6,4 @@ call mtr.add_suppression("Plugin 'InnoDB' registration as a STORAGE ENGINE faile
 # MDEV-25019 memory allocation failures during startup cause server failure in different, confusing ways
 #
 # restart: --debug_dbug=+d,ib_buf_chunk_init_fails
+FOUND 1 /\[ERROR\] InnoDB: Cannot allocate memory for the buffer pool/ in mysqld.1.err

--- a/mysql-test/suite/innodb/r/recovery_memory,debug.rdiff
+++ b/mysql-test/suite/innodb/r/recovery_memory,debug.rdiff
@@ -1,0 +1,10 @@
+--- recovery_memory.result	2024-06-21 12:54:38.026355524 +0530
++++ recovery_memory.reject	2024-06-21 17:22:49.394535026 +0530
+@@ -23,6 +23,7 @@
+ CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+ INSERT INTO t1 SELECT * FROM seq_1_to_65536;
+ # restart: with restart_parameters
++FOUND 1 /\[ERROR\] InnoDB: The change buffer is corrupted or has been removed on upgrade to MariaDB 11.0 or later/ in mysqld.1.err
+ # restart
+ SHOW CREATE TABLE t1;
+ Table	Create Table

--- a/mysql-test/suite/innodb/t/alter_copy.test
+++ b/mysql-test/suite/innodb/t/alter_copy.test
@@ -57,7 +57,7 @@ ALTER TABLE t ADD INDEX(b,c,d,a),ADD INDEX(b,c,a,d),ADD INDEX(b,a,c,d),ADD INDEX
 connection default;
 SET DEBUG_SYNC='now WAIT_FOR hung';
 let $shutdown_timeout=0;
---let $restart_parameters= --innodb-force-recovery=3 --debug_dbug="+d,recv_ran_out_of_buffer"
+--let $restart_parameters= --innodb-force-recovery=3 --debug_dbug=+d,recv_ran_out_of_buffer
 --source include/restart_mysqld.inc
 disconnect hang;
 let $shutdown_timeout=;

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_fail.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_fail.test
@@ -7,5 +7,8 @@ call mtr.add_suppression("Plugin 'InnoDB' registration as a STORAGE ENGINE faile
 --echo #
 --echo # MDEV-25019 memory allocation failures during startup cause server failure in different, confusing ways
 --echo #
-let restart_parameters=--debug_dbug="+d,ib_buf_chunk_init_fails";
+let restart_parameters=--debug_dbug=+d,ib_buf_chunk_init_fails;
 --source include/restart_mysqld.inc
+let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err;
+let SEARCH_PATTERN=\[ERROR\] InnoDB: Cannot allocate memory for the buffer pool;
+--source include/search_pattern_in_file.inc

--- a/mysql-test/suite/innodb/t/recovery_memory.test
+++ b/mysql-test/suite/innodb/t/recovery_memory.test
@@ -33,7 +33,7 @@ DROP PROCEDURE dorepeat;
 --echo #
 if ($have_debug) {
 SET DEBUG_DBUG="+d,ib_log_checkpoint_avoid_hard";
-let $restart_parameters=--innodb_buffer_pool_size=5242880 --debug_dbug="+d,ibuf_init_corrupt";
+let $restart_parameters=--innodb_buffer_pool_size=5242880 --debug_dbug=+d,ibuf_init_corrupt;
 }
 if (!$have_debug) {
 --echo SET DEBUG_DBUG="+d,ib_log_checkpoint_avoid_hard";
@@ -44,6 +44,11 @@ INSERT INTO t1 SELECT * FROM seq_1_to_65536;
 let $restart_noprint=1;
 let $shutdown_timeout=0;
 --source include/restart_mysqld.inc
+if ($have_debug) {
+let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err;
+let SEARCH_PATTERN=\[ERROR\] InnoDB: The change buffer is corrupted or has been removed on upgrade to MariaDB 11.0 or later;
+--source include/search_pattern_in_file.inc
+}
 let $restart_noprint=0;
 let $restart_parameters=;
 --source include/restart_mysqld.inc


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-34435*

## Description
- Few of test case should make sure that InnoDB does hit the debug sync point during startup of the server. InnoDB can remove the double quotes of debug point in restart parameters.

## How can this PR be tested?
./mtr innodb.innodb_buffer_pool_fail innodb.alter_copy innodb.recovery_memory
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.