### PR TITLE
MDEV-34437: handle error on getaddrinfo

### DIFF
--- a/mysql-test/main/bad_startup_options_debug.result
+++ b/mysql-test/main/bad_startup_options_debug.result
@@ -1,0 +1,7 @@
+#
+# MDEV-34437 SIGSEGV in vio_get_normalized_ip when using extra-port
+#
+FOUND 1 /\[ERROR\] Can't create IP socket: Servname not supported/ in errorlog.err
+FOUND 1 /\[ERROR\] Can't create IP socket: Servname not supported/ in errorlog.err
+# restart
+# End of 10.11 tests

--- a/mysql-test/main/bad_startup_options_debug.test
+++ b/mysql-test/main/bad_startup_options_debug.test
@@ -1,0 +1,34 @@
+# mysqld refuses to run as root normally.
+--source include/not_as_root.inc
+--source include/have_debug.inc
+--source include/not_embedded.inc
+--source include/linux.inc
+
+--source include/shutdown_mysqld.inc
+
+# Try to start the server, with bad values for some options.
+# Make sure, the starts fails, and expected message is in the error log
+
+--let errorlog=$MYSQL_TMP_DIR/errorlog.err
+--let SEARCH_FILE=$errorlog
+
+--echo #
+--echo # MDEV-34437 SIGSEGV in vio_get_normalized_ip when using extra-port
+--echo #
+
+# getaddrinfo failure by fixing port to invalid value
+--error 1
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --debug='d,sabotage_port_number' --log-error=$errorlog
+--let SEARCH_PATTERN=\[ERROR\] Can't create IP socket: Servname not supported
+--source include/search_pattern_in_file.inc
+--remove_file $SEARCH_FILE
+
+--error 1
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --debug='d,sabotage_port_number' --bind-address=0.0.0.0 --log-error=$errorlog
+--let SEARCH_PATTERN=\[ERROR\] Can't create IP socket: Servname not supported
+--source include/search_pattern_in_file.inc
+--remove_file $SEARCH_FILE
+
+--source include/start_mysqld.inc
+
+--echo # End of 10.11 tests

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2329,6 +2329,7 @@ static void activate_tcp_port(uint port,
   else
     real_bind_addr_str= my_bind_addr_str;
 
+  DBUG_EXECUTE_IF("sabotage_port_number", port= UINT_MAX32;);
   my_snprintf(port_buf, NI_MAXSERV, "%d", port);
 
   if (real_bind_addr_str && *real_bind_addr_str)
@@ -2372,6 +2373,13 @@ static void activate_tcp_port(uint port,
   else
   {
     error= getaddrinfo(real_bind_addr_str, port_buf, &hints, &ai);
+    if (unlikely(error != 0))
+    {
+      sql_print_error("%s: %s", ER_DEFAULT(ER_IPSOCK_ERROR),
+                      gai_strerror(error));
+      unireg_abort(1); /* purecov: tested */
+    }
+
     head= ai;
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34437*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

When getaddrinfo returns and error, the contents
of ai are invalid so we cannot continue based
on their data structures.

In the previous branch of the if statement, we
abort there if there is an error so for consistency we abort here too.

## Release Notes

Handle errors looking up getaddrinfo better.

## How can this PR be tested?

```
$ sql/mariadbd --no-defaults --datadir=/tmp/${PWD##*/}-datadir --socket=/tmp/${PWD##*/}.sock --plugin-dir=${PWD}/mysql-test/var/plugins/ --verbose  --port 3321  --extra-port=4294967295
sql/mariadbd: Warning: Charset id '33' csname 'utf8' trying to replace existing csname 'utf8mb3'
sql/mariadbd: Warning: Charset id '83' csname 'utf8' trying to replace existing csname 'utf8mb3'
2024-06-24  9:19:46 0 [Note] Starting MariaDB 10.11.9-MariaDB source revision 82ba486e5484a9dfb5608956453574542a89930d as process 1265693
2024-06-24  9:19:47 0 [Note] InnoDB: Compressed tables use zlib 1.2.13
2024-06-24  9:19:47 0 [Note] InnoDB: Number of transaction pools: 1
2024-06-24  9:19:47 0 [Note] InnoDB: Using AVX512 instructions
2024-06-24  9:19:47 0 [Note] InnoDB: Using liburing
2024-06-24  9:19:47 0 [Note] InnoDB: Initializing buffer pool, total size = 128.000MiB, chunk size = 2.000MiB
2024-06-24  9:19:47 0 [Note] InnoDB: Initialized memory pressure event listener
2024-06-24  9:19:47 0 [Note] InnoDB: Completed initialization of buffer pool
2024-06-24  9:19:47 0 [Note] InnoDB: Buffered log writes (block size=512 bytes)
2024-06-24  9:19:47 0 [Note] InnoDB: End of log at LSN=46894
2024-06-24  9:19:47 0 [Note] InnoDB: 128 rollback segments are active.
2024-06-24  9:19:47 0 [Note] InnoDB: Setting file './ibtmp1' size to 12.000MiB. Physically writing the file full; Please wait ...
2024-06-24  9:19:47 0 [Note] InnoDB: File './ibtmp1' size is now 12.000MiB.
2024-06-24  9:19:47 0 [Note] InnoDB: log sequence number 46894; transaction id 14
2024-06-24  9:19:47 0 [Note] Plugin 'FEEDBACK' is disabled.
2024-06-24  9:19:47 0 [Note] InnoDB: Loading buffer pool(s) from /tmp/build-mariadb-server-10.11-datadir/ib_buffer_pool
2024-06-24  9:19:47 0 [Note] InnoDB: Buffer pool(s) load completed at 240624  9:19:47
2024-06-24  9:19:47 0 [Note] Server socket created on IP: '0.0.0.0'.
2024-06-24  9:19:47 0 [Note] Server socket created on IP: '::'.
2024-06-24  9:19:47 0 [ERROR] Can't create IP socket: Servname not supported for ai_socktype
2024-06-24  9:19:47 0 [ERROR] Aborting
```

previously this would have segfaulted by running on a pointer to invalid data.

#3350 also corrects this by only allowing valid values for port numbers.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
