### PR TITLE
MDEV-34443 ha_innobase::info_low() does not distinguish HA_STATUS_VARIABLE_EXTRA

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14493,11 +14493,13 @@ ha_innobase::info_low(
 			stats.index_file_length
 				= ulonglong(stat_sum_of_other_index_sizes)
 				* size;
-			rw_lock_s_lock(&space->latch);
-			stats.delete_length = 1024
-				* fsp_get_available_space_in_free_extents(
+			if (flag & HA_STATUS_VARIABLE_EXTRA) {
+				rw_lock_s_lock(&space->latch);
+				stats.delete_length = 1024
+					* fsp_get_available_space_in_free_extents(
 					*space);
-			rw_lock_s_unlock(&space->latch);
+				rw_lock_s_unlock(&space->latch);
+			}
 		}
 		stats.check_time = 0;
 		stats.mrr_length_per_rec= (uint)ref_length +  8; // 8 = max(sizeof(void *));


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34443*
## Description
`ha_innobase::info_low()`: For `HA_STATUS_VARIABLE` without `HA_STATUS_VARIABLE_EXTRA`, let us avoid unnecessary and costly updates of the `data_free` or `delete_length` statistics, which are only needed for `SHOW TABLE STATUS`. This optimization had been enabled in 247ecb7597015d02a93732373c742e0c8bd8fc73 but not utilized until now.
## Release Notes
This is a minor performance improvement that is not worth mentioning.
## How can this PR be tested?
`sysbench` with flame graphs.

Note that in the `./mtr` regression test suite, this data is often being masked. The following will report a nonzero `Data_free`:
```diff
diff --git a/mysql-test/suite/innodb/t/default_row_format_create.test b/mysql-test/suite/innodb/t/default_row_format_create.test
index 534a7312620..62a91624c77 100644
--- a/mysql-test/suite/innodb/t/default_row_format_create.test
+++ b/mysql-test/suite/innodb/t/default_row_format_create.test
@@ -1,10 +1,12 @@
 --source include/have_innodb.inc
 --source include/innodb_row_format.inc
 
+set global innodb_file_per_table=0;
 CREATE TABLE t1(c1 TEXT,c2 BLOB) ENGINE=InnoDB;
---replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 12 #
 SHOW TABLE STATUS LIKE 't1';
 DROP TABLE t1;
+set global innodb_file_per_table=1;
 
 CREATE TABLE t1(c1 TEXT,c2 BLOB) ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
 --replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 # 12 #
```
If we use the default `innodb_file_per_table=1`, then the `Data_free` will be reported as 0.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.