### PR TITLE
Refactor import * statement

### DIFF
--- a/debian/additions/source_mariadb-10.5.py
+++ b/debian/additions/source_mariadb-10.5.py
@@ -7,7 +7,7 @@ Author: Mathias Gug <mathias.gug@canonical.com>
 from __future__ import print_function, unicode_literals
 import os, os.path
 
-from apport.hookutils import *
+from apport.hookutils import path_to_key, read_file, attach_conffiles, attach_mac_events, attach_file
 
 def _add_my_conf_files(report, filename):
     key = 'MySQLConf' + path_to_key(filename)


### PR DESCRIPTION
## Description
Refactor import * statements to only import the required functions instead of all functions from the module. Note that all code changes are non-functional.

## Release Notes
N/A

## How can this PR be tested?
All tests are confirmed to pass by running the command `./mtr --suite=main`.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.