### PR TITLE
MDEV-23278 Incorrect Calculation while using Avg Function

### DIFF
--- a/mysql-test/main/case.result
+++ b/mysql-test/main/case.result
@@ -575,3 +575,18 @@ DROP TABLE t1;
 #
 # End of 10.3 test
 #
+#
+# Start of 10.5 tests
+#
+CREATE TABLE t1 (id int);
+INSERT INTO t1 values (3),(2),(1),(3),(1);
+SELECT * FROM (SELECT avg(CASE
+WHEN id=3 THEN 3
+WHEN id=2 THEN 2
+WHEN id=1 THEN 1 END) av FROM t1) t;
+av
+2.0000
+DROP TABLE t1;
+#
+# End of 10.5 tests
+#

--- a/mysql-test/main/case.test
+++ b/mysql-test/main/case.test
@@ -416,3 +416,21 @@ DROP TABLE t1;
 --echo #
 --echo # End of 10.3 test
 --echo #
+
+--echo #
+--echo # Start of 10.5 tests
+--echo #
+
+CREATE TABLE t1 (id int);
+INSERT INTO t1 values (3),(2),(1),(3),(1);
+
+SELECT * FROM (SELECT avg(CASE
+	WHEN id=3 THEN 3
+	WHEN id=2 THEN 2
+	WHEN id=1 THEN 1 END) av FROM t1) t;
+
+DROP TABLE t1;
+
+--echo #
+--echo # End of 10.5 tests
+--echo #

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -2995,6 +2995,16 @@ Item_func_nullif::is_null()
   return (null_value= (!compare() ? 1 : args[2]->is_null()));
 }
 
+
+uint Item_func_case::decimal_precision() const
+{
+  int max_int_part=0;
+  for (uint i= 0; i < arg_count; ++i)
+    set_if_bigger(max_int_part, args[i]->decimal_int_part());
+  return MY_MIN(max_int_part + decimals, DECIMAL_MAX_PRECISION);
+}
+
+
 void Item_func_case::reorder_args(uint start)
 {
   /*

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -2229,6 +2229,7 @@ public:
   Item_func_case(THD *thd, List<Item> &list)
    :Item_func_case_expression(thd, list)
   { }
+  uint decimal_precision() const override;
   double real_op() override;
   longlong int_op() override;
   String *str_op(String *) override;


### PR DESCRIPTION
The decimal_precision virtual override for Item_func_case is necessary to accurately compute precision of values populated into decimal fields.  This method was removed apparently during a refactor of the Item_func_case family of classes between 10.2 and 10.5.
