### PR TITLE
MDEV-34455 innodb_read_only=ON fails to imply innodb_doublewrite=OFF

### DIFF
--- a/mysql-test/suite/innodb/r/alter_copy.result
+++ b/mysql-test/suite/innodb/r/alter_copy.result
@@ -186,6 +186,11 @@ t1	CREATE TABLE `t1` (
 CHECK TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
+SET GLOBAL innodb_doublewrite=ON;
+SELECT @@GLOBAL.innodb_doublewrite "OFF expected";
+OFF expected
+OFF
+SET GLOBAL innodb_buf_flush_list_now=ON;
 # restart
 FTS_INDEX_1.ibd
 FTS_INDEX_2.ibd

--- a/mysql-test/suite/innodb/t/alter_copy.test
+++ b/mysql-test/suite/innodb/t/alter_copy.test
@@ -87,6 +87,10 @@ SELECT * FROM t1 WHERE MATCH(b,c) AGAINST ('column');
 SHOW CREATE TABLE t1;
 CHECK TABLE t1;
 
+SET GLOBAL innodb_doublewrite=ON;
+SELECT @@GLOBAL.innodb_doublewrite "OFF expected";
+SET GLOBAL innodb_buf_flush_list_now=ON;
+
 --let $restart_parameters=
 --source include/restart_mysqld.inc
 --replace_regex /FTS_[0-9a-f]*_[0-9a-f]*/FTS/

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18420,7 +18420,8 @@ static void innodb_data_file_write_through_update(THD *, st_mysql_sys_var*,
 static void innodb_doublewrite_update(THD *, st_mysql_sys_var*,
                                       void *, const void *save)
 {
-  fil_system.set_use_doublewrite(*static_cast<const ulong*>(save));
+  if (!srv_read_only_mode)
+    fil_system.set_use_doublewrite(*static_cast<const ulong*>(save));
 }
 
 static void innodb_log_file_size_update(THD *thd, st_mysql_sys_var*,


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34455*
## Description
`innodb_doublewrite_update()`: Disallow any change if `srv_read_only_mode` holds, that is, the server was started with `innodb_read_only=ON` or `innodb_force_recovery=6`.

This fixes up commit 1122ac978e2e709ae17a19335cbf0e4e5b53ad01 (MDEV-33545).
## Release Notes
`SET GLOBAL innodb_doublewrite` will have no effect if `innodb_read_only=ON` or `innodb_force_recovery=6`.
## How can this PR be tested?
```sh
./mtr innodb.alter_copy
```
Yes, the test name has nothing to do with this change, but it was a test that uses `innodb_read_only` and requires a debug instrumented server. I did not want to slow down the regression tests by adding another server restart to cover this bug.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.