### PR TITLE
MDEV-34458 wait_for_read in buf_page_get_low hurts performance

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1220,7 +1220,7 @@ dberr_t btr_cur_t::search_leaf(const dtuple_t *tuple, page_cur_mode_t mode,
           ut_ad(rw_lock_type_t(latch_mode & ~12) == RW_X_LATCH);
           goto relatch_x;
         }
-        if (latch_mode != BTR_MODIFY_PREV)
+        else
         {
           if (!latch_by_caller)
             /* Release the tree s-latch */
@@ -1292,8 +1292,6 @@ dberr_t btr_cur_t::search_leaf(const dtuple_t *tuple, page_cur_mode_t mode,
 
     switch (latch_mode) {
     case BTR_SEARCH_PREV:
-    case BTR_MODIFY_PREV:
-      static_assert(BTR_MODIFY_PREV & BTR_MODIFY_LEAF, "");
       static_assert(BTR_SEARCH_PREV & BTR_SEARCH_LEAF, "");
       ut_ad(!latch_by_caller);
       ut_ad(rw_latch ==
@@ -1470,7 +1468,6 @@ release_tree:
     case BTR_MODIFY_ROOT_AND_LEAF:
       rw_latch= RW_X_LATCH;
       break;
-    case BTR_MODIFY_PREV: /* btr_pcur_move_to_prev() */
     case BTR_SEARCH_PREV: /* btr_pcur_move_to_prev() */
       ut_ad(rw_latch == RW_S_LATCH || rw_latch == RW_X_LATCH);
 
@@ -1854,7 +1851,6 @@ dberr_t btr_cur_t::open_leaf(bool first, dict_index_t *index,
     ut_ad(!(latch_mode & 8));
     /* This function doesn't need to lock left page of the leaf page */
     static_assert(int{BTR_SEARCH_PREV} == (4 | BTR_SEARCH_LEAF), "");
-    static_assert(int{BTR_MODIFY_PREV} == (4 | BTR_MODIFY_LEAF), "");
     latch_mode= btr_latch_mode(latch_mode & (RW_S_LATCH | RW_X_LATCH));
     ut_ad(!latch_by_caller ||
           mtr->memo_contains_flagged(&index->lock,

--- a/storage/innobase/gis/gis0sea.cc
+++ b/storage/innobase/gis/gis0sea.cc
@@ -604,7 +604,6 @@ dberr_t rtr_search_to_nth_level(btr_cur_t *cur, que_thr_t *thr,
     upper_rw_latch= RW_X_LATCH;
     break;
   default:
-    ut_ad(latch_mode != BTR_MODIFY_PREV);
     ut_ad(latch_mode != BTR_SEARCH_PREV);
     if (!latch_by_caller)
       mtr_s_lock_index(index, mtr);

--- a/storage/innobase/include/btr0types.h
+++ b/storage/innobase/include/btr0types.h
@@ -68,9 +68,6 @@ enum btr_latch_mode {
 	/** Search the previous record.
 	Used in btr_pcur_move_backward_from_page(). */
 	BTR_SEARCH_PREV = 4 | BTR_SEARCH_LEAF,
-	/** Modify the previous record.
-	Used in btr_pcur_move_backward_from_page(). */
-	BTR_MODIFY_PREV = 4 | BTR_MODIFY_LEAF,
 	/** Start modifying the entire B-tree. */
 	BTR_MODIFY_TREE = 8 | BTR_MODIFY_LEAF,
 	/** Continue modifying the entire R-tree.


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34458*
## Description
`BTR_MODIFY_PREV`: Remove. This mode was only used by the change buffer, which commit f27e9c894779a4c7ebe6446ba9aa408f1771c114 (MDEV-29694) removed.

`buf_page_get_gen()`: Revert the change that was made in commit 90b95c6149c72f43aa2324353a76f370d018a5ac (MDEV-33543) because it is not applicable after MDEV-29694. This fixes the performance regression that @vaintroub reported.
## Release Notes
A performance regression related to loading pages into the InnoDB buffer pool was fixed.
## How can this PR be tested?
This is a low-level change that is adequately covered by the regression test suite.

The `BTR_MODIFY_PREV` removal is mechanical, maybe except for `btr_pcur_optimistic_latch_leaves()`. The change to `buf_page_get_gen()` is best reviewed by considering that it is reverting #3234.

I do not think that this change requires any additional stress testing.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

A different fix will be needed for 10.6 and 10.11, where the change buffer is present.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.