### PR TITLE
MDEV-30536: Fix Galera bulk insert optimization MTR test

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -14,7 +14,6 @@ galera_as_slave_ctas : MDEV-28378 timeout
 galera_pc_recovery : MDEV-25199 cluster fails to start up
 galera_bf_kill_debug : timeout after 900 seconds
 galera_ssl_upgrade : [Warning] Failed to load slave replication state from table mysql.gtid_slave_pos: 130: Incorrect file format 'gtid_slave_pos'
-galera_insert_bulk : MDEV-30536 no expected deadlock in galera_insert_bulk test
 galera_sequences : MDEV-32561 WSREP FSM failure: no such a transition REPLICATING -> COMMITTED
 galera_concurrent_ctas : MDEV-32779 galera_concurrent_ctas: assertion in the galera::ReplicatorSMM::finish_cert()
 galera_as_slave_replay : MDEV-32780 galera_as_slave_replay: assertion in the wsrep::transaction::before_rollback()

--- a/mysql-test/suite/galera/r/galera_insert_bulk.result
+++ b/mysql-test/suite/galera/r/galera_insert_bulk.result
@@ -2,6 +2,8 @@ connection node_2;
 connection node_1;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_apply_cb';
+connection node_1;
 SET foreign_key_checks = 0;
 SET unique_checks = 0;
 START TRANSACTION;
@@ -10,11 +12,20 @@ SET foreign_key_checks = 1;
 SET unique_checks = 1;
 INSERT INTO t1 VALUES (1001);
 connection node_1;
+SET DEBUG_SYNC = 'wsrep_before_certification WAIT_FOR sync.wsrep_apply_cb_reached';
+SET DEBUG_SYNC = 'wsrep_after_certification SIGNAL signal.wsrep_apply_cb';
 COMMIT;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE t1;
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+connection node_2;
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_apply_cb';
+connection node_1;
+SET foreign_key_checks = 0;
+SET unique_checks = 0;
 START TRANSACTION;
 connection node_2;
 SET foreign_key_checks = 1;
@@ -23,8 +34,14 @@ START TRANSACTION;
 INSERT INTO t1 VALUES (1001);
 connection node_1;
 COMMIT;
-2
+3
 connection node_2;
+SET DEBUG_SYNC = 'wsrep_before_certification WAIT_FOR sync.wsrep_apply_cb_reached';
+SET DEBUG_SYNC = 'wsrep_after_certification SIGNAL signal.wsrep_apply_cb';
 COMMIT;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 DROP TABLE t1;
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/galera_insert_bulk.test
+++ b/mysql-test/suite/galera/t/galera_insert_bulk.test
@@ -5,6 +5,8 @@
 
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
 
 #
 # Make bulk insert BF-abort, but regular insert succeed.
@@ -13,6 +15,10 @@
 --connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
+# Delay applying of the single insert from the other node.
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_apply_cb';
+
+--connection node_1
 # Disable foreign and unique key checks to allow bulk insert.
 SET foreign_key_checks = 0;
 SET unique_checks = 0;
@@ -30,7 +36,7 @@ while ($count < 1000)
 
 --connection node_2
 
-# Disable bulk insert.
+# Disable bulk insert on this node.
 SET foreign_key_checks = 1;
 SET unique_checks = 1;
 
@@ -38,10 +44,20 @@ SET unique_checks = 1;
 INSERT INTO t1 VALUES (1001);
 
 --connection node_1
+
+# We need to trigger Galera-level certification conflict. For this:
+# - start applying single insert from the other node before bulk insert certifies
+# - certifying bulk insert will lead to the conflict
+# - keep applying single insert
+SET DEBUG_SYNC = 'wsrep_before_certification WAIT_FOR sync.wsrep_apply_cb_reached';
+SET DEBUG_SYNC = 'wsrep_after_certification SIGNAL signal.wsrep_apply_cb';
+
 --error ER_LOCK_DEADLOCK
 COMMIT;
 
 DROP TABLE t1;
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
 
 #
 # Make bulk insert succeed, but regular insert BF-abort.
@@ -50,7 +66,16 @@ DROP TABLE t1;
 --connection node_1
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
+--connection node_2
+# Delay applying of the bulk insert from the other node.
+SET GLOBAL DEBUG_DBUG = 'd,sync.wsrep_apply_cb';
+
+--connection node_1
 --let $before_bulk_keys = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_repl_keys'`
+
+# Disable foreign and unique key checks to allow bulk insert.
+SET foreign_key_checks = 0;
+SET unique_checks = 0;
 
 START TRANSACTION;
 
@@ -64,8 +89,7 @@ while ($count < 1000)
 --enable_query_log
 
 --connection node_2
-
-# Disable bulk insert.
+# Disable bulk insert on this node.
 SET foreign_key_checks = 1;
 SET unique_checks = 1;
 
@@ -77,12 +101,23 @@ INSERT INTO t1 VALUES (1001);
 --connection node_1
 COMMIT;
 
-# Expect two keys to be added for bulk insert: DB-level shared key and table-level exclusive key.
+# Expect three keys to be added for bulk insert: "zero-level" key, DB-level shared key and table-level exclusive key.
 --let $bulk_keys_count = `SELECT VARIABLE_VALUE - $before_bulk_keys FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_repl_keys'`
 --echo $bulk_keys_count
 
 --connection node_2
+
+# We need to trigger Galera-level certification conflict. For this:
+# - start applying bulk insert from the other node before local insert certifies
+# - certifying local insert will lead to the conflict
+# - keep applying bulk insert
+SET DEBUG_SYNC = 'wsrep_before_certification WAIT_FOR sync.wsrep_apply_cb_reached';
+SET DEBUG_SYNC = 'wsrep_after_certification SIGNAL signal.wsrep_apply_cb';
+
 --error ER_LOCK_DEADLOCK
 COMMIT;
 
 DROP TABLE t1;
+SET GLOBAL DEBUG_DBUG = '';
+SET DEBUG_SYNC = 'RESET';
+--source include/galera_end.inc


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30536*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

After closing https://github.com/codership/galera-bugs/issues/947, Galera now correctly certifies table-level keys, which made bulk insert work again.

## Release Notes

Requires Galera 26.4.19

## How can this PR be tested?

The corresponding MTR test is made deterministic and re-enabled.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
