### PR TITLE
MDEV-34456: Move mariadb.pc to not-installed

### DIFF
--- a/debian/libmariadbd-dev.install
+++ b/debian/libmariadbd-dev.install
@@ -3,4 +3,3 @@ usr/lib/*/libmariadbd.a
 usr/lib/*/libmariadbd.so
 usr/lib/*/libmysqld.a
 usr/lib/*/libmysqld.so
-usr/lib/*/pkgconfig/mariadb.pc

--- a/debian/not-installed
+++ b/debian/not-installed
@@ -18,6 +18,7 @@ usr/lib/*/libdbbc.a #  ColumnStore static library
 usr/lib/*/libidbboot.a #  ColumnStore static library
 usr/lib/*/libprocessor.a #  ColumnStore static library
 usr/lib/*/libwe_xml.a #  ColumnStore static library
+usr/lib/*/pkgconfig/mariadb.pc
 usr/bin/test-connect-t
 usr/bin/uca-dump
 usr/bin/wsrep_sst_backup


### PR DESCRIPTION

Move mariadb.pc to not-installed from libmariadbd-dev to clear out this situation

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34456*

## Description
As `mariadb.pc` contains mostly the same than `libmariadb.pc` and it mainly only creates distortion for client developers. They use libmariadb.pc not mariadb.pc (which is for embbeded use mainly).

## Release Notes
Remove mariadb.pc in Debian libmariadbd-dev-package

## How can this PR be tested?
As Salsa-CI is currently not having enough space by hand build package in Debian Sid wih `debian/autobake-debs.sh` and after that install current version with `apt install libmariadbd-dev`. Then install needed build packages with `apt install ./package.deb`. When one gets to `libmariadbd-dev` deb package and `libmariadb-dev` there should be any errors.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
