### PR TITLE
MDEV-34489 innodb.innodb_row_lock_time_ms fails

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_row_lock_time_ms.result
+++ b/mysql-test/suite/innodb/r/innodb_row_lock_time_ms.result
@@ -12,29 +12,29 @@ ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 disconnect con1;
 connection default;
 COMMIT;
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT CAST(variable_value AS INT) > 100 FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_row_lock_time';
-variable_value > 100
+CAST(variable_value AS INT) > 100
 1
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT CAST(variable_value AS INT) > 100 FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_row_lock_time_max';
-variable_value > 100
+CAST(variable_value AS INT) > 100
 1
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT CAST(variable_value AS INT) > 100 FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_row_lock_time_avg';
-variable_value > 100
+CAST(variable_value AS INT) > 100
 1
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
+SELECT CAST(count_reset AS INT) > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
 WHERE NAME="lock_row_lock_time";
-count_reset > 100
+CAST(count_reset AS INT) > 100
 1
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
+SELECT CAST(count_reset AS INT) > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
 WHERE NAME="lock_row_lock_time_max";
-count_reset > 100
+CAST(count_reset AS INT) > 100
 1
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
+SELECT CAST(count_reset AS INT) > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
 WHERE NAME="lock_row_lock_time_avg";
-count_reset > 100
+CAST(count_reset AS INT) > 100
 1
 DROP TABLE t;
 SET GLOBAL innodb_monitor_reset=default;

--- a/mysql-test/suite/innodb/t/innodb_row_lock_time_ms.test
+++ b/mysql-test/suite/innodb/t/innodb_row_lock_time_ms.test
@@ -19,18 +19,18 @@ SELECT * FROM t FOR UPDATE;
 --connection default
 COMMIT;
 
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT CAST(variable_value AS INT) > 100 FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_row_lock_time';
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT CAST(variable_value AS INT) > 100 FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_row_lock_time_max';
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT CAST(variable_value AS INT) > 100 FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_row_lock_time_avg';
 
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
+SELECT CAST(count_reset AS INT) > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
   WHERE NAME="lock_row_lock_time";
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
+SELECT CAST(count_reset AS INT) > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
   WHERE NAME="lock_row_lock_time_max";
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
+SELECT CAST(count_reset AS INT) > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
   WHERE NAME="lock_row_lock_time_avg";
 
 DROP TABLE t;


### PR DESCRIPTION
The test fails because 'variable_value' has not the same type as the value which it's compared to. The fix is to use CAST() not only for 'variable_value', but also for 'count_reset' to avoid future failures.

Reviewed by Marko Mäkelä.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
