### PR TITLE
MDEV-23983 Assertion failure on multiple equalities present in HAVING…

### DIFF
--- a/mysql-test/main/having.result
+++ b/mysql-test/main/having.result
@@ -953,5 +953,20 @@ WHERE (0, a) IN ((0,-1),(+1,0))
 ORDER BY 1+AVG(a) OVER (ORDER BY a)) ORDER BY a;
 DROP TABLE t;
 #
+# MDEV-23983: Assertion failure on multiple equalities present
+#             in HAVING during execution phase
+#
+CREATE TABLE t1 (id INT PRIMARY KEY, a INT, descr TEXT, tp INT);
+INSERT INTO t1 VALUES (3,7,'b',1), (4,7,'b',1);
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	Warning	Engine-independent statistics are not collected for column 'descr'
+test.t1	analyze	status	OK
+SELECT * FROM t1 WHERE id = 3 GROUP BY t1.a HAVING descr = 'b' AND tp = 1;
+id	a	descr	tp
+3	7	b	1
+DROP TABLE t1;
+#
 # End of 10.4 tests
 #

--- a/mysql-test/main/having.test
+++ b/mysql-test/main/having.test
@@ -1000,5 +1000,16 @@ UPDATE t SET a = ''
 DROP TABLE t;
 
 --echo #
+--echo # MDEV-23983: Assertion failure on multiple equalities present
+--echo #             in HAVING during execution phase
+--echo #
+CREATE TABLE t1 (id INT PRIMARY KEY, a INT, descr TEXT, tp INT);
+INSERT INTO t1 VALUES (3,7,'b',1), (4,7,'b',1);
+ANALYZE TABLE t1;
+SELECT * FROM t1 WHERE id = 3 GROUP BY t1.a HAVING descr = 'b' AND tp = 1;
+
+DROP TABLE t1;
+
+--echo #
 --echo # End of 10.4 tests
 --echo #

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -2684,6 +2684,19 @@ public:
   table_map used_tables() const override
     { return used_tables_cache | RAND_TABLE_BIT; }
   bool const_item() const override { return FALSE; }
+
+  /*
+    Since there is an uncopyable member Item_in_subselect *owner, do not allow
+    copying/cloning of instances of this class
+  */
+  Item *build_clone(THD *thd) override
+  {
+    return nullptr;
+  }
+  Item *get_copy(THD *thd) override
+  {
+    return nullptr;
+  }
 };
 
 

--- a/sql/sql_select.h
+++ b/sql/sql_select.h
@@ -1907,6 +1907,7 @@ private:
   void init_join_cache_and_keyread();
   bool prepare_sum_aggregators(THD *thd,Item_sum **func_ptr,
                                bool need_distinct);
+  bool is_impossible_having_noticed();
 };
 
 enum enum_with_bush_roots { WITH_BUSH_ROOTS, WITHOUT_BUSH_ROOTS};


### PR DESCRIPTION
… during execution phase

During optimization, there is a step where the HAVING clause is checked for being an impossible condition (i.e, always FALSE). This check is performed using the `remove_eq_conds()` function. However, a side effect of this function is that it may convert some predicates into multiple equalities, which are not allowed during the execution stage, causing an assertion failure.

To address this issue, a clone of the HAVING clause is created before calling `remove_eq_conds()`. This preserves the original HAVING clause from modification, ensuring it remains unchanged while only checking for an impossible condition

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_23983_*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
