### PR TITLE
MDEV-34503 Archive Storage Engine fails to compile with gcc-14

### DIFF
--- a/storage/archive/azio.c
+++ b/storage/archive/azio.c
@@ -99,7 +99,7 @@ int az_open (azio_stream *s, const char *path, int Flags, File fd)
     if (err != Z_OK)
     {
       destroy(s);
-      return Z_NULL;
+      return 0;
     }
   } else {
     s->stream.next_in  = s->inbuf;
@@ -114,7 +114,7 @@ int az_open (azio_stream *s, const char *path, int Flags, File fd)
     if (err != Z_OK)
     {
       destroy(s);
-      return Z_NULL;
+      return 0;
     }
   }
   s->stream.avail_out = AZ_BUFSIZE_WRITE;
@@ -134,7 +134,7 @@ int az_open (azio_stream *s, const char *path, int Flags, File fd)
   if (s->file < 0 ) 
   {
     destroy(s);
-    return Z_NULL;
+    return 0;
   }
 
   if (Flags & O_CREAT || Flags & O_TRUNC) 

--- a/storage/archive/azlib.h
+++ b/storage/archive/azlib.h
@@ -194,7 +194,6 @@ extern "C" {
 #define Z_DEFLATED   8
 /* The deflate compression method (the only one supported in this version) */
 
-#define Z_NULL  0  /* for initializing zalloc, zfree, opaque */
 #define AZ_BUFSIZE_READ 32768
 #define AZ_BUFSIZE_WRITE 16384
 


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34503*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

gcc has started to recognise the difference between NULL and 0.

As such the NULL_Z defination in the azlib.h is an inconsistent uplicate.

As the function return an integer, make the return value 0 rather than Z_NULL.

## Release Notes
Archive storage engine can now compile with gcc-14.

Or nothing as its compile only.

## How can this PR be tested?

Compile with gcc-14.



## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.