### PR TITLE
MDEV-34490 get_copy() and build_clone() may return an instance of an …

### DIFF
--- a/plugin/func_test/plugin.cc
+++ b/plugin/func_test/plugin.cc
@@ -37,7 +37,7 @@ public:
   }
   const char *func_name() const override { return "sysconst_test"; }
   const char *fully_qualified_func_name() const override { return "sysconst_test()"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sysconst_test>(thd, this); }
 };
 

--- a/plugin/type_inet/item_inetfunc.h
+++ b/plugin/type_inet/item_inetfunc.h
@@ -41,7 +41,7 @@ public:
     unsigned_flag= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_inet_aton>(thd, this); }
 };
 
@@ -64,7 +64,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_inet_ntoa>(thd, this); }
 };
 
@@ -108,7 +108,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_inet6_aton>(thd, this); }
 
   String *val_str(String *to) override;
@@ -143,7 +143,7 @@ public:
     return FALSE;
   }
   String *val_str_ascii(String *to) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_inet6_ntoa>(thd, this); }
 };
 
@@ -162,7 +162,7 @@ public:
 public:
   const char *func_name() const override
   { return "is_ipv4"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_is_ipv4>(thd, this); }
 
   longlong val_int() override;
@@ -182,7 +182,7 @@ public:
 
   const char *func_name() const override
   { return "is_ipv6"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_is_ipv6>(thd, this); }
 
   longlong val_int() override;
@@ -201,7 +201,7 @@ public:
   { }
   const char *func_name() const override
   { return "is_ipv4_compat"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_is_ipv4_compat>(thd, this); }
   longlong val_int() override;
 };
@@ -219,7 +219,7 @@ public:
   { }
   const char *func_name() const override
   { return "is_ipv4_mapped"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_is_ipv4_mapped>(thd, this); }
   longlong val_int() override;
 };

--- a/plugin/type_inet/sql_type_inet.cc
+++ b/plugin/type_inet/sql_type_inet.cc
@@ -1090,7 +1090,7 @@ public:
     Inet6_null tmp(args[0]);
     return null_value= tmp.is_null() || tmp.to_native(to);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_typecast_inet6>(thd, this); }
 };
 
@@ -1102,8 +1102,9 @@ public:
   Item_cache_inet6(THD *thd)
    :Item_cache(thd, &type_handler_inet6)
   { }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_inet6>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
   bool cache_value() override
   {
     if (!example)
@@ -1225,8 +1226,9 @@ public:
     str->append(tmp);
     str->append('\'');
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_literal_inet6>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 
   // Non-overriding methods
   void set_value(const Inet6 &value)
@@ -1282,8 +1284,9 @@ public:
   {
     return Item::save_in_field(field, no_conversions);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_copy_inet6>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -2715,7 +2715,7 @@ bool Type_std_attributes::agg_item_set_converter(const DTCollation &coll,
    @retval 0 on a failure
 */
 
-Item* Item_func_or_sum::build_clone(THD *thd)
+Item* Item_func_or_sum::do_build_clone(THD *thd) const
 {
   Item *copy_tmp_args[2]= {0,0};
   Item **copy_args= copy_tmp_args;
@@ -3035,7 +3035,7 @@ Item_sp::init_result_field(THD *thd, uint max_length, uint maybe_null,
      0 if an error occurred
 */ 
 
-Item* Item_ref::build_clone(THD *thd)
+Item* Item_ref::do_build_clone(THD *thd) const
 {
   Item_ref *copy= (Item_ref *) get_copy(thd);
   if (unlikely(!copy) ||
@@ -3847,7 +3847,7 @@ void Item_decimal::set_decimal_value(my_decimal *value_par)
 }
 
 
-Item *Item_decimal::clone_item(THD *thd)
+Item *Item_decimal::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_decimal(thd, name.str, &decimal_value, decimals,
                                          max_length);
@@ -3868,7 +3868,7 @@ my_decimal *Item_float::val_decimal(my_decimal *decimal_value)
 }
 
 
-Item *Item_float::clone_item(THD *thd)
+Item *Item_float::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_float(thd, name.str, value, decimals,
                                        max_length);
@@ -4032,7 +4032,7 @@ Item *Item_null::safe_charset_converter(THD *thd, CHARSET_INFO *tocs)
   return this;
 }
 
-Item *Item_null::clone_item(THD *thd)
+Item *Item_null::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_null(thd, name.str);
 }
@@ -4837,7 +4837,7 @@ bool Item_param::basic_const_item() const
 }
 
 
-Item *Item_param::value_clone_item(THD *thd)
+Item *Item_param::value_clone_item(THD *thd) const
 {
   MEM_ROOT *mem_root= thd->mem_root;
   switch (value.type_handler()->cmp_type()) {
@@ -4851,12 +4851,15 @@ Item *Item_param::value_clone_item(THD *thd)
   case DECIMAL_RESULT:
     return 0; // Should create Item_decimal. See MDEV-11361.
   case STRING_RESULT:
+  {
+    String value_copy = value.m_string; // to preserve constness of the func
     return new (mem_root) Item_string(thd, name,
-                                      Lex_cstring(value.m_string.c_ptr_quick(),
-                                                  value.m_string.length()),
-                                      value.m_string.charset(),
+                                      Lex_cstring(value_copy.c_ptr_quick(),
+                                                  value_copy.length()),
+                                      value_copy.charset(),
                                       collation.derivation,
                                       collation.repertoire);
+  }
   case TIME_RESULT:
     break;
   case ROW_RESULT:
@@ -4870,7 +4873,7 @@ Item *Item_param::value_clone_item(THD *thd)
 /* see comments in the header file */
 
 Item *
-Item_param::clone_item(THD *thd)
+Item_param::do_clone_const_item(THD *thd) const
 {
   // There's no "default". See comments in Item_param::save_in_field().
   switch (state) {
@@ -6950,7 +6953,7 @@ int Item_string::save_in_field(Field *field, bool no_conversions)
 }
 
 
-Item *Item_string::clone_item(THD *thd)
+Item *Item_string::do_clone_const_item(THD *thd) const
 {
   LEX_CSTRING val;
   str_value.get_value(&val);
@@ -7014,7 +7017,7 @@ int Item_int::save_in_field(Field *field, bool no_conversions)
 }
 
 
-Item *Item_int::clone_item(THD *thd)
+Item *Item_int::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_int(thd, name.str, value, max_length, unsigned_flag);
 }
@@ -7043,7 +7046,7 @@ int Item_decimal::save_in_field(Field *field, bool no_conversions)
 }
 
 
-Item *Item_int_with_ref::clone_item(THD *thd)
+Item *Item_int_with_ref::do_clone_const_item(THD *thd) const
 {
   DBUG_ASSERT(ref->const_item());
   /*
@@ -7139,7 +7142,7 @@ Item *Item_uint::neg(THD *thd)
 }
 
 
-Item *Item_uint::clone_item(THD *thd)
+Item *Item_uint::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_uint(thd, name.str, value, max_length);
 }
@@ -7379,7 +7382,7 @@ void Item_date_literal::print(String *str, enum_query_type query_type)
 }
 
 
-Item *Item_date_literal::clone_item(THD *thd)
+Item *Item_date_literal::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_date_literal(thd, &cached_time);
 }
@@ -7404,7 +7407,7 @@ void Item_datetime_literal::print(String *str, enum_query_type query_type)
 }
 
 
-Item *Item_datetime_literal::clone_item(THD *thd)
+Item *Item_datetime_literal::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_datetime_literal(thd, &cached_time, decimals);
 }
@@ -7429,7 +7432,7 @@ void Item_time_literal::print(String *str, enum_query_type query_type)
 }
 
 
-Item *Item_time_literal::clone_item(THD *thd)
+Item *Item_time_literal::do_clone_const_item(THD *thd) const
 {
   return new (thd->mem_root) Item_time_literal(thd, &cached_time, decimals);
 }
@@ -10388,7 +10391,7 @@ void Item_cache_temporal::store_packed(longlong val_arg, Item *example_arg)
 }
 
 
-Item *Item_cache_temporal::clone_item(THD *thd)
+Item *Item_cache_temporal::do_clone_const_item(THD *thd) const
 {
   Item_cache *tmp= type_handler()->Item_get_cache(thd, this);
   Item_cache_temporal *item= static_cast<Item_cache_temporal*>(tmp);

--- a/sql/item.h
+++ b/sql/item.h
@@ -30,6 +30,7 @@
 #include "sql_time.h"
 #include "sql_schema.h"
 #include "mem_root_array.h"
+#include <typeinfo>
 
 C_MODE_START
 #include <ma_dyncol.h>
@@ -1658,10 +1659,61 @@ public:
     raise_error_not_evaluable();
     return true;    // Error
   }
-  /* cloning of constant items (0 if it is not const) */
-  virtual Item *clone_item(THD *thd) { return 0; }
-  /* deep copy item */
-  virtual Item* build_clone(THD *thd) { return get_copy(thd); }
+
+  /*
+    Create a shallow copy of the item (usually invoking copy constructor).
+    For deep copying see build_clone().
+
+    Return value:
+    - pointer to a copy of the Item
+    - nullptr if the item is not copyable
+  */
+  Item *get_copy(THD *thd) const
+  {
+    Item *copy= do_get_copy(thd);
+    if (copy)
+    {
+      // Make sure the copy is of same type as this item
+      DBUG_ASSERT(typeid(*copy) == typeid(*this));
+    }
+    return copy;
+  }
+
+  /*
+    Creates a clone of the item by deep copying.
+
+    Return value:
+    - pointer to a clone of the Item
+    - nullptr if the item is not clonable
+  */
+  Item* build_clone(THD *thd) const
+  {
+    Item *clone= do_build_clone(thd);
+    if (clone)
+    {
+      // Make sure the clone is of same type as this item
+      DBUG_ASSERT(typeid(*clone) == typeid(*this));
+    }
+    return clone;
+  }
+
+  /*
+    Clones the constant item
+
+    Return value:
+    - pointer to a clone of the Item
+    - nullptr if the item is not clonable */
+  Item *clone_const_item(THD *thd) const
+  {
+    Item *clone= do_clone_const_item(thd);
+    if (clone)
+    {
+      // Make sure the clone is of same type as this item
+      DBUG_ASSERT(typeid(*clone) == typeid(*this));
+    }
+    return clone;
+  }
+
   virtual cond_result eq_cmp_result() const { return COND_OK; }
   inline uint float_length(uint decimals_par) const
   { return decimals < FLOATING_POINT_DECIMALS ? (DBL_DIG+2+decimals_par) : DBL_DIG+8;}
@@ -2189,12 +2241,6 @@ public:
   */
   virtual bool find_not_null_fields(table_map allowed) { return false; }
 
-  /*
-    Does not guarantee deep copy (depends on copy ctor).
-    See build_clone() for deep copy.
-  */
-  virtual Item *get_copy(THD *thd)=0;
-
   bool cache_const_expr_analyzer(uchar **arg);
   Item* cache_const_expr_transformer(THD *thd, uchar *arg);
 
@@ -2527,12 +2573,33 @@ public:
     DBUG_ASSERT(is_fixed());
     return false;
   }
+
+protected:
+  /*
+    Service function for public method get_copy(). See comments for get_copy()
+    above. Override this method in derived classes to create shallow copies of
+    the item
+  */
+  virtual Item *do_get_copy(THD *thd) const = 0;
+
+  /*
+    Service function for public method build_clone(). See comments for
+    build_clone() above. Override this method in derived classes to create
+    deep copies (clones) of the item where possible
+  */
+  virtual Item* do_build_clone(THD *thd) const = 0;
+
+  /*
+    Service function for public method clone_const_item(). See comments for
+    clone_const_item() above
+  */
+  virtual Item *do_clone_const_item(THD *thd) const { return nullptr; }
 };
 
 MEM_ROOT *get_thd_memroot(THD *thd);
 
 template <class T>
-inline Item* get_item_copy (THD *thd, T* item)
+inline Item* get_item_copy (THD *thd, const T* item)
 {
   Item *copy= new (get_thd_memroot(thd)) T(*item);
   if (likely(copy))
@@ -3040,7 +3107,8 @@ public:
 
   bool append_for_log(THD *thd, String *str) override;
 
-  Item *get_copy(THD *) override { return nullptr; }
+  Item *do_get_copy(THD *) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 
   /*
     Override the inherited create_field_for_create_select(),
@@ -3085,6 +3153,9 @@ public:
    :Item_splocal(thd, rh, sp_var_name, sp_var_idx, &type_handler_null,
                  pos_in_q, len_in_q)
   { }
+
+  Item *do_get_copy(THD *) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 };
 
 
@@ -3117,6 +3188,9 @@ public:
   Item **this_item_addr(THD *thd, Item **) override;
   bool append_for_log(THD *thd, String *str) override;
   void print(String *str, enum_query_type query_type) override;
+
+  Item *do_get_copy(THD *) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 };
 
 
@@ -3137,6 +3211,9 @@ public:
   { }
   bool fix_fields(THD *thd, Item **it) override;
   void print(String *str, enum_query_type query_type) override;
+
+  Item *do_get_copy(THD *) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 };
 
 
@@ -3180,7 +3257,8 @@ public:
     purposes.
   */
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *) override { return nullptr; }
+  Item *do_get_copy(THD *) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 
 private:
   uint m_case_expr_id;
@@ -3260,8 +3338,9 @@ public:
   {
     return mark_unsupported_function("name_const()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_name_const>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -3627,8 +3706,9 @@ public:
   bool cleanup_excluding_const_fields_processor(void *arg) override
   { return field && const_item() ? 0 : cleanup_processor(arg); }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_field>(thd, this); }
+  Item* do_build_clone(THD *thd) const override { return get_copy(thd); }
   bool is_outer_field() const override
   {
     DBUG_ASSERT(fixed);
@@ -3652,7 +3732,7 @@ public:
    :Item_field(thd, field),
     Item_args()
   { }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_field_row>(thd, this); }
 
   const Type_handler *type_handler() const override
@@ -3740,7 +3820,7 @@ public:
   const Type_handler *type_handler() const override
   { return &type_handler_null; }
   bool basic_const_item() const override { return true; }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   bool const_is_null() const override { return true; }
   bool is_null() override { return true; }
 
@@ -3754,8 +3834,9 @@ public:
   Item_basic_constant *make_string_literal_concat(THD *thd,
                                                   const LEX_CSTRING *)
     override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_null>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 class Item_null_result :public Item_null
@@ -3964,7 +4045,7 @@ class Item_param :public Item_basic_value,
   PValue value;
 
   const String *value_query_val_str(THD *thd, String* str) const;
-  Item *value_clone_item(THD *thd);
+  Item *value_clone_item(THD *thd) const;
   bool is_evaluable_expression() const override;
   bool can_return_value() const;
 
@@ -4189,7 +4270,7 @@ public:
     basic_const_item returned TRUE.
   */
   Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override;
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   void set_param_type_and_swap_value(Item_param *from);
 
   Rewritable_query_parameter *get_rewritable_query_parameter() override
@@ -4199,7 +4280,8 @@ public:
 
   bool append_for_log(THD *thd, String *str) override;
   bool check_vcol_func_processor(void *) override { return false; }
-  Item *get_copy(THD *) override { return nullptr; }
+  Item *do_get_copy(THD *thd) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 
   bool add_as_clone(THD *thd);
   void sync_clones();
@@ -4287,13 +4369,14 @@ public:
   String *val_str(String*) override;
   int save_in_field(Field *field, bool no_conversions) override;
   bool is_order_clause_position() const override { return true; }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   void print(String *str, enum_query_type query_type) override;
   Item *neg(THD *thd) override;
   uint decimal_precision() const override
   { return (uint) (max_length - MY_TEST(value < 0)); }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_int>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4321,6 +4404,9 @@ public:
       predicate at various condition optimization stages in sql_select.
     */
   }
+  Item *do_get_copy(THD *thd) const override
+  { return get_item_copy<Item_bool>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4331,10 +4417,10 @@ public:
   Item_uint(THD *thd, ulonglong i): Item_int(thd, i, 10) {}
   Item_uint(THD *thd, const char *str_arg, longlong i, uint length);
   double val_real() override { return ulonglong2double((ulonglong)value); }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   Item *neg(THD *thd) override;
   uint decimal_precision() const override { return max_length; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_uint>(thd, this); }
 };
 
@@ -4382,7 +4468,7 @@ public:
   const my_decimal *const_ptr_my_decimal() const override
   { return &decimal_value; }
   int save_in_field(Field *field, bool no_conversions) override;
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   void print(String *str, enum_query_type query_type) override
   {
     decimal_value.to_string(&str_value);
@@ -4391,8 +4477,9 @@ public:
   Item *neg(THD *thd) override;
   uint decimal_precision() const override { return decimal_value.precision(); }
   void set_decimal_value(my_decimal *value_par);
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_decimal>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4434,11 +4521,12 @@ public:
   }
   String *val_str(String*) override;
   my_decimal *val_decimal(my_decimal *) override;
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   Item *neg(THD *thd) override;
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_float>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4556,7 +4644,7 @@ public:
   int save_in_field(Field *field, bool no_conversions) override;
   const Type_handler *type_handler() const override
   { return &type_handler_varchar; }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override
   {
     return const_charset_converter(thd, tocs, true);
@@ -4600,8 +4688,9 @@ public:
     override;
   Item *make_odbc_literal(THD *thd, const LEX_CSTRING *typestr) override;
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_string>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 
 };
 
@@ -4621,6 +4710,9 @@ public:
   {
     return true;
   }
+  Item *do_get_copy(THD *thd) const override
+  { return get_item_copy<Item_string_with_introducer>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4809,8 +4901,9 @@ public:
     return field->store_hex_hybrid(str_value.ptr(), str_value.length());
   }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_hex_hybrid>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4848,8 +4941,9 @@ public:
                         collation.collation);
   }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_hex_string>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4905,8 +4999,9 @@ public:
   {
     m_value= value;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_timestamp_literal>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -4972,7 +5067,7 @@ public:
   {
     return cached_time.get_mysql_time();
   }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   longlong val_int() override
   {
     return update_null() ? 0 : cached_time.to_longlong();
@@ -4994,8 +5089,9 @@ public:
     return update_null() ? 0 : cached_time.valid_date_to_packed();
   }
   bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_date_literal>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -5021,7 +5117,7 @@ public:
   {
     return cached_time.get_mysql_time();
   }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   longlong val_int() override { return cached_time.to_longlong(); }
   double val_real() override { return cached_time.to_double(); }
   String *val_str(String *to) override
@@ -5037,8 +5133,9 @@ public:
   {
     return Time(thd, this).to_native(to, decimals);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_time_literal>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -5071,7 +5168,7 @@ public:
   {
     return cached_time.get_mysql_time();
   }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   longlong val_int() override
   {
     return update_null() ? 0 : cached_time.to_longlong();
@@ -5093,8 +5190,9 @@ public:
     return update_null() ? 0 : cached_time.valid_datetime_to_packed();
   }
   bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_datetime_literal>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -5355,7 +5453,7 @@ public:
   virtual bool fix_length_and_dec()= 0;
   bool const_item() const override { return const_item_cache; }
   table_map used_tables() const override { return used_tables_cache; }
-  Item* build_clone(THD *thd) override;
+  Item* do_build_clone(THD *thd) const override;
   Sql_mode_dependency value_depends_on_sql_mode() const override
   {
     return Item_args::value_depends_on_sql_mode_bit_or().soft_to_hard();
@@ -5602,13 +5700,13 @@ public:
     return (*ref)->is_outer_field();
   }
 
-  Item* build_clone(THD *thd) override;
+  Item *do_build_clone(THD *thd) const override;
 
   /**
     Checks if the item tree that ref points to contains a subquery.
   */
   bool with_subquery() const override { return (*ref)->with_subquery(); }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_ref>(thd, this); }
   bool excl_dep_on_table(table_map tab_map) override
   {
@@ -5691,7 +5789,7 @@ public:
   longlong val_datetime_packed(THD *) override;
   longlong val_time_packed(THD *) override;
   Ref_Type ref_type() override { return DIRECT_REF; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_direct_ref>(thd, this); }
   Item *remove_item_direct_ref() override
   { return (*ref)->remove_item_direct_ref(); }
@@ -5859,9 +5957,9 @@ public:
   {
     return mark_unsupported_function("cache", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_wrapper>(thd, this); }
-  Item *build_clone(THD *) override { return nullptr; }
+  Item *do_build_clone(THD *) const override { return nullptr; }
 };
 
 
@@ -6073,7 +6171,7 @@ public:
   my_decimal *val_decimal_result(my_decimal *val) override;
   bool val_bool_result() override;
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_direct_view_ref>(thd, this); }
   Item *field_transformer_for_having_pushdown(THD *, uchar *) override
   { return this; }
@@ -6136,6 +6234,9 @@ public:
   table_map not_null_tables() const override { return 0; }
   Ref_Type ref_type() override { return OUTER_REF; }
   bool check_inner_refs_processor(void * arg) override;
+  Item *do_get_copy(THD *thd) const override
+  { return get_item_copy<Item_outer_ref>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -6172,7 +6273,7 @@ public:
   bool val_native(THD *thd, Native *to) override;
   void print(String *str, enum_query_type query_type) override;
   table_map used_tables() const override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_ref_null_helper>(thd, this); }
 };
 
@@ -6198,7 +6299,7 @@ public:
   {
     return ref->save_in_field(field, no_conversions);
   }
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   Item *real_item() override { return ref; }
 };
 
@@ -6335,8 +6436,9 @@ public:
   { return get_date_from_string(thd, ltime, fuzzydate); }
   void copy() override;
   int save_in_field(Field *field, bool no_conversions) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_copy_string>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -6406,8 +6508,9 @@ public:
     DBUG_ASSERT(sane());
     return null_value || m_value.to_native(to, decimals);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_copy_timestamp>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -6687,8 +6790,9 @@ public:
     param->set_default();
     return false;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_default_specification>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -6721,8 +6825,9 @@ public:
     return false;
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_ignore_specification>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7064,8 +7169,9 @@ public:
   bool cache_value() override;
   int save_in_field(Field *field, bool no_conversions) override;
   Item *convert_to_basic_const_item(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_int>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7078,6 +7184,7 @@ public:
   {
     return type_handler_year.Item_get_date_with_warn(thd, this, to, mode);
   }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7102,7 +7209,7 @@ public:
     is a constant and need not be optimized further.
     Important when storing packed datetime values.
   */
-  Item *clone_item(THD *thd) override;
+  Item *do_clone_const_item(THD *thd) const override;
   Item *convert_to_basic_const_item(THD *thd) override;
   virtual Item *make_literal(THD *) =0;
 };
@@ -7114,7 +7221,7 @@ public:
   Item_cache_time(THD *thd)
    :Item_cache_temporal(thd, &type_handler_time2) { }
   bool cache_value() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_time>(thd, this); }
   Item *make_literal(THD *) override;
   longlong val_datetime_packed(THD *thd) override
@@ -7154,7 +7261,7 @@ class Item_cache_datetime: public Item_cache_temporal
 public:
   Item_cache_datetime(THD *thd)
    :Item_cache_temporal(thd, &type_handler_datetime2) { }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_datetime>(thd, this); }
   Item *make_literal(THD *) override;
   longlong val_datetime_packed(THD *) override
@@ -7189,7 +7296,7 @@ class Item_cache_date: public Item_cache_temporal
 public:
   Item_cache_date(THD *thd)
    :Item_cache_temporal(thd, &type_handler_newdate) { }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_date>(thd, this); }
   Item *make_literal(THD *) override;
   longlong val_datetime_packed(THD *) override
@@ -7222,8 +7329,9 @@ class Item_cache_timestamp: public Item_cache
 public:
   Item_cache_timestamp(THD *thd)
    :Item_cache(thd, &type_handler_timestamp2) { }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_timestamp>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
   bool cache_value() override;
   String* val_str(String *to) override
   {
@@ -7282,8 +7390,9 @@ public:
    :Item_cache_real(thd, &type_handler_double)
   { }
   String* val_str(String *str) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_double>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7294,8 +7403,9 @@ public:
    :Item_cache_real(thd, &type_handler_float)
   { }
   String* val_str(String *str) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_float>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7317,8 +7427,9 @@ public:
   }
   bool cache_value() override;
   Item *convert_to_basic_const_item(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_decimal>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7347,8 +7458,9 @@ public:
   int save_in_field(Field *field, bool no_conversions) override;
   bool cache_value() override;
   Item *convert_to_basic_const_item(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_str>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7372,8 +7484,9 @@ public:
     */
     return Item::safe_charset_converter(thd, tocs);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_str_for_nullif>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7449,8 +7562,9 @@ public:
   }
   bool cache_value() override;
   void set_null() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cache_row>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -7531,7 +7645,8 @@ public:
            make_and_init_table_field(root, &name, Record_addr(maybe_null),
                                      *this, table);
   }
-  Item* get_copy(THD *) override { return nullptr; }
+  Item *do_get_copy(THD *thd) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 
 };
 
@@ -7686,7 +7801,7 @@ public:
   Item *safe_charset_converter(THD *thd, CHARSET_INFO *tocs) override;
   Item *get_tmp_table_item(THD *thd) override
   { return m_item->get_tmp_table_item(thd); }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_direct_ref_to_item>(thd, this); }
   COND *build_equal_items(THD *thd, COND_EQUAL *inherited,
                           bool link_item_fields,
@@ -7756,7 +7871,7 @@ public:
   { return m_item->excl_dep_on_grouping_fields(sel); }
   bool is_expensive() override { return m_item->is_expensive(); }
   void set_item(Item *item) { m_item= item; }
-  Item *build_clone(THD *thd) override
+  Item *do_build_clone(THD *thd) const override
   {
     Item *clone_item= m_item->build_clone(thd);
     if (clone_item)

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -5465,17 +5465,16 @@ void Item_cond::neg_arguments(THD *thd)
      0 if an error occurred
 */ 
 
-Item *Item_cond::build_clone(THD *thd)
+Item *Item_cond::do_build_clone(THD *thd) const
 {
-  List_iterator_fast<Item> li(list);
-  Item *item;
   Item_cond *copy= (Item_cond *) get_copy(thd);
   if (!copy)
     return 0;
   copy->list.empty();
-  while ((item= li++))
+
+  for (const Item &item : list)
   {
-    Item *arg_clone= item->build_clone(thd);
+    Item *arg_clone= item.build_clone(thd);
     if (!arg_clone)
       return 0;
     if (copy->list.push_back(arg_clone, thd->mem_root))

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -288,7 +288,7 @@ public:
   Item_func_istrue(THD *thd, Item *a): Item_func_truth(thd, a, true, true) {}
   ~Item_func_istrue() = default;
   const char* func_name() const override { return "istrue"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_istrue>(thd, this); }
 };
 
@@ -305,7 +305,7 @@ public:
   ~Item_func_isnottrue() = default;
   const char* func_name() const override { return "isnottrue"; }
   bool find_not_null_fields(table_map allowed) override { return false; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isnottrue>(thd, this); }
   bool eval_not_null_tables(void *) override { not_null_tables_cache= 0; return false; }
 };
@@ -321,7 +321,7 @@ public:
   Item_func_isfalse(THD *thd, Item *a): Item_func_truth(thd, a, false, true) {}
   ~Item_func_isfalse() = default;
   const char* func_name() const override { return "isfalse"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isfalse>(thd, this); }
 };
 
@@ -338,7 +338,7 @@ public:
   ~Item_func_isnotfalse() = default;
   const char* func_name() const override { return "isnotfalse"; }
   bool find_not_null_fields(table_map allowed) override { return false; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isnotfalse>(thd, this); }
   bool eval_not_null_tables(void *) override { not_null_tables_cache= 0; return false; }
 };
@@ -408,7 +408,7 @@ public:
   void restore_first_argument();
   Item* get_wrapped_in_subselect_item()
   { return args[1]; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_in_optimizer>(thd, this); }
   enum precedence precedence() const override { return args[1]->precedence(); }
 };
@@ -579,10 +579,10 @@ public:
     return add_key_fields_optimize_op(join, key_fields, and_level,
                                       usable_tables, sargables, false);
   }
-  Item *build_clone(THD *thd) override
+  Item *do_build_clone(THD *thd) const override
   {
     Item_bool_rowready_func2 *clone=
-      (Item_bool_rowready_func2 *) Item_func::build_clone(thd);
+      (Item_bool_rowready_func2 *) Item_func::do_build_clone(thd);
     if (clone)
     {
       clone->cmp.comparators= 0;
@@ -613,7 +613,7 @@ public:
     Item_args::propagate_equal_fields(thd, Context_boolean(), cond);
     return this;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_xor>(thd, this); }
 };
 
@@ -633,7 +633,7 @@ public:
   Item *neg_transformer(THD *thd) override;
   bool fix_fields(THD *, Item **) override;
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_not>(thd, this); }
 };
 
@@ -682,7 +682,7 @@ public:
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields,
                       uint *and_level, table_map usable_tables,
                       SARGABLE_PARAM **sargables) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_trig_cond>(thd, this); }
 };
 
@@ -722,7 +722,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "<nop>"; }
   Item *neg_transformer(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_nop_all>(thd, this); }
 };
 
@@ -763,7 +763,7 @@ public:
   uint in_equality_no;
   uint exists2in_reserved_items() override { return 1; };
   friend class  Arg_comparator;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_eq>(thd, this); }
 };
 
@@ -788,7 +788,7 @@ public:
     return add_key_fields_optimize_op(join, key_fields, and_level,
                                       usable_tables, sargables, true);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_equal>(thd, this); }
 };
 
@@ -804,7 +804,7 @@ public:
   cond_result eq_cmp_result() const override { return COND_TRUE; }
   const char *func_name() const override { return ">="; }
   Item *negated_item(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ge>(thd, this); }
 };
 
@@ -820,7 +820,7 @@ public:
   cond_result eq_cmp_result() const override { return COND_FALSE; }
   const char *func_name() const override { return ">"; }
   Item *negated_item(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_gt>(thd, this); }
 };
 
@@ -836,7 +836,7 @@ public:
   cond_result eq_cmp_result() const override { return COND_TRUE; }
   const char *func_name() const override { return "<="; }
   Item *negated_item(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_le>(thd, this); }
 };
 
@@ -852,7 +852,7 @@ public:
   cond_result eq_cmp_result() const override { return COND_FALSE; }
   const char *func_name() const override { return "<"; }
   Item *negated_item(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_lt>(thd, this); }
 };
 
@@ -873,7 +873,7 @@ public:
   Item *negated_item(THD *thd) override;
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields, uint *and_level,
                       table_map usable_tables, SARGABLE_PARAM **sargables) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ne>(thd, this); }
 };
 
@@ -968,7 +968,7 @@ public:
                                       cond);
     return this;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_between>(thd, this); }
 
   longlong val_int_cmp_string();
@@ -1000,7 +1000,7 @@ public:
     fix_char_length(2); // returns "1" or "0" or "-1"
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_strcmp>(thd, this); }
 };
 
@@ -1035,7 +1035,7 @@ public:
     str->append(func_name());
     print_args(str, 0, query_type);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_interval>(thd, this); }
 };
 
@@ -1063,7 +1063,7 @@ public:
   }
   const char *func_name() const override { return "coalesce"; }
   table_map not_null_tables() const override { return 0; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_coalesce>(thd, this); }
 };
 
@@ -1154,7 +1154,7 @@ public:
   const char *func_name() const override { return "ifnull"; }
 
   table_map not_null_tables() const override { return 0; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ifnull>(thd, this); }
 };
 
@@ -1227,7 +1227,7 @@ public:
   const char *func_name() const override { return "if"; }
   bool eval_not_null_tables(void *opt_arg) override;
   void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_if>(thd, this); }
 private:
   void cache_type_info(Item *source);
@@ -1248,7 +1248,7 @@ public:
   {
     return fix_length_and_dec2_eliminate_null(args + 1);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_nvl2>(thd, this); }
 };
 
@@ -1337,7 +1337,7 @@ public:
                                                            cond, &args[2]);
     return this;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_nullif>(thd, this); }
   Item *derived_field_transformer_for_having(THD *thd, uchar *arg) override
   { reset_first_arg_if_needed(); return this; }
@@ -2273,7 +2273,7 @@ public:
     return this;
   }
   Item *find_item() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_case_searched>(thd, this); }
 };
 
@@ -2321,7 +2321,7 @@ public:
   bool fix_length_and_dec() override;
   Item *propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override;
   Item *find_item() override;
-  Item *build_clone(THD *thd) override
+  Item *do_build_clone(THD *thd) const override
   {
     Item_func_case_simple *clone= (Item_func_case_simple *)
                                   Item_func_case::build_clone(thd);
@@ -2330,7 +2330,7 @@ public:
       return NULL;
     return clone;
   } 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_case_simple>(thd, this); }
 };
 
@@ -2346,7 +2346,7 @@ public:
   void print(String *str, enum_query_type query_type) override;
   bool fix_length_and_dec() override;
   Item *find_item() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_decode_oracle>(thd, this); }
 };
 
@@ -2511,11 +2511,11 @@ public:
   bool find_not_null_fields(table_map allowed) override;
   void fix_after_pullout(st_select_lex *new_parent, Item **ref, bool merge) override;
   bool count_sargable_conds(void *arg) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_in>(thd, this); }
-  Item *build_clone(THD *thd) override
+  Item *do_build_clone(THD *thd) const override
   {
-    Item_func_in *clone= (Item_func_in *) Item_func::build_clone(thd);
+    Item_func_in *clone= (Item_func_in *) Item_func::do_build_clone(thd);
     if (clone)
     {
       clone->array= 0;
@@ -2655,7 +2655,7 @@ public:
   table_map not_null_tables() const override { return 0; }
   bool find_not_null_fields(table_map allowed) override;
   Item *neg_transformer(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isnull>(thd, this); }
 };
 
@@ -2703,7 +2703,7 @@ public:
   Item *neg_transformer(THD *thd) override;
   void print(String *str, enum_query_type query_type) override;
   void top_level_item() override { abort_on_null=1; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isnotnull>(thd, this); }
 };
 
@@ -2856,7 +2856,7 @@ public:
 
   bool find_selective_predicates_list_processor(void *arg) override;
   
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_like>(thd, this); }
 };
 
@@ -2949,7 +2949,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "regexp"; }
   enum precedence precedence() const override { return IN_PRECEDENCE; }
-  Item *get_copy(THD *) override { return 0; }
+  Item *do_get_copy(THD *thd) const override { return 0; }
   void print(String *str, enum_query_type query_type) override
   {
     print_op(str, query_type);
@@ -2988,7 +2988,7 @@ public:
   longlong val_int() override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "regexp_instr"; }
-  Item *get_copy(THD *thd) override { return 0; }
+  Item *do_get_copy(THD *thd) const override { return 0; }
 };
 
 
@@ -3084,7 +3084,7 @@ public:
   }
   bool eval_not_null_tables(void *opt_arg) override;
   bool find_not_null_fields(table_map allowed) override;
-  Item *build_clone(THD *thd) override;
+  Item *do_build_clone(THD *thd) const override;
   bool excl_dep_on_table(table_map tab_map) override;
   bool excl_dep_on_grouping_fields(st_select_lex *sel) override;
 
@@ -3268,7 +3268,7 @@ public:
 
   void set_context_field(Item_field *ctx_field) { context_field= ctx_field; }
   void set_link_equal_fields(bool flag) { link_equal_fields= flag; }
-  Item* get_copy(THD *thd) override { return 0; }
+  Item* do_get_copy(THD *thd) const override { return 0; }
   /*
     This does not comply with the specification of the virtual method,
     but Item_equal items are processed distinguishly anyway
@@ -3433,7 +3433,7 @@ public:
   void add_key_fields(JOIN *join, KEY_FIELD **key_fields, uint *and_level,
                       table_map usable_tables, SARGABLE_PARAM **sargables) override;
   SEL_TREE *get_mm_tree(RANGE_OPT_PARAM *param, Item **cond_ptr) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cond_and>(thd, this); }
 };
 
@@ -3457,7 +3457,7 @@ public:
   table_map not_null_tables() const override { return and_tables_cache; }
   Item *copy_andor_structure(THD *thd) override;
   Item *neg_transformer(THD *thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_cond_or>(thd, this); }
 };
 
@@ -3468,7 +3468,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "column_check"; }
   bool need_parentheses_in_default() override { return false; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dyncol_check>(thd, this); }
 };
 
@@ -3480,7 +3480,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "column_exists"; }
   bool need_parentheses_in_default() override { return false; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dyncol_exists>(thd, this); }
 };
 
@@ -3509,7 +3509,7 @@ public:
    :Item_func_cursor_bool_attr(thd, name, offset) { }
   const char *func_name() const override { return "%ISOPEN"; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_cursor_isopen>(thd, this); }
 };
 
@@ -3521,7 +3521,7 @@ public:
    :Item_func_cursor_bool_attr(thd, name, offset) { maybe_null= true; }
   const char *func_name() const override { return "%FOUND"; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_cursor_found>(thd, this); }
 };
 
@@ -3533,7 +3533,7 @@ public:
    :Item_func_cursor_bool_attr(thd, name, offset) { maybe_null= true; }
   const char *func_name() const override { return "%NOTFOUND"; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_cursor_notfound>(thd, this); }
 };
 

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -1265,7 +1265,7 @@ public:
   longlong val_int() override;
   bool fix_length_and_dec() override;
   const Type_handler *type_handler() const override { return &type_handler_slong; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_hash>(thd, this); }
   const char *func_name() const override { return "<hash>"; }
 };
@@ -1277,7 +1277,7 @@ public:
    :Item_func_hash(thd, item)
   {}
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_hash_mariadb_100403>(thd, this); }
   const char *func_name() const override { return "<hash_mariadb_100403>"; }
 };
@@ -1332,7 +1332,7 @@ public:
   {
     return Cursor_ref::print_func(str, func_name());
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_cursor_rowcount>(thd, this); }
 };
 
@@ -1352,7 +1352,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_connection_id>(thd, this); }
 };
 
@@ -1419,7 +1419,7 @@ public:
   void print(String *str, enum_query_type query_type) override;
   uint decimal_precision() const override { return args[0]->decimal_precision(); }
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_signed>(thd, this); }
 };
 
@@ -1450,7 +1450,7 @@ public:
   }
   uint decimal_precision() const override { return max_length; }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_unsigned>(thd, this); }
 };
 
@@ -1486,7 +1486,7 @@ public:
   const char *func_name() const override { return "decimal_typecast"; }
   void print(String *str, enum_query_type query_type) override;
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_decimal_typecast>(thd, this); }
 };
 
@@ -1533,7 +1533,7 @@ public:
     nr.to_string(str, decimals);
     return str;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_float_typecast>(thd, this); }
 };
 
@@ -1551,7 +1551,7 @@ public:
   }
   const char *func_name() const override { return "double_typecast"; }
   double val_real() override { return val_real_with_truncate(DBL_MAX); }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_double_typecast>(thd, this); }
 };
 
@@ -1577,7 +1577,7 @@ public:
   longlong int_op() override;
   double real_op() override;
   my_decimal *decimal_op(my_decimal *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_plus>(thd, this); }
 };
 
@@ -1612,7 +1612,7 @@ public:
     Item_func_additive_op::fix_length_and_dec_int();
     fix_unsigned_flag();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_minus>(thd, this); }
 };
 
@@ -1631,7 +1631,7 @@ public:
   bool fix_length_and_dec() override;
   bool check_partition_func_processor(void *int_arg) override {return FALSE;}
   bool check_vcol_func_processor(void *arg) override { return FALSE;}
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_mul>(thd, this); }
 };
 
@@ -1650,7 +1650,7 @@ public:
   void fix_length_and_dec_double();
   void fix_length_and_dec_int();
   void result_precision() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_div>(thd, this); }
 };
 
@@ -1674,7 +1674,7 @@ public:
   bool check_partition_func_processor(void *int_arg) override {return FALSE;}
   bool check_vcol_func_processor(void *arg) override { return FALSE;}
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_int_div>(thd, this); }
 };
 
@@ -1708,7 +1708,7 @@ public:
   }
   bool check_partition_func_processor(void *int_arg) override {return FALSE;}
   bool check_vcol_func_processor(void *arg) override { return FALSE;}
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_mod>(thd, this); }
 };
 
@@ -1734,7 +1734,7 @@ public:
   bool fix_length_and_dec() override;
   uint decimal_precision() const override { return args[0]->decimal_precision(); }
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_neg>(thd, this); }
 };
 
@@ -1752,7 +1752,7 @@ public:
   void fix_length_and_dec_double();
   void fix_length_and_dec_decimal();
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_abs>(thd, this); }
 };
 
@@ -1779,7 +1779,7 @@ public:
   Item_func_exp(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "exp"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_exp>(thd, this); }
 };
 
@@ -1790,7 +1790,7 @@ public:
   Item_func_ln(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "ln"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ln>(thd, this); }
 };
 
@@ -1802,7 +1802,7 @@ public:
   Item_func_log(THD *thd, Item *a, Item *b): Item_dec_func(thd, a, b) {}
   double val_real() override;
   const char *func_name() const override { return "log"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_log>(thd, this); }
 };
 
@@ -1813,7 +1813,7 @@ public:
   Item_func_log2(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "log2"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_log2>(thd, this); }
 };
 
@@ -1824,7 +1824,7 @@ public:
   Item_func_log10(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "log10"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_log10>(thd, this); }
 };
 
@@ -1835,7 +1835,7 @@ public:
   Item_func_sqrt(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "sqrt"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sqrt>(thd, this); }
 };
 
@@ -1846,7 +1846,7 @@ public:
   Item_func_pow(THD *thd, Item *a, Item *b): Item_dec_func(thd, a, b) {}
   double val_real() override;
   const char *func_name() const override { return "pow"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_pow>(thd, this); }
 };
 
@@ -1857,7 +1857,7 @@ public:
   Item_func_acos(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "acos"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_acos>(thd, this); }
 };
 
@@ -1867,7 +1867,7 @@ public:
   Item_func_asin(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "asin"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_asin>(thd, this); }
 };
 
@@ -1878,7 +1878,7 @@ public:
   Item_func_atan(THD *thd, Item *a, Item *b): Item_dec_func(thd, a, b) {}
   double val_real() override;
   const char *func_name() const override { return "atan"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_atan>(thd, this); }
 };
 
@@ -1888,7 +1888,7 @@ public:
   Item_func_cos(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "cos"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_cos>(thd, this); }
 };
 
@@ -1898,7 +1898,7 @@ public:
   Item_func_sin(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "sin"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sin>(thd, this); }
 };
 
@@ -1908,7 +1908,7 @@ public:
   Item_func_tan(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "tan"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_tan>(thd, this); }
 };
 
@@ -1918,7 +1918,7 @@ public:
   Item_func_cot(THD *thd, Item *a): Item_dec_func(thd, a) {}
   double val_real() override;
   const char *func_name() const override { return "cot"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_cot>(thd, this); }
 };
 
@@ -1960,7 +1960,7 @@ public:
   my_decimal *decimal_op(my_decimal *) override;
   bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
   bool time_op(THD *thd, MYSQL_TIME *ltime) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ceiling>(thd, this); }
 };
 
@@ -1976,7 +1976,7 @@ public:
   my_decimal *decimal_op(my_decimal *) override;
   bool date_op(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
   bool time_op(THD *thd, MYSQL_TIME *ltime) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_floor>(thd, this); }
 };
 
@@ -2021,7 +2021,7 @@ public:
     */
     return args[0]->real_type_handler()->Item_func_round_fix_length_and_dec(this);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_round>(thd, this); }
 };
 
@@ -2047,7 +2047,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_rand>(thd, this); }
 };
 
@@ -2062,7 +2062,7 @@ public:
   uint decimal_precision() const override { return 1; }
   bool fix_length_and_dec() override { fix_char_length(2); return FALSE; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sign>(thd, this); }
 };
 
@@ -2085,7 +2085,7 @@ public:
     max_length= float_length(decimals);
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_units>(thd, this); }
 };
 
@@ -2187,7 +2187,7 @@ class Item_func_min :public Item_func_min_max
 public:
   Item_func_min(THD *thd, List<Item> &list): Item_func_min_max(thd, list, 1) {}
   const char *func_name() const override { return "least"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_min>(thd, this); }
 };
 
@@ -2196,7 +2196,7 @@ class Item_func_max :public Item_func_min_max
 public:
   Item_func_max(THD *thd, List<Item> &list): Item_func_min_max(thd, list, -1) {}
   const char *func_name() const override { return "greatest"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_max>(thd, this); }
 };
 
@@ -2230,7 +2230,7 @@ public:
     Type_std_attributes::set(*args[0]);
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_rollup_const>(thd, this); }
 };
 
@@ -2252,7 +2252,7 @@ public:
   Item_func_octet_length(THD *thd, Item *a): Item_long_func_length(thd, a) {}
   longlong val_int() override;
   const char *func_name() const override { return "octet_length"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_octet_length>(thd, this); }
 };
 
@@ -2268,7 +2268,7 @@ public:
   }
   longlong val_int() override;
   const char *func_name() const override { return "bit_length"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_bit_length>(thd, this); }
 };
 
@@ -2279,7 +2279,7 @@ public:
   Item_func_char_length(THD *thd, Item *a): Item_long_func_length(thd, a) {}
   longlong val_int() override;
   const char *func_name() const override { return "char_length"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_char_length>(thd, this); }
 };
 
@@ -2304,7 +2304,7 @@ public:
   Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   { return this; }
   bool const_item() const override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_coercibility>(thd, this); }
 };
 
@@ -2337,7 +2337,7 @@ public:
     return agg_arg_charsets_for_comparison(cmp_collation, args, 2);
   }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_locate>(thd, this); }
 };
 
@@ -2352,7 +2352,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "field"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_field>(thd, this); }
 };
 
@@ -2367,7 +2367,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "ascii"; }
   bool fix_length_and_dec() override { max_length=3; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ascii>(thd, this); }
 };
 
@@ -2381,7 +2381,7 @@ public:
   bool fix_length_and_dec() override { fix_char_length(7); return FALSE; }
   longlong val_int() override;
   const char *func_name() const override { return "ord"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ord>(thd, this); }
 };
 
@@ -2399,7 +2399,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "find_in_set"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_find_in_set>(thd, this); }
 };
 
@@ -2441,7 +2441,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "|"; }
   enum precedence precedence() const override { return BITOR_PRECEDENCE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_bit_or>(thd, this); }
 };
 
@@ -2453,7 +2453,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "&"; }
   enum precedence precedence() const override { return BITAND_PRECEDENCE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_bit_and>(thd, this); }
 };
 
@@ -2465,7 +2465,7 @@ public:
   Item_func_bit_count(THD *thd, Item *a): Item_handled_func(thd, a) {}
   const char *func_name() const override { return "bit_count"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_bit_count>(thd, this); }
 };
 
@@ -2477,7 +2477,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "<<"; }
   enum precedence precedence() const override { return SHIFT_PRECEDENCE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_shift_left>(thd, this); }
 };
 
@@ -2489,7 +2489,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return ">>"; }
   enum precedence precedence() const override { return SHIFT_PRECEDENCE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_shift_right>(thd, this); }
 };
 
@@ -2505,7 +2505,7 @@ public:
     str->append(func_name());
     args[0]->print_parenthesised(str, query_type, precedence());
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_bit_neg>(thd, this); }
 };
 
@@ -2531,7 +2531,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_last_insert_id>(thd, this); }
 };
 
@@ -2555,7 +2555,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_benchmark>(thd, this); }
 };
 
@@ -2582,7 +2582,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sleep>(thd, this); }
 };
 
@@ -2733,7 +2733,7 @@ class Item_func_udf_float :public Item_udf_func
   String *val_str(String *str) override;
   const Type_handler *type_handler() const override { return &type_handler_double; }
   bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_udf_float>(thd, this); }
 };
 
@@ -2760,7 +2760,7 @@ public:
     return &type_handler_slonglong;
   }
   bool fix_length_and_dec() override { decimals= 0; max_length= 21; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_udf_int>(thd, this); }
 };
 
@@ -2787,7 +2787,7 @@ public:
   }
   const Type_handler *type_handler() const override { return &type_handler_newdecimal; }
   bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_udf_decimal>(thd, this); }
 };
 
@@ -2826,7 +2826,7 @@ public:
   }
   const Type_handler *type_handler() const override { return string_type_handler(); }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_udf_str>(thd, this); }
 };
 
@@ -2919,7 +2919,7 @@ class Item_func_get_lock final :public Item_func_lock
   longlong val_int() override final;
   const char *func_name() const override final { return "get_lock"; }
   bool fix_length_and_dec() override { max_length= 1; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) override final
+  Item *do_get_copy(THD *thd) const override final
   { return get_item_copy<Item_func_get_lock>(thd, this); }
 };
 
@@ -2931,7 +2931,7 @@ public:
   { unsigned_flag= 1; }
   longlong val_int() override final;
   const char *func_name() const override final { return "release_all_locks"; }
-  Item *get_copy(THD *thd) override final
+  Item *do_get_copy(THD *thd) const override final
   { return get_item_copy<Item_func_release_all_locks>(thd, this); }
 };
 
@@ -2946,7 +2946,7 @@ public:
   longlong val_int() override final;
   const char *func_name() const override { return "release_lock"; }
   bool fix_length_and_dec() override { max_length= 1; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) override final
+  Item *do_get_copy(THD *thd) const override final
   { return get_item_copy<Item_func_release_lock>(thd, this); }
 };
 
@@ -2978,7 +2978,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_master_pos_wait>(thd, this); }
 };
 
@@ -3003,7 +3003,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_master_gtid_wait>(thd, this); }
 };
 
@@ -3119,7 +3119,7 @@ public:
   bool register_field_in_bitmap(void *arg) override;
   bool set_entry(THD *thd, bool create_if_not_exists);
   void cleanup() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_set_user_var>(thd, this); }
   bool excl_dep_on_table(table_map tab_map) override { return false; }
 };
@@ -3148,7 +3148,7 @@ public:
   table_map used_tables() const override
   { return const_item() ? 0 : RAND_TABLE_BIT; }
   bool eq(const Item *item, bool binary_cmp) const override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_get_user_var>(thd, this); }
 private:
   bool set_value(THD *thd, sp_rcontext *ctx, Item **it) override;
@@ -3230,8 +3230,9 @@ public:
   void set_null_value(CHARSET_INFO* cs);
   void set_value(const char *str, uint length, CHARSET_INFO* cs);
   const Type_handler *type_handler() const override { return &type_handler_double; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_user_var_as_out_param>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -3289,7 +3290,7 @@ public:
 
   void cleanup() override;
   bool check_vcol_func_processor(void *arg) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_get_system_var>(thd, this); }
 };
 
@@ -3348,9 +3349,9 @@ public:
   {
     return mark_unsupported_function("match ... against()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_match>(thd, this); }
-  Item *build_clone(THD *thd) override { return 0; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 private:
   /**
      Check whether storage engine for given table, 
@@ -3396,7 +3397,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "^"; }
   enum precedence precedence() const override { return BITXOR_PRECEDENCE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_bit_xor>(thd, this); }
 };
 
@@ -3418,7 +3419,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_is_free_lock>(thd, this); }
 };
 
@@ -3440,7 +3441,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_is_used_lock>(thd, this); }
 };
 
@@ -3492,7 +3493,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_row_count>(thd, this); }
 };
 
@@ -3630,7 +3631,7 @@ public:
   {
     return TRUE;
   }
-  Item *get_copy(THD *) override { return 0; }
+  Item *do_get_copy(THD *thd) const override { return 0; }
   bool eval_not_null_tables(void *opt_arg) override
   {
     not_null_tables_cache= 0;
@@ -3656,7 +3657,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_found_rows>(thd, this); }
 };
 
@@ -3675,7 +3676,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_oracle_sql_rowcount>(thd, this); }
 };
 
@@ -3700,7 +3701,7 @@ public:
     max_length= 11;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sqlcode>(thd, this); }
 };
 
@@ -3721,7 +3722,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_NON_DETERMINISTIC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_uuid_short>(thd, this); }
 };
 
@@ -3757,7 +3758,7 @@ public:
     Item_func::update_used_tables();
     maybe_null= last_value->maybe_null;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_last_value>(thd, this); }
 };
 
@@ -3798,7 +3799,7 @@ public:
     }
   }
   bool const_item() const override { return 0; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_nextval>(thd, this); }
   void print(String *str, enum_query_type query_type) override;
   bool check_vcol_func_processor(void *arg) override
@@ -3817,7 +3818,7 @@ public:
   Item_func_nextval(thd, table_list_arg) {}
   longlong val_int() override;
   const char *func_name() const override { return "lastval"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_lastval>(thd, this); }
 };
 
@@ -3838,7 +3839,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "setval"; }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_setval>(thd, this); }
 };
 

--- a/sql/item_geofunc.h
+++ b/sql/item_geofunc.h
@@ -214,7 +214,7 @@ public:
     Item_geometry_func(thd, a, srid) {}
   const char *func_name() const override { return "st_geometryfromtext"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_geometry_from_text>(thd, this); }
 };
 
@@ -232,7 +232,7 @@ public:
     Item_geometry_func(thd, a, srid) {}
   const char *func_name() const override { return "st_geometryfromwkb"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_geometry_from_wkb>(thd, this); }
 };
 
@@ -254,7 +254,7 @@ public:
     Item_geometry_func(thd, js, opt, srid) {}
   const char *func_name() const override { return "st_geomfromgeojson"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_geometry_from_json>(thd, this); }
 };
 
@@ -267,7 +267,7 @@ public:
   const char *func_name() const override { return "st_astext"; }
   String *val_str_ascii(String *) override;
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_as_wkt>(thd, this); }
 };
 
@@ -287,7 +287,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_as_wkb>(thd, this); }
 };
 
@@ -310,7 +310,7 @@ public:
   const char *func_name() const override { return "st_asgeojson"; }
   bool fix_length_and_dec() override;
   String *val_str_ascii(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_as_geojson>(thd, this); }
 };
 
@@ -329,7 +329,7 @@ public:
     maybe_null= 1;
     return FALSE;
   };
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_geometry_type>(thd, this); }
 };
 
@@ -364,7 +364,7 @@ public:
     {}
   const char *func_name() const override { return "st_convexhull"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_convexhull>(thd, this); }
 };
 
@@ -380,7 +380,7 @@ public:
   {
     return &type_handler_point;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_centroid>(thd, this); }
 };
 
@@ -395,7 +395,7 @@ public:
   {
     return &type_handler_polygon;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_envelope>(thd, this); }
 };
 
@@ -429,7 +429,7 @@ public:
    :Item_geometry_func_args_geometry(thd, a) {}
   const char *func_name() const override { return "st_boundary"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_boundary>(thd, this); }
 };
 
@@ -448,7 +448,7 @@ public:
   {
     return &type_handler_point;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_point>(thd, this); }
 };
 
@@ -474,7 +474,7 @@ public:
     }
   }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_spatial_decomp>(thd, this); }
 };
 
@@ -507,7 +507,7 @@ public:
     }
   }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_spatial_decomp_n>(thd, this); }
 };
 
@@ -563,7 +563,7 @@ public:
     return &type_handler_geometrycollection;
   }
   const char *func_name() const override { return "geometrycollection"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_geometrycollection>(thd, this); }
 };
 
@@ -578,7 +578,7 @@ public:
   { }
   const Type_handler *type_handler() const override { return &type_handler_linestring; }
   const char *func_name() const override { return "linestring"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_linestring>(thd, this); }
 };
 
@@ -593,7 +593,7 @@ public:
   { }
   const Type_handler *type_handler() const override { return &type_handler_polygon; }
   const char *func_name() const override { return "polygon"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_polygon>(thd, this); }
 };
 
@@ -611,7 +611,7 @@ public:
     return &type_handler_multilinestring;
   }
   const char *func_name() const override { return "multilinestring"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_multilinestring>(thd, this); }
 };
 
@@ -629,7 +629,7 @@ public:
     return &type_handler_multipoint;
   }
   const char *func_name() const override { return "multipoint"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_multipoint>(thd, this); }
 };
 
@@ -647,7 +647,7 @@ public:
     return &type_handler_multipolygon;
   }
   const char *func_name() const override { return "multipolygon"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_multipolygon>(thd, this); }
 };
 
@@ -699,7 +699,7 @@ public:
                                       usable_tables, sargables, false);
   }
   bool need_parentheses_in_default() override { return false; }
-  Item *build_clone(THD *thd) override { return 0; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 };
 
 
@@ -711,7 +711,7 @@ public:
   { }
   longlong val_int() override;
   const char *func_name() const override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_spatial_mbr_rel>(thd, this); }
 };
 
@@ -727,7 +727,7 @@ public:
   { }
   longlong val_int() override;
   const char *func_name() const override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_spatial_precise_rel>(thd, this); }
 };
 
@@ -750,7 +750,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "st_relate"; }
   bool need_parentheses_in_default() override { return false; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_spatial_relate>(thd, this); }
 };
 
@@ -787,7 +787,7 @@ public:
   {
     Item_func::print(str, query_type);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_spatial_operation>(thd, this); }
 };
 
@@ -844,7 +844,7 @@ public:
    :Item_geometry_func_args_geometry(thd, obj, distance) {}
   const char *func_name() const override { return "st_buffer"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_buffer>(thd, this); }
 };
 
@@ -858,7 +858,7 @@ public:
   const char *func_name() const override { return "st_isempty"; }
   bool fix_length_and_dec() override { maybe_null= 1; return FALSE; }
   bool need_parentheses_in_default() override { return false; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isempty>(thd, this); }
 };
 
@@ -875,7 +875,7 @@ public:
   const char *func_name() const override { return "st_issimple"; }
   bool fix_length_and_dec() override { decimals=0; max_length=2; return FALSE; }
   uint decimal_precision() const override { return 1; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_issimple>(thd, this); }
 };
 
@@ -888,7 +888,7 @@ public:
   const char *func_name() const override { return "st_isclosed"; }
   bool fix_length_and_dec() override { decimals=0; max_length=2; return FALSE; }
   uint decimal_precision() const override { return 1; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isclosed>(thd, this); }
 };
 
@@ -898,7 +898,7 @@ public:
   Item_func_isring(THD *thd, Item *a): Item_func_issimple(thd, a) {}
   longlong val_int() override;
   const char *func_name() const override { return "st_isring"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_isring>(thd, this); }
 };
 
@@ -910,7 +910,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "st_dimension"; }
   bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dimension>(thd, this); }
 };
 
@@ -928,7 +928,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_x>(thd, this); }
 };
 
@@ -946,7 +946,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_y>(thd, this); }
 };
 
@@ -959,7 +959,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "st_numgeometries"; }
   bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_numgeometries>(thd, this); }
 };
 
@@ -972,7 +972,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "st_numinteriorrings"; }
   bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_numinteriorring>(thd, this); }
 };
 
@@ -985,7 +985,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "st_numpoints"; }
   bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_numpoints>(thd, this); }
 };
 
@@ -1003,7 +1003,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_area>(thd, this); }
 };
 
@@ -1023,7 +1023,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_glength>(thd, this); }
 };
 
@@ -1036,7 +1036,7 @@ public:
   longlong val_int() override;
   const char *func_name() const override { return "srid"; }
   bool fix_length_and_dec() override { max_length= 10; maybe_null= 1; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_srid>(thd, this); }
 };
 
@@ -1053,7 +1053,7 @@ public:
    :Item_real_func_args_geometry_geometry(thd, a, b) {}
   double val_real() override;
   const char *func_name() const override { return "st_distance"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_distance>(thd, this); }
 };
 
@@ -1067,7 +1067,7 @@ public:
     Item_real_func(thd, list) {}
   double val_real() override;
   const char *func_name() const override { return "st_distance_sphere"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sphere_distance>(thd, this); }
 };
 
@@ -1087,7 +1087,7 @@ public:
   {
     return &type_handler_point;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_pointonsurface>(thd, this); }
 };
 
@@ -1105,7 +1105,7 @@ class Item_func_gis_debug: public Item_long_func
     {
       return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
     }
-    Item *get_copy(THD *thd) override
+    Item *do_get_copy(THD *thd) const override
     { return get_item_copy<Item_func_gis_debug>(thd, this); }
 };
 #endif

--- a/sql/item_jsonfunc.h
+++ b/sql/item_jsonfunc.h
@@ -89,7 +89,7 @@ public:
     static const Lex_cstring fmt(STRING_WITH_LEN("json"));
     return to->set_format_name(fmt);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_valid>(thd, this); }
   enum Functype functype() const override   { return JSON_VALID_FUNC; }
 };
@@ -106,7 +106,7 @@ public:
     Item_bool_func(thd, js, i_path) {}
   const char *func_name() const override { return "json_exists"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_exists>(thd, this); }
   longlong val_int() override;
 };
@@ -150,7 +150,7 @@ public:
   {
     return je->check_and_get_value_scalar(res, error);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_value>(thd, this); }
 };
 
@@ -174,7 +174,7 @@ public:
   {
     return je->check_and_get_value_complex(res, error);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_query>(thd, this); }
 };
 
@@ -189,7 +189,7 @@ public:
   const char *func_name() const override { return "json_quote"; }
   bool fix_length_and_dec() override;
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_quote>(thd, this); }
 };
 
@@ -204,7 +204,7 @@ public:
   const char *func_name() const override { return "json_unquote"; }
   bool fix_length_and_dec() override;
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_unquote>(thd, this); }
 };
 
@@ -255,7 +255,7 @@ public:
   double val_real() override;
   my_decimal *val_decimal(my_decimal *) override;
   uint get_n_paths() const override { return arg_count - 1; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_extract>(thd, this); }
 };
 
@@ -274,7 +274,7 @@ public:
   const char *func_name() const override { return "json_contains"; }
   bool fix_length_and_dec() override;
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_contains>(thd, this); }
 };
 
@@ -297,7 +297,7 @@ public:
   bool fix_fields(THD *thd, Item **ref) override;
   bool fix_length_and_dec() override;
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_contains_path>(thd, this); }
 };
 
@@ -315,7 +315,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "json_array"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_array>(thd, this); }
 };
 
@@ -332,7 +332,7 @@ public:
   String *val_str(String *) override;
   uint get_n_paths() const override { return arg_count/2; }
   const char *func_name() const override { return "json_array_append"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_array_append>(thd, this); }
 };
 
@@ -344,7 +344,7 @@ public:
     Item_func_json_array_append(thd, list) {}
   String *val_str(String *) override;
   const char *func_name() const override { return "json_array_insert"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_array_insert>(thd, this); }
 };
 
@@ -358,7 +358,7 @@ public:
     Item_func_json_array(thd, list) {}
   String *val_str(String *) override;
   const char *func_name() const override { return "json_object"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_object>(thd, this); }
 };
 
@@ -372,7 +372,7 @@ public:
     Item_func_json_array(thd, list) {}
   String *val_str(String *) override;
   const char *func_name() const override { return "json_merge_preserve"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_merge>(thd, this); }
 };
 
@@ -383,7 +383,7 @@ public:
     Item_func_json_merge(thd, list) {}
   const char *func_name() const override { return "json_merge_patch"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_merge_patch>(thd, this); }
 };
 
@@ -410,7 +410,7 @@ public:
   const char *func_name() const override { return "json_length"; }
   bool fix_length_and_dec() override;
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_length>(thd, this); }
 };
 
@@ -426,7 +426,7 @@ public:
   const char *func_name() const override { return "json_depth"; }
   bool fix_length_and_dec() override { max_length= 10; return FALSE; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_depth>(thd, this); }
 };
 
@@ -440,7 +440,7 @@ public:
   const char *func_name() const override { return "json_type"; }
   bool fix_length_and_dec() override;
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_type>(thd, this); }
 };
 
@@ -463,7 +463,7 @@ public:
     return mode_insert ?
              (mode_replace ? "json_set" : "json_insert") : "json_replace";
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_insert>(thd, this); }
 };
 
@@ -479,7 +479,7 @@ public:
   String *val_str(String *) override;
   uint get_n_paths() const override { return arg_count - 1; }
   const char *func_name() const override { return "json_remove"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_remove>(thd, this); }
 };
 
@@ -496,7 +496,7 @@ public:
   const char *func_name() const override { return "json_keys"; }
   bool fix_length_and_dec() override;
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_keys>(thd, this); }
 };
 
@@ -521,7 +521,7 @@ public:
   bool fix_length_and_dec() override;
   String *val_str(String *) override;
   uint get_n_paths() const override { return arg_count > 4 ? arg_count - 4 : 0; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_search>(thd, this); }
 };
 
@@ -549,7 +549,7 @@ public:
   bool fix_length_and_dec() override;
   String *val_str(String *str) override;
   String *val_json(String *str) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_format>(thd, this); }
 };
 
@@ -591,7 +591,7 @@ public:
   String* val_str(String *str) override;
 
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_arrayagg>(thd, this); }
 };
 
@@ -636,7 +636,7 @@ public:
   String* val_str(String* str) override;
   Item *copy_or_same(THD* thd) override;
   void no_rows_in_result() override {}
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_json_objectagg>(thd, this); }
 };
 

--- a/sql/item_row.cc
+++ b/sql/item_row.cc
@@ -183,7 +183,7 @@ void Item_row::bring_value()
 }
 
 
-Item* Item_row::build_clone(THD *thd)
+Item* Item_row::do_build_clone(THD *thd) const
 {
   Item **copy_args= static_cast<Item**>
     (alloc_root(thd->mem_root, sizeof(Item*) * arg_count));

--- a/sql/item_row.h
+++ b/sql/item_row.h
@@ -152,9 +152,9 @@ public:
   }
 
   bool check_vcol_func_processor(void *arg) override {return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_row>(thd, this); }
-  Item *build_clone(THD *thd) override;
+  Item *do_build_clone(THD *thd) const override;
 };
 
 #endif /* ITEM_ROW_INCLUDED */

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -150,7 +150,7 @@ public:
     return FALSE;
   }
   const char *func_name() const override { return "md5"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_md5>(thd, this); }
 };
 
@@ -162,7 +162,7 @@ public:
   String *val_str_ascii(String *) override;    
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "sha"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sha>(thd, this); }
 };
 
@@ -174,7 +174,7 @@ public:
   String *val_str_ascii(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "sha2"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sha2>(thd, this); }
 };
 
@@ -187,7 +187,7 @@ public:
   String *val_str_ascii(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "to_base64"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_to_base64>(thd, this); }
 };
 
@@ -200,7 +200,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "from_base64"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_from_base64>(thd, this); }
 };
 
@@ -227,7 +227,7 @@ public:
    :Item_aes_crypt(thd, a, b) {}
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "aes_encrypt"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_aes_encrypt>(thd, this); }
 };
 
@@ -238,7 +238,7 @@ public:
     Item_aes_crypt(thd, a, b) {}
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "aes_decrypt"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_aes_decrypt>(thd, this); }
 };
 
@@ -268,7 +268,7 @@ public:
     print_args_parenthesized(str, query_type);
   }
   const char *func_name() const override { return "concat"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_concat>(thd, this); }
 };
 
@@ -299,7 +299,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   {
     return get_item_copy<Item_func_concat_operator_oracle>(thd, this);
   }
@@ -320,7 +320,7 @@ public:
     return FALSE;
   }
   const char *func_name() const override { return "decode_histogram"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_decode_histogram>(thd, this); }
 };
 
@@ -333,7 +333,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "concat_ws"; }
   table_map not_null_tables() const override { return 0; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_concat_ws>(thd, this); }
 };
 
@@ -345,7 +345,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "reverse"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_reverse>(thd, this); }
 };
 
@@ -367,7 +367,7 @@ public:
     print_args_parenthesized(str, query_type);
   }
   const char *func_name() const override { return "replace"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_replace>(thd, this); }
 };
 
@@ -391,7 +391,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_replace_oracle>(thd, this); }
 };
 
@@ -427,7 +427,7 @@ public:
   }
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "regexp_replace"; }
-  Item *get_copy(THD *thd) override { return 0;}
+  Item *do_get_copy(THD *thd) const override { return 0;}
 };
 
 
@@ -468,7 +468,7 @@ public:
   String *val_str(String *str) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "regexp_substr"; }
-  Item *get_copy(THD *thd) override { return 0; }
+  Item *do_get_copy(THD *thd) const override { return 0; }
 };
 
 
@@ -482,7 +482,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "insert"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_insert>(thd, this); }
 };
 
@@ -505,7 +505,7 @@ public:
   Item_func_lcase(THD *thd, Item *item): Item_str_conv(thd, item) {}
   const char *func_name() const override { return "lcase"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_lcase>(thd, this); }
 };
 
@@ -515,7 +515,7 @@ public:
   Item_func_ucase(THD *thd, Item *item): Item_str_conv(thd, item) {}
   const char *func_name() const override { return "ucase"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ucase>(thd, this); }
 };
 
@@ -529,7 +529,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "left"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_left>(thd, this); }
 };
 
@@ -542,7 +542,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "right"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_right>(thd, this); }
 };
 
@@ -567,7 +567,7 @@ public:
     print_args_parenthesized(str, query_type);
   }
   const char *func_name() const override { return "substr"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_substr>(thd, this); }
 };
 
@@ -603,7 +603,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_substr_oracle>(thd, this); }
 };
 
@@ -616,7 +616,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "substring_index"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_substr_index>(thd, this); }
 
 };
@@ -655,7 +655,7 @@ public:
   const char *func_name() const override { return "trim"; }
   void print(String *str, enum_query_type query_type) override;
   virtual const char *mode_name() const { return "both"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_trim>(thd, this); }
 };
 
@@ -676,7 +676,7 @@ public:
     maybe_null= true;
     return res;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_trim_oracle>(thd, this); }
 };
 
@@ -694,7 +694,7 @@ public:
   const Schema *schema() const override { return &mariadb_schema; }
   const char *func_name() const override { return "ltrim"; }
   const char *mode_name() const override { return "leading"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ltrim>(thd, this); }
 };
 
@@ -715,7 +715,7 @@ public:
     maybe_null= true;
     return res;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_ltrim_oracle>(thd, this); }
 };
 
@@ -729,7 +729,7 @@ public:
   const Schema *schema() const override { return &mariadb_schema; }
   const char *func_name() const override { return "rtrim"; }
   const char *mode_name() const override { return "trailing"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_rtrim>(thd, this); }
 };
 
@@ -750,7 +750,7 @@ public:
     maybe_null= true;
     return res;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_rtrim_oracle>(thd, this); }
 };
 
@@ -789,7 +789,7 @@ public:
                                           "password" : "old_password"); }
   static char *alloc(THD *thd, const char *password, size_t pass_len,
                      enum PW_Alg al);
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_password>(thd, this); }
 };
 
@@ -812,7 +812,7 @@ public:
     return FALSE;
   }
   const char *func_name() const override { return "des_encrypt"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_des_encrypt>(thd, this); }
 };
 
@@ -835,7 +835,7 @@ public:
     return FALSE;
   }
   const char *func_name() const override { return "des_decrypt"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_des_decrypt>(thd, this); }
 };
 
@@ -871,7 +871,7 @@ public:
   {
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_encrypt>(thd, this); }
 };
 
@@ -891,7 +891,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "encode"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_encode>(thd, this); }
 protected:
   virtual void crypto_transform(String *);
@@ -912,7 +912,7 @@ public:
     print_args_parenthesized(str, query_type);
   }
   const char *func_name() const override { return "decode"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_decode>(thd, this); }
 protected:
   void crypto_transform(String *) override;
@@ -953,7 +953,7 @@ public:
   }
   const char *func_name() const override { return "database"; }
   const char *fully_qualified_func_name() const override { return "database()"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_database>(thd, this); }
 };
 
@@ -975,7 +975,7 @@ public:
     null_value= maybe_null= false;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sqlerrm>(thd, this); }
 };
 
@@ -1008,7 +1008,7 @@ public:
   {
     return save_str_value_in_field(field, &str_value);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_user>(thd, this); }
 };
 
@@ -1061,7 +1061,7 @@ public:
     return mark_unsupported_function(fully_qualified_func_name(), arg,
                                      VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_current_role>(thd, this); }
 };
 
@@ -1074,7 +1074,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "soundex"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_soundex>(thd, this); }
 };
 
@@ -1088,7 +1088,7 @@ public:
   String *val_str(String *str) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "elt"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_elt>(thd, this); }
 };
 
@@ -1102,7 +1102,7 @@ public:
   String *val_str(String *str) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "make_set"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_make_set>(thd, this); }
 };
 
@@ -1119,7 +1119,7 @@ public:
   String *val_str_ascii(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "format"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_format>(thd, this); }
 };
 
@@ -1144,7 +1144,7 @@ public:
   }
   const char *func_name() const override { return "char"; }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_char>(thd, this); }
 };
 
@@ -1160,7 +1160,7 @@ public:
     return FALSE;
   }
   const char *func_name() const override { return "chr"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_chr>(thd, this); }
 };
 
@@ -1173,7 +1173,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "repeat"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_repeat>(thd, this); }
 };
 
@@ -1185,7 +1185,7 @@ public:
   String *val_str(String *) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "space"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_space>(thd, this); }
 };
 
@@ -1202,7 +1202,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_binlog_gtid_pos>(thd, this); }
 };
 
@@ -1240,7 +1240,7 @@ public:
   }
   const char *func_name() const override { return "rpad"; }
   Sql_mode_dependency value_depends_on_sql_mode() const override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_rpad>(thd, this); }
 };
 
@@ -1274,7 +1274,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_rpad_oracle>(thd, this); }
 };
 
@@ -1296,7 +1296,7 @@ public:
     print_args_parenthesized(str, query_type);
   }
   const char *func_name() const override { return "lpad"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_lpad>(thd, this); }
 };
 
@@ -1330,7 +1330,7 @@ public:
       print_sql_mode_qualified_name(str, query_type);
     print_args_parenthesized(str, query_type);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_lpad_oracle>(thd, this); }
 };
 
@@ -1349,7 +1349,7 @@ public:
     maybe_null= 1;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_conv>(thd, this); }
 };
 
@@ -1395,7 +1395,7 @@ public:
     fix_char_length(char_length);
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_hex>(thd, this); }
 };
 
@@ -1417,7 +1417,7 @@ public:
     max_length=(1+args[0]->max_length)/2;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_unhex>(thd, this); }
 };
 
@@ -1450,7 +1450,7 @@ public:
   Item_func_like_range_min(THD *thd, Item *a, Item *b):
     Item_func_like_range(thd, a, b, true) { }
   const char *func_name() const override { return "like_range_min"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_like_range_min>(thd, this); }
 };
 
@@ -1461,7 +1461,7 @@ public:
   Item_func_like_range_max(THD *thd, Item *a, Item *b):
     Item_func_like_range(thd, a, b, false) { }
   const char *func_name() const override { return "like_range_max"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_like_range_max>(thd, this); }
 };
 #endif
@@ -1489,7 +1489,7 @@ public:
   void print(String *str, enum_query_type query_type) override;
   const char *func_name() const override { return "cast_as_binary"; }
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_binary>(thd, this); }
 };
 
@@ -1512,7 +1512,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_IMPOSSIBLE);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_load_file>(thd, this); }
 };
 
@@ -1529,7 +1529,7 @@ class Item_func_export_set: public Item_str_func
   String  *val_str(String *str) override;
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "export_set"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_export_set>(thd, this); }
 };
 
@@ -1552,7 +1552,7 @@ public:
     max_length= (uint32) MY_MIN(max_result_length, MAX_BLOB_WIDTH);
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_quote>(thd, this); }
 };
 
@@ -1644,7 +1644,7 @@ public:
   bool fix_length_and_dec() override;
   const char *func_name() const override { return "convert"; }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_conv_charset>(thd, this); }
 };
 
@@ -1667,7 +1667,7 @@ public:
     return args[0]->field_for_view_update();
   }
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_set_collation>(thd, this); }
 };
 
@@ -1697,7 +1697,7 @@ public:
     :Item_func_expr_str_metadata(thd, a) { }
   String *val_str(String *) override;
   const char *func_name() const override { return "charset"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_charset>(thd, this); }
 };
 
@@ -1709,7 +1709,7 @@ public:
     :Item_func_expr_str_metadata(thd, a) {}
   String *val_str(String *) override;
   const char *func_name() const override { return "collation"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_collation>(thd, this); }
 };
 
@@ -1744,7 +1744,7 @@ public:
   Item* propagate_equal_fields(THD *thd, const Context &ctx, COND_EQUAL *cond) override
   { return this; }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_weight_string>(thd, this); }
 };
 
@@ -1759,7 +1759,7 @@ public:
   const char *func_name() const override { return "crc32"; }
   bool fix_length_and_dec() override { max_length=10; return FALSE; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_crc32>(thd, this); }
 };
 
@@ -1772,7 +1772,7 @@ public:
   const char *func_name() const override{return "uncompressed_length";}
   bool fix_length_and_dec() override { max_length=10; maybe_null= true; return FALSE; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_uncompressed_length>(thd, this); }
 };
 
@@ -1795,7 +1795,7 @@ public:
   }
   const char *func_name() const override{return "compress";}
   String *val_str(String *) override ZLIB_DEPENDED_FUNCTION
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_compress>(thd, this); }
 };
 
@@ -1812,7 +1812,7 @@ public:
   }
   const char *func_name() const override{return "uncompress";}
   String *val_str(String *) override ZLIB_DEPENDED_FUNCTION
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_uncompress>(thd, this); }
 };
 
@@ -1835,7 +1835,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_NON_DETERMINISTIC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_uuid>(thd, this); }
 };
 
@@ -1858,7 +1858,7 @@ public:
   String *val_str(String *) override;
   void print(String *str, enum_query_type query_type) override;
   enum Functype functype() const override   { return DYNCOL_FUNC; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dyncol_create>(thd, this); }
 };
 
@@ -1872,7 +1872,7 @@ public:
   const char *func_name() const override{ return "column_add"; }
   String *val_str(String *) override;
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dyncol_add>(thd, this); }
 };
 
@@ -1890,7 +1890,7 @@ public:
     decimals= 0;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dyncol_json>(thd, this); }
 };
 
@@ -1932,7 +1932,7 @@ public:
   bool get_dyn_value(THD *thd, DYNAMIC_COLUMN_VALUE *val, String *tmp);
   bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_dyncol_get>(thd, this); }
 };
 
@@ -1946,7 +1946,7 @@ public:
   { maybe_null= 1; max_length= MAX_BLOB_WIDTH; return FALSE; };
   const char *func_name() const override{ return "column_list"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dyncol_list>(thd, this); }
 };
 
@@ -1967,7 +1967,7 @@ public:
   enum Functype functype() const override { return  TEMPTABLE_ROWID; }
   const char *func_name() const override { return "<rowid>"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_temptable_rowid>(thd, this); }
 };
 #ifdef WITH_WSREP
@@ -1987,7 +1987,7 @@ public:
     maybe_null= true;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_wsrep_last_written_gtid>(thd, this); }
 };
 
@@ -2004,7 +2004,7 @@ public:
     maybe_null= true;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_wsrep_last_seen_gtid>(thd, this); }
 };
 
@@ -2017,7 +2017,7 @@ public:
   const Type_handler *type_handler() const override { return &type_handler_string; }
   const char *func_name() const override { return "wsrep_sync_wait_upto_gtid"; }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_wsrep_sync_wait_upto>(thd, this); }
 };
 #endif /* WITH_WSREP */

--- a/sql/item_subselect.h
+++ b/sql/item_subselect.h
@@ -281,8 +281,8 @@ public:
   void register_as_with_rec_ref(With_element *with_elem);
   void init_expr_cache_tracker(THD *thd);
 
-  Item* build_clone(THD *thd) override { return 0; }
-  Item* get_copy(THD *thd) override { return 0; }
+  Item* do_build_clone(THD *thd) const override { return nullptr; }
+  Item *do_get_copy(THD *thd) const override { return 0; }
 
   st_select_lex *wrap_tvc_into_select(THD *thd, st_select_lex *tvc_sl);
 

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -855,7 +855,7 @@ public:
   }
   Item *copy_or_same(THD* thd) override;
   void remove() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_sum>(thd, this); }
 
   bool supports_removal() const override
@@ -927,7 +927,7 @@ public:
     return has_with_distinct() ? "count(distinct " : "count(";
   }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_count>(thd, this); }
 
   bool supports_removal() const override
@@ -983,7 +983,7 @@ public:
     count= 0;
     Item_sum_sum::cleanup();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_avg>(thd, this); }
 
   bool supports_removal() const override
@@ -1068,7 +1068,7 @@ public:
     m_stddev= Stddev();
     Item_sum_double::cleanup();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_variance>(thd, this); }
 };
 
@@ -1090,7 +1090,7 @@ class Item_sum_std final :public Item_sum_variance
   const char *func_name() const override final
   { return sample ? "stddev_samp(" : "std("; }
   Item *copy_or_same(THD* thd) override final;
-  Item *get_copy(THD *thd) override final
+  Item *do_get_copy(THD *thd) const override final
   { return get_item_copy<Item_sum_std>(thd, this); }
 };
 
@@ -1187,7 +1187,7 @@ public:
   bool add() override;
   const char *func_name() const override { return "min("; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_min>(thd, this); }
 };
 
@@ -1202,7 +1202,7 @@ public:
   bool add() override;
   const char *func_name() const override { return "max("; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_max>(thd, this); }
 };
 
@@ -1289,7 +1289,7 @@ public:
   bool add() override;
   const char *func_name() const override { return "bit_or("; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_or>(thd, this); }
 
 private:
@@ -1306,7 +1306,7 @@ public:
   bool add() override;
   const char *func_name() const override { return "bit_and("; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_and>(thd, this); }
 
 private:
@@ -1321,7 +1321,7 @@ public:
   bool add() override;
   const char *func_name() const override { return "bit_xor("; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_xor>(thd, this); }
 
 private:
@@ -1465,7 +1465,7 @@ public:
   {
     return sp_result_field;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_sp>(thd, this); }
   Item *copy_or_same(THD *thd) override;
 };
@@ -1528,8 +1528,9 @@ public:
   my_decimal *val_decimal(my_decimal *dec) override { return val_decimal_from_real(dec); }
   String *val_str(String *str) override { return val_string_from_real(str); }
   double val_real() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_avg_field_double>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -1557,8 +1558,9 @@ public:
     return VDec(this).to_string_round(str, decimals);
   }
   my_decimal *val_decimal(my_decimal *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_avg_field_decimal>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -1578,8 +1580,9 @@ public:
   { return val_decimal_from_real(dec_buf); }
   bool is_null() override { update_null_value(); return null_value; }
   const Type_handler *type_handler() const override { return &type_handler_double; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_variance_field>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -1591,8 +1594,9 @@ public:
   { }
   enum Type type() const override { return FIELD_STD_ITEM; }
   double val_real() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_std_field>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -1684,7 +1688,7 @@ class Item_sum_udf_float :public Item_udf_sum
   const Type_handler *type_handler() const override { return &type_handler_double; }
   bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_udf_float>(thd, this); }
 };
 
@@ -1711,7 +1715,7 @@ public:
   }
   bool fix_length_and_dec() override { decimals=0; max_length=21; return FALSE; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_udf_int>(thd, this); }
 };
 
@@ -1752,7 +1756,7 @@ public:
   const Type_handler *type_handler() const override { return string_type_handler(); }
   bool fix_length_and_dec() override;
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_udf_str>(thd, this); }
 };
 
@@ -1782,7 +1786,7 @@ public:
   const Type_handler *type_handler() const override { return &type_handler_newdecimal; }
   bool fix_length_and_dec() override { fix_num_length_and_dec(); return FALSE; }
   Item *copy_or_same(THD* thd) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_udf_decimal>(thd, this); }
 };
 
@@ -2037,7 +2041,7 @@ public:
   void print(String *str, enum_query_type query_type) override;
   bool change_context_processor(void *cntx) override
     { context= (Name_resolution_context *)cntx; return FALSE; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_group_concat>(thd, this); }
   qsort_cmp2 get_comparator_function_for_distinct();
   qsort_cmp2 get_comparator_function_for_order_by();

--- a/sql/item_timefunc.h
+++ b/sql/item_timefunc.h
@@ -63,7 +63,7 @@ public:
     max_length=6*MY_CHARSET_BIN_MB_MAXLEN;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_period_add>(thd, this); }
 };
 
@@ -82,7 +82,7 @@ public:
     max_length=6*MY_CHARSET_BIN_MB_MAXLEN;
     return FALSE;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_period_diff>(thd, this); }
 };
 
@@ -108,7 +108,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_to_days>(thd, this); }
 };
 
@@ -137,7 +137,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_to_seconds>(thd, this); }
 };
 
@@ -161,7 +161,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dayofmonth>(thd, this); }
 };
 
@@ -186,7 +186,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_month>(thd, this); }
 };
 
@@ -208,7 +208,7 @@ public:
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_monthname>(thd, this); }
 };
 
@@ -232,7 +232,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dayofyear>(thd, this); }
 };
 
@@ -256,7 +256,7 @@ public:
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_hour>(thd, this); }
 };
 
@@ -280,7 +280,7 @@ public:
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_minute>(thd, this); }
 };
 
@@ -304,7 +304,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_quarter>(thd, this); }
 };
 
@@ -328,7 +328,7 @@ public:
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_second>(thd, this); }
 };
 
@@ -362,7 +362,7 @@ public:
   {
     return arg_count == 2;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_week>(thd, this); }
 };
 
@@ -391,7 +391,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_yearweek>(thd, this); }
 };
 
@@ -417,7 +417,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_year>(thd, this); }
 };
 
@@ -450,7 +450,7 @@ public:
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_weekday>(thd, this); }
 };
 
@@ -472,7 +472,7 @@ class Item_func_dayname :public Item_str_func
   {
     return !has_date_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_dayname>(thd, this); }
 };
 
@@ -537,7 +537,7 @@ public:
   }
   longlong int_op() override;
   my_decimal *decimal_op(my_decimal* buf) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_unix_timestamp>(thd, this); }
 };
 
@@ -561,7 +561,7 @@ public:
   }
   longlong int_op() override;
   my_decimal *decimal_op(my_decimal* buf) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_time_to_sec>(thd, this); }
 };
 
@@ -653,7 +653,7 @@ public:
   Item_func_curtime_local(THD *thd, uint dec): Item_func_curtime(thd, dec) {}
   const char *func_name() const override { return "curtime"; }
   void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_curtime_local>(thd, this); }
 };
 
@@ -664,7 +664,7 @@ public:
   Item_func_curtime_utc(THD *thd, uint dec): Item_func_curtime(thd, dec) {}
   const char *func_name() const override { return "utc_time"; }
   void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_curtime_utc>(thd, this); }
 };
 
@@ -692,7 +692,7 @@ public:
   Item_func_curdate_local(THD *thd): Item_func_curdate(thd) {}
   const char *func_name() const override { return "curdate"; }
   void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_curdate_local>(thd, this); }
 };
 
@@ -703,7 +703,7 @@ public:
   Item_func_curdate_utc(THD *thd): Item_func_curdate(thd) {}
   const char *func_name() const override { return "utc_date"; }
   void store_now_in_TIME(THD* thd, MYSQL_TIME *now_time) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_curdate_utc>(thd, this); }
 };
 
@@ -742,7 +742,7 @@ public:
   int save_in_field(Field *field, bool no_conversions) override;
   void store_now_in_TIME(THD *thd, MYSQL_TIME *now_time) override;
   enum Functype functype() const override { return NOW_FUNC; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_now_local>(thd, this); }
 };
 
@@ -759,7 +759,7 @@ public:
     return mark_unsupported_function(func_name(), "()", arg,
                                      VCOL_TIME_FUNC | VCOL_NON_DETERMINISTIC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_now_utc>(thd, this); }
 };
 
@@ -783,7 +783,7 @@ public:
                                      VCOL_TIME_FUNC | VCOL_NON_DETERMINISTIC);
   }
   enum Functype functype() const override { return SYSDATE_FUNC; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sysdate_local>(thd, this); }
 };
 
@@ -802,7 +802,7 @@ public:
   {
     return has_date_args() || has_time_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_from_days>(thd, this); }
 };
 
@@ -835,7 +835,7 @@ public:
       return false;
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_date_format>(thd, this); }
 };
 
@@ -846,7 +846,7 @@ public:
     Item_func_date_format(thd, a, b) { is_time_format= true; }
   const char *func_name() const override { return "time_format"; }
   bool check_vcol_func_processor(void *arg) override { return false; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_time_format>(thd, this); }
 };
 
@@ -865,7 +865,7 @@ class Item_func_from_unixtime :public Item_datetimefunc
   {
     return mark_unsupported_function(func_name(), "()", arg, VCOL_SESSION_FUNC);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_from_unixtime>(thd, this); }
 };
 
@@ -911,7 +911,7 @@ class Item_func_convert_tz :public Item_datetimefunc
   }
   bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
   void cleanup() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_convert_tz>(thd, this); }
 };
 
@@ -930,7 +930,7 @@ public:
     return FALSE;
   }
   const char *func_name() const override { return "sec_to_time"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_sec_to_time>(thd, this); }
 };
 
@@ -950,7 +950,7 @@ public:
   void print(String *str, enum_query_type query_type) override;
   enum precedence precedence() const override { return INTERVAL_PRECEDENCE; }
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_date_add_interval>(thd, this); }
 };
 
@@ -1058,7 +1058,7 @@ class Item_extract :public Item_int_func,
     }
     return true;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_extract>(thd, this); }
 };
 
@@ -1101,7 +1101,7 @@ public:
   }
   void print(String *str, enum_query_type query_type) override;
   bool need_parentheses_in_default() override { return true; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_char_typecast>(thd, this); }
 };
 
@@ -1138,7 +1138,7 @@ public:
   {
     return args[0]->type_handler()->Item_date_typecast_fix_length_and_dec(this);
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_date_typecast>(thd, this); }
 };
 
@@ -1160,7 +1160,7 @@ public:
            Item_time_typecast_fix_length_and_dec(this);
   }
   Sql_mode_dependency value_depends_on_sql_mode() const override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_time_typecast>(thd, this); }
 };
 
@@ -1182,7 +1182,7 @@ public:
            Item_datetime_typecast_fix_length_and_dec(this);
   }
   Sql_mode_dependency value_depends_on_sql_mode() const override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_datetime_typecast>(thd, this); }
 };
 
@@ -1196,7 +1196,7 @@ public:
     Item_datefunc(thd, a, b) {}
   const char *func_name() const override { return "makedate"; }
   bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_makedate>(thd, this); }
 };
 
@@ -1233,7 +1233,7 @@ public:
     return (null_value= Sec6_add(dt.get_mysql_time(), it.get_mysql_time(), 1).
                            to_datetime(ltime));
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_timestamp>(thd, this); }
 };
 
@@ -1260,7 +1260,7 @@ public:
   { }
   bool fix_length_and_dec() override;
   const char *func_name() const override { return sign > 0 ? "addtime" : "subtime"; }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_add_time>(thd, this); }
 };
 
@@ -1282,7 +1282,7 @@ public:
     return FALSE;
   }
   bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_timediff>(thd, this); }
 };
 
@@ -1305,7 +1305,7 @@ public:
   }
   const char *func_name() const override { return "maketime"; }
   bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_maketime>(thd, this); }
 };
 
@@ -1329,7 +1329,7 @@ public:
   {
     return !has_time_args();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_microsecond>(thd, this); }
 };
 
@@ -1354,7 +1354,7 @@ public:
     return FALSE;
   }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_timestamp_diff>(thd, this); }
 };
 
@@ -1381,7 +1381,7 @@ public:
     return FALSE;
   }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_get_format>(thd, this); }
 };
 
@@ -1401,7 +1401,7 @@ public:
                        timestamp_type);
   const char *func_name() const override { return "str_to_date"; }
   bool fix_length_and_dec() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_str_to_date>(thd, this); }
 };
 
@@ -1414,7 +1414,7 @@ public:
   Item_func_last_day(THD *thd, Item *a): Item_datefunc(thd, a) {}
   const char *func_name() const override { return "last_day"; }
   bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_last_day>(thd, this); }
 };
 

--- a/sql/item_vers.h
+++ b/sql/item_vers.h
@@ -48,7 +48,7 @@ public:
   }
   const char* func_name() const override { return "is_history"; }
   void print(String *str, enum_query_type query_type) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_history>(thd, this); }
 };
 
@@ -66,7 +66,7 @@ public:
     return "trt_commit_ts";
   }
   bool get_date(THD *thd, MYSQL_TIME *res, date_mode_t fuzzydate) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_trt_ts>(thd, this); }
   bool fix_length_and_dec() override
   { fix_attributes_datetime(decimals); return FALSE; }
@@ -108,7 +108,7 @@ public:
   }
 
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_trt_id>(thd, this); }
 };
 
@@ -124,7 +124,7 @@ public:
     return "trt_trx_sees";
   }
   longlong val_int() override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_trt_trx_sees>(thd, this); }
 };
 

--- a/sql/item_windowfunc.h
+++ b/sql/item_windowfunc.h
@@ -148,7 +148,7 @@ public:
     return "row_number";
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_row_number>(thd, this); }
 };
 
@@ -221,7 +221,7 @@ public:
     }
     Item_sum_int::cleanup();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_rank>(thd, this); }
 };
 
@@ -292,7 +292,7 @@ class Item_sum_dense_rank: public Item_sum_int
     }
     Item_sum_int::cleanup();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_dense_rank>(thd, this); }
 };
 
@@ -355,7 +355,7 @@ class Item_sum_first_value : public Item_sum_hybrid_simple
     return "first_value";
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_first_value>(thd, this); }
 };
 
@@ -381,7 +381,7 @@ class Item_sum_last_value : public Item_sum_hybrid_simple
     return "last_value";
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_last_value>(thd, this); }
 };
 
@@ -401,7 +401,7 @@ class Item_sum_nth_value : public Item_sum_hybrid_simple
     return "nth_value";
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_nth_value>(thd, this); }
 };
 
@@ -421,7 +421,7 @@ class Item_sum_lead : public Item_sum_hybrid_simple
     return "lead";
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_lead>(thd, this); }
 };
 
@@ -441,7 +441,7 @@ class Item_sum_lag : public Item_sum_hybrid_simple
     return "lag";
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_lag>(thd, this); }
 };
 
@@ -554,7 +554,7 @@ class Item_sum_percent_rank: public Item_sum_double,
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_percent_rank>(thd, this); }
 
  private:
@@ -640,7 +640,7 @@ class Item_sum_cume_dist: public Item_sum_double,
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_cume_dist>(thd, this); }
 
 };
@@ -715,7 +715,7 @@ class Item_sum_ntile : public Item_sum_int,
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_ntile>(thd, this); }
 
  private:
@@ -878,7 +878,7 @@ public:
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_percentile_disc>(thd, this); }
   void setup_window_func(THD *thd, Window_spec *window_spec) override;
   void setup_hybrid(THD *thd, Item *item);
@@ -1014,7 +1014,7 @@ public:
     Partition_row_count::set_partition_row_count(count);
   }
 
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_sum_percentile_cont>(thd, this); }
   void setup_window_func(THD *thd, Window_spec *window_spec) override;
   void setup_hybrid(THD *thd, Item *item);
@@ -1365,7 +1365,7 @@ public:
   
   void print(String *str, enum_query_type query_type) override;
 
- Item *get_copy(THD *thd) override { return 0; }
+ Item *do_get_copy(THD *thd) const override { return 0; }
 
 };
 

--- a/sql/item_xmlfunc.cc
+++ b/sql/item_xmlfunc.cc
@@ -215,7 +215,7 @@ public:
     Item_nodeset_func(thd, pxml) {}
   const char *func_name() const override { return "xpath_rootelement"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_rootelement>(thd, this); }
 };
 
@@ -228,7 +228,7 @@ public:
     Item_nodeset_func(thd, a, b, pxml) {}
   const char *func_name() const override { return "xpath_union"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_union>(thd, this); }
 };
 
@@ -262,7 +262,7 @@ public:
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
   const char *func_name() const override { return "xpath_selfbyname"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_selfbyname>(thd, this); }
 };
 
@@ -276,7 +276,7 @@ public:
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
   const char *func_name() const override { return "xpath_childbyname"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_childbyname>(thd, this); }
 };
 
@@ -292,7 +292,7 @@ public:
       need_self(need_self_arg) {}
   const char *func_name() const override { return "xpath_descendantbyname"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_descendantbyname>(thd, this); }
 };
 
@@ -308,7 +308,7 @@ public:
       need_self(need_self_arg) {}
   const char *func_name() const override { return "xpath_ancestorbyname"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_ancestorbyname>(thd, this); }
 };
 
@@ -322,7 +322,7 @@ public:
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
   const char *func_name() const override { return "xpath_parentbyname"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_parentbyname>(thd, this); }
 };
 
@@ -336,7 +336,7 @@ public:
     Item_nodeset_func_axisbyname(thd, a, n_arg, l_arg, pxml) {}
   const char *func_name() const override { return "xpath_attributebyname"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_attributebyname>(thd, this); }
 };
 
@@ -353,7 +353,7 @@ public:
     Item_nodeset_func(thd, a, b, pxml) {}
   const char *func_name() const override { return "xpath_predicate"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_predicate>(thd, this); }
 };
 
@@ -366,7 +366,7 @@ public:
     Item_nodeset_func(thd, a, b, pxml) { }
   const char *func_name() const override { return "xpath_elementbyindex"; }
   bool val_native(THD *thd, Native *nodeset) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_func_elementbyindex>(thd, this); }
 };
 
@@ -394,7 +394,7 @@ public:
     }
     return args[0]->val_real() ? 1 : 0;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_xpath_cast_bool>(thd, this); }
 };
 
@@ -408,7 +408,7 @@ public:
   Item_xpath_cast_number(THD *thd, Item *a): Item_real_func(thd, a) {}
   const char *func_name() const override { return "xpath_cast_number"; }
   double val_real() override { return args[0]->val_real(); }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_xpath_cast_number>(thd, this); }
 };
 
@@ -427,7 +427,7 @@ public:
     return nodeset->copy(*native_cache);
   }
   bool fix_length_and_dec() override { max_length= MAX_BLOB_WIDTH;; return FALSE;  }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_context_cache>(thd, this); }
 };
 
@@ -448,7 +448,7 @@ public:
       return tmp_native_value.element(0).pos + 1;
     return 0;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_xpath_position>(thd, this); }
 };
 
@@ -471,7 +471,7 @@ public:
       return predicate_supplied_context_size;
     return tmp_native_value.elements();
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_xpath_count>(thd, this); }
 };
 
@@ -516,7 +516,7 @@ public:
     }
     return sum;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_xpath_sum>(thd, this); }
 };
 
@@ -598,7 +598,7 @@ public:
     }
     return 0;
   }
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_nodeset_to_const_comparator>(thd, this); }
 };
 

--- a/sql/item_xmlfunc.h
+++ b/sql/item_xmlfunc.h
@@ -133,7 +133,7 @@ public:
     Item_xml_str_func(thd, a, b) {}
   const char *func_name() const override { return "extractvalue"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_xml_extractvalue>(thd, this); }
 };
 
@@ -150,7 +150,7 @@ public:
     Item_xml_str_func(thd, a, b, c) {}
   const char *func_name() const override { return "updatexml"; }
   String *val_str(String *) override;
-  Item *get_copy(THD *thd) override
+  Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_xml_update>(thd, this); }
 };
 

--- a/sql/procedure.h
+++ b/sql/procedure.h
@@ -70,7 +70,7 @@ public:
   {
     return type_handler()->Item_get_date_with_warn(thd, this, ltime, fuzzydate);
   }
-  Item* get_copy(THD *thd) override { return 0; }
+  Item* do_get_copy(THD *thd) const override { return 0; }
 };
 
 class Item_proc_real :public Item_proc
@@ -123,6 +123,8 @@ public:
   String *val_str(String *s) override { s->set(value, default_charset()); return s; }
   my_decimal *val_decimal(my_decimal *) override;
   unsigned int size_of() { return sizeof(*this);}
+  Item *do_get_copy(THD *thd) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 };
 
 
@@ -156,6 +158,8 @@ public:
   }
   my_decimal *val_decimal(my_decimal *) override;
   unsigned int size_of() { return sizeof(*this);}  
+  Item *do_get_copy(THD *thd) const override { return nullptr; }
+  Item *do_build_clone(THD *thd) const override { return nullptr; }
 };
 
 /* The procedure class definitions */

--- a/sql/sql_list.h
+++ b/sql/sql_list.h
@@ -537,10 +537,9 @@ public:
   class Iterator;
   using value_type= T;
   using iterator= Iterator;
-  using const_iterator= const Iterator;
 
-  Iterator begin() const { return Iterator(first); }
-  Iterator end() const { return Iterator(); }
+  iterator begin() const { return iterator(first); }
+  iterator end() const { return iterator(); }
 
   class Iterator
   {
@@ -561,7 +560,7 @@ public:
       return *this;
     }
 
-    T operator++(int)
+    Iterator operator++(int)
     {
       Iterator tmp(*this);
       operator++();

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -16632,7 +16632,7 @@ change_cond_ref_to_const(THD *thd, I_List<COND_CMP> *save_list,
   if (can_change_cond_ref_to_const(func, right_item, left_item,
                                    field_value_owner, field, value))
   {
-    Item *tmp=value->clone_item(thd);
+    Item *tmp=value->clone_const_item(thd);
     if (tmp)
     {
       tmp->collation.set(right_item->collation);
@@ -16662,7 +16662,7 @@ change_cond_ref_to_const(THD *thd, I_List<COND_CMP> *save_list,
   else if (can_change_cond_ref_to_const(func, left_item, right_item,
                                         field_value_owner, field, value))
   {
-    Item *tmp= value->clone_item(thd);
+    Item *tmp= value->clone_const_item(thd);
     if (tmp)
     {
       tmp->collation.set(left_item->collation);

--- a/sql/sql_string.h
+++ b/sql/sql_string.h
@@ -577,7 +577,7 @@ public:
     LEX_CSTRING tmp= {Ptr, str_length};
     return tmp;
   }
-  inline LEX_CSTRING *get_value(LEX_CSTRING *res)
+  inline LEX_CSTRING *get_value(LEX_CSTRING *res) const
   {
     res->str=    Ptr;
     res->length= str_length;


### PR DESCRIPTION
…ancestor class instead of a copy/clone

The `Item` class methods `get_copy()`, `build_clone()`, and `clone_item()` face an issue where they may be defined in a descendant class (e.g., `Item_func`) but not in a further descendant (e.g., `Item_func_child`). This can lead to scenarios where `build_clone()`, when operating on an instance of `Item_func_child` with a pointer to the base class (`Item`), returns an instance of `Item_func` instead of `Item_func_child`.

Since this limitation cannot be resolved at compile time, this commit introduces runtime type checks for the copy/clone operations. A debug assertion will now trigger in case of a type mismatch.

`get_copy()`, `build_clone()`, and `clone_item()` are no more virtual, but virtual `do_get_copy()`, `do_build_clone()`, and `do_clone_item()` are added to the protected section of the class `Item`.

Additionally, const qualifiers have been added to certain methods to enhance code reliability.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-_34490_*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
