### PR TITLE
MDEV-34519 innodb_log_checkpoint_now crashes when innodb_read_only is enabled

### DIFF
--- a/mysql-test/suite/innodb/r/log_file_overwrite.result
+++ b/mysql-test/suite/innodb/r/log_file_overwrite.result
@@ -5,4 +5,17 @@ CREATE TABLE t1(f1 INT NOT NULL, f2 TEXT)ENGINE=InnoDB;
 INSERT INTO t1 SELECT seq, repeat('a', 4000) FROM seq_1_to_1800;
 # restart: --debug_dbug=+d,before_final_redo_apply --innodb_log_file_size=8M
 # restart: --innodb_log_file_size=10M
+#
+# MDEV-34519 innodb_log_checkpoint_now crashes when
+#              innodb_read_only is enabled
+#
+# restart: --innodb-force-recovery=6
+SET GLOBAL innodb_log_checkpoint_now=1;
+Warnings:
+Warning	138	InnoDB doesn't force checkpoint when innodb-force-recovery=6.
+# restart: --innodb-read-only=1
+SET GLOBAL innodb_log_checkpoint_now=1;
+Warnings:
+Warning	138	InnoDB doesn't force checkpoint when innodb-read-only=1.
+# restart
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/log_file_overwrite.test
+++ b/mysql-test/suite/innodb/t/log_file_overwrite.test
@@ -14,4 +14,18 @@ let $shutdown_timeout=0;
 let $restart_parameters=--innodb_log_file_size=10M;
 let $shutdown_timeout=;
 --source include/restart_mysqld.inc
+
+--echo #
+--echo # MDEV-34519 innodb_log_checkpoint_now crashes when
+--echo #              innodb_read_only is enabled
+--echo #
+--let $restart_parameters=--innodb-force-recovery=6
+--source include/restart_mysqld.inc
+SET GLOBAL innodb_log_checkpoint_now=1;
+--let $restart_parameters=--innodb-read-only=1
+--source include/restart_mysqld.inc
+SET GLOBAL innodb_log_checkpoint_now=1;
+let $restart_parameters=;
+--source include/restart_mysqld.inc
+
 DROP TABLE t1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18378,28 +18378,42 @@ wait_background_drop_list_empty(THD*, st_mysql_sys_var*, void*, const void*)
 Force innodb to checkpoint. */
 static
 void
-checkpoint_now_set(THD*, st_mysql_sys_var*, void*, const void* save)
+checkpoint_now_set(THD* thd, st_mysql_sys_var*, void*, const void* save)
 {
-	if (*(my_bool*) save) {
-		mysql_mutex_unlock(&LOCK_global_system_variables);
-
-		lsn_t lsn;
-
-		while (log_sys.last_checkpoint_lsn.load(
-			       std::memory_order_acquire)
-		       + SIZE_OF_FILE_CHECKPOINT
-		       + log_sys.framing_size()
-		       < (lsn= log_sys.get_lsn(std::memory_order_acquire))) {
-			log_make_checkpoint();
-			log_sys.log.flush();
-		}
-
-		if (dberr_t err = fil_write_flushed_lsn(lsn)) {
-			ib::warn() << "Checkpoint set failed " << err;
-		}
-
-		mysql_mutex_lock(&LOCK_global_system_variables);
+	if (!*(my_bool*) save) {
+		return;
 	}
+
+	if (srv_read_only_mode) {
+		push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+				    HA_ERR_UNSUPPORTED,
+				    "InnoDB doesn't force checkpoint "
+				    "when %s",
+				    (srv_force_recovery
+				     == SRV_FORCE_NO_LOG_REDO)
+				    ? "innodb-force-recovery=6."
+				    : "innodb-read-only=1.");
+		return;
+	}
+
+	mysql_mutex_unlock(&LOCK_global_system_variables);
+
+	lsn_t lsn;
+
+	while (log_sys.last_checkpoint_lsn.load(
+		       std::memory_order_acquire)
+	       + SIZE_OF_FILE_CHECKPOINT
+	       + log_sys.framing_size()
+	       < (lsn= log_sys.get_lsn(std::memory_order_acquire))) {
+		log_make_checkpoint();
+		log_sys.log.flush();
+	}
+
+	if (dberr_t err = fil_write_flushed_lsn(lsn)) {
+		ib::warn() << "Checkpoint set failed " << err;
+	}
+
+	mysql_mutex_lock(&LOCK_global_system_variables);
 }
 
 /****************************************************************//**


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34519*

## Description
During read only mode, InnoDB doesn't allow checkpoint to happen. So InnoDB should throw the warning when InnoDB tries to force the checkpoint when innodb_read_only = 1 or
innodb_force_recovery = 6.
## How can this PR be tested?
./mtr innodb.log_file_overwrite 

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
