### PR TITLE
MDEV-34552  innodb.temp_tablespace_freed fails with ER_WRONG_ARGUMENTS

### DIFF
--- a/mysql-test/suite/innodb/r/temp_truncate_freed.result
+++ b/mysql-test/suite/innodb/r/temp_truncate_freed.result
@@ -7,5 +7,5 @@ INSERT INTO t1 VALUES (repeat(1,16777215));
 DROP TEMPORARY TABLE t1;
 SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
 SET GLOBAL innodb_buffer_pool_size=10485760;
-set global innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
 set global innodb_immediate_scrub_data_uncompressed = @old_immediate_scrub_data_val;
+set global innodb_buffer_pool_size = @old_innodb_buffer_pool_size;

--- a/mysql-test/suite/innodb/t/temp_truncate_freed.test
+++ b/mysql-test/suite/innodb/t/temp_truncate_freed.test
@@ -3,8 +3,14 @@
 set @old_innodb_buffer_pool_size = @@innodb_buffer_pool_size;
 set @old_immediate_scrub_data_val= @@innodb_immediate_scrub_data_uncompressed;
 
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
+  FROM information_schema.global_status
+  WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
+
 SET GLOBAL innodb_immediate_scrub_data_uncompressed=1;
 SET GLOBAL innodb_buffer_pool_size= 16777216;
+--source include/wait_condition.inc
 
 CREATE TEMPORARY TABLE t1(c1 MEDIUMTEXT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (repeat(1,16777215));
@@ -13,13 +19,18 @@ SET GLOBAL innodb_truncate_temporary_tablespace_now=1;
 
 let $wait_timeout = 180;
 let $wait_condition =
-  SELECT SUBSTR(variable_value, 1, 30) = 'Completed resizing buffer pool'
+  SELECT SUBSTR(variable_value, 1, 45) = 'Completed resizing buffer pool from 16777216'
   FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
 
 SET GLOBAL innodb_buffer_pool_size=10485760;
 --source include/wait_condition.inc
 
-set global innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
 set global innodb_immediate_scrub_data_uncompressed = @old_immediate_scrub_data_val;
+
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 45) = 'Completed resizing buffer pool from 10485760'
+  FROM information_schema.global_status
+  WHERE LOWER(variable_name) = 'innodb_buffer_pool_resize_status';
+set global innodb_buffer_pool_size = @old_innodb_buffer_pool_size;
 --source include/wait_condition.inc

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2061,10 +2061,12 @@ calc_buf_pool_size:
 	}
 
 	if (srv_buf_pool_old_size != srv_buf_pool_size) {
-
-	        buf_resize_status("Completed resizing buffer pool from %zu to %zu bytes."
-			    ,srv_buf_pool_old_size, srv_buf_pool_size);
+		std::ostringstream sout;
+		sout << "Completed resizing buffer pool from "
+		     << srv_buf_pool_old_size << " to "
+		     << srv_buf_pool_size <<" bytes.";
 		srv_buf_pool_old_size = srv_buf_pool_size;
+		buf_resize_status(sout.str().c_str());
 	}
 
 #ifdef BTR_CUR_HASH_ADAPT


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34552*

## Description
Problem:
========
- innodb.temp_truncate_freed fails with ER_WRONG_ARGUMENTS and states that another buffer pool resize is already in progress. Test case has wait condition to ensure that buffer pool resize is completed. There is a possibility that wait condition check could get false impression that InnoDB buffer pool resize completed due to previous buffer pool resize.

Fix:
===
Add more elaborate wait_condition to ensure the current buffer pool resize completed.

buf_pool_t::resize(): Set the buffer pool resize status only after setting previous buffer pool size to current buffer pool size. This should help the test case to make reliable.

## How can this PR be tested?
./mtr innodb.temp_tablespace_freed

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
