### PR TITLE
mtr: remove not_valgrind_build

### DIFF
--- a/mysql-test/include/not_valgrind_build.inc
+++ b/mysql-test/include/not_valgrind_build.inc
@@ -1,4 +1,0 @@
-if (`select version() like '%valgrind%' || version() like '%asan%'`)
-{
-  skip Does not run with binaries built with valgrind or asan;
-}

--- a/mysql-test/main/sp-no-valgrind.test
+++ b/mysql-test/main/sp-no-valgrind.test
@@ -1,5 +1,5 @@
 --source include/not_msan.inc
---source include/not_valgrind_build.inc
+--source include/not_valgrind.inc
 
 --echo # MDEV-20699 do not cache SP in SHOW CREATE
 --echo # Warmup round, this might allocate some memory for session variable


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The version test on not_valgrind_build.inc was
broken as in BB the sp-no-valgrind.test was
executed.

The implication that it wouldn't work on ASAN
was also incorrect as ASAN tests show it running
fine there.

Correct sp-no-valgrind.test for not_valgrind.inc.

failing on valgrind: https://buildbot.mariadb.org/#/builders/551/builds/15311
succeeding on asan: https://buildbot.mariadb.org/#/builders/588/builds/6950/steps/8/logs/stdio

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

mtr tests it.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.