### PR TITLE
MDEV-34568 rpl.rpl_mdev12179 - correct for Windows

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_mdev12179.test
+++ b/mysql-test/suite/rpl/t/rpl_mdev12179.test
@@ -55,9 +55,7 @@ SET sql_log_bin=1;
 # Restart the slave mysqld server, and verify that the GTID position is
 # read correctly from the new mysql.gtid_slave_pos_innodb table.
 
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
-wait
-EOF
+--write_line wait $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --shutdown_server
 --source include/wait_until_disconnected.inc
 
@@ -94,9 +92,7 @@ DROP TABLE mysql.gtid_slave_pos;
 RENAME TABLE mysql.gtid_slave_pos_innodb TO mysql.gtid_slave_pos;
 SET sql_log_bin=1;
 
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
-wait
-EOF
+--write_line wait $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --shutdown_server
 --source include/wait_until_disconnected.inc
 
@@ -132,9 +128,7 @@ SET sql_log_bin=0;
 ALTER TABLE mysql.gtid_slave_pos ENGINE=Aria;
 SET sql_log_bin=1;
 
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
-wait
-EOF
+--write_line wait $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --shutdown_server
 --source include/wait_until_disconnected.inc
 
@@ -176,9 +170,7 @@ INSERT INTO mysql.gtid_slave_pos SELECT * FROM mysql.gtid_slave_pos_InnoDB;
 DROP TABLE mysql.gtid_slave_pos_InnoDB;
 SET sql_log_bin=1;
 
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
-wait
-EOF
+--write_line "wait" $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --shutdown_server
 --source include/wait_until_disconnected.inc
 
@@ -272,9 +264,7 @@ while (!$done)
 # MDEV-15373 engine gtid_slave_pos table name disobeys lower-case-table-names
 # This snippet verifies that engine gtid_slave_pos table is found,
 # its data are up-to-date.
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
-wait
-EOF
+--write_line wait $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --connection server_2
 --shutdown_server
 --source include/wait_until_disconnected.inc


### PR DESCRIPTION
Simplify in an attempt to avoid:

mysqltest: At line 275: File already exist: on the write_file lines.

Using write_line as that's what a lot of other tests do for writing small bits to a expect file.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34568*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

It was failing on write_file with file already existing on the windows-packaging builder only.

This replaces write_file with just a write line in an attempt to acheive the same thing.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
