### PR TITLE
MDEV-33967 hander socket writes do not result in binary log entries

### DIFF
--- a/plugin/handler_socket/handlersocket/database.cpp
+++ b/plugin/handler_socket/handlersocket/database.cpp
@@ -549,9 +549,16 @@ dbcontext::modify_record(dbcallback_i& cb, TABLE *const table,
   const prep_stmt& pst, const cmd_exec_args& args, char mod_op,
   size_t& modified_count)
 {
+  if (!thd->is_current_stmt_binlog_format_row())
+    push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
+                        ER_WRONG_VALUE_FOR_VAR,
+                        ER_THD(thd, ER_WRONG_VALUE_FOR_VAR),
+                        "binlog_format", "statement");
   if (mod_op == 'U') {
     /* update */
     handler *const hnd = table->file;
+    table->mark_columns_needed_for_update();
+    hnd->prepare_for_row_logging();
     uchar *const buf = table->record[0];
     store_record(table, record[1]);
     const prep_stmt::fields_type& rf = pst.get_ret_fields();
@@ -576,6 +583,8 @@ dbcontext::modify_record(dbcallback_i& cb, TABLE *const table,
   } else if (mod_op == 'D') {
     /* delete */
     handler *const hnd = table->file;
+    table->mark_columns_needed_for_delete();
+    hnd->prepare_for_row_logging();
     table_vec[pst.get_table_id()].modified = true;
     const int r = hnd->ha_delete_row(table->record[0]);
     if (r != 0) {
@@ -585,6 +594,8 @@ dbcontext::modify_record(dbcallback_i& cb, TABLE *const table,
   } else if (mod_op == '+' || mod_op == '-') {
     /* increment/decrement */
     handler *const hnd = table->file;
+    table->mark_columns_needed_for_update();
+    hnd->prepare_for_row_logging();
     uchar *const buf = table->record[0];
     store_record(table, record[1]);
     const prep_stmt::fields_type& rf = pst.get_ret_fields();
@@ -658,6 +669,8 @@ dbcontext::cmd_insert_internal(dbcallback_i& cb, const prep_stmt& pst,
   }
   table->next_number_field = table->found_next_number_field;
     /* FIXME: test */
+  table->mark_columns_needed_for_insert();
+  hnd->prepare_for_row_logging();
   const int r = hnd->ha_write_row(buf);
   const ulonglong insert_id = table->file->insert_id_for_cur_row;
   table->next_number_field = 0;

--- a/plugin/handler_socket/handlersocket/database.cpp
+++ b/plugin/handler_socket/handlersocket/database.cpp
@@ -1128,7 +1128,6 @@ dbcontext::cmd_exec(dbcallback_i& cb, const cmd_exec_args& args)
   }
   ha_rkey_function find_flag = HA_READ_KEY_EXACT;
   db_write_op wrop = db_write_op_none;
-  init_thd_for_query();
   if (args.op.size() == 1) {
     switch (args.op.begin()[0]) {
     case '=':
@@ -1170,8 +1169,10 @@ dbcontext::cmd_exec(dbcallback_i& cb, const cmd_exec_args& args)
   case db_write_op_none:
     return cmd_find_internal(cb, p, find_flag, args);
   case db_write_op_insert:
+    init_thd_for_query();
     return cmd_insert_internal(cb, p, args.kvals, args.kvalslen);
   case db_write_op_sql:
+    init_thd_for_query();
     return cmd_sql_internal(cb, p, args.kvals, args.kvalslen);
   }
 }

--- a/plugin/handler_socket/handlersocket/database.cpp
+++ b/plugin/handler_socket/handlersocket/database.cpp
@@ -138,6 +138,7 @@ struct dbcontext : public dbcontext_i, private noncopyable {
   bool get_commit_error() override;
   void clear_error() override;
   void close_tables_if() override;
+  void init_thd_for_query() override;
   void table_addref(size_t tbl_id) override;
   void table_release(size_t tbl_id) override;
   void cmd_open(dbcallback_i& cb, const cmd_open_args& args) override;
@@ -473,6 +474,13 @@ dbcontext::close_tables_if()
     table_vec.clear();
     table_map.clear();
   }
+}
+
+void
+dbcontext::init_thd_for_query()
+{
+  thd->set_time();
+  thd->set_query_id(next_query_id());
 }
 
 void
@@ -1120,6 +1128,7 @@ dbcontext::cmd_exec(dbcallback_i& cb, const cmd_exec_args& args)
   }
   ha_rkey_function find_flag = HA_READ_KEY_EXACT;
   db_write_op wrop = db_write_op_none;
+  init_thd_for_query();
   if (args.op.size() == 1) {
     switch (args.op.begin()[0]) {
     case '=':

--- a/plugin/handler_socket/handlersocket/database.hpp
+++ b/plugin/handler_socket/handlersocket/database.hpp
@@ -115,6 +115,7 @@ struct dbcontext_i {
   virtual void init_thread(const void *stack_bottom,
     volatile int& shutdown_flag) = 0;
   virtual void term_thread() = 0;
+  virtual void init_thd_for_query() = 0;
   virtual bool check_alive() = 0;
   virtual void lock_tables_if() = 0;
   virtual void unlock_tables_if() = 0;

--- a/plugin/handler_socket/handlersocket/hstcpsvr.cpp
+++ b/plugin/handler_socket/handlersocket/hstcpsvr.cpp
@@ -133,6 +133,7 @@ hstcpsvr::stop_workers()
   vshared.shutdown = 1;
   for (size_t i = 0; i < threads.size(); ++i) {
     threads[i]->join();
+    delete threads[i];
   }
   threads.clear();
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33967*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

As handlersocket bypasses the sql layer that prepares and causes binary log entries to be created, we need to do this in the plugin directly to create binary log entries.

Reported thanks to Yutaro Iwasaki on Zulip.

## Release Notes

Correct handler socket to allow changed rows to be replicated.

## How can this PR be tested?

Manual testing.

I attempted to restructure the tests, but cmake on top of two levels of build system for the perl module wasn't something I managed to unravel.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.