### PR TITLE
MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-condition

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_datetime.result
+++ b/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_datetime.result
@@ -1,0 +1,23 @@
+
+# MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-datetime
+
+set timestamp=1000000000;
+CREATE TABLE t1(word VARCHAR(20));
+set timestamp=1000000010;
+INSERT INTO t1 VALUES ("abirvalg");
+set timestamp=1000000020;
+INSERT INTO t1 SELECT * FROM t1;
+flush logs;
+Case: Default, must not see warning.
+# MYSQL_BINLOG --short-form MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+Case: Stop datetime before EOF, must not see warning.
+# MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:50' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+Case: Stop datetime between records, must not see warning.
+# MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+Case: Stop datetime at EOF, must not see warning.
+# MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+Case: Stop datetime after EOF, must see warning.
+# MYSQL_BINLOG --short-form --stop-datetime='2035-01-19 03:14:05' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+WARNING: Did not reach stop datetime '2035-01-19 03:14:05' before end of input
+DROP TABLE t1;
+# End of binlog_mysqlbinlog_warn_stop_datetime.test

--- a/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_position.result
+++ b/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_position.result
@@ -1,0 +1,13 @@
+
+# MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-condition
+
+Case: Default stop position, WARNING must not appear
+# MYSQL_BINLOG --short-form --start-position=4 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+Case: Stop position before EOF, WARNING must not appear
+# MYSQL_BINLOG --short-form --start-position=4 --stop-position=97 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+Case: Stop position at EOF, WARNING must not appear
+# MYSQL_BINLOG --short-form --start-position=4 --stop-position=98 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+Case: Stop position after EOF, WARNING must appear
+# MYSQL_BINLOG --short-form --start-position=4 --stop-position=99 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+WARNING: Did not reach stop position 99 before end of input
+# End of binlog_mysqlbinlog_warn_stop_position.test

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_datetime.test
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_datetime.test
@@ -1,0 +1,42 @@
+--echo
+--echo # MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-datetime
+--echo
+
+--source include/have_binlog_format_statement.inc
+
+--let ignored_output_file= $MYSQLTEST_VARDIR/tmp/warn_pos_test_file.out
+
+set timestamp=1000000000;
+CREATE TABLE t1(word VARCHAR(20));
+set timestamp=1000000010;
+INSERT INTO t1 VALUES ("abirvalg");
+set timestamp=1000000020;
+INSERT INTO t1 SELECT * FROM t1;
+--let MYSQLD_DATADIR= `select @@datadir;`
+flush logs;
+
+--echo Case: Default, must not see warning.
+--echo # MYSQL_BINLOG --short-form MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+--exec $MYSQL_BINLOG --short-form $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+
+--echo Case: Stop datetime before EOF, must not see warning.
+--echo # MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:50' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+--exec $MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:50' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+
+--echo Case: Stop datetime between records, must not see warning.
+--echo # MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+--exec $MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+
+--echo Case: Stop datetime at EOF, must not see warning.
+--echo # MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+--exec $MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+
+--echo Case: Stop datetime after EOF, must see warning.
+--echo # MYSQL_BINLOG --short-form --stop-datetime='2035-01-19 03:14:05' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
+--exec $MYSQL_BINLOG --short-form --stop-datetime='2035-01-19 03:14:05' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+
+DROP TABLE t1;
+
+--remove_file $ignored_output_file
+
+--echo # End of binlog_mysqlbinlog_warn_stop_datetime.test

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.test
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.test
@@ -1,0 +1,26 @@
+--echo
+--echo # MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-condition
+--echo
+
+--let assert_file= $MYSQLTEST_VARDIR/tmp/warn_pos_test_file.out
+--let data_file= $MYSQLTEST_VARDIR/std_data/master-bin.000001
+
+--echo Case: Default stop position, WARNING must not appear
+--echo # MYSQL_BINLOG --short-form --start-position=4 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+--exec $MYSQL_BINLOG --short-form --start-position=4 $data_file --result-file=$assert_file 2>&1
+
+--echo Case: Stop position before EOF, WARNING must not appear
+--echo # MYSQL_BINLOG --short-form --start-position=4 --stop-position=97 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+--exec $MYSQL_BINLOG --short-form --start-position=4 --stop-position=97 $data_file --result-file=$assert_file 2>&1
+
+--echo Case: Stop position at EOF, WARNING must not appear
+--echo # MYSQL_BINLOG --short-form --start-position=4 --stop-position=98 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+--exec $MYSQL_BINLOG --short-form --start-position=4 --stop-position=98 $data_file --result-file=$assert_file 2>&1
+
+--echo Case: Stop position after EOF, WARNING must appear
+--echo # MYSQL_BINLOG --short-form --start-position=4 --stop-position=99 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
+--exec $MYSQL_BINLOG --short-form --start-position=4 --stop-position=99 $data_file --result-file=$assert_file 2>&1
+
+--remove_file $assert_file
+
+--echo # End of binlog_mysqlbinlog_warn_stop_position.test


### PR DESCRIPTION
Emit warnings if finished processing input files before reaching the boundary conditions indicated by either `--stop-position` or `--stop-datetime`.
