### PR TITLE
 MDEV-34159: Implement the GIS function ST_LatFromGeoHash

### DIFF
--- a/mysql-test/main/spatial_utility_function_geohash.result
+++ b/mysql-test/main/spatial_utility_function_geohash.result
@@ -1,3 +1,254 @@
+CREATE TABLE geohashes  (gid INT NOT NULL PRIMARY KEY, hash_value VARCHAR(255));
+INSERT INTO geohashes VALUES
+(1, "000000000000000000000"),
+(2, "zzzzzzzzzzzzzzzzzzzzz"),
+(3, NULL),
+(4, "s00t"),
+(5, "7zzzm"),
+(6, "s00d"),
+(7, "0"),
+(8, "z"),
+(9, "3ejh6z75ddt2d839zh2u"),
+(10, "twtsuqg3q7vh3nrbt0nn"),
+(11, "yw8s10dxddhe4s06nsph"),
+(12, "h4g4h9yrjtgzvewxm0ru"),
+(13, "9kqbredcnhq1b44ue48s"),
+(14, "1pckwjkqw3km0v6ye5d2"),
+(15, "wm313fnr92ggsysm64e6"),
+(16, "vqghx20fx6d8r5vfkbgf"),
+(17, "wvetm3u23kr9r6663k31"),
+(18, "e5t2p7sk291vpyb08pwu");
+# valid characters
+SELECT ST_LATFROMGEOHASH("0");
+ST_LATFROMGEOHASH("0")
+-68
+SELECT ST_LATFROMGEOHASH("z");
+ST_LATFROMGEOHASH("z")
+68
+SELECT ST_LATFROMGEOHASH("0z");
+ST_LATFROMGEOHASH("0z")
+-48
+SELECT ST_LATFROMGEOHASH("xbpb");
+ST_LATFROMGEOHASH("xbpb")
+0
+SELECT ST_LATFROMGEOHASH("8000");
+ST_LATFROMGEOHASH("8000")
+0
+SELECT ST_LATFROMGEOHASH("s000");
+ST_LATFROMGEOHASH("s000")
+0
+SELECT ST_LATFROMGEOHASH("0123456789");
+ST_LATFROMGEOHASH("0123456789")
+-82.774507
+SELECT ST_LATFROMGEOHASH("9876543210");
+ST_LATFROMGEOHASH("9876543210")
+1.770175
+SELECT ST_LATFROMGEOHASH("bcdefghjkmnpqrstuvwxyz");
+ST_LATFROMGEOHASH("bcdefghjkmnpqrstuvwxyz")
+54.11408847964353
+SELECT ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb");
+ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb")
+82.77450549262497
+SELECT ST_LATFROMGEOHASH("zzzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("zzzzzzzzzzzzzzzzzzzz")
+90
+SELECT ST_LATFROMGEOHASH("bpbpbpbpbpbpbpbpbpbp");
+ST_LATFROMGEOHASH("bpbpbpbpbpbpbpbpbpbp")
+90
+SELECT ST_LATFROMGEOHASH("pbpbpbpbpbpbpbpbpbpb");
+ST_LATFROMGEOHASH("pbpbpbpbpbpbpbpbpbpb")
+-90
+SELECT ST_LATFROMGEOHASH("00000000000000000000");
+ST_LATFROMGEOHASH("00000000000000000000")
+-90
+SELECT ST_LATFROMGEOHASH("gzzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("gzzzzzzzzzzzzzzzzzzz")
+90
+SELECT ST_LATFROMGEOHASH("5bpbpbpbpbpbpbpbpbpb");
+ST_LATFROMGEOHASH("5bpbpbpbpbpbpbpbpbpb")
+-90
+SELECT ST_LATFROMGEOHASH("7zzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("7zzzzzzzzzzzzzzzzzzz")
+0
+SELECT ST_LATFROMGEOHASH("rzzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("rzzzzzzzzzzzzzzzzzzz")
+0
+SELECT ST_LATFROMGEOHASH("2pbpbpbpbpbpbpbpbpbp");
+ST_LATFROMGEOHASH("2pbpbpbpbpbpbpbpbpbp")
+0
+SELECT ST_LATFROMGEOHASH("0000000000zzzzzzzzzz");
+ST_LATFROMGEOHASH("0000000000zzzzzzzzzz")
+-89.999994635582
+SELECT ST_LATFROMGEOHASH("zzzzzzzzzz0000000000");
+ST_LATFROMGEOHASH("zzzzzzzzzz0000000000")
+89.999994635582
+SELECT ST_LATFROMGEOHASH("s000000001z7wsg7zzm6");
+ST_LATFROMGEOHASH("s000000001z7wsg7zzm6")
+0.00001
+SELECT ST_LATFROMGEOHASH("ebpbpbpbpcbe9kuebp6d");
+ST_LATFROMGEOHASH("ebpbpbpbpcbe9kuebp6d")
+0.00001
+SELECT ST_LATFROMGEOHASH("kpbpbpbpbnpkqe5kpbtm");
+ST_LATFROMGEOHASH("kpbpbpbpbnpkqe5kpbtm")
+-0.00001
+SELECT ST_LATFROMGEOHASH("7zzzzzzzzy0s37hs00dt");
+ST_LATFROMGEOHASH("7zzzzzzzzy0s37hs00dt")
+-0.00001
+SELECT ST_LATFROMGEOHASH("tzzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("tzzzzzzzzzzzzzzzzzzz")
+45
+SELECT ST_LATFROMGEOHASH("9zzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("9zzzzzzzzzzzzzzzzzzz")
+45
+SELECT ST_LATFROMGEOHASH("jzzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("jzzzzzzzzzzzzzzzzzzz")
+-45
+SELECT ST_LATFROMGEOHASH("1zzzzzzzzzzzzzzzzzzz");
+ST_LATFROMGEOHASH("1zzzzzzzzzzzzzzzzzzz")
+-45
+SELECT ST_LATFROMGEOHASH("zbzurypzpgxczbzurypz");
+ST_LATFROMGEOHASH("zbzurypzpgxczbzurypz")
+50
+SELECT ST_LATFROMGEOHASH("5zpgxczbzurypzpgxczb");
+ST_LATFROMGEOHASH("5zpgxczbzurypzpgxczb")
+-50
+SELECT ST_LATFROMGEOHASH("0z0z0z0z0z0z0z0z0z0z0z0z0z0z0z0z");
+ST_LATFROMGEOHASH("0z0z0z0z0z0z0z0z0z0z0z0z0z0z0z0z")
+-49.35483870967742
+SELECT ST_LATFROMGEOHASH("0123456789bcdefghjkmnpqrstuvwxyz");
+ST_LATFROMGEOHASH("0123456789bcdefghjkmnpqrstuvwxyz")
+-82.77450549262497
+SELECT ST_LATFROMGEOHASH("0123456789BCDEFGHJKMNPQRSTUVWXYZ");
+ST_LATFROMGEOHASH("0123456789BCDEFGHJKMNPQRSTUVWXYZ")
+-82.77450549262497
+SELECT ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb9876543210");
+ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb9876543210")
+82.77450549262497
+SELECT ST_LATFROMGEOHASH("ZYXWVUTSRQPNMKJHGFEDCB9876543210");
+ST_LATFROMGEOHASH("ZYXWVUTSRQPNMKJHGFEDCB9876543210")
+82.77450549262497
+SELECT ST_LATFROMGEOHASH("1e1");
+ST_LATFROMGEOHASH("1e1")
+-72
+SELECT ST_LATFROMGEOHASH("100");
+ST_LATFROMGEOHASH("100")
+-89
+SELECT ST_LATFROMGEOHASH(CAST(100 AS CHAR));
+ST_LATFROMGEOHASH(CAST(100 AS CHAR))
+-89
+SELECT ST_LATFROMGEOHASH("10111000110001111001");
+ST_LATFROMGEOHASH("10111000110001111001")
+-89.8242133801793
+SELECT ST_LATFROMGEOHASH("11111111111111111111");
+ST_LATFROMGEOHASH("11111111111111111111")
+-84.1935483870967
+SELECT ST_LATFROMGEOHASH("99999999999999999999");
+ST_LATFROMGEOHASH("99999999999999999999")
+8.7096774193548
+SELECT ST_LATFROMGEOHASH(NULL);
+ST_LATFROMGEOHASH(NULL)
+NULL
+SELECT ST_LATFROMGEOHASH(null);
+ST_LATFROMGEOHASH(null)
+NULL
+SELECT ST_LATFROMGEOHASH(CAST("012" AS BINARY));
+ST_LATFROMGEOHASH(CAST("012" AS BINARY))
+-82
+# invalid characters and inputs
+SELECT ST_LATFROMGEOHASH("0123a45");
+ERROR HY000: Incorrect geohash value: '0123a45' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("xyzi");
+ERROR HY000: Incorrect geohash value: 'xyzi' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("zyxLwv");
+ERROR HY000: Incorrect geohash value: 'zyxLwv' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("bcdjo");
+ERROR HY000: Incorrect geohash value: 'bcdjo' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("zyx**wv");
+ERROR HY000: Incorrect geohash value: 'zyx**wv' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("1 2 3 4");
+ERROR HY000: Incorrect geohash value: '1 2 3 4' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("1''2345");
+ERROR HY000: Incorrect geohash value: '1''2345' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("12.345");
+ERROR HY000: Incorrect geohash value: '12.345' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("   ");
+ERROR HY000: Incorrect geohash value: '   ' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("NULL");
+ERROR HY000: Incorrect geohash value: 'NULL' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("-100");
+ERROR HY000: Incorrect geohash value: '-100' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH("");
+ERROR HY000: Incorrect geohash value: '' for function st_latfromgeohash
+SELECT ST_LATFROMGEOHASH(9876543210);
+ERROR 22023: Invalid GIS data provided to function ST_LatFromGeohash.
+SELECT ST_LATFROMGEOHASH(0123456789);
+ERROR 22023: Invalid GIS data provided to function ST_LatFromGeohash.
+SELECT ST_LATFROMGEOHASH(1e1);
+ERROR 22023: Invalid GIS data provided to function ST_LatFromGeohash.
+SELECT ST_LATFROMGEOHASH();
+ERROR 42000: Incorrect parameter count in the call to native function 'ST_LATFROMGEOHASH'
+SELECT ST_LATFROMGEOHASH("123","456");
+ERROR 42000: Incorrect parameter count in the call to native function 'ST_LATFROMGEOHASH'
+SELECT ST_LATFROMGEOHASH("123",);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1
+SELECT ST_LATFROMGEOHASH(,"456");
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '"456")' at line 1
+SELECT ST_LATFROMGEOHASH(,);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1
+SELECT ST_LATFROMGEOHASH("0123456"789);
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '789)' at line 1
+SELECT ST_LATFROMGEOHASH(abcdef);
+ERROR 42S22: Unknown column 'abcdef' in 'field list'
+# very long geohash
+SELECT ST_LATFROMGEOHASH("0123456789bcdefghjkmnpqrstuvwxyz0123456789bcdefghjkmn"
+                         "pqrstuvwxyz0123456789bcdefghjkmnpqrstuvwxyz0123456789"
+                         "bcdefghjkmnpqrstuvwxyz");
+ST_LATFROMGEOHASH("0123456789bcdefghjkmnpqrstuvwxyz0123456789bcdefghjkmn"
+                         "pqrstuvwxyz0123456789bcdefghjkmnpqrstuvwxyz0123456789"
+                         "bcdefghjkmnpqrstuvwxyz")
+-82.77450549262497
+SELECT ST_LATFROMGEOHASH("0123456789BCDEFGHJKMNPQRSTUVWXYZ0123456789BCDEFGHJKMN"
+                         "PQRSTUVWXYZ0123456789BCDEFGHJKMNPQRSTUVWXYZ0123456789"
+                         "BCDEFGHJKMNPQRSTUVWXYZ");
+ST_LATFROMGEOHASH("0123456789BCDEFGHJKMNPQRSTUVWXYZ0123456789BCDEFGHJKMN"
+                         "PQRSTUVWXYZ0123456789BCDEFGHJKMNPQRSTUVWXYZ0123456789"
+                         "BCDEFGHJKMNPQRSTUVWXYZ")
+-82.77450549262497
+SELECT ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb9876543210zyxwvutsrqpnmkjhgfedc"
+                         "b9876543210zyxwvutsrqpnmkjhgfedcb9876543210zyxwvutsrq"
+                         "pnmkjhgfedcb9876543210");
+ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb9876543210zyxwvutsrqpnmkjhgfedc"
+                         "b9876543210zyxwvutsrqpnmkjhgfedcb9876543210zyxwvutsrq"
+                         "pnmkjhgfedcb9876543210")
+82.77450549262497
+SELECT ST_LATFROMGEOHASH("ZYXWVUTSRQPNMKJHGFEDCB9876543210ZYXWVUTSRQPNMKJHGFEDC"
+                         "B9876543210ZYXWVUTSRQPNMKJHGFEDCB9876543210ZYXWVUTSRQ"
+                         "PNMKJHGFEDCB9876543210");
+ST_LATFROMGEOHASH("ZYXWVUTSRQPNMKJHGFEDCB9876543210ZYXWVUTSRQPNMKJHGFEDC"
+                         "B9876543210ZYXWVUTSRQPNMKJHGFEDCB9876543210ZYXWVUTSRQ"
+                         "PNMKJHGFEDCB9876543210")
+82.77450549262497
+# different random geohash values
+SELECT ST_LATFROMGEOHASH(hash_value) FROM geohashes;
+ST_LATFROMGEOHASH(hash_value)
+-90
+90
+NULL
+1
+-0.1
+0.4
+-68
+68
+-27.3374899367448
+37.4347752334972
+82.269670295412
+-74.168840669129
+23.9696161514665
+-45.5852718924236
+29.763254995923
+83.7602082514146
+31.8700305354552
+19.7074618731612
 # valid inputs
 SELECT ST_GEOHASH(0,0,1);
 ST_GEOHASH(0,0,1)
@@ -362,3 +613,5 @@ SELECT ST_GEOHASH(ST_DIFFERENCE(ST_GEOMFROMTEXT('POINT(180 90)'),ST_GEOMFROMTEXT
 ERROR 22023: Invalid GIS data provided to function ST_GeoHash.
 SELECT ST_GEOHASH(ST_SYMDIFFERENCE(ST_GEOMFROMTEXT('POINT(180 90)'),ST_GEOMFROMTEXT('POINT(0 0)')),20);
 ERROR 22023: Invalid GIS data provided to function ST_GeoHash.
+# Clean up
+DROP TABLE geohashes;

--- a/mysql-test/main/spatial_utility_function_geohash.test
+++ b/mysql-test/main/spatial_utility_function_geohash.test
@@ -17,6 +17,213 @@
 
 -- disable_warnings
 
+# Table with different extreme values
+CREATE TABLE geohashes  (gid INT NOT NULL PRIMARY KEY, hash_value VARCHAR(255));
+INSERT INTO geohashes VALUES
+  (1, "000000000000000000000"),
+  (2, "zzzzzzzzzzzzzzzzzzzzz"),
+  (3, NULL),
+  (4, "s00t"),
+  (5, "7zzzm"),
+  (6, "s00d"),
+  (7, "0"),
+  (8, "z"),
+  (9, "3ejh6z75ddt2d839zh2u"),
+  (10, "twtsuqg3q7vh3nrbt0nn"),
+  (11, "yw8s10dxddhe4s06nsph"),
+  (12, "h4g4h9yrjtgzvewxm0ru"),
+  (13, "9kqbredcnhq1b44ue48s"),
+  (14, "1pckwjkqw3km0v6ye5d2"),
+  (15, "wm313fnr92ggsysm64e6"),
+  (16, "vqghx20fx6d8r5vfkbgf"),
+  (17, "wvetm3u23kr9r6663k31"),
+  (18, "e5t2p7sk291vpyb08pwu");
+
+#####################################################################
+# ST_LATFROMGEOHASH()
+#####################################################################
+
+# Check for all valid characters and inputs
+--echo # valid characters
+SELECT ST_LATFROMGEOHASH("0");
+
+SELECT ST_LATFROMGEOHASH("z");
+
+SELECT ST_LATFROMGEOHASH("0z");
+
+SELECT ST_LATFROMGEOHASH("xbpb");
+
+SELECT ST_LATFROMGEOHASH("8000");
+
+SELECT ST_LATFROMGEOHASH("s000");
+
+SELECT ST_LATFROMGEOHASH("0123456789");
+
+SELECT ST_LATFROMGEOHASH("9876543210");
+
+SELECT ST_LATFROMGEOHASH("bcdefghjkmnpqrstuvwxyz");
+
+SELECT ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb");
+
+SELECT ST_LATFROMGEOHASH("zzzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("bpbpbpbpbpbpbpbpbpbp");
+
+SELECT ST_LATFROMGEOHASH("pbpbpbpbpbpbpbpbpbpb");
+
+SELECT ST_LATFROMGEOHASH("00000000000000000000");
+
+SELECT ST_LATFROMGEOHASH("gzzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("5bpbpbpbpbpbpbpbpbpb");
+
+SELECT ST_LATFROMGEOHASH("7zzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("rzzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("2pbpbpbpbpbpbpbpbpbp");
+
+SELECT ST_LATFROMGEOHASH("0000000000zzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("zzzzzzzzzz0000000000");
+
+SELECT ST_LATFROMGEOHASH("s000000001z7wsg7zzm6");
+
+SELECT ST_LATFROMGEOHASH("ebpbpbpbpcbe9kuebp6d");
+
+SELECT ST_LATFROMGEOHASH("kpbpbpbpbnpkqe5kpbtm");
+
+SELECT ST_LATFROMGEOHASH("7zzzzzzzzy0s37hs00dt");
+
+SELECT ST_LATFROMGEOHASH("tzzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("9zzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("jzzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("1zzzzzzzzzzzzzzzzzzz");
+
+SELECT ST_LATFROMGEOHASH("zbzurypzpgxczbzurypz");
+
+SELECT ST_LATFROMGEOHASH("5zpgxczbzurypzpgxczb");
+
+SELECT ST_LATFROMGEOHASH("0z0z0z0z0z0z0z0z0z0z0z0z0z0z0z0z");
+
+SELECT ST_LATFROMGEOHASH("0123456789bcdefghjkmnpqrstuvwxyz");
+
+SELECT ST_LATFROMGEOHASH("0123456789BCDEFGHJKMNPQRSTUVWXYZ");
+
+SELECT ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb9876543210");
+
+SELECT ST_LATFROMGEOHASH("ZYXWVUTSRQPNMKJHGFEDCB9876543210");
+
+SELECT ST_LATFROMGEOHASH("1e1");
+
+SELECT ST_LATFROMGEOHASH("100");
+
+SELECT ST_LATFROMGEOHASH(CAST(100 AS CHAR));
+
+SELECT ST_LATFROMGEOHASH("10111000110001111001");
+
+SELECT ST_LATFROMGEOHASH("11111111111111111111");
+
+SELECT ST_LATFROMGEOHASH("99999999999999999999");
+
+SELECT ST_LATFROMGEOHASH(NULL);
+
+SELECT ST_LATFROMGEOHASH(null);
+
+SELECT ST_LATFROMGEOHASH(CAST("012" AS BINARY));
+
+# Invalid characters and inputs
+--echo # invalid characters and inputs
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("0123a45");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("xyzi");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("zyxLwv");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("bcdjo");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("zyx**wv");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("1 2 3 4");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("1''2345");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("12.345");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("   ");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("NULL");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("-100");
+
+--error ER_WRONG_VALUE_FOR_TYPE
+SELECT ST_LATFROMGEOHASH("");
+
+--error ER_GIS_INVALID_DATA
+SELECT ST_LATFROMGEOHASH(9876543210);
+
+--error ER_GIS_INVALID_DATA
+SELECT ST_LATFROMGEOHASH(0123456789);
+
+--error ER_GIS_INVALID_DATA
+SELECT ST_LATFROMGEOHASH(1e1);
+
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT ST_LATFROMGEOHASH();
+
+--error ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT
+SELECT ST_LATFROMGEOHASH("123","456");
+
+--error ER_PARSE_ERROR
+SELECT ST_LATFROMGEOHASH("123",);
+
+--error ER_PARSE_ERROR
+SELECT ST_LATFROMGEOHASH(,"456");
+
+--error ER_PARSE_ERROR
+SELECT ST_LATFROMGEOHASH(,);
+
+--error ER_PARSE_ERROR
+SELECT ST_LATFROMGEOHASH("0123456"789);
+
+--error ER_BAD_FIELD_ERROR
+SELECT ST_LATFROMGEOHASH(abcdef);
+
+# Test geohashes that are long
+--echo # very long geohash
+SELECT ST_LATFROMGEOHASH("0123456789bcdefghjkmnpqrstuvwxyz0123456789bcdefghjkmn"
+                         "pqrstuvwxyz0123456789bcdefghjkmnpqrstuvwxyz0123456789"
+                         "bcdefghjkmnpqrstuvwxyz");
+
+SELECT ST_LATFROMGEOHASH("0123456789BCDEFGHJKMNPQRSTUVWXYZ0123456789BCDEFGHJKMN"
+                         "PQRSTUVWXYZ0123456789BCDEFGHJKMNPQRSTUVWXYZ0123456789"
+                         "BCDEFGHJKMNPQRSTUVWXYZ");
+
+SELECT ST_LATFROMGEOHASH("zyxwvutsrqpnmkjhgfedcb9876543210zyxwvutsrqpnmkjhgfedc"
+                         "b9876543210zyxwvutsrqpnmkjhgfedcb9876543210zyxwvutsrq"
+                         "pnmkjhgfedcb9876543210");
+
+SELECT ST_LATFROMGEOHASH("ZYXWVUTSRQPNMKJHGFEDCB9876543210ZYXWVUTSRQPNMKJHGFEDC"
+                         "B9876543210ZYXWVUTSRQPNMKJHGFEDCB9876543210ZYXWVUTSRQ"
+                         "PNMKJHGFEDCB9876543210");
+
+--echo # different random geohash values
+SELECT ST_LATFROMGEOHASH(hash_value) FROM geohashes;
+
 #####################################################################
 # ST_GEOHASH()
 #####################################################################
@@ -406,3 +613,5 @@ SELECT ST_GEOHASH(ST_DIFFERENCE(ST_GEOMFROMTEXT('POINT(180 90)'),ST_GEOMFROMTEXT
 --error ER_GIS_INVALID_DATA
 SELECT ST_GEOHASH(ST_SYMDIFFERENCE(ST_GEOMFROMTEXT('POINT(180 90)'),ST_GEOMFROMTEXT('POINT(0 0)')),20);
 
+--echo # Clean up
+DROP TABLE geohashes;

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -2831,6 +2831,226 @@ void Item_func_geohash::set_bit(double &max_value, double &min_value, const doub
 }
 
 
+const uint8_t Item_func_latlongfromgeohash::geohash_alphabet[256] = {
+    // 0-47
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255,
+    // '0'-'9' (48-57)
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    // 58-65
+    255, 255, 255, 255, 255, 255, 255, 255,
+    // 'B'-'H' (66-73)
+    10, 11, 12, 13, 14, 15, 16,
+    // 'I' (74)
+    255,
+    // 'J'-'K' (75-76)
+    17, 18,
+    // 'L' (77)
+    255,
+    // 'M'-'N' (78-79)
+    19, 20,
+    // O (80)
+    255,
+    // 'P'-'Z' (81-92)
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+    255, 255, 255, 255, 255, 255, 255,
+    // 'b'-'h' (97-104)
+    10, 11, 12, 13, 14, 15, 16,
+    // 'i' (105)
+    255,
+    // 'j'-'k' (106-107)
+    17, 18,
+    // 'l' (108)
+    255,
+    // 'm'-'n' (109-110)
+    19, 20,
+    // 'o' (111)
+    255,
+    // 'p'-'z' (112-122)
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+    // 123-255
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
+};
+
+
+/**
+  Decodes a geohash string into longitude and latitude.
+  The results are rounded,  based on the length of input geohash. The function
+  will stop evaluating when the error range, or "accuracy", has become 0.0 for
+  both latitude and longitude since no more changes can happen after this.
+  @param geohash The geohash to decode.
+  @param upper_latitude Upper limit of returned latitude (normally 90.0).
+  @param[out] result_latitude Calculated latitude.
+  @param[out] result_longitude Calculated longitude.
+  @return false on success, true on failure (invalid geohash string).
+*/
+bool Item_func_latlongfromgeohash::decode_geohash(
+    String *geohash, double *result_latitude,
+    double *result_longitude)
+{
+  double latitude_accuracy= (MAX_LATITUDE - MIN_LATITUDE) / 2.0;
+  double longitude_accuracy= (MAX_LONGITUDE - MIN_LONGITUDE) / 2.0;
+
+  double latitude_value= (MAX_LATITUDE + MIN_LATITUDE) / 2.0;
+  double longitude_value= (MAX_LONGITUDE + MIN_LONGITUDE) / 2.0;
+
+  uint number_of_bits_used= 0;
+  const uint input_length= geohash->length();
+
+  for (uint i = 0; i < input_length; i++)
+  {
+    int converted_character =
+      Item_func_latlongfromgeohash::geohash_alphabet[(int) (*geohash)[i]];
+
+    if (converted_character == 255) {
+      return true;
+    }
+
+    for (int bit_number = 4; bit_number >= 0; bit_number--)
+    {
+      if (number_of_bits_used % 2) {
+        latitude_accuracy/= 2.0;
+        if (converted_character & (1 << bit_number))
+          latitude_value+= latitude_accuracy;
+        else
+          latitude_value-= latitude_accuracy;
+      } else {
+        longitude_accuracy/= 2.0;
+        if (converted_character & (1 << bit_number))
+          longitude_value+= longitude_accuracy;
+        else
+          longitude_value-= longitude_accuracy;
+      }
+
+      number_of_bits_used++;
+    }
+
+    if (latitude_accuracy <= 0.0 || longitude_accuracy <= 0.0)
+      break;
+  }
+
+  *result_latitude= round_latlongitude(latitude_value, latitude_accuracy * 2.0,
+                                       latitude_value - latitude_accuracy,
+                                       latitude_value + latitude_accuracy);
+  *result_longitude= round_latlongitude(longitude_value,
+                                        longitude_accuracy * 2.0,
+                                        longitude_value - longitude_accuracy,
+                                        longitude_value + longitude_accuracy);
+
+  return false;
+}
+
+
+/**
+  Rounds a latitude or longitude value.
+  This will round a latitude or longitude value, based on error_range.
+  The error_range is the difference between upper and lower lat/longitude
+  (e.g upper value of 45.0 and a lower value of 22.5, gives an error range of
+  22.5).
+  The returned result will always be in the range [lower_limit, upper_limit]
+  @param latlongitude The latitude or longitude to round.
+  @param error_range The total error range of the calculated laglongitude.
+  @param lower_limit Lower limit of the returned result.
+  @param upper_limit Upper limit of the returned result.
+  @return A rounded latitude or longitude.
+*/
+double Item_func_latlongfromgeohash::round_latlongitude(double latlongitude,
+                                                        double error_range,
+                                                        double lower_limit,
+                                                        double upper_limit)
+{
+  if (error_range == 0.0)
+    return latlongitude;
+
+  uint number_of_decimals= 0;
+  while (error_range <= 0.1 && number_of_decimals <= DBL_DIG) {
+    number_of_decimals++;
+    error_range*= 10.0;
+  }
+
+  double return_value;
+  do {
+    return_value= my_double_round(latlongitude, number_of_decimals, false,
+                                  false);
+    number_of_decimals++;
+  } while ((lower_limit > return_value || return_value > upper_limit) &&
+           number_of_decimals <= DBL_DIG);
+
+  // If the result is outside the allowed range, return the input value
+  if (lower_limit > return_value || return_value > upper_limit)
+    return_value= latlongitude;
+
+  // Avoid printing signed zero
+  return return_value + 0.0;
+}
+
+
+bool Item_func_latlongfromgeohash::is_invalid_geohash_field(
+      enum_field_types field_type)
+{
+  switch (field_type)
+  {
+    case MYSQL_TYPE_NULL:
+    case MYSQL_TYPE_VARCHAR:
+      return false;
+    default:
+      return true;
+  }
+}
+
+
+double Item_func_latlongfromgeohash::val_real()
+{
+  null_value= 1;
+  String *input_value;
+
+  if (args[0]->null_value)
+    return 0.0;
+
+  if (is_invalid_geohash_field(args[0]->field_type()))
+  {
+    my_error(ER_GIS_INVALID_DATA, MYF(0), decode_longitude ?
+                                          "ST_LongFromGeoHas" :
+                                          "ST_LatFromGeohash");
+    return 0.0;
+  }
+
+  input_value= args[0]->val_str(&buf);
+  if (args[0]->null_value)
+  {
+    args[0]->null_value= 0;
+    return 0.0;
+  }
+
+  if (input_value->is_empty())
+  {
+    my_error(ER_WRONG_VALUE_FOR_TYPE, MYF(0), "geohash",
+            input_value->c_ptr_safe(), func_name());
+    return 0.0;
+  }
+
+  double latitude= 0.0, longitude= 0.0;
+  if (decode_geohash(input_value, &latitude, &longitude)) {
+    my_error(ER_WRONG_VALUE_FOR_TYPE, MYF(0), "geohash",
+             input_value->c_ptr_safe(), func_name());
+    return 0.0;
+  }
+
+  null_value= 0;
+  if (decode_longitude) return longitude;
+  return latitude;
+}
+
 String *Item_func_pointonsurface::val_str(String *str)
 {
   Gcalc_operation_transporter trn(&func, &collector);
@@ -3242,6 +3462,20 @@ Create_func_geohash::create_native(THD *thd, const LEX_CSTRING *name,
   return func;
 }
 
+class Create_func_latfromgeohash : public Create_func_arg1
+{
+public:
+  Item *create_1_arg(THD *thd, Item *arg1) override
+  {
+    return new (thd->mem_root) Item_func_latfromgeohash(thd, arg1);
+  }
+
+  static Create_func_latfromgeohash s_singleton;
+
+protected:
+  Create_func_latfromgeohash() = default;
+  virtual ~Create_func_latfromgeohash() = default;
+};
 
 class Create_func_endpoint : public Create_func_arg1
 {
@@ -4095,6 +4329,7 @@ Create_func_disjoint Create_func_disjoint::s_singleton;
 Create_func_distance Create_func_distance::s_singleton;
 Create_func_distance_sphere Create_func_distance_sphere::s_singleton;
 Create_func_geohash Create_func_geohash::s_singleton;
+Create_func_latfromgeohash Create_func_latfromgeohash ::s_singleton;
 Create_func_endpoint Create_func_endpoint::s_singleton;
 Create_func_envelope Create_func_envelope::s_singleton;
 Create_func_equals Create_func_equals::s_singleton;
@@ -4216,6 +4451,7 @@ static Native_func_registry func_array_geom[] =
   { { STRING_WITH_LEN("POLYGONFROMTEXT") }, GEOM_BUILDER(Create_func_geometry_from_text)},
   { { STRING_WITH_LEN("POLYGONFROMWKB") }, GEOM_BUILDER(Create_func_geometry_from_wkb)},
   { { STRING_WITH_LEN("GEOHASH") }, GEOM_BUILDER(Create_func_geohash)},
+  { { STRING_WITH_LEN("LATFROMGEOHASH") }, GEOM_BUILDER(Create_func_latfromgeohash)},
   { { STRING_WITH_LEN("SRID") }, GEOM_BUILDER(Create_func_srid)},
   { { STRING_WITH_LEN("ST_AREA") }, GEOM_BUILDER(Create_func_area)},
   { { STRING_WITH_LEN("STARTPOINT") }, GEOM_BUILDER(Create_func_startpoint)},
@@ -4297,6 +4533,7 @@ static Native_func_registry func_array_geom[] =
   { { STRING_WITH_LEN("ST_Y") }, GEOM_BUILDER(Create_func_y)},
   { { STRING_WITH_LEN("ST_DISTANCE_SPHERE") }, GEOM_BUILDER(Create_func_distance_sphere)},
   { { STRING_WITH_LEN("ST_GEOHASH") }, GEOM_BUILDER(Create_func_geohash)},
+  { { STRING_WITH_LEN("ST_LATFROMGEOHASH") }, GEOM_BUILDER(Create_func_latfromgeohash)},
   { { STRING_WITH_LEN("TOUCHES") }, GEOM_BUILDER(Create_func_touches)},
   { { STRING_WITH_LEN("WITHIN") }, GEOM_BUILDER(Create_func_within)},
   { { STRING_WITH_LEN("X") }, GEOM_BUILDER(Create_func_x)},

--- a/sql/item_geofunc.h
+++ b/sql/item_geofunc.h
@@ -1257,6 +1257,40 @@ public:
 };
 
 
+class Item_func_latlongfromgeohash : public Item_real_func {
+ private:
+  String buf;
+  static const uint8_t geohash_alphabet[256];
+  const bool decode_longitude;
+  static bool is_invalid_geohash_field(enum_field_types field_type);
+
+ public:
+  Item_func_latlongfromgeohash(THD *thd, Item *a, bool start_on_even_bit_arg)
+      : Item_real_func(thd, a),
+        decode_longitude(start_on_even_bit_arg) {}
+  double val_real() override;
+  static bool decode_geohash(String *geohash, double *result_latitude,
+                             double *result_longitude);
+  static double round_latlongitude(double latlongitude, double error_range,
+                                   double lower_limit, double upper_limit);
+};
+
+
+class Item_func_latfromgeohash: public Item_func_latlongfromgeohash
+{
+public:
+  Item_func_latfromgeohash(THD *thd, Item *a)
+   :Item_func_latlongfromgeohash(thd, a, false) {}
+  LEX_CSTRING func_name_cstring() const override
+  {
+    static LEX_CSTRING name= {STRING_WITH_LEN("st_latfromgeohash") };
+    return name;
+  }
+  Item *get_copy(THD *thd) override
+  { return get_item_copy<Item_func_latfromgeohash>(thd, this); }
+};
+
+
 class Item_func_pointonsurface: public Item_geometry_func_args_geometry
 {
   String tmp_value;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-34159](https://jira.mariadb.org/browse/MDEV-34159)

## Description

MariaDB GIS functionalities are limited when compared to other DBMs. To facilitate the migration from MySQL to MariaDB the GIS functionality should be the same. This PR implements the GIS function `ST_LatFromGeoHash(geohash_str)`. The GIS function ST_LatFromGeoHash takes in input a geohash and returns its latitude. The latitude is returned as a numeric value in the interval [90, -90].
If the argument is NULL, the return value is NULL. If the argument is invalid, an ER_INCORRECT_TYPE is thrown.

To ensure compatibility between the MySQL implementation of this function and the MariaDB implementation, the tests for this function have been cherry-picked from MySQL.

This patch has no side effects.

## Release Notes
Adds the function:
`ST_LatFromGeoHash(geohash_str)` and `LatFromGeoHash(geohash_str)`:  takes in input a geohash and returns its latitude.

## How can this PR be tested?

An extensive test suite has been cherry-picked from MySQL.

## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
