### PR TITLE
MDEV-34625 Fix undefined behavior of using uninitialized member variables

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -8375,7 +8375,7 @@ TABLE_LIST *st_select_lex::add_table_to_list(THD *thd,
   }
 
   bool has_alias_ptr= alias != nullptr;
-  void *memregion= thd->calloc(sizeof(TABLE_LIST));
+  void *memregion= thd->alloc(sizeof(TABLE_LIST));
   TABLE_LIST *ptr= new (memregion) TABLE_LIST(thd, db, fqtn, alias_str,
                                               has_alias_ptr, table, lock_type,
                                               mdl_type, table_options,

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -5865,6 +5865,7 @@ TABLE_LIST::TABLE_LIST(THD *thd,
                        List<Index_hint> *index_hints_ptr,
                        LEX_STRING *option_ptr)
 {
+  reset();
   db= db_str;
   is_fqtn= fqtn;
   alias= alias_str;


### PR DESCRIPTION
- [x] _The Jira issue number for this PR is: MDEV-34625_

## Description

Commit a8a75ba2d causes the MariaDB server to crash, usually with signal 11, at random code locations due to invalid pointer values during any table operation. This issue occurs when the server is built with -O3 and other customized compiler flags.

For example, the command `use db1;` causes server to crash in the `check_table_access` function at line sql_parse.cc:7080 because `tables->correspondent_table` is an invalid pointer value of 0x1.

The crashes are due to undefined behavior from using uninitialized variables. The problematic commit a8a75ba2d introduces code that allocates memory and sets it to 0 using thd-\>calloc before initializing it with a placement new operation. This process depends on setting memory to 0 to initialize member variables not explicitly set in the constructor. However, the compiler can optimize out the memset/bfill, leading to uninitialized values and unpredictable issues.

Once a constructor function initializes an object, any uninitialized variables within that object are subject to undefined behavior. The state of memory before the constructor runs, whether it involves memset or was used for other purposes, is irrelevant after the placement new operation.

Now we ensure the constructor initializes variables correctly by running the reset() function in the constructor to perform the memset/bfill(0) operation. After applying the fix, the crash is gone.

### Detailed explanation of the issue

[Following code](https://github.com/MariaDB/server/blob/a8a75ba2d0dd639b2b14337a6c4f495fcaaff7e4/sql/sql_parse.cc#L8352-L8357 "Follow link") mainly does three things:

1. It allocates memory from mem_root using the `calloc` function implemented in `THD` class.
2. In the same `calloc` , it sets all allocated memory to 0.
3. In the `placement new` it initializes the `TABLE_LIST` at the memory allocated in step 1.

```
  void *memregion= thd->calloc(sizeof(TABLE_LIST));
  TABLE_LIST *ptr= new (memregion) TABLE_LIST(thd, db, fqtn, alias_str,
                                              has_alias_ptr, table, lock_type,
                                              mdl_type, table_options,
                                              info_schema, this,
                                              index_hints_arg, option);
```

There's a critical issue in above code because it depends on step 2 to initialize all the member variables of TABLE_LIST that are not explicitly set in the constructor function. There's no guarantee that the memset/bfill in step 2 will always happen as compiler could optimize it out. Using the uninitialized value can lead to unpredictable issues which are hard to debug.

This behavior can be demonstrated with this test https://gcc.godbolt.org/z/5n87z1raG I wrote to examine the assembly code. The code in MariaDB can be abstracted to the following, though it has many layers wrapped around it and more complex logic, causing slight differences in optimization in the MariaDB build. ( and in default MariaDB build, it seems it's not optimized out so there's no issue, but there are chances to be optimized out with some customized flags which are happening in our build )

_To summarize, on x86, the memset in the following code is optimized out with both -O2 and -O3 in GCC 13, and is only preserved in the much older GCC 4.9._

```
struct S {
  int i;     // uninitialized in consturctor
  S() {};
};

int bar() {
  void *buf = malloc(sizeof(S));
  memset(buf, 0, sizeof(S));       // optimized out
  S* s = new(buf) S;
  return s->i;
}
```

GCC13 -O3

```
bar():
        sub     rsp, 8
        mov     edi, 4
        call    malloc
        mov     eax, DWORD PTR [rax]
        add     rsp, 8
        ret
```

GCC 4.9 -O3

```
bar():
        sub     rsp, 8
        mov     edi, 4
        call    malloc
        mov     DWORD PTR [rax], 0
        xor     eax, eax
        add     rsp, 8
        ret
```

## Release Notes

What should the release notes say about this change?

N/A

## How can this PR be tested?

This change does not change any server behavior so all MTR tests should pass.

## Basing the PR against the correct MariaDB version

- [ ] _This is a new feature and the PR is based against the latest MariaDB development branch._
- [x] _This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced._

The fix is targeting on 10.6 which is the lowest major version includes the problematic commit a8a75ba2d.

## PR quality check

- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services.