### PR TITLE
MDEV-34634 Types mismatch when cloning items causes debug assertion

### DIFF
--- a/mysql-test/main/item_types.result
+++ b/mysql-test/main/item_types.result
@@ -1,0 +1,16 @@
+#
+# MDEV-34634 Types mismatch when cloning items causes debug assertion
+#
+CREATE TABLE t1 (a DATETIME);
+SET optimizer_switch='derived_merge=off';
+SELECT * FROM (SELECT * FROM t1) AS t1 WHERE a='';
+a
+Warnings:
+Warning	1292	Truncated incorrect datetime value: ''
+DROP TABLE t1;
+CREATE TABLE t1 (c YEAR);
+CREATE TABLE t2 (c INT);
+SELECT * FROM t1 JOIN t2 ON t1.c=t2.c WHERE t1.c<=>5;
+c	c
+DROP TABLE t1, t2;
+SET optimizer_switch=default;

--- a/mysql-test/main/item_types.test
+++ b/mysql-test/main/item_types.test
@@ -1,0 +1,15 @@
+--echo #
+--echo # MDEV-34634 Types mismatch when cloning items causes debug assertion
+--echo #
+
+CREATE TABLE t1 (a DATETIME);
+SET optimizer_switch='derived_merge=off';
+SELECT * FROM (SELECT * FROM t1) AS t1 WHERE a='';
+DROP TABLE t1;
+
+CREATE TABLE t1 (c YEAR);
+CREATE TABLE t2 (c INT);
+SELECT * FROM t1 JOIN t2 ON t1.c=t2.c WHERE t1.c<=>5;
+DROP TABLE t1, t2;
+
+SET optimizer_switch=default;

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -3847,7 +3847,7 @@ void Item_decimal::set_decimal_value(my_decimal *value_par)
 }
 
 
-Item *Item_decimal::do_clone_const_item(THD *thd) const
+Item *Item_decimal::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_decimal(thd, name.str, &decimal_value, decimals,
                                          max_length);
@@ -3868,7 +3868,7 @@ my_decimal *Item_float::val_decimal(my_decimal *decimal_value)
 }
 
 
-Item *Item_float::do_clone_const_item(THD *thd) const
+Item *Item_float::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_float(thd, name.str, value, decimals,
                                        max_length);
@@ -4032,7 +4032,7 @@ Item *Item_null::safe_charset_converter(THD *thd, CHARSET_INFO *tocs)
   return this;
 }
 
-Item *Item_null::do_clone_const_item(THD *thd) const
+Item *Item_null::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_null(thd, name.str);
 }
@@ -4873,7 +4873,7 @@ Item *Item_param::value_clone_item(THD *thd) const
 /* see comments in the header file */
 
 Item *
-Item_param::do_clone_const_item(THD *thd) const
+Item_param::clone_item(THD *thd) const
 {
   // There's no "default". See comments in Item_param::save_in_field().
   switch (state) {
@@ -6953,7 +6953,7 @@ int Item_string::save_in_field(Field *field, bool no_conversions)
 }
 
 
-Item *Item_string::do_clone_const_item(THD *thd) const
+Item *Item_string::clone_item(THD *thd) const
 {
   LEX_CSTRING val;
   str_value.get_value(&val);
@@ -7017,7 +7017,7 @@ int Item_int::save_in_field(Field *field, bool no_conversions)
 }
 
 
-Item *Item_int::do_clone_const_item(THD *thd) const
+Item *Item_int::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_int(thd, name.str, value, max_length, unsigned_flag);
 }
@@ -7046,7 +7046,7 @@ int Item_decimal::save_in_field(Field *field, bool no_conversions)
 }
 
 
-Item *Item_int_with_ref::do_clone_const_item(THD *thd) const
+Item *Item_int_with_ref::clone_item(THD *thd) const
 {
   DBUG_ASSERT(ref->const_item());
   /*
@@ -7142,7 +7142,7 @@ Item *Item_uint::neg(THD *thd)
 }
 
 
-Item *Item_uint::do_clone_const_item(THD *thd) const
+Item *Item_uint::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_uint(thd, name.str, value, max_length);
 }
@@ -7380,7 +7380,7 @@ void Item_date_literal::print(String *str, enum_query_type query_type)
 }
 
 
-Item *Item_date_literal::do_clone_const_item(THD *thd) const
+Item *Item_date_literal::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_date_literal(thd, &cached_time);
 }
@@ -7405,7 +7405,7 @@ void Item_datetime_literal::print(String *str, enum_query_type query_type)
 }
 
 
-Item *Item_datetime_literal::do_clone_const_item(THD *thd) const
+Item *Item_datetime_literal::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_datetime_literal(thd, &cached_time, decimals);
 }
@@ -7430,7 +7430,7 @@ void Item_time_literal::print(String *str, enum_query_type query_type)
 }
 
 
-Item *Item_time_literal::do_clone_const_item(THD *thd) const
+Item *Item_time_literal::clone_item(THD *thd) const
 {
   return new (thd->mem_root) Item_time_literal(thd, &cached_time, decimals);
 }
@@ -10389,7 +10389,7 @@ void Item_cache_temporal::store_packed(longlong val_arg, Item *example_arg)
 }
 
 
-Item *Item_cache_temporal::do_clone_const_item(THD *thd) const
+Item *Item_cache_temporal::clone_item(THD *thd) const
 {
   Item_cache *tmp= type_handler()->Item_get_cache(thd, this);
   Item_cache_temporal *item= static_cast<Item_cache_temporal*>(tmp);

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -16632,7 +16632,7 @@ change_cond_ref_to_const(THD *thd, I_List<COND_CMP> *save_list,
   if (can_change_cond_ref_to_const(func, right_item, left_item,
                                    field_value_owner, field, value))
   {
-    Item *tmp=value->clone_const_item(thd);
+    Item *tmp=value->clone_item(thd);
     if (tmp)
     {
       tmp->collation.set(right_item->collation);
@@ -16662,7 +16662,7 @@ change_cond_ref_to_const(THD *thd, I_List<COND_CMP> *save_list,
   else if (can_change_cond_ref_to_const(func, left_item, right_item,
                                         field_value_owner, field, value))
   {
-    Item *tmp= value->clone_const_item(thd);
+    Item *tmp= value->clone_item(thd);
     if (tmp)
     {
       tmp->collation.set(left_item->collation);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34634*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
New runtime diagnostic introduced with MDEV-34490 has detected that `Item_int_with_ref` incorrectly returns an instance of its ancestor class `Item_int`. This commit fixes that.

In addition, this commit reverts a part of the diagnostic related to `clone_item()` checks. As it turned out, `clone_item()` is not required to return an object of the same class as the cloned one. For example, look at `Item_param::clone_item()`: it can return objects of `Item_null`, `Item_int`, `Item_string`, etc, depending on the object state. So the runtime type diagnostic is not applicable to `clone_item()` and is disabled with this commit.

As the similar diagnostic failures are expected to appear again in the future, this commit introduces a new test file in the main suite: item_types.test, and new test cases may be added to this file

## Release Notes
Not worth mentioning in release notes.


## How can this PR be tested?

New test file item_types.test is added to the main suite.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
