### PR TITLE
MDEV-34357   InnoDB: Assertion failure in file ./storage/innobase/page/page0zip.cc line 4211

### DIFF
--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -811,11 +811,11 @@ zip_reorganize:
 			the predefined infimum record, then it would
 			still be the infimum, and we would have
 			ret_pos == 0. */
-			if (UNIV_UNLIKELY(!ret_pos
-					  || ret_pos == ULINT_UNDEFINED)) {
+			if (UNIV_UNLIKELY(ret_pos == ULINT_UNDEFINED)) {
 				*err = DB_CORRUPTION;
 				return nullptr;
 			}
+
 			*err = page_zip_reorganize(new_block, index,
 						   page_zip_level, mtr);
 			switch (*err) {


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34357*

## Description
During InnoDB root page split, InnoDB does the following 
1) First move the root records to the new page(p1)
2) Empty the root, insert the node pointer to the root page
3) Split the new page and make it as child nodes.
4) Finds the split record, allocate another new page(p2) to the index
5) InnoDB stores the record(ret) predecessor to the supremum record of the page (p2).
6) In page_copy_rec_list_start(), move the records from p1 to p2 upto the split record
6) Given table is a compressed row format page, InnoDB attempts to compress the page p2 and failed (due to innodb_compression_level = 0)
7) Since the compression fails, InnoDB gets the number of preceding records(ret_pos) of a record (ret) on the page (p2)
8) Page (p2) is a new page, ret points to infimum record. ret_pos can be 0. InnoDB have wrong condition that ret_pos shouldn't be 0 and returns corruption. InnoDB has similar wrong check in page_copy_rec_list_end()

## How can this PR be tested?
```
--source include/have_innodb.inc
--source include/have_sequence.inc
 
SET SQL_MODE='';
CREATE OR REPLACE TABLE t1(c CHAR(100) CHARACTER SET utf16,KEY k1(c(100))) engine=INNODB ROW_FORMAT=COMPRESSED;
INSERT INTO t1 SET c=NULL;
ALTER TABLE t1 ADD COLUMN c1 INT;
INSERT INTO t1 SET c=NULL;
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
INSERT INTO t1 SET c=NULL;
INSERT INTO t1 SET c='';
INSERT INTO t1 SET c='';
INSERT INTO t1 SET c=NULL;
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
INSERT INTO t1 SET c='';
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
INSERT INTO t1 SET c='';
EXPLAIN SELECT DISTINCT BIT_OR(100) OVER () FROM dual GROUP BY LEFT('abcdefghijklmnopqrstuvwxyz',100) WITH ROLLUP HAVING @A :='abcdefghijklmnopqrstuvwxyz';
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
INSERT INTO t1 SET c=@a;
INSERT INTO t1 SET c='';
SET GLOBAL innodb_compression_level=0;
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
INSERT INTO t1 SELECT seq,concat(seq,'abcdefghijklmnopqrstuvwxyz') FROM seq_1_to_100;
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
