### PR TITLE
MDEV-34066  Output of SHOW ENGINE INNODB STATUS uses the nanoseconds suffix for microseconds

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -5015,7 +5015,7 @@ void lock_trx_print_wait_and_mvcc_state(FILE *file, const trx_t *trx,
 	if (const lock_t* wait_lock = trx->lock.wait_lock) {
 		const my_hrtime_t suspend_time= trx->lock.suspend_time;
 		fprintf(file,
-			"------- TRX HAS BEEN WAITING %llu ns"
+			"------- TRX HAS BEEN WAITING %llu us"
 			" FOR THIS LOCK TO BE GRANTED:\n",
 			now.val - suspend_time.val);
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34066*

## Description
- This issue is caused by commit e71e6133535da8d5eab86e504f0b116a03680780 (MDEV-24671). Change the output of transaction lock wait time in microseconds suffix.



## How can this PR be tested?
SHOW ENGINE INNODB STATUS output while waiting for the transaction lock
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
