### PR TITLE
MDEV-34181  Instant table aborts after discard tablespace

### DIFF
--- a/mysql-test/suite/innodb/r/import_bugs.result
+++ b/mysql-test/suite/innodb/r/import_bugs.result
@@ -61,4 +61,30 @@ id
 4
 5
 DROP TABLE t2;
+#
+# MDEV-34181  Instant table aborts after discard tablespace
+#
+CREATE TABLE t1(c3 INT, c2 INT, c1 INT KEY)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, 1, 1), (2, 2, 2);
+CREATE TABLE t2 (c1 INT KEY) ENGINE=InnoDB;
+INSERT INTO t2 VALUES(1);
+ALTER TABLE t2 ADD c2 INT;
+FLUSH TABLES t1 FOR EXPORT;
+UNLOCK TABLES;
+ALTER TABLE t2 DISCARD TABLESPACE;
+ALTER TABLE t2 ADD c3 INT FIRST;
+Warnings:
+Warning	1814	Tablespace has been discarded for table `t2`
+ALTER TABLE t2 IMPORT TABLESPACE;
+Warnings:
+Warning	1810	IO Read error: (2, No such file or directory) Error opening './test/t2.cfg', will attempt to import without schema verification
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `c3` int(11) DEFAULT NULL,
+  `c1` int(11) NOT NULL,
+  `c2` int(11) DEFAULT NULL,
+  PRIMARY KEY (`c1`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+DROP TABLE t2, t1;
 # End of 10.5 tests

--- a/mysql-test/suite/innodb/t/import_bugs.test
+++ b/mysql-test/suite/innodb/t/import_bugs.test
@@ -78,4 +78,24 @@ INSERT INTO t2() VALUES();
 SELECT * FROM t2 ORDER BY id;
 DROP TABLE t2;
 
+--echo #
+--echo # MDEV-34181  Instant table aborts after discard tablespace
+--echo #
+CREATE TABLE t1(c3 INT, c2 INT, c1 INT KEY)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, 1, 1), (2, 2, 2);
+CREATE TABLE t2 (c1 INT KEY) ENGINE=InnoDB;
+INSERT INTO t2 VALUES(1);
+ALTER TABLE t2 ADD c2 INT;
+FLUSH TABLES t1 FOR EXPORT;
+let $datadir=`select @@datadir`;
+--copy_file $datadir/test/t1.ibd $datadir/test/imp_t1.ibd
+UNLOCK TABLES;
+ALTER TABLE t2 DISCARD TABLESPACE;
+ALTER TABLE t2 ADD c3 INT FIRST;
+--copy_file $datadir/test/imp_t1.ibd $datadir/test/t2.ibd
+
+--replace_regex /opening '.*\/test\//opening '.\/test\//
+ALTER TABLE t2 IMPORT TABLESPACE;
+SHOW CREATE TABLE t2;
+DROP TABLE t2, t1;
 --echo # End of 10.5 tests

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -374,10 +374,12 @@ found_j:
 			}
 		}
 
-		/* In case of discarded tablespace, InnoDB can't
-		read the root page. So assign the null bytes based
-		on nullabled fields */
-		if (!oindex.table->space) {
+		/* Discard tablespace doesn't remove the instantness
+		from the table definition. if n_core_null_bytes wasn't
+		initialized then assign it based on nullable fields */
+		if (!oindex.table->space
+		    && oindex.n_core_null_bytes
+		       == dict_index_t::NO_CORE_NULL_BYTES) {
 			oindex.n_core_null_bytes = static_cast<uint8_t>(
 				UT_BITS_IN_BYTES(unsigned(oindex.n_nullable)));
 		}


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34181*

## Description
- commit 85db5347311340e39753b0200fb9d459a5024535 (MDEV-33400) avoid the clearing of the instant alter metadata during discard tablespace. But it fails to remove the assignment of n_core_null_bytes with total nullable fields exist in the index for discarded tablespace.

## How can this PR be tested?
./mtr innodb.import_bugs
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
