### PR TITLE
MDEV-33755 Some test cause MSAN alarms due to uninitialized Item_func…

### DIFF
--- a/include/my_valgrind.h
+++ b/include/my_valgrind.h
@@ -29,6 +29,7 @@
 # define HAVE_valgrind
 # define HAVE_MEM_CHECK
 # define MEM_UNDEFINED(a,len) __msan_allocated_memory(a,len)
+# define MEM_UNDEFINED_VALGRIND_ONLY(a, len) ((void) 0)
 # define MEM_MAKE_ADDRESSABLE(a,len) MEM_UNDEFINED(a,len)
 # define MEM_MAKE_DEFINED(a,len) __msan_unpoison(a,len)
 # define MEM_NOACCESS(a,len) ((void) 0)
@@ -46,6 +47,7 @@
 # include <valgrind/memcheck.h>
 # define HAVE_MEM_CHECK
 # define MEM_UNDEFINED(a,len) VALGRIND_MAKE_MEM_UNDEFINED(a,len)
+# define MEM_UNDEFINED_VALGRIND_ONLY(a, len) VALGRIND_MAKE_MEM_UNDEFINED(a,len)
 # define MEM_MAKE_ADDRESSABLE(a,len) MEM_UNDEFINED(a,len)
 # define MEM_MAKE_DEFINED(a,len) VALGRIND_MAKE_MEM_DEFINED(a,len)
 # define MEM_NOACCESS(a,len) VALGRIND_MAKE_MEM_NOACCESS(a,len)
@@ -60,6 +62,7 @@
 /* How to do manual poisoning:
 https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
 # define MEM_UNDEFINED(a,len) ((void) 0)
+# define MEM_UNDEFINED_VALGRIND_ONLY(a, len) ((void) 0)
 # define MEM_MAKE_ADDRESSABLE(a,len) ASAN_UNPOISON_MEMORY_REGION(a,len)
 # define MEM_MAKE_DEFINED(a,len) ((void) 0)
 # define MEM_NOACCESS(a,len) ASAN_POISON_MEMORY_REGION(a,len)
@@ -72,6 +75,7 @@ https://github.com/google/sanitizers/wiki/AddressSanitizerManualPoisoning */
 # define REDZONE_SIZE 8
 #else
 # define MEM_UNDEFINED(a,len) ((void) 0)
+# define MEM_UNDEFINED_VALGRIND_ONLY(a, len) ((void) 0)
 # define MEM_MAKE_ADDRESSABLE(a,len) ((void) 0)
 # define MEM_MAKE_DEFINED(a,len) ((void) 0)
 # define MEM_NOACCESS(a,len) ((void) 0)

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -90,7 +90,7 @@ public:
   static void wrong_param_count_error(const LEX_CSTRING &schema_name,
                                       const LEX_CSTRING &func_name);
 
-  table_map not_null_tables_cache= 0;
+  table_map not_null_tables_cache;
 
   enum Functype { UNKNOWN_FUNC,EQ_FUNC,EQUAL_FUNC,NE_FUNC,LT_FUNC,LE_FUNC,
 		  GE_FUNC,GT_FUNC,FT_FUNC,
@@ -132,24 +132,36 @@ public:
   {
     with_field= 0;
     with_param= 0;
+    not_null_tables_cache= 0;
+    MEM_UNDEFINED_VALGRIND_ONLY(&not_null_tables_cache,
+                                sizeof(not_null_tables_cache));
   }
   Item_func(THD *thd, Item *a)
    :Item_func_or_sum(thd, a), With_sum_func_cache(a)
   {
     with_param= a->with_param;
     with_field= a->with_field;
+    not_null_tables_cache= 0;
+    MEM_UNDEFINED_VALGRIND_ONLY(&not_null_tables_cache,
+                                sizeof(not_null_tables_cache));
   }
   Item_func(THD *thd, Item *a, Item *b)
    :Item_func_or_sum(thd, a, b), With_sum_func_cache(a, b)
   {
     with_param= a->with_param || b->with_param;
     with_field= a->with_field || b->with_field;
+    not_null_tables_cache= 0;
+    MEM_UNDEFINED_VALGRIND_ONLY(&not_null_tables_cache,
+                                sizeof(not_null_tables_cache));
   }
   Item_func(THD *thd, Item *a, Item *b, Item *c)
    :Item_func_or_sum(thd, a, b, c), With_sum_func_cache(a, b, c)
   {
     with_field= a->with_field || b->with_field || c->with_field;
     with_param= a->with_param || b->with_param || c->with_param;
+    not_null_tables_cache= 0;
+    MEM_UNDEFINED_VALGRIND_ONLY(&not_null_tables_cache,
+                                sizeof(not_null_tables_cache));
   }
   Item_func(THD *thd, Item *a, Item *b, Item *c, Item *d)
    :Item_func_or_sum(thd, a, b, c, d), With_sum_func_cache(a, b, c, d)
@@ -158,6 +170,9 @@ public:
                 c->with_field || d->with_field;
     with_param= a->with_param || b->with_param ||
                 c->with_param || d->with_param;
+    not_null_tables_cache= 0;
+    MEM_UNDEFINED_VALGRIND_ONLY(&not_null_tables_cache,
+                                sizeof(not_null_tables_cache));
   }
   Item_func(THD *thd, Item *a, Item *b, Item *c, Item *d, Item* e)
    :Item_func_or_sum(thd, a, b, c, d, e), With_sum_func_cache(a, b, c, d, e)
@@ -166,11 +181,17 @@ public:
                 c->with_field || d->with_field || e->with_field;
     with_param= a->with_param || b->with_param ||
                 c->with_param || d->with_param || e->with_param;
+    not_null_tables_cache= 0;
+    MEM_UNDEFINED_VALGRIND_ONLY(&not_null_tables_cache,
+                                sizeof(not_null_tables_cache));
   }
   Item_func(THD *thd, List<Item> &list):
     Item_func_or_sum(thd, list)
   {
     set_arguments(thd, list);
+    not_null_tables_cache= 0;
+    MEM_UNDEFINED_VALGRIND_ONLY(&not_null_tables_cache,
+                                sizeof(not_null_tables_cache));
   }
   // Constructor used for Item_cond_and/or (see Item comment)
   Item_func(THD *thd, Item_func *item)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33755*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Commit 09d991d01c47e22030879e5bf0c7a4893a598199 resolved false MSAN alarms by initializing `Item_func::not_null_tables_cache` with 0 during construction. However, this solution inadvertently disabled Valgrind diagnostics, which we want to retain to detect potential issues (e.g., failing to set not_null_tables_cache after calling Item_func::quick_fix_field()).

This commit introduces the macro `MEM_UNDEFINED_VALGRIND_ONLY`, enabling Valgrind diagnostic without triggering MSAN.
Now, Item_func::not_null_tables_cache is marked as undefined during construction using this macro

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

No need for special test cases, it's enough that all tests with Valgrind diagnostic enabled pass

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
