### PR TITLE
MDEV-34647 : 'INSERT...SELECT' on MyISAM table suddenly replicated by…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-34647.result
+++ b/mysql-test/suite/galera/r/MDEV-34647.result
@@ -1,0 +1,101 @@
+connection node_2;
+connection node_1;
+create table t1(id serial, val varchar(100)) engine=myisam;
+insert into t1 values(null, 'a');
+insert into t1 values(null, 'b');
+insert into t1 select null, 'c';
+insert into t1 select null, 'd' from t1;
+select * from t1;
+id	val
+1	a
+3	b
+5	c
+7	d
+9	d
+11	d
+create table t2(id serial, val varchar(100)) engine=aria;
+insert into t2 values(null, 'a');
+insert into t2 values(null, 'b');
+insert into t2 select null, 'c';
+insert into t2 select null, 'd' from t2;
+select * from t2;
+id	val
+1	a
+3	b
+5	c
+7	d
+9	d
+11	d
+create table t3(id serial, val varchar(100)) engine=innodb;
+insert into t3 values(null, 'a');
+insert into t3 values(null, 'b');
+insert into t3 select null, 'c';
+insert into t3 select null, 'd' from t3;
+select * from t3;
+id	val
+1	a
+3	b
+5	c
+7	d
+9	d
+11	d
+set global wsrep_mode='REPLICATE_MYISAM,REPLICATE_ARIA';
+create table t4(id serial, val varchar(100)) engine=myisam;
+insert into t4 values(null, 'a');
+insert into t4 values(null, 'b');
+insert into t4 select null, 'c';
+insert into t4 select null, 'd' from t4;
+select * from t4;
+id	val
+1	a
+2	b
+3	c
+4	d
+5	d
+6	d
+create table t5(id serial, val varchar(100)) engine=myisam;
+insert into t5 values(null, 'a');
+insert into t5 values(null, 'b');
+insert into t5 select null, 'c';
+insert into t5 select null, 'd' from t5;
+select * from t2;
+id	val
+1	a
+3	b
+5	c
+7	d
+9	d
+11	d
+connection node_2;
+select * from t1;
+id	val
+select * from t2;
+id	val
+select * from t3;
+id	val
+1	a
+3	b
+5	c
+7	d
+9	d
+11	d
+select * from t4;
+id	val
+1	a
+2	b
+3	c
+4	d
+5	d
+6	d
+select * from t5;
+id	val
+1	a
+2	b
+3	c
+4	d
+5	d
+6	d
+set global wsrep_mode=default;
+connection node_1;
+drop table t1,t2,t3,t4,t5;
+set global wsrep_mode=default;

--- a/mysql-test/suite/galera/r/mdev-22063.result
+++ b/mysql-test/suite/galera/r/mdev-22063.result
@@ -17,12 +17,14 @@ SELECT * FROM s;
 next_not_cached_value	minimum_value	maximum_value	start_value	increment	cache_size	cycle_option	cycle_count
 1	1	9223372036854775806	1	1	1000	0	0
 connection node_2;
+SET GLOBAL WSREP_MODE='REPLICATE_ARIA,REPLICATE_MYISAM';
 SELECT * FROM t1;
 a
 SELECT * FROM s;
 next_not_cached_value	minimum_value	maximum_value	start_value	increment	cache_size	cycle_option	cycle_count
 1	1	9223372036854775806	1	1	1000	0	0
 connection node_1;
+SET GLOBAL WSREP_MODE='REPLICATE_ARIA,REPLICATE_MYISAM';
 DROP TABLE t1;
 DROP SEQUENCE s;
 # Case 2 REPLACE INTO ... SELECT with error
@@ -238,4 +240,6 @@ pk
 5
 DROP TABLE t1;
 DROP VIEW view_t1;
+SET GLOBAL wsrep_mode=DEFAULT;
+connection node_2;
 SET GLOBAL wsrep_mode=DEFAULT;

--- a/mysql-test/suite/galera/t/MDEV-34647.test
+++ b/mysql-test/suite/galera/t/MDEV-34647.test
@@ -1,0 +1,52 @@
+--source include/galera_cluster.inc
+--source include/have_aria.inc
+
+create table t1(id serial, val varchar(100)) engine=myisam;
+insert into t1 values(null, 'a');
+insert into t1 values(null, 'b');
+insert into t1 select null, 'c';
+insert into t1 select null, 'd' from t1;
+select * from t1;
+
+create table t2(id serial, val varchar(100)) engine=aria;
+insert into t2 values(null, 'a');
+insert into t2 values(null, 'b');
+insert into t2 select null, 'c';
+insert into t2 select null, 'd' from t2;
+select * from t2;
+
+create table t3(id serial, val varchar(100)) engine=innodb;
+insert into t3 values(null, 'a');
+insert into t3 values(null, 'b');
+insert into t3 select null, 'c';
+insert into t3 select null, 'd' from t3;
+select * from t3;
+
+set global wsrep_mode='REPLICATE_MYISAM,REPLICATE_ARIA';
+
+create table t4(id serial, val varchar(100)) engine=myisam;
+insert into t4 values(null, 'a');
+insert into t4 values(null, 'b');
+insert into t4 select null, 'c';
+insert into t4 select null, 'd' from t4;
+select * from t4;
+
+create table t5(id serial, val varchar(100)) engine=myisam;
+insert into t5 values(null, 'a');
+insert into t5 values(null, 'b');
+insert into t5 select null, 'c';
+insert into t5 select null, 'd' from t5;
+select * from t2;
+
+
+--connection node_2
+select * from t1;
+select * from t2;
+select * from t3;
+select * from t4;
+select * from t5;
+set global wsrep_mode=default;
+
+--connection node_1
+drop table t1,t2,t3,t4,t5;
+set global wsrep_mode=default;

--- a/mysql-test/suite/galera/t/mdev-22063.test
+++ b/mysql-test/suite/galera/t/mdev-22063.test
@@ -16,6 +16,7 @@ SELECT * FROM t1;
 SELECT * FROM s;
 
 --connection node_2
+SET GLOBAL WSREP_MODE='REPLICATE_ARIA,REPLICATE_MYISAM';
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
 --source include/wait_condition.inc
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 's'
@@ -27,6 +28,7 @@ SELECT * FROM t1;
 SELECT * FROM s;
 
 --connection node_1
+SET GLOBAL WSREP_MODE='REPLICATE_ARIA,REPLICATE_MYISAM';
 DROP TABLE t1;
 DROP SEQUENCE s;
 
@@ -181,4 +183,10 @@ INSERT INTO view_t1 VALUES (5);
 SELECT * FROM t1;
 DROP TABLE t1;
 DROP VIEW view_t1;
+SET GLOBAL wsrep_mode=DEFAULT;
+
+--connection node_1
+SET GLOBAL wsrep_mode=DEFAULT;
+
+--connection node_2
 SET GLOBAL wsrep_mode=DEFAULT;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4719,7 +4719,16 @@ mysql_execute_command(THD *thd, bool is_called_from_prepared_stmt)
 
         // For !InnoDB we start TOI if it is not yet started and hope for the best
         if (!is_innodb && !wsrep_toi)
-          WSREP_TO_ISOLATION_BEGIN(first_table->db.str, first_table->table_name.str, NULL);
+        {
+          const legacy_db_type db_type= first_table->table->file->partition_ht()->db_type;
+          const bool replicate=
+            ((db_type == DB_TYPE_MYISAM && wsrep_check_mode(WSREP_MODE_REPLICATE_MYISAM)) ||
+             (db_type == DB_TYPE_ARIA && wsrep_check_mode(WSREP_MODE_REPLICATE_ARIA)));
+
+          /* Currently we support TOI for MyISAM and Aria only. */
+          if (replicate)
+            WSREP_TO_ISOLATION_BEGIN(first_table->db.str, first_table->table_name.str, NULL);
+        }
       }
 #endif /* WITH_WSREP */
       /*


### PR DESCRIPTION
… Galera


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34647*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Replication of MyISAM and Aria DML is experimental and best effort only. Earlier change make INSERT SELECT on both MyISAM and Aria to replicate using TOI and STATEMENT replication. Replication should happen only if user has set needed wsrep_mode setting.


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
