### PR TITLE
MDEV-34565: SIGILL due to OS not supporting AVX512

### DIFF
--- a/mysys/crc32/crc32c_x86.cc
+++ b/mysys/crc32/crc32c_x86.cc
@@ -28,7 +28,8 @@
 # elif __GNUC__ >= 14 || (defined __clang_major__ && __clang_major__ >= 18)
 #  define TARGET "pclmul,evex512,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"
 #  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
-# elif __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 8)
+# elif __GNUC__ >= 11 || (defined __clang_major__ && __clang_major__ >= 9)
+/* clang 8 does not support _xgetbv(), which we also need */
 #  define TARGET "pclmul,avx512f,avx512dq,avx512bw,avx512vl,vpclmulqdq"
 #  define USE_VPCLMULQDQ __attribute__((target(TARGET)))
 # endif
@@ -38,6 +39,7 @@ extern "C" unsigned crc32c_sse42(unsigned crc, const void* buf, size_t size);
 
 constexpr uint32_t cpuid_ecx_SSE42= 1U << 20;
 constexpr uint32_t cpuid_ecx_SSE42_AND_PCLMUL= cpuid_ecx_SSE42 | 1U << 1;
+constexpr uint32_t cpuid_ecx_XSAVE= 1U << 26;
 
 static uint32_t cpuid_ecx()
 {
@@ -382,8 +384,19 @@ static unsigned crc32_avx512(unsigned crc, const char *buf, size_t size,
   }
 }
 
-static ATTRIBUTE_NOINLINE int have_vpclmulqdq()
+#ifdef __GNUC__
+__attribute__((target("xsave")))
+#endif
+static bool os_have_avx512()
 {
+  // The following flags must be set: SSE, AVX, OPMASK, ZMM_HI256, HI16_ZMM
+  return !(~_xgetbv(0 /*_XCR_XFEATURE_ENABLED_MASK*/) & 0xe6);
+}
+
+static ATTRIBUTE_NOINLINE bool have_vpclmulqdq(uint32_t cpuid_ecx)
+{
+  if (!(cpuid_ecx & cpuid_ecx_XSAVE) || !os_have_avx512())
+    return false;
 # ifdef _MSC_VER
   int regs[4];
   __cpuidex(regs, 7, 0);
@@ -410,10 +423,11 @@ static unsigned crc32c_vpclmulqdq(unsigned crc, const void *buf, size_t size)
 
 extern "C" my_crc32_t crc32_pclmul_enabled(void)
 {
-  if (~cpuid_ecx() & cpuid_ecx_SSE42_AND_PCLMUL)
+  const uint32_t ecx= cpuid_ecx();
+  if (~ecx & cpuid_ecx_SSE42_AND_PCLMUL)
     return nullptr;
 #ifdef USE_VPCLMULQDQ
-  if (have_vpclmulqdq())
+  if (have_vpclmulqdq(ecx))
     return crc32_vpclmulqdq;
 #endif
   return crc32_pclmul;
@@ -421,19 +435,20 @@ extern "C" my_crc32_t crc32_pclmul_enabled(void)
 
 extern "C" my_crc32_t crc32c_x86_available(void)
 {
+  const uint32_t ecx= cpuid_ecx();
 #ifdef USE_VPCLMULQDQ
-  if (have_vpclmulqdq())
+  if (have_vpclmulqdq(ecx))
     return crc32c_vpclmulqdq;
 #endif
 #if SIZEOF_SIZE_T == 8
-  switch (cpuid_ecx() & cpuid_ecx_SSE42_AND_PCLMUL) {
+  switch (ecx & cpuid_ecx_SSE42_AND_PCLMUL) {
   case cpuid_ecx_SSE42_AND_PCLMUL:
     return crc32c_3way;
   case cpuid_ecx_SSE42:
     return crc32c_sse42;
   }
 #else
-  if (cpuid_ecx() & cpuid_ecx_SSE42)
+  if (ecx & cpuid_ecx_SSE42)
     return crc32c_sse42;
 #endif
   return nullptr;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34565*
## Description
It is not sufficient to check that the CPU supports the necessary instructions. Also the operating system (or virtual machine hypervisor) must enable all the AVX registers to be saved and restored on a context switch.

Because clang 8 does not support the compiler intrinsic `_xgetbv()` we will require clang 9 or later for enabling the use of `vpclmulqdq` and the related AVX512 features.
## Release Notes
MariaDB Server would catch SIGILL on a system where the CPU but not the operating system supports AVX-512.
## How can this PR be tested?
`InnoDB: Using AVX512 instructions` should continue to be reported on the `amd64-debian-11-msan` builder.

Unfortunately, I do not have the ability to change the boot parameters of an environment to test that `_xgetbv()` would prevent the use of AVX512 instructions when the operating system does not enable saving and restoring the registers.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.