### PR TITLE
MDEV-34458: Remove more traces of BTR_MODIFY_PREV

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1301,11 +1301,9 @@ dberr_t btr_cur_t::search_leaf(const dtuple_t *tuple, page_cur_mode_t mode,
     }
 
     switch (latch_mode) {
-    case BTR_SEARCH_PREV:
-      static_assert(BTR_SEARCH_PREV & BTR_SEARCH_LEAF, "");
+    case BTR_SEARCH_PREV: /* btr_pcur_move_to_prev() */
       ut_ad(!latch_by_caller);
-      ut_ad(rw_latch ==
-            rw_lock_type_t(latch_mode & (RW_X_LATCH | RW_S_LATCH)));
+      ut_ad(rw_latch == RW_S_LATCH);
 
       /* latch also siblings from left to right */
       if (page_has_prev(block->page.frame) &&
@@ -1479,7 +1477,7 @@ release_tree:
       rw_latch= RW_X_LATCH;
       break;
     case BTR_SEARCH_PREV: /* btr_pcur_move_to_prev() */
-      ut_ad(rw_latch == RW_S_LATCH || rw_latch == RW_X_LATCH);
+      ut_ad(rw_latch == RW_S_LATCH);
 
       if (!not_first_access)
         buf_read_ahead_linear(page_id, zip_size);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34458*
## Description
In commit 2f6df9374806665db0764c74187a384b562b150a we fixed the bug by removing some code related to the no longer needed `BTR_MODIFY_PREV` mode.
In commit 73ad436e16c3ac022a2f1c477eac0e9a7e702707 an alternative fix was applied that also fixes the `BTR_SEARCH_PREV` case.

Let us clean up some implicit references to `BTR_MODIFY_PREV` that were missed in 2f6df9374806665db0764c74187a384b562b150a.

`btr_pcur_move_backward_from_page()`: Assume that the latch mode was `BTR_SEARCH_LEAF`.

`btr_pcur_move_to_prev()`: Assert that the latch mode is `BTR_SEARCH_LEAF`. This function is mostly invoked in `row0sel.cc` for read operations, as well as in `row0merge.cc` for reading from the clustered index. All callers indeed use a cursor in the `BTR_SEARCH_LEAF` mode.
## Release Notes
This code cleanup does not need to be mentioned in release notes.
## How can this PR be tested?
These low level operations are well covered by the regression test suite. The function `btr_pcur_move_backward_from_page()` may not be covered, but its caller `btr_pcur_move_to_prev()` definitely is.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.