### PR TITLE
MDEV-34422 InnoDB writes corrupted log on macOS and AIX due to uninitialized log_sys.lsn_lock

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -132,6 +132,7 @@ bool log_t::create()
 #endif
 
   latch.SRW_LOCK_INIT(log_latch_key);
+  lsn_lock.init();
 
   last_checkpoint_lsn= FIRST_LSN;
   log_capacity= 0;
@@ -1330,6 +1331,7 @@ void log_t::close()
 #endif
 
   latch.destroy();
+  lsn_lock.destroy();
 
   recv_sys.close();
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34422*
## Description
On systems where `log_sys.lsn_lock` is not based on a `futex` like system call but the `pthread_mutex_wrapper`, we must invoke `lsn_lock.init()` to avoid a corrupted `ib_logfile0` due to race conditions on writes to `log_sys.buf`.
## Release Notes
On Apple macOS, IBM AIX, Solaris derivatives and some other platforms, InnoDB would corrupt its `ib_logfile0`, which would not only break crash recovery and `mariadb-backup --backup` but often prevent a normal restart as well.
## How can this PR be tested?
Without this fix, the test suite on our CI would fail very early on Apple macOS as well as IBM AIX, as well as on Microsoft Windows if we unconditionally enabled `SUX_LOCK_GENERIC` (disabled the futex-like system calls).
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.