### PR TITLE
MDEV-34605 Fix tmp_table_count-7586

### DIFF
--- a/mysql-test/main/tmp_table_count-7586.result
+++ b/mysql-test/main/tmp_table_count-7586.result
@@ -7,10 +7,8 @@ a
 1
 2
 3
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 Variable_name	Value
-Created_tmp_disk_tables	0
-Created_tmp_files	0
 Created_tmp_tables	0
 explain select * from v2;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -20,10 +18,8 @@ a
 1
 2
 3
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 Variable_name	Value
-Created_tmp_disk_tables	0
-Created_tmp_files	0
 Created_tmp_tables	0
 explain select * from (select * from t2) T1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
@@ -46,10 +42,8 @@ CREATE TABLE t3 SELECT * FROM t1 WHERE a IN (SELECT * FROM t2 GROUP BY a HAVING 
 select sum(created_tmp_tables) from performance_schema.events_statements_history_long;
 sum(created_tmp_tables)
 2
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 Variable_name	Value
-Created_tmp_disk_tables	0
-Created_tmp_files	0
 Created_tmp_tables	2
 drop table t3;
 set @@optimizer_switch="firstmatch=off";
@@ -65,10 +59,8 @@ CREATE TABLE t3 SELECT * FROM t1 WHERE a IN (SELECT * FROM t2 GROUP BY a);
 select sum(created_tmp_tables) from performance_schema.events_statements_history_long;
 sum(created_tmp_tables)
 1
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 Variable_name	Value
-Created_tmp_disk_tables	0
-Created_tmp_files	0
 Created_tmp_tables	1
 set @@optimizer_switch=default;
 drop table t1,t2,t3;
@@ -78,8 +70,6 @@ flush status;
 select sum(created_tmp_tables) from performance_schema.events_statements_history_long;
 sum(created_tmp_tables)
 0
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 Variable_name	Value
-Created_tmp_disk_tables	0
-Created_tmp_files	0
 Created_tmp_tables	0

--- a/mysql-test/main/tmp_table_count-7586.test
+++ b/mysql-test/main/tmp_table_count-7586.test
@@ -14,14 +14,14 @@ create view v2 as select a from t2;
 flush status;
 select * from v2;
 --disable_ps_protocol
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 --enable_ps_protocol
 
 explain select * from v2;
 
 select * from (select * from t2) T1;
 --disable_ps_protocol
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 --enable_ps_protocol
 
 explain select * from (select * from t2) T1;
@@ -44,7 +44,7 @@ flush status;
 CREATE TABLE t3 SELECT * FROM t1 WHERE a IN (SELECT * FROM t2 GROUP BY a HAVING a > 1);
 --echo # Performance schema should be the same as "Created_tmp_tables" variable below
 select sum(created_tmp_tables) from performance_schema.events_statements_history_long;
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 drop table t3;
 
 set @@optimizer_switch="firstmatch=off";
@@ -54,7 +54,7 @@ flush status;
 CREATE TABLE t3 SELECT * FROM t1 WHERE a IN (SELECT * FROM t2 GROUP BY a);
 --echo # Performance schema should be the same as "Created_tmp_tables" variable below
 select sum(created_tmp_tables) from performance_schema.events_statements_history_long;
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';
 set @@optimizer_switch=default;
 
 drop table t1,t2,t3;
@@ -63,4 +63,4 @@ truncate table performance_schema.events_statements_history_long;
 flush status;
 --echo # Performance schema should be the same as "Created_tmp_tables" variable below
 select sum(created_tmp_tables) from performance_schema.events_statements_history_long;
-show status like '%Created_tmp%';
+show status like '%Created_tmp_tables%';


### PR DESCRIPTION
This test ran `show status like '%Created_tmp%'`. This captures `Created_tmp_files` as well as the intended `Created_tmp_tables`. In 11.5, the former got moved to `FLUSH GLOBAL`, so when testing, the result can now be random.

This fix makes the test just use `Created_tmp_tables`.

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34605*

## How can this PR be tested?

Run a multi-threaded MTR, `amd64-fedora-38-last-N-failed` should now pass in BuildBot.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*