### PR TITLE
MDEV-32363 Shut down Galera networking and logging on fatal signal

### DIFF
--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -25,6 +25,10 @@
 #include "my_stacktrace.h"
 #include <source_revision.h>
 
+#ifdef WITH_WSREP
+#include "wsrep_server_state.h"
+#endif /* WITH_WSREP */
+
 #ifdef __WIN__
 #include <crtdbg.h>
 #include <direct.h>
@@ -220,6 +224,10 @@ extern "C" sig_handler handle_fatal_signal(int sig)
                           "Hope that's ok; if not, decrease some variables in "
                           "the equation.\n\n");
   }
+
+#ifdef WITH_WSREP
+  Wsrep_server_state::handle_fatal_signal();
+#endif /* WITH_WSREP */
 
 #ifdef HAVE_STACKTRACE
   thd= current_thd;

--- a/sql/wsrep_server_service.cc
+++ b/sql/wsrep_server_service.cc
@@ -161,9 +161,16 @@ void Wsrep_server_service::bootstrap()
   wsrep_set_SE_checkpoint(wsrep::gtid::undefined(), wsrep_gtid_server.undefined());
 }
 
+static std::atomic<bool> suppress_logging{false};
+void wsrep_suppress_error_logging() { suppress_logging= true; }
+
 void Wsrep_server_service::log_message(enum wsrep::log::level level,
-                                       const char* message)
+                                       const char *message)
 {
+  if (suppress_logging.load(std::memory_order_relaxed))
+  {
+    return;
+  }
   switch (level)
   {
   case wsrep::log::debug:

--- a/sql/wsrep_server_service.h
+++ b/sql/wsrep_server_service.h
@@ -99,4 +99,8 @@ class Wsrep_storage_service;
 Wsrep_storage_service*
 wsrep_create_storage_service(THD *orig_thd, const char *ctx);
 
+/**
+   Suppress all error logging from wsrep/Galera library.
+ */
+void wsrep_suppress_error_logging();
 #endif /* WSREP_SERVER_SERVICE */

--- a/sql/wsrep_server_state.cc
+++ b/sql/wsrep_server_state.cc
@@ -18,6 +18,8 @@
 #include "wsrep_server_state.h"
 #include "wsrep_binlog.h" /* init/deinit group commit */
 
+#include "my_stacktrace.h" /* my_safe_printf_stderr() */
+
 mysql_mutex_t LOCK_wsrep_server_state;
 mysql_cond_t  COND_wsrep_server_state;
 
@@ -80,5 +82,26 @@ void Wsrep_server_state::destroy()
     m_instance= 0;
     mysql_mutex_destroy(&LOCK_wsrep_server_state);
     mysql_cond_destroy(&COND_wsrep_server_state);
+  }
+}
+
+void Wsrep_server_state::handle_fatal_signal()
+{
+  if (m_instance)
+  {
+    /* Galera background threads are still running and the logging may be
+       relatively verbose in case of networking error. Silence all wsrep
+       logging before shutting down networking to avoid garbling signal
+       handler output. */
+    my_safe_printf_stderr("WSREP: Suppressing further logging\n");
+    wsrep_suppress_error_logging();
+
+    /* Shut down all communication with other nodes to fail silently. */
+    my_safe_printf_stderr("WSREP: Shutting down network communications\n");
+    if (m_instance->provider().set_node_isolation(
+          wsrep::provider::node_isolation::isolated)) {
+      my_safe_printf_stderr("WSREP: Galera library does not support node isolation\n");
+    }
+    my_safe_printf_stderr("\n");
   }
 }

--- a/sql/wsrep_server_state.h
+++ b/sql/wsrep_server_state.h
@@ -56,6 +56,8 @@ public:
     return (get_provider().capabilities() & capability);
   }
 
+  static void handle_fatal_signal();
+
 private:
   Wsrep_server_state(const std::string& name,
                      const std::string& incoming_address,


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32363*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

When handling fatal signal, shut down Galera networking before printing out stack trace and writing core file. This is to achieve fail-silent semantics on crashes which may keep the process running for a long time, but not fully responding e.g. due to core dumping or symbol resolving.

Also suppress all Galera/wsrep logging to avoid logging from background threads to garble crash information from signal handler.

Notice that for fully fail-silent crash, Galera 26.4.19 is needed.

## How can this PR be tested?

Deterministic test case does not exist. In order to test, start a 3 node cluster and kill one of the nodes by `kill -SIGABRT`. Observe that the killed node logs 
```
WSREP: Suppressing further logging
WSREP: Shutting down network communications
```
before printing out stacktrace. Other nodes should report lost connection almost immediately.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
