### PR TITLE
MDEV-34670 IMPORT TABLESPACE unnecessarily traverses tablespace list

### DIFF
--- a/mysql-test/suite/encryption/r/innodb_encryption_discard_import.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_discard_import.result
@@ -1,3 +1,5 @@
+SET @start_encr_threads = @@global.innodb_encryption_threads;
+SET @start_encrypt_tables = @@global.innodb_encrypt_tables;
 CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB encrypted=yes;
 CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
 CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB row_format=compressed encrypted=yes;
@@ -116,3 +118,42 @@ NOT FOUND /temp/ in t2.ibd
 # t3 ... on expecting NOT FOUND
 UNLOCK TABLES;
 DROP TABLE t1, t2, t3;
+#
+# MDEV-34670 IMPORT TABLESPACE unnecessary traverses
+# 		tablespace list
+#
+SET GLOBAL innodb_encrypt_tables= OFF;
+SET GLOBAL innodb_encryption_threads= 0;
+CREATE TABLE t1(f1 int,f2 text)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, "InnoDB");
+CREATE TABLE t2 LIKE t1;
+ALTER TABLE t2 DISCARD TABLESPACE;
+FLUSH TABLES t1 FOR EXPORT;
+UNLOCK TABLES;
+ALTER TABLE t2 IMPORT TABLESPACE;
+SET GLOBAL innodb_encryption_threads=2;
+SET GLOBAL innodb_encrypt_tables = ON;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+NAME
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+NAME
+innodb_system
+test/t1
+test/t2
+SET GLOBAL innodb_encrypt_tables = OFF;
+# Wait max 10 min for key encryption threads to decrypt all spaces
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+NAME
+innodb_system
+test/t1
+test/t2
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+NAME
+DROP TABLE t1, t2;
+SET GLOBAL innodb_encryption_threads=@start_encr_threads;
+SET GLOBAL innodb_encrypt_tables=@start_encrypt_tables;

--- a/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
@@ -2,7 +2,8 @@
 -- source include/have_example_key_management_plugin.inc
 -- source include/not_valgrind.inc
 -- source include/not_embedded.inc
-
+SET @start_encr_threads = @@global.innodb_encryption_threads;
+SET @start_encrypt_tables = @@global.innodb_encrypt_tables;
 let MYSQLD_DATADIR = `SELECT @@datadir`;
 
 --let SEARCH_RANGE = 10000000
@@ -124,3 +125,56 @@ FLUSH TABLES t1, t2, t3 FOR EXPORT;
 UNLOCK TABLES;
 
 DROP TABLE t1, t2, t3;
+
+--echo #
+--echo # MDEV-34670 IMPORT TABLESPACE unnecessary traverses
+--echo # 		tablespace list
+--echo #
+SET GLOBAL innodb_encrypt_tables= OFF;
+SET GLOBAL innodb_encryption_threads= 0;
+
+CREATE TABLE t1(f1 int,f2 text)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, "InnoDB");
+CREATE TABLE t2 LIKE t1;
+ALTER TABLE t2 DISCARD TABLESPACE;
+FLUSH TABLES t1 FOR EXPORT;
+--copy_file $MYSQLD_DATADIR/test/t1.cfg $MYSQLD_DATADIR/test/t2.cfg
+--copy_file $MYSQLD_DATADIR/test/t1.ibd $MYSQLD_DATADIR/test/t2.ibd
+UNLOCK TABLES;
+ALTER TABLE t2 IMPORT TABLESPACE;
+
+SET GLOBAL innodb_encryption_threads=2;
+SET GLOBAL innodb_encrypt_tables = ON;
+
+--let $tables_count= `select count(*) + @@global.innodb_undo_tablespaces + 1 from information_schema.tables where engine = 'InnoDB'`
+
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) >= $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
+--source include/wait_condition.inc
+
+--sorted_result
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+--sorted_result
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+
+SET GLOBAL innodb_encrypt_tables = OFF;
+
+--echo # Wait max 10 min for key encryption threads to decrypt all spaces
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
+--source include/wait_condition.inc
+
+--sorted_result
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+
+--sorted_result
+SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+AND NAME NOT LIKE 'innodb_undo%' AND NAME NOT LIKE 'mysql/innodb_%_stats' AND NAME NOT LIKE 'mysql/transaction_registry';
+
+DROP TABLE t1, t2;
+SET GLOBAL innodb_encryption_threads=@start_encr_threads;
+SET GLOBAL innodb_encrypt_tables=@start_encrypt_tables;

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -1461,6 +1461,8 @@ inline bool fil_space_t::acquire_if_not_stopped()
 
 bool fil_crypt_must_default_encrypt()
 {
+  /* prevents a race condition with fil_crypt_set_rotate_key_age() */
+  ut_ad(mutex_own(&fil_system.mutex));
   return !srv_fil_crypt_rotate_key_age || !srv_encrypt_rotate;
 }
 
@@ -2362,6 +2364,24 @@ fil_crypt_set_rotation_iops(
 {
 	srv_n_fil_crypt_iops = val;
 	os_event_set(fil_crypt_threads_event);
+}
+
+/** Add the import tablespace to default_encrypt list
+if necessary and signal fil_crypt_threads
+@param space imported tablespace */
+void fil_crypt_add_imported_space(fil_space_t *space)
+{
+  mutex_enter(&fil_system.mutex);
+
+  if (fil_crypt_must_default_encrypt())
+  {
+    fil_system.default_encrypt_tables.push_back(*space);
+    space->is_in_default_encrypt= true;
+  }
+
+  mutex_exit(&fil_system.mutex);
+
+  os_event_set(fil_crypt_threads_event);
 }
 
 /*********************************************************************

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -13286,7 +13286,7 @@ ha_innobase::discard_or_import_tablespace(
 			     | HA_STATUS_VARIABLE
 			     | HA_STATUS_AUTO);
 
-			fil_crypt_set_encrypt_tables(srv_encrypt_tables);
+			fil_crypt_add_imported_space(m_prebuilt->table->space);
 		}
 	}
 

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -383,6 +383,11 @@ void
 fil_crypt_set_rotation_iops(
 	uint val);
 
+/** Add the import tablespace to default_encrypt list
+if necessary and signal fil_crypt_threads
+@param space imported tablespace */
+void fil_crypt_add_imported_space(fil_space_t *space);
+
 /*********************************************************************
 Adjust encrypt tables
 @param[in]	val		New setting for innodb-encrypt-tables */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV- 34670 *

## Description
Problem:
========
- After the commit ada1074bb10359342ee00e220fe9c172574265fb (MDEV-14398) fil_crypt_set_encrypt_tables() iterates through all tablespaces to fill the default_encrypt tables list. This was a trigger to encrypt or decrypt when key rotation age is set to 0. But import tablespace does call fil_crypt_set_encrypt_tables() unnecessarily. The motivation for the call is to signal the encryption threads.

Fix:
====
ha_innobase::discard_or_import_tablespace: Remove the fil_crypt_set_encrypt_tables() and add the import tablespace to the default encrypt list if necessary


## How can this PR be tested?
```
--source include/have_innodb.inc
--source include/have_partition.inc

CREATE TABLE t1 (c1 CHAR(1) ,c2 INT) ENGINE=INNODB
                PARTITION BY LINEAR HASH ((c2)) PARTITIONS 8192;
CREATE TABLE t2(f1 INT, f2 INT)ENGINE=InnoDB;
CREATE TABLE t2_imp like t2;
ALTER TABLE t2_imp DISCARD TABLESPACE;
FLUSH TABLE t2 FOR EXPORT;
let $datadir=`select @@datadir`;
--copy_file $datadir/test/t2.ibd $datadir/test/t2_imp.ibd
--copy_file $datadir/test/t2.cfg $datadir/test/t2_imp.cfg
UNLOCK TABLES;
ALTER TABLE t2_imp IMPORT TABLESPACE;
DROP TABLE t2, t2_imp, t1;
```
./mtr encryption.innodb_encryption_discard_import

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
