### PR TITLE
MDEV-34678 pthread_mutex_init() without pthread_mutex_destroy()

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -842,6 +842,7 @@ buf_block_init(buf_block_t* block, byte* frame)
 	MEM_MAKE_DEFINED(&block->modify_clock, sizeof block->modify_clock);
 	ut_ad(!block->modify_clock);
 	MEM_MAKE_DEFINED(&block->page.lock, sizeof block->page.lock);
+	block->page.lock.init();
 	block->page.init(buf_page_t::NOT_USED, page_id_t(~0ULL));
 #ifdef BTR_CUR_HASH_ADAPT
 	MEM_MAKE_DEFINED(&block->index, sizeof block->index);

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -212,6 +212,7 @@ static buf_page_t* buf_page_init_for_read(ulint mode, const page_id_t page_id,
     page_zip_set_size(&bpage->zip, zip_size);
     bpage->zip.data = (page_zip_t*) data;
 
+    bpage->lock.init();
     bpage->init(buf_page_t::READ_FIX, page_id);
     bpage->lock.x_lock(true);
 

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -648,10 +648,10 @@ public:
   void init(uint32_t state, page_id_t id)
   {
     ut_ad(state < REMOVE_HASH || state >= UNFIXED);
+    ut_ad(!lock.is_locked_or_waiting());
     id_= id;
     zip.fix= state;
     oldest_modification_= 0;
-    lock.init();
     ut_d(in_zip_hash= false);
     ut_d(in_free_list= false);
     ut_d(in_LRU_list= false);

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -3212,6 +3212,7 @@ static void add_fts_index(dict_table_t *table)
 {
   dict_index_t *fts_index= dict_mem_index_create(
     table, FTS_DOC_ID_INDEX_NAME, DICT_UNIQUE, 2);
+  fts_index->lock.SRW_LOCK_INIT(index_tree_rw_lock_key);
   fts_index->page= FIL_NULL;
   fts_index->cached= 1;
   fts_index->n_uniq= 1;
@@ -3293,6 +3294,7 @@ static dict_table_t *build_fts_hidden_table(
       new_table, old_index->name, old_index->type,
       old_index->n_fields + is_clustered);
 
+    new_index->lock.SRW_LOCK_INIT(index_tree_rw_lock_key);
     new_index->id= old_index->id;
     new_index->n_uniq= old_index->n_uniq;
     new_index->type= old_index->type;

--- a/storage/innobase/sync/srw_lock.cc
+++ b/storage/innobase/sync/srw_lock.cc
@@ -661,6 +661,7 @@ void srw_lock_debug::destroy()
     ut_ad(r->empty());
     delete r;
   }
+  readers_lock.destroy();
   srw_lock::destroy();
 }
 

--- a/storage/innobase/trx/trx0rseg.cc
+++ b/storage/innobase/trx/trx0rseg.cc
@@ -631,6 +631,7 @@ dberr_t trx_rseg_array_init()
 				sys, rseg_id);
 			if (page_no != FIL_NULL) {
 				trx_rseg_t& rseg = trx_sys.rseg_array[rseg_id];
+				rseg.destroy();
 				rseg.init(fil_space_get(
 						  trx_sysf_rseg_get_space(
 							  sys, rseg_id)),
@@ -715,6 +716,7 @@ dberr_t trx_temp_rseg_create(mtr_t *mtr)
       mtr->commit();
       return err;
     }
+    trx_sys.temp_rsegs[i].destroy();
     trx_sys.temp_rsegs[i].init(fil_system.temp_space,
                                rblock->page.id().page_no());
     mtr->commit();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34678*
## Description
When `SUX_LOCK_GENERIC` is defined, the `srw_mutex`, `srw_lock`, `sux_lock` are implemented based on `pthread_mutex_t` and `pthread_cond_t`.  This is the only option for systems that lack a `futex`-like system call.

In the `SUX_LOCK_GENERIC` mode, if `pthread_mutex_init()` is allocating some resources that need to be freed by `pthread_mutex_destroy()`, a memory leak could occur when we are repeatedly invoking `pthread_mutex_init()` without a `pthread_mutex_destroy()` in between.

`pthread_mutex_wrapper::initialized`: A debug field to track whether `pthread_mutex_init()` has been invoked.  This also helps find bugs like the one that was fixed by commit 1c8af2ae53a3a48d64b4167d21b20ff5e1caef36 (MDEV-34422); one simply needs to add `-DSUX_LOCK_GENERIC` to the CMAKE_CXX_FLAGS to catch that particular bug on the initial server bootstrap.

`buf_block_init()`, `buf_page_init_for_read()`: Invoke `block_lock::init()` because `buf_page_t::init()` will no longer do that.

`buf_page_t::init()`: Instead of invoking `lock.init()`, assert that it has already been invoked (the lock is vacant).

`add_fts_index()`, `build_fts_hidden_table()`: Explicitly invoke `index_lock::init()` in order to avoid a `pthread_mutex_destroy()` invocation on an uninitialized object.

`srw_lock_debug::destroy()`: Invoke `readers_lock.destroy()`.

`trx_sys_t::create()`: Invoke `trx_rseg_t::init()` on all rollback segments in order to guarantee a deterministic state for shutdown, even if InnoDB fails to start up.

`trx_rseg_array_init()`, `trx_temp_rseg_create()`, `trx_rseg_create()`: Invoke `trx_rseg_t::destroy()` before `trx_rseg_t::init()` in order to balance `pthread_mutex_init()` and `pthread_mutex_destroy()` calls.
## Release Notes
On operating systems that lack a `futex`-like system call (such as macOS, AIX, Solaris), memory could be leaked as a result of repeated calls to `pthread_mutex_init()` without a call to `pthread_mutex_destroy()` in between.
## How can this PR be tested?
If the system does support a `futex` like system call (Linux, Windows, FreeBSD, OpenBSD, NetBSD, Dragonfly BSD), add `-DSUX_LOCK_GENERIC` to the `CMAKE_CXX_FLAGS` so that this fallback code will be used.

The default `./mtr` regression test suites should pass. I tested it on Debian GNU/Linux with both `-DPLUGIN_PERFSCHEMA=NO` and  `-DPLUGIN_PERFSCHEMA=STATIC`.

I tested this also on 10.11 cc8eefb0dca1372378905fbae11044f20364c42d (right before the #3433 fix) and got an assertion failure on server bootstrap, as expected, for both "fake PMEM" on `/dev/shm` and on the `pwrite` based log writes:
```
mariadbd: /mariadb/10.11/storage/innobase/include/srw_lock.h:64: void pthread_mutex_wrapper<spinloop>::wr_lock() [with bool spinloop = false]: Assertion `initialized' failed.
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.