### PR TITLE
MDEV-32782 : galera_sst_mysqldump_with_key test failed

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -16,5 +16,4 @@ galera_sequences : MDEV-32561 WSREP FSM failure: no such a transition REPLICATIN
 galera_concurrent_ctas : MDEV-32779 galera_concurrent_ctas: assertion in the galera::ReplicatorSMM::finish_cert()
 galera_as_slave_replay : MDEV-32780 galera_as_slave_replay: assertion in the wsrep::transaction::before_rollback()
 galera_slave_replay : MDEV-32780 galera_as_slave_replay: assertion in the wsrep::transaction::before_rollback()
-galera_sst_mysqldump_with_key : MDEV-32782 galera_sst_mysqldump_with_key test failed
 galera_var_ignore_apply_errors : MENT-1997 galera_var_ignore_apply_errors test freezes

--- a/mysql-test/suite/galera/t/galera_sst_mysqldump_with_key.cnf
+++ b/mysql-test/suite/galera/t/galera_sst_mysqldump_with_key.cnf
@@ -3,6 +3,11 @@
 # We do not set mysqldump-related SST options here because doing so on startup
 # causes the first MTR connection to be forefully dropped by Galera, which in turn confuses MTR
 
+[mysqld]
+wsrep-debug=1
+wsrep-sync_wait=15
+loose-galera_sst_mysqldump_with_key=1
+
 [mysqld.1]
 wsrep_provider_options='base_port=@mysqld.1.#galera_port;gcache.size=1;pc.ignore_sb=true'
 

--- a/mysql-test/suite/galera/t/galera_sst_mysqldump_with_key.test
+++ b/mysql-test/suite/galera/t/galera_sst_mysqldump_with_key.test
@@ -6,6 +6,7 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
 --source include/have_ssl_communication.inc
+--source include/force_restart.inc
 
 --source suite/galera/include/galera_sst_set_mysqldump.inc
 --let $node_1=node_1


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32782*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Modified config to use wsrep_sync_wait to make sure committed transactions are replicated before next
operation.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
