### PR TITLE
MDEV-29010	Table cannot be loaded after instant ALTER

### DIFF
--- a/mysql-test/suite/innodb/r/instant_alter_bugs.result
+++ b/mysql-test/suite/innodb/r/instant_alter_bugs.result
@@ -521,3 +521,12 @@ COUNT(*)
 1
 DROP TABLE t1;
 # End of 10.4 tests
+#
+#  MDEV-29010  Table cannot be loaded after instant ALTER
+#
+CREATE TABLE t1 (a CHAR(255), b INT,
+c INT as (b) VIRTUAL)ENGINE=InnoDB CHARACTER SET utf32;
+ALTER TABLE t1 DROP COLUMN a;
+ALTER TABLE t1 DROP COLUMN c;
+DROP TABLE t1;
+# End of 10.5 tests

--- a/mysql-test/suite/innodb/t/instant_alter_bugs.test
+++ b/mysql-test/suite/innodb/t/instant_alter_bugs.test
@@ -553,3 +553,14 @@ SELECT COUNT(*) FROM t1;
 DROP TABLE t1;
 
 --echo # End of 10.4 tests
+
+--echo #
+--echo #  MDEV-29010  Table cannot be loaded after instant ALTER
+--echo #
+CREATE TABLE t1 (a CHAR(255), b INT,
+		 c INT as (b) VIRTUAL)ENGINE=InnoDB CHARACTER SET utf32;
+ALTER TABLE t1 DROP COLUMN a;
+ALTER TABLE t1 DROP COLUMN c;
+DROP TABLE t1;
+
+--echo # End of 10.5 tests

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -181,6 +181,13 @@ inline void dict_table_t::init_instant(const dict_table_t& table)
 
 		auto fixed_len = dict_col_get_fixed_size(
 			f.col, not_redundant());
+
+		/* Long fixed length can be treated as variable
+		length fields that needs external storage */
+		if (fixed_len > DICT_MAX_FIXED_COL_LEN) {
+			fixed_len = 0;
+		}
+
 		field_map_it->set_dropped();
 		if (!f.col->is_nullable()) {
 			field_map_it->set_not_null();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-29010*
## Description
Reason:
======
- InnoDB fails to load the instant alter table metadata from clustered index while loading the table definition. The reason is that InnoDB metadata blob has the column length exceeds maximum fixed length column size.

Fix:
===
- InnoDB should treat the long fixed length column as variable length fields that needs external storage while initializing the field map for instant alter operation

## How can this PR be tested?
./mtr innodb.instant_alter_bugs
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
