### PR TITLE
MDEV-34665 Simplify IN predicate processing for NULL-aware materializ…

### DIFF
--- a/mysql-test/main/subselect_mat.result
+++ b/mysql-test/main/subselect_mat.result
@@ -3013,3 +3013,310 @@ UNION ALL
 1
 1
 drop table t1, t2;
+#
+# MDEV-34665: Simplify IN predicate processing for NULL-aware
+#             materialization involving only one column
+set @save_optimizer_switch=@@optimizer_switch;
+set @@optimizer_switch = "materialization=on,in_to_exists=off,semijoin=off";
+create table t1 (a int);
+create table t2 (b int);
+insert into t1 values (null), (1), (2), (3);
+# Query against empty t2
+select a, a in (select b from t2) from t1;
+a	a in (select b from t2)
+1	0
+2	0
+3	0
+NULL	0
+# Insert some not-NULL values
+insert into t2 values (3), (4);
+select a, a in (select b from t2) from t1;
+a	a in (select b from t2)
+1	0
+2	0
+3	1
+NULL	NULL
+# Ensure the correct strategy is tested
+analyze format=json select a, a in (select b from t2) from t1;
+ANALYZE
+{
+  "query_block": {
+    "select_id": 1,
+    "r_loops": 1,
+    "r_total_time_ms": "REPLACED",
+    "table": {
+      "table_name": "t1",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "rows": 4,
+      "r_rows": 4,
+      "r_table_time_ms": "REPLACED",
+      "r_other_time_ms": "REPLACED",
+      "filtered": 100,
+      "r_filtered": 100
+    },
+    "subqueries": [
+      {
+        "materialization": {
+          "r_strategy": "null-aware index_lookup",
+          "r_loops": 4,
+          "r_index_lookups": 3,
+          "r_partial_matches": 1,
+          "query_block": {
+            "select_id": 2,
+            "r_loops": 1,
+            "r_total_time_ms": "REPLACED",
+            "table": {
+              "table_name": "t2",
+              "access_type": "ALL",
+              "r_loops": 1,
+              "rows": 2,
+              "r_rows": 2,
+              "r_table_time_ms": "REPLACED",
+              "r_other_time_ms": "REPLACED",
+              "filtered": 100,
+              "r_filtered": 100
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+# Insert NULL value (so there are both NULLs and and not-NULL values)
+insert into t2 values (null);
+select a, a in (select b from t2) from t1;
+a	a in (select b from t2)
+1	NULL
+2	NULL
+3	1
+NULL	NULL
+analyze format=json select a, a in (select b from t2) from t1;
+ANALYZE
+{
+  "query_block": {
+    "select_id": 1,
+    "r_loops": 1,
+    "r_total_time_ms": "REPLACED",
+    "table": {
+      "table_name": "t1",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "rows": 4,
+      "r_rows": 4,
+      "r_table_time_ms": "REPLACED",
+      "r_other_time_ms": "REPLACED",
+      "filtered": 100,
+      "r_filtered": 100
+    },
+    "subqueries": [
+      {
+        "materialization": {
+          "r_strategy": "null-aware index_lookup",
+          "r_loops": 4,
+          "r_index_lookups": 3,
+          "query_block": {
+            "select_id": 2,
+            "r_loops": 1,
+            "r_total_time_ms": "REPLACED",
+            "table": {
+              "table_name": "t2",
+              "access_type": "ALL",
+              "r_loops": 1,
+              "rows": 3,
+              "r_rows": 3,
+              "r_table_time_ms": "REPLACED",
+              "r_other_time_ms": "REPLACED",
+              "filtered": 100,
+              "r_filtered": 100
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+delete from t2;
+# Insert NULL values only
+insert into t2 values (null), (null);
+select a, a in (select b from t2) from t1;
+a	a in (select b from t2)
+1	NULL
+2	NULL
+3	NULL
+NULL	NULL
+analyze format=json select a, a in (select b from t2) from t1;
+ANALYZE
+{
+  "query_block": {
+    "select_id": 1,
+    "r_loops": 1,
+    "r_total_time_ms": "REPLACED",
+    "table": {
+      "table_name": "t1",
+      "access_type": "ALL",
+      "r_loops": 1,
+      "rows": 4,
+      "r_rows": 4,
+      "r_table_time_ms": "REPLACED",
+      "r_other_time_ms": "REPLACED",
+      "filtered": 100,
+      "r_filtered": 100
+    },
+    "subqueries": [
+      {
+        "materialization": {
+          "r_strategy": "return NULL",
+          "query_block": {
+            "select_id": 2,
+            "r_loops": 1,
+            "r_total_time_ms": "REPLACED",
+            "table": {
+              "table_name": "t2",
+              "access_type": "ALL",
+              "r_loops": 1,
+              "rows": 2,
+              "r_rows": 2,
+              "r_table_time_ms": "REPLACED",
+              "r_other_time_ms": "REPLACED",
+              "filtered": 100,
+              "r_filtered": 100
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+# Test UPDATE
+insert into t2 values (3), (4);
+update t1 set a=a+1 where a not in (select b from t2);
+# Nothing updated due to NULLs on both sides of IN
+select * from t1;
+a
+NULL
+1
+2
+3
+# Remove NULLs from the right side
+delete from t2 where b is null;
+update t1 set a=a+1 where a not in (select b from t2);
+# Now some rows are updated:
+select * from t1;
+a
+NULL
+2
+3
+3
+analyze format=json update t1 set a=a+1 where a not in (select b from t2);
+ANALYZE
+{
+  "query_block": {
+    "select_id": 1,
+    "r_total_time_ms": "REPLACED",
+    "table": {
+      "update": 1,
+      "table_name": "t1",
+      "access_type": "ALL",
+      "rows": 4,
+      "r_rows": 4,
+      "r_filtered": 25,
+      "r_total_time_ms": "REPLACED",
+      "attached_condition": "!(<in_optimizer>(t1.a,t1.a in (subquery#2)))"
+    },
+    "subqueries": [
+      {
+        "materialization": {
+          "r_strategy": "null-aware index_lookup",
+          "r_loops": 4,
+          "r_index_lookups": 3,
+          "r_partial_matches": 1,
+          "query_block": {
+            "select_id": 2,
+            "r_loops": 1,
+            "r_total_time_ms": "REPLACED",
+            "table": {
+              "table_name": "t2",
+              "access_type": "ALL",
+              "r_loops": 1,
+              "rows": 2,
+              "r_rows": 2,
+              "r_table_time_ms": "REPLACED",
+              "r_other_time_ms": "REPLACED",
+              "filtered": 100,
+              "r_filtered": 100
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+# Test DELETE
+# Restore initial data-set:
+delete from t1;
+insert into t1 values (null), (1), (2), (3);
+# Add some NULL values to the right side of IN
+insert into t2 values (null), (null);
+delete from t1 where a not in (select b from t2);
+# Nothing deleted due to NULLs on both sides of IN
+select * from t1;
+a
+NULL
+1
+2
+3
+# Remove NULLs from the right side
+delete from t2 where b is null;
+delete from t1 where a not in (select b from t2);
+# Now some rows are deleted:
+select * from t1;
+a
+NULL
+3
+analyze format=json delete from t1 where a not in (select b from t2);
+ANALYZE
+{
+  "query_block": {
+    "select_id": 1,
+    "r_total_time_ms": "REPLACED",
+    "table": {
+      "delete": 1,
+      "table_name": "t1",
+      "access_type": "ALL",
+      "rows": 2,
+      "r_rows": 2,
+      "r_filtered": 0,
+      "r_total_time_ms": "REPLACED",
+      "attached_condition": "!(<in_optimizer>(t1.a,t1.a in (subquery#2)))"
+    },
+    "subqueries": [
+      {
+        "materialization": {
+          "r_strategy": "null-aware index_lookup",
+          "r_loops": 2,
+          "r_index_lookups": 1,
+          "r_partial_matches": 1,
+          "query_block": {
+            "select_id": 2,
+            "r_loops": 1,
+            "r_total_time_ms": "REPLACED",
+            "table": {
+              "table_name": "t2",
+              "access_type": "ALL",
+              "r_loops": 1,
+              "rows": 2,
+              "r_rows": 2,
+              "r_table_time_ms": "REPLACED",
+              "r_other_time_ms": "REPLACED",
+              "filtered": 100,
+              "r_filtered": 100
+            }
+          }
+        }
+      }
+    ]
+  }
+}
+drop table t1, t2;
+set @@optimizer_switch=@save_optimizer_switch;

--- a/mysql-test/main/subselect_mat.test
+++ b/mysql-test/main/subselect_mat.test
@@ -296,3 +296,76 @@ UNION ALL
 ;
 
 drop table t1, t2;
+
+--echo #
+--echo # MDEV-34665: Simplify IN predicate processing for NULL-aware
+--echo #             materialization involving only one column
+
+set @save_optimizer_switch=@@optimizer_switch;
+set @@optimizer_switch = "materialization=on,in_to_exists=off,semijoin=off";
+
+create table t1 (a int);
+create table t2 (b int);
+insert into t1 values (null), (1), (2), (3);
+
+--echo # Query against empty t2
+--sorted_result
+select a, a in (select b from t2) from t1;
+
+--echo # Insert some not-NULL values
+insert into t2 values (3), (4);
+--sorted_result
+select a, a in (select b from t2) from t1;
+--echo # Ensure the correct strategy is tested
+--source include/analyze-format.inc
+analyze format=json select a, a in (select b from t2) from t1;
+
+--echo # Insert NULL value (so there are both NULLs and and not-NULL values)
+insert into t2 values (null);
+--sorted_result
+select a, a in (select b from t2) from t1;
+--source include/analyze-format.inc
+analyze format=json select a, a in (select b from t2) from t1;
+
+delete from t2;
+--echo # Insert NULL values only
+insert into t2 values (null), (null);
+--sorted_result
+select a, a in (select b from t2) from t1;
+--source include/analyze-format.inc
+analyze format=json select a, a in (select b from t2) from t1;
+
+--echo # Test UPDATE
+insert into t2 values (3), (4);
+update t1 set a=a+1 where a not in (select b from t2);
+--echo # Nothing updated due to NULLs on both sides of IN
+select * from t1;
+--echo # Remove NULLs from the right side
+delete from t2 where b is null;
+update t1 set a=a+1 where a not in (select b from t2);
+--echo # Now some rows are updated:
+select * from t1;
+--source include/analyze-format.inc
+analyze format=json update t1 set a=a+1 where a not in (select b from t2);
+
+--echo # Test DELETE
+--echo # Restore initial data-set:
+delete from t1;
+insert into t1 values (null), (1), (2), (3);
+--echo # Add some NULL values to the right side of IN
+insert into t2 values (null), (null);
+delete from t1 where a not in (select b from t2);
+--echo # Nothing deleted due to NULLs on both sides of IN
+select * from t1;
+--echo # Remove NULLs from the right side
+delete from t2 where b is null;
+delete from t1 where a not in (select b from t2);
+--echo # Now some rows are deleted:
+select * from t1;
+--source include/analyze-format.inc
+analyze format=json delete from t1 where a not in (select b from t2);
+
+drop table t1, t2;
+
+set @@optimizer_switch=@save_optimizer_switch;
+

--- a/mysql-test/main/subselect_mat_analyze_json.result
+++ b/mysql-test/main/subselect_mat_analyze_json.result
@@ -80,8 +80,6 @@ ANALYZE
   }
 }
 # "Partial match" is used due to NOT IN
-# Force rowid-merge partial partial matching
-set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=off";
 analyze format=json select * from t1 where a not in (select b from t2);
 ANALYZE
 {
@@ -104,58 +102,7 @@ ANALYZE
     "subqueries": [
       {
         "materialization": {
-          "r_strategy": "index_lookup;array merge for partial match",
-          "r_loops": 4,
-          "r_index_lookups": 3,
-          "r_partial_matches": 1,
-          "r_partial_match_buffer_size": "REPLACED",
-          "r_partial_match_array_sizes": ["2"],
-          "query_block": {
-            "select_id": 2,
-            "r_loops": 1,
-            "r_total_time_ms": "REPLACED",
-            "table": {
-              "table_name": "t2",
-              "access_type": "ALL",
-              "r_loops": 1,
-              "rows": 2,
-              "r_rows": 2,
-              "r_table_time_ms": "REPLACED",
-              "r_other_time_ms": "REPLACED",
-              "filtered": 100,
-              "r_filtered": 100
-            }
-          }
-        }
-      }
-    ]
-  }
-}
-# Force table scan partial matching
-set @@optimizer_switch="partial_match_rowid_merge=off,partial_match_table_scan=on";
-analyze format=json select * from t1 where a not in (select b from t2);
-ANALYZE
-{
-  "query_block": {
-    "select_id": 1,
-    "r_loops": 1,
-    "r_total_time_ms": "REPLACED",
-    "table": {
-      "table_name": "t1",
-      "access_type": "ALL",
-      "r_loops": 1,
-      "rows": 4,
-      "r_rows": 4,
-      "r_table_time_ms": "REPLACED",
-      "r_other_time_ms": "REPLACED",
-      "filtered": 100,
-      "r_filtered": 50,
-      "attached_condition": "!<in_optimizer>(t1.a,t1.a in (subquery#2))"
-    },
-    "subqueries": [
-      {
-        "materialization": {
-          "r_strategy": "index_lookup;full scan for partial match",
+          "r_strategy": "null-aware index_lookup",
           "r_loops": 4,
           "r_index_lookups": 3,
           "r_partial_matches": 1,
@@ -211,7 +158,7 @@ ANALYZE
         "subqueries": [
           {
             "materialization": {
-              "r_strategy": "index_lookup;full scan for partial match",
+              "r_strategy": "null-aware index_lookup",
               "r_loops": 4,
               "r_index_lookups": 3,
               "r_partial_matches": 1,
@@ -238,7 +185,6 @@ ANALYZE
     }
   }
 }
-set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=off";
 analyze format=json select a from t1 group by a not in (select b from t2);
 ANALYZE
 {
@@ -269,12 +215,10 @@ ANALYZE
         "subqueries": [
           {
             "materialization": {
-              "r_strategy": "index_lookup;array merge for partial match",
+              "r_strategy": "null-aware index_lookup",
               "r_loops": 4,
               "r_index_lookups": 3,
               "r_partial_matches": 1,
-              "r_partial_match_buffer_size": "REPLACED",
-              "r_partial_match_array_sizes": ["2"],
               "query_block": {
                 "select_id": 2,
                 "r_loops": 1,
@@ -298,7 +242,6 @@ ANALYZE
     }
   }
 }
-set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=on";
 # Subselect in ORDER BY
 analyze format=json select a from t1 order by a in (select b from t2);
 ANALYZE
@@ -333,7 +276,7 @@ ANALYZE
     "subqueries": [
       {
         "materialization": {
-          "r_strategy": "index_lookup;full scan for partial match",
+          "r_strategy": "null-aware index_lookup",
           "r_loops": 4,
           "r_index_lookups": 3,
           "r_partial_matches": 1,
@@ -381,7 +324,7 @@ ANALYZE
     "subqueries": [
       {
         "materialization": {
-          "r_strategy": "index_lookup;full scan for partial match",
+          "r_strategy": "null-aware index_lookup",
           "r_loops": 4,
           "r_index_lookups": 3,
           "r_partial_matches": 1,
@@ -521,7 +464,7 @@ ANALYZE
     "subqueries": [
       {
         "materialization": {
-          "r_strategy": "index_lookup;full scan for partial match",
+          "r_strategy": "null-aware index_lookup",
           "r_loops": 4,
           "r_index_lookups": 3,
           "query_block": {
@@ -614,6 +557,7 @@ create table t1 (a1 char(1), a2 char(1));
 insert into t1 values (null, 'b');
 create table t2 (b1 char(1), b2 char(2));
 insert into t2 values ('a','b'), ('c', 'd'), (null, 'e'), ('f', 'g');
+# Force rowid-merge partial matching
 set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=off";
 explain format=json select * from t1 where (a1, a2) not in (select b1, b2 from t2);
 EXPLAIN
@@ -690,6 +634,7 @@ ANALYZE
     ]
   }
 }
+# Force table scan partial matching
 set @@optimizer_switch="partial_match_rowid_merge=off,partial_match_table_scan=on";
 analyze format=json select * from t1 where (a1, a2) not in (select b1, b2 from t2);
 ANALYZE

--- a/mysql-test/main/subselect_mat_analyze_json.test
+++ b/mysql-test/main/subselect_mat_analyze_json.test
@@ -13,13 +13,6 @@ explain format=json select * from t1 where a in (select b from t2);
 analyze format=json select * from t1 where a in (select b from t2);
 
 --echo # "Partial match" is used due to NOT IN
---echo # Force rowid-merge partial partial matching
-set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=off";
---source include/analyze-format.inc
-analyze format=json select * from t1 where a not in (select b from t2);
-
---echo # Force table scan partial matching
-set @@optimizer_switch="partial_match_rowid_merge=off,partial_match_table_scan=on";
 --source include/analyze-format.inc
 analyze format=json select * from t1 where a not in (select b from t2);
 
@@ -27,11 +20,9 @@ analyze format=json select * from t1 where a not in (select b from t2);
 --source include/analyze-format.inc
 analyze format=json select a from t1 group by a in (select b from t2);
 
-set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=off";
 --source include/analyze-format.inc
 analyze format=json select a from t1 group by a not in (select b from t2);
 
-set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=on";
 --echo # Subselect in ORDER BY
 --source include/analyze-format.inc
 analyze format=json select a from t1 order by a in (select b from t2);
@@ -68,11 +59,13 @@ insert into t1 values (null, 'b');
 create table t2 (b1 char(1), b2 char(2));
 insert into t2 values ('a','b'), ('c', 'd'), (null, 'e'), ('f', 'g');
 
+--echo # Force rowid-merge partial matching
 set @@optimizer_switch="partial_match_rowid_merge=on,partial_match_table_scan=off";
 explain format=json select * from t1 where (a1, a2) not in (select b1, b2 from t2);
 --source include/analyze-format.inc
 analyze format=json select * from t1 where (a1, a2) not in (select b1, b2 from t2);
 
+--echo # Force table scan partial matching
 set @@optimizer_switch="partial_match_rowid_merge=off,partial_match_table_scan=on";
 --source include/analyze-format.inc
 analyze format=json select * from t1 where (a1, a2) not in (select b1, b2 from t2);

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -4973,12 +4973,18 @@ subselect_hash_sj_engine::get_strategy_using_data()
 
 void
 subselect_hash_sj_engine::choose_partial_match_strategy(
-  bool has_non_null_key, bool has_covering_null_row,
+  uint field_count, bool has_non_null_key, bool has_covering_null_row,
   MY_BITMAP *partial_match_key_parts_arg)
 {
   ulonglong pm_buff_size;
 
   DBUG_ASSERT(strategy == PARTIAL_MATCH);
+  if (field_count == 1)
+  {
+    strategy= SINGLE_COLUMN_MATCH;
+    return;
+  }
+
   /*
     Choose according to global optimizer switch. If only one of the switches is
     'ON', then the remaining strategy is the only possible one. The only cases
@@ -5414,7 +5420,8 @@ void subselect_hash_sj_engine::cleanup()
     related engines are created and chosen for each execution.
   */
   item->get_IN_subquery()->engine= materialize_engine;
-  if (lookup_engine_type == TABLE_SCAN_ENGINE ||
+  if (lookup_engine_type == SINGLE_COLUMN_ENGINE ||
+      lookup_engine_type == TABLE_SCAN_ENGINE ||
       lookup_engine_type == ROWID_MERGE_ENGINE)
   {
     subselect_engine *inner_lookup_engine;
@@ -5740,8 +5747,9 @@ int subselect_hash_sj_engine::exec()
       item_in->null_value= 1;
       item_in->make_const();
       item_in->set_first_execution();
-      thd->lex->current_select= save_select;
-      DBUG_RETURN(FALSE);
+      res= 0;
+      strategy= CONST_RETURN_NULL;
+      goto err;
     }
 
     if (has_covering_null_row)
@@ -5755,11 +5763,26 @@ int subselect_hash_sj_engine::exec()
       count_pm_keys= count_partial_match_columns - count_null_only_columns +
                      (nn_key_parts ? 1 : 0);
 
-    choose_partial_match_strategy(MY_TEST(nn_key_parts),
+    choose_partial_match_strategy(field_count, MY_TEST(nn_key_parts),
                                   has_covering_null_row,
                                   &partial_match_key_parts);
-    DBUG_ASSERT(strategy == PARTIAL_MATCH_MERGE ||
+    DBUG_ASSERT(strategy == SINGLE_COLUMN_MATCH ||
+                strategy == PARTIAL_MATCH_MERGE ||
                 strategy == PARTIAL_MATCH_SCAN);
+    if (strategy == SINGLE_COLUMN_MATCH)
+    {
+      if (!(pm_engine= new subselect_single_column_match_engine(
+              (subselect_uniquesubquery_engine*) lookup_engine, tmp_table,
+              item, result, semi_join_conds->argument_list(),
+              has_covering_null_row, has_covering_null_columns,
+              count_columns_with_nulls)) ||
+          pm_engine->prepare(thd))
+      {
+        /* This is an irrecoverable error. */
+        res= 1;
+        goto err;
+      }
+    }
     if (strategy == PARTIAL_MATCH_MERGE)
     {
       pm_engine=
@@ -5786,7 +5809,6 @@ int subselect_hash_sj_engine::exec()
         strategy= PARTIAL_MATCH_SCAN;
       }
     }
-
     if (strategy == PARTIAL_MATCH_SCAN)
     {
       if (!(pm_engine=
@@ -5806,12 +5828,12 @@ int subselect_hash_sj_engine::exec()
     }
   }
 
-  item_in->get_materialization_tracker()->report_exec_strategy(strategy);
   if (pm_engine)
     lookup_engine= pm_engine;
   item_in->change_engine(lookup_engine);
 
 err:
+  item_in->get_materialization_tracker()->report_exec_strategy(strategy);
   thd->lex->current_select= save_select;
   DBUG_RETURN(res);
 }
@@ -6975,6 +6997,44 @@ end:
 
 void subselect_table_scan_engine::cleanup()
 {
+}
+
+
+subselect_single_column_match_engine::subselect_single_column_match_engine(
+  subselect_uniquesubquery_engine *engine_arg,
+  TABLE *tmp_table_arg,
+  Item_subselect *item_arg,
+  select_result_interceptor *result_arg,
+  List<Item> *equi_join_conds_arg,
+  bool has_covering_null_row_arg,
+  bool has_covering_null_columns_arg,
+  uint count_columns_with_nulls_arg)
+  :subselect_partial_match_engine(engine_arg, tmp_table_arg, item_arg,
+                                  result_arg, equi_join_conds_arg,
+                                  has_covering_null_row_arg,
+                                  has_covering_null_columns_arg,
+                                  count_columns_with_nulls_arg)
+{}
+
+
+bool subselect_single_column_match_engine::partial_match()
+{
+  /*
+    We get here if:
+    - there is only one column in the materialized table;
+    - its current value of left_expr is NULL (otherwise we would have hit
+         the earlier "index lookup" branch at subselect_partial_match::exec());
+    - the materialized table does not have NULL values (for a similar reason);
+    - the materialized table is not empty.
+    The case when materialization produced no rows (empty table) is handled at
+    subselect_hash_sj_engine::exec(), the result of IN predicate is always
+    FALSE in that case.
+    After all those preconditions met, the result of the partial match is TRUE.
+  */
+  DBUG_ASSERT(item->get_IN_subquery()->left_expr_has_null() &&
+              !has_covering_null_row &&
+              tmp_table->file->stats.records > 0);
+  return true;
 }
 
 


### PR DESCRIPTION
…ation involving only one column

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34665

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
It was found that unnecessary work of building Ordered_key structures is being done when processing NULL-aware materialization for IN predicates having only one column. In fact, the logic for that simplified case can be expressed as follows.
Say we have predicate `left_expr IN (SELECT <subq1>)`, where `left_expr` is scalar(not a tuple). Then
   ```
 if (left_expr is NULL) {
      if (subq1 produced any rows) {
        // note that we don't care if subq1 has produced
        // NULLs or not.
        NULL IN (<some values>) -> UNKNOWN, i.e. NULL.
      } else {
        NULL IN ({empty-set}) -> FALSE.
      }
    } else {
      // left_expr is a non-NULL value
      if (subq1 output has a match for left_expr) {
        left_expr IN (..., left_expr ...) -> TRUE
      } else {
        // no "known" matches.
        if (subq1 output has a NULL) {
          left_expr IN ( ... NULL ...) ->
           (NULL could have been a match or not)
           -> NULL.
        } else {
          // subq1 didn't produce any "UNKNOWNs" so
          // we're positive there weren't any matches
          -> FALSE.
        }
      }
    }
```

This commit introduces subselect_single_column_partial_engine class implementing the logic described.
## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
