### PR TITLE
MDEV-34683 Types mismatch when cloning items causes debug assertion

### DIFF
--- a/mysql-test/main/item_types.result
+++ b/mysql-test/main/item_types.result
@@ -14,3 +14,17 @@ SELECT * FROM t1 JOIN t2 ON t1.c=t2.c WHERE t1.c<=>5;
 c	c
 DROP TABLE t1, t2;
 SET optimizer_switch=default;
+#
+# MDEV-34683 Types mismatch when cloning items causes debug assertion
+#
+CREATE TABLE t1 (a date);
+CREATE ALGORITHM=TEMPTABLE VIEW v1 AS SELECT * FROM t1;
+SELECT a FROM v1 WHERE a IN ('a', 'b', 'c');
+a
+CREATE VIEW v2 AS SELECT '' as a;
+SELECT * FROM v2 WHERE a='' AND CASE '' WHEN '' THEN '' ELSE a END='';
+a
+
+DROP TABLE t1;
+DROP VIEW v1, v2;
+# End of 10.5 tests

--- a/mysql-test/main/item_types.test
+++ b/mysql-test/main/item_types.test
@@ -13,3 +13,21 @@ SELECT * FROM t1 JOIN t2 ON t1.c=t2.c WHERE t1.c<=>5;
 DROP TABLE t1, t2;
 
 SET optimizer_switch=default;
+
+--echo #
+--echo # MDEV-34683 Types mismatch when cloning items causes debug assertion
+--echo #
+
+CREATE TABLE t1 (a date);
+CREATE ALGORITHM=TEMPTABLE VIEW v1 AS SELECT * FROM t1;
+--disable_warnings
+SELECT a FROM v1 WHERE a IN ('a', 'b', 'c');
+--enable_warnings
+
+CREATE VIEW v2 AS SELECT '' as a;
+SELECT * FROM v2 WHERE a='' AND CASE '' WHEN '' THEN '' ELSE a END='';
+
+DROP TABLE t1;
+DROP VIEW v1, v2;
+
+--echo # End of 10.5 tests

--- a/sql/item.h
+++ b/sql/item.h
@@ -5225,6 +5225,9 @@ public:
     cached_time.copy_to_mysql_time(ltime);
     return (null_value= false);
   }
+  Item *do_get_copy(THD *thd) const override
+  { return get_item_copy<Item_date_literal_for_invalid_dates>(thd, this); }
+  Item *do_build_clone(THD *thd) const override { return get_copy(thd); }
 };
 
 
@@ -6699,7 +6702,9 @@ public:
     description
   */
   bool associate_with_target_field(THD *thd, Item_field *field) override;
-
+  Item *do_get_copy(THD *thd) const override
+  { return get_item_copy<Item_default_value>(thd, this); }
+  Item* do_build_clone(THD *thd) const override { return get_copy(thd); }
 private:
   bool tie_field(THD *thd);
 };

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -1814,6 +1814,16 @@ longlong Item_func_eq::val_int()
 }
 
 
+Item *Item_func_eq::do_build_clone(THD *thd) const
+{
+  /*
+    Clone the parent and cast to the child class since there is nothing
+    specific for Item_func_eq
+  */
+  return (Item_func_eq*) Item_bool_rowready_func2::do_build_clone(thd);
+}
+
+
 /** Same as Item_func_eq, but NULL = NULL. */
 
 bool Item_func_equal::fix_length_and_dec()

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -765,6 +765,7 @@ public:
   friend class  Arg_comparator;
   Item *do_get_copy(THD *thd) const override
   { return get_item_copy<Item_func_eq>(thd, this); }
+  Item *do_build_clone(THD *thd) const override;
 };
 
 class Item_func_equal final :public Item_bool_rowready_func2
@@ -2324,7 +2325,7 @@ public:
   Item *do_build_clone(THD *thd) const override
   {
     Item_func_case_simple *clone= (Item_func_case_simple *)
-                                  Item_func_case::build_clone(thd);
+                                  Item_func_case::do_build_clone(thd);
     uint ncases= when_count();
     if (clone && clone->Predicant_to_list_comparator::init_clone(thd, ncases))
       return NULL;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34683*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
New runtime type diagnostic (MDEV-34490) has detected that classes Item_func_eq, Item_default_value and Item_date_literal_for_invalid_dates incorrectly return an instance of its ancestor classes when being cloned. This commit fixes that.

Additionally, it fixes a bug at Item_func_case_simple::do_build_clone() which led to an endless loop of cloning functions calls.

## Release Notes
<Not worth mentioning>

## How can this PR be tested?
New test cases were added to main/item_types.test
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
