### PR TITLE
MDEV-27201 Do not compute unused aggregate functions for derived tables and views

### DIFF
--- a/include/my_bitmap.h
+++ b/include/my_bitmap.h
@@ -41,6 +41,8 @@ extern "C" {
 
 extern void create_last_word_mask(MY_BITMAP *map);
 extern my_bool my_bitmap_init(MY_BITMAP *map, my_bitmap_map *buf, uint n_bits);
+extern my_bool my_bitmap_init_memroot(MY_BITMAP *map, uint n_bits,
+                                      MEM_ROOT *mem_root);
 extern my_bool bitmap_is_clear_all(const MY_BITMAP *map);
 extern my_bool bitmap_is_prefix(const MY_BITMAP *map, uint prefix_size);
 extern my_bool bitmap_is_set_all(const MY_BITMAP *map);

--- a/mysql-test/main/aggr_funcs_elimination.result
+++ b/mysql-test/main/aggr_funcs_elimination.result
@@ -253,8 +253,8 @@ elim_func
         "sum(`t1`.`b`)"
     ]
 ]
-select group_id, sum(max_suma) from 
-(select group_id, max(suma) as max_suma, min(sumb) as min_sumb, sum(avgb) sum_avgb 
+select group_id, sum(max_suma) from
+(select group_id, max(suma) as max_suma, min(sumb) as min_sumb, sum(avgb) sum_avgb
 from v1 group by group_id
 ) as T;
 group_id	sum(max_suma)

--- a/mysql-test/main/aggr_funcs_elimination.result
+++ b/mysql-test/main/aggr_funcs_elimination.result
@@ -1,0 +1,339 @@
+#
+# MDEV-27201 Non-merged derived table: do not compute unused fields
+#
+create table t1 (
+group_id int,
+a int,
+b int,
+c int
+);
+insert into t1 values (1,1,1,1),(1,2,2,2),(1,3,3,3), (2,4,4,4),(2,5,5,5),(2,6,6,6),
+(3,7,7,7),(3,8,8,8),(3,9,9,9);
+create table t2 (a int);
+insert into t2 values (1),(2),(3);
+set optimizer_trace = 'enabled=on';
+# avgb is not used so must not be calculated
+select T.group_id, T.suma
+from (select
+group_id, sum(a) as suma, avg(b) as avgb
+from t1
+group by group_id
+) T;
+group_id	suma
+1	6
+2	15
+3	24
+# Make sure that the elimination is reflected in the optimizer_trace
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    ["avg(`t1`.`b`)"]
+]
+# sum(a) and max(a) are not used so must not be calculated
+select T.group_id, T.avgb
+from (select
+group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+from t1
+group by group_id
+) as T;
+group_id	avgb
+1	2.0000
+2	5.0000
+3	8.0000
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    [
+        "sum(`t1`.`a`)",
+        "max(`t1`.`a`)"
+    ]
+]
+# max(a) is not used and can be eliminated but sum(a) is used in WHERE
+select T.group_id, T.avgb
+from (select
+group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+from t1
+group by group_id
+) as T
+where T.suma > 10;
+group_id	avgb
+2	5.0000
+3	8.0000
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    ["max(`t1`.`a`)"]
+]
+# Join of a derived and a regular tables
+select T.group_id, T.maxa
+from t2, (select
+group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+from t1
+group by group_id
+) as T
+where T.group_id = t2.a;
+group_id	maxa
+1	3
+2	6
+3	9
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    [
+        "sum(`t1`.`a`)",
+        "avg(`t1`.`b`)"
+    ]
+]
+# No aggregate functions must be calculated
+select T.group_id
+from (select
+group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+from t1
+group by group_id
+) as T;
+group_id
+1
+2
+3
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    [
+        "sum(`t1`.`a`)",
+        "avg(`t1`.`b`)",
+        "max(`t1`.`a`)"
+    ]
+]
+# Aggregate function not present in SELECT list but present in HAVING
+select T.group_id, T.avgb
+from (select
+group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+from t1
+group by group_id
+having suma > 7
+) as T;
+group_id	avgb
+2	5.0000
+3	8.0000
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    ["max(`t1`.`a`)"]
+]
+# Aggregate function not present in SELECT list but present in ORDER BY
+select T.group_id, T.sumb
+from (select
+group_id, sum(a) as SUMA, sum(b) as SUMB
+from t1
+group by group_id
+order by suma desc LIMIT 1
+) as T;
+group_id	sumb
+3	24
+# Hidden field sum(b) is added to process HAVING
+select T.group_id, maxab
+from (select
+group_id, sum(a) as suma, max(a) as maxab
+from t1
+group by group_id
+having sum(b) > 10
+) as T;
+group_id	maxab
+2	6
+3	9
+# Aggregate function is used in having
+select group_id
+from (select group_id, count(*) as cnt
+from t1
+group by group_id
+having (select count(*) from t2 where t2.a > t1.group_id)+3 > cnt
+) T;
+group_id
+1
+2
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    []
+]
+# Hidden field sum(b) is added to process ORDER BY, this must not harm
+select T.group_id, maxab
+from (select
+group_id, sum(a) as suma, max(a) as maxab
+from t1
+group by group_id
+order by sum(b) desc limit 1
+) as T;
+group_id	maxab
+3	9
+# Hidden fields sum(a) and sum(b) are added to process HAVING and ORDER BY
+select T.group_id
+from (select
+group_id, max(a) as maxa
+from t1
+group by group_id
+having sum(b) > 10
+order by sum(a) desc limit 1
+) as T;
+group_id
+3
+# Sum of two aggregate functions: elimination is not implemented yet
+select T.group_id
+from (select
+group_id, sum(a) + sum(b) as sumab
+from t1
+group by group_id
+having sum(a) + sum(b) > 20
+) as T;
+group_id
+2
+3
+# GROUP BY multiple columns
+select T.group_id, T.suma
+from (select
+group_id, a+b, sum(a) as suma, max(a) as maxa
+from t1
+group by group_id, a+b
+having maxa >= 5
+) as T;
+group_id	suma
+2	5
+2	6
+3	7
+3	8
+3	9
+# Tests for the VIEW
+create view v1 as
+select
+group_id, sum(a) as SUMA, sum(b) as sumb, avg(b) as avgb
+from t1
+group by group_id;
+select group_id, suma from v1;
+group_id	suma
+1	6
+2	15
+3	24
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    [
+        "sum(`t1`.`b`)",
+        "avg(`t1`.`b`)"
+    ]
+]
+select group_id, avgb from v1 where sumb > 10;
+group_id	avgb
+2	5.0000
+3	8.0000
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    ["sum(`t1`.`a`)"]
+]
+select avgb from v1;
+avgb
+2.0000
+5.0000
+8.0000
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    [
+        "sum(`t1`.`a`)",
+        "sum(`t1`.`b`)"
+    ]
+]
+select group_id, sum(max_suma) from 
+(select group_id, max(suma) as max_suma, min(sumb) as min_sumb, sum(avgb) sum_avgb 
+from v1 group by group_id
+) as T;
+group_id	sum(max_suma)
+1	45
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+from information_schema.optimizer_trace;
+elim_func
+[
+    [
+        "min(`v1`.`sumb`)",
+        "sum(`v1`.`avgb`)"
+    ]
+]
+# References to group functions are not supported, and this
+# test is added to ensure they are still not supported. Otherwise,
+# the functionality of disabling aggregate functions needs to be
+# adjusted (see sql/sql_derived.cc eliminate_unused_aggr_funcs()).
+# Additionally, Sql_mode=EXTENDED_ALIASES must be checked
+# where applicable
+select T.group_id
+from (select
+group_id, sum(a) as suma,
+(select count(*) from t2 where t2.a = suma) as cnt
+from t1
+group by group_id
+having cnt = 0
+) as T;
+ERROR 42S22: Reference 'suma' not supported (reference to group function)
+select suma_1
+from (select group_id, sum(a) as suma, suma+1 as suma_1
+from t1
+group by group_id) T;
+ERROR 42S22: Unknown column 'suma' in 'field list'
+# Make sure aggregate functions splitting is not affected
+select group_id
+from (select group_id, sum(a) + sum(b) as sumab
+from t1
+group by group_id
+having sumab < 40
+) T;
+group_id
+1
+2
+# Make sure arithmetic for aggregate functions works correctly
+select group_id
+from (select group_id, sum(a)+5 as sumab
+from t1
+group by group_id
+having sumab < 25
+) T;
+group_id
+1
+2
+# Make sure table elimination works
+create table t3 (
+pk int primary key,
+col int
+);
+insert into t3 values (1,2),(2,2),(3,4);
+# Table t3 must be absent in the EXPLAIN output (eliminated):
+explain select T.group_id, T.maxa
+from t2, (select group_id, max(a) as maxa, sum(t3.col) as sumb
+from t1 left join t3 on t3.pk=t1.c
+group by group_id
+) as T
+where T.group_id = t2.a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	3	Using where
+1	PRIMARY	<derived2>	ref	key0	key0	5	test.t2.a	1	
+2	DERIVED	t1	ALL	NULL	NULL	NULL	NULL	9	Using temporary; Using filesort
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func,
+json_detailed(json_extract(trace, '$**.eliminated_tables'))  as elim_tables
+from information_schema.optimizer_trace;
+elim_func	elim_tables
+[
+    ["sum(`t3`.`col`)"]
+]	[
+    ["t3"]
+]
+drop table t1, t2, t3;
+drop view v1;
+set optimizer_trace = 'enabled=off';

--- a/mysql-test/main/aggr_funcs_elimination.test
+++ b/mysql-test/main/aggr_funcs_elimination.test
@@ -1,0 +1,247 @@
+--source include/not_embedded.inc
+
+--echo #
+--echo # MDEV-27201 Non-merged derived table: do not compute unused fields
+--echo #
+
+create table t1 (
+  group_id int,
+  a int,
+  b int,
+  c int
+);
+
+insert into t1 values (1,1,1,1),(1,2,2,2),(1,3,3,3), (2,4,4,4),(2,5,5,5),(2,6,6,6),
+ (3,7,7,7),(3,8,8,8),(3,9,9,9);
+
+create table t2 (a int);
+insert into t2 values (1),(2),(3);
+
+set optimizer_trace = 'enabled=on';
+
+--echo # avgb is not used so must not be calculated
+select T.group_id, T.suma
+  from (select
+         group_id, sum(a) as suma, avg(b) as avgb
+       from t1
+       group by group_id
+       ) T;
+
+--echo # Make sure that the elimination is reflected in the optimizer_trace
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # sum(a) and max(a) are not used so must not be calculated
+select T.group_id, T.avgb
+  from (select
+          group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+        from t1
+        group by group_id
+        ) as T;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # max(a) is not used and can be eliminated but sum(a) is used in WHERE
+select T.group_id, T.avgb
+  from (select
+          group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+        from t1
+        group by group_id
+       ) as T
+where T.suma > 10;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # Join of a derived and a regular tables
+select T.group_id, T.maxa
+  from t2, (select
+             group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+           from t1
+           group by group_id
+           ) as T
+where T.group_id = t2.a;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # No aggregate functions must be calculated
+select T.group_id
+  from (select
+          group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+        from t1
+        group by group_id
+       ) as T;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # Aggregate function not present in SELECT list but present in HAVING
+select T.group_id, T.avgb
+  from (select
+         group_id, sum(a) as suma, avg(b) as avgb, max(a) as maxa
+        from t1
+        group by group_id
+        having suma > 7
+       ) as T;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # Aggregate function not present in SELECT list but present in ORDER BY
+select T.group_id, T.sumb
+  from (select
+          group_id, sum(a) as SUMA, sum(b) as SUMB
+        from t1
+        group by group_id
+        order by suma desc LIMIT 1
+       ) as T;
+
+--echo # Hidden field sum(b) is added to process HAVING
+select T.group_id, maxab
+  from (select
+         group_id, sum(a) as suma, max(a) as maxab
+       from t1
+       group by group_id
+       having sum(b) > 10
+      ) as T;
+
+--echo # Aggregate function is used in having
+select group_id
+  from (select group_id, count(*) as cnt
+        from t1
+        group by group_id
+        having (select count(*) from t2 where t2.a > t1.group_id)+3 > cnt
+       ) T;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # Hidden field sum(b) is added to process ORDER BY, this must not harm
+select T.group_id, maxab
+  from (select
+          group_id, sum(a) as suma, max(a) as maxab
+        from t1
+        group by group_id
+        order by sum(b) desc limit 1
+       ) as T;
+
+--echo # Hidden fields sum(a) and sum(b) are added to process HAVING and ORDER BY
+select T.group_id
+  from (select
+         group_id, max(a) as maxa
+        from t1
+        group by group_id
+        having sum(b) > 10
+        order by sum(a) desc limit 1
+       ) as T;
+
+--echo # Sum of two aggregate functions: elimination is not implemented yet
+select T.group_id
+  from (select
+         group_id, sum(a) + sum(b) as sumab
+        from t1
+        group by group_id
+        having sum(a) + sum(b) > 20
+       ) as T;
+
+--echo # GROUP BY multiple columns
+select T.group_id, T.suma
+  from (select
+          group_id, a+b, sum(a) as suma, max(a) as maxa
+        from t1
+        group by group_id, a+b
+        having maxa >= 5
+       ) as T;
+
+--echo # Tests for the VIEW
+create view v1 as
+  select
+    group_id, sum(a) as SUMA, sum(b) as sumb, avg(b) as avgb
+  from t1
+  group by group_id;
+
+select group_id, suma from v1;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+select group_id, avgb from v1 where sumb > 10;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+select avgb from v1;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+select group_id, sum(max_suma) from 
+  (select group_id, max(suma) as max_suma, min(sumb) as min_sumb, sum(avgb) sum_avgb 
+   from v1 group by group_id
+  ) as T;
+
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
+  from information_schema.optimizer_trace;
+
+--echo # References to group functions are not supported, and this
+--echo # test is added to ensure they are still not supported. Otherwise,
+--echo # the functionality of disabling aggregate functions needs to be
+--echo # adjusted (see sql/sql_derived.cc eliminate_unused_aggr_funcs()).
+--echo # Additionally, Sql_mode=EXTENDED_ALIASES must be checked
+--echo # where applicable
+--error ER_ILLEGAL_REFERENCE
+select T.group_id
+  from (select
+          group_id, sum(a) as suma,
+          (select count(*) from t2 where t2.a = suma) as cnt
+        from t1
+        group by group_id
+        having cnt = 0
+       ) as T;
+
+--error ER_BAD_FIELD_ERROR
+select suma_1
+  from (select group_id, sum(a) as suma, suma+1 as suma_1
+        from t1
+        group by group_id) T;
+
+--echo # Make sure aggregate functions splitting is not affected
+select group_id
+  from (select group_id, sum(a) + sum(b) as sumab
+        from t1
+        group by group_id
+        having sumab < 40
+       ) T;
+
+--echo # Make sure arithmetic for aggregate functions works correctly
+select group_id
+  from (select group_id, sum(a)+5 as sumab
+        from t1
+        group by group_id
+        having sumab < 25
+       ) T;
+
+--echo # Make sure table elimination works
+create table t3 (
+  pk int primary key,
+  col int
+);
+insert into t3 values (1,2),(2,2),(3,4);
+
+--echo # Table t3 must be absent in the EXPLAIN output (eliminated):
+explain select T.group_id, T.maxa
+  from t2, (select group_id, max(a) as maxa, sum(t3.col) as sumb
+              from t1 left join t3 on t3.pk=t1.c
+              group by group_id
+           ) as T
+  where T.group_id = t2.a;
+  
+select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func,
+       json_detailed(json_extract(trace, '$**.eliminated_tables'))  as elim_tables
+  from information_schema.optimizer_trace;
+
+drop table t1, t2, t3;
+drop view v1;
+set optimizer_trace = 'enabled=off';

--- a/mysql-test/main/aggr_funcs_elimination.test
+++ b/mysql-test/main/aggr_funcs_elimination.test
@@ -177,8 +177,8 @@ select avgb from v1;
 select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func
   from information_schema.optimizer_trace;
 
-select group_id, sum(max_suma) from 
-  (select group_id, max(suma) as max_suma, min(sumb) as min_sumb, sum(avgb) sum_avgb 
+select group_id, sum(max_suma) from
+  (select group_id, max(suma) as max_suma, min(sumb) as min_sumb, sum(avgb) sum_avgb
    from v1 group by group_id
   ) as T;
 
@@ -237,7 +237,7 @@ explain select T.group_id, T.maxa
               group by group_id
            ) as T
   where T.group_id = t2.a;
-  
+
 select json_detailed(json_extract(trace, '$**.aggregate_functions_eliminated')) as elim_func,
        json_detailed(json_extract(trace, '$**.eliminated_tables'))  as elim_tables
   from information_schema.optimizer_trace;

--- a/mysql-test/main/derived_cond_pushdown.result
+++ b/mysql-test/main/derived_cond_pushdown.result
@@ -12971,7 +12971,7 @@ EXPLAIN
                       "attached_condition": "t1.f is not null"
                     },
                     "buffer_type": "flat",
-                    "buffer_size": "64",
+                    "buffer_size": "1",
                     "join_type": "BNL"
                   }
                 }

--- a/mysql-test/main/table_elim.result
+++ b/mysql-test/main/table_elim.result
@@ -948,13 +948,13 @@ create view v2d as
 select t11.a as a, t11.b as b, max(t12.col1) as max_col1
 from t11 left join t12 on t12.pk=t11.b
 group by t11.a, t11.b;
-# This one must not be eliminated since only one of the GROUP BY fields is bound:
+# The view v2d cannot be eliminated because only one of the GROUP BY fields
+# is bound, but table t12 from v2d must be eliminated:
 explain select t1.* from t1 left join v2d on v2d.a=t1.a;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	10	
 1	PRIMARY	<derived2>	ref	key0	key0	5	test.t1.a	10	Using where
 2	DERIVED	t11	ALL	a	NULL	NULL	NULL	1000	Using temporary; Using filesort
-2	DERIVED	t12	eq_ref	PRIMARY	PRIMARY	4	test.t11.b	1	Using where
 # This must be eliminated since both fields are bound:
 explain select t1.* from t1 left join v2d on v2d.a=t1.a and v2d.b=t1.b;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra

--- a/mysql-test/main/table_elim.test
+++ b/mysql-test/main/table_elim.test
@@ -721,7 +721,8 @@ select t11.a as a, t11.b as b, max(t12.col1) as max_col1
 from t11 left join t12 on t12.pk=t11.b
 group by t11.a, t11.b;
 
---echo # This one must not be eliminated since only one of the GROUP BY fields is bound:
+--echo # The view v2d cannot be eliminated because only one of the GROUP BY fields
+--echo # is bound, but table t12 from v2d must be eliminated:
 explain select t1.* from t1 left join v2d on v2d.a=t1.a;
 
 --echo # This must be eliminated since both fields are bound:

--- a/mysys/my_bitmap.c
+++ b/mysys/my_bitmap.c
@@ -165,6 +165,24 @@ my_bool my_bitmap_init(MY_BITMAP *map, my_bitmap_map *buf, uint n_bits)
 }
 
 
+/*
+  Initialize a MY_BITMAP with a buffer allocated on the current
+  memory root.
+*/
+
+my_bool my_bitmap_init_memroot(MY_BITMAP *map, uint n_bits, MEM_ROOT *mem_root)
+{
+  my_bitmap_map *bitmap_buf;
+
+  if (!(bitmap_buf= (my_bitmap_map*) alloc_root(mem_root,
+                                                bitmap_buffer_size(n_bits))) ||
+      my_bitmap_init(map, bitmap_buf, n_bits))
+    return TRUE;
+  bitmap_clear_all(map);
+  return FALSE;
+}
+
+
 void my_bitmap_free(MY_BITMAP *map)
 {
   DBUG_ENTER("my_bitmap_free");

--- a/sql/create_tmp_table.h
+++ b/sql/create_tmp_table.h
@@ -73,7 +73,8 @@ public:
                          const ST_SCHEMA_TABLE &schema_table);
 
   bool finalize(THD *thd, TABLE *table, TMP_TABLE_PARAM *param,
-                bool do_not_open, bool keep_row_order);
+                bool do_not_open, bool keep_row_order,
+                bool set_all_bits_of_read_set_to_1);
   void cleanup_on_failure(THD *thd, TABLE *table);
 };
 

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -8668,6 +8668,22 @@ Item *Item_ref::get_tmp_table_item(THD *thd)
 }
 
 
+bool Item_ref::find_item_in_ref_ptr_array(void *arg)
+{
+  std::pair<JOIN*, MY_BITMAP*> *param= (std::pair<JOIN*, MY_BITMAP*>*) arg;
+  JOIN *join= param->first;
+  MY_BITMAP *bitmap= param->second;
+
+  long offset= static_cast<long>(this->ref -
+                                 &join->select_lex->ref_pointer_array[0]);
+  if(offset < 0 || offset >= join->all_fields.elements)
+    return true;
+
+  bitmap_set_bit(bitmap, offset);
+  return false;
+}
+
+
 void Item_ref_null_helper::print(String *str, enum_query_type query_type)
 {
   str->append(STRING_WITH_LEN("<ref_null_helper>("));

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -8674,12 +8674,11 @@ bool Item_ref::find_item_in_ref_ptr_array(void *arg)
   JOIN *join= param->first;
   MY_BITMAP *bitmap= param->second;
 
-  long offset= static_cast<long>(this->ref -
-                                 &join->select_lex->ref_pointer_array[0]);
-  if(offset < 0 || offset >= join->all_fields.elements)
+  long long offset= this->ref - &join->select_lex->ref_pointer_array[0];
+  if(offset < 0 || offset >= static_cast<long>(join->all_fields.elements))
     return true;
 
-  bitmap_set_bit(bitmap, offset);
+  bitmap_set_bit(bitmap, static_cast<uint>(offset));
   return false;
 }
 

--- a/sql/item.h
+++ b/sql/item.h
@@ -2354,6 +2354,21 @@ public:
     If there is some, sets a bit for this key in the proper key map.
   */
   virtual bool check_index_dependence(void *arg) { return 0; }
+
+  /**
+    Find this item in the given JOIN::SELECT_LEX::ref_pointer_array
+    and set the bit according to the item index in the ref_pointer_array.
+
+    @param arg Pointer to std::pair<JOIN*, MY_BITMAP*>
+    JOIN*           JOIN in whose SELECT_LEX::ref_pointer_array the search
+                    is performed
+    MY_BITMAP*      bitmap where the bit must be set
+
+    @retval false   the item is found in ref_pointer_array
+    @retval true    the item is NOT found in ref_pointer_array
+  */
+  virtual bool find_item_in_ref_ptr_array(void *arg) { return 0; }
+
   /*============== End of Item processor list ======================*/
 
   /*
@@ -2734,6 +2749,10 @@ public:
     Checks if this item consists in the left part of arg IN subquery predicate
   */
   bool pushable_equality_checker_for_subquery(uchar *arg);
+
+  virtual void mark_as_eliminated() {}
+
+  virtual bool is_eliminated() const { return false; }
 };
 
 MEM_ROOT *get_thd_memroot(THD *thd);
@@ -5562,6 +5581,7 @@ public:
   }
 };
 
+
 class Item_ref :public Item_ident
 {
 protected:
@@ -5807,6 +5827,8 @@ public:
     *ref= (*ref)->remove_item_direct_ref();
     return this;
   }
+
+  bool find_item_in_ref_ptr_array(void *arg) override;
 };
 
 

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -5157,26 +5157,6 @@ ulonglong subselect_hash_sj_engine::rowid_merge_buff_size(
 }
 
 
-/*
-  Initialize a MY_BITMAP with a buffer allocated on the current
-  memory root.
-  TIMOUR: move to bitmap C file?
-*/
-
-static my_bool
-my_bitmap_init_memroot(MY_BITMAP *map, uint n_bits, MEM_ROOT *mem_root)
-{
-  my_bitmap_map *bitmap_buf;
-
-  if (!(bitmap_buf= (my_bitmap_map*) alloc_root(mem_root,
-                                                bitmap_buffer_size(n_bits))) ||
-      my_bitmap_init(map, bitmap_buf, n_bits))
-    return TRUE;
-  bitmap_clear_all(map);
-  return FALSE;
-}
-
-
 /**
   Create all structures needed for IN execution that can live between PS
   reexecution.

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -479,6 +479,7 @@ Item_sum::Item_sum(THD *thd, List<Item> &list): Item_func_or_sum(thd, list)
 
 Item_sum::Item_sum(THD *thd, Item_sum *item):
   Item_func_or_sum(thd, item),
+  eliminated(item->is_eliminated()),
   aggr_sel(item->aggr_sel),
   nest_level(item->nest_level), aggr_level(item->aggr_level),
   quick_group(item->quick_group),

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -343,6 +343,8 @@ private:
   /* TRUE if this is aggregate function of a window function */
   bool window_func_sum_expr_flag;
 
+  bool eliminated= false;
+
 public:
 
   bool has_force_copy_fields() const { return force_copy_fields; }
@@ -599,6 +601,13 @@ public:
   bool is_window_func_sum_expr() { return window_func_sum_expr_flag; }
   virtual void setup_caches(THD *thd) {};
   virtual void set_partition_row_count(ulonglong count) { DBUG_ASSERT(0); }
+
+  /*
+    Marks the aggregate function as eliminated, meaning that its result is not
+    used anywhere and so its calculation was disabled for performance reasons
+  */
+  void mark_as_eliminated() override { eliminated= true; }
+  bool is_eliminated() const override { return eliminated; }
 };
 
 

--- a/sql/json_table.cc
+++ b/sql/json_table.cc
@@ -729,7 +729,7 @@ bool Create_json_table::finalize(THD *thd, TABLE *table,
   DBUG_ENTER("Create_json_table::finalize");
   DBUG_ASSERT(table);
 
-  if (Create_tmp_table::finalize(thd, table, param, 1, 0))
+  if (Create_tmp_table::finalize(thd, table, param, 1, 0, true))
     DBUG_RETURN(true);
 
   table->db_stat= HA_OPEN_KEYFILE;

--- a/sql/opt_subselect.cc
+++ b/sql/opt_subselect.cc
@@ -4906,7 +4906,7 @@ SJ_TMP_TABLE::create_sj_weedout_tmp_table(THD *thd)
     table->record[1]= table->record[0]+alloc_length;
     share->default_values= table->record[1]+alloc_length;
   }
-  setup_tmp_table_column_bitmaps(table, bitmaps, table->s->fields);
+  setup_tmp_table_column_bitmaps(table, bitmaps, table->s->fields, true);
 
   recinfo= start_recinfo;
   null_flags=(uchar*) table->record[0];

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4304,7 +4304,8 @@ create_result_table(THD *thd_arg, List<Item> *column_types,
                     const LEX_CSTRING *table_alias, bool bit_fields_as_long,
                     bool create_table,
                     bool keep_row_order,
-                    uint hidden)
+                    uint hidden,
+                    bool set_all_bits_of_read_set_to_1)
 {
   DBUG_ASSERT(table == 0);
   tmp_table_param.field_count= column_types->elements;
@@ -4314,7 +4315,8 @@ create_result_table(THD *thd_arg, List<Item> *column_types,
   if (! (table= create_tmp_table(thd_arg, &tmp_table_param, *column_types,
                                  (ORDER*) 0, is_union_distinct, 1,
                                  options, HA_POS_ERROR, table_alias,
-                                 !create_table, keep_row_order)))
+                                 !create_table, keep_row_order,
+                                 set_all_bits_of_read_set_to_1)))
     return TRUE;
 
   col_stat= (Column_statistics*) table->in_use->alloc(table->s->fields *

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -6428,7 +6428,8 @@ public:
                                    bool bit_fields_as_long,
                                    bool create_table,
                                    bool keep_row_order,
-                                   uint hidden);
+                                   uint hidden,
+                                   bool set_all_bits_of_read_set_to_1= true);
   TMP_TABLE_PARAM *get_tmp_table_param() { return &tmp_table_param; }
   void init()
   {
@@ -6616,7 +6617,8 @@ class select_union_recursive :public select_unit
                            bool bit_fields_as_long,
                            bool create_table,
                            bool keep_row_order,
-                           uint hidden);
+                           uint hidden,
+                           bool set_all_bits_of_read_set_to_1= true);
   void cleanup();
 };
 
@@ -6783,7 +6785,8 @@ public:
                            bool bit_fields_as_long,
                            bool create_table,
                            bool keep_row_order,
-                           uint hidden);
+                           uint hidden,
+                           bool set_all_bits_of_read_set_to_1= true);
   bool init_result_table(ulonglong select_options);
   int send_data(List<Item> &items);
   void cleanup();
@@ -8013,7 +8016,8 @@ public:
 extern THD_list server_threads;
 
 void setup_tmp_table_column_bitmaps(TABLE *table, uchar *bitmaps,
-                                    uint field_count);
+                                    uint field_count,
+                                    bool set_all_bits_of_read_set_to_1);
 #ifdef WITH_WSREP
 extern void wsrep_to_isolation_end(THD*);
 #endif

--- a/sql/sql_derived.cc
+++ b/sql/sql_derived.cc
@@ -976,7 +976,6 @@ int find_field_in_list(List<Item> &fields_list, Item *field)
 
 /*
   Find sum_func_to_remove in the JOIN::sum_funcs list and remove it.
-  OLEGS: add logging of the removal to opt_trace or dbug_print (or both)
 */
 static
 void remove_item_from_sum_funcs_list(JOIN *join, Item *sum_func_to_remove)

--- a/sql/sql_select.h
+++ b/sql/sql_select.h
@@ -1495,7 +1495,7 @@ public:
   THD	   *thd;
   Item_sum  **sum_funcs, ***sum_funcs_end;
   /** second copy of sumfuncs (for queries with 2 temporary tables */
-  Item_sum  **sum_funcs2, ***sum_funcs_end2;
+  //Item_sum  **sum_funcs2, ***sum_funcs_end2; /* todo: not used, remove */
   Procedure *procedure;
   Item	    *having;
   Item      *tmp_having; ///< To store having when processed temporary table
@@ -2549,11 +2549,12 @@ void unpack_to_base_table_fields(TABLE *table);
 #define MIN_STRING_LENGTH_TO_PACK_ROWS   10
 
 void calc_group_buffer(TMP_TABLE_PARAM *param, ORDER *group);
-TABLE *create_tmp_table(THD *thd,TMP_TABLE_PARAM *param,List<Item> &fields,
-			ORDER *group, bool distinct, bool save_sum_fields,
-			ulonglong select_options, ha_rows rows_limit,
+TABLE *create_tmp_table(THD *thd, TMP_TABLE_PARAM *param, List<Item> &fields,
+                        ORDER *group, bool distinct, bool save_sum_fields,
+                        ulonglong select_options, ha_rows rows_limit,
                         const LEX_CSTRING *alias, bool do_not_open=FALSE,
-                        bool keep_row_order= FALSE);
+                        bool keep_row_order= FALSE,
+                        bool set_all_bits_of_read_set_to_1= TRUE);
 TABLE *create_tmp_table_for_schema(THD *thd, TMP_TABLE_PARAM *param,
                                    const ST_SCHEMA_TABLE &schema_table,
                                    longlong select_options,

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1498,6 +1498,7 @@ mysqld_list_fields(THD *thd, TABLE_LIST *table_list, const char *wild)
                                      DT_INIT | DT_PREPARE))
     DBUG_VOID_RETURN;
   table= table_list->table;
+  bitmap_set_all(&table->def_read_set);
 
   List<Field> field_list;
 
@@ -4763,6 +4764,8 @@ fill_schema_table_by_open(THD *thd, MEM_ROOT *mem_root,
     if (unlikely(thd->is_error()))
       get_table_engine_for_i_s(thd, buf, table_list, &db_name, &table_name);
 
+    if (table_list->table)
+      bitmap_set_all(&table_list->table->def_read_set);
     result= schema_table->process_table(thd, table_list,
                                         table, result,
                                         orig_db_name,

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -326,6 +326,10 @@ bool select_unit::flush()
       keep_row_order     keep rows in order as they were inserted
       hidden             number of hidden fields (for INTERSECT)
                          plus one for `ALL`
+      set_all_bits_of_read_set_to_1
+                         if set, all bits of TABLE::read_set
+                         will be set to 1, which means all fields of the
+                         table will be marked for read
 
   DESCRIPTION
     Create a temporary table that is used to store the result of a UNION,
@@ -342,7 +346,8 @@ select_unit::create_result_table(THD *thd_arg, List<Item> *column_types,
                                  const LEX_CSTRING *alias,
                                   bool bit_fields_as_long, bool create_table,
                                   bool keep_row_order,
-                                  uint hidden)
+                                  uint hidden,
+                                  bool set_all_bits_of_read_set_to_1)
 {
   DBUG_ASSERT(table == 0);
   tmp_table_param.init();
@@ -354,7 +359,8 @@ select_unit::create_result_table(THD *thd_arg, List<Item> *column_types,
   if (! (table= create_tmp_table(thd_arg, &tmp_table_param, *column_types,
                                  (ORDER*) 0, is_union_distinct, 1,
                                  options, HA_POS_ERROR, alias,
-                                 !create_table, keep_row_order)))
+                                 !create_table, keep_row_order,
+                                 set_all_bits_of_read_set_to_1)))
     return TRUE;
 
   table->keys_in_use_for_query.clear_all();
@@ -376,13 +382,14 @@ select_union_recursive::create_result_table(THD *thd_arg,
                                             bool bit_fields_as_long,
                                             bool create_table,
                                             bool keep_row_order,
-                                            uint hidden)
+                                            uint hidden,
+                                            bool set_all_bits_of_read_set_to_1)
 {
   if (select_unit::create_result_table(thd_arg, column_types,
                                        is_union_distinct, options,
                                        &empty_clex_str, bit_fields_as_long,
                                        create_table, keep_row_order,
-                                       hidden))
+                                       hidden, set_all_bits_of_read_set_to_1))
     return true;
   
   incr_table_param.init();


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27201*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Disable the calculation of aggregate functions whose results are not used,
neither inside the derived table SQL nor outside, in the outer select.
For example, in the following case:
  SELECT sum_b
  FROM (SELECT a, sum(b) AS sum_b, max(c) AS max_c, min(d) AS min_d
        FROM t1
        GROUP BY a
        HAVING max_c > 10
       ) T
T.min_d is not used anywhere, thus there is no need to calculate the
aggregate function min(d).
This applies to both VIEWs and derived tables.

This commit discards setting all bits of read_set for temporary tables
to 1, which was done by default. That allows to determine
which fields of a view/derived table are not used in the outer query.
If some of those fields are aggregate functions (descendants from Item_sum)
there is no need to calculate them (given, of course, that those fields
are neither used inside the derived table/view - in HAVING or ORDER BY clauses).

To disable the calculation of unused aggregate functions they are removed
from JOIN::sum_funcs list and marked as eliminated. So the commit does not
change the item tree (items are left in place) but only disables
their calculation. Marking items as eliminated allows to later eliminate
whole derived tables/views in the corresponding optimization.

## Release Notes
TODO: What should the release notes say about this change?


## How can this PR be tested?

Necessary tests have been added
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
