### PR TITLE
MDEV-33756: Deprecate binlog_optimize_thread_scheduling

### DIFF
--- a/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
@@ -505,7 +505,7 @@ COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	BINLOG_OPTIMIZE_THREAD_SCHEDULING
 VARIABLE_SCOPE	GLOBAL
 VARIABLE_TYPE	BOOLEAN
-VARIABLE_COMMENT	Run fast part of group commit in a single thread, to optimize kernel thread scheduling. On by default. Disable to run each transaction in group commit in its own thread, which can be slower at very high concurrency. This option is mostly for testing one algorithm versus the other, and it should not normally be necessary to change it
+VARIABLE_COMMENT	Run fast part of group commit in a single thread, to optimize kernel thread scheduling. On by default. Disable to run each transaction in group commit in its own thread, which can be slower at very high concurrency. This option is mostly for testing one algorithm versus the other, and it should not normally be necessary to change it. This variable is deprecated and will be removed in a future release
 NUMERIC_MIN_VALUE	NULL
 NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -12605,12 +12605,13 @@ static SHOW_VAR binlog_status_vars_top[]= {
 static MYSQL_SYSVAR_BOOL(
   optimize_thread_scheduling,
   opt_optimize_thread_scheduling,
-  PLUGIN_VAR_READONLY,
+  PLUGIN_VAR_READONLY | PLUGIN_VAR_DEPRECATED,
   "Run fast part of group commit in a single thread, to optimize kernel "
   "thread scheduling. On by default. Disable to run each transaction in group "
   "commit in its own thread, which can be slower at very high concurrency. "
   "This option is mostly for testing one algorithm versus the other, and it "
-  "should not normally be necessary to change it",
+  "should not normally be necessary to change it. This variable is deprecated "
+  "and will be removed in a future release",
   NULL,
   NULL,
   1);


### PR DESCRIPTION
The option binlog_optimize_thread_scheduling was initially added to provide a safe alternative for the newly added binlog group commit logic, such that when 0, it would disable a leader thread from performing the binlog write for all transactions that are a part of the group commit. Any problems related to the binlog group commit optimization should be sorted out by now, so we can deprecate-to-eventually-remove the option altogether.

This commit performs the deprecation, and the removal is tracked by MDEV-33745. Note, as the option is only able to be provided via configuration at startup time, users will not see a deprecation message unless looking through the CLI help message.