### PR TITLE
MDEV-34707: BUF_GET_RECOVER assertion failure on upgrade

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2606,8 +2606,11 @@ buf_page_get_gen(
 	would typically be around 60000 with the default
 	innodb_undo_tablespaces=3, and less than 110000 with the maximum
 	innodb_undo_tablespaces=127. */
+	ut_d(extern bool ibuf_upgrade_was_needed;)
 	ut_ad(mode == BUF_GET_RECOVER
 	      ? recv_recovery_is_on() || log_sys.get_lsn() < 120000
+	      || log_sys.get_lsn() == recv_sys.lsn + SIZE_OF_FILE_CHECKPOINT
+	      || ibuf_upgrade_was_needed
 	      : !recv_recovery_is_on() || recv_sys.after_apply);
 	ut_ad(!mtr || mtr->is_active());
 	ut_ad(mtr || mode == BUF_PEEK_IF_IN_POOL);

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1163,8 +1163,11 @@ static dberr_t srv_log_rebuild_if_needed()
   return srv_log_rebuild();
 }
 
+ut_d(bool ibuf_upgrade_was_needed;)
+
 ATTRIBUTE_COLD static dberr_t ibuf_log_rebuild_if_needed()
 {
+  ut_d(ibuf_upgrade_was_needed= true;)
   mysql_mutex_lock(&recv_sys.mutex);
   recv_sys.apply(true);
   mysql_mutex_unlock(&recv_sys.mutex);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-34707](https://jira.mariadb.org/browse/MDEV-34707)*
## Description
`buf_page_get_gen()`: Relax the assertion once more. The LSN may grow by invoking `ibuf_upgrade()`, that is, when upgrading files where `innodb_change_buffering≠none` was used. The LSN may also have been recovered from a log that needs to be upgraded to the current format.
## Release Notes
N/A. This was a false alarm in a debug assertion whose intention is to catch the misuse of an internal API.
## How can this PR be tested?
1. Download the attachment from [MDEV-34707](https://jira.mariadb.org/browse/MDEV-34707)
2. `7z x dt.7z`
2. (Optional:) Start up and shut down MariaDB Server 10.5 or 10.6 with `--datadir` pointing to the `dt` subdirectory that was extracted in the previous step.
3. Start up MariaDB Server 11.x with `--datadir` pointing to the `dt `subdirectory.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
The earliest applicable branch is 11.1, but I think that this will be pushed after the pending quarterly releases, at which point the 11.2 branch would be the last maintained one.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.