### PR TITLE
MDEV-20153: Slave error message incorrectly mentions server_uuid

### DIFF
--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -8698,7 +8698,7 @@ ER_JSON_PATH_EMPTY
         eng "Path expression '$' is not allowed in argument %d to function '%s'."
 ER_SLAVE_SAME_ID
         chi "与此从站相同的server_uuId / server_id的从站已连接到主设备"
-        eng "A slave with the same server_uuid/server_id as this slave has connected to the master"
+        eng "A slave with the same server_id as this slave has connected to the master"
 ER_FLASHBACK_NOT_SUPPORTED
         chi "闪回不支持%s%s"
         eng "Flashback does not support %s %s"

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -3001,8 +3001,8 @@ err:
 
   if (info->thd->killed == KILL_SLAVE_SAME_ID)
   {
-    info->errmsg= "A slave with the same server_uuid/server_id as this slave "
-                  "has connected to the master";
+    info->errmsg= "A slave with the same server_id as this slave has "
+                  "connected to the master";
     info->error= ER_SLAVE_SAME_ID;
   }
 


### PR DESCRIPTION
Correct an error message thrown by the slave to remove the descriptor "slave_uuid", as it was never ported to MariaDB