### PR TITLE
fix typo at mysql-test README

### DIFF
--- a/mysql-test/README
+++ b/mysql-test/README
@@ -5,15 +5,18 @@ Some tests are known to fail on some platforms or be otherwise unreliable.
 In the file collections/smoke_test there is a list of tests that are
 expected to be stable.
 
-In general you do not have to have to do "make install", and you can have
+In general you do not have to do "make install", and you can have
 a co-existing MariaDB installation, the tests will not conflict with it.
 To run the tests in a source directory, you must do "make" first.
 
 In Red Hat distributions, you should run the script as user "mysql".
 The user is created with nologin shell, so the best bet is something like
-  # su -
-  # cd /usr/share/mariadb-test
-  # su -s /bin/bash mysql -c ./mysql-test-run
+
+# su -
+
+# cd /usr/share/mariadb-test
+
+# su -s /bin/bash mysql -c ./mysql-test-run
 
 This will use the installed MariaDB executables, but will run a private
 copy of the server process (using data files within /usr/share/mariadb-test),
@@ -23,7 +26,8 @@ You can omit --skip-test-list option if you want to check whether
 the listed failures occur for you.
 
 To clean up afterwards, remove the created "var" subdirectory, e.g.
-  # su -s /bin/bash - mysql -c "rm -rf /usr/share/mariadb-test/var"
+
+# su -s /bin/bash - mysql -c "rm -rf /usr/share/mariadb-test/var"
 
 If tests fail on your system, please read the following manual section
 for instructions on how to report the problem:
@@ -37,7 +41,7 @@ you are expected to provide names of the tests to run.
 For example, here is the command to run the "alias" and "analyze" tests
 with an external server:
 
-  # mariadb-test-run --extern socket=/tmp/mysql.sock alias analyze
+# mariadb-test-run --extern socket=/tmp/mysql.sock alias analyze
 
 To match your setup, you might need to provide other relevant options.
 
@@ -51,7 +55,7 @@ You can create your own test cases. To create a test case, create a new
 file in the main subdirectory using a text editor. The file should have a .test
 extension. For example:
 
-  # xemacs t/test_case_name.test
+# xemacs t/test_case_name.test
 
 In the file, put a set of SQL statements that create some tables,
 load test data, and run some queries to manipulate it.
@@ -63,20 +67,20 @@ and over again.
 If you are using mysqltest commands in your test case, you should create
 the result file as follows:
 
-  # mariadb-test-run --record test_case_name
+# mariadb-test-run --record test_case_name
 
-  or
+or
 
-  # mariadb-test --record < t/test_case_name.test
+# mariadb-test --record < t/test_case_name.test
 
 If you only have a simple test case consisting of SQL statements and
 comments, you can create the result file in one of the following ways:
 
-  # mariadb-test-run --record test_case_name
+# mariadb-test-run --record test_case_name
 
-  # mariadb test < t/test_case_name.test > r/test_case_name.result
+# mariadb test < t/test_case_name.test > r/test_case_name.result
 
-  # mariadb-test --record --database test --result-file=r/test_case_name.result < t/test_case_name.test
+# mariadb-test --record --database test --result-file=r/test_case_name.result < t/test_case_name.test
 
 When this is done, take a look at r/test_case_name.result.
 If the result is incorrect, you have found a bug. In this case, you should


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
There is a typo at the mysql-test README. so I fixed it!

## Release Notes
None.

## How can this PR be tested?
There is no functional change.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
