### PR TITLE
Fix typo at mysql-test README

### DIFF
--- a/mysql-test/README
+++ b/mysql-test/README
@@ -5,7 +5,7 @@ Some tests are known to fail on some platforms or be otherwise unreliable.
 In the file collections/smoke_test there is a list of tests that are
 expected to be stable.
 
-In general you do not have to have to do "make install", and you can have
+In general you do not have to do "make install", and you can have
 a co-existing MariaDB installation, the tests will not conflict with it.
 To run the tests in a source directory, you must do "make" first.
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
There is a typo at the mysql-test README. so I fixed it!

## Release Notes
None.

## How can this PR be tested?
There is no functional change.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
