### PR TITLE
MDEV-34750 SET GLOBAL innodb_log_file_size is not crash safe

### DIFF
--- a/mysql-test/suite/innodb/r/log_file_size_online.result
+++ b/mysql-test/suite/innodb/r/log_file_size_online.result
@@ -19,8 +19,10 @@ SHOW VARIABLES LIKE 'innodb_log_file_size';
 Variable_name	Value
 innodb_log_file_size	4194304
 FOUND 1 /InnoDB: Resized log to 4\.000MiB/ in mysqld.1.err
-UPDATE t SET b='' WHERE a<10;
 SET GLOBAL innodb_log_file_size=5242880;
+connect con1,localhost,root;
+UPDATE t SET b='' WHERE a<10;
+connection default;
 SHOW VARIABLES LIKE 'innodb_log_file_size';
 Variable_name	Value
 innodb_log_file_size	5242880
@@ -28,6 +30,9 @@ SELECT global_value FROM information_schema.system_variables
 WHERE variable_name = 'innodb_log_file_size';
 global_value
 5242880
+connection con1;
+disconnect con1;
+connection default;
 # restart
 SELECT * FROM t WHERE a<10;
 a	b
@@ -40,6 +45,10 @@ a	b
 7	
 8	
 9	
+SELECT COUNT(*),LENGTH(b) FROM t GROUP BY b;
+COUNT(*)	LENGTH(b)
+9	0
+19991	255
 SHOW VARIABLES LIKE 'innodb_log_file_size';
 Variable_name	Value
 innodb_log_file_size	5242880

--- a/mysql-test/suite/innodb/t/log_file_size_online.test
+++ b/mysql-test/suite/innodb/t/log_file_size_online.test
@@ -25,17 +25,28 @@ SHOW VARIABLES LIKE 'innodb_log_file_size';
 let SEARCH_PATTERN = InnoDB: Resized log to 4\\.000MiB;
 --source include/search_pattern_in_file.inc
 
-UPDATE t SET b='' WHERE a<10;
+send SET GLOBAL innodb_log_file_size=5242880;
 
-SET GLOBAL innodb_log_file_size=5242880;
+--connect con1,localhost,root
+send UPDATE t SET b='' WHERE a<10;
+
+--connection default
+reap;
 SHOW VARIABLES LIKE 'innodb_log_file_size';
 SELECT global_value FROM information_schema.system_variables
 WHERE variable_name = 'innodb_log_file_size';
 
+--connection con1
+reap;
+--disconnect con1
+--connection default
+
+--let $shutdown_timeout=0
 --let $restart_parameters=
 --source include/restart_mysqld.inc
 
 SELECT * FROM t WHERE a<10;
+SELECT COUNT(*),LENGTH(b) FROM t GROUP BY b;
 
 SHOW VARIABLES LIKE 'innodb_log_file_size';
 let SEARCH_PATTERN = InnoDB: Resized log to 5\\.000MiB;

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -224,7 +224,7 @@ public:
   /** exclusive latch for checkpoint, shared for mtr_t::commit() to buf */
   alignas(CPU_LEVEL1_DCACHE_LINESIZE) log_rwlock latch;
 
-  /** number of std::swap(buf, flush_buf) and writes from buf to log;
+  /** number of writes from buf or flush_buf to log;
   protected by latch.wr_lock() */
   ulint write_to_log;
 
@@ -232,8 +232,9 @@ public:
   lsn_t write_lsn;
 
   /** buffer for writing data to ib_logfile0, or nullptr if is_pmem()
-  In write_buf(), buf and flush_buf are swapped */
+  In write_buf(), buf and flush_buf may be swapped */
   byte *flush_buf;
+
   /** set when there may be need to initiate a log checkpoint.
   This must hold if lsn - last_checkpoint_lsn > max_checkpoint_age. */
   std::atomic<bool> need_checkpoint;
@@ -370,9 +371,10 @@ public:
 
 private:
   /** Write resize_buf to resize_log.
-  @param length  the used length of resize_buf */
+  @param b       resize_buf or resize_flush_buf
+  @param length  the used length of b */
   ATTRIBUTE_COLD ATTRIBUTE_NOINLINE
-  void resize_write_buf(size_t length) noexcept;
+  void resize_write_buf(const byte *b, size_t length) noexcept;
 public:
 
   /** Rename a log file after resizing.
@@ -502,13 +504,7 @@ public:
   @param d     destination
   @param s     string of bytes
   @param size  length of str, in bytes */
-  void append(byte *&d, const void *s, size_t size) noexcept
-  {
-    ut_ad(latch_have_any());
-    ut_ad(d + size <= buf + (is_pmem() ? file_size : buf_size));
-    memcpy(d, s, size);
-    d+= size;
-  }
+  static inline void append(byte *&d, const void *s, size_t size) noexcept;
 
   /** Set the log file format. */
   void set_latest_format(bool encrypted) noexcept

--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -1310,6 +1310,15 @@ inline void log_t::resize_write(lsn_t lsn, const byte *end, size_t len,
   }
 }
 
+inline void log_t::append(byte *&d, const void *s, size_t size) noexcept
+{
+  ut_ad(log_sys.latch_have_any());
+  ut_ad(d + size <= log_sys.buf +
+        (log_sys.is_pmem() ? log_sys.file_size : log_sys.buf_size));
+  memcpy(d, s, size);
+  d+= size;
+}
+
 template<bool spin,bool pmem>
 std::pair<lsn_t,mtr_t::page_flush_ahead>
 mtr_t::finish_writer(mtr_t *mtr, size_t len)


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34750*
## Description
The recent commit 4ca355d863e3b6a14439eebbb2958afccb3548e3 (MDEV-33894) caused a serious regression for online InnoDB `ib_logfile0` resizing, breaking crash-safety unless the memory-mapped log file interface is being used. However, the log resizing was broken also before this.
## Release Notes
If InnoDB was killed soon after executing `SET GLOBAL innodb_log_file_size`, it could fail to recover.
## How can this PR be tested?
To prevent such regressions in the future, we will extend the test `innodb.log_file_size_online` with a kill and restart of the server and with some writes running concurrently with the log size change.

I tested this on a 4-thread system with the following invocation, not using memory-mapped log (`/dev/shm` or `WITH_INNODB_PMEM`): 
```bash
./mtr --parallel=auto --repeat=10 innodb.log_file_size_online{,}
```
Memory-mapped log files were not affected by this, but by #3355.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.