### PR TITLE
MDEV-33075 [backport/2f5174e556] [10.11] Resolve server shutdown issues on macOS, Solaris, and FreeBSD

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2092,6 +2092,7 @@ static void clean_up(bool print_message)
 */
 static void wait_for_signal_thread_to_end()
 {
+#ifndef _WIN32
   uint i, n_waits= DBUG_IF("force_sighup_processing_timeout") ? 5 : 100;
   int err= 0;
   /*
@@ -2100,9 +2101,7 @@ static void wait_for_signal_thread_to_end()
   */
   for (i= 0 ; i < n_waits && signal_thread_in_use; i++)
   {
-    err= pthread_kill(signal_thread, MYSQL_KILL_SIGNAL);
-    if (err)
-      break;
+    kill(getpid(), MYSQL_KILL_SIGNAL);
     my_sleep(100000); // Give it time to die, .1s per iteration
   }
 
@@ -2119,6 +2118,7 @@ static void wait_for_signal_thread_to_end()
                       "Continuing to wait for it to stop..");
     pthread_join(signal_thread, NULL);
   }
+#endif
 }
 #endif /*EMBEDDED_LIBRARY*/
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3224,23 +3224,14 @@ static void start_signal_handler(void)
   DBUG_VOID_RETURN;
 }
 
-/** Called only from signal_hand function. */
-static void* exit_signal_handler()
-{
-    my_thread_end();
-    signal_thread_in_use= 0;
-    pthread_exit(0);  // Safety
-    return nullptr;  // Avoid compiler warnings
-}
-
-
-/** This threads handles all signals and alarms. */
+/** This threads handles all signals */
 /* ARGSUSED */
-pthread_handler_t signal_hand(void *arg __attribute__((unused)))
+pthread_handler_t signal_hand(void *)
 {
   sigset_t set;
   int sig;
   my_thread_init();				// Init new thread
+  DBUG_ENTER("signal_hand");
   signal_thread_in_use= 1;
 
   /*
@@ -3289,16 +3280,17 @@ pthread_handler_t signal_hand(void *arg __attribute__((unused)))
     int error;
     int origin;
 
-    while ((error= my_sigwait(&set, &sig, &origin)) == EINTR) /* no-op */;
     if (abort_loop)
-    {
-      DBUG_PRINT("quit",("signal_handler: calling my_thread_end()"));
-      return exit_signal_handler();
-    }
+      break;
+
+    while ((error= my_sigwait(&set, &sig, &origin)) == EINTR) /* no-op */;
+
+    if (abort_loop)
+      break;
+
     switch (sig) {
     case SIGTERM:
     case SIGQUIT:
-    case SIGKILL:
 #ifdef EXTRA_DEBUG
       sql_print_information("Got signal %d to shutdown server",sig);
 #endif
@@ -3306,22 +3298,15 @@ pthread_handler_t signal_hand(void *arg __attribute__((unused)))
       logger.set_handlers(global_system_variables.sql_log_slow ? LOG_FILE:LOG_NONE,
                           opt_log ? LOG_FILE:LOG_NONE);
       DBUG_PRINT("info",("Got signal: %d  abort_loop: %d",sig,abort_loop));
-      if (!abort_loop)
-      {
-        /* Delete the instrumentation for the signal thread */
-        PSI_CALL_delete_current_thread();
-        my_sigset(sig, SIG_IGN);
-        break_connect_loop(); // MIT THREAD has a alarm thread
-        return exit_signal_handler();
-      }
+
+      break_connect_loop();
+      DBUG_ASSERT(abort_loop);
       break;
     case SIGHUP:
 #if defined(SI_KERNEL)
-      if (!abort_loop && origin != SI_KERNEL)
+      if (origin != SI_KERNEL)
 #elif defined(SI_USER)
-      if (!abort_loop && origin <= SI_USER)
-#else
-      if (!abort_loop)
+      if (origin <= SI_USER)
 #endif
       {
         int not_used;
@@ -3341,11 +3326,6 @@ pthread_handler_t signal_hand(void *arg __attribute__((unused)))
                             opt_log ? fixed_log_output_options : LOG_NONE);
       }
       break;
-#ifdef USE_ONE_SIGNAL_HAND
-    case THR_SERVER_ALARM:
-      process_alarm(sig);			// Trigger alarms.
-      break;
-#endif
     default:
 #ifdef EXTRA_DEBUG
       sql_print_warning("Got signal: %d  error: %d",sig,error); /* purecov: tested */
@@ -3353,6 +3333,11 @@ pthread_handler_t signal_hand(void *arg __attribute__((unused)))
       break;					/* purecov: tested */
     }
   }
+  DBUG_PRINT("quit", ("signal_handler: calling my_thread_end()"));
+  my_thread_end();
+  DBUG_LEAVE; // Must match DBUG_ENTER()
+  signal_thread_in_use= 0;
+  pthread_exit(0); // Safety
   return(0);					/* purecov: deadcode */
 }
 


### PR DESCRIPTION
Backport of 2f5174e556cd247133aa14d7b37372ae49fe83c5: MDEV-33075 Resolve server shutdown issues on macOS, Solaris, and FreeBSD.

This commit addresses multiple server shutdown problems observed on macOS,
Solaris, and FreeBSD:

1. Corrected a non-portable assumption where socket shutdown was expected
to wake up poll() with listening sockets in the main thread.

Use more robust self-pipe to wake up poll() by writing to the pipe's write
end.

2. Fixed a random crash on macOS from pthread_kill(signal_handler)
when the signal_handler was detached and the thread had already exited.

Use more robust `kill(getpid(), SIGTERM)` to wake up the signal handler
thread.

3. Made sure, that signal handler thread always exits once `abort_loop` is
set, and also calls `my_thread_end()` and clears `signal_thread_in_use`
when exiting.

This fixes warning "1 thread did not exit"  by `my_global_thread_end()`
seen on FreeBSD/macOS when the process is terminated via signal.

Additionally, the shutdown code underwent light refactoring
for better readability and maintainability:

- Modified `break_connect_loop()` to no longer wait for the main thread,
  aligning behavior with Windows (since 10.4).
- Removed dead code related to the unused `USE_ONE_SIGNAL_HAND`
  preprocessor constant.
- Eliminated support for `#ifndef HAVE_POLL` in `handle_connection_sockets`
  This code is also dead, since 10.4