### PR TITLE
Fix typo in xtrabackup output

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -1704,7 +1704,7 @@ struct my_option xb_server_options[] =
    0, GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0 },
 
   {"check-privileges", OPT_XTRA_CHECK_PRIVILEGES, "Check database user "
-   "privileges fro the backup user",
+   "privileges for the backup user",
    &opt_check_privileges, &opt_check_privileges,
    0, GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0 },
 


### PR DESCRIPTION
## Description
Typo fixed

## Release Notes
Irrelevant for this change

## How can this PR be tested?
Irrelevant for this change

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

## Basing the PR against the correct MariaDB version
Neither of the boxes apply. I took the latest release-branch.

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
