### PR TITLE
MDEV-34753 memory pressure - erroneous termination condition

### DIFF
--- a/mysql-test/include/have_cgroupv2.inc
+++ b/mysql-test/include/have_cgroupv2.inc
@@ -1,0 +1,28 @@
+--source include/linux.inc
+--error 0,1
+perl;
+use strict;
+use warnings;
+use File::Spec;
+
+# Read the cgroup file
+my $cgroup_file = '/proc/self/cgroup';
+open my $fh, '<', $cgroup_file or exit 1;
+my $line = <$fh>;
+close $fh;
+
+# Process the cgroup file content
+$line =~ s/^0:://;
+chomp($line);
+
+# Construct the path
+my $path = File::Spec->catdir('/sys/fs/cgroup', $line, 'memory.pressure');
+
+# Check if the file is writable exists
+exit 0 if -w $path;
+exit 1;
+EOF
+if ($errno)
+{
+  --skip Requires cgroupv2
+}

--- a/mysql-test/suite/innodb/r/mem_pressure.result
+++ b/mysql-test/suite/innodb/r/mem_pressure.result
@@ -15,6 +15,7 @@ FROM INFORMATION_SCHEMA.GLOBAL_STATUS
 WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';
 set debug_dbug="d,trigger_garbage_collection";
 SET GLOBAL innodb_buffer_pool_size=@@innodb_buffer_pool_size;
+FOUND 1 /[Mm]emory pressure.*/ in mysqld.1.err
 SELECT CAST(VARIABLE_VALUE AS INTEGER) < @dirty_prev AS LESS_DIRTY_IS_GOOD
 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
 WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';

--- a/mysql-test/suite/innodb/t/mem_pressure.test
+++ b/mysql-test/suite/innodb/t/mem_pressure.test
@@ -1,5 +1,5 @@
 --source include/have_debug.inc
---source include/linux.inc
+--source include/have_cgroupv2.inc
 --source include/not_embedded.inc
 --source include/have_innodb.inc
 --source include/have_sequence.inc
@@ -31,11 +31,15 @@ WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';
 set debug_dbug="d,trigger_garbage_collection";
 SET GLOBAL innodb_buffer_pool_size=@@innodb_buffer_pool_size;
 
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+# either a fail or the pressure event
+let SEARCH_PATTERN= [Mm]emory pressure.*;
+--source include/search_pattern_in_file.inc
+
 SELECT CAST(VARIABLE_VALUE AS INTEGER) < @dirty_prev AS LESS_DIRTY_IS_GOOD
 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
 WHERE VARIABLE_NAME='Innodb_buffer_pool_pages_dirty';
 
-let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
 let SEARCH_PATTERN= InnoDB: Memory pressure event freed.*;
 --source include/search_pattern_in_file.inc
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34753*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The 'if (!m_abort) break' condition was inverted by accident.

Thanks Kristian Nielsen for noticing.

## Release Notes

Linux memory pressure events are now correctly handled.

## How can this PR be tested?

innodb.mem_pressure tests shows the handling:

Version: '10.11.10-MariaDB-debug-log'  socket: '/home/dan/repos/build-mariadb-server-10.11-debug/mysql-test/var/tmp/mysqld.1.sock'  port: 19000  Source distribution
2024-08-14  8:23:29 4 [Note] InnoDB: Memory pressure event freed 146 pages
2024-08-14  8:23:29 0 [Note] InnoDB: Memory pressure event freed 0 pages

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.