### PR TITLE
MDEV-34278: Implements DISTINCT for ST_Collect

### DIFF
--- a/mysql-test/main/spatial_utility_function_collect.result
+++ b/mysql-test/main/spatial_utility_function_collect.result
@@ -18,6 +18,13 @@ ST_EQUALS( (SELECT ST_COLLECT( location ) AS t FROM
 table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,0 0,1 0,2
 0,3 0) ',4326))
 1
+SELECT ST_EQUALS( (SELECT ST_COLLECT( DISTINCT location ) AS t FROM
+table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,1 0,2 0,3
+0) ',4326));
+ST_EQUALS( (SELECT ST_COLLECT( DISTINCT location ) AS t FROM
+table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,1 0,2 0,3
+0) ',4326))
+1
 INSERT INTO table_simple_aggregation (location) VALUES
 ( ST_GEOMFROMTEXT('POINT(0 -0)'         ,4326)),
 ( NULL);

--- a/mysql-test/main/spatial_utility_function_collect.test
+++ b/mysql-test/main/spatial_utility_function_collect.test
@@ -35,9 +35,9 @@ table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,0 0,1 0,2
 0,3 0) ',4326));
 # --echo # Functional requirement F-8 Shall support DISTINCT in aggregates
 # --echo # result shall be 1
-# SELECT ST_EQUALS( (SELECT ST_COLLECT( DISTINCT location ) AS t FROM
-# table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,1 0,2 0,3
-# 0) ',4326));
+SELECT ST_EQUALS( (SELECT ST_COLLECT( DISTINCT location ) AS t FROM
+table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,1 0,2 0,3
+0) ',4326));
 # --echo # Functional requirement F-5: ST_COLLECT shall support group by, which
 # --echo # is given by aggregation machinery
 # --echo # result shall be

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -4649,6 +4649,9 @@ bool Item_func_collect::add() {
   if (tmp_arg[0]->null_value)
     return 0;
 
+  if(is_distinct && list_contains_element(wkb))
+    return 0;
+
   current_geometry_srid= uint4korr(wkb->ptr());
   if (geometries.is_empty())
     srid= current_geometry_srid;
@@ -4664,7 +4667,6 @@ bool Item_func_collect::add() {
 
 
 void Item_func_collect::remove() {
-  String value;
   String *wkb= args[0]->val_str(&value);
   has_cached_result= false;
 
@@ -4689,17 +4691,34 @@ void Item_func_collect::remove() {
 }
 
 
-Item_func_collect::Item_func_collect(THD *thd, Item *item_par) :
+bool Item_func_collect::list_contains_element(String *wkb) {
+  List_iterator<String> geometries_iterator(geometries);
+  String* temp_geometry;
+  while ((temp_geometry= geometries_iterator++))
+  {
+    String temp(temp_geometry->ptr(), temp_geometry->length(), &my_charset_bin);
+
+    if (wkb->eq(&temp, &my_charset_bin))
+      return true;
+  }
+
+  return false;
+}
+
+
+Item_func_collect::Item_func_collect(THD *thd, bool is_distinct, Item *item_par) :
   Item_sum_int(thd, item_par),
   mem_root(thd->mem_root),
+  is_distinct(is_distinct),
   group_collect_max_len(thd->variables.group_concat_max_len)
 {
 }
 
 
-Item_func_collect::Item_func_collect(THD *thd, Item_func_collect *item) :
+Item_func_collect::Item_func_collect(THD *thd, bool is_distinct, Item_func_collect *item) :
   Item_sum_int(thd, item),
   mem_root(thd->mem_root),
+  is_distinct(is_distinct),
   group_collect_max_len(thd->variables.group_concat_max_len)
 {
 }
@@ -4776,5 +4795,5 @@ String *Item_func_collect::val_str(String *str)
 
 
 Item *Item_func_collect::copy_or_same(THD *thd) {
-  return new (thd->mem_root) Item_func_collect(thd, this);
+  return new (thd->mem_root) Item_func_collect(thd, is_distinct, this);
 }

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -2125,6 +2125,7 @@ class Item_func_collect :public Item_sum_int
   bool has_cached_result;
   String cached_result;
   MEM_ROOT *mem_root;
+  bool is_distinct;
   List<String> geometries;
   String value;
   const uint group_collect_max_len;
@@ -2133,10 +2134,11 @@ class Item_func_collect :public Item_sum_int
   bool add() override;
   void cleanup() override;
   void remove() override;
+  bool list_contains_element(String* wkb);
 
 public:
-  Item_func_collect(THD *thd, Item *item_par);
-  Item_func_collect(THD *thd, Item_func_collect *item);
+  Item_func_collect(THD *thd, bool is_distinct, Item *item_par);
+  Item_func_collect(THD *thd, bool is_distinct, Item_func_collect *item);
 
   enum Sumfunctype sum_func () const override
   {

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -11033,9 +11033,9 @@ sum_expr:
             if (unlikely($$ == NULL))
               MYSQL_YYABORT;
           }
-        | ST_COLLECT_SYM '(' in_sum_expr ')'
+        | ST_COLLECT_SYM '(' opt_distinct in_sum_expr ')'
           {
-            $$= new (thd->mem_root) Item_func_collect(thd, $3);
+            $$= new (thd->mem_root) Item_func_collect(thd, $3, $4);
             if (unlikely($$ == NULL))
               MYSQL_YYABORT;
           }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: [MDEV-34278](https://jira.mariadb.org/browse/MDEV-34278)

## Description

This PR implements the `DISTINCT` clause for the `ST_Collect` function.

To ensure compatibility between the MySQL implementation of this function and the MariaDB implementation, the tests for this function have been cherry-picked from MySQL.

This patch has no side effects.

## Release Notes
Adds the `DISTINCT clause for `ST_Collect` function.

## How can this PR be tested?

An extensive test suite has been cherry-picked from MySQL.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
