### PR TITLE
MDEV-34756  Validation of new foreign key skipped if innodb_alter_copy_bulk= ON

### DIFF
--- a/mysql-test/suite/innodb/r/alter_copy_bulk.result
+++ b/mysql-test/suite/innodb/r/alter_copy_bulk.result
@@ -22,3 +22,30 @@ ALTER TABLE t1 FORCE;
 INSERT INTO t1 SELECT seq, seq * 2 FROM seq_3_to_65536;
 ALTER TABLE t1 ADD INDEX(f2);
 DROP TABLE t1;
+#
+# MDEV-34756 Validation of new foreign key skipped
+#            if innodb_alter_copy_bulk=ON
+#
+CREATE TABLE t1(f1 INT NOT NULL PRIMARY KEY,
+f2 INT NOT NULL)ENGINE=InnoDB;
+CREATE TABLE t2(f1 INT NOT NULL PRIMARY KEY,
+f2 INT NOT NULL)ENGINE=InnoDB;
+ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(f1) REFERENCES t1(f1);
+affected rows: 0
+info: Records: 0  Duplicates: 0  Warnings: 0
+INSERT INTO t1 VALUES (1, 1);
+INSERT INTO t2 VALUES (1, 2);
+ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(f2) REFERENCES t1(f1);
+ERROR 23000: Cannot add or update a child row: a foreign key constraint fails (`test`.`#sql-alter`, CONSTRAINT `#sql-alter_ibfk_2` FOREIGN KEY (`f2`) REFERENCES `t1` (`f1`))
+INSERT INTO t1 VALUES(3, 1);
+SET STATEMENT foreign_key_checks=0 FOR
+ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(f2) REFERENCES t1(f1);
+affected rows: 1
+info: Records: 1  Duplicates: 0  Warnings: 0
+ALTER TABLE t1 FORCE;
+affected rows: 2
+info: Records: 2  Duplicates: 0  Warnings: 0
+ALTER TABLE t2 FORCE;
+affected rows: 1
+info: Records: 1  Duplicates: 0  Warnings: 0
+DROP TABLE t2, t1;

--- a/mysql-test/suite/innodb/t/alter_copy_bulk.test
+++ b/mysql-test/suite/innodb/t/alter_copy_bulk.test
@@ -42,3 +42,28 @@ INSERT INTO t1 SELECT seq, seq * 2 FROM seq_3_to_65536;
 # Alter should use temporary file for sorting
 ALTER TABLE t1 ADD INDEX(f2);
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-34756 Validation of new foreign key skipped
+--echo #            if innodb_alter_copy_bulk=ON
+--echo #
+CREATE TABLE t1(f1 INT NOT NULL PRIMARY KEY,
+		f2 INT NOT NULL)ENGINE=InnoDB;
+CREATE TABLE t2(f1 INT NOT NULL PRIMARY KEY,
+		f2 INT NOT NULL)ENGINE=InnoDB;
+--enable_info
+ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(f1) REFERENCES t1(f1);
+--disable_info
+INSERT INTO t1 VALUES (1, 1);
+INSERT INTO t2 VALUES (1, 2);
+--replace_regex /#sql-alter-[0-9a-f-]*/#sql-alter/
+--error ER_NO_REFERENCED_ROW_2
+ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(f2) REFERENCES t1(f1);
+INSERT INTO t1 VALUES(3, 1);
+--enable_info
+SET STATEMENT foreign_key_checks=0 FOR
+ALTER TABLE t2 ADD CONSTRAINT FOREIGN KEY(f2) REFERENCES t1(f1);
+ALTER TABLE t1 FORCE;
+ALTER TABLE t2 FORCE;
+--disable_info
+DROP TABLE t2, t1;

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2775,10 +2775,16 @@ avoid_bulk:
 
 		ut_ad(index->table->skip_alter_undo);
 		ut_ad(!entry->is_metadata());
+
+		/* If foreign key exist and foreign key is enabled
+		then avoid using bulk insert for copy algorithm */
 		if (innodb_alter_copy_bulk
 		    && !index->table->is_temporary()
 		    && !index->table->versioned()
-		    && !index->table->has_spatial_index()) {
+		    && !index->table->has_spatial_index()
+		    && (!trx->check_foreigns
+                        || (index->table->foreign_set.empty()
+                            && index->table->referenced_set.empty()))) {
 			ut_ad(page_is_empty(block->page.frame));
 			/* This code path has been executed at the
 			start of the alter operation. Consecutive


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-34756*

## Description
- During copy algorithm, InnoDB should disable bulk insert operation if the table has foreign key relation and foreign key check is enabled.
## How can this PR be tested?
./mtr innodb.alter_copy_bulk

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
