### PR TITLE
MDEV-34529  Shrink the system tablespace when system tablespace contains MDEV-30671 leaked undo pages

### DIFF
--- a/mysql-test/suite/innodb/r/recovery_shutdown.result
+++ b/mysql-test/suite/innodb/r/recovery_shutdown.result
@@ -1,5 +1,6 @@
 FLUSH TABLES;
 call mtr.add_suppression("Found 1 prepared XA transactions");
+call mtr.add_suppression("InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0 or XA PREPARE transactions exist");
 #
 # MDEV-13797 InnoDB may hang if shutdown is initiated soon after startup
 # while rolling back recovered incomplete transactions

--- a/mysql-test/suite/innodb/r/sys_truncate_debug.result
+++ b/mysql-test/suite/innodb/r/sys_truncate_debug.result
@@ -19,8 +19,15 @@ InnoDB		0 transactions not purged
 SELECT NAME, FILE_SIZE FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE SPACE = 0;
 NAME	FILE_SIZE
 innodb_system	540016640
-# restart: --debug_dbug=+d,shrink_buffer_pool_full
+# restart: --debug_dbug=+d,traversal_extent_fail
 FOUND 1 /\[Warning\] InnoDB: Cannot shrink the system tablespace/ in mysqld.1.err
+SELECT * FROM INFORMATION_SCHEMA.ENGINES
+WHERE engine = 'innodb'
+AND support IN ('YES', 'DEFAULT', 'ENABLED');
+ENGINE	SUPPORT	COMMENT	TRANSACTIONS	XA	SAVEPOINTS
+InnoDB	YES	Supports transactions, row-level locking, foreign keys and encryption for tables	YES	YES	YES
+# restart: --debug_dbug=+d,shrink_buffer_pool_full
+FOUND 2 /\[Warning\] InnoDB: Cannot shrink the system tablespace/ in mysqld.1.err
 SELECT * FROM INFORMATION_SCHEMA.ENGINES
 WHERE engine = 'innodb'
 AND support IN ('YES', 'DEFAULT', 'ENABLED');

--- a/mysql-test/suite/innodb/r/undo_leak.result
+++ b/mysql-test/suite/innodb/r/undo_leak.result
@@ -1,0 +1,25 @@
+# restart: --debug_dbug=d,undo_segment_leak
+SET GLOBAL INNODB_FILE_PER_TABLE=0;
+Warnings:
+Warning	1287	'@@innodb_file_per_table' is deprecated and will be removed in a future release
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+UPDATE t1 SET f1 = f1 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f1 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f1 + 1 WHERE f1 > 1000;
+DELETE FROM t1;
+DROP TABLE t1;
+set GLOBAL innodb_fast_shutdown=0;
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	79691776
+# restart
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	12582912

--- a/mysql-test/suite/innodb/r/undo_leak_fail.result
+++ b/mysql-test/suite/innodb/r/undo_leak_fail.result
@@ -1,0 +1,94 @@
+call mtr.add_suppression("InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0");
+call mtr.add_suppression("InnoDB: :autoshrink failed to read the used segment");
+call mtr.add_suppression("InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FULL list");
+call mtr.add_suppression("InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FREE list");
+call mtr.add_suppression("InnoDB: :autoshrink failed to free the segment");
+call mtr.add_suppression("Found .* prepared XA transactions");
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	10485760
+SET GLOBAL INNODB_FILE_PER_TABLE=0;
+Warnings:
+Warning	1287	'@@innodb_file_per_table' is deprecated and will be removed in a future release
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL)STATS_PERSISTENT=0, ENGINE=InnoDB;
+XA START 'x';
+insert into t1 values (1, 1);
+XA END 'x';
+XA PREPARE 'x';
+set GLOBAL innodb_fast_shutdown=0;
+# restart
+# Fail to free the segment due to XA PREPARE transaction
+FOUND 2 /InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0/ in mysqld.1.err
+XA COMMIT 'x';
+DROP TABLE t1;
+# restart: --debug_dbug=d,undo_segment_leak
+SET GLOBAL INNODB_FILE_PER_TABLE=0;
+Warnings:
+Warning	1287	'@@innodb_file_per_table' is deprecated and will be removed in a future release
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL)STATS_PERSISTENT=0, ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+UPDATE t1 SET f1 = f1 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f1 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f1 + 1 WHERE f1 > 1000;
+DELETE FROM t1;
+DROP TABLE t1;
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	77594624
+# restart: --debug_dbug=d,unused_undo_free_fail_1
+# Fail to free the segment due to previous shutdown
+FOUND 4 /InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0/ in mysqld.1.err
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	15728640
+SET GLOBAL innodb_fast_shutdown= 0;
+# Fail to free the segment while finding the used segments
+# restart: --debug_dbug=d,unused_undo_free_fail_2
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+IF(file_size>10485760,'ok',file_size)
+ok
+FOUND 1 /InnoDB: :autoshrink failed to read the used segment/ in mysqld.1.err
+FOUND 1 /InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FULL list/ in mysqld.1.err
+SET GLOBAL innodb_fast_shutdown= 0;
+# Fail to free the segment while finding the used segments
+# restart: --debug_dbug=d,unused_undo_free_fail_3
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+IF(file_size>10485760,'ok',file_size)
+ok
+FOUND 1 /InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FREE list/ in mysqld.1.err
+SET GLOBAL innodb_fast_shutdown= 0;
+# Fail to free the segment while freeing the unused segments
+# restart: --debug_dbug=d,unused_undo_free_fail_4
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+IF(file_size>10485760,'ok',file_size)
+ok
+FOUND 1 /InnoDB: :autoshrink failed to free the segment .* in page .*/ in mysqld.1.err
+SET GLOBAL innodb_fast_shutdown= 0;
+# Fail to free the segment while freeing the used segments
+# restart: --debug_dbug=d,unused_undo_free_fail_5
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+IF(file_size>10485760,'ok',file_size)
+ok
+FOUND 1 /InnoDB: :autoshrink failed to free the segment .* in page .*/ in mysqld.1.err
+SET GLOBAL innodb_fast_shutdown= 0;
+# restart
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	10485760
+# Fail to reset the TRX_SYS_FSEG_HEADER during undo tablespace
+# reinitialization. garbage_collect() shouldn't free the
+# TRX_SYS_FSEG_HEADER index node
+set global innodb_fast_shutdown=0;
+# restart: --innodb_undo_tablespaces=2 --debug_dbug=d,sys_fseg_header_fail
+FOUND 1 /InnoDB: :autoshrink freed the segment .* in page .*/ in mysqld.1.err
+set global innodb_fast_shutdown=0;
+# restart
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	10485760

--- a/mysql-test/suite/innodb/t/recovery_shutdown.test
+++ b/mysql-test/suite/innodb/t/recovery_shutdown.test
@@ -6,6 +6,7 @@
 # Flush any open myisam tables from previous tests
 FLUSH TABLES;
 call mtr.add_suppression("Found 1 prepared XA transactions");
+call mtr.add_suppression("InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0 or XA PREPARE transactions exist");
 
 --echo #
 --echo # MDEV-13797 InnoDB may hang if shutdown is initiated soon after startup

--- a/mysql-test/suite/innodb/t/sys_truncate_debug.test
+++ b/mysql-test/suite/innodb/t/sys_truncate_debug.test
@@ -23,6 +23,18 @@ DROP TABLE t1;
 --source include/wait_all_purged.inc
 SELECT NAME, FILE_SIZE FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE SPACE = 0;
 
+# Corruption during traversal of extent
+let $restart_parameters=--debug_dbug=+d,traversal_extent_fail;
+--source include/restart_mysqld.inc
+
+--let SEARCH_PATTERN= \[Warning\] InnoDB: Cannot shrink the system tablespace
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+
+SELECT * FROM INFORMATION_SCHEMA.ENGINES
+WHERE engine = 'innodb'
+AND support IN ('YES', 'DEFAULT', 'ENABLED');
+
 # Ran out of buffer pool
 let $restart_parameters=--debug_dbug=+d,shrink_buffer_pool_full;
 --source include/restart_mysqld.inc

--- a/mysql-test/suite/innodb/t/undo_leak.opt
+++ b/mysql-test/suite/innodb/t/undo_leak.opt
@@ -1,0 +1,2 @@
+--innodb_undo_tablespaces=0
+--innodb_sys_tablespaces

--- a/mysql-test/suite/innodb/t/undo_leak.test
+++ b/mysql-test/suite/innodb/t/undo_leak.test
@@ -1,0 +1,26 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/have_debug.inc
+--source include/not_embedded.inc
+
+let $restart_parameters=--debug_dbug=d,undo_segment_leak;
+--source include/restart_mysqld.inc
+SET GLOBAL INNODB_FILE_PER_TABLE=0;
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+UPDATE t1 SET f1 = f1 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f1 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f1 + 1 WHERE f1 > 1000;
+DELETE FROM t1;
+DROP TABLE t1;
+set GLOBAL innodb_fast_shutdown=0;
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+let $restart_parameters=;
+--source include/restart_mysqld.inc
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;

--- a/mysql-test/suite/innodb/t/undo_leak_fail.opt
+++ b/mysql-test/suite/innodb/t/undo_leak_fail.opt
@@ -1,0 +1,3 @@
+--innodb_data_file_path=ibdata1:10M:autoextend:autoshrink
+--innodb_undo_tablespaces=0
+--innodb_sys_tablespaces

--- a/mysql-test/suite/innodb/t/undo_leak_fail.test
+++ b/mysql-test/suite/innodb/t/undo_leak_fail.test
@@ -1,0 +1,119 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/have_debug.inc
+--source include/not_embedded.inc
+
+call mtr.add_suppression("InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0");
+call mtr.add_suppression("InnoDB: :autoshrink failed to read the used segment");
+call mtr.add_suppression("InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FULL list");
+call mtr.add_suppression("InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FREE list");
+call mtr.add_suppression("InnoDB: :autoshrink failed to free the segment");
+call mtr.add_suppression("Found .* prepared XA transactions");
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+
+SET GLOBAL INNODB_FILE_PER_TABLE=0;
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL)STATS_PERSISTENT=0, ENGINE=InnoDB;
+XA START 'x';
+insert into t1 values (1, 1);
+XA END 'x';
+XA PREPARE 'x';
+set GLOBAL innodb_fast_shutdown=0;
+--source include/restart_mysqld.inc
+--echo # Fail to free the segment due to XA PREPARE transaction
+let SEARCH_PATTERN= InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+XA COMMIT 'x';
+DROP TABLE t1;
+
+let $restart_parameters=--debug_dbug=d,undo_segment_leak;
+--source include/restart_mysqld.inc
+SET GLOBAL INNODB_FILE_PER_TABLE=0;
+CREATE TABLE t1(f1 INT NOT NULL, f2 INT NOT NULL)STATS_PERSISTENT=0, ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+INSERT INTO t1 SELECT seq, seq FROM seq_1_to_4096;
+UPDATE t1 SET f1 = f1 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f1 = f2 + 1 WHERE f1 > 1000;
+UPDATE t1 SET f2 = f1 + 1 WHERE f1 > 1000;
+DELETE FROM t1;
+DROP TABLE t1;
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+let $shutdown_timeout=0;
+let $restart_parameters=--debug_dbug=d,unused_undo_free_fail_1;
+--source include/restart_mysqld.inc
+
+let $shutdown_timeout=;
+--echo # Fail to free the segment due to previous shutdown
+--let SEARCH_PATTERN= InnoDB: Cannot free the unused segments in system tablespace because a previous shutdown was not with innodb_fast_shutdown=0
+
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+SET GLOBAL innodb_fast_shutdown= 0;
+
+--echo # Fail to free the segment while finding the used segments
+let $restart_parameters=--debug_dbug=d,unused_undo_free_fail_2;
+--source include/restart_mysqld.inc
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+let SEARCH_PATTERN= InnoDB: :autoshrink failed to read the used segment;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+
+let SEARCH_PATTERN= InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FULL list;
+--source include/search_pattern_in_file.inc
+SET GLOBAL innodb_fast_shutdown= 0;
+
+--echo # Fail to free the segment while finding the used segments
+let $restart_parameters=--debug_dbug=d,unused_undo_free_fail_3;
+--source include/restart_mysqld.inc
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+
+let SEARCH_PATTERN= InnoDB: :autoshrink failed due to .* in FSP_SEG_INODES_FREE list;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+SET GLOBAL innodb_fast_shutdown= 0;
+
+--echo # Fail to free the segment while freeing the unused segments
+let $restart_parameters=--debug_dbug=d,unused_undo_free_fail_4;
+--source include/restart_mysqld.inc
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+
+let SEARCH_PATTERN= InnoDB: :autoshrink failed to free the segment .* in page .*;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+
+SET GLOBAL innodb_fast_shutdown= 0;
+
+--echo # Fail to free the segment while freeing the used segments
+let $restart_parameters=--debug_dbug=d,unused_undo_free_fail_5;
+--source include/restart_mysqld.inc
+SELECT IF(file_size>10485760,'ok',file_size) FROM information_schema.innodb_sys_tablespaces WHERE space=0;
+
+let SEARCH_PATTERN= InnoDB: :autoshrink failed to free the segment .* in page .*;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+
+SET GLOBAL innodb_fast_shutdown= 0;
+let $restart_parameters=;
+--source include/restart_mysqld.inc
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+
+--echo # Fail to reset the TRX_SYS_FSEG_HEADER during undo tablespace
+--echo # reinitialization. garbage_collect() shouldn't free the
+--echo # TRX_SYS_FSEG_HEADER index node
+set global innodb_fast_shutdown=0;
+let $restart_parameters=--innodb_undo_tablespaces=2 --debug_dbug=d,sys_fseg_header_fail;
+--source include/restart_mysqld.inc
+let SEARCH_PATTERN= InnoDB: :autoshrink freed the segment .* in page .*;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+--source include/search_pattern_in_file.inc
+let $restart_parameters=;
+set global innodb_fast_shutdown=0;
+--source include/restart_mysqld.inc
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -172,36 +172,24 @@ name_of_col_is(
 }
 #endif /* UNIV_DEBUG */
 
-/********************************************************************//**
-This function gets the next system table record as it scans the table.
-@return the next record if found, NULL if end of scan */
-static
 const rec_t*
-dict_getnext_system_low(
-/*====================*/
-	btr_pcur_t*	pcur,		/*!< in/out: persistent cursor to the
-					record*/
-	mtr_t*		mtr)		/*!< in: the mini-transaction */
+dict_getnext_system_low(btr_pcur_t *pcur, mtr_t *mtr)
 {
-	rec_t*	rec = NULL;
-
-	while (!rec) {
-		btr_pcur_move_to_next_user_rec(pcur, mtr);
-
-		rec = btr_pcur_get_rec(pcur);
-
-		if (!btr_pcur_is_on_user_rec(pcur)) {
-			/* end of index */
-			btr_pcur_close(pcur);
-
-			return(NULL);
-		}
-	}
-
-	/* Get a record, let's save the position */
-	btr_pcur_store_position(pcur, mtr);
-
-	return(rec);
+  rec_t *rec = nullptr;
+  while (!rec)
+  {
+    btr_pcur_move_to_next_user_rec(pcur, mtr);
+    rec = btr_pcur_get_rec(pcur);
+    if (!btr_pcur_is_on_user_rec(pcur))
+    {
+      /* end of index */
+      btr_pcur_close(pcur);
+      return nullptr;
+    }
+  }
+  /* Get a record, let's save the position */
+  btr_pcur_store_position(pcur, mtr);
+  return rec;
 }
 
 /********************************************************************//**

--- a/storage/innobase/include/dict0load.h
+++ b/storage/innobase/include/dict0load.h
@@ -213,4 +213,12 @@ dict_process_sys_foreign_col_rec(
 					in referenced table */
 	ulint*		pos);		/*!< out: column position */
 
+/** This function gets the next system table record as it scans
+the table.
+@param pcur persistent cursor
+@param mtr  mini-transaction
+@return the next record if found
+@retval nullptr at the end of the table */
+const rec_t*
+dict_getnext_system_low(btr_pcur_t *pcur, mtr_t *mtr);
 #endif

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -988,6 +988,10 @@ public:
   /** Update the data structures on write completion */
   void complete_write();
 
+  /** Free the unused segment for the tablespace
+  @param shutdown called during slow shutdown
+  @return error code */
+  dberr_t garbage_collect(bool shutdown);
 private:
   /** @return whether the file is usable for io() */
   ATTRIBUTE_COLD bool prepare_acquired();

--- a/storage/innobase/include/fsp0fsp.h
+++ b/storage/innobase/include/fsp0fsp.h
@@ -555,8 +555,9 @@ inline void fsp_init_file_page(
 	mtr->init(block);
 }
 
-/** Truncate the system tablespace */
-void fsp_system_tablespace_truncate();
+/** Truncate the system tablespace
+@param shutdown Called during shutdown */
+void fsp_system_tablespace_truncate(bool shutdown);
 
 #ifndef UNIV_DEBUG
 # define fsp_init_file_page(space, block, mtr) fsp_init_file_page(block, mtr)

--- a/storage/innobase/include/fsp0sysspace.h
+++ b/storage/innobase/include/fsp0sysspace.h
@@ -174,6 +174,11 @@ public:
 		ulint*	sum_new_sizes)
 		MY_ATTRIBUTE((warn_unused_result));
 
+	/** @return whether shrinking failed during
+	previous attempt of system tablespace shrinking */
+	bool is_shrink_fail() noexcept { return m_auto_shrink_fail; }
+
+	void set_shrink_fail() noexcept { m_auto_shrink_fail= true; }
 private:
 	/** Check the tablespace header for this tablespace.
 	@return DB_SUCCESS or error code */
@@ -271,6 +276,10 @@ private:
 	/** Shrink the system tablespace if the value is
 	enabled */
 	bool		m_auto_shrink;
+
+	/** Set to true only when InnoDB system tablespace
+	shrink fails during startup */
+	bool		m_auto_shrink_fail;
 };
 
 /* GLOBAL OBJECTS */

--- a/storage/innobase/include/trx0sys.h
+++ b/storage/innobase/include/trx0sys.h
@@ -1202,6 +1202,9 @@ public:
   /** Get the undo log empty value */
   bool is_undo_empty() const { return !undo_log_nonempty; }
 
+  /** @return whether XA transaction is in PREPARED state */
+  static bool is_xa_exist() noexcept;
+
   /* Reset the trx_sys page and retain the dblwr information,
   system rollback segment header page
   @return error code */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1578,7 +1578,8 @@ void srv_purge_shutdown()
     purge_sys.coordinator_shutdown();
     srv_shutdown_purge_tasks();
     if (!srv_fast_shutdown && !high_level_read_only && srv_was_started &&
-        !opt_bootstrap && srv_operation == SRV_OPERATION_NORMAL)
-      fsp_system_tablespace_truncate();
+        !opt_bootstrap && srv_operation == SRV_OPERATION_NORMAL &&
+        !srv_sys_space.is_shrink_fail())
+      fsp_system_tablespace_truncate(true);
   }
 }

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -482,6 +482,7 @@ loop:
     free_segment:
       ut_ad(rseg.curr_size >= seg_size);
       rseg.curr_size-= seg_size;
+      DBUG_EXECUTE_IF("undo_segment_leak", goto skip_purge_free;);
       trx_purge_free_segment(rseg_hdr, b, mtr);
       break;
     case TRX_UNDO_CACHED:
@@ -509,7 +510,9 @@ loop:
       goto free_segment;
     }
   }
-
+#ifndef DBUG_OFF
+skip_purge_free:
+#endif /* !DBUG_OFF */
   hdr_addr= prev_hdr_addr;
 
   mtr.commit();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34529*

## Description
- InnoDB fails to shrink the system tablespace when it contains
the leaked undo log pages caused by MDEV-30671.

- InnoDB does free the unused segment in system tablespace
before shrinking the tablespace.

inode_info: Structure to store the inode page and offsets.

fil_space_t::garbage_collect():
Frees the system tablespace unused segment

fsp_free_unused_seg(): Frees the unused segment

fsp_get_sys_used_segment(): Iterates through all default
file segment and index segment present in system tablespace.

## How can this PR be tested?

Added the test case innodb.undo_leak which basically leaks the undo segment by purge thread.


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARD- (https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
