### PR TITLE
MDEV-34765: rpl.master_last_event_time_stmt fails with Result Length …

### DIFF
--- a/mysql-test/suite/rpl/r/master_last_event_time_row.result
+++ b/mysql-test/suite/rpl/r/master_last_event_time_row.result
@@ -54,9 +54,11 @@ include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
 # Test that changes are properly applied by server_2 and server_3
 #
 connection server_1;
-include/save_master_gtid.inc
+include/save_master_pos.inc
 connection server_2;
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
+include/save_master_pos.inc
 # Show that the server_2 received the insert from master
 select * from t1;
 a
@@ -67,7 +69,8 @@ master_time == slave_time ; Should be 1
 1
 connection server_3;
 include/start_slave.inc
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
 # Show that the server_3 received the insert from master
 select * from t1;
 a
@@ -87,9 +90,11 @@ insert into t1 values (1+sleep(3));
 # Test that changes are properly applied by server_2 and server_3
 #
 connection server_1;
-include/save_master_gtid.inc
+include/save_master_pos.inc
 connection server_2;
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
+include/save_master_pos.inc
 # Show that the server_2 received the insert from master
 select * from t1;
 a
@@ -101,7 +106,8 @@ master_time == slave_time ; Should be 1
 1
 connection server_3;
 include/start_slave.inc
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
 # Show that the server_3 received the insert from master
 select * from t1;
 a
@@ -123,9 +129,11 @@ SET TIMESTAMP=DEFAULT;
 # Test that changes are properly applied by server_2 and server_3
 #
 connection server_1;
-include/save_master_gtid.inc
+include/save_master_pos.inc
 connection server_2;
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
+include/save_master_pos.inc
 # Show that the server_2 received the insert from master
 select * from t1;
 a
@@ -138,7 +146,8 @@ master_time == slave_time ; Should be 1
 1
 connection server_3;
 include/start_slave.inc
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
 # Show that the server_3 received the insert from master
 select * from t1;
 a
@@ -162,9 +171,11 @@ commit;
 # Test that changes are properly applied by server_2 and server_3
 #
 connection server_1;
-include/save_master_gtid.inc
+include/save_master_pos.inc
 connection server_2;
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
+include/save_master_pos.inc
 # Show that the server_2 received the insert from master
 select * from t1;
 a
@@ -179,7 +190,8 @@ master_time == slave_time ; Should be 1
 1
 connection server_3;
 include/start_slave.inc
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
 # Show that the server_3 received the insert from master
 select * from t1;
 a

--- a/mysql-test/suite/rpl/r/master_last_event_time_stmt.result
+++ b/mysql-test/suite/rpl/r/master_last_event_time_stmt.result
@@ -38,9 +38,11 @@ include/assert_grep.inc [Ensure serial slave doesn't overwrite exec_time in the 
 # Test that changes are properly applied by server_2 and server_3
 #
 connection server_1;
-include/save_master_gtid.inc
+include/save_master_pos.inc
 connection server_2;
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
+include/save_master_pos.inc
 # Show that the server_2 received the insert from master
 select * from t1;
 a
@@ -51,7 +53,8 @@ master_time == slave_time ; Should be 1
 1
 connection server_3;
 include/start_slave.inc
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
 # Show that the server_3 received the insert from master
 select * from t1;
 a
@@ -86,9 +89,11 @@ include/assert_grep.inc [Ensure parallel slave doesn't overwrite exec_time in th
 # Test that changes are properly applied by server_2 and server_3
 #
 connection server_1;
-include/save_master_gtid.inc
+include/save_master_pos.inc
 connection server_2;
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
+include/save_master_pos.inc
 # Show that the server_2 received the insert from master
 select * from t1;
 a
@@ -100,7 +105,8 @@ master_time == slave_time ; Should be 1
 1
 connection server_3;
 include/start_slave.inc
-include/sync_with_master_gtid.inc
+include/wait_for_slave_param.inc [Relay_Master_Log_File]
+include/wait_for_slave_param.inc [Exec_Master_Log_Pos]
 # Show that the server_3 received the insert from master
 select * from t1;
 a

--- a/mysql-test/suite/rpl/t/master_last_event_time.inc
+++ b/mysql-test/suite/rpl/t/master_last_event_time.inc
@@ -2,11 +2,21 @@
 --echo # Test that changes are properly applied by server_2 and server_3
 --echo #
 
+# MDEV-34765: Slave to master synchronization must be done via binlog
+# coordinates, as GTID with statement format would cause the sync_with_master
+# points to continue too early due to the gtid_slave_pos update happening
+# during the Query_log_event::do_apply_event(), which is before the
+# *_last_event_time fields are updated.
 --connection server_1
---source include/save_master_gtid.inc
+--source include/save_master_pos.inc
 
 --connection server_2
---source include/sync_with_master_gtid.inc
+--source include/sync_with_master.inc
+
+# binlog coordinate on server_2 differs from server_1's, so update the sync pos
+# so server_3 can sync
+--source include/save_master_pos.inc
+
 
 --echo # Show that the server_2 received the insert from master
 select * from t1;
@@ -30,7 +40,7 @@ if (`SELECT NOT "$master_time" = "$slave_time"`)
 
 --connection server_3
 --source include/start_slave.inc
---source include/sync_with_master_gtid.inc
+--source include/sync_with_master.inc
 
 --echo # Show that the server_3 received the insert from master
 select * from t1;


### PR DESCRIPTION
…Mismatch

Starting this PR with only a regression patch to show the issue, to start a discussion about the direction for a fix.

When executing a Query_log_event that is a COMMIT query, gtid_slave_pos is updated before other replication status variables, so when an MTR test syncs a replica with primaries via GTID, there is a slight window where accessing status variables, e.g. via SHOW ALL SLAVES STATUS, results in "stale" values because gtid_slave_pos has been updated before inc_group_relay_log_pos() has been called, which is when gtid_slave_pos is typically updated.

Where we can easily fix the test to just use coordinates rather than GTID, it seems like unexpected behavior (and may also confuse users collecting info via scripts), so I wonder we should change the behavior to make things consistent.