### PR TITLE
MDEV-33075 [backport/2f5174e556] [10.5] Resolve server shutdown issues on macOS, Solaris, and FreeBSD

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2091,6 +2091,7 @@ static void clean_up(bool print_message)
 */
 static void wait_for_signal_thread_to_end()
 {
+#ifndef _WIN32
   uint i, n_waits= DBUG_EVALUATE("force_sighup_processing_timeout", 5, 100);
   int err= 0;
   /*
@@ -2099,9 +2100,7 @@ static void wait_for_signal_thread_to_end()
   */
   for (i= 0 ; i < n_waits && signal_thread_in_use; i++)
   {
-    err= pthread_kill(signal_thread, MYSQL_KILL_SIGNAL);
-    if (err)
-      break;
+    kill(getpid(), MYSQL_KILL_SIGNAL);
     my_sleep(100000); // Give it time to die, .1s per iteration
   }
 
@@ -2118,6 +2117,7 @@ static void wait_for_signal_thread_to_end()
                       "Continuing to wait for it to stop..");
     pthread_join(signal_thread, NULL);
   }
+#endif
 }
 #endif /*EMBEDDED_LIBRARY*/
 


### PR DESCRIPTION
Follow up to https://github.com/MariaDB/server/pull/3459. 
Differences in `handle_connections_sockets()` are larger in comparison to 10.11 port so I thought to make it a separate branch.

---

Backport of 2f5174e556cd247133aa14d7b37372ae49fe83c5: MDEV-33075 Resolve server shutdown issues on macOS, Solaris, and FreeBSD.

This commit addresses multiple server shutdown problems observed on macOS,
Solaris, and FreeBSD:

1. Corrected a non-portable assumption where socket shutdown was expected
to wake up poll() with listening sockets in the main thread.

Use more robust self-pipe to wake up poll() by writing to the pipe's write
end.

2. Fixed a random crash on macOS from pthread_kill(signal_handler)
when the signal_handler was detached and the thread had already exited.

Use more robust `kill(getpid(), SIGTERM)` to wake up the signal handler
thread.

3. Made sure, that signal handler thread always exits once `abort_loop` is
set, and also calls `my_thread_end()` and clears `signal_thread_in_use`
when exiting.

This fixes warning "1 thread did not exit"  by `my_global_thread_end()`
seen on FreeBSD/macOS when the process is terminated via signal.

Additionally, the shutdown code underwent light refactoring
for better readability and maintainability:

- Modified `break_connect_loop()` to no longer wait for the main thread,
  aligning behavior with Windows (since 10.4).
- Removed dead code related to the unused `USE_ONE_SIGNAL_HAND`
  preprocessor constant.
- Eliminated support for `#ifndef HAVE_POLL` in `handle_connection_sockets`
  This code is also dead, since 10.4