### PR TITLE
MDEV-34772  Overuse of big stackvariables results in stackoverflows

### DIFF
--- a/extra/mariabackup/fil_cur.cc
+++ b/extra/mariabackup/fil_cur.cc
@@ -244,15 +244,12 @@ xb_fil_cur_open(
 	return(XB_FIL_CUR_SUCCESS);
 }
 
-/* Stack usage 131224 with clang */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 static bool page_is_corrupted(const byte *page, ulint page_no,
 			      const xb_fil_cur_t *cursor,
 			      const fil_space_t *space)
 {
-	byte tmp_frame[UNIV_PAGE_SIZE_MAX];
-	byte tmp_page[UNIV_PAGE_SIZE_MAX];
+	thread_local byte tmp_frame[UNIV_PAGE_SIZE_MAX];
+	thread_local byte tmp_page[UNIV_PAGE_SIZE_MAX];
 	const ulint page_size = cursor->page_size;
 	uint16_t page_type = fil_page_get_type(page);
 

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -3820,8 +3820,8 @@ static dberr_t enumerate_ibd_files(process_single_tablespace_func_t callback)
 	ulint		dbpath_len	= 100;
 	os_file_dir_t	dir;
 	os_file_dir_t	dbdir;
-	os_file_stat_t	dbinfo;
-	os_file_stat_t	fileinfo;
+	thread_local os_file_stat_t dbinfo;
+	thread_local os_file_stat_t fileinfo;
 	dberr_t		err		= DB_SUCCESS;
 	size_t len;
 
@@ -5809,11 +5809,11 @@ static ibool xb_process_datadir(const char *path, const char *suffix,
                                 void *func_arg = NULL)
 {
 	ulint		ret;
-	char		dbpath[OS_FILE_MAX_PATH+2];
+	thread_local char dbpath[OS_FILE_MAX_PATH+2];
 	os_file_dir_t	dir;
 	os_file_dir_t	dbdir;
-	os_file_stat_t	dbinfo;
-	os_file_stat_t	fileinfo;
+	thread_local os_file_stat_t dbinfo;
+	thread_local os_file_stat_t fileinfo;
 	ulint		suffix_len;
 	dberr_t		err 		= DB_SUCCESS;
 	static char	current_dir[2];

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2670,7 +2670,7 @@ innobase_raw_format(
 	/* XXX we use a hard limit instead of allocating
 	but_size bytes from the heap */
 	CHARSET_INFO*	data_cs;
-	char		buf_tmp[8192];
+	thread_local char buf_tmp[8192];
 	ulint		buf_tmp_used;
 	uint		num_errors;
 
@@ -9613,7 +9613,7 @@ ha_innobase::ft_init_ext(
 	NEW_FT_INFO*		fts_hdl = NULL;
 	dict_index_t*		index;
 	fts_result_t*		result;
-	char			buf_tmp[8192];
+	thread_local char	buf_tmp[8192];
 	ulint			buf_tmp_used;
 	uint			num_errors;
 	ulint			query_len = key->length();
@@ -12321,8 +12321,8 @@ create_table_info_t::create_foreign_keys()
 	dberr_t		      error;
 	ulint		      number	      = 1;
 	static const unsigned MAX_COLS_PER_FK = 500;
-	const char*	      column_names[MAX_COLS_PER_FK];
-	const char*	      ref_column_names[MAX_COLS_PER_FK];
+	thread_local const char*column_names[MAX_COLS_PER_FK];
+	thread_local const char*ref_column_names[MAX_COLS_PER_FK];
 	char		      create_name[MAX_DATABASE_NAME_LEN + 1 +
 					  MAX_TABLE_NAME_LEN + 1];
 	dict_index_t*	      index	  = NULL;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -3234,9 +3234,9 @@ innobase_get_foreign_key_info(
 			continue;
 		}
 
-		const char*	column_names[MAX_NUM_FK_COLUMNS];
+		thread_local const char* column_names[MAX_NUM_FK_COLUMNS];
 		dict_index_t*	index = NULL;
-		const char*	referenced_column_names[MAX_NUM_FK_COLUMNS];
+		thread_local const char* referenced_column_names[MAX_NUM_FK_COLUMNS];
 		dict_index_t*	referenced_index = NULL;
 		ulint		num_col = 0;
 		ulint		referenced_num_col = 0;

--- a/storage/innobase/log/log0sync.cc
+++ b/storage/innobase/log/log0sync.cc
@@ -280,7 +280,7 @@ group_commit_lock::lock_return_code group_commit_lock::acquire(value_type num, c
 
 group_commit_lock::value_type group_commit_lock::release(value_type num)
 {
-  completion_callback callbacks[1000];
+  thread_local completion_callback callbacks[1000];
   size_t callback_count = 0;
   value_type ret = 0;
   std::unique_lock<std::mutex> lk(m_mtx);

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -853,7 +853,7 @@ FetchIndexRootPages::build_row_import(row_import* cfg) const UNIV_NOTHROW
 
 	row_index_t*	cfg_index = cfg->m_indexes;
 
-	char	name[BUFSIZ];
+	thread_local char name[BUFSIZ];
 
 	snprintf(name, sizeof(name), "index" IB_ID_FMT, m_index.m_id);
 
@@ -2656,7 +2656,7 @@ row_import_read_index_data(
 				(void) fseek(file, 0L, SEEK_END););
 
 		if (n_bytes != sizeof(row)) {
-			char	msg[BUFSIZ];
+			thread_local char msg[BUFSIZ];
 
 			snprintf(msg, sizeof(msg),
 				 "while reading index meta-data, expected "
@@ -3659,7 +3659,7 @@ row_import_read_cfg(
 	row_import&	cfg)	/*!< out: contents of the .cfg file */
 {
 	dberr_t		err;
-	char		name[OS_FILE_MAX_PATH];
+	char name[OS_FILE_MAX_PATH];
 
 	cfg.m_table = table;
 
@@ -3668,7 +3668,7 @@ row_import_read_cfg(
 	FILE*	file = fopen(name, "rb");
 
 	if (file == NULL) {
-		char	msg[BUFSIZ];
+		thread_local char msg[BUFSIZ];
 
 		snprintf(msg, sizeof(msg),
 			 "Error opening '%s', will attempt to import"

--- a/storage/innobase/row/row0quiesce.cc
+++ b/storage/innobase/row/row0quiesce.cc
@@ -432,9 +432,6 @@ row_quiesce_write_header(
 Write the table meta data after quiesce.
 @return DB_SUCCESS or error code */
 
-/* Stack size 20904 with clang */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 static	MY_ATTRIBUTE((nonnull, warn_unused_result))
 dberr_t
 row_quiesce_write_cfg(
@@ -444,7 +441,7 @@ row_quiesce_write_cfg(
 	THD*			thd)	/*!< in/out: session */
 {
 	dberr_t			err;
-	char			name[OS_FILE_MAX_PATH];
+	thread_local char	name[OS_FILE_MAX_PATH];
 
 	srv_get_meta_data_filename(table, name, sizeof(name));
 
@@ -470,7 +467,7 @@ row_quiesce_write_cfg(
 
 		if (fflush(file) != 0) {
 
-			char	msg[BUFSIZ];
+			thread_local char msg[BUFSIZ];
 
 			snprintf(msg, sizeof(msg), "%s flush() failed", name);
 
@@ -480,7 +477,7 @@ row_quiesce_write_cfg(
 		}
 
 		if (fclose(file) != 0) {
-			char	msg[BUFSIZ];
+			thread_local char msg[BUFSIZ];
 
 			snprintf(msg, sizeof(msg), "%s flose() failed", name);
 

--- a/storage/innobase/trx/trx0i_s.cc
+++ b/storage/innobase/trx/trx0i_s.cc
@@ -622,7 +622,7 @@ fill_lock_data(
 	mem_heap_t*		heap;
 	rec_offs		offsets_onstack[REC_OFFS_NORMAL_SIZE];
 	rec_offs*		offsets;
-	char			buf[TRX_I_S_LOCK_DATA_MAX_LEN];
+	thread_local char	buf[TRX_I_S_LOCK_DATA_MAX_LEN];
 	ulint			buf_used;
 	ulint			i;
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34772*

## Description
- This patch removes the PRAGMA_DISABLE_CHECK_STACK_FRAME usage
    inside innodb and also made the large variable into thread_local
    storage.

## How can this PR be tested?
I ran with gcc -Wstack-usage=8192

cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS=-Wstack-usage=8192


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
