### PR TITLE
MDEV-34565 MariaDB crashes with SIGILL because the OS does not support AVX512

### DIFF
--- a/mysys/crc32/crc32c_x86.cc
+++ b/mysys/crc32/crc32c_x86.cc
@@ -39,7 +39,7 @@ extern "C" unsigned crc32c_sse42(unsigned crc, const void* buf, size_t size);
 
 constexpr uint32_t cpuid_ecx_SSE42= 1U << 20;
 constexpr uint32_t cpuid_ecx_SSE42_AND_PCLMUL= cpuid_ecx_SSE42 | 1U << 1;
-constexpr uint32_t cpuid_ecx_XSAVE= 1U << 26;
+constexpr uint32_t cpuid_ecx_AVX_AND_XSAVE= 1U << 28 | 1U << 27;
 
 static uint32_t cpuid_ecx()
 {
@@ -395,7 +395,7 @@ static bool os_have_avx512()
 
 static ATTRIBUTE_NOINLINE bool have_vpclmulqdq(uint32_t cpuid_ecx)
 {
-  if (!(cpuid_ecx & cpuid_ecx_XSAVE) || !os_have_avx512())
+  if ((~cpuid_ecx & cpuid_ecx_AVX_AND_XSAVE) || !os_have_avx512())
     return false;
 # ifdef _MSC_VER
   int regs[4];


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34565*
## Description
In commit 232d7a5e2dc50181294b927e2bc4b02e282725a8 (#3430) we almost got the detection logic right. However, the `xgetbv` instruction would crash if Linux was started up with the option `noxsave`.
## Release Notes
MariaDB Server should no longer crash on startup when the CPU but not the operating system supports AVX512.
TODO: What should the release notes say about this change?

`have_vpclmulqdq()`: Check for the XSAVE flag at the correct position and also for the AVX flag.
## How can this PR be tested?
This was tested by invoking `unittest/mysys/crc32-t` on Ubuntu 22.04, on its Linux 5.15 kernel running with and without the `noxsave` option.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.