### PR TITLE
MDEV-34787: invalid instruction signal 4

### DIFF
--- a/mysys/CMakeLists.txt
+++ b/mysys/CMakeLists.txt
@@ -134,7 +134,10 @@ ELSEIF(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
   ENDIF()
 ENDIF()
 
-IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|powerpc64" OR CMAKE_SYSTEM_NAME MATCHES AIX)
+cmake_host_system_information(RESULT procname QUERY PROCESSOR_NAME)
+string(FIND ${procname} "PPC970" proc_is_ppc970)
+IF((proc_is_ppc970 EQUAL -1) AND
+   (CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|powerpc64" OR CMAKE_SYSTEM_NAME MATCHES AIX))
   SET(MYSYS_SOURCES ${MYSYS_SOURCES} crc32/crc32_ppc64.c crc32/crc32c_ppc.c)
   SET_SOURCE_FILES_PROPERTIES(crc32/crc32_ppc64.c crc32/crc32c_ppc.c PROPERTIES
         COMPILE_FLAGS "${COMPILE_FLAGS} -maltivec -mvsx -mpower8-vector -mcrypto -mpower8-vector")

--- a/mysys/crc32ieee.cc
+++ b/mysys/crc32ieee.cc
@@ -50,9 +50,6 @@ static my_crc32_t init_crc32()
 
 static const my_crc32_t my_checksum_func= init_crc32();
 
-#ifdef __powerpc64__
-# error "my_checksum() is defined in mysys/crc32/crc32_ppc64.c"
-#endif
 extern "C"
 unsigned int my_checksum(unsigned int crc, const void *data, size_t len)
 {


### PR DESCRIPTION
    Changes for powerpc in git commit dec3f8ca69e5 assume power8 VSX
    extensions for faster crc32 support, but earlier processors
    (e.g. power5) don't have them.  On unexpected powerpc chips,
    we will not use an optimized crc32 implementation.  CMake does
    not provide a facility to detect processor features or in the
    case of powerpc, flavors of the chip.  Create a place where we
    can detect such flavors and caveat as necessary.