### PR TITLE
MDEV-34687: Attempt to warn on unexpected binlog file modification

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -460,6 +460,22 @@ typedef struct st_io_cache		/* Used when caching files */
     somewhere else
   */
   size_t alloced_buffer;
+
+  /*
+    The following four on_*_callback functions are invoked on the file
+    backing this cache (if configured) when:
+  */
+  /* 1. we open it */
+  void (*on_open_callback)(struct st_io_cache *);
+
+  /* 2. just before we write through the cache to the file */
+  void (*on_pre_write_callback)(struct st_io_cache *);
+
+  /* 3. immediately after we write through the cache to the file*/
+  void (*on_post_write_callback)(struct st_io_cache *);
+
+  /* 4. we close it */
+  void (*on_close_callback)(struct st_io_cache *);
 } IO_CACHE;
 
 typedef int (*qsort2_cmp)(const void *, const void *, const void *);

--- a/mysql-test/suite/binlog/r/binlog_warn_on_corruption_case_1_case_4.result
+++ b/mysql-test/suite/binlog/r/binlog_warn_on_corruption_case_1_case_4.result
@@ -1,0 +1,5 @@
+
+# MDEV-34687: Attempt to warn on unexpected binlog file modification
+
+call mtr.add_suppression("The binlog file was written unexpectedly by another thread or process and may be corrupt");
+FOUND 1 /The binlog file was written unexpectedly/ in mysqld.1.err

--- a/mysql-test/suite/binlog/r/binlog_warn_on_corruption_case_2_case_3.result
+++ b/mysql-test/suite/binlog/r/binlog_warn_on_corruption_case_2_case_3.result
@@ -1,0 +1,11 @@
+
+# MDEV-34687: Attempt to warn on unexpected binlog file modification
+
+set timestamp=1000000000;
+CREATE TABLE t1(word VARCHAR(20));
+call mtr.add_suppression("The binlog file was written unexpectedly by another thread or process and may be corrupt");
+SELECT SLEEP(5);
+SLEEP(5)
+0
+NOT FOUND /The binlog file was written unexpectedly/ in mysqld.1.err
+DROP TABLE t1;

--- a/mysql-test/suite/binlog/t/binlog_warn_on_corruption_case_1_case_4.test
+++ b/mysql-test/suite/binlog/t/binlog_warn_on_corruption_case_1_case_4.test
@@ -1,0 +1,11 @@
+--echo
+--echo # MDEV-34687: Attempt to warn on unexpected binlog file modification
+--echo
+
+--source include/have_binlog_format_statement.inc
+--let MYSQLD_DATADIR= `select @@datadir;`
+--exec touch $MYSQLD_DATADIR/master-bin.000001
+call mtr.add_suppression("The binlog file was written unexpectedly by another thread or process and may be corrupt");
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN=The binlog file was written unexpectedly
+--source include/search_pattern_in_file.inc

--- a/mysql-test/suite/binlog/t/binlog_warn_on_corruption_case_2_case_3.test
+++ b/mysql-test/suite/binlog/t/binlog_warn_on_corruption_case_2_case_3.test
@@ -1,0 +1,15 @@
+--echo
+--echo # MDEV-34687: Attempt to warn on unexpected binlog file modification
+--echo
+
+--source include/have_binlog_format_statement.inc
+--let MYSQLD_DATADIR= `select @@datadir;`
+set timestamp=1000000000;
+CREATE TABLE t1(word VARCHAR(20));
+--exec touch $MYSQLD_DATADIR/master-bin.000001
+call mtr.add_suppression("The binlog file was written unexpectedly by another thread or process and may be corrupt");
+SELECT SLEEP(5);
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN=The binlog file was written unexpectedly
+--source include/search_pattern_in_file.inc
+DROP TABLE t1;

--- a/mysys/mf_cache.c
+++ b/mysys/mf_cache.c
@@ -63,6 +63,7 @@ my_bool real_open_cached_file(IO_CACHE *cache)
                                     O_BINARY, MYF(MY_WME | MY_TEMPORARY))) >= 0)
   {
     error=0;
+    cache->on_open_callback(cache);
   }
   DBUG_RETURN(error);
 }
@@ -74,6 +75,8 @@ void close_cached_file(IO_CACHE *cache)
   if (my_b_inited(cache))
   {
     File file=cache->file;
+    if (file >= 0)
+      cache->on_close_callback(cache);
     cache->file= -1;				/* Don't flush data */
     (void) end_io_cache(cache);
     if (file >= 0)

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -932,6 +932,13 @@ class Log_event_writer
   /* Log_event_writer is updated when ctx is set */
   int (Log_event_writer::*encrypt_or_write)(const uchar *pos, size_t len);
 public:
+  Log_event_writer() = delete;
+  Log_event_writer(const Log_event_writer&) = delete;
+  Log_event_writer(Log_event_writer&&) = delete;
+  Log_event_writer& operator=(const Log_event_writer&) = delete;
+  Log_event_writer& operator=(Log_event_writer&&) = delete;
+  virtual ~Log_event_writer() = default;
+
   ulonglong bytes_written;
   void *ctx;         ///< Encryption context or 0 if no encryption is needed
   uint checksum_len;


### PR DESCRIPTION
Make an effort to emit a warning if we detect that an outside force has modified the binlog.  This warning will not halt binlog writes.

We rely on file modification times to detect unexpected writes to the binlog file.  This best-effort approach isn't fool-proof because we cannot write to the binlog and get both the prior and current modification times as an atomic operation.

There are four cases in which unexpected modification could occur:
 1. The time from when the we open the file until the first write.
 2. The time between the first and next writes (or between writes k and k+1)
 3. The time between the last write and when we close the file.
 4. In the case of 0 writes, the time from when we open the file until we close the file.

MariaDB writes binlogs with the help of the IO_CACHE, buffering application writes together in memory, then later writing them through to disk.  We need to see through the IO_CACHE to know when file modifications occur so that we can compare the last known file modification time to the most recent modification time. However, not every user of IO_CACHE cares for this protection and the overhead of extra stat system calls.  To encapsulate this new behavior to binlogs, we add four new callbacks to the IO_CACHE which in the default case do nothing.  These new callbacks are triggered on certain file events:  file open, pre-write, post-write, and file close.  We extend the IO_CACHE with a new type that holds a copy of struct stat, containing the last file modification time, keeping the new field(s) encapsulated away from the original IO_CACHE. In the case of binlogs, we use instances of this new type wherever we previously used IO_CACHE and we set the four new callbacks to invoke the file modification time checks.
