### PR TITLE
MDEV-35999 - Update THIRDPARTY license file to reflect reality

### DIFF
--- a/THIRDPARTY
+++ b/THIRDPARTY
@@ -93,14 +93,14 @@ cmake-2.4.8/Utilities/cmtar/compat/gethostname.c:
 
 --------------------------------------------
 
- Skeleton parser for Yacc-like parsing with Bison,
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003 Free Software
-   Foundation, Inc.
+/* Bison implementation for Yacc-like parsers in C
 
-   This program is free software; you can redistribute it and/or modify
+      Copyright (C) 1984, 1989-1990, 2000-2011 Free Software Foundation, Inc.
+
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -108,14 +108,20 @@ cmake-2.4.8/Utilities/cmtar/compat/gethostname.c:
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02110-1335  USA.  
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-   As a special exception, when this file is copied by Bison into a
-   Bison output file, you may use that output file without restriction.
-   This special exception was added by the Free Software Foundation
-   in version 1.24 of Bison.  
+/* As a special exception, you may create a larger work that contains
+   part or all of the Bison parser skeleton and distribute that work
+   under terms of your choice, so long as that work isn't itself a
+   parser generator using the skeleton or a modified version thereof
+   as a parser skeleton.  Alternatively, if you modify or redistribute
+   the parser skeleton itself, you may (at your option) remove this
+   special exception, which will cause the skeleton and the resulting
+   Bison output files to be licensed under the GNU General Public
+   License without this special exception.
+
+   This special exception was added by the Free Software Foundation in
+   version 2.2 of Bison.  */
 
 ---------------------------------------------------
 


### PR DESCRIPTION
## Description
There are several files under the GPL with BISON expection license.

However none of them are 'GPL-2.0-or-later' today, all of them are 'GPL-3.0-or-later' now, and none of them have '... version 1.24 of Bison' and all of them have '... version 2.2 of Bison'.

Search done by using:
  grep -i -e "of bison" -r .
for quick file listing,

and by:
  grep --before=20 --after=20 -i -e "bison" -r . | grep --after=2 --before=20 -i exception
to list the whole license blocks (with the GPL part), but it contains few false positive results (matched code instead of license block)


## Release Notes
Nothing?

## How can this PR be tested?
Use GREP commands listed above,
or try some of your own to try to disprove my findings.

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
