### PR TITLE
MDEV-30653 : With wsrep_mode=REPLICATE_ARIA only part of mixed-engine…

### DIFF
--- a/mysql-test/suite/galera/r/mdev-30653.result
+++ b/mysql-test/suite/galera/r/mdev-30653.result
@@ -1,0 +1,64 @@
+connection node_2;
+connection node_1;
+create table t1 (id serial, val int) engine=innodb;
+create table t2 (id serial, val int) engine=aria;
+insert into t1 values(1, 23);
+insert into t2 values(2, 42);
+call mtr.add_suppression("WSREP: Replication of non-transactional engines is experimental. Storage engine Aria for table 'test'.'t2' is not supported in Galera");
+begin;
+update t1 set val=24 where id=1;
+update t2 set val=41 where id=2;
+commit;
+ERROR HY000: Transactional commit not supported by involved engine(s)
+select * from t1;
+id	val
+1	23
+select * from t2;
+id	val
+2	41
+connection node_2;
+select * from t1;
+id	val
+1	23
+select * from t2;
+id	val
+connection node_1;
+drop table t1, t2;
+SET GLOBAL wsrep_mode=REPLICATE_ARIA;
+create table t1 (id serial, val int) engine=innodb;
+create table t2 (id serial, val int) engine=aria;
+insert into t1 values(1, 23);
+insert into t2 values(2, 42);
+begin;
+update t1 set val=24 where id=1;
+update t2 set val=41 where id=2;
+ERROR HY000: Transactional commit not supported by involved engine(s)
+commit;
+select * from t1;
+id	val
+1	24
+select * from t2;
+id	val
+2	42
+connection node_2;
+select * from t1;
+id	val
+1	23
+select * from t2;
+id	val
+2	42
+connection node_1;
+drop table t1, t2;
+create table t2 (id serial, val int) engine=aria;
+INSERT INTO t2 values(1,1);
+UPDATE t2 set id=5,val=6 where id = 1;
+SELECT * from t2;
+id	val
+5	6
+connection node_2;
+SELECT * from t2;
+id	val
+5	6
+DROP TABLE t2;
+connection node_1;
+SET GLOBAL wsrep_mode=DEFAULT;

--- a/mysql-test/suite/galera/t/mdev-30653.test
+++ b/mysql-test/suite/galera/t/mdev-30653.test
@@ -1,0 +1,62 @@
+--source include/galera_cluster.inc
+--source include/have_aria.inc
+
+create table t1 (id serial, val int) engine=innodb;
+create table t2 (id serial, val int) engine=aria;
+ 
+insert into t1 values(1, 23);
+insert into t2 values(2, 42);
+call mtr.add_suppression("WSREP: Replication of non-transactional engines is experimental. Storage engine Aria for table 'test'.'t2' is not supported in Galera");
+
+begin;
+update t1 set val=24 where id=1;
+update t2 set val=41 where id=2;
+--error ER_ERROR_DURING_COMMIT
+commit;
+
+select * from t1;
+select * from t2;
+
+--connection node_2
+select * from t1;
+select * from t2;
+
+--connection node_1
+drop table t1, t2;
+
+# case 2
+SET GLOBAL wsrep_mode=REPLICATE_ARIA;
+create table t1 (id serial, val int) engine=innodb;
+create table t2 (id serial, val int) engine=aria;
+ 
+insert into t1 values(1, 23);
+insert into t2 values(2, 42);
+ 
+begin;
+update t1 set val=24 where id=1;
+--error ER_ERROR_DURING_COMMIT
+update t2 set val=41 where id=2;
+commit;
+
+select * from t1;
+select * from t2;
+
+--connection node_2
+select * from t1;
+select * from t2;
+
+--connection node_1
+drop table t1, t2;
+
+# case 3 
+create table t2 (id serial, val int) engine=aria;
+INSERT INTO t2 values(1,1);
+UPDATE t2 set id=5,val=6 where id = 1;
+SELECT * from t2;
+
+--connection node_2
+SELECT * from t2;
+DROP TABLE t2;
+
+--connection node_1
+SET GLOBAL wsrep_mode=DEFAULT;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -7539,6 +7539,11 @@ public:
   DDL statement that may be subject to error filtering.
 */
 #define CF_WSREP_MAY_IGNORE_ERRORS (1U << 24)
+/**
+   Basic DML statements that create writeset.
+*/
+#define CF_WSREP_BASIC_DML (1u << 25)
+
 #endif /* WITH_WSREP */
 
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -895,6 +895,18 @@ void init_update_queries(void)
   sql_command_flags[SQLCOM_DROP_TABLE]|=       CF_WSREP_MAY_IGNORE_ERRORS;
   sql_command_flags[SQLCOM_DROP_INDEX]|=       CF_WSREP_MAY_IGNORE_ERRORS;
   sql_command_flags[SQLCOM_ALTER_TABLE]|=      CF_WSREP_MAY_IGNORE_ERRORS;
+  /*
+    Basic DML-statements that create writeset.
+  */
+  sql_command_flags[SQLCOM_INSERT]|=           CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_INSERT_SELECT]|=    CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_REPLACE]|=          CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_REPLACE_SELECT]|=   CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_UPDATE]|=           CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_UPDATE_MULTI]|=     CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_LOAD]|=             CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_DELETE]|=           CF_WSREP_BASIC_DML;
+  sql_command_flags[SQLCOM_DELETE_MULTI]|=     CF_WSREP_BASIC_DML;
 #endif /* WITH_WSREP */
 }
 

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -1220,7 +1220,8 @@ enum wsrep_warning_type {
   WSREP_DISABLED = 0,
   WSREP_REQUIRE_PRIMARY_KEY= 1,
   WSREP_REQUIRE_INNODB= 2,
-  WSREP_REQUIRE_MAX=3,
+  WSREP_EXPERIMENTAL= 3,
+  WSREP_REQUIRE_MAX=4,
 };
 
 static ulonglong wsrep_warning_start_time=0;
@@ -1257,6 +1258,9 @@ static const char* wsrep_warning_name(const enum wsrep_warning_type type)
     return "WSREP_REQUIRE_PRIMARY_KEY"; break;
   case WSREP_REQUIRE_INNODB:
     return "WSREP_REQUIRE_INNODB"; break;
+  case WSREP_EXPERIMENTAL:
+    return "WSREP_EXPERIMENTAL"; break;
+
   default: assert(0); return " "; break; // for compiler
   }
 }
@@ -1390,7 +1394,22 @@ static void wsrep_push_warning(THD *thd,
                  ha_resolve_storage_engine_name(hton),
                  tables->db.str, tables->table_name.str);
     break;
-
+  case WSREP_EXPERIMENTAL:
+    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
+                        ER_ERROR_DURING_COMMIT,
+                        "WSREP: Replication of non-transactional engines is experimental. "
+                        "Storage engine %s for table '%s'.'%s' is "
+                        "not supported in Galera",
+                        ha_resolve_storage_engine_name(hton),
+                        tables->db.str, tables->table_name.str);
+    if (global_system_variables.log_warnings > 1 &&
+	!wsrep_protect_against_warning_flood(type))
+      WSREP_WARN("Replication of non-transactional engines is experimental. "
+                 "Storage engine %s for table '%s'.'%s' is "
+                 "not supported in Galera",
+                 ha_resolve_storage_engine_name(hton),
+                 tables->db.str, tables->table_name.str);
+    break;
   default: assert(0); break;
   }
 }
@@ -1400,15 +1419,8 @@ bool wsrep_check_mode_after_open_table (THD *thd,
 	TABLE_LIST *tables)
 {
   enum_sql_command sql_command= thd->lex->sql_command;
-  bool is_dml_stmt= thd->get_command() != COM_STMT_PREPARE &&
-                    (sql_command == SQLCOM_INSERT ||
-                     sql_command == SQLCOM_INSERT_SELECT ||
-                     sql_command == SQLCOM_REPLACE ||
-                     sql_command == SQLCOM_REPLACE_SELECT ||
-                     sql_command == SQLCOM_UPDATE ||
-                     sql_command == SQLCOM_UPDATE_MULTI ||
-                     sql_command == SQLCOM_LOAD ||
-                     sql_command == SQLCOM_DELETE);
+  bool is_dml_stmt= (thd->get_command() != COM_STMT_PREPARE &&
+                     (sql_command_flags[sql_command] & CF_WSREP_BASIC_DML));
 
   if (!is_dml_stmt)
     return true;
@@ -1435,9 +1447,24 @@ bool wsrep_check_mode_after_open_table (THD *thd,
         wsrep_push_warning(thd, WSREP_REQUIRE_PRIMARY_KEY, hton, tables);
       }
 
+      // Check are we inside a transaction
+      uint rw_ha_count= ha_check_and_coalesce_trx_read_only(thd, thd->transaction->all.ha_list, true);
+      bool changes= wsrep_has_changes(thd);
+
+      // Roll back current stmt if exists
       wsrep_before_rollback(thd, true);
       wsrep_after_rollback(thd, true);
       wsrep_after_statement(thd);
+
+      // If there is updates, they would be lost above rollback
+      if (rw_ha_count > 0 && changes)
+      {
+	my_message(ER_ERROR_DURING_COMMIT, "Transactional commit not supported "
+                     "by involved engine(s)", MYF(0));
+        wsrep_push_warning(thd, WSREP_EXPERIMENTAL, hton, tables);
+	return false;
+      }
+
       WSREP_TO_ISOLATION_BEGIN(NULL, NULL, (tables));
     }
   } else if (db_type != DB_TYPE_UNKNOWN &&
@@ -2722,6 +2749,8 @@ static int wsrep_TOI_begin(THD *thd, const char *db, const char *table,
   }
 
   thd_proc_info(thd, "acquiring total order isolation");
+
+  DEBUG_SYNC(thd, "wsrep_before_toi_begin");
 
   wsrep::client_state& cs(thd->wsrep_cs());
 


### PR DESCRIPTION
… transactions is replicated



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-30653*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Replication of non-transactional engines is experimental and uses TOI. This naturally means that if there is open transaction with transactional engine it's changes will be rolled back.

Fixed by adding error message if non-transactional engine is part of multi-engine transaction with warning.

## Release Notes

Replication of non-transactional engines like MyISAM or Aria is experimental. and transaction should not
contain DML to both transactional and non-transactional engines. Unfortunately, this is not possible
to enforce in all cases e.g. in procedures and triggers. In this change simple cases are enforced.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the latest MariaDB development branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
