### PR TITLE
Extract some of #3360 fixes to 10.6.x

### DIFF
--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -1474,8 +1474,8 @@ bool print_admin_msg(THD* thd, uint len,
      Also we likely need to lock mutex here (in both cases with protocol and
      push_warning).
   */
-  DBUG_PRINT("info",("print_admin_msg:  %s, %s, %s, %s", name, op_name,
-                     msg_type, msgbuf));
+  DBUG_PRINT("info",("print_admin_msg:  %s, %s, %s, %s", name, op_name->str,
+                     msg_type->str, msgbuf));
   protocol->prepare_for_resend();
   protocol->store(name, length, system_charset_info);
   protocol->store(op_name, system_charset_info);

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -11412,7 +11412,7 @@ int TC_LOG_BINLOG::recover(LOG_INFO *linfo, const char *last_log_name,
         Query_log_event *query_ev= (Query_log_event*) ev;
         if (query_ev->xid)
         {
-          DBUG_PRINT("QQ", ("xid: %llu xid"));
+          DBUG_PRINT("QQ", ("xid: %llu xid", query_ev->xid));
           DBUG_ASSERT(sizeof(query_ev->xid) == sizeof(my_xid));
           uchar *x= (uchar *) memdup_root(&mem_root,
                                           (uchar*) &query_ev->xid,

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -178,7 +178,7 @@ bool partition_info::add_named_partition(const char *part_name, size_t length)
   }
   DBUG_PRINT("info", ("Found partition %u is_subpart %d for name %.*s",
                       part_def->part_id, part_def->is_subpart,
-                      length, part_name));
+                      static_cast<int>(length), part_name));
   DBUG_RETURN(false);
 }
 

--- a/sql/semisync_master.cc
+++ b/sql/semisync_master.cc
@@ -1468,7 +1468,7 @@ void Repl_semi_sync_master::await_all_slave_replies(const char *msg)
     if (msg && first)
     {
       first= false;
-      sql_print_information(msg);
+      sql_print_information("%s", msg);
     }
 
     wait_result=

--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -194,7 +194,7 @@ static bool btr_root_fseg_validate(ulint offset,
   sql_print_error("InnoDB: Index root page " UINT32PF " in %s is corrupted "
                   "at " ULINTPF,
                   block.page.id().page_no(),
-                  UT_LIST_GET_FIRST(space.chain)->name);
+                  UT_LIST_GET_FIRST(space.chain)->name, offset);
   return false;
 }
 

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -2300,9 +2300,9 @@ dict_load_tablespace(
 		table->file_unreadable = true;
 
 		if (!(ignore_err & DICT_ERR_IGNORE_RECOVER_LOCK)) {
-			sql_print_error("InnoDB: Failed to load tablespace "
-					ULINTPF " for table %s",
-					table->space_id, table->name);
+			sql_print_error("InnoDB: Failed to load tablespace %"
+					PRIu32 " for table %s",
+					table->space_id, table->name.m_name);
 		}
 	}
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2042,7 +2042,7 @@ static int innodb_check_version(handlerton *hton, const char *path,
     const trx_id_t trx_id= table->def_trx_id;
     DBUG_ASSERT(trx_id <= create_id);
     dict_table_close(table);
-    DBUG_PRINT("info", ("create_id: %llu  trx_id: %llu", create_id, trx_id));
+    DBUG_PRINT("info", ("create_id: %llu  trx_id: %" PRIu64, create_id, trx_id));
     DBUG_RETURN(create_id != trx_id);
   }
   else

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -2808,7 +2808,7 @@ os_file_io(
 
 		if (type.type != IORequest::READ_MAYBE_PARTIAL) {
 			sql_print_warning("InnoDB: %zu bytes should have been"
-					  " %s at %llu from %s,"
+					  " %s at %" PRIu64 " from %s,"
 					  " but got only %zd."
 					  " Retrying.",
 					  n, type.is_read()
@@ -2982,7 +2982,7 @@ os_file_read_func(
 
   os_file_handle_error_cond_exit(type.node ? type.node->name : nullptr, "read",
                                  false, false);
-  sql_print_error("InnoDB: Tried to read %zu bytes at offset %llu"
+  sql_print_error("InnoDB: Tried to read %zu bytes at offset %" PRIu64
                   " of file %s, but was only able to read %zd",
                   n, offset, type.node ? type.node->name : "(unknown)",
                   n_bytes);

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -6777,7 +6777,7 @@ rec_loop:
     {
       push_warning_printf(prebuilt->trx->mysql_thd,
                           Sql_condition::WARN_LEVEL_WARN, ER_NOT_KEYFILE,
-                          "InnoDB: Invalid PAGE_MAX_TRX_ID=%llu"
+                          "InnoDB: Invalid PAGE_MAX_TRX_ID=%" PRIu64
                           " in index '%-.200s'",
                           page_trx_id, index->name());
       prebuilt->autoinc_error= DB_INDEX_CORRUPT;

--- a/storage/maria/ma_info.c
+++ b/storage/maria/ma_info.c
@@ -149,7 +149,7 @@ void _ma_report_error(int errcode, const LEX_STRING *name, myf flags)
     }
   }
   my_printf_error(errcode, "Got error '%M' for '%s'",
-                  flags, (int) errcode, file_name);
+                  flags, errcode, file_name);
   DBUG_VOID_RETURN;
 }
 

--- a/storage/maria/ma_loghandler.c
+++ b/storage/maria/ma_loghandler.c
@@ -8705,7 +8705,7 @@ my_bool translog_purge(TRANSLOG_ADDRESS low)
                     log_descriptor.open_files.elements);
         DBUG_ASSERT(log_descriptor.min_file == i);
         file= *((TRANSLOG_FILE **)pop_dynamic(&log_descriptor.open_files));
-        DBUG_PRINT("info", ("Files : %d", log_descriptor.open_files.elements));
+        DBUG_PRINT("info", ("Files : %zu", log_descriptor.open_files.elements));
         DBUG_ASSERT(i == file->number);
         log_descriptor.min_file++;
         DBUG_ASSERT(log_descriptor.max_file - log_descriptor.min_file + 1 ==


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: [MDEV-21978](https://jira.mariadb.org/browse/MDEV-21978)*~~
  * Update: *The Jira issue number for this PR is: [MDEV-35430](https://jira.mariadb.org/browse/MDEV-35430)*
* Sibling of #3485
* To clarify, my coding period for Google Summer of Code (GSoC) 2024 ended.
  While this code originates from my GSoC project, this publication (i.e., commit and PR descriptions) isn’t.

## Description

#3360 uncovered countless *potential minor security vulnerabilities* on `my_snprintf` uses.
This commit ports a squashed subset of their fixes according to the bug-fixing process to 10.6, covering cases that weren’t applicable for 10.5 (#3485).
(My GSoC mentor said that they aren’t much of a problem and I can open a PR normally.)

Similar to #3485, I haven’t changed `size_t`s from `%d` to `%u` and haven’t searched issues obsolete in 11.6.

## Release Notes
~~Nothing either?~~
* Fixed data size mismatches that were garbling outputs (or possibly even crashes) on *problematic* platforms – mostly on error messages and debug logs
  * [MDEV-34799](https://jira.mariadb.org/browse/MDEV-34799) is already fixed as 3e5e97b26f.

## How can this PR be tested?
I’m not certain how we could catch these human errors besides testing #3360 (MDEV-21978) and syncing this PR with it.

## Basing the PR against the correct MariaDB version
* *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.