### PR TITLE
MDEV-34855  Bootstrap hangs while shrinking the system tablespace 

### DIFF
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -40,6 +40,9 @@ Created 11/29/1995 Heikki Tuuri
 #include "dict0mem.h"
 #include "fsp0types.h"
 #include "log.h"
+#ifndef DBUG_OFF
+# include "trx0purge.h"
+#endif
 
 /** Returns the first extent descriptor for a segment.
 We think of the extent lists of the segment catenated in the order
@@ -3576,6 +3579,8 @@ dberr_t fsp_sys_tablespace_validate()
 
 void fsp_system_tablespace_truncate()
 {
+  ut_ad(!purge_sys.enabled());
+  ut_ad(!srv_undo_sources);
   uint32_t last_used_extent= 0;
   fil_space_t *space= fil_system.sys_space;
   mtr_t mtr;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4283,12 +4283,6 @@ innobase_end(handlerton*, ha_panic_function)
 		 	}
 		}
 
-		/* Do system tablespace truncation during slow shutdown */
-		if (!srv_fast_shutdown && !high_level_read_only
-		    && srv_operation == SRV_OPERATION_NORMAL) {
-			fsp_system_tablespace_truncate();
-		}
-
 		innodb_shutdown();
 		mysql_mutex_destroy(&log_requests.mutex);
 	}

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1577,5 +1577,8 @@ void srv_purge_shutdown()
     }
     purge_sys.coordinator_shutdown();
     srv_shutdown_purge_tasks();
+    if (!srv_fast_shutdown && !high_level_read_only && srv_was_started &&
+        !opt_bootstrap && srv_operation == SRV_OPERATION_NORMAL)
+      fsp_system_tablespace_truncate();
   }
 }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV- 34855*


## Description
Reason:
 - During bootstrap, InnoDB shrinks the system tablespace while purge is
 still active on system tablespace. This could lead to deadlock.
 
Fix:
   - Avoid System tablespace shrinking during bootstrap.
   -  Move the shrinking logic of system tablespace after purge gets shutdown.
 
## How can this PR be tested?
Patch to test this scenario during bootstrap
```
diff --git a/storage/innobase/fsp/fsp0fsp.cc b/storage/innobase/fsp/fsp0fsp.cc
index 64f22c1cbe8..ec604a81315 100644
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -40,6 +40,7 @@ Created 11/29/1995 Heikki Tuuri
 #include "dict0mem.h"
 #include "fsp0types.h"
 #include "log.h"
+#include "trx0purge.h"
 
 /** Returns the first extent descriptor for a segment.
 We think of the extent lists of the segment catenated in the order
@@ -3598,6 +3599,7 @@ void fsp_system_tablespace_truncate()
     /* Tablespace is being used within fixed size */
     return;
 
+  ut_ad(!purge_sys.enabled());
   /* Set fixed size as threshold to truncate */
   if (fixed_size > last_used_extent)
     last_used_extent= fixed_size;
```

Test case to check whether the purge system is active during shrinking of system tablespace.
```
.opt file:
--innodb_sys_tablespaces
--innodb_purge_threads=1
--innodb_page_size=64k
--innodb_data_file_path=ibdata1:3M:autoextend
```
Test case:
========
```
--source include/have_innodb.inc
create table t1(f1 int not null)engine=innodb;
drop table t1;
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
