### PR TITLE
MDEV-34864 SHOW INDEX FROM - SEQ_IN_INDEX to ULong

### DIFF
--- a/mysql-test/main/show_check.result
+++ b/mysql-test/main/show_check.result
@@ -66,7 +66,7 @@ Catalog	Database	Table	Table_alias	Column	Column_alias	Type	Length	Max length	Is
 def	information_schema	STATISTICS	STATISTICS	TABLE_NAME	Table	253	64	2	N	4097	0	8
 def	information_schema	STATISTICS	STATISTICS	NON_UNIQUE	Non_unique	8	1	1	N	36865	0	63
 def	information_schema	STATISTICS	STATISTICS	INDEX_NAME	Key_name	253	64	7	N	4097	0	8
-def	information_schema	STATISTICS	STATISTICS	SEQ_IN_INDEX	Seq_in_index	8	2	1	N	36865	0	63
+def	information_schema	STATISTICS	STATISTICS	SEQ_IN_INDEX	Seq_in_index	3	2	1	N	36897	0	63
 def	information_schema	STATISTICS	STATISTICS	COLUMN_NAME	Column_name	253	64	1	N	4097	0	8
 def	information_schema	STATISTICS	STATISTICS	COLLATION	Collation	253	1	1	Y	4096	0	8
 def	information_schema	STATISTICS	STATISTICS	CARDINALITY	Cardinality	8	21	1	Y	36864	0	63
@@ -650,7 +650,7 @@ Catalog	Database	Table	Table_alias	Column	Column_alias	Type	Length	Max length	Is
 def	information_schema	STATISTICS	STATISTICS	TABLE_NAME	Table	253	64	2	N	4097	0	63
 def	information_schema	STATISTICS	STATISTICS	NON_UNIQUE	Non_unique	8	1	1	N	36865	0	63
 def	information_schema	STATISTICS	STATISTICS	INDEX_NAME	Key_name	253	64	7	N	4097	0	63
-def	information_schema	STATISTICS	STATISTICS	SEQ_IN_INDEX	Seq_in_index	8	2	1	N	36865	0	63
+def	information_schema	STATISTICS	STATISTICS	SEQ_IN_INDEX	Seq_in_index	3	2	1	N	36897	0	63
 def	information_schema	STATISTICS	STATISTICS	COLUMN_NAME	Column_name	253	64	6	N	4097	0	63
 def	information_schema	STATISTICS	STATISTICS	COLLATION	Collation	253	1	1	Y	4096	0	63
 def	information_schema	STATISTICS	STATISTICS	CARDINALITY	Cardinality	8	21	1	Y	36864	0	63
@@ -920,7 +920,7 @@ Catalog	Database	Table	Table_alias	Column	Column_alias	Type	Length	Max length	Is
 def	information_schema	STATISTICS	STATISTICS	TABLE_NAME	Table	253	192	2	N	4097	0	33
 def	information_schema	STATISTICS	STATISTICS	NON_UNIQUE	Non_unique	8	1	1	N	36865	0	63
 def	information_schema	STATISTICS	STATISTICS	INDEX_NAME	Key_name	253	192	7	N	4097	0	33
-def	information_schema	STATISTICS	STATISTICS	SEQ_IN_INDEX	Seq_in_index	8	2	1	N	36865	0	63
+def	information_schema	STATISTICS	STATISTICS	SEQ_IN_INDEX	Seq_in_index	3	2	1	N	36897	0	63
 def	information_schema	STATISTICS	STATISTICS	COLUMN_NAME	Column_name	253	192	1	N	4097	0	33
 def	information_schema	STATISTICS	STATISTICS	COLLATION	Collation	253	3	1	Y	4096	0	33
 def	information_schema	STATISTICS	STATISTICS	CARDINALITY	Cardinality	8	21	1	Y	36864	0	63

--- a/mysql-test/suite/funcs_1/r/is_columns_is.result
+++ b/mysql-test/suite/funcs_1/r/is_columns_is.result
@@ -356,7 +356,7 @@ def	information_schema	STATISTICS	INDEX_TYPE	14	NULL	NO	varchar	16	48	NULL	NULL	
 def	information_schema	STATISTICS	NON_UNIQUE	4	NULL	NO	bigint	NULL	NULL	19	0	NULL	NULL	NULL	bigint(1)			select		NEVER	NULL
 def	information_schema	STATISTICS	NULLABLE	13	NULL	NO	varchar	3	9	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(3)			select		NEVER	NULL
 def	information_schema	STATISTICS	PACKED	12	NULL	YES	varchar	10	30	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(10)			select		NEVER	NULL
-def	information_schema	STATISTICS	SEQ_IN_INDEX	7	NULL	NO	bigint	NULL	NULL	19	0	NULL	NULL	NULL	bigint(2)			select		NEVER	NULL
+def	information_schema	STATISTICS	SEQ_IN_INDEX	7	NULL	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(2) unsigned			select		NEVER	NULL
 def	information_schema	STATISTICS	SUB_PART	11	NULL	YES	bigint	NULL	NULL	19	0	NULL	NULL	NULL	bigint(3)			select		NEVER	NULL
 def	information_schema	STATISTICS	TABLE_CATALOG	1	NULL	NO	varchar	512	1536	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(512)			select		NEVER	NULL
 def	information_schema	STATISTICS	TABLE_NAME	3	NULL	NO	varchar	64	192	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(64)			select		NEVER	NULL
@@ -898,7 +898,7 @@ NULL	information_schema	SPATIAL_REF_SYS	AUTH_SRID	int	NULL	NULL	NULL	NULL	int(5)
 NULL	information_schema	STATISTICS	NON_UNIQUE	bigint	NULL	NULL	NULL	NULL	bigint(1)
 3.0000	information_schema	STATISTICS	INDEX_SCHEMA	varchar	64	192	utf8	utf8_general_ci	varchar(64)
 3.0000	information_schema	STATISTICS	INDEX_NAME	varchar	64	192	utf8	utf8_general_ci	varchar(64)
-NULL	information_schema	STATISTICS	SEQ_IN_INDEX	bigint	NULL	NULL	NULL	NULL	bigint(2)
+NULL	information_schema	STATISTICS	SEQ_IN_INDEX	int	NULL	NULL	NULL	NULL	int(2) unsigned
 3.0000	information_schema	STATISTICS	COLUMN_NAME	varchar	64	192	utf8	utf8_general_ci	varchar(64)
 3.0000	information_schema	STATISTICS	COLLATION	varchar	1	3	utf8	utf8_general_ci	varchar(1)
 NULL	information_schema	STATISTICS	CARDINALITY	bigint	NULL	NULL	NULL	NULL	bigint(21)

--- a/mysql-test/suite/funcs_1/r/is_columns_is_embedded.result
+++ b/mysql-test/suite/funcs_1/r/is_columns_is_embedded.result
@@ -356,7 +356,7 @@ def	information_schema	STATISTICS	INDEX_TYPE	14	NULL	NO	varchar	16	48	NULL	NULL	
 def	information_schema	STATISTICS	NON_UNIQUE	4	NULL	NO	bigint	NULL	NULL	19	0	NULL	NULL	NULL	bigint(1)					NEVER	NULL
 def	information_schema	STATISTICS	NULLABLE	13	NULL	NO	varchar	3	9	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(3)					NEVER	NULL
 def	information_schema	STATISTICS	PACKED	12	NULL	YES	varchar	10	30	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(10)					NEVER	NULL
-def	information_schema	STATISTICS	SEQ_IN_INDEX	7	NULL	NO	bigint	NULL	NULL	19	0	NULL	NULL	NULL	bigint(2)					NEVER	NULL
+def	information_schema	STATISTICS	SEQ_IN_INDEX	7	NULL	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(2) unsigned					NEVER	NULL
 def	information_schema	STATISTICS	SUB_PART	11	NULL	YES	bigint	NULL	NULL	19	0	NULL	NULL	NULL	bigint(3)					NEVER	NULL
 def	information_schema	STATISTICS	TABLE_CATALOG	1	NULL	NO	varchar	512	1536	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(512)					NEVER	NULL
 def	information_schema	STATISTICS	TABLE_NAME	3	NULL	NO	varchar	64	192	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(64)					NEVER	NULL
@@ -898,7 +898,7 @@ NULL	information_schema	SPATIAL_REF_SYS	AUTH_SRID	int	NULL	NULL	NULL	NULL	int(5)
 NULL	information_schema	STATISTICS	NON_UNIQUE	bigint	NULL	NULL	NULL	NULL	bigint(1)
 3.0000	information_schema	STATISTICS	INDEX_SCHEMA	varchar	64	192	utf8	utf8_general_ci	varchar(64)
 3.0000	information_schema	STATISTICS	INDEX_NAME	varchar	64	192	utf8	utf8_general_ci	varchar(64)
-NULL	information_schema	STATISTICS	SEQ_IN_INDEX	bigint	NULL	NULL	NULL	NULL	bigint(2)
+NULL	information_schema	STATISTICS	SEQ_IN_INDEX	int	NULL	NULL	NULL	NULL	int(2) unsigned
 3.0000	information_schema	STATISTICS	COLUMN_NAME	varchar	64	192	utf8	utf8_general_ci	varchar(64)
 3.0000	information_schema	STATISTICS	COLLATION	varchar	1	3	utf8	utf8_general_ci	varchar(1)
 NULL	information_schema	STATISTICS	CARDINALITY	bigint	NULL	NULL	NULL	NULL	bigint(21)

--- a/mysql-test/suite/funcs_1/r/is_statistics.result
+++ b/mysql-test/suite/funcs_1/r/is_statistics.result
@@ -34,7 +34,7 @@ TABLE_NAME	varchar(64)	NO		NULL
 NON_UNIQUE	bigint(1)	NO		NULL	
 INDEX_SCHEMA	varchar(64)	NO		NULL	
 INDEX_NAME	varchar(64)	NO		NULL	
-SEQ_IN_INDEX	bigint(2)	NO		NULL	
+SEQ_IN_INDEX	int(2) unsigned	NO		NULL	
 COLUMN_NAME	varchar(64)	NO		NULL	
 COLLATION	varchar(1)	YES		NULL	
 CARDINALITY	bigint(21)	YES		NULL	
@@ -53,7 +53,7 @@ STATISTICS	CREATE TEMPORARY TABLE `STATISTICS` (
   `NON_UNIQUE` bigint(1) NOT NULL,
   `INDEX_SCHEMA` varchar(64) NOT NULL,
   `INDEX_NAME` varchar(64) NOT NULL,
-  `SEQ_IN_INDEX` bigint(2) NOT NULL,
+  `SEQ_IN_INDEX` int(2) unsigned NOT NULL,
   `COLUMN_NAME` varchar(64) NOT NULL,
   `COLLATION` varchar(1),
   `CARDINALITY` bigint(21),
@@ -72,7 +72,7 @@ TABLE_NAME	varchar(64)	NO		NULL
 NON_UNIQUE	bigint(1)	NO		NULL	
 INDEX_SCHEMA	varchar(64)	NO		NULL	
 INDEX_NAME	varchar(64)	NO		NULL	
-SEQ_IN_INDEX	bigint(2)	NO		NULL	
+SEQ_IN_INDEX	int(2) unsigned	NO		NULL	
 COLUMN_NAME	varchar(64)	NO		NULL	
 COLLATION	varchar(1)	YES		NULL	
 CARDINALITY	bigint(21)	YES		NULL	

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -9392,7 +9392,7 @@ ST_FIELD_INFO stat_fields_info[]=
   Column("NON_UNIQUE",    SLonglong(1),NOT_NULL, "Non_unique",  OPEN_FRM_ONLY),
   Column("INDEX_SCHEMA",  Name(),      NOT_NULL,                OPEN_FRM_ONLY),
   Column("INDEX_NAME",    Name(),      NOT_NULL, "Key_name",    OPEN_FRM_ONLY),
-  Column("SEQ_IN_INDEX",  SLonglong(2),NOT_NULL, "Seq_in_index",OPEN_FRM_ONLY),
+  Column("SEQ_IN_INDEX",  ULong(2),    NOT_NULL, "Seq_in_index",OPEN_FRM_ONLY),
   Column("COLUMN_NAME",   Name(),      NOT_NULL, "Column_name", OPEN_FRM_ONLY),
   Column("COLLATION",     Varchar(1),  NULLABLE, "Collation",   OPEN_FULL_TABLE),
   Column("CARDINALITY",   SLonglong(), NULLABLE, "Cardinality", OPEN_FULL_TABLE),


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34864*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

MySQL-Connector-Net casts SEQ_IN_INDEX to uint and will raise an exception if the type is a System.Int64.

As we don't support a huge number of multi-column indexes reducing to a uint is sufficient to represent all values and maintain compatibility with MySQL-Connector-Net.

## Release Notes

Add compatibility to MYSQL-Connector-Net for index introspection.

## How can this PR be tested?

Current MTR test cases covered the type of SEQ_IN_INDEX

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.