### PR TITLE
MDEV-34869 ssl_cipher parameter cannot configure TLSv1.3 and TLSv1.2 ciphers at the same time

### DIFF
--- a/mysql-test/include/have_tlsv13.inc
+++ b/mysql-test/include/have_tlsv13.inc
@@ -1,0 +1,10 @@
+--disable_query_log
+connect (ssl_connection,localhost,root,,,,,SSL);
+
+if (`SELECT VARIABLE_VALUE NOT LIKE 'TLSv1.3' FROM information_schema.SESSION_STATUS WHERE VARIABLE_NAME = 'ssl_version'`) {
+  skip Needs TLSv1.3;
+}
+
+disconnect ssl_connection;
+connection default;
+--enable_query_log

--- a/mysql-test/main/tlsv13.result
+++ b/mysql-test/main/tlsv13.result
@@ -1,0 +1,18 @@
+# restart: --ssl-cipher=TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384
+Variable_name	Value
+Ssl_cipher	TLS_AES_128_GCM_SHA256
+Ssl_cipher_list	TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384
+Variable_name	Value
+Ssl_cipher	ECDHE-RSA-AES256-GCM-SHA384
+Ssl_cipher_list	TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+ERROR 2026 (HY000): TLS/SSL error: ssl/tls alert handshake failure
+# restart: --ssl-cipher=ECDHE-RSA-AES256-GCM-SHA384
+Variable_name	Value
+Ssl_cipher	TLS_AES_128_GCM_SHA256
+Variable_name	Value
+Ssl_cipher	ECDHE-RSA-AES256-GCM-SHA384
+# restart: --ssl-cipher=TLS_AES_128_GCM_SHA256
+Variable_name	Value
+Ssl_cipher	TLS_AES_128_GCM_SHA256
+Ssl_cipher_list	TLS_AES_128_GCM_SHA256

--- a/mysql-test/main/tlsv13.test
+++ b/mysql-test/main/tlsv13.test
@@ -1,0 +1,43 @@
+--source include/have_ssl_communication.inc
+--source include/require_openssl_client.inc
+--source include/have_tlsv13.inc
+
+#
+# BUG - SSL_CIPHER SYSTEM VARIABLE CANNOT CONFIGURE TLSV1.3 AND TLSV1.2 CIPHERS AT THE SAME TIME
+#
+# If users specify TLSv1.3 and TLSv1.2 ciphers, it will only configure the
+# TLSv1.3 ciphers correctly but then it will keep all TLSv1.2 ciphers enabled.
+#
+# This is a potential security vulnerability because users trying to restrict
+# secure TLSv1.3 and TLSv1.2 ciphers will unintentionally have insecure TLSv1.2
+# ciphers enabled on the database.
+#
+let $restart_parameters=--ssl-cipher=TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES256-GCM-SHA384;
+source include/restart_mysqld.inc;
+
+--exec $MYSQL --host=localhost --ssl-cipher=TLS_AES_128_GCM_SHA256 --tls-version=TLSv1.3 -e "SHOW STATUS LIKE 'Ssl_cipher%';"
+--exec $MYSQL --host=localhost --ssl-cipher=ECDHE-RSA-AES256-GCM-SHA384 --tls-version=TLSv1.2 -e "SHOW STATUS LIKE 'Ssl_cipher%';"
+
+# Check that other ciphers are correctly not supported by the server
+--replace_regex /sslv3 alert handshake failure/ssl\/tls alert handshake failure/
+--error 1
+--exec $MYSQL --host=localhost --ssl-cipher=TLS_AES_256_GCM_SHA384 --tls-version=TLSv1.3 -e "SHOW STATUS LIKE 'Ssl_cipher';" 2>&1
+
+--replace_regex /sslv3 alert handshake failure/ssl\/tls alert handshake failure/
+--error 1
+--exec $MYSQL --host=localhost --ssl-cipher=ECDHE-RSA-AES128-GCM-SHA256 --tls-version=TLSv1.2 -e "SHOW STATUS LIKE 'Ssl_cipher';" 2>&1
+
+# TLSv1.3 ciphers are still supported if only TLSv1.2 ciphers are passed to --ssl-cipher
+let $restart_parameters=--ssl-cipher=ECDHE-RSA-AES256-GCM-SHA384;
+source include/restart_mysqld.inc;
+--exec $MYSQL --host=localhost --ssl-cipher=TLS_AES_128_GCM_SHA256 --tls-version=TLSv1.3 -e "SHOW STATUS LIKE 'Ssl_cipher';"
+--exec $MYSQL --host=localhost --ssl-cipher=ECDHE-RSA-AES256-GCM-SHA384 --tls-version=TLSv1.2 -e "SHOW STATUS LIKE 'Ssl_cipher';"
+--error 1
+--exec $MYSQL --host=localhost --ssl-cipher=ECDHE-RSA-AES128-GCM-SHA256 --tls-version=TLSv1.2 -e "SHOW STATUS LIKE 'Ssl_cipher';"
+
+# TLSv1.2 ciphers are not supported if only TLSv1.3 ciphers are passed to --ssl-cipher
+let $restart_parameters=--ssl-cipher=TLS_AES_128_GCM_SHA256;
+source include/restart_mysqld.inc;
+--exec $MYSQL --host=localhost --ssl-cipher=TLS_AES_128_GCM_SHA256 --tls-version=TLSv1.3 -e "SHOW STATUS LIKE 'Ssl_cipher%';"
+--error 1
+--exec $MYSQL --host=localhost --ssl-cipher=ECDHE-RSA-AES128-GCM-SHA256 --tls-version=TLSv1.2 -e "SHOW STATUS LIKE 'Ssl_cipher';"

--- a/mysql-test/suite.pm
+++ b/mysql-test/suite.pm
@@ -71,6 +71,9 @@ sub skip_combinations {
   $skip{'main/ssl_7937.combinations'} = [ 'x509v3' ]
     unless $ssl_lib =~ /WolfSSL/ or $openssl_ver ge "1.0.2";
 
+  $skip{'main/tlsv13.test'} = 'does not work with OpenSSL <= 1.1.1'
+    unless $ssl_lib =~ /WolfSSL/ or $openssl_ver ge "3.0.0";
+
   $skip{'main/ssl_verify_ip.test'} = 'x509v3 support required'
     unless $openssl_ver ge "1.0.2";
 

--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -295,16 +295,22 @@ new_VioSSLFd(const char *key_file, const char *cert_file,
 
   /*
     Set the ciphers that can be used
-    NOTE: SSL_CTX_set_cipher_list will return 0 if
+    NOTE: SSL_CTX_set_ciphersuites/SSL_CTX_set_cipher_list will return 0 if
     none of the provided ciphers could be selected
   */
-  if (cipher &&
-      SSL_CTX_set_ciphersuites(ssl_fd->ssl_context, cipher) == 0 &&
-      SSL_CTX_set_cipher_list(ssl_fd->ssl_context, cipher) == 0)
+  if (cipher)
   {
-    *error= SSL_INITERR_CIPHERS;
-    DBUG_PRINT("error", ("%s", sslGetErrString(*error)));
-    goto err2;
+    int cipher_result= 0;
+
+    cipher_result|= SSL_CTX_set_ciphersuites(ssl_fd->ssl_context, cipher);
+    cipher_result|= SSL_CTX_set_cipher_list(ssl_fd->ssl_context, cipher);
+
+    if (cipher_result == 0)
+    {
+      *error= SSL_INITERR_CIPHERS;
+      DBUG_PRINT("error", ("%s", sslGetErrString(*error)));
+      goto err2;
+    }
   }
 
   /* Load certs from the trusted ca */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34869*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Allow users to configure exact ciphers supported for all TLS versions including TLSv1.3 ciphers through the `ssl_cipher` server system variables. This configuration ability is supported by other databases and it may be necessary to meet compliance for certain security requirements/regulations.


## Release Notes

ssl_cipher supports configuring TLSv1.3 cipher suites. Note that if no TLSv1.3 ciphers are specified to `--ssl-cipher`, then the TLSv1.3 ciphers enabled by default will still be supported.

Pages that needs updates:
- https://mariadb.com/kb/en/ssltls-system-variables/#ssl_cipher
- https://mariadb.com/kb/en/using-tlsv13/

## How can this PR be tested?

Test cases were added to the main.ssl_cipher MTR.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
see [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) for the latest versions.
-->
## Basing the PR against the correct MariaDB version
- [X] *This is a bug fix and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.

---

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.