### PR TITLE
[MDEV-33834] Extend audit plugin to include tls_version and tls_version_length variables

### DIFF
--- a/include/mysql/plugin_audit.h
+++ b/include/mysql/plugin_audit.h
@@ -29,7 +29,7 @@ extern "C" {
 
 #define MYSQL_AUDIT_CLASS_MASK_SIZE 1
 
-#define MYSQL_AUDIT_INTERFACE_VERSION 0x0302
+#define MYSQL_AUDIT_INTERFACE_VERSION 0x0303
 
 
 /*************************************************************************
@@ -102,6 +102,8 @@ struct mysql_event_connection
   const char *ip;
   unsigned int ip_length;
   MYSQL_CONST_LEX_STRING database;
+  const char *tls_version;
+  unsigned int tls_version_length;
 };
 
 /*

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -728,6 +728,8 @@ struct mysql_event_connection
   const char *ip;
   unsigned int ip_length;
   MYSQL_CONST_LEX_STRING database;
+  const char *tls_version;
+  unsigned int tls_version_length;
 };
 struct mysql_event_table
 {

--- a/mysql-test/suite/plugins/r/server_audit.result
+++ b/mysql-test/suite/plugins/r/server_audit.result
@@ -240,7 +240,7 @@ set global server_audit_logging= on;
 disconnect cn1;
 drop user user1@localhost;
 set global server_audit_events='';
-set global server_audit_incl_users='root, plug_dest';
+set global server_audit_incl_users='root, plug_dest, ssl_user1';
 CREATE USER plug IDENTIFIED WITH 'test_plugin_server' AS 'plug_dest';
 CREATE USER plug_dest IDENTIFIED BY 'plug_dest_passwd';
 connect(localhost,plug,plug_dest,test,MYSQL_PORT,MYSQL_SOCK);
@@ -256,6 +256,14 @@ connection default;
 disconnect plug_con;
 DROP USER plug;
 DROP USER plug_dest;
+CREATE USER ssl_user1@localhost require SSL;
+connect  conssl1,localhost,ssl_user1,,,,,SSL;
+SHOW STATUS LIKE 'Ssl_cipher';
+Variable_name	Value
+Ssl_cipher	CIPHER_NAME
+disconnect conssl1;
+connection default;
+DROP USER ssl_user1@localhost;
 set global server_audit_query_log_limit= 15;
 select (1), (2), (3), (4);
 1	2	3	4
@@ -301,7 +309,7 @@ server_audit_file_path
 server_audit_file_rotate_now	OFF
 server_audit_file_rotate_size	1000000
 server_audit_file_rotations	9
-server_audit_incl_users	root, plug_dest
+server_audit_incl_users	root, plug_dest, ssl_user1
 server_audit_logging	ON
 server_audit_mode	1
 server_audit_output_type	file
@@ -318,10 +326,10 @@ TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'set global server_audit_incl_user
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'show variables like \'server_audit_incl_users\'',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'set global server_audit_excl_users= repeat("\'root\',", 10000)',ID
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'show variables like \'server_audit_excl_users\'',0
-TIME,HOSTNAME,root,localhost,ID,0,CONNECT,mysql,,0
-TIME,HOSTNAME,root,localhost,ID,0,DISCONNECT,mysql,,0
-TIME,HOSTNAME,no_such_user,localhost,ID,0,FAILED_CONNECT,,,ID
-TIME,HOSTNAME,no_such_user,localhost,ID,0,DISCONNECT,,,0
+TIME,HOSTNAME,root,localhost,ID,0,CONNECT,mysql,,0,
+TIME,HOSTNAME,root,localhost,ID,0,DISCONNECT,mysql,,0,
+TIME,HOSTNAME,no_such_user,localhost,ID,0,FAILED_CONNECT,,,ID,
+TIME,HOSTNAME,no_such_user,localhost,ID,0,DISCONNECT,,,0,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'set global server_audit_incl_users=\'odin, dva, tri\'',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'set global server_audit_incl_users=\'odin, root, dva, tri\'',0
 TIME,HOSTNAME,root,localhost,ID,ID,CREATE,test,t2,
@@ -360,7 +368,7 @@ TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'show variables like \'server_audi
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'set global server_audit_mode=1',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'set global server_audit_events=\'\'',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'create database sa_db',0
-TIME,HOSTNAME,root,localhost,ID,0,CONNECT,test,,0
+TIME,HOSTNAME,root,localhost,ID,0,CONNECT,test,,0,
 TIME,HOSTNAME,root,localhost,ID,ID,CREATE,test,t1,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'create table t1 (id2 int)',0
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,test,t1,
@@ -392,7 +400,7 @@ TIME,HOSTNAME,root,localhost,ID,ID,READ,mysql,proc,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,proc,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,event,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'drop database sa_db',0
-TIME,HOSTNAME,root,localhost,ID,0,DISCONNECT,,,0
+TIME,HOSTNAME,root,localhost,ID,0,DISCONNECT,,,0,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,test,'create database sa_db',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'use sa_db',0
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,db,
@@ -461,7 +469,7 @@ TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,proxies_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,roles_mapping,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,global_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'set global server_audit_events=\'\'',0
-TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'set global server_audit_incl_users=\'root, plug_dest\'',0
+TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'set global server_audit_incl_users=\'root, plug_dest, ssl_user1\'',0
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,db,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,tables_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,columns_priv,
@@ -478,15 +486,15 @@ TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,proxies_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,roles_mapping,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,global_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'CREATE USER plug_dest IDENTIFIED BY *****',0
-TIME,HOSTNAME,plug,localhost,ID,0,FAILED_CONNECT,,,ID
-TIME,HOSTNAME,plug,localhost,ID,0,DISCONNECT,,,0
+TIME,HOSTNAME,plug,localhost,ID,0,FAILED_CONNECT,,,ID,
+TIME,HOSTNAME,plug,localhost,ID,0,DISCONNECT,,,0,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,proxies_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,global_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'GRANT PROXY ON plug_dest TO plug',0
-TIME,HOSTNAME,plug,localhost,ID,0,CONNECT,,,0
-TIME,HOSTNAME,plug,localhost,ID,0,PROXY_CONNECT,,`plug_dest`@`%`,0
+TIME,HOSTNAME,plug,localhost,ID,0,CONNECT,,,0,
+TIME,HOSTNAME,plug,localhost,ID,0,PROXY_CONNECT,,`plug_dest`@`%`,0,
 TIME,HOSTNAME,plug,localhost,ID,ID,QUERY,,'select USER(),CURRENT_USER()',0
-TIME,HOSTNAME,plug,localhost,ID,0,DISCONNECT,,,0
+TIME,HOSTNAME,plug,localhost,ID,0,DISCONNECT,,,0,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,db,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,tables_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,columns_priv,
@@ -503,6 +511,26 @@ TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,proxies_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,roles_mapping,
 TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,global_priv,
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'DROP USER plug_dest',0
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,db,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,tables_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,columns_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,procs_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,proxies_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,roles_mapping,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,global_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'CREATE USER ssl_user1@localhost require SSL',0
+TIME,HOSTNAME,ssl_user1,localhost,ID,0,CONNECT,,,0,TLS_VERSION
+TIME,HOSTNAME,ssl_user1,localhost,ID,ID,QUERY,Access denied for user 'ssl_user1'@'localhost' to database 'test','SHOW STATUS LIKE \'Ssl_version\'',0
+TIME,HOSTNAME,ssl_user1,localhost,ID,ID,QUERY,Access denied for user 'ssl_user1'@'localhost' to database 'test','SHOW STATUS LIKE \'Ssl_cipher\'',0
+TIME,HOSTNAME,ssl_user1,localhost,ID,0,DISCONNECT,,,0,TLS_VERSION
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,db,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,tables_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,columns_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,procs_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,proxies_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,roles_mapping,
+TIME,HOSTNAME,root,localhost,ID,ID,WRITE,mysql,global_priv,
+TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'DROP USER ssl_user1@localhost',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'set global serv',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'select (1), (2)',0
 TIME,HOSTNAME,root,localhost,ID,ID,QUERY,sa_db,'select \'A\', ',0

--- a/mysql-test/suite/plugins/t/server_audit.test
+++ b/mysql-test/suite/plugins/t/server_audit.test
@@ -1,5 +1,7 @@
 --source include/have_plugin_auth.inc
 --source include/not_embedded.inc
+--source include/have_ssl_communication.inc
+--source include/have_tlsv13.inc
 
 if (!$SERVER_AUDIT_SO) {
   skip No SERVER_AUDIT plugin;
@@ -190,7 +192,7 @@ source include/wait_until_count_sessions.inc;
 drop user user1@localhost;
 
 set global server_audit_events='';
-set global server_audit_incl_users='root, plug_dest';
+set global server_audit_incl_users='root, plug_dest, ssl_user1';
 
 CREATE USER plug IDENTIFIED WITH 'test_plugin_server' AS 'plug_dest';
 CREATE USER plug_dest IDENTIFIED BY 'plug_dest_passwd';
@@ -210,6 +212,16 @@ disconnect plug_con;
 --sleep 2
 DROP USER plug;
 DROP USER plug_dest;
+
+CREATE USER ssl_user1@localhost require SSL;
+connect (conssl1,localhost,ssl_user1,,,,,SSL);
+--let $ssl_version = query_get_value(SHOW STATUS LIKE 'Ssl_version', Value, 1)
+--replace_column 2 CIPHER_NAME
+SHOW STATUS LIKE 'Ssl_cipher';
+disconnect conssl1;
+connection default;
+--sleep 2
+DROP USER ssl_user1@localhost;
 
 set global server_audit_query_log_limit= 15;
 select (1), (2), (3), (4);
@@ -237,6 +249,8 @@ show status like 'server_audit_current_log';
 show variables like 'server_audit%';
 uninstall plugin server_audit;
 
+# replace stored SSL verison with constant string "TLS_VERSION"
+--replace_result $ssl_version TLS_VERSION
 # replace the timestamp and the hostname with constant values
 --replace_regex /[0-9]* [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\,[^,]*\,/TIME,HOSTNAME,/ /\,[1-9][0-9]*\,/,1,/ /\,[1-9][0-9]*/,ID/
 cat_file $MYSQLD_DATADIR/server_audit.log;


### PR DESCRIPTION
MDEV: https://jira.mariadb.org/browse/MDEV-33834

## Description
This is the continuous work of https://github.com/MariaDB/server/pull/3175.

Add tls_version and tls_version_length variables to the audit plugin so they can be logged. This is useful to help identify suspicious or malformed connections attempting to use unsupported TLS versions. A log with this information will allow to detect and block more malicious connection attempts.

Users with 'server_audit_events' empty will have these two new variables automatically visible in their logs, but if users don't want them, they can always configure what fields to include by listing the fields in 'server_audit_events'.

In connection event, The TLS version will be populated in `object` field
in key=value format, and the key-value pair will be omitted when the
value is empty.

To ensure the MTR test result matches in all environments, the TLS
version string is replaced with a general `TLS_VERSION` to avoid the MTR
test failing unexpectedly. The regex is based on the output of
`SSL_get_version()` function in latest OpenSSL library (v3.3), which
returns 10 possible values[1]:
  - SSLv3
  - TLSv1
  - TLSv1.1
  - TLSv1.2
  - TLSv1.3
  - DTLSv0.9
  - DTLSv1
  - DTLSv1.2
  - QUICv1
  - unknown

All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.

[1]: https://docs.openssl.org/3.2/man3/SSL_get_version/

## Release Notes
None. This just adds more possibilities for users.

## How can this PR be tested?

Modified the server audit plugin to include this new info, and updated the server audit plugin MTR tests.

## Basing the PR against the correct MariaDB version
- [X] *This is a new feature and the PR is based against the latest MariaDB development branch.*

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.