### PR TITLE
MDEV-34879 InnoDB fails to merge the change buffer to ROW_FORMAT=COMPRESSED tables

### DIFF
--- a/mysql-test/suite/encryption/r/innodb-compressed-blob.result
+++ b/mysql-test/suite/encryption/r/innodb-compressed-blob.result
@@ -1,6 +1,8 @@
 call mtr.add_suppression("InnoDB: The page \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\] in file '.*test.t[123]\\.ibd' cannot be decrypted; key_version=1");
 call mtr.add_suppression("InnoDB: Recovery failed to read page");
-call mtr.add_suppression("InnoDB: Unable to decompress ..test.t[1-3]\\.ibd\\[page id: space=[1-9][0-9]*, page number=[0-9]+\\]");
+call mtr.add_suppression("InnoDB: Unable to decompress ..test.t[12]\\.ibd\\[page id: space=[1-9][0-9]*, page number=[0-9]+\\]");
+call mtr.add_suppression("InnoDB: Database page corruption on disk or a failed read of file '.*test/t[12]\\.ibd' page \\[page id: space=[1-9][0-9]*, page number=3\\]");
+call mtr.add_suppression("InnoDB: File '.*test/t[12]\\.ibd' is corrupted");
 call mtr.add_suppression("InnoDB: Table `test`\\.`t[12]` is corrupted");
 # Restart mysqld --file-key-management-filename=keys2.txt
 # restart: --file-key-management-filename=MYSQL_TEST_DIR/std_data/keys2.txt

--- a/mysql-test/suite/encryption/t/innodb-compressed-blob.test
+++ b/mysql-test/suite/encryption/t/innodb-compressed-blob.test
@@ -6,7 +6,9 @@
 
 call mtr.add_suppression("InnoDB: The page \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\] in file '.*test.t[123]\\.ibd' cannot be decrypted; key_version=1");
 call mtr.add_suppression("InnoDB: Recovery failed to read page");
-call mtr.add_suppression("InnoDB: Unable to decompress ..test.t[1-3]\\.ibd\\[page id: space=[1-9][0-9]*, page number=[0-9]+\\]");
+call mtr.add_suppression("InnoDB: Unable to decompress ..test.t[12]\\.ibd\\[page id: space=[1-9][0-9]*, page number=[0-9]+\\]");
+call mtr.add_suppression("InnoDB: Database page corruption on disk or a failed read of file '.*test/t[12]\\.ibd' page \\[page id: space=[1-9][0-9]*, page number=3\\]");
+call mtr.add_suppression("InnoDB: File '.*test/t[12]\\.ibd' is corrupted");
 call mtr.add_suppression("InnoDB: Table `test`\\.`t[12]` is corrupted");
 
 --echo # Restart mysqld --file-key-management-filename=keys2.txt

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2608,7 +2608,10 @@ buf_block_t *buf_pool_t::page_fix(const page_id_t id,
           return reinterpret_cast<buf_block_t*>(-1);
         }
 
-        if (UNIV_UNLIKELY(!b->frame))
+        if (UNIV_LIKELY(b->frame != nullptr));
+        else if (state < buf_page_t::READ_FIX)
+          goto unzip;
+        else
         {
         wait_for_unzip:
           b->unfix();
@@ -2629,6 +2632,7 @@ buf_block_t *buf_pool_t::page_fix(const page_id_t id,
 
       if (UNIV_UNLIKELY(!b->frame))
       {
+      unzip:
         if (b->lock.x_lock_try());
         else if (c == FIX_NOWAIT)
           goto would_block;

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3769,7 +3769,7 @@ release_page:
   if (recovery && !recv_recover_page(node.space, this))
     return DB_PAGE_CORRUPTED;
 
-  const bool ibuf_may_exist= frame && !recv_no_ibuf_operations &&
+  const bool ibuf_may_exist= !recv_no_ibuf_operations &&
     (!expected_id.space() || !is_predefined_tablespace(expected_id.space())) &&
     fil_page_get_type(read_frame) == FIL_PAGE_INDEX &&
     page_is_leaf(read_frame);

--- a/storage/innobase/include/buf0rea.h
+++ b/storage/innobase/include/buf0rea.h
@@ -29,10 +29,8 @@ Created 11/5/1995 Heikki Tuuri
 
 #include "buf0buf.h"
 
-/** High-level function which reads a page asynchronously from a file to the
-buffer buf_pool if it is not already there. Sets the io_fix flag and sets
-an exclusive lock on the buffer frame. The flag is cleared and the x-lock
-released by the i/o-handler thread.
+/** Read a page synchronously from a file. buf_page_t::read_complete()
+will be invoked on read completion.
 @param page_id   page id
 @retval DB_SUCCESS if the page was read and is not corrupted
 @retval DB_SUCCESS_LOCKED_REC if the page was not read


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34879*
## Description
`buf_page_t::read_complete()`: Fix an incorrect condition that had been added in commit aaef2e1d8c843d1e40b1ce0c5199c3abb3c5da28 (MDEV-27058). Also for compressed-only pages we must remember that buffered changes may exist.

`buf_read_page()`: Correct the function comment; this is for a synchronous and not asynchronous read. Pass the parameter `unzip=true` to `buf_read_page_low()`, because each of our callers will be interested in the uncompressed page frame.
## Release Notes
InnoDB could corrupt secondary index pages of `ROW_FORMAT=COMPRESSED` tables unless `innodb_change_buffering=none` had never been used.
## How can this PR be tested?
Stress test with `innodb_change_buffering=all`, including server restarts. This fix was tested on a copy of a data directory on which the failure was originally reproduced.

By its design, the change buffer is very difficult to cover with tests. It is also disabled by default (5c46751f238ee8dcef1e718ac5f63952bff5d09d) and has been removed in later major versions (f27e9c894779a4c7ebe6446ba9aa408f1771c114). That said, the test `innodb_zip.wl5522-zip` kind of does cover these changes. It would hit an infinite loop due to a bug that was revealed in `buf_pool_t::page_fix()`: If the page exists in the buffer pool in compressed-only format but needs a change buffer merge, the current thread must proceed to decompress the block.

The change to `buf_read_page()` is reflected by the test `encryption.innodb-compressed-blob`, where we would start to emit more errors due to `page_zip_decompress()` failing after mis-decrypting the page.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.