### PR TITLE
MDEV-34650 main.having_cond_pushdown test failure - crash server (s390x)

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -1295,7 +1295,7 @@ Item *Item::multiple_equality_transformer(THD *thd, uchar *arg)
       This flag will be removed at the end of the pushdown optimization by
       remove_immutable_flag_processor processor.
     */
-    int new_flag= MARKER_IMMUTABLE;
+    int16 new_flag= MARKER_IMMUTABLE;
     this->walk(&Item::set_extraction_flag_processor, false,
                (void*)&new_flag);
   }


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34650*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Code added in 10.5 as fix for MDEV-32608.

During merge in f071b7620b2e the new flag name was used.

Unfortunately missed in the merge was the refactoring performed in c76eabfb5e39a1b0831159decd3e0b544b9ad2e3, that changed the flag types to uint16.

While on little-endian processors, the cast of uint16 and int are the same, this is not true on big-endian processors (cast performed in set_extraction_flag_processor).

The result is big-endian processors cleared the immutable flag rather than set the flag, resulting in MDEV-32608 being unfixed on big-endian processors.

## Release Notes

Correct MDEV-34650  for big-endian processors.

## How can this PR be tested?

main.having_cond_pushdown test on big-endian processors
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.