### PR TITLE
MDEV-32996 : galera.galera_var_ignore_apply_errors -> [ERROR] WSREP: …

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_ignore_apply_errors.result
+++ b/mysql-test/suite/galera/r/galera_var_ignore_apply_errors.result
@@ -208,7 +208,9 @@ DROP TABLE t1;
 connection node_2;
 SELECT * FROM t1;
 ERROR 42S02: Table 'test.t1' doesn't exist
-SET GLOBAL wsrep_ignore_apply_errors = 7;
+SET GLOBAL wsrep_ignore_apply_errors = 10;
+Warnings:
+Warning	1292	Truncated incorrect wsrep_ignore_apply_errors value: '10'
 CALL mtr.add_suppression("Can't find record in ");
 CALL mtr.add_suppression("Slave SQL: Could not execute Delete_rows event");
 CALL mtr.add_suppression("Slave SQL: Error 'Unknown table 'test\\.t1'' on query\\. Default database: 'test'\\. Query: 'DROP TABLE t1', Error_code: 1051");
@@ -217,3 +219,4 @@ CALL mtr.add_suppression("Slave SQL: Error 'Can't DROP 'idx1'; check that column
 CALL mtr.add_suppression("Slave SQL: Error 'Can't DROP 'idx1'; check that column/key exists' on query\\. Default database: 'test'\\. Query: 'ALTER TABLE t1 DROP INDEX idx1', Error_code: 1091");
 CALL mtr.add_suppression("Slave SQL: Error 'Can't DROP 'f2'; check that column/key exists' on query\\. Default database: 'test'\\. Query: 'ALTER TABLE t1 DROP COLUMN f2', Error_code: 1091");
 CALL mtr.add_suppression("Slave SQL: Error 'Table 't1' already exists' on query\\.");
+CALL mtr.add_suppression("Inconsistency detected: Inconsistent by consensus on.*");

--- a/mysql-test/suite/galera/t/galera_var_ignore_apply_errors.cnf
+++ b/mysql-test/suite/galera/t/galera_var_ignore_apply_errors.cnf
@@ -2,5 +2,5 @@
 
 [mysqld]
 wsrep_debug=1
-wsrep_sync_wait=15
+wsrep_sync_wait=0
 loose-galera-var-ignore-apply-errors=1

--- a/mysql-test/suite/galera/t/galera_var_ignore_apply_errors.test
+++ b/mysql-test/suite/galera/t/galera_var_ignore_apply_errors.test
@@ -17,6 +17,7 @@ SET GLOBAL wsrep_ignore_apply_errors = 1;
 SET GLOBAL wsrep_on = OFF;
 CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 DROP TABLE t1;
 
 --connection node_2
@@ -27,6 +28,7 @@ SHOW TABLES;
 SET GLOBAL wsrep_on = OFF;
 CREATE SCHEMA s1;
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 DROP SCHEMA s1;
 
 --connection node_2
@@ -38,6 +40,7 @@ CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = OFF;
 CREATE INDEX idx1 ON t1 (f1);
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 DROP INDEX idx1 ON t1;
 
 --connection node_2
@@ -50,6 +53,7 @@ CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = OFF;
 CREATE INDEX idx1 ON t1 (f1);
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 ALTER TABLE t1 DROP INDEX idx1;
 
 --connection node_2
@@ -62,6 +66,7 @@ CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = OFF;
 ALTER TABLE t1 ADD COLUMN f2 INTEGER;
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 ALTER TABLE t1 DROP COLUMN f2;
 
 --connection node_2
@@ -82,6 +87,7 @@ CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = OFF;
 INSERT INTO t1 VALUES (1);
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 DELETE FROM t1 WHERE f1 = 1;
 SELECT COUNT(*) AS expect_0 FROM t1;
 
@@ -96,6 +102,7 @@ INSERT INTO t1 VALUES (2);
 SET GLOBAL wsrep_on = OFF;
 INSERT INTO t1 VALUES (1);
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 START TRANSACTION;
 INSERT INTO t1 VALUES (3);
 DELETE FROM t1 WHERE f1 = 1;
@@ -121,6 +128,7 @@ INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 SET SESSION wsrep_on = OFF;
 DELETE FROM t1 WHERE f1 = 3;
 SET SESSION wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 --connection node_1
 DELETE FROM t1;
@@ -147,6 +155,7 @@ INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 SET SESSION wsrep_on = OFF;
 DELETE FROM t1 WHERE f1 = 3;
 SET SESSION wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 --connection node_1
 SET AUTOCOMMIT=OFF;
@@ -185,6 +194,7 @@ SET SESSION wsrep_on = OFF;
 DELETE FROM t2 WHERE f1 = 2;
 DELETE FROM t1 WHERE f1 = 3;
 SET SESSION wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 --connection node_1
 DELETE t1, t2 FROM t1 JOIN t2 WHERE t1.f1 = t2.f1;
@@ -214,6 +224,7 @@ INSERT INTO child VALUES (1,1),(2,2),(3,3);
 SET SESSION wsrep_on = OFF;
 DELETE FROM child WHERE parent_id = 2;
 SET SESSION wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 --connection node_1
 DELETE FROM parent;
@@ -240,6 +251,7 @@ SET GLOBAL wsrep_ignore_apply_errors = 4;
 SET GLOBAL wsrep_on = OFF;
 CREATE TABLE t1 (f1 INTEGER);
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 --connection node_1
 CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
@@ -248,7 +260,7 @@ DROP TABLE t1;
 --connection node_2
 --error ER_NO_SUCH_TABLE
 SELECT * FROM t1;
-SET GLOBAL wsrep_ignore_apply_errors = 7;
+SET GLOBAL wsrep_ignore_apply_errors = 10;
 
 CALL mtr.add_suppression("Can't find record in ");
 CALL mtr.add_suppression("Slave SQL: Could not execute Delete_rows event");
@@ -258,3 +270,4 @@ CALL mtr.add_suppression("Slave SQL: Error 'Can't DROP 'idx1'; check that column
 CALL mtr.add_suppression("Slave SQL: Error 'Can't DROP 'idx1'; check that column/key exists' on query\\. Default database: 'test'\\. Query: 'ALTER TABLE t1 DROP INDEX idx1', Error_code: 1091");
 CALL mtr.add_suppression("Slave SQL: Error 'Can't DROP 'f2'; check that column/key exists' on query\\. Default database: 'test'\\. Query: 'ALTER TABLE t1 DROP COLUMN f2', Error_code: 1091");
 CALL mtr.add_suppression("Slave SQL: Error 'Table 't1' already exists' on query\\.");
+CALL mtr.add_suppression("Inconsistency detected: Inconsistent by consensus on.*");


### PR DESCRIPTION
…Inconsistency detected


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32996*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Test case changes only. Add wait_until_ready waits after wsrep_on is set on again to make sure that node is ready for next step before continuing.


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
