### PR TITLE
MDEV-33035 : Galera test case MDEV-16509 unstable

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-16509.result
+++ b/mysql-test/suite/galera/r/MDEV-16509.result
@@ -28,6 +28,11 @@ wsrep_last_seen_gtid_do_not_match
 1
 SET DEBUG_SYNC = "now SIGNAL after_group_continue";
 connection node_1;
+SELECT * from t1;
+f1
+1
+connection ctrl;
+SET DEBUG_SYNC = "RESET";
 SET SESSION wsrep_sync_wait = 0;
 connection ctrl;
 connection node_1;
@@ -69,6 +74,11 @@ SET DEBUG_SYNC = "now SIGNAL agac_continue_2";
 connection node_1a;
 connection ctrl;
 SET DEBUG_SYNC = "RESET";
+SELECT * from t1;
+f1
+1
+2
+3
 DROP TABLE t1;
 disconnect ctrl;
 disconnect node_1a;

--- a/mysql-test/suite/galera/t/MDEV-16509.test
+++ b/mysql-test/suite/galera/t/MDEV-16509.test
@@ -58,6 +58,12 @@ SET DEBUG_SYNC = "now SIGNAL after_group_continue";
 
 --connection node_1
 --reap
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.t1;
+--source include/wait_condition.inc
+SELECT * from t1;
+
+--connection ctrl
+SET DEBUG_SYNC = "RESET";
 
 #
 # Scenario 2: Verify that two INSERTs from two different connections
@@ -136,6 +142,10 @@ SET DEBUG_SYNC = "now SIGNAL agac_continue_2";
 
 --connection ctrl
 SET DEBUG_SYNC = "RESET";
+
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.t1;
+--source include/wait_condition.inc
+SELECT * from t1;
 
 DROP TABLE t1;
 


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-33035*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Test case changes only. Stabilize test by reseting DEBUG_SYNC and add wait_condition for expected table contents.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
