### PR TITLE
MDEV-34721: Make debian/autobake-debs.sh change compat level when needed

### DIFF
--- a/debian/autobake-deb.sh
+++ b/debian/autobake-deb.sh
@@ -77,6 +77,14 @@ disable_libfmt()
   sed '/libfmt-dev/d' -i debian/control
 }
 
+change_compat_level()
+{
+  echo "${1}" > debian/compat
+  sed -e 's/ --fail-missing//' \
+      -e 's/#override_dh_missing/override_dh_missing/' \
+      -e 's/#\tdh_missing/\tdh_missing/' -i debian/rules
+}
+
 architecture=$(dpkg-architecture -q DEB_BUILD_ARCH)
 uname_machine=$(uname -m)
 
@@ -111,9 +119,10 @@ in
   "buster")
     disable_libfmt
     replace_uring_with_aio
-    ;&
+    ;;
   "bullseye")
     add_lsb_base_depends
+    change_compat_level 12
     ;&
   "bookworm")
     # mariadb-plugin-rocksdb in control is 4 arches covered by the distro rocksdb-tools
@@ -122,10 +131,12 @@ in
     then
       replace_uring_with_aio
     fi
+    change_compat_level 12
     ;&
   "trixie"|"sid")
     # The default packaging should always target Debian Sid, so in this case
     # there is intentionally no customizations whatsoever.
+    change_compat_level 12
     ;;
   # Ubuntu
   "focal")
@@ -134,12 +145,13 @@ in
     ;&
   "jammy"|"kinetic")
     add_lsb_base_depends
-    ;&
+    ;;
   "lunar"|"mantic")
     if [[ ! "$architecture" =~ amd64|arm64|armhf|ppc64el|s390x ]]
     then
       replace_uring_with_aio
     fi
+    change_compat_level 12
     ;&
   "noble")
     # mariadb-plugin-rocksdb s390x not supported by us (yet)
@@ -149,6 +161,7 @@ in
     then
       remove_rocksdb_tools
     fi
+    change_compat_level 12
     ;;
   *)
     echo "Error: Unknown release '$LSBNAME'" >&2

--- a/debian/rules
+++ b/debian/rules
@@ -192,6 +192,11 @@ override_dh_installinit-arch:
 override_dh_gencontrol:
 	dh_gencontrol -- -Tdebian/substvars
 
+# When running compat level 12 or higher this is needed
+# to preserve --fail-missing
+#override_dh_missing:
+#	dh_missing --list-missing --fail-missing
+
 # If a file is not supposed to be included anywhere, add it to the not-installed
 # file and document the reason. Note that dh_install supports the above mentioned
 # white list file only starting from Debian Stretch and Ubuntu Xenial.


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34721*

## Description
Debian Deb Compat level version 12 brings more Systemd confort to Debian package installation handling.
Althought it's not working correctly on certain Debian and Ubuntu version which MariaDB supports.

Commit add change to compat level to version 12 when it's should be working correctly.

Currently these distros that are changed:
  * Debian Bullseye (11)
  * Debian Bookwork (12)
  * Debian Trixie (13)
  * Debian Sid
  * Ubuntu Lunar (23.04)
  * Ubuntu Mantic (23.10)
  * Ubuntu Noble (24.04)
  * Ubuntu Oracular (24.10)

## Release Notes
Bit tricky one as this changes compat level but should not be seen to user anyhow

## How can this PR be tested?
Manually on docker one can pull repo and run `AUTOBAKE_PREP_CONTROL_RULES_ONLY=1 debian/autobuild-debs.sh` and see with `git diff` if changes have been made or not. 
One can also download debs from this Salsa-CI build to test with https://salsa.debian.org/illuusio/mariadb-server/-/commit/5efd075a00b80d916cf25f92b0bc433ef9cb4d46

and see if that build is all green.

## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
