### PR TITLE
Extract some of #3360 fixes to 10.11.x

### DIFF
--- a/mysys/array.c
+++ b/mysys/array.c
@@ -283,7 +283,7 @@ void get_dynamic(DYNAMIC_ARRAY *array, void *element, size_t idx)
 {
   if (idx >= array->elements)
   {
-    DBUG_PRINT("warning",("To big array idx: %d, array size is %d",
+    DBUG_PRINT("warning",("To big array idx: %zu, array size is %zu",
                           idx,array->elements));
     bzero(element,array->size_of_element);
     return;

--- a/mysys/waiting_threads.c
+++ b/mysys/waiting_threads.c
@@ -829,7 +829,7 @@ static int unlock_lock_and_free_resource(WT_THD *thd, WT_RESOURCE *rc)
 
   if (rc->owners.elements || rc->waiter_count)
   {
-    DBUG_PRINT("wt", ("nothing to do, %u owners, %u waiters",
+    DBUG_PRINT("wt", ("nothing to do, %zu owners, %u waiters",
                       rc->owners.elements, rc->waiter_count));
     rc_unlock(rc);
     DBUG_RETURN(0);
@@ -1142,4 +1142,3 @@ void wt_thd_release(WT_THD *thd, const WT_RESOURCE_ID *resid)
     reset_dynamic(&thd->my_resources);
   DBUG_VOID_RETURN;
 }
-

--- a/plugin/hashicorp_key_management/hashicorp_key_management_plugin.cc
+++ b/plugin/hashicorp_key_management/hashicorp_key_management_plugin.cc
@@ -562,7 +562,7 @@ int HCData::curl_run (const char *url, std::string *response,
     else if (is_error)
     {
       my_printf_error(ER_UNKNOWN_ERROR, PLUGIN_ERROR_HEADER
-                      "Hashicorp server error: %d, response: %s",
+                      "Hashicorp server error: %ld, response: %s",
                       ME_ERROR_LOG_ONLY | ME_WARNING, http_code, res);
     }
   }

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -2705,7 +2705,7 @@ static void check_and_remove_stale_alter(Relay_log_info *rli)
   {
     DBUG_ASSERT(info->state == start_alter_state::REGISTERED);
 
-    sql_print_warning("ALTER query started at %u-%u-%llu could not "
+    sql_print_warning("ALTER query started at %llu-%u-%u could not "
                       "be completed because of unexpected master server "
                       "or its binlog change", info->sa_seq_no, // todo:gtid
                       0, 0);

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -2705,10 +2705,10 @@ static void check_and_remove_stale_alter(Relay_log_info *rli)
   {
     DBUG_ASSERT(info->state == start_alter_state::REGISTERED);
 
-    sql_print_warning("ALTER query started at %llu-%u-%u could not "
+    sql_print_warning("ALTER query started at %u-%lu-%llu could not "
                       "be completed because of unexpected master server "
-                      "or its binlog change", info->sa_seq_no, // todo:gtid
-                      0, 0);
+                      "or its binlog change", info->domain_id,
+                      mi->master_id, info->sa_seq_no);
     info_iterator.remove();
     mysql_mutex_lock(&mi->start_alter_lock);
     info->state= start_alter_state::ROLLBACK_ALTER;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -3380,7 +3380,7 @@ void plugin_thdvar_cleanup(THD *thd)
   if ((idx= thd->lex->plugins.elements))
   {
     list= ((plugin_ref*) thd->lex->plugins.buffer) + idx - 1;
-    DBUG_PRINT("info",("unlocking %d plugins", idx));
+    DBUG_PRINT("info",("unlocking %zu plugins", idx));
     while ((uchar*) list >= thd->lex->plugins.buffer)
       intern_plugin_unlock(NULL, *list--);
   }

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -6406,9 +6406,9 @@ remove_key:
         }
         if (!part_elem)
         {
-          push_warning_printf(thd, Sql_condition::WARN_LEVEL_NOTE,
-                              ER_PARTITION_DOES_NOT_EXIST,
-                              ER_THD(thd, ER_PARTITION_DOES_NOT_EXIST));
+          push_warning(thd, Sql_condition::WARN_LEVEL_NOTE,
+                       ER_PARTITION_DOES_NOT_EXIST,
+                       ER_THD(thd, ER_PARTITION_DOES_NOT_EXIST));
           names_it.remove();
         }
       }

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2487,7 +2487,7 @@ fil_ibd_load(uint32_t space_id, const char *filename, fil_space_t *&space)
 
 	if (space) {
 		sql_print_information("InnoDB: Ignoring data file '%s'"
-				      " with space ID " ULINTPF
+				      " with space ID %" PRIu32
 				      ". Another data file called %s"
 				      " exists"
 				      " with the same space ID.",

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -2638,7 +2638,7 @@ dberr_t fseg_free_page(fseg_header_t *seg_header, fil_space_t *space,
     mtr->x_lock_space(space);
 
   DBUG_PRINT("fseg_free_page",
-             ("space_id: " ULINTPF ", page_no: %u", space->id, offset));
+             ("space_id: %" PRIu32 ", page_no: %" PRIu32, space->id, offset));
 
   dberr_t err;
   if (fseg_inode_t *seg_inode= fseg_inode_try_get(seg_header,

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3771,7 +3771,7 @@ compression_algorithm_is_not_loaded(ulong compression_algorithm, myf flags)
   if (is_loaded[compression_algorithm])
     return 0;
 
-  my_printf_error(HA_ERR_UNSUPPORTED, "InnoDB: compression algorithm %s (%u)"
+  my_printf_error(HA_ERR_UNSUPPORTED, "InnoDB: compression algorithm %s (%lu)"
     " is not available. Please, load the corresponding provider plugin.", flags,
     page_compression_algorithms[compression_algorithm], compression_algorithm);
   return 1;
@@ -4016,7 +4016,7 @@ static int innodb_init_params()
 			"InnoDB: innodb_open_files=%lu is not greater "
 			"than the number of system tablespace files, "
 			"temporary tablespace files, "
-			"innodb_undo_tablespaces=%lu; adjusting "
+			"innodb_undo_tablespaces=%u; adjusting "
 			"to innodb_open_files=%zu",
 			innobase_open_files, srv_undo_tablespaces,
 			min_open_files_limit);
@@ -18565,7 +18565,7 @@ static void innodb_log_file_size_update(THD *thd, st_mysql_sys_var*,
            *static_cast<const ulonglong*>(save) < log_sys.buf_size)
     my_printf_error(ER_WRONG_ARGUMENTS,
                     "innodb_log_file_size must be at least"
-                    " innodb_log_buffer_size=%zu", MYF(0), log_sys.buf_size);
+                    " innodb_log_buffer_size=%u", MYF(0), log_sys.buf_size);
   else
   {
     switch (log_sys.resize_start(*static_cast<const ulonglong*>(save))) {

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -4517,7 +4517,7 @@ static dberr_t recv_rename_files()
         err= space->rename(new_name, false);
         if (err != DB_SUCCESS)
           sql_print_error("InnoDB: Cannot replay rename of tablespace "
-                          UINT32PF " to '%s: %s", new_name, ut_strerr(err));
+                          UINT32PF " to '%s': %s", id, new_name, ut_strerr(err));
         goto done;
       }
       mysql_mutex_unlock(&fil_system.mutex);

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3941,7 +3941,8 @@ bool fil_node_t::read_page0(const byte *dpage, bool no_lsn) noexcept
     invalid:
       if (dpage)
         goto retry_dpage;
-      sql_print_error("InnoDB: Expected tablespace flags 0x%zx but found 0x%zx"
+      sql_print_error("InnoDB: Expected tablespace flags 0x%" PRIx32
+                      " but found 0x%" PRIx32
                       " in the file %s", space->flags, flags, name);
       goto err_exit;
     }

--- a/storage/maria/ma_loghandler.c
+++ b/storage/maria/ma_loghandler.c
@@ -5707,7 +5707,7 @@ translog_write_variable_record_mgroup(LSN *lsn,
       goto err_unlock;
     }
 
-    DBUG_PRINT("info", ("chunk: #%u  first_page: %u (%u)  "
+    DBUG_PRINT("info", ("chunk: #%zu  first_page: %u (%u)  "
                         "full_pages: %lu (%lu)  "
                         "Left %lu",
                         groups.elements,
@@ -5875,8 +5875,8 @@ translog_write_variable_record_mgroup(LSN *lsn,
          record_rest + header_fixed_part +
          (groups.elements - groups_per_page * (chunk0_pages - 1)) * (7 + 1))
     chunk0_pages++;
-  DBUG_PRINT("info", ("chunk0_pages: %u  groups %u  groups per full page: %u  "
-                      "Group on last page: %u",
+  DBUG_PRINT("info", ("chunk0_pages: %u  groups %zu  groups per full page: %u  "
+                      "Group on last page: %zu",
                       chunk0_pages, groups.elements,
                       groups_per_page,
                       (groups.elements -


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: [MDEV-21978](https://jira.mariadb.org/browse/MDEV-21978)*~~
  * Update: *The Jira issue number for this PR is: [MDEV-35431](https://jira.mariadb.org/browse/MDEV-35431)*
* Sibling of #3485 and #3493
* To clarify, my coding period for Google Summer of Code (GSoC) 2024 ended.
  While this code originates from my GSoC project, this publication (i.e., commit and PR descriptions) isn’t.

## Description

#3360 uncovered countless *potential minor security vulnerabilities* on `my_snprintf` uses.
This commit ports a squashed subset of their fixes according to the bug-fixing process to 10.11, covering cases that weren’t applicable for 10.5 (#3485) and 10.6 (#3493).
(My GSoC mentor said that they aren’t much of a problem and I can open a PR normally.)

Similar to the previous iterations, I haven’t searched issues obsolete in 11.6.

## Release Notes
* Fixed data size mismatches that were garbling outputs (or possibly even crashes) on *problematic* platforms – mostly on error messages and debug logs

## How can this PR be tested?
I’m not certain how we could catch these human errors besides testing #3360 (MDEV-21978) and syncing this PR with it.

## Basing the PR against the correct MariaDB version
* *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.