### PR TITLE
MDEV-34921 MemorySanitizer reports errors for non-debug builds

### DIFF
--- a/sql/mf_iocache_encr.cc
+++ b/sql/mf_iocache_encr.cc
@@ -175,8 +175,8 @@ static int my_b_encr_write(IO_CACHE *info, const uchar *Buffer, size_t Count)
       DBUG_RETURN(info->error= -1);
     }
     crypt_data->counter= 0;
-
-    IF_DBUG(crypt_data->block_length= 0,);
+    crypt_data->block_length= 0;
+    crypt_data->last_block_length= 0;
   }
 
   do

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -3498,7 +3498,6 @@ pthread_handler_t handle_delayed_insert(void *arg)
     DBUG_LEAVE;
   }
   my_thread_end();
-  pthread_exit(0);
 
   return 0;
 }

--- a/unittest/mysys/stacktrace-t.c
+++ b/unittest/mysys/stacktrace-t.c
@@ -30,7 +30,7 @@ void test_my_safe_print_str()
   memcpy(b_bss, "LEGAL", 6);
 
 #ifdef HAVE_STACKTRACE
-#ifndef __SANITIZE_ADDRESS__
+# if !defined __SANITIZE_ADDRESS__ && !__has_feature(memory_sanitizer)
   fprintf(stderr, "\n===== stack =====\n");
   my_safe_print_str(b_stack, 65535);
   fprintf(stderr, "\n===== heap =====\n");
@@ -40,15 +40,15 @@ void test_my_safe_print_str()
   fprintf(stderr, "\n===== data =====\n");
   my_safe_print_str("LEGAL", 65535);
   fprintf(stderr, "\n===== Above is a junk, but it is expected. =====\n");
-#endif /*__SANITIZE_ADDRESS__*/
+# endif
   fprintf(stderr, "\n===== Nornal length test =====\n");
   my_safe_print_str("LEGAL", 5);
   fprintf(stderr, "\n===== NULL =====\n");
   my_safe_print_str(0, 5);
-#ifndef __SANITIZE_ADDRESS__
+# ifndef __SANITIZE_ADDRESS__
   fprintf(stderr, "\n===== (const char*) 1 =====\n");
   my_safe_print_str((const char*)1, 5);
-#endif /*__SANITIZE_ADDRESS__*/
+# endif /*__SANITIZE_ADDRESS__*/
 #endif /*HAVE_STACKTRACE*/
 
   free(b_heap);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34921*
## Description
`my_b_encr_write()`: Initialize also `block_length`, and at the same time `last_block_length`, so that all 128 bits can be initialized with fewer writes (such as a single x86 `movaps` instruction). This fixes an error that was caught in the test `encryption.tempfiles_encrypted`.

`test_my_safe_print_str()`: Fully initialize the `b_stack` buffer in order to avoid a failure of the test `unit.stacktrace`. Previously, unit tests had been disabled in MemorySanitizer builds on our CI.

`handle_delayed_insert()`: Remove a redundant call to `pthread_exit(0)`, which would for some reason cause MemorySanitizer in  `clang-19` to report a stack overflow in a `RelWithDebInfo` build. This fixes a failure of several tests.
## Release Notes
Nothing needs to be said, except maybe something about encrypted temporary files.
## How can this PR be tested?
I tested this as follows. Note: All Spider tests but one, plus 9 Connect tests failed due to MemorySanitizer errors. I did not try to fix them.
```bash
cmake -DCMAKE_{C_COMPILER=clang,CXX_COMPILER=clang++}-19 -DCMAKE_C_FLAGS='-O2 -march=native' -DCMAKE_CXX_FLAGS='-stdlib=libc++ -O2 -march=native' -DCMAKE_BUILD_TYPE=RelWIthDebInfo -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF -DWITH_{ZLIB,SSL,PCRE}=bundled -DHAVE_LIBAIO_H=0 -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 -DWITH_MSAN=ON -DSECURITY_HARDENED=OFF ~/10.5 -G Ninja
cmake --build .
cd mysql-test
LD_LIBRARY_PATH=~/libmsan-19 MSAN_OPTIONS=poison_in_dtor=0:abort_on_error=1 MSAN_SYMBOLIZER_PATH=~/bin/llvm-symbolizer-msan ./mtr --parallel=152 --big-test --force --max-test-fail=0 --skip-stack-trace --skip-core-file
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.