### PR TITLE
MDEV-31636 Memory leak in Sys_var_gtid_binlog_state::do_check()

### DIFF
--- a/mysql-test/main/mdev-31636.result
+++ b/mysql-test/main/mdev-31636.result
@@ -1,0 +1,8 @@
+RESET MASTER;
+SET
+@@global.gtid_binlog_state='1-1-101,2-1-2002',
+@@global.slave_parallel_mode=x;
+ERROR 42000: Variable 'slave_parallel_mode' can't be set to the value of 'x'
+SELECT @@global.gtid_binlog_state;
+@@global.gtid_binlog_state
+

--- a/mysql-test/main/mdev-31636.test
+++ b/mysql-test/main/mdev-31636.test
@@ -1,0 +1,7 @@
+--source include/have_log_bin.inc
+RESET MASTER;
+--error ER_WRONG_VALUE_FOR_VAR
+SET
+  @@global.gtid_binlog_state='1-1-101,2-1-2002',
+  @@global.slave_parallel_mode=x;
+SELECT @@global.gtid_binlog_state;


### PR DESCRIPTION
Move memory allocations performed during Sys_var_gtid_binlog_state::do_check to Sys_var_gtid_binlog_state::global_update where they will be freed before the latter method returns.
