### PR TITLE
MDEV-34952 main.log_slow test failure on opensuse builder

### DIFF
--- a/mysql-test/main/log_slow.test
+++ b/mysql-test/main/log_slow.test
@@ -213,7 +213,7 @@ set log_slow_filter=default;
 set timestamp=default;
 
 let SEARCH_FILE=`select @@slow_query_log_file`;
-let SEARCH_PATTERN=use.*2;
+let SEARCH_PATTERN= use \`a\n.*2;
 let SEARCH_OUTPUT=matches;
 source include/search_pattern_in_file.inc;
 


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34952*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The loose regex for the MDEV-34539 test ended up
matching the opensuse in the path in buildbot.

Adjust to more complete regex including space,
backtick and \n, which becomes much less common
as a path name.

## Release Notes

Un-noteworty

## How can this PR be tested?

Build in directory containing "use" like build-mariadb-server-rebase-opensuse which I tested with.

Or wait until its merged up to 10.11 on opensuse where it will fail.


## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codeing style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.