### PR TITLE
MDEV-34453 Trying to read 16384 bytes at 70368744161280 outside the b…

### DIFF
--- a/mysql-test/suite/stress/t/ddl_innodb.test
+++ b/mysql-test/suite/stress/t/ddl_innodb.test
@@ -1,4 +1,5 @@
 --source include/no_valgrind_without_big.inc
+--source include/maybe_debug.inc
 ######## t/ddl_innodb.test ######
 #
 # Stress the storage engine InnoDB with CREATE/DROP TABLE/INDEX
@@ -34,6 +35,13 @@ if (!$run)
 ##### Some preparations needed for the ddl*.inc scripts
 --source suite/stress/include/ddl.pre
 
+if ($have_debug) {
+  --disable_query_log
+  SET @old_debug_dbug = @@global.debug_dbug;
+  SET DEBUG_DBUG="+d,ib_buf_create_intermittent_wait";
+  --enable_query_log
+}
+
 --source suite/stress/include/ddl1.inc
 --source suite/stress/include/ddl2.inc
 --source suite/stress/include/ddl3.inc
@@ -42,6 +50,12 @@ if (!$run)
 --source suite/stress/include/ddl6.inc
 --source suite/stress/include/ddl7.inc
 --source suite/stress/include/ddl8.inc
+
+if ($have_debug) {
+  --disable_query_log
+  SET @@global.debug_dbug = @old_debug_dbug;
+  --enable_query_log
+}
 
 ##### Cleanup
 --source suite/stress/include/ddl.cln


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34453*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
    The issue is caused by a race between buf_page_create_low getting the
    page from buffer pool hash and buf_LRU_free_page evicting it from LRU.
    
    The issue is introduced in 10.6 by MDEV-27058
    commit aaef2e1d8c843d1e40b1ce0c5199c3abb3c5da28
    MDEV-27058: Reduce the size of buf_block_t and buf_page_t
    
    The solution is buffer fix the page before releasing buffer pool mutex
    in buf_page_create_low when x_lock_try fails to acquire the page latch.

## Release Notes
TBD

## How can this PR be tested?
It is a hard to repeat the issue as it is. If we enforce the try_lock failed block in storage/innobase/buf/buf0buf.cc
buf_page_create_low() by commenting the try lock code, the issue repeats in release mode.
      // const bool got= bpage->lock.x_lock_try();
      // if (!got)

./mtr --mem repeat=50 stress.ddl_innodb

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
