### PR TITLE
MDEV-34909 DDL hang during SET GLOBAL innodb_log_file_size on PMEM

### DIFF
--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -452,8 +452,9 @@ public:
 
 #ifdef HAVE_PMEM
   /** Persist the log.
-  @param lsn    desired new value of flushed_to_disk_lsn */
-  inline void persist(lsn_t lsn) noexcept;
+  @param lsn            desired new value of flushed_to_disk_lsn
+  @param holding_latch  whether the caller is holding exclusive latch */
+  void persist(lsn_t lsn, bool holding_latch) noexcept;
 #endif
 
   bool check_for_checkpoint() const


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34909*
## Description
Executing a DDL operation concurrently with `SET GLOBAL innodb_log_file_size` could lead to a hang of most InnoDB threads.

`log_t::persist()`: Add a parameter holding_latch to specify whether the caller is already holding exclusive `log_sys.latch`, like `log_write_and_flush()` always is.
## Release Notes
Executing a DDL operation concurrently with `SET GLOBAL innodb_log_file_size` when `ib_logfile0` resides on a `mount -o dax` file system (persistent memory mapped log) could lead to a hang of most InnoDB threads.
## How can this PR be tested?
Build with `CMAKE_CXX_FLAGS` including `-DLOG_LATCH_DEBUG`.
```sh
./mtr --parallel=auto innodb.log_file_size_online
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.