### PR TITLE
MDEV-34836: TOI on parent table must BF abort SR in progress on a child

### DIFF
--- a/include/mysql/service_wsrep.h
+++ b/include/mysql/service_wsrep.h
@@ -209,7 +209,7 @@ extern "C" my_bool wsrep_thd_is_local_toi(const MYSQL_THD thd);
 extern "C" my_bool wsrep_thd_is_in_rsu(const MYSQL_THD thd);
 /* Return true if thd is in BF mode, either high_priority or TOI */
 extern "C" my_bool wsrep_thd_is_BF(const MYSQL_THD thd, my_bool sync);
-/* Return true if thd is streaming */
+/* Return true if thd is streaming in progress */
 extern "C" my_bool wsrep_thd_is_SR(const MYSQL_THD thd);
 extern "C" void wsrep_handle_SR_rollback(MYSQL_THD BF_thd, MYSQL_THD victim_thd);
 /* Return thd retry counter */

--- a/mysql-test/suite/galera_sr/r/MDEV-34836.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-34836.result
@@ -1,0 +1,23 @@
+connection node_2;
+connection node_1;
+connection node_1;
+CREATE TABLE parent (id INT AUTO_INCREMENT PRIMARY KEY, v INT) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1, 1),(2, 2),(3, 3);
+CREATE TABLE child (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT, CONSTRAINT parent_fk
+FOREIGN KEY (parent_id) REFERENCES parent (id)) ENGINE=InnoDB;
+connection node_2;
+SET SESSION wsrep_trx_fragment_size = 1;
+START TRANSACTION;
+INSERT INTO child (parent_id) VALUES (1),(2),(3);
+connection node_1;
+SET SESSION wsrep_sync_wait = 15;
+SELECT COUNT(*) FROM child;
+COUNT(*)
+0
+ALTER TABLE parent AUTO_INCREMENT = 100;
+connection node_2;
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+DROP TABLE child, parent;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera_sr/t/MDEV-34836.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-34836.test
@@ -1,0 +1,56 @@
+#
+# MDEV-34836: TOI transaction on FK-referenced parent table must BF abort
+# SR transaction in progress on a child table.
+#
+# Applied SR transaction on the child table was not BF aborted by TOI running
+# on the parent table for several reasons:
+# Although SR correctly collected FK-referenced keys to parent, TOI in Galera
+# disregards common certification index and simply sets itself to depend on the
+# latest certified write set seqno.
+# Since this write set was the fragment of SR transaction, TOI was allowed to run in
+# parallel with SR presuming it would BF abort the latter.
+#
+# At the same time, DML transactions in the server don't grab MDL locks on FK-referenced
+# tables, thus parent table wasn't protected by an MDL lock from SR and it couldn't
+# provoke MDL lock conflict for TOI to BF abort SR transaction.
+# In InnoDB, DDL transactions grab shared MDL locks on child tables, which is not enough
+# to trigger MDL conflict in Galera.
+# InnoDB-level Wsrep patch didn't contain correct conflict resolution logic due to the
+# fact that it was believed MDL locking should always produce conflicts correctly.
+#
+# The fix brings conflict resolution rules similar to MDL-level checks to InnoDB, thus
+# accounting for the problematic case.
+#
+
+--source include/galera_cluster.inc
+--source include/have_innodb.inc
+
+--connection node_1
+CREATE TABLE parent (id INT AUTO_INCREMENT PRIMARY KEY, v INT) ENGINE=InnoDB;
+INSERT INTO parent VALUES (1, 1),(2, 2),(3, 3);
+
+CREATE TABLE child (id INT AUTO_INCREMENT PRIMARY KEY, parent_id INT, CONSTRAINT parent_fk
+    FOREIGN KEY (parent_id) REFERENCES parent (id)) ENGINE=InnoDB;
+
+--connection node_2
+# Start SR transaction and make it lock both parent and child tales.
+SET SESSION wsrep_trx_fragment_size = 1;
+START TRANSACTION;
+INSERT INTO child (parent_id) VALUES (1),(2),(3);
+
+--connection node_1
+# Sync wait for SR transaction to replicate and apply fragments, thus
+# locking parent table as well.
+SET SESSION wsrep_sync_wait = 15;
+SELECT COUNT(*) FROM child;
+# Now run TOI on the parent, which BF-aborts the SR-transaction in progress.
+ALTER TABLE parent AUTO_INCREMENT = 100;
+
+--connection node_2
+# Check that SR is BF-aborted.
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+# Cleanup
+DROP TABLE child, parent;
+--source include/galera_end.inc

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -183,7 +183,8 @@ extern "C" my_bool wsrep_thd_is_BF(const THD *thd, my_bool sync)
 
 extern "C" my_bool wsrep_thd_is_SR(const THD *thd)
 {
-  return thd && thd->wsrep_cs().transaction().is_streaming();
+  return thd && thd->wsrep_cs().transaction().is_streaming() &&
+    thd->wsrep_cs().transaction().state() == wsrep::transaction::s_executing;
 }
 
 extern "C" void wsrep_handle_SR_rollback(THD *bf_thd,


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34836*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Applied SR transaction on the child table was not BF aborted by TOI running on the parent table for several reasons:
Although SR correctly collected FK-referenced keys to parent, TOI in Galera disregards common certification index and simply sets itself to depend on the latest certified write set seqno.
Since this write set was the fragment of SR transaction, TOI was allowed to run in parallel with SR presuming it would BF abort the latter.

At the same time, DML transactions in the server don't grab MDL locks on FK-referenced tables, thus parent table wasn't protected by an MDL lock from SR and it couldn't provoke MDL lock conflict for TOI to BF abort SR transaction. In InnoDB, DDL transactions grab shared MDL locks on child tables, which is not enough to trigger MDL conflict in Galera.
InnoDB-level Wsrep patch didn't contain correct conflict resolution logic due to the fact that it was believed MDL locking should always produce conflicts correctly.

The fix brings conflict resolution rules similar to MDL-level checks to InnoDB, thus accounting for the problematic case.

Apart from that, wsrep_thd_is_SR() is patched to return true only for executing SR transactions. It should be safe as any other SR state is either the same as for any single write set (thus making the two logically equivalent), or it reflects an SR transaction as being aborting or prepared, which is handled separately in BF-aborting logic, and for regular execution path it should not matter at all.

## Release Notes

## How can this PR be tested?

MTR test is provided.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
