### PR TITLE
MDEV-34976 Server crash report broken if Galera is not loaded

### DIFF
--- a/sql/wsrep_server_state.cc
+++ b/sql/wsrep_server_state.cc
@@ -87,7 +87,7 @@ void Wsrep_server_state::destroy()
 
 void Wsrep_server_state::handle_fatal_signal()
 {
-  if (m_instance)
+  if (m_instance && m_instance->is_provider_loaded())
   {
     /* Galera background threads are still running and the logging may be
        relatively verbose in case of networking error. Silence all wsrep


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34976*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The crash report terminates prematurely when Galera library was not loaded.

As a fix, check whether the provider is loaded before shutting down Galera connections.

## How can this PR be tested?

No MTR test cases exist. Test by starting the server, signal the server to abort and observer crash report output.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
