### PR TITLE
Fix `DBUG_PRINT` format of `group_trp->records`

### DIFF
--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -3106,7 +3106,7 @@ SQL_SELECT::test_quick_select(THD *thd,
         group_by_optimization_used= 1;
         param.table->set_opt_range_condition_rows(group_trp->records);
         DBUG_PRINT("info", ("table_rows: %llu  opt_range_condition_rows: %llu  "
-                            "group_trp->records: %ull",
+                            "group_trp->records: %llu",
                             table_records,
                             param.table->opt_range_condition_rows,
                             group_trp->records));


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: [MDEV-21978](https://jira.mariadb.org/browse/MDEV-21978)*~~
  * Update: *The Jira issue number for this PR is: [MDEV-35432](https://jira.mariadb.org/browse/MDEV-35432)*

This commit backports a lone fix from #3360 for 11.2, our oldest 11.x in maintenance.
It is the only mistake introduced during 11.0–11.2.

### Release Notes
Not needed
### How can this PR be tested?
Use `DBUG` to confirm that the log doesn’t have an extraneous `ll` suffix
### Basing the PR against the correct MariaDB version
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
### PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
