### PR TITLE
Add missing `LEX_STRING::str`s for `my_snprintf`

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5732,7 +5732,7 @@ static void test_lc_time_sz()
         (*loc)->max_day_name_length != max_day_len)
     {
       DBUG_PRINT("Wrong max day name(or month name) length for locale:",
-                 ("%s", (*loc)->name));
+                 ("%s", (*loc)->name.str));
       DBUG_ASSERT(0);
     }
   }

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6063,7 +6063,7 @@ static bool check_locale(sys_var *self, THD *thd, set_var *var)
     {
       push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN, ER_UNKNOWN_ERROR,
                           "Can't process error message file for locale '%s'",
-                          locale->name);
+                          locale->name.str);
       return true;
     }
   }

--- a/storage/maria/ha_maria.cc
+++ b/storage/maria/ha_maria.cc
@@ -2079,7 +2079,7 @@ int ha_maria::enable_indexes(key_map map, bool persist)
     {
       sql_print_warning("Warning: Enabling keys got errno %d on %s, "
                         "retrying",
-                        my_errno, file->s->open_file_name);
+                        my_errno, file->s->open_file_name.str);
       /* Repairing by sort failed. Now try standard repair method. */
       param->testflag &= ~T_REP_BY_SORT;
       file->state->records= start_rows;


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: [MDEV-21978](https://jira.mariadb.org/browse/MDEV-21978)*~~
  * Udate: *The Jira issue number for this PR is: [MDEV-35434](https://jira.mariadb.org/browse/MDEV-35434)*

## Description
This commit backports a fix group from #3360 for 11.5.
These are the only mistakes introduced during 11.5.x.

### What problem is the patch trying to solve?
When these members switched from plain `char*` to `LEX_CSTRING`, not all usages were converted. Specifically, in this commit are args of `my_snprintf` derivatives.
Because until MDEV-21978 (#3360), automated type checks were unavailable for those functions due to their incompatibility, so these tools didn’t catch them.

### If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
`str` is the initial member of `LEX_CSTRING` (`typedef` of `struct st_mysql_const_lex_string`), so this difference did not cause incompatibility on most platforms with seamless alignments;
howëver, [my co-mentor notes that Visual Studio reads garbage](https://github.com/MariaDB/server/pull/3360#discussion_r1712667580).

## Release Notes
* Fixed data size mismatches that were garbling error and debug outputs (or possibly even crashes) on problematic platforms
  * (I adapted this line from the mould I used for previous iterations of https://github.com/MariaDB/server/pull/3360#issue-2374107080 backports.)

## How can this PR be tested?
This difference only manifests when `LEX_CSTRING::str` does not align on the `0`th index of the overall `LEX_CSTRING`.
Besides using Visual Studio as noted, another deception to disregard this leniency is to shift the `str` member away from the `0`th alignment, such as adding a padding member before it or moving it after member `length`.

## Basing the PR against the correct MariaDB version
* *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.