### PR TITLE
Add MTRs to further test coverage around TLS functionality

### DIFF
--- a/mysql-test/main/bad_startup_options.result
+++ b/mysql-test/main/bad_startup_options.result
@@ -1,2 +1,3 @@
 FOUND 1 /\[ERROR\] SSL error: Unable to get certificate/ in errorlog.err
+FOUND 1 /\[ERROR\] SSL error: Failed to set ciphers to use/ in errorlog.err
 # restart

--- a/mysql-test/main/bad_startup_options.test
+++ b/mysql-test/main/bad_startup_options.test
@@ -19,4 +19,11 @@
 --source include/search_pattern_in_file.inc
 --remove_file $SEARCH_FILE
 
+# No valid cipher suites
+--error 1
+--exec $MYSQLD --defaults-group-suffix=.1 --defaults-file=$MYSQLTEST_VARDIR/my.cnf --ssl-cipher=ECDHE-ECDSA-FAKE-CIPHER:ECDHE-RSA-INVALID --log-error=$errorlog
+--let SEARCH_PATTERN=\[ERROR\] SSL error: Failed to set ciphers to use
+--source include/search_pattern_in_file.inc
+--remove_file $SEARCH_FILE
+
 --source include/start_mysqld.inc

--- a/mysql-test/main/ssl_cipher.result
+++ b/mysql-test/main/ssl_cipher.result
@@ -68,3 +68,6 @@ disconnect ssl_con;
 connection default;
 call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
 FOUND 2 /TLSv1.0 and TLSv1.1 are insecure/ in mysqld.1.err
+# restart: --ssl-cipher=ECDHE-ECDSA-AES128-GCM-SHA256
+Variable_name	Value
+Ssl_version	

--- a/mysql-test/main/ssl_cipher.test
+++ b/mysql-test/main/ssl_cipher.test
@@ -112,3 +112,20 @@ call mtr.add_suppression("TLSv1.0 and TLSv1.1 are insecure");
 --let SEARCH_FILE=$MYSQLTEST_VARDIR/log/mysqld.1.err
 --let SEARCH_PATTERN= TLSv1.0 and TLSv1.1 are insecure
 --source include/search_pattern_in_file.inc
+
+#
+# Server is configured with ciphers that are not compatible with the server certificate (std_data/cacert.pem is RSA)
+#
+let $restart_parameters=--ssl-cipher=ECDHE-ECDSA-AES128-GCM-SHA256;
+source include/restart_mysqld.inc;
+
+# Connections are rejected as client attempts tls by default
+--error 1
+--exec $MYSQL --host=localhost -e "SHOW STATUS LIKE 'ssl_version'"
+
+# Connections are rejected if client explicitly specifies tls
+--error 1
+--exec $MYSQL --host=localhost --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-verify-server-cert -e "SHOW STATUS LIKE 'ssl_version'"
+
+# Connections can be made with --skip-ssl
+--exec $MYSQL --host=localhost --skip-ssl -e "SHOW STATUS LIKE 'ssl_version'"


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Increase TLS functionality coverage in MTRs.

A few additional test coverage added:

- Server behaves safely with invalid `ssl-cipher` configuration
- Server behaves safely when cipher and server certificate are incompatible

## Release Notes
N/A

## How can this PR be tested?

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

N/A

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.

## Copyright
All new code of the whole pull request, including one or several files
that are either new files or modified ones, are contributed under the
BSD-new license. I am contributing on behalf of my employer Amazon Web
Services, Inc.