### PR TITLE
Fix a couple of `my_snprintf` arg mismatches

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -7285,7 +7285,7 @@ int main(int argc, char **argv)
       goto err;
     connection_pool.for_each_connection([](MYSQL *c) {
       if (start_transaction(c))
-        maybe_die(EX_MYSQLERR, "Failed to start transaction on connection ID %u", mysql->thread_id);
+        maybe_die(EX_MYSQLERR, "Failed to start transaction on connection ID %lu", mysql->thread_id);
     });
   }
 

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -3901,7 +3901,8 @@ bool MYSQL_BIN_LOG::open(const char *log_name,
           if (!gtid_index)
             sql_print_information("Could not create GTID index for binlog "
                                   "file '%s'. Accesses to this binlog file will "
-                                  "fallback to slower sequential scan.");
+                                  "fallback to slower sequential scan.",
+                                  log_file_name);
         }
         else
           gtid_index= nullptr;


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: [MDEV-21978](https://jira.mariadb.org/browse/MDEV-21978)*~~
* Sibling of #3485, #3493 and #3518

## Description
This commit ports two fixes from #3360 according to the bug-fixing process to 11.4, covering cases introduced during 11.4.x.
* `client/mysqldump.cc`: Error message template had `%u` for a `long` arg (`MYSQL::thread_id`)
* `sql/log.cc`: Log message template had a `%s` but received no arg.

## Release Notes
* Fixed data size mismatches that were garbling error and debug outputs (or possibly even crashes) on problematic platforms
  * This should  match #3538.

## How can this PR be tested?
* `client/mysqldump.cc`: I’m not sure which platforms has `sizeof(long)` different from `sizeof(int)`.
* `sql/log.cc`: The dangling `%s` could pick up a garbage byte sequence in *ideal* scenarios.

## Basing the PR against the correct MariaDB version
* *This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.