### PR TITLE
reformat galera sst error messages

### DIFF
--- a/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
+++ b/mysql-test/suite/galera_3nodes/galera_3nodes.cnf
@@ -48,6 +48,7 @@ wsrep_sst_receive_address='127.0.0.1:@mysqld.3.#sst_port'
 
 [sst]
 sst-log-archive-dir=@ENV.MYSQLTEST_VARDIR/log
+transferfmt=@ENV.MTR_GALERA_TFMT
 
 [ENV]
 NODE_MYPORT_1= @mysqld.1.port

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -597,8 +597,8 @@ static void* sst_joiner_thread (void* a)
       if (!tmp || strlen(tmp) < (magic_len + 2) ||
           strncasecmp (tmp, magic, magic_len))
       {
-        WSREP_ERROR("Failed to read '%s <addr>' from: %s\n\tRead: '%s'",
-                    magic, arg->cmd, tmp);
+        WSREP_ERROR("Failed to read '%s <addr>' (got '%s') from: %s",
+                    magic, tmp, arg->cmd);
         proc.wait();
         if (proc.error()) err= proc.error();
       }
@@ -610,8 +610,8 @@ static void* sst_joiner_thread (void* a)
     else
     {
       err= proc.error();
-      WSREP_ERROR("Failed to execute: %s : %d (%s)",
-                  arg->cmd, err, strerror(err));
+      WSREP_ERROR("Failed to execute (%M): %s",
+                  err, arg->cmd);
     }
 
     /*


### PR DESCRIPTION
put the command line at the end. so that when a very long command line
is truncated, it doesn't take the actual error message with it