### PR TITLE
MDEV-34994: sql/mysqld: stop accept() loop after the first EAGAIN

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6360,7 +6360,9 @@ void handle_connections_sockets()
                                     &length);
       if (mysql_socket_getfd(new_sock) != INVALID_SOCKET)
         handle_accepted_socket(new_sock, sock);
-      else if (socket_errno != SOCKET_EINTR && socket_errno != SOCKET_EAGAIN)
+      else if (socket_errno == SOCKET_EAGAIN || socket_errno == SOCKET_EWOULDBLOCK)
+        break;
+      else if (socket_errno != SOCKET_EINTR)
       {
         /*
           accept(2) failed on the listening port.


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34994*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Each time a listener socket becomes ready, MariaDB calls accept() ten
times (MAX_ACCEPT_RETRY), even if all but the first one return EAGAIN
because there are no more connections.  This causes unnecessary CPU
usage - on our server, the CPU load of that thread, which does nothing
but accept(), saturates one CPU core by ~45%.  The loop should stop
after the first EAGAIN.

Perf report:

```
    11.01%  mariadbd  libc.so.6          [.] accept4
     6.42%  mariadbd  [kernel.kallsyms]  [k] finish_task_switch.isra.0
     5.50%  mariadbd  [kernel.kallsyms]  [k] _raw_spin_unlock_irqrestore
     5.50%  mariadbd  [kernel.kallsyms]  [k] syscall_enter_from_user_mode
     4.59%  mariadbd  [kernel.kallsyms]  [k] __fget_light
     3.67%  mariadbd  [kernel.kallsyms]  [k] kmem_cache_alloc
     2.75%  mariadbd  [kernel.kallsyms]  [k] fput
     2.75%  mariadbd  [kernel.kallsyms]  [k] mod_objcg_state
     1.83%  mariadbd  [kernel.kallsyms]  [k] __inode_wait_for_writeback
     1.83%  mariadbd  [kernel.kallsyms]  [k] __sys_accept4
     1.83%  mariadbd  [kernel.kallsyms]  [k] _raw_spin_unlock_irq
     1.83%  mariadbd  [kernel.kallsyms]  [k] alloc_inode
     1.83%  mariadbd  [kernel.kallsyms]  [k] call_rcu
```

## Release Notes
Reduce number of accept() system calls.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
