### PR TITLE
MDEV-32631 : galera_2_cluster: before_rollback(): Assertion `0' failed

### DIFF
--- a/mysql-test/suite/galera/disabled.def
+++ b/mysql-test/suite/galera/disabled.def
@@ -12,7 +12,6 @@
 
 galera_as_slave_ctas : MDEV-28378 timeout
 galera_pc_recovery : MDEV-25199 cluster fails to start up
-galera_sequences : MDEV-32561 WSREP FSM failure: no such a transition REPLICATING -> COMMITTED
 galera_concurrent_ctas : MDEV-32779 galera_concurrent_ctas: assertion in the galera::ReplicatorSMM::finish_cert()
 galera_as_slave_replay : MDEV-32780 galera_as_slave_replay: assertion in the wsrep::transaction::before_rollback()
 galera_slave_replay : MDEV-32780 galera_as_slave_replay: assertion in the wsrep::transaction::before_rollback()

--- a/mysql-test/suite/galera/r/galera_sequences.result
+++ b/mysql-test/suite/galera/r/galera_sequences.result
@@ -249,10 +249,13 @@ CREATE SEQUENCE t INCREMENT BY 0 CACHE=20 ENGINE=INNODB;
 ALTER TABLE t ENGINE=MYISAM;
 ERROR 42000: This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
 ALTER SEQUENCE t INCREMENT BY 1 CACHE=10;
-ERROR 42000: This version of MariaDB doesn't yet support 'CACHE without INCREMENT BY 0 in Galera cluster'
+ERROR 42000: This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
 ALTER SEQUENCE t INCREMENT BY 1 NOCACHE;
+ERROR 42000: This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
 ALTER SEQUENCE t INCREMENT BY 0 NOCACHE;
+ERROR 42000: This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
 ALTER SEQUENCE t INCREMENT BY 0 CACHE=10;
+ERROR 42000: This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
 DROP SEQUENCE t;
 CREATE SEQUENCE t INCREMENT BY 0 CACHE=20 ENGINE=INNODB;
 CREATE TABLE t1(a int not null primary key default nextval(t), b int) engine=innodb;
@@ -314,3 +317,9 @@ NEXTVAL(t)
 connection node_1;
 DROP TABLE t1;
 DROP SEQUENCE t;
+CREATE OR REPLACE TABLE t1(c INT ) ENGINE=ARIA;
+SET SESSION WSREP_OSU_METHOD=RSU;
+INSERT INTO t1 SELECT seq,concat(seq,1) FROM seq_1_to_100;
+ERROR 42000: This version of MariaDB doesn't yet support 'RSU on this table engine'
+SET SESSION WSREP_OSU_METHOD=TOI;
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_sequences.test
+++ b/mysql-test/suite/galera/t/galera_sequences.test
@@ -1,5 +1,8 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/have_aria.inc
+--source include/log_bin.inc
 
 #
 # MDEV-19353 : Alter Sequence do not replicate to another nodes with in Galera Cluster
@@ -283,8 +286,11 @@ CREATE SEQUENCE t INCREMENT BY 0 CACHE=20 ENGINE=INNODB;
 ALTER TABLE t ENGINE=MYISAM;
 --error ER_NOT_SUPPORTED_YET
 ALTER SEQUENCE t INCREMENT BY 1 CACHE=10;
+--error ER_NOT_SUPPORTED_YET
 ALTER SEQUENCE t INCREMENT BY 1 NOCACHE;
+--error ER_NOT_SUPPORTED_YET
 ALTER SEQUENCE t INCREMENT BY 0 NOCACHE;
+--error ER_NOT_SUPPORTED_YET
 ALTER SEQUENCE t INCREMENT BY 0 CACHE=10;
 DROP SEQUENCE t;
 
@@ -341,3 +347,14 @@ SELECT NEXTVAL(t);
 --connection node_1
 DROP TABLE t1;
 DROP SEQUENCE t;
+
+#
+# MDEV-32631
+#
+
+CREATE OR REPLACE TABLE t1(c INT ) ENGINE=ARIA;
+SET SESSION WSREP_OSU_METHOD=RSU;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 SELECT seq,concat(seq,1) FROM seq_1_to_100;
+SET SESSION WSREP_OSU_METHOD=TOI;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_3nodes/disabled.def
+++ b/mysql-test/suite/galera_3nodes/disabled.def
@@ -10,7 +10,6 @@
 #
 ##############################################################################
 
-galera_2_cluster : MDEV-32631 galera_2_cluster: before_rollback(): Assertion `0' failed
 galera_ipv6_rsync : MDEV-34842 Can't connect to server on '::1' (115)
 galera_ipv6_rsync_section : MDEV-34842 Can't connect to server on '::1' (115)
 galera_ipv6_mariabackup_section : MDEV-34842 Can't connect to server on '::1' (115)

--- a/mysql-test/suite/galera_3nodes/r/galera_2_cluster.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_2_cluster.result
@@ -1,5 +1,6 @@
 connection node_2;
 connection node_1;
+connect node_6, 127.0.0.1, root, , test, $NODE_MYPORT_6;
 connect node_5, 127.0.0.1, root, , test, $NODE_MYPORT_5;
 connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4;
 connection node_4;
@@ -21,7 +22,6 @@ include/sync_with_master_gtid.inc
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
 1
-connect node_6, 127.0.0.1, root, , test, $NODE_MYPORT_6;
 connection node_6;
 SELECT COUNT(*) = 1 FROM t1;
 COUNT(*) = 1
@@ -51,12 +51,22 @@ SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
 COUNT(*) = 3
 1
 connection node_2;
+connection node_1;
+connection node_3;
+connection node_4;
+connection node_5;
+connection node_6;
+connection node_2;
 OPTIMIZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
 test.t1	optimize	status	OK
+Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it uses a system variable that may have a different value on the slave
 connection node_1;
+connection node_3;
 connection node_4;
+connection node_5;
 connection node_6;
 connection node_1;
 DROP TABLE t1;
@@ -75,19 +85,33 @@ connection node_2;
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
-CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
 connection node_3;
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
-CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
 connection node_5;
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
-CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
 connection node_6;
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
+connection node_1;
 CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+connection node_2;
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+connection node_3;
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+connection node_4;
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+connection node_5;
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+connection node_6;
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");

--- a/mysql-test/suite/galera_3nodes/t/galera_2_cluster.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_2_cluster.cnf
@@ -1,25 +1,38 @@
 !include ../galera_2x3nodes.cnf
 
+[mysqld]
+wsrep-debug=1
+log-bin
+log-slave-updates
+
 [mysqld.1]
 wsrep_gtid_domain_id=1
 server-id=11
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.1.#galera_port;evs.suspect_timeout=PT20S;evs.inactive_timeout=PT30S;evs.install_timeout=PT25S;pc.wait_prim_timeout=PT60S;gcache.size=128M;pc.weight=2'
+
 
 [mysqld.2]
 wsrep_gtid_domain_id=1
 server-id=12
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.2.#galera_port;evs.suspect_timeout=PT20S;evs.inactive_timeout=PT30S;evs.install_timeout=PT25S;pc.wait_prim_timeout=PT60S;gcache.size=128M'
 
 [mysqld.3]
 wsrep_gtid_domain_id=1
 server-id=13
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.3.#galera_port;evs.suspect_timeout=PT20S;evs.inactive_timeout=PT30S;evs.install_timeout=PT25S;pc.wait_prim_timeout=PT60S;gcache.size=128M'
 
 [mysqld.4]
 wsrep_gtid_domain_id=2
 server-id=21
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.4.#galera_port;evs.suspect_timeout=PT20S;evs.inactive_timeout=PT30S;evs.install_timeout=PT25S;pc.wait_prim_timeout=PT60S;gcache.size=128M'
 
 [mysqld.5]
 wsrep_gtid_domain_id=2
 server-id=22
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.5.#galera_port;evs.suspect_timeout=PT20S;evs.inactive_timeout=PT30S;evs.install_timeout=PT25S;pc.wait_prim_timeout=PT60S;gcache.size=128M'
+
 
 [mysqld.6]
 wsrep_gtid_domain_id=2
 server-id=23
+wsrep_provider_options='repl.causal_read_timeout=PT90S;base_port=@mysqld.6.#galera_port;evs.suspect_timeout=PT20S;evs.inactive_timeout=PT30S;evs.install_timeout=PT25S;pc.wait_prim_timeout=PT60S;gcache.size=128M'

--- a/mysql-test/suite/galera_3nodes/t/galera_2_cluster.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_2_cluster.test
@@ -9,9 +9,10 @@
 --source include/big_test.inc
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
+--connect node_6, 127.0.0.1, root, , test, $NODE_MYPORT_6
 --connect node_5, 127.0.0.1, root, , test, $NODE_MYPORT_5
-
 --connect node_4, 127.0.0.1, root, , test, $NODE_MYPORT_4
 --connection node_4
 
@@ -42,7 +43,6 @@ SELECT COUNT(*) = 1 FROM t1;
 
 SELECT COUNT(*) = 1 FROM t1;
 
---connect node_6, 127.0.0.1, root, , test, $NODE_MYPORT_6
 --connection node_6
 
 SELECT COUNT(*) = 1 FROM t1;
@@ -82,22 +82,46 @@ SELECT COUNT(*) = 3 FROM information_schema.columns WHERE table_name ='t1';
 
 --connection node_2
 
---let $wsrep_last_committed_before = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
-OPTIMIZE TABLE t1;
+--let $wsrep_last_committed_before_2 = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
 --connection node_1
+--let $wsrep_last_committed_before_1 = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
 
---let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--connection node_3
+--let $wsrep_last_committed_before_3 = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_4
+--let $wsrep_last_committed_before_4 = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_5
+--let $wsrep_last_committed_before_5 = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_6
+--let $wsrep_last_committed_before_6 = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'`
+
+--connection node_2
+OPTIMIZE TABLE t1;
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before_2 + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition.inc
+
+--connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before_1 + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition.inc
+
+--connection node_3
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before_3 + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
 --source include/wait_condition.inc
 
 --connection node_4
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before_4 + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--source include/wait_condition.inc
 
---let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--connection node_5
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before_5 + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
 --source include/wait_condition.inc
 
 --connection node_6
-
---let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
+--let $wait_condition = SELECT VARIABLE_VALUE >= $wsrep_last_committed_before_6 + 1 FROM INFORMATION_SCHEMA.SESSION_STATUS WHERE VARIABLE_NAME = 'wsrep_last_committed'
 --source include/wait_condition.inc
 
 #
@@ -115,6 +139,7 @@ RESET SLAVE;
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 SET GLOBAL GTID_SLAVE_POS="";
 
 --connection node_1
@@ -122,35 +147,50 @@ SET GLOBAL GTID_SLAVE_POS="";
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
-
+--source include/wait_until_ready.inc
 --connection node_2
 
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
-
-CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+--source include/wait_until_ready.inc
 
 --connection node_3
 
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
-
-CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+--source include/wait_until_ready.inc
 
 --connection node_5
 
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
-
-CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+--source include/wait_until_ready.inc
 
 --connection node_6
 
 SET GLOBAL wsrep_on = OFF;
 RESET MASTER;
 SET GLOBAL wsrep_on = ON;
+--source include/wait_until_ready.inc
 
+--connection node_1
 CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+--connection node_2
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+--connection node_3
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+--connection node_4
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+--connection node_5
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");
+--connection node_6
+CALL mtr.add_suppression("Ignoring server id for non bootstrap node");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since.*");


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32631*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Test case changes only. Add wait_conditions to make sure nodes rejoin the cluster. Assertion itself should not be possible anymore as we do not allow sequences on Aria tables.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
