### PR TITLE
MDEV-35022 Fix Overuse of big stackvariables results inside InnoDB & mariabackup

### DIFF
--- a/extra/mariabackup/backup_copy.cc
+++ b/extra/mariabackup/backup_copy.cc
@@ -756,7 +756,7 @@ directory_exists_and_empty(const char *dir, const char *comment)
 {
 	os_file_dir_t os_dir;
 	dberr_t err;
-	os_file_stat_t info;
+	thread_local os_file_stat_t info;
 	bool empty;
 
 	if (!directory_exists(dir, true)) {
@@ -2213,7 +2213,7 @@ static bool backup_files_from_datadir(ds_ctxt_t *ds_data,
 	os_file_dir_t dir = os_file_opendir(dir_path);
 	if (dir == IF_WIN(INVALID_HANDLE_VALUE, nullptr)) return false;
 
-	os_file_stat_t info;
+	thread_local os_file_stat_t info;
 	bool ret = true;
 	while (os_file_readdir_next_file(dir_path, dir, &info) == 0) {
 

--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -1685,10 +1685,11 @@ operator<<(std::ostream& s, const escape_and_quote& eq)
 		return s << "NULL";
 	s << '\'';
 	size_t len = strlen(eq.str);
-	char* escaped = (char *)alloca(2 * len + 1);
+	char* escaped = (char *)malloc(2 * len + 1);
 	len = mysql_real_escape_string(eq.mysql, escaped, eq.str, (ulong)len);
 	s << std::string(escaped, len);
 	s << '\'';
+	free(escaped);
 	return s;
 }
 

--- a/extra/mariabackup/encryption_plugin.cc
+++ b/extra/mariabackup/encryption_plugin.cc
@@ -93,7 +93,7 @@ void encryption_plugin_backup_init(MYSQL *mysql)
   MYSQL_RES *result;
   MYSQL_ROW row;
   std::ostringstream oss;
-  char *argv[PLUGIN_MAX_ARGS];
+  thread_local char *argv[PLUGIN_MAX_ARGS];
   int argc;
 
   result = xb_mysql_query(mysql, QUERY_PLUGIN, true, true);

--- a/extra/mariabackup/fil_cur.cc
+++ b/extra/mariabackup/fil_cur.cc
@@ -244,15 +244,12 @@ xb_fil_cur_open(
 	return(XB_FIL_CUR_SUCCESS);
 }
 
-/* Stack usage 131224 with clang */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 static bool page_is_corrupted(const byte *page, ulint page_no,
 			      const xb_fil_cur_t *cursor,
 			      const fil_space_t *space)
 {
-	byte tmp_frame[UNIV_PAGE_SIZE_MAX];
-	byte tmp_page[UNIV_PAGE_SIZE_MAX];
+	thread_local byte tmp_frame[UNIV_PAGE_SIZE_MAX];
+	thread_local byte tmp_page[UNIV_PAGE_SIZE_MAX];
 	const ulint page_size = cursor->page_size;
 	uint16_t page_type = fil_page_get_type(page);
 

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -3820,8 +3820,8 @@ static dberr_t enumerate_ibd_files(process_single_tablespace_func_t callback)
 	ulint		dbpath_len	= 100;
 	os_file_dir_t	dir;
 	os_file_dir_t	dbdir;
-	os_file_stat_t	dbinfo;
-	os_file_stat_t	fileinfo;
+	thread_local os_file_stat_t dbinfo;
+	thread_local os_file_stat_t fileinfo;
 	dberr_t		err		= DB_SUCCESS;
 	size_t len;
 
@@ -5809,11 +5809,11 @@ static ibool xb_process_datadir(const char *path, const char *suffix,
                                 void *func_arg = NULL)
 {
 	ulint		ret;
-	char		dbpath[OS_FILE_MAX_PATH+2];
+	thread_local char dbpath[OS_FILE_MAX_PATH+2];
 	os_file_dir_t	dir;
 	os_file_dir_t	dbdir;
-	os_file_stat_t	dbinfo;
-	os_file_stat_t	fileinfo;
+	thread_local os_file_stat_t dbinfo;
+	thread_local os_file_stat_t fileinfo;
 	ulint		suffix_len;
 	dberr_t		err 		= DB_SUCCESS;
 	static char	current_dir[2];

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -238,8 +238,8 @@ buf_dump(
 {
 #define SHOULD_QUIT()	(SHUTTING_DOWN() && obey_shutdown)
 
-	char	full_filename[OS_FILE_MAX_PATH];
-	char	tmp_filename[OS_FILE_MAX_PATH + sizeof "incomplete"];
+	thread_local char full_filename[OS_FILE_MAX_PATH];
+	thread_local char tmp_filename[OS_FILE_MAX_PATH + sizeof "incomplete"];
 	char	now[32];
 	FILE*	f;
 	int	ret;
@@ -424,7 +424,7 @@ void
 buf_load()
 /*======*/
 {
-	char		full_filename[OS_FILE_MAX_PATH];
+	thread_local char full_filename[OS_FILE_MAX_PATH];
 	char		now[32];
 	FILE*		f;
 	page_id_t*	dump;

--- a/storage/innobase/fsp/fsp0sysspace.cc
+++ b/storage/innobase/fsp/fsp0sysspace.cc
@@ -629,7 +629,7 @@ SysTablespace::check_file_status(
 	const Datafile&		file,
 	file_status_t&		reason)
 {
-	os_file_stat_t	stat;
+	thread_local os_file_stat_t	stat;
 
 	memset(&stat, 0x0, sizeof(stat));
 

--- a/storage/innobase/fts/fts0fts.cc
+++ b/storage/innobase/fts/fts0fts.cc
@@ -1904,8 +1904,8 @@ fts_create_common_tables(
 	mem_heap_t*	heap = mem_heap_create(1024);
 	pars_info_t*	info;
 	char		fts_name[MAX_FULL_NAME_LEN];
-	char		full_name[sizeof(fts_common_tables) / sizeof(char*)]
-				[MAX_FULL_NAME_LEN];
+	thread_local char full_name[sizeof(fts_common_tables) / sizeof(char*)]
+				   [MAX_FULL_NAME_LEN];
 
 	dict_index_t*					index = NULL;
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -734,9 +734,9 @@ innodb_tmpdir_validate(
 
 	char*	alter_tmp_dir;
 	char*	innodb_tmp_dir;
-	char	buff[OS_FILE_MAX_PATH];
+	thread_local char buff[OS_FILE_MAX_PATH];
 	int	len = sizeof(buff);
-	char	tmp_abs_path[FN_REFLEN + 2];
+	thread_local char tmp_abs_path[FN_REFLEN + 2];
 
 	ut_ad(save != NULL);
 	ut_ad(value != NULL);
@@ -2670,7 +2670,7 @@ innobase_raw_format(
 	/* XXX we use a hard limit instead of allocating
 	but_size bytes from the heap */
 	CHARSET_INFO*	data_cs;
-	char		buf_tmp[8192];
+	thread_local char buf_tmp[8192];
 	ulint		buf_tmp_used;
 	uint		num_errors;
 
@@ -8480,7 +8480,7 @@ wsrep_calc_row_hash(
 					dictionary */
 	row_prebuilt_t*	prebuilt)	/*!< in: InnoDB prebuilt struct */
 {
-	void *ctx = alloca(my_md5_context_size());
+	void *ctx = ut_malloc_nokey(my_md5_context_size());
 	my_md5_init(ctx);
 
 	for (uint i = 0; i < table->s->fields; i++) {
@@ -8536,7 +8536,7 @@ wsrep_calc_row_hash(
 	}
 
 	my_md5_result(ctx, digest);
-
+	ut_free(ctx);
 	return(0);
 }
 
@@ -9613,7 +9613,7 @@ ha_innobase::ft_init_ext(
 	NEW_FT_INFO*		fts_hdl = NULL;
 	dict_index_t*		index;
 	fts_result_t*		result;
-	char			buf_tmp[8192];
+	thread_local char	buf_tmp[8192];
 	ulint			buf_tmp_used;
 	uint			num_errors;
 	ulint			query_len = key->length();
@@ -10041,7 +10041,7 @@ wsrep_append_foreign_key(
 		return DB_ERROR;
 	}
 
-	byte  key[WSREP_MAX_SUPPORTED_KEY_LENGTH+1] = {'\0'};
+	thread_local byte key[WSREP_MAX_SUPPORTED_KEY_LENGTH+1] = {'\0'};
 	ulint len = WSREP_MAX_SUPPORTED_KEY_LENGTH;
 
 	dict_index_t *idx_target = (referenced) ?
@@ -10269,7 +10269,7 @@ ha_innobase::wsrep_append_keys(
 	}
 
 	if (wsrep_protocol_version == 0) {
-		char 	keyval[WSREP_MAX_SUPPORTED_KEY_LENGTH+1] = {'\0'};
+		thread_local char keyval[WSREP_MAX_SUPPORTED_KEY_LENGTH+1] = {'\0'};
 		char 	*key 		= &keyval[0];
 		bool    is_null;
 
@@ -10311,8 +10311,8 @@ ha_innobase::wsrep_append_keys(
 			/* keyval[] shall contain an ordinal number at byte 0
 			   and the actual key data shall be written at byte 1.
 			   Hence the total data length is the key length + 1 */
-			char keyval0[WSREP_MAX_SUPPORTED_KEY_LENGTH+1]= {'\0'};
-			char keyval1[WSREP_MAX_SUPPORTED_KEY_LENGTH+1]= {'\0'};
+			thread_local char keyval0[WSREP_MAX_SUPPORTED_KEY_LENGTH+1]= {'\0'};
+			thread_local char keyval1[WSREP_MAX_SUPPORTED_KEY_LENGTH+1]= {'\0'};
 			keyval0[0] = (char)i;
 			keyval1[0] = (char)i;
 			char* key0 = &keyval0[1];
@@ -12321,8 +12321,8 @@ create_table_info_t::create_foreign_keys()
 	dberr_t		      error;
 	ulint		      number	      = 1;
 	static const unsigned MAX_COLS_PER_FK = 500;
-	const char*	      column_names[MAX_COLS_PER_FK];
-	const char*	      ref_column_names[MAX_COLS_PER_FK];
+	thread_local const char*column_names[MAX_COLS_PER_FK];
+	thread_local const char*ref_column_names[MAX_COLS_PER_FK];
 	char		      create_name[MAX_DATABASE_NAME_LEN + 1 +
 					  MAX_TABLE_NAME_LEN + 1];
 	dict_index_t*	      index	  = NULL;
@@ -14730,7 +14730,7 @@ ha_innobase::info_low(
 	dict_table_t*	ib_table;
 	ib_uint64_t	n_rows;
 	char		path[FN_REFLEN];
-	os_file_stat_t	stat_info;
+	thread_local os_file_stat_t stat_info;
 
 	DBUG_ENTER("info");
 

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -3234,9 +3234,9 @@ innobase_get_foreign_key_info(
 			continue;
 		}
 
-		const char*	column_names[MAX_NUM_FK_COLUMNS];
+		thread_local const char* column_names[MAX_NUM_FK_COLUMNS];
 		dict_index_t*	index = NULL;
-		const char*	referenced_column_names[MAX_NUM_FK_COLUMNS];
+		thread_local const char* referenced_column_names[MAX_NUM_FK_COLUMNS];
 		dict_index_t*	referenced_index = NULL;
 		ulint		num_col = 0;
 		ulint		referenced_num_col = 0;

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1282,7 +1282,7 @@ std::vector<std::string> get_existing_log_files_paths() {
   for (int i= 0; i < 101; i++) {
     auto path= get_log_file_path(LOG_FILE_NAME_PREFIX)
                                  .append(std::to_string(i));
-    os_file_stat_t stat;
+    thread_local os_file_stat_t stat;
     dberr_t err= os_file_get_status(path.c_str(), &stat, false, true);
     if (err)
       break;

--- a/storage/innobase/log/log0sync.cc
+++ b/storage/innobase/log/log0sync.cc
@@ -280,7 +280,7 @@ group_commit_lock::lock_return_code group_commit_lock::acquire(value_type num, c
 
 group_commit_lock::value_type group_commit_lock::release(value_type num)
 {
-  completion_callback callbacks[1000];
+  thread_local completion_callback callbacks[1000];
   size_t callback_count = 0;
   value_type ret = 0;
   std::unique_lock<std::mutex> lk(m_mtx);

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -3387,7 +3387,7 @@ size_t os_file_get_fs_block_size(const char *path)
                        &numberOfFreeClusters, &totalNumberOfClusters))
     return ((size_t) bytesPerSector) * sectorsPerCluster;
 #else
-  os_file_stat_t info;
+  thread_local os_file_stat_t info;
   if (os_file_get_status(path, &info, false, false) == DB_SUCCESS)
     return info.block_size;
 #endif

--- a/storage/innobase/pars/pars0opt.cc
+++ b/storage/innobase/pars/pars0opt.cc
@@ -554,8 +554,8 @@ opt_search_plan_for_table(
 	dict_index_t*	index;
 	ulint		n_fields;
 	ulint		best_last_op;
-	que_node_t*	index_plan[256];
-	que_node_t*	best_index_plan[256];
+	thread_local que_node_t* index_plan[256];
+	thread_local que_node_t* best_index_plan[256];
 
 	plan = sel_node_get_nth_plan(sel_node, i);
 

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -853,7 +853,7 @@ FetchIndexRootPages::build_row_import(row_import* cfg) const UNIV_NOTHROW
 
 	row_index_t*	cfg_index = cfg->m_indexes;
 
-	char	name[BUFSIZ];
+	thread_local char name[BUFSIZ];
 
 	snprintf(name, sizeof(name), "index" IB_ID_FMT, m_index.m_id);
 
@@ -2656,7 +2656,7 @@ row_import_read_index_data(
 				(void) fseek(file, 0L, SEEK_END););
 
 		if (n_bytes != sizeof(row)) {
-			char	msg[BUFSIZ];
+			thread_local char msg[BUFSIZ];
 
 			snprintf(msg, sizeof(msg),
 				 "while reading index meta-data, expected "
@@ -3659,7 +3659,7 @@ row_import_read_cfg(
 	row_import&	cfg)	/*!< out: contents of the .cfg file */
 {
 	dberr_t		err;
-	char		name[OS_FILE_MAX_PATH];
+	char name[OS_FILE_MAX_PATH];
 
 	cfg.m_table = table;
 
@@ -3668,7 +3668,7 @@ row_import_read_cfg(
 	FILE*	file = fopen(name, "rb");
 
 	if (file == NULL) {
-		char	msg[BUFSIZ];
+		thread_local char msg[BUFSIZ];
 
 		snprintf(msg, sizeof(msg),
 			 "Error opening '%s', will attempt to import"

--- a/storage/innobase/row/row0quiesce.cc
+++ b/storage/innobase/row/row0quiesce.cc
@@ -432,9 +432,6 @@ row_quiesce_write_header(
 Write the table meta data after quiesce.
 @return DB_SUCCESS or error code */
 
-/* Stack size 20904 with clang */
-PRAGMA_DISABLE_CHECK_STACK_FRAME
-
 static	MY_ATTRIBUTE((nonnull, warn_unused_result))
 dberr_t
 row_quiesce_write_cfg(
@@ -444,7 +441,7 @@ row_quiesce_write_cfg(
 	THD*			thd)	/*!< in/out: session */
 {
 	dberr_t			err;
-	char			name[OS_FILE_MAX_PATH];
+	thread_local char	name[OS_FILE_MAX_PATH];
 
 	srv_get_meta_data_filename(table, name, sizeof(name));
 
@@ -470,7 +467,7 @@ row_quiesce_write_cfg(
 
 		if (fflush(file) != 0) {
 
-			char	msg[BUFSIZ];
+			thread_local char msg[BUFSIZ];
 
 			snprintf(msg, sizeof(msg), "%s flush() failed", name);
 
@@ -480,7 +477,7 @@ row_quiesce_write_cfg(
 		}
 
 		if (fclose(file) != 0) {
-			char	msg[BUFSIZ];
+			thread_local char msg[BUFSIZ];
 
 			snprintf(msg, sizeof(msg), "%s flose() failed", name);
 
@@ -611,7 +608,7 @@ row_quiesce_table_complete(
 		/* Remove the .cfg file now that the user has resumed
 		normal operations. Otherwise it will cause problems when
 		the user tries to drop the database (remove directory). */
-		char		cfg_name[OS_FILE_MAX_PATH];
+		thread_local char	cfg_name[OS_FILE_MAX_PATH];
 
 		srv_get_meta_data_filename(table, cfg_name, sizeof(cfg_name));
 

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -166,7 +166,7 @@ srv_file_check_mode(
 /*================*/
 	const char*	name)		/*!< in: filename to check */
 {
-	os_file_stat_t	stat;
+	thread_local os_file_stat_t	stat;
 
 	memset(&stat, 0x0, sizeof(stat));
 
@@ -594,7 +594,7 @@ srv_check_undo_redo_logs_exists()
 {
 	bool		ret;
 	pfs_os_file_t	fh;
-	char	name[OS_FILE_MAX_PATH];
+	thread_local char name[OS_FILE_MAX_PATH];
 
 	/* Check if any undo tablespaces exist */
 	for (ulint i = 1; i <= srv_undo_tablespaces; ++i) {
@@ -656,7 +656,7 @@ static dberr_t srv_all_undo_tablespaces_open(bool create_new_db, ulint n_undo)
 
   for (ulint i= 0; i < n_undo; ++i)
   {
-    char name[OS_FILE_MAX_PATH];
+    thread_local char name[OS_FILE_MAX_PATH];
     snprintf(name, sizeof name, "%s/undo%03zu", srv_undo_dir, i + 1);
     ulint space_id= srv_undo_tablespace_open(create_new_db, name, i);
     switch (space_id) {
@@ -688,7 +688,7 @@ unused_undo:
   for (ulint i= prev_id + 1; i < srv_undo_space_id_start + TRX_SYS_N_RSEGS;
        ++i)
   {
-     char name[OS_FILE_MAX_PATH];
+     thread_local char name[OS_FILE_MAX_PATH];
      snprintf(name, sizeof name, "%s/undo%03zu", srv_undo_dir, i);
      ulint space_id= srv_undo_tablespace_open(create_new_db, name, i);
      if (!space_id || space_id == ULINT_UNDEFINED)
@@ -723,7 +723,7 @@ srv_undo_tablespaces_init(bool create_new_db)
 
     for (ulint i= 0; i < srv_undo_tablespaces; ++i)
     {
-      char name[OS_FILE_MAX_PATH];
+      thread_local char name[OS_FILE_MAX_PATH];
       snprintf(name, sizeof name, "%s/undo%03zu", srv_undo_dir, i + 1);
       if (dberr_t err= srv_undo_tablespace_create(name))
       {
@@ -990,7 +990,7 @@ static dberr_t find_and_check_log_file(bool &log_file_found)
   log_file_found= false;
 
   auto logfile0= get_log_file_path();
-  os_file_stat_t stat_info;
+  thread_local os_file_stat_t stat_info;
   const dberr_t err= os_file_get_status(logfile0.c_str(), &stat_info, false,
                                         srv_read_only_mode);
 

--- a/storage/innobase/trx/trx0i_s.cc
+++ b/storage/innobase/trx/trx0i_s.cc
@@ -622,7 +622,7 @@ fill_lock_data(
 	mem_heap_t*		heap;
 	rec_offs		offsets_onstack[REC_OFFS_NORMAL_SIZE];
 	rec_offs*		offsets;
-	char			buf[TRX_I_S_LOCK_DATA_MAX_LEN];
+	thread_local char	buf[TRX_I_S_LOCK_DATA_MAX_LEN];
 	ulint			buf_used;
 	ulint			i;
 

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -267,7 +267,7 @@ ut_copy_file(
 	FILE*	src)	/*!< in: input file to be appended to output */
 {
 	long	len = ftell(src);
-	char	buf[4096];
+	thread_local char buf[4096];
 
 	rewind(src);
 	do {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35022*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
- This patch removes the PRAGMA_DISABLE_CHECK_STACK_FRAME usage inside innodb, mariabackup and also made the large variable into thread_local storage or use the heap memory


## Release Notes
Made big stack variable into thread local storage and make use of heap memory.

## How can this PR be tested?
cmake -DCMAKE_BUILD_TYPE=Debug   -DCMAKE_CXX_FLAGS=-Wstack-usage=8192 -DMYSQL_MAINTAINER_MODE  && make -j4
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
