### PR TITLE
MDEV-34907 Bogus assertion failure and busy work while parsing FILE_ records

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -2847,7 +2847,7 @@ restart:
                                    last_offset)
                 : file_name_t::initial_flags;
               if (it == recv_spaces.end())
-                ut_ad(!file_checkpoint || space_id == TRX_SYS_SPACE ||
+                ut_ad(!store || space_id == TRX_SYS_SPACE ||
                       srv_is_undo_tablespace(space_id));
               else if (!it->second.space)
               {


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34907*

## Description
A server that was running with `innodb_log_file_size=96M` and `innodb_buffer_pool_size=6M` had inserted some data into a table that was subsequently dropped. When the server was killed and restarted, an assertion failed in `recv_sys_t::parse()` while a `FSP_SIZE` change was unnecessarily being processed during the `skip_the_rest:` loop in `recv_scan_log()`.

The `ib_logfile0` contents was as follows:

1. The checkpoint start LSN points to the start of some mini-transaction.
2. There may be log records for modifying files for which a `FILE_MODIFY` had been written before the checkpoint. These records were "purged" by advancing the checkpoint.
3. At some point during the initial parsing with `store=true` the space reserved for `recv_sys.pages` will run out and `recv_scan_log()` would switch to the skip_the_rest: mode.
4. We encounter a log record for extending a tablespace that will be deleted a bit later. This would trip the bogus debug assertion.
5. Later on, there would be a `FILE_DELETE` record for this tablespace.
6. The checkpoint end LSN points to a possibly empty sequence of `FILE_MODIFY` records and a `FILE_CHECKPOINT` record. Recovery had parsed these records first, before rewinding to the checkpoint start LSN.
7. There could be further records following the `FILE_CHECKPOINT` record. Recovery will process all records until an inconsistency is found and it is assumed that the end of the circular `ib_logfile0` was reached.

`recv_sys_t::parse()`: For the template instantiation with `store=false`, remove a debug assertion that could fail in a multi-batch recovery, while `recv_scan_log(false)` would be in the `skip_the_rest:` loop. It is very well possible that we have not encountered all `FILE_` records yet, and therefore we should not complain about unknown tablespaces.
## Release Notes
Nothing. This is only removing a bogus debug assertion.
## How can this PR be tested?
Kill and restart the server right after a rebuild of a large table, such after a completed `OPTIMIZE TABLE`. Another scenario would be to kill the server right after a large `INSERT` followed by a `DROP TABLE`.

This change was also tested by successfully running the crash recovery of a saved data directory. `CHECK TABLE…EXTENDED` did not report any errors on any tables.

The code change here is identical to the initial revision of #3507, which was transformed into a performance fix.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.