### PR TITLE
MDEV-34880 Incorrect result for query with derived table having TEXT …

### DIFF
--- a/mysql-test/main/derived.result
+++ b/mysql-test/main/derived.result
@@ -1862,3 +1862,19 @@ pk	a
 deallocate prepare stmt;
 drop table t1,t2,t3;
 # End of MariaDB 11.1 tests
+#
+# MDEV-34880: Incorrect result for query with derived table having TEXT field
+#
+CREATE TABLE t1 (id int NOT NULL  PRIMARY KEY, notes TEXT NOT NULL);
+INSERT INTO t1 VALUES (1, 'test1'), (2, 'test2');
+SELECT dt.* FROM (SELECT * FROM t1 UNION SELECT * FROM t1) dt WHERE id = 1;
+id	notes
+1	test1
+SELECT dt.* FROM (SELECT * FROM t1 UNION SELECT * FROM t1) dt WHERE id = 1 AND
+notes = 'test1';
+id	notes
+1	test1
+DROP TABLE t1;
+#
+# End of 11.2 tests
+#

--- a/mysql-test/main/derived.test
+++ b/mysql-test/main/derived.test
@@ -1514,3 +1514,20 @@ deallocate prepare stmt;
 drop table t1,t2,t3;
 
 --echo # End of MariaDB 11.1 tests
+
+--echo #
+--echo # MDEV-34880: Incorrect result for query with derived table having TEXT field
+--echo #
+CREATE TABLE t1 (id int NOT NULL  PRIMARY KEY, notes TEXT NOT NULL);
+INSERT INTO t1 VALUES (1, 'test1'), (2, 'test2');
+
+SELECT dt.* FROM (SELECT * FROM t1 UNION SELECT * FROM t1) dt WHERE id = 1;
+
+SELECT dt.* FROM (SELECT * FROM t1 UNION SELECT * FROM t1) dt WHERE id = 1 AND
+  notes = 'test1';
+
+DROP TABLE t1;
+
+--echo #
+--echo # End of 11.2 tests
+--echo #

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -3737,6 +3737,28 @@ int handler::ha_rnd_pos(uchar *buf, uchar *pos)
   DBUG_RETURN(result);
 }
 
+
+int handler::ha_index_init(uint idx, bool sorted)
+{
+  DBUG_EXECUTE_IF("ha_index_init_fail", return HA_ERR_TABLE_DEF_CHANGED;);
+  int result;
+  DBUG_ENTER("ha_index_init");
+  DBUG_ASSERT(inited==NONE);
+  if (!(result= index_init(idx, sorted)))
+  {
+    inited=       INDEX;
+    active_index= idx;
+    end_range= NULL;
+  }
+  /*
+    Do not allow reads from UNIQUE HASH indexes.
+  */
+  DBUG_ASSERT(!(table->key_info[active_index].flags & HA_UNIQUE_HASH));
+
+  DBUG_RETURN(result);
+}
+
+
 int handler::ha_index_read_map(uchar *buf, const uchar *key,
                                       key_part_map keypart_map,
                                       enum ha_rkey_function find_flag)

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -3449,20 +3449,7 @@ public:
   
   int ha_open(TABLE *table, const char *name, int mode, uint test_if_locked,
               MEM_ROOT *mem_root= 0, List<String> *partitions_to_open=NULL);
-  int ha_index_init(uint idx, bool sorted)
-  {
-    DBUG_EXECUTE_IF("ha_index_init_fail", return HA_ERR_TABLE_DEF_CHANGED;);
-    int result;
-    DBUG_ENTER("ha_index_init");
-    DBUG_ASSERT(inited==NONE);
-    if (!(result= index_init(idx, sorted)))
-    {
-      inited=       INDEX;
-      active_index= idx;
-      end_range= NULL;
-    }
-    DBUG_RETURN(result);
-  }
+  int ha_index_init(uint idx, bool sorted);
   int ha_index_end()
   {
     DBUG_ENTER("ha_index_end");

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -7257,8 +7257,14 @@ add_key_part(DYNAMIC_ARRAY *keyuse_array, KEY_FIELD *key_field)
     {
       if (!(form->keys_in_use_for_query.is_set(key)))
 	continue;
-      if (form->key_info[key].flags & (HA_FULLTEXT | HA_SPATIAL))
+      if (form->key_info[key].flags & (HA_FULLTEXT|HA_SPATIAL|HA_UNIQUE_HASH))
+      {
+        /*
+         HA_UNIQUE_HASH indexes are excluded since they cannot be used
+         for lookups. See Create_tmp_field::finalize() for details
+        */
 	continue;    // ToDo: ft-keys in non-ft queries.   SerG
+      }
 
       KEY *keyinfo= form->key_info+key;
       uint key_parts= form->actual_n_key_parts(keyinfo);


### PR DESCRIPTION
…field

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34880*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
When a derived table which has distinct values and BLOB fields is materialized, an index is created over all columns to ensure only distinct values are placed to the result.
This index is created in a special mode HA_UNIQUE_HASH to support BLOBs. Later in `best_access_path` the optimizer may incorrectly choose this index to retrieve values from the derived table, although such type of index cannot be used for data retrieval.

This commit excludes HA_UNIQUE_HASH indexes from consideration in `best_access_path`

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

A test case is added to `main/derived.test`
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
