### PR TITLE
MDEV-34207: ALTER TABLE...STATS_PERSISTENT=0 fails to drop statistics

### DIFF
--- a/mysql-test/suite/innodb/r/stat_tables.result
+++ b/mysql-test/suite/innodb/r/stat_tables.result
@@ -82,4 +82,22 @@ WHERE database_name='test' AND table_name='t1' AND stat_name='size';
 TIMESTAMPDIFF(DAY,last_update,now())<=1
 1
 DROP TABLE t1;
+#
+# MDEV-34207: ALTER TABLE...STATS_PERSISTENT=0 fails to drop statistics
+#
+CREATE TABLE t1 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
+ALTER TABLE t1 STATS_PERSISTENT 0;
+DROP TABLE t1;
+SET @save_persistent=@@GLOBAL.innodb_stats_persistent;
+SET GLOBAL innodb_stats_persistent=1;
+CREATE TABLE t2 (c1 INT) ENGINE=InnoDB;
+RENAME TABLE t2 TO t1;
+DROP TABLE t1;
+SET GLOBAL innodb_stats_persistent=0;
+CREATE TABLE t2 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
+RENAME TABLE t2 TO t1;
+SET GLOBAL innodb_stats_persistent=@save_persistent;
+DROP TABLE t1;
+CREATE TABLE t1 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
+DROP TABLE t1;
 # End of 10.6 tests

--- a/mysql-test/suite/innodb/t/stat_tables.test
+++ b/mysql-test/suite/innodb/t/stat_tables.test
@@ -80,5 +80,29 @@ SELECT TIMESTAMPDIFF(DAY,last_update,now())<=1 FROM mysql.innodb_index_stats
 WHERE database_name='test' AND table_name='t1' AND stat_name='size';
 DROP TABLE t1;
 
+--echo #
+--echo # MDEV-34207: ALTER TABLE...STATS_PERSISTENT=0 fails to drop statistics
+--echo #
+CREATE TABLE t1 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
+ALTER TABLE t1 STATS_PERSISTENT 0;
+DROP TABLE t1;
+
+SET @save_persistent=@@GLOBAL.innodb_stats_persistent;
+SET GLOBAL innodb_stats_persistent=1;
+
+CREATE TABLE t2 (c1 INT) ENGINE=InnoDB;
+RENAME TABLE t2 TO t1;
+
+DROP TABLE t1;
+SET GLOBAL innodb_stats_persistent=0;
+
+CREATE TABLE t2 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
+RENAME TABLE t2 TO t1;
+
+SET GLOBAL innodb_stats_persistent=@save_persistent;
+DROP TABLE t1;
+
+CREATE TABLE t1 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
+DROP TABLE t1;
 
 --echo # End of 10.6 tests


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34207*
## Description
Statements like `ALTER TABLE t STATS_PERSISTENT 0` would fail to delete the persistent InnoDB statistics for the table, which would cause a duplicate key error on a subsequent operation that would create or rename tables.

Note that `DROP TABLE` will on purpose not attempt to drop persistent statistics if they were not enabled for the table. This will reduce the chances of `DROP TABLE` failing due to a locking conflict.

`commit_try_norebuild()`: If the `STATS_PERSISTENT` attribute of the table is being changed to disabled, drop the persistent statistics of the table.

## Release Notes
Statements like `ALTER TABLE t STATS_PERSISTENT 0` failed to delete the persistent InnoDB statistics for the table, which would cause a duplicate key error on a subsequent operation that would create or rename tables.
## How can this PR be tested?
```sh
./mtr innodb.stat_tables
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.