### PR TITLE
MDEV-34450 os_file_write_func() is an overkill for ib_logfile0

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -46,6 +46,7 @@ Created 12/9/1995 Heikki Tuuri
 #include "buf0dump.h"
 #include "log0sync.h"
 #include "log.h"
+#include "tpool.h"
 
 /*
 General philosophy of InnoDB redo-logs:
@@ -132,18 +133,57 @@ __attribute__((warn_unused_result))
 dberr_t log_file_t::read(os_offset_t offset, span<byte> buf) noexcept
 {
   ut_ad(is_opened());
-  return os_file_read(IORequestRead, m_file, buf.data(), offset, buf.size(),
-                      nullptr);
+  byte *data= buf.data();
+  size_t size= buf.size();
+  ut_ad(size);
+  ssize_t s;
+
+  for (;;)
+  {
+    s= IF_WIN(tpool::pread(m_file, data, size, offset),
+              pread(m_file, data, size, offset));
+    if (UNIV_UNLIKELY(s <= 0))
+      break;
+    size-= size_t(s);
+    if (!size)
+      return DB_SUCCESS;
+    offset+= s;
+    data+= s;
+    ut_a(size < buf.size());
+  }
+
+  sql_print_error("InnoDB: pread(\"ib_logfile0\") returned %zd,"
+                  " operating system error %u",
+                  s, unsigned(IF_WIN(GetLastError(), errno)));
+  return DB_IO_ERROR;
 }
 
 void log_file_t::write(os_offset_t offset, span<const byte> buf) noexcept
 {
   ut_ad(is_opened());
-  if (dberr_t err= os_file_write_func(IORequestWrite, "ib_logfile0", m_file,
-                                      buf.data(), offset, buf.size()))
-    ib::fatal() << "write(\"ib_logfile0\") returned " << err
-                << ". Operating system error number "
-                << IF_WIN(GetLastError(), errno) << ".";
+  const byte *data= buf.data();
+  size_t size= buf.size();
+  ut_ad(size);
+  ssize_t s;
+
+  for (;;)
+  {
+    s= IF_WIN(tpool::pwrite(m_file, data, size, offset),
+              pwrite(m_file, data, size, offset));
+    if (UNIV_UNLIKELY(s <= 0))
+      break;
+    size-= size_t(s);
+    if (!size)
+      return;
+    offset+= s;
+    data+= s;
+    ut_a(size < buf.size());
+  }
+
+  sql_print_error("[FATAL] InnoDB: pwrite(\"ib_logfile0\") returned %zd,"
+                  " operating system error %u",
+                  s, unsigned(IF_WIN(GetLastError(), errno)));
+  abort();
 }
 
 #ifdef HAVE_INNODB_MMAP

--- a/tpool/aio_simulated.cc
+++ b/tpool/aio_simulated.cc
@@ -73,7 +73,7 @@ static WinIoInit win_io_init;
 
 
 SSIZE_T pread(const native_file_handle &h, void *buf, size_t count,
-                 unsigned long long offset)
+              unsigned long long offset)
 {
   OVERLAPPED ov{};
   ULARGE_INTEGER uli;
@@ -95,8 +95,8 @@ SSIZE_T pread(const native_file_handle &h, void *buf, size_t count,
   return -1;
 }
 
-SSIZE_T pwrite(const native_file_handle &h, void *buf, size_t count,
-                  unsigned long long offset)
+SSIZE_T pwrite(const native_file_handle &h, const void *buf, size_t count,
+               unsigned long long offset)
 {
   OVERLAPPED ov{};
   ULARGE_INTEGER uli;

--- a/tpool/tpool.h
+++ b/tpool/tpool.h
@@ -293,10 +293,10 @@ create_thread_pool_win(int min_threads= DEFAULT_MIN_POOL_THREADS,
   opened with FILE_FLAG_OVERLAPPED, and bound to completion
   port.
 */
-SSIZE_T pwrite(const native_file_handle &h, void *buf, size_t count,
-           unsigned long long offset);
+SSIZE_T pwrite(const native_file_handle &h, const void *buf, size_t count,
+               unsigned long long offset);
 SSIZE_T pread(const native_file_handle &h, void *buf, size_t count,
-          unsigned long long offset);
+              unsigned long long offset);
 HANDLE win_get_syncio_event();
 #endif
 } // namespace tpool


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34450*
## Description
`log_file_t::read()`, `log_file_t::write()`: Invoke `pread()` or `pwrite()` directly, so that we can give more accurate diagnostics in case of a failure, and so that we will avoid the overhead of setting up 5(!) stack frames and related objects.
## Release Notes
This could be a minor performance improvement, probably not worth mentioning.
## How can this PR be tested?
The log writing and crash recovery are exercised by the existing test suite, in particular by the `innodb`, `encryption`, and `mariabackup` suites.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

This could be applicable to other versions as well. 10.11 is the earliest maintained branch after the last major refactoring of the log reading and writing in 685d958e38b825ad9829be311f26729cccf37c46.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.