### PR TITLE
MDEV-34902: Fix Debian reporting error on Aria/MyISAM even tables are…

### DIFF
--- a/debian/additions/debian-start.inc.sh
+++ b/debian/additions/debian-start.inc.sh
@@ -23,17 +23,19 @@ function check_for_crashed_tables() {
   # If a crashed table is encountered, the "mariadb" command will return with a status different from 0
   #
   # The first query will generate lines like.
-  #   select count(*) into @discard from 'mysql'.'db'
+  #   select count(*) into @discard from `mysql`.`db`
   # The second line will load all tables without printing any actual results,
   # but may show warnings and definitely is expected to have some error and
   # exit code if crashed tables are encountered.
   #
-  # Note that inside single quotes must be quoted with '\'' (to be outside of single quotes).
+  # Note that the below is inside an echo with single quotes which is why double-quotes and back-ticks
+  # are used.
   set +e
   # The $MARIADB is intentionally used to expand into a command and arguments
   # shellcheck disable=SC2086
+  # shellcheck disable=SC2016
   echo '
-    SELECT CONCAT("select count(*) into @discard from '\''", TABLE_SCHEMA, "'\''.'\''", TABLE_NAME, "'\''")
+    SELECT CONCAT("select count(*) into @discard from `", TABLE_SCHEMA, "`.`", TABLE_NAME, "`")
     FROM information_schema.TABLES WHERE TABLE_SCHEMA<>"INFORMATION_SCHEMA" AND TABLE_SCHEMA<>"PERFORMANCE_SCHEMA"
     AND (ENGINE="MyISAM" OR ENGINE="Aria")
     ' | \


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34902*

## Description
Commit changes '\'' to single back-tick char in  Debian start-up script function 'check_for_crashed_tables' which is used to check are Aria/MyISAM tables crashed and do they need manual repairing.

Without this initial script can report for crashed tables even if they are all good.

## Release Notes
Should not add anything

## How can this PR be tested?
This is bit tricky to test (automatic test is on it's was but still in works).  This bit WIP currently
If you have podman with systemd:
```
podman run -it --systemd=true registry.salsa.debian.org/salsa-ci-team/pipeline/autopkgtest systemd
```
and then
```
podman exec -it correctsha bash
```
one can install system MariaDB with these: https://mariadb.org/download/?t=repo-config&d=Debian+%22Sid%22&v=10.11&r_m=xtom_tal
After that should install nano
```
apt install nano bsd-mailx
```
and then run add this script:
```
#!/bin/bash

function check_journalctl
{
  JOURNALCTL_ERROR=$(journalctl | grep "\[ERROR\] mariadbd: Table './mydatabase/mytable name' is marked as crashed and should be repaired")

  if [ -z "${JOURNALCTL_ERROR}" ]
  then
     echo "There should be error that MyISAM crashed and it's repaired"
     exit 1
  fi

  JOURNALCTL_ERROR=$(journalctl | grep "\[Warning\] Checking table:   './mydatabase/mytable name'")

  if [ -z "${JOURNALCTL_ERROR}" ]
  then
      echo "There should be warning for MyISAM check"
      exit 1
  fi
}

set -ex

systemctl restart mariadb

echo '
  DROP DATABASE IF EXISTS mydatabase;
  CREATE DATABASE IF NOT EXISTS mydatabase;
  USE mydatabase;
  CREATE TABLE `ariamytabledev` (id INT(11), name VARCHAR(100)) ENGINE=Aria;
  INSERT INTO `ariamytabledev` (id, name) VALUES (1, "John Doe");
  CREATE TABLE `aria-mytable-dev` (id INT(11), name VARCHAR(100)) ENGINE=Aria;
  INSERT INTO `aria-mytable-dev` (id, name) VALUES (1, "John Doe");
  CREATE TABLE `aria mytable dev` (id INT(11), name VARCHAR(100)) ENGINE=Aria;
  INSERT INTO `aria mytable dev` (id, name) VALUES (1, "John Doe");
  CREATE TABLE `myisammytabledev` (id INT(11), name VARCHAR(100)) ENGINE=MyISAM;
  INSERT INTO `myisammytabledev` (id, name) VALUES (1, "John Doe");
  CREATE TABLE `myisam-mytable-dev` (id INT(11), name VARCHAR(100)) ENGINE=MyISAM;
  INSERT INTO `myisam-mytable-dev` (id, name) VALUES (1, "John Doe");
  CREATE TABLE `myisam mytable dev` (id INT(11), name VARCHAR(100)) ENGINE=MyISAM;
  INSERT INTO `myisam mytable dev` (id, name) VALUES (1, "John Doe");
' | mariadb

systemctl restart mariadb

check_journalctl

exit 0

```

It should fail even without `killall -9 mariadb` every time.  After that tester should download deb packages from https://salsa.debian.org/illuusio/mariadb-server/-/pipelines/740935 and install them with
```
apt install debian/output/*.deb
```
and run script again and it should not complain all the times in journalctl. I'll update this testing..


## Basing the PR against the correct MariaDB version
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
