### PR TITLE
MDEV-35125: Unnecessary buf_pool.page_hash lookups

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -5899,18 +5899,23 @@ btr_blob_get_next_page_no(
 @param mtr     mini-transaction to commit */
 static void btr_blob_free(buf_block_t *block, bool all, mtr_t *mtr)
 {
-  const page_id_t page_id(block->page.id());
   ut_ad(mtr->memo_contains_flagged(block, MTR_MEMO_PAGE_X_FIX));
+  block->page.fix();
+#ifdef UNIV_DEBUG
+  const page_id_t page_id{block->page.id()};
+  buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(page_id.fold());
+#endif
   mtr->commit();
 
-  buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(page_id.fold());
   mysql_mutex_lock(&buf_pool.mutex);
+  block->page.unfix();
+  ut_ad(block->page.id() == page_id);
+  ut_ad(&block->page == buf_pool.page_hash.get(page_id, chain));
 
-  if (buf_page_t *bpage= buf_pool.page_hash.get(page_id, chain))
-    if (!buf_LRU_free_page(bpage, all) && all && bpage->zip.data)
-      /* Attempt to deallocate the redundant copy of the uncompressed page
-      if the whole ROW_FORMAT=COMPRESSED block cannot be deallocted. */
-      buf_LRU_free_page(bpage, false);
+  if (!buf_LRU_free_page(&block->page, all) && all && block->page.zip.data)
+    /* Attempt to deallocate the redundant copy of the uncompressed page
+    if the whole ROW_FORMAT=COMPRESSED block cannot be deallocted. */
+    buf_LRU_free_page(&block->page, false);
 
   mysql_mutex_unlock(&buf_pool.mutex);
 }

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -2474,24 +2474,21 @@ corrupted:
 			only to delete the .ibd files. */
 			goto corrupted;
 		} else {
-			const page_id_t page_id{table->space->id, pk->page};
 			mtr.start();
-			buf_block_t* block = buf_page_get(
-				page_id, table->space->zip_size(),
-				RW_S_LATCH, &mtr);
-			const bool corrupted = !block
-				|| page_get_space_id(block->page.frame)
-				!= page_id.space()
-				|| page_get_page_no(block->page.frame)
-				!= page_id.page_no()
-				|| (mach_read_from_2(FIL_PAGE_TYPE
-						    + block->page.frame)
-				    != FIL_PAGE_INDEX
-				    && mach_read_from_2(FIL_PAGE_TYPE
-							+ block->page.frame)
-				    != FIL_PAGE_TYPE_INSTANT);
+			bool ok = false;
+			if (buf_block_t* b = buf_page_get(
+				    page_id_t(table->space->id, pk->page),
+				    table->space->zip_size(),
+				    RW_S_LATCH, &mtr)) {
+				switch (mach_read_from_2(FIL_PAGE_TYPE
+							 + b->page.frame)) {
+				case FIL_PAGE_INDEX:
+				case FIL_PAGE_TYPE_INSTANT:
+					ok = true;
+				}
+			}
 			mtr.commit();
-			if (corrupted) {
+			if (!ok) {
 				goto corrupted;
 			}
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35125*
## Description
InnoDB could avoid a `buf_pool.page_hash` look up as well as some operations on buffer page descriptors in a few places.

`dict_index_t::clear()`, `btr_drop_temporary_table()`: Make use of the root page guess if it is available.

`btr_read_autoinc()`: Invoke `btr_root_block_get()` to access the root page.

`btr_blob_free()`: Retain a buffer-fix on the page across `mtr_t::commit()` in order to avoid a `buf_pool.page_hash` lookup.

`dict_load_table_one()`: Remove a redundant check for page id. It was already validated in `buf_page_t::read_complete()`.

`trx_t::apply_log()`: Make use of `buf_pool.page_fix()` to avoid some `mtr_t` related overhead.
## Release Notes
This is a minor performance fix that probably is not worth a special mention.
## How can this PR be tested?
This low-level code should be well covered by the existing regression tests. An additional stress test with RQG should always be useful.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

This would be partly applicable to the 10.5 version, but it depends on `buf_pool.page_fix()` that was added in 9878238f7457280f3368e5d31b66aac49433c792 for 10.6 only.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.