### PR TITLE
[Draft] Innodb : page compression does not work on Windows anymore

### DIFF
--- a/mysql-test/suite/innodb/page_compression_windows.test
+++ b/mysql-test/suite/innodb/page_compression_windows.test
@@ -1,0 +1,7 @@
+--source include/have_innodb.inc
+--source include/windows.inc
+create table t_compressed(b longblob) page_compressed=1;
+insert into  t_compressed values(repeat(1,1000000));
+# Check that compression worked, i.e allocated size (physical file size) < logical file size
+select allocated_size < file_size from information_schema.innodb_sys_tablespaces where name='test/t_compressed';
+drop table t_compressed;

--- a/mysql-test/suite/innodb/r/page_compression_windows.result
+++ b/mysql-test/suite/innodb/r/page_compression_windows.result
@@ -1,0 +1,6 @@
+create table t_compressed(b longblob) engine=InnoDB page_compressed=1;
+insert into  t_compressed values(repeat(1,1000000));
+select allocated_size < file_size from information_schema.innodb_sys_tablespaces where name='test/t_compressed';
+allocated_size < file_size
+1
+drop table t_compressed;

--- a/mysql-test/suite/innodb/t/page_compression_windows.opt
+++ b/mysql-test/suite/innodb/t/page_compression_windows.opt
@@ -1,0 +1,1 @@
+--innodb-sys-tablespaces

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -2897,22 +2897,8 @@ os_file_set_size(
 
 #ifdef _WIN32
 	/* On Windows, changing file size works well and as expected for both
-	sparse and normal files.
-
-	However, 10.2 up until 10.2.9 made every file sparse in innodb,
-	causing NTFS fragmentation issues(MDEV-13941). We try to undo
-	the damage, and unsparse the file.*/
-
-	if (!is_sparse && os_is_sparse_file_supported(file)) {
-		if (!os_file_set_sparse_win32(file, false))
-			/* Unsparsing file failed. Fallback to writing binary
-			zeros, to avoid even higher fragmentation.*/
-			goto fallback;
-	}
-
+	sparse and normal files. */
 	return os_file_change_size_win32(name, file, size);
-
-fallback:
 #else
 	struct stat statbuf;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34929*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Sparse files, that are created for Innodb for page compressed tables on Windows, loose "sparse" property when file is extended.

This happens due to combination of Innodb inconsistent use of is_sparse parameter for compressed tables when table is extended, and the old workaround for MDEV-13941

## Release Notes
Fixed page_compressed tables on Windows to be compressed

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
