### PR TITLE
MDEV-35174 Possible hang in trx_undo_prev_version()

### DIFF
--- a/storage/innobase/include/trx0purge.h
+++ b/storage/innobase/include/trx0purge.h
@@ -125,7 +125,8 @@ class purge_sys_t
 
 public:
   /** latch protecting view, m_enabled */
-  alignas(CPU_LEVEL1_DCACHE_LINESIZE) mutable srw_spin_lock latch;
+  alignas(CPU_LEVEL1_DCACHE_LINESIZE)
+  mutable IF_DBUG(srw_lock_debug,srw_spin_lock) latch;
 private:
   /** Read view at the start of a purge batch. Any encountered index records
   that are older than view will be removed. */

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -2040,8 +2040,10 @@ err_exit:
 
 static dberr_t trx_undo_prev_version(const rec_t *rec, dict_index_t *index,
                                      rec_offs *offsets, mem_heap_t *heap,
-                                     rec_t **old_vers, mem_heap_t *v_heap,
-                                     dtuple_t **vrow, ulint v_status,
+                                     rec_t **old_vers,
+                                     const purge_sys_t::view_guard &check,
+                                     ulint v_status,
+                                     mem_heap_t *v_heap, dtuple_t **vrow,
                                      const trx_undo_rec_t *undo_rec);
 
 inline const buf_block_t *
@@ -2142,7 +2144,8 @@ dberr_t trx_undo_prev_version_build(const rec_t *rec, dict_index_t *index,
       if (UNIV_UNLIKELY(end > offset &&
                         end < srv_page_size - FIL_PAGE_DATA_END))
         err= trx_undo_prev_version(rec, index, offsets, heap,
-                                   old_vers, v_heap, vrow, v_status, undo_rec);
+                                   old_vers, check, v_status, v_heap, vrow,
+                                   undo_rec);
     }
   }
 
@@ -2152,8 +2155,10 @@ dberr_t trx_undo_prev_version_build(const rec_t *rec, dict_index_t *index,
 
 static dberr_t trx_undo_prev_version(const rec_t *rec, dict_index_t *index,
                                      rec_offs *offsets, mem_heap_t *heap,
-                                     rec_t **old_vers, mem_heap_t *v_heap,
-                                     dtuple_t **vrow, ulint v_status,
+                                     rec_t **old_vers,
+                                     const purge_sys_t::view_guard &check,
+                                     ulint v_status,
+                                     mem_heap_t *v_heap, dtuple_t **vrow,
                                      const trx_undo_rec_t *undo_rec)
 {
 	byte type, cmpl_info;
@@ -2223,7 +2228,7 @@ static dberr_t trx_undo_prev_version(const rec_t *rec, dict_index_t *index,
 		the BLOB. */
 
 		if (update->info_bits & REC_INFO_DELETED_FLAG
-		    && purge_sys.is_purgeable(trx_id)) {
+		    && check.view().changes_visible(trx_id)) {
 			return DB_SUCCESS;
 		}
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34174*
## Description
In commit b7b9f3ce825a08f16ad851c16f603365ae473195 (MDEV-34515) we accidentally made the InnoDB MVCC code acquire a shared purge_sys.latch twice. Recursive shared latch acquisition may cause a deadlock of InnoDB threads if another thread in between will start waiting for an exclusive latch.

`purge_sys_t::latch`: In debug builds, use `srw_lock_debug` instead of `srw_spin_lock`, so that bugs like this will result in debug assertion failures.

`trx_undo_report_row_operation()`: Pass the `view_guard` to `trx_undo_prev_version()` and the rest of the arguments in the same order, so that the work to permute argument registers is minimized.
## Release Notes
This does not need to be mentioned, because there is no release that would include the bug but not this fix.
## How can this PR be tested?
Stress test with any workload that includes transaction rollbacks.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.