### PR TITLE
MDEV-35183  ADD FULLTEXT INDEX unnecessarily DROPS FTS COMMON TABLES

### DIFF
--- a/mysql-test/suite/innodb_fts/r/fulltext.result
+++ b/mysql-test/suite/innodb_fts/r/fulltext.result
@@ -784,3 +784,28 @@ f1	MATCH(f1) AGAINST ("test" IN BOOLEAN MODE)
 test	0.000000001885928302414186
 DROP TABLE t1;
 # End of 10.3 tests
+#
+#  MDEV-35183 ADD FULLTEXT INDEX unnecessarily DROPS FTS
+#		COMMON TABLES
+#
+CREATE TABLE t1 (
+ID INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+title VARCHAR(200), book VARCHAR(200),
+FULLTEXT fidx(title)) ENGINE = InnoDB;
+INSERT INTO t1(title) VALUES('database');
+ALTER TABLE t1 DROP INDEX fidx;
+select space into @common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
+ALTER TABLE t1 ADD FULLTEXT fidx_1(book);
+select space=@common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
+space=@common_space
+1
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `ID` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(200) DEFAULT NULL,
+  `book` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`ID`),
+  FULLTEXT KEY `fidx_1` (`book`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+DROP TABLE t1;

--- a/mysql-test/suite/innodb_fts/t/fulltext.test
+++ b/mysql-test/suite/innodb_fts/t/fulltext.test
@@ -803,3 +803,19 @@ SELECT f1, MATCH(f1) AGAINST ("test" IN BOOLEAN MODE) FROM t1;
 DROP TABLE t1;
 
 --echo # End of 10.3 tests
+
+--echo #
+--echo #  MDEV-35183 ADD FULLTEXT INDEX unnecessarily DROPS FTS
+--echo #		COMMON TABLES
+--echo #
+CREATE TABLE t1 (
+        ID INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
+        title VARCHAR(200), book VARCHAR(200),
+        FULLTEXT fidx(title)) ENGINE = InnoDB;
+INSERT INTO t1(title) VALUES('database');
+ALTER TABLE t1 DROP INDEX fidx;
+select space into @common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
+ALTER TABLE t1 ADD FULLTEXT fidx_1(book);
+select space=@common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
+SHOW CREATE TABLE t1;
+DROP TABLE t1;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35183*

## Description
- InnoDB fulltext rebuilds the FTS COMMON table while adding the new fulltext index. This can be optimized by avoiding rebuilding the FTS COMMON table in case of FTS COMMON TABLE already exists.


## How can this PR be tested?
./mtr innodb_fts.fulltext

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.