### PR TITLE
MDEV-35189: Updating cache for INNODB_LOCKS et al is suboptimal

### DIFF
--- a/storage/innobase/ha/ha0storage.cc
+++ b/storage/innobase/ha/ha0storage.cc
@@ -29,7 +29,6 @@ Created September 22, 2007 Vasil Dimov
 #include "ha0storage.h"
 #include "hash0hash.h"
 #include "mem0mem.h"
-#include "ut0rnd.h"
 
 /*******************************************************************//**
 Retrieves a data from a storage. If it is present, a pointer to the
@@ -40,17 +39,10 @@ ha_storage_get(
 /*===========*/
 	ha_storage_t*	storage,	/*!< in: hash storage */
 	const void*	data,		/*!< in: data to check for */
-	ulint		data_len)	/*!< in: data length */
+	ulint		data_len,	/*!< in: data length */
+	uint32_t	fold)		/*!< in: my_crc32(data, data_len) */
 {
 	ha_storage_node_t*	node;
-	ulint			fold;
-
-	/* avoid repetitive calls to ut_fold_binary() in the HASH_SEARCH
-	macro */
-	fold = ut_fold_binary(static_cast<const byte*>(data), data_len);
-
-#define IS_FOUND	\
-	node->data_len == data_len && memcmp(node->data, data, data_len) == 0
 
 	HASH_SEARCH(
 		next,			/* node->"next" */
@@ -59,7 +51,9 @@ ha_storage_get(
 		ha_storage_node_t*,	/* type of node->next */
 		node,			/* auxiliary variable */
 		,			/* assertion */
-		IS_FOUND);		/* search criteria */
+		node->data_len == data_len
+		&& memcmp(node->data, data, data_len) == 0);
+					/* search criteria */
 
 	if (node == NULL) {
 
@@ -90,10 +84,10 @@ ha_storage_put_memlim(
 	void*			raw;
 	ha_storage_node_t*	node;
 	const void*		data_copy;
-	ulint			fold;
+	const uint32_t fold = my_crc32c(0, data, data_len);
 
 	/* check if data chunk is already present */
-	data_copy = ha_storage_get(storage, data, data_len);
+	data_copy = ha_storage_get(storage, data, data_len, fold);
 	if (data_copy != NULL) {
 
 		return(data_copy);
@@ -120,10 +114,6 @@ ha_storage_put_memlim(
 
 	node->data_len = data_len;
 	node->data = data_copy;
-
-	/* avoid repetitive calls to ut_fold_binary() in the HASH_INSERT
-	macro */
-	fold = ut_fold_binary(static_cast<const byte*>(data), data_len);
 
 	HASH_INSERT(
 		ha_storage_node_t,	/* type used in the hash chain */

--- a/storage/innobase/trx/trx0i_s.cc
+++ b/storage/innobase/trx/trx0i_s.cc
@@ -59,47 +59,6 @@ now, then 39th chunk would accommodate 1677416425 rows and all chunks
 would accommodate 3354832851 rows. */
 #define MEM_CHUNKS_IN_TABLE_CACHE	39
 
-/** The following are some testing auxiliary macros. Do not enable them
-in a production environment. */
-/* @{ */
-
-#if 0
-/** If this is enabled then lock folds will always be different
-resulting in equal rows being put in a different cells of the hash
-table. Checking for duplicates will be flawed because different
-fold will be calculated when a row is searched in the hash table. */
-#define TEST_LOCK_FOLD_ALWAYS_DIFFERENT
-#endif
-
-#if 0
-/** This effectively kills the search-for-duplicate-before-adding-a-row
-function, but searching in the hash is still performed. It will always
-be assumed that lock is not present and insertion will be performed in
-the hash table. */
-#define TEST_NO_LOCKS_ROW_IS_EVER_EQUAL_TO_LOCK_T
-#endif
-
-#if 0
-/** This aggressively repeats adding each row many times. Depending on
-the above settings this may be noop or may result in lots of rows being
-added. */
-#define TEST_ADD_EACH_LOCKS_ROW_MANY_TIMES
-#endif
-
-#if 0
-/** Very similar to TEST_NO_LOCKS_ROW_IS_EVER_EQUAL_TO_LOCK_T but hash
-table search is not performed at all. */
-#define TEST_DO_NOT_CHECK_FOR_DUPLICATE_ROWS
-#endif
-
-#if 0
-/** Do not insert each row into the hash table, duplicates may appear
-if this is enabled, also if this is enabled searching into the hash is
-noop because it will be empty. */
-#define TEST_DO_NOT_INSERT_INTO_THE_HASH_TABLE
-#endif
-/* @} */
-
 /** Memory limit passed to ha_storage_put_memlim().
 @param cache hash storage
 @return maximum allowed allocation size */
@@ -820,34 +779,17 @@ ulint
 fold_lock(
 /*======*/
 	const lock_t*	lock,	/*!< in: lock object to fold */
-	ulint		heap_no)/*!< in: lock's record number
+	uint16_t	heap_no)/*!< in: lock's record number
 				or 0xFFFF if the lock
 				is a table lock */
 {
-#ifdef TEST_LOCK_FOLD_ALWAYS_DIFFERENT
-	static ulint	fold = 0;
-
-	return(fold++);
-#else
-	ulint	ret;
-
-	if (!lock->is_table()) {
-		ut_a(heap_no != 0xFFFF);
-		ret = ut_fold_ulint_pair((ulint) lock->trx->id,
-					 lock->un_member.rec_lock.page_id.
-					 fold());
-		ret = ut_fold_ulint_pair(ret, heap_no);
-	} else {
-		/* this check is actually not necessary for continuing
-		correct operation, but something must have gone wrong if
-		it fails. */
-		ut_a(heap_no == 0xFFFF);
-
-		ret = (ulint) lock_get_table(*lock)->id;
-	}
-
-	return(ret);
-#endif
+  ut_ad((heap_no == 0xFFFF) == lock->is_table());
+  if (heap_no == 0xFFFF)
+    return ulint(lock->un_member.tab_lock.table->id);
+  char buf[8 + 8];
+  memcpy(buf, &lock->trx->id, 8);
+  memcpy(buf + 8, &lock->un_member.rec_lock.page_id, 8);
+  return my_crc32c(heap_no, buf, sizeof buf);
 }
 
 /*******************************************************************//**
@@ -864,9 +806,6 @@ locks_row_eq_lock(
 					is a table lock */
 {
 	ut_ad(i_s_locks_row_validate(row));
-#ifdef TEST_NO_LOCKS_ROW_IS_EVER_EQUAL_TO_LOCK_T
-	return(0);
-#else
 	if (!lock->is_table()) {
 		ut_a(heap_no != 0xFFFF);
 
@@ -882,49 +821,6 @@ locks_row_eq_lock(
 		return(row->lock_trx_id == lock->trx->id
 		       && row->lock_table_id == lock_get_table(*lock)->id);
 	}
-#endif
-}
-
-/*******************************************************************//**
-Searches for a row in the innodb_locks cache that has a specified id.
-This happens in O(1) time since a hash table is used. Returns pointer to
-the row or NULL if none is found.
-@return row or NULL */
-static
-i_s_locks_row_t*
-search_innodb_locks(
-/*================*/
-	trx_i_s_cache_t*	cache,	/*!< in: cache */
-	const lock_t*		lock,	/*!< in: lock to search for */
-	uint16_t		heap_no)/*!< in: lock's record number
-					or 0xFFFF if the lock
-					is a table lock */
-{
-	i_s_hash_chain_t*	hash_chain;
-
-	HASH_SEARCH(
-		/* hash_chain->"next" */
-		next,
-		/* the hash table */
-		&cache->locks_hash,
-		/* fold */
-		fold_lock(lock, heap_no),
-		/* the type of the next variable */
-		i_s_hash_chain_t*,
-		/* auxiliary variable */
-		hash_chain,
-		/* assertion on every traversed item */
-		ut_ad(i_s_locks_row_validate(hash_chain->value)),
-		/* this determines if we have found the lock */
-		locks_row_eq_lock(hash_chain->value, lock, heap_no));
-
-	if (hash_chain == NULL) {
-
-		return(NULL);
-	}
-	/* else */
-
-	return(hash_chain->value);
 }
 
 /*******************************************************************//**
@@ -940,26 +836,36 @@ add_lock_to_cache(
 	trx_i_s_cache_t*	cache,	/*!< in/out: cache */
 	const lock_t*		lock,	/*!< in: the element to add */
 	uint16_t		heap_no)/*!< in: lock's record number
-					or 0 if the lock
+					or 0xFFFF if the lock
 					is a table lock */
 {
-	i_s_locks_row_t*	dst_row;
+	const ulint fold = fold_lock(lock, heap_no);
 
-#ifdef TEST_ADD_EACH_LOCKS_ROW_MANY_TIMES
-	ulint	i;
-	for (i = 0; i < 10000; i++) {
-#endif
-#ifndef TEST_DO_NOT_CHECK_FOR_DUPLICATE_ROWS
 	/* quit if this lock is already present */
-	dst_row = search_innodb_locks(cache, lock, heap_no);
-	if (dst_row != NULL) {
+	i_s_hash_chain_t*	hash_chain;
 
-		ut_ad(i_s_locks_row_validate(dst_row));
-		return(dst_row);
+	HASH_SEARCH(
+		/* hash_chain->"next" */
+		next,
+		/* the hash table */
+		&cache->locks_hash,
+		/* fold */
+		fold,
+		/* the type of the next variable */
+		i_s_hash_chain_t*,
+		/* auxiliary variable */
+		hash_chain,
+		/* assertion on every traversed item */
+		ut_ad(i_s_locks_row_validate(hash_chain->value)),
+		/* this determines if we have found the lock */
+		locks_row_eq_lock(hash_chain->value, lock, heap_no));
+
+	if (hash_chain && hash_chain->value) {
+		ut_ad(i_s_locks_row_validate(hash_chain->value));
+		return hash_chain->value;
 	}
-#endif
 
-	dst_row = (i_s_locks_row_t*)
+	i_s_locks_row_t* dst_row = (i_s_locks_row_t*)
 		table_cache_create_empty_row(&cache->innodb_locks, cache);
 
 	/* memory could not be allocated */
@@ -975,7 +881,6 @@ add_lock_to_cache(
 		return(NULL);
 	}
 
-#ifndef TEST_DO_NOT_INSERT_INTO_THE_HASH_TABLE
 	HASH_INSERT(
 		/* the type used in the hash chain */
 		i_s_hash_chain_t,
@@ -984,13 +889,9 @@ add_lock_to_cache(
 		/* the hash table */
 		&cache->locks_hash,
 		/* fold */
-		fold_lock(lock, heap_no),
+		fold,
 		/* add this data to the hash */
 		&dst_row->hash_chain);
-#endif
-#ifdef TEST_ADD_EACH_LOCKS_ROW_MANY_TIMES
-	} /* for()-loop */
-#endif
 
 	ut_ad(i_s_locks_row_validate(dst_row));
 	return(dst_row);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35189*
## Description
There are some performance issues with the cache that is underlying the `INFORMATION_SCHEMA` tables `INNODB_LOCKS`, `INNODB_LOCK_WAITS` and `INNODB_TRX`.

`ha_storage_put_memlim()`: Invoke `my_crc32c()` just once to "fold".

`fold_lock()`: Remove some redundant conditions and use `my_crc32c()` instead of `ut_fold_ulint_pair()`.

`add_lock_to_cache()`: Invoke `fold_lock()` only once.

TODO (MDEV-35190): Combine `HASH_SEARCH` and `HASH_INSERT` similar to `buf_pool.page_hash.cell_get()`.
## Release Notes
There performance of InnoDB hash table operations was slightly improved.
## How can this PR be tested?
```sh
./mtr --parallel=auto innodb.innodb_i_s_innodb_trx innodb.innodb_i_s_innodb_locks
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

Some of this would be applicable to 10.5 as well, but we target 10.6 because of the MDEV-35190 dependency.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.