### PR TITLE
MDEV-35208 mtr correct behaviour of --port-base

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -1474,7 +1474,6 @@ sub command_line_setup {
       mtr_warning ("Port base $opt_port_base rounded down to multiple of 10");
       $opt_port_base-= $rem;
     }
-    $opt_build_thread= $opt_port_base / 10 - 1000;
   }
 
   # --------------------------------------------------------------------------
@@ -1702,11 +1701,6 @@ sub command_line_setup {
 # an environment variable can be used to control all ports. A small
 # number is to be used, 0 - 16 or similar.
 #
-# Note the MASTER_MYPORT has to be set the same in all 4.x and 5.x
-# versions of this script, else a 4.0 test run might conflict with a
-# 5.1 test run, even if different MTR_BUILD_THREAD is used. This means
-# all port numbers might not be used in this version of the script.
-#
 # Also note the limitation of ports we are allowed to hand out. This
 # differs between operating systems and configuration, see
 # http://www.ncftp.com/ncftpd/doc/misc/ephemeral_ports.html
@@ -1717,10 +1711,14 @@ sub set_build_thread_ports($) {
 
   if ( lc($opt_build_thread) eq 'auto' ) {
     my $found_free = 0;
-    $build_thread = 300;	# Start attempts from here
-    my $build_thread_upper = $build_thread + ($opt_parallel > 1500
-                                              ? 3000
-                                              : 2 * $opt_parallel) + 300;
+    if ($opt_port_base eq "auto") {
+      $build_thread = 16000;
+    } else {
+      $build_thread = $opt_port_base;
+    }
+    $build_thread += ($thread - 1) * $opt_port_group_size;
+    my $build_thread_upper = $build_thread + $opt_parallel * 2;
+
     while (! $found_free)
     {
       $build_thread= mtr_get_unique_id($build_thread, $build_thread_upper);
@@ -1737,7 +1735,7 @@ sub set_build_thread_ports($) {
   }
   else
   {
-    $build_thread = $opt_build_thread + $thread - 1;
+    $build_thread = $opt_port_base + $thread - 1;
     if (! check_ports_free($build_thread)) {
       # Some port was not free(which one has already been printed)
       mtr_error("Some port(s) was not free")
@@ -1746,7 +1744,7 @@ sub set_build_thread_ports($) {
   $ENV{MTR_BUILD_THREAD}= $build_thread;
 
   # Calculate baseport
-  $baseport= $build_thread * $opt_port_group_size + 10000;
+  $baseport= $build_thread;
   if ( $baseport < 5001 or $baseport + $opt_port_group_size >= 32767 )
   {
     mtr_error("MTR_BUILD_THREAD number results in a port",
@@ -2943,7 +2941,7 @@ sub kill_leftovers ($) {
 sub check_ports_free ($)
 {
   my $bthread= shift;
-  my $portbase = $bthread * $opt_port_group_size + 10000;
+  my $portbase = $bthread;
   for ($portbase..$portbase+($opt_port_group_size-1)){
     if (mtr_ping_port($_)){
       mtr_report(" - 'localhost:$_' was not free");


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35208*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Commit c2d9762011aa74e076390af1500d89dd3146796d added additional ports for galera, and moved the starting port into the 19000 range.

Unfortunately --port-base settings have some odd relationships and now mtr --port-base=21000 will end up looking for ports 0-30.

This patch removes some existing code related to 4.0 and 5.1 MySQL testing concurrently which I assume no-one has done for 15+ years.

Replace the concept of a build_thread to refer straight to the port number of the worker being used. Once this is done the number of calculations is reduced.

Also put the default --port-base back to 16000 where it was for very many years.

## Release Notes

Correct mariadb-test-suite --port-base behaviour and puts default port-base back to 16000

## How can this PR be tested?

mtr main.select
mtr --mtr-port-base=19000 main.select
mtr --mtr-port-base=21000 main.select
mtr --mtr-port-base=21000 --parallel 30 main.select{,,,,,,,,,,,,,,,,,,}


<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
