### PR TITLE
MDEV-35171 remove OS_FILE_NORMAL, OS_FILE_AIO

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -3953,7 +3953,7 @@ static dberr_t xb_assign_undo_space_start()
 	ulint		fsp_flags;
 
 	file = os_file_create(0, srv_sys_space.first_datafile()->filepath(),
-		OS_FILE_OPEN, OS_FILE_NORMAL, OS_DATA_FILE, true, &ret);
+		OS_FILE_OPEN, OS_DATA_FILE, true, &ret);
 
 	if (!ret) {
 		msg("Error opening %s", srv_sys_space.first_datafile()->filepath());

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -389,7 +389,7 @@ static bool fil_node_open_file_low(fil_node_t *node, const byte *page,
                                  node->is_raw_disk
                                  ? OS_FILE_OPEN_RAW | OS_FILE_ON_ERROR_NO_EXIT
                                  : OS_FILE_OPEN | OS_FILE_ON_ERROR_NO_EXIT,
-                                 OS_FILE_AIO, type,
+                                 type,
                                  srv_read_only_mode, &success);
 
     if (success && node->is_open())
@@ -1999,7 +1999,7 @@ fil_ibd_create(
 	file = os_file_create(
 		innodb_data_file_key, path,
 		OS_FILE_CREATE | OS_FILE_ON_ERROR_NO_EXIT,
-		OS_FILE_AIO, type, srv_read_only_mode, &success);
+		type, srv_read_only_mode, &success);
 
 	if (!success) {
 		/* The following call will print an error message */

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -53,7 +53,7 @@ Datafile::open_or_create(bool read_only_mode)
 
 	m_handle = os_file_create(
 		innodb_data_file_key, m_filepath, m_open_flags,
-		OS_FILE_NORMAL, OS_DATA_FILE, read_only_mode, &success);
+		OS_DATA_FILE, read_only_mode, &success);
 
 	if (!success) {
 		m_last_os_error = os_file_get_last_error(true);

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -145,9 +145,6 @@ static const ulint OS_FILE_READ_WRITE = 444;
 /** Used by MySQLBackup */
 static const ulint OS_FILE_READ_ALLOW_DELETE = 555;
 
-/* Options for file_create */
-static const ulint OS_FILE_AIO = 61;
-static const ulint OS_FILE_NORMAL = 62;
 /* @} */
 
 /** Types for file create @{ */
@@ -409,12 +406,6 @@ Opens an existing file or creates a new.
 @param[in]	name		name of the file or path as a null-terminated
 				string
 @param[in]	create_mode	create mode
-@param[in]	purpose		OS_FILE_AIO, if asynchronous, non-buffered I/O
-				is desired, OS_FILE_NORMAL, if any normal file;
-				NOTE that it also depends on type, os_aio_..
-				and srv_.. variables whether we really use
-				async I/O or unbuffered I/O: look in the
-				function source code for the exact rules
 @param[in]	type		OS_DATA_FILE or OS_LOG_FILE
 @param[in]	read_only	if true read only mode checks are enforced
 @param[in]	success		true if succeeded
@@ -424,7 +415,6 @@ pfs_os_file_t
 os_file_create_func(
 	const char*	name,
 	ulint		create_mode,
-	ulint		purpose,
 	ulint		type,
 	bool		read_only,
 	bool*		success)
@@ -564,9 +554,9 @@ os_file_write
 
 The wrapper functions have the prefix of "innodb_". */
 
-# define os_file_create(key, name, create, purpose, type, read_only,	\
+# define os_file_create(key, name, create, type, read_only,	\
 			success)					\
-	pfs_os_file_create_func(key, name, create, purpose,	type,	\
+	pfs_os_file_create_func(key, name, create,	type,	\
 		read_only, success, __FILE__, __LINE__)
 
 # define os_file_create_simple(key, name, create, access,		\
@@ -669,12 +659,6 @@ Add instrumentation to monitor file creation/open.
 @param[in]	name		name of the file or path as a null-terminated
 				string
 @param[in]	create_mode	create mode
-@param[in]	purpose		OS_FILE_AIO, if asynchronous, non-buffered I/O
-				is desired, OS_FILE_NORMAL, if any normal file;
-				NOTE that it also depends on type, os_aio_..
-				and srv_.. variables whether we really use
-				async I/O or unbuffered I/O: look in the
-				function source code for the exact rules
 @param[in]	read_only	if true read only mode checks are enforced
 @param[out]	success		true if succeeded
 @param[in]	src_file	file name where func invoked
@@ -687,7 +671,6 @@ pfs_os_file_create_func(
 	mysql_pfs_key_t key,
 	const char*	name,
 	ulint		create_mode,
-	ulint		purpose,
 	ulint		type,
 	bool		read_only,
 	bool*		success,
@@ -837,9 +820,9 @@ pfs_os_file_delete_if_exists_func(
 
 /* If UNIV_PFS_IO is not defined, these I/O APIs point
 to original un-instrumented file I/O APIs */
-# define os_file_create(key, name, create, purpose, type, read_only,	\
+# define os_file_create(key, name, create, type, read_only,	\
 			success)					\
-	os_file_create_func(name, create, purpose, type, read_only,	\
+	os_file_create_func(name, create, type, read_only,	\
 			success)
 
 # define os_file_create_simple(key, name, create_mode, access,		\

--- a/storage/innobase/include/os0file.inl
+++ b/storage/innobase/include/os0file.inl
@@ -129,12 +129,6 @@ Add instrumentation to monitor file creation/open.
 @param[in]	name		name of the file or path as a null-terminated
 				string
 @param[in]	create_mode	create mode
-@param[in]	purpose		OS_FILE_AIO, if asynchronous, non-buffered I/O
-				is desired, OS_FILE_NORMAL, if any normal file;
-				NOTE that it also depends on type, os_aio_..
-				and srv_.. variables whether we really us
-				async I/O or unbuffered I/O: look in the
-				function source code for the exact rules
 @param[in]	read_only	if true read only mode checks are enforced
 @param[out]	success		true if succeeded
 @param[in]	src_file	file name where func invoked
@@ -147,7 +141,6 @@ pfs_os_file_create_func(
 	mysql_pfs_key_t key,
 	const char*	name,
 	ulint		create_mode,
-	ulint		purpose,
 	ulint		type,
 	bool		read_only,
 	bool*		success,
@@ -165,7 +158,7 @@ pfs_os_file_create_func(
 		name, src_file, src_line);
 
 	pfs_os_file_t	file = os_file_create_func(
-		name, create_mode, purpose, type, read_only, success);
+		name, create_mode, type, read_only, success);
 
 	register_pfs_file_open_end(locker, file,
 				(*success == TRUE ? success : 0));

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -252,7 +252,7 @@ dberr_t file_os_io::open(const char *path, bool read_only) noexcept
   bool success;
   auto tmp_fd= os_file_create(
       innodb_log_file_key, path, OS_FILE_OPEN | OS_FILE_ON_ERROR_NO_EXIT,
-      OS_FILE_NORMAL, OS_LOG_FILE, read_only, &success);
+      OS_LOG_FILE, read_only, &success);
   if (!success)
     return DB_ERROR;
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -858,7 +858,7 @@ processed:
       handle= os_file_create(innodb_data_file_key, filename,
                              OS_FILE_CREATE | OS_FILE_ON_ERROR_NO_EXIT |
                              OS_FILE_ON_ERROR_SILENT,
-                             OS_FILE_AIO, OS_DATA_FILE, false, &success);
+                             OS_DATA_FILE, false, &success);
     }
     space->add(filename, handle, size, false, false);
     space->recv_size= it->second.size;

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -1106,12 +1106,6 @@ Opens an existing file or creates a new.
 @param[in]	name		name of the file or path as a null-terminated
 				string
 @param[in]	create_mode	create mode
-@param[in]	purpose		OS_FILE_AIO, if asynchronous, non-buffered I/O
-				is desired, OS_FILE_NORMAL, if any normal file;
-				NOTE that it also depends on type, os_aio_..
-				and srv_.. variables whether we really use async
-				I/O or unbuffered I/O: look in the function
-				source code for the exact rules
 @param[in]	type		OS_DATA_FILE or OS_LOG_FILE
 @param[in]	read_only	true, if read only checks should be enforcedm
 @param[in]	success		true if succeeded
@@ -1121,7 +1115,6 @@ pfs_os_file_t
 os_file_create_func(
 	const char*	name,
 	ulint		create_mode,
-	ulint		purpose,
 	ulint		type,
 	bool		read_only,
 	bool*		success)
@@ -1189,7 +1182,6 @@ os_file_create_func(
 	ut_a(type == OS_LOG_FILE || type == OS_DATA_FILE);
 #endif
 
-	ut_a(purpose == OS_FILE_AIO || purpose == OS_FILE_NORMAL);
 
 	/* We let O_DSYNC only affect log files */
 
@@ -2032,12 +2024,6 @@ Opens an existing file or creates a new.
 @param[in]	name		name of the file or path as a null-terminated
 				string
 @param[in]	create_mode	create mode
-@param[in]	purpose		OS_FILE_AIO, if asynchronous, non-buffered I/O
-				is desired, OS_FILE_NORMAL, if any normal file;
-				NOTE that it also depends on type, os_aio_..
-				and srv_.. variables whether we really use async
-				I/O or unbuffered I/O: look in the function
-				source code for the exact rules
 @param[in]	type		OS_DATA_FILE or OS_LOG_FILE
 @param[in]	success		true if succeeded
 @return handle to the file, not defined if error, error number
@@ -2046,7 +2032,6 @@ pfs_os_file_t
 os_file_create_func(
 	const char*	name,
 	ulint		create_mode,
-	ulint		purpose,
 	ulint		type,
 	bool		read_only,
 	bool*		success)
@@ -2115,31 +2100,7 @@ os_file_create_func(
 		return(OS_FILE_CLOSED);
 	}
 
-	DWORD		attributes = 0;
-
-	if (purpose == OS_FILE_AIO) {
-
-#ifdef WIN_ASYNC_IO
-		/* If specified, use asynchronous (overlapped) io and no
-		buffering of writes in the OS */
-
-		if (srv_use_native_aio) {
-			attributes |= FILE_FLAG_OVERLAPPED;
-		}
-#endif /* WIN_ASYNC_IO */
-
-	} else if (purpose == OS_FILE_NORMAL) {
-
-		/* Use default setting. */
-
-	} else {
-
-		ib::error()
-			<< "Unknown purpose flag (" << purpose << ") "
-			<< "while opening file '" << name << "'";
-
-		return(OS_FILE_CLOSED);
-	}
+	DWORD attributes= FILE_FLAG_OVERLAPPED;
 
 	if (type == OS_LOG_FILE) {
 		/* There is not reason to use buffered write to logs.*/

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -260,7 +260,7 @@ static dberr_t create_log_file(bool create_new_db, lsn_t lsn,
 	bool ret;
 	pfs_os_file_t file = os_file_create(
 		innodb_log_file_key, logfile0.c_str(),
-		OS_FILE_CREATE|OS_FILE_ON_ERROR_NO_EXIT, OS_FILE_NORMAL,
+		OS_FILE_CREATE|OS_FILE_ON_ERROR_NO_EXIT,
 		OS_LOG_FILE, srv_read_only_mode, &ret);
 
 	if (!ret) {
@@ -383,7 +383,7 @@ static dberr_t srv_undo_tablespace_create(const char* name)
 		innodb_data_file_key,
 		name,
 		srv_read_only_mode ? OS_FILE_OPEN : OS_FILE_CREATE,
-		OS_FILE_NORMAL, OS_DATA_FILE, srv_read_only_mode, &ret);
+		OS_DATA_FILE, srv_read_only_mode, &ret);
 
 	if (!ret) {
 		if (os_file_get_last_error(false) != OS_FILE_ALREADY_EXISTS
@@ -500,7 +500,7 @@ static ulint srv_undo_tablespace_open(bool create, const char* name, ulint i)
   pfs_os_file_t fh= os_file_create(innodb_data_file_key, name, OS_FILE_OPEN |
                                    OS_FILE_ON_ERROR_NO_EXIT |
                                    OS_FILE_ON_ERROR_SILENT,
-                                   OS_FILE_AIO, OS_DATA_FILE,
+                                   OS_DATA_FILE,
                                    srv_read_only_mode, &success);
 
   if (!success)
@@ -621,7 +621,6 @@ srv_check_undo_redo_logs_exists()
 			OS_FILE_OPEN_RETRY
 			| OS_FILE_ON_ERROR_NO_EXIT
 			| OS_FILE_ON_ERROR_SILENT,
-			OS_FILE_NORMAL,
 			OS_DATA_FILE,
 			srv_read_only_mode,
 			&ret);
@@ -644,7 +643,7 @@ srv_check_undo_redo_logs_exists()
 	fh = os_file_create(innodb_log_file_key, logfilename.c_str(),
 			    OS_FILE_OPEN_RETRY | OS_FILE_ON_ERROR_NO_EXIT
 				    | OS_FILE_ON_ERROR_SILENT,
-			    OS_FILE_NORMAL, OS_LOG_FILE, srv_read_only_mode,
+			    OS_LOG_FILE, srv_read_only_mode,
 			    &ret);
 
 	if (ret) {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35171*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Removed 'purpose' parameter from os_file_create() and related functions, and OS_AIO_NORMAL, OS_AIO_ASYNC
Always use FILE_FLAG_OVERLAPPED when opening Windows files in Innodb.

PS. Evaluated option of overlapping writes and flushes in Innodb group commit (log_write_up_to),  since [corresponding MySQL 
commit ](https://github.com/mysql/mysql-server/commit/c41ad32dda8145b4b0db0b937007a06f001a041a) suggested it could be faster with FILE_FLAG_OVERLAPPED on Windows. It was not, thus group commit logic remained the same.

## Release Notes
Should not be mentioned in release notes, since it is merely a cleanup.


## How can this PR be tested?

MTR already tests it well, no further test is required.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
