### PR TITLE
MDEV-35225 Bogus debug assertion failures in innodb.innodb-32k-crash

### DIFF
--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -4671,7 +4671,8 @@ completed:
 			rescan = true;
 		}
 
-		ut_ad(log_sys.get_lsn() >= recv_sys.scanned_lsn);
+		ut_ad(log_sys.get_lsn() >= recv_sys.scanned_lsn
+		      || log_sys.get_lsn() >= recv_sys.recovered_lsn);
 
 		recv_sys.parse_start_lsn = checkpoint_lsn;
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3653,7 +3653,7 @@ static void log_sort_flush_list()
             [](const buf_page_t *lhs, const buf_page_t *rhs) {
               const lsn_t l{lhs->oldest_modification()};
               const lsn_t r{rhs->oldest_modification()};
-              DBUG_ASSERT(l > 2); DBUG_ASSERT(r > 2);
+              DBUG_ASSERT(l == 1 || l > 2); DBUG_ASSERT(r == 1 || r > 2);
               return r < l;
             });
 
@@ -3661,8 +3661,12 @@ static void log_sort_flush_list()
 
   for (size_t i= 0; i < idx; i++)
   {
-    UT_LIST_ADD_LAST(buf_pool.flush_list, list[i]);
-    DBUG_ASSERT(list[i]->oldest_modification() > 2);
+    buf_page_t *b= list[i];
+    const lsn_t lsn{b->oldest_modification()};
+    if (lsn == 1)
+      continue;
+    DBUG_ASSERT(lsn > 2);
+    UT_LIST_ADD_LAST(buf_pool.flush_list, b);
   }
 
   mysql_mutex_unlock(&buf_pool.flush_list_mutex);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35225*
## Description
During the execution of the test `innodb.innodb-32k-crash` some debug assertions that had been added to `log_sort_flush_list()` in 0d175968d1181a0308ce6caccc2e4fbc972ca6c6 are occasionally failing when executing the test `innodb.innodb-32k-crash`.

Furthermore, an assertion that was added to `recv_recovery_from_checkpoint_start()` in #3488 is occasionally failing when the last mini-transaction had been incompletely written.
## Release Notes
This mostly fixes bogus debug assertions; nothing needs to be mentioned.
## How can this PR be tested?
On a system with 152 hardware threads, I executed the following:
```bash
./mtr --parallel=160 --repeat=1000 innodb.innodb-32k-crash{,,,,,,,,,}{,,,,,,,}{,}
```
This used to easily reproduce the failures within less than 10 repetitions. Now both failures are gone, but there may still be occasional failures, such as the following, which was observed after about 900×160 rounds:
```
2024-10-21 23:10:11 0 [Note] InnoDB: Starting crash recovery from checkpoint LSN=1059287101,1062232449
2024-10-21 23:10:11 0 [ERROR] InnoDB: Cannot apply log to [page id: space=704, page number=0] of corrupted file './test/t1.ibd'
2024-10-21 23:10:11 0 [ERROR] InnoDB: Plugin initialization aborted at srv0start.cc[1513] with error Data structure corruption
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.