### PR TITLE
MDEV-35235 innodb_snapshot_isolation=ON fails to signal transaction rollback

### DIFF
--- a/mysql-test/suite/innodb/r/lock_isolation.result
+++ b/mysql-test/suite/innodb/r/lock_isolation.result
@@ -134,8 +134,10 @@ BEGIN;
 INSERT INTO t SET a=2;
 connection consistent;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
+SAVEPOINT sp1;
 SELECT * FROM t FORCE INDEX (b) FOR UPDATE;
 ERROR HY000: Record has changed since last read in table 't'
+SAVEPOINT sp1;
 connection con_weird;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 SELECT * FROM t FORCE INDEX (b) FOR UPDATE;
@@ -155,3 +157,4 @@ a	b
 disconnect consistent;
 connection default;
 DROP TABLE t;
+# End of 10.6 tests

--- a/mysql-test/suite/innodb/t/lock_isolation.test
+++ b/mysql-test/suite/innodb/t/lock_isolation.test
@@ -152,10 +152,12 @@ BEGIN; INSERT INTO t SET a=2;
 
 --connection consistent
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
+SAVEPOINT sp1;
 --disable_ps2_protocol
 --error ER_CHECKREAD
 SELECT * FROM t FORCE INDEX (b) FOR UPDATE;
 --enable_ps2_protocol
+SAVEPOINT sp1;
 
 --connection con_weird
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
@@ -181,3 +183,5 @@ SELECT * FROM t FORCE INDEX (b) FOR UPDATE;
 
 --connection default
 DROP TABLE t;
+
+--echo # End of 10.6 tests

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2234,6 +2234,7 @@ convert_error_code_to_mysql(
 		return(HA_ERR_NO_ACTIVE_RECORD);
 
 	case DB_DEADLOCK:
+	case DB_RECORD_CHANGED:
 		/* Since we rolled back the whole transaction, we must
 		tell it also to MySQL so that MySQL knows to empty the
 		cached binlog for this transaction */
@@ -2242,10 +2243,8 @@ convert_error_code_to_mysql(
 			thd_mark_transaction_to_rollback(thd, 1);
 		}
 
-		return(HA_ERR_LOCK_DEADLOCK);
-
-	case DB_RECORD_CHANGED:
-		return HA_ERR_RECORD_CHANGED;
+		return error == DB_DEADLOCK
+			? HA_ERR_LOCK_DEADLOCK : HA_ERR_RECORD_CHANGED;
 
 	case DB_LOCK_WAIT_TIMEOUT:
 		/* Starting from 5.0.13, we let MySQL just roll back the


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35235*
## Description
`convert_error_code_to_mysql()`: Treat `DB_DEADLOCK` and `DB_RECORD_CHANGED` in the same way, that is, signal to the SQL layer that the transaction had been rolled back.
## Release Notes
When `innodb_snapshot_isolation=ON` caused an `ER_CHECKREAD` error to be flagged, the SQL layer would remain unaware that the InnoDB transaction had actually been rolled back.
## How can this PR be tested?
```sh
./mtr innodb.lock_isolation
```
Without the code change, the test would trigger an assertion failure.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.