### PR TITLE
MDEV-35130 - Assertion fails in trx_t::check_bulk_buffer upon CREATE.. SELECT with vector key

### DIFF
--- a/mysql-test/main/vector_innodb.result
+++ b/mysql-test/main/vector_innodb.result
@@ -179,3 +179,8 @@ create table t (v vector(1), key(v)) engine=innodb;
 select v from t where v = vec_fromtext('[1]');
 v
 drop table t;
+#
+# MDEV-35130 Assertion fails in trx_t::check_bulk_buffer upon CREATE.. SELECT with vector key
+#
+CREATE TABLE t (pk INT PRIMARY KEY, v VECTOR(5) NOT NULL, VECTOR(v)) ENGINE=InnoDB SELECT 1 AS pk, x'f09baa3ea172763f123def3e0c7fe53e288bf33e' AS v;
+DROP TABLE t;

--- a/mysql-test/main/vector_innodb.test
+++ b/mysql-test/main/vector_innodb.test
@@ -175,3 +175,9 @@ drop table t;
 create table t (v vector(1), key(v)) engine=innodb;
 select v from t where v = vec_fromtext('[1]');
 drop table t;
+
+--echo #
+--echo # MDEV-35130 Assertion fails in trx_t::check_bulk_buffer upon CREATE.. SELECT with vector key
+--echo #
+CREATE TABLE t (pk INT PRIMARY KEY, v VECTOR(5) NOT NULL, VECTOR(v)) ENGINE=InnoDB SELECT 1 AS pk, x'f09baa3ea172763f123def3e0c7fe53e288bf33e' AS v;
+DROP TABLE t;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35130*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Similarly to 4b814066dcd, don't enable bulk insert when issuing create ...
insert into a table containing vector index. InnoDB can't handle situation
when bulk insert is enabled for one table but disabled for another. We can't
do bulk insert on vector index as it does table updates currently.
## Release Notes
N/A
## How can this PR be tested?
mtr vector_innodb
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
