### PR TITLE
MDEV-34900: Fix stage names for profiling

### DIFF
--- a/mysql-test/include/check_shared_row_lock.inc
+++ b/mysql-test/include/check_shared_row_lock.inc
@@ -33,8 +33,8 @@ connection default;
 # least it acquires S-locks on some of rows.
 let $wait_condition=
   select count(*) = 1 from information_schema.processlist
-  where state in ("Sending data","statistics", "preparing", "updating",
-                  "executing", "Searching rows for update") and
+  where state in ("statistics", "preparing", "updating",
+                  "Executing", "Searching rows for update") and
         info = "$wait_statement";
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/innodb/t/create_select.test
+++ b/mysql-test/suite/innodb/t/create_select.test
@@ -14,7 +14,7 @@ send CREATE TABLE t1 ENGINE=InnoDB SELECT * FROM seq_1_to_100000000;
 connection con1;
 let $wait_condition=
   select count(*) = 1 from information_schema.processlist
-  where state = 'Sending data'
+  where state = 'Executing'
   and info = 'CREATE TABLE t1 ENGINE=InnoDB SELECT * FROM seq_1_to_100000000';
 --source include/wait_condition.inc
 KILL QUERY @id;

--- a/mysql-test/suite/innodb/t/deadlock_in_subqueries_join.test
+++ b/mysql-test/suite/innodb/t/deadlock_in_subqueries_join.test
@@ -56,7 +56,7 @@ if ($i == $update) {
 --connection default
 let $wait_condition=
   SELECT count(*) = 1 FROM information_schema.processlist
-  WHERE (state = 'Sending data' OR state = "Updating")
+  WHERE (state = 'Executing' OR state = "Updating")
   AND (info LIKE 'delete from t2 where%' OR
        info LIKE 'UPDATE t2 SET pkey=pkey+10 WHERE%');
 --source include/wait_condition.inc

--- a/mysql-test/suite/innodb/t/innodb-blob.test
+++ b/mysql-test/suite/innodb/t/innodb-blob.test
@@ -40,7 +40,7 @@ connect (con2,localhost,root,,);
 # Check that the above SELECT is blocked
 let $wait_condition=
   select count(*) = 1 from information_schema.processlist
-  where state in ('Sending data', 'Opening tables') and
+  where state in ('Executing', 'Opening tables') and
         info = 'SELECT a, RIGHT(b,20) FROM t1';
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/innodb/t/innodb-lock.test
+++ b/mysql-test/suite/innodb/t/innodb-lock.test
@@ -156,7 +156,7 @@ connection con2;
 # Check that the above SELECT is blocked
 let $wait_condition=
   select count(*) = 1 from information_schema.processlist
-  where state = 'Sending data' and
+  where state = 'Executing' and
         info = 'SELECT * FROM t1 FOR UPDATE';
 --source include/wait_condition.inc
 disconnect con2;

--- a/mysql-test/suite/innodb/t/lock_isolation.test
+++ b/mysql-test/suite/innodb/t/lock_isolation.test
@@ -172,7 +172,7 @@ SELECT * FROM t FORCE INDEX (b) FOR UPDATE;
 --connection default
 let $wait_condition=
   select count(*) = 1 from information_schema.processlist
-  where state = 'Sending data'
+  where state = 'Executing'
   and info LIKE 'SELECT * FROM t %';
 --source include/wait_condition.inc
 ROLLBACK;

--- a/mysql-test/suite/innodb/t/xa_recovery.test
+++ b/mysql-test/suite/innodb/t/xa_recovery.test
@@ -36,7 +36,7 @@ connect (con1,localhost,root);
 connection default;
 let $wait_condition=
   select count(*) = 1 from information_schema.processlist
-  where state = 'Sending data' and
+  where state = 'Executing' and
         info = 'SELECT * FROM t1 LOCK IN SHARE MODE';
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/perfschema/r/nesting.result
+++ b/mysql-test/suite/perfschema/r/nesting.result
@@ -125,7 +125,7 @@ relative_event_id	relative_end_event_id	event_name	comment	nesting_event_type	re
 8	8	stage/sql/After opening tables	(stage)	STATEMENT	0
 9	9	stage/sql/init	(stage)	STATEMENT	0
 10	10	stage/sql/Optimizing	(stage)	STATEMENT	0
-11	11	stage/sql/Executing	(stage)	STATEMENT	0
+11	11	stage/sql/Preparing for execution	(stage)	STATEMENT	0
 12	12	stage/sql/End of update loop	(stage)	STATEMENT	0
 13	14	stage/sql/Query end	(stage)	STATEMENT	0
 14	14	wait/synch/mutex/sql/THD::LOCK_thd_kill	lock	STAGE	13
@@ -149,7 +149,7 @@ relative_event_id	relative_end_event_id	event_name	comment	nesting_event_type	re
 32	32	stage/sql/After opening tables	(stage)	STATEMENT	24
 33	33	stage/sql/init	(stage)	STATEMENT	24
 34	34	stage/sql/Optimizing	(stage)	STATEMENT	24
-35	35	stage/sql/Executing	(stage)	STATEMENT	24
+35	35	stage/sql/Preparing for execution	(stage)	STATEMENT	24
 36	36	stage/sql/End of update loop	(stage)	STATEMENT	24
 37	38	stage/sql/Query end	(stage)	STATEMENT	24
 38	38	wait/synch/mutex/sql/THD::LOCK_thd_kill	lock	STAGE	37
@@ -173,7 +173,7 @@ relative_event_id	relative_end_event_id	event_name	comment	nesting_event_type	re
 56	56	stage/sql/After opening tables	(stage)	STATEMENT	48
 57	57	stage/sql/init	(stage)	STATEMENT	48
 58	58	stage/sql/Optimizing	(stage)	STATEMENT	48
-59	59	stage/sql/Executing	(stage)	STATEMENT	48
+59	59	stage/sql/Preparing for execution	(stage)	STATEMENT	48
 60	60	stage/sql/End of update loop	(stage)	STATEMENT	48
 61	62	stage/sql/Query end	(stage)	STATEMENT	48
 62	62	wait/synch/mutex/sql/THD::LOCK_thd_kill	lock	STAGE	61
@@ -200,7 +200,7 @@ select "With a third part to make things complete" as payload	NULL	NULL
 81	81	stage/sql/After opening tables	(stage)	STATEMENT	72
 82	82	stage/sql/init	(stage)	STATEMENT	72
 83	83	stage/sql/Optimizing	(stage)	STATEMENT	72
-84	84	stage/sql/Executing	(stage)	STATEMENT	72
+84	84	stage/sql/Preparing for execution	(stage)	STATEMENT	72
 85	85	stage/sql/End of update loop	(stage)	STATEMENT	72
 86	87	stage/sql/Query end	(stage)	STATEMENT	72
 87	87	wait/synch/mutex/sql/THD::LOCK_thd_kill	lock	STAGE	86
@@ -219,7 +219,7 @@ select "With a third part to make things complete" as payload	NULL	NULL
 99	99	stage/sql/After opening tables	(stage)	STATEMENT	93
 100	100	stage/sql/init	(stage)	STATEMENT	93
 101	101	stage/sql/Optimizing	(stage)	STATEMENT	93
-102	102	stage/sql/Executing	(stage)	STATEMENT	93
+102	102	stage/sql/Preparing for execution	(stage)	STATEMENT	93
 103	103	stage/sql/End of update loop	(stage)	STATEMENT	93
 104	105	stage/sql/Query end	(stage)	STATEMENT	93
 105	105	wait/synch/mutex/sql/THD::LOCK_thd_kill	lock	STAGE	104
@@ -236,7 +236,7 @@ select "With a third part to make things complete" as payload	NULL	NULL
 116	116	stage/sql/After opening tables	(stage)	STATEMENT	111
 117	117	stage/sql/init	(stage)	STATEMENT	111
 118	118	stage/sql/Optimizing	(stage)	STATEMENT	111
-119	119	stage/sql/Executing	(stage)	STATEMENT	111
+119	119	stage/sql/Preparing for execution	(stage)	STATEMENT	111
 120	120	stage/sql/End of update loop	(stage)	STATEMENT	111
 121	122	stage/sql/Query end	(stage)	STATEMENT	111
 122	122	wait/synch/mutex/sql/THD::LOCK_thd_kill	lock	STAGE	121
@@ -260,7 +260,7 @@ select "With a third part to make things complete" as payload	NULL	NULL
 140	140	stage/sql/After opening tables	(stage)	STATEMENT	132
 141	141	stage/sql/init	(stage)	STATEMENT	132
 142	142	stage/sql/Optimizing	(stage)	STATEMENT	132
-143	143	stage/sql/Executing	(stage)	STATEMENT	132
+143	143	stage/sql/Preparing for execution	(stage)	STATEMENT	132
 144	144	stage/sql/End of update loop	(stage)	STATEMENT	132
 145	146	stage/sql/Query end	(stage)	STATEMENT	132
 146	146	wait/synch/mutex/sql/THD::LOCK_thd_kill	lock	STAGE	145

--- a/mysql-test/suite/perfschema/r/stage_mdl_table.result
+++ b/mysql-test/suite/perfschema/r/stage_mdl_table.result
@@ -16,7 +16,7 @@ username	event_name	sql_text
 user1	statement/sql/select	select * from test.t1 for update
 username	event_name	nesting_event_type
 username	event_name	nesting_event_type
-user1	stage/sql/Sending data	STATEMENT
+user1	stage/sql/Executing	STATEMENT
 user1	stage/sql/End of update loop	STATEMENT
 user1	stage/sql/Query end	STATEMENT
 user1	stage/sql/closing tables	STATEMENT

--- a/mysql-test/suite/perfschema/r/threads_history.result
+++ b/mysql-test/suite/perfschema/r/threads_history.result
@@ -231,7 +231,7 @@ stage/sql/Opening tables
 stage/sql/After opening tables
 stage/sql/init
 stage/sql/Optimizing
-stage/sql/Executing
+stage/sql/Preparing for execution
 stage/sql/End of update loop
 stage/sql/Query end
 stage/sql/closing tables
@@ -831,7 +831,7 @@ stage/sql/Opening tables
 stage/sql/After opening tables
 stage/sql/init
 stage/sql/Optimizing
-stage/sql/Executing
+stage/sql/Preparing for execution
 stage/sql/End of update loop
 stage/sql/Query end
 stage/sql/closing tables

--- a/mysql-test/suite/rpl/t/rpl_parallel_autoinc.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_autoinc.test
@@ -100,7 +100,7 @@ DELETE FROM t2 WHERE a=30;
 # but it is not yet waiting for a row lock held by T2.
 --connection slave2
 ROLLBACK;
---let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state='Sending data' and info LIKE 'INSERT INTO t1(b, c) SELECT 3, t2.b%' and time_ms > 500 and command LIKE 'Slave_worker';
+--let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state='Executing' and info LIKE 'INSERT INTO t1(b, c) SELECT 3, t2.b%' and time_ms > 500 and command LIKE 'Slave_worker';
 --source include/wait_condition.inc
 
 # Now let T1 continue, while T3 is holding the autoinc lock but before

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9528,6 +9528,7 @@ PSI_stage_info stage_master_has_sent_all_binlog_to_slave= { 0, "Master has sent 
 PSI_stage_info stage_opening_tables= { 0, "Opening tables", 0};
 PSI_stage_info stage_optimizing= { 0, "Optimizing", 0};
 PSI_stage_info stage_preparing= { 0, "Preparing", 0};
+PSI_stage_info stage_prepare_for_executing = { 0, "Preparing for execution", 0};
 PSI_stage_info stage_purging_old_relay_logs= { 0, "Purging old relay logs", 0};
 PSI_stage_info stage_query_end= { 0, "Query end", 0};
 PSI_stage_info stage_starting_cleanup= { 0, "Starting cleanup", 0};
@@ -9771,6 +9772,7 @@ PSI_stage_info *all_server_stages[]=
   & stage_opening_tables,
   & stage_optimizing,
   & stage_preparing,
+  & stage_prepare_for_executing,
   & stage_purging_old_relay_logs,
   & stage_starting_cleanup,
   & stage_query_end,

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -559,6 +559,7 @@ extern PSI_stage_info stage_master_has_sent_all_binlog_to_slave;
 extern PSI_stage_info stage_opening_tables;
 extern PSI_stage_info stage_optimizing;
 extern PSI_stage_info stage_preparing;
+extern PSI_stage_info stage_prepare_for_executing;
 extern PSI_stage_info stage_purging_old_relay_logs;
 extern PSI_stage_info stage_query_end;
 extern PSI_stage_info stage_starting_cleanup;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -4858,7 +4858,7 @@ int JOIN::exec_inner()
   DBUG_ENTER("JOIN::exec_inner");
   DBUG_ASSERT(optimization_state == JOIN::OPTIMIZATION_DONE);
 
-  THD_STAGE_INFO(thd, stage_executing);
+  THD_STAGE_INFO(thd, stage_prepare_for_executing);
 
   /*
     Enable LIMIT ROWS EXAMINED during query execution if:
@@ -5050,7 +5050,7 @@ int JOIN::exec_inner()
     DBUG_RETURN(error);
   }
 
-  THD_STAGE_INFO(thd, stage_sending_data);
+  THD_STAGE_INFO(thd, stage_executing);
   DBUG_PRINT("info", ("%s", thd->proc_info));
   result->send_result_set_metadata(
                  procedure ? procedure_fields_list : *fields,

--- a/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case3.inc
+++ b/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case3.inc
@@ -54,7 +54,7 @@ send SELECT * FROM t0 WHERE value > 0 FOR UPDATE;
 connection con2;
 let $wait_condition =
     SELECT 1 FROM information_schema.processlist
-    WHERE (id = $ID/* OR srv_id = $ID*/) AND state = "Sending data";
+    WHERE (id = $ID/* OR srv_id = $ID*/) AND state = "Executing";
 --source include/wait_condition.inc
 eval SET SESSION TRANSACTION ISOLATION LEVEL $isolation_level;
 UPDATE t0 SET VALUE=VALUE+1 WHERE id=190000;

--- a/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case4.inc
+++ b/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case4.inc
@@ -54,7 +54,7 @@ send SELECT * FROM t0 WHERE value > 0 FOR UPDATE;
 connection con2;
 let $wait_condition =
     SELECT 1 FROM information_schema.processlist
-    WHERE (id = $ID/* OR srv_id = $ID*/) AND state = "Sending data";
+    WHERE (id = $ID/* OR srv_id = $ID*/) AND state = "Executing";
 --source include/wait_condition.inc
 eval SET SESSION TRANSACTION ISOLATION LEVEL $isolation_level;
 INSERT INTO t0 VALUES(200001,1), (-1,1);

--- a/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case5.inc
+++ b/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case5.inc
@@ -57,7 +57,7 @@ send SELECT * FROM t0 WHERE value > 0 FOR UPDATE;
 connection con2;
 let $wait_condition =
     SELECT 1 FROM information_schema.processlist
-    WHERE (id = $ID /* OR srv_id = $ID*/) AND state = "Sending data";
+    WHERE (id = $ID /* OR srv_id = $ID*/) AND state = "Executing";
 --source include/wait_condition.inc
 eval SET SESSION TRANSACTION ISOLATION LEVEL $isolation_level;
 BEGIN;

--- a/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case6.inc
+++ b/storage/rocksdb/mysql-test/rocksdb/include/locking_issues_case6.inc
@@ -57,7 +57,7 @@ send SELECT * FROM t0 WHERE value > 0 FOR UPDATE;
 connection con2;
 let $wait_condition =
    SELECT 1 FROM information_schema.processlist
-   WHERE (id = $ID/* OR srv_id = $ID*/) AND state = "Sending data";
+   WHERE (id = $ID/* OR srv_id = $ID*/) AND state = "Executing";
 --source include/wait_condition.inc
 eval SET SESSION TRANSACTION ISOLATION LEVEL $isolation_level;
 BEGIN;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34900*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This PR addresses MDEV-34900 by renaming `stage_executing` to "Prepare for executing" and `stage_sending_data` to "executing" in `JOIN::exec_inner() ` to better reflect the actual process during profiling.

## Release Notes
Renaming few of the profiler stages.


<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.


