### PR TITLE
MDEV-35257 Backup fails during an ALTER TABLE with FULLTEXT INDEX

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -1185,27 +1185,25 @@ static void backup_file_op_fail(uint32_t space_id, int type,
 	const byte* new_name, ulint new_len)
 {
 	bool fail = false;
-	switch(type) {
+	const static std::string spacename{filename_to_spacename(name, len)};
+	switch (type) {
 	case FILE_CREATE:
 		msg("DDL tracking : create %u \"%.*s\"", space_id, int(len), name);
-		fail = !check_if_skip_table(
-				filename_to_spacename(name, len).c_str());
+		fail = !check_if_skip_table(spacename.c_str());
 		break;
 	case FILE_MODIFY:
 		break;
 	case FILE_RENAME:
 		msg("DDL tracking : rename %u \"%.*s\",\"%.*s\"",
 			space_id, int(len), name, int(new_len), new_name);
-		fail = !check_if_skip_table(
-				filename_to_spacename(name, len).c_str())
+		fail = !check_if_skip_table(spacename.c_str())
 		       || !check_if_skip_table(
 				filename_to_spacename(new_name, new_len).c_str());
 		break;
 	case FILE_DELETE:
-		fail = !check_if_skip_table(
-                                filename_to_spacename(name, len).c_str())
-                       && !check_if_fts_table(reinterpret_cast<const char*>(name));
-                msg("DDL tracking : delete %u \"%.*s\"", space_id, int(len), name);
+		fail = !check_if_skip_table(spacename.c_str())
+			&& !check_if_fts_table(spacename.c_str());
+		msg("DDL tracking : delete %u \"%.*s\"", space_id, int(len), name);
 		break;
 	default:
 		ut_ad(0);
@@ -3892,16 +3890,18 @@ static void xb_load_single_table_tablespace(const char *dirname,
 
 	if (is_remote) {
 		RemoteDatafile* rf = new RemoteDatafile();
-		if (!rf->open_link_file(n)) {
-			die("Can't open datafile %s", name);
-		}
 		file = rf;
+		if (!rf->open_link_file(n)) {
+			goto cant_open;
+		}
 	} else {
 		file = new Datafile();
 		file->make_filepath(".", n, IBD);
 	}
 
 	if (file->open_read_only(true) != DB_SUCCESS) {
+	cant_open:
+		delete file;
 		// Ignore FTS tables, as they can be removed for intermediate tables,
 		// this code must be executed under stronger or equal to BLOCK_DDL lock,
 		// so there must not be errors for non-intermediate FTS tables.

--- a/mysql-test/suite/mariabackup/disabled.def
+++ b/mysql-test/suite/mariabackup/disabled.def
@@ -1,3 +1,2 @@
 log_page_corruption : MDEV-26210
 mariabackup.xb_compressed_encrypted : MDEV-26154 (error 194 "Tablespace is missing for a table")
-innodb_ddl_on_intermediate_table : MENT-1213

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -11956,6 +11956,7 @@ copy_data_between_tables(THD *thd, TABLE *from, TABLE *to, bool ignore,
   }
 
   backup_set_alter_copy_lock(thd, from);
+  DEBUG_SYNC(thd, "copy_data_between_tables_after_set_backup_lock");
 
   alter_table_manage_keys(to, from->file->indexes_are_disabled(),
                           alter_info->keys_onoff);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35257*
-->
## Description
In commit 1c55b845e0fe337e647ba230288ed13e966cb7c7 (MDEV-32932) the test `mariabackup.innodb_ddl_on_intermediate_table` was introduced but disabled.

`xb_load_single_table_tablespace()`: Properly handle missing `FTS_` tables.
## Release Notes
`mariadb-backup --backup` could fail if an `ALTER TABLE` or `OPTIMIZE TABLE` statement is concurrently being executed on an InnoDB table that contains `FULLTEXT INDEX`.
## How can this PR be tested?
```sh
./mtr mariabackup.innodb_ddl_on_intermediate_table
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.