### PR TITLE
MDEV-35265 wsrep.wsrep-recover, wsrep.wsrep-recover-v25 fail on assertion

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2684,7 +2684,8 @@ static void xarecover_do_commit_or_rollback(handlerton *hton,
 
   if (xarecover_decide_to_commit(member, ptr_commit_max))
     rc= hton->commit_by_xid(hton, &x);
-  else if (hton->recover_rollback_by_xid)
+  else if (hton->recover_rollback_by_xid &&
+           IF_WSREP(!(WSREP_ON || wsrep_recovery), true))
     rc= hton->recover_rollback_by_xid(&x);
   else
     rc= hton->rollback_by_xid(hton, &x);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17211,7 +17211,8 @@ int innobase_recover_rollback_by_xid(const XID *xid)
   ut_ad(trx->state == TRX_STATE_PREPARED);
 
 #ifdef WITH_WSREP
-  ut_ad(!wsrep_is_wsrep_xid(&trx->xid));
+  // prepared transactions must not be rolled back asynchronously when wsrep is on
+  ut_ad(!(WSREP_ON || wsrep_recovery));
 #endif
 
   if (trx->rsegs.m_redo.undo)


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35265

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The tests fail on assertion

    ut_ad(!wsrep_is_wsrep_xid(&trx->xid));

in `innobase_recover_rollback_by_xid()`.

The fix is to avoid async rollback for prepared transactions when wsrep is ON or wsrep recovery is in progress. The rationale is that the rollback of prepared transactions must complete before the node starts applying write sets after SST, or in case of wsrep recovery, the recovery must complete before the process exists.

Change the assertion into stronger one

    ut_ad(!(WSREP_ON || wsrep_recovery));

to catch if the async rollback codepath is taken when wsrep is enabled.



## How can this PR be tested?

Prior to this change, MTR tests wsrep.wsrep-recover, wsrep.wsrep-recover-v25 failed on assertion. These tests pass now.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
