### PR TITLE
MDEV-35301: Bump minimum cmake version to 3.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1335 USA
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.12.0)
 
 IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   # Setting build type to RelWithDebInfo as none was specified.


### PR DESCRIPTION
Libmariadb introduced a cmake change that required 3.12 or newer.

Since none of the platforms we currently support have anything lower than 3.12 available, we should make this a proper requirement for the Server as well.
