### PR TITLE
MDEV-32779 : galera_concurrent_ctas: assertion in the galera::Replica…

### DIFF
--- a/mysql-test/suite/galera/r/galera_concurrent_ctas.result
+++ b/mysql-test/suite/galera/r/galera_concurrent_ctas.result
@@ -3,6 +3,7 @@ connection node_1;
 connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_1;
 SET DEBUG_SYNC = 'wsrep_create_table_as_select WAIT_FOR continue';
 CREATE table t1 as SELECT SLEEP(0.1);;
@@ -17,14 +18,30 @@ connection node_1b;
 SET SESSION debug_sync = 'now WAIT_FOR sync.wsrep_apply_cb_reached';
 # Signal first CTAS to continue and wait until CTAS has executed
 SET DEBUG_SYNC= 'now SIGNAL continue';
+connection node_2b;
+# Wait first CTAS to replicate
+SELECT * FROM t1;
+SLEEP(0.2)
+0
+connection node_1b;
 SET GLOBAL debug_dbug= '';
 SET DEBUG_SYNC = 'now SIGNAL signal.wsrep_apply_cb';
 connection node_2a;
 connection node_1b;
 SET DEBUG_SYNC= 'RESET';
 connection node_2;
+SELECT * FROM t1;
+SLEEP(0.2)
+0
 connection node_1;
+SELECT * FROM t1;
+SLEEP(0.2)
+0
 DROP TABLE t1;
+disconnect node_1a;
+disconnect node_1b;
+disconnect node_2a;
+disconnect node_2b;
 disconnect node_2;
 disconnect node_1;
 # End of test

--- a/mysql-test/suite/galera/t/galera_concurrent_ctas.combinations
+++ b/mysql-test/suite/galera/t/galera_concurrent_ctas.combinations
@@ -1,0 +1,4 @@
+[binlogoff]
+
+[binlogon]
+log-bin

--- a/mysql-test/suite/galera/t/galera_concurrent_ctas.test
+++ b/mysql-test/suite/galera/t/galera_concurrent_ctas.test
@@ -9,6 +9,7 @@
 --connect node_1a, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1
 --connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connect node_2b, 127.0.0.1, root, , test, $NODE_MYPORT_2
 
 --connection node_1
 #
@@ -48,6 +49,14 @@ SET SESSION debug_sync = 'now WAIT_FOR sync.wsrep_apply_cb_reached';
 SET DEBUG_SYNC= 'now SIGNAL continue';
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Creating table	CREATE table t1 as SELECT SLEEP(0.1)'
 --source include/wait_condition.inc
+
+--connection node_2b
+--echo # Wait first CTAS to replicate
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1'
+--source include/wait_condition.inc
+SELECT * FROM t1;
+
+--connection node_1b
 #
 # Release second CTAS and cleanup
 #
@@ -74,12 +83,18 @@ SET DEBUG_SYNC= 'RESET';
 #
 --connection node_2
 --reap
+SELECT * FROM t1;
 
 --connection node_1
---error 0,ER_TABLE_EXISTS_ERROR,ER_QUERY_INTERRUPTED
+--error 0,ER_QUERY_INTERRUPTED,ER_LOCK_DEADLOCK
 --reap
+SELECT * FROM t1;
 DROP TABLE t1;
 
+--disconnect node_1a
+--disconnect node_1b
+--disconnect node_2a
+--disconnect node_2b
 
 --source include/galera_end.inc
 --echo # End of test


### PR DESCRIPTION
…torSMM::finish_cert()



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32779*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
I could not reproduce reported assertion. However, I could reporoduce test failure because missing wait_condition and error in test case. Added missing wait_condition and fixed error in test case to make test stable.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
