### PR TITLE
MDEV-36009 - Systemd: Restart on OOM

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -105,7 +105,7 @@ SendSIGKILL=no
 
 # Restart crashed server only, on-failure would also restart, for example, when
 # my.cnf contains unknown option
-Restart=on-abort
+Restart=on-abnormal
 RestartSec=5s
 
 UMask=007

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -219,7 +219,7 @@ SendSIGKILL=no
 
 # Restart crashed server only, on-failure would also restart, for example, when
 # my.cnf contains unknown option
-Restart=on-abort
+Restart=on-abnormal
 RestartSec=5s
 
 UMask=007


### PR DESCRIPTION
## Description
After an OOM kill, the process should be restarted by systemd. Prior to this change, that did not happen.

The comment in the file says it doesn't use on-failure in case of config errors, which I assume is caused by an unclean exit code. on-abnormal is the same as on-failure except for unclean exit code.

## Release Notes
Changed systemd Restart mode to ensure that the server is restarted in abnormal situations such as OOM.