### PR TITLE
MDEV-32667   dict_stats_save_index_stat() reads uninitialized index->stats_error_printed

### DIFF
--- a/mysql-test/suite/innodb/r/stat_tables.result
+++ b/mysql-test/suite/innodb/r/stat_tables.result
@@ -13,3 +13,19 @@ a
 drop table t1;
 rename table mysql.table_stats_save to mysql.table_stats;
 flush tables;
+#
+# MDEV-32667 dict_stats_save_index_stat() reads uninitialized
+#              index->stats_error_printed
+#
+call mtr.add_suppression("InnoDB: Cannot save index statistics for table");
+CREATE TABLE t1(a INT) ENGINE=InnoDB STATS_PERSISTENT=1 STATS_AUTO_RECALC=1;
+BEGIN;
+SELECT COUNT(*)>=0 FROM mysql.innodb_index_stats LOCK IN SHARE MODE;
+COUNT(*)>=0
+1
+INSERT INTO t1 VALUES(0),(0);
+SELECT sleep(1);
+sleep(1)
+0
+COMMIT;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/stat_tables.test
+++ b/mysql-test/suite/innodb/t/stat_tables.test
@@ -15,3 +15,16 @@ select * from t1;
 drop table t1;
 rename table mysql.table_stats_save to mysql.table_stats;
 flush tables;
+
+--echo #
+--echo # MDEV-32667 dict_stats_save_index_stat() reads uninitialized
+--echo #              index->stats_error_printed
+--echo #
+call mtr.add_suppression("InnoDB: Cannot save index statistics for table");
+CREATE TABLE t1(a INT) ENGINE=InnoDB STATS_PERSISTENT=1 STATS_AUTO_RECALC=1;
+BEGIN;
+SELECT COUNT(*)>=0 FROM mysql.innodb_index_stats LOCK IN SHARE MODE;
+INSERT INTO t1 VALUES(0),(0);
+SELECT sleep(1);
+COMMIT;
+DROP TABLE t1;

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -423,6 +423,8 @@ dict_stats_table_clone_create(
 	UT_LIST_INIT(t->freed_indexes, &dict_index_t::indexes);
 #endif /* BTR_CUR_HASH_ADAPT */
 
+	t->stats_error_printed = table->stats_error_printed;
+
 	for (index = dict_table_get_first_index(table);
 	     index != NULL;
 	     index = dict_table_get_next_index(index)) {
@@ -479,6 +481,7 @@ dict_stats_table_clone_create(
 
 		idx->stat_defrag_n_page_split = 0;
 		idx->stat_defrag_n_pages_freed = 0;
+		idx->stats_error_printed = index->stats_error_printed;
 	}
 
 	ut_d(t->magic_n = DICT_TABLE_MAGIC_N);


### PR DESCRIPTION
## Description
Problem:
========
- dict_stats_table_clone_create() does not initialize the flag stats_error_printed in either dict_table_t or dict_index_t. Because dict_stats_save_index_stat() is operating on a copy of a dict_index_t object, it appears that
dict_index_t::stats_error_printed will always be false for actual metadata objects, and uninitialized in
dict_stats_save_index_stat().

Solution:
=========
dict_stats_table_clone_create(): Assign stats_error_printed for table and index while copying the statistics


## How can this PR be tested?
./mtr innodb.table_stats

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
