### PR TITLE
SR transaction crashes with innodb_snapshot_isolation.

### DIFF
--- a/mysql-test/suite/galera_sr/r/GCF-572.result
+++ b/mysql-test/suite/galera_sr/r/GCF-572.result
@@ -37,8 +37,6 @@ f1	f2
 SET SESSION wsrep_trx_fragment_size = 10000;
 START TRANSACTION;
 INSERT INTO t1 VALUE (10, 'node1');
-SELECT * FROM mysql.wsrep_streaming_log;
-node_uuid	trx_id	seqno	flags	frag
 connection node_1a;
 INSERT INTO t1 VALUES(15, 'node2');
 connection node_1;
@@ -47,6 +45,7 @@ f1	f2
 1	node1
 5	node2
 10	node1
+15	node2
 INSERT INTO t1 VALUES(15, 'node1');
 ERROR 23000: Duplicate entry '15' for key 'PRIMARY'
 COMMIT;

--- a/mysql-test/suite/galera_sr/r/MDEV-35281.result
+++ b/mysql-test/suite/galera_sr/r/MDEV-35281.result
@@ -1,0 +1,9 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+SET SESSION wsrep_trx_fragment_size=1;
+SET SESSION innodb_snapshot_isolation=ON;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+INSERT INTO t1 VALUES (1);
+COMMIT;
+DROP TABLE t1;

--- a/mysql-test/suite/galera_sr/t/GCF-572.test
+++ b/mysql-test/suite/galera_sr/t/GCF-572.test
@@ -61,7 +61,6 @@ SET SESSION wsrep_trx_fragment_size = 10000;
 
 START TRANSACTION;
 INSERT INTO t1 VALUE (10, 'node1');
-SELECT * FROM mysql.wsrep_streaming_log;
 
 --connection node_1a
 INSERT INTO t1 VALUES(15, 'node2');

--- a/mysql-test/suite/galera_sr/t/MDEV-35281.test
+++ b/mysql-test/suite/galera_sr/t/MDEV-35281.test
@@ -1,0 +1,37 @@
+#
+# MDEV-35281 - SR transaction crashes with innodb_snapshot_isolation
+#
+# Test outline: a simple SR transaction fails to remove
+# its fragments from streaming_log table, with error
+# HA_ERR_RECORD_CHANGED.
+# This happens with the following sequence of events:
+# 1. Start a streaming replication transaction
+# 2. The transaction creates a read view in InnoDB
+#    (this must happen before a fragment is replicated)
+# 3. The transaction replicates a fragment.
+#    Internally, a new transaction is created to INSERT
+#    a row representing the fragment into the streaming_log
+#    table and is committed immediately.
+# 4. The streaming replication transaction COMMITs.
+#    Before committing, the transaction replicates
+#    a commit fragment and DELETEs its fragments that
+#    were created in the streaming_log table.
+#    If bug is present, fragment removal from the
+#    streaming_log table violates snapshot isolation,
+#    thus the operation fails with HA_ERR_RECORD_CHANGED.
+#    (One or more records from the streaming_log table
+#    are removed, while these were not visible to
+#    the transaction).
+
+--source include/galera_cluster.inc
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+
+SET SESSION wsrep_trx_fragment_size=1;
+SET SESSION innodb_snapshot_isolation=ON;
+
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+INSERT INTO t1 VALUES (1);
+COMMIT;
+
+DROP TABLE t1;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5561,9 +5561,11 @@ public:
   query_id_t                wsrep_last_query_id;
   XID                       wsrep_xid;
 
-  /** This flag denotes that record locking should be skipped during INSERT
-  and gap locking during SELECT. Only used by the streaming replication thread
-  that only modifies the wsrep_schema.SR table. */
+  /** This flag denotes that record locking should be skipped during INSERT,
+     gap locking during SELECT, and write-write conflicts due to innodb
+     snapshot isolation during DELETE.
+     Only used by the streaming replication thread that only modifies the
+     mysql.wsrep_streaming_log table. */
   my_bool                   wsrep_skip_locking;
 
   mysql_cond_t              COND_wsrep_thd;

--- a/sql/wsrep_schema.cc
+++ b/sql/wsrep_schema.cc
@@ -183,6 +183,25 @@ private:
   my_bool m_wsrep_ignore_table;
 };
 
+class wsrep_skip_locking
+{
+public:
+  wsrep_skip_locking(THD *thd)
+      : m_thd(thd)
+      , m_wsrep_skip_locking(thd->wsrep_skip_locking)
+  {
+    thd->wsrep_skip_locking= true;
+  }
+  ~wsrep_skip_locking()
+  {
+    m_thd->wsrep_skip_locking= m_wsrep_skip_locking;
+  }
+
+private:
+  THD *m_thd;
+  my_bool m_wsrep_skip_locking;
+};
+
 class thd_server_status
 {
 public:
@@ -1235,6 +1254,7 @@ int Wsrep_schema::remove_fragments(THD* thd,
   Wsrep_schema_impl::wsrep_ignore_table wsrep_ignore_table(thd);
   Wsrep_schema_impl::binlog_off binlog_off(thd);
   Wsrep_schema_impl::sql_safe_updates sql_safe_updates(thd);
+  Wsrep_schema_impl::wsrep_skip_locking skip_locking(thd);
 
   Query_tables_list query_tables_list_backup;
   Open_tables_backup open_tables_backup;

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -6375,7 +6375,9 @@ lock_clust_rec_read_check_and_lock(
             && trx->snapshot_isolation
 	    && trx->read_view.is_open()
 	    && !trx->read_view.changes_visible(
-		trx_read_trx_id(rec + row_trx_id_offset(rec, index)))) {
+		trx_read_trx_id(rec + row_trx_id_offset(rec, index)))
+	    && IF_WSREP(!(trx->is_wsrep()
+			&& wsrep_thd_skip_locking(trx->mysql_thd)), true)) {
 		return DB_RECORD_CHANGED;
 	}
 


### PR DESCRIPTION

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35281*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Make galera streaming replication feature compatible with the new innodb-snapshot-isolation option. Fragment removal during commit of streaming replication transaction would fail due to snapshot isolation write-write conflicts.

## Release Notes
Using Galera's streaming replication feature, in combination with innodb-snapshot-isolation, could result in server crashes or transactions that would be rolled back unnecessarily.

## How can this PR be tested?

The pull request includes a MTR test case.


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
