### PR TITLE
MDEV-35355 : Galera test failure on galera_sr.mysql-wsrep-features#165

### DIFF
--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -187,39 +187,29 @@ extern "C" my_bool wsrep_thd_is_SR(const THD *thd)
     thd->wsrep_cs().transaction().state() == wsrep::transaction::s_executing;
 }
 
-extern "C" void wsrep_handle_SR_rollback(THD *bf_thd,
+extern "C" void wsrep_handle_SR_rollback(THD *bf_thd __attribute__((unused)),
                                          THD *victim_thd)
 {
+  /*
+    We should always be in victim_thd context, either client session is
+    rolling back or rollbacker thread should be in control.
+  */
   DBUG_ASSERT(victim_thd);
+  DBUG_ASSERT(current_thd == victim_thd);
   DBUG_ASSERT(wsrep_thd_is_SR(victim_thd));
-  if (!victim_thd || !wsrep_on(bf_thd)) return;
 
-  WSREP_DEBUG("handle rollback, for deadlock: thd %llu trx_id %" PRIu64 " frags %zu conf %s",
+  /* Defensive measure to avoid crash in production. */
+  if (!victim_thd) return;
+
+  WSREP_DEBUG("Handle SR rollback, for deadlock: thd %llu trx_id %" PRIu64 " frags %zu conf %s",
               victim_thd->thread_id,
               victim_thd->wsrep_trx_id(),
               victim_thd->wsrep_sr().fragments_certified(),
               wsrep_thd_transaction_state_str(victim_thd));
 
-  /* Note: do not store/reset globals before wsrep_bf_abort() call
-     to avoid losing BF thd context. */
-  if (!(bf_thd && bf_thd != victim_thd))
-  {
-    DEBUG_SYNC(victim_thd, "wsrep_before_SR_rollback");
-  }
-  mysql_mutex_lock(&victim_thd->LOCK_thd_data);
-  if (bf_thd)
-  {
-    wsrep_bf_abort(bf_thd, victim_thd);
-  }
-  else
-  {
-    wsrep_thd_self_abort(victim_thd);
-  }
-  mysql_mutex_unlock(&victim_thd->LOCK_thd_data);
-  if (bf_thd)
-  {
-    wsrep_store_threadvars(bf_thd);
-  }
+  DEBUG_SYNC(victim_thd, "wsrep_before_SR_rollback");
+
+  wsrep_thd_self_abort(victim_thd);
 }
 
 extern "C" my_bool wsrep_thd_bf_abort(THD *bf_thd, THD *victim_thd,


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35355*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Problem was that in Deadlock::report() we hold lock_sys before we call wsrep_handle_SR_rollback() where THD::LOCK_thd_data (and some cases THD::LOCK_thd_kill) are acquired. This is against current mutex ordering rules.

However, acquiring THD::LOCK_thd_data is not necessary because we always are in victim_thd context, either client session is rolling back or rollbacker thread should be in control. Therefore, we should always use wsrep_thd_self_abort() and then no additional mutexes are required.

Fixed by removing locking of THD::LOCK_thd_data and using only wsrep_thd_self_abort(). In debug builds added assertions to verify that we are always in victim_thd context.

This fix is for MariaDB 10.6+ and we already have a test case that sporadically fail in Jenkins
before this fix.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
