### PR TITLE
MDEV-35046 SIGSEGV in list_delete in optimized builds when using pseu…

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -733,6 +733,7 @@ void mysql_query_cache_invalidate4(MYSQL_THD thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
 
+void *thd_pseudo_slave_and_get_prepared_xid(MYSQL_THD thd);
 
 /**
   Provide a handler data getter to simplify coding

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -672,6 +672,7 @@ void thd_get_xid(const THD* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(THD* thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
+void *thd_pseudo_slave_and_get_prepared_xid(THD* thd);
 void *thd_get_ha_data(const THD* thd, const struct handlerton *hton);
 void thd_set_ha_data(THD* thd, const struct handlerton *hton,
                      const void *ha_data);

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -672,6 +672,7 @@ void thd_get_xid(const THD* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(THD* thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
+void *thd_pseudo_slave_and_get_prepared_xid(THD* thd);
 void *thd_get_ha_data(const THD* thd, const struct handlerton *hton);
 void thd_set_ha_data(THD* thd, const struct handlerton *hton,
                      const void *ha_data);

--- a/include/mysql/plugin_data_type.h.pp
+++ b/include/mysql/plugin_data_type.h.pp
@@ -672,6 +672,7 @@ void thd_get_xid(const THD* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(THD* thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
+void *thd_pseudo_slave_and_get_prepared_xid(THD* thd);
 void *thd_get_ha_data(const THD* thd, const struct handlerton *hton);
 void thd_set_ha_data(THD* thd, const struct handlerton *hton,
                      const void *ha_data);

--- a/include/mysql/plugin_encryption.h.pp
+++ b/include/mysql/plugin_encryption.h.pp
@@ -672,6 +672,7 @@ void thd_get_xid(const THD* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(THD* thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
+void *thd_pseudo_slave_and_get_prepared_xid(THD* thd);
 void *thd_get_ha_data(const THD* thd, const struct handlerton *hton);
 void thd_set_ha_data(THD* thd, const struct handlerton *hton,
                      const void *ha_data);

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -624,6 +624,7 @@ void thd_get_xid(const THD* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(THD* thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
+void *thd_pseudo_slave_and_get_prepared_xid(THD* thd);
 void *thd_get_ha_data(const THD* thd, const struct handlerton *hton);
 void thd_set_ha_data(THD* thd, const struct handlerton *hton,
                      const void *ha_data);

--- a/include/mysql/plugin_function.h.pp
+++ b/include/mysql/plugin_function.h.pp
@@ -672,6 +672,7 @@ void thd_get_xid(const THD* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(THD* thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
+void *thd_pseudo_slave_and_get_prepared_xid(THD* thd);
 void *thd_get_ha_data(const THD* thd, const struct handlerton *hton);
 void thd_set_ha_data(THD* thd, const struct handlerton *hton,
                      const void *ha_data);

--- a/include/mysql/plugin_password_validation.h.pp
+++ b/include/mysql/plugin_password_validation.h.pp
@@ -672,6 +672,7 @@ void thd_get_xid(const THD* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(THD* thd,
                                    const char *key, unsigned int key_length,
                                    int using_trx);
+void *thd_pseudo_slave_and_get_prepared_xid(THD* thd);
 void *thd_get_ha_data(const THD* thd, const struct handlerton *hton);
 void thd_set_ha_data(THD* thd, const struct handlerton *hton,
                      const void *ha_data);

--- a/mysql-test/main/mdev-35046.result
+++ b/mysql-test/main/mdev-35046.result
@@ -1,0 +1,13 @@
+SET pseudo_slave_mode=1;
+CREATE TABLE t1 (c INT) ENGINE=InnoDB;
+CREATE TABLE t2 (c INT) ENGINE=MEMORY;
+XA START 'a';
+INSERT INTO t1 VALUES (0);
+CREATE TEMPORARY TABLE t1t (c INT) ENGINE=InnoDB;
+INSERT INTO t1t VALUES (0);
+XA END 'a';
+XA PREPARE 'a';
+OPTIMIZE TABLE t1t;
+ERROR XAE07: XAER_RMFAIL: The command cannot be executed when global transaction is in the  PREPARED state
+XA COMMIT 'a';
+DROP TABLE t1, t2;

--- a/mysql-test/main/mdev-35046.test
+++ b/mysql-test/main/mdev-35046.test
@@ -1,0 +1,18 @@
+#
+# MDEV-35046 SIGSEGV in list_delete in optimized builds when using pseudo_slave_mode
+# https://jira.mariadb.org/browse/MDEV-35046
+#
+--source include/have_innodb.inc
+SET pseudo_slave_mode=1;
+CREATE TABLE t1 (c INT) ENGINE=InnoDB;
+CREATE TABLE t2 (c INT) ENGINE=MEMORY;
+XA START 'a';
+INSERT INTO t1 VALUES (0);
+CREATE TEMPORARY TABLE t1t (c INT) ENGINE=InnoDB;
+INSERT INTO t1t VALUES (0);
+XA END 'a';
+XA PREPARE 'a';
+--error ER_XAER_RMFAIL
+OPTIMIZE TABLE t1t;
+XA COMMIT 'a';
+DROP TABLE t1, t2;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -900,7 +900,7 @@ typedef ulonglong my_xid; // this line is the same as in log_event.h
   @see MYSQL_XID in mysql/plugin.h
 */
 struct xid_t {
-  long formatID;
+  long formatID{-1};
   long gtrid_length;
   long bqual_length;
   char data[XIDDATASIZE];  // not \0-terminated !

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -443,6 +443,12 @@ void thd_storage_lock_wait(THD *thd, long long value)
   thd->utime_after_lock+= value;
 }
 
+extern "C"
+void *thd_pseudo_slave_and_get_prepared_xid(THD *thd)
+{
+  return fetch_cached_xa_trans(thd);
+}
+
 /**
   Provide a handler data getter to simplify coding
 */

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3369,6 +3369,7 @@ public:
     bool on;                            // see ha_enable_transaction()
     XID_STATE xid_state;
     XID implicit_xid;
+    XID prepared_xid;                   // is_null() false in XA PREPARE
     WT_THD wt;                          ///< for deadlock detection
     Rows_log_event *m_pending_rows_event;
 
@@ -3412,10 +3413,14 @@ public:
     st_transactions()
     {
       bzero((char*)this, sizeof(*this));
+      prepared_xid.null();
       implicit_xid.null();
       init_sql_alloc(key_memory_thd_transactions, &mem_root, 256,
                      0, MYF(MY_THREAD_SPECIFIC));
     }
+    void enter_prepared_state();
+    void exit_prepared_state();
+    bool is_in_prepared_state() const;
   } default_transaction, *transaction;
   Global_read_lock global_read_lock;
   Field      *dup_field;

--- a/sql/xa.h
+++ b/sql/xa.h
@@ -54,6 +54,7 @@ bool trans_xa_commit(THD *thd);
 bool trans_xa_rollback(THD *thd);
 bool trans_xa_detach(THD *thd);
 bool mysql_xa_recover(THD *thd);
+void *fetch_cached_xa_trans(THD *thd);
 
 void xa_recover_get_fields(THD *thd, List<Item> *field_list,
                            my_hash_walk_action *action);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -13466,6 +13466,15 @@ static bool delete_table_check_foreigns(const dict_table_t &table,
   return false;
 }
 
+static trx_t *get_parent_trx(THD *thd)
+{
+  XID *xa_xid = (XID*)thd_pseudo_slave_and_get_prepared_xid(thd);
+  trx_t *parent_trx = xa_xid ? trx_get_trx_by_xid(xa_xid) : nullptr;
+  if (!parent_trx)
+    parent_trx = check_trx_exists(thd);
+  return parent_trx;
+}
+
 /** DROP TABLE (possibly as part of DROP DATABASE, CREATE/ALTER TABLE)
 @param name   table name
 @return error number */
@@ -13481,7 +13490,7 @@ int ha_innobase::delete_table(const char *name)
                   test_normalize_table_name_low(););
 
   const enum_sql_command sqlcom= enum_sql_command(thd_sql_command(thd));
-  trx_t *parent_trx= check_trx_exists(thd);
+  trx_t *parent_trx = get_parent_trx(thd);
   dict_table_t *table;
 
   {


### PR DESCRIPTION
…do_slave_mode

This patch disallows OPTIMIZE TABLE when (1) in pseudo slave mode and (2) after the session has run XA PREPARE, matching the behavior of the system when pseudo slave mode is disabled.

This patch fixes a memory corruption issue where we would tell innodb to delete a table, which it correctly dropped, but then the SQL layer would not remove it from the correct trx_t structure.  Later, when the session closed and we iterated tables on trx_t (specifically mod_tables), we would attempt to access memory associated with the dropped table and crash.

When in pseudo slave mode, we "forget" that we're within an XA transaction during XA PREPARE, and we can't reject statements like OPTIMIZE TABLE. XA PREPARE with pseudo-slave mode enabled resets the XA transaction sim state to one-phase commit by clearing the cached XA transaction state (that is, by setting to NULL the xid_state.xid_cache_element in slave_applier_reset_xa_trans.  So we need a way to remember that we're in pseudo slave mode for a particular transaction and also remember whatever transaction ID is in flight.

With that information, we can lookup the XA transaction ID when dropping a table and, if it exists, use that instead of the XA state information associated between the handler and THD.  Of course, as a fallback, we will still look at the XA state (trx_t) associated between the handler and THD when the XA transaction doesn't exist (because we're not in XA, or it rolled-back, etc).  This fixes the memory corruption by removing the table from the correct trx_t structure when we tell innodb to delete it, keeping consistency.
