### PR TITLE
MDEV-24485 : galera.galera_bf_kill_debug MTR failed: A long semaphore…

### DIFF
--- a/mysql-test/suite/galera/r/galera_bf_kill_debug.result
+++ b/mysql-test/suite/galera/r/galera_bf_kill_debug.result
@@ -40,18 +40,19 @@ drop table t1;
 disconnect node_2a;
 connect node_2a, 127.0.0.1, root, , test, $NODE_MYPORT_2;
 connection node_2a;
-CREATE TABLE t1 (i int primary key);
+CREATE TABLE t1 (i int primary key) engine=innodb;
 SET DEBUG_SYNC = "before_wsrep_ordered_commit SIGNAL bwoc_reached WAIT_FOR bwoc_continue";
 INSERT INTO t1 VALUES (1);
 connection node_2;
 SET DEBUG_SYNC = "now WAIT_FOR bwoc_reached";
 SET DEBUG_SYNC = "now SIGNAL bwoc_continue";
-SET DEBUG_SYNC='RESET';
 connection node_2a;
 connection node_2;
+SET DEBUG_SYNC='RESET';
 select * from t1;
 i
 1
 disconnect node_2a;
+disconnect node_2b;
 connection node_1;
 drop table t1;

--- a/mysql-test/suite/galera/t/galera_bf_kill_debug.test
+++ b/mysql-test/suite/galera/t/galera_bf_kill_debug.test
@@ -110,7 +110,7 @@ drop table t1;
 --connection node_2a
 --let $connection_id = `SELECT CONNECTION_ID()`
 
-CREATE TABLE t1 (i int primary key);
+CREATE TABLE t1 (i int primary key) engine=innodb;
 
 # Set up sync point
 SET DEBUG_SYNC = "before_wsrep_ordered_commit SIGNAL bwoc_reached WAIT_FOR bwoc_continue";
@@ -129,16 +129,17 @@ SET DEBUG_SYNC = "now WAIT_FOR bwoc_reached";
 --enable_query_log
 
 SET DEBUG_SYNC = "now SIGNAL bwoc_continue";
-SET DEBUG_SYNC='RESET';
 --connection node_2a
 --error 0,1213
 --reap
 
 --connection node_2
+SET DEBUG_SYNC='RESET';
 # victim was able to complete the INSERT
 select * from t1;
 
 --disconnect node_2a
+--disconnect node_2b
 
 --connection node_1
 drop table t1;


### PR DESCRIPTION
… wait



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-24485*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Test sends a signal to debug_sync and in next command resets debug_sync signals. There is small possibility that sended signal is not yet handled in receiving thread and reset will destroy it causing sync wait timeout.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
