### PR TITLE
MDEV-34915 track session variables - test adjust

### DIFF
--- a/mysql-test/suite/sys_vars/r/session_track_system_variables_basic.result
+++ b/mysql-test/suite/sys_vars/r/session_track_system_variables_basic.result
@@ -154,17 +154,15 @@ SET @@global.session_track_system_variables = @global_saved_tmp;
 #
 # MDEV-31609 Send initial values of system variables in first OK packet
 #
-set @old_session_track_system_variables=@@global.session_track_system_variables;
-set global session_track_system_variables="autocommit,character_set_client,character_set_connection,redirect_url,time_zone";
 connect foo,localhost,root;
 -- Tracker : SESSION_TRACK_SYSTEM_VARIABLES
 -- autocommit: ON
 -- character_set_client: latin1
 -- character_set_connection: latin1
+-- character_set_results: latin1
 -- redirect_url: 
 -- time_zone: SYSTEM
 
 connection default;
 disconnect foo;
-set global session_track_system_variables=@old_session_track_system_variables;
 # End of tests 11.5

--- a/mysql-test/suite/sys_vars/t/session_track_system_variables_basic.test
+++ b/mysql-test/suite/sys_vars/t/session_track_system_variables_basic.test
@@ -129,11 +129,6 @@ SET @@global.session_track_system_variables = @global_saved_tmp;
 --echo # MDEV-31609 Send initial values of system variables in first OK packet
 --echo #
 
-set @old_session_track_system_variables=@@global.session_track_system_variables;
-# We set the session_track_system_variables to exclude
-# character_set_results as it can appear out of order in the CI
-# builder x86-debian-sid.
-set global session_track_system_variables="autocommit,character_set_client,character_set_connection,redirect_url,time_zone";
 enable_session_track_info;
 
 connect foo,localhost,root;
@@ -141,6 +136,5 @@ connect foo,localhost,root;
 disable_session_track_info;
 connection default;
 disconnect foo;
-set global session_track_system_variables=@old_session_track_system_variables;
 
 --echo # End of tests 11.5


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34915*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

With MDEV-34915 adjusting the mtr output of session variables to be in order, the original omition for x86_32 (added by MDEV-31609) is no longer required.

## Release Notes

nothing - internal test result

## How can this PR be tested?

examining the sys_vars.session_track_system_variables_basic test on a x86_32 builder.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
