### PR TITLE
MDEV-34719 Disable purge for LOAD DATA INFILE into empty table

### DIFF
--- a/mysql-test/main/auto_increment_ranges_innodb.result
+++ b/mysql-test/main/auto_increment_ranges_innodb.result
@@ -273,7 +273,6 @@ with system versioning partition by system_time interval 2 day
 load data infile 'load.data' ignore into table t1;
 Warnings:
 Warning	1062	Duplicate entry '1' for key 'x'
-Warning	1062	Duplicate entry '1' for key 'x'
 drop table t1;
 create table t1 (pk int auto_increment primary key, f varchar(20));
 insert t1 (f) values ('a'), ('b'), ('c'), ('d');

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2797,6 +2797,15 @@ avoid_bulk:
 					*entry, *index, trx);
 			goto err_exit;
 		}
+	} else if (trx->mysql_thd
+		   && page_is_empty(block->page.frame)
+		   && block->page.id().page_no() == index->page
+                   && thd_sql_command(trx->mysql_thd) == SQLCOM_LOAD) {
+			trx_start_if_not_started(trx, true);
+			trx->bulk_insert = true;
+			auto m = trx->mod_tables.emplace(index->table, 0);
+			m.first->second.start_bulk_insert(
+					index->table, true);
 	}
 
 row_level_insert:

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -1859,6 +1859,11 @@ trx_undo_report_row_operation(
 		ut_ad(thr->run_node);
 		ut_ad(que_node_get_type(thr->run_node) == QUE_NODE_INSERT);
 		ut_ad(trx->bulk_insert);
+
+		if (m.first->second.has_written_empty_undo()) {
+			m.first->second.write_undo_empty();
+			goto skip_bulk;
+		}
 		return DB_SUCCESS;
 	} else if (!m.second || !trx->bulk_insert) {
 		bulk = false;
@@ -1871,10 +1876,12 @@ trx_undo_report_row_operation(
 			    *clust_entry, *index, trx)) {
 			return err;
 		}
+		m.first->second.write_undo_empty();
 	} else {
 		bulk = false;
 	}
 
+skip_bulk:
 	mtr_t		mtr;
 	dberr_t		err;
 	mtr.start();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34179*

## Description
- While doing LOAD DATA INFILE into the empty table, write only TRX_UNDO_EMPTY undo log. This can be achieved by having separate flag in trx_mod_table_time_t for writing the TRX_UNDO_EMPTY record

row_ins_clust_index_entry_low(): Start the bulk insert for load command and don't create bulk buffer.

trx_undo_report_row_operation(): Enable the write empty undo log for the first time.

## How can this PR be tested?
need to come up with test case to prove undo log wasn't written for every insert
in load data statement

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.