### PR TITLE
MDEV-35069 - IMPORT TABLESPACE does not work for tables with vector, although allowed

### DIFF
--- a/mysql-test/main/vector_innodb.result
+++ b/mysql-test/main/vector_innodb.result
@@ -252,4 +252,39 @@ d
 0.00000
 0.00000
 drop table t;
+#
+# MDEV-35069 - IMPORT TABLESPACE does not work for tables with vector,
+#              although allowed
+#
+create table t1 (id int auto_increment primary key, v vector(5) not null, vector index (v) m=5) engine=InnoDB;
+insert t1 (v) values (x'e360d63ebe554f3fcdbc523f4522193f5236083d'),
+(x'f511303f72224a3fdd05fe3eb22a133ffae86a3f'),
+(x'f09baa3ea172763f123def3e0c7fe53e288bf33e'),
+(x'b97a523f2a193e3eb4f62e3f2d23583e9dd60d3f'),
+(x'f7c5df3e984b2b3e65e59d3d7376db3eac63773e'),
+(x'de01453ffa486d3f10aa4d3fdd66813c71cb163f'),
+(x'76edfc3e4b57243f10f8423fb158713f020bda3e'),
+(x'56926c3fdf098d3e2c8c5e3d1ad4953daa9d0b3e'),
+(x'7b713f3e5258323f80d1113d673b2b3f66e3583f'),
+(x'6ca1d43e9df91b3fe580da3e1c247d3f147cf33e');
+create table t2 like t1;
+alter table t2 discard tablespace;
+select id,vec_distance_euclidean(v, x'B047263c9f87233fcfd27e3eae493e3f0329f43e') d from t2 order by d limit 3;
+ERROR HY000: Tablespace has been discarded for table `t2`
+flush table t1 for export;
+db.opt
+t1#i#01.cfg
+t1#i#01.ibd
+t1.cfg
+t1.frm
+t1.ibd
+t2.frm
+unlock tables;
+alter table t2 import tablespace;
+select id,vec_distance_euclidean(v, x'B047263c9f87233fcfd27e3eae493e3f0329f43e') d from t2 order by d limit 3;
+id	d
+9	0.47199
+10	0.50690
+3	0.58656
+drop table t1, t2;
 # End of 11.7 tests

--- a/mysql-test/main/vector_innodb.test
+++ b/mysql-test/main/vector_innodb.test
@@ -254,4 +254,39 @@ insert into t values (1,0x31313131),(2,0x32323232); # optional, fails either way
 select distinct vec_distance_euclidean(v, 0x30303030) as d from t order by pk;
 drop table t;
 
+--echo #
+--echo # MDEV-35069 - IMPORT TABLESPACE does not work for tables with vector,
+--echo #              although allowed
+--echo #
+let $datadir=`select @@datadir`;
+create table t1 (id int auto_increment primary key, v vector(5) not null, vector index (v) m=5) engine=InnoDB;
+insert t1 (v) values (x'e360d63ebe554f3fcdbc523f4522193f5236083d'),
+                     (x'f511303f72224a3fdd05fe3eb22a133ffae86a3f'),
+                     (x'f09baa3ea172763f123def3e0c7fe53e288bf33e'),
+                     (x'b97a523f2a193e3eb4f62e3f2d23583e9dd60d3f'),
+                     (x'f7c5df3e984b2b3e65e59d3d7376db3eac63773e'),
+                     (x'de01453ffa486d3f10aa4d3fdd66813c71cb163f'),
+                     (x'76edfc3e4b57243f10f8423fb158713f020bda3e'),
+                     (x'56926c3fdf098d3e2c8c5e3d1ad4953daa9d0b3e'),
+                     (x'7b713f3e5258323f80d1113d673b2b3f66e3583f'),
+                     (x'6ca1d43e9df91b3fe580da3e1c247d3f147cf33e');
+create table t2 like t1;
+alter table t2 discard tablespace;
+--error ER_TABLESPACE_DISCARDED
+select id,vec_distance_euclidean(v, x'B047263c9f87233fcfd27e3eae493e3f0329f43e') d from t2 order by d limit 3;
+
+flush table t1 for export;
+--list_files $datadir/test/
+--copy_file $datadir/test/t1.ibd $datadir/test/t2.ibd
+--copy_file $datadir/test/t1.cfg $datadir/test/t2.cfg
+--copy_file $datadir/test/t1#i#01.ibd $datadir/test/t2#i#01.ibd
+--copy_file $datadir/test/t1#i#01.cfg $datadir/test/t2#i#01.cfg
+unlock tables;
+
+alter table t2 import tablespace;
+--replace_regex /(\.\d{5})\d+/\1/
+select id,vec_distance_euclidean(v, x'B047263c9f87233fcfd27e3eae493e3f0329f43e') d from t2 order by d limit 3;
+
+drop table t1, t2;
+
 --echo # End of 11.7 tests

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7667,6 +7667,9 @@ int handler::ha_external_lock(THD *thd, int lock_type)
     }
   }
 
+  if (lock_type == F_UNLCK)
+    (void) table->unlock_hlindexes();
+
   /*
     We cache the table flags if the locking succeeded. Otherwise, we
     keep them as they were when they were fetched in ha_open().
@@ -7741,8 +7744,6 @@ int handler::ha_reset()
     delete lookup_handler;
     lookup_handler= this;
   }
-  if (table->reset_hlindexes())
-    return 1;
   DBUG_RETURN(reset());
 }
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -9894,7 +9894,7 @@ int TABLE::open_hlindexes_for_write()
   return 0;
 }
 
-int TABLE::reset_hlindexes()
+int TABLE::unlock_hlindexes()
 {
   if (hlindex && hlindex->in_use)
   {

--- a/sql/sql_reload.cc
+++ b/sql/sql_reload.cc
@@ -641,6 +641,9 @@ bool flush_tables_with_read_lock(THD *thd, TABLE_LIST *all_tables)
           table_list->table &&
           table_list->table->file->extra(HA_EXTRA_FLUSH))
         goto error_reset_bits;
+      if (table_list->table &&
+          table_list->table->open_hlindexes_for_write())
+        goto error_reset_bits;
     }
   }
 

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -6082,6 +6082,23 @@ int mysql_discard_or_import_tablespace(THD *thd,
     DBUG_RETURN(-1);
   }
 
+  DBUG_ASSERT(table_list->table->s->hlindexes() <= 1);
+  for (uint i= table_list->table->s->keys; i < table_list->table->s->total_keys; i++)
+  {
+    if (table_list->table->hlindex_open(i))
+    {
+      thd->tablespace_op= FALSE;
+      DBUG_RETURN(-1);
+    }
+  }
+  for (uint i= table_list->table->s->keys; i < table_list->table->s->total_keys; i++)
+  {
+    error= table_list->table->hlindex->file->
+      ha_discard_or_import_tablespace(discard);
+    if (unlikely(error))
+      goto err;
+  }
+
   error= table_list->table->file->ha_discard_or_import_tablespace(discard);
 
   THD_STAGE_INFO(thd, stage_end);

--- a/sql/table.h
+++ b/sql/table.h
@@ -1806,7 +1806,7 @@ public:
   int hlindexes_on_update();
   int hlindexes_on_delete(const uchar *buf);
   int hlindexes_on_delete_all(bool truncate);
-  int reset_hlindexes();
+  int unlock_hlindexes();
 
   void prepare_triggers_for_insert_stmt_or_event();
   bool prepare_triggers_for_delete_stmt_or_event();


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35069*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Propagate discard/import tablespace request to hlindexes.

Let FLUSH TABLES ... FOR EXPORT open/lock hlindexes, so that InnoDB prepares hlindexes for export.

Moved reset_hlindexes() to external_lock(F_UNLCK), so that hlindexes are available for export until UNLOCK TABLES.

## Release Notes
Probably update "Copying Transportable Tablespaces" with information about VECTOR indexes. Their tablespaces have to be copied along with parent table.

## How can this PR be tested?
mtr vector_innodb

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
