### PR TITLE
MDEV-35398  Improve shrinking of system tablespace

### DIFF
--- a/mysql-test/suite/innodb/r/shrink_cached_undo.result
+++ b/mysql-test/suite/innodb/r/shrink_cached_undo.result
@@ -1,0 +1,23 @@
+#
+# MDEV-35398 Improve shrinking of system tablespace
+#
+# restart: --debug_dbug=d,skip_cached_undo
+SET GLOBAL innodb_file_per_table= 0;
+Warnings:
+Warning	1287	'@@innodb_file_per_table' is deprecated and will be removed in a future release
+CREATE TABLE t1(f1 INT PRIMARY KEY)ENGINE=InnoDB;
+CREATE TABLE t2(f1 INT PRIMARY KEY)ENGINE=InnoDB;
+SET STATEMENT unique_checks=0,foreign_key_checks=0 FOR
+INSERT INTO t1 SELECT seq FROM seq_1_to_24576;
+SET STATEMENT unique_checks=0,foreign_key_checks=0 FOR
+INSERT INTO t2 SELECT seq FROM seq_1_to_24576;
+# Insert 34 transaction which has undo cached records
+DROP TABLE t2, t1;
+SET GLOBAL innodb_fast_shutdown=0;
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	79691776
+# restart
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+NAME	FILE_SIZE
+innodb_system	12582912

--- a/mysql-test/suite/innodb/t/shrink_cached_undo.opt
+++ b/mysql-test/suite/innodb/t/shrink_cached_undo.opt
@@ -1,0 +1,2 @@
+--innodb_undo_tablespaces=0
+--innodb_sys_tablespaces

--- a/mysql-test/suite/innodb/t/shrink_cached_undo.test
+++ b/mysql-test/suite/innodb/t/shrink_cached_undo.test
@@ -1,0 +1,47 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/have_debug.inc
+--source include/not_embedded.inc
+--source include/big_test.inc
+--echo #
+--echo # MDEV-35398 Improve shrinking of system tablespace
+--echo #
+# Make pre-10.6.13 version data directory which skips the
+# purging of cached undo log records
+let $restart_parameters=--debug_dbug=d,skip_cached_undo;
+--source include/restart_mysqld.inc
+SET GLOBAL innodb_file_per_table= 0;
+CREATE TABLE t1(f1 INT PRIMARY KEY)ENGINE=InnoDB;
+CREATE TABLE t2(f1 INT PRIMARY KEY)ENGINE=InnoDB;
+
+SET STATEMENT unique_checks=0,foreign_key_checks=0 FOR
+INSERT INTO t1 SELECT seq FROM seq_1_to_24576;
+SET STATEMENT unique_checks=0,foreign_key_checks=0 FOR
+INSERT INTO t2 SELECT seq FROM seq_1_to_24576;
+
+--echo # Insert 34 transaction which has undo cached records
+--disable_query_log
+let $c = 34;
+while ($c)
+{
+  connect (con$c,localhost,root,,);
+  START TRANSACTION;
+  eval INSERT INTO t1 SELECT seq+$c*32768 FROM seq_1_to_3753;
+  dec $c;
+}
+
+connection default;
+let $c = 34;
+while ($c)
+{
+  disconnect con$c;
+  dec $c;
+}
+--enable_query_log
+
+DROP TABLE t2, t1;
+SET GLOBAL innodb_fast_shutdown=0;
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;
+let $restart_parameters=;
+--source include/restart_mysqld.inc
+SELECT NAME, FILE_SIZE FROM information_schema.innodb_sys_tablespaces WHERE SPACE = 0;

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -497,6 +497,7 @@ loop:
       if (UNIV_UNLIKELY(mach_read_from_4(TRX_RSEG + TRX_RSEG_FORMAT +
                                          rseg_hdr->page.frame)))
         trx_rseg_format_upgrade(rseg_hdr, &mtr);
+      DBUG_EXECUTE_IF("skip_cached_undo", goto skip_purge_free;);
       if (UNIV_LIKELY(undo != nullptr))
       {
         UT_LIST_REMOVE(rseg.undo_cached, undo);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35398*

## Description
Problem:
========
From 10.6.13(86767bcc0f121db3ad83a74647a642754a0ce57f) version, InnoDB purge thread does free the TRX_UNDO_CACHED undo segment. Pre-10.6.13 version data directory can contain TRX_UNDO_CACHED undo segment in system tablespace even though it has external undo tablespace.

During slow shutdown, InnoDB collects the segment from tables exist in system tablespace and cached undo segment in the system tablespace as used segment exist in system tablespace. While shrinking the system tablespace, last used extent can be used by undo cached segment. This extent blocks the shrinking of system tablespace in a effective way.

Solution:
========
While freeing the unused segment, InnoDB should free the cached undo segment header page exists in system tablespace and reset the TRX_RSEG_UNDO_SLOTS to 0xff for the rollback segment header page exists in system tablespace. This could improve the shrinking of system tablespace further.

## How can this PR be tested?
./mtr innodb.undo_leak --mem
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
