### PR TITLE
MDEV-35046 SIGSEGV in list_delete in optimized builds when using pseu…

### DIFF
--- a/mysql-test/main/mdev-35046.result
+++ b/mysql-test/main/mdev-35046.result
@@ -1,0 +1,17 @@
+SET pseudo_slave_mode=1;
+CREATE TABLE t1 (c INT) ENGINE=InnoDB;
+CREATE TABLE t2 (c INT) ENGINE=MEMORY;
+XA START 'a';
+INSERT INTO t1 VALUES (0);
+CREATE TEMPORARY TABLE t1t (c INT) ENGINE=InnoDB;
+INSERT INTO t1t VALUES (0);
+XA END 'a';
+XA PREPARE 'a';
+OPTIMIZE TABLE t1t;
+Table	Op	Msg_type	Msg_text
+test.t1t	optimize	Error	Table 'test.t1t' doesn't exist
+test.t1t	optimize	status	Operation failed
+LOCK TABLE t2 READ;
+XA COMMIT 'a';
+# restart
+DROP TABLE t1, t2;

--- a/mysql-test/main/mdev-35046.test
+++ b/mysql-test/main/mdev-35046.test
@@ -1,0 +1,19 @@
+#
+# MDEV-35046 SIGSEGV in list_delete in optimized builds when using pseudo_slave_mode
+# https://jira.mariadb.org/browse/MDEV-35046
+#
+--source include/have_innodb.inc
+SET pseudo_slave_mode=1;
+CREATE TABLE t1 (c INT) ENGINE=InnoDB;
+CREATE TABLE t2 (c INT) ENGINE=MEMORY;
+XA START 'a';
+INSERT INTO t1 VALUES (0);
+CREATE TEMPORARY TABLE t1t (c INT) ENGINE=InnoDB;
+INSERT INTO t1t VALUES (0);
+XA END 'a';
+XA PREPARE 'a';
+OPTIMIZE TABLE t1t;
+LOCK TABLE t2 READ;
+XA COMMIT 'a';
+--source include/restart_mysqld.inc
+DROP TABLE t1, t2;

--- a/mysql-test/suite/rpl/r/rpl_xa.result
+++ b/mysql-test/suite/rpl/r/rpl_xa.result
@@ -29,6 +29,8 @@ xa start 's';
 insert into t2 values (0);
 xa end 's';
 xa prepare 's';
+Warnings:
+Warning	4196	Pseudo thread id should not be modified by the client as it will be overwritten
 include/save_master_gtid.inc
 connection slave;
 include/sync_with_master_gtid.inc

--- a/mysql-test/suite/rpl/r/rpl_xa_gtid_pos_auto_engine.result
+++ b/mysql-test/suite/rpl/r/rpl_xa_gtid_pos_auto_engine.result
@@ -35,6 +35,8 @@ xa start 's';
 insert into t2 values (0);
 xa end 's';
 xa prepare 's';
+Warnings:
+Warning	4196	Pseudo thread id should not be modified by the client as it will be overwritten
 include/save_master_gtid.inc
 connection slave;
 include/sync_with_master_gtid.inc

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12270,3 +12270,5 @@ ER_JSON_SCHEMA_KEYWORD_UNSUPPORTED
         sw "%s neno kuu halitumiki"
 ER_JSON_NO_VARIABLE_SCHEMA
         eng "Variable schema is not supported."
+ER_PSEUDO_THREAD_ID_OVERWRITE
+        eng "Pseudo thread id should not be modified by the client as it will be overwritten"

--- a/sql/xa.cc
+++ b/sql/xa.cc
@@ -1196,5 +1196,10 @@ static bool slave_applier_reset_xa_trans(THD *thd)
   thd->has_waiter= false;
   MYSQL_COMMIT_TRANSACTION(thd->m_transaction_psi); // TODO/Fixme: commit?
   thd->m_transaction_psi= NULL;
+  if (thd->variables.pseudo_slave_mode && thd->variables.pseudo_thread_id == 0)
+    push_warning(thd, Sql_condition::WARN_LEVEL_WARN,
+		 ER_PSEUDO_THREAD_ID_OVERWRITE,
+		 ER_THD(thd, ER_PSEUDO_THREAD_ID_OVERWRITE));
+  thd->variables.pseudo_thread_id= 0;
   return thd->is_error();
 }


### PR DESCRIPTION
…do_slave_mode

slave_applier_reset_xa_trans() should clear the THD::pseudo_thread_id when called to reset XA transaction state completely.
