### PR TITLE
MDEV-35421 - main.mysql_upgrade fails without unix_socket plugin

### DIFF
--- a/mysql-test/main/mysql_upgrade.result
+++ b/mysql-test/main/mysql_upgrade.result
@@ -1062,7 +1062,7 @@ set global sql_safe_updates=@orig_sql_safe_updates;
 # MDEV-32043 Remove plugins previously external that are now built in (unix_socket)
 #
 INSERT INTO mysql.plugin SELECT 'unix_socket', 'auth_socket.so'
-    FROM dual WHERE convert(@@version_compile_os using latin1) not in ('Win32', 'Win64', 'Windows');
+    FROM information_schema.plugins WHERE plugin_name='unix_socket' AND plugin_library IS NULL;
 # mariadb-upgrade --force --silent 2>&1
 SELECT * FROM mysql.plugin WHERE name='unix_socket';
 name	dl

--- a/mysql-test/main/mysql_upgrade.test
+++ b/mysql-test/main/mysql_upgrade.test
@@ -500,7 +500,7 @@ set global sql_safe_updates=@orig_sql_safe_updates;
 --echo #
 
 INSERT INTO mysql.plugin SELECT 'unix_socket', 'auth_socket.so'
-    FROM dual WHERE convert(@@version_compile_os using latin1) not in ('Win32', 'Win64', 'Windows');
+    FROM information_schema.plugins WHERE plugin_name='unix_socket' AND plugin_library IS NULL;
 --echo # mariadb-upgrade --force --silent 2>&1
 --exec $MYSQL_UPGRADE --force --silent 2>&1
 SELECT * FROM mysql.plugin WHERE name='unix_socket';

--- a/plugin/auth_socket/CMakeLists.txt
+++ b/plugin/auth_socket/CMakeLists.txt
@@ -15,7 +15,9 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA
 
 CHECK_CXX_SOURCE_COMPILES(
-"#define _GNU_SOURCE
+"#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <sys/socket.h>
 int main() {
   struct ucred cred;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35421*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Fixed main.mysql_upgrade to pass when unix_socket plugin is unavailable.

Also don't redefine _GNU_SOURCE, which was previously defined by command line/environment. This fixes silent auth_socket build failure with MYSQL_MAINTAINER_MODE=ERR.

## Release Notes
N/A

## How can this PR be tested?
mtr main.mysql_upgrade


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
