### PR TITLE
MDEV-35438 Annotate InnoDB I/O functions with noexcept

### DIFF
--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -938,7 +938,7 @@ btr_search_failure(btr_search_t* info, btr_cur_t* cursor)
 }
 
 /** Clear the adaptive hash index on all pages in the buffer pool. */
-inline void buf_pool_t::clear_hash_index()
+inline void buf_pool_t::clear_hash_index() noexcept
 {
   ut_ad(!resizing);
   ut_ad(!btr_search_enabled);
@@ -990,7 +990,7 @@ inline void buf_pool_t::clear_hash_index()
 This function does not return if the block is not identified.
 @param ptr  pointer to within a page frame
 @return pointer to block, never NULL */
-inline buf_block_t* buf_pool_t::block_from_ahi(const byte *ptr) const
+inline buf_block_t* buf_pool_t::block_from_ahi(const byte *ptr) const noexcept
 {
   chunk_t::map *chunk_map = chunk_t::map_ref;
   ut_ad(chunk_t::map_ref == chunk_t::map_reg);

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -278,7 +278,7 @@ the read requests for the whole area.
 
 #ifndef UNIV_INNOCHECKSUM
 # ifdef SUX_LOCK_GENERIC
-void page_hash_latch::read_lock_wait()
+void page_hash_latch::read_lock_wait() noexcept
 {
   /* First, try busy spinning for a while. */
   for (auto spin= srv_n_spin_wait_rounds; spin--; )
@@ -293,7 +293,7 @@ void page_hash_latch::read_lock_wait()
   while (!read_trylock());
 }
 
-void page_hash_latch::write_lock_wait()
+void page_hash_latch::write_lock_wait() noexcept
 {
   write_lock_wait_start();
 
@@ -487,7 +487,7 @@ bool
 buf_page_is_checksum_valid_crc32(
 	const byte*			read_buf,
 	ulint				checksum_field1,
-	ulint				checksum_field2)
+	ulint				checksum_field2) noexcept
 {
 	const uint32_t	crc32 = buf_calc_page_crc32(read_buf);
 
@@ -555,7 +555,7 @@ static bool buf_page_check_lsn(bool check_lsn, const byte *read_buf)
 /** Check if a buffer is all zeroes.
 @param[in]	buf	data to check
 @return whether the buffer is all zeroes */
-bool buf_is_zeroes(span<const byte> buf)
+bool buf_is_zeroes(span<const byte> buf) noexcept
 {
   ut_ad(buf.size() <= UNIV_PAGE_SIZE_MAX);
   return memcmp(buf.data(), field_ref_zero, buf.size()) == 0;
@@ -570,7 +570,7 @@ buf_page_is_corrupted_reason
 buf_page_is_corrupted(
 	bool			check_lsn,
 	const byte*		read_buf,
-	ulint			fsp_flags)
+	ulint			fsp_flags) noexcept
 {
 	if (fil_space_t::full_crc32(fsp_flags)) {
 		bool compressed = false, corrupted = false;
@@ -828,7 +828,7 @@ static inline byte hex_to_ascii(byte hex_digit)
 @param[in]	read_buf	database page
 @param[in]	zip_size	compressed page size, or 0 */
 ATTRIBUTE_COLD
-void buf_page_print(const byte *read_buf, ulint zip_size)
+void buf_page_print(const byte *read_buf, ulint zip_size) noexcept
 {
 #ifndef UNIV_DEBUG
   const size_t size = zip_size ? zip_size : srv_page_size;
@@ -887,7 +887,7 @@ buf_block_init(buf_block_t* block, byte* frame)
 /** Allocate a chunk of buffer frames.
 @param bytes    requested size
 @return whether the allocation succeeded */
-inline bool buf_pool_t::chunk_t::create(size_t bytes)
+inline bool buf_pool_t::chunk_t::create(size_t bytes) noexcept
 {
   DBUG_EXECUTE_IF("ib_buf_chunk_init_fails", return false;);
   /* Round down to a multiple of page size, although it already should be. */
@@ -973,7 +973,7 @@ inline bool buf_pool_t::chunk_t::create(size_t bytes)
 /** Check that all file pages in the buffer chunk are in a replaceable state.
 @return address of a non-free block
 @retval nullptr if all freed */
-inline const buf_block_t *buf_pool_t::chunk_t::not_freed() const
+inline const buf_block_t *buf_pool_t::chunk_t::not_freed() const noexcept
 {
   buf_block_t *block= blocks;
   for (auto i= size; i--; block++)
@@ -1013,7 +1013,7 @@ inline const buf_block_t *buf_pool_t::chunk_t::not_freed() const
 
 /** Create the hash table.
 @param n  the lower bound of n_cells */
-void buf_pool_t::page_hash_table::create(ulint n)
+void buf_pool_t::page_hash_table::create(ulint n) noexcept
 {
   n_cells= ut_find_prime(n);
   const size_t size= MY_ALIGN(pad(n_cells) * sizeof *array,
@@ -1142,7 +1142,7 @@ bool buf_pool_t::create()
 }
 
 /** Clean up after successful create() */
-void buf_pool_t::close()
+void buf_pool_t::close() noexcept
 {
   ut_ad(this == &buf_pool);
   if (!is_initialised())
@@ -1202,7 +1202,7 @@ void buf_pool_t::close()
 /** Try to reallocate a control block.
 @param block  control block to reallocate
 @return whether the reallocation succeeded */
-inline bool buf_pool_t::realloc(buf_block_t *block)
+inline bool buf_pool_t::realloc(buf_block_t *block) noexcept
 {
 	buf_block_t*	new_block;
 
@@ -1318,7 +1318,7 @@ inline bool buf_pool_t::realloc(buf_block_t *block)
 	return(true); /* free_list was enough */
 }
 
-void buf_pool_t::io_buf_t::create(ulint n_slots)
+void buf_pool_t::io_buf_t::create(ulint n_slots) noexcept
 {
   this->n_slots= n_slots;
   slots= static_cast<buf_tmp_buffer_t*>
@@ -1326,7 +1326,7 @@ void buf_pool_t::io_buf_t::create(ulint n_slots)
   memset((void*) slots, 0, n_slots * sizeof *slots);
 }
 
-void buf_pool_t::io_buf_t::close()
+void buf_pool_t::io_buf_t::close() noexcept
 {
   for (buf_tmp_buffer_t *s= slots, *e= slots + n_slots; s != e; s++)
   {
@@ -1338,7 +1338,7 @@ void buf_pool_t::io_buf_t::close()
   n_slots= 0;
 }
 
-buf_tmp_buffer_t *buf_pool_t::io_buf_t::reserve(bool wait_for_reads)
+buf_tmp_buffer_t *buf_pool_t::io_buf_t::reserve(bool wait_for_reads) noexcept
 {
   for (;;)
   {
@@ -1383,7 +1383,7 @@ buf_resize_status(
 
 /** Withdraw blocks from the buffer pool until meeting withdraw_target.
 @return whether retry is needed */
-inline bool buf_pool_t::withdraw_blocks()
+inline bool buf_pool_t::withdraw_blocks() noexcept
 {
 	buf_block_t*	block;
 	ulint		loop_count = 0;
@@ -1512,7 +1512,7 @@ realloc_frame:
 
 
 
-inline void buf_pool_t::page_hash_table::write_lock_all()
+inline void buf_pool_t::page_hash_table::write_lock_all() noexcept
 {
   for (auto n= pad(n_cells) & ~ELEMENTS_PER_LATCH;; n-= ELEMENTS_PER_LATCH + 1)
   {
@@ -1523,7 +1523,7 @@ inline void buf_pool_t::page_hash_table::write_lock_all()
 }
 
 
-inline void buf_pool_t::page_hash_table::write_unlock_all()
+inline void buf_pool_t::page_hash_table::write_unlock_all() noexcept
 {
   for (auto n= pad(n_cells) & ~ELEMENTS_PER_LATCH;; n-= ELEMENTS_PER_LATCH + 1)
   {
@@ -2016,7 +2016,7 @@ static void buf_relocate(buf_page_t *bpage, buf_page_t *dpage)
 }
 
 buf_page_t *buf_pool_t::watch_set(const page_id_t id,
-                                  buf_pool_t::hash_chain &chain)
+                                  buf_pool_t::hash_chain &chain) noexcept
 {
   ut_ad(&chain == &page_hash.cell_get(id.fold()));
   page_hash.lock_get(chain).lock();
@@ -2087,6 +2087,7 @@ watch_set(id) must have returned nullptr before.
 @param chain      unlocked hash table chain */
 TRANSACTIONAL_TARGET
 void buf_pool_t::watch_unset(const page_id_t id, buf_pool_t::hash_chain &chain)
+  noexcept
 {
   mysql_mutex_assert_not_owner(&mutex);
   buf_page_t *w;
@@ -2200,7 +2201,7 @@ static void buf_inc_get(ha_handler_stats *stats)
 }
 
 TRANSACTIONAL_TARGET
-buf_page_t *buf_page_get_zip(const page_id_t page_id)
+buf_page_t *buf_page_get_zip(const page_id_t page_id) noexcept
 {
   ha_handler_stats *const stats= mariadb_stats;
   buf_inc_get(stats);
@@ -2310,14 +2311,7 @@ buf_block_init_low(
 #endif /* BTR_CUR_HASH_ADAPT */
 }
 
-/********************************************************************//**
-Decompress a block.
-@return true if successful */
-bool
-buf_zip_decompress(
-/*===============*/
-	buf_block_t*	block,	/*!< in/out: block */
-	ibool		check)	/*!< in: TRUE=verify the page checksum */
+bool buf_zip_decompress(buf_block_t *block, bool check) noexcept
 {
 	const byte*	frame = block->page.zip.data;
 	ulint		size = page_zip_get_size(&block->page.zip);
@@ -2468,6 +2462,7 @@ static bool buf_page_ibuf_merge_try(buf_block_t *block, ulint rw_latch,
 
 ATTRIBUTE_COLD
 buf_block_t *buf_pool_t::unzip(buf_page_t *b, buf_pool_t::hash_chain &chain)
+  noexcept
 {
   buf_block_t *block= buf_LRU_get_free_block(false);
   buf_block_init_low(block);
@@ -2558,7 +2553,7 @@ buf_block_t *buf_pool_t::unzip(buf_page_t *b, buf_pool_t::hash_chain &chain)
 
 buf_block_t *buf_pool_t::page_fix(const page_id_t id,
                                   dberr_t *err,
-                                  buf_pool_t::page_fix_conflicts c)
+                                  buf_pool_t::page_fix_conflicts c) noexcept
 {
   ha_handler_stats *const stats= mariadb_stats;
   buf_inc_get(stats);
@@ -2689,7 +2684,7 @@ buf_page_get_low(
 	ulint			mode,
 	mtr_t*			mtr,
 	dberr_t*		err,
-	bool			allow_ibuf_merge)
+	bool			allow_ibuf_merge) noexcept
 {
 	ulint		retries = 0;
 
@@ -3047,7 +3042,7 @@ buf_page_get_gen(
 	ulint			mode,
 	mtr_t*			mtr,
 	dberr_t*		err,
-	bool			allow_ibuf_merge)
+	bool			allow_ibuf_merge) noexcept
 {
   buf_block_t *block= recv_sys.recover(page_id);
   if (UNIV_LIKELY(!block))
@@ -3127,7 +3122,7 @@ buf_page_get_gen(
 }
 
 TRANSACTIONAL_TARGET
-buf_block_t *buf_page_optimistic_fix(buf_block_t *block, page_id_t id)
+buf_block_t *buf_page_optimistic_fix(buf_block_t *block, page_id_t id) noexcept
 {
   buf_pool_t::hash_chain &chain= buf_pool.page_hash.cell_get(id.fold());
   transactional_shared_lock_guard<page_hash_latch> g
@@ -3145,7 +3140,8 @@ buf_block_t *buf_page_optimistic_fix(buf_block_t *block, page_id_t id)
 
 buf_block_t *buf_page_optimistic_get(buf_block_t *block,
                                      rw_lock_type_t rw_latch,
-                                     uint64_t modify_clock, mtr_t *mtr)
+                                     uint64_t modify_clock,
+                                     mtr_t *mtr) noexcept
 {
   ut_ad(mtr->is_active());
   ut_ad(rw_latch == RW_S_LATCH || rw_latch == RW_X_LATCH);
@@ -3215,7 +3211,7 @@ Suitable for using when holding the lock_sys latches (as it avoids deadlock).
 @return the block
 @retval nullptr if an S-latch cannot be granted immediately */
 TRANSACTIONAL_TARGET
-buf_block_t *buf_page_try_get(const page_id_t page_id, mtr_t *mtr)
+buf_block_t *buf_page_try_get(const page_id_t page_id, mtr_t *mtr) noexcept
 {
   ut_ad(mtr);
   ut_ad(mtr->is_active());
@@ -3250,7 +3246,7 @@ buf_block_t *buf_page_try_get(const page_id_t page_id, mtr_t *mtr)
 @param zip_size ROW_FORMAT=COMPRESSED page size, or 0
 @param fix      initial buf_fix_count() */
 void buf_block_t::initialise(const page_id_t page_id, ulint zip_size,
-                             uint32_t fix)
+                             uint32_t fix) noexcept
 {
   ut_ad(!page.in_file());
   buf_block_init_low(this);
@@ -3261,6 +3257,7 @@ void buf_block_t::initialise(const page_id_t page_id, ulint zip_size,
 TRANSACTIONAL_TARGET
 static buf_block_t *buf_page_create_low(page_id_t page_id, ulint zip_size,
                                         mtr_t *mtr, buf_block_t *free_block)
+  noexcept
 {
   ut_ad(mtr->is_active());
   ut_ad(page_id.space() != 0 || !zip_size);
@@ -3474,7 +3471,7 @@ FILE_PAGE (the other is buf_page_get_gen).
 @return pointer to the block, page bufferfixed */
 buf_block_t*
 buf_page_create(fil_space_t *space, uint32_t offset,
-                ulint zip_size, mtr_t *mtr, buf_block_t *free_block)
+                ulint zip_size, mtr_t *mtr, buf_block_t *free_block) noexcept
 {
   space->free_page(offset, false);
   return buf_page_create_low({space->id, offset}, zip_size, mtr, free_block);
@@ -3488,7 +3485,8 @@ deferred tablespace
 @param free_block 	pre-allocated buffer block
 @return pointer to the block, page bufferfixed */
 buf_block_t* buf_page_create_deferred(uint32_t space_id, ulint zip_size,
-                                      mtr_t *mtr, buf_block_t *free_block)
+                                      mtr_t *mtr,
+                                      buf_block_t *free_block) noexcept
 {
   return buf_page_create_low({space_id, 0}, zip_size, mtr, free_block);
 }
@@ -3497,7 +3495,8 @@ buf_block_t* buf_page_create_deferred(uint32_t space_id, ulint zip_size,
 counter value in MONITOR_MODULE_BUF_PAGE.
 @param bpage   buffer page whose read or write was completed
 @param read    true=read, false=write */
-ATTRIBUTE_COLD void buf_page_monitor(const buf_page_t &bpage, bool read)
+ATTRIBUTE_COLD
+void buf_page_monitor(const buf_page_t &bpage, bool read) noexcept
 {
 	monitor_id_t	counter;
 
@@ -3590,7 +3589,7 @@ ATTRIBUTE_COLD void buf_page_monitor(const buf_page_t &bpage, bool read)
 @param[in]	is_compressed	compressed page
 @return true if page is corrupted or false if it isn't */
 static bool buf_page_full_crc32_is_corrupted(ulint space_id, const byte* d,
-                                             bool is_compressed)
+                                             bool is_compressed) noexcept
 {
   if (space_id != mach_read_from_4(d + FIL_PAGE_SPACE_ID))
     return true;
@@ -3680,7 +3679,7 @@ static dberr_t buf_page_check_corrupt(buf_page_t *bpage,
 @return whether the operation succeeded
 @retval DB_PAGE_CORRUPTED    if the checksum or the page ID is incorrect
 @retval DB_DECRYPTION_FAILED if the page cannot be decrypted */
-dberr_t buf_page_t::read_complete(const fil_node_t &node)
+dberr_t buf_page_t::read_complete(const fil_node_t &node) noexcept
 {
   const page_id_t expected_id{id()};
   ut_ad(is_read_fixed());
@@ -3834,7 +3833,7 @@ success_page:
 /** Check that all blocks are in a replaceable state.
 @return address of a non-free block
 @retval nullptr if all freed */
-void buf_pool_t::assert_all_freed()
+void buf_pool_t::assert_all_freed() noexcept
 {
   mysql_mutex_lock(&mutex);
   const chunk_t *chunk= chunks;
@@ -3846,7 +3845,7 @@ void buf_pool_t::assert_all_freed()
 #endif /* UNIV_DEBUG */
 
 /** Refresh the statistics used to print per-second averages. */
-void buf_refresh_io_stats()
+void buf_refresh_io_stats() noexcept
 {
 	buf_pool.last_printout_time = time(NULL);
 	buf_pool.old_stat = buf_pool.stat;
@@ -3854,7 +3853,7 @@ void buf_refresh_io_stats()
 
 /** Invalidate all pages in the buffer pool.
 All pages must be in a replaceable state (not modified or latched). */
-void buf_pool_invalidate()
+void buf_pool_invalidate() noexcept
 {
 	/* It is possible that a write batch that has been posted
 	earlier is still not complete. For buffer pool invalidation to
@@ -3881,7 +3880,7 @@ void buf_pool_invalidate()
 
 #ifdef UNIV_DEBUG
 /** Validate the buffer pool. */
-void buf_pool_t::validate()
+void buf_pool_t::validate() noexcept
 {
 	ulint		n_lru		= 0;
 	ulint		n_flushing	= 0;
@@ -3976,7 +3975,7 @@ void buf_pool_t::validate()
 
 #if defined UNIV_DEBUG_PRINT || defined UNIV_DEBUG
 /** Write information of the buf_pool to the error log. */
-void buf_pool_t::print()
+void buf_pool_t::print() noexcept
 {
 	index_id_t*	index_ids;
 	ulint*		counts;
@@ -4080,7 +4079,7 @@ void buf_pool_t::print()
 
 #ifdef UNIV_DEBUG
 /** @return the number of latched pages in the buffer pool */
-ulint buf_get_latched_pages_number()
+ulint buf_get_latched_pages_number() noexcept
 {
   ulint fixed_pages_number= 0;
 
@@ -4099,7 +4098,7 @@ ulint buf_get_latched_pages_number()
 
 /** Collect buffer pool metadata.
 @param[out]	pool_info	buffer pool metadata */
-void buf_stats_get_pool_info(buf_pool_info_t *pool_info)
+void buf_stats_get_pool_info(buf_pool_info_t *pool_info) noexcept
 {
 	time_t			current_time;
 	double			time_elapsed;
@@ -4332,7 +4331,7 @@ This function should be called only if tablespace contains crypt data metadata.
 @param[in]	page		page frame
 @param[in]	fsp_flags	tablespace flags
 @return true if true if page is encrypted and OK, false otherwise */
-bool buf_page_verify_crypt_checksum(const byte* page, ulint fsp_flags)
+bool buf_page_verify_crypt_checksum(const byte* page, ulint fsp_flags) noexcept
 {
 	if (!fil_space_t::full_crc32(fsp_flags)) {
 		return fil_space_verify_crypt_checksum(

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -41,13 +41,13 @@ using st_::span;
 buf_dblwr_t buf_dblwr;
 
 /** @return the TRX_SYS page */
-inline buf_block_t *buf_dblwr_trx_sys_get(mtr_t *mtr)
+inline buf_block_t *buf_dblwr_trx_sys_get(mtr_t *mtr) noexcept
 {
   return buf_page_get(page_id_t(TRX_SYS_SPACE, TRX_SYS_PAGE_NO),
                       0, RW_X_LATCH, mtr);
 }
 
-void buf_dblwr_t::init()
+void buf_dblwr_t::init() noexcept
 {
   if (!active_slot)
   {
@@ -59,7 +59,7 @@ void buf_dblwr_t::init()
 
 /** Initialise the persistent storage of the doublewrite buffer.
 @param header   doublewrite page header in the TRX_SYS page */
-inline void buf_dblwr_t::init(const byte *header)
+inline void buf_dblwr_t::init(const byte *header) noexcept
 {
   ut_ad(!active_slot->first_free);
   ut_ad(!active_slot->reserved);
@@ -81,7 +81,7 @@ inline void buf_dblwr_t::init(const byte *header)
 
 /** Create or restore the doublewrite buffer in the TRX_SYS page.
 @return whether the operation succeeded */
-bool buf_dblwr_t::create()
+bool buf_dblwr_t::create() noexcept
 {
   if (is_created())
     return true;
@@ -113,9 +113,9 @@ start_again:
 
   if (UT_LIST_GET_FIRST(fil_system.sys_space->chain)->size < 3 * size)
   {
-    ib::error() << "Cannot create doublewrite buffer: "
-                   "the first file in innodb_data_file_path must be at least "
-                << (3 * (size >> (20U - srv_page_size_shift))) << "M.";
+    sql_print_error("InnoDB: Cannot create doublewrite buffer: "
+                    "the first file in innodb_data_file_path must be at least "
+                    "%zuM.", 3 * (size >> (20U - srv_page_size_shift)));
 fail:
     mtr.commit();
     return false;
@@ -127,11 +127,13 @@ fail:
                                 &mtr, &err, false, trx_sys_block);
     if (!b)
     {
-      ib::error() << "Cannot create doublewrite buffer: " << err;
+      sql_print_error("InnoDB: Cannot create doublewrite buffer: %s",
+                      ut_strerr(err));
       goto fail;
     }
 
-    ib::info() << "Doublewrite buffer not found: creating new";
+    sql_print_information("InnoDB: Doublewrite buffer not found:"
+                          " creating new");
 
     /* FIXME: After this point, the doublewrite buffer creation
     is not atomic. The doublewrite buffer should not exist in
@@ -150,9 +152,9 @@ fail:
                                    false, &mtr, &mtr, &err);
     if (!new_block)
     {
-      ib::error() << "Cannot create doublewrite buffer: "
+      sql_print_error("InnoDB: Cannot create doublewrite buffer: "
                      " you must increase your tablespace size."
-                     " Cannot continue operation.";
+                     " Cannot continue operation.");
       /* This may essentially corrupt the doublewrite
       buffer. However, usually the doublewrite buffer
       is created at database initialization, and it
@@ -239,7 +241,7 @@ fail:
   /* Remove doublewrite pages from LRU */
   buf_pool_invalidate();
 
-  ib::info() << "Doublewrite buffer created";
+  sql_print_information("InnoDB: Doublewrite buffer created");
   goto start_again;
 }
 
@@ -252,6 +254,7 @@ loads the pages from double write buffer into memory.
 @param path Path name of file
 @return DB_SUCCESS or error code */
 dberr_t buf_dblwr_t::init_or_load_pages(pfs_os_file_t file, const char *path)
+  noexcept
 {
   ut_ad(this == &buf_dblwr);
   const uint32_t size= block_size();
@@ -266,7 +269,8 @@ dberr_t buf_dblwr_t::init_or_load_pages(pfs_os_file_t file, const char *path)
 
   if (err != DB_SUCCESS)
   {
-    ib::error() << "Failed to read the system tablespace header page";
+    sql_print_error("InnoDB: Failed to read the system tablespace"
+                    " header page");
 func_exit:
     aligned_free(read_buf);
     return err;
@@ -298,7 +302,8 @@ func_exit:
 
   if (err != DB_SUCCESS)
   {
-    ib::error() << "Failed to read the first double write buffer extent";
+    sql_print_error("InnoDB: Failed to read"
+                    " the first double write buffer extent");
     goto func_exit;
   }
 
@@ -308,7 +313,8 @@ func_exit:
                     size << srv_page_size_shift, nullptr);
   if (err != DB_SUCCESS)
   {
-    ib::error() << "Failed to read the second double write buffer extent";
+    sql_print_error("InnoDB: Failed to read"
+                    " the second double write buffer extent");
     goto func_exit;
   }
 
@@ -316,7 +322,8 @@ func_exit:
 
   if (UNIV_UNLIKELY(upgrade_to_innodb_file_per_table))
   {
-    ib::info() << "Resetting space id's in the doublewrite buffer";
+    sql_print_information("InnoDB: Resetting space id's in "
+                          "the doublewrite buffer");
 
     for (ulint i= 0; i < size * 2; i++, page += srv_page_size)
     {
@@ -332,7 +339,7 @@ func_exit:
                          source_page_no << srv_page_size_shift, srv_page_size);
       if (err != DB_SUCCESS)
       {
-        ib::error() << "Failed to upgrade the double write buffer";
+        sql_print_error("InnoDB: Failed to upgrade the double write buffer");
         goto func_exit;
       }
     }
@@ -352,7 +359,7 @@ func_exit:
 }
 
 /** Process and remove the double write buffer pages for all tablespaces. */
-void buf_dblwr_t::recover()
+void buf_dblwr_t::recover() noexcept
 {
   ut_ad(recv_sys.parse_start_lsn);
   if (!is_created())
@@ -481,7 +488,7 @@ next_page:
 }
 
 /** Free the doublewrite buffer. */
-void buf_dblwr_t::close()
+void buf_dblwr_t::close() noexcept
 {
   if (!active_slot)
     return;
@@ -502,7 +509,7 @@ void buf_dblwr_t::close()
 }
 
 /** Update the doublewrite buffer on write completion. */
-void buf_dblwr_t::write_completed()
+void buf_dblwr_t::write_completed() noexcept
 {
   ut_ad(this == &buf_dblwr);
   ut_ad(!srv_read_only_mode);
@@ -537,6 +544,7 @@ void buf_dblwr_t::write_completed()
 @param[in] page  page to check
 @param[in] s     tablespace */
 static void buf_dblwr_check_page_lsn(const page_t* page, const fil_space_t& s)
+  noexcept
 {
   /* Ignore page_compressed or encrypted pages */
   if (s.is_compressed() || buf_page_get_key_version(page, s.flags))
@@ -552,6 +560,7 @@ static void buf_dblwr_check_page_lsn(const page_t* page, const fil_space_t& s)
 }
 
 static void buf_dblwr_check_page_lsn(const buf_page_t &b, const byte *page)
+  noexcept
 {
   if (fil_space_t *space= fil_space_t::get_for_write(b.id().space()))
   {
@@ -561,7 +570,7 @@ static void buf_dblwr_check_page_lsn(const buf_page_t &b, const byte *page)
 }
 
 /** Check the LSN values on the page with which this block is associated. */
-static void buf_dblwr_check_block(const buf_page_t *bpage)
+static void buf_dblwr_check_block(const buf_page_t *bpage) noexcept
 {
   ut_ad(bpage->in_file());
   const page_t *page= bpage->frame;
@@ -593,7 +602,7 @@ static void buf_dblwr_check_block(const buf_page_t *bpage)
 }
 #endif /* UNIV_DEBUG */
 
-bool buf_dblwr_t::flush_buffered_writes(const ulint size)
+bool buf_dblwr_t::flush_buffered_writes(const ulint size) noexcept
 {
   mysql_mutex_assert_owner(&mutex);
   ut_ad(size == block_size());
@@ -658,7 +667,7 @@ bool buf_dblwr_t::flush_buffered_writes(const ulint size)
   return true;
 }
 
-static void *get_frame(const IORequest &request)
+static void *get_frame(const IORequest &request) noexcept
 {
   if (request.slot)
     return request.slot->out_buf;
@@ -667,6 +676,7 @@ static void *get_frame(const IORequest &request)
 }
 
 void buf_dblwr_t::flush_buffered_writes_completed(const IORequest &request)
+  noexcept
 {
   ut_ad(this == &buf_dblwr);
   ut_ad(srv_use_doublewrite_buf);
@@ -734,7 +744,7 @@ void buf_dblwr_t::flush_buffered_writes_completed(const IORequest &request)
 It is very important to call this function after a batch of writes has been
 posted, and also when we may have to wait for a page latch!
 Otherwise a deadlock of threads can occur. */
-void buf_dblwr_t::flush_buffered_writes()
+void buf_dblwr_t::flush_buffered_writes() noexcept
 {
   if (!is_created() || !srv_use_doublewrite_buf)
   {
@@ -754,7 +764,7 @@ void buf_dblwr_t::flush_buffered_writes()
 flush_buffered_writes() will be invoked to make space.
 @param request    asynchronous write request
 @param size       payload size in bytes */
-void buf_dblwr_t::add_to_batch(const IORequest &request, size_t size)
+void buf_dblwr_t::add_to_batch(const IORequest &request, size_t size) noexcept
 {
   ut_ad(request.is_async());
   ut_ad(request.is_write());

--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -57,6 +57,7 @@ that the block has been replaced with the real block.
 @return           w->state() */
 inline uint32_t buf_pool_t::watch_remove(buf_page_t *w,
                                          buf_pool_t::hash_chain &chain)
+  noexcept
 {
   mysql_mutex_assert_owner(&buf_pool.mutex);
   ut_ad(xtest() || page_hash.lock_get(chain).is_write_locked());
@@ -95,7 +96,7 @@ and the lock released later.
 @retval	NULL	in case of an error */
 TRANSACTIONAL_TARGET
 static buf_page_t* buf_page_init_for_read(ulint mode, const page_id_t page_id,
-                                          ulint zip_size, bool unzip)
+                                          ulint zip_size, bool unzip) noexcept
 {
   mtr_t mtr;
 
@@ -266,7 +267,7 @@ buf_read_page_low(
 	ulint			mode,
 	const page_id_t		page_id,
 	ulint			zip_size,
-	bool			unzip)
+	bool			unzip) noexcept
 {
 	buf_page_t*	bpage;
 
@@ -357,7 +358,7 @@ wants to access
 pages, it may happen that the page at the given page number does not
 get read even if we return a positive value! */
 TRANSACTIONAL_TARGET
-ulint buf_read_ahead_random(const page_id_t page_id, bool ibuf)
+ulint buf_read_ahead_random(const page_id_t page_id, bool ibuf) noexcept
 {
   if (!srv_random_read_ahead || page_id.space() >= SRV_TMP_SPACE_ID)
     /* Disable the read-ahead for temporary tablespace */
@@ -447,7 +448,7 @@ read_ahead:
   return count;
 }
 
-dberr_t buf_read_page(const page_id_t page_id, bool unzip)
+dberr_t buf_read_page(const page_id_t page_id, bool unzip) noexcept
 {
   fil_space_t *space= fil_space_t::get(page_id.space());
   if (UNIV_UNLIKELY(!space))
@@ -473,7 +474,7 @@ released by the i/o-handler thread.
 @param[in]	page_id		page id
 @param[in]	zip_size	ROW_FORMAT=COMPRESSED page size, or 0 */
 void buf_read_page_background(fil_space_t *space, const page_id_t page_id,
-                              ulint zip_size)
+                              ulint zip_size) noexcept
 {
 	buf_read_page_low(space, false, BUF_READ_ANY_PAGE,
 			  page_id, zip_size, false);
@@ -512,7 +513,7 @@ which could result in a deadlock if the OS does not support asynchronous io.
 @param[in]	ibuf		whether if we are inside ibuf routine
 @return number of page read requests issued */
 TRANSACTIONAL_TARGET
-ulint buf_read_ahead_linear(const page_id_t page_id, bool ibuf)
+ulint buf_read_ahead_linear(const page_id_t page_id, bool ibuf) noexcept
 {
   /* check if readahead is disabled.
   Disable the read ahead logic for temporary tablespace */
@@ -689,7 +690,7 @@ failed:
 @param recs     log records
 @param init     page initialization, or nullptr if the page needs to be read */
 void buf_read_recover(fil_space_t *space, const page_id_t page_id,
-                      page_recv_t &recs, recv_init *init)
+                      page_recv_t &recs, recv_init *init) noexcept
 {
   ut_ad(space->id == page_id.space());
   space->reacquire();

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -1364,7 +1364,7 @@ the encryption parameters were changed
 @retval nullptr upon reaching the end of the iteration */
 inline fil_space_t *fil_system_t::default_encrypt_next(fil_space_t *space,
                                                        bool recheck,
-                                                       bool encrypt)
+                                                       bool encrypt) noexcept
 {
   mysql_mutex_assert_owner(&mutex);
 
@@ -1431,7 +1431,7 @@ encryption parameters were changed
 @retval fil_system.temp_space if there is no work to do
 @retval end() upon reaching the end of the iteration */
 space_list_t::iterator fil_space_t::next(space_list_t::iterator space,
-                                         bool recheck, bool encrypt)
+                                         bool recheck, bool encrypt) noexcept
 {
   mysql_mutex_lock(&fil_system.mutex);
 
@@ -1480,7 +1480,7 @@ space_list_t::iterator fil_space_t::next(space_list_t::iterator space,
 static bool fil_crypt_find_space_to_rotate(
 	key_state_t*		key_state,
 	rotate_thread_t*	state,
-	bool*			recheck)
+	bool*			recheck) noexcept
 {
 	/* we need iops to start rotating */
 	do {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -21399,9 +21399,7 @@ void ins_node_t::vers_update_end(row_prebuilt_t *prebuilt, bool history_row)
 if needed.
 @param[in]	size	size in bytes
 @return	aligned size */
-ulint
-buf_pool_size_align(
-	ulint	size)
+ulint buf_pool_size_align(ulint size) noexcept
 {
   const ulong	m = srv_buf_pool_chunk_unit;
   size = ut_max((size_t) size, (size_t) MYSQL_SYSVAR_NAME(buffer_pool_size).min_val);

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -153,7 +153,7 @@ operator<<(
 @param id            expected block->page.id()
 @return block if it was buffer-fixed
 @retval nullptr if the block no longer is valid */
-buf_block_t *buf_page_optimistic_fix(buf_block_t *block, page_id_t id)
+buf_block_t *buf_page_optimistic_fix(buf_block_t *block, page_id_t id) noexcept
   MY_ATTRIBUTE((nonnull, warn_unused_result));
 
 /** Try to acquire a page latch after buf_page_optimistic_fix().
@@ -165,7 +165,8 @@ buf_block_t *buf_page_optimistic_fix(buf_block_t *block, page_id_t id)
 @retval nullptr if block->unfix() was called because it no longer is valid */
 buf_block_t *buf_page_optimistic_get(buf_block_t *block,
                                      rw_lock_type_t rw_latch,
-                                     uint64_t modify_clock, mtr_t *mtr)
+                                     uint64_t modify_clock,
+                                     mtr_t *mtr) noexcept
   MY_ATTRIBUTE((nonnull, warn_unused_result));
 
 /** Try to S-latch a page.
@@ -174,14 +175,14 @@ Suitable for using when holding the lock_sys latches (as it avoids deadlock).
 @param[in,out]	mtr	mini-transaction
 @return the block
 @retval nullptr if an S-latch cannot be granted immediately */
-buf_block_t *buf_page_try_get(const page_id_t page_id, mtr_t *mtr);
+buf_block_t *buf_page_try_get(const page_id_t page_id, mtr_t *mtr) noexcept;
 
 /** Get read access to a compressed page (usually of type
 FIL_PAGE_TYPE_ZBLOB or FIL_PAGE_TYPE_ZBLOB2).
 The page must be released with s_unlock().
 @param page_id   page identifier
 @return pointer to the block, s-latched */
-buf_page_t *buf_page_get_zip(const page_id_t page_id);
+buf_page_t *buf_page_get_zip(const page_id_t page_id) noexcept;
 
 /** Get access to a database page. Buffered redo log may be applied.
 @param[in]	page_id			page id
@@ -204,7 +205,7 @@ buf_page_get_gen(
 	ulint			mode,
 	mtr_t*			mtr,
 	dberr_t*		err = nullptr,
-	bool			allow_ibuf_merge = false)
+	bool			allow_ibuf_merge = false) noexcept
 	MY_ATTRIBUTE((nonnull(6), warn_unused_result));
 
 /** This is the low level function used to get access to a database page.
@@ -229,7 +230,7 @@ buf_page_get_low(
 	ulint			mode,
 	mtr_t*			mtr,
 	dberr_t*		err,
-	bool			allow_ibuf_merge)
+	bool			allow_ibuf_merge) noexcept
 	MY_ATTRIBUTE((nonnull(6), warn_unused_result));
 
 /** Initialize a page in the buffer pool. The page is usually not read
@@ -244,7 +245,8 @@ of the functions which perform to a block a state transition NOT_USED => LRU
 @return pointer to the block, page bufferfixed */
 buf_block_t*
 buf_page_create(fil_space_t *space, uint32_t offset,
-                ulint zip_size, mtr_t *mtr, buf_block_t *free_block);
+                ulint zip_size, mtr_t *mtr, buf_block_t *free_block)
+  noexcept;
 
 /** Initialize a page in buffer pool while initializing the
 deferred tablespace
@@ -255,7 +257,7 @@ deferred tablespace
 @return pointer to the block, page bufferfixed */
 buf_block_t*
 buf_page_create_deferred(uint32_t space_id, ulint zip_size, mtr_t *mtr,
-                         buf_block_t *free_block);
+                         buf_block_t *free_block) noexcept;
 
 /** Mark the page status as FREED for the given tablespace and page number.
 @param[in,out]	space	tablespace
@@ -292,7 +294,7 @@ buf_block_modify_clock_inc(
 /** Check if a buffer is all zeroes.
 @param[in]	buf	data to check
 @return whether the buffer is all zeroes */
-bool buf_is_zeroes(st_::span<const byte> buf);
+bool buf_is_zeroes(st_::span<const byte> buf) noexcept;
 
 /** Reason why buf_page_is_corrupted() fails */
 enum buf_page_is_corrupted_reason
@@ -311,7 +313,7 @@ buf_page_is_corrupted_reason
 buf_page_is_corrupted(
 	bool			check_lsn,
 	const byte*		read_buf,
-	ulint			fsp_flags)
+	ulint			fsp_flags) noexcept
 	MY_ATTRIBUTE((warn_unused_result));
 
 /** Read the key version from the page. In full crc32 format,
@@ -320,7 +322,8 @@ stored in 26th position.
 @param[in]	read_buf	database page
 @param[in]	fsp_flags	tablespace flags
 @return key version of the page. */
-inline uint32_t buf_page_get_key_version(const byte* read_buf, ulint fsp_flags)
+inline uint32_t buf_page_get_key_version(const byte *read_buf, ulint fsp_flags)
+  noexcept
 {
   static_assert(FIL_PAGE_FCRC32_KEY_VERSION == 0, "compatibility");
   return fil_space_t::full_crc32(fsp_flags)
@@ -335,7 +338,8 @@ stored in page type.
 @param[in]	read_buf	database page
 @param[in]	fsp_flags	tablespace flags
 @return true if page is compressed. */
-inline bool buf_page_is_compressed(const byte* read_buf, ulint fsp_flags)
+inline bool buf_page_is_compressed(const byte *read_buf, ulint fsp_flags)
+  noexcept
 {
   uint16_t page_type= fil_page_get_type(read_buf);
   return fil_space_t::full_crc32(fsp_flags)
@@ -348,7 +352,8 @@ inline bool buf_page_is_compressed(const byte* read_buf, ulint fsp_flags)
 @param[out]	comp	whether the page could be compressed
 @param[out]	cr	whether the page could be corrupted
 @return the payload size in the file page */
-inline uint buf_page_full_crc32_size(const byte* buf, bool* comp, bool* cr)
+inline uint buf_page_full_crc32_size(const byte *buf, bool *comp, bool *cr)
+  noexcept
 {
 	uint t = fil_page_get_type(buf);
 	uint page_size = uint(srv_page_size);
@@ -376,20 +381,17 @@ inline uint buf_page_full_crc32_size(const byte* buf, bool* comp, bool* cr)
 /** Dump a page to stderr.
 @param[in]	read_buf	database page
 @param[in]	zip_size	compressed page size, or 0 */
-void buf_page_print(const byte* read_buf, ulint zip_size = 0)
+void buf_page_print(const byte* read_buf, ulint zip_size = 0) noexcept
 	ATTRIBUTE_COLD __attribute__((nonnull));
-/********************************************************************//**
-Decompress a block.
+/** Decompress a ROW_FORMAT=COMPRESSED block.
+@param block   buffer page
+@param check whether to verify the page checksum
 @return true if successful */
-bool
-buf_zip_decompress(
-/*===============*/
-	buf_block_t*	block,	/*!< in/out: block */
-	ibool		check);	/*!< in: TRUE=verify the page checksum */
+bool buf_zip_decompress(buf_block_t *block, bool check) noexcept;
 
 #ifdef UNIV_DEBUG
 /** @return the number of latched pages in the buffer pool */
-ulint buf_get_latched_pages_number();
+ulint buf_get_latched_pages_number() noexcept;
 #endif /* UNIV_DEBUG */
 /*********************************************************************//**
 Prints info of the buffer i/o. */
@@ -399,14 +401,14 @@ buf_print_io(
 	FILE*	file);	/*!< in: file where to print */
 /** Collect buffer pool metadata.
 @param[out]	pool_info	buffer pool metadata */
-void buf_stats_get_pool_info(buf_pool_info_t *pool_info);
+void buf_stats_get_pool_info(buf_pool_info_t *pool_info) noexcept;
 
 /** Refresh the statistics used to print per-second averages. */
-void buf_refresh_io_stats();
+void buf_refresh_io_stats() noexcept;
 
 /** Invalidate all pages in the buffer pool.
 All pages must be in a replaceable state (not modified or latched). */
-void buf_pool_invalidate();
+void buf_pool_invalidate() noexcept;
 
 /*========================================================================
 --------------------------- LOWER LEVEL ROUTINES -------------------------
@@ -426,15 +428,14 @@ if applicable. */
 counter value in MONITOR_MODULE_BUF_PAGE.
 @param bpage   buffer page whose read or write was completed
 @param read    true=read, false=write */
-ATTRIBUTE_COLD void buf_page_monitor(const buf_page_t &bpage, bool read);
+ATTRIBUTE_COLD void buf_page_monitor(const buf_page_t &bpage, bool read)
+  noexcept;
 
 /** Calculate aligned buffer pool size based on srv_buf_pool_chunk_unit,
 if needed.
 @param[in]	size	size in bytes
 @return	aligned size */
-ulint
-buf_pool_size_align(
-	ulint	size);
+ulint buf_pool_size_align(ulint size) noexcept;
 
 /** Verify that post encryption checksum match with the calculated checksum.
 This function should be called only if tablespace contains crypt data metadata.
@@ -443,12 +444,12 @@ This function should be called only if tablespace contains crypt data metadata.
 @return true if page is encrypted and OK, false otherwise */
 bool buf_page_verify_crypt_checksum(
 	const byte*	page,
-	ulint		fsp_flags);
+	ulint		fsp_flags) noexcept;
 
 /** Calculate a ROW_FORMAT=COMPRESSED page checksum and update the page.
 @param[in,out]	page		page to update
 @param[in]	size		compressed page size */
-void buf_flush_update_zip_checksum(buf_frame_t* page, ulint size);
+void buf_flush_update_zip_checksum(buf_frame_t* page, ulint size) noexcept;
 
 /** @brief The temporary memory structure.
 
@@ -471,14 +472,15 @@ public:
   byte *out_buf;
 
   /** Release the slot */
-  void release() { reserved.store(false, std::memory_order_relaxed); }
+  void release() noexcept { reserved.store(false, std::memory_order_relaxed); }
 
   /** Acquire the slot
   @return whether the slot was acquired */
-  bool acquire() { return !reserved.exchange(true, std::memory_order_relaxed);}
+  bool acquire() noexcept
+  { return !reserved.exchange(true, std::memory_order_relaxed);}
 
   /** Allocate a buffer for encryption, decryption or decompression. */
-  void allocate()
+  void allocate() noexcept
   {
     if (!crypt_buf)
       crypt_buf= static_cast<byte*>
@@ -629,7 +631,7 @@ public:
   }
 
   /** Initialize some more fields */
-  void init(uint32_t state, page_id_t id)
+  void init(uint32_t state, page_id_t id) noexcept
   {
     ut_ad(state < REMOVE_HASH || state >= UNFIXED);
     ut_ad(!lock.is_locked_or_waiting());
@@ -646,45 +648,46 @@ public:
   }
 
 public:
-  const page_id_t &id() const { return id_; }
-  uint32_t state() const { return zip.fix; }
-  static uint32_t buf_fix_count(uint32_t s)
+  const page_id_t &id() const noexcept { return id_; }
+  uint32_t state() const noexcept { return zip.fix; }
+  static uint32_t buf_fix_count(uint32_t s) noexcept
   { ut_ad(s >= FREED); return s < UNFIXED ? (s - FREED) : (~LRU_MASK & s); }
 
   uint32_t buf_fix_count() const { return buf_fix_count(state()); }
   /** Check if a file block is io-fixed.
   @param s   state()
   @return whether s corresponds to an io-fixed block */
-  static bool is_io_fixed(uint32_t s)
+  static bool is_io_fixed(uint32_t s) noexcept
   { ut_ad(s >= FREED); return s >= READ_FIX; }
   /** Check if a file block is read-fixed.
   @param s   state()
   @return whether s corresponds to a read-fixed block */
-  static bool is_read_fixed(uint32_t s)
+  static bool is_read_fixed(uint32_t s) noexcept
   { return is_io_fixed(s) && s < WRITE_FIX; }
   /** Check if a file block is write-fixed.
   @param s   state()
   @return whether s corresponds to a write-fixed block */
-  static bool is_write_fixed(uint32_t s)
+  static bool is_write_fixed(uint32_t s) noexcept
   { ut_ad(s >= FREED); return s >= WRITE_FIX; }
 
   /** @return whether this block is read or write fixed;
   read_complete() or write_complete() will always release
   the io-fix before releasing U-lock or X-lock */
-  bool is_io_fixed() const { return is_io_fixed(state()); }
+  bool is_io_fixed() const noexcept { return is_io_fixed(state()); }
   /** @return whether this block is write fixed;
   write_complete() will always release the write-fix before releasing U-lock */
-  bool is_write_fixed() const { return is_write_fixed(state()); }
+  bool is_write_fixed() const noexcept { return is_write_fixed(state()); }
   /** @return whether this block is read fixed */
-  bool is_read_fixed() const { return is_read_fixed(state()); }
+  bool is_read_fixed() const noexcept { return is_read_fixed(state()); }
 
   /** @return if this belongs to buf_pool.unzip_LRU */
-  bool belongs_to_unzip_LRU() const
+  bool belongs_to_unzip_LRU() const noexcept
   { return UNIV_LIKELY_NULL(zip.data) && frame; }
 
-  static bool is_freed(uint32_t s) { ut_ad(s >= FREED); return s < UNFIXED; }
-  bool is_freed() const { return is_freed(state()); }
-  static bool is_ibuf_exist(uint32_t s)
+  static bool is_freed(uint32_t s) noexcept
+  { ut_ad(s >= FREED); return s < UNFIXED; }
+  bool is_freed() const noexcept { return is_freed(state()); }
+  static bool is_ibuf_exist(uint32_t s) noexcept
   {
     ut_ad(s >= UNFIXED);
     ut_ad(s < READ_FIX);
@@ -693,7 +696,7 @@ public:
   bool is_ibuf_exist() const { return is_ibuf_exist(state()); }
   bool is_reinit() const { return !(~state() & REINIT); }
 
-  void set_reinit(uint32_t prev_state)
+  void set_reinit(uint32_t prev_state) noexcept
   {
     ut_ad(prev_state < READ_FIX);
     ut_d(const auto s=) zip.fix.fetch_add(REINIT - prev_state);
@@ -701,7 +704,7 @@ public:
     ut_ad(s < prev_state + UNFIXED);
   }
 
-  void set_ibuf_exist()
+  void set_ibuf_exist() noexcept
   {
     ut_ad(lock.is_write_locked());
     ut_ad(id() < page_id_t(SRV_SPACE_ID_UPPER_BOUND, 0));
@@ -711,7 +714,7 @@ public:
     ut_ad(s < IBUF_EXIST || s >= REINIT);
     zip.fix.fetch_add(IBUF_EXIST - (LRU_MASK & s));
   }
-  void clear_ibuf_exist()
+  void clear_ibuf_exist() noexcept
   {
     ut_ad(lock.is_write_locked());
     ut_ad(id() < page_id_t(SRV_SPACE_ID_UPPER_BOUND, 0));
@@ -720,7 +723,7 @@ public:
     ut_ad(s < REINIT);
   }
 
-  uint32_t read_unfix(uint32_t s)
+  uint32_t read_unfix(uint32_t s) noexcept
   {
     ut_ad(lock.is_write_locked());
     ut_ad(s == UNFIXED + 1 || s == IBUF_EXIST + 1 || s == REINIT + 1);
@@ -730,7 +733,7 @@ public:
     return old_state + (s - READ_FIX);
   }
 
-  void set_freed(uint32_t prev_state, uint32_t count= 0)
+  void set_freed(uint32_t prev_state, uint32_t count= 0) noexcept
   {
     ut_ad(lock.is_write_locked());
     ut_ad(prev_state >= UNFIXED);
@@ -739,28 +742,28 @@ public:
     ut_ad(!((prev_state ^ s) & LRU_MASK));
   }
 
-  inline void set_state(uint32_t s);
-  inline void set_corrupt_id();
+  inline void set_state(uint32_t s) noexcept;
+  inline void set_corrupt_id() noexcept;
 
   /** @return the log sequence number of the oldest pending modification
   @retval 0 if the block is being removed from (or not in) buf_pool.flush_list
   @retval 1 if the block is in buf_pool.flush_list but not modified
   @retval 2 if the block belongs to the temporary tablespace and
   has unwritten changes */
-  lsn_t oldest_modification() const { return oldest_modification_; }
+  lsn_t oldest_modification() const noexcept { return oldest_modification_; }
   /** @return the log sequence number of the oldest pending modification,
   @retval 0 if the block is definitely not in buf_pool.flush_list
   @retval 1 if the block is in buf_pool.flush_list but not modified
   @retval 2 if the block belongs to the temporary tablespace and
   has unwritten changes */
-  lsn_t oldest_modification_acquire() const
+  lsn_t oldest_modification_acquire() const noexcept
   { return oldest_modification_.load(std::memory_order_acquire); }
   /** Set oldest_modification when adding to buf_pool.flush_list */
-  inline void set_oldest_modification(lsn_t lsn);
+  inline void set_oldest_modification(lsn_t lsn) noexcept;
   /** Clear oldest_modification after removing from buf_pool.flush_list */
-  inline void clear_oldest_modification();
+  inline void clear_oldest_modification() noexcept;
   /** Reset the oldest_modification when marking a persistent page freed */
-  void reset_oldest_modification()
+  void reset_oldest_modification() noexcept
   {
     ut_ad(oldest_modification() > 2);
     oldest_modification_.store(1, std::memory_order_release);
@@ -771,21 +774,21 @@ public:
   @return whether the operation succeeded
   @retval DB_PAGE_CORRUPTED    if the checksum or the page ID is incorrect
   @retval DB_DECRYPTION_FAILED if the page cannot be decrypted */
-  dberr_t read_complete(const fil_node_t &node);
+  dberr_t read_complete(const fil_node_t &node) noexcept;
 
   /** Release a write fix after a page write was completed.
   @param persistent  whether the page belongs to a persistent tablespace
   @param error       whether an error may have occurred while writing
   @param state       recently read state() value with the correct io-fix */
-  void write_complete(bool persistent, bool error, uint32_t state);
+  void write_complete(bool persistent, bool error, uint32_t state) noexcept;
 
   /** Write a flushable page to a file or free a freeable block.
   @param space       tablespace
   @return whether a page write was initiated and buf_pool.mutex released */
-  bool flush(fil_space_t *space);
+  bool flush(fil_space_t *space) noexcept;
 
   /** Notify that a page in a temporary tablespace has been modified. */
-  void set_temp_modified()
+  void set_temp_modified() noexcept
   {
     ut_ad(fsp_is_system_temporary(id().space()));
     ut_ad(in_file());
@@ -794,7 +797,7 @@ public:
   }
 
   /** Prepare to release a file page to buf_pool.free. */
-  void free_file_page()
+  void free_file_page() noexcept
   {
     ut_ad((zip.fix.fetch_sub(REMOVE_HASH - MEMORY)) == REMOVE_HASH);
     /* buf_LRU_block_free_non_file_page() asserts !oldest_modification() */
@@ -802,14 +805,14 @@ public:
     id_= page_id_t(~0ULL);
   }
 
-  void fix_on_recovery()
+  void fix_on_recovery() noexcept
   {
     ut_d(const auto f=) zip.fix.fetch_sub(READ_FIX - UNFIXED - 1);
     ut_ad(f >= READ_FIX);
     ut_ad(f < WRITE_FIX);
   }
 
-  uint32_t fix(uint32_t count= 1)
+  uint32_t fix(uint32_t count= 1) noexcept
   {
     ut_ad(count);
     ut_ad(count < IBUF_EXIST);
@@ -819,7 +822,7 @@ public:
     return f;
   }
 
-  uint32_t unfix()
+  uint32_t unfix() noexcept
   {
     uint32_t f= zip.fix.fetch_sub(1);
     ut_ad(f > FREED);
@@ -828,20 +831,20 @@ public:
   }
 
   /** @return the physical size, in bytes */
-  ulint physical_size() const
+  ulint physical_size() const noexcept
   {
     return zip.ssize ? (UNIV_ZIP_SIZE_MIN >> 1) << zip.ssize : srv_page_size;
   }
 
   /** @return the ROW_FORMAT=COMPRESSED physical size, in bytes
   @retval 0 if not compressed */
-  ulint zip_size() const
+  ulint zip_size() const noexcept
   {
     return zip.ssize ? (UNIV_ZIP_SIZE_MIN >> 1) << zip.ssize : 0;
   }
 
   /** @return the byte offset of the page within a file */
-  os_offset_t physical_offset() const
+  os_offset_t physical_offset() const noexcept
   {
     os_offset_t o= id().page_no();
     return zip.ssize
@@ -850,18 +853,18 @@ public:
   }
 
   /** @return whether the block is mapped to a data file */
-  bool in_file() const { return state() >= FREED; }
+  bool in_file() const noexcept { return state() >= FREED; }
 
   /** @return whether the block can be relocated in memory.
   The block can be dirty, but it must not be I/O-fixed or bufferfixed. */
-  inline bool can_relocate() const;
+  inline bool can_relocate() const noexcept;
   /** @return whether the block has been flagged old in buf_pool.LRU */
-  inline bool is_old() const;
+  inline bool is_old() const noexcept;
   /** Set whether a block is old in buf_pool.LRU */
-  inline void set_old(bool old);
+  inline void set_old(bool old) noexcept;
   /** Flag a page accessed in buf_pool
   @return whether this is not the first access */
-  bool set_accessed()
+  bool set_accessed() noexcept
   {
     if (is_accessed()) return true;
     access_time= static_cast<uint32_t>(ut_time_ms());
@@ -869,7 +872,8 @@ public:
   }
   /** @return ut_time_ms() at the time of first access of a block in buf_pool
   @retval 0 if not accessed */
-  unsigned is_accessed() const { ut_ad(in_file()); return access_time; }
+  unsigned is_accessed() const noexcept
+  { ut_ad(in_file()); return access_time; }
 };
 
 /** The buffer control block structure */
@@ -999,21 +1003,22 @@ struct buf_block_t{
 # define assert_block_ahi_empty_on_init(block) /* nothing */
 # define assert_block_ahi_valid(block) /* nothing */
 #endif /* BTR_CUR_HASH_ADAPT */
-  void fix() { page.fix(); }
-  uint32_t unfix() { return page.unfix(); }
+  void fix() noexcept { page.fix(); }
+  uint32_t unfix() noexcept { return page.unfix(); }
 
   /** @return the physical size, in bytes */
-  ulint physical_size() const { return page.physical_size(); }
+  ulint physical_size() const noexcept { return page.physical_size(); }
 
   /** @return the ROW_FORMAT=COMPRESSED physical size, in bytes
   @retval 0 if not compressed */
-  ulint zip_size() const { return page.zip_size(); }
+  ulint zip_size() const noexcept { return page.zip_size(); }
 
   /** Initialize the block.
   @param page_id  page identifier
   @param zip_size ROW_FORMAT=COMPRESSED page size, or 0
   @param state    initial state() */
-  void initialise(const page_id_t page_id, ulint zip_size, uint32_t state);
+  void initialise(const page_id_t page_id, ulint zip_size, uint32_t state)
+    noexcept;
 };
 
 /**********************************************************************//**
@@ -1034,11 +1039,12 @@ public:
   virtual ~HazardPointer() = default;
 
   /** @return current value */
-  buf_page_t *get() const { mysql_mutex_assert_owner(m_mutex); return m_hp; }
+  buf_page_t *get() const noexcept
+  { mysql_mutex_assert_owner(m_mutex); return m_hp; }
 
   /** Set current value
   @param bpage buffer block to be set as hp */
-  void set(buf_page_t *bpage)
+  void set(buf_page_t *bpage) noexcept
   {
     mysql_mutex_assert_owner(m_mutex);
     ut_ad(!bpage || bpage->in_file());
@@ -1048,13 +1054,13 @@ public:
   /** Checks if a bpage is the hp
   @param bpage  buffer block to be compared
   @return true if it is hp */
-  bool is_hp(const buf_page_t *bpage) const
+  bool is_hp(const buf_page_t *bpage) const noexcept
   { mysql_mutex_assert_owner(m_mutex); return bpage == m_hp; }
 
   /** Adjust the value of hp. This happens when some
   other thread working on the same list attempts to
   remove the hp from the list. */
-  virtual void adjust(const buf_page_t*) = 0;
+  virtual void adjust(const buf_page_t*) noexcept = 0;
 
 #ifdef UNIV_DEBUG
   /** mutex that protects access to the m_hp. */
@@ -1077,7 +1083,7 @@ public:
   remove the hp from the list.
   @param bpage  buffer block to be compared */
   MY_ATTRIBUTE((nonnull))
-  void adjust(const buf_page_t *bpage) override
+  void adjust(const buf_page_t *bpage) noexcept override
   {
     /* We only support reverse traversal for now. */
     if (is_hp(bpage))
@@ -1097,7 +1103,7 @@ public:
   remove the hp from the list.
   @param bpage  buffer block to be compared */
   MY_ATTRIBUTE((nonnull))
-  void adjust(const buf_page_t *bpage) override
+  void adjust(const buf_page_t *bpage) noexcept override
   {
     /** We only support reverse traversal for now. */
     if (is_hp(bpage))
@@ -1119,7 +1125,7 @@ public:
   too deep into the LRU list it resets the value to the tail
   of the LRU list.
   @return buf_page_t from where to start scan. */
-  inline buf_page_t *start();
+  inline buf_page_t *start() noexcept;
 };
 
 /** Struct that is embedded in the free zip blocks */
@@ -1146,7 +1152,7 @@ struct buf_buddy_free_t {
 protected by buf_pool.mutex unless otherwise noted. */
 struct buf_pool_stat_t{
 	/** Initialize the counters */
-	void init() { memset((void*) this, 0, sizeof *this); }
+	void init() noexcept { memset((void*) this, 0, sizeof *this); }
 
 	ib_counter_t<ulint, ib_counter_element_t>	n_page_gets;
 				/*!< number of page gets performed;
@@ -1210,22 +1216,23 @@ class buf_pool_t
     static map *map_ref;
 
     /** @return the memory size bytes. */
-    size_t mem_size() const { return mem_pfx.m_size; }
+    size_t mem_size() const noexcept { return mem_pfx.m_size; }
 
     /** Register the chunk */
-    void reg() { map_reg->emplace(map::value_type(blocks->page.frame, this)); }
+    void reg() noexcept
+    { map_reg->emplace(map::value_type(blocks->page.frame, this)); }
 
     /** Allocate a chunk of buffer frames.
     @param bytes    requested size
     @return whether the allocation succeeded */
-    inline bool create(size_t bytes);
+    inline bool create(size_t bytes) noexcept;
 
 #ifdef UNIV_DEBUG
     /** Find a block that points to a ROW_FORMAT=COMPRESSED page
     @param data  pointer to the start of a ROW_FORMAT=COMPRESSED page frame
     @return the block
     @retval nullptr  if not found */
-    const buf_block_t *contains_zip(const void *data) const
+    const buf_block_t *contains_zip(const void *data) const noexcept
     {
       const buf_block_t *block= blocks;
       for (auto i= size; i--; block++)
@@ -1237,7 +1244,7 @@ class buf_pool_t
     /** Check that all blocks are in a replaceable state.
     @return address of a non-free block
     @retval nullptr if all freed */
-    inline const buf_block_t *not_freed() const;
+    inline const buf_block_t *not_freed() const noexcept;
 #endif /* UNIV_DEBUG */
   };
 public:
@@ -1250,13 +1257,13 @@ public:
 private:
   /** Withdraw blocks from the buffer pool until meeting withdraw_target.
   @return whether retry is needed */
-  inline bool withdraw_blocks();
+  inline bool withdraw_blocks() noexcept;
 
   /** Determine if a pointer belongs to a buf_block_t. It can be a pointer to
   the buf_block_t itself or a member of it.
   @param ptr    a pointer that will not be dereferenced
   @return whether the ptr belongs to a buf_block_t struct */
-  bool is_block_field(const void *ptr) const
+  bool is_block_field(const void *ptr) const noexcept
   {
     const chunk_t *chunk= chunks;
     const chunk_t *const echunk= chunk + ut_min(n_chunks, n_chunks_new);
@@ -1273,29 +1280,29 @@ private:
   /** Try to reallocate a control block.
   @param block  control block to reallocate
   @return whether the reallocation succeeded */
-  inline bool realloc(buf_block_t *block);
+  inline bool realloc(buf_block_t *block) noexcept;
 
 public:
-  bool is_initialised() const { return chunks != nullptr; }
+  bool is_initialised() const noexcept { return chunks != nullptr; }
 
   /** Create the buffer pool.
   @return whether the creation failed */
   bool create();
 
   /** Clean up after successful create() */
-  void close();
+  void close() noexcept;
 
   /** Resize from srv_buf_pool_old_size to srv_buf_pool_size. */
   inline void resize();
 
   /** @return whether resize() is in progress */
-  bool resize_in_progress() const
+  bool resize_in_progress() const noexcept
   {
     return UNIV_UNLIKELY(resizing.load(std::memory_order_relaxed));
   }
 
   /** @return the current size in blocks */
-  size_t get_n_pages() const
+  size_t get_n_pages() const noexcept
   {
     ut_ad(is_initialised());
     size_t size= 0;
@@ -1307,7 +1314,7 @@ public:
   /** Determine whether a frame is intended to be withdrawn during resize().
   @param ptr    pointer within a buf_page_t::frame
   @return whether the frame will be withdrawn */
-  bool will_be_withdrawn(const byte *ptr) const
+  bool will_be_withdrawn(const byte *ptr) const noexcept
   {
     ut_ad(n_chunks_new < n_chunks);
 #ifdef SAFE_MUTEX
@@ -1327,7 +1334,7 @@ public:
   /** Determine whether a block is intended to be withdrawn during resize().
   @param bpage  buffer pool block
   @return whether the frame will be withdrawn */
-  bool will_be_withdrawn(const buf_page_t &bpage) const
+  bool will_be_withdrawn(const buf_page_t &bpage) const noexcept
   {
     ut_ad(n_chunks_new < n_chunks);
 #ifdef SAFE_MUTEX
@@ -1358,7 +1365,7 @@ public:
   @param data  pointer to the start of a ROW_FORMAT=COMPRESSED page frame
   @return the block
   @retval nullptr  if not found */
-  const buf_block_t *contains_zip(const void *data) const
+  const buf_block_t *contains_zip(const void *data) const noexcept
   {
     mysql_mutex_assert_owner(&mutex);
     for (const chunk_t *chunk= chunks, * const end= chunks + n_chunks;
@@ -1369,24 +1376,24 @@ public:
   }
 
   /** Assert that all buffer pool pages are in a replaceable state */
-  void assert_all_freed();
+  void assert_all_freed() noexcept;
 #endif /* UNIV_DEBUG */
 
 #ifdef BTR_CUR_HASH_ADAPT
   /** Clear the adaptive hash index on all pages in the buffer pool. */
-  inline void clear_hash_index();
+  inline void clear_hash_index() noexcept;
 
   /** Get a buffer block from an adaptive hash index pointer.
   This function does not return if the block is not identified.
   @param ptr  pointer to within a page frame
   @return pointer to block, never NULL */
-  inline buf_block_t *block_from_ahi(const byte *ptr) const;
+  inline buf_block_t *block_from_ahi(const byte *ptr) const noexcept;
 #endif /* BTR_CUR_HASH_ADAPT */
 
   /**
   @return the smallest oldest_modification lsn for any page
   @retval empty_lsn if all modified persistent pages have been flushed */
-  lsn_t get_oldest_modification(lsn_t empty_lsn)
+  lsn_t get_oldest_modification(lsn_t empty_lsn) noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
     while (buf_page_t *bpage= UT_LIST_GET_LAST(flush_list))
@@ -1406,7 +1413,7 @@ public:
   /** Determine if a buffer block was created by chunk_t::create().
   @param block  block descriptor (not dereferenced)
   @return whether block has been created by chunk_t::create() */
-  bool is_uncompressed(const buf_block_t *block) const
+  bool is_uncompressed(const buf_block_t *block) const noexcept
   {
     return is_block_field(reinterpret_cast<const void*>(block));
   }
@@ -1436,11 +1443,10 @@ public:
   @retval -1       if c=FIX_NOWAIT and buffer-fixing would require waiting
   @retval nullptr  if the undo page was corrupted or freed */
   buf_block_t *page_fix(const page_id_t id, dberr_t *err,
-                        page_fix_conflicts c);
+                        page_fix_conflicts c) noexcept;
 
-  buf_block_t *page_fix(const page_id_t id)
+  buf_block_t *page_fix(const page_id_t id) noexcept
   { return page_fix(id, nullptr, FIX_WAIT_READ); }
-
 
   /** Decompress a page and relocate the block descriptor
   @param b      buffer-fixed compressed-only ROW_FORMAT=COMPRESSED page
@@ -1448,7 +1454,7 @@ public:
   @return the decompressed block, x-latched and read-fixed
   @retval nullptr if the decompression failed (b->unfix() will be invoked) */
   ATTRIBUTE_COLD __attribute__((nonnull, warn_unused_result))
-  buf_block_t *unzip(buf_page_t *b, hash_chain &chain);
+  buf_block_t *unzip(buf_page_t *b, hash_chain &chain) noexcept;
 
   /** @return whether the buffer pool contains a page
   @tparam allow_watch  whether to allow watch_is_sentinel()
@@ -1456,7 +1462,7 @@ public:
   @param chain         hash table chain for page_id.fold() */
   template<bool allow_watch= false>
   TRANSACTIONAL_INLINE
-  bool page_hash_contains(const page_id_t page_id, hash_chain &chain)
+  bool page_hash_contains(const page_id_t page_id, hash_chain &chain) noexcept
   {
     transactional_shared_lock_guard<page_hash_latch> g
       {page_hash.lock_get(chain)};
@@ -1474,7 +1480,7 @@ public:
   /** Determine if a block is a sentinel for a buffer pool watch.
   @param bpage page descriptor
   @return whether bpage a sentinel for a buffer pool watch */
-  bool watch_is_sentinel(const buf_page_t &bpage)
+  bool watch_is_sentinel(const buf_page_t &bpage) noexcept
   {
 #ifdef SAFE_MUTEX
     DBUG_ASSERT(mysql_mutex_is_owner(&mutex) ||
@@ -1494,7 +1500,7 @@ public:
   @param id   page identifier
   @return whether the page was read to the buffer pool */
   TRANSACTIONAL_INLINE
-  bool watch_occurred(const page_id_t id)
+  bool watch_occurred(const page_id_t id) noexcept
   {
     hash_chain &chain= page_hash.cell_get(id.fold());
     transactional_shared_lock_guard<page_hash_latch> g
@@ -1508,13 +1514,13 @@ public:
   @param chain      page_hash.cell_get(id.fold())
   @return a buffer page corresponding to id
   @retval nullptr   if the block was not present in page_hash */
-  buf_page_t *watch_set(const page_id_t id, hash_chain &chain);
+  buf_page_t *watch_set(const page_id_t id, hash_chain &chain) noexcept;
 
   /** Stop watching whether a page has been read in.
   watch_set(id) must have returned nullptr before.
   @param id         page identifier
   @param chain      unlocked hash table chain */
-  void watch_unset(const page_id_t id, hash_chain &chain);
+  void watch_unset(const page_id_t id, hash_chain &chain) noexcept;
 
   /** Remove the sentinel block for the watch before replacing it with a
   real block. watch_unset() or watch_occurred() will notice
@@ -1522,11 +1528,11 @@ public:
   @param w          sentinel
   @param chain      locked hash table chain
   @return           w->state() */
-  inline uint32_t watch_remove(buf_page_t *w, hash_chain &chain);
+  inline uint32_t watch_remove(buf_page_t *w, hash_chain &chain) noexcept;
 
   /** @return whether less than 1/4 of the buffer pool is available */
   TPOOL_SUPPRESS_TSAN
-  bool running_out() const
+  bool running_out() const noexcept
   {
     return !recv_recovery_is_on() &&
       UT_LIST_GET_LEN(free) + UT_LIST_GET_LEN(LRU) <
@@ -1534,26 +1540,26 @@ public:
   }
 
   /** @return whether the buffer pool is running low */
-  bool need_LRU_eviction() const;
+  bool need_LRU_eviction() const noexcept;
 
   /** @return whether the buffer pool is shrinking */
-  inline bool is_shrinking() const
+  inline bool is_shrinking() const noexcept
   {
     return n_chunks_new < n_chunks;
   }
 
 #ifdef UNIV_DEBUG
   /** Validate the buffer pool. */
-  void validate();
+  void validate() noexcept;
 #endif /* UNIV_DEBUG */
 #if defined UNIV_DEBUG_PRINT || defined UNIV_DEBUG
   /** Write information of the buf_pool to the error log. */
-  void print();
+  void print() noexcept;
 #endif /* UNIV_DEBUG_PRINT || UNIV_DEBUG */
 
   /** Remove a block from the LRU list.
   @return the predecessor in the LRU list */
-  buf_page_t *LRU_remove(buf_page_t *bpage)
+  buf_page_t *LRU_remove(buf_page_t *bpage) noexcept
   {
     mysql_mutex_assert_owner(&mutex);
     ut_ad(bpage->in_LRU_list);
@@ -1621,15 +1627,16 @@ public:
 
     /** Create the hash table.
     @param n  the lower bound of n_cells */
-    void create(ulint n);
+    void create(ulint n) noexcept;
 
     /** Free the hash table. */
-    void free() { aligned_free(array); array= nullptr; }
+    void free() noexcept { aligned_free(array); array= nullptr; }
 
     /** @return the index of an array element */
-    ulint calc_hash(ulint fold) const { return calc_hash(fold, n_cells); }
+    ulint calc_hash(ulint fold) const noexcept
+    { return calc_hash(fold, n_cells); }
     /** @return raw array index converted to padded index */
-    static ulint pad(ulint h)
+    static ulint pad(ulint h) noexcept
     {
       ulint latches= h / ELEMENTS_PER_LATCH;
       ulint empty_slots= latches * EMPTY_SLOTS_PER_LATCH;
@@ -1643,7 +1650,7 @@ public:
     }
   public:
     /** @return the latch covering a hash table chain */
-    static page_hash_latch &lock_get(hash_chain &chain)
+    static page_hash_latch &lock_get(hash_chain &chain) noexcept
     {
       static_assert(!((ELEMENTS_PER_LATCH + 1) & ELEMENTS_PER_LATCH),
                     "must be one less than a power of 2");
@@ -1658,7 +1665,7 @@ public:
     { return array[calc_hash(fold, n_cells)]; }
 
     /** Append a block descriptor to a hash bucket chain. */
-    void append(hash_chain &chain, buf_page_t *bpage)
+    void append(hash_chain &chain, buf_page_t *bpage) noexcept
     {
       ut_ad(!bpage->in_page_hash);
       ut_ad(!bpage->hash);
@@ -1673,7 +1680,7 @@ public:
     }
 
     /** Remove a block descriptor from a hash bucket chain. */
-    void remove(hash_chain &chain, buf_page_t *bpage)
+    void remove(hash_chain &chain, buf_page_t *bpage) noexcept
     {
       ut_ad(bpage->in_page_hash);
       buf_page_t **prev= &chain.first;
@@ -1689,6 +1696,7 @@ public:
 
     /** Replace a block descriptor with another. */
     void replace(hash_chain &chain, buf_page_t *old, buf_page_t *bpage)
+      noexcept
     {
       ut_ad(old->in_page_hash);
       ut_ad(bpage->in_page_hash);
@@ -1705,13 +1713,14 @@ public:
     }
 
     /** Look up a page in a hash bucket chain. */
-    inline buf_page_t *get(const page_id_t id, const hash_chain &chain) const;
+    inline buf_page_t *get(const page_id_t id, const hash_chain &chain) const
+      noexcept;
 
     /** Exclusively aqcuire all latches */
-    inline void write_lock_all();
+    inline void write_lock_all() noexcept;
 
     /** Release all latches */
-    inline void write_unlock_all();
+    inline void write_unlock_all() noexcept;
   };
 
   /** Buffer pool mutex */
@@ -1778,45 +1787,45 @@ public:
   pthread_cond_t done_flush_list;
 
   /** @return number of pending LRU flush */
-  unsigned n_flush() const
+  unsigned n_flush() const noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
     return page_cleaner_status / LRU_FLUSH;
   }
 
   /** Increment the number of pending LRU flush */
-  inline void n_flush_inc();
+  inline void n_flush_inc() noexcept;
 
   /** Decrement the number of pending LRU flush */
-  inline void n_flush_dec();
+  inline void n_flush_dec() noexcept;
 
   /** @return whether flush_list flushing is active */
-  bool flush_list_active() const
+  bool flush_list_active() const noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
     return page_cleaner_status & FLUSH_LIST_ACTIVE;
   }
 
-  void flush_list_set_active()
+  void flush_list_set_active() noexcept
   {
     ut_ad(!flush_list_active());
     page_cleaner_status+= FLUSH_LIST_ACTIVE;
   }
-  void flush_list_set_inactive()
+  void flush_list_set_inactive() noexcept
   {
     ut_ad(flush_list_active());
     page_cleaner_status-= FLUSH_LIST_ACTIVE;
   }
 
   /** @return whether the page cleaner must sleep due to being idle */
-  bool page_cleaner_idle() const
+  bool page_cleaner_idle() const noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
     return page_cleaner_status & PAGE_CLEANER_IDLE;
   }
 
   /** @return whether the page cleaner may be initiating writes */
-  bool page_cleaner_active() const
+  bool page_cleaner_active() const noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
     static_assert(PAGE_CLEANER_IDLE == 1, "efficiency");
@@ -1825,10 +1834,10 @@ public:
 
   /** Wake up the page cleaner if needed.
   @param for_LRU  whether to wake up for LRU eviction */
-  void page_cleaner_wakeup(bool for_LRU= false);
+  void page_cleaner_wakeup(bool for_LRU= false) noexcept;
 
   /** Register whether an explicit wakeup of the page cleaner is needed */
-  void page_cleaner_set_idle(bool deep_sleep)
+  void page_cleaner_set_idle(bool deep_sleep) noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
     page_cleaner_status= (page_cleaner_status & ~PAGE_CLEANER_IDLE) |
@@ -1836,7 +1845,7 @@ public:
   }
 
   /** Update server last activity count */
-  void update_last_activity_count(ulint activity_count)
+  void update_last_activity_count(ulint activity_count) noexcept
   {
     mysql_mutex_assert_owner(&flush_list_mutex);
     last_activity_count= activity_count;
@@ -1920,27 +1929,27 @@ public:
   a delete-buffering operation is pending. Protected by mutex. */
   buf_page_t watch[innodb_purge_threads_MAX + 1];
   /** Reserve a buffer. */
-  buf_tmp_buffer_t *io_buf_reserve(bool wait_for_reads)
+  buf_tmp_buffer_t *io_buf_reserve(bool wait_for_reads) noexcept
   { return io_buf.reserve(wait_for_reads); }
 
 private:
   /** Remove a block from the flush list. */
-  inline void delete_from_flush_list_low(buf_page_t *bpage);
+  inline void delete_from_flush_list_low(buf_page_t *bpage) noexcept;
 public:
   /** Remove a block from flush_list.
   @param bpage   buffer pool page */
-  void delete_from_flush_list(buf_page_t *bpage);
+  void delete_from_flush_list(buf_page_t *bpage) noexcept;
 
   /** Insert a modified block into the flush list.
   @param block    modified block
   @param lsn      start LSN of the mini-transaction that modified the block */
-  void insert_into_flush_list(buf_block_t *block, lsn_t lsn);
+  void insert_into_flush_list(buf_block_t *block, lsn_t lsn) noexcept;
 
   /** Free a page whose underlying file page has been freed. */
-  ATTRIBUTE_COLD void release_freed_page(buf_page_t *bpage);
+  ATTRIBUTE_COLD void release_freed_page(buf_page_t *bpage) noexcept;
 
   /** Issue a warning that we could not free up buffer pool pages. */
-  ATTRIBUTE_COLD void LRU_warn();
+  ATTRIBUTE_COLD void LRU_warn() noexcept;
 
 private:
   /** Temporary memory for page_compressed and encrypted I/O */
@@ -1951,12 +1960,12 @@ private:
     /** array of slots */
     buf_tmp_buffer_t *slots;
 
-    void create(ulint n_slots);
+    void create(ulint n_slots) noexcept;
 
-    void close();
+    void close() noexcept;
 
     /** Reserve a buffer */
-    buf_tmp_buffer_t *reserve(bool wait_for_reads);
+    buf_tmp_buffer_t *reserve(bool wait_for_reads) noexcept;
   } io_buf;
 
   /** whether resize() is in the critical path */
@@ -1968,7 +1977,7 @@ extern buf_pool_t buf_pool;
 
 inline buf_page_t *buf_pool_t::page_hash_table::get(const page_id_t id,
                                                     const hash_chain &chain)
-  const
+  const noexcept
 {
 #ifdef SAFE_MUTEX
   DBUG_ASSERT(mysql_mutex_is_owner(&buf_pool.mutex) ||
@@ -1985,21 +1994,21 @@ inline buf_page_t *buf_pool_t::page_hash_table::get(const page_id_t id,
 }
 
 #ifdef SUX_LOCK_GENERIC
-inline void page_hash_latch::lock_shared()
+inline void page_hash_latch::lock_shared() noexcept
 {
   mysql_mutex_assert_not_owner(&buf_pool.mutex);
   if (!read_trylock())
     read_lock_wait();
 }
 
-inline void page_hash_latch::lock()
+inline void page_hash_latch::lock() noexcept
 {
   if (!write_trylock())
     write_lock_wait();
 }
 #endif /* SUX_LOCK_GENERIC */
 
-inline void buf_page_t::set_state(uint32_t s)
+inline void buf_page_t::set_state(uint32_t s) noexcept
 {
   mysql_mutex_assert_owner(&buf_pool.mutex);
   ut_ad(s <= REMOVE_HASH || s >= UNFIXED);
@@ -2008,7 +2017,7 @@ inline void buf_page_t::set_state(uint32_t s)
   zip.fix= s;
 }
 
-inline void buf_page_t::set_corrupt_id()
+inline void buf_page_t::set_corrupt_id() noexcept
 {
 #ifdef UNIV_DEBUG
   switch (oldest_modification()) {
@@ -2034,7 +2043,7 @@ inline void buf_page_t::set_corrupt_id()
 }
 
 /** Set oldest_modification when adding to buf_pool.flush_list */
-inline void buf_page_t::set_oldest_modification(lsn_t lsn)
+inline void buf_page_t::set_oldest_modification(lsn_t lsn) noexcept
 {
   mysql_mutex_assert_owner(&buf_pool.flush_list_mutex);
   ut_ad(oldest_modification() <= 1);
@@ -2043,7 +2052,7 @@ inline void buf_page_t::set_oldest_modification(lsn_t lsn)
 }
 
 /** Clear oldest_modification after removing from buf_pool.flush_list */
-inline void buf_page_t::clear_oldest_modification()
+inline void buf_page_t::clear_oldest_modification() noexcept
 {
 #ifdef SAFE_MUTEX
   if (oldest_modification() != 2)
@@ -2062,7 +2071,7 @@ inline void buf_page_t::clear_oldest_modification()
 
 /** @return whether the block can be relocated in memory.
 The block can be dirty, but it must not be I/O-fixed or bufferfixed. */
-inline bool buf_page_t::can_relocate() const
+inline bool buf_page_t::can_relocate() const noexcept
 {
   mysql_mutex_assert_owner(&buf_pool.mutex);
   const auto f= state();
@@ -2073,7 +2082,7 @@ inline bool buf_page_t::can_relocate() const
 }
 
 /** @return whether the block has been flagged old in buf_pool.LRU */
-inline bool buf_page_t::is_old() const
+inline bool buf_page_t::is_old() const noexcept
 {
   mysql_mutex_assert_owner(&buf_pool.mutex);
   ut_ad(in_file());
@@ -2082,7 +2091,7 @@ inline bool buf_page_t::is_old() const
 }
 
 /** Set whether a block is old in buf_pool.LRU */
-inline void buf_page_t::set_old(bool old)
+inline void buf_page_t::set_old(bool old) noexcept
 {
   mysql_mutex_assert_owner(&buf_pool.mutex);
   ut_ad(in_LRU_list);
@@ -2156,7 +2165,7 @@ REMOVE_HASH => NOT_USED	(if and only if !oldest_modification())
 too deep into the LRU list it resets the value to the tail
 of the LRU list.
 @return buf_page_t from where to start scan. */
-inline buf_page_t *LRUItr::start()
+inline buf_page_t *LRUItr::start() noexcept
 {
   mysql_mutex_assert_owner(m_mutex);
 
@@ -2169,12 +2178,12 @@ inline buf_page_t *LRUItr::start()
 #ifdef UNIV_DEBUG
 /** Functor to validate the LRU list. */
 struct	CheckInLRUList {
-	void	operator()(const buf_page_t* elem) const
+	void	operator()(const buf_page_t* elem) const noexcept
 	{
 		ut_a(elem->in_LRU_list);
 	}
 
-	static void validate()
+	static void validate() noexcept
 	{
 		ut_list_validate(buf_pool.LRU, CheckInLRUList());
 	}
@@ -2182,25 +2191,25 @@ struct	CheckInLRUList {
 
 /** Functor to validate the LRU list. */
 struct	CheckInFreeList {
-	void	operator()(const buf_page_t* elem) const
+	void	operator()(const buf_page_t* elem) const noexcept
 	{
 		ut_a(elem->in_free_list);
 	}
 
-	static void validate()
+	static void validate() noexcept
 	{
 		ut_list_validate(buf_pool.free, CheckInFreeList());
 	}
 };
 
 struct	CheckUnzipLRUAndLRUList {
-	void	operator()(const buf_block_t* elem) const
+	void	operator()(const buf_block_t* elem) const noexcept
 	{
                 ut_a(elem->page.in_LRU_list);
                 ut_a(elem->in_unzip_LRU_list);
 	}
 
-	static void validate()
+	static void validate() noexcept
 	{
 		ut_list_validate(buf_pool.unzip_LRU,
 				 CheckUnzipLRUAndLRUList());

--- a/storage/innobase/include/buf0dblwr.h
+++ b/storage/innobase/include/buf0dblwr.h
@@ -76,30 +76,30 @@ class buf_dblwr_t
 
   /** Initialise the persistent storage of the doublewrite buffer.
   @param header   doublewrite page header in the TRX_SYS page */
-  inline void init(const byte *header);
+  inline void init(const byte *header) noexcept;
 
   /** Flush possible buffered writes to persistent storage. */
-  bool flush_buffered_writes(const ulint size);
+  bool flush_buffered_writes(const ulint size) noexcept;
 
 public:
   /** Initialise the doublewrite buffer data structures. */
-  void init();
+  void init() noexcept;
   /** Create or restore the doublewrite buffer in the TRX_SYS page.
   @return whether the operation succeeded */
-  bool create();
+  bool create() noexcept;
   /** Free the doublewrite buffer. */
-  void close();
+  void close() noexcept;
 
   /** Acquire the mutex */
-  void lock() { mysql_mutex_lock(&mutex); }
+  void lock() noexcept { mysql_mutex_lock(&mutex); }
   /** @return the number of completed batches */
-  ulint batches() const
+  ulint batches() const noexcept
   { mysql_mutex_assert_owner(&mutex); return writes_completed; }
   /** @return the number of final pages written */
-  ulint written() const
+  ulint written() const noexcept
   { mysql_mutex_assert_owner(&mutex); return pages_written; }
   /** Release the mutex */
-  void unlock() { mysql_mutex_unlock(&mutex); }
+  void unlock() noexcept { mysql_mutex_unlock(&mutex); }
 
   /** Initialize the doublewrite buffer memory structure on recovery.
   If we are upgrading from a version before MySQL 4.1, then this
@@ -110,37 +110,37 @@ public:
   @param file File handle
   @param path Path name of file
   @return DB_SUCCESS or error code */
-  dberr_t init_or_load_pages(pfs_os_file_t file, const char *path);
+  dberr_t init_or_load_pages(pfs_os_file_t file, const char *path) noexcept;
 
   /** Process and remove the double write buffer pages for all tablespaces. */
-  void recover();
+  void recover() noexcept;
 
   /** Update the doublewrite buffer on data page write completion. */
-  void write_completed();
+  void write_completed() noexcept;
   /** Flush possible buffered writes to persistent storage.
   It is very important to call this function after a batch of writes has been
   posted, and also when we may have to wait for a page latch!
   Otherwise a deadlock of threads can occur. */
-  void flush_buffered_writes();
+  void flush_buffered_writes() noexcept;
   /** Update the doublewrite buffer on write batch completion
   @param request  the completed batch write request */
-  void flush_buffered_writes_completed(const IORequest &request);
+  void flush_buffered_writes_completed(const IORequest &request) noexcept;
 
   /** Size of the doublewrite block in pages */
-  uint32_t block_size() const { return FSP_EXTENT_SIZE; }
+  uint32_t block_size() const noexcept { return FSP_EXTENT_SIZE; }
 
   /** Schedule a page write. If the doublewrite memory buffer is full,
   flush_buffered_writes() will be invoked to make space.
   @param request    asynchronous write request
   @param size       payload size in bytes */
-  void add_to_batch(const IORequest &request, size_t size);
+  void add_to_batch(const IORequest &request, size_t size) noexcept;
 
   /** Determine whether the doublewrite buffer has been created */
-  bool is_created() const
+  bool is_created() const noexcept
   { return UNIV_LIKELY(block1 != page_id_t(0, 0)); }
 
   /** @return whether a page identifier is part of the doublewrite buffer */
-  bool is_inside(const page_id_t id) const
+  bool is_inside(const page_id_t id) const noexcept
   {
     if (!is_created())
       return false;
@@ -152,7 +152,7 @@ public:
   }
 
   /** Wait for flush_buffered_writes() to be fully completed */
-  void wait_flush_buffered_writes()
+  void wait_flush_buffered_writes() noexcept
   {
     mysql_mutex_lock(&mutex);
     while (batch_running)

--- a/storage/innobase/include/buf0flu.h
+++ b/storage/innobase/include/buf0flu.h
@@ -44,27 +44,22 @@ deleting the data file of that tablespace.
 The pages still remain a part of LRU and are evicted from
 the list as they age towards the tail of the LRU.
 @param id    tablespace identifier */
-void buf_flush_remove_pages(ulint id);
+void buf_flush_remove_pages(ulint id) noexcept;
 
-/*******************************************************************//**
-Relocates a buffer control block on the flush_list.
-Note that it is assumed that the contents of bpage has already been
-copied to dpage. */
+/** Relocate a buffer control block in buf_pool.flush_list.
+@param bpage   control block being moved
+@param dpage   destination block; the page contents has already been copied */
 ATTRIBUTE_COLD
-void
-buf_flush_relocate_on_flush_list(
-/*=============================*/
-	buf_page_t*	bpage,	/*!< in/out: control block being moved */
-	buf_page_t*	dpage);	/*!< in/out: destination block */
-
+void buf_flush_relocate_on_flush_list(buf_page_t *bpage, buf_page_t *dpage)
+  noexcept;
 /** Complete write of a file page from buf_pool.
 @param request write request
 @param error   whether the write may have failed */
-void buf_page_write_complete(const IORequest &request, bool error);
+void buf_page_write_complete(const IORequest &request, bool error) noexcept;
 
 /** Assign the full crc32 checksum for non-compressed page.
 @param[in,out]	page	page to be updated */
-void buf_flush_assign_full_crc32_checksum(byte* page);
+void buf_flush_assign_full_crc32_checksum(byte* page) noexcept;
 
 /** Initialize a page for writing to the tablespace.
 @param[in]	block			buffer block; NULL if bypassing the buffer pool
@@ -76,30 +71,32 @@ buf_flush_init_for_writing(
 	const buf_block_t*	block,
 	byte*			page,
 	void*			page_zip_,
-	bool			use_full_checksum);
+	bool			use_full_checksum) noexcept;
 
 /** Try to flush dirty pages that belong to a given tablespace.
 @param space       tablespace
 @param n_flushed   number of pages written
 @return whether the flush for some pages might not have been initiated */
 bool buf_flush_list_space(fil_space_t *space, ulint *n_flushed= nullptr)
+  noexcept
   MY_ATTRIBUTE((warn_unused_result));
 
 /** Wait until a LRU flush batch ends. */
-void buf_flush_wait_LRU_batch_end();
+void buf_flush_wait_LRU_batch_end() noexcept;
 /** Wait until all persistent pages are flushed up to a limit.
 @param sync_lsn   buf_pool.get_oldest_modification(LSN_MAX) to wait for */
-ATTRIBUTE_COLD void buf_flush_wait_flushed(lsn_t sync_lsn);
+ATTRIBUTE_COLD void buf_flush_wait_flushed(lsn_t sync_lsn) noexcept;
 /** Initiate more eager page flushing if the log checkpoint age is too old.
 @param lsn      buf_pool.get_oldest_modification(LSN_MAX) target
 @param furious  true=furious flushing, false=limit to innodb_io_capacity */
-ATTRIBUTE_COLD void buf_flush_ahead(lsn_t lsn, bool furious);
+ATTRIBUTE_COLD void buf_flush_ahead(lsn_t lsn, bool furious) noexcept;
 
 /********************************************************************//**
 This function should be called at a mini-transaction commit, if a page was
 modified in it. Puts the block to the list of modified blocks, if it not
 already in it. */
 inline void buf_flush_note_modification(buf_block_t *b, lsn_t start, lsn_t end)
+  noexcept
 {
   ut_ad(!srv_read_only_mode);
   ut_d(const auto s= b->page.state());
@@ -121,20 +118,20 @@ inline void buf_flush_note_modification(buf_block_t *b, lsn_t start, lsn_t end)
 }
 
 /** Initialize page_cleaner. */
-ATTRIBUTE_COLD void buf_flush_page_cleaner_init();
+ATTRIBUTE_COLD void buf_flush_page_cleaner_init() noexcept;
 
 /** Flush the buffer pool on shutdown. */
-ATTRIBUTE_COLD void buf_flush_buffer_pool();
+ATTRIBUTE_COLD void buf_flush_buffer_pool() noexcept;
 
 #ifdef UNIV_DEBUG
 /** Validate the flush list. */
-void buf_flush_validate();
+void buf_flush_validate() noexcept;
 #endif /* UNIV_DEBUG */
 
 /** Synchronously flush dirty blocks during recv_sys_t::apply().
 NOTE: The calling thread is not allowed to hold any buffer page latches! */
-void buf_flush_sync_batch(lsn_t lsn);
+void buf_flush_sync_batch(lsn_t lsn) noexcept;
 
 /** Synchronously flush dirty blocks.
 NOTE: The calling thread is not allowed to hold any buffer page latches! */
-void buf_flush_sync();
+void buf_flush_sync() noexcept;

--- a/storage/innobase/include/buf0rea.h
+++ b/storage/innobase/include/buf0rea.h
@@ -39,7 +39,7 @@ will be invoked on read completion.
 @retval DB_DECRYPTION_FAILED if page post encryption checksum matches but
 after decryption normal page checksum does not match.
 @retval DB_TABLESPACE_DELETED if tablespace .ibd file is missing */
-dberr_t buf_read_page(const page_id_t page_id, bool unzip= true);
+dberr_t buf_read_page(const page_id_t page_id, bool unzip= true) noexcept;
 
 /** High-level function which reads a page asynchronously from a file to the
 buffer buf_pool if it is not already there. Sets the io_fix flag and sets
@@ -49,7 +49,7 @@ released by the i/o-handler thread.
 @param[in]	page_id		page id
 @param[in]	zip_size	ROW_FORMAT=COMPRESSED page size, or 0 */
 void buf_read_page_background(fil_space_t *space, const page_id_t page_id,
-                              ulint zip_size)
+                              ulint zip_size) noexcept
   MY_ATTRIBUTE((nonnull));
 
 /** Applies a random read-ahead in buf_pool if there are at least a threshold
@@ -67,7 +67,7 @@ wants to access
 @return number of page read requests issued; NOTE that if we read ibuf
 pages, it may happen that the page at the given page number does not
 get read even if we return a positive value! */
-ulint buf_read_ahead_random(const page_id_t page_id, bool ibuf);
+ulint buf_read_ahead_random(const page_id_t page_id, bool ibuf) noexcept;
 
 /** Applies linear read-ahead if in the buf_pool the page is a border page of
 a linear read-ahead area and all the pages in the area have been accessed.
@@ -95,7 +95,7 @@ which could result in a deadlock if the OS does not support asynchronous io.
 @param[in]	ibuf		whether if we are inside ibuf routine
 @return number of page read requests issued */
 ulint
-buf_read_ahead_linear(const page_id_t page_id, bool ibuf);
+buf_read_ahead_linear(const page_id_t page_id, bool ibuf) noexcept;
 
 /** Schedule a page for recovery.
 @param space    tablespace
@@ -103,7 +103,7 @@ buf_read_ahead_linear(const page_id_t page_id, bool ibuf);
 @param recs     log records
 @param init     page initialization, or nullptr if the page needs to be read */
 void buf_read_recover(fil_space_t *space, const page_id_t page_id,
-                      page_recv_t &recs, recv_init *init);
+                      page_recv_t &recs, recv_init *init) noexcept;
 
 /** @name Modes used in read-ahead @{ */
 /** read only pages belonging to the insert buffer tree */

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -211,19 +211,20 @@ public:
                       buf_tmp_buffer_t *slot= nullptr) :
     bpage(bpage), slot(slot), type(type) {}
 
-  bool is_read() const { return (type & READ_SYNC) != 0; }
-  bool is_write() const { return (type & WRITE_SYNC) != 0; }
-  bool is_async() const { return (type & (READ_SYNC ^ READ_ASYNC)) != 0; }
+  bool is_read() const noexcept { return (type & READ_SYNC) != 0; }
+  bool is_write() const noexcept { return (type & WRITE_SYNC) != 0; }
+  bool is_async() const noexcept
+  { return (type & (READ_SYNC ^ READ_ASYNC)) != 0; }
 
-  void write_complete(int io_error) const;
-  void read_complete(int io_error) const;
-  void fake_read_complete(os_offset_t offset) const;
+  void write_complete(int io_error) const noexcept;
+  void read_complete(int io_error) const noexcept;
+  void fake_read_complete(os_offset_t offset) const noexcept;
 
   /** If requested, free storage space associated with a section of the file.
   @param off   byte offset from the start (SEEK_SET)
   @param len   size of the hole in bytes
   @return DB_SUCCESS or error code */
-  dberr_t maybe_punch_hole(os_offset_t off, ulint len)
+  dberr_t maybe_punch_hole(os_offset_t off, ulint len) noexcept
   {
     return off && len && node && (type & (PUNCH ^ WRITE_ASYNC))
       ? punch_hole(off, len)
@@ -235,7 +236,7 @@ private:
   @param off   byte offset from the start (SEEK_SET)
   @param len   size of the hole in bytes
   @return DB_SUCCESS or error code */
-  dberr_t punch_hole(os_offset_t off, ulint len) const;
+  dberr_t punch_hole(os_offset_t off, ulint len) const noexcept;
 
 public:
   /** Page to be written on write operation */
@@ -318,8 +319,7 @@ struct os_file_stat_t {
 the temporary file is created in the in the mysql server configuration
 parameter (--tmpdir).
 @return temporary file handle, or NULL on error */
-FILE*
-os_file_create_tmpfile();
+FILE *os_file_create_tmpfile() noexcept;
 
 /**
 This function attempts to create a directory named pathname. The new directory
@@ -331,10 +331,8 @@ fail_if_exists arguments is true.
 @param[in]	fail_if_exists	if true, pre-existing directory is treated
 				as an error.
 @return true if call succeeds, false on error */
-bool
-os_file_create_directory(
-	const char*	pathname,
-	bool		fail_if_exists);
+bool os_file_create_directory(const char *pathname, bool fail_if_exists)
+  noexcept;
 
 /** NOTE! Use the corresponding macro os_file_create_simple(), not directly
 this function!
@@ -353,7 +351,7 @@ os_file_create_simple_func(
 	ulint		create_mode,
 	ulint		access_type,
 	bool		read_only,
-	bool*		success);
+	bool*		success) noexcept;
 
 /** NOTE! Use the corresponding macro
 os_file_create_simple_no_error_handling(), not directly this function!
@@ -373,7 +371,7 @@ os_file_create_simple_no_error_handling_func(
 	ulint		create_mode,
 	ulint		access_type,
 	bool		read_only,
-	bool*		success)
+	bool*		success) noexcept
 	MY_ATTRIBUTE((warn_unused_result));
 
 #ifndef HAVE_FCNTL_DIRECT
@@ -389,7 +387,7 @@ os_file_set_nocache(
 /*================*/
 	int	fd,		/*!< in: file descriptor to alter */
 	const char*	file_name,
-	const char*	operation_name);
+	const char*	operation_name) noexcept;
 #endif
 
 #ifndef _WIN32 /* On Microsoft Windows, mandatory locking is used */
@@ -397,7 +395,7 @@ os_file_set_nocache(
 @param fd      file descriptor
 @param name    file name
 @return 0 on success */
-int os_file_lock(int fd, const char *name);
+int os_file_lock(int fd, const char *name) noexcept;
 #endif
 
 /** NOTE! Use the corresponding macro os_file_create(), not directly
@@ -417,7 +415,7 @@ os_file_create_func(
 	ulint		create_mode,
 	ulint		type,
 	bool		read_only,
-	bool*		success)
+	bool*		success) noexcept
 	MY_ATTRIBUTE((warn_unused_result));
 
 /** Deletes a file. The file has to be closed before calling this.
@@ -859,9 +857,7 @@ to original un-instrumented file I/O APIs */
 @param[in]	file		handle to a file
 @return file size if OK, else set m_total_size to ~0 and m_alloc_size
 	to errno */
-os_file_size_t
-os_file_get_size(
-	const char*	filename)
+os_file_size_t os_file_get_size(const char *filename) noexcept
 	MY_ATTRIBUTE((warn_unused_result));
 
 /** Determine the logical size of a file.
@@ -876,9 +872,7 @@ os_offset_t os_file_get_size(os_file_t file) noexcept
 /** Truncates a file at its current position.
 @param[in/out]	file	file to be truncated
 @return true if success */
-bool
-os_file_set_eof(
-	FILE*		file);	/*!< in: file to be truncated */
+bool os_file_set_eof(FILE *file) noexcept;
 
 /** Truncate a file to a specified size in bytes.
 @param[in]	pathname	file path
@@ -891,16 +885,14 @@ os_file_truncate(
 	const char*	pathname,
 	os_file_t	file,
 	os_offset_t	size,
-	bool		allow_shrink = false);
+	bool		allow_shrink = false) noexcept;
 
 /** NOTE! Use the corresponding macro os_file_flush(), not directly this
 function!
 Flushes the write buffers of a given file to the disk.
 @param[in]	file		handle to a file
 @return true if success */
-bool
-os_file_flush_func(
-	os_file_t	file);
+bool os_file_flush_func(os_file_t file) noexcept;
 
 /** Retrieves the last error number if an error occurs in a file io function.
 The number should be retrieved before any other OS calls (because they may
@@ -912,7 +904,7 @@ the OS error number + OS_FILE_ERROR_MAX is returned.
                                         to the log
 @return error number, or OS error number + OS_FILE_ERROR_MAX */
 ulint os_file_get_last_error(bool report_all_errors,
-                             bool on_error_silent= false);
+                             bool on_error_silent= false) noexcept;
 
 /** NOTE! Use the corresponding macro os_file_read(), not directly this
 function!
@@ -931,7 +923,7 @@ os_file_read_func(
 	void*			buf,
 	os_offset_t		offset,
 	ulint			n,
-	ulint*			o)
+	ulint*			o) noexcept
 	MY_ATTRIBUTE((warn_unused_result));
 
 /** Rewind file to its start, read at most size - 1 bytes from it to str, and
@@ -944,7 +936,7 @@ void
 os_file_read_string(
 	FILE*		file,
 	char*		str,
-	ulint		size);
+	ulint		size) noexcept;
 
 /** NOTE! Use the corresponding macro os_file_write(), not directly this
 function!
@@ -974,7 +966,7 @@ bool
 os_file_status(
 	const char*	path,
 	bool*		exists,
-	os_file_type_t* type);
+	os_file_type_t* type) noexcept;
 
 /** This function reduces a null-terminated full remote path name into
 the path that is sent by MySQL for DATA DIRECTORY clause.  It replaces
@@ -988,34 +980,30 @@ This function manipulates that path in place.
 If the path format is not as expected, just return.  The result is used
 to inform a SHOW CREATE TABLE command.
 @param[in,out]	data_dir_path		Full path/data_dir_path */
-void
-os_file_make_data_dir_path(
-	char*	data_dir_path);
+void os_file_make_data_dir_path(char *data_dir_path) noexcept;
 
 /** Create all missing subdirectories along the given path.
 @return DB_SUCCESS if OK, otherwise error code. */
-dberr_t
-os_file_create_subdirs_if_needed(
-	const char*	path);
+dberr_t os_file_create_subdirs_if_needed(const char* path) noexcept;
 
 #ifdef UNIV_ENABLE_UNIT_TEST_GET_PARENT_DIR
 /* Test the function os_file_get_parent_dir. */
 void
-unit_test_os_file_get_parent_dir();
+unit_test_os_file_get_parent_dir() noexcept;
 #endif /* UNIV_ENABLE_UNIT_TEST_GET_PARENT_DIR */
 
 /**
 Initializes the asynchronous io system. */
-int os_aio_init();
+int os_aio_init() noexcept;
 
 /**
 Frees the asynchronous io system. */
-void os_aio_free();
+void os_aio_free() noexcept;
 
 /** Submit a fake read request during crash recovery.
 @param type   fake read request
 @param offset additional context */
-void os_fake_read(const IORequest &type, os_offset_t offset);
+void os_fake_read(const IORequest &type, os_offset_t offset) noexcept;
 
 /** Request a read or write.
 @param type		I/O request
@@ -1024,36 +1012,34 @@ void os_fake_read(const IORequest &type, os_offset_t offset);
 @param n		number of bytes
 @retval DB_SUCCESS if request was queued successfully
 @retval DB_IO_ERROR on I/O error */
-dberr_t os_aio(const IORequest &type, void *buf, os_offset_t offset, size_t n);
+dberr_t os_aio(const IORequest &type, void *buf, os_offset_t offset, size_t n)
+  noexcept;
 
 /** @return number of pending reads */
-size_t os_aio_pending_reads();
+size_t os_aio_pending_reads() noexcept;
 /** @return approximate number of pending reads */
-size_t os_aio_pending_reads_approx();
+size_t os_aio_pending_reads_approx() noexcept;
 /** @return number of pending writes */
-size_t os_aio_pending_writes();
+size_t os_aio_pending_writes() noexcept;
 
 /** Wait until there are no pending asynchronous writes.
 @param declare  whether the wait will be declared in tpool */
-void os_aio_wait_until_no_pending_writes(bool declare);
+void os_aio_wait_until_no_pending_writes(bool declare) noexcept;
 
 /** Wait until all pending asynchronous reads have completed.
 @param declare  whether the wait will be declared in tpool */
-void os_aio_wait_until_no_pending_reads(bool declare);
+void os_aio_wait_until_no_pending_reads(bool declare) noexcept;
 
 /** Prints info of the aio arrays.
 @param[in/out]	file		file where to print */
-void
-os_aio_print(FILE* file);
+void os_aio_print(FILE *file) noexcept;
 
 /** Refreshes the statistics used to print per-second averages. */
-void
-os_aio_refresh_stats();
+void os_aio_refresh_stats() noexcept;
 
 /** Checks that all slots in the system have been freed, that is, there are
 no pending io operations. */
-bool
-os_aio_all_slots_free();
+bool os_aio_all_slots_free() noexcept;
 
 
 /** This function returns information about the specified file
@@ -1068,7 +1054,7 @@ os_file_get_status(
 	const char*	path,
 	os_file_stat_t* stat_info,
 	bool		check_rw_perm,
-	bool		read_only);
+	bool		read_only) noexcept;
 
 #ifdef _WIN32
 
@@ -1079,7 +1065,7 @@ Make file sparse, on Windows.
 @param[in]	is_sparse if true, make file sparse,
 			otherwise "unsparse" the file
 @return true on success, false on error */
-bool os_file_set_sparse_win32(os_file_t file, bool is_sparse = true);
+bool os_file_set_sparse_win32(os_file_t file, bool is_sparse = true) noexcept;
 
 /**
 Changes file size on Windows
@@ -1096,14 +1082,12 @@ If file is normal, file system allocates storage.
 @param[in]	file		file handle
 @param[in]	size		size to preserve in bytes
 @return true if success */
-bool
-os_file_set_size(
-	const char*	pathname,
-	os_file_t	file,
-	os_offset_t	size);
+bool os_file_set_size(const char *pathname, os_file_t file, os_offset_t size)
+  noexcept;
 
 inline bool
 os_file_set_size(const char* name, os_file_t file, os_offset_t size, bool)
+  noexcept
 {
   return os_file_set_size(name, file, size);
 }
@@ -1127,14 +1111,14 @@ dberr_t
 os_file_punch_hole(
 	os_file_t	fh,
 	os_offset_t	off,
-	os_offset_t	len)
+	os_offset_t	len) noexcept
 	MY_ATTRIBUTE((warn_unused_result));
 
 /* Determine if a path is an absolute path or not.
 @param[in]	OS directory or file path to evaluate
 @retval true if an absolute path
 @retval false if a relative path */
-inline bool is_absolute_path(const char *path)
+inline bool is_absolute_path(const char *path) noexcept
 {
   switch (path[0]) {
 #ifdef _WIN32

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -3256,7 +3256,7 @@ func_exit:
   return success;
 }
 
-void IORequest::fake_read_complete(os_offset_t offset) const
+void IORequest::fake_read_complete(os_offset_t offset) const noexcept
 {
   ut_ad(node);
   ut_ad(is_read());
@@ -3297,7 +3297,7 @@ void IORequest::fake_read_complete(os_offset_t offset) const
 }
 
 /** @return whether a page has been freed */
-inline bool fil_space_t::is_freed(uint32_t page)
+inline bool fil_space_t::is_freed(uint32_t page) noexcept
 {
   std::lock_guard<std::mutex> freed_lock(freed_range_mutex);
   return freed_ranges.contains(page);
@@ -3598,7 +3598,7 @@ ATTRIBUTE_COLD buf_block_t *recv_sys_t::recover_low(const page_id_t page_id)
   return nullptr;
 }
 
-inline fil_space_t *fil_system_t::find(const char *path) const
+inline fil_space_t *fil_system_t::find(const char *path) const noexcept
 {
   mysql_mutex_assert_owner(&mutex);
   for (fil_space_t &space : fil_system.space_list)
@@ -3608,7 +3608,7 @@ inline fil_space_t *fil_system_t::find(const char *path) const
 }
 
 /** Thread-safe function which sorts flush_list by oldest_modification */
-static void log_sort_flush_list()
+static void log_sort_flush_list() noexcept
 {
   /* Ensure that oldest_modification() cannot change during std::sort() */
   {

--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -259,7 +259,7 @@ void mtr_t::rollback_to_savepoint(ulint begin, ulint end)
 }
 
 /** Set create_lsn. */
-inline void fil_space_t::set_create_lsn(lsn_t lsn)
+inline void fil_space_t::set_create_lsn(lsn_t lsn) noexcept
 {
   ut_ad(latch.have_wr());
   /* Concurrent log_checkpoint_low() must be impossible. */


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35438*
This is a follow up to #3531.
## Description
Most InnoDB functions do not throw any exceptions, not even indirectly `std::bad_alloc`, which could be thrown by a C++ memory allocation function. Let us annotate many functions with `noexcept` in order to reduce the code footprint related to exception handling.
## Release Notes
This is a minor change that does not need to be documented.
## How can this PR be tested?
This low level code should be well covered by the existing regression tests.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.