### PR TITLE
Correct cursor protocol tests main.{loaddata,grant_plugin} & innodb_f…

### DIFF
--- a/mysql-test/main/grant_plugin.result
+++ b/mysql-test/main/grant_plugin.result
@@ -4,14 +4,12 @@
 install soname 'auth_0x0100';
 CREATE USER foo@localhost IDENTIFIED VIA auth_0x0100;
 uninstall plugin auth_0x0100;
-select Priv from mysql.global_priv where User = "foo" and host="localhost"
-into @priv;
-Warnings:
-Warning	1287	'<select expression> INTO <destination>;' is deprecated and will be removed in a future release. Please use 'SELECT <select list> INTO <destination> FROM...' instead
+create table t as select Priv from mysql.global_priv where User = "foo" and host="localhost";
 SET PASSWORD FOR foo@localhost = "1111";
 ERROR HY000: Plugin 'auth_0x0100' is not loaded
-select Priv = @priv as "Nothing changed" from mysql.global_priv where User = "foo" and host="localhost";
+select global_priv.Priv = t.Priv as "Nothing changed" from mysql.global_priv join t where User = "foo" and host="localhost";
 Nothing changed
 1
+drop table t;
 DROP USER foo@localhost;
 # End of 10.5 tests

--- a/mysql-test/main/grant_plugin.test
+++ b/mysql-test/main/grant_plugin.test
@@ -13,11 +13,12 @@ install soname 'auth_0x0100';
 CREATE USER foo@localhost IDENTIFIED VIA auth_0x0100;
 uninstall plugin auth_0x0100;
 
-select Priv from mysql.global_priv where User = "foo" and host="localhost"
-into @priv;
+create table t as select Priv from mysql.global_priv where User = "foo" and host="localhost";
 --error ER_PLUGIN_IS_NOT_LOADED
 SET PASSWORD FOR foo@localhost = "1111";
-select Priv = @priv as "Nothing changed" from mysql.global_priv where User = "foo" and host="localhost";
+select global_priv.Priv = t.Priv as "Nothing changed" from mysql.global_priv join t where User = "foo" and host="localhost";
+
+drop table t;
 
 DROP USER foo@localhost;
 

--- a/mysql-test/main/loaddata.test
+++ b/mysql-test/main/loaddata.test
@@ -843,10 +843,12 @@ CREATE OR REPLACE TABLE t1 (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 INSERT INTO t1 VALUES (GeomFromText('POINT(37.646944 -75.761111)'));
 
+--disable_cursor_protocol
 --disable_ps2_protocol
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 eval SELECT * INTO OUTFILE '$MYSQLTEST_VARDIR/tmp/t1.tsv' FROM t1;
 --enable_ps2_protocol
+--enable_cursor_protocol
 
 CREATE OR REPLACE TABLE t2 LIKE t1;
 
@@ -863,10 +865,12 @@ CREATE OR REPLACE TABLE t1 (
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO t1 VALUES (GeomFromText('POINT(37.646944 -75.761111)'),"їєі");
+--disable_cursor_protocol
 --disable_ps2_protocol
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 eval SELECT * INTO OUTFILE '$MYSQLTEST_VARDIR/tmp/t1.tsv' FROM t1;
 --enable_ps2_protocol
+--enable_cursor_protocol
 
 CREATE OR REPLACE TABLE t2 LIKE t1;
 

--- a/mysql-test/main/stack.result
+++ b/mysql-test/main/stack.result
@@ -18,8 +18,8 @@ FROM Fibonacci
 WHERE N < 100000
 )
 SELECT PrevN as N, Stack FROM Fibonacci;
-select (select stack from t1 where n=2) = (select stack from t1 where N=75025);
-(select stack from t1 where n=2) = (select stack from t1 where N=75025)
+select (select stack from t1 where n=2) = (select stack from t1 where N=75025) as c;
+c
 1
 DROP table t1;
 #

--- a/mysql-test/main/stack.test
+++ b/mysql-test/main/stack.test
@@ -22,7 +22,7 @@ WITH recursive Fibonacci(PrevN, N, Stack) AS
 )
 SELECT PrevN as N, Stack FROM Fibonacci;
 
-select (select stack from t1 where n=2) = (select stack from t1 where N=75025);
+select (select stack from t1 where n=2) = (select stack from t1 where N=75025) as c;
 DROP table t1;
 
 --echo #

--- a/mysql-test/suite/innodb_fts/r/fulltext.result
+++ b/mysql-test/suite/innodb_fts/r/fulltext.result
@@ -794,10 +794,10 @@ title VARCHAR(200), book VARCHAR(200),
 FULLTEXT fidx(title)) ENGINE = InnoDB;
 INSERT INTO t1(title) VALUES('database');
 ALTER TABLE t1 DROP INDEX fidx;
-select space into @common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
+create table t2 as select space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
 ALTER TABLE t1 ADD FULLTEXT fidx_1(book);
-select space=@common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
-space=@common_space
+select i_s.space=t2.space from information_schema.innodb_sys_tables i_s join t2 where name like "test/FTS_%_CONFIG";
+i_s.space=t2.space
 1
 SHOW CREATE TABLE t1;
 Table	Create Table
@@ -808,4 +808,5 @@ t1	CREATE TABLE `t1` (
   PRIMARY KEY (`ID`),
   FULLTEXT KEY `fidx_1` (`book`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
-DROP TABLE t1;
+DROP TABLE t1, t2;
+# End of 10.5 tests

--- a/mysql-test/suite/innodb_fts/t/fulltext.test
+++ b/mysql-test/suite/innodb_fts/t/fulltext.test
@@ -814,8 +814,10 @@ CREATE TABLE t1 (
         FULLTEXT fidx(title)) ENGINE = InnoDB;
 INSERT INTO t1(title) VALUES('database');
 ALTER TABLE t1 DROP INDEX fidx;
-select space into @common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
+create table t2 as select space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
 ALTER TABLE t1 ADD FULLTEXT fidx_1(book);
-select space=@common_space from information_schema.innodb_sys_tables where name like "test/FTS_%_CONFIG";
+select i_s.space=t2.space from information_schema.innodb_sys_tables i_s join t2 where name like "test/FTS_%_CONFIG";
 SHOW CREATE TABLE t1;
-DROP TABLE t1;
+DROP TABLE t1, t2;
+
+--echo # End of 10.5 tests


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-______*

## Description

3 mtr tests failed under cursor protocol on x86-debian-12-fulltest builder.

## Release Notes

not important

## How can this PR be tested?

look at mtr on x86-debian-12-fulltest for the cursor protocol

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.