### PR TITLE
MDEV-35478 Correction for table->space_id in dict_load_tablespace() was mistakenly applied on an earlier branch

### DIFF
--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -2300,8 +2300,8 @@ dict_load_tablespace(
 		table->file_unreadable = true;
 
 		if (!(ignore_err & DICT_ERR_IGNORE_RECOVER_LOCK)) {
-			sql_print_error("InnoDB: Failed to load tablespace %"
-					PRIu32 " for table %s",
+			sql_print_error("InnoDB: Failed to load tablespace "
+					ULINTPF " for table %s",
 					table->space_id, table->name.m_name);
 		}
 	}


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-35478](https://jira.mariadb.org/browse/MDEV-35478)*

## Description
It is `ulint` on 10.6 and `uint32_t` on 10.11+, but I included its format specifier change in 10.6 (MDEV-35430, merged #3493) rather than 10.11.
This commit reverts that change so 10.11 can reapply it.

## Release Notes
N/A

## How can this PR be tested?
N/A

## Basing the PR against the correct MariaDB version
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.