### PR TITLE
MDEV-35478 part 2: Redo `space_id` format fix

### DIFF
--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -2298,8 +2298,8 @@ dict_load_tablespace(
 		table->file_unreadable = true;
 
 		if (!(ignore_err & DICT_ERR_IGNORE_RECOVER_LOCK)) {
-			sql_print_error("InnoDB: Failed to load tablespace "
-					ULINTPF " for table %s",
+			sql_print_error("InnoDB: Failed to load tablespace %"
+					PRIu32 " for table %s",
 					table->space_id, table->name);
 		}
 	}


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-35478](https://jira.mariadb.org/browse/MDEV-35478)*

## Description
`table->space_id` is `ulint` on 10.6 and `uint32_t` on 10.11+, but I included its format specifier change in 10.6 rather than 10.11.

PR #3650 reverts the change from 10.6; this commit reapplies it on 10.11 as a follow up on its batch (MDEV-35431, merged #3518).

## Release Notes
N/A

Note that this’ll be a merge conflict if this merges before #3518 merges to 10.11.

## How can this PR be tested?
N/A

## Basing the PR against the correct MariaDB version
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.