### PR TITLE
MDEV-35473 : Sporadic failures in the galera_3nodes.galera_evs_suspec…

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_evs_suspect_timeout.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_evs_suspect_timeout.result
@@ -12,16 +12,10 @@ connection node_3;
 Suspending node ...
 connection node_1;
 SET SESSION wsrep_sync_wait=0;
-SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-VARIABLE_VALUE = 2
-1
 CREATE TABLE t1 (f1 INTEGER) engine=InnoDB;
 INSERT INTO t1 VALUES (1);
 connection node_2;
 SET SESSION wsrep_sync_wait=0;
-SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
-VARIABLE_VALUE = 2
-1
 SET SESSION wsrep_sync_wait = 15;
 SELECT COUNT(*) FROM t1;
 COUNT(*)

--- a/mysql-test/suite/galera_3nodes/t/galera_evs_suspect_timeout.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_evs_suspect_timeout.test
@@ -18,6 +18,9 @@
 --source ../galera/include/auto_increment_offset_save.inc
 
 --connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
 --let $wsrep_provider_options_node1 = `SELECT @@wsrep_provider_options`
 SET GLOBAL wsrep_provider_options = 'evs.inactive_timeout=PT100M; evs.suspect_timeout=PT1S';
 
@@ -26,20 +29,20 @@ SET GLOBAL wsrep_provider_options = 'evs.inactive_timeout=PT100M; evs.suspect_ti
 SET GLOBAL wsrep_provider_options = 'evs.inactive_timeout=PT100M; evs.suspect_timeout=PT1S';
 
 --connection node_3
---source include/wait_until_connected_again.inc
 --let $wsrep_cluster_address_node3 = `SELECT @@wsrep_cluster_address`
+--let $wsrep_provider_options_node3 = `SELECT @@wsrep_provider_options`
 
 # Suspend node #3
 --connection node_3
 --source include/galera_suspend.inc
---sleep 5
 
 # Confirm that the other nodes have booted it out
 
 --connection node_1
---source include/wait_until_connected_again.inc
 SET SESSION wsrep_sync_wait=0;
-SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
 --disable_query_log
 --eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_node1';
 --enable_query_log
@@ -49,9 +52,10 @@ CREATE TABLE t1 (f1 INTEGER) engine=InnoDB;
 INSERT INTO t1 VALUES (1);
 
 --connection node_2
---source include/wait_until_connected_again.inc
 SET SESSION wsrep_sync_wait=0;
-SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size';
+--let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
 --disable_query_log
 --eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_node2';
 --enable_query_log
@@ -67,6 +71,7 @@ SELECT COUNT(*) FROM t1;
 --source include/wait_until_connected_again.inc
 
 --disable_query_log
+--eval SET GLOBAL wsrep_provider_options = '$wsrep_provider_options_node3';
 --eval SET GLOBAL wsrep_cluster_address = '$wsrep_cluster_address_node3';
 --enable_query_log
 --source include/galera_wait_ready.inc
@@ -78,6 +83,9 @@ SET SESSION wsrep_sync_wait = 15;
 SELECT COUNT(*) FROM t1;
 
 --connection node_1
+--let $wait_condition = SELECT VARIABLE_VALUE = 3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
+--source include/wait_condition.inc
+
 DROP TABLE t1;
 # Restore original auto_increment_offset values.
 --source ../galera/include/auto_increment_offset_restore.inc


### PR DESCRIPTION
…t_timeout mtr test



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35473*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Remove unnecessary sleep and replace it with proper wait_conditions.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
