### PR TITLE
MDEV-35440 : Protocol error warning in the galera_wsrep_schema_detach…

### DIFF
--- a/mysql-test/suite/galera/r/galera_wsrep_schema_detached.result
+++ b/mysql-test/suite/galera/r/galera_wsrep_schema_detached.result
@@ -3,8 +3,9 @@ connection node_1;
 connection node_1;
 connection node_2;
 connection node_1;
-call mtr.add_suppression("WSREP: async IST sender failed to serve.*");
+call mtr.add_suppression("WSREP:.*");
 SET @wsrep_provider_options_orig = @@GLOBAL.wsrep_provider_options;
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=true;pc.weight=2';
 connection node_2;
 SET @wsrep_cluster_address_orig = @@GLOBAL.wsrep_cluster_address;
 SET GLOBAL WSREP_ON=0;
@@ -17,11 +18,37 @@ EXPECT_1
 SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
 EXPECT_2
 2
-connection node_1;
-SET GLOBAL wsrep_provider_options ='pc.ignore_sb=true';
 connection node_2;
 Killing server ...
 connection node_1;
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster_members;
+EXPECT_1
+1
 connection node_2;
 connection node_1;
-SET GLOBAL wsrep_provider_options ='pc.ignore_sb=false';
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=false;pc.weight=1';
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2
+connection node_2;
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+EXPECT_0
+0
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+EXPECT_1
+1
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+EXPECT_2
+2

--- a/mysql-test/suite/galera/t/galera_wsrep_schema_detached.test
+++ b/mysql-test/suite/galera/t/galera_wsrep_schema_detached.test
@@ -6,8 +6,9 @@
 --source include/auto_increment_offset_save.inc
 
 --connection node_1
-call mtr.add_suppression("WSREP: async IST sender failed to serve.*");
+call mtr.add_suppression("WSREP:.*");
 SET @wsrep_provider_options_orig = @@GLOBAL.wsrep_provider_options;
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=true;pc.weight=2';
 
 --connection node_2
 SET @wsrep_cluster_address_orig = @@GLOBAL.wsrep_cluster_address;
@@ -16,15 +17,15 @@ SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
 SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
 SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
 
---connection node_1
-SET GLOBAL wsrep_provider_options ='pc.ignore_sb=true';
-
 --connection node_2
 --source include/kill_galera.inc
 
 --connection node_1
 --let $wait_condition = SELECT VARIABLE_VALUE = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
 --source include/wait_condition.inc
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster_members;
 
 --connection node_2
 --source include/start_mysqld.inc
@@ -33,7 +34,16 @@ SET GLOBAL wsrep_provider_options ='pc.ignore_sb=true';
 --let $wait_condition = SELECT VARIABLE_VALUE = 2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_cluster_size'
 --source include/wait_condition.inc
 
-SET GLOBAL wsrep_provider_options ='pc.ignore_sb=false';
+SET GLOBAL wsrep_provider_options ='pc.ignore_sb=false;pc.weight=1';
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+
+--connection node_2
+SELECT COUNT(*) AS EXPECT_0 FROM mysql.wsrep_streaming_log;
+SELECT COUNT(*) AS EXPECT_1 FROM mysql.wsrep_cluster;
+SELECT COUNT(*) AS EXPECT_2 FROM mysql.wsrep_cluster_members;
+
 
 # Cleanup
 --source include/auto_increment_offset_restore.inc


### PR DESCRIPTION
…ed test



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35440*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Make sure that node_1 remains in primary view by increasing it's weight. Add suppression on expected warnings because we kill node_2.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
