### PR TITLE
MDEV-30469 Support ORDER BY and LIMIT for multi-table DELETE, index h…

### DIFF
--- a/mysql-test/main/delete.result
+++ b/mysql-test/main/delete.result
@@ -680,3 +680,105 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 2	MATERIALIZED	t2	ALL	NULL	NULL	NULL	NULL	20000	
 drop table t1, t2;
 # End of 11.7 tests
+#
+# MDEV-30469: Add support of ORDER BY and LIMIT to multidelete query.
+#
+# Check that limits work with hints
+create table t2 (id int, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+DELETE t2.* FROM t2 use index(xid) ORDER BY (id) LIMIT 2;
+select * from t2 ORDER BY (id);
+id
+3
+8
+9
+10
+DELETE t2.* FROM t2 use index(xid) ORDER BY (id) DESC LIMIT 3;
+select * from t2;
+id
+3
+# Check some useles syntax
+DELETE t2.* FROM t2 FORCE INDEX FOR GROUP BY (xid) ORDER BY (id) LIMIT 1;
+drop table t2;
+# Check that hints work with limit
+create table t2 (id int primary key, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+# default primary index
+explain
+DELETE t2.* FROM t2 ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	PRIMARY	4	NULL	2	
+# make it use other undex
+explain
+DELETE t2.* FROM t2 use index(xid) ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	xid	4	NULL	2	
+explain
+DELETE t2.* FROM t2 force index(xid) ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	xid	4	NULL	2	
+# prohibit primary index
+explain
+DELETE t2.* FROM t2 ignore index(primary) ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	xid	4	NULL	2	
+drop table t2;
+# Check that limits work with hints & PS protocol
+create table t2 (id int, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+prepare stmt from
+"DELETE t2.* FROM t2 use index(xid) ORDER BY (id) LIMIT ?";
+set @lim= 2;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+id
+3
+8
+9
+10
+set @lim= 1;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+id
+8
+9
+10
+set @lim= 3;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+id
+drop table t2;
+# Check that hints work with limit in normal DELETE syntax
+create table t2 (id int primary key, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+# default primary index
+explain
+DELETE FROM t2 ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	PRIMARY	4	NULL	2	
+# make it use other undex
+explain
+DELETE FROM t2 use index(xid) ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	xid	4	NULL	2	
+explain
+DELETE FROM t2 force index(xid) ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	xid	4	NULL	2	
+# prohibit primary index
+explain
+DELETE FROM t2 ignore index(primary) ORDER BY (id) LIMIT 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	index	NULL	xid	4	NULL	2	
+# should issue warnings becaouse we can not switch it internally
+# to multiupdate due to RETURNING
+DELETE FROM t2 ignore index(primary) ORDER BY (id) LIMIT 2 RETURNING id;
+id
+1
+2
+Warnings:
+Warning	4206	Index hints are ignored because they are incompatible with RETURNING clause
+drop table t2;
+#
+# End of 11.4 test
+#

--- a/mysql-test/main/delete.test
+++ b/mysql-test/main/delete.test
@@ -744,3 +744,87 @@ explain delete from t1  where    b <= 3 and a not in (select b from t2);
 drop table t1, t2;
 
 --echo # End of 11.7 tests
+
+--echo #
+--echo # MDEV-30469: Add support of ORDER BY and LIMIT to multidelete query.
+--echo #
+
+--echo # Check that limits work with hints
+
+create table t2 (id int, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+
+DELETE t2.* FROM t2 use index(xid) ORDER BY (id) LIMIT 2;
+select * from t2 ORDER BY (id);
+DELETE t2.* FROM t2 use index(xid) ORDER BY (id) DESC LIMIT 3;
+select * from t2;
+--echo # Check some useles syntax
+DELETE t2.* FROM t2 FORCE INDEX FOR GROUP BY (xid) ORDER BY (id) LIMIT 1;
+
+drop table t2;
+
+
+--echo # Check that hints work with limit
+
+create table t2 (id int primary key, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+
+--echo # default primary index
+explain
+DELETE t2.* FROM t2 ORDER BY (id) LIMIT 2;
+--echo # make it use other undex
+explain
+DELETE t2.* FROM t2 use index(xid) ORDER BY (id) LIMIT 2;
+explain
+DELETE t2.* FROM t2 force index(xid) ORDER BY (id) LIMIT 2;
+--echo # prohibit primary index
+explain
+DELETE t2.* FROM t2 ignore index(primary) ORDER BY (id) LIMIT 2;
+
+drop table t2;
+
+--echo # Check that limits work with hints & PS protocol
+
+create table t2 (id int, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+
+prepare stmt from
+"DELETE t2.* FROM t2 use index(xid) ORDER BY (id) LIMIT ?";
+set @lim= 2;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+set @lim= 1;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+set @lim= 3;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+
+drop table t2;
+
+--echo # Check that hints work with limit in normal DELETE syntax
+
+create table t2 (id int primary key, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+
+--echo # default primary index
+explain
+DELETE FROM t2 ORDER BY (id) LIMIT 2;
+--echo # make it use other undex
+explain
+DELETE FROM t2 use index(xid) ORDER BY (id) LIMIT 2;
+explain
+DELETE FROM t2 force index(xid) ORDER BY (id) LIMIT 2;
+--echo # prohibit primary index
+explain
+DELETE FROM t2 ignore index(primary) ORDER BY (id) LIMIT 2;
+
+--echo # should issue warnings becaouse we can not switch it internally
+--echo # to multiupdate due to RETURNING
+DELETE FROM t2 ignore index(primary) ORDER BY (id) LIMIT 2 RETURNING id;
+
+drop table t2;
+
+--echo #
+--echo # End of 11.4 test
+--echo #

--- a/mysql-test/main/delete_innodb.result
+++ b/mysql-test/main/delete_innodb.result
@@ -60,8 +60,8 @@ INSERT INTO t2 values (3);
 disallows sj optimization
 analyze DELETE FROM t1 WHERE c1 IN (select c2 from t2) ORDER BY c1 limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	5	1.00	100.00	100.00	Using where; Using filesort
-2	DEPENDENT SUBQUERY	t2	ALL	NULL	NULL	NULL	NULL	1	1.00	100.00	20.00	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	5	2.00	100.00	100.00	Using filesort
+1	PRIMARY	t2	ALL	NULL	NULL	NULL	NULL	1	1.00	100.00	50.00	Using where; FirstMatch(t1)
 select * from t1;
 c1
 1

--- a/mysql-test/main/delete_multi_order_by.result
+++ b/mysql-test/main/delete_multi_order_by.result
@@ -1,0 +1,239 @@
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 order by t1.id desc limit 3;
+select * from t1;
+id	v
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+6	6
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 order by t1.id desc;
+select * from t1;
+id	v
+select * from t2;
+id	v
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 limit 2;
+select * from t1;
+id	v
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+2	3
+6	6
+create table t3 (a int primary key, b text);
+insert into t3 (a, b) values (1, 'hello');
+delete from t3 where b = '';
+drop table t3;
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 where t1.id=t2.id;
+select * from t1;
+id	v
+4	1
+1	4
+select * from t2;
+id	v
+5	5
+6	6
+drop table if exists t1;
+create table t1(a INT);
+insert into t1 values (1),(2),(3);
+set session sql_buffer_result=1;
+delete t1 from (select sum(a) a from t1) x,t1;
+set session sql_buffer_result=default;
+select * from t1;
+a
+drop table t1;
+drop table if exists t1, t2;
+Warnings:
+Note	1051	Unknown table 'test.t1'
+create table t1(id1 smallint(5), field char(5));
+create table t2(id2 smallint(5), field char(5));
+insert into t1 values (1, 'a'), (2, 'aa');
+insert into t2 values (1, 'b'), (2, 'bb');
+update t2 inner join t1 on t1.id1=t2.id2 set t2.field=t1.field  where 0=1;
+update t2, t1 set t2.field=t1.field  where t1.id1=t2.id2 and 0=1;
+delete t1, t2 from t2 inner join t1 on t1.id1=t2.id2  where 0=1;
+drop table t1, t2;
+set session sql_buffer_result=1;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 order by t1.id desc limit 3;
+select * from t1;
+id	v
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+6	6
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 order by t1.id desc;
+select * from t1;
+id	v
+select * from t2;
+id	v
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 limit 2;
+select * from t1;
+id	v
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+2	3
+6	6
+create table t3 (a int primary key, b text);
+insert into t3 (a, b) values (1, 'hello');
+delete from t3 where b = '';
+drop table t3;
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+id	v
+4	1
+3	2
+2	3
+1	4
+select * from t2;
+id	v
+5	5
+3	2
+2	3
+6	6
+delete t1.*, t2.* from t1, t2 where t1.id=t2.id;
+select * from t1;
+id	v
+4	1
+1	4
+select * from t2;
+id	v
+5	5
+6	6
+drop table if exists t1, t2;
+create table t1(id1 smallint(5), field char(5));
+create table t2(id2 smallint(5), field char(5));
+insert into t1 values (1, 'a'), (2, 'aa');
+insert into t2 values (1, 'b'), (2, 'bb');
+update t2 inner join t1 on t1.id1=t2.id2 set t2.field=t1.field  where 0=1;
+update t2, t1 set t2.field=t1.field  where t1.id1=t2.id2 and 0=1;
+delete t1, t2 from t2 inner join t1 on t1.id1=t2.id2  where 0=1;
+drop table t1, t2;
+set session sql_buffer_result=default;

--- a/mysql-test/main/delete_multi_order_by.test
+++ b/mysql-test/main/delete_multi_order_by.test
@@ -1,0 +1,131 @@
+#
+# MDEV-30469 Support ORDER BY and LIMIT for multi-table DELETE, index hints for single-table DELETE.
+#
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 order by t1.id desc limit 3;
+select * from t1;
+select * from t2;
+
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 order by t1.id desc;
+select * from t1;
+select * from t2;
+
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 limit 2;
+select * from t1;
+select * from t2;
+
+create table t3 (a int primary key, b text);
+insert into t3 (a, b) values (1, 'hello');
+delete from t3 where b = '';
+drop table t3;
+
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 where t1.id=t2.id;
+select * from t1;
+select * from t2;
+
+drop table if exists t1;
+create table t1(a INT);
+insert into t1 values (1),(2),(3);
+set session sql_buffer_result=1;
+delete t1 from (select sum(a) a from t1) x,t1;
+set session sql_buffer_result=default;
+select * from t1;
+drop table t1;
+
+drop table if exists t1, t2;
+create table t1(id1 smallint(5), field char(5));
+create table t2(id2 smallint(5), field char(5));
+insert into t1 values (1, 'a'), (2, 'aa');
+insert into t2 values (1, 'b'), (2, 'bb');
+update t2 inner join t1 on t1.id1=t2.id2 set t2.field=t1.field  where 0=1;
+update t2, t1 set t2.field=t1.field  where t1.id1=t2.id2 and 0=1;
+delete t1, t2 from t2 inner join t1 on t1.id1=t2.id2  where 0=1;
+drop table t1, t2;
+
+
+set session sql_buffer_result=1;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 order by t1.id desc limit 3;
+select * from t1;
+select * from t2;
+
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 order by t1.id desc;
+select * from t1;
+select * from t2;
+
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 limit 2;
+select * from t1;
+select * from t2;
+
+create table t3 (a int primary key, b text);
+insert into t3 (a, b) values (1, 'hello');
+delete from t3 where b = '';
+drop table t3;
+
+drop table if exists t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (4,1),(3,2),(2,3),(1,4);
+insert into t2 (id, v) values (5,5),(3,2),(2,3),(6,6);
+select * from t1;
+select * from t2;
+delete t1.*, t2.* from t1, t2 where t1.id=t2.id;
+select * from t1;
+select * from t2;
+
+drop table if exists t1, t2;
+create table t1(id1 smallint(5), field char(5));
+create table t2(id2 smallint(5), field char(5));
+insert into t1 values (1, 'a'), (2, 'aa');
+insert into t2 values (1, 'b'), (2, 'bb');
+update t2 inner join t1 on t1.id1=t2.id2 set t2.field=t1.field  where 0=1;
+update t2, t1 set t2.field=t1.field  where t1.id1=t2.id2 and 0=1;
+delete t1, t2 from t2 inner join t1 on t1.id1=t2.id2  where 0=1;
+
+drop table t1, t2;
+set session sql_buffer_result=default;

--- a/mysql-test/main/delete_single_to_multi.result
+++ b/mysql-test/main/delete_single_to_multi.result
@@ -3342,22 +3342,22 @@ o_custkey in (select c_custkey from customer
 where c_nationkey in (1,2))
 order by o_totalprice limit 500;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	orders	range	i_o_orderdate	i_o_orderdate	4	NULL	108	Using where; Using filesort
-2	DEPENDENT SUBQUERY	customer	unique_subquery	PRIMARY,i_c_nationkey	PRIMARY	4	func	1	Using where
+1	PRIMARY	customer	range	PRIMARY,i_c_nationkey	i_c_nationkey	5	NULL	13	Using index condition; Using temporary; Using filesort
+1	PRIMARY	orders	ref|filter	i_o_orderdate,i_o_custkey	i_o_custkey|i_o_orderdate	5|4	dbt3_s001.customer.c_custkey	15 (7%)	Using where; Using rowid filter
 create table t as
 select * from orders where o_orderDATE between '1992-01-01' and '1992-06-30' and
 o_custkey in (select c_custkey from customer
 where c_nationkey in (1,2));
 select o_orderkey, o_totalprice from t;
 o_orderkey	o_totalprice
-1221	117397.16
 324	26868.85
 1856	189361.42
-4903	34363.63
-5607	24660.06
+1221	117397.16
 1344	43809.37
 1925	146382.71
 3139	40975.96
+4903	34363.63
+5607	24660.06
 delete from orders where o_orderDATE between '1992-01-01' and '1992-06-30' and
 o_custkey in (select c_custkey from customer
 where c_nationkey in (1,2))
@@ -3394,14 +3394,14 @@ o_custkey in (select c_custkey from customer
 where c_nationkey in (1,2));
 select o_orderkey, o_totalprice from t;
 o_orderkey	o_totalprice
-1221	117397.16
-324	26868.85
 1856	189361.42
+324	26868.85
+1221	117397.16
+3139	40975.96
+1925	146382.71
+1344	43809.37
 4903	34363.63
 5607	24660.06
-1344	43809.37
-1925	146382.71
-3139	40975.96
 delete from orders where o_orderDATE between '1992-01-01' and '1992-06-30' and
 o_custkey in (select c_custkey from customer
 where c_nationkey in (1,2));

--- a/mysql-test/main/delete_use_source_engines.result
+++ b/mysql-test/main/delete_use_source_engines.result
@@ -232,8 +232,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	ALL	NULL	NULL	NULL	NULL	32	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -788,8 +788,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	index_subquery	t1_c2	t1_c2	5	func	5	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	ALL	t1_c2	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -1345,8 +1345,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	index	NULL	PRIMARY	4	NULL	1	Using where
-2	DEPENDENT SUBQUERY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
+1	PRIMARY	t1	index	PRIMARY	PRIMARY	4	NULL	1	
+1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -1995,8 +1995,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	ALL	NULL	NULL	NULL	NULL	32	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -2767,7 +2767,7 @@ explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	index_subquery	t1_c2	t1_c2	5	func	5	Using where
+1	PRIMARY	a	ref	t1_c2	t1_c2	5	test.t1.c1	5	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -3394,7 +3394,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 analyze delete from t1 where c1 = 1 and exists (select 'X' from t1 a where a.c1 = t1.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	32.00	9.38	9.38	Using where
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	12.00	3.12	5.56	Using where; FirstMatch(t1)
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	13.33	3.12	5.00	Using where; FirstMatch(t1)
 select * from t1;
 c1	c2	c3
 1	3	3
@@ -3535,8 +3535,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	index	NULL	PRIMARY	4	NULL	1	Using where
-2	DEPENDENT SUBQUERY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
+1	PRIMARY	t1	index	PRIMARY	PRIMARY	4	NULL	1	
+1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -4054,7 +4054,7 @@ and c1 = 2
 and exists (select 'X' from v1 a where a.c1 = v1.c1);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	#	32.00	3.91	3.12	Using where
-3	DEPENDENT SUBQUERY	t1	ALL	NULL	NULL	NULL	NULL	#	6.00	25.00	16.67	Using where
+3	DEPENDENT SUBQUERY	t1	ALL	NULL	NULL	NULL	NULL	#	10.00	25.00	10.00	Using where
 2	DEPENDENT SUBQUERY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	#	1.00	100.00	100.00	
 select * from t1;
 c1	c2	c3
@@ -4400,8 +4400,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	ALL	NULL	NULL	NULL	NULL	32	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -5171,8 +5171,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	index_subquery	t1_c2	t1_c2	5	func	5	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	ALL	t1_c2	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -5799,7 +5799,7 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 analyze delete from t1 where c1 = 1 and exists (select 'X' from t1 a where a.c1 = t1.c2);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	r_rows	filtered	r_filtered	Extra
 1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	32.00	9.38	9.38	Using where
-1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	13.33	3.12	5.00	Using where; FirstMatch(t1)
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	14.00	3.12	4.76	Using where; FirstMatch(t1)
 select * from t1;
 c1	c2	c3
 1	3	3
@@ -5940,8 +5940,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	index	NULL	PRIMARY	4	NULL	1	Using where
-2	DEPENDENT SUBQUERY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
+1	PRIMARY	t1	index	PRIMARY	PRIMARY	4	NULL	1	
+1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -6888,8 +6888,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	ALL	NULL	NULL	NULL	NULL	32	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	ALL	NULL	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -7643,8 +7643,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	ALL	t1_c2	NULL	NULL	NULL	32	Using where
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	ALL	t1_c2	NULL	NULL	NULL	32	Using where; FirstMatch(t1)
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1
@@ -8401,8 +8401,8 @@ id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 explain delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	32	Using where; Using filesort
-2	DEPENDENT SUBQUERY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
+1	PRIMARY	t1	ALL	PRIMARY	NULL	NULL	NULL	32	Using filesort
+1	PRIMARY	a	eq_ref	PRIMARY	PRIMARY	4	test.t1.c3	1	Using where
 delete from t1 where c1 in (select a.c2 from t1 a where a.c3 = t1.c3)
 order by c3 desc limit 1;
 affected rows: 1

--- a/mysql-test/main/multidelete_engine.combinations
+++ b/mysql-test/main/multidelete_engine.combinations
@@ -1,0 +1,12 @@
+[myisam]
+default-storage-engine=myisam
+
+[aria]
+default-storage-engine=aria
+
+[innodb]
+innodb
+default-storage-engine=innodb
+
+[heap]
+default-storage-engine=memory

--- a/mysql-test/main/multidelete_engine.test
+++ b/mysql-test/main/multidelete_engine.test
@@ -1,0 +1,20 @@
+
+--echo # Check that limits work with hints & PS protocol
+
+create table t2 (id int, index xid(id));
+insert into t2 values (1),(10),(2),(9),(3),(8);
+
+prepare stmt from
+"DELETE t2.* FROM t2 use index(xid) ORDER BY (id) LIMIT ?";
+set @lim= 6;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+set @lim= 1;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+set @lim= 3;
+execute stmt using @lim;
+select * from t2 ORDER BY (id);
+
+drop table t2;
+

--- a/mysql-test/main/myisam_explain_non_select_all.result
+++ b/mysql-test/main/myisam_explain_non_select_all.result
@@ -120,7 +120,8 @@ Handler_read_rnd_next	4
 Variable_name	Value
 Handler_delete	1
 Handler_read_key	2
-Handler_read_rnd_next	4
+Handler_read_rnd	1
+Handler_read_rnd_next	6
 
 DROP TABLE t1;
 #4
@@ -927,8 +928,9 @@ Variable_name	Value
 Handler_delete	8
 Handler_read_key	19
 Handler_read_next	3
-Handler_read_rnd	5
-Handler_read_rnd_next	4
+Handler_read_rnd	8
+Handler_read_rnd_deleted	1
+Handler_read_rnd_next	15
 
 DROP TABLE t1, t2, t3;
 #20
@@ -1064,7 +1066,8 @@ Handler_read_rnd_next	12
 Variable_name	Value
 Handler_delete	3
 Handler_read_key	4
-Handler_read_rnd_next	30
+Handler_read_rnd	3
+Handler_read_rnd_next	34
 
 DROP TABLE t1, t2;
 #22
@@ -2891,7 +2894,7 @@ Variable_name	Value
 Handler_delete	4
 Handler_read_key	10
 Handler_read_rnd	4
-Handler_read_rnd_next	5
+Handler_read_rnd_next	10
 
 DROP TABLE t1,t2;
 DROP VIEW v1;
@@ -2940,7 +2943,7 @@ Variable_name	Value
 Handler_delete	4
 Handler_read_key	10
 Handler_read_rnd	4
-Handler_read_rnd_next	5
+Handler_read_rnd_next	10
 
 DROP TABLE t1,t2;
 DROP VIEW v1;

--- a/mysql-test/main/partition_explicit_prune.result
+++ b/mysql-test/main/partition_explicit_prune.result
@@ -1236,8 +1236,8 @@ HANDLER_READ_FIRST	1
 HANDLER_READ_KEY	2
 HANDLER_READ_NEXT	2
 HANDLER_READ_RND	4
-HANDLER_READ_RND_NEXT	16
-HANDLER_TMP_WRITE	24
+HANDLER_READ_RND_NEXT	22
+HANDLER_TMP_WRITE	28
 # 4 delete (2 in t2 + 2 in t3)
 # 12 locks (3 in t2, 1 in t3, 2 in t1) x 2 (lock + unlock)
 # 3 read first (1 in t1 + 1 in t3 + 1 in t3, for second row in t1)

--- a/mysql-test/suite/binlog/r/binlog_row_annotate.result
+++ b/mysql-test/suite/binlog/r/binlog_row_annotate.result
@@ -307,13 +307,13 @@ START TRANSACTION
 #010909  4:46:40 server id #  end_log_pos # 	Delete_rows: table id # flags: STMT_END_F
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
 ###   @1=2 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
 # Number of rows: 3
 # at #
 #010909  4:46:40 server id #  end_log_pos # 	Query	thread_id=#	exec_time=#	error_code=0	xid=<xid>
@@ -688,13 +688,13 @@ START TRANSACTION
 #010909  4:46:40 server id #  end_log_pos # 	Delete_rows: table id # flags: STMT_END_F
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
 ###   @1=2 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
 # Number of rows: 3
 # at #
 #010909  4:46:40 server id #  end_log_pos # 	Query	thread_id=#	exec_time=#	error_code=0	xid=<xid>
@@ -930,13 +930,13 @@ START TRANSACTION
 #010909  4:46:40 server id #  end_log_pos # 	Delete_rows: table id # flags: STMT_END_F
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
 ###   @1=2 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
 # Number of rows: 3
 # at #
 #010909  4:46:40 server id #  end_log_pos # 	Query	thread_id=#	exec_time=#	error_code=0	xid=<xid>
@@ -1305,13 +1305,13 @@ START TRANSACTION
 #010909  4:46:40 server id #  end_log_pos # 	Delete_rows: table id # flags: STMT_END_F
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
 ###   @1=2 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
 # Number of rows: 3
 # at #
 #010909  4:46:40 server id #  end_log_pos # 	Query	thread_id=#	exec_time=#	error_code=0	xid=<xid>

--- a/mysql-test/suite/binlog_encryption/binlog_row_annotate.result
+++ b/mysql-test/suite/binlog_encryption/binlog_row_annotate.result
@@ -311,13 +311,13 @@ START TRANSACTION
 #010909  4:46:40 server id #  end_log_pos # 	Delete_rows: table id # flags: STMT_END_F
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
 ###   @1=2 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
 # Number of rows: 3
 # at #
 #010909  4:46:40 server id #  end_log_pos # 	Query	thread_id=#	exec_time=#	error_code=0	xid=<xid>
@@ -692,13 +692,13 @@ START TRANSACTION
 #010909  4:46:40 server id #  end_log_pos # 	Delete_rows: table id # flags: STMT_END_F
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
 ###   @1=2 /* INT meta=0 nullable=1 is_null=0 */
 ### DELETE FROM `test2`.`t2`
 ### WHERE
-###   @1=1 /* INT meta=0 nullable=1 is_null=0 */
+###   @1=3 /* INT meta=0 nullable=1 is_null=0 */
 # Number of rows: 3
 # at #
 #010909  4:46:40 server id #  end_log_pos # 	Query	thread_id=#	exec_time=#	error_code=0	xid=<xid>

--- a/mysql-test/suite/federated/federated_maybe_16324629.result
+++ b/mysql-test/suite/federated/federated_maybe_16324629.result
@@ -10,7 +10,7 @@ connection master;
 create table t1 (a int, b int, unique key (a), key (b))
 engine=federated CONNECTION='mysql://root@127.0.0.1:SLAVE_PORT/federated/t1';
 insert into t1 values (3, 3), (7, 7);
-delete t1 from t1 where a = 3;
+delete t1 from t1 where b = 3;
 select * from t1;
 a	b
 7	7

--- a/mysql-test/suite/federated/federated_maybe_16324629.test
+++ b/mysql-test/suite/federated/federated_maybe_16324629.test
@@ -13,7 +13,7 @@ eval create table t1 (a int, b int, unique key (a), key (b))
  engine=federated CONNECTION='mysql://root@127.0.0.1:$SLAVE_MYPORT/federated/t1';
 
 insert into t1 values (3, 3), (7, 7);
-delete t1 from t1 where a = 3;
+delete t1 from t1 where b = 3;
 select * from t1;
 drop table t1;
 

--- a/mysql-test/suite/perfschema/r/multi_table_io.result
+++ b/mysql-test/suite/perfschema/r/multi_table_io.result
@@ -69,6 +69,7 @@ wait/io/table/sql/handler		TABLE	test1	t2	update	1
 wait/io/table/sql/handler		TABLE	test	marker	insert	1
 wait/io/table/sql/handler		TABLE	test	t1	fetch	1
 wait/io/table/sql/handler		TABLE	test1	t2	fetch	1
+wait/io/table/sql/handler		TABLE	test	t1	fetch	1
 wait/io/table/sql/handler		TABLE	test	t1	delete	1
 wait/io/table/sql/handler		TABLE	test1	t2	fetch	1
 wait/io/table/sql/handler		TABLE	test1	t2	delete	1

--- a/mysql-test/suite/sql_sequence/other.result
+++ b/mysql-test/suite/sql_sequence/other.result
@@ -202,11 +202,8 @@ CREATE SEQUENCE s;
 CREATE table t1 (a int);
 insert into t1 values (1),(2);
 DELETE s FROM s;
-ERROR HY000: Storage engine SEQUENCE of the table `test`.`s` doesn't have this option
 delete t1,s from s,t1;
-ERROR HY000: Storage engine SEQUENCE of the table `test`.`s` doesn't have this option
 delete s,t1 from t1,s;
-ERROR HY000: Storage engine SEQUENCE of the table `test`.`s` doesn't have this option
 DROP SEQUENCE s;
 DROP TABLE t1;
 #

--- a/mysql-test/suite/sql_sequence/other.test
+++ b/mysql-test/suite/sql_sequence/other.test
@@ -177,11 +177,8 @@ drop sequence s1;
 CREATE SEQUENCE s;
 CREATE table t1 (a int);
 insert into t1 values (1),(2);
---error ER_ILLEGAL_HA
 DELETE s FROM s;
---error ER_ILLEGAL_HA
 delete t1,s from s,t1;
---error ER_ILLEGAL_HA
 delete s,t1 from t1,s;
 DROP SEQUENCE s;
 DROP TABLE t1;

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -7160,7 +7160,7 @@ bool subselect_single_column_match_engine::partial_match()
 
 void Item_subselect::register_as_with_rec_ref(With_element *with_elem)
 {
-  with_elem->sq_with_rec_ref.link_in_list(this, &this->next_with_rec_ref);
+  with_elem->sq_with_rec_ref.insert(this, &this->next_with_rec_ref);
   with_recursive_reference= true;
 }
 

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -12291,3 +12291,6 @@ ER_VECTOR_BINARY_FORMAT_INVALID
         eng "Invalid binary vector format. Must use IEEE standard float representation in little-endian format. Use VEC_FromText() to generate it."
 ER_VECTOR_FORMAT_INVALID
         eng "Invalid vector format at offset: %d for '%-.100s'. Must be a valid JSON array of numbers."
+WARN_INDEX_HINTS_IGNORED
+        eng "Index hints are ignored because they are incompatible with RETURNING clause"
+        ukr "Підказки по використанню индексів ігноруются тому що вони несумісні з RETURNING"

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -2415,7 +2415,7 @@ bool sp_add_used_routine(Query_tables_list *prelocking_ctx, Query_arena *arena,
     MDL_REQUEST_INIT_BY_KEY(&rn->mdl_request, key, MDL_SHARED, MDL_TRANSACTION);
     if (my_hash_insert(&prelocking_ctx->sroutines, (uchar *)rn))
       return FALSE;
-    prelocking_ctx->sroutines_list.link_in_list(rn, &rn->next);
+    prelocking_ctx->sroutines_list.insert(rn, &rn->next);
     rn->belong_to_view= belong_to_view;
     rn->m_handler= handler;
     rn->m_sp_cache_version= 0;

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -3159,7 +3159,7 @@ int sp_head::add_instr(sp_instr *instr)
     if (instr_trig_fld_list)
     {
       m_cur_instr_trig_field_items.save_and_clear(instr_trig_fld_list);
-      m_trg_table_fields.link_in_list(
+      m_trg_table_fields.insert(
         instr_trig_fld_list,
         &instr_trig_fld_list->first->next_trig_field_list);
     }

--- a/sql/sp_instr.cc
+++ b/sql/sp_instr.cc
@@ -1342,7 +1342,7 @@ bool sp_instr_set_trigger_field::on_after_expr_parsing(THD *thd)
   if (!val || !trigger_field)
     return true;
 
-  thd->spcont->m_sp->m_cur_instr_trig_field_items.link_in_list(
+  thd->spcont->m_sp->m_cur_instr_trig_field_items.insert(
     trigger_field, &trigger_field->next_trg_field);
 
   value= val;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -7602,7 +7602,8 @@ class multi_update :public select_result_interceptor
 {
   TABLE_LIST *all_tables; /* query/update command tables */
   List<TABLE_LIST> *leaves;     /* list of leaves of join table tree */
-  List<TABLE_LIST> updated_leaves;  /* list of of updated leaves */
+  List<TABLE_LIST> updated_leaves;  /* a superset of tables which will be updated */
+  List<TABLE_LIST> update_targets;  /* the tables that will be UPDATE'd */
   TABLE_LIST *update_tables;
   TABLE **tmp_tables, *main_table, *table_to_update;
   TMP_TABLE_PARAM *tmp_table_param;
@@ -7634,6 +7635,7 @@ class multi_update :public select_result_interceptor
   ha_rows updated_sys_ver;
 
   bool has_vers_fields;
+  const table_map tables_to_update;
 
 public:
   multi_update(THD *thd_arg, TABLE_LIST *ut, List<TABLE_LIST> *leaves_list,

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -7563,16 +7563,17 @@ class SORT_INFO;
 class multi_delete :public select_result_interceptor
 {
   TABLE_LIST *delete_tables, *table_being_deleted;
+  TMP_TABLE_PARAM *tmp_table_param;
+  TABLE **tmp_tables, *main_table;
   Unique **tempfiles;
   ha_rows deleted, found;
-  uint num_of_tables;
+  uint table_count;
   int error;
   bool do_delete;
   /* True if at least one table we delete from is transactional */
   bool transactional_tables;
   /* True if at least one table we delete from is not transactional */
   bool normal_tables;
-  bool delete_while_scanning;
   /*
      error handling (rollback and binlogging) can happen in send_eof()
      so that afterward abort_result_set() needs to find out that.
@@ -7581,15 +7582,17 @@ class multi_delete :public select_result_interceptor
 
 public:
   // Methods used by ColumnStore
-  uint get_num_of_tables() const { return num_of_tables; }
+  uint get_num_of_tables() const { return table_count; }
   TABLE_LIST* get_tables() const { return delete_tables; }
 public:
   multi_delete(THD *thd_arg, TABLE_LIST *dt, uint num_of_tables);
   ~multi_delete();
   int prepare(List<Item> &list, SELECT_LEX_UNIT *u) override;
+  int prepare2(JOIN *join) override;
   int send_data(List<Item> &items) override;
   bool initialize_tables (JOIN *join) override;
   int do_deletes();
+  int rowid_table_deletes(TABLE *table, bool ignore);
   int do_table_deletes(TABLE *table, SORT_INFO *sort_info, bool ignore);
   bool send_eof() override;
   inline ha_rows num_deleted() const { return deleted; }

--- a/sql/sql_cte.cc
+++ b/sql/sql_cte.cc
@@ -51,7 +51,7 @@ bool With_clause::add_with_element(With_element *elem)
   elem->owner= this;
   elem->number= with_list.elements;
   elem->spec->with_element= elem;
-  with_list.link_in_list(elem, &elem->next);
+  with_list.insert(elem, &elem->next);
   return false;
 }
 

--- a/sql/sql_derived.cc
+++ b/sql/sql_derived.cc
@@ -1112,7 +1112,7 @@ bool mysql_derived_create(THD *thd, LEX *lex, TABLE_LIST *derived)
 
 void TABLE_LIST::register_as_derived_with_rec_ref(With_element *rec_elem)
 {
-  rec_elem->derived_with_rec_ref.link_in_list(this, &this->next_with_rec_ref);
+  rec_elem->derived_with_rec_ref.insert(this, &this->next_with_rec_ref);
   is_derived_with_recursive_reference= true;
   get_unit()->uncacheable|= UNCACHEABLE_DEPENDENT;
 }

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -242,7 +242,7 @@ bool LEX::set_trigger_new_row(const LEX_CSTRING *name, Item *val,
     Let us add this item to list of all Item_trigger_field
     objects in trigger.
   */
-  sphead->m_cur_instr_trig_field_items.link_in_list(trg_fld,
+  sphead->m_cur_instr_trig_field_items.insert(trg_fld,
                                                     &trg_fld->next_trg_field);
 
   return sphead->add_instr(sp_fld);
@@ -8172,7 +8172,7 @@ Item *LEX::create_and_link_Item_trigger_field(THD *thd,
     in trigger.
   */
   if (likely(trg_fld))
-    sphead->m_cur_instr_trig_field_items.link_in_list(trg_fld,
+    sphead->m_cur_instr_trig_field_items.insert(trg_fld,
                                                       &trg_fld->next_trg_field);
 
   return trg_fld;

--- a/sql/sql_list.h
+++ b/sql/sql_list.h
@@ -61,7 +61,7 @@ public:
     next= &first;
   }
 
-  inline void link_in_list(T *element, T **next_ptr)
+  inline void insert(T *element, T **next_ptr)
   {
     elements++;
     (*next)= element;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2065,7 +2065,7 @@ dispatch_command_return dispatch_command(enum enum_server_command command, THD *
     */
     table_list.select_lex= thd->lex->first_select_lex();
     thd->lex->
-      first_select_lex()->table_list.link_in_list(&table_list,
+      first_select_lex()->table_list.insert(&table_list,
                                                   &table_list.next_local);
     thd->lex->add_to_query_tables(&table_list);
 
@@ -7989,7 +7989,7 @@ add_proc_to_list(THD* thd, Item *item)
   item_ptr = (Item**) (order+1);
   *item_ptr= item;
   order->item=item_ptr;
-  thd->lex->proc_list.link_in_list(order, &order->next);
+  thd->lex->proc_list.insert(order, &order->next);
   return 0;
 }
 
@@ -8010,7 +8010,7 @@ bool add_to_list(THD *thd, SQL_I_List<ORDER> &list, Item *item,bool asc)
   order->used=0;
   order->counter_used= 0;
   order->fast_field_copier_setup= 0; 
-  list.link_in_list(order, &order->next);
+  list.insert(order, &order->next);
   DBUG_RETURN(0);
 }
 
@@ -8188,7 +8188,7 @@ TABLE_LIST *st_select_lex::add_table_to_list(THD *thd,
     and SELECT.
   */
   if (likely(!ptr->sequence))
-    table_list.link_in_list(ptr, &ptr->next_local);
+    table_list.insert(ptr, &ptr->next_local);
   ptr->next_name_resolution_table= NULL;
 #ifdef WITH_PARTITION_STORAGE_ENGINE
   ptr->partition_names= partition_names;

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -1055,7 +1055,7 @@ st_select_lex_unit::init_prepare_fake_select_lex(THD *thd_arg,
                                                   bool first_execution) 
 {
   thd_arg->lex->current_select= fake_select_lex;
-  fake_select_lex->table_list.link_in_list(&result_table_list,
+  fake_select_lex->table_list.insert(&result_table_list,
                                            &result_table_list.next_local);
   fake_select_lex->context.table_list= 
     fake_select_lex->context.first_name_resolution_table= 

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1761,6 +1761,7 @@ rule:
         query_expression_tail
         opt_query_expression_tail
         order_or_limit
+        opt_order_or_limit
         order_limit_lock
         opt_order_limit_lock
 
@@ -12886,6 +12887,18 @@ opt_procedure_or_into:
           }
         ;
 
+opt_order_or_limit:
+          /* empty */
+          {
+            $$= NULL;
+          }
+        |
+          order_or_limit
+          {
+            $1->lock.empty();
+            $$= $1;
+          }
+        ;
 
 order_or_limit:
           order_clause opt_limit_clause
@@ -13878,7 +13891,7 @@ delete_part2:
         ;
 
 delete_single_table:
-          FROM table_ident opt_table_alias_clause opt_use_partition
+          FROM table_ident opt_table_alias_clause opt_key_definition opt_use_partition
           {
             if (unlikely(!Select->
                          add_table_to_list(thd, $2, $3, TL_OPTION_UPDATING,
@@ -13897,8 +13910,8 @@ delete_single_table:
                          add_table_to_list(thd, $2, $3, TL_OPTION_UPDATING,
                                            YYPS->m_lock_type,
                                            YYPS->m_mdl_type,
-                                           NULL,
-                                           $4)))
+                                           Select->pop_index_hints(),
+                                           $5)))
               MYSQL_YYABORT;
             Lex->auxiliary_table_list.first->correspondent_table=
               Lex->query_tables;
@@ -13944,10 +13957,15 @@ single_multi:
             YYPS->m_lock_type= TL_READ_DEFAULT;
             YYPS->m_mdl_type= MDL_SHARED_READ;
           }
-          FROM join_table_list opt_where_clause
+          FROM join_table_list opt_where_clause opt_order_or_limit
           {
             if (unlikely(multi_delete_set_locks_and_link_aux_tables(Lex)))
               MYSQL_YYABORT;
+            if ($6)
+            {
+              DBUG_ASSERT(Lex->select_stack_head() == Select);
+              $6->set_to(Lex->select_stack_head());
+            }
           } stmt_end {}
         | FROM table_alias_ref_list
           {
@@ -13960,10 +13978,15 @@ single_multi:
             YYPS->m_lock_type= TL_READ_DEFAULT;
             YYPS->m_mdl_type= MDL_SHARED_READ;
           }
-          USING join_table_list opt_where_clause
+          USING join_table_list opt_where_clause opt_order_or_limit
           {
             if (unlikely(multi_delete_set_locks_and_link_aux_tables(Lex)))
               MYSQL_YYABORT;
+            if ($7)
+            {
+              DBUG_ASSERT(Lex->select_stack_head() == Select);
+              $7->set_to(Lex->select_stack_head());
+            }
           } stmt_end {}
         ;
 


### PR DESCRIPTION
…ints for single-table DELETE.

We now allow multitable queries with order by and limit, such as:
  delete t1.*, t2.* from t1, t2 order by t1.id desc limit 3;
To predict what rows will be deleted, run the equivalent select:
  select t1.*, t2.* from t1, t2 order by t1.id desc limit 3;
Additionally, index hints are now supported with single table delete statements:
  delete from t2 use index(xid) order by (id) limit 2;

This approach changes the multi_delete SELECT result interceptor to use a temporary table to collect row ids pertaining to the rows that will be deleted, rather than directly deleting rows from the target table(s).  Row ids are collected during send_data, then read during send_eof to delete target rows.  In the event that the temporary table created in memory is not big enough for all matching rows, it is converted to an aria table.

This patch includes a number of changes that begin to make the code easier to maintain
  - Renamed SQL_I_List::link_in_list to SQL_I_List::insert.  link_in_list was ambiguous as it could refer to a link or it could refer to a node
  - Remove field_name local variable in multi_update::initialize_tables because it is not used when creating the temporary tables
  - multi_update changes:
    - Move temp table callocs to init, a more natural location for them, and moved tables_to_update to const member variable so we don't recompute it.
    - Filter out jtbm tables and tables not in the update map, pushing those that will be updated into an update_targets container.  This simplifies checks and loops in initialize_tables.

Other changes:

- Deleting from a sequence now affects zero rows instead of emitting an error

Limitations:
  - The federated connector does not create implicit row ids, so we to use a key when conditionally deleting.  See the change in federated_maybe_16324629.test
