### PR TITLE
MDEV-11675 fixup: MDEV-35474 Start Alter GTID Error Message Can Use Wrong Server_Id

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_start_alter_restart_master.result
+++ b/mysql-test/suite/rpl/r/rpl_start_alter_restart_master.result
@@ -12,7 +12,8 @@ set global slave_parallel_mode=optimistic;
 set global gtid_strict_mode=1;
 start slave;
 connection master;
-call mtr.add_suppression("ALTER query started at .+ could not be completed");
+SET @@session.server_id= 11;
+call mtr.add_suppression("ALTER query started at 0-11-\\d+ could not be completed");
 SET @old_debug_master= @@global.debug;
 set binlog_alter_two_phase=true;
 create table t3( a int primary key, b int) engine=innodb;
@@ -37,7 +38,7 @@ t3	CREATE TABLE `t3` (
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
-master-bin.000001	#	Query	#	#	use `mtr`; INSERT INTO test_suppressions (pattern) VALUES ( NAME_CONST('pattern',_latin1'ALTER query started at .+ could not be completed' COLLATE 'latin1_swedish_ci'))
+master-bin.000001	#	Query	#	#	use `mtr`; INSERT INTO test_suppressions (pattern) VALUES ( NAME_CONST('pattern',_latin1'ALTER query started at 0-11-\\d+ could not be completed' COLLATE 'latin1_swedish_ci'))
 master-bin.000001	#	Query	#	#	COMMIT
 master-bin.000001	#	Gtid	#	#	GTID #-#-#
 master-bin.000001	#	Query	#	#	use `test`; create table t3( a int primary key, b int) engine=innodb
@@ -56,7 +57,7 @@ connection slave;
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 slave-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
-slave-bin.000001	#	Query	#	#	use `mtr`; INSERT INTO test_suppressions (pattern) VALUES ( NAME_CONST('pattern',_latin1'ALTER query started at .+ could not be completed' COLLATE 'latin1_swedish_ci'))
+slave-bin.000001	#	Query	#	#	use `mtr`; INSERT INTO test_suppressions (pattern) VALUES ( NAME_CONST('pattern',_latin1'ALTER query started at 0-11-\\d+ could not be completed' COLLATE 'latin1_swedish_ci'))
 slave-bin.000001	#	Query	#	#	COMMIT
 slave-bin.000001	#	Gtid	#	#	GTID #-#-#
 slave-bin.000001	#	Query	#	#	use `test`; create table t3( a int primary key, b int) engine=innodb

--- a/mysql-test/suite/rpl/t/rpl_start_alter_restart_master.test
+++ b/mysql-test/suite/rpl/t/rpl_start_alter_restart_master.test
@@ -26,7 +26,12 @@ set global gtid_strict_mode=1;
 start slave;
 
 --connection master
-call mtr.add_suppression("ALTER query started at .+ could not be completed");
+# MDEV-35474 Start Alter GTID Error Message Can Use Wrong Server_Id
+#
+# When replicating, the GTID the slave warns should be of this sessional
+# server_id rather than 1 from reconnecting to the restarted master.
+SET @@session.server_id= 11;
+call mtr.add_suppression("ALTER query started at 0-11-\\d+ could not be completed");
 
 SET @old_debug_master= @@global.debug;
 --let $binlog_alter_two_phase= `select @@binlog_alter_two_phase`

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -626,8 +626,9 @@ bool write_bin_log_start_alter(THD *thd, bool& partial_alter,
     start_alter_info *info= thd->rgi_slave->sa_info;
     bool is_shutdown= false;
 
-    info->sa_seq_no= start_alter_id;
-    info->domain_id= thd->variables.gtid_domain_id;
+    info->gtid.domain_id= thd->variables.gtid_domain_id;
+    info->gtid.server_id= thd->variables.server_id;
+    info->gtid.seq_no= start_alter_id;
     mysql_mutex_lock(&mi->start_alter_list_lock);
     // possible stop-slave's marking of the whole alter state list is checked
     is_shutdown= mi->is_shutdown;

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -654,8 +654,7 @@ struct start_alter_info
   /*
     ALTER id is defined as a pair of GTID's seq_no and domain_id.
   */
-  decltype(rpl_gtid::seq_no) sa_seq_no; // key for searching (SA's id)
-  uint32 domain_id;
+  rpl_gtid gtid; // rpl_gtid::seq_no is the key for searching (SA's id)
   bool   direct_commit_alter; // when true CA thread executes the whole query
   /*
     0 prepared and not error from commit and rollback

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7628,7 +7628,7 @@ write_bin_log_start_alter_rollback(THD *thd, uint64 &start_alter_id,
     start_alter_info *info= thd->rgi_slave->sa_info;
     Master_info *mi= thd->rgi_slave->rli->mi;
 
-    if (info->sa_seq_no == 0)
+    if (info->gtid.seq_no == 0)
     {
       /*
          Error occurred before SA got to processing incl its binlogging.


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-35474](https://jira.mariadb.org/browse/MDEV-35474)*

## Description
Store a whole GTID in `start_alter_info` entries.

While Two-Phase ALTER only cares about the `domain_id` and `seq_no`, logs/warnings that show full GTIDs also need the ALTER’s `server_id`.

### What problem is the patch trying to solve?
The Two-Phase ALTER work ([MDEV-11675](https://jira.mariadb.org/browse/MDEV-11675)) left an error message with an incomplete (and out-of-order), TODO GTID report.
The fix https://github.com/MariaDB/server/pull/3518/commits/8c18af91bf4bfe58d7ac02e04d0648af75d6886f also incorrectly filled it in with the *current primary* `server_id`, which isn’t necessarily the `server_id` of the ALTER (which varies on replication setups or `server_id` configs).

### Do you think this patch might introduce side-effects in other parts of the server?
Instead of filling in a `struct start_alter_info::server_id` member, I decided to replace its current `sa_seq_no` & `domain_id` with a whole GTID (inline-memory) member.
I find this design more intuitively structural.

I normally wouldn’t refactor APIs in a bug fix, but it looks like only Two-Phase ALTER uses `struct`, so I made this exception.
Of course, this’d still conflict with collegues’ related work, if any.

## Release Notes
(We can nest this under #3518.)
Fixed the GTID in the warning message of when replication encounters a two-phase ALTER query that failed to complete in the primary.

## How can this PR be tested?
MDEV-11675 includes the test `rpl_start_alter_restart_master` for testing this “failed to complete” behavior.
I included the transaction server ID in its warning suppression to check for the current session server ID.

## Basing the PR against the correct MariaDB version
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.