### PR TITLE
MDEV-35207 ignored error at binlogging by CREATE-TABLE-SELECT leads to assert + MDEV-35499 + MDEV-35502

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_create_select_row.result
+++ b/mysql-test/suite/rpl/r/rpl_create_select_row.result
@@ -6,7 +6,7 @@ set @binlog_cache_size             = @@global.binlog_cache_size;
 set @@global.max_binlog_cache_size = 4096;
 set @@global.    binlog_cache_size = 4096;
 #
-# MDEV-35207
+# MDEV-35207 ignored error at binlogging by CREATE-TABLE-SELECT leads to assert
 #
 connect  conn_err,localhost,root,,;
 call mtr.add_suppression("Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage");
@@ -22,7 +22,7 @@ disconnect conn_err;
 connection master;
 
 #
-# TODO: MDEV-35499 errored CoRS does not DROP table in binlog
+# MDEV-35499 errored CREATE-OR-REPLACE-SELECT does not DROP table in binlog
 #
 #
 # Engine = innodb

--- a/mysql-test/suite/rpl/r/rpl_create_select_row.result
+++ b/mysql-test/suite/rpl/r/rpl_create_select_row.result
@@ -1,0 +1,109 @@
+include/master-slave.inc
+[connection master]
+connection master;
+set @max_binlog_cache_size         = @@global.max_binlog_cache_size;
+set @binlog_cache_size             = @@global.binlog_cache_size;
+set @@global.max_binlog_cache_size = 4096;
+set @@global.    binlog_cache_size = 4096;
+#
+# MDEV-35207
+#
+connect  conn_err,localhost,root,,;
+call mtr.add_suppression("Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage");
+create table t engine=myisam select repeat ('a',4096*3) AS a;
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mariadbd variable and try again
+create table t engine=innodb select repeat ('a',4096*3) AS a;
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mariadbd variable and try again
+create table t (a int unique, b char) select 1 AS a, 'b' as b union select 1 as a, 'c' as b;
+ERROR 23000: Duplicate entry '1' for key 'a'
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist
+disconnect conn_err;
+connection master;
+
+#
+# TODO: MDEV-35499 errored CoRS does not DROP table in binlog
+#
+#
+# Engine = innodb
+#
+set statement binlog_format=statement for create table t (a int) select 1 as a;
+set statement binlog_format=row for create or replace table t (a int primary key, b char) engine=innodb select 1 AS a, 'b' as b union select 1 as a, 'c' as b;
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist
+#
+# Prove an expected lonely `DROP table t'
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; DROP TABLE IF EXISTS `test`.`t`/* Generated to handle failed CREATE OR REPLACE */
+master-bin.000001	#	Query	#	#	ROLLBACK
+set statement binlog_format=statement for create table t (a int) select 1 as a;
+set statement binlog_format=row for create or replace table t (a text) engine=innodb select repeat ('a',1024) AS a union select repeat ('a',3*4096) AS a union select repeat ('a',3*4096) AS a;
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mariadbd variable and try again
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist
+#
+# Prove an expected lonely `DROP table t'
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; DROP TABLE IF EXISTS `test`.`t`/* Generated to handle failed CREATE OR REPLACE */
+master-bin.000001	#	Query	#	#	ROLLBACK
+set statement binlog_format=statement for create table t (a int) select 1 as a;
+set statement binlog_format=row for create or replace table t (a text) engine=innodb select repeat ('a',4096*3) AS a;;
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mariadbd variable and try again
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist
+#
+# Prove an expected lonely `DROP table t'
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; DROP TABLE IF EXISTS `test`.`t`/* Generated to handle failed CREATE OR REPLACE */
+master-bin.000001	#	Query	#	#	ROLLBACK
+#
+# Engine = myisam
+#
+set statement binlog_format=statement for create table t (a int) select 1 as a;
+set statement binlog_format=row for create or replace table t (a int primary key, b char) engine=myisam select 1 AS a, 'b' as b union select 1 as a, 'c' as b;
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist
+#
+# Prove an expected lonely `DROP table t'
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; DROP TABLE IF EXISTS `test`.`t`/* Generated to handle failed CREATE OR REPLACE */
+master-bin.000001	#	Query	#	#	ROLLBACK
+set statement binlog_format=statement for create table t (a int) select 1 as a;
+set statement binlog_format=row for create or replace table t (a text) engine=myisam select repeat ('a',1024) AS a union select repeat ('a',3*4096) AS a union select repeat ('a',3*4096) AS a;
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mariadbd variable and try again
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist
+#
+# Prove an expected lonely `DROP table t'
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; DROP TABLE IF EXISTS `test`.`t`/* Generated to handle failed CREATE OR REPLACE */
+master-bin.000001	#	Query	#	#	ROLLBACK
+set statement binlog_format=statement for create table t (a int) select 1 as a;
+set statement binlog_format=row for create or replace table t (a text) engine=myisam select repeat ('a',4096*3) AS a;;
+ERROR HY000: Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage; increase this mariadbd variable and try again
+select * from t;
+ERROR 42S02: Table 'test.t' doesn't exist
+#
+# Prove an expected lonely `DROP table t'
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Query	#	#	use `test`; DROP TABLE IF EXISTS `test`.`t`/* Generated to handle failed CREATE OR REPLACE */
+master-bin.000001	#	Query	#	#	ROLLBACK
+SET @@global.max_binlog_cache_size = @max_binlog_cache_size;
+SET @@global.    binlog_cache_size = @binlog_cache_size;
+connection slave;
+End of the tests
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_create_select_row.result
+++ b/mysql-test/suite/rpl/r/rpl_create_select_row.result
@@ -102,6 +102,55 @@ Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
 master-bin.000001	#	Query	#	#	use `test`; DROP TABLE IF EXISTS `test`.`t`/* Generated to handle failed CREATE OR REPLACE */
 master-bin.000001	#	Query	#	#	ROLLBACK
+create table ti_pk (a int primary key) engine=innodb;
+create table ta (a int) engine=aria;
+create function f_ia(arg int)
+returns integer
+begin
+insert into ti_pk set a=1;
+insert into ta set a=1;
+insert into ti_pk set a=arg;
+return 1;
+end |
+set statement binlog_format = ROW for create table t_y (a int) engine=aria select f_ia(1 /* err */) as a;
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+select * from t_y;
+ERROR 42S02: Table 'test.t_y' doesn't exist
+# correct execution: `ta` is modified and its new record is binlogged
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Gtid	#	#	BEGIN GTID #-#-#
+master-bin.000001	#	Table_map	#	#	table_id: # (test.ta)
+master-bin.000001	#	Write_rows_v1	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Query	#	#	COMMIT
+select * from ta;
+a
+1
+select * from ti_pk;
+a
+connection slave;
+include/diff_tables.inc [master:ta,slave:ta]
+connection master;
+delete from ta;
+connection slave;
+connection master;
+set statement binlog_format = STATEMENT for create table t_y (a int) engine=aria select f_ia(1 /* err */) as a;
+ERROR 23000: Duplicate entry '1' for key 'PRIMARY'
+select * from t_y;
+ERROR 42S02: Table 'test.t_y' doesn't exist
+# MDEV-36027: `ta` is modified but that's not binlogged
+include/show_binlog_events.inc
+select *,'on_master' from ta;
+a	on_master
+1	on_master
+select * from ti_pk;
+a
+connection slave;
+select *,'on_slave' from ta;
+a	on_slave
+connection master;
+drop function f_ia;
+drop table ti_pk, ta;
 SET @@global.max_binlog_cache_size = @max_binlog_cache_size;
 SET @@global.    binlog_cache_size = @binlog_cache_size;
 connection slave;

--- a/mysql-test/suite/rpl/t/rpl_create_select_row.test
+++ b/mysql-test/suite/rpl/t/rpl_create_select_row.test
@@ -9,9 +9,9 @@ set @@global.max_binlog_cache_size = 4096;
 set @@global.    binlog_cache_size = 4096;
 
 --echo #
---echo # MDEV-35207
+--echo # MDEV-35207 ignored error at binlogging by CREATE-TABLE-SELECT leads to assert
 --echo #
-# fixate the current (write) binlog position
+# fix the current (write) binlog position
 --let $binlog_file_0= query_get_value(SHOW MASTER STATUS, File, 1)
 --let $binlog_start_0 = query_get_value(SHOW MASTER STATUS, Position, 1)
 
@@ -45,7 +45,7 @@ if (!$cmp)
 
 --echo
 --echo #
---echo # TODO: MDEV-35499 errored CoRS does not DROP table in binlog
+--echo # MDEV-35499 errored CREATE-OR-REPLACE-SELECT does not DROP table in binlog
 --echo #
 --let $i = 2
 while ($i)
@@ -95,7 +95,7 @@ while ($i)
 SET @@global.max_binlog_cache_size = @max_binlog_cache_size;
 SET @@global.    binlog_cache_size = @binlog_cache_size;
 
-# prove binlog is sane for slave as well
+# test that binlog replicates correctly to slave
 # --connection slave
 --sync_slave_with_master
 

--- a/mysql-test/suite/rpl/t/rpl_create_select_row.test
+++ b/mysql-test/suite/rpl/t/rpl_create_select_row.test
@@ -92,6 +92,64 @@ while ($i)
 --dec $i
 }
 
+# Tests of mixed engines to demonstrate non-transaction table updates
+# are binlogged or otherwise MDEV-36027.
+create table ti_pk (a int primary key) engine=innodb;
+create table ta (a int) engine=aria;
+delimiter |;
+create function f_ia(arg int)
+returns integer
+begin
+  insert into ti_pk set a=1;
+  insert into ta set a=1;
+  insert into ti_pk set a=arg;
+  return 1;
+end |
+delimiter ;|
+
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $binlog_start = query_get_value(SHOW MASTER STATUS, Position, 1)
+
+--error ER_DUP_ENTRY
+set statement binlog_format = ROW for create table t_y (a int) engine=aria select f_ia(1 /* err */) as a;
+--error ER_NO_SUCH_TABLE
+select * from t_y;
+
+--echo # correct execution: `ta` is modified and its new record is binlogged
+--source include/show_binlog_events.inc
+select * from ta;
+select * from ti_pk;
+
+--sync_slave_with_master
+--let  $diff_tables=master:ta,slave:ta
+--source include/diff_tables.inc
+
+--connection master
+delete from ta;
+--sync_slave_with_master
+
+--connection master
+# MDEV-36027 Errored-out CREATE-SELECT does not binlog results of any function modifying non-transactional table
+--let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $binlog_start = query_get_value(SHOW MASTER STATUS, Position, 1)
+--error ER_DUP_ENTRY
+set statement binlog_format = STATEMENT for create table t_y (a int) engine=aria select f_ia(1 /* err */) as a;
+--error ER_NO_SUCH_TABLE
+select * from t_y;
+
+--echo # MDEV-36027: `ta` is modified but that's not binlogged
+--source include/show_binlog_events.inc
+select *,'on_master' from ta;
+select * from ti_pk;
+
+--sync_slave_with_master
+select *,'on_slave' from ta;
+
+# Cleanup
+--connection master
+drop function f_ia;
+drop table ti_pk, ta;
+
 SET @@global.max_binlog_cache_size = @max_binlog_cache_size;
 SET @@global.    binlog_cache_size = @binlog_cache_size;
 

--- a/mysql-test/suite/rpl/t/rpl_create_select_row.test
+++ b/mysql-test/suite/rpl/t/rpl_create_select_row.test
@@ -1,0 +1,103 @@
+--source include/have_binlog_format_row.inc
+--source include/have_innodb.inc
+--source include/master-slave.inc
+
+--connection master
+set @max_binlog_cache_size         = @@global.max_binlog_cache_size;
+set @binlog_cache_size             = @@global.binlog_cache_size;
+set @@global.max_binlog_cache_size = 4096;
+set @@global.    binlog_cache_size = 4096;
+
+--echo #
+--echo # MDEV-35207
+--echo #
+# fixate the current (write) binlog position
+--let $binlog_file_0= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $binlog_start_0 = query_get_value(SHOW MASTER STATUS, Position, 1)
+
+# use a separate connection also to validate its close will be clean
+connect (conn_err,localhost,root,,);
+
+call mtr.add_suppression("Multi-statement transaction required more than 'max_binlog_cache_size' bytes of storage");
+--error ER_TRANS_CACHE_FULL
+create table t engine=myisam select repeat ('a',4096*3) AS a;
+
+--error ER_TRANS_CACHE_FULL
+create table t engine=innodb select repeat ('a',4096*3) AS a;
+
+--error ER_DUP_ENTRY
+create table t (a int unique, b char) select 1 AS a, 'b' as b union select 1 as a, 'c' as b;
+--error ER_NO_SUCH_TABLE
+select * from t;
+
+--disconnect conn_err
+
+--connection master
+--let $binlog_file_1= query_get_value(SHOW MASTER STATUS, File, 1)
+--let $binlog_start_1= query_get_value(SHOW MASTER STATUS, Position, 1)
+
+--let $cmp = `select strcmp('$binlog_file_1', '$binlog_file_0') <> 0 OR $binlog_start_1 <> $binlog_start_0`
+if (!$cmp)
+{
+   --echo *** Error: unexpected advance of binlog position
+   --die
+}
+
+--echo
+--echo #
+--echo # TODO: MDEV-35499 errored CoRS does not DROP table in binlog
+--echo #
+--let $i = 2
+while ($i)
+{
+  --let $engine=`select if($i % 2, "myisam", "innodb")`
+  --echo #
+  --echo # Engine = $engine
+  --echo #
+  set statement binlog_format=statement for create table t (a int) select 1 as a;
+  --let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+  --let $binlog_start = query_get_value(SHOW MASTER STATUS, Position, 1)
+  --error ER_DUP_ENTRY
+  --eval set statement binlog_format=row for create or replace table t (a int primary key, b char) engine=$engine select 1 AS a, 'b' as b union select 1 as a, 'c' as b
+  --error ER_NO_SUCH_TABLE
+  select * from t;
+  --echo #
+  --echo # Prove an expected lonely `DROP table t'
+  --source include/show_binlog_events.inc
+
+  # error before stmt commit
+  set statement binlog_format=statement for create table t (a int) select 1 as a;
+  --let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+  --let $binlog_start = query_get_value(SHOW MASTER STATUS, Position, 1)
+  --error ER_TRANS_CACHE_FULL
+  --eval set statement binlog_format=row for create or replace table t (a text) engine=$engine select repeat ('a',1024) AS a union select repeat ('a',3*4096) AS a union select repeat ('a',3*4096) AS a
+  --error ER_NO_SUCH_TABLE
+  select * from t;
+  --echo #
+  --echo # Prove an expected lonely `DROP table t'
+  --source include/show_binlog_events.inc
+
+  # error at stmt commit
+  set statement binlog_format=statement for create table t (a int) select 1 as a;
+  --let $binlog_file= query_get_value(SHOW MASTER STATUS, File, 1)
+  --let $binlog_start = query_get_value(SHOW MASTER STATUS, Position, 1)
+  --error ER_TRANS_CACHE_FULL
+  --eval set statement binlog_format=row for create or replace table t (a text) engine=$engine select repeat ('a',4096*3) AS a;
+  --error ER_NO_SUCH_TABLE
+  select * from t;
+  --echo #
+  --echo # Prove an expected lonely `DROP table t'
+  --source include/show_binlog_events.inc
+
+--dec $i
+}
+
+SET @@global.max_binlog_cache_size = @max_binlog_cache_size;
+SET @@global.    binlog_cache_size = @binlog_cache_size;
+
+# prove binlog is sane for slave as well
+# --connection slave
+--sync_slave_with_master
+
+--echo End of the tests
+--source include/rpl_end.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -320,6 +320,11 @@ public:
     incident= TRUE;
   }
   
+  void clear_incident(void)
+  {
+    incident= FALSE;
+  }
+
   bool has_incident(void)
   {
     return(incident);
@@ -1957,13 +1962,9 @@ binlog_truncate_trx_cache(THD *thd, binlog_cache_mngr *cache_mngr, bool all)
   */
   if (ending_trans(thd, all))
   {
-    DBUG_ASSERT(!cache_mngr->trx_cache.has_incident() ||
-		thd->lex->sql_command != SQLCOM_CREATE_TABLE ||
-		thd->is_current_stmt_binlog_format_row());
-
-    if (cache_mngr->trx_cache.has_incident() &&
-	thd->lex->sql_command != SQLCOM_CREATE_TABLE)
+    if (cache_mngr->trx_cache.has_incident())
       error= mysql_bin_log.write_incident(thd);
+
     thd->reset_binlog_for_next_statement();
 
     cache_mngr->reset(false, true);
@@ -2358,6 +2359,18 @@ void binlog_reset_cache(THD *thd)
     cache_mngr->reset(true, true);
   }
   DBUG_VOID_RETURN;
+}
+
+
+void binlog_clear_incident(THD *thd)
+{
+  binlog_cache_mngr *const cache_mngr= opt_bin_log ?
+    (binlog_cache_mngr*) thd_get_ha_data(thd, binlog_hton) : 0;
+  if (cache_mngr)
+  {
+    cache_mngr->stmt_cache.clear_incident();
+    cache_mngr->trx_cache.clear_incident();
+  }
 }
 
 

--- a/sql/log.h
+++ b/sql/log.h
@@ -1186,6 +1186,7 @@ File open_binlog(IO_CACHE *log, const char *log_file_name,
 
 void make_default_log_name(char **out, const char* log_ext, bool once);
 void binlog_reset_cache(THD *thd);
+void binlog_clear_incident(THD *thd);
 bool write_annotated_row(THD *thd);
 
 extern MYSQL_PLUGIN_IMPORT MYSQL_BIN_LOG mysql_bin_log;

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -4475,7 +4475,8 @@ void select_insert::abort_result_set()
 	  query_cache_invalidate3(thd, table, 1);
     }
     DBUG_ASSERT(transactional_table || !changed ||
-		thd->transaction->stmt.modified_non_trans_table);
+		(thd->transaction->stmt.modified_non_trans_table ||
+                 thd->transaction->all.modified_non_trans_table));
 
     table->s->table_creation_was_logged|= binary_logged;
     table->file->ha_release_auto_increment();
@@ -5189,9 +5190,14 @@ bool select_create::send_eof()
     /* Remember xid's for the case of row based logging */
     ddl_log_update_xid(&ddl_log_state_create, thd->binlog_xid);
     ddl_log_update_xid(&ddl_log_state_rm, thd->binlog_xid);
-    trans_commit_stmt(thd);
-    if (!(thd->variables.option_bits & OPTION_GTID_BEGIN))
-      trans_commit_implicit(thd);
+    if (trans_commit_stmt(thd) ||
+	(!(thd->variables.option_bits & OPTION_GTID_BEGIN) &&
+	 trans_commit_implicit(thd)))
+    {
+        abort_result_set();
+        DBUG_RETURN(true);
+    }
+
     thd->binlog_xid= 0;
 
 #ifdef WITH_WSREP
@@ -5311,6 +5317,7 @@ void select_create::abort_result_set()
   /* possible error of writing binary log is ignored deliberately */
   (void) thd->binlog_flush_pending_rows_event(TRUE, TRUE);
 
+  bool has_drop_table_logged= false;
   if (table)
   {
     bool tmp_table= table->s->tmp_table;
@@ -5357,6 +5364,7 @@ void select_create::abort_result_set()
                          create_info->db_type == partition_hton,
                          &create_info->tabledef_version,
                          tmp_table);
+          has_drop_table_logged= true;
           debug_crash_here("ddl_log_create_after_binlog");
           thd->binlog_xid= 0;
         }
@@ -5381,8 +5389,21 @@ void select_create::abort_result_set()
 
   if (create_info->table_was_deleted)
   {
-    /* Unlock locked table that was dropped by CREATE. */
-    (void) trans_rollback_stmt(thd);
+    if (has_drop_table_logged)
+    {
+      /* for DROP binlogging the error status has to be canceled first */
+      Diagnostics_area new_stmt_da(thd->query_id, false, true);
+      Diagnostics_area *old_stmt_da= thd->get_stmt_da();
+
+      thd->set_stmt_da(&new_stmt_da);
+      (void) trans_rollback_stmt(thd);
+      thd->set_stmt_da(old_stmt_da);
+    }
+    else
+    {
+      /* Unlock locked table that was dropped by CREATE. */
+      (void) trans_rollback_stmt(thd);
+    }
     thd->locked_tables_list.unlock_locked_table(thd, create_info->mdl_ticket);
   }
 

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -4264,7 +4264,11 @@ bool select_insert::store_values(List<Item> &values)
 bool select_insert::prepare_eof()
 {
   int error;
-  bool const trans_table= table->file->has_transactions_and_rollback();
+  // make sure any ROW format pending event is logged in the same binlog cache
+  bool const trans_table= (thd->is_current_stmt_binlog_format_row() > 0 &&
+                           table->file->row_logging) ?
+    table->file->row_logging_has_trans :
+    table->file->has_transactions_and_rollback();
   bool changed;
   bool binary_logged= 0;
   killed_state killed_status= thd->killed;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [ ] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The PR branch consists of 4 commits.
The 1st one was reviewed, its edited commit message follows.
The 2nd one addresses the Kristian's notes.
The 3rd, with the summary line
```
MDEV-35502 incremental commit to address a special case of
```
makes sure CREATE-TABLE-SELECT handler chooses the correct cache and by that
eliminates possibility of failing in binlog_commit().
The 4th one extends tests to involve stored functions with side effects.

MDEV-35207 ignored error at binlogging by CREATE-TABLE-SELECT leads to assert

MDEV-35499 Errored-out CREATE-or-REPLACE-SELECT does not log DROP table into binlog
MDEV-35502 Failed at ROW-format binlogging CREATE-TABLE-SELECT should
           not generate Incident event

CREATE-TABLE-SELECT can face an error near the end of its execution
select_create::send_eof() but the error was never checked, therefore no
cleanup action were undertaken which led to various assert inside
binlogging.
E.g when binlog_commit() of ha_commit_one_phase() that
CREATE-TABLE-SELECT employs errored out because of a limited cache size
(binlog_commit may try writing to a transactional cache) the cache
was not flushed to binlog. The missed error check allowed further
execution down to trans_commit_implicit() in whose stack

  DBUG_ASSERT(!(entry->using_trx_cache && !mngr->trx_cache.empty() &&
                mngr->get_binlog_cache_log(TRUE)->error));

fired.

The fixes need and install the error checking in select_create::send_eof().
That prevents from any further execution when ha_commit_one_phase() fails
for any reason (typically due to binlog_commit()).
Note the patch did not address an immediate disconnect after
binlog_commit() error which is a MDEV-35506 subject.

This commit also covers CREATE-or-REPLACE-SELECT that additionally had
a specific issue in that DROP TABLE was not logged the binary log, MDEV-35499.
See select_create::abort_result_set().

The current commit also corrects an unnecessary Incident event
logging when CREATE-TABLE-SELECT encounters a binloging issue, MDEV-35502.
The Incident was actually only harmful in this case as the table was
never going to be created, therefore replicated, in such a case.

NOTE: a new test does not verify a binlog cache emptiness upon disconnect
which is the MDEV-35506 subject.


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
