### PR TITLE
MDEV-35525: Index corruption in reverse scans

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1660,6 +1660,7 @@ release_tree:
         ut_ad(block_savepoint + 2 == mtr->get_savepoint());
         if (ret < 0)
         {
+          up_match= 0, low_match= 0, up_bytes= 0, low_bytes= 0;
           /* While our latch on the level-2 page prevents splits or
           merges of this level-1 block, other threads may have
           modified it due to splitting or merging some level-0 (leaf)


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35525*
## Description
`btr_cur_t::search_leaf()`: In the `BTR_SEARCH_PREV` and `BTR_MODIFY_PREV` modes, reset the previous search status before invoking `page_cur_search_with_match()`. Otherwise, we the search could invoke in a totally wrong subtree.
## Release Notes
See [MDEV-35525](https://jira.mariadb.org/browse/MDEV-35525).
## How can this PR be tested?
The bug was reproduced as part of testing #3562 in the random query generator (RQG) by using `innodb_change_buffering=all` and `innodb_page_size=4k`. Possibly also using `innodb_change_buffering_debug`.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.