### PR TITLE
MDEV-35528: mariadb-binlog cannot process more than 1 logfiles when --stop-datetime is specified

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_datetime.result
+++ b/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_datetime.result
@@ -1,23 +1,115 @@
-
-# MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-datetime
-
-set timestamp=1000000000;
-CREATE TABLE t1(word VARCHAR(20));
-set timestamp=1000000010;
-INSERT INTO t1 VALUES ("abirvalg");
-set timestamp=1000000020;
-INSERT INTO t1 SELECT * FROM t1;
-flush logs;
-Case: Default, must not see warning.
-# MYSQL_BINLOG --short-form MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
-Case: Stop datetime before EOF, must not see warning.
-# MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:50' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
-Case: Stop datetime between records, must not see warning.
-# MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
-Case: Stop datetime at EOF, must not see warning.
-# MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
-Case: Stop datetime after EOF, must see warning.
-# MYSQL_BINLOG --short-form --stop-datetime='2035-01-19 03:14:05' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
-WARNING: Did not reach stop datetime '2035-01-19 03:14:05' before end of input
-DROP TABLE t1;
+SET TIMESTAMP= UNIX_TIMESTAMP('2024-12-01 10:20:30.123456');
+#
+# Clear the existing binary log state, and start fresh using
+# the timestamp variable set above
+#
+RESET MASTER;
+create table t1 (a int);
+insert into t1 values (1);
+SET TIMESTAMP= UNIX_TIMESTAMP('2024-12-02 10:20:30.123456');
+insert into t1 values (2);
+SET TIMESTAMP= UNIX_TIMESTAMP('2024-12-03 10:20:30.123456');
+flush binary logs;
+SET TIMESTAMP= UNIX_TIMESTAMP('2024-12-04 10:20:30.123456');
+insert into t1 values (3);
+insert into t1 values (4);
+SET TIMESTAMP= UNIX_TIMESTAMP('2024-12-05 10:20:30.123456');
+insert into t1 values (5);
+insert into t1 values (6);
+insert into t1 values (7);
+SET TIMESTAMP=UNIX_TIMESTAMP('2024-12-06 10:20:30.123456');
+flush binary logs;
+drop table t1;
+# Ensuring binary log order is correct
+#
+#
+# Test using --read-from-remote-server
+#
+connection default;
+#
+# --stop-datetime tests
+# Note: MDEV-35528 reported that mysqlbinlog would fail on tests cases
+# 2.a, 2.b, and 2.c.
+#
+#  Case 1.a) With one binlog file, a --stop-datetime before the end of
+# the file should not result in a warning
+# MYSQL_BINLOG --read-from-remote-server --stop-datetime='2024-12-02 10:20:30.123456' binlog_f1_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+#
+#  Case 1.b) With one binlog file, a --stop-datetime at the end of the
+# file should not result in a warning
+# MYSQL_BINLOG --read-from-remote-server --stop-datetime='2024-12-03 10:20:30.123456' binlog_f1_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+#
+#  Case 1.c) With one binlog file, a --stop-datetime beyond the end of
+# the file should(!) result in a warning
+# MYSQL_BINLOG --read-from-remote-server --stop-datetime='2024-12-04 10:20:30.123456' binlog_f1_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+WARNING: Did not reach stop datetime '2024-12-04 10:20:30.123456' before end of input
+#
+#  Case 2.a) With two binlog files, a --stop-datetime within the
+# timespan of binlog 2 should:
+#    1) not provide any warnings
+#    2) not prevent binlog 1 or 2 from outputting the desired events
+# MYSQL_BINLOG --read-from-remote-server --stop-datetime='2024-12-04 10:20:30.123456' binlog_f1_full binlog_f2_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+include/assert_grep.inc [Ensure all intended GTIDs are present]
+include/assert_grep.inc [Ensure the next GTID binlogged is _not_ present]
+#
+#  Case 2.b) With two binlog files, a --stop-datetime at the end of
+# binlog 2 should:
+#    1) not provide any warnings
+#    2) not prevent binlog 1 or 2 from outputting all events
+# MYSQL_BINLOG --read-from-remote-server --stop-datetime='2024-12-06 10:20:30.123456' binlog_f1_full binlog_f2_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+include/assert_grep.inc [Ensure a GTID exists for each transaction]
+#
+#  Case 2.c) With two binlog files, a --stop-datetime beyond the end of
+# binlog 2 should:
+#    1) provide a warning that the stop datetime was not reached
+#    2) not prevent binlog 1 or 2 from outputting all events
+# MYSQL_BINLOG --read-from-remote-server --stop-datetime='2024-12-07 10:20:30.123456' binlog_f1_full binlog_f2_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+WARNING: Did not reach stop datetime '2024-12-07 10:20:30.123456' before end of input
+include/assert_grep.inc [Ensure a GTID exists for each transaction]
+#
+#
+# Test using local binlog files
+#
+connection default;
+#
+# --stop-datetime tests
+# Note: MDEV-35528 reported that mysqlbinlog would fail on tests cases
+# 2.a, 2.b, and 2.c.
+#
+#  Case 1.a) With one binlog file, a --stop-datetime before the end of
+# the file should not result in a warning
+# MYSQL_BINLOG  --stop-datetime='2024-12-02 10:20:30.123456' binlog_f1_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+#
+#  Case 1.b) With one binlog file, a --stop-datetime at the end of the
+# file should not result in a warning
+# MYSQL_BINLOG  --stop-datetime='2024-12-03 10:20:30.123456' binlog_f1_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+#
+#  Case 1.c) With one binlog file, a --stop-datetime beyond the end of
+# the file should(!) result in a warning
+# MYSQL_BINLOG  --stop-datetime='2024-12-04 10:20:30.123456' binlog_f1_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+WARNING: Did not reach stop datetime '2024-12-04 10:20:30.123456' before end of input
+#
+#  Case 2.a) With two binlog files, a --stop-datetime within the
+# timespan of binlog 2 should:
+#    1) not provide any warnings
+#    2) not prevent binlog 1 or 2 from outputting the desired events
+# MYSQL_BINLOG  --stop-datetime='2024-12-04 10:20:30.123456' binlog_f1_full binlog_f2_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+include/assert_grep.inc [Ensure all intended GTIDs are present]
+include/assert_grep.inc [Ensure the next GTID binlogged is _not_ present]
+#
+#  Case 2.b) With two binlog files, a --stop-datetime at the end of
+# binlog 2 should:
+#    1) not provide any warnings
+#    2) not prevent binlog 1 or 2 from outputting all events
+# MYSQL_BINLOG  --stop-datetime='2024-12-06 10:20:30.123456' binlog_f1_full binlog_f2_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+include/assert_grep.inc [Ensure a GTID exists for each transaction]
+#
+#  Case 2.c) With two binlog files, a --stop-datetime beyond the end of
+# binlog 2 should:
+#    1) provide a warning that the stop datetime was not reached
+#    2) not prevent binlog 1 or 2 from outputting all events
+# MYSQL_BINLOG  --stop-datetime='2024-12-07 10:20:30.123456' binlog_f1_full binlog_f2_full --result-file=tmp/warn_datetime_test_file.out 2>&1
+WARNING: Did not reach stop datetime '2024-12-07 10:20:30.123456' before end of input
+include/assert_grep.inc [Ensure a GTID exists for each transaction]
+#
 # End of binlog_mysqlbinlog_warn_stop_datetime.test

--- a/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_position.result
+++ b/mysql-test/suite/binlog/r/binlog_mysqlbinlog_warn_stop_position.result
@@ -1,13 +1,65 @@
-
-# MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-condition
-
-Case: Default stop position, WARNING must not appear
-# MYSQL_BINLOG --short-form --start-position=4 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
-Case: Stop position before EOF, WARNING must not appear
-# MYSQL_BINLOG --short-form --start-position=4 --stop-position=97 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
-Case: Stop position at EOF, WARNING must not appear
-# MYSQL_BINLOG --short-form --start-position=4 --stop-position=98 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
-Case: Stop position after EOF, WARNING must appear
-# MYSQL_BINLOG --short-form --start-position=4 --stop-position=99 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
-WARNING: Did not reach stop position 99 before end of input
+#
+# Clear the existing binary log state.
+#
+RESET MASTER;
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+flush binary logs;
+insert into t1 values (3);
+# Tag binlog_f2_mid
+insert into t1 values (4);
+insert into t1 values (5);
+insert into t1 values (6);
+insert into t1 values (7);
+flush binary logs;
+drop table t1;
+# Ensuring binary log order is correct
+# Ensuring file offset of binlog_f2_mid < binlog_f1_end
+#
+#
+# Test using local binlog files
+#
+connection default;
+#
+# --stop-position tests
+#
+#  Case 1.a) With one binlog file, a --stop-position before the end of
+# the file should not result in a warning
+# MYSQL_BINLOG  --stop-position=binlog_f1_pre_rotate binlog_f1_full --result-file=tmp/warn_position_test_file.out 2>&1
+#
+#  Case 1.b) With one binlog file, a --stop-position at the exact end of
+# the file should not result in a warning
+# MYSQL_BINLOG  --stop-position=binlog_f1_end binlog_f1_full --result-file=tmp/warn_position_test_file.out 2>&1
+#
+#  Case 1.c) With one binlog file, a --stop-position past the end of the
+# file should(!) result in a warning
+# MYSQL_BINLOG  --short-form --stop-position=binlog_f1_over_eof binlog_f1_full --result-file=tmp/warn_position_test_file.out 2>&1
+WARNING: Did not reach stop position <BINLOG_F1_OVER_EOF> before end of input
+#
+#  Case 2.a) With two binlog files, a --stop-position targeting b2 which
+# exists in the size of b1 should:
+#    1) not provide any warnings
+#    2) not prevent b2 from outputting its desired events before the
+#       stop position
+# MYSQL_BINLOG  --stop-position=binlog_f2_mid binlog_f1_full binlog_f2_full --result-file=tmp/warn_position_test_file.out 2>&1
+include/assert_grep.inc [Ensure all intended GTIDs are present]
+include/assert_grep.inc [Ensure the next GTID binlogged is _not_ present]
+#
+#  Case 2.b) With two binlog files, a --stop-position targeting the end
+# of binlog 2 should:
+#    1) not provide any warnings
+#    2) not prevent b2 from outputting its entire binary log
+# MYSQL_BINLOG  --stop-position=binlog_f2_end binlog_f1_full binlog_f2_full --result-file=tmp/warn_position_test_file.out 2>&1
+include/assert_grep.inc [Ensure a GTID exists for each transaction]
+include/assert_grep.inc [Ensure the last GTID binlogged is present]
+#
+#  Case 2.c) With two binlog files, a --stop-position targeting beyond
+# the eof of binlog 2 should:
+#    1) provide a warning that the stop position was not reached
+#    2) not prevent b2 from outputting its entire binary log
+# MYSQL_BINLOG  --stop-position=binlog_f2_over_eof binlog_f1_full binlog_f2_full --result-file=tmp/warn_position_test_file.out 2>&1
+WARNING: Did not reach stop position <BINLOG_F2_OVER_EOF> before end of input
+include/assert_grep.inc [Ensure a GTID exists for each transaction]
+#
 # End of binlog_mysqlbinlog_warn_stop_position.test

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_datetime.inc
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_datetime.inc
@@ -1,0 +1,106 @@
+#
+# Helper file that ensures mysqlbinlog --stop-datetime behavior for local
+# files or a remote server
+#
+# Parameters:
+#   read_from_remote_server (bool): A boolean that changes which source to use
+#   for mysqlbinlog. When true, reads remotely; when false, uses local files.
+#
+
+--connection default
+--let $MYSQLD_DATADIR= `select @@datadir`
+
+# PARAM_READ_FROM_REMOTE is used as a parameter to mysqlbinlog (_OUT suffix is
+# output in echo commands). If using local files, they are blank; if reading
+# from remote server, it is overridden to the correct values.
+--let $PARAM_READ_FROM_REMOTE=
+# Used in echo statements to remove potentially changing values
+--let $PARAM_READ_FROM_REMOTE_OUT=
+
+if ($read_from_remote_server)
+{
+  --let $PARAM_READ_FROM_REMOTE= --read-from-remote-server --user=root --host=127.0.0.1 --port=$MASTER_MYPORT
+  --let $PARAM_READ_FROM_REMOTE_OUT= --read-from-remote-server
+  # binlog files in --read-from-remote-server don't use file system path
+  --let $binlog_f1_full= $binlog_f1
+  --let $binlog_f2_full= $binlog_f2
+}
+if (!$read_from_remote_server)
+{
+  # If using local files, file system path to the binlog files is needed
+  --let $binlog_f1_full= $MYSQLD_DATADIR/$binlog_f1
+  --let $binlog_f2_full= $MYSQLD_DATADIR/$binlog_f2
+}
+
+--echo #
+--echo # --stop-datetime tests
+--echo # Note: MDEV-35528 reported that mysqlbinlog would fail on tests cases
+--echo # 2.a, 2.b, and 2.c.
+--echo #
+
+--echo #  Case 1.a) With one binlog file, a --stop-datetime before the end of
+--echo # the file should not result in a warning
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-datetime='$b1_timestamp2' binlog_f1_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-datetime='$b1_timestamp2' $binlog_f1_full --result-file=$binlog_out 2>&1
+
+--echo #
+--echo #  Case 1.b) With one binlog file, a --stop-datetime at the end of the
+--echo # file should not result in a warning
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-datetime='$b1_timestamp3' binlog_f1_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-datetime='$b1_timestamp3' $binlog_f1_full --result-file=$binlog_out 2>&1
+
+--echo #
+--echo #  Case 1.c) With one binlog file, a --stop-datetime beyond the end of
+--echo # the file should(!) result in a warning
+--let $future_timestamp= 2035-12-06 10:20:30.123456
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-datetime='$b2_timestamp1' binlog_f1_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-datetime='$b2_timestamp1' $binlog_f1_full --result-file=$binlog_out 2>&1
+
+--echo #
+--echo #  Case 2.a) With two binlog files, a --stop-datetime within the
+--echo # timespan of binlog 2 should:
+--echo #    1) not provide any warnings
+--echo #    2) not prevent binlog 1 or 2 from outputting the desired events
+
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-datetime='$b2_timestamp1' binlog_f1_full binlog_f2_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-datetime='$b2_timestamp1' $binlog_f1_full $binlog_f2_full --result-file=$binlog_out 2>&1
+
+--let $server_id= `SELECT @@GLOBAL.server_id`
+--let $domain_id= `SELECT @@GLOBAL.gtid_domain_id`
+--let $assert_file= $binlog_out
+--let $assert_text= Ensure all intended GTIDs are present
+--let $assert_select= GTID $domain_id-$server_id-
+--let $assert_count= 3
+--source include/assert_grep.inc
+
+--let $assert_text= Ensure the next GTID binlogged is _not_ present
+--let $assert_select= GTID $binlog_f2_gtid_after_midpoint
+--let $assert_count= 0
+--source include/assert_grep.inc
+
+--echo #
+--echo #  Case 2.b) With two binlog files, a --stop-datetime at the end of
+--echo # binlog 2 should:
+--echo #    1) not provide any warnings
+--echo #    2) not prevent binlog 1 or 2 from outputting all events
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-datetime='$b2_timestamp3' binlog_f1_full binlog_f2_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-datetime='$b2_timestamp3' $binlog_f1_full $binlog_f2_full --result-file=$binlog_out 2>&1
+
+--let $assert_text= Ensure a GTID exists for each transaction
+--let $assert_select= GTID $domain_id-$server_id-
+--let $assert_count= 8
+--source include/assert_grep.inc
+
+--echo #
+--echo #  Case 2.c) With two binlog files, a --stop-datetime beyond the end of
+--echo # binlog 2 should:
+--echo #    1) provide a warning that the stop datetime was not reached
+--echo #    2) not prevent binlog 1 or 2 from outputting all events
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-datetime='$b2_timestamp_not_reached' binlog_f1_full binlog_f2_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-datetime='$b2_timestamp_not_reached' $binlog_f1_full $binlog_f2_full --result-file=$binlog_out 2>&1
+
+--let $assert_text= Ensure a GTID exists for each transaction
+--let $assert_select= GTID $domain_id-$server_id-
+--let $assert_count= 8
+--source include/assert_grep.inc
+

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_datetime.test
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_datetime.test
@@ -1,42 +1,86 @@
---echo
---echo # MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-datetime
---echo
+#
+# Test ensures that --stop-datetime work correctly for mysqlbinlog. This high
+# level test sets up the binary log (and tags certain locations for comparison),
+# and the helper file binlog_mysqlbinlog_warn_stop_datetime.inc performs the
+# actual tests.
+#
+# References:
+#   MDEV-27037: mysqlbinlog emits a warning when reaching EOF before
+#               stop-condition
+#   MDEV-35528: mariadb-binlog cannot process more than 1 logfiles when
+#               --stop-datetime is specified
+#
+--source include/have_log_bin.inc
 
---source include/have_binlog_format_statement.inc
+--let $binlog_out_relpath= tmp/warn_datetime_test_file.out
+--let $binlog_out= $MYSQLTEST_VARDIR/$binlog_out_relpath
 
---let ignored_output_file= $MYSQLTEST_VARDIR/tmp/warn_pos_test_file.out
+--let $b1_timestamp1= 2024-12-01 10:20:30.123456
+--let $b1_timestamp2= 2024-12-02 10:20:30.123456
+--let $b1_timestamp3= 2024-12-03 10:20:30.123456
+--let $b2_timestamp1= 2024-12-04 10:20:30.123456
+--let $b2_timestamp2= 2024-12-05 10:20:30.123456
+--let $b2_timestamp3= 2024-12-06 10:20:30.123456
+--let $b2_timestamp_not_reached= 2024-12-07 10:20:30.123456
 
-set timestamp=1000000000;
-CREATE TABLE t1(word VARCHAR(20));
-set timestamp=1000000010;
-INSERT INTO t1 VALUES ("abirvalg");
-set timestamp=1000000020;
-INSERT INTO t1 SELECT * FROM t1;
---let MYSQLD_DATADIR= `select @@datadir;`
-flush logs;
+--eval SET TIMESTAMP= UNIX_TIMESTAMP('$b1_timestamp1')
 
---echo Case: Default, must not see warning.
---echo # MYSQL_BINLOG --short-form MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
---exec $MYSQL_BINLOG --short-form $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+--echo #
+--echo # Clear the existing binary log state, and start fresh using
+--echo # the timestamp variable set above
+--echo #
+RESET MASTER;
 
---echo Case: Stop datetime before EOF, must not see warning.
---echo # MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:50' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
---exec $MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:50' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+--let $binlog_f1= query_get_value(SHOW MASTER STATUS, File, 1)
+create table t1 (a int);
+insert into t1 values (1);
+--eval SET TIMESTAMP= UNIX_TIMESTAMP('$b1_timestamp2')
+insert into t1 values (2);
+--eval SET TIMESTAMP= UNIX_TIMESTAMP('$b1_timestamp3')
+flush binary logs;
+--let $binlog_f2= query_get_value(SHOW MASTER STATUS, File, 1)
+--eval SET TIMESTAMP= UNIX_TIMESTAMP('$b2_timestamp1')
+insert into t1 values (3);
+insert into t1 values (4);
+--eval SET TIMESTAMP= UNIX_TIMESTAMP('$b2_timestamp2')
+--let $binlog_f2_gtid_after_midpoint= `SELECT @@GLOBAL.gtid_binlog_pos`
+insert into t1 values (5);
+insert into t1 values (6);
+insert into t1 values (7);
+--let $binlog_f2_last_gtid= `SELECT @@GLOBAL.gtid_binlog_pos`
+--eval SET TIMESTAMP=UNIX_TIMESTAMP('$b2_timestamp3')
+flush binary logs;
+drop table t1;
 
---echo Case: Stop datetime between records, must not see warning.
---echo # MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
---exec $MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+--echo # Ensuring binary log order is correct
+--let $binlog_f1_show= query_get_value(SHOW BINARY LOGS, Log_name, 1)
+if (`SELECT strcmp('$binlog_f1','$binlog_f1_show') != 0`)
+{
+  --echo # Real binlog_f1: $binlog_f1
+  --echo # First binlog in SHOW BINLOG FILES: $binlog_f1_show
+  --die Wrong order of binary log files in SHOW BINARY LOGS
+}
+--let $binlog_f2_show= query_get_value(SHOW BINARY LOGS, Log_name, 2)
+if (`SELECT strcmp('$binlog_f2','$binlog_f2_show') != 0`)
+{
+  --echo # Real binlog_f2: $binlog_f2
+  --echo # First binlog in SHOW BINLOG FILES: $binlog_f2_show
+  --die Wrong order of binary log files in SHOW BINARY LOGS
+}
 
---echo Case: Stop datetime at EOF, must not see warning.
---echo # MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
---exec $MYSQL_BINLOG --short-form --stop-datetime='2001-09-08 21:46:55' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+--echo #
+--echo #
+--echo # Test using --read-from-remote-server
+--echo #
+--let $read_from_remote_server= 1
+--source binlog_mysqlbinlog_warn_stop_datetime.inc
 
---echo Case: Stop datetime after EOF, must see warning.
---echo # MYSQL_BINLOG --short-form --stop-datetime='2035-01-19 03:14:05' MYSQLD_DATADIR/master-bin.000001 --result-file=ignored_output_file
---exec $MYSQL_BINLOG --short-form --stop-datetime='2035-01-19 03:14:05' $MYSQLD_DATADIR/master-bin.000001 --result-file=$ignored_output_file 2>&1
+--echo #
+--echo #
+--echo # Test using local binlog files
+--echo #
+--let $read_from_remote_server= 0
+--source binlog_mysqlbinlog_warn_stop_datetime.inc
 
-DROP TABLE t1;
-
---remove_file $ignored_output_file
-
+--echo #
 --echo # End of binlog_mysqlbinlog_warn_stop_datetime.test

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.inc
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.inc
@@ -1,0 +1,115 @@
+#
+# Helper file that ensures mysqlbinlog --stop-position behavior for local
+# files or a remote server
+#
+# Parameters:
+#   read_from_remote_server (bool): A boolean that changes which source to use
+#   for mysqlbinlog. When true, reads remotely; when false, uses local files.
+#
+
+--connection default
+--let $MYSQLD_DATADIR= `select @@datadir`
+
+# PARAM_READ_FROM_REMOTE is used as a parameter to mysqlbinlog (_OUT suffix is
+# output in echo commands). If using local files, they are blank; if reading
+# from remote server, it is overridden to the correct values.
+--let $PARAM_READ_FROM_REMOTE=
+# Used in echo statements to remove potentially changing values
+--let $PARAM_READ_FROM_REMOTE_OUT=
+
+if ($read_from_remote_server)
+{
+  --let $PARAM_READ_FROM_REMOTE= --read-from-remote-server --user=root --host=127.0.0.1 --port=$MASTER_MYPORT
+  --let $PARAM_READ_FROM_REMOTE_OUT= --read-from-remote-server
+  # binlog files in --read-from-remote-server don't use file system path
+  --let $binlog_f1_full= $binlog_f1
+  --let $binlog_f2_full= $binlog_f2
+}
+if (!$read_from_remote_server)
+{
+  # If using local files, file system path to the binlog files is needed
+  --let $binlog_f1_full= $MYSQLD_DATADIR/$binlog_f1
+  --let $binlog_f2_full= $MYSQLD_DATADIR/$binlog_f2
+}
+
+--echo #
+--echo # --stop-position tests
+--echo #
+
+--echo #  Case 1.a) With one binlog file, a --stop-position before the end of
+--echo # the file should not result in a warning
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-position=binlog_f1_pre_rotate binlog_f1_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-position=$binlog_f1_pre_rotate $binlog_f1_full --result-file=$binlog_out 2>&1
+
+--echo #
+--echo #  Case 1.b) With one binlog file, a --stop-position at the exact end of
+--echo # the file should not result in a warning
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-position=binlog_f1_end binlog_f1_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-position=$binlog_f1_end $binlog_f1_full --result-file=$binlog_out 2>&1
+
+--echo #
+--echo #  Case 1.c) With one binlog file, a --stop-position past the end of the
+--echo # file should(!) result in a warning
+--let $binlog_f1_over_eof= `SELECT $binlog_f1_end + 1`
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --short-form --stop-position=binlog_f1_over_eof binlog_f1_full --result-file=$binlog_out_relpath 2>&1
+--replace_result $binlog_f1_over_eof <BINLOG_F1_OVER_EOF>
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --short-form --stop-position=$binlog_f1_over_eof $binlog_f1_full --result-file=$binlog_out 2>&1
+
+--echo #
+--echo #  Case 2.a) With two binlog files, a --stop-position targeting b2 which
+--echo # exists in the size of b1 should:
+--echo #    1) not provide any warnings
+--echo #    2) not prevent b2 from outputting its desired events before the
+--echo #       stop position
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-position=binlog_f2_mid binlog_f1_full binlog_f2_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-position=$binlog_f2_mid $binlog_f1_full $binlog_f2_full --result-file=$binlog_out 2>&1
+
+--let $server_id= `SELECT @@GLOBAL.server_id`
+--let $domain_id= `SELECT @@GLOBAL.gtid_domain_id`
+--let $assert_file= $binlog_out
+--let $assert_text= Ensure all intended GTIDs are present
+--let $assert_select= GTID $domain_id-$server_id-
+--let $assert_count= 4
+--source include/assert_grep.inc
+
+--let $assert_text= Ensure the next GTID binlogged is _not_ present
+--let $assert_select= GTID $binlog_f2_gtid_after_midpoint
+--let $assert_count= 0
+--source include/assert_grep.inc
+
+--echo #
+--echo #  Case 2.b) With two binlog files, a --stop-position targeting the end
+--echo # of binlog 2 should:
+--echo #    1) not provide any warnings
+--echo #    2) not prevent b2 from outputting its entire binary log
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-position=binlog_f2_end binlog_f1_full binlog_f2_full --result-file=$binlog_out_relpath 2>&1
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-position=$binlog_f2_end $binlog_f1_full $binlog_f2_full --result-file=$binlog_out 2>&1
+
+--let $server_id= `SELECT @@GLOBAL.server_id`
+--let $domain_id= `SELECT @@GLOBAL.gtid_domain_id`
+--let $assert_text= Ensure a GTID exists for each transaction
+--let $assert_select= GTID $domain_id-$server_id-
+--let $assert_count= 8
+--source include/assert_grep.inc
+
+--let $assert_text= Ensure the last GTID binlogged is present
+--let $assert_select= GTID $binlog_f2_last_gtid
+--let $assert_count= 1
+--source include/assert_grep.inc
+
+--echo #
+--echo #  Case 2.c) With two binlog files, a --stop-position targeting beyond
+--echo # the eof of binlog 2 should:
+--echo #    1) provide a warning that the stop position was not reached
+--echo #    2) not prevent b2 from outputting its entire binary log
+--let $binlog_f2_over_eof= `SELECT $binlog_f2_end + 1`
+--echo # MYSQL_BINLOG $PARAM_READ_FROM_REMOTE_OUT --stop-position=binlog_f2_over_eof binlog_f1_full binlog_f2_full --result-file=$binlog_out_relpath 2>&1
+--replace_result $binlog_f2_over_eof <BINLOG_F2_OVER_EOF>
+--exec $MYSQL_BINLOG $PARAM_READ_FROM_REMOTE --stop-position=$binlog_f2_over_eof $binlog_f1_full $binlog_f2_full --result-file=$binlog_out 2>&1
+
+--let $server_id= `SELECT @@GLOBAL.server_id`
+--let $domain_id= `SELECT @@GLOBAL.gtid_domain_id`
+--let $assert_text= Ensure a GTID exists for each transaction
+--let $assert_select= GTID $domain_id-$server_id-
+--let $assert_count= 8
+--source include/assert_grep.inc

--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.test
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_warn_stop_position.test
@@ -1,26 +1,83 @@
---echo
---echo # MDEV-27037 mysqlbinlog emits a warning when reaching EOF before stop-condition
---echo
+#
+# Test ensures that --stop-position work correctly for mysqlbinlog. This high
+# level test sets up the binary log (and tags certain locations for comparison),
+# and the helper file binlog_mysqlbinlog_warn_stop_position.inc performs the
+# actual tests.
+#
+# References:
+#   MDEV-27037: mysqlbinlog emits a warning when reaching EOF before
+#               stop-condition
+#
+--source include/have_log_bin.inc
 
---let assert_file= $MYSQLTEST_VARDIR/tmp/warn_pos_test_file.out
---let data_file= $MYSQLTEST_VARDIR/std_data/master-bin.000001
+--let $binlog_out_relpath= tmp/warn_position_test_file.out
+--let $binlog_out= $MYSQLTEST_VARDIR/$binlog_out_relpath
 
---echo Case: Default stop position, WARNING must not appear
---echo # MYSQL_BINLOG --short-form --start-position=4 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
---exec $MYSQL_BINLOG --short-form --start-position=4 $data_file --result-file=$assert_file 2>&1
+--echo #
+--echo # Clear the existing binary log state.
+--echo #
+RESET MASTER;
 
---echo Case: Stop position before EOF, WARNING must not appear
---echo # MYSQL_BINLOG --short-form --start-position=4 --stop-position=97 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
---exec $MYSQL_BINLOG --short-form --start-position=4 --stop-position=97 $data_file --result-file=$assert_file 2>&1
+--let $binlog_f1= query_get_value(SHOW MASTER STATUS, File, 1)
+create table t1 (a int);
+insert into t1 values (1);
+insert into t1 values (2);
+--let $binlog_f1_pre_rotate= query_get_value(SHOW MASTER STATUS, Position, 1)
+flush binary logs;
+--let $binlog_f2= query_get_value(SHOW MASTER STATUS, File, 1)
+insert into t1 values (3);
+--echo # Tag binlog_f2_mid
+--let $binlog_f2_mid= query_get_value(SHOW MASTER STATUS, Position, 1)
+insert into t1 values (4);
+--let $binlog_f2_gtid_after_midpoint= `SELECT @@GLOBAL.gtid_binlog_pos`
+insert into t1 values (5);
+insert into t1 values (6);
+insert into t1 values (7);
+--let $binlog_f2_last_gtid= `SELECT @@GLOBAL.gtid_binlog_pos`
+--let $binlog_f2_pre_rot= query_get_value(SHOW MASTER STATUS, Position, 1)
+flush binary logs;
+drop table t1;
 
---echo Case: Stop position at EOF, WARNING must not appear
---echo # MYSQL_BINLOG --short-form --start-position=4 --stop-position=98 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
---exec $MYSQL_BINLOG --short-form --start-position=4 --stop-position=98 $data_file --result-file=$assert_file 2>&1
+--echo # Ensuring binary log order is correct
+--let $binlog_f1_show= query_get_value(SHOW BINARY LOGS, Log_name, 1)
+--let $binlog_f1_end= query_get_value(SHOW BINARY LOGS, File_size, 1)
+if (`SELECT strcmp('$binlog_f1','$binlog_f1_show') != 0`)
+{
+  --echo # Real binlog_f1: $binlog_f1
+  --echo # First binlog in SHOW BINLOG FILES: $binlog_f1_show
+  --die Wrong order of binary log files in SHOW BINARY LOGS
+}
+--let $binlog_f2_show= query_get_value(SHOW BINARY LOGS, Log_name, 2)
+--let $binlog_f2_end= query_get_value(SHOW BINARY LOGS, File_size, 2)
+if (`SELECT strcmp('$binlog_f2','$binlog_f2_show') != 0`)
+{
+  --echo # Real binlog_f2: $binlog_f2
+  --echo # First binlog in SHOW BINLOG FILES: $binlog_f2_show
+  --die Wrong order of binary log files in SHOW BINARY LOGS
+}
 
---echo Case: Stop position after EOF, WARNING must appear
---echo # MYSQL_BINLOG --short-form --start-position=4 --stop-position=99 mysql-test/std_data/master-bin.000001 --result-file=warn_pos_test_file.out 2>&1
---exec $MYSQL_BINLOG --short-form --start-position=4 --stop-position=99 $data_file --result-file=$assert_file 2>&1
+--echo # Ensuring file offset of binlog_f2_mid < binlog_f1_end
+if ($binlog_f2_mid > $binlog_f1_end)
+{
+  --echo # Binlog 1 end: $binlog_f1:$binlog_f1_end
+  --echo # Binlog 2 stop point: $binlog_f2:$binlog_f2_mid
+  --die Mid point chosen to end in binlog 2 does not exist in earlier binlog
+}
 
---remove_file $assert_file
+#--echo #
+#--echo #
+#--echo # Test using --read-from-remote-server
+#--echo #
+#--let $read_from_remote_server= 1
+#--emit warning is not supported by --read-from-remote-server now
+#--source binlog_mysqlbinlog_warn_stop_position.inc
 
+--echo #
+--echo #
+--echo # Test using local binlog files
+--echo #
+--let $read_from_remote_server= 0
+--source binlog_mysqlbinlog_warn_stop_position.inc
+
+--echo #
 --echo # End of binlog_mysqlbinlog_warn_stop_position.test


### PR DESCRIPTION
## Description

Fix regression introduced by commit [9588526](https://github.com/MariaDB/server/commit/95885261f0) which attempted to address [MDEV-27037](https://jira.mariadb.org/browse/MDEV-27037). With the regression, mariadb-binlog cannot process multiple log files when --stop-datetime is specified.

The PR is to keep recording timestamp of last processed event, and after all log files are processed, if the last recorded timestamp has not reached specified --stop-datetime, it will emit a warning. This applies when processing local log files, or log files from remote servers. Also added MTR test cases to ensure it works as expected in different scenario.

This PR does not impact the commit [242b67f](https://github.com/MariaDB/server/commit/242b67f1de) to emit warning when reaching EOF before specified --stop-position, since that logic only applies to last log file, so no need to fix. Though also added test cases for --stop-position to make sure it works well for multiple log files case.

## Release Notes

N/A

## How can this PR be tested?

1. Added necessary MTR test cases.

2. Manually tested to verify that it can process multiple log files for command like below:

```
mariadb-binlog --stop-datetime="2024-11-30 18:52:00" mariadb-bin.000001 mariadb-bin.000002 mariadb-bin.000003
```

While before the change, the same command can only process the first log file.

## Basing the PR against the correct MariaDB version

This change should apply to all minor versions these 2 commits [9588526](https://github.com/MariaDB/server/commit/95885261f0) and [242b67f](https://github.com/MariaDB/server/commit/242b67f1de) are merged in

* [mariadb-11.7.1](https://github.com/MariaDB/server/releases/tag/mariadb-11.7.1)
* [mariadb-11.6.2](https://github.com/MariaDB/server/releases/tag/mariadb-11.6.2)
* [mariadb-11.4.4](https://github.com/MariaDB/server/releases/tag/mariadb-11.4.4)
* [mariadb-11.2.6](https://github.com/MariaDB/server/releases/tag/mariadb-11.2.6)
* [mariadb-10.11.10](https://github.com/MariaDB/server/releases/tag/mariadb-10.11.10)
* [mariadb-10.6.20](https://github.com/MariaDB/server/releases/tag/mariadb-10.6.20)
* [mariadb-10.5.27](https://github.com/MariaDB/server/releases/tag/mariadb-10.5.27)

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.
