### PR TITLE
MDEV-35446 Sporadic failure of galera.galera_insert_multi 

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -9620,7 +9620,7 @@ void init_re(void)
     //"[[:space:]]*CALL[[:space:]]|" // XXX run_query_stmt doesn't read multiple result sets
     "[[:space:]]*CHANGE[[:space:]]|"
     "[[:space:]]*CHECKSUM[[:space:]]|"
-    "[[:space:]]*COMMIT[[:space:]]|"
+    "[[:space:]]*COMMIT[[:space:]]*|"
     "[[:space:]]*COMPOUND[[:space:]]|"
     "[[:space:]]*CREATE[[:space:]]+DATABASE[[:space:]]|"
     "[[:space:]]*CREATE[[:space:]]+INDEX[[:space:]]|"

--- a/mysql-test/suite/galera/r/MDEV-35446.result
+++ b/mysql-test/suite/galera/r/MDEV-35446.result
@@ -1,0 +1,22 @@
+connection node_2;
+connection node_1;
+connect bf_trx, 127.0.0.1, root, , test, $NODE_MYPORT_1;
+connect victim_trx, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+connect node_2_ctrl, 127.0.0.1, root, , test, $NODE_MYPORT_2;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+connection victim_trx;
+START TRANSACTION;
+INSERT INTO t1 VALUES (2), (1);
+connection node_2_ctrl;
+SET GLOBAL debug_dbug = '+d,sync.wsrep_apply_cb';
+connection bf_trx;
+INSERT INTO t1 VALUES (1), (2);
+connection node_2_ctrl;
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET GLOBAL debug_dbug = '';
+connection victim_trx;
+SET DEBUG_SYNC = "wsrep_at_dispatch_end_before_result SIGNAL signal.wsrep_apply_cb WAIT_FOR bf_abort";
+COMMIT;
+ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;

--- a/mysql-test/suite/galera/t/MDEV-35446.cnf
+++ b/mysql-test/suite/galera/t/MDEV-35446.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqltest]
+ps-protocol

--- a/mysql-test/suite/galera/t/MDEV-35446.test
+++ b/mysql-test/suite/galera/t/MDEV-35446.test
@@ -1,0 +1,57 @@
+#
+# MDEV-35446
+#
+# Test BF abort of a transaction under PS protocol, after
+# a statement is prepared (and the diagnostics area is
+# disabled).
+#
+
+--source include/have_debug_sync.inc
+--source include/galera_cluster.inc
+
+#
+# Setup: bf_trx executes in node_1 and will BF abort victim_trx.
+#
+--connect bf_trx, 127.0.0.1, root, , test, $NODE_MYPORT_1
+--connect victim_trx, 127.0.0.1, root, , test, $NODE_MYPORT_2
+--connect node_2_ctrl, 127.0.0.1, root, , test, $NODE_MYPORT_2
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
+
+--connection victim_trx
+START TRANSACTION;
+INSERT INTO t1 VALUES (2), (1);
+
+--connection node_2_ctrl
+SET GLOBAL debug_dbug = '+d,sync.wsrep_apply_cb';
+
+--connection bf_trx
+INSERT INTO t1 VALUES (1), (2);
+
+--connection node_2_ctrl
+SET DEBUG_SYNC = "now WAIT_FOR sync.wsrep_apply_cb_reached";
+SET GLOBAL debug_dbug = '';
+
+#
+# COMMIT the victim_trx and expect a deadlock error.
+# Here we park the client in a sync point at the end of prepare
+# command (COM_STMT_PREPARE), where the diagnostics area of the
+# client has already been disabled. The client signals the
+# applier to continue and will be BF aborted.
+# If bug is present, the transaction is aborted, but the COMMIT
+# statement succeeds (instead of returning deadlock error).
+#
+--connection victim_trx
+
+--disable_ps_protocol
+SET DEBUG_SYNC = "wsrep_at_dispatch_end_before_result SIGNAL signal.wsrep_apply_cb WAIT_FOR bf_abort";
+--enable_ps_protocol
+
+--error ER_LOCK_DEADLOCK
+COMMIT;
+
+#
+# Cleanup
+#
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1165,7 +1165,8 @@ static bool wsrep_command_no_result(char command)
 {
   return (command == COM_STMT_FETCH            ||
           command == COM_STMT_SEND_LONG_DATA   ||
-          command == COM_STMT_CLOSE);
+          command == COM_STMT_CLOSE            ||
+          command == COM_STMT_PREPARE);
 }
 #endif /* WITH_WSREP */
 #ifndef EMBEDDED_LIBRARY
@@ -2438,6 +2439,10 @@ dispatch_end:
     if (thd->killed == KILL_QUERY)
     {
       WSREP_DEBUG("THD is killed at dispatch_end");
+    }
+    if (thd->lex->sql_command != SQLCOM_SET_OPTION)
+    {
+      DEBUG_SYNC(thd, "wsrep_at_dispatch_end_before_result");
     }
     wsrep_after_command_before_result(thd);
     if (wsrep_current_error(thd) && !wsrep_command_no_result(command))


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35446*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This pull request contains two commits.
1) 4f9fbab8063  Fixes a issue in mysqltest client which
    prevented statement "COMMIT;" to use ps protocol.
    This was` necessary to test/reproduce the issue in 10.5.
    (this commit is not needed in 10.6)
2) 64418341ed Fixes a issue which caused no error to
    be reported, for a transaction that was aborted due to
    cluster-wide conflict.

## Release Notes
The issue in MDEV-35446 could cause a situation were a transaction that was aborted due to a cluster-wide conflict, would report no errors back to the client.

## How can this PR be tested?
The fix for MDEV-35446 comes with a MTR test,

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
