### PR TITLE
MDEV-35574 remove obsolete pthread_exit calls

### DIFF
--- a/client/mysqlimport.c
+++ b/client/mysqlimport.c
@@ -631,7 +631,6 @@ error:
   pthread_cond_signal(&count_threshhold);
   pthread_mutex_unlock(&counter_mutex);
   mysql_thread_end();
-  pthread_exit(0);
   return 0;
 }
 

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -991,7 +991,6 @@ end_thread:
   cn->mysql= 0;
   cn->query_done= 1;
   mysql_thread_end();
-  pthread_exit(0);
   DBUG_RETURN(0);
 }
 

--- a/mysys/thr_alarm.c
+++ b/mysys/thr_alarm.c
@@ -566,8 +566,7 @@ static void *alarm_handler(void *arg __attribute__((unused)))
   alarm_thread_running= 0;
   mysql_cond_signal(&COND_alarm);
   mysql_mutex_unlock(&LOCK_alarm);
-  pthread_exit(0);
-  return 0;					/* Impossible */
+  return 0;
 }
 #endif /* USE_ALARM_THREAD */
 #endif

--- a/mysys/thr_timer.c
+++ b/mysys/thr_timer.c
@@ -330,8 +330,7 @@ static void *timer_handler(void *arg __attribute__((unused)))
   }
   mysql_mutex_unlock(&LOCK_timer);
   my_thread_end();
-  pthread_exit(0);
-  return 0;					/* Impossible */
+  return 0;
 }
 
 

--- a/plugin/feedback/sender_thread.cc
+++ b/plugin/feedback/sender_thread.cc
@@ -290,7 +290,6 @@ pthread_handler_t background_thread(void *arg __attribute__((unused)))
   }
 
   my_thread_end();
-  pthread_exit(0);
   return 0;
 }
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2948,7 +2948,6 @@ pthread_handler_t signal_hand(void *)
   sigset_t set;
   int sig;
   my_thread_init();				// Init new thread
-  DBUG_ENTER("signal_hand");
   signal_thread_in_use= 1;
 
   /*
@@ -3014,7 +3013,6 @@ pthread_handler_t signal_hand(void *)
       /* switch to the old log message processing */
       logger.set_handlers(global_system_variables.sql_log_slow ? LOG_FILE:LOG_NONE,
                           opt_log ? LOG_FILE:LOG_NONE);
-      DBUG_PRINT("info",("Got signal: %d  abort_loop: %d",sig,abort_loop));
 
       break_connect_loop();
       DBUG_ASSERT(abort_loop);
@@ -3050,12 +3048,9 @@ pthread_handler_t signal_hand(void *)
       break;					/* purecov: tested */
     }
   }
-  DBUG_PRINT("quit", ("signal_handler: calling my_thread_end()"));
   my_thread_end();
-  DBUG_LEAVE; // Must match DBUG_ENTER()
   signal_thread_in_use= 0;
-  pthread_exit(0); // Safety
-  return(0);					/* purecov: deadcode */
+  return nullptr;
 }
 
 static void check_data_home(const char *path)

--- a/storage/mroonga/vendor/groonga/src/groonga_benchmark.c
+++ b/storage/mroonga/vendor/groonga/src/groonga_benchmark.c
@@ -271,12 +271,7 @@ error_exit_in_thread(intptr_t code)
   CRITICAL_SECTION_ENTER(grntest_cs);
   grntest_stop_flag = 1;
   CRITICAL_SECTION_LEAVE(grntest_cs);
-#ifdef WIN32
-  _endthreadex(code);
-#else
-  pthread_exit((void *)code);
-#endif /* WIN32 */
-  return 0;
+  return code;
 }
 
 

--- a/tests/thread_test.c
+++ b/tests/thread_test.c
@@ -70,7 +70,6 @@ end:
   thread_count--;
   pthread_cond_signal(&COND_thread_count); /* Tell main we are ready */
   pthread_mutex_unlock(&LOCK_thread_count);
-  pthread_exit(0);
   return 0;
 }
 

--- a/unittest/mysys/stack_allocation-t.c
+++ b/unittest/mysys/stack_allocation-t.c
@@ -91,7 +91,6 @@ pthread_handler_t thread_stack_check(void *arg __attribute__((unused)))
   test_stack_detection(1, STACK_ALLOC_SMALL_BLOCK_SIZE-1);
   test_stack_detection(2, STACK_ALLOC_SMALL_BLOCK_SIZE+1);
   my_thread_end();
-  pthread_exit(0);
   return 0;
 }
 

--- a/unittest/sql/my_apc-t.cc
+++ b/unittest/sql/my_apc-t.cc
@@ -108,7 +108,6 @@ void *test_apc_service_thread(void *ptr)
   apc_target.destroy();
   mysql_mutex_destroy(&target_mutex);
   my_thread_end();
-  pthread_exit(0);
   return NULL;
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35574*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Threads can normally exit without a explicit pthread_exit call.

There seem to date to old glibc bugs, many around 2.2.5.

The semi related bug was https://bugs.mysql.com/bug.php?id=82886.

To improve safety in the signal handlers DBUG_* code was removed.

These where also needed to avoid some MSAN unresolved stack issues.

This is effectively a backport of 2719cc4925c032f483edb0e61c0f487e0c429ae6.

## Release Notes

Nothing, internal refactor

## How can this PR be tested?

Plenty of unit tests and other  tests around exit to sufficiently test these changes.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.