### PR TITLE
MDEV-35577  online log file resizing corrupts redo log

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -1840,6 +1840,7 @@ inline void log_t::write_checkpoint(lsn_t end_lsn) noexcept
   if (resizing > 1 && resizing <= checkpoint_lsn)
   {
     ut_ad(is_mmap() == !resize_flush_buf);
+    ut_ad(is_mmap() == !resize_log.is_opened());
 
     if (!is_mmap())
     {
@@ -1905,6 +1906,7 @@ inline void log_t::write_checkpoint(lsn_t end_lsn) noexcept
     resize_flush_buf= nullptr;
     resize_target= 0;
     resize_lsn.store(0, std::memory_order_relaxed);
+    writer_update();
   }
 
   log_resize_release();

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -60,7 +60,7 @@ wait and check if an already running write is covering the request.
 @param durable  whether the write needs to be durable
 @param callback log write completion callback */
 void log_write_up_to(lsn_t lsn, bool durable,
-                     const completion_callback *callback= nullptr);
+                     const completion_callback *callback= nullptr) noexcept;
 
 /** Write to the log file up to the last log entry.
 @param durable  whether to wait for a durable write to complete */
@@ -249,6 +249,8 @@ public:
 
   /** latest completed checkpoint (protected by latch.wr_lock()) */
   Atomic_relaxed<lsn_t> last_checkpoint_lsn;
+  /** The log writer (protected by latch.wr_lock()) */
+  lsn_t (*writer)() noexcept;
   /** next checkpoint LSN (protected by latch.wr_lock()) */
   lsn_t next_checkpoint_lsn;
 
@@ -270,7 +272,8 @@ private:
   @return the value of buf_free */
   size_t lock_lsn() noexcept;
 
-  /** log sequence number when log resizing was initiated, or 0 */
+  /** log sequence number when log resizing was initiated;
+  0 if the log is not being resized, 1 if resize_start() is in progress */
   std::atomic<lsn_t> resize_lsn;
   /** the log sequence number at the start of the log file */
   lsn_t first_lsn;
@@ -358,7 +361,8 @@ public:
   inline lsn_t get_write_target() const;
 
   /** @return LSN at which log resizing was started and is still in progress
-      @retval 0 if no log resizing is in progress */
+      @retval 0 if no log resizing is in progress
+      @retval 1 if resize_start() is in progress */
   lsn_t resize_in_progress() const noexcept
   { return resize_lsn.load(std::memory_order_relaxed); }
 
@@ -387,7 +391,6 @@ private:
   /** Write resize_buf to resize_log.
   @param b       resize_buf or resize_flush_buf
   @param length  the used length of b */
-  ATTRIBUTE_COLD ATTRIBUTE_NOINLINE
   void resize_write_buf(const byte *b, size_t length) noexcept;
 public:
 
@@ -489,6 +492,9 @@ public:
 #endif
 
 private:
+  /** Update writer and mtr_t::finisher */
+  void writer_update() noexcept;
+
   /** Wait in append_prepare() for buffer to become available
   @tparam spin  whether to use the spin-only lock_lsn()
   @param b      the value of buf_free
@@ -551,10 +557,20 @@ public:
   @param end_lsn    start LSN of the FILE_CHECKPOINT mini-transaction */
   inline void write_checkpoint(lsn_t end_lsn) noexcept;
 
-  /** Write buf to ib_logfile0.
-  @tparam release_latch whether to invoke latch.wr_unlock()
+  /** Variations of write_buf() */
+  enum resizing_and_latch {
+    /** skip latch.wr_unlock(); log resizing may or may not be in progress */
+    RETAIN_LATCH,
+    /** invoke latch.wr_unlock(); !(resize_in_progress() > 1) */
+    NOT_RESIZING,
+    /** invoke latch.wr_unlock(); resize_in_progress() > 1 */
+    RESIZING
+  };
+
+  /** Write buf to ib_logfile0 and possibly ib_logfile101.
+  @tparam resizing whether to release latch and whether resize_in_progress()>1
   @return the current log sequence number */
-  template<bool release_latch> inline lsn_t write_buf() noexcept;
+  template<resizing_and_latch resizing> inline lsn_t write_buf() noexcept;
 
   /** Create the log. */
   void create(lsn_t lsn) noexcept;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35577*
## Description
If InnoDB is killed in such a way that there had been no writes to a newly resized `ib_logfile101` after it replaced `ib_logfile0` in `log_t::write_checkpoint()`, it is possible that recovery will accidentally interpret some garbage at the end of the log as valid.

`log_t::write_buf()`: To prevent the corruption, write an extra NUL byte at the end of `log_sys.resize_buf`, like we always did for the main `log_sys.buf`. To remove some conditional branches from a time critical code path, we instantiate a separate template for the rare case that the log is being resized. Define as `__attribute__((always_inline))` so that this will be inlined also in the rare case the log is being resized.

`log_t::writer`: Pointer to the current implementation of `log_write_up_to()`. For quick access, this is located in the same cache line with `log_sys.latch`.

`log_writer()`: Replaces `log_write_up_to()`.

`log_t::write_update()`: Update the `log_write_up_to()` implementation. We have a separate implementations for memory-mapped writes and for log resizing.

`log_t::resize_write_buf()`: Remove `ATTRIBUTE_NOINLINE ATTRIBUTE_COLD`. Now that `log_writer()` will be instantiated separately for the rare case of log resizing being in progress, there is no need to forbid this code from being inlined.
## How can this PR be tested?
```sh
./mtr innodb.log_file_size_online
```
when the log is *not* memory-mapped, that is, `cmake -DWITH_INNODB_PMEM=OFF` or `mysql-test/var` does not point to `/dev/shm` or a `mount -o dax` file system.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.