### PR TITLE
MDEV-35583 Tests failing on macOS

### DIFF
--- a/unittest/mysys/dynstring-t.c
+++ b/unittest/mysys/dynstring-t.c
@@ -26,8 +26,10 @@ static void check(const char *res)
   str1.length= 0;
 }
 
-int main(void)
+int main(int argc, char** argv)
 {
+  MY_INIT(argv[0]);
+
   plan(23);
 
   IF_WIN(skip_all("Test of POSIX shell escaping rules, not for CMD.EXE\n"), );
@@ -69,6 +71,7 @@ int main(void)
 
   dynstr_free(&str1);
 
+  my_end(MY_CHECK_ERROR);
   return exit_status();
 }
 

--- a/unittest/sql/my_json_writer-t.cc
+++ b/unittest/sql/my_json_writer-t.cc
@@ -51,6 +51,8 @@ public:
 
 int main(int args, char **argv)
 {
+  MY_INIT(argv[0]);
+
   plan(NO_PLAN);
   diag("Testing Json_writer checks");
 
@@ -123,6 +125,7 @@ int main(int args, char **argv)
 
   diag("Done");
 
+  my_end(MY_CHECK_ERROR);
   return exit_status();
 }
 


### PR DESCRIPTION
These tests, unit.my_json_writer and unit.dynstring, rely on THR_KEY_mysys but it is not initialized.  On Linux, the corresponding thread variable is null, but on macOS it has a nonzero value.  In all cases, initialize the variable explicitly by calling MY_INIT and my_end appropriately.
