### PR TITLE
MDEV-35587 unit.innodb_sync leaks memory on mac

### DIFF
--- a/storage/innobase/unittest/innodb_sync-t.cc
+++ b/storage/innobase/unittest/innodb_sync-t.cc
@@ -209,4 +209,7 @@ int main(int argc __attribute__((unused)), char **argv)
 
   ok(true, "sux_lock");
   sux.free();
+
+  my_end(MY_CHECK_ERROR);
+  return exit_status();
 }


### PR DESCRIPTION
unit.innodb_sync calls my_end to cleanup its memory
