### PR TITLE
MDEV-35607 - gcc-15 fixes - use void for sig_handler returns

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -1168,10 +1168,10 @@ static void print_warnings(void);
 static void print_last_query_cost(void);
 static void end_timer(ulonglong start_time, char *buff);
 static void nice_time(double sec,char *buff,bool part_second);
-extern "C" sig_handler mysql_end(int sig) __attribute__ ((noreturn));
-extern "C" sig_handler handle_sigint(int sig);
+extern "C" void mysql_end(int sig) __attribute__ ((noreturn));
+extern "C" void handle_sigint(int sig);
 #if defined(HAVE_TERMIOS_H) && defined(GWINSZ_IN_SYS_IOCTL)
-static sig_handler window_resize(int sig);
+static void window_resize(int sig);
 #endif
 
 static void end_in_sig_handler(int sig);
@@ -1409,7 +1409,7 @@ int main(int argc,char *argv[])
 #endif
 }
 
-sig_handler mysql_end(int sig)
+void mysql_end(int sig)
 {
 #ifndef _WIN32
   /*
@@ -1594,7 +1594,7 @@ bool kill_query(const char *reason)
   If 'source' is executed, abort source command
   no query in process, regenerate prompt.
 */
-sig_handler handle_sigint(int sig)
+void handle_sigint(int sig)
 {
   /*
      On Unix only, if no query is being executed just clear the prompt,
@@ -1634,7 +1634,7 @@ sig_handler handle_sigint(int sig)
 
 
 #if defined(HAVE_TERMIOS_H) && defined(GWINSZ_IN_SYS_IOCTL)
-sig_handler window_resize(int sig)
+void window_resize(int sig)
 {
   struct winsize window_size;
 

--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -62,7 +62,7 @@ static my_bool sql_connect(MYSQL *mysql, uint wait);
 static int execute_commands(MYSQL *mysql,int argc, char **argv);
 static char **mask_password(int argc, char ***argv);
 static int drop_db(MYSQL *mysql,const char *db);
-extern "C" sig_handler endprog(int signal_number);
+extern "C" void endprog(int signal_number);
 static void nice_time(ulong sec,char *buff);
 static void print_header(MYSQL_RES *result);
 static void print_top(MYSQL_RES *result);
@@ -513,7 +513,7 @@ err2:
 }
 
 
-sig_handler endprog(int signal_number __attribute__((unused)))
+void endprog(int signal_number __attribute__((unused)))
 {
   interrupted=1;
 }

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -98,7 +98,7 @@ static int setenv(const char *name, const char *value, int overwrite);
 #endif
 
 C_MODE_START
-static sig_handler signal_handler(int sig);
+static void signal_handler(int sig);
 static my_bool get_one_option(const struct my_option *, const char *,
                               const char *);
 C_MODE_END
@@ -10077,7 +10077,7 @@ static void dump_backtrace(void)
 
 #endif
 
-static sig_handler signal_handler(int sig)
+static void signal_handler(int sig)
 {
   fprintf(stderr, "mysqltest got " SIGNAL_FMT "\n", sig);
   dump_backtrace();

--- a/mysys/stacktrace.c
+++ b/mysys/stacktrace.c
@@ -41,7 +41,7 @@
    Default handler for printing stacktrace
 */
 
-static sig_handler default_handle_fatal_signal(int sig)
+static void default_handle_fatal_signal(int sig)
 {
   my_safe_printf_stderr("%s: Got signal %d. Attempting backtrace\n",
                         my_progname_short, sig);

--- a/mysys/thr_timer.c
+++ b/mysys/thr_timer.c
@@ -244,7 +244,7 @@ void thr_timer_end(thr_timer_t *timer_data)
   Come here when some timer in queue is due.
 */
 
-static sig_handler process_timers(struct timespec *now)
+static void process_timers(struct timespec *now)
 {
   thr_timer_t *timer_data;
   DBUG_ENTER("process_timers");

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -271,7 +271,7 @@ inline void setup_fpu()
 extern "C" int gethostname(char *name, int namelen);
 #endif
 
-extern "C" sig_handler handle_fatal_signal(int sig);
+extern "C" void handle_fatal_signal(int sig);
 
 #if defined(__linux__)
 #define ENABLE_TEMP_POOL 1
@@ -1868,7 +1868,7 @@ static void close_connections(void)
 #endif /*EMBEDDED_LIBRARY*/
 
 
-extern "C" sig_handler print_signal_warning(int sig)
+extern "C" void print_signal_warning(int sig)
 {
   if (global_system_variables.log_warnings)
     sql_print_warning("Got signal %d from thread %u", sig,
@@ -2836,7 +2836,7 @@ void close_connection(THD *thd, uint sql_errno)
 
 /** Called when mysqld is aborted with ^C */
 /* ARGSUSED */
-extern "C" sig_handler end_mysqld_signal(int sig __attribute__((unused)))
+extern "C" void end_mysqld_signal(int sig __attribute__((unused)))
 {
   DBUG_ENTER("end_mysqld_signal");
   /* Don't kill if signal thread is not running */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: [MDEV-35607](https://jira.mariadb.org/browse/MDEV-35607)*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
fixes compile issue with gcc-15
```
../mysys/stacktrace.c: In function 'default_handle_fatal_signal':
../mysys/stacktrace.c:53:3: error: 'return' with no value, in function 
returning non-void [-Wreturn-mismatch]
    53 |   return;
       |   ^~~~~~
...
```

## Release Notes
Fixes build with gcc-15 when combined with fixes from:
- https://jira.mariadb.org/browse/MDEV-35605
- https://jira.mariadb.org/browse/MDEV-35606

## How can this PR be tested?
Testing can be performed using gcc-15 as a compiler

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
