### PR TITLE
MDEV-35443: opt_search_plan_for_table() may degrade to full table scan

### DIFF
--- a/mysql-test/suite/innodb/r/stats_persistent.result
+++ b/mysql-test/suite/innodb/r/stats_persistent.result
@@ -6,14 +6,23 @@ SET DEBUG_SYNC='dict_stats_update_persistent SIGNAL stop WAIT_FOR go';
 ANALYZE TABLE t1;
 connect con1, localhost, root;
 SET DEBUG_SYNC='now WAIT_FOR stop';
+connect con2, localhost, root;
+SET DEBUG_SYNC='innodb_inplace_alter_table_enter SIGNAL astop WAIT_FOR ago';
+ALTER TABLE mysql.innodb_index_stats FORCE;
+connection con1;
 SELECT SUM(DATA_LENGTH+INDEX_LENGTH) FROM information_schema.TABLES WHERE ENGINE='InnoDB';
 SUM(DATA_LENGTH+INDEX_LENGTH)
 SUM
+SET DEBUG_SYNC='now WAIT_FOR astop';
 SET DEBUG_SYNC='now SIGNAL go';
 disconnect con1;
 connection default;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	Engine-independent statistics collected
 test.t1	analyze	status	OK
+SET DEBUG_SYNC='now SIGNAL ago';
+connection con2;
+disconnect con2;
+connection default;
 SET DEBUG_SYNC= 'RESET';
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/stats_persistent.test
+++ b/mysql-test/suite/innodb/t/stats_persistent.test
@@ -14,14 +14,25 @@ SET DEBUG_SYNC='dict_stats_update_persistent SIGNAL stop WAIT_FOR go';
 --connect(con1, localhost, root)
 SET DEBUG_SYNC='now WAIT_FOR stop';
 
+--connect(con2, localhost, root)
+SET DEBUG_SYNC='innodb_inplace_alter_table_enter SIGNAL astop WAIT_FOR ago';
+send ALTER TABLE mysql.innodb_index_stats FORCE;
+
+--connection con1
 --replace_column 1 SUM
 SELECT SUM(DATA_LENGTH+INDEX_LENGTH) FROM information_schema.TABLES WHERE ENGINE='InnoDB';
 
+SET DEBUG_SYNC='now WAIT_FOR astop';
 SET DEBUG_SYNC='now SIGNAL go';
 --disconnect con1
 
 --connection default
 --reap
+SET DEBUG_SYNC='now SIGNAL ago';
+--connection con2
+reap;
+--disconnect con2
+--connection default
 SET DEBUG_SYNC= 'RESET';
 DROP TABLE t1;
 

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -1203,6 +1203,14 @@ public:
 	/** @return whether this is the change buffer */
 	bool is_ibuf() const { return UNIV_UNLIKELY(type & DICT_IBUF); }
 
+	/** @return whether this is a normal, non-virtual B-tree index
+	(not the change buffer, not SPATIAL or FULLTEXT) */
+	bool is_normal_btree() const noexcept {
+		return UNIV_LIKELY(!(type & (DICT_IBUF | DICT_SPATIAL
+					     | DICT_FTS | DICT_CORRUPT
+					     | DICT_VIRTUAL)));
+	}
+
 	/** @return whether the index includes virtual columns */
 	bool has_virtual() const { return type & DICT_VIRTUAL; }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35443*
## Description
`opt_calc_index_goodness()`: Correct an inaccurate condition. We can very well use a clustered index of a table that is subject to online rebuild. But we must not choose an index that has not been committed (it is a secondary index that was not fully created) or that is corrupted or not a normal B-tree index.

`opt_search_plan_for_table()`: Remove some redundant code, now that `opt_calc_index_goodness()` checks against corrupted indexes.
## Release Notes
During the execution of `OPTIMIZE TABLE mysql.innodb_index_stats` or `OPTIMIZE TABLE mysql.innodb_table_stats` or a similar statement, InnoDB could execute an unnecessary and costly full scan of these tables while updating persistent statistics.
## How can this PR be tested?
The test case allows this code to be exercised. The main observation in the following:
```sh
./mtr --rr innodb.stats_persistent
rr replay var/log/mysqld.1.rr/latest-trace
```
should be that when `opt_search_plan_for_table()` is being invoked by `dict_stats_update_persistent()` on the being-altered statistics table, and the fix in `opt_calc_index_goodness()` is absent, it would choose the code path `if (n_fields == 0)`, that is, a full table scan, instead of searching for the record. The commands to execute in `rr replay` should be the following:
```gdb
break ha_innobase::inplace_alter_table
continue
break opt_search_plan_for_table
ignore 2 1
continue
```
After the `ALTER TABLE mysql.innodb_index_stats FORCE` in the modified test case is blocked, the first invocation for `opt_search_plan_for_table()` will be for the other statistics table `mysql.innodb_table_stats` and the second one for this being-altered table. You can observe that without the fix we will end up with `goodness=0` and `n_fields=0`. With the fix, we will have `n_fields=4` and `goodness=0x811`.

Note: The test case will pass even if the change to `opt_calc_index_goodness()` is omitted.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.