### PR TITLE
TODO-5067 : Add test case for Galera library protocol versions

### DIFF
--- a/mysql-test/suite/wsrep/r/wsrep_protocol_versions.result
+++ b/mysql-test/suite/wsrep/r/wsrep_protocol_versions.result
@@ -1,0 +1,7 @@
+# Correct Galera library found
+show status like 'wsrep_protocol%';
+Variable_name	Value
+wsrep_protocol_application	4
+wsrep_protocol_gcs	5
+wsrep_protocol_replicator	11
+wsrep_protocol_version	11

--- a/mysql-test/suite/wsrep/t/wsrep_protocol_versions.cnf
+++ b/mysql-test/suite/wsrep/t/wsrep_protocol_versions.cnf
@@ -1,0 +1,14 @@
+# Use default setting for mysqld processes
+!include include/default_mysqld.cnf
+
+[mysqld.1]
+wsrep-on=ON
+binlog-format=ROW
+innodb-flush-log-at-trx-commit=1
+wsrep-cluster-address=gcomm://
+wsrep-provider=@ENV.WSREP_PROVIDER
+innodb-autoinc-lock-mode=2
+#galera_port=@OPT.port
+#ist_port=@OPT.port
+#sst_port=@OPT.port
+

--- a/mysql-test/suite/wsrep/t/wsrep_protocol_versions.test
+++ b/mysql-test/suite/wsrep/t/wsrep_protocol_versions.test
@@ -1,0 +1,9 @@
+--source include/have_wsrep.inc
+--source include/force_restart.inc
+--source include/have_innodb.inc
+
+--let $galera_version=26.4.21
+source include/check_galera_version.inc;
+
+--sorted_result
+show status like 'wsrep_protocol%';


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: TODO-5067*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Add test case to verify has Galera library protocol versions changed. This version of test requires Galera library 26.4.21 to work.


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
