### PR TITLE
MDEV-35638 wsrep_last_{written,seen}_gtid call my_error(ER_OUTOFMEMORY) incorrectly

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -5327,7 +5327,7 @@ String *Item_func_wsrep_last_written_gtid::val_str_ascii(String *str)
 {
   if (gtid_str.alloc(WSREP_MAX_WSREP_SERVER_GTID_STR_LEN+1))
   {
-    my_error(ER_OUTOFMEMORY, WSREP_MAX_WSREP_SERVER_GTID_STR_LEN);
+    my_error(ER_OUTOFMEMORY, MYF(0), WSREP_MAX_WSREP_SERVER_GTID_STR_LEN+1);
     null_value= TRUE;
     return 0;
   }
@@ -5352,7 +5352,7 @@ String *Item_func_wsrep_last_seen_gtid::val_str_ascii(String *str)
 {
   if (gtid_str.alloc(WSREP_MAX_WSREP_SERVER_GTID_STR_LEN+1))
   {
-    my_error(ER_OUTOFMEMORY, WSREP_MAX_WSREP_SERVER_GTID_STR_LEN);
+    my_error(ER_OUTOFMEMORY, MYF(0), WSREP_MAX_WSREP_SERVER_GTID_STR_LEN+1);
     null_value= TRUE;
     return 0;
   }
@@ -5414,7 +5414,8 @@ longlong Item_func_wsrep_sync_wait_upto::val_int()
       }
       else if (wait_gtid_ret == ENOMEM)
       {
-        my_error(ER_OUTOFMEMORY, MYF(0), func_name());
+        /* length is bogus here, no idea how much it tried */
+        my_error(ER_OUTOFMEMORY, MYF(0), WSREP_GTID_STR_LEN);
         ret= 0;
       }
     }


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35638*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The my_error has a flags argument before the varargs size, which in ER_OUTOFMEMORY is a %d. Pass in the size, corrected for what was attempted to be allocated.

For wsrep_sync_wait_upto we error a size roughly of a gtid, though the allocation that failed in wait_gtid_upto was doing:

   "m_wait_map.insert(std::make_pair(seqno, &wait_cond))"

which fails. Rather than working out the exact size, which won't be large and not actionably by the user, doing an approximation instead.

## Release Notes

Correct OOM messages if they occured during wsrep_last_{writtent,seen}_gtid functions.

## How can this PR be tested?

Not easily, manual memory limited, but the calling convention on the error message is quite clear.

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.