### PR TITLE
MDEV-35639 func sha2/char - handle OOM

### DIFF
--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -271,7 +271,12 @@ String *Item_func_sha2::val_str_ascii(String *str)
     Since we're subverting the usual String methods, we must make sure that
     the destination has space for the bytes we're about to write.
   */
-  str->alloc((uint) digest_length*2 + 1); /* Each byte as two nybbles */
+  if (str->alloc((uint) digest_length*2 + 1)) /* Each byte as two nybbles */
+  {
+    my_error(ER_OUTOFMEMORY, MYF(0), (int) digest_length*2 +1);
+    null_value= TRUE;
+    return NULL;
+  }
 
   /* Convert the large number to a string-hex representation. */
   array_to_hex((char *) str->ptr(), digest_buf, (uint)digest_length);
@@ -2987,7 +2992,12 @@ String *Item_func_char::val_str(String *str)
     if (!args[i]->null_value)
       append_char(str, num);
   }
-  str->realloc(str->length());			// Add end 0 (for Purify)
+  if (str->realloc(str->length()))
+  {
+    my_error(ER_OUTOFMEMORY, MYF(0), (int) str->length());
+    null_value= TRUE;
+    return NULL;
+  }
   return check_well_formed_result(str);
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35639*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The SQL functions sha2 and char perform string allocations without returning
a SQL error if these allocations fail.

Corrected so SQL errors are returned if the reallocation failed.

## Release Notes

Handle sha2/char function out of memory errors on the chance reallocation of memory fails.

## How can this PR be tested?

With difficulty. The error handling is pretty straight forward.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.