### PR TITLE
MDEV-35619 Assertion failure in row_purge_del_mark_error

### DIFF
--- a/storage/innobase/include/trx0sys.h
+++ b/storage/innobase/include/trx0sys.h
@@ -971,18 +971,23 @@ public:
 
     Our IA-32 target is not "i386" but at least "i686", that is, at least
     Pentium MMX, which has a 64-bit data bus and 64-bit XMM registers. */
+    bool hot= false;
     trx->mutex_lock();
     trx_id_t &max_inactive_id= trx->max_inactive_id;
-    const bool hot{max_inactive_id < id && find_same_or_older(trx, id)};
+    if (max_inactive_id >= id);
+    else if (!find_same_or_older_low(trx, id))
+      max_inactive_id= id;
+    else
+      hot= true;
 #else
     Atomic_relaxed<trx_id_t> &max_inactive_id= trx->max_inactive_id_atomic;
     if (max_inactive_id >= id)
       return false;
     trx->mutex_lock();
-    const bool hot{find_same_or_older(trx, id)};
-#endif
-    if (hot)
+    const bool hot{find_same_or_older_low(trx, id)};
+    if (!hot)
       max_inactive_id= id;
+#endif
     trx->mutex_unlock();
     return hot;
   }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35619*
## Description
`trx_sys_t::find_same_or_older_in_purge()`: Correct a mistake that was made in #3668 and make the caching logic correspond to the one in `trx_sys_t::find_same_or_older()`. In the more common code path for 64-bit systems, the condition !hot was inadvertently inverted, making us wrongly skip calls to find_same_or_older_low() when the transaction may still be active.

Furthermore, the call should have been to `find_same_or_older_low()` and not the wrapper `find_same_or_older()`.
## Release Notes
Same as MDEV-35508 (#3668). This is fixing up that fix.
## How can this PR be tested?
An based RQG test case was run in [MDEV-35619](https://jira.mariadb.org/browse/MDEV-35619). It is very hard to write a deterministic test for a case like this.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.