### PR TITLE
MDEV-35568 Reintroduce delete_while_scanning for multi_delete

### DIFF
--- a/mysql-test/main/myisam_explain_non_select_all.result
+++ b/mysql-test/main/myisam_explain_non_select_all.result
@@ -120,8 +120,7 @@ Handler_read_rnd_next	4
 Variable_name	Value
 Handler_delete	1
 Handler_read_key	2
-Handler_read_rnd	1
-Handler_read_rnd_next	6
+Handler_read_rnd_next	4
 
 DROP TABLE t1;
 #4
@@ -928,9 +927,9 @@ Variable_name	Value
 Handler_delete	8
 Handler_read_key	19
 Handler_read_next	3
-Handler_read_rnd	8
+Handler_read_rnd	5
 Handler_read_rnd_deleted	1
-Handler_read_rnd_next	15
+Handler_read_rnd_next	11
 
 DROP TABLE t1, t2, t3;
 #20
@@ -1066,8 +1065,7 @@ Handler_read_rnd_next	12
 Variable_name	Value
 Handler_delete	3
 Handler_read_key	4
-Handler_read_rnd	3
-Handler_read_rnd_next	34
+Handler_read_rnd_next	30
 
 DROP TABLE t1, t2;
 #22

--- a/mysql-test/suite/innodb/r/innodb.result
+++ b/mysql-test/suite/innodb/r/innodb.result
@@ -1302,7 +1302,7 @@ insert into `t2`values ( 1 ) ;
 create table `t3` (`id` int( 11 ) not null default '0',key `id` ( `id` ) ,constraint `t2_id_fk` foreign key ( `id` ) references `t2` (`id` )) engine = innodb;
 insert into `t3`values ( 1 ) ;
 delete t3,t2,t1 from t1,t2,t3 where t1.id =1 and t2.id = t1.id and t3.id = t2.id;
-ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t1_id_fk` FOREIGN KEY (`id`) REFERENCES `t1` (`id`))
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t3`, CONSTRAINT `t2_id_fk` FOREIGN KEY (`id`) REFERENCES `t2` (`id`))
 update t1,t2,t3 set t3.id=5, t2.id=6, t1.id=7  where t1.id =1 and t2.id = t1.id and t3.id = t2.id;
 ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t1_id_fk` FOREIGN KEY (`id`) REFERENCES `t1` (`id`))
 update t3 set  t3.id=7  where t1.id =1 and t2.id = t1.id and t3.id = t2.id;

--- a/mysql-test/suite/innodb/r/innodb_mysql.result
+++ b/mysql-test/suite/innodb/r/innodb_mysql.result
@@ -2526,9 +2526,9 @@ INSERT INTO t4 VALUES (1),(2),(3),(4),(5);
 INSERT INTO t5 VALUES (1);
 DELETE t5 FROM t4 LEFT JOIN t5 ON t4.a= t5.a;
 DELETE t2, t1 FROM t2 INNER JOIN t1 ON (t2.aid = t1.id) WHERE t2.id = 1;
-ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t3`, CONSTRAINT `t3_ibfk_1` FOREIGN KEY (`bid`) REFERENCES `t2` (`id`))
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`aid`) REFERENCES `t1` (`id`))
 DELETE t2, t1 FROM t2 INNER JOIN t1 ON (t2.aid = t1.id) WHERE t2.id = 1;
-ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t3`, CONSTRAINT `t3_ibfk_1` FOREIGN KEY (`bid`) REFERENCES `t2` (`id`))
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails (`test`.`t2`, CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`aid`) REFERENCES `t1` (`id`))
 DELETE IGNORE t2, t1 FROM t2 INNER JOIN t1 ON (t2.aid = t1.id) WHERE t2.id = 1;
 DROP TABLE t3;
 DROP TABLE t2;

--- a/mysql-test/suite/perfschema/r/multi_table_io.result
+++ b/mysql-test/suite/perfschema/r/multi_table_io.result
@@ -69,7 +69,6 @@ wait/io/table/sql/handler		TABLE	test1	t2	update	1
 wait/io/table/sql/handler		TABLE	test	marker	insert	1
 wait/io/table/sql/handler		TABLE	test	t1	fetch	1
 wait/io/table/sql/handler		TABLE	test1	t2	fetch	1
-wait/io/table/sql/handler		TABLE	test	t1	fetch	1
 wait/io/table/sql/handler		TABLE	test	t1	delete	1
 wait/io/table/sql/handler		TABLE	test1	t2	fetch	1
 wait/io/table/sql/handler		TABLE	test1	t2	delete	1

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -7574,6 +7574,7 @@ class multi_delete :public select_result_interceptor
   bool transactional_tables;
   /* True if at least one table we delete from is not transactional */
   bool normal_tables;
+  bool delete_while_scanning;
   /*
      error handling (rollback and binlogging) can happen in send_eof()
      so that afterward abort_result_set() needs to find out that.


### PR DESCRIPTION
Reintroduces delete_while_scanning optimization for multi_delete. Reverse some test changes from the initial feature devlopment now that we delete-on-the-fly once again.
