### PR TITLE
MDEV-35338 - Non-copying ALTER does not pad VECTOR column, vector sea…

### DIFF
--- a/mysql-test/main/vector_innodb.result
+++ b/mysql-test/main/vector_innodb.result
@@ -227,3 +227,17 @@ connection con1;
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 drop table t;
 disconnect con1;
+connection default;
+#
+# MDEV-35338 - Non-copying ALTER does not pad VECTOR column,
+#              vector search further does not work
+#
+create or replace table t (a int, v vector(1) not null, primary key (a)) engine=InnoDB;
+insert into t values (1,0x38383838),(2,0x37373737),(3,0x31313131);
+alter table t modify v vector(2) not null;
+select hex(v) from t order by a;
+hex(v)
+3838383800000000
+3737373700000000
+3131313100000000
+drop table t;

--- a/mysql-test/main/vector_innodb.test
+++ b/mysql-test/main/vector_innodb.test
@@ -231,3 +231,14 @@ rollback;
 --reap
 drop table t;
 --disconnect con1
+connection default;
+
+--echo #
+--echo # MDEV-35338 - Non-copying ALTER does not pad VECTOR column,
+--echo #              vector search further does not work
+--echo #
+create or replace table t (a int, v vector(1) not null, primary key (a)) engine=InnoDB;
+insert into t values (1,0x38383838),(2,0x37373737),(3,0x31313131);
+alter table t modify v vector(2) not null;
+select hex(v) from t order by a;
+drop table t;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -119,6 +119,7 @@ simple_thread_local ha_handler_stats *mariadb_stats;
 
 #include <limits>
 #include <myisamchk.h>                          // TT_FOR_UPGRADE
+#include "sql_type_vector.h"
 
 #define thd_get_trx_isolation(X) ((enum_tx_isolation)thd_tx_isolation(X))
 
@@ -20763,6 +20764,9 @@ bool ha_innobase::can_convert_blob(const Field_blob *field,
 bool ha_innobase::can_convert_nocopy(const Field &field,
                                      const Column_definition &new_type) const
 {
+  if (dynamic_cast<const Field_vector *>(&field))
+    return false;
+
   if (const Field_string *tf= dynamic_cast<const Field_string *>(&field))
     return can_convert_string(tf, new_type);
 


### PR DESCRIPTION
…rch further does not work

Since VECTOR data type is based on VARCHAR, ALTER TABLE expanding VECTOR column was allowed to go with ALGORITHM=INPLACE.

However InnoDB sees such columns as VARCHAR and thus it doesn't pad updated columns data to new length. In contrast to ALGORITHM=COPY, which goes with field copy routines.

With this patch ALGORITHM=INPLACE is not allowed for VECTOR columns.

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35338*

## Release Notes


## How can this PR be tested?
mtr test added
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
