### PR TITLE
MDEV-35659 Suppress error "Transaction was aborted due to Deadlocks"

### DIFF
--- a/mysql-test/suite/galera/t/MDEV-20616.test
+++ b/mysql-test/suite/galera/t/MDEV-20616.test
@@ -242,3 +242,8 @@ CALL proc_update_2;
 DROP PROCEDURE proc_update_1;
 DROP PROCEDURE proc_update_2;
 DROP TABLE t1;
+
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera/t/galera_FK_duplicate_client_insert.test
+++ b/mysql-test/suite/galera/t/galera_FK_duplicate_client_insert.test
@@ -159,3 +159,8 @@ while($counter > 0)
 --connection node_1
 
 drop table user_session,user;
+
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera/t/galera_sequences.test
+++ b/mysql-test/suite/galera/t/galera_sequences.test
@@ -356,3 +356,12 @@ ALTER SEQUENCE IF EXISTS t MINVALUE=1;
 
 DROP TABLE t;
 --echo End of 10.5 tests
+
+
+--disable_query_log
+--connection node_1
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+
+--connection node_2
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera_sr/t/GCF-1018B.test
+++ b/mysql-test/suite/galera_sr/t/GCF-1018B.test
@@ -38,3 +38,7 @@ while ($count)
 --enable_query_log
 
 DROP TABLE t1;
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log

--- a/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
+++ b/mysql-test/suite/galera_sr/t/mysql-wsrep-features#165.inc
@@ -111,3 +111,7 @@ SELECT * FROM t1;
 --connection node_1
 SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+
+--disable_query_log
+call mtr.add_suppression("InnoDB: Transaction was aborted due to ");
+--enable_query_log


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35659*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
With MDEV-24035, a new error is logged in the error log when innodb detects a deadlock. This commit adds supporesions to the affected tests in galera test suites.


## Release Notes
None

## How can this PR be tested?
This commit only changes existing tests, no changes in the code. Run those to verify that they pass.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
