### PR TITLE
unittest output improvement for json_normalize-t

### DIFF
--- a/unittest/json_lib/json_normalize-t.c
+++ b/unittest/json_lib/json_normalize-t.c
@@ -32,11 +32,11 @@ check_json_normalize(const char *in, const char *expected)
 
   err= json_normalize(&result, in, strlen(in), cs);
 
-  ok(err == 0, "normalize err?");
+  ok(err == 0, "normalize err: %d", err);
 
   ok(strcmp(expected, result.str) == 0,
-    "expected '%s' from '%s' but was '%s'",
-    expected, in, result.str);
+    "from '%s'\n expect: '%s'\n actual: '%s'",
+    in, expected, result.str);
 
   dynstr_free(&result);
 }
@@ -205,13 +205,13 @@ test_json_normalize_non_utf8(void)
 
   init_dynamic_string(&result, NULL, 0, 0);
   err= json_normalize(&result, utf8, strlen(utf8), cs_utf8);
-  ok(err == 0, "normalize err?");
+  ok(err == 0, "normalize err: %d", err);
   ok((strcmp(utf8, result.str) == 0), "utf8 round trip");
   dynstr_free(&result);
 
   init_dynamic_string(&result, NULL, 0, 0);
   err= json_normalize(&result, latin, strlen(latin), cs_latin);
-  ok(err == 0, "normalize err?");
+  ok(err == 0, "normalize err: %d", err);
   ok((strcmp(utf8, result.str) == 0), "latin to utf8 round trip");
   dynstr_free(&result);
 }
@@ -226,15 +226,15 @@ check_number_normalize(const char *in, const char *expected)
   init_dynamic_string(&buf, NULL, 0, 0);
 
   err= json_normalize_number(&buf, in, strlen(in));
-  ok(err == 0, "normalize number err?");
+  ok(err == 0, "normalize number err: %d", err);
 
   ok(strcmp(buf.str, expected) == 0,
+    "    from: %s\n"
     "expected: %s\n"
-    " but was: %s\n"
-    "    from: %s\n",
+    "  actual: %s\n",
+    in,
     expected,
-    buf.str,
-    in);
+    buf.str);
 
   dynstr_free(&buf);
 }


### PR DESCRIPTION
The ok() function outputs the TAP context string in both the success and failure cases. The strings were worded to make sense in the failure case, yet were confusing in the success case. This changes the strings to be appropriate, and even more informative in either the success or failure cases.  In the cases where input, expected, and result values are included in the context string, they have been adjusted such that expected and actual result values are aligned for easy visual comparison.

- [x] *The Jira issue number for this PR is: MDEV-35672*

## Description
This adjusts the context strings of the unit test assertions such that they make sense in both the success and failure cases, as well as aligns the expected and actual result strings for at-a-glance distinction.

## Release Notes
No release notes are needed for this change in unittest output

## How can this PR be tested?
Run `build/unittest/json_lib/json_normalize-t` from `main` and compare the results to this branch's results

## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
