### PR TITLE
MDEV-35660 Assertion `trx->xid.is_null()' failed

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3076,7 +3076,10 @@ static int innobase_rollback_by_xid(handlerton*, XID *xid) noexcept
     return XAER_RMFAIL;
   if (trx_t *trx= trx_get_trx_by_xid(xid))
   {
-    ut_ad(trx->xid.is_null()); /* should have been cleared by the lookup */
+    /* Lookup by xid clears the transaction xid.
+       For wsrep we clear it below. */
+    ut_ad(trx->xid.is_null() || wsrep_is_wsrep_xid(&trx->xid));
+    trx->xid.null();
     trx_deregister_from_2pc(trx);
     THD* thd= trx->mysql_thd;
     dberr_t err= trx_rollback_for_mysql(trx);


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x]  *The Jira issue number for this PR is: MDEV-35660*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The assertion fails during wsrep recovery step, in function innobase_rollback_by_xid(). The transaction's xid is normally cleared as part of lookup by xid, unless the transaction has a wsrep specific xid.
This is a regression from MDEV-24035 (commit ddd7d5d8e34c3edd) which removed the part clears xid before rollback for transaction with a wsrep specific xid.


## Release Notes
Nothing.

## How can this PR be tested?
Should fix regression on wsrep.wsrep-recover.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
 
<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
