### PR TITLE
MDEV-35665 Potential Buffer Overrun in Gtid_log_event::write()

### DIFF
--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -3729,7 +3729,12 @@ Gtid_log_event::peek(const uchar *event_start, size_t event_len,
 bool
 Gtid_log_event::write()
 {
-  uchar buf[GTID_HEADER_LEN+2+sizeof(XID) + /* flags_extra: */ 1+4];
+  uchar buf[GTID_HEADER_LEN+2
+    + sizeof(XID)
+    + 1 // flags_extra:
+    + 1 // extra_engines
+    + 8 // sa_seq_no
+  ];
   size_t write_len= 13;
 
   int8store(buf, seq_no);


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-35665](https://jira.mariadb.org/browse/MDEV-35665)*

## Description

Two-Phase ALTER added a `sa_seq_no` field, but `Gtid_log_event::write()`’s size calculation doesn’t have an addend in its name.
This means `sa_seq_no` can overrun `Gtid_log_event::write()`’s buffer.

This patch resizes the buffer to match `write()`'s code.

`Gtid_log_event` is variable-sized, but it’s possible that an instance flags all its fields for writing.

## Release Notes
Fixed internal buffer overrun when writing a GTID event with all flags active.

## How can this PR be tested?
**TODO:** We need a test that writes a `Gtid_log_event` with every field flagged active, not only so Valgrind (or a manual `DBUG_ASSERT`) can catch buffer overruns, but also to validate future new fields that they don’t impact any existing fields.

## Basing the PR against the correct MariaDB version
* ~~[ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.