### PR TITLE
MDEV-35695: mtr failure suggests wrong url

### DIFF
--- a/mysql-test/lib/mtr_report.pm
+++ b/mysql-test/lib/mtr_report.pm
@@ -454,9 +454,8 @@ sub mtr_report_stats ($$$$) {
     # Print info about reporting the error
     print
       "The log files in var/log may give you some hint of what went wrong.\n\n",
-      "If you want to report this error, please read first ",
-      "the documentation\n",
-      "at http://dev.mysql.com/doc/mysql/en/mysql-test-suite.html\n\n";
+      "If you want to report this error, MariaDB's bug tracker is found at\n",
+      "https://jira.mariadb.org\n\n";
 
    }
   else

--- a/mysql-test/lib/v1/mtr_report.pl
+++ b/mysql-test/lib/v1/mtr_report.pl
@@ -198,9 +198,8 @@ sub mtr_report_stats ($) {
     print
       "The log files in var/log may give you some hint\n",
       "of what went wrong.\n",
-      "If you want to report this error, please read first ",
-      "the documentation at\n",
-      "http://dev.mysql.com/doc/mysql/en/mysql-test-suite.html\n";
+      "If you want to report this error, MariaDB's bug tracker is found at\n",
+      "https://jira.mariadb.org\n"
   }
   if (!$::opt_extern)
   {


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-35695*

## Description

When running the ./mtr tests and getting failures, rather than provide a dead-link to mysql.com, this points developers to the Jira instance.

## Release Notes

No release notes needed.

## How can this PR be tested?

Build and test the server with any failing test, then observe the message.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

Neither of the above, as this is a bug fix mostly relevant to active development, the PR is based against the `main` branch .... I can rebase to the earliest maintained branch if that seems actually useful.

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
