### PR TITLE
MDEV-35309 - ALTER performs vector truncation without WARN_DATA_TRUNCATED or similar warnings/errors

### DIFF
--- a/mysql-test/main/vector2.result
+++ b/mysql-test/main/vector2.result
@@ -369,3 +369,20 @@ vec_totext(v)
 [7]
 [6]
 drop table t;
+#
+# MDEV-35309 - ALTER performs vector truncation without WARN_DATA_TRUNCATED or similar warnings/errors
+#
+create table t (v vector(2));
+insert into t values (0x3131313132323232);
+select * from t;
+v
+11112222
+alter table t modify v vector(1);
+ERROR 01000: Data truncated for column 'v' at row 1
+set statement sql_mode='' for alter table t modify v vector(1);
+Warnings:
+Warning	1265	Data truncated for column 'v' at row 1
+select * from t;
+v
+1111
+drop table t;

--- a/mysql-test/main/vector2.test
+++ b/mysql-test/main/vector2.test
@@ -265,3 +265,15 @@ create table t (v vector(1) not null, vector(v));
 insert into t select vec_fromtext(concat('[',seq,']')) FROM seq_1_to_10;
 select vec_totext(v) from t order by vec_distance_euclidean(v,vec_fromtext('[0]')) desc limit 5;
 drop table t;
+
+--echo #
+--echo # MDEV-35309 - ALTER performs vector truncation without WARN_DATA_TRUNCATED or similar warnings/errors
+--echo #
+create table t (v vector(2));
+insert into t values (0x3131313132323232);
+select * from t;
+--error WARN_DATA_TRUNCATED
+alter table t modify v vector(1);
+set statement sql_mode='' for alter table t modify v vector(1);
+select * from t;
+drop table t;

--- a/sql/sql_type_vector.cc
+++ b/sql/sql_type_vector.cc
@@ -256,7 +256,22 @@ static void do_copy_vec(const Copy_field *copy)
     int2store(copy->to_ptr, to_length);
 
   if (from_length > to_length)
+  {
     memcpy(to, from, to_length);
+    if (copy->from_field->table->in_use->count_cuted_fields >
+        CHECK_FIELD_EXPRESSION)
+    {
+      for (uint i= to_length; i < from_length; i++)
+      {
+        if (from[i] != 0)
+        {
+            copy->to_field->set_warning(Sql_condition::WARN_LEVEL_WARN,
+                                        WARN_DATA_TRUNCATED, 1);
+            break;
+        }
+      }
+    }
+  }
   else
   {
     memcpy(to, from, from_length);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35309*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Let ALTER TABLE issue a warning/error when VECTOR data is truncated, but only if tail has meaningful (non-zero) values.

## Release Notes


## How can this PR be tested?
mtr vector2

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
