### PR TITLE
MDEV-34119  Assertion `page_dir_get_n_heap(new_page) == 2U' failed in dberr_t PageBulk::init()

### DIFF
--- a/mysql-test/suite/innodb/r/insert_into_empty,4k.rdiff
+++ b/mysql-test/suite/innodb/r/insert_into_empty,4k.rdiff
@@ -9,11 +9,10 @@
  CHECK TABLE t1;
  Table	Op	Msg_type	Msg_text
  test.t1	check	status	OK
-@@ -541,26 +541,4 @@
- DELETE FROM t1;
+@@ -542,28 +542,6 @@
  commit;
  DROP TABLE t1;
--#
+ #
 -#  MDEV-35475 Assertion `!rec_offs_nth_extern(offsets1, n)'
 -#               failed in cmp_rec_rec_simple_field
 -#
@@ -35,4 +34,7 @@
 -(REPEAT('x',16111),'bb'), (REPEAT('x',4805),'cc'),
 -(REPEAT('x',65535),'dd');
 -DROP TABLE t1;
- # End of 10.11 tests
+-#
+ #  Assertion `page_dir_get_n_heap(new_page) == 2U' failed
+ #                  in dberr_t PageBulk::init()
+ #

--- a/mysql-test/suite/innodb/r/insert_into_empty,8k.rdiff
+++ b/mysql-test/suite/innodb/r/insert_into_empty,8k.rdiff
@@ -9,11 +9,10 @@
  CHECK TABLE t1;
  Table	Op	Msg_type	Msg_text
  test.t1	check	status	OK
-@@ -541,26 +541,4 @@
- DELETE FROM t1;
+@@ -542,28 +542,6 @@
  commit;
  DROP TABLE t1;
--#
+ #
 -#  MDEV-35475 Assertion `!rec_offs_nth_extern(offsets1, n)'
 -#               failed in cmp_rec_rec_simple_field
 -#
@@ -35,4 +34,7 @@
 -(REPEAT('x',16111),'bb'), (REPEAT('x',4805),'cc'),
 -(REPEAT('x',65535),'dd');
 -DROP TABLE t1;
- # End of 10.11 tests
+-#
+ #  Assertion `page_dir_get_n_heap(new_page) == 2U' failed
+ #                  in dberr_t PageBulk::init()
+ #

--- a/mysql-test/suite/innodb/r/insert_into_empty.result
+++ b/mysql-test/suite/innodb/r/insert_into_empty.result
@@ -563,4 +563,21 @@ INSERT INTO t1 VALUES (REPEAT('x',4805),'a'), (REPEAT('x',16111),'b'),
 (REPEAT('x',16111),'bb'), (REPEAT('x',4805),'cc'),
 (REPEAT('x',65535),'dd');
 DROP TABLE t1;
+#
+#  Assertion `page_dir_get_n_heap(new_page) == 2U' failed
+#                  in dberr_t PageBulk::init()
+#
+CREATE TABLE t1(f1 INT)ENGINE=InnoDB PARTITION BY RANGE (f1) (PARTITION p0 VALUES LESS THAN (100));
+SET @old_bulk_op=
+(SELECT variable_value FROM information_schema.global_status
+WHERE variable_name = 'innodb_bulk_operations');
+BEGIN;
+INSERT INTO t1 SELECT seq FROM seq_1_to_1;
+COMMIT;
+SELECT variable_value-@old_bulk_op bulk_operations
+FROM information_schema.global_status
+WHERE variable_name = 'innodb_bulk_operations';
+bulk_operations
+1
+DROP TABLE t1;
 # End of 10.11 tests

--- a/mysql-test/suite/innodb/t/insert_into_empty.test
+++ b/mysql-test/suite/innodb/t/insert_into_empty.test
@@ -619,4 +619,23 @@ INSERT INTO t1 VALUES (REPEAT('x',4805),'a'), (REPEAT('x',16111),'b'),
 		      (REPEAT('x',65535),'dd');
 DROP TABLE t1;
 }
+
+--echo #
+--echo #  Assertion `page_dir_get_n_heap(new_page) == 2U' failed
+--echo #                  in dberr_t PageBulk::init()
+--echo #
+CREATE TABLE t1(f1 INT)ENGINE=InnoDB PARTITION BY RANGE (f1) (PARTITION p0 VALUES LESS THAN (100));
+
+SET @old_bulk_op=
+(SELECT variable_value FROM information_schema.global_status
+WHERE variable_name = 'innodb_bulk_operations');
+
+BEGIN;
+INSERT INTO t1 SELECT seq FROM seq_1_to_1;
+COMMIT;
+
+SELECT variable_value-@old_bulk_op bulk_operations
+FROM information_schema.global_status
+WHERE variable_name = 'innodb_bulk_operations';
+DROP TABLE t1;
 --echo # End of 10.11 tests

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2562,6 +2562,22 @@ row_ins_index_entry_big_rec(
 	return(error);
 }
 
+/** Check whether the executed sql command is from insert
+statement
+@param thd thread information
+@return true if it is insert statement */
+static bool thd_sql_is_insert(const THD *thd) noexcept
+{
+  switch(thd_sql_command(thd))
+  {
+    case SQLCOM_INSERT:
+    case SQLCOM_INSERT_SELECT:
+      return true;
+    default:
+      return false;
+  }
+}
+
 #if defined __aarch64__&&defined __GNUC__&&__GNUC__==4&&!defined __clang__
 /* Avoid GCC 4.8.5 internal compiler error due to srw_mutex::wr_unlock().
 We would only need this for row_ins_clust_index_entry_low(),
@@ -2712,7 +2728,7 @@ err_exit:
 	    && block->page.id().page_no() == index->page
 	    && !index->table->is_native_online_ddl()
 	    && (!dict_table_is_partition(index->table)
-	        || thd_sql_command(trx->mysql_thd) == SQLCOM_INSERT)) {
+		|| thd_sql_is_insert(trx->mysql_thd))) {
 
 		if (!index->table->n_rec_locks
 		    && !index->table->versioned()


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34119*

## Description

Problem:
=======
- insert..select statement on partition table fails to use bulk insert for the transaction.

Solution:
========
- Enable the bulk insert operation for insert..select statement for partition table.

## How can this PR be tested?
./mtr innodb.insert_into_empty

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
