### PR TITLE
MDEV-34218: Mariadb Galera cluster fails when replicating from Mysql …

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2041,6 +2041,9 @@ Format_description_log_event::
 Format_description_log_event(uint8 binlog_ver, const char* server_ver)
   :Start_log_event_v3(), event_type_permutation(0)
 {
+#ifdef WITH_WSREP
+  skip_gtid_seqno_check = false;
+#endif /* WITH_WSREP */
   binlog_version= binlog_ver;
   switch (binlog_ver) {
   case 4: /* MySQL 5.0 */
@@ -2235,6 +2238,9 @@ Format_description_log_event(const uchar *buf, uint event_len,
    common_header_len(0), post_header_len(NULL), event_type_permutation(0)
 {
   DBUG_ENTER("Format_description_log_event::Format_description_log_event(char*,...)");
+#ifdef WITH_WSREP
+  skip_gtid_seqno_check = false;
+#endif /* WITH_WSREP */
   if (!Start_log_event_v3::is_valid())
     DBUG_VOID_RETURN; /* sanity check */
   buf+= LOG_EVENT_MINIMAL_HEADER_LEN;
@@ -2604,6 +2610,9 @@ Gtid_log_event::Gtid_log_event(const uchar *buf, uint event_len,
   : Log_event(buf, description_event), seq_no(0), commit_id(0),
     flags_extra(0), extra_engines(0)
 {
+#ifdef WITH_WSREP
+  skip_gtid_seqno_check = description_event->skip_gtid_seqno_check;
+#endif /* WITH_WSREP */
   uint8 header_size= description_event->common_header_len;
   uint8 post_header_len= description_event->post_header_len[GTID_EVENT-1];
   const uchar *buf_0= buf;

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -2807,6 +2807,9 @@ public:
 class Format_description_log_event: public Start_log_event_v3
 {
 public:
+#ifdef WITH_WSREP
+  bool skip_gtid_seqno_check;
+#endif /* WITH_WSREP */
   /*
      The size of the fixed header which _all_ events have
      (for binlogs written by this version, this is equal to
@@ -3658,6 +3661,9 @@ public:
     to the event when the transaction involves only one engine.
   */
   static const uchar FL_EXTRA_MULTI_ENGINE= 1;
+#ifdef WITH_WSREP
+  bool skip_gtid_seqno_check;
+#endif /* WITH_WSREP */
 
 #ifdef MYSQL_SERVER
   Gtid_log_event(THD *thd_arg, uint64 seq_no, uint32 domain_id, bool standalone,
@@ -3684,6 +3690,13 @@ public:
 
   bool is_valid() const override
   {
+#ifdef WITH_WSREP
+    if (skip_gtid_seqno_check)
+    {
+      return true;
+    }
+#endif /* WITH_WSREP */
+
     /*
       seq_no is set to 0 if the structure of a serialized GTID event does not
       align with that as indicated by flags and extra_flags.

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -3310,6 +3310,9 @@ Gtid_log_event::Gtid_log_event(THD *thd_arg, uint64 seq_no_arg,
            (commit_id_arg ? FL_GROUP_COMMIT_ID : 0)),
     flags_extra(0), extra_engines(0)
 {
+#ifdef WITH_WSREP
+  skip_gtid_seqno_check = false;
+#endif /* WITH_WSREP */
   cache_type= Log_event::EVENT_NO_CACHE;
   bool is_tmp_table= thd_arg->lex->stmt_accessed_temp_table();
   if (thd_arg->transaction->stmt.trans_did_wait() ||

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2459,7 +2459,7 @@ bool wsrep_can_run_in_toi(THD *thd, const char *db, const char *table,
       create table event.
     */
     if (thd->slave_thread &&
-	!(thd->rgi_slave->gtid_ev_flags2 & Gtid_log_event::FL_STANDALONE))
+       !(thd->rgi_slave->gtid_ev_flags2 & Gtid_log_event::FL_STANDALONE))
     {
       /* this is CTAS, either empty or populated table */
       ulonglong event_size = 0;


### PR DESCRIPTION
…5.7 on use of DDL

Issue:
Mariadb Galera cluster fails to replicate from Mysql 5.7 when configured with MASTER_USE_GTID=no option for CHANGE MASTER.

HOST: mysql, mysql 5.7.44 binlog_format=ROW
HOST: m1, mariadb 10.6 GALERA NODE replicating from HOST mysql, Using_Gtid: No (log file and position)
HOST: m2 mariadb 10.6 GALERA NODE
HOST: m3 mariadb 10.6 GALERA NODE

Error on m1:
  2024-05-22 16:11:07 1 [ERROR] WSREP: Vote 0 (success) on 78cebda7-1876-11ef-896b-8a58fca50d36:2565 is inconsistent with group. Leaving cluster.

Error on m2 and m3:
  2024-05-22 16:11:06 2 [ERROR] Error in Log_event::read_log_event(): 'Found invalid event in binary log', data_len: 42, event_type: -94
  2024-05-22 16:11:06 2 [ERROR] WSREP: applier could not read binlog event, seqno: 2565, len: 482

Solution:
Skip Gtid_log_event::is_valid() check when MASTER_USE_GTID==no.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
