### PR TITLE
Remove dup check from `throw_bounds_warning`

### DIFF
--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -486,11 +486,6 @@ bool throw_bounds_warning(THD *thd, const char *name,
     else
       llstr(v, buf);
 
-    if (thd->variables.sql_mode & MODE_STRICT_ALL_TABLES)
-    {
-      my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name, buf);
-      return true;
-    }
     return throw_bounds_warning(thd, name, buf);
   }
   return false;
@@ -504,11 +499,6 @@ bool throw_bounds_warning(THD *thd, const char *name, bool fixed, double v)
 
     my_gcvt(v, MY_GCVT_ARG_DOUBLE, sizeof(buf) - 1, buf, NULL);
 
-    if (thd->variables.sql_mode & MODE_STRICT_ALL_TABLES)
-    {
-      my_error(ER_WRONG_VALUE_FOR_VAR, MYF(0), name, buf);
-      return true;
-    }
     return throw_bounds_warning(thd, name, buf);
   }
   return false;


### PR DESCRIPTION
* [x] ~~*The Jira issue number for this PR is: [MDEV-11917][]*~~

## Description
[MDEV-11917][] merged a unified `const char*` overload for the two numeric `throw_bounds_warning` overloads. The `my_error`-on- `MODE_STRICT_ALL_TABLES` branch wasn’t removed from the two, though.
In result, the two checks if they should switch to this branch before calling the unified overload, but its first action is also to check if it should switch to a branch with the exact same (assembly) code.
This commit removes this leftover duplication.

## Release Notes
N/A – This is a miscellaneous refactor with no output changes.

## How can this PR be tested?
Run existing MTR tests

## Basing the PR against the correct MariaDB version
* [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
(I filed this tiny diff as a PR because of good habit… :grinning:)
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

[MDEV-11917]: https://jira.mariadb.org/browse/MDEV-11917