### PR TITLE
MDEV-35785 innodb_log_file_mmap is not defined on 32-bit systems

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -1331,9 +1331,7 @@ enum options_xtrabackup
   OPT_INNODB_BUFFER_POOL_FILENAME,
   OPT_INNODB_LOCK_WAIT_TIMEOUT,
   OPT_INNODB_LOG_BUFFER_SIZE,
-#ifdef HAVE_INNODB_MMAP
   OPT_INNODB_LOG_FILE_MMAP,
-#endif
 #if defined __linux__ || defined _WIN32
   OPT_INNODB_LOG_FILE_BUFFERING,
 #endif
@@ -1895,13 +1893,11 @@ struct my_option xb_server_options[] =
    (G_PTR*) &log_sys.buf_size, (G_PTR*) &log_sys.buf_size, 0,
    GET_UINT, REQUIRED_ARG, 2U << 20,
    2U << 20, log_sys.buf_size_max, 0, 4096, 0},
-#ifdef HAVE_INNODB_MMAP
   {"innodb_log_file_mmap", OPT_INNODB_LOG_FILE_SIZE,
    "Whether ib_logfile0 should be memory-mapped",
    (G_PTR*) &log_sys.log_mmap,
    (G_PTR*) &log_sys.log_mmap, 0, GET_BOOL, NO_ARG,
    log_sys.log_mmap_default, 0, 0, 0, 0, 0},
-#endif
 #if defined __linux__ || defined _WIN32
   {"innodb_log_file_buffering", OPT_INNODB_LOG_FILE_BUFFERING,
    "Whether the file system cache for ib_logfile0 is enabled during --backup",
@@ -3370,7 +3366,6 @@ skip:
 	return(FALSE);
 }
 
-#ifdef HAVE_INNODB_MMAP
 static int
 xtrabackup_copy_mmap_snippet(ds_file_t *ds, const byte *start, const byte *end)
 {
@@ -3470,7 +3465,6 @@ static bool xtrabackup_copy_mmap_logfile()
     msg(">> log scanned up to (" LSN_PF ")", recv_sys.lsn);
   return false;
 }
-#endif
 
 /** Copy redo log until the current end of the log is reached
 @return whether the operation failed */
@@ -3482,10 +3476,9 @@ static bool xtrabackup_copy_logfile()
   ut_a(dst_log_file);
   ut_ad(recv_sys.is_initialised());
 
-#ifdef HAVE_INNODB_MMAP
   if (log_sys.is_mmap())
     return xtrabackup_copy_mmap_logfile();
-#endif
+
   const size_t sequence_offset{log_sys.is_encrypted() ? 8U + 5U : 5U};
   const size_t block_size_1{log_sys.write_size - 1};
 

--- a/mysql-test/suite/mariabackup/innodb_redo_log_overwrite.combinations
+++ b/mysql-test/suite/mariabackup/innodb_redo_log_overwrite.combinations
@@ -1,0 +1,4 @@
+[pread]
+--innodb-log-file-mmap=OFF
+[mmap]
+--innodb-log-file-mmap=ON

--- a/mysql-test/suite/sys_vars/r/sysvars_innodb.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_innodb.result
@@ -4,7 +4,6 @@ variable_name not in (
 'innodb_numa_interleave',           # only available WITH_NUMA
 'innodb_evict_tables_on_commit_debug', # one may want to override this
 'innodb_use_native_aio',            # default value depends on OS
-'innodb_log_file_mmap',             # only available on 64-bit
 'innodb_log_file_buffering',        # only available on Linux and Windows
 'innodb_buffer_pool_load_pages_abort')            # debug build only, and is only for testing
 order by variable_name;
@@ -1027,6 +1026,18 @@ NUMERIC_MAX_VALUE	NULL
 NUMERIC_BLOCK_SIZE	NULL
 ENUM_VALUE_LIST	OFF,ON
 READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	OPTIONAL
+VARIABLE_NAME	INNODB_LOG_FILE_MMAP
+SESSION_VALUE	NULL
+DEFAULT_VALUE	ON
+VARIABLE_SCOPE	GLOBAL
+VARIABLE_TYPE	BOOLEAN
+VARIABLE_COMMENT	Whether ib_logfile0 resides in persistent memory (when supported) or should initially be memory-mapped
+NUMERIC_MIN_VALUE	NULL
+NUMERIC_MAX_VALUE	NULL
+NUMERIC_BLOCK_SIZE	NULL
+ENUM_VALUE_LIST	OFF,ON
+READ_ONLY	YES
 COMMAND_LINE_ARGUMENT	OPTIONAL
 VARIABLE_NAME	INNODB_LOG_FILE_SIZE
 SESSION_VALUE	NULL

--- a/mysql-test/suite/sys_vars/t/sysvars_innodb.test
+++ b/mysql-test/suite/sys_vars/t/sysvars_innodb.test
@@ -11,7 +11,6 @@ select VARIABLE_NAME, SESSION_VALUE, DEFAULT_VALUE, VARIABLE_SCOPE, VARIABLE_TYP
     'innodb_numa_interleave',           # only available WITH_NUMA
     'innodb_evict_tables_on_commit_debug', # one may want to override this
     'innodb_use_native_aio',            # default value depends on OS
-    'innodb_log_file_mmap',             # only available on 64-bit
     'innodb_log_file_buffering',        # only available on Linux and Windows
     'innodb_buffer_pool_load_pages_abort')            # debug build only, and is only for testing
   order by variable_name;

--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -49,7 +49,7 @@ IF(UNIX)
       LINK_LIBRARIES(numa)
     ENDIF()
     IF(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      IF(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch|AARCH|p(ower)?pc|x86_|amd)64")
+      IF(CMAKE_SYSTEM_PROCESSOR MATCHES "(aarch|AARCH|p(ower)?pc|x86_|amd|loongarch|riscv)64")
         OPTION(WITH_INNODB_PMEM "Support memory-mapped InnoDB redo log" ON)
       ELSE() # Disable by default on ISA that are not covered by our CI
         OPTION(WITH_INNODB_PMEM "Support memory-mapped InnoDB redo log" OFF)

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -19475,18 +19475,14 @@ static MYSQL_SYSVAR_UINT(log_buffer_size, log_sys.buf_size,
   "Redo log buffer size in bytes.",
   NULL, NULL, 16U << 20, 2U << 20, log_sys.buf_size_max, 4096);
 
-#ifdef HAVE_INNODB_MMAP
   static constexpr const char *innodb_log_file_mmap_description=
     "Whether ib_logfile0"
-# ifdef HAVE_PMEM
-    " resides in persistent memory or"
-# endif
+    " resides in persistent memory (when supported) or"
     " should initially be memory-mapped";
 static MYSQL_SYSVAR_BOOL(log_file_mmap, log_sys.log_mmap,
   PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
   innodb_log_file_mmap_description,
   nullptr, nullptr, log_sys.log_mmap_default);
-#endif
 
 #if defined __linux__ || defined _WIN32
 static MYSQL_SYSVAR_BOOL(log_file_buffering, log_sys.log_buffered,
@@ -19982,9 +19978,7 @@ static struct st_mysql_sys_var* innobase_system_variables[]= {
   MYSQL_SYSVAR(deadlock_report),
   MYSQL_SYSVAR(page_size),
   MYSQL_SYSVAR(log_buffer_size),
-#ifdef HAVE_INNODB_MMAP
   MYSQL_SYSVAR(log_file_mmap),
-#endif
 #if defined __linux__ || defined _WIN32
   MYSQL_SYSVAR(log_file_buffering),
 #endif

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -282,7 +282,6 @@ public:
   uint write_size;
   /** format of the redo log: e.g., FORMAT_10_8 */
   uint32_t format;
-#ifdef HAVE_INNODB_MMAP
   /** whether the memory-mapped interface is enabled for the log */
   my_bool log_mmap;
   /** the default value of log_mmap */
@@ -294,7 +293,6 @@ public:
 # else /* an unnecessary read-ahead of a large ib_logfile0 is a risk */
 # endif
     false;
-#endif
 #if defined __linux__ || defined _WIN32
   /** whether file system caching is enabled for the log */
   my_bool log_buffered;
@@ -347,11 +345,7 @@ public:
   void set_buf_free(size_t f) noexcept
   { ut_ad(f < buf_free_LOCK); buf_free.store(f, std::memory_order_relaxed); }
 
-#ifdef HAVE_INNODB_MMAP
   bool is_mmap() const noexcept { return !flush_buf; }
-#else
-  static constexpr bool is_mmap() { return false; }
-#endif
 
   /** @return whether a handle to the log is open;
   is_mmap() && !is_opened() holds for PMEM */
@@ -412,14 +406,9 @@ public:
   @return whether the memory allocation succeeded */
   bool attach(log_file_t file, os_offset_t size);
 
-#ifdef HAVE_INNODB_MMAP
   /** Disable memory-mapped access (update log_mmap) */
   void clear_mmap();
   void close_file(bool really_close= true);
-#else
-  static void clear_mmap() {}
-  void close_file();
-#endif
 #if defined __linux__ || defined _WIN32
   /** Try to enable or disable file system caching (update log_buffered) */
   void set_buffered(bool buffered);

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -430,12 +430,7 @@ public:
   @tparam storing   whether to store the records
   @param  if_exists storing=YES: whether to check if the tablespace exists */
   template<store storing>
-  static parse_mtr_result parse_mmap(bool if_exists) noexcept
-#ifdef HAVE_INNODB_MMAP
-    ;
-#else
-  { return parse_mtr<storing>(if_exists); }
-#endif
+  static parse_mtr_result parse_mmap(bool if_exists) noexcept;
 
   /** Erase log records for a page. */
   void erase(map::iterator p);

--- a/storage/innobase/include/univ.i
+++ b/storage/innobase/include/univ.i
@@ -169,9 +169,6 @@ using the call command. */
 #define UNIV_INLINE static inline
 
 #define UNIV_WORD_SIZE		SIZEOF_SIZE_T
-#if SIZEOF_SIZE_T == 8
-# define HAVE_INNODB_MMAP
-#endif
 
 /** The following alignment is used in memory allocations in memory heap
 management to ensure correct alignment for doubles etc. */

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -2285,7 +2285,6 @@ struct recv_buf
   }
 };
 
-#ifdef HAVE_INNODB_MMAP
 /** Ring buffer wrapper for log_sys.buf[]; recv_sys.len == log_sys.file_size */
 struct recv_ring : public recv_buf
 {
@@ -2417,7 +2416,6 @@ struct recv_ring : public recv_buf
     return log_decrypt_buf(iv, tmp + s, b, static_cast<uint>(len));
   }
 };
-#endif
 
 template<typename source>
 void recv_sys_t::rewind(source &l, source &begin) noexcept
@@ -3152,7 +3150,6 @@ template
 recv_sys_t::parse_mtr_result
 recv_sys_t::parse_mtr<recv_sys_t::store::BACKUP>(bool) noexcept;
 
-#ifdef HAVE_INNODB_MMAP
 template<recv_sys_t::store storing>
 recv_sys_t::parse_mtr_result recv_sys_t::parse_mmap(bool if_exists) noexcept
 {
@@ -3173,7 +3170,6 @@ recv_sys_t::parse_mtr_result recv_sys_t::parse_mmap(bool if_exists) noexcept
 template
 recv_sys_t::parse_mtr_result
 recv_sys_t::parse_mmap<recv_sys_t::store::BACKUP>(bool) noexcept;
-#endif
 
 /** Apply the hashed log records to the page, if the page lsn is less than the
 lsn of a log record.

--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -1212,7 +1212,7 @@ inline void log_t::resize_write(lsn_t lsn, const byte *end, size_t len,
     end-= len;
     size_t s;
 
-#ifdef HAVE_INNODB_MMAP
+#ifdef HAVE_PMEM
     if (!resize_flush_buf)
     {
       ut_ad(is_mmap());

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1879,15 +1879,11 @@ skip_monitors:
 	if (srv_print_verbose_log) {
 		sql_print_information("InnoDB: "
 				      "log sequence number " LSN_PF
-#ifdef HAVE_INNODB_MMAP
 				      "%s"
-#endif
 				      "; transaction id " TRX_ID_FMT,
 				      recv_sys.lsn,
-#ifdef HAVE_INNODB_MMAP
 				      log_sys.is_mmap()
 				      ? " (memory-mapped)" : "",
-#endif
 				      trx_sys.get_max_trx_id());
 	}
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35785*
## Description
`HAVE_INNODB_MMAP`: Remove, and unconditionally enable this code.

`log_mmap()`: On 32-bit systems, ensure that the size fits in 32 bits.

`log_t::resize_start()`, `log_t::resize_abort()`: Only handle memory-mapping if `HAVE_PMEM` is defined. The generic memory-mapped interface is only for reading the log in recovery. Writable memory mappings are only for persistent memory, that is, Linux file systems with `mount -o dax`.
## Release Notes
The configuration parameter `innodb_log_file_mmap` will be available in all target platforms.
## How can this PR be tested?
This is covered by the regression test suite. The test `sys_vars.sysvars_innodb` will ensure that the parameter is present.

I tested this by running the regression test suite on IA-32 and AMD64 in my local development environment.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.