### PR TITLE
MDEV-35699 Multi-batch recovery occasionally fails

### DIFF
--- a/mysql-test/suite/encryption/r/recovery_memory.result
+++ b/mysql-test/suite/encryption/r/recovery_memory.result
@@ -1,0 +1,15 @@
+CREATE TABLE t1(f1 text, index idx(f1(20))) ENGINE INNODB;
+set global innodb_fast_shutdown=0;
+# restart: --debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0
+set global debug_dbug="+d,ib_log_checkpoint_avoid_hard";
+INSERT INTO t1 SELECT repeat('a', 8000) FROM seq_1_to_1280;
+DELETE FROM t1;
+SET GLOBAL innodb_max_purge_lag_wait=0;
+INSERT INTO t1 VALUES('a');
+# XTRABACKUP PREPARE
+# restart
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
+ALTER TABLE t1 FORCE;
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/t/recovery_memory.opt
+++ b/mysql-test/suite/encryption/t/recovery_memory.opt
@@ -1,0 +1,8 @@
+--innodb_doublewrite=0
+--innodb_log_file_size=24m
+--innodb_immediate_scrub_data_uncompressed=1
+--plugin-load-add=$FILE_KEY_MANAGEMENT_SO
+--loose-file-key-management
+--loose-file-key-management-filename=$MYSQL_TEST_DIR/std_data/logkey.txt
+--file-key-management-encryption-algorithm=aes_cbc
+--innodb-encrypt-log=1

--- a/mysql-test/suite/encryption/t/recovery_memory.test
+++ b/mysql-test/suite/encryption/t/recovery_memory.test
@@ -1,0 +1,45 @@
+--source include/have_debug.inc
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source filekeys_plugin.inc
+
+let $basedir=$MYSQLTEST_VARDIR/tmp/backup;
+let MYSQLD_DATADIR=`select @@datadir`;
+
+CREATE TABLE t1(f1 text, index idx(f1(20))) ENGINE INNODB;
+
+# No checkpoint happens during this restart
+
+let $shutdown_timeout=;
+set global innodb_fast_shutdown=0;
+let $restart_parameters=--debug_dbug=+d,ib_log_checkpoint_avoid_hard --innodb_flush_sync=0;
+--source include/restart_mysqld.inc
+set global debug_dbug="+d,ib_log_checkpoint_avoid_hard";
+
+--disable_result_log
+exec $XTRABACKUP --defaults-file=$MYSQLTEST_VARDIR/my.cnf  --backup --target-dir=$basedir;
+--enable_result_log
+
+INSERT INTO t1 SELECT repeat('a', 8000) FROM seq_1_to_1280;
+DELETE FROM t1;
+SET GLOBAL innodb_max_purge_lag_wait=0;
+INSERT INTO t1 VALUES('a');
+
+--echo # XTRABACKUP PREPARE
+exec $XTRABACKUP --prepare --target-dir=$basedir;
+
+let $shutdown_timeout=0;
+--source include/shutdown_mysqld.inc
+
+# Since there is no checkpoint during previous run, we can
+# Copy the datafile from t1.ibd and start the server
+
+remove_file $MYSQLD_DATADIR/test/t1.ibd;
+copy_file $basedir/test/t1.ibd $MYSQLD_DATADIR/test/t1.ibd;
+--enable_result_log
+let $restart_parameters=;
+--source include/start_mysqld.inc
+
+SELECT COUNT(*) FROM t1;
+ALTER TABLE t1 FORCE;
+DROP TABLE t1;

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -2787,7 +2787,6 @@ restart:
           erase(r);
           continue;
         }
-      copy_if_needed:
         cl= l.copy_if_needed(iv, decrypt_buf, recs, rlen);
         break;
       case EXTENDED:
@@ -2839,8 +2838,14 @@ restart:
         last_offset= FIL_PAGE_TYPE;
         break;
       case OPTION:
-        if (storing == YES && rlen == 5 && *l == OPT_PAGE_CHECKSUM)
-          goto copy_if_needed;
+        /* OPTION records can be safely ignored in recovery */
+        if (storing == YES &&
+            rlen == 5/* OPT_PAGE_CHECKSUM and CRC-32C; see page_checksum() */)
+        {
+          cl= l.copy_if_needed(iv, decrypt_buf, recs, rlen);
+          if (*cl == OPT_PAGE_CHECKSUM)
+            break;
+        }
         /* fall through */
       case RESERVED:
         continue;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35699*
## Description
This fixes a regression that had been introduced in #3507. In a multi-batch crash recovery, we would fail to invoke `fil_space_set_recv_size_and_flags()` while parsing the remaining log, before starting the first recovery batch.

`recv_sys_t::parse<storing=NO>()`: Do invoke `fil_space_set_recv_size_and_flags()` and do parse enough of page 0 to facilitate that.
## Release Notes
InnoDB crash recovery could fail to recover the correct size of a file when the `innodb_buffer_pool_size` is too small to process the `ib_logfile0` in a single batch.
## How can this PR be tested?
```sh
./mtr encryption.recovery_memory
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.