### PR TITLE
MDEV-35647 Possible hang during CREATE TABLE…SELECT error handling

### DIFF
--- a/mysql-test/suite/innodb/r/create_select.result
+++ b/mysql-test/suite/innodb/r/create_select.result
@@ -3,7 +3,6 @@ connection default;
 CREATE TABLE t1 ENGINE=InnoDB SELECT * FROM seq_1_to_100000000;
 connection con1;
 KILL QUERY @id;
-disconnect con1;
 connection default;
 ERROR 70100: Query execution was interrupted
 CREATE TABLE t1 (a SERIAL) ENGINE=InnoDB;
@@ -18,3 +17,26 @@ execute stmt;
 execute stmt;
 drop table t;
 # End of 10.5 tests
+#
+# MDEV-35647 Possible hang during CREATE TABLE…SELECT error handling
+#
+call mtr.add_suppression("InnoDB: DROP TABLE `test`\\.`t4`: Record changed");
+SET @save_debug= @@GLOBAL.innodb_evict_tables_on_commit_debug;
+SET GLOBAL innodb_evict_tables_on_commit_debug=on;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+SET GLOBAL innodb_evict_tables_on_commit_debug=@save_debug;
+connection con1;
+CREATE TABLE t2 (b BLOB) ENGINE=InnoDB;
+INSERT INTO t2 VALUES (1),('2025-01-21 00:00:00');
+SET STATEMENT innodb_snapshot_isolation=ON FOR
+CREATE TABLE t3 ENGINE=InnoDB AS SELECT * FROM t1;
+connection default;
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SET STATEMENT innodb_snapshot_isolation=ON FOR
+CREATE TABLE t4 (b BLOB CHECK (b)) ENGINE=InnoDB AS SELECT b FROM t2;
+ERROR 22007: Truncated incorrect DOUBLE value: '2025-01-21 00:00:00'
+connection con1;
+disconnect con1;
+connection default;
+DROP TABLE t3,t2,t1;
+# End of 10.6 tests

--- a/mysql-test/suite/innodb/t/create_select.test
+++ b/mysql-test/suite/innodb/t/create_select.test
@@ -1,6 +1,7 @@
 --source include/have_innodb.inc
 --source include/have_sequence.inc
 --source include/count_sessions.inc
+--source include/maybe_debug.inc
 
 let $ID= `SELECT @id := CONNECTION_ID()`;
 
@@ -17,7 +18,6 @@ let $wait_condition=
   and info = 'CREATE TABLE t1 ENGINE=InnoDB SELECT * FROM seq_1_to_100000000';
 --source include/wait_condition.inc
 KILL QUERY @id;
-disconnect con1;
 
 connection default;
 --error ER_QUERY_INTERRUPTED
@@ -25,7 +25,6 @@ reap;
 
 CREATE TABLE t1 (a SERIAL) ENGINE=InnoDB;
 DROP TABLE t1;
---source include/wait_until_count_sessions.inc
 
 --echo # End of 10.2 tests
 
@@ -39,3 +38,38 @@ execute stmt;
 drop table t;
 
 --echo # End of 10.5 tests
+
+--echo #
+--echo # MDEV-35647 Possible hang during CREATE TABLE…SELECT error handling
+--echo #
+call mtr.add_suppression("InnoDB: DROP TABLE `test`\\.`t4`: Record changed");
+
+--error 0,ER_UNKNOWN_SYSTEM_VARIABLE
+SET @save_debug= @@GLOBAL.innodb_evict_tables_on_commit_debug;
+--error 0,ER_UNKNOWN_SYSTEM_VARIABLE
+SET GLOBAL innodb_evict_tables_on_commit_debug=on;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+--error 0,ER_UNKNOWN_SYSTEM_VARIABLE
+SET GLOBAL innodb_evict_tables_on_commit_debug=@save_debug;
+
+connection con1;
+CREATE TABLE t2 (b BLOB) ENGINE=InnoDB;
+INSERT INTO t2 VALUES (1),('2025-01-21 00:00:00');
+--send
+SET STATEMENT innodb_snapshot_isolation=ON FOR
+CREATE TABLE t3 ENGINE=InnoDB AS SELECT * FROM t1;
+
+connection default;
+SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+--error ER_TRUNCATED_WRONG_VALUE
+SET STATEMENT innodb_snapshot_isolation=ON FOR
+CREATE TABLE t4 (b BLOB CHECK (b)) ENGINE=InnoDB AS SELECT b FROM t2;
+connection con1;
+reap;
+disconnect con1;
+connection default;
+DROP TABLE t3,t2,t1;
+
+--source include/wait_until_count_sessions.inc
+
+--echo # End of 10.6 tests

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -13798,7 +13798,6 @@ int ha_innobase::delete_table(const char *name)
   if (err != DB_SUCCESS)
   {
 err_exit:
-    trx->dict_operation_lock_mode= false;
     trx->rollback();
     switch (err) {
     case DB_CANNOT_DROP_CONSTRAINT:
@@ -13820,7 +13819,7 @@ err_exit:
       dict_table_close(table_stats, true, thd, mdl_table);
     if (index_stats)
       dict_table_close(index_stats, true, thd, mdl_index);
-    dict_sys.unlock();
+    row_mysql_unlock_data_dictionary(trx);
     if (trx != parent_trx)
       trx->free();
     DBUG_RETURN(convert_error_code_to_mysql(err, 0, NULL));


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35647*
## Description
`ha_innobase::delete_table()`: Clear `trx->dict_operation_lock_mode` after, not before `invoking trx->rollback()`, so that `row_undo_mod_parse_undo_rec()` will be invoked with `dict_locked=true` and `dict_sys_t::freeze()` will not be invoked for loading a table definition. Inside `dict_sys_t::freeze()`, an assertion `!have_any()` would fail when the current thread is already holding the latch.

This fixes up c5fd9aa562fb15e8d6ededceccbec0c9792a3243 (MDEV-25919).
## Release Notes
InnoDB could hang if `CREATE TABLE…SELECT` would fail, for example, due to a lock wait timeout.
## How can this PR be tested?
```sh
./mtr innodb.create_select
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.