### PR TITLE
MDEV-34218: Mariadb Galera cluster fails when replicating from Mysql 5.7 on use of DDL

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2159,11 +2159,18 @@ int wsrep_to_buf_helper(
       domain_id= wsrep_gtid_server.domain_id;
       server_id= wsrep_gtid_server.server_id;
     }
-    Gtid_log_event gtid_event(thd, seqno, domain_id, true,
-                              LOG_EVENT_SUPPRESS_USE_F, true, 0);
-    gtid_event.server_id= server_id;
-    if (!gtid_event.is_valid()) ret= 0;
-    ret= writer.write(&gtid_event);
+    /*
+    * Ignore if both thd->variables.gtid_seq_no and
+    * thd->variables.wsrep_gtid_seq_no are not set.
+    */
+    if (seqno)
+    {
+      Gtid_log_event gtid_event(thd, seqno, domain_id, true,
+                                LOG_EVENT_SUPPRESS_USE_F, true, 0);
+      gtid_event.server_id= server_id;
+      if (!gtid_event.is_valid()) ret= 0;
+      ret= writer.write(&gtid_event);
+    }
   }
   /*
     It's local DDL so in case of possible gtid seqno (SET gtid_seq_no=X)


### PR DESCRIPTION
MDEV-34218: Mariadb Galera cluster fails when replicating from Mysql 5.7 on use of DDL

Issue:
Mariadb Galera cluster fails to replicate from Mysql 5.7 when configured with MASTER_USE_GTID=no option for CHANGE MASTER.

HOST: mysql, mysql 5.7.44 binlog_format=ROW
HOST: m1, mariadb 10.6 GALERA NODE replicating from HOST mysql, Using_Gtid: No (log file and position)
HOST: m2 mariadb 10.6 GALERA NODE
HOST: m3 mariadb 10.6 GALERA NODE

Error on m1:
2024-05-22 16:11:07 1 [ERROR] WSREP: Vote 0 (success) on 78cebda7-1876-11ef-896b-8a58fca50d36:2565 is inconsistent with group. Leaving cluster.

Error on m2 and m3:
2024-05-22 16:11:06 2 [ERROR] Error in Log_event::read_log_event(): 'Found invalid event in binary log', data_len: 42, event_type: -94 2024-05-22 16:11:06 2 [ERROR] WSREP: applier could not read binlog event, seqno: 2565, len: 482

It fails in Gtid_log_event::is_valid() check on secondary node when sequence number sent from primary is 0. On primary for applier or slave thread sequence number is set to 0, when both thd->variables.gtid_seq_no and thd->variables.wsrep_gtid_seq_no have value 0.

Solution:
Skip adding Gtid Event on primary for applier or slave thread when both thd->variables.gtid_seq_no and thd->variables.wsrep_gtid_seq_no have value 0.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-34218*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
