### PR TITLE
MDEV-35765 ST_OVERLAPS wrong result when dim(geom1) <> dim(geom2)

### DIFF
--- a/mysql-test/main/mdev-35765.result
+++ b/mysql-test/main/mdev-35765.result
@@ -1,0 +1,20 @@
+#
+# MDEV-35765 ST_OVERLAPS returns true despite dim(originalInput1) <> dim(originalInput2)
+#
+DROP table if EXISTS t1;
+Warnings:
+Note	1051	Unknown table 'test.t1'
+DROP table if EXISTS t2;
+Warnings:
+Note	1051	Unknown table 'test.t2'
+CREATE TABLE t1(geom geometry NOT NULL);
+CREATE TABLE t2(geom geometry NOT NULL);
+INSERT INTO t1 (geom) VALUES(ST_GeomFromText('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'));
+INSERT INTO t2 (geom) VALUES(ST_GeomFromText('LINESTRING (1 1, 1 2, 2 2, 2 1, 1 1)'));
+SELECT ST_OVERLAPS(t1.geom, t2.geom) FROM t1, t2;
+ST_OVERLAPS(t1.geom, t2.geom)
+0
+DROP TABLE t1, t2;
+#
+# End of 10.6 tests
+#

--- a/mysql-test/main/mdev-35765.test
+++ b/mysql-test/main/mdev-35765.test
@@ -1,0 +1,14 @@
+--echo #
+--echo # MDEV-35765 ST_OVERLAPS returns true despite dim(originalInput1) <> dim(originalInput2)
+--echo #
+DROP table if EXISTS t1;
+DROP table if EXISTS t2;
+CREATE TABLE t1(geom geometry NOT NULL);
+CREATE TABLE t2(geom geometry NOT NULL);
+INSERT INTO t1 (geom) VALUES(ST_GeomFromText('POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))'));
+INSERT INTO t2 (geom) VALUES(ST_GeomFromText('LINESTRING (1 1, 1 2, 2 2, 2 1, 1 1)'));
+SELECT ST_OVERLAPS(t1.geom, t2.geom) FROM t1, t2;
+DROP TABLE t1, t2;
+--echo #
+--echo # End of 10.6 tests
+--echo #

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -1459,6 +1459,16 @@ bool Item_func_spatial_precise_rel::val_bool()
       null_value= g1.store_shapes(&trn) || g2.store_shapes(&trn);
       break;
     case SP_OVERLAPS_FUNC:
+    {
+      // Both geometries must have the same number of dimensions.
+      uint32 g1_dim, g2_dim;
+      const char *dummy;
+      g1.geom->dimension(&g1_dim, &dummy);
+      g2.geom->dimension(&g2_dim, &dummy);
+      if (g1_dim != g2_dim)
+        DBUG_RETURN(0);
+      // Intentionally fall-through to SP_CROSSES_FUNC case.
+    }
     case SP_CROSSES_FUNC:
       func.add_operation(Gcalc_function::op_intersection, 2);
       if (func.reserve_op_buffer(3))


### PR DESCRIPTION
Validates that the two geometries passed to ST_OVERLAPS have the same number of dimensions.
