### PR TITLE
MDEV-35805 Update main.lowercase_table4 for new default collation

### DIFF
--- a/mysql-test/main/lowercase_table4.result
+++ b/mysql-test/main/lowercase_table4.result
@@ -30,7 +30,7 @@ Create Table	CREATE TABLE `Table2` (
   PRIMARY KEY (`c1`),
   KEY `fk1` (`c2`),
   CONSTRAINT `fk1` FOREIGN KEY (`c2`) REFERENCES `Table1` (`c1`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 SELECT * FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA='test';
 CONSTRAINT_CATALOG	def
 CONSTRAINT_SCHEMA	test
@@ -75,7 +75,7 @@ Create Table	CREATE TABLE `Product_Order` (
   KEY `Customer_Id` (`Customer_Id`),
   CONSTRAINT `product_order_ibfk_1` FOREIGN KEY (`Product_Category`, `Product_Id`) REFERENCES `Product` (`Category`, `Id`) ON UPDATE CASCADE,
   CONSTRAINT `product_order_ibfk_2` FOREIGN KEY (`Customer_Id`) REFERENCES `Customer` (`Id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 SHOW CREATE TABLE Product;
 Table	Product
 Create Table	CREATE TABLE `Product` (
@@ -83,13 +83,13 @@ Create Table	CREATE TABLE `Product` (
   `Id` int(11) NOT NULL,
   `Price` decimal(10,0) DEFAULT NULL,
   PRIMARY KEY (`Category`,`Id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 SHOW CREATE TABLE Customer;
 Table	Customer
 Create Table	CREATE TABLE `Customer` (
   `Id` int(11) NOT NULL,
   PRIMARY KEY (`Id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 SELECT * FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS WHERE CONSTRAINT_SCHEMA='test';
 CONSTRAINT_CATALOG	def
 CONSTRAINT_SCHEMA	test


### PR DESCRIPTION
Update main.lowercase_table4 for new default collation at 11.6 as described in https://mariadb.com/kb/en/setting-character-sets-and-collations/