### PR TITLE
MDEV-35802 Race condition in log_t::persist()

### DIFF
--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -462,9 +462,8 @@ public:
 
 #ifdef HAVE_PMEM
   /** Persist the log.
-  @param lsn            desired new value of flushed_to_disk_lsn
-  @param holding_latch  whether the caller is holding exclusive latch */
-  void persist(lsn_t lsn, bool holding_latch) noexcept;
+  @param lsn            desired new value of flushed_to_disk_lsn */
+  void persist(lsn_t lsn) noexcept;
 #endif
 
   bool check_for_checkpoint() const


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35802*
## Description
`log_t::persist()`: Remove the parameter `holding_latch`, and assert `latch_holding_any()`. We used to avoid acquiring a latch when log resizing was not in progress. That allowed a race condition to occur where `log_t::write_checkpoint()` has just completed log resizing. In that case, we could wrongly invoke `pmem_persist()` on the old `log_sys.buf` instead of the new one, which was shortly before known as `log_sys.resize_buf`.

`log_write_persist()`: A non-inline wrapper function that will invoke `log_sys.persist()` while holding a shared `log_sys.latch`.
## Release Notes
This is a rare race condition, probably not worth mentioning, because the use of PMEM is very rare.
## How can this PR be tested?
This code is being covered by the following test:
```sh
./mtr innodb.log_file_size_online
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.