### PR TITLE
MDEV-35806: Error in read_log_event() corrupts relay log writer, cras…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_from_mysql80.result
+++ b/mysql-test/suite/rpl/r/rpl_from_mysql80.result
@@ -11,8 +11,6 @@ START SLAVE IO_THREAD;
 include/wait_for_slave_io_to_start.inc
 START SLAVE UNTIL Master_log_file='master-bin.000001', Master_log_pos= 1178;
 SELECT MASTER_POS_WAIT('master-bin.000001', 1178, 60);
-MASTER_POS_WAIT('master-bin.000001', 1178, 60)
-NULL
 SELECT * FROM t1 ORDER BY a;
 a	b	c
 1	0	

--- a/mysql-test/suite/rpl/t/rpl_from_mysql80.test
+++ b/mysql-test/suite/rpl/t/rpl_from_mysql80.test
@@ -81,7 +81,9 @@ START SLAVE IO_THREAD;
 # The position 1178 is the start of: INSERT INTO t1 VALUES (4, 0, 'skip');
 # After that comes unknown MySQL 8.0 events, which we test error for below.
 START SLAVE UNTIL Master_log_file='master-bin.000001', Master_log_pos= 1178;
+--disable_result_log
 SELECT MASTER_POS_WAIT('master-bin.000001', 1178, 60);
+--enable_result_log
 SELECT * FROM t1 ORDER BY a;
 
 --source include/wait_for_slave_sql_to_stop.inc

--- a/mysys/mf_iocache.c
+++ b/mysys/mf_iocache.c
@@ -1735,7 +1735,7 @@ int my_b_flush_io_cache(IO_CACHE *info, int need_append_buffer_lock)
       info->write_pos= info->write_buffer;
       ++info->disk_writes;
       UNLOCK_APPEND_BUFFER;
-      DBUG_RETURN(info->error);
+      DBUG_RETURN(0);
     }
   }
   UNLOCK_APPEND_BUFFER;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -11385,7 +11385,8 @@ int TC_LOG_BINLOG::recover(LOG_INFO *linfo, const char *last_log_name,
   binlog_checkpoint_found= false;
   for (round= 1;;)
   {
-    while ((ev= Log_event::read_log_event(round == 1 ? first_log : &log,
+    int error;
+    while ((ev= Log_event::read_log_event(round == 1 ? first_log : &log, &error,
                                           fdle, opt_master_verify_checksum))
            && ev->is_valid())
     {
@@ -11671,7 +11672,8 @@ MYSQL_BIN_LOG::do_binlog_recovery(const char *opt_name, bool do_xa_recovery)
     return 1;
   }
 
-  if ((ev= Log_event::read_log_event(&log, &fdle,
+  int read_error;
+  if ((ev= Log_event::read_log_event(&log, &read_error, &fdle,
                                      opt_master_verify_checksum)) &&
       ev->get_type_code() == FORMAT_DESCRIPTION_EVENT)
   {
@@ -11895,10 +11897,11 @@ get_gtid_list_event(IO_CACHE *cache, Gtid_list_log_event **out_gtid_list)
   Format_description_log_event *fdle;
   Log_event *ev;
   const char *errormsg = NULL;
+  int read_error;
 
   *out_gtid_list= NULL;
 
-  if (!(ev= Log_event::read_log_event(cache, &init_fdle,
+  if (!(ev= Log_event::read_log_event(cache, &read_error, &init_fdle,
                                       opt_master_verify_checksum)) ||
       ev->get_type_code() != FORMAT_DESCRIPTION_EVENT)
   {
@@ -11914,7 +11917,8 @@ get_gtid_list_event(IO_CACHE *cache, Gtid_list_log_event **out_gtid_list)
   {
     Log_event_type typ;
 
-    ev= Log_event::read_log_event(cache, fdle, opt_master_verify_checksum);
+    ev= Log_event::read_log_event(cache, &read_error, fdle,
+                                  opt_master_verify_checksum);
     if (!ev)
     {
       errormsg= "Could not read GTID list event while looking for GTID "

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1344,7 +1344,7 @@ public:
     we detect the event's type, then call the specific event's
     constructor and pass description_event as an argument.
   */
-  static Log_event* read_log_event(IO_CACHE* file,
+  static Log_event* read_log_event(IO_CACHE* file, int *out_error,
                                    const Format_description_log_event
                                    *description_event,
                                    my_bool crc_check,

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -5041,7 +5041,7 @@ int Execute_load_log_event::do_apply_event(rpl_group_info *rgi)
   char fname[FN_REFLEN+10];
   char *ext;
   int fd;
-  int error= 1;
+  int error= 1, read_error;
   IO_CACHE file;
   Load_log_event *lev= 0;
   Relay_log_info const *rli= rgi->rli;
@@ -5060,7 +5060,7 @@ int Execute_load_log_event::do_apply_event(rpl_group_info *rgi)
     goto err;
   }
   if (!(lev= (Load_log_event*)
-        Log_event::read_log_event(&file,
+        Log_event::read_log_event(&file, &read_error,
                                   rli->relay_log.description_event_for_exec,
                                   opt_slave_sql_verify_checksum)) ||
       lev->get_type_code() != NEW_LOAD_EVENT)

--- a/sql/rpl_parallel.cc
+++ b/sql/rpl_parallel.cc
@@ -1037,14 +1037,15 @@ do_retry:
     /* The loop is here so we can try again the next relay log file on EOF. */
     for (;;)
     {
+      int error;
       old_offset= cur_offset;
-      ev= Log_event::read_log_event(&rlog, description_event,
+      ev= Log_event::read_log_event(&rlog, &error, description_event,
                                     opt_slave_sql_verify_checksum);
       cur_offset= my_b_tell(&rlog);
 
       if (ev)
         break;
-      if (unlikely(rlog.error < 0))
+      if (unlikely(error))
       {
         errmsg= "slave SQL thread aborted because of I/O error";
         err= 1;

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -544,12 +544,13 @@ read_relay_log_description_event(IO_CACHE *cur_log, ulonglong start_pos,
     if (my_b_tell(cur_log) >= start_pos)
       break;
 
-    if (!(ev= Log_event::read_log_event(cur_log, fdev,
+    int read_error;
+    if (!(ev= Log_event::read_log_event(cur_log, &read_error, fdev,
                                         opt_slave_sql_verify_checksum)))
     {
-      DBUG_PRINT("info",("could not read event, cur_log->error=%d",
-                         cur_log->error));
-      if (cur_log->error) /* not EOF */
+      DBUG_PRINT("info",("could not read event, read_error=%d",
+                         read_error));
+      if (read_error) /* not EOF */
       {
         *errmsg= "I/O error reading event at position 4";
         delete fdev;

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -7845,7 +7845,8 @@ static Log_event* next_event(rpl_group_info *rgi, ulonglong *event_size)
       MYSQL_BIN_LOG::open() will write the buffered description event.
     */
     old_pos= rli->event_relay_log_pos;
-    if ((ev= Log_event::read_log_event(cur_log,
+    int error;
+    if ((ev= Log_event::read_log_event(cur_log, &error,
                                        rli->relay_log.description_event_for_exec,
                                        opt_slave_sql_verify_checksum)))
 
@@ -7862,8 +7863,8 @@ static Log_event* next_event(rpl_group_info *rgi, ulonglong *event_size)
       DBUG_RETURN(ev);
     }
     if (opt_reckless_slave)                     // For mysql-test
-      cur_log->error = 0;
-    if (unlikely(cur_log->error < 0))
+      error = 0;
+    if (unlikely(error))
     {
       errmsg = "slave SQL thread aborted because of I/O error";
       if (hot_log)

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -4188,7 +4188,8 @@ bool mysql_show_binlog_events(THD* thd)
     my_off_t scan_pos = BIN_LOG_HEADER_SIZE;
     while (scan_pos < pos)
     {
-      ev= Log_event::read_log_event(&log, description_event,
+      int error;
+      ev= Log_event::read_log_event(&log, &error, description_event,
                                     opt_master_verify_checksum);
       scan_pos = my_b_tell(&log);
       if (ev == NULL || !ev->is_valid())
@@ -4263,8 +4264,9 @@ bool mysql_show_binlog_events(THD* thd)
       writing about this in the server log would be confusing as it isn't
       related to server operational status.
     */
+    int error;
     for (event_count = 0;
-         (ev = Log_event::read_log_event(&log,
+         (ev = Log_event::read_log_event(&log, &error,
                                          description_event,
                                          (opt_master_verify_checksum ||
                                           verify_checksum_once), false)); )
@@ -4308,7 +4310,7 @@ bool mysql_show_binlog_events(THD* thd)
 	      break;
     }
 
-    if (unlikely(event_count < unit->lim.get_select_limit() && log.error))
+    if (unlikely(event_count < unit->lim.get_select_limit() && error))
     {
       errmsg = "Wrong offset or I/O error";
       mysql_mutex_unlock(log_lock);


### PR DESCRIPTION
MDEV-35806: Error in read_log_event() corrupts relay log writer, crashes server

In Log_event::read_log_event(), don't use IO_CACHE::error of the relay log's
IO_CACHE to signal an error back to the caller. When reading the active
relay log, this flag is also being used by the IO thread, and setting it can
randomly cause the IO thread to wrongly detect IO error on writing and
permanently disable the relay log.

This was seen sporadically in test case rpl.rpl_from_mysql80. The read
error set by the SQL thread in the IO_CACHE would be interpreted as a
write error by the IO thread, which would cause it to throw a fatal
error and close the relay log. And this would later cause CHANGE
MASTER to try to purge a closed relay log, resulting in nullptr crash.

Also fix another sporadic failure in rpl.rpl_from_mysql80 where the outout
of MASTER_POS_WAIT() depended on timing of SQL and IO thread.
