### PR TITLE
MDEV-35818: Fix `replace_binlog_file` info message

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -13257,10 +13257,11 @@ bool Binlog_commit_by_rotate::replace_binlog_file()
   DBUG_EXECUTE_IF("simulate_required_size_too_big", required_size= 10000;);
   if (required_size > m_cache_data->file_reserved_bytes())
   {
-    sql_print_information("Could not rename binlog cache to binlog(as "
+    sql_print_information("Could not rename binlog cache to binlog (as "
                           "requested by --binlog-commit-by-rotate-threshold). "
-                          "Required %llu bytes but only %llu bytes reserved.",
-                          required_size, m_cache_data->file_reserved_bytes());
+                          "Required %zu bytes but only %lu bytes reserved.",
+                          required_size, static_cast<unsigned long>(
+                            m_cache_data->file_reserved_bytes()));
     return false;
   }
 


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-35818 my_snprintf fix for 11.7+](https://jira.mariadb.org/browse/MDEV-35818)*

## Description
`ATTRIBUITE_FORMAT` from #3360 uncovers issues on `my_snprintf` uses.
This commit fixes the one in `Binlog_commit_by_rotate::` `replace_binlog_file()` about “required size too big”.

All I found is that it’s not present in 11.4 (after I prepared previous batches for all maintained branches), for GitHub blame can’t process a file with over 10K lines.

## Release Notes
*But 11.7 wasn’t Generally Available yet?*

## How can this PR be tested?
I suppose we can trigger this issue by running the `simulate_required_size_too_big` test (wherever it is) in __32-bit Linux__.

## PR quality check
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.