### PR TITLE
MDEV-35687 Various UBSAN function-type-mismatch debug_sync and myisam

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -44,7 +44,8 @@ class THD;
 class Item;
 #define MYSQL_THD THD*
 #else
-#define MYSQL_THD void*
+struct THD;
+typedef struct THD* MYSQL_THD;
 #endif
 
 typedef char my_bool;

--- a/include/mysql/service_debug_sync.h
+++ b/include/mysql/service_debug_sync.h
@@ -351,7 +351,11 @@ extern void (*debug_sync_C_callback_ptr)(MYSQL_THD, const char *, size_t);
 #endif /* defined(ENABLED_DEBUG_SYNC) */
 
 /* compatibility macro */
+#ifdef __cplusplus
+#define DEBUG_SYNC_C(name) DEBUG_SYNC(nullptr, name)
+#else
 #define DEBUG_SYNC_C(name) DEBUG_SYNC(NULL, name)
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35687*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

storage/maria/ma_open.c:352:7: runtime error: call to function debug_sync(THD*, char const*, unsigned long) through pointer to incorrect function type 'void (*)(void *, const char *, unsigned long)'

The THD argument is a void *. Because of the way myisam is .c files the function prototype is mismatched.

As Marko pointed out the MYSQL_THD is declared as void * in C.

Thanks Jimmy Hú for noting that struct THD is the equalivalant in C to the class THD. The C NULL was also different to the C++ nullptr.

Corrected the definitions of MYSQL_THD and DEBUG_SYNC_C to be C and C++ compatible.

## Release Notes

nothing to be said, internal fix.

## How can this PR be tested?

mtr + debug + ubsan - will not start a basic bootstrap without this fix.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.