### PR TITLE
MDEV-34703  LOAD DATA INFILE using Innodb bulk load aborts

### DIFF
--- a/mysql-test/suite/innodb/r/bulk_load.result
+++ b/mysql-test/suite/innodb/r/bulk_load.result
@@ -1,0 +1,50 @@
+CREATE TABLE t1(f1 INT NOT NULL,f2 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, seq from seq_1_to_131072;
+INSERT INTO t1 VALUES(131073, 131073), (131074, 131073);
+SELECT * INTO OUTFILE "VARDIR/tmp/t1.outfile" FROM t1;
+# successful load statement using bulk insert
+CREATE TABLE t2(f1 INT NOT NULL PRIMARY KEY,
+f2 INT NOT NULL)ENGINE=InnoDB;
+SET unique_checks=0, foreign_key_checks=0;
+LOAD DATA INFILE 'VARDIR/tmp/t1.outfile' INTO TABLE t2;
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+131074
+CHECK TABLE t2 EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t2	check	status	OK
+DROP TABLE t2;
+CREATE TABLE t2(f1 INT NOT NULL, PRIMARY KEY(f1 DESC),
+f2 INT NOT NULL)ENGINE=InnoDB;
+LOAD DATA INFILE 'VARDIR/tmp/t1.outfile' INTO TABLE t2;
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+131074
+CHECK TABLE t2 EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t2	check	status	OK
+DROP TABLE t2;
+# load statement using bulk insert fails during secondary index
+CREATE TABLE t2(f1 INT NOT NULL PRIMARY KEY,
+f2 INT NOT NULL UNIQUE KEY)ENGINE=InnoDB;
+LOAD DATA INFILE 'VARDIR/tmp/t1.outfile' INTO TABLE t2;
+ERROR HY000: Got error 1 "Operation not permitted" during COMMIT
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+0
+CHECK TABLE t2 EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t2	check	status	OK
+DROP TABLE t2;
+# load statement using bulk insert fails during primary index
+CREATE TABLE t2(f1 INT NOT NULL,
+f2 INT NOT NULL PRIMARY KEY)ENGINE=InnoDB;
+LOAD DATA INFILE 'VARDIR/tmp/t1.outfile' INTO TABLE t2;
+ERROR 23000: Duplicate entry '131073' for key 'PRIMARY'
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+0
+CHECK TABLE t2 EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t2	check	status	OK
+DROP TABLE t2, t1;

--- a/mysql-test/suite/innodb/t/bulk_load.opt
+++ b/mysql-test/suite/innodb/t/bulk_load.opt
@@ -1,0 +1,1 @@
+--innodb_sort_buffer_size=65536

--- a/mysql-test/suite/innodb/t/bulk_load.test
+++ b/mysql-test/suite/innodb/t/bulk_load.test
@@ -1,0 +1,52 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/big_test.inc
+
+CREATE TABLE t1(f1 INT NOT NULL,f2 INT NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, seq from seq_1_to_131072;
+INSERT INTO t1 VALUES(131073, 131073), (131074, 131073);
+--replace_result $MYSQLTEST_VARDIR VARDIR
+--disable_cursor_protocol
+--disable_ps2_protocol
+eval SELECT * INTO OUTFILE "$MYSQLTEST_VARDIR/tmp/t1.outfile" FROM t1;
+--enable_ps2_protocol
+--enable_cursor_protocol
+
+--echo # successful load statement using bulk insert
+CREATE TABLE t2(f1 INT NOT NULL PRIMARY KEY,
+                f2 INT NOT NULL)ENGINE=InnoDB;
+SET unique_checks=0, foreign_key_checks=0;
+--replace_result $MYSQLTEST_VARDIR VARDIR
+eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/t1.outfile' INTO TABLE t2;
+SELECT COUNT(*) FROM t2;
+CHECK TABLE t2 EXTENDED;
+DROP TABLE t2;
+
+CREATE TABLE t2(f1 INT NOT NULL, PRIMARY KEY(f1 DESC),
+                f2 INT NOT NULL)ENGINE=InnoDB;
+--replace_result $MYSQLTEST_VARDIR VARDIR
+eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/t1.outfile' INTO TABLE t2;
+SELECT COUNT(*) FROM t2;
+CHECK TABLE t2 EXTENDED;
+DROP TABLE t2;
+
+--echo # load statement using bulk insert fails during secondary index
+CREATE TABLE t2(f1 INT NOT NULL PRIMARY KEY,
+                f2 INT NOT NULL UNIQUE KEY)ENGINE=InnoDB;
+--replace_result $MYSQLTEST_VARDIR VARDIR
+--error ER_ERROR_DURING_COMMIT
+eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/t1.outfile' INTO TABLE t2;
+SELECT COUNT(*) FROM t2;
+CHECK TABLE t2 EXTENDED;
+DROP TABLE t2;
+
+--echo # load statement using bulk insert fails during primary index
+CREATE TABLE t2(f1 INT NOT NULL,
+                f2 INT NOT NULL PRIMARY KEY)ENGINE=InnoDB;
+--replace_result $MYSQLTEST_VARDIR VARDIR
+--error ER_DUP_ENTRY
+eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/t1.outfile' INTO TABLE t2;
+SELECT COUNT(*) FROM t2;
+CHECK TABLE t2 EXTENDED;
+--remove_file $MYSQLTEST_VARDIR/tmp/t1.outfile
+DROP TABLE t2, t1;

--- a/sql/sql_load.cc
+++ b/sql/sql_load.cc
@@ -725,7 +725,15 @@ int mysql_load(THD *thd, const sql_exchange *ex, TABLE_LIST *table_list,
       table->file->print_error(my_errno, MYF(0));
       error= 1;
     }
-    table->file->extra(HA_EXTRA_NO_IGNORE_DUP_KEY);
+    if (!error)
+    {
+      int err= table->file->extra(HA_EXTRA_NO_IGNORE_DUP_KEY);
+      if (err == HA_ERR_FOUND_DUPP_KEY)
+      {
+	error= 1;
+	my_error(ER_ERROR_DURING_COMMIT, MYF(0), 1);
+      }
+    }
     table->file->extra(HA_EXTRA_WRITE_CANNOT_REPLACE);
     table->next_number_field=0;
   }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -15851,7 +15851,8 @@ ha_innobase::extra(
 			/* Allow a subsequent INSERT into an empty table
 			if !unique_checks && !foreign_key_checks. */
 			if (dberr_t err = trx->bulk_insert_apply()) {
-				return err;
+				return convert_error_code_to_mysql(
+					 err, 0, trx->mysql_thd);
 			}
 			break;
 		}

--- a/storage/innobase/include/row0merge.h
+++ b/storage/innobase/include/row0merge.h
@@ -447,12 +447,21 @@ class row_merge_bulk_t
   /** Block for encryption */
   row_merge_block_t *m_crypt_block= nullptr;
 public:
+  /** If this is false, then there will be only one
+  bulk_insert_buffered() call for the primary key followed by
+  load_one_row() and row_ins_clust_index_entry() for subsequent rows.
+  For secondary indexes or for true, bulk_insert_buffered() will be
+  invoked for each row. */
+  const bool m_sort_primary_key;
   /** Constructor.
   Create all merge files, merge buffer for all the table indexes
   expect fts indexes.
   Create a merge block which is used to write IO operation
-  @param table  table which undergoes bulk insert operation */
-  row_merge_bulk_t(dict_table_t *table);
+  @param table  table which undergoes bulk insert operation
+  @param sort_primary_key Allow primary key sort for bulk
+  operation. In case of load, InnoDB skips the
+  primary key sorting */
+  row_merge_bulk_t(dict_table_t *table, bool sort_primary_key);
 
   /** Destructor.
   Remove all merge files, merge buffer for all table indexes. */
@@ -498,4 +507,9 @@ public:
 
   /** Init temporary files for each index */
   void init_tmp_file();
+
+  /** Load one row into the primary index
+  @param trx     bulk transaction
+  @return error code */
+  dberr_t load_one_row(trx_t *trx);
 };

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2811,7 +2811,7 @@ avoid_bulk:
 			trx_start_if_not_started(trx, true);
 			trx->bulk_insert = true;
 			auto m = trx->mod_tables.emplace(index->table, 0);
-			m.first->second.start_bulk_insert(index->table);
+			m.first->second.start_bulk_insert(index->table, true);
 			err = m.first->second.bulk_insert_buffered(
 					*entry, *index, trx);
 			goto err_exit;
@@ -3430,7 +3430,12 @@ row_ins_index_entry(
 			return(DB_LOCK_WAIT);});
 
 	if (index->is_btree()) {
-		if (auto t= trx->check_bulk_buffer(index->table)) {
+		/* If the InnoDB skips the sorting of primary
+		index for bulk insert operation then InnoDB
+		should have called load_one_row() for the
+		first insert statement and shouldn't use
+		buffer for consecutive insert statement */
+		if (auto t= trx->use_bulk_buffer(index)) {
 			/* MDEV-25036 FIXME:
 			row_ins_check_foreign_constraint() check
 			should be done before buffering the insert

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -1865,7 +1865,9 @@ trx_undo_report_row_operation(
 	} else if (index->table->is_temporary()) {
 	} else if (trx_has_lock_x(*trx, *index->table)
 		   && index->table->bulk_trx_id == trx->id) {
-		m.first->second.start_bulk_insert(index->table);
+		m.first->second.start_bulk_insert(
+			index->table,
+			thd_sql_command(trx->mysql_thd) != SQLCOM_LOAD);
 
 		if (dberr_t err = m.first->second.bulk_insert_buffered(
 			    *clust_entry, *index, trx)) {


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34703*

## Description
Problem:
=======
- During load statement, InnoDB bulk operation relies on temporary directory and it got crash when exhausted.

Solution:
========
- For load statement, InnoDB bulk operation does the following
1) Avoids creation of temporary file for clustered index.
2) Use normal insert operation for clustered index
3) Writes the undo log for first insert operation alone

## How can this PR be tested?
./mtr innodb.bulk_load

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
