### PR TITLE
MDEV-35827 The generic MY_RELAX_CPU is expensive

### DIFF
--- a/include/my_cpu.h
+++ b/include/my_cpu.h
@@ -101,13 +101,11 @@ static inline void MY_RELAX_CPU(void)
   /* Changed from __ppc_get_timebase for musl compatibility */
   __builtin_ppc_get_timebase();
 #endif
-#elif defined __GNUC__ && (defined __arm__ || defined __aarch64__)
+#elif defined __GNUC__ && defined __riscv
+  __builtin_riscv_pause();
+#elif defined __GNUC__
   /* Mainly, prevent the compiler from optimizing away delay loops */
   __asm__ __volatile__ ("":::"memory");
-#else
-  int32 var, oldval = 0;
-  my_atomic_cas32_strong_explicit(&var, &oldval, 1, MY_MEMORY_ORDER_RELAXED,
-                                  MY_MEMORY_ORDER_RELAXED);
 #endif
 }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35827*
## Description
`MY_RELAX_CPU()`: On GCC and compatible compilers (including clang and its derivatives), let us use a null inline assembler block as the fallback. This should benefit s390x and LoongArch, for example.

Also, let us remove the generic fallback block that does exactly the opposite of what this function aims to achieve: avoid hogging the memory bus so that other threads will have a chance to let our spin loop to proceed.

On RISC-V, we will use `__builtin_riscv_pause()` which is a valid instruction encoding in all ISA versions according to https://gcc.gnu.org/pipermail/gcc-patches/2021-January/562936.html
## Release Notes
Spin loops on other ISA than x86, POWER, ARM were simplified.
## How can this PR be tested?
This is a low level change that is covered by `./mtr --suite=innodb`. On https://buildbot.mariadb.org we might  observe a performance improvement on s390x, because this will be removing some code.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

This is a bug fix that would also be applicable to MariaDB Server 10.5, but due to 76d2846a71a155ee2861fd52e6635e35490a9dd1 the code is slightly different (using the `isb` instruction on ARMv8).
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.