### PR TITLE
MDEV-35658 Assertion `commit_trx' failed in test galera_as_master

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7761,7 +7761,12 @@ MYSQL_BIN_LOG::write_transaction_to_binlog(THD *thd,
   {
     DBUG_RETURN(0);
   }
-  else if (!(thd->variables.option_bits & OPTION_BIN_LOG))
+
+  if (!(thd->variables.option_bits & OPTION_BIN_LOG)
+#ifdef WITH_WSREP
+      && !WSREP(thd)
+#endif
+      )
   {
     cache_mngr->need_unlog= false;
     DBUG_RETURN(0);
@@ -8668,6 +8673,13 @@ MYSQL_BIN_LOG::write_transaction_or_stmt(group_commit_entry *entry,
   bool has_xid= entry->end_event->get_type_code() == XID_EVENT;
 
   DBUG_ENTER("MYSQL_BIN_LOG::write_transaction_or_stmt");
+#ifdef WITH_WSREP
+  if (WSREP(entry->thd) &&
+      !(entry->thd->variables.option_bits & OPTION_BIN_LOG))
+  {
+    DBUG_RETURN(0);
+  }
+#endif /* WITH_WSREP */
 
   /*
     An error in the trx_cache will truncate the cache to the last good


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35658*


## Description
Fix assertion `commit_trx` in innobase_commit() during MTR test galera.galera_as_master. 
The test issues a simple INSERT statement, while sql_log_bin = 0. This option disables writes to binlog.  However, since MDEV-7205, the option does not affect Galera, so changes are still replicated. So sql_log_bin=off, "partially" disabled the binlog and the INSERT will involve both binlog and innodb, thus requiring internal 2 phase commit (2PC). In 2PC INSERT is first prepared, which will make it transition to PREPARED state in innodb, and later committed which causes the new assertion from MDEV-24035 to fail.
Running the same test with sql_log_bin enabled also results in 2PC, but the execution has one more step for ordered commit, between prepare and commit. Ordered commit causes the transaction state to transition back to TRX_STATE_NOT_STARTED. Thus avoiding the assertion. This patch makes sure that when sql_log_bin=off, the ordered commit step is not skipped, thus going through the expected state transitions in the storage engine.

## Release Notes
Nothing.

## How can this PR be tested?
Should fix MTR test galera.galera_as_master.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
