### PR TITLE
MDEV-35810 Missing error handling in log resizing

### DIFF
--- a/mysql-test/include/mtr_check.sql
+++ b/mysql-test/include/mtr_check.sql
@@ -31,6 +31,7 @@ BEGIN
     WHERE variable_name NOT IN ('timestamp')
      AND variable_name not like "Last_IO_Err*"
      AND variable_name != 'INNODB_IBUF_MAX_SIZE'
+     AND variable_name != 'INNODB_LOG_FILE_BUFFERING'
      AND variable_name != 'INNODB_USE_NATIVE_AIO'
      AND variable_name != 'INNODB_BUFFER_POOL_LOAD_AT_STARTUP'
      AND variable_name not like 'GTID%POS'

--- a/mysql-test/suite/innodb/r/log_file_size_online.result
+++ b/mysql-test/suite/innodb/r/log_file_size_online.result
@@ -25,8 +25,14 @@ SET GLOBAL innodb_log_file_buffering=ON;
 SET GLOBAL innodb_log_file_buffering=@save;
 SET GLOBAL innodb_log_file_mmap=OFF;
 Got one of the listed errors
-SET GLOBAL innodb_log_file_size=5242880;
 connect con1,localhost,root;
+SET GLOBAL innodb_log_file_size=7340032;
+connection default;
+KILL QUERY @id;
+connection con1;
+connection default;
+SET GLOBAL innodb_log_file_size=5242880;
+connection con1;
 UPDATE t SET b='' WHERE a<10;
 connection default;
 SHOW VARIABLES LIKE 'innodb_log_file_size';

--- a/mysql-test/suite/innodb/t/log_file_size_online.test
+++ b/mysql-test/suite/innodb/t/log_file_size_online.test
@@ -36,9 +36,19 @@ SET GLOBAL innodb_log_file_buffering=@save;
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR,ER_UNKNOWN_SYSTEM_VARIABLE
 SET GLOBAL innodb_log_file_mmap=OFF;
 
+--connect con1,localhost,root
+let $ID= `SELECT @id := CONNECTION_ID()`;
+send SET GLOBAL innodb_log_file_size=7340032;
+--connection default
+let $ignore= `SELECT @id := $ID`;
+KILL QUERY @id;
+--connection con1
+reap;
+
+--connection default
 send SET GLOBAL innodb_log_file_size=5242880;
 
---connect con1,localhost,root
+--connection con1
 send UPDATE t SET b='' WHERE a<10;
 
 --connection default

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -663,9 +663,9 @@ log_t::resize_start_status log_t::resize_start(os_offset_t size) noexcept
 
         writer_update();
       }
-      resize_lsn.store(start_lsn, std::memory_order_relaxed);
       status= success ? RESIZE_STARTED : RESIZE_FAILED;
     }
+    resize_lsn.store(start_lsn, std::memory_order_relaxed);
   }
 
   log_resize_release();
@@ -715,6 +715,8 @@ void log_t::resize_abort() noexcept
     resize_buf= nullptr;
     resize_target= 0;
     resize_lsn.store(0, std::memory_order_relaxed);
+    std::string path{get_log_file_path("ib_logfile101")};
+    IF_WIN(DeleteFile(path.c_str()), unlink(path.c_str()));
   }
 
   writer_update();


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35810*
## Description
`log_t::resize_start()`: If the `ib_logfile101` cannot be created, be sure to reset `log_sys.resize_lsn`.

`log_t::resize_abort()`: In case `SET GLOBAL innodb_log_file_size` is aborted, delete the `ib_logfile101`.
## Release Notes
The error handling of `SET GLOBAL innodb_log_file_size` was improved.
## How can this PR be tested?
```bash
./mtr --parallel=6 innodb.log_file_size_online{,,,} --repeat=5
```
Without the fix, the test would fail to resize the log from 5 MiB.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.