### PR TITLE
MDEV-35838 libressl support differences in CRYPTO_set_mem_functions

### DIFF
--- a/mysys_ssl/openssl.c
+++ b/mysys_ssl/openssl.c
@@ -36,8 +36,12 @@ int check_openssl_compatibility()
 static uint testing;
 static size_t alloc_size, alloc_count;
 
-static void *coc_malloc(size_t size, const char *f __attribute__((unused)),
-                                             int l __attribute__((unused)))
+static void *coc_malloc(size_t size
+#ifndef LIBRESSL_VERSION_NUMBER
+                        , const char *f __attribute__((unused)),
+                        int l __attribute__((unused))
+#endif
+)
 {
   if (unlikely(testing))
   {
@@ -47,15 +51,22 @@ static void *coc_malloc(size_t size, const char *f __attribute__((unused)),
   return malloc(size);
 }
 
-static void *coc_realloc(void *addr, size_t num,
-                         const char *file __attribute__((unused)),
-                         int line __attribute__((unused)))
+static void *coc_realloc(void *addr, size_t num
+#ifndef LIBRESSL_VERSION_NUMBER
+                         , const char *file __attribute__((unused)),
+                         int line __attribute__((unused))
+#endif
+)
 {
   return realloc(addr, num);
 }
 
-static void coc_free(void *addr, const char *file __attribute__((unused)),
-                    int line __attribute__((unused)))
+static void coc_free(void *addr
+#ifndef LIBRESSL_VERSION_NUMBER
+                     , const char *file __attribute__((unused)),
+                     int line __attribute__((unused))
+#endif
+)
 {
   free(addr);
 }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35838*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Based on FreeBSD patch.

The FreeBSD inclusion of check_openssl_compatibility prevented any use of the crypto callbacks and as such the later differences where ignored.

The later differences in coc_malloc didn't propegate to the other callback functions of CRYPTO_set_mem_functions where a reduced argument list also applied.

Looking where[2] libressl added the functions it was of the same prototype 10 years ago so omitting any version check.

[1] https://github.com/freebsd/freebsd-ports/blob/a34cf9c2dbf503c8248371ba3bab24f34d2d045d/databases/mariadb106-server/files/patch-mysys__ssl_openssl.c
[2] https://github.com/libressl/openbsd/commit/5ebad8aceae77c6da6a1e47c3f7e70e8ffae3dae#diff-7f393e5489e6c5780773408f11ca27d9b3bb8f55b174631a1e9467a1dd3010b9R22

## Release Notes

Add compatibility for libressl

## How can this PR be tested?

Build/test against libressl and all ssl mtr tests shouldn't leak memory.
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [X] *This is a compatibility fix, narrowly scoped, for a previously unsupported version.@

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [?] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.


FYI @Sp1l because the patch you did I think bypasses the fix by not using CRYPTO_set_mem_functions (hopefully explained in commit message).