### PR TITLE
MDEV-32575 MSAN / Valgrind errors in test_if_cheaper_ordering upon re…

### DIFF
--- a/mysql-test/main/opt_tvc.result
+++ b/mysql-test/main/opt_tvc.result
@@ -780,3 +780,15 @@ deallocate prepare stmt;
 drop table t1;
 set in_predicate_conversion_threshold=default;
 # End of 10.3 tests
+#
+# MDEV-32575 MSAN / Valgrind errors in test_if_cheaper_ordering
+#            upon reaching in_predicate_conversion_threshold
+#
+create table t1 (a int, b int, c int, primary key (a, b));
+insert into t1 (a, b) values (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8);
+set in_predicate_conversion_threshold = 2;
+select * from t1 where a in (1, 2) and b = 2 order by a, b;
+a	b	c
+1	2	NULL
+drop table t1;
+# End of 11.4 tests

--- a/mysql-test/main/opt_tvc.test
+++ b/mysql-test/main/opt_tvc.test
@@ -474,3 +474,18 @@ drop table t1;
 set in_predicate_conversion_threshold=default;
 
 --echo # End of 10.3 tests
+
+--echo #
+--echo # MDEV-32575 MSAN / Valgrind errors in test_if_cheaper_ordering
+--echo #            upon reaching in_predicate_conversion_threshold
+--echo #
+
+create table t1 (a int, b int, c int, primary key (a, b));
+insert into t1 (a, b) values (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8);
+
+set in_predicate_conversion_threshold = 2;
+select * from t1 where a in (1, 2) and b = 2 order by a, b;
+
+drop table t1;
+
+--echo # End of 11.4 tests

--- a/storage/heap/ha_heap.h
+++ b/storage/heap/ha_heap.h
@@ -59,7 +59,7 @@ public:
             HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER | HA_READ_RANGE :
             HA_ONLY_WHOLE_INDEX | HA_KEY_SCAN_NOT_ROR);
   }
-  const key_map *keys_to_use_for_scanning() override { return &btree_keys; }
+  const key_map *keys_to_use_for_scanning() override;
   uint max_supported_keys()          const override { return MAX_KEY; }
   uint max_supported_key_part_length() const override { return MAX_KEY_LENGTH; }
   IO_AND_CPU_COST scan_time() override;
@@ -121,5 +121,4 @@ public:
   int find_unique_row(uchar *record, uint unique_idx) override;
 private:
   void update_key_stats();
-  void set_keys_for_scanning(void);
 };


### PR DESCRIPTION
…aching in_predicate_conversion_threshold

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32575*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
When converting an IN-list to a subquery, a temporary table stores the IN-list values and participates in join optimization. The problem is the bitmap of usable keys for the temporary table is initialized after the optimization phase, during execution. It happens when the table is opened via `ha_heap::open()`, after the subroutine `set_keys_for_scanning()` is called. Trying to access the bitmap earlier, during optimization, leads to MSAN/Valgrind errors.

This fix removes the dependency on `set_keys_for_scanning()`. The key bitmap is now dynamically composed on demand in `keys_to_use_for_scanning()`, ensuring correctness without imposing strict call-order constraints.

## Release Notes
When [converting a large IN-list of values to a subquery](https://mariadb.com/kb/en/conversion-of-big-in-predicates-into-subqueries/) there was a chance that optimizer accessed an uninitialized bitmap of indexes which could lead to wrong results or a crash

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
