### PR TITLE
MDEV-35849: index records in a wrong order

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-index.result
+++ b/mysql-test/suite/innodb/r/innodb-index.result
@@ -1996,4 +1996,14 @@ a
 c
 DROP TABLE t1;
 # End of 10.8 tests
+#
+# MDEV-35849: index records in a wrong order
+#
+CREATE TABLE t (pk INT PRIMARY KEY, a VARCHAR(1), KEY (a DESC)) ENGINE=InnoDB;
+INSERT INTO t VALUES (1,NULL),(2,'x');
+CHECK TABLE t;
+Table	Op	Msg_type	Msg_text
+test.t	check	status	OK
+DROP TABLE t;
+# End of 11.8 tests
 ALTER DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_uca1400_ai_ci;

--- a/mysql-test/suite/innodb/t/innodb-index.test
+++ b/mysql-test/suite/innodb/t/innodb-index.test
@@ -1229,6 +1229,17 @@ DROP TABLE t1;
 
 --echo # End of 10.8 tests
 
+--echo #
+--echo # MDEV-35849: index records in a wrong order
+--echo #
+
+CREATE TABLE t (pk INT PRIMARY KEY, a VARCHAR(1), KEY (a DESC)) ENGINE=InnoDB;
+INSERT INTO t VALUES (1,NULL),(2,'x');
+CHECK TABLE t;
+DROP TABLE t;
+
+--echo # End of 11.8 tests
+
 --disable_query_log
 
 call mtr.add_suppression("InnoDB: Tablespace .* was not found at .*t[12].ibd.");

--- a/storage/innobase/page/page0cur.cc
+++ b/storage/innobase/page/page0cur.cc
@@ -606,7 +606,7 @@ static int page_cur_dtuple_cmp(const dtuple_t &dtuple, const rec_t *rec,
         {
           if (i < cur_field || dtuple.fields[i].len == UNIV_SQL_NULL)
             continue;
-          ret= 1;
+          ret= field->descending ? -1 : 1;
           break;
         }
       }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35849*
## Description
`page_cur_dtuple_cmp()`: Take `DESC` index fields into account also when comparing a `NULL` value in a `ROW_FORMAT≠REDUNDANT` record.
## Release Notes
N/A. This bug is not present in any tagged release.
## How can this PR be tested?
```sh
./mtr innodb.innodb-index
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.