### PR TITLE
MDEV-35748 : Attempting to create a CONNECT engine Table results in n…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-35748.result
+++ b/mysql-test/suite/galera/r/MDEV-35748.result
@@ -1,0 +1,31 @@
+connection node_2;
+connection node_1;
+connection node_1;
+INSTALL PLUGIN IF NOT EXISTS connect SONAME 'ha_connect';
+CREATE TABLE t1 (f INT) ENGINE=CONNECT;
+Warnings:
+Warning	1105	No table_type. Will be set to DOS
+Warning	1105	No file name. Table will use t1.dos
+CREATE TABLE t2 (f INT) ENGINE=ROCKSDB;
+CREATE TABLE t3 (f INT) ENGINE=SEQUENCE;
+ERROR 42000: This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
+show warnings;
+Level	Code	Message
+Error	1235	This version of MariaDB doesn't yet support 'non-InnoDB sequences in Galera cluster'
+Note	1235	ENGINE=SEQUENCE not supported by Galera
+connection node_2;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f` int(11) DEFAULT NULL
+) ENGINE=CONNECT DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `f` int(11) DEFAULT NULL
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+show create table t3;
+ERROR 42S02: Table 'test.t3' doesn't exist
+connection node_1;
+DROP TABLE t1, t2;
+UNINSTALL PLUGIN IF EXISTS connect;

--- a/mysql-test/suite/galera/t/MDEV-35748.test
+++ b/mysql-test/suite/galera/t/MDEV-35748.test
@@ -1,0 +1,23 @@
+--source include/galera_cluster.inc
+--source include/have_sequence.inc
+--source include/have_rocksdb.inc
+
+--connection node_1
+INSTALL PLUGIN IF NOT EXISTS connect SONAME 'ha_connect';
+
+CREATE TABLE t1 (f INT) ENGINE=CONNECT;
+CREATE TABLE t2 (f INT) ENGINE=ROCKSDB;
+--error ER_NOT_SUPPORTED_YET
+CREATE TABLE t3 (f INT) ENGINE=SEQUENCE;
+show warnings;
+
+--connection node_2
+show create table t1;
+show create table t2;
+--error ER_NO_SUCH_TABLE
+show create table t3;
+
+--connection node_1
+DROP TABLE t1, t2;
+UNINSTALL PLUGIN IF EXISTS connect;
+

--- a/sql/sql_cmd.h
+++ b/sql/sql_cmd.h
@@ -141,6 +141,8 @@ public:
                                          handlerton **ha,
                                          bool tmp_table);
   bool is_set() { return m_storage_engine_name.str != NULL; }
+
+  const LEX_CSTRING *name() const { return &m_storage_engine_name; }
 };
 
 


### PR DESCRIPTION
…on-InnoDB sequences in Galera cluster error


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35748*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Problem was incorrect condition on wsrep_check_sequence when ENGINE!=InnoDB.

Fix is not use DB_TYPE_XXX because it is not correct on dynamic storage engines. Instead used storage engine name is looked from thd->lex->m_sql_cmd->option_storage_engine_name.

For CREATE TABLE allow anyting except ENGINE=SEQUENCE. 
For CREATE SEQUENCE only ENGINE=InnoDB is supported. 
For ALTER TABLE if original table contains sequence information only ENGINE=InnoDB is supported.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
