### PR TITLE
MDEV-35852 : ASAN heap-use-after-free in WSREP_DEBUG after INSERT DEL…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-35852.result
+++ b/mysql-test/suite/galera/r/MDEV-35852.result
@@ -1,0 +1,8 @@
+connection node_2;
+connection node_1;
+CREATE TABLE t (a INT) ENGINE=InnoDB;
+INSERT DELAYED INTO t VALUES ();
+ERROR HY000: DELAYED option not supported for table 't'
+DROP TABLE t;
+INSERT DELAYED t1 () VALUES ();
+ERROR 42S02: Table 'test.t1' doesn't exist

--- a/mysql-test/suite/galera/t/MDEV-35852.cnf
+++ b/mysql-test/suite/galera/t/MDEV-35852.cnf
@@ -1,0 +1,4 @@
+!include ../galera_2nodes.cnf
+
+[mysqld]
+wsrep-debug=1

--- a/mysql-test/suite/galera/t/MDEV-35852.test
+++ b/mysql-test/suite/galera/t/MDEV-35852.test
@@ -1,0 +1,9 @@
+--source include/galera_cluster.inc
+
+CREATE TABLE t (a INT) ENGINE=InnoDB;
+--error ER_DELAYED_NOT_SUPPORTED
+INSERT DELAYED INTO t VALUES ();
+DROP TABLE t;
+
+--error ER_NO_SUCH_TABLE
+INSERT DELAYED t1 () VALUES ();

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -1,4 +1,4 @@
-/* Copyright 2018-2024 Codership Oy <info@codership.com>
+/* Copyright 2018-2025 Codership Oy <info@codership.com>
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -86,7 +86,9 @@ extern "C" const char *wsrep_thd_query(const THD *thd)
         return "SET PASSWORD";
       /* fallthrough */
     default:
+    {
       return (thd->query() ? thd->query() : "NULL");
+    }
   }
   return "NULL";
 }

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2433,6 +2433,7 @@ public:
     delayed_insert_threads--;
 
     my_free(thd.query());
+    thd->reset_query_inner();
     thd.security_ctx->user= 0;
     thd.security_ctx->host= 0;
   }


### PR DESCRIPTION
…AYED


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35852*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Problem was that in case of INSERT DELAYED thd->query() is deleted before we call trans_rollback where WSREP_DEBUG could access thd->query().

Fix is to return NULL from wsrep_query() in case when thd is killed and thread is insert delayed thread.


## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
