### PR TITLE
MDEV-35632 HandlerSocket uses deprecated C++98 auto_ptr

### DIFF
--- a/plugin/handler_socket/client/hslongrun.cpp
+++ b/plugin/handler_socket/client/hslongrun.cpp
@@ -927,7 +927,7 @@ hs_longrun_main(int argc, char **argv)
   shared.verbose = shared.conf.get_int("verbose", 1);
   const int table_size = shared.conf.get_int("table_size", 10000);
   for (int i = 0; i < table_size; ++i) {
-    std::auto_ptr<record_value> rec(new record_value());
+    std::unique_ptr<record_value> rec(new record_value());
     rec->key = to_stdstring(i);
     shared.records.push_back_ptr(rec);
   }
@@ -966,7 +966,7 @@ hs_longrun_main(int argc, char **argv)
       int id = thrs.size();
       const hs_longrun_thread_hs::arg_type arg(id, e.type, e.op, e.lock,
 	shared);
-      std::auto_ptr<hs_longrun_thread_base> thr;
+      std::unique_ptr<hs_longrun_thread_base> thr;
       if (e.hs) {
       	thr.reset(new hs_longrun_thread_hs(arg));
       } else {

--- a/plugin/handler_socket/client/hstest.cpp
+++ b/plugin/handler_socket/client/hstest.cpp
@@ -561,7 +561,7 @@ hstest_thread::test_9(int test_num)
     flds += std::string(buf);
   }
   int connected = 0;
-  std::auto_ptr<auto_mysql_stmt> stmt;
+  std::unique_ptr<auto_mysql_stmt> stmt;
   string_buffer wbuf;
   for (int i = 0; i < num; ++i) {
     const double tm1 = gettimeofday_double();
@@ -1474,7 +1474,7 @@ hstest_main(int argc, char **argv)
   #endif
   const int num_thrs = shared.num_threads;
   typedef thread<hstest_thread> thread_type;
-  typedef std::auto_ptr<thread_type> thread_ptr;
+  typedef std::unique_ptr<thread_type> thread_ptr;
   typedef auto_ptrcontainer< std::vector<thread_type *> > thrs_type;
   thrs_type thrs;
   for (int i = 0; i < num_thrs; ++i) {

--- a/plugin/handler_socket/handlersocket/database.cpp
+++ b/plugin/handler_socket/handlersocket/database.cpp
@@ -175,7 +175,7 @@ struct dbcontext : public dbcontext_i, private noncopyable {
   THD *thd;
   MYSQL_LOCK *lock;
   bool lock_failed;
-  std::auto_ptr<expr_user_lock> user_lock;
+  std::unique_ptr<expr_user_lock> user_lock;
   int user_level_lock_timeout;
   bool user_level_lock_locked;
   bool commit_error;

--- a/plugin/handler_socket/handlersocket/database.hpp
+++ b/plugin/handler_socket/handlersocket/database.hpp
@@ -9,11 +9,6 @@
 #ifndef DENA_DATABASE_HPP
 #define DENA_DATABASE_HPP
 
-#ifdef __GNUC__
-/* auto_ptr is deprecated */
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 #include <string>
 #include <memory>
 #include <vector>
@@ -26,10 +21,10 @@
 namespace dena {
 
 struct database_i;
-typedef std::auto_ptr<volatile database_i> database_ptr;
+typedef std::unique_ptr<volatile database_i> database_ptr;
 
 struct dbcontext_i;
-typedef std::auto_ptr<dbcontext_i> dbcontext_ptr;
+typedef std::unique_ptr<dbcontext_i> dbcontext_ptr;
 
 struct database_i {
   virtual ~database_i() = default;

--- a/plugin/handler_socket/handlersocket/handlersocket.cpp
+++ b/plugin/handler_socket/handlersocket/handlersocket.cpp
@@ -76,7 +76,7 @@ daemon_handlersocket_init(void *p)
   conf["readsize"] = to_stdstring(handlersocket_readsize);
   conf["accept_balance"] = to_stdstring(handlersocket_accept_balance);
   conf["wrlock_timeout"] = to_stdstring(handlersocket_wrlock_timeout);
-  std::auto_ptr<daemon_handlersocket_data> ap(new daemon_handlersocket_data);
+  std::unique_ptr<daemon_handlersocket_data> ap(new daemon_handlersocket_data);
   if (handlersocket_port != 0 && handlersocket_port_wr != handlersocket_port) {
     conf["port"] = handlersocket_port;
     if (handlersocket_plain_secret) {

--- a/plugin/handler_socket/handlersocket/hstcpsvr.cpp
+++ b/plugin/handler_socket/handlersocket/hstcpsvr.cpp
@@ -115,7 +115,7 @@ hstcpsvr::start_listen()
     arg.cshared = &cshared;
     arg.vshared = &vshared;
     arg.worker_id = i;
-    std::auto_ptr< thread<worker_throbj> > thr(
+    std::unique_ptr< thread<worker_throbj> > thr(
       new thread<worker_throbj>(arg, stack_size));
     threads.push_back_ptr(thr);
   }

--- a/plugin/handler_socket/handlersocket/hstcpsvr.hpp
+++ b/plugin/handler_socket/handlersocket/hstcpsvr.hpp
@@ -44,7 +44,7 @@ struct hstcpsvr_shared_v : public mutex {
 };
 
 struct hstcpsvr_i;
-typedef std::auto_ptr<hstcpsvr_i> hstcpsvr_ptr;
+typedef std::unique_ptr<hstcpsvr_i> hstcpsvr_ptr;
 
 struct hstcpsvr_i {
   virtual ~hstcpsvr_i() = default;

--- a/plugin/handler_socket/handlersocket/hstcpsvr_worker.cpp
+++ b/plugin/handler_socket/handlersocket/hstcpsvr_worker.cpp
@@ -451,7 +451,7 @@ hstcpsvr_worker::run_one_nb()
   {
     pollfd& pfd = pfds[nfds - 1];
     if ((pfd.revents & mask_in) != 0) {
-      std::auto_ptr<hstcpsvr_conn> c(new hstcpsvr_conn());
+      std::unique_ptr<hstcpsvr_conn> c(new hstcpsvr_conn());
       c->nonblocking = true;
       c->readsize = cshared.readsize;
       c->accept(cshared);
@@ -498,7 +498,7 @@ hstcpsvr_worker::run_one_ep()
       /* listener */
       ++accept_count;
       DBG_EP(fprintf(stderr, "IN listener\n"));
-      std::auto_ptr<hstcpsvr_conn> c(new hstcpsvr_conn());
+      std::unique_ptr<hstcpsvr_conn> c(new hstcpsvr_conn());
       c->nonblocking = true;
       c->readsize = cshared.readsize;
       c->accept(cshared);

--- a/plugin/handler_socket/handlersocket/hstcpsvr_worker.hpp
+++ b/plugin/handler_socket/handlersocket/hstcpsvr_worker.hpp
@@ -14,7 +14,7 @@
 namespace dena {
 
 struct hstcpsvr_worker_i;
-typedef std::auto_ptr<hstcpsvr_worker_i> hstcpsvr_worker_ptr;
+typedef std::unique_ptr<hstcpsvr_worker_i> hstcpsvr_worker_ptr;
 
 struct hstcpsvr_worker_arg {
   const hstcpsvr_shared_c *cshared;

--- a/plugin/handler_socket/libhsclient/hstcpcli.hpp
+++ b/plugin/handler_socket/libhsclient/hstcpcli.hpp
@@ -19,11 +19,6 @@
 #include "string_ref.hpp"
 #include "string_buffer.hpp"
 
-#ifdef __GNUC__
-/* auto_ptr is deprecated */
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
 namespace dena {
 
 struct hstcpcli_filter {
@@ -35,7 +30,7 @@ struct hstcpcli_filter {
 };
 
 struct hstcpcli_i;
-typedef std::auto_ptr<hstcpcli_i> hstcpcli_ptr;
+typedef std::unique_ptr<hstcpcli_i> hstcpcli_ptr;
 
 struct hstcpcli_i {
   virtual ~hstcpcli_i() = default;


### PR DESCRIPTION
Change uses of auto_ptr to unique_ptr
