### PR TITLE
MDEV-35723: applying non-zero offset to null pointer in INSERT

### DIFF
--- a/mysql-test/suite/innodb/r/innodb.result
+++ b/mysql-test/suite/innodb/r/innodb.result
@@ -3337,3 +3337,9 @@ Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
 ALTER TABLE t1 FORCE;
 DROP TABLE t1;
+#
+# MDEV-35723: applying zero offset to null pointer on INSERT
+#
+CREATE TABLE t1(c TEXT(1) NOT NULL, INDEX (c)) ENGINE=InnoDB;
+INSERT INTO t1 SET c='';
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/innodb.test
+++ b/mysql-test/suite/innodb/t/innodb.test
@@ -2605,3 +2605,10 @@ CHECK TABLE t1;
 ALTER TABLE t1 FORCE;
 # Cleanup
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-35723: applying zero offset to null pointer on INSERT
+--echo #
+CREATE TABLE t1(c TEXT(1) NOT NULL, INDEX (c)) ENGINE=InnoDB;
+INSERT INTO t1 SET c='';
+DROP TABLE t1;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -244,6 +244,14 @@ row_mysql_read_blob_ref(
 
 	*len = mach_read_from_n_little_endian(ref, col_len - 8);
 
+	if (!*len) {
+		/* Field_blob::store() if (!length) would encode both
+		the length and the pointer in the same area. An empty
+		string must be a valid (nonnull) pointer in the
+		collation functions that cmp_data() may invoke. */
+		return ref;
+	}
+
 	memcpy(&data, ref + col_len - 8, sizeof data);
 
 	return(data);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35723*
## Description
`row_mysql_read_blob_ref()`: Correctly handle what `Field_blob::store()` generates for `length=0`.
## Release Notes
This probably does not need to be documented, because it is not known that this undefined behaviour would have caused any problem with any build.
## How can this PR be tested?
Compile with a suitable version of clang and `cmake -DWITH_UBSAN=ON`.
```sh
./mtr --rr innodb.innodb
rr replay var/log/mysql.1.rr/latest-trace
```
```gdb
break __ubsan::ScopedReport::~ScopedReport()
continue
backtrace
…
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.