### PR TITLE
MDEV-7611 mysqldump --dump-slave always starts stopped slave

### DIFF
--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -184,7 +184,7 @@ static DYNAMIC_STRING extended_row;
 static DYNAMIC_STRING dynamic_where;
 static MYSQL_RES *get_table_name_result= NULL;
 static MEM_ROOT glob_root;
-static MYSQL_RES *routine_res, *routine_list_res;
+static MYSQL_RES *routine_res, *routine_list_res, *slave_status_res= NULL;
 
 
 #include <sslopt-vars.h>
@@ -1908,6 +1908,8 @@ static void free_resources()
     mysql_free_result(routine_res);
   if (routine_list_res)
     mysql_free_result(routine_list_res);
+  if (slave_status_res)
+    mysql_free_result(slave_status_res);
   if (mysql)
   {
     mysql_close(mysql);
@@ -6257,17 +6259,19 @@ static int do_show_master_status(MYSQL *mysql_con, int consistent_binlog_pos,
 
 static int do_stop_slave_sql(MYSQL *mysql_con)
 {
-  MYSQL_RES *slave;
   MYSQL_ROW row;
+  DBUG_ASSERT(
+    !slave_status_res // do_stop_slave_sql() should only be called once
+  );
 
-  if (mysql_query_with_error_report(mysql_con, &slave,
+  if (mysql_query_with_error_report(mysql_con, &slave_status_res,
                                     multi_source ?
                                     "SHOW ALL SLAVES STATUS" :
                                     "SHOW SLAVE STATUS"))
     return(1);
 
   /* Loop over all slaves */
-  while ((row= mysql_fetch_row(slave)))
+  while ((row= mysql_fetch_row(slave_status_res)))
   {
     if (row[11 + multi_source])
     {
@@ -6282,13 +6286,11 @@ static int do_stop_slave_sql(MYSQL *mysql_con)
 
         if (mysql_query_with_error_report(mysql_con, 0, query))
         {
-          mysql_free_result(slave);
           return 1;
         }
       }
     }
   }
-  mysql_free_result(slave);
   return(0);
 }
 
@@ -6412,32 +6414,35 @@ static int do_show_slave_status(MYSQL *mysql_con, int have_mariadb_gtid,
 
 static int do_start_slave_sql(MYSQL *mysql_con)
 {
-  MYSQL_RES *slave;
   MYSQL_ROW row;
   int error= 0;
   DBUG_ENTER("do_start_slave_sql");
 
-  /* We need to check if the slave sql is stopped in the first place */
-  if (mysql_query_with_error_report(mysql_con, &slave,
-                                    multi_source ?
-                                    "SHOW ALL SLAVES STATUS" :
-                                    "SHOW SLAVE STATUS"))
-    DBUG_RETURN(1);
+  /*
+    do_start_slave_sql() should normally be called
+    sometime after do_stop_slave_sql() succeeds
+  */
+  if (!slave_status_res)
+    DBUG_RETURN(error);
+  mysql_data_seek(slave_status_res, 0);
 
-  while ((row= mysql_fetch_row(slave)))
+  while ((row= mysql_fetch_row(slave_status_res)))
   {
     DBUG_PRINT("info", ("Connection: '%s'  status: '%s'",
                         multi_source ? row[0] : "", row[11 + multi_source]));
     if (row[11 + multi_source])
     {
-      /* if SLAVE SQL is not running, we don't start it */
-      if (strcmp(row[11 + multi_source], "Yes"))
+      /*
+        If SLAVE_SQL was not running but is now,
+        we start it anyway to warn the unexpected state change.
+      */
+      if (strcmp(row[11 + multi_source], "No"))
       {
         char query[160];
         if (multi_source)
-          sprintf(query, "START SLAVE '%.80s'", row[0]);
+          sprintf(query, "START SLAVE '%.80s' SQL_THREAD", row[0]);
         else
-          strmov(query, "START SLAVE");
+          strmov(query, "START SLAVE SQL_THREAD");
 
         if (mysql_query_with_error_report(mysql_con, 0, query))
         {
@@ -6448,7 +6453,6 @@ static int do_start_slave_sql(MYSQL *mysql_con)
       }
     }
   }
-  mysql_free_result(slave);
   DBUG_RETURN(error);
 }
 

--- a/mysql-test/main/mysqldump.result
+++ b/mysql-test/main/mysqldump.result
@@ -5617,7 +5617,6 @@ proc
 one
 DROP DATABASE bug25717383;
 mariadb-dump: Got error: 2005: "Unknown server host 'unknownhost'" when trying to connect
-mariadb-dump: Couldn't execute 'SHOW SLAVE STATUS': Server has gone away (2006)
 Usage: mariadb-dump [OPTIONS] database [tables]
 OR     mariadb-dump [OPTIONS] --databases DB1 [DB2 DB3...]
 OR     mariadb-dump [OPTIONS] --all-databases

--- a/mysql-test/suite/multi_source/mariadb-dump_slave.result
+++ b/mysql-test/suite/multi_source/mariadb-dump_slave.result
@@ -1,0 +1,56 @@
+connect    active_master, 127.0.0.1, root, , , $SERVER_MYPORT_2;
+connect  inactive_master, 127.0.0.1, root, , , $SERVER_MYPORT_3;
+connect            slave, 127.0.0.1, root, , , $SERVER_MYPORT_1;
+CHANGE MASTER TO
+master_host='127.0.0.1', master_port=MYPORT_2, master_user='root';
+START SLAVE SQL_THREAD;
+CHANGE MASTER 'inactive' TO
+master_host='127.0.0.1', master_port=MYPORT_3;
+include/wait_for_slave_sql_to_start.inc
+# Control State
+Connection_name = ''
+Connection_name = 'inactive'
+Slave_IO_Running = 'No'
+Slave_IO_Running = 'No'
+Slave_SQL_Running = 'Yes'
+Slave_SQL_Running = 'No'
+# Basic
+$MYSQL_DUMP --compact --dump-slave --include-master-host-port test
+/*M!999999\- enable the sandbox mode */ 
+CHANGE MASTER '' TO MASTER_HOST='127.0.0.1', MASTER_PORT=MYPORT_2, MASTER_LOG_FILE='', MASTER_LOG_POS=4;
+CHANGE MASTER 'inactive' TO MASTER_HOST='127.0.0.1', MASTER_PORT=MYPORT_3, MASTER_LOG_FILE='', MASTER_LOG_POS=0;
+
+-- SET GLOBAL gtid_slave_pos='';
+# MDEV-7611 mysqldump --dump-slave always starts stopped slave
+$MYSQL_DUMP --compact --dump-slave test
+/*M!999999\- enable the sandbox mode */ 
+CHANGE MASTER '' TO MASTER_LOG_FILE='', MASTER_LOG_POS=4;
+CHANGE MASTER 'inactive' TO MASTER_LOG_FILE='', MASTER_LOG_POS=0;
+
+-- SET GLOBAL gtid_slave_pos='';
+include/wait_for_slave_sql_to_start.inc
+Connection_name = ''
+Connection_name = 'inactive'
+Slave_IO_Running = 'No'
+Slave_IO_Running = 'No'
+Slave_SQL_Running = 'Yes'
+Slave_SQL_Running = 'No'
+# MDEV-5624 mysqldump --dump-slave option does not restart the replication if the dump has failed
+$MYSQL_DUMP --compact --dump-slave no_such_db
+/*M!999999\- enable the sandbox mode */ 
+CHANGE MASTER '' TO MASTER_LOG_FILE='', MASTER_LOG_POS=4;
+CHANGE MASTER 'inactive' TO MASTER_LOG_FILE='', MASTER_LOG_POS=0;
+
+include/wait_for_slave_sql_to_start.inc
+Connection_name = ''
+Connection_name = 'inactive'
+Slave_IO_Running = 'No'
+Slave_IO_Running = 'No'
+Slave_SQL_Running = 'Yes'
+Slave_SQL_Running = 'No'
+# Cleanup
+STOP SLAVE SQL_THREAD;
+disconnect active_master;
+disconnect inactive_master;
+include/wait_for_slave_sql_to_stop.inc
+disconnect slave;

--- a/mysql-test/suite/multi_source/mariadb-dump_slave.test
+++ b/mysql-test/suite/multi_source/mariadb-dump_slave.test
@@ -1,0 +1,55 @@
+# `mariadb-dump --dump-slave` multi-source interactions
+# (see `main.rpl_mysqldump_slave` for general testing with single-source)
+
+--source include/have_log_bin.inc
+--let $status_items= Connection_name, Slave_IO_Running, Slave_SQL_Running
+--let $all_slaves_status= 1
+
+# $MYSQL_DUMP dumps the $SERVER_MYPORT_1 server
+--connect (  active_master, 127.0.0.1, root, , , $SERVER_MYPORT_2)
+--connect (inactive_master, 127.0.0.1, root, , , $SERVER_MYPORT_3)
+--connect (          slave, 127.0.0.1, root, , , $SERVER_MYPORT_1)
+
+--replace_result $SERVER_MYPORT_2 MYPORT_2
+eval CHANGE MASTER TO
+  master_host='127.0.0.1', master_port=$SERVER_MYPORT_2, master_user='root';
+START SLAVE SQL_THREAD;
+--replace_result $SERVER_MYPORT_3 MYPORT_3
+eval CHANGE MASTER 'inactive' TO
+  master_host='127.0.0.1', master_port=$SERVER_MYPORT_3;
+# wait for the active default '' connection only
+--source include/wait_for_slave_sql_to_start.inc
+
+
+--echo # Control State
+--source include/show_slave_status.inc
+
+--echo # Basic
+--echo \$MYSQL_DUMP --compact --dump-slave --include-master-host-port test
+--replace_result $SERVER_MYPORT_2 MYPORT_2 $SERVER_MYPORT_3 MYPORT_3
+--exec  $MYSQL_DUMP --compact --dump-slave --include-master-host-port test
+
+
+# The 'inactive' connection should remain stopped
+# while the active '' connection should restart.
+
+--echo # MDEV-7611 mysqldump --dump-slave always starts stopped slave
+--echo \$MYSQL_DUMP --compact --dump-slave test
+--exec  $MYSQL_DUMP --compact --dump-slave test
+--source include/wait_for_slave_sql_to_start.inc
+--source include/show_slave_status.inc
+
+--echo # MDEV-5624 mysqldump --dump-slave option does not restart the replication if the dump has failed
+--echo \$MYSQL_DUMP --compact --dump-slave no_such_db
+--error 2
+--exec  $MYSQL_DUMP --compact --dump-slave no_such_db
+--source include/wait_for_slave_sql_to_start.inc
+--source include/show_slave_status.inc
+
+
+--echo # Cleanup
+STOP SLAVE SQL_THREAD;
+--disconnect active_master
+--disconnect inactive_master
+--source include/wait_for_slave_sql_to_stop.inc
+--disconnect slave

--- a/mysql-test/suite/rpl/r/rpl_mysqldump_gtid_slave_pos.result
+++ b/mysql-test/suite/rpl/r/rpl_mysqldump_gtid_slave_pos.result
@@ -51,7 +51,6 @@ after initial slave got in sync
 include/stop_slave.inc
 # 3. A
 include/stop_slave.inc
-include/stop_slave.inc
 # 4.
 set statement sql_log_bin=0 for delete from mysql.gtid_slave_pos;
 insert into mysql.gtid_slave_pos values (99 + 2, 1, 1, 1);

--- a/mysql-test/suite/rpl/t/rpl_mysqldump_gtid_slave_pos.test
+++ b/mysql-test/suite/rpl/t/rpl_mysqldump_gtid_slave_pos.test
@@ -73,7 +73,6 @@ select @@global.gtid_slave_pos as "after initial slave got in sync";
 --echo # 3. A
 # Two dumps prepared to be restored in the following loop
 --exec $MYSQL_DUMP_SLAVE --dump-slave  --gtid mysql gtid_slave_pos > $MYSQLTEST_VARDIR/tmp/dump_2.sql
---source include/stop_slave.inc
 
 --exec $MYSQL_DUMP_SLAVE --master-data  --gtid mysql gtid_slave_pos > $MYSQLTEST_VARDIR/tmp/dump_1.sql
 


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-7611][]*
  * This bug’s reported 10½ years ago!? :astonished:

## Description
Store the _SLAVE_ STATUS when pausing replicas for `mariadb-dump --dump-slave`;
use that (instead of a new SHOW _SLAVE_ STATUS) to resume replicas when the program ends.

### What problem is the patch trying to solve?
> When making a dump with --dump-slave option, upon completion mysqldump starts slave threads [IO & SQL for all multi-source connections] even if they were not stopped by mysqldump itself.
> This behavior breaks delayed/manually synchronized slaves which have not to be running all the time.
> ⸺ [MDEV-7611][]

## Release Notes
* Fix `mariadb-dump --dump-thread` starts replication threads that were not running

## How can this PR be tested?
* The new `multi_source.mariadb-dump_slave` tests this issue for multi-source and, by consequence, single-source replication.
* Edge cases and changed side-effects remain testable by existing methods such as `main.mysqldump`.

## Basing the PR against the correct MariaDB version
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest _maintained_ branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

[MDEV-7611]: https://jira.mariadb.org/browse/MDEV-7611