### PR TITLE
MDEV-29182 Assertion fld->field_no < table->n_v_def failed on cascade

### DIFF
--- a/mysql-test/suite/innodb/r/foreign_key.result
+++ b/mysql-test/suite/innodb/r/foreign_key.result
@@ -1022,4 +1022,21 @@ t2	CREATE TABLE `t2` (
   CONSTRAINT `t2_ibfk_1` FOREIGN KEY (`a`) REFERENCES `t1` (`a`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
 drop tables t2, t1;
+#
+# MDEV-29182 Assertion fld->field_no < table->n_v_def failed on cascade
+#
+CREATE TABLE t1(a INT PRIMARY KEY, b VARCHAR(3), c INT AS (LENGTH(b)) VIRTUAL,
+INDEX(c)) ENGINE=InnoDB;
+CREATE TABLE t2(a INT REFERENCES t1(a) ON UPDATE CASCADE,
+b INT GENERATED ALWAYS AS(a) VIRTUAL, INDEX(b)) ENGINE=InnoDB;
+INSERT INTO t1 SET a=1,b='fu';
+INSERT INTO t2 SET a=1;
+UPDATE t1 SET a=2,b='bar';
+SELECT * FROM t1;
+a	b	c
+2	bar	3
+SELECT * FROM t2;
+a	b
+2	2
+DROP TABLE t2,t1;
 # End of 10.5 tests

--- a/mysql-test/suite/innodb/t/foreign_key.test
+++ b/mysql-test/suite/innodb/t/foreign_key.test
@@ -1063,6 +1063,21 @@ alter table t2 add foreign key(a) references t1;
 show create table t2;
 drop tables t2, t1;
 
+
+--echo #
+--echo # MDEV-29182 Assertion fld->field_no < table->n_v_def failed on cascade
+--echo #
+CREATE TABLE t1(a INT PRIMARY KEY, b VARCHAR(3), c INT AS (LENGTH(b)) VIRTUAL,
+                INDEX(c)) ENGINE=InnoDB;
+CREATE TABLE t2(a INT REFERENCES t1(a) ON UPDATE CASCADE,
+                b INT GENERATED ALWAYS AS(a) VIRTUAL, INDEX(b)) ENGINE=InnoDB;
+INSERT INTO t1 SET a=1,b='fu';
+INSERT INTO t2 SET a=1;
+UPDATE t1 SET a=2,b='bar';
+SELECT * FROM t1;
+SELECT * FROM t2;
+DROP TABLE t2,t1;
+
 --echo # End of 10.5 tests
 
 --source include/wait_until_count_sessions.inc

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -479,7 +479,9 @@ row_ins_cascade_calc_update_vec(
 			const upd_field_t*	parent_ufield
 				= &parent_update->fields[j];
 
-			if (parent_ufield->field_no == parent_field_no) {
+			if (parent_ufield->field_no == parent_field_no
+			    && !(parent_ufield->new_val.type.prtype
+				 & DATA_VIRTUAL)) {
 
 				ulint			min_size;
 				const dict_col_t*	col;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-29182*
## Description
`row_ins_cascade_calc_update_vec()`: Skip any virtual columns in the update vector of the parent table.

Based on mysql/mysql-server@0ac176453bfef7fb1fdfa70af74618c32910181c
## Release Notes
See the test case.
## How can this PR be tested?
```sh
./mtr innodb.foreign_key
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.