### PR TITLE
MDEV-35905: Revert CONC-710 induced mysqlbinlog FIXME

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -43,11 +43,6 @@
 #include "sql_priv.h"
 #include "sql_basic_types.h"
 #include <atomic>
-#if 0 /* FIXME: the following is broken for now */
-# include "mariadb_rpl.h"
-#else
-enum Item_result {STRING_RESULT,REAL_RESULT,INT_RESULT,ROW_RESULT,DECIMAL_RESULT};
-#endif
 #include "log_event.h"
 #include "compat56.h"
 #include "sql_common.h"


### PR DESCRIPTION
mariadb-corporation/mariadb-connector-c@1a2ed3f67af698b394b2faed069b49d4f409a155
and
mariadb-corporation/mariadb-connector-c@78e56a7fd3c1af3de659a736a90702e76ad5675b
of CONC-710 mistakenly moved Item_result from mariadb_com.h to
mariadb_rpl.h thinking it was only used by Connector/C's binlog API;
however it is also used by mysqlbinlog in the server. This broke
server compilation.
    
mariadb/server@e41145f76bb668d4b262ef30f14da32d23e3937e
provided a temporary fix to re-define Item_result in mysqlbinlog.cc
to get the build working

mariadb-corporation/mariadb-connector-c@75d381ffb2bd183912759819bd60d685c015eeb9
reverted the change from CONC-710 in libmariadb to move Item_result
back to mariadb_com.h
    
This patch updates the server libmariadb version to include the
latest connector-c fix, and reverts the old temporary fix, so
mysqlbinlog uses Item_result from mariadb_com.h again.

It was initially tested locally by compiling and running MTR with an
updated `libmariadb` submodule, and then verified via CI runs,
e.g. [this](https://buildbot.mariadb.org/#/builders/369/builds/27816) build
