### PR TITLE
Update WolfSSL to the latest release 5.7.6

### DIFF
--- a/extra/wolfssl/CMakeLists.txt
+++ b/extra/wolfssl/CMakeLists.txt
@@ -130,6 +130,8 @@ if(MSVC)
   if(CMAKE_C_COMPILER_ID MATCHES Clang)
     target_compile_options(wolfssl PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-incompatible-function-pointer-types>)
   endif()
+  target_compile_definitions(wolfssl PRIVATE
+    _CRT_USE_CONFORMING_ANNEX_K_TIME HAVE_GMTIME_S WOLFSSL_HAVE_MIN WOLFSSL_HAVE_MAX)
 endif()
 
 CONFIGURE_FILE(user_settings.h.in user_settings.h)

--- a/extra/wolfssl/user_settings.h.in
+++ b/extra/wolfssl/user_settings.h.in
@@ -3,7 +3,21 @@
 
 #define HAVE_CRL
 #define WOLFSSL_HAVE_ERROR_QUEUE
+
+/*
+ Workaround bug in 5.7.6
+ WOLFSSL_MYSQL_COMPATIBLE breaks building wolfssl
+
+ But it is needed to avoid redefinition of protocol_version
+ when its public header ssl.h is included
+*/
+#ifndef BUILDING_WOLFSSL
 #define WOLFSSL_MYSQL_COMPATIBLE
+#endif
+
+#define SP_INT_BITS 8192
+#define HAVE_EMPTY_AGGREGATES 0
+
 #define HAVE_ECC
 #define ECC_TIMING_RESISTANT
 #define HAVE_HASHDRBG
@@ -24,7 +38,8 @@
 #define HAVE_THREAD_LS
 #define WOLFSSL_AES_COUNTER
 #define NO_WOLFSSL_STUB
-#define OPENSSL_ALL
+// #define OPENSSL_ALL
+#define OPENSSL_EXTRA
 #define WOLFSSL_ALLOW_TLSV10
 #define NO_OLD_TIMEVAL_NAME
 #define HAVE_SECURE_RENEGOTIATION


### PR DESCRIPTION
Workaround build bugs with preprocessor flags du-jour

1. OPENSSL_ALL does not work anymore (error in ssl.h) nor WOLFSSL_MYSQL_COMPATIBLE, would work, when building library.

2. OPENSSL_EXTRA has to be used instead of OPENSSL_ALL now. WOLFSSL_MYSQL_COMPATIBLE needs to be used to workaround their conflicting definition of protocol_version, which is used in server code.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Upgrade WolfSSL submodule

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

By building and testing server on platforms where wolfssl is built.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
