### PR TITLE
MDEV-35169  ALTER TABLE...IMPORT TABLESPACE does not work with INDEX DESC

### DIFF
--- a/mysql-test/suite/innodb/r/import_cfg.result
+++ b/mysql-test/suite/innodb/r/import_cfg.result
@@ -1,0 +1,67 @@
+#
+#  MDEV-35169 ALTER TABLE...IMPORT TABLESPACE does not
+#		work with INDEX DESC
+#
+# prepare cfg for primary key with desc column
+create table t1 (pk int, a int, primary key(pk desc)) engine=InnoDB;
+insert into t1 values (1,10),(2,20),(3,15);
+flush table t1 for export;
+unlock tables;
+drop table t1;
+# prepare cfg for secondary index with desc column
+create table t1 (pk int primary key, a int,key(a desc)) engine=InnoDB;
+insert into t1 values (1,10),(2,20),(3,15);
+flush table t1 for export;
+unlock tables;
+drop table t1;
+# prepare cfg for secondary index with ascending column
+create table t1 (pk int primary key, a int, key(a)) engine=InnoDB;
+insert into t1 values (1,10),(2,20),(3,15);
+flush table t1 for export;
+unlock tables;
+drop table t1;
+# Import desc tablespace into desc frm
+# Import into table with desc primary key column
+create table t1 (pk int, a int, primary key(pk desc)) engine=InnoDB;
+alter table t1 discard tablespace;
+alter table t1 import tablespace;
+check table t1 extended;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+drop table t1;
+# Import into table with desc secondary index
+create table t1 (pk int primary key, a int, key(a desc))engine=InnoDB;
+alter table t1 discard tablespace;
+alter table t1 import tablespace;
+check table t1 extended;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+drop table t1;
+# Import asc tablespace into desc frm
+create table t1 (pk int primary key, a int, key(a desc))engine=InnoDB;
+alter table t1 discard tablespace;
+alter table t1 import tablespace;
+ERROR HY000: Schema mismatch (Index a field a is DESC which does not match with .cfg file)
+check table t1 extended;
+Table	Op	Msg_type	Msg_text
+test.t1	check	Error	Tablespace has been discarded for table `t1`
+test.t1	check	error	Corrupt
+drop table t1;
+# Import desc tablespace into asc frm
+create table t1 (pk int primary key, a int, key(a)) engine=InnoDB;
+alter table t1 discard tablespace;
+alter table t1 import tablespace;
+ERROR HY000: Schema mismatch (Index a field a is ASC which does not match with .cfg file)
+check table t1 extended;
+Table	Op	Msg_type	Msg_text
+test.t1	check	Error	Tablespace has been discarded for table `t1`
+test.t1	check	error	Corrupt
+drop table t1;
+# Import asc tablespace into asc frm
+create table t1 (pk int primary key, a int, key(a)) engine=InnoDB;
+alter table t1 discard tablespace;
+alter table t1 import tablespace;
+check table t1 extended;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+drop table t1;

--- a/mysql-test/suite/innodb/r/innodb-wl5522-debug.result
+++ b/mysql-test/suite/innodb/r/innodb-wl5522-debug.result
@@ -158,16 +158,6 @@ SET SESSION debug_dbug=@saved_debug_dbug;
 DROP TABLE t1;
 CREATE TABLE t1 (c1 INT) ENGINE = Innodb;
 INSERT INTO t1 VALUES (1);
-SET SESSION debug_dbug="+d,ib_export_io_write_failure_9";
-FLUSH TABLES t1 FOR EXPORT;
-Warnings:
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flush() failed
-Warning	1811	IO Write error: (9, Bad file descriptor) t1.cfg flose() failed
-UNLOCK TABLES;
-SET SESSION debug_dbug=@saved_debug_dbug;
-DROP TABLE t1;
-CREATE TABLE t1 (c1 INT) ENGINE = Innodb;
-INSERT INTO t1 VALUES (1);
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_10";
 FLUSH TABLES t1 FOR EXPORT;
 Warnings:

--- a/mysql-test/suite/innodb/t/import_cfg.test
+++ b/mysql-test/suite/innodb/t/import_cfg.test
@@ -1,0 +1,83 @@
+--source include/have_innodb.inc
+--let $datadir= `select @@datadir`
+
+--echo #
+--echo #  MDEV-35169 ALTER TABLE...IMPORT TABLESPACE does not
+--echo #		work with INDEX DESC
+--echo #
+
+--echo # prepare cfg for primary key with desc column
+create table t1 (pk int, a int, primary key(pk desc)) engine=InnoDB;
+insert into t1 values (1,10),(2,20),(3,15);
+flush table t1 for export;
+--copy_file $datadir/test/t1.ibd $datadir/test/t1_pk.ibd.desc
+--copy_file $datadir/test/t1.cfg $datadir/test/t1_pk.cfg.desc
+unlock tables;
+drop table t1;
+
+--echo # prepare cfg for secondary index with desc column
+create table t1 (pk int primary key, a int,key(a desc)) engine=InnoDB;
+insert into t1 values (1,10),(2,20),(3,15);
+flush table t1 for export;
+--copy_file $datadir/test/t1.ibd $datadir/test/t1.ibd.desc
+--copy_file $datadir/test/t1.cfg $datadir/test/t1.cfg.desc
+unlock tables;
+drop table t1;
+
+--echo # prepare cfg for secondary index with ascending column
+create table t1 (pk int primary key, a int, key(a)) engine=InnoDB;
+insert into t1 values (1,10),(2,20),(3,15);
+flush table t1 for export;
+--copy_file $datadir/test/t1.ibd $datadir/test/t1.ibd.asc
+--copy_file $datadir/test/t1.cfg $datadir/test/t1.cfg.asc
+unlock tables;
+drop table t1;
+
+--echo # Import desc tablespace into desc frm
+
+--echo # Import into table with desc primary key column
+create table t1 (pk int, a int, primary key(pk desc)) engine=InnoDB;
+alter table t1 discard tablespace;
+--copy_file $datadir/test/t1_pk.ibd.desc $datadir/test/t1.ibd
+--copy_file $datadir/test/t1_pk.cfg.desc $datadir/test/t1.cfg
+alter table t1 import tablespace;
+check table t1 extended;
+drop table t1;
+
+--echo # Import into table with desc secondary index
+create table t1 (pk int primary key, a int, key(a desc))engine=InnoDB;
+alter table t1 discard tablespace;
+--copy_file $datadir/test/t1.ibd.desc $datadir/test/t1.ibd
+--copy_file $datadir/test/t1.cfg.desc $datadir/test/t1.cfg
+alter table t1 import tablespace;
+check table t1 extended;
+drop table t1;
+
+--echo # Import asc tablespace into desc frm
+create table t1 (pk int primary key, a int, key(a desc))engine=InnoDB;
+alter table t1 discard tablespace;
+--copy_file $datadir/test/t1.ibd.asc $datadir/test/t1.ibd
+--copy_file $datadir/test/t1.cfg.asc $datadir/test/t1.cfg
+--error ER_TABLE_SCHEMA_MISMATCH
+alter table t1 import tablespace;
+check table t1 extended;
+drop table t1;
+
+--echo # Import desc tablespace into asc frm
+create table t1 (pk int primary key, a int, key(a)) engine=InnoDB;
+alter table t1 discard tablespace;
+--copy_file $datadir/test/t1.ibd.desc $datadir/test/t1.ibd
+--copy_file $datadir/test/t1.cfg.desc $datadir/test/t1.cfg
+--error ER_TABLE_SCHEMA_MISMATCH
+alter table t1 import tablespace;
+check table t1 extended;
+drop table t1;
+
+--echo # Import asc tablespace into asc frm
+create table t1 (pk int primary key, a int, key(a)) engine=InnoDB;
+alter table t1 discard tablespace;
+--copy_file $datadir/test/t1.ibd.asc $datadir/test/t1.ibd
+--copy_file $datadir/test/t1.cfg.asc $datadir/test/t1.cfg
+alter table t1 import tablespace;
+check table t1 extended;
+drop table t1;

--- a/mysql-test/suite/innodb/t/innodb-wl5522-debug.test
+++ b/mysql-test/suite/innodb/t/innodb-wl5522-debug.test
@@ -283,22 +283,6 @@ DROP TABLE t1;
 CREATE TABLE t1 (c1 INT) ENGINE = Innodb;
 INSERT INTO t1 VALUES (1);
 
-SET SESSION debug_dbug="+d,ib_export_io_write_failure_9";
-
---replace_regex /, .*\).*t1.cfg/, Bad file descriptor) t1.cfg/
-
-FLUSH TABLES t1 FOR EXPORT;
-
-UNLOCK TABLES;
-
-SET SESSION debug_dbug=@saved_debug_dbug;
-
-DROP TABLE t1;
-
-
-CREATE TABLE t1 (c1 INT) ENGINE = Innodb;
-INSERT INTO t1 VALUES (1);
-
 SET SESSION debug_dbug="+d,ib_export_io_write_failure_10";
 
 --replace_regex /, .*\).*t1.cfg/, Bad file descriptor) t1.cfg/

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -1213,6 +1213,16 @@ row_import::match_index_columns(
 
 			err = DB_ERROR;
 		}
+
+		if (cfg_field->descending != field->descending) {
+			ib_errf(thd, IB_LOG_LEVEL_ERROR,
+				ER_TABLE_SCHEMA_MISMATCH,
+				"Index %s field %s is %s which does "
+				"not match with .cfg file",
+				index->name(), field->name(),
+				field->descending ? "DESC" : "ASC");
+			err = DB_ERROR;
+		}
 	}
 
 	return(err);
@@ -2557,7 +2567,11 @@ row_import_cfg_read_index_fields(
 		field->prefix_len = mach_read_from_4(ptr) & ((1U << 12) - 1);
 		ptr += sizeof(ib_uint32_t);
 
-		field->fixed_len = mach_read_from_4(ptr) & ((1U << 10) - 1);
+		uint32_t fixed_len = mach_read_from_4(ptr);
+
+		field->descending = bool(fixed_len >> 31);
+
+		field->fixed_len = fixed_len & ((1U << 10) - 1);
 		ptr += sizeof(ib_uint32_t);
 
 		/* Include the NUL byte in the length. */

--- a/storage/innobase/row/row0quiesce.cc
+++ b/storage/innobase/row/row0quiesce.cc
@@ -47,45 +47,38 @@ row_quiesce_write_index_fields(
 	FILE*			file,	/*!< in: file to write to */
 	THD*			thd)	/*!< in/out: session */
 {
-	byte			row[sizeof(ib_uint32_t) * 2];
+	byte			row[sizeof(ib_uint32_t) * 3];
 
 	for (ulint i = 0; i < index->n_fields; ++i) {
 		byte*			ptr = row;
 		const dict_field_t*	field = &index->fields[i];
 
 		mach_write_to_4(ptr, field->prefix_len);
-		ptr += sizeof(ib_uint32_t);
+		ptr += 4;
 
-		mach_write_to_4(ptr, field->fixed_len);
-
-		DBUG_EXECUTE_IF("ib_export_io_write_failure_9",
-				close(fileno(file)););
-
-		if (fwrite(row, 1, sizeof(row), file) != sizeof(row)) {
-
-			ib_senderrf(
-				thd, IB_LOG_LEVEL_WARN, ER_IO_WRITE_ERROR,
-				(ulong) errno, strerror(errno),
-				"while writing index fields.");
-
-			return(DB_IO_ERROR);
-		}
+		/* Since maximum fixed length can be
+		DICT_ANTELOPE_MAX_INDEX_COL_LEN, InnoDB
+		can use the 0th bit to store the
+		field descending information */
+		mach_write_to_4(ptr, field->fixed_len
+				     | uint32_t(field->descending) << 31);
+		ptr += 4;
 
 		const char* field_name = field->name ? field->name : "";
 		/* Include the NUL byte in the length. */
-		ib_uint32_t	len = static_cast<ib_uint32_t>(strlen(field_name) + 1);
-		mach_write_to_4(row, len);
+		uint32_t	len = uint32_t(strlen(field_name) + 1);
+		mach_write_to_4(ptr, len);
 
 		DBUG_EXECUTE_IF("ib_export_io_write_failure_10",
 				close(fileno(file)););
 
-		if (fwrite(row, 1,  sizeof(len), file) != sizeof(len)
+		if (fwrite(row, 1, sizeof(row), file) != sizeof(row)
 		    || fwrite(field_name, 1, len, file) != len) {
 
 			ib_senderrf(
 				thd, IB_LOG_LEVEL_WARN, ER_IO_WRITE_ERROR,
 				(ulong) errno, strerror(errno),
-				"while writing index column.");
+				"while writing index fields.");
 
 			return(DB_IO_ERROR);
 		}


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35169*

## Description
Problem:
=======
- Import tablespace fails to check the index fields descending property while matching the schema given in cfg file with the table schema.

Fix:
===
- Introduce the new version format for the cfg file which has the descending bool information for all index fields

row_import_cfg_read_index_fields(): Read the field descending property from cfg file depends on the config version

row_quiesce_write_index_fields(): Write the descending property of the index fields into cfg file

## How can this PR be tested?
./mtr innodb.import_cfg --mem
Basically which does create old version cfg file and import tablespace with old cfg file

Taken the cfg file from 10.11 (with patch) and tried to run it in 10.6, tested how it behaves:


```
primary key with descending field in 10.6
=========================================
MariaDB [test]> create table t1_pk_desc(f1 int not null, f2 int not null, primary key(f1 desc))engine=innodb;
Query OK, 0 rows affected (0.015 sec)

MariaDB [test]> alter table t1_pk_desc discard tablespace;
Query OK, 0 rows affected (0.018 sec)


MariaDB [test]> alter table t1_pk_desc import tablespace;
Query OK, 0 rows affected (0.030 sec)

MariaDB [test]> check table t1_pk_desc;
+-----------------+-------+----------+---------------------------------------------------+
| Table           | Op    | Msg_type | Msg_text                                          |
+-----------------+-------+----------+---------------------------------------------------+
| test.t1_pk_desc | check | Warning  | InnoDB: The B-tree of index PRIMARY is corrupted. |
| test.t1_pk_desc | check | error    | Corrupt                                           |
+-----------------+-------+----------+---------------------------------------------------+
2 rows in set (0.013 sec)

MariaDB [test]> alter table t1_pk_desc force;
ERROR 1177 (42000): Can't open table

Avoided check table and tried table rebuild directly:
===========================================
MariaDB [test]> alter table t1_pk_desc import tablespace;
Query OK, 0 rows affected (0.030 sec)

MariaDB [test]> alter table t1_pk_desc force;
ERROR 2013 (HY000): Lost connection to server during query

mysqld: /home/thiru/source_file/server/10.6/storage/innobase/btr/btr0bulk.cc:173: void PageBulk::insertPage(rec_t*, rec_offs*) [with format <anonymous> = PageBulk::DYNAMIC; rec_t = unsigned char; rec_offs = short unsigned int]: Assertion `cmp_rec_rec(rec, old_rec, offsets, old_offsets, m_index) > 0' failed

Tried copy algorithm
===================

MariaDB [test]> alter table t1_pk_desc force, algorithm=copy;
Query OK, 2 rows affected (0.043 sec)              
Records: 2  Duplicates: 0  Warnings: 0

MariaDB [test]> check table t1_pk_desc extended;
+-----------------+-------+----------+----------+
| Table           | Op    | Msg_type | Msg_text |
+-----------------+-------+----------+----------+
| test.t1_pk_desc | check | status   | OK       |
+-----------------+-------+----------+----------+
1 row in set (0.016 sec)

Table with secondary index of descending field:
===============================================

MariaDB [test]> create table t1_sec_desc(f1 int not null, f2 int not null, primary key(f1), index(f2 desc))engine=innodb;
Query OK, 0 rows affected (0.028 sec)

MariaDB [test]> alter table t1_sec_desc discard tablespace;
Query OK, 0 rows affected (0.019 sec)

MariaDB [test]> alter table t1_sec_desc import tablespace;
Query OK, 0 rows affected (0.026 sec)

MariaDB [test]> check table t1_sec_desc extended;
+------------------+-------+----------+----------------------------------------------+
| Table            | Op    | Msg_type | Msg_text                                     |
+------------------+-------+----------+----------------------------------------------+
| test.t1_sec_desc | check | Warning  | InnoDB: The B-tree of index f2 is corrupted. |
| test.t1_sec_desc | check | error    | Corrupt                                      |
+------------------+-------+----------+----------------------------------------------+
2 rows in set (0.011 sec)

MariaDB [test]> alter table t1_sec_desc drop index f2;
Query OK, 0 rows affected (0.026 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [test]> alter table t1_sec_desc add index(f2 desc);
Query OK, 0 rows affected (0.025 sec)
Records: 0  Duplicates: 0  Warnings: 0

MariaDB [test]> select * from t1_sec_desc use index(f2);
+----+----+
| f1 | f2 |
+----+----+
|  4 |  1 |
|  2 |  3 |
+----+----+
2 rows in set (0.006 sec)

Table with no desc index:
=========================

MariaDB [test]> create table t1(f1 int not null, f2 int not null, primary key (f1), index(f2))engine=innodb;
Query OK, 0 rows affected (0.021 sec)

MariaDB [test]> alter table t1 discard tablespace;
Query OK, 0 rows affected (0.020 sec)

MariaDB [test]> alter table t1 import tablespace;
Query OK, 0 rows affected (0.024 sec)

MariaDB [test]> check table t1 extended;
+---------+-------+----------+----------+
| Table   | Op    | Msg_type | Msg_text |
+---------+-------+----------+----------+
| test.t1 | check | status   | OK       |
+---------+-------+----------+----------+
1 row in set (0.011 sec)

MariaDB [test]> select * from t1;
+----+----+
| f1 | f2 |
+----+----+
|  1 |  3 |
|  2 |  3 |
+----+----+
2 rows in set (0.002 sec)
```

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
