### PR TITLE
MDEV-36366 - cmake(libfmt): use find_package to find libfmt

### DIFF
--- a/cmake/libfmt.cmake
+++ b/cmake/libfmt.cmake
@@ -1,5 +1,6 @@
 INCLUDE (CheckCXXSourceRuns)
 INCLUDE (ExternalProject)
+FIND_PACKAGE(fmt QUIET)
 
 SET(WITH_LIBFMT "auto" CACHE STRING
    "Which libfmt to use (possible values are 'bundled', 'system', or 'auto')")
@@ -24,23 +25,33 @@ MACRO(BUNDLE_LIBFMT)
   )
 ENDMACRO()
 
-MACRO (CHECK_LIBFMT)
-  IF(WITH_LIBFMT STREQUAL "system" OR WITH_LIBFMT STREQUAL "auto")
-    SET(CMAKE_REQUIRED_INCLUDES ${LIBFMT_INCLUDE_DIR})
-    CHECK_CXX_SOURCE_RUNS(
-    "#define FMT_STATIC_THOUSANDS_SEPARATOR ','
-     #define FMT_HEADER_ONLY 1
-     #include <fmt/args.h>
-     int main() {
-       using ArgStore= fmt::dynamic_format_arg_store<fmt::format_context>;
-       ArgStore arg_store;
-       int answer= 4321;
-       arg_store.push_back(answer);
-       return fmt::vformat(\"{:L}\", arg_store).compare(\"4,321\");
-     }" HAVE_SYSTEM_LIBFMT)
-    SET(CMAKE_REQUIRED_INCLUDES)
+MACRO(CHECK_LIBFMT)
+  IF (WITH_LIBFMT STREQUAL "system" OR WITH_LIBFMT STREQUAL "auto")
+    IF (fmt_FOUND)
+      MESSAGE(STATUS "Found system libfmt: ${fmt_VERSION}")
+      SET(HAVE_SYSTEM_LIBFMT 1)
+    ELSE()
+      MESSAGE(STATUS "Could NOT find system libfmt via config; trying compile test.")
+
+      SET(CMAKE_REQUIRED_INCLUDES "${LIBFMT_INCLUDE_DIR}")
+      CHECK_CXX_SOURCE_RUNS(
+        "#define FMT_STATIC_THOUSANDS_SEPARATOR ','
+         #define FMT_HEADER_ONLY 1
+         #include <fmt/args.h>
+         int main() {
+           using ArgStore= fmt::dynamic_format_arg_store<fmt::format_context>;
+           ArgStore arg_store;
+           int answer= 4321;
+           arg_store.push_back(answer);
+           return fmt::vformat(\"{:L}\", arg_store).compare(\"4,321\");
+         }"
+        HAVE_SYSTEM_LIBFMT
+      )
+      SET(CMAKE_REQUIRED_INCLUDES)
+    ENDIF()
   ENDIF()
-  IF(NOT HAVE_SYSTEM_LIBFMT OR WITH_LIBFMT STREQUAL "bundled")
+
+  IF (NOT HAVE_SYSTEM_LIBFMT OR WITH_LIBFMT STREQUAL "bundled")
     IF (WITH_LIBFMT STREQUAL "system")
       MESSAGE(FATAL_ERROR "system libfmt library is not found or unusable")
     ENDIF()


### PR DESCRIPTION
## Description
TODO: fill description here

This patch improves libfmt detection by calling find_package(fmt QUIET) first when WITH_LIBFMT is set to system or auto. If a system libfmt is located successfully, we skip the custom source-compile snippet. Otherwise, we proceed with the old detection logic (compile test) and finally fall back to the bundled library if needed. This change makes it easier for package managers (e.g., Homebrew) or system environments that already have a modern fmt installed to integrate with MariaDB, without having to override CMake variables manually.

Before this patch, the logic always set CMAKE_REQUIRED_INCLUDES to the bundled copy’s include directory and ran a snippet test, failing if the user had removed or disabled the bundled directory. Now, if a system installation is discoverable via CMake config files, MariaDB can be built cleanly against that library.

## Release Notes

- Enhancement: MariaDB can now detect and use system-provided libfmt more reliably when WITH_LIBFMT is system or auto. If find_package(fmt) succeeds, the bundled fallback is skipped, ensuring smoother packaging in environments providing up-to-date versions of libfmt.

No system variables or status variables were changed. No existing behavior changed aside from this improvement in build-time detection of libfmt.

## How can this PR be tested?

homebrew PRs

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.


---

relates to:
- https://github.com/Homebrew/homebrew-core/pull/205321
- https://github.com/Homebrew/homebrew-core/pull/205322