### PR TITLE
MDEV-21375: Get option group suffix from $MARIADB_GROUP_SUFFIX in addition to $MYSQL_GROUP_SUFFIX

### DIFF
--- a/mysys/my_default.c
+++ b/mysys/my_default.c
@@ -318,6 +318,9 @@ int get_defaults_options(char **argv)
   }
 
   if (! my_defaults_group_suffix)
+    my_defaults_group_suffix= getenv("MARIADB_GROUP_SUFFIX");
+
+  if (! my_defaults_group_suffix)
     my_defaults_group_suffix= getenv("MYSQL_GROUP_SUFFIX");
 
   if (my_defaults_extra_file && my_defaults_extra_file != extra_file_buffer)


### PR DESCRIPTION
## Description
Currently, if the `--default-group-suffix` argument is not passed when initializing
an instance of MariaDB, the `MYSQL_GROUP_SUFFIX` environment variable, if set, is used to specify the group suffix. 

Add an additional check for the `MARIADB_GROUP_SUFFIX` environment variable before checking for `MYSQL_GROUP_SUFFIX`. This environment variable will take precedence over the `MYSQL_GROUP_SUFFIX` if both are set, with the goal of furthering MariaDB's branding. 

This behaviour is consistent with how `MARIADB_HOME` is checked before `MYSQL_HOME` ([MDEV-21365](https://jira.mariadb.org/browse/MDEV-21365)). 

## Release Notes
N/A 

## How can this PR be tested?
Create a custom config file with at least two different suffix groups.  
For example:
`test.cnf`
```
[mysqld]
max_connections=100

[mysqld_test1]
max_connections=300

[mysqld_test2]
max_connections=500
```
Set the `MARIADB_GROUP_SUFFIX` and `MYSQL_GROUP_SUFFIX` environment variables:
```
export MARIADB_GROUP_SUFFIX=_test1
export MYSQL_GROUP_SUFFIX=_test2
```
Start the server, passing in the config file:
```
./build/sql/mariadbd --defaults-file=./my-test.cnf --datadir=./data --user=username &
``` 
Run the client:
```
./build/client/mariadb -u root
```
Run the appropriate query:
```
MariaDB [(none)]> SHOW VARIABLES LIKE 'max_connections';
+-----------------+-------+
| Variable_name   | Value |
+-----------------+-------+
| max_connections | 300   |
+-----------------+-------+
```
## Basing the PR against the correct MariaDB version
- [x] _This is a new feature and the PR is based against the latest MariaDB development branch._

## Copyright
All new code of the whole pull request, including one or several files that are
either new files or modified ones, are contributed under the BSD-new license. I
am contributing on behalf of my employer Amazon Web Services, Inc.