### PR TITLE
MDEV-31334: Consider dates ending in 'T' as malformed

### DIFF
--- a/mysql-test/main/func_extract.result
+++ b/mysql-test/main/func_extract.result
@@ -368,6 +368,8 @@ EXTRACT(DAY FROM '01-02-03')
 SELECT EXTRACT(DAY FROM '24:02:03T');
 EXTRACT(DAY FROM '24:02:03T')
 3
+Warnings:
+Warning	1292	Truncated incorrect date value: '24:02:03T'
 SELECT EXTRACT(DAY FROM '24-02-03');
 EXTRACT(DAY FROM '24-02-03')
 3
@@ -380,33 +382,63 @@ EXTRACT(DAY FROM '11111')
 SELECT TIME('2001-01-01T'), TIME('2001-01-01T ');
 TIME('2001-01-01T')	TIME('2001-01-01T ')
 00:00:00	00:00:00
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001-01-01T'
+Warning	1292	Truncated incorrect date value: '2001-01-01T '
 SELECT TIME('2001/01/01T'), TIME('2001/01/01T ');
 TIME('2001/01/01T')	TIME('2001/01/01T ')
 00:00:00	00:00:00
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001/01/01T'
+Warning	1292	Truncated incorrect date value: '2001/01/01T '
 SELECT TIME('2001:01:01T'), TIME('2001:01:01T ');
 TIME('2001:01:01T')	TIME('2001:01:01T ')
 00:00:00	00:00:00
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001:01:01T'
+Warning	1292	Truncated incorrect date value: '2001:01:01T '
 SELECT EXTRACT(DAY FROM '2001-01-01T'), EXTRACT(DAY FROM '2001-01-01T ');
 EXTRACT(DAY FROM '2001-01-01T')	EXTRACT(DAY FROM '2001-01-01T ')
 1	1
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001-01-01T'
+Warning	1292	Truncated incorrect date value: '2001-01-01T '
 SELECT EXTRACT(DAY FROM '2001/01/01T'), EXTRACT(DAY FROM '2001/01/01T ');
 EXTRACT(DAY FROM '2001/01/01T')	EXTRACT(DAY FROM '2001/01/01T ')
 1	1
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001/01/01T'
+Warning	1292	Truncated incorrect date value: '2001/01/01T '
 SELECT EXTRACT(DAY FROM '2001:01:01T'), EXTRACT(DAY FROM '2001:01:01T ');
 EXTRACT(DAY FROM '2001:01:01T')	EXTRACT(DAY FROM '2001:01:01T ')
 1	1
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001:01:01T'
+Warning	1292	Truncated incorrect date value: '2001:01:01T '
 SELECT TIME('2001:01:01T'), TIME('2001:01:01T ');
 TIME('2001:01:01T')	TIME('2001:01:01T ')
 00:00:00	00:00:00
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001:01:01T'
+Warning	1292	Truncated incorrect date value: '2001:01:01T '
 SELECT EXTRACT(HOUR FROM '2001-01-01T'), EXTRACT(HOUR FROM '2001-01-01T ');
 EXTRACT(HOUR FROM '2001-01-01T')	EXTRACT(HOUR FROM '2001-01-01T ')
 0	0
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001-01-01T'
+Warning	1292	Truncated incorrect date value: '2001-01-01T '
 SELECT EXTRACT(HOUR FROM '2001/01/01T'), EXTRACT(HOUR FROM '2001/01/01T ');
 EXTRACT(HOUR FROM '2001/01/01T')	EXTRACT(HOUR FROM '2001/01/01T ')
 0	0
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001/01/01T'
+Warning	1292	Truncated incorrect date value: '2001/01/01T '
 SELECT EXTRACT(HOUR FROM '2001:01:01T'), EXTRACT(HOUR FROM '2001:01:01T ');
 EXTRACT(HOUR FROM '2001:01:01T')	EXTRACT(HOUR FROM '2001:01:01T ')
 0	0
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001:01:01T'
+Warning	1292	Truncated incorrect date value: '2001:01:01T '
 # This still parses as DATE and returns NULL (without trying TIME)
 SELECT EXTRACT(DAY FROM '100000:02:03T');
 EXTRACT(DAY FROM '100000:02:03T')

--- a/mysql-test/main/func_time.result
+++ b/mysql-test/main/func_time.result
@@ -6253,6 +6253,9 @@ Warning	1292	Truncated incorrect time value: '1 2 '
 SELECT TIME('2001-01-01T'), TIME('2001-01-01T ');
 TIME('2001-01-01T')	TIME('2001-01-01T ')
 00:00:00	00:00:00
+Warnings:
+Warning	1292	Truncated incorrect date value: '2001-01-01T'
+Warning	1292	Truncated incorrect date value: '2001-01-01T '
 SELECT TIME('901-01-01T1'), TIME('901-01-01T10');
 TIME('901-01-01T1')	TIME('901-01-01T10')
 01:00:00	10:00:00

--- a/mysql-test/main/strict.result
+++ b/mysql-test/main/strict.result
@@ -85,6 +85,27 @@ ERROR 22007: Incorrect date value: '2003-02-29' for column `test`.`t1`.`col1` at
 INSERT ignore INTO t1 VALUES('2003-02-30');
 Warnings:
 Warning	1265	Data truncated for column 'col1' at row 1
+INSERT INTO t1 VALUES('2001-01-01W');
+ERROR 22007: Incorrect date value: '2001-01-01W' for column `test`.`t1`.`col1` at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+ERROR 22007: Incorrect date value: '2001-01-01T' for column `test`.`t1`.`col1` at row 1
+set @@sql_mode='strict_all_tables';
+INSERT INTO t1 VALUES('2001-01-01W');
+ERROR 22007: Incorrect date value: '2001-01-01W' for column `test`.`t1`.`col1` at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+ERROR 22007: Incorrect date value: '2001-01-01T' for column `test`.`t1`.`col1` at row 1
+set @@sql_mode='strict_all_tables,strict_trans_tables';
+INSERT INTO t1 VALUES('2001-01-01W');
+ERROR 22007: Incorrect date value: '2001-01-01W' for column `test`.`t1`.`col1` at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+ERROR 22007: Incorrect date value: '2001-01-01T' for column `test`.`t1`.`col1` at row 1
+set @@sql_mode='';
+INSERT INTO t1 VALUES('2001-01-01W');
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
 set @@sql_mode='STRICT_ALL_TABLES,ALLOW_INVALID_DATES';
 INSERT ignore INTO t1 VALUES('2003-02-31');
 select * from t1;
@@ -95,6 +116,8 @@ col1
 0000-00-00
 2004-01-04
 0000-00-00
+2001-01-01
+2001-01-01
 2003-02-31
 drop table t1;
 set @@sql_mode='strict_trans_tables';
@@ -111,6 +134,27 @@ ERROR 22007: Incorrect date value: '2003-02-29' for column `test`.`t1`.`col1` at
 INSERT ignore INTO t1 VALUES('2003-02-30');
 Warnings:
 Warning	1265	Data truncated for column 'col1' at row 1
+INSERT INTO t1 VALUES('2001-01-01W');
+ERROR 22007: Incorrect date value: '2001-01-01W' for column `test`.`t1`.`col1` at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+ERROR 22007: Incorrect date value: '2001-01-01T' for column `test`.`t1`.`col1` at row 1
+set @@sql_mode='strict_all_tables';
+INSERT INTO t1 VALUES('2001-01-01W');
+ERROR 22007: Incorrect date value: '2001-01-01W' for column `test`.`t1`.`col1` at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+ERROR 22007: Incorrect date value: '2001-01-01T' for column `test`.`t1`.`col1` at row 1
+set @@sql_mode='strict_all_tables,strict_trans_tables';
+INSERT INTO t1 VALUES('2001-01-01W');
+ERROR 22007: Incorrect date value: '2001-01-01W' for column `test`.`t1`.`col1` at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+ERROR 22007: Incorrect date value: '2001-01-01T' for column `test`.`t1`.`col1` at row 1
+set @@sql_mode='';
+INSERT INTO t1 VALUES('2001-01-01W');
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
+INSERT INTO t1 VALUES('2001-01-01T');
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
 set @@sql_mode='STRICT_ALL_TABLES,ALLOW_INVALID_DATES';
 INSERT ignore INTO t1 VALUES('2003-02-31');
 select * from t1;
@@ -118,6 +162,8 @@ col1
 0000-00-00
 2004-01-04
 0000-00-00
+2001-01-01
+2001-01-01
 2003-02-31
 drop table t1;
 set @@sql_mode='ansi,traditional';

--- a/mysql-test/main/strict.test
+++ b/mysql-test/main/strict.test
@@ -77,6 +77,23 @@ INSERT IGNORE INTO t1 VALUES('2004-13-31'),('2004-1-4');
 --error 1292
 INSERT INTO t1 VALUES ('2003-02-29');
 INSERT ignore INTO t1 VALUES('2003-02-30');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01W');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01T');
+set @@sql_mode='strict_all_tables';
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01W');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01T');
+set @@sql_mode='strict_all_tables,strict_trans_tables';
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01W');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01T');
+set @@sql_mode='';
+INSERT INTO t1 VALUES('2001-01-01W');
+INSERT INTO t1 VALUES('2001-01-01T');
 set @@sql_mode='STRICT_ALL_TABLES,ALLOW_INVALID_DATES';
 INSERT ignore INTO t1 VALUES('2003-02-31');
 select * from t1;
@@ -92,6 +109,23 @@ INSERT IGNORE INTO t1 VALUES('2004-13-31'),('2004-1-4');
 --error 1292
 INSERT INTO t1 VALUES ('2003-02-29');
 INSERT ignore INTO t1 VALUES('2003-02-30');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01W');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01T');
+set @@sql_mode='strict_all_tables';
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01W');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01T');
+set @@sql_mode='strict_all_tables,strict_trans_tables';
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01W');
+--error 1292
+INSERT INTO t1 VALUES('2001-01-01T');
+set @@sql_mode='';
+INSERT INTO t1 VALUES('2001-01-01W');
+INSERT INTO t1 VALUES('2001-01-01T');
 set @@sql_mode='STRICT_ALL_TABLES,ALLOW_INVALID_DATES';
 INSERT ignore INTO t1 VALUES('2003-02-31');
 select * from t1;

--- a/sql-common/my_time.c
+++ b/sql-common/my_time.c
@@ -168,9 +168,20 @@ static int get_date_time_separator(uint *number_of_fields,
   if (s >= end)
     return 0;
 
+  /*
+    According to ISO_8601 - 2016
+    "
+    The character [T] shall be used as time designator to indicate the start of the	 
+    representation of the time of day  component in these expressions.
+    "
+  
+    That means that after T there *must* be a time component.
+  */
   if (*s == 'T')
   {
     (*str)++;
+    if (s + 1 >= end)
+      return 1;
     return 0;
   }
 


### PR DESCRIPTION
## Description

MariaDB 10.6 currently accepts dates that end in 'T' without a warning or error: for example '`insert into t1 values ("2003-02-05T")`'. This is an issue as ISO 8601 standards state that a 'T' should be followed by the time of day. Dates that terminate in 'T' should receive the same error in strict mode and warning otherwise as dates that terminate in any other (invalid) character. Commit includes bug fix and tests for dates ending in 'T'.

## How can this PR be tested?

Execute the main suite in mysql-test-run. This commit adds a test in that suite.

## Basing the PR against the correct MariaDB version

* [x] _This is a new feature and the PR is based against the latest MariaDB development branch_

## Backward compatibility

This is a new feature introducing stricter date formatting that will consider dates ending in 'T' as malformed and affect backwards compatibility.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.