### PR TITLE
MDEV-35921: s3.mysqldump fails in buildbot

### DIFF
--- a/mysql-test/suite/s3/mysqldump.result
+++ b/mysql-test/suite/s3/mysqldump.result
@@ -25,12 +25,14 @@ CREATE TABLE `t1` (
   PRIMARY KEY (`pk`)
 ) ENGINE=Aria DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci PAGE_CHECKSUM=1;
 /*!40101 SET character_set_client = @saved_cs_client */;
+set autocommit=0;
 INSERT INTO `t1` VALUES
 (1,1),
 (2,2),
 (3,3),
 (4,4);
 ALTER TABLE `t1` ENGINE=S3;
+commit;
 #####
 # mysqldump with --copy-s3-tables=1 XML
 ###


### PR DESCRIPTION
This is a fixup for MDEV-32250, introduced via
b24ecd7ca6b5d59be524d4e6413736dc88c26ee0, the test case was not recorded given the new mariadb-dump format.