### PR TITLE
MDEV-35937  InnoDB: Failing assertion: sym_node->table != NULL in pars_retrieve_table_def

### DIFF
--- a/mysql-test/suite/innodb_fts/r/innodb_fts_misc_1.result
+++ b/mysql-test/suite/innodb_fts/r/innodb_fts_misc_1.result
@@ -993,3 +993,18 @@ FTS_DOC_ID	f1	f2
 4294967298	txt	bbb
 100000000000	aaa	bbb
 DROP TABLE t1;
+#
+# MDEV-35937 sym_node->table != NULL in pars_retrieve_table_def
+#
+CREATE TABLE t1 (a TEXT ,FULLTEXT (a)) ENGINE=INNODB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+SET @save_ft = @@GLOBAL.innodb_ft_aux_table;
+SET GLOBAL innodb_ft_aux_table='test/t1';
+SELECT * FROM information_schema.innodb_ft_config;
+KEY	VALUE
+SELECT * FROM information_schema.innodb_ft_index_cache;
+WORD	FIRST_DOC_ID	LAST_DOC_ID	DOC_COUNT	DOC_ID	POSITION
+SELECT * FROM information_schema.innodb_ft_index_table;
+WORD	FIRST_DOC_ID	LAST_DOC_ID	DOC_COUNT	DOC_ID	POSITION
+DROP TABLE t1;
+SET GLOBAL innodb_ft_aux_table=@save_ft;

--- a/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.opt
+++ b/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.opt
@@ -1,1 +1,4 @@
 --innodb-ft-deleted
+--innodb-ft-config
+--innodb-ft-index-cache
+--innodb-ft-index-table

--- a/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.test
+++ b/mysql-test/suite/innodb_fts/t/innodb_fts_misc_1.test
@@ -960,3 +960,16 @@ CREATE FULLTEXT INDEX i ON t1 (f2);
 SELECT * FROM t1 WHERE match(f2) against("bbb");
 # Cleanup
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-35937 sym_node->table != NULL in pars_retrieve_table_def
+--echo #
+CREATE TABLE t1 (a TEXT ,FULLTEXT (a)) ENGINE=INNODB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+SET @save_ft = @@GLOBAL.innodb_ft_aux_table;
+SET GLOBAL innodb_ft_aux_table='test/t1';
+SELECT * FROM information_schema.innodb_ft_config;
+SELECT * FROM information_schema.innodb_ft_index_cache;
+SELECT * FROM information_schema.innodb_ft_index_table;
+DROP TABLE t1;
+SET GLOBAL innodb_ft_aux_table=@save_ft;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35937*

## Description
- InnoDB tries to fetch the metadata about fulltext index for discarded tablespace and fails for discarded tablespace.
In i_s_fts_config_fill(), i_s_fts_index_cache_fill() and i_s_fts_index_table_fill(), InnoDB needs to check whether
the tablespace is discarded or accessable before accessing the fulltext auxiliary table. This issue doesn't exist in
10.6+ version due to MDEV-19445(commit https://github.com/MariaDB/server/commit/0aa2bc7a94d96397e2e061dacb8ed04a32c13fa0)


## How can this PR be tested?
./mtr innodb_fts.innodb_fts_misc_1

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
