### PR TITLE
MDEV-33978 P_S.THREADS is not showing all server threads

### DIFF
--- a/mysql-test/suite/perfschema/r/threads_innodb.result
+++ b/mysql-test/suite/perfschema/r/threads_innodb.result
@@ -6,4 +6,5 @@ WHERE name LIKE 'thread/innodb/%'
 GROUP BY name;
 name	type	processlist_user	processlist_host	processlist_db	processlist_command	processlist_time	processlist_state	processlist_info	parent_thread_id	role	instrumented
 thread/innodb/page_cleaner_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
+thread/innodb/page_encrypt_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/thread_pool_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES

--- a/mysql-test/suite/perfschema/t/threads_innodb.opt
+++ b/mysql-test/suite/perfschema/t/threads_innodb.opt
@@ -1,0 +1,1 @@
+--innodb-encryption-threads=2

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -80,6 +80,10 @@ static uint n_fil_crypt_iops_allocated = 0;
 
 #define DEBUG_KEYROTATION_THROTTLING 0
 
+#ifdef UNIV_PFS_THREAD
+mysql_pfs_key_t page_encrypt_thread_key;
+#endif /* UNIV_PFS_THREAD */
+
 /** Statistics variables */
 static fil_crypt_stat_t crypt_stat;
 static ib_mutex_t crypt_stat_mutex;
@@ -2145,6 +2149,10 @@ extern "C" UNIV_INTERN
 os_thread_ret_t
 DECLARE_THREAD(fil_crypt_thread)(void*)
 {
+	my_thread_init();
+#ifdef UNIV_PFS_THREAD
+	pfs_register_thread(page_encrypt_thread_key);
+#endif /* UNIV_PFS_THREAD */
 	mutex_enter(&fil_crypt_threads_mutex);
 	uint thread_no = srv_n_fil_crypt_threads_started;
 	srv_n_fil_crypt_threads_started++;
@@ -2242,6 +2250,7 @@ DECLARE_THREAD(fil_crypt_thread)(void*)
 	/* We count the number of threads in os_thread_exit(). A created
 	thread should always use that to exit and not use return() to exit. */
 
+	my_thread_end();
 	return os_thread_exit();
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -579,6 +579,7 @@ performance schema instrumented if "UNIV_PFS_THREAD"
 is defined */
 static PSI_thread_info	all_innodb_threads[] = {
 	PSI_KEY(page_cleaner_thread),
+	PSI_KEY(page_encrypt_thread),
 	PSI_KEY(trx_rollback_clean_thread),
 	PSI_KEY(thread_pool_thread)
 };

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -469,6 +469,7 @@ extern ulong srv_buf_dump_status_frequency;
 
 # ifdef UNIV_PFS_THREAD
 extern mysql_pfs_key_t	page_cleaner_thread_key;
+extern mysql_pfs_key_t	page_encrypt_thread_key;
 extern mysql_pfs_key_t	trx_rollback_clean_thread_key;
 extern mysql_pfs_key_t	thread_pool_thread_key;
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33978*
## Description
`page_encrypt_thread_key`: The key for `fil_crypt_thread()`.

All other InnoDB threads should already have been registered for performance_schema ever since
commit a2f510fccff23e5011486c240587b8f1a98ecacc
## Release Notes
`PERFORMANCE_SCHEMA.THREADS` was not showing all InnoDB threads.
## How can this PR be tested?
```sh
./mtr perfschema.threads_innodb
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.