### PR TITLE
MDEV-33978 P_S.THREADS is not showing all server threads

### DIFF
--- a/mysql-test/suite/perfschema/r/threads_innodb.result
+++ b/mysql-test/suite/perfschema/r/threads_innodb.result
@@ -6,4 +6,5 @@ WHERE name LIKE 'thread/innodb/%'
 GROUP BY name;
 name	type	processlist_user	processlist_host	processlist_db	processlist_command	processlist_time	processlist_state	processlist_info	parent_thread_id	role	instrumented
 thread/innodb/page_cleaner_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
+thread/innodb/page_encrypt_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/thread_pool_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES

--- a/mysql-test/suite/perfschema/t/threads_innodb.opt
+++ b/mysql-test/suite/perfschema/t/threads_innodb.opt
@@ -1,0 +1,1 @@
+--innodb-encryption-threads=2

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -2007,10 +2007,18 @@ static void fil_crypt_complete_rotate_space(rotate_thread_t* state)
 	mysql_mutex_unlock(&crypt_data->mutex);
 }
 
+#ifdef UNIV_PFS_THREAD
+mysql_pfs_key_t page_encrypt_thread_key;
+#endif /* UNIV_PFS_THREAD */
+
 /** A thread which monitors global key state and rotates tablespaces
 accordingly */
 static void fil_crypt_thread()
 {
+	my_thread_init();
+#ifdef UNIV_PFS_THREAD
+	pfs_register_thread(page_encrypt_thread_key);
+#endif /* UNIV_PFS_THREAD */
 	mysql_mutex_lock(&fil_crypt_threads_mutex);
 	rotate_thread_t thr(srv_n_fil_crypt_threads_started++);
 	pthread_cond_signal(&fil_crypt_cond); /* signal that we started */
@@ -2088,6 +2096,7 @@ wait_for_work:
 	pthread_cond_signal(&fil_crypt_cond); /* signal that we stopped */
 	mysql_mutex_unlock(&fil_crypt_threads_mutex);
 
+	my_thread_end();
 #ifdef UNIV_PFS_THREAD
 	pfs_delete_thread();
 #endif

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -624,6 +624,7 @@ performance schema instrumented if "UNIV_PFS_THREAD"
 is defined */
 static PSI_thread_info	all_innodb_threads[] = {
 	PSI_KEY(page_cleaner_thread),
+	PSI_KEY(page_encrypt_thread),
 	PSI_KEY(trx_rollback_clean_thread),
 	PSI_KEY(thread_pool_thread)
 };

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -462,6 +462,7 @@ extern ulong srv_buf_dump_status_frequency;
 
 # ifdef UNIV_PFS_THREAD
 extern mysql_pfs_key_t	page_cleaner_thread_key;
+extern mysql_pfs_key_t	page_encrypt_thread_key;
 extern mysql_pfs_key_t	trx_rollback_clean_thread_key;
 extern mysql_pfs_key_t	thread_pool_thread_key;
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-33978*
## Description
`page_encrypt_thread_key`: The key for `fil_crypt_thread()`.

All other InnoDB threads should already have been registered for performance_schema ever since
commit a2f510fccff23e5011486c240587b8f1a98ecacc

This is a 10.6 version of #3791.
## Release Notes
`PERFORMANCE_SCHEMA.THREADS` was not showing all InnoDB threads.
## How can this PR be tested?
```sh
./mtr perfschema.threads_innodb
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.