### PR TITLE
MDEV-34591  InnoDB fails to rename index from lowercase to uppercase

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-index.result
+++ b/mysql-test/suite/innodb/r/innodb-index.result
@@ -1947,3 +1947,20 @@ Warnings:
 Warning	1082	InnoDB: Table test/t contains 0 indexes inside InnoDB, which is different from the number of indexes 1 defined in the MariaDB 
 Warning	1082	InnoDB: Table test/t contains 0 indexes inside InnoDB, which is different from the number of indexes 1 defined in the MariaDB 
 DROP TABLE t;
+CREATE TABLE t1 (a INT,b INT,KEY(b)) ENGINE=INNODB;
+ALTER TABLE t1 RENAME KEY b TO B;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) DEFAULT NULL,
+  KEY `B` (`b`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
+SELECT name FROM INFORMATION_SCHEMA.INNODB_SYS_INDEXES WHERE table_id IN (SELECT table_id FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE NAME="test/t1");
+name
+GEN_CLUST_INDEX
+B
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/innodb-index.opt
+++ b/mysql-test/suite/innodb/t/innodb-index.opt
@@ -1,0 +1,2 @@
+--innodb_sys_tables
+--innodb_sys_indexes

--- a/mysql-test/suite/innodb/t/innodb-index.test
+++ b/mysql-test/suite/innodb/t/innodb-index.test
@@ -1193,6 +1193,14 @@ SHOW CREATE TABLE t;
 --disable_prepare_warnings
 DROP TABLE t;
 
+# Rename the index from lowercase to uppercase
+CREATE TABLE t1 (a INT,b INT,KEY(b)) ENGINE=INNODB;
+ALTER TABLE t1 RENAME KEY b TO B;
+SHOW CREATE TABLE t1;
+SELECT name FROM INFORMATION_SCHEMA.INNODB_SYS_INDEXES WHERE table_id IN (SELECT table_id FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES WHERE NAME="test/t1");
+CHECK TABLE t1;
+DROP TABLE t1;
+
 --disable_query_log
 
 call mtr.add_suppression("InnoDB: Tablespace .* was not found at .*t[12].ibd.");

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7704,8 +7704,7 @@ static bool fill_alter_inplace_info(THD *thd, TABLE *table, bool varchar,
          new_key < new_key_end;
          new_key++)
     {
-      if (!lex_string_cmp(system_charset_info, &table_key->name,
-                          &new_key->name))
+      if (!strcmp(table_key->name.str, new_key->name.str))
         break;
     }
     if (new_key >= new_key_end)
@@ -7755,8 +7754,7 @@ static bool fill_alter_inplace_info(THD *thd, TABLE *table, bool varchar,
     /* Search an old key with the same name. */
     for (table_key= table->key_info; table_key < table_key_end; table_key++)
     {
-      if (!lex_string_cmp(system_charset_info, &table_key->name,
-                          &new_key->name))
+      if (!strcmp(table_key->name.str, new_key->name.str))
         break;
     }
     if (table_key >= table_key_end)
@@ -7788,9 +7786,7 @@ static bool fill_alter_inplace_info(THD *thd, TABLE *table, bool varchar,
         continue;
       }
 
-      DBUG_ASSERT(
-          lex_string_cmp(system_charset_info, &old_key->name, &new_key->name));
-
+      DBUG_ASSERT(strcmp(old_key->name.str, new_key->name.str));
       ha_alter_info->handler_flags|= ALTER_RENAME_INDEX;
       ha_alter_info->rename_keys.push_back(
           Alter_inplace_info::Rename_key_pair(old_key, new_key));


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34591*

## Description
- InnoDB fails to rename the index when there is a case conversion. Problem is that server fails to fill the inplace alter information about the renaming of index before sending it to InnoDB.

fill_alter_inplace_info(): Should check strcmp instead of lex_string_cmp() for comparing the index name.


## How can this PR be tested?
./mtr innodb.innodb-index

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
