### PR TITLE
MDEV-35948: Test OG `replicate_*`s with long lists

### DIFF
--- a/mysql-test/suite/sys_vars/r/replicate_do_db_basic.result
+++ b/mysql-test/suite/sys_vars/r/replicate_do_db_basic.result
@@ -1,3 +1,4 @@
+CHANGE MASTER TO master_host='example.com';
 #
 # Basic testing of replicate_do_db.
 #
@@ -17,6 +18,20 @@ SET @@GLOBAL.replicate_do_db=1.1;
 ERROR 42000: Incorrect argument type to variable 'replicate_do_db'
 SET @@GLOBAL.replicate_do_db=1e1;
 ERROR 42000: Incorrect argument type to variable 'replicate_do_db'
+# Argument size acceptance.
+SELECT GROUP_CONCAT(CONCAT("database_name_", seq) SEPARATOR ",")
+INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+LENGTH(@name)
+127
+SET @@GLOBAL.replicate_do_db= @name;
+SELECT @@GLOBAL.replicate_do_db;
+@@GLOBAL.replicate_do_db
+database_name_1,database_name_2,database_name_3,database_name_4,database_name_5,database_name_6,database_name_7,database_name_8
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_db';
+VARIABLE_VALUE
+database_name_1,database_name_2,database_name_3,database_name_4,database_name_5,database_name_6,database_name_7,database_name_8
+Replicate_Do_DB = 'database_name_1,database_name_2,database_name_3,database_name_4,database_name_5,database_name_6,database_name_7,database_name_8'
 # Argument syntax.
 SET @@GLOBAL.replicate_do_db="db1,,,,,db3";
 SELECT @@GLOBAL.replicate_do_db;
@@ -25,6 +40,7 @@ db1,db3
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_db';
 VARIABLE_NAME	VARIABLE_VALUE
 REPLICATE_DO_DB	db1,db3
+Replicate_Do_DB = 'db1,db3'
 SET @@GLOBAL.replicate_do_db="db1,,,db2,,,db3";
 SELECT @@GLOBAL.replicate_do_db;
 @@GLOBAL.replicate_do_db
@@ -42,4 +58,5 @@ SELECT @@GLOBAL.replicate_do_db;
 @@GLOBAL.replicate_do_db
 
 # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_do_db = @save_replicate_do_db;

--- a/mysql-test/suite/sys_vars/r/replicate_do_table_basic.result
+++ b/mysql-test/suite/sys_vars/r/replicate_do_table_basic.result
@@ -1,3 +1,4 @@
+CHANGE MASTER TO master_host='example.com';
 #
 # Basic testing of replicate_do_table.
 #
@@ -24,6 +25,20 @@ SET @@GLOBAL.replicate_do_table="test.t1, t2";
 ERROR HY000: Incorrect arguments to SET
 SET @@GLOBAL.replicate_do_table="test.,t1";
 ERROR HY000: Incorrect arguments to SET
+# Argument size acceptance.
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+LENGTH(@name)
+255
+SET @@GLOBAL.replicate_do_table= @name;
+SELECT @@GLOBAL.replicate_do_table;
+@@GLOBAL.replicate_do_table
+database_name.long_table_name_5,database_name.long_table_name_1,database_name.long_table_name_6,database_name.long_table_name_2,database_name.long_table_name_7,database_name.long_table_name_3,database_name.long_table_name_8,database_name.long_table_name_4
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_table';
+VARIABLE_VALUE
+database_name.long_table_name_5,database_name.long_table_name_1,database_name.long_table_name_6,database_name.long_table_name_2,database_name.long_table_name_7,database_name.long_table_name_3,database_name.long_table_name_8,database_name.long_table_name_4
+Replicate_Do_Table = 'database_name.long_table_name_5,database_name.long_table_name_1,database_name.long_table_name_6,database_name.long_table_name_2,database_name.long_table_name_7,database_name.long_table_name_3,database_name.long_table_name_8,database_name.long_table_name_4'
 # Argument syntax.
 SET @@GLOBAL.replicate_do_table="test.t1,,,,,test.t3";
 SELECT @@GLOBAL.replicate_do_table;
@@ -32,6 +47,7 @@ test.t3,test.t1
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_table';
 VARIABLE_NAME	VARIABLE_VALUE
 REPLICATE_DO_TABLE	test.t3,test.t1
+Replicate_Do_Table = 'test.t3,test.t1'
 SET @@GLOBAL.replicate_do_table="test.t1,,,test2.t2,,,test.t3";
 SELECT @@GLOBAL.replicate_do_table;
 @@GLOBAL.replicate_do_table
@@ -44,5 +60,10 @@ SET @@GLOBAL.replicate_do_table=null;
 SELECT @@GLOBAL.replicate_do_table;
 @@GLOBAL.replicate_do_table
 
+SET @@GLOBAL.replicate_do_table=DEFAULT;
+SELECT @@GLOBAL.replicate_do_table;
+@@GLOBAL.replicate_do_table
+
 # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_do_table = @save_replicate_do_table;

--- a/mysql-test/suite/sys_vars/r/replicate_ignore_db_basic.result
+++ b/mysql-test/suite/sys_vars/r/replicate_ignore_db_basic.result
@@ -1,3 +1,4 @@
+CHANGE MASTER TO master_host='example.com';
 #
 # Basic testing of replicate_ignore_db.
 #
@@ -17,6 +18,20 @@ SET @@GLOBAL.replicate_ignore_db=1.1;
 ERROR 42000: Incorrect argument type to variable 'replicate_ignore_db'
 SET @@GLOBAL.replicate_ignore_db=1e1;
 ERROR 42000: Incorrect argument type to variable 'replicate_ignore_db'
+# Argument size acceptance.
+SELECT GROUP_CONCAT(CONCAT("database_name_", seq) SEPARATOR ",")
+INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+LENGTH(@name)
+127
+SET @@GLOBAL.replicate_ignore_db= @name;
+SELECT @@GLOBAL.replicate_ignore_db;
+@@GLOBAL.replicate_ignore_db
+database_name_1,database_name_2,database_name_3,database_name_4,database_name_5,database_name_6,database_name_7,database_name_8
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_db';
+VARIABLE_VALUE
+database_name_1,database_name_2,database_name_3,database_name_4,database_name_5,database_name_6,database_name_7,database_name_8
+Replicate_Ignore_DB = 'database_name_1,database_name_2,database_name_3,database_name_4,database_name_5,database_name_6,database_name_7,database_name_8'
 # Argument syntax.
 SET @@GLOBAL.replicate_ignore_db="db1,,,,,db3";
 SELECT @@GLOBAL.replicate_ignore_db;
@@ -25,6 +40,7 @@ db1,db3
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_db';
 VARIABLE_NAME	VARIABLE_VALUE
 REPLICATE_IGNORE_DB	db1,db3
+Replicate_Ignore_DB = 'db1,db3'
 SET @@GLOBAL.replicate_ignore_db="db1,,,db2,,,db3";
 SELECT @@GLOBAL.replicate_ignore_db;
 @@GLOBAL.replicate_ignore_db
@@ -37,5 +53,10 @@ SET @@GLOBAL.replicate_ignore_db=null;
 SELECT @@GLOBAL.replicate_ignore_db;
 @@GLOBAL.replicate_ignore_db
 
+SET @@GLOBAL.replicate_ignore_db=DEFAULT;
+SELECT @@GLOBAL.replicate_ignore_db;
+@@GLOBAL.replicate_ignore_db
+
 # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_ignore_db = @save_replicate_ignore_db;

--- a/mysql-test/suite/sys_vars/r/replicate_ignore_table_basic.result
+++ b/mysql-test/suite/sys_vars/r/replicate_ignore_table_basic.result
@@ -1,3 +1,4 @@
+CHANGE MASTER TO master_host='example.com';
 #
 # Basic testing of replicate_ignore_table.
 #
@@ -24,6 +25,20 @@ SET @@GLOBAL.replicate_ignore_table="test.t1, t2";
 ERROR HY000: Incorrect arguments to SET
 SET @@GLOBAL.replicate_ignore_table="test.,t1";
 ERROR HY000: Incorrect arguments to SET
+# Argument size acceptance.
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+LENGTH(@name)
+255
+SET @@GLOBAL.replicate_ignore_table= @name;
+SELECT @@GLOBAL.replicate_ignore_table;
+@@GLOBAL.replicate_ignore_table
+database_name.long_table_name_5,database_name.long_table_name_1,database_name.long_table_name_6,database_name.long_table_name_2,database_name.long_table_name_7,database_name.long_table_name_3,database_name.long_table_name_8,database_name.long_table_name_4
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_table';
+VARIABLE_VALUE
+database_name.long_table_name_5,database_name.long_table_name_1,database_name.long_table_name_6,database_name.long_table_name_2,database_name.long_table_name_7,database_name.long_table_name_3,database_name.long_table_name_8,database_name.long_table_name_4
+Replicate_Ignore_Table = 'database_name.long_table_name_5,database_name.long_table_name_1,database_name.long_table_name_6,database_name.long_table_name_2,database_name.long_table_name_7,database_name.long_table_name_3,database_name.long_table_name_8,database_name.long_table_name_4'
 # Argument syntax.
 SET @@GLOBAL.replicate_ignore_table="test.t1,,,,,test.t3";
 SELECT @@GLOBAL.replicate_ignore_table;
@@ -32,6 +47,7 @@ test.t3,test.t1
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_table';
 VARIABLE_NAME	VARIABLE_VALUE
 REPLICATE_IGNORE_TABLE	test.t3,test.t1
+Replicate_Ignore_Table = 'test.t3,test.t1'
 SET @@GLOBAL.replicate_ignore_table="test.t1,,,test2.t2,,,test.t3";
 SELECT @@GLOBAL.replicate_ignore_table;
 @@GLOBAL.replicate_ignore_table
@@ -44,7 +60,12 @@ SET @@GLOBAL.replicate_ignore_table=null;
 SELECT @@GLOBAL.replicate_ignore_table;
 @@GLOBAL.replicate_ignore_table
 
+SET @@GLOBAL.replicate_ignore_table=DEFAULT;
+SELECT @@GLOBAL.replicate_ignore_table;
+@@GLOBAL.replicate_ignore_table
+
 # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_ignore_table = @save_replicate_ignore_table;
 #
 # MDEV-20101 Assertion failure on select @@global.'m2'.replicate_ignore_table

--- a/mysql-test/suite/sys_vars/r/replicate_wild_do_table_basic.result
+++ b/mysql-test/suite/sys_vars/r/replicate_wild_do_table_basic.result
@@ -1,3 +1,4 @@
+CHANGE MASTER TO master_host='example.com';
 #
 # Basic testing of replicate_wild_do_table.
 #
@@ -24,6 +25,20 @@ SET @@GLOBAL.replicate_wild_do_table="test.t, t2";
 ERROR HY000: Incorrect arguments to SET
 SET @@GLOBAL.replicate_wild_do_table="test.,t1";
 ERROR HY000: Incorrect arguments to SET
+# Argument size acceptance.
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+LENGTH(@name)
+255
+SET @@GLOBAL.replicate_wild_do_table= @name;
+SELECT @@GLOBAL.replicate_wild_do_table;
+@@GLOBAL.replicate_wild_do_table
+database_name.long_table_name_1,database_name.long_table_name_2,database_name.long_table_name_3,database_name.long_table_name_4,database_name.long_table_name_5,database_name.long_table_name_6,database_name.long_table_name_7,database_name.long_table_name_8
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_do_table';
+VARIABLE_VALUE
+database_name.long_table_name_1,database_name.long_table_name_2,database_name.long_table_name_3,database_name.long_table_name_4,database_name.long_table_name_5,database_name.long_table_name_6,database_name.long_table_name_7,database_name.long_table_name_8
+Replicate_Wild_Do_Table = 'database_name.long_table_name_1,database_name.long_table_name_2,database_name.long_table_name_3,database_name.long_table_name_4,database_name.long_table_name_5,database_name.long_table_name_6,database_name.long_table_name_7,database_name.long_table_name_8'
 # Argument syntax.
 SET @@GLOBAL.replicate_wild_do_table="test.%,,,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_do_table;
@@ -32,6 +47,7 @@ test.%,test.t3
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_do_table';
 VARIABLE_NAME	VARIABLE_VALUE
 REPLICATE_WILD_DO_TABLE	test.%,test.t3
+Replicate_Wild_Do_Table = 'test.%,test.t3'
 SET @@GLOBAL.replicate_wild_do_table="test.t1,,,test2.%,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_do_table;
 @@GLOBAL.replicate_wild_do_table
@@ -44,5 +60,10 @@ SET @@GLOBAL.replicate_wild_do_table=null;
 SELECT @@GLOBAL.replicate_wild_do_table;
 @@GLOBAL.replicate_wild_do_table
 
+SET @@GLOBAL.replicate_wild_do_table=DEFAULT;
+SELECT @@GLOBAL.replicate_wild_do_table;
+@@GLOBAL.replicate_wild_do_table
+
 # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_wild_do_table = @save_replicate_wild_do_table;

--- a/mysql-test/suite/sys_vars/r/replicate_wild_ignore_table_basic.result
+++ b/mysql-test/suite/sys_vars/r/replicate_wild_ignore_table_basic.result
@@ -1,3 +1,4 @@
+CHANGE MASTER TO master_host='example.com';
 #
 # Basic testing of replicate_wild_ignore_table.
 #
@@ -24,6 +25,20 @@ SET @@GLOBAL.replicate_wild_ignore_table="test.t, t2";
 ERROR HY000: Incorrect arguments to SET
 SET @@GLOBAL.replicate_wild_ignore_table="test.,t1";
 ERROR HY000: Incorrect arguments to SET
+# Argument size acceptance.
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+LENGTH(@name)
+255
+SET @@GLOBAL.replicate_wild_ignore_table= @name;
+SELECT @@GLOBAL.replicate_wild_ignore_table;
+@@GLOBAL.replicate_wild_ignore_table
+database_name.long_table_name_1,database_name.long_table_name_2,database_name.long_table_name_3,database_name.long_table_name_4,database_name.long_table_name_5,database_name.long_table_name_6,database_name.long_table_name_7,database_name.long_table_name_8
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_ignore_table';
+VARIABLE_VALUE
+database_name.long_table_name_1,database_name.long_table_name_2,database_name.long_table_name_3,database_name.long_table_name_4,database_name.long_table_name_5,database_name.long_table_name_6,database_name.long_table_name_7,database_name.long_table_name_8
+Replicate_Wild_Ignore_Table = 'database_name.long_table_name_1,database_name.long_table_name_2,database_name.long_table_name_3,database_name.long_table_name_4,database_name.long_table_name_5,database_name.long_table_name_6,database_name.long_table_name_7,database_name.long_table_name_8'
 # Argument syntax.
 SET @@GLOBAL.replicate_wild_ignore_table="test.%,,,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_ignore_table;
@@ -32,6 +47,7 @@ test.%,test.t3
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_ignore_table';
 VARIABLE_NAME	VARIABLE_VALUE
 REPLICATE_WILD_IGNORE_TABLE	test.%,test.t3
+Replicate_Wild_Ignore_Table = 'test.%,test.t3'
 SET @@GLOBAL.replicate_wild_ignore_table="test.t1,,,test2.%,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_ignore_table;
 @@GLOBAL.replicate_wild_ignore_table
@@ -44,5 +60,10 @@ SET @@GLOBAL.replicate_wild_ignore_table=null;
 SELECT @@GLOBAL.replicate_wild_ignore_table;
 @@GLOBAL.replicate_wild_ignore_table
 
+SET @@GLOBAL.replicate_wild_ignore_table=DEFAULT;
+SELECT @@GLOBAL.replicate_wild_ignore_table;
+@@GLOBAL.replicate_wild_ignore_table
+
 # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_wild_ignore_table = @save_replicate_wild_ignore_table;

--- a/mysql-test/suite/sys_vars/t/replicate_do_db_basic.test
+++ b/mysql-test/suite/sys_vars/t/replicate_do_db_basic.test
@@ -1,4 +1,8 @@
---source include/not_embedded.inc
+--source include/have_sequence.inc
+# have show_slave_status
+--source include/have_log_bin.inc
+CHANGE MASTER TO master_host='example.com';
+--let $status_items= Replicate_Do_DB
 
 --echo #
 --echo # Basic testing of replicate_do_db.
@@ -23,11 +27,23 @@ SET @@GLOBAL.replicate_do_db=1.1;
 --error ER_WRONG_TYPE_FOR_VAR
 SET @@GLOBAL.replicate_do_db=1e1;
 
+# MDEV-35693 Replicate_* fields of Show-Slave-Status display truncated
+--echo # Argument size acceptance.
+
+SELECT GROUP_CONCAT(CONCAT("database_name_", seq) SEPARATOR ",")
+  INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+SET @@GLOBAL.replicate_do_db= @name;
+SELECT @@GLOBAL.replicate_do_db;
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_db';
+--source include/show_slave_status.inc
+
 --echo # Argument syntax.
 
 SET @@GLOBAL.replicate_do_db="db1,,,,,db3";
 SELECT @@GLOBAL.replicate_do_db;
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_db';
+--source include/show_slave_status.inc
 
 SET @@GLOBAL.replicate_do_db="db1,,,db2,,,db3";
 SELECT @@GLOBAL.replicate_do_db;
@@ -42,4 +58,5 @@ SET @@GLOBAL.replicate_do_db=DEFAULT;
 SELECT @@GLOBAL.replicate_do_db;
 
 --echo # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_do_db = @save_replicate_do_db;

--- a/mysql-test/suite/sys_vars/t/replicate_do_table_basic.test
+++ b/mysql-test/suite/sys_vars/t/replicate_do_table_basic.test
@@ -1,4 +1,8 @@
---source include/not_embedded.inc
+--source include/have_sequence.inc
+# have show_slave_status
+--source include/have_log_bin.inc
+CHANGE MASTER TO master_host='example.com';
+--let $status_items= Replicate_Do_Table
 
 --echo #
 --echo # Basic testing of replicate_do_table.
@@ -32,11 +36,23 @@ SET @@GLOBAL.replicate_do_table="test.t1, t2";
 --error ER_WRONG_ARGUMENTS
 SET @@GLOBAL.replicate_do_table="test.,t1";
 
+# MDEV-35693 Replicate_* fields of Show-Slave-Status display truncated
+--echo # Argument size acceptance.
+
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+  INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+SET @@GLOBAL.replicate_do_table= @name;
+SELECT @@GLOBAL.replicate_do_table;
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_table';
+--source include/show_slave_status.inc
+
 --echo # Argument syntax.
 
 SET @@GLOBAL.replicate_do_table="test.t1,,,,,test.t3";
 SELECT @@GLOBAL.replicate_do_table;
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_do_table';
+--source include/show_slave_status.inc
 
 SET @@GLOBAL.replicate_do_table="test.t1,,,test2.t2,,,test.t3";
 SELECT @@GLOBAL.replicate_do_table;
@@ -47,5 +63,9 @@ SELECT @@GLOBAL.replicate_do_table;
 SET @@GLOBAL.replicate_do_table=null;
 SELECT @@GLOBAL.replicate_do_table;
 
+SET @@GLOBAL.replicate_do_table=DEFAULT;
+SELECT @@GLOBAL.replicate_do_table;
+
 --echo # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_do_table = @save_replicate_do_table;

--- a/mysql-test/suite/sys_vars/t/replicate_ignore_db_basic.test
+++ b/mysql-test/suite/sys_vars/t/replicate_ignore_db_basic.test
@@ -1,4 +1,8 @@
---source include/not_embedded.inc
+--source include/have_sequence.inc
+# have show_slave_status
+--source include/have_log_bin.inc
+CHANGE MASTER TO master_host='example.com';
+--let $status_items= Replicate_Ignore_DB
 
 --echo #
 --echo # Basic testing of replicate_ignore_db.
@@ -23,11 +27,23 @@ SET @@GLOBAL.replicate_ignore_db=1.1;
 --error ER_WRONG_TYPE_FOR_VAR
 SET @@GLOBAL.replicate_ignore_db=1e1;
 
+# MDEV-35693 Replicate_* fields of Show-Slave-Status display truncated
+--echo # Argument size acceptance.
+
+SELECT GROUP_CONCAT(CONCAT("database_name_", seq) SEPARATOR ",")
+  INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+SET @@GLOBAL.replicate_ignore_db= @name;
+SELECT @@GLOBAL.replicate_ignore_db;
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_db';
+--source include/show_slave_status.inc
+
 --echo # Argument syntax.
 
 SET @@GLOBAL.replicate_ignore_db="db1,,,,,db3";
 SELECT @@GLOBAL.replicate_ignore_db;
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_db';
+--source include/show_slave_status.inc
 
 SET @@GLOBAL.replicate_ignore_db="db1,,,db2,,,db3";
 SELECT @@GLOBAL.replicate_ignore_db;
@@ -38,5 +54,9 @@ SELECT @@GLOBAL.replicate_ignore_db;
 SET @@GLOBAL.replicate_ignore_db=null;
 SELECT @@GLOBAL.replicate_ignore_db;
 
+SET @@GLOBAL.replicate_ignore_db=DEFAULT;
+SELECT @@GLOBAL.replicate_ignore_db;
+
 --echo # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_ignore_db = @save_replicate_ignore_db;

--- a/mysql-test/suite/sys_vars/t/replicate_ignore_table_basic.test
+++ b/mysql-test/suite/sys_vars/t/replicate_ignore_table_basic.test
@@ -1,4 +1,8 @@
---source include/not_embedded.inc
+--source include/have_sequence.inc
+# have show_slave_status
+--source include/have_log_bin.inc
+CHANGE MASTER TO master_host='example.com';
+--let $status_items= Replicate_Ignore_Table
 
 --echo #
 --echo # Basic testing of replicate_ignore_table.
@@ -32,11 +36,23 @@ SET @@GLOBAL.replicate_ignore_table="test.t1, t2";
 --error ER_WRONG_ARGUMENTS
 SET @@GLOBAL.replicate_ignore_table="test.,t1";
 
+# MDEV-35693 Replicate_* fields of Show-Slave-Status display truncated
+--echo # Argument size acceptance.
+
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+  INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+SET @@GLOBAL.replicate_ignore_table= @name;
+SELECT @@GLOBAL.replicate_ignore_table;
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_table';
+--source include/show_slave_status.inc
+
 --echo # Argument syntax.
 
 SET @@GLOBAL.replicate_ignore_table="test.t1,,,,,test.t3";
 SELECT @@GLOBAL.replicate_ignore_table;
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_ignore_table';
+--source include/show_slave_status.inc
 
 SET @@GLOBAL.replicate_ignore_table="test.t1,,,test2.t2,,,test.t3";
 SELECT @@GLOBAL.replicate_ignore_table;
@@ -47,7 +63,11 @@ SELECT @@GLOBAL.replicate_ignore_table;
 SET @@GLOBAL.replicate_ignore_table=null;
 SELECT @@GLOBAL.replicate_ignore_table;
 
+SET @@GLOBAL.replicate_ignore_table=DEFAULT;
+SELECT @@GLOBAL.replicate_ignore_table;
+
 --echo # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_ignore_table = @save_replicate_ignore_table;
 
 --echo #

--- a/mysql-test/suite/sys_vars/t/replicate_wild_do_table_basic.test
+++ b/mysql-test/suite/sys_vars/t/replicate_wild_do_table_basic.test
@@ -1,4 +1,8 @@
---source include/not_embedded.inc
+--source include/have_sequence.inc
+# have show_slave_status
+--source include/have_log_bin.inc
+CHANGE MASTER TO master_host='example.com';
+--let $status_items= Replicate_Wild_Do_Table
 
 --echo #
 --echo # Basic testing of replicate_wild_do_table.
@@ -32,11 +36,23 @@ SET @@GLOBAL.replicate_wild_do_table="test.t, t2";
 --error ER_WRONG_ARGUMENTS
 SET @@GLOBAL.replicate_wild_do_table="test.,t1";
 
+# MDEV-35693 Replicate_* fields of Show-Slave-Status display truncated
+--echo # Argument size acceptance.
+
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+  INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+SET @@GLOBAL.replicate_wild_do_table= @name;
+SELECT @@GLOBAL.replicate_wild_do_table;
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_do_table';
+--source include/show_slave_status.inc
+
 --echo # Argument syntax.
 
 SET @@GLOBAL.replicate_wild_do_table="test.%,,,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_do_table;
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_do_table';
+--source include/show_slave_status.inc
 
 SET @@GLOBAL.replicate_wild_do_table="test.t1,,,test2.%,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_do_table;
@@ -47,5 +63,9 @@ SELECT @@GLOBAL.replicate_wild_do_table;
 SET @@GLOBAL.replicate_wild_do_table=null;
 SELECT @@GLOBAL.replicate_wild_do_table;
 
+SET @@GLOBAL.replicate_wild_do_table=DEFAULT;
+SELECT @@GLOBAL.replicate_wild_do_table;
+
 --echo # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_wild_do_table = @save_replicate_wild_do_table;

--- a/mysql-test/suite/sys_vars/t/replicate_wild_ignore_table_basic.test
+++ b/mysql-test/suite/sys_vars/t/replicate_wild_ignore_table_basic.test
@@ -1,4 +1,8 @@
---source include/not_embedded.inc
+--source include/have_sequence.inc
+# have show_slave_status
+--source include/have_log_bin.inc
+CHANGE MASTER TO master_host='example.com';
+--let $status_items= Replicate_Wild_Ignore_Table
 
 --echo #
 --echo # Basic testing of replicate_wild_ignore_table.
@@ -32,11 +36,23 @@ SET @@GLOBAL.replicate_wild_ignore_table="test.t, t2";
 --error ER_WRONG_ARGUMENTS
 SET @@GLOBAL.replicate_wild_ignore_table="test.,t1";
 
+# MDEV-35693 Replicate_* fields of Show-Slave-Status display truncated
+--echo # Argument size acceptance.
+
+SELECT GROUP_CONCAT(CONCAT("database_name.long_table_name_", seq) SEPARATOR ",")
+  INTO @name FROM seq_1_to_8;
+SELECT LENGTH(@name);
+SET @@GLOBAL.replicate_wild_ignore_table= @name;
+SELECT @@GLOBAL.replicate_wild_ignore_table;
+SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_ignore_table';
+--source include/show_slave_status.inc
+
 --echo # Argument syntax.
 
 SET @@GLOBAL.replicate_wild_ignore_table="test.%,,,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_ignore_table;
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME='replicate_wild_ignore_table';
+--source include/show_slave_status.inc
 
 SET @@GLOBAL.replicate_wild_ignore_table="test.t1,,,test2.%,,,test.t3";
 SELECT @@GLOBAL.replicate_wild_ignore_table;
@@ -47,5 +63,9 @@ SELECT @@GLOBAL.replicate_wild_ignore_table;
 SET @@GLOBAL.replicate_wild_ignore_table=null;
 SELECT @@GLOBAL.replicate_wild_ignore_table;
 
+SET @@GLOBAL.replicate_wild_ignore_table=DEFAULT;
+SELECT @@GLOBAL.replicate_wild_ignore_table;
+
 --echo # Cleanup.
+RESET REPLICA ALL;
 SET @@GLOBAL.replicate_wild_ignore_table = @save_replicate_wild_ignore_table;


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-35948](https://jira.mariadb.org/browse/MDEV-35948)*
  * [ ] Spiritually a prerequisite of #3772 ([MDEV-35693][])

## Description
Assert that 1st-gen `replicate_*` filter variables display their input – including long but reasonable lists – correctly (without truncation) in
* direct SELECT
* [semi-new] INFORMATION_SCHEMA.GLOBAL_VARIABLES.VARIABLE_VALUE
* [new] SHOW REPLICA STATUS

This tests the fields affected by [MDEV-35693][] (an 11.6 oversignt).

Also test the input `DEFAULT` as part of this edge-case testing.

## Release Notes
N/A – This is a dev task.
## How can this PR be tested?
run the modified files

## Basing the PR against the correct MariaDB version
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.

[MDEV-35693]: https://jira.mariadb.org/browse/MDEV-35693