### PR TITLE
MDEV-35941 : galera_bf_abort_lock_table fails with wait for metadata …

### DIFF
--- a/mysql-test/include/wait_condition_with_debug_and_kill.inc
+++ b/mysql-test/include/wait_condition_with_debug_and_kill.inc
@@ -1,0 +1,70 @@
+# include/wait_condition_with_debug_and_kill.inc
+#
+# SUMMARY
+#
+#    Waits until the passed statement returns true, or the operation
+#    times out.  If the operation times out, the additional error
+#    statement will be executed and server is killed.
+#
+# USAGE
+#
+#    let $wait_condition=
+#      SELECT c = 3 FROM t;
+#    let $wait_condition_on_error_output= select count(*) from t;
+#    [let $explicit_default_wait_timeout= N] # to override the default reset
+#    --source include/wait_condition_with_debug.inc
+#
+#   OR
+#
+#    let $wait_timeout= 60; # Override default 30 seconds with 60.
+#    let $wait_condition=
+#      SELECT c = 3 FROM t;
+#    let $wait_condition_on_error_output= select count(*) from t;
+#    --source include/wait_condition_with_debug.inc
+#    --echo Executed the test condition $wait_condition_reps times
+#
+#
+# EXAMPLE
+#    events_bugs.test, events_time_zone.test
+#
+
+let $wait_counter= 300;
+if ($wait_timeout)
+{
+  let $wait_counter= `SELECT $wait_timeout * 10`;
+}
+# Reset $wait_timeout so that its value won't be used on subsequent
+# calls, and default will be used instead.
+if ($explicit_default_wait_timeout)
+{
+  --let $wait_timeout= $explicit_default_wait_timeout
+}
+if (!$explicit_default_wait_timeout)
+{
+  --let $wait_timeout= 0
+}
+
+# Keep track of how many times the wait condition is tested
+# This is used by some tests (e.g., main.status)
+let $wait_condition_reps= 0;
+while ($wait_counter)
+{
+    --error 0,ER_NO_SUCH_TABLE,ER_LOCK_WAIT_TIMEOUT,ER_UNKNOWN_COM_ERROR,ER_LOCK_DEADLOCK
+    let $success= `$wait_condition`;
+    inc $wait_condition_reps;
+    if ($success)
+    {
+        let $wait_counter= 0;
+    }
+    if (!$success)
+    {
+        real_sleep 0.1;
+        dec $wait_counter;
+    }
+}
+if (!$success)
+{
+  echo Timeout in wait_condition.inc for $wait_condition;
+  --eval $wait_condition_on_error_output
+  --source include/kill_galera.inc
+}

--- a/mysql-test/suite/galera/r/galera_bf_abort_lock_table.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_lock_table.result
@@ -7,6 +7,7 @@ LOCK TABLE t1 WRITE;
 connection node_1;
 INSERT INTO t1 VALUES (2);
 connection node_2;
+SET SESSION wsrep_sync_wait = 0;
 UNLOCK TABLES;
 COMMIT;
 SELECT COUNT(*) = 1 FROM t1;

--- a/mysql-test/suite/galera/t/galera_bf_abort_lock_table.cnf
+++ b/mysql-test/suite/galera/t/galera_bf_abort_lock_table.cnf
@@ -1,7 +1,6 @@
 !include ../galera_2nodes.cnf
 
-[mysqld]
-log-bin
+[mysqld.1]
 wsrep-debug=1
-loose-mysql-wsrep198=1
+loose-galera-bf-abort-lock-table=1
 

--- a/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
@@ -1,5 +1,6 @@
 --source include/galera_cluster.inc
 --source include/have_innodb.inc
+--source include/force_restart.inc
 
 #
 # Test that a local LOCK TABLE will NOT be broken by an incoming remote transaction against that table
@@ -16,13 +17,16 @@ LOCK TABLE t1 WRITE;
 INSERT INTO t1 VALUES (2);
 
 --connection node_2
+SET SESSION wsrep_sync_wait = 0;
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
+--source include/wait_condition_with_debug_and_kill.inc
 
 UNLOCK TABLES;
 
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
+--source include/wait_condition_with_debug_and_kill.inc
 
 COMMIT;
 SELECT COUNT(*) = 1 FROM t1;

--- a/mysql-test/suite/galera/t/mysql-wsrep#198.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#198.test
@@ -22,7 +22,8 @@ LOCK TABLE t2 WRITE;
 --connection node_2
 SET SESSION wsrep_sync_wait = 0;
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for table metadata lock'
---source include/wait_condition.inc
+--let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
+--source include/wait_condition_with_debug_and_kill.inc
 
 --connection node_1
 INSERT INTO t2 VALUES (1);


### PR DESCRIPTION
…lock

Test fixes only.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35941*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
