### PR TITLE
[MDEV-35969] reset service manager status

### DIFF
--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -132,6 +132,8 @@ static void* wsrep_sst_donor_monitor_thread(void *arg __attribute__((unused)))
   WSREP_INFO("Donor monitor thread ended with total time %lu sec", time_waited);
   mysql_mutex_unlock(&LOCK_wsrep_donor_monitor);
 
+  sd_notify(0, "STATUS=WSREP state transfer (role donor) completed.\n");
+
   return NULL;
 }
 
@@ -168,6 +170,8 @@ static void* wsrep_sst_joiner_monitor_thread(void *arg __attribute__((unused)))
 
   WSREP_INFO("Joiner monitor thread ended with total time %lu sec", time_waited);
   mysql_mutex_unlock(&LOCK_wsrep_joiner_monitor);
+
+  sd_notify(0, "STATUS=WSREP state transfer (role joiner) completed.\n");
 
   return NULL;
 }

--- a/sql/wsrep_sst.cc
+++ b/sql/wsrep_sst.cc
@@ -125,7 +125,7 @@ static void* wsrep_sst_donor_monitor_thread(void *arg __attribute__((unused)))
                  "is not completed",
                  time_waited);
       service_manager_extend_timeout(WSREP_EXTEND_TIMEOUT_INTERVAL,
-        "WSREP state transfer ongoing...");
+        "WSREP state transfer (role donor) ongoing...");
     }
   }
 
@@ -162,7 +162,7 @@ static void* wsrep_sst_joiner_monitor_thread(void *arg __attribute__((unused)))
                  "is not completed",
                  time_waited);
       service_manager_extend_timeout(WSREP_EXTEND_TIMEOUT_INTERVAL,
-        "WSREP state transfer ongoing...");
+        "WSREP state transfer (role joiner) ongoing...");
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35969*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
I am running a Galera cluster with MariaDB 11.4.4. When ever a server does a WSREP state transfer it results in the service manager reporting that WSREP state transfer, visible in status:
```
root@mariadb01 ~ # systemctl --lines=0 --no-pager status mariadb.service
● mariadb.service - MariaDB 11.4.4 database server
     Loaded: loaded (/usr/lib/systemd/system/mariadb.service; enabled; preset: disabled)
    Drop-In: /etc/systemd/system/mariadb.service.d
             └─LimitNOFILE.conf, Shutdown.conf
     Active: active (running) since Tue 2025-01-28 12:12:19 CET; 23h ago
 Invocation: e079a859e5f24b2f8a9e48013e7d61cb
       Docs: man:mariadbd(8)
             https://mariadb.com/kb/en/library/systemd/
   Main PID: 984 (mariadbd)
     Status: "WSREP state transfer ongoing..."
      Tasks: 491 (limit: 1020061)
     Memory: 116.9G (peak: 123G)
        CPU: 11h 46min 3.224s
     CGroup: /system.slice/mariadb.service
             └─984 /usr/bin/mariadbd --wsrep_start_position=00000000-0000-0000-0000-000000000000:-1
```
However that status is not updated after the state transfer. Instead it should change back to the default status "_Taking your SQL requests now..._".

## Release Notes

* Update status in service manager after state transfer

## How can this PR be tested?

After a state transfer the status should switch back. No idea if this can be tested in current test suite.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
