### PR TITLE
MDEV-35951 : Complete freeze during MW-329 test

### DIFF
--- a/mysql-test/suite/galera/r/MW-329.result
+++ b/mysql-test/suite/galera/r/MW-329.result
@@ -2,21 +2,24 @@ connection node_2;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER, f2 CHAR(20) DEFAULT 'abc') ENGINE=InnoDB;
 INSERT INTO t1 (f1) VALUES (1),(65535);
-CREATE PROCEDURE proc_insert ()
+CREATE PROCEDURE proc_insert (repeat_count int)
 BEGIN
+DECLARE current_num int;
 DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+SET current_num = 0;
 SET SESSION wsrep_sync_wait = 0;
-WHILE 1 DO
+WHILE current_num < repeat_count do
 INSERT INTO t1 (f1) VALUES (FLOOR( 1 + RAND( ) * 65535 ));
 SELECT SLEEP(0.1);
+SET current_num = current_num + 1;
 END WHILE;
 END|
 connect node_1b, 127.0.0.1, root, , test, $NODE_MYPORT_1;
 connection node_1b;
-connection node_1;
 connection node_1b;
 connection node_1;
 DROP PROCEDURE proc_insert;
 DROP TABLE t1;
+disconnect node_1b;
 CALL mtr.add_suppression("WSREP: .* conflict state after post commit ");
 set global innodb_status_output=Default;

--- a/mysql-test/suite/galera/t/MW-329.test
+++ b/mysql-test/suite/galera/t/MW-329.test
@@ -15,13 +15,16 @@ INSERT INTO t1 (f1) VALUES (1),(65535);
 #
 
 DELIMITER |;
-CREATE PROCEDURE proc_insert ()
+CREATE PROCEDURE proc_insert (repeat_count int)
 BEGIN
+        DECLARE current_num int;
         DECLARE CONTINUE HANDLER FOR SQLEXCEPTION BEGIN END;
+        SET current_num = 0;
         SET SESSION wsrep_sync_wait = 0;
-        WHILE 1 DO
-		INSERT INTO t1 (f1) VALUES (FLOOR( 1 + RAND( ) * 65535 ));
-		SELECT SLEEP(0.1);
+        WHILE current_num < repeat_count do
+            INSERT INTO t1 (f1) VALUES (FLOOR( 1 + RAND( ) * 65535 ));
+            SELECT SLEEP(0.1);
+            SET current_num = current_num + 1;
         END WHILE;
 END|
 DELIMITER ;|
@@ -31,7 +34,7 @@ DELIMITER ;|
 --let $connection_id = `SELECT CONNECTION_ID()`
 --disable_query_log
 --disable_result_log
---send CALL proc_insert();
+--send CALL proc_insert(500);
 
 #
 # Run concurrent UPDATEs. We expect that each UPDATE will report that
@@ -39,7 +42,7 @@ DELIMITER ;|
 #
 
 --connection node_2
---let $count = 10
+--let $count = 2
 --let $wsrep_local_replays_old = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_replays'`
 
 while ($count)
@@ -78,14 +81,8 @@ while ($count)
 --enable_query_log
 
 #
-# Terminate the stored procedure
 #
-
---connection node_1
---disable_query_log
---eval KILL CONNECTION $connection_id
---enable_query_log
-
+#
 --connection node_1b
 --error 0,2013,1317
 --reap
@@ -95,6 +92,8 @@ while ($count)
 --connection node_1
 DROP PROCEDURE proc_insert;
 DROP TABLE t1;
+
+--disconnect node_1b
 
 # Due to MW-330, Multiple "conflict state 3 after post commit" warnings if table is dropped while SP is running
 CALL mtr.add_suppression("WSREP: .* conflict state after post commit ");


### PR DESCRIPTION
Rewrite test not to use infinite procedure, it is not necessary to test.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35951*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
