### PR TITLE
MDEV-35955 Wrong result for UPDATE ... ORDER BY LIMIT using tmp.table

### DIFF
--- a/mysql-test/main/update.result
+++ b/mysql-test/main/update.result
@@ -765,3 +765,83 @@ ccc	yyy
 u	xxb
 drop table t1;
 # End of MariaDB 10.4 tests
+#
+# MDEV-35955 Wrong result for UPDATE ... ORDER BY LIMIT which uses tmp.table
+#
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (2,3),(1,4);
+insert into t2 (id, v) values (5,5),(6,6);
+select t1.*, t2.* from t1, t2 order by t1.id, t2.id limit 2;
+id	v	id	v
+1	4	5	5
+1	4	6	6
+UPDATE t1, t2 SET t1.v=-1, t2.v=-1 ORDER BY t1.id, t2.id LIMIT 2;
+select * from t1;
+id	v
+2	3
+1	-1
+select * from t2;
+id	v
+5	-1
+6	-1
+drop table t1, t2;
+create table t1 (id int primary key, v text) engine=myisam;
+create table t2 (id int primary key, v text) engine=myisam;
+insert into t1 (id, v) values (1,'b'),(2,'fo'),(3,'bar'),(4,'barr'),(5,'bazzz');
+insert into t2 (id, v) values (6,'quxqux'),(7,'foofoof'),(8,'barbarba'),(9,'quxquxqux'),(10,'bazbazbazb');
+select t1.*, t2.* from t1, t2 order by t1.id, t2.id limit 2;
+id	v	id	v
+1	b	6	quxqux
+1	b	7	foofoof
+update t1, t2 set t1.v='DELETED', t2.v='DELETED' order by t1.id, t2.id limit 2;
+select * from t1;
+id	v
+1	DELETED
+2	fo
+3	bar
+4	barr
+5	bazzz
+select * from t2;
+id	v
+6	DELETED
+7	DELETED
+8	barbarba
+9	quxquxqux
+10	bazbazbazb
+drop table t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+create table t3 (id int primary key, v int);
+insert into t1 (id, v) values (1, 1000), (2, 2000), (3, 3000), (4, 4000), (5, 5000);
+insert into t2 (id, v) values (10, 100), (20, 200), (30, 300), (40, 400), (50, 500);
+insert into t3 (id, v) values (11, 111), (22, 222), (33, 333), (44, 444), (55, 555);
+select t1.*, t2.*, t3.* from t1, t2, t3 order by t1.id, t2.id, t3.id limit 3;
+id	v	id	v	id	v
+1	1000	10	100	11	111
+1	1000	10	100	22	222
+1	1000	10	100	33	333
+UPDATE t1, t2, t3 SET t1.v=-1, t2.v=-2, t3.v=-3 ORDER BY t1.id, t2.id, t3.id LIMIT 3;
+select * from t1;
+id	v
+1	-1
+2	2000
+3	3000
+4	4000
+5	5000
+select * from t2;
+id	v
+10	-2
+20	200
+30	300
+40	400
+50	500
+select * from t3;
+id	v
+11	-3
+22	-3
+33	-3
+44	444
+55	555
+drop table t1, t2, t3;
+# End of MariaDB 10.11 tests

--- a/mysql-test/main/update.test
+++ b/mysql-test/main/update.test
@@ -707,3 +707,43 @@ select * from t1;
 drop table t1;
 
 --echo # End of MariaDB 10.4 tests
+
+--echo #
+--echo # MDEV-35955 Wrong result for UPDATE ... ORDER BY LIMIT which uses tmp.table
+--echo #
+
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+insert into t1 (id, v) values (2,3),(1,4);
+insert into t2 (id, v) values (5,5),(6,6);
+select t1.*, t2.* from t1, t2 order by t1.id, t2.id limit 2;
+UPDATE t1, t2 SET t1.v=-1, t2.v=-1 ORDER BY t1.id, t2.id LIMIT 2;
+select * from t1;
+select * from t2;
+
+drop table t1, t2;
+create table t1 (id int primary key, v text) engine=myisam;
+create table t2 (id int primary key, v text) engine=myisam;
+insert into t1 (id, v) values (1,'b'),(2,'fo'),(3,'bar'),(4,'barr'),(5,'bazzz');
+insert into t2 (id, v) values (6,'quxqux'),(7,'foofoof'),(8,'barbarba'),(9,'quxquxqux'),(10,'bazbazbazb');
+select t1.*, t2.* from t1, t2 order by t1.id, t2.id limit 2;
+update t1, t2 set t1.v='DELETED', t2.v='DELETED' order by t1.id, t2.id limit 2;
+select * from t1;
+select * from t2;
+
+drop table t1, t2;
+create table t1 (id int primary key, v int);
+create table t2 (id int primary key, v int);
+create table t3 (id int primary key, v int);
+insert into t1 (id, v) values (1, 1000), (2, 2000), (3, 3000), (4, 4000), (5, 5000);
+insert into t2 (id, v) values (10, 100), (20, 200), (30, 300), (40, 400), (50, 500);
+insert into t3 (id, v) values (11, 111), (22, 222), (33, 333), (44, 444), (55, 555);
+select t1.*, t2.*, t3.* from t1, t2, t3 order by t1.id, t2.id, t3.id limit 3;
+UPDATE t1, t2, t3 SET t1.v=-1, t2.v=-2, t3.v=-3 ORDER BY t1.id, t2.id, t3.id LIMIT 3;
+select * from t1;
+select * from t2;
+select * from t3;
+
+drop table t1, t2, t3;
+
+--echo # End of MariaDB 10.11 tests


### PR DESCRIPTION
Queries of the form
```
  UPDATE t1.*, t2.* ORDER BY t1.col1, t2.col2, ... LIMIT N;
```
now correctly sort first by t1.col, then by t2.col2.  Previously, such queries would, when more than one ORDER BY column was specified, incorrectly sort the columns from the input tables; as an example, when two ORDER BY columns were specified, the sorting would first be by t2.col2 and then by t1.col1, updating more rows from the first table than the second.
