### PR TITLE
MDEV-34489 innodb.innodb_row_lock_time_ms fails

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_row_lock_time_ms.result
+++ b/mysql-test/suite/innodb/r/innodb_row_lock_time_ms.result
@@ -1,10 +1,18 @@
 CREATE TABLE `t`(`id` INT, PRIMARY KEY(`id`)) ENGINE=InnoDB STATS_PERSISTENT=0;
 INSERT INTO t VALUES (1);
-SET GLOBAL innodb_monitor_reset = "module_innodb";
+SET GLOBAL innodb_monitor_disable="lock_row_lock_time";
+SET GLOBAL innodb_monitor_disable="lock_row_lock_time_max";
+SET GLOBAL innodb_monitor_reset_all='lock_row_lock_time';
+SET GLOBAL innodb_monitor_reset_all='lock_row_lock_time_max';
+SET GLOBAL innodb_monitor_enable="lock_row_lock_time";
+SET GLOBAL innodb_monitor_enable="lock_row_lock_time_max";
 BEGIN;
 SELECT * FROM t FOR UPDATE;
 id
 1
+SELECT @innodb_row_lock_time_before := variable_value
+FROM information_schema.global_status
+WHERE LOWER(variable_name) = 'innodb_row_lock_time';
 connect con1,localhost,root,,;
 SET innodb_lock_wait_timeout = 1;
 SELECT * FROM t FOR UPDATE;
@@ -12,29 +20,27 @@ ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 disconnect con1;
 connection default;
 COMMIT;
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT variable_value - @innodb_row_lock_time_before > 100
+FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_row_lock_time';
-variable_value > 100
+variable_value - @innodb_row_lock_time_before > 100
 1
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT  variable_value > 100
+FROM information_schema.global_status
 WHERE LOWER(variable_name) = 'innodb_row_lock_time_max';
 variable_value > 100
 1
-SELECT variable_value > 100 FROM information_schema.global_status
-WHERE LOWER(variable_name) = 'innodb_row_lock_time_avg';
-variable_value > 100
-1
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
-WHERE NAME="lock_row_lock_time";
+SELECT count_reset > 100
+FROM INFORMATION_SCHEMA.INNODB_METRICS
+WHERE NAME='lock_row_lock_time';
 count_reset > 100
 1
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
-WHERE NAME="lock_row_lock_time_max";
-count_reset > 100
-1
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
-WHERE NAME="lock_row_lock_time_avg";
+SELECT count_reset > 100
+FROM INFORMATION_SCHEMA.INNODB_METRICS
+WHERE NAME='lock_row_lock_time_max';
 count_reset > 100
 1
 DROP TABLE t;
-SET GLOBAL innodb_monitor_reset=default;
+SET GLOBAL innodb_monitor_enable=default;
+SET GLOBAL innodb_monitor_disable=default;
+SET GLOBAL innodb_monitor_reset_all=default;

--- a/mysql-test/suite/innodb/t/innodb_row_lock_time_ms.test
+++ b/mysql-test/suite/innodb/t/innodb_row_lock_time_ms.test
@@ -5,10 +5,25 @@ CREATE TABLE `t`(`id` INT, PRIMARY KEY(`id`)) ENGINE=InnoDB STATS_PERSISTENT=0;
 
 INSERT INTO t VALUES (1);
 
-SET GLOBAL innodb_monitor_reset = "module_innodb";
+SET GLOBAL innodb_monitor_disable="lock_row_lock_time";
+SET GLOBAL innodb_monitor_disable="lock_row_lock_time_max";
+SET GLOBAL innodb_monitor_reset_all='lock_row_lock_time';
+SET GLOBAL innodb_monitor_reset_all='lock_row_lock_time_max';
+SET GLOBAL innodb_monitor_enable="lock_row_lock_time";
+SET GLOBAL innodb_monitor_enable="lock_row_lock_time_max";
 
 BEGIN;
 SELECT * FROM t FOR UPDATE;
+
+# We can't predict (innodb/lock)_row_lock_time_avg value, because it's counted
+# as the whole waiting time divided by the amount of waits. The
+# corresponding counters in lock_sys can't be reset with any query.
+
+--disable_result_log
+SELECT @innodb_row_lock_time_before := variable_value
+  FROM information_schema.global_status
+  WHERE LOWER(variable_name) = 'innodb_row_lock_time';
+--enable_result_log
 
 --connect(con1,localhost,root,,)
 SET innodb_lock_wait_timeout = 1;
@@ -19,24 +34,28 @@ SELECT * FROM t FOR UPDATE;
 --connection default
 COMMIT;
 
-SELECT variable_value > 100 FROM information_schema.global_status
+SELECT variable_value - @innodb_row_lock_time_before > 100
+  FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_row_lock_time';
-SELECT variable_value > 100 FROM information_schema.global_status
+# We can't use 'variable_value - @innodb_row_lock_time_max_before' trick for
+# innodb_row_lock_time_max, because we can't reset it, and we don't know the
+# initial value at the moment of the test execution.
+SELECT  variable_value > 100
+  FROM information_schema.global_status
   WHERE LOWER(variable_name) = 'innodb_row_lock_time_max';
-SELECT variable_value > 100 FROM information_schema.global_status
-  WHERE LOWER(variable_name) = 'innodb_row_lock_time_avg';
-
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
-  WHERE NAME="lock_row_lock_time";
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
-  WHERE NAME="lock_row_lock_time_max";
-SELECT count_reset > 100 FROM INFORMATION_SCHEMA.INNODB_METRICS
-  WHERE NAME="lock_row_lock_time_avg";
+SELECT count_reset > 100
+  FROM INFORMATION_SCHEMA.INNODB_METRICS
+  WHERE NAME='lock_row_lock_time';
+SELECT count_reset > 100
+  FROM INFORMATION_SCHEMA.INNODB_METRICS
+  WHERE NAME='lock_row_lock_time_max';
 
 DROP TABLE t;
 
 --disable_warnings
-SET GLOBAL innodb_monitor_reset=default;
+SET GLOBAL innodb_monitor_enable=default;
+SET GLOBAL innodb_monitor_disable=default;
+SET GLOBAL innodb_monitor_reset_all=default;
 --enable_warnings
 
 --source include/wait_until_count_sessions.inc


### PR DESCRIPTION
The test fails trying to compare (innodb/lock)_row_lock_time_avg with some limit. We can't predict (innodb/lock)_row_lock_time_avg value, because it's counted as the whole waiting time divided by the amount of waits. Both waiting time and amount of waits depend on the previous tests execution. The corresponding counters in lock_sys can't be reset with any query. Remove (innodb/lock)_row_lock_time_avg comparision from the test.

information_schema.global_status.innodb_row_lock_time can't be reset, compare its difference instead of absolute value.

Reviewed by: Marko Mäkelä

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
