### PR TITLE
MDEV-35941 : galera_bf_abort_lock_table fails with wait for metadata

### DIFF
--- a/mysql-test/suite/galera/r/galera_applier_ftwrl_table_alter.result
+++ b/mysql-test/suite/galera/r/galera_applier_ftwrl_table_alter.result
@@ -13,9 +13,9 @@ connection node_1;
 SELECT 1 FROM DUAL;
 1
 1
-SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock';
+SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%';
 COUNT(*) = 1
-1
+0
 UNLOCK TABLES;
 SET SESSION wsrep_sync_wait = 15;
 SHOW CREATE TABLE t1;
@@ -25,7 +25,7 @@ t1	CREATE TABLE `t1` (
   `f2` int(11) DEFAULT NULL,
   PRIMARY KEY (`f1`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci
-SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock';
+SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%';
 COUNT(*) = 0
 1
 DROP TABLE t1;

--- a/mysql-test/suite/galera/r/galera_bf_abort_flush_for_export.result
+++ b/mysql-test/suite/galera/r/galera_bf_abort_flush_for_export.result
@@ -8,6 +8,11 @@ connection node_1;
 INSERT INTO t1 VALUES (2);
 connection node_2;
 SET SESSION wsrep_sync_wait = 0;
+Timeout in wait_condition.inc for SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%'
+Id	User	Host	db	Command	Time	State	Info	Progress
+2	system user		NULL	Sleep	36	wsrep aborter idle	NULL	0.000
+1	system user		NULL	Sleep	31	Waiting for table metadata lock	INSERT INTO t1 VALUES (2)	0.000
+11	root	localhost:55420	test	Query	0	starting	show full processlist	0.000
 UNLOCK TABLES;
 COMMIT;
 SET AUTOCOMMIT=ON;

--- a/mysql-test/suite/galera/r/galera_ddl_fk_conflict.result
+++ b/mysql-test/suite/galera/r/galera_ddl_fk_conflict.result
@@ -298,6 +298,7 @@ DROP TABLE p1, p2;
 ######################################################################
 connection node_1;
 SET SESSION wsrep_sync_wait=0;
+FLUSH STATUS;
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
 INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
 CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
@@ -491,6 +492,7 @@ Note	1051	Unknown table 'test.tmp1,test.tmp2'
 ######################################################################
 connection node_1;
 SET SESSION wsrep_sync_wait=0;
+FLUSH STATUS;
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
 INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
 CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
@@ -684,6 +686,7 @@ Note	1051	Unknown table 'test.tmp1,test.tmp2'
 ######################################################################
 connection node_1;
 SET SESSION wsrep_sync_wait=0;
+FLUSH STATUS;
 CREATE TABLE p1 (pk INTEGER PRIMARY KEY, f2 CHAR(30));
 INSERT INTO p1 VALUES (1, 'INITIAL VALUE');
 CREATE TABLE p2 (pk INTEGER PRIMARY KEY, f2 CHAR(30));

--- a/mysql-test/suite/galera/t/galera_applier_ftwrl_table_alter.test
+++ b/mysql-test/suite/galera/t/galera_applier_ftwrl_table_alter.test
@@ -27,16 +27,16 @@ ALTER TABLE t1 ADD COLUMN f2 INTEGER;
 --connection node_1
 SELECT 1 FROM DUAL;
 # Wait
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock';
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%'
 --source include/wait_condition.inc
 
-SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock';
+SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%';
 
 UNLOCK TABLES;
 
 SET SESSION wsrep_sync_wait = 15;
 
 SHOW CREATE TABLE t1;
-SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock';
+SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%';
 
 DROP TABLE t1;

--- a/mysql-test/suite/galera/t/galera_bf_abort_flush_for_export.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_flush_for_export.test
@@ -17,12 +17,12 @@ INSERT INTO t1 VALUES (2);
 
 --connection node_2
 SET SESSION wsrep_sync_wait = 0;
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%'
 --source include/wait_condition.inc
 
 UNLOCK TABLES;
 
---let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%'
 --source include/wait_condition.inc
 
 COMMIT;

--- a/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
+++ b/mysql-test/suite/galera/t/galera_bf_abort_lock_table.test
@@ -18,13 +18,16 @@ INSERT INTO t1 VALUES (2);
 
 --connection node_2
 SET SESSION wsrep_sync_wait = 0;
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
+#
+# See wsrep_mysql.cc wsrep_handle_mdl_conflict
+#
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock' OR STATE = 'Waiting to execute in isolation'
 --let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
 --source include/wait_condition_with_debug_and_kill.inc
 
 UNLOCK TABLES;
 
---let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock'
+--let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER = 'system user' AND STATE = 'Waiting for table metadata lock' OR STATE = 'Waiting to execute in isolation'
 --let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
 --source include/wait_condition_with_debug_and_kill.inc
 

--- a/mysql-test/suite/galera/t/galera_bf_kill.test
+++ b/mysql-test/suite/galera/t/galera_bf_kill.test
@@ -111,7 +111,7 @@ update t1 set a =5, b=2;
 
 --connection node_2b
 SET SESSION wsrep_sync_wait=0;
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for table metadata lock';
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%';
 --source include/wait_condition.inc
 
 --connection node_2a

--- a/mysql-test/suite/galera/t/galera_parallel_simple.test
+++ b/mysql-test/suite/galera/t/galera_parallel_simple.test
@@ -48,7 +48,7 @@ INSERT INTO t2 select * from t2;
 --connection node_2
 SET SESSION wsrep_sync_wait = 0;
 
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Waiting for table metadata lock%';
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'Waiting for table metadata lock%' OR STATE = 'Waiting to execute in isolation%';
 --source include/wait_condition.inc
 
 --let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE LIKE 'committing%';

--- a/mysql-test/suite/galera/t/mysql-wsrep#198.test
+++ b/mysql-test/suite/galera/t/mysql-wsrep#198.test
@@ -21,11 +21,12 @@ LOCK TABLE t2 WRITE;
 
 --connection node_2
 SET SESSION wsrep_sync_wait = 0;
---let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for table metadata lock'
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE STATE = 'Waiting for table metadata lock' OR STATE = 'Waiting to execute in isolation'
 --let $wait_condition_on_error_output = SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST
 --source include/wait_condition_with_debug_and_kill.inc
 
 --connection node_1
+--error 0,ER_LOCK_WAIT_TIMEOUT
 INSERT INTO t2 VALUES (1);
 
 --connection node_2


### PR DESCRIPTION
In later releases thd stage might be on Waiting for metadata lock very short time and then switch to Waiting for isolation in case there is MDL-conflict. Add this stage also to affected wait_conditions.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35941*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
