### PR TITLE
MDEV-36038 ALTER TABLE…SEQUENCE does not work correctly with InnoDB

### DIFF
--- a/mysql-test/suite/sql_sequence/alter.opt
+++ b/mysql-test/suite/sql_sequence/alter.opt
@@ -1,0 +1,1 @@
+--innodb-sys-tables

--- a/mysql-test/suite/sql_sequence/alter.result
+++ b/mysql-test/suite/sql_sequence/alter.result
@@ -166,6 +166,32 @@ next_not_cached_value	minimum_value	maximum_value	start_value	increment	cache_si
 select next value for t1;
 next value for t1
 11
+$check_innodb_flags;
+is_sequence
+12288
+alter table t1 sequence=0;
+begin;
+delete from t1;
+rollback;
+$check_innodb_flags;
+is_sequence
+0
+alter table t1 sequence=1;
+$check_innodb_flags;
+is_sequence
+12288
+alter table t1 sequence=0, algorithm=copy;
+$check_innodb_flags;
+is_sequence
+0
+alter table t1 sequence=1, algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: SEQUENCE. Try ALGORITHM=COPY
+alter table t1 sequence=1, algorithm=copy;
+$check_innodb_flags;
+is_sequence
+12288
+alter table t1 sequence=0, algorithm=inplace;
+ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: SEQUENCE. Try ALGORITHM=COPY
 drop sequence t1;
 #
 # ALTER TABLE

--- a/mysql-test/suite/sql_sequence/alter.test
+++ b/mysql-test/suite/sql_sequence/alter.test
@@ -80,6 +80,25 @@ alter sequence t1 start=100;
 show create sequence t1;
 select * from t1;
 select next value for t1;
+let $check_innodb_flags =
+select flag & 12288 is_sequence from information_schema.innodb_sys_tables
+where name='test/t1';
+evalp $check_innodb_flags;
+alter table t1 sequence=0;
+begin;
+delete from t1;
+rollback;
+evalp $check_innodb_flags;
+alter table t1 sequence=1;
+evalp $check_innodb_flags;
+alter table t1 sequence=0, algorithm=copy;
+evalp $check_innodb_flags;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t1 sequence=1, algorithm=inplace;
+alter table t1 sequence=1, algorithm=copy;
+evalp $check_innodb_flags;
+--error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON
+alter table t1 sequence=0, algorithm=inplace;
 drop sequence t1;
 
 --echo #

--- a/sql/ha_sequence.cc
+++ b/sql/ha_sequence.cc
@@ -353,6 +353,12 @@ bool ha_sequence::check_if_incompatible_data(HA_CREATE_INFO *create_info,
   return(COMPATIBLE_DATA_YES);
 }
 
+enum_alter_inplace_result
+ha_sequence::check_if_supported_inplace_alter(TABLE *altered_table,
+                                              Alter_inplace_info *ai)
+{
+  return file->check_if_supported_inplace_alter(altered_table, ai);
+}
 
 int ha_sequence::external_lock(THD *thd, int lock_type)
 {

--- a/sql/ha_sequence.h
+++ b/sql/ha_sequence.h
@@ -94,6 +94,9 @@ public:
   /* For ALTER ONLINE TABLE */
   bool check_if_incompatible_data(HA_CREATE_INFO *create_info,
                                   uint table_changes) override;
+  enum_alter_inplace_result
+  check_if_supported_inplace_alter(TABLE *altered_table,
+                                   Alter_inplace_info *ai) override;
   void write_lock() { write_locked= 1;}
   void unlock() { write_locked= 0; }
   bool is_locked() { return write_locked; }

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -11534,7 +11534,8 @@ do_continue:;
     - Neither old or new engine uses files from another engine
       The above is mainly true for the sequence and the partition engine.
   */
-  engine_changed= ((new_table->file->ht != table->file->ht) &&
+  engine_changed= ((new_table->file->storage_ht() !=
+                    table->file->storage_ht()) &&
                    ((!(new_table->file->ha_table_flags() & HA_FILE_BASED) ||
                      !(table->file->ha_table_flags() & HA_FILE_BASED))) &&
                    !(table->file->ha_table_flags() & HA_REUSES_FILE_NAMES) &&

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -2049,6 +2049,12 @@ ha_innobase::check_if_supported_inplace_alter(
 		DBUG_RETURN(HA_ALTER_INPLACE_NOT_SUPPORTED);
 	}
 
+	if (ha_alter_info->create_info->used_fields
+	    & HA_CREATE_USED_SEQUENCE) {
+		ha_alter_info->unsupported_reason = "SEQUENCE";
+		DBUG_RETURN(HA_ALTER_INPLACE_NOT_SUPPORTED);
+	}
+
 	update_thd();
 
 	if (!m_prebuilt->table->space) {
@@ -6317,6 +6323,8 @@ prepare_inplace_alter_table_dict(
 	DBUG_ASSERT(!ctx->add_index);
 	DBUG_ASSERT(!ctx->add_key_numbers);
 	DBUG_ASSERT(!ctx->num_to_add_index);
+	DBUG_ASSERT(!(ha_alter_info->create_info->used_fields
+		      & HA_CREATE_USED_SEQUENCE));
 
 	user_table = ctx->new_table;
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36038*
## Description
`mysql_alter_table()`: Consider `ha_sequence::storage_ht()` when determining if the storage engine changed.

`ha_sequence::check_if_supported_inplace_alter()`: A new function, to ensure that `ha_innobase::check_if_supported_inplace_alter()` will be called on `ALTER TABLE name_of_sequence SEQUENCE=0`.

`ha_innobase::check_if_supported_inplace_alter()`: For any change of the `SEQUENCE` attribute, always return `HA_ALTER_INPLACE_NOT_SUPPORTED`, forcing `ALGORITHM=COPY`.
## Release Notes
`ALTER TABLE…SEQUENCE=…` no longer corrupts the InnoDB data dictionary.
## How can this PR be tested?
```sh
./mtr sequence.alter
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.