### PR TITLE
MDEV-35152 - DATA/INDEX DIRECTORY options are ignored for vector index

### DIFF
--- a/mysql-test/main/vector_symlink.result
+++ b/mysql-test/main/vector_symlink.result
@@ -1,0 +1,66 @@
+#
+# MDEV-35152 - DATA/INDEX DIRECTORY options are ignored for vector index
+#
+create table t1i (a vector(1) not null, vector(a)) engine=InnoDB data directory 'MYSQL_TMP_DIR';
+create table t1m (a vector(1) not null, vector(a)) engine=MyISAM data directory 'MYSQL_TMP_DIR' index directory 'MYSQL_TMP_DIR';
+create table t1md (a vector(1) not null, vector(a)) engine=MyISAM data directory 'MYSQL_TMP_DIR';
+create table t1mi (a vector(1) not null, vector(a)) engine=MyISAM index directory 'MYSQL_TMP_DIR';
+show create table t1i;
+Table	Create Table
+t1i	CREATE TABLE `t1i` (
+  `a` vector(1) NOT NULL,
+  VECTOR KEY `a` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci DATA DIRECTORY='MYSQL_TMP_DIR/'
+show create table t1m;
+Table	Create Table
+t1m	CREATE TABLE `t1m` (
+  `a` vector(1) NOT NULL,
+  VECTOR KEY `a` (`a`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci DATA DIRECTORY='MYSQL_TMP_DIR/' INDEX DIRECTORY='MYSQL_TMP_DIR/'
+show create table t1md;
+Table	Create Table
+t1md	CREATE TABLE `t1md` (
+  `a` vector(1) NOT NULL,
+  VECTOR KEY `a` (`a`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci DATA DIRECTORY='MYSQL_TMP_DIR/'
+show create table t1mi;
+Table	Create Table
+t1mi	CREATE TABLE `t1mi` (
+  `a` vector(1) NOT NULL,
+  VECTOR KEY `a` (`a`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci INDEX DIRECTORY='MYSQL_TMP_DIR/'
+######### MYSQL_TMP_DIR:
+t1m#i#00.MYD
+t1m#i#00.MYI
+t1m.MYD
+t1m.MYI
+t1md#i#00.MYD
+t1md.MYD
+t1mi#i#00.MYI
+t1mi.MYI
+######### MYSQL_TMP_DIR/test:
+t1i#i#00.ibd
+t1i.ibd
+######### datadir/test:
+t1i#i#00.isl
+t1i.frm
+t1i.isl
+t1m#i#00.MYD
+t1m#i#00.MYI
+t1m.MYD
+t1m.MYI
+t1m.frm
+t1md#i#00.MYD
+t1md#i#00.MYI
+t1md.MYD
+t1md.MYI
+t1md.frm
+t1mi#i#00.MYD
+t1mi#i#00.MYI
+t1mi.MYD
+t1mi.MYI
+t1mi.frm
+drop table t1i, t1m, t1md, t1mi;
+######### MYSQL_TMP_DIR:
+######### MYSQL_TMP_DIR/test:
+######### datadir/test:

--- a/mysql-test/main/vector_symlink.test
+++ b/mysql-test/main/vector_symlink.test
@@ -1,0 +1,42 @@
+--source include/have_symlink.inc
+--source include/not_windows.inc
+--source include/have_innodb.inc
+
+
+ --echo #
+ --echo # MDEV-35152 - DATA/INDEX DIRECTORY options are ignored for vector index
+ --echo #
+--let $datadir= `select @@datadir`
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+eval create table t1i (a vector(1) not null, vector(a)) engine=InnoDB data directory '$MYSQL_TMP_DIR';
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+eval create table t1m (a vector(1) not null, vector(a)) engine=MyISAM data directory '$MYSQL_TMP_DIR' index directory '$MYSQL_TMP_DIR';
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+eval create table t1md (a vector(1) not null, vector(a)) engine=MyISAM data directory '$MYSQL_TMP_DIR';
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+eval create table t1mi (a vector(1) not null, vector(a)) engine=MyISAM index directory '$MYSQL_TMP_DIR';
+
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+show create table t1i;
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+show create table t1m;
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+show create table t1md;
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+show create table t1mi;
+
+--echo ######### MYSQL_TMP_DIR:
+--list_files $MYSQL_TMP_DIR/ t1*
+--echo ######### MYSQL_TMP_DIR/test:
+--list_files $MYSQL_TMP_DIR/test/ t1*
+--echo ######### datadir/test:
+--list_files $datadir/test/ t1*
+
+drop table t1i, t1m, t1md, t1mi;
+
+--echo ######### MYSQL_TMP_DIR:
+--list_files $MYSQL_TMP_DIR/ t1*
+--echo ######### MYSQL_TMP_DIR/test:
+--list_files $MYSQL_TMP_DIR/test/ t1*
+--echo ######### datadir/test:
+--list_files $datadir/test/ t1*


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35152*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Let high-level indexes honor DATA/INDEX DIRECTORY table options: now they store high-level index data files in DATA DIRECTORT and index files in INDEX DIRECTORY.

## How can this PR be tested?
mtr vector_symlink

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
