### PR TITLE
MDEV-35049: Use CRC-32C and avoid allocating heap (postfix)

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1047,9 +1047,9 @@ static void buf_block_init_low(buf_block_t *block) noexcept
   /* No adaptive hash index entries may point to a previously unused
   (and now freshly allocated) block. */
   MEM_MAKE_DEFINED(&block->index, sizeof block->index);
-  MEM_MAKE_DEFINED(&block->n_pointers, sizeof block->n_pointers);
   MEM_MAKE_DEFINED(&block->n_hash_helps, sizeof block->n_hash_helps);
 # if defined UNIV_AHI_DEBUG || defined UNIV_DEBUG
+  MEM_MAKE_DEFINED(&block->n_pointers, sizeof block->n_pointers);
   ut_a(!block->index);
   ut_a(!block->n_pointers);
   ut_a(!block->n_hash_helps);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35049*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The n_pointers member of block is only defined (in the C++ meaning) under the 'if defined UNIV_AHI_DEBUG || defined UNIV_DEBUG' condition. As without this change, this won't compile under WITH_MSAN=ON build for non-debug builds.

## Release Notes

No noted needed.

## How can this PR be tested?

build WITH_MSAN=ON on non-debug build

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.