### PR TITLE
MDEV-11341 STR_TO_DATE does not return NULL for invalid dates

### DIFF
--- a/mysql-test/main/func_time.result
+++ b/mysql-test/main/func_time.result
@@ -1314,6 +1314,47 @@ SELECT UTC_TIMESTAMP();
 SET TIMESTAMP=1;
 SELECT UTC_TIMESTAMP();
 SET TIMESTAMP=0;
+#
+# MDEV-11341 STR_TO_DATE does not return NULL for invalid dates
+#
+SELECT STR_TO_DATE('1949-02-30','%Y-%m-%d');
+STR_TO_DATE('1949-02-30','%Y-%m-%d')
+NULL
+Warnings:
+Warning	1411	Incorrect datetime value: '1949-02-30' for function str_to_date
+SELECT STR_TO_DATE('1949-02-28','%Y-%m-%d');
+STR_TO_DATE('1949-02-28','%Y-%m-%d')
+1949-02-28
+SELECT STR_TO_DATE('1949-06-31','%Y-%m-%d');
+STR_TO_DATE('1949-06-31','%Y-%m-%d')
+NULL
+Warnings:
+Warning	1411	Incorrect datetime value: '1949-06-31' for function str_to_date
+SELECT STR_TO_DATE('2000-02-29','%Y-%m-%d');
+STR_TO_DATE('2000-02-29','%Y-%m-%d')
+2000-02-29
+SELECT STR_TO_DATE('1900-02-29','%Y-%m-%d');
+STR_TO_DATE('1900-02-29','%Y-%m-%d')
+NULL
+Warnings:
+Warning	1411	Incorrect datetime value: '1900-02-29' for function str_to_date
+SET sql_mode=ALLOW_INVALID_DATES;
+SELECT STR_TO_DATE('1949-02-30','%Y-%m-%d');
+STR_TO_DATE('1949-02-30','%Y-%m-%d')
+1949-02-30
+SELECT STR_TO_DATE('1949-02-28','%Y-%m-%d');
+STR_TO_DATE('1949-02-28','%Y-%m-%d')
+1949-02-28
+SELECT STR_TO_DATE('1949-06-31','%Y-%m-%d');
+STR_TO_DATE('1949-06-31','%Y-%m-%d')
+1949-06-31
+SELECT STR_TO_DATE('2000-02-29','%Y-%m-%d');
+STR_TO_DATE('2000-02-29','%Y-%m-%d')
+2000-02-29
+SELECT STR_TO_DATE('1900-02-29','%Y-%m-%d');
+STR_TO_DATE('1900-02-29','%Y-%m-%d')
+1900-02-29
+SET sql_mode=DEFAULT;
 End of 5.0 tests
 select date_sub("0050-01-01 00:00:01",INTERVAL 2 SECOND);
 date_sub("0050-01-01 00:00:01",INTERVAL 2 SECOND)

--- a/mysql-test/main/func_time.test
+++ b/mysql-test/main/func_time.test
@@ -838,6 +838,23 @@ SET TIMESTAMP=1; SELECT UTC_TIMESTAMP();
 #reset back the timestamp value
 SET TIMESTAMP=0;
 
+--echo #
+--echo # MDEV-11341 STR_TO_DATE does not return NULL for invalid dates
+--echo #
+
+SELECT STR_TO_DATE('1949-02-30','%Y-%m-%d');
+SELECT STR_TO_DATE('1949-02-28','%Y-%m-%d');
+SELECT STR_TO_DATE('1949-06-31','%Y-%m-%d');
+SELECT STR_TO_DATE('2000-02-29','%Y-%m-%d');
+SELECT STR_TO_DATE('1900-02-29','%Y-%m-%d');
+
+SET sql_mode=ALLOW_INVALID_DATES;
+SELECT STR_TO_DATE('1949-02-30','%Y-%m-%d');
+SELECT STR_TO_DATE('1949-02-28','%Y-%m-%d');
+SELECT STR_TO_DATE('1949-06-31','%Y-%m-%d');
+SELECT STR_TO_DATE('2000-02-29','%Y-%m-%d');
+SELECT STR_TO_DATE('1900-02-29','%Y-%m-%d');
+SET sql_mode=DEFAULT;
 
 --echo End of 5.0 tests
 

--- a/mysql-test/main/strict.result
+++ b/mysql-test/main/strict.result
@@ -260,11 +260,11 @@ ERROR HY000: Incorrect datetime value: '31.0.2004 15.30' for function str_to_dat
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('0.10.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '0.10.2004 15.30' for function str_to_date
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('31.9.2004 15.30','%d.%m.%Y %H.%i'));
-ERROR 22007: Incorrect date value: '2004-09-31 15:30:00' for column `test`.`t1`.`col1` at row 1
+ERROR HY000: Incorrect datetime value: '31.9.2004 15.30' for function str_to_date
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('32.10.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '32.10.2004 15.30' for function str_to_date
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('29.02.2003 15.30','%d.%m.%Y %H.%i'));
-ERROR 22007: Incorrect date value: '2003-02-29 15:30:00' for column `test`.`t1`.`col1` at row 1
+ERROR HY000: Incorrect datetime value: '29.02.2003 15.30' for function str_to_date
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('15.13.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '15.13.2004 15.30' for function str_to_date
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('00.00.0000','%d.%m.%Y'));
@@ -274,11 +274,11 @@ ERROR HY000: Incorrect datetime value: '31.0.2004 15.30' for function str_to_dat
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('0.10.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '0.10.2004 15.30' for function str_to_date
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('31.9.2004 15.30','%d.%m.%Y %H.%i'));
-ERROR 22007: Incorrect datetime value: '2004-09-31 15:30:00' for column `test`.`t1`.`col2` at row 1
+ERROR HY000: Incorrect datetime value: '31.9.2004 15.30' for function str_to_date
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('32.10.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '32.10.2004 15.30' for function str_to_date
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('29.02.2003 15.30','%d.%m.%Y %H.%i'));
-ERROR 22007: Incorrect datetime value: '2003-02-29 15:30:00' for column `test`.`t1`.`col2` at row 1
+ERROR HY000: Incorrect datetime value: '29.02.2003 15.30' for function str_to_date
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('15.13.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '15.13.2004 15.30' for function str_to_date
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('00.00.0000','%d.%m.%Y'));
@@ -290,11 +290,11 @@ ERROR HY000: Incorrect datetime value: '31.0.2004 15.30' for function str_to_dat
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('0.10.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '0.10.2004 15.30' for function str_to_date
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('31.9.2004 15.30','%d.%m.%Y %H.%i'));
-ERROR 22007: Incorrect datetime value: '2004-09-31 15:30:00' for column `test`.`t1`.`col3` at row 1
+ERROR HY000: Incorrect datetime value: '31.9.2004 15.30' for function str_to_date
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('32.10.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '32.10.2004 15.30' for function str_to_date
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('29.02.2003 15.30','%d.%m.%Y %H.%i'));
-ERROR 22007: Incorrect datetime value: '2003-02-29 15:30:00' for column `test`.`t1`.`col3` at row 1
+ERROR HY000: Incorrect datetime value: '29.02.2003 15.30' for function str_to_date
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('15.13.2004 15.30','%d.%m.%Y %H.%i'));
 ERROR HY000: Incorrect datetime value: '15.13.2004 15.30' for function str_to_date
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('00.00.0000','%d.%m.%Y'));

--- a/mysql-test/main/strict.test
+++ b/mysql-test/main/strict.test
@@ -237,11 +237,11 @@ INSERT INTO t1 (col2) VALUES(STR_TO_DATE('31.10.0000 15.30','%d.%m.%Y %H.%i'));
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('31.0.2004 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('0.10.2004 15.30','%d.%m.%Y %H.%i'));
---error 1292
+--error ER_WRONG_VALUE_FOR_TYPE
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('31.9.2004 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('32.10.2004 15.30','%d.%m.%Y %H.%i'));
---error 1292
+--error ER_WRONG_VALUE_FOR_TYPE
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('29.02.2003 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col1) VALUES(STR_TO_DATE('15.13.2004 15.30','%d.%m.%Y %H.%i'));
@@ -256,11 +256,11 @@ INSERT INTO t1 (col1) VALUES(STR_TO_DATE('00.00.0000','%d.%m.%Y'));
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('31.0.2004 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('0.10.2004 15.30','%d.%m.%Y %H.%i'));
---error 1292
+--error ER_WRONG_VALUE_FOR_TYPE
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('31.9.2004 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('32.10.2004 15.30','%d.%m.%Y %H.%i'));
---error 1292
+--error ER_WRONG_VALUE_FOR_TYPE
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('29.02.2003 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col2) VALUES(STR_TO_DATE('15.13.2004 15.30','%d.%m.%Y %H.%i'));
@@ -277,11 +277,11 @@ INSERT INTO t1 (col3) VALUES(STR_TO_DATE('31.10.0000 15.30','%d.%m.%Y %H.%i'));
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('31.0.2004 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('0.10.2004 15.30','%d.%m.%Y %H.%i'));
---error 1292
+--error ER_WRONG_VALUE_FOR_TYPE
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('31.9.2004 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('32.10.2004 15.30','%d.%m.%Y %H.%i'));
---error 1292
+--error ER_WRONG_VALUE_FOR_TYPE
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('29.02.2003 15.30','%d.%m.%Y %H.%i'));
 --error 1411
 INSERT INTO t1 (col3) VALUES(STR_TO_DATE('15.13.2004 15.30','%d.%m.%Y %H.%i'));

--- a/sql/item_timefunc.cc
+++ b/sql/item_timefunc.cc
@@ -433,7 +433,7 @@ static bool extract_date_time(THD *thd, DATE_TIME_FORMAT *format,
     goto err;
 
   int was_cut;
-  if (check_date(l_time, fuzzydate | TIME_INVALID_DATES, &was_cut))
+  if (check_date(l_time, fuzzydate, &was_cut))
     goto err;
 
   if (val != val_end)


### PR DESCRIPTION
## Description

STR_TO_DATE function in MariaDB does date to string conversion for invalid dates strings, e.g.: 1949-02-30, and 1949-06-31, but null is return by other invalid dates such as 1949-01-32 because the checking function returns null for any date whose day is larger than 31, which is too naive and needs to be changed.

This commit changed the rule of check_date in extract_date_time function, which is executed after extracting date and time and check if
the result is valid. Now the conversion will consider the number of days in a month, including skip years.

## How can this PR be tested?

Execute the main suite in mysql-test-run.

## Basing the PR against the correct MariaDB version

* [x] _This is a new feature and the PR is based against the latest MariaDB development branch_

## Backward compatibility

This is a new feature introducing stricter date check before a conversion is generated and affect backwards compatibility.

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.