### PR TITLE
MDEV-36061 Incorrect error handling on DDL with FULLTEXT INDEX

### DIFF
--- a/mysql-test/suite/innodb_fts/r/index_table.result
+++ b/mysql-test/suite/innodb_fts/r/index_table.result
@@ -5,6 +5,9 @@ id INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
 title VARCHAR(200),
 content TEXT
 ) ENGINE= InnoDB;
+SET STATEMENT debug_dbug='+d,innodb_report_deadlock' FOR
+CREATE FULLTEXT INDEX idx ON articles (title, content);
+ERROR HY000: Got error 11 "Resource temporarily unavailable" from storage engine InnoDB
 CREATE FULLTEXT INDEX idx ON articles (title, content);
 INSERT INTO articles (title, content) VALUES
 ('MySQL Tutorial','DBMS stands for MySQL DataBase ...'),

--- a/mysql-test/suite/innodb_fts/t/index_table.test
+++ b/mysql-test/suite/innodb_fts/t/index_table.test
@@ -3,6 +3,9 @@
 
 -- source include/have_innodb.inc
 -- source include/have_debug.inc
+--disable_query_log
+call mtr.add_suppression("InnoDB: \\(Deadlock\\) writing `use_stopword'");
+--enable_query_log
 
 SET @optimize=@@GLOBAL.INNODB_OPTIMIZE_FULLTEXT_ONLY;
 SET GLOBAL INNODB_OPTIMIZE_FULLTEXT_ONLY=1;
@@ -14,6 +17,9 @@ CREATE TABLE articles (
 	content TEXT
 	) ENGINE= InnoDB;
 
+--error ER_GET_ERRNO
+SET STATEMENT debug_dbug='+d,innodb_report_deadlock' FOR
+CREATE FULLTEXT INDEX idx ON articles (title, content);
 CREATE FULLTEXT INDEX idx ON articles (title, content);
 
 INSERT INTO articles (title, content) VALUES

--- a/storage/innobase/fts/fts0config.cc
+++ b/storage/innobase/fts/fts0config.cc
@@ -231,7 +231,7 @@ fts_config_set_value(
 	n_rows_updated = trx->undo_no - undo_no;
 
 	/* Check if we need to do an insert. */
-	if (n_rows_updated == 0) {
+	if (error == DB_SUCCESS && n_rows_updated == 0) {
 		info = pars_info_create();
 
 		pars_info_bind_varchar_literal(

--- a/storage/innobase/fts/fts0fts.cc
+++ b/storage/innobase/fts/fts0fts.cc
@@ -37,6 +37,7 @@ Full Text Search interface
 #include "fts0plugin.h"
 #include "dict0stats.h"
 #include "btr0pcur.h"
+#include "log.h"
 
 static const ulint FTS_MAX_ID_LEN = 32;
 
@@ -1870,8 +1871,10 @@ fts_create_one_common_table(
 		}
 	}
 
-	ib::warn() << "Failed to create FTS common table " << fts_table_name;
-	trx->error_state = error;
+	ut_ad(trx->state == TRX_STATE_NOT_STARTED
+	      || trx->error_state == error);
+	sql_print_warning("InnoDB: Failed to create FTS common table %s: %s",
+			  fts_table_name, ut_strerr(error));
 	return NULL;
 }
 
@@ -2055,8 +2058,10 @@ fts_create_one_index_table(
 		}
 	}
 
-	ib::warn() << "Failed to create FTS index table " << table_name;
-	trx->error_state = error;
+	ut_ad(trx->state == TRX_STATE_NOT_STARTED
+	      || trx->error_state == error);
+	sql_print_warning("InnoDB: Failed to create FTS index table %s: %s",
+			  table_name, ut_strerr(error));
 	return NULL;
 }
 

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -2181,11 +2181,9 @@ row_create_index_for_mysql(
 
 		index = node->index;
 
-		ut_ad(!index == (err != DB_SUCCESS));
-
 		que_graph_free((que_t*) que_node_get_parent(thr));
 
-		if (index && (index->type & DICT_FTS)) {
+		if (err == DB_SUCCESS && (index->type & DICT_FTS)) {
 			err = fts_create_index_tables(trx, index, table->id);
 		}
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36061*
## Description
`row_create_index_for_mysql()`: Tolerate `DB_LOCK_TABLE_FULL` better.

`fts_create_one_common_table()`, `fts_create_one_index_table()`: Do not corrupt the error state of a non-active transaction object.

`fts_config_set_value()`: Only run another statement if there was no error yet.
## Release Notes
Some DDL error handling for InnoDB `FULLTEXT INDEX` was improved.
## How can this PR be tested?
This is somewhat covered by the tests `innodb_fts.index_table` and `innodb_fts.innodb-fts-ddl,vers_trx`.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

This is a bug fix, targeting the 10.6 release because that was the major version on which this bug was originally reproduced. The 10.5 branch might be affected as well, but it is close to end of life.
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.