### PR TITLE
MDEV-36082 Race condition between log_t::resize_start() and log_t::resize_abort()

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -1912,7 +1912,8 @@ inline void log_t::write_checkpoint(lsn_t end_lsn) noexcept
     resize_flush_buf= nullptr;
     resize_target= 0;
     resize_lsn.store(0, std::memory_order_relaxed);
-    writer_update();
+    resize_initiator= nullptr;
+    writer_update(false);
   }
 
   log_resize_release();

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -353,7 +353,7 @@ bool log_t::attach(log_file_t file, os_offset_t size)
 # endif
       buf= static_cast<byte*>(ptr);
       max_buf_free= 1;
-      writer_update();
+      writer_update(false);
 # ifdef HAVE_PMEM
       if (is_pmem)
         return true;
@@ -395,7 +395,7 @@ bool log_t::attach(log_file_t file, os_offset_t size)
   TRASH_ALLOC(buf, buf_size);
   TRASH_ALLOC(flush_buf, buf_size);
   max_buf_free= buf_size / LOG_BUF_FLUSH_RATIO - LOG_BUF_FLUSH_MARGIN;
-  writer_update();
+  writer_update(false);
   memset_aligned<512>(checkpoint_buf, 0, write_size);
 
  func_exit:
@@ -570,31 +570,35 @@ void log_t::set_buffered(bool buffered)
 
 /** Start resizing the log and release the exclusive latch.
 @param size  requested new file_size
+@param thd   the current thread identifier
 @return whether the resizing was started successfully */
-log_t::resize_start_status log_t::resize_start(os_offset_t size) noexcept
+log_t::resize_start_status log_t::resize_start(os_offset_t size, void *thd)
+  noexcept
 {
   ut_ad(size >= 4U << 20);
   ut_ad(!(size & 4095));
   ut_ad(!srv_read_only_mode);
+  ut_ad(thd);
 
   log_resize_acquire();
 
-  resize_start_status status= RESIZE_NO_CHANGE;
-  lsn_t start_lsn{0};
-#ifdef HAVE_PMEM
-  bool is_pmem{false};
-#endif
+  resize_start_status status;
 
-  if (resize_in_progress())
+  if (size == file_size)
+    status= RESIZE_NO_CHANGE;
+  else if (resize_in_progress())
     status= RESIZE_IN_PROGRESS;
-  else if (size != file_size)
+  else
   {
+    lsn_t start_lsn;
     ut_ad(!resize_in_progress());
     ut_ad(!resize_log.is_opened());
     ut_ad(!resize_buf);
     ut_ad(!resize_flush_buf);
+    ut_ad(!resize_initiator);
     std::string path{get_log_file_path("ib_logfile101")};
     bool success;
+    resize_initiator= thd;
     resize_lsn.store(1, std::memory_order_relaxed);
     resize_target= 0;
     resize_log.m_file=
@@ -612,6 +616,7 @@ log_t::resize_start_status log_t::resize_start(os_offset_t size) noexcept
 #ifdef HAVE_PMEM
       else if (is_mmap())
       {
+        bool is_pmem{false};
         ptr= ::log_mmap(resize_log.m_file, is_pmem, size);
 
         if (ptr == MAP_FAILED)
@@ -661,34 +666,33 @@ log_t::resize_start_status log_t::resize_start(os_offset_t size) noexcept
         else if (!is_opened())
           resize_log.close();
 
-        writer_update();
+        resize_lsn.store(start_lsn, std::memory_order_relaxed);
+        writer_update(true);
+        log_resize_release();
+
+        mysql_mutex_lock(&buf_pool.flush_list_mutex);
+        lsn_t target_lsn= buf_pool.get_oldest_modification(0);
+        mysql_mutex_unlock(&buf_pool.flush_list_mutex);
+        buf_flush_ahead(start_lsn < target_lsn ? target_lsn + 1 : start_lsn,
+                        false);
+        return RESIZE_STARTED;
       }
-      status= success ? RESIZE_STARTED : RESIZE_FAILED;
     }
-    resize_lsn.store(start_lsn, std::memory_order_relaxed);
+    resize_initiator= nullptr;
+    resize_lsn.store(0, std::memory_order_relaxed);
+    status= RESIZE_FAILED;
   }
 
   log_resize_release();
-
-  if (start_lsn)
-  {
-    mysql_mutex_lock(&buf_pool.flush_list_mutex);
-    lsn_t target_lsn= buf_pool.get_oldest_modification(0);
-    if (start_lsn < target_lsn)
-      start_lsn= target_lsn + 1;
-    mysql_mutex_unlock(&buf_pool.flush_list_mutex);
-    buf_flush_ahead(start_lsn, false);
-  }
-
   return status;
 }
 
-/** Abort log resizing. */
-void log_t::resize_abort() noexcept
+/** Abort a resize_start() that we started. */
+void log_t::resize_abort(void *thd) noexcept
 {
   log_resize_acquire();
 
-  if (resize_in_progress() > 1)
+  if (resize_running(thd))
   {
 #ifdef HAVE_PMEM
     const bool is_mmap{this->is_mmap()};
@@ -715,11 +719,12 @@ void log_t::resize_abort() noexcept
     resize_buf= nullptr;
     resize_target= 0;
     resize_lsn.store(0, std::memory_order_relaxed);
+    resize_initiator= nullptr;
     std::string path{get_log_file_path("ib_logfile101")};
     IF_WIN(DeleteFile(path.c_str()), unlink(path.c_str()));
+    writer_update(false);
   }
 
-  writer_update();
   log_resize_release();
 }
 
@@ -1190,10 +1195,11 @@ ATTRIBUTE_COLD static lsn_t log_writer_resizing() noexcept
   return log_sys.write_buf<log_t::RESIZING>();
 }
 
-void log_t::writer_update() noexcept
+void log_t::writer_update(bool resizing) noexcept
 {
   ut_ad(latch_have_wr());
-  writer= resize_in_progress() ? log_writer_resizing : log_writer;
+  ut_ad(resizing == (resize_in_progress() > 1));
+  writer= resizing ? log_writer_resizing : log_writer;
   mtr_t::finisher_update();
 }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36082*
## Description
`log_t::writer_update()`: Enable `log_writer_resizing` only if `resize_lsn>1`, to ensure that `log_t::resize_abort()` will not choose the wrong `log_sys.log_writer`.

`log_t::resize_start()`: Before invoking `writer_update()`, assign `resize_lsn>1` if applicable, so that the resizing will start correctly.
## Release Notes
When `SET GLOBAL innodb_log_file_size` is frequently attempted and interrupted during a write workload, InnoDB could crash due to attempting to write to a non-existing copy of a log.
## How can this PR be tested?
Stress testing with RQG generating `SET GLOBAL innodb_log_file_size` and `KILL` statements.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.