### PR TITLE
MDEV-35217: Provide information for debugging parallel replication

### DIFF
--- a/mysql-test/main/mysqld--help.result
+++ b/mysql-test/main/mysqld--help.result
@@ -1174,6 +1174,15 @@ The following specify which files/extra groups are read (specified before remain
  parallelism, possibly at the cost of increased conflict
  rate. "minimal" only parallelizes the commit steps of
  transactions. "none" disables parallel apply completely.
+ --slave-parallel-print-all-deadlocks=# 
+ Used to debug conflicts and deadlocks in parallel
+ replication. When set to 1, additional information will
+ be printed to the error log if a replicated transaction
+ gets a lock wait timeout or needs to retry more than once
+ due to a conflict or deadlock. When set to 2, all
+ conflicts and deadlocks will print additional
+ information; this should be used with care as it can
+ generate a lot of output
  --slave-parallel-threads=# 
  If non-zero, number of threads to spawn to apply in
  parallel events on the slave that were group-committed on
@@ -1714,6 +1723,7 @@ slave-max-allowed-packet 1073741824
 slave-net-timeout 60
 slave-parallel-max-queued 131072
 slave-parallel-mode conservative
+slave-parallel-print-all-deadlocks 0
 slave-parallel-threads 0
 slave-parallel-workers 0
 slave-run-triggers-for-rbr NO

--- a/mysql-test/suite/rpl/r/rpl_parallel_print_deadlocks.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_print_deadlocks.result
@@ -1,0 +1,249 @@
+include/master-slave.inc
+[connection master]
+MDEV-35217: Provide information for debugging parallel replication conflicts and hangs
+connection master;
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+CREATE TABLE t1 (a INT PRIMARY KEY AUTO_INCREMENT, b INT, c INT, INDEX (c)) ENGINE=InnoDB;
+INSERT INTO t1 (b,c) VALUES (0, 1), (0, 1), (0, 2), (0,3), (0, 5), (0, 7), (0, 8);
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+INSERT INTO t2 VALUES (10,1), (20,2), (30,3), (40,4), (50,5);
+CREATE TABLE t3 (a VARCHAR(20) PRIMARY KEY, b INT) ENGINE=InnoDB;
+INSERT INTO t3 VALUES ('row for T1', 0), ('row for T2', 0), ('row for T3', 0);
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET @save_innodb_lock_wait_timeout= @@global.innodb_lock_wait_timeout;
+SET @save_slave_parallel_print_all_deadlocks= @@global.slave_parallel_print_all_deadlocks;
+SET @save_slave_parallel_threads= @@global.slave_parallel_threads;
+SET @save_slave_parallel_mode= @@global.slave_parallel_mode;
+SET @save_slave_transaction_retries= @@global.slave_transaction_retries;
+SET @save_innodb_status_output_locks= @@global.innodb_status_output_locks;
+set @@global.slave_parallel_threads= 3;
+set @@global.slave_parallel_mode= OPTIMISTIC;
+SET @@global.innodb_status_output_locks= 1;
+CHANGE MASTER TO master_use_gtid= Slave_pos;
+*** Test --slave-parallel-print-all-deadlocks set to 0:
+connection slave;
+SET GLOBAL slave_parallel_print_all_deadlocks= 0;
+*** 1. Provoke a lock wait timeout.
+SET GLOBAL innodb_lock_wait_timeout= 1;
+SET @@global.slave_transaction_retries= 2;
+include/start_slave.inc
+connection slave1;
+BEGIN;
+SELECT COUNT(*) FROM t1 FOR UPDATE;
+COUNT(*)
+7
+connection master;
+INSERT INTO t1 (b, c) VALUES (0, 100 + 0*10);
+include/save_master_gtid.inc
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=1205]
+connection slave1;
+ROLLBACK;
+connection slave;
+SET GLOBAL innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+SET GLOBAL slave_transaction_retries= @save_slave_transaction_retries;
+START SLAVE SQL_THREAD;
+include/sync_with_master_gtid.inc
+*** 2. A normal conflict that causes only a single retry.
+connection slave1;
+BEGIN;
+SELECT * FROM t3 WHERE a="row for T1" FOR UPDATE;
+a	b
+row for T1	0
+connection master;
+BEGIN;
+UPDATE t3 SET b=b+1 WHERE a="row for T1";
+UPDATE t2 SET b=101 + 10*0 WHERE a=10;
+COMMIT;
+UPDATE t2 SET b=102 + 10*0 WHERE a=10;
+include/save_master_gtid.inc
+connection slave;
+connection slave1;
+ROLLBACK;
+connection slave;
+include/sync_with_master_gtid.inc
+*** 3. Simulate a double retry.
+connection slave;
+SET @old_dbug= @@GLOBAL.debug_dbug;
+SET GLOBAL debug_dbug="+d,rpl_parallel_simulate_temp_err_gtid_0_x_100,rpl_parallel_simulate_double_temp_err_gtid_0_x_100";
+connection master;
+SET gtid_seq_no = 100*(0+1);
+BEGIN;
+INSERT INTO t2 VALUES (100 + 10*0 + 4, 1);
+UPDATE t2 SET b=b+1 WHERE a=20;
+INSERT INTO t2 VALUES (100 + 10*0 + 5, 1);
+INSERT INTO t2 VALUES (100 + 10*0 + 6, 1);
+COMMIT;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+SET GLOBAL debug_dbug=@old_dbug;
+*** No debug output when disabled.
+NOT FOUND /Slave SQL thread: Deadlock detected, aborting/ in mysqld.2.err
+NOT FOUND /Slave SQL thread: Parallel replication retry/ in mysqld.2.err
+connection slave;
+include/stop_slave.inc
+*** Test --slave-parallel-print-all-deadlocks set to 1:
+connection slave;
+SET GLOBAL slave_parallel_print_all_deadlocks= 1;
+*** 1. Provoke a lock wait timeout.
+SET GLOBAL innodb_lock_wait_timeout= 1;
+SET @@global.slave_transaction_retries= 2;
+include/start_slave.inc
+connection slave1;
+BEGIN;
+SELECT COUNT(*) FROM t1 FOR UPDATE;
+COUNT(*)
+8
+connection master;
+INSERT INTO t1 (b, c) VALUES (1, 100 + 1*10);
+include/save_master_gtid.inc
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=1205]
+connection slave1;
+ROLLBACK;
+*** Lock wait timeout printed also for first retry.
+FOUND 1 /Slave SQL thread: Parallel replication retry 1 for event group GTID 0-1-101 .*error: 1205.*Lock wait timeout exceeded; try restarting transaction/ in mysqld.2.err
+FOUND 1 /Slave SQL thread: Parallel replication retry 2 for event group GTID 0-1-101 .*error: 1205.*Lock wait timeout exceeded; try restarting transaction/ in mysqld.2.err
+FOUND 2 /END OF INNODB MONITOR OUTPUT/ in mysqld.2.err
+connection slave;
+SET GLOBAL innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+SET GLOBAL slave_transaction_retries= @save_slave_transaction_retries;
+START SLAVE SQL_THREAD;
+include/sync_with_master_gtid.inc
+*** 2. A normal conflict that causes only a single retry.
+connection slave1;
+BEGIN;
+SELECT * FROM t3 WHERE a="row for T1" FOR UPDATE;
+a	b
+row for T1	1
+connection master;
+BEGIN;
+UPDATE t3 SET b=b+1 WHERE a="row for T1";
+UPDATE t2 SET b=101 + 10*1 WHERE a=10;
+COMMIT;
+UPDATE t2 SET b=102 + 10*1 WHERE a=10;
+include/save_master_gtid.inc
+connection slave;
+connection slave1;
+ROLLBACK;
+connection slave;
+include/sync_with_master_gtid.inc
+*** Normal conflict and retry _not_ printed when --slave-parallel-print-all-deadlocks=1
+NOT FOUND /GTID 0-1-102: MySQL thread id/ in mysqld.2.err
+NOT FOUND /GTID 0-1-103: MySQL thread id/ in mysqld.2.err
+NOT FOUND /Slave SQL thread: Parallel replication retry [0-9]* for event group GTID 0-1-103/ in mysqld.2.err
+*** 3. Simulate a double retry.
+connection slave;
+SET @old_dbug= @@GLOBAL.debug_dbug;
+SET GLOBAL debug_dbug="+d,rpl_parallel_simulate_temp_err_gtid_0_x_100,rpl_parallel_simulate_double_temp_err_gtid_0_x_100";
+connection master;
+SET gtid_seq_no = 100*(1+1);
+BEGIN;
+INSERT INTO t2 VALUES (100 + 10*1 + 4, 1);
+UPDATE t2 SET b=b+1 WHERE a=20;
+INSERT INTO t2 VALUES (100 + 10*1 + 5, 1);
+INSERT INTO t2 VALUES (100 + 10*1 + 6, 1);
+COMMIT;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+SET GLOBAL debug_dbug=@old_dbug;
+*** Double retry printed for both --slave-parallel-print-all-deadlocks=1 and =2
+FOUND 1 /Slave SQL thread: Parallel replication retry 2 for event group GTID 0-1-200 .*error: 1213.*Deadlock found when trying to get lock/ in mysqld.2.err
+FOUND 2 /END OF INNODB MONITOR OUTPUT/ in mysqld.2.err
+*** First retry only printed in --slave-parallel-print-all-deadlocks=2
+NOT FOUND /Slave SQL thread: Parallel replication retry 1 for event group GTID 0-1-200 .*error: 1213.*Deadlock found when trying to get lock/ in mysqld.2.err
+connection slave;
+include/stop_slave.inc
+*** Test --slave-parallel-print-all-deadlocks set to 2:
+connection slave;
+SET GLOBAL slave_parallel_print_all_deadlocks= 2;
+*** 1. Provoke a lock wait timeout.
+SET GLOBAL innodb_lock_wait_timeout= 1;
+SET @@global.slave_transaction_retries= 2;
+include/start_slave.inc
+connection slave1;
+BEGIN;
+SELECT COUNT(*) FROM t1 FOR UPDATE;
+COUNT(*)
+9
+connection master;
+INSERT INTO t1 (b, c) VALUES (2, 100 + 2*10);
+include/save_master_gtid.inc
+connection slave;
+include/wait_for_slave_sql_error.inc [errno=1205]
+connection slave1;
+ROLLBACK;
+*** Lock wait timeout printed also for first retry.
+FOUND 1 /Slave SQL thread: Parallel replication retry 1 for event group GTID 0-1-201 .*error: 1205.*Lock wait timeout exceeded; try restarting transaction/ in mysqld.2.err
+FOUND 1 /Slave SQL thread: Parallel replication retry 2 for event group GTID 0-1-201 .*error: 1205.*Lock wait timeout exceeded; try restarting transaction/ in mysqld.2.err
+FOUND 4 /END OF INNODB MONITOR OUTPUT/ in mysqld.2.err
+connection slave;
+SET GLOBAL innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+SET GLOBAL slave_transaction_retries= @save_slave_transaction_retries;
+START SLAVE SQL_THREAD;
+include/sync_with_master_gtid.inc
+*** 2. A normal conflict that causes only a single retry.
+connection slave1;
+BEGIN;
+SELECT * FROM t3 WHERE a="row for T1" FOR UPDATE;
+a	b
+row for T1	2
+connection master;
+BEGIN;
+UPDATE t3 SET b=b+1 WHERE a="row for T1";
+UPDATE t2 SET b=101 + 10*2 WHERE a=10;
+COMMIT;
+UPDATE t2 SET b=102 + 10*2 WHERE a=10;
+include/save_master_gtid.inc
+connection slave;
+connection slave1;
+ROLLBACK;
+connection slave;
+include/sync_with_master_gtid.inc
+*** Any conflict and retry printed when --slave-parallel-print-all-deadlocks=2
+FOUND 1 /Slave SQL thread: Deadlock detected, aborting second event group/ in mysqld.2.err
+FOUND 1 /GTID 0-1-202: MySQL thread id/ in mysqld.2.err
+FOUND 1 /GTID 0-1-203: MySQL thread id/ in mysqld.2.err
+FOUND 1 /Slave SQL thread: Parallel replication retry 1 for event group GTID 0-1-203 .*error: 1213.*Deadlock found when trying to get lock/ in mysqld.2.err
+FOUND 5 /END OF INNODB MONITOR OUTPUT/ in mysqld.2.err
+*** 3. Simulate a double retry.
+connection slave;
+SET @old_dbug= @@GLOBAL.debug_dbug;
+SET GLOBAL debug_dbug="+d,rpl_parallel_simulate_temp_err_gtid_0_x_100,rpl_parallel_simulate_double_temp_err_gtid_0_x_100";
+connection master;
+SET gtid_seq_no = 100*(2+1);
+BEGIN;
+INSERT INTO t2 VALUES (100 + 10*2 + 4, 1);
+UPDATE t2 SET b=b+1 WHERE a=20;
+INSERT INTO t2 VALUES (100 + 10*2 + 5, 1);
+INSERT INTO t2 VALUES (100 + 10*2 + 6, 1);
+COMMIT;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+SET GLOBAL debug_dbug=@old_dbug;
+*** Double retry printed for both --slave-parallel-print-all-deadlocks=1 and =2
+FOUND 1 /Slave SQL thread: Parallel replication retry 2 for event group GTID 0-1-300 .*error: 1213.*Deadlock found when trying to get lock/ in mysqld.2.err
+FOUND 6 /END OF INNODB MONITOR OUTPUT/ in mysqld.2.err
+*** First retry only printed in --slave-parallel-print-all-deadlocks=2
+FOUND 1 /Slave SQL thread: Parallel replication retry 1 for event group GTID 0-1-300 .*error: 1213.*Deadlock found when trying to get lock/ in mysqld.2.err
+connection slave;
+include/stop_slave.inc
+connection slave;
+SET GLOBAL innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+SET GLOBAL slave_parallel_print_all_deadlocks= @save_slave_parallel_print_all_deadlocks;
+SET GLOBAL slave_parallel_threads= @save_slave_parallel_threads;
+SET GLOBAL slave_parallel_mode= @save_slave_parallel_mode;
+SET GLOBAL slave_transaction_retries= @save_slave_transaction_retries;
+SET GLOBAL innodb_status_output_locks= @save_innodb_status_output_locks;
+include/start_slave.inc
+connection master;
+CALL mtr.add_suppression("Slave worker thread retried transaction");
+DROP TABLE t1, t2, t3;
+connection slave;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_parallel_print_deadlocks.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_print_deadlocks.test
@@ -1,0 +1,202 @@
+--source include/have_debug.inc
+--source include/have_innodb.inc
+--source include/have_binlog_format_mixed.inc
+--source include/master-slave.inc
+
+--echo MDEV-35217: Provide information for debugging parallel replication conflicts and hangs
+
+--connection master
+ALTER TABLE mysql.gtid_slave_pos ENGINE=InnoDB;
+
+CREATE TABLE t1 (a INT PRIMARY KEY AUTO_INCREMENT, b INT, c INT, INDEX (c)) ENGINE=InnoDB;
+INSERT INTO t1 (b,c) VALUES (0, 1), (0, 1), (0, 2), (0,3), (0, 5), (0, 7), (0, 8);
+
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=InnoDB;
+INSERT INTO t2 VALUES (10,1), (20,2), (30,3), (40,4), (50,5);
+
+# A table to help order slave worker threads to setup the desired scenario.
+CREATE TABLE t3 (a VARCHAR(20) PRIMARY KEY, b INT) ENGINE=InnoDB;
+INSERT INTO t3 VALUES ('row for T1', 0), ('row for T2', 0), ('row for T3', 0);
+--source include/save_master_gtid.inc
+
+--connection slave
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+SET @save_innodb_lock_wait_timeout= @@global.innodb_lock_wait_timeout;
+SET @save_slave_parallel_print_all_deadlocks= @@global.slave_parallel_print_all_deadlocks;
+SET @save_slave_parallel_threads= @@global.slave_parallel_threads;
+SET @save_slave_parallel_mode= @@global.slave_parallel_mode;
+SET @save_slave_transaction_retries= @@global.slave_transaction_retries;
+SET @save_innodb_status_output_locks= @@global.innodb_status_output_locks;
+set @@global.slave_parallel_threads= 3;
+set @@global.slave_parallel_mode= OPTIMISTIC;
+SET @@global.innodb_status_output_locks= 1;
+CHANGE MASTER TO master_use_gtid= Slave_pos;
+
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.2.err;
+
+
+let $i= 0;
+while ($i < 3) {
+  --echo *** Test --slave-parallel-print-all-deadlocks set to $i:
+  --connection slave
+  eval SET GLOBAL slave_parallel_print_all_deadlocks= $i;
+
+  --echo *** 1. Provoke a lock wait timeout.
+  SET GLOBAL innodb_lock_wait_timeout= 1;
+  SET @@global.slave_transaction_retries= 2;
+  --source include/start_slave.inc
+  --connection slave1
+  # Block the replication thread from applying its event.
+  BEGIN;
+  SELECT COUNT(*) FROM t1 FOR UPDATE;
+
+  --connection master
+  eval INSERT INTO t1 (b, c) VALUES ($i, 100 + $i*10);
+  --let $gtid= `SELECT @@last_gtid`
+  --source include/save_master_gtid.inc
+
+  --connection slave
+  --let $slave_sql_errno= 1205
+  --source include/wait_for_slave_sql_error.inc
+
+  --connection slave1
+  ROLLBACK;
+
+  if ($i > 0) {
+    --echo *** Lock wait timeout printed also for first retry.
+    --let SEARCH_PATTERN= Slave SQL thread: Parallel replication retry 1 for event group GTID $gtid .*error: 1205.*Lock wait timeout exceeded; try restarting transaction
+    --let SEARCH_ABORT= NOT FOUND
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= Slave SQL thread: Parallel replication retry 2 for event group GTID $gtid .*error: 1205.*Lock wait timeout exceeded; try restarting transaction
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= END OF INNODB MONITOR OUTPUT
+    --source include/search_pattern_in_file.inc
+  }
+
+  --connection slave
+  SET GLOBAL innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+  SET GLOBAL slave_transaction_retries= @save_slave_transaction_retries;
+  START SLAVE SQL_THREAD;
+  --source include/sync_with_master_gtid.inc
+
+  --echo *** 2. A normal conflict that causes only a single retry.
+  --connection slave1
+  # Block T1 temporarily so it will reliably get a conflict with T2.
+  BEGIN;
+  SELECT * FROM t3 WHERE a="row for T1" FOR UPDATE;
+  --connection master
+  # T1.
+  BEGIN;
+  UPDATE t3 SET b=b+1 WHERE a="row for T1";
+  eval UPDATE t2 SET b=101 + 10*$i WHERE a=10;
+  COMMIT;
+  --let $gtid1= `SELECT @@last_gtid`
+  # T2.
+  eval UPDATE t2 SET b=102 + 10*$i WHERE a=10;
+  --let $gtid2= `SELECT @@last_gtid`
+  --source include/save_master_gtid.inc
+
+  --connection slave
+  # Wait for T2 to have gotten its lock that will block T1.
+  --let $wait_condition= SELECT count(*)=1 FROM information_schema.processlist WHERE state='Waiting for prior transaction to commit' and command LIKE 'Slave_worker';
+  --source include/wait_condition.inc
+  --connection slave1
+  # Release T1; it will deadlock kill T2 and eventually both will complete.
+  ROLLBACK;
+  --connection slave
+  --source include/sync_with_master_gtid.inc
+  if ($i == 1) {
+    --echo *** Normal conflict and retry _not_ printed when --slave-parallel-print-all-deadlocks=1
+    --let SEARCH_PATTERN= GTID $gtid1: MySQL thread id
+    --let SEARCH_ABORT= FOUND
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= GTID $gtid2: MySQL thread id
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= Slave SQL thread: Parallel replication retry [0-9]* for event group GTID $gtid2
+    --source include/search_pattern_in_file.inc
+  }
+  if ($i == 2) {
+    --echo *** Any conflict and retry printed when --slave-parallel-print-all-deadlocks=2
+    --let SEARCH_PATTERN= Slave SQL thread: Deadlock detected, aborting second event group
+    --let SEARCH_ABORT= NOT FOUND
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= GTID $gtid1: MySQL thread id
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= GTID $gtid2: MySQL thread id
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= Slave SQL thread: Parallel replication retry 1 for event group GTID $gtid2 .*error: 1213.*Deadlock found when trying to get lock
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= END OF INNODB MONITOR OUTPUT
+    --source include/search_pattern_in_file.inc
+  }
+
+  --echo *** 3. Simulate a double retry.
+  --connection slave
+  SET @old_dbug= @@GLOBAL.debug_dbug;
+  SET GLOBAL debug_dbug="+d,rpl_parallel_simulate_temp_err_gtid_0_x_100,rpl_parallel_simulate_double_temp_err_gtid_0_x_100";
+
+  --connection master
+  # The seq_no=100/200/300 triggers the DBUG injection that simulates double retry.
+  eval SET gtid_seq_no = 100*($i+1);
+  BEGIN;
+  eval INSERT INTO t2 VALUES (100 + 10*$i + 4, 1);
+  UPDATE t2 SET b=b+1 WHERE a=20;
+  eval INSERT INTO t2 VALUES (100 + 10*$i + 5, 1);
+  eval INSERT INTO t2 VALUES (100 + 10*$i + 6, 1);
+  COMMIT;
+  --let $gtid= `SELECT @@last_gtid`
+  --source include/save_master_gtid.inc
+
+  --connection slave
+  --source include/sync_with_master_gtid.inc
+  SET GLOBAL debug_dbug=@old_dbug;
+
+  if ($i > 0) {
+    --echo *** Double retry printed for both --slave-parallel-print-all-deadlocks=1 and =2
+    --let SEARCH_PATTERN= Slave SQL thread: Parallel replication retry 2 for event group GTID $gtid .*error: 1213.*Deadlock found when trying to get lock
+    --let SEARCH_ABORT= NOT FOUND
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= END OF INNODB MONITOR OUTPUT
+    --source include/search_pattern_in_file.inc
+    --echo *** First retry only printed in --slave-parallel-print-all-deadlocks=2
+    --let SEARCH_PATTERN= Slave SQL thread: Parallel replication retry 1 for event group GTID $gtid .*error: 1213.*Deadlock found when trying to get lock
+    if ($i == 1) {
+      --let SEARCH_ABORT= FOUND
+    }
+    --source include/search_pattern_in_file.inc
+  }
+
+
+  if ($i == 0) {
+    --echo *** No debug output when disabled.
+    --let SEARCH_PATTERN= Slave SQL thread: Deadlock detected, aborting
+    --let SEARCH_ABORT= FOUND
+    --source include/search_pattern_in_file.inc
+    --let SEARCH_PATTERN= Slave SQL thread: Parallel replication retry
+    --source include/search_pattern_in_file.inc
+  }
+    --let SEARCH_ABORT=
+
+  --connection slave
+  --source include/stop_slave.inc
+  inc $i;
+}
+
+
+# Cleanup.
+--connection slave
+SET GLOBAL innodb_lock_wait_timeout= @save_innodb_lock_wait_timeout;
+SET GLOBAL slave_parallel_print_all_deadlocks= @save_slave_parallel_print_all_deadlocks;
+SET GLOBAL slave_parallel_threads= @save_slave_parallel_threads;
+SET GLOBAL slave_parallel_mode= @save_slave_parallel_mode;
+SET GLOBAL slave_transaction_retries= @save_slave_transaction_retries;
+SET GLOBAL innodb_status_output_locks= @save_innodb_status_output_locks;
+--source include/start_slave.inc
+
+--connection master
+CALL mtr.add_suppression("Slave worker thread retried transaction");
+DROP TABLE t1, t2, t3;
+
+--connection slave
+--source include/rpl_end.inc

--- a/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
+++ b/mysql-test/suite/sys_vars/r/sysvars_server_notembedded.result
@@ -3602,6 +3602,16 @@ NUMERIC_BLOCK_SIZE	NULL
 ENUM_VALUE_LIST	none,minimal,conservative,optimistic,aggressive
 READ_ONLY	NO
 COMMAND_LINE_ARGUMENT	NULL
+VARIABLE_NAME	SLAVE_PARALLEL_PRINT_ALL_DEADLOCKS
+VARIABLE_SCOPE	GLOBAL
+VARIABLE_TYPE	INT UNSIGNED
+VARIABLE_COMMENT	Used to debug conflicts and deadlocks in parallel replication. When set to 1, additional information will be printed to the error log if a replicated transaction gets a lock wait timeout or needs to retry more than once due to a conflict or deadlock. When set to 2, all conflicts and deadlocks will print additional information; this should be used with care as it can generate a lot of output
+NUMERIC_MIN_VALUE	0
+NUMERIC_MAX_VALUE	2
+NUMERIC_BLOCK_SIZE	1
+ENUM_VALUE_LIST	NULL
+READ_ONLY	NO
+COMMAND_LINE_ARGUMENT	REQUIRED
 VARIABLE_NAME	SLAVE_PARALLEL_THREADS
 VARIABLE_SCOPE	GLOBAL
 VARIABLE_TYPE	BIGINT UNSIGNED

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -552,6 +552,7 @@ ulong opt_binlog_commit_wait_usec= 0;
 ulong opt_slave_parallel_max_queued= 131072;
 my_bool opt_gtid_ignore_duplicates= FALSE;
 uint opt_gtid_cleanup_batch_size= 64;
+uint opt_slave_parallel_print_all_deadlocks= 0;
 
 const double log_10[] = {
   1e000, 1e001, 1e002, 1e003, 1e004, 1e005, 1e006, 1e007, 1e008, 1e009,

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -253,6 +253,7 @@ extern ulong opt_slave_parallel_threads;
 extern ulong opt_slave_domain_parallel_threads;
 extern ulong opt_slave_parallel_max_queued;
 extern ulong opt_slave_parallel_mode;
+extern uint opt_slave_parallel_print_all_deadlocks;
 extern ulong opt_binlog_commit_wait_count;
 extern ulong opt_binlog_commit_wait_usec;
 extern my_bool opt_gtid_ignore_duplicates;

--- a/sql/rpl_parallel.cc
+++ b/sql/rpl_parallel.cc
@@ -731,7 +731,10 @@ rpl_pause_for_ftwrl(THD *thd)
 static int
 dbug_simulate_tmp_error(rpl_group_info *rgi, THD *thd)
 {
-  if (rgi->current_gtid.domain_id == 0 && rgi->current_gtid.seq_no == 100 &&
+  if (rgi->current_gtid.domain_id == 0 &&
+      (rgi->current_gtid.seq_no == 100 ||
+       rgi->current_gtid.seq_no == 200 ||
+       rgi->current_gtid.seq_no == 300) &&
       rgi->retry_event_count == 4)
   {
     thd->clear_error();
@@ -801,6 +804,97 @@ is_group_ending(Log_event *ev, Log_event_type event_type)
 }
 
 
+static bool
+rpl_parallel_print_engine(THD *thd, const char *type, size_t type_len,
+                          const char *file, size_t file_len,
+                          const char *status, size_t status_len)
+{
+  /*
+    Annoyingly, we have to zero-terminate the string for
+    sql_print_information().
+  */
+  StringBuffer<32> engine_str;
+  engine_str.append(type, type_len);
+  sql_print_information("Slave SQL thread: Engine '%s' status:",
+                        engine_str.c_ptr_safe());
+  /*
+    Write the engine status directly to stderr. This is necessary to get a
+    useful amount of information, as sql_print_information() cuts the length
+    to 1024 max. The similar innobase_print_all_deadlocks option works in a
+    similar way.
+  */
+  fwrite(status, sizeof(char), status_len, stderr);
+  return false;
+}
+
+
+/*
+  Output some information to the error log to help debug problems or conflicts
+  in parallel replication.
+
+  Arguments:
+    thd              THD of the thread calling this function
+    conflicting_thd  THD that caused a conflict or a retry; the information
+                     output will be based on the open transaction in this THD.
+*/
+static void
+rpl_parallel_print_info(THD *thd, THD *conflicting_thd)
+{
+  char buf[1024];
+
+  sql_print_information("Slave SQL thread: Event groups in reverse "
+                        "commit order:");
+  wait_for_commit *wfc= conflicting_thd->wait_for_commit_ptr;
+  if (wfc)
+  {
+    mysql_mutex_lock(&wfc->LOCK_wait_commit);
+    for (;;)
+    {
+      THD *info_thd= wfc->owner_thd;
+      if (info_thd)
+      {
+        char *info=
+          thd_get_error_context_description(info_thd, buf, sizeof(buf), 512);
+        const rpl_group_info *rgi= info_thd->rgi_slave;
+        if (rgi)
+          sql_print_information("Slave SQL thread:   GTID %u-%u-%llu, %s",
+                                rgi->current_gtid.domain_id,
+                                rgi->current_gtid.server_id,
+                                (ulonglong)rgi->current_gtid.seq_no, info);
+        else
+          sql_print_information("Slave SQL thread:   --- %s", info);
+      }
+      else
+        sql_print_information("Slave SQL thread:   (unknown commit_orderer %p)",
+                              wfc);
+
+      wait_for_commit *parent_wfc= wfc->waitee.load(std::memory_order_relaxed);
+      if (!parent_wfc)
+        break;
+      mysql_mutex_lock(&parent_wfc->LOCK_wait_commit);
+      mysql_mutex_unlock(&wfc->LOCK_wait_commit);
+      wfc= parent_wfc;
+    }
+    mysql_mutex_unlock(&wfc->LOCK_wait_commit);
+  }
+
+  Ha_trx_info *ha_list= conflicting_thd->transaction.all.ha_list;
+  if (ha_list && ha_list->is_started())
+  {
+    sql_print_information("Slave SQL thread: Status from engines participating "
+                          "in active transaction:");
+    do
+    {
+      handlerton *engine= ha_list->ht();
+      if (engine->show_status)
+        (*engine->show_status)(engine, thd, rpl_parallel_print_engine,
+                               HA_ENGINE_STATUS);
+      ha_list= ha_list->next();
+    } while (ha_list);
+  }
+}
+
+
 static int
 retry_event_group(rpl_group_info *rgi, rpl_parallel_thread *rpt,
                   rpl_parallel_thread::queued_event *orig_qev)
@@ -825,6 +919,38 @@ do_retry:
   event_count= 0;
   err= 0;
   errmsg= NULL;
+
+  if (unlikely(opt_slave_parallel_print_all_deadlocks))
+  {
+    uint error_code= rli->last_error().number;
+    const char *error_msg= "";
+    if (thd->is_error())
+    {
+      error_code= thd->get_stmt_da()->sql_errno();
+      error_msg= thd->get_stmt_da()->message();
+    }
+    /*
+      Output debug info if this is an unexpected retry. It is unexpected to
+      retry more than once, since we do wait_for_prior_commit() before the
+      retry. It is also unexpected to ever get lock wait timeout, that could
+      mean an unhandled conflict (which would indicate a bug).
+
+      Or if user requested it, then output the info for any retry.
+    */
+    if (retries >= 1 ||
+        error_code == ER_LOCK_WAIT_TIMEOUT ||
+        opt_slave_parallel_print_all_deadlocks == 2)
+    {
+      sql_print_information("Slave SQL thread: Parallel replication retry %lu "
+                            "for event group GTID %u-%u-%llu (error: %u %s); "
+                            "additional information follows:", retries+1,
+                            rgi->current_gtid.domain_id,
+                            rgi->current_gtid.server_id,
+                            (ulonglong)rgi->current_gtid.seq_no,
+                            error_code, error_msg);
+      rpl_parallel_print_info(thd, thd);
+    }
+  }
 
   /*
     If we already started committing before getting the deadlock (or other
@@ -886,6 +1012,7 @@ do_retry:
   thd->reset_killed();
   thd->clear_error();
   rgi->killed_for_retry = rpl_group_info::RETRY_KILL_NONE;
+  rgi->trans_retries= retries + 1;
 #ifdef ENABLED_DEBUG_SYNC
     DBUG_EXECUTE_IF("hold_worker2_favor_worker3", {
       if (rgi->current_gtid.seq_no == 2003) {
@@ -1346,7 +1473,7 @@ handle_rpl_parallel_thread(void *arg)
                  Gtid_log_event::FL_STANDALONE));
 
         event_gtid_sub_id= rgi->gtid_sub_id;
-        rgi->thd= thd;
+        rgi->thd= rgi->commit_orderer.owner_thd= thd;
 
         DBUG_EXECUTE_IF("gco_wait_delay_gtid_0_x_99", {
             if (rgi->current_gtid.domain_id == 0 && rgi->current_gtid.seq_no == 99) {

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -5289,8 +5289,9 @@ pthread_handler_t handle_slave_sql(void *arg)
     In single thread replication this is the THD for the thread that is
     executing SQL queries too.
   */
-  serial_rgi->thd= rli->sql_driver_thd= thd;
-  
+  serial_rgi->thd= serial_rgi->commit_orderer.owner_thd=
+    rli->sql_driver_thd= thd;
+
   /* Inform waiting threads that slave has started */
   rli->slave_run_id++;
   rli->slave_running= MYSQL_SLAVE_RUN_NOT_CONNECT;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -5191,6 +5191,27 @@ thd_rpl_deadlock_check(MYSQL_THD thd, MYSQL_THD other_thd)
     releasing the lock for this transaction so replication can proceed.
   */
 #ifdef HAVE_REPLICATION
+  if (unlikely(opt_slave_parallel_print_all_deadlocks) &&
+      (other_rgi->trans_retries >= 1 ||
+       opt_slave_parallel_print_all_deadlocks == 2))
+  {
+    char thd_info[400];
+    char other_thd_info[400];
+    thd_get_error_context_description(thd, thd_info, sizeof(thd_info), 350);
+    thd_get_error_context_description(other_thd, other_thd_info,
+                                      sizeof(other_thd_info), 350);
+    sql_print_information("Slave SQL thread: Deadlock detected, aborting "
+                          "second event group:\nGTID %u-%u-%llu: %s\n"
+                          "GTID %u-%u-%llu: %s",
+                          rgi->current_gtid.domain_id,
+                          rgi->current_gtid.server_id,
+                          (ulonglong)rgi->current_gtid.seq_no,
+                          thd_info,
+                          other_rgi->current_gtid.domain_id,
+                          other_rgi->current_gtid.server_id,
+                          (ulonglong)other_rgi->current_gtid.seq_no,
+                          other_thd_info);
+  }
   slave_background_kill_request(other_thd);
 #endif
   return 1;
@@ -7560,6 +7581,7 @@ wait_for_commit::reinit()
   next_subsequent_commit= NULL;
   waitee.store(NULL, std::memory_order_relaxed);
   opaque_pointer= NULL;
+  owner_thd= NULL;
   wakeup_error= 0;
   wakeup_subsequent_commits_running= false;
   commit_started= false;
@@ -7702,7 +7724,7 @@ wait_for_commit::register_wait_for_prior_commit(wait_for_commit *waitee)
 
   If ALLOW_KILL is set to true (the default), the wait can be aborted by a
   kill. In case of kill, the wait registration is still removed, so another
-  call of unregister_wait_for_prior_commit() is needed to later retry the
+  call of register_wait_for_prior_commit() is needed to later retry the
   wait. If ALLOW_KILL is set to false, then kill will be ignored and this
   function will not return until the prior commit (if any) has called
   wakeup_subsequent_commits().

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2135,6 +2135,8 @@ struct wait_for_commit
     used by another transaction coordinator for similar purposes.
   */
   void *opaque_pointer;
+  /* The owning THD, if any. */
+  THD *owner_thd;
   /* The wakeup error code from the waitee. 0 means no error. */
   int wakeup_error;
   /*

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2253,6 +2253,18 @@ static Sys_var_bit Sys_skip_parallel_replication(
        DEFAULT(FALSE));
 
 
+static Sys_var_uint Sys_slave_parallel_print_all_deadlocks(
+       "slave_parallel_print_all_deadlocks",
+       "Used to debug conflicts and deadlocks in parallel replication. "
+       "When set to 1, additional information will be printed to the error "
+       "log if a replicated transaction gets a lock wait timeout or needs to "
+       "retry more than once due to a conflict or deadlock. When set to 2, "
+       "all conflicts and deadlocks will print additional information; this "
+       "should be used with care as it can generate a lot of output",
+       GLOBAL_VAR(opt_slave_parallel_print_all_deadlocks),
+       CMD_LINE(REQUIRED_ARG), VALID_RANGE(0, 2), DEFAULT(0), BLOCK_SIZE(1));
+
+
 static bool
 check_gtid_ignore_duplicates(sys_var *self, THD *thd, set_var *var)
 {


### PR DESCRIPTION
Implement an option --slave-parallel-print-all-deadlocks to debug parallel replication conflicts. This option enables additional information in the server's error log when a parallel replication conflict or deadlock occurs, similar to --innodb-print-all-deadlocks. This should be very useful to help investigate the cause of problems with parallel replication, including helping to find the root cause of any bugs.

The information printed includes the GTID and thread info of conflicting threads; the chain of wait_for_prior_commits; and the SHOW ENGINE STATUS of engines participating in the current transaction.

Setting @@slave_parallel_print_all_deadlocks to 1 will output the information when an unexpected conflict occurs; this means an event group that needed to retry more than once, or any lock wait timeout. Setting @@slave_parallel_print_all_deadlocks to 2 will output the information for any detected conflict.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
