### PR TITLE
MDEV-32362 Handle generated columns in mariadb-dump INSERT statements 

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -3205,7 +3205,7 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
                                 char *ignore_flag, my_bool *versioned)
 {
   my_bool    init=0, delayed, write_data, complete_insert;
-  my_bool    is_generated=0, is_vector=0;
+  my_bool    is_generated=0;
   my_ulonglong num_fields;
   char       *result_table, *opt_quoted_table;
   const char *insert_option;
@@ -3688,40 +3688,32 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       check_io(sql_file);
     }
 
+    if (write_data)
+    {
+      if (opt_replace_into)
+        dynstr_append_checked(&insert_pat, "REPLACE ");
+      else
+        dynstr_append_checked(&insert_pat, "INSERT ");
+      dynstr_append_checked(&insert_pat, insert_option);
+      dynstr_append_checked(&insert_pat, "INTO ");
+      dynstr_append_checked(&insert_pat, result_table);
+      if (complete_insert)
+        dynstr_append_checked(&insert_pat, " (");
+      else
+      {
+        dynstr_append_checked(&insert_pat, " VALUES ");
+        if (!extended_insert)
+          dynstr_append_checked(&insert_pat, "(");
+      }
+    }
+
     while ((row= mysql_fetch_row(result)))
     {
       ulong *lengths= mysql_fetch_lengths(result);
-      bool is_row_start= strstr(row[SHOW_EXTRA], "ROW START") != 0;
-      bool is_row_end= strstr(row[SHOW_EXTRA], "ROW END") != 0;
-      is_generated= 0;
-      is_vector= 0;
-
+      dynstr_append_mem_checked(&field_flags, "", 1);
       /* VECTOR doesn't have a type code yet, must be detected by name */
       if (strncmp(row[SHOW_TYPE], STRING_WITH_LEN("vector(")) == 0)
-        is_vector= 1;
-      else if (strstr(row[SHOW_EXTRA], "GENERATED") &&
-               !is_row_start && !is_row_end)
-        is_generated= 1;
-      if (strstr(row[SHOW_EXTRA], "INVISIBLE"))
-        complete_insert= 1;
-
-      /*
-        When complete_insert is enabled, skip generated columns entirely.
-        Otherwise, include them and mark them so DEFAULT is emitted.
-      */
-      if (is_generated && !path && !opt_dir && !opt_dump_history &&
-          complete_insert)
-        continue;
-
-      dynstr_append_mem_checked(&field_flags, "", 1);
-      if (is_generated)
-        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_GENERATED;
-      if (is_vector)
         field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VECTOR;
-      /* Mark system versioning columns */
-      if (is_row_start || is_row_end)
-        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VERS_COL;
-
       if (init)
       {
         if (!opt_xml && !opt_no_create_info)
@@ -3766,29 +3758,9 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
         check_io(sql_file);
       }
     }
-
-    if (write_data)
-    {
-      if (opt_replace_into)
-        dynstr_append_checked(&insert_pat, "REPLACE ");
-      else
-        dynstr_append_checked(&insert_pat, "INSERT ");
-      dynstr_append_checked(&insert_pat, insert_option);
-      dynstr_append_checked(&insert_pat, "INTO ");
-      dynstr_append_checked(&insert_pat, result_table);
-      if (complete_insert)
-        dynstr_append_checked(&insert_pat, " (");
-      else
-      {
-        dynstr_append_checked(&insert_pat, " VALUES ");
-        if (!extended_insert)
-          dynstr_append_checked(&insert_pat, "(");
-      }
-    }
-
     if (complete_insert)
       dynstr_append_checked(&insert_pat, select_field_names.str);
-    num_fields= field_flags.length;
+    num_fields= mysql_num_rows(result);
     mysql_free_result(result);
     if (!opt_no_create_info)
     {

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -104,7 +104,9 @@
 #define DUMP_TABLE_SEQUENCE 1
 
 /* until MDEV-35831 is implemented, we'll have to detect VECTOR by name */
-#define MYSQL_TYPE_VECTOR "V"
+#define MYSQL_TYPE_VECTOR 1
+#define MYSQL_TYPE_VERS_COL 2
+#define MYSQL_TYPE_GENERATED 4
 
 static my_bool ignore_table_data(const uchar *hash_key, size_t len);
 static void add_load_option(DYNAMIC_STRING *str, const char *option,
@@ -3203,6 +3205,7 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
                                 char *ignore_flag, my_bool *versioned)
 {
   my_bool    init=0, delayed, write_data, complete_insert;
+  my_bool    is_generated=0, is_vector=0;
   my_ulonglong num_fields;
   char       *result_table, *opt_quoted_table;
   const char *insert_option;
@@ -3521,9 +3524,16 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
 
     while ((row= mysql_fetch_row(result)))
     {
-      if (strstr(row[1],"INVISIBLE"))
+      bool is_row_start= row[2] && strcmp(row[2], "ROW START") == 0;
+      bool is_row_end= row[2] && strcmp(row[2], "ROW END") == 0;
+
+      is_generated= 0;
+      if (strstr(row[1], "GENERATED") && !is_row_start && !is_row_end)
+        is_generated= 1;
+      if (strstr(row[1], "INVISIBLE"))
         complete_insert= 1;
-      if (vers_hidden && row[2] && strcmp(row[2], "ROW START") == 0)
+
+      if (vers_hidden && is_row_start)
       {
         vers_hidden= 0;
         if (row[3] && strcmp(row[3], "bigint") == 0)
@@ -3533,6 +3543,24 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
           *versioned= 0;
         }
       }
+
+      /*
+        When complete_insert is enabled, skip generated columns entirely.
+        Otherwise, include them and mark them so DEFAULT is emitted.
+      */
+      if (is_generated && !path && !opt_dir && !opt_dump_history &&
+          complete_insert)
+        continue;
+
+      dynstr_append_mem_checked(&field_flags, "", 1);
+      if (is_generated)
+        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_GENERATED;
+      if (row[3] && strcmp(row[3], "vector") == 0)
+        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VECTOR;
+      /* Mark system versioning columns */
+      if (is_row_start || is_row_end)
+        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VERS_COL;
+
       if (init)
       {
         dynstr_append_checked(&select_field_names, ", ");
@@ -3543,8 +3571,7 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       init=1;
 
       last_name= quote_name(row[0], name_buff, 0);
-      if (opt_dump_history && *versioned && opt_update_history &&
-          row[2] && strcmp(row[2], "ROW END") == 0)
+      if (opt_dump_history && *versioned && opt_update_history && is_row_end)
       {
         dynstr_append_checked(&select_field_names, "if(");
         dynstr_append_checked(&select_field_names, last_name);
@@ -3561,11 +3588,6 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       if (opt_header)
         dynstr_append_checked(&select_field_names_for_header,
                               quote_for_equal(row[0], name_buff));
-      /* VECTOR doesn't have a type code yet, must be detected by name */
-      if (row[3] && strcmp(row[3], "vector") == 0)
-        dynstr_append_checked(&field_flags, MYSQL_TYPE_VECTOR);
-      else
-        dynstr_append_checked(&field_flags, " ");
     }
 
     if (vers_hidden)
@@ -3579,7 +3601,11 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
                             "row_end" :
                             "row_end");
       dynstr_append_checked(&insert_field_names, ", row_start, row_end");
-      dynstr_append_checked(&field_flags, "  ");
+      /* Mark both row_start and row_end as versioning columns */
+      dynstr_append_mem_checked(&field_flags, "", 1);
+      field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VERS_COL;
+      dynstr_append_mem_checked(&field_flags, "", 1);
+      field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VERS_COL;
     }
 
     /*
@@ -3598,9 +3624,7 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       dynstr_append_checked(&insert_pat, "INTO ");
       dynstr_append_checked(&insert_pat, opt_quoted_table);
       if (complete_insert)
-      {
         dynstr_append_checked(&insert_pat, " (");
-      }
       else
       {
         if (extended_insert)
@@ -3612,7 +3636,7 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
 
     if (complete_insert)
       dynstr_append_checked(&insert_pat, insert_field_names.str);
-    num_fields= mysql_num_rows(result) + (vers_hidden ? 2 : 0);
+    num_fields= field_flags.length;
     mysql_free_result(result);
   }
   else
@@ -3664,6 +3688,85 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       check_io(sql_file);
     }
 
+    while ((row= mysql_fetch_row(result)))
+    {
+      ulong *lengths= mysql_fetch_lengths(result);
+      bool is_row_start= strstr(row[SHOW_EXTRA], "ROW START") != 0;
+      bool is_row_end= strstr(row[SHOW_EXTRA], "ROW END") != 0;
+      is_generated= 0;
+      is_vector= 0;
+
+      /* VECTOR doesn't have a type code yet, must be detected by name */
+      if (strncmp(row[SHOW_TYPE], STRING_WITH_LEN("vector(")) == 0)
+        is_vector= 1;
+      else if (strstr(row[SHOW_EXTRA], "GENERATED") &&
+               !is_row_start && !is_row_end)
+        is_generated= 1;
+      if (strstr(row[SHOW_EXTRA], "INVISIBLE"))
+        complete_insert= 1;
+
+      /*
+        When complete_insert is enabled, skip generated columns entirely.
+        Otherwise, include them and mark them so DEFAULT is emitted.
+      */
+      if (is_generated && !path && !opt_dir && !opt_dump_history &&
+          complete_insert)
+        continue;
+
+      dynstr_append_mem_checked(&field_flags, "", 1);
+      if (is_generated)
+        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_GENERATED;
+      if (is_vector)
+        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VECTOR;
+      /* Mark system versioning columns */
+      if (is_row_start || is_row_end)
+        field_flags.str[field_flags.length-1]|= MYSQL_TYPE_VERS_COL;
+
+      if (init)
+      {
+        if (!opt_xml && !opt_no_create_info)
+        {
+          fputs(",\n",sql_file);
+          check_io(sql_file);
+        }
+        dynstr_append_checked(&select_field_names, ", ");
+        if (opt_header)
+          dynstr_append_checked(&select_field_names_for_header, ", ");
+      }
+      dynstr_append_checked(&select_field_names,
+                            quote_name(row[SHOW_FIELDNAME], name_buff, 0));
+      if (opt_header)
+        dynstr_append_checked(&select_field_names_for_header,
+                              quote_for_equal(row[SHOW_FIELDNAME], name_buff));
+      init=1;
+
+      if (!opt_no_create_info)
+      {
+        if (opt_xml)
+        {
+          print_xml_row(sql_file, "field", result, &row, NullS);
+          continue;
+        }
+
+        if (opt_keywords)
+          fprintf(sql_file, "  %s.%s %s", result_table,
+                  quote_name(row[SHOW_FIELDNAME],name_buff, 0), row[SHOW_TYPE]);
+        else
+          fprintf(sql_file, "  %s %s",
+                  quote_name(row[SHOW_FIELDNAME], name_buff, 0), row[SHOW_TYPE]);
+        if (row[SHOW_DEFAULT])
+        {
+          fputs(" DEFAULT ", sql_file);
+          unescape(sql_file, row[SHOW_DEFAULT], lengths[SHOW_DEFAULT]);
+        }
+        if (!row[SHOW_NULL][0])
+          fputs(" NOT NULL", sql_file);
+        if (row[SHOW_EXTRA][0])
+          fprintf(sql_file, " %s",row[SHOW_EXTRA]);
+        check_io(sql_file);
+      }
+    }
+
     if (write_data)
     {
       if (opt_replace_into)
@@ -3683,60 +3786,9 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       }
     }
 
-    while ((row= mysql_fetch_row(result)))
-    {
-      ulong *lengths= mysql_fetch_lengths(result);
-      /* VECTOR doesn't have a type code yet, must be detected by name */
-      if (strncmp(row[SHOW_TYPE], STRING_WITH_LEN("vector(")) == 0)
-        dynstr_append_checked(&field_flags, MYSQL_TYPE_VECTOR);
-      else
-        dynstr_append_checked(&field_flags, " ");
-      if (init)
-      {
-        if (!opt_xml && !opt_no_create_info)
-        {
-          fputs(",\n",sql_file);
-          check_io(sql_file);
-        }
-        dynstr_append_checked(&select_field_names, ", ");
-        if (opt_header)
-          dynstr_append_checked(&select_field_names_for_header, ", ");
-      }
-      dynstr_append_checked(&select_field_names,
-              quote_name(row[SHOW_FIELDNAME], name_buff, 0));
-      if (opt_header)
-        dynstr_append_checked(&select_field_names_for_header,
-                              quote_for_equal(row[SHOW_FIELDNAME], name_buff));
-      init=1;
-      if (!opt_no_create_info)
-      {
-        if (opt_xml)
-        {
-          print_xml_row(sql_file, "field", result, &row, NullS);
-          continue;
-        }
-
-        if (opt_keywords)
-          fprintf(sql_file, "  %s.%s %s", result_table,
-                  quote_name(row[SHOW_FIELDNAME],name_buff, 0), row[SHOW_TYPE]);
-        else
-          fprintf(sql_file, "  %s %s",
-                quote_name(row[SHOW_FIELDNAME], name_buff, 0), row[SHOW_TYPE]);
-        if (row[SHOW_DEFAULT])
-        {
-          fputs(" DEFAULT ", sql_file);
-          unescape(sql_file, row[SHOW_DEFAULT], lengths[SHOW_DEFAULT]);
-        }
-        if (!row[SHOW_NULL][0])
-          fputs(" NOT NULL", sql_file);
-        if (row[SHOW_EXTRA][0])
-          fprintf(sql_file, " %s",row[SHOW_EXTRA]);
-        check_io(sql_file);
-      }
-    }
     if (complete_insert)
       dynstr_append_checked(&insert_pat, select_field_names.str);
-    num_fields= mysql_num_rows(result);
+    num_fields= field_flags.length;
     mysql_free_result(result);
     if (!opt_no_create_info)
     {
@@ -4275,7 +4327,6 @@ static void dump_table(const char *table, const char *db, const uchar *hash_key,
   uint num_fields;
   size_t total_length, init_length;
   my_bool versioned= 0;
-
   MYSQL_RES     *res= NULL;
   MYSQL_FIELD   *field;
   MYSQL_ROW     row;
@@ -4286,7 +4337,6 @@ static void dump_table(const char *table, const char *db, const uchar *hash_key,
     --no-data flag below. Otherwise, the create table info won't be printed.
   */
   num_fields= get_table_structure(table, db, table_type, &ignore_flag, &versioned);
-
   /*
     The "table" could be a view.  If so, we don't do anything here.
   */
@@ -4579,7 +4629,7 @@ static void dump_table(const char *table, const char *db, const uchar *hash_key,
         */
         is_blob= field->type == MYSQL_TYPE_GEOMETRY ||
                  field->type == MYSQL_TYPE_BIT ||
-                 field_flags.str[i] == MYSQL_TYPE_VECTOR[0] ||
+                 field_flags.str[i] & MYSQL_TYPE_VECTOR ||
                  (opt_hex_blob && field->charsetnr == 63 &&
                    (field->type == MYSQL_TYPE_STRING ||
                     field->type == MYSQL_TYPE_VAR_STRING ||
@@ -4595,7 +4645,9 @@ static void dump_table(const char *table, const char *db, const uchar *hash_key,
           else
             dynstr_append_checked(&extended_row,",");
 
-          if (row[i])
+          if (field_flags.str[i] & MYSQL_TYPE_GENERATED)
+            dynstr_append_checked(&extended_row, "DEFAULT");
+          else if (row[i])
           {
             if (length)
             {
@@ -4665,7 +4717,18 @@ static void dump_table(const char *table, const char *db, const uchar *hash_key,
             fputc(',', md_result_file);
             check_io(md_result_file);
           }
-          if (row[i])
+          if (field_flags.str[i] & MYSQL_TYPE_GENERATED)
+          {
+            if (opt_xml)
+            {
+              print_xml_tag(md_result_file, "\t\t", "", "field", "name=",
+                            field->name, NullS);
+              fputs("DEFAULT</field>\n", md_result_file);
+            }
+            else
+              fputs("DEFAULT", md_result_file);
+          }
+          else if (row[i])
           {
             if (!(field->flags & NUM_FLAG))
             {

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -3205,7 +3205,7 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
                                 char *ignore_flag, my_bool *versioned)
 {
   my_bool    init=0, delayed, write_data, complete_insert;
-  my_bool    is_generated=0;
+  my_bool    is_generated=0, all_generated=0;
   my_ulonglong num_fields;
   char       *result_table, *opt_quoted_table;
   const char *insert_option;
@@ -3522,6 +3522,25 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       DBUG_RETURN(0);
     }
 
+    /*
+      Detect tables where every column is generated. Otherwise, skipping all
+      generated columns under --complete-insert would leave INSERT with an
+      empty column list, causing dump_table() to bail on num_fields == 0 and
+      lose row counts on reload (MDEV-40217).
+    */
+    all_generated= 1;
+    while ((row= mysql_fetch_row(result)))
+    {
+      bool is_row_start= row[2] && strcmp(row[2], "ROW START") == 0;
+      bool is_row_end= row[2] && strcmp(row[2], "ROW END") == 0;
+      if (!(strstr(row[1], "GENERATED") && !is_row_start && !is_row_end))
+      {
+        all_generated= 0;
+        break;
+      }
+    }
+    mysql_data_seek(result, 0);
+
     while ((row= mysql_fetch_row(result)))
     {
       bool is_row_start= row[2] && strcmp(row[2], "ROW START") == 0;
@@ -3547,9 +3566,11 @@ static uint get_table_structure(const char *table, const char *db, char *table_t
       /*
         When complete_insert is enabled, skip generated columns entirely.
         Otherwise, include them and mark them so DEFAULT is emitted.
+        Exception: if every column is generated, keep them all so DEFAULT is
+        emitted for their values and rows are preserved on reload.
       */
       if (is_generated && !path && !opt_dir && !opt_dump_history &&
-          complete_insert)
+          complete_insert && !all_generated)
         continue;
 
       dynstr_append_mem_checked(&field_flags, "", 1);

--- a/mysql-test/main/mysqldump.result
+++ b/mysql-test/main/mysqldump.result
@@ -8129,3 +8129,147 @@ mariadb-dump: Error: no databases matching the pattern 'perf%' found.
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
 
+#
+# MDEV-32362 Remove generated columns from INSERT statements in dump
+# Generated columns are omitted entirely from INSERT statements
+#
+CREATE DATABASE dump_generated;
+USE dump_generated;
+# Table with virtual generated columns at the end
+CREATE TABLE t1 (pk INTEGER, a INTEGER, b INTEGER, c VARCHAR(16),
+sum INTEGER GENERATED ALWAYS AS (a+b) VIRTUAL,
+sub VARCHAR(4) GENERATED ALWAYS AS (SUBSTRING(c, 1, 4)) VIRTUAL,
+key k1(sum),
+key k2(sub)
+) engine=innodb;
+INSERT INTO t1(pk, a, b, c) VALUES (1, 11, 12, 'oneone'), (2, 21, 22, 'twotwo');
+SELECT * FROM t1;
+pk	a	b	c	sum	sub
+1	11	12	oneone	23	oneo
+2	21	22	twotwo	43	twot
+# Default (extended insert) - generated columns use DEFAULT
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t1` VALUES
+(1,11,12,'oneone',DEFAULT,DEFAULT),
+(2,21,22,'twotwo',DEFAULT,DEFAULT);
+# Without extended insert - generated columns use DEFAULT
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t1` VALUES (1,11,12,'oneone',DEFAULT,DEFAULT);
+INSERT INTO `t1` VALUES (2,21,22,'twotwo',DEFAULT,DEFAULT);
+# With --complete-insert - generated columns are omitted
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t1` (`pk`, `a`, `b`, `c`) VALUES (1,11,12,'oneone'),
+(2,21,22,'twotwo');
+# With --xml
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="dump_generated">
+	<table_data name="t1">
+	<row>
+		<field name="pk">1</field>
+		<field name="a">11</field>
+		<field name="b">12</field>
+		<field name="c">oneone</field>
+		<field name="sum">DEFAULT</field>
+		<field name="sub">DEFAULT</field>
+	</row>
+	<row>
+		<field name="pk">2</field>
+		<field name="a">21</field>
+		<field name="b">22</field>
+		<field name="c">twotwo</field>
+		<field name="sum">DEFAULT</field>
+		<field name="sub">DEFAULT</field>
+	</row>
+	</table_data>
+</database>
+</mysqldump>
+# Dump/reload roundtrip
+DELETE FROM t1;
+SELECT * FROM t1;
+pk	a	b	c	sum	sub
+1	11	12	oneone	23	oneo
+2	21	22	twotwo	43	twot
+# With --tab
+DELETE FROM t1;
+LOAD DATA INFILE 'MYSQLTEST_VARDIR/tmp/t1.txt' INTO TABLE t1;
+SELECT * FROM t1;
+pk	a	b	c	sum	sub
+1	11	12	oneone	23	oneo
+2	21	22	twotwo	43	twot
+DROP TABLE t1;
+# Table with stored generated columns in the middle
+CREATE TABLE t2 (pk INTEGER, a INTEGER, b INTEGER,
+sum INTEGER GENERATED ALWAYS AS (a+b) STORED,
+c VARCHAR(16),
+key k1(sum)
+) engine=innodb;
+INSERT INTO t2(pk, a, b, c) VALUES (1, 11, 12, 'oneone'), (2, 21, 22, 'twotwo');
+SELECT * FROM t2;
+pk	a	b	sum	c
+1	11	12	23	oneone
+2	21	22	43	twotwo
+# Default (extended insert) - generated columns use DEFAULT
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t2` VALUES
+(1,11,12,DEFAULT,'oneone'),
+(2,21,22,DEFAULT,'twotwo');
+# Without extended insert - generated columns use DEFAULT
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t2` VALUES (1,11,12,DEFAULT,'oneone');
+INSERT INTO `t2` VALUES (2,21,22,DEFAULT,'twotwo');
+# With --xml
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="dump_generated">
+	<table_data name="t2">
+	<row>
+		<field name="pk">1</field>
+		<field name="a">11</field>
+		<field name="b">12</field>
+		<field name="sum">DEFAULT</field>
+		<field name="c">oneone</field>
+	</row>
+	<row>
+		<field name="pk">2</field>
+		<field name="a">21</field>
+		<field name="b">22</field>
+		<field name="sum">DEFAULT</field>
+		<field name="c">twotwo</field>
+	</row>
+	</table_data>
+</database>
+</mysqldump>
+# Dump/reload roundtrip
+DELETE FROM t2;
+SELECT * FROM t2;
+pk	a	b	sum	c
+1	11	12	23	oneone
+2	21	22	43	twotwo
+DROP TABLE t2;
+# Table with invisible generated column
+CREATE TABLE t3 (pk INTEGER, a INTEGER, b INTEGER,
+sum INTEGER GENERATED ALWAYS AS (a+b) INVISIBLE
+) engine=innodb;
+INSERT INTO t3(pk, a, b) VALUES (1, 11, 12), (2, 21, 22);
+SELECT pk, a, b, sum FROM t3;
+pk	a	b	sum
+1	11	12	23
+2	21	22	43
+# Default (extended insert) - invisible forces complete_insert, generated columns omitted
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t3` (`pk`, `a`, `b`) VALUES (1,11,12),
+(2,21,22);
+# Without extended insert
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t3` (`pk`, `a`, `b`) VALUES (1,11,12);
+INSERT INTO `t3` (`pk`, `a`, `b`) VALUES (2,21,22);
+# Dump/reload roundtrip
+DELETE FROM t3;
+SELECT pk, a, b, sum FROM t3;
+pk	a	b	sum
+1	11	12	23
+2	21	22	43
+DROP TABLE t3;
+DROP DATABASE dump_generated;
+USE test;

--- a/mysql-test/main/mysqldump.result
+++ b/mysql-test/main/mysqldump.result
@@ -8285,6 +8285,40 @@ pk	a	b	c	d
 1	2	3	10	3
 4	5	6	20	9
 DROP TABLE t3, t4;
+# Table with only generated columns (MDEV-40217)
+CREATE TABLE t5 (a INT GENERATED ALWAYS AS (1) VIRTUAL,
+b INT GENERATED ALWAYS AS (2) STORED
+) engine=innodb;
+INSERT INTO t5 () VALUES (),(),();
+SELECT * FROM t5;
+a	b
+1	2
+1	2
+1	2
+# Default (extended insert) - generated columns use DEFAULT
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t5` VALUES
+(DEFAULT,DEFAULT),
+(DEFAULT,DEFAULT),
+(DEFAULT,DEFAULT);
+# Without extended insert - generated columns use DEFAULT
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t5` VALUES (DEFAULT,DEFAULT);
+INSERT INTO `t5` VALUES (DEFAULT,DEFAULT);
+INSERT INTO `t5` VALUES (DEFAULT,DEFAULT);
+# With --complete-insert - all generated columns kept, values use DEFAULT
+/*M!999999\- enable the sandbox mode */ 
+INSERT INTO `t5` (`a`, `b`) VALUES (DEFAULT,DEFAULT),
+(DEFAULT,DEFAULT),
+(DEFAULT,DEFAULT);
+# Dump/reload roundtrip preserves row count
+DELETE FROM t5;
+SELECT * FROM t5;
+a	b
+1	2
+1	2
+1	2
+DROP TABLE t5;
 DROP DATABASE dump_generated;
 USE test;
 # End of 13.2 tests

--- a/mysql-test/main/mysqldump.result
+++ b/mysql-test/main/mysqldump.result
@@ -8129,9 +8129,9 @@ mariadb-dump: Error: no databases matching the pattern 'perf%' found.
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
 
+# End of 13.1 tests
 #
-# MDEV-32362 Remove generated columns from INSERT statements in dump
-# Generated columns are omitted entirely from INSERT statements
+# MDEV-32362 Omit generated column values from mariadb-dump dumps
 #
 CREATE DATABASE dump_generated;
 USE dump_generated;
@@ -8170,16 +8170,16 @@ INSERT INTO `t1` (`pk`, `a`, `b`, `c`) VALUES (1,11,12,'oneone'),
 		<field name="a">11</field>
 		<field name="b">12</field>
 		<field name="c">oneone</field>
-		<field name="sum">DEFAULT</field>
-		<field name="sub">DEFAULT</field>
+		<field name="sum">23</field>
+		<field name="sub">oneo</field>
 	</row>
 	<row>
 		<field name="pk">2</field>
 		<field name="a">21</field>
 		<field name="b">22</field>
 		<field name="c">twotwo</field>
-		<field name="sum">DEFAULT</field>
-		<field name="sub">DEFAULT</field>
+		<field name="sum">43</field>
+		<field name="sub">twot</field>
 	</row>
 	</table_data>
 </database>
@@ -8227,14 +8227,14 @@ INSERT INTO `t2` VALUES (2,21,22,DEFAULT,'twotwo');
 		<field name="pk">1</field>
 		<field name="a">11</field>
 		<field name="b">12</field>
-		<field name="sum">DEFAULT</field>
+		<field name="sum">23</field>
 		<field name="c">oneone</field>
 	</row>
 	<row>
 		<field name="pk">2</field>
 		<field name="a">21</field>
 		<field name="b">22</field>
-		<field name="sum">DEFAULT</field>
+		<field name="sum">43</field>
 		<field name="c">twotwo</field>
 	</row>
 	</table_data>
@@ -8256,20 +8256,35 @@ SELECT pk, a, b, sum FROM t3;
 pk	a	b	sum
 1	11	12	23
 2	21	22	43
+# Table with invisible/generated mix
+CREATE TABLE t4 (pk INTEGER, a INTEGER,
+b INTEGER GENERATED ALWAYS AS (a+1),
+c INTEGER INVISIBLE, d INTEGER GENERATED ALWAYS AS (a+pk));
+INSERT INTO t4 (pk, a, c) VALUES (1,2,10),(4,5,20);
 # Default (extended insert) - invisible forces complete_insert, generated columns omitted
 /*M!999999\- enable the sandbox mode */ 
 INSERT INTO `t3` (`pk`, `a`, `b`) VALUES (1,11,12),
 (2,21,22);
+INSERT INTO `t4` (`pk`, `a`, `b`, `c`) VALUES (1,2,DEFAULT,10),
+(4,5,DEFAULT,20);
 # Without extended insert
 /*M!999999\- enable the sandbox mode */ 
 INSERT INTO `t3` (`pk`, `a`, `b`) VALUES (1,11,12);
 INSERT INTO `t3` (`pk`, `a`, `b`) VALUES (2,21,22);
+INSERT INTO `t4` (`pk`, `a`, `b`, `c`) VALUES (1,2,DEFAULT,10);
+INSERT INTO `t4` (`pk`, `a`, `b`, `c`) VALUES (4,5,DEFAULT,20);
 # Dump/reload roundtrip
 DELETE FROM t3;
+DELETE FROM t4;
 SELECT pk, a, b, sum FROM t3;
 pk	a	b	sum
 1	11	12	23
 2	21	22	43
-DROP TABLE t3;
+SELECT pk, a, b, c, d FROM t4;
+pk	a	b	c	d
+1	2	3	10	3
+4	5	6	20	9
+DROP TABLE t3, t4;
 DROP DATABASE dump_generated;
 USE test;
+# End of 13.2 tests

--- a/mysql-test/main/mysqldump.test
+++ b/mysql-test/main/mysqldump.test
@@ -3480,6 +3480,29 @@ SELECT pk, a, b, sum FROM t3;
 SELECT pk, a, b, c, d FROM t4;
 DROP TABLE t3, t4;
 
+--echo # Table with only generated columns (MDEV-40217)
+CREATE TABLE t5 (a INT GENERATED ALWAYS AS (1) VIRTUAL,
+                 b INT GENERATED ALWAYS AS (2) STORED
+) engine=innodb;
+INSERT INTO t5 () VALUES (),(),();
+SELECT * FROM t5;
+
+--echo # Default (extended insert) - generated columns use DEFAULT
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments dump_generated t5
+
+--echo # Without extended insert - generated columns use DEFAULT
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --skip-extended-insert dump_generated t5
+
+--echo # With --complete-insert - all generated columns kept, values use DEFAULT
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --complete-insert dump_generated t5
+
+--echo # Dump/reload roundtrip preserves row count
+--exec $MYSQL_DUMP --complete-insert dump_generated t5 > $MYSQLTEST_VARDIR/tmp/t5.sql
+DELETE FROM t5;
+--exec $MYSQL dump_generated < $MYSQLTEST_VARDIR/tmp/t5.sql
+SELECT * FROM t5;
+DROP TABLE t5;
+
 DROP DATABASE dump_generated;
 USE test;
 

--- a/mysql-test/main/mysqldump.test
+++ b/mysql-test/main/mysqldump.test
@@ -3381,3 +3381,96 @@ DROP DATABASE test1;
 --exec $MYSQL_DUMP --skip-comments -L -B  a% 2>&1
 --replace_result mariadb-dump.exe mariadb-dump
 --exec $MYSQL_DUMP --skip-comments --databases --wildcards=ON perf% 2>&1
+
+--echo #
+--echo # MDEV-32362 Remove generated columns from INSERT statements in dump
+--echo # Generated columns are omitted entirely from INSERT statements
+--echo #
+
+CREATE DATABASE dump_generated;
+USE dump_generated;
+
+--echo # Table with virtual generated columns at the end
+CREATE TABLE t1 (pk INTEGER, a INTEGER, b INTEGER, c VARCHAR(16),
+                 sum INTEGER GENERATED ALWAYS AS (a+b) VIRTUAL,
+                 sub VARCHAR(4) GENERATED ALWAYS AS (SUBSTRING(c, 1, 4)) VIRTUAL,
+                 key k1(sum),
+                 key k2(sub)
+) engine=innodb;
+INSERT INTO t1(pk, a, b, c) VALUES (1, 11, 12, 'oneone'), (2, 21, 22, 'twotwo');
+SELECT * FROM t1;
+
+--echo # Default (extended insert) - generated columns use DEFAULT
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments dump_generated t1
+
+--echo # Without extended insert - generated columns use DEFAULT
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --skip-extended-insert dump_generated t1
+
+--echo # With --complete-insert - generated columns are omitted
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --complete-insert dump_generated t1
+
+--echo # With --xml
+--exec $MYSQL_DUMP --no-create-info --skip-comments --xml dump_generated t1
+
+--echo # Dump/reload roundtrip
+--exec $MYSQL_DUMP dump_generated t1 > $MYSQLTEST_VARDIR/tmp/t1.sql
+DELETE FROM t1;
+--exec $MYSQL dump_generated < $MYSQLTEST_VARDIR/tmp/t1.sql
+SELECT * FROM t1;
+
+--echo # With --tab
+--exec $MYSQL_DUMP dump_generated t1 --tab=$MYSQLTEST_VARDIR/tmp/
+DELETE FROM t1;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/t1.txt' INTO TABLE t1
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--echo # Table with stored generated columns in the middle
+CREATE TABLE t2 (pk INTEGER, a INTEGER, b INTEGER,
+                 sum INTEGER GENERATED ALWAYS AS (a+b) STORED,
+                 c VARCHAR(16),
+                 key k1(sum)
+) engine=innodb;
+INSERT INTO t2(pk, a, b, c) VALUES (1, 11, 12, 'oneone'), (2, 21, 22, 'twotwo');
+SELECT * FROM t2;
+
+--echo # Default (extended insert) - generated columns use DEFAULT
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments dump_generated t2
+
+--echo # Without extended insert - generated columns use DEFAULT
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --skip-extended-insert dump_generated t2
+
+--echo # With --xml
+--exec $MYSQL_DUMP --no-create-info --skip-comments --xml dump_generated t2
+
+--echo # Dump/reload roundtrip
+--exec $MYSQL_DUMP dump_generated t2 > $MYSQLTEST_VARDIR/tmp/t2.sql
+DELETE FROM t2;
+--exec $MYSQL dump_generated < $MYSQLTEST_VARDIR/tmp/t2.sql
+SELECT * FROM t2;
+DROP TABLE t2;
+
+--echo # Table with invisible generated column
+CREATE TABLE t3 (pk INTEGER, a INTEGER, b INTEGER,
+                 sum INTEGER GENERATED ALWAYS AS (a+b) INVISIBLE
+) engine=innodb;
+INSERT INTO t3(pk, a, b) VALUES (1, 11, 12), (2, 21, 22);
+SELECT pk, a, b, sum FROM t3;
+
+--echo # Default (extended insert) - invisible forces complete_insert, generated columns omitted
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments dump_generated t3
+
+--echo # Without extended insert
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --skip-extended-insert dump_generated t3
+
+--echo # Dump/reload roundtrip
+--exec $MYSQL_DUMP dump_generated t3 > $MYSQLTEST_VARDIR/tmp/t3.sql
+DELETE FROM t3;
+--exec $MYSQL dump_generated < $MYSQLTEST_VARDIR/tmp/t3.sql
+SELECT pk, a, b, sum FROM t3;
+DROP TABLE t3;
+
+DROP DATABASE dump_generated;
+USE test;
+

--- a/mysql-test/main/mysqldump.test
+++ b/mysql-test/main/mysqldump.test
@@ -3382,9 +3382,10 @@ DROP DATABASE test1;
 --replace_result mariadb-dump.exe mariadb-dump
 --exec $MYSQL_DUMP --skip-comments --databases --wildcards=ON perf% 2>&1
 
+--echo # End of 13.1 tests
+
 --echo #
---echo # MDEV-32362 Remove generated columns from INSERT statements in dump
---echo # Generated columns are omitted entirely from INSERT statements
+--echo # MDEV-32362 Omit generated column values from mariadb-dump dumps
 --echo #
 
 CREATE DATABASE dump_generated;
@@ -3458,19 +3459,28 @@ CREATE TABLE t3 (pk INTEGER, a INTEGER, b INTEGER,
 INSERT INTO t3(pk, a, b) VALUES (1, 11, 12), (2, 21, 22);
 SELECT pk, a, b, sum FROM t3;
 
+--echo # Table with invisible/generated mix
+CREATE TABLE t4 (pk INTEGER, a INTEGER,
+  b INTEGER GENERATED ALWAYS AS (a+1),
+  c INTEGER INVISIBLE, d INTEGER GENERATED ALWAYS AS (a+pk));
+INSERT INTO t4 (pk, a, c) VALUES (1,2,10),(4,5,20);
+
 --echo # Default (extended insert) - invisible forces complete_insert, generated columns omitted
---exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments dump_generated t3
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments dump_generated t3 t4
 
 --echo # Without extended insert
---exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --skip-extended-insert dump_generated t3
+--exec $MYSQL_DUMP --compact --no-autocommit=0 --no-create-info --skip-comments --skip-extended-insert dump_generated t3 t4
 
 --echo # Dump/reload roundtrip
---exec $MYSQL_DUMP dump_generated t3 > $MYSQLTEST_VARDIR/tmp/t3.sql
+--exec $MYSQL_DUMP dump_generated t3 t4 > $MYSQLTEST_VARDIR/tmp/t34.sql
 DELETE FROM t3;
---exec $MYSQL dump_generated < $MYSQLTEST_VARDIR/tmp/t3.sql
+DELETE FROM t4;
+--exec $MYSQL dump_generated < $MYSQLTEST_VARDIR/tmp/t34.sql
 SELECT pk, a, b, sum FROM t3;
-DROP TABLE t3;
+SELECT pk, a, b, c, d FROM t4;
+DROP TABLE t3, t4;
 
 DROP DATABASE dump_generated;
 USE test;
 
+--echo # End of 13.2 tests


### PR DESCRIPTION
## Description

Currently, generated column names and values are present in `INSERT` statements created by the dump tool. While this doesn't break restorability, it is unnecessary as values for generated columns are calculated based on other column values and need not be explicitly inserted.
    
Modify `mariadb-dump` to handle generated columns in `INSERT` statements:
- In default mode, generated column values are replaced with `DEFAULT`, preserving the user's chosen insert style.
- When `--complete-insert` is enabled (either explicitly or due to `INVISIBLE` columns), generated columns are omitted entirely from the column list and values.
- Exception: if every column in a table is generated, generated columns are kept in the `INSERT` and `DEFAULT` is emitted for their values, so row counts are preserved on reload ([MDEV-40217](https://jira.mariadb.org/browse/MDEV-40217)).
    
The server computes the generated column values automatically in all cases.

## Release Notes

N/A

## How can this PR be tested?

Execute `main.mysqldump` in mysql-test-run. This commit adds a test in the `main` suite.

## Basing the PR against the correct MariaDB version

* [x] _This is a new feature and the PR is based against the latest MariaDB development branch._

## Copyright

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.