### PR TITLE
MDEV-27126 my_getopt compares option names case sensitively

### DIFF
--- a/mysql-test/main/my_getopt_case_insensitive.opt
+++ b/mysql-test/main/my_getopt_case_insensitive.opt
@@ -1,0 +1,1 @@
+--slOw_QuEry_loG=OFF

--- a/mysql-test/main/my_getopt_case_insensitive.result
+++ b/mysql-test/main/my_getopt_case_insensitive.result
@@ -1,0 +1,8 @@
+#
+# MDEV-27126: my_getopt compares option names case sensitively
+#
+# Check if the variable is set correctly from options
+SELECT @@GLOBAL.slow_query_log;
+@@GLOBAL.slow_query_log
+0
+# End of test.

--- a/mysql-test/main/my_getopt_case_insensitive.test
+++ b/mysql-test/main/my_getopt_case_insensitive.test
@@ -1,0 +1,8 @@
+--echo #
+--echo # MDEV-27126: my_getopt compares option names case sensitively
+--echo #
+
+--echo # Check if the variable is set correctly from options
+SELECT @@GLOBAL.slow_query_log;
+
+--echo # End of test.

--- a/mysql-test/suite/wsrep/r/wsrep_mixed_case_cmd_arg.result
+++ b/mysql-test/suite/wsrep/r/wsrep_mixed_case_cmd_arg.result
@@ -1,0 +1,8 @@
+#
+# MDEV-27126: my_getopt compares option names case sensitively
+#
+# Check if the variable is set correctly from options
+SELECT @@GLOBAL.wsrep_slave_uk_checks;
+@@GLOBAL.wsrep_slave_uk_checks
+1
+# End of test.

--- a/mysql-test/suite/wsrep/t/wsrep_mixed_case_cmd_arg.cnf
+++ b/mysql-test/suite/wsrep/t/wsrep_mixed_case_cmd_arg.cnf
@@ -1,0 +1,7 @@
+!include ../my.cnf
+
+[mysqld.1]
+wsrep-on=ON
+wsrep-provider=@ENV.WSREP_PROVIDER
+wsrep-cluster-address=gcomm://
+

--- a/mysql-test/suite/wsrep/t/wsrep_mixed_case_cmd_arg.opt
+++ b/mysql-test/suite/wsrep/t/wsrep_mixed_case_cmd_arg.opt
@@ -1,0 +1,1 @@
+--wsrep-slave-uk-checks=1

--- a/mysql-test/suite/wsrep/t/wsrep_mixed_case_cmd_arg.test
+++ b/mysql-test/suite/wsrep/t/wsrep_mixed_case_cmd_arg.test
@@ -1,0 +1,11 @@
+--source include/have_innodb.inc
+--source include/have_wsrep_provider.inc
+--source include/have_binlog_format_row.inc
+--echo #
+--echo # MDEV-27126: my_getopt compares option names case sensitively
+--echo #
+
+--echo # Check if the variable is set correctly from options
+SELECT @@GLOBAL.wsrep_slave_uk_checks;
+
+--echo # End of test.

--- a/mysys/my_getopt.c
+++ b/mysys/my_getopt.c
@@ -18,6 +18,7 @@
 #include <mysys_priv.h>
 #include <my_default.h>
 #include <m_string.h>
+#include <ctype.h>
 #include <stdlib.h>
 #include <mysys_err.h>
 #include <my_getopt.h>
@@ -962,7 +963,7 @@ my_bool getopt_compare_strings(register const char *s, register const char *t,
 
   for (;s != end ; s++, t++)
   {
-    if ((*s != '-' ? *s : '_') != (*t != '-' ? *t : '_'))
+    if ((*s != '-' ? tolower(*s) : '_') != (*t != '-' ? tolower(*t) : '_'))
       DBUG_RETURN(1);
   }
   DBUG_RETURN(0);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-27126*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
my_getopt compares option names case-sensitively, causing "Unknown option" errors when users type mixed-case options like wsrep_slave_UK_checks in lowercase wsrep_slave_fk_checks.

Made the comparison in the getopt_compare_strings() case-insensitive.


## Release Notes
N/A

## How can this PR be tested?
`./mtr main.my_getopt_case_insensitive`
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->



<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
