### PR TITLE
MDEV-23818 mysql option --script-dir

### DIFF
--- a/mysql-test/main/client.result
+++ b/mysql-test/main/client.result
@@ -60,3 +60,23 @@ drop table t1;
 #
 # End of 10.5 tests
 #
+#
+# MDEV-23818: mysql option --script-dir
+#
+# test 1: can't find the file at all
+ERROR at line 1: Failed to open file 'file1', error: 2
+# test 2: file in the current working directory
+1
+1
+# test 3: file is present in CWD and also in script-dir
+hello from file1
+hello from file1
+# test 4: file is only present in the script-dir
+hello from dir1/file1.sql
+hello from dir1/file1.sql
+# test 5: script-dir file has source command that references CWD
+hello from file2.sql
+hello from file2.sql
+# test 6: script-dir file has source command that references script-dir
+hello from file2.sql
+hello from file2.sql

--- a/mysql-test/main/client.test
+++ b/mysql-test/main/client.test
@@ -44,3 +44,68 @@ drop table t1;
 --echo #
 --echo # End of 10.5 tests
 --echo #
+
+--echo #
+--echo # MDEV-23818: mysql option --script-dir
+--echo #
+
+--echo # test 1: can't find the file at all
+--mkdir $MYSQLTEST_VARDIR/dir1
+--error 1
+--exec echo "source file1;" | $MYSQL --script-dir=$MYSQLTEST_VARDIR/dir1/ 2>&1
+--rmdir $MYSQLTEST_VARDIR/dir1
+
+--echo # test 2: file in the current working directory
+--mkdir $MYSQLTEST_VARDIR/dir1
+--write_file $MYSQLTEST_VARDIR/file1.sql
+select 1;
+EOF
+--exec echo "source $MYSQLTEST_VARDIR/file1.sql;" | $MYSQL --script-dir=$MYSQLTEST_VARDIR/dir1/ 2>&1
+--remove_file $MYSQLTEST_VARDIR/file1.sql
+--rmdir $MYSQLTEST_VARDIR/dir1
+
+--echo # test 3: file is present in CWD and also in script-dir
+--mkdir $MYSQLTEST_VARDIR/dir1
+--write_file $MYSQLTEST_VARDIR/file1.sql
+select 'hello from file1'
+EOF
+--write_file $MYSQLTEST_VARDIR/dir1/file1.sql
+select 'hello from dir1/file1.sql';
+EOF
+--exec echo "source $MYSQLTEST_VARDIR/file1.sql;" | $MYSQL --script-dir=./dir1/ 2>&1
+--remove_file $MYSQLTEST_VARDIR/file1.sql
+--remove_file $MYSQLTEST_VARDIR/dir1/file1.sql
+--rmdir $MYSQLTEST_VARDIR/dir1
+
+--echo # test 4: file is only present in the script-dir
+--mkdir $MYSQLTEST_VARDIR/dir1
+--write_file $MYSQLTEST_VARDIR/dir1/file1.sql
+select 'hello from dir1/file1.sql';
+EOF
+--exec echo "source file1.sql;" | $MYSQL --script-dir=$MYSQLTEST_VARDIR/dir1/ 2>&1
+--remove_file $MYSQLTEST_VARDIR/dir1/file1.sql
+--rmdir $MYSQLTEST_VARDIR/dir1
+
+--echo # test 5: script-dir file has source command that references CWD
+--mkdir $MYSQLTEST_VARDIR/dir1
+--write_file $MYSQLTEST_VARDIR/dir1/file1.sql
+source file2.sql;
+EOF
+--exec echo "select 'hello from file2.sql'" > $MYSQLTEST_VARDIR/file2.sql
+--exec cd $MYSQLTEST_VARDIR && $MYSQL --script-dir=$MYSQLTEST_VARDIR/dir1/ -e "source file1.sql;" 2>&1
+--remove_file $MYSQLTEST_VARDIR/dir1/file1.sql
+--remove_file $MYSQLTEST_VARDIR/file2.sql
+--rmdir $MYSQLTEST_VARDIR/dir1
+
+--echo # test 6: script-dir file has source command that references script-dir
+--mkdir $MYSQLTEST_VARDIR/dir1
+--write_file $MYSQLTEST_VARDIR/dir1/file1.sql
+source file2.sql;
+EOF
+--write_file $MYSQLTEST_VARDIR/dir1/file2.sql
+select 'hello from file2.sql';
+EOF
+--exec echo "source file1.sql" | $MYSQL --script-dir=$MYSQLTEST_VARDIR/dir1/ 2>&1
+--remove_file $MYSQLTEST_VARDIR/dir1/file1.sql
+--remove_file $MYSQLTEST_VARDIR/dir1/file2.sql
+--rmdir $MYSQLTEST_VARDIR/dir1


### PR DESCRIPTION

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->
______
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-23818*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
This PR is for testing script execution in a specified `--script-dir`
## Release Notes
A new static variable, `script_dir`, has been added to **mysql.cc** and set to NULL. Additionally, a new option has been introduced in `my_long_options` to locate and assign the `script_dir`. The behavior of com_source has also been modified to append `script_dir` to its directory if the specified file is not found.

## How can this PR be tested?

This PR can be tested by running the server and adding the `--script-dir` option in the terminal.
Here's an example: 

`mariadb --script-dir=foo/bar`

`mariadb[database_name]> source filename.sql`

where filename is located at `foo/bar`

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
