### PR TITLE
MDEV-36116: Remove debug assert in TOI when executing thread is killed

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-36116.result
+++ b/mysql-test/suite/galera/r/MDEV-36116.result
@@ -1,0 +1,22 @@
+connection node_2;
+connection node_1;
+connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1;
+connection node_1;
+CALL mtr.add_suppression("CREATE TABLE isolation failure");
+SET DEBUG_SYNC = 'wsrep_kill_thd_before_enter_toi SIGNAL may_kill WAIT_FOR continue';
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+connection con1;
+SET DEBUG_SYNC = 'now WAIT_FOR may_kill';
+SET DEBUG_SYNC = 'now SIGNAL continue';
+connection node_1;
+ERROR HY000: Lost connection to MySQL server during query
+connection node_2;
+SHOW TABLES LIKE 't1';
+Tables_in_test (t1)
+connection con1;
+SHOW TABLES LIKE 't1';
+Tables_in_test (t1)
+SET DEBUG_SYNC = 'RESET';
+disconnect con1;
+disconnect node_2;
+disconnect node_1;

--- a/mysql-test/suite/galera/t/MDEV-36116.test
+++ b/mysql-test/suite/galera/t/MDEV-36116.test
@@ -1,0 +1,42 @@
+#
+# MDEV-36116: TOI crashes in debug assert if executing thread is killed.
+#
+
+--source include/galera_cluster.inc
+--source include/have_debug_sync.inc
+--source include/have_debug.inc
+
+--connect con1,127.0.0.1,root,,test,$NODE_MYPORT_1
+
+# Start TOI operation and wait for the thread to be killed.
+--connection node_1
+CALL mtr.add_suppression("CREATE TABLE isolation failure");
+
+--let $connection_id = `SELECT CONNECTION_ID()`
+SET DEBUG_SYNC = 'wsrep_kill_thd_before_enter_toi SIGNAL may_kill WAIT_FOR continue';
+--send
+  CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+
+# Kill the thread and let it continue.
+--connection con1
+SET DEBUG_SYNC = 'now WAIT_FOR may_kill';
+--disable_query_log
+--eval KILL CONNECTION $connection_id
+--enable_query_log
+SET DEBUG_SYNC = 'now SIGNAL continue';
+
+--connection node_1
+--error 2013
+--reap
+
+# Verify no tables created on either nodes.
+--connection node_2
+SHOW TABLES LIKE 't1';
+
+--connection con1
+SHOW TABLES LIKE 't1';
+
+# Cleanup
+SET DEBUG_SYNC = 'RESET';
+--disconnect con1
+--source include/galera_end.inc

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -2621,12 +2621,13 @@ int wsrep_to_isolation_begin(THD *thd, const char *db_, const char *table_,
                              const wsrep::key_array *fk_tables,
                              const HA_CREATE_INFO *create_info)
 {
+  DEBUG_SYNC(thd, "wsrep_kill_thd_before_enter_toi");
   mysql_mutex_lock(&thd->LOCK_thd_kill);
   const killed_state killed = thd->killed;
   mysql_mutex_unlock(&thd->LOCK_thd_kill);
   if (killed)
   {
-    DBUG_ASSERT(FALSE);
+    /* The thread may have been killed as a result of memory pressure. */
     return -1;
   }
 


### PR DESCRIPTION
<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36116*

## Description
Prevent debug assert crash in TOI if executing thread is killed.

## Release Notes

## How can this PR be tested?

MTR test is provided.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.