### PR TITLE
MDEV-33671 Remove hardcoded open-files limit in safe_process.cc

### DIFF
--- a/mysql-test/lib/My/SafeProcess.pm
+++ b/mysql-test/lib/My/SafeProcess.pm
@@ -138,6 +138,7 @@ sub new {
   my $error    = delete($opts{'error'});
   my $verbose  = delete($opts{'verbose'}) || $::opt_verbose;
   my $nocore   = delete($opts{'nocore'});
+  my $open_files_limit = delete($opts{'open_files_limit'});
   my $host     = delete($opts{'host'});
   my $shutdown = delete($opts{'shutdown'});
   my $user_data= delete($opts{'user_data'});
@@ -160,6 +161,8 @@ sub new {
 
   push(@safe_args, "--verbose") if $verbose > 0;
   push(@safe_args, "--nocore") if $nocore;
+
+  push(@safe_args, "--open-files-limit=$open_files_limit") if $open_files_limit;
 
   # Point the safe_process at the right parent if running on cygwin
   push(@safe_args, "--parent-pid=".Cygwin::pid_to_winpid($$)) if IS_CYGWIN;

--- a/mysql-test/mariadb-test-run.pl
+++ b/mysql-test/mariadb-test-run.pl
@@ -130,6 +130,8 @@ our $path_language;
 our $path_current_testlog;
 our $path_testlog;
 
+our $opt_open_files_limit;
+
 our $default_vardir;
 our $opt_vardir;                # Path to use for var/ dir
 our $plugindir;
@@ -1277,6 +1279,7 @@ sub command_line_setup {
 	     'list-options'             => \$opt_list_options,
              'skip-test-list=s'         => \@opt_skip_test_list,
              'xml-report=s'             => \$opt_xml_report,
+             'open-files-limit=i',      => \$opt_open_files_limit,
 
              My::Debugger::options(),
              My::CoreDump::options(),
@@ -5767,6 +5770,7 @@ sub start_mysqltest ($) {
      append        => 1,
      error         => $path_current_testlog,
      verbose       => $opt_verbose,
+     open_files_limit => $opt_open_files_limit,
     );
   mtr_verbose("Started $proc");
   return $proc;
@@ -6065,6 +6069,8 @@ Misc options
   timediff              With --timestamp, also print time passed since
                         *previous* test started
   max-connections=N     Max number of open connection to server in mysqltest
+  open-files-limit=N    Max number of open files allowed for any of the children
+                        of my_safe_process. Default is 1024.
   report-times          Report how much time has been spent on different
                         phases of test execution.
   stress=ARGS           Run stress test, providing options to


### PR DESCRIPTION
This commit allows specifying the open-files limit dynamically instead of previously hard coding it with 1024 files  using a new option in MTR ```open-files-limit=X``` 

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: [MDEV-33671](https://jira.mariadb.org/browse/MDEV-33671)

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
With only 1024 open file descriptors it is impossible to use
mtr for high concurrency testing.

This commit removes the hardcoded value and adds a new
option to control the limit when running tests: ```./mtr --open-files-limit=X.```

The default is still 1024, but it can now be changed when needed,
making it easier to test scenarios that require different number of
open file descriptors at the same time e.g: partition_notwin.test


## How can this PR be tested?
This is part of the MTR infrastructure so it can be tested manually and locally using the ```--open-filies-limit=<value>```
e.g: ```./mtr --open-files-limit=1000 alter_algorithm.test```

Note that in https://github.com/MariaDB/server/commit/7d17ee97c2d07a1497c11aa475505d0a993563d0 it caused a test failure by succeeding when having the default number of files before but now it fails as it should when the number of open files is not correct 

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.