### PR TITLE
MDEV-31134: sync galera settings with KB doc

### DIFF
--- a/debian/additions/mariadb.conf.d/60-galera.cnf
+++ b/debian/additions/mariadb.conf.d/60-galera.cnf
@@ -1,21 +1,24 @@
 #
 # * Galera-related settings
 #
-# See the examples of server wsrep.cnf files in /usr/share/mariadb
-# and read more at https://mariadb.com/kb/en/galera-cluster/
+# See the examples of server wsrep.cnf files in /usr/share/mariadb and read
+# more at https://mariadb.com/kb/en/galera-cluster/ and
+# https://mariadb.com/kb/en/configuring-mariadb-galera-cluster/
 
 [galera]
-# Mandatory settings
-#wsrep_on                 = ON
 #wsrep_cluster_name       = "MariaDB Galera Cluster"
+
+# Mandatory settings
+#wsrep_provider           = /usr/lib/galera/libgalera_smm.so
 #wsrep_cluster_address    = gcomm://
-#binlog_format            = row
+#binlog_format            = ROW
+#wsrep_on                 = ON
 #default_storage_engine   = InnoDB
-#innodb_autoinc_lock_mode = 2
 
 # Allow server to accept connections on all interfaces.
 #bind-address = 0.0.0.0
 
-# Optional settings
-#wsrep_slave_threads = 1
+# Performance related settings
+#innodb_autoinc_lock_mode = 2
 #innodb_flush_log_at_trx_commit = 0
+#wsrep_slave_threads = 1


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-31134*

## Description

The `wsrep_provider` setting is mandatory and needs to be present as a guidance for the setup of Galera cluster. `wsrep_cluster_name` and `innodb_autoinc_lock_mode` are not mandatory.

See: https://mariadb.com/kb/en/configuring-mariadb-galera-cluster/

## Release Notes

Update galera configuration settings as in KB doc.

## How can this PR be tested?

There is no impact since it's all commented settings but we might want to test that default settings are working. 

## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
