### PR TITLE
`rpl_start`/`stop_server.inc` fixes

### DIFF
--- a/mysql-test/include/rpl_reconnect.inc
+++ b/mysql-test/include/rpl_reconnect.inc
@@ -31,44 +31,13 @@ if (!$rpl_server_number)
 {
   --die ERROR IN TEST: you must set $rpl_server_number before you source rpl_connect.inc
 }
+--let $rpl_connection_name= server_$rpl_server_number
 
 
 if ($rpl_debug)
 {
   --echo ---- Enable reconnect ----
 }
-
---let $_rpl_server_number= $rpl_server_number
-
---dec $_rpl_server_number
-if (!$_rpl_server_number)
-{
-  --let $rpl_connection_name= default
-  --source include/rpl_connection.inc
-  --enable_reconnect
-
-  --let $rpl_connection_name= master
-  --source include/rpl_connection.inc
-  --enable_reconnect
-
-  --let $rpl_connection_name= master1
-  --source include/rpl_connection.inc
-  --enable_reconnect
-}
-
---dec $_rpl_server_number
-if (!$_rpl_server_number)
-{
-  --let $rpl_connection_name= slave
-  --source include/rpl_connection.inc
-  --enable_reconnect
-
-  --let $rpl_connection_name= slave1
-  --source include/rpl_connection.inc
-  --enable_reconnect
-}
-
---let $rpl_connection_name= server_$rpl_server_number
 --source include/rpl_connection.inc
 --enable_reconnect
 
@@ -76,44 +45,6 @@ if ($rpl_debug)
 {
   --echo ---- Wait for reconnect and disable reconnect on all connections ----
 }
-
---let $_rpl_server_number= $rpl_server_number
-
---dec $_rpl_server_number
-if (!$_rpl_server_number)
-{
-  --let $rpl_connection_name= default
-  --source include/rpl_connection.inc
-  --source include/wait_until_connected_again.inc
-  --disable_reconnect
-
-  --let $rpl_connection_name= master
-  --source include/rpl_connection.inc
-  --source include/wait_until_connected_again.inc
-  --disable_reconnect
-
-  --let $rpl_connection_name= master1
-  --source include/rpl_connection.inc
-  --source include/wait_until_connected_again.inc
-  --disable_reconnect
-}
-
---dec $_rpl_server_number
-if (!$_rpl_server_number)
-{
-  --let $rpl_connection_name= slave
-  --source include/rpl_connection.inc
-  --source include/wait_until_connected_again.inc
-  --disable_reconnect
-
-  --let $rpl_connection_name= slave1
-  --source include/rpl_connection.inc
-  --source include/wait_until_connected_again.inc
-  --disable_reconnect
-}
-
---let $rpl_connection_name= server_$rpl_server_number
---source include/rpl_connection.inc
 --source include/wait_until_connected_again.inc
 --disable_reconnect
 

--- a/mysql-test/include/rpl_start_server.inc
+++ b/mysql-test/include/rpl_start_server.inc
@@ -54,6 +54,6 @@ if ($rpl_server_parameters)
 if (!$rpl_server_error)
 {
   --source include/rpl_reconnect.inc
-  --let $include_filename= rpl_start_server.inc $_rpl_start_server_args
-  --source include/end_include_file.inc
 }
+--let $include_filename= rpl_start_server.inc $_rpl_start_server_args
+--source include/end_include_file.inc

--- a/mysql-test/include/rpl_stop_server.inc
+++ b/mysql-test/include/rpl_stop_server.inc
@@ -28,6 +28,7 @@
 # executing on a server and the server will go down after this script.
 if (!$_include_file_depth)
 {
+  --let $_include_file_depth= 0
   --echo include/rpl_stop_server.inc [server_number=$rpl_server_number]
 }
 --inc $_include_file_depth


### PR DESCRIPTION
* ~~*The Jira issue number for this PR is: MDEV-______*~~

## Description
* `rpl_stop_server.inc`: re. “can’t use `begin`/`end_include_file”, (re)define `$_include_file_depth= 0` in case this is the first `--source` in a `rpl_init.inc`-less setup (e.g., `multi_source.*`)
* `rpl_start_server.inc`: move the `end_include_file.inc` call out of `if (!$rpl_server_error)` to always close the `begin_include_file.inc`
* `rpl_reconnect.inc` (called by rpl_start_server.inc`): skip reconnecting ‘master/slave’ aliases of `server_*` to lift its practical requirement of `master-slave.inc` (It failed with “no connection named master/slave” for even a `rpl_init.inc` setup, let alone `rpl_init`-less.)

## Release Notes
*Do our users even use our `include/*.inc`s?*

## How can this PR be tested?
* [ ] *Do we need a test for a test?*

## PR quality check
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.