### PR TITLE
MDEV-36122 Assertion ctx0->old_table->get_ref_count() == 1

### DIFF
--- a/storage/innobase/dict/dict0defrag_bg.cc
+++ b/storage/innobase/dict/dict0defrag_bg.cc
@@ -217,47 +217,17 @@ dberr_t dict_stats_save_defrag_summary(dict_index_t *index, THD *thd)
   if (index->is_ibuf())
     return DB_SUCCESS;
 
-  MDL_ticket *mdl_table= nullptr, *mdl_index= nullptr;
-  dict_table_t *table_stats= dict_table_open_on_name(TABLE_STATS_NAME, false,
-                                                     DICT_ERR_IGNORE_NONE);
-  if (table_stats)
-  {
-    dict_sys.freeze(SRW_LOCK_CALL);
-    table_stats= dict_acquire_mdl_shared<false>(table_stats, thd, &mdl_table);
-    dict_sys.unfreeze();
-  }
-  if (!table_stats || strcmp(table_stats->name.m_name, TABLE_STATS_NAME))
-  {
-release_and_exit:
-    if (table_stats)
-      dict_table_close(table_stats, false, thd, mdl_table);
+  dict_stats stats;
+  if (stats.open(thd))
     return DB_STATS_DO_NOT_EXIST;
-  }
-
-  dict_table_t *index_stats= dict_table_open_on_name(INDEX_STATS_NAME, false,
-                                                     DICT_ERR_IGNORE_NONE);
-  if (index_stats)
-  {
-    dict_sys.freeze(SRW_LOCK_CALL);
-    index_stats= dict_acquire_mdl_shared<false>(index_stats, thd, &mdl_index);
-    dict_sys.unfreeze();
-  }
-  if (!index_stats)
-    goto release_and_exit;
-  if (strcmp(index_stats->name.m_name, INDEX_STATS_NAME))
-  {
-    dict_table_close(index_stats, false, thd, mdl_index);
-    goto release_and_exit;
-  }
-
   trx_t *trx= trx_create();
   trx->mysql_thd= thd;
   trx_start_internal(trx);
   dberr_t ret= trx->read_only
     ? DB_READ_ONLY
-    : lock_table_for_trx(table_stats, trx, LOCK_X);
+    : lock_table_for_trx(stats.table(), trx, LOCK_X);
   if (ret == DB_SUCCESS)
-    ret= lock_table_for_trx(index_stats, trx, LOCK_X);
+    ret= lock_table_for_trx(stats.index(), trx, LOCK_X);
   row_mysql_lock_data_dictionary(trx);
   if (ret == DB_SUCCESS)
     ret= dict_stats_save_index_stat(index, time(nullptr), "n_pages_freed",
@@ -271,13 +241,9 @@ release_and_exit:
   else
     trx->rollback();
 
-  if (table_stats)
-    dict_table_close(table_stats, true, thd, mdl_table);
-  if (index_stats)
-    dict_table_close(index_stats, true, thd, mdl_index);
-
   row_mysql_unlock_data_dictionary(trx);
   trx->free();
+  stats.close();
 
   return ret;
 }
@@ -353,49 +319,18 @@ dict_stats_save_defrag_stats(
   if (n_leaf_reserved == ULINT_UNDEFINED)
     return DB_SUCCESS;
 
-  THD *thd= current_thd;
-  MDL_ticket *mdl_table= nullptr, *mdl_index= nullptr;
-  dict_table_t* table_stats= dict_table_open_on_name(TABLE_STATS_NAME, false,
-                                                     DICT_ERR_IGNORE_NONE);
-  if (table_stats)
-  {
-    dict_sys.freeze(SRW_LOCK_CALL);
-    table_stats= dict_acquire_mdl_shared<false>(table_stats, thd, &mdl_table);
-    dict_sys.unfreeze();
-  }
-  if (!table_stats || strcmp(table_stats->name.m_name, TABLE_STATS_NAME))
-  {
-release_and_exit:
-    if (table_stats)
-      dict_table_close(table_stats, false, thd, mdl_table);
+  THD *const thd= current_thd;
+  dict_stats stats;
+  if (stats.open(thd))
     return DB_STATS_DO_NOT_EXIST;
-  }
-
-  dict_table_t *index_stats= dict_table_open_on_name(INDEX_STATS_NAME, false,
-                                                     DICT_ERR_IGNORE_NONE);
-  if (index_stats)
-  {
-    dict_sys.freeze(SRW_LOCK_CALL);
-    index_stats= dict_acquire_mdl_shared<false>(index_stats, thd, &mdl_index);
-    dict_sys.unfreeze();
-  }
-  if (!index_stats)
-    goto release_and_exit;
-
-  if (strcmp(index_stats->name.m_name, INDEX_STATS_NAME))
-  {
-    dict_table_close(index_stats, false, thd, mdl_index);
-    goto release_and_exit;
-  }
-
   trx_t *trx= trx_create();
   trx->mysql_thd= thd;
   trx_start_internal(trx);
   dberr_t ret= trx->read_only
     ? DB_READ_ONLY
-    : lock_table_for_trx(table_stats, trx, LOCK_X);
+    : lock_table_for_trx(stats.table(), trx, LOCK_X);
   if (ret == DB_SUCCESS)
-    ret= lock_table_for_trx(index_stats, trx, LOCK_X);
+    ret= lock_table_for_trx(stats.index(), trx, LOCK_X);
 
   row_mysql_lock_data_dictionary(trx);
 
@@ -423,12 +358,9 @@ release_and_exit:
   else
     trx->rollback();
 
-  if (table_stats)
-    dict_table_close(table_stats, true, thd, mdl_table);
-  if (index_stats)
-    dict_table_close(index_stats, true, thd, mdl_index);
   row_mysql_unlock_data_dictionary(trx);
   trx->free();
+  stats.close();
 
   return ret;
 }

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -2896,11 +2896,12 @@ dict_stats_save(
 	pars_info_t*	pinfo;
 	char		db_utf8[MAX_DB_UTF8_LEN];
 	char		table_utf8[MAX_TABLE_UTF8_LEN];
+	THD* const	thd = current_thd;
 
 #ifdef ENABLED_DEBUG_SYNC
 	DBUG_EXECUTE_IF("dict_stats_save_exit_notify",
-	   SCOPE_EXIT([] {
-	       debug_sync_set_action(current_thd,
+	   SCOPE_EXIT([thd] {
+	       debug_sync_set_action(thd,
 	       STRING_WITH_LEN("now SIGNAL dict_stats_save_finished"));
 	    });
 	);
@@ -2914,41 +2915,10 @@ dict_stats_save(
 		return (dict_stats_report_error(table));
 	}
 
-	THD* thd = current_thd;
-	MDL_ticket *mdl_table = nullptr, *mdl_index = nullptr;
-	dict_table_t* table_stats = dict_table_open_on_name(
-		TABLE_STATS_NAME, false, DICT_ERR_IGNORE_NONE);
-	if (table_stats) {
-		dict_sys.freeze(SRW_LOCK_CALL);
-		table_stats = dict_acquire_mdl_shared<false>(table_stats, thd,
-							     &mdl_table);
-		dict_sys.unfreeze();
-	}
-	if (!table_stats
-	    || strcmp(table_stats->name.m_name, TABLE_STATS_NAME)) {
-release_and_exit:
-		if (table_stats) {
-			dict_table_close(table_stats, false, thd, mdl_table);
-		}
+	dict_stats stats;
+	if (stats.open(thd)) {
 		return DB_STATS_DO_NOT_EXIST;
 	}
-
-	dict_table_t* index_stats = dict_table_open_on_name(
-		INDEX_STATS_NAME, false, DICT_ERR_IGNORE_NONE);
-	if (index_stats) {
-		dict_sys.freeze(SRW_LOCK_CALL);
-		index_stats = dict_acquire_mdl_shared<false>(index_stats, thd,
-							     &mdl_index);
-		dict_sys.unfreeze();
-	}
-	if (!index_stats) {
-		goto release_and_exit;
-	}
-	if (strcmp(index_stats->name.m_name, INDEX_STATS_NAME)) {
-		dict_table_close(index_stats, false, thd, mdl_index);
-		goto release_and_exit;
-	}
-
 	dict_fs2utf8(table->name.m_name, db_utf8, sizeof(db_utf8),
 		     table_utf8, sizeof(table_utf8));
 	const time_t now = time(NULL);
@@ -2957,9 +2927,9 @@ release_and_exit:
 	trx_start_internal(trx);
 	dberr_t ret = trx->read_only
 		? DB_READ_ONLY
-		: lock_table_for_trx(table_stats, trx, LOCK_X);
+		: lock_table_for_trx(stats.table(), trx, LOCK_X);
 	if (ret == DB_SUCCESS) {
-		ret = lock_table_for_trx(index_stats, trx, LOCK_X);
+		ret = lock_table_for_trx(stats.index(), trx, LOCK_X);
 	}
 	if (ret != DB_SUCCESS) {
 		if (trx->state != TRX_STATE_NOT_STARTED) {
@@ -3014,8 +2984,7 @@ free_and_exit:
 		dict_sys.unlock();
 unlocked_free_and_exit:
 		trx->free();
-		dict_table_close(table_stats, false, thd, mdl_table);
-		dict_table_close(index_stats, false, thd, mdl_index);
+		stats.close();
 		return ret;
 	}
 
@@ -3495,41 +3464,10 @@ dict_stats_fetch_from_ps(
 	stats. */
 	dict_stats_empty_table(table, true);
 
-	THD* thd = current_thd;
-	MDL_ticket *mdl_table = nullptr, *mdl_index = nullptr;
-	dict_table_t* table_stats = dict_table_open_on_name(
-		TABLE_STATS_NAME, false, DICT_ERR_IGNORE_NONE);
-	if (!table_stats) {
+	THD* const thd = current_thd;
+	dict_stats stats;
+	if (stats.open(thd)) {
 		return DB_STATS_DO_NOT_EXIST;
-	}
-	dict_table_t* index_stats = dict_table_open_on_name(
-		INDEX_STATS_NAME, false, DICT_ERR_IGNORE_NONE);
-	if (!index_stats) {
-		dict_table_close(table_stats);
-		return DB_STATS_DO_NOT_EXIST;
-	}
-
-	dict_sys.freeze(SRW_LOCK_CALL);
-	table_stats = dict_acquire_mdl_shared<false>(table_stats, thd,
-						     &mdl_table);
-	if (!table_stats
-	    || strcmp(table_stats->name.m_name, TABLE_STATS_NAME)) {
-release_and_exit:
-		if (table_stats) {
-			dict_table_close(table_stats, true, thd, mdl_table);
-		}
-		if (index_stats) {
-			dict_table_close(index_stats, true, thd, mdl_index);
-		}
-		dict_sys.unfreeze();
-		return DB_STATS_DO_NOT_EXIST;
-	}
-
-	index_stats = dict_acquire_mdl_shared<false>(index_stats, thd,
-						     &mdl_index);
-	if (!index_stats
-	    || strcmp(index_stats->name.m_name, INDEX_STATS_NAME)) {
-		goto release_and_exit;
 	}
 
 #ifdef ENABLED_DEBUG_SYNC
@@ -3556,7 +3494,6 @@ release_and_exit:
 			        "fetch_index_stats_step",
 			        dict_stats_fetch_index_stats_step,
 			        &index_fetch_arg);
-	dict_sys.unfreeze();
 	dict_sys.lock(SRW_LOCK_CALL);
 	que_t* graph = pars_sql(
 		pinfo,
@@ -3622,18 +3559,11 @@ release_and_exit:
 	trx_start_internal_read_only(trx);
 	que_run_threads(que_fork_start_command(graph));
 	que_graph_free(graph);
-
-	dict_table_close(table_stats, false, thd, mdl_table);
-	dict_table_close(index_stats, false, thd, mdl_index);
-
 	trx_commit_for_mysql(trx);
-	dberr_t ret = trx->error_state;
+	dberr_t ret = index_fetch_arg.stats_were_modified
+		? trx->error_state : DB_STATS_DO_NOT_EXIST;
 	trx->free();
-
-	if (!index_fetch_arg.stats_were_modified) {
-		return DB_STATS_DO_NOT_EXIST;
-	}
-
+	stats.close();
 	return ret;
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14023,6 +14023,7 @@ int ha_innobase::truncate()
 
   const bool fts= error == DB_SUCCESS &&
     ib_table->flags2 & (DICT_TF2_FTS_HAS_DOC_ID | DICT_TF2_FTS);
+  const bool pause_purge= error == DB_SUCCESS && ib_table->get_ref_count() > 1;
 
   if (fts)
   {
@@ -14030,6 +14031,8 @@ int ha_innobase::truncate()
     purge_sys.stop_FTS(*ib_table);
     error= fts_lock_tables(trx, *ib_table);
   }
+  else if (pause_purge)
+    purge_sys.stop_FTS();
 
   /* Wait for purge threads to stop using the table. */
   for (uint n = 15; ib_table->get_ref_count() > 1; )

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1357,38 +1357,17 @@ static void innodb_drop_database(handlerton*, char *path)
 
   dict_sys.unlock();
 
-  dict_table_t *table_stats, *index_stats;
-  MDL_ticket *mdl_table= nullptr, *mdl_index= nullptr;
-  table_stats= dict_table_open_on_name(TABLE_STATS_NAME, false,
-                                       DICT_ERR_IGNORE_NONE);
-  if (table_stats)
-  {
-    dict_sys.freeze(SRW_LOCK_CALL);
-    table_stats= dict_acquire_mdl_shared<false>(table_stats,
-                                                thd, &mdl_table);
-    dict_sys.unfreeze();
-  }
-  index_stats= dict_table_open_on_name(INDEX_STATS_NAME, false,
-                                       DICT_ERR_IGNORE_NONE);
-  if (index_stats)
-  {
-    dict_sys.freeze(SRW_LOCK_CALL);
-    index_stats= dict_acquire_mdl_shared<false>(index_stats,
-                                                thd, &mdl_index);
-    dict_sys.unfreeze();
-  }
-
+  dict_stats stats;
+  const bool stats_failed{stats.open(thd)};
   trx_start_for_ddl(trx);
 
   uint errors= 0;
   char db[NAME_LEN + 1];
   strconvert(&my_charset_filename, namebuf, len, system_charset_info, db,
              sizeof db, &errors);
-  if (!errors && table_stats && index_stats &&
-      !strcmp(table_stats->name.m_name, TABLE_STATS_NAME) &&
-      !strcmp(index_stats->name.m_name, INDEX_STATS_NAME) &&
-      lock_table_for_trx(table_stats, trx, LOCK_X) == DB_SUCCESS &&
-      lock_table_for_trx(index_stats, trx, LOCK_X) == DB_SUCCESS)
+  if (!errors && !stats_failed &&
+      lock_table_for_trx(stats.table(), trx, LOCK_X) == DB_SUCCESS &&
+      lock_table_for_trx(stats.index(), trx, LOCK_X) == DB_SUCCESS)
   {
     row_mysql_lock_data_dictionary(trx);
     if (dict_stats_delete(db, trx))
@@ -1484,19 +1463,16 @@ static void innodb_drop_database(handlerton*, char *path)
   if (err != DB_SUCCESS)
   {
     trx->rollback();
-    namebuf[len] = '\0';
-    ib::error() << "DROP DATABASE " << namebuf << ": " << err;
+    sql_print_error("InnoDB: DROP DATABASE %.*s: %s",
+                    int(len), namebuf, ut_strerr(err));
   }
   else
     trx->commit();
 
-  if (table_stats)
-    dict_table_close(table_stats, true, thd, mdl_table);
-  if (index_stats)
-    dict_table_close(index_stats, true, thd, mdl_index);
   row_mysql_unlock_data_dictionary(trx);
-
   trx->free();
+  if (!stats_failed)
+    stats.close();
 
   if (err == DB_SUCCESS)
   {
@@ -13682,8 +13658,6 @@ int ha_innobase::delete_table(const char *name)
       err= lock_table_children(table, trx);
   }
 
-  dict_table_t *table_stats= nullptr, *index_stats= nullptr;
-  MDL_ticket *mdl_table= nullptr, *mdl_index= nullptr;
   if (err == DB_SUCCESS)
     err= lock_table_for_trx(table, trx, LOCK_X);
 
@@ -13722,37 +13696,18 @@ int ha_innobase::delete_table(const char *name)
 #endif
 
   DEBUG_SYNC(thd, "before_delete_table_stats");
+  dict_stats stats;
+  bool stats_failed= true;
 
   if (err == DB_SUCCESS && dict_stats_is_persistent_enabled(table) &&
       !table->is_stats_table())
   {
-    table_stats= dict_table_open_on_name(TABLE_STATS_NAME, false,
-                                         DICT_ERR_IGNORE_NONE);
-    if (table_stats)
-    {
-      dict_sys.freeze(SRW_LOCK_CALL);
-      table_stats= dict_acquire_mdl_shared<false>(table_stats,
-                                                  thd, &mdl_table);
-      dict_sys.unfreeze();
-    }
-
-    index_stats= dict_table_open_on_name(INDEX_STATS_NAME, false,
-                                         DICT_ERR_IGNORE_NONE);
-    if (index_stats)
-    {
-      dict_sys.freeze(SRW_LOCK_CALL);
-      index_stats= dict_acquire_mdl_shared<false>(index_stats,
-                                                  thd, &mdl_index);
-      dict_sys.unfreeze();
-    }
-
+    stats_failed= stats.open(thd);
     const bool skip_wait{table->name.is_temporary()};
 
-    if (table_stats && index_stats &&
-        !strcmp(table_stats->name.m_name, TABLE_STATS_NAME) &&
-        !strcmp(index_stats->name.m_name, INDEX_STATS_NAME) &&
-        !(err= lock_table_for_trx(table_stats, trx, LOCK_X, skip_wait)))
-      err= lock_table_for_trx(index_stats, trx, LOCK_X, skip_wait);
+    if (!stats_failed &&
+        !(err= lock_table_for_trx(stats.table(), trx, LOCK_X, skip_wait)))
+      err= lock_table_for_trx(stats.index(), trx, LOCK_X, skip_wait);
 
     if (err != DB_SUCCESS && skip_wait)
     {
@@ -13761,10 +13716,8 @@ int ha_innobase::delete_table(const char *name)
       ut_ad(err == DB_LOCK_WAIT);
       ut_ad(trx->error_state == DB_SUCCESS);
       err= DB_SUCCESS;
-      dict_table_close(table_stats, false, thd, mdl_table);
-      dict_table_close(index_stats, false, thd, mdl_index);
-      table_stats= nullptr;
-      index_stats= nullptr;
+      stats.close();
+      stats_failed= true;
     }
   }
 
@@ -13835,13 +13788,11 @@ err_exit:
     else if (rollback_add_partition)
       purge_sys.resume_FTS();
 #endif
-    if (table_stats)
-      dict_table_close(table_stats, true, thd, mdl_table);
-    if (index_stats)
-      dict_table_close(index_stats, true, thd, mdl_index);
     row_mysql_unlock_data_dictionary(trx);
     if (trx != parent_trx)
       trx->free();
+    if (!stats_failed)
+      stats.close();
     DBUG_RETURN(convert_error_code_to_mysql(err, 0, NULL));
   }
 
@@ -13856,7 +13807,7 @@ err_exit:
     err= trx->drop_table_foreign(table->name);
   }
 
-  if (err == DB_SUCCESS && table_stats && index_stats)
+  if (err == DB_SUCCESS && !stats_failed)
     err= trx->drop_table_statistics(table->name);
   if (err != DB_SUCCESS)
     goto err_exit;
@@ -13867,11 +13818,9 @@ err_exit:
 
   std::vector<pfs_os_file_t> deleted;
   trx->commit(deleted);
-  if (table_stats)
-    dict_table_close(table_stats, true, thd, mdl_table);
-  if (index_stats)
-    dict_table_close(index_stats, true, thd, mdl_index);
   row_mysql_unlock_data_dictionary(trx);
+  if (!stats_failed)
+    stats.close();
   for (pfs_os_file_t d : deleted)
     os_file_close(d);
   log_write_up_to(trx->commit_lsn, true);
@@ -14067,9 +14016,6 @@ int ha_innobase::truncate()
                                         ib_table->name.m_name, ib_table->id);
   const char *name= mem_heap_strdup(heap, ib_table->name.m_name);
 
-  dict_table_t *table_stats = nullptr, *index_stats = nullptr;
-  MDL_ticket *mdl_table = nullptr, *mdl_index = nullptr;
-
   dberr_t error= lock_table_children(ib_table, trx);
 
   if (error == DB_SUCCESS)
@@ -14096,33 +14042,16 @@ int ha_innobase::truncate()
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
   }
 
+  dict_stats stats;
+  bool stats_failed= true;
+
   if (error == DB_SUCCESS && dict_stats_is_persistent_enabled(ib_table) &&
       !ib_table->is_stats_table())
   {
-    table_stats= dict_table_open_on_name(TABLE_STATS_NAME, false,
-                                         DICT_ERR_IGNORE_NONE);
-    if (table_stats)
-    {
-      dict_sys.freeze(SRW_LOCK_CALL);
-      table_stats= dict_acquire_mdl_shared<false>(table_stats, m_user_thd,
-                                                  &mdl_table);
-      dict_sys.unfreeze();
-    }
-    index_stats= dict_table_open_on_name(INDEX_STATS_NAME, false,
-                                         DICT_ERR_IGNORE_NONE);
-    if (index_stats)
-    {
-      dict_sys.freeze(SRW_LOCK_CALL);
-      index_stats= dict_acquire_mdl_shared<false>(index_stats, m_user_thd,
-                                                  &mdl_index);
-      dict_sys.unfreeze();
-    }
-
-    if (table_stats && index_stats &&
-        !strcmp(table_stats->name.m_name, TABLE_STATS_NAME) &&
-        !strcmp(index_stats->name.m_name, INDEX_STATS_NAME) &&
-        !(error= lock_table_for_trx(table_stats, trx, LOCK_X)))
-      error= lock_table_for_trx(index_stats, trx, LOCK_X);
+    stats_failed= stats.open(m_user_thd);
+    if (!stats_failed &&
+        !(error= lock_table_for_trx(stats.table(), trx, LOCK_X)))
+      error= lock_table_for_trx(stats.index(), trx, LOCK_X);
   }
 
   if (error == DB_SUCCESS)
@@ -14214,14 +14143,9 @@ int ha_innobase::truncate()
   }
 
   trx->free();
-
+  if (!stats_failed)
+    stats.close();
   mem_heap_free(heap);
-
-  if (table_stats)
-    dict_table_close(table_stats, false, m_user_thd, mdl_table);
-  if (index_stats)
-    dict_table_close(index_stats, false, m_user_thd, mdl_index);
-
   DBUG_RETURN(err);
 }
 
@@ -14247,8 +14171,6 @@ ha_innobase::rename_table(
 	trx_t*	trx = innobase_trx_allocate(thd);
 	trx_start_for_ddl(trx);
 
-	dict_table_t *table_stats = nullptr, *index_stats = nullptr;
-	MDL_ticket *mdl_table = nullptr, *mdl_index = nullptr;
 	char norm_from[MAX_FULL_NAME_LEN];
 	char norm_to[MAX_FULL_NAME_LEN];
 
@@ -14269,34 +14191,19 @@ ha_innobase::rename_table(
 		table->release();
 	}
 
+	dict_stats stats;
+	bool stats_fail = true;
+
 	if (strcmp(norm_from, TABLE_STATS_NAME)
 	    && strcmp(norm_from, INDEX_STATS_NAME)
 	    && strcmp(norm_to, TABLE_STATS_NAME)
 	    && strcmp(norm_to, INDEX_STATS_NAME)) {
-		table_stats = dict_table_open_on_name(TABLE_STATS_NAME, false,
-						      DICT_ERR_IGNORE_NONE);
-		if (table_stats) {
-			dict_sys.freeze(SRW_LOCK_CALL);
-			table_stats = dict_acquire_mdl_shared<false>(
-				table_stats, thd, &mdl_table);
-			dict_sys.unfreeze();
-		}
-		index_stats = dict_table_open_on_name(INDEX_STATS_NAME, false,
-						      DICT_ERR_IGNORE_NONE);
-		if (index_stats) {
-			dict_sys.freeze(SRW_LOCK_CALL);
-			index_stats = dict_acquire_mdl_shared<false>(
-				index_stats, thd, &mdl_index);
-			dict_sys.unfreeze();
-		}
-
-		if (error == DB_SUCCESS && table_stats && index_stats
-		    && !strcmp(table_stats->name.m_name, TABLE_STATS_NAME)
-		    && !strcmp(index_stats->name.m_name, INDEX_STATS_NAME)) {
-			error = lock_table_for_trx(table_stats, trx, LOCK_X,
-						   from_temp);
+		stats_fail = stats.open(thd);
+		if (!stats_fail && error == DB_SUCCESS) {
+			error = lock_table_for_trx(stats.table(), trx,
+						   LOCK_X, from_temp);
 			if (error == DB_SUCCESS) {
-				error = lock_table_for_trx(index_stats, trx,
+				error = lock_table_for_trx(stats.index(), trx,
 							   LOCK_X, from_temp);
 			}
 			if (error != DB_SUCCESS && from_temp) {
@@ -14307,12 +14214,8 @@ ha_innobase::rename_table(
 				we cannot lock the tables, when the
 				table is being renamed from from a
 				temporary name. */
-				dict_table_close(table_stats, false, thd,
-						 mdl_table);
-				dict_table_close(index_stats, false, thd,
-						 mdl_index);
-				table_stats = nullptr;
-				index_stats = nullptr;
+				stats.close();
+				stats_fail = true;
 			}
 		}
 	}
@@ -14339,7 +14242,7 @@ ha_innobase::rename_table(
 
 	DEBUG_SYNC(thd, "after_innobase_rename_table");
 
-	if (error == DB_SUCCESS && table_stats && index_stats) {
+	if (error == DB_SUCCESS && !stats_fail) {
 		error = dict_stats_rename_table(norm_from, norm_to, trx);
 		if (error == DB_DUPLICATE_KEY) {
 			/* The duplicate may also occur in
@@ -14357,18 +14260,15 @@ ha_innobase::rename_table(
 		trx->rollback();
 	}
 
-	if (table_stats) {
-		dict_table_close(table_stats, true, thd, mdl_table);
-	}
-	if (index_stats) {
-		dict_table_close(index_stats, true, thd, mdl_index);
-	}
 	row_mysql_unlock_data_dictionary(trx);
 	if (error == DB_SUCCESS) {
 		log_write_up_to(trx->commit_lsn, true);
 	}
 	trx->flush_log_later = false;
 	trx->free();
+	if (!stats_fail) {
+		stats.close();
+	}
 
 	if (error == DB_DUPLICATE_KEY) {
 		/* We are not able to deal with handler::get_dup_key()
@@ -17615,11 +17515,16 @@ static int innodb_ft_aux_table_validate(THD *thd, st_mysql_sys_var*,
 	int len = sizeof buf;
 
 	if (const char* table_name = value->val_str(value, buf, &len)) {
+		/* Because we are not acquiring MDL on the table name,
+		we must contiguously hold dict_sys.latch while we are
+		examining the table, to protect us against concurrent DDL. */
+		dict_sys.lock(SRW_LOCK_CALL);
 		if (dict_table_t* table = dict_table_open_on_name(
-			    table_name, false, DICT_ERR_IGNORE_NONE)) {
+			    table_name, true, DICT_ERR_IGNORE_NONE)) {
+			table->release();
 			const table_id_t id = dict_table_has_fts_index(table)
 				? table->id : 0;
-			dict_table_close(table);
+			dict_sys.unlock();
 			if (id) {
 				innodb_ft_aux_table_id = id;
 				if (table_name == buf) {
@@ -17630,12 +17535,11 @@ static int innodb_ft_aux_table_validate(THD *thd, st_mysql_sys_var*,
 								 len);
 				}
 
-
 				*static_cast<const char**>(save) = table_name;
 				return 0;
 			}
 		}
-
+		dict_sys.unlock();
 		return 1;
 	} else {
 		*static_cast<char**>(save) = NULL;

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -1660,6 +1660,27 @@ bool
 dict_table_have_virtual_index(
 	dict_table_t*	table);
 
+/** Helper for opening the InnoDB persistent statistics tables */
+class dict_stats final
+{
+  MDL_context *mdl_context= nullptr;
+  MDL_ticket *mdl_table= nullptr, *mdl_index= nullptr;
+  dict_table_t *table_stats= nullptr, *index_stats= nullptr;
+
+public:
+  dict_stats()= default;
+
+  /** Open the statistics tables.
+  @return whether the operation failed */
+  bool open(THD *thd) noexcept;
+
+  /** Close the statistics tables after !open_tables(thd). */
+  void close() noexcept;
+
+  dict_table_t *table() const noexcept { return table_stats; }
+  dict_table_t *index() const noexcept { return index_stats; }
+};
+
 #include "dict0dict.inl"
 
 #endif

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -4140,13 +4140,12 @@ dberr_t lock_table_children(dict_table_t *table, trx_t *trx)
           children.end())
         continue; /* We already acquired MDL on this child table. */
       MDL_ticket *mdl= nullptr;
-      child->acquire();
       child= dict_acquire_mdl_shared<false>(child, mdl_context, &mdl,
                                             DICT_TABLE_OP_NORMAL);
       if (child)
       {
-        if (!mdl)
-          child->release();
+        if (mdl)
+          child->acquire();
         children.emplace_back(table_mdl{child, mdl});
         goto rescan;
       }

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1292,8 +1292,6 @@ static purge_sys_t::iterator trx_purge_attach_undo_recs(THD *thd,
       break;
   }
 
-  purge_sys.m_active= false;
-
 #ifdef UNIV_DEBUG
   thr= UT_LIST_GET_FIRST(purge_sys.query->thrs);
   for (ulint i= 0; thr && i < *n_work_items;
@@ -1342,6 +1340,8 @@ static void trx_purge_wait_for_workers_to_complete()
 TRANSACTIONAL_INLINE
 void purge_sys_t::batch_cleanup(const purge_sys_t::iterator &head)
 {
+  m_active= false;
+
   /* Release the undo pages. */
   for (auto p : pages)
     p.second->unfix();

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1051,16 +1051,25 @@ inline trx_purge_rec_t purge_sys_t::fetch_next_rec()
 /** Close all tables that were opened in a purge batch for a worker.
 @param node   purge task context
 @param thd    purge coordinator thread handle */
-static void trx_purge_close_tables(purge_node_t *node, THD *thd)
+static void trx_purge_close_tables(purge_node_t *node, THD *thd) noexcept
 {
   for (auto &t : node->tables)
   {
-    if (!t.second.first);
-    else if (t.second.first == reinterpret_cast<dict_table_t*>(-1));
-    else
+    dict_table_t *table= t.second.first;
+    if (table != nullptr && table != reinterpret_cast<dict_table_t*>(-1))
+      dict_table_close(table);
+  }
+
+  MDL_context *mdl_context= static_cast<MDL_context*>(thd_mdl_context(thd));
+
+  for (auto &t : node->tables)
+  {
+    dict_table_t *table= t.second.first;
+    if (table != nullptr && table != reinterpret_cast<dict_table_t*>(-1))
     {
-      dict_table_close(t.second.first, false, thd, t.second.second);
       t.second.first= reinterpret_cast<dict_table_t*>(-1);
+      if (mdl_context != nullptr && t.second.second != nullptr)
+        mdl_context->release_lock(t.second.second);
     }
   }
 }
@@ -1072,36 +1081,35 @@ void purge_sys_t::wait_FTS(bool also_sys)
 }
 
 __attribute__((nonnull))
-/** Aqcuire a metadata lock on a table.
+/** Acquire a metadata lock on a table.
 @param table        table handle
 @param mdl_context  metadata lock acquisition context
-@param mdl          metadata lcok
+@param mdl          metadata lock
 @return table handle
 @retval nullptr if the table is not found or accessible
 @retval -1      if the purge of history must be suspended due to DDL */
 static dict_table_t *trx_purge_table_acquire(dict_table_t *table,
                                              MDL_context *mdl_context,
-                                             MDL_ticket **mdl)
+                                             MDL_ticket **mdl) noexcept
 {
   ut_ad(dict_sys.frozen_not_locked());
   *mdl= nullptr;
 
   if (!table->is_readable() || table->corrupted)
-  {
-    table->release();
     return nullptr;
-  }
 
   size_t db_len= dict_get_db_name_len(table->name.m_name);
   if (db_len == 0)
-    return table; /* InnoDB system tables are not covered by MDL */
+  {
+    /* InnoDB system tables are not covered by MDL */
+  got_table:
+    table->acquire();
+    return table;
+  }
 
   if (purge_sys.must_wait_FTS())
-  {
   must_wait:
-    table->release();
     return reinterpret_cast<dict_table_t*>(-1);
-  }
 
   char db_buf[NAME_LEN + 1];
   char tbl_buf[NAME_LEN + 1];
@@ -1109,7 +1117,7 @@ static dict_table_t *trx_purge_table_acquire(dict_table_t *table,
 
   if (!table->parse_name<true>(db_buf, tbl_buf, &db_len, &tbl_len))
     /* The name of an intermediate table starts with #sql */
-    return table;
+    goto got_table;
 
   {
     MDL_request request;
@@ -1122,37 +1130,38 @@ static dict_table_t *trx_purge_table_acquire(dict_table_t *table,
       goto must_wait;
   }
 
-  return table;
+  goto got_table;
 }
 
 /** Open a table handle for the purge of committed transaction history
 @param table_id     InnoDB table identifier
 @param mdl_context  metadata lock acquisition context
-@param mdl          metadata lcok
+@param mdl          metadata lock
 @return table handle
 @retval nullptr if the table is not found or accessible
 @retval -1      if the purge of history must be suspended due to DDL */
 static dict_table_t *trx_purge_table_open(table_id_t table_id,
                                           MDL_context *mdl_context,
-                                          MDL_ticket **mdl)
+                                          MDL_ticket **mdl) noexcept
 {
-  dict_sys.freeze(SRW_LOCK_CALL);
+  dict_table_t *table;
 
-  dict_table_t *table= dict_sys.find_table(table_id);
-
-  if (table)
-    table->acquire();
-  else
+  for (;;)
   {
+    dict_sys.freeze(SRW_LOCK_CALL);
+    table= dict_sys.find_table(table_id);
+    if (table)
+      break;
     dict_sys.unfreeze();
     dict_sys.lock(SRW_LOCK_CALL);
     table= dict_load_table_on_id(table_id, DICT_ERR_IGNORE_FK_NOKEY);
-    if (table)
-      table->acquire();
     dict_sys.unlock();
     if (!table)
       return nullptr;
-    dict_sys.freeze(SRW_LOCK_CALL);
+    /* At this point, the freshly loaded table may already have been evicted.
+    We must look it up again while holding a shared dict_sys.latch.  We keep
+    trying this until the table is found in the cache or it cannot be found
+    in the dictionary (because the table has been dropped or rebuilt). */
   }
 
   table= trx_purge_table_acquire(table, mdl_context, mdl);
@@ -1171,10 +1180,7 @@ dict_table_t *purge_sys_t::close_and_reopen(table_id_t id, THD *thd,
 
   for (que_thr_t *thr= UT_LIST_GET_FIRST(purge_sys.query->thrs); thr;
        thr= UT_LIST_GET_NEXT(thrs, thr))
-  {
-    purge_node_t *node= static_cast<purge_node_t*>(thr->child);
-    trx_purge_close_tables(node, thd);
-  }
+    trx_purge_close_tables(static_cast<purge_node_t*>(thr->child), thd);
 
   m_active= false;
   wait_FTS(false);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36122*
## Description
`trx_purge_close_tables()`: Before releasing any metadata locks (MDL), release all table references, in case an `ALTER TABLE…ALGORITHM=COPY` operation has confused our logic.

`trx_purge_table_acquire()`, `trx_purge_table_open()`: Do not acquire any table reference before successfully acquiring a necessary metadata lock. In this way, if purge is waiting for MDL, a concurrent `ha_innobase::commit_inplace_alter_table(commit=true)` that is holding a conflicting `MDL_EXCLUSIVE` will only observe its own reference on the table that it may need to replace.

`dict_table_open_on_id()`: Simplify the logic.

`dict_stats`: A helper for acquiring MDL and opening the tables `mysql.innodb_table_stats` and `mysql.innodb_index_stats`.

`innodb_ft_aux_table_validate()`: Contiguously hold `dict_sys.latch` while accessing the table that we open with `dict_table_open_on_name()`.

`lock_table_children()`: Do not hold a table reference while invoking `dict_acquire_mdl_shared<false>()`, which may temporarily release and reacquire the shared `dict_sys.latch` that we are holding.

`prepare_inplace_alter_table_dict()`: If an unexpected reference to the table exists, wait for the purge subsystem to release its table handle, similar to how we would do in case `FULLTEXT INDEX` existed. This function is supposed to be protected by `MDL_EXCLUSIVE` on the table name. If purge is going to access the table again later during is `ALTER TABLE` operation, it will have access to an MDL compatible name for it and therefore should conflict with any `MDL_EXCLUSIVE` that would cover `ha_innobase::commit_inplace_alter_table(commit=true)`.

With these changes, no caller of `dict_acquire_mdl_shared<false>` should be holding a table reference.

All remaining calls to `dict_table_open_on_name(dict_locked=false)` except the one in `fts_lock_table()` and possibly in the DDL recovery predicate `innodb_check_version()` should be protected by MDL, but there currently is no assertion that would enforce this.
## Release Notes
Some race conditions between InnoDB internal table access and DDL were fixed.
## How can this PR be tested?
Stress test by the RQG grammar that reproduced the assertion failures.

I would also like to fix a similar problem in `dict_acquire_mdl_shared<false>` and `dict_table_open_on_id()`.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.