### PR TITLE
MDEV-36155: MSAN use-of-uninitialized-value innodb.log_file_size_online

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1044,12 +1044,13 @@ lsn_t log_t::write_buf() noexcept
         the current LSN are generated. */
         MEM_MAKE_DEFINED(buf + length, (write_size_1 + 1) - new_buf_free);
         buf[length]= 0; /* allow recovery to catch EOF faster */
+        if (UNIV_LIKELY_NULL(re_write_buf))
+          MEM_MAKE_DEFINED(re_write_buf + length, (write_size_1 + 1) -
+                           new_buf_free);
         length&= ~write_size_1;
         memcpy_aligned<16>(flush_buf, buf + length, (new_buf_free + 15) & ~15);
         if (UNIV_LIKELY_NULL(re_write_buf))
         {
-          MEM_MAKE_DEFINED(re_write_buf + length, (write_size_1 + 1) -
-                           new_buf_free);
           memcpy_aligned<16>(resize_flush_buf, re_write_buf + length,
                              (new_buf_free + 15) & ~15);
           re_write_buf[length + new_buf_free]= 0;


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36155*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Writing the redo log resized will write uninitialized data. There is a MEM_MAKE_DEFINED construct in the code to bless this however it was correct on the initial length, but not the changed length.

The MEM_MAKE_DEFINED is moved earlier in the code where the length contains the correct value.


## Release Notes

If anything: innodb.log_file_size_online test result made reliable MSAN compiled code.

## How can this PR be tested?

```
buildbot@1209234bb2fb:/build$ mysql-test/mtr  innodb.log_file_size_online 
Logging: /source/mysql-test/mariadb-test-run.pl  innodb.log_file_size_online
VS config: 
vardir: /build/mysql-test/var
Checking leftover processes...
Removing old var directory...
Creating var directory '/build/mysql-test/var'...
Checking supported features...
MariaDB Version 12.0.0-MariaDB
 - SSL connections supported
 - binaries built with wsrep patch
Collecting tests...
Installing system database...

==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[01] Using MTR_BUILD_THREAD 300, with reserved ports 19000..19029
innodb.log_file_size_online 'slow'       [ pass ]   9190
innodb.log_file_size_online 'encrypted'  [ pass ]   8334
--------------------------------------------------------------------------
The servers were restarted 1 times
Spent 17.524 of 22 seconds executing testcases

Completed: All 2 tests were successful.

buildbot@1209234bb2fb:/build$ clang --version
Debian clang version 20.1.0 (++20250225053057+098492a228f7-1~exp1~20250225053219.63)
```

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.