### PR TITLE
fix: Use of Kernel.open or IO.read or similar sinks with a non-constant value

### DIFF
--- a/storage/mroonga/vendor/groonga/vendor/download_mecab.rb
+++ b/storage/mroonga/vendor/groonga/vendor/download_mecab.rb
@@ -42,7 +42,7 @@ def download(url, base)
 
   tar = "#{base}.tar"
   tar_gz = "#{tar}.gz"
-  open(url, :ssl_verify_mode => ssl_verify_mode) do |remote_tar_gz|
+  URI.open(url, :ssl_verify_mode => ssl_verify_mode) do |remote_tar_gz|
     File.open(tar_gz, "wb") do |local_tar_gz|
       local_tar_gz.print(remote_tar_gz.read)
     end


### PR DESCRIPTION
https://github.com/MariaDB/server/blob/5091986ceaca20c650d4469de08201c5b85428e4/storage/mroonga/vendor/groonga/vendor/download_mecab.rb#L45-L49

If `Kernel.open` is given a file name that starts with a `|` character, it will execute the remaining string as a shell command. If a malicious user can control the file name, they can execute arbitrary code. The same vulnerability applies to `IO.read`, `IO.write`, `IO.binread`, `IO.binwrite`, `IO.foreach`, `IO.readlines` and `URI.open`.



## POC
The following shows code that calls `Kernel.open` on a user-supplied file path.
```rb
require "open-uri"

class UsersController < ActionController::Base
  def create
    filename = params[:filename]
    open(filename) # BAD

    web_page = params[:web_page]
    URI.open(web_page) # BAD - calls `Kernel.open` internally
  end
end
```
Instead, `File.open` should be used, as in the following example.
```rb
class UsersController < ActionController::Base
  def create
    filename = params[:filename]
    File.open(filename)

    web_page = params[:web_page]
    Net::HTTP.get(URI.parse(web_page))
  end
end
```
## References
- [Command Injection](https://www.owasp.org/index.php/Command_Injection). [Ruby on Rails Cheat Sheet: Command Injection](https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#command-injection)
- [Command Injection in RDoc](https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/)
- [CWE-78](https://cwe.mitre.org/data/definitions/78.html)
- [CWE-88](https://cwe.mitre.org/data/definitions/88.html)
- [CWE-73](https://cwe.mitre.org/data/definitions/73.html)









-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
