### PR TITLE
Merge `copy_cache_to_string`/`file_wrapped`

### DIFF
--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -5866,11 +5866,7 @@ public:
 };
 
 #ifdef MYSQL_CLIENT
-bool copy_cache_to_string_wrapped(IO_CACHE *body,
-                                  LEX_STRING *to,
-                                  bool do_wrap,
-                                  const char *delimiter,
-                                  bool is_verbose);
+/** @deprecated compatibility with `log_event_old.cc`; inlineable in 11.0+ */
 bool copy_cache_to_file_wrapped(IO_CACHE *body,
                                 FILE *file,
                                 bool do_wrap,


### PR DESCRIPTION
**Update: [MDEV-28768](https://jira.mariadb.org/browse/MDEV-28768) is cancelled in favor of lifting inherent limitations in MDEV-32570, which will likely leave this small refactor obsolete.**

---

`copy_cache_to_file_wrapped`, MDEV-10963’s original implementation, was not flashback-compatible.
`copy_cache_to_string_wrapped`, a version for flashback, replaced it in the next MariaDB version, and soon they merge conflicted. The resolution was to keep both, complete with all the duplicate code (that differ only at how they output their chars).

This commit
1. replaces those differing outputters with reüsable C++ lambdas
2. merges the common portion to a single function.

---

* ~~*The Jira issue number for this PR is: MDEV-28768*~~

## Description
TODO: An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).

Behavior & Performance: If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

## PR quality check
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* ~~*This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*~~
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.