### PR TITLE
MDEV-14432: mysqldump does not preserve case of table names in generated sql

### DIFF
--- a/mysql-test/main/lowercase_table2.result
+++ b/mysql-test/main/lowercase_table2.result
@@ -185,7 +185,7 @@ create table myUC (i int);
 select TABLE_SCHEMA,TABLE_NAME FROM information_schema.TABLES
 where TABLE_SCHEMA ='mysqltest_LC2';
 TABLE_SCHEMA	TABLE_NAME
-mysqltest_lc2	myUC
+mysqltest_LC2	myUC
 use test;
 drop database mysqltest_LC2;
 #

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -4348,7 +4348,7 @@ bool get_lookup_field_values(THD *thd, COND *cond, bool fix_table_name_case,
     break;
   }
 
-  if (lower_case_table_names && !rc)
+  if (lower_case_table_names == 1 && !rc)
   {
     /* 
       We can safely do in-place upgrades here since all of the above cases


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: [MDEV-14432](https://jira.mariadb.org/browse/MDEV-14432) "this also affects [MDEV-31472](https://jira.mariadb.org/browse/MDEV-31472) directly"

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
```lower_case_table_names``` has three values only 0, 1, 2 ... On windows the default is 1 but when changing that value to 2 (or testing it on MacOS since the default value should also be 2) it should deal with table/db names with their original created table name and compare lowercase only not convert them into lowercase 

```get_lookup_field_values()``` should only convert the names to lowercase when ```lower_case_table_names``` is 1 only not 2 

## Release Notes
Nothing should be changed since this was already mentioned in 
https://mariadb.com/kb/en/identifier-case-sensitivity/ 

## How can this PR be tested?
On windows 64-bit machines use the following test case
```bash 
perl mysql-test-run.pl lowercase_table2.test 
```
In the ```lowercase_table2.test``` and ```lowercase_table2.result``` both have already covered a test case where one could create a table with uppercase and then expect the output to reserve the case when using ```lower_case_table_names``` as 2

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
