### PR TITLE
MDEV-32732 Support DESC indexes in loose scan optimization

### DIFF
--- a/mysql-test/main/desc_index_range.result
+++ b/mysql-test/main/desc_index_range.result
@@ -140,13 +140,14 @@ jd
 ]
 drop table t2;
 #
-# Check that "Using index for group-by" is disabled (it's not supported, yet)
+# "Using index for group-by" was disabled for reverse index but
+# not any more after MDEV-32732
 #
 CREATE TABLE t1 (p int NOT NULL, a int NOT NULL, PRIMARY KEY (p,a desc));
 insert into t1 select 2,seq from seq_0_to_1000;
 EXPLAIN select MIN(a) from t1 where p = 2 group by p;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	ref	PRIMARY	PRIMARY	4	const	1000	Using index
+1	SIMPLE	t1	range	PRIMARY	PRIMARY	4	NULL	1	Using where; Using index for group-by
 select json_detailed(json_extract(trace, '$**.potential_group_range_indexes')) as jd
 from information_schema.optimizer_trace;
 jd
@@ -154,8 +155,11 @@ jd
     [
         {
             "index": "PRIMARY",
-            "usable": false,
-            "cause": "Reverse-ordered (not supported yet)"
+            "covering": true,
+            "ranges": 
+            ["(2) <= (p) <= (2)"],
+            "rows": 1,
+            "cost": 0.000838227
         }
     ]
 ]
@@ -199,3 +203,400 @@ select * from t1 where b = 255 AND a IS NULL;
 pk	a	b
 10000	NULL	255
 drop table t1;
+#
+# MDEV-32732 Support DESC indexes in loose scan optimization
+#
+create table t1 (a int, c int, key (a, c desc));
+insert into t1 values (1, 9), (1, 6), (1, 3);
+explain SELECT MAX(c), MIN(c) FROM t1 group by a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	3	Using index for group-by
+SELECT MAX(c), MIN(c) FROM t1 group by a;
+MAX(c)	MIN(c)
+9	3
+drop table t1;
+create table t1 (a int, b int, c int, key (a desc, b, c desc));
+insert into t1 values (1, 2, 9), (1, 2, 6), (2, 1, 3), (2, 1, 12);
+explain SELECT a, b, MAX(c), MIN(c) FROM t1 group by a, b;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	15	NULL	4	Using index for group-by; Using temporary; Using filesort
+SELECT a, b, MAX(c), MIN(c) FROM t1 group by a, b;
+a	b	MAX(c)	MIN(c)
+1	2	9	6
+2	1	12	3
+drop table t1;
+CREATE TABLE t1 (a int, b int, KEY (a, b desc));
+insert into t1 values (1, 23), (3, 45), (1, 11), (3, 88), (3, 70), (4, NULL), (1, 14), (4, NULL);
+EXPLAIN SELECT MIN(b) FROM t1 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using index for group-by
+SELECT MIN(b) FROM t1 GROUP BY a;
+MIN(b)
+11
+45
+NULL
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b < 68 GROUP BY a;
+MIN(b)
+11
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b > 13 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b > 13 GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b > 14 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b > 14 AND b < 68 GROUP BY a;
+MIN(b)
+23
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+MIN(b)
+14
+70
+EXPLAIN SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+MIN(b)
+14
+45
+NULL
+EXPLAIN SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MAX(b) FROM t1 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	5	NULL	8	Using index for group-by
+SELECT MAX(b) FROM t1 GROUP BY a;
+MAX(b)
+23
+88
+NULL
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b < 68 GROUP BY a;
+MAX(b)
+23
+45
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b > 13 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	5	NULL	8	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b > 13 GROUP BY a;
+MAX(b)
+23
+88
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+MAX(b)
+23
+45
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+MAX(b)
+23
+45
+EXPLAIN SELECT MAX(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+MAX(b)
+23
+88
+EXPLAIN SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+MAX(b)
+23
+45
+NULL
+EXPLAIN SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	8	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+MAX(b)
+23
+45
+insert into t1 values (4, 8);
+EXPLAIN SELECT MIN(b) FROM t1 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using index for group-by
+SELECT MIN(b) FROM t1 GROUP BY a;
+MIN(b)
+11
+45
+8
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b < 68 GROUP BY a;
+MIN(b)
+11
+45
+8
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b > 13 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b > 13 GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MIN(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+MIN(b)
+14
+70
+EXPLAIN SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+MIN(b)
+14
+45
+NULL
+EXPLAIN SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+MIN(b)
+14
+45
+EXPLAIN SELECT MAX(b) FROM t1 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	5	NULL	9	Using index for group-by
+SELECT MAX(b) FROM t1 GROUP BY a;
+MAX(b)
+23
+88
+8
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b < 68 GROUP BY a;
+MAX(b)
+23
+45
+8
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b > 13 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	5	NULL	9	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b > 13 GROUP BY a;
+MAX(b)
+23
+88
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+MAX(b)
+23
+45
+EXPLAIN SELECT MAX(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+MAX(b)
+23
+45
+EXPLAIN SELECT MAX(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+MAX(b)
+23
+88
+EXPLAIN SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+MAX(b)
+23
+45
+NULL
+EXPLAIN SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	a	10	NULL	9	Using where; Using index for group-by
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+MAX(b)
+23
+45
+drop table t1;
+create table t1(c1 int, c2 int, c3 int, c4 int, key (c1 desc, c2 desc, c3 desc));
+insert into t1 values (1, 2, 9, 2), (3, 2, 6, 9), (1, 2, 6, 9), (4, 1, 3, 38), (4, 1, 12, 12);
+EXPLAIN select distinct c1 from t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	5	NULL	5	Using index for group-by; Using temporary
+select distinct c1 from t1;
+c1
+4
+3
+1
+EXPLAIN select distinct c1 from t1 where c2 = 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	10	NULL	5	Using where; Using index for group-by; Using temporary
+select distinct c1 from t1 where c2 = 2;
+c1
+3
+1
+EXPLAIN select c1 from t1 group by c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	5	NULL	5	Using index for group-by; Using temporary; Using filesort
+select c1 from t1 group by c1;
+c1
+1
+3
+4
+EXPLAIN select distinct c1, c2 from t1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	10	NULL	5	Using index for group-by; Using temporary
+select distinct c1, c2 from t1;
+c1	c2
+4	1
+3	2
+1	2
+EXPLAIN select c1, c2 from t1 group by c1, c2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	10	NULL	5	Using index for group-by; Using temporary; Using filesort
+select c1, c2 from t1 group by c1, c2;
+c1	c2
+1	2
+3	2
+4	1
+EXPLAIN SELECT c1, MIN(c2) FROM t1 GROUP BY c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	10	NULL	5	Using index for group-by; Using temporary; Using filesort
+SELECT c1, MIN(c2) FROM t1 GROUP BY c1;
+c1	MIN(c2)
+1	2
+3	2
+4	1
+EXPLAIN SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	15	NULL	5	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+c1	c2	min(c3)	max(c3)
+1	2	6	9
+3	2	6	6
+EXPLAIN SELECT c1, c2 FROM t1 WHERE c1 < 3 GROUP BY c1, c2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	c1	c1	10	NULL	2	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT c1, c2 FROM t1 WHERE c1 < 3 GROUP BY c1, c2;
+c1	c2
+1	2
+EXPLAIN SELECT MAX(c3), MIN(c3), c1, c2 FROM t1 WHERE c2 > 1 GROUP BY c1, c2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	15	NULL	5	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT MAX(c3), MIN(c3), c1, c2 FROM t1 WHERE c2 > 1 GROUP BY c1, c2;
+MAX(c3)	MIN(c3)	c1	c2
+9	6	1	2
+6	6	3	2
+EXPLAIN SELECT c2 FROM t1 WHERE c1 < 3 GROUP BY c1, c2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	c1	c1	10	NULL	2	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT c2 FROM t1 WHERE c1 < 3 GROUP BY c1, c2;
+c2
+2
+EXPLAIN SELECT c1, c2 FROM t1 WHERE c3 = 6 GROUP BY c1, c2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	15	NULL	5	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT c1, c2 FROM t1 WHERE c3 = 6 GROUP BY c1, c2;
+c1	c2
+1	2
+3	2
+EXPLAIN SELECT c1, c3 FROM t1 WHERE c3 = 6 GROUP BY c1, c2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	15	NULL	5	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT c1, c3 FROM t1 WHERE c3 = 6 GROUP BY c1, c2;
+c1	c3
+1	6
+3	6
+insert into t1 values (1, 3, 3, 4);
+EXPLAIN SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	15	NULL	6	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+c1	c2	min(c3)	max(c3)
+1	2	6	9
+3	2	6	6
+insert into t1 values (1, 4, NULL, 4);
+EXPLAIN SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	NULL	c1	15	NULL	7	Using where; Using index for group-by; Using temporary; Using filesort
+SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+c1	c2	min(c3)	max(c3)
+1	2	6	9
+3	2	6	6
+drop table t1;
+create table t20 (
+kp1 int,
+kp2 int,
+index (kp1 desc, kp2 desc)
+);
+insert into t20 select A.seq, B.seq from seq_1_to_10 A, seq_1_to_10 B;
+insert into t20 values (1, NULL);
+insert into t20 values (10, NULL);
+EXPLAIN select min(kp2) from t20 where kp2=3 or kp2=5 or kp2 is null group by kp1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t20	range	NULL	kp1	10	NULL	11	Using where; Using index for group-by; Using temporary; Using filesort
+select min(kp2) from t20 where kp2=3 or kp2=5 or kp2 is null group by kp1;
+min(kp2)
+3
+3
+3
+3
+3
+3
+3
+3
+3
+3
+drop table t20;

--- a/mysql-test/main/desc_index_range.test
+++ b/mysql-test/main/desc_index_range.test
@@ -94,7 +94,8 @@ from information_schema.optimizer_trace;
 drop table t2;
 
 --echo #
---echo # Check that "Using index for group-by" is disabled (it's not supported, yet)
+--echo # "Using index for group-by" was disabled for reverse index but
+--echo # not any more after MDEV-32732
 --echo #
 CREATE TABLE t1 (p int NOT NULL, a int NOT NULL, PRIMARY KEY (p,a desc));
 insert into t1 select 2,seq from seq_0_to_1000;
@@ -147,3 +148,251 @@ explain select * from t1 where b = 255 AND a IS NULL;
 select * from t1 where b = 255 AND a IS NULL;
 
 drop table t1;
+
+--echo #
+--echo # MDEV-32732 Support DESC indexes in loose scan optimization
+--echo #
+
+create table t1 (a int, c int, key (a, c desc));
+insert into t1 values (1, 9), (1, 6), (1, 3);
+let $query=
+SELECT MAX(c), MIN(c) FROM t1 group by a;
+eval explain $query;
+eval $query;
+drop table t1;
+
+create table t1 (a int, b int, c int, key (a desc, b, c desc));
+insert into t1 values (1, 2, 9), (1, 2, 6), (2, 1, 3), (2, 1, 12);
+let $query=
+SELECT a, b, MAX(c), MIN(c) FROM t1 group by a, b;
+eval explain $query;
+eval $query;
+drop table t1;
+
+# innodb is more cost "sensitive" here somehow, and could result in
+# not choosing loose index scan without
+# set debug="+d,force_group_by":
+# --source include/have_innodb.inc
+# CREATE TABLE t1 (a int, b int, KEY (a, b desc)) engine=innodb;
+
+CREATE TABLE t1 (a int, b int, KEY (a, b desc));
+insert into t1 values (1, 23), (3, 45), (1, 11), (3, 88), (3, 70), (4, NULL), (1, 14), (4, NULL);
+
+let $query=
+SELECT MIN(b) FROM t1 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b > 13 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b > 14 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+
+let $query=
+SELECT MAX(b) FROM t1 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b > 13 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+
+insert into t1 values (4, 8);
+
+let $query=
+SELECT MIN(b) FROM t1 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b > 13 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MIN(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+
+let $query=
+SELECT MAX(b) FROM t1 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b > 13 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b > 13 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE b >= 14 AND b < 68 GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE (b > 47 AND b < 91) OR (b > 11 AND b < 30) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b IS NULL) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(b) FROM t1 WHERE (b > 13 AND b < 68) OR (b = 100) GROUP BY a;
+eval EXPLAIN $query;
+eval $query;
+
+drop table t1;
+
+create table t1(c1 int, c2 int, c3 int, c4 int, key (c1 desc, c2 desc, c3 desc));
+insert into t1 values (1, 2, 9, 2), (3, 2, 6, 9), (1, 2, 6, 9), (4, 1, 3, 38), (4, 1, 12, 12);
+let $query=
+select distinct c1 from t1;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+select distinct c1 from t1 where c2 = 2;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+select c1 from t1 group by c1;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+select distinct c1, c2 from t1;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+select c1, c2 from t1 group by c1, c2;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT c1, MIN(c2) FROM t1 GROUP BY c1;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT c1, c2 FROM t1 WHERE c1 < 3 GROUP BY c1, c2;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT MAX(c3), MIN(c3), c1, c2 FROM t1 WHERE c2 > 1 GROUP BY c1, c2;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT c2 FROM t1 WHERE c1 < 3 GROUP BY c1, c2;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT c1, c2 FROM t1 WHERE c3 = 6 GROUP BY c1, c2;
+eval EXPLAIN $query;
+eval $query;
+let $query=
+SELECT c1, c3 FROM t1 WHERE c3 = 6 GROUP BY c1, c2;
+eval EXPLAIN $query;
+eval $query;
+
+insert into t1 values (1, 3, 3, 4);
+let $query=
+SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+eval EXPLAIN $query;
+eval $query;
+insert into t1 values (1, 4, NULL, 4);
+let $query=
+SELECT c1, c2, min(c3), max(c3) FROM t1 WHERE c2 = 2 GROUP BY c1;
+eval EXPLAIN $query;
+eval $query;
+drop table t1;
+
+create table t20 (
+  kp1 int,
+  kp2 int,
+  index (kp1 desc, kp2 desc)
+);
+
+insert into t20 select A.seq, B.seq from seq_1_to_10 A, seq_1_to_10 B;
+insert into t20 values (1, NULL);
+insert into t20 values (10, NULL);
+let $query=
+select min(kp2) from t20 where kp2=3 or kp2=5 or kp2 is null group by kp1;
+eval EXPLAIN $query;
+eval $query;
+
+drop table t20;

--- a/mysql-test/main/myisam.result
+++ b/mysql-test/main/myisam.result
@@ -2764,10 +2764,10 @@ Table	Op	Msg_type	Msg_text
 test.t	check	status	OK
 select distinct c from t;
 c
-NULL
-
-bar
 foo
+bar
+
+NULL
 select c from t;
 c
 foo

--- a/mysql-test/suite/maria/maria2.result
+++ b/mysql-test/suite/maria/maria2.result
@@ -127,10 +127,10 @@ Table	Op	Msg_type	Msg_text
 test.t	check	status	OK
 select distinct c from t;
 c
-NULL
-
-bar
 foo
+bar
+
+NULL
 select c from t;
 c
 foo

--- a/sql/opt_range.h
+++ b/sql/opt_range.h
@@ -1836,10 +1836,9 @@ public:
   QUICK_RANGE_SELECT *quick_prefix_select;/* For retrieval of group prefixes. */
 private:
   int  next_prefix();
-  int  next_min_in_range();
-  int  next_max_in_range();
-  int  next_min();
-  int  next_max();
+  int  next_min_max_in_range(bool min, bool reverse);
+  int  next_min_max(bool min, bool reverse);
+  int  skip_nulls(bool reverse);
   void update_min_result();
   void update_max_result();
   int cmp_min_max_key(const uchar *key, uint16 length);


### PR DESCRIPTION
Extend loose index scan to support descending indexes.

This is achieved by removing a block skipping creating loose index
scan plan for descending index, as well as generalising the execution
of such plans.

The generalisation applies to all levels looking for min/max in loose
index scan. In the highest level (get_next), generalise min and max to
first and last, so that it still proceeds in the direction agreeing
with the index parity. In the lower levels, combine next_min and
next_max methods into next_min_max, and combine next_min_in_range and
next_max_in_range into next_min_max_in_range. This retains existing
logic of these functions and reduces code duplication, while allowing
handling of all four combinations (min, max) x (asc index, desc
index).

-------

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling this template <3

If you have any questions related to MariaDB or you just want to
hang out and meet other community members, please join us on
https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue
that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32732*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed, what was it looking like before
   the change and how it's looking with this patch applied
3. Do you think this patch might introduce side-effects in
   other parts of the server?
-->
## Description

See the commit message.

Addressing comments in the first round of review:

> * Please look at this patch fixing the coding style
>   [^mdev32732-fix-coding-style.diff]  and apply if there are no
>   objections

Applied.


> * The commit comment needs to be more verbose. It should be a
>   description of what the patch does and how.

Done.

>  * QUICK_GROUP_MIN_MAX_SELECT::skip_nulls() is misleading: it also does the part which has nothing to do with NULLs:
>    " Apply the constant equality conditions to the non-group select fields"
>  This needs to be either moved or of the function or the function
>    needs to be renamed.

Done. Moved the call out into next_min_max(). Also added some tests
covering these index lookups before the call to skip_nulls().

>  * I do not quite understand what  QUICK_GROUP_MIN_MAX_SELECT::next_min_max_in_range() tries to do with NULL_RANGE-s.
>  AFAIU it shouldn't have gotten them, if it got them, it should ignore them - do not even look for  rows in them.
>  Currently it produces wrong results:

Fixed the handling of NULL_RANGE's, especially when looking for a MIN,
which the logic in next_min_in_range before the patch carries over.
More specifically, in case of MIN we consider ranges from the left to
the right, if the leftmost range is NULL_RANGE and a NULL is found,
then the NULL needs to be saved:

- if a key is found in the remaining ranges, then we use that key
- if no key is found in the remaining ranges, then we use the saved
  NULL

## How can this PR be tested?

See tests in the patch

<!--
Tick one of the following boxes [x] to help us understand
if the base branch for the PR is correct
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature and the PR is based against the latest MariaDB development branch*
- [ ] *This is a bug fix and the PR is based against the earliest branch in which the bug can be reproduced*

<!--
You might consider answering some questions like:
1. Does this affect the on-disk format used by MariaDB?
2. Does this change any behavior experienced by a user
   who upgrades from a version prior to this patch?
3. Would a user be able to start MariaDB on a datadir
   created prior to your fix?
-->