### PR TITLE
MDEV-36229: Remove CAP_DAC_OVERRIDE CAP_AUDIT_WRITE from AmbientCapabilities

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -48,10 +48,13 @@ User=mysql
 Group=mysql
 
 # CAP_IPC_LOCK To allow memlock to be used as non-root user
+# These are enabled by default
+AmbientCapabilities=CAP_IPC_LOCK
+
 # CAP_DAC_OVERRIDE To allow auth_pam_tool (which is SUID root) to read /etc/shadow when it's chmod 0
 #   does nothing for non-root, not needed if /etc/shadow is u+r
 # CAP_AUDIT_WRITE auth_pam_tool needs it on Debian for whatever reason
-AmbientCapabilities=CAP_IPC_LOCK CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
 
 # PrivateDevices=true implies NoNewPrivileges=true and
 # SUID auth_pam_tool suddenly doesn't do setuid anymore

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -178,10 +178,13 @@ PrivateNetwork=false
 ##
 
 # CAP_IPC_LOCK To allow memlock to be used as non-root user
+# These are enabled by default
+AmbientCapabilities=CAP_IPC_LOCK
+
 # CAP_DAC_OVERRIDE To allow auth_pam_tool (which is SUID root) to read /etc/shadow when it's chmod 0
 #   does nothing for non-root, not needed if /etc/shadow is u+r
 # CAP_AUDIT_WRITE auth_pam_tool needs it on Debian for whatever reason
-AmbientCapabilities=CAP_IPC_LOCK CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
 
 # PrivateDevices=true implies NoNewPrivileges=true and
 # SUID auth_pam_tool suddenly doesn't do setuid anymore


### PR DESCRIPTION
…ilities



<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36229*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

In resolving MDEV-33301 (76a27155b4cd8174e900577dd01df2db1327b120) we moved all the capabilities from CapabilityBoundingSet to AmbientCapabilities where only add/moving CAP_IPC_LOCK was intended.

The effect of this is the defaulting running MariaDB HAS the capability CAP_DAC_OVERRIDE CAP_AUDIT_WRITE allowing it to access any file, even while running as a non-root user.

Resolve this by making CAP_IPC_LOCK apply to AmbientCapabilities and leave the remaining CAP_DAC_OVERRIDE CAP_AUDIT_WRITE to CapabilityBoundingSet for the use by auth_pam_tool.

## Release Notes

SECURITY: Correct mistake in previous release where systemd MariaDB services had capabilities CAP_DAC_OVERRIDE CAP_AUDIT_WRITE by default allowing arbitrary file access .

## How can this PR be tested?

```
chown -R root:root /var/lib/mysql
chmod ugo-rwX
systemctl start mariadb.service
```
And it should fail.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a big and important bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.