### PR TITLE
MDEV-36238 Functional Tests for --master-info-file and --show-slave-auth-info

### DIFF
--- a/mysql-test/suite/multi_source/master_info_file.opt
+++ b/mysql-test/suite/multi_source/master_info_file.opt
@@ -1,0 +1,1 @@
+--master-info-file=$MYSQL_TMP_DIR/master_info_file.txt

--- a/mysql-test/suite/multi_source/master_info_file.result
+++ b/mysql-test/suite/multi_source/master_info_file.result
@@ -1,0 +1,18 @@
+CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=SERVER_MYPORT_1;
+CHANGE MASTER 'named' TO master_host='localhost', master_user='test', master_port=SERVER_MYPORT_2;
+--list_files @@datadir *.info
+relay-log-named.info
+relay-log.info
+--list_files MYSQL_TMP_DIR *.txt
+master_info_file-named.txt
+master_info_file.txt
+multi-master_info_file.txt
+--cat_file MYSQL_TMP_DIR/multi-master_info_file.txt
+named
+FOUND 1 matches in master_info_file.txt
+FOUND 1 matches in master_info_file.txt
+FOUND 1 matches in master_info_file.txt
+FOUND 1 matches in master_info_file-named.txt
+FOUND 1 matches in master_info_file-named.txt
+FOUND 1 matches in master_info_file-named.txt
+RESET REPLICA 'named' ALL;

--- a/mysql-test/suite/multi_source/master_info_file.test
+++ b/mysql-test/suite/multi_source/master_info_file.test
@@ -1,0 +1,38 @@
+# MDEV-36238: Test `--master-info-file`
+#
+# Other tests (such as `info_logs`) work explicitly with `(multi-)master.info`.
+# This test sees that `--master-info-file` moves/renames this file.
+
+--source include/not_embedded.inc
+--replace_result $SERVER_MYPORT_1 SERVER_MYPORT_1
+--eval CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=$SERVER_MYPORT_1
+--replace_result $SERVER_MYPORT_2 SERVER_MYPORT_2
+--eval CHANGE MASTER 'named' TO master_host='localhost', master_user='test', master_port=$SERVER_MYPORT_2
+
+--let $datadir = `SELECT @@datadir`
+--echo --list_files @@datadir *.info
+--list_files $datadir *.info
+--echo --list_files MYSQL_TMP_DIR *.txt
+--list_files $MYSQL_TMP_DIR *.txt
+
+--echo --cat_file MYSQL_TMP_DIR/multi-master_info_file.txt
+--cat_file $MYSQL_TMP_DIR/multi-master_info_file.txt
+--let SEARCH_OUTPUT= count
+
+--let SEARCH_FILE= $MYSQL_TMP_DIR/master_info_file.txt
+--let SEARCH_PATTERN= \\n127.0.0.1\\n
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \\nroot\\n
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \\n$SERVER_MYPORT_1\\n
+--source include/search_pattern_in_file.inc
+
+--let SEARCH_FILE= $MYSQL_TMP_DIR/master_info_file-named.txt
+--let SEARCH_PATTERN= \\nlocalhost\\n
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \\ntest\\n
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \\n$SERVER_MYPORT_2\\n
+--source include/search_pattern_in_file.inc
+
+RESET REPLICA 'named' ALL;

--- a/mysql-test/suite/multi_source/show_slave_auth_info.cnf
+++ b/mysql-test/suite/multi_source/show_slave_auth_info.cnf
@@ -1,0 +1,13 @@
+!include ./my.cnf
+
+[mysqld.1]
+show-slave-auth-info
+
+[mysqld.4]
+server-id=4
+log-warnings=2
+report-user=my_user
+report-password=my_password
+
+[ENV]
+SERVER_MYPORT_4= @mysqld.4.port

--- a/mysql-test/suite/multi_source/show_slave_auth_info.result
+++ b/mysql-test/suite/multi_source/show_slave_auth_info.result
@@ -1,0 +1,45 @@
+# Setup
+connect  master1,127.0.0.1,root,,,$SERVER_MYPORT_1;
+connect  master2,127.0.0.1,root,,,$SERVER_MYPORT_2;
+connect  slave1,127.0.0.1,root,,,$SERVER_MYPORT_3;
+connect  slave2,127.0.0.1,root,,,$SERVER_MYPORT_4;
+connection slave2;
+CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=SERVER_MYPORT_1;
+CHANGE MASTER 'control sample' TO master_host='127.0.0.1', master_user='root', master_port=SERVER_MYPORT_2;
+START ALL SLAVES;
+connection slave1;
+CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=SERVER_MYPORT_1;
+CHANGE MASTER 'control sample' TO master_host='127.0.0.1', master_user='root', master_port=SERVER_MYPORT_2;
+START ALL SLAVES;
+# Test
+connection master2;
+SHOW SLAVE HOSTS;
+Server_id	Host	Port	Master_id
+3	localhost	SERVER_MYPORT_3	2
+4	localhost	SERVER_MYPORT_4	2
+connection master1;
+SHOW SLAVE HOSTS;
+Server_id	Host	User	Password	Port	Master_id
+3	localhost			SERVER_MYPORT_3	1
+4	localhost	my_user	my_password	SERVER_MYPORT_4	1
+SHOW REPLICA HOSTS;
+Server_id	Host	User	Password	Port	Master_id
+3	localhost			SERVER_MYPORT_3	1
+4	localhost	my_user	my_password	SERVER_MYPORT_4	1
+# Cleanup
+connection slave2;
+STOP ALL SLAVES;
+include/wait_for_slave_to_stop.inc
+SET @@SESSION.default_master_connection= 'control sample';
+include/wait_for_slave_to_stop.inc
+RESET SLAVE ALL;
+connection slave1;
+STOP ALL SLAVES;
+include/wait_for_slave_to_stop.inc
+SET @@SESSION.default_master_connection= 'control sample';
+include/wait_for_slave_to_stop.inc
+RESET SLAVE ALL;
+disconnect master1;
+disconnect master2;
+disconnect slave1;
+disconnect slave2;

--- a/mysql-test/suite/multi_source/show_slave_auth_info.test
+++ b/mysql-test/suite/multi_source/show_slave_auth_info.test
@@ -1,0 +1,83 @@
+# MDEV-36238: Test `--show-slave-auth-info` (and `--report-user`/`password`)
+#
+# `rpl.rpl_show_slave_hosts` and `rpl.rpl_slave_alias_replica`
+# (and several others) test SHOW SLAVE HOSTS without `--show-slave-auth-info`.
+# This test supplements them with a comparison between with and without.
+
+# SHOW SLAVE HOSTS is agnostic of binlog formats
+--source include/have_binlog_format_mixed.inc
+
+--echo # Setup
+
+# This server has `--show-slave-auth-info`.
+--connect (master1,127.0.0.1,root,,,$SERVER_MYPORT_1)
+# This `--show-slave-auth-info`-less server asserts that it is per-master.
+--connect (master2,127.0.0.1,root,,,$SERVER_MYPORT_2)
+# This is a non-reporting slave.
+--connect (slave1,127.0.0.1,root,,,$SERVER_MYPORT_3)
+# This is a self-reporting slave.
+--connect (slave2,127.0.0.1,root,,,$SERVER_MYPORT_4)
+
+--let $rpl_server_number= 2
+while ($rpl_server_number)
+{
+  --connection slave$rpl_server_number
+
+  --replace_result $SERVER_MYPORT_1 SERVER_MYPORT_1
+  --eval CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=$SERVER_MYPORT_1
+  --replace_result $SERVER_MYPORT_2 SERVER_MYPORT_2
+  --eval CHANGE MASTER 'control sample' TO master_host='127.0.0.1', master_user='root', master_port=$SERVER_MYPORT_2
+  --disable_warnings
+  START ALL SLAVES;
+  --enable_warnings
+
+  --dec $rpl_server_number
+}
+
+--echo # Test
+
+--let $rpl_server_number= 2
+while ($rpl_server_number)
+{
+  --connection master$rpl_server_number
+
+  # Make sure the master's synced up
+  --let $show_statement= SHOW SLAVE HOSTS
+  --let $field= Server_id
+  --let $condition= =3
+  --source include/wait_show_condition.inc
+  --let $condition= =4
+  --source include/wait_show_condition.inc
+
+  --replace_result $SERVER_MYPORT_3 SERVER_MYPORT_3 $SERVER_MYPORT_4 SERVER_MYPORT_4
+  SHOW SLAVE HOSTS;
+
+  --dec $rpl_server_number
+}
+
+# MDEV-20601 Make REPLICA a synonym for SLAVE in SQL statements
+--replace_result $SERVER_MYPORT_3 SERVER_MYPORT_3 $SERVER_MYPORT_4 SERVER_MYPORT_4
+SHOW REPLICA HOSTS;
+
+--echo # Cleanup
+
+--let $rpl_server_number= 2
+while ($rpl_server_number)
+{
+  --connection slave$rpl_server_number
+
+  --disable_warnings
+  STOP ALL SLAVES;
+  --enable_warnings
+  --source include/wait_for_slave_to_stop.inc
+  SET @@SESSION.default_master_connection= 'control sample';
+  --source include/wait_for_slave_to_stop.inc
+  RESET SLAVE ALL;
+
+  --dec $rpl_server_number
+}
+
+--disconnect master1
+--disconnect master2
+--disconnect slave1
+--disconnect slave2


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-36238](https://jira.mariadb.org/browse/MDEV-36238)*
  * Subtask of [MDEV-30189 Add and alias remaining mariadbd replication command line options as system variables](https://jira.mariadb.org/browse/MDEV-30189)

## Description
Add MTR tests
* `multi_source.master_info_file`
* `rpl.rpl_show_slave_auth_info`

## Release Notes
N/A

## PR quality check
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.