### PR TITLE
MDEV-36227 Race condition between ALTER TABLE…EXCHANGE PARTITION and SELECT

### DIFF
--- a/mysql-test/suite/innodb/r/alter_partitioned_debug.result
+++ b/mysql-test/suite/innodb/r/alter_partitioned_debug.result
@@ -1,4 +1,5 @@
 CREATE TABLE t1 (a INT, b VARCHAR(10)) ENGINE=InnoDB
+STATS_PERSISTENT=1 STATS_AUTO_RECALC=0
 PARTITION BY RANGE(a)
 (PARTITION pa VALUES LESS THAN (3),
 PARTITION pb VALUES LESS THAN (5));
@@ -19,9 +20,30 @@ connection ddl;
 ERROR 23000: Duplicate entry '2-two' for key 'a'
 connection default;
 DELETE FROM t1;
-disconnect ddl;
 SET DEBUG_SYNC = 'RESET';
 CHECK TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
-DROP TABLE t1;
+CREATE TABLE t(a INT, b VARCHAR(10)) ENGINE=InnoDB
+STATS_PERSISTENT=1 STATS_AUTO_RECALC=1;
+RENAME TABLE t TO u;
+DELETE FROM mysql.innodb_table_stats WHERE table_name='u';
+DELETE FROM mysql.innodb_index_stats WHERE table_name='u';
+SET STATEMENT debug_dbug='+d,dict_stats_save_exit_notify_and_wait' FOR
+SELECT * FROM u;
+connection ddl;
+SET DEBUG_SYNC='open_tables_after_open_and_process_table
+WAIT_FOR dict_stats_save_finished';
+ALTER TABLE t1 EXCHANGE PARTITION pb WITH TABLE u;
+connect sync,localhost,root;
+SET DEBUG_SYNC='now SIGNAL dict_stats_save_unblock';
+disconnect sync;
+connection default;
+a	b
+connection ddl;
+disconnect ddl;
+connection default;
+SELECT * FROM u;
+a	b
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1,u;

--- a/mysql-test/suite/innodb/t/alter_partitioned_debug.test
+++ b/mysql-test/suite/innodb/t/alter_partitioned_debug.test
@@ -4,6 +4,7 @@
 --source include/have_debug_sync.inc
 
 CREATE TABLE t1 (a INT, b VARCHAR(10)) ENGINE=InnoDB
+STATS_PERSISTENT=1 STATS_AUTO_RECALC=0
 PARTITION BY RANGE(a)
 (PARTITION pa VALUES LESS THAN (3),
 PARTITION pb VALUES LESS THAN (5));
@@ -26,9 +27,46 @@ reap;
 
 connection default;
 DELETE FROM t1;
-disconnect ddl;
 
 SET DEBUG_SYNC = 'RESET';
 
 CHECK TABLE t1;
-DROP TABLE t1;
+
+CREATE TABLE t(a INT, b VARCHAR(10)) ENGINE=InnoDB
+STATS_PERSISTENT=1 STATS_AUTO_RECALC=1;
+RENAME TABLE t TO u;
+DELETE FROM mysql.innodb_table_stats WHERE table_name='u';
+DELETE FROM mysql.innodb_index_stats WHERE table_name='u';
+
+send SET STATEMENT debug_dbug='+d,dict_stats_save_exit_notify_and_wait' FOR
+SELECT * FROM u;
+
+connection ddl;
+SET DEBUG_SYNC='open_tables_after_open_and_process_table
+WAIT_FOR dict_stats_save_finished';
+send ALTER TABLE t1 EXCHANGE PARTITION pb WITH TABLE u;
+
+connect sync,localhost,root;
+let $wait_condition=
+  select count(*) = 1 from information_schema.processlist
+  where state = 'debug sync point: now'
+  and info like 'SET STATEMENT debug_dbug%SELECT * FROM u';
+--source include/wait_condition.inc
+let $wait_condition=
+  select count(*) = 1 from information_schema.processlist
+  where state = 'Waiting for table metadata lock'
+  and info like 'ALTER TABLE t1 EXCHANGE PARTITION pb WITH TABLE u';
+--source include/wait_condition.inc
+SET DEBUG_SYNC='now SIGNAL dict_stats_save_unblock';
+disconnect sync;
+
+connection default;
+reap;
+connection ddl;
+reap;
+disconnect ddl;
+connection default;
+SELECT * FROM u;
+SET DEBUG_SYNC = 'RESET';
+
+DROP TABLE t1,u;

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -2887,6 +2887,13 @@ dberr_t dict_stats_save(dict_table_t* table, index_id_t index_id)
 	       STRING_WITH_LEN("now SIGNAL dict_stats_save_finished"));
 	    });
 	);
+	DBUG_EXECUTE_IF("dict_stats_save_exit_notify_and_wait",
+	   SCOPE_EXIT([] {
+	       debug_sync_set_action(current_thd,
+	       STRING_WITH_LEN("now SIGNAL dict_stats_save_finished"
+			       " WAIT_FOR dict_stats_save_unblock"));
+	    });
+	);
 #endif /* ENABLED_DEBUG_SYNC */
 
 	if (high_level_read_only) {

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17424,7 +17424,12 @@ ha_innobase::check_if_incompatible_data(
 	param_new = info->option_struct;
 	param_old = table->s->option_struct;
 
-	innobase_copy_frm_flags_from_create_info(m_prebuilt->table, info);
+	m_prebuilt->table->stats_mutex_lock();
+	if (!m_prebuilt->table->stat_initialized()) {
+		innobase_copy_frm_flags_from_create_info(
+			m_prebuilt->table, info);
+	}
+	m_prebuilt->table->stats_mutex_unlock();
 
 	if (table_changes != IS_EQUAL_YES) {
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36227*
## Description
In #3729 a race condition was exposed.

`ha_innobase::check_if_incompatible_data()`: If the statistics have already been initialized for the table, skip the invocation of `innobase_copy_frm_flags_from_create_info()` in order to avoid unexpectedly ruining things for other threads that are concurrently accessing the table.

`dict_stats_save()`: Add debug instrumentation that is necessary for reproducing the interlocking of the failure scenario.
## Release Notes
N/A. The symptoms are not reproducible in any release.
## How can this PR be tested?
```sh
./mtr innodb.alter_partitioned_debug
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.