### PR TITLE
Fix sporadic failures of rpl.rpl_gtid_crash

### DIFF
--- a/mysql-test/include/long_test.inc
+++ b/mysql-test/include/long_test.inc
@@ -1,6 +1,6 @@
 # We use this --source include to mark a test as taking long to run.
 # We can use this to schedule such test early (to not be left with
-# only one or two long tests running, and rests of works idle), or to
+# only one or two long tests running, and rests of workers idle), or to
 # run a quick test skipping long-running test cases.
 
 --source include/no_valgrind_without_big.inc

--- a/mysql-test/main/backup_locks.test
+++ b/mysql-test/main/backup_locks.test
@@ -2,6 +2,7 @@
 # Tests BACKUP STAGE locking
 ########################################################################
 
+--source include/long_test.inc
 --source include/have_innodb.inc
 --source include/have_metadata_lock_info.inc
 --source include/not_embedded.inc

--- a/mysql-test/suite/binlog_encryption/encrypted_master.test
+++ b/mysql-test/suite/binlog_encryption/encrypted_master.test
@@ -18,6 +18,7 @@
 # - with annotated events, default checksums and minimal binlog row image
 #
 
+--source include/long_test.inc
 # The test can take very long time with valgrind
 --source include/not_valgrind.inc
 

--- a/mysql-test/suite/funcs_2/t/innodb_charset.test
+++ b/mysql-test/suite/funcs_2/t/innodb_charset.test
@@ -6,7 +6,7 @@
 # Checking of other prerequisites is in charset_master.test                    #
 ################################################################################
 
---source include/no_valgrind_without_big.inc
+--source include/long_test.inc
 --source include/have_innodb.inc
 
 # Starting with MariaDB 10.6, ensure that DDL recovery will have completed

--- a/mysql-test/suite/innodb/t/innodb_bug52663.test
+++ b/mysql-test/suite/innodb/t/innodb_bug52663.test
@@ -1,3 +1,4 @@
+--source include/long_test.inc
 --source include/have_innodb.inc
 
 set session transaction isolation level read committed;

--- a/mysql-test/suite/mariabackup/log_page_corruption.test
+++ b/mysql-test/suite/mariabackup/log_page_corruption.test
@@ -1,5 +1,5 @@
+--source include/long_test.inc
 --source include/have_debug.inc
---source include/no_valgrind_without_big.inc
 --source include/innodb_undo_tablespaces.inc
 
 --echo ########

--- a/mysql-test/suite/parts/t/partition_exchange_innodb.test
+++ b/mysql-test/suite/parts/t/partition_exchange_innodb.test
@@ -1,3 +1,4 @@
+--source include/long_test.inc
 --source include/have_innodb.inc
 --source include/have_partition.inc
 --source include/have_debug_sync.inc

--- a/mysql-test/suite/parts/t/partition_exchange_memory.test
+++ b/mysql-test/suite/parts/t/partition_exchange_memory.test
@@ -1,3 +1,4 @@
+--source include/long_test.inc
 --source include/have_partition.inc
 --source include/have_debug_sync.inc
 

--- a/mysql-test/suite/parts/t/partition_exchange_myisam.test
+++ b/mysql-test/suite/parts/t/partition_exchange_myisam.test
@@ -1,3 +1,4 @@
+--source include/long_test.inc
 --source include/have_partition.inc
 --source include/have_debug_sync.inc
 

--- a/mysql-test/suite/rpl/r/rpl_gtid_crash.result
+++ b/mysql-test/suite/rpl/r/rpl_gtid_crash.result
@@ -11,6 +11,8 @@ INSERT INTO t1 VALUES (1, 0);
 connection server_2;
 SET sql_log_bin=0;
 call mtr.add_suppression('Master command COM_REGISTER_SLAVE failed: failed registering on master, reconnecting to try again');
+call mtr.add_suppression('Slave I/O: .*Lost connection to server during query');
+call mtr.add_suppression("Slave I/O thread couldn't register on master");
 SET sql_log_bin=1;
 include/stop_slave.inc
 CHANGE MASTER TO master_host = '127.0.0.1', master_port = MASTER_PORT,

--- a/mysql-test/suite/rpl/t/rpl_gtid_crash-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_gtid_crash-slave.opt
@@ -1,1 +1,1 @@
---master-retry-count=100 --slave-net-timeout=10
+--master-retry-count=500 --slave-net-timeout=10

--- a/mysql-test/suite/rpl/t/rpl_gtid_crash.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_crash.test
@@ -23,6 +23,8 @@ INSERT INTO t1 VALUES (1, 0);
 --sync_with_master
 SET sql_log_bin=0;
 call mtr.add_suppression('Master command COM_REGISTER_SLAVE failed: failed registering on master, reconnecting to try again');
+call mtr.add_suppression('Slave I/O: .*Lost connection to server during query');
+call mtr.add_suppression("Slave I/O thread couldn't register on master");
 SET sql_log_bin=1;
 --source include/stop_slave.inc
 --replace_result $MASTER_MYPORT MASTER_PORT

--- a/mysql-test/suite/rpl/t/rpl_heartbeat_basic.test
+++ b/mysql-test/suite/rpl/t/rpl_heartbeat_basic.test
@@ -9,6 +9,7 @@
 # * Various states of master and heartbeat
 # * Circular replication
 #############################################################
+--source include/long_test.inc
 --source include/master-slave.inc
 #
 # The test runs long and does not have any specifics to 

--- a/mysql-test/suite/rpl/t/rpl_semi_sync.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync.test
@@ -4,6 +4,7 @@
 # Please check all dependent tests after modifying it
 #
 
+source include/long_test.inc;
 source include/not_embedded.inc;
 source include/have_innodb.inc;
 source include/master-slave.inc;

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_after_sync.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_after_sync.test
@@ -1,3 +1,4 @@
+--source include/long_test.inc
 --source include/have_binlog_format_statement.inc
 set global rpl_semi_sync_master_wait_point=AFTER_SYNC;
 source rpl_semi_sync.test;

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_after_sync_row.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_after_sync_row.test
@@ -1,3 +1,4 @@
+--source include/long_test.inc
 --source include/have_binlog_format_row.inc
 set global rpl_semi_sync_master_wait_point=AFTER_SYNC;
 source rpl_semi_sync.test;

--- a/mysql-test/suite/rpl/t/rpl_typeconv.test
+++ b/mysql-test/suite/rpl/t/rpl_typeconv.test
@@ -4,6 +4,7 @@
 # Please check all dependent tests after modifying it
 #
 
+--source include/long_test.inc
 --source include/have_binlog_format_row.inc
 --source include/master-slave.inc
 

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -3162,19 +3162,24 @@ static bool send_show_master_info_data(THD *thd, Master_info *mi, bool full,
     if (full)
       protocol->store(mi->connection_name.str, mi->connection_name.length,
                       &my_charset_bin);
+
     mysql_mutex_lock(&mi->run_lock);
+    THD *sql_thd= mi->rli.sql_driver_thd;
+    const char *slave_sql_running_state=
+      sql_thd ? sql_thd->get_proc_info() : "";
+    THD *io_thd= mi->io_thd;
+    const char *slave_io_running_state= io_thd ? io_thd->get_proc_info() : "";
+    mysql_mutex_unlock(&mi->run_lock);
+
     if (full)
     {
       /*
         Show what the sql driver replication thread is doing
         This is only meaningful if there is only one slave thread.
       */
-      protocol->store(mi->rli.sql_driver_thd ?
-                      mi->rli.sql_driver_thd->get_proc_info() : "",
-                      &my_charset_bin);
+      protocol->store(slave_sql_running_state, &my_charset_bin);
     }
-    protocol->store(mi->io_thd ? mi->io_thd->get_proc_info() : "", &my_charset_bin);
-    mysql_mutex_unlock(&mi->run_lock);
+    protocol->store(slave_io_running_state, &my_charset_bin);
 
     mysql_mutex_lock(&mi->data_lock);
     mysql_mutex_lock(&mi->rli.data_lock);
@@ -3341,10 +3346,6 @@ static bool send_show_master_info_data(THD *thd, Master_info *mi, bool full,
 
     protocol->store((uint32) mi->rli.get_sql_delay());
     // SQL_Remaining_Delay
-    // THD::proc_info is not protected by any lock, so we read it once
-    // to ensure that we use the same value throughout this function.
-    const char *slave_sql_running_state=
-      mi->rli.sql_driver_thd ? mi->rli.sql_driver_thd->proc_info : "";
     if (slave_sql_running_state == stage_sql_thd_waiting_until_delay.m_name)
     {
       time_t t= my_time(0), sql_delay_end= mi->rli.get_sql_delay_end();


### PR DESCRIPTION
 - Suppress a couple errors the slave can get as the master crashes.

 - The mysql-test-run occasionally takes 120 seconds between crashing
   the master and starting it back up for some (unknown) reason. For
   now, work-around that by letting the slave try for 500 seconds to
   connect to master before giving up instead of only 100 seconds.

Signed-off-by: Kristian Nielsen <knielsen@knielsen-hq.org>
