### PR TITLE
MDEV-36206: Fix mysqld deprecation warning

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -2119,7 +2119,7 @@ static int prepare_export()
   if (strncmp(orig_argv1,"--defaults-file=", 16) == 0)
   {
     snprintf(cmdline, sizeof cmdline,
-      IF_WIN("\"","") "\"%s\" --mysqld \"%s\""
+      IF_WIN("\"","") "\"%s\" --mariadbd \"%s\""
       " --defaults-extra-file=./backup-my.cnf --defaults-group-suffix=%s --datadir=."
       " --innodb --innodb-fast-shutdown=0 --loose-partition"
       " --innodb-buffer-pool-size=%llu"
@@ -2133,7 +2133,7 @@ static int prepare_export()
   else
   {
     snprintf(cmdline, sizeof cmdline,
-      IF_WIN("\"","") "\"%s\" --mysqld"
+      IF_WIN("\"","") "\"%s\" --mariadbd"
       " --defaults-file=./backup-my.cnf --defaults-group-suffix=%s --datadir=."
       " --innodb --innodb-fast-shutdown=0 --loose-partition"
       " --innodb-buffer-pool-size=%llu"
@@ -7528,9 +7528,9 @@ int main(int argc, char **argv)
 	{
 		/* In "prepare export", we need  to start mysqld 
 		Since it is not always be installed on the machine,
-		we start "mariabackup --mysqld", which acts as mysqld
+		we start "mariabackup --mariadbd", which acts as mysqld
 		*/
-		if (strcmp(argv[1], "--mysqld") == 0)
+		if (strcmp(argv[1], "--mariadbd") == 0)
 		{
 			srv_operation= SRV_OPERATION_EXPORT_RESTORED;
 			extern int mysqld_main(int argc, char **argv);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36206*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
When running mariabackup with --prepare --export options, a deprecation warning appears because the program name is set to "mysqld" instead of "mariadbd"

The fix ensures that when running in mysqld mode, we properly set the program name to "mariadbd" to avoid the deprecation warning while maintaining the original functionality

## Release Notes
Fixed "mysqld: Deprecated" warning in --prepare --export mode

## How can this PR be tested?

Testing Instructions:

- Steps to reproduce and verify:
   ```bash
   # Create a backup
   $ mariadb-backup --prepare --export --target-dir=/path/to/backup
   ```

- Expected results:
   - The prepare command should complete successfully
   - The deprecation warning "mysqld: Deprecated program name. It will be removed in a future release, use 'mariadb/bin/mariadb-backup' instead" should NOT appear

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
