### PR TITLE
MDEV-35876: speedup collation/charset lookup

### DIFF
--- a/mysys/charset.c
+++ b/mysys/charset.c
@@ -30,6 +30,7 @@
 #endif
 
 extern HASH charset_name_hash;
+extern HASH collation_name_hash;
 
 /*
   The code below implements this functionality:
@@ -45,16 +46,10 @@ static uint
 get_collation_number_internal(const char *name)
 {
 
-  CHARSET_INFO **cs;
-  for (cs= all_charsets;
-       cs < all_charsets + array_elements(all_charsets);
-       cs++)
-  {
-    if (cs[0] && cs[0]->coll_name.str &&
-        !my_strcasecmp_latin1(cs[0]->coll_name.str, name))
-      return cs[0]->number;
-  }  
-  return 0;
+  CHARSET_INFO *cs;
+  size_t name_len = strlen(name);
+  cs = (CHARSET_INFO*) my_hash_search(&collation_name_hash,(uchar*) name, name_len);
+  return cs ? cs->number : 0;
 }
 
 
@@ -712,6 +707,16 @@ static void init_available_charsets(void)
   my_hash_init2(key_memory_charsets, &charset_name_hash, 16,
                 &my_charset_latin1, 64, 0, 0, get_charset_key,
                 0, 0, HASH_UNIQUE);
+  
+  /* Initialize collation name hash */
++  my_hash_init2(key_memory_charsets, &collation_name_hash, 16,
++                &my_charset_latin1, 64, 0, 0,
++                [](const uchar *object, size_t *length, my_bool) -> uchar* {
++                  CHARSET_INFO *cs = (CHARSET_INFO*) object;
++                  *length = cs->coll_name.length;
++                  return (uchar*) cs->coll_name.str;
++                },
+                 0, 0, HASH_UNIQUE);
 
   init_compiled_charsets(MYF(0));
 
@@ -733,6 +738,16 @@ static void init_available_charsets(void)
   my_charset_loader_init_mysys(&loader);
   strmov(get_charsets_dir(fname), MY_CHARSET_INDEX);
   my_read_charset_file(&loader, fname, MYF(0));
+
+  /* Populate the collation_name_hash*/
+  for (cs = all_charsets; cs < all_charsets + array_elements(all_charsets); cs ++)
+  {
+    CHARSET_INFO *c = *cs;
+    if(c && c->coll_name.str) {
+      my_hash_insert(&collation_name_hash, (uchar*)c);
+    }
+  }
+
   DBUG_VOID_RETURN;
 }
 
@@ -741,6 +756,7 @@ void free_charsets(void)
 {
   charsets_initialized= charsets_template;
   my_hash_free(&charset_name_hash);
+  my_hash_free(&collation_name_hash);
 }
 
 


### PR DESCRIPTION

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35876*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
- Replaces O(n) linear scans for collation lookups with O(1) hash lookups to eliminate performance bottlenecks as collation counts grow.
- No user-visible output changes. Internally, collation searches are faster (hash-based vs. array scan).
- Hash initialization occurs once during server startup, using existing thread-safe mechanisms.

## Release Notes
N/A 

## How can this PR be tested?


If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
