### PR TITLE
MDEV-36253  Redundant check in wf_incremental_process()

### DIFF
--- a/extra/mariabackup/backup_mysql.cc
+++ b/extra/mariabackup/backup_mysql.cc
@@ -1893,7 +1893,7 @@ bool write_backup_config_file(ds_ctxt *datasink)
 		srv_log_file_size,
 		srv_page_size,
 		srv_undo_dir,
-                (uint) srv_undo_tablespaces,
+		srv_undo_tablespaces,
 		page_zip_level,
 		innobase_buffer_pool_filename ?
 			"innodb_buffer_pool_filename=" : "",

--- a/extra/mariabackup/write_filt.cc
+++ b/extra/mariabackup/write_filt.cc
@@ -144,18 +144,6 @@ wf_incremental_process(xb_write_filt_ctxt_t *ctxt, ds_file_t *dstfile)
 			return false;
 		}
 
-		/* Check whether TRX_SYS page has been changed */
-		if (mach_read_from_4(page + FIL_PAGE_SPACE_ID)
-				== TRX_SYS_SPACE
-		    && mach_read_from_4(page + FIL_PAGE_OFFSET)
-				== TRX_SYS_PAGE_NO) {
-			msg(cursor->thread_n,
-			    "--incremental backup is impossible if "
-			    "the server had been restarted with "
-			    "different innodb_undo_tablespaces.");
-			return false;
-		}
-
 		/* updated page */
 		if (cp->npages == page_size / 4) {
 			/* flush buffer */

--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -201,8 +201,6 @@ struct xb_filter_entry_t{
 	xb_filter_entry_t *name_hash;
 };
 
-lsn_t checkpoint_lsn_start;
-lsn_t checkpoint_no_start;
 /** whether log_copying_thread() is active; protected by recv_sys.mutex */
 static bool log_copying_running;
 /** for --backup, target LSN to copy the log to; protected by recv_sys.mutex */


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-36253*
## Description
- Remove the redundant check of TRX_SYS page change in wf_incremental_process(). This is a regression which caused by commit 1c55b845e0fe337e647ba230288ed13e966cb7c7.

## How can this PR be tested?
./mtr --suite=mariabackup

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
