### PR TITLE
MDEV-35420 Server aborts while deleting the record in spatial index

### DIFF
--- a/mysql-test/suite/innodb_gis/r/rollback.result
+++ b/mysql-test/suite/innodb_gis/r/rollback.result
@@ -412,3 +412,16 @@ update t1 set a=point(5,5), b=point(5,5), c=5 where i < 3;
 ERROR HY000: Lost connection to MySQL server during query
 insert into t1 values(5, point(5,5), point(5,5), 5);
 drop table t1;
+#
+# MDEV-35420 Server aborts while deleting the record
+#               in spatial index
+#
+CREATE TABLE t1 (c POINT NOT NULL, SPATIAL(c)) engine=InnoDB;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SET STATEMENT unique_checks=0,foreign_key_checks=0 FOR
+START TRANSACTION;
+INSERT INTO t1 SELECT ST_GeomFromText('POINT(114368751 656950466)') FROM seq_1_to_512;
+ROLLBACK;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb_gis/t/rollback.test
+++ b/mysql-test/suite/innodb_gis/t/rollback.test
@@ -8,6 +8,7 @@
 # Avoid CrashReporter popup on Mac
 --source include/not_crashrep.inc
 --source include/have_innodb_16k.inc
+--source include/have_sequence.inc
 
 CREATE TABLE t4 (id bigint(12) unsigned NOT NULL auto_increment,
   c2 varchar(15) collate utf8_bin default NULL,
@@ -475,3 +476,15 @@ update t1 set a=point(5,5), b=point(5,5), c=5 where i < 3;
 insert into t1 values(5, point(5,5), point(5,5), 5);
 
 drop table t1;
+
+--echo #
+--echo # MDEV-35420 Server aborts while deleting the record
+--echo #               in spatial index
+--echo #
+CREATE TABLE t1 (c POINT NOT NULL, SPATIAL(c)) engine=InnoDB;
+CHECK TABLE t1;
+SET STATEMENT unique_checks=0,foreign_key_checks=0 FOR
+START TRANSACTION;
+INSERT INTO t1 SELECT ST_GeomFromText('POINT(114368751 656950466)') FROM seq_1_to_512;
+ROLLBACK;
+DROP TABLE t1;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-35420*

## Description
- InnoDB spatial index keep track of all active r-tree search cursor. While deleting a record from the index, spatial index discards the page present in the active r-tree search cursor.
rtr_check_discard_page() have the assumption that all active r-tree cursor should point to shadow block for the matched records. If the cursor was opened when the table is empty then there won't be any shadow block.

## How can this PR be tested?
./mtr innodb_gis.rollback

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
