### PR TITLE
MDEV-36270 mariabackup.incremental_compressed fails in 10.11+

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -5508,9 +5508,22 @@ xtrabackup_apply_delta(
 					buf + FSP_HEADER_OFFSET + FSP_SIZE);
 				if (mach_read_from_4(buf
 						     + FIL_PAGE_SPACE_ID)) {
+#ifdef _WIN32
+					os_offset_t last_page =
+					  os_file_get_size(dst_file) /
+					  page_size;
+
+					/* os_file_set_size() would
+					shrink the size of the file */
+					if (last_page < n_pages &&
+					    !os_file_set_size(
+					       dst_path, dst_file,
+					       n_pages * page_size))
+#else
 					if (!os_file_set_size(
 						    dst_path, dst_file,
 						    n_pages * page_size))
+#endif /* _WIN32 */
 						goto error;
 				} else if (fil_space_t* space
 					   = fil_system.sys_space) {

--- a/mysql-test/suite/mariabackup/incremental_compressed.result
+++ b/mysql-test/suite/mariabackup/incremental_compressed.result
@@ -4,6 +4,9 @@
 #
 CREATE TABLE t (pk INT PRIMARY KEY) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 ALTER TABLE t PARTITION BY KEY(pk);
+# Incremental backup
+# Prepare fullbackup
+# Prepare incremental backup
 # shutdown server
 # remove datadir
 # xtrabackup move back

--- a/mysql-test/suite/mariabackup/incremental_compressed.test
+++ b/mysql-test/suite/mariabackup/incremental_compressed.test
@@ -16,12 +16,18 @@ CREATE TABLE t (pk INT PRIMARY KEY) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 
 ALTER TABLE t PARTITION BY KEY(pk);
 
+--echo # Incremental backup
 --exec $XTRABACKUP --backup --target-dir=$incremental_dir --incremental-basedir=$basedir --protocol=tcp --port=$MASTER_MYPORT --user=root > $incremental_dir.log 2>&1
+--echo # Prepare fullbackup
 --exec $XTRABACKUP --prepare --target-dir=$basedir --user=root > $MYSQL_TMP_DIR/backup_prepare_0.log 2>&1
---exec $XTRABACKUP --prepare --target-dir=$basedir --incremental-dir=$incremental_dir --user=root >  $MYSQL_TMP_DIR/backup_prepare_1.log
---cat_file $MYSQL_TMP_DIR/backup_prepare_1.log
+--echo # Prepare incremental backup
+--exec $XTRABACKUP --prepare --target-dir=$basedir --incremental-dir=$incremental_dir --user=root >  $MYSQL_TMP_DIR/backup_prepare_1.log 2>&1
 let $targetdir=$basedir;
 -- source include/restart_and_restore.inc
-
 SHOW CREATE TABLE t;
 DROP TABLE t;
+remove_file $incremental_dir.log;
+remove_file $MYSQL_TMP_DIR/backup_prepare_0.log;
+remove_file $MYSQL_TMP_DIR/backup_prepare_1.log;
+rmdir $basedir;
+rmdir $incremental_dir;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36270*

## Description
Problem:
=======
- During prepare of incremental backup, mariabackup does create new file in target directory with default file size of 4 * innodb_page_size. While applying .delta file to corresponding data file, it encounters the FSP_SIZE modification on page0 and tries to extend the file to the size which is 4 in our case. Since the table is in compressed row format, page_size for the table is 8k. This lead to shrinking of tablespace file from 65536 to
32768. This issue happens only in windows because os_file_set_size() doesn't check for the current size and shrinks the file.

Solution:
==========
xtrabackup_apply_delta(): Check for the current size before doing setting size for the file.

## How can this PR be tested?
./mtr mariabackup.incremental_compressed

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
