### PR TITLE
MDEV-36297: Ability to backup selected partitions only

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -6327,7 +6327,7 @@ static int dump_selected_tables(char *db, char **table_names, int tables)
 
       // move partition name, if we're skipping a table
       if (partition_names != NULL) {
-        *partition_names_pos = partition_names[table_num];
+        *partition_names_pos= partition_names[table_num];
         partition_names_pos++;
       }
     }
@@ -6408,7 +6408,7 @@ static int dump_selected_tables(char *db, char **table_names, int tables)
   for (pos= dump_tables; pos < end; pos++)
   {
     char *partition = NULL;
-    if (*partition_names_pos != NULL) {
+    if (partition_names_pos != NULL && *partition_names_pos != NULL) {
       partition = (*partition_names_pos)->str;
       partition_names_pos++;
     }

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -6178,12 +6178,13 @@ static int get_sys_var_lower_case_table_names()
   return lower_case_table_names;
 }
 
-// Returns partition name from table name if no partition is specified.
-// Will return NULL if no partition is there. Otherwise you need to do my_free on the result
-// Will put \0 in *tablename in place of partition separator, so after return
-// *tablename is quaranteed to contain only table name.
+// Returns partition name from table name. NULL if no partition is specified.
+// Will put \0 in place of partition separator, so after return
+// *tablename will contain only table name.
+// 
 // Will treat double separator as escape in table name
 // Will replace backtick in partition name with double backtick
+// You need to do my_free on the result, if not NULL
 static char* get_partition_from_table_name(char *tablename, const char separator = '#')
 {
   int namelen = strlen(tablename);

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -6319,7 +6319,7 @@ static int dump_selected_tables(char *db, char **table_names, int tables)
     if (partition == NULL)
       DBUG_PRINT("info",("Dumping table %s", *pos));
     else
-      DBUG_PRINT("info",("Dumping table %s, partition %s", *pos, part));
+      DBUG_PRINT("info",("Dumping table %s, partition %s", *pos, partition));
 
     dump_table(*pos, db, NULL, 0, partition);
     if (opt_dump_triggers &&

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -6187,9 +6187,9 @@ static int get_sys_var_lower_case_table_names()
 // You need to do my_free on the result, if not NULL
 static char* get_partition_from_table_name(char *tablename, const char separator = '#')
 {
-  int namelen = strlen(tablename);
+  size_t namelen = strlen(tablename);
   int jj = 0;
-  for (int ii=0; ii<namelen; ii++)
+  for (size_t ii=0; ii<namelen; ii++)
   {
     if (tablename[ii] != separator)
     {


### PR DESCRIPTION
## Description
This code adds ability to backup selected partition(s) by mariadb-dump by using --partition-separator=@ and then specifying partition name in table's name, eg. mytable1@p0,p1. There should be no side effects, support for selecting partition(s) is disabled by default.
`./mariadb-dump -umyuser -pmypass -h127.0.0.1 mydatabase _test1@p0,p1 _test2@p0 --partition-separator=@`

## Release Notes
Ability to backup specific partitions with mariadb-dump by using --partition-separator and specifying partition list in table's name

## How can this PR be tested?
Won't affect mariadb-server, will try to write test case if that gets accepted.

## Basing the PR against the correct MariaDB version
- [X] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
