### PR TITLE
MDEV-34621: Fix division by zero in mariadb-slap when iterations=0

### DIFF
--- a/client/mysqlslap.c
+++ b/client/mysqlslap.c
@@ -2237,6 +2237,13 @@ generate_stats(conclusions *con, option_string *eng, stats *sptr)
   stats *ptr;
   unsigned int x;
 
+  if (eng && eng->string)
+    con->engine= eng->string;
+
+  /* Early return when iterations is 0 to avoid accessing uninitialized sptr */
+  if (iterations == 0)
+    return;
+
   con->min_timing= sptr->timing; 
   con->max_timing= sptr->timing;
   con->min_rows= sptr->rows;
@@ -2257,11 +2264,6 @@ generate_stats(conclusions *con, option_string *eng, stats *sptr)
       con->min_timing= ptr->timing;
   }
   con->avg_timing= con->avg_timing/iterations;
-
-  if (eng && eng->string)
-    con->engine= eng->string;
-  else
-    con->engine= NULL;
 }
 
 void

--- a/mysql-test/main/mysqlslap.result
+++ b/mysql-test/main/mysqlslap.result
@@ -260,3 +260,6 @@ DROP TABLE t1;
 #
 # Bug MDEV-15789 (Upstream: #80329): MYSQLSLAP OPTIONS --AUTO-GENERATE-SQL-GUID-PRIMARY and --AUTO-GENERATE-SQL-SECONDARY-INDEXES DONT WORK
 #
+#
+# Bug MDEV-34621: Fix division by zero in mariadb-slap when iterations=0
+#

--- a/mysql-test/main/mysqlslap.test
+++ b/mysql-test/main/mysqlslap.test
@@ -88,3 +88,9 @@ DROP TABLE t1;
 --exec $MYSQL_SLAP --concurrency=1 --silent --iterations=1 --number-int-cols=2 --number-char-cols=3 --auto-generate-sql --auto-generate-sql-guid-primary --create-schema=slap
 
 --exec $MYSQL_SLAP --concurrency=1 --silent --iterations=1 --number-int-cols=2 --number-char-cols=3 --auto-generate-sql --auto-generate-sql-secondary-indexes=1 --create-schema=slap
+
+--echo #
+--echo # Bug MDEV-34621: Fix division by zero in mariadb-slap when iterations=0
+--echo #
+
+--exec $MYSQL_SLAP -i0 --only-print


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-34621*


## Description
`mariadb-slap` crashes with a floating point exception when run with `-i0` due to division by zero in `generate_stats()`. This occurs when calculating average timing by dividing by the number of iterations.
Instead of modifying the minimum value for the `-i` option (which would cause unexpected warning messages even with valid values), this PR implements a targeted fix in the `generate_stats()`. The solution checks if `iterations == 0` before performing the division, and in such cases, returns early from the function.

## Release Notes
Fixed a floating point exception (division by zero) crash in `mariadb-slap` when running with `-i0` (zero iterations).

## How can this PR be tested?

This PR can be tested by manually running mariadb-slap with zero iterations, which would previously cause a crash:

   ```
   $ mariadb-slap -i0 --only-print
   ```
Or
```
$ ./mtr main.mysqlslap
```



## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
