### PR TITLE
MDEV-36281	DML aborts during online virtual index

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-index-online.result
+++ b/mysql-test/suite/innodb/r/innodb-index-online.result
@@ -534,7 +534,6 @@ INSERT INTO t1 VALUES(1,1);
 ROLLBACK;
 SET DEBUG_SYNC = 'now SIGNAL inserted';
 connection con1;
-disconnect con1;
 connection default;
 SELECT * FROM t1;
 a	b
@@ -542,6 +541,31 @@ a	b
 CHECK TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
+DROP TABLE t1;
+#
+# MDEV-36281 DML aborts during online virtual index
+#
+CREATE TABLE t1(f1 INT NOT NULL PRIMARY KEY, f2 INT NOT NULL,
+f3 INT NOT NULL, f4 INT AS (f3) VIRTUAL,
+f5 INT AS (f1) VIRTUAL, INDEX(f4))ENGINE=InnoDB;
+INSERT INTO t1(f1, f2, f3) VALUES(1, 2, 3);
+SET DEBUG_SYNC = 'innodb_inplace_alter_table_enter SIGNAL dml_start WAIT_FOR dml_finish';
+ALTER TABLE t1 ADD INDEX v1(f5, f2, f4), ADD INDEX v2(f3, f5);
+connection con1;
+set DEBUG_SYNC="now WAIT_FOR dml_start";
+UPDATE t1 SET f3= f3 + 1;
+set DEBUG_SYNC="now SIGNAL dml_finish";
+disconnect con1;
+connection default;
+CHECK TABLE t1 EXTENDED;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SELECT f5, f2, f4 FROM t1 USE INDEX(v1);
+f5	f2	f4
+1	2	4
+SELECT f3, f5 FROM t1 USE INDEX(v2);
+f3	f5
+4	1
 DROP TABLE t1;
 SET DEBUG_SYNC = 'RESET';
 SET GLOBAL innodb_file_per_table = @global_innodb_file_per_table_orig;

--- a/mysql-test/suite/innodb/t/innodb-index-online.test
+++ b/mysql-test/suite/innodb/t/innodb-index-online.test
@@ -510,12 +510,35 @@ SET DEBUG_SYNC = 'now SIGNAL inserted';
 
 connection con1;
 reap;
-disconnect con1;
 
 connection default;
 SELECT * FROM t1;
 CHECK TABLE t1;
 DROP TABLE t1;
+
+--echo #
+--echo # MDEV-36281 DML aborts during online virtual index
+--echo #
+CREATE TABLE t1(f1 INT NOT NULL PRIMARY KEY, f2 INT NOT NULL,
+		f3 INT NOT NULL, f4 INT AS (f3) VIRTUAL,
+		f5 INT AS (f1) VIRTUAL, INDEX(f4))ENGINE=InnoDB;
+INSERT INTO t1(f1, f2, f3) VALUES(1, 2, 3);
+SET DEBUG_SYNC = 'innodb_inplace_alter_table_enter SIGNAL dml_start WAIT_FOR dml_finish';
+send ALTER TABLE t1 ADD INDEX v1(f5, f2, f4), ADD INDEX v2(f3, f5);
+
+connection con1;
+set DEBUG_SYNC="now WAIT_FOR dml_start";
+UPDATE t1 SET f3= f3 + 1;
+set DEBUG_SYNC="now SIGNAL dml_finish";
+
+disconnect con1;
+connection default;
+reap;
+CHECK TABLE t1 EXTENDED;
+SELECT f5, f2, f4 FROM t1 USE INDEX(v1);
+SELECT f3, f5 FROM t1 USE INDEX(v2);
+DROP TABLE t1;
+
 SET DEBUG_SYNC = 'RESET';
 
 # Check that all connections opened by test cases in this file are really

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -4065,20 +4065,19 @@ void UndorecApplier::log_update(const dtuple_t &tuple,
   if (!(this->cmpl_info & UPD_NODE_NO_ORD_CHANGE))
   {
     for (ulint i = 0; i < dict_table_get_n_v_cols(table); i++)
-       dfield_get_type(
-         dtuple_get_nth_v_field(row, i))->mtype = DATA_MISSING;
-  }
-
-  if (is_update)
-  {
-    old_row= dtuple_copy(row, heap);
-    row_upd_replace(old_row, &old_ext, clust_index, update, heap);
+     dfield_get_type(dtuple_get_nth_v_field(row, i))->mtype = DATA_MISSING;
   }
 
   if (table->n_v_cols)
     row_upd_replace_vcol(row, table, update, false, nullptr,
                          (cmpl_info & UPD_NODE_NO_ORD_CHANGE)
                          ? nullptr : undo_rec);
+
+  if (is_update)
+  {
+    old_row= dtuple_copy(row, heap);
+    row_upd_replace(old_row, &old_ext, clust_index, update, heap);
+  }
 
   bool success= true;
   dict_index_t *index= dict_table_get_next_index(clust_index);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36281*

## Description
Reason:
=======
- InnoDB DML commit aborts the server when InnoDB does online virtual index. During online DDL, concurrent DML commit operation does read the undo log record and their related current version of the clustered index record. Based on the operation, InnoDB do build the old tuple and new tuple for the table. If the concurrent online index can be affected by the operation, InnoDB does build the entry
for the index and log the operation.

Problematic case is update operation, InnoDB does build the update vector. But while building the old row, InnoDB fails to fill the non-affected virtual column. This lead to server abort while build the entry for index.

Fix:
===
- First, fill the virtual column entries for the new row. Duplicate the old row based on new row and change only the affected fields in old row based on the update vector.


## How can this PR be tested?
./mtr innodb.innodb-index-online

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.