### PR TITLE
MDEV-35304 fixup: Timing-independent MTR test

### DIFF
--- a/mysql-test/suite/multi_source/connects_tried.result
+++ b/mysql-test/suite/multi_source/connects_tried.result
@@ -3,35 +3,40 @@ include/master-slave.inc [rpl_server_count=3]
 include/rpl_stop_server.inc [server_number=1]
 include/rpl_stop_server.inc [server_number=3]
 connection slave;
-CHANGE MASTER TO master_connect_retry=1;
-CHANGE MASTER 'named' TO master_host='127.0.0.1', master_port=SERVER_MYPORT_3, master_user='root', master_ssl_verify_server_cert=0, master_connect_retry=2;
+CHANGE MASTER TO master_connect_retry=2;
+CHANGE MASTER 'named' TO master_host='127.0.0.1', master_port=SERVER_MYPORT_3, master_user='root', master_ssl_verify_server_cert=0, master_connect_retry=1;
 # `Connects_Tried` is 0 before connections begin.
 SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 Connection_name	Connects_Tried
 	0
 named	0
 START ALL SLAVES;
+SET @time_begin= CURRENT_TIMESTAMP(1);
 SET @@SESSION.default_master_connection= 'named';
 include/wait_for_slave_io_error.inc [errno=2003]
 SET @@SESSION.default_master_connection= '';
 include/wait_for_slave_io_error.inc [errno=2003]
 CREATE TEMPORARY TABLE status_begin AS
 SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
-# `Connects_Tried` is 1 immediately after connections begin.
+# `Connects_Tried` is 1 immediately after connection begins.
 SELECT Connection_name, Connects_Tried
 FROM status_begin
 WHERE Connects_Tried <= 0;
 Connection_name	Connects_Tried
-DO SLEEP(3);
-# `Connects_Tried` increments (at least) 3 for connection '' and 1 for 'named'.
-CREATE TEMPORARY TABLE status_sleep AS
-SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
-SELECT *
-FROM status_begin JOIN status_sleep USING(Connection_name)
-WHERE status_sleep.Connects_Tried - status_begin.Connects_Tried <
-IF(LENGTH(Connection_name), 1, 3);
-Connection_name	Connects_Tried	Connects_Tried
-# Boot replication up and assert final count
+# `Connects_Tried` takes (at least) 2s to increment for connection '' and 1s for 'named'.
+SET @@SESSION.default_master_connection= 'named';
+include/wait_for_slave_param.inc [Connects_Tried]
+SELECT @time_begin, CURRENT_TIMESTAMP(1)
+WHERE TIMESTAMPDIFF(SECOND, @time_begin, CURRENT_TIMESTAMP(1)) < 1;
+@time_begin	CURRENT_TIMESTAMP(1)
+CREATE TEMPORARY TABLE status_sleep AS SELECT 'named' Connection_name, Connects_Tried Connects_Tried;
+SET @@SESSION.default_master_connection= '';
+include/wait_for_slave_param.inc [Connects_Tried]
+SELECT @time_begin, CURRENT_TIMESTAMP(1)
+WHERE TIMESTAMPDIFF(SECOND, @time_begin, CURRENT_TIMESTAMP(1)) < 2;
+@time_begin	CURRENT_TIMESTAMP(1)
+INSERT INTO status_sleep SET Connection_name= '', Connects_Tried= Connects_Tried;
+# Boot replication up and compare the final counts
 include/rpl_start_server.inc [server_number=1]
 include/rpl_start_server.inc [server_number=3]
 connection slave;
@@ -58,11 +63,11 @@ Connection_name	Connects_Tried	Connects_Tried
 SELECT * FROM status_end;
 Connection_name	Connects_Tried
 	connects_tried
-named	connects_tried_named
+named	connects_tried
 SELECT * FROM status_end;
 Connection_name	Connects_Tried
 	connects_tried
-named	connects_tried_named
+named	connects_tried
 STOP ALL SLAVES;
 SET @@SESSION.default_master_connection= 'named';
 include/wait_for_slave_to_stop.inc
@@ -83,7 +88,7 @@ SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 SELECT *
 FROM status_restart JOIN status_stop USING(Connection_name)
 WHERE status_restart.Connects_Tried NOT BETWEEN IF(
-LENGTH(Connection_name), status_stop.Connects_Tried, 1
+Connection_name = '', 1, status_stop.Connects_Tried
 ) AND status_stop.Connects_Tried;
 Connection_name	Connects_Tried	Connects_Tried
 STOP SLAVE;
@@ -95,7 +100,7 @@ SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 SELECT *
 FROM status_reset JOIN status_restart USING(Connection_name)
 WHERE status_reset.Connects_Tried <>
-IF(LENGTH(Connection_name), status_restart.Connects_Tried, 0);
+IF(Connection_name = '', 0, status_restart.Connects_Tried);
 Connection_name	Connects_Tried	Connects_Tried
 # Cleanup
 RESET SLAVE 'named' ALL;

--- a/mysql-test/suite/multi_source/connects_tried.test
+++ b/mysql-test/suite/multi_source/connects_tried.test
@@ -4,7 +4,7 @@
 # separate counters in parallel multi-source (SHOW SLAVE [name] STATUS).
 #
 # Note: nearly all SELECT results are timing-sensitive,
-# they therefore list unexpected rows because.
+# therefore, they only list unexpected rows.
 
 --source include/have_binlog_format_mixed.inc # The test is agnostic of binlog formats.
 # `rpl_*.inc` (still) expects `server_1` be `master` and `server_2` be `slave`.
@@ -17,14 +17,16 @@
 --source include/rpl_stop_server.inc
 
 --connection slave
-CHANGE MASTER TO master_connect_retry=1;
+CHANGE MASTER TO master_connect_retry=2;
 --replace_result $SERVER_MYPORT_3 SERVER_MYPORT_3
---eval CHANGE MASTER 'named' TO master_host='127.0.0.1', master_port=$SERVER_MYPORT_3, master_user='root', master_ssl_verify_server_cert=0, master_connect_retry=2
+--eval CHANGE MASTER 'named' TO master_host='127.0.0.1', master_port=$SERVER_MYPORT_3, master_user='root', master_ssl_verify_server_cert=0, master_connect_retry=1
 --echo # `Connects_Tried` is 0 before connections begin.
 SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 
 --disable_warnings
 START ALL SLAVES; # will fail because the masters are down
+SET @time_begin= CURRENT_TIMESTAMP(1);
+--enable_warnings
 # CR_CONN_HOST_ERROR
 --let $slave_io_errno= 2003
 --let $slave_io_error_is_nonfatal= 1
@@ -33,25 +35,39 @@ SET @@SESSION.default_master_connection= 'named';
 --let $slave_io_error_is_nonfatal= 1
 SET @@SESSION.default_master_connection= '';
 --source include/wait_for_slave_io_error.inc
---enable_warnings
 
 CREATE TEMPORARY TABLE status_begin AS
   SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
---echo # `Connects_Tried` is 1 immediately after connections begin.
+--echo # `Connects_Tried` is 1 immediately after connection begins.
+# (Though it might have ticked additional reconnects by now if stress-testing.)
 SELECT Connection_name, Connects_Tried
   FROM status_begin
   WHERE Connects_Tried <= 0;
 
-DO SLEEP(3);
---echo # `Connects_Tried` increments (at least) 3 for connection '' and 1 for 'named'.
-CREATE TEMPORARY TABLE status_sleep AS
-  SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
-SELECT *
-  FROM status_begin JOIN status_sleep USING(Connection_name)
-  WHERE status_sleep.Connects_Tried - status_begin.Connects_Tried <
-    IF(LENGTH(Connection_name), 1, 3);
+--echo # `Connects_Tried` takes (at least) 2s to increment for connection '' and 1s for 'named'.
+--let $slave_param= Connects_Tried
+--let $slave_param_comparison= >
 
---echo # Boot replication up and assert final count
+SET @@SESSION.default_master_connection= 'named';
+--let $slave_param_value= `SELECT Connects_Tried FROM status_begin WHERE Connection_name = ''`
+--source include/wait_for_slave_param.inc
+SELECT @time_begin, CURRENT_TIMESTAMP(1)
+  WHERE TIMESTAMPDIFF(SECOND, @time_begin, CURRENT_TIMESTAMP(1)) < 1;
+--replace_result $_show_slave_status_value Connects_Tried
+--eval CREATE TEMPORARY TABLE status_sleep AS SELECT 'named' Connection_name, $_show_slave_status_value Connects_Tried
+
+SET @@SESSION.default_master_connection= '';
+--let $slave_param_value= `SELECT Connects_Tried FROM status_begin WHERE Connection_name <> ''`
+--source include/wait_for_slave_param.inc
+SELECT @time_begin, CURRENT_TIMESTAMP(1)
+  WHERE TIMESTAMPDIFF(SECOND, @time_begin, CURRENT_TIMESTAMP(1)) < 2;
+--replace_result $_show_slave_status_value Connects_Tried
+--eval INSERT INTO status_sleep SET Connection_name= '', Connects_Tried= $_show_slave_status_value
+
+--echo # Boot replication up and compare the final counts
+# (In an ideal environment, the 'named' connection that reconnects
+#  more frequently would have a `Connects_Tried` ahead of the '' one.
+#  In stress-testing, it instead depends on the thread timing and scheduling.)
 --let $rpl_server_number= 1
 --source include/rpl_start_server.inc
 --let $rpl_server_number= 3
@@ -60,6 +76,7 @@ SELECT *
 # `wait_for_slave_io_to_start.inc` fails if the IO thread has an error.
 --let $slave_param= Slave_IO_Running
 --let $slave_param_value= Yes
+--let $slave_param_comparison= =
 SET @@SESSION.default_master_connection= 'named';
 --source include/wait_for_slave_param.inc
 SET @@SESSION.default_master_connection= '';
@@ -83,11 +100,11 @@ SELECT *
 --echo # Conventional views
 --let $connects_tried= query_get_value("SHOW SLAVE STATUS", Connects_Tried, 1)
 --let $connects_tried_named= query_get_value("SHOW SLAVE 'named' STATUS", Connects_Tried, 1)
---replace_result $connects_tried connects_tried $connects_tried_named connects_tried_named
+--replace_result $connects_tried connects_tried $connects_tried_named connects_tried
 SELECT * FROM status_end;
 --let $connects_tried= query_get_value("SHOW ALL SLAVES STATUS", Connects_Tried, 1)
 --let $connects_tried_named= query_get_value("SHOW ALL SLAVES STATUS", Connects_Tried, 2)
---replace_result $connects_tried connects_tried $connects_tried_named connects_tried_named
+--replace_result $connects_tried connects_tried $connects_tried_named connects_tried
 SELECT * FROM status_end;
 
 --disable_warnings
@@ -113,7 +130,7 @@ CREATE TEMPORARY TABLE status_restart AS
 SELECT *
   FROM status_restart JOIN status_stop USING(Connection_name)
   WHERE status_restart.Connects_Tried NOT BETWEEN IF(
-    LENGTH(Connection_name), status_stop.Connects_Tried, 1
+    Connection_name = '', 1, status_stop.Connects_Tried
   ) AND status_stop.Connects_Tried;
 
 STOP SLAVE;
@@ -125,7 +142,7 @@ CREATE TEMPORARY TABLE status_reset AS
 SELECT *
   FROM status_reset JOIN status_restart USING(Connection_name)
   WHERE status_reset.Connects_Tried <>
-    IF(LENGTH(Connection_name), status_restart.Connects_Tried, 0);
+    IF(Connection_name = '', 0, status_restart.Connects_Tried);
 
 --echo # Cleanup
 RESET SLAVE 'named' ALL;


### PR DESCRIPTION
* [x] ~~*The Jira issue number for this PR is: [MDEV-35304](https://jira.mariadb.org/browse/MDEV-35304)*~~

## Description
Improve the `multi_source.connects_tried` feature test:
* Replace the main course from *checking `Connect_Tried` after sleeping a specific time* to *checking the duration after reaching a minimum `Connect_Tried`*
  * Not using a specific SLEEP eliminates the possibility (of failure) that it awakens before the `Connects_Tried` counter increments.
* In replacement-based tests of conventional views (SHOW & variants), assert the parallel values without distinguishing which is which
  * There were rare cases where both values end up equal (even though one was configured to tick more frequently than the other).
* Comment touchups

## Release Notes
N/A

## How can this PR be tested?
It has been evident that timing tests easily lead to sporadic failures.
Perhaps our CI (Buildbot) are overloaded with concurrent jobs that their thread schedulers had to make possibly-unrealistic compromises.

## PR quality check
(Yes, this is a refactoring fix concerning a `main`-exclusive (unreleased) new feature.)
* [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.