### PR TITLE
MDEV-36042 Assertion failed in Binary_string::q_append

### DIFF
--- a/mysql-test/main/spatial_utility_function_isvalid.result
+++ b/mysql-test/main/spatial_utility_function_isvalid.result
@@ -474,3 +474,9 @@ c
 SELECT ST_IsValid(ST_GEOMFROMTEXT('  MULTIPOLYGON( ( (2 2, 2 4, 4 4, 4 2, 2 2) ), ( (3 5, 2 5, 2 4, 3 4, 3 5) ) ) '));
 ST_IsValid(ST_GEOMFROMTEXT('  MULTIPOLYGON( ( (2 2, 2 4, 4 4, 4 2, 2 2) ), ( (3 5, 2 5, 2 4, 3 4, 3 5) ) ) '))
 0
+#
+# MDEV-36042 Assertion failed in Binary_string::q_append
+#
+SELECT st_astext(ST_VALIDATE(ST_SYMDIFFERENCE(ST_GEOMFROMTEXT(' MULTIPOLYGON( ( ( 2 2, 2 8, 8 8, 8 2, 2 2 ), ( 4 4, 4 6, 6 6, 6 4, 4 4 ) ), ( (0 2,1 2,1 3,0 3,0 2) ) ) '),  ST_GEOMFROMTEXT(' POLYGON( ( 2 4, 5 8, 0 8, 8 1, 7 6, 2 4 ) ) ') ) ) ) <> '';
+st_astext(ST_VALIDATE(ST_SYMDIFFERENCE(ST_GEOMFROMTEXT(' MULTIPOLYGON( ( ( 2 2, 2 8, 8 8, 8 2, 2 2 ), ( 4 4, 4 6, 6 6, 6 4, 4 4 ) ), ( (0 2,1 2,1 3,0 3,0 2) ) ) '),  ST_GEOMFROMTEXT(' POLYGON( ( 2 4, 5 8, 0 8, 8 1, 7 6, 2 4 ) ) ') ) ) ) <> ''
+1

--- a/mysql-test/main/spatial_utility_function_isvalid.test
+++ b/mysql-test/main/spatial_utility_function_isvalid.test
@@ -391,3 +391,7 @@ SELECT ST_IsValid(ST_GEOMFROMTEXT(' POLYGON( ( 0 0, 0 0, 8 0, 0 0 ) )  '));
 SELECT ST_IsValid(ST_GEOMFROMTEXT('  MULTIPOLYGON( ( ( 2 2, 2 8, 8 8, 8 2, 2 2 ), ( 4 4, 4 6, 6 6, 6 4, 4 4 ) ), ( ( 2 2, 1 2, 0 5, 2 9, 2 2 ) ) ) ')) c;
 SELECT ST_IsValid(ST_GEOMFROMTEXT('  MULTIPOLYGON( ( (2 2, 2 4, 4 4, 4 2, 2 2) ), ( (3 5, 2 5, 2 4, 3 4, 3 5) ) ) '));
 
+--echo #
+--echo # MDEV-36042 Assertion failed in Binary_string::q_append
+--echo #
+SELECT st_astext(ST_VALIDATE(ST_SYMDIFFERENCE(ST_GEOMFROMTEXT(' MULTIPOLYGON( ( ( 2 2, 2 8, 8 8, 8 2, 2 2 ), ( 4 4, 4 6, 6 6, 6 4, 4 4 ) ), ( (0 2,1 2,1 3,0 3,0 2) ) ) '),  ST_GEOMFROMTEXT(' POLYGON( ( 2 4, 5 8, 0 8, 8 1, 7 6, 2 4 ) ) ') ) ) ) <> '';

--- a/sql/spatial.cc
+++ b/sql/spatial.cc
@@ -4225,9 +4225,12 @@ int Gis_multi_polygon::make_clockwise(String *result) const
         !(polygon= Geometry::construct(&buffer, wkb.ptr(), wkb.length())))
       return 1;
 
-    if(polygon->make_clockwise(&clockwise_wkb))
+    if (polygon->make_clockwise(&clockwise_wkb))
       return 1;
 
+    // Reserve space for the byte order and GIS type.
+    if (result->reserve(sizeof(char) + sizeof(uint32)))
+      return 1;
     result->q_append((char) wkb_ndr);
     result->q_append((uint32) wkb_polygon);
     result->append(clockwise_wkb.ptr() + WKB_HEADER_SIZE,


### PR DESCRIPTION
Like MDEV-35062, reserve sufficient space in the result for q_append'ed data, as q_append does not itself reserve space like it's append counterpart.
