### PR TITLE
MDEV-36316/MDEV-36327/MDEV-36328 Debug msan fixes 10.6

### DIFF
--- a/include/my_pthread.h
+++ b/include/my_pthread.h
@@ -668,7 +668,17 @@ extern void my_mutex_end(void);
   We need to have at least 256K stack to handle calls to myisamchk_init()
   with the current number of keys and key parts.
 */
-# if defined(__SANITIZE_ADDRESS__) || defined(WITH_UBSAN)
+#if !defined(__has_feature)
+#define __has_feature(x) 0
+#endif
+#if defined(__clang__) && __has_feature(memory_sanitizer) && !defined(DBUG_OFF)
+/*
+  MSAN in Debug with clang-20.1 required more memory to complete
+  mtr begin/end checks. The result without increase was MSAN
+  errors triggered on a call instruction.
+*/
+#  define DEFAULT_THREAD_STACK	(448*1024L) /* 458752 */
+# elif defined(__SANITIZE_ADDRESS__) || defined(WITH_UBSAN)
 /*
   Optimized WITH_ASAN=ON executables produced
   by GCC 12.3.0, GCC 13.2.0, or clang 16.0.6

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14476,8 +14476,8 @@ ha_innobase::records_in_range(
 		n_rows = rtr_estimate_n_rows_in_range(
 			index, range_start, mode1);
 	} else {
-		btr_pos_t tuple1(range_start, mode1, pages->first_page);
-		btr_pos_t tuple2(range_end,   mode2, pages->last_page);
+		btr_pos_t tuple1(range_start, mode1, 0);
+		btr_pos_t tuple2(range_end,   mode2, 0);
 		n_rows = btr_estimate_n_rows_in_range(index, &tuple1, &tuple2);
 		pages->first_page= tuple1.page_id.raw();
 		pages->last_page=  tuple2.page_id.raw();

--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -5453,7 +5453,7 @@ i_s_dict_fill_sys_columns(
 	const char*	col_name,	/*!< in: column name */
 	dict_col_t*	column,		/*!< in: dict_col_t struct holding
 					more column information */
-	ulint		nth_v_col,	/*!< in: virtual column, its
+	ulint*		nth_v_col,	/*!< in: virtual column, its
 					sequence number (nth virtual col) */
 	TABLE*		table_to_fill)	/*!< in/out: fill this table */
 {
@@ -5468,7 +5468,7 @@ i_s_dict_fill_sys_columns(
 	OK(field_store_string(fields[SYS_COLUMN_NAME], col_name));
 
 	if (column->is_virtual()) {
-		ulint	pos = dict_create_v_col_pos(nth_v_col, column->ind);
+		ulint	pos = dict_create_v_col_pos(*nth_v_col, column->ind);
 		OK(fields[SYS_COLUMN_POSITION]->store(pos, true));
 	} else {
 		OK(fields[SYS_COLUMN_POSITION]->store(column->ind, true));
@@ -5535,7 +5535,7 @@ i_s_sys_columns_fill_table(
 		if (!err_msg) {
 			err = i_s_dict_fill_sys_columns(
 				thd, table_id, col_name,
-				&column_rec, nth_v_col,
+				&column_rec, &nth_v_col,
 				tables->table);
 			if (err) {
 				err = i_s_sys_error_handling(err, thd);

--- a/storage/innobase/include/rem0rec.inl
+++ b/storage/innobase/include/rem0rec.inl
@@ -156,6 +156,9 @@ rec_set_bit_field_1(
 	ut_ad(((mask >> shift) << shift) == mask);
 	ut_ad(((val << shift) & mask) == (val << shift));
 
+#ifndef DBUG_OFF
+	MEM_MAKE_DEFINED(rec - offs, 1);
+#endif
 	mach_write_to_1(rec - offs,
 			(mach_read_from_1(rec - offs) & ~mask)
 			| (val << shift));
@@ -198,6 +201,9 @@ rec_set_bit_field_2(
 	ut_ad(((mask >> shift) << shift) == mask);
 	ut_ad(((val << shift) & mask) == (val << shift));
 
+#ifndef DBUG_OFF
+	MEM_MAKE_DEFINED(rec - offs, 2);
+#endif
 	mach_write_to_2(rec - offs,
 			(mach_read_from_2(rec - offs) & ~mask)
 			| (val << shift));


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36316/MDEV-36317/MDEV-36318*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Various fixing to allow a Debug MSAN with Clang-20 to pass tests.

See individual commit messages for details.

## Release Notes
* Internal changes only.

## How can this PR be tested?

```
podman run --rm -ti -v "$PWD":/source:z --mount=type=tmpfs,tmpfs-size=10G,dst=/build --shm-size=10g --workdir /build --entrypoint /bin/bash --user buildbot --cap-add=SYS_PTRACE --privileged quay.io/mariadb-foundation/bb-worker:dev_debian12-msan-clang-20

cmake    -DWITH_EMBEDDED_SERVER=OFF \
                -DWITH_INNODB_{BZIP2,LZ4,LZMA,LZO,SNAPPY}=OFF \
                -DPLUGIN_{MROONGA,ROCKSDB,OQGRAPH,SPIDER}=NO \
                -DWITH_ZLIB=bundled \
                -DHAVE_LIBAIO_H=0 \
                -DCMAKE_DISABLE_FIND_PACKAGE_{URING,LIBAIO}=1 \
                -DWITH_NUMA=NO \
                -DWITH_SYSTEMD=no \
                -DWITH_MSAN=ON \
                -DHAVE_CXX_NEW=1 \
                -DCMAKE_{EXE,MODULE}_LINKER_FLAGS="-L${MSAN_LIBDIR} -Wl,-rpath=${MSAN_LIBDIR}" \
                -DCMAKE_CXX_FLAGS=-fsanitize=memory \
                -DWITH_DBUG_TRACE=OFF
                -DCMAKE_BUILD_TYPE=Debug \
                /source
cmake --build .
mysql-test/mtr --parallel=auto --force --big-test
```


<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.