### PR TITLE
Fixes linker issues and compilation issues while building on AIX

### DIFF
--- a/storage/innobase/unittest/CMakeLists.txt
+++ b/storage/innobase/unittest/CMakeLists.txt
@@ -32,7 +32,7 @@ IF (WITH_INNODB_AHI)
   MY_ADD_TEST(innodb_ahi)
 ENDIF()
 # See explanation in innobase/CmakeLists.txt
-IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|powerpc64|s390x")
+IF(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|powerpc64|s390x" OR CMAKE_SYSTEM_NAME MATCHES "AIX")
   ADD_COMPILE_FLAGS(
       ../sync/srw_lock.cc
       COMPILE_FLAGS "-mhtm"

--- a/unittest/sql/CMakeLists.txt
+++ b/unittest/sql/CMakeLists.txt
@@ -19,6 +19,10 @@ INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/sql
                     ${CMAKE_SOURCE_DIR}/include
                     ${CMAKE_SOURCE_DIR}/unittest/mytap
                     ${CMAKE_SOURCE_DIR}/extra/yassl/include)
+IF(CMAKE_SYSTEM_NAME MATCHES AIX)
+  # Workaround linker bug on AIX
+  SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-berok")
+ENDIF()
 ADD_EXECUTABLE(explain_filename-t explain_filename-t.cc  dummy_builtins.cc)
 
 


### PR DESCRIPTION
We need berok flag to ignore unresolved symbol errors while building on AIX. Former part of the patch detects AIX system during compilation.