### PR TITLE
MDEV-36017 Alter table aborts when temporary directory is full

### DIFF
--- a/mysql-test/suite/innodb/r/alloc_fail.result
+++ b/mysql-test/suite/innodb/r/alloc_fail.result
@@ -1,0 +1,47 @@
+#
+# MDEV-36017 Alter table aborts when temporary
+#                directory is full
+#
+SET SESSION DEFAULT_STORAGE_ENGINE=InnoDB;
+CREATE TABLE t1(f1 CHAR(100) NOT NULL, f2 CHAR(100) NOT NULL,
+f3 CHAR(100) NOT NULL, f4 CHAR(100) NOT NULL,
+f5 CHAR(100) NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 SELECT 'a', 'b', 'c', 'd', 'e' FROM seq_1_to_65536;
+SET STATEMENT DEBUG_DBUG="+d,write_to_tmp_file_fail" FOR
+CREATE TABLE t2 as SELECT * FROM t1;
+ERROR HY000: Got error 59 'Temp file write failure' from InnoDB
+DROP TABLE t1;
+CREATE TABLE t1(f1 INT NOT NULL, f2 CHAR(100),
+f3 CHAR(100))ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, 'a', 'b' FROM seq_1_to_1024;
+SET STATEMENT DEBUG_DBUG="+d,write_to_tmp_file_fail" FOR
+ALTER TABLE t1 FORCE, ALGORITHM=COPY;
+ERROR HY000: Got error 59 'Temp file write failure' from InnoDB
+DROP TABLE t1;
+CREATE TABLE t1(f1 INT NOT NULL, f2 CHAR(100),
+f3 CHAR(100))ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, 'a', 'b' FROM seq_1_to_4096;
+SET DEBUG_SYNC="inplace_after_index_build SIGNAL dml_start WAIT_FOR dml_commit";
+ALTER TABLE t1 ADD KEY(f1), ADD INDEX(f3(10));
+connect con1,localhost,root,,,;
+SET DEBUG_SYNC="now WAIT_FOR dml_start";
+BEGIN;
+INSERT INTO t1 SELECT * FROM t1;
+SET STATEMENT DEBUG_DBUG="+d,os_file_write_fail" FOR COMMIT;
+SET DEBUG_SYNC="now SIGNAL dml_commit";
+connection default;
+ERROR HY000: Temporary file write failure
+disconnect con1;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;
+SET STATEMENT DEBUG_DBUG="+d,ddl_log_write_fail" FOR
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+DROP TABLE t1;
+CREATE TABLE t1(f1 TEXT, index(f1(2)))ENGINE=InnoDB;
+INSERT INTO t1 VALUES('a');
+set statement DEBUG_DBUG="+d,btr_page_alloc_fail" for
+UPDATE t1 set f1= REPEAT('b', 12000);
+ERROR HY000: The table 't1' is full
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/alloc_fail.opt
+++ b/mysql-test/suite/innodb/t/alloc_fail.opt
@@ -1,0 +1,2 @@
+--innodb_sort_buffer_size=64k
+--innodb_rollback_on_timeout=1

--- a/mysql-test/suite/innodb/t/alloc_fail.test
+++ b/mysql-test/suite/innodb/t/alloc_fail.test
@@ -1,0 +1,55 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/have_debug.inc
+--echo #
+--echo # MDEV-36017 Alter table aborts when temporary
+--echo #                directory is full
+--echo #
+SET SESSION DEFAULT_STORAGE_ENGINE=InnoDB;
+CREATE TABLE t1(f1 CHAR(100) NOT NULL, f2 CHAR(100) NOT NULL,
+		f3 CHAR(100) NOT NULL, f4 CHAR(100) NOT NULL,
+		f5 CHAR(100) NOT NULL)ENGINE=InnoDB;
+INSERT INTO t1 SELECT 'a', 'b', 'c', 'd', 'e' FROM seq_1_to_65536;
+--error ER_GET_ERRMSG
+SET STATEMENT DEBUG_DBUG="+d,write_to_tmp_file_fail" FOR
+CREATE TABLE t2 as SELECT * FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1(f1 INT NOT NULL, f2 CHAR(100),
+		f3 CHAR(100))ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, 'a', 'b' FROM seq_1_to_1024;
+--error ER_GET_ERRMSG
+SET STATEMENT DEBUG_DBUG="+d,write_to_tmp_file_fail" FOR
+ALTER TABLE t1 FORCE, ALGORITHM=COPY;
+DROP TABLE t1;
+
+CREATE TABLE t1(f1 INT NOT NULL, f2 CHAR(100),
+		f3 CHAR(100))ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, 'a', 'b' FROM seq_1_to_4096;
+SET DEBUG_SYNC="inplace_after_index_build SIGNAL dml_start WAIT_FOR dml_commit";
+SEND ALTER TABLE t1 ADD KEY(f1), ADD INDEX(f3(10));
+
+connect(con1,localhost,root,,,);
+SET DEBUG_SYNC="now WAIT_FOR dml_start";
+BEGIN;
+INSERT INTO t1 SELECT * FROM t1;
+SET STATEMENT DEBUG_DBUG="+d,os_file_write_fail" FOR COMMIT;
+SET DEBUG_SYNC="now SIGNAL dml_commit";
+
+connection default;
+--error ER_TEMP_FILE_WRITE_FAILURE
+reap;
+disconnect con1;
+CHECK TABLE t1;
+DROP TABLE t1;
+
+SET STATEMENT DEBUG_DBUG="+d,ddl_log_write_fail" FOR
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+DROP TABLE t1;
+
+CREATE TABLE t1(f1 TEXT, index(f1(2)))ENGINE=InnoDB;
+INSERT INTO t1 VALUES('a');
+--error ER_RECORD_FILE_FULL
+set statement DEBUG_DBUG="+d,btr_page_alloc_fail" for
+UPDATE t1 set f1= REPEAT('b', 12000);
+DROP TABLE t1;

--- a/sql/ddl_log.cc
+++ b/sql/ddl_log.cc
@@ -3051,13 +3051,15 @@ static bool ddl_log_write(DDL_LOG_STATE *ddl_state,
   error= ((ddl_log_write_entry(ddl_log_entry, &log_entry)) ||
           ddl_log_write_execute_entry(log_entry->entry_pos, 0,
                                       &ddl_state->execute_entry));
-  mysql_mutex_unlock(&LOCK_gdl);
+  DBUG_EXECUTE_IF("ddl_log_write_fail", error= true;);
   if (error)
   {
     if (log_entry)
       ddl_log_release_memory_entry(log_entry);
+    mysql_mutex_unlock(&LOCK_gdl);
     DBUG_RETURN(1);
   }
+  mysql_mutex_unlock(&LOCK_gdl);
   ddl_log_add_entry(ddl_state, log_entry);
   ddl_state->flags|= ddl_log_entry->flags;      // Update cache
   DBUG_RETURN(0);

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -605,7 +605,7 @@ fil_space_extend_must_retry(
 	*success = os_file_set_size(node->name, node->handle, new_size,
 				    node->punch_hole == 1);
 
-	os_has_said_disk_full = *success;
+	os_has_said_disk_full = !*success;
 	if (*success) {
 		os_file_flush(node->handle);
 		last_page_no = size;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2161,6 +2161,11 @@ convert_error_code_to_mysql(
 		return(HA_ERR_RECORD_FILE_FULL);
 
 	case DB_TEMP_FILE_WRITE_FAIL:
+		/* This error can happen during
+		copy_data_between_tables() or bulk insert operation */
+		innodb_transaction_abort(thd,
+					 innobase_rollback_on_timeout,
+					 error);
 		my_error(ER_GET_ERRMSG, MYF(0),
                          DB_TEMP_FILE_WRITE_FAIL,
                          ut_strerr(DB_TEMP_FILE_WRITE_FAIL),
@@ -15931,7 +15936,7 @@ ha_innobase::extra(
 		}
 		m_prebuilt->table->skip_alter_undo = 0;
 		if (dberr_t err= trx->bulk_insert_apply<TRX_DDL_BULK>()) {
-			m_prebuilt->table->skip_alter_undo = 0;
+			trx->rollback();
 			return convert_error_code_to_mysql(
 				 err, m_prebuilt->table->flags,
 				 trx->mysql_thd);

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -398,12 +398,17 @@ start_log:
 		}
 
 		log->tail.blocks++;
+		DBUG_EXECUTE_IF("os_file_write_fail",
+				log->error = DB_TEMP_FILE_WRITE_FAIL;
+				goto write_failed;);
+
 		if (os_file_write(
 			    IORequestWrite,
 			    "(modification log)",
 			    log->fd,
 			    buf, byte_offset, srv_sort_buf_size)
 		    != DB_SUCCESS) {
+			log->error = DB_TEMP_FILE_WRITE_FAIL;
 write_failed:
 			index->type |= DICT_CORRUPT;
 		}

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -5177,6 +5177,9 @@ dberr_t row_merge_bulk_t::write_to_tmp_file(ulint index_no)
                        m_block, m_crypt_block,
                        buf->index->table->space->id))
     return DB_TEMP_FILE_WRITE_FAIL;
+
+  DBUG_EXECUTE_IF("write_to_tmp_file_fail",
+                  return DB_TEMP_FILE_WRITE_FAIL;);
   MEM_UNDEFINED(&m_block[0], srv_sort_buf_size);
   return DB_SUCCESS;
 }

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -708,6 +708,7 @@ handle_new_error:
 	case DB_DEADLOCK:
 	case DB_RECORD_CHANGED:
 	case DB_LOCK_TABLE_FULL:
+	case DB_TEMP_FILE_WRITE_FAIL:
 	rollback:
 		/* Roll back the whole transaction; this resolution was added
 		to version 3.23.43 */

--- a/storage/innobase/row/row0umod.cc
+++ b/storage/innobase/row/row0umod.cc
@@ -1130,9 +1130,8 @@ row_undo_mod_upd_exist_sec(
 		dtuple_t* entry = row_build_index_entry(
 			node->row, node->ext, index, heap);
 		if (UNIV_UNLIKELY(!entry)) {
-			/* The server must have crashed in
-			row_upd_clust_rec_by_insert() before
-			the updated externally stored columns (BLOBs)
+			/* InnoDB must have run of space or been killed
+			before the updated externally stored columns (BLOBs)
 			of the new clustered index entry were written. */
 
 			/* The table must be in DYNAMIC or COMPRESSED
@@ -1140,19 +1139,6 @@ row_undo_mod_upd_exist_sec(
 			store a local 768-byte prefix of each
 			externally stored column. */
 			ut_a(dict_table_has_atomic_blobs(index->table));
-
-			/* This is only legitimate when
-			rolling back an incomplete transaction
-			after crash recovery. */
-			ut_a(thr_get_trx(thr)->is_recovered);
-
-			/* The server must have crashed before
-			completing the insert of the new
-			clustered index entry and before
-			inserting to the secondary indexes.
-			Because node->row was not yet written
-			to this index, we can ignore it.  But
-			we must restore node->undo_row. */
 		} else {
 			/* NOTE that if we updated the fields of a
 			delete-marked secondary index record so that

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -1414,16 +1414,11 @@ row_upd_changes_ord_field_binary_func(
 			if (UNIV_LIKELY_NULL(buf)) {
 				if (UNIV_UNLIKELY(buf == field_ref_zero)) {
 					/* The externally stored field
-					was not written yet. This
-					record should only be seen by
-					trx_rollback_recovered()
-					when the server had crashed before
-					storing the field. */
-					ut_ad(!thr
-					      || thr->graph->trx->is_recovered);
-					ut_ad(!thr
-					      || thr->graph->trx
-					         == trx_roll_crash_recv_trx);
+					was not written yet. InnoDB must
+					have ran out of space or been killed
+					before storing the page */
+					ut_ad(thr);
+					ut_ad(thr->graph->trx->in_rollback);
 					return(TRUE);
 				}
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36017*

## Description
Problem:
=======
- In 10.11, During Copy algorithm, InnoDB does use bulk insert for row by row insert operation. When temporary directory ran out of memory, row_mysql_handle_errors() fails to handle DB_TEMP_FILE_WRITE_FAIL.

- During inplace algorithm, concurrent DML fails to write the log operation into the temporary file. InnoDB fail to mark the error for the online log.

Fix:
===
row_mysql_handle_errors(): Rollback the transaction when InnoDB encounters DB_TEMP_FILE_WRITE_FAIL

convert_error_code_to_mysql(): Report an aborted transaction when InnoDB encounters DB_TEMP_FILE_WRITE_FAIL

row_log_online_op(): Mark the error in online log when InnoDB ran out of temporary space

## How can this PR be tested?
./mtr innodb.alter_temp_fail

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
