### PR TITLE
MDEV-36017 Alter table aborts when temporary directory is full

### DIFF
--- a/mysql-test/suite/innodb/r/alter_temp_fail.result
+++ b/mysql-test/suite/innodb/r/alter_temp_fail.result
@@ -1,0 +1,25 @@
+#
+# MDEV-36017 Alter table aborts when temporary
+#                directory is full
+#
+CREATE TABLE t1(f1 INT NOT NULL, f2 CHAR(100),
+f3 CHAR(100))ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, 'a', 'b' FROM seq_1_to_4096;
+SET DEBUG_SYNC="inplace_after_index_build SIGNAL dml_start WAIT_FOR dml_commit";
+ALTER TABLE t1 ADD KEY(f1), ADD INDEX(f3(10));
+connect con1,localhost,root,,,;
+SET DEBUG_SYNC="now WAIT_FOR dml_start";
+BEGIN;
+INSERT INTO t1 SELECT * FROM t1;
+SET STATEMENT DEBUG_DBUG="+d,os_file_write_fail" FOR COMMIT;
+SET DEBUG_SYNC="now SIGNAL dml_commit";
+connection default;
+ERROR HY000: Temporary file write failure
+disconnect con1;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;
+SET STATEMENT DEBUG_DBUG="+d,ddl_log_write_fail" FOR
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/alter_temp_fail.opt
+++ b/mysql-test/suite/innodb/t/alter_temp_fail.opt
@@ -1,0 +1,1 @@
+--innodb_sort_buffer_size=64k

--- a/mysql-test/suite/innodb/t/alter_temp_fail.test
+++ b/mysql-test/suite/innodb/t/alter_temp_fail.test
@@ -1,0 +1,30 @@
+--source include/have_innodb.inc
+--source include/have_sequence.inc
+--source include/have_debug.inc
+--echo #
+--echo # MDEV-36017 Alter table aborts when temporary
+--echo #                directory is full
+--echo #
+CREATE TABLE t1(f1 INT NOT NULL, f2 CHAR(100),
+		f3 CHAR(100))ENGINE=InnoDB;
+INSERT INTO t1 SELECT seq, 'a', 'b' FROM seq_1_to_4096;
+SET DEBUG_SYNC="inplace_after_index_build SIGNAL dml_start WAIT_FOR dml_commit";
+SEND ALTER TABLE t1 ADD KEY(f1), ADD INDEX(f3(10));
+
+connect(con1,localhost,root,,,);
+SET DEBUG_SYNC="now WAIT_FOR dml_start";
+BEGIN;
+INSERT INTO t1 SELECT * FROM t1;
+SET STATEMENT DEBUG_DBUG="+d,os_file_write_fail" FOR COMMIT;
+SET DEBUG_SYNC="now SIGNAL dml_commit";
+
+connection default;
+--error ER_TEMP_FILE_WRITE_FAILURE
+reap;
+disconnect con1;
+CHECK TABLE t1;
+DROP TABLE t1;
+
+SET STATEMENT DEBUG_DBUG="+d,ddl_log_write_fail" FOR
+CREATE TABLE t1(f1 INT NOT NULL)ENGINE=InnoDB;
+DROP TABLE t1;

--- a/sql/ddl_log.cc
+++ b/sql/ddl_log.cc
@@ -3029,13 +3029,15 @@ static bool ddl_log_write(DDL_LOG_STATE *ddl_state,
   error= ((ddl_log_write_entry(ddl_log_entry, &log_entry)) ||
           ddl_log_write_execute_entry(log_entry->entry_pos,
                                       &ddl_state->execute_entry));
-  mysql_mutex_unlock(&LOCK_gdl);
+  DBUG_EXECUTE_IF("ddl_log_write_fail", error= true;);
   if (error)
   {
     if (log_entry)
       ddl_log_release_memory_entry(log_entry);
+    mysql_mutex_unlock(&LOCK_gdl);
     DBUG_RETURN(1);
   }
+  mysql_mutex_unlock(&LOCK_gdl);
   add_log_entry(ddl_state, log_entry);
   ddl_state->flags|= ddl_log_entry->flags;      // Update cache
   DBUG_RETURN(0);

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -591,7 +591,7 @@ fil_space_extend_must_retry(
 	*success = os_file_set_size(node->name, node->handle, new_size,
 				    node->punch_hole == 1);
 
-	os_has_said_disk_full = *success;
+	os_has_said_disk_full = !*success;
 	if (*success) {
 		os_file_flush(node->handle);
 		last_page_no = size;

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -398,12 +398,17 @@ start_log:
 		}
 
 		log->tail.blocks++;
+		DBUG_EXECUTE_IF("os_file_write_fail",
+				log->error = DB_TEMP_FILE_WRITE_FAIL;
+				goto write_failed;);
+
 		if (os_file_write(
 			    IORequestWrite,
 			    "(modification log)",
 			    log->fd,
 			    buf, byte_offset, srv_sort_buf_size)
 		    != DB_SUCCESS) {
+			log->error = DB_TEMP_FILE_WRITE_FAIL;
 write_failed:
 			index->type |= DICT_CORRUPT;
 		}

--- a/storage/innobase/row/row0umod.cc
+++ b/storage/innobase/row/row0umod.cc
@@ -1128,9 +1128,8 @@ row_undo_mod_upd_exist_sec(
 		dtuple_t* entry = row_build_index_entry(
 			node->row, node->ext, index, heap);
 		if (UNIV_UNLIKELY(!entry)) {
-			/* The server must have crashed in
-			row_upd_clust_rec_by_insert() before
-			the updated externally stored columns (BLOBs)
+			/* InnoDB must have run of space or been killed
+			before the updated externally stored columns (BLOBs)
 			of the new clustered index entry were written. */
 
 			/* The table must be in DYNAMIC or COMPRESSED
@@ -1138,19 +1137,6 @@ row_undo_mod_upd_exist_sec(
 			store a local 768-byte prefix of each
 			externally stored column. */
 			ut_a(dict_table_has_atomic_blobs(index->table));
-
-			/* This is only legitimate when
-			rolling back an incomplete transaction
-			after crash recovery. */
-			ut_a(thr_get_trx(thr)->is_recovered);
-
-			/* The server must have crashed before
-			completing the insert of the new
-			clustered index entry and before
-			inserting to the secondary indexes.
-			Because node->row was not yet written
-			to this index, we can ignore it.  But
-			we must restore node->undo_row. */
 		} else {
 			/* NOTE that if we updated the fields of a
 			delete-marked secondary index record so that

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -1414,16 +1414,11 @@ row_upd_changes_ord_field_binary_func(
 			if (UNIV_LIKELY_NULL(buf)) {
 				if (UNIV_UNLIKELY(buf == field_ref_zero)) {
 					/* The externally stored field
-					was not written yet. This
-					record should only be seen by
-					trx_rollback_recovered()
-					when the server had crashed before
-					storing the field. */
-					ut_ad(!thr
-					      || thr->graph->trx->is_recovered);
-					ut_ad(!thr
-					      || thr->graph->trx
-					         == trx_roll_crash_recv_trx);
+					was not written yet. InnoDB must
+					have ran out of space or been killed
+					before storing the page */
+					ut_ad(thr);
+					ut_ad(thr->graph->trx->in_rollback);
 					return(TRUE);
 				}
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36017*

## Description
Problem:
=======
- During inplace algorithm, concurrent DML fails to write the log operation into the temporary file. InnoDB fail to mark the error for the online log.

Fix:
===
row_log_online_op(): Mark the error in online log when InnoDB ran out of temporary spac

## How can this PR be tested?
./mtr innodb.alter_temp_fail

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
