### PR TITLE
MDEV-24035 fixup: GCC 4.8.5 CMAKE_BUILD_TYPE=Debug

### DIFF
--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -452,7 +452,7 @@ void trx_t::free()
 /** Transition to committed state, to release implicit locks. */
 TRANSACTIONAL_INLINE inline void trx_t::commit_state()
 {
-  ut_d(auto trx_state{state});
+  ut_d(auto trx_state= state);
   ut_ad(trx_state == TRX_STATE_PREPARED ||
         trx_state == TRX_STATE_PREPARED_RECOVERED ||
         trx_state == TRX_STATE_ACTIVE);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-24035*
## Description
MDEV-24035 (#3676) broke the `cmake -DCMAKE_BUILD_TYPE=Debug` build on GCC 4.8.5, which is not entirely C++11 compliant.
## Release Notes
N/A. GCC 4.8.5 was the default compiler of Red Hat Enterprise Linux 7, which is not under regular maintenance anymore.
## How can this PR be tested?
On RHEL 7:
```sh
cmake -DCMAKE_BUILD_TYPE=Debug .
make -j$(nproc) innobase
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.