### PR TITLE
MDEV-32084: Assertion in best_extension_by_limited_search() ...

### DIFF
--- a/mysql-test/main/join_nested.result
+++ b/mysql-test/main/join_nested.result
@@ -2051,3 +2051,15 @@ a	b	c	a	a	b
 DROP TABLE t1, t2, t3;
 set join_cache_level= @save_join_cache_level;
 # end of 10.3 tests
+#
+# MDEV-32084: Assertion in best_extension_by_limited_search(), or crash elsewhere in release
+#
+CREATE TABLE t1 (i int);
+INSERT INTO t1 values (1),(2);
+SELECT 1 FROM  t1 WHERE i IN
+(SELECT 1 FROM t1 c
+LEFT JOIN  (t1 a LEFT JOIN t1 b ON t1.i = b.i)  ON c.i = t1.i);
+1
+1
+DROP TABLE t1;
+# end of 10.11 tests

--- a/mysql-test/main/join_nested.test
+++ b/mysql-test/main/join_nested.test
@@ -1458,3 +1458,16 @@ DROP TABLE t1, t2, t3;
 set join_cache_level= @save_join_cache_level;
 
 --echo # end of 10.3 tests
+
+--echo #
+--echo # MDEV-32084: Assertion in best_extension_by_limited_search(), or crash elsewhere in release
+--echo #
+CREATE TABLE t1 (i int);
+INSERT INTO t1 values (1),(2);
+
+SELECT 1 FROM  t1 WHERE i IN
+  (SELECT 1 FROM t1 c
+    LEFT JOIN  (t1 a LEFT JOIN t1 b ON t1.i = b.i)  ON c.i = t1.i);
+
+DROP TABLE t1;
+--echo # end of 10.11 tests

--- a/mysql-test/main/join_nested_jcl6.result
+++ b/mysql-test/main/join_nested_jcl6.result
@@ -2060,6 +2060,18 @@ a	b	c	a	a	b
 DROP TABLE t1, t2, t3;
 set join_cache_level= @save_join_cache_level;
 # end of 10.3 tests
+#
+# MDEV-32084: Assertion in best_extension_by_limited_search(), or crash elsewhere in release
+#
+CREATE TABLE t1 (i int);
+INSERT INTO t1 values (1),(2);
+SELECT 1 FROM  t1 WHERE i IN
+(SELECT 1 FROM t1 c
+LEFT JOIN  (t1 a LEFT JOIN t1 b ON t1.i = b.i)  ON c.i = t1.i);
+1
+1
+DROP TABLE t1;
+# end of 10.11 tests
 CREATE TABLE t5 (a int, b int, c int, PRIMARY KEY(a), KEY b_i (b));
 CREATE TABLE t6 (a int, b int, c int, PRIMARY KEY(a), KEY b_i (b));
 CREATE TABLE t7 (a int, b int, c int, PRIMARY KEY(a), KEY b_i (b));


### PR DESCRIPTION
When subquery with LEFT JOIN is converted into semi-join, it is possible to construct cases where the LEFT JOIN's ON expression refers to a table in the current select but not in the current join nest, for example, here "ON t4.col=t1.col" has this property:

  t1 SEMI JOIN (
    t2
    LEFT JOIN (t3 LEFT JOIN t4 ON t4.col=t1.col) ON expr
  )
Let's denote this as ON-EXPR-HAS-REF-OUTSIDE-NEST.

The optimizer handles LEFT JOINs like so:
- Outer join runtime requires that "inner tables follow outer" in any join order.
- Join optimizer enforces this by following table's dependencies as set in TABLE_LIST::dep_tables.
- The dep_tables are set in simplify_joins() according to the contents of ON expressions and LEFT JOIN structure.

However, the logic in simplify_joins() failed to account for possible ON-EXPR-HAS-REF-OUTSIDE-NEST. It assumed that references outside the current join nest could only be OUTER_REF_TABLE_BIT or RAND_TABLE_BIT.

The fix was to add the missing logic.


- [x] *The Jira issue number for this PR is: MDEV-32084*
