### PR TITLE
MDEV-36373 Bogus Warning: ... storage is corrupted

### DIFF
--- a/mysql-test/suite/innodb/r/stat_tables.result
+++ b/mysql-test/suite/innodb/r/stat_tables.result
@@ -101,3 +101,13 @@ DROP TABLE t1;
 CREATE TABLE t1 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
 DROP TABLE t1;
 # End of 10.6 tests
+#
+# MDEV-36373 Warning: ... persistent statistics storage is corrupted
+#
+CREATE TABLE t1 (c INT) ENGINE=InnoDB;
+SET STATEMENT tx_read_only=1 FOR ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	Engine-independent statistics collected
+test.t1	analyze	status	OK
+DROP TABLE t1;
+# End of 10.11 tests

--- a/mysql-test/suite/innodb/t/stat_tables.test
+++ b/mysql-test/suite/innodb/t/stat_tables.test
@@ -110,3 +110,12 @@ CREATE TABLE t1 (c1 INT) ENGINE=InnoDB STATS_PERSISTENT 1;
 DROP TABLE t1;
 
 --echo # End of 10.6 tests
+
+--echo #
+--echo # MDEV-36373 Warning: ... persistent statistics storage is corrupted
+--echo #
+CREATE TABLE t1 (c INT) ENGINE=InnoDB;
+SET STATEMENT tx_read_only=1 FOR ANALYZE TABLE t1;
+DROP TABLE t1;
+
+--echo # End of 10.11 tests

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5872,7 +5872,7 @@ dberr_t ha_innobase::statistics_init(dict_table_t *table, bool recalc)
           if (err == DB_STATS_DO_NOT_EXIST && table->stats_is_auto_recalc())
             goto recalc;
         }
-        if (err == DB_SUCCESS)
+        if (err == DB_SUCCESS || err == DB_READ_ONLY)
           return err;
         if (!recalc)
           break;
@@ -14934,6 +14934,7 @@ recalc:
 				ret = statistics_init(ib_table, is_analyze);
 				switch (ret) {
 				case DB_SUCCESS:
+				case DB_READ_ONLY:
 					break;
 				default:
 					goto error;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36373*
## Description
`ha_innobase::statistics_init()`, `ha_innobase::info_low()`: Correctly handle a `DB_READ_ONLY` return value from `dict_stats_save()`. Fixes up #3729.
## Release Notes
N/A. This regression is not present in any release.
## How can this PR be tested?
```sh
./mtr innodb.stat_tables
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.