### PR TITLE
MDEV-36378 Recognize innodb_purge_rseg_truncate_frequency

### DIFF
--- a/mysql-test/suite/sys_vars/t/sysvars_innodb.opt
+++ b/mysql-test/suite/sys_vars/t/sysvars_innodb.opt
@@ -1,2 +1,4 @@
---loose-innodb-flush-log-at-timeout=3
+--innodb
+--innodb-purge-rseg-truncate-frequency=64
+--innodb-flush-log-at-timeout=3
 --table_open_cache=200

--- a/mysql-test/suite/sys_vars/t/sysvars_innodb.test
+++ b/mysql-test/suite/sys_vars/t/sysvars_innodb.test
@@ -3,6 +3,10 @@
 --source include/not_valgrind.inc
 --source include/word_size.inc
 
+--disable_query_log
+call mtr.add_suppression("'innodb-purge-rseg-truncate-frequency' was removed");
+--enable_query_log
+
 --vertical_results
 --replace_regex /^\/\S+/PATH/ /\.\//PATH/
 select VARIABLE_NAME, SESSION_VALUE, DEFAULT_VALUE, VARIABLE_SCOPE, VARIABLE_TYPE, VARIABLE_COMMENT, NUMERIC_MIN_VALUE, NUMERIC_MAX_VALUE, NUMERIC_BLOCK_SIZE, ENUM_VALUE_LIST, READ_ONLY, COMMAND_LINE_ARGUMENT from information_schema.system_variables

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5220,7 +5220,7 @@ static int init_server_components()
       MARIADB_REMOVED_OPTION("innodb-log-optimize-ddl"),
       MARIADB_REMOVED_OPTION("innodb-lru-flush-size"),
       MARIADB_REMOVED_OPTION("innodb-page-cleaners"),
-      MARIADB_REMOVED_OPTION("innodb-purge-truncate-frequency"),
+      MARIADB_REMOVED_OPTION("innodb-purge-rseg-truncate-frequency"),
       MARIADB_REMOVED_OPTION("innodb-replication-delay"),
       MARIADB_REMOVED_OPTION("innodb-scrub-log"),
       MARIADB_REMOVED_OPTION("innodb-scrub-log-speed"),


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36378*
## Description
In #3483 there was a spelling mistake that somehow causes the deprecated parameter `innodb_purge_rseg_truncate_frequency` to be rejected at server startup.
## Release Notes
The start-up parameter `innodb_purge_rseg_truncate_frequency` that is deprecated and with no effect was not recognized as a valid start-up option. 
## How can this PR be tested?
```sh
./mtr sys_vars.sysvars_innodb
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.