### PR TITLE
MTR test to verify that Galera gcs.stateless flag works

### DIFF
--- a/mysql-test/suite/galera_3nodes/r/galera_sst_stateless.result
+++ b/mysql-test/suite/galera_3nodes/r/galera_sst_stateless.result
@@ -1,0 +1,11 @@
+connection node_2;
+connection node_1;
+connection node_1;
+connection node_2;
+connection node_3;
+connection node_3;
+connection node_2;
+connection node_3;
+# restart
+include/assert_grep.inc [DONOR]
+include/assert_grep.inc [DONOR]

--- a/mysql-test/suite/galera_3nodes/t/galera_sst_stateless.cnf
+++ b/mysql-test/suite/galera_3nodes/t/galera_sst_stateless.cnf
@@ -1,0 +1,8 @@
+!include ../galera_3nodes.cnf
+
+[mysqld.2]
+wsrep_provider_options="gcs.stateless=1"
+
+# make node3 prefer node2 for donor, but also allow other nodes
+[mysqld.3]
+wsrep_sst_donor=node2,

--- a/mysql-test/suite/galera_3nodes/t/galera_sst_stateless.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_sst_stateless.test
@@ -1,0 +1,46 @@
+#
+# Test that a node marked as stateless is not chosen as a donor.
+# For that purpose
+# - set stateless flag for node2 in .cnf
+# - configure node3 to prefer node2 as SST donor in .cnf
+# - force SST for node3 after node2 is fully initialized
+# - check that node2 was not chosen as SST donor
+#
+
+--source include/galera_cluster.inc
+--source include/big_test.inc
+
+--let $galera_connection_name = node_3
+--let $galera_server_number = 3
+--source include/galera_connect.inc
+
+--let $node_1=node_1
+--let $node_2=node_2
+--let $node_3=node_3
+--source suite/galera/include/auto_increment_offset_save.inc
+
+--connection node_3
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/mysqld.3/data/grastate.dat
+
+# make sure node_2 is ready to be a DONOR
+--connection node_2
+--let $wait_condition = SELECT VARIABLE_VALUE = 'ON' FROM performance_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready'
+--source include/wait_condition.inc
+
+--connection node_3
+--source include/start_mysqld.inc
+
+--source suite/galera/include/auto_increment_offset_restore.inc
+
+--let $assert_only_after = CURRENT_TEST
+--let $assert_text = DONOR
+--let $assert_select = DONOR
+
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_count = 6
+--source include/assert_grep.inc
+
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_count = 0
+--source include/assert_grep.inc


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-______*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Add an MTR tests to test the efficacy of gcs.stateless flag added to Galera in commit 6739948b871317c4c01f4ee054b24b663b0848f4 (scheduled for release 4.23)

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
