### PR TITLE
MDEV-32083 INSERT..SELECT crashes if target table appears in a derive…

### DIFF
--- a/mysql-test/main/insert_select.result
+++ b/mysql-test/main/insert_select.result
@@ -1031,5 +1031,15 @@ a
 DROP VIEW v1;
 DROP TABLE t1;
 #
+# MDEV-32083 INSERT..SELECT crashes if target table appears
+#             in a derived table within the SELECT clause
+#
+CREATE TABLE t1 (i int);
+CREATE TABLE t2 (i int);
+INSERT INTO t1 VALUES (1),(2);
+INSERT INTO t1
+SELECT (SELECT min(dt.a) FROM (SELECT 1 as a FROM t1) dt ORDER BY i, dt.a) FROM t1 tb;
+DROP TABLE t1, t2;
+#
 # End of 10.5 test
 #

--- a/mysql-test/main/insert_select.test
+++ b/mysql-test/main/insert_select.test
@@ -592,5 +592,21 @@ DROP VIEW v1;
 DROP TABLE t1;
 
 --echo #
+--echo # MDEV-32083 INSERT..SELECT crashes if target table appears
+--echo #             in a derived table within the SELECT clause
+--echo #
+
+CREATE TABLE t1 (i int);
+CREATE TABLE t2 (i int);
+
+INSERT INTO t1 VALUES (1),(2);
+
+INSERT INTO t1
+  SELECT (SELECT min(dt.a) FROM (SELECT 1 as a FROM t1) dt ORDER BY i, dt.a) FROM t1 tb;
+
+DROP TABLE t1, t2;
+
+
+--echo #
 --echo # End of 10.5 test
 --echo #

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -1198,6 +1198,14 @@ retry:
       DBUG_PRINT("info",
                  ("convert merged to materialization to resolve the conflict"));
       derived->change_refs_to_fields();
+      /*
+        Update JOIN::tmp_table_param to reflect new number of fields
+        and functions
+      */
+      SELECT_LEX *sl= derived->select_lex;
+      count_field_types(sl, &sl->join->tmp_table_param,
+                        sl->join->all_fields, 0);
+
       derived->set_materialized_derived();
       goto retry;
     }

--- a/sql/sql_derived.cc
+++ b/sql/sql_derived.cc
@@ -354,6 +354,13 @@ bool mysql_derived_merge(THD *thd, LEX *lex, TABLE_LIST *derived)
   if (derived->dt_handler)
   {
     derived->change_refs_to_fields();
+    /*
+      Update JOIN::tmp_table_param to reflect new number of fields
+      and functions
+    */
+    SELECT_LEX *sl= derived->select_lex;
+    count_field_types(sl, &sl->join->tmp_table_param, sl->join->all_fields, 0);
+
     derived->set_materialized_derived();
     DBUG_RETURN(FALSE);
   }
@@ -465,6 +472,13 @@ unconditional_materialization:
   }
 
   derived->change_refs_to_fields();
+  /*
+    Update JOIN::tmp_table_param to reflect new number of fields
+    and functions
+  */
+  SELECT_LEX *sl= derived->select_lex;
+  count_field_types(sl, &sl->join->tmp_table_param, sl->join->all_fields, 0);
+
   derived->set_materialized_derived();
   if (!derived->table || !derived->table->is_created())
     res= mysql_derived_create(thd, lex, derived);
@@ -1042,6 +1056,14 @@ bool mysql_derived_optimize(THD *thd, LEX *lex, TABLE_LIST *derived)
     if (derived->is_merged_derived())
     {
       derived->change_refs_to_fields();
+      /*
+        Update JOIN::tmp_table_param to reflect new number of fields
+        and functions
+      */
+      SELECT_LEX *sl= derived->select_lex;
+      count_field_types(sl, &sl->join->tmp_table_param,
+                        sl->join->all_fields, 0);
+
       derived->set_materialized_derived();
     }
     if ((res= mysql_derived_create(thd, lex, derived)))


### PR DESCRIPTION
…d table within the SELECT clause

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32083*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The cause if the problem is an outdated value of
`JOIN::tmp_table_param::field_count` after derived table materialization.

`JOIN::tmp_table_param` is initialized during `count_field_types()` (join preparation phase). A derived table may be marked as merged at this point, but later it may be forced to materialization. Materialized derived table provides other values for `JOIN::tmp_table_param`, so it is necessary to re-calculate them after switch to materialization

## Release Notes

## How can this PR be tested?
`./mtr insert_select`

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
