### PR TITLE
MDEV-36393 Test failure on galera_sr.GCF-572

### DIFF
--- a/mysql-test/suite/galera_sr/r/GCF-572.result
+++ b/mysql-test/suite/galera_sr/r/GCF-572.result
@@ -37,9 +37,6 @@ f1	f2
 SET SESSION wsrep_trx_fragment_size = 10000;
 START TRANSACTION;
 INSERT INTO t1 VALUE (10, 'node1');
-SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
-COUNT(*)
-0
 connection node_1a;
 INSERT INTO t1 VALUES(15, 'node2');
 connection node_1;
@@ -48,6 +45,7 @@ f1	f2
 1	node1
 5	node2
 10	node1
+15	node2
 INSERT INTO t1 VALUES(15, 'node1');
 ERROR 23000: Duplicate entry '15' for key 'PRIMARY'
 COMMIT;

--- a/mysql-test/suite/galera_sr/t/GCF-572.test
+++ b/mysql-test/suite/galera_sr/t/GCF-572.test
@@ -61,7 +61,6 @@ SET SESSION wsrep_trx_fragment_size = 10000;
 
 START TRANSACTION;
 INSERT INTO t1 VALUE (10, 'node1');
-SELECT COUNT(*) FROM mysql.wsrep_streaming_log;
 
 --connection node_1a
 INSERT INTO t1 VALUES(15, 'node2');


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36393*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
Fix a regression on test galera_sr.GCF-572 introduced by commit c9a6adba. This commit partially reverted a trivial test fix for the galera_sr.GCF-572 test (commit 11ef59fb), which was targeted at 10.6.
This is backporting the fix from commit 11ef59fb fix to 10.5, so that the test stays the same all versions >= 10.5.

## Release Notes
Not needed.

## How can this PR be tested?
Run galera_sr.GCF-572. Make sure it passes.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
