### PR TITLE
MDEV-36359: Patch NULL deref after disabling semi-sync primary

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_master_disable_with_slave.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_master_disable_with_slave.result
@@ -1,0 +1,41 @@
+# Set up Semi-Sync with rpl_semi_sync_master_wait_no_slave=0
+include/master-slave.inc
+[connection master]
+SET @@GLOBAL.rpl_semi_sync_master_enabled= 1;
+SET @@GLOBAL.rpl_semi_sync_master_wait_no_slave= 0;
+connection slave;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= 1;
+include/start_slave.inc
+connection master;
+connection slave;
+connection master;
+SELECT ID INTO @binlog_dump_tid
+FROM information_schema.PROCESSLIST WHERE COMMAND = 'Binlog Dump';
+# Control State
+SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
+STATE
+Master has sent all binlog to slave; waiting for more updates
+SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+Variable_name	Value
+Rpl_semi_sync_master_clients	1
+# Disable Semi-Sync while the dump thread is still connected to its slave
+SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
+SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
+STATE
+Master has sent all binlog to slave; waiting for more updates
+SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+Variable_name	Value
+Rpl_semi_sync_master_clients	1
+# Disconnect the slave and wait until the master's dump thread is gone
+connection slave;
+STOP SLAVE;
+connection master;
+SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+Variable_name	Value
+Rpl_semi_sync_master_clients	0
+# Cleanup
+SET @@GLOBAL.rpl_semi_sync_master_enabled= 0;
+SET @@GLOBAL.rpl_semi_sync_master_wait_no_slave= 1;
+connection slave;
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= 0;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_master_disable_with_slave.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_master_disable_with_slave.test
@@ -1,0 +1,68 @@
+# MDEV-36359: Master crashes when reverting to async after Semi-Sync disabled.
+#
+# Assert behavior of turning Semi-Sync off on
+# the master when still connected to a slave
+
+--source include/have_binlog_format_mixed.inc # format-agnostic
+
+--echo # Set up Semi-Sync with rpl_semi_sync_master_wait_no_slave=0
+--let $rpl_skip_start_slave= 1
+--source include/master-slave.inc
+
+--let $orig_master_enabled=`SELECT @@GLOBAL.rpl_semi_sync_master_enabled`
+SET @@GLOBAL.rpl_semi_sync_master_enabled= 1;
+--let $orig_wait_no_slave=`SELECT @@GLOBAL.rpl_semi_sync_master_wait_no_slave`
+SET @@GLOBAL.rpl_semi_sync_master_wait_no_slave= 0;
+
+--connection slave
+--let $orig_slave_enabled=`SELECT @@GLOBAL.rpl_semi_sync_slave_enabled`
+SET @@GLOBAL.rpl_semi_sync_slave_enabled= 1;
+--source include/start_slave.inc
+
+--connection master
+# Make sure Semi-Sync is active
+--let $status_var= Rpl_semi_sync_master_status
+--let $status_var_value= ON
+--source include/wait_for_status_var.inc
+
+--sync_slave_with_master
+--connection master
+
+--disable_cursor_protocol
+SELECT ID INTO @binlog_dump_tid
+  FROM information_schema.PROCESSLIST WHERE COMMAND = 'Binlog Dump';
+--enable_cursor_protocol
+
+--echo # Control State
+SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
+SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+
+--echo # Disable Semi-Sync while the dump thread is still connected to its slave
+SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
+--let $status_var_value= OFF
+--source include/wait_for_status_var.inc
+
+SELECT STATE FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid;
+SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+
+--echo # Disconnect the slave and wait until the master's dump thread is gone
+--connection slave
+STOP SLAVE;
+# Starting with MDEV-13073,
+# Semi-Sync STOP SLAVE also terminates its dump thread on the master.
+--connection master
+
+# MDEV-36359: The disconnection would crash the master and leave the wait with
+# error 2013 'Lost connection to server during query'
+--let $wait_condition= SELECT COUNT(*)=0 FROM information_schema.PROCESSLIST WHERE ID = @binlog_dump_tid
+--source include/wait_condition.inc
+SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
+
+--echo # Cleanup
+--eval SET @@GLOBAL.rpl_semi_sync_master_enabled= $orig_master_enabled
+--eval SET @@GLOBAL.rpl_semi_sync_master_wait_no_slave= $orig_wait_no_slave
+--connection slave
+--eval SET @@GLOBAL.rpl_semi_sync_slave_enabled= $orig_slave_enabled
+
+--let $rpl_only_running_threads= 1
+--source include/rpl_end.inc

--- a/sql/semisync_master.cc
+++ b/sql/semisync_master.cc
@@ -565,12 +565,14 @@ void Repl_semi_sync_master::remove_slave()
 {
   lock();
   DBUG_ASSERT(rpl_semi_sync_master_clients > 0);
-  if (!(--rpl_semi_sync_master_clients) && !rpl_semi_sync_master_wait_no_slave)
+  if (!(--rpl_semi_sync_master_clients) && !rpl_semi_sync_master_wait_no_slave
+      && get_master_enabled())
   {
     /*
       Signal transactions waiting in commit_trx() that they do not have to
       wait anymore.
     */
+    DBUG_ASSERT(m_active_tranxs);
     m_active_tranxs->clear_active_tranx_nodes(NULL, 0,
                                               signal_waiting_transaction);
   }


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-36359](https://jira.mariadb.org/browse/MDEV-36359)*

## Description
### The Bug
Under `@@rpl_semi_sync_master_wait_no_slave = 0`, when `rpl_semi_sync_master_clients` decrements to zero, the primary reverts to async replication.
This code did not check whether Semi-Sync is still globally enabled or not as it didn’t matter before.

However, after #3089 ([MDEV-33551](https://jira.mariadb.org/browse/MDEV-33551)) split the transactions’ACK condition variables to per-transaction, this function now needs Semi-Sync’s transaction tracker to unblock these condition variables in batch, but this tracker is `NULL` when Semi-Sync Primary is disabled.

### Background
* FWIW, the Semi-Sync Primary subsystem can “orphanate” its Binlog Dump threads(’ connection to their replicas) when it disables (`SET @@rpl_semi_sync_master_enabled = 0`) while they remain connected.
  ```console
  $ SET @@GLOBAL.rpl_semi_sync_master_enabled = 0;
  $ SELECT STATE FROM information_schema.PROCESSLIST WHERE COMMAND = 'Binlog Dump';
  STATE
  Master has sent all binlog to slave; waiting for more updates
  $ SHOW STATUS LIKE 'Rpl_semi_sync_master_clients';
  Variable_name	Value
  Rpl_semi_sync_master_clients	1
  ```
* *The code for “automatic revert to async” is not an active function, but rather passive behaviors of various functions when the conditions are met.*

Stateful component are okay, but Schrödinger Boxes? Not so much.

## Release Notes
* Fix primary crash when it reverts to async replication after its Semi-Synchronous Replication disabled while still connected to replica(s).

## How can this PR be tested?
As demonstrated the included `rpl.rpl_semi_sync_master_disable_with_slave`:
1. Connect a Semi-Sync replica to a Semi-Sync, `@@rpl_semi_sync_master_wait_no_slave = 0` primary
2. Disable Semi-Sync on the primary
3. Disconnect the replica(’s IO thread) from replication
4. Observe the primary’s wellbeïng as the Binlog Dump thread exits
5. (optional) Reconnect the replica and confirm success

## PR quality check
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
  * This is a **crash** in a criticals-only version series.
    The higher-ups locked those branches against “unnecessary” pushes, so I added one as a assignee on this PR.
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.