### PR TITLE
MDEV-36420 Assertion failure in SET GLOBAL innodb_ft_aux_table

### DIFF
--- a/mysql-test/suite/innodb_fts/r/innodb_ft_aux_table.result
+++ b/mysql-test/suite/innodb_fts/r/innodb_ft_aux_table.result
@@ -118,4 +118,13 @@ KEY	VALUE
 SELECT @@GLOBAL.innodb_ft_aux_table;
 @@GLOBAL.innodb_ft_aux_table
 test/t1
+CREATE TABLE t(a INT) ENGINE=InnoDB;
+SET GLOBAL innodb_ft_aux_table='test/t';
+ERROR 42000: Variable 'innodb_ft_aux_table' can't be set to the value of 'test/t'
+DROP TABLE t;
+SET GLOBAL innodb_ft_aux_table='test/t';
+ERROR 42000: Variable 'innodb_ft_aux_table' can't be set to the value of 'test/t'
+SELECT @@GLOBAL.innodb_ft_aux_table;
+@@GLOBAL.innodb_ft_aux_table
+test/t1
 SET GLOBAL innodb_ft_aux_table = @save_ft_aux_table;

--- a/mysql-test/suite/innodb_fts/t/innodb_ft_aux_table.test
+++ b/mysql-test/suite/innodb_fts/t/innodb_ft_aux_table.test
@@ -41,4 +41,13 @@ SELECT * FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE;
 SELECT * FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE;
 SELECT * FROM INFORMATION_SCHEMA.INNODB_FT_CONFIG;
 SELECT @@GLOBAL.innodb_ft_aux_table;
+
+CREATE TABLE t(a INT) ENGINE=InnoDB;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_ft_aux_table='test/t';
+DROP TABLE t;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_ft_aux_table='test/t';
+SELECT @@GLOBAL.innodb_ft_aux_table;
+
 SET GLOBAL innodb_ft_aux_table = @save_ft_aux_table;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -17541,8 +17541,9 @@ static int innodb_ft_aux_table_validate(THD *thd, st_mysql_sys_var*,
 				*static_cast<const char**>(save) = table_name;
 				return 0;
 			}
+		} else {
+			dict_sys.unlock();
 		}
-		dict_sys.unlock();
 		return 1;
 	} else {
 		*static_cast<char**>(save) = NULL;


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36420*
## Description
`innodb_ft_aux_table_validate()`: If the table is found in InnoDB but not valid for the parameter, only invoke `dict_sys.unlock()` once.

This fixes a regression due to #3856.
## Release Notes
N/A. This regression will not be present in any release.
## How can this PR be tested?
```sh
./mtr innodb_fts.innodb_ft_aux_table
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.