### PR TITLE
MDEV-36167 Assertion in Item_sum_st with st_collect and group by

### DIFF
--- a/mysql-test/main/spatial_utility_function_collect.combinations
+++ b/mysql-test/main/spatial_utility_function_collect.combinations
@@ -1,0 +1,9 @@
+[myisam]
+default-storage-engine=myisam
+
+[innodb]
+innodb
+default-storage-engine=innodb
+
+[aria]
+default-storage-engine=aria

--- a/mysql-test/main/spatial_utility_function_collect.result
+++ b/mysql-test/main/spatial_utility_function_collect.result
@@ -16,11 +16,23 @@ table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,0 0,1 0,2
 0,3 0) ',4326)) c;
 c
 1
+# Functional requirement F-8 Shall support DISTINCT in aggregates
+# result shall be 1
 SELECT ST_EQUALS( (SELECT ST_COLLECT( DISTINCT location ) AS t FROM
 table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,1 0,2 0,3
 0) ',4326)) c;
 c
 1
+# Functional requirement F-5: ST_COLLECT shall support group by, which
+# is given by aggregation machinery
+# result shall be
+# MULTIPOINT(0 0,1 0,3 0)
+# MULTIPOINT(2 0,0 0)
+SELECT ST_ASTEXT(ST_COLLECT( DISTINCT location )) AS t FROM
+table_simple_aggregation GROUP BY grouping_condition;
+t
+MULTIPOINT(0 0,1 0,3 0)
+MULTIPOINT(0 0,2 0)
 INSERT INTO table_simple_aggregation (location) VALUES
 ( ST_GEOMFROMTEXT('POINT(0 -0)'         ,4326)),
 ( NULL);
@@ -63,6 +75,48 @@ MULTIPOINT(0 -0)
 MULTIPOINT(0 -0)
 MULTIPOINT(0 -0)
 NULL
+Excercising multiple code paths.
+SELECT ST_ASTEXT(ST_COLLECT(DISTINCT location)) AS geo, SUM(running_number)
+OVER()  FROM table_simple_aggregation GROUP BY running_number;
+geo	SUM(running_number)
+OVER()
+MULTIPOINT(0 -0)	55
+MULTIPOINT(0 -0)	55
+MULTIPOINT(0 0)	55
+MULTIPOINT(0 0)	55
+MULTIPOINT(1 0)	55
+MULTIPOINT(2 0)	55
+MULTIPOINT(3 0)	55
+NULL	55
+NULL	55
+NULL	55
+SELECT ST_ASTEXT(ST_COLLECT(DISTINCT location)) AS geo, SUM(grouping_condition)
+OVER(), grouping_condition FROM table_simple_aggregation GROUP BY
+grouping_condition;
+geo	SUM(grouping_condition)
+OVER()	grouping_condition
+MULTIPOINT(0 -0)	1	NULL
+MULTIPOINT(0 0,1 0,3 0)	1	0
+MULTIPOINT(0 0,2 0)	1	1
+SELECT ST_ASTEXT(ST_COLLECT(location)) AS geo, SUM(grouping_condition) OVER(),
+grouping_condition FROM table_simple_aggregation GROUP BY grouping_condition;
+geo	SUM(grouping_condition) OVER()	grouping_condition
+MULTIPOINT(0 -0,0 -0)	1	NULL
+MULTIPOINT(0 0,1 0,3 0)	1	0
+MULTIPOINT(0 0,2 0)	1	1
+SELECT ST_ASTEXT(ST_COLLECT(location)) AS geo, SUM(running_number) OVER()  FROM
+table_simple_aggregation GROUP BY running_number;
+geo	SUM(running_number) OVER()
+MULTIPOINT(0 -0)	55
+MULTIPOINT(0 -0)	55
+MULTIPOINT(0 0)	55
+MULTIPOINT(0 0)	55
+MULTIPOINT(1 0)	55
+MULTIPOINT(2 0)	55
+MULTIPOINT(3 0)	55
+NULL	55
+NULL	55
+NULL	55
 set session group_concat_max_len= 10;
 SELECT ST_COLLECT( location ) AS t FROM table_simple_aggregation;
 t
@@ -83,6 +137,29 @@ INSERT INTO multi_srs_table( geometry ) VALUES
 # ST_COLLECT MUST raise ER_GIS_DIFFERENT_SRIDS.
 SELECT ST_ASTEXT(ST_COLLECT(geometry)) AS t FROM multi_srs_table;
 ERROR HY000: Arguments to function st_collect( contains geometries with different SRIDs: 4326 and 0. All geometries must have the same SRID.
+# F-2 b) If all the elements in an aggregate is of same SRS, ST_COLLECT
+# MUST return a result in that SRS.
+# result shall be one MULTIPOINT((60 -24),(61 -24)) with SRID 4326 and
+# one
+# Multipoint((38 77)) with SRID 0. There is some rounding issue on the
+# result, bug #31535105
+SELECT st_srid(geometry),ST_ASTEXT(ST_COLLECT( geometry )) AS t FROM
+multi_srs_table GROUP BY ST_SRID(geometry);
+st_srid(geometry)	t
+0	MULTIPOINT(38 77)
+4326	MULTIPOINT(60 -24,61 -24)
+Rollup needs all SRIDs to be the same.
+SELECT st_srid(geometry),ST_ASTEXT(ST_COLLECT( geometry )) AS t FROM
+multi_srs_table GROUP BY ST_SRID(geometry) WITH ROLLUP;
+ERROR HY000: Arguments to function st_collect( contains geometries with different SRIDs: 0 and 4326. All geometries must have the same SRID.
+# Triggering a codepath for geometrycollection in temp tables
+INSERT INTO multi_srs_table( geometry ) VALUES
+(ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(POINT(60 -24))'         ,4326));
+SELECT st_srid(geometry),ST_ASTEXT( geometry ) AS t FROM
+multi_srs_table GROUP BY ST_SRID(geometry);
+st_srid(geometry)	t
+0	POINT(38 77)
+4326	POINT(60 -24)
 #teardown of testing handling of multiple SRS
 DROP TABLE multi_srs_table;
 # setup of testing handling different geometry types
@@ -121,6 +198,35 @@ GEOMETRYCOLLECTION(POLYGON((4 0,0 0,0 4,4 4,4 0)),MULTIPOINT(5 0))
 GEOMETRYCOLLECTION(MULTIPOINT(5 0),MULTIPOINT(6 0))
 GEOMETRYCOLLECTION(MULTIPOINT(6 0),GEOMETRYCOLLECTION EMPTY)
 GEOMETRYCOLLECTION(GEOMETRYCOLLECTION EMPTY,GEOMETRYCOLLECTION EMPTY)
+# with DISTINCT this result is expected to be:
+# MP, GC, MLS, GC, MPpoly, GC, GC, GC, GC with only one EMPTY GC
+SELECT ST_ASTEXT(ST_COLLECT(DISTINCT geo) OVER( ORDER BY running_number ROWS BETWEEN 1
+PRECEDING AND CURRENT ROW)) AS geocollect FROM simple_table;
+geocollect
+MULTIPOINT(0 0)
+GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(1 0,1 1))
+MULTILINESTRING((1 0,1 1),(2 0,2 1))
+GEOMETRYCOLLECTION(LINESTRING(2 0,2 1),POLYGON((3 0,0 0,0 3,3 3,3 0)))
+MULTIPOLYGON(((3 0,0 0,0 3,3 3,3 0)),((4 0,0 0,0 4,4 4,4 0)))
+GEOMETRYCOLLECTION(POLYGON((4 0,0 0,0 4,4 4,4 0)),MULTIPOINT(5 0))
+GEOMETRYCOLLECTION(MULTIPOINT(5 0),MULTIPOINT(6 0))
+GEOMETRYCOLLECTION(MULTIPOINT(6 0),GEOMETRYCOLLECTION EMPTY)
+GEOMETRYCOLLECTION(GEOMETRYCOLLECTION EMPTY)
+# Exercising the "copy" constructor
+SELECT ST_ASTEXT(ST_COLLECT(geo)) FROM simple_table GROUP BY geo WITH ROLLUP;
+ST_ASTEXT(ST_COLLECT(geo))
+MULTIPOINT(0 0)
+MULTILINESTRING((2 0,2 1))
+MULTILINESTRING((1 0,1 1))
+MULTIPOLYGON(((3 0,0 0,0 3,3 3,3 0)))
+MULTIPOLYGON(((4 0,0 0,0 4,4 4,4 0)))
+GEOMETRYCOLLECTION(MULTIPOINT(5 0))
+GEOMETRYCOLLECTION(MULTIPOINT(6 0))
+GEOMETRYCOLLECTION(GEOMETRYCOLLECTION EMPTY,GEOMETRYCOLLECTION EMPTY)
+GEOMETRYCOLLECTION(POINT(0 0),LINESTRING(2 0,2 1),LINESTRING(1 0,1 1),POLYGON((3 0,0 0,0 3,3 3,3 0)),POLYGON((4 0,0 0,0 4,4 4,4 0)),MULTIPOINT(5 0),MULTIPOINT(6 0),GEOMETRYCOLLECTION EMPTY,GEOMETRYCOLLECTION EMPTY)
+# Casting Geometry as decimal invokes val_decimal()
+SELECT CAST(ST_COLLECT(geo) AS DECIMAL ) FROM simple_table;
+ERROR HY000: Illegal parameter data type geometry for operation 'decimal_typecast'
 DROP TABLE simple_table;
 #
 # MDEV-35102 CREATE TABLE AS SELECT ST_collect ... does not work
@@ -129,11 +235,6 @@ SELECT ST_astext(ST_collect(( POINTFROMTEXT(' POINT( 4 1 ) ') )));
 ST_astext(ST_collect(( POINTFROMTEXT(' POINT( 4 1 ) ') )))
 MULTIPOINT(4 1)
 CREATE TABLE tb1 AS SELECT (ST_collect(( POINTFROMTEXT(' POINT( 4 1 ) ') )) );
-SHOW CREATE TABLE tb1;
-Table	Create Table
-tb1	CREATE TABLE `tb1` (
-  `(ST_collect(( POINTFROMTEXT(' POINT( 4 1 ) ') )) )` geometry DEFAULT NULL
-) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci
 DROP TABLE tb1;
 #
 # MDEV-35975 Server crashes after CREATE VIEW as SELECT ST_COLLECT
@@ -142,3 +243,13 @@ create view v1 as SELECT ST_COLLECT(ST_GEOMFROMTEXT('POINT(0 0)'));
 drop view v1;
 create view v1 as SELECT GROUP_CONCAT(ST_GEOMFROMTEXT('POINT(0 0)'));
 drop view v1;
+#
+# MDEV-36167 Assertion `0' failed in Item_sum_str::reset_field after selecting st_collect + group by
+#
+CREATE TABLE t1 (a int, p point);
+INSERT INTO t1 (a, p) VALUES (0,st_geomfromtext('POINT(1 1)')), ( 1,st_geomfromtext('POINT(0 0)')), ( 0,st_geomfromtext('POINT(1 1)'));
+SELECT st_astext(ST_COLLECT(p)) FROM t1 GROUP BY a;
+st_astext(ST_COLLECT(p))
+MULTIPOINT(1 1,1 1)
+MULTIPOINT(0 0)
+DROP TABLE t1;

--- a/mysql-test/main/spatial_utility_function_collect.test
+++ b/mysql-test/main/spatial_utility_function_collect.test
@@ -33,24 +33,19 @@ INSERT INTO table_simple_aggregation ( grouping_condition, location ) VALUES
 SELECT ST_EQUALS( (SELECT ST_COLLECT( location ) AS t FROM
 table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,0 0,1 0,2
 0,3 0) ',4326)) c;
-# --echo # Functional requirement F-8 Shall support DISTINCT in aggregates
-# --echo # result shall be 1
+--echo # Functional requirement F-8 Shall support DISTINCT in aggregates
+--echo # result shall be 1
 SELECT ST_EQUALS( (SELECT ST_COLLECT( DISTINCT location ) AS t FROM
 table_simple_aggregation) , ST_GEOMFROMTEXT('MULTIPOINT(0 0,1 0,2 0,3
 0) ',4326)) c;
-# --echo # Functional requirement F-5: ST_COLLECT shall support group by, which
-# --echo # is given by aggregation machinery
-# --echo # result shall be
-# --echo # MULTIPOINT(0 0,1 0,3 0)
-# --echo # MULTIPOINT(2 0,0 0)
-# --sorted_result
-# SELECT ST_ASTEXT(ST_COLLECT( DISTINCT location )) AS t FROM
-# table_simple_aggregation GROUP BY grouping_condition;
-
-# --echo # Distinct with rollup
-# SELECT st_astext(ST_COLLECT( distinct location )) AS t from
-# table_simple_aggregation group by st_latitude(location) with rollup;
-
+--echo # Functional requirement F-5: ST_COLLECT shall support group by, which
+--echo # is given by aggregation machinery
+--echo # result shall be
+--echo # MULTIPOINT(0 0,1 0,3 0)
+--echo # MULTIPOINT(2 0,0 0)
+--sorted_result
+SELECT ST_ASTEXT(ST_COLLECT( DISTINCT location )) AS t FROM
+table_simple_aggregation GROUP BY grouping_condition;
 
 INSERT INTO table_simple_aggregation (location) VALUES
 ( ST_GEOMFROMTEXT('POINT(0 -0)'         ,4326)),
@@ -81,20 +76,20 @@ SELECT ST_ASTEXT(ST_COLLECT(location) OVER ( ROWS BETWEEN 1 PRECEDING AND
 CURRENT ROW)) c FROM table_simple_aggregation;
 
 
-# --echo Excercising multiple code paths.
-# --sorted_result
-# SELECT ST_ASTEXT(ST_COLLECT(DISTINCT location)) AS geo, SUM(running_number)
-# OVER()  FROM table_simple_aggregation GROUP BY running_number;
-# --sorted_result
-# SELECT ST_ASTEXT(ST_COLLECT(DISTINCT location)) AS geo, SUM(grouping_condition)
-# OVER(), grouping_condition FROM table_simple_aggregation GROUP BY
-# grouping_condition;
-# --sorted_result
-# SELECT ST_ASTEXT(ST_COLLECT(location)) AS geo, SUM(grouping_condition) OVER(),
-# grouping_condition FROM table_simple_aggregation GROUP BY grouping_condition;
-# --sorted_result
-# SELECT ST_ASTEXT(ST_COLLECT(location)) AS geo, SUM(running_number) OVER()  FROM
-# table_simple_aggregation GROUP BY running_number;
+--echo Excercising multiple code paths.
+--sorted_result
+SELECT ST_ASTEXT(ST_COLLECT(DISTINCT location)) AS geo, SUM(running_number)
+OVER()  FROM table_simple_aggregation GROUP BY running_number;
+--sorted_result
+SELECT ST_ASTEXT(ST_COLLECT(DISTINCT location)) AS geo, SUM(grouping_condition)
+OVER(), grouping_condition FROM table_simple_aggregation GROUP BY
+grouping_condition;
+--sorted_result
+SELECT ST_ASTEXT(ST_COLLECT(location)) AS geo, SUM(grouping_condition) OVER(),
+grouping_condition FROM table_simple_aggregation GROUP BY grouping_condition;
+--sorted_result
+SELECT ST_ASTEXT(ST_COLLECT(location)) AS geo, SUM(running_number) OVER()  FROM
+table_simple_aggregation GROUP BY running_number;
 
 --enable_warnings
 set session group_concat_max_len= 10;
@@ -120,28 +115,27 @@ INSERT INTO multi_srs_table( geometry ) VALUES
 --echo # ST_COLLECT MUST raise ER_GIS_DIFFERENT_SRIDS.
 --error ER_GIS_DIFFERENT_SRIDS_AGGREGATION
 SELECT ST_ASTEXT(ST_COLLECT(geometry)) AS t FROM multi_srs_table;
-# TODO fix this
-# --echo # F-2 b) If all the elements in an aggregate is of same SRS, ST_COLLECT
-# --echo # MUST return a result in that SRS.
-# --echo # result shall be one MULTIPOINT((60 -24),(61 -24)) with SRID 4326 and
-# --echo # one
-# --echo # Multipoint((38 77)) with SRID 0. There is some rounding issue on the
-# --echo # result, bug #31535105
-# --sorted_result
-# SELECT st_srid(geometry),ST_ASTEXT(ST_COLLECT( geometry )) AS t FROM
-# multi_srs_table GROUP BY ST_SRID(geometry);
+--echo # F-2 b) If all the elements in an aggregate is of same SRS, ST_COLLECT
+--echo # MUST return a result in that SRS.
+--echo # result shall be one MULTIPOINT((60 -24),(61 -24)) with SRID 4326 and
+--echo # one
+--echo # Multipoint((38 77)) with SRID 0. There is some rounding issue on the
+--echo # result, bug #31535105
+--sorted_result
+SELECT st_srid(geometry),ST_ASTEXT(ST_COLLECT( geometry )) AS t FROM
+multi_srs_table GROUP BY ST_SRID(geometry);
 
-# --echo Rollup needs all SRIDs to be the same.
-# --error ER_GIS_DIFFERENT_SRIDS_AGGREGATION
-# SELECT st_srid(geometry),ST_ASTEXT(ST_COLLECT( geometry )) AS t FROM
-# multi_srs_table GROUP BY ST_SRID(geometry) WITH ROLLUP;
+--echo Rollup needs all SRIDs to be the same.
+--error ER_GIS_DIFFERENT_SRIDS_AGGREGATION
+SELECT st_srid(geometry),ST_ASTEXT(ST_COLLECT( geometry )) AS t FROM
+multi_srs_table GROUP BY ST_SRID(geometry) WITH ROLLUP;
 
-# --echo # Triggering a codepath for geometrycollection in temp tables
-# INSERT INTO multi_srs_table( geometry ) VALUES
-# (ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(POINT(60 -24))'         ,4326));
-# --sorted_result
-# SELECT st_srid(geometry),ST_ASTEXT(ST_COLLECT( geometry )) AS t FROM
-# multi_srs_table GROUP BY ST_SRID(geometry);
+--echo # Triggering a codepath for geometrycollection in temp tables
+INSERT INTO multi_srs_table( geometry ) VALUES
+(ST_GEOMFROMTEXT('GEOMETRYCOLLECTION(POINT(60 -24))'         ,4326));
+--sorted_result
+SELECT st_srid(geometry),ST_ASTEXT( geometry ) AS t FROM
+multi_srs_table GROUP BY ST_SRID(geometry);
 
 
 --echo #teardown of testing handling of multiple SRS
@@ -175,18 +169,17 @@ INSERT INTO simple_table ( geo) VALUES
 --echo # GC, GC, GC, GC
 SELECT ST_ASTEXT(ST_COLLECT(geo) OVER( ORDER BY running_number ROWS BETWEEN 1
 PRECEDING AND CURRENT ROW)) AS geocollect  FROM simple_table;
-# --echo # with DISTINCT this result is expected to be:
-# --echo # GEMETRYCOLLECTION(GEOMETRYCOLLECTION EMPTY)
-# --echo # GEMETRYCOLLECTION(GEOMETRYCOLLECTION EMPTY)
-# SELECT ST_ASTEXT(ST_COLLECT( DISTINCT geo) OVER( ORDER BY running_number ROWS
-# BETWEEN 1 PRECEDING AND CURRENT ROW)) AS geocollect  FROM simple_table WHERE
-# ST_EQUALS(geo,ST_GEOMFROMTEXT('GEOMETRYCOLLECTION EMPTY'));
+--echo # with DISTINCT this result is expected to be:
+--echo # MP, GC, MLS, GC, MPpoly, GC, GC, GC, GC with only one EMPTY GC
+SELECT ST_ASTEXT(ST_COLLECT(DISTINCT geo) OVER( ORDER BY running_number ROWS BETWEEN 1
+PRECEDING AND CURRENT ROW)) AS geocollect FROM simple_table;
 
-# --echo # Exercising the "copy" constructor
-# SELECT ST_ASTEXT(ST_COLLECT(geo)) FROM simple_table GROUP BY geo WITH ROLLUP;
+--echo # Exercising the "copy" constructor
+SELECT ST_ASTEXT(ST_COLLECT(geo)) FROM simple_table GROUP BY geo WITH ROLLUP;
 
-# --echo # Casting Geometry as decimal invokes val_decimal()
-# SELECT CAST(ST_COLLECT(geo) AS DECIMAL ) FROM simple_table;
+--echo # Casting Geometry as decimal invokes val_decimal()
+--error ER_ILLEGAL_PARAMETER_DATA_TYPE_FOR_OPERATION
+SELECT CAST(ST_COLLECT(geo) AS DECIMAL ) FROM simple_table;
 
 DROP TABLE simple_table;
 
@@ -195,7 +188,6 @@ DROP TABLE simple_table;
 --echo #
 SELECT ST_astext(ST_collect(( POINTFROMTEXT(' POINT( 4 1 ) ') )));
 CREATE TABLE tb1 AS SELECT (ST_collect(( POINTFROMTEXT(' POINT( 4 1 ) ') )) );
-SHOW CREATE TABLE tb1;
 DROP TABLE tb1;
 
 --echo #
@@ -205,3 +197,11 @@ create view v1 as SELECT ST_COLLECT(ST_GEOMFROMTEXT('POINT(0 0)'));
 drop view v1;
 create view v1 as SELECT GROUP_CONCAT(ST_GEOMFROMTEXT('POINT(0 0)'));
 drop view v1;
+
+--echo #
+--echo # MDEV-36167 Assertion `0' failed in Item_sum_str::reset_field after selecting st_collect + group by
+--echo #
+CREATE TABLE t1 (a int, p point);
+INSERT INTO t1 (a, p) VALUES (0,st_geomfromtext('POINT(1 1)')), ( 1,st_geomfromtext('POINT(0 0)')), ( 0,st_geomfromtext('POINT(1 1)'));
+SELECT st_astext(ST_COLLECT(p)) FROM t1 GROUP BY a;
+DROP TABLE t1;

--- a/sql/item_sum.cc
+++ b/sql/item_sum.cc
@@ -4692,6 +4692,7 @@ Item_func_collect::Item_func_collect(THD *thd, bool is_distinct, Item *item_par)
   is_distinct(is_distinct),
   group_collect_max_len(thd->variables.group_concat_max_len)
 {
+  quick_group= false;
 }
 
 
@@ -4701,6 +4702,7 @@ Item_func_collect::Item_func_collect(THD *thd, bool is_distinct, Item_func_colle
   is_distinct(is_distinct),
   group_collect_max_len(thd->variables.group_concat_max_len)
 {
+  quick_group= false;
 }
 
 


### PR DESCRIPTION
The GIS function st_collect can now be used with GROUP BY.  Previously, such queries resulted in a crash because Item_func_stcollect did not specify quick_group = false and did not implement reset_field, update_field methods.

With quick_group as false, an implementation of Item_sum tells the SQL layer that the aggregate can be computed with the TemporaryTableWithPartialSums algorithm.  That is the case for st_collect.  This is convenient because the SQL layer will rely on the Item_sum to produce the correct, updated aggregate value for a given result field.  Otherwise, using reset_field and update_field implementations gives greater flexibility when computing the aggregate but requires more complexity.
