### PR TITLE
MDEV-36469 don't check is_infoschema_db for null db

### DIFF
--- a/sql/lex_ident.h
+++ b/sql/lex_ident.h
@@ -165,6 +165,7 @@ public:
 */
 class Lex_ident_db: public Lex_ident_fs
 {
+public:
   bool is_null() const
   {
     return length == 0 && str == NULL;
@@ -174,7 +175,6 @@ class Lex_ident_db: public Lex_ident_fs
   {
     return length == 0 && str != NULL;
   }
-public:
   static bool check_name(const LEX_CSTRING &str);
   static bool check_name_with_error(const LEX_CSTRING &str);
 public:

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -8111,7 +8111,8 @@ TABLE_LIST *st_select_lex::add_table_to_list(THD *thd,
     DBUG_RETURN(0);
   else
     fqtn= FALSE;
-  bool info_schema= is_infoschema_db(&db);
+  bool info_schema= (db.is_null() || db.is_empty())
+	            ? false : is_infoschema_db(&db);
   if (!table->sel && info_schema &&
       (table_options & TL_OPTION_UPDATING) &&
       /* Special cases which are processed by commands itself */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36469*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The is_infoschema_db is a deep character set based comparison. In in many cases the db is still
an empty structure.

Doing this comparison early prevents a UBSAN error
by not performing character set operations on
a null pointer.

## Release Notes

Optimise information_schema check in parser.

## How can this PR be tested?

UBSAN builders (on update) will fail tests per multiple entries listed in MDEV.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

Earlier branches have very different `Lex_ident_db` interface therefore a difference solution would be needed for those.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
