### PR TITLE
MDEV-20065 parallel replication for galera slave

### DIFF
--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -3998,6 +3998,16 @@ bool THD::wsrep_parallel_slave_wait_for_prior_commit()
   return false;
 }
 
+void wsrep_parallel_slave_wakeup_subsequent_commits(void *thd_ptr)
+{
+  THD *thd = (THD*)thd_ptr;
+  if (thd->rgi_slave && thd->rgi_slave->is_parallel_exec &&
+      thd->wait_for_commit_ptr)
+  {
+    thd->wait_for_commit_ptr->wakeup_subsequent_commits(0);
+  }
+}
+
 /***** callbacks for wsrep service ************/
 
 my_bool get_wsrep_recovery()


### PR DESCRIPTION


<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-20065*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

When replicating transactions from parallel slave replication processing, Galera must respect the commit order of the parallel slave replication. In the current implementation this is done by calling `wait_for_prior_commit()` before the write set is replicated and certified in before-prepare processing. This however establishes a critical section which is held over whole Galera replication step, and the commit rate will be limited by Galera replication latency.

In order to allow concurrency in Galera replication step, the critical section must be released at earliest point where Galera can guarantee sequential consistency for replicated write sets. This change passes a callback to release the critical section by calling `wakeup_subsequent_commits()` to Galera library, which will call the callback once the correct replication order can be established. This functionality will be available from Galera 26.4.22 onwards.

Note that call to `wakeup_subsequent_commits()` at this stage is safe from group commit point of view as Galera uses separate `wait_for_commit` context to control commit ordering.


## How can this PR be tested?

This change is an optimization, and does not have associated MTR or unit tests.

In order to test, Start Galera Cluster and make one of the Galera nodes as a slave to MariaDB master server. 
By varying `slave_parallel_threads` it should be observed that the transaction throughput increases when
more parallel slave threads are added. For this to work, `slave_parallel_mode` should be set to `optimistic` or
`aggressive`. 

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
