### PR TITLE
MDEV-35770 Augment DBUG_ASSERT with __builtin_assume

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,9 @@ ENDIF()
 # Be nice to profilers etc
 MY_CHECK_AND_SET_COMPILER_FLAG("-fno-omit-frame-pointer" RELWITHDEBINFO)
 
+# Assert-as-assume makes arbitrary exprs appear in assumptions, causing warnings
+MY_CHECK_AND_SET_COMPILER_FLAG("-Wno-assume")
+
 # enable security hardening features, like most distributions do
 # in our benchmarks that costs about ~1% of performance, depending on the load
 OPTION(SECURITY_HARDENED "Use security-enhancing compiler features (stack protector, relro, etc)" ON)

--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -2530,9 +2530,7 @@ static void print_xml_row(FILE *xml_file, const char *row_name,
       {
         create_stmt_ptr= (*row)[i];
         create_stmt_len= lengths[i];
-#ifdef DBUG_ASSERT_EXISTS
         body_found= 1;
-#endif
       }
       else
       {

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -1950,7 +1950,7 @@ ATTRIBUTE_NORETURN static void cleanup_and_exit(int exit_code,
     break;
     default:
       printf("unknown exit code: %d\n", exit_code);
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
     }
   }
 
@@ -11016,7 +11016,7 @@ static void append_session_track_info(DYNAMIC_STRING *ds, MYSQL *mysql)
       }
       else
       {
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
         dynstr_append_mem(ds, STRING_WITH_LEN("Tracker???\n"));
       }
     }

--- a/include/my_compiler.h
+++ b/include/my_compiler.h
@@ -29,6 +29,8 @@
   Compiler-dependent internal convenience macros.
 */
 
+#include <stddef.h>
+
 /* C vs C++ */
 #ifdef __cplusplus
 #define CONSTEXPR constexpr
@@ -79,6 +81,25 @@
 # define MY_ALIGNOF(type)   __alignof__(type)
 /** Determine the alignment requirement of a type. */
 # define MY_ALIGNED(n)      __attribute__((__aligned__((n))))
+#endif
+
+/*
+   An analogue of c++23 [[assume(cond)]]
+   for GCC >= 13.0, Clang and MSVC.
+*/
+#if defined __GNUC__ && __GNUC__ >= 13
+#ifdef __cplusplus
+# define MY_ASSUME(A) [[gnu::assume(!!(A))]]
+#else
+// In gnu-c, statement attributes are ambiguous.
+# define MY_ASSUME(A) do { [[gnu::assume(!!(A))]]; } while (0)
+#endif
+#elif defined __clang__
+# define MY_ASSUME(A) __builtin_assume(!!(A))
+#elif defined _MSC_VER
+# define MY_ASSUME(A) __assume(!!(A))
+#else
+# define MY_ASSUME(A) do { } while(0)
 #endif
 
 /**

--- a/include/my_dbug.h
+++ b/include/my_dbug.h
@@ -17,6 +17,8 @@
 #ifndef _my_dbug_h
 #define _my_dbug_h
 
+#include "my_compiler.h"
+
 #ifndef _WIN32
 #include <signal.h>
 #endif
@@ -116,9 +118,10 @@ extern int (*dbug_sanity)(void);
 #define DBUG_END()  _db_end_ ()
 #define DBUG_LOCK_FILE _db_lock_file_()
 #define DBUG_UNLOCK_FILE _db_unlock_file_()
-#define DBUG_ASSERT(A) do { \
+#define DBUG_ASSERT_NO_ASSUME(A) do { \
   if (unlikely(!(A)) && _db_my_assert(__FILE__, __LINE__, #A)) assert(A); \
 } while (0)
+#define DBUG_ASSERT(A) DBUG_ASSERT_NO_ASSUME(A)
 #define DBUG_SLOW_ASSERT(A) DBUG_ASSERT(A)
 #define DBUG_ASSERT_EXISTS
 #define DBUG_EXPLAIN(buf,len) _db_explain_(0, (buf),(len))
@@ -200,11 +203,13 @@ extern void _db_suicide_(void);
 
 #ifdef DBUG_ASSERT_AS_PRINTF
 extern void (*my_dbug_assert_failed)(const char *assert_expr, const char* file, unsigned long line);
-#define DBUG_ASSERT(assert_expr) do { if (!(assert_expr)) { my_dbug_assert_failed(#assert_expr, __FILE__, __LINE__); }} while (0)
+#define DBUG_ASSERT_NO_ASSUME(assert_expr) do { if (!(assert_expr)) { my_dbug_assert_failed(#assert_expr, __FILE__, __LINE__); }} while (0)
+#define DBUG_ASSERT(assert_expr) DBUG_ASSERT_NO_ASSUME(assert_expr)
 #define DBUG_ASSERT_EXISTS
 #define IF_DBUG_ASSERT(A,B)             A
 #else
-#define DBUG_ASSERT(A)                  do { } while(0)
+#define DBUG_ASSERT(A)                  MY_ASSUME(A)
+#define DBUG_ASSERT_NO_ASSUME(A)        do { } while (0)
 #define IF_DBUG_ASSERT(A,B)             B
 #endif /* DBUG_ASSERT_AS_PRINTF */
 #endif /* !defined(DBUG_OFF) */

--- a/libmysqld/emb_qcache.cc
+++ b/libmysqld/emb_qcache.cc
@@ -399,7 +399,7 @@ void emb_store_querycache_result(Querycache_stream *dst, THD *thd)
       }
     }
   }
-  DBUG_ASSERT(emb_count_querycache_size(thd) == dst->stored_size);
+  DBUG_ASSERT_NO_ASSUME(emb_count_querycache_size(thd) == dst->stored_size);
   DBUG_VOID_RETURN;
 }
 

--- a/libmysqld/libmysql.c
+++ b/libmysqld/libmysql.c
@@ -4424,7 +4424,7 @@ static void stmt_update_metadata(MYSQL_STMT *stmt, MYSQL_ROWS *data)
   {
     if (!(*null_ptr & bit))
       (*my_bind->skip_result)(my_bind, field, &row);
-    DBUG_ASSERT(row <= row_end);
+    DBUG_ASSERT_NO_ASSUME(row <= row_end);
     if (!(bit= (uchar) (bit << 1)))
     {
       bit= 1;					/* To next uchar */

--- a/mysys/charset.c
+++ b/mysys/charset.c
@@ -1542,7 +1542,7 @@ static UINT get_codepage(const char *s)
   UINT cp;
   if (s[0] != 'c' || s[1] != 'p')
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   }
   cp= strtoul(s + 2, NULL, 10);

--- a/mysys/ma_dyncol.c
+++ b/mysys/ma_dyncol.c
@@ -527,7 +527,7 @@ static my_bool type_and_offset_read_num(DYNAMIC_COLUMN_TYPE *type,
     lim= 0x1fffffff;
     break;
   default:
-    DBUG_ASSERT(0);                             /* impossible */
+    DBUG_ASSERT_NO_ASSUME(0);                             /* impossible */
     return 1;
   }
   *type= (val & 0x7) + 1;
@@ -562,7 +562,7 @@ static my_bool type_and_offset_read_named(DYNAMIC_COLUMN_TYPE *type,
     break;
   case 1:
   default:
-    DBUG_ASSERT(0);                             /* impossible */
+    DBUG_ASSERT_NO_ASSUME(0);                             /* impossible */
     return 1;
   }
   *type= (val & 0xf) + 1;
@@ -960,7 +960,7 @@ dynamic_column_value_len(DYNAMIC_COLUMN_VALUE *value,
     */
     if (scale < 0 || precision <= 0)
     {
-      DBUG_ASSERT(0);                           /* Impossible */
+      DBUG_ASSERT_NO_ASSUME(0);                           /* Impossible */
       return (size_t) ~0;
     }
     return (dynamic_column_var_uint_bytes(value->x.decimal.value.intg) +
@@ -985,7 +985,7 @@ dynamic_column_value_len(DYNAMIC_COLUMN_VALUE *value,
   case DYN_COL_DYNCOL:
     return value->x.string.value.length;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return 0;
 }
 
@@ -1563,7 +1563,7 @@ data_store(DYNAMIC_COLUMN *str, DYNAMIC_COLUMN_VALUE *value,
   case DYN_COL_NULL:
     break;                                      /* Impossible */
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return ER_DYNCOL_OK;                          /* Impossible */
 }
 

--- a/mysys/mf_keycache.c
+++ b/mysys/mf_keycache.c
@@ -425,9 +425,7 @@ static int keycache_pthread_cond_signal(mysql_cond_t *cond);
 static int fail_hlink(HASH_LINK *hlink);
 static int cache_empty(SIMPLE_KEY_CACHE_CB *keycache);
 #endif
-#ifdef DBUG_ASSERT_EXISTS
 static int fail_block(BLOCK_LINK *block);
-#endif
 
 static inline uint next_power(uint value)
 {
@@ -440,7 +438,7 @@ static inline uint next_power(uint value)
 
   SYNOPSIS
     init_simple_key_cache()
-    keycache                pointer to the control block of a simple key cache 
+    keycache                pointer to the control block of a simple key cache
     key_cache_block_size    size of blocks to keep cached data
     use_mem                 memory to use for the key cache buffers/structures
     division_limit          division limit (may be zero)
@@ -450,14 +448,14 @@ static inline uint next_power(uint value)
     This function is the implementation of the init_key_cache interface
     function that is employed by simple (non-partitioned) key caches.
     The function builds a simple key cache and initializes the control block
-    structure of the type SIMPLE_KEY_CACHE_CB that is used for this key cache. 
-    The parameter keycache is supposed to point to this structure. 
+    structure of the type SIMPLE_KEY_CACHE_CB that is used for this key cache.
+    The parameter keycache is supposed to point to this structure.
     The parameter key_cache_block_size specifies the size of the blocks in
     the key cache to be built. The parameters division_limit and age_threshold
     determine the initial values of those characteristics of the key cache
     that are used for midpoint insertion strategy. The parameter use_mem
     specifies the total amount of memory to be allocated for key cache blocks
-    and auxiliary structures.       
+    and auxiliary structures.
 
   RETURN VALUE
     number of blocks in the key cache, if successful,
@@ -651,15 +649,15 @@ err:
 
   SYNOPSIS
     prepare_resize_simple_key_cache()
-    keycache                pointer to the control block of a simple key cache	
+    keycache                pointer to the control block of a simple key cache
     release_lock            <=> release the key cache lock before return
 
   DESCRIPTION
     This function flushes all dirty pages from a simple key cache and after
-    this it destroys the key cache calling end_simple_key_cache. The function 
-    takes the parameter keycache as a pointer to the control block 
+    this it destroys the key cache calling end_simple_key_cache. The function
+    takes the parameter keycache as a pointer to the control block
     structure of the type SIMPLE_KEY_CACHE_CB for this key cache.
-    The parameter release_lock says whether the key cache lock must be 
+    The parameter release_lock says whether the key cache lock must be
     released before return from the function.
 
   RETURN VALUE
@@ -669,16 +667,16 @@ err:
   NOTES
     This function is the called by resize_simple_key_cache and
     resize_partitioned_key_cache that resize simple and partitioned key caches
-    respectively. 
+    respectively.
 */
 
-static 
+static
 int prepare_resize_simple_key_cache(SIMPLE_KEY_CACHE_CB *keycache,
                                     my_bool release_lock)
 {
   int res= 0;
-  DBUG_ENTER("prepare_resize_simple_key_cache"); 
- 
+  DBUG_ENTER("prepare_resize_simple_key_cache");
+
   keycache_pthread_mutex_lock(&keycache->cache_lock);
 
   /*
@@ -734,12 +732,12 @@ int prepare_resize_simple_key_cache(SIMPLE_KEY_CACHE_CB *keycache,
   */
   while (keycache->cnt_for_resize_op)
     wait_on_queue(&keycache->waiting_for_resize_cnt, &keycache->cache_lock);
-  
+
   end_simple_key_cache(keycache, 0);
 
 finish:
   if (release_lock)
-    keycache_pthread_mutex_unlock(&keycache->cache_lock);     
+    keycache_pthread_mutex_unlock(&keycache->cache_lock);
   DBUG_RETURN(res);
 }
 
@@ -749,10 +747,10 @@ finish:
 
   SYNOPSIS
     finish_resize_simple_key_cache()
-    keycache                pointer to the control block of a simple key cache		
+    keycache                pointer to the control block of a simple key cache
 
   DESCRIPTION
-    This function performs finalizing actions for the operation of 
+    This function performs finalizing actions for the operation of
     resizing a simple key cache. The function takes the parameter
     keycache as a pointer to the control block structure of the type
     SIMPLE_KEY_CACHE_CB for this key cache. The function sets the flag
@@ -764,22 +762,22 @@ finish:
   NOTES
     This function is the called by resize_simple_key_cache and
     resize_partitioned_key_cache that resize simple and partitioned key caches
-    respectively. 
+    respectively.
 */
 
-static 
+static
 void finish_resize_simple_key_cache(SIMPLE_KEY_CACHE_CB *keycache)
 {
   DBUG_ENTER("finish_resize_simple_key_cache");
 
   mysql_mutex_assert_owner(&keycache->cache_lock);
-			   
+
   /*
     Mark the resize finished. This allows other threads to start a
     resize or to request new cache blocks.
   */
   keycache->in_resize= 0;
-  
+
 
   /* Signal waiting threads. */
   release_whole_queue(&keycache->resize_queue);
@@ -807,13 +805,13 @@ void finish_resize_simple_key_cache(SIMPLE_KEY_CACHE_CB *keycache)
     function that is employed by simple (non-partitioned) key caches.
     The function takes the parameter keycache as a pointer to the
     control block structure of the type SIMPLE_KEY_CACHE_CB for the simple key
-    cache to be resized. 
+    cache to be resized.
     The parameter key_cache_block_size specifies the new size of the blocks in
     the key cache. The parameters division_limit and age_threshold
     determine the new initial values of those characteristics of the key cache
     that are used for midpoint insertion strategy. The parameter use_mem
     specifies the total amount of memory to be allocated for key cache blocks
-    and auxiliary structures in the new key cache.           
+    and auxiliary structures in the new key cache.
 
   RETURN VALUE
     number of blocks in the key cache, if successful,
@@ -848,13 +846,13 @@ int resize_simple_key_cache(void *keycache_,
 
   /*
     Note that the cache_lock mutex and the resize_queue are left untouched.
-    We do not lose the cache_lock and will release it only at the end of 
+    We do not lose the cache_lock and will release it only at the end of
     this function.
   */
   if (prepare_resize_simple_key_cache(keycache, 0))
     goto finish;
 
-  /* The following will work even if use_mem is 0 */ 
+  /* The following will work even if use_mem is 0 */
   blocks= init_simple_key_cache(keycache, key_cache_block_size, use_mem,
 			        division_limit, age_threshold,
                                 changed_blocks_hash_size);
@@ -891,7 +889,7 @@ static inline void dec_counter_for_resize_op(SIMPLE_KEY_CACHE_CB *keycache)
 
   SYNOPSIS
     change_simple_key_cache_param()
-    keycache                pointer to the control block of a simple key cache	
+    keycache                pointer to the control block of a simple key cache
     division_limit          new division limit (if not zero)
     age_threshold           new age threshold (if not zero)
 
@@ -911,8 +909,8 @@ static inline void dec_counter_for_resize_op(SIMPLE_KEY_CACHE_CB *keycache)
     Presently the function resets the key cache parameters concerning
     midpoint insertion strategy - division_limit and age_threshold.
     This function changes some parameters of a given key cache without
-    reformatting it. The function does not touch the contents the key 
-    cache blocks.    
+    reformatting it. The function does not touch the contents the key
+    cache blocks.
 */
 
 static
@@ -934,7 +932,7 @@ void change_simple_key_cache_param(void *keycache_, uint division_limit,
 
 
 /*
-  Destroy a simple key cache 
+  Destroy a simple key cache
 
   SYNOPSIS
     end_simple_key_cache()
@@ -948,7 +946,7 @@ void change_simple_key_cache_param(void *keycache_, uint division_limit,
     control block structure of the type SIMPLE_KEY_CACHE_CB for the simple key
     cache to be destroyed.
     The function frees the memory allocated for the key cache blocks and
-    auxiliary structures. If the value of the parameter cleanup is TRUE 
+    auxiliary structures. If the value of the parameter cleanup is TRUE
     then even the key cache mutex is freed.
 
   RETURN VALUE
@@ -1457,6 +1455,8 @@ static void link_block(SIMPLE_KEY_CACHE_CB *keycache, BLOCK_LINK *block,
 #endif
 }
 
+#undef DBUG_ASSERT
+#define DBUG_ASSERT(x) DBUG_ASSERT_NO_ASSUME(x)
 
 /*
   Unlink a block from the LRU chain
@@ -1752,7 +1752,6 @@ static void unlink_hash(SIMPLE_KEY_CACHE_CB *keycache, HASH_LINK *hash_link)
   hash_link->next= keycache->free_hash_list;
   keycache->free_hash_list= hash_link;
 }
-
 
 /*
   Get the hash link for a page
@@ -2278,7 +2277,7 @@ restart:
           DBUG_ASSERT(keycache->blocks_used <
                       (ulong) keycache->disk_blocks);
           block= &keycache->block_root[keycache->blocks_used];
-          block_mem_offset= 
+          block_mem_offset=
            ((size_t) keycache->blocks_used) * keycache->key_cache_block_size;
           block->buffer= ADD_TO_PTR(keycache->block_mem,
                                     block_mem_offset,
@@ -2735,7 +2734,7 @@ static void read_block_secondary(SIMPLE_KEY_CACHE_CB *keycache,
     level               determines the weight of the data
     buff                buffer to where the data must be placed
     length              length of the buffer
-    block_length        length of the read data from a key cache block 
+    block_length        length of the read data from a key cache block
     return_buffer       return pointer to the key cache buffer with the data
 
   DESCRIPTION
@@ -2751,15 +2750,15 @@ static void read_block_secondary(SIMPLE_KEY_CACHE_CB *keycache,
     of the buffer. The data is read into the buffer in key_cache_block_size
     increments. If the next portion of the data is not found in any key cache
     block, first it is read from file into the key cache.
-    If the parameter return_buffer is not ignored and its value is TRUE, and 
+    If the parameter return_buffer is not ignored and its value is TRUE, and
     the data to be read of the specified size block_length can be read from one
     key cache buffer, then the function returns a pointer to the data in the
     key cache buffer.
     The function takse into account parameters block_length and return buffer
     only in a single-threaded environment.
-    The parameter 'level' is used only by the midpoint insertion strategy 
-    when the data or its portion cannot be found in the key cache. 
-   
+    The parameter 'level' is used only by the midpoint insertion strategy
+    when the data or its portion cannot be found in the key cache.
+
   RETURN VALUE
     Returns address from where the data is placed if successful, 0 - otherwise.
 
@@ -2798,7 +2797,7 @@ uchar *simple_key_cache_read(void *keycache_,
                                 (ulong) (keycache->blocks_unused *
                                          keycache->key_cache_block_size));
     }
-  
+
     /*
       When the key cache is once initialized, we use the cache_lock to
       reliably distinguish the cases of normal operation, resizing, and
@@ -2987,7 +2986,7 @@ end:
 
   SYNOPSIS
     simple_key_cache_insert()
-    keycache            pointer to the control block of a simple key cache 
+    keycache            pointer to the control block of a simple key cache
     file                handler for the file to insert data from
     filepos             position of the block of data in the file to insert
     level               determines the weight of the data
@@ -3008,13 +3007,13 @@ end:
     increments.
     The parameter level is used to set one characteristic for the key buffers
     loaded with the data from buff. The characteristic is used only by the
-    midpoint insertion strategy.  
-   
+    midpoint insertion strategy.
+
   RETURN VALUE
     0 if a success, 1 - otherwise.
 
   NOTES
-    The function is used by MyISAM to move all blocks from a index file to 
+    The function is used by MyISAM to move all blocks from a index file to
     the key cache. It can be performed in parallel with reading the file data
     from the key buffers by other threads.
 
@@ -3246,8 +3245,8 @@ int simple_key_cache_insert(void *keycache_,
     simple_key_cache_write()
     keycache            pointer to the control block of a simple key cache
     file                handler for the file to write data to
-    file_extra          maps of key cache partitions containing 
-                        dirty pages from file 
+    file_extra          maps of key cache partitions containing
+                        dirty pages from file
     filepos             position in the file to write data to
     level               determines the weight of the data
     buff                buffer with the data
@@ -3275,9 +3274,9 @@ int simple_key_cache_insert(void *keycache_,
     The parameter file_extra currently makes sense only for simple key caches
     that are elements of a partitioned key cache. It provides a pointer to the
     shared bitmap of the partitions that may contains dirty pages for the file.
-    This bitmap is used to optimize the function 
-    flush_partitioned_key_cache_blocks. 
-      
+    This bitmap is used to optimize the function
+    flush_partitioned_key_cache_blocks.
+
   RETURN VALUE
     0 if a success, 1 - otherwise.
 
@@ -3288,7 +3287,7 @@ int simple_key_cache_insert(void *keycache_,
 
 static
 int simple_key_cache_write(void *keycache_,
-                           File file, void *file_extra __attribute__((unused)),                       
+                           File file, void *file_extra __attribute__((unused)),
                            my_off_t filepos, int level,
                            uchar *buff, uint length,
                            uint block_length  __attribute__((unused)),
@@ -3589,7 +3588,7 @@ end:
     dec_counter_for_resize_op(keycache);
     keycache_pthread_mutex_unlock(&keycache->cache_lock);
   }
-  
+
   if (MYSQL_KEYCACHE_WRITE_DONE_ENABLED())
   {
     MYSQL_KEYCACHE_WRITE_DONE((ulong) (keycache->blocks_used *
@@ -3597,7 +3596,7 @@ end:
                               (ulong) (keycache->blocks_unused *
                                        keycache->key_cache_block_size));
   }
-  
+
 #if !defined(DBUG_OFF) && defined(EXTRA_DEBUG)
   DBUG_EXECUTE("exec",
                test_key_cache(keycache, "end of key_cache_write", 1););
@@ -4342,15 +4341,15 @@ err:
 PRAGMA_REENABLE_CHECK_STACK_FRAME
 
 /*
-  Flush all blocks for a file from key buffers of a simple key cache 
+  Flush all blocks for a file from key buffers of a simple key cache
 
   SYNOPSIS
 
     flush_simple_key_blocks()
     keycache            pointer to the control block of a simple key cache
     file                handler for the file to flush to
-    file_extra          maps of key cache partitions containing 
-                        dirty pages from file (not used)         
+    file_extra          maps of key cache partitions containing
+                        dirty pages from file (not used)
     flush_type          type of the flush operation
 
   DESCRIPTION
@@ -4362,12 +4361,12 @@ PRAGMA_REENABLE_CHECK_STACK_FRAME
     In a general case the function flushes the data from all dirty key
     buffers related to the file 'file' into this file. The function does
     exactly this if the value of the parameter type is FLUSH_KEEP. If the
-    value of this parameter is FLUSH_RELEASE, the function additionally 
+    value of this parameter is FLUSH_RELEASE, the function additionally
     releases the key buffers containing data from 'file' for new usage.
     If the value of the parameter type is FLUSH_IGNORE_CHANGED the function
-    just releases the key buffers containing data from 'file'.  
+    just releases the key buffers containing data from 'file'.
     The parameter file_extra currently is not used by this function.
-      
+
   RETURN
     0   ok
     1  error
@@ -4811,8 +4810,9 @@ void keycache_debug_log_close(void)
 
 #endif /* defined(KEYCACHE_DEBUG) */
 
-#ifdef DBUG_ASSERT_EXISTS 
+#ifndef DBUG_OFF
 #define F_B_PRT(_f_, _v_) DBUG_PRINT("assert_fail", (_f_, _v_))
+#endif
 
 static int fail_block(BLOCK_LINK *block  __attribute__((unused)))
 {
@@ -4830,7 +4830,6 @@ static int fail_block(BLOCK_LINK *block  __attribute__((unused)))
 #endif
   return 0; /* Let the assert fail. */
 }
-#endif
 
 #ifndef DBUG_OFF
 static int fail_hlink(HASH_LINK *hlink  __attribute__((unused)))

--- a/mysys/my_virtual_mem.c
+++ b/mysys/my_virtual_mem.c
@@ -68,7 +68,7 @@ char *my_virtual_mem_commit(char *ptr, size_t size)
 #ifdef _WIN32
   if (my_use_large_pages)
   {
-    DBUG_ASSERT(is_memory_committed(ptr, size));
+    DBUG_ASSERT_NO_ASSUME(is_memory_committed(ptr, size));
   }
   else
   {
@@ -127,7 +127,7 @@ char *my_virtual_mem_commit(char *ptr, size_t size)
 void my_virtual_mem_decommit(char *ptr, size_t size)
 {
 #ifdef _WIN32
-  DBUG_ASSERT(is_memory_committed(ptr, size));
+  DBUG_ASSERT_NO_ASSUME(is_memory_committed(ptr, size));
 # ifndef HAVE_UNACCESSIBLE_AFTER_MEM_DECOMMIT
 #  error "VirtualFree(MEM_DECOMMIT) will not allow subsequent reads!"
 # endif
@@ -184,7 +184,7 @@ void my_virtual_mem_decommit(char *ptr, size_t size)
 void my_virtual_mem_release(char *ptr, size_t size)
 {
 #ifdef _WIN32
-  DBUG_ASSERT(my_use_large_pages || !is_memory_committed(ptr, size));
+  DBUG_ASSERT_NO_ASSUME(my_use_large_pages || !is_memory_committed(ptr, size));
   if (!VirtualFree(ptr, 0, MEM_RELEASE))
   {
     my_error(EE_BADMEMORYRELEASE, MYF(ME_ERROR_LOG_ONLY), ptr, size,

--- a/mysys/ptr_cmp.c
+++ b/mysys/ptr_cmp.c
@@ -228,7 +228,7 @@ my_off_t my_get_ptr(uchar *ptr, size_t pack_length)
   case 3: pos= (my_off_t) mi_uint3korr(ptr); break;
   case 2: pos= (my_off_t) mi_uint2korr(ptr); break;
   case 1: pos= (my_off_t) *(uchar*) ptr; break;
-  default: DBUG_ASSERT(0); return 0;
+  default: DBUG_ASSERT_NO_ASSUME(0); return 0;
   }
  return pos;
 }

--- a/plugin/type_assoc_array/sql_type_assoc_array.cc
+++ b/plugin/type_assoc_array/sql_type_assoc_array.cc
@@ -148,8 +148,8 @@ public:
 #ifndef DBUG_OFF
     StringBuffer<64> type;
     field->sql_type(type);
-    const uchar *pend=
 #endif
+    const uchar *pend=
     field->pack(start, field->ptr);
     DBUG_ASSERT((uint) (pend - start) == length);
     DBUG_EXECUTE_IF("assoc_array_pack",
@@ -1983,7 +1983,7 @@ bool Item_splocal_assoc_array_element::fix_fields(THD *thd, Item **ref)
 Item *
 Item_splocal_assoc_array_element::this_item()
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   DBUG_ASSERT(m_key->fixed());
   StringBufferKey buffer;
@@ -1995,7 +1995,7 @@ Item_splocal_assoc_array_element::this_item()
 const Item *
 Item_splocal_assoc_array_element::this_item() const
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   DBUG_ASSERT(m_key->fixed());
   StringBufferKey buffer;
@@ -2007,7 +2007,7 @@ Item_splocal_assoc_array_element::this_item() const
 Item **
 Item_splocal_assoc_array_element::this_item_addr(THD *thd, Item **ref)
 {
-  DBUG_ASSERT(m_sp == thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   DBUG_ASSERT(m_key->fixed());
   StringBufferKey buffer;
@@ -2105,7 +2105,7 @@ bool Item_splocal_assoc_array_element_field::fix_fields(THD *thd, Item **ref)
 Item *
 Item_splocal_assoc_array_element_field::this_item()
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
 
   StringBufferKey buffer;
@@ -2121,7 +2121,7 @@ Item_splocal_assoc_array_element_field::this_item()
 const Item *
 Item_splocal_assoc_array_element_field::this_item() const
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
 
   StringBufferKey buffer;
@@ -2137,7 +2137,7 @@ Item_splocal_assoc_array_element_field::this_item() const
 Item **
 Item_splocal_assoc_array_element_field::this_item_addr(THD *thd, Item **)
 {
-  DBUG_ASSERT(m_sp == thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
 
   StringBufferKey buffer;

--- a/plugin/type_mysql_json/mysql_json.cc
+++ b/plugin/type_mysql_json/mysql_json.cc
@@ -220,7 +220,7 @@ static bool print_mysql_datetime_value(String *buffer, enum_field_types type,
       TIME_from_longlong_datetime_packed(&t, sint8korr(data));
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return true;
   }
   /* Wrap all datetime strings within double quotes. */

--- a/sql-common/my_time.c
+++ b/sql-common/my_time.c
@@ -103,7 +103,7 @@ static const ulonglong C_KNOWN_FLAGS= C_TIME_NO_ZERO_IN_DATE |
 my_bool check_date(const MYSQL_TIME *ltime, my_bool not_zero_date,
                    ulonglong flags, int *was_cut)
 {
-  DBUG_ASSERT(C_FLAGS_OK(flags));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(flags));
   if (ltime->time_type == MYSQL_TIMESTAMP_TIME)
     return FALSE;
   if (not_zero_date)
@@ -534,7 +534,7 @@ str_to_datetime_or_date_body(const char *str, size_t length, MYSQL_TIME *l_time,
   uint digits, year_length, not_zero_date;
   int warn= 0;
   DBUG_ENTER("str_to_datetime_or_date_body");
-  DBUG_ASSERT(C_FLAGS_OK(flags));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(flags));
   bzero(l_time, sizeof(*l_time));
   *number_of_fields= 0;
   *endptr= str;
@@ -685,7 +685,7 @@ str_to_datetime_or_date_or_time_body(const char *str, size_t length,
                                      my_bool allow_dates_numeric)
 {
   const char *endptr;
-  DBUG_ASSERT(C_FLAGS_OK(fuzzydate));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(fuzzydate));
 
   /* Check first if this is a full TIMESTAMP */
   if (is_datetime_body_candidate(str, length,
@@ -832,7 +832,7 @@ str_to_datetime_or_date_or_time(const char *str, size_t length,
                                 ulong time_err_hour)
 {
   my_bool neg;
-  DBUG_ASSERT(C_FLAGS_OK(mode));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(mode));
   my_time_status_init(status);
   return
     find_body(&neg, str, length, to, &status->warnings, &str, &length) ||
@@ -851,7 +851,7 @@ str_to_datetime_or_date_or_interval_hhmmssff(const char *str, size_t length,
                                              ulong time_err_hour)
 {
   my_bool neg;
-  DBUG_ASSERT(C_FLAGS_OK(mode));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(mode));
   my_time_status_init(status);
   return
     find_body(&neg, str, length, to, &status->warnings, &str, &length) ||
@@ -870,7 +870,7 @@ str_to_datetime_or_date_or_interval_day(const char *str, size_t length,
                                         ulong time_err_hour)
 {
   my_bool neg;
-  DBUG_ASSERT(C_FLAGS_OK(mode));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(mode));
   my_time_status_init(status);
   /*
     For backward compatibility we allow to parse non-delimited
@@ -893,7 +893,7 @@ str_to_datetime_or_date(const char *str, size_t length, MYSQL_TIME *l_time,
   my_bool neg;
   uint number_of_fields;
   const char *endptr;
-  DBUG_ASSERT(C_FLAGS_OK(flags));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(flags));
   my_time_status_init(status);
   return
     find_body(&neg, str, length, l_time, &status->warnings, &str, &length) ||
@@ -1630,7 +1630,7 @@ static char* fmt_usec(uint val, char *out, uint digits)
   case 6:
     return fmt_number6(val, out);
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return out;
 }
 
@@ -1824,7 +1824,7 @@ longlong number_to_datetime_or_date(longlong nr, ulong sec_part,
                                     ulonglong flags, int *was_cut)
 {
   long part1,part2;
-  DBUG_ASSERT(C_FLAGS_OK(flags));
+  DBUG_ASSERT_NO_ASSUME(C_FLAGS_OK(flags));
 
   *was_cut= 0;
   time_res->time_type=MYSQL_TIMESTAMP_DATE;

--- a/sql/create_options.cc
+++ b/sql/create_options.cc
@@ -229,7 +229,7 @@ static bool set_one_value(ha_create_table_option *opt, THD *thd,
                                      suppress_warning));
     }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   my_error(ER_UNKNOWN_ERROR, MYF(0));
   DBUG_RETURN(1);
 }

--- a/sql/ddl_log.cc
+++ b/sql/ddl_log.cc
@@ -555,7 +555,7 @@ static uchar *store_string(uchar *pos, uchar *end, const LEX_CSTRING *str)
   uint32 length= (uint32) str->length;
   if (unlikely(pos + 2 + length + 1 > end))
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return end;                                 // Overflow
   }
 
@@ -587,7 +587,7 @@ static LEX_CSTRING get_string(uchar **pos, const uchar *end)
     Overflow on read, should never happen
     Set *pos to end to ensure any future calls also returns empty string
   */
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   *pos= (uchar*) end;
   tmp.str= "";
   tmp.length= 0;
@@ -2776,7 +2776,7 @@ int ddl_log_execute_recovery()
   */
   if (!(thd=new THD(0)))
   {
-    DBUG_ASSERT(0);                             // Fatal error
+    DBUG_ASSERT_NO_ASSUME(0);                             // Fatal error
     DBUG_RETURN(1);
   }
   original_thd= current_thd;                    // Probably NULL

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -2786,7 +2786,7 @@ bool Field_row::row_create_fields(THD *thd, const Spvar_definition &def)
   if (def.is_row()) // e.g. ROW(a INT, b VARCHAR(32))
     return row_create_fields(thd, def.row_field_definitions());
 
-  DBUG_ASSERT(0); // Unknown ROW declaration style
+  DBUG_ASSERT_NO_ASSUME(0); // Unknown ROW declaration style
   return true;
 }
 
@@ -3943,7 +3943,7 @@ Item *Field_new_decimal::get_equal_const_item(THD *thd, const Context &ctx,
       VDec val(const_item);
       if (val.is_null())
       {
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
         return const_item;
       }
       /*
@@ -5768,7 +5768,7 @@ static longlong read_native(const uchar *from, uint bytes)
   case 3: return uint3korr(from);
   case 4: { uint32 tmp; longget(tmp, from); return tmp; }
   case 8: { longlong tmp; longlongget(tmp, from); return tmp; }
-  default: DBUG_ASSERT(0); return 0;
+  default: DBUG_ASSERT_NO_ASSUME(0); return 0;
   }
 }
 #endif
@@ -9195,7 +9195,7 @@ static struct blob_storage_check
 #endif
 Field *Field_blob::make_new_field(MEM_ROOT *root, TABLE *newt, bool keep_type)
 {
-  DBUG_ASSERT((intptr(newt->blob_storage) & blob_storage_check.val.p) == 0);
+  DBUG_ASSERT_NO_ASSUME((intptr(newt->blob_storage) & blob_storage_check.val.p) == 0);
   if (newt->group_concat)
     return new (root) Field_blob(field_length, maybe_null(), &field_name,
                                  charset());
@@ -11294,7 +11294,7 @@ uint32 Field_blob::character_octet_length() const
   case 4:
     return (uint32) UINT_MAX32;
   default:
-    DBUG_ASSERT(0); // we should never go here
+    DBUG_ASSERT_NO_ASSUME(0); // we should never go here
     return 0;
   }
 }
@@ -11381,7 +11381,7 @@ uint32 Field_blob::max_display_length() const
   case 4:
     return (uint32) UINT_MAX32;
   default:
-    DBUG_ASSERT(0); // we should never go here
+    DBUG_ASSERT_NO_ASSUME(0); // we should never go here
     return 0;
   }
 }

--- a/sql/field.h
+++ b/sql/field.h
@@ -516,7 +516,7 @@ inline bool is_temporal_type_with_date(enum_field_types type)
     return true;
   case MYSQL_TYPE_DATETIME2:
   case MYSQL_TYPE_TIMESTAMP2:
-    DBUG_ASSERT(0); // field->real_type() should not get to here.
+    DBUG_ASSERT_NO_ASSUME(0); // field->real_type() should not get to here.
     return false;
   default:
     return false;
@@ -4493,7 +4493,7 @@ static inline longlong read_bigendian(const uchar *from, uint bytes)
   case 6: return mi_uint6korr(from);
   case 7: return mi_uint7korr(from);
   case 8: return mi_sint8korr(from);
-  default: DBUG_ASSERT(0); return 0;
+  default: DBUG_ASSERT_NO_ASSUME(0); return 0;
   }
 }
 
@@ -4517,7 +4517,7 @@ static inline longlong read_lowendian(const uchar *from, uint bytes)
   case 3: return uint3korr(from);
   case 4: return uint4korr(from);
   case 8: return sint8korr(from);
-  default: DBUG_ASSERT(0); return 0;
+  default: DBUG_ASSERT_NO_ASSUME(0); return 0;
   }
 }
 

--- a/sql/field_conv.cc
+++ b/sql/field_conv.cc
@@ -129,7 +129,7 @@ static int set_bad_null_error(Field *field, int err)
       my_error(err, MYF(0), field->field_name.str);
     return -1;
   }
-  DBUG_ASSERT(0); // impossible
+  DBUG_ASSERT_NO_ASSUME(0); // impossible
   return -1;
 }
 

--- a/sql/filesort.cc
+++ b/sql/filesort.cc
@@ -122,7 +122,7 @@ static uint32 read_keypart_length(const uchar *from, uint bytes)
   case 2: return uint2korr(from);
   case 3: return uint3korr(from);
   case 4: return uint4korr(from);
-  default: DBUG_ASSERT(0); return 0;
+  default: DBUG_ASSERT_NO_ASSUME(0); return 0;
   }
 }
 
@@ -1249,7 +1249,7 @@ Type_handler_string_result::make_sort_key_part(uchar *to, Item *item,
         of memory or have an item marked not null when it can be null.
         This code is here mainly to avoid a hard crash in this case.
       */
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_PRINT("warning",
                  ("Got null on something that shouldn't be null"));
       memset(to, 0, sort_field->length);	// Avoid crash
@@ -2581,7 +2581,7 @@ Type_handler_string_result::make_packed_sort_key_part(uchar *to, Item *item,
         of memory or have an item marked not null when it can be null.
         This code is here mainly to avoid a hard crash in this case.
       */
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_PRINT("warning",
                  ("Got null on something that shouldn't be null"));
       memset(to, 0, sort_field->length);  // Avoid crash

--- a/sql/gtid_index.cc
+++ b/sql/gtid_index.cc
@@ -999,7 +999,7 @@ int Gtid_index_reader::do_index_search_leaf(bool current_state_updated,
   int res= get_offset_count(&offset, &gtid_count);
   if (res == 1)
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     give_error("Corrupt index; empty leaf node");
     return -1;
   }

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -3232,7 +3232,7 @@ bool ha_partition::setup_engine_array(MEM_ROOT *mem_root,
       DBUG_PRINT("error", ("partition %u engine %d is not same as "
                            "first partition %d", i, db_type,
                            (int) first_db_type));
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       clear_handler_file();
       goto err;
     }
@@ -6160,7 +6160,7 @@ int ha_partition::index_read_idx_map(uchar *buf, uint index,
       If not only used with READ_EXACT, we should investigate if possible
       to optimize for other find_flag's as well.
     */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     /* fall back on the default implementation */
     error= handler::index_read_idx_map(buf, index, key, keypart_map, find_flag);
   }
@@ -7860,7 +7860,7 @@ int ha_partition::handle_unordered_next(uchar *buf, bool is_next_same)
   if (i >= m_tot_parts)
   {
     /* Should never happen! */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     DBUG_RETURN(HA_ERR_END_OF_FILE);
   }
   file= m_file[i];
@@ -8510,7 +8510,7 @@ int ha_partition::handle_ordered_next(uchar *buf, bool is_next_same)
   if (part_id >= m_tot_parts)
   {
     /* This should never happen! */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     DBUG_RETURN(HA_ERR_END_OF_FILE);
   }
 
@@ -10541,7 +10541,7 @@ const char *ha_partition::index_type(uint inx)
 
   if (first_used_partition == MY_BIT_NONE)
   {
-    DBUG_ASSERT(0);                             // How can this happen?
+    DBUG_ASSERT_NO_ASSUME(0);                             // How can this happen?
     DBUG_RETURN(handler::index_type(inx));
   }
 
@@ -10698,7 +10698,7 @@ void ha_partition::print_error(int error, myf errflag)
   {
     if (m_last_part >= m_tot_parts)
     {
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       m_last_part= 0;
     }
     m_file[m_last_part]->print_error(error, errflag);
@@ -10886,7 +10886,7 @@ ha_partition::check_if_supported_inplace_alter(TABLE *altered_table,
       else if (first_is_set != (ha_alter_info->handler_ctx != NULL))
       {
         /* Either none or all partitions must set handler_ctx! */
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
         DBUG_RETURN(HA_ALTER_ERROR);
       }
       if (p_result < result)

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -1799,7 +1799,7 @@ int ha_commit_trans(THD *thd, bool all)
   DBUG_ASSERT(thd->transaction->stmt.ha_list == NULL ||
               trans == &thd->transaction->stmt);
 
-  DBUG_ASSERT(!thd->in_sub_stmt);
+  DBUG_ASSERT_NO_ASSUME(!thd->in_sub_stmt);
 
   if (thd->in_sub_stmt)
   {
@@ -2355,7 +2355,7 @@ int ha_rollback_trans(THD *thd, bool all)
 
   if (thd->in_sub_stmt)
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     /*
       If we are inside stored function or trigger we should not commit or
       rollback current statement transaction. See comment in ha_commit_trans()
@@ -3202,7 +3202,7 @@ int ha_recover(HASH *commit_list, MEM_ROOT *arg_mem_root)
   /* commit_list and tc_heuristic_recover cannot be set both */
   DBUG_ASSERT(info.commit_list==0 || tc_heuristic_recover==0);
   /* if either is set, total_ha_2pc must be set too */
-  DBUG_ASSERT(info.dry_run ||
+  DBUG_ASSERT_NO_ASSUME(info.dry_run ||
               (failed_ha_2pc + total_ha_2pc) > (ulong)opt_bin_log);
 
   if (total_ha_2pc <= (ulong)opt_bin_log)
@@ -4838,7 +4838,7 @@ void handler::get_auto_increment(ulonglong offset, ulonglong increment,
   if (ha_index_init(table->s->next_number_index, 1))
   {
     /* This should never happen, assert in debug, and fail in release build */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     (void) extra(HA_EXTRA_NO_KEYREAD);
     *first_value= ULONGLONG_MAX;
     if (rnd_inited && ha_rnd_init_with_error(0))

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -5639,8 +5639,8 @@ public:
   { return HA_ERR_WRONG_COMMAND; }
   virtual bool set_ha_share_ref(Handler_share **arg_ha_share)
   {
-    DBUG_ASSERT(!ha_share);
-    DBUG_ASSERT(arg_ha_share);
+    DBUG_ASSERT_NO_ASSUME(!ha_share);
+    DBUG_ASSERT_NO_ASSUME(arg_ha_share);
     if (ha_share || !arg_ha_share)
       return true;
     ha_share= arg_ha_share;

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -1869,7 +1869,7 @@ bool Item_splocal::fix_fields(THD *thd, Item **ref)
 Item *
 Item_splocal::this_item()
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   return get_variable(m_thd->spcont);
 }
@@ -1877,7 +1877,7 @@ Item_splocal::this_item()
 const Item *
 Item_splocal::this_item() const
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   return get_variable(m_thd->spcont);
 }
@@ -1886,7 +1886,7 @@ Item_splocal::this_item() const
 Item **
 Item_splocal::this_item_addr(THD *thd, Item **)
 {
-  DBUG_ASSERT(m_sp == thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   return get_rcontext(thd->spcont)->get_variable_addr(m_var_idx);
 }
@@ -2013,7 +2013,7 @@ bool Item_splocal_row_field::fix_fields(THD *thd, Item **ref)
 Item *
 Item_splocal_row_field::this_item()
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   return get_variable(m_thd->spcont)->element_index(m_field_idx);
 }
@@ -2022,7 +2022,7 @@ Item_splocal_row_field::this_item()
 const Item *
 Item_splocal_row_field::this_item() const
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   return get_variable(m_thd->spcont)->element_index(m_field_idx);
 }
@@ -2031,7 +2031,7 @@ Item_splocal_row_field::this_item() const
 Item **
 Item_splocal_row_field::this_item_addr(THD *thd, Item **)
 {
-  DBUG_ASSERT(m_sp == thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == thd->spcont->m_sp);
   DBUG_ASSERT(fixed());
   return get_variable(thd->spcont)->addr(m_field_idx);
 }
@@ -2123,7 +2123,7 @@ bool Item_case_expr::fix_fields(THD *thd, Item **ref)
 Item *
 Item_case_expr::this_item()
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
 
   return m_thd->spcont->get_case_expr(m_case_expr_id);
 }
@@ -2133,7 +2133,7 @@ Item_case_expr::this_item()
 const Item *
 Item_case_expr::this_item() const
 {
-  DBUG_ASSERT(m_sp == m_thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == m_thd->spcont->m_sp);
 
   return m_thd->spcont->get_case_expr(m_case_expr_id);
 }
@@ -2142,7 +2142,7 @@ Item_case_expr::this_item() const
 Item **
 Item_case_expr::this_item_addr(THD *thd, Item **)
 {
-  DBUG_ASSERT(m_sp == thd->spcont->m_sp);
+  DBUG_ASSERT_NO_ASSUME(m_sp == thd->spcont->m_sp);
 
   return thd->spcont->get_case_expr_addr(m_case_expr_id);
 }
@@ -4746,7 +4746,7 @@ int Item_param::save_in_field(Field *field, bool no_conversions)
       switch (find_ignore_reaction(field->table->in_use))
       {
         case IGNORE_MEANS_DEFAULT:
-          DBUG_ASSERT(0); // impossible now, but fully working code if needed
+          DBUG_ASSERT_NO_ASSUME(0); // impossible now, but fully working code if needed
           return assign_default(field);
         case IGNORE_MEANS_FIELD_VALUE:
           m_associated_field->save_val(field);
@@ -4754,7 +4754,7 @@ int Item_param::save_in_field(Field *field, bool no_conversions)
         default:
           ; // fall through to error
       }
-      DBUG_ASSERT(0); //impossible
+      DBUG_ASSERT_NO_ASSUME(0); //impossible
       my_error(ER_INVALID_DEFAULT_PARAM, MYF(0));
       return true;
     }
@@ -4762,10 +4762,10 @@ int Item_param::save_in_field(Field *field, bool no_conversions)
                                              top_table() !=
                                              field->table->pos_in_table_list);
   case NO_VALUE:
-    DBUG_ASSERT(0); // Should not be possible
+    DBUG_ASSERT_NO_ASSUME(0); // Should not be possible
     return true;
   }
-  DBUG_ASSERT(0); // Garbage
+  DBUG_ASSERT_NO_ASSUME(0); // Garbage
   return 1;
 }
 
@@ -4817,10 +4817,10 @@ bool Item_param::can_return_value() const
   case NULL_VALUE:
     return false;
   case NO_VALUE:
-    DBUG_ASSERT(0); // Should not be possible
+    DBUG_ASSERT_NO_ASSUME(0); // Should not be possible
     return false;
   }
-  DBUG_ASSERT(0); // Garbage
+  DBUG_ASSERT_NO_ASSUME(0); // Garbage
   return false;
 }
 
@@ -5492,7 +5492,7 @@ bool Item_param::assign_default(Field *field)
 
 double Item_copy_string::val_real()
 {
-  DBUG_ASSERT(copied_in);
+  DBUG_ASSERT_NO_ASSUME(copied_in);
   int err_not_used;
   char *end_not_used;
   return (null_value ? 0.0 :
@@ -5503,7 +5503,7 @@ double Item_copy_string::val_real()
 
 longlong Item_copy_string::val_int()
 {
-  DBUG_ASSERT(copied_in);
+  DBUG_ASSERT_NO_ASSUME(copied_in);
   int err;
   return null_value ? 0 : str_value.charset()->strntoll(str_value.ptr(),
                                                         str_value.length(), 10,
@@ -5513,7 +5513,7 @@ longlong Item_copy_string::val_int()
 
 int Item_copy_string::save_in_field(Field *field, bool no_conversions)
 {
-  DBUG_ASSERT(copied_in);
+  DBUG_ASSERT_NO_ASSUME(copied_in);
   return save_str_value_in_field(field, &str_value);
 }
 
@@ -5532,7 +5532,7 @@ void Item_copy_string::copy()
 /* ARGSUSED */
 String *Item_copy_string::val_str(String *str)
 {
-  DBUG_ASSERT(copied_in);
+  DBUG_ASSERT_NO_ASSUME(copied_in);
   // Item_copy_string is used without fix_fields call
   if (null_value)
     return (String*) 0;
@@ -5542,7 +5542,7 @@ String *Item_copy_string::val_str(String *str)
 
 my_decimal *Item_copy_string::val_decimal(my_decimal *decimal_value)
 {
-  DBUG_ASSERT(copied_in);
+  DBUG_ASSERT_NO_ASSUME(copied_in);
   // Item_copy_string is used without fix_fields call
   if (null_value)
     return (my_decimal *) 0;
@@ -8274,7 +8274,7 @@ Item *get_field_item_for_having(THD *thd, Item *item, st_select_lex *sel)
                                                 field_item->field_name);
     return ref;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL; 
 }
 
@@ -10869,7 +10869,7 @@ int stored_field_cmp_to_item(THD *thd, Field *field, Item *item)
   if (cmp.aggregate_for_comparison(item->type_handler_for_comparison()))
   {
     // At fix_fields() time we checked that "field" and "item" are comparable
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   }
   return cmp.type_handler()->stored_field_cmp_to_item(thd, field, item);
@@ -11478,7 +11478,7 @@ void Item_cache_row::illegal_method_call(const char *method)
 {
   DBUG_ENTER("Item_cache_row::illegal_method_call");
   DBUG_PRINT("error", ("!!! %s method was called for row item", method));
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   my_error(ER_OPERAND_COLUMNS, MYF(0), 1);
   DBUG_VOID_RETURN;
 }

--- a/sql/item.h
+++ b/sql/item.h
@@ -4443,7 +4443,7 @@ public:
     case DEFAULT_VALUE:    return PARAM_ITEM;
     case IGNORE_VALUE:     return PARAM_ITEM;
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return PARAM_ITEM;
   }
 
@@ -7112,7 +7112,7 @@ public:
   longlong val_int() override;
   bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     return get_date_from_string(thd, ltime, fuzzydate);
   }
   void copy() override;
@@ -7152,7 +7152,7 @@ public:
   }
   int save_in_field(Field *field, bool) override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     DBUG_ASSERT(sane());
     if (null_value)
       return set_field_to_null(field);
@@ -7162,35 +7162,35 @@ public:
   }
   longlong val_int() override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     DBUG_ASSERT(sane());
     return null_value ? 0 :
            m_value.to_datetime(current_thd).to_longlong();
   }
   double val_real() override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     DBUG_ASSERT(sane());
     return null_value ? 0e0 :
            m_value.to_datetime(current_thd).to_double();
   }
   String *val_str(String *to) override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     DBUG_ASSERT(sane());
     return null_value ? NULL :
            m_value.to_datetime(current_thd).to_string(to, decimals);
   }
   my_decimal *val_decimal(my_decimal *to) override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     DBUG_ASSERT(sane());
     return null_value ? NULL :
            m_value.to_datetime(current_thd).to_decimal(to);
   }
   bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     DBUG_ASSERT(sane());
     bool res= m_value.to_TIME(thd, ltime, fuzzydate);
     DBUG_ASSERT(!res);
@@ -7198,7 +7198,7 @@ public:
   }
   bool val_native(THD *thd, Native *to) override
   {
-    DBUG_ASSERT(copied_in);
+    DBUG_ASSERT_NO_ASSUME(copied_in);
     DBUG_ASSERT(sane());
     decimal_digits_t dec= MY_MIN(decimals, TIME_SECOND_PART_DIGITS);
     return null_value || m_value.to_native(to, dec);
@@ -7370,7 +7370,7 @@ public:
   bool save_in_param(THD *, Item_param *param) override
   {
     // It should not be possible to have "EXECUTE .. USING DEFAULT(a)"
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     param->set_default(true);
     return false;
   }

--- a/sql/item_buff.cc
+++ b/sql/item_buff.cc
@@ -56,7 +56,7 @@ Cached_item *new_Cached_item(THD *thd, Item *item, bool pass_through_ref)
     return new Cached_item_decimal(item);
   case ROW_RESULT:
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   }
 }

--- a/sql/item_cmpfunc.cc
+++ b/sql/item_cmpfunc.cc
@@ -7764,7 +7764,7 @@ Item* Item_equal::get_first(JOIN_TAB *context, Item *field_item)
     return equal_items.head();
   }
   // Shouldn't get here.
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL;
 }
 

--- a/sql/item_cmpfunc.h
+++ b/sql/item_cmpfunc.h
@@ -184,7 +184,7 @@ protected:
                                      Field *field, Item *value)
   {
     DBUG_ENTER("Item_bool_func::get_func_mm_tree");
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     DBUG_RETURN(0);
   }
   /*

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -2381,7 +2381,7 @@ bool Item_func_int_val::native_op(THD *thd, Native *to)
   // TODO: turn Item_func_int_val into Item_handled_func eventually.
   if (type_handler()->mysql_timestamp_type() == MYSQL_TIMESTAMP_TIME)
     return Time(thd, this).to_native(to, decimals);
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return true;
 }
 
@@ -2838,7 +2838,7 @@ bool Item_func_round::native_op(THD *thd, Native *to)
   // TODO: turn Item_func_round into Item_handled_func eventually.
   if (type_handler()->mysql_timestamp_type() == MYSQL_TIMESTAMP_TIME)
     return Time(thd, this).to_native(to, decimals);
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return true;
 }
 
@@ -3714,7 +3714,7 @@ udf_handler::fix_fields(THD *thd, Item_func_or_sum *func,
           break;
         case ROW_RESULT:
         case TIME_RESULT:
-          DBUG_ASSERT(0);          // This case should never be chosen
+          DBUG_ASSERT_NO_ASSUME(0);          // This case should never be chosen
           break;
         }
       }
@@ -3790,7 +3790,7 @@ bool udf_handler::get_arguments()
       break;
     case ROW_RESULT:
     case TIME_RESULT:
-      DBUG_ASSERT(0);              // This case should never be chosen
+      DBUG_ASSERT_NO_ASSUME(0);              // This case should never be chosen
       break;
     }
   }
@@ -4625,7 +4625,7 @@ longlong Item_func_benchmark::val_int()
       break;
     case ROW_RESULT:
     case TIME_RESULT:
-      DBUG_ASSERT(0);              // This case should never be chosen
+      DBUG_ASSERT_NO_ASSUME(0);              // This case should never be chosen
       return 0;
     }
   }
@@ -4864,7 +4864,7 @@ bool Item_func_set_user_var::fix_fields(THD *thd, Item **ref)
     set_handler(&type_handler_newdecimal);
     break;
   case ROW_RESULT:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     set_handler(args[0]->type_handler());
     break;
   }

--- a/sql/item_func.h
+++ b/sql/item_func.h
@@ -156,7 +156,7 @@ public:
     case GT_FUNC:    return SCALAR_CMP_GT;
     default: break;
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return SCALAR_CMP_EQ;
   }
   enum Type type() const override { return FUNC_ITEM; }
@@ -561,7 +561,7 @@ public:
     virtual bool get_date(THD *thd, Item_handled_func *, MYSQL_TIME *, date_mode_t fuzzydate) const= 0;
     virtual bool val_native(THD *thd, Item_handled_func *, Native *to) const
     {
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       to->length(0);
       return true;
     }

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -1169,7 +1169,7 @@ LEX_CSTRING Item_func_spatial_mbr_rel::func_name_cstring() const
     case SP_OVERLAPS_FUNC:
       return { STRING_WITH_LEN("mbroverlaps") };
     default:
-      DBUG_ASSERT(0);  // Should never happened
+      DBUG_ASSERT_NO_ASSUME(0);  // Should never happened
       return { STRING_WITH_LEN("mbrsp_unknown") };
   }
 }
@@ -1249,7 +1249,7 @@ LEX_CSTRING Item_func_spatial_precise_rel::func_name_cstring() const
     case SP_OVERLAPS_FUNC:
       return { STRING_WITH_LEN("st_overlaps") } ;
     default:
-      DBUG_ASSERT(0);  // Should never happened
+      DBUG_ASSERT_NO_ASSUME(0);  // Should never happened
       return { STRING_WITH_LEN("sp_unknown") };
   }
 }
@@ -1656,7 +1656,7 @@ LEX_CSTRING Item_func_spatial_operation::func_name_cstring() const
     case Gcalc_function::op_symdifference:
       return { STRING_WITH_LEN("st_symdifference") };
     default:
-      DBUG_ASSERT(0);  // Should never happen
+      DBUG_ASSERT_NO_ASSUME(0);  // Should never happen
       return { STRING_WITH_LEN("sp_unknown") };
   }
 }

--- a/sql/item_geofunc.h
+++ b/sql/item_geofunc.h
@@ -551,7 +551,7 @@ public:
       case SP_EXTERIORRING:
         return exteriorring;
       default:
-	DBUG_ASSERT(0);  // Should never happened
+	DBUG_ASSERT_NO_ASSUME(0);  // Should never happened
         return unknown;
     }
   }
@@ -590,7 +590,7 @@ public:
       case SP_INTERIORRINGN:
         return interiorringn;
       default:
-	DBUG_ASSERT(0);  // Should never happened
+	DBUG_ASSERT_NO_ASSUME(0);  // Should never happened
         return unknown;
     }
   }

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -730,7 +730,7 @@ String *Item_func_decode_histogram::val_str(String *str)
       break;
     default:
       val= 0;
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
     }
     /* show delta with previous value */
     size_t size= my_snprintf(numbuf, sizeof(numbuf),
@@ -1392,7 +1392,7 @@ String *Item_func_sformat::val_str(String *res)
     case TIME_RESULT: // TODO
     case ROW_RESULT: // TODO
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return NULL;
     }
   }
@@ -2137,7 +2137,7 @@ String *Item_func_substr_index::val_str(String *str)
       }
     }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL;
 }
 
@@ -4890,7 +4890,7 @@ bool Item_func_dyncol_create::prepare_arguments(THD *thd, bool force_names_arg)
       args[valpos]->get_time(thd, &vals[i].x.time_value);
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       vals[i].type= DYN_COL_NULL;
     }
     if (vals[i].type != DYN_COL_NULL && args[valpos]->null_value)

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -2137,7 +2137,7 @@ Item_in_subselect::single_value_transformer(JOIN *join)
     thd->lex->current_select= current;
 
     /* We will refer to upper level cache array => we have to save it for SP */
-    DBUG_ASSERT(optimizer->get_cache()[0]->is_array_kept());
+    DBUG_ASSERT_NO_ASSUME(optimizer->get_cache()[0]->is_array_kept());
 
     /*
       As far as  Item_in_optimizer does not substitute itself on fix_fields
@@ -2148,7 +2148,6 @@ Item_in_subselect::single_value_transformer(JOIN *join)
                               no_matter_name,
 			      in_left_expr_name);
   }
-
   DBUG_RETURN(false);
 }
 
@@ -2537,7 +2536,7 @@ Item_in_subselect::row_value_transformer(JOIN *join)
     }
 
     // we will refer to upper level cache array => we have to save it in PS
-    DBUG_ASSERT(optimizer->get_cache()[0]->is_array_kept());
+    DBUG_ASSERT_NO_ASSUME(optimizer->get_cache()[0]->is_array_kept());
 
     thd->lex->current_select= current;
     /*
@@ -5322,7 +5321,7 @@ bool subselect_hash_sj_engine::init(List<Item> *tmp_columns, uint subquery_id)
   if (tmp_table->s->keys == 0)
   {
     //fprintf(stderr, "Q: %s\n", current_thd->query());
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     DBUG_ASSERT(
       (tmp_table->key_info->flags & HA_UNIQUE_HASH) ||
       tmp_table->key_info->key_length >= tmp_table->file->max_key_length() ||

--- a/sql/item_sum.h
+++ b/sql/item_sum.h
@@ -485,7 +485,7 @@ public:
       should already be replaced to Item_aggregate_ref by the time when
       build_equal_items() is called. See Item::split_sum_func2().
     */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return Item::build_equal_items(thd, inherited, link_item_fields,
                                    cond_equal_ref);
   }

--- a/sql/lex_charset.cc
+++ b/sql/lex_charset.cc
@@ -218,7 +218,7 @@ bool Lex_exact_charset_opt_extended_collate::
   if (cl.is_contextually_typed_collate_default())
   {
     CHARSET_INFO *ci= find_mapped_default_collation(used, map);
-    DBUG_ASSERT(ci);
+    DBUG_ASSERT_NO_ASSUME(ci);
     if (!ci)
       return true;
     m_ci= ci;
@@ -260,7 +260,7 @@ bool Lex_extended_collation_st::merge_exact_charset(Sql_used *used,
       return false;
     }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -292,7 +292,7 @@ bool Lex_extended_collation_st::
       return false;
     }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -321,7 +321,7 @@ bool Lex_extended_collation_st::
       return Lex_context_collation(m_ci).raise_if_not_equal(rhs);
     }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -354,7 +354,7 @@ bool Lex_extended_collation_st::merge(const Lex_extended_collation_st &rhs)
     return raise_if_conflicts_with_context_collation(
              Lex_context_collation(rhs.m_ci));
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -446,7 +446,7 @@ Lex_exact_charset_opt_extended_collate::find_compiled_default_collation() const
     The above should never fail, as we have default collations for
     all character sets.
   */
-  DBUG_ASSERT(cs);
+  DBUG_ASSERT_NO_ASSUME(cs);
   return cs;
 }
 
@@ -500,7 +500,7 @@ CHARSET_INFO *Lex_exact_charset_extended_collation_attrs_st::
     return tmp.collation().charset_info();
   }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL;
 }
 
@@ -541,7 +541,7 @@ bool Lex_exact_charset_extended_collation_attrs_st::
       return false;
     }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -578,7 +578,7 @@ bool Lex_exact_charset_extended_collation_attrs_st::
     return Lex_context_collation(m_ci).raise_if_not_equal(cl);
   }
 
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -629,7 +629,7 @@ bool Lex_exact_charset_extended_collation_attrs_st::
     return merge_context_collation(used, map,
                                    Lex_context_collation(cl.charset_info()));
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -679,7 +679,7 @@ bool Lex_exact_charset_extended_collation_attrs_st::
       return false;
     }
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -807,6 +807,6 @@ Lex_extended_charset_extended_collation_attrs_st::
                                        ctx.charset_default().
                                          collation().charset_info());
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL;
 }

--- a/sql/lex_charset.h
+++ b/sql/lex_charset.h
@@ -286,7 +286,7 @@ public:
     case TYPE_EXACT:
       return m_ci->coll_name;
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return m_ci->coll_name;
   }
   static Lex_extended_collation_st collate_default()
@@ -378,7 +378,7 @@ public:
       return merge_context_collation(used, map,
                                      Lex_context_collation(cl.charset_info()));
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return false;
   }
   bool merge_collation_override(Sql_used *used,
@@ -393,7 +393,7 @@ public:
       return merge_context_collation_override(
         used, map, Lex_context_collation(cl.charset_info()));
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return false;
   }
   /*
@@ -487,7 +487,7 @@ protected:
     case Lex_extended_collation_st::TYPE_CONTEXTUALLY_TYPED:
       return TYPE_COLLATE_CONTEXTUALLY_TYPED;
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return TYPE_COLLATE_EXACT;
   }
 public:
@@ -616,7 +616,7 @@ public:
     case TYPE_CHARACTER_SET_COLLATE_EXACT:
       break;
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return false;
   }
   /*
@@ -642,7 +642,7 @@ public:
     case TYPE_CHARACTER_SET_COLLATE_EXACT:
       break;
     }
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return false;
   }
   bool merge_exact_charset(Sql_used *used,

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -8383,7 +8383,7 @@ MYSQL_BIN_LOG::write_gtid_event(THD *thd, binlog_cache_data *cache_data,
     Check that any binlogging during DDL recovery preserves the FL_DLL flag
     on the GTID event.
   */
-  DBUG_ASSERT((gtid_event.flags2 & Gtid_log_event::FL_DDL) ||
+  DBUG_ASSERT_NO_ASSUME((gtid_event.flags2 & Gtid_log_event::FL_DDL) ||
               !is_in_ddl_recovery);
 
   if (opt_binlog_engine_hton)
@@ -9732,7 +9732,7 @@ int Event_log::write_cache_raw(THD *thd, IO_CACHE *cache)
       DBUG_RETURN(res);
     IF_DBUG(total-= read_len,);
   } while (my_b_fill(cache));
-  DBUG_ASSERT(total == 0);
+  DBUG_ASSERT_NO_ASSUME(total == 0);
   DBUG_RETURN(0);
 }
 

--- a/sql/log.h
+++ b/sql/log.h
@@ -116,7 +116,7 @@ public:
   int log_and_order(THD *thd, my_xid xid, bool all,
                     bool need_prepare_ordered, bool need_commit_ordered) override
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 1;
   }
   int unlog(THD *thd, ulong cookie, my_xid xid) override  { return 0; }
@@ -516,7 +516,7 @@ public:
   {
     IF_DBUG(auto prev= ,)
     ref_count.fetch_add(1);
-    DBUG_ASSERT(prev != 0);
+    DBUG_ASSERT_NO_ASSUME(prev != 0);
   }
 
   void release()

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -914,7 +914,7 @@ Log_event* Log_event::read_log_event(IO_CACHE* file, int *out_error,
       goto err;
     case LOG_READ_CHECKSUM_FAILURE:
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       error= "internal error";
       goto err;
   }

--- a/sql/log_event_client.cc
+++ b/sql/log_event_client.cc
@@ -1475,7 +1475,7 @@ void Rows_log_event::count_row_events(PRINT_EVENT_INFO *print_event_info)
     row_events= 2;
     break;
   default:
-    DBUG_ASSERT(0); /* Not possible */
+    DBUG_ASSERT_NO_ASSUME(0); /* Not possible */
     return;
   }
 
@@ -1578,7 +1578,7 @@ bool Rows_log_event::print_verbose(IO_CACHE *file,
   default:
     sql_command= sql_clause1= sql_clause2= NULL;
     sql_command_short= "";
-    DBUG_ASSERT(0); /* Not possible */
+    DBUG_ASSERT_NO_ASSUME(0); /* Not possible */
   }
 
   if (!(map= print_event_info->m_table_map.get_table(m_table_id)) ||

--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -2864,7 +2864,7 @@ Rotate_log_event::do_shall_skip(rpl_group_info *rgi)
   case Log_event::EVENT_SKIP_IGNORE:
     return Log_event::EVENT_SKIP_IGNORE;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return Log_event::EVENT_SKIP_NOT;             // To keep compiler happy
 }
 
@@ -3880,7 +3880,7 @@ int Xid_apply_log_event::do_apply_event(rpl_group_info *rgi)
   {
     DBUG_ASSERT(!thd->transaction->xid_state.is_explicit_XA());
 
-    DBUG_ASSERT(record_gtid_delayed_for_xa);
+    DBUG_ASSERT_NO_ASSUME(record_gtid_delayed_for_xa);
     if (thd->rgi_slave->is_parallel_exec)
     {
       /*
@@ -4214,7 +4214,7 @@ bool User_var_log_event::write(Log_event_writer *writer)
       break;
     case ROW_RESULT:
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return 0;
     }
     int4store(buf1 + 2 + UV_CHARSET_NUMBER_SIZE, val_len);
@@ -4334,7 +4334,7 @@ int User_var_log_event::do_apply_event(rpl_group_info *rgi)
       break;
     case ROW_RESULT:
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_RETURN(0);
     }
   }

--- a/sql/my_decimal.cc
+++ b/sql/my_decimal.cc
@@ -385,7 +385,7 @@ my_decimal::my_decimal(Field *field)
   my_decimal *dec=
 #endif
   field->val_decimal(this);
-  DBUG_ASSERT(dec == this);
+  DBUG_ASSERT_NO_ASSUME(dec == this);
 }
 
 

--- a/sql/my_json_writer.h
+++ b/sql/my_json_writer.h
@@ -32,7 +32,7 @@
 #else
 #include "sql_class.h"  // For class THD
 #include "log.h" // for sql_print_error
-#define VALIDITY_ASSERT(x) DBUG_ASSERT(x)
+#define VALIDITY_ASSERT(x) DBUG_ASSERT_NO_ASSUME(x)
 #endif
 
 #include <type_traits>

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5911,7 +5911,7 @@ static void test_lc_time_sz()
     {
       DBUG_PRINT("Wrong max day name(or month name) length for locale:",
                  ("%s", (*loc)->name.str));
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
     }
   }
   DBUG_VOID_RETURN;

--- a/sql/net_serv.cc
+++ b/sql/net_serv.cc
@@ -768,7 +768,7 @@ static handle_proxy_header_result handle_proxy_header(NET *net)
 
   if (!thd->net.vio)
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return ABORT;
   }
 

--- a/sql/opt_hints_parser.cc
+++ b/sql/opt_hints_parser.cc
@@ -408,7 +408,7 @@ bool Parser::Table_level_hint::resolve(Parse_context *pc) const
     hint_state= false;
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return true;
   }
 

--- a/sql/opt_histogram_json.cc
+++ b/sql/opt_histogram_json.cc
@@ -1144,7 +1144,7 @@ int Histogram_json_hb::find_bucket(const Field *field, const uchar *lookup_val,
 
 end:
   // Verification: *cmp has correct value
-  DBUG_ASSERT(SGN(*cmp) ==
+  DBUG_ASSERT_NO_ASSUME(SGN(*cmp) ==
               SGN(field->key_cmp(lookup_val,
                                  (uchar*)buckets[low].start_value.data())));
   // buckets[low] <= lookup_val, with one exception of the first bucket.

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -9867,7 +9867,7 @@ SEL_ARG *Field::stored_field_make_mm_leaf(RANGE_OPT_PARAM *param,
     DBUG_RETURN(new (mem_root) SEL_ARG(this, str, str));
     break;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   DBUG_RETURN(NULL);
 }
 
@@ -9896,7 +9896,7 @@ SEL_ARG *Field::stored_field_make_mm_leaf_exact(RANGE_OPT_PARAM *param,
     DBUG_RETURN(new (param->mem_root) SEL_ARG(this, str, str));
     break;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   DBUG_RETURN(NULL);
 }
 

--- a/sql/opt_rewrite_date_cmp.cc
+++ b/sql/opt_rewrite_date_cmp.cc
@@ -101,7 +101,7 @@ bool Date_cmp_func_rewriter::check_cond_match_and_prepare(
 {
   if (thd->lex->is_ps_or_view_context_analysis())
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return false;
   }
 
@@ -314,7 +314,7 @@ Item *Date_cmp_func_rewriter::create_cmp_func(Item_func::Functype func_type,
       res= new (thd->mem_root) Item_func_lt(thd, arg1, arg2);
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       res= NULL;
   }
   return res;

--- a/sql/opt_subselect.cc
+++ b/sql/opt_subselect.cc
@@ -3151,7 +3151,7 @@ void optimize_semi_joins(JOIN *join, table_map remaining_tables, uint idx,
           sname= "LooseScan";
           break;
         default:
-          DBUG_ASSERT(0);
+          DBUG_ASSERT_NO_ASSUME(0);
           sname="Invalid";
       }
       tr.add("chosen_strategy", sname);

--- a/sql/parse_file.cc
+++ b/sql/parse_file.cc
@@ -98,7 +98,7 @@ static ulonglong view_algo_to_frm(ulonglong val)
     case VIEW_ALGORITHM_TMPTABLE:
       return VIEW_ALGORITHM_TMPTABLE_FRM;
   }
-  DBUG_ASSERT(0); /* Should never happen */
+  DBUG_ASSERT_NO_ASSUME(0); /* Should never happen */
   return VIEW_ALGORITHM_UNDEFINED;
 }
 

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -718,7 +718,7 @@ char *partition_info::find_duplicate_name()
                    Lex_ident_partition::charset_info(),
                    max_names, 0, 0, get_part_name_from_elem, 0, HASH_UNIQUE))
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     curr_name= (const uchar*) "Internal failure";
     goto error;
   }

--- a/sql/procedure.h
+++ b/sql/procedure.h
@@ -59,7 +59,7 @@ public:
   unsigned int size_of() { return sizeof(*this);}
   bool check_vcol_func_processor(void *arg) override
   {
-    DBUG_ASSERT(0); // impossible
+    DBUG_ASSERT_NO_ASSUME(0); // impossible
     return mark_unsupported_function("proc", arg, VCOL_IMPOSSIBLE);
   }
   bool get_date(THD *thd, MYSQL_TIME *ltime, date_mode_t fuzzydate) override

--- a/sql/protocol.cc
+++ b/sql/protocol.cc
@@ -636,7 +636,7 @@ void Protocol::end_statement()
   case Diagnostics_area::DA_EMPTY:
   default:
     thd->stop_collecting_unit_results();
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     error= send_ok(thd->server_status, 0, 0, 0, NULL);
     break;
   }
@@ -1163,13 +1163,13 @@ static bool should_send_column_info(THD* thd, List<Item>* list, uint flags)
   auto cmd= thd->get_command();
 #endif
 
-  DBUG_ASSERT(cmd == COM_STMT_EXECUTE || cmd == COM_STMT_PREPARE
+  DBUG_ASSERT_NO_ASSUME(cmd == COM_STMT_EXECUTE || cmd == COM_STMT_PREPARE
               || cmd == COM_STMT_BULK_EXECUTE);
-  DBUG_ASSERT(cmd != COM_STMT_PREPARE || !column_info_state.initialized);
+  DBUG_ASSERT_NO_ASSUME(cmd != COM_STMT_PREPARE || !column_info_state.initialized);
 
   bool ret= metadata_columns_changed(column_info_state, thd, *list);
 
-  DBUG_ASSERT(cmd != COM_STMT_PREPARE || ret);
+  DBUG_ASSERT_NO_ASSUME(cmd != COM_STMT_PREPARE || ret);
   if (!ret)
     thd->status_var.skip_metadata_count++;
 
@@ -1570,7 +1570,7 @@ bool Protocol_text::store_longlong(longlong from, bool unsigned_flag)
 bool Protocol_text::store_decimal(const my_decimal *d)
 {
 #ifndef DBUG_OFF
-  DBUG_ASSERT(0); // This method is not used yet
+  DBUG_ASSERT_NO_ASSUME(0); // This method is not used yet
   field_pos++;
 #endif
   StringBuffer<DECIMAL_MAX_STR_LENGTH> str;
@@ -1689,7 +1689,7 @@ bool Protocol_text::send_out_parameters(List<Item_param> *sp_params)
 
     if (!(sparam= param->get_settable_routine_parameter()))
     {
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       continue;
     }
 

--- a/sql/rowid_filter.cc
+++ b/sql/rowid_filter.cc
@@ -36,7 +36,7 @@ lookup_cost(Rowid_filter_container_type cont_type)
   case SORTED_ARRAY_CONTAINER:
     return log2(est_elements) * rowid_compare_cost + base_lookup_cost;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   }
 }
@@ -167,7 +167,7 @@ Range_rowid_filter_cost_info::build_cost(Rowid_filter_container_type cont_type)
              costs->rowid_cmp_cost * log2(est_elements))); // Sort
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
   }
 
   return cost;
@@ -186,7 +186,7 @@ Rowid_filter_container *Range_rowid_filter_cost_info::create_container()
                                                        elem_sz);
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
   }
   return res;
 }
@@ -337,7 +337,7 @@ get_max_range_rowid_filter_elems_for_table(
   case SORTED_ARRAY_CONTAINER :
     return thd->variables.max_rowid_filter_size/tab->file->ref_length;
   default :
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   }
 }

--- a/sql/rpl_gtid.cc
+++ b/sql/rpl_gtid.cc
@@ -336,7 +336,7 @@ rpl_slave_state::update_nolock(uint32 domain_id, uint32 server_id, uint64 sub_id
 #endif
       uint32 count= elem->owner_count;
       DBUG_ASSERT(count > 0);
-      DBUG_ASSERT(elem->owner_rli == rli);
+      DBUG_ASSERT_NO_ASSUME(elem->owner_rli == rli);
       --count;
       elem->owner_count= count;
       if (count == 0)
@@ -2541,7 +2541,7 @@ slave_connection_state::remove(const rpl_gtid *in_gtid)
   err= 
 #endif
     my_hash_delete(&hash, rec);
-  DBUG_ASSERT(!err);
+  DBUG_ASSERT_NO_ASSUME(!err);
 }
 
 
@@ -3591,7 +3591,7 @@ Id_delegating_gtid_event_filter<T>::Id_delegating_gtid_event_filter()
   if (std::is_same<T,uint32>::value)
     free_func= free_u32_gtid_filter_element;
   else
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
 
   my_hash_init(PSI_INSTRUMENT_ME, &m_filters_by_id_hash, &my_charset_bin, 32,
                offsetof(gtid_filter_element<T>, identifier),

--- a/sql/rpl_parallel.cc
+++ b/sql/rpl_parallel.cc
@@ -2500,7 +2500,7 @@ static bool handle_split_alter(rpl_parallel_entry *e,
       j= j % e->rpl_thread_max;
     }
     //We did not find and idx
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
 
     return false;
 

--- a/sql/rpl_reporting.cc
+++ b/sql/rpl_reporting.cc
@@ -62,7 +62,7 @@ Slave_reporting_capability::report(loglevel level, int err_code,
     break;
   default:
     va_end(args);
-    DBUG_ASSERT(0);                            // should not come here
+    DBUG_ASSERT_NO_ASSUME(0);                            // should not come here
     return;          // don't crash production builds, just do nothing
   }
 

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2394,11 +2394,11 @@ mark_start_commit_inner(rpl_parallel_entry *e, group_commit_orderer *gco,
   /* Signal any following GCO whose wait_count has been reached now. */
   tmp= gco;
 
-  DBUG_ASSERT(!tmp->gc_done);
+  DBUG_ASSERT_NO_ASSUME(!tmp->gc_done);
 
   while ((tmp= tmp->next_gco))
   {
-    DBUG_ASSERT(!tmp->gc_done);
+    DBUG_ASSERT_NO_ASSUME(!tmp->gc_done);
 
     uint64 wait_count= tmp->wait_count;
     if (wait_count > count)

--- a/sql/rpl_utility.cc
+++ b/sql/rpl_utility.cc
@@ -339,7 +339,7 @@ bool event_checksum_test(uchar *event_buf, size_t event_len,
          The only algorithm currently is CRC32. Zero indicates 
          the binlog file is checksum-free *except* the FD-event.
       */
-      DBUG_ASSERT(fd_alg == BINLOG_CHECKSUM_ALG_CRC32 || fd_alg == 0);
+      DBUG_ASSERT_NO_ASSUME(fd_alg == BINLOG_CHECKSUM_ALG_CRC32 || fd_alg == 0);
       DBUG_ASSERT(alg == BINLOG_CHECKSUM_ALG_CRC32);
       /*
         Complile time guard to watch over  the max number of alg

--- a/sql/semisync_master.cc
+++ b/sql/semisync_master.cc
@@ -964,8 +964,8 @@ int Repl_semi_sync_master::commit_trx(const char *trx_wait_binlog_name,
          * semi-sync was turned off then on, so on debug builds, we track
          * the number of times semi-sync turned off at binlogging, and compare
          * to the current value. */
-        DBUG_ASSERT(rpl_semi_sync_master_off_times >
-                    thd->expected_semi_sync_offs);
+        DBUG_ASSERT_NO_ASSUME(rpl_semi_sync_master_off_times >
+                              thd->expected_semi_sync_offs);
 
         break;
       }

--- a/sql/semisync_master.h
+++ b/sql/semisync_master.h
@@ -183,7 +183,7 @@ public:
     }
 
     /* Node does not find should never happen */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 1;
   }
 

--- a/sql/service_wsrep.cc
+++ b/sql/service_wsrep.cc
@@ -195,9 +195,9 @@ extern "C" void wsrep_handle_SR_rollback(THD *bf_thd __attribute__((unused)),
     We should always be in victim_thd context, either client session is
     rolling back or rollbacker thread should be in control.
   */
-  DBUG_ASSERT(victim_thd);
-  DBUG_ASSERT(current_thd == victim_thd);
-  DBUG_ASSERT(wsrep_thd_is_SR(victim_thd));
+  DBUG_ASSERT_NO_ASSUME(victim_thd);
+  DBUG_ASSERT_NO_ASSUME(current_thd == victim_thd);
+  DBUG_ASSERT_NO_ASSUME(wsrep_thd_is_SR(victim_thd));
 
   /* Defensive measure to avoid crash in production. */
   if (!victim_thd) return;

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -1368,7 +1368,7 @@ enum sys_var::where get_sys_var_value_origin(void *ptr)
     }
   }
 
-  DBUG_ASSERT(0); // variable must have been found
+  DBUG_ASSERT_NO_ASSUME(0); // variable must have been found
   return sys_var::CONFIG;
 }
 

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -6237,7 +6237,7 @@ static int queue_event(Master_info* mi, const uchar *buf, ulong event_len)
               mi->gtid_current_pos.find(mi->last_queued_gtid.domain_id),);
 
       // Slave gtid state must not have updated yet to the last received gtid.
-      DBUG_ASSERT((mi->using_gtid == Master_info::USE_GTID_NO ||
+      DBUG_ASSERT_NO_ASSUME((mi->using_gtid == Master_info::USE_GTID_NO ||
                    !opt_gtid_strict_mode) ||
                   (!gtid_in_slave_state ||
                    !(*gtid_in_slave_state == mi->last_queued_gtid)));

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -1346,7 +1346,7 @@ Sp_handler::sp_create_routine(THD *thd, const sp_head *sp) const
           break;
         case SP_TYPE_TRIGGER:
         case SP_TYPE_EVENT:
-          DBUG_ASSERT(0);
+          DBUG_ASSERT_NO_ASSUME(0);
           ret= SP_OK;
         }
       }

--- a/sql/sp_instr.cc
+++ b/sql/sp_instr.cc
@@ -350,7 +350,8 @@ sp_lex_keeper::reset_lex_and_exec_core(THD *thd, uint *nextp,
        (assoc_array(spvar_latin1 || CONVERT(' ' USING ucs2)));
     wraps CONVERT into Item_func_conv_charset.
   */
-  DBUG_ASSERT(dbug_rqp_are_fixed(instr) || thd->Item_change_list::is_empty());
+  DBUG_ASSERT_NO_ASSUME(dbug_rqp_are_fixed(instr) ||
+                        thd->Item_change_list::is_empty());
   /*
     Use our own lex.
     We should not save old value since it is saved/restored in

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -4083,14 +4083,15 @@ static bool add_role_user_mapping(const LEX_CSTRING &uname,
 */
 static void remove_ptr_from_dynarray(DYNAMIC_ARRAY *array, void *ptr)
 {
-  bool found __attribute__((unused))= false;
+  bool found= false;
   for (size_t i= 0; i < array->elements; i++)
   {
     if (ptr == *dynamic_element(array, i, void**))
     {
       DBUG_ASSERT(!found);
       delete_dynamic_element(array, i);
-      IF_DBUG_ASSERT(found= true, break);
+      found= true;
+      IF_DBUG_ASSERT(, break);
     }
   }
   DBUG_ASSERT(found);
@@ -6443,7 +6444,7 @@ static enum PRIVS_TO_MERGE::what sp_privs_to_merge(enum_sp_type type)
   case SP_TYPE_TRIGGER:
     break;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return PRIVS_TO_MERGE::PROC;
 }
 
@@ -10742,7 +10743,7 @@ static int handle_grant_struct(enum enum_acl_lists struct_no, bool drop,
     elements= roles_mappings_hash->records;
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     DBUG_RETURN(-1);
   }
 

--- a/sql/sql_acl_getsort.inl
+++ b/sql/sql_acl_getsort.inl
@@ -205,7 +205,7 @@ static ulonglong get_magic_sort(const char *templ, ...)
     sort= (sort << magic_bits) + magic;
     IF_DBUG(bits_used+= magic_bits,);
   }
-  DBUG_ASSERT(bits_used < 8*sizeof(sort));
+  DBUG_ASSERT_NO_ASSUME(bits_used < 8*sizeof(sort));
   va_end(args);
   return ~sort;
 }

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -107,7 +107,7 @@ const char* Alter_info::algorithm_clause(THD *thd) const
   case ALTER_TABLE_ALGORITHM_COPY:
     return "ALGORITHM=COPY";
   case ALTER_TABLE_ALGORITHM_NONE:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     /* Fall through */
   case ALTER_TABLE_ALGORITHM_DEFAULT:
     return "ALGORITHM=DEFAULT";
@@ -175,7 +175,7 @@ bool Alter_info::supports_algorithm(THD *thd,
     return true;
   }
   /* purecov: begin deadcode */
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -221,7 +221,7 @@ bool Alter_info::supports_lock(THD *thd, bool online,
     return true;
   }
   /* purecov: begin deadcode */
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -1030,7 +1030,7 @@ void close_thread_table(THD *thd, TABLE **table_ptr)
     The metadata lock must be released after giving back
     the table to the table cache.
   */
-  DBUG_ASSERT(thd->mdl_context.is_lock_owner(MDL_key::TABLE,
+  DBUG_ASSERT_NO_ASSUME(thd->mdl_context.is_lock_owner(MDL_key::TABLE,
                                              table->s->db.str,
                                              table->s->table_name.str,
                                              MDL_SHARED) ||
@@ -6156,7 +6156,7 @@ bool restart_trans_for_tables(THD *thd, TABLE_LIST *table)
 
     if (check_lock_and_start_stmt(thd, thd->lex, table))
     {
-      DBUG_ASSERT(0);                           // Should never happen
+      DBUG_ASSERT_NO_ASSUME(0);                           // Should never happen
       DBUG_RETURN(TRUE);
     }
   }

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -1219,7 +1219,7 @@ void Query_cache::end_of_result(THD *thd)
         to this function. In the release version that query should be ignored
         and removed from QC.
       */
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       free_query(query_block);
       unlock();
       DBUG_VOID_RETURN;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4036,7 +4036,7 @@ void select_max_min_finder_subselect::set_op(const Type_handler *th)
     break;
   case ROW_RESULT:
     // This case should never be chosen
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     op= 0;
   }
 }
@@ -4475,7 +4475,7 @@ void THD::end_statement()
 void THD::set_n_backup_active_arena(Query_arena *set, Query_arena *backup)
 {
   DBUG_ENTER("THD::set_n_backup_active_arena");
-  DBUG_ASSERT(backup->is_backup_arena == FALSE);
+  DBUG_ASSERT_NO_ASSUME(backup->is_backup_arena == FALSE);
 
   backup->set_query_arena(this);
   set_query_arena(set);
@@ -4495,7 +4495,7 @@ void THD::set_n_backup_active_arena(Query_arena *set, Query_arena *backup)
 void THD::restore_active_arena(Query_arena *set, Query_arena *backup)
 {
   DBUG_ENTER("THD::restore_active_arena");
-  DBUG_ASSERT(backup->is_backup_arena);
+  DBUG_ASSERT_NO_ASSUME(backup->is_backup_arena);
   set->set_query_arena(this);
   set_query_arena(backup);
 #ifdef DBUG_ASSERT_EXISTS

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -732,7 +732,7 @@ class Time_zone;
 #define THD_SENTRY_MAGIC 0xfeedd1ff
 #define THD_SENTRY_GONE  0xdeadbeef
 
-#define THD_CHECK_SENTRY(thd) DBUG_ASSERT(thd->dbug_sentry == THD_SENTRY_MAGIC)
+#define THD_CHECK_SENTRY(thd) DBUG_ASSERT_NO_ASSUME(thd->dbug_sentry == THD_SENTRY_MAGIC)
 
 typedef struct system_variables
 {

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -968,7 +968,7 @@ int thd_set_peer_addr(THD *thd,
       addr_data= &((struct sockaddr_in6 *)addr)->sin6_addr;
     if (!inet_ntop(addr->ss_family,addr_data, ip_string, sizeof(ip_string)))
     {
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return 1;
     }
     ip= ip_string;

--- a/sql/sql_explain.cc
+++ b/sql/sql_explain.cc
@@ -125,7 +125,7 @@ void Explain_query::add_node(Explain_node *node)
     Explain_select *sel= (Explain_select*)node;
     if (sel->select_id == FAKE_SELECT_LEX_ID)
     {
-      DBUG_ASSERT(0); // this is a "fake select" from a UNION.
+      DBUG_ASSERT_NO_ASSUME(0); // this is a "fake select" from a UNION.
     }
     else
     {
@@ -555,7 +555,7 @@ uint Explain_union::make_union_table_name(char *buf)
       type= { STRING_WITH_LEN("<except") };
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       type= { NULL, 0 };
   }
   memcpy(buf, type.str, (len= (uint)type.length));
@@ -2584,7 +2584,7 @@ const char * Explain_quick_select::get_name_by_type()
     case QUICK_SELECT_I::QS_TYPE_INDEX_INTERSECT:
       return "sort_intersect";
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return "unknown quick select type";
   }
 }

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -5045,15 +5045,12 @@ TABLE *select_create::create_table_from_items(THD *thd, List<Item> *items,
         table->create_info.
       */
       table_list->table= create_info->table;
-      if (!table_list->table)
-      {
-        /*
-          This shouldn't happen as creation of temporary table should make
-          it preparable for open. Anyway we can't drop temporary table if
-          we are unable to find it.
-        */
-        DBUG_ASSERT(0);
-      }
+      /*
+        This shouldn't happen as creation of temporary table should make
+        it preparable for open. Anyway we can't drop temporary table if
+        we are unable to find it.
+      */
+      DBUG_ASSERT(table_list->table);
       table_list->table->pos_in_table_list= table_list;
     }
   }

--- a/sql/sql_join_cache.cc
+++ b/sql/sql_join_cache.cc
@@ -1710,7 +1710,7 @@ enum JOIN_CACHE::Match_flag JOIN_CACHE::get_match_flag_by_pos(uchar *rec_ptr)
     uchar *prev_rec_ptr= prev_cache->get_rec_ref(rec_ptr);
     return prev_cache->get_match_flag_by_pos(prev_rec_ptr);
   } 
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return match_fl;
 }
 

--- a/sql/sql_join_cache.h
+++ b/sql/sql_join_cache.h
@@ -474,7 +474,7 @@ protected:
   /* Shall set an auxiliary buffer up (currently used only by BKA joins) */
   virtual int setup_aux_buffer(HANDLER_BUFFER &aux_buff) 
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   }
 

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -8737,7 +8737,7 @@ Item *LEX::make_item_plsql_cursor_attr(THD *thd, const LEX_CSTRING *name,
   case PLSQL_CURSOR_ATTR_ROWCOUNT:
     return new (thd->mem_root) Item_func_cursor_rowcount(thd, ref);
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL;
 }
 
@@ -10754,7 +10754,7 @@ Item *Lex_trim_st::make_item_func_trim_std(THD *thd) const
   case TRIM_TRAILING:
    return new (thd->mem_root) Item_func_rtrim(thd, m_source);
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL;
 }
 
@@ -10781,7 +10781,7 @@ Item *Lex_trim_st::make_item_func_trim_oracle(THD *thd) const
   case TRIM_TRAILING:
    return new (thd->mem_root) Item_func_rtrim_oracle(thd, m_source);
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return NULL;
 }
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3097,7 +3097,7 @@ mysql_create_routine(THD *thd, LEX *lex)
 {
   DBUG_ASSERT(lex->sphead != 0);
   DBUG_ASSERT(lex->sphead->m_db.str); /* Must be initialized in the parser */
-  DBUG_ASSERT(lower_case_table_names != 1 ||
+  DBUG_ASSERT_NO_ASSUME(lower_case_table_names != 1 ||
               Lex_ident_fs(lex->sphead->m_db).is_in_lower_case());
 
   if (Lex_ident_db::check_name_with_error(lex->sphead->m_db))

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -396,7 +396,7 @@ static bool set_up_field_array(THD *thd, TABLE *table, bool is_sub_part)
               add_column_list_values, handle_list_of_fields,
               check_partition_info etc.
             */
-            DBUG_ASSERT(0);
+            DBUG_ASSERT_NO_ASSUME(0);
             my_error(ER_FIELD_NOT_FOUND_PART_ERROR, MYF(0));
             result= TRUE;
             continue;
@@ -2547,7 +2547,7 @@ int partition_info::gen_part_type(THD *thd, String *str) const
       err+= str->append(STRING_WITH_LEN("SYSTEM_TIME "));
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       /* We really shouldn't get here, no use in continuing from here */
       my_error(ER_OUT_OF_RESOURCES, MYF(ME_FATAL));
       return -1;

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -105,7 +105,7 @@ bool Sql_cmd_alter_table_exchange_partition::execute(THD *thd)
     DBUG_RETURN(TRUE);
 
   /* Not allowed with EXCHANGE PARTITION */
-  DBUG_ASSERT(!create_info.data_file_name && !create_info.index_file_name);
+  DBUG_ASSERT_NO_ASSUME(!create_info.data_file_name && !create_info.index_file_name);
   WSREP_TO_ISOLATION_BEGIN_WRTCHK(NULL, NULL, first_table);
 
   DBUG_RETURN(exchange_partition(thd, first_table, &alter_info));

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -3042,7 +3042,7 @@ static size_t var_storage_size(int flags)
   case PLUGIN_VAR_SET:          return sizeof(ulonglong);
   case PLUGIN_VAR_STR:          return sizeof(char*);
   case PLUGIN_VAR_DOUBLE:       return sizeof(double);
-  default: DBUG_ASSERT(0);      return 0;
+  default: DBUG_ASSERT_NO_ASSUME(0);      return 0;
   }
 }
 
@@ -3121,7 +3121,7 @@ static st_bookmark *register_var(const char *plugin, const char *name,
     if (my_hash_insert(&bookmark_hash, (uchar*) result))
     {
       fprintf(stderr, "failed to add placeholder to hash");
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
     }
   }
   my_afree(varname);
@@ -3486,7 +3486,7 @@ static SHOW_TYPE pluginvar_show_type(const st_mysql_sys_var *plugin_var)
   case PLUGIN_VAR_DOUBLE:
     return SHOW_DOUBLE;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return SHOW_UNDEF;
   }
 }
@@ -3579,7 +3579,7 @@ bool sys_var_pluginvar::session_is_default(THD *thd)
   case PLUGIN_VAR_DOUBLE:
     return getopt_ulonglong2double(option.def_value) == *(double*)value;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return 0;
 }
 
@@ -3684,7 +3684,7 @@ static const void *var_def_ptr(st_mysql_sys_var *pv)
     case PLUGIN_VAR_DOUBLE | PLUGIN_VAR_THDLOCAL:
       return &((thdvar_double_t*) pv)->def_val;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return NULL;
     }
 }

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -1021,7 +1021,7 @@ static bool insert_bulk_params(Prepared_statement *stmt,
         param->set_ignore(false);
         break;
       default:
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
         DBUG_RETURN(1);
       }
     }
@@ -3138,7 +3138,7 @@ void reinit_stmt_before_use(THD *thd, LEX *lex)
       bool res=
 #endif
         sl->handle_derived(lex, DT_REINIT);
-      DBUG_ASSERT(res == 0);
+      DBUG_ASSERT_NO_ASSUME(res == 0);
     }
 
     {
@@ -4899,7 +4899,7 @@ reexecute:
       allocated items when cleaning up after validation of the prepared
       statement.
     */
-    DBUG_ASSERT(thd->free_list == free_list_state);
+    DBUG_ASSERT_NO_ASSUME(thd->free_list == free_list_state);
 
     /*
       Install the metadata observer. If some metadata version is

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -1647,7 +1647,7 @@ found_pos_check_gtid(const rpl_gtid *found_gtid, slave_connection_state *state,
       domain in earlier binlogs, and then we can not encounter it in any
       further GTIDs in the Gtid_list.
     */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
   } else if (gtid->server_id == found_gtid->server_id &&
              gtid->seq_no == found_gtid->seq_no)
   {

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -3941,7 +3941,7 @@ bool JOIN::make_aggr_tables_info()
   {
     aggr_tables++;
     curr_tab= join_tab + exec_join_tab_cnt();
-    DBUG_ASSERT(curr_tab - join_tab < dbug_join_tab_array_size);
+    DBUG_ASSERT_NO_ASSUME(curr_tab - join_tab < dbug_join_tab_array_size);
     bzero((void*)curr_tab, sizeof(JOIN_TAB));
     curr_tab->ref.key= -1;
     if (only_const_tables())
@@ -4081,7 +4081,7 @@ bool JOIN::make_aggr_tables_info()
 
       curr_tab++;
       aggr_tables++;
-      DBUG_ASSERT(curr_tab - join_tab < dbug_join_tab_array_size);
+      DBUG_ASSERT_NO_ASSUME(curr_tab - join_tab < dbug_join_tab_array_size);
       bzero((void*)curr_tab, sizeof(JOIN_TAB));
       curr_tab->ref.key= -1;
 
@@ -4711,7 +4711,7 @@ bool JOIN::shrink_join_buffers(JOIN_TAB *jt,
           Safety: fail if we've exhausted available buffer space with
           reduced join buffers.
         */
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
         return TRUE;
       }
       needed_space-= buff_size;
@@ -4848,7 +4848,7 @@ bool JOIN::save_explain_data(Explain_query *output, bool can_overwrite,
     If there is SELECT in this statement with the same number it must be the
     same SELECT
   */
-  DBUG_ASSERT(select_lex->select_number == FAKE_SELECT_LEX_ID || !output ||
+  DBUG_ASSERT_NO_ASSUME(select_lex->select_number == FAKE_SELECT_LEX_ID || !output ||
               !output->get_select(select_lex->select_number) ||
               output->get_select(select_lex->select_number)->select_lex ==
                 select_lex);
@@ -21648,7 +21648,7 @@ Field *Item_sum::create_tmp_field(MEM_ROOT *root, bool group, TABLE *table)
     break;
   case ROW_RESULT:
     // This case should never be chosen
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     new_field= 0;
     break;
   }
@@ -24996,7 +24996,7 @@ join_read_const_table(THD *thd, JOIN_TAB *tab, POSITION *pos)
   if (tab->table->pos_in_table_list->is_materialized_derived() &&
       !tab->table->pos_in_table_list->fill_me)
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     //TODO: don't get here at all
     /*
       Skip materialized derived tables/views as they temporary table is not
@@ -29373,7 +29373,7 @@ void calc_group_buffer(TMP_TABLE_PARAM *param, ORDER *group)
       }
       default:
         /* This case should never be chosen */
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
         my_error(ER_OUT_OF_RESOURCES, MYF(ME_FATAL));
       }
     }
@@ -31804,7 +31804,7 @@ static void print_table_array(THD *thd,
                                 ~eliminated_tables))))
     {
       /* as of 5.5, print_join doesnt put eliminated elements into array */
-      DBUG_ASSERT(0); 
+      DBUG_ASSERT_NO_ASSUME(0); 
       continue;
     }
 

--- a/sql/sql_servers.cc
+++ b/sql/sql_servers.cc
@@ -1022,7 +1022,7 @@ update_server_record(TABLE *table, FOREIGN_SERVER *server)
                                              server->server_name_length,
                                              system_charset_info))
   {
-    DBUG_ASSERT(0); /* Protected by servers_cache */
+    DBUG_ASSERT_NO_ASSUME(0); /* Protected by servers_cache */
     THD *thd= table->in_use;
     DBUG_ASSERT(thd->is_error());
     return thd->get_stmt_da()->get_sql_errno();

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -6326,7 +6326,7 @@ static bool print_anchor_data_type(const Spvar_definition *def,
     "ROW TYPE OF cursor" is not possible yet.
     May become possible when we add package-wide cursors.
   */
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -6355,7 +6355,7 @@ static bool print_anchor_dtd_identifier(THD *thd, const Spvar_definition *def,
            dtd_identifier->append(STRING_WITH_LEN("%ROWTYPE")) :
            dtd_identifier->append(STRING_WITH_LEN("ROW TYPE OF ")) ||
            def->table_rowtype_ref()->append_to(thd, dtd_identifier);
-  DBUG_ASSERT(0); // See comments in print_anchor_data_type()
+  DBUG_ASSERT_NO_ASSUME(0); // See comments in print_anchor_data_type()
   return false;
 }
 
@@ -8324,7 +8324,7 @@ static int get_schema_partitions_record(THD *thd, TABLE_LIST *tables,
       table->field[7]->store(STRING_WITH_LEN("SYSTEM_TIME"), cs);
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       my_error(ER_OUT_OF_RESOURCES, MYF(ME_FATAL));
       DBUG_RETURN(1);
     }

--- a/sql/sql_statistics.cc
+++ b/sql/sql_statistics.cc
@@ -716,7 +716,7 @@ public:
       store_stat_fields();
       if ((err= stat_file->ha_write_row(record[0])))
       {
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
 	return TRUE;
       }
     }
@@ -3643,7 +3643,7 @@ int rename_columns_in_stat_table(THD *thd, TABLE *tab,
           {
             if (likely(err != HA_ERR_FOUND_DUPP_KEY))
             {
-              DBUG_ASSERT(0);
+              DBUG_ASSERT_NO_ASSUME(0);
               it.remove();                      // Unknown error, ignore column
             }
             else

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7149,7 +7149,7 @@ static bool fill_alter_inplace_info(THD *thd, TABLE *table,
               it should have ealier called Column_definition_implicit_upgrade(),
               which replaces old data types to up-to-date data types.
           */
-          DBUG_ASSERT(0);
+          DBUG_ASSERT_NO_ASSUME(0);
           is_equal= false;
         }
       }
@@ -8518,7 +8518,7 @@ blob_length_by_type(enum_field_types type)
   case MYSQL_TYPE_LONG_BLOB:
     return (uint) UINT_MAX32;
   default:
-    DBUG_ASSERT(0); // we should never go here
+    DBUG_ASSERT_NO_ASSUME(0); // we should never go here
     return 0;
   }
 }
@@ -13442,8 +13442,6 @@ bool check_engine(THD *thd, const char *db_name,
   bool no_substitution= thd->variables.sql_mode & MODE_NO_ENGINE_SUBSTITUTION;
   *new_engine= ha_checktype(thd, req_engine, no_substitution);
   DBUG_ASSERT(*new_engine);
-  if (!*new_engine)
-    DBUG_RETURN(true);
 
   /*
     Enforced storage engine should not be used in ALTER TABLE that does not

--- a/sql/sql_time.cc
+++ b/sql/sql_time.cc
@@ -135,7 +135,7 @@ int append_interval(String *str, interval_type int_type, const INTERVAL &interva
     len= my_snprintf(buf,sizeof(buf),"%llu.%06llu", interval.second, interval.second_part);
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     len= 0;
   }
   return str->append(buf, len) || str->append(' ') ||
@@ -568,7 +568,7 @@ const char *get_date_time_format_str(KNOWN_DATE_TIME_FORMAT *format,
   case MYSQL_TIMESTAMP_TIME:
     return format->time_format;
   default:
-    DBUG_ASSERT(0);				// Impossible
+    DBUG_ASSERT_NO_ASSUME(0);				// Impossible
     return 0;
   }
 }

--- a/sql/sql_type.cc
+++ b/sql/sql_type.cc
@@ -404,7 +404,7 @@ uint Timestamp::binary_length_to_precision(uint length)
   case 6: return 4;
   case 7: return 6;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return 0;
 }
 
@@ -667,7 +667,7 @@ Interval_DDhhmmssff::Interval_DDhhmmssff(THD *thd, Status *st,
 {
   switch (item->cmp_type()) {
   case ROW_RESULT:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     time_type= MYSQL_TIMESTAMP_NONE;
     break;
   case TIME_RESULT:
@@ -756,7 +756,7 @@ decimal_digits_t Interval_DDhhmmssff::fsp(THD *thd, Item *item)
   case DECIMAL_RESULT:
     return MY_MIN(item->decimals, TIME_SECOND_PART_DIGITS);
   case ROW_RESULT:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   case STRING_RESULT:
     break;
@@ -856,7 +856,7 @@ bool Temporal::add_nanoseconds_with_round(THD *thd, int *warn,
   case MYSQL_TIMESTAMP_ERROR:
     break;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 
@@ -980,7 +980,7 @@ uint Time::binary_length_to_precision(uint length)
   case 5: return 4;
   case 6: return 6;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return 0;
 }
 
@@ -1867,7 +1867,7 @@ aggregate_for_result(const LEX_CSTRING &funcname, Item **items, uint nitems,
   bool bit_and_non_bit_mixture_found= false;
   if (!nitems)
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     set_handler(&type_handler_null);
     return true;
   }
@@ -2227,7 +2227,7 @@ Type_handler::get_handler_by_field_type(enum_field_types type)
   case MYSQL_TYPE_BLOB_COMPRESSED:
     break;
   };
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return &type_handler_string;
 }
 

--- a/sql/sql_type.h
+++ b/sql/sql_type.h
@@ -163,7 +163,7 @@ scalar_comparison_op_to_lex_cstring(scalar_comparison_op op)
   case SCALAR_CMP_GE:    return LEX_CSTRING{STRING_WITH_LEN(">=")};
   case SCALAR_CMP_GT:    return LEX_CSTRING{STRING_WITH_LEN(">")};
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return LEX_CSTRING{STRING_WITH_LEN("<?>")};
 }
 

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -2261,7 +2261,7 @@ bool st_select_lex_unit::optimize()
       if ((union_result->force_enable_index_if_needed() || union_distinct))
       {
         if(table->file->ha_enable_indexes(key_map(table->s->keys), false))
-          DBUG_ASSERT(0);
+          DBUG_ASSERT_NO_ASSUME(0);
         else
           table->no_keyread= 0;
       }

--- a/sql/sql_window.cc
+++ b/sql/sql_window.cc
@@ -482,7 +482,7 @@ int compare_order_elements(ORDER *ord1, int weight1,
         The weight is the same. That is, the elements come from the same
         window specification... This shouldn't happen.
       */
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       cmp= item1 - item2;
     }
   }

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -15279,7 +15279,7 @@ opt_format_json:
             if (lex_string_eq(&$3, STRING_WITH_LEN("JSON")))
               Lex->explain_json= true;
             else if (lex_string_eq(&$3, STRING_WITH_LEN("TRADITIONAL")))
-              DBUG_ASSERT(Lex->explain_json==false);
+              DBUG_ASSERT_NO_ASSUME(Lex->explain_json==false);
             else
               my_yyabort_error((ER_UNKNOWN_EXPLAIN_FORMAT, MYF(0),
                                 "EXPLAIN/ANALYZE", $3.str));

--- a/sql/sys_vars.inl
+++ b/sql/sys_vars.inl
@@ -100,7 +100,7 @@ extern const char *UNUSED_HELP;
     while(!(X))                                                         \
     {                                                                   \
       fprintf(stderr, "Sysvar '%s' failed '%s'\n", name_arg, #X);       \
-      DBUG_ASSERT(0);                                                   \
+      DBUG_ASSERT_NO_ASSUME(0);                                                   \
       exit(255);                                                        \
     }
 
@@ -696,7 +696,7 @@ public:
          sysvartrack_validate_value(thd,
                                     var->save_result.string_value.str,
                                     var->save_result.string_value.length);
-       DBUG_ASSERT(res == 0);
+       DBUG_ASSERT_NO_ASSUME(res == 0);
      }
   }
 };
@@ -2465,7 +2465,7 @@ public:
           l= TX_ISOL_SERIALIZABLE;
           break;
         default:
-          DBUG_ASSERT(0);
+          DBUG_ASSERT_NO_ASSUME(0);
           return TRUE;
         }
         if (thd->variables.session_track_transaction_info > TX_TRACK_NONE)

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -5921,7 +5921,7 @@ bool TABLE_SHARE::wait_for_old_version(THD *thd, struct timespec *abstime,
   case MDL_wait::KILLED:
     return TRUE;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return TRUE;
   }
 }
@@ -10979,7 +10979,7 @@ bool vers_select_conds_t::eq(const vers_select_conds_t &conds) const
   case SYSTEM_TIME_BETWEEN:
     return start.eq(conds.start) && end.eq(conds.end);
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return false;
 }
 

--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -153,7 +153,7 @@ get_fieldno_by_name(HA_CREATE_INFO *create_info,
     }
   }
 
-  DBUG_ASSERT(0); /* Not Reachable */
+  DBUG_ASSERT_NO_ASSUME(0); /* Not Reachable */
   return NO_CACHED_FIELD_INDEX;
 }
 

--- a/sql/wsrep_high_priority_service.cc
+++ b/sql/wsrep_high_priority_service.cc
@@ -724,7 +724,7 @@ Wsrep_replayer_service::~Wsrep_replayer_service()
   }
   else
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     WSREP_ERROR("trx_replay failed for: %d, schema: %s, query: %s",
                 m_replay_status,
                 m_orig_thd->db.str, wsrep_thd_query(m_orig_thd));

--- a/sql/wsrep_mysqld.cc
+++ b/sql/wsrep_mysqld.cc
@@ -452,7 +452,7 @@ void wsrep_init_sidno(const wsrep::id& uuid)
 
 void wsrep_init_schema()
 {
-  DBUG_ASSERT(!wsrep_schema);
+  DBUG_ASSERT_NO_ASSUME(!wsrep_schema);
 
   WSREP_INFO("wsrep_init_schema_and_SR %p", wsrep_schema);
   if (!wsrep_schema)
@@ -3998,7 +3998,7 @@ enum wsrep::streaming_context::fragment_unit wsrep_fragment_unit(ulong unit)
   case WSREP_FRAG_ROWS: return wsrep::streaming_context::row;
   case WSREP_FRAG_STATEMENTS: return wsrep::streaming_context::statement;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return wsrep::streaming_context::bytes;
   }
 }

--- a/storage/connect/ha_connect.cc
+++ b/storage/connect/ha_connect.cc
@@ -2838,7 +2838,7 @@ PFIL ha_connect::CondFilter(PGLOBAL g, Item *cond)
               *((double*)pp->Value)= pval->val_real();
               break;
             case ROW_RESULT:
-              DBUG_ASSERT(0);
+              DBUG_ASSERT_NO_ASSUME(0);
               return NULL;
           }
           }

--- a/storage/federatedx/ha_federatedx.cc
+++ b/storage/federatedx/ha_federatedx.cc
@@ -2876,7 +2876,7 @@ int ha_federatedx::free_result()
     federatedx_io *tmp_io= 0, **iop;
     if (!*(iop= &io) && (error= txn->acquire(share, ha_thd(), TRUE, (iop= &tmp_io))))
     {
-      DBUG_ASSERT(0);                             // Fail when testing
+      DBUG_ASSERT_NO_ASSUME(0);                             // Fail when testing
       insert_dynamic(&results, (uchar*) &stored_result);
       goto end;
     }
@@ -3225,7 +3225,7 @@ int ha_federatedx::reset(void)
 
     if (!*(iop= &io) && (error= tmp_txn->acquire(share, thd, TRUE, (iop= &tmp_io))))
     {
-      DBUG_ASSERT(0);                             // Fail when testing
+      DBUG_ASSERT_NO_ASSUME(0);                             // Fail when testing
       return error;
     }
 

--- a/storage/heap/hp_hash.c
+++ b/storage/heap/hp_hash.c
@@ -931,7 +931,7 @@ void heap_update_auto_increment(HP_INFO *info, const uchar *record)
     value= uint8korr(key);
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     value=0;                                    /* Error */
     break;
   }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8333,7 +8333,7 @@ calc_row_difference(
 	if (prebuilt->versioned_write) {
 		/* Guaranteed by CREATE TABLE, but anyway we make sure we
 		generate history only when there are versioned fields. */
-		DBUG_ASSERT(vers_fields);
+		DBUG_ASSERT_NO_ASSUME(vers_fields);
 		prebuilt->upd_node->vers_make_update(trx);
 	}
 

--- a/storage/innobase/include/rw_lock.h
+++ b/storage/innobase/include/rw_lock.h
@@ -107,7 +107,7 @@ public:
     static_assert(WRITER == 1U << 31, "compatibility");
     IF_DBUG_ASSERT(auto l=,) lock.fetch_sub(WRITER, std::memory_order_release);
     /* the write lock must have existed */
-    DBUG_ASSERT(l & WRITER);
+    DBUG_ASSERT_NO_ASSUME(l & WRITER);
   }
   /** Try to acquire a shared lock.
   @return whether the lock was acquired */

--- a/storage/innobase/include/srw_lock.h
+++ b/storage/innobase/include/srw_lock.h
@@ -221,14 +221,14 @@ public:
   void init() noexcept
   {
     writer.init();
-    DBUG_ASSERT(is_vacant());
+    DBUG_ASSERT_NO_ASSUME(is_vacant());
 #ifdef SUX_LOCK_GENERIC
     pthread_cond_init(&readers_cond, nullptr);
 #endif
   }
   void destroy() noexcept
   {
-    DBUG_ASSERT(is_vacant());
+    DBUG_ASSERT_NO_ASSUME(is_vacant());
     writer.destroy();
 #ifdef SUX_LOCK_GENERIC
     pthread_cond_destroy(&readers_cond);

--- a/storage/innobase/rem/rem0cmp.cc
+++ b/storage/innobase/rem/rem0cmp.cc
@@ -289,7 +289,7 @@ int cmp_data(ulint mtype, ulint prtype, bool descending,
       break;
     /* fall through */
   case DATA_VARMYSQL:
-    DBUG_ASSERT(is_strnncoll_compatible(prtype & DATA_MYSQL_TYPE_MASK));
+    DBUG_ASSERT_NO_ASSUME(is_strnncoll_compatible(prtype & DATA_MYSQL_TYPE_MASK));
     if (CHARSET_INFO *cs= all_charsets[dtype_get_charset_coll(prtype)])
     {
       cmp= cs->coll->strnncollsp(cs, data1, len1, data2, len2);
@@ -298,7 +298,7 @@ int cmp_data(ulint mtype, ulint prtype, bool descending,
   no_collation:
     ib::fatal() << "Unable to find charset-collation for " << prtype;
   case DATA_MYSQL:
-    DBUG_ASSERT(is_strnncoll_compatible(prtype & DATA_MYSQL_TYPE_MASK));
+    DBUG_ASSERT_NO_ASSUME(is_strnncoll_compatible(prtype & DATA_MYSQL_TYPE_MASK));
     if (CHARSET_INFO *cs= all_charsets[dtype_get_charset_coll(prtype)])
     {
       cmp= cs->coll->

--- a/storage/maria/lockman.c
+++ b/storage/maria/lockman.c
@@ -309,7 +309,7 @@ retry:
         {
           prev_active= cur_active;
           if (cur_flags & ACTIVE)
-            DBUG_ASSERT(prev_active == TRUE);
+            DBUG_ASSERT_NO_ASSUME(prev_active == TRUE);
           else
             cur_active&= lock_compatibility_matrix[prev_lock][cur_lock];
           if (upgrading && !cur_active /*&& !(cur_flags & UPGRADED)*/)

--- a/storage/maria/ma_bitmap.c
+++ b/storage/maria/ma_bitmap.c
@@ -2560,7 +2560,7 @@ my_bool _ma_bitmap_set_full_page_bits(MARIA_HA *info,
   if (page == bitmap_page ||
       page + page_count > bitmap_page + bitmap->pages_covered)
   {
-    DBUG_ASSERT(0);                             /* Wrong in data */
+    DBUG_ASSERT_NO_ASSUME(0);                             /* Wrong in data */
     DBUG_RETURN(1);
   }
 
@@ -3067,7 +3067,7 @@ my_bool _ma_check_if_right_bitmap_type(MARIA_HA *info,
   default:
     break;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   return 1;
 }
 
@@ -3128,7 +3128,7 @@ flush_log_for_bitmap(PAGECACHE_IO_HOOK_ARGS *args __attribute__ ((unused)))
   const MARIA_SHARE *share= (MARIA_SHARE*)args->data;
 #endif
   DBUG_ENTER("flush_log_for_bitmap");
-  DBUG_ASSERT(share->now_transactional);
+  DBUG_ASSERT_NO_ASSUME(share->now_transactional);
   /*
     WAL imposes that UNDOs reach disk before bitmap is flushed. We don't know
     the LSN of the last UNDO about this bitmap page, so we flush whole log.

--- a/storage/maria/ma_blockrec.c
+++ b/storage/maria/ma_blockrec.c
@@ -3024,7 +3024,7 @@ static my_bool write_block_record(MARIA_HA *info,
           cur_block++;
         }
 #ifdef SANITY_CHECKS
-        DBUG_ASSERT(!(cur_block >= end_block));
+        DBUG_ASSERT_NO_ASSUME(!(cur_block >= end_block));
         if ((cur_block >= end_block))
           goto crashed;
 #endif
@@ -5009,7 +5009,7 @@ int _ma_read_block_record2(MARIA_HA *info, uchar *record,
     }
     default:
 #ifdef EXTRA_DEBUG
-      DBUG_ASSERT(0);                           /* purecov: deadcode */
+      DBUG_ASSERT_NO_ASSUME(0);                           /* purecov: deadcode */
 #endif
       goto err;
     }
@@ -6971,8 +6971,8 @@ uint _ma_apply_redo_insert_row_blobs(MARIA_HA *info,
                                        LSN_IMPOSSIBLE, 0, FALSE);
               goto fix_bitmap;
             }
-            DBUG_ASSERT((found_page_type == (uchar) BLOB_PAGE) ||
-                        (found_page_type == (uchar) UNALLOCATED_PAGE));
+            DBUG_ASSERT_NO_ASSUME((found_page_type == (uchar) BLOB_PAGE) ||
+                                 (found_page_type == (uchar) UNALLOCATED_PAGE));
           }
           unlock_method= PAGECACHE_LOCK_WRITE_UNLOCK;
           unpin_method=  PAGECACHE_UNPIN;

--- a/storage/maria/ma_checkpoint.c
+++ b/storage/maria/ma_checkpoint.c
@@ -901,7 +901,7 @@ static int collect_tables(LEX_STRING *str, LSN checkpoint_start_log_horizon)
     filter= NULL;
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     goto err;
   }
 
@@ -1005,7 +1005,7 @@ static int collect_tables(LEX_STRING *str, LSN checkpoint_start_log_horizon)
 
     /* locate our state among these cached ones */
     for ( ; state_copy->index != i; state_copy++)
-      DBUG_ASSERT(state_copy <= state_copies_end);
+      DBUG_ASSERT_NO_ASSUME(state_copy <= state_copies_end);
 
     /* OS file descriptors are ints which we stored in 4 bytes */
     compile_time_assert(sizeof(int) <= 4);

--- a/storage/maria/ma_delete.c
+++ b/storage/maria/ma_delete.c
@@ -130,7 +130,7 @@ int maria_delete(MARIA_HA *info,const uchar *record)
 
 err:
   save_errno= my_errno;
-  DBUG_ASSERT(save_errno);
+  DBUG_ASSERT_NO_ASSUME(save_errno);
   if (!save_errno)
     save_errno= HA_ERR_INTERNAL_ERROR;          /* Should never happen */
 

--- a/storage/maria/ma_key.c
+++ b/storage/maria/ma_key.c
@@ -794,7 +794,7 @@ ulonglong ma_retrieve_auto_increment(const uchar *key, uint8 key_type)
     value= uint8korr(key);
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     value=0;                                    /* Error */
     break;
   }

--- a/storage/maria/ma_key_recover.c
+++ b/storage/maria/ma_key_recover.c
@@ -1176,13 +1176,13 @@ uint _ma_apply_redo_index(MARIA_HA *info,
     }
     case KEY_OP_NONE:
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       result= mark_crashed= 1;
       goto err;
     }
   } while (header < header_end);
   DBUG_ASSERT(header == header_end);
-  DBUG_ASSERT(new_page_length == 0 || new_page_length == page_length);
+  DBUG_ASSERT_NO_ASSUME(new_page_length == 0 || new_page_length == page_length);
 
   /* Write modified page */
   page.size= page_length;

--- a/storage/maria/ma_loghandler.c
+++ b/storage/maria/ma_loghandler.c
@@ -935,7 +935,7 @@ void translog_stop_writing()
                     TRANSLOG_READONLY);
   log_descriptor.is_everything_flushed= 1;
   log_descriptor.open_flags= O_BINARY | O_RDONLY;
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   DBUG_VOID_RETURN;
 }
 
@@ -2559,7 +2559,7 @@ static uint16 translog_get_total_chunk_length(uchar *page, uint16 offset)
     DBUG_PRINT("info", ("length: %u", uint2korr(page + offset + 1) + 3));
     DBUG_RETURN(uint2korr(page + offset + 1) + 3);
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     DBUG_RETURN(0);
   }
 }
@@ -3189,7 +3189,7 @@ restart:
             args.data= (uchar*) &file_copy;
             if (translog_page_validator(0, &args))
             {
-              DBUG_ASSERT(0);
+              DBUG_ASSERT_NO_ASSUME(0);
               buffer= NULL;
             }
           }
@@ -3201,7 +3201,7 @@ restart:
         translog_buffer_unlock(buffer_unlock);
         buffer_unlock= curr_buffer;
         /* we can't make a full circle */
-        DBUG_ASSERT(buffer_start != buffer_no);
+        DBUG_ASSERT_NO_ASSUME(buffer_start != buffer_no);
       }
     }
     translog_unlock();
@@ -3382,7 +3382,7 @@ static uint16 translog_get_chunk_header_length(uchar *chunk)
         calculation (we skip to the first group to read the header) so if we
         stuck here something is wrong.
       */
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_RETURN(0);                               /* Keep compiler happy */
     }
     DBUG_RETURN(header_len);
@@ -3404,7 +3404,7 @@ static uint16 translog_get_chunk_header_length(uchar *chunk)
     DBUG_RETURN(3);
     break;
   }
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   DBUG_RETURN(0);                               /* Keep compiler happy */
 }
 
@@ -5497,7 +5497,7 @@ static uchar *translog_get_LSN_from_diff(LSN base_lsn, uchar *src, uchar *dst)
     break;
   }
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     DBUG_RETURN(NULL);
   }
   lsn= MAKE_LSN(file_no, rec_offset);
@@ -6535,7 +6535,7 @@ my_bool translog_write_record(LSN *lsn,
       break;
     case LOGRECTYPE_NOT_ALLOWED:
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       rc= 1;
     }
   }
@@ -7206,7 +7206,7 @@ int translog_read_record_header_from_buffer(uchar *page,
     res= translog_fixed_length_header(page, page_offset, buff);
     break;
   default:
-    DBUG_ASSERT(0); /* we read some junk (got no LSN) */
+    DBUG_ASSERT_NO_ASSUME(0); /* we read some junk (got no LSN) */
     res= RECHEADER_READ_ERROR;
   }
   DBUG_RETURN(res);

--- a/storage/maria/ma_page.c
+++ b/storage/maria/ma_page.c
@@ -208,7 +208,7 @@ my_bool _ma_write_keypage(MARIA_PAGE *page, enum pagecache_page_lock lock,
                           (long) share->state.state.key_file_length,
                           (long) page->pos));
       my_errno=EINVAL;
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_RETURN(1);
     }
     DBUG_PRINT("page",("write page at: %lu",(ulong) (page->pos / block_size)));

--- a/storage/maria/ma_pagecache.c
+++ b/storage/maria/ma_pagecache.c
@@ -3884,7 +3884,7 @@ restart:
                             unlock_pin, FALSE))
       {
         pagecache_pthread_mutex_unlock(&pagecache->cache_lock);
-        DBUG_ASSERT(0);
+        DBUG_ASSERT_NO_ASSUME(0);
         DBUG_RETURN((uchar*) 0);
       }
     }
@@ -5008,7 +5008,7 @@ static int flush_pagecache_blocks_int(PAGECACHE *pagecache,
         table to be marked as corrupted (cf maria_chk_size(), maria_close())
         and thus require a table check.
       */
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       pagecache_pthread_mutex_unlock(&pagecache->cache_lock);
       if (my_thread_var->abort)
         DBUG_RETURN(1);		/* End if aborted by user */
@@ -5462,7 +5462,7 @@ void pagecache_file_no_dirty_page(PAGECACHE *pagecache, PAGECACHE_FILE *file)
     {
       DBUG_PRINT("info", ("pagecache_file_not_in error"));
       PCBLOCK_INFO(block);
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
     }
 }
 

--- a/storage/maria/ma_pagecrc.c
+++ b/storage/maria/ma_pagecrc.c
@@ -292,7 +292,7 @@ my_bool maria_page_filler_set_normal(PAGECACHE_IO_HOOK_ARGS *args)
 #endif
   MARIA_SHARE *share= (MARIA_SHARE *)args->data;
   DBUG_ENTER("maria_page_filler_set_normal");
-  DBUG_ASSERT(page_no != 0);                    /* Catches some simple bugs */
+  DBUG_ASSERT_NO_ASSUME(page_no != 0);                    /* Catches some simple bugs */
   int4store_aligned(page + share->block_size - CRC_SIZE,
                     MARIA_NO_CRC_NORMAL_PAGE);
   DBUG_RETURN(0);

--- a/storage/maria/ma_range.c
+++ b/storage/maria/ma_range.c
@@ -322,7 +322,7 @@ static uint _ma_keynr(MARIA_PAGE *page, uchar *keypos, uint *ret_max_key)
   {
     if (!(pos= (*keyinfo->skip_key)(&key, page_flag, nod_flag, pos)))
     {
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return 0;					/* Error */
     }
     max_key++;

--- a/storage/maria/ma_rt_split.c
+++ b/storage/maria/ma_rt_split.c
@@ -503,7 +503,7 @@ int maria_rtree_split_page(const MARIA_KEY *key, MARIA_PAGE *page,
   { /* verify that above loop didn't touch header bytes */
     uint i;
     for (i= 0; i < share->keypage_header; i++)
-      DBUG_ASSERT(new_page_buff[i]==0);
+      DBUG_ASSERT_NO_ASSUME(new_page_buff[i]==0);
   }
 
   if (nod_flag)

--- a/storage/maria/ma_update.c
+++ b/storage/maria/ma_update.c
@@ -209,7 +209,7 @@ int maria_update(register MARIA_HA *info, const uchar *oldrec,
 err:
   DBUG_PRINT("error",("key: %d  errno: %d",i,my_errno));
   save_errno= my_errno;
-  DBUG_ASSERT(save_errno);
+  DBUG_ASSERT_NO_ASSUME(save_errno);
   if (!save_errno)
     save_errno= HA_ERR_INTERNAL_ERROR;          /* Should never happen */
 

--- a/storage/maria/ma_write.c
+++ b/storage/maria/ma_write.c
@@ -415,7 +415,7 @@ err:
   my_errno=save_errno;
 err2:
   save_errno=my_errno;
-  DBUG_ASSERT(save_errno);
+  DBUG_ASSERT_NO_ASSUME(save_errno);
   if (!save_errno)
     save_errno= HA_ERR_INTERNAL_ERROR;          /* Should never happen */
   DBUG_PRINT("error", ("got error: %d", save_errno));

--- a/storage/maria/unittest/ma_test_loghandler_multigroup-t.c
+++ b/storage/maria/unittest/ma_test_loghandler_multigroup-t.c
@@ -577,7 +577,7 @@ int main(int argc __attribute__((unused)), char *argv[])
                   (uint) rec.header[22],
                   LSN_IN_PARTS(rec.lsn));
           translog_free_record_header(&rec);
-          DBUG_ASSERT(0);
+          DBUG_ASSERT_NO_ASSUME(0);
           goto err;
         }
       }

--- a/storage/myisam/ft_parser.c
+++ b/storage/myisam/ft_parser.c
@@ -89,7 +89,7 @@ my_bool ft_boolean_check_syntax_string(const uchar *str, size_t length,
 
   if (cs->mbminlen != 1)
   {
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 1;
   }
 

--- a/storage/myisam/mi_check.c
+++ b/storage/myisam/mi_check.c
@@ -3676,7 +3676,7 @@ static int sort_get_next_record(MI_SORT_PARAM *sort_param)
       DBUG_ASSERT(0);                           /* Impossible */
       break;
   }
-  DBUG_ASSERT(0);                               /* Impossible */
+  DBUG_ASSERT_NO_ASSUME(0);                               /* Impossible */
   DBUG_RETURN(1);                               /* Impossible */
 finish:
   if (sort_param->calc_checksum)

--- a/storage/myisam/mi_key.c
+++ b/storage/myisam/mi_key.c
@@ -628,7 +628,7 @@ ulonglong retrieve_auto_increment(MI_INFO *info,const uchar *record)
     value= uint8korr(key);
     break;
   default:
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     value=0;                                    /* Error */
     break;
   }

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -6440,7 +6440,7 @@ bool ha_rocksdb::should_hide_ttl_rec(const Rdb_key_def &kd,
         "Decoding ttl from PK value failed, "
         "for index (%u,%u), val: %s",
         gl_index_id.cf_id, gl_index_id.index_id, buf.c_str());
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return false;
   }
 
@@ -7024,7 +7024,7 @@ int ha_rocksdb::rdb_error_to_mysql(const rocksdb::Status &s,
       err = HA_ERR_ROCKSDB_STATUS_TRY_AGAIN;
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return -1;
   }
 
@@ -7585,7 +7585,7 @@ int rdb_normalize_tablename(const std::string &tablename,
                             std::string *const strbuf) {
   if (tablename.size() < 2 || tablename[0] != '.' ||
       (tablename[1] != FN_LIBCHAR && tablename[1] != FN_LIBCHAR2)) {
-    DBUG_ASSERT(0);  // We were not passed table name?
+    DBUG_ASSERT_NO_ASSUME(0);  // We were not passed table name?
     return HA_ERR_ROCKSDB_INVALID_TABLE;
   }
 
@@ -7595,7 +7595,7 @@ int rdb_normalize_tablename(const std::string &tablename,
   }
 
   if (pos == std::string::npos) {
-    DBUG_ASSERT(0);  // We were not passed table name?
+    DBUG_ASSERT_NO_ASSUME(0);  // We were not passed table name?
     return HA_ERR_ROCKSDB_INVALID_TABLE;
   }
 
@@ -9058,9 +9058,9 @@ int ha_rocksdb::get_row_by_rowid(uchar *const buf, const char *const rowid,
     s = tx->get(m_pk_descr->get_cf(), key_slice, &m_retrieved_record);
   } else if (m_insert_with_update && m_dup_pk_found) {
     DBUG_ASSERT(m_pk_descr->get_keyno() == m_dupp_errkey);
-    DBUG_ASSERT(m_dup_pk_retrieved_record.length() ==
+    DBUG_ASSERT_NO_ASSUME(m_dup_pk_retrieved_record.length() ==
                 m_retrieved_record.size());
-    DBUG_ASSERT(memcmp(m_dup_pk_retrieved_record.ptr(),
+    DBUG_ASSERT_NO_ASSUME(memcmp(m_dup_pk_retrieved_record.ptr(),
                        m_retrieved_record.data(),
                        m_retrieved_record.size()) == 0);
 
@@ -11717,7 +11717,7 @@ Rdb_tbl_def *ha_rocksdb::get_table_if_exists(const char *const tablename) {
   std::string str;
   if (rdb_normalize_tablename(tablename, &str) != HA_EXIT_SUCCESS) {
     // We were not passed table name?
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return nullptr;
   }
 
@@ -13404,7 +13404,7 @@ static ulonglong io_stall_prop_value(
   } else {
     DBUG_PRINT("warning",
                ("RocksDB GetMapPropery hasn't returned key=%s", key.c_str()));
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     return 0;
   }
 }

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -1752,7 +1752,7 @@ bool Rdb_key_def::index_format_min_check(const int pk_min,
     case INDEX_TYPE_SECONDARY:
       return (m_kv_format_version >= sk_min);
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       return false;
   }
 }

--- a/storage/spider/spd_db_conn.cc
+++ b/storage/spider/spd_db_conn.cc
@@ -5075,7 +5075,7 @@ int spider_db_simple_action(
       );
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       error_num = HA_ERR_CRASHED;
       break;
   }

--- a/storage/spider/spd_db_mysql.cc
+++ b/storage/spider/spd_db_mysql.cc
@@ -2438,7 +2438,7 @@ bool spider_db_mbase::inserted_info(
       copy_info->updated+= duplicates;
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_RETURN(FALSE);
   }
   DBUG_RETURN(TRUE);
@@ -2565,7 +2565,7 @@ int spider_db_mbase::xa_start(
 ) {
   DBUG_ENTER("spider_db_mbase::xa_start");
   DBUG_PRINT("info",("spider this=%p", this));
-  DBUG_ASSERT(0);
+  DBUG_ASSERT_NO_ASSUME(0);
   DBUG_RETURN(0);
 }
 
@@ -9810,7 +9810,7 @@ int spider_mbase_handler::append_match_where_part(
       str = &sql;
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_RETURN(0);
   }
   error_num = append_match_where(str);
@@ -12840,7 +12840,7 @@ int spider_mbase_handler::simple_action(
       }
       break;
     default:
-      DBUG_ASSERT(0);
+      DBUG_ASSERT_NO_ASSUME(0);
       DBUG_RETURN(0);
     }
   spider_lock_before_query(conn, &spider->need_mons[link_idx]);

--- a/strings/ctype-ucs2.c
+++ b/strings/ctype-ucs2.c
@@ -1090,7 +1090,8 @@ my_scan_mb2(CHARSET_INFO *cs __attribute__((unused)),
     }
     return (size_t) (str - str0);
   case MY_SEQ_NONSPACES:
-    DBUG_ASSERT(0); /* Not implemented */
+    DBUG_ASSERT_NO_ASSUME(0); /* Not implemented */
+	return 0; /* keep compiler happy */
     /* pass through */
   default:
     return 0;
@@ -2577,7 +2578,7 @@ void my_fill_utf32(CHARSET_INFO *cs,
   buflen=
 #endif
     my_ci_wc_mb(cs, (my_wc_t) fill, (uchar*) buf, (uchar*) buf + sizeof(buf));
-  DBUG_ASSERT(buflen == 4);
+  DBUG_ASSERT_NO_ASSUME(buflen == 4);
   while (s < e)
   {
     memcpy(s, buf, 4);
@@ -2605,8 +2606,8 @@ my_scan_utf32(CHARSET_INFO *cs,
     }
     return (size_t) (str - str0);
   case MY_SEQ_NONSPACES:
-    DBUG_ASSERT(0); /* Not implemented */
-    /* pass through */
+    DBUG_ASSERT_NO_ASSUME(0); /* Not implemented */
+	return 0; /* keep compiler happy */
   default:
     return 0;
   }

--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -537,7 +537,7 @@ new_VioSSLFd(const char *key_file, const char *cert_file, const char *ca_file,
   {
 #ifdef HAVE_WOLFSSL
     /* CRL does not work with WolfSSL. */
-    DBUG_ASSERT(0);
+    DBUG_ASSERT_NO_ASSUME(0);
     goto err2;
 #else
     X509_STORE *store= SSL_CTX_get_cert_store(ssl_fd->ssl_context);


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-35770*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
The DBUG_ASSERT macro tests an invariant at runtime in debug build and aborts if the check fails. Although assertions are disabled in optimized builds, code is usually written in such a manner, that failing an assertion condition would lead to undefined behavior. It therefore makes sense to introduce platform-specific analog of C++23 `[[assume(cond)]]` and use it in these cases, which potentially could lead to generation of more optimized builds in production.
E.g. compiler would be able to optimize `while` loop into `do-while` loop (which means less instructions in assembly) if it knows that the loop will run at least once.

## Special patterns case
There are lots of code fragments like:
```cpp
DBUG_ASSERT(!thd->in_sub_stmt);
if (thd->in_sub_stmt)  {
  ...
}
```
and
```cpp
switch (i)
{
  case 1: x=myisam_sint1korr(from); break;
  case 2: x=myisam_sint2korr(from); break;
  case 3: x=myisam_sint3korr(from); break;
  case 4: x=myisam_sint4korr(from); break;
  default: DBUG_ASSERT(0); x= 0;
}
```
If we simply wrap DBUG_ASSERT in an assume, the compiler will elide both the if-guard and the default branch — removing important fallback code.

There are also cases like:
```cpp
  void acquire()
  {
    IF_DBUG(auto prev= ,)
    ref_count.fetch_add(1);
    DBUG_ASSERT(prev != 0);
  }
```
In this case compilation in release mode would fail, because assume is called with undeclared variable.

This PR:
1. Introduces new platform-dependent macro MY_ASSUME, implemented for GCC >= 13.0, Clang and MSVC.
2. Augments DBUG_ASSERT to use it by default in DBUG. Notably, it will enable MY_ASSUME in the release mode as well.
3. Provides DBUG_ASSERT_NO_ASSUME (identical to the old DBUG_ASSERT) for described above **special** cases.

MY_ASSUME is implemented for GCC >= 13.0, Clang and MSVC.

~~TODO: Measure actual performance improvements and document LLVM/assembly diffs.~~ -- will stay out of scope for this PR

## How can this PR be tested?
This patch doesn't intend to change the behaviour, so it's only important that the existing tests will pass. We assume that test coverage of the **special** cases is out of scope for this work -- it was supposed to have been done in scope of the same task when it was added, if that was feasible at all.  

We acknowledge we may have missed a few “special” patterns, but we’ve covered all the occurrences we could find.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.