### PR TITLE
MDEV-36469 empty db passed to is_infoschema_db is wasteful

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -8389,7 +8389,11 @@ TABLE_LIST *st_select_lex::add_table_to_list(THD *thd,
     DBUG_RETURN(0);
   else
     fqtn= FALSE;
-  bool info_schema= is_infoschema_db(&db);
+  /*
+    The test for length==0 is for performance purposes as is_infoschema_db()
+    is quite heavy. Without explict db SQL syntax, length==0 is a common case.
+  */
+  bool info_schema= db.length ? is_infoschema_db(&db) : false;
   if (!table->sel && info_schema &&
       (table_options & TL_OPTION_UPDATING) &&
       /* Special cases which are processed by commands itself */


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36469*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

This is backport of #3940 that removes forms of undefined behaviour in 10.11+, but also is a performance improvement. When merging to 11.8 the existing 11.8 code should prevail.

@vuvova acceptable enough for 10.6?

In many cases parsing a table name doesn't include a database name, therefore the empty db isn't going to be the information_schema.

The streq in is_infoschema_db is quite heavy in the so opportunities to bypass this should be taken.

In branches 10.11+ the collation improvements resulting in UBSAN errors when a null pointer reached the lower layers.

In 11.8+ the db is a Lex_ident_db type, and the is_null/is_emtpy usage that will result in the merge conflict with
db5bb6f3339be5a49c0f397eb80a0f259f73f447. The 11.8+ code should remain during the merge.

Alternatives considered:

Implementing check inside is_infoschema_db was rejected as the other callers of this function seemed to have meanisms already to validate that the db passed wasn't null.

Porting is_null/is_empty mechanisms to st_mysql_const_lex_string would create asymmetry with non-const functions. This is also in an ABI compatible sensitive area of the code. As a structure the direct access of str and length as needed is also quite common.

Changing db to a Lex_ident_db in the sql_parse function was incompatible with the other usages.

## Release Notes

SQL parsing speed improved by less overhead in checking if the database is an information_schema.
This eliminated some undefined behaviour with pointers (10.11+)

## How can this PR be tested?

Existing MTR test cover this already.
<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [X] * This is a bug fix for 10.11, correcting undefined behaviour, and a parsing performance improvement on 10.6.

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.