### PR TITLE
MDEV-36482: Make aio work WITH_MSAN=ON

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3690,6 +3690,11 @@ dberr_t buf_page_t::read_complete(const fil_node_t &node) noexcept
 
   const byte *read_frame= zip.data ? zip.data : frame;
   ut_ad(read_frame);
+#if __has_feature(memory_sanitizer)
+  if (srv_use_native_aio)
+    /* Work around uninstrumented asynchronous I/O interface */
+    MEM_MAKE_DEFINED(read_frame, zip.data ? zip_size() : srv_page_size);
+#endif
 
   dberr_t err;
   if (!buf_page_decrypt_after_read(this, node))

--- a/tpool/aio_linux.cc
+++ b/tpool/aio_linux.cc
@@ -15,6 +15,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 - 1301 USA*/
 
 #include "tpool_structs.h"
 #include "tpool.h"
+#include "my_valgrind.h"
 
 # include <thread>
 # include <atomic>
@@ -117,6 +118,9 @@ class aio_linux final : public aio
           abort();
           goto end;
         }
+#if __has_feature(memory_sanitizer)
+        MEM_MAKE_DEFINED(events, ret * sizeof *events);
+#endif
         for (int i= 0; i < ret; i++)
         {
           const io_event &event= events[i];


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36482*
## Description
As noted in c36834c8324974f26770d64192898f4f45d9f772 the MemorySanitizer instrumented builds so far only work with the synchronous I/O interface (`innodb_use_native_aio=OFF`).

It is not that hard to make asynchronous I/O work with `libaio`, without even instrumenting that library.

`buf_page_t::read_complete()`: When using asynchronous I/O, declare the page as initialized.

`aio_linux::getevent_thread_routine()`: Declare the buffer that is returned by `my_getevents()` as initialized.

FIXME: How to make `liburing` work? Is it feasible to compile an instrumented version of it?
## Release Notes
N/A
## How can this PR be tested?
```sh
cmake -DWITH_MSAN=ON -DCMAKE_DISABLE_FIND_PACKAGE_URING=1 …
```
and run the test suite. Keep in mind that `io_setup(2)` of `libaio` will fail on `tmpfs`.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.