### PR TITLE
MDEV-36238 11.4 follow-up: `Master_SSL_Verify_Server_Cert=0`

### DIFF
--- a/mysql-test/suite/multi_source/master_info_file.result
+++ b/mysql-test/suite/multi_source/master_info_file.result
@@ -1,4 +1,4 @@
-CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=SERVER_MYPORT_1;
+CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=SERVER_MYPORT_1, master_ssl_verify_server_cert=0;
 CHANGE MASTER 'named' TO master_host='localhost', master_user='test', master_port=SERVER_MYPORT_2;
 --list_files @@datadir *.info
 relay-log-named.info

--- a/mysql-test/suite/multi_source/master_info_file.test
+++ b/mysql-test/suite/multi_source/master_info_file.test
@@ -5,7 +5,7 @@
 
 --source include/not_embedded.inc
 --replace_result $SERVER_MYPORT_1 SERVER_MYPORT_1
---eval CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=$SERVER_MYPORT_1
+--eval CHANGE MASTER TO master_host='127.0.0.1', master_user='root', master_port=$SERVER_MYPORT_1, master_ssl_verify_server_cert=0
 --replace_result $SERVER_MYPORT_2 SERVER_MYPORT_2
 --eval CHANGE MASTER 'named' TO master_host='localhost', master_user='test', master_port=$SERVER_MYPORT_2
 


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-36238](https://jira.mariadb.org/browse/MDEV-36238)*

## What problem is the patch trying to solve?
### Tweak `multi_source.master_info_file` re. [MDEV-31857](https://jira.mariadb.org/browse/MDEV-31857)’s new default

`Master_SSL_Verify_Server_Cert=0` was optional before that secure-by-default change.
Now, passwordless connections must disable SSL certificate verification.

Because the default unnamed connection cannot be deleted by RESET REPLICA ALL, it must be explicitly left passwordless and having `Master_SSL_Verify_Server_Cert=0`.
The named connection is cleaned up by RESET REPLICA ALL and thus not affected.

## Release Notes
N/A – this is a CI test.
## How can this PR be tested?
Run it, and check that its post-test MTR internal check no longer complains `Master_SSL_Verify_Server_Cert` being Yes.

## PR quality check
* ~~*This is a new feature or a refactoring, and the PR is based against the `main` branch.*~~
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.