### PR TITLE
MDEV-36489 10.11 crashes during bootstrap on macOS

### DIFF
--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_temporary.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_resize_temporary.test
@@ -25,8 +25,8 @@ SET DEBUG_SYNC='buf_pool_shrink_before_wakeup SIGNAL blocked WAIT_FOR go';
 send SET GLOBAL innodb_buffer_pool_size=8388608;
 connection default;
 SET DEBUG_SYNC='now WAIT_FOR blocked';
-# adjust for 32-bit
---replace_result 504/504 505/505
+# adjust for 32-bit and SUX_LOCK_GENERIC
+--replace_regex /(5..)\/\1/505\/505/
 SHOW STATUS LIKE 'innodb_buffer_pool_resize_status';
 SET DEBUG_SYNC='now SIGNAL go';
 connection con1;

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -3409,7 +3409,6 @@ void buf_block_t::initialise(const page_id_t page_id, ulint zip_size,
 {
   ut_ad(!page.in_file());
   buf_block_init_low(this);
-  page.lock.init();
   page.init(fix, page_id);
   page.set_os_used();
   page_zip_set_size(&page.zip, zip_size);


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36489*
## Description
`buf_block_t::initialise()`: Remove a redundant call to `page.lock.init()` that was already executed in `buf_pool_t::create()` or `buf_pool_t::resize()`.

This fixes a regression that was introduced in #3826.
## Release Notes
N/A
## How can this PR be tested?
Ensure that `-DSUX_LOCK_GENERIC` is defined in a `CMAKE_BUILD_TYPE=Debug` build:
```diff
diff --git a/storage/innobase/include/srw_lock.h b/storage/innobase/include/srw_lock.h
index 79a3e7c42a7..43ab43d90a6 100644
--- a/storage/innobase/include/srw_lock.h
+++ b/storage/innobase/include/srw_lock.h
@@ -30,7 +30,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 # define SUX_LOCK_GENERIC /* fall back to generic synchronization primitives */
 #endif
 
-#if !defined SUX_LOCK_GENERIC && 0 /* defined SAFE_MUTEX */
+#if !defined SUX_LOCK_GENERIC && 1 /* defined SAFE_MUTEX */
 # define SUX_LOCK_GENERIC /* Use dummy implementation for debugging purposes */
 #endif
 
```
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.