### PR TITLE
MDEV-36558 Performance schema fails to compile on AIX

### DIFF
--- a/storage/perfschema/CMakeLists.txt
+++ b/storage/perfschema/CMakeLists.txt
@@ -280,6 +280,11 @@ table_replication_applier_status_by_worker.cc
 #table_replication_group_member_stats.cc
 )
 
+# These may warning on warning: implicit declaration of function
+# which isn't good enough as a compile test.
+set(SAVED_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -Wall -Werror")
+
 # Check for pthread_threadid_np()
 CHECK_C_SOURCE_COMPILES("
 #include <pthread.h>
@@ -325,6 +330,9 @@ int main(int ac, char **av)
   return (tid != 0 ? 0 : 1);
 }"
 HAVE_PTHREAD_GETTHREADID_NP)
+
+# Restore original flags
+set(CMAKE_REQUIRED_FLAGS "${SAVED_CMAKE_REQUIRED_FLAGS}")
 
 # Check for pthread_self() returning an integer type
 CHECK_C_SOURCE_COMPILES("

--- a/storage/perfschema/my_thread.h
+++ b/storage/perfschema/my_thread.h
@@ -28,8 +28,13 @@ typedef uint32 my_thread_os_id_t;
 #elif defined(HAVE_PTHREAD_GETTHREADID_NP)
 typedef int my_thread_os_id_t;
 #elif defined(HAVE_INTEGER_PTHREAD_SELF)
+#ifdef _AIX
+#include <sys/thread.h>
+typedef tid_t my_thread_os_id_t;
+#else /* _AIX */
 typedef uintptr_t my_thread_os_id_t;
-#else
+#endif /* _AIX */
+#else /* ! HAVE_INTEGER_PTHREAD_SELF */
 typedef unsigned long long my_thread_os_id_t;
 #endif
 
@@ -88,7 +93,7 @@ static inline my_thread_os_id_t my_thread_os_id()
   return getthrid();
 #else
 #ifdef HAVE_INTEGER_PTHREAD_SELF
-  /* NetBSD, and perhaps something else, fallback. */
+  /* NetBSD and AIX, and perhaps something else, fallback. */
   return (my_thread_os_id_t) pthread_self();
 #else
   /* Feature not available. */


### PR DESCRIPTION
try compile tests are flawed, particularly on AIX as they succeed with an "warning: implicit declaration of function".

Upon compulation of these detected feature there is a link error for the missing function.

AIX can use the HAVE_INTEGER_PTHREAD_SELF implementation

Interface per:
https://www.ibm.com/docs/en/aix/7.3?topic=t-thread-self-kernel-service

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36558*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Enable Performance Schema to compile on AIX.

## Release Notes

Corrected compilation of performance schema on AIX

## How can this PR be tested?

Compile under AIX:

With patch:
```
-- Performing Test HAVE_PTHREAD_THREADID_NP
-- Performing Test HAVE_PTHREAD_THREADID_NP - Failed
-- Looking for gettid
-- Looking for gettid - not found
-- Performing Test HAVE_SYS_GETTID
-- Performing Test HAVE_SYS_GETTID - Failed
-- Performing Test HAVE_GETTHRID
-- Performing Test HAVE_GETTHRID - Failed
-- Performing Test HAVE_PTHREAD_GETTHREADID_NP
-- Performing Test HAVE_PTHREAD_GETTHREADID_NP - Failed
-- Performing Test HAVE_INTEGER_PTHREAD_SELF
-- Performing Test HAVE_INTEGER_PTHREAD_SELF - Success

buildbot@mariadb:[/home/buildbot/build_10.6]make -j16 perfschema

[100%] Linking CXX static library libperfschema.a
[100%] Built target perfschema
```

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
