### PR TITLE
MDEV-36587 InnoDB uses too much memory

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1237,11 +1237,10 @@ void log_t::clear_mmap() noexcept
 #ifdef HAVE_PMEM
   if (!is_opened())
   {
-    latch.wr_lock(SRW_LOCK_CALL);
+    ut_d(latch.wr_lock(SRW_LOCK_CALL));
     ut_ad(!resize_in_progress());
     ut_ad(get_lsn() == get_flushed_lsn(std::memory_order_relaxed));
-    buf_size= unsigned(std::min<uint64_t>(capacity(), buf_size_max));
-    latch.wr_unlock();
+    ut_d(latch.wr_unlock());
     return;
   }
 #endif

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -4590,7 +4590,10 @@ inline void log_t::set_recovered() noexcept
   }
 #ifdef HAVE_PMEM
   else
+  {
+    buf_size= unsigned(std::min<uint64_t>(capacity(), buf_size_max));
     mprotect(buf, size_t(file_size), PROT_READ | PROT_WRITE);
+  }
 #endif
 }
 


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36587*
## Description
`log_t::clear_mmap()`: Do not modify `buf_size`; we may have `file_size==0` here during bootstrap.

`log_t::set_recovered()`: If we are writing to a memory-mapped log, update `log_sys.buf_size` to the record payload area of `log_sys.buf`.

This fixes up #3925.
## Release Notes
N/A. This bug is not present in any release.
## How can this PR be tested?
In a `cmake -DWITH_INNODB_PMEM=ON` build:
```sh
./mtr --boot-rr --rr innodb.innodb
```
Set `watch -l log_sys.buf_size` and `watch -l log_sys.buf` and ensure that the `log_sys.buf_size` is either the specified `innodb_log_file_size` or the size of a memory-mapped `ib_logfile0` that will be used for writing.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.