### PR TITLE
MDEV-36340: Reset `Connects_Tried` with `Master_Retry_Count=X`

### DIFF
--- a/mysql-test/suite/multi_source/connects_tried.result
+++ b/mysql-test/suite/multi_source/connects_tried.result
@@ -80,27 +80,36 @@ SELECT *
 FROM status_after JOIN status_stop USING(Connection_name)
 WHERE status_stop.Connects_Tried <> status_after.Connects_Tried;
 Connection_name	Connects_Tried	Connects_Tried
-START SLAVE;
-include/wait_for_slave_to_start.inc
+include/start_slave.inc
 # START SLAVE recounts `Connects_Tried` from 1 (for the restarted connection only).
 CREATE TEMPORARY TABLE status_restart AS
 SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 SELECT *
-FROM status_restart JOIN status_stop USING(Connection_name)
+FROM status_stop JOIN status_restart USING(Connection_name)
 WHERE status_restart.Connects_Tried NOT BETWEEN IF(
 Connection_name = '', 1, status_stop.Connects_Tried
 ) AND status_stop.Connects_Tried;
 Connection_name	Connects_Tried	Connects_Tried
-STOP SLAVE;
-include/wait_for_slave_to_stop.inc
+include/stop_slave.inc
+CHANGE MASTER TO Master_Retry_Count=777;
+# Setting `Master_Retry_Count` resets `Connects_Tried` to 0 (for the changed connection only).
+CREATE TEMPORARY TABLE status_change AS
+SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
+SELECT *
+FROM status_restart JOIN status_change USING(Connection_name)
+WHERE status_change.Connects_Tried <>
+IF(Connection_name = '', 0, status_restart.Connects_Tried);
+Connection_name	Connects_Tried	Connects_Tried
+include/start_slave.inc
+include/stop_slave.inc
 RESET SLAVE;
 # RESET SLAVE resets `Connects_Tried` to 0 (for the resetted connection only).
 CREATE TEMPORARY TABLE status_reset AS
 SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 SELECT *
-FROM status_reset JOIN status_restart USING(Connection_name)
+FROM status_change JOIN status_reset USING(Connection_name)
 WHERE status_reset.Connects_Tried <>
-IF(Connection_name = '', 0, status_restart.Connects_Tried);
+IF(Connection_name = '', 0, status_change.Connects_Tried);
 Connection_name	Connects_Tried	Connects_Tried
 # Cleanup
 RESET SLAVE 'named' ALL;

--- a/mysql-test/suite/multi_source/connects_tried.test
+++ b/mysql-test/suite/multi_source/connects_tried.test
@@ -122,27 +122,37 @@ SELECT *
   FROM status_after JOIN status_stop USING(Connection_name)
   WHERE status_stop.Connects_Tried <> status_after.Connects_Tried;
 
-START SLAVE;
---source include/wait_for_slave_to_start.inc
+--source include/start_slave.inc
 --echo # START SLAVE recounts `Connects_Tried` from 1 (for the restarted connection only).
 CREATE TEMPORARY TABLE status_restart AS
   SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 SELECT *
-  FROM status_restart JOIN status_stop USING(Connection_name)
+  FROM status_stop JOIN status_restart USING(Connection_name)
   WHERE status_restart.Connects_Tried NOT BETWEEN IF(
     Connection_name = '', 1, status_stop.Connects_Tried
   ) AND status_stop.Connects_Tried;
 
-STOP SLAVE;
---source include/wait_for_slave_to_stop.inc
+--source include/stop_slave.inc
+# MDEV-36340 Master_Retry_Count should never be less than Connects_Tried
+CHANGE MASTER TO Master_Retry_Count=777;
+--echo # Setting `Master_Retry_Count` resets `Connects_Tried` to 0 (for the changed connection only).
+CREATE TEMPORARY TABLE status_change AS
+  SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
+SELECT *
+  FROM status_restart JOIN status_change USING(Connection_name)
+  WHERE status_change.Connects_Tried <>
+    IF(Connection_name = '', 0, status_restart.Connects_Tried);
+
+--source include/start_slave.inc # build up Connects_Tried again
+--source include/stop_slave.inc
 RESET SLAVE;
 --echo # RESET SLAVE resets `Connects_Tried` to 0 (for the resetted connection only).
 CREATE TEMPORARY TABLE status_reset AS
   SELECT Connection_name, Connects_Tried FROM information_schema.SLAVE_STATUS;
 SELECT *
-  FROM status_reset JOIN status_restart USING(Connection_name)
+  FROM status_change JOIN status_reset USING(Connection_name)
   WHERE status_reset.Connects_Tried <>
-    IF(Connection_name = '', 0, status_restart.Connects_Tried);
+    IF(Connection_name = '', 0, status_change.Connects_Tried);
 
 --echo # Cleanup
 RESET SLAVE 'named' ALL;

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -4052,7 +4052,10 @@ bool change_master(THD* thd, Master_info* mi, bool *master_info_added)
   if (lex_mi->connect_retry)
     mi->connect_retry = lex_mi->connect_retry;
   if (lex_mi->retry_count)
+  {
     mi->retry_count= lex_mi->retry_count;
+    mi->connects_tried= 0;
+  }
   if (lex_mi->heartbeat_opt != LEX_MASTER_INFO::LEX_MI_UNCHANGED)
     mi->heartbeat_period = lex_mi->heartbeat_period;
   else


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-36340](https://jira.mariadb.org/browse/MDEV-36340)*
  * Follow-up of [MDEV-35304](https://jira.mariadb.org/browse/MDEV-35304)

## Description
CHANGE MASTER can set `Master_Retry_Count` to be lower than `Connects_Tried`, which’ll look strange to those unaware of that CHANGE.

Now, setting `Master_Retry_Count` also resets `Connects_Tried` to 0.

## Release Notes
Amend MDEV-35304’s with:
* STOP REPLICA does not reset `Connects_Tried` to 0, but RESET REPLICA does, and also does changing `Master_Retry_Count` with CHANGE MASTER.

## How can this PR be tested?
This PR adds a test case to `multi_source.connects_tried`.

This PR also
* swaps some other tests’ SELECTs so they’re all `FROM status_before JOIN status_after USING(Connection_name)`; no function change
* “simplifies” START/STOP SLAVE + `wait_for_slave_to_start`/`stop.inc` to `start`/`stop_slave.inc`

## PR quality check
The bug is about a feature exclusive to the `main` branch. Or is this a new sub-feature?
* [x] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.