### PR TITLE
MDEV-36182 revert incorrect 5.14 kernel warnings and correct liburing interface usage

### DIFF
--- a/extra/mariabackup/xtrabackup.cc
+++ b/extra/mariabackup/xtrabackup.cc
@@ -1581,11 +1581,6 @@ uint xb_client_options_count = array_elements(xb_client_options);
 static const char *dbug_option;
 #endif
 
-#ifdef HAVE_URING
-extern const char *io_uring_may_be_unsafe;
-bool innodb_use_native_aio_default();
-#endif
-
 struct my_option xb_server_options[] =
 {
   {"datadir", 'h', "Path to the database root.", (G_PTR*) &mysql_data_home,
@@ -1705,12 +1700,7 @@ struct my_option xb_server_options[] =
    "Use native AIO if supported on this platform.",
    (G_PTR*) &srv_use_native_aio,
    (G_PTR*) &srv_use_native_aio, 0, GET_BOOL, NO_ARG,
-#ifdef HAVE_URING
-   innodb_use_native_aio_default(),
-#else
-   TRUE,
-#endif
-   0, 0, 0, 0, 0},
+   TRUE, 0, 0, 0, 0, 0},
   {"innodb_page_size", OPT_INNODB_PAGE_SIZE,
    "The universal page size of the database.",
    (G_PTR*) &innobase_page_size, (G_PTR*) &innobase_page_size, 0,
@@ -2302,12 +2292,8 @@ static bool innodb_init_param()
 		msg("InnoDB: Using Linux native AIO");
 	}
 #elif defined(HAVE_URING)
-	if (!srv_use_native_aio) {
-	} else if (io_uring_may_be_unsafe) {
-		msg("InnoDB: Using liburing on this kernel %s may cause hangs;"
-		    " see https://jira.mariadb.org/browse/MDEV-26674",
-		    io_uring_may_be_unsafe);
-	} else {
+
+	if (srv_use_native_aio) {
 		msg("InnoDB: Using liburing");
 	}
 #else

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -151,7 +151,7 @@ void close_thread_tables(THD* thd);
 
 #ifdef HAVE_URING
 /** The Linux kernel version if io_uring() is considered unsafe */
-const char *io_uring_may_be_unsafe;
+static const char *io_uring_may_be_unsafe;
 #endif
 
 #define INSIDE_HA_INNOBASE_CC
@@ -19502,10 +19502,9 @@ static MYSQL_SYSVAR_STR(version, innodb_version_str,
 #ifdef HAVE_URING
 # include <sys/utsname.h>
 static utsname uname_for_io_uring;
-#else
-static
 #endif
-bool innodb_use_native_aio_default()
+
+static bool innodb_use_native_aio_default()
 {
 #ifdef HAVE_URING
   utsname &u= uname_for_io_uring;

--- a/tpool/aio_liburing.cc
+++ b/tpool/aio_liburing.cc
@@ -34,9 +34,9 @@ class aio_uring final : public tpool::aio
 public:
   aio_uring(tpool::thread_pool *tpool, int max_aio) : tpool_(tpool)
   {
-    if (io_uring_queue_init(max_aio, &uring_, 0) != 0)
+    if (const auto e= io_uring_queue_init(max_aio, &uring_, 0))
     {
-      switch (const auto e= errno) {
+      switch (-e) {
       case ENOMEM:
         my_printf_error(ER_UNKNOWN_ERROR,
                         "io_uring_queue_init() failed with ENOMEM:"
@@ -57,6 +57,12 @@ public:
                         "(newer than 5.1 required)",
                         ME_ERROR_LOG | ME_WARNING);
         break;
+      case EPERM:
+	my_printf_error(ER_UNKNOWN_ERROR,
+                        "io_uring_queue_init() failed with EPERM:"
+			" sysctl kernel.io_uring_disabled has the value 2, or 1 and the user of the process is not a member of sysctl kernel.io_uring_group. (see man 2 io_uring_setup).",
+                        ME_ERROR_LOG | ME_WARNING);
+	break;
       default:
         my_printf_error(ER_UNKNOWN_ERROR,
                         "io_uring_queue_init() failed with errno %d",

--- a/tpool/tpool_generic.cc
+++ b/tpool/tpool_generic.cc
@@ -218,7 +218,6 @@ class thread_pool_generic : public thread_pool
 
   /** Overall number of enqueues*/
   unsigned long long m_tasks_enqueued;
-  unsigned long long m_group_enqueued;
   /** Overall number of dequeued tasks. */
   unsigned long long m_tasks_dequeued;
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36182*

## Description

The kernel warnings adding in MDEV-26674 where at the very early stages of kernel development. Since then RHEL9 and its clones and compatible distros have stabilised on the 5.14 kernel which no longer has broken behaviour as the initial kernels but users are still receiving warnings and disabling of innodb_native_aio.

Because of this, its safe to revert the kernel checks. We've checked that the kernel of RHEL9 works correctly with io_uring. During this it was discovered that the default RHEL9 kernels will have sysctl kernel.io_uring_disabled=2 set which disable io_uring usage for all users. This is either out of compatibility or from the early days where there where more io_uring bug reports. Either way, we don't need to provide another slightly broken layer of control around this, the end user has the option (via sysctl) and reverting this change isn't going to do anything except remove a false warning in the MariaDB logs.

We also correct a bug in our liburing usage. It is the return value of `io_uring_queue_init` that has the error number and not the `errno` variable. The obvious case this was presented was with the EPERM error, which meant users where getting a warning "mariadbd: io_uring_queue_init() failed with errno 0" which is very unintuitive. So correcting the usage of this function and adding EPERM description as it applies to MariaDB is a necessary change for those warning to use liburing on RHEL kernels.

The revert commits are unmodified in content from what git-revert produced with no conflicts.

Removed an used variable from tpool because it was on the list of things to clean-up and it is as risk free as it gets.

## Release Notes

Remove out of date warning about the 5.14 kernel about io_uring bugs, and produce useful error messages if the io_uring_disabled is set and leave the rest to user choice.

## How can this PR be tested?

```
$ sudo sysctl kernel.io_uring_disabled=2

and start MariaDB
2025-04-17 15:51:26 0 [Warning] mysqld: io_uring_queue_init() failed with EPERM: sysctl kernel.io_uring_disabled has the value 2, or 1 and the user of the process is not a member of sysctl kernel.io_uring_group. (see man 2 io_uring_setup).
2025-04-17 15:51:26 0 [Warning] InnoDB: liburing disabled: falling back to innodb_use_native_aio=OFF

$ sudo sysctl kernel.io_uring_disabled=0

...
2025-04-17 15:52:16 0 [Note] InnoDB: Using liburing
```

no incorrect warnings, useful descriptions, and with disable=0, a functioning working MariaDB

Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->

## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.