### PR TITLE
MDEV-36516 : galera_3nodes.galera_gtid_2_cluster test failed on 10.5

### DIFF
--- a/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
+++ b/mysql-test/suite/galera_3nodes/t/galera_gtid_2_cluster.test
@@ -77,6 +77,8 @@ select @@gtid_binlog_state;
 
 --echo cluster 2 node 1
 --connection node_4
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
@@ -85,11 +87,16 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 2 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 2
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 2 FROM test.t1;
+--source include/wait_condition.inc
+
 select @@gtid_binlog_state;
 insert into t1 values (1, 12, 3);
 select @@gtid_binlog_state;
@@ -99,10 +106,14 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 3
 --connection node_3
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (1, 13, 4);
 select @@gtid_binlog_state;
@@ -112,10 +123,14 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 4 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 2
 --connection node_5
+--let $wait_condition = SELECT COUNT(*) = 4 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (2, 22, 2);
 select @@gtid_binlog_state;
@@ -125,37 +140,55 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 5 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 3
 --connection node_6
+--let $wait_condition = SELECT COUNT(*) = 5 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (2, 23, 3);
 select @@gtid_binlog_state;
 
 --echo #wait for sync  cluster 2 and 1
 --connection node_4
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo # check other nodes are consistent
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 --connection node_3
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 --connection node_5
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 --connection node_6
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 1
 --connection node_1
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 drop table t1;
 stop slave;
@@ -250,6 +283,8 @@ select @@gtid_binlog_state;
 --sleep 2
 --echo cluster 2 node 1
 --connection node_4
+--let $wait_condition = SELECT COUNT(*) = 1 FROM test.t1;
+--source include/wait_condition.inc
 insert into t1 values (2, 21, 1);
 select @@gtid_binlog_state;
 
@@ -258,11 +293,16 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 2 FROM test.t1;
+--source include/wait_condition.inc
+
 select * from t1 order by 1, 2, 3;
 
 
 --echo cluster 1 node 2
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 2 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (1, 12, 3);
 select @@gtid_binlog_state;
@@ -272,10 +312,14 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 3
 --connection node_3
+--let $wait_condition = SELECT COUNT(*) = 3 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (1, 13, 4);
 select @@gtid_binlog_state;
@@ -285,10 +329,14 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_4
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 4 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 2
 --connection node_5
+--let $wait_condition = SELECT COUNT(*) = 4 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (2, 22, 2);
 select @@gtid_binlog_state;
@@ -298,10 +346,14 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 5 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 2 node 3
 --connection node_6
+--let $wait_condition = SELECT COUNT(*) = 5 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 insert into t1 values (2, 23, 3);
 select @@gtid_binlog_state;
@@ -311,24 +363,36 @@ select @@gtid_binlog_state;
 --source include/save_master_gtid.inc
 --connection node_1
 --source include/sync_with_master_gtid.inc
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select * from t1 order by 1, 2, 3;
 
 --echo # check other nodes are consistent
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 --connection node_3
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 --connection node_5
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 --connection node_6
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 select * from t1 order by 1, 2, 3;
 
 --echo cluster 1 node 1
 --connection node_1
+--let $wait_condition = SELECT COUNT(*) = 6 FROM test.t1;
+--source include/wait_condition.inc
 select @@gtid_binlog_state;
 drop table t1;
 stop slave;


### PR DESCRIPTION
Add wait-conditions to verify that INSERTs are replicated before checking GTIDs.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36516*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x ] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
