### PR TITLE
MDEV-36618 : galera.galera_as_slave_nonprim test: result content mism…

### DIFF
--- a/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
+++ b/mysql-test/suite/galera/r/galera_as_slave_nonprim.result
@@ -12,7 +12,6 @@ connection node_1;
 connection node_4;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 connection node_2;
-connection node_1;
 expected_error
 1
 connection node_2;

--- a/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
+++ b/mysql-test/suite/galera/t/galera_as_slave_nonprim.test
@@ -2,7 +2,7 @@
 # Test the behavior of a Galera async slave if it goes non-prim. Async replication
 # should abort with an error but it should be possible to restart it.
 #
-# The galera/galera_2node_slave.cnf describes the setup of the nodes
+# The galera_3nodes_as_slave.cnf describes the setup of the nodes
 #
 
 --source include/have_innodb.inc
@@ -45,9 +45,8 @@ SET GLOBAL wsrep_provider_options = 'gmcast.isolate=1';
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 
 --connection node_2
---sleep 5
+wait_for_slave_to_stop;
 --let $value = query_get_value(SHOW SLAVE STATUS, Last_SQL_Error, 1)
---connection node_1
 --disable_query_log
 --eval SELECT "$value" IN ("Error 'Unknown command' on query. Default database: 'test'. Query: 'BEGIN'", "Node has dropped from cluster") AS expected_error
 --enable_query_log
@@ -75,7 +74,6 @@ START SLAVE;
 --connection node_4
 DROP TABLE t1;
 
---sleep 2
 --connection node_2
 --let $wait_condition = SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
 --source include/wait_condition.inc


### PR DESCRIPTION
…atch

Remove unnecessary sleeps and use wait_for_slave_to_stop instead.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36618*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
