### PR TITLE
MDEV-36649 dict_acquire_mdl_shared() aborts when table mode is DICT_TABLE_OP_OPEN_ONLY_IF_CACHED

### DIFF
--- a/mysql-test/suite/innodb/r/stats_persistent.result
+++ b/mysql-test/suite/innodb/r/stats_persistent.result
@@ -17,3 +17,13 @@ test.t1	analyze	status	Engine-independent statistics collected
 test.t1	analyze	status	OK
 SET DEBUG_SYNC= 'RESET';
 DROP TABLE t1;
+#
+# MDEV-36649 dict_acquire_mdl_shared() aborts when table
+#      mode is DICT_TABLE_OP_OPEN_ONLY_IF_CACHED
+#
+set @old_defragment_stats_accuracy= @@innodb_defragment_stats_accuracy;
+SET GLOBAL innodb_defragment_stats_accuracy=1;
+CREATE TABLE t (a INT ) ENGINE=INNODB;
+INSERT INTO t SELECT * FROM seq_1_to_1000;
+DROP TABLE t;
+set global innodb_defragment_stats_accuracy= @old_defragment_stats_accuracy;

--- a/mysql-test/suite/innodb/t/stats_persistent.test
+++ b/mysql-test/suite/innodb/t/stats_persistent.test
@@ -1,4 +1,5 @@
 --source include/have_innodb.inc
+--source include/have_sequence.inc
 --source include/have_debug.inc
 --source include/have_debug_sync.inc
 --source include/count_sessions.inc
@@ -26,3 +27,14 @@ SET DEBUG_SYNC= 'RESET';
 DROP TABLE t1;
 
 --source include/wait_until_count_sessions.inc
+
+--echo #
+--echo # MDEV-36649 dict_acquire_mdl_shared() aborts when table
+--echo #      mode is DICT_TABLE_OP_OPEN_ONLY_IF_CACHED
+--echo #
+set @old_defragment_stats_accuracy= @@innodb_defragment_stats_accuracy;
+SET GLOBAL innodb_defragment_stats_accuracy=1;
+CREATE TABLE t (a INT ) ENGINE=INNODB;
+INSERT INTO t SELECT * FROM seq_1_to_1000;
+DROP TABLE t;
+set global innodb_defragment_stats_accuracy= @old_defragment_stats_accuracy;

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -795,6 +795,8 @@ lookup:
       dict_sys.freeze(SRW_LOCK_CALL);
     goto return_without_mdl;
   }
+  else
+    goto return_without_mdl;
 
   if (*mdl)
   {


### PR DESCRIPTION

- [x] *The Jira issue number for this PR is: MDEV-36649*

## Description
- InnoDB fails to check the table is being dropped or evicted while acquiring the MDL for the table when table open operation mode is DICT_TABLE_OP_OPEN_ONLY_IF_CACHED.

Fix:
===
dict_acquire_mdl_shared(): Check whether the table name length before retrying to acquire MDL for the table. In case of evicted or dropped table, new table length is 0.


## How can this PR be tested?
./mtr innodb.stats_persistent

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
