### PR TITLE
HAVE_valgrind typo fixup and -asan suffix

### DIFF
--- a/mysql-test/main/sp-no-valgrind.test
+++ b/mysql-test/main/sp-no-valgrind.test
@@ -1,5 +1,5 @@
 --source include/not_msan.inc
---source include/not_valgrind.inc
+--source include/not_valgrind_build.inc
 
 --echo # MDEV-20699 do not cache SP in SHOW CREATE
 --echo # Warmup round, this might allocate some memory for session variable

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8787,11 +8787,18 @@ char *set_server_version(char *buf, size_t size)
     !strstr(MYSQL_SERVER_SUFFIX_STR, "-valgrind") ? "-valgrind" :
 #endif
     "";
+  const char *is_asan=
+#ifdef __SANITIZE_ADDRESS__
+    !strstr(MYSQL_SERVER_SUFFIX_STR, "-asan") ? "-asan" :
+#endif
+    "";
+
   return strxnmov(buf, size - 1,
                   MYSQL_SERVER_VERSION,
                   MYSQL_SERVER_SUFFIX_STR,
                   IF_EMBEDDED("-embedded", ""),
                   is_valgrind,
+                  is_asan,
                   is_debug ? "-debug" : "",
                   is_log ? "-log" : "",
                   NullS);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8783,7 +8783,7 @@ char *set_server_version(char *buf, size_t size)
   bool is_log= opt_log || global_system_variables.sql_log_slow || opt_bin_log;
   bool is_debug= IF_DBUG(!strstr(MYSQL_SERVER_SUFFIX_STR, "-debug"), 0);
   const char *is_valgrind=
-#ifdef HAVE_VALGRIND
+#ifdef HAVE_valgrind
     !strstr(MYSQL_SERVER_SUFFIX_STR, "-valgrind") ? "-valgrind" :
 #endif
     "";


### PR DESCRIPTION
As discussed with @montywi, this patch fixes two things:

1. It ensures that when the server is compiled with valgrind, that the proper server suffix is appended. This is used by tests.
2. It also adds the same kind of suffix for -asan

This ensures that one does not need to add SERVER_SUFFIX as part of BUILD scripts either.