### PR TITLE
MDEV-36646: innodb_buffer_pool_size change aborted

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1696,8 +1696,7 @@ ATTRIBUTE_COLD buf_pool_t::shrink_status buf_pool_t::shrink(size_t size)
         continue;
       }
 
-      if (UNIV_LIKELY_NULL(b->zip.data) &&
-          will_be_withdrawn(b->zip.data, size))
+      if (UNIV_UNLIKELY(will_be_withdrawn(b->zip.data, size)))
       {
         block= buf_buddy_shrink(b, block);
         ut_ad(mach_read_from_4(b->zip.data + FIL_PAGE_OFFSET) == id.page_no());

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1288,7 +1288,7 @@ public:
   bool will_be_withdrawn(const byte *ptr, size_t size) const noexcept
   {
     const char *p= reinterpret_cast<const char*>(ptr);
-    ut_ad(p >= memory);
+    ut_ad(!p || p >= memory);
     ut_ad(p < memory + size_in_bytes_max);
     return p >= memory + size;
   }


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36646*
## Description
A statement `SET GLOBAL innodb_buffer_pool_size=…` could fail for no good reason when the buffer pool contains many pages that can actually be evicted.

`buf_flush_LRU_list_batch()`: Keep evicting as long as the buffer pool is being shrunk, for at most `innodb_lru_scan_depth` extra blocks. Disregard the flush limit for pages that are marked as freed in files.

`buf_pool_t::will_be_withdrawn()`: Allow also `ptr=nullptr` (the condition will not hold for it).

This fixes a regression that was introduced in #3826 and caught by the test `innodb.temp_truncate_freed` in MariaDB Server 11.4.
## Release Notes
N/A; this regression is not present in any release.
## How can this PR be tested?
In 11.4:
```sh
./mtr --valgrind innodb.temp_truncate_freed
```
This was tested by @Thirunarayanan.
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.