### PR TITLE
MDEV-36625 : galera.galera_var_replicate_myisam_on test failure

### DIFF
--- a/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
+++ b/mysql-test/suite/galera/r/galera_var_replicate_myisam_on.result
@@ -202,6 +202,9 @@ id	b
 3	200
 4	5
 connection node_2;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+10
 SELECT * FROM t1 ORDER BY id;
 id	b
 1	1
@@ -227,6 +230,9 @@ DROP TABLE t1, t2;
 CREATE TABLE t1 (a INT, b INT, UNIQUE(a)) ENGINE=MyISAM;
 CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW SET NEW.a=1;
 INSERT INTO t1  (a,b) VALUES (10,20);
+SELECT * from t1;
+a	b
+1	20
 connection node_2;
 SELECT * from t1;
 a	b

--- a/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
+++ b/mysql-test/suite/galera/t/galera_var_replicate_myisam_on.test
@@ -23,6 +23,11 @@ INSERT INTO t1 VALUES (2), (3);
 INSERT INTO t1 SELECT 4 FROM DUAL UNION ALL SELECT 5 FROM DUAL;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 5 FROM t1;
+--source include/wait_condition.inc
+
 SELECT COUNT(*) AS EXPECT_5 FROM t1;
 
 DROP TABLE t1;
@@ -38,6 +43,13 @@ REPLACE INTO t1 VALUES (1, 'klm'), (2,'xyz');
 REPLACE INTO t1 SELECT 3, 'yyy' FROM DUAL;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 3 FROM t1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE f1 = 3 AND f2 = 'yyy';
+--source include/wait_condition.inc
+
 SELECT COUNT(*) AS EXPECT_3 FROM t1;
 SELECT COUNT(*) AS EXPECT_1 FROM t1 WHERE f1 = 1 AND f2 = 'klm';
 SELECT COUNT(*) AS EXPECT_1 FROM t1 WHERE f1 = 2 AND f2 = 'xyz';
@@ -51,6 +63,9 @@ SELECT COUNT(*) AS EXPECT_1 FROM t1 WHERE f1 = 3 AND f2 = 'yyy';
 UPDATE t1 SET f2 = 'zzz' WHERE f2 = 'yyy';
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1 WHERE f2 = 'zzz';
+--source include/wait_condition.inc
+
 SELECT COUNT(*) AS EXPECT_1 FROM t1 WHERE f2 = 'zzz';
 
 #
@@ -61,6 +76,9 @@ SELECT COUNT(*) AS EXPECT_1 FROM t1 WHERE f2 = 'zzz';
 DELETE FROM t1 WHERE f2 = 'zzz';
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM t1 WHERE f2 = 'zzz';
+--source include/wait_condition.inc
+
 SELECT COUNT(*) AS EXPECT_0 FROM t1 WHERE f2 = 'zzz';
 
 #
@@ -71,6 +89,9 @@ SELECT COUNT(*) AS EXPECT_0 FROM t1 WHERE f2 = 'zzz';
 TRUNCATE TABLE t1;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 0 FROM t1;
+--source include/wait_condition.inc
+
 SELECT COUNT(*) AS EXPECT_0 FROM t1;
 DROP TABLE t1;
 
@@ -88,6 +109,15 @@ INSERT INTO t2 VALUES (1);
 COMMIT;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t2;
+--source include/wait_condition.inc
+
 SELECT COUNT(*) AS EXPECT_1 FROM t1;
 SELECT COUNT(*) AS EXPECT_1 FROM t2;
 
@@ -102,6 +132,11 @@ INSERT INTO t2 VALUES (2);
 ROLLBACK;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 2 FROM t1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t2;
+--source include/wait_condition.inc
+
 SELECT COUNT(*) AS EXPECT_2 FROM t1;
 SELECT COUNT(*) AS EXPECT_1 FROM t2;
 
@@ -120,7 +155,13 @@ INSERT INTO t1 VALUES (1);
 INSERT INTO t2 VALUES (1);
 
 --connection node_2
-# The MyISAM update is replicated immediately, so a duplicate key error happens even before the COMMIT
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+# The MyISAM update is replicated when executed, so a duplicate key error happens even before the COMMIT
 --error ER_DUP_ENTRY
 INSERT INTO t1 VALUES (1);
 
@@ -149,6 +190,10 @@ EXECUTE rep;
 SELECT * FROM t1 ORDER BY id;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 11 FROM t1;
+--source include/wait_condition.inc
 SELECT * FROM t1 ORDER BY id;
 
 DROP TABLE t1;
@@ -175,6 +220,10 @@ CALL proc();
 SELECT * FROM t1 ORDER BY id;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 11 FROM t1;
+--source include/wait_condition.inc
 SELECT * FROM t1 ORDER BY id;
 
 DROP PROCEDURE proc;
@@ -198,6 +247,13 @@ SELECT * FROM t1 ORDER BY id;
 SELECT * FROM t2 ORDER BY id;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't2';
+--source include/wait_condition.inc
+SELECT COUNT(*) FROM t1;
+--let $wait_condition = SELECT COUNT(*) = 10 FROM t1;
+--source include/wait_condition.inc
 SELECT * FROM t1 ORDER BY id;
 SELECT * FROM t2 ORDER BY id;
 DROP TRIGGER tr1;
@@ -208,8 +264,14 @@ DROP TABLE t1, t2;
 CREATE TABLE t1 (a INT, b INT, UNIQUE(a)) ENGINE=MyISAM;
 CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW SET NEW.a=1;
 INSERT INTO t1  (a,b) VALUES (10,20);
+SELECT * from t1;
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t1;
+--source include/wait_condition.inc
+
 SELECT * from t1;
 --connection node_1
 DROP TABLE t1;


### PR DESCRIPTION
Test case changes only. Add proper wait_conditions to wait expected database state.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36625*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
