### PR TITLE
MDEV-36681 Remove systemd CapabilityBoundingSet as unnecessary

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -51,11 +51,6 @@ Group=mysql
 # These are enabled by default
 AmbientCapabilities=CAP_IPC_LOCK
 
-# CAP_DAC_OVERRIDE To allow auth_pam_tool (which is SUID root) to read /etc/shadow when it's chmod 0
-#   does nothing for non-root, not needed if /etc/shadow is u+r
-# CAP_AUDIT_WRITE auth_pam_tool needs it on Debian for whatever reason
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
-
 # PrivateDevices=true implies NoNewPrivileges=true and
 # SUID auth_pam_tool suddenly doesn't do setuid anymore
 PrivateDevices=false

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -181,11 +181,6 @@ PrivateNetwork=false
 # These are enabled by default
 AmbientCapabilities=CAP_IPC_LOCK
 
-# CAP_DAC_OVERRIDE To allow auth_pam_tool (which is SUID root) to read /etc/shadow when it's chmod 0
-#   does nothing for non-root, not needed if /etc/shadow is u+r
-# CAP_AUDIT_WRITE auth_pam_tool needs it on Debian for whatever reason
-CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_AUDIT_WRITE
-
 # PrivateDevices=true implies NoNewPrivileges=true and
 # SUID auth_pam_tool suddenly doesn't do setuid anymore
 PrivateDevices=false


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36681*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

At some stage they where needed. Testing showed
they where hindering in RHEL8 environment by providing unix_chkpwd with an unneeded capability (CAP_DAC_OVERRIDE) which wasn't permitted in the selinux rules. The selinux rules did allow it to access /etc/shadow for authentication so it functioned correctly without it.

CAP_AUDIT_WRITE also appeared to be unneeded.

Currently /etc/shadow isn't read by auth_pam_tool, it loads pam_unix via library calls which executes unix_chkpwd which via selinux adopts a different security context which has the required permissions to read /etc/shadow.

Tested all other supported distros and the passed the pamv2 tests which MariaDB having no CapabilityBoundingSets.

Note this will merge conflict with MDEV-36591
(8925877dc86bdcff0170e1b0ec21483cc57a211a). When it does, the MDEV-36591 solution can be reverted. This is because the condition that CapabilityBoundingSet and AmbientCapabilties and not both present in the old systemd. By removing CapabilityBoundingSet it allows AmbientCapabilties to be unconditional.

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
