### PR TITLE
MDEV-36682  Conflict between MDEV-36504 and MDEV-16329

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -15939,7 +15939,7 @@ ha_innobase::extra(
 		}
 
 		trx->end_bulk_insert(*m_prebuilt->table);
-		trx->bulk_insert &= TRX_DDL_BULK;
+		trx->bulk_insert &= TRX_DML_BULK;
 		if (!m_prebuilt->table->is_temporary()
 		    && !high_level_read_only) {
 			/* During copy_data_between_tables(), InnoDB only


### PR DESCRIPTION
- [x] *The Jira issue number for this PR is: MDEV-36682*

## Description
Reason:
=======
- MDEV-16239 does apply the DML logs after bulk insert for ALTER TABLE..ALGORITHM=COPY, but InnoDB fails to reset the bulk_insert in ha_innobase::extra(HA_EXTRA_END_ALTER_COPY). This leads to crash while applying DML logs.

Solution:
=======
ha_innobase::extra(HA_EXTRA_END_ALTER_COPY): Reset TRX_DDL_BULK at the end of bulk insert operation

## How can this PR be tested?
./mtr innodb.alter_copy_bulk

## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
