### PR TITLE
MDEV-36648 - main.mdl_sync extra test.t2 row in I_S.metadata_lock_info

### DIFF
--- a/mysql-test/main/mdl_sync.result
+++ b/mysql-test/main/mdl_sync.result
@@ -2431,9 +2431,6 @@ create table t1 (a int) engine=myisam;
 create table t2 (a int) stats_persistent=0, engine=innodb;
 insert into t1 values (1);
 insert into t2 values (1);
-connect  con1, localhost, root;
-start transaction with consistent snapshot;
-connection default;
 SET DEBUG_SYNC= 'after_open_table_mdl_shared SIGNAL table_opened WAIT_FOR grlwait execute 2';
 update t1,t2 set t1.a=2,t2.a=3;
 connection con2;
@@ -2456,6 +2453,7 @@ SET DEBUG_SYNC= 'now SIGNAL grlwait';
 SET DEBUG_SYNC= 'now WAIT_FOR table_opened';
 SET DEBUG_SYNC= 'mdl_acquire_lock_wait SIGNAL grlwait';
 FLUSH TABLES WITH READ LOCK;
+InnoDB		0 transactions not purged
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 LOCK_MODE	LOCK_TYPE	TABLE_SCHEMA	TABLE_NAME
 MDL_BACKUP_FTWRL2	Backup lock		
@@ -2465,7 +2463,6 @@ connection default;
 SET DEBUG_SYNC= 'RESET';
 drop table t1,t2;
 disconnect con2;
-disconnect con1;
 #
 # Bug#50786 Assertion `thd->mdl_context.trans_sentinel() == __null' 
 #           failed in open_ltable()

--- a/mysql-test/main/mdl_sync.test
+++ b/mysql-test/main/mdl_sync.test
@@ -3115,12 +3115,6 @@ create table t2 (a int) stats_persistent=0, engine=innodb;
 insert into t1 values (1);
 insert into t2 values (1);
 
-connect (con1, localhost, root);
-# disable innodb purge thread, otherwise it might start purging t2,
-# and will take an mdl, affecting metadata_lock_info output.
-start transaction with consistent snapshot;
-connection default;
-
 SET DEBUG_SYNC= 'after_open_table_mdl_shared SIGNAL table_opened WAIT_FOR grlwait execute 2';
 --send update t1,t2 set t1.a=2,t2.a=3
 
@@ -3156,6 +3150,7 @@ FLUSH TABLES WITH READ LOCK;
 
 let $wait_condition= SELECT COUNT(*)=1 FROM information_schema.metadata_lock_info;
 --source include/wait_condition.inc
+--source ../suite/innodb/include/wait_all_purged.inc
 SELECT LOCK_MODE, LOCK_TYPE, TABLE_SCHEMA, TABLE_NAME FROM information_schema.metadata_lock_info;
 
 unlock tables;
@@ -3166,7 +3161,6 @@ connection default;
 SET DEBUG_SYNC= 'RESET';
 drop table t1,t2;
 disconnect con2;
-disconnect con1;
 
 --echo #
 --echo # Bug#50786 Assertion `thd->mdl_context.trans_sentinel() == __null' 


### PR DESCRIPTION
SELECT FROM information_schema.metadata_lock_info may sporadically return MDL_SHARED lock acquired by InnoDB purge thread.

Fix proposed in a7bf0a42d0c wasn't enough to solve this problem: apparently it did protect against purging old rows, but not against locking the table.

Reverted a7bf0a42d0c in favour of solution proposed in e996f77cd87. That is use wait_all_purged.inc to make sure purge is completed.