### PR TITLE
MDEV-36684 - main.mdl_sync fails under valgrind (test for Bug#42643)

### DIFF
--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -4460,6 +4460,7 @@ restart:
             goto error;
 
           error= FALSE;
+          std::this_thread::yield();
           goto restart;
         }
         goto error;
@@ -4522,6 +4523,7 @@ restart:
               goto error;
 
             error= FALSE;
+            std::this_thread::yield();
             goto restart;
           }
           /*

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -20,6 +20,7 @@
 /* Classes in mysql */
 
 #include <atomic>
+#include <thread>
 #include "dur_prop.h"
 #include <waiting_threads.h>
 #include "sql_const.h"

--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -901,6 +901,7 @@ retry:
   {
     mysql_mutex_unlock(&element->LOCK_table_share);
     lf_hash_search_unpin(thd->tdc_hash_pins);
+    std::this_thread::yield();
     goto retry;
   }
   lf_hash_search_unpin(thd->tdc_hash_pins);

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1076,6 +1076,7 @@ static void trx_purge_close_tables(purge_node_t *node, THD *thd) noexcept
 
 void purge_sys_t::wait_FTS(bool also_sys)
 {
+  std::this_thread::yield();
   for (const uint32_t mask= also_sys ? ~0U : ~PAUSED_SYS; m_FTS_paused & mask;)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 }


### PR DESCRIPTION
Valgrind is single threaded and only changes threads as part of system calls or waits.

I found some busy loops where the server assumes that some other thread will change the state, which will not happen with valgrind.

Added VALGRIND_YIELD to the loops, which calls pthread_yield() if HAVE_VALGRIND is defined.

Added pthread_yield() to the loops in table_cache.

We should consider changing some of the VALGRIND_YIELD calls to call pthread_yield() as busy loop without any sleep() is usually a bad thing.

Reviewer: svojtovich@gmail.com