### PR TITLE
MDEV-36628 : galera_vote_during_ist test failed

### DIFF
--- a/mysql-test/suite/galera/r/galera_vote_during_ist.result
+++ b/mysql-test/suite/galera/r/galera_vote_during_ist.result
@@ -8,6 +8,8 @@ connection node_2;
 connection node_3;
 connection node_4;
 connection node_1;
+SET SESSION wsrep_on = ON;
+SET SESSION wsrep_sync_wait = 15;
 CREATE TABLE t1(pk INT AUTO_INCREMENT PRIMARY KEY);
 CREATE PROCEDURE p1(IN max INT)
 BEGIN
@@ -48,6 +50,8 @@ CREATE TABLE t2(pk INT AUTO_INCREMENT PRIMARY KEY);
 SET SESSION wsrep_on = ON;
 INSERT INTO t2 VALUES (DEFAULT);
 CALL p1(130);
+connection node_2;
+connection node_3;
 connection node_1;
 SET GLOBAL debug = "+d,sync.wsrep_sst_donor_after_donation";
 Restarting server 4
@@ -58,8 +62,6 @@ SET SESSION DEBUG_SYNC = "now SIGNAL signal.wsrep_sst_donor_after_donation_conti
 SET GLOBAL debug = "";
 SET DEBUG_SYNC='RESET';
 Waiting for server 4 to leave the cluster
-SET SESSION wsrep_on = ON;
-SET SESSION wsrep_sync_wait = 15;
 connection node_2;
 SET SESSION wsrep_on = ON;
 SET SESSION wsrep_sync_wait = 15;
@@ -69,8 +71,16 @@ SET SESSION wsrep_sync_wait = 15;
 connection node_4;
 Server 4 left the cluster, killing it...
 Killed server 4...
+connection node_1;
+connection node_4;
 Restarting server 4...
 connection node_1;
+SET SESSION wsrep_on = ON;
+SET SESSION wsrep_sync_wait = 15;
+connection node_2;
+SET SESSION wsrep_on = ON;
+SET SESSION wsrep_sync_wait = 15;
+connection node_3;
 SET SESSION wsrep_on = ON;
 SET SESSION wsrep_sync_wait = 15;
 connection node_1;

--- a/mysql-test/suite/galera/t/galera_vote_during_ist.test
+++ b/mysql-test/suite/galera/t/galera_vote_during_ist.test
@@ -20,6 +20,10 @@ source ../wsrep/include/check_galera_version.inc;
 
 # create table t1 and procedure p1 to generate wirtesets
 --connection node_1
+
+--let $members = 4
+--source include/wsrep_wait_membership.inc
+
 CREATE TABLE t1(pk INT AUTO_INCREMENT PRIMARY KEY);
 
 DELIMITER |;
@@ -39,11 +43,17 @@ DELIMITER ;|
 CALL p1(130);
 
 --connection node_4
+--let $wait_condition = SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't1';
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 130 FROM t1;
+--source include/wait_condition.inc
+
 --echo Shutting down server 4...
 --let $node_4_server_id= `SELECT @@server_id`
 --let $node_4_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$node_4_server_id.expect
 --let $node_4_pid_file= `SELECT @@pid_file`
 --source include/shutdown_mysqld.inc
+--source include/wait_until_disconnected.inc
 
 # Wait for node #4 to leave cluster
 --let $members = 3
@@ -65,22 +75,36 @@ CALL p1(130);
 SET SESSION wsrep_on = OFF;
 CREATE TABLE t2(pk INT AUTO_INCREMENT PRIMARY KEY);
 SET SESSION wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 --connection node_2
+--let $wait_condition = SELECT COUNT(*) = 260 FROM t1;
+--source include/wait_condition.inc
 SET SESSION wsrep_on = OFF;
 CREATE TABLE t2(pk INT AUTO_INCREMENT PRIMARY KEY);
 SET SESSION wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 --connection node_3
+--let $wait_condition = SELECT COUNT(*) = 260 FROM t1;
+--source include/wait_condition.inc
 SET SESSION wsrep_on = OFF;
 CREATE TABLE t2(pk INT AUTO_INCREMENT PRIMARY KEY);
 SET SESSION wsrep_on = ON;
+--source include/wait_until_ready.inc
 
 # This should cause error during IST
 INSERT INTO t2 VALUES (DEFAULT);
 
 # make sure nodes 1,2,3 progress far enough for commit cut update
 CALL p1(130);
+
+--connection node_2
+--let $wait_condition = SELECT COUNT(*) = 390 FROM t1;
+--source include/wait_condition.inc
+--connection node_3
+--let $wait_condition = SELECT COUNT(*) = 390 FROM t1;
+--source include/wait_condition.inc
 
 --connection node_1
 # prepare to stop SST donor thread when it receives a request from starting node #4
@@ -96,14 +120,12 @@ SET SESSION DEBUG_SYNC = "now WAIT_FOR sync.wsrep_sst_donor_after_donation_reach
 SET SESSION DEBUG_SYNC = "now SIGNAL signal.wsrep_sst_donor_after_donation_continue";
 SET GLOBAL debug = "";
 SET DEBUG_SYNC='RESET';
-
 #
 # After this point node #4 shall proceed to IST and bail out
 #
 
 --echo Waiting for server 4 to leave the cluster
 --let $members = 3
---source include/wsrep_wait_membership.inc
 --connection node_2
 --source include/wsrep_wait_membership.inc
 --connection node_3
@@ -124,13 +146,26 @@ SET DEBUG_SYNC='RESET';
 EOF
 --echo Killed server 4...
 --source include/wait_until_disconnected.inc
+
+--connection node_1
+--source include/wait_until_ready.inc
+--let $wait_condition = SELECT VARIABLE_VALUE = 'Synced' FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--let $wait_condition_on_error_output = SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'wsrep_local_state_comment';
+--source include/wait_condition_with_debug.inc
+
+--connection node_4
 --echo Restarting server 4...
 --source include/start_mysqld.inc
 --source include/galera_wait_ready.inc
 
+
 # Confirm node #4 has rejoined
 --connection node_1
 --let $members = 4
+--source include/wsrep_wait_membership.inc
+--connection node_2
+--source include/wsrep_wait_membership.inc
+--connection node_3
 --source include/wsrep_wait_membership.inc
 
 # Confirm that all is good and all nodes have identical data
@@ -148,6 +183,10 @@ SELECT count(*) AS expect3_390 FROM t1;
 SELECT count(*) AS expect3_1 FROM t2;
 
 --connection node_4
+--let $wait_condition = SELECT COUNT(*) = 390 FROM t1;
+--source include/wait_condition.inc
+--let $wait_condition = SELECT COUNT(*) = 1 FROM t2;
+--source include/wait_condition.inc
 SELECT count(*) AS expect4_390 FROM t1;
 SELECT count(*) AS expect4_1 FROM t2;
 


### PR DESCRIPTION
Test changes only. Add wait_conditions to wait correct database state.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36628*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [ x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [ x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
