### PR TITLE
MDEV-28823 Secure mariadb-secure-installation output file with chmod

### DIFF
--- a/scripts/mysql_secure_installation.sh
+++ b/scripts/mysql_secure_installation.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 # Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1335  USA
@@ -218,8 +218,8 @@ validate_reply () {
 }
 
 prepare() {
-    touch $config $command
-    chmod 600 $config $command
+    touch $config $command $output
+    chmod 600 $config $command $output
 }
 
 do_query() {


### PR DESCRIPTION
## Description

This commit addresses a security issue in the `mariadb-secure-installation` script where the temporary output file containing SQL commands and potentially password hashes was being created with default permissions (typically world-readable).

The fix involves modifying the `prepare()` function to:

1. Create the `$output` file explicitly using `touch` before it's used
2. Apply `chmod 600` permissions to restrict access to owner only
3. Maintain consistency with how `$config` and `$command` files are already handled

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.

## How can this PR be tested?

1. Run the original `mariadb-secure-installation` script and observe file permissions:

   ```bash
   ./build/scripts/mariadb-secure-installation --socket=/tmp/mysql.sock
   # In another terminal
   ls -la .my* | grep -v .mysql_history
   ```

   The `.my.output.*` file will have `-rw-r--r--` permissions
2. With the patched version:

   ```bash
   # After applying the fix and rebuilding
   ./build/scripts/mariadb-secure-installation --socket=/tmp/mysql.sock
   # In another terminal 
   ls -la .my* | grep -v .mysql_history
   ```

   The `.my.output.*` file will have `-rw-------` permissions

## Results from my testing

1. Before changes

   ```
   root@03b5517f4303:/quick-rebuilds# ls -la .my* | grep -v .mysql_history
   -rw------- 1 root root  70 Apr 22 16:55 .my.cnf.15643
   -rw-r--r-- 1 root root 130 Apr 22 16:55 .my.output.15643
   -rw------- 1 root root  32 Apr 22 16:55 .mysql.15643
   ```
2. After Changes

   ```
   root@03b5517f4303:/quick-rebuilds# ls -la .my* | grep -v .mysql_history
   -rw------- 1 root root  70 Apr 22 17:04 .my.cnf.16290
   -rw------- 1 root root 130 Apr 22 17:04 .my.output.16290
   -rw------- 1 root root  32 Apr 22 17:04 .mysql.16290
   ```

## Basing the PR against the correct MariaDB version

* ✅ _This is a security fix applicable to multiple versions, and the PR is based against the latest MariaDB development branch._

## PR quality check

* ✅ I have checked the `CODING_STANDARDS.md` file and my PR conforms to this where appropriate.
* ✅ For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.