### PR TITLE
MDEV-36627 : galera.MDEV-29142: certification position less than last…

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-29142.result
+++ b/mysql-test/suite/galera/r/MDEV-29142.result
@@ -42,4 +42,8 @@ connection node_2;
 call mtr.add_suppression("WSREP: Failed to open table mysql\\.wsrep_streaming_log for writing");
 call mtr.add_suppression("WSREP: Failed to open SR table for write");
 call mtr.add_suppression("WSREP: Failed to recover SR transactions from schema: wsrep_on : 0");
+connection node_1;
+call mtr.add_suppression("WSREP: Cert position .* less than last committed.*");
+connection node_2;
+call mtr.add_suppression("WSREP: Cert position .* less than last committed.*");
 DROP TABLE IF EXISTS t1;

--- a/mysql-test/suite/galera/t/MDEV-29142.test
+++ b/mysql-test/suite/galera/t/MDEV-29142.test
@@ -53,15 +53,25 @@ SET SESSION wsrep_sync_wait = 0;
 --let $start_mysqld_params =--wsrep-new-cluster
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --source include/start_mysqld.inc
+--source include/wait_until_ready.inc
 
 --connection node_2
 --let $start_mysqld_params =
 --let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.2.expect
 --source include/start_mysqld.inc
+--source include/wait_until_ready.inc
 
 call mtr.add_suppression("WSREP: Failed to open table mysql\\.wsrep_streaming_log for writing");
 call mtr.add_suppression("WSREP: Failed to open SR table for write");
 call mtr.add_suppression("WSREP: Failed to recover SR transactions from schema: wsrep_on : 0");
+
+--connection node_1
+#
+# after the membership change on a newly synced node, then this is just a warning
+#
+call mtr.add_suppression("WSREP: Cert position .* less than last committed.*");
+--connection node_2
+call mtr.add_suppression("WSREP: Cert position .* less than last committed.*");
 
 #
 # Cleanup


### PR DESCRIPTION
… commited

After the membership change on a newly synced node, then this is just a warning and safe to suppress.

<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36627*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description
TODO: fill description here

## Release Notes
TODO: What should the release notes say about this change?
Include any changed system variables, status variables or behaviour. Optionally list any https://mariadb.com/kb/ pages that need changing.

## How can this PR be tested?

TODO: modify the automated test suite to verify that the PR causes MariaDB to behave as intended.
Consult the documentation on ["Writing good test cases"](https://mariadb.org/get-involved/getting-started-for-developers/writing-good-test-cases-mariadb-server).
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x ] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and codying style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [ x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x ] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
