### PR TITLE
MDEV-36168 ASAN error in Item_func_latlongfromgeohash::decode_geohash…

### DIFF
--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -3035,12 +3035,19 @@ const uint8_t Item_func_latlongfromgeohash::geohash_alphabet[256] = {
 };
 
 
+/**
+  converts a geohash character to an int.
+  @return false on success, true on valid (invalid geohash character)
+*/
 bool Item_func_latlongfromgeohash::convert_character(char in, int &out)
 {
+#if CHAR_MIN
+  /* representing signed char, unsigned char always has a map */
   if (in < 0)
     return true;
+#endif
   out= Item_func_latlongfromgeohash::geohash_alphabet[(int) in];
-  return false;
+  return out == 255;
 }
 
 
@@ -3071,10 +3078,8 @@ bool Item_func_latlongfromgeohash::decode_geohash(
   for (uint i = 0; i < input_length; i++)
   {
     int converted_character= -1;
-    if (convert_character((*geohash)[i], converted_character) ||
-        converted_character == 255) {
+    if (convert_character((*geohash)[i], converted_character))
       return true;
-    }
 
     for (int bit_number = 4; bit_number >= 0; bit_number--)
     {


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36168*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

… (postfix)

pppc64le, aarch64, and s390x have char defined as unsigned so a < 0 comparison is a compile error. The CHAR_MIN defined in limits.h is 0 on these platforms, false, meaning the if condition is only on signed char platforms.

To make the interface cleaner we return true on out == 255 to simplify the calling function.

## Release Notes

Nothing, covered already

## How can this PR be tested?

It was a compile error on mentioned platforms already covered in buildbot.
<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.