### PR TITLE
MDEV-36710: Revert "MDEV-33136: backport corrections from 10.11+"

### DIFF
--- a/mysql-test/suite/galera/r/MDEV-33136.result
+++ b/mysql-test/suite/galera/r/MDEV-33136.result
@@ -4,7 +4,7 @@ connect node_1a,127.0.0.1,root,,test,$NODE_MYPORT_1;
 connection node_1;
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 connection node_1a;
-RENAME TABLE t1 TO tmp, tmp TO t1;
+TRUNCATE TABLE t1;
 SET SESSION wsrep_retry_autocommit = 0;
 SET DEBUG_SYNC = 'dict_stats_mdl_acquired SIGNAL may_toi WAIT_FOR bf_abort';
 INSERT INTO t1 VALUES (1);

--- a/mysql-test/suite/galera/t/MDEV-33136.test
+++ b/mysql-test/suite/galera/t/MDEV-33136.test
@@ -20,8 +20,8 @@
 CREATE TABLE t1 (f1 INTEGER PRIMARY KEY) ENGINE=InnoDB;
 
 --connection node_1a
-RENAME TABLE t1 TO tmp, tmp TO t1;
-# RENAME forces the next statement to re-read statistics from persistent storage,
+TRUNCATE TABLE t1;
+# TRUNCATE forces the next statement to re-read statistics from persistent storage,
 # which will acquire MDL locks on the statistics tables in InnoDB.
 SET SESSION wsrep_retry_autocommit = 0;
 SET DEBUG_SYNC = 'dict_stats_mdl_acquired SIGNAL may_toi WAIT_FOR bf_abort';


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36710*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

This reverts commit 0403f0147f176190b6a2ca61996c12eada275e4c. It caused MDEV-33136 test to fail in 10.6 branch.

## Release Notes

This fix is ONLY for 10.6 branch.

## How can this PR be tested?

MTR test case is made passing again.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
