### PR TITLE
MDEV-36714: Rows_log_event::write_data_header overallocates buffer size

### DIFF
--- a/sql/log_event_server.cc
+++ b/sql/log_event_server.cc
@@ -6501,7 +6501,7 @@ Rows_log_event::do_update_pos(rpl_group_info *rgi)
 
 bool Rows_log_event::write_data_header()
 {
-  uchar buf[ROWS_HEADER_LEN_V2];        // No need to init the buffer
+  uchar buf[ROWS_HEADER_LEN];        // No need to init the buffer
   DBUG_ASSERT(m_table_id != UINT32_MAX);
   DBUG_EXECUTE_IF("old_row_based_repl_4_byte_map_id_master",
                   {


### PR DESCRIPTION
Nothing is broken by this, but the function Rows_log_event::write_data_header slightly over-allocates its buf by 2 bytes. It allocates 10 (ROWS_HEADER_LEN_V2), but only 8 are ever written.

This patch fixes the buf size to match what is written (i.e. ROWS_HEADER_LEN, or 8 bytes).