### PR TITLE
MDEV-36721: remove PrivateDevices=false from systemd services

### DIFF
--- a/support-files/mariadb.service.in
+++ b/support-files/mariadb.service.in
@@ -51,10 +51,6 @@ Group=mysql
 # These are enabled by default
 AmbientCapabilities=CAP_IPC_LOCK
 
-# PrivateDevices=true implies NoNewPrivileges=true and
-# SUID auth_pam_tool suddenly doesn't do setuid anymore
-PrivateDevices=false
-
 # Prevent writes to /usr, /boot, and /etc
 ProtectSystem=full
 

--- a/support-files/mariadb@.service.in
+++ b/support-files/mariadb@.service.in
@@ -181,10 +181,6 @@ PrivateNetwork=false
 # These are enabled by default
 AmbientCapabilities=CAP_IPC_LOCK
 
-# PrivateDevices=true implies NoNewPrivileges=true and
-# SUID auth_pam_tool suddenly doesn't do setuid anymore
-PrivateDevices=false
-
 # Prevent writes to /usr, /boot, and /etc
 ProtectSystem=full
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36721*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

The association between PrivateDevices=false and NoNewPrivileges as an old mistake in the kernel that has been now corrected.

This was in 2019 via Debian bug #911152.

## Release Notes

This removes PrivateDefaults=false from systemd service files. This means the default is now PrivateDevices=true providing more security. The old kernels where this was an issue should not be in use. Those uses using a specific InnODB on raw partitions via innodb_data_file_path=/dev/XXX then reapply PrivateDevices=false locally as documented https://mariadb.com/kb/en/systemd/#useful-systemd-options.

## How can this PR be tested?

per package autobake-install tests on https://buildbot.mariadb.org/#/grid?branch=bb-10.11-systemd-remove-privatedevices-pkgtest which perform a systemctl start on the native kernel for the distro.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
-  [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
