### PR TITLE
MDEV-36729: ha_example::show_func_example is incorrectly defined

### DIFF
--- a/storage/example/ha_example.cc
+++ b/storage/example/ha_example.cc
@@ -1078,11 +1078,11 @@ static struct st_mysql_sys_var* example_system_variables[]= {
 // this is an example of SHOW_SIMPLE_FUNC and of my_snprintf() service
 // If this function would return an array, one should use SHOW_FUNC
 static int show_func_example(MYSQL_THD thd, struct st_mysql_show_var *var,
-                             char *buf)
+                             void *buf, system_status_var *, enum_var_type)
 {
   var->type= SHOW_CHAR;
   var->value= buf; // it's of SHOW_VAR_FUNC_BUFF_SIZE bytes
-  my_snprintf(buf, SHOW_VAR_FUNC_BUFF_SIZE,
+  my_snprintf((char*) buf, SHOW_VAR_FUNC_BUFF_SIZE,
               "enum_var is %lu, ulong_var is %lu, int_var is %d, "
               "double_var is %f, %.6b", // %b is a MySQL extension
               srv_enum_var, srv_ulong_var, THDVAR(thd, int_var),


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-36729*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

In the main.plugin this function is called assuming the function prototype int (*)(THD *, st_mysql_show_var *, void *, system_status_var *, enum_var_type)' as changed in b4ff64568c88ab3ce559e7bd39853d9cbf86704a.

We update the ha_example::show_func_example to match the prototype on which it is called.

## Release Notes

internal test issue.

## How can this PR be tested?

Under clang UBSAN tests run the unit test main.plugin.

<!--
In many cases, this will be as simple as modifying one `.test` and one `.result` file in the `mysql-test/` subdirectory.
Without automated tests, future regressions in the expected behavior can't be automatically detected and verified.
-->

If the changes are not amenable to automated testing, please explain why not and carefully describe how to test manually.

<!--
Tick one of the following boxes [x] to help us understand if the base branch for the PR is correct.
-->
## Basing the PR against the correct MariaDB version
- [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
- [X] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
- [X] *This is a bug fix of a type than cannot be filtered with UBSAN filters that would otherwise block testing on the 10.6 branch with an updated UBSAN tester (MDBF-741).

<!--
  All code merged into the MariaDB codebase must meet a quality standard and coding style.
  Maintainers are happy to point out inconsistencies but in order to speed up the review and merge process we ask you to check the CODING standards.
-->
## PR quality check
- [X] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [X] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.