### PR TITLE
MDEV-35837: Update CODING_STANDARDS to C++17

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -187,7 +187,7 @@ C file names use the `.c` extension, C++ files use the `.cc` extension and heade
 
 ### Language standards
 
-For pure-C files we use C99 and for C++ we use C++11.
+For pure-C files we use C99 (starting with 10.4.25) and for C++ we use C++17 (starting with 11.8.1).
 The code need to be able to compile on multiple platforms using different compilers (for example: Windows / Linux, x86_64 / ARM).
 
 ### Line lengths


### PR DESCRIPTION
* [x] *The Jira issue number for this PR is: [MDEV-35837](https://jira.mariadb.org/browse/MDEV-35837)*
  * #3853 fixup 

## What problem is the patch trying to solve?
#3853 intended to update `CODING_STANDARDS.md` to say C++17 re. #3758, but somehow didn’t (lost diff when I squashed?), and it __still__ says C++11.

## Release Notes
N/A
## How can this PR be tested?
N/A?

## PR quality check
* [ ] *This is a new feature or a refactoring, and the PR is based against the `main` branch.*
* [x] *This is a bug fix, and the PR is based against the earliest maintained branch in which the bug can be reproduced.*
* [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
* [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.