### PR TITLE
MDEV-35570 parallel slave ALTER-SEQUNCE attemted to binlog out-of-order

### DIFF
--- a/mysql-test/suite/archive/archive-big.test
+++ b/mysql-test/suite/archive/archive-big.test
@@ -1,6 +1,7 @@
 --source include/big_test.inc
-# Valgrind is to slow for this test
+# Valgrind and msan is to slow for this test
 --source include/not_valgrind.inc
+--source include/not_msan.inc
 --source include/have_archive.inc
 CREATE TABLE t1(a BLOB) ENGINE=ARCHIVE;
 --disable_query_log

--- a/mysql-test/suite/federated/federatedx_create_handlers.test
+++ b/mysql-test/suite/federated/federatedx_create_handlers.test
@@ -7,9 +7,6 @@ connection default;
 
 set global federated_pushdown=1;
 
-#Enable after fix MDEV-31846 or in v. 10.5 and later
---disable_cursor_protocol
-
 connection slave;
 
 DROP TABLE IF EXISTS federated.t1;
@@ -165,11 +162,13 @@ insert into federated.t4 select * from federated.t1;
 --sorted_result
 select * from federated.t4;
 
+--disable_cursor_protocol
 select name into @var from federated.t1 where id=3 limit 1 ;
 select @var;
 --disable_ps2_protocol
 select name into outfile 'tmp.txt' from federated.t1;
 --enable_ps2_protocol
+--enable_cursor_protocol
 
 let $path=`select concat(@@datadir, 'test/tmp.txt')`;
 remove_file $path;
@@ -435,8 +434,6 @@ DEALLOCATE PREPARE stmt;
 
 
 set global federated_pushdown=0;
-
---enable_cursor_protocol
 
 source include/federated_cleanup.inc;
 

--- a/mysql-test/suite/innodb/r/foreign_key.result
+++ b/mysql-test/suite/innodb/r/foreign_key.result
@@ -155,7 +155,6 @@ INSERT INTO parent SET a=0;
 FLUSH TABLES;
 # restart
 disconnect incomplete;
-SET @save_stats_persistent = @@GLOBAL.innodb_stats_persistent;
 SET GLOBAL innodb_stats_persistent = 0;
 INSERT INTO child SET a=0;
 INSERT INTO child SET a=1;
@@ -1182,5 +1181,23 @@ ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fail
 ALTER TABLE t2 ADD KEY(b), ALGORITHM=NOCOPY;
 DELETE FROM t1;
 DROP TABLE t2, t1;
+#
+# MDEV-33167 ASAN errors after failing to load foreign key
+#   relation for the table
+#
+call mtr.add_suppression("InnoDB: Load table `test`.`t3` failed, the table has missing foreign key indexes. Turn off 'foreign_key_checks' and try again.");
+SET STATEMENT FOREIGN_KEY_CHECKS = 0 FOR
+CREATE TABLE t1(f1 VARCHAR(8),
+FOREIGN KEY(f1) REFERENCES test.t3(f1))ENGINE=InnoDB;
+SET STATEMENT FOREIGN_KEY_CHECKS = 0 FOR
+CREATE TABLE t2(f1 VARCHAR(8),
+FOREIGN KEY(f1) REFERENCES test.t3(f1))
+ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+SET STATEMENT FOREIGN_KEY_CHECKS = 0 FOR
+CREATE TABLE t3(f1 VARCHAR(8) PRIMARY KEY)
+ENGINE=InnoDB DEFAULT CHARSET=latin1;
+set GLOBAL innodb_fast_shutdown=0;
+# restart
+ALTER TABLE t2 FORCE;
+DROP TABLE t2, t1, t3;
 # End of 10.6 tests
-SET GLOBAL innodb_stats_persistent = @save_stats_persistent;

--- a/mysql-test/suite/innodb/r/innodb_bug52663.result
+++ b/mysql-test/suite/innodb/r/innodb_bug52663.result
@@ -1,10 +1,11 @@
+SET @save_innodb_timeout=@@innodb_lock_wait_timeout;
+SET GLOBAL innodb_lock_wait_timeout=1;
 set session transaction isolation level read committed;
 create table innodb_bug52663 (what varchar(5), id integer, count integer, primary key
 (what, id)) engine=innodb;
 insert into innodb_bug52663 values ('total', 0, 0);
 begin;
 connect  addconroot, localhost, root,,;
-connection addconroot;
 set session transaction isolation level read committed;
 begin;
 connection default;
@@ -31,3 +32,4 @@ select * from innodb_bug52663;
 what	id	count
 total	0	2
 drop table innodb_bug52663;
+SET GLOBAL innodb_lock_wait_timeout=@save_innodb_timeout;

--- a/mysql-test/suite/innodb/r/instant_alter_debug,redundant.rdiff
+++ b/mysql-test/suite/innodb/r/instant_alter_debug,redundant.rdiff
@@ -1,8 +1,9 @@
-@@ -527,6 +527,6 @@
+@@ -576,7 +576,7 @@
  FROM information_schema.global_status
  WHERE variable_name = 'innodb_instant_alter_column';
  instants
 -37
 +38
- SET GLOBAL innodb_stats_persistent = @save_stats_persistent;
- # End of 10.6 tests
+ CREATE TABLE t1(f1 INT, f2 TEXT)ENGINE=InnoDB;
+ INSERT INTO t1 VALUES(1, 'a');
+ ALTER TABLE t1 ADD COLUMN f3 TEXT FIRST;

--- a/mysql-test/suite/innodb/r/instant_alter_debug.result
+++ b/mysql-test/suite/innodb/r/instant_alter_debug.result
@@ -577,5 +577,16 @@ FROM information_schema.global_status
 WHERE variable_name = 'innodb_instant_alter_column';
 instants
 37
+CREATE TABLE t1(f1 INT, f2 TEXT)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, 'a');
+ALTER TABLE t1 ADD COLUMN f3 TEXT FIRST;
+SET STATEMENT DEBUG_DBUG="+d,instant_insert_fail" FOR
+ALTER TABLE t1 DROP COLUMN f1;
+ERROR HY000: Internal error: InnoDB: Insert into SYS_COLUMNS failed
+ALTER TABLE t1 DROP COLUMN f1;
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;
 SET GLOBAL innodb_stats_persistent = @save_stats_persistent;
 # End of 10.6 tests

--- a/mysql-test/suite/innodb/t/foreign_key.test
+++ b/mysql-test/suite/innodb/t/foreign_key.test
@@ -133,7 +133,6 @@ FLUSH TABLES;
 --let $shutdown_timeout=
 disconnect incomplete;
 
-SET @save_stats_persistent = @@GLOBAL.innodb_stats_persistent;
 SET GLOBAL innodb_stats_persistent = 0;
 
 INSERT INTO child SET a=0;
@@ -1245,8 +1244,31 @@ ALTER TABLE t2 ADD KEY(b), ALGORITHM=NOCOPY;
 DELETE FROM t1;
 DROP TABLE t2, t1;
 
+--echo #
+--echo # MDEV-33167 ASAN errors after failing to load foreign key
+--echo #   relation for the table
+--echo #
+call mtr.add_suppression("InnoDB: Load table `test`.`t3` failed, the table has missing foreign key indexes. Turn off 'foreign_key_checks' and try again.");
+SET STATEMENT FOREIGN_KEY_CHECKS = 0 FOR
+CREATE TABLE t1(f1 VARCHAR(8),
+	        FOREIGN KEY(f1) REFERENCES test.t3(f1))ENGINE=InnoDB;
+
+SET STATEMENT FOREIGN_KEY_CHECKS = 0 FOR
+CREATE TABLE t2(f1 VARCHAR(8),
+	        FOREIGN KEY(f1) REFERENCES test.t3(f1))
+                ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+SET STATEMENT FOREIGN_KEY_CHECKS = 0 FOR
+CREATE TABLE t3(f1 VARCHAR(8) PRIMARY KEY)
+		ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+set GLOBAL innodb_fast_shutdown=0;
+--let $shutdown_timeout=
+--source include/restart_mysqld.inc
+# Error encountered while loading the foreign key
+# constraint for t3. t1 wasn't loaded into memory yet
+# t2 failed to find index for foreign key relation
+ALTER TABLE t2 FORCE;
+DROP TABLE t2, t1, t3;
+
 --echo # End of 10.6 tests
-
-SET GLOBAL innodb_stats_persistent = @save_stats_persistent;
-
---source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/innodb/t/innodb_bug52663.test
+++ b/mysql-test/suite/innodb/t/innodb_bug52663.test
@@ -1,6 +1,7 @@
---source include/long_test.inc
 --source include/have_innodb.inc
 
+SET @save_innodb_timeout=@@innodb_lock_wait_timeout;
+SET GLOBAL innodb_lock_wait_timeout=1;
 set session transaction isolation level read committed;
 
 create table innodb_bug52663 (what varchar(5), id integer, count integer, primary key
@@ -9,7 +10,6 @@ insert into innodb_bug52663 values ('total', 0, 0);
 begin;
 
 connect (addconroot, localhost, root,,);
-connection addconroot;
 set session transaction isolation level read committed;
 begin;
 
@@ -33,3 +33,4 @@ select * from innodb_bug52663;
 connection default;
 select * from innodb_bug52663;
 drop table innodb_bug52663;
+SET GLOBAL innodb_lock_wait_timeout=@save_innodb_timeout;

--- a/mysql-test/suite/innodb/t/instant_alter_debug.test
+++ b/mysql-test/suite/innodb/t/instant_alter_debug.test
@@ -657,11 +657,19 @@ DROP TABLE t1;
 SET DEBUG_SYNC=RESET;
 
 --echo # End of 10.5 tests
-
 SELECT variable_value-@old_instant instants
 FROM information_schema.global_status
 WHERE variable_name = 'innodb_instant_alter_column';
 
-SET GLOBAL innodb_stats_persistent = @save_stats_persistent;
+CREATE TABLE t1(f1 INT, f2 TEXT)ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, 'a');
+ALTER TABLE t1 ADD COLUMN f3 TEXT FIRST;
+--error ER_INTERNAL_ERROR
+SET STATEMENT DEBUG_DBUG="+d,instant_insert_fail" FOR
+ALTER TABLE t1 DROP COLUMN f1;
+ALTER TABLE t1 DROP COLUMN f1;
+CHECK TABLE t1;
+DROP TABLE t1;
 
+SET GLOBAL innodb_stats_persistent = @save_stats_persistent;
 --echo # End of 10.6 tests

--- a/mysql-test/suite/rpl/r/rpl_parallel_seq.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_seq.result
@@ -82,6 +82,29 @@ SELECT @@global.gtid_binlog_state, @@global.gtid_slave_pos as "all through 101 h
 @@global.gtid_binlog_state	all through 101 have been committed
 0-1-101	0-1-101
 connection slave;
+include/stop_slave.inc
+set @@global.slave_parallel_mode = conservative;
+include/start_slave.inc
+connection master;
+INSERT INTO ti SET a=2;
+include/save_master_gtid.inc
+connection slave;
+include/sync_with_master_gtid.inc
+lock table ti write;
+SET GLOBAL debug_dbug= "+d,halt_past_mark_start_commit";
+connection master;
+INSERT INTO ti SET a=35570;
+ALTER SEQUENCE s2 restart with 1;
+include/save_master_gtid.inc
+connection slave;
+unlock tables;
+SET debug_sync = "now SIGNAL past_mark_continue";
+include/sync_with_master_gtid.inc
+include/stop_slave.inc
+SET @@global.slave_parallel_mode = @@global.slave_parallel_mode;
+SET @@global.debug_dbug = @@GLOBAL.debug_dbug;
+include/start_slave.inc
+connection slave;
 flush tables with read lock;
 connection master;
 CREATE OR REPLACE SEQUENCE s3 ENGINE=innodb;

--- a/mysql-test/suite/rpl/t/rpl_parallel_seq.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_seq.test
@@ -128,6 +128,53 @@ SET DEBUG_SYNC = 'now SIGNAL continue_worker';
 
 SELECT @@global.gtid_binlog_state, @@global.gtid_slave_pos as "all through 101 have been committed";
 
+#
+# MDEV-35570 parallel slave ALTER-SEQUNCE attemted to binlog out-of-order.
+# Let two transactions I_1 -> AS_2 where AS_2 depends on a commit parent I_1.
+# Under the bug condition AS_2 may complete its work including binlogging
+# while I_1 is slowly executing Xid_log_event.
+# The test simulate the slowness, AS_2 must defer its completion.
+#
+--connection slave
+--source include/stop_slave.inc
+--let $saved_mode= @@global.slave_parallel_mode
+set @@global.slave_parallel_mode = conservative;
+--source include/start_slave.inc
+
+--connection master
+INSERT INTO ti SET a=2;
+--source include/save_master_gtid.inc
+
+--connection slave
+--source include/sync_with_master_gtid.inc
+# allow to proceed to sync with the 1st following WFPT2SC wait condtion
+lock table ti write;
+# allow to proceed into commit to sync with the 2nd following WFPC wait condition
+--let $saved_dbug= @@GLOBAL.debug_dbug
+SET GLOBAL debug_dbug= "+d,halt_past_mark_start_commit";
+
+--connection master
+INSERT INTO ti SET a=35570;
+ALTER SEQUENCE s2 restart with 1;
+--source include/save_master_gtid.inc
+
+--connection slave
+--let $wait_condition= SELECT count(*) = 1 FROM information_schema.processlist WHERE state LIKE "Waiting for prior transaction to start commit"
+--source include/wait_condition.inc
+# the 1st wait release
+unlock tables;
+
+--let $wait_condition= SELECT count(*) = 1 FROM information_schema.processlist WHERE state LIKE "Waiting for prior transaction to commit"
+--source include/wait_condition.inc
+# the 2nd wait release
+SET debug_sync = "now SIGNAL past_mark_continue";
+
+--source include/sync_with_master_gtid.inc
+--source include/stop_slave.inc
+--eval SET @@global.slave_parallel_mode = $saved_mode
+--eval SET @@global.debug_dbug = $saved_dbug
+--source include/start_slave.inc
+
 # MDEV-31792 Assertion in MDL_context::acquire_lock upon parallel replication of CREATE SEQUENCE
 
 --let $iter = 3

--- a/plugin/auth_examples/auth_0x0100.c
+++ b/plugin/auth_examples/auth_0x0100.c
@@ -56,6 +56,10 @@ struct st_mysql_auth
 };
 #endif
 
+/* function-type-mismatch ignore */
+#if defined(__clang__)
+__attribute__((no_sanitize("undefined")))
+#endif
 static int do_auth_0x0100(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info)
 {
   info->password_used= 1;

--- a/sql/rpl_parallel.cc
+++ b/sql/rpl_parallel.cc
@@ -1507,6 +1507,14 @@ handle_rpl_parallel_thread(void *arg)
           else
             rgi->mark_start_commit();
           DEBUG_SYNC(thd, "rpl_parallel_after_mark_start_commit");
+#ifdef ENABLED_DEBUG_SYNC
+          DBUG_EXECUTE_IF("halt_past_mark_start_commit",
+          {
+            DBUG_ASSERT(!debug_sync_set_action
+                        (thd, STRING_WITH_LEN("now WAIT_FOR past_mark_continue")));
+            DBUG_SET_INITIAL("-d,halt_past_mark_start_commit");
+          };);
+#endif
         }
       }
 

--- a/storage/federatedx/ha_federatedx.cc
+++ b/storage/federatedx/ha_federatedx.cc
@@ -1489,20 +1489,20 @@ static void fill_server(MEM_ROOT *mem_root, FEDERATEDX_SERVER *server,
        sizeof(int) + 8);
   key.append(scheme);
   key.q_append('\0');
-  server->hostname= (const char *) (intptr) key.length();
+  size_t hostname_pos= key.length();
   key.append(hostname);
   key.q_append('\0');
-  server->database= (const char *) (intptr) key.length();
+  size_t database_pos= key.length();
   key.append(database);
   key.q_append('\0');
   key.q_append((uint32) share->port);
-  server->socket= (const char *) (intptr) key.length();
+  size_t socket_pos= key.length();
   key.append(socket);
   key.q_append('\0');
-  server->username= (const char *) (intptr) key.length();
+  size_t username_pos= key.length();
   key.append(username);
   key.q_append('\0');
-  server->password= (const char *) (intptr) key.length();
+  size_t password_pos= key.length();
   key.append(password);
   key.c_ptr_safe();                             // Ensure we have end \0
 
@@ -1510,13 +1510,12 @@ static void fill_server(MEM_ROOT *mem_root, FEDERATEDX_SERVER *server,
   /* Copy and add end \0 */
   server->key= (uchar *)  strmake_root(mem_root, key.ptr(), key.length());
 
-  /* pointer magic */
-  server->scheme+= (intptr) server->key;
-  server->hostname+= (intptr) server->key;
-  server->database+= (intptr) server->key;
-  server->username+= (intptr) server->key;
-  server->password+= (intptr) server->key;
-  server->socket+= (intptr) server->key;
+  server->scheme= (const char *)server->key;
+  server->hostname= (const char *)server->key + hostname_pos;
+  server->database= (const char *)server->key + database_pos;
+  server->username= (const char *)server->key + username_pos;
+  server->password= (const char *)server->key + password_pos;
+  server->socket= (const char*)server->key + socket_pos;
   server->port= share->port;
 
   if (!share->socket)

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -630,7 +630,7 @@ bool buf_dblwr_t::flush_buffered_writes(const ulint size) noexcept
       static_cast<size_t>(srv_fatal_semaphore_wait_threshold);
   size_t log_count= first_log_count;
 
-  for (ulong count= 0;;)
+  for (size_t count= 0;;)
   {
     if (!active_slot->first_free)
       return false;

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -2515,10 +2515,12 @@ corrupted:
 	if (!table->is_readable()) {
 		/* Don't attempt to load the indexes from disk. */
 	} else if (err == DB_SUCCESS) {
+		auto i = fk_tables.size();
 		err = dict_load_foreigns(table->name.m_name, nullptr,
 					 0, true, ignore_err, fk_tables);
 
 		if (err != DB_SUCCESS) {
+			fk_tables.erase(fk_tables.begin() + i, fk_tables.end());
 			ib::warn() << "Load table " << table->name
 				<< " failed, the table has missing"
 				" foreign key indexes. Turn off"

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -621,6 +621,16 @@ inline bool dict_table_t::instant_column(const dict_table_t& table,
 	}
 
 	dict_index_t* index = dict_table_get_first_index(this);
+	if (instant) {
+		instant->field_map= static_cast<field_map_element_t*>(
+			mem_heap_dup(heap, instant->field_map,
+				     (index->n_fields -
+				      index->first_user_field()) *
+					sizeof *instant->field_map));
+		instant= static_cast<dict_instant_t*>(
+			mem_heap_dup(heap, instant, sizeof *instant));
+	}
+
 	bool metadata_changed;
 	{
 		const dict_index_t& i = *dict_table_get_first_index(&table);
@@ -5514,6 +5524,11 @@ static bool innodb_insert_sys_columns(
 
 		return false;
 	}
+
+	DBUG_EXECUTE_IF("instant_insert_fail",
+			my_error(ER_INTERNAL_ERROR, MYF(0),
+				 "InnoDB: Insert into SYS_COLUMNS failed");
+			return true;);
 
 	if (DB_SUCCESS != que_eval_sql(
 		    info,

--- a/storage/mroonga/vendor/groonga/lib/db.c
+++ b/storage/mroonga/vendor/groonga/lib/db.c
@@ -969,8 +969,8 @@ calc_rec_size(grn_table_flags flags, uint32_t max_n_subrecs, uint32_t range_size
       *subrec_size = range_size + sizeof(uint32_t) + sizeof(uint32_t);
       break;
     }
-    *value_size = (uintptr_t)GRN_RSET_SUBRECS_NTH((((grn_rset_recinfo *)0)->subrecs),
-                                                  *subrec_size, max_n_subrecs);
+    *value_size = (uintptr_t) GRN_RSET_SUBRECS_NTH(offsetof(grn_rset_recinfo, subrecs),
+                                                   *subrec_size, max_n_subrecs);
   } else {
     *value_size = range_size;
   }

--- a/storage/mroonga/vendor/groonga/lib/hash.c
+++ b/storage/mroonga/vendor/groonga/lib/hash.c
@@ -1727,15 +1727,15 @@ grn_io_hash_calculate_entry_size(uint32_t key_size, uint32_t value_size,
 {
   if (flags & GRN_OBJ_KEY_VAR_SIZE) {
     if (flags & GRN_OBJ_KEY_LARGE) {
-      return (uintptr_t)((grn_io_hash_entry_large *)0)->value + value_size;
+      return offsetof(grn_io_hash_entry_large, value) + value_size;
     } else {
-      return (uintptr_t)((grn_io_hash_entry_normal *)0)->value + value_size;
+      return offsetof(grn_io_hash_entry_normal, value) + value_size;
     }
   } else {
     if (key_size == sizeof(uint32_t)) {
-      return (uintptr_t)((grn_plain_hash_entry *)0)->value + value_size;
+      return offsetof(grn_plain_hash_entry, value) + value_size;
     } else {
-      return (uintptr_t)((grn_rich_hash_entry *)0)->key_and_value
+      return offsetof(grn_rich_hash_entry, key_and_value)
           + key_size + value_size;
     }
   }
@@ -1865,12 +1865,12 @@ grn_tiny_hash_calculate_entry_size(uint32_t key_size, uint32_t value_size,
 {
   uint32_t entry_size;
   if (flags & GRN_OBJ_KEY_VAR_SIZE) {
-    entry_size = (uintptr_t)((grn_tiny_hash_entry *)0)->value + value_size;
+    entry_size = offsetof(grn_tiny_hash_entry, value) + value_size;
   } else {
     if (key_size == sizeof(uint32_t)) {
-      entry_size = (uintptr_t)((grn_plain_hash_entry *)0)->value + value_size;
+      entry_size = offsetof(grn_plain_hash_entry, value) + value_size;
     } else {
-      entry_size = (uintptr_t)((grn_rich_hash_entry *)0)->key_and_value
+      entry_size = offsetof(grn_rich_hash_entry, key_and_value)
           + key_size + value_size;
     }
   }

--- a/storage/mroonga/vendor/groonga/lib/ii.c
+++ b/storage/mroonga/vendor/groonga/lib/ii.c
@@ -2049,7 +2049,7 @@ grn_p_decv(grn_ctx *ctx, uint8_t *data, uint32_t data_size, datavec *dv, uint32_
   if ((df & 1)) {
     df >>= 1;
     size = nreq == dvlen ? data_size : df * nreq;
-    if (dv[dvlen].data < dv[0].data + size) {
+    if (!dv[0].data || dv[dvlen].data < dv[0].data + size) {
       if (dv[0].data) { GRN_FREE(dv[0].data); }
       if (!(rp = GRN_MALLOC(size * sizeof(uint32_t)))) { return 0; }
       dv[dvlen].data = rp + size;
@@ -10653,7 +10653,7 @@ grn_ii_builder_options_fix(grn_ii_builder_options *options)
 }
 
 #define GRN_II_BUILDER_TERM_INPLACE_SIZE\
-  (sizeof(grn_ii_builder_term) - (uintptr_t)&((grn_ii_builder_term *)0)->dummy)
+  (sizeof(grn_ii_builder_term) - offsetof(grn_ii_builder_term, dummy))
 
 typedef struct {
   grn_id   rid;    /* Last record ID */


### PR DESCRIPTION
_The description is copied from the commit message of the initial branch's commit_

Since MDEV-31503 fixes ALTER-SEQUENCE might be able to  complete its
work including binlogging before a preceding in binlog-order
transaction. There may not be data dependency between the two
transactions, but there would be
   "an attempt was made to binlog GTID D-S-XYZ which would create an
   out-of-order sequence number"
error in the gtid_strict_mode = ON.

After the preceding transaction started committing, and does is very
slow, ALTER-SEQUNCE was able to find a time window to complete because
it temporarily releases its link with the waitee parent transaction.
And while having released it it also erroneously executed binlogging part.

Fixed with restoring the commit dependency on the parent before
ALTER-SEQUNCE takes on binlogging.