### PR TITLE
MDEV-32294 fix_fields() problem with inconsistent outer context paths

### DIFF
--- a/mysql-test/main/subquery_merge.result
+++ b/mysql-test/main/subquery_merge.result
@@ -1,0 +1,169 @@
+#
+# MDEV-32294 2nd execution problem with inconsistent outer context paths
+#
+SELECT
+(
+WITH x AS
+(
+WITH RECURSIVE x ( x ) AS
+(
+SELECT 1 UNION SELECT x FROM x
+)
+SELECT * FROM x WHERE x IN
+(
+SELECT x FROM x WHERE
+(
+SELECT 1 GROUP BY x HAVING ( x )
+)
+)
+)
+SELECT * FROM x
+) AS R;
+R
+1
+SELECT * FROM (
+WITH RECURSIVE x ( a ) AS ( SELECT 1 UNION SELECT a FROM x )
+SELECT * FROM x
+WHERE a IN (
+SELECT a FROM x WHERE ( SELECT 1 GROUP BY a HAVING ( a ) )
+)
+) as dt ;
+a
+1
+create table t1 (a int) engine=myisam;
+insert into t1 values (1), (2);
+create table t2 (b int) engine=myisam;
+insert into t2 values (3), (1);
+create table t3 (c int) select a as c from t1;
+select * from
+(
+with recursive x as ( select a from t1 union select a+1 from x where a < 4 )
+select * from x where a in
+(
+select a from x where
+(
+select b from t2 where b < 3 group by a having a > 0
+) <> 0
+)
+) dt;
+a
+1
+2
+3
+4
+select * from
+(
+with x as ( select distinct a from t1 )
+select * from x where a in
+(
+select a from x where
+(
+select b from t2 where b < 3 group by a having a > 0
+) <> 0
+)
+) dt;
+a
+1
+2
+select * from
+(
+select * from t1 where a in
+(
+select a from t1 where
+(
+select b from t2 where b < 3 group by a having a > 0
+) <> 0
+)
+) dt;
+a
+1
+2
+select * from
+(
+select * from t1 where a in
+(
+select a from t1 where
+(
+select b from t2 where b < 3 group by a
+) <> 0
+)
+) dt;
+a
+1
+2
+select * from
+(
+select * from t3 where c in
+(
+select a from t1 where
+(
+select b from t2 where b < 3 group by a
+) <> 0
+)
+) dt;
+c
+1
+2
+select * from
+(
+select * from t3 where c in
+(
+select a from t1 where
+(
+select b from t2 where a > 0 and b < 3
+) <> 0
+)
+) dt;
+c
+1
+2
+select * from
+(
+select * from t3 where c in
+(
+select a from t1 where
+(
+select b from t2 where a > 0 and b < 3
+) <> 0
+)
+) dt
+where dt.c  > 1;
+c
+2
+select * from
+(
+select * from t3 where c in
+(
+select a from t1 where
+(
+select b from t2
+where a > 0 and b < 3
+) <> 0
+)
+) dt;
+c
+1
+2
+prepare stmt from "with cte as
+( select * from t3 where c in
+(
+select a from t1 where
+(
+select b from t2 where a > 0 and b < 3
+) <> 0
+)
+)
+select * from cte";
+execute stmt;
+c
+1
+2
+execute stmt;
+c
+1
+2
+deallocate prepare stmt;
+drop table t1, t2, t3;
+#
+# End of 10.11 tests
+#

--- a/mysql-test/main/subquery_merge.test
+++ b/mysql-test/main/subquery_merge.test
@@ -1,0 +1,151 @@
+--echo #
+--echo # MDEV-32294 2nd execution problem with inconsistent outer context paths
+--echo #
+
+SELECT
+(
+  WITH x AS
+  (
+    WITH RECURSIVE x ( x ) AS
+    (
+      SELECT 1 UNION SELECT x FROM x
+    )
+    SELECT * FROM x WHERE x IN
+    (
+      SELECT x FROM x WHERE
+      (
+        SELECT 1 GROUP BY x HAVING ( x )
+      )
+    )
+  )
+  SELECT * FROM x
+) AS R;
+
+SELECT * FROM (
+    WITH RECURSIVE x ( a ) AS ( SELECT 1 UNION SELECT a FROM x )
+    SELECT * FROM x
+    WHERE a IN (
+        SELECT a FROM x WHERE ( SELECT 1 GROUP BY a HAVING ( a ) )
+        )
+) as dt ;
+
+create table t1 (a int) engine=myisam;
+insert into t1 values (1), (2);
+create table t2 (b int) engine=myisam;
+insert into t2 values (3), (1);
+create table t3 (c int) select a as c from t1;
+
+select * from
+(
+  with recursive x as ( select a from t1 union select a+1 from x where a < 4 )
+  select * from x where a in
+  (
+    select a from x where
+    (
+      select b from t2 where b < 3 group by a having a > 0
+    ) <> 0
+  )
+) dt;
+
+select * from
+(
+  with x as ( select distinct a from t1 )
+  select * from x where a in
+  (
+    select a from x where
+    (
+      select b from t2 where b < 3 group by a having a > 0
+    ) <> 0
+  )
+) dt;
+
+select * from
+(
+  select * from t1 where a in
+  (
+    select a from t1 where
+    (
+      select b from t2 where b < 3 group by a having a > 0
+    ) <> 0
+  )
+) dt;
+
+select * from
+(
+  select * from t1 where a in
+  (
+    select a from t1 where
+    (
+      select b from t2 where b < 3 group by a
+    ) <> 0
+  )
+) dt;
+
+select * from
+(
+  select * from t3 where c in
+  (
+    select a from t1 where
+    (
+      select b from t2 where b < 3 group by a
+    ) <> 0
+  )
+) dt;
+
+select * from
+(
+  select * from t3 where c in
+  (
+    select a from t1 where
+    (
+      select b from t2 where a > 0 and b < 3
+    ) <> 0
+  )
+) dt;
+
+select * from
+(
+  select * from t3 where c in
+  (
+    select a from t1 where
+    (
+      select b from t2 where a > 0 and b < 3
+    ) <> 0
+  )
+) dt
+where dt.c  > 1;
+
+select * from
+(
+  select * from t3 where c in
+  (
+    select a from t1 where
+    (
+      select b from t2
+      where a > 0 and b < 3
+    ) <> 0
+  )
+) dt;
+
+let $q=
+with cte as
+( select * from t3 where c in
+  (
+    select a from t1 where
+    (
+      select b from t2 where a > 0 and b < 3
+    ) <> 0
+  )
+)
+select * from cte;
+
+eval prepare stmt from "$q";
+execute stmt;
+execute stmt;
+deallocate prepare stmt;
+
+drop table t1, t2, t3;
+
+--echo #
+--echo # End of 10.11 tests
+--echo #

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -3348,6 +3348,15 @@ void st_select_lex_unit::exclude_level()
     SELECT_LEX_UNIT **last= 0;
     for (SELECT_LEX_UNIT *u= sl->first_inner_unit(); u; u= u->next_unit())
     {
+      for (SELECT_LEX *inner_sel= u->first_select();
+           inner_sel; inner_sel= inner_sel->next_select())
+      {
+        if (&sl->context == inner_sel->context.outer_context)
+          inner_sel->context.outer_context = &sl->outer_select()->context;
+      }
+      if (u->fake_select_lex &&
+          u->fake_select_lex->context.outer_context == &sl->context)
+        u->fake_select_lex->context.outer_context= &sl->outer_select()->context;
       u->master= master;
       last= (SELECT_LEX_UNIT**)&(u->next);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to the MariaDB Server repository!

You can help us review your changes faster by filling in this template <3

If you have any questions related to MariaDB or you just want to hang out and meet other community members, please join us on https://mariadb.zulipchat.com/ .
-->

<!--
If you've already identified a https://jira.mariadb.org/ issue that seems to track this bug/feature, please add its number below.
-->
- [x] *The Jira issue number for this PR is: MDEV-32294*

<!--
An amazing description should answer some questions like:
1. What problem is the patch trying to solve?
2. If some output changed that is not visible in a test case, what was it looking like before the change and how it's looking with this patch applied?
3. Do you think this patch might introduce side-effects in other parts of the server?
-->
## Description

Exclude associated contexts when excluding SELECT_LEXs.  These exclusions can happen when merging derived tables into the parent SELECT_LEX.  Later, attempting to call fix_fields() on an Item that interacts with a merged SELECT_LEX should not be able to access a context associated with a merged select.

## Release Notes

Usage of outer references in merged selects can cause problems, especially in prepared statements.


## PR quality check
- [x] I checked the [CODING_STANDARDS.md](https://github.com/MariaDB/server/blob/-/CODING_STANDARDS.md) file and my PR conforms to this where appropriate.
- [x] For any trivial modifications to the PR, I am ok with the reviewer making the changes themselves.
